### PR TITLE
Code Printing refactor, matrix support

### DIFF
--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -188,8 +188,8 @@ However, when the user_functions argument is not provided, ``fcode`` attempts to
 use a reasonable default and adds a comment to inform the user of the issue.
 
     >>> print(fcode(1 - gamma(x)**2))
-    C     Not Fortran:
-    C     gamma(x)
+    C     Not supported in Fortran:
+    C     gamma
           -gamma(x)**2 + 1
 
 By default the output is human readable code, ready for copy and paste. With the

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -136,10 +136,13 @@ For piecewise functions, the ``assign_to`` option is mandatory:
             var = x**2
           end if
 
-Note that only top-level piecewise functions are supported due to the lack of
-a conditional operator in Fortran. Nested piecewise functions would require the
-introduction of temporary variables, which is a type of expression manipulation
-that goes beyond the scope of ``fcode``.
+Note that by default only top-level piecewise functions are supported due to
+the lack of a conditional operator in Fortran 77. Inline conditionals can be
+supported using the ``merge`` function introduced in Fortran 95 by setting of
+the kwarg ``standard=95``:
+
+    >>> print(fcode(Piecewise((x,x<1),(x**2,True)), standard=95))
+          merge(x, x**2, x < 1)
 
 Loops are generated if there are Indexed objects in the expression. This
 also requires use of the assign_to option.
@@ -181,7 +184,7 @@ function.
 When some functions are not part of the Fortran standard, it might be desirable
 to introduce the names of user-defined functions in the Fortran expression.
 
-    >>> print(fcode(1 - gamma(x)**2, user_functions={gamma: 'mygamma'}))
+    >>> print(fcode(1 - gamma(x)**2, user_functions={'gamma': 'mygamma'}))
           -mygamma(x)**2 + 1
 
 However, when the user_functions argument is not provided, ``fcode`` attempts to

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3212,6 +3212,11 @@ def test_sympy__physics__optics__medium__Medium():
     assert _test_args(Medium('m'))
 
 
+def test_sympy__printing__codeprinter__Assignment():
+    from sympy.printing.codeprinter import Assignment
+    assert _test_args(Assignment(x, y))
+
+
 def test_sympy__vector__coordsysrect__CoordSysCartesian():
     from sympy.vector.coordsysrect import CoordSysCartesian
     assert _test_args(CoordSysCartesian('C'))

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -75,7 +75,8 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
         """
         if not hasattr(other, 'shape') or self.shape != other.shape:
             return S.false
-        if isinstance(other, MatrixExpr):
+        if isinstance(other, MatrixExpr) and not isinstance(
+                other, ImmutableMatrix):
             return None
         diff = self - other
         return sympify(diff.is_zero)

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -75,6 +75,8 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
         """
         if not hasattr(other, 'shape') or self.shape != other.shape:
             return S.false
+        if isinstance(other, MatrixExpr):
+            return None
         diff = self - other
         return sympify(diff.is_zero)
 

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -57,10 +57,10 @@ class CCodePrinter(CodePrinter):
         return "%s;" % codestring
 
     def _get_comment(self, text):
-        return "// {:}".format(text)
+        return "// {0}".format(text)
 
     def _declare_number_const(self, name, value):
-        return "double const {:} = {:};".format(name, value)
+        return "double const {0} = {1};".format(name, value)
 
     def _format_code(self, lines):
         return self.indent_code(lines)
@@ -167,7 +167,7 @@ class CCodePrinter(CodePrinter):
         return CodePrinter._print_Function(self, expr)
 
     def _print_MatrixElement(self, expr):
-        return "{:}[{:}][{:}]".format(expr.parent, expr.i, expr.j)
+        return "{0}[{1}][{2}]".format(expr.parent, expr.i, expr.j)
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -206,6 +206,10 @@ def ccode(expr, assign_to=None, **settings):
 
         expr : sympy.core.Expr
             a sympy expression to be converted
+        assign_to : optional
+            When given, the argument is used as the name of the
+            variable to which the Fortran expression is assigned.
+            (This is helpful in case of line-wrapping.)
         precision : optional
             the precision for numbers such as pi [default=15]
         user_functions : optional

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -201,41 +201,12 @@ class CCodePrinter(CodePrinter):
             return self._print(expr._imp_(*expr.args))
         return CodePrinter._print_Function(self, expr)
 
+    def _traverse_matrix_indices(self, mat):
+        rows, cols = mat.shape
+        return ((i, j) for i in range(rows) for j in range(cols))
+
     def _print_MatrixElement(self, expr):
         return "{:}[{:}][{:}]".format(expr.parent, expr.i, expr.j)
-
-    def _print_Assignment(self, expr):
-        lhs = expr.lhs
-        rhs = expr.rhs
-        # We special case assignments that take multiple lines
-        if isinstance(expr.rhs, C.Piecewise):
-            # Here we modify Piecewise so each expression is now
-            # an Assignment, and then continue on the print.
-            expressions = []
-            conditions = []
-            for (e, c) in rhs.args:
-                expressions.append(Assignment(lhs, e))
-                conditions.append(c)
-            temp = C.Piecewise(*zip(expressions, conditions))
-            return self._print(temp)
-        elif isinstance(lhs, C.MatrixSymbol):
-            # Here we form an Assignment for each element in the array,
-            # printing each one.
-            rows, cols = lhs.shape
-            lines = []
-            for j in range(cols):
-                for i in range(rows):
-                    temp = Assignment(lhs[i, j], rhs[i, j])
-                    code0 = self._print(temp)
-                    lines.append(code0)
-            return "\n".join(lines)
-        elif isinstance(lhs, C.Indexed):
-            # Here we handle an indexed loop
-            return self._doprint_indexed_loop(rhs, lhs)
-        else:
-            lhs_text = self._print(lhs)
-            rhs_text = self._print(rhs)
-            return "{:} = {:};".format(lhs_text, rhs_text)
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -21,9 +21,26 @@ from sympy.printing.precedence import precedence
 # dictionary mapping sympy function to (argument_conditions, C_function).
 # Used in CCodePrinter._print_Function(self)
 known_functions = {
-    "ceiling": [(lambda x: True, "ceil")],
     "Abs": [(lambda x: not x.is_integer, "fabs")],
-    "gamma": [(lambda x: True, "tgamma")],
+    "gamma": "tgamma",
+    "sin": "sin",
+    "cos": "cos",
+    "tan": "tan",
+    "asin": "asin",
+    "acos": "acos",
+    "atan": "atan",
+    "atan2": "atan2",
+    "exp": "exp",
+    "log": "log",
+    "erf": "erf",
+    "sinh": "sinh",
+    "cosh": "cosh",
+    "tanh": "tanh",
+    "asinh": "asinh",
+    "acosh": "acosh",
+    "atanh": "atanh",
+    "floor": "floor",
+    "ceiling": "ceil",
 }
 
 
@@ -45,9 +62,6 @@ class CCodePrinter(CodePrinter):
         CodePrinter.__init__(self, settings)
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {})
-        for k, v in userfuncs.items():
-            if not isinstance(v, list):
-                userfuncs[k] = [(lambda *x: True, v)]
         self.known_functions.update(userfuncs)
 
     def _rate_index_position(self, p):
