### PR TITLE
Use '\ ' instead of '\quad' for latex of lists, tuples, and dicts

### DIFF
--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -82,7 +82,7 @@ def test_print_builtin_option():
         text = app.user_ns['a'][0]['text/plain']
         latex = app.user_ns['a'][0]['text/latex']
     assert text == u('{n\u1d62: 3, \u03c0: 3.14}')
-    assert latex == r'$$\left \{ n_{i} : 3, \quad \pi : 3.14\right \}$$'
+    assert latex == r'$$\left \{ n_{i} : 3, \  \pi : 3.14\right \}$$'
 
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
     app.run_cell("init_printing(use_latex=True, print_builtin=False)")

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1317,14 +1317,14 @@ class LatexPrinter(Printer):
 
     def _print_tuple(self, expr):
         return r"\left ( %s\right )" % \
-            r", \quad ".join([ self._print(i) for i in expr ])
+            r", \  ".join([ self._print(i) for i in expr ])
 
     def _print_Tuple(self, expr):
         return self._print_tuple(expr)
 
     def _print_list(self, expr):
         return r"\left [ %s\right ]" % \
-            r", \quad ".join([ self._print(i) for i in expr ])
+            r", \  ".join([ self._print(i) for i in expr ])
 
     def _print_dict(self, d):
         keys = sorted(d.keys(), key=default_sort_key)
@@ -1334,7 +1334,7 @@ class LatexPrinter(Printer):
             val = d[key]
             items.append("%s : %s" % (self._print(key), self._print(val)))
 
-        return r"\left \{ %s\right \}" % r", \quad ".join(items)
+        return r"\left \{ %s\right \}" % r", \  ".join(items)
 
     def _print_Dict(self, expr):
         return self._print_dict(expr)
@@ -1851,7 +1851,7 @@ def latex(expr, **settings):
     dictionary.
 
     >>> print(latex([2/x, y], mode='inline'))
