### PR TITLE
oo comparisions with non-number non-reals should raise errors

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2250,26 +2250,30 @@ class Infinity(with_metaclass(Singleton, Number)):
 
     @_sympifyit('other', NotImplemented)
     def __lt__(self, other):
-        if other.is_number and other.is_real is False:
-            raise TypeError("Invalid comparison of %s and %s" % (self, other))
+        if other.is_complex and other.is_real is False:
+            raise TypeError("Invalid complex comparison: %s and %s" %
+                            (self, other))
         return S.false
 
     @_sympifyit('other', NotImplemented)
     def __le__(self, other):
-        if other.is_number and other.is_real is False:
-            raise TypeError("Invalid comparison of %s and %s" % (self, other))
+        if other.is_complex and other.is_real is False:
+            raise TypeError("Invalid complex comparison: %s and %s" %
+                            (self, other))
         return _sympify(other is S.Infinity)
 
     @_sympifyit('other', NotImplemented)
     def __gt__(self, other):
-        if other.is_number and other.is_real is False:
-            raise TypeError("Invalid comparison of %s and %s" % (self, other))
+        if other.is_complex and other.is_real is False:
+            raise TypeError("Invalid complex comparison: %s and %s" %
+                            (self, other))
         return _sympify(other is not S.Infinity)
 
     @_sympifyit('other', NotImplemented)
     def __ge__(self, other):
-        if other.is_number and other.is_real is False:
-            raise TypeError("Invalid comparison of %s and %s" % (self, other))
+        if other.is_complex and other.is_real is False:
+            raise TypeError("Invalid complex comparison: %s and %s" %
+                            (self, other))
         return S.true
 
     def __mod__(self, other):
@@ -2443,26 +2447,30 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
 
     @_sympifyit('other', NotImplemented)
     def __lt__(self, other):
-        if other.is_number and other.is_real is False:
-            raise TypeError("Invalid comparison of %s and %s" % (self, other))
+        if other.is_complex and other.is_real is False:
+            raise TypeError("Invalid complex comparison: %s and %s" %
+                            (self, other))
         return _sympify(other is not S.NegativeInfinity)
 
     @_sympifyit('other', NotImplemented)
     def __le__(self, other):
-        if other.is_number and other.is_real is False:
-            raise TypeError("Invalid comparison of %s and %s" % (self, other))
+        if other.is_complex and other.is_real is False:
+            raise TypeError("Invalid complex comparison: %s and %s" %
+                            (self, other))
         return S.true
 
     @_sympifyit('other', NotImplemented)
     def __gt__(self, other):
-        if other.is_number and other.is_real is False:
-            raise TypeError("Invalid comparison of %s and %s" % (self, other))
+        if other.is_complex and other.is_real is False:
+            raise TypeError("Invalid complex comparison: %s and %s" %
+                            (self, other))
         return S.false
 
     @_sympifyit('other', NotImplemented)
     def __ge__(self, other):
-        if other.is_number and other.is_real is False:
-            raise TypeError("Invalid comparison of %s and %s" % (self, other))
+        if other.is_complex and other.is_real is False:
+            raise TypeError("Invalid complex comparison: %s and %s" %
+                            (self, other))
         return _sympify(other is S.NegativeInfinity)
 
     def __mod__(self, other):

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -371,6 +371,13 @@ def test_complex_compare_not_real():
         assert_all_ineq_give_class_Inequality(2, w)
 
 
+def test_imaginary_and_inf_compare_raises_TypeError():
+    # See pull request #7835
+    y = Symbol('y', imaginary=True)
+    assert_all_ineq_raise_TypeError(oo, y)
+    assert_all_ineq_raise_TypeError(-oo, y)
+
+
 def test_complex_pure_imag_not_ordered():
     raises(TypeError, lambda: 2*I < 3*I)
 


### PR DESCRIPTION
Follow-up to pr #7815
More descriptive error messages to inform that "complex" is the cause
