### PR TITLE
atan2 recognizes im args

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -678,11 +678,17 @@ def test_atan2():
     assert atan2(y, x).rewrite(atan) == 2*atan(y/(x + sqrt(x**2 + y**2)))
 
     ex = atan2(y, x) - arg(x + I*y)
-    # these 4 agree with wolframalpha
     assert ex.subs({x:2, y:3}).rewrite(arg) == 0
-    assert ex.subs({x:2, y:3*I}).rewrite(arg) == -pi + I*atanh(3/S(2))
-    assert ex.subs({x:2*I, y:3}).rewrite(arg) == 3*pi/2 - I*atanh(3/S(2))
-    assert ex.subs({x:2*I, y:3*I}).rewrite(arg) == atan(2/S(3)) + atan(3/S(2))
+    assert ex.subs({x:2, y:3*I}).rewrite(arg) == -pi - I*log(sqrt(5)*I/5)
+    assert ex.subs({x:2*I, y:3}).rewrite(arg) == -pi/2 - I*log(sqrt(5)*I)
+    assert ex.subs({x:2*I, y:3*I}).rewrite(arg) == -pi + atan(2/S(3)) + atan(3/S(2))
+    i = symbols('i', imaginary=True)
+    r = symbols('r', real=True)
+    e = atan2(i, r)
+    rewrite = e.rewrite(arg)
+    reps = {i: I, r: -2}
+    assert rewrite == -I*log(abs(I*i + r)/sqrt(abs(i**2 + r**2))) + arg((I*i + r)/sqrt(i**2 + r**2))
+    assert (e - rewrite).subs(reps).equals(0)
 
     assert conjugate(atan2(x, y)) == atan2(conjugate(x), conjugate(y))
 

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -659,6 +659,12 @@ def test_atan2():
     assert atan2(-1, -1) == -3*pi/4
     assert atan2(-1, 0) == -pi/2
     assert atan2(-1, 1) == -pi/4
+    i = symbols('i', imaginary=True)
+    r = symbols('r', real=True)
+    eq = atan2(r, i)
+    ans = -I*log((i + I*r)/sqrt(i**2 + r**2))
+    reps = ((r, 2), (i, I))
+    assert eq.subs(reps) == ans.subs(reps)
 
     u = Symbol("u", positive=True)
     assert atan2(0, u) == 0
@@ -672,10 +678,11 @@ def test_atan2():
     assert atan2(y, x).rewrite(atan) == 2*atan(y/(x + sqrt(x**2 + y**2)))
 
     ex = atan2(y, x) - arg(x + I*y)
+    # these 4 agree with wolframalpha
     assert ex.subs({x:2, y:3}).rewrite(arg) == 0
-    assert ex.subs({x:2, y:3*I}).rewrite(arg) == 0
-    assert ex.subs({x:2*I, y:3}).rewrite(arg) == 0
-    assert ex.subs({x:2*I, y:3*I}).rewrite(arg) == 0
+    assert ex.subs({x:2, y:3*I}).rewrite(arg) == -pi + I*atanh(3/S(2))
+    assert ex.subs({x:2*I, y:3}).rewrite(arg) == 3*pi/2 - I*atanh(3/S(2))
+    assert ex.subs({x:2*I, y:3*I}).rewrite(arg) == atan(2/S(3)) + atan(3/S(2))
 
     assert conjugate(atan2(x, y)) == atan2(conjugate(x), conjugate(y))
 
@@ -684,8 +691,6 @@ def test_atan2():
 
     assert simplify(diff(atan2(y, x).rewrite(log), x)) == -y/(x**2 + y**2)
     assert simplify(diff(atan2(y, x).rewrite(log), y)) ==  x/(x**2 + y**2)
-
-    assert isinstance(atan2(2, 3*I).n(), atan2)
 
 
 def test_acot():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -4,7 +4,7 @@ from sympy.core.add import Add
 from sympy.core.basic import C, sympify, cacheit
 from sympy.core.singleton import S
 from sympy.core.numbers import igcdex
