### PR TITLE
7619: fix recursion error on nested Min

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -322,7 +322,7 @@ class AssocOp(Basic):
         walks the args of the non-number part recursively (doing the same
         thing).
         """
-        x, tail = self.as_independent(C.Symbol)
+        x, tail = self.as_independent(C.Symbol, C.AppliedUndef)
 
         if tail is not self.identity:
             # here, we have a number so we just call to _evalf with prec;

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -1,9 +1,12 @@
+from sympy.core.add import Add
+from sympy.core.function import Function
+from sympy.core.numbers import Float, I, oo, pi, Rational
+from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
-from sympy.core.numbers import Rational
-from sympy.utilities.pytest import raises
 from sympy.functions.elementary.miscellaneous import sqrt, cbrt, root, Min, Max, real_root
-from sympy import S, Float, I, cos, sin, oo, pi, Add
+from sympy.functions.elementary.trigonometric import cos, sin
 
+from sympy.utilities.pytest import raises
 
 def test_Min():
     from sympy.abc import x, y, z
@@ -101,6 +104,10 @@ def test_Min():
     a, b = Symbol('a', real=True), Symbol('b', real=True)
     # a and b are both real, Min(a, b) should be real
     assert Min(a, b).is_real
+
+    # issue 7619
+    f = Function('f')
+    assert Min(1, 2*Min(f(1), 2))  # doesn't fail
 
 
 def test_Max():


### PR DESCRIPTION
Alternatively, instead of checking that the there was no AppliedUndef,
if the expression involving the Min were denested as 2_Min(a,b)->Min(2_a,2*b)
the recursion error would not have occured, either...but one might not
want the unnested expression.
