### PR TITLE
Changed lambdify to use numpy.array for Matrix

### DIFF
--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -42,7 +42,7 @@ leveraging a variety of numerical libraries.  It is used as follows:
     >>> from sympy import *
     >>> from sympy.abc import x
     >>> expr = sin(x)/x
-    >>> f = lambdify(x, expr)
+    >>> f = lambdify(x, expr, new_defaults=True)
     >>> f(3.14)
     0.000507214304614
 
@@ -55,12 +55,16 @@ difference between SymPy and raw Python.
 Lambdify can leverage a variety of numerical backends.  By default it uses the
 ``math`` library.  However it also supports ``mpmath`` and most notably,
 ``numpy``.  Using the ``numpy`` library gives the generated function access to
-powerful vectorized ufuncs that are backed by compiled C code.
+powerful vectorized ufuncs that are backed by compiled C code. Previously
+``lambdify`` defaulted to expressing ``sympy.Matrix`` as ``numpy.Matrix``.
+This behavior is deprecated in favor of ``numpy.array``, and will be removed in
+the next release. For now, setting ``new_defaults=True`` will provide the
+new behavior, and avoid a ``SymPyDeprecationWarning``.
 
     >>> from sympy import *
     >>> from sympy.abc import x
     >>> expr = sin(x)/x
-    >>> f = lambdify(x, expr, "numpy")
+    >>> f = lambdify(x, expr, "numpy", new_defaults=True)
 
     >>> import numpy
     >>> data = numpy.linspace(1, 10, 10000)

--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -42,7 +42,7 @@ leveraging a variety of numerical libraries.  It is used as follows:
     >>> from sympy import *
     >>> from sympy.abc import x
     >>> expr = sin(x)/x
-    >>> f = lambdify(x, expr, new_defaults=True)
+    >>> f = lambdify(x, expr, default_array=True)
     >>> f(3.14)
     0.000507214304614
 
@@ -58,13 +58,14 @@ Lambdify can leverage a variety of numerical backends.  By default it uses the
 powerful vectorized ufuncs that are backed by compiled C code. Previously
 ``lambdify`` defaulted to expressing ``sympy.Matrix`` as ``numpy.Matrix``.
 This behavior is deprecated in favor of ``numpy.array``, and will be removed in
-the next release. For now, setting ``new_defaults=True`` will provide the
-new behavior, and avoid a ``SymPyDeprecationWarning``.
+the next release. For now, setting ``default_array=True`` will provide the
+new behavior, and avoid a ``SymPyDeprecationWarning``. See issue
+`#7853 <https://github.com/sympy/sympy/issues/7853>`_ for more information.
 
     >>> from sympy import *
     >>> from sympy.abc import x
     >>> expr = sin(x)/x
-    >>> f = lambdify(x, expr, "numpy", new_defaults=True)
+    >>> f = lambdify(x, expr, "numpy", default_array=True)
 
     >>> import numpy
     >>> data = numpy.linspace(1, 10, 10000)

--- a/doc/src/tutorial/basic_operations.rst
+++ b/doc/src/tutorial/basic_operations.rst
@@ -173,15 +173,20 @@ the given numerical library, usually NumPy.  For example
     >>> import numpy # doctest:+SKIP
     >>> a = numpy.arange(10) # doctest:+SKIP
     >>> expr = sin(x)
-    >>> f = lambdify(x, expr, "numpy") # doctest:+SKIP
+    >>> f = lambdify(x, expr, "numpy", new_defaults=True) # doctest:+SKIP
     >>> f(a) # doctest:+SKIP
     [ 0.          0.84147098  0.90929743  0.14112001 -0.7568025  -0.95892427
      -0.2794155   0.6569866   0.98935825  0.41211849]
+     
+Previously ``lambdify`` defaulted to expressing ``sympy.Matrix`` as
+``numpy.Matrix``.  This behavior is deprecated in favor of ``numpy.array``, and
+will be removed in the next release. For now, setting ``new_defaults=True``
+will provide the new behavior, and avoid a ``SymPyDeprecationWarning``.
 
 You can use other libraries than NumPy. For example, to use the standard
 library math module, use ``"math"``.
 
-    >>> f = lambdify(x, expr, "math")
+    >>> f = lambdify(x, expr, "math", new_defaults=True)
     >>> f(0.1)
     0.0998334166468
 
