### PR TITLE
Autowrap improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,11 @@ matrix:
     - python: 3.4
       env:
         - TEST_THEANO="true"
+    - python: 2.7
+      env:
+        - TEST_AUTOWRAP="true"
+      virtualenv:
+        system_site_packages: true
   allow_failures:
     - python: 3.3 # Dummy value
       env:
@@ -73,6 +78,11 @@ matrix:
 before_install:
   - if [[ "${FASTCACHE}" != "false" ]]; then
       pip install "fastcache==0.4.0";
+    fi
+  - if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
+      pip uninstall -y numpy;
+      sudo apt-get update;
+      sudo apt-get install gfortran gcc python-numpy cython;
     fi
   - if [[ "${TEST_GMPY}" == "true" ]]; then
       sudo apt-get update;

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -52,6 +52,12 @@ if not (sympy.test('sympy/polys/', 'sympy/plotting') and
         sympy.doctest('sympy/polys/', 'sympy/plotting')):
     raise Exception('Tests failed')
 EOF
+    elif [[ "${TEST_AUTOWRAP}" == "true" ]]; then
+        cat << EOF | python
+import sympy
+if not sympy.test('sympy/external/tests/test_autowrap.py'):
+    raise Exception('Tests failed')
+EOF
     else
         cat << EOF | python
 import sympy

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -4,8 +4,8 @@ from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.autowrap import autowrap, ufuncify, CodeWrapError
 from sympy.utilities.pytest import XFAIL, skip
 
-numpy = import_module('numpy')
-Cython = import_module('Cython')
+numpy = import_module('numpy', min_module_version='1.6.1')
+Cython = import_module('Cython', min_module_version='0.15.1')
 f2py = import_module('numpy.f2py', __import__kwargs={'fromlist': ['f2py']})
 
 f2pyworks = False
@@ -133,33 +133,26 @@ def test_ufuncify_f95_f2py():
 
 # Cython
 
-# See issue 6107.  This XFAIL can be removed if we can accurately determine the
-# correct minimum Cython version required.
-@XFAIL
 def test_wrap_twice_c_cython():
     has_module('Cython')
     runtest_autowrap_twice('C', 'cython')
 
 
-@XFAIL
 def test_autowrap_trace_C_Cython():
     has_module('Cython')
     runtest_autowrap_trace('C', 'cython')
 
 
-@XFAIL
 def test_autowrap_matrix_vector_C_cython():
     has_module('Cython')
     runtest_autowrap_matrix_vector('C', 'cython')
 
 
-@XFAIL
 def test_autowrap_matrix_matrix_C_cython():
     has_module('Cython')
     runtest_autowrap_matrix_matrix('C', 'cython')
 
 
-@XFAIL
 def test_ufuncify_C_Cython():
     has_module('Cython')
     runtest_ufuncify('C', 'cython')

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -56,6 +56,7 @@ class CCodePrinter(CodePrinter):
         'user_functions': {},
         'human': True,
         'contract': True,
+        'dereference': set()
     }
 
     def __init__(self, settings={}):
@@ -63,6 +64,7 @@ class CCodePrinter(CodePrinter):
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {})
         self.known_functions.update(userfuncs)
+        self._dereference = set(settings.get('dereference', []))
 
     def _rate_index_position(self, p):
         return p*5
@@ -173,6 +175,12 @@ class CCodePrinter(CodePrinter):
         return "{0}[{1}]".format(expr.parent, expr.j +
                 expr.i*expr.parent.shape[1])
 
+    def _print_Symbol(self, expr):
+        if expr in self._dereference:
+            return '(*{0})'.format(expr.name)
+        else:
+            return expr.name
+
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
 
@@ -222,6 +230,11 @@ def ccode(expr, assign_to=None, **settings):
         their string representations. Alternatively, the dictionary value can
         be a list of tuples i.e. [(argument_test, cfunction_string)]. See below
         for examples.
+    dereference : iterable, optional
+        An iterable of symbols that should be dereferenced in the printed code
+        expression. These would be values passed by address to the function.
+        For example, if ``dereference=[a]``, the resulting code would print
+        ``(*a)`` instead of ``a``.
     human : bool, optional
         If True, the result is a single string that may contain some constant
         declarations for the number symbols. If False, the same information is

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -170,7 +170,8 @@ class CCodePrinter(CodePrinter):
             return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
     def _print_MatrixElement(self, expr):