@@ -155,17 +169,6 @@ class CCodePrinter(CodePrinter):
             last_line = ": (\n%s\n)" % self._print(expr.args[-1].expr)
             return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
-    def _print_Function(self, expr):
-        if expr.func.__name__ in self.known_functions:
-            cond_cfunc = self.known_functions[expr.func.__name__]
-            for cond, cfunc in cond_cfunc:
-                if cond(*expr.args):
-                    return "%s(%s)" % (cfunc, self.stringify(expr.args, ", "))
-        if hasattr(expr, '_imp_') and isinstance(expr._imp_, C.Lambda):
-            # inlined function
-            return self._print(expr._imp_(*expr.args))
-        return CodePrinter._print_Function(self, expr)
-
     def _print_MatrixElement(self, expr):
         return "{0}[{1}][{2}]".format(expr.parent, expr.i, expr.j)
 
@@ -199,64 +202,110 @@ class CCodePrinter(CodePrinter):
 
 
 def ccode(expr, assign_to=None, **settings):
-    r"""Converts an expr to a string of c code
+    """Converts an expr to a string of c code
 
-        Parameters
-        ==========
+    Parameters
+    ==========
 
-        expr : sympy.core.Expr
-            a sympy expression to be converted
-        assign_to : optional
-            When given, the argument is used as the name of the
-            variable to which the Fortran expression is assigned.
-            (This is helpful in case of line-wrapping.)
-        precision : optional
-            the precision for numbers such as pi [default=15]
-        user_functions : optional
-            A dictionary where keys are FunctionClass instances and values
-            are their string representations.  Alternatively, the
-            dictionary value can be a list of tuples i.e. [(argument_test,
-            cfunction_string)].  See below for examples.
-        human : optional
-            If True, the result is a single string that may contain some
-            constant declarations for the number symbols. If False, the
-            same information is returned in a more programmer-friendly
-            data structure.
-        contract: optional
-            If True, `Indexed` instances are assumed to obey
-            tensor contraction rules and the corresponding nested
-            loops over indices are generated. Setting contract = False
-            will not generate loops, instead the user is responsible
-            to provide values for the indices in the code. [default=True]
+    expr : Expr
+        A sympy expression to be converted.
+    assign_to : optional
+        When given, the argument is used as the name of the variable to which
+        the expression is assigned. Can be a string, ``Symbol``,
+        ``MatrixSymbol``, or ``Indexed`` type. This is helpful in case of
+        line-wrapping, or for expressions that generate multi-line statements.
+    precision : integer, optional
+        The precision for numbers such as pi [default=15].
+    user_functions : dict, optional
+        A dictionary where keys are ``FunctionClass`` instances and values are
+        their string representations. Alternatively, the dictionary value can
+        be a list of tuples i.e. [(argument_test, cfunction_string)]. See below
+        for examples.
+    human : bool, optional
+        If True, the result is a single string that may contain some constant
+        declarations for the number symbols. If False, the same information is
+        returned in a tuple of (symbols_to_declare, not_supported_functions,
+        code_text). [default=True].
+    contract: bool, optional
+        If True, ``Indexed`` instances are assumed to obey tensor contraction
+        rules and the corresponding nested loops over indices are generated.
+        Setting contract=False will not generate loops, instead the user is
+        responsible to provide values for the indices in the code.
+        [default=True].
 
+    Examples
+    ========
 
-        Examples
-        ========
+    >>> from sympy import ccode, symbols, Rational, sin, ceiling, Abs
+    >>> x, tau = symbols("x, tau")
+    >>> ccode((2*tau)**Rational(7, 2))
+    '8*sqrt(2)*pow(tau, 7.0L/2.0L)'
+    >>> ccode(sin(x), assign_to="s")
+    's = sin(x);'
 
-        >>> from sympy import ccode, symbols, Rational, sin, ceiling, Abs
-        >>> x, tau = symbols(["x", "tau"])
-        >>> ccode((2*tau)**Rational(7,2))
-        '8*sqrt(2)*pow(tau, 7.0L/2.0L)'
-        >>> ccode(sin(x), assign_to="s")
-        's = sin(x);'
-        >>> custom_functions = {
-        ...   "ceiling": "CEIL",
-        ...   "Abs": [(lambda x: not x.is_integer, "fabs"),
-        ...           (lambda x: x.is_integer, "ABS")]
-        ... }
-        >>> ccode(Abs(x) + ceiling(x), user_functions=custom_functions)
-        'fabs(x) + CEIL(x)'
-        >>> from sympy import Eq, IndexedBase, Idx
-        >>> len_y = 5
-        >>> y = IndexedBase('y', shape=(len_y,))
-        >>> t = IndexedBase('t', shape=(len_y,))
-        >>> Dy = IndexedBase('Dy', shape=(len_y-1,))
-        >>> i = Idx('i', len_y-1)
-        >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
-        >>> ccode(e.rhs, assign_to=e.lhs, contract=False)
-        'Dy[i] = (y[i + 1] - y[i])/(t[i + 1] - t[i]);'
+    Custom printing can be defined for certain types by passing a dictionary of
+    "type" : "function" to the ``user_functions`` kwarg. Alternatively, the
+    dictionary value can be a list of tuples i.e. [(argument_test,
+    cfunction_string)].
 
