### PR TITLE
Printing: print x**-1.0 differently from 1/x

### DIFF
--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -359,6 +359,36 @@ x\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+    # not the same as 1/x
+    expr = x**-1.0
+    ascii_str = \
+"""\
+ -1.0\n\
+x    \
+"""
+    ucode_str = \
+("""\
+ -1.0\n\
+x    \
+""")
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    # see issue #2860
+    expr = S(2)**-1.0
+    ascii_str = \
+"""\
+ -1.0\n\
+2    \
+"""
+    ucode_str = \
+("""\
+ -1.0\n\
+2    \
+""")
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
     expr = y*x**-2
     ascii_str = \
 """\

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -485,7 +485,8 @@ class StrPrinter(Printer):
                 # Note: Don't test "expr.exp == -S.Half" here, because that will
                 # match -0.5, which we don't want.
                 return "1/sqrt(%s)" % self._print(expr.base)
-            if expr.exp == -1:
+            if expr.exp is -S.One:
+                # Similarly to the S.Half case, don't test with "==" here.
                 return '1/%s' % self.parenthesize(expr.base, PREC)
 
         e = self.parenthesize(expr.exp, PREC)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -402,7 +402,10 @@ def test_Pow():
     assert str(x**Rational(1, 3)) == "x**(1/3)"
     assert str(1/x**Rational(1, 3)) == "x**(-1/3)"
     assert str(sqrt(sqrt(x))) == "x**(1/4)"
-    assert str(x**-1.0) == '1/x'
+    # not the same as x**-1
+    assert str(x**-1.0) == 'x**(-1.0)'
+    # see issue #2860
+    assert str(S(2)**-1.0) == '2**(-1.0)'
 
 
 def test_sqrt():


### PR DESCRIPTION
`x**-1.0` and `x**-1` should print differently.  Fixed this and added
tests.  Pretty printing seemed to work already but tests added.
Issue #2860 is related and seems fixed; added tests.
