### PR TITLE
Rename assumptions: bounded -> finite, unbounded -> infinite

### DIFF
--- a/doc/src/guide.rst
+++ b/doc/src/guide.rst
@@ -285,7 +285,7 @@ How to create a new function with one variable::
                 if not isinstance(coeff, Basic.One):
                     return cls(coeff) * cls(Basic.Mul(*terms))
 
-        is_bounded = True
+        is_finite = True
 
         def _eval_conjugate(self):
             return self

--- a/sympy/benchmarks/bench_meijerint.py
+++ b/sympy/benchmarks/bench_meijerint.py
@@ -17,10 +17,10 @@ apos, bpos, cpos, dpos, posk, p = symbols('a b c d k p', positive=True)
 k = Symbol('k', real=True)
 negk = Symbol('k', negative=True)
 
-mu1, mu2 = symbols('mu1 mu2', real=True, nonzero=True, bounded=True)
+mu1, mu2 = symbols('mu1 mu2', real=True, nonzero=True, finite=True)
 sigma1, sigma2 = symbols('sigma1 sigma2', real=True, nonzero=True,
-                         bounded=True, positive=True)
-rate = Symbol('lambda', real=True, positive=True, bounded=True)
+                         finite=True, positive=True)
+rate = Symbol('lambda', real=True, positive=True, finite=True)
 
 
 def normal(x, mu, sigma):

--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -260,7 +260,7 @@ def deltasummation(f, limit, no_piecewise=False):
 
     >>> from sympy import oo, symbols
     >>> from sympy.abc import k
-    >>> i, j = symbols('i, j', integer=True, bounded=True)
+    >>> i, j = symbols('i, j', integer=True, finite=True)
     >>> from sympy.concrete.delta import deltasummation
     >>> from sympy import KroneckerDelta, Piecewise
     >>> deltasummation(KroneckerDelta(i, k), (k, -oo, oo))

--- a/sympy/concrete/tests/test_delta.py
+++ b/sympy/concrete/tests/test_delta.py
@@ -4,7 +4,7 @@ from sympy.core import Eq, S, symbols, oo
 from sympy.functions import KroneckerDelta as KD, Piecewise, piecewise_fold
 from sympy.logic import And
 
-i, j, k, l, m = symbols("i j k l m", integer=True, bounded=True)
+i, j, k, l, m = symbols("i j k l m", integer=True, finite=True)
 x, y = symbols("x y", commutative=False)
 
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -512,7 +512,7 @@ class Add(Expr, AssocOp):
             return False
         for a in args:
             ispos = a.is_positive
-            ubound = a.is_unbounded
+            ubound = a.is_infinite
             if ubound:
                 unbounded.add(ispos)
                 if len(unbounded) > 1:
@@ -554,7 +554,7 @@ class Add(Expr, AssocOp):
             return False
         for a in args:
             isneg = a.is_negative
-            ubound = a.is_unbounded
+            ubound = a.is_infinite
             if ubound:
                 unbounded.add(isneg)
                 if len(unbounded) > 1:
@@ -698,7 +698,7 @@ class Add(Expr, AssocOp):
         if not self.is_Add:
             return self.as_leading_term(x)
 
-        unbounded = [t for t in self.args if t.is_unbounded]
+        unbounded = [t for t in self.args if t.is_infinite]
 
         self = self.func(*[t.as_leading_term(x) for t in self.args]).removeO()
         if not self:

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -512,8 +512,8 @@ class Add(Expr, AssocOp):
             return False
         for a in args:
             ispos = a.is_positive
-            ubound = a.is_infinite
-            if ubound:
+            infinite = a.is_infinite
+            if infinite:
                 unbounded.add(ispos)
                 if len(unbounded) > 1:
                     return
@@ -529,7 +529,7 @@ class Add(Expr, AssocOp):
             elif a.is_zero:
                 continue
 
-            if ubound is None:
+            if infinite is None:
                 return
             unknown_sign = True
 
@@ -554,8 +554,8 @@ class Add(Expr, AssocOp):
             return False
         for a in args:
             isneg = a.is_negative
-            ubound = a.is_infinite
-            if ubound:
+            infinite = a.is_infinite
+            if infinite:
                 unbounded.add(isneg)
                 if len(unbounded) > 1:
                     return
@@ -571,7 +571,7 @@ class Add(Expr, AssocOp):
             elif a.is_zero:
                 continue
 
-            if ubound is None:
+            if infinite is None:
                 return
             unknown_sign = True
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -130,7 +130,7 @@ class Add(Expr, AssocOp):
             # 3 or NaN
             elif o.is_Number:
                 if (o is S.NaN or coeff is S.ComplexInfinity and
-                        o.is_bounded is False):
+                        o.is_finite is False):
                     # we know for sure the result will be nan
                     return [S.NaN], [], None
                 if coeff.is_Number:
@@ -141,7 +141,7 @@ class Add(Expr, AssocOp):
                 continue
 
             elif o is S.ComplexInfinity:
-                if coeff.is_bounded is False:
+                if coeff.is_finite is False:
                     # we know for sure the result will be nan
                     return [S.NaN], [], None
                 coeff = S.ComplexInfinity
@@ -216,11 +216,11 @@ class Add(Expr, AssocOp):
         # oo, -oo
         if coeff is S.Infinity:
             newseq = [f for f in newseq if not
-                      (f.is_nonnegative or f.is_real and f.is_bounded)]
+                      (f.is_nonnegative or f.is_real and f.is_finite)]
 
         elif coeff is S.NegativeInfinity:
             newseq = [f for f in newseq if not
-                      (f.is_nonpositive or f.is_real and f.is_bounded)]
+                      (f.is_nonpositive or f.is_real and f.is_finite)]
 
         if coeff is S.ComplexInfinity:
             # zoo might be
@@ -231,7 +231,7 @@ class Add(Expr, AssocOp):
             # change the zoo nature; if unbounded a NaN condition could result
             # if the unbounded symbol had sign opposite of the unbounded
             # portion of zoo, e.g., unbounded_real - unbounded_real.
