### PR TITLE
modify test that took 4 minutes to compute

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -476,11 +476,9 @@ def test_cot():
 def test_cot_series():
     assert cot(x).series(x, 0, 9) == \
         1/x - x/3 - x**3/45 - 2*x**5/945 - x**7/4725 + O(x**9)
-    # issue 6210:
-    assert cot(x**20 + x**21 + x**22).series(x, 0, 4) == \
-        x**(-20) - 1/x**19 + x**(-17) - 1/x**16 + x**(-14) - 1/x**13 + \
-        x**(-11) - 1/x**10 + x**(-8) - 1/x**7 + x**(-5) - 1/x**4 + \
-        x**(-2) - 1/x + x - x**2 + O(x**4)
+    # issue 6210
+    assert cot(x**4 + x**5).series(x, 0, 1) == \
+        x**(-4) - 1/x**3 + x**(-2) - 1/x + 1 + O(x)
 
 
 def test_cot_rewrite():


### PR DESCRIPTION
Rather than marking it as slow I just modified the original expression to give something that failed before the original change was made which succeeded after the change...but takes a LOT less time.
