### PR TITLE
NaN: remove erroneous docstring about inequality raising TypeError

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2538,8 +2538,7 @@ class NaN(with_metaclass(Singleton, Number)):
 
     NaN is mathematically not equal to anything else, even NaN itself.  This
     explains the initially counter-intuitive results with ``Eq`` and ``==`` in
-    the examples below.  NaN is not comparable so inequalities raise a
-    TypeError.
+    the examples below.
 
     NaN is a singleton, and can be accessed by ``S.NaN``, or can be imported
     as ``nan``.


### PR DESCRIPTION
This is an artifact of pr #7776 and should not have been included.
#7834 puts this back, but that is not too likely to merge soon (or at all), so please merge this.
