### PR TITLE
NaN inequalities should raise TypeError

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -237,6 +237,8 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
+            if me is S.NaN:
+                raise TypeError("Invalid NaN comparison")
         if self.is_real and other.is_real:
             dif = self - other
             if dif.is_nonnegative is not None and \
@@ -252,6 +254,8 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
+            if me is S.NaN:
+                raise TypeError("Invalid NaN comparison")
         if self.is_real and other.is_real:
             dif = self - other
             if dif.is_nonpositive is not None and \
@@ -267,6 +271,8 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
+            if me is S.NaN:
+                raise TypeError("Invalid NaN comparison")
         if self.is_real and other.is_real:
             dif = self - other
             if dif.is_positive is not None and \
@@ -282,6 +288,8 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
+            if me is S.NaN:
+                raise TypeError("Invalid NaN comparison")
         if self.is_real and other.is_real:
             dif = self - other
             if dif.is_negative is not None and \

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2636,15 +2636,15 @@ class NaN(with_metaclass(Singleton, Number)):
     """
     Not a Number.
 
-    This represents the corresponding data type to floating point nan, which
-    is defined in the IEEE 754 floating point standard, and corresponds to the
-    Python ``float('nan')``.
-
-    NaN serves as a place holder for numeric values that are indeterminate.
+    This serves as a place holder for numeric values that are indeterminate.
     Most operations on NaN, produce another NaN.  Most indeterminate forms,
     such as ``0/0`` or ``oo - oo` produce NaN.  Two exceptions are ``0**0``
     and ``oo**0``, which all produce ``1`` (this is consistent with Python's
     float).
+
+    NaN is loosely related to floating point nan, which is defined in the
+    IEEE 754 floating point standard, and corresponds to the Python
+    ``float('nan')``.  Differences are noted below.
 
     NaN is mathematically not equal to anything else, even NaN itself.  This
     explains the initially counter-intuitive results with ``Eq`` and ``==`` in

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -896,7 +896,7 @@ class Float(Number):
             return other.__le__(self)
         if other.is_comparable:
             other = other.evalf()
-        if isinstance(other, Number):
+        if isinstance(other, Number) and other is not S.NaN:
             return _sympify(bool(
                 mlib.mpf_gt(self._mpf_, other._as_mpf_val(self._prec))))
         return Expr.__gt__(self, other)
@@ -910,7 +910,7 @@ class Float(Number):
             return other.__lt__(self)
         if other.is_comparable:
             other = other.evalf()
-        if isinstance(other, Number):
+        if isinstance(other, Number) and other is not S.NaN:
             return _sympify(bool(
                 mlib.mpf_ge(self._mpf_, other._as_mpf_val(self._prec))))
         return Expr.__ge__(self, other)
@@ -924,7 +924,7 @@ class Float(Number):
             return other.__ge__(self)
         if other.is_real and other.is_number:
             other = other.evalf()
-        if isinstance(other, Number):
+        if isinstance(other, Number) and other is not S.NaN:
             return _sympify(bool(
                 mlib.mpf_lt(self._mpf_, other._as_mpf_val(self._prec))))
         return Expr.__lt__(self, other)
@@ -938,7 +938,7 @@ class Float(Number):
             return other.__gt__(self)
         if other.is_real and other.is_number:
             other = other.evalf()
-        if isinstance(other, Number):
+        if isinstance(other, Number) and other is not S.NaN:
             return _sympify(bool(
                 mlib.mpf_le(self._mpf_, other._as_mpf_val(self._prec))))
         return Expr.__le__(self, other)
@@ -1355,8 +1355,6 @@ class Rational(Number):
             if isinstance(other, Float):
                 return _sympify(bool(mlib.mpf_gt(
                     self._as_mpf_val(other._prec), other._mpf_)))
-            if other is S.NaN:
-                return other.__le__(self)
         elif other.is_number and other.is_real:
             self, other = Integer(self.p), self.q*other
         return Expr.__gt__(self, other)
@@ -1374,8 +1372,6 @@ class Rational(Number):
             if isinstance(other, Float):
                 return _sympify(bool(mlib.mpf_ge(
                     self._as_mpf_val(other._prec), other._mpf_)))
-            if other is S.NaN:
-                return other.__lt__(self)
         elif other.is_number and other.is_real:
             self, other = Integer(self.p), self.q*other
         return Expr.__ge__(self, other)
@@ -1393,8 +1389,6 @@ class Rational(Number):
             if isinstance(other, Float):
                 return _sympify(bool(mlib.mpf_lt(
                     self._as_mpf_val(other._prec), other._mpf_)))
-            if other is S.NaN:
-                return other.__ge__(self)
         elif other.is_number and other.is_real:
             self, other = Integer(self.p), self.q*other
         return Expr.__lt__(self, other)
@@ -1412,8 +1406,6 @@ class Rational(Number):
             if isinstance(other, Float):
                 return _sympify(bool(mlib.mpf_le(
                     self._as_mpf_val(other._prec), other._mpf_)))
-            if other is S.NaN:
-                return other.__gt__(self)
         elif other.is_number and other.is_real:
             self, other = Integer(self.p), self.q*other
         return Expr.__le__(self, other)
@@ -2658,6 +2650,9 @@ class NaN(with_metaclass(Singleton, Number)):
     explains the initially counter-intuitive results with ``Eq`` and ``==`` in
     the examples below.
 
+    NaN is not comparable so inequalities raise a TypeError.  This is in
+    constrast with floating point nan where all inequalities are false.
+
     NaN is a singleton, and can be accessed by ``S.NaN``, or can be imported
     as ``nan``.
 
@@ -2743,33 +2738,11 @@ class NaN(with_metaclass(Singleton, Number)):
         # NaN is not mathematically equal to anything, even NaN
         return S.false
 
-    def __gt__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
-        return S.false
-
-    def __ge__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        return S.false
-
-    def __lt__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
-        return S.false
-
-    def __le__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        return S.false
+    # Expr will _sympify and raise TypeError
+    __gt__ = Expr.__gt__
+    __ge__ = Expr.__ge__
+    __lt__ = Expr.__lt__
+    __le__ = Expr.__le__
 
 nan = S.NaN
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2390,54 +2390,42 @@ class Infinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s < %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             return S.false
-        return C.StrictLessThan(self, other, evaluate=False)
+        return Expr.__lt__(self, other)
 
     def __le__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             if other.is_finite or other is S.NegativeInfinity:
                 return S.false
             elif other is S.Infinity:
                 return S.true
-        return C.LessThan(self, other, evaluate=False)
+        return Expr.__le__(self, other)
 
     def __gt__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s > %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             if other.is_finite or other is S.NegativeInfinity:
                 return S.true
             elif other is S.Infinity:
                 return S.false
-        return C.StrictGreaterThan(self, other, evaluate=False)
+        return Expr.__gt__(self, other)
 
     def __ge__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             return S.true
-        return C.GreaterThan(self, other, evaluate=False)
+        return Expr.__ge__(self, other)
 
     def __mod__(self, other):
         return S.NaN
@@ -2609,54 +2597,42 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s < %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             if other.is_finite or other is S.Infinity:
                 return S.true
             elif other is S.NegativeInfinity:
                 return S.false
-        return C.StrictLessThan(self, other, evaluate=False)
+        return Expr.__lt__(self, other)
 
     def __le__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             return S.true
-        return C.LessThan(self, other, evaluate=False)
+        return Expr.__le__(self, other)
 
     def __gt__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s > %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             return S.false
-        return C.StrictGreaterThan(self, other, evaluate=False)
+        return Expr.__gt__(self, other)
 
     def __ge__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             if other.is_finite or other is S.Infinity:
                 return S.false
             elif other is S.NegativeInfinity:
                 return S.true
-        return C.GreaterThan(self, other, evaluate=False)
+        return Expr.__ge__(self, other)
 
     def __mod__(self, other):
         return S.NaN

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -332,10 +332,10 @@ def test_Rational_cmp():
     assert not (Rational(-1) > 0)
     assert Rational(-1) < 0
 
-    assert (n1 < S.NaN) is S.false
-    assert (n1 <= S.NaN) is S.false
-    assert (n1 > S.NaN) is S.false
-    assert (n1 >= S.NaN) is S.false
+    raises(TypeError, lambda: n1 < S.NaN)
+    raises(TypeError, lambda: n1 <= S.NaN)
+    raises(TypeError, lambda: n1 > S.NaN)
+    raises(TypeError, lambda: n1 >= S.NaN)
 
 
 def test_Float():
@@ -743,14 +743,14 @@ def test_NaN():
     assert 1/nan == nan
     assert 1/(-nan) == nan
     assert 8/nan == nan
-    assert not nan > 0
-    assert not nan < 0
-    assert not nan >= 0
-    assert not nan <= 0
-    assert not 0 < nan
-    assert not 0 > nan
-    assert not 0 <= nan
-    assert not 0 >= nan
+    raises(TypeError, lambda: nan > 0)
+    raises(TypeError, lambda: nan < 0)
+    raises(TypeError, lambda: nan >= 0)
+    raises(TypeError, lambda: nan <= 0)
+    raises(TypeError, lambda: 0 < nan)
+    raises(TypeError, lambda: 0 > nan)
+    raises(TypeError, lambda: 0 <= nan)
+    raises(TypeError, lambda: 0 >= nan)
     assert S.One + nan == nan
     assert S.One - nan == nan
     assert S.One*nan == nan

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -444,6 +444,20 @@ def test_nan_equality_exceptions():
     assert Unequality(random.choice(A), nan) is S.true
 
 
+def test_nan_inequality_raise_errors():
+    # See discussion in pull request #7776.  We test inequalities with
+    # a set including examples of various classes.
+    for q in (x, S(0), S(10), S(1)/3, pi, S(1.3), oo, -oo, nan):
+        assert_all_ineq_raise_TypeError(q, nan)
+
+
+def test_nan_complex_inequalities():
+    # Comparisons of NaN with non-real raise errors, we're not too
+    # fussy whether its the NaN error or complex error.
+    for r in (I, Symbol('z', imaginary=True)):
+        assert_all_ineq_raise_TypeError(r, nan)
+
+
 def test_inequalities_symbol_name_same():
     """Using the operator and functional forms should give same results."""
     # We test all combinations from a set
@@ -474,7 +488,6 @@ def test_inequalities_symbol_name_same_complex():
     With complex non-real numbers, both should raise errors.
     """
     # FIXME: could replace with random selection after test passes