+    >>> custom_functions = {
+    ...   "ceiling": "CEIL",
+    ...   "Abs": [(lambda x: not x.is_integer, "fabs"),
+    ...           (lambda x: x.is_integer, "ABS")]
+    ... }
+    >>> ccode(Abs(x) + ceiling(x), user_functions=custom_functions)
+    'fabs(x) + CEIL(x)'
+
+    ``Piecewise`` expressions are converted into conditionals. If an
+    ``assign_to`` variable is provided an if statement is created, otherwise
+    the ternary operator is used. Note that if the ``Piecewise`` lacks a
+    default term, represented by ``(expr, True)`` then an error will be thrown.
+    This is to prevent generating an expression that may not evaluate to
+    anything.
+
+    >>> from sympy import Piecewise
+    >>> expr = Piecewise((x + 1, x > 0), (x, True))
+    >>> print(ccode(expr, tau))
+    if (x > 0) {
+    tau = x + 1;
+    }
+    else {
+    tau = x;
+    }
+
+    Support for loops is provided through ``Indexed`` types. With
+    ``contract=True`` these expressions will be turned into loops, whereas
+    ``contract=False`` will just print the assignment expression that should be
+    looped over:
+
+    >>> from sympy import Eq, IndexedBase, Idx
+    >>> len_y = 5
+    >>> y = IndexedBase('y', shape=(len_y,))
+    >>> t = IndexedBase('t', shape=(len_y,))
+    >>> Dy = IndexedBase('Dy', shape=(len_y-1,))
+    >>> i = Idx('i', len_y-1)
+    >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
+    >>> ccode(e.rhs, assign_to=e.lhs, contract=False)
+    'Dy[i] = (y[i + 1] - y[i])/(t[i + 1] - t[i]);'
+
+    Matrices are also supported, but a ``MatrixSymbol`` of the same dimensions
+    must be provided to ``assign_to``. Note that any expression that can be
+    generated normally can also exist inside a Matrix:
+
+    >>> from sympy import Matrix, MatrixSymbol
+    >>> mat = Matrix([x**2, Piecewise((x + 1, x > 0), (x, True)), sin(x)])
+    >>> A = MatrixSymbol('A', 3, 1)
+    >>> print(ccode(mat, A))
+    A[0][0] = pow(x, 2);
+    if (x > 0) {
+       A[1][0] = x + 1;
+    }
+    else {
+       A[1][0] = x;
+    }
+    A[2][0] = sin(x);
     """
+
     return CCodePrinter(settings).doprint(expr, assign_to)
 
 

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -223,8 +223,8 @@ class CCodePrinter(CodePrinter):
             # printing each one.
             rows, cols = lhs.shape
             lines = []
-            for i in range(rows):
-                for j in range(cols):
+            for j in range(cols):
+                for i in range(rows):
                     temp = Assignment(lhs[i, j], rhs[i, j])
                     code0 = self._print(temp)
                     lines.append(code0)

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -74,10 +74,6 @@ class CCodePrinter(CodePrinter):
 
         if assign_to:
             expr = Assignment(assign_to, expr)
-        elif isinstance(expr, C.Equality) and not isinstance(expr, Assignment):
-            # For backwards compatability, convert all root level equality to
-            # Assignment type.
-            expr = Assignment(*expr.args)
 
         # keep a set of expressions that are not strictly translatable to C
         # and number constants that must be declared and initialized

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -124,6 +124,14 @@ class CCodePrinter(CodePrinter):
         return '-HUGE_VAL'
 
     def _print_Piecewise(self, expr):
+        if expr.args[-1].cond != True:
+            # We need the last conditional to be a True, otherwise the resulting
+            # function may not return a result.
+            raise ValueError("All Piecewise expressions must contain an "
+                             "(expr, True) statement to be used as a default "
+                             "condition. Without one, the generated "
+                             "expression may not evaluate to anything under "
+                             "some condition.")
         lines = []
         if expr.has(Assignment):
             for i, (e, c) in enumerate(expr.args):
@@ -139,21 +147,13 @@ class CCodePrinter(CodePrinter):
             return "\n".join(lines)
         else:
             # The piecewise was used in an expression, need to do inline
-            # operators. This has the downside that if none of the conditions
-            # are true, the last expression will still be returned. Also, these
-            # inline operators will not work for statements that span multiple
-            # lines (Matrix or Indexed expressions).
+            # operators. This has the downside that inline operators will
+            # not work for statements that span multiple lines (Matrix or
+            # Indexed expressions).
             ecpairs = ["((%s) ? (\n%s\n)\n" % (self._print(c), self._print(e))
                     for e, c in expr.args[:-1]]
-            last_line = ""
-            if expr.args[-1].cond == True:
-                last_line = ": (\n%s\n)" % self._print(expr.args[-1].expr)
-            else:
-                ecpairs.append("(%s) ? (\n%s\n)" %
-                (self._print(expr.args[-1].cond),
-                    self._print(expr.args[-1].expr)))
-            code = "%s" + last_line
-            return code % ": ".join(ecpairs) + " ".join([")"*len(ecpairs)])
+            last_line = ": (\n%s\n)" % self._print(expr.args[-1].expr)
+            return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -323,6 +323,24 @@ class CodePrinter(StrPrinter):
             rhs_code = self._print(rhs)
             return self._get_statement("%s = %s" % (lhs_code, rhs_code))
 
+    def _print_Function(self, expr):
+        if expr.func.__name__ in self.known_functions:
+            cond_func = self.known_functions[expr.func.__name__]
+            func = None
+            if isinstance(cond_func, str):
+                func = cond_func
+            else:
+                for cond, func in cond_func:
+                    if cond(*expr.args):
+                        break
+            if func is not None:
+                return "%s(%s)" % (func, self.stringify(expr.args, ", "))
+        elif hasattr(expr, '_imp_') and isinstance(expr._imp_, C.Lambda):
+            # inlined function
+            return self._print(expr._imp_(*expr.args))
+        else:
+            return self._print_not_supported(expr)
+
     def _print_NumberSymbol(self, expr):
         # A Number symbol that is not implemented here or with _printmethod
         # is registered and evaluated
@@ -337,6 +355,8 @@ class CodePrinter(StrPrinter):
     _print_Catalan = _print_NumberSymbol
     _print_EulerGamma = _print_NumberSymbol
     _print_GoldenRatio = _print_NumberSymbol
+    _print_Exp1 = _print_NumberSymbol
+    _print_Pi = _print_NumberSymbol
 
     def _print_And(self, expr):
         PREC = precedence(expr)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -14,6 +14,9 @@ class AssignmentError(Exception):
     pass
 
 class Assignment(C.Equality):
+    """
+    Represents variable assignment for code generation.
+    """
     pass
 
 
@@ -253,7 +256,8 @@ class CodePrinter(StrPrinter):
                 code0 = self._print(temp)
                 lines.append(code0)
             return "\n".join(lines)
-        elif lhs.has(C.IndexedBase) or rhs.has(C.IndexedBase):
+        elif self._settings["contract"] and (lhs.has(C.IndexedBase) or
+                rhs.has(C.IndexedBase)):
             # Here we check if there is looping to be done, and if so
             # print the required loops.
             return self._doprint_loops(rhs, lhs)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -159,6 +159,7 @@ class CodePrinter(StrPrinter):
         elif isinstance(lhs, C.MatrixSymbol):
             # Here we form an Assignment for each element in the array,
             # printing each one.
+            lines = []
             for (i, j) in self._traverse_matrix_indices(lhs):
                 temp = Assignment(lhs[i, j], rhs[i, j])
                 code0 = self._print(temp)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -105,7 +105,7 @@ class CodePrinter(StrPrinter):
         if isinstance(assign_to, string_types):
             assign_to = C.Symbol(assign_to)
         elif not isinstance(assign_to, (C.Basic, type(None))):
-            raise TypeError("{:} cannot assign to object of type {:}".format(
+            raise TypeError("{0} cannot assign to object of type {1}".format(
                     type(self).__name__, type(assign_to)))
 
         if assign_to:
@@ -123,7 +123,7 @@ class CodePrinter(StrPrinter):
             frontlines = []
             if len(self._not_supported) > 0:
                 frontlines.append(self._get_comment(
-                        "Not supported in {:}:".format(self.language)))
+                        "Not supported in {0}:".format(self.language)))
                 for expr in sorted(self._not_supported, key=str):
                     frontlines.append(self._get_comment(type(expr).__name__))
             for name, value in sorted(self._number_symbols, key=str):

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -206,6 +206,9 @@ class FCodePrinter(CodePrinter):
             rhs_text = self._print(rhs)
             return "{:} = {:}".format(lhs_text, rhs_text)
 
+    def _print_MatrixElement(self, expr):
+        return "{:}({:}, {:})".format(expr.parent, expr.i + 1, expr.j + 1)
+
     def _print_Add(self, expr):
         # purpose: print complex numbers nicely in Fortran.
         # collect the purely real and purely imaginary parts:

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -85,10 +85,10 @@ class FCodePrinter(CodePrinter):
         return codestring
 
     def _get_comment(self, text):
-        return "! {:}".format(text)
+        return "! {0}".format(text)
 
     def _declare_number_const(self, name, value):
-        return "parameter ({:} = {:})".format(name, value)
+        return "parameter ({0} = {1})".format(name, value)
 
     def _format_code(self, lines):
         return self._wrap_fortran(self.indent_code(lines))
@@ -151,7 +151,7 @@ class FCodePrinter(CodePrinter):
                                       "standards earlier than Fortran95.")
 
     def _print_MatrixElement(self, expr):
-        return "{:}({:}, {:})".format(expr.parent, expr.i + 1, expr.j + 1)
+        return "{0}({1}, {2})".format(expr.parent, expr.i + 1, expr.j + 1)
 
     def _print_Add(self, expr):
         # purpose: print complex numbers nicely in Fortran.

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -26,6 +26,25 @@ from sympy.core.compatibility import string_types
 from sympy.printing.codeprinter import CodePrinter, Assignment
 from sympy.printing.precedence import precedence
 
+known_functions = {
+    "sin": "sin",
+    "cos": "cos",
+    "tan": "tan",
+    "asin": "asin",
+    "acos": "acos",
+    "atan": "atan",
+    "atan2": "atan2",
+    "sinh": "sinh",
+    "cosh": "cosh",
+    "tanh": "tanh",
+    "log": "log",
+    "exp": "exp",
+    "erf": "erf",
+    "Abs": "Abs",
+    "sign": "sign",
+    "conjugate": "conjg"
+}
+
 class FCodePrinter(CodePrinter):
     """A printer to convert sympy expressions to strings of Fortran code"""
     printmethod = "_fcode"
@@ -42,11 +61,6 @@ class FCodePrinter(CodePrinter):
         'standard': 77
     }
 
-    _implicit_functions = set([
-        "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh",
-        "cosh", "tanh", "sqrt", "log", "exp", "erf", "Abs", "sign", "conjugate",
-    ])
-
     _operators = {
         'and': '.and.',
         'or': '.or.',
@@ -59,8 +73,11 @@ class FCodePrinter(CodePrinter):
         '!=': '/=',
     }
 
-    def __init__(self, settings=None):
+    def __init__(self, settings={}):
         CodePrinter.__init__(self, settings)
+        self.known_functions = dict(known_functions)
+        userfuncs = settings.get('user_functions', {})
+        self.known_functions.update(userfuncs)
         # leading columns depend on fixed or free format
         if self._settings['source_format'] == 'fixed':
             self._lead_code = "      "
@@ -193,26 +210,14 @@ class FCodePrinter(CodePrinter):
             return CodePrinter._print_Add(self, expr)
 
     def _print_Function(self, expr):
-        name = self._settings["user_functions"].get(expr.__class__)
-        eargs = expr.args
-        if name is None:
-            from sympy.functions import conjugate
-            if expr.func == conjugate:
-                name = "conjg"
-            else:
-                name = expr.func.__name__
-            if hasattr(expr, '_imp_') and isinstance(expr._imp_, C.Lambda):
-                # inlined function.
-                # the expression is printed with _print to avoid loops
-                return self._print(expr._imp_(*eargs))
-            if expr.func.__name__ not in self._implicit_functions:
-                self._not_supported.add(expr)
-            else:
-                # convert all args to floats
-                eargs = map(N, eargs)
-        return "%s(%s)" % (name, self.stringify(eargs, ", "))
-
-    _print_factorial = _print_Function
+        # All constant function args are evaluated as floats
+        prec =  self._settings['precision']
+        args = [N(a, prec) for a in expr.args]
+        eval_expr = expr.func(*args)
+        if not isinstance(eval_expr, C.Function):
+            return self._print(eval_expr)
+        else:
+            return CodePrinter._print_Function(self, expr.func(*args))
 
     def _print_ImaginaryUnit(self, expr):
         # purpose: print complex numbers nicely in Fortran.
@@ -229,9 +234,6 @@ class FCodePrinter(CodePrinter):
             )
         else:
             return CodePrinter._print_Mul(self, expr)
-
-    _print_Exp1 = CodePrinter._print_NumberSymbol
-    _print_Pi = CodePrinter._print_NumberSymbol
 
     def _print_Pow(self, expr):
         PREC = precedence(expr)
@@ -399,67 +401,116 @@ class FCodePrinter(CodePrinter):
 
 
 def fcode(expr, assign_to=None, **settings):
-    """Converts an expr to a string of Fortran 77 code
+    """Converts an expr to a string of c code
 
-       Parameters
-       ==========
+    Parameters
+    ==========
 
-       expr : sympy.core.Expr
-           a sympy expression to be converted
-       assign_to : optional
-           When given, the argument is used as the name of the
-           variable to which the Fortran expression is assigned.
-           (This is helpful in case of line-wrapping.)
-       precision : optional
-           the precision for numbers such as pi [default=15]
-       user_functions : optional
-           A dictionary where keys are FunctionClass instances and values
-           are there string representations.
-       human : optional
-           If True, the result is a single string that may contain some
-           parameter statements for the number symbols. If False, the same
-           information is returned in a more programmer-friendly data
-           structure.
-       source_format : optional
-           The source format can be either 'fixed' or 'free'.
-           [default='fixed']
-       standard : optional
-           The Fortran standard to be followed. This is specified as an integer.
-           Acceptable standards are 66, 77, 90, 95, 2003, and 2008. Default is
-           77. Note that currently the only distinction internally is between
-           standards before 95, and those 95 and after. This may change later
-           as more features are added.
-       contract: optional
-           If True, `Indexed` instances are assumed to obey
-           tensor contraction rules and the corresponding nested
-           loops over indices are generated. Setting contract = False
-           will not generate loops, instead the user is responsible
-           to provide values for the indices in the code. [default=True]
+    expr : Expr
+        A sympy expression to be converted.
+    assign_to : optional
+        When given, the argument is used as the name of the variable to which
+        the expression is assigned. Can be a string, ``Symbol``,
+        ``MatrixSymbol``, or ``Indexed`` type. This is helpful in case of
+        line-wrapping, or for expressions that generate multi-line statements.
+    precision : integer, optional
+        The precision for numbers such as pi [default=15].
+    user_functions : dict, optional
+        A dictionary where keys are ``FunctionClass`` instances and values are
+        their string representations. Alternatively, the dictionary value can
+        be a list of tuples i.e. [(argument_test, cfunction_string)]. See below
+        for examples.
+    human : bool, optional
+        If True, the result is a single string that may contain some constant
+        declarations for the number symbols. If False, the same information is
+        returned in a tuple of (symbols_to_declare, not_supported_functions,
+        code_text). [default=True].
+    contract: bool, optional
+        If True, ``Indexed`` instances are assumed to obey tensor contraction
+        rules and the corresponding nested loops over indices are generated.
+        Setting contract=False will not generate loops, instead the user is
+        responsible to provide values for the indices in the code.
+        [default=True].
+    source_format : optional
+        The source format can be either 'fixed' or 'free'. [default='fixed']
+    standard : integer, optional
+        The Fortran standard to be followed. This is specified as an integer.
+        Acceptable standards are 66, 77, 90, 95, 2003, and 2008. Default is 77.
+        Note that currently the only distinction internally is between
+        standards before 95, and those 95 and after. This may change later as
+        more features are added.
 
-       Examples
-       ========
+    Examples
+    ========
 
-       >>> from sympy import fcode, symbols, Rational, pi, sin
-       >>> x, tau = symbols('x,tau')
-       >>> fcode((2*tau)**Rational(7,2))
-       '      8*sqrt(2.0d0)*tau**(7.0d0/2.0d0)'
-       >>> fcode(sin(x), assign_to="s")
-       '      s = sin(x)'
-       >>> print(fcode(pi))
-             parameter (pi = 3.14159265358979d0)
-             pi
-       >>> from sympy import Eq, IndexedBase, Idx
-       >>> len_y = 5
-       >>> y = IndexedBase('y', shape=(len_y,))
-       >>> t = IndexedBase('t', shape=(len_y,))
-       >>> Dy = IndexedBase('Dy', shape=(len_y-1,))
-       >>> i = Idx('i', len_y-1)
-       >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
-       >>> fcode(e.rhs, assign_to=e.lhs, contract=False)
-       '      Dy(i) = (y(i + 1) - y(i))/(t(i + 1) - t(i))'
+    >>> from sympy import fcode, symbols, Rational, sin, ceiling, floor
+    >>> x, tau = symbols("x, tau")
+    >>> fcode((2*tau)**Rational(7, 2))
+    '      8*sqrt(2.0d0)*tau**(7.0d0/2.0d0)'
+    >>> fcode(sin(x), assign_to="s")
+    '      s = sin(x)'
 
+    Custom printing can be defined for certain types by passing a dictionary of
+    "type" : "function" to the ``user_functions`` kwarg. Alternatively, the
+    dictionary value can be a list of tuples i.e. [(argument_test,
+    cfunction_string)].
+
+    >>> custom_functions = {
+    ...   "ceiling": "CEIL",
+    ...   "floor": [(lambda x: not x.is_integer, "FLOOR1"),
+    ...             (lambda x: x.is_integer, "FLOOR2")]
+    ... }
+    >>> fcode(floor(x) + ceiling(x), user_functions=custom_functions)
+    '      CEIL(x) + FLOOR1(x)'
+
+    ``Piecewise`` expressions are converted into conditionals. If an
+    ``assign_to`` variable is provided an if statement is created, otherwise
+    the ternary operator is used. Note that if the ``Piecewise`` lacks a
+    default term, represented by ``(expr, True)`` then an error will be thrown.
+    This is to prevent generating an expression that may not evaluate to
+    anything.
+
+    >>> from sympy import Piecewise
+    >>> expr = Piecewise((x + 1, x > 0), (x, True))
+    >>> print(fcode(expr, tau))
+          if (x > 0) then
+             tau = x + 1
+          else
+             tau = x
+          end if
+
+    Support for loops is provided through ``Indexed`` types. With
+    ``contract=True`` these expressions will be turned into loops, whereas
+    ``contract=False`` will just print the assignment expression that should be
+    looped over:
+
+    >>> from sympy import Eq, IndexedBase, Idx
+    >>> len_y = 5
+    >>> y = IndexedBase('y', shape=(len_y,))
+    >>> t = IndexedBase('t', shape=(len_y,))
+    >>> Dy = IndexedBase('Dy', shape=(len_y-1,))
+    >>> i = Idx('i', len_y-1)
+    >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
+    >>> fcode(e.rhs, assign_to=e.lhs, contract=False)
+    '      Dy(i) = (y(i + 1) - y(i))/(t(i + 1) - t(i))'
+
+    Matrices are also supported, but a ``MatrixSymbol`` of the same dimensions
+    must be provided to ``assign_to``. Note that any expression that can be
+    generated normally can also exist inside a Matrix:
+
+    >>> from sympy import Matrix, MatrixSymbol
+    >>> mat = Matrix([x**2, Piecewise((x + 1, x > 0), (x, True)), sin(x)])
+    >>> A = MatrixSymbol('A', 3, 1)
+    >>> print(fcode(mat, A))
+          A(1, 1) = x**2
+             if (x > 0) then
+          A(2, 1) = x + 1
+             else
+          A(2, 1) = x
+             end if
+          A(3, 1) = sin(x)
     """
