### PR TITLE
tests: shortcuts like "Lt" should give same as "<"

### DIFF
--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -430,3 +430,38 @@ def test_nan_equality_exceptions():
     assert Equality(random.choice(A), nan) is S.false
     assert Unequality(nan, random.choice(A)) is S.true
     assert Unequality(random.choice(A), nan) is S.true
+
+
+@XFAIL
+def test_inequalities_symbol_name_same():
+    """Using the operator and functional forms should give same results."""
+    # currently fails because rhs reduces to bool but the lhs does not
+    assert Lt(x, oo) == (x < oo)
+
+    # We test all combinations from a set
+    # FIXME: could replace with random selection after test passes
+    A = (x, y, S(0), S(1)/3, pi, oo, -oo)
+    for a in A:
+        for b in A:
+            assert Gt(a, b) == (a > b)
+            assert Lt(a, b) == (a < b)
+            assert Ge(a, b) == (a >= b)
+            assert Le(a, b) == (a <= b)
+
+
+@XFAIL
+def test_inequalities_symbol_name_same_complex():
+    """Using the operator and functional forms should give same results.
+    With complex non-real numbers, both should raise errors.
+    """
+    # FIXME: could replace with random selection after test passes
+    # FIXME: add NaN here too later
+    for a in (x, S(0), S(1)/3, pi, oo):
+        raises(TypeError, lambda: Gt(a, I))
+        raises(TypeError, lambda: a > I)
+        raises(TypeError, lambda: Lt(a, I))
+        raises(TypeError, lambda: a < I)
+        raises(TypeError, lambda: Ge(a, I))
+        raises(TypeError, lambda: a >= I)
+        raises(TypeError, lambda: Le(a, I))
+        raises(TypeError, lambda: a <= I)


### PR DESCRIPTION
In Issue #7775, @asmeurer said that `< and Lt should be the same`.  Here are some tests for that (which currently fail).
