### PR TITLE
Return False if Ellipses don't intersect

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -770,8 +770,8 @@ class Ellipse(GeometryEntity):
             inter = self.intersection(o)
             if isinstance(inter, Ellipse):
                 return False
-            return (inter is not None and isinstance(inter[0], Point)
-                    and len(inter) == 1)
+            return (inter is not None and len(inter) == 1
+                    and isinstance(inter[0], Point))
         elif isinstance(o, LinearEntity):
             inter = self._do_line_intersection(o)
             if inter is not None and len(inter) == 1:

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -900,6 +900,7 @@ def test_ellipse():
         Polygon(Point(1, 1), Point(1, -1), Point(2, 0))) is True
     assert c1.is_tangent(
         Polygon(Point(1, 1), Point(1, 0), Point(2, 0))) is False
+    assert Circle(Point(5, 5), 3).is_tangent(Circle(Point(0, 5), 1)) is False
 
     assert Ellipse(Point(5, 5), 2, 1).tangent_lines(Point(0, 0)) == \
         [Line(Point(0, 0), Point(77/25, 132/25)),


### PR DESCRIPTION
Fixes #7939

If the function `intersection` returns an empty list `inter`, the function `is_tangent` will return False as required.
