### PR TITLE
is_zero and free_symbols/is_number modifications

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -162,8 +162,6 @@ class ExprWithLimits(Expr):
 
     @property
     def free_symbols(self):
-        if self.function.is_zero:
-            return set()
         return self._free_symbols()
 
     def as_dummy(self):

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -204,28 +204,9 @@ class Product(ExprWithIntLimits):
         return self._args[0]
     function = term
 
-    @property
-    def free_symbols(self):
-        """
-        This method returns the symbols that will affect the value of
-        the Product when evaluated. This is useful if one is trying to
-        determine whether a product depends on a certain symbol or not.
-
-        >>> from sympy import Product
-        >>> from sympy.abc import x, y
-        >>> Product(x, (x, y, 1)).free_symbols
-        set([y])
-        """
-        return self._free_symbols()
-
     def _eval_is_zero(self):
         # a Product is zero only if its term is zero.
         return self.term.is_zero
-
-    @property
-    def is_number(self):
-        """Return True if the Sum has no free symbols, else False."""
-        return not self.free_symbols
 
     def doit(self, **hints):
         f = self.function

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -224,27 +224,8 @@ class Product(ExprWithIntLimits):
 
     @property
     def is_number(self):
-        """
-        Return True if the Product will result in a number, else False.
-
-        Examples
-        ========
-
-        >>> from sympy import log, Product
-        >>> from sympy.abc import x, y, z
-        >>> log(2).is_number
-        True
-        >>> Product(x, (x, 1, 2)).is_number
-        True
-        >>> Product(y, (x, 1, 2)).is_number
-        False
-        >>> Product(1, (x, y, z)).is_number
-        True
-        >>> Product(2, (x, y, z)).is_number
-        False
-        """
-
-        return self.function.is_zero or self.function == 1 or not self.free_symbols
+        """Return True if the Sum has no free symbols, else False."""
+        return not self.free_symbols
 
     def doit(self, **hints):
         f = self.function

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -216,8 +216,6 @@ class Product(ExprWithIntLimits):
         >>> Product(x, (x, y, 1)).free_symbols
         set([y])
         """
-        if self.function.is_zero or self.function == 1:
-            return set()
         return self._free_symbols()
 
     @property

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -218,10 +218,8 @@ class Product(ExprWithIntLimits):
         """
         return self._free_symbols()
 
-    @property
-    def is_zero(self):
-        """A Product is zero only if its term is zero.
-        """
+    def _eval_is_zero(self):
+        # a Product is zero only if its term is zero.
         return self.term.is_zero
 
     @property

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -153,11 +153,6 @@ class Sum(AddWithLimits,ExprWithIntLimits):
         if self.function.is_zero:
             return True
 
-    @property
-    def is_number(self):
-        """Return True if the Sum has no free symbols, else False."""
-        return not self.free_symbols
-
     def doit(self, **hints):
         if hints.get('deep', True):
             f = self.function.doit(**hints)

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -155,36 +155,8 @@ class Sum(AddWithLimits,ExprWithIntLimits):
 
     @property
     def is_number(self):
-        """
-        Return True if the Sum will result in a number, else False.
-
-        Sums are a special case since they contain symbols that can
-        be replaced with numbers. Whether the sum can be done or not in
-        closed form is another issue. But answering whether the final
-        result is a number is not difficult.
-
-        Examples
-        ========
-
-        >>> from sympy import Sum
-        >>> from sympy.abc import x, y
-        >>> Sum(x, (y, 1, x)).is_number
-        False
-        >>> Sum(1, (y, 1, x)).is_number
-        False
-        >>> Sum(0, (y, 1, x)).is_number
-        True
-        >>> Sum(x, (y, 1, 2)).is_number
-        False
-        >>> Sum(x, (y, 1, 1)).is_number
-        False
-        >>> Sum(x, (x, 1, 2)).is_number
-        True
-        >>> Sum(x*y, (x, 1, 2), (y, 1, 3)).is_number
-        True
-        """
-
-        return self.function.is_zero or not self.free_symbols
+        """Return True if the Sum has no free symbols, else False."""
+        return not self.free_symbols
 
     def doit(self, **hints):
         if hints.get('deep', True):

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -145,12 +145,13 @@ class Sum(AddWithLimits,ExprWithIntLimits):
 
         return obj
 