-    # run the printer
+
     return FCodePrinter(settings).doprint(expr, assign_to)
 
 

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -173,38 +173,9 @@ class FCodePrinter(CodePrinter):
                                       "inline operators is not supported in "
                                       "Fortran77.")
 
-    def _print_Assignment(self, expr):
-        lhs = expr.lhs
-        rhs = expr.rhs
-        # We special case assignments that take multiple lines
-        if isinstance(expr.rhs, C.Piecewise):
-            # Here we modify Piecewise so each expression is now
-            # an Assignment, and then continue on the print.
-            expressions = []
-            conditions = []
-            for (e, c) in rhs.args:
-                expressions.append(Assignment(lhs, e))
-                conditions.append(c)
-            temp = C.Piecewise(*zip(expressions, conditions))
-            return self._print(temp)
-        elif isinstance(lhs, C.MatrixSymbol):
-            # Here we form an Assignment for each element in the array,
-            # printing each one.
-            rows, cols = lhs.shape
-            lines = []
-            for i in range(rows):
-                for j in range(cols):
-                    temp = Assignment(lhs[i, j], rhs[i, j])
-                    code0 = self._print(temp)
-                    lines.append(code0)
-            return "\n".join(lines)
-        elif isinstance(lhs, C.Indexed):
-            # Here we handle an indexed loop
-            return self._doprint_indexed_loop(rhs, lhs)
-        else:
-            lhs_text = self._print(lhs)
-            rhs_text = self._print(rhs)
-            return "{:} = {:}".format(lhs_text, rhs_text)
+    def _traverse_matrix_indices(self, mat):
+        rows, cols = mat.shape
+        return ((i, j) for j in range(cols) for i in range(rows))
 
     def _print_MatrixElement(self, expr):
         return "{:}({:}, {:})".format(expr.parent, expr.i + 1, expr.j + 1)

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -66,10 +66,10 @@ class JavascriptCodePrinter(CodePrinter):
         return "%s;" % codestring
 
     def _get_comment(self, text):
