### PR TITLE
fix is_zero detection on Mul._eval_is_* tests

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1011,6 +1011,8 @@ class Mul(Expr, AssocOp):
                 if one_neither:
                     return  # complex terms might cancel
                 one_neither = True
+            else:
+                return
 
         if one_neither:  # N = a+I*b or I*b
             if real:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -965,33 +965,19 @@ class Mul(Expr, AssocOp):
         when_multiple=None)
 
     def _eval_is_zero(self):
-        zero = None
-        bound = True
-        for a in self.args:
-            if a.is_zero:
-                zero = True
-            elif not a.is_bounded:  # None or False
-                return  # (0*oo).is_zero is None
-        return zero
-
-    def _eval_is_nonzero(self):
         zero = unbound = False
         for a in self.args:
             if a.is_zero:
                 zero = True
-            elif a.is_zero is None:
-                return  # might be zero or nonzero
-            elif a.is_unbounded:
+                if unbound:  # 0*oo is nan and nan.is_zero is None
+                    return
+            elif zero is False and a.is_zero is None:
+                zero = None
+            elif not a.is_bounded:
                 unbound = True
-            elif a.is_unbounded is None:
-                # it *could* be True but this is only a problem
-                # if we see a zero
-                unbound = True
-            if unbound == zero == True:
-                # Since 0*oo = nan and nan.is_nonzero is None, if we've seen a
-                # zero and a factor that could be unbounded, we are done
-                return
-        return not zero
+                if zero:  # 0*oo is nan and nan.is_zero is None
+                    return
+        return zero
 
     def _eval_is_integer(self):
         is_rational = self.is_rational

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -964,6 +964,16 @@ class Mul(Expr, AssocOp):
     _eval_is_complex = lambda self: self._eval_template_is_attr('is_complex',
         when_multiple=None)
 
+    def _eval_is_zero(self):
+        zero = None
+        bound = True
+        for a in self.args:
+            if a.is_zero:
+                zero = True
+            elif not a.is_bounded:  # None or False
+                return  # (0*oo).is_zero is None
+        return zero
+
     def _eval_is_nonzero(self):
         zero = False
         bounded = True
@@ -1081,18 +1091,6 @@ class Mul(Expr, AssocOp):
             if a is None:
                 return
         return False
