### PR TITLE
manually revert 4346424be94ff3e0a4a4fbfc5a6f35a3a0009d5a

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -64,8 +64,6 @@ class Symbol(AtomicExpr, Boolean):
 
         """
 
-        if assumptions.get('zero', False):
-            return S.Zero
         is_commutative = fuzzy_bool(assumptions.get('commutative', True))
         if is_commutative is None:
             raise ValueError(

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -493,6 +493,10 @@ def test_Add_is_even_odd():
 def test_Mul_is_negative_positive():
     x = Symbol('x', real=True)
     y = Symbol('y', real=False)
+    z = Symbol('z', zero=True)
+
+    e = 2*z
+    assert e.is_Mul and e.is_positive is False and e.is_negative is False
 
     neg = Symbol('neg', negative=True)
     pos = Symbol('pos', positive=True)
@@ -1035,42 +1039,51 @@ def test_Pow_is_even_odd():
 
 
 def test_Pow_is_negative_positive():
-    x = Symbol('x', real=True)
+    r = Symbol('r', real=True)
 
     k = Symbol('k', integer=True, positive=True)
     n = Symbol('n', even=True)
     m = Symbol('m', odd=True)
 
-    z = Symbol('z')
+    x = Symbol('x')
 
-    assert (2**x).is_positive is True
-    assert ((-2)**x).is_positive is None
+    assert (2**r).is_positive is True
+    assert ((-2)**r).is_positive is None
     assert ((-2)**n).is_positive is True
     assert ((-2)**m).is_positive is False
 
     assert (k**2).is_positive is True
     assert (k**(-2)).is_positive is True
 
-    assert (k**x).is_positive is True
-    assert ((-k)**x).is_positive is None
+    assert (k**r).is_positive is True
+    assert ((-k)**r).is_positive is None
     assert ((-k)**n).is_positive is True
     assert ((-k)**m).is_positive is False
 
-    assert (2**x).is_negative is False
-    assert ((-2)**x).is_negative is None
+    assert (2**r).is_negative is False
+    assert ((-2)**r).is_negative is None
     assert ((-2)**n).is_negative is False
     assert ((-2)**m).is_negative is True
 
     assert (k**2).is_negative is False
     assert (k**(-2)).is_negative is False
 
-    assert (k**x).is_negative is False
-    assert ((-k)**x).is_negative is None
+    assert (k**r).is_negative is False
+    assert ((-k)**r).is_negative is None
     assert ((-k)**n).is_negative is False
     assert ((-k)**m).is_negative is True
 
-    assert (2**z).is_positive is None
-    assert (2**z).is_negative is None
+    assert (2**x).is_positive is None
+    assert (2**x).is_negative is None
+
+
+@XFAIL
+def test_Pow_is_zero():
+    z = Symbol('z', zero=True)
+    e = z**2
+    assert e.is_zero
+    assert e.is_positive is False
+    assert e.is_negative is False
 
 
 def test_Pow_is_nonpositive_nonnegative():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -673,16 +673,6 @@ def test_sanitize_assumptions():
 
 
 def test_special_assumptions():
-    x = Symbol('x')
-    z2 = z = Symbol('z', zero=True)
-    assert z2 == z == S.Zero
-    assert (2*z).is_positive is False
-    assert (2*z).is_negative is False
-    assert (2*z).is_zero is True
-    assert (z2*z).is_positive is False
-    assert (z2*z).is_negative is False
-    assert (z2*z).is_zero is True
-
     e = -3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2
     assert (e < 0) is S.false
     assert (e > 0) is S.false


### PR DESCRIPTION
allow var('x', zero=True) -- there are already many ways to work around the current return of 0. One advantage of having this is that then one can work with a zero expression without using an unevaluated expression:

```
>>> var('z',zero=1)
z
>>> var('x',bounded=1)
x
>>> z*x  # doesn't evaluates
x*z
>>> _.is_zero
True
>>> 0*x  # evaluates
0
```
