### PR TITLE
finite and infinite are both complex

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -104,9 +104,11 @@ _assume_rules = FactRules([
 
     'imaginary      ->  !real',
 
-    '!finite        ==  infinite',
     'noninteger     ==  real & !integer',
-    '!zero        ==  nonzero',
+    '!zero          ==  nonzero',
+
+    'finite         ==  complex & !infinite',
+    'infinite       ==  complex & !finite',
 ])
 
 _assume_defined = _assume_rules.defined_facts.copy()

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2711,18 +2711,8 @@ class NaN(with_metaclass(Singleton, Number)):
     .. [1] http://en.wikipedia.org/wiki/NaN
 
     """
-    is_commutative = True
-    is_real = None
-    is_rational = None
-    is_algebraic = None
-    is_transcendental = None
-    is_integer = None
     is_comparable = False
-    is_finite = None
-    is_zero = None
-    is_prime = None
-    is_positive = None
-    is_negative = None
+    is_complex = False
     is_number = True
 
     __slots__ = []

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -594,8 +594,6 @@ class Float(Number):
 
     # A Float represents many real numbers,
     # both rational and irrational.
-    is_rational = None
-    is_irrational = None
     is_number = True
 
     is_real = True
@@ -1044,7 +1042,6 @@ class Rational(Number):
     ========
     sympify, sympy.simplify.simplify.nsimplify
     """
-    is_real = True
     is_integer = False
     is_rational = True
     is_number = True
@@ -2244,15 +2241,8 @@ class Infinity(with_metaclass(Singleton, Number)):
     .. [1] http://en.wikipedia.org/wiki/Infinity
     """
 
-    is_commutative = True
     is_positive = True
-    is_finite = False
-    is_integer = None
-    is_rational = None
-    is_algebraic = None
-    is_transcendental = None
-    is_odd = None
-    is_number = True
+    is_infinite = True
 
     __slots__ = []
 
@@ -2459,15 +2449,8 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     Infinity
     """
 
-    is_commutative = True
-    is_real = True
-    is_positive = False
-    is_finite = False
-    is_integer = None
-    is_rational = None
-    is_number = True
-    is_algebraic = None
-    is_transcendental = None
+    is_negative = True
+    is_infinite = True
 
     __slots__ = []
 
@@ -2711,7 +2694,6 @@ class NaN(with_metaclass(Singleton, Number)):
     .. [1] http://en.wikipedia.org/wiki/NaN
 
     """
-    is_comparable = False
     is_complex = False
     is_number = True
 
@@ -2823,8 +2805,7 @@ class ComplexInfinity(with_metaclass(Singleton, AtomicExpr)):
     """
 
     is_commutative = True
-    is_finite = False
-    is_real = None
+    is_infinite = True
     is_number = True
 
     __slots__ = []
@@ -2990,7 +2971,6 @@ class Exp1(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False  # XXX Forces is_negative/is_nonnegative
     is_irrational = True
     is_number = True
     is_algebraic = False
@@ -3069,7 +3049,6 @@ class Pi(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
     is_irrational = True
     is_number = True
     is_algebraic = False
@@ -3130,7 +3109,6 @@ class GoldenRatio(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
     is_irrational = True
     is_number = True
     is_algebraic = True
@@ -3195,8 +3173,6 @@ class EulerGamma(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
-    is_irrational = None
     is_number = True
 
     __slots__ = []
@@ -3251,8 +3227,6 @@ class Catalan(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
-    is_irrational = None
     is_number = True
 
     __slots__ = []

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -155,26 +155,26 @@ def test_nan():
     nan = S.NaN
 
     assert nan.is_commutative is True
-    assert nan.is_integer is None
-    assert nan.is_rational is None
-    assert nan.is_algebraic is None
-    assert nan.is_transcendental is None
-    assert nan.is_real is None
-    assert nan.is_complex is None
-    assert nan.is_noninteger is None
-    assert nan.is_irrational is None
-    assert nan.is_imaginary is None
-    assert nan.is_positive is None
-    assert nan.is_negative is None
-    assert nan.is_nonpositive is None
-    assert nan.is_nonnegative is None
-    assert nan.is_even is None
-    assert nan.is_odd is None
-    assert nan.is_finite is None
-    assert nan.is_infinite is None
+    assert nan.is_integer is False
+    assert nan.is_rational is False
+    assert nan.is_algebraic is False
+    assert nan.is_transcendental is False
+    assert nan.is_real is False
+    assert nan.is_complex is False
+    assert nan.is_noninteger is False
+    assert nan.is_irrational is False
+    assert nan.is_imaginary is False
+    assert nan.is_positive is False
+    assert nan.is_negative is False
+    assert nan.is_nonpositive is False
+    assert nan.is_nonnegative is False
+    assert nan.is_even is False
+    assert nan.is_odd is False
+    assert nan.is_finite is False
+    assert nan.is_infinite is False
     assert nan.is_comparable is False
-    assert nan.is_prime is None
-    assert nan.is_composite is None
+    assert nan.is_prime is False
+    assert nan.is_composite is False
     assert nan.is_number is True
 
 

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -814,3 +814,26 @@ def test_issue_7899():
     assert (I*x).is_real is None
     assert ((x - I)*(x - 1)).is_zero is None
     assert ((x - I)*(x - 1)).is_real is None
+
+
+@XFAIL
+def test_zero_finite_infinite_interactions():
+    assert d(zero=True).is_finite is True
+    assert d(zero=True).is_infinite is False
+    assert d(infinite=True).is_zero is False
+
+
+def test_finite_infinite():
+    d = lambda **x: Symbol('x', **x)
+    assert d(infinite=True).is_finite is False
+
+    assert d(finite=True).is_infinite is False
+
+    assert d(finite=True).is_zero is None
+
+    assert d(infinite=True).is_complex
+    assert d(finite=True).is_complex
+
+    # finite=False --x--> infinite=True, etc...
+    assert d(infinite=False).is_finite is None
+    assert d(finite=False).is_complex is None


### PR DESCRIPTION
If we assume finite == !infinite in assumptions, we
create an alias: finite=False is the same as infinite=True
and vice versa. We don't want to do that. What we want is
behavior like integer and noninteger:

Dummy(integer=0) is not the same thing as Dummy(noninteger=1).
A noninteger is commutative, complex, hermitian, noninteger,
nonzero, and real while integer=0 is only commutative -- nothing
else is known about it (other than that it is not 0).

/!\ In general, it is much easier to comprehend what one means
by using only true attributes to desccribe it. If something is
not zero but still complex, say nonzero=True instead of zero=False.

So assumptions.py has been modified to make the following true:

```
finite  : 0 <= abs(x) < oo
infinite : abs(x) == oo
```
