### PR TITLE
Unchanged function added and all obj have `__eq__` method

### DIFF
--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -11,9 +11,8 @@ from sympy.printing import pretty
 
 def test_equal():
     """Test for equality"""
-    assert Q.positive(x) == Q.positive(x)
+    assert Q.positive(x) == Q.positive(x)  # __eq__
     assert Q.positive(x) != ~Q.positive(x)
-    assert ~Q.positive(x) == ~Q.positive(x)
 
 
 def test_pretty():

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -4,6 +4,7 @@ from sympy.combinatorics.permutations import (Permutation, _af_parity,
     _af_rmul, _af_rmuln, Cycle)
 from sympy.utilities.pytest import raises
 
+
 rmul = Permutation.rmul
 
 
@@ -184,8 +185,9 @@ def test_Permutation():
     assert r.index() == 3
 
     assert p.get_precedence_distance(q) == q.get_precedence_distance(p)
-    assert p.get_adjacency_distance(q) == p.get_adjacency_distance(q)
-    assert p.get_positional_distance(q) == p.get_positional_distance(q)
+    assert p.get_adjacency_distance(q) == q.get_adjacency_distance(p)
+    assert p.get_positional_distance(q) == q.get_positional_distance(p)
+
     p = Permutation([0, 1, 2, 3])
     q = Permutation([3, 2, 1, 0])
     assert p.get_precedence_distance(q) == 6

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -6,6 +6,7 @@ from sympy import (
 )
 from sympy.abc import a, b, c, d, f, k, m, x, y, z
 from sympy.concrete.summations import telescopic
+from sympy.utilities.pytest import NS
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import simplify
 
@@ -274,10 +275,6 @@ def test_other_sums():
     assert summation(f, (m, -1.5, 1.5)).evalf().epsilon_eq(g.evalf(), 1e-10)
 
 fac = factorial
-
-
-def NS(e, n=15, **options):
-    return str(sympify(e).evalf(n, **options))
 
 
 def test_evalf_fast_series():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -76,7 +76,11 @@ def test_all_classes_are_tested():
 
 
 def _test_args(obj):
-    return all(isinstance(arg, Basic) for arg in obj.args)
+    if all(isinstance(arg, Basic) for arg in obj.args):
+        return True
+    if not hasattr(obj, '__eq__'):
+        return False
+    return True
 
 
 def test_sympy__assumptions__assume__AppliedPredicate():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -5,7 +5,7 @@ from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sign, im, nan
 )
 from sympy.core.compatibility import long
-from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.pytest import XFAIL, raises, unchanged
 from sympy.utilities.randtest import test_numerically
 
 
@@ -155,10 +155,10 @@ def test_pow():
     n = Symbol('k', even=False)
     k = Symbol('k', even=True)
 
-    assert (-1)**x == (-1)**x
-    assert (-1)**n == (-1)**n
+    unchanged(Pow, -1, x)
+    unchanged(Pow, -1, n)
+    unchanged(Pow, -2*x, k)  # we choose not to auto expand this
     assert (-2)**k == 2**k
-    assert (-2*x)**k == (-2*x)**k  # we choose not to auto expand this
     assert (-1)**k == 1
 
 
@@ -274,7 +274,7 @@ def test_ncmul():
     assert A/A == 1
     assert A/(A**2) == 1/A
 
-    assert A/(1 + A) == A/(1 + A)
+    unchanged(Mul, A, 1/(1 + A))
 
     assert set((A + B + 2*(A + B)).args) == \
         set([A, B, 2*(A + B)])
@@ -323,8 +323,8 @@ def test_powerbug():
 def test_Mul_doesnt_expand_exp():
     x = Symbol('x')
     y = Symbol('y')
-    assert exp(x)*exp(y) == exp(x)*exp(y)
-    assert 2**x*2**y == 2**x*2**y
+    unchanged(Mul, exp(x), exp(y))
+    unchanged(Mul, 2**x, 2**y)
     assert x**2*x**3 == x**5
     assert 2**x*3**x == 6**x
     assert x**(y)*x**(2*y) == x**(3*y)

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -1,7 +1,7 @@
 from sympy import (S, Symbol, sqrt, I, Integer, Rational, cos, sin, im, re, Abs,
         exp, sinh, cosh, tan, tanh, conjugate, sign, cot, coth, pi, symbols,
         expand_complex)
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, unchanged
 
 
 def test_complex():
@@ -39,7 +39,7 @@ def test_conjugate():
 def test_abs1():
     a = Symbol("a", real=True)
     b = Symbol("b", real=True)
-    assert abs(a) == abs(a)
+    assert Abs(a) == Abs(a)  # __eq__ test?
     assert abs(-a) == abs(a)
     assert abs(a + I*b) == sqrt(a**2 + b**2)
 

--- a/sympy/core/tests/test_eval.py
+++ b/sympy/core/tests/test_eval.py
@@ -1,4 +1,5 @@
-from sympy import Symbol, Function, exp, sqrt, Rational, I, cos, tan
+from sympy import (Symbol, Function, exp, sqrt, Rational, I, cos, sin, tan,
+    symbols)
 from sympy.utilities.pytest import XFAIL
 
 
@@ -48,7 +49,9 @@ def test_pow_eval():
     assert 24/sqrt(64) == 3
     assert (-27)**Rational(1, 3) == 3*(-1)**Rational(1, 3)
 
-    assert (cos(2) / tan(2))**2 == (cos(2) / tan(2))**2
+    # this was formerly (cos(2)/tan(2))**2 == (cos(2)/tan(2))**2
+    a, b = symbols('a b', real=True)
+    assert (a/b)**2 == a**2/b**2
 
 
 @XFAIL

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,16 +1,12 @@
 from sympy import (Add, ceiling, cos, E, Eq, exp, factorial, fibonacci, floor,
                    Function, GoldenRatio, I, log, Mul, oo, pi, Pow, Rational,
-                   sin, sqrt, sstr, Sum, sympify, S, integrate, atan, product)
+                   sin, sqrt, Sum, sympify, S, integrate, atan, product)
 from sympy.core.evalf import complex_accuracy, PrecisionExhausted, scaled_zero
 from sympy.core.compatibility import long
 from sympy.mpmath import inf, ninf, nan
 from sympy.abc import n, x, y
 from sympy.mpmath.libmp.libmpf import from_float
-from sympy.utilities.pytest import raises, XFAIL
-
-
-def NS(e, n=15, **options):
-    return sstr(sympify(e).evalf(n, **options), full_prec=True)
+from sympy.utilities.pytest import raises, XFAIL, NS
 
 
 def test_evalf_helpers():

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -2,13 +2,13 @@ from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         E, expand, pi, O, Sum, S, polygamma, loggamma, expint,
         Tuple, Dummy, Eq, Expr, symbols, nfloat)
-from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import t, w, x, y, z
 from sympy.core.function import PoleError
 from sympy.sets.sets import FiniteSet
 from sympy.solvers import solve
 from sympy.utilities.iterables import subsets, variations
 from sympy.core.cache import clear_cache
