### PR TITLE
modifications of arg

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -2,7 +2,8 @@ from __future__ import print_function, division
 
 from sympy.core import S, C
 from sympy.core.compatibility import u
-from sympy.core.function import Function, Derivative, ArgumentIndexError
+from sympy.core.function import (Function, Derivative, ArgumentIndexError,
+    AppliedUndef)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.core import Add, Mul
@@ -475,9 +476,9 @@ class arg(Function):
     @classmethod
     def eval(cls, arg):
         x, y = re(arg), im(arg)
-        arg = C.atan2(y, x)
-        if arg.is_number:
-            return arg
+        rv = C.atan2(y, x)
+        if rv.is_number and not rv.atoms(AppliedUndef):
+            return rv
 
     def _eval_derivative(self, t):
         x, y = re(self.args[0]), im(self.args[0])

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -402,6 +402,23 @@ def test_arg():
     x = Symbol('x')
     assert conjugate(arg(x)) == arg(x)
 
+    e = p + I*p**2
+    assert arg(e) == arg(1 + p*I)
+    # make sure sign doesn't swap
+    e = -2*p + 4*I*p**2
+    assert arg(e) == arg(-1 + 2*p*I)
+    # make sure sign isn't lost
+    x = symbols('x', real=True)  # could be zero
+    e = x + I*x
+    assert arg(e) == arg(x*(1 + I))
+    assert arg(e/p) == arg(x*(1 + I))
+    e = p*cos(p) + I*log(p)*exp(p)
+    assert arg(e).args[0] == e
+    # keep it simple -- let the user do more advanced cancellation
+    e = (p + 1) + I*(p**2 - 1)
+    assert arg(e).args[0] == e
+
+
 def test_arg_rewrite():
     assert arg(1 + I) == atan2(1, 1)
 

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -390,6 +390,8 @@ def test_arg():
     assert arg(1 + I) == pi/4
     assert arg(-1 + I) == 3*pi/4
     assert arg(1 - I) == -pi/4
+    f = Function('f')
+    assert not arg(f(0) + I*f(1)).atoms(re)
 
     p = Symbol('p', positive=True)
     assert arg(p) == 0


### PR DESCRIPTION
There are two changes here to arg:

1) it leaves arguments containing AppliedUndef unevaluated, so `arg(f(0) + I*f(1))` does not become `atan2(re(f(1)) + im(f(0)), re(f(0)) - im(f(1)))`

2) factors that don't change the value of arg are removed so arg(2*x) just becomes arg(x).
