### PR TITLE
t, f = hyper_as_trig(e) should preserve f(t) = e invariant

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -2103,7 +2103,7 @@ def hyper_as_trig(rv):
     """
     from sympy.simplify.simplify import signsimp
 
-    # mask of trig functions
+    # mask off trig functions
     trigs = rv.atoms(C.TrigonometricFunction)
     reps = [(t, Dummy()) for t in trigs]
     masked = rv.xreplace(dict(reps))
@@ -2111,5 +2111,11 @@ def hyper_as_trig(rv):
     # get inversion substitutions in place
     reps = [(v, k) for k, v in reps]
 
-    return _osborne(masked), lambda x: signsimp(
+    t, f = _osborne(masked), lambda x: signsimp(
         _osbornei(x).xreplace(dict(reps)))
+
+    # test if the invariant holds
+    if signsimp(f(t) - rv) == 0:
+        return t, f
+    else:
+        return rv, lambda x: x

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -293,6 +293,10 @@ def test_trigsimp_issue_4032():
         2**(n/2)*cos(pi*n/4)/2 + 2**n/4
 
 
+def test_trigsimp_issue_7761():
+    assert trigsimp(cosh(pi/4)) == cosh(pi/4)
+
+
 def test_trigsimp_noncommutative():
     x, y = symbols('x,y')
     A, B = symbols('A,B', commutative=False)


### PR DESCRIPTION
This was not the case for constant expressions, see #7761.  Closes #7761.

@smichr
