### PR TITLE
ineq `<` same as functional forms `Lt` and drop ineq simplification

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -225,7 +225,7 @@ class Expr(Basic, EvalfMixin):
         if dif.is_nonnegative is not None and \
                 dif.is_nonnegative is not dif.is_negative:
             return sympify(dif.is_nonnegative)
-        return C.GreaterThan(self, other)
+        return C.GreaterThan(self, other, evaluate=False)
 
     def __le__(self, other):
         try:
@@ -239,7 +239,7 @@ class Expr(Basic, EvalfMixin):
         if dif.is_nonpositive is not None and \
                 dif.is_nonpositive is not dif.is_positive:
             return sympify(dif.is_nonpositive)
-        return C.LessThan(self, other)
+        return C.LessThan(self, other, evaluate=False)
 
     def __gt__(self, other):
         try:
@@ -253,7 +253,7 @@ class Expr(Basic, EvalfMixin):
         if dif.is_positive is not None and \
                 dif.is_positive is not dif.is_nonpositive:
             return sympify(dif.is_positive)
-        return C.StrictGreaterThan(self, other)
+        return C.StrictGreaterThan(self, other, evaluate=False)
 
     def __lt__(self, other):
         try:
@@ -267,7 +267,7 @@ class Expr(Basic, EvalfMixin):
         if dif.is_negative is not None and \
                 dif.is_negative is not dif.is_nonnegative:
             return sympify(dif.is_negative)
-        return C.StrictLessThan(self, other)
+        return C.StrictLessThan(self, other, evaluate=False)
 
     @staticmethod
     def _from_mpmath(x, prec):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -596,7 +596,8 @@ class GreaterThan(_Greater):
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
-        return _sympify(lhs >= rhs)
+        # We don't use the op symbol here: workaround issue #7951
+        return _sympify(lhs.__ge__(rhs))
 
 Ge = GreaterThan
 
@@ -609,7 +610,8 @@ class LessThan(_Less):
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
-        return _sympify(lhs <= rhs)
+        # We don't use the op symbol here: workaround issue #7951
+        return _sympify(lhs.__le__(rhs))
 
 Le = LessThan
 
@@ -622,7 +624,8 @@ class StrictGreaterThan(_Greater):
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
-        return _sympify(lhs > rhs)
+        # We don't use the op symbol here: workaround issue #7951
+        return _sympify(lhs.__gt__(rhs))
 
 Gt = StrictGreaterThan
 
@@ -635,7 +638,8 @@ class StrictLessThan(_Less):
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
-        return _sympify(lhs < rhs)
+        # We don't use the op symbol here: workaround issue #7951
+        return _sympify(lhs.__lt__(rhs))
 
 Lt = StrictLessThan
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -106,8 +106,15 @@ class Relational(Boolean, Expr, EvalfMixin):
         return cls(lhs, rhs)
 
     def _eval_simplify(self, ratio, measure):
-        return self.__class__(self.lhs.simplify(ratio=ratio),
-                              self.rhs.simplify(ratio=ratio))
+        r = self.__class__(self.lhs.simplify(ratio=ratio),
+                           self.rhs.simplify(ratio=ratio))
+        if r not in (S.true, S.false):
+            # try harder to reduce to boolean
+            # NOTE: may want to move _eval_sides() code here
+            rr = self._eval_sides(self.lhs, self.rhs)
+            if rr is not None:
+                return rr
+        return r
 
     def __nonzero__(self):
         raise TypeError("symbolic boolean expression has no truth value.")

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,6 +1,7 @@
 from sympy import I, sqrt, log, exp, sin, asin
 from sympy.core import Symbol, S, Rational, Integer
 from sympy.core.facts import InconsistentAssumptions
+from sympy import simplify
 
 from sympy.utilities.pytest import raises, XFAIL
 
@@ -664,8 +665,8 @@ def test_sanitize_assumptions():
 
 def test_special_assumptions():
     e = -3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2
-    assert (e < 0) is S.false
-    assert (e > 0) is S.false
+    assert simplify(e < 0) is S.false
+    assert simplify(e > 0) is S.false
     assert (e == 0) is False  # it's not a literal 0
     assert e.equals(0) is True
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -481,3 +481,27 @@ def test_inequalities_cant_sympify_other():
     for a in (x, S(0), S(1)/3, pi, I, zoo, oo, -oo, nan):
         for op in (lt, gt, le, ge):
             raises(TypeError, lambda: op(a, bar))
+
+
+@XFAIL
+def test_inequalities_wild_symbol_no_flip():
+    # see issue #7951.
+    from sympy.core.symbol import Wild
+    p = symbols('p', cls=Wild)
+    # here's particular failure I encountered which gave `q_ > x`
+    e = Lt(x, y)
+    e = e.subs({y: p})
+    x_lt_p = Lt(x, p, evaluate=False)
+    assert e == x_lt_p
+    # and some generalized tests
+    x_gt_p = Gt(x, p, evaluate=False)
+    x_le_p = Le(x, p, evaluate=False)
+    x_ge_p = Ge(x, p, evaluate=False)
+    assert x < p == x_lt_p
+    assert x > p == x_gt_p
+    assert x <= p == x_le_p
+    assert x >= p == x_ge_p
+    assert Lt(x, p) == x_lt_p
+    assert Gt(x, p) == x_gt_p
+    assert Le(x, p) == x_le_p
+    assert Ge(x, p) == x_ge_p

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -439,7 +439,6 @@ def test_nan_equality_exceptions():
     assert Unequality(random.choice(A), nan) is S.true
 
 
