### PR TITLE
Element wise class for matrices Fixing #6801

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1888,6 +1888,16 @@ def test_sympy__matrices__expressions__matadd__MatAdd():
     assert _test_args(MatAdd(X, Y))
 
 
+def test_sympy__matrices__expressions__matexpr__ElemWise():
+    from sympy.matrices.expressions.matexpr import ElemWise
+    from sympy.matrices.expressions import MatrixSymbol
+    from sympy import Symbol, Lambda
+    X = MatrixSymbol('X', x, x)
+    k = Symbol('k')
+    f = Lambda(k, 2*k)
+    assert _test_args(ElemWise(X, f))
+
+
 def test_sympy__matrices__expressions__matexpr__Identity():
     from sympy.matrices.expressions.matexpr import Identity
     assert _test_args(Identity(3))
@@ -3396,3 +3406,4 @@ def test_sympy__vector__scalar__BaseScalar():
     from sympy.vector.coordsysrect import CoordSysCartesian
     C = CoordSysCartesian('C')
     assert _test_args(BaseScalar('Cx', 0, C, ' ', ' '))
+test_sympy__matrices__expressions__matexpr__ElemWise()

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -27,4 +27,4 @@ from .expressions import (MatrixSlice, BlockDiagMatrix, BlockMatrix,
         FunctionMatrix, Identity, Inverse, MatAdd, MatMul, MatPow, MatrixExpr,
         MatrixSymbol, Trace, Transpose, ZeroMatrix, blockcut, block_collapse,
         matrix_symbols, Adjoint, hadamard_product, HadamardProduct,
-        Determinant, det, DiagonalMatrix, DiagonalOf, trace)
+        Determinant, det, DiagonalMatrix, DiagonalOf, trace, ElemWise )

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -6,7 +6,7 @@ from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
 from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix,
-     matrix_symbols)
+     matrix_symbols, ElemWise)
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -1,10 +1,11 @@
 from sympy.core import S, symbols, Add, Mul
 from sympy.functions import transpose, sin, cos, sqrt
 from sympy.simplify import simplify
-from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
+from sympy.matrices import (ElemWise, Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
         Transpose, Adjoint)
 from sympy.utilities.pytest import raises
+from sympy.core.function import Lambda
 
 n, m, l, k, p = symbols('n m l k p', integer=True)
 x = symbols('x')
@@ -38,6 +39,20 @@ def test_subs():
     assert (A*B).subs(B, C) == A*C
 
     assert (A*B).subs(l, n).is_square
+
+
+def test_ElemWise():
+    f = Lambda(x, 2*x)
+    g = Lambda(x, cos(x)**2)
+    h = Lambda(x, -1*x)
+    a, b, c = symbols('a b c')
+    m = Lambda(x, x**2+a+b+2*c)
+    X = MatrixSymbol('X', 3, 3)
+    assert ElemWise(X, Lambda(x, 4*x)) == ElemWise(ElemWise(X, f), f).doit()
+    assert ElemWise(X, Lambda(x, 2*cos(x)**2)) == ElemWise(ElemWise(X, g), f).doit()
+    assert X == ElemWise(ElemWise(X, h), h).doit()
+    assert ElemWise(X, Lambda(x, 2*a + 2*b + 4*c + 2*(a + b + 2*c + x**2)**2)) == \
+ElemWise(ElemWise(ElemWise(X, m), m), f).doit()
 
 
 def test_ZeroMatrix():


### PR DESCRIPTION
Hi I have been a little busy all the while. I have just completed the code for Element wise matrix functions. The PR I have submitted earlier was very confusing and was unable to rebase it, so I am writing a new one.

```
    >>> from sympy import MatrixSymbol, Lambda, Symbol, symbols, cos, ElemWise, Matrix
    >>> A = MatrixSymbol('A', 3, 3)
    >>> B = MatrixSymbol('B', 3, 4)
    >>> x = symbols('x')
    >>> S = ElemWise(A, Lambda(x, x**2))
    >>> Matrix(S)
    Matrix([
    [A[0, 0]**2, A[0, 1]**2, A[0, 2]**2],
    [A[1, 0]**2, A[1, 1]**2, A[1, 2]**2],
    [A[2, 0]**2, A[2, 1]**2, A[2, 2]**2]])
    >>> z = Symbol('z', real=True)
    >>> f = Lambda(x, z*x)
    >>> g = Lambda(x, cos(z*x)**2)
    >>> L = ElemWise(ElemWise(A*B, f), f).doit()
    >>> L[1, 1]
    z**2*(A[1, 0]*B[0, 1] + A[1, 1]*B[1, 1] + A[1, 2]*B[2, 1])
    >>> O = ElemWise(ElemWise(A, g), f).doit()
    >>> O
    ElemWise(A, Lambda(x, z*cos(x*z)**2))
    >>> T = ElemWise(ElemWise(A, f), g).doit()
    >>> T
    ElemWise(A, Lambda(x, cos(x*z**2)**2))
```

Fixes #6801.
