### PR TITLE
remove --slow option from py.test

### DIFF
--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -24,24 +24,9 @@ def pytest_report_header(config):
     return s
 
 
-def pytest_addoption(parser):
-    parser.addoption("--slow", action="store_true",
-        help="allow slow tests to run")
-
-
-def pytest_configure(config):
-    # register an additional marker
-    config.addinivalue_line("markers", "slow: slow test")
-
-
 def pytest_runtest_setup(item):
     if not isinstance(item, pytest.Function):
         return
-    if item.config.getoption("--slow"):
-        if not 'slow' in item.keywords:
-            pytest.skip()
-    elif 'slow' in item.keywords:
-        pytest.skip("slow test: pass --slow to run")
 
 
 def pytest_terminal_summary(terminalreporter):


### PR DESCRIPTION
The `--slow` option is not the appropriate way to run slow tests with py.test.  This functionality is build into py.test via

``` bash
$ py.test sympy -m slow
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 6406 items 

sympy/assumptions/tests/test_query.py .
sympy/core/tests/test_wester.py ........x.xx.xxxxxxs
```

Note that only the marked tests are listed as oppose to #8101.

``` bash
$ py.test sympy -m "not slow"
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 6406 items 

sympy/assumptions/tests/test_assumptions_2.py .....
sympy/assumptions/tests/test_context.py ....
sympy/assumptions/tests/test_matrices.py ...x........x......
sympy/assumptions/tests/test_query.py ...............x..^C

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/home/peter/git-codes/sympy/sympy/core/basic.py:102: KeyboardInterrupt
==================== 70 tests deselected by "-m 'not slow'" ====================
```

Not only is `--slow` superfluous but it inhibits the expected py.test functionality. 
- On master

``` bash
 $ py.test sympy -m slow
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 6406 items 

sympy/assumptions/tests/test_query.py s
sympy/core/tests/test_wester.py ssssssssssssssssssssssss
sympy/functions/elementary/tests/test_trigonometric.py sss
sympy/geometry/tests/test_geometry.py s
sympy/integrals/tests/test_failing_integrals.py sssssss
sympy/integrals/tests/test_heurisch.py sss
sympy/integrals/tests/test_integrals.py s
sympy/integrals/tests/test_transforms.py s
sympy/matrices/tests/test_matrices.py s
sympy/physics/mechanics/tests/test_kane3.py s
sympy/polys/tests/test_groebnertools.py sss
sympy/polys/tests/test_numberfields.py s
sympy/simplify/tests/test_hyperexpand.py sssssssssssss
sympy/simplify/tests/test_simplify.py s
sympy/solvers/tests/test_diophantine.py s
sympy/solvers/tests/test_ode.py ss
sympy/solvers/tests/test_solvers.py sss
sympy/stats/tests/test_continuous_rv.py s
sympy/stats/tests/test_finite_rv.py s
sympy/utilities/tests/test_enumerative.py s

===================== 6336 tests deselected by "-m 'slow'" =====================
=========== 70 skipped, 6336 deselected, 1 warnings in 9.07 seconds ============
```
