### PR TITLE
Ensure pytest skips tests that have been disabled

### DIFF
--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -21,6 +21,13 @@ if not ipython:
     disabled = True
 
 
+def setup_module(module):
+    """py.test support"""
+    if getattr(module, 'disabled', False):
+        import pytest
+        pytest.skip("ipython isn't available.")
+
+
 def test_automatic_symbols():
     # this implicitly requires readline
     if not readline:

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -15,6 +15,13 @@ if not ipython:
     disabled = True
 
 
+def setup_module(module):
+    """py.test support"""
+    if getattr(module, 'disabled', False):
+        import pytest
+        pytest.skip("ipython isn't available.")
+
+
 def test_ipythonprinting():
     # Initialize and setup IPython session
     app = init_ipython_session()

--- a/sympy/plotting/intervalmath/tests/test_interval_functions.py
+++ b/sympy/plotting/intervalmath/tests/test_interval_functions.py
@@ -11,6 +11,13 @@ np = import_module('numpy')
 if not np:
     disabled = True
 
+
+def setup_module(module):
+    """py.test support"""
+    if getattr(module, 'disabled', False):
+        import pytest
+        pytest.skip("numpy isn't available.")
+
 #requires Numpy. Hence included in interval_functions
 
 

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -1,5 +1,5 @@
 from sympy.external import import_module
-from sympy.utilities.pytest import raises, SKIP, USE_PYTEST
+from sympy.utilities.pytest import raises, SKIP
 
 theano = import_module('theano')
 if theano:
@@ -7,15 +7,15 @@ if theano:
     ts = theano.scalar
     tt = theano.tensor
     xt, yt, zt = [tt.scalar(name, 'floatX') for name in 'xyz']
-    disabled = False
 else:
     #bin/test will not execute any tests now
     disabled = True
 
-if USE_PYTEST:
-    import py.test
-    pytestmark = py.test.mark.skipif(disabled is True,
-                                     reason=("theano not installed"))
+def setup_module(module):
+    """py.test support"""
+    if getattr(module, 'disabled', False):
+        import pytest
+        pytest.skip("theano isn't available.")
 
 import sympy
 from sympy import S


### PR DESCRIPTION
`bin/test` tests if required modules are available for certain tests and if not does not run the test.  Some of these files had corresponding `setup_module` functions so pytest would skip them if the required modules were not available and some did not.  This PR ensures that `bin/test` and `pytest` will see the same tests as disabled/skipped
- On master (no numpy installed)

``` bash
$ py.test sympy/plotting/intervalmath/tests/test_interval_functions.py 
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 24 items 

sympy/plotting/intervalmath/tests/test_interval_functions.py FFFFFFFFF..FFFFFFFFFF...
```
- PR (still no numpy)

``` bash
$ py.test sympy/plotting/intervalmath/tests/test_interval_functions.py 
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.20 -- pytest-2.5.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 24 items 

sympy/plotting/intervalmath/tests/test_interval_functions.py ssssssssssssssssssssssss

========================== 24 skipped in 0.22 seconds ==========================
```
