### PR TITLE
skip tests in test_pytest if running under pytest

### DIFF
--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -1,4 +1,9 @@
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, USE_PYTEST
+
+if USE_PYTEST:
+    import py.test
+    pytestmark = py.test.mark.skipif(USE_PYTEST,
+                                     reason=("using py.test"))
 
 # Test callables
 


### PR DESCRIPTION
- On Master

``` bash
$ py.test sympy/utilities/tests/test_pytest.py 
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 7 items 

sympy/utilities/tests/test_pytest.py .F..F..

=================================== FAILURES ===================================
___________ test_lack_of_exception_triggers_AssertionError_callable ____________

    def test_lack_of_exception_triggers_AssertionError_callable():
        try:
>           raises(Exception, lambda: 1 + 1)
E           Failed: DID NOT RAISE

sympy/utilities/tests/test_pytest.py:14: Failed
_____________ test_lack_of_exception_triggers_AssertionError_with ______________

    def test_lack_of_exception_triggers_AssertionError_with():
        try:
            with raises(Exception):
>               1 + 1
E               Failed: DID NOT RAISE

sympy/utilities/tests/test_pytest.py:39: Failed
                                DO *NOT* COMMIT!                                
====================== 2 failed, 5 passed in 0.03 seconds ======================
```

The test_pytest tests are designed to test sympy's custom pytest implementation when not running under pytest.  The failure are do to slightly different implementations of `raises` between py.test and bin/test.  It was suggested [here](https://groups.google.com/forum/#!topic/sympy/XrZQUPDxgIo) to simply skip these test when running with pytest.
- PR

``` bash
$ py.test sympy/utilities/tests/test_pytest.py 
============================= test session starts ==============================
platform linux -- Python 3.4.1 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 7 items 

sympy/utilities/tests/test_pytest.py sssssss

========================== 7 skipped in 0.02 seconds ===========================
```
