### PR TITLE
Add numexpr option for lambdify

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -69,6 +69,39 @@ class LambdaPrinter(StrPrinter):
     def _print_BooleanFalse(self, expr):
         return "False"
 
+# numexpr works by altering the string passed to numexpr.evaluate
+# rather than by populating a namespace.  Thus a special printer...
+# This class cannot be placed in lambdify.py due to circular imports
+class NumExprPrinter(LambdaPrinter):
+    # strings to substitute for sympy expressions
+    str_subs = {
+        "Abs": "abs",
+        "acos": "arccos",
+        "acosh": "arccosh",
+        "asin": "arcsin",
+        "asinh": "arcsinh",
+        "atan": "arctan",
+        "atan2": "arctan2",
+        "atanh": "arctanh",
+        "E": "e",
+        "im": "imag",
+        "ln": "log",
+        "re": "real",
+        "I": "1j",
+    }
+    # numexpr does not support these operations, throw TypeError if found
+    blacklisted = ('matrix', 'list', 'tuple')
+    def doprint(self, expr):
+        lstr = super(NumExprPrinter, self).doprint(expr)
+        # check blacklisted
+        for b in self.blacklisted:
+            if b in lstr.lower():
+                raise TypeError("numexpr cannot be used with {}".format(b))
+        # substitute strings
+        for k, v in sorted(self.str_subs.items(), key=lambda x : -len(x[0])):
+            lstr = lstr.replace(k, v)
+        return "evaluate('"+lstr+"')"
+
 def lambdarepr(expr, **settings):
     """
     Returns a string usable for lambdifying.

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -104,14 +104,26 @@ class NumExprPrinter(LambdaPrinter):
     def _print_ImaginaryUnit(self, expr):
         return '1j'
 
+    def _print_seq(self, seq, delimiter=', '):
+        # simplified _print_seq taken from pretty.py
+        s = [self._print(item) for item in seq]
+        if s:
+            return delimiter.join(s)
+        else:
+            return ""
+
     def _print_Function(self, e):
         func_name = e.func.__name__
-        try:
-            nstr = self._numexpr_functions[func_name]
-        except KeyError:
-            raise TypeError("numexpr does not support function %s" %
-                            func_name)
-        return "%s(%s)" % (nstr, self._print(e.args[0]))
+
+        nstr = self._numexpr_functions.get(func_name, None)
+        if nstr is None:
+            # check for implemented_function
+            if hasattr(e, '_imp_'):
+                return "(%s)" % self._print(e._imp_(*e.args))
+            else:
+                raise TypeError("numexpr does not support function '%s'" %
+                                func_name)
+        return "%s(%s)" % (nstr, self._print_seq(e.args))
 
     def blacklisted(self, expr):
         raise TypeError("numexpr cannot be used with %s" %

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -161,7 +161,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     functions - exactly in this order. To change this behavior, the "modules"
     argument can be used. It accepts:
 
-     - the strings "math", "mpmath", "numpy", "sympy", "numexpr"
+     - the strings "math", "mpmath", "numpy", "numexpr", "sympy"
      - any modules (e.g. math)
      - dictionaries that map names of sympy functions to arbitrary functions
      - lists that contain a mix of the arguments above, with higher priority
@@ -177,6 +177,13 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     If numpy is installed, the default behavior is to substitute Sympy Matrices
     with numpy.matrix. If you would rather have a numpy.array returned,
     set use_array=True.
+
+    For functions involving large array calculations, numexpr can provide a
+    significant speedup over numpy.  Please note that the available functions
+    for numexpr are more limited than numpy but can be expanded with
+    implemented_function and user defined subclasses of Function.  The official
+    list of numexpr functions can be found at:
+    https://github.com/pydata/numexpr#supported-functions
 
     Usage
     =====

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -30,7 +30,7 @@ MATH_DEFAULT = {}
 MPMATH_DEFAULT = {}
 NUMPY_DEFAULT = {"I": 1j}
 SYMPY_DEFAULT = {}
-NUMEXPR_DEFAULT = {"I": 1j}
+NUMEXPR_DEFAULT = {}
 
 # Mappings between sympy and other modules function names.
 MATH_TRANSLATIONS = {
@@ -95,17 +95,16 @@ NUMEXPR_TRANSLATIONS = {
     "Abs": "abs",
     "acos": "arccos",
     "acosh": "arccosh",
-    "arg": "angle",
     "asin": "arcsin",
     "asinh": "arcsinh",
     "atan": "arctan",
     "atan2": "arctan2",
     "atanh": "arctanh",
-    "ceiling": "ceil",
     "E": "e",
     "im": "imag",
     "ln": "log",
     "re": "real",
+    "I": "1j",
 }
 
 # Available modules:
@@ -366,6 +365,9 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         m = NUMEXPR_PAT.search(lstr)
         st = m.start()
         lstr = lstr[:st+2]+"evaluate('"+lstr[st+2:]+"')"
+        # use translation table to directly modify lstr
+        for k in sorted(NUMEXPR_TRANSLATIONS.keys(), key=len)[::-1]:
+            lstr = lstr.replace(k, NUMEXPR_TRANSLATIONS[k])
     if flat in lstr:
         import itertools
         namespace.update({flat: flatten})

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -181,8 +181,9 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     For functions involving large array calculations, numexpr can provide a
     significant speedup over numpy.  Please note that the available functions
     for numexpr are more limited than numpy but can be expanded with
-    implemented_function and user defined subclasses of Function.  The official
-    list of numexpr functions can be found at:
+    implemented_function and user defined subclasses of Function.  If specified,
+    numexpr may be the only option in modules. The official list of numexpr
+    functions can be found at:
     https://github.com/pydata/numexpr#supported-functions
 
     Usage
@@ -324,6 +325,9 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     if isinstance(modules, (dict, str)) or not hasattr(modules, '__iter__'):
         namespaces.append(modules)
     else:
+        # consistency check
+        if 'numexpr' in modules and len(modules) > 1:
+            raise TypeError("numexpr must be the only item in 'modules'")
         namespaces += list(modules)
     # fill namespace with first having highest priority
     namespace = {}


### PR DESCRIPTION
Sometimes numpy just isn't fast enough....

``` python
In [1]: from sympy.abc import x, y, z

In [2]: from sympy import lambdify, S

In [3]: import numpy as np

In [4]: a, b, c = np.random.randn(300000).reshape((3, 100000))

In [5]: f = lambdify((x, y, z), 3*x**2+2*(y-z)+S('sin')(z**3)+S('exp')(x*y-z), modules="numpy")

In [6]: ff = lambdify((x, y, z), 3*x**2+2*(y-z)+S('sin')(z**3)+S('exp')(x*y-z), modules="numexpr")

In [7]: np.allclose(f(a, b, c), ff(a, b, c))
Out[7]: True

In [8]: %timeit(f(a, b, c))
10 loops, best of 3: 22 ms per loop

In [9]: %timeit(ff(a, b, c))
100 loops, best of 3: 2.07 ms per loop

In [10]: 
```

My functions tend to be long but simple as in the example above, so I haven't tested this extensively on more complex functions.  If those interested in this could post any successes/failures that would be appreciated! 
