### PR TITLE
srepr(Symbol(...)) will show assumptions

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -134,7 +134,15 @@ class ReprPrinter(Printer):
                                            self._print(expr.a), self._print(expr.b))
 
     def _print_Symbol(self, expr):
-        return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+        from sympy.core.assumptions import _minimal_assumptions as m
+        t, f = m(expr)
+        if t or f:
+            attr = ['%s=1'%k for k in t]
+            attr.extend(['%s=0'%k for k in f])
+            return "%s(%s, %s)" % (expr.__class__.__name__,
+                self._print(expr.name), ', '.join(attr))
+        else:
+            return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
 
     def _print_Predicate(self, expr):
         return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,7 @@
 from sympy.utilities.pytest import raises
-from sympy import symbols, Function, Integer, Matrix, Abs, \
-    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false
+from sympy import (symbols, Function, Integer, Matrix, Abs,
+    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false,
+    Symbol)
 from sympy.core.compatibility import exec_
 from sympy.geometry import Point, Ellipse
 from sympy.printing import srepr
@@ -105,6 +106,10 @@ def test_Float():
 def test_Symbol():
     sT(x, "Symbol('x')")
     sT(y, "Symbol('y')")
+    sT(Symbol('x', negative=True), "Symbol('x', negative=1)")
+    sT(Symbol('x', negative=0, integer=1), "Symbol('x', integer=1, nonnegative=1)")
+    sT(Symbol('x', odd=0, integer=1), "Symbol('x', even=1)")
+    sT(Symbol('x', odd=0, real=1), "Symbol('x', real=1, odd=0)")
 
 
 def test_tuple():


### PR DESCRIPTION
The modifications here allow one to see a canonical representation of the assumptions needed to create a given symbol (whereas in master we can't see the assumptions easily and although we can inspect the assumptions0 mapping, there isn't a canonical representation of that):

```
>>> srepr(Dummy('',odd=1,positive=1))
"Dummy('', nonnegative=1, odd=1)"
>>> srepr(Dummy('',real=0,nonnegative=0))
"Dummy('', real=0)"
```
