### PR TITLE
Add symbol's assumptions to the global_assumptions context

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -20,17 +20,16 @@ class AssumptionsContext(set):
     ========
 
     >>> from sympy import AppliedPredicate, Q
-    >>> from sympy.assumptions.assume import global_assumptions
-    >>> global_assumptions
-    AssumptionsContext()
+    >>> from sympy.assumptions.assume import AssumptionsContext
+    >>> assumptions = AssumptionsContext()
     >>> from sympy.abc import x
-    >>> global_assumptions.add(Q.real(x))
-    >>> global_assumptions
+    >>> assumptions.add(Q.real(x))
+    >>> assumptions
     AssumptionsContext([Q.real(x)])
-    >>> global_assumptions.remove(Q.real(x))
-    >>> global_assumptions
+    >>> assumptions.remove(Q.real(x))
+    >>> assumptions
     AssumptionsContext()
-    >>> global_assumptions.clear()
+    >>> assumptions.clear()
 
     """
 
@@ -186,6 +185,7 @@ class Predicate(Boolean):
                         raise ValueError('incompatible resolutors')
                 break
         return res
+
 
 @contextmanager
 def assuming(*assumptions):

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -109,6 +109,11 @@ class Symbol(AtomicExpr, Boolean):
             if not hasattr(Q, str(key)):
                 continue
 
+            if key == 'commutative':
+                if not assumptions[key]:
+                    global_assumptions.add(getattr(Q, str(key))(x))
+                continue
+
             if assumptions[key]:
                 global_assumptions.add(getattr(Q, str(key))(x))
             elif assumptions[key] is False:

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -99,7 +99,22 @@ class Symbol(AtomicExpr, Boolean):
 
         """
         cls._sanitize(assumptions, cls)
-        return Symbol.__xnew_cached_(cls, name, **assumptions)
+
+        x = Symbol.__xnew_cached_(cls, name, **assumptions)
+
+        from sympy.assumptions.ask import Q
+        from sympy.assumptions.assume import global_assumptions
+
+        for key in assumptions.keys():
+            if not hasattr(Q, str(key)):
+                continue
+
+            if assumptions[key]:
+                global_assumptions.add(getattr(Q, str(key))(x))
+            elif assumptions[key] is False:
+                global_assumptions.add(~getattr(Q, str(key))(x))
+
+        return x
 
     def __new_stage2__(cls, name, **assumptions):
         if not isinstance(name, string_types):

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -579,7 +579,7 @@ def test_H32():  # issue 6558
 
 
 def test_H33():
-    A, B, C = symbols('A, B, C', commutatative=False)
+    A, B, C = symbols('A, B, C', commutative=False)
     assert (Commutator(A, Commutator(B, C))
         + Commutator(B, Commutator(C, A))
         + Commutator(C, Commutator(A, B))).doit().expand() == 0


### PR DESCRIPTION
``` python
In [2]: r = Symbol('r', real=True)
In [3]: x = Symbol('x')
In [4]: ask(Q.real(x))
In [5]: ask(Q.real(r))
Out[5]: True
In [6]: ask(Q.real(Symbol('spam')))
In [7]: ask(Q.real(Symbol('spam', real=True)))
Out[7]: True
In [8]: ask(Q.real(Symbol('spam')))
```
