### PR TITLE
Print rerun counter 

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -415,10 +415,14 @@ def test(*paths, **kwargs):
     """
     subprocess = kwargs.pop("subprocess", True)
     rerun = kwargs.pop("rerun", 0)
+    # count up from 0, do not print 0
+    print_counter = lambda i : (print("rerun %d" % (rerun-i))
+                                if rerun-i else None)
 
     if subprocess:
         # loop backwards so last i is 0
         for i in xrange(rerun, -1, -1):
+            print_counter(i)
             ret = run_in_subprocess_with_hash_randomization("_test",
                         function_args=paths, function_kwargs=kwargs)
             if ret is False:
@@ -430,6 +434,7 @@ def test(*paths, **kwargs):
 
     # rerun even if hash randomization is not supported
     for i in xrange(rerun, -1, -1):
+        print_counter(i)
         val = not bool(_test(*paths, **kwargs))
         if not val or i == 0:
             return val


### PR DESCRIPTION
When specify a large number for `--rerun` to test for failures it can be helpful to know how many reruns have already passed.  This PR prints the counter when --rerun is specified.  The rerun count is printed before the test.  Note that the counter is not printed for the zeroth run since it's technically not a rerun at that point.

Some examples.
- Regular behavior without `--rerun`

``` bash
$ bin/test sympy/core/tests/test_cache.py
============================= test process starts ==============================
executable:         /home/ptb/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        34619550
hash randomization: on (PYTHONHASHSEED=542324729)

sympy/core/tests/test_cache.py[2] ..                                        [OK]

================== tests finished: 2 passed, in 0.01 seconds ===================
```
- New behavior with `--rerun`

``` bash
$ bin/test sympy/core/tests/test_cache.py --rerun 3
============================= test process starts ==============================
executable:         /home/ptb/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        6013830
hash randomization: on (PYTHONHASHSEED=2232953711)

sympy/core/tests/test_cache.py[2] ..                                        [OK]

================== tests finished: 2 passed, in 0.01 seconds ===================
rerun 1
============================= test process starts ==============================
executable:         /home/ptb/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        53629875
hash randomization: on (PYTHONHASHSEED=2065740230)

sympy/core/tests/test_cache.py[2] ..                                        [OK]

================== tests finished: 2 passed, in 0.01 seconds ===================
rerun 2
============================= test process starts ==============================
executable:         /home/ptb/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        68537878
hash randomization: on (PYTHONHASHSEED=4011210339)

sympy/core/tests/test_cache.py[2] ..                                        [OK]

================== tests finished: 2 passed, in 0.01 seconds ===================
rerun 3
============================= test process starts ==============================
executable:         /home/ptb/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        51676033
hash randomization: on (PYTHONHASHSEED=1673038697)

sympy/core/tests/test_cache.py[2] ..                                        [OK]

================== tests finished: 2 passed, in 0.01 seconds ===================
```
