### PR TITLE
relational ops: Don't use False as a replacement for 'other', if we can't sympify 'other'

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -647,7 +647,6 @@ def ordered(seq, keys=None, default=True, warn=False):
         if not isinstance(keys, (list, tuple)):
             keys = [keys]
         keys = list(keys)
-
         f = keys.pop(0)
         for a in seq:
             d[f(a)].append(a)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from .core import C
-from .sympify import sympify
+from .sympify import sympify, _sympify, SympifyError
 from .basic import Basic, Atom
 from .singleton import S
 from .evalf import EvalfMixin, pure_complex
@@ -213,8 +213,11 @@ class Expr(Basic, EvalfMixin):
         re, im = result.as_real_imag()
         return complex(float(re), float(im))
 
-    @_sympifyit('other', False)  # sympy >  other
     def __ge__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
@@ -224,8 +227,11 @@ class Expr(Basic, EvalfMixin):
             return sympify(dif.is_nonnegative)
         return C.GreaterThan(self, other)
 
-    @_sympifyit('other', False)  # sympy >  other
     def __le__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
@@ -235,8 +241,11 @@ class Expr(Basic, EvalfMixin):
             return sympify(dif.is_nonpositive)
         return C.LessThan(self, other)
 
-    @_sympifyit('other', False)  # sympy >  other
     def __gt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
@@ -246,8 +255,11 @@ class Expr(Basic, EvalfMixin):
             return sympify(dif.is_positive)
         return C.StrictGreaterThan(self, other)
 
-    @_sympifyit('other', False)  # sympy >  other
     def __lt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -380,17 +380,33 @@ class Number(AtomicExpr):
             (self.__class__.__name__))
 
     def __lt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
         raise NotImplementedError('%s needs .__lt__() method' %
             (self.__class__.__name__))
 
     def __le__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
         raise NotImplementedError('%s needs .__le__() method' %
             (self.__class__.__name__))
 
     def __gt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
         return _sympify(other).__lt__(self)
 
     def __ge__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
         return _sympify(other).__le__(self)
 
     def __hash__(self):
@@ -870,7 +886,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
         if isinstance(other, NumberSymbol):
             return other.__le__(self)
         if other.is_comparable:
@@ -884,7 +900,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other  -->  ! <=
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
         if isinstance(other, NumberSymbol):
             return other.__lt__(self)
         if other.is_comparable:
@@ -898,7 +914,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
         if isinstance(other, NumberSymbol):
             return other.__ge__(self)
         if other.is_real and other.is_number:
