### PR TITLE
Rename test_numerically to verify_numerically for py.test compatibility

### DIFF
--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -9,7 +9,7 @@ from sympy.core.tests.test_evalf import NS
 from sympy.core.compatibility import long
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
-from sympy.utilities.randtest import test_numerically
+from sympy.utilities.randtest import verify_numerically
 
 
 a, c, x, y, z = symbols('a,c,x,y,z')
@@ -203,7 +203,7 @@ def test_pow_E():
         r, i = b.as_real_imag()
         if i:
             break
-    assert test_numerically(b**(1/(log(-b) + sign(i)*I*pi).n()), S.Exp1)
+    assert verify_numerically(b**(1/(log(-b) + sign(i)*I*pi).n()), S.Exp1)
 
 
 def test_pow_issue_3516():
@@ -1468,7 +1468,7 @@ def test_Mod():
     r3 = sqrt(3)
     for i in [-r3, -r2, r2, r3]:
         for j in [-r3, -r2, r2, r3]:
-            assert test_numerically(i % j, i.n() % j.n())
+            assert verify_numerically(i % j, i.n() % j.n())
     for _x in range(4):
         for _y in range(9):
             reps = [(x, _x), (y, _y)]

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -6,7 +6,7 @@ from sympy.core.function import (
 
 from sympy.utilities.pytest import raises
 from sympy.core.function import expand_power_base
-from sympy.utilities.randtest import test_numerically
+from sympy.utilities.randtest import verify_numerically
 
 from sympy.abc import x, y, z
 
@@ -285,7 +285,7 @@ def test_issues_5919_6830():
     # coverage
     def ok(a, b, n):
         e = (a + I*b)**n
-        return test_numerically(e, expand_multinomial(e))
+        return verify_numerically(e, expand_multinomial(e))
 
     for a in [2, S.Half]:
         for b in [3, S(1)/3]:

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -6,7 +6,7 @@ from sympy.functions.special.bessel import fn
 from sympy.functions.special.bessel import (airyai, airybi,
                                             airyaiprime, airybiprime)
 from sympy.utilities.randtest import (random_complex_number as randcplx,
-                                      test_numerically as tn,
+                                      verify_numerically as tn,
                                       test_derivative_numerically as td,
                                       _randint)
 

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -4,7 +4,7 @@ from sympy.functions.special.elliptic_integrals import (elliptic_k as K,
     elliptic_f as F, elliptic_e as E, elliptic_pi as P)
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                                       random_complex_number as randcplx,
-                                      test_numerically as tn)
+                                      verify_numerically as tn)
 from sympy.abc import x, y, z, m, n
 
 i = Symbol('i', integer=True)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -277,12 +277,12 @@ def test_erf2inv():
 
 
 def mytn(expr1, expr2, expr3, x, d=0):
-    from sympy.utilities.randtest import test_numerically, random_complex_number
+    from sympy.utilities.randtest import verify_numerically, random_complex_number
     subs = {}
     for a in expr1.free_symbols:
         if a != x:
             subs[a] = random_complex_number()
