### PR TITLE
Binary ineq like `<` should give same as functional forms `Lt`

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -221,10 +221,19 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
+        # try to deal with assumptions
         dif = self - other
         if dif.is_nonnegative is not None and \
                 dif.is_nonnegative is not dif.is_negative:
             return sympify(dif.is_nonnegative)
+        # try to simplify expressions without symbols
+        if not dif.has(C.Symbol):
+            know = dif.equals(0)
+            # could be None for don't know: return unevaluated
+            if know == True:
+                return S.true
+            elif know == False:
+                return dif.evalf().__ge__(S.zero)
         return C.GreaterThan(self, other, evaluate=False)
 
     def __le__(self, other):
@@ -235,10 +244,19 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
+        # try to deal with assumptions
         dif = self - other
         if dif.is_nonpositive is not None and \
                 dif.is_nonpositive is not dif.is_positive:
             return sympify(dif.is_nonpositive)
+        # try to simplify expressions without symbols
+        if not dif.has(C.Symbol):
+            know = dif.equals(0)
+            # could be None for don't know: return unevaluated
+            if know == True:
+                return S.true
+            elif know == False:
+                return dif.evalf().__le__(S.zero)
         return C.LessThan(self, other, evaluate=False)
 
     def __gt__(self, other):
@@ -249,10 +267,19 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
+        # try to deal with assumptions
         dif = self - other
         if dif.is_positive is not None and \
                 dif.is_positive is not dif.is_nonpositive:
             return sympify(dif.is_positive)
+        # try to simplify expressions without symbols
+        if not dif.has(C.Symbol):
+            know = dif.equals(0)
+            # could be None for don't know: return unevaluated
+            if know == True:
+                return S.false
+            elif know == False:
+                return dif.evalf().__gt__(S.zero)
         return C.StrictGreaterThan(self, other, evaluate=False)
 
     def __lt__(self, other):
@@ -264,9 +291,18 @@ class Expr(Basic, EvalfMixin):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
         dif = self - other
+        # try to deal with assumptions
         if dif.is_negative is not None and \
                 dif.is_negative is not dif.is_nonnegative:
             return sympify(dif.is_negative)
+        # try to simplify expressions without symbols
+        if not dif.has(C.Symbol):
+            know = dif.equals(0)
+            # could be None for don't know: return unevaluated
+            if know == True:
+                return S.false
+            elif know == False:
+                return dif.evalf().__lt__(S.zero)
         return C.StrictLessThan(self, other, evaluate=False)
 
     @staticmethod


### PR DESCRIPTION
Is this the right fix for underlying issue in pr #7783?
- [x] pass tests from #7783 
- [x] pass rest of `test_relational.py`
- [x] make sure non-evaluated but potentially evaluatable still works.  E.g., things like:

```
e = Lt(7,7, evaluate=False)
e.doit()
```
- [X] Make sure `e = Lt(x,y); e.doit()` takes same path.   update: it does.
- [X] consider removing `_eval_sides` from code, or make it specific to the Equality/Unequality.  Update: for now, I call it from `Expr.__lt__` (which may not be the "cleanest" given that its a `_` method.)
- [x] consider the broader test suite.
- [x] There is bound to be some fallout...  Update: surprisingly little so far, all changes local to `expr.py` and `relational.py`.
- [X] Consider: Could `lhs.__lt__(rhs)` return None?  `Equality` and `_eval_Eq` use this but `__lt__` is not a helper function so not sure its useful here...  Update:  current approach seems to be working.
- [x] Are any documentation changes needed?  E.g., should the docs contain something like my explanation of the approach given in the commit message?  No: there are comments in the code and the documentation in `GreaterThan` already implies `>` should be the same.
