### PR TITLE
proper rendering of the Beta function

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -821,6 +821,15 @@ class LatexPrinter(Printer):
         else:
             return r"\Gamma%s" % tex
 
+    def _print_beta(self, expr, exp=None):
+        tex = r"\left(%s, %s\right)" % (self._print(expr.args[0]),
+                                        self._print(expr.args[1]))
+
+        if exp is not None:
+            return r"\operatorname{B}^{%s}%s" % (exp, tex)
+        else:
+            return r"\operatorname{B}%s" % tex
+
     def _print_uppergamma(self, expr, exp=None):
         tex = r"\left(%s, %s\right)" % (self._print(expr.args[0]),
                                         self._print(expr.args[1]))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1032,6 +1032,16 @@ class PrettyPrinter(Printer):
         else:
             return self._print_Function(e)
 
+    def _print_beta(self, e):
+        if self._use_unicode:
+            pform = self._print(e.args[0])
+            pform = prettyForm(*pform.right(', ', self._print(e.args[1])))
+            pform = prettyForm(*pform.parens())
+            pform = prettyForm(*pform.left(u('B')))
+            return pform
+        else:
+            return self._print_Function(e)
+
     def _print_uppergamma(self, e):
         if self._use_unicode:
             pform = self._print(e.args[0])


### PR DESCRIPTION
printing out an expression involving the beta function would display it in terms of the gamma function, both in an IPython notebook (screenshot below) and in the console. This fixes that, using a non-italicized roman upper case "B" which is a function of two arguments.

![image](https://cloud.githubusercontent.com/assets/573848/3791415/7ba58d24-1b3b-11e4-8827-523f601e2c2f.png)
