### PR TITLE
XFAIL'd tests for cases Equality.simplify() could improve on

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -243,7 +243,10 @@ class Equality(Relational):
                 return S.false
             # Consider the difference of lhs and rhs.  Here "is_zero" should
             # detect incompatibilities (e.g., lhs negative and rhs positive).
-            if (isinstance(lhs, Expr) and isinstance(rhs, Expr)
+            # [Note: clean-up after pr #7997.]  Do not use this for
+            # non-complex things such as non-commutative symbols.
+            if (isinstance(lhs, Expr) and isinstance(rhs, Expr) and
+                    lhs.is_complex and rhs.is_complex):
                 r = (lhs - rhs).is_zero
                 if r is not None:
                     return _sympify(r)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -722,3 +722,11 @@ def test_issue_7899():
     assert (I*x).is_real is None
     assert ((x - I)*(x - 1)).is_zero is None
     assert ((x - I)*(x - 1)).is_real is None
+
+
+@XFAIL
+def test_is_zero_int_minus_nonzero_nonint():
+    # see issue #7993
+    x = Dummy(integer=True)
+    y = Dummy(noninteger=True)
+    assert (x-y).is_zero == False

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -165,6 +165,37 @@ def test_doit():
     assert Eq(x, 0).doit() == Eq(x, 0)
 
 
+@XFAIL
+def test_eq_pos_neg_assumptions():
+    p = Symbol('p', positive=True)
+    n = Symbol('n', negative=True)
+    np = Symbol('np', nonpositive=True)
+    nn = Symbol('nn', nonnegative=True)
+    assert Eq(p, 0) is S.false
+    assert Ne(p, 0) is S.true
+    assert Eq(n, 0) is S.false
+    assert Ne(n, 0) is S.true
+    assert Eq(np, 0) == Eq(np, 0, evaluate=False)
+    assert Eq(nn, 0) == Eq(nn, 0, evaluate=False)
+    assert Ne(np, 0) == Ne(np, 0, evaluate=False)
+    assert Ne(nn, 0) == Ne(nn, 0, evaluate=False)
+
+
+def test_eq_pos_neg_times_I_assump():
+    p = Symbol('p', positive=True)
+    n = Symbol('n', negative=True)
+    np = Symbol('np', nonpositive=True)
+    nn = Symbol('nn', nonnegative=True)
+    assert Eq(p*I, 0) is S.false
+    assert Ne(p*I, 0) is S.true
+    assert Eq(n*I, 0) is S.false
+    assert Ne(n*I, 0) is S.true
+    assert Eq(np*I, 0) == Eq(np*I, 0, evaluate=False)
+    assert Eq(nn*I, 0) == Eq(nn*I, 0, evaluate=False)
+    assert Ne(np*I, 0) == Ne(np*I, 0, evaluate=False)
+    assert Ne(nn*I, 0) == Ne(nn*I, 0, evaluate=False)
+
+
 def test_new_relational():
     x = Symbol('x')
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,6 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
                    Implies, Xor, zoo)
+from sympy.core.symbol import Dummy
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
@@ -193,6 +194,11 @@ def test_eq_pos_neg_times_I_assump():
     assert Eq(nn*I, 0) == Eq(nn*I, 0, evaluate=False)
     assert Ne(np*I, 0) == Ne(np*I, 0, evaluate=False)
     assert Ne(nn*I, 0) == Ne(nn*I, 0, evaluate=False)
+
+
+def test_eq_noncommutative():
+    A, B = symbols('A B', commutative=False)
+    assert Eq(A, B) == Eq(A, B, evaluate=False)
 
 
 def test_new_relational():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -546,3 +546,19 @@ def test_eq_simplify_to_true():
     assert e.subs(x, 10).simplify()
     assert e.simplify()  # FAIL
     #print((lhs - rhs).equals(0))
+
+
+@XFAIL
+def test_eq_simplify_cancels_lhs_rhs():
+    # should simplifying an Equality cancel terms from lhs and rhs?
+    b = Dummy(bounded=True)
+    r = Dummy(real=True)
+    data = [(2 + I, r + I, Eq(2, r)),
+            (2 + I, x + I, Eq(2, x)),
+            (2 + b, x + b, Eq(2, x)),
+            (x + 1, y + 1, Eq(x, y)),
+            (2 + y, x + y, Eq(2, x))]  # maybe not this one
+    for (lhs, rhs, expected_simplify) in data:
+        e = Eq(lhs, rhs)
+        assert e == Eq(lhs, rhs, evaluate=False)
+        assert e.simplify() == expected_simplify

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -521,3 +521,16 @@ def test_ineq_avoid_wild_symbol_flip():
     # Previously failed as 'p <= x':
     e = Ge(x, p).doit()
     assert e == Ge(x, p, evaluate=False)