-            newseq = [c for c in newseq if not (c.is_bounded and
+            newseq = [c for c in newseq if not (c.is_finite and
                                                 c.is_real is not None)]
 
         # process O(x)
@@ -451,8 +451,8 @@ class Add(Expr, AssocOp):
         (a.is_complex for a in self.args), quick_exit=True)
     _eval_is_antihermitian = lambda self: _fuzzy_group(
         (a.is_antihermitian for a in self.args), quick_exit=True)
-    _eval_is_bounded = lambda self: _fuzzy_group(
-        (a.is_bounded for a in self.args), quick_exit=True)
+    _eval_is_finite = lambda self: _fuzzy_group(
+        (a.is_finite for a in self.args), quick_exit=True)
     _eval_is_hermitian = lambda self: _fuzzy_group(
         (a.is_hermitian for a in self.args), quick_exit=True)
     _eval_is_integer = lambda self: _fuzzy_group(

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -63,6 +63,8 @@ from sympy.core.compatibility import integer_types, with_metaclass
 # imaginary     -- http://en.wikipedia.org/wiki/Imaginary_number
 # composite     -- http://en.wikipedia.org/wiki/Composite_number
 # finite        -- http://en.wikipedia.org/wiki/Finite
+#                  https://docs.python.org/3/library/math.html#math.isfinite
+#                  http://docs.scipy.org/doc/numpy/reference/generated/numpy.isfinite.html
 # irrational    -- http://en.wikipedia.org/wiki/Irrational_number
 # transcendental -- http://en.wikipedia.org/wiki/Transcendental_number
 # ...

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -25,13 +25,13 @@ Here follows a list of possible assumption names:
                         of algebraic numbers
     - transcendental - object can have only values from the set
                         of transcendental numbers
-    - bounded       - object absolute value is bounded
+    - finite        - object absolute value is bounded
     - positive      - object can have only positive values
     - negative      - object can have only negative values
     - nonpositive      - object can have only nonpositive values
     - nonnegative      - object can have only nonnegative values
     - irrational    - object value cannot be represented exactly by Rational
-    - unbounded     - object value is arbitrarily large
+    - infinite      - object value is arbitrarily large
 
 Implementation note: assumption values are stored in
 ._assumptions dictionary or are returned by getter methods (with
@@ -101,7 +101,7 @@ _assume_rules = FactRules([
 
     'imaginary      ->  !real',
 
-    '!bounded     ==  unbounded',
+    '!finite        ==  infinite',
     'noninteger     ==  real & !integer',
     '!zero        ==  nonzero',
 ])

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1588,6 +1588,16 @@ class Basic(with_metaclass(ManagedProperties)):
                 else:
                     return self
 
+    @property
+    @deprecated(useinstead="is_finite", issue=8071, deprecated_since_version="0.7.6")
+    def is_bounded(self):
+        return super(Basic, self).__getattribute__('is_finite')
+
+    @property
+    @deprecated(useinstead="is_infinite", issue=8071, deprecated_since_version="0.7.6")
+    def is_unbounded(self):
+        return super(Basic, self).__getattribute__('is_infinite')
+
 
 class Atom(Basic):
     """

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -393,7 +393,7 @@ def add_terms(terms, prec, target_prec):
     special = []
     for t in terms:
         arg = C.Float._new(t[0], 1)
-        if arg is S.NaN or arg.is_unbounded:
+        if arg is S.NaN or arg.is_infinite:
             special.append(arg)
     if special:
         from sympy.core.add import Add
@@ -503,7 +503,7 @@ def evalf_mul(v, prec, options):
         if arg[0] is None:
             continue
         arg = C.Float._new(arg[0], 1)
-        if arg is S.NaN or arg.is_unbounded:
+        if arg is S.NaN or arg.is_infinite:
             special.append(arg)
     if special:
         from sympy.core.mul import Mul

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2411,7 +2411,7 @@ class Expr(Basic, EvalfMixin):
 
         if x.is_positive is x.is_negative is None or x.is_Symbol is not True:
             # replace x with an x that has a positive assumption
-            xpos = C.Dummy('x', positive=True, bounded=True)
+            xpos = C.Dummy('x', positive=True, finite=True)
             rv = self.subs(x, xpos).series(xpos, x0, n, dir, logx=logx)
             if n is None:
                 return (s.subs(xpos, x) for s in rv)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -558,7 +558,7 @@ class Function(Application, Expr):
         from sympy.sets.sets import FiniteSet
         args = self.args
         args0 = [t.limit(x, 0) for t in args]
-        if any(t.is_bounded is False for t in args0):
+        if any(t.is_finite is False for t in args0):
             from sympy import oo, zoo, nan
             # XXX could use t.as_leading_term(x) here but it's a little
             # slower
@@ -602,7 +602,7 @@ class Function(Application, Expr):
                 #for example when e = sin(x+1) or e = sin(cos(x))
                 #let's try the general algorithm
                 term = e.subs(x, S.Zero)
-                if term.is_bounded is False or term is S.NaN:
+                if term.is_finite is False or term is S.NaN:
                     raise PoleError("Cannot expand %s around 0" % (self))
                 series = term
                 fact = S.One
@@ -616,7 +616,7 @@ class Function(Application, Expr):
                     if subs is S.NaN:
                         # try to evaluate a limit if we have to
                         subs = e.limit(_x, S.Zero)
-                    if subs.is_bounded is False:
+                    if subs.is_finite is False:
                         raise PoleError("Cannot expand %s around 0" % (self))
                     term = subs*(x**i)/fact
                     term = term.expand()

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -956,8 +956,8 @@ class Mul(Expr, AssocOp):
     def _eval_is_algebraic_expr(self, syms):
         return all(term._eval_is_algebraic_expr(syms) for term in self.args)
 
-    _eval_is_bounded = lambda self: _fuzzy_group(
-        a.is_bounded for a in self.args)
+    _eval_is_finite = lambda self: _fuzzy_group(
+        a.is_finite for a in self.args)
     _eval_is_commutative = lambda self: _fuzzy_group(
         a.is_commutative for a in self.args)
     _eval_is_complex = lambda self: _fuzzy_group(
@@ -986,7 +986,7 @@ class Mul(Expr, AssocOp):
                     return  # 0*oo is nan and nan.is_zero is None
                 zero = True
             else:
-                if not a.is_bounded:
+                if not a.is_finite:
                     if zero:
                         return  # 0*oo is nan and nan.is_zero is None
                     unbound = True
@@ -1026,7 +1026,7 @@ class Mul(Expr, AssocOp):
                     if not z and zero is False:
                         zero = z
                     elif z:
-                        if all(a.is_bounded for a in self.args):
+                        if all(a.is_finite for a in self.args):
                             return True
                         return
             elif t.is_real is False:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -304,7 +304,7 @@ class Number(AtomicExpr):
             return -new
         return self  # there is no other possibility
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         return True
 
     @classmethod
@@ -723,7 +723,7 @@ class Float(Number):
     def _as_mpf_op(self, prec):
         return self._mpf_, max(prec, self._prec)
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         if self._mpf_ in (_mpf_inf, _mpf_ninf):
             return False
         return True
@@ -2131,7 +2131,7 @@ class Infinity(with_metaclass(Singleton, Number)):
 
     is_commutative = True
     is_positive = True
-    is_bounded = False
+    is_finite = False
     is_integer = None
     is_rational = None
     is_algebraic = None
@@ -2291,7 +2291,7 @@ class Infinity(with_metaclass(Singleton, Number)):
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         if other.is_real:
-            if other.is_bounded or other is S.NegativeInfinity:
+            if other.is_finite or other is S.NegativeInfinity:
                 return S.false
             elif other is S.Infinity:
                 return S.true
@@ -2306,7 +2306,7 @@ class Infinity(with_metaclass(Singleton, Number)):
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         if other.is_real:
-            if other.is_bounded or other is S.NegativeInfinity:
+            if other.is_finite or other is S.NegativeInfinity:
                 return S.true
             elif other is S.Infinity:
                 return S.false
@@ -2347,7 +2347,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     is_commutative = True
     is_real = True
     is_positive = False
-    is_bounded = False
+    is_finite = False
     is_integer = None
     is_rational = None
     is_number = True
@@ -2503,7 +2503,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         if other.is_real:
-            if other.is_bounded or other is S.Infinity:
+            if other.is_finite or other is S.Infinity:
                 return S.true
             elif other is S.NegativeInfinity:
                 return S.false
@@ -2542,7 +2542,7 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         if other.is_real:
-            if other.is_bounded or other is S.Infinity:
+            if other.is_finite or other is S.Infinity:
                 return S.false
             elif other is S.NegativeInfinity:
                 return S.true
@@ -2603,7 +2603,7 @@ class NaN(with_metaclass(Singleton, Number)):
     is_transcendental = None
     is_integer = None
     is_comparable = False
-    is_bounded = None
+    is_finite = None
     is_zero = None
     is_prime = None
     is_positive = None
@@ -2718,7 +2718,7 @@ class ComplexInfinity(with_metaclass(Singleton, AtomicExpr)):
     """
 
     is_commutative = True
-    is_bounded = False
+    is_finite = False
     is_real = None
     is_number = True
 
@@ -2757,7 +2757,7 @@ zoo = S.ComplexInfinity
 class NumberSymbol(AtomicExpr):
 
     is_commutative = True
-    is_bounded = True
+    is_finite = True
     is_number = True
 
     __slots__ = []
@@ -3197,7 +3197,7 @@ class ImaginaryUnit(with_metaclass(Singleton, AtomicExpr)):
 
     is_commutative = True
     is_imaginary = True
-    is_bounded = True
+    is_finite = True
     is_number = True
     is_algebraic = True
     is_transcendental = False

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1169,8 +1169,8 @@ class Pow(Expr):
             """return the integer value (if possible) of e and a
             flag indicating whether it is bounded or not."""
             n = e.limit(x, 0)
-            unbounded = n.is_infinite
-            if not unbounded:
+            infinite = n.is_infinite
+            if not infinite:
                 # XXX was int or floor intended? int used to behave like floor
                 # so int(-Rational(1, 2)) returned -1 rather than int's 0
                 try:
@@ -1182,12 +1182,12 @@ class Pow(Expr):
                     except TypeError:
                         pass  # hope that base allows this to be resolved
                 n = _sympify(n)
-            return n, unbounded
+            return n, infinite
 
         order = O(x**n, x)
-        ei, unbounded = e2int(e)
+        ei, infinite = e2int(e)
         b0 = b.limit(x, 0)
-        if unbounded and (b0 is S.One or b0.has(Symbol)):
+        if infinite and (b0 is S.One or b0.has(Symbol)):
             # XXX what order
             if b0 is S.One:
                 resid = (b - 1)
@@ -1200,7 +1200,7 @@ class Pow(Expr):
             return b0**ei
 
         if (b0 is S.Zero or b0.is_infinite):
-            if unbounded is not False:
+            if infinite is not False:
                 return b0**e  # XXX what order
 
             if not ei.is_number:  # if not, how will we proceed?
@@ -1251,21 +1251,21 @@ class Pow(Expr):
                 rv += order
             return rv
 
-        # either b0 is bounded but neither 1 nor 0 or e is unbounded
+        # either b0 is bounded but neither 1 nor 0 or e is infinite
         # b -> b0 + (b-b0) -> b0 * (1 + (b/b0-1))
         o2 = order*(b0**-e)
         z = (b/b0 - 1)
         o = O(z, x)
         #r = self._compute_oseries3(z, o2, self.taylor_term)
         if o is S.Zero or o2 is S.Zero:
-            unbounded = True
+            infinite = True
         else:
             if o.expr.is_number:
                 e2 = log(o2.expr*x)/log(x)
             else:
                 e2 = log(o2.expr)/log(o.expr)
-            n, unbounded = e2int(e2)
-        if unbounded:
+            n, infinite = e2int(e2)
+        if infinite:
             # requested accuracy gives infinite series,
             # order is probably non-polynomial e.g. O(exp(-1/x), x).
             r = 1 + z

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -464,7 +464,7 @@ class Pow(Expr):
         if self.exp.is_negative:
             if self.base.is_zero:
                 return False
-            if self.base.is_unbounded:
+            if self.base.is_infinite:
                 return True
         c1 = self.base.is_finite
         if c1 is None:
@@ -1169,7 +1169,7 @@ class Pow(Expr):
             """return the integer value (if possible) of e and a
             flag indicating whether it is bounded or not."""
             n = e.limit(x, 0)
-            unbounded = n.is_unbounded
+            unbounded = n.is_infinite
             if not unbounded:
                 # XXX was int or floor intended? int used to behave like floor
                 # so int(-Rational(1, 2)) returned -1 rather than int's 0
@@ -1199,7 +1199,7 @@ class Pow(Expr):
 
             return b0**ei
 
-        if (b0 is S.Zero or b0.is_unbounded):
+        if (b0 is S.Zero or b0.is_infinite):
             if unbounded is not False:
                 return b0**e  # XXX what order
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -354,7 +354,7 @@ class Pow(Expr):
                 return True
             if self.exp.is_negative:
                 return False
-        if c1 and e.is_negative and e.is_bounded:  # int**neg
+        if c1 and e.is_negative and e.is_finite:  # int**neg
             return False
         if b.is_Number and e.is_Number:
             # int**nonneg or rat**?
@@ -460,16 +460,16 @@ class Pow(Expr):
             elif self.base is S.NegativeOne:
                 return True
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         if self.exp.is_negative:
             if self.base.is_zero:
                 return False
             if self.base.is_unbounded:
                 return True
-        c1 = self.base.is_bounded
+        c1 = self.base.is_finite
         if c1 is None:
             return
-        c2 = self.exp.is_bounded
+        c2 = self.exp.is_finite
         if c2 is None:
             return
         if c1 and c2:

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -68,6 +68,20 @@ class Symbol(AtomicExpr, Boolean):
 
         # sanitize other assumptions so 1 -> True and 0 -> False
         for key in list(assumptions.keys()):
+            from collections import defaultdict
+            from sympy.utilities.exceptions import SymPyDeprecationWarning
+            keymap = defaultdict(lambda: None)
+            keymap.update({'bounded': 'finite', 'unbounded': 'infinite'})
+            if keymap[key]:
+                SymPyDeprecationWarning(
+                    feature="%s assumption" % key,
+                    useinstead="%s" % keymap[key],
+                    issue=8071,
+                    deprecated_since_version="0.7.6").warn()
+                assumptions[keymap[key]] = assumptions[key]
+                assumptions.pop(key)
+                key = keymap[key]
+
             v = assumptions[key]
             if v is None:
                 assumptions.pop(key)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -366,22 +366,22 @@ def test_Add_Mul_is_integer():
     assert (1 + (1 + sqrt(3))*(-sqrt(3) + 1)).is_integer is not False
 
 
-def test_Add_Mul_is_bounded():
+def test_Add_Mul_is_finite():
     x = Symbol('x', real=True, bounded=False)
 
-    assert sin(x).is_bounded is True
-    assert (x*sin(x)).is_bounded is False
-    assert (1024*sin(x)).is_bounded is True
-    assert (sin(x)*exp(x)).is_bounded is not True
-    assert (sin(x)*cos(x)).is_bounded is True
-    assert (x*sin(x)*exp(x)).is_bounded is not True
+    assert sin(x).is_finite is True
+    assert (x*sin(x)).is_finite is False
+    assert (1024*sin(x)).is_finite is True
+    assert (sin(x)*exp(x)).is_finite is not True
+    assert (sin(x)*cos(x)).is_finite is True
+    assert (x*sin(x)*exp(x)).is_finite is not True
 
-    assert (sin(x) - 67).is_bounded is True
-    assert (sin(x) + exp(x)).is_bounded is not True
-    assert (1 + x).is_bounded is False
-    assert (1 + x**2 + (1 + x)*(1 - x)).is_bounded is None
-    assert (sqrt(2)*(1 + x)).is_bounded is False
-    assert (sqrt(2)*(1 + x)*(1 - x)).is_bounded is False
+    assert (sin(x) - 67).is_finite is True
+    assert (sin(x) + exp(x)).is_finite is not True
+    assert (1 + x).is_finite is False
+    assert (1 + x**2 + (1 + x)*(1 - x)).is_finite is None
+    assert (sqrt(2)*(1 + x)).is_finite is False
+    assert (sqrt(2)*(1 + x)*(1 - x)).is_finite is False
 
 
 def test_Mul_is_even_odd():
@@ -986,21 +986,21 @@ def test_real_Pow():
     assert (k**(I*pi/log(k))).is_real
 
 
-def test_Pow_is_bounded():
+def test_Pow_is_finite():
     x = Symbol('x', real=True)
     p = Symbol('p', positive=True)
     n = Symbol('n', negative=True)
 
-    assert (x**2).is_bounded is None  # x could be oo
-    assert (x**x).is_bounded is None  # ditto
-    assert (p**x).is_bounded is None  # ditto
-    assert (n**x).is_bounded is None  # ditto
-    assert (1/S.Pi).is_bounded
-    assert (sin(x)**2).is_bounded is True
-    assert (sin(x)**x).is_bounded is None
-    assert (sin(x)**exp(x)).is_bounded is None
-    assert (1/sin(x)).is_bounded is None  # if zero, no, otherwise yes
-    assert (1/exp(x)).is_bounded is None  # x could be -oo
+    assert (x**2).is_finite is None  # x could be oo
+    assert (x**x).is_finite is None  # ditto
+    assert (p**x).is_finite is None  # ditto
+    assert (n**x).is_finite is None  # ditto
+    assert (1/S.Pi).is_finite
+    assert (sin(x)**2).is_finite is True
+    assert (sin(x)**x).is_finite is None
+    assert (sin(x)**exp(x)).is_finite is None
+    assert (1/sin(x)).is_finite is None  # if zero, no, otherwise yes
+    assert (1/exp(x)).is_finite is None  # x could be -oo
 
 
 def test_Pow_is_even_odd():
@@ -1717,7 +1717,7 @@ def test_mul_zero_detection():
 
     # real is unknonwn
     def test(z, b, e):
-        if z.is_zero and b.is_bounded:
+        if z.is_zero and b.is_finite:
             assert e.is_real and e.is_zero
         else:
             assert e.is_real == e.is_zero == None
@@ -1734,7 +1734,7 @@ def test_mul_zero_detection():
 
     # real is True
     def test(z, b, e):
-        if z.is_zero and not b.is_bounded:
+        if z.is_zero and not b.is_finite:
             assert e.is_real is None
         else:
             assert e.is_real

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -367,7 +367,7 @@ def test_Add_Mul_is_integer():
 
 
 def test_Add_Mul_is_finite():
-    x = Symbol('x', real=True, bounded=False)
+    x = Symbol('x', real=True, finite=False)
 
     assert sin(x).is_finite is True
     assert (x*sin(x)).is_finite is False
@@ -460,7 +460,7 @@ def test_Mul_is_rational():
     z = Symbol('z', zero=True)
     i = Symbol('i', imaginary=True)
     assert (z*i).is_rational is None
-    bi = Symbol('i', imaginary=True, bounded=True)
+    bi = Symbol('i', imaginary=True, finite=True)
     assert (z*bi).is_zero is True
 
 
@@ -1689,11 +1689,11 @@ def test_mul_coeff():
 
 
 def test_mul_zero_detection():
-    nz = Dummy(real=True, zero=False, bounded=True)
+    nz = Dummy(real=True, zero=False, finite=True)
     r = Dummy(real=True)
-    c = Dummy(real=False, complex=True, bounded=True)
-    c2 = Dummy(real=False, complex=True, bounded=True)
-    i = Dummy(imaginary=True, bounded=True)
+    c = Dummy(real=False, complex=True, finite=True)
+    c2 = Dummy(real=False, complex=True, finite=True)
+    i = Dummy(imaginary=True, finite=True)
     e = nz*r*c
     assert e.is_imaginary is None
     assert e.is_real is None
@@ -1724,11 +1724,11 @@ def test_mul_zero_detection():
 
     for iz, ib in cartes(*[[True, False, None]]*2):
         z = Dummy(nonzero=iz)
-        b = Dummy(bounded=ib)
+        b = Dummy(finite=ib)
         e = Mul(z, b, evaluate=False)
         test(z, b, e)
         z = Dummy(nonzero=iz)
-        b = Dummy(bounded=ib)
+        b = Dummy(finite=ib)
         e = Mul(b, z, evaluate=False)
         test(z, b, e)
 
@@ -1741,10 +1741,10 @@ def test_mul_zero_detection():
 
     for iz, ib in cartes(*[[True, False, None]]*2):
         z = Dummy('z', nonzero=iz, real=True)
-        b = Dummy('b', bounded=ib, real=True)
+        b = Dummy('b', finite=ib, real=True)
         e = Mul(z, b, evaluate=False)
         test(z, b, e)
         z = Dummy('z', nonzero=iz, real=True)
-        b = Dummy('b', bounded=ib, real=True)
+        b = Dummy('b', finite=ib, real=True)
         e = Mul(b, z, evaluate=False)
         test(z, b, e)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -629,10 +629,10 @@ def test_hash_vs_eq():
 
 def test_Add_is_pos_neg():
     # these cover lines not covered by the rest of tests in core
-    n = Symbol('n', negative=True, bounded=False)
-    p = Symbol('p', positive=True, bounded=False)
+    n = Symbol('n', negative=True, finite=False)
+    p = Symbol('p', positive=True, finite=False)
     x = Symbol('x')
-    xb = Symbol('xb', bounded=True)
+    xb = Symbol('xb', finite=True)
     assert (n + p).is_positive is None
     assert (n + x).is_positive is None
     assert (p + x).is_positive is None
@@ -741,7 +741,7 @@ def test_issue_6275():
     # This is similar to x/x => 1 even though if x = 0, it is really nan.
     assert isinstance(x*0, type(0*S.Infinity))
     if 0*S.Infinity is S.NaN:
-        b = Symbol('b', bounded=None)
+        b = Symbol('b', finite=None)
         assert (b*0).is_zero is None
 
 

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -34,7 +34,7 @@ def test_zero():
     assert z.is_even is True
     assert z.is_odd is False
     assert z.is_finite is True
-    assert z.is_unbounded is False
+    assert z.is_infinite is False
     assert z.is_comparable is True
     assert z.is_prime is False
     assert z.is_composite is False
@@ -60,7 +60,7 @@ def test_one():
     assert z.is_even is False
     assert z.is_odd is True
     assert z.is_finite is True
-    assert z.is_unbounded is False
+    assert z.is_infinite is False
     assert z.is_comparable is True
     assert z.is_prime is False
     assert z.is_number is True
@@ -90,7 +90,7 @@ def test_negativeone():
     assert z.is_even is False
     assert z.is_odd is True
     assert z.is_finite is True
-    assert z.is_unbounded is False
+    assert z.is_infinite is False
     assert z.is_comparable is True
     assert z.is_prime is False
     assert z.is_composite is False
@@ -117,7 +117,7 @@ def test_infinity():
     assert oo.is_even is None
     assert oo.is_odd is None
     assert oo.is_finite is False
-    assert oo.is_unbounded is True
+    assert oo.is_infinite is True
     assert oo.is_comparable is True
     assert oo.is_prime is None
     assert oo.is_composite is None
@@ -144,7 +144,7 @@ def test_neg_infinity():
     assert mm.is_even is None
     assert mm.is_odd is None
     assert mm.is_finite is False
-    assert mm.is_unbounded is True
+    assert mm.is_infinite is True
     assert mm.is_comparable is True
     assert mm.is_prime is False
     assert mm.is_composite is False
@@ -171,7 +171,7 @@ def test_nan():
     assert nan.is_even is None
     assert nan.is_odd is None
     assert nan.is_finite is None
-    assert nan.is_unbounded is None
+    assert nan.is_infinite is None
     assert nan.is_comparable is False
     assert nan.is_prime is None
     assert nan.is_composite is None
@@ -197,7 +197,7 @@ def test_pos_rational():
     assert r.is_even is False
     assert r.is_odd is False
     assert r.is_finite is True
-    assert r.is_unbounded is False
+    assert r.is_infinite is False
     assert r.is_comparable is True
     assert r.is_prime is False
     assert r.is_composite is False
@@ -261,7 +261,7 @@ def test_pi():
     assert z.is_even is False
     assert z.is_odd is False
     assert z.is_finite is True
-    assert z.is_unbounded is False
+    assert z.is_infinite is False
     assert z.is_comparable is True
     assert z.is_prime is False
     assert z.is_composite is False
@@ -286,7 +286,7 @@ def test_E():
     assert z.is_even is False
     assert z.is_odd is False
     assert z.is_finite is True
-    assert z.is_unbounded is False
+    assert z.is_infinite is False
     assert z.is_comparable is True
     assert z.is_prime is False
     assert z.is_composite is False
@@ -311,7 +311,7 @@ def test_I():
     assert z.is_even is False
     assert z.is_odd is False
     assert z.is_finite is True
-    assert z.is_unbounded is False
+    assert z.is_infinite is False
     assert z.is_comparable is False
     assert z.is_prime is False
     assert z.is_composite is False

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -33,7 +33,7 @@ def test_zero():
     assert z.is_nonnegative is True
     assert z.is_even is True
     assert z.is_odd is False
-    assert z.is_bounded is True
+    assert z.is_finite is True
     assert z.is_unbounded is False
     assert z.is_comparable is True
     assert z.is_prime is False
@@ -59,7 +59,7 @@ def test_one():
     assert z.is_nonnegative is True
     assert z.is_even is False
     assert z.is_odd is True
-    assert z.is_bounded is True
+    assert z.is_finite is True
     assert z.is_unbounded is False
     assert z.is_comparable is True
     assert z.is_prime is False
@@ -89,7 +89,7 @@ def test_negativeone():
     assert z.is_nonnegative is False
     assert z.is_even is False
     assert z.is_odd is True
-    assert z.is_bounded is True
+    assert z.is_finite is True
     assert z.is_unbounded is False
     assert z.is_comparable is True
     assert z.is_prime is False
@@ -116,7 +116,7 @@ def test_infinity():
     assert oo.is_nonnegative is True
     assert oo.is_even is None
     assert oo.is_odd is None
-    assert oo.is_bounded is False
+    assert oo.is_finite is False
     assert oo.is_unbounded is True
     assert oo.is_comparable is True
     assert oo.is_prime is None
@@ -143,7 +143,7 @@ def test_neg_infinity():
     assert mm.is_nonnegative is False
     assert mm.is_even is None
     assert mm.is_odd is None
-    assert mm.is_bounded is False
+    assert mm.is_finite is False
     assert mm.is_unbounded is True
     assert mm.is_comparable is True
     assert mm.is_prime is False
@@ -170,7 +170,7 @@ def test_nan():
     assert nan.is_nonnegative is None
     assert nan.is_even is None
     assert nan.is_odd is None
-    assert nan.is_bounded is None
+    assert nan.is_finite is None
     assert nan.is_unbounded is None
     assert nan.is_comparable is False
     assert nan.is_prime is None
@@ -196,7 +196,7 @@ def test_pos_rational():
     assert r.is_nonnegative is True
     assert r.is_even is False
     assert r.is_odd is False
-    assert r.is_bounded is True
+    assert r.is_finite is True
     assert r.is_unbounded is False
     assert r.is_comparable is True
     assert r.is_prime is False
@@ -260,7 +260,7 @@ def test_pi():
     assert z.is_nonnegative is True
     assert z.is_even is False
     assert z.is_odd is False
-    assert z.is_bounded is True
+    assert z.is_finite is True
     assert z.is_unbounded is False
     assert z.is_comparable is True
     assert z.is_prime is False
@@ -285,7 +285,7 @@ def test_E():
     assert z.is_nonnegative is True
     assert z.is_even is False
     assert z.is_odd is False
-    assert z.is_bounded is True
+    assert z.is_finite is True
     assert z.is_unbounded is False
     assert z.is_comparable is True
     assert z.is_prime is False
@@ -310,7 +310,7 @@ def test_I():
     assert z.is_nonnegative is False
     assert z.is_even is False
     assert z.is_odd is False
-    assert z.is_bounded is True
+    assert z.is_finite is True
     assert z.is_unbounded is False
     assert z.is_comparable is False
     assert z.is_prime is False

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -367,19 +367,19 @@ def test_Float():
 
     raises(ValueError, lambda: Float((0, 7, 1, 3), ''))
 
-    assert Float('+inf').is_bounded is False
+    assert Float('+inf').is_finite is False
     assert Float('+inf').is_negative is False
     assert Float('+inf').is_positive is True
     assert Float('+inf').is_unbounded is True
     assert Float('+inf').is_zero is False
 
-    assert Float('-inf').is_bounded is False
+    assert Float('-inf').is_finite is False
     assert Float('-inf').is_negative is True
     assert Float('-inf').is_positive is False
     assert Float('-inf').is_unbounded is True
     assert Float('-inf').is_zero is False
 
-    assert Float('0.0').is_bounded is True
+    assert Float('0.0').is_finite is True
     assert Float('0.0').is_negative is False
     assert Float('0.0').is_positive is False
     assert Float('0.0').is_unbounded is False
@@ -1257,12 +1257,12 @@ def test_zoo():
     imb = Symbol('ib', imaginary=True, bounded=True)
     for i in [I, S.Infinity, S.NegativeInfinity, S.Zero, S.One, S.Pi, S.Half, S(3), log(3),
               b, nz, p, n, im, pb, nb, imb, c]:
-        if i.is_bounded and (i.is_real or i.is_imaginary):
+        if i.is_finite and (i.is_real or i.is_imaginary):
             assert i + zoo is zoo
             assert i - zoo is zoo
             assert zoo + i is zoo
             assert zoo - i is zoo
-        elif i.is_bounded is not False:
+        elif i.is_finite is not False:
             assert (i + zoo).is_Add
             assert (i - zoo).is_Add
             assert (zoo + i).is_Add

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -370,19 +370,19 @@ def test_Float():
     assert Float('+inf').is_finite is False
     assert Float('+inf').is_negative is False
     assert Float('+inf').is_positive is True
-    assert Float('+inf').is_unbounded is True
+    assert Float('+inf').is_infinite is True
     assert Float('+inf').is_zero is False
 
     assert Float('-inf').is_finite is False
     assert Float('-inf').is_negative is True
     assert Float('-inf').is_positive is False
-    assert Float('-inf').is_unbounded is True
+    assert Float('-inf').is_infinite is True
     assert Float('-inf').is_zero is False
 
     assert Float('0.0').is_finite is True
     assert Float('0.0').is_negative is False
     assert Float('0.0').is_positive is False
-    assert Float('0.0').is_unbounded is False
+    assert Float('0.0').is_infinite is False
     assert Float('0.0').is_zero is True
 
     # rationality properties

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -716,7 +716,7 @@ def test_Infinity_inequations():
     assert oo >= oo and oo <= oo and -oo >= -oo and -oo <= -oo
 
     x = Symbol('x')
-    b = Symbol('b', bounded=True, real=True)
+    b = Symbol('b', finite=True, real=True)
     assert (x < oo) == Lt(x, oo)  # issue 7775
     assert b < oo and b > -oo and b <= oo and b >= -oo
     assert oo > b and oo >= b and (oo < b) == False and (oo <= b) == False
@@ -1246,15 +1246,15 @@ def test_Rational_int():
 
 
 def test_zoo():
-    b = Symbol('b', bounded=True)
+    b = Symbol('b', finite=True)
     nz = Symbol('nz', nonzero=True)
     p = Symbol('p', positive=True)
     n = Symbol('n', negative=True)
     im = Symbol('i', imaginary=True)
     c = Symbol('c', complex=True)
-    pb = Symbol('pb', positive=True, bounded=True)
-    nb = Symbol('nb', negative=True, bounded=True)
-    imb = Symbol('ib', imaginary=True, bounded=True)
+    pb = Symbol('pb', positive=True, finite=True)
+    nb = Symbol('nb', negative=True, finite=True)
+    imb = Symbol('ib', imaginary=True, finite=True)
     for i in [I, S.Infinity, S.NegativeInfinity, S.Zero, S.One, S.Pi, S.Half, S(3), log(3),
               b, nz, p, n, im, pb, nb, imb, c]:
         if i.is_finite and (i.is_real or i.is_imaginary):
@@ -1308,21 +1308,21 @@ def test_zoo():
 def test_issue_4122():
     x = Symbol('x', nonpositive=True)
     assert (oo + x).is_Add
-    x = Symbol('x', bounded=True)
+    x = Symbol('x', finite=True)
     assert (oo + x).is_Add  # x could be imaginary
     x = Symbol('x', nonnegative=True)
     assert oo + x == oo
-    x = Symbol('x', bounded=True, real=True)
+    x = Symbol('x', finite=True, real=True)
     assert oo + x == oo
 
     # similarily for negative infinity
     x = Symbol('x', nonnegative=True)
     assert (-oo + x).is_Add
-    x = Symbol('x', bounded=True)
+    x = Symbol('x', finite=True)
     assert (-oo + x).is_Add
     x = Symbol('x', nonpositive=True)
     assert -oo + x == -oo
-    x = Symbol('x', bounded=True, real=True)
+    x = Symbol('x', finite=True, real=True)
     assert -oo + x == -oo
 
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -239,7 +239,7 @@ class sign(Function):
     Abs, conjugate
     """
 
-    is_bounded = True
+    is_finite = True
     is_complex = True
 
     def doit(self):
@@ -506,7 +506,7 @@ class arg(Function):
     """Returns the argument (in radians) of a complex number"""
 
     is_real = True
-    is_bounded = True
+    is_finite = True
 
     @classmethod
     def eval(cls, arg):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -77,7 +77,7 @@ class ExpBase(Function):
 
     def _eval_is_finite(self):
         arg = self.args[0]
-        if arg.is_unbounded:
+        if arg.is_infinite:
             if arg.is_negative:
                 return True
             if arg.is_positive:
@@ -661,7 +661,7 @@ class log(Function):
     def _eval_is_positive(self):
         arg = self.args[0]
         if arg.is_positive:
-            if arg.is_unbounded:
+            if arg.is_infinite:
                 return True
             if arg.is_zero:
                 return False

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -75,14 +75,14 @@ class ExpBase(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
         if arg.is_unbounded:
             if arg.is_negative:
                 return True
             if arg.is_positive:
                 return False
-        if arg.is_bounded:
+        if arg.is_finite:
             return True
 
     def _eval_is_rational(self):
@@ -652,11 +652,11 @@ class log(Function):
     def _eval_is_real(self):
         return self.args[0].is_positive
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
         if arg.is_zero:
             return False
-        return arg.is_bounded
+        return arg.is_finite
 
     def _eval_is_positive(self):
         arg = self.args[0]

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -177,7 +177,7 @@ class sinh(HyperbolicFunction):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
         if arg.is_imaginary:
             return True
@@ -325,7 +325,7 @@ class cosh(HyperbolicFunction):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
         if arg.is_imaginary:
             return True
@@ -462,7 +462,7 @@ class tanh(HyperbolicFunction):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
         if arg.is_real:
             return True

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -66,8 +66,8 @@ class RoundFunction(Function):
         else:
             return ipart + cls(spart, evaluate=False)
 
-    def _eval_is_bounded(self):
-        return self.args[0].is_bounded
+    def _eval_is_finite(self):
+        return self.args[0].is_finite
 
     def _eval_is_real(self):
         return self.args[0].is_real

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -474,8 +474,8 @@ class Piecewise(Function):
                 return when_multiple
         return b
 
-    _eval_is_bounded = lambda self: self._eval_template_is_attr(
-        'is_bounded', when_multiple=False)
+    _eval_is_finite = lambda self: self._eval_template_is_attr(
+        'is_finite', when_multiple=False)
     _eval_is_complex = lambda self: self._eval_template_is_attr('is_complex')
     _eval_is_even = lambda self: self._eval_template_is_attr('is_even')
     _eval_is_imaginary = lambda self: self._eval_template_is_attr(

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -144,7 +144,7 @@ def test_sign():
     assert sign(sqrt(1 - sqrt(3))) == I
 
     x = Symbol('x')
-    assert sign(x).is_bounded is True
+    assert sign(x).is_finite is True
     assert sign(x).is_complex is True
     assert sign(x).is_imaginary is None
     assert sign(x).is_integer is None

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -135,7 +135,7 @@ def test_piecewise_free_symbols():
 
 
 def test_piecewise_integrate():
-    x, y = symbols('x y', real=True, bounded=True)
+    x, y = symbols('x y', real=True, finite=True)
 
     # XXX Use '<=' here! '>=' is not yet implemented ..
     f = Piecewise(((x - 2)**2, 0 <= x), (1, True))
@@ -227,10 +227,10 @@ def test_piecewise_integrate_inequality_conditions():
 
 
 def test_piecewise_integrate_symbolic_conditions():
-    a = Symbol('a', real=True, bounded=True)
-    b = Symbol('b', real=True, bounded=True)
-    x = Symbol('x', real=True, bounded=True)
-    y = Symbol('y', real=True, bounded=True)
+    a = Symbol('a', real=True, finite=True)
+    b = Symbol('b', real=True, finite=True)
+    x = Symbol('x', real=True, finite=True)
+    y = Symbol('y', real=True, finite=True)
     p0 = Piecewise((0, Or(x < a, x > b)), (1, True))
     p1 = Piecewise((0, x < a), (0, x > b), (1, True))
     p2 = Piecewise((0, x > b), (0, x < a), (1, True))

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -492,10 +492,10 @@ def test_cot():
     assert cot(11*pi/7) == -cot(3*pi/7)
     assert cot(-11*pi/7) == cot(3*pi/7)
 
-    assert cot(x).is_bounded is None
-    assert cot(r).is_bounded is None
+    assert cot(x).is_finite is None
+    assert cot(r).is_finite is None
     i = Symbol('i', imaginary=True)
-    assert cot(i).is_bounded is True
+    assert cot(i).is_finite is True
 
     assert cot(x).subs(x, 3*pi) == zoo
 
@@ -1105,9 +1105,9 @@ def test_sec():
 
     assert sec(x).as_leading_term() == sec(x)
 
-    assert sec(0).is_bounded == True
-    assert sec(x).is_bounded == None
-    assert sec(pi/2).is_bounded == False
+    assert sec(0).is_finite == True
+    assert sec(x).is_finite == None
+    assert sec(pi/2).is_finite == False
 
     assert series(sec(x), x, x0=0, n=6) == 1 + x**2/2 + 5*x**4/24 + O(x**6)
 
@@ -1179,9 +1179,9 @@ def test_csc():
 
     assert csc(x).as_leading_term() == csc(x)
 
-    assert csc(0).is_bounded == False
-    assert csc(x).is_bounded == None
-    assert csc(pi/2).is_bounded == True
+    assert csc(0).is_finite == False
+    assert csc(x).is_finite == None
+    assert csc(pi/2).is_finite == True
 
     assert series(csc(x), x, x0=pi/2, n=6) == \
         1 + (x - pi/2)**2/2 + 5*(x - pi/2)**4/24 + O((x - pi/2)**6, (x, pi/2))

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -375,7 +375,7 @@ class sin(TrigonometricFunction):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
         if arg.is_real:
             return True
@@ -720,7 +720,7 @@ class cos(TrigonometricFunction):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
 
         if arg.is_real:
@@ -953,7 +953,7 @@ class tan(TrigonometricFunction):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
 
         if arg.is_imaginary:
@@ -1189,7 +1189,7 @@ class cot(TrigonometricFunction):
                 return (C.re(P)/C.im(P)).subs([(z, cot(terms))])
         return cot(arg)
 
-    def _eval_is_bounded(self):
+    def _eval_is_finite(self):
         arg = self.args[0]
         if arg.is_imaginary:
             return True
@@ -1302,8 +1302,8 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
     def _eval_as_leading_term(self, x):
         return (1/self._reciprocal_of(self.args[0]))._eval_as_leading_term(x)
 
-    def _eval_is_bounded(self):
-        return (1/self._reciprocal_of(self.args[0])).is_bounded
+    def _eval_is_finite(self):
+        return (1/self._reciprocal_of(self.args[0])).is_finite
 
     def _eval_nseries(self, x, n, logx):
         return (1/self._reciprocal_of(self.args[0]))._eval_nseries(x, n, logx)

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1010,7 +1010,7 @@ class Line(LinearEntity):
                 'If it was a slope, enter it with keyword "slope".')
         elif slope is not None and pt is None:
             slope = sympify(slope)
-            if slope.is_bounded is False:
+            if slope.is_finite is False:
                 # when unbounded slope, don't change x
                 dx = 0
                 dy = 1

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -318,7 +318,7 @@ class Integral(AddWithLimits):
             where sign of b is considered
             """
             wok = F.subs(d, a)
-            if wok is S.NaN or wok.is_bounded is False and a.is_bounded:
+            if wok is S.NaN or wok.is_finite is False and a.is_finite:
                 return limit(sign(b)*F, d, a)
             return wok
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -836,7 +836,7 @@ def test_issue_4199():
 
 
 def test_issue_3940():
-    a, b, c, d = symbols('a:d', positive=True, bounded=True)
+    a, b, c, d = symbols('a:d', positive=True, finite=True)
     assert integrate(exp(-x**2 + I*c*x), x) == \
         -sqrt(pi)*exp(-c**2/4)*erf(I*c/2 - x)/2
     assert integrate(exp(a*x**2 + b*x + c), x) == \

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -327,10 +327,10 @@ def test_probability():
     # various integrals from probability theory
     from sympy.abc import x, y, z
     from sympy import symbols, Symbol, Abs, expand_mul, combsimp, powsimp, sin
-    mu1, mu2 = symbols('mu1 mu2', real=True, nonzero=True, bounded=True)
+    mu1, mu2 = symbols('mu1 mu2', real=True, nonzero=True, finite=True)
     sigma1, sigma2 = symbols('sigma1 sigma2', real=True, nonzero=True,
-                             bounded=True, positive=True)
-    rate = Symbol('lambda', real=True, positive=True, bounded=True)
+                             finite=True, positive=True)
+    rate = Symbol('lambda', real=True, positive=True, finite=True)
 
     def normal(x, mu, sigma):
         return 1/sqrt(2*pi*sigma**2)*exp(-(x - mu)**2/2/sigma**2)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -339,7 +339,7 @@ def test_inverse_mellin_transform():
     # Now test the inverses of all direct transforms tested above
 
     # Section 8.4.2
-    nu = symbols('nu', real=True, bounded=True)
+    nu = symbols('nu', real=True, finite=True)
     assert IMT(-1/(nu + s), s, x, (-oo, None)) == x**nu*Heaviside(x - 1)
     assert IMT(1/(nu + s), s, x, (None, oo)) == x**nu*Heaviside(1 - x)
     assert simp_pows(IMT(gamma(beta)*gamma(s)/gamma(s + beta), s, x, (0, oo))) \
@@ -509,7 +509,7 @@ def test_inverse_laplace_transform():
     from sympy import (expand, sinh, cosh, besselj, besseli, exp_polar,
                        unpolarify, simplify, factor_terms)
     ILT = inverse_laplace_transform
-    a, b, c, = symbols('a b c', positive=True, bounded=True)
+    a, b, c, = symbols('a b c', positive=True, finite=True)
     t = symbols('t')
 
     def simp_hyp(expr):

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -144,7 +144,7 @@ def compare(a, b, x):
     c = limitinf(la/lb, x)
     if c == 0:
         return "<"
-    elif c.is_unbounded:
+    elif c.is_infinite:
         return ">"
     else:
         return "="
@@ -273,7 +273,7 @@ def mrv(e, x):
         # be simplified here, and doing so is vital for termination.
         if e.args[0].func is log:
             return mrv(e.args[0].args[0], x)
-        if limitinf(e.args[0], x).is_unbounded:
+        if limitinf(e.args[0], x).is_infinite:
             s1 = SubsSet()
             e1 = s1[e]
             s2, e2 = mrv(e.args[0], x)

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -414,7 +414,7 @@ def limitinf(e, x):
         # We make sure that x.is_positive is True so we
         # get all the correct mathematical bechavior from the expression.
         # We need a fresh variable.
-        p = Dummy('p', positive=True, bounded=True)
+        p = Dummy('p', positive=True, finite=True)
         e = e.subs(x, p)
         x = p
     c0, e0 = mrv_leadterm(e, x)
@@ -497,7 +497,7 @@ def mrv_leadterm(e, x):
     # For limits of complex functions, the algorithm would have to be
     # improved, or just find limits of Re and Im components separately.
     #
-    w = Dummy("w", real=True, positive=True, bounded=True)
+    w = Dummy("w", real=True, positive=True, finite=True)
     f, logw = rewrite(exps, Omega, x, w)
     series = calculate_series(f, w, logx=logw)
     return series.leadterm(w)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -96,7 +96,7 @@ def heuristics(e, z, z0, dir):
         for a in e.args:
             try:
                 l = limit(a, z, z0, dir)
-                if l.has(S.Infinity) and l.is_bounded is None:
+                if l.has(S.Infinity) and l.is_finite is None:
                     break
                 else:
                     r.append(l)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -270,7 +270,7 @@ def test_issue_5184():
     assert limit(cos(x)/x, x, oo) == 0
     assert limit(gamma(x), x, Rational(1, 2)) == sqrt(pi)
 
-    r = Symbol('r', real=True, bounded=True)
+    r = Symbol('r', real=True, finite=True)
     assert limit(r*sin(1/r), r, 0) == 0
 
 
@@ -335,7 +335,7 @@ def test_extended_real_line():
 @XFAIL
 def test_order_oo():
     from sympy import C
-    x = Symbol('x', positive=True, bounded=True)
+    x = Symbol('x', positive=True, finite=True)
     assert C.Order(x)*oo != C.Order(1, x)
     assert limit(oo/(x**2 - 4), x, oo) == oo
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -314,7 +314,7 @@ class Range(Set):
             raise ValueError("Inputs to Range must be Integer Valued\n" +
                     "Use ImageSets of Ranges for other cases")
 
-        if not step.is_bounded:
+        if not step.is_finite:
             raise ValueError("Infinite step is not allowed")
         if start == stop:
             return S.EmptySet
@@ -325,7 +325,7 @@ class Range(Set):
 
         # normalize args: regardless of how they are entered they will show
         # canonically as Range(inf, sup, step) with step > 0
-        if n.is_bounded:
+        if n.is_finite:
             start, stop = sorted((start, start + (n - 1)*step))
         else:
             start, stop = sorted((start, stop - step))
@@ -358,7 +358,7 @@ class Range(Set):
             inf = ceiling(Max(self.inf, oinf))
             sup = floor(Min(self.sup, osup))
             # if we are off the sequence, get back on
-            if inf.is_bounded and self.inf.is_bounded:
+            if inf.is_finite and self.inf.is_finite:
                 off = (inf - self.inf) % self.step
             else:
                 off = S.Zero

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -592,7 +592,7 @@ def test_product_basic():
 
 
 def test_real():
-    x = Symbol('x', real=True, bounded=True)
+    x = Symbol('x', real=True, finite=True)
 
     I = Interval(0, 5)
     J = Interval(10, 20)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3906,7 +3906,7 @@ def nsimplify(expr, constants=[], tolerance=None, full=False, rational=None):
             expr = sympify(newexpr)
             if x and not expr:  # don't let x become 0
                 raise ValueError
-            if expr.is_bounded is False and not xv in [mpmath.inf, mpmath.ninf]:
+            if expr.is_finite is False and not xv in [mpmath.inf, mpmath.ninf]:
                 raise ValueError
             return expr
         finally:

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -195,7 +195,7 @@ class SingleContinuousDistribution(ContinuousDistribution, NamedArgsMixin):
 
         Returns a Lambda
         """
-        x, z = symbols('x, z', real=True, bounded=True, cls=Dummy)
+        x, z = symbols('x, z', real=True, finite=True, cls=Dummy)
         left_bound = self.set.start
 
         # CDF is integral of PDF from left bound to z
@@ -270,7 +270,7 @@ class ContinuousPSpace(PSpace):
             pdf = self.domain.integrate(self.pdf, symbols, **kwargs)
             return Lambda(expr.symbol, pdf)
 
-        z = Dummy('z', real=True, bounded=True)
+        z = Dummy('z', real=True, finite=True)
         return Lambda(z, self.integrate(DiracDelta(expr - z), **kwargs))
 
     @cacheit
@@ -280,7 +280,7 @@ class ContinuousPSpace(PSpace):
                 "CDF not well defined on multivariate expressions")
 
         d = self.compute_density(expr, **kwargs)
-        x, z = symbols('x, z', real=True, bounded=True, cls=Dummy)
+        x, z = symbols('x, z', real=True, finite=True, cls=Dummy)
         left_bound = self.domain.set.start
 
         # CDF is integral of PDF from left bound to z
@@ -290,7 +290,7 @@ class ContinuousPSpace(PSpace):
         return Lambda(z, cdf)
 
     def probability(self, condition, **kwargs):
-        z = Dummy('z', real=True, bounded=True)
+        z = Dummy('z', real=True, finite=True)
         # Univariate case can be handled by where
         try:
             domain = self.where(condition)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2150,7 +2150,7 @@ class UniformDistribution(SingleContinuousDistribution):
 
     def compute_cdf(self, **kwargs):
         from sympy import Lambda, Min
-        z = Dummy('z', real=True, bounded=True)
+        z = Dummy('z', real=True, finite=True)
         result = SingleContinuousDistribution.compute_cdf(self, **kwargs)
         result = result(z).subs({Min(z, self.right): z,
                                  Min(z, self.left, self.right): self.left,

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -54,7 +54,7 @@ class SingleDiscreteDistribution(Basic, NamedArgsMixin):
 
         Returns a Lambda
         """
-        x, z = symbols('x, z', integer=True, bounded=True, cls=Dummy)
+        x, z = symbols('x, z', integer=True, finite=True, cls=Dummy)
         left_bound = self.set.inf
 
         # CDF is integral of PDF from left bound to z

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -232,7 +232,7 @@ class RandomSymbol(Expr):
             raise TypeError("pspace variable should be of type PSpace")
         return Basic.__new__(cls, pspace, symbol)
 
-    is_bounded = True
+    is_finite = True
     is_Symbol = True
     is_Atom = True
 

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -93,7 +93,7 @@ def covariance(X, Y, condition=None, **kwargs):
     >>> from sympy.stats import Exponential, covariance
     >>> from sympy import Symbol
 
-    >>> rate = Symbol('lambda', positive=True, real=True, bounded = True)
+    >>> rate = Symbol('lambda', positive=True, real=True, finite=True)
     >>> X = Exponential('X', rate)
     >>> Y = Exponential('Y', rate)
 
@@ -126,7 +126,7 @@ def correlation(X, Y, condition=None, **kwargs):
     >>> from sympy.stats import Exponential, correlation
     >>> from sympy import Symbol
 
-    >>> rate = Symbol('lambda', positive=True, real=True, bounded = True)
+    >>> rate = Symbol('lambda', positive=True, real=True, finite=True)
     >>> X = Exponential('X', rate)
     >>> Y = Exponential('Y', rate)
 
@@ -172,7 +172,7 @@ def smoment(X, n, condition=None, **kwargs):
 
     >>> from sympy.stats import skewness, Exponential, smoment
     >>> from sympy import Symbol
-    >>> rate = Symbol('lambda', positive=True, real=True, bounded = True)
+    >>> rate = Symbol('lambda', positive=True, real=True, finite=True)
     >>> Y = Exponential('Y', rate)
     >>> smoment(Y, 4)
     9
@@ -201,7 +201,7 @@ def skewness(X, condition=None, **kwargs):
     >>> X = Normal('X', 0, 1)
     >>> skewness(X)
     0
-    >>> rate = Symbol('lambda', positive=True, real=True, bounded = True)
+    >>> rate = Symbol('lambda', positive=True, real=True, finite=True)
     >>> Y = Exponential('Y', rate)
     >>> skewness(Y)
     2

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -31,8 +31,8 @@ x, y, z = map(Symbol, 'xyz')
 
 
 def test_single_normal():
-    mu = Symbol('mu', real=True, bounded=True)
-    sigma = Symbol('sigma', real=True, positive=True, bounded=True)
+    mu = Symbol('mu', real=True, finite=True)
+    sigma = Symbol('sigma', real=True, positive=True, finite=True)
     X = Normal('x', 0, 1)
     Y = X*sigma + mu
 
@@ -97,13 +97,13 @@ def test_multiple_normal():
 
 @slow
 def test_symbolic():
-    mu1, mu2 = symbols('mu1 mu2', real=True, bounded=True)
-    s1, s2 = symbols('sigma1 sigma2', real=True, bounded=True, positive=True)
-    rate = Symbol('lambda', real=True, positive=True, bounded=True)
+    mu1, mu2 = symbols('mu1 mu2', real=True, finite=True)
+    s1, s2 = symbols('sigma1 sigma2', real=True, finite=True, positive=True)
+    rate = Symbol('lambda', real=True, positive=True, finite=True)
     X = Normal('x', mu1, s1)
     Y = Normal('y', mu2, s2)
     Z = Exponential('z', rate)
-    a, b, c = symbols('a b c', real=True, bounded=True)
+    a, b, c = symbols('a b c', real=True, finite=True)
 
     assert E(X) == mu1
     assert E(X + Y) == mu1 + mu2
@@ -250,7 +250,7 @@ def test_erlang():
     assert density(X)(x) == x**(k - 1)*l**k*exp(-x*l)/gamma(k)
 
 def test_exponential():
-    rate = Symbol('lambda', positive=True, real=True, bounded=True)
+    rate = Symbol('lambda', positive=True, real=True, finite=True)
     X = Exponential('x', rate)
 
     assert E(X) == 1/rate
@@ -302,7 +302,7 @@ def test_gamma():
     # assert simplify(variance(X)) == k*theta**2  # handled numerically below
     assert E(X) == moment(X, 1)
 
-    k, theta = symbols('k theta', real=True, bounded=True, positive=True)
+    k, theta = symbols('k theta', real=True, finite=True, positive=True)
     X = Gamma('x', k, theta)
     assert simplify(E(X)) == k*theta
     # can't get things to simplify on this one so we use subs
@@ -339,8 +339,8 @@ def test_logistic():
     assert density(X)(x) == exp((-x + mu)/s)/(s*(exp((-x + mu)/s) + 1)**2)
 
 def test_lognormal():
-    mean = Symbol('mu', real=True, bounded=True)
-    std = Symbol('sigma', positive=True, real=True, bounded=True)
+    mean = Symbol('mu', real=True, finite=True)
+    std = Symbol('sigma', positive=True, real=True, finite=True)
     X = LogNormal('x', mean, std)
     # The sympy integrator can't do this too well
     #assert E(X) == exp(mean+std**2/2)
@@ -389,7 +389,7 @@ def test_nakagami():
 
 
 def test_pareto():
-    xm, beta = symbols('xm beta', positive=True, bounded=True)
+    xm, beta = symbols('xm beta', positive=True, finite=True)
     alpha = beta + 5
     X = Pareto('x', xm, alpha)
 
@@ -460,8 +460,8 @@ def test_quadratic_u():
                           And(x <= b, a <= x)), (0, True)))
 
 def test_uniform():
