### PR TITLE
5083: make bases somewhat canonical wrt sign

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -167,7 +167,12 @@ class Pow(Expr):
                 return S.One
             elif e is S.One:
                 return b
-            elif b is S.One:
+            elif e.is_integer and _coeff_isneg(b):
+                if e.is_even:
+                    b = -b
+                elif e.is_odd:
+                    return -Pow(-b, e)
+            if b is S.One:
                 if e in (S.NaN, S.Infinity, -S.Infinity):
                     return S.NaN
                 return S.One

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -154,13 +154,15 @@ def test_pow():
     assert (x**(y**(x + exp(x + y)) + z)).expand() == \
         x**z*x**(y**x*y**(exp(x)*exp(y)))
 
-    n = Symbol('k', even=False)
+    n = Symbol('n', even=False)
     k = Symbol('k', even=True)
+    o = Symbol('o', odd=True)
 
     assert (-1)**x == (-1)**x
     assert (-1)**n == (-1)**n
     assert (-2)**k == 2**k
-    assert (-2*x)**k == (-2*x)**k  # we choose not to auto expand this
+    assert (-2*x)**k == (2*x)**k  # we choose not to auto expand this
+    assert (-2*x)**o == -(2*x)**o  # but we do handle coefficient sign
     assert (-1)**k == 1
 
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3490,8 +3490,9 @@ def signsimp(expr, evaluate=None):
     Examples
     ========
 
-    >>> from sympy import signsimp, exp
+    >>> from sympy import signsimp, exp, symbols
     >>> from sympy.abc import x, y
+    >>> i = symbols('i', odd=True)
     >>> n = -1 + 1/x
     >>> n/x/(-n)**2 - 1/n/x
     (-1 + 1/x)/(x*(1 - 1/x)**2) - 1/(x*(-1 + 1/x))
@@ -3501,10 +3502,19 @@ def signsimp(expr, evaluate=None):
     x*(-1 + 1/x) + x*(1 - 1/x)
     >>> signsimp(_)
     0
-    >>> n**3
-    (-1 + 1/x)**3
+
+    Since powers automatically handle leading signs
+
+    >>> (-2)**i
+    -2**i
+
+    signsimp can be used to put the base of a power with an integer
+    exponent into canonical form:
+
+    >>> n**i
+    (-1 + 1/x)**i
     >>> signsimp(_)
-    -(1 - 1/x)**3
+    -(1 - 1/x)**i
 
     By default, signsimp doesn't leave behind any hollow simplification:
     if making an Add canonical wrt sign didn't change the expression, the


### PR DESCRIPTION
There are different levels of sign extraction:

1) coefficient sign
2) extractable sign via could_extract_minus_sign
3) "           "    via signsimp

Some sort of sign simplification must be done by Pow or
else other routines cannot do theirs. e.g. if (1-x)**3 is
written as (-(x - 1))**3 by extracting a sign on the interior,
if Pow doesn't do anything then a non-Pow routine has to do the
work. This PR implements handling of the leading coeffient's sign.

fixes #5083 in that the leading sign is handled; using signsimp will handle the rest of the
canonicalization:

in master

```
>>> from sympy import *;var('x y');var('i',even=1)
(x, y)
i
>>> (x-y)**i - (y-x)**i
-(-x + y)**i + (x - y)**i
>>> signsimp(_)
-(-x + y)**i + (x - y)**i
```

in this PR

```
>>> from sympy import *;var('x y');var('i',even=1)
(x, y)
i
>>> (x-y)**i - (y-x)**i
-(-x + y)**i + (x - y)**i
>>> signsimp(_)
0
```
