### PR TITLE
Removed authors header from docs

### DIFF
--- a/doc/src/modules/physics/mechanics/index.rst
+++ b/doc/src/modules/physics/mechanics/index.rst
@@ -2,8 +2,6 @@
 Classical Mechanics
 ===================
 
-:Authors: Gilbert Gede, Luke Peterson, Angadh Nanjangud
-
 .. topic:: Abstract
 
    In this documentation many components of the physics/mechanics module will

--- a/doc/src/modules/physics/vector/index.rst
+++ b/doc/src/modules/physics/vector/index.rst
@@ -2,8 +2,6 @@
 The Physics Vector Module
 =========================
 
-:Authors: Gilbert Gede, Luke Peterson, Angadh Nanjangud, Sachin Joglekar
-
 .. topic:: Abstract
 
    In this documentation the components of the sympy.physics.vector module


### PR DESCRIPTION
Removed authors header from docs in mechanics and vector. If people want to know the names of everyone that worked on these modules, they can look it up in the sympy contributors list, or in the git log.