+
+
+def test_eq_no_simplification():
+    from sympy import sin, cos, sqrt
+    data = [ (cos(x)**2 + sin(x)**2, 1, S.true),
+             (cos(x)**2 + sin(x)**2, 2, S.false),
+             (x*(y + z), x*y + x*z, S.true),
+             (sqrt(4*sqrt(2) + 4), 2*sqrt(sqrt(2) + 1), S.true),
+             ((6**pi + 2**pi)**(1/pi), 2*(3**pi + 1)**(1/pi), S.true) ]
+    for (lhs, rhs, truth) in data:
+        e = Eq(lhs, rhs)
+        assert e == Eq(lhs, rhs, evaluate=False)
+        assert e.simplify() is truth

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -534,3 +534,15 @@ def test_eq_no_simplification():
         e = Eq(lhs, rhs)
         assert e == Eq(lhs, rhs, evaluate=False)
         assert e.simplify() is truth
+
+
+@XFAIL
+def test_eq_simplify_to_true():
+    # should probably simplify but doesn't with a variable.  The
+    # simplification is based on .equals(0) which returns None here.
+    lhs = (2**pi*x + 2**pi)**(1/pi)
+    rhs = 2*(x + 1)**(1/pi)
+    e = Eq(lhs, rhs)
+    assert e.subs(x, 10).simplify()
+    assert e.simplify()  # FAIL
+    #print((lhs - rhs).equals(0))

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -167,33 +167,22 @@ def test_doit():
 
 
 def test_eq_pos_neg_assumptions():
-    p = Symbol('p', positive=True)
-    n = Symbol('n', negative=True)
-    np = Symbol('np', nonpositive=True)
-    nn = Symbol('nn', nonnegative=True)
+    # see issue #6116
+    p = Dummy(positive=True)
+    n = Dummy(negative=True)
+    np = Dummy(nonpositive=True)
+    nn = Dummy(nonnegative=True)
     assert Eq(p, 0) is S.false
-    assert Ne(p, 0) is S.true
     assert Eq(n, 0) is S.false
-    assert Ne(n, 0) is S.true
     assert Eq(np, 0) == Eq(np, 0, evaluate=False)
     assert Eq(nn, 0) == Eq(nn, 0, evaluate=False)
-    assert Ne(np, 0) == Ne(np, 0, evaluate=False)
-    assert Ne(nn, 0) == Ne(nn, 0, evaluate=False)
 
 
-def test_eq_pos_neg_times_I_assump():
-    p = Symbol('p', positive=True)
-    n = Symbol('n', negative=True)
-    np = Symbol('np', nonpositive=True)
-    nn = Symbol('nn', nonnegative=True)
-    assert Eq(p*I, 0) is S.false
-    assert Ne(p*I, 0) is S.true
-    assert Eq(n*I, 0) is S.false
-    assert Ne(n*I, 0) is S.true
-    assert Eq(np*I, 0) == Eq(np*I, 0, evaluate=False)
-    assert Eq(nn*I, 0) == Eq(nn*I, 0, evaluate=False)
-    assert Ne(np*I, 0) == Ne(np*I, 0, evaluate=False)
-    assert Ne(nn*I, 0) == Ne(nn*I, 0, evaluate=False)
+def test_eq_incompatibility_gives_false():
+    # Incompatibility between lhs and rhs should be detected by 'is_zero'
+    a = Dummy(irrational=True)
+    b = Dummy(integer=True)
+    assert Eq(a, b) is S.false
 
 
 def test_eq_noncommutative():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -165,7 +165,6 @@ def test_doit():
     assert Eq(x, 0).doit() == Eq(x, 0)
 
 
-@XFAIL
 def test_eq_pos_neg_assumptions():
     p = Symbol('p', positive=True)
     n = Symbol('n', negative=True)


### PR DESCRIPTION
This is on top of #7960.  See final two commits w/ "XFail test".

Not very urgent, stuff like `Eq(x+1, y+1)` which user might like to simplify to `Eq(x, y)`.

The other example is take radicals like #7981 and put symbols inside.  `(lhs-rhs).equals(0)` (main tool from `_eval_sides()`) doesn't help here.
