### PR TITLE
cache autowrap

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -75,6 +75,7 @@ import shutil
 import tempfile
 from subprocess import STDOUT, CalledProcessError
 
+from sympy.core.cache import cacheit
 from sympy.core.compatibility import check_output
 from sympy.utilities.codegen import (
     get_code_generator, Routine, OutputArgument, InOutArgument, InputArgument,
@@ -401,11 +402,11 @@ def _get_code_wrapper_class(backend):
         'DUMMY': DummyWrapper}
     return wrappers[backend.upper()]
 
-
+@cacheit
 @doctest_depends_on(exe=('f2py', 'gfortran'), modules=('numpy',))
 def autowrap(
-    expr, language='F95', backend='f2py', tempdir=None, args=None, flags=[],
-        verbose=False, helpers=[]):
+    expr, language='F95', backend='f2py', tempdir=None, args=None, flags=(),
+        verbose=False, helpers=()):
     """Generates python callable binaries based on the math expression.
 
     expr

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -426,17 +426,17 @@ def autowrap(
         Sequence of the formal parameters of the generated code, if ommited the
         function signature is determined by the code generator.
     flags
-        Additional option flags that will be passed to the backend
+        Tuple of additional option flags that will be passed to the backend
     verbose
         If True, autowrap will not mute the command line backends.  This can be
         helpful for debugging.
     helpers
         Used to define auxillary expressions needed for the main expr.  If the
         main expression need to do call a specialized function it should be put
-        in the ``helpers`` list.  Autowrap will then make sure that the compiled
-        main expression can link to the helper routine.  Items should be tuples
-        with (<funtion_name>, <sympy_expression>, <arguments>).  It is
-        mandatory to supply an argument sequence to helper routines.
+        in the ``helpers`` tuple.  Autowrap will then make sure that the
+        compiled main expression can link to the helper routine.  Items should
+        also be tuples with (<funtion_name>, <sympy_expression>, <arguments>).
+        It is mandatory to supply an argument sequence to helper routines.
 
     >>> from sympy.abc import x, y, z
     >>> from sympy.utilities.autowrap import autowrap


### PR DESCRIPTION
cache results of autowrap following discussion of #7973.

Sample session:

``` python
In [1]: from sympy.utilities.autowrap import autowrap

In [2]: from sympy import (
    symbols, lambdify, sqrt, sin, cos, tan, pi, atan, acos, acosh, Rational,
    Float, Matrix, Lambda, exp, Integral, oo, I, Abs, Function, true, false)

In [3]: w, x, y, z = symbols('w,x,y,z')

In [4]: expr = sin(x) + cos(y) + tan(z)**2 + Abs(z-y)*acos(sin(y*z)) + \
           Abs(y-z)*acosh(2+exp(y-x))- sqrt(x**2+I*y**2)

In [5]: %time bin = autowrap(expr)
CPU times: user 100 ms, sys: 14 ms, total: 114 ms
Wall time: 1.12 s

In [6]: bin(1, 2, 3)
Out[6]: 2.9323081800586097

In [7]: %time bin = autowrap(expr)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 41.7 µs

In [8]: bin(1, 2, 3)
Out[8]: 2.9323081800586097
```
