### PR TITLE
`ufuncify` makes actual ufuncs

### DIFF
--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -90,14 +90,14 @@ def runtest_autowrap_matrix_matrix(language, backend):
 def runtest_ufuncify(language, backend):
     has_module('numpy')
     a, b, c = symbols('a b c')
-    fabc = ufuncify([a, b, c], a*b + c, language=language, backend=backend)
-    facb = ufuncify([a, c, b], a*b + c, language=language, backend=backend)
+    fabc = ufuncify([a, b, c], a*b + c, backend=backend)
+    facb = ufuncify([a, c, b], a*b + c, backend=backend)
     grid = numpy.linspace(-2, 2, 50)
-    for b in numpy.linspace(-5, 4, 3):
-        for c in numpy.linspace(-1, 1, 3):
-            expected = grid*b + c
-            assert numpy.sum(numpy.abs(expected - fabc(grid, b, c))) < 1e-13
-            assert numpy.sum(numpy.abs(expected - facb(grid, c, b))) < 1e-13
+    b = numpy.linspace(-5, 4, 50)
+    c = numpy.linspace(-1, 1, 50)
+    expected = grid*b + c
+    assert numpy.all(numpy.sum(numpy.abs(expected - fabc(grid, b, c))) < 1e-13)
+    assert numpy.all(numpy.sum(numpy.abs(expected - facb(grid, c, b))) < 1e-13)
 
 #
 # tests of language-backend combinations
@@ -156,3 +156,12 @@ def test_autowrap_matrix_matrix_C_cython():
 def test_ufuncify_C_Cython():
     has_module('Cython')
     runtest_ufuncify('C', 'cython')
+
+
+# Numpy
+
+def test_ufuncify_numpy():
+    # This test doesn't use Cython, but if Cython works, then there is a valid
+    # C compiler, which is needed.
+    has_module('Cython')
+    runtest_ufuncify('C', 'numpy')

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -96,8 +96,8 @@ def runtest_ufuncify(language, backend):
     b = numpy.linspace(-5, 4, 50)
     c = numpy.linspace(-1, 1, 50)
     expected = grid*b + c
-    assert numpy.all(numpy.sum(numpy.abs(expected - fabc(grid, b, c))) < 1e-13)
-    assert numpy.all(numpy.sum(numpy.abs(expected - facb(grid, c, b))) < 1e-13)
+    numpy.testing.assert_allclose(fabc(grid, b, c), expected)
+    numpy.testing.assert_allclose(facb(grid, c, b), expected)
 
 #
 # tests of language-backend combinations

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -436,8 +436,8 @@ def _validate_backend_language(backend, language):
 @cacheit
 @doctest_depends_on(exe=('f2py', 'gfortran'), modules=('numpy',))
 def autowrap(
-    expr, language=None, backend='f2py', tempdir=None, args=None, flags=(),
-        verbose=False, helpers=()):
+    expr, language=None, backend='f2py', tempdir=None, args=None, flags=None,
+    verbose=False, helpers=None):
     """Generates python callable binaries based on the math expression.
 
     Parameters
@@ -456,16 +456,16 @@ def autowrap(
         the generated code and the wrapper input files are left intact in the
         specified path.
     args : iterable, optional
-        A tuple of symbols. Specifies the argument sequence for the function.
+        An iterable of symbols. Specifies the argument sequence for the function.
     flags : iterable, optional
-        Additional option flags that will be passed to the backend
+        Additional option flags that will be passed to the backend.
     verbose : bool, optional
         If True, autowrap will not mute the command line backends. This can be
         helpful for debugging.
-    helpers : list, optional
+    helpers : iterable, optional
         Used to define auxillary expressions needed for the main expr. If the
         main expression needs to call a specialized function it should be put
-        in the ``helpers`` list. Autowrap will then make sure that the
+        in the ``helpers`` iterable. Autowrap will then make sure that the
         compiled main expression can link to the helper routine. Items should
         be tuples with (<funtion_name>, <sympy_expression>, <arguments>). It
         is mandatory to supply an argument sequence to helper routines.
@@ -482,6 +482,9 @@ def autowrap(
         _validate_backend_language(backend, language)
     else:
         language = _infer_language(backend)
+
+    helpers = helpers if helpers else ()
+    flags = flags if flags else ()
 
     code_generator = get_code_generator(language, "autowrap")
     CodeWrapperClass = _get_code_wrapper_class(backend)
@@ -753,14 +756,14 @@ class UfuncifyCodeWrapper(CodeWrapper):
 @cacheit
 @doctest_depends_on(exe=('f2py', 'gfortran', 'gcc'), modules=('numpy',))
 def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
-        flags=(), verbose=False, helpers=()):
+        flags=None, verbose=False, helpers=None):
     """Generates a binary function that supports broadcasting on numpy arrays.
 
     Parameters
     ----------
