### PR TITLE
`sympify` input to codeprinters

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -110,6 +110,8 @@ class CodePrinter(StrPrinter):
 
         if assign_to:
             expr = Assignment(assign_to, expr)
+        else:
+            expr = _sympify(expr)
 
         # keep a set of expressions that are not strictly translatable to Code
         # and number constants that must be declared and initialized


### PR DESCRIPTION
Ensures expression is hashable. Fixes issue #7980.
