### PR TITLE
Adds line wrapping to Fortran codegen call signatures.

### DIFF
--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -769,7 +769,7 @@ class FCodeGen(CodeGen):
         args = ", ".join("%s" % self._get_symbol(arg.name)
                         for arg in routine.arguments)
 
-        call_sig = "{}({})\n".format(routine.name, args)
+        call_sig = "{0}({1})\n".format(routine.name, args)
         # Fortran 95 requires all lines be less than 132 characters, so wrap
         # this line before appending.
         call_sig = ' &\n'.join(textwrap.wrap(call_sig,

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -78,6 +78,7 @@ unsurmountable issues that can only be tackled with dedicated code generator:
 from __future__ import print_function, division
 
 import os
+import textwrap
 
 from sympy import __version__ as sympy_version
 from sympy.core import Symbol, S, Expr, Tuple, Equality, Function
@@ -766,12 +767,16 @@ class FCodeGen(CodeGen):
             code_list.append("subroutine")
 
         args = ", ".join("%s" % self._get_symbol(arg.name)
-                for arg in routine.arguments)
+                        for arg in routine.arguments)
 
-        # name of the routine + arguments
-        code_list.append("%s(%s)\n" % (routine.name, args))
-        code_list = [ " ".join(code_list) ]
-
+        call_sig = "{}({})\n".format(routine.name, args)
+        # Fortran 95 requires all lines be less than 132 characters, so wrap
+        # this line before appending.
+        call_sig = ' &\n'.join(textwrap.wrap(call_sig,
+                                             width=60,
+                                             break_long_words=False)) + '\n'
+        code_list.append(call_sig)
+        code_list = [' '.join(code_list)]
         code_list.append('implicit none\n')
         return code_list
 

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1126,6 +1126,46 @@ def test_inline_function():
         code == expected % args[::-1]
 
 
+def test_f_code_call_signature_wrap():
+    # Issue #7934
+    x = symbols('x:20')
+    expr = 0
+    for sym in x:
+        expr += sym
+    routine = Routine("test", expr)
+    code_gen = FCodeGen()
+    source = get_string(code_gen.dump_f95, [routine])
+    expected = """\
+REAL*8 function test(x0, x1, x10, x11, x12, x13, x14, x15, x16, x17, x18, &
+      x19, x2, x3, x4, x5, x6, x7, x8, x9)
+implicit none
+REAL*8, intent(in) :: x0
+REAL*8, intent(in) :: x1
+REAL*8, intent(in) :: x10
+REAL*8, intent(in) :: x11
+REAL*8, intent(in) :: x12
+REAL*8, intent(in) :: x13
+REAL*8, intent(in) :: x14
+REAL*8, intent(in) :: x15
+REAL*8, intent(in) :: x16
+REAL*8, intent(in) :: x17
+REAL*8, intent(in) :: x18
+REAL*8, intent(in) :: x19
+REAL*8, intent(in) :: x2
+REAL*8, intent(in) :: x3
+REAL*8, intent(in) :: x4
+REAL*8, intent(in) :: x5
+REAL*8, intent(in) :: x6
+REAL*8, intent(in) :: x7
+REAL*8, intent(in) :: x8
+REAL*8, intent(in) :: x9
+test = x0 + x1 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + &
+      x19 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9
+end function
+"""
+    assert source == expected
+
+
 def test_check_case():
     x, X = symbols('x,X')
     raises(CodeGenError, lambda: codegen(('test', x*X), 'f95', 'prefix'))


### PR DESCRIPTION
Fortran has a maximum line length of 132 characters. The fcode printer handles
this for the expressions itself, but the call signature failed to wrap if the
number or length of arguments is too large. This fix should deal with most
normal cases.

Fixes issue #7934.
