### PR TITLE
Update fastcache to most recent version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
         - SPLIT="4/4"
 before_install:
   - if [[ "${FASTCACHE}" != "false" ]]; then
-      pip install "fastcache==0.4.3";
+      pip install fastcache;
     fi
   - if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
       pip uninstall -y numpy;


### PR DESCRIPTION
The frequent timeouts in the slow tests have likely been due to the timeout signal getting lost in fastcache: pbrady/fastcache#26.  The latest release addresses this issue with better error checking.  The `No output for 10 minutes` errors during the slow tests should become significantly less frequent.