-    return expr2 == expr3 and test_numerically(expr1.subs(subs),
+    return expr2 == expr3 and verify_numerically(expr1.subs(subs),
                                                expr2.subs(subs), x, d=d)
 
 
@@ -661,14 +661,14 @@ def test_fresnel():
         meijerg(((), (1,)), ((S(1)/4,),
         (S(3)/4, 0)), -pi**2*z**4/16)/(2*(-z)**(S(1)/4)*(z**2)**(S(1)/4))
 
-    from sympy.utilities.randtest import test_numerically
+    from sympy.utilities.randtest import verify_numerically
 
-    test_numerically(re(fresnels(z)), fresnels(z).as_real_imag()[0], z)
-    test_numerically(im(fresnels(z)), fresnels(z).as_real_imag()[1], z)
-    test_numerically(fresnels(z), fresnels(z).rewrite(hyper), z)
-    test_numerically(fresnels(z), fresnels(z).rewrite(meijerg), z)
+    verify_numerically(re(fresnels(z)), fresnels(z).as_real_imag()[0], z)
+    verify_numerically(im(fresnels(z)), fresnels(z).as_real_imag()[1], z)
+    verify_numerically(fresnels(z), fresnels(z).rewrite(hyper), z)
+    verify_numerically(fresnels(z), fresnels(z).rewrite(meijerg), z)
 
-    test_numerically(re(fresnelc(z)), fresnelc(z).as_real_imag()[0], z)
-    test_numerically(im(fresnelc(z)), fresnelc(z).as_real_imag()[1], z)
-    test_numerically(fresnelc(z), fresnelc(z).rewrite(hyper), z)
-    test_numerically(fresnelc(z), fresnelc(z).rewrite(meijerg), z)
+    verify_numerically(re(fresnelc(z)), fresnelc(z).as_real_imag()[0], z)
+    verify_numerically(im(fresnelc(z)), fresnelc(z).as_real_imag()[1], z)
+    verify_numerically(fresnelc(z), fresnelc(z).rewrite(hyper), z)
+    verify_numerically(fresnelc(z), fresnelc(z).rewrite(meijerg), z)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -5,7 +5,7 @@ from sympy import (
 from sympy.core.function import ArgumentIndexError
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                                       random_complex_number as randcplx,
-                                      test_numerically as tn)
+                                      verify_numerically as tn)
 from sympy.utilities.pytest import raises
 
 x = Symbol('x')

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -5,7 +5,7 @@ from sympy.abc import x, z, k
 from sympy.utilities.pytest import raises
 from sympy.utilities.randtest import (
     random_complex_number as randcplx,
-    test_numerically as tn,
+    verify_numerically as tn,
     test_derivative_numerically as td)
 
 

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -2,7 +2,7 @@ from sympy import (Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log,
                    zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I,
                    exp_polar, polar_lift, O)
 from sympy.utilities.randtest import (test_derivative_numerically as td,
-                      random_complex_number as randcplx, test_numerically as tn)
+                      random_complex_number as randcplx, verify_numerically as tn)
 from sympy.utilities.pytest import XFAIL
 
 x = Symbol('x')

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -13,7 +13,7 @@ from sympy.geometry.polygon import _asa as asa, rad, deg
 from sympy.geometry.util import idiff, are_coplanar
 from sympy.solvers.solvers import solve
 from sympy.utilities.iterables import cartes
-from sympy.utilities.randtest import test_numerically
+from sympy.utilities.randtest import verify_numerically
 from sympy.utilities.pytest import raises, slow
 
 x = Symbol('x', real=True)
@@ -1535,7 +1535,7 @@ def test_reflect():
     r = p.reflect(l)
     dp = l.perpendicular_segment(p).length
     dr = l.perpendicular_segment(r).length
-    assert test_numerically(dp, dr)
+    assert verify_numerically(dp, dr)
     t = Triangle((0, 0), (1, 0), (2, 3))
     assert t.area == -t.reflect(l).area
     e = Ellipse((1, 0), 1, 2)

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -5,7 +5,7 @@ from sympy.integrals.meijerint import (_rewrite_single, _rewrite1,
          meijerint_indefinite, _inflate_g, _create_lookup_table,
          meijerint_definite, meijerint_inversion)
 from sympy.utilities import default_sort_key
-from sympy.utilities.randtest import (test_numerically,
+from sympy.utilities.randtest import (verify_numerically,
          random_complex_number as randcplx)
 from sympy.abc import x, y, a, b, c, d, s, t, z
 
@@ -31,7 +31,7 @@ def test_rewrite_single():
         r = _rewrite_single(expr, x)
         e = Add(*[res[0]*res[2] for res in r[0]]).replace(
             exp_polar, exp)  # XXX Hack?
-        assert test_numerically(e, expr, x)
+        assert verify_numerically(e, expr, x)
 
     u(exp(-x)*sin(x), x)
 
@@ -63,7 +63,7 @@ def test_meijerint_indefinite_numerically():
                 c: randcplx(), d: randcplx()}
         integral = meijerint_indefinite(g, x)
         assert integral is not None
