### PR TITLE
Make --slow option for py.test consistent with bin/test usage

### DIFF
--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -25,7 +25,7 @@ def pytest_report_header(config):
 
 
 def pytest_addoption(parser):
-    parser.addoption("--slow", dest="runslow", action="store_true",
+    parser.addoption("--slow", action="store_true",
         help="allow slow tests to run")
 
 
@@ -37,7 +37,10 @@ def pytest_configure(config):
 def pytest_runtest_setup(item):
     if not isinstance(item, pytest.Function):
         return
-    if not item.config.getvalue("runslow") and hasattr(item.obj, 'slow'):
+    if item.config.getoption("--slow"):
+        if not 'slow' in item.keywords:
+            pytest.skip()
+    elif 'slow' in item.keywords:
         pytest.skip("slow test: pass --slow to run")
 
 

--- a/sympy/mpmath/conftest.py
+++ b/sympy/mpmath/conftest.py
@@ -1,8 +1,5 @@
-# The py library is part of the "py.test" testing suite (python-codespeak-lib
-# on Debian), see http://codespeak.net/py/
+import os
 
-import py
-
-#this makes py.test put mpath directory into the sys.path, so that we can
-#"import mpmath" from tests nicely
-rootdir = py.magic.autopath().dirpath()
+# This makes py.test put mpath directory into the sys.path, so that we can
+# import mpmath" from tests nicely
+rootdir = os.path.abspath(os.getcwd())


### PR DESCRIPTION
Currently on master `py.test --slow` runs all unmarked tests as well as those marked with `@slow`

Example:

``` bash
$ py.test sympy --slow
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 6411 items / 1 skipped 

sympy/assumptions/tests/test_assumptions_2.py .....
sympy/assumptions/tests/test_context.py ....
sympy/assumptions/tests/test_matrices.py ...x........x......
sympy/assumptions/tests/test_query.py ...............^C

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/home/ptb/gitrepos/sympy_test/sympy/logic/algorithms/dpll2.py:351: KeyboardInterrupt
============== 41 passed, 1 skipped, 2 xfailed in 125.54 seconds ===============
```

This PR changes the behavior to match that of bin/test where _only_ the slow tests are run with the `--slow` option

``` bash
$ py.test sympy --slow --durations 15
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 6405 items / 1 skipped 

sympy/assumptions/tests/test_assumptions_2.py sssss
sympy/assumptions/tests/test_context.py ssss
sympy/assumptions/tests/test_matrices.py sssssssssssssssssss
sympy/assumptions/tests/test_query.py sssssssssssssss.sssssssssssssssssssssssssssssssssssssssss
sympy/assumptions/tests/test_refine.py ssssss
sympy/calculus/tests/test_euler.py sssss
sympy/calculus/tests/test_finite_diff.py sss
sympy/calculus/tests/test_singularities.py ss
sympy/categories/tests/test_baseclasses.py sss
sympy/categories/tests/test_drawing.py ssssssss
sympy/combinatorics/tests/test_generators.py s
sympy/combinatorics/tests/test_graycode.py s
sympy/combinatorics/tests/test_group_constructs.py s
sympy/combinatorics/tests/test_named_groups.py sssss
sympy/combinatorics/tests/test_partitions.py sss
sympy/combinatorics/tests/test_perm_groups.py ssssssssssssssssssssssssssssssssssssss
sympy/combinatorics/tests/test_permutations.py sssssss
sympy/combinatorics/tests/test_polyhedron.py s
sympy/combinatorics/tests/test_prufer.py ss
sympy/combinatorics/tests/test_subsets.py s
sympy/combinatorics/tests/test_tensor_can.py ssssssssssss
sympy/combinatorics/tests/test_testutil.py sssss
sympy/combinatorics/tests/test_util.py ssssssss
sympy/concrete/tests/test_delta.py ssssssssssssssssssssssssss
sympy/concrete/tests/test_gosper.py sssssssssss
sympy/concrete/tests/test_products.py ssssssssssssssss
sympy/concrete/tests/test_sums_products.py ssssssssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_args.py sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_arit.py sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_assumptions.py sssssssssssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_basic.py sssssssssssssss
sympy/core/tests/test_cache.py ss
sympy/core/tests/test_compatibility.py ssss
sympy/core/tests/test_complex.py sssssssssssssssss
sympy/core/tests/test_containers.py ssssssssssss
sympy/core/tests/test_count_ops.py ss
sympy/core/tests/test_diff.py ssssss
sympy/core/tests/test_equal.py ssssss
sympy/core/tests/test_eval.py ssssssss
sympy/core/tests/test_eval_power.py ssssssssssssssssssss
sympy/core/tests/test_evalf.py ssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_evaluate.py ss
sympy/core/tests/test_expand.py ssssssssssssss
sympy/core/tests/test_expr.py ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_exprtools.py sssssssss
sympy/core/tests/test_facts.py ssssssssss
sympy/core/tests/test_function.py ssssssssssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_logic.py ssssssssssss
sympy/core/tests/test_match.py sssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_noncommutative.py sssssssssssssss
sympy/core/tests/test_numbers.py sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_operations.py ssss
sympy/core/tests/test_priority.py sssss
sympy/core/tests/test_relational.py sssssssssssssssssssssssss
sympy/core/tests/test_rules.py s
sympy/core/tests/test_subs.py ssssssssssssssssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_symbol.py ssssssssss
sympy/core/tests/test_sympify.py ssssssssssssssssssssssssssssssssssss
sympy/core/tests/test_trace.py sss
sympy/core/tests/test_truediv.py sss
sympy/core/tests/test_var.py sssss
sympy/core/tests/test_wester.py ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss.sssssss...ssssssssssssssssssssssssssss.ssssssssssssssssssssssssssssssssssssssssssss.sssssssssssssss.ssssssssssssssssssss.sxsssssssssssssssssssssss.sssssssssssssssssssssssssssssssssssssxsssxssssssssssssssssss.ssssssssssssssssssssssssssssssxssssssxxssxsssssxssssssssssssssssxsxxssssssssssssssssssssssssssxssssssssssssssss
sympy/crypto/tests/test_crypto.py ssssssssssssssssssssssssssssssss
sympy/diffgeom/tests/test_class_structure.py sss
sympy/diffgeom/tests/test_diffgeom.py sssssssssss
sympy/diffgeom/tests/test_function_diffgeom_book.py ssss
sympy/diffgeom/tests/test_hyperbolic_space.py s
sympy/external/tests/test_autowrap.py sssssssssss
sympy/external/tests/test_codegen.py ssssssss
sympy/external/tests/test_importtools.py sss
sympy/external/tests/test_numpy.py sssssssssssssssssssssss
sympy/external/tests/test_sage.py ssssssssssssss
sympy/external/tests/test_scipy.py s
sympy/functions/combinatorial/tests/test_comb_factorials.py ssssssssssss
sympy/functions/combinatorial/tests/test_comb_numbers.py ssssssssssssss
sympy/functions/elementary/tests/test_complexes.py ssssssssssssssssssssssss
sympy/functions/elementary/tests/test_exponential.py ssssssssssssssssssssssssss
sympy/functions/elementary/tests/test_hyperbolic.py sssssssssssssssssssssssssssssss
sympy/functions/elementary/tests/test_integers.py ssss
sympy/functions/elementary/tests/test_interface.py sss
sympy/functions/elementary/tests/test_miscellaneous.py ssss
sympy/functions/elementary/tests/test_piecewise.py ssssssssssssssssssssssss
sympy/functions/elementary/tests/test_trigonometric.py ssssssssssssssssssssssssssssssssssssssssssss..ssssx
sympy/functions/special/tests/test_bessel.py sssssssssssssssss
sympy/functions/special/tests/test_beta_functions.py s
sympy/functions/special/tests/test_bsplines.py sssss
sympy/functions/special/tests/test_delta_functions.py sss
sympy/functions/special/tests/test_elliptic_integrals.py ssss
sympy/functions/special/tests/test_error_functions.py sssssssssssssssssssssss
sympy/functions/special/tests/test_gamma_functions.py ssssssss
sympy/functions/special/tests/test_hyper.py ssssssssssss
sympy/functions/special/tests/test_spec_polynomials.py ssssssss
sympy/functions/special/tests/test_spherical_harmonics.py sss
sympy/functions/special/tests/test_tensor_functions.py sss
sympy/functions/special/tests/test_zeta_functions.py sssssss
sympy/galgebra/tests/test_ga.py sssssssssssssssssssssss
sympy/geometry/tests/test_geometry.py ssssssssssssssssssssssss.
sympy/integrals/tests/test_deltafunctions.py ss
sympy/integrals/tests/test_failing_integrals.py ssssxss
```

Note that the unmarked tests are still collected but messing with the py.test collection process is a bit more involved
