### PR TITLE
Consolidate all warnings.simplefilter calls to sympy.utilities.exceptions

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -175,7 +175,6 @@ See also isympy --help.
 
 import os
 import sys
-import warnings
 
 # hook in-tree SymPy into Python path, if possible
 
@@ -350,9 +349,6 @@ def main():
     args['quiet'] = options.quiet
     args['auto_symbols'] = options.auto_symbols or options.interactive
     args['auto_int_to_Integer'] = options.auto_int_to_Integer or options.interactive
-
-    from sympy.utilities.exceptions import SymPyDeprecationWarning
-    warnings.simplefilter("always", SymPyDeprecationWarning)
 
     from sympy.interactive import init_session
     init_session(ipython, **args)

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -9,7 +9,6 @@ import operator
 from collections import defaultdict
 from sympy.external import import_module
 
-
 """
 Python 2 and Python 3 compatible imports
 

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division
-import warnings
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import filldedent
@@ -28,8 +27,6 @@ __all__ = ['inertia',
            'mlatex',
            'msubs',
            'find_dynamicsymbols']
-
-warnings.simplefilter("always", SymPyDeprecationWarning)
 
 # These are functions that we've moved and renamed during extracting the
 # basic vector calculus code from the mechanics packages.

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -12,11 +12,7 @@ from sympy.physics.mechanics.functions import (msubs, find_dynamicsymbols,
         _f_list_parser)
 from sympy.physics.mechanics.linearize import Linearizer
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-import warnings
 from sympy.utilities.iterables import iterable
-
-warnings.simplefilter("always", SymPyDeprecationWarning)
-
 
 class KanesMethod(object):
     """Kane's method object.

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -10,9 +10,6 @@ from sympy.physics.mechanics.linearize import Linearizer
 from sympy.utilities import default_sort_key
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.iterables import iterable
-import warnings
-
-warnings.simplefilter("always", SymPyDeprecationWarning)
 
 
 class LagrangesMethod(object):

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -152,3 +152,6 @@ class SymPyDeprecationWarning(DeprecationWarning):
         # if stacklevel was set to 1. If you are writting a wrapper around this,
         # increase the stacklevel accordingly.
         warnings.warn(see_above, SymPyDeprecationWarning, stacklevel=stacklevel)
+
+# Python by default hides DeprecationWarnings, which we do not want.
+warnings.simplefilter("once", SymPyDeprecationWarning)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -10,9 +10,6 @@ from sympy.core.compatibility import exec_, is_sequence, iterable, string_types
 from sympy.utilities.decorator import doctest_depends_on
 import inspect
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-import warnings
-
-warnings.simplefilter("always", SymPyDeprecationWarning)
 
 # These are the namespaces the lambda functions will use.
 MATH = {}


### PR DESCRIPTION
This is the file where SymPyDeprecationWarning is defined, so the filter will
always be set when that warning is used.

This also changes the warning to once, rather than always, which matches the
default Python warning behavior.

This does cause the SymPyDeprecationWarning to show, which by default it
wouldn't, because Python hides DeprecationWarnings by default.  This is
intentional, as we want our users to know about deprecated behavior.