-        return "{0}[{1}][{2}]".format(expr.parent, expr.i, expr.j)
+        return "{0}[{1}]".format(expr.parent, expr.j +
+                expr.i*expr.parent.shape[1])
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
@@ -296,14 +297,14 @@ def ccode(expr, assign_to=None, **settings):
     >>> mat = Matrix([x**2, Piecewise((x + 1, x > 0), (x, True)), sin(x)])
     >>> A = MatrixSymbol('A', 3, 1)
     >>> print(ccode(mat, A))
-    A[0][0] = pow(x, 2);
+    A[0] = pow(x, 2);
     if (x > 0) {
-       A[1][0] = x + 1;
+       A[1] = x + 1;
     }
     else {
-       A[1][0] = x;
+       A[1] = x;
     }
-    A[2][0] = sin(x);
+    A[2] = sin(x);
     """
 
     return CCodePrinter(settings).doprint(expr, assign_to)

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -159,7 +159,8 @@ class JavascriptCodePrinter(CodePrinter):
             return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
     def _print_MatrixElement(self, expr):
-        return "{0}[{1}][{2}]".format(expr.parent, expr.i, expr.j)
+        return "{0}[{1}]".format(expr.parent, expr.j +
+                expr.i*expr.parent.shape[1])
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
@@ -285,14 +286,14 @@ def jscode(expr, assign_to=None, **settings):
     >>> mat = Matrix([x**2, Piecewise((x + 1, x > 0), (x, True)), sin(x)])
     >>> A = MatrixSymbol('A', 3, 1)
     >>> print(jscode(mat, A))
-    A[0][0] = Math.pow(x, 2);
+    A[0] = Math.pow(x, 2);
     if (x > 0) {
-       A[1][0] = x + 1;
+       A[1] = x + 1;
     }
     else {
-       A[1][0] = x;
+       A[1] = x;
     }
-    A[2][0] = Math.sin(x);
+    A[2] = Math.sin(x);
     """
 
     return JavascriptCodePrinter(settings).doprint(expr, assign_to)

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -371,23 +371,23 @@ def test_Matrix_printing():
     mat = Matrix([x*y, Piecewise((2 + x, y>0), (y, True)), sin(z)])
     A = MatrixSymbol('A', 3, 1)
     assert ccode(mat, A) == (
-        "A[0][0] = x*y;\n"
+        "A[0] = x*y;\n"
         "if (y > 0) {\n"
-        "   A[1][0] = x + 2;\n"
+        "   A[1] = x + 2;\n"
         "}\n"
         "else {\n"
-        "   A[1][0] = y;\n"
+        "   A[1] = y;\n"
         "}\n"
-        "A[2][0] = sin(z);")
+        "A[2] = sin(z);")
     # Test using MatrixElements in expressions
     expr = Piecewise((2*A[2, 0], x > 0), (A[2, 0], True)) + sin(A[1, 0]) + A[0, 0]
     assert ccode(expr) == (
         "((x > 0) ? (\n"
-        "   2*A[2][0]\n"
+        "   2*A[2]\n"
         ")\n"
         ": (\n"
-        "   A[2][0]\n"
-        ")) + sin(A[1][0]) + A[0][0]")
+        "   A[2]\n"
+        ")) + sin(A[1]) + A[0]")
     # Test using MatrixElements in a Matrix
     q = MatrixSymbol('q', 5, 1)
     M = MatrixSymbol('M', 3, 3)