@@ -193,7 +198,7 @@ dictionary of ``sympy_name:numerical_function`` pairs.  For example
     ...     My sine. Not only accurate for small x.
     ...     """
     ...     return x
-    >>> f = lambdify(x, expr, {"sin":mysin})
+    >>> f = lambdify(x, expr, {"sin":mysin}, new_defaults=True)
     >>> f(0.1)
     0.1
 

--- a/doc/src/tutorial/basic_operations.rst
+++ b/doc/src/tutorial/basic_operations.rst
@@ -173,20 +173,21 @@ the given numerical library, usually NumPy.  For example
     >>> import numpy # doctest:+SKIP
     >>> a = numpy.arange(10) # doctest:+SKIP
     >>> expr = sin(x)
-    >>> f = lambdify(x, expr, "numpy", new_defaults=True) # doctest:+SKIP
+    >>> f = lambdify(x, expr, "numpy", default_array=True) # doctest:+SKIP
     >>> f(a) # doctest:+SKIP
     [ 0.          0.84147098  0.90929743  0.14112001 -0.7568025  -0.95892427
      -0.2794155   0.6569866   0.98935825  0.41211849]
      
 Previously ``lambdify`` defaulted to expressing ``sympy.Matrix`` as
 ``numpy.Matrix``.  This behavior is deprecated in favor of ``numpy.array``, and
-will be removed in the next release. For now, setting ``new_defaults=True``
+will be removed in the next release. For now, setting ``default_array=True``
 will provide the new behavior, and avoid a ``SymPyDeprecationWarning``.
+See issue `#7853 <https://github.com/sympy/sympy/issues/7853>`_ for more information.
 
 You can use other libraries than NumPy. For example, to use the standard
 library math module, use ``"math"``.
 
-    >>> f = lambdify(x, expr, "math", new_defaults=True)
+    >>> f = lambdify(x, expr, "math", default_array=True)
     >>> f(0.1)
     0.0998334166468
 
@@ -198,7 +199,7 @@ dictionary of ``sympy_name:numerical_function`` pairs.  For example
     ...     My sine. Not only accurate for small x.
     ...     """
     ...     return x
-    >>> f = lambdify(x, expr, {"sin":mysin}, new_defaults=True)
+    >>> f = lambdify(x, expr, {"sin":mysin}, default_array=True)
     >>> f(0.1)
     0.1
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1025,9 +1025,9 @@ def hypsum(expr, n, start, prec):
     polynomials.
     """
     from sympy import hypersimp, lambdify
-    # TODO: This should be removed for the release of 0.7.7
+    # TODO: This should be removed for the release of 0.7.7, see issue #7853
     from functools import partial
-    lambdify = partial(lambdify, new_defaults=True)
+    lambdify = partial(lambdify, default_array=True)
 
     if start:
         expr = expr.subs(n, n + start)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1025,6 +1025,9 @@ def hypsum(expr, n, start, prec):
     polynomials.
     """
     from sympy import hypersimp, lambdify
+    # TODO: This should be removed for the release of 0.7.7
+    from functools import partial
+    lambdify = partial(lambdify, new_defaults=True)
 
     if start:
         expr = expr.subs(n, n + start)

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -31,6 +31,10 @@ from sympy import mpmath
 from sympy.abc import x, y, z
 from sympy.utilities.decorator import conserve_mpmath_dps
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 # first, systematically check, that all operations are implemented and don't
 # raise an exception
 
@@ -246,7 +250,7 @@ def test_lambdify():
 
 def test_lambdify_matrix():
     f = lambdify(x, Matrix([[x, 2*x], [1, 2]]), "numpy")
-    assert (f(1) == matrix([[1, 2], [1, 2]])).all()
+    assert (f(1) == array([[1, 2], [1, 2]])).all()
 
 
 def test_lambdify_matrix_multi_input():
@@ -256,9 +260,9 @@ def test_lambdify_matrix_multi_input():
     f = lambdify((x, y, z), M, "numpy")
 
     xh, yh, zh = 1.0, 2.0, 3.0
-    expected = matrix([[xh**2, xh*yh, xh*zh],
-                       [yh*xh, yh**2, yh*zh],
-                       [zh*xh, zh*yh, zh**2]])
+    expected = array([[xh**2, xh*yh, xh*zh],
+                      [yh*xh, yh**2, yh*zh],
+                      [zh*xh, zh*yh, zh**2]])
     actual = f(xh, yh, zh)
     assert numpy.allclose(actual, expected)
 