-
-    def _eval_is_zero(self):
-        zero = None
-        for a in self.args:
-            if a.is_zero:
-                zero = True
-                continue
-            bound = a.is_bounded
-            if not bound:
-                return bound
-        if zero:
-            return True
 
     def _eval_is_positive(self):
         """Return True if self is positive, False if not, and None if it

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -998,9 +998,7 @@ class Mul(Expr, AssocOp):
         zero = one_neither = False
 
         for t in self.args:
-            if not t.is_complex:
-                return
-            elif t.is_imaginary:
+            if t.is_imaginary:
                 real = not real
             elif t.is_real:
                 if zero is False:
@@ -1014,20 +1012,20 @@ class Mul(Expr, AssocOp):
             else:
                 return
 
-        if one_neither:
+        if one_neither:  # N = a+I*b or I*b
             if real:
-                return zero  # imag*imag is real but imag*(a+I*b) is not
-        elif zero is False or real:
-            return real
+                return zero  # real*N is like N: neither is real
+        elif zero is False:
+            return real  # real*N that can't be trumped by 0
+        elif real:
+            return real  # doesn't matter what zero is
 
     def _eval_is_imaginary(self):
         real = True
         zero = one_neither = False
 
         for t in self.args:
-            if not t.is_complex:
-                return
-            elif t.is_imaginary:
+            if t.is_imaginary:
                 real = not real
             elif t.is_real:
                 if zero is False:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -964,6 +964,18 @@ class Mul(Expr, AssocOp):
     _eval_is_complex = lambda self: self._eval_template_is_attr('is_complex',
         when_multiple=None)
 
+    def _eval_is_nonzero(self):
+        rv = True
+        for i in self.args:
+            nz = i.is_nonzero
+            if nz:
+                continue
+            elif nz is False:
+                return False
+            elif rv:
+                rv = None
+        return rv
+
     def _eval_is_integer(self):
         is_rational = self.is_rational
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -965,16 +965,25 @@ class Mul(Expr, AssocOp):
         when_multiple=None)
 
     def _eval_is_nonzero(self):
-        rv = True
+        zero = False
+        bounded = True
         for i in self.args:
+            b = i.is_bounded
+            if not b:
+                if bounded is not None:
+                    bounded = b
             nz = i.is_nonzero
             if nz:
                 continue
             elif nz is False:
-                return False
-            elif rv:
-                rv = None
-        return rv
+                zero = True
+            elif zero is False:
+                zero = None
+        if bounded:
+            if zero:
+                return True
+        elif zero is False:
+            return True
 
     def _eval_is_integer(self):
         is_rational = self.is_rational

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1027,7 +1027,7 @@ class Mul(Expr, AssocOp):
                 if zero is False:
                     zero = fuzzy_not(t.is_nonzero)
                     if zero:
-                        return True
+                        return self.is_zero  # let _eval_is_zero decide
             elif t.is_real is False:
                 if one_neither:
                     return  # complex terms might cancel
@@ -1035,11 +1035,11 @@ class Mul(Expr, AssocOp):
             else:
                 return
 
-        if one_neither:  # N = a+I*b or I*b
+        if one_neither:  # self is a+I*b or I*b
             if real:
-                return zero  # real*N is like N: neither is real
+                return zero  # real*self is like self: neither is real
         elif zero is False:
-            return real  # real*N that can't be trumped by 0
+            return real  # can't be trumped by 0
         elif real:
             return real  # doesn't matter what zero is
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1040,8 +1040,10 @@ class Mul(Expr, AssocOp):
                 return
 
         if zero is False:
-            if one_neither:
-                return False  # neither real*(a+I*b) nor I*(a+I*b) is imag
+            if one_neither:  # N = a+I*b or I*b
+                if real:
+                    return  # r*N is like N: could be either
+                return False  # neither I*N values is imaginary
             if not real:
                 return True
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1021,31 +1021,8 @@ class Mul(Expr, AssocOp):
             return real  # doesn't matter what zero is
 
     def _eval_is_imaginary(self):
-        real = True
-        zero = one_neither = False
-
-        for t in self.args:
-            if t.is_imaginary:
-                real = not real
-            elif t.is_real:
-                if zero is False:
-                    zero = fuzzy_not(t.is_nonzero)
-                    if zero:
-                        return False
-            elif t.is_real is False:
-                if one_neither:
-                    return  # complex terms might cancel
-                one_neither = True
-            else:
-                return
-
-        if zero is False:
-            if one_neither:  # N = a+I*b or I*b
-                if real:
-                    return  # r*N is like N: could be either
-                return False  # neither I*N values is imaginary
-            if not real:
-                return True
+        if self.is_nonzero:
+            return (S.ImaginaryUnit*self).is_real
 
     def _eval_is_hermitian(self):
         real = True

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1055,34 +1055,8 @@ class Mul(Expr, AssocOp):
             return real
 
     def _eval_is_antihermitian(self):
-        real = True
-        one_nc = zero = one_neither = False
-
-        for t in self.args:
-            if not t.is_commutative:
-                if one_nc:
-                    return
-                one_nc = True
-
-            if t.is_antihermitian:
-                real = not real
-            elif t.is_hermitian:
-                if zero is False:
-                    zero = fuzzy_not(t.is_nonzero)
-                    if zero:
-                        return False
-            elif t.is_hermitian is False:
-                if one_neither:
-                    return
-                one_neither = True
-            else:
-                return
-
-        if zero is False:
-            if one_neither:
-                return False
-            if not real:
-                return True
+        if self.is_nonzero:
+            return (S.ImaginaryUnit*self).is_hermitian
 
     def _eval_is_irrational(self):
         for t in self.args:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1036,73 +1036,64 @@ class Mul(Expr, AssocOp):
                 return True
 
     def _eval_is_hermitian(self):
-        nc_count = 0
-        im_count = 0
-        is_neither = False
-        is_zero = False
+        real = True
+        one_nc = zero = one_neither = False
+
         for t in self.args:
             if not t.is_commutative:
-                nc_count += 1
-                if nc_count > 1:
+                if one_nc:
                     return
+                one_nc = True
+
             if t.is_antihermitian:
-                im_count += 1
-                continue
-            t_real = t.is_hermitian
-            if t_real:
-                if is_zero is False:
-                    is_zero = fuzzy_not(t.is_nonzero)
-                    if is_zero:
+                real = not real
+            elif t.is_hermitian:
+                if zero is False:
+                    zero = fuzzy_not(t.is_nonzero)
+                    if zero:
                         return True
-            elif t_real is False:
-                if is_neither:
+            elif t.is_hermitian is False:
+                if one_neither:
                     return
-                else:
-                    is_neither = True
+                one_neither = True
             else:
                 return
 
-        real = im_count % 2 == 0
-        if is_neither:
+        if one_neither:
             if real:
-                return is_zero
-        else:
-            if real:
-                return True
-            return is_zero
+                return zero
+        elif zero is False or real:
+            return real
 
     def _eval_is_antihermitian(self):
-        nc_count = 0
-        im_count = 0
-        is_neither = False
-        is_zero = False
+        real = True
+        one_nc = zero = one_neither = False
+
         for t in self.args:
             if not t.is_commutative:
-                nc_count += 1
-                if nc_count > 1:
+                if one_nc:
                     return
+                one_nc = True
+
             if t.is_antihermitian:
-                im_count += 1
-                continue
-            t_real = t.is_hermitian
-            if t_real:
-                if is_zero is False:
-                    is_zero = fuzzy_not(t.is_nonzero)
-                    if is_zero:
+                real = not real
+            elif t.is_hermitian:
+                if zero is False:
+                    zero = fuzzy_not(t.is_nonzero)
+                    if zero:
                         return False
-            elif t_real is False:
-                if is_neither:
+            elif t.is_hermitian is False:
+                if one_neither:
                     return
-                else:
-                    is_neither = True
+                one_neither = True
             else:
                 return
 
-        if is_neither:
-            return is_zero
-        else:
-            if im_count % 2 == 0:
-                return is_zero
+        if zero is False:
+            if one_neither:
+                return False
+            if not real:
+                return True
 
     def _eval_is_irrational(self):
         for t in self.args:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -975,25 +975,21 @@ class Mul(Expr, AssocOp):
         return zero
 
     def _eval_is_nonzero(self):
-        # unbounded: might iniclude oo, could be zero
-        # bounded: doesn't include oo, could be zero
-        # not bounded is +/oo
-        # not unbounded is not +/-oo
-        # 0*oo = nan and nan.is_nonzero is None so
-        # if we don't know if a factor is zero or not then the answer is None
-        # if we don't know if a factor is bounded or not then the answer is None
-        # otherwise the answer is False if there was a zero else True
         zero = unbound = False
-        for i in self.args:
-            if i.is_zero:
+        for a in self.args:
+            if a.is_zero:
                 zero = True
-            elif i.is_zero is None:
-                return
-            elif i.is_bounded is False:
+            elif a.is_zero is None:
+                return  # might be zero or nonzero
+            elif a.is_unbounded:
                 unbound = True
-            elif i.is_bounded is None:
-                return
+            elif a.is_unbounded is None:
+                # it *could* be True but this is only a problem
+                # if we see a zero
+                unbound = True
             if unbound == zero == True:
+                # Since 0*oo = nan and nan.is_nonzero is None, if we've seen a
+                # zero and a factor that could be unbounded, we are done
                 return
         return not zero
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -982,57 +982,60 @@ class Mul(Expr, AssocOp):
             all(arg.is_polar or arg.is_positive for arg in self.args)
 
     def _eval_is_real(self):
-        from sympy.core.logic import fuzzy_not
         real = True
-        is_zero = one_neither = False
+        zero = one_neither = False
+
         for t in self.args:
-            if t.is_imaginary:
+            if not t.is_complex:
+                return
+            elif t.is_imaginary:
                 real = not real
             elif t.is_real:
-                if is_zero is False:
-                    is_zero = fuzzy_not(t.is_nonzero)
-                    if is_zero:
+                if zero is False:
+                    zero = fuzzy_not(t.is_nonzero)
+                    if zero:
                         return True
-            elif t.is_real is None:
-                return
-            else:
+            elif t.is_real is False:
                 if one_neither:
                     return  # complex terms might cancel
                 one_neither = True
-        if one_neither:
-            if real and is_zero is False:
-                return False
             else:
-                return  # imag*imag is real but imag*(a+I*b) is not
-        elif is_zero is False or real:
+                return
+
+        if one_neither:
+            if real:
+                return zero  # imag*imag is real but imag*(a+I*b) is not
+        elif zero is False or real:
             return real
 
     def _eval_is_imaginary(self):
-        from sympy.core.logic import fuzzy_not
         real = True
-        is_zero = one_neither = False
+        zero = one_neither = False
+
         for t in self.args:
-            if t.is_imaginary:
+            if not t.is_complex:
+                return
+            elif t.is_imaginary:
                 real = not real
             elif t.is_real:
-                if is_zero is False:
-                    is_zero = fuzzy_not(t.is_nonzero)
-                    if is_zero:
+                if zero is False:
+                    zero = fuzzy_not(t.is_nonzero)
+                    if zero:
                         return False
-            elif t.is_real is None:
-                return
-            else:
+            elif t.is_real is False:
                 if one_neither:
                     return  # complex terms might cancel
                 one_neither = True
-        if is_zero is False:
+            else:
+                return
+
+        if zero is False:
             if one_neither:
                 return False  # neither real*(a+I*b) nor I*(a+I*b) is imag
             if not real:
                 return True
 
     def _eval_is_hermitian(self):
-        from sympy.core.logic import fuzzy_not
         nc_count = 0
         im_count = 0
         is_neither = False
@@ -1069,7 +1072,6 @@ class Mul(Expr, AssocOp):
             return is_zero
 
     def _eval_is_antihermitian(self):
-        from sympy.core.logic import fuzzy_not
         nc_count = 0
         im_count = 0
         is_neither = False

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -998,7 +998,9 @@ class Mul(Expr, AssocOp):
         zero = one_neither = False
 
         for t in self.args:
-            if t.is_imaginary:
+            if not t.is_complex:
+                return
+            elif t.is_imaginary:
                 real = not real
             elif t.is_real:
                 if zero is False:
@@ -1009,8 +1011,6 @@ class Mul(Expr, AssocOp):
                 if one_neither:
                     return  # complex terms might cancel
                 one_neither = True
-            else:
-                return
 
         if one_neither:  # N = a+I*b or I*b
             if real:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1004,7 +1004,7 @@ class Mul(Expr, AssocOp):
 
         for t in self.args:
             if not t.is_complex:
-                return
+                return t.is_complex
             elif t.is_imaginary:
                 real = not real
             elif t.is_real:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -492,7 +492,7 @@ def test_Add_is_even_odd():
 
 def test_Mul_is_negative_positive():
     x = Symbol('x', real=True)
-    y = Symbol('y', real=False)
+    y = Symbol('y', real=False, complex=True)
     z = Symbol('z', zero=True)
 
     e = 2*z
@@ -1160,7 +1160,7 @@ def test_Mul_is_imaginary_real():
     assert (r*i*ii).is_real is True
 
     # Github's issue 5874:
-    nr = Symbol('nr', real=False)
+    nr = Symbol('nr', real=False, complex=True)
     a = Symbol('a', real=True, nonzero=True)
     b = Symbol('b', real=True)
     assert (i*nr).is_real is None
@@ -1171,7 +1171,7 @@ def test_Mul_is_imaginary_real():
     a = Symbol('a', real=True, zero=False)
     b = Symbol('b', real=True)
     bb = Symbol('b', real=True, zero=False)
-    c = Symbol('c', real=False)
+    c = Symbol('c', real=False, complex=True)
     e1 = Mul(a, b, c, evaluate=False)
     e2 = Mul(b, a, c, evaluate=False)
     assert e1.is_imaginary is None

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1688,13 +1688,5 @@ def test_mul_nonzero():
 
     assert Mul(oo, i, evaluate=False).is_nonzero
     assert Mul(oo, i, x, evaluate=False).is_nonzero is None
-    # replace these with the two XFAIL tests below when they pass
-    assert Mul(oo, z, evaluate=False)._eval_is_nonzero() is None
-    assert Mul(oo, z, x, evaluate=False)._eval_is_nonzero() is None
-
-
-@XFAIL
-def test_mul_nonzero_fail():
-    z = Symbol('z', nonzero=False)
     assert Mul(oo, z, evaluate=False).is_nonzero is None
     assert Mul(oo, z, x, evaluate=False).is_nonzero is None

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1202,8 +1202,8 @@ def test_Mul_hermitian_antihermitian():
     assert e2.is_antihermitian is None
     assert e3.is_antihermitian is None
     assert e4.is_antihermitian is None
-    assert e5.is_antihermitian is False
-    assert e6.is_antihermitian is False
+    assert e5.is_antihermitian is None
+    assert e6.is_antihermitian is None
 
 
 def test_Add_is_comparable():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1167,6 +1167,48 @@ def test_Mul_is_imaginary_real():
     assert (a*nr).is_real is False
     assert (b*nr).is_real is None
 
+    # is_zero detection
+    a = Symbol('a', real=True, zero=False)
+    b = Symbol('b', real=True)
+    bb = Symbol('b', real=True, zero=False)
+    c = Symbol('c', real=False)
+    e1 = Mul(a, b, c, evaluate=False)
+    e2 = Mul(b, a, c, evaluate=False)
+    assert e1.is_imaginary is None
+    assert e2.is_imaginary is None
+    e1 = Mul(a, bb, c, evaluate=False)
+    assert e1.is_imaginary is False
+    a = Symbol('a', hermitian=True, zero=False)
+    b = Symbol('b', hermitian=True)
+    bb = Symbol('b', hermitian=True, zero=False)
+    c = Symbol('c', hermitian=False)
+    d = Symbol('d', antihermitian=True)
+    e1 = Mul(a, b, c, evaluate=False)
+    e2 = Mul(b, a, c, evaluate=False)
+    e3 = Mul(a, b, c, d, evaluate=False)
+    e4 = Mul(b, a, c, d, evaluate=False)
+    assert e1.is_antihermitian is None
+    assert e2.is_antihermitian is None
+    assert e3.is_antihermitian is None
+    assert e4.is_antihermitian is None
+    e1 = Mul(a, bb, c, evaluate=False)
+    e3 = Mul(a, bb, c, d, evaluate=False)
+    assert e1.is_antihermitian is False
+    assert e3.is_antihermitian is False
+
+    a = Symbol('a', real=True, zero=False)
+    b = Symbol('b', real=True)
+    bb = Symbol('b', real=True, zero=False)
+    c = Symbol('c', imaginary=True)
+    e1 = Mul(a, b, c, evaluate=False)
+    e2 = Mul(b, a, c, evaluate=False)
+    assert e1.is_real is None
+    assert e2.is_real is None
+    assert e1.is_hermitian is None
+    assert e2.is_hermitian is None
+    e1 = Mul(a, bb, c, evaluate=False)
+    assert e1.is_real is False
+
 
 def test_Add_is_comparable():
     assert (x + y).is_comparable is False

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1668,3 +1668,11 @@ def test_mul_coeff():
     # This can be tricky when powers combine to produce those numbers
     p = exp(I*pi/3)
     assert p**2*x*p*y*p*x*p**2 == x**2*y
+
+def test_mul_nonzero():
+    i = Symbol('i', integer=True, zero=False)
+    n = Symbol('n', nonzero=False)
+    assert (2*i).is_nonzero
+    assert (2*x).is_nonzero is None
+    assert Mul(x, n, evaluate=False).is_nonzero is False
+    assert Mul(n, x, evaluate=False).is_nonzero is False

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1673,8 +1673,17 @@ def test_mul_coeff():
 
 def test_mul_nonzero():
     i = Symbol('i', integer=True, zero=False)
-    n = Symbol('n', nonzero=False)
+    z = Symbol('n', nonzero=False)
+    b = Symbol('b', bounded=True)
+    ub = Symbol('ub', unbounded=True)
     assert (2*i).is_nonzero
     assert (2*x).is_nonzero is None
-    assert Mul(x, n, evaluate=False).is_nonzero is False
-    assert Mul(n, x, evaluate=False).is_nonzero is False
+    assert Mul(b, z, evaluate=False).is_nonzero is False
+    assert Mul(b, z, x, evaluate=False).is_nonzero is None
+    assert Mul(b, i, evaluate=False).is_nonzero is None
+    assert Mul(b, i, x, evaluate=False).is_nonzero is None
+
+    assert Mul(ub, z, evaluate=False).is_nonzero is None
+    assert Mul(ub, z, x, evaluate=False).is_nonzero is None
+    assert Mul(ub, i, evaluate=False).is_nonzero
+    assert Mul(ub, i, x, evaluate=False).is_nonzero is None

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1177,7 +1177,7 @@ def test_Mul_is_imaginary_real():
     assert e1.is_imaginary is None
     assert e2.is_imaginary is None
     e1 = Mul(a, bb, c, evaluate=False)
-    assert e1.is_imaginary is False
+    assert e1.is_imaginary is None
     a = Symbol('a', hermitian=True, zero=False)
     b = Symbol('b', hermitian=True)
     bb = Symbol('b', hermitian=True, zero=False)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1170,44 +1170,40 @@ def test_Mul_is_imaginary_real():
     # is_zero detection
     a = Symbol('a', real=True, zero=False)
     b = Symbol('b', real=True)
-    bb = Symbol('b', real=True, zero=False)
     c = Symbol('c', real=False)
     e1 = Mul(a, b, c, evaluate=False)
     e2 = Mul(b, a, c, evaluate=False)
+    e3 = Mul(a, c, evaluate=False)
+    e4 = Mul(a, i, c, evaluate=False)
     assert e1.is_imaginary is None
     assert e2.is_imaginary is None
-    e1 = Mul(a, bb, c, evaluate=False)
-    assert e1.is_imaginary is None
+    assert e3.is_imaginary is None
+    assert e4.is_imaginary is False
+    assert e1.is_real is None
+    assert e2.is_real is None
+    assert e3.is_real is False
+    assert e4.is_imaginary is False
+
+
+def test_Mul_hermitian_antihermitian():
     a = Symbol('a', hermitian=True, zero=False)
     b = Symbol('b', hermitian=True)
-    bb = Symbol('b', hermitian=True, zero=False)
     c = Symbol('c', hermitian=False)
     d = Symbol('d', antihermitian=True)
     e1 = Mul(a, b, c, evaluate=False)
     e2 = Mul(b, a, c, evaluate=False)
     e3 = Mul(a, b, c, d, evaluate=False)
     e4 = Mul(b, a, c, d, evaluate=False)
+    e5 = Mul(a, c, evaluate=False)
+    e6 = Mul(a, c, d, evaluate=False)
+    assert e1.is_hermitian is None
+    assert e2.is_hermitian is None
     assert e1.is_antihermitian is None
     assert e2.is_antihermitian is None
     assert e3.is_antihermitian is None
     assert e4.is_antihermitian is None
-    e1 = Mul(a, bb, c, evaluate=False)
-    e3 = Mul(a, bb, c, d, evaluate=False)
-    assert e1.is_antihermitian is False
-    assert e3.is_antihermitian is False
-
-    a = Symbol('a', real=True, zero=False)
-    b = Symbol('b', real=True)
-    bb = Symbol('b', real=True, zero=False)
-    c = Symbol('c', imaginary=True)
-    e1 = Mul(a, b, c, evaluate=False)
-    e2 = Mul(b, a, c, evaluate=False)
-    assert e1.is_real is None
-    assert e2.is_real is None
-    assert e1.is_hermitian is None
-    assert e2.is_hermitian is None
-    e1 = Mul(a, bb, c, evaluate=False)
-    assert e1.is_real is False
+    assert e5.is_antihermitian is False
+    assert e6.is_antihermitian is False
 
 
 def test_Add_is_comparable():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -11,19 +11,14 @@ from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.randtest import test_numerically
 
 
-x = Symbol('x')
-y = Symbol('y')
-z = Symbol('z')
+a, c, x, y, z = symbols('a,c,x,y,z')
+b = Symbol("b", positive=True)
 
 
 def test_bug1():
     assert re(x) != x
     x.series(x, 0, 1)
     assert re(x) != x
-
-a = Symbol("a")
-b = Symbol("b", positive=True)
-c = Symbol("c")
 
 
 def test_Symbol():
@@ -32,6 +27,17 @@ def test_Symbol():
     assert a*b*b == a*b**2
     assert a*b*b + c == c + a*b**2
     assert a*b*b - c == -c + a*b**2
+
+    x = Symbol('x', complex=True, real=False)
+    assert x.is_imaginary is None  # could be I or 1 + I
+    x = Symbol('x', complex=True, imaginary=False)
+    assert x.is_real is None  # could be 1 or 1 + I
+    x = Symbol('x', real=True)
+    assert x.is_complex
+    x = Symbol('x', imaginary=True)
+    assert x.is_complex
+    x = Symbol('x', real=False, imaginary=False)
+    assert x.is_complex is None  # might be a non-number
 
 
 def test_arit0():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1665,11 +1665,13 @@ def test_denest_add_mul():
     assert 2*eq == Mul(-4, x - 2, evaluate=False)
     assert -eq == Mul(2, x - 2, evaluate=False)
 
+
 def test_mul_coeff():
     # It is important that all Numbers be removed from the seq;
     # This can be tricky when powers combine to produce those numbers
     p = exp(I*pi/3)
     assert p**2*x*p*y*p*x*p**2 == x**2*y
+
 
 def test_mul_nonzero():
     i = Symbol('i', integer=True, zero=False)
@@ -1687,3 +1689,8 @@ def test_mul_nonzero():
     assert Mul(ub, z, x, evaluate=False).is_nonzero is None
     assert Mul(ub, i, evaluate=False).is_nonzero
     assert Mul(ub, i, x, evaluate=False).is_nonzero is None
+
+
+def test_Mul_is_zero():
+    z = Symbol('n', nonzero=False)
+    assert Mul(oo, z, evaluate=False)._eval_is_zero() is None

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -498,7 +498,7 @@ def test_Add_is_even_odd():
 
 def test_Mul_is_negative_positive():
     x = Symbol('x', real=True)
-    y = Symbol('y', real=False)
+    y = Symbol('y', real=False, complex=True)
     z = Symbol('z', zero=True)
 
     e = 2*z
@@ -1166,7 +1166,7 @@ def test_Mul_is_imaginary_real():
     assert (r*i*ii).is_real is True
 
     # Github's issue 5874:
-    nr = Symbol('nr', real=False)
+    nr = Symbol('nr', real=False, complex=True)
     a = Symbol('a', real=True, nonzero=True)
     b = Symbol('b', real=True)
     assert (i*nr).is_real is None
@@ -1176,7 +1176,7 @@ def test_Mul_is_imaginary_real():
     # is_zero detection
     a = Symbol('a', real=True, zero=False)
     b = Symbol('b', real=True)
-    c = Symbol('c', real=False)
+    c = Symbol('c', real=False, complex=True)
     e1 = Mul(a, b, c, evaluate=False)
     e2 = Mul(b, a, c, evaluate=False)
     e3 = Mul(a, c, evaluate=False)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1173,23 +1173,6 @@ def test_Mul_is_imaginary_real():
     assert (a*nr).is_real is False
     assert (b*nr).is_real is None
 
-    # is_zero detection
-    a = Symbol('a', real=True, zero=False)
-    b = Symbol('b', real=True)
-    c = Symbol('c', real=False, complex=True)
-    e1 = Mul(a, b, c, evaluate=False)
-    e2 = Mul(b, a, c, evaluate=False)
-    e3 = Mul(a, c, evaluate=False)
-    e4 = Mul(a, i, c, evaluate=False)
-    assert e1.is_imaginary is None
-    assert e2.is_imaginary is None
-    assert e3.is_imaginary is None
-    assert e4.is_imaginary is False
-    assert e1.is_real is None
-    assert e2.is_real is None
-    assert e3.is_real is False
-    assert e4.is_imaginary is False
-
 
 def test_Mul_hermitian_antihermitian():
     a = Symbol('a', hermitian=True, zero=False)
@@ -1674,10 +1657,28 @@ def test_mul_coeff():
 
 
 def test_mul_nonzero():
-    i = Symbol('i', integer=True, zero=False)
-    z = Symbol('n', nonzero=False)
+    # is_zero detection
+    nz = Symbol('a', real=True, zero=False, bounded=True)
+    r = Symbol('b', real=True)
+    c = Symbol('c', real=False, complex=True, bounded=True)
+    i = Symbol('i', imaginary=True, bounded=True)
+    e1 = Mul(nz, r, c, evaluate=False)
+    e2 = Mul(r, nz, c, evaluate=False)
+    e3 = Mul(nz, c, evaluate=False)
+    e4 = Mul(nz, i, c, evaluate=False)
+    assert e1.is_imaginary is None
+    assert e2.is_imaginary is None
+    assert e3.is_imaginary is None
+    assert e4.is_imaginary is False
+    assert e1.is_real is None
+    assert e2.is_real is None
+    assert e3.is_real is False
+    assert e4.is_imaginary is False
+
+
+    i = Symbol('i', integer=True, zero=False, bounded=True)
+    z = Symbol('z', nonzero=False)
     b = Symbol('b', bounded=True)
-    ub = Symbol('ub', unbounded=True)
     assert (2*i).is_nonzero
     assert (2*x).is_nonzero is None
     assert Mul(b, z, evaluate=False).is_nonzero is False
@@ -1685,12 +1686,15 @@ def test_mul_nonzero():
     assert Mul(b, i, evaluate=False).is_nonzero is None
     assert Mul(b, i, x, evaluate=False).is_nonzero is None
 
-    assert Mul(ub, z, evaluate=False).is_nonzero is None
-    assert Mul(ub, z, x, evaluate=False).is_nonzero is None
-    assert Mul(ub, i, evaluate=False).is_nonzero
-    assert Mul(ub, i, x, evaluate=False).is_nonzero is None
+    assert Mul(oo, i, evaluate=False).is_nonzero
+    assert Mul(oo, i, x, evaluate=False).is_nonzero is None
+    # replace these with the two XFAIL tests below when they pass
+    assert Mul(oo, z, evaluate=False)._eval_is_nonzero() is None
+    assert Mul(oo, z, x, evaluate=False)._eval_is_nonzero() is None
 
 
-def test_Mul_is_zero():
-    z = Symbol('n', nonzero=False)
-    assert Mul(oo, z, evaluate=False)._eval_is_zero() is None
+@XFAIL
+def test_mul_nonzero_fail():
+    z = Symbol('z', nonzero=False)
+    assert Mul(oo, z, evaluate=False).is_nonzero is None
+    assert Mul(oo, z, x, evaluate=False).is_nonzero is None

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -492,7 +492,7 @@ def test_Add_is_even_odd():
 
 def test_Mul_is_negative_positive():
     x = Symbol('x', real=True)
-    y = Symbol('y', real=False, complex=True)
+    y = Symbol('y', real=False)
     z = Symbol('z', zero=True)
 
     e = 2*z
@@ -1160,7 +1160,7 @@ def test_Mul_is_imaginary_real():
     assert (r*i*ii).is_real is True
 
     # Github's issue 5874:
-    nr = Symbol('nr', real=False, complex=True)
+    nr = Symbol('nr', real=False)
     a = Symbol('a', real=True, nonzero=True)
     b = Symbol('b', real=True)
     assert (i*nr).is_real is None
@@ -1171,7 +1171,7 @@ def test_Mul_is_imaginary_real():
     a = Symbol('a', real=True, zero=False)
     b = Symbol('b', real=True)
     bb = Symbol('b', real=True, zero=False)
-    c = Symbol('c', real=False, complex=True)
+    c = Symbol('c', real=False)
     e1 = Mul(a, b, c, evaluate=False)
     e2 = Mul(b, a, c, evaluate=False)
     assert e1.is_imaginary is None

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -242,9 +242,14 @@ class RandomSymbol(Expr):
     symbol = property(lambda self: self.args[1])
     name   = property(lambda self: self.symbol.name)
 
-    is_positive = property(lambda self: self.symbol.is_positive)
-    is_integer = property(lambda self: self.symbol.is_integer)
-    is_real = property(lambda self: self.symbol.is_real or self.pspace.is_real)
+    def _eval_is_positive(self):
+        return self.symbol.is_positive
+
+    def _eval_is_integer(self):
+        return self.symbol.is_integer
+
+    def _eval_is_real(self):
+        return self.symbol.is_real or self.pspace.is_real
 
     @property
     def is_commutative(self):


### PR DESCRIPTION
Once a None is obtained for is_zero, it should no longer be updated.
The return value must consider the value of is_zero. This can
change if S.Zero.is_imaginary = S.Zero.is_real = True is ever true.

The routines were shortened a bit, too.