@@ -912,7 +928,7 @@ class Float(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other  -->  ! <=
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
         if isinstance(other, NumberSymbol):
             return other.__gt__(self)
         if other.is_real and other.is_number:
@@ -1328,7 +1344,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other  --> not <
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
         if isinstance(other, NumberSymbol):
             return other.__le__(self)
         if other.is_real and other.is_number and not isinstance(other, Rational):
@@ -1347,7 +1363,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other  -->  not <=
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
         if isinstance(other, NumberSymbol):
             return other.__lt__(self)
         if other.is_real and other.is_number and not isinstance(other, Rational):
@@ -1366,7 +1382,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other  --> not <
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
         if isinstance(other, NumberSymbol):
             return other.__ge__(self)
         if other.is_real and other.is_number and not isinstance(other, Rational):
@@ -1385,7 +1401,7 @@ class Rational(Number):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other  -->  not <=
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
         if isinstance(other, NumberSymbol):
             return other.__gt__(self)
         if other.is_real and other.is_number and not isinstance(other, Rational):
@@ -1687,30 +1703,38 @@ class Integer(Rational):
         return not self.__eq__(other)
 
     def __gt__(self, other):
-        if isinstance(other, integer_types):
-            return _sympify(self.p > other)
-        elif isinstance(other, Integer):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
+        if isinstance(other, Integer):
             return _sympify(self.p > other.p)
         return Rational.__gt__(self, other)
 
     def __lt__(self, other):
-        if isinstance(other, integer_types):
-            return _sympify(self.p < other)
-        elif isinstance(other, Integer):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
+        if isinstance(other, Integer):
             return _sympify(self.p < other.p)
         return Rational.__lt__(self, other)
 
     def __ge__(self, other):
-        if isinstance(other, integer_types):
-            return _sympify(self.p >= other)
-        elif isinstance(other, Integer):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
+        if isinstance(other, Integer):
             return _sympify(self.p >= other.p)
         return Rational.__ge__(self, other)
 
     def __le__(self, other):
-        if isinstance(other, integer_types):
-            return _sympify(self.p <= other)
-        elif isinstance(other, Integer):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
+        if isinstance(other, Integer):
             return _sympify(self.p <= other.p)
         return Rational.__le__(self, other)
 
@@ -2248,29 +2272,41 @@ class Infinity(with_metaclass(Singleton, Number)):
     def __ne__(self, other):
         return other is not S.Infinity
 
-    @_sympifyit('other', NotImplemented)
     def __lt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
         if other.is_complex and other.is_real is False:
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         return S.false
 
-    @_sympifyit('other', NotImplemented)
     def __le__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
         if other.is_complex and other.is_real is False:
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         return _sympify(other is S.Infinity)
 
-    @_sympifyit('other', NotImplemented)
     def __gt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
         if other.is_complex and other.is_real is False:
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         return _sympify(other is not S.Infinity)
 
-    @_sympifyit('other', NotImplemented)
     def __ge__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
         if other.is_complex and other.is_real is False:
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
@@ -2445,29 +2481,41 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     def __ne__(self, other):
         return other is not S.NegativeInfinity
 
-    @_sympifyit('other', NotImplemented)
     def __lt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
         if other.is_complex and other.is_real is False:
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         return _sympify(other is not S.NegativeInfinity)
 
-    @_sympifyit('other', NotImplemented)
     def __le__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
         if other.is_complex and other.is_real is False:
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         return S.true
 
-    @_sympifyit('other', NotImplemented)
     def __gt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
         if other.is_complex and other.is_real is False:
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
         return S.false
 
-    @_sympifyit('other', NotImplemented)
     def __ge__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
         if other.is_complex and other.is_real is False:
             raise TypeError("Invalid complex comparison: %s and %s" %
                             (self, other))
@@ -2582,15 +2630,31 @@ class NaN(with_metaclass(Singleton, Number)):
         return S.false
 
     def __gt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
         return S.false
 
     def __ge__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
         return S.false
 
     def __lt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
         return S.false
 
     def __le__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
         return S.false
 
 nan = S.NaN
@@ -2703,7 +2767,7 @@ class NumberSymbol(AtomicExpr):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other  --> not <
+            raise TypeError("Invalid comparison %s < %s" % (self, other))
         if self is other:
             return S.false
         if isinstance(other, Number):
@@ -2724,7 +2788,7 @@ class NumberSymbol(AtomicExpr):
         try:
             other = _sympify(other)
         except SympifyError:
-            return S.false    # sympy > other  --> not <=
+            raise TypeError("Invalid comparison %s <= %s" % (self, other))
         if self is other:
             return S.true
         if other.is_real and other.is_number:
@@ -2734,9 +2798,17 @@ class NumberSymbol(AtomicExpr):
         return Expr.__le__(self, other)
 
     def __gt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s > %s" % (self, other))
         return _sympify((-self) < (-other))
 
     def __ge__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            raise TypeError("Invalid comparison %s >= %s" % (self, other))
         return _sympify((-self) <= (-other))
 
     def __int__(self):

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,6 +1,6 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
-                   Implies, Xor)
+                   Implies, Xor, zoo)
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
@@ -472,3 +472,14 @@ def test_inequalities_symbol_name_same_complex():
         raises(TypeError, lambda: a >= I)
         raises(TypeError, lambda: Le(a, I))
         raises(TypeError, lambda: a <= I)
+
+
+def test_inequalities_cant_sympify_other():
+    # see issue 7833
+    from operator import gt, lt, ge, le
+
+    bar = "foo"
+
+    for a in (x, S(0), S(1)/3, pi, I, zoo, oo, -oo, nan):
+        for op in (lt, gt, le, ge):
+            raises(TypeError, lambda: op(a, bar))

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -44,14 +44,14 @@ class Set(Basic):
     @staticmethod
     def _infimum_key(expr):
         """
-        Return infimum (if possible) else None.
+        Return infimum (if possible) else S.Infinity.
         """
         try:
             infimum = expr.inf
             assert infimum.is_comparable
         except (NotImplementedError,
                 AttributeError, AssertionError, ValueError):
-            infimum = None
+            infimum = S.Infinity
         return infimum
 
     def union(self, other):


### PR DESCRIPTION
Unfortunately, we can't use _sympifyit decorator, because in py2 class
instances are compared by object identity ("address") if no other
comparison helpers are defined.

fixes #7833
