### PR TITLE
increase evalf workprec more quickly

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -971,13 +971,21 @@ def evalf_integral(expr, prec, options):
     maxprec = options.get('maxprec', INF)
     while 1:
         result = do_integral(expr, workprec, options)
-        # if a scaled_zero comes back accuracy will compute to -1
-        # which will cause workprec to increment by 1
         accuracy = complex_accuracy(result)
-        if accuracy >= prec or workprec >= maxprec:
-            return result
-        workprec += prec - max(-2**i, accuracy)
+        if accuracy >= prec:  # achieved desired precision
+            break
+        if workprec >= maxprec:  # can't increase accuracy any more
+            break
+        if accuracy == -1:
+            # maybe the answer really is zero and maybe we just haven't increased
+            # the precision enough. So increase by doubling to not take too long
+            # to get to maxprec.
+            workprec *= 2
+        else:
+            workprec += max(prec, 2**i)
+        workprec = min(workprec, maxprec)
         i += 1
+    return result
 
 
 def check_convergence(numer, denom, n):

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,7 +1,7 @@
 from sympy import (Add, ceiling, cos, E, Eq, exp, factorial, fibonacci, floor,
                    Function, GoldenRatio, I, log, Mul, oo, pi, Pow, Rational,
                    sin, sqrt, sstr, sympify, S, integrate, atan, product,
-                   Sum, Product)
+                   Sum, Product, Integral)
 from sympy.core.evalf import complex_accuracy, PrecisionExhausted, scaled_zero
 from sympy.core.compatibility import long
 from sympy.mpmath import inf, ninf, nan
@@ -433,3 +433,9 @@ def test_issue_4945():
     from sympy.abc import H
     from sympy import zoo
     assert (H/0).evalf(subs={H:1}) == zoo*H
+
+
+def test_evalf_integral():
+    # test that workprec has to increase in order to get a result other than 0
+    eps = Rational(1, 1000000)
+    assert Integral(sin(x), (x, -pi, pi + eps)).n(2)._prec == 10


### PR DESCRIPTION
There were some oddities here that have been here since this code was
added. If the desired precision was not obtained, the precision appears
to want to increase in a doubling fashion based on the iteration number
but that computed value is never used by using the expression prec -
max(-2**i, accuracy)

Let's say prec was 15 but accuracy was 10 on the first iteration: the
new workprec would increase by 15 - max(-1, 10) = 5. If accuracy was 12
on the next step the new workprec would be 15 - max(-2, 12) = 3.
So the workprec is increasing but in a very slow fashion based
on the difference between the desired prec and the accuracy.

If a result of 0 was calculated, however, this would cause the working
prec to increase at a rate of prec + 1 until the maxprec was reached
because the accuracy for a scaled zero is -1. So, for example, if a value
of 0 is still being obtained when i=10 a change in prec is calculated
as 15 - max(-2**10, -1) = 16.

In both cases the value based on iteration (2**i) is being ignored.

With the changes of this commit, the larger of 2**i and prec is used as
the increment for workprec when accuracy != -1; it doubles each step when
accuracy is -1.