@@ -395,12 +395,12 @@ def test_Matrix_printing():
         [q[1,0] + q[2,0], q[3, 0], 5],
         [2*q[4, 0]/q[1,0], sqrt(q[0,0]) + 4, 0]])
     assert ccode(m, M) == (
-        "M[0][0] = sin(q[1][0]);\n"
-        "M[0][1] = 0;\n"
-        "M[0][2] = cos(q[2][0]);\n"
-        "M[1][0] = q[1][0] + q[2][0];\n"
-        "M[1][1] = q[3][0];\n"
-        "M[1][2] = 5;\n"
-        "M[2][0] = 2*q[4][0]*1.0/q[1][0];\n"
-        "M[2][1] = 4 + sqrt(q[0][0]);\n"
-        "M[2][2] = 0;")
+        "M[0] = sin(q[1]);\n"
+        "M[1] = 0;\n"
+        "M[2] = cos(q[2]);\n"
+        "M[3] = q[1] + q[2];\n"
+        "M[4] = q[3];\n"
+        "M[5] = 5;\n"
+        "M[6] = 2*q[4]*1.0/q[1];\n"
+        "M[7] = 4 + sqrt(q[0]);\n"
+        "M[8] = 0;")

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -366,6 +366,12 @@ def test_ccode_loops_multiple_terms():
             c == s0 + s3 + s1 + s2[:-1] or
             c == s0 + s3 + s2 + s1[:-1])
 
+
+def test_dereference_printing():
+    expr = x + y + sin(z) + z
+    assert ccode(expr, dereference=[z]) == "x + y + (*z) + sin((*z))"
+
+
 def test_Matrix_printing():
     # Test returning a Matrix
     mat = Matrix([x*y, Piecewise((2 + x, y>0), (y, True)), sin(z)])

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -335,23 +335,23 @@ def test_Matrix_printing():
     mat = Matrix([x*y, Piecewise((2 + x, y>0), (y, True)), sin(z)])
     A = MatrixSymbol('A', 3, 1)
     assert jscode(mat, A) == (
-        "A[0][0] = x*y;\n"
+        "A[0] = x*y;\n"
         "if (y > 0) {\n"
-        "   A[1][0] = x + 2;\n"
+        "   A[1] = x + 2;\n"
         "}\n"
         "else {\n"
-        "   A[1][0] = y;\n"
+        "   A[1] = y;\n"
         "}\n"
-        "A[2][0] = Math.sin(z);")
+        "A[2] = Math.sin(z);")
     # Test using MatrixElements in expressions
     expr = Piecewise((2*A[2, 0], x > 0), (A[2, 0], True)) + sin(A[1, 0]) + A[0, 0]
     assert jscode(expr) == (
         "((x > 0) ? (\n"
-        "   2*A[2][0]\n"
+        "   2*A[2]\n"
         ")\n"
         ": (\n"
-        "   A[2][0]\n"
-        ")) + Math.sin(A[1][0]) + A[0][0]")
+        "   A[2]\n"
+        ")) + Math.sin(A[1]) + A[0]")
     # Test using MatrixElements in a Matrix
     q = MatrixSymbol('q', 5, 1)
     M = MatrixSymbol('M', 3, 3)
@@ -359,12 +359,12 @@ def test_Matrix_printing():
         [q[1,0] + q[2,0], q[3, 0], 5],
         [2*q[4, 0]/q[1,0], sqrt(q[0,0]) + 4, 0]])
     assert jscode(m, M) == (
-        "M[0][0] = Math.sin(q[1][0]);\n"
-        "M[0][1] = 0;\n"
-        "M[0][2] = Math.cos(q[2][0]);\n"
-        "M[1][0] = q[1][0] + q[2][0];\n"
-        "M[1][1] = q[3][0];\n"
-        "M[1][2] = 5;\n"
-        "M[2][0] = 2*q[4][0]*1/q[1][0];\n"
-        "M[2][1] = 4 + Math.sqrt(q[0][0]);\n"
-        "M[2][2] = 0;")
+        "M[0] = Math.sin(q[1]);\n"
+        "M[1] = 0;\n"
+        "M[2] = Math.cos(q[2]);\n"
+        "M[3] = q[1] + q[2];\n"
+        "M[4] = q[3];\n"
+        "M[5] = 5;\n"
+        "M[6] = 2*q[4]*1/q[1];\n"
+        "M[7] = 4 + Math.sqrt(q[0]);\n"
+        "M[8] = 0;")

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -77,8 +77,8 @@ from subprocess import STDOUT, CalledProcessError
 
 from sympy.core.compatibility import check_output
 from sympy.utilities.codegen import (
-    get_code_generator, Routine, OutputArgument, InOutArgument,
-    CodeGenArgumentListError, Result
+    get_code_generator, Routine, OutputArgument, InOutArgument, InputArgument,
+    CodeGenArgumentListError, Result, ResultBase
 )
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.decorator import doctest_depends_on
@@ -156,7 +156,7 @@ class CodeWrapper:
         except CalledProcessError as e:
             raise CodeWrapError(
                 "Error while executing command: %s. Command output is:\n%s" % (
-                    " ".join(command), e.output))
+                    " ".join(command), e.output.decode()))
         if not self.quiet:
             print(retoutput)
 