@@ -272,9 +276,9 @@ def test_lambdify_matrix_vec_input():
     f = lambdify(X, M, "numpy")
 
     Xh = array([1.0, 2.0, 3.0])
-    expected = matrix([[Xh[0]**2, Xh[0]*Xh[1], Xh[0]*Xh[2]],
-                       [Xh[1]*Xh[0], Xh[1]**2, Xh[1]*Xh[2]],
-                       [Xh[2]*Xh[0], Xh[2]*Xh[1], Xh[2]**2]])
+    expected = array([[Xh[0]**2, Xh[0]*Xh[1], Xh[0]*Xh[2]],
+                      [Xh[1]*Xh[0], Xh[1]**2, Xh[1]*Xh[2]],
+                      [Xh[2]*Xh[0], Xh[2]*Xh[1], Xh[2]**2]])
     actual = f(Xh)
     assert numpy.allclose(actual, expected)
 

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -31,9 +31,9 @@ from sympy import mpmath
 from sympy.abc import x, y, z
 from sympy.utilities.decorator import conserve_mpmath_dps
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 # first, systematically check, that all operations are implemented and don't
 # raise an exception

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -6,9 +6,9 @@ from sympy import (
 )
 from sympy.utilities.pytest import XFAIL, raises
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 x, y = symbols('x y')
 z = symbols('z', nonzero=True)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -6,6 +6,10 @@ from sympy import (
 )
 from sympy.utilities.pytest import XFAIL, raises
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 x, y = symbols('x y')
 z = symbols('z', nonzero=True)
 

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -73,7 +73,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 3
         >>> knots = range(10)
         >>> b0 = bspline_basis(d, knots, 0, x)
-        >>> f = lambdify(x, b0, new_defaults=True)
+        >>> f = lambdify(x, b0, default_array=True)
         >>> y = f(0.5)
 
     See Also

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -73,7 +73,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 3
         >>> knots = range(10)
         >>> b0 = bspline_basis(d, knots, 0, x)
-        >>> f = lambdify(x, b0)
+        >>> f = lambdify(x, b0, new_defaults=True)
         >>> y = f(0.5)
 
     See Also

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -31,6 +31,10 @@ import random
 
 from sympy.utilities.decorator import doctest_depends_on
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 
 class Ellipse(GeometryEntity):
     """An elliptical GeometryEntity.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -31,9 +31,9 @@ import random
 
 from sympy.utilities.decorator import doctest_depends_on
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 
 class Ellipse(GeometryEntity):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -53,7 +53,7 @@ class DeferredVector(Symbol, NotIterable):
     >>> X
     X
     >>> expr = (X[0] + 2, X[2] + 3)
-    >>> func = lambdify( X, expr, new_defaults=True )
+    >>> func = lambdify( X, expr, default_array=True )
     >>> func( [1, 2, 3] )
     (3, 6)
     """

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -53,7 +53,7 @@ class DeferredVector(Symbol, NotIterable):
     >>> X
     X
     >>> expr = (X[0] + 2, X[2] + 3)
-    >>> func = lambdify( X, expr )
+    >>> func = lambdify( X, expr, new_defaults=True )
     >>> func( [1, 2, 3] )
     (3, 6)
     """

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -4,6 +4,10 @@ from sympy import Basic, Symbol, symbols, lambdify
 from util import interpolate, rinterpolate, create_bounds, update_bounds
 from sympy.core.compatibility import xrange
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 
 class ColorGradient(object):
     colors = [0.4, 0.4, 0.4], [0.9, 0.9, 0.9]

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -4,9 +4,9 @@ from sympy import Basic, Symbol, symbols, lambdify
 from util import interpolate, rinterpolate, create_bounds, update_bounds
 from sympy.core.compatibility import xrange
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 
 class ColorGradient(object):

--- a/sympy/plotting/pygletplot/plot_modes.py
+++ b/sympy/plotting/pygletplot/plot_modes.py
@@ -8,6 +8,9 @@ from sympy.functions import sin, cos
 from math import sin as p_sin
 from math import cos as p_cos
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
 
 def float_vec3(f):
     def inner(*args):

--- a/sympy/plotting/pygletplot/plot_modes.py
+++ b/sympy/plotting/pygletplot/plot_modes.py
@@ -8,9 +8,9 @@ from sympy.functions import sin, cos
 from math import sin as p_sin
 from math import cos as p_cos
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 def float_vec3(f):
     def inner(*args):

--- a/sympy/plotting/textplot.py
+++ b/sympy/plotting/textplot.py
@@ -3,6 +3,10 @@ from __future__ import print_function, division
 from sympy.core.symbol import Dummy
 from sympy.utilities.lambdify import lambdify
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 
 def textplot(expr, a, b, W=55, H=18):
     """

