### PR TITLE
Skip the slowest of the slow tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,33 +43,19 @@ matrix:
     - python: 2.7
       env:
         - TEST_SLOW="true"
-        - SPLIT="1/3"
-        - FASTCACHE="false"
+        - SPLIT="1/2"
     - python: 2.7
       env:
         - TEST_SLOW="true"
-        - SPLIT="2/3"
-        - FASTCACHE="false"
-    - python: 2.7
-      env:
-        - TEST_SLOW="true"
-        - SPLIT="3/3"
-        - FASTCACHE="false"
+        - SPLIT="2/2"
     - python: 3.4
       env:
         - TEST_SLOW="true"
-        - SPLIT="1/3"
-        - FASTCACHE="false"
+        - SPLIT="1/2"
     - python: 3.4
       env:
         - TEST_SLOW="true"
-        - SPLIT="2/3"
-        - FASTCACHE="false"
-    - python: 3.4
-      env:
-        - TEST_SLOW="true"
-        - SPLIT="3/3"
-        - FASTCACHE="false"
+        - SPLIT="2/2"
     - python: 2.7
       env:
         - TEST_THEANO="true"

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -34,7 +34,7 @@ EOF
     elif [[ "${TEST_SLOW}" == "true" ]]; then
         cat << EOF | python
 import sympy
