### PR TITLE
Change behavior of lambdify deprecation

### DIFF
--- a/doc/src/tutorial/basic_operations.rst
+++ b/doc/src/tutorial/basic_operations.rst
@@ -173,7 +173,7 @@ the given numerical library, usually NumPy.  For example
     >>> import numpy # doctest:+SKIP
     >>> a = numpy.arange(10) # doctest:+SKIP
     >>> expr = sin(x)
-    >>> f = lambdify(x, expr, "numpy", default_array=True) # doctest:+SKIP
+    >>> f = lambdify(x, expr, "numpy") # doctest:+SKIP
     >>> f(a) # doctest:+SKIP
     [ 0.          0.84147098  0.90929743  0.14112001 -0.7568025  -0.95892427
      -0.2794155   0.6569866   0.98935825  0.41211849]
@@ -187,7 +187,7 @@ See issue `#7853 <https://github.com/sympy/sympy/issues/7853>`_ for more informa
 You can use other libraries than NumPy. For example, to use the standard
 library math module, use ``"math"``.
 
-    >>> f = lambdify(x, expr, "math", default_array=True)
+    >>> f = lambdify(x, expr, "math")
     >>> f(0.1)
     0.0998334166468
 
@@ -199,7 +199,7 @@ dictionary of ``sympy_name:numerical_function`` pairs.  For example
     ...     My sine. Not only accurate for small x.
     ...     """
     ...     return x
-    >>> f = lambdify(x, expr, {"sin":mysin}, default_array=True)
+    >>> f = lambdify(x, expr, {"sin":mysin})
     >>> f(0.1)
     0.1
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1035,9 +1035,6 @@ def hypsum(expr, n, start, prec):
     polynomials.
     """
     from sympy import hypersimp, lambdify
-    # TODO: This should be removed for the release of 0.7.7, see issue #7853
-    from functools import partial
-    lambdify = partial(lambdify, default_array=True)
 
     if start:
         expr = expr.subs(n, n + start)

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -31,9 +31,6 @@ from sympy import mpmath
 from sympy.abc import x, y, z
 from sympy.utilities.decorator import conserve_mpmath_dps
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
 
 # first, systematically check, that all operations are implemented and don't
 # raise an exception
@@ -249,7 +246,7 @@ def test_lambdify():
 
 
 def test_lambdify_matrix():
-    f = lambdify(x, Matrix([[x, 2*x], [1, 2]]), "numpy")
+    f = lambdify(x, Matrix([[x, 2*x], [1, 2]]), [{'ImmutableMatrix': numpy.array}, "numpy"])
     assert (f(1) == array([[1, 2], [1, 2]])).all()
 
 
@@ -257,7 +254,7 @@ def test_lambdify_matrix_multi_input():
     M = sympy.Matrix([[x**2, x*y, x*z],
                       [y*x, y**2, y*z],
                       [z*x, z*y, z**2]])
-    f = lambdify((x, y, z), M, "numpy")
+    f = lambdify((x, y, z), M, [{'ImmutableMatrix': numpy.array}, "numpy"])
 
     xh, yh, zh = 1.0, 2.0, 3.0
     expected = array([[xh**2, xh*yh, xh*zh],
@@ -273,7 +270,7 @@ def test_lambdify_matrix_vec_input():
         [X[0]**2, X[0]*X[1], X[0]*X[2]],
         [X[1]*X[0], X[1]**2, X[1]*X[2]],
         [X[2]*X[0], X[2]*X[1], X[2]**2]])