-    @property
-    def is_zero(self):
-        """A Sum is only zero if its function is zero or if all terms
-        cancel out. This only answers whether the summand zero."""
-
-        return self.function.is_zero
+    def _eval_is_zero(self):
+        # a Sum is only zero if its function is zero or if all terms
+        # cancel out. This only answers whether the summand is zero; if
+        # not then None is returned since we don't analyze whether all
+        # terms cancel out.
+        if self.function.is_zero:
+            return True
 
     @property
     def is_number(self):

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -583,12 +583,6 @@ def test_issue_4170():
     assert summation(1/factorial(k), (k, 0, oo)) == E
 
 
-def test_is_zero():
-    for func in [Sum, Product]:
-        assert func(0, (x, 1, 1)).is_zero is True
-        assert func(x, (x, 1, 1)).is_zero is None
-
-
 def test_is_commutative():
     from sympy.physics.secondquant import NO, F, Fd
     m = Symbol('m', commutative=False)
@@ -600,10 +594,18 @@ def test_is_commutative():
         assert f(NO(Fd(x)*F(y))*z, (z, 1, 2)).is_commutative is False
 
 
+def test_is_zero():
+    for func in [Sum, Product]:
+        assert func(0, (x, 1, 1)).is_zero is True
+        assert func(x, (x, 1, 1)).is_zero is None
+
+
 def test_is_number():
+    # is number should not rely on evaluation or assumptions,
+    # it should be equivalent to `not foo.free_symbols`
     assert Sum(1, (x, 1, 1)).is_number is True
     assert Sum(1, (x, 1, x)).is_number is False
-    assert Sum(0, (x, y, z)).is_number is True
+    assert Sum(0, (x, y, z)).is_number is False
     assert Sum(x, (y, 1, 2)).is_number is False
     assert Sum(x, (y, 1, 1)).is_number is False
     assert Sum(x, (x, 1, 2)).is_number is True
@@ -611,8 +613,8 @@ def test_is_number():
 
     assert Product(2, (x, 1, 1)).is_number is True
     assert Product(2, (x, 1, y)).is_number is False
-    assert Product(0, (x, y, z)).is_number is True
-    assert Product(1, (x, y, z)).is_number is True
+    assert Product(0, (x, y, z)).is_number is False
+    assert Product(1, (x, y, z)).is_number is False
     assert Product(x, (y, 1, x)).is_number is False
     assert Product(x, (y, 1, 2)).is_number is False
     assert Product(x, (y, 1, 1)).is_number is False

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -622,7 +622,7 @@ def test_is_number():
 def test_free_symbols():
     for func in [Sum, Product]:
         assert func(1, (x, 1, 2)).free_symbols == set()
-        assert func(0, (x, 1, y)).free_symbols == set()
+        assert func(0, (x, 1, y)).free_symbols == set([y])
         assert func(2, (x, 1, y)).free_symbols == set([y])
         assert func(x, (x, 1, 2)).free_symbols == set()
         assert func(x, (x, 1, y)).free_symbols == set([y])
@@ -635,7 +635,9 @@ def test_free_symbols():
         assert func(x, (x, 1, y), (y, 1, y)).free_symbols == set([y])
         assert func(x, (y, 1, y), (y, 1, z)).free_symbols == set([x, z])
     assert Sum(1, (x, 1, y)).free_symbols == set([y])
-    assert Product(1, (x, 1, y)).free_symbols == set()
+    # free_symbols answers whether the object *as written* has free symbols,
+    # not whether the evaluated expression has free symbols
+    assert Product(1, (x, 1, y)).free_symbols == set([y])
 
 
 def test_conjugate_transpose():

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -48,6 +48,7 @@ class Basic(with_metaclass(ManagedProperties)):
                 ]
 
     # To be overridden with True in the appropriate subclasses
+    is_number = False
     is_Atom = False
     is_Symbol = False
     is_Dummy = False
