### PR TITLE
Fix py.test failure in test_coordinate_vars

### DIFF
--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -1,10 +1,17 @@
 from sympy import sin, cos, pi, zeros, ImmutableMatrix as Matrix
 from sympy.physics.vector import (ReferenceFrame, Vector, CoordinateSym,
                                   dynamicsymbols, time_derivative, express)
+from sympy.utilities.pytest import USE_PYTEST
 
-
-Vector.simp = True
-A = ReferenceFrame('A')
+if USE_PYTEST:
+    from py.test import fixture
+    @fixture(autouse=True)
+    def global_vars(request):
+        request.function.__globals__['A'] = ReferenceFrame('A')
+        request.function.__globals__['Vector.simp'] = True
+else:
+    Vector.simp = True
+    A = ReferenceFrame('A')
 
 
 def test_coordinate_vars():

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -1,21 +1,12 @@
 from sympy import sin, cos, pi, zeros, ImmutableMatrix as Matrix
 from sympy.physics.vector import (ReferenceFrame, Vector, CoordinateSym,
                                   dynamicsymbols, time_derivative, express)
-from sympy.utilities.pytest import USE_PYTEST
 
-if USE_PYTEST:
-    from py.test import fixture
-    @fixture(autouse=True)
-    def global_vars(request):
-        request.function.__globals__['A'] = ReferenceFrame('A')
-        request.function.__globals__['Vector.simp'] = True
-else:
-    Vector.simp = True
-    A = ReferenceFrame('A')
-
+Vector.simp = True
 
 def test_coordinate_vars():
     """Tests the coordinate variables functionality"""
+    A = ReferenceFrame('A')
     assert CoordinateSym('Ax', A, 0) == A[0]
     assert CoordinateSym('Ax', A, 1) == A[1]
     assert CoordinateSym('Ax', A, 2) == A[2]

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -7,22 +7,13 @@ from sympy.vector.point import Point
 from sympy.vector.vector import Vector
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-from sympy.utilities.pytest import USE_PYTEST
 
-if USE_PYTEST:
-    from py.test import fixture
-    @fixture(autouse=True)
-    def global_vars(request):
-        request.function.__globals__['A'] = CoordSysCartesian('A')
-        for v in ['a', 'b', 'c', 'q', 'q1', 'q2', 'q3', 'q4']:
-            request.function.__globals__[v] = S(v)
-else:
-    A = CoordSysCartesian('A')
-    a, b, c, q = symbols('a b c q')
-    q1, q2, q3, q4 = symbols('q1 q2 q3 q4')
+a, b, c, q = symbols('a b c q')
+q1, q2, q3, q4 = symbols('q1 q2 q3 q4')
 
 
 def test_coordsyscartesian_equivalence():
+    A = CoordSysCartesian('A')
     A1 = CoordSysCartesian('A')
     assert A1 == A
     B = CoordSysCartesian('B')
@@ -33,6 +24,7 @@ def test_coordsyscartesian_equivalence():
 
 
 def test_orienters():
+    A = CoordSysCartesian('A')
     axis_orienter = AxisOrienter(a, A.k)
     body_orienter = BodyOrienter(a, b, c, '123')
     space_orienter = SpaceOrienter(a, b, c, '123')
@@ -68,6 +60,7 @@ def test_coordinate_vars():
     Tests the coordinate variables functionality with respect to
     reorientation of coordinate systems.
     """
+    A = CoordSysCartesian('A')
     assert BaseScalar('Ax', 0, A, ' ', ' ') == A.x
     assert BaseScalar('Ay', 1, A, ' ', ' ') == A.y
     assert BaseScalar('Az', 2, A, ' ', ' ') == A.z
@@ -257,6 +250,7 @@ def test_locatenew_point():
     """
     Tests Point class, and locate_new method in CoordSysCartesian.
     """
+    A = CoordSysCartesian('A')
     assert isinstance(A.origin, Point)
     v = a*A.i + b*A.j + c*A.k
     C = A.locate_new('C', v)
@@ -280,6 +274,7 @@ def test_locatenew_point():
 
 
 def test_evalf():
+    A = CoordSysCartesian('A')
     v = 3*A.i + 4*A.j + a*A.k
     assert v.n() == v.evalf()
     assert v.evalf(subs={a:1}) == v.subs(a, 1).evalf()

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -1,17 +1,25 @@
 from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.scalar import BaseScalar
 from sympy import Symbol, sin, cos, pi, ImmutableMatrix as Matrix, \
-     symbols, simplify, sqrt, zeros
+     symbols, simplify, sqrt, zeros, S
 from sympy.vector.functions import express
 from sympy.vector.point import Point
 from sympy.vector.vector import Vector
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
+from sympy.utilities.pytest import USE_PYTEST
 
-
-A = CoordSysCartesian('A')
-a, b, c, q = symbols('a b c q')
-q1, q2, q3, q4 = symbols('q1 q2 q3 q4')
+if USE_PYTEST:
+    from py.test import fixture
+    @fixture(autouse=True)
+    def global_vars(request):
+        request.function.__globals__['A'] = CoordSysCartesian('A')
+        for v in ['a', 'b', 'c', 'q', 'q1', 'q2', 'q3', 'q4']:
+            request.function.__globals__[v] = S(v)
+else:
+    A = CoordSysCartesian('A')
+    a, b, c, q = symbols('a b c q')
+    q1, q2, q3, q4 = symbols('q1 q2 q3 q4')
 
 
 def test_coordsyscartesian_equivalence():


### PR DESCRIPTION
Add fixture so py.test can inject variables into function global namespace.  Fixes failures in test_coordinate_vars
- On Master

``` bash
$ py.test sympy -k test_coordinate_vars
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 6406 items 

sympy/physics/vector/tests/test_frame.py F
sympy/vector/tests/test_coordsysrect.py F

=================================== FAILURES ===================================
_____________________________ test_coordinate_vars _____________________________

    def test_coordinate_vars():
        """Tests the coordinate variables functionality"""
>       assert CoordinateSym('Ax', A, 0) == A[0]
E       assert Ax == A_x
E        +  where Ax = CoordinateSym('Ax', A, 0)

sympy/physics/vector/tests/test_frame.py:12: AssertionError
_____________________________ test_coordinate_vars _____________________________

    def test_coordinate_vars():
        """
        Tests the coordinate variables functionality with respect to
        reorientation of coordinate systems.
        """
>       assert BaseScalar('Ax', 0, A, ' ', ' ') == A.x
E       assert Ax == A.x
E        +  where Ax = BaseScalar('Ax', 0, A, ' ', ' ')
E        +  and   A.x = A.x

sympy/vector/tests/test_coordsysrect.py:63: AssertionError
                                DO *NOT* COMMIT!                                
============== 6404 tests deselected by '-ktest_coordinate_vars' ===============
============ 2 failed, 6404 deselected, 1 warnings in 22.61 seconds ============
```
- This PR

``` bash
$ py.test sympy -k test_coordinate_vars
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 6406 items 

sympy/physics/vector/tests/test_frame.py .
sympy/vector/tests/test_coordsysrect.py .

============== 6404 tests deselected by '-ktest_coordinate_vars' ===============
============ 2 passed, 6404 deselected, 1 warnings in 13.91 seconds ============
```
