### PR TITLE
Fix for #7906: apply (inverse) laplace transform element-wise on matrices

### DIFF
--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -14,6 +14,7 @@ from sympy import (
     exp_polar, polar_lift, unpolarify, Function, expint, expand_mul,
     combsimp, trigsimp)
 from sympy.utilities.pytest import XFAIL, slow, skip
+from sympy.matrices import Matrix, eye
 from sympy.abc import x, s, a, b, c, d
 nu, beta, rho = symbols('nu beta rho')
 
@@ -504,6 +505,12 @@ def test_laplace_transform():
         (sin(s**2/(2*pi))*fresnelc(s/pi)/s - cos(s**2/(2*pi))*fresnels(s/pi)/s
         + sqrt(2)*cos(s**2/(2*pi) + pi/4)/(2*s), 0, True))
 
+    assert LT(Matrix([[exp(t), t*exp(-t)], [t*exp(-t), exp(t)]]), t, s) ==\
+        Matrix([
+            [(1/(s - 1), 1, True), ((s + 1)**(-2), 0, True)],
+            [((s + 1)**(-2), 0, True), (1/(s - 1), 1, True)]
+        ])
+
 
 def test_inverse_laplace_transform():
     from sympy import (expand, sinh, cosh, besselj, besseli, exp_polar,
@@ -549,6 +556,9 @@ def test_inverse_laplace_transform():
     # TODO can we make erf(t) work?
 
     assert ILT(1/(s**2*(s**2 + 1)),s,t) == (t - sin(t))*Heaviside(t)
+
+    assert ILT( (s * eye(2) - Matrix([[1, 0], [0, 2]])).inv(), s, t) ==\
+        Matrix([[exp(t)*Heaviside(t), 0], [0, exp(2*t)*Heaviside(t)]])
 
 
 def test_fourier_transform():

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -12,6 +12,7 @@ from sympy.integrals.meijerint import _dummy
 from sympy.logic.boolalg import to_cnf, conjuncts, disjuncts, Or, And
 from sympy.simplify import simplify
 from sympy.utilities import default_sort_key
+from sympy.matrices.matrices import MatrixBase
 
 
 ##########################################################################
@@ -1112,6 +1113,8 @@ def laplace_transform(f, t, s, **hints):
     inverse_laplace_transform, mellin_transform, fourier_transform
     hankel_transform, inverse_hankel_transform
     """
+    if isinstance(f, MatrixBase) and hasattr(f, 'applyfunc'):
+        return f.applyfunc(lambda fij: laplace_transform(fij, t, s, **hints))
     return LaplaceTransform(f, t, s).doit(**hints)
 
 
@@ -1259,6 +1262,8 @@ def inverse_laplace_transform(F, s, t, plane=None, **hints):
     laplace_transform
     hankel_transform, inverse_hankel_transform
     """
+    if isinstance(F, MatrixBase) and hasattr(F, 'applyfunc'):
+        return F.applyfunc(lambda Fij: inverse_laplace_transform(Fij, s, t, plane, **hints))
     return InverseLaplaceTransform(F, s, t, plane).doit(**hints)
 
 


### PR DESCRIPTION
Added test case for each LP AND ILP
Test result before change:
    sympy/integrals/tests/test_transforms.py[15] ....w..........[OK]
    tests finished: 14 passed, 1 skipped, in 185.04 seconds
Test result after change:
    sympy/integrals/tests/test_transforms.py[15] ....w..........[OK]
    tests finished: 14 passed, 1 skipped, in 195.63 seconds