-        assert test_numerically(g.subs(subs), integral.diff(x).subs(subs), x)
+        assert verify_numerically(g.subs(subs), integral.diff(x).subs(subs), x)
     t(1, x)
     t(2, x)
     t(1, 2*x)
@@ -83,7 +83,7 @@ def test_inflate():
         m2 = Mul(*_inflate_g(m1, n))
         # NOTE: (the random number)**9 must still be on the principal sheet.
         # Thus make b&d small to create random numbers of small imaginary part.
-        return test_numerically(m1.subs(subs), m2.subs(subs), x, b=0.1, d=-0.1)
+        return verify_numerically(m1.subs(subs), m2.subs(subs), x, b=0.1, d=-0.1)
     assert t([[a], [b]], [[c], [d]], x, 3)
     assert t([[a, y], [b]], [[c], [d]], x, 3)
     assert t([[a], [b]], [[c, y], [d]], 2*x**3, 3)

--- a/sympy/mpmath/conftest.py
+++ b/sympy/mpmath/conftest.py
@@ -1,8 +1,5 @@
-# The py library is part of the "py.test" testing suite (python-codespeak-lib
-# on Debian), see http://codespeak.net/py/
+import os
 
-import py
-
-#this makes py.test put mpath directory into the sys.path, so that we can
-#"import mpmath" from tests nicely
-rootdir = py.magic.autopath().dirpath()
+# This makes py.test put mpath directory into the sys.path, so that we can
+# import mpmath" from tests nicely
+rootdir = os.path.abspath(os.getcwd())

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -14,7 +14,7 @@ from sympy.polys.polyroots import (root_factors, roots_linear,
 from sympy.polys.orthopolys import legendre_poly
 
 from sympy.utilities.pytest import raises
-from sympy.utilities.randtest import test_numerically
+from sympy.utilities.randtest import verify_numerically
 import sympy
 
 
@@ -94,11 +94,11 @@ def test_roots_quartic():
     # not all symbolic quartics are unresolvable
     eq = Poly(q*x + q/4 + x**4 + x**3 + 2*x**2 - Rational(1, 3), x)
     sol = roots_quartic(eq)
-    assert all(test_numerically(eq.subs(x, i), 0) for i in sol)
+    assert all(verify_numerically(eq.subs(x, i), 0) for i in sol)
     z = symbols('z', negative=True)
     eq = x**4 + 2*x**3 + 3*x**2 + x*(z + 11) + 5
     zans = roots_quartic(Poly(eq, x))
-    assert all([test_numerically(eq.subs(((x, i), (z, -1))), 0) for i in zans])
+    assert all([verify_numerically(eq.subs(((x, i), (z, -1))), 0) for i in zans])
     # but some are (see also issue 4989)
     # it's ok if the solution is not Piecewise, but the tests below should pass
     eq = Poly(y*x**4 + x**3 - x + z, x)
@@ -110,7 +110,7 @@ def test_roots_quartic():
         dict(y=-Rational(1, 3), z=-2))  # 0 real
     for rep in reps:
         sol = roots_quartic(Poly(eq.subs(rep), x))
-        assert all([test_numerically(w.subs(rep) - s, 0) for w, s in zip(ans, sol)])
+        assert all([verify_numerically(w.subs(rep) - s, 0) for w, s in zip(ans, sol)])
 
 
 def test_roots_cyclotomic():

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -6,7 +6,7 @@ from sympy.simplify.fu import (
     TR111, TR2, TR2i, TR3, TR5, TR6, TR7, TR8, TR9, TRmorrie, _TR56 as T,
     hyper_as_trig, csc, fu, process_common_addends, sec, trig_split,
     as_f_sign_1)