@@ -490,8 +491,7 @@ class Basic(with_metaclass(ManagedProperties)):
 
         Any other method that uses bound variables should implement a symbols
         method."""
-        union = set.union
-        return reduce(union, [arg.free_symbols for arg in self.args], set())
+        return reduce(set.union, [a.free_symbols for a in self.args], set())
 
     @property
     def canonical_variables(self):
@@ -559,19 +559,6 @@ class Basic(with_metaclass(ManagedProperties)):
     def is_hypergeometric(self, k):
         from sympy.simplify import hypersimp
         return hypersimp(self, k) is not None
-
-    @property
-    def is_number(self):
-        """Returns ``True`` if 'self' contains no free symbols.
-
-        See Also
-        ========
-        is_comparable
-        sympy.core.expr.is_number
-
-        """
-        # should be overriden by subclasses
-        return False
 
     @property
     def is_comparable(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -293,8 +293,6 @@ class Expr(Basic, EvalfMixin):
         True
 
         """
-        if not self.args:
-            return False
         return all(obj.is_number for obj in self.args)
 
     def _random(self, n=None, re_min=-1, im_min=-1, re_max=1, im_max=1):
@@ -3044,7 +3042,7 @@ class AtomicExpr(Atom, Expr):
     For example: Symbol, Number, Rational, Integer, ...
     But not: Add, Mul, Pow, ...
     """
-
+    is_number = False
     is_Atom = True
 
     __slots__ = []

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -783,10 +783,6 @@ class WildFunction(Function, AtomicExpr):
         repl_dict[self] = expr
         return repl_dict
 
-    @property
-    def is_number(self):
-        return False
-
 
 class Derivative(Expr):
     """

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -216,13 +216,12 @@ class Number(AtomicExpr):
     """
     is_commutative = True
     is_number = True
+    is_Number = True
 
     __slots__ = []
 
     # Used to make max(x._prec, y._prec) return x._prec when only x is a float
     _prec = -1
-
-    is_Number = True
 
     def __new__(cls, *obj):
         if len(obj) == 1:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -581,6 +581,7 @@ class Float(Number):
     # both rational and irrational.
     is_rational = None
     is_irrational = None
+    is_number = True
 
     is_real = True
 
@@ -1031,6 +1032,7 @@ class Rational(Number):
     is_real = True
     is_integer = False
     is_rational = True
+    is_number = True
 
     __slots__ = ['p', 'q']
 
@@ -1546,6 +1548,7 @@ class Integer(Rational):
 
     q = 1
     is_integer = True
+    is_number = True
 
     is_Integer = True
 
@@ -1894,6 +1897,7 @@ class Zero(with_metaclass(Singleton, IntegerConstant)):
     is_negative = False
     is_zero = True
     is_composite = False
+    is_number = True
 
     __slots__ = []
 
@@ -1948,6 +1952,7 @@ class One(with_metaclass(Singleton, IntegerConstant)):
 
     .. [1] http://en.wikipedia.org/wiki/1_%28number%29
     """
+    is_number = True
 
     p = 1
     q = 1
@@ -1999,6 +2004,7 @@ class NegativeOne(with_metaclass(Singleton, IntegerConstant)):
     .. [1] http://en.wikipedia.org/wiki/%E2%88%921_%28number%29
 
     """
+    is_number = True
 
     p = -1
     q = 1
@@ -2053,6 +2059,7 @@ class Half(with_metaclass(Singleton, RationalConstant)):
 
     .. [1] http://en.wikipedia.org/wiki/One_half
     """
+    is_number = True
 
     p = 1
     q = 2
@@ -2109,6 +2116,7 @@ class Infinity(with_metaclass(Singleton, Number)):
     is_integer = None
     is_rational = None
     is_odd = None
+    is_number = True
 
     __slots__ = []
 
@@ -2296,6 +2304,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     is_infinitesimal = False
     is_integer = None
     is_rational = None
+    is_number = True
 
     __slots__ = []
 
@@ -2524,6 +2533,7 @@ class NaN(with_metaclass(Singleton, Number)):
     is_prime = None
     is_positive = None
     is_negative = None
+    is_number = True
 
     __slots__ = []
 
@@ -2773,6 +2783,7 @@ class Exp1(with_metaclass(Singleton, NumberSymbol)):
     is_positive = True
     is_negative = False  # XXX Forces is_negative/is_nonnegative
     is_irrational = True
+    is_number = True
 
     __slots__ = []
 