-        return "// {:}".format(text)
+        return "// {0}".format(text)
 
     def _declare_number_const(self, name, value):
-        return "var {:} = {:};".format(name, value)
+        return "var {0} = {1};".format(name, value)
 
     def _format_code(self, lines):
         return self.indent_code(lines)
@@ -175,7 +175,7 @@ class JavascriptCodePrinter(CodePrinter):
         return CodePrinter._print_Function(self, expr)
 
     def _print_MatrixElement(self, expr):
-        return "{:}[{:}][{:}]".format(expr.parent, expr.i, expr.j)
+        return "{0}[{1}][{2}]".format(expr.parent, expr.i, expr.j)
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -214,6 +214,10 @@ def jscode(expr, assign_to=None, **settings):
 
        expr : sympy.core.Expr
            a sympy expression to be converted
+       assign_to : optional
+           When given, the argument is used as the name of the
+           variable to which the Fortran expression is assigned.
+           (This is helpful in case of line-wrapping.)
        precision : optional
            the precision for numbers such as pi [default=15]
        user_functions : optional

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -5,6 +5,7 @@ Mathematica code printer
 from __future__ import print_function, division
 from sympy.core import S, C
 from sympy.printing.codeprinter import CodePrinter
+from sympy.printing.str import StrPrinter
 from sympy.printing.precedence import precedence
 
 # Used in MCodePrinter._print_Function(self)
