### PR TITLE
Add banded diagonal storage and solver

### DIFF
--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -92,7 +92,7 @@ def _banded_LUdecomposition(A, l_and_u=None, overwrite=False):
         for j in range(k+1, min(k+u+1, n)):
             A[u+i-j:u+ii-j, j] -= A[u+i-k:u+ii-k, k]*A[u+k-j,j]
 
-    return (l, u), m
+    return (l, u), A
 
 def banded_LUsolve(A, rhs, l_and_u=None, have_LU=False, overwrite=False):
     """
@@ -126,16 +126,20 @@ def banded_LUsolve(A, rhs, l_and_u=None, have_LU=False, overwrite=False):
             raise TypeError("Expected tuple of lower, upper bandwidths.")
         if not have_LU:
             (l, u), A = _banded_LUdecomposition(A, (l, u), overwrite=overwrite)
-    rhs = rhs.copy()
-    l, u = l_and_u
-    n = lu.shape[-1]
+        else:
+            l, u = l_and_u
+
+    if not overwrite:
+        rhs = rhs.copy()
+
+    n = A.shape[-1]
     # forward subs
     for j in range(n):
         i, ii = j+1, min(j+l+1, n)
-        rhs[i:ii, :] -= lu[u+i-j:u+ii-j, j]*rhs[j, :]
+        rhs[i:ii, :] -= A[u+i-j:u+ii-j, j]*rhs[j, :]
     # backward subs
     for j in range(n-1, -1, -1):
-        rhs[j, :] /= lu[u, j]
+        rhs[j, :] /= A[u, j]
         i, ii = max(0, j-u), j
-        rhs[i:ii, :] -= lu[u+i-j:u+ii-j, j]*rhs[j, :]
+        rhs[i:ii, :] -= A[u+i-j:u+ii-j, j]*rhs[j, :]
     return rhs

--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy import SparseMatrix
+from sympy import SparseMatrix, Matrix
 
 
 def _doktocsr(dok):
@@ -34,3 +34,108 @@ def _csrtodok(csr):
         for l, m in zip(A[indices], JA[indices]):
             smat[i, m] = l
     return SparseMatrix(*(shape + [smat]))
+
+
+def _doktodia(dok):
+    """Return a tuple of the lower and upper bandwidths and converts the
+       DOK to diagonal ordered form:
+
+       ab[u + i - j, j] == a[i, j], where 'u' is the upper bandwidth of 'a'.
+    """
+    offsets = sorted(set(map(lambda x: x[1]-x[0], dok.CL)))[::-1]
+    offmap = {i:o for i,o in enumerate(offsets)}
+    def todia(i, j):
+        im = j-offmap[i]
+        if 0 <= im < dok.shape[0]:
+            return dok[im,j]
+        return 0
+    return ((abs(offsets[-1]), offsets[0]),
+            Matrix(len(offsets), dok.shape[0], todia))
+
+def _banded_LUdecomposition(A, l_and_u=None, overwrite=False):
+    """
+    Returns the LU decomposition of a matrix A in diagonal ordered form.
+
+    Note that a single matrix utilizing diagonal ordered form will be
+    returned with LU[0:u, :] corresponding to U and LU[u:, :] corresponds
+    to L.
+
+    Parameters
+    ==========
+
+    A : Either a `SparseMatrix` or a `Matrix` in diagonal ordered form.
+    l_and_u : Tuple of lower and upper bandwidths.  Must be specified if
+    A is in diagonal ordered form.
+    overwrite : If True, overwrite input matrix A.  Applies if A is in diagonal
+    form.
+
+    References
+    ==========
+
+    Matrix Computations, 4th Ed.
+    Gene H. Golub, Charles F. Van Loan  (2013)
+    """
+    if isinstance(A, SparseMatrix):
+        (l, u), A = _doktodia(A)
+    else:
+        if l_and_u is None:
+            raise TypeError("Expected tuple of lower and upper bandwidths.")
+        l, u = l_and_u
+        if not overwrite:
+            A = A.copy()
+
+    n = A.shape[-1]
+    for k in range(n-1):
+        A[u+1:u+l+1, k] /= A[u, k]
+
+        i, ii = k+1, min(k+l, n)+1
+        for j in range(k+1, min(k+u+1, n)):
+            A[u+i-j:u+ii-j, j] -= A[u+i-k:u+ii-k, k]*A[u+k-j,j]
+
+    return (l, u), m
+
+def banded_LUsolve(A, rhs, l_and_u=None, have_LU=False, overwrite=False):
+    """
+    Solves the linear system A * x = rhs via LU decomposition where A is banded
+
+    Parameters
+    ==========
+
+    A : Either a `SparseMatrix` or a `Matrix` in diagonal ordered form.  If the
+    same system will be solved multiple times, A should be passed in as an LU
+    factorized matrix in diagonal form (i.e. the result of
+    _banded_LUdecomposition).  This should significantly increase performance.
+    rhs : solution vector/matrix.
+    l_and_u : Tuple of lower and upper bandwidths.  Must be specified if
+    A is in diagonal ordered form.
+    have_LU : Set this to True if A is already an LU factorized matrix in
+    diagonal form.  If set to False (default), The LU decomposition
+    will be computed.
+    overwrite : If True, overwrite solution matrix rhs.
+
+    References
+    ==========
+
+    Matrix Computations, 4th Ed.
+    Gene H. Golub, Charles F. Van Loan  (2013)
+    """
+    if isinstance(A, SparseMatrix):
+        (l, u), A = _banded_LUdecomposition(A)
+    else:
+        if l_and_u is None:
+            raise TypeError("Expected tuple of lower, upper bandwidths.")
+        if not have_LU:
+            (l, u), A = _banded_LUdecomposition(A, (l, u), overwrite=overwrite)
+    rhs = rhs.copy()
+    l, u = l_and_u
+    n = lu.shape[-1]
+    # forward subs
+    for j in range(n):
+        i, ii = j+1, min(j+l+1, n)
+        rhs[i:ii, :] -= lu[u+i-j:u+ii-j, j]*rhs[j, :]
+    # backward subs
+    for j in range(n-1, -1, -1):
+        rhs[j, :] /= lu[u, j]
+        i, ii = max(0, j-u), j
+        rhs[i:ii, :] -= lu[u+i-j:u+ii-j, j]*rhs[j, :]
+    return rhs

--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import SparseMatrix, Matrix
+from sympy.core.compatibility import xrange
 
 
 def _doktocsr(dok):
@@ -43,7 +44,7 @@ def _doktodia(dok):
        ab[u + i - j, j] == a[i, j], where 'u' is the upper bandwidth of 'a'.
     """
     offsets = sorted(set(map(lambda x: x[1]-x[0], dok.CL)))[::-1]
