### PR TITLE
Fix boolalg test failure

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -587,7 +587,7 @@ class Xor(BooleanFunction):
             argset.remove(True)
             return Not(Xor(*argset))
         else:
-            obj._args = tuple(argset)
+            obj._args = tuple(ordered(argset))
             obj._argset = frozenset(argset)
             return obj
 


### PR DESCRIPTION
See issue #7684.  The failure is caused by non-deterministic (hash) ordering of _args.

This PR orders _args in a consistent and deterministic manner (using the str based comparison in `ordered`).
- on master

``` bash
PYTHONHASHSEED=2264035752 bin/test sympy/logic/tests/test_boolalg.py --seed 52767090 -k test_Xor
============================= test process starts ==============================
executable:         /home/ptb/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        52767090
hash randomization: on (PYTHONHASHSEED=2264035752)

sympy/logic/tests/test_boolalg.py[1] F                                    [FAIL]

________________________________________________________________________________
__________________ sympy/logic/tests/test_boolalg.py:test_Xor __________________
  File "/home/ptb/gitrepos/sympy/sympy/logic/tests/test_boolalg.py", line 71, in test_Xor
    assert Xor(True, False, False, A, B) == ~Xor(A, B)
AssertionError

============= tests finished: 0 passed, 1 failed, in 0.13 seconds ==============
DO *NOT* COMMIT!
```
- this PR

``` bash
PYTHONHASHSEED=2264035752 bin/test sympy/logic/tests/test_boolalg.py --seed 52767090 -k test_Xor
============================= test process starts ==============================
executable:         /home/ptb/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        52767090
hash randomization: on (PYTHONHASHSEED=2264035752)

sympy/logic/tests/test_boolalg.py[1] .                                      [OK]

================== tests finished: 1 passed, in 0.18 seconds ===================
```