@@ -2849,6 +2860,7 @@ class Pi(with_metaclass(Singleton, NumberSymbol)):
     is_positive = True
     is_negative = False
     is_irrational = True
+    is_number = True
 
     __slots__ = []
 
@@ -2907,6 +2919,7 @@ class GoldenRatio(with_metaclass(Singleton, NumberSymbol)):
     is_positive = True
     is_negative = False
     is_irrational = True
+    is_number = True
 
     __slots__ = []
 
@@ -2969,6 +2982,7 @@ class EulerGamma(with_metaclass(Singleton, NumberSymbol)):
     is_positive = True
     is_negative = False
     is_irrational = None
+    is_number = True
 
     __slots__ = []
 
@@ -3024,6 +3038,7 @@ class Catalan(with_metaclass(Singleton, NumberSymbol)):
     is_positive = True
     is_negative = False
     is_irrational = None
+    is_number = True
 
     __slots__ = []
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -129,10 +129,6 @@ class Symbol(AtomicExpr, Boolean):
         return not self in wrt
 
     @property
-    def is_number(self):
-        return False
-
-    @property
     def free_symbols(self):
         return set([self])
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -132,6 +132,10 @@ class Symbol(AtomicExpr, Boolean):
     def free_symbols(self):
         return set([self])
 
+    @property
+    def is_number(self):
+        return False
+
 
 class Dummy(Symbol):
     """Dummy symbols are each unique, identified by an internal count index:
@@ -180,6 +184,10 @@ class Dummy(Symbol):
 
     def _hashable_content(self):
         return Symbol._hashable_content(self) + (self.dummy_index,)
+
+    @property
+    def is_number(self):
+        return False
 
 
 class Wild(Symbol):
@@ -290,6 +298,10 @@ class Wild(Symbol):
 
     def __call__(self, *args, **kwargs):
         raise TypeError("'%s' object is not callable" % type(self).__name__)
+
+    @property
+    def is_number(self):
+        return False
 
 
 _range = _re.compile('([0-9]*:[0-9]+|[a-zA-Z]?:[a-zA-Z])')

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -132,10 +132,6 @@ class Symbol(AtomicExpr, Boolean):
     def free_symbols(self):
         return set([self])
 
-    @property
-    def is_number(self):
-        return False
-
 
 class Dummy(Symbol):
     """Dummy symbols are each unique, identified by an internal count index:
@@ -184,10 +180,6 @@ class Dummy(Symbol):
 
     def _hashable_content(self):
         return Symbol._hashable_content(self) + (self.dummy_index,)
-
-    @property
-    def is_number(self):
-        return False
 
 
 class Wild(Symbol):