--- a/sympy/plotting/textplot.py
+++ b/sympy/plotting/textplot.py
@@ -3,9 +3,9 @@ from __future__ import print_function, division
 from sympy.core.symbol import Dummy
 from sympy.utilities.lambdify import lambdify
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 
 def textplot(expr, a, b, W=55, H=18):

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -52,9 +52,9 @@ from sympy.mpmath import pslq, mp
 from sympy.core.compatibility import reduce
 from sympy.core.compatibility import xrange
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 
 def _choose_factor(factors, x, v, dom=QQ, prec=200, bound=5):

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -52,6 +52,10 @@ from sympy.mpmath import pslq, mp
 from sympy.core.compatibility import reduce
 from sympy.core.compatibility import xrange
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 
 def _choose_factor(factors, x, v, dom=QQ, prec=200, bound=5):
     """

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -32,9 +32,9 @@ from sympy.utilities import lambdify, public
 
 from sympy.core.compatibility import xrange
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 _reals_cache = {}
 _complexes_cache = {}

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -32,6 +32,10 @@ from sympy.utilities import lambdify, public
 
 from sympy.core.compatibility import xrange
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 _reals_cache = {}
 _complexes_cache = {}
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -58,6 +58,10 @@ from types import GeneratorType
 from collections import defaultdict
 import warnings
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 
 def _ispow(e):
     """Return True if e is a Pow or is exp."""

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -58,9 +58,9 @@ from types import GeneratorType
 from collections import defaultdict
 import warnings
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 
 def _ispow(e):

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -4,6 +4,10 @@ from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.pytest import raises, XFAIL
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 
 def test_nsolve():
     # onedimensional

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -4,9 +4,9 @@ from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.pytest import raises, XFAIL
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 
 def test_nsolve():

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -20,6 +20,10 @@ from sympy.core.compatibility import reduce
 from sympy.sets.sets import FiniteSet, ProductSet
 from sympy.abc import x
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 
 class RandomDomain(Basic):
     """

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -20,9 +20,9 @@ from sympy.core.compatibility import reduce
 from sympy.sets.sets import FiniteSet, ProductSet
 from sympy.abc import x
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 
 class RandomDomain(Basic):

--- a/sympy/utilities/compilef.py
+++ b/sympy/utilities/compilef.py
@@ -426,9 +426,9 @@ void evalonarray(double *array, int length)
 from sympy import sqrt, pi, lambdify
 from math import exp as _exp, cos as _cos, sin as _sin
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 
 def test_cexpr():

--- a/sympy/utilities/compilef.py
+++ b/sympy/utilities/compilef.py
@@ -426,6 +426,10 @@ void evalonarray(double *array, int length)
 from sympy import sqrt, pi, lambdify
 from math import exp as _exp, cos as _cos, sin as _sin
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 
 def test_cexpr():
     expr = '1/(g(x)*3.5)**(x - a**x)/(x**2 + a)'

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -8,8 +8,11 @@ from __future__ import print_function, division
 from sympy.external import import_module
 from sympy.core.compatibility import exec_, is_sequence, iterable, string_types
 from sympy.utilities.decorator import doctest_depends_on
-
 import inspect
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+import warnings
+
+warnings.simplefilter("always", SymPyDeprecationWarning)
 
 # These are the namespaces the lambda functions will use.
 MATH = {}
