### PR TITLE
Relational: add tests for `Eq(p, 0)` where p is positive and similar

### DIFF
--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -165,6 +165,22 @@ def test_doit():
     assert Eq(x, 0).doit() == Eq(x, 0)
 
 
+@XFAIL
+def test_eq_pos_neg_assumptions():
+    p = Symbol('p', positive=True)
+    n = Symbol('n', negative=True)
+    np = Symbol('np', nonpositive=True)
+    nn = Symbol('nn', nonnegative=True)
+    assert Eq(p, 0) is S.false
+    assert Ne(p, 0) is S.true
+    assert Eq(n, 0) is S.false
+    assert Ne(n, 0) is S.true
+    assert Eq(np, 0) is Eq(np, 0, evaluate=False)
+    assert Eq(nn, 0) is Eq(nn, 0, evaluate=False)
+    assert Ne(np, 0) is Ne(np, 0, evaluate=False)
+    assert Ne(nn, 0) is Ne(nn, 0, evaluate=False)
+
+
 def test_new_relational():
     x = Symbol('x')
 


### PR DESCRIPTION
TODO:
- [x] test code.
- [x] Currently XFAIL'd.
- [ ] there are surely many related issues about this, find some.
- [X] related to assumptions
- [ ] Perhaps it is possible to fix this with something like the `dif` code in `Expr.__lt__`.  Try doing this in `Equality.__new__` before the call to `_eval_sides`.  Notably these are exactly the sorts of failures I get in Inequalities if I drop the `dif` code, see also pr #7838.