@@ -206,16 +206,31 @@ def %(name)s():
 class CythonCodeWrapper(CodeWrapper):
     """Wrapper that uses Cython"""
 
-    setup_template = """
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Distutils import build_ext
+    setup_template = (
+            "from distutils.core import setup\n"
+            "from distutils.extension import Extension\n"
+            "from Cython.Distutils import build_ext\n"
+            "\n"
+            "setup(\n"
+            "    cmdclass = {{'build_ext': build_ext}},\n"
+            "    ext_modules = [Extension({ext_args}, extra_compile_args=['-std=c99'])]\n"
+            "        )")
 
-setup(
-    cmdclass = {'build_ext': build_ext},
-    ext_modules = [Extension(%(args)s)]
-        )
-"""
+    pyx_imports = (
+            "import numpy as np\n"
+            "cimport numpy as np\n\n")
+
+    pyx_header = (
+            "cdef extern from '{header_file}.h':\n"
+            "    {prototype}\n\n")
+
+    pyx_func = (
+            "def {name}_c({arg_string}):\n"
+            "\n"
+            "{declarations}"
+            "{body}")
+
+    _need_numpy = False
 
     @property
     def command(self):
@@ -228,90 +243,139 @@ setup(
 
         # pyx
         with open(pyxfilename, 'w') as f:
-            self.dump_pyx([routine], f, self.filename,
-                self.include_header, self.include_empty)
+            self.dump_pyx([routine], f, self.filename)
 
         # setup.py
         ext_args = [repr(self.module_name), repr([pyxfilename, codefilename])]
         with open('setup.py', 'w') as f:
-            print(CythonCodeWrapper.setup_template % {
-                'args': ", ".join(ext_args)}, file=f)
+            f.write(self.setup_template.format(ext_args=", ".join(ext_args)))
 
     @classmethod
     def _get_wrapped_function(cls, mod):
         return mod.autofunc_c
 
-    def dump_pyx(self, routines, f, prefix, header=True, empty=True):
+    def dump_pyx(self, routines, f, prefix):
         """Write a Cython file with python wrappers
 
-           This file contains all the definitions of the routines in c code and
-           refers to the header file.
+        This file contains all the definitions of the routines in c code and
+        refers to the header file.
 
-           :Arguments:
-
-           routines
-                List of Routine instances
-           f
-                File-like object to write the file to
-           prefix
-                The filename prefix, used to refer to the proper header file.
-                Only the basename of the prefix is used.
-           empty
-                Optional. When True, empty lines are included to structure the
-                source files. [DEFAULT=True]
+        Arguments
+        ---------
+        routines
+            List of Routine instances
+        f
+            File-like object to write the file to
+        prefix
+            The filename prefix, used to refer to the proper header file.
+            Only the basename of the prefix is used.
         """
+        headers = []
+        functions = []
         for routine in routines:
             prototype = self.generator.get_prototype(routine)
 
-            # declare
-            print('cdef extern from "%s.h":' % prefix, file=f)
-            print('   %s' % prototype, file=f)
-            if empty:
-                print(file=f)
+            # C Function Header Import
+            headers.append(self.pyx_header.format(header_file=prefix,
+                    prototype=prototype))
 
-            # wrap
-            ret, args_py = self._split_retvals_inargs(routine.arguments)
-            args_c = ", ".join([str(a.name) for a in routine.arguments])
-            print("def %s_c(%s):" % (routine.name,
-                ", ".join(self._declare_arg(arg) for arg in args_py)), file=f)
-            for r in ret:
-                if not r in args_py:
-                    print("   cdef %s" % self._declare_arg(r), file=f)
-            rets = ", ".join([str(r.name) for r in ret])
+            # Partition the C function arguments into categories
+            py_rets, py_args, py_loc, py_inf = self._partition_args(routine.arguments)
+
+            # Function prototype
+            name = routine.name
+            arg_string = ", ".join(self._prototype_arg(arg) for arg in py_args)
+
+            # Local Declarations
+            local_decs = []
+            for arg, val in py_inf.items():
+                proto = self._prototype_arg(arg)
+                mat, ind = val
+                local_decs.append("    cdef {0} = {1}.shape[{2}]".format(proto, mat, ind))
+            local_decs.extend(["    cdef {0}".format(self._declare_arg(a)) for a in py_loc])
+            declarations = "\n".join(local_decs)
+            if declarations:
+                declarations = declarations + "\n"
+
+            # Function Body
+            args_c = ", ".join([self._call_arg(a) for a in routine.arguments])
+            rets = ", ".join([str(r.name) for r in py_rets])
             if routine.results:
-                call = '   return %s(%s)' % (routine.name, args_c)
+                body = '    return %s(%s)' % (routine.name, args_c)
                 if rets:
-                    print(call + ', ' + rets, file=f)
-                else:
-                    print(call, file=f)
+                    body = body + ', ' + rets
             else:
-                print('   %s(%s)' % (routine.name, args_c), file=f)
-                print('   return %s' % rets, file=f)
+                body = '    %s(%s)\n' % (routine.name, args_c)
+                body = body + '    return ' + rets
 
-            if empty:
-                print(file=f)
-    dump_pyx.extension = "pyx"
+            functions.append(self.pyx_func.format(name=name, arg_string=arg_string,
+                    declarations=declarations, body=body))
 
-    def _split_retvals_inargs(self, args):
-        """Determines arguments and return values for python wrapper"""
+        # Write text to file
+        if self._need_numpy:
+            # Only import numpy if required
+            f.write(self.pyx_imports)
+        f.write('\n'.join(headers))
+        f.write('\n'.join(functions))
+
+    def _partition_args(self, args):
+        """Group function arguments into categories."""
         py_args = []
         py_returns = []
+        py_locals = []
+        py_inferred = {}
         for arg in args:
             if isinstance(arg, OutputArgument):
                 py_returns.append(arg)
+                py_locals.append(arg)
             elif isinstance(arg, InOutArgument):
                 py_returns.append(arg)
                 py_args.append(arg)
             else:
                 py_args.append(arg)
-        return py_returns, py_args
+        # Find arguments that are array dimensions. These can be inferred
+        # locally in the Cython code.
+            if isinstance(arg, (InputArgument, InOutArgument)) and arg.dimensions:
+                dims = [d[1] + 1 for d in arg.dimensions]
+                sym_dims = [(i, d) for (i, d) in enumerate(dims) if isinstance(d, C.Symbol)]
+                for (i, d) in sym_dims:
+                    py_inferred[d] = (arg.name, i)
+        for arg in args:
+            if arg.name in py_inferred:
+                py_inferred[arg] = py_inferred.pop(arg.name)
+        # Filter inferred arguments from py_args
+        py_args = [a for a in py_args if not a in py_inferred]
+        return py_returns, py_args, py_locals, py_inferred
 
-    def _declare_arg(self, arg):
+    def _prototype_arg(self, arg):
+        mat_dec = "np.ndarray[{mtype}, ndim={ndim}] {name}"
+        np_types = {'double': 'np.double_t',
+                    'int': 'np.int_t'}
         t = arg.get_datatype('c')
         if arg.dimensions:
-            return "%s *%s" % (t, str(arg.name))
+            self._need_numpy = True
+            ndim = len(arg.dimensions)
+            mtype = np_types[t]
+            return mat_dec.format(mtype=mtype, ndim=ndim, name=arg.name)
         else:
             return "%s %s" % (t, str(arg.name))
+
+    def _declare_arg(self, arg):
+        proto = self._prototype_arg(arg)
+        if arg.dimensions:
+            shape = '(' + ','.join(str(i[1] + 1) for i in arg.dimensions) + ')'
+            return proto + " = np.empty({shape})".format(shape=shape)
+        else:
+            return proto + " = 0"
+
+    def _call_arg(self, arg):
+        if arg.dimensions:
+            t = arg.get_datatype('c')
+            return "<{0}*> {1}.data".format(t, arg.name)
+        elif isinstance(arg, ResultBase):
+            return "&{0}".format(arg.name)
+        else:
+            return str(arg.name)
 
 
 class F2PyCodeWrapper(CodeWrapper):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -593,12 +593,7 @@ class CCodeGen(CodeGen):
             name = ccode(arg.name)
             if arg.dimensions:
                 dims = arg.dimensions
-                if isinstance(arg.name, MatrixSymbol):
-                    type_args.append((arg.get_datatype('C'),
-                            "{:}[{:}][{:}]".format(name, dims[0][1] + 1,
-                            dims[1][1] + 1)))
-                else:
-                    type_args.append((arg.get_datatype('C'), "*%s" % name))
+                type_args.append((arg.get_datatype('C'), "*%s" % name))
             elif isinstance(arg, ResultBase):
                 type_args.append((arg.get_datatype('C'), "&%s" % name))
             else:

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -13,7 +13,7 @@ from sympy.core import symbols, Eq
 from sympy.core.compatibility import StringIO
 
 
-def get_string(dump_fn, routines, prefix="file", header=False, empty=False):
+def get_string(dump_fn, routines, prefix="file"):
     """Wrapper for dump_fn. dump_fn writes its results to a stream object and
        this wrapper returns the contents of that stream as a string. This
        auxiliary function is used by many tests below.
@@ -22,7 +22,7 @@ def get_string(dump_fn, routines, prefix="file", header=False, empty=False):
        testing of the output.
     """
     output = StringIO()
-    dump_fn(routines, output, prefix, header, empty)
+    dump_fn(routines, output, prefix)
     source = output.getvalue()
     output.close()
     return source
@@ -35,11 +35,12 @@ def test_cython_wrapper_scalar_function():
     code_gen = CythonCodeWrapper(CCodeGen())
     source = get_string(code_gen.dump_pyx, [routine])
     expected = (
-        'cdef extern from "file.h":\n'
-        '   double test(double x, double y, double z)\n'
-        'def test_c(double x, double y, double z):\n'
-        '   return test(x, y, z)\n'
-    )
+        "cdef extern from 'file.h':\n"
+        "    double test(double x, double y, double z)\n"
+        "\n"
+        "def test_c(double x, double y, double z):\n"
+        "\n"
+        "    return test(x, y, z)")
     assert source == expected
 
 