@@ -76,9 +79,9 @@ NUMPY_TRANSLATIONS = {
     "E": "e",
     "im": "imag",
     "ln": "log",
-    "Matrix": "matrix",
-    "MutableDenseMatrix": "matrix",
-    "ImmutableMatrix": "matrix",
+    "Matrix": "array",
+    "MutableDenseMatrix": "array",
+    "ImmutableMatrix": "array",
     "Max": "amax",
     "Min": "amin",
     "oo": "inf",
@@ -146,7 +149,7 @@ def _import(module, reload="False"):
 
 @doctest_depends_on(modules=('numpy'))
 def lambdify(args, expr, modules=None, printer=None, use_imps=True,
-        dummify=True, use_array=False):
+        dummify=True, new_defaults=False):
     """
     Returns a lambda function for fast calculation of numerical values.
 
@@ -168,16 +171,26 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     to view the lambdified function or provide "sympy" as the module, you
     should probably set dummify=False.
 
-    If numpy is installed, the default behavior is to substitute Sympy Matrices
-    with numpy.matrix. If you would rather have a numpy.array returned,
-    set use_array=True.
+    Deprecation Warnings
+    ====================
+
+    In previous releases ``lambdify`` replaced ``Matrix`` with ``numpy.matrix``
+    by default. As of release 0.7.6 ``numpy.array`` is being transitioned to
+    the default. In release 0.7.7 this transition will be complete. For now,
+    to use the new default behavior you must pass in ``new_defaults=True``. If
+    you plan on using ``lambdify`` often in your code it may be to your benefit
+    to apply ``functools.partial``:
+
+        >>> from sympy import lambdify
+        >>> from functools import partial
+        >>> lambdify = partial(lambdify, new_defaults=True)
 
     Usage
     =====
 
     (1) Use one of the provided modules:
 
-        >>> from sympy import lambdify, sin, tan, gamma
+        >>> from sympy import sin, tan, gamma
         >>> from sympy.utilities.lambdify import lambdastr
         >>> from sympy.abc import x, y
         >>> f = lambdify(x, sin(x), "math")
@@ -215,7 +228,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     Examples
     ========
 
-    >>> from sympy.utilities.lambdify import implemented_function, lambdify
+    >>> from sympy.utilities.lambdify import implemented_function
     >>> from sympy import sqrt, sin, Matrix
     >>> from sympy import Function
     >>> from sympy.abc import w, x, y, z
@@ -235,10 +248,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> row = lambdify((x, y), Matrix((x, x + y)).T, modules='sympy')
     >>> row(1, 2)
     Matrix([[1, 3]])
-    >>> col = lambdify((x, y), Matrix((x, x + y)), use_array=True)
-    >>> col(1, 2)
-    array([[1],
-           [3]])
 
     Tuple arguments are handled and the lambdified function should
     be called with the same type of arguments as were used to create
@@ -283,17 +292,25 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         #      might be the reason for irreproducible errors.
         modules = ["math", "mpmath", "sympy"]
 
-        #If numpy.array should be used instead of numpy.matrix
-        if use_array:
-            NUMPY_TRANSLATIONS.update({"Matrix": "array",
-                "MutableDenseMatrix": "array",
-                "ImmutableMatrix": "array"})
-        else:
-            #Ensures that the translation dict is set back
-            #to matrix if lambdify was already called
+        # If the new defaults should be used (part of the deprecation cycle)
+        if not new_defaults:
+            # Ensures that the translation dict is set back
+            # to matrix if lambdify was already called
             NUMPY_TRANSLATIONS.update({"Matrix": "matrix",
                 "MutableDenseMatrix": "matrix",
                 "ImmutableMatrix": "matrix"})
+            SymPyDeprecationWarning("Replacing sympy.Matrix with numpy.matrix "
+                                    "by default is deprecated in favor of "
+                                    "numpy.array. For now, to use the new "
+                                    "behavior and remove the warning set "
+                                    "the kwarg new_defaults=True. The old "
+                                    "behavior can still be used by passing "
+                                    "in a custom dictionary to the modules "
+                                    "kwarg.").warn()
+        else:
+            NUMPY_TRANSLATIONS.update({"Matrix": "array",
+                "MutableDenseMatrix": "array",
+                "ImmutableMatrix": "array"})
         #Attempt to import numpy
         try:
             _import("numpy")
@@ -556,7 +573,7 @@ def implemented_function(symfunc, implementation):
     >>> from sympy.utilities.lambdify import lambdify, implemented_function
     >>> from sympy import Function
     >>> f = implemented_function(Function('f'), lambda x: x+1)
-    >>> lam_f = lambdify(x, f(x))
+    >>> lam_f = lambdify(x, f(x), new_defaults=True)
     >>> lam_f(4)
     5
     """

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -149,7 +149,7 @@ def _import(module, reload="False"):
 
 @doctest_depends_on(modules=('numpy'))
 def lambdify(args, expr, modules=None, printer=None, use_imps=True,
-        dummify=True, new_defaults=False):
+        dummify=True, default_array=False):
     """
     Returns a lambda function for fast calculation of numerical values.
 
@@ -177,13 +177,13 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     In previous releases ``lambdify`` replaced ``Matrix`` with ``numpy.matrix``
     by default. As of release 0.7.6 ``numpy.array`` is being transitioned to
     the default. In release 0.7.7 this transition will be complete. For now,
-    to use the new default behavior you must pass in ``new_defaults=True``. If
+    to use the new default behavior you must pass in ``default_array=True``. If
     you plan on using ``lambdify`` often in your code it may be to your benefit
     to apply ``functools.partial``:
 
         >>> from sympy import lambdify
         >>> from functools import partial
-        >>> lambdify = partial(lambdify, new_defaults=True)
+        >>> lambdify = partial(lambdify, default_array=True)
 
     Usage
     =====
@@ -293,7 +293,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         modules = ["math", "mpmath", "sympy"]
 
         # If the new defaults should be used (part of the deprecation cycle)
-        if not new_defaults:
+        if not default_array:
             # Ensures that the translation dict is set back
             # to matrix if lambdify was already called
             NUMPY_TRANSLATIONS.update({"Matrix": "matrix",
@@ -303,10 +303,10 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
                                     "by default is deprecated in favor of "
                                     "numpy.array. For now, to use the new "
                                     "behavior and remove the warning set "
-                                    "the kwarg new_defaults=True. The old "
+                                    "the kwarg default_array=True. The old "
                                     "behavior can still be used by passing "
                                     "in a custom dictionary to the modules "
-                                    "kwarg.").warn()
+                                    "kwarg.", issue=7853).warn()
         else:
             NUMPY_TRANSLATIONS.update({"Matrix": "array",
                 "MutableDenseMatrix": "array",
@@ -573,7 +573,7 @@ def implemented_function(symfunc, implementation):
     >>> from sympy.utilities.lambdify import lambdify, implemented_function
     >>> from sympy import Function
     >>> f = implemented_function(Function('f'), lambda x: x+1)
-    >>> lam_f = lambdify(x, f(x), new_defaults=True)
+    >>> lam_f = lambdify(x, f(x), default_array=True)
     >>> lam_f(4)
     5
     """

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -11,9 +11,9 @@ from sympy.external import import_module
 import math
 import sympy
 