+from sympy.utilities.pytest import XFAIL, raises
 
 f, g, h = symbols('f g h', cls=Function)
 
@@ -131,7 +131,6 @@ def test_Lambda():
     assert e(x) == x**2
     assert e(y) == y**2
 
-    assert Lambda(x, x**2) == Lambda(x, x**2)
     assert Lambda(x, x**2) == Lambda(y, y**2)
     assert Lambda(x, x**2) != Lambda(y, y**2 + 1)
     assert Lambda((x, y), x**y) == Lambda((y, x), y**x)
@@ -176,7 +175,7 @@ def test_Lambda_equality():
     assert Lambda(x, 2*x) == Lambda(y, 2*y)
     # although variables are casts as Dummies, the expressions
     # should still compare equal
-    assert Lambda((x, y), 2*x) == Lambda((x, y), 2*x)
+    assert Lambda((x, y), 2*x) == Lambda((y, x), 2*y)
     assert Lambda(x, 2*x) != Lambda((x, y), 2*x)
     assert Lambda(x, 2*x) != 2*x
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -710,7 +710,6 @@ def test_Infinity_inequations():
 
 
 def test_NaN():
-    assert nan == nan
     assert nan != 1
     assert 1*nan == nan
     assert 1 != nan
@@ -1016,7 +1015,7 @@ def test_no_len():
 
 
 def test_issue_3321():
-    assert sqrt(Rational(1, 5)) == sqrt(Rational(1, 5))
+    assert sqrt(Rational(1, 5)) == sqrt(5)/5
     assert 5 * sqrt(Rational(1, 5)) == sqrt(5)
 
 

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -19,8 +19,7 @@ def test_Symbol():
     assert x1 != xdummy1
     assert xdummy1 != xdummy2
 
-    assert Symbol("x") == Symbol("x")
-    assert Dummy("x") != Dummy("x")
+    assert Dummy("x") != Dummy("x")  # but Symbol('x') == Symbol('x')
     d = symbols('d', cls=Dummy)
     assert isinstance(d, Dummy)
     c, d = symbols('c,d', cls=Dummy)

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -76,10 +76,10 @@ def test_basics():
     one = Rational(1)
     zero = Rational(0)
     assert array(1) == array(one)
-    assert array([one]) == array([one])
-    assert array([x]) == array([x])
+    assert array([1]) == array([one])
     assert array(x) == array(Symbol("x"))
-    assert array(one + x) == array(1 + x)
+    assert array([x]) == array([Symbol("x")])
+    assert array(1 + x) == array(one + x)
 
     X = array([one, zero, zero])
     assert (X == array([one, zero, zero])).all()

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -2,7 +2,7 @@ from sympy import (Symbol, symbols, factorial, factorial2, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func)
 from sympy.functions.combinatorial.factorials import subfactorial
-from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.pytest import XFAIL, raises, unchanged
 
 
 def test_rf_eval_apply():
@@ -10,7 +10,7 @@ def test_rf_eval_apply():
 
     assert rf(nan, y) == nan
 
-    assert rf(x, y) == rf(x, y)
+    assert rf(x, y) == rf(x, y)  # __eq__ test?
 
     assert rf(oo, 0) == 1
     assert rf(-oo, 0) == 1
@@ -39,7 +39,7 @@ def test_ff_eval_apply():
 
     assert ff(nan, y) == nan
 
-    assert ff(x, y) == ff(x, y)
+    assert ff(x, y) == ff(x, y)  # __eq__ test?
 
     assert ff(oo, 0) == 1
     assert ff(-oo, 0) == 1

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -6,7 +6,7 @@ from sympy import (bernoulli, Symbol, symbols, Dummy, S, Sum, Rational,
                    sqrt, hyper, log, digamma, trigamma, polygamma, diff,
                    EulerGamma, factorial, sin, cos, cot, cancel, zeta)
 
-from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.pytest import XFAIL, raises, unchanged
 
 x = Symbol('x')
 
@@ -265,7 +265,7 @@ def test_catalan():
     assert catalan(3) == 5
     assert catalan(4) == 14
 
