### PR TITLE
2777: check nonlinear systems

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -15,7 +15,7 @@ from sympy.simplify import simplify, trigsimp
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
 from sympy.functions.elementary.complexes import im
 from sympy.geometry.exceptions import GeometryError
-from sympy.polys import Poly, PolynomialError
+from sympy.polys import Poly, PolynomialError, DomainError
 from sympy.solvers import solve
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.iterables import uniq
@@ -852,20 +852,16 @@ class Ellipse(GeometryEntity):
             yis = solve(seq, y)[0]
             xeq = eq.subs(y, yis).as_numer_denom()[0].expand()
             try:
-                iv = list(zip(*Poly(xeq).intervals()))[0]
+                iv = list(zip(*Poly(xeq, x).intervals()))[0]
                 # bisection is safest here since other methods may miss root
                 xsol = [S(nroot(lambdify(x, xeq), i, solver="anderson"))
                     for i in iv]
                 points = [Point(i, solve(eq.subs(x, i), y)[0]).n(prec)
                     for i in xsol]
-            except PolynomialError:
-                pass
-        if not points:
-            points = solve((seq, eq), (x, y))
-            # complicated expressions may not be decidably real so evaluate to
-            # check whether they are real or not
-            points = [Point(i).n(prec) if prec is not None else Point(i)
-                      for i in points if all(j.n(2).is_real for j in i)]
+            except (DomainError, PolynomialError):
+                xvals = solve(xeq, x)
+                points = [Point(xis, yis.xreplace({x: xis})) for xis in xvals]
+        points = [pt.n(prec) if prec is not None else pt for pt in points]
         slopes = [norm.subs(zip((x, y), pt.args)) for pt in points]
         if prec is not None:
             slopes = [i.n(prec) if i not in (-oo, oo, zoo) else i

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -905,9 +905,9 @@ def test_ellipse():
         [Line(Point(0, 0), Point(77/25, 132/25)),
      Line(Point(0, 0), Point(33/5, 22/5))]
     assert Ellipse(Point(5, 5), 2, 1).tangent_lines(Point(3, 4)) == \
-        [Line(Point(3, 4), Point(3, 5)), Line(Point(3, 4), Point(5, 4))]
+        [Line(Point(3, 4), Point(4, 4)), Line(Point(3, 4), Point(3, 5))]
     assert Circle(Point(5, 5), 2).tangent_lines(Point(3, 3)) == \
-        [Line(Point(3, 3), Point(3, 5)), Line(Point(3, 3), Point(5, 3))]
+        [Line(Point(3, 3), Point(4, 3)), Line(Point(3, 3), Point(3, 4))]
     assert Circle(Point(5, 5), 2).tangent_lines(Point(5 - 2*sqrt(2), 5)) == \
         [Line(Point(5 - 2*sqrt(2), 5), Point(5 - sqrt(2), 5 - sqrt(2))),
      Line(Point(5 - 2*sqrt(2), 5), Point(5 - sqrt(2), 5 + sqrt(2))), ]
@@ -1011,7 +1011,7 @@ def test_ellipse():
     assert e1.intersection(e2) == ans
     e2 = Ellipse(Point(x, y), 4, 8)
     c = sqrt(3991)
-    ans = [Point(c/68 + a, -2*c/17 + a/2), Point(-c/68 + a, 2*c/17 + a/2)]
+    ans = [Point(-c/68 + a, 2*c/17 + a/2), Point(c/68 + a, -2*c/17 + a/2)]
     assert [p.subs({x: 2, y:1}) for p in e1.intersection(e2)] == ans
 
     # Combinations of above

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -391,7 +391,7 @@ def solve(f, *symbols, **flags):
             do a fast numerical check if ``f`` has only one symbol.
         'minimal=True (default is False)'
             a very fast, minimal testing.
-        'warning=True (default is False)'
+        'warn=True (default is False)'
             show a warning if checksol() could not conclude.
         'simplify=True (default)'
             simplify all but cubic and quartic solutions before
@@ -988,7 +988,7 @@ def solve(f, *symbols, **flags):
 
     if check and solution:
 
-        warning = flags.get('warn', False)
+        warn = flags.get('warn', False)
         got_None = []  # solutions for which one or more symbols gave None
         no_False = []  # solutions for which no symbols gave False
         if type(solution) is list:
@@ -1043,7 +1043,7 @@ def solve(f, *symbols, **flags):
         elif isinstance(solution, (Relational, And, Or)):
             if len(symbols) != 1:
                 raise ValueError("Length should be 1")
-            if warning and symbols[0].assumptions0:
+            if warn and symbols[0].assumptions0:
                 warnings.warn(filldedent("""
                     \tWarning: assumptions about variable '%s' are
                     not handled currently.""" % symbols[0]))
@@ -1053,7 +1053,7 @@ def solve(f, *symbols, **flags):
             raise TypeError('Unrecognized solution')  # improve the checker
 
         solution = no_False
-        if warning and got_None:
+        if warn and got_None:
             warnings.warn(filldedent("""
                 \tWarning: assumptions concerning following solution(s)
                 can't be checked:""" + '\n\t' +

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -119,7 +119,7 @@ def test_solve_args():
     assert solve(a*x**2 + b*x + c -
                 ((x - h)**2 + 4*p*k)/4/p,
                 [h, p, k], exclude=[a, b, c], dict=True) == \
-        [{k: (4*a*c - b**2)/(4*a), h: -b/(2*a), p: 1/(4*a)}]
+        [{k: c - b**2/(4*a), h: -b/(2*a), p: 1/(4*a)}]
     # failing undetermined system
     assert solve(a*x + b**2/(x + 4) - 3*x - 4/x, a, b) == \
         [{a: (-b**2*x + 3*x**3 + 12*x**2 + 4*x + 16)/(x**2*(x + 4))}]
@@ -650,11 +650,9 @@ def test_issue_4671_4463_4467():
 def test_issue_5132():
     r, t = symbols('r,t')
     assert set(solve([r - x**2 - y**2, tan(t) - y/x], [x, y])) == \
-        set([
-            (-sqrt(r*tan(t)**2/(tan(t)**2 + 1))/tan(t),
-        -sqrt(r*tan(t)**2/(tan(t)**2 + 1))),
-        (sqrt(r*tan(t)**2/(tan(t)**2 + 1))/tan(t),
-        sqrt(r*tan(t)**2/(tan(t)**2 + 1)))])
+        set([(
+            -sqrt(r*sin(t)**2)/tan(t), -sqrt(r*sin(t)**2)),
+            (sqrt(r*sin(t)**2)/tan(t), sqrt(r*sin(t)**2))])
     assert solve([exp(x) - sin(y), 1/y - 3], [x, y]) == \
         [(log(sin(S(1)/3)), S(1)/3)]
     assert solve([exp(x) - sin(y), 1/exp(y) - 3], [x, y]) == \
@@ -1164,8 +1162,8 @@ def test_exclude():
         {
             Rf: Ri*(C*R*s + 1)**2/(C*R*s),
             Vminus: Vplus,
-            V1: Vplus*(2*C*R*s + 1)/(C*R*s),
-            Vout: Vplus*(C**2*R**2*s**2 + 3*C*R*s + 1)/(C*R*s)},
+            V1: 2*Vplus + Vplus/(C*R*s),
+            Vout: C*R*Vplus*s + 3*Vplus + Vplus/(C*R*s)},
         {
             Vplus: 0,
             Vminus: 0,
@@ -1504,3 +1502,17 @@ def test_issue_7547():
 def test_issue_7895():
     r = symbols('r', real=True)
     assert solve(sqrt(r) - 2) == [4]
+
+
+def test_issue_2777():
+    # the equations represent two circles
+    x, y = symbols('x y', real=True)
+    e1, e2 = sqrt(x**2 + y**2) - 10, sqrt(y**2 + (-x + 10)**2) - 3
+    a, b = 191/S(20), 3*sqrt(391)/20
+    ans = [(a, -b), (a, b)]
+    assert solve((e1, e2), (x, y)) == ans
+    assert solve((e1, e2/(x - a)), (x, y)) == []
+    # make the 2nd circle's radius be -3
+    e2 += 6
+    assert solve((e1, e2), (x, y)) == []
+    assert solve((e1, e2), (x, y), check=False) == ans


### PR DESCRIPTION
fixes #2777

checking/simplification was not being done on non-linear systems of equations. Correcting this lead to some modified tests as a result of simplification.

In addition, the wrong keyword was listed in the docstring of solve: warning instead of warn. Although the code could have been changed, the keyword was changed in favor of the verb.