-    args
-        Either a Symbol or a tuple of symbols. Specifies the argument sequence
-        for the function.
+    args : iterable
+        Either a Symbol or an iterable of symbols. Specifies the argument
+        sequence for the function.
     expr
         A SymPy expression that defines the element wise operation.
     language : string, optional
@@ -779,10 +782,10 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
     verbose : bool, optional
         If True, autowrap will not mute the command line backends. This can be
         helpful for debugging.
-    helpers : list, optional
+    helpers : iterable, optional
         Used to define auxillary expressions needed for the main expr. If the
         main expression needs to call a specialized function it should be put
-        in the ``helpers`` list. Autowrap will then make sure that the
+        in the ``helpers`` iterable. Autowrap will then make sure that the
         compiled main expression can link to the helper routine. Items should
         be tuples with (<funtion_name>, <sympy_expression>, <arguments>). It
         is mandatory to supply an argument sequence to helper routines.
@@ -839,6 +842,9 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
         _validate_backend_language(backend, language)
     else:
         language = _infer_language(backend)
+
+    helpers = helpers if helpers else ()
+    flags = flags if flags else ()
 
     if backend.upper() == 'NUMPY':
         routine = Routine('autofunc', expr, args)

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -455,6 +455,8 @@ def autowrap(
         Path to directory for temporary files. If this argument is supplied,
         the generated code and the wrapper input files are left intact in the
         specified path.
+    args : iterable, optional
+        A tuple of symbols. Specifies the argument sequence for the function.
     flags : iterable, optional
         Additional option flags that will be passed to the backend
     verbose : bool, optional
@@ -748,6 +750,7 @@ class UfuncifyCodeWrapper(CodeWrapper):
         return py_in, py_out
 
 
+@cacheit
 @doctest_depends_on(exe=('f2py', 'gfortran', 'gcc'), modules=('numpy',))
 def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
         flags=(), verbose=False, helpers=()):
@@ -801,7 +804,7 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
     >>> from sympy.utilities.autowrap import ufuncify
     >>> from sympy.abc import x, y
     >>> import numpy as np
-    >>> f = ufuncify([x, y], y + x**2)
+    >>> f = ufuncify((x, y), y + x**2)
     >>> type(f)
     numpy.ufunc
     >>> f([1, 2, 3], 2)
@@ -813,12 +816,12 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
     1-dimensional arrays. The F2Py backend will perform type conversion, but
     the Cython backend will error if the inputs are not of the expected type.
 
-    >>> f_fortran = ufuncify([x, y], y + x**2, backend='F2Py')
+    >>> f_fortran = ufuncify((x, y), y + x**2, backend='F2Py')
     >>> f_fortran(1, 2)
     3
     >>> f_fortran(numpy.array([1, 2, 3]), numpy.array([1.0, 2.0, 3.0]))
     array([2.,  6.,  12.])
-    >>> f_cython = ufuncify([x, y], y + x**2, backend='Cython')
+    >>> f_cython = ufuncify((x, y), y + x**2, backend='Cython')
     >>> f_cython(1, 2)
     Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
