### PR TITLE
Fix #7814: Handle symbols in line-ellipse intersection.

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1075,19 +1075,13 @@ class Ellipse(GeometryEntity):
         if det == 0:
             t = -b / a
             result.append(lp[0] + (lp[1] - lp[0]) * t)
-        else:
-            is_good = True
-            try:
-                is_good = (det > 0)
-            except NotImplementedError:  # symbolic, allow
-                is_good = True
-
-            if is_good:
-                root = sqrt(det)
-                t_a = (-b - root) / a
-                t_b = (-b + root) / a
-                result.append( lp[0] + (lp[1] - lp[0]) * t_a )
-                result.append( lp[0] + (lp[1] - lp[0]) * t_b )
+        # Definite and potential symbolic intersections are allowed.
+        elif (det > 0) != False:
+            root = sqrt(det)
+            t_a = (-b - root) / a
+            t_b = (-b + root) / a
+            result.append( lp[0] + (lp[1] - lp[0]) * t_a )
+            result.append( lp[0] + (lp[1] - lp[0]) * t_b )
 
         return [r for r in result if r in o]
 

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -14,7 +14,7 @@ from sympy.geometry.util import idiff, are_coplanar
 from sympy.solvers.solvers import solve
 from sympy.utilities.iterables import cartes
 from sympy.utilities.randtest import test_numerically
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, slow
 
 x = Symbol('x', real=True)
 y = Symbol('y', real=True)
@@ -1587,3 +1587,12 @@ def test_issue_2941():
     c, d = (-2, -3), (-2, 0)
     a, b = (0, 0), (1, 1)
     _check()
+
+
+@slow
+def test_symbolic_intersect():
+    # Issue 7814.
+    circle = Circle(Point(x, 0), y)
+    line = Line(Point(k, z), slope=0)
+    assert line.intersection(circle) == [
+        Point(x - sqrt(y**2 - z**2), z), Point(x + sqrt(y**2 - z**2), z)]


### PR DESCRIPTION
Fixes issue #7814.

I added one test for this, but it only runs to make sure no errors are raised.  I do not have enough familiarity with the algorithm to know exactly what results are expected, but can add them if someone else can confirm what it should be.