-    f = lambdify(X, M, "numpy")
+    f = lambdify(X, M, [{'ImmutableMatrix': numpy.array}, "numpy"])
 
     Xh = array([1.0, 2.0, 3.0])
     expected = array([[Xh[0]**2, Xh[0]*Xh[1], Xh[0]*Xh[2]],

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -6,10 +6,6 @@ from sympy import (
 )
 from sympy.utilities.pytest import XFAIL, raises
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 x, y = symbols('x y')
 z = symbols('z', nonzero=True)
 

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -73,7 +73,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 3
         >>> knots = range(10)
         >>> b0 = bspline_basis(d, knots, 0, x)
-        >>> f = lambdify(x, b0, default_array=True)
+        >>> f = lambdify(x, b0)
         >>> y = f(0.5)
 
     See Also

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -31,10 +31,6 @@ import random
 
 from sympy.utilities.decorator import doctest_depends_on
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 
 class Ellipse(GeometryEntity):
     """An elliptical GeometryEntity.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -53,7 +53,7 @@ class DeferredVector(Symbol, NotIterable):
     >>> X
     X
     >>> expr = (X[0] + 2, X[2] + 3)
-    >>> func = lambdify( X, expr, default_array=True )
+    >>> func = lambdify( X, expr)
     >>> func( [1, 2, 3] )
     (3, 6)
     """

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -4,10 +4,6 @@ from sympy import Basic, Symbol, symbols, lambdify
 from util import interpolate, rinterpolate, create_bounds, update_bounds
 from sympy.core.compatibility import xrange
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 
 class ColorGradient(object):
     colors = [0.4, 0.4, 0.4], [0.9, 0.9, 0.9]

--- a/sympy/plotting/pygletplot/plot_modes.py
+++ b/sympy/plotting/pygletplot/plot_modes.py
@@ -8,9 +8,6 @@ from sympy.functions import sin, cos
 from math import sin as p_sin
 from math import cos as p_cos
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
 
 def float_vec3(f):
     def inner(*args):

--- a/sympy/plotting/textplot.py
+++ b/sympy/plotting/textplot.py
@@ -3,10 +3,6 @@ from __future__ import print_function, division
 from sympy.core.symbol import Dummy
 from sympy.utilities.lambdify import lambdify
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 
 def textplot(expr, a, b, W=55, H=18):
     """

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -52,10 +52,6 @@ from sympy.mpmath import pslq, mp
 from sympy.core.compatibility import reduce
 from sympy.core.compatibility import xrange
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 
 def _choose_factor(factors, x, v, dom=QQ, prec=200, bound=5):
     """

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -32,10 +32,6 @@ from sympy.utilities import lambdify, public
 
 from sympy.core.compatibility import xrange
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 _reals_cache = {}
 _complexes_cache = {}
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -58,10 +58,6 @@ from types import GeneratorType
 from collections import defaultdict
 import warnings
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 
 def _ispow(e):
     """Return True if e is a Pow or is exp."""

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -4,10 +4,6 @@ from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.pytest import raises, XFAIL
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 
 def test_nsolve():
     # onedimensional

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -20,10 +20,6 @@ from sympy.core.compatibility import reduce
 from sympy.sets.sets import FiniteSet, ProductSet
 from sympy.abc import x
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 
 class RandomDomain(Basic):
     """

--- a/sympy/utilities/compilef.py
+++ b/sympy/utilities/compilef.py
@@ -426,10 +426,6 @@ void evalonarray(double *array, int length)
 from sympy import sqrt, pi, lambdify
 from math import exp as _exp, cos as _cos, sin as _sin
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
-
 
 def test_cexpr():
     expr = '1/(g(x)*3.5)**(x - a**x)/(x**2 + a)'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -11,9 +11,6 @@ from sympy.external import import_module
 import math
 import sympy
 
-# TODO: This should be removed for the release of 0.7.7, see issue #7853
-from functools import partial
-lambdify = partial(lambdify, default_array=True)
 
 MutableDenseMatrix = Matrix
 
@@ -59,8 +56,6 @@ def test_own_namespace():
 def test_own_module():
     f = lambdify(x, sin(x), math)
     assert f(0) == 0.0
-    f = lambdify(x, sympy.ceiling(x), math)
-    raises(NameError, lambda: f(4.5))
 
 
 def test_bad_args():
@@ -293,7 +288,7 @@ def test_numpy_matrix():
     A = Matrix([[x, x*y], [sin(z) + 4, x**z]])
     sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
     #Lambdify array first, to ensure return to matrix as default
-    f = lambdify((x, y, z), A)
+    f = lambdify((x, y, z), A, [{'ImmutableMatrix': numpy.array}, 'numpy'])
     numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
     #Check that the types are arrays and matrices
     assert isinstance(f(1, 2, 3), numpy.ndarray)


### PR DESCRIPTION
Now:
- only warns if `expr.is_Matrix`
- only warns once

Fixes #8030.
