### PR TITLE
Fix timeout for SLOW tests

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -32,7 +32,7 @@ EOF
         cd ..
         bin/doctest doc/
     elif [[ "${TEST_SLOW}" == "true" ]]; then
-        cat << EOF | python
+        cat << EOF | SYMPY_CACHE_SIZE=None python
 import sympy
 if not sympy.test(split='${SPLIT}', slow=True, timeout=180):
     # Travis times out if no activity is seen for 10 minutes. It also times


### PR DESCRIPTION
The `SLOW` tests on travis time out fairly regularly with 'no output for 10 minutes' and such.  This is likely due to the copious number of symbols that are created during the slow tests.  An excessive number of symbols would lead to lots and lots and lots of cache misses, resulting in a significant slowdown.  To address this issue, use an unbounded cache for `SLOW` tests.  This may not fix the issue entirely but it should make the timeouts much less frequent.

The only way to really test this is to restart the `SLOW` tests a few times.  I've restarted them 3x on my own branch and didn't see any timeouts but we should repeat the procedure here.
