### PR TITLE
give MaxMinBase an evalf routine

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -420,6 +420,10 @@ class MinMaxBase(Expr, LatticeOp):
             l.append(df * da)
         return Add(*l)
 
+    def evalf(self, prec=None, **options):
+        return self.func(*[a.evalf(prec, options) for a in self.args])
+    n = evalf
+
     @property
     def is_real(self):
         return fuzzy_and(arg.is_real for arg in self.args)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -109,6 +109,12 @@ def test_Min():
     f = Function('f')
     assert Min(1, 2*Min(f(1), 2))  # doesn't fail
 
+    # issue 7233
+    e = Min(0, x)
+    assert e.evalf == e.n
+    assert e.n().subs(x, .5) == 0
+    assert e.args == (0, x)
+
 
 def test_Max():
     from sympy.abc import x, y, z
@@ -158,6 +164,13 @@ def test_Max():
     a, b = Symbol('a', real=True), Symbol('b', real=True)
     # a and b are both real, Max(a, b) should be real
     assert Max(a, b).is_real
+
+    # issue 7233
+    e = Max(0, x)
+    assert e.evalf == e.n
+    assert e.n().subs(x, .5) == .5
+    assert e.args == (0, x)
+
 
 def test_root():
     from sympy.abc import x, y, z

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -112,8 +112,7 @@ def test_Min():
     # issue 7233
     e = Min(0, x)
     assert e.evalf == e.n
-    assert e.n().subs(x, .5) == 0
-    assert e.args == (0, x)
+    assert e.n().args == (0, x)
 
 
 def test_Max():
@@ -168,8 +167,7 @@ def test_Max():
     # issue 7233
     e = Max(0, x)
     assert e.evalf == e.n
-    assert e.n().subs(x, .5) == .5
-    assert e.args == (0, x)
+    assert e.n().args == (0, x)
 
 
 def test_root():


### PR DESCRIPTION
Although Or, And, etc... will not have a number as an
argument, Min and Max can. When the operations version
of _eval_evalf is called a call to as_independent is
made. This creates an x (=1) that is assumed to be an
argument of the object so Max(0,y).n() becomes Max(1, 0, y) -> Max(1, y).
To avoid this an evalf routine was added to handle MaxMinBase separately.

fixes #7233
