### PR TITLE
refactor for Codegen Routine

### DIFF
--- a/sympy/external/tests/test_codegen.py
+++ b/sympy/external/tests/test_codegen.py
@@ -25,9 +25,8 @@ from __future__ import print_function
 
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import skip
-from sympy.utilities.codegen import(
-    codegen, Routine, InputArgument, Result, get_code_generator
-)
+from sympy.utilities.codegen import (codegen, make_routine, InputArgument,
+                                     Result, get_code_generator)
 import sys
 import os
 import tempfile
@@ -244,7 +243,7 @@ def fortranize_double_constants(code_string):
 
 def is_feasible(language, commands):
     # This test should always work, otherwise the compiler is not present.
-    routine = Routine("test", x)
+    routine = make_routine("test", x)
     numerical_tests = [
         ("test", ( 1.0,), 1.0, 1e-15),
         ("test", (-1.0,), -1.0, 1e-15),

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -82,10 +82,9 @@ from sympy.core.function import Lambda
 from sympy.core.relational import Eq
 from sympy.core.symbol import Dummy, Symbol
 from sympy.tensor.indexed import Idx, IndexedBase
-from sympy.utilities.codegen import (
-    get_code_generator, Routine, OutputArgument, InOutArgument, InputArgument,
-    CodeGenArgumentListError, Result, ResultBase, CCodeGen
-)
+from sympy.utilities.codegen import (make_routine, get_code_generator,
+            OutputArgument, InOutArgument, InputArgument,
+            CodeGenArgumentListError, Result, ResultBase, CCodeGen)
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.decorator import doctest_depends_on
 
@@ -490,7 +489,7 @@ def autowrap(
     CodeWrapperClass = _get_code_wrapper_class(backend)
     code_wrapper = CodeWrapperClass(code_generator, tempdir, flags, verbose)
     try:
-        routine = Routine('autofunc', expr, args)
+        routine = make_routine('autofunc', expr, args)
     except CodeGenArgumentListError as e:
         # if all missing arguments are for pure output, we simply attach them
         # at the end and try again, because the wrappers will silently convert
@@ -500,11 +499,11 @@ def autowrap(
             if not isinstance(missing, OutputArgument):
                 raise
             new_args.append(missing.name)
-        routine = Routine('autofunc', expr, args + new_args)
+        routine = make_routine('autofunc', expr, args + new_args)
 
     helps = []
     for name, expr, args in helpers:
-        helps.append(Routine(name, expr, args))
+        helps.append(make_routine(name, expr, args))
 
     return code_wrapper.wrap_code(routine, helpers=helps)
 
@@ -856,10 +855,10 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
     flags = flags if flags else ()
 
     if backend.upper() == 'NUMPY':
-        routine = Routine('autofunc', expr, args)
+        routine = make_routine('autofunc', expr, args)
         helps = []
         for name, expr, args in helpers:
-            helps.append(Routine(name, expr, args))
+            helps.append(make_routine(name, expr, args))
         code_wrapper = UfuncifyCodeWrapper(CCodeGen("ufuncify"), tempdir,
                                            flags, verbose)
         return code_wrapper.wrap_code(routine, helpers=helps)

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -5,9 +5,10 @@ import os
 import tempfile
 import shutil
 
-from sympy.utilities.autowrap import autowrap, binary_function, CythonCodeWrapper, \
-    ufuncify, UfuncifyCodeWrapper, CodeWrapper
-from sympy.utilities.codegen import Routine, CCodeGen, CodeGenArgumentListError
+from sympy.utilities.autowrap import (autowrap, binary_function,
+            CythonCodeWrapper, ufuncify, UfuncifyCodeWrapper, CodeWrapper)
+from sympy.utilities.codegen import (CCodeGen, CodeGenArgumentListError,
+                                     make_routine)
 from sympy.utilities.pytest import raises
 from sympy.core import symbols, Eq
 from sympy.core.compatibility import StringIO
@@ -31,7 +32,7 @@ def get_string(dump_fn, routines, prefix="file"):
 def test_cython_wrapper_scalar_function():
     x, y, z = symbols('x,y,z')
     expr = (x + y)*z
-    routine = Routine("test", expr)
+    routine = make_routine("test", expr)
     code_gen = CythonCodeWrapper(CCodeGen())
     source = get_string(code_gen.dump_pyx, [routine])
     expected = (
@@ -49,7 +50,7 @@ def test_cython_wrapper_outarg():
     x, y, z = symbols('x,y,z')
     code_gen = CythonCodeWrapper(CCodeGen())
 
-    routine = Routine("test", Equality(z, x + y))
+    routine = make_routine("test", Equality(z, x + y))
     source = get_string(code_gen.dump_pyx, [routine])
     expected = (
         "cdef extern from 'file.h':\n"
@@ -67,7 +68,7 @@ def test_cython_wrapper_inoutarg():
     from sympy import Equality
     x, y, z = symbols('x,y,z')
     code_gen = CythonCodeWrapper(CCodeGen())
-    routine = Routine("test", Equality(z, x + y + z))
+    routine = make_routine("test", Equality(z, x + y + z))
     source = get_string(code_gen.dump_pyx, [routine])
     expected = (
         "cdef extern from 'file.h':\n"
@@ -139,7 +140,7 @@ def test_ufuncify_source():
     x, y, z = symbols('x,y,z')
     code_wrapper = UfuncifyCodeWrapper(CCodeGen("ufuncify"))
     CodeWrapper._module_counter = 0
-    routine = Routine("test", x + y + z)
+    routine = make_routine("test", x + y + z)
     source = get_string(code_wrapper.dump_c, [routine])
     expected = """\
 #include "Python.h"

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -3,9 +3,9 @@ from sympy.core.compatibility import StringIO
 from sympy import erf, Integral
 from sympy import Equality
 from sympy.matrices import Matrix, MatrixSymbol
-from sympy.utilities.codegen import (CCodeGen, Routine, InputArgument,
-    CodeGenError, FCodeGen, codegen, CodeGenArgumentListError, OutputArgument,
-    InOutArgument)
+from sympy.utilities.codegen import (CCodeGen, InputArgument, CodeGenError,
+    FCodeGen, codegen, CodeGenArgumentListError, OutputArgument, InOutArgument)
+from sympy.utilities.codegen import routine as Routine
 from sympy.utilities.pytest import raises
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import XFAIL


### PR DESCRIPTION
For OctaveCodeGen (pr #7824), I need some refactoring of `Routine`.
- [x] add Fortran matrix tests
- [x] add C matrix tests
- [x] move language specific stuff out of `Routine.__new__`
- [x] rework docstrings
- [x] rework Result, added NamedResult.
- [x] clear-up FIXMEs on name versus result_var in docstrings.

see this comment https://github.com/sympy/sympy/pull/7824#discussion_r17892414
