### PR TITLE
Ensure that theano tests are not run under py.test if theano is not installed

### DIFF
--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -1,5 +1,5 @@
 from sympy.external import import_module
-from sympy.utilities.pytest import raises, SKIP
+from sympy.utilities.pytest import raises, SKIP, USE_PYTEST
 
 theano = import_module('theano')
 if theano:
@@ -7,9 +7,15 @@ if theano:
     ts = theano.scalar
     tt = theano.tensor
     xt, yt, zt = [tt.scalar(name, 'floatX') for name in 'xyz']
+    disabled = False
 else:
     #bin/test will not execute any tests now
     disabled = True
+
+if USE_PYTEST:
+    import py.test
+    pytestmark = py.test.mark.skipif(disabled is True,
+                                     reason=("theano not installed"))
 
 import sympy
 from sympy import S


### PR DESCRIPTION
- On master (without theano installed):

``` bash
$ py.test sympy/printing
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 419 items 

sympy/printing/pretty/tests/test_pretty.py .................................................................
sympy/printing/tests/test_ccode.py .........................
sympy/printing/tests/test_codeprinter.py ...
sympy/printing/tests/test_conventions.py ..
sympy/printing/tests/test_dot.py .........
sympy/printing/tests/test_fcode.py ................................
sympy/printing/tests/test_gtk.py x.
sympy/printing/tests/test_jscode.py ......................
sympy/printing/tests/test_lambdarepr.py ....
sympy/printing/tests/test_latex.py .....x.........................................................................x.....
sympy/printing/tests/test_mathematica.py .........
sympy/printing/tests/test_mathml.py .................
sympy/printing/tests/test_precedence.py ............
sympy/printing/tests/test_python.py .....x....
sympy/printing/tests/test_repr.py ....................
sympy/printing/tests/test_str.py ........................................................................
sympy/printing/tests/test_tableform.py ..
sympy/printing/tests/test_theanocode.py FFFFFFFFFF.F.FFFFFFFFFF.FFFE
```
- PR

``` bash
$ py.test sympy/printing
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 419 items 

sympy/printing/pretty/tests/test_pretty.py .................................................................
sympy/printing/tests/test_ccode.py .........................
sympy/printing/tests/test_codeprinter.py ...
sympy/printing/tests/test_conventions.py ..
sympy/printing/tests/test_dot.py .........
sympy/printing/tests/test_fcode.py ................................
sympy/printing/tests/test_gtk.py x.
sympy/printing/tests/test_jscode.py ......................
sympy/printing/tests/test_lambdarepr.py ....
sympy/printing/tests/test_latex.py .....x.........................................................................x.....
sympy/printing/tests/test_mathematica.py .........
sympy/printing/tests/test_mathml.py .................
sympy/printing/tests/test_precedence.py ............
sympy/printing/tests/test_python.py .....x....
sympy/printing/tests/test_repr.py ....................
sympy/printing/tests/test_str.py ........................................................................
sympy/printing/tests/test_tableform.py ..
sympy/printing/tests/test_theanocode.py ssssssssssssssssssssssssssss

============== 387 passed, 28 skipped, 4 xfailed in 4.71 seconds ===============
```
