### PR TITLE
Support for single indexes in MatrixExpr

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -217,6 +217,22 @@ class MatrixExpr(Basic):
                 return self._entry(i, j)
             else:
                 raise IndexError("Invalid indices (%s, %s)" % (i, j))
+        elif isinstance(key, (int, Integer)):
+            # row-wise decomposition of matrix
+            rows, cols = self.shape
+            if not (isinstance(rows, Integer) and isinstance(cols, Integer)):
+                raise IndexError("Single index only supported for "
+                                 "non-symbolic matrix shapes.")
+            key = sympify(key)
+            i = key // cols
+            j = key % cols
+            if self.valid_index(i, j) != False:
+                return self._entry(i, j)
+            else:
+                raise IndexError("Invalid index %s" % key)
+        elif isinstance(key, (Symbol, Expr)):
+                raise IndexError("Single index only supported for "
+                                 "non-symbolic indices.")
         raise IndexError("Invalid index, wanted %s[i,j]" % self)
 
     def as_explicit(self):

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -193,5 +193,17 @@ def test_indexing():
     A[l, k]
     A[l+1, k+1]
 
+
+def test_single_indexing():
+    A = MatrixSymbol('A', 2, 3)
+    assert A[1] == A[0, 1]
+    assert A[3] == A[1, 0]
+    assert list(A[:2, :2]) == [A[0, 0], A[0, 1], A[1, 0], A[1, 1]]
+    raises(IndexError, lambda: A[6])
+    raises(IndexError, lambda: A[n])
+    B = MatrixSymbol('B', n, m)
+    raises(IndexError, lambda: B[1])
+
+
 def test_MatrixElement_diff():
     assert (A[3, 0]*A[0, 0]).diff(A[0, 0]) == A[3, 0]


### PR DESCRIPTION
This allows MatrixSymbols to be iterated over, and gives a similar
interface to DenseMatrix. MatExpr are treated as row-major order arrays.
This only works if both the matrix shape and index are Integer/int.

Demo:

```
>>> qs = symbols('q0:5')
>>> q = MatrixSymbol('q', 5, 1)
>>> expr = sum(qs); expr
q0 + q1 + q2 + q3 + q4

# Can be used to create a sub_dict, with all symbols in a vector representation.
# This is useful for code-generation or numerical evaluation
>>> sub_dict = dict(zip(qs, q)); sub_dict
{q4: q[4, 0], q3: q[3, 0], q0: q[0, 0], q1: q[1, 0], q2: q[2, 0]}
>>> expr.subs(sub_dict)
q[0, 0] + q[1, 0] + q[2, 0] + q[3, 0] + q[4, 0]

# Can also iterate over slices. This will sum just the fourth row of matrix A
>>> A = MatrixSymbol('A', 5, 5)
>>> sum(A[3, :])
A[3, 0] + A[3, 1] + A[3, 2] + A[3, 3] + A[3, 4]
```