@@ -258,9 +250,9 @@ class Wild(Symbol):
     {a_: 2, b_: x**3*y*z}
 
     """
+    is_Wild = True
 
     __slots__ = ['exclude', 'properties']
-    is_Wild = True
 
     def __new__(cls, name, exclude=(), properties=(), **assumptions):
         exclude = tuple([sympify(x) for x in exclude])
@@ -298,10 +290,6 @@ class Wild(Symbol):
 
     def __call__(self, *args, **kwargs):
         raise TypeError("'%s' object is not callable" % type(self).__name__)
-
-    @property
-    def is_number(self):
-        return False
 
 
 _range = _re.compile('([0-9]*:[0-9]+|[a-zA-Z]?:[a-zA-Z])')

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -168,3 +168,26 @@ def test_call():
     #assert (2*f)(x) == 2*f(x)
 
     assert (Q.real & Q.positive).rcall(x) == Q.real(x) & Q.positive(x)
+
+def test_literal_evalf_is_number_is_zero_is_comparable():
+    from sympy.integrals.integrals import Integral
+    from sympy.core.symbol import symbols
+    from sympy.core.function import Function
+    x = symbols('x')
+    f = Function('f')
+
+    # the following should not be changed without a lot of dicussion
+    # `foo.is_number` should be equivalent to `not foo.free_symbols`
+    # it should not attempt anything fancy; see is_zero, is_constant
+    # and equals for more rigorous tests.
+    assert f(1).is_number is True
+    i = Integral(0, (x, x, x))
+    # expressions that are symbolically 0 can be difficult to prove
+    # so in case there is some easy way to know if something is 0
+    # it should appear in the is_zero property for that object;
+    # if is_zero is true evalf should always be able to compute that
+    # zero
+    assert i.n() == 0
+    assert i.is_zero
+    assert i.is_number is False
+    assert i.evalf(2, strict=False) == 0

--- a/sympy/core/trace.py
+++ b/sympy/core/trace.py
@@ -173,8 +173,7 @@ class Tr(Expr):
 
     @property
     def is_number(self):
-        #TODO : This function to be reviewed
-        # and implementation improved.
+        # TODO : improve this implementation
         return True
 
     #TODO: Review if the permute method is needed

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -644,11 +644,6 @@ class log(Function):
                 return False
             return (arg - 1).is_positive
 
-    def _eval_is_zero(self):
-        # XXX This is not quite useless. Try evaluating log(0.5).is_negative
-        #     without it. There's probably a nicer way though.
-        return (self.args[0] - 1).is_zero
-
     def _eval_nseries(self, x, n, logx):
         # NOTE Please see the comment at the beginning of this file, labelled
         #      IMPORTANT.

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -647,12 +647,7 @@ class log(Function):
     def _eval_is_zero(self):
         # XXX This is not quite useless. Try evaluating log(0.5).is_negative
         #     without it. There's probably a nicer way though.
-        if self.args[0] is S.One:
-            return True
-        elif self.args[0].is_number:
-            return self.args[0].expand() is S.One
-        elif self.args[0].is_negative:
-            return False
+        return (self.args[0] - 1).is_zero
 
     def _eval_nseries(self, x, n, logx):
         # NOTE Please see the comment at the beginning of this file, labelled

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -242,9 +242,10 @@ def test_exp_assumptions():
 def test_log_assumptions():
     p = symbols('p', positive=True)
     n = symbols('n', negative=True)
+    z = 2 - pi - pi*(1/pi - 1)
     assert log(2) > 0
     assert log(1).is_zero
-    assert log(2 - pi - pi*(1/pi - 1)).is_zero
+    assert log(z).is_zero is None  # is_zero is naive
     assert log(p).is_zero is None
     assert log(n).is_zero is False
     assert log(0.5).is_negative is True

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -245,7 +245,12 @@ def test_log_assumptions():
     z = 2 - pi - pi*(1/pi - 1)
     assert log(2) > 0
     assert log(1).is_zero
-    assert log(z).is_zero is None  # is_zero is naive
+    # is_zero is not supposed to work real hard so this
+    # should be None -- no simplification but if numerical
+    # evaluation is used it should be used to calculate the
+    # `value` not `value - 1` since the former can be done with
+    # precision but the latter can't
+    assert log(2 - pi - pi*(1/pi - 1)).is_zero is None
     assert log(p).is_zero is None
     assert log(n).is_zero is False
     assert log(0.5).is_negative is True

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -140,10 +140,6 @@ class Integral(AddWithLimits):
         if self.function.is_zero is False and got_none is False:
             return False
 
-    @property
-    def is_number(self):
-        return not self.free_symbols
-
     def transform(self, x, u):
         r"""
         Performs a change of variables from `x` to `u` using the relationship

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -103,139 +103,39 @@ class Integral(AddWithLimits):
 
         function, limits, variables
         """
-        for xab in self.limits:
-            if len(xab) == 3 and xab[1] == xab[2]:
-                return set()
         return AddWithLimits.free_symbols.fget(self)
 
     @property
     def is_zero(self):
         """Since Integral doesn't autosimplify, it is useful to see if
-        it would simplify to zero or not in a trivial manner, i.e. when
-        the function is 0 or two limits of a definite integral are the same.
+        it would simplify to zero or not in a trivial manner.
 
         This is a very naive and quick test, not intended to check for special
-        patterns like Integral(sin(m*x)*cos(n*x), (x, 0, 2*pi)) == 0.
+        patterns like Integral(sin(m*x)*cos(n*x), (x, 0, 2*pi)) == 0 or even
+        test if the upper and lower limits are the same. So even though it
+        is zero in those cases, None is returned instead.
 
         Examples
         ========
 
         >>> from sympy import Integral
         >>> from sympy.abc import x, y, z