@@ -51,13 +52,14 @@ def test_cython_wrapper_outarg():
     routine = Routine("test", Equality(z, x + y))
     source = get_string(code_gen.dump_pyx, [routine])
     expected = (
-        'cdef extern from "file.h":\n'
-        '   void test(double x, double y, double &z)\n'
-        'def test_c(double x, double y):\n'
-        '   cdef double z\n'
-        '   test(x, y, z)\n'
-        '   return z\n'
-    )
+        "cdef extern from 'file.h':\n"
+        "    void test(double x, double y, double *z)\n"
+        "\n"
+        "def test_c(double x, double y):\n"
+        "\n"
+        "    cdef double z = 0\n"
+        "    test(x, y, &z)\n"
+        "    return z")
     assert source == expected
 
 
@@ -68,12 +70,13 @@ def test_cython_wrapper_inoutarg():
     routine = Routine("test", Equality(z, x + y + z))
     source = get_string(code_gen.dump_pyx, [routine])
     expected = (
-        'cdef extern from "file.h":\n'
-        '   void test(double x, double y, double &z)\n'
-        'def test_c(double x, double y, double z):\n'
-        '   test(x, y, z)\n'
-        '   return z\n'
-    )
+        "cdef extern from 'file.h':\n"
+        "    void test(double x, double y, double *z)\n"
+        "\n"
+        "def test_c(double x, double y, double z):\n"
+        "\n"
+        "    test(x, y, &z)\n"
+        "    return z")
     assert source == expected
 
 

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -94,7 +94,9 @@ def test_simple_c_code():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test(double x, double y, double z) {\n"
-        "   return z*(x + y);\n"
+        "   double test_result;\n"
+        "   test_result = z*(x + y);\n"
+        "   return test_result;\n"
         "}\n"
     )
     assert source == expected
