### PR TITLE
Allow -k to take a variable number of arguments

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -17,6 +17,32 @@ import re
 from get_sympy import path_hack
 path_hack()
 
+# callback to support variable length argument in optparse
+# docs.python.org/2/library/optparse.html#callback-example-6-variable-arguments
+def vararg_callback(option, opt_str, value, parser):
+    assert value is None
+    value = []
+
+    def floatable(str):
+        try:
+            float(str)
+            return True
+        except ValueError:
+            return False
+
+    for arg in parser.rargs:
+        # stop on --foo like options
+        if arg[:2] == "--" and len(arg) > 2:
+            break
+        # stop on -a, but not on -3 or -3.0
+        if arg[:1] == "-" and len(arg) > 1 and not floatable(arg):
+            break
+        value.append(arg)
+
+    del parser.rargs[:len(value)]
+    setattr(parser.values, option.dest, value)
+
+
 parser = OptionParser()
 parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
         default=False)
@@ -27,8 +53,8 @@ parser.add_option("--no-colors", action="store_false", dest="colors",
 parser.add_option("--force-colors", action="store_true", dest="force_colors",
         default=False, help="Always use colors, even if the output is not to a terminal.")
 parser.add_option("-k", dest="kw",
-        help="only run tests matching the given keyword expression",
-        metavar="KEYWORD", default="")
+        help="only run tests matching the given keyword expressions",
+        metavar="KEYWORDS", action="callback", callback=vararg_callback)
 parser.add_option("--tb", dest="tb",
         help="traceback verboseness (short/no) [default: %default]",
         metavar="TBSTYLE", default="short")

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -452,7 +452,10 @@ def _test(*paths, **kwargs):
     """
     verbose = kwargs.get("verbose", False)
     tb = kwargs.get("tb", "short")
-    kw = kwargs.get("kw", "")
+    kw = kwargs.get("kw", [])
+    # ensure that kw is a tuple (list is fine too)
+    if isinstance(kw, str):
+        kw = (kw, )
     post_mortem = kwargs.get("pdb", False)
     colors = kwargs.get("colors", True)
     force_colors = kwargs.get("force_colors", False)
@@ -1136,9 +1139,12 @@ class SymPyTests(object):
 
         Always returns True if self._kw is "".
         """
-        if self._kw == "":
+        if not self._kw:
             return True
-        return x.__name__.find(self._kw) != -1
+        for kw in self._kw:
+            if x.__name__.find(kw) != -1:
+                return True
+        return False
 
     def get_test_files(self, dir, pat='test_*.py'):
         """


### PR DESCRIPTION
Add a callback function so that -k can take a variable number of arguments.  Fixes #5228.  This would be much simpler if we could use argparse but it's not part of the standard library in 2.6.

Example:

``` bash
$ bin/test *arit* -k dup mul -v
============================= test process starts ==============================
executable:         /home/ptb/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        18540787
hash randomization: on (PYTHONHASHSEED=1532168274)

sympy/core/tests/test_arit.py[8] 
test_real_mul ok
test_ncmul ok
test_Add_as_coeff_mul ok
test_Pow_as_coeff_mul_doesnt_expand ok
test_mul_flatten_oo ok
test_denest_add_mul ok
test_mul_coeff ok
test_mul_zero_detection ok                                                  [OK]

sympy/matrices/tests/test_densearith.py[2] 
test_mulmatmat ok
test_mulmatscaler ok                                                        [OK]

sympy/polys/tests/test_densearith.py[29] 
test_dup_add_term ok
test_dup_sub_term ok
test_dup_mul_term ok
test_dmp_mul_term ok
test_dup_add_ground ok
test_dup_sub_ground ok
test_dup_mul_ground ok
test_dmp_mul_ground ok
test_dup_quo_ground ok
test_dup_exquo_ground ok
test_dup_lshift ok
test_dup_rshift ok
test_dup_abs ok
test_dup_neg ok
test_dup_add ok
test_dup_sub ok
test_dup_add_mul ok
test_dup_sub_mul ok
test_dup_mul ok
test_dmp_mul ok
test_dup_sqr ok
test_dup_pow ok
test_dup_pdiv ok
test_dup_rr_div ok
test_dup_ff_div ok
test_dup_div ok
test_dup_max_norm ok
test_dup_l1_norm ok
test_dup_expand ok                                                          [OK]


================== tests finished: 39 passed, in 0.58 seconds ==================
```