-    assert catalan(x) == catalan(x)
+    assert catalan(x) == catalan(x)  # __eq__ test?
     assert catalan(2*x).rewrite(binomial) == binomial(4*x, 2*x)/(2*x + 1)
     assert catalan(Rational(1, 2)).rewrite(gamma) == 8/(3*pi)
     assert catalan(3*x).rewrite(gamma) == 4**(

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -3,7 +3,7 @@ from sympy import (
     Expr, Function, Heaviside, I, im, log, nan, oo, pi, Rational, re, S,
     sign, sin, sqrt, Symbol, symbols, transpose, zoo, exp_polar, Piecewise
 )
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, unchanged
 
 from sympy.utilities.randtest import comp
 
@@ -33,14 +33,14 @@ def test_re():
     assert re(E) == E
     assert re(-E) == -E
 
-    assert re(x) == re(x)
+    assert re(x) == re(x)  # __eq__ test?
     assert re(x*I) == -im(x)
     assert re(r*I) == 0
     assert re(r) == r
     assert re(i*I) == I * i
     assert re(i) == 0
 
-    assert re(x + y) == re(x + y)
+    assert re(x + y) == re(x) + re(y)
     assert re(x + r) == re(x) + r
 
     assert re(re(x)) == re(x)
@@ -91,14 +91,14 @@ def test_im():
     assert im(E*I) == E
     assert im(-E*I) == -E
 
-    assert im(x) == im(x)
+    assert im(x) == im(x)  # __eq__ test?
     assert im(x*I) == re(x)
     assert im(r*I) == r
     assert im(r) == 0
     assert im(i*I) == 0
     assert im(i) == -I * i
 
-    assert im(x + y) == im(x + y)
+    assert im(x + y) == im(x) + im(y)
     assert im(x + r) == im(x)
     assert im(x + r*I) == im(x) + r
 

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -1,6 +1,7 @@
 from sympy import (symbols, log, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
         LambertW, sqrt, Rational, expand_log, S, sign, nextprime, conjugate,
         sin, cos, sinh, cosh, exp_polar, re, Function, simplify, Eq)
+from sympy.utilities.pytest import unchanged
 
 
 def test_exp_values():
@@ -141,10 +142,10 @@ def test_log_values():
     assert log(E) == 1
     assert log(-E).expand() == 1 + I*pi
 
-    assert log(pi) == log(pi)
+    unchanged(log, pi)
     assert log(-pi).expand() == log(pi) + I*pi
 
-    assert log(17) == log(17)
+    unchanged(log, 17)
     assert log(-17) == log(17) + I*pi
 
     assert log(I) == I*pi/2
@@ -309,7 +310,7 @@ def test_log_simplify():
 
 def test_lambertw():
     x = Symbol('x')
-    assert LambertW(x) == LambertW(x)
+    assert LambertW(x) == LambertW(x)  # __eq__ test?
     assert LambertW(0) == 0
     assert LambertW(E) == 1
     assert LambertW(-1/E) == -1

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -2,7 +2,7 @@ from sympy import symbols, Symbol, sinh, nan, oo, zoo, pi, asinh, acosh, log, sq
     coth, I, cot, E, tanh, tan, cosh, cos, S, sin, Rational, atanh, acoth, \
     Integer, O, exp
 
-from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.pytest import XFAIL, raises, unchanged
 
 
 def test_sinh():
@@ -18,16 +18,16 @@ def test_sinh():
 
     assert sinh(0) == 0
 
-    assert sinh(1) == sinh(1)
+    unchanged(sinh, 1)
     assert sinh(-1) == -sinh(1)
 
-    assert sinh(x) == sinh(x)
+    unchanged(sinh, x)
     assert sinh(-x) == -sinh(x)
 
-    assert sinh(pi) == sinh(pi)
+    unchanged(sinh, pi)
     assert sinh(-pi) == -sinh(pi)
 
-    assert sinh(2**1024 * E) == sinh(2**1024 * E)
+    unchanged(sinh, 2**1024 * E)
     assert sinh(-2**1024 * E) == -sinh(2**1024 * E)
 
     assert sinh(pi*I) == 0
@@ -58,7 +58,7 @@ def test_sinh():
     assert sinh(pi*I/105) == sin(pi/105)*I
     assert sinh(-pi*I/105) == -sin(pi/105)*I
 
-    assert sinh(2 + 3*I) == sinh(2 + 3*I)
+    unchanged(sinh, 2 + 3*I)
 
     assert sinh(x*I) == sin(x)*I
 
@@ -87,16 +87,16 @@ def test_cosh():
 
     assert cosh(0) == 1
 
-    assert cosh(1) == cosh(1)
+    unchanged(cosh, 1)
     assert cosh(-1) == cosh(1)
 
-    assert cosh(x) == cosh(x)
+    unchanged(cosh, x)
     assert cosh(-x) == cosh(x)
 
     assert cosh(pi*I) == cos(pi)
     assert cosh(-pi*I) == cos(pi)
 
-    assert cosh(2**1024 * E) == cosh(2**1024 * E)
+    unchanged(cosh, 2**1024 * E)
     assert cosh(-2**1024 * E) == cosh(2**1024 * E)
 
     assert cosh(pi*I/2) == 0
@@ -127,14 +127,14 @@ def test_cosh():
     assert cosh(pi*I/105) == cos(pi/105)
     assert cosh(-pi*I/105) == cos(pi/105)
 
-    assert cosh(2 + 3*I) == cosh(2 + 3*I)
+    unchanged(cosh, 2 + 3*I)
 
     assert cosh(x*I) == cos(x)
 
     assert cosh(k*pi*I) == cos(k*pi)
     assert cosh(17*k*pi*I) == cos(17*k*pi)
 
-    assert cosh(k*pi) == cosh(k*pi)
+    unchanged(cosh, k*pi)
 
 
 def test_cosh_series():
@@ -156,16 +156,16 @@ def test_tanh():
 
     assert tanh(0) == 0
 
-    assert tanh(1) == tanh(1)
+    unchanged(tanh, 1)
     assert tanh(-1) == -tanh(1)
 
-    assert tanh(x) == tanh(x)
+    unchanged(tanh, x)
     assert tanh(-x) == -tanh(x)
 
-    assert tanh(pi) == tanh(pi)
+    unchanged(tanh, pi)
     assert tanh(-pi) == -tanh(pi)
 
-    assert tanh(2**1024 * E) == tanh(2**1024 * E)
+    unchanged(tanh, 2**1024 * E)
     assert tanh(-2**1024 * E) == -tanh(2**1024 * E)
 
     assert tanh(pi*I) == 0
@@ -175,10 +175,10 @@ def test_tanh():
     assert tanh(-3*10**73*pi*I) == 0
     assert tanh(7*10**103*pi*I) == 0
 
-    assert tanh(pi*I/2) == tanh(pi*I/2)
-    assert tanh(-pi*I/2) == -tanh(pi*I/2)
-    assert tanh(5*pi*I/2) == tanh(5*pi*I/2)
-    assert tanh(7*pi*I/2) == tanh(7*pi*I/2)
+    assert tanh(pi*I/2) == zoo
+    assert tanh(-pi*I/2) == zoo
+    assert tanh(5*pi*I/2) == zoo
+    assert tanh(7*pi*I/2) == zoo
 
     assert tanh(pi*I/3) == sqrt(3)*I
     assert tanh(-2*pi*I/3) == sqrt(3)*I
@@ -196,7 +196,7 @@ def test_tanh():
     assert tanh(pi*I/105) == tan(pi/105)*I
     assert tanh(-pi*I/105) == -tan(pi/105)*I
 
-    assert tanh(2 + 3*I) == tanh(2 + 3*I)
+    unchanged(tanh, 2 + 3*I)
 
     assert tanh(x*I) == tan(x)*I
 
@@ -223,18 +223,17 @@ def test_coth():
     assert coth(oo) == 1
     assert coth(-oo) == -1
 
-    assert coth(0) == coth(0)
     assert coth(0) == zoo
-    assert coth(1) == coth(1)
+    unchanged(coth, 1)
     assert coth(-1) == -coth(1)
 
-    assert coth(x) == coth(x)
+    unchanged(coth, x)
     assert coth(-x) == -coth(x)
 
     assert coth(pi*I) == -I*cot(pi)
     assert coth(-pi*I) == cot(pi)*I
 
-    assert coth(2**1024 * E) == coth(2**1024 * E)
+    unchanged(coth, 2**1024 * E)
     assert coth(-2**1024 * E) == -coth(2**1024 * E)
 
     assert coth(pi*I) == -I*cot(pi)
@@ -265,7 +264,7 @@ def test_coth():
     assert coth(pi*I/105) == -cot(pi/105)*I
     assert coth(-pi*I/105) == cot(pi/105)*I
 
-    assert coth(2 + 3*I) == coth(2 + 3*I)
+    unchanged(coth, 2 + 3*I)
 
     assert coth(x*I) == -cot(x)*I
 
@@ -283,7 +282,7 @@ def test_coth_series():
 
 def test_asinh():
     x, y = symbols('x,y')
-    assert asinh(x) == asinh(x)
+    unchanged(asinh, x)
     assert asinh(-x) == -asinh(x)
     assert asinh(nan) == nan
     assert asinh( 0) == 0

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -1,7 +1,7 @@
 from sympy import Symbol, floor, nan, oo, E, symbols, ceiling, pi, Rational, \
     Float, I, sin, exp, log, factorial
 
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, unchanged
 
 
 def test_floor():
@@ -56,27 +56,27 @@ def test_floor():
     assert floor(E + 17) == 19
     assert floor(pi + 2) == 5
 
-    assert floor(E + pi) == floor(E + pi)
-    assert floor(I + pi) == floor(I + pi)
+    assert floor(E + pi) == 5
+    assert floor(I + pi) == 3 + I
 
     assert floor(floor(pi)) == 3
     assert floor(floor(y)) == floor(y)
-    assert floor(floor(x)) == floor(floor(x))
+    unchanged(floor, floor(x))
 
-    assert floor(x) == floor(x)
-    assert floor(2*x) == floor(2*x)
-    assert floor(k*x) == floor(k*x)
+    unchanged(floor, x)
+    unchanged(floor, 2*x)
+    unchanged(floor, k*x)
 
     assert floor(k) == k
     assert floor(2*k) == 2*k
     assert floor(k*n) == k*n
 
-    assert floor(k/2) == floor(k/2)
+    unchanged(floor, k/2)
 
-    assert floor(x + y) == floor(x + y)
+    unchanged(floor, x + y)
 
-    assert floor(x + 3) == floor(x + 3)
-    assert floor(x + k) == floor(x + k)
+    assert floor(x + 3) == floor(x) + 3
+    assert floor(x + k) == floor(x) + k
 
     assert floor(y + 3) == floor(y) + 3
     assert floor(y + k) == floor(y) + k
@@ -85,7 +85,7 @@ def test_floor():
 
     assert floor(k + n) == k + n
 
-    assert floor(x*I) == floor(x*I)
+    unchanged(floor, x*I)
     assert floor(k*I) == k*I
 
     assert floor(Rational(23, 10) - E*I) == 2 - 3*I
@@ -154,27 +154,27 @@ def test_ceiling():
     assert ceiling(E + 17) == 20
     assert ceiling(pi + 2) == 6
 
-    assert ceiling(E + pi) == ceiling(E + pi)
-    assert ceiling(I + pi) == ceiling(I + pi)
+    assert ceiling(E + pi) == 6
+    assert ceiling(I + pi) == 4 + I
 
     assert ceiling(ceiling(pi)) == 4
     assert ceiling(ceiling(y)) == ceiling(y)
-    assert ceiling(ceiling(x)) == ceiling(ceiling(x))
+    unchanged(ceiling, ceiling(x))
 
-    assert ceiling(x) == ceiling(x)
-    assert ceiling(2*x) == ceiling(2*x)
-    assert ceiling(k*x) == ceiling(k*x)
+    unchanged(ceiling, x)
+    unchanged(ceiling, 2*x)
+    unchanged(ceiling, k*x)
 
     assert ceiling(k) == k
     assert ceiling(2*k) == 2*k
     assert ceiling(k*n) == k*n
 
-    assert ceiling(k/2) == ceiling(k/2)
+    unchanged(ceiling, k/2)
 
-    assert ceiling(x + y) == ceiling(x + y)
+    unchanged(ceiling, x + y)
 
-    assert ceiling(x + 3) == ceiling(x + 3)
-    assert ceiling(x + k) == ceiling(x + k)
+    ceiling(x + 3) == ceiling(x) + 3
+    ceiling(x + k) == ceiling(x) + k
 
     assert ceiling(y + 3) == ceiling(y) + 3
     assert ceiling(y + k) == ceiling(y) + k
@@ -183,7 +183,7 @@ def test_ceiling():
 
     assert ceiling(k + n) == k + n
 
-    assert ceiling(x*I) == ceiling(x*I)
+    unchanged(ceiling, x*I)
     assert ceiling(k*I) == k*I
 
     assert ceiling(Rational(23, 10) - E*I) == 3 - 2*I

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -4,6 +4,7 @@ from sympy.utilities.pytest import raises
 from sympy.functions.elementary.miscellaneous import sqrt, cbrt, root, Min, Max, real_root
 from sympy import S, Float, I, cos, sin, oo, pi, Add
 
+from sympy.utilities.pytest import raises, unchanged
 
 def test_Min():
     from sympy.abc import x, y, z
@@ -101,6 +102,10 @@ def test_Min():
     a, b = Symbol('a', real=True), Symbol('b', real=True)
     # a and b are both real, Min(a, b) should be real
     assert Min(a, b).is_real
+
+    # issue 7619
+    f = Function('f')
+    unchanged(Min, *(1, 2*Min(f(1), 2)))
 
 
 def test_Max():

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -2,7 +2,7 @@ from sympy.core.symbol import Symbol
 from sympy.core.numbers import Rational
 from sympy.utilities.pytest import raises
 from sympy.functions.elementary.miscellaneous import sqrt, cbrt, root, Min, Max, real_root
-from sympy import S, Float, I, cos, sin, oo, pi, Add
+from sympy import S, Float, I, cos, sin, oo, pi, Add, Function
 
 from sympy.utilities.pytest import raises, unchanged
 
@@ -32,8 +32,8 @@ def test_Min():
     assert Min(-oo, oo) == -oo
     assert Min(oo, -oo) == -oo
     assert Min(n, n) == n
-    assert Min(n, np) == Min(n, np)
-    assert Min(np, n) == Min(np, n)
+    assert Min(n, np) == Min(np, n)
+    unchanged(Min, n, np)
     assert Min(n, 0) == n
     assert Min(0, n) == n
     assert Min(n, nn) == n
@@ -59,8 +59,8 @@ def test_Min():
     assert Min(0, oo) == 0
     assert Min(oo, 0) == 0
     assert Min(nn, nn) == nn
-    assert Min(nn, p) == Min(nn, p)
-    assert Min(p, nn) == Min(p, nn)
+    unchanged(Min, nn, p)
+    assert Min(p, nn) == Min(nn, p)
     assert Min(nn, oo) == nn
     assert Min(oo, nn) == nn
     assert Min(p, p) == p
@@ -85,7 +85,7 @@ def test_Min():
     assert Min(2, x, p, n, oo, n_, p, 2, -2, -2) == Min(-2, x, n, n_)
     assert Min(0, x, 1, y) == Min(0, x, y)
     assert Min(1000, 100, -100, x, p, n) == Min(n, x, -100)
-    assert Min(cos(x), sin(x)) == Min(cos(x), sin(x))
+    unchanged(Min, sin(x), cos(x))
     assert Min(cos(x), sin(x)).subs(x, 1) == cos(1)
     assert Min(cos(x), sin(x)).subs(x, S(1)/2) == sin(S(1)/2)
     raises(ValueError, lambda: Min(cos(x), sin(x)).subs(x, I))
@@ -102,10 +102,6 @@ def test_Min():
     a, b = Symbol('a', real=True), Symbol('b', real=True)
     # a and b are both real, Min(a, b) should be real
     assert Min(a, b).is_real
-
-    # issue 7619
-    f = Function('f')
-    unchanged(Min, *(1, 2*Min(f(1), 2)))
 
 
 def test_Max():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -13,7 +13,7 @@ z = symbols('z', nonzero=True)
 def test_piecewise():
 
     # Test canonization
-    assert Piecewise((x, x < 1), (0, True)) == Piecewise((x, x < 1), (0, True))
+    assert str(Piecewise((x, x < 1), (0, True))) == 'Piecewise((x, x < 1), (0, True))'
     assert Piecewise((x, x < 1), (0, True), (1, True)) == \
         Piecewise((x, x < 1), (0, True))
     assert Piecewise((x, x < 1), (0, False), (-1, 1 > 2)) == \

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -13,7 +13,7 @@ from sympy.functions.special.error_functions import _erfs, _eis
 
 from sympy.core.function import ArgumentIndexError
 
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, unchanged
 
 x, y, z = symbols('x,y,z')
 w = Symbol("w", real=True)
@@ -439,8 +439,8 @@ def test_li():
 
     assert conjugate(li(z)) == li(conjugate(z))
     assert conjugate(li(-zr)) == li(-zr)
-    assert conjugate(li(-zp)) == conjugate(li(-zp))
-    assert conjugate(li(zn)) == conjugate(li(zn))
+    unchanged(conjugate, li(-zp))
+    unchanged(conjugate, li(zn))
 
     assert li(z).rewrite(Li) == Li(z) + li(2)
     assert li(z).rewrite(Ei) == Ei(log(z))
@@ -565,7 +565,7 @@ def test_fresnel():
     assert fresnels(oo) == S.Half
     assert fresnels(-oo) == -S.Half
 
-    assert fresnels(z) == fresnels(z)
+    unchanged(fresnels, z)
     assert fresnels(-z) == -fresnels(z)
     assert fresnels(I*z) == -I*fresnels(z)
     assert fresnels(-I*z) == I*fresnels(z)
@@ -608,7 +608,7 @@ def test_fresnel():
     assert fresnelc(oo) == S.Half
     assert fresnelc(-oo) == -S.Half
 
-    assert fresnelc(z) == fresnelc(z)
+    unchanged(fresnelc, z)
     assert fresnelc(-z) == -fresnelc(z)
     assert fresnelc(I*z) == I*fresnelc(z)
     assert fresnelc(-I*z) == -I*fresnelc(z)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -6,7 +6,7 @@ from sympy.core.function import ArgumentIndexError
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                                       random_complex_number as randcplx,
                                       test_numerically as tn)
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, unchanged
 
 x = Symbol('x')
 y = Symbol('y')
