### PR TITLE
Revert "simplify Mul._eval_is_even"

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1151,7 +1151,13 @@ class Mul(Expr, AssocOp):
             return False
 
     def _eval_is_even(self):
-        return (self + S.One).is_odd
+        is_integer = self.is_integer
+
+        if is_integer:
+            return fuzzy_not(self._eval_is_odd())
+
+        elif is_integer is False:
+            return False
 
     def _eval_subs(self, old, new):
         from sympy.functions.elementary.complexes import sign


### PR DESCRIPTION
This reverts commit 1b436d045107f610b51065e03eff0dbdf92e76c5.

This "simplification" produces loop, because Add._eval_is_odd
call in turn is_even property on Add's arguments.

fixes #8050
