### PR TITLE
MatExpr: Fix entry when power is zero and other cases

### DIFF
--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -3,6 +3,8 @@ from __future__ import print_function, division
 from .matexpr import MatrixExpr, ShapeError, Identity
 from sympy import Pow, S, Basic
 from sympy.core.sympify import _sympify
+from sympy.matrices import MatrixBase
+from sympy.core import S
 
 
 class MatPow(MatrixExpr):
@@ -27,8 +29,28 @@ class MatPow(MatrixExpr):
         return self.base.shape
 
     def _entry(self, i, j):
-        if self.exp.is_Integer:
-            # Make an explicity MatMul out of the MatPow
-            return MatMul(*[self.base for k in range(self.exp)])._entry(i, j)
+        if self.exp.is_zero:
+            if not self.base.is_square:
+                raise ShapeError("Power of non-square matrix %s" % self.base)
+            T = Identity(self.base.shape[0])
+        elif self.exp is S.One:
+            T = self.base
+        elif isinstance(self.base, MatrixBase):
+            # e.g., ImmutableMatrix**S.Half not covered by MatMul cases below
+            T = self.base**self.exp
+        elif self.exp.is_Integer and self.exp.is_positive:
+            # Make an explicit MatMul out of the MatPow
+            T = MatMul(*[self.base for k in range(self.exp)])
+        #elif self.exp.is_Integer and self.exp.is_negative:
+        #    # Note: possible future improvement: in principle we can take
+        #    # positive powers of the inverse, but carefully avoid recursion,
+        #    # perhaps by adding `_entry` to Inverse (as it is our subclass).
+        #    T = self.base.inverse()
+        #    T = MatMul(*[T for k in range(-self.exp)])
+        else:
+            raise NotImplementedError(("(%d, %d) entry" % (int(i), int(j))) +
+                    "of matrix power either not defined or not implemented")
+        return T._entry(i, j)
+
 
 from .matmul import MatMul

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -1,0 +1,41 @@
+from sympy.utilities.pytest import XFAIL, raises
+from sympy.core import I, symbols, Basic, pi, S
+from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ImmutableMatrix)
+from sympy.matrices.expressions import MatMul, MatPow
+from sympy.matrices.expressions.matexpr import ShapeError
+
+n, m, l, k = symbols('n m l k', integer=True)
+A = MatrixSymbol('A', n, m)
+B = MatrixSymbol('B', m, l)
+C = MatrixSymbol('C', n, n)
+D = MatrixSymbol('D', n, n)
+E = MatrixSymbol('E', m, n)
+
+
+def test_entry():
+    from sympy.concrete import Sum
+    assert MatPow(A, 1)[0, 0] == A[0, 0]
+    assert MatPow(C, 0)[0, 0] == 1
+    assert MatPow(C, 0)[0, 1] == 0
+    assert isinstance(MatPow(C, 2)[0, 0], Sum)
+
+
+def test_as_explicit():
+    A = ImmutableMatrix([[1, 2], [3, 4]])
+    assert MatPow(A, 0).as_explicit() == ImmutableMatrix(Identity(2))
+    assert MatPow(A, 1).as_explicit() == A
+    assert MatPow(A, 2).as_explicit() == A**2
+    assert MatPow(A, -1).as_explicit() == A.inv()
+    assert MatPow(A, -2).as_explicit() == (A.inv())**2
+    # less expensive than testing on a 2x2
+    A = ImmutableMatrix([4]);
+    assert MatPow(A, S.Half).as_explicit() == A**S.Half
+
+
+def test_as_explicit_nonsquare():
+    A = ImmutableMatrix([[1, 2, 3], [4, 5, 6]])
+    assert MatPow(A, 1).as_explicit() == A
+    raises(ShapeError, lambda: MatPow(A, 0).as_explicit())
+    raises(ShapeError, lambda: MatPow(A, 2).as_explicit())
+    raises(ShapeError, lambda: MatPow(A, -1).as_explicit())
+    raises(ValueError, lambda: MatPow(A, pi).as_explicit())


### PR DESCRIPTION
-  `MatPow(A, 0)[0, 0]` would give an error because an empty list was
  passed to MatMult.  Fixed, added tests.
-  Entries of `MatPow` of ImmutableMatrix added as a special case.
  This fixes `.as_explicit` for MatPow of ImmutableMatrices, added
  tests for this.
-  Previously, `MatPow._entry` would return None if couldn't do it,
  instead raise errors.
-  Negative powers probably do-able in some cases, left comments.