@@ -47,6 +48,8 @@ class MCodePrinter(CodePrinter):
             if not isinstance(v, list):
                 userfuncs[k] = [(lambda *x: True, v)]
                 self.known_functions.update(userfuncs)
+
+    doprint = StrPrinter.doprint
 
     def _print_Pow(self, expr):
         PREC = precedence(expr)

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -119,13 +119,14 @@ def test_ccode_Piecewise():
     p = ccode(Piecewise((x, x < 1), (x**2, True)))
     s = \
 """\
-if (x < 1) {
+((x < 1) ? (
    x
-}
-else {
+)
+: (
    pow(x, 2)
-}\
+))\
 """
+
     assert p == s
 
 
@@ -141,7 +142,7 @@ def test_ccode_Piecewise_deep():
 )
 : (
    pow(x, 2)
-)) )\
+)))\
 """
     assert p == s
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -116,7 +116,8 @@ def test_ccode_boolean():
 
 
 def test_ccode_Piecewise():
-    p = ccode(Piecewise((x, x < 1), (x**2, True)))
+    expr = Piecewise((x, x < 1), (x**2, True))
+    p = ccode(expr)
     s = \
 """\
 ((x < 1) ? (
@@ -126,8 +127,17 @@ def test_ccode_Piecewise():
    pow(x, 2)
 ))\
 """
-
     assert p == s
+    assert ccode(expr, assign_to="c") == (
+    "if (x < 1) {\n"
+    "   c = x;\n"
+    "}\n"
+    "else {\n"
+    "   c = pow(x, 2);\n"
+    "}")
+    # Check that Piecewise without a True (default) condition error
+    expr = Piecewise((x, x < 1), (x**2, x > 1), (sin(x), x > 0))
+    raises(ValueError, lambda: ccode(expr))
 
 
 def test_ccode_Piecewise_deep():

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -10,7 +10,6 @@ from sympy.matrices import Matrix, MatrixSymbol
 from sympy import ccode
 
 x, y, z = symbols('x,y,z')
-g = Function('g')
 
 
 def test_printmethod():
@@ -29,8 +28,9 @@ def test_ccode_sqrt():
 def test_ccode_Pow():
     assert ccode(x**3) == "pow(x, 3)"
     assert ccode(x**(y**3)) == "pow(x, pow(y, 3))"
+    g = implemented_function('g', Lambda(x, 2*x))
     assert ccode(1/(g(x)*3.5)**(x - y**x)/(x**2 + y)) == \
-        "pow(3.5*g(x), -x + pow(y, x))/(pow(x, 2) + y)"
+        "pow(3.5*2*x, -x + pow(y, x))/(pow(x, 2) + y)"
     assert ccode(x**-1.0) == '1.0/x'
     assert ccode(x**Rational(2, 3)) == 'pow(x, 2.0L/3.0L)'
     _cond_cfunc = [(lambda base, exp: exp.is_integer, "dpowi"),
@@ -366,7 +366,7 @@ def test_ccode_loops_multiple_terms():
             c == s0 + s3 + s1 + s2[:-1] or
             c == s0 + s3 + s2 + s1[:-1])
 
-def test_Matrix_codegen():
+def test_Matrix_printing():
     # Test returning a Matrix
     mat = Matrix([x*y, Piecewise((2 + x, y>0), (y, True)), sin(z)])
     A = MatrixSymbol('A', 3, 1)

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -1,6 +1,9 @@
-from sympy.printing.codeprinter import CodePrinter
+from sympy.printing.codeprinter import CodePrinter, Assignment
 from sympy.printing.ccode import ccode
 from sympy.core import C, symbols
+from sympy.matrices import MatrixSymbol, Matrix
+from sympy.tensor import IndexedBase, Idx
+from sympy.utilities.pytest import raises
 
 def setup_test_printer(*args, **kwargs):
     p = CodePrinter(*args, **kwargs)
@@ -16,3 +19,35 @@ def test_print_Dummy():
 def test_print_Mul():
     x, y = symbols("x y")
     s = ccode(x ** (-3) * y ** (-2))
+
+def test_Assignment():
+    x, y = symbols("x, y")
+    A = MatrixSymbol('A', 3, 1)
+    mat = Matrix([1, 2, 3])
+    B = IndexedBase('B')
+    n = symbols("n", integer=True)
+    i = Idx("i", n)
+    # Here we just do things to show they don't error
+    Assignment(x, y)
+    Assignment(x, 0)
+    Assignment(A, mat)
+    Assignment(A[1,0], 0)
+    Assignment(A[1,0], x)
+    Assignment(B[i], x)
+    Assignment(B[i], 0)
+    # Here we test things to show that they error
+    # Matrix to scalar
+    raises(ValueError, lambda: Assignment(B[i], A))
+    raises(ValueError, lambda: Assignment(B[i], mat))
+    raises(ValueError, lambda: Assignment(x, mat))
+    raises(ValueError, lambda: Assignment(x, A))
+    raises(ValueError, lambda: Assignment(A[1,0], mat))
+    # Scalar to matrix
+    raises(ValueError, lambda: Assignment(A, x))
+    raises(ValueError, lambda: Assignment(A, 0))
+    # Non-atomic lhs
+    raises(TypeError, lambda: Assignment(mat, A))
+    raises(TypeError, lambda: Assignment(0, x))
+    raises(TypeError, lambda: Assignment(x*x, 1))
+    raises(TypeError, lambda: Assignment(A + A, mat))
+    raises(TypeError, lambda: Assignment(B, 0))

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -35,10 +35,7 @@ def test_fcode_Pow():
     assert fcode(sqrt(x)) == '      sqrt(x)'
     assert fcode(sqrt(10)) == '      sqrt(10.0d0)'
     assert fcode(x**-1.0) == '      1.0/x'
-    assert fcode(x**-2.0,
-                 assign_to='y',
-                 source_format='free',
-                 human=True) == 'y = x**(-2.0d0)'  # 2823
+    assert fcode(x**-2.0, 'y', source_format='free') == 'y = x**(-2.0d0)'  # 2823
     assert fcode(x**Rational(3, 7)) == '      x**(3.0d0/7.0d0)'
 
 
@@ -354,15 +351,15 @@ def test_fcode_Relational():
 
 def test_fcode_Piecewise():
     x = symbols('x')
-    code = fcode(Piecewise((x, x < 1), (x**2, True)))
-    expected = (
-        "      if (x < 1) then\n"
-        "         x\n"
-        "      else\n"
-        "         x**2\n"
-        "      end if"
-    )
-    assert code == expected
+    #code = fcode(Piecewise((x, x < 1), (x**2, True)))
+    #expected = (
+        #"      if (x < 1) then\n"
+        #"         x\n"
+        #"      else\n"
+        #"         x**2\n"
+        #"      end if"
+    #)
+    #assert code == expected
     assert fcode(Piecewise((x, x < 1), (x**2, True)), assign_to="var") == (
         "      if (x < 1) then\n"
         "         var = x\n"
@@ -390,24 +387,24 @@ def test_fcode_Piecewise():
     )
     code = fcode(Piecewise((a, x < 0), (b, True)), assign_to="weird_name")
     assert code == expected
-    assert fcode(Piecewise((x, x < 1), (x**2, x > 1), (sin(x), True))) == (
-        "      if (x < 1) then\n"
-        "         x\n"
-        "      else if (x > 1) then\n"
-        "         x**2\n"
-        "      else\n"
-        "         sin(x)\n"
-        "      end if"
-    )
-    assert fcode(Piecewise((x, x < 1), (x**2, x > 1), (sin(x), x > 0))) == (
-        "      if (x < 1) then\n"
-        "         x\n"
-        "      else if (x > 1) then\n"
-        "         x**2\n"
-        "      else if (x > 0) then\n"
-        "         sin(x)\n"
-        "      end if"
-    )
+    #assert fcode(Piecewise((x, x < 1), (x**2, x > 1), (sin(x), True))) == (
+        #"      if (x < 1) then\n"
+        #"         x\n"
+        #"      else if (x > 1) then\n"
+        #"         x**2\n"
+        #"      else\n"
+        #"         sin(x)\n"
+        #"      end if"
+    #)
+    #assert fcode(Piecewise((x, x < 1), (x**2, x > 1), (sin(x), x > 0))) == (
+        #"      if (x < 1) then\n"
+        #"         x\n"
+        #"      else if (x > 1) then\n"
+        #"         x**2\n"
+        #"      else if (x > 0) then\n"
+        #"         sin(x)\n"
+        #"      end if"
+    #)
 
 
 def test_wrap_fortran():
@@ -582,11 +579,10 @@ def test_fcode_Indexed_without_looking_for_contraction():
 def test_derived_classes():
     class MyFancyFCodePrinter(FCodePrinter):
         _default_settings = FCodePrinter._default_settings.copy()
-        _default_settings['assign_to'] = "bork"
 
     printer = MyFancyFCodePrinter()
     x = symbols('x')
-    assert printer.doprint(sin(x)) == "      bork = sin(x)"
+    assert printer.doprint(sin(x), "bork") == "      bork = sin(x)"
 
 
 def test_indent():

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -68,12 +68,13 @@ def test_fcode_functions():
 #issue 6814
 def test_fcode_functions_with_integers():
     x= symbols('x')
-    assert fcode(x * log(10)) == "      x*log(10.0d0)"
-    assert fcode(x * log(S(10))) == "      x*log(10.0d0)"
-    assert fcode(log(S(10))) == "      log(10.0d0)"
-    assert fcode(exp(10)) == "      exp(10.0d0)"
-    assert fcode(x * log(log(10))) == "      x*log(2.30258509299405d0)"
-    assert fcode(x * log(log(S(10)))) == "      x*log(2.30258509299405d0)"
+    assert fcode(x * log(10)) == "      x*2.30258509299405d0"
+    assert fcode(x * log(10)) == "      x*2.30258509299405d0"
+    assert fcode(x * log(S(10))) == "      x*2.30258509299405d0"
+    assert fcode(log(S(10))) == "      2.30258509299405d0"
+    assert fcode(exp(10)) == "      22026.4657948067d0"
+    assert fcode(x * log(log(10))) == "      x*0.834032445247956d0"
+    assert fcode(x * log(log(S(10)))) == "      x*0.834032445247956d0"
 
 
 def test_fcode_NumberSymbol():
@@ -131,15 +132,15 @@ def test_not_fortran():
 
 def test_user_functions():
     x = symbols('x')
-    assert fcode(sin(x), user_functions={sin: "zsin"}) == "      zsin(x)"
+    assert fcode(sin(x), user_functions={"sin": "zsin"}) == "      zsin(x)"
     x = symbols('x')
     assert fcode(
-        gamma(x), user_functions={gamma: "mygamma"}) == "      mygamma(x)"
+        gamma(x), user_functions={"gamma": "mygamma"}) == "      mygamma(x)"
     g = Function('g')
-    assert fcode(g(x), user_functions={g: "great"}) == "      great(x)"
+    assert fcode(g(x), user_functions={"g": "great"}) == "      great(x)"
     n = symbols('n', integer=True)
     assert fcode(
-        factorial(n), user_functions={factorial: "fct"}) == "      fct(n)"
+        factorial(n), user_functions={"factorial": "fct"}) == "      fct(n)"
 
 
 def test_inline_function():
@@ -500,7 +501,7 @@ def test_free_form_continuation_line():
 
 
 def test_free_form_comment_line():
-    printer = FCodePrinter({ 'source_format': 'free'})
+    printer = FCodePrinter({'source_format': 'free'})
     lines = [ "! This is a long comment on a single line that must be wrapped properly to produce nice output"]
     expected = [
         '! This is a long comment on a single line that must be wrapped properly',
@@ -634,7 +635,7 @@ def test_indent():
     result = p.indent_code(codelines)
     assert result == expected
 
-def test_Matrix_codegen():
+def test_Matrix_printing():
     x, y, z = symbols('x,y,z')
     # Test returning a Matrix
     mat = Matrix([x*y, Piecewise((2 + x, y>0), (y, True)), sin(z)])

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -123,9 +123,9 @@ def test_not_fortran():
     x = symbols('x')
     g = Function('g')
     assert fcode(
-        gamma(x)) == "C     Not Fortran:\nC     gamma(x)\n      gamma(x)"
-    assert fcode(Integral(sin(x))) == "C     Not Fortran:\nC     Integral(sin(x), x)\n      Integral(sin(x), x)"
-    assert fcode(g(x)) == "C     Not Fortran:\nC     g(x)\n      g(x)"
+        gamma(x)) == "C     Not supported in Fortran:\nC     gamma\n      gamma(x)"
+    assert fcode(Integral(sin(x))) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
+    assert fcode(g(x)) == "C     Not supported in Fortran:\nC     g\n      g(x)"
 
 
 def test_user_functions():

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -96,12 +96,12 @@ def test_jscode_Piecewise():
     p = jscode(Piecewise((x, x < 1), (x**2, True)))
     s = \
 """\