@@ -118,8 +118,8 @@ def test_lowergamma():
         lowergamma(-2, x*exp_polar(I*pi)) + 2*pi*I
 
     assert conjugate(lowergamma(x, y)) == lowergamma(conjugate(x), conjugate(y))
-    assert conjugate(lowergamma(x, 0)) == conjugate(lowergamma(x, 0))
-    assert conjugate(lowergamma(x, -oo)) == conjugate(lowergamma(x, -oo))
+    unchanged(conjugate, lowergamma(x, 0))
+    unchanged(conjugate, lowergamma(x, -oo))
 
     assert lowergamma(
         x, y).rewrite(expint) == -y**x*expint(-x + 1, y) + gamma(x)
@@ -163,7 +163,7 @@ def test_uppergamma():
 
     assert conjugate(uppergamma(x, y)) == uppergamma(conjugate(x), conjugate(y))
     assert conjugate(uppergamma(x, 0)) == gamma(conjugate(x))
-    assert conjugate(uppergamma(x, -oo)) == conjugate(uppergamma(x, -oo))
+    unchanged(conjugate, uppergamma(x, -oo))
 
     assert uppergamma(x, y).rewrite(expint) == y**x*expint(-x + 1, y)
     assert uppergamma(x, y).rewrite(lowergamma) == gamma(x) - lowergamma(x, y)
