### PR TITLE
Make inequalities behave the same as their operators when infinity is involved.

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -292,6 +292,10 @@ class _Inequality(Relational):
         evaluate = options.pop('evaluate', global_evaluate[0])
 
         if evaluate:
+            # If infinity is involved, defer to its implementation.
+            _infs = (S.Infinity, S.NegativeInfinity)
+            if lhs.has(*_infs) or rhs.has(*_infs):
+                return cls._eval_relation(lhs, rhs)
             # Try to evaluate the difference between sides.
             r = cls._eval_sides(lhs, rhs)
             if r is not None:

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -442,9 +442,6 @@ def test_nan_equality_exceptions():
 @XFAIL
 def test_inequalities_symbol_name_same():
     """Using the operator and functional forms should give same results."""
-    # currently fails because rhs reduces to bool but the lhs does not
-    assert Lt(x, oo) == (x < oo)
-
     # We test all combinations from a set
     # FIXME: could replace with random selection after test passes
     A = (x, y, S(0), S(1)/3, pi, oo, -oo)


### PR DESCRIPTION
Previously, Lt(x, oo) would not evaluate, while x < oo would return True.
Tests for this (marked XFAIL) were added in pull request #7783.  Now, all
inequality classes (Lt, etc.) will harness the same code behind the operators
(<, etc.) whenever positive or negative infinities are involved, guaranteeing
that the two produce identical results.

Note that the test in question has not had its XFAIL removed, as pi > x does
not yet behave the same as Gt(pi, x).  Once this is corrected too, the test
will pass.
