### PR TITLE
Initialize missing values in Medium constructor

### DIFF
--- a/sympy/physics/optics/medium.py
+++ b/sympy/physics/optics/medium.py
@@ -71,6 +71,9 @@ class Medium(Symbol):
             if permittivity != None and permittivity != None:
                 if abs(n - c*sqrt(obj._permittivity*obj._permeability)) > 1e-6:
                    raise ValueError("Values are not consistent.")
+            if permittivity is None and permeability is None:
+                obj._permittivity = e0
+                obj._permeability = u0
         elif permittivity is not None and permeability is not None:
             obj._n = c*sqrt(permittivity*permeability)
         elif permittivity is None and permeability is None:

--- a/sympy/physics/optics/tests/test_medium.py
+++ b/sympy/physics/optics/tests/test_medium.py
@@ -36,3 +36,9 @@ def test_medium():
     assert simplify(m5.refractive_index - 1.33000000000000) == 0
     assert simplify(m5.permittivity - 7.1e-10*A**2*s**4/(kg*m**3)) == 0
     assert simplify(m5.permeability - 2.77206575232851e-8*kg*m/(A**2*s**2)) == 0
+    m6 = Medium('m5', permittivity=710*10**(-12)*s**4*A**2/(m**3*kg), n=1.33)
+    assert m5 == m6
+    assert m5 != m4
+    n = Symbol('n')
+    m7 = Medium('m7', permeability=u0, n=Symbol('n'))
+    m7.refractive_index == sqrt(n**2)

--- a/sympy/physics/optics/tests/test_medium.py
+++ b/sympy/physics/optics/tests/test_medium.py
@@ -7,6 +7,8 @@ from sympy.physics.units import c, u0, e0, m, kg, s, A
 
 def test_medium():
     m1 = Medium('m1')
+    m2 = Medium('m2', n=Symbol('m2'))
+    assert m2.refractive_index == 1
     assert m1.intrinsic_impedance == sqrt(u0/e0)
     assert m1.speed == 1/sqrt(e0*u0)
     assert m1.refractive_index == c*sqrt(e0*u0)


### PR DESCRIPTION
Initialize permittivity and permeability of Medium with e0 and u0 respectively when not provided in the parameters