-    l = Symbol('l', real=True, bounded=True)
-    w = Symbol('w', positive=True, bounded=True)
+    l = Symbol('l', real=True, finite=True)
+    w = Symbol('w', positive=True, finite=True)
     X = Uniform('x', l, l + w)
 
     assert simplify(E(X)) == l + w/2
@@ -483,8 +483,8 @@ def test_uniform_P():
     I decided to regress on this class for general cleanliness (and I suspect
     speed) of the algorithm.
     """
-    l = Symbol('l', real=True, bounded=True)
-    w = Symbol('w', positive=True, bounded=True)
+    l = Symbol('l', real=True, finite=True)
+    w = Symbol('w', positive=True, finite=True)
     X = Uniform('x', l, l + w)
     assert P(X < l) == 0 and P(X > l + w) == 0
 

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -160,7 +160,7 @@ def test_dependent_finite():
 
 def test_normality():
     X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)
-    x, z = symbols('x, z', real=True, bounded=True)
+    x, z = symbols('x, z', real=True, finite=True)
     dens = density(X - Y, Eq(X + Y, z))
 
     assert integrate(dens(x), (x, -oo, oo)) == 1


### PR DESCRIPTION
fixes #7943
fixes #5294

finite: `abs(x) < oo`
infinite: `abs(x) = oo`
- [x] decide about naming (e.g. unbounded)
- [x] change temporary variable names (e.g. bounded -> finite)
- [x] rebase to fix commit msg (bounded -> finite!)
- [x] add some references