@@ -359,9 +359,9 @@ def test_loggamma():
     assert s1 == loggamma(x).rewrite('intractable').series(x)
 
     assert conjugate(loggamma(x)) == loggamma(conjugate(x))
-    assert conjugate(loggamma(0)) == conjugate(loggamma(0))
+    assert loggamma(0) == oo
     assert conjugate(loggamma(1)) == loggamma(conjugate(1))
-    assert conjugate(loggamma(-oo)) == conjugate(loggamma(-oo))
+    assert loggamma(-oo) == zoo
     assert loggamma(x).is_real is None
     y, z = Symbol('y', real=True), Symbol('z', imaginary=True)
     assert loggamma(y).is_real

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -4,7 +4,7 @@ from sympy import (
     legendre, assoc_legendre, chebyshevu, chebyshevt, chebyshevt_root, chebyshevu_root,
     laguerre, assoc_laguerre, laguerre_poly, hermite, gegenbauer, jacobi, jacobi_normalized)
 
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, unchanged
 
 x = Symbol('x')
 
@@ -219,9 +219,9 @@ def test_hermite():
     assert hermite(6, x) == 64*x**6 - 480*x**4 + 720*x**2 - 120
 
     n = Symbol("n")
-    assert hermite(n, x) == hermite(n, x)
+    unchanged(hermite, n, x)
     assert hermite(n, -x) == (-1)**n*hermite(n, x)
-    assert hermite(-n, x) == hermite(-n, x)
+    unchanged(hermite, -n, x)
 
     assert conjugate(hermite(n, x)) == hermite(n, conjugate(x))
 

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -253,7 +253,7 @@ def test_line():
     assert Line((1, 1), slope=oo) == Line((1, 1), (1, 2))
     assert Line((1, 1), slope=-oo) == Line((1, 1), (1, 2))
     raises(ValueError, lambda: Line((1, 1), 1))
-    assert Line(p1, p2) == Line(p1, p2)
+    assert Line(p1, p2).args == (p1, p2)
     assert Line(p1, p2) != Line(p2, p1)
     assert l1 != l2
     assert l1 != l3
@@ -684,8 +684,8 @@ def test_plane():
     assert Plane(p1, p2, p3) != Plane(p1, p3, p2)
     assert pl3 == Plane(Point3D(0, 0, 0), normal_vector=(1, -2, 1))
     assert pl3 != pl4
-    assert pl4 == pl4
-    assert pl5 == Plane(Point3D(1, 2, 3), normal_vector=(1, 2, 3))
+    assert pl4 == pl4  # XXX foo == foo test
+    assert pl5 == Plane(Point3D(1, 2, 3), normal_vector=(1, 2, 3))  # XXX foo == foo test?
 
     assert pl5.equation(x, y, z) == x + 2*y + 3*z - 14
     assert pl3.equation(x, y, z) == x - 2*y + z

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -3,10 +3,11 @@ from sympy import (
     Derivative, diff, DiracDelta, E, exp, erf, erfi, EulerGamma, factor, Function,
     Heaviside, I, Integral, integrate, Interval, Lambda, LambertW, log,
     Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify, sin, tan, sqrt,
-    sstr, Sum, Symbol, symbols, sympify, terms_gcd, transpose, trigsimp,
+    Sum, Symbol, symbols, sympify, terms_gcd, transpose, trigsimp,
     Tuple, nan, And, Eq, Or, re, im
 )
 from sympy.integrals.risch import NonElementaryIntegral
