### PR TITLE
Minor typo fixes in docs

### DIFF
--- a/doc/src/modules/utilities/codegen.rst
+++ b/doc/src/modules/utilities/codegen.rst
@@ -12,7 +12,7 @@ below for advanced users that may want to use the framework directly.
 
    >>> from sympy.utilities.codegen import codegen
 
-Impementation Details
+Implementation Details
 =====================
 
 Here we present the most important pieces of the internal structure, as

--- a/doc/src/modules/utilities/codegen.rst
+++ b/doc/src/modules/utilities/codegen.rst
@@ -13,7 +13,7 @@ below for advanced users that may want to use the framework directly.
    >>> from sympy.utilities.codegen import codegen
 
 Implementation Details
-=====================
+======================
 
 Here we present the most important pieces of the internal structure, as
 advanced users may want to use it directly, for instance by subclassing a code

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -537,7 +537,7 @@ class CCodeGen(CodeGen):
     Generator for C code
 
     The .write() method inherited from CodeGen will output a code file and an
-    inteface file, <prefix>.c and <prefix>.h respectively.
+    interface file, <prefix>.c and <prefix>.h respectively.
     """
 
     code_extension = "c"
@@ -693,7 +693,7 @@ class FCodeGen(CodeGen):
     Generator for Fortran 95 code
 
     The .write() method inherited from CodeGen will output a code file and an
-    inteface file, <prefix>.f90 and <prefix>.h respectively.
+    interface file, <prefix>.f90 and <prefix>.h respectively.
     """
 
     code_extension = "f90"

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -17,7 +17,7 @@ def get_string(dump_fn, routines, prefix="file", header=False, empty=False):
        this wrapper returns the contents of that stream as a string. This
        auxiliary function is used by many tests below.
 
-       The header and the empty lines are not generator to facilitate the
+       The header and the empty lines are not generated to facilitate the
        testing of the output.
     """
     output = StringIO()


### PR DESCRIPTION
Here are a few typos I found while looking at the codegen stuff.
