### PR TITLE
Sort key for rule pattern dispatch

### DIFF
--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -32,3 +32,69 @@ def test_ordered():
     assert list(ordered(l, warn=True)) == [[1], [1], [2]]
     raises(ValueError, lambda: list(ordered(['a', 'ab'], keys=[lambda x: x[0]],
         default=False, warn=True)))
+
+def test_reversed_rule_dispatch_sort_key():
+    from sympy.core.compatibility import reversed_rule_dispatch_sort_key as key
+    from sympy import symbols, Wild, S, sin, Function, cos
+
+    x, y, z = symbols('x y z')
+    u_, v_, w_ = map(Wild, list('uvw'))
+    f = Function('f')
+
+    pl = [x, u_, S.One, sin(x), sin(u_), sin(S.One)]
+    res = [u_, x, S.One, sin(u_), sin(x), sin(S.One)]
+    assert sorted(pl, key=key) == res
+
+    pl = [f(x), f(u_), f(S.One)]
+    res = [f(u_), f(x), f(S.One)]
+    assert sorted(pl, key=key) == res
+
+    pl = [f(x), f(u_), f(S.One), x, u_, S.One]
+    res = [u_, x, S.One, f(u_), f(x), f(S.One)]
+    assert sorted(pl, key=key) == res
+
+    pl = [f(x), f(x, y), f(x, y, z)]
+    res = [f(x), f(x, y), f(x, y, z)]
+    assert sorted(pl, key=key) == res
+
+    pl = [f(sin(x)),
+         f(w_),
+         f(sin(w_)),
+         f(x, y),
+         f(x, w_),
+         f(v_, w_),
+         f(x, y, z),
+         f(x, y, v_),
+         f(x, v_, y),
+         f(x, sin(w_), cos(y))
+        ]
+    # Mathics output:
+    #res = [
+         #f(w_),
+         #f(v_, w_),
+         #f(sin(w_)),
+         #f(sin(x)),
+         #f(x, w_),
+         #f(x, v_, y),
+         #f(x, sin(w_), cos(y)),
+         #f(x, y),
+         #f(x, y, v_),
+         #f(x, y, z),
+    #]
+    res = [
+         f(w_),
+         f(sin(w_)),
+         f(sin(x)),
+         f(v_, w_),
+         f(x, w_),
+         f(x, y),
+         f(x, v_, y),
+         f(x, y, v_),
+         f(x, y, z),
+         f(x, sin(w_), cos(y)),
+    ]
+    assert sorted(pl, key=key) == res
+
+    pl = [f(x, y), f(u_, v_), f(sin(x), cos(y)), f(sin(u_), cos(v_))]
+    res = [f(u_, v_), f(x, y), f(sin(u_), cos(v_)), f(sin(x), cos(y))]
+    assert sorted(pl, key=key) == res


### PR DESCRIPTION
The set of all possible matching patterns is a partially ordered set when one considers the _specificity_ of the patterns. A pattern is more _specific_ if it matches a proper subset of the expressions that another pattern matches.

The goal of this PR is to create a key that promotes this partial order to a total order.

Clearly, `f(sin(x_))` is more specific than `f(x_)`, while there may be cases in which this kind of order is not defined, e.g. `f(cos(x_))` vs `f(sin(x_))`. In this last case, the sets of matching expressions are disjoint, but that's not a serious problem, as one could add an additional factor (say, lexicographic order) to determine which of `f(cos(x_))` and `f(sin(x_))` comes first.

Unfortunately, there is an even worse case, in which the sets of matching expressions for two patterns partly overlap, which creates ambiguities. This problem may be solved by considering the argument order in the expression tree.

If assumptions on wildcards were included, it would get even worse. This case is currently ignored, as SymPy Wilds still ignore assumptions.

Node dispatching priority (order given by the list below):
- non-atoms
- numbers
- symbols
- wildcards

`x_` in Mathematica is short for `Pattern[x, Blank[]]`, because `_` is an operator.
- [ ] which order for `f(sin(w_))` and `f(x)`. Mathematica has `f(x) > f(sin(w_))`
- [ ] how to treat non-sympified objects? Should they be treated as atoms?
- [ ] add parser for non-sympified objects. Maybe sympify them?
- [ ] add tests for non-sympified objects.
- [ ] what to do with uninstanciated classes? `Add` vs `Add(x, y)`. If `Add` is in the expression without being called?
- [ ] what to do with dummies?
- [ ] add tests for dummies.
- [ ] test expressions that are one-parameter-identities.