-# TODO: This should be removed for the release of 0.7.7
+# TODO: This should be removed for the release of 0.7.7, see issue #7853
 from functools import partial
-lambdify = partial(lambdify, new_defaults=True)
+lambdify = partial(lambdify, default_array=True)
 
 MutableDenseMatrix = Matrix
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -11,6 +11,10 @@ from sympy.external import import_module
 import math
 import sympy
 
+# TODO: This should be removed for the release of 0.7.7
+from functools import partial
+lambdify = partial(lambdify, new_defaults=True)
+
 MutableDenseMatrix = Matrix
 
 numpy = import_module('numpy')
@@ -263,16 +267,12 @@ def test_numpy_matrix():
     if not numpy:
         skip("numpy not installed.")
     A = Matrix([[x, x*y], [sin(z) + 4, x**z]])
-    sol_mat = numpy.matrix([[1, 2], [numpy.sin(3) + 4, 1]])
     sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
     #Lambdify array first, to ensure return to matrix as default
-    f_arr = lambdify((x, y, z), A, use_array=True)(1, 2, 3)
-    f_mat = lambdify((x, y, z), A)(1, 2, 3)
-    numpy.testing.assert_allclose(f_mat, sol_mat)
-    numpy.testing.assert_allclose(f_arr, sol_arr)
+    f = lambdify((x, y, z), A)
+    numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
     #Check that the types are arrays and matrices
-    assert isinstance(f_mat, numpy.matrix)
-    assert isinstance(f_arr, numpy.ndarray)
+    assert isinstance(f(1, 2, 3), numpy.ndarray)
 
 def test_integral():
     f = Lambda(x, exp(-x**2))
@@ -400,7 +400,7 @@ def test_python_keywords():
     # functions. This is an additional regression test.
     python_if = symbols('if')
     expr = python_if / 2
-    f = sympy.lambdify(python_if, expr)
+    f = lambdify(python_if, expr)
     assert f(4.0) == 2.0
 
 


### PR DESCRIPTION
This is the first step on moving towards using numpy.array to represent
sympy.Matrix by default. This change adds a kwarg `new_defaults` that
defaults to False. If it's False, the previous behavior (numpy.matrix)
is used, and a SymPyDeprecationWarning is issued. If it's True, the new
default of numpy.array is used. In the next release this kwarg should be
removed. Fixes #7284.
