### PR TITLE
Proof of concept: new assumptions check old assumptions for Symbol

### DIFF
--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -17,6 +17,10 @@ class AskInfinitesimalHandler(CommonHandler):
     """
 
     @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_infinitesimal
+
+    @staticmethod
     def _number(expr, assumptions):
         # helper method
         return expr.evalf() == 0
@@ -91,6 +95,8 @@ class AskBoundedHandler(CommonHandler):
         True
 
         """
+        if expr.is_bounded is not None:
+            return expr.is_bounded
         if Q.bounded(expr) in conjuncts(assumptions):
             return True
         return None

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -29,6 +29,8 @@ class AskCommutativeHandler(CommonHandler):
     @staticmethod
     def Symbol(expr, assumptions):
         """Objects are expected to be commutative unless otherwise stated"""
+        if expr.is_commutative is not None:
+            return expr.is_commutative
         assumps = conjuncts(assumptions)
         if Q.commutative(expr) in assumps:
             return True

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -18,6 +18,10 @@ class AskPrimeHandler(CommonHandler):
     """
 
     @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_prime
+
+    @staticmethod
     def _number(expr, assumptions):
         # helper method
         try:
@@ -76,6 +80,11 @@ class AskPrimeHandler(CommonHandler):
 
 
 class AskCompositeHandler(CommonHandler):
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_composite
+
     @staticmethod
     def Basic(expr, assumptions):
         _positive = ask(Q.positive(expr), assumptions)
@@ -93,6 +102,11 @@ class AskCompositeHandler(CommonHandler):
 
 
 class AskEvenHandler(CommonHandler):
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_even
+
     @staticmethod
     def _number(expr, assumptions):
         # helper method
@@ -218,6 +232,10 @@ class AskOddHandler(CommonHandler):
     Handler for key 'odd'
     Test that an expression represents an odd number
     """
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_odd
 
     @staticmethod
     def Basic(expr, assumptions):

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -25,6 +25,10 @@ class AskNegativeHandler(CommonHandler):
     """
 
     @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_negative
+
+    @staticmethod
     def _number(expr, assumptions):
         r, i = expr.as_real_imag()
         # If the imaginary part can symbolically be shown to be zero then
@@ -116,6 +120,11 @@ class AskNegativeHandler(CommonHandler):
 
 
 class AskNonNegativeHandler(CommonHandler):
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_nonnegative
+
     @staticmethod
     def Basic(expr, assumptions):
         if expr.is_number:
@@ -131,6 +140,10 @@ class AskNonZeroHandler(CommonHandler):
     Handler for key 'zero'
     Test that an expression is not identically zero
     """
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_nonzero
 
     @staticmethod
     def Basic(expr, assumptions):
@@ -168,6 +181,11 @@ class AskNonZeroHandler(CommonHandler):
         return ask(Q.nonzero(expr.args[0]), assumptions)
 
 class AskZeroHandler(CommonHandler):
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_zero
+
     @staticmethod
     def Basic(expr, assumptions):
         return fuzzy_and([fuzzy_not(ask(Q.nonzero(expr), assumptions)),
@@ -179,6 +197,11 @@ class AskZeroHandler(CommonHandler):
         return fuzzy_or(ask(Q.zero(arg), assumptions) for arg in expr.args)
 
 class AskNonPositiveHandler(CommonHandler):
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_nonpositive
+
     @staticmethod
     def Basic(expr, assumptions):
         if expr.is_number:
@@ -193,6 +216,10 @@ class AskPositiveHandler(CommonHandler):
     Handler for key 'positive'
     Test that an expression is greater (strict) than zero
     """
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_positive
 
     @staticmethod
     def _number(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -17,6 +17,10 @@ class AskIntegerHandler(CommonHandler):
     """
 
     @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_integer
+
+    @staticmethod
     def _number(expr, assumptions):
         # helper method
         try:
@@ -100,6 +104,11 @@ class AskRationalHandler(CommonHandler):
     Test that an expression belongs to the field of rational numbers
     """
 
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_rational
+
     @staticmethod
     def Add(expr, assumptions):
         """
@@ -157,6 +166,11 @@ class AskRationalHandler(CommonHandler):
 
 class AskIrrationalHandler(CommonHandler):
 
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_irrational
+
     @staticmethod
     def Basic(expr, assumptions):
         _real = ask(Q.real(expr), assumptions)
@@ -174,6 +188,10 @@ class AskRealHandler(CommonHandler):
     Handler for Q.real
     Test that an expression belongs to the field of real numbers
     """
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_real
 
     @staticmethod
     def _number(expr, assumptions):
@@ -380,6 +398,10 @@ class AskComplexHandler(CommonHandler):
     """
 
     @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_complex
+
+    @staticmethod
     def Add(expr, assumptions):
         return test_closed_group(expr, assumptions, Q.complex)
 
@@ -403,6 +425,10 @@ class AskImaginaryHandler(CommonHandler):
     Test that an expression belongs to the field of imaginary numbers,
     that is, numbers in the form x*I, where x is real
     """
+
+    @staticmethod
+    def Symbol(expr, assumptions):
+        return expr.is_imaginary
 
     @staticmethod
     def _number(expr, assumptions):


### PR DESCRIPTION
That is, ask(Q.real(Symbol('x', real=True))) now gives True (but it only
checks old assumptions Symbols, not all expressions).

They only check for Symbol to reduce the number of test failures and things
that need to be fixed. So far, only one thing fails, which is
ask(Q.commutative(x), ~Q.commutative(x)), because x is commutative by default
in the old assumptions. If we go forward with this, we should probably either
have the new assumptions override the old ones, or else disallow them to
conflict.