-from sympy.core.function import Function, ArgumentIndexError, AppliedUndef
+from sympy.core.function import Function, ArgumentIndexError
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
@@ -1958,10 +1958,9 @@ class atan2(Function):
                     return S.NaN
         if y.is_zero and x.is_real and x.is_nonzero:
             return S.Pi * (S.One - C.Heaviside(x))
-        if (x.is_number and not x.atoms(AppliedUndef) and
-                y.is_number and not y.atoms(AppliedUndef)):
+        if x.is_number and y.is_number:
             return -S.ImaginaryUnit*C.log(
-                (x + S.ImaginaryUnit*y) / sqrt(x**2 + y**2))
+                (x + S.ImaginaryUnit*y)/sqrt(x**2 + y**2))
 
     def _eval_rewrite_as_log(self, y, x):
         return -S.ImaginaryUnit*C.log((x + S.ImaginaryUnit*y) / sqrt(x**2 + y**2))
@@ -1970,8 +1969,12 @@ class atan2(Function):
         return 2*atan(y / (sqrt(x**2 + y**2) + x))
 
     def _eval_rewrite_as_arg(self, y, x):
-        if (x.is_real or x.is_imaginary) and (y.is_real or y.is_imaginary):
+        if x.is_real and y.is_real:
             return C.arg(x + y*S.ImaginaryUnit)
+        I = S.ImaginaryUnit
+        n = x + I*y
+        d = x**2 + y**2
+        return C.arg(n/sqrt(d)) - I*log(abs(n)/sqrt(abs(d)))
 
     def _eval_is_real(self):
         return self.args[0].is_real and self.args[1].is_real

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -4,7 +4,7 @@ from sympy.core.add import Add
 from sympy.core.basic import C, sympify, cacheit
 from sympy.core.singleton import S
 from sympy.core.numbers import igcdex
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import Function, ArgumentIndexError, AppliedUndef
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
@@ -1937,6 +1937,9 @@ class atan2(Function):
             return 2*S.Pi*(C.Heaviside(C.re(y))) - S.Pi
         elif x is S.Infinity:
             return S.Zero
+        elif x.is_imaginary and y.is_imaginary and x.is_number and y.is_number:
+            x = C.im(x)
+            y = C.im(y)
 
         if x.is_real and y.is_real:
             if x.is_positive:
@@ -1953,9 +1956,12 @@ class atan2(Function):
                     return -S.Pi/2
                 elif y.is_zero:
                     return S.NaN
-
         if y.is_zero and x.is_real and x.is_nonzero:
             return S.Pi * (S.One - C.Heaviside(x))
+        if (x.is_number and not x.atoms(AppliedUndef) and
+                y.is_number and not y.atoms(AppliedUndef)):
+            return -S.ImaginaryUnit*C.log(
+                (x + S.ImaginaryUnit*y) / sqrt(x**2 + y**2))
 
     def _eval_rewrite_as_log(self, y, x):
         return -S.ImaginaryUnit*C.log((x + S.ImaginaryUnit*y) / sqrt(x**2 + y**2))


### PR DESCRIPTION
The test used to decide whether to rewrite atan2 as arg did not discriminate against imaginary arguments for which the given expression did not apply. In addition, imaginary args are now recognized by the eval method of atan2 so something like atan2(2, 3*I) will not remain unevaluated.

In master

```
>>> from sympy import *
>>> atan2(2*I,I)
atan2(2*I, I)
>>> _.rewrite(arg)
-atan(1/2) + pi
>>> _.n()
2.67794504458899
>>> atan(2).n()
1.10714871779409
```

The rewriting is wrong and the imaginary arguments were not recognized.

In this branch

```
>>> from sympy import *
>>> atan2(2*I,I)
atan(2)
>>> atan2(2*I,I,evaluate=False)
atan2(2*I, I)
>>> _.rewrite(arg)
atan(2)
```