-    offmap = {i:o for i,o in enumerate(offsets)}
+    offmap = dict(enumerate(offsets))
     def todia(i, j):
         im = j-offmap[i]
         if 0 <= im < dok.shape[0]:
@@ -51,6 +52,7 @@ def _doktodia(dok):
         return 0
     return ((abs(offsets[-1]), offsets[0]),
             Matrix(len(offsets), dok.shape[0], todia))
+
 
 def _banded_LUdecomposition(A, l_and_u=None, overwrite=False):
     """
@@ -85,14 +87,15 @@ def _banded_LUdecomposition(A, l_and_u=None, overwrite=False):
             A = A.copy()
 
     n = A.shape[-1]
-    for k in range(n-1):
+    for k in xrange(n-1):
         A[u+1:u+l+1, k] /= A[u, k]
 
         i, ii = k+1, min(k+l, n)+1
-        for j in range(k+1, min(k+u+1, n)):
+        for j in xrange(k+1, min(k+u+1, n)):
             A[u+i-j:u+ii-j, j] -= A[u+i-k:u+ii-k, k]*A[u+k-j,j]
 
     return (l, u), A
+
 
 def banded_LUsolve(A, rhs, l_and_u=None, have_LU=False, overwrite=False):
     """
@@ -134,11 +137,11 @@ def banded_LUsolve(A, rhs, l_and_u=None, have_LU=False, overwrite=False):
 
     n = A.shape[-1]
     # forward subs
-    for j in range(n):
+    for j in xrange(n):
         i, ii = j+1, min(j+l+1, n)
         rhs[i:ii, :] -= A[u+i-j:u+ii-j, j]*rhs[j, :]
     # backward subs
-    for j in range(n-1, -1, -1):
+    for j in xrange(n-1, -1, -1):
         rhs[j, :] /= A[u, j]
         i, ii = max(0, j-u), j
         rhs[i:ii, :] -= A[u+i-j:u+ii-j, j]*rhs[j, :]


### PR DESCRIPTION
Finiite-difference and finite-volume schemes tend to yield matrices with a banded structure.  For such matrices, the DOK implementation is far from optimal so this PR implements a matrix diagonal storage form and solver.

Sample session:

``` python
$ ipython
Python 3.4.1 |Continuum Analytics, Inc.| (default, Sep  2 2014, 14:00:37) 
Type "copyright", "credits" or "license" for more information.

IPython 2.2.0 -- An enhanced Interactive Python.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from sympy import SparseMatrix, Matrix, randMatrix

In [2]: from numpy.random import randint

In [3]: from sympy.matrices import sparsetools

In [4]: np = 100

In [5]: sol = randMatrix(np, 5)

In [6]: upper, lower = 1, 3 # bandwidths

In [7]: def fd_mat(i, j, upper=upper, lower=lower, np=np):
        for shift in range(-upper, lower+1):
                if i==j+shift:
                        return randint(shift, high=2*np//(abs(shift)+1))
   ...:         

In [8]: s = SparseMatrix(np, np, fd_mat)

In [9]: (sparsetools.banded_LUsolve(s, sol) - s.LUsolve(sol)).is_zero
Out[9]: True

In [10]: %timeit sparsetools.banded_LUsolve(s, sol)
1 loops, best of 3: 976 ms per loop

In [11]: %timeit s.LUsolve(sol)
1 loops, best of 3: 14.6 s per loop
```

The new routine `banded_LUsolve` can simply take a DOK sparse matrix, convert it into diag storage, compute the LU and solve.  However, if one is going to be solving the same system many times with different rhs it can be beneficial to precompute the LU.  This is available as well (somewhat hidden because it's an 'expert' option)

``` python
In [12]: l_and_u, LU = sparsetools._banded_LUdecomposition(s)

In [13]: (sparsetools.banded_LUsolve(LU, sol, l_and_u, have_LU=True) - s.LUsolve(sol)).is_zero
Out[13]: True

In [14]: %timeit sparsetools.banded_LUsolve(LU, sol, l_and_u, have_LU=True)
1 loops, best of 3: 829 ms per loop
```

Here are items that need to be addressed to move forward
- [ ] Doctests?
- [ ] Is sparse_tools the appropriate place?
- [ ] tests

@tjl do you want to test this out?