-        >>> Integral(1, (x, 1, 1)).is_zero
-        True
         >>> Integral(0, (x, y, z)).is_zero
         True
         >>> Integral(1, (x, 1, 2)).is_zero
-        False
+        >>> Integral(1, (x, 1, 1)).is_zero
 
         See Also
         ========
 
         is_number
         """
-        if (self.function.is_zero or
-                any(len(xab) == 3 and xab[1] == xab[2] for xab in self.limits)):
+        if self.function.is_zero:
             return True
-        free = self.function.free_symbols
-        for xab in self.limits:
-            if len(xab) == 1:
-                free.add(xab[0])
-                continue
-            if len(xab) == 2 and xab[1].is_zero and xab[0] not in free:
-                return True
-            # take integration symbol out of free since it will be replaced
-            # with the free symbols in the limits
-            free.discard(xab[0])
-            # add in the new symbols
-            for i in xab[1:]:
-                free.update(i.free_symbols)
-        if not self.free_symbols and self.function.is_number:
-            # the integrand is a number and the limits are numerical
-            return False
 
     @property
     def is_number(self):
-        """
-        Return True if the Integral will result in a number, else False.
-
-        Integrals are a special case since they contain symbols that can
-        be replaced with numbers. Whether the integral can be done or not is
-        another issue. But answering whether the final result is a number is
-        not difficult.
-
-        Examples
-        ========
-
-        >>> from sympy import Integral
-        >>> from sympy.abc import x, y
-        >>> Integral(x).is_number
-        False
-        >>> Integral(x, y).is_number
-        False
-        >>> Integral(x, (y, 1, x)).is_number
-        False
-        >>> Integral(x, (y, 1, 2)).is_number
-        False
-        >>> Integral(x, (y, 1, 1)).is_number
-        True
-        >>> Integral(x, (x, 1, 2)).is_number
-        True
-        >>> Integral(x*y, (x, 1, 2), (y, 1, 3)).is_number
-        True
-        >>> Integral(1, x, (x, 1, 2)).is_number
-        True
-
-        Notes
-        =====
-
-        There are two non-heroic tests that are made here to recognize
-        situations where a free symbol is not actually free: when the upper
-        and lower limits are the same and when an integration variable is
-        not in the free symbols (in which case only free symbols of the
-        difference in limits are potential free symbols). The tests are of
-        the most trivial nature, however, and it should always be true that if
-        this routine returns True that evalf should be able to evaluate the
-        expression.
-
-        See Also
-        ========
-
-        is_zero
-        """
-
-        integrand, limits = self.function, self.limits
-        isyms = integrand.free_symbols
-        for xab in limits:
-            if len(xab) == 1:
-                isyms.add(xab[0])
-                continue  # it may be removed later
-
-            if len(xab) == 3 and xab[1] == xab[2]:
-                # this is a non-heroic test and evalf knows about it
-                return True
-
-            if xab[0] in isyms:
-                # take it out of the symbols since it will be replaced
-                # with the free symbols in the limits
-                isyms.remove(xab[0])
-            elif len(xab) == 3:
-                # the integration variable isn't in the free symbols so
-                # integration will introduce a linear factor and any
-                # expression in the lower and upper limit that doesn't
-                # appear in the difference of those limits will cancel
-                # and thus NOT add to the free symbols, e.g.
-                # Integral(x, (y, d, d + 1)) == Integral(x, (y, 0, 1)).
-                # This is a non-heroic test and evalf knows about it
-                isyms.update((xab[2] - xab[1]).free_symbols)
-                continue
-
-            # add in the new symbols
-            for i in xab[1:]:
-                isyms.update(i.free_symbols)
-
-        # if there are no surviving symbols then the result is a number
-        return not isyms
+        return not self.free_symbols
 
     def transform(self, x, u):
         r"""
@@ -488,15 +388,28 @@ class Integral(AddWithLimits):
         if risch and any(len(xab) > 1 for xab in self.limits):
             raise ValueError('risch=True is only allowed for indefinite integrals.')
 
-        # check for the trivial case of equal upper and lower limits
-        if self.is_zero:
+        # check for the trivial case
+        if (self.is_zero or
+                any(len(xab) == 3 and xab[1] == xab[2] for xab in self.limits)):
             return S.Zero