-if (x < 1) {
+((x < 1) ? (
    x
-}
-else {
+)
+: (
    Math.pow(x, 2)
-}\
+))\
 """
     assert p == s
 
@@ -110,12 +110,12 @@ def test_jscode_Piecewise_deep():
     p = jscode(2*Piecewise((x, x < 1), (x**2, True)))
     s = \
 """\
-2*if (x < 1) {
+2*((x < 1) ? (
    x
-}
-else {
+)
+: (
    Math.pow(x, 2)
-}\
+))\
 """
     assert p == s
 

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -93,7 +93,8 @@ def test_jscode_boolean():
 
 
 def test_jscode_Piecewise():
-    p = jscode(Piecewise((x, x < 1), (x**2, True)))
+    expr = Piecewise((x, x < 1), (x**2, True))
+    p = jscode(expr)
     s = \
 """\
 ((x < 1) ? (
@@ -104,6 +105,16 @@ def test_jscode_Piecewise():
 ))\
 """
     assert p == s
+    assert jscode(expr, assign_to="c") == (
+    "if (x < 1) {\n"
+    "   c = x;\n"
+    "}\n"
+    "else {\n"
+    "   c = Math.pow(x, 2);\n"
+    "}")
+    # Check that Piecewise without a True (default) condition error
+    expr = Piecewise((x, x < 1), (x**2, x > 1), (sin(x), x > 0))
+    raises(ValueError, lambda: jscode(expr))
 
 
 def test_jscode_Piecewise_deep():

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -4,6 +4,7 @@ from sympy.utilities.pytest import raises
 from sympy.printing.jscode import JavascriptCodePrinter
 from sympy.utilities.lambdify import implemented_function
 from sympy.tensor import IndexedBase, Idx
+from sympy.matrices import Matrix, MatrixSymbol
 
 # import test
 from sympy import jscode
@@ -327,3 +328,42 @@ def test_jscode_loops_multiple_terms():
             c == s0 + s2 + s3 + s1[:-1] or
             c == s0 + s3 + s1 + s2[:-1] or
             c == s0 + s3 + s2 + s1[:-1])
+
+def test_Matrix_codegen():
+    # Test returning a Matrix
+    mat = Matrix([x*y, Piecewise((2 + x, y>0), (y, True)), sin(z)])
+    A = MatrixSymbol('A', 3, 1)
+    assert jscode(mat, A) == (
+        "A[0][0] = x*y;\n"
+        "if (y > 0) {\n"
+        "   A[1][0] = x + 2;\n"
+        "}\n"
+        "else {\n"
+        "   A[1][0] = y;\n"
+        "}\n"
+        "A[2][0] = Math.sin(z);")
+    # Test using MatrixElements in expressions
+    expr = Piecewise((2*A[2, 0], x > 0), (A[2, 0], True)) + sin(A[1, 0]) + A[0, 0]
+    assert jscode(expr) == (
+        "((x > 0) ? (\n"
+        "   2*A[2][0]\n"
+        ")\n"
+        ": (\n"
+        "   A[2][0]\n"
+        ")) + Math.sin(A[1][0]) + A[0][0]")
+    # Test using MatrixElements in a Matrix
+    q = MatrixSymbol('q', 5, 1)
+    M = MatrixSymbol('M', 3, 3)
+    m = Matrix([[sin(q[1,0]), 0, cos(q[2,0])],
+        [q[1,0] + q[2,0], q[3, 0], 5],
+        [2*q[4, 0]/q[1,0], sqrt(q[0,0]) + 4, 0]])
+    assert jscode(m, M) == (
+        "M[0][0] = Math.sin(q[1][0]);\n"
+        "M[0][1] = 0;\n"
+        "M[0][2] = Math.cos(q[2][0]);\n"
+        "M[1][0] = q[1][0] + q[2][0];\n"
+        "M[1][1] = q[3][0];\n"
+        "M[1][2] = 5;\n"
+        "M[2][0] = 2*q[4][0]*1/q[1][0];\n"
+        "M[2][1] = 4 + Math.sqrt(q[0][0]);\n"
+        "M[2][2] = 0;")

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -86,7 +86,7 @@ from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.ccode import ccode, CCodePrinter
 from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import Idx, Indexed, IndexedBase
-from sympy.matrices import MatrixSymbol
+from sympy.matrices import MatrixSymbol, ImmutableMatrix, MatrixBase
 
 
 __all__ = [
@@ -142,7 +142,7 @@ class Routine(object):
         """
         arg_list = []
 