-    # FIXME: add NaN here too later
     for a in (x, S(0), S(1)/3, pi, oo):
         raises(TypeError, lambda: Gt(a, I))
         raises(TypeError, lambda: a > I)

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -944,6 +944,14 @@ def _check_antecedents(g1, g2, x):
     theta = (pi*(v - s - t) + abs(arg(sigma)))/(v - u)
     lambda_c = (q - p)*abs(omega)**(1/(q - p))*cos(psi) \
         + (v - u)*abs(sigma)**(1/(v - u))*cos(theta)
+    # `psi` could be NaN.  If that happens, `lambda_c` and `lambda_s`
+    # will be NaN.  `lambda_c` and `lambda_s` are used (only?) in the
+    # computation of `c15` below.  Two examples that activate this in
+    # test_integrals.py are 'test_issue_4992' and 'test_issue_6253'.
+    # FIXME: probably an expert on MeijerG should think about this!
+    #if psi is S.NaN:
+    #    raise NameError('psi is NaN, what to do?')
+
 
     def lambda_s0(c1, c2):
         return c1*(q - p)*abs(omega)**(1/(q - p))*sin(psi) \
@@ -1036,8 +1044,21 @@ def _check_antecedents(g1, g2, x):
                   Or(And(Ne(zos, 1), abs(arg_(1 - zos)) < pi),
                      And(re(mu + rho + v - u) < 1, Eq(zos, 1))))
 