-@XFAIL
 def test_inequalities_symbol_name_same():
     """Using the operator and functional forms should give same results."""
     # currently fails because rhs reduces to bool but the lhs does not
@@ -456,7 +455,6 @@ def test_inequalities_symbol_name_same():
             assert Le(a, b) == (a <= b)
 
 
-@XFAIL
 def test_inequalities_symbol_name_same_complex():
     """Using the operator and functional forms should give same results.
     With complex non-real numbers, both should raise errors.

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -483,25 +483,16 @@ def test_inequalities_cant_sympify_other():
             raises(TypeError, lambda: op(a, bar))
 
 
-@XFAIL
-def test_inequalities_wild_symbol_no_flip():
-    # see issue #7951.
+def test_ineq_avoid_wild_symbol_flip():
+    # see issue #7951, we try to avoid this internally, e.g., by using
+    # __lt__ instead of "<".
     from sympy.core.symbol import Wild
     p = symbols('p', cls=Wild)
-    # here's particular failure I encountered which gave `q_ > x`
-    e = Lt(x, y)
-    e = e.subs({y: p})
-    x_lt_p = Lt(x, p, evaluate=False)
-    assert e == x_lt_p
-    # and some generalized tests
-    x_gt_p = Gt(x, p, evaluate=False)
-    x_le_p = Le(x, p, evaluate=False)
-    x_ge_p = Ge(x, p, evaluate=False)
-    assert x < p == x_lt_p
-    assert x > p == x_gt_p
-    assert x <= p == x_le_p
-    assert x >= p == x_ge_p
-    assert Lt(x, p) == x_lt_p
-    assert Gt(x, p) == x_gt_p
-    assert Le(x, p) == x_le_p
-    assert Ge(x, p) == x_ge_p
+    # x > p might flip, but Gt should not:
+    assert Gt(x, p) == Gt(x, p, evaluate=False)
+    # Previously failed as 'p > x':
+    e = Lt(x, y).subs({y: p})
+    assert e == Lt(x, p, evaluate=False)
+    # Previously failed as 'p <= x':
+    e = Ge(x, p).doit()
+    assert e == Ge(x, p, evaluate=False)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -130,10 +130,10 @@ def test_bool():
     assert Ge(1, 1) is S.true
     assert Eq(I, 2) is S.false
     assert Ne(I, 2) is S.true
-    assert Gt(I, 2) not in [S.true, S.false]
-    assert Ge(I, 2) not in [S.true, S.false]
-    assert Lt(I, 2) not in [S.true, S.false]
-    assert Le(I, 2) not in [S.true, S.false]
+    raises(TypeError, lambda: Gt(I, 2))
+    raises(TypeError, lambda: Ge(I, 2))
+    raises(TypeError, lambda: Lt(I, 2))
+    raises(TypeError, lambda: Le(I, 2))
     a = Float('.000000000000000000001', '')
     b = Float('.0000000000000000000001', '')
     assert Eq(pi + a, pi + b) is S.false

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1830,7 +1830,8 @@ def test_matrix_norm():
         # Check Triangle Inequality for all Pairs of Matrices
         for X in L:
             for Y in L:
-                assert X.norm(order) + Y.norm(order) >= (X + Y).norm(order)
+                assert simplify(X.norm(order) + Y.norm(order) >=
+                                (X + Y).norm(order))
         # Scalar multiplication linearity
         for M in [A, B, C, D]:
             if order in [2, -2]:
@@ -1863,7 +1864,8 @@ def test_matrix_norm():
         if order >= 1:  # Triangle InEq holds only for these norms
             for v in L:
                 for w in L:
-                    assert v.norm(order) + w.norm(order) >= (v + w).norm(order)
+                    assert simplify(v.norm(order) + w.norm(order) >=
+                                    (v + w).norm(order))
         # Linear to scalar multiplication
         if order in [1, 2, -1, -2, S.Infinity, S.NegativeInfinity]:
             for vec in L:

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -12,6 +12,7 @@ from sympy.assumptions import ask, AppliedPredicate, Q
 from sympy.functions import re, im, Abs
 from sympy.logic import And
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
+from sympy.simplify import simplify
 
 
 def solve_poly_inequality(poly, rel):
@@ -390,17 +391,17 @@ def solve_univariate_inequality(expr, gen, assume=True, relational=True):
 
     for x in sorted(s for s in solns if s.is_real):
         end = x
-        if expr.subs(gen, (start + end)/2 if start != -oo else end - 1):
+        if simplify(expr.subs(gen, (start + end)/2 if start != -oo else end - 1)):
             sol_sets.append(Interval(start, end, True, True))
 
-        if expr.subs(gen, x):
+        if simplify(expr.subs(gen, x)):
             sol_sets.append(FiniteSet(x))
 
         start = end
 
     end = oo
 
-    if expr.subs(gen, start + 1):
+    if simplify(expr.subs(gen, start + 1)):
         sol_sets.append(Interval(start, end, True, True))
 
     rv = Union(*sol_sets)


### PR DESCRIPTION
This is like #7838 but does not attempt to maintain the status quo of simplifying during inequality creation.  Expect broken tests.