+        free = self.function.free_symbols
+        for xab in self.limits:
+            if len(xab) == 1:
+                free.add(xab[0])
+                continue
+            if len(xab) == 2 and xab[1].is_zero and xab[0] not in free:
+                return S.Zero
+            # take integration symbol out of free since it will be replaced
+            # with the free symbols in the limits
+            free.discard(xab[0])
+            # add in the new symbols
+            for i in xab[1:]:
+                free.update(i.free_symbols)
 
         # now compute and check the function
         function = self.function
         if deep:
             function = function.doit(**hints)
-
         if function.is_zero:
             return S.Zero
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -527,7 +527,8 @@ def test_subs5():
     e = Integral(exp(-x**2), (x, x))
     assert e.subs(x, 5) == Integral(exp(-x**2), (x, 5))
     e = Integral(exp(x), x)
-    assert (e.subs(x,1)-e.subs(x,0) - Integral(exp(x),(x,0,1))).doit().is_zero
+    assert (e.subs(x,1) - e.subs(x,0) - Integral(exp(x), (x, 0, 1))
+        ).doit().is_zero
 
 
 def test_subs6():
@@ -721,13 +722,19 @@ def test_symbols():
 
 
 def test_is_zero():
-    from sympy.abc import x, m, n
+    from sympy.abc import x, m
     assert Integral(0, (x, 1, x)).is_zero
-    # these are zero but these cases are beyond the scope of what is_zero
+    assert Integral(1, (x, 1, 1)).is_zero
+    assert Integral(1, (x, 1, 2), (y, 2)).is_zero is False
+    assert Integral(x, (m, 0)).is_zero
+    assert Integral(x + m, (m, 0)).is_zero is None
+    i = Integral(m, (m, 1, exp(x)), (x, 0))
+    assert i.is_zero is None
+    assert Integral(m, (x, 0), (m, 1, exp(x))).is_zero is True
+
+    # this is zero but is beyond the scope of what is_zero
     # should be doing
-    assert Integral(1, (x, 1, 1)).is_zero is None
-    assert Integral(1, (x, 1, 2)).is_zero is None
-    assert Integral(sin(m*x)*cos(n*x), (x, 0, 2*pi)).is_zero is None
+    assert Integral(sin(x), (x, 0, 2*pi)).is_zero is None
 
 
 def test_series():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -679,7 +679,7 @@ def test_is_number():
     assert Integral(x, (y, 1, x)).is_number is False
     assert Integral(x, (y, 1, 2)).is_number is False
     assert Integral(x, (x, 1, 2)).is_number is True
-    # is_number should always be eqivalent to no foo.free_symbols
+    # `foo.is_number` should always be eqivalent to `not foo.free_symbols`
     # in each of these cases, there are pseudo-free symbols
     i = Integral(x, (y, 1, 1))
     assert i.is_number is False and i.n() == 0

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -640,7 +640,7 @@ def test_integral_reconstruct():
     assert e == Integral(*e.args)
 
 
-def test_doit():
+def test_doit_integrals():
     e = Integral(Integral(2*x), (x, 0, 1))
     assert e.doit() == Rational(1, 3)
     assert e.doit(deep=False) == Rational(1, 3)
@@ -649,6 +649,10 @@ def test_doit():
     assert Integral(f(x), (x, 1, 1)).doit() == 0
     # doesn't matter if the limits can't be evaluated
     assert Integral(0, (x, 1, Integral(f(x), x))).doit() == 0
+    assert Integral(x, (a, 0)).doit() == 0
+    limits = ((a, 1, exp(x)), (x, 0))
+    assert Integral(a, *limits).doit() == S(1)/4
+    assert Integral(a, *list(reversed(limits))).doit() == 0
 
 
 def test_issue_4884():
@@ -674,12 +678,15 @@ def test_is_number():
     assert Integral(x, (y, 1, x)).is_number is False
     assert Integral(x, (y, 1, 2)).is_number is False
     assert Integral(x, (x, 1, 2)).is_number is True
+    # is_number should always be eqivalent to no foo.free_symbols
+    # in each of these cases, there are pseudo-free symbols
     i = Integral(x, (y, 1, 1))