-from sympy.utilities.randtest import test_numerically
+from sympy.utilities.randtest import verify_numerically
 from sympy.abc import a, b, c, x, y, z
 
 
@@ -64,7 +64,7 @@ def test_TR3():
     for f in (cos, sin, tan, cot, csc, sec):
         i = f(3*pi/7)
         j = TR3(i)
-        assert test_numerically(i, j) and i.func != j.func
+        assert verify_numerically(i, j) and i.func != j.func
 
 
 def test__TR56():
@@ -130,7 +130,7 @@ def test_TR9():
             ex = Add(*[Mul(*ai) for ai in args])
             t = TR9(ex)
             assert not (a[0].func == a[1].func and (
-                not test_numerically(ex, t.expand(trig=True)) or t.is_Add)
+                not verify_numerically(ex, t.expand(trig=True)) or t.is_Add)
                 or a[1].func != a[0].func and ex != t)
 
 

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -12,7 +12,7 @@ from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
 from sympy import hyper, I, S, meijerg, Piecewise, exp_polar
 from sympy.utilities.pytest import raises
 from sympy.abc import z, a, b, c
-from sympy.utilities.randtest import test_numerically as tn
+from sympy.utilities.randtest import verify_numerically as tn
 from sympy.utilities.pytest import XFAIL, skip, slow
 
 from sympy import (cos, sin, log, exp, asin, lowergamma, atanh, besseli,

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1827,7 +1827,7 @@ def test_issue_7001():
 
 def test_exptrigsimp():
     def valid(a, b):
-        from sympy.utilities.randtest import test_numerically as tn
+        from sympy.utilities.randtest import verify_numerically as tn
         if not (tn(a, b) and a == b):
             return False
         return True

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -16,7 +16,7 @@ from sympy.physics.units import cm
 from sympy.polys.rootoftools import RootOf
 
 from sympy.utilities.pytest import slow, XFAIL, raises, skip
-from sympy.utilities.randtest import test_numerically as tn
+from sympy.utilities.randtest import verify_numerically as tn
 
 from sympy.abc import a, b, c, d, k, h, p, x, y, z, t, q, m
 

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -40,7 +40,7 @@ def comp(z1, z2, tol):
         return diff <= tol
 
 
-def test_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
+def verify_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     """
     Test numerically that f and g agree when evaluated in the argument z.
 
@@ -54,7 +54,7 @@ def test_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
 
     >>> from sympy import sin, cos
     >>> from sympy.abc import x
-    >>> from sympy.utilities.randtest import test_numerically as tn
+    >>> from sympy.utilities.randtest import verify_numerically as tn
     >>> tn(sin(x)**2 + cos(x)**2, 1, x)
     True
     """


### PR DESCRIPTION
Partial fix for #5641.  The function test_numerically was imported into many files to do numerical comparisons and resulted in the following error with py.test:
- On master

``` bash
$ py.test sympy/simplify/tests/test_fu.py 
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 27 items 

sympy/simplify/tests/test_fu.py ..........................E

==================================== ERRORS ====================================
______________________ ERROR at setup of test_numerically ______________________
file /home/ptb/gitrepos/sympy/sympy/utilities/randtest.py, line 43
  def test_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
        fixture 'f' not found
        available fixtures: pytestconfig, recwarn, capsys, capfd, tmpdir, monkeypatch
        use 'py.test --fixtures [testpath]' for help on them.

/home/ptb/gitrepos/sympy/sympy/utilities/randtest.py:43
                                DO *NOT* COMMIT!                                
====================== 26 passed, 1 error in 2.71 seconds ======================
```

Renaming this function to something which doesn't start with 'test_' gets rid of the error
- This PR

``` bash
$ py.test sympy/simplify/tests/test_fu.py 
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 26 items 

sympy/simplify/tests/test_fu.py ..........................

========================== 26 passed in 2.67 seconds ===========================
```
