### PR TITLE
Fix broken test::test_sympify_mpmath

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -97,15 +97,15 @@ def test_sympify_mpmath():
 
     mpmath.mp.dps = 12
     assert sympify(
-        mpmath.pi).epsilon_eq(Float("3.14159265359"), Float("1e-12")) is True
+        mpmath.pi).epsilon_eq(Float("3.14159265359"), Float("1e-12")) == True
     assert sympify(
-        mpmath.pi).epsilon_eq(Float("3.14159265359"), Float("1e-13")) is False
+        mpmath.pi).epsilon_eq(Float("3.14159265359"), Float("1e-13")) == False
 
     mpmath.mp.dps = 6
     assert sympify(
-        mpmath.pi).epsilon_eq(Float("3.14159"), Float("1e-5")) is True
+        mpmath.pi).epsilon_eq(Float("3.14159"), Float("1e-5")) == True
     assert sympify(
-        mpmath.pi).epsilon_eq(Float("3.14159"), Float("1e-6")) is False
+        mpmath.pi).epsilon_eq(Float("3.14159"), Float("1e-6")) == False
 
     assert sympify(mpmath.mpc(1.0 + 2.0j)) == Float(1.0) + Float(2.0)*I
 


### PR DESCRIPTION
Note that sympy/core/tests/test_sympify.py::test_sympify_mpmath does not acutally get run using bin/test thus the failure was only discovered when working on compatibility with py.test.

``` bash
In [1]: from sympy import sympify 

In [2]: from sympy import Float, mpmath

In [3]: mpmath.mp.dps = 12

In [4]: sympify(
        mpmath.pi).epsilon_eq(Float("3.14159265359"), Float("1e-12")) is True
Out[4]: False

In [5]: sympify(
        mpmath.pi).epsilon_eq(Float("3.14159265359"), Float("1e-12")) == True
Out[5]: True
```
- On Master

``` bash
$ py.test sympy/core/tests/test_sympify.py 
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 36 items 

sympy/core/tests/test_sympify.py ....F...............................

=================================== FAILURES ===================================
_____________________________ test_sympify_mpmath ______________________________

    def func_wrapper():
        dps = mpmath.mp.dps
        try:
>           func()

sympy/utilities/decorator.py:89: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    @conserve_mpmath_dps
    def test_sympify_mpmath():
        value = sympify(mpmath.mpf(1.0))
        assert value == Float(1.0) and type(value) is Float

        mpmath.mp.dps = 12
>       assert sympify(
            mpmath.pi).epsilon_eq(Float("3.14159265359"), Float("1e-12")) is True
E       assert True is True
E        +  where True = <bound method Float.epsilon_eq of 3.14159265359>(3.14159265359000, 1.00000000000000e-12)
E        +    where <bound method Float.epsilon_eq of 3.14159265359> = 3.14159265359.epsilon_eq
E        +      where 3.14159265359 = sympify(<pi: 3.14159~>)
E        +        where <pi: 3.14159~> = mpmath.pi
E        +    and   3.14159265359000 = Float('3.14159265359')
E        +    and   1.00000000000000e-12 = Float('1e-12')

sympy/core/tests/test_sympify.py:99: AssertionError
                                DO *NOT* COMMIT!                                
===================== 1 failed, 35 passed in 0.52 seconds ======================
```
- PR

``` bash
$ py.test sympy/core/tests/test_sympify.py 
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 36 items 

sympy/core/tests/test_sympify.py ....................................

========================== 36 passed in 0.51 seconds ===========================
```