-        if is_sequence(expr):
+        if is_sequence(expr) and not isinstance(expr, MatrixBase):
             if not expr:
                 raise ValueError("No expression given")
             expressions = Tuple(*expr)
@@ -184,6 +184,12 @@ class Routine(object):
 
                 # avoid duplicate arguments
                 symbols.remove(symbol)
+            elif isinstance(expr, ImmutableMatrix):
+                # Create a "dummy" MatrixSymbol to use as the InOut arg
+                out_arg = MatrixSymbol('inout_%s' % abs(hash(expr)), *expr.shape)
+                dims = tuple([ (S.Zero, dim - 1) for dim in out_arg.shape])
+                output_args.append(InOutArgument(out_arg, out_arg, expr,
+                        dimensions=dims))
             else:
                 return_val.append(Result(expr))
 
@@ -283,6 +289,11 @@ def get_default_datatype(expr):
     """Derives a decent data type based on the assumptions on the expression."""
     if expr.is_integer:
         return default_datatypes["int"]
+    elif isinstance(expr, MatrixBase):
+        for element in expr:
+            if not element.is_integer:
+                return(default_datatypes["float"])
+        return default_datatypes["int"]
     else:
         return default_datatypes["float"]
 
@@ -293,7 +304,7 @@ class Variable(object):
     def __init__(self, name, datatype=None, dimensions=None, precision=None):
         """Initializes a Variable instance
 
-           name  --  must be of class Symbol
+           name  --  must be of class Symbol or MatrixSymbol
            datatype  --  When not given, the data type will be guessed based
                          on the assumptions on the symbol argument.
            dimension  --  If present, the argument is interpreted as an array.
@@ -388,6 +399,8 @@ class InOutArgument(Argument, ResultBase):
     def __init__(self, name, result_var, expr, datatype=None, dimensions=None, precision=None):
         """ See docstring of Variable.__init__
         """
+        if not datatype:
+            datatype = get_default_datatype(expr)
         Argument.__init__(self, name, datatype, dimensions, precision)
         ResultBase.__init__(self, expr, result_var)
 
@@ -409,7 +422,7 @@ class Result(ResultBase):
         if not isinstance(expr, Expr):
             raise TypeError("The first argument must be a sympy expression.")
 
-        temp_var = Variable(Symbol('result_%s' % hash(expr)),
+        temp_var = Variable(Symbol('result_%s' % abs(hash(expr))),
                 datatype=datatype, dimensions=None, precision=precision)
         ResultBase.__init__(self, expr, temp_var.name)
         self._temp_variable = temp_var
@@ -579,10 +592,11 @@ class CCodeGen(CodeGen):
         for arg in routine.arguments:
             name = ccode(arg.name)
             if arg.dimensions:
+                dims = arg.dimensions
                 if isinstance(arg.name, MatrixSymbol):
                     type_args.append((arg.get_datatype('C'),
-                            "{:}[{:}][{:}]".format(name, arg.name.shape[0],
-                            arg.name.shape[1])))
+                            "{:}[{:}][{:}]".format(name, dims[0][1] + 1,
+                            dims[1][1] + 1)))
                 else:
                     type_args.append((arg.get_datatype('C'), "*%s" % name))
             elif isinstance(arg, ResultBase):


### PR DESCRIPTION
*\* Edit **
This started out as just adding support for `Matrix` in codeprinting/codegen, but turned into a fairly substantial refactor of the existing codebase. I have updated this to reflect that. The TODO list is a trimmed down version of the original TODO, `autowrap` support should come in a later PR, this only has to do with printing now.

See my mammoth sized comment below for what's inside this PR now
*\* end edit **

TODO:
- [x] Support for matrix output in ccode and CCodeGen
- [x] Support for matrix output in fcode and FCodeGen
- [x] Support for `MatrixSymbol` input in ccode and CCodeGen
- [x] Support for `MatrixSymbol` input in fcode and FCodeGen
- [x] Tests
