### PR TITLE
Fix broken test, test_lambddify::test_math_lambda

### DIFF
--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -101,7 +101,7 @@ def test_math_lambda():
     f = lambdify(x, sin(x), "math")
     prec = 1e-15
     assert -prec < f(0.2) - sin02 < prec
-    raises(ValueError, lambda: f(x))
+    raises(TypeError, lambda: f(x))
            # if this succeeds, it can't be a python math function
 
 


### PR DESCRIPTION
This test was allowed to remain broken because the tests decorated with `@conserve_mpmath_dps` are not run using bin/test.  This error was discovered using py.test:
- On Master

``` bash
$ py.test sympy/utilities/tests/test_lambdify.py -k test_math_lambda
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 44 items 

sympy/utilities/tests/test_lambdify.py F

=================================== FAILURES ===================================
_______________________________ test_math_lambda _______________________________

    def func_wrapper():
        dps = mpmath.mp.dps
        try:
>           func()

sympy/utilities/decorator.py:89: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    @conserve_mpmath_dps
    def test_math_lambda():
        mpmath.mp.dps = 50
        sin02 = mpmath.mpf("0.19866933079506121545941262711838975037020672954020")
        f = lambdify(x, sin(x), "math")
        prec = 1e-15
        assert -prec < f(0.2) - sin02 < prec
>       raises(ValueError, lambda: f(x))

sympy/utilities/tests/test_lambdify.py:104: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   raises(ValueError, lambda: f(x))

sympy/utilities/tests/test_lambdify.py:104: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

_Dummy_13 = x

>   ???

<string>:1: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = x

    def __float__(self):
        # Don't bother testing if it's a number; if it's not this is going
        # to fail, and if it is we still need to check that it evalf'ed to
        # a number.
        result = self.evalf()
        if result.is_Number:
            return float(result)
        if result.is_number and result.as_real_imag()[1]:
            raise TypeError("can't convert complex to float")
>       raise TypeError("can't convert expression to float")
E       TypeError: can't convert expression to float

sympy/core/expr.py:209: TypeError
                                DO *NOT* COMMIT!                                
================= 43 tests deselected by '-ktest_math_lambda' ==================
=================== 1 failed, 43 deselected in 0.19 seconds ====================
```
- PR

``` bash
$ py.test sympy/utilities/tests/test_lambdify.py -k test_math_lambda
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 44 items 

sympy/utilities/tests/test_lambdify.py .

================= 43 tests deselected by '-ktest_math_lambda' ==================
=================== 1 passed, 43 deselected in 0.16 seconds ====================
```

`bin/test` only reports 40 tests instead of pytest's 44 (corresponding to the four decorated with `@conserve_mpmath_dps`

``` bash
$ bin/test sympy/utilities/tests/test_lambdify.py
============================= test process starts ==============================
executable:         /home/peter/miniconda3/bin/python  (3.4.1-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        86426641
hash randomization: on (PYTHONHASHSEED=2759404070)

sympy/utilities/tests/test_lambdify.py[40] .....................................
...                                                                         [OK]

================== tests finished: 40 passed, in 0.69 seconds ==================
```
