### PR TITLE
sign(sqrt(1-sqrt(2))) -> I instead of being unevaluated

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -234,28 +234,25 @@ class sign(Function):
         if arg.is_Mul:
             c, args = arg.as_coeff_mul()
             unk = []
-            is_imag = c.is_imaginary
-            is_neg = c.is_negative
+            s = sign(c)
             for a in args:
                 if a.is_negative:
-                    is_neg = not is_neg
+                    s = -s
                 elif a.is_positive:
                     pass
                 else:
                     ai = im(a)
                     if a.is_imaginary and ai.is_comparable:  # i.e. a = I*real
-                        if is_imag:
-                            is_neg = not is_neg  # I*I = -1
-                        is_imag = not is_imag
+                        s *= S.ImaginaryUnit
                         if ai.is_negative:
-                            is_neg = not is_neg
+                            # can't use sign(ai) here since ai might not be
+                            # a Number
+                            s = -s
                     else:
                         unk.append(a)
             if c is S.One and len(unk) == len(args):
                 return None
-            return (S.NegativeOne if is_neg else S.One) \
-                * (S.ImaginaryUnit if is_imag else S.One) \
-                * cls(arg._new_rawargs(*unk))
+            return s * cls(arg._new_rawargs(*unk))
         if arg is S.NaN:
             return S.NaN
         if arg.is_zero:  # it may be an Expr that is zero

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -5,6 +5,7 @@ from sympy.core.compatibility import u
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import (Function, Derivative, ArgumentIndexError,
     AppliedUndef)
+from sympy.core.logic import fuzzy_not
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.core import Add, Mul
@@ -291,6 +292,14 @@ class sign(Function):
             from sympy.functions.special.delta_functions import DiracDelta
             return 2 * Derivative(self.args[0], x, evaluate=True) \
                 * DiracDelta(-S.ImaginaryUnit * self.args[0])
+
+    def _eval_is_nonnegative(self):
+        if self.args[0].is_nonnegative:
+            return True
+
+    def _eval_is_nonpositive(self):
+        if self.args[0].is_nonpositive:
+            return True
 
     def _eval_is_imaginary(self):
         return self.args[0].is_imaginary

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -266,6 +266,10 @@ class sign(Function):
             if arg.func is sign:
                 return arg
         if arg.is_imaginary:
+            if arg.is_Pow and arg.exp is S.Half:
+                # we catch this because non-trivial sqrt args are not expanded
+                # e.g. sqrt(1-sqrt(2)) --x-->  to I*sqrt(sqrt(2) - 1)
+                return S.ImaginaryUnit
             arg2 = -S.ImaginaryUnit * arg
             if arg2.is_positive:
                 return S.ImaginaryUnit

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -200,20 +200,38 @@ class im(Function):
 
 class sign(Function):
     """
-    Returns the sign of an expression, that is:
+    Returns the complex sign of an expression:
 
-    * 1 if expression is positive
-    * 0 if expression is equal to zero
-    * -1 if expression is negative
+    If the expresssion is real the sign will be:
+
+        * 1 if expression is positive
+        * 0 if expression is equal to zero
+        * -1 if expression is negative
+
+    If the expresssion is imaginary the sign will be:
+
+        * I if im(expression) is positive
+        * -I if im(expression) is negative
+
+    Otherwise an unevaluated expression will be returned. When evaluated, the
+    result (in general) will be ``cos(arg(expr)) + I*sin(arg(expr))``.
 
     Examples
     ========
 
     >>> from sympy.functions import sign
+    >>> from sympy.core.numbers import I
+
     >>> sign(-1)
     -1
     >>> sign(0)
     0
+    >>> sign(-3*I)
+    -I
+    >>> sign(1 + I)
+    sign(1 + I)
+    >>> _.evalf()
+    0.707106781186548 + 0.707106781186548*I
 
     See Also
     ========

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -244,6 +244,8 @@ class sign(Function):
                 else:
                     ai = im(a)
                     if a.is_imaginary and ai.is_comparable:  # i.e. a = I*real
+                        if is_imag:
+                            is_neg = not is_neg  # I*I = -1
                         is_imag = not is_imag
                         if ai.is_negative:
                             is_neg = not is_neg

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -217,6 +217,14 @@ def test_sign():
     assert sign(nz)**2 == 1
     assert (sign(nz)**3).args == (sign(nz), 3)
 
+    assert sign(Symbol('x', nonnegative=True)).is_nonnegative
+    assert sign(Symbol('x', nonnegative=True)).is_nonpositive is None
+    assert sign(Symbol('x', nonpositive=True)).is_nonnegative is None
+    assert sign(Symbol('x', nonpositive=True)).is_nonpositive
+    assert sign(Symbol('x', real=True)).is_nonnegative is None
+    assert sign(Symbol('x', real=True)).is_nonpositive is None
+    assert sign(Symbol('x', real=True, zero=False)).is_nonpositive is None
+
     x, y = Symbol('x', real=True), Symbol('y')
     assert sign(x).rewrite(Piecewise) == \
         Piecewise((1, x > 0), (-1, x < 0), (0, True))

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -140,6 +140,8 @@ def test_sign():
     assert sign(2 + 2*I).doit() == sqrt(2)*(2 + 2*I)/4
     assert sign(2 + 3*I).simplify() == sign(2 + 3*I)
     assert sign(2 + 2*I).simplify() == sign(1 + I)
+    assert sign(im(sqrt(1 - sqrt(3)))) == 1
+    assert sign(sqrt(1 - sqrt(3))) == I
 
     x = Symbol('x')
     assert sign(x).is_bounded is True


### PR DESCRIPTION
Numerical expression that are not not Numbers and symbolic expressions are not autoexpanded like sqrt(-2)->I*sqrt(2). So sign is made aware of this condition so sign of well defined negative args of sqrt can be returned as `I`.

In addition, the changing of sign by multiple I tems is better implemented.