-if not sympy.test(split='${SPLIT}', slow=True, timeout=180):
+if not sympy.test(split='${SPLIT}', slow=True):
     # Travis times out if no activity is seen for 10 minutes. It also times
     # out if the whole tests run for more than 50 minutes.
     raise Exception('Tests failed')

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -24,7 +24,7 @@ from sympy import (Rational, symbols, factorial, sqrt, log, exp, oo, zoo,
 from sympy.functions.combinatorial.numbers import stirling
 from sympy.functions.special.zeta_functions import zeta
 from sympy.integrals.deltafunctions import deltaintegrate
-from sympy.utilities.pytest import XFAIL, slow, SKIP
+from sympy.utilities.pytest import XFAIL, slow, SKIP, skip, ON_TRAVIS
 from sympy.utilities.iterables import partitions
 from sympy.mpmath import mpi, mpc
 from sympy.matrices import Matrix, GramSchmidt, eye
@@ -2563,19 +2563,21 @@ def test_W23b():
     assert r1 == r2
 
 
-@SKIP("Too slow.")
 @XFAIL
 @slow
 def test_W24():
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     x, y = symbols('x y', real=True)
     r1 = integrate(integrate(sqrt(x**2 + y**2), (x, 0, 1)), (y, 0, 1))
     assert (r1 - (sqrt(2) + asinh(1))/3).simplify() == 0
 
 
-@SKIP("Too slow.")
 @XFAIL
 @slow
 def test_W25():
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     a, x, y = symbols('a x y', real=True)
     i1 = integrate(sin(a)*sin(y)/sqrt(1- sin(a)**2*sin(x)**2*sin(y)**2),
                    (x, 0, pi/2))

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2563,6 +2563,7 @@ def test_W23b():
     assert r1 == r2
 
 
+@SKIP("Too slow.")
 @XFAIL
 @slow
 def test_W24():
@@ -2571,6 +2572,7 @@ def test_W24():
     assert (r1 - (sqrt(2) + asinh(1))/3).simplify() == 0
 
 
+@SKIP("Too slow.")
 @XFAIL
 @slow
 def test_W25():

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -7,7 +7,7 @@ from sympy import (
     tan, S, log, Function, gamma, sinh,
 )
 
-from sympy.utilities.pytest import XFAIL, SKIP, slow
+from sympy.utilities.pytest import XFAIL, SKIP, slow, skip, ON_TRAVIS
 
 from sympy.abc import x, k, c, y, R, b, h, a, m, A, z, t
 
@@ -74,10 +74,12 @@ def test_issue_4525():
     assert not integrate((x**m * (1 - x)**n * (a + b*x + c*x**2))/(1 + x**2), (x, 0, 1)).has(Integral)
 
 
-@SKIP("Too slow.")
+
 @XFAIL
 @slow
 def test_issue_4540():
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     # Note, this integral is probably nonelementary
     assert not integrate(
         (sin(1/x) - x*exp(x)) /
@@ -127,10 +129,11 @@ def test_issue_4895d():
     assert not integrate(exp(2*b*x)*exp(-a*x**2), (x, 0, oo)).has(Integral)
 
 
-@SKIP("Too slow.")
 @XFAIL
 @slow
 def test_issue_4941():
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     assert not integrate(sqrt(1 + sinh(x/20)**2), (x, -25, 25)).has(Integral)
 
 

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -74,6 +74,7 @@ def test_issue_4525():
     assert not integrate((x**m * (1 - x)**n * (a + b*x + c*x**2))/(1 + x**2), (x, 0, 1)).has(Integral)
 
 
+@SKIP("Too slow.")
 @XFAIL
 @slow
 def test_issue_4540():
@@ -126,6 +127,7 @@ def test_issue_4895d():
     assert not integrate(exp(2*b*x)*exp(-a*x**2), (x, 0, oo)).has(Integral)
 
 
+@SKIP("Too slow.")
 @XFAIL
 @slow
 def test_issue_4941():

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -2,7 +2,7 @@ from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, S, erf, tan, asin, asinh, acos, acosh, Function, Derivative, diff, simplify, \
     LambertW, Eq, Piecewise, Symbol, Add, ratsimp, Integral, Sum
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
-from sympy.utilities.pytest import XFAIL, skip, slow
+from sympy.utilities.pytest import XFAIL, skip, slow, SKIP
 
 x, y, z, nu = symbols('x,y,z,nu')
 f = Function('f')
@@ -265,6 +265,7 @@ def test_pmint_besselj():
 
     assert heurisch(f, x) == g
 
+@SKIP("Too slow.")
 @slow # 110 seconds on 3.4 GHz
 def test_pmint_WrightOmega():
     def omega(x):

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -2,7 +2,7 @@ from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, S, erf, tan, asin, asinh, acos, acosh, Function, Derivative, diff, simplify, \
     LambertW, Eq, Piecewise, Symbol, Add, ratsimp, Integral, Sum
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
-from sympy.utilities.pytest import XFAIL, skip, slow, SKIP
+from sympy.utilities.pytest import XFAIL, skip, slow, ON_TRAVIS
 
 x, y, z, nu = symbols('x,y,z,nu')
 f = Function('f')
@@ -265,9 +265,10 @@ def test_pmint_besselj():
 
     assert heurisch(f, x) == g
 
-@SKIP("Too slow.")
 @slow # 110 seconds on 3.4 GHz
 def test_pmint_WrightOmega():
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     def omega(x):
         return LambertW(exp(x))
 

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -1,11 +1,12 @@
 from sympy import evalf, symbols, zeros, pi, sin, cos, sqrt, acos, Matrix
 from sympy.physics.mechanics import (ReferenceFrame, dynamicsymbols, inertia,
                                      KanesMethod, RigidBody, Point, dot)
-from sympy.utilities.pytest import slow, SKIP
+from sympy.utilities.pytest import slow, ON_TRAVIS, skip
 
-@SKIP("Way too slow.")
 @slow
 def test_bicycle():
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     # Code to get equations of motion for a bicycle modeled as in:
     # J.P Meijaard, Jim M Papadopoulos, Andy Ruina and A.L Schwab. Linearized
     # dynamics equations for the balance and steer of a bicycle: a benchmark

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -1,8 +1,9 @@
 from sympy import evalf, symbols, zeros, pi, sin, cos, sqrt, acos, Matrix
 from sympy.physics.mechanics import (ReferenceFrame, dynamicsymbols, inertia,
                                      KanesMethod, RigidBody, Point, dot)
-from sympy.utilities.pytest import slow
+from sympy.utilities.pytest import slow, SKIP
 
+@SKIP("Way too slow.")
 @slow
 def test_bicycle():
     # Code to get equations of motion for a bicycle modeled as in:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -9,7 +9,7 @@ from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
     classify_ode, classify_sysode, constant_renumber, constantsimp,
     homogeneous_order, infinitesimals, checkinfsol, checksysodesol)
 from sympy.solvers.deutils import ode_order
-from sympy.utilities.pytest import XFAIL, skip, raises, slow, SKIP
+from sympy.utilities.pytest import XFAIL, skip, raises, slow, ON_TRAVIS
 
 C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10 = symbols('C0:11')
 x, y, z = symbols('x:z', real=True)
@@ -912,7 +912,6 @@ def test_1st_exact1():
     assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
 
 
-@SKIP("Too slow.")
 @slow
 @XFAIL
 def test_1st_exact2():
@@ -925,6 +924,8 @@ def test_1st_exact2():
     equivalent, but it is so complex that checkodesol fails, and takes a long
     time to do so.
     """
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     eq = (x*sqrt(x**2 + f(x)**2) - (x**2*f(x)/(f(x) -
           sqrt(x**2 + f(x)**2)))*f(x).diff(x))
     sol = dsolve(eq)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -9,7 +9,7 @@ from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
     classify_ode, classify_sysode, constant_renumber, constantsimp,
     homogeneous_order, infinitesimals, checkinfsol, checksysodesol)
 from sympy.solvers.deutils import ode_order
-from sympy.utilities.pytest import XFAIL, skip, raises, slow
+from sympy.utilities.pytest import XFAIL, skip, raises, slow, SKIP
 
 C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10 = symbols('C0:11')
 x, y, z = symbols('x:z', real=True)
@@ -912,6 +912,7 @@ def test_1st_exact1():
     assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
 
 
+@SKIP("Too slow.")
 @slow
 @XFAIL
 def test_1st_exact2():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -15,7 +15,7 @@ from sympy.solvers.solvers import _invert, unrad, checksol, posify, _ispow, \
 from sympy.physics.units import cm
 from sympy.polys.rootoftools import RootOf
 
-from sympy.utilities.pytest import slow, XFAIL, raises, skip, SKIP
+from sympy.utilities.pytest import slow, XFAIL, raises, skip, ON_TRAVIS
 from sympy.utilities.randtest import verify_numerically as tn
 
 from sympy.abc import a, b, c, d, k, h, p, x, y, z, t, q, m
@@ -1218,9 +1218,10 @@ def test_real_roots():
     assert len(solve(x**5 + x**3 + 1)) == 1
 
 
-@SKIP("Too slow.")
 @slow
 def test_issue_6528():
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     eqs = [
         327600995*x**2 - 37869137*x + 1809975124*y**2 - 9998905626,
         895613949*x**2 - 273830224*x*y + 530506983*y**2 - 10000000000]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -15,7 +15,7 @@ from sympy.solvers.solvers import _invert, unrad, checksol, posify, _ispow, \
 from sympy.physics.units import cm
 from sympy.polys.rootoftools import RootOf
 
-from sympy.utilities.pytest import slow, XFAIL, raises, skip
+from sympy.utilities.pytest import slow, XFAIL, raises, skip, SKIP
 from sympy.utilities.randtest import verify_numerically as tn
 
 from sympy.abc import a, b, c, d, k, h, p, x, y, z, t, q, m
@@ -1218,6 +1218,7 @@ def test_real_roots():
     assert len(solve(x**5 + x**3 + 1)) == 1
 
 
+@SKIP("Too slow.")
 @slow
 def test_issue_6528():
     eqs = [

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -4,6 +4,7 @@ from __future__ import print_function, division
 
 import sys
 import functools
+import os
 
 from sympy.core.compatibility import get_function_name
 
@@ -13,6 +14,8 @@ try:
     USE_PYTEST = getattr(sys, '_running_pytest', False)
 except ImportError:
     USE_PYTEST = False
+
+ON_TRAVIS = os.getenv('TRAVIS_BUILD_NUMBER', None)
 
 if not USE_PYTEST:
     def raises(expectedException, code=None):


### PR DESCRIPTION
The following tests never actually run to completion on Travis due to the specified timeout of 180s.  Rather than waste 3 minutes on these tests (most of which are xfailed anyway) which are not run to completion, this PR ~~skips them~~  checks to see if we are running on travis via the TRAVIS_BUILD_NUMBER environment variable and if so, skips them. 

6745.05s call     sympy/physics/mechanics/tests/test_kane3.py::test_bicycle
2083.29s call     sympy/solvers/tests/test_ode.py::test_1st_exact2
1522.66s call     sympy/integrals/tests/test_failing_integrals.py::test_issue_4540
1221.33s call     sympy/core/tests/test_wester.py::test_W25
1090.84s call     sympy/integrals/tests/test_failing_integrals.py::test_issue_4941
963.31s call     sympy/solvers/tests/test_solvers.py::test_issue_6528
437.72s call     sympy/integrals/tests/test_heurisch.py::test_pmint_WrightOmega
411.27s call     sympy/core/tests/test_wester.py::test_W24
(The times are from py.test --durations)

Because of this we can restore the split to halves instead of thirds and use fastcache to further speed things along.  Furthermore, we will no longer be relying on the timeout signal to kill these tests which should reduce the frequency of timeouts in the slow tests.

There is some discussion of this issue on the mailing list: https://groups.google.com/forum/#!topic/sympy/xDM4NHWP9cA
