### PR TITLE
modify tests while maintaining coverage

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2426,9 +2426,7 @@ class Expr(Basic, EvalfMixin):
                         if newn != ngot:
                             ndo = n + (n - ngot)*more/(newn - ngot)
                             s1 = self._eval_nseries(x, n=ndo, logx=logx)
-                            print(1)
                             while s1.getn() < n:
-                                print(2)
                                 s1 = self._eval_nseries(x, n=ndo, logx=logx)
                                 ndo += 1
                             break

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2426,7 +2426,9 @@ class Expr(Basic, EvalfMixin):
                         if newn != ngot:
                             ndo = n + (n - ngot)*more/(newn - ngot)
                             s1 = self._eval_nseries(x, n=ndo, logx=logx)
+                            print(1)
                             while s1.getn() < n:
+                                print(2)
                                 s1 = self._eval_nseries(x, n=ndo, logx=logx)
                                 ndo += 1
                             break

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -5,7 +5,6 @@ from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.series.order import O
-from sympy.utilities.pytest import slow
 
 
 def test_rational():
@@ -291,18 +290,7 @@ def test_issue_6782():
 
 def test_issue_6653():
     x = Symbol('x')
-    assert (1 / sqrt(1 + cos(x) * sin(x**2))).series(x, 0, 7) == \
-        1 - x**2/2 + 5*x**4/8 - 5*x**6/8 + O(x**7)
-    assert (1 / sqrt(1 + cos(x) * sin(x**2))).series(x, 0, 8) == \
-        1 - x**2/2 + 5*x**4/8 - 5*x**6/8 + O(x**8)
-
-
-@slow
-def test_issue_6653s():
-    x = Symbol('x')
-    assert (1 / sqrt(1 + cos(x) * sin(x**2))).series(x, 0, 15) == \
-        1 - x**2/2 + 5*x**4/8 - 5*x**6/8 + 4039*x**8/5760 - 5393*x**10/6720 + \
-        13607537*x**12/14515200 - 532056047*x**14/479001600 + O(x**15)
+    assert (1 / sqrt(1 + sin(x**2))).series(x, 0, 3) == 1 - x**2/2 + O(x**3)
 
 
 def test_issue_6429():


### PR DESCRIPTION
This eliminates a slow test and two others, replacing them with an expression that failed the same way in the old master at 0fa7b9730e56759e5f4bc3752143f5cfd9279f4 as the expression that identified the issue. In addition, all the added code is covered by this expression. It also runs in a couple of seconds instead of minutes.