+        # Note: if `zso` is 1 then we get a NaN below.  This raises a
+        # TypeError on `NaN < pi`.  Previously this gave `False` so
+        # I've hardcoded that behaviour.
+
+        # FIXME: someone should check if this NaN is more serious!
+        # test_meijerint() in test_meijerint.py can hit this.
+        # Specifically: `meijerint_definite(exp(x), x, 0, I)`
+
+        tmp = abs(arg_(1 - zso))
+        if tmp is S.NaN:
+            absarg_1mzso_lt_pi = False
+        else:
+            absarg_1mzso_lt_pi = tmp < pi;
         c14_alt = And(Eq(phi, 0), cstar - 1 + bstar <= 0,
-                  Or(And(Ne(zso, 1), abs(arg_(1 - zso)) < pi),
+                  Or(And(Ne(zso, 1), absarg_1mzso_lt_pi),
                      And(re(mu + rho + q - p) < 1, Eq(zso, 1))))
 
         # Since r=k=l=1, in our case there is c14_alt which is the same as calling
@@ -1049,12 +1070,18 @@ def _check_antecedents(g1, g2, x):
         # Hence the following seems correct:
         c14 = Or(c14, c14_alt)
 
-    tmp = [lambda_c > 0,
-           And(Eq(lambda_c, 0), Ne(lambda_s, 0), re(eta) > -1),
-           And(Eq(lambda_c, 0), Eq(lambda_s, 0), re(eta) > 0)]
-    c15 = Or(*tmp)
-    if _eval_cond(lambda_c > 0) != False:
-        c15 = (lambda_c > 0)
+    # Previously `NaN > 0` was False, which resulted in `c15` being
+    # False.  Now `NaN > 0` raises TypeError.  We hardcode `c15` to
+    # False in that case.  See discussion about `psi` being NaN above.
+    if lambda_c is S.NaN and lambda_s is S.NaN:
+        c15 = False;
+    else:
+        tmp = [lambda_c > 0,
+               And(Eq(lambda_c, 0), Ne(lambda_s, 0), re(eta) > -1),
+               And(Eq(lambda_c, 0), Eq(lambda_s, 0), re(eta) > 0)]
+        c15 = Or(*tmp)
+        if _eval_cond(lambda_c > 0) != False:
+            c15 = (lambda_c > 0)
 
     for cond, i in [(c1, 1), (c2, 2), (c3, 3), (c4, 4), (c5, 5), (c6, 6),
                     (c7, 7), (c8, 8), (c9, 9), (c10, 10), (c11, 11),

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -958,6 +958,7 @@ def test_issue_4737():
 
 
 def test_issue_4992():
+    # Note: psi in _check_antecedents becomes NaN.
     from sympy import simplify, expand_func, polygamma, gamma
     a = Symbol('a', positive=True)
     assert simplify(expand_func(integrate(exp(-x)*log(x)*x**a, (x, 0, oo)))) == \
@@ -984,6 +985,7 @@ def test_issue_4400():
 
 def test_issue_6253():
     # Note: this used to raise NotImplementedError
+    # Note: psi in _check_antecedents becomes NaN.
     assert integrate((sqrt(1 - x) + sqrt(1 + x))**2/x, x, meijerg=True) == \
         Integral((sqrt(-x + 1) + sqrt(x + 1))**2/x, x)
 

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -152,6 +152,7 @@ def test_meijerint():
 
     # Test substitutions to change limits
     assert meijerint_definite(exp(x), x, -oo, 2) == (exp(2), True)
+    # Note: causes a NaN in _check_antecedents
     assert expand(meijerint_definite(exp(x), x, 0, I)[0]) == exp(I) - 1
     assert expand(meijerint_definite(exp(-x), x, 0, x)[0]) == \
         1 - exp(-exp(I*arg(x))*abs(x))


### PR DESCRIPTION
See PR #7776 for discussion.
- [x] NumberSymbol needs special case.
- [x] `oo` needs special case.
- [x] `Float` needs special case.
- [x] 'Rational' works as is (as existing special case).
- [x] lots of asymmetric results: IMHO we really do want _lots_ of tests, not just spot tests, sorry @smichr!
- [x] All of this is for the binary ops, `Lt` is not tackled, that is pr #7783.
- [x] clean up tests, test comments
- [x] couple FIXME's: one remains but its documented and I left it as question in the code
- [x] rebase, squash
- [x] proper commit msg