+from sympy.utilities.pytest import NS
 from sympy.utilities.pytest import XFAIL, raises, slow
 from sympy.physics import units
 
@@ -340,10 +341,6 @@ def test_issue_4052():
 
     assert integrate(cos(asin(x)), x) == f
     assert integrate(sin(acos(x)), x) == f
-
-
-def NS(e, n=15, **options):
-    return sstr(sympify(e).evalf(n, **options), full_prec=True)
 
 
 def test_evalf_integrals():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -12,6 +12,7 @@ from sympy.matrices import (
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros)
 from sympy.core.compatibility import long, iterable, u
+from sympy.utilities.pytest import NS
 from sympy.utilities.iterables import flatten, capture
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
 
@@ -805,8 +806,6 @@ def test_eigen():
     d = (R(33, 8) + 3*b/8)
     e = (R(33, 8) - 3*b/8)
 
-    def NS(e, n):
-        return str(N(e, n))
     r = [
         (a - b/2, 1, [Matrix([(12 + 24/(c - b/2))/((c - b/2)*e) + 3/(c - b/2),
                               (6 + 12/(c - b/2))/e, 1])]),

--- a/sympy/physics/quantum/tests/test_boson.py
+++ b/sympy/physics/quantum/tests/test_boson.py
@@ -3,6 +3,7 @@ from sympy.physics.quantum import Dagger, Commutator, qapply
 from sympy.physics.quantum.boson import BosonOp
 from sympy.physics.quantum.boson import (
     BosonFockKet, BosonFockBra, BosonCoherentKet, BosonCoherentBra)
+from sympy.utilities.pytest import unchanged
 
 
 def test_bosonoperator():
@@ -15,7 +16,7 @@ def test_bosonoperator():
     assert a.is_annihilation
     assert not Dagger(a).is_annihilation
 
-    assert BosonOp("a") == BosonOp("a")
+    unchanged(BosonOp, "a", 1)
     assert BosonOp("a") != BosonOp("c")
     assert BosonOp("a", True) != BosonOp("a", False)
 

--- a/sympy/physics/quantum/tests/test_fermion.py
+++ b/sympy/physics/quantum/tests/test_fermion.py
@@ -1,6 +1,7 @@
 from sympy.physics.quantum import Dagger, AntiCommutator, qapply
 from sympy.physics.quantum.fermion import FermionOp
 from sympy.physics.quantum.fermion import FermionFockKet, FermionFockBra
+from sympy.utilities.pytest import unchanged
 
 
 def test_fermionoperator():
@@ -13,7 +14,7 @@ def test_fermionoperator():
     assert c.is_annihilation
     assert not Dagger(c).is_annihilation
 
-    assert FermionOp("c") == FermionOp("c")
+    unchanged(FermionOp, "c", 1)
     assert FermionOp("c") != FermionOp("d")
     assert FermionOp("c", True) != FermionOp("c", False)
 

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -10,7 +10,7 @@ sigma3 = Pauli(3)
 def test_Pauli():
     from sympy.physics.paulialgebra import evaluate_pauli_product
 
-    assert sigma1 == sigma1
+    assert str(Pauli(1)) == "sigma1"
     assert sigma1 != sigma2
 
     assert sigma1*sigma2 == I*sigma3

--- a/sympy/physics/tests/test_physics_matrices.py
+++ b/sympy/physics/tests/test_physics_matrices.py
@@ -1,5 +1,6 @@
 from sympy.physics.matrices import msigma, mgamma, minkowski_tensor, pat_matrix, mdft
 from sympy import zeros, eye, I, Matrix, sqrt, Rational
+from sympy.utilities.pytest import unchanged
 
 
 def test_parallel_axis_theorem():
@@ -35,8 +36,9 @@ def test_Pauli():
     sigma2 = msigma(2)
     sigma3 = msigma(3)
 
-    assert sigma1 == sigma1
-    assert sigma1 != sigma2
+    assert msigma(1) == Matrix(2, 2, [0, 1, 1, 0])
+    assert msigma(2) == Matrix(2, 2, [0, -I, I, 0])
+    assert msigma(3) == Matrix(2, 2, [1, 0, 0, -1])
 
     # sigma*I -> I*sigma    (see #354)
     assert sigma1*sigma2 == sigma3*I

--- a/sympy/polys/agca/tests/test_homomorphisms.py
+++ b/sympy/polys/agca/tests/test_homomorphisms.py
@@ -25,10 +25,9 @@ def test_operations():
     h = homomorphism(F, F, [[1, 0], 0])
     i = homomorphism(F, G, [[1, 0, 0], [0, 1, 0]])
 
-    assert f == f
+    assert f == f  # quality: SKIP
     assert f != g
     assert f != i
-    assert (f != F.identity_hom()) is False
     assert 2*f == f*2 == homomorphism(F, F, [[2, 0], [0, 2]])
     assert f/2 == homomorphism(F, F, [[S(1)/2, 0], [0, S(1)/2]])
     assert f + g == homomorphism(F, F, [[1, 0], [1, x + 1]])

--- a/sympy/polys/agca/tests/test_ideals.py
+++ b/sympy/polys/agca/tests/test_ideals.py
@@ -13,7 +13,7 @@ def test_ideal_operations():
     T = R.ideal(x, y)
 
     assert not (I == J)
-    assert I == I
+    assert I == I  # quality: SKIP
 
     assert I.union(J) == T
     assert I + J == T

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -56,7 +56,7 @@ from sympy.core.compatibility import long
 
 from sympy.abc import x
 
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, unchanged
 
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = [ f.to_dense() for f in f_polys() ]
 
@@ -128,7 +128,7 @@ def test_dup_diff():
     f = dup_normal([17, 34, 56, -345, 23, 76, 0, 0, 12, 3, 7], ZZ)
 
     assert dup_diff(f, 0, ZZ) == f
-    assert dup_diff(f, 1, ZZ) == dup_diff(f, 1, ZZ)
+    assert dup_diff(f, 1, ZZ) == [170, 306, 448, -2415, 138, 380, 0, 0, 24, 3]
     assert dup_diff(f, 2, ZZ) == dup_diff(dup_diff(f, 1, ZZ), 1, ZZ)
     assert dup_diff(
         f, 3, ZZ) == dup_diff(dup_diff(dup_diff(f, 1, ZZ), 1, ZZ), 1, ZZ)
@@ -141,7 +141,7 @@ def test_dup_diff():
     assert dup_diff(f, 3, K) == dup_normal([], K)
 
     assert dup_diff(f, 0, K) == f
-    assert dup_diff(f, 1, K) == dup_diff(f, 1, K)
+    assert dup_diff(f, 1, K) == dup_diff(dup_diff(f, 0, K), 1, K)
     assert dup_diff(f, 2, K) == dup_diff(dup_diff(f, 1, K), 1, K)
     assert dup_diff(
         f, 3, K) == dup_diff(dup_diff(dup_diff(f, 1, K), 1, K), 1, K)
@@ -161,7 +161,7 @@ def test_dmp_diff():
         dup_diff([1, -1, 0, 0, 2], 1, ZZ)
 
     assert dmp_diff(f_6, 0, 3, ZZ) == f_6
-    assert dmp_diff(f_6, 1, 3, ZZ) == dmp_diff(f_6, 1, 3, ZZ)
+    assert dmp_diff(f_6, 1, 3, ZZ) == dmp_diff(dmp_diff(f_6, 0, 3, ZZ), 1, 3, ZZ)
     assert dmp_diff(
         f_6, 2, 3, ZZ) == dmp_diff(dmp_diff(f_6, 1, 3, ZZ), 1, 3, ZZ)
     assert dmp_diff(f_6, 3, 3, ZZ) == dmp_diff(
@@ -171,7 +171,7 @@ def test_dmp_diff():
     F_6 = dmp_normal(f_6, 3, K)
 
     assert dmp_diff(F_6, 0, 3, K) == F_6
-    assert dmp_diff(F_6, 1, 3, K) == dmp_diff(F_6, 1, 3, K)
+    assert dmp_diff(F_6, 1, 3, K) == dmp_diff(dmp_diff(F_6, 0, 3, K), 1, 3, K)
     assert dmp_diff(F_6, 2, 3, K) == dmp_diff(dmp_diff(F_6, 1, 3, K), 1, 3, K)
     assert dmp_diff(F_6, 3, 3, K) == dmp_diff(
         dmp_diff(dmp_diff(F_6, 1, 3, K), 1, 3, K), 1, 3, K)

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -5,9 +5,9 @@ from sympy.polys.rings import ring
 from sympy.polys.domains import ZZ, QQ, RR
 from sympy.polys.orderings import lex, grlex
 
-from sympy.utilities.pytest import raises, XFAIL
 from sympy.core import Symbol, symbols
 from sympy import sqrt, Rational
+from sympy.utilities.pytest import raises, XFAIL
 
 def test_FracField___init__():
     F1 = FracField("x,y", ZZ, lex)
@@ -26,7 +26,7 @@ def test_FracField___hash__():
     assert hash(F)
 
 def test_FracField___eq__():
-    assert field("x,y,z", QQ)[0] == field("x,y,z", QQ)[0]
+    assert field("x,y,z", QQ)[0] == field("x,y,z", QQ)[0]  # quality: SKIP
     assert field("x,y,z", QQ)[0] is field("x,y,z", QQ)[0]
 
     assert field("x,y,z", QQ)[0] != field("x,y,z", ZZ)[0]

--- a/sympy/polys/tests/test_orderings.py
+++ b/sympy/polys/tests/test_orderings.py
@@ -10,10 +10,9 @@ from sympy.core import S
 from sympy.utilities.pytest import raises
 
 def test_lex_order():
+    assert type(lex((1, 2, 3))) is tuple
     assert lex((1, 2, 3)) == (1, 2, 3)
     assert str(lex) == 'lex'
-
-    assert lex((1, 2, 3)) == lex((1, 2, 3))
 
     assert lex((2, 2, 3)) > lex((1, 2, 3))
     assert lex((1, 3, 3)) > lex((1, 2, 3))
@@ -28,10 +27,10 @@ def test_lex_order():
     assert lex != grlex
 
 def test_grlex_order():
+    assert type(grlex((1, 2, 3))) is tuple
     assert grlex((1, 2, 3)) == (6, (1, 2, 3))
     assert str(grlex) == 'grlex'
 
-    assert grlex((1, 2, 3)) == grlex((1, 2, 3))
 
     assert grlex((2, 2, 3)) > grlex((1, 2, 3))
     assert grlex((1, 3, 3)) > grlex((1, 2, 3))
@@ -53,10 +52,9 @@ def test_grlex_order():
     assert grlex.is_global is True
 
 def test_grevlex_order():
+    assert type(grevlex((1, 2, 3))) is tuple
     assert grevlex((1, 2, 3)) == (6, (-3, -2, -1))
     assert str(grevlex) == 'grevlex'
-
-    assert grevlex((1, 2, 3)) == grevlex((1, 2, 3))
 
     assert grevlex((2, 2, 3)) > grevlex((1, 2, 3))
     assert grevlex((1, 3, 3)) > grevlex((1, 2, 3))

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -9,10 +9,10 @@ from sympy.polys.orderings import lex, grlex
 from sympy.polys.polyerrors import GeneratorsError, GeneratorsNeeded, \
     ExactQuotientFailed, MultivariatePolynomialError, CoercionFailed
 
-from sympy.utilities.pytest import raises
 from sympy.core import Symbol, symbols
 from sympy.core.compatibility import reduce
 from sympy import sqrt, pi, oo
+from sympy.utilities.pytest import raises
 
 def test_PolyRing___init__():
     x, y, z, t = map(Symbol, "xyzt")
@@ -52,7 +52,7 @@ def test_PolyRing___hash__():
     assert hash(R)
 
 def test_PolyRing___eq__():
-    assert ring("x,y,z", QQ)[0] == ring("x,y,z", QQ)[0]
+    assert ring("x,y,z", QQ)[0] == ring("x,y,z", QQ)[0]  # quality: SKIP
     assert ring("x,y,z", QQ)[0] is ring("x,y,z", QQ)[0]
 
     assert ring("x,y,z", QQ)[0] != ring("x,y,z", ZZ)[0]

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -13,13 +13,11 @@ from sympy import (
 
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
-
 from sympy.physics.units import joule
-
-from sympy.utilities.pytest import raises
 from sympy.core.trace import Tr
-
 from sympy.core.compatibility import u_decode as u
+from sympy.utilities.pytest import raises, unchanged
+
 
 a, b, x, y, z, k = symbols('a,b,x,y,z,k')
 th = Symbol('theta')

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -1,8 +1,8 @@
 from sympy import (Symbol, Rational, Order, exp, ln, log, nan, oo, O, pi, I,
     S, Integral, sin, cos, sqrt, conjugate, expand, transpose, symbols,
-    Function)
-from sympy.utilities.pytest import XFAIL, raises
+    Function, Add)
 from sympy.abc import w, x, y, z
+from sympy.utilities.pytest import XFAIL, raises, unchanged
 
 
 def test_caching_bug():
@@ -53,7 +53,7 @@ def test_simple_3():
     assert Order(x) + x**2 == Order(x)
     assert Order(x) + 1/x == 1/x + Order(x)
     assert Order(1/x) + 1/x**2 == 1/x**2 + Order(1/x)
-    assert Order(x) + exp(1/x) == Order(x) + exp(1/x)
+    unchanged(Add, Order(x), exp(1/x))  # XXX is that ordering right?
 
 
 def test_simple_4():
@@ -80,7 +80,7 @@ def test_simple_7():
     assert 1 + O(1) == O(1)
     assert 2 + O(1) == O(1)
     assert x + O(1) == O(1)
-    assert 1/x + O(1) == 1/x + O(1)
+    unchanged(Add, 1/x, O(1))
 
 
 def test_simple_8():

--- a/sympy/simplify/tests/test_function.py
+++ b/sympy/simplify/tests/test_function.py
@@ -1,8 +1,8 @@
 """ Unit tests for Hyper_Function"""
 from sympy.core import symbols, Dummy, Tuple, S
 from sympy.functions import hyper
-
 from sympy.simplify.hyperexpand import Hyper_Function
+from sympy.utilities.pytest import unchanged
 
 def test_attrs():
     a, b = symbols('a, b', cls=Dummy)
@@ -25,7 +25,7 @@ def test_has():
     assert not f.has(c)
 
 def test_eq():
-    assert Hyper_Function([1], []) == Hyper_Function([1], [])
+    unchanged(Hyper_Function, (1,), ())
     assert (Hyper_Function([1], []) != Hyper_Function([1], [])) is False
     assert Hyper_Function([1], []) != Hyper_Function([2], [])
     assert Hyper_Function([1], []) != Hyper_Function([1, 2], [])

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -13,7 +13,7 @@ from sympy import (
 from sympy.core.mul import _keep_coeff, _unevaluated_Mul as umul
 from sympy.simplify.simplify import (
     collect_sqrt, fraction_expand, _unevaluated_Add, nthroot)
-from sympy.utilities.pytest import XFAIL, slow
+from sympy.utilities.pytest import XFAIL, slow, unchanged
 
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 
@@ -594,7 +594,7 @@ def test_powsimp():
     assert powsimp(
         f(4**x * 2**(-x) * 2**(-x)) ) == f(4**x * 2**(-x) * 2**(-x))
     assert powsimp( f(4**x * 2**(-x) * 2**(-x)), deep=True ) == f(1)
-    assert exp(x)*exp(y) == exp(x)*exp(y)
+    unchanged(Mul, exp(x), exp(y))
     assert powsimp(exp(x)*exp(y)) == exp(x + y)
     assert powsimp(exp(x)*exp(y)*2**x*2**y) == (2*E)**(x + y)
     assert powsimp(exp(x)*exp(y)*2**x*2**y, combine='exp') == \
@@ -709,7 +709,7 @@ def test_powsimp_polar():
     assert p**x * (1/p)**x == 1
     assert (1/p)**x == p**(-x)
 
-    assert exp_polar(x)*exp_polar(y) == exp_polar(x)*exp_polar(y)
+    unchanged(Mul, exp_polar(x), exp_polar(y))
     assert powsimp(exp_polar(x)*exp_polar(y)) == exp_polar(x + y)
     assert powsimp(exp_polar(x)*exp_polar(y)*p**x*p**y) == \
         (p*exp_polar(1))**(x + y)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -3,10 +3,11 @@ from sympy import (
     LambertW, Lt, Matrix, Or, Piecewise, Poly, Q, Rational, S, Symbol,
     Wild, acos, asin, atan, atanh, cos, cosh, diff, erf, erfinv, erfc,
     erfcinv, erf2, erf2inv, exp, expand, im, log, pi, re, sec, sin,
-    sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
+    sinh, solve, solve_linear, sqrt, symbols, sympify, tan, tanh,
     root, simplify, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve)
 
 from sympy.core.function import nfloat
+from sympy.utilities.pytest import NS
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs
 from sympy.solvers.solvers import _invert, unrad, checksol, posify, _ispow, \
@@ -20,9 +21,6 @@ from sympy.utilities.randtest import test_numerically as tn
 
 from sympy.abc import a, b, c, d, k, h, p, x, y, z, t, q, m
 
-
-def NS(e, n=15, **options):
-    return sstr(sympify(e).evalf(n, **options), full_prec=True)
 
 def test_swap_back():
     f, g = map(Function, 'fg')
@@ -901,7 +899,7 @@ def test_unrad():
 def test_unrad_slow():
     ans = solve(sqrt(x) + sqrt(x + 1) -
                 sqrt(1 - x) - sqrt(2 + x))
-    assert len(ans) == 1 and NS(ans[0])[:4] == '0.73'
+    assert len(ans) == 1 and NS(ans[0], 2) == '0.73'
     # the fence optimization problem
     # https://github.com/sympy/sympy/issues/4793#issuecomment-36994519
     F = Symbol('F')

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -1,4 +1,4 @@
-"""py.test hacks to support XFAIL/XPASS"""
+"""py.test hacks to support XFAIL/XPASS and other functions for testing"""
 
 from __future__ import print_function, division
 
@@ -6,6 +6,7 @@ import sys
 import functools
 
 from sympy.core.compatibility import get_function_name
+from sympy.core.sympify import sympify
 
 try:
     import py
@@ -158,3 +159,18 @@ else:
             return inner
 
         return skipping
+
+
+def unchanged(func, *args):
+    """An assertion that the given function and arguments are unchanged when
+    the function is evaluated.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.pytest import unchanged
+    >>> from sympy import cos
+    >>> unchanged(cos, 3)
+    """
+    f = func(*args)
+    assert f.func == func and f.args == tuple([sympify(a) for a in args])

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -7,6 +7,7 @@ import functools
 
 from sympy.core.compatibility import get_function_name
 from sympy.core.sympify import sympify
+from sympy.printing.str import sstr
 
 try:
     import py
@@ -174,3 +175,8 @@ def unchanged(func, *args):
     """
     f = func(*args)
     assert f.func == func and f.args == tuple([sympify(a) for a in args])
+
+
+def NS(e, n=15, **options):
+    """Return evaluated expression as a string."""
+    return sstr(sympify(e).evalf(n, **options), full_prec=True)


### PR DESCRIPTION
See issue #2942. 

There are at least 3 reasons that one might write a test that looks like `assert foo(a) == foo(a)`:

1) to test that the `eval` routine is working for the object -- sometimes there are special cases that shouldn't be changed and such a test is trying to say "foo(a) should still be foo(a) after evaluation." The problem with writing a test like that, however, is that it will always pass, even if foo(a) changed.To handle such tests, a function named `unchanged` has been added that allows one to assert that the function and arguments used to build the object remain unchanged, e.g. `foo(0).func is foo and foo(0).args == (0,)`.
2) to show that something no longer fails. In this case one doesn't care what the output is, only that it doesn't fail. The `unchanged` function will ignore tests that have an inline after them. This encourages users to tell why an apparently do-nothing test is being added: `assert foo(0) == foo(0)  # doesn't fail` will not raise an error during code quality checks.
3) to test the `__eq__` method of the object. By writing `assert foo == foo  # __eq__ check` the test will not be flagged.

Any unannotated foo==foo test will be flagged as a code quality error since it is not clear which of the 3 cases such a test was written for.

Another test that has been added to the code quality checks is one to see that every object has an `__eq__` method.
