### PR TITLE
test_numbers: fix minor typo in a test so both >= and <= are tested

### DIFF
--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -335,7 +335,7 @@ def test_Rational_cmp():
     assert (n1 < S.NaN) is S.false
     assert (n1 <= S.NaN) is S.false
     assert (n1 > S.NaN) is S.false
-    assert (n1 <= S.NaN) is S.false
+    assert (n1 >= S.NaN) is S.false
 
 
 def test_Float():


### PR DESCRIPTION
The test did `<=` twice.  Use `>=` for one of them.