@@ -828,9 +831,9 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
     """
 
     if isinstance(args, Symbol):
-        args = [args]
+        args = (args,)
     else:
-        args = list(args)
+        args = tuple(args)
 
     if language:
         _validate_backend_language(backend, language)

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -6,7 +6,7 @@ import tempfile
 import shutil
 
 from sympy.utilities.autowrap import autowrap, binary_function, CythonCodeWrapper, \
-    ufuncify
+    ufuncify, UfuncifyCodeWrapper, CodeWrapper
 from sympy.utilities.codegen import Routine, CCodeGen, CodeGenArgumentListError
 from sympy.utilities.pytest import raises
 from sympy.core import symbols, Eq
@@ -134,7 +134,95 @@ def test_binary_function():
     assert f._imp_() == str(x + y)
 
 
-def test_ufuncify():
-    x, y = symbols('x y')
-    f = ufuncify((x, y), x + y, backend='dummy')
-    assert f() == "f(_x[_i], y)"
+def test_ufuncify_source():
+    from sympy import Equality
+    x, y, z = symbols('x,y,z')
+    code_wrapper = UfuncifyCodeWrapper(CCodeGen("ufuncify"))
+    CodeWrapper._module_counter = 0
+    routine = Routine("test", x + y + z)
+    source = get_string(code_wrapper.dump_c, [routine])
+    expected = """\
+#include "Python.h"
+#include "math.h"
+#include "numpy/ndarraytypes.h"
+#include "numpy/ufuncobject.h"
+#include "numpy/halffloat.h"
+#include "file.h"
+
+static PyMethodDef wrapper_module_0Methods[] = {
+        {NULL, NULL, 0, NULL}
+};
+
+static void test_ufunc(char **args, npy_intp *dimensions, npy_intp* steps, void* data)
+{
+    npy_intp i;
+    npy_intp n = dimensions[0];
+    char *in0 = args[0];
+    char *in1 = args[1];
+    char *in2 = args[2];
+    char *out1 = args[3];
+    npy_intp in0_step = steps[0];
+    npy_intp in1_step = steps[1];
+    npy_intp in2_step = steps[2];
+    npy_intp out1_step = steps[3];
+    for (i = 0; i < n; i++) {
+        *((double *)out1) = test(*(double *)in0, *(double *)in1, *(double *)in2);
+        in0 += in0_step;
+        in1 += in1_step;
+        in2 += in2_step;
+        out1 += out1_step;
+    }
+}
+PyUFuncGenericFunction test_funcs[1] = {&test_ufunc};
+static char test_types[4] = {NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE};
+static void *test_data[1] = {NULL};
+
+#if PY_VERSION_HEX >= 0x03000000
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "wrapper_module_0",
+    NULL,
+    -1,
+    wrapper_module_0Methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC PyInit_wrapper_module_0(void)
+{
+    PyObject *m, *d;
+    PyObject *ufunc0;
+    m = PyModule_Create(&moduledef);
+    if (!m) {
+        return NULL;
+    }
+    import_array();
+    import_umath();
+    d = PyModule_GetDict(m);
+    ufunc0 = PyUFunc_FromFuncAndData(test_funcs, test_data, test_types, 1, 3, 1,
+            PyUFunc_None, "wrapper_module_0", "Created in SymPy with Ufuncify", 0);
+    PyDict_SetItemString(d, "test", ufunc0);
+    Py_DECREF(ufunc0);
+    return m;
+}
+#else
+PyMODINIT_FUNC initwrapper_module_0(void)
+{
+    PyObject *m, *d;
+    PyObject *ufunc0;
+    m = Py_InitModule("wrapper_module_0", wrapper_module_0Methods);
+    if (m == NULL) {
+        return;
+    }
+    import_array();
+    import_umath();
+    d = PyModule_GetDict(m);
+    ufunc0 = PyUFunc_FromFuncAndData(test_funcs, test_data, test_types, 1, 3, 1,
+            PyUFunc_None, "wrapper_module_0", "Created in SymPy with Ufuncify", 0);
+    PyDict_SetItemString(d, "test", ufunc0);
+    Py_DECREF(ufunc0);
+}
+#endif"""
+    assert source == expected


### PR DESCRIPTION
This PR modifies `ufuncify` to create actual `numpy.ufunc`s.

```
In [1]: from sympy import *

In [2]: a, b, c = symbols('a, b, c')

In [3]: expr = (sin(a) + sqrt(b)*c**2)/2

In [4]: from sympy.utilities.autowrap import ufuncify

In [5]: func = ufuncify((a, b, c), expr)

In [6]: func(1, 2, 3)
Out[6]: 6.7846965230828769

In [7]: func([1, 2, 3, 4, 5], [6, 7, 8, 9, 10], 3)
Out[7]: array([ 11.44343933,  12.36052961,  12.79848207,  13.12159875,  13.75078733])
```

TODO:
- [x] Cleanup code. It's ugly and messy.
- [x] Tests
- [x] Docs
- [x] Optimizations (inline ufunc'ed function call?)