@@ -108,8 +110,10 @@ def test_numbersymbol_c_code():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test() {\n"
+        "   double test_result;\n"
         "   double const Catalan = 0.915965594177219;\n"
-        "   return pow(M_PI, Catalan);\n"
+        "   test_result = pow(M_PI, Catalan);\n"
+        "   return test_result;\n"
         "}\n"
     )
     assert source == expected
@@ -125,7 +129,9 @@ def test_c_code_argument_order():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test(double z, double x, double y) {\n"
-        "   return x + y;\n"
+        "   double test_result;\n"
+        "   test_result = x + y;\n"
+        "   return test_result;\n"
         "}\n"
     )
     assert source == expected
@@ -155,7 +161,9 @@ def test_simple_c_codegen():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test(double x, double y, double z) {\n"
-        "   return z*(x + y);\n"
+        "   double test_result;\n"
+        "   test_result = z*(x + y);\n"
+        "   return test_result;\n"
         "}\n"),
         ("file.h",
         "#ifndef PROJECT__FILE__H\n"
@@ -208,21 +216,21 @@ def test_ansi_math1_codegen():
     assert result[0][0] == "file.c"
     assert result[0][1] == (
         '#include "file.h"\n#include <math.h>\n'
-        'double test_fabs(double x) {\n   return fabs(x);\n}\n'
-        'double test_acos(double x) {\n   return acos(x);\n}\n'
-        'double test_asin(double x) {\n   return asin(x);\n}\n'
-        'double test_atan(double x) {\n   return atan(x);\n}\n'
-        'double test_ceil(double x) {\n   return ceil(x);\n}\n'
-        'double test_cos(double x) {\n   return cos(x);\n}\n'
-        'double test_cosh(double x) {\n   return cosh(x);\n}\n'
-        'double test_floor(double x) {\n   return floor(x);\n}\n'
-        'double test_log(double x) {\n   return log(x);\n}\n'
-        'double test_ln(double x) {\n   return log(x);\n}\n'
-        'double test_sin(double x) {\n   return sin(x);\n}\n'
-        'double test_sinh(double x) {\n   return sinh(x);\n}\n'
-        'double test_sqrt(double x) {\n   return sqrt(x);\n}\n'
-        'double test_tan(double x) {\n   return tan(x);\n}\n'
-        'double test_tanh(double x) {\n   return tanh(x);\n}\n'
+        'double test_fabs(double x) {\n   double test_fabs_result;\n   test_fabs_result = fabs(x);\n   return test_fabs_result;\n}\n'
+        'double test_acos(double x) {\n   double test_acos_result;\n   test_acos_result = acos(x);\n   return test_acos_result;\n}\n'
+        'double test_asin(double x) {\n   double test_asin_result;\n   test_asin_result = asin(x);\n   return test_asin_result;\n}\n'
+        'double test_atan(double x) {\n   double test_atan_result;\n   test_atan_result = atan(x);\n   return test_atan_result;\n}\n'
+        'double test_ceil(double x) {\n   double test_ceil_result;\n   test_ceil_result = ceil(x);\n   return test_ceil_result;\n}\n'
+        'double test_cos(double x) {\n   double test_cos_result;\n   test_cos_result = cos(x);\n   return test_cos_result;\n}\n'
+        'double test_cosh(double x) {\n   double test_cosh_result;\n   test_cosh_result = cosh(x);\n   return test_cosh_result;\n}\n'
+        'double test_floor(double x) {\n   double test_floor_result;\n   test_floor_result = floor(x);\n   return test_floor_result;\n}\n'
+        'double test_log(double x) {\n   double test_log_result;\n   test_log_result = log(x);\n   return test_log_result;\n}\n'
+        'double test_ln(double x) {\n   double test_ln_result;\n   test_ln_result = log(x);\n   return test_ln_result;\n}\n'
+        'double test_sin(double x) {\n   double test_sin_result;\n   test_sin_result = sin(x);\n   return test_sin_result;\n}\n'
+        'double test_sinh(double x) {\n   double test_sinh_result;\n   test_sinh_result = sinh(x);\n   return test_sinh_result;\n}\n'
+        'double test_sqrt(double x) {\n   double test_sqrt_result;\n   test_sqrt_result = sqrt(x);\n   return test_sqrt_result;\n}\n'
+        'double test_tan(double x) {\n   double test_tan_result;\n   test_tan_result = tan(x);\n   return test_tan_result;\n}\n'
+        'double test_tanh(double x) {\n   double test_tanh_result;\n   test_tanh_result = tanh(x);\n   return test_tanh_result;\n}\n'
     )
     assert result[1][0] == "file.h"
     assert result[1][1] == (
@@ -250,8 +258,8 @@ def test_ansi_math2_codegen():
     assert result[0][0] == "file.c"
     assert result[0][1] == (
         '#include "file.h"\n#include <math.h>\n'
-        'double test_atan2(double x, double y) {\n   return atan2(x, y);\n}\n'
-        'double test_pow(double x, double y) {\n   return pow(x, y);\n}\n'
+        'double test_atan2(double x, double y) {\n   double test_atan2_result;\n   test_atan2_result = atan2(x, y);\n   return test_atan2_result;\n}\n'
+        'double test_pow(double x, double y) {\n   double test_pow_result;\n   test_pow_result = pow(x, y);\n   return test_pow_result;\n}\n'
     )
     assert result[1][0] == "file.h"
     assert result[1][1] == (
@@ -274,7 +282,8 @@ def test_complicated_codegen():
     assert result[0][1] == (
         '#include "file.h"\n#include <math.h>\n'
         'double test1(double x, double y, double z) {\n'
-        '   return '
+        '   double test1_result;\n'
+        '   test1_result = '
         'pow(sin(x), 7) + '
         '7*pow(sin(x), 6)*cos(y) + '
         '7*pow(sin(x), 6)*tan(z) + '
@@ -311,9 +320,12 @@ def test_complicated_codegen():
         '21*pow(cos(y), 2)*pow(tan(z), 5) + '
         '7*cos(y)*pow(tan(z), 6) + '
         'pow(tan(z), 7);\n'
+        '   return test1_result;\n'
         '}\n'
         'double test2(double x, double y, double z) {\n'
-        '   return cos(cos(cos(cos(cos(cos(cos(cos(x + y + z))))))));\n'
+        '   double test2_result;\n'
+        '   test2_result = cos(cos(cos(cos(cos(cos(cos(cos(x + y + z))))))));\n'
+        '   return test2_result;\n'
         '}\n'
     )
     assert result[1][0] == "file.h"
@@ -446,9 +458,11 @@ def test_output_arg_c():
     expected = (
         '#include "test.h"\n'
         '#include <math.h>\n'
-        'double foo(double x, double &y) {\n'
-        '   y = sin(x);\n'
-        '   return cos(x);\n'
+        'double foo(double x, double *y) {\n'
+        '   (*y) = sin(x);\n'
+        '   double foo_result;\n'
+        '   foo_result = cos(x);\n'
+        '   return foo_result;\n'
         '}\n'
     )
     assert result[0][1] == expected


### PR DESCRIPTION
This PR is intended to get autowrap to work over a larger set of inputs for both backends.

Changes:
- `ccode` has new kwarg `dereference` which prints symbols as dereferenced variables (i.e. `(*a)` not `a`). This is used for code that has pass-by-address arguments.
- Switched C indexing to use index math rather than multiple indices. This allows the code to work with Cython.
- All C functions that have a return variable now create a local var `"{function_name}_result"` that the result is stored in, and then returned at the end of the function. This allows for return values to be allocated in multiline statements, which was impossible before. This allows all the looping code to be used with scalar accumulators, as seen in the autowrap_trace test. While the printed code isn't as pretty, it covers more cases, will always compile, and modern compilers should remove the unneeded allocation if possible.
- Cython autowrap now works. All the time. I'm not sure if it ever did before, as it never allocated arrays or removed inferred variables. Looking at the tests in external/tests/test_autowrap I don't think these ever passed with Cython, but they all do now. Once a minimum version is identified, I think the Xfails can be removed.
- autowrap now supports matrix inputs.
