### PR TITLE
Don't mix old and new assumptions in the sympy codebase

### DIFF
--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -19,7 +19,7 @@ from sympy import (Rational, symbols, factorial, sqrt, log, exp, oo, zoo,
     continued_fraction_periodic as cf_p, continued_fraction_convergents as cf_c,
     continued_fraction_reduce as cf_r, FiniteSet, elliptic_e, elliptic_f,
     powsimp, hessian, wronskian, fibonacci, sign, Lambda, Piecewise, Subs,
-    residue, Derivative, logcombine)
+    residue, Derivative, logcombine, Symbol)
 
 from sympy.functions.combinatorial.numbers import stirling
 from sympy.functions.special.zeta_functions import zeta
@@ -1155,38 +1155,43 @@ def test_N8():
 
 
 def test_N9():
-    with assuming(Q.real(x)):
-        assert solve(abs(x - 1) > 2) == Or(And(Lt(-oo, x), Lt(x, -1)),
+    x = Symbol('x', real=True)
+    assert solve(abs(x - 1) > 2) == Or(And(Lt(-oo, x), Lt(x, -1)),
                                            And(Lt(3, x), Lt(x, oo)))
 
 
 def test_N10():
+    x = Symbol('x', real=True)
     p = (x - 1)*(x - 2)*(x - 3)*(x - 4)*(x - 5)
-    assert solve(expand(p) < 0, assume=Q.real(x)) == Or(
+    assert solve(expand(p) < 0) == Or(
         And(Lt(-oo, x), Lt(x, 1)), And(Lt(2, x), Lt(x, 3)),
         And(Lt(4, x), Lt(x, 5)))
 
 
 def test_N11():
-    assert solve(6/(x - 3) <= 3, assume=Q.real(x)) == \
+    x = Symbol('x', real=True)
+    assert solve(6/(x - 3) <= 3) == \
         Or(And(Le(5, x), Lt(x, oo)), And(Lt(-oo, x), Lt(x, 3)))
 
 
 @XFAIL
 def test_N12():
-    assert solve(sqrt(x) < 2, assume=Q.real(x)) == And(Le(0, x), Lt(x, 4))
+    x = Symbol('x', real=True)
+    assert solve(sqrt(x) < 2) == And(Le(0, x), Lt(x, 4))
 
 
 @XFAIL
 def test_N13():
     # raises NotImplementedError: can't reduce [sin(x) < 2]
-    assert solve(sin(x) < 2, assume=Q.real(x)) == [] # S.Reals not found
+    x = Symbol('x', real=True)
+    assert solve(sin(x) < 2) == [] # S.Reals not found
 
 
 @XFAIL
 def test_N14():
     # raises NotImplementedError: can't reduce [sin(x) < 1]
-    assert (solve(sin(x) < 1, assume=Q.real(x)) == Ne(x, pi/2))
+    x = Symbol('x', real=True)
+    assert (solve(sin(x) < 1) == Ne(x, pi/2))
 
 
 @XFAIL

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -234,9 +234,9 @@ def power_rule(integral):
     elif symbol not in base.free_symbols and isinstance(exp, sympy.Symbol):
         rule = ExpRule(base, exp, integrand, symbol)
 
-        if sympy.ask(~sympy.Q.zero(sympy.log(base))):
+        if sympy.log(base).is_nonzero:
             return rule
-        elif sympy.ask(sympy.Q.zero(sympy.log(base))):
+        elif sympy.log(base).is_zero:
             return ConstantRule(1, 1, symbol)
 
         return PiecewiseRule([
@@ -260,7 +260,7 @@ def inverse_trig_rule(integral):
         return
 
     def negative(x):
-        return sympy.ask(sympy.Q.negative(x)) or x.is_negative or x.could_extract_minus_sign()
+        return x.is_negative or x.could_extract_minus_sign()
 
     def ArcsinhRule(integrand, symbol):
         return InverseHyperbolicRule(sympy.asinh, integrand, symbol)
@@ -758,7 +758,7 @@ def substitution_rule(integral):
                         could_be_zero.append(denom)
 
                     for expr in could_be_zero:
-                        if not sympy.ask(~sympy.Q.zero(expr)):
+                        if not expr.is_nonzero:
                             substep = integral_steps(integrand.subs(expr, 0), symbol)
 
                             if substep:

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,6 +1,6 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Mul, Integral, integrate, pi, Dummy, Derivative,
-                   diff, I, sqrt, erf, Piecewise, Eq, Ne, Q, assuming, symbols,
+                   diff, I, sqrt, erf, Piecewise, Eq, Ne, Q, symbols,
                    And, Heaviside, Max, S, acos, asinh, acosh)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
     integral_steps, _parts_rule
@@ -207,6 +207,8 @@ def test_manual_true():
 
 
 def test_issue_6746():
+    y = Symbol('y')
+    n = Symbol('n')
     assert manualintegrate(y**x, x) == \
         Piecewise((x, Eq(log(y), 0)), (y**x/log(y), True))
     assert manualintegrate(y**(n*x), x) == \
@@ -218,19 +220,20 @@ def test_issue_6746():
     assert manualintegrate(exp(n*x), x) == \
         Piecewise((x, Eq(n, 0)), (exp(n*x)/n, True))
 
-    with assuming(~Q.zero(log(y))):
-        assert manualintegrate(y**x, x) == y**x/log(y)
-    with assuming(Q.zero(log(y))):
-        assert manualintegrate(y**x, x) == x
-    with assuming(~Q.zero(n)):
-        assert manualintegrate(y**(n*x), x) == \
-            Piecewise((n*x, Eq(log(y), 0)), (y**(n*x)/log(y), True))/n
-    with assuming(~Q.zero(n) & ~Q.zero(log(y))):
-        assert manualintegrate(y**(n*x), x) == \
-            y**(n*x)/(n*log(y))
-    with assuming(Q.negative(a)):
-        assert manualintegrate(1 / (a + b*x**2), x) == \
-            Integral(1/(a + b*x**2), x)
+    y = Symbol('y', positive=True)
+    assert manualintegrate((y + 1)**x, x) == (y + 1)**x/log(y + 1)
+    y = Symbol('y', zero=True)
+    assert manualintegrate((y + 1)**x, x) == x
+    y = Symbol('y')
+    n = Symbol('n', nonzero=True)
+    assert manualintegrate(y**(n*x), x) == \
+        Piecewise((n*x, Eq(log(y), 0)), (y**(n*x)/log(y), True))/n
+    y = Symbol('y', positive=True)
+    assert manualintegrate((y + 1)**(n*x), x) == \
+        (y + 1)**(n*x)/(n*log(y + 1))
+    a = Symbol('a', negative=True)
+    assert manualintegrate(1 / (a + b*x**2), x) == \
+        Integral(1/(a + b*x**2), x)
 
 
 def test_issue_2850():

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -8,7 +8,6 @@ from sympy.core.relational import Relational, Eq, Ge, Lt
 from sympy.sets.sets import FiniteSet, Union
 from sympy.core.singleton import S
 
-from sympy.assumptions import ask, AppliedPredicate, Q
 from sympy.functions import re, im, Abs
 from sympy.logic import And
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
@@ -140,7 +139,7 @@ def solve_rational_inequalities(eqs):
     result = S.EmptySet
 
     for _eqs in eqs:
-        global_intervals = None
+        global_intervals = [Interval(S.NegativeInfinity, S.Infinity)]
 
         for (numer, denom), rel in _eqs:
             numer_intervals = solve_poly_inequality(numer*denom, rel)
@@ -180,7 +179,7 @@ def solve_rational_inequalities(eqs):
     return result
 
 
-def reduce_rational_inequalities(exprs, gen, assume=True, relational=True):
+def reduce_rational_inequalities(exprs, gen, relational=True):
     """Reduce a system of rational inequalities with rational coefficients.
 
     Examples
@@ -216,6 +215,11 @@ def reduce_rational_inequalities(exprs, gen, assume=True, relational=True):
                 else:
                     expr, rel = expr, '=='
 
+            if expr is S.true:
+                continue
+            elif expr is S.false:
+                return S.EmptySet if not relational else expr
+
             try:
                 (numer, denom), opt = parallel_poly_from_expr(
                     expr.together().as_numer_denom(), gen)
@@ -244,7 +248,7 @@ def reduce_rational_inequalities(exprs, gen, assume=True, relational=True):
     if not relational:
         return solution
 
-    real = ask(Q.real(gen), assumptions=assume)
+    real = gen.is_real
 
     if not real:
         result = And(solution.as_relational(re(gen)), Eq(im(gen), 0))
@@ -254,29 +258,30 @@ def reduce_rational_inequalities(exprs, gen, assume=True, relational=True):
     return result
 
 
-def reduce_abs_inequality(expr, rel, gen, assume=True):
+def reduce_abs_inequality(expr, rel, gen):
     """Reduce an inequality with nested absolute values.
 
     Examples
     ========
 
-    >>> from sympy import Q, Abs
-    >>> from sympy.abc import x
+    >>> from sympy import Q, Abs, Symbol
     >>> from sympy.solvers.inequalities import reduce_abs_inequality
+    >>> x = Symbol('x', real=True)
 
-    >>> reduce_abs_inequality(Abs(x - 5) - 3, '<', x, assume=Q.real(x))
+    >>> reduce_abs_inequality(Abs(x - 5) - 3, '<', x)
     And(2 < x, x < 8)
 
-    >>> reduce_abs_inequality(Abs(x + 2)*3 - 13, '<', x, assume=Q.real(x))
+    >>> reduce_abs_inequality(Abs(x + 2)*3 - 13, '<', x)
     And(-19/3 < x, x < 7/3)
 
     See Also
     ========
+
     reduce_abs_inequalities
     """
-    if not ask(Q.real(gen), assumptions=assume):
+    if not gen.is_real:
         raise NotImplementedError("can't solve inequalities with absolute "
-            "values of a complex variable")
+                                  "values of a complex variable")
 
     def _bottom_up_scan(expr):
         exprs = []
@@ -332,36 +337,37 @@ def reduce_abs_inequality(expr, rel, gen, assume=True):
 
         inequalities.append([expr] + conds)
 
-    return reduce_rational_inequalities(inequalities, gen, assume)
+    return reduce_rational_inequalities(inequalities, gen)
 
 
-def reduce_abs_inequalities(exprs, gen, assume=True):
+def reduce_abs_inequalities(exprs, gen):
     """Reduce a system of inequalities with nested absolute values.
 
     Examples
     ========
 
-    >>> from sympy import Q, Abs
+    >>> from sympy import Q, Abs, Symbol
     >>> from sympy.abc import x
     >>> from sympy.solvers.inequalities import reduce_abs_inequalities
+    >>> x = Symbol('x', real=True)
 
     >>> reduce_abs_inequalities([(Abs(3*x - 5) - 7, '<'),
-    ... (Abs(x + 25) - 13, '>')], x, assume=Q.real(x))
+    ... (Abs(x + 25) - 13, '>')], x)
     And(-2/3 < x, Or(And(-12 < x, x < oo), And(-oo < x, x < -38)), x < 4)
 
-    >>> reduce_abs_inequalities([(Abs(x - 4) + Abs(3*x - 5) - 7, '<')], x,
-    ... assume=Q.real(x))
+    >>> reduce_abs_inequalities([(Abs(x - 4) + Abs(3*x - 5) - 7, '<')], x)
     And(1/2 < x, x < 4)
 
     See Also
     ========
+
     reduce_abs_inequality
     """
-    return And(*[ reduce_abs_inequality(expr, rel, gen, assume)
+    return And(*[ reduce_abs_inequality(expr, rel, gen)
         for expr, rel in exprs ])
 
 
-def solve_univariate_inequality(expr, gen, assume=True, relational=True):
+def solve_univariate_inequality(expr, gen, relational=True):
     """Solves a real univariate inequality.
 
     Examples
@@ -383,7 +389,7 @@ def solve_univariate_inequality(expr, gen, assume=True, relational=True):
 
     from sympy.solvers.solvers import solve
 
-    solns = solve(expr.lhs - expr.rhs, gen, assume=assume)
+    solns = solve(expr.lhs - expr.rhs, gen)
     oo = S.Infinity
 
     start = -oo
@@ -409,7 +415,7 @@ def solve_univariate_inequality(expr, gen, assume=True, relational=True):
     return rv if not relational else rv.as_relational(gen)
 
 
-def _solve_inequality(ie, s, assume=True):
+def _solve_inequality(ie, s):
     """ A hacky replacement for solve, since the latter only works for
         univariate inequalities. """
     if not ie.rel_op in ('>', '>=', '<', '<='):
@@ -422,9 +428,9 @@ def _solve_inequality(ie, s, assume=True):
     except (PolynomialError, NotImplementedError):
         try:
             n, d = expr.as_numer_denom()
-            return reduce_rational_inequalities([[ie]], s, assume=assume)
+            return reduce_rational_inequalities([[ie]], s)
         except PolynomialError:
-            return solve_univariate_inequality(ie, s, assume=assume)
+            return solve_univariate_inequality(ie, s)
     a, b = p.all_coeffs()
     if a.is_positive:
         return ie.func(s, -b/a)
@@ -434,20 +440,22 @@ def _solve_inequality(ie, s, assume=True):
         raise NotImplementedError
 
 
-def reduce_inequalities(inequalities, assume=True, symbols=[]):
+def reduce_inequalities(inequalities, symbols=[]):
     """Reduce a system of inequalities with rational coefficients.
 
     Examples
     ========
 
-    >>> from sympy import Q, sympify as S
+    >>> from sympy import Q, sympify as S, Symbol
     >>> from sympy.abc import x, y
     >>> from sympy.solvers.inequalities import reduce_inequalities
 
-    >>> reduce_inequalities(S(0) <= x + 3, Q.real(x), [])
+    >>> x = Symbol('x', real=True)
+    >>> reduce_inequalities(S(0) <= x + 3, [])
     And(-3 <= x, x < oo)
 
-    >>> reduce_inequalities(S(0) <= x + y*2 - 1, True, [x])
+    >>> x = Symbol('x')
+    >>> reduce_inequalities(S(0) <= x + y*2 - 1, [x])
     -2*y + 1 <= x
     """
     if not hasattr(inequalities, '__iter__'):
@@ -456,22 +464,17 @@ def reduce_inequalities(inequalities, assume=True, symbols=[]):
     if len(inequalities) == 1 and len(symbols) == 1 \
             and inequalities[0].is_Relational:
         try:
-            return _solve_inequality(inequalities[0], symbols[0],
-                assume=assume)
+            return _solve_inequality(inequalities[0], symbols[0])
         except NotImplementedError:
             pass
 
-    poly_part, abs_part, extra_assume = {}, {}, []
+    poly_part, abs_part = {}, {}
 
     for inequality in inequalities:
         if inequality == True:
             continue
         elif inequality == False:
             return False
-
-        if isinstance(inequality, AppliedPredicate):
-            extra_assume.append(inequality)
-            continue
 
         if inequality.is_Relational:
             expr, rel = inequality.lhs - inequality.rhs, inequality.rel_op
@@ -504,20 +507,13 @@ def reduce_inequalities(inequalities, assume=True, symbols=[]):
             else:
                 raise NotImplementedError("can't reduce %s" % inequalities)
 
-    extra_assume = And(*extra_assume)
-
-    if assume is not None:
-        assume = And(assume, extra_assume)
-    else:
-        assume = extra_assume
-
     poly_reduced = []
     abs_reduced = []
 
     for gen, exprs in poly_part.items():
-        poly_reduced.append(reduce_rational_inequalities([exprs], gen, assume))
+        poly_reduced.append(reduce_rational_inequalities([exprs], gen))
 
     for gen, exprs in abs_part.items():
-        abs_reduced.append(reduce_abs_inequalities(exprs, gen, assume))
+        abs_reduced.append(reduce_abs_inequalities(exprs, gen))
 
     return And(*(poly_reduced + abs_reduced))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -52,8 +52,6 @@ from sympy.mpmath import findroot
 from sympy.solvers.polysys import solve_poly_system
 from sympy.solvers.inequalities import reduce_inequalities
 
-from sympy.assumptions import Q, ask
-
 from types import GeneratorType
 from collections import defaultdict
 import warnings
@@ -694,8 +692,7 @@ def solve(f, *symbols, **flags):
         elif isinstance(fi, Poly):
             f[i] = fi.as_expr()
         elif isinstance(fi, (bool, C.BooleanAtom)) or fi.is_Relational:
-            return reduce_inequalities(f, assume=flags.get('assume'),
-                                       symbols=symbols)
+            return reduce_inequalities(f, symbols=symbols)
 
         # if we have a Matrix, we need to iterate over its elements again
         if f[i].is_Matrix:

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -3,8 +3,6 @@
 from sympy import (And, Eq, FiniteSet, Ge, Gt, im, Interval, Le, Lt, Ne, oo,
                    Or, Q, re, S, sin, sqrt, Symbol, Union, Integral, Sum,
                    Function, Float)
-from sympy.assumptions import assuming
-from sympy.abc import x, y
 from sympy.solvers.inequalities import (reduce_inequalities,
                                         reduce_rational_inequalities,
                                         solve_univariate_inequality as isolve)
@@ -14,100 +12,105 @@ inf = oo.evalf()
 
 
 def test_reduce_poly_inequalities_real_interval():
-    with assuming(Q.real(x), Q.real(y)):
-        assert reduce_rational_inequalities(
-            [[Eq(x**2, 0)]], x, relational=False) == FiniteSet(0)
-        assert reduce_rational_inequalities(
-            [[Le(x**2, 0)]], x, relational=False) == FiniteSet(0)
-        assert reduce_rational_inequalities(
-            [[Lt(x**2, 0)]], x, relational=False) == S.EmptySet
-        assert reduce_rational_inequalities(
-            [[Ge(x**2, 0)]], x, relational=False) == Interval(-oo, oo)
-        assert reduce_rational_inequalities(
-            [[Gt(x**2, 0)]], x, relational=False) == FiniteSet(0).complement(S.Reals)
-        assert reduce_rational_inequalities(
-            [[Ne(x**2, 0)]], x, relational=False) == FiniteSet(0).complement(S.Reals)
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
 
-        assert reduce_rational_inequalities(
-            [[Eq(x**2, 1)]], x, relational=False) == FiniteSet(-1, 1)
-        assert reduce_rational_inequalities(
-            [[Le(x**2, 1)]], x, relational=False) == Interval(-1, 1)
-        assert reduce_rational_inequalities(
-            [[Lt(x**2, 1)]], x, relational=False) == Interval(-1, 1, True, True)
-        assert reduce_rational_inequalities([[Ge(x**2, 1)]], x, relational=False) == Union(Interval(-oo, -1), Interval(1, oo))
-        assert reduce_rational_inequalities(
-            [[Gt(x**2, 1)]], x, relational=False) == Interval(-1, 1).complement(S.Reals)
-        assert reduce_rational_inequalities(
-            [[Ne(x**2, 1)]], x, relational=False) == FiniteSet(-1, 1).complement(S.Reals)
-        assert reduce_rational_inequalities([[Eq(
-            x**2, 1.0)]], x, relational=False) == FiniteSet(-1.0, 1.0).evalf()
-        assert reduce_rational_inequalities(
-            [[Le(x**2, 1.0)]], x, relational=False) == Interval(-1.0, 1.0)
-        assert reduce_rational_inequalities([[Lt(
-            x**2, 1.0)]], x, relational=False) == Interval(-1.0, 1.0, True, True)
-        assert reduce_rational_inequalities([[Ge(x**2, 1.0)]], x, relational=False) == Union(Interval(-inf, -1.0), Interval(1.0, inf))
-        assert reduce_rational_inequalities([[Gt(x**2, 1.0)]], x, relational=False) == Union(Interval(-inf, -1.0, right_open=True), Interval(1.0, inf, left_open=True))
-        assert reduce_rational_inequalities([[Ne(
-            x**2, 1.0)]], x, relational=False) == FiniteSet(-1.0, 1.0).complement(S.Reals)
+    assert reduce_rational_inequalities(
+        [[Eq(x**2, 0)]], x, relational=False) == FiniteSet(0)
+    assert reduce_rational_inequalities(
+        [[Le(x**2, 0)]], x, relational=False) == FiniteSet(0)
+    assert reduce_rational_inequalities(
+        [[Lt(x**2, 0)]], x, relational=False) == S.EmptySet
+    assert reduce_rational_inequalities(
+        [[Ge(x**2, 0)]], x, relational=False) == Interval(-oo, oo)
+    assert reduce_rational_inequalities(
+        [[Gt(x**2, 0)]], x, relational=False) == FiniteSet(0).complement(S.Reals)
+    assert reduce_rational_inequalities(
+        [[Ne(x**2, 0)]], x, relational=False) == FiniteSet(0).complement(S.Reals)
 
-        s = sqrt(2)
+    assert reduce_rational_inequalities(
+        [[Eq(x**2, 1)]], x, relational=False) == FiniteSet(-1, 1)
+    assert reduce_rational_inequalities(
+        [[Le(x**2, 1)]], x, relational=False) == Interval(-1, 1)
+    assert reduce_rational_inequalities(
+        [[Lt(x**2, 1)]], x, relational=False) == Interval(-1, 1, True, True)
+    assert reduce_rational_inequalities([[Ge(x**2, 1)]], x, relational=False) == Union(Interval(-oo, -1), Interval(1, oo))
+    assert reduce_rational_inequalities(
+        [[Gt(x**2, 1)]], x, relational=False) == Interval(-1, 1).complement(S.Reals)
+    assert reduce_rational_inequalities(
+        [[Ne(x**2, 1)]], x, relational=False) == FiniteSet(-1, 1).complement(S.Reals)
+    assert reduce_rational_inequalities([[Eq(
+        x**2, 1.0)]], x, relational=False) == FiniteSet(-1.0, 1.0).evalf()
+    assert reduce_rational_inequalities(
+        [[Le(x**2, 1.0)]], x, relational=False) == Interval(-1.0, 1.0)
+    assert reduce_rational_inequalities([[Lt(
+        x**2, 1.0)]], x, relational=False) == Interval(-1.0, 1.0, True, True)
+    assert reduce_rational_inequalities([[Ge(x**2, 1.0)]], x, relational=False) == Union(Interval(-inf, -1.0), Interval(1.0, inf))
+    assert reduce_rational_inequalities([[Gt(x**2, 1.0)]], x, relational=False) == Union(Interval(-inf, -1.0, right_open=True), Interval(1.0, inf, left_open=True))
+    assert reduce_rational_inequalities([[Ne(
+        x**2, 1.0)]], x, relational=False) == FiniteSet(-1.0, 1.0).complement(S.Reals)
 
-        assert reduce_rational_inequalities([[Lt(
-            x**2 - 1, 0), Gt(x**2 - 1, 0)]], x, relational=False) == S.EmptySet
-        assert reduce_rational_inequalities([[Le(x**2 - 1, 0), Ge(
-            x**2 - 1, 0)]], x, relational=False) == FiniteSet(-1, 1)
-        assert reduce_rational_inequalities([[Le(x**2 - 2, 0), Ge(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, False, False), Interval(1, s, False, False))
-        assert reduce_rational_inequalities([[Le(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, False, True), Interval(1, s, True, False))
-        assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Ge(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, False), Interval(1, s, False, True))
-        assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, True), Interval(1, s, True, True))
-        assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Ne(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, True), Interval(-1, 1, True, True), Interval(1, s, True, True))
+    s = sqrt(2)
+
+    assert reduce_rational_inequalities([[Lt(
+        x**2 - 1, 0), Gt(x**2 - 1, 0)]], x, relational=False) == S.EmptySet
+    assert reduce_rational_inequalities([[Le(x**2 - 1, 0), Ge(
+        x**2 - 1, 0)]], x, relational=False) == FiniteSet(-1, 1)
+    assert reduce_rational_inequalities([[Le(x**2 - 2, 0), Ge(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, False, False), Interval(1, s, False, False))
+    assert reduce_rational_inequalities([[Le(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, False, True), Interval(1, s, True, False))
+    assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Ge(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, False), Interval(1, s, False, True))
+    assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, True), Interval(1, s, True, True))
+    assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Ne(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, True), Interval(-1, 1, True, True), Interval(1, s, True, True))
 
 
 
 def test_reduce_poly_inequalities_real_relational():
-    with assuming(Q.real(x), Q.real(y)):
-        assert reduce_rational_inequalities(
-            [[Eq(x**2, 0)]], x, relational=True) == Eq(x, 0)
-        assert reduce_rational_inequalities(
-            [[Le(x**2, 0)]], x, relational=True) == Eq(x, 0)
-        assert reduce_rational_inequalities(
-            [[Lt(x**2, 0)]], x, relational=True) == False
-        assert reduce_rational_inequalities(
-            [[Ge(x**2, 0)]], x, relational=True) == And(Lt(-oo, x), Lt(x, oo))
-        assert reduce_rational_inequalities(
-            [[Gt(x**2, 0)]], x, relational=True) == Or(And(Lt(-oo, x), Lt(x, 0)), And(Lt(0, x), Lt(x, oo)))
-        assert reduce_rational_inequalities(
-            [[Ne(x**2, 0)]], x, relational=True) == Or(And(Lt(-oo, x), Lt(x, 0)), And(Lt(0, x), Lt(x, oo)))
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
 
-        assert reduce_rational_inequalities(
-            [[Eq(x**2, 1)]], x, relational=True) == Or(Eq(x, -1), Eq(x, 1))
-        assert reduce_rational_inequalities(
-            [[Le(x**2, 1)]], x, relational=True) == And(Le(-1, x), Le(x, 1))
-        assert reduce_rational_inequalities(
-            [[Lt(x**2, 1)]], x, relational=True) == And(Lt(-1, x), Lt(x, 1))
-        assert reduce_rational_inequalities(
-            [[Ge(x**2, 1)]], x, relational=True) == Or(And(Le(1, x), Lt(x, oo)), And(Le(x, -1), Lt(-oo, x)))
-        assert reduce_rational_inequalities(
-            [[Gt(x**2, 1)]], x, relational=True) == Or(And(Lt(1, x), Lt(x, oo)), And(Lt(x, -1), Lt(-oo, x)))
-        assert reduce_rational_inequalities([[Ne(x**2, 1)]], x, relational=True) == Or(
+    assert reduce_rational_inequalities(
+        [[Eq(x**2, 0)]], x, relational=True) == Eq(x, 0)
+    assert reduce_rational_inequalities(
+        [[Le(x**2, 0)]], x, relational=True) == Eq(x, 0)
+    assert reduce_rational_inequalities(
+        [[Lt(x**2, 0)]], x, relational=True) == False
+    assert reduce_rational_inequalities(
+        [[Ge(x**2, 0)]], x, relational=True) == And(Lt(-oo, x), Lt(x, oo))
+    assert reduce_rational_inequalities(
+        [[Gt(x**2, 0)]], x, relational=True) == Or(And(Lt(-oo, x), Lt(x, 0)), And(Lt(0, x), Lt(x, oo)))
+    assert reduce_rational_inequalities(
+        [[Ne(x**2, 0)]], x, relational=True) == Or(And(Lt(-oo, x), Lt(x, 0)), And(Lt(0, x), Lt(x, oo)))
+
+    assert reduce_rational_inequalities(
+        [[Eq(x**2, 1)]], x, relational=True) == Or(Eq(x, -1), Eq(x, 1))
+    assert reduce_rational_inequalities(
+        [[Le(x**2, 1)]], x, relational=True) == And(Le(-1, x), Le(x, 1))
+    assert reduce_rational_inequalities(
+        [[Lt(x**2, 1)]], x, relational=True) == And(Lt(-1, x), Lt(x, 1))
+    assert reduce_rational_inequalities(
+        [[Ge(x**2, 1)]], x, relational=True) == Or(And(Le(1, x), Lt(x, oo)), And(Le(x, -1), Lt(-oo, x)))
+    assert reduce_rational_inequalities(
+        [[Gt(x**2, 1)]], x, relational=True) == Or(And(Lt(1, x), Lt(x, oo)), And(Lt(x, -1), Lt(-oo, x)))
+    assert reduce_rational_inequalities([[Ne(x**2, 1)]], x, relational=True) == Or(
             And(Lt(-oo, x), Lt(x, -1)), And(Lt(-1, x), Lt(x, 1)), And(Lt(1, x), Lt(x, oo)))
 
-        assert reduce_rational_inequalities(
-            [[Le(x**2, 1.0)]], x, relational=True) == And(Le(-1.0, x), Le(x, 1.0))
-        assert reduce_rational_inequalities(
-            [[Lt(x**2, 1.0)]], x, relational=True) == And(Lt(-1.0, x), Lt(x, 1.0))
-        assert reduce_rational_inequalities(
-            [[Ge(x**2, 1.0)]], x, relational=True) == Or(And(Lt(Float('-inf'), x), Le(x, -1.0)),
+    assert reduce_rational_inequalities(
+        [[Le(x**2, 1.0)]], x, relational=True) == And(Le(-1.0, x), Le(x, 1.0))
+    assert reduce_rational_inequalities(
+        [[Lt(x**2, 1.0)]], x, relational=True) == And(Lt(-1.0, x), Lt(x, 1.0))
+    assert reduce_rational_inequalities(
+        [[Ge(x**2, 1.0)]], x, relational=True) == Or(And(Lt(Float('-inf'), x), Le(x, -1.0)),
                                                          And(Le(1.0, x), Lt(x, Float('+inf'))))
-        assert reduce_rational_inequalities(
-            [[Gt(x**2, 1.0)]], x, relational=True) == Or(And(Lt(Float('-inf'), x), Lt(x, -1.0)),
+    assert reduce_rational_inequalities(
+        [[Gt(x**2, 1.0)]], x, relational=True) == Or(And(Lt(Float('-inf'), x), Lt(x, -1.0)),
                                                          And(Lt(1.0, x), Lt(x, Float('+inf'))))
-        assert reduce_rational_inequalities([[Ne(x**2, 1.0)]], x, relational=True) == \
+    assert reduce_rational_inequalities([[Ne(x**2, 1.0)]], x, relational=True) == \
             Or(And(Lt(-1.0, x), Lt(x, 1.0)), And(Lt(Float('-inf'), x), Lt(x, -1.0)),
                And(Lt(1.0, x), Lt(x, Float('+inf'))))
 
 
 def test_reduce_poly_inequalities_complex_relational():
+    x = Symbol('x')
     cond = Eq(im(x), 0)
 
     assert reduce_rational_inequalities(
@@ -160,57 +163,57 @@ def test_reduce_rational_inequalities_real_relational():
     def RightOpenInterval(a, b):
         return Interval(a, b, False, True)
 
-    with assuming(Q.real(x)):
-        assert reduce_rational_inequalities([[(x**2 + 3*x + 2)/(x**2 - 16) >= 0]], x, relational=False) == \
-            Union(OpenInterval(-oo, -4), Interval(-2, -1), OpenInterval(4, oo))
+    x = Symbol('x', real=True)
 
-        assert reduce_rational_inequalities([[((-2*x - 10)*(3 - x))/((x**2 + 5)*(x - 2)**2) < 0]], x, relational=False) == \
-            Union(OpenInterval(-5, 2), OpenInterval(2, 3))
+    assert reduce_rational_inequalities([[(x**2 + 3*x + 2)/(x**2 - 16) >= 0]], x, relational=False) == \
+        Union(OpenInterval(-oo, -4), Interval(-2, -1), OpenInterval(4, oo))
 
-        assert reduce_rational_inequalities([[(x + 1)/(x - 5) <= 0]], x, assume=Q.real(x), relational=False) == \
-            RightOpenInterval(-1, 5)
+    assert reduce_rational_inequalities([[((-2*x - 10)*(3 - x))/((x**2 + 5)*(x - 2)**2) < 0]], x, relational=False) == \
+        Union(OpenInterval(-5, 2), OpenInterval(2, 3))
 
-        assert reduce_rational_inequalities([[(x**2 + 4*x + 3)/(x - 1) > 0]], x, assume=Q.real(x), relational=False) == \
-            Union(OpenInterval(-3, -1), OpenInterval(1, oo))
+    assert reduce_rational_inequalities([[(x + 1)/(x - 5) <= 0]], x, relational=False) == \
+        RightOpenInterval(-1, 5)
 
-        assert reduce_rational_inequalities([[(x**2 - 16)/(x - 1)**2 < 0]], x, assume=Q.real(x), relational=False) == \
-            Union(OpenInterval(-4, 1), OpenInterval(1, 4))
+    assert reduce_rational_inequalities([[(x**2 + 4*x + 3)/(x - 1) > 0]], x, relational=False) == \
+        Union(OpenInterval(-3, -1), OpenInterval(1, oo))
 
-        assert reduce_rational_inequalities([[(3*x + 1)/(x + 4) >= 1]], x, assume=Q.real(x), relational=False) == \
-            Union(OpenInterval(-oo, -4), RightOpenInterval(S(3)/2, oo))
+    assert reduce_rational_inequalities([[(x**2 - 16)/(x - 1)**2 < 0]], x, relational=False) == \
+        Union(OpenInterval(-4, 1), OpenInterval(1, 4))
 
-        assert reduce_rational_inequalities([[(x - 8)/x <= 3 - x]], x, assume=Q.real(x), relational=False) == \
-            Union(LeftOpenInterval(-oo, -2), LeftOpenInterval(0, 4))
+    assert reduce_rational_inequalities([[(3*x + 1)/(x + 4) >= 1]], x, relational=False) == \
+        Union(OpenInterval(-oo, -4), RightOpenInterval(S(3)/2, oo))
+
+    assert reduce_rational_inequalities([[(x - 8)/x <= 3 - x]], x, relational=False) == \
+        Union(LeftOpenInterval(-oo, -2), LeftOpenInterval(0, 4))
 
 
 def test_reduce_abs_inequalities():
-    real = Q.real(x)
+    x = Symbol('x', real=True)
 
+    assert reduce_inequalities(abs(x - 5) < 3) == And(Lt(2, x), Lt(x, 8))
     assert reduce_inequalities(
-        abs(x - 5) < 3, assume=real) == And(Lt(2, x), Lt(x, 8))
-    assert reduce_inequalities(
-        abs(2*x + 3) >= 8, assume=real) == Or(And(Le(S(5)/2, x), Lt(x, oo)), And(Le(x, -S(11)/2), Lt(-oo, x)))
+        abs(2*x + 3) >= 8) == Or(And(Le(S(5)/2, x), Lt(x, oo)), And(Le(x, -S(11)/2), Lt(-oo, x)))
     assert reduce_inequalities(abs(x - 4) + abs(
-        3*x - 5) < 7, assume=real) == And(Lt(S(1)/2, x), Lt(x, 4))
-    assert reduce_inequalities(abs(x - 4) + abs(3*abs(x) - 5) < 7, assume=real) == Or(And(S(-2) < x, x < -1), And(S(1)/2 < x, x < 4))
+        3*x - 5) < 7) == And(Lt(S(1)/2, x), Lt(x, 4))
+    assert reduce_inequalities(abs(x - 4) + abs(3*abs(x) - 5) < 7) == \
+        Or(And(S(-2) < x, x < -1), And(S(1)/2 < x, x < 4))
 
+    x = Symbol('x')
     raises(NotImplementedError, lambda: reduce_inequalities(abs(x - 5) < 3))
 
 
 def test_reduce_inequalities_boolean():
+    x = Symbol('x')
+
     assert reduce_inequalities(
         [Eq(x**2, 0), True]) == And(Eq(re(x), 0), Eq(im(x), 0))
     assert reduce_inequalities([Eq(x**2, 0), False]) is False
 
 
-def test_reduce_inequalities_assume():
-    assert reduce_inequalities(
-        [Le(x**2, 1), Q.real(x)]) == And(Le(-1, x), Le(x, 1))
-    assert reduce_inequalities(
-        [Le(x**2, 1)], Q.real(x)) == And(Le(-1, x), Le(x, 1))
-
-
 def test_reduce_inequalities_multivariate():
+    x = Symbol('x')
+    y = Symbol('y')
+
     assert reduce_inequalities([Ge(x**2, 1), Ge(y**2, 1)]) == \
         And(Eq(im(x), 0), Eq(im(y), 0), Or(And(Le(1, re(x)), Lt(re(x), oo)),
                                            And(Le(re(x), -1), Lt(-oo, re(x)))),
@@ -218,28 +221,39 @@ def test_reduce_inequalities_multivariate():
 
 
 def test_reduce_inequalities_errors():
+    x = Symbol('x')
+    y = Symbol('y')
+
     raises(NotImplementedError, lambda: reduce_inequalities(Ge(sin(x) + x, 1)))
     raises(NotImplementedError, lambda: reduce_inequalities(Ge(x**2*y + y, 1)))
     raises(NotImplementedError, lambda: reduce_inequalities(Ge(sqrt(2)*x, 1)))
 
 
 def test_hacky_inequalities():
+    x = Symbol('x')
+    y = Symbol('y')
+
     assert reduce_inequalities(x + y < 1, symbols=[x]) == (x < 1 - y)
     assert reduce_inequalities(x + y >= 1, symbols=[x]) == (x >= 1 - y)
 
 
 def test_issue_6343():
+    x = Symbol('x', real=True)
+
     eq = -3*x**2/2 - 45*x/4 + S(33)/2 > 0
-    assert reduce_inequalities(eq, Q.real(x)) == \
+    assert reduce_inequalities(eq) == \
         And(x < -S(15)/4 + sqrt(401)/4, -sqrt(401)/4 - S(15)/4 < x)
 
 
 def test_issue_5526():
-    assert reduce_inequalities(S(0) <= x + Integral(y**2, (y, 1, 3)) - 1, True, [x]) == \
+    x = Symbol('x')
+    y = Symbol('y')
+
+    assert reduce_inequalities(S(0) <= x + Integral(y**2, (y, 1, 3)) - 1, [x]) == \
         (-Integral(y**2, (y, 1, 3)) + 1 <= x)
     f = Function('f')
     e = Sum(f(x), (x, 1, 3))
-    assert reduce_inequalities(S(0) <= x + e + y**2, True, [x]) == \
+    assert reduce_inequalities(S(0) <= x + e + y**2, [x]) == \
         (-y**2 - Sum(f(x), (x, 1, 3)) <= x)
 
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -506,17 +506,23 @@ def test_solve_undetermined_coeffs():
 
 
 def test_solve_inequalities():
+    x = Symbol('x')
     system = [Lt(x**2 - 2, 0), Gt(x**2 - 1, 0)]
 
     assert solve(system) == \
         And(Or(And(Lt(-sqrt(2), re(x)), Lt(re(x), -1)),
                And(Lt(1, re(x)), Lt(re(x), sqrt(2)))), Eq(im(x), 0))
-    assert solve(system, assume=Q.real(x)) == \
+
+    x = Symbol('x', real=True)
+    system = [Lt(x**2 - 2, 0), Gt(x**2 - 1, 0)]
+
+    assert solve(system) == \
         Or(And(Lt(-sqrt(2), x), Lt(x, -1)), And(Lt(1, x), Lt(x, sqrt(2))))
 
     # issue 6627, 3448
-    assert solve((x - 3)/(x - 2) < 0, x, assume=Q.real(x)) == And(Lt(2, x), Lt(x, 3))
-    assert solve(x/(x + 1) > 1, x, assume=Q.real(x)) == And(Lt(-oo, x), Lt(x, -1))
+    assert solve((x - 3)/(x - 2) < 0, x) == And(Lt(2, x), Lt(x, 3))
+    assert solve(x/(x + 1) > 1, x) == And(Lt(-oo, x), Lt(x, -1))
+
 
 def test_issue_4793():
     assert solve(1/x) == []


### PR DESCRIPTION
Until we move to the new assumptions, I think we shouldn't use this system in the sympy modules, unless there is no options.

ToDo
- [x] more tests (is_number, is_algebraic)
- [x] inequalities module
- [x] BlockMatrix._eval_determinant (we don't have Q.invertible analog in the old assumtions, so, I guess, it's fine)
- [x] rebase
