### PR TITLE
(continued from #8403) changing assumptions

### DIFF
--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -260,7 +260,7 @@ def deltasummation(f, limit, no_piecewise=False):
 
     >>> from sympy import oo, symbols
     >>> from sympy.abc import k
-    >>> i, j = symbols('i, j', integer=True, finite=True)
+    >>> i, j = symbols('i, j', integer=True)
     >>> from sympy.concrete.delta import deltasummation
     >>> from sympy import KroneckerDelta, Piecewise
     >>> deltasummation(KroneckerDelta(i, k), (k, -oo, oo))

--- a/sympy/concrete/tests/test_delta.py
+++ b/sympy/concrete/tests/test_delta.py
@@ -4,7 +4,7 @@ from sympy.core import Eq, S, symbols, oo
 from sympy.functions import KroneckerDelta as KD, Piecewise, piecewise_fold
 from sympy.logic import And
 
-i, j, k, l, m = symbols("i j k l m", integer=True, finite=True)
+i, j, k, l, m = symbols("i j k l m", integer=True)
 x, y = symbols("x y", commutative=False)
 
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -521,7 +521,7 @@ def test_Sum_doit():
     assert Sum(f(n)*Sum(KroneckerDelta(m, n), (m, 0, oo)), (n, 1, 3)).doit() == \
         f(1) + f(2) + f(3)
     assert Sum(f(n)*Sum(KroneckerDelta(m, n), (m, 0, oo)), (n, 1, oo)).doit() == \
-        Sum(Piecewise((f(n), And(Le(0, n), n < oo)), (0, True)), (n, 1, oo))
+        Sum(Piecewise((f(n), n >= 0), (0, True)), (n, 1, oo))
     l = Symbol('l', integer=True, positive=True)
     assert Sum(f(l)*Sum(KroneckerDelta(m, l), (m, 0, oo)), (l, 1, oo)).doit() == \
         Sum(f(l), (l, 1, oo))

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -445,14 +445,8 @@ class Add(Expr, AssocOp):
         return all(term._eval_is_algebraic_expr(syms) for term in self.args)
 
     # assumption methods
-    _eval_is_real = lambda self: _fuzzy_group(
-        (a.is_real for a in self.args), quick_exit=True)
-    _eval_is_complex = lambda self: _fuzzy_group(
-        (a.is_complex for a in self.args), quick_exit=True)
     _eval_is_antihermitian = lambda self: _fuzzy_group(
         (a.is_antihermitian for a in self.args), quick_exit=True)
-    _eval_is_finite = lambda self: _fuzzy_group(
-        (a.is_finite for a in self.args), quick_exit=True)
     _eval_is_hermitian = lambda self: _fuzzy_group(
         (a.is_hermitian for a in self.args), quick_exit=True)
     _eval_is_integer = lambda self: _fuzzy_group(
@@ -464,11 +458,114 @@ class Add(Expr, AssocOp):
     _eval_is_commutative = lambda self: _fuzzy_group(
         a.is_commutative for a in self.args)
 
+    def _eval_is_complex(self):
+        c = True
+        pos = POS = neg = NEG = unk = False
+        im = com = 0
+        for a in self.args:
+            ic = a.is_complex
+            if not ic:
+                if ic is False:
+                    return False
+                c = ic
+                continue
+            f = a.is_finite
+            if f:
+                continue
+            r = a.is_real
+            if r:
+                p = a.is_positive
+                if p:
+                    if f is False:
+                        POS = True
+                    else:
+                        pos = True
+                    continue
+                n = a.is_negative
+                if n:
+                    if f is False:
+                        NEG = True
+                    else:
+                        neg = True
+                    continue
+                unk = True
+                continue
+            i = a.is_imaginary
+            if i:
+                im += 1
+                continue
+            if not r and not i:
+                com += 1
+                continue
+        if not c:
+            return c
+        if NEG and POS:
+            return False
+        if sum([im, com]) > 1:
+            return
+        if sum([NEG or neg, POS or pos, unk, com]) > 1:
+            return
+        return True
+
+    def _eval_is_finite(self):
+        c = self._eval_is_complex()
+        if c is False:
+            return c
+        if c is True:
+            return _fuzzy_group((a.is_finite for a in self.args))
+        # it is not known if nan will occur; to answer finite we want to
+        # convert nan cases to False
+        if all(a.is_complex for a in self.args):
+            return False
+
+    def _eval_is_real(self):
+        # complex is not False or we wouldn't be here
+        if any(not a.is_complex for a in self.args):
+            return
+        # all args are complex;
+        f = self._eval_is_finite()
+        r = _fuzzy_group(a.is_real for a in self.args)
+        if f:  # no worry about nan
+            return r
+        if r:
+            # if actual nan, complex is False and we wouldn't be here
+            # if potential nan return None; if complex is None then
+            # we had a potential nan else we didn't; either way the answer
+            # for real is the same as for complex since we know all args
+            # are real
+            return self._eval_is_complex()
+        # a term had an imaginary component (since we know all terms are complex);
+        # if any of these terms is infinite then real is False or
+        # if there is only one term that has real and imag parts then False,
+        # else None
+        neither = False
+        im = False
+        notir = 0
+        for a in self.args:
+            if a.is_finite:
+                continue
+            if a.is_imaginary:
+                return False
+            elif a.is_imaginary is False and a.is_real is False:
+                notir += 1
+            elif not a.is_real:
+                if neither:
+                    return
+                neither = True
+        if neither and notir:
+            return
+        elif notir == 1:
+            return False
+
     def _eval_is_imaginary(self):
         from sympy import im
-        ret = _fuzzy_group(a.is_imaginary for a in self.args)
-        if not ret:
-            return ret
+        i = _fuzzy_group(a.is_imaginary for a in self.args)
+        if not i:
+            inf = False
+            for a in self.args:
+                if a.is_real and a.is_infinite:
+                    return False
+            return i
         newarg = []
         for a in self.args:
             t = im(a)
@@ -478,8 +575,8 @@ class Add(Expr, AssocOp):
                 newarg.append(t)
             else:
                 return
-        i = self.func(*newarg)
-        if i.is_zero is False:
+        z = self.func(*newarg).is_zero
+        if z is False:
             return True
 
     def _eval_is_odd(self):
@@ -493,14 +590,15 @@ class Add(Expr, AssocOp):
         for t in self.args:
             a = t.is_irrational
             if a:
-                others = list(self.args)
-                others.remove(t)
-                if all(x.is_rational is True for x in others):
-                    return True
-                return None
+                break
             if a is None:
                 return
-        return False
+        else:
+            return False
+        others = list(self.args)
+        others.remove(t)
+        if all(x.is_rational is True for x in others):
+            return True
 
     def _eval_is_positive(self):
         if self.is_number:

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -231,11 +231,11 @@ class Add(Expr, AssocOp):
         # oo, -oo
         if coeff is S.Infinity:
             newseq = [f for f in newseq if not
-                      (f.is_nonnegative or f.is_real and f.is_finite)]
+                      (f.is_nonnegative or f.is_finite_real)]
 
         elif coeff is S.NegativeInfinity:
             newseq = [f for f in newseq if not
-                      (f.is_nonpositive or f.is_real and f.is_finite)]
+                      (f.is_nonpositive or f.is_finite_real)]
 
         if coeff is S.ComplexInfinity:
             # zoo might be

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -68,13 +68,14 @@ def _unevaluated_Add(*args):
             num += a
         else:
             newargs.append(a)
-    if num:
-        if num.is_Number:
-            co += num
-        elif num.is_Add:
-            newargs.extend(num.args)
-        else:
-            newargs.append(num)
+    if num.is_Number:
+        # usually this will just be zero but just in
+        # case, we add it anyway without testing
+        co += num
+    elif num.is_Add:
+        newargs.extend(num.args)
+    else:
+        newargs.append(num)
     _addsort(newargs)
     if co:
         newargs.insert(0, co)
@@ -651,8 +652,6 @@ class Add(Expr, AssocOp):
             elif a.is_nonpositive:
                 nonpos = True
                 continue
-            elif a.is_zero:
-                continue
 
             if infinite is None:
                 return
@@ -695,8 +694,6 @@ class Add(Expr, AssocOp):
                 continue
             elif a.is_nonnegative:
                 nonneg = True
-                continue
-            elif a.is_zero:
                 continue
 
             if infinite is None:

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -461,17 +461,17 @@ class Add(Expr, AssocOp):
 
     # assumption methods
     _eval_is_antihermitian = lambda self: _fuzzy_group(
-        (a.is_antihermitian for a in self.args), quick_exit=True)
+        (a.is_antihermitian for a in Add.make_args(_unevaluated_Add(self))), quick_exit=True)
     _eval_is_hermitian = lambda self: _fuzzy_group(
-        (a.is_hermitian for a in self.args), quick_exit=True)
+        (a.is_hermitian for a in Add.make_args(_unevaluated_Add(self))), quick_exit=True)
     _eval_is_integer = lambda self: _fuzzy_group(
-        (a.is_integer for a in self.args), quick_exit=True)
+        (a.is_integer for a in Add.make_args(_unevaluated_Add(self))), quick_exit=True)
     _eval_is_rational = lambda self: _fuzzy_group(
-        (a.is_rational for a in self.args), quick_exit=True)
+        (a.is_rational for a in Add.make_args(_unevaluated_Add(self))), quick_exit=True)
     _eval_is_algebraic = lambda self: _fuzzy_group(
         (a.is_algebraic for a in self.args), quick_exit=True)
     _eval_is_commutative = lambda self: _fuzzy_group(
-        a.is_commutative for a in self.args)
+        a.is_commutative for a in Add.make_args(_unevaluated_Add(self)))
 
     def _eval_is_complex(self):
         c = True
@@ -534,6 +534,9 @@ class Add(Expr, AssocOp):
             return False
 
     def _eval_is_real(self):
+        self = _unevaluated_Add(self)
+        if not self.is_Add:
+            return self.is_real
         # complex is not False or we wouldn't be here
         if any(not a.is_complex for a in self.args):
             return
@@ -574,6 +577,9 @@ class Add(Expr, AssocOp):
 
     def _eval_is_imaginary(self):
         from sympy import im
+        self = _unevaluated_Add(self)
+        if not self.is_Add:
+            return self.is_imaginary
         i = _fuzzy_group(a.is_imaginary for a in self.args)
         if not i:
             inf = False
@@ -595,6 +601,9 @@ class Add(Expr, AssocOp):
             return True
 
     def _eval_is_odd(self):
+        self = _unevaluated_Add(self)
+        if not self.is_Add:
+            return self.is_odd
         l = [f for f in self.args if not (f.is_even is True)]
         if not l:
             return False
@@ -616,6 +625,9 @@ class Add(Expr, AssocOp):
             return True
 
     def _eval_is_positive(self):
+        self = _unevaluated_Add(self)
+        if not self.is_Add:
+            return self.is_positive
         if self.is_number:
             return super(Add, self)._eval_is_positive()
         pos = nonneg = nonpos = unknown_sign = False
@@ -658,6 +670,9 @@ class Add(Expr, AssocOp):
             return False
 
     def _eval_is_negative(self):
+        self = _unevaluated_Add(self)
+        if not self.is_Add:
+            return self.is_negative
         if self.is_number:
             return super(Add, self)._eval_is_negative()
         neg = nonpos = nonneg = unknown_sign = False

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -51,6 +51,8 @@ from sympy.core.facts import FactRules, FactKB
 from sympy.core.core import BasicMeta
 from sympy.core.compatibility import integer_types, with_metaclass
 