-    $\left [ 2 / x, \quad y\right ]$
+    $\left [ 2 / x, \  y\right ]$
 
     """
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -240,9 +240,9 @@ def test_latex_functions():
     assert latex(Order(x, x)) == r"\mathcal{O}\left(x\right)"
     assert latex(Order(x, (x, 0))) == r"\mathcal{O}\left(x\right)"
     assert latex(Order(x, (x, oo))) == r"\mathcal{O}\left(x; x\rightarrow\infty\right)"
-    assert latex(Order(x, x, y)) == r"\mathcal{O}\left(x; \left ( x, \quad y\right )\rightarrow\left ( 0, \quad 0\right )\right)"
-    assert latex(Order(x, x, y)) == r"\mathcal{O}\left(x; \left ( x, \quad y\right )\rightarrow\left ( 0, \quad 0\right )\right)"
-    assert latex(Order(x, (x, oo), (y, oo))) == r"\mathcal{O}\left(x; \left ( x, \quad y\right )\rightarrow\left ( \infty, \quad \infty\right )\right)"
+    assert latex(Order(x, x, y)) == r"\mathcal{O}\left(x; \left ( x, \  y\right )\rightarrow\left ( 0, \  0\right )\right)"
+    assert latex(Order(x, x, y)) == r"\mathcal{O}\left(x; \left ( x, \  y\right )\rightarrow\left ( 0, \  0\right )\right)"
+    assert latex(Order(x, (x, oo), (y, oo))) == r"\mathcal{O}\left(x; \left ( x, \  y\right )\rightarrow\left ( \infty, \  \infty\right )\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
     assert latex(uppergamma(x, y)) == r'\Gamma\left(x, y\right)'
 
@@ -553,19 +553,19 @@ def test_latex():
         "\\begin{equation*}8 \\sqrt{2} \\mu^{\\frac{7}{2}}\\end{equation*}"
     assert latex((2*mu)**Rational(7, 2), mode='equation', itex=True) == \
         "$$8 \\sqrt{2} \\mu^{\\frac{7}{2}}$$"
-    assert latex([2/x, y]) == r"\left [ \frac{2}{x}, \quad y\right ]"
+    assert latex([2/x, y]) == r"\left [ \frac{2}{x}, \  y\right ]"
 
 
 def test_latex_dict():
     d = {Rational(1): 1, x**2: 2, x: 3, x**3: 4}
-    assert latex(d) == r'\left \{ 1 : 1, \quad x : 3, \quad x^{2} : 2, \quad x^{3} : 4\right \}'
+    assert latex(d) == r'\left \{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right \}'
     D = Dict(d)
-    assert latex(D) == r'\left \{ 1 : 1, \quad x : 3, \quad x^{2} : 2, \quad x^{3} : 4\right \}'
+    assert latex(D) == r'\left \{ 1 : 1, \  x : 3, \  x^{2} : 2, \  x^{3} : 4\right \}'
 
 
 def test_latex_list():
     l = [Symbol('omega1'), Symbol('a'), Symbol('alpha')]
-    assert latex(l) == r'\left [ \omega_{1}, \quad a, \quad \alpha\right ]'
+    assert latex(l) == r'\left [ \omega_{1}, \  a, \  \alpha\right ]'
 
 
 def test_latex_rational():
@@ -752,7 +752,7 @@ def test_latex_Lambda():
     assert latex(Lambda(x, x + 1)) == \
         r"\left( x \mapsto x + 1 \right)"
     assert latex(Lambda((x, y), x + 1)) == \
-        r"\left( \left ( x, \quad y\right ) \mapsto x + 1 \right)"
+        r"\left( \left ( x, \  y\right ) \mapsto x + 1 \right)"
 
 
 def test_latex_PolyElement():
@@ -954,19 +954,19 @@ def test_categories():
 
     d = Diagram({f1: "unique", f2: S.EmptySet})
     assert latex(d) == r"\left \{ f_{2}\circ f_{1}:A_{1}" \
-        r"\rightarrow A_{3} : \emptyset, \quad id:A_{1}\rightarrow " \
-        r"A_{1} : \emptyset, \quad id:A_{2}\rightarrow A_{2} : " \
-        r"\emptyset, \quad id:A_{3}\rightarrow A_{3} : \emptyset, " \
-        r"\quad f_{1}:A_{1}\rightarrow A_{2} : \left\{unique\right\}, " \
-        r"\quad f_{2}:A_{2}\rightarrow A_{3} : \emptyset\right \}"
+        r"\rightarrow A_{3} : \emptyset, \  id:A_{1}\rightarrow " \
+        r"A_{1} : \emptyset, \  id:A_{2}\rightarrow A_{2} : " \
+        r"\emptyset, \  id:A_{3}\rightarrow A_{3} : \emptyset, " \
+        r"\  f_{1}:A_{1}\rightarrow A_{2} : \left\{unique\right\}, " \
+        r"\  f_{2}:A_{2}\rightarrow A_{3} : \emptyset\right \}"
 
     d = Diagram({f1: "unique", f2: S.EmptySet}, {f2 * f1: "unique"})
     assert latex(d) == r"\left \{ f_{2}\circ f_{1}:A_{1}" \
-        r"\rightarrow A_{3} : \emptyset, \quad id:A_{1}\rightarrow " \
-        r"A_{1} : \emptyset, \quad id:A_{2}\rightarrow A_{2} : " \
-        r"\emptyset, \quad id:A_{3}\rightarrow A_{3} : \emptyset, " \
-        r"\quad f_{1}:A_{1}\rightarrow A_{2} : \left\{unique\right\}," \
-        r" \quad f_{2}:A_{2}\rightarrow A_{3} : \emptyset\right \}" \
+        r"\rightarrow A_{3} : \emptyset, \  id:A_{1}\rightarrow " \
+        r"A_{1} : \emptyset, \  id:A_{2}\rightarrow A_{2} : " \
+        r"\emptyset, \  id:A_{3}\rightarrow A_{3} : \emptyset, " \
+        r"\  f_{1}:A_{1}\rightarrow A_{2} : \left\{unique\right\}," \
+        r" \  f_{2}:A_{2}\rightarrow A_{3} : \emptyset\right \}" \
         r"\Longrightarrow \left \{ f_{2}\circ f_{1}:A_{1}" \
         r"\rightarrow A_{3} : \left\{unique\right\}\right \}"
 


### PR DESCRIPTION
See [this](https://twitter.com/asmeurer/status/487982939536248833) Twitter
discussion.
