### PR TITLE
update fastcache to most recent version in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
         - SPLIT="4/4"
 before_install:
   - if [[ "${FASTCACHE}" != "false" ]]; then
-      pip install "fastcache==0.4.0";
+      pip install "fastcache==0.4.3";
     fi
   - if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
       pip uninstall -y numpy;


### PR DESCRIPTION
The most recent version (0.4.3) fixes the bug which resulted in a `stack overflow` instead of a `RuntimeError` when reaching the maximum recursion limit.  See #7918 and this [fastcache PR](https://github.com/pbrady/fastcache/pull/21) for the discussion.
