### PR TITLE
integrals: An amendment to spde()

### DIFF
--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -384,12 +384,11 @@ def spde(a, b, c, n, DE):
 
     alpha = Poly(1, DE.t)
     beta = Poly(0, DE.t)
-    pow_a = 0
 
     while True:
+        if c.is_zero:
+            return (zero, zero, 0, zero, beta)  # -1 is more to the point
         if (n < 0) is True:
-            if c.is_zero:
-                return (zero, zero, 0, zero, beta)
             raise NonElementaryIntegralException
 
         g = a.gcd(b)
@@ -407,9 +406,9 @@ def spde(a, b, c, n, DE):
         b += derivation(a, DE)
         c = z - derivation(r, DE)
         n -= a.degree(DE.t)
+
+        beta += alpha * r
         alpha *= a
-        beta += (a**pow_a)*r
-        pow_a += 1
 
 def no_cancel_b_large(b, c, n, DE):
     """
@@ -755,6 +754,9 @@ def rischDE(fa, fd, ga, gd, DE):
         n = oo
 
     B, C, m, alpha, beta = spde(A, B, C, n, DE)
-    y = solve_poly_rde(B, C, m, DE)
+    if C.is_zero:
+        y = C
+    else:
+        y = solve_poly_rde(B, C, m, DE)
 
     return (alpha*y + beta, hn*hs)

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -132,6 +132,10 @@ def test_spde():
         (Poly(0, x), Poly(x/2 - S(1)/4, x), -2 + n, Poly(x**2 + x + 1, x), Poly(5*x/4, x))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
     raises(NonElementaryIntegralException, lambda: spde(Poly((t - 1)*(t**2 + 1)**2, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), 0, DE))
+    DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
+    assert spde(Poly(x**2 - x, x), Poly(1, x), Poly(9*x**4 - 10*x**3 + 2*x**2, x), 4, DE) == (Poly(0, x), Poly(0, x), 0, Poly(0, x), Poly(3*x**3 - 2*x**2, x))
+    assert spde(Poly(x**2 - x, x), Poly(x**2 - 5*x + 3, x), Poly(x**7 - x**6 - 2*x**4 + 3*x**3 - x**2, x), 5, DE) == \
+        (Poly(1, x), Poly(x + 1, x), 1, Poly(x**4 - x**3, x), Poly(x**3 - x**2, x))
 
 def test_solve_poly_rde_no_cancel():
     # deg(b) large


### PR DESCRIPTION
The iterative version of `spde()` currently assumes that the
coefficient  `a`  of  `Dp`  were invariant in the loop, in which
case the values of the multiplier  `alpha`  are powers of  `a`.
Otherwise the offset  `beta`  of the solution will be incorrect.

I have added two test cases where  `a`  is not invariant.
In the general case,  `alpha`  can be used instead of a power of  `a`
to construct the correct value of  `beta`.
