### PR TITLE
Fix log._eval_is_rational: check for zero

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -633,6 +633,8 @@ class log(Function):
     def _eval_is_rational(self):
         s = self.func(*self.args)
         if s.func == self.func:
+            if (self.args[0] - 1).is_zero:
+                return True
             if s.args[0].is_rational:
                 return False
         else:

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -265,6 +265,8 @@ def test_log_assumptions():
     assert log(1, evaluate=False).is_algebraic
     assert log(42, evaluate=False).is_algebraic is False
 
+    assert log(1 + z).is_rational
+
 
 def test_log_hashing():
     x = Symbol("y")


### PR DESCRIPTION
This fixes travis failure in the master:

```
$ ./bin/test sympy/integrals/tests/test_manual.py --rerun 10
===================================================== test process starts ======================================================executable:         /usr/bin/python  (2.7.3-final-0) [CPython]
architecture:       32-bit
cache:              yes
ground types:       gmpy 1.15
random seed:        41680150
hash randomization: on (PYTHONHASHSEED=3487214350)

sympy/integrals/tests/test_manual.py[17] ..............F..                                                                [FAIL]
_____________________________________________________________________________________________________________________________________________________________________ sympy/integrals/tests/test_manual.py:test_issue_6746 _____________________________________  File "/home/sk/src/sympy/sympy/sympy/integrals/tests/test_manual.py", line 226, in test_issue_6746
    assert manualintegrate((y + 1)**x, x) == x
AssertionError

==================================== tests finished: 16 passed, 1 failed, in 189.46 seconds ====================================DO *NOT* COMMIT!
```
