### PR TITLE
Add --rerun option (and counter) to bin/doctest.

### DIFF
--- a/bin/doctest
+++ b/bin/doctest
@@ -41,6 +41,9 @@ parser.add_option("--no-subprocess", action="store_false", dest="subprocess",
                   "subprocess.  This may prevent hash randomization from being enabled.")
 parser.add_option('--split', action="store", type='str', default=None,
     help="Only run part of the doctests. Should be of the form a/b, e.g., 1/2")
+parser.add_option('--rerun', action="store", dest="rerun",
+                  default=0, help="Number of times to rerun the specified tests",
+                  type='int')
 parser.set_usage("test [options ...] [files ...]")
 parser.epilog = """\
 "options" are any of the options above. "files" are 0 or more glob strings of \
@@ -66,7 +69,8 @@ if options.types:
 import sympy
 
 ok = sympy.doctest(*args, verbose=options.verbose, blacklist=blacklist,
-    normal=options.normal, subprocess=options.subprocess, split=options.split)
+    normal=options.normal, subprocess=options.subprocess, split=options.split,
+    rerun=options.rerun)
 
 if ok:
     sys.exit(0)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -558,12 +558,30 @@ def doctest(*paths, **kwargs):
 
     """
     subprocess = kwargs.pop("subprocess", True)
+    rerun = kwargs.pop("rerun", 0)
+    # count up from 0, do not print 0
+    print_counter = lambda i : (print("rerun %d" % (rerun-i))
+                                if rerun-i else None)
+
     if subprocess:
-        ret = run_in_subprocess_with_hash_randomization("_doctest",
-            function_args=paths, function_kwargs=kwargs)
-        if ret is not False:
-            return not bool(ret)
-    return not bool(_doctest(*paths, **kwargs))
+        # loop backwards so last i is 0
+        for i in xrange(rerun, -1, -1):
+            print_counter(i)
+            ret = run_in_subprocess_with_hash_randomization("_doctest",
+                        function_args=paths, function_kwargs=kwargs)
+            if ret is False:
+                break
+            val = not bool(ret)
+            # exit on the first failure or if done
+            if not val or i == 0:
+                return val
+
+    # rerun even if hash randomization is not supported
+    for i in xrange(rerun, -1, -1):
+        print_counter(i)
+        val = not bool(_test(*paths, **kwargs))
+        if not val or i == 0:
+            return val
 
 
 def _doctest(*paths, **kwargs):


### PR DESCRIPTION
Assures a consistent API for test and doctest.  Suggested [here](https://github.com/sympy/sympy/pull/8054#issuecomment-56190579)

Some examples:
- Regular behavior when `--rerun` not specified

``` bash
$ bin/doctest sympy/core/cache.py
============================= test process starts ==============================
executable:         /home/peter/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
hash randomization: on (PYTHONHASHSEED=2427431791)

sympy/core/cache.py[1] .                                                    [OK]

================== tests finished: 1 passed, in 0.10 seconds ===================
```
- With `--rerun`

``` bash
$ bin/doctest sympy/stats/crv_types.py --rerun 3
============================= test process starts ==============================
executable:         /home/peter/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
hash randomization: on (PYTHONHASHSEED=288382127)

sympy/stats/crv_types.py[35] ...................................            [OK]

================= tests finished: 35 passed, in 17.04 seconds ==================
rerun 1
============================= test process starts ==============================
executable:         /home/peter/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
hash randomization: on (PYTHONHASHSEED=973603448)

sympy/stats/crv_types.py[35] ...................................            [OK]

================= tests finished: 35 passed, in 17.13 seconds ==================
rerun 2
============================= test process starts ==============================
executable:         /home/peter/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
hash randomization: on (PYTHONHASHSEED=3823669305)

sympy/stats/crv_types.py[35] ...................................            [OK]

================= tests finished: 35 passed, in 17.77 seconds ==================
rerun 3
============================= test process starts ==============================
executable:         /home/peter/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
hash randomization: on (PYTHONHASHSEED=3696587817)

sympy/stats/crv_types.py[35] ...................................            [OK]

================= tests finished: 35 passed, in 17.41 seconds ==================
```