+from random import shuffle
+
 
 # This are the rules under which our assumptions function
 #
@@ -195,7 +197,9 @@ def _ask(fact, obj):
             return a
 
     # Try assumption's prerequisites
-    for pk in _assume_rules.prereq[fact]:
+    prereq = list(_assume_rules.prereq[fact])
+    shuffle(prereq)
+    for pk in prereq:
         if pk in assumptions:
             continue
         if pk in handler_map:

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -88,7 +88,6 @@ _assume_rules = FactRules([
     'even           ==  integer & !odd',
 
     'real           ==  negative | zero | positive',
-    'transcendental ==  complex & !algebraic & finite',
 
     'negative       ==  nonpositive & nonzero',
     'positive       ==  nonnegative & nonzero',
@@ -103,6 +102,8 @@ _assume_rules = FactRules([
     'composite      ==  integer & nonzero & !prime',
 
     'irrational     ==  real & !rational & finite',
+
+    'transcendental ==  irrational & !algebraic',
 
     'imaginary      ->  !real',
 

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -98,7 +98,7 @@ _assume_rules = FactRules([
     'zero           ->  even',
 
     'prime          ->  integer & positive',
-    'composite      ==  integer & positive & !prime',
+    'composite      ==  integer & nonzero & !prime',
 
     'irrational     ==  real & !rational & finite',
 

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -89,6 +89,9 @@ _assume_rules = FactRules([
 
     'real           ==  negative | zero | positive',
 
+    'finite_real    ==  irrational | rational',
+    'finite_real    ==  finite & real',
+
     'negative       ==  nonpositive & nonzero',
     'positive       ==  nonnegative & nonzero',
     'zero           ==  nonnegative & nonpositive',

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -75,7 +75,7 @@ _assume_rules = FactRules([
     'integer        ->  rational',
     'rational       ->  real',
     'rational       ->  algebraic',
-    'algebraic      ->  complex',
+    'algebraic      ->  complex & finite',
     'real           ->  complex',
     'real           ->  hermitian',
     'imaginary      ->  complex',
@@ -86,7 +86,7 @@ _assume_rules = FactRules([
     'even           ==  integer & !odd',
 
     'real           ==  negative | zero | positive',
-    'transcendental ==  complex & !algebraic',
+    'transcendental ==  complex & !algebraic & finite',
 
     'negative       ==  nonpositive & nonzero',
     'positive       ==  nonnegative & nonzero',
@@ -100,13 +100,16 @@ _assume_rules = FactRules([
     'prime          ->  integer & positive',
     'composite      ==  integer & positive & !prime',
 
-    'irrational     ==  real & !rational',
+    'irrational     ==  real & !rational & finite',
 
     'imaginary      ->  !real',
 
-    '!finite        ==  infinite',
     'noninteger     ==  real & !integer',
-    '!zero        ==  nonzero',
+
+    'nonzero        ==  complex & !zero',
+
+    'finite         ==  complex & !infinite',
+    'infinite       ==  complex & !finite',
 ])
 
 _assume_defined = _assume_rules.defined_facts.copy()

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -645,7 +645,7 @@ class Expr(Basic, EvalfMixin):
 
     def _eval_is_positive(self):
         if self.is_number:
-            if self.is_real is False:
+            if getattr(self, '_eval_is_real', None) is False:
                 return False
             try:
                 # check to see that we can get a value
@@ -671,7 +671,7 @@ class Expr(Basic, EvalfMixin):
 
     def _eval_is_negative(self):
         if self.is_number:
-            if self.is_real is False:
+            if getattr(self, '_eval_is_real', None) is False:
                 return False
             try:
                 # check to see that we can get a value

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -602,7 +602,7 @@ class Function(Application, Expr):
                 #for example when e = sin(x+1) or e = sin(cos(x))
                 #let's try the general algorithm
                 term = e.subs(x, S.Zero)
-                if term.is_finite is False or term is S.NaN:
+                if term.is_finite is False:
                     raise PoleError("Cannot expand %s around 0" % (self))
                 series = term
                 fact = S.One

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1032,8 +1032,6 @@ class Mul(Expr, AssocOp):
                 if one_neither:
                     return  # (1 + I)*(1 -/+ I) would be real/complex
                 one_neither = t
-            else:
-                return
 
         if one_neither:  # the `neither` might be a+I*b or I*b
             if real:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1190,11 +1190,17 @@ class Mul(Expr, AssocOp):
             all(arg.is_polar or arg.is_positive for arg in self.args)
 
     def _eval_is_imaginary(self):
-        if self.is_nonzero:
+        z = self._eval_is_zero()
+        if z:
+            return False
+        elif z is False:
             return (S.ImaginaryUnit*self).is_real
 
     def _eval_is_antihermitian(self):
-        if self.is_nonzero:
+        z = self._eval_is_zero()
+        if z:
+            return False
+        elif z is False:
             return (S.ImaginaryUnit*self).is_hermitian
 
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1120,7 +1120,7 @@ class Mul(Expr, AssocOp):
             return False
 
     def _eval_is_integer(self):
-        rational = self.is_rational
+        rational = self._eval_is_rational()
         if not rational:
             return rational
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -8,7 +8,7 @@ from .basic import Basic, C
 from .singleton import S
 from .operations import AssocOp
 from .cache import cacheit
-from .logic import fuzzy_not, _fuzzy_group, _fuzzy_group_inverse
+from .logic import fuzzy_not, _fuzzy_group, _fuzzy_group_inverse, fuzzy_and
 from .compatibility import cmp_to_key, reduce, xrange
 from .expr import Expr
 
@@ -541,8 +541,8 @@ class Mul(Expr, AssocOp):
         # zoo
         if coeff is S.ComplexInfinity:
             # zoo might be
-            #   infinite_real + bounded_im
-            #   bounded_real + infinite_im
+            #   infinite_real + finite_im
+            #   finite_real + infinite_im
             #   infinite_real + infinite_im
             # and non-zero real or imaginary will not change that status.
             c_part = [c for c in c_part if not (c.is_nonzero and
@@ -956,19 +956,10 @@ class Mul(Expr, AssocOp):
     def _eval_is_algebraic_expr(self, syms):
         return all(term._eval_is_algebraic_expr(syms) for term in self.args)
 
-    _eval_is_finite = lambda self: _fuzzy_group(
-        a.is_finite for a in self.args)
     _eval_is_commutative = lambda self: _fuzzy_group(
         a.is_commutative for a in self.args)
-    _eval_is_complex = lambda self: _fuzzy_group(
-        (a.is_complex for a in self.args), quick_exit=True)
-
-    def _eval_is_rational(self):
-        r = _fuzzy_group((a.is_rational for a in self.args), quick_exit=True)
-        if r:
-            return r
-        elif r is False:
-            return self._eval_is_zero()
+    _eval_is_finite = lambda self: _fuzzy_group(
+        a.is_finite for a in self.args)
 
     def _eval_is_algebraic(self):
         r = _fuzzy_group((a.is_algebraic for a in self.args), quick_exit=True)
@@ -978,75 +969,187 @@ class Mul(Expr, AssocOp):
             return self._eval_is_zero()
 
     def _eval_is_zero(self):
-        zero = unbound = False
+        # return True if 0, False if NaN or != 0, None if uncertain
+        zero = False
+        finite = True
         for a in self.args:
             z = a.is_zero
             if z:
-                if unbound:
-                    return  # 0*oo is nan and nan.is_zero is None
+                if not finite:
+                    return finite
                 zero = True
             else:
-                if not a.is_finite:
+                b = a.is_finite
+                if b is False:
                     if zero:
-                        return  # 0*oo is nan and nan.is_zero is None
-                    unbound = True
+                        return False
+                    if finite is not b:
+                        finite = b
+                elif finite is not None and b is None:
+                    finite = b  # trap None
                 if zero is False and z is None:  # trap None
                     zero = None
-        return zero
+        return fuzzy_and((zero, finite))
 
-    def _eval_is_integer(self):
-        is_rational = self.is_rational
-
-        if is_rational:
-            n, d = self.as_numer_denom()
-            if d is S.One:
-                return True
-            elif d is S(2):
-                return n.is_even
-        elif is_rational is False:
-            return False
-
-    def _eval_is_polar(self):
-        has_polar = any(arg.is_polar for arg in self.args)
-        return has_polar and \
-            all(arg.is_polar or arg.is_positive for arg in self.args)
+    def _eval_is_complex(self):
+        # return True if complex, False if NaN or other non-complex, else None
+        c = _fuzzy_group(a.is_complex for a in self.args)
+        if not c:
+            return c
+        z = self._eval_is_zero()
+        if z:
+            return True  # zero/finite is T/T
+        if z is False:
+            # zero/finite is F/F or T/F or F/T
+            if any(a.is_zero for a in self.args):
+                if any(a.is_infinite for a in self.args):
+                    return False
+            return True
+        # zero/finite is :
+        #     T/? - something that is not zero is not known to be finite -> complex or nan
+        #     ?/T - something that is finite is not known to be zero -> complex
+        #     ?/? - none of the above -> complex or nan
+        if any(not a.is_zero for a in self.args if a.is_finite):
+            return True  # this was ?/T case
 
     def _eval_is_real(self):
+        c = self._eval_is_complex()
+        if not c:
+            return c
+        zero = self._eval_is_zero()
+        if zero:
+            return True
+
         real = True
-        zero = one_neither = False
+        one_neither = False
 
         for t in self.args:
-            if not t.is_complex:
-                return t.is_complex
-            elif t.is_imaginary:
+            if t.is_imaginary:
                 real = not real
             elif t.is_real:
-                if not zero:
-                    z = t.is_zero
-                    if not z and zero is False:
-                        zero = z
-                    elif z:
-                        if all(a.is_finite for a in self.args):
-                            return True
-                        return
-            elif t.is_real is False:
+                pass
+            elif not t.is_real:
                 if one_neither:
-                    return  # complex terms might cancel
-                one_neither = True
+                    return  # (1 + I)*(1 -/+ I) would be real/complex
+                one_neither = t
             else:
                 return
 
-        if one_neither:  # self is a+I*b or I*b
+        if one_neither:  # the `neither` might be a+I*b or I*b
             if real:
-                return zero  # real*self is like self: neither is real
+                return zero
+            if one_neither.is_real is False and one_neither.is_imaginary is False:
+                return zero
+            return
         elif zero is False:
             return real  # can't be trumped by 0
         elif real:
             return real  # doesn't matter what zero is
 
-    def _eval_is_imaginary(self):
-        if self.is_nonzero:
-            return (S.ImaginaryUnit*self).is_real
+    def _eval_is_rational(self):
+        r = self._eval_is_real()
+        if not r:
+            return r
+        r = _fuzzy_group((a.is_rational for a in self.args), quick_exit=True)
+        if r is None:
+            return
+        if r is True:
+            n, d = self.as_numer_denom()
+            return fuzzy_not(d.is_zero)
+        else:
+            # answer depends on whether the rational part is zero
+            return Mul._from_args([a for a in self.args
+                if a.is_rational]).is_zero
+
+    def _eval_is_positive(self):
+        """Return True if self is positive, False if not, and None if it
+        cannot be determined.
+
+        This algorithm works by keeping track of the sign which changes
+        when a negative, nonpositive or imaginary is encountered.
+        Whether a nonpositive or nonnegative is seen is also tracked since
+        the presence of these makes it impossible to return True, but
+        possible to return False if the end result is nonpositive. e.g.
+
+            pos * neg * nonpositive -> pos or zero -> None is returned
+            pos * neg * nonnegative -> neg or zero -> False is returned
+
+        If a non-complex factor is observed, False is returned; if a
+        factor is not known to be complex then None is returned. The presence
+        of a non-real that is also not imaginary is also tracked: if, except
+        for such factors, the sign is real then False is returned otherwise
+        None is returned.
+        """
+        from sympy.functions.elementary.complexes import sign
+        if self._eval_is_zero():
+            return False
+
+        s = S.One
+        saw_NON = saw_i = zero = False
+        for t in self.args:
+            if t.is_positive:
+                continue
+            elif t.is_negative:
+                s = -s
+            elif t.is_zero:
+                zero = True
+            elif t.is_imaginary:
+                if t.is_Symbol:
+                    if saw_i:
+                        return
+                    saw_i = True
+                else:
+                    s *= sign(t)
+            elif t.is_nonpositive:
+                s = -s
+                saw_NON = True
+            elif t.is_nonnegative:
+                saw_NON = True
+            else:
+                return
+
+        if s.is_imaginary:
+            if saw_i:
+                return
+            return False
+        if zero and saw_i:
+            return False
+        if s.is_positive and saw_NON is False:
+            return True
+        if s.is_negative:
+            return False
+
+    def _eval_is_integer(self):
+        rational = self.is_rational
+        if not rational:
+            return rational
+
+        n, d = self.as_numer_denom()
+        if d is S.One:
+            return True
+        elif d is S(2):
+            return n.is_even
+
+    def _eval_is_odd(self):
+        i = self._eval_is_integer()
+        if not i:
+            return i
+
+        odd, acc = True, 1
+        for t in self.args:
+            if not t.is_integer:  # XXX necessary?
+                return None
+            elif t.is_even:
+                odd = False
+            elif t.is_integer:
+                if odd is False:
+                    pass
+                elif acc != 1 and (acc + t).is_odd:
+                    odd = False
+                elif t.is_odd is None:
+                    odd = None
+            acc = t
+        return odd
 
     def _eval_is_hermitian(self):
         real = True
@@ -1078,93 +1181,22 @@ class Mul(Expr, AssocOp):
         elif zero is False or real:
             return real
 
+    def _eval_is_negative(self):
+        return (-self).is_positive
+
+    def _eval_is_polar(self):
+        has_polar = any(arg.is_polar for arg in self.args)
+        return has_polar and \
+            all(arg.is_polar or arg.is_positive for arg in self.args)
+
+    def _eval_is_imaginary(self):
+        if self.is_nonzero:
+            return (S.ImaginaryUnit*self).is_real
+
     def _eval_is_antihermitian(self):
         if self.is_nonzero:
             return (S.ImaginaryUnit*self).is_hermitian
 
-    def _eval_is_irrational(self):
-        for t in self.args:
-            a = t.is_irrational
-            if a:
-                others = list(self.args)
-                others.remove(t)
-                if all((x.is_rational and x.is_nonzero) is True for x in others):
-                    return True
-                return
-            if a is None:
-                return
-        return False
-
-    def _eval_is_positive(self):
-        """Return True if self is positive, False if not, and None if it
-        cannot be determined.
-
-        This algorithm is non-recursive and works by keeping track of the
-        sign which changes when a negative or nonpositive is encountered.
-        Whether a nonpositive or nonnegative is seen is also tracked since
-        the presence of these makes it impossible to return True, but
-        possible to return False if the end result is nonpositive. e.g.
-
-            pos * neg * nonpositive -> pos or zero -> None is returned
-            pos * neg * nonnegative -> neg or zero -> False is returned
-        """
-
-        sign = 1
-        saw_NON = False
-        for t in self.args:
-            if t.is_positive:
-                continue
-            elif t.is_negative:
-                sign = -sign
-            elif t.is_zero:
-                return False
-            elif t.is_nonpositive:
-                sign = -sign
-                saw_NON = True
-            elif t.is_nonnegative:
-                saw_NON = True
-            else:
-                return
-        if sign == 1 and saw_NON is False:
-            return True
-        if sign < 0:
-            return False
-
-    def _eval_is_negative(self):
-        return (-self).is_positive
-
-    def _eval_is_odd(self):
-        is_integer = self.is_integer
-
-        if is_integer:
-            r, acc = True, 1
-            for t in self.args:
-                if not t.is_integer:
-                    return None
-                elif t.is_even:
-                    r = False
-                elif t.is_integer:
-                    if r is False:
-                        pass
-                    elif acc != 1 and (acc + t).is_odd:
-                        r = False
-                    elif t.is_odd is None:
-                        r = None
-                acc = t
-            return r
-
-        # !integer -> !odd
-        elif is_integer is False:
-            return False
-
-    def _eval_is_even(self):
-        is_integer = self.is_integer
-
-        if is_integer:
-            return fuzzy_not(self._eval_is_odd())
-
-        elif is_integer is False:
-            return False
 
     def _eval_subs(self, old, new):
         from sympy.functions.elementary.complexes import sign

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -594,8 +594,6 @@ class Float(Number):
 
     # A Float represents many real numbers,
     # both rational and irrational.
-    is_rational = None
-    is_irrational = None
     is_number = True
 
     is_real = True
@@ -1044,7 +1042,6 @@ class Rational(Number):
     ========
     sympify, sympy.simplify.simplify.nsimplify
     """
-    is_real = True
     is_integer = False
     is_rational = True
     is_number = True
@@ -2244,15 +2241,8 @@ class Infinity(with_metaclass(Singleton, Number)):
     .. [1] http://en.wikipedia.org/wiki/Infinity
     """
 
-    is_commutative = True
     is_positive = True
-    is_finite = False
-    is_integer = None
-    is_rational = None
-    is_algebraic = None
-    is_transcendental = None
-    is_odd = None
-    is_number = True
+    is_infinite = True
 
     __slots__ = []
 
@@ -2459,15 +2449,8 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     Infinity
     """
 
-    is_commutative = True
-    is_real = True
-    is_positive = False
-    is_finite = False
-    is_integer = None
-    is_rational = None
-    is_number = True
-    is_algebraic = None
-    is_transcendental = None
+    is_negative = True
+    is_infinite = True
 
     __slots__ = []
 
@@ -2712,17 +2695,19 @@ class NaN(with_metaclass(Singleton, Number)):
 
     """
     is_commutative = True
-    is_real = None
-    is_rational = None
-    is_algebraic = None
-    is_transcendental = None
-    is_integer = None
+    is_real = False
+    is_complex = False
+    is_rational = False
+    is_algebraic = False
+    is_transcendental = False
+    is_integer = False
     is_comparable = False
-    is_finite = None
-    is_zero = None
-    is_prime = None
-    is_positive = None
-    is_negative = None
+    is_finite = False
+    is_infinite = False
+    is_zero = False
+    is_prime = False
+    is_positive = False
+    is_negative = False
     is_number = True
 
     __slots__ = []
@@ -2833,8 +2818,7 @@ class ComplexInfinity(with_metaclass(Singleton, AtomicExpr)):
     """
 
     is_commutative = True
-    is_finite = False
-    is_real = None
+    is_infinite = True
     is_number = True
 
     __slots__ = []
@@ -3000,7 +2984,6 @@ class Exp1(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False  # XXX Forces is_negative/is_nonnegative
     is_irrational = True
     is_number = True
     is_algebraic = False
@@ -3079,7 +3062,6 @@ class Pi(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
     is_irrational = True
     is_number = True
     is_algebraic = False
@@ -3140,7 +3122,6 @@ class GoldenRatio(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
     is_irrational = True
     is_number = True
     is_algebraic = True
@@ -3205,8 +3186,6 @@ class EulerGamma(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
-    is_irrational = None
     is_number = True
 
     __slots__ = []
@@ -3261,8 +3240,6 @@ class Catalan(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
-    is_irrational = None
     is_number = True
 
     __slots__ = []

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -508,17 +508,20 @@ def test_Add_is_even_odd():
 
 
 def test_Mul_is_negative_positive():
-    x = Symbol('x', real=True)
-    y = Symbol('y', real=False, complex=True)
-    z = Symbol('z', zero=True)
+    x = Dummy(real=True)
+    y = Dummy(real=False, complex=True)
+    z = Dummy(zero=True)
+    i, j = symbols('i j', cls=Dummy, imaginary=True)
+    nc = Dummy(commutative=False)
 
     e = 2*z
     assert e.is_Mul and e.is_positive is False and e.is_negative is False
+    assert (z*i).is_positive is False
 
-    neg = Symbol('neg', negative=True)
-    pos = Symbol('pos', positive=True)
-    nneg = Symbol('nneg', nonnegative=True)
-    npos = Symbol('npos', nonpositive=True)
+    neg = Dummy(negative=True)
+    pos = Dummy(positive=True)
+    nneg = Dummy(nonnegative=True)
+    npos = Dummy(nonpositive=True)
 
     assert neg.is_negative is True
     assert (-neg).is_negative is False

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, Or, symbols, oo, Integer,
-        sign, im, nan, cbrt, Dummy, subsets
+        sign, im, nan, cbrt, Dummy, subsets, Function
 )
 from sympy.core.evalf import PrecisionExhausted
 from sympy.core.tests.test_evalf import NS
@@ -363,6 +363,20 @@ def test_Add_Mul_is_integer():
 
 
 def test_Add_Mul_is_complex_finite_real_infinite():
+    # test flattening
+    eq = Add(1, I, Add(1, -I, evaluate=False), evaluate=False)
+    for atr in 'hermitian integer rational real positive'.split():
+        assert getattr(eq, '_eval_is_%s' % atr)()
+    for atr in 'imaginary negative'.split():
+        assert getattr(eq, '_eval_is_%s' % atr)() is False
+    eq = Add(1, I, Add(-1, I, evaluate=False), evaluate=False)
+    for atr in 'hermitian integer rational real positive negative'.split():
+        assert getattr(eq, '_eval_is_%s' % atr)() is False
+    for atr in 'imaginary antihermitian'.split():
+        assert getattr(eq, '_eval_is_%s' % atr)()
+    f = Function('f')
+    assert Add(f(0), -f(0), evaluate=False).is_real is None  # could be oo - oo
+
     _r = x = Dummy('r', infinite=True, real=True)
     _p = Dummy('p', infinite=True, positive=True)
     _n = Dummy('n', infinite=True, negative=True)
@@ -998,6 +1012,10 @@ def test_Add_is_negative_positive():
     assert (p + x - n).is_positive is None
 
     assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).is_zero is not False
+
+    f = Function('f')
+    assert (f(0) + 1).is_positive is None
+    assert (f(0) + 1).is_negative is None
 
 
 def test_Add_is_nonpositive_nonnegative():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, Or, symbols, oo, Integer,
-        sign, im, nan, cbrt, Dummy
+        sign, im, nan, cbrt, Dummy, subsets
 )
 from sympy.core.evalf import PrecisionExhausted
 from sympy.core.tests.test_evalf import NS
@@ -293,12 +293,8 @@ def test_ncmul():
 
 
 def test_ncpow():
-    x = Symbol('x', commutative=False)
-    y = Symbol('y', commutative=False)
-    z = Symbol('z', commutative=False)
-    a = Symbol('a')
-    b = Symbol('b')
-    c = Symbol('c')
+    x, y, z = symbols('x:z', commutative=False)
+    a, b, c = symbols('a:c')
 
     assert (x**2)*(y**2) != (y**2)*(x**2)
     assert (x**-2)*y != y*(x**2)
@@ -366,8 +362,14 @@ def test_Add_Mul_is_integer():
     assert (1 + (1 + sqrt(3))*(-sqrt(3) + 1)).is_integer is not False
 
 
-def test_Add_Mul_is_finite():
-    x = Symbol('x', real=True, finite=False)
+def test_Add_Mul_is_complex_finite_real_infinite():
+    _r = x = Dummy('r', infinite=True, real=True)
+    _p = Dummy('p', infinite=True, positive=True)
+    _n = Dummy('n', infinite=True, negative=True)
+    _i = Dummy('i', infinite=True, imaginary=True)
+    _c = Dummy('c', infinite=True)
+    _z = Dummy('z', infinite=True, imaginary=False, real=False, complex=True)
+    all = [_r, _p, _n, _i, _c, _z]
 
     assert sin(x).is_finite is True
     assert (x*sin(x)).is_finite is False
@@ -379,9 +381,164 @@ def test_Add_Mul_is_finite():
     assert (sin(x) - 67).is_finite is True
     assert (sin(x) + exp(x)).is_finite is not True
     assert (1 + x).is_finite is False
-    assert (1 + x**2 + (1 + x)*(1 - x)).is_finite is None
+    assert (1 + x**2 + (1 + x)*(1 - x)).is_finite is False
     assert (sqrt(2)*(1 + x)).is_finite is False
     assert (sqrt(2)*(1 + x)*(1 - x)).is_finite is False
+
+    assert Add(_p, _r, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_r,_p)], evaluate=False).is_complex is None
+    assert Add(_n, _r, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_r,_n)], evaluate=False).is_complex is None
+    assert Add(_i, _r, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_r,_i)], evaluate=False).is_complex
+    assert Add(_c, _r, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_r,_c)], evaluate=False).is_complex is None
+    assert Add(_z, _r, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_r,_z)], evaluate=False).is_complex is None
+    assert Add(_n, _p, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_p,_n)], evaluate=False).is_complex is False
+    assert Add(_i, _p, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_p,_i)], evaluate=False).is_complex
+    assert Add(_c, _p, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_p,_c)], evaluate=False).is_complex is None
+    assert Add(_z, _p, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_p,_z)], evaluate=False).is_complex is None
+    assert Add(_i, _n, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_n,_i)], evaluate=False).is_complex
+    assert Add(_c, _n, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_n,_c)], evaluate=False).is_complex is None
+    assert Add(_z, _n, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_n,_z)], evaluate=False).is_complex is None
+    assert Add(_c, _i, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_i,_c)], evaluate=False).is_complex is None
+    assert Add(_z, _i, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_i,_z)], evaluate=False).is_complex is None
+    assert Add(_z, _c, evaluate=False).is_complex == \
+           Add(*[a.as_dummy() for a in (_c,_z)], evaluate=False).is_complex is None
+
+    assert Add(_p, _r, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_r,_p)], evaluate=False).is_finite is False
+    assert Add(_n, _r, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_r,_n)], evaluate=False).is_finite is False
+    assert Add(_i, _r, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_r,_i)], evaluate=False).is_finite is False
+    assert Add(_c, _r, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_r,_c)], evaluate=False).is_finite is False
+    assert Add(_z, _r, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_r,_z)], evaluate=False).is_finite is False
+    assert Add(_n, _p, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_p,_n)], evaluate=False).is_finite is False
+    assert Add(_i, _p, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_p,_i)], evaluate=False).is_finite is False
+    assert Add(_c, _p, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_p,_c)], evaluate=False).is_finite is False
+    assert Add(_z, _p, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_p,_z)], evaluate=False).is_finite is False
+    assert Add(_i, _n, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_n,_i)], evaluate=False).is_finite is False
+    assert Add(_c, _n, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_n,_c)], evaluate=False).is_finite is False
+    assert Add(_z, _n, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_n,_z)], evaluate=False).is_finite is False
+    assert Add(_c, _i, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_i,_c)], evaluate=False).is_finite is False
+    assert Add(_z, _i, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_i,_z)], evaluate=False).is_finite is False
+    assert Add(_z, _c, evaluate=False).is_finite == \
+           Add(*[a.as_dummy() for a in (_c,_z)], evaluate=False).is_finite is False
+
+    assert Add(_p, _r, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_r,_p)], evaluate=False).is_real is None
+    assert Add(_n, _r, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_r,_n)], evaluate=False).is_real is None
+    assert Add(_i, _r, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_r,_i)], evaluate=False).is_real is False
+    assert Add(_c, _r, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_r,_c)], evaluate=False).is_real is None
+    assert Add(_z, _r, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_r,_z)], evaluate=False).is_real is False
+    assert Add(_n, _p, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_p,_n)], evaluate=False).is_real is False
+    assert Add(_i, _p, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_p,_i)], evaluate=False).is_real is False
+    assert Add(_c, _p, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_p,_c)], evaluate=False).is_real is None
+    assert Add(_z, _p, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_p,_z)], evaluate=False).is_real is False
+    assert Add(_i, _n, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_n,_i)], evaluate=False).is_real is False
+    assert Add(_c, _n, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_n,_c)], evaluate=False).is_real is None
+    assert Add(_z, _n, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_n,_z)], evaluate=False).is_real is False
+    assert Add(_c, _i, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_i,_c)], evaluate=False).is_real is False
+    assert Add(_z, _i, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_i,_z)], evaluate=False).is_real is False
+    assert Add(_z, _c, evaluate=False).is_real == \
+           Add(*[a.as_dummy() for a in (_c,_z)], evaluate=False).is_real is None
+
+    assert Add(_p, _r, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_r,_p)], evaluate=False).is_infinite is None
+    assert Add(_n, _r, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_r,_n)], evaluate=False).is_infinite is None
+    assert Add(_i, _r, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_r,_i)], evaluate=False).is_infinite
+    assert Add(_c, _r, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_r,_c)], evaluate=False).is_infinite is None
+    assert Add(_z, _r, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_r,_z)], evaluate=False).is_infinite is None
+    assert Add(_n, _p, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_p,_n)], evaluate=False).is_infinite is False
+    assert Add(_i, _p, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_p,_i)], evaluate=False).is_infinite
+    assert Add(_c, _p, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_p,_c)], evaluate=False).is_infinite is None
+    assert Add(_z, _p, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_p,_z)], evaluate=False).is_infinite is None
+    assert Add(_i, _n, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_n,_i)], evaluate=False).is_infinite
+    assert Add(_c, _n, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_n,_c)], evaluate=False).is_infinite is None
+    assert Add(_z, _n, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_n,_z)], evaluate=False).is_infinite is None
+    assert Add(_c, _i, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_i,_c)], evaluate=False).is_infinite is None
+    assert Add(_z, _i, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_i,_z)], evaluate=False).is_infinite is None
+    assert Add(_z, _c, evaluate=False).is_infinite == \
+           Add(*[a.as_dummy() for a in (_c,_z)], evaluate=False).is_infinite is None
+
+    assert Add(_p, _r, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_r,_p)], evaluate=False).is_imaginary is False
+    assert Add(_n, _r, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_r,_n)], evaluate=False).is_imaginary is False
+    assert Add(_i, _r, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_r,_i)], evaluate=False).is_imaginary is False
+    assert Add(_c, _r, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_r,_c)], evaluate=False).is_imaginary is False
+    assert Add(_z, _r, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_r,_z)], evaluate=False).is_imaginary is False
+    assert Add(_n, _p, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_p,_n)], evaluate=False).is_imaginary is False
+    assert Add(_i, _p, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_p,_i)], evaluate=False).is_imaginary is False
+    assert Add(_c, _p, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_p,_c)], evaluate=False).is_imaginary is False
+    assert Add(_z, _p, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_p,_z)], evaluate=False).is_imaginary is False
+    assert Add(_i, _n, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_n,_i)], evaluate=False).is_imaginary is False
+    assert Add(_c, _n, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_n,_c)], evaluate=False).is_imaginary is False
+    assert Add(_z, _n, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_n,_z)], evaluate=False).is_imaginary is False
+    assert Add(_c, _i, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_i,_c)], evaluate=False).is_imaginary is None
+    assert Add(_z, _i, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_i,_z)], evaluate=False).is_imaginary is False
+    assert Add(_z, _c, evaluate=False).is_imaginary == \
+           Add(*[a.as_dummy() for a in (_c,_z)], evaluate=False).is_imaginary is None
 
 
 def test_Mul_is_even_odd():
@@ -444,17 +601,27 @@ def test_Mul_is_even_odd():
 
 
 def test_Mul_is_rational():
-    x = Symbol('x')
-    n = Symbol('n', integer=True)
-    m = Symbol('m', integer=True, nonzero=True)
+    x = Dummy()
+    n = Dummy(integer=True)
+    m = Dummy(integer=True)
+    z = Dummy(zero=True)
 
-    assert (n/m).is_rational is True
+    assert (z/pi).is_rational
+
     assert (x/pi).is_rational is None
     assert (x/n).is_rational is None
-    assert (m/pi).is_rational is False
+    assert (n/m).is_rational is None
+    assert (n/pi).is_rational is None
 
-    r = Symbol('r', rational=True)
-    assert (pi*r).is_rational is None
+    n = Dummy(integer=True, nonzero=True)
+    m = Dummy(integer=True, nonzero=True)
+    assert (n/m).is_rational is True
+    assert (n/pi).is_rational is False
+
+    n = Dummy(integer=True, zero=False)
+    m = Dummy(integer=True, zero=False)
+    assert (n/m).is_rational is True
+    assert (n/pi).is_rational is False
 
     # issue 8008
     z = Symbol('z', zero=True)
@@ -612,199 +779,223 @@ def test_Mul_is_negative_positive():
     assert (x*neg).is_positive is None
     assert (nneg*npos*pos*x*neg).is_positive is None
 
+    assert (i*j).is_negative is None  # could be (2*I)*(-3*I)
+    assert (i*j).is_positive is None  # ditto
+    assert (I*sqrt(1 - sqrt(3))).is_negative
+    assert (-nc).is_negative is False
+
+    assert Mul(Mul(0, I, evaluate=False), I, evaluate=False).is_negative \
+        is False
+    assert Mul(I, Mul(I, pos, evaluate=False), evaluate=False).is_negative
+    assert Mul(I, Mul(I, neg, evaluate=False), evaluate=False).is_negative is False
+    assert Mul(I, Mul(I, nneg, evaluate=False), evaluate=False).is_negative is None
+    assert Mul(I, Mul(I, npos, evaluate=False), evaluate=False).is_negative is False
+    assert Mul(I, Mul(I, i, evaluate=False), evaluate=False).is_negative is False
+    assert Mul(2, Mul(I, pos, evaluate=False), evaluate=False).is_negative is False
+    assert Mul(2, Mul(I, neg, evaluate=False), evaluate=False).is_negative is False
+    assert Mul(2, Mul(I, nneg, evaluate=False), evaluate=False).is_negative is False
+    assert Mul(2, Mul(I, npos, evaluate=False), evaluate=False).is_negative is False
+    assert Mul(2, Mul(I, i, evaluate=False), evaluate=False).is_negative is None
+
 
 def test_Mul_is_negative_positive_2():
-    a = Symbol('a', nonnegative=True)
-    b = Symbol('b', nonnegative=True)
-    c = Symbol('c', nonpositive=True)
-    d = Symbol('d', nonpositive=True)
+    nneg = Dummy(nonnegative=True)
+    nneg1 = Dummy(nonnegative=True)
+    npos = Dummy(nonpositive=True)
+    npos1 = Dummy(nonpositive=True)
 
-    assert (a*b).is_nonnegative is True
-    assert (a*b).is_negative is False
-    assert (a*b).is_zero is None
-    assert (a*b).is_positive is None
+    e = nneg*nneg1
+    assert e.is_nonpositive is None
+    assert e.is_nonnegative is None
+    assert e.is_negative is False
+    assert e.is_zero is None
+    assert e.is_positive is None
 
-    assert (c*d).is_nonnegative is True
-    assert (c*d).is_negative is False
-    assert (c*d).is_zero is None
-    assert (c*d).is_positive is None
+    e = npos*npos1
+    assert e.is_nonpositive is None
+    assert e.is_nonnegative is None
+    assert e.is_negative is False
+    assert e.is_zero is None
+    assert e.is_positive is None
 
-    assert (a*c).is_nonpositive is True
-    assert (a*c).is_positive is False
-    assert (a*c).is_zero is None
-    assert (a*c).is_negative is None
+    e = nneg*npos
+    assert e.is_nonnegative is None
+    assert e.is_nonpositive is None
+    assert e.is_positive is False
+    assert e.is_zero is None
+    assert e.is_negative is None
 
 
 def test_Mul_is_nonpositive_nonnegative():
-    x = Symbol('x', real=True)
+    r = Symbol('r', real=True)
 
-    k = Symbol('k', negative=True)
-    n = Symbol('n', positive=True)
-    u = Symbol('u', nonnegative=True)
-    v = Symbol('v', nonpositive=True)
+    n = Symbol('n', negative=True, finite=True)
+    p = Symbol('p', positive=True, finite=True)
+    nn = Symbol('nn', nonnegative=True, finite=True)
+    np = Symbol('np', nonpositive=True, finite=True)
 
-    assert k.is_nonpositive is True
-    assert (-k).is_nonpositive is False
-    assert (2*k).is_nonpositive is True
+    assert n.is_nonpositive is True
+    assert (-n).is_nonpositive is False
+    assert (2*n).is_nonpositive is True
 
-    assert n.is_nonpositive is False
-    assert (-n).is_nonpositive is True
-    assert (2*n).is_nonpositive is False
+    assert p.is_nonpositive is False
+    assert (-p).is_nonpositive is True
+    assert (2*p).is_nonpositive is False
 
-    assert (n*k).is_nonpositive is True
-    assert (2*n*k).is_nonpositive is True
-    assert (-n*k).is_nonpositive is False
+    assert (p*n).is_nonpositive is True
+    assert (2*p*n).is_nonpositive is True
+    assert (-p*n).is_nonpositive is False
 
-    assert u.is_nonpositive is None
-    assert (-u).is_nonpositive is True
-    assert (2*u).is_nonpositive is None
+    assert nn.is_nonpositive is None
+    assert (-nn).is_nonpositive is True
+    assert (2*nn).is_nonpositive is None
 
-    assert v.is_nonpositive is True
-    assert (-v).is_nonpositive is None
-    assert (2*v).is_nonpositive is True
+    assert np.is_nonpositive is True
+    assert (-np).is_nonpositive is None
+    assert (2*np).is_nonpositive is True
 
-    assert (u*v).is_nonpositive is True
+    assert (nn*np).is_nonpositive is True
 
-    assert (k*u).is_nonpositive is True
-    assert (k*v).is_nonpositive is None
+    assert (n*nn).is_nonpositive is True
+    assert (n*np).is_nonpositive is None
 
-    assert (n*u).is_nonpositive is None
-    assert (n*v).is_nonpositive is True
+    assert (p*nn).is_nonpositive is None
+    assert (p*np).is_nonpositive is True
 
-    assert (v*k*u).is_nonpositive is None
-    assert (v*n*u).is_nonpositive is True
+    assert (np*n*nn).is_nonpositive is None
+    assert (np*p*nn).is_nonpositive is True
 
-    assert (-v*k*u).is_nonpositive is True
-    assert (-v*n*u).is_nonpositive is None
+    assert (-np*n*nn).is_nonpositive is True
+    assert (-np*p*nn).is_nonpositive is None
 
-    assert (17*v*k*u).is_nonpositive is None
-    assert (17*v*n*u).is_nonpositive is True
+    assert (17*np*n*nn).is_nonpositive is None
+    assert (17*np*p*nn).is_nonpositive is True
 
-    assert (k*v*n*u).is_nonpositive is None
+    assert (n*np*p*nn).is_nonpositive is None
 
-    assert (x*k).is_nonpositive is None
-    assert (u*v*n*x*k).is_nonpositive is None
+    assert (r*n).is_nonpositive is None
+    assert (nn*np*p*r*n).is_nonpositive is None
 
-    assert k.is_nonnegative is False
-    assert (-k).is_nonnegative is True
-    assert (2*k).is_nonnegative is False
+    assert n.is_nonnegative is False
+    assert (-n).is_nonnegative is True
+    assert (2*n).is_nonnegative is False
 
-    assert n.is_nonnegative is True
-    assert (-n).is_nonnegative is False
-    assert (2*n).is_nonnegative is True
+    assert p.is_nonnegative is True
+    assert (-p).is_nonnegative is False
+    assert (2*p).is_nonnegative is True
 
-    assert (n*k).is_nonnegative is False
-    assert (2*n*k).is_nonnegative is False
-    assert (-n*k).is_nonnegative is True
+    assert (p*n).is_nonnegative is False
+    assert (2*p*n).is_nonnegative is False
+    assert (-p*n).is_nonnegative is True
 
-    assert u.is_nonnegative is True
-    assert (-u).is_nonnegative is None
-    assert (2*u).is_nonnegative is True
+    assert nn.is_nonnegative is True
+    assert (-nn).is_nonnegative is None
+    assert (2*nn).is_nonnegative is True
 
-    assert v.is_nonnegative is None
-    assert (-v).is_nonnegative is True
-    assert (2*v).is_nonnegative is None
+    assert np.is_nonnegative is None
+    assert (-np).is_nonnegative is True
+    assert (2*np).is_nonnegative is None
 
-    assert (u*v).is_nonnegative is None
+    assert (nn*np).is_nonnegative is None
 
-    assert (k*u).is_nonnegative is None
-    assert (k*v).is_nonnegative is True
+    assert (n*nn).is_nonnegative is None
+    assert (n*np).is_nonnegative is True
 
-    assert (n*u).is_nonnegative is True
-    assert (n*v).is_nonnegative is None
+    assert (p*nn).is_nonnegative is True
+    assert (p*np).is_nonnegative is None
 
-    assert (v*k*u).is_nonnegative is True
-    assert (v*n*u).is_nonnegative is None
+    assert (np*n*nn).is_nonnegative is True
+    assert (np*p*nn).is_nonnegative is None
 
-    assert (-v*k*u).is_nonnegative is None
-    assert (-v*n*u).is_nonnegative is True
+    assert (-np*n*nn).is_nonnegative is None
+    assert (-np*p*nn).is_nonnegative is True
 
-    assert (17*v*k*u).is_nonnegative is True
-    assert (17*v*n*u).is_nonnegative is None
+    assert (17*np*n*nn).is_nonnegative is True
+    assert (17*np*p*nn).is_nonnegative is None
 
-    assert (k*v*n*u).is_nonnegative is True
+    assert (n*np*p*nn).is_nonnegative is True
 
-    assert (x*k).is_nonnegative is None
-    assert (u*v*n*x*k).is_nonnegative is None
+    assert (r*n).is_nonnegative is None
+    assert (nn*np*p*r*n).is_nonnegative is None
 
 
 def test_Add_is_negative_positive():
     x = Symbol('x', real=True)
 
-    k = Symbol('k', negative=True)
-    n = Symbol('n', positive=True)
-    u = Symbol('u', nonnegative=True)
-    v = Symbol('v', nonpositive=True)
+    n = Symbol('n', negative=True)
+    p = Symbol('p', positive=True)
+    nn = Symbol('nn', nonnegative=True)
+    np = Symbol('np', nonpositive=True)
 
-    assert (k - 2).is_negative is True
-    assert (k + 17).is_negative is None
-    assert (-k - 5).is_negative is None
-    assert (-k + 123).is_negative is False
+    assert (n - 2).is_negative is True
+    assert (n + 17).is_negative is None
+    assert (-n - 5).is_negative is None
+    assert (-n + 123).is_negative is False
 
-    assert (k - n).is_negative is True
-    assert (k + n).is_negative is None
-    assert (-k - n).is_negative is None
-    assert (-k + n).is_negative is False
+    assert (n - p).is_negative is True
+    assert (n + p).is_negative is None
+    assert (-n - p).is_negative is None
+    assert (-n + p).is_negative is False
 
-    assert (k - n - 2).is_negative is True
-    assert (k + n + 17).is_negative is None
-    assert (-k - n - 5).is_negative is None
-    assert (-k + n + 123).is_negative is False
+    assert (n - p - 2).is_negative is True
+    assert (n + p + 17).is_negative is None
+    assert (-n - p - 5).is_negative is None
+    assert (-n + p + 123).is_negative is False
 
-    assert (-2*k + 123*n + 17).is_negative is False
+    assert (-2*n + 123*p + 17).is_negative is False
 
-    assert (k + u).is_negative is None
-    assert (k + v).is_negative is True
-    assert (n + u).is_negative is False
-    assert (n + v).is_negative is None
+    assert (n + nn).is_negative is None
+    assert (n + np).is_negative is True
+    assert (p + nn).is_negative is False
+    assert (p + np).is_negative is None
 
-    assert (u - v).is_negative is False
-    assert (u + v).is_negative is None
-    assert (-u - v).is_negative is None
-    assert (-u + v).is_negative is None
+    assert (nn - np).is_negative is False
+    assert (nn + np).is_negative is None
+    assert (-nn - np).is_negative is None
+    assert (-nn + np).is_negative is None
 
-    assert (u - v + n + 2).is_negative is False
-    assert (u + v + n + 2).is_negative is None
-    assert (-u - v + n + 2).is_negative is None
-    assert (-u + v + n + 2).is_negative is None
+    assert (nn - np + p + 2).is_negative is False
+    assert (nn + np + p + 2).is_negative is None
+    assert (-nn - np + p + 2).is_negative is None
+    assert (-nn + np + p + 2).is_negative is None
 
-    assert (k + x).is_negative is None
-    assert (k + x - n).is_negative is None
+    assert (n + x).is_negative is None
+    assert (n + x - p).is_negative is None
 
-    assert (k - 2).is_positive is False
-    assert (k + 17).is_positive is None
-    assert (-k - 5).is_positive is None
-    assert (-k + 123).is_positive is True
+    assert (n - 2).is_positive is False
+    assert (n + 17).is_positive is None
+    assert (-n - 5).is_positive is None
+    assert (-n + 123).is_positive is True
 
-    assert (k - n).is_positive is False
-    assert (k + n).is_positive is None
-    assert (-k - n).is_positive is None
-    assert (-k + n).is_positive is True
+    assert (n - p).is_positive is False
+    assert (n + p).is_positive is None
+    assert (-n - p).is_positive is None
+    assert (-n + p).is_positive is True
 
-    assert (k - n - 2).is_positive is False
-    assert (k + n + 17).is_positive is None
-    assert (-k - n - 5).is_positive is None
-    assert (-k + n + 123).is_positive is True
+    assert (n - p - 2).is_positive is False
+    assert (n + p + 17).is_positive is None
+    assert (-n - p - 5).is_positive is None
+    assert (-n + p + 123).is_positive is True
 
-    assert (-2*k + 123*n + 17).is_positive is True
+    assert (-2*n + 123*p + 17).is_positive is True
 
-    assert (k + u).is_positive is None
-    assert (k + v).is_positive is False
-    assert (n + u).is_positive is True
-    assert (n + v).is_positive is None
+    assert (n + nn).is_positive is None
+    assert (n + np).is_positive is False
+    assert (p + nn).is_positive is True
+    assert (p + np).is_positive is None
 
-    assert (u - v).is_positive is None
-    assert (u + v).is_positive is None
-    assert (-u - v).is_positive is None
-    assert (-u + v).is_positive is False
+    assert (nn - np).is_positive is None
+    assert (nn + np).is_positive is None
+    assert (-nn - np).is_positive is None
+    assert (-nn + np).is_positive is False
 
-    assert (u - v - n - 2).is_positive is None
-    assert (u + v - n - 2).is_positive is None
-    assert (-u - v - n - 2).is_positive is None
-    assert (-u + v - n - 2).is_positive is False
+    assert (nn - np - p - 2).is_positive is None
+    assert (nn + np - p - 2).is_positive is None
+    assert (-nn - np - p - 2).is_positive is None
+    assert (-nn + np - p - 2).is_positive is False
 
-    assert (n + x).is_positive is None
-    assert (n + x - k).is_positive is None
+    assert (p + x).is_positive is None
+    assert (p + x - n).is_positive is None
 
     assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).is_zero is not False
 
@@ -812,80 +1003,80 @@ def test_Add_is_negative_positive():
 def test_Add_is_nonpositive_nonnegative():
     x = Symbol('x', real=True)
 
-    k = Symbol('k', negative=True)
-    n = Symbol('n', positive=True)
-    u = Symbol('u', nonnegative=True)
-    v = Symbol('v', nonpositive=True)
+    n = Symbol('n', negative=True)
+    p = Symbol('p', positive=True)
+    nn = Symbol('nn', nonnegative=True)
+    np = Symbol('np', nonpositive=True)
 
-    assert (u - 2).is_nonpositive is None
-    assert (u + 17).is_nonpositive is False
-    assert (-u - 5).is_nonpositive is True
-    assert (-u + 123).is_nonpositive is None
+    assert (nn - 2).is_nonpositive is None
+    assert (nn + 17).is_nonpositive is False
+    assert (-nn - 5).is_nonpositive is True
+    assert (-nn + 123).is_nonpositive is None
 
-    assert (u - v).is_nonpositive is None
-    assert (u + v).is_nonpositive is None
-    assert (-u - v).is_nonpositive is None
-    assert (-u + v).is_nonpositive is True
+    assert (nn - np).is_nonpositive is None
+    assert (nn + np).is_nonpositive is None
+    assert (-nn - np).is_nonpositive is None
+    assert (-nn + np).is_nonpositive is True
 
-    assert (u - v - 2).is_nonpositive is None
-    assert (u + v + 17).is_nonpositive is None
-    assert (-u - v - 5).is_nonpositive is None
-    assert (-u + v - 123).is_nonpositive is True
+    assert (nn - np - 2).is_nonpositive is None
+    assert (nn + np + 17).is_nonpositive is None
+    assert (-nn - np - 5).is_nonpositive is None
+    assert (-nn + np - 123).is_nonpositive is True
 
-    assert (-2*u + 123*v - 17).is_nonpositive is True
+    assert (-2*nn + 123*np - 17).is_nonpositive is True
 
-    assert (k + u).is_nonpositive is None
-    assert (k + v).is_nonpositive is True
-    assert (n + u).is_nonpositive is False
-    assert (n + v).is_nonpositive is None
+    assert (n + nn).is_nonpositive is None
+    assert (n + np).is_nonpositive is True
+    assert (p + nn).is_nonpositive is False
+    assert (p + np).is_nonpositive is None
 
-    assert (k - n).is_nonpositive is True
-    assert (k + n).is_nonpositive is None
-    assert (-k - n).is_nonpositive is None
-    assert (-k + n).is_nonpositive is False
+    assert (n - p).is_nonpositive is True
+    assert (n + p).is_nonpositive is None
+    assert (-n - p).is_nonpositive is None
+    assert (-n + p).is_nonpositive is False
 
-    assert (k - n + u + 2).is_nonpositive is None
-    assert (k + n + u + 2).is_nonpositive is None
-    assert (-k - n + u + 2).is_nonpositive is None
-    assert (-k + n + u + 2).is_nonpositive is False
+    assert (n - p + nn + 2).is_nonpositive is None
+    assert (n + p + nn + 2).is_nonpositive is None
+    assert (-n - p + nn + 2).is_nonpositive is None
+    assert (-n + p + nn + 2).is_nonpositive is False
 
-    assert (u + x).is_nonpositive is None
-    assert (v - x - n).is_nonpositive is None
+    assert (nn + x).is_nonpositive is None
+    assert (np - x - p).is_nonpositive is None
 
-    assert (u - 2).is_nonnegative is None
-    assert (u + 17).is_nonnegative is True
-    assert (-u - 5).is_nonnegative is False
-    assert (-u + 123).is_nonnegative is None
+    assert (nn - 2).is_nonnegative is None
+    assert (nn + 17).is_nonnegative is True
+    assert (-nn - 5).is_nonnegative is False
+    assert (-nn + 123).is_nonnegative is None
 
-    assert (u - v).is_nonnegative is True
-    assert (u + v).is_nonnegative is None
-    assert (-u - v).is_nonnegative is None
-    assert (-u + v).is_nonnegative is None
+    assert (nn - np).is_nonnegative is True
+    assert (nn + np).is_nonnegative is None
+    assert (-nn - np).is_nonnegative is None
+    assert (-nn + np).is_nonnegative is None
 
-    assert (u - v + 2).is_nonnegative is True
-    assert (u + v + 17).is_nonnegative is None
-    assert (-u - v - 5).is_nonnegative is None
-    assert (-u + v - 123).is_nonnegative is False
+    assert (nn - np + 2).is_nonnegative is True
+    assert (nn + np + 17).is_nonnegative is None
+    assert (-nn - np - 5).is_nonnegative is None
+    assert (-nn + np - 123).is_nonnegative is False
 
-    assert (2*u - 123*v + 17).is_nonnegative is True
+    assert (2*nn - 123*np + 17).is_nonnegative is True
 
-    assert (k + u).is_nonnegative is None
-    assert (k + v).is_nonnegative is False
-    assert (n + u).is_nonnegative is True
-    assert (n + v).is_nonnegative is None
+    assert (n + nn).is_nonnegative is None
+    assert (n + np).is_nonnegative is False
+    assert (p + nn).is_nonnegative is True
+    assert (p + np).is_nonnegative is None
 
-    assert (k - n).is_nonnegative is False
-    assert (k + n).is_nonnegative is None
-    assert (-k - n).is_nonnegative is None
-    assert (-k + n).is_nonnegative is True
+    assert (n - p).is_nonnegative is False
+    assert (n + p).is_nonnegative is None
+    assert (-n - p).is_nonnegative is None
+    assert (-n + p).is_nonnegative is True
 
-    assert (k - n - u - 2).is_nonnegative is False
-    assert (k + n - u - 2).is_nonnegative is None
-    assert (-k - n - u - 2).is_nonnegative is None
-    assert (-k + n - u - 2).is_nonnegative is None
+    assert (n - p - nn - 2).is_nonnegative is False
+    assert (n + p - nn - 2).is_nonnegative is None
+    assert (-n - p - nn - 2).is_nonnegative is None
+    assert (-n + p - nn - 2).is_nonnegative is None
 
-    assert (u - x).is_nonnegative is None
-    assert (v + x + n).is_nonnegative is None
+    assert (nn - x).is_nonnegative is None
+    assert (np + x + p).is_nonnegative is None
 
 
 def test_Pow_is_integer():
@@ -1106,6 +1297,11 @@ def test_Pow_is_zero():
     assert e.is_negative is False
 
 
+@XFAIL
+def test_Pow_rational():
+    assert (1/Dummy(integer=1)).is_rational is None
+
+
 def test_Pow_is_nonpositive_nonnegative():
     x = Symbol('x', real=True)
 
@@ -1123,7 +1319,7 @@ def test_Pow_is_nonpositive_nonnegative():
     assert (k**2).is_nonnegative is True
     assert (k**(-2)).is_nonnegative is True
 
-    assert (k**x).is_nonnegative is None    # NOTE (0**x).is_real = U
+    assert (k**x).is_nonnegative is None  # NOTE (0**x).is_real = U
     assert (l**x).is_nonnegative is True
     assert (l**x).is_positive is True
     assert ((-k)**x).is_nonnegative is None
@@ -1157,6 +1353,7 @@ def test_Mul_is_imaginary_real():
     p = Symbol('p', positive=True)
     i = Symbol('i', imaginary=True)
     ii = Symbol('ii', imaginary=True)
+    c = Symbol('c', complex=True, real=False, imaginary=False)
     x = Symbol('x')
 
     assert I.is_imaginary is True
@@ -1167,6 +1364,8 @@ def test_Mul_is_imaginary_real():
     assert (3*I).is_real is False
     assert (I*I).is_imaginary is False
     assert (I*I).is_real is True
+    assert (I*c).is_real is False
+    assert (r*I*c).is_real is None
 
     e = (p + p*I)
     j = Symbol('j', integer=True, zero=False)
@@ -1196,8 +1395,8 @@ def test_Mul_is_imaginary_real():
     assert (i*ii).is_imaginary is False
     assert (i*ii).is_real is True
 
-    assert (r*i*ii).is_imaginary is False
-    assert (r*i*ii).is_real is True
+    assert (r*i*ii).is_imaginary is None
+    assert (r*i*ii).is_real is None
 
     # Github's issue 5874:
     nr = Symbol('nr', real=False, complex=True)
@@ -1233,6 +1432,7 @@ def test_Add_is_comparable():
     assert (x + y).is_comparable is False
     assert (x + 1).is_comparable is False
     assert (Rational(1, 3) - sqrt(8)).is_comparable is True
+    assert (1 + Symbol('x', imaginary=True)).is_comparable is False
 
 
 def test_Mul_is_comparable():
@@ -1718,36 +1918,60 @@ def test_mul_zero_detection():
     # zero value so args should be tested in both directions and
     # TO AVOID GETTING THE CACHED RESULT, Dummy MUST BE USED
 
-    # real is unknonwn
-    def test(z, b, e):
-        if z.is_zero and b.is_finite:
-            assert e.is_real and e.is_zero
-        else:
-            assert e.is_real == e.is_zero == None
+    from sympy.core.facts import InconsistentAssumptions
+    def test(e):
+        from sympy.core.function import expand_mul
+        # get the assumptions for each arg
+        args = e.args
+        d = [a.assumptions0 for a in args]
 
-    for iz, ib in cartes(*[[True, False, None]]*2):
-        z = Dummy(nonzero=iz)
-        b = Dummy(finite=ib)
-        e = Mul(z, b, evaluate=False)
-        test(z, b, e)
-        z = Dummy(nonzero=iz)
-        b = Dummy(finite=ib)
-        e = Mul(b, z, evaluate=False)
-        test(z, b, e)
+        # select from these numbers
+        n = [S.Zero, S.One, S.NegativeOne, I, 1 + I, oo, I*oo]
+        ni = [[i for i in n if all(getattr(i, 'is_' + k) == di[k] for k in di)] for di in d]
 
-    # real is True
-    def test(z, b, e):
-        if z.is_zero and not b.is_finite:
-            assert e.is_real is None
-        else:
-            assert e.is_real
+        # check that we got numbers for each symbol
+        for j, _n in enumerate(ni):
+            if not _n:
+                print('No numbers matched these attributes: %s' % (
+                    key[symbols.index(args[j])],))
+                assert None
 
-    for iz, ib in cartes(*[[True, False, None]]*2):
-        z = Dummy('z', nonzero=iz, real=True)
-        b = Dummy('b', finite=ib, real=True)
-        e = Mul(z, b, evaluate=False)
-        test(z, b, e)
-        z = Dummy('z', nonzero=iz, real=True)
-        b = Dummy('b', finite=ib, real=True)
-        e = Mul(b, z, evaluate=False)
-        test(z, b, e)
+        def check(attr):
+            # perform the check of the is_* method's result
+            v = getattr(e, attr)  # this is what we get
+            # here are possible expressions that match the assumptions
+            possible = set([getattr(expand_mul(Mul(*m)), attr) for m in cartes(*ni)])
+            if len(possible) == 1:
+                assert v == possible.pop()
+            else:
+                if (len(possible) == 2 and None in possible and v in possible):
+                    # we don't fault a routine if it gives None as long
+                    # as the desired value is present
+                    pass
+                else:
+                    assert v is None
+
+        check('is_zero')
+        check('is_nonzero')
+        check('is_complex')
+        check('is_finite')
+        check('is_infinite')
+
+    # build a list of symbols to choose from
+    symbols = []
+    key = []
+    for iz, ib, ir in cartes(*[[True, False]]*3):
+        i += 1
+        if iz is ib is ir is False:
+            continue
+        try:
+            d = dict(zero=iz, finite=ib, real=ir)
+            symbols.append(Dummy(**d))
+            key.append(d)
+        except InconsistentAssumptions:
+            continue
+    for s in subsets(symbols, 3):
+        # generate a fresh symbol with the same assumptions
+        # to avoid cached results by using as_dummy()
+        test(Mul(*[i.as_dummy() for i in s], evaluate=False))
+        test(Mul(*[i.as_dummy() for i in reversed(s)], evaluate=False))

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -362,6 +362,23 @@ def test_Add_Mul_is_integer():
     assert (1 + (1 + sqrt(3))*(-sqrt(3) + 1)).is_integer is not False
 
 
+@XFAIL
+def test_Add_is_imaginary_fail():
+    nn = Dummy(nonnegative=True)
+    assert (3*I + nn*I).is_imaginary is True
+
+
+def test_Add_is_imaginary():
+    i = Dummy(imaginary=True)
+    nn = Dummy(nonnegative=True)
+    z = Dummy(zero=True)
+    assert (3*I + i).is_imaginary is None
+    assert (3*I - nn*I).is_imaginary is None
+    # this tests the Add and Mul routine
+    assert (z*I - sqrt(2)*z*I).is_imaginary is False
+    assert (z*I - sqrt(2)*z*I).is_antihermitian is S.Zero.is_antihermitian
+
+
 def test_Add_Mul_is_complex_finite_real_infinite():
     # test flattening
     eq = Add(1, I, Add(1, -I, evaluate=False), evaluate=False)
@@ -374,9 +391,12 @@ def test_Add_Mul_is_complex_finite_real_infinite():
         assert getattr(eq, '_eval_is_%s' % atr)() is False
     for atr in 'imaginary antihermitian'.split():
         assert getattr(eq, '_eval_is_%s' % atr)()
+    # coverage: case when eq collapses to non-Add
+    eq = Add(1, sqrt(2), Add(-1, -sqrt(2), evaluate=False), evaluate=False)
+    assert eq.is_zero
+
     f = Function('f')
     assert Add(f(0), -f(0), evaluate=False).is_real is None  # could be oo - oo
-
     _r = x = Dummy('r', infinite=True, real=True)
     _p = Dummy('p', infinite=True, positive=True)
     _n = Dummy('n', infinite=True, negative=True)
@@ -1444,6 +1464,10 @@ def test_Mul_hermitian_antihermitian():
     assert e4.is_antihermitian is None
     assert e5.is_antihermitian is None
     assert e6.is_antihermitian is None
+
+    nc1 = Dummy(commutative=False)
+    nc2 = Dummy(commutative=False)
+    assert (nc1*nc2).is_hermitian is None
 
 
 def test_Add_is_comparable():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -842,3 +842,16 @@ def test_finite_infinite_bounded():
     # finite=False --x--> infinite=True, etc...
     assert d(infinite=False).is_finite is None
     assert d(finite=False).is_complex is None
+
+
+def test_finite_reals():
+    assert Dummy(algebraic=True).is_complex
+
+    assert Dummy(rational=True).is_real
+    assert Dummy(irrational=True).is_real
+    assert Dummy(transcendental=True).is_real # None in master
+
+    assert Dummy(real=True).is_finite is None  # real includes oo
+    assert Dummy(algebraic=True).is_finite  # None in master
+    assert Dummy(irrational=True).is_finite  # None in master
+    assert Dummy(transcendental=True).is_finite  # None in master

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -63,12 +63,14 @@ def test_one():
     assert z.is_infinite is False
     assert z.is_comparable is True
     assert z.is_prime is False
+    #assert z.is_composite is False
     assert z.is_number is True
 
 
 @XFAIL
 def test_one_is_composite():
-    assert S(1).is_composite is False
+    assert S(1).is_composite is False  # uncomment above if passing
+    assert S(-1).is_composite is False  # uncomment below if passing
 
 
 def test_negativeone():
@@ -93,7 +95,7 @@ def test_negativeone():
     assert z.is_infinite is False
     assert z.is_comparable is True
     assert z.is_prime is False
-    assert z.is_composite is False
+    #assert z.is_composite is True
     assert z.is_number is True
 
 
@@ -472,20 +474,17 @@ def test_neg_symbol_falsenonnegative_real():
 
 
 def test_prime():
-    assert S(-1).is_prime is False
     assert S(-2).is_prime is False
     assert S(-4).is_prime is False
     assert S(0).is_prime is False
-    assert S(1).is_prime is False
     assert S(2).is_prime is True
     assert S(17).is_prime is True
     assert S(4).is_prime is False
 
 
 def test_composite():
-    assert S(-1).is_composite is False
-    assert S(-2).is_composite is False
-    assert S(-4).is_composite is False
+    assert S(-2).is_composite is True
+    assert S(-4).is_composite is True
     assert S(0).is_composite is False
     assert S(2).is_composite is False
     assert S(17).is_composite is False

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -101,26 +101,26 @@ def test_infinity():
     oo = S.Infinity
 
     assert oo.is_commutative is True
-    assert oo.is_integer is None
-    assert oo.is_rational is None
-    assert oo.is_algebraic is None
-    assert oo.is_transcendental is None
+    assert oo.is_integer is False
+    assert oo.is_rational is False
+    assert oo.is_algebraic is False
+    assert oo.is_transcendental is False
     assert oo.is_real is True
     assert oo.is_complex is True
-    assert oo.is_noninteger is None
-    assert oo.is_irrational is None
+    assert oo.is_noninteger is True
+    assert oo.is_irrational is False
     assert oo.is_imaginary is False
     assert oo.is_positive is True
     assert oo.is_negative is False
     assert oo.is_nonpositive is False
     assert oo.is_nonnegative is True
-    assert oo.is_even is None
-    assert oo.is_odd is None
+    assert oo.is_even is False
+    assert oo.is_odd is False
     assert oo.is_finite is False
     assert oo.is_infinite is True
     assert oo.is_comparable is True
-    assert oo.is_prime is None
-    assert oo.is_composite is None
+    assert oo.is_prime is False
+    assert oo.is_composite is False
     assert oo.is_number is True
 
 
@@ -128,21 +128,21 @@ def test_neg_infinity():
     mm = S.NegativeInfinity
 
     assert mm.is_commutative is True
-    assert mm.is_integer is None
-    assert mm.is_rational is None
-    assert mm.is_algebraic is None
-    assert mm.is_transcendental is None
+    assert mm.is_integer is False
+    assert mm.is_rational is False
+    assert mm.is_algebraic is False
+    assert mm.is_transcendental is False
     assert mm.is_real is True
     assert mm.is_complex is True
-    assert mm.is_noninteger is None
-    assert mm.is_irrational is None
+    assert mm.is_noninteger is True
+    assert mm.is_irrational is False
     assert mm.is_imaginary is False
     assert mm.is_positive is False
     assert mm.is_negative is True
     assert mm.is_nonpositive is True
     assert mm.is_nonnegative is False
-    assert mm.is_even is None
-    assert mm.is_odd is None
+    assert mm.is_even is False
+    assert mm.is_odd is False
     assert mm.is_finite is False
     assert mm.is_infinite is True
     assert mm.is_comparable is True
@@ -155,26 +155,26 @@ def test_nan():
     nan = S.NaN
 
     assert nan.is_commutative is True
-    assert nan.is_integer is None
-    assert nan.is_rational is None
-    assert nan.is_algebraic is None
-    assert nan.is_transcendental is None
-    assert nan.is_real is None
-    assert nan.is_complex is None
-    assert nan.is_noninteger is None
-    assert nan.is_irrational is None
-    assert nan.is_imaginary is None
-    assert nan.is_positive is None
-    assert nan.is_negative is None
-    assert nan.is_nonpositive is None
-    assert nan.is_nonnegative is None
-    assert nan.is_even is None
-    assert nan.is_odd is None
-    assert nan.is_finite is None
-    assert nan.is_infinite is None
+    assert nan.is_integer is False
+    assert nan.is_rational is False
+    assert nan.is_algebraic is False
+    assert nan.is_transcendental is False
+    assert nan.is_real is False
+    assert nan.is_complex is False
+    assert nan.is_noninteger is False
+    assert nan.is_irrational is False
+    assert nan.is_imaginary is False
+    assert nan.is_positive is False
+    assert nan.is_negative is False
+    assert nan.is_nonpositive is False
+    assert nan.is_nonnegative is False
+    assert nan.is_even is False
+    assert nan.is_odd is False
+    assert nan.is_finite is False
+    assert nan.is_infinite is False
     assert nan.is_comparable is False
-    assert nan.is_prime is None
-    assert nan.is_composite is None
+    assert nan.is_prime is False
+    assert nan.is_composite is False
     assert nan.is_number is True
 
 
@@ -328,6 +328,17 @@ def test_symbol_real():
     assert a.is_nonnegative is False
     assert a.is_nonpositive is False
     assert a.is_zero is False
+
+
+def test_symbol_nonzero():
+    x = Symbol('x', nonzero=True)
+    assert x.is_positive is None
+    assert x.is_nonpositive is None
+    assert x.is_negative is None
+    assert x.is_nonnegative is None
+    assert x.is_zero is False
+    assert x.is_nonzero is True
+    assert x.is_complex
 
 
 def test_symbol_zero():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -39,6 +39,7 @@ def test_zero():
     assert z.is_prime is False
     assert z.is_composite is False
     assert z.is_number is True
+    assert z.is_finite_real
 
 
 def test_one():
@@ -65,6 +66,7 @@ def test_one():
     assert z.is_prime is False
     #assert z.is_composite is False
     assert z.is_number is True
+    assert z.is_finite_real
 
 
 @XFAIL
@@ -97,6 +99,7 @@ def test_negativeone():
     assert z.is_prime is False
     #assert z.is_composite is True
     assert z.is_number is True
+    assert z.is_finite_real
 
 
 def test_infinity():
@@ -124,6 +127,7 @@ def test_infinity():
     assert oo.is_prime is False
     assert oo.is_composite is False
     assert oo.is_number is True
+    assert oo.is_finite_real is False
 
 
 def test_neg_infinity():
@@ -151,6 +155,7 @@ def test_neg_infinity():
     assert mm.is_prime is False
     assert mm.is_composite is False
     assert mm.is_number is True
+    assert mm.is_finite_real is False
 
 
 def test_nan():
@@ -178,6 +183,7 @@ def test_nan():
     assert nan.is_prime is False
     assert nan.is_composite is False
     assert nan.is_number is True
+    assert nan.is_finite_real is False
 
 
 def test_pos_rational():
@@ -203,6 +209,7 @@ def test_pos_rational():
     assert r.is_comparable is True
     assert r.is_prime is False
     assert r.is_composite is False
+    assert r.is_finite_real
 
     r = Rational(1, 4)
     assert r.is_nonpositive is False
@@ -267,6 +274,7 @@ def test_pi():
     assert z.is_comparable is True
     assert z.is_prime is False
     assert z.is_composite is False
+    assert z.is_finite_real
 
 
 def test_E():
@@ -292,6 +300,7 @@ def test_E():
     assert z.is_comparable is True
     assert z.is_prime is False
     assert z.is_composite is False
+    assert z.is_finite_real
 
 
 def test_I():
@@ -317,6 +326,7 @@ def test_I():
     assert z.is_comparable is False
     assert z.is_prime is False
     assert z.is_composite is False
+    assert z.is_finite_real is False
 
 
 def test_symbol_real():
@@ -341,6 +351,7 @@ def test_symbol_nonzero():
     assert x.is_zero is False
     assert x.is_nonzero is True
     assert x.is_complex
+    assert x.is_finite_real is None
 
 
 def test_symbol_zero():
@@ -351,6 +362,7 @@ def test_symbol_zero():
     assert x.is_nonnegative is True
     assert x.is_zero is True
     assert x.is_nonzero is False
+    assert x.is_finite_real
 
 
 def test_symbol_positive():
@@ -361,6 +373,7 @@ def test_symbol_positive():
     assert x.is_nonnegative is True
     assert x.is_zero is False
     assert x.is_nonzero is True
+    assert x.is_finite_real is None
 
 
 def test_neg_symbol_positive():
@@ -491,7 +504,7 @@ def test_composite():
     assert S(4).is_composite is True
 
 
-def test_prime_symbol():
+def test_prime_composite_symbol():
     x = Symbol('x', prime=True)
     assert x.is_prime is True
     assert x.is_integer is True
@@ -499,6 +512,7 @@ def test_prime_symbol():
     assert x.is_negative is False
     assert x.is_nonpositive is False
     assert x.is_nonnegative is True
+    assert x.is_finite_real
 
     x = Symbol('x', prime=False)
     assert x.is_prime is False
@@ -507,6 +521,15 @@ def test_prime_symbol():
     assert x.is_negative is None
     assert x.is_nonpositive is None
     assert x.is_nonnegative is None
+
+    x = Symbol('x', composite=True)
+    assert x.is_prime is False
+    assert x.is_integer
+    assert x.is_positive is None
+    assert x.is_negative is None
+    assert x.is_nonpositive is None
+    assert x.is_nonnegative is None
+    assert x.is_finite_real
 
 
 def test_symbol_noncommutative():
@@ -855,3 +878,8 @@ def test_finite_reals():
     assert Dummy(algebraic=True).is_finite  # None in master
     assert Dummy(irrational=True).is_finite  # None in master
     assert Dummy(transcendental=True).is_finite  # None in master
+
+    assert Dummy(algebraic=True).is_finite_real is None
+    assert Dummy(rational=True).is_finite_real
+    assert Dummy(irrational=True).is_finite_real
+    assert Dummy(transcendental=True).is_finite_real

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -438,18 +438,17 @@ def test_symbol_falsenonnegative():
     assert x.is_negative is None
     assert x.is_nonnegative is False
     assert x.is_zero is False
-    assert x.is_nonzero is True
+    assert x.is_nonzero is None
 
 
-@XFAIL
 def test_neg_symbol_falsenonnegative():
     x = -Symbol('x', nonnegative=False)
     assert x.is_positive is None
-    assert x.is_nonpositive is False  # this currently returns None
-    assert x.is_negative is False  # this currently returns None
+    assert x.is_nonpositive is None
+    assert x.is_negative is False
     assert x.is_nonnegative is None
-    assert x.is_zero is False  # this currently returns None
-    assert x.is_nonzero is True  # this currently returns None
+    assert x.is_zero is False
+    assert x.is_nonzero is None
 
 
 def test_symbol_falsenonnegative_real():
@@ -644,10 +643,10 @@ def test_Add_is_pos_neg():
     p = Symbol('p', positive=True, finite=False)
     x = Symbol('x')
     xb = Symbol('xb', finite=True)
-    assert (n + p).is_positive is None
+    assert (n + p).is_positive is False
     assert (n + x).is_positive is None
     assert (p + x).is_positive is None
-    assert (n + p).is_negative is None
+    assert (n + p).is_negative is False
     assert (n + x).is_negative is None
     assert (p + x).is_negative is None
 
@@ -799,7 +798,7 @@ def test_issue_4149():
     assert (3*I + S.Pi*I).is_imaginary
     # as Zero.is_imaginary is False, see issue 7649
     y = Symbol('y', real=True)
-    assert (3*I + S.Pi*I + y*I).is_imaginary is None
+    assert (3*I + S.Pi*I + y*I).is_imaginary is None # 0 if y = -3 - pi
     p = Symbol('p', positive=True)
     assert (3*I + S.Pi*I + p*I).is_imaginary
     n = Symbol('n', negative=True)
@@ -825,3 +824,22 @@ def test_issue_7899():
     assert (I*x).is_real is None
     assert ((x - I)*(x - 1)).is_zero is None
     assert ((x - I)*(x - 1)).is_real is None
+
+
+def test_finite_infinite_bounded():
+    d = lambda **x: Symbol('x', **x)
+    assert d(zero=True).is_finite
+    assert d(infinite=True).is_finite is False
+
+    assert d(zero=True).is_infinite is False
+    assert d(finite=True).is_infinite is False
+
+    assert d(infinite=True).is_zero is False
+    assert d(finite=True).is_zero is None
+
+    assert d(infinite=True).is_complex
+    assert d(finite=True).is_complex
+
+    # finite=False --x--> infinite=True, etc...
+    assert d(infinite=False).is_finite is None
+    assert d(finite=False).is_complex is None

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -966,7 +966,8 @@ def test_M23():
 
 
 def test_M24():
-    solution = solve(1 - binomial(m, 2)*2**k, k)
+    # XXX why does check fail to validate solution?
+    solution = solve(1 - binomial(m, 2)*2**k, k, check=False)
     answer = log(2/(m*(m - 1)), 2)
     assert solution[0].expand() == answer.expand()
 

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -1350,7 +1350,7 @@ def test_P8():
 
 
 def test_P9():
-    a, b, c = symbols('a b c', real=True)
+    a, b, c = symbols('a b c', real=True, finite=True, zero=False)
     M = Matrix([[a/(b*c), 1/c, 1/b],
                 [1/c, b/(a*c), 1/a],
                 [1/b, 1/a, c/(a*b)]])

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -223,9 +223,12 @@ class elliptic_e(Function):
         raise ArgumentIndexError(self, argindex)
 
     def _eval_conjugate(self):
-        z, m = self.args
-        if (m.is_real and (m - 1).is_positive) is False:
-            return self.func(z.conjugate(), m.conjugate())
+        if len(self.args) == 2:
+            z, m = self.args
+            if (m.is_real and (m - 1).is_positive) is False:
+                return self.func(z.conjugate(), m.conjugate())
+        #else:
+        #    return self.func(self.args[0].conjugate())
 
     def _eval_nseries(self, x, n, logx):
         from sympy.simplify import hyperexpand

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -86,8 +86,11 @@ def print_tree(node):
     | commutative: True
     | complex: True
     | even: True
+    | finite: True
+    | finite_real: True
     | hermitian: True
     | imaginary: False
+    | infinite: False
     | integer: True
     | irrational: False
     | noninteger: False
@@ -100,8 +103,11 @@ def print_tree(node):
       commutative: True
       complex: True
       even: False
+      finite: True
+      finite_real: True
       hermitian: True
       imaginary: False
+      infinite: False
       integer: True
       irrational: False
       noninteger: False

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -619,8 +619,8 @@ def test_powsimp():
         (1 + exp(1 + E))*exp(-E)
     assert powsimp((1 + E*exp(E))*exp(-E), combine='base') == \
         (1 + E*exp(E))*exp(-E)
-    x, y = symbols('x,y', nonnegative=True)
-    n = Symbol('n', real=True)
+    x, y = symbols('x,y', nonnegative=True, finite=True)
+    n = Symbol('n', real=True, finite=True)
     assert powsimp(y**n * (y/x)**(-n)) == x**n
     assert powsimp(x**(x**(x*y)*y**(x*y))*y**(x**(x*y)*y**(x*y)), deep=True) \
         == (x*y)**(x*y)**(x*y)

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -54,7 +54,7 @@ class SingleDiscreteDistribution(Basic, NamedArgsMixin):
 
         Returns a Lambda
         """
-        x, z = symbols('x, z', integer=True, finite=True, cls=Dummy)
+        x, z = symbols('x, z', integer=True, cls=Dummy)
         left_bound = self.set.inf
 
         # CDF is integral of PDF from left bound to z


### PR DESCRIPTION
## Motivation

It is currently possible to create a meaningless set of assumptions (fixes #8075):

neither

```
    Dummy(zero=True, finite=False) nor
    Dummy(zero=True, infinite=True)
```

raise an error.
### results

```
>>> Dummy(integer=1).is_finite
True <--formerly None
>>> oo.is_rational
False <--formerly None
```
## major changes
- nonzero, finite and infinite are all complex
- nan has all attributes except `is_number` and `commutative` as False
- integers are now finite (hence oo.is_odd and other such integer properties are False)
- 16 of 17 issues in #8043 are addressed
- 2 XFAILed tests are now working
- about 7 tests with wrong results were corrected
- fixes #8081
- fixes #8088 
## todo
- [ ] fix Add._eval_is_imaginary so XFAILed test passes
