### PR TITLE
do not use fastcache for slow tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,19 +43,33 @@ matrix:
     - python: 2.7
       env:
         - TEST_SLOW="true"
-        - SPLIT="1/2"
+        - SPLIT="1/3"
+        - FASTCACHE="false"
     - python: 2.7
       env:
         - TEST_SLOW="true"
-        - SPLIT="2/2"
+        - SPLIT="2/3"
+        - FASTCACHE="false"
+    - python: 2.7
+      env:
+        - TEST_SLOW="true"
+        - SPLIT="3/3"
+        - FASTCACHE="false"
     - python: 3.4
       env:
         - TEST_SLOW="true"
-        - SPLIT="1/2"
+        - SPLIT="1/3"
+        - FASTCACHE="false"
     - python: 3.4
       env:
         - TEST_SLOW="true"
-        - SPLIT="2/2"
+        - SPLIT="2/3"
+        - FASTCACHE="false"
+    - python: 3.4
+      env:
+        - TEST_SLOW="true"
+        - SPLIT="3/3"
+        - FASTCACHE="false"
     - python: 2.7
       env:
         - TEST_THEANO="true"


### PR DESCRIPTION
The cause of the frequent `No output for 10 minutes` timeouts during the slow tests is the timeout signal not being properly handled in fastcache.  I thought I had fixed this with pbrady/fastcache#27 but the problem is still occurring.  As it may take some time to debug this, it's best to disable fastcache for the slow tests (and increase the splits since they will take longer) until a suitable fix is in place.