-    assert i.is_number is True and i.n() == 0
+    assert i.is_number is False and i.n() == 0
     i = Integral(x, (y, z, z))
-    assert i.is_number is True and i.n() == 0
+    assert i.is_number is False and i.n() == 0
     i = Integral(1, (y, z, z + 2))
-    assert i.is_number is True and i.n() == 2
+    assert i.is_number is False and i.n() == 2
+
     assert Integral(x*y, (x, 1, 2), (y, 1, 3)).is_number is True
     assert Integral(x*y, (x, 1, 2), (y, 1, z)).is_number is False
     assert Integral(x, (x, 1)).is_number is True
@@ -693,7 +700,7 @@ def test_is_number():
 
 def test_symbols():
     from sympy.abc import x, y, z
-    assert Integral(0, x).free_symbols == set()
+    assert Integral(0, x).free_symbols == set([x])
     assert Integral(x).free_symbols == set([x])
     assert Integral(x, (x, None, y)).free_symbols == set([y])
     assert Integral(x, (x, y, None)).free_symbols == set([y])
@@ -703,7 +710,8 @@ def test_symbols():
     assert Integral(x, x, y).free_symbols == set([x, y])
     assert Integral(x, (x, 1, 2)).free_symbols == set()
     assert Integral(x, (y, 1, 2)).free_symbols == set([x])
-    assert Integral(x, (y, z, z)).free_symbols == set()
+    # pseudo-free in this case
+    assert Integral(x, (y, z, z)).free_symbols == set([x, z])
     assert Integral(x, (y, 1, 2), (y, None, None)).free_symbols == set([x, y])
     assert Integral(x, (y, 1, 2), (x, 1, y)).free_symbols == set([y])
     assert Integral(2, (y, 1, 2), (y, 1, x), (x, 1, 2)).free_symbols == set()
@@ -715,14 +723,11 @@ def test_symbols():
 def test_is_zero():
     from sympy.abc import x, m, n
     assert Integral(0, (x, 1, x)).is_zero
-    assert Integral(1, (x, 1, 1)).is_zero
-    assert Integral(1, (x, 1, 2)).is_zero is False
+    # these are zero but these cases are beyond the scope of what is_zero
+    # should be doing
+    assert Integral(1, (x, 1, 1)).is_zero is None
+    assert Integral(1, (x, 1, 2)).is_zero is None
     assert Integral(sin(m*x)*cos(n*x), (x, 0, 2*pi)).is_zero is None
-    assert Integral(x, (m, 0)).is_zero
-    assert Integral(x + 1/m, (m, 0)).is_zero is None
-    i = Integral(m, (m, 1, exp(x)), (x, 0))
-    assert i.is_zero is None and i.doit() == S(1)/4
-    assert Integral(m, (x, 0), (m, 1, exp(x))).is_zero is True
 
 
 def test_series():

--- a/sympy/physics/units.py
+++ b/sympy/physics/units.py
@@ -97,7 +97,6 @@ class Unit(AtomicExpr):
     """
     is_positive = True    # make sqrt(m**2) --> m
     is_commutative = True
-    is_number = False
 
     __slots__ = ["name", "abbrev"]
 


### PR DESCRIPTION
see also #7662 

Integral's `is_zero`  processing is now more conservative and is moved to `_eval_is_zero` (as are Product and Sum's is_zero logic, thus fixes #7890).

foo.is_number is equivalent to not foo.free_symbols but is a faster way of
arriving at that answer because is_number will fail if a single free
symbol is encountered. For this reason, the Integral.is_number routine
was modified.

Note: the first occurrence of `is_number` was

```
def is_number(self):
    """Returns True if self is a number (like 1, or 1+log(2)), and False
    otherwise (e.g. 1+x).""" 
    return len(self.atoms(Basic.Symbol)) == 0
```

foo.free_symbols should give any free symbols in the expression _as
written_ without any regard to whether those symbols will disappear after
simplification of some sort. The test for is_zero was removed from
expr_with_limits calculation of free symbols for this reason.

Other comments about the rationale of these changes are in the test
suite (esp in test_basic) so that anyone changing the behavior will be
sure to see the desired state of affairs.
