### PR TITLE
Fix failures in interactive ipython tests due to pytest capturing behavior

### DIFF
--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -23,9 +23,16 @@ if not ipython:
 
 def setup_module(module):
     """py.test support"""
+    import pytest
     if getattr(module, 'disabled', False):
-        import pytest
         pytest.skip("ipython isn't available.")
+    else:
+        # versions of pytest prior to 2.6.3 will raise
+        # AttributeError: DontReadFromInput instance has no attribute 'encoding'
+        # This can be fixed by running py.test with the `-s` option
+        if (pytest.__version__ < '2.6.3' and
+            pytest.config.getvalue('-s') != 'no'):
+            pytest.skip("run py.test with -s or upgrade to newer version")
 
 
 def test_automatic_symbols():

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -17,10 +17,16 @@ if not ipython:
 
 def setup_module(module):
     """py.test support"""
+    import pytest
     if getattr(module, 'disabled', False):
-        import pytest
         pytest.skip("ipython isn't available.")
-
+    else:
+        # versions of pytest prior to 2.6.3 will raise
+        # AttributeError: DontReadFromInput instance has no attribute 'encoding'
+        # This can be fixed by running py.test with the `-s` option
+        if (pytest.__version__ < '2.6.3' and
+            pytest.config.getvalue('-s') != 'no'):
+            pytest.skip("run py.test with -s or upgrade to newer version")
 
 def test_ipythonprinting():
     # Initialize and setup IPython session


### PR DESCRIPTION
- On master with `pytest.__version__ == 2.6.2`

``` bash
$ conda install pytest=2.6.2
$ py.test sympy/interactive/tests
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.24 -- pytest-2.6.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 6 items 

sympy/interactive/tests/test_interactive.py .
sympy/interactive/tests/test_ipython.py FF
sympy/interactive/tests/test_ipythonprinting.py FFF

=================================== FAILURES ===================================
____________________________ test_automatic_symbols ____________________________

    def test_automatic_symbols():
        # this implicitly requires readline
        if not readline:
            return None
        # NOTE: Because of the way the hook works, you have to use run_cell(code,
        # True).  This means that the code must have no Out, or it will be printed
        # during the tests.
>       app = init_ipython_session()

sympy/interactive/tests/test_ipython.py:38: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sympy/interactive/session.py:290: in init_ipython_session
    app.initialize(argv)
<string>:2: in initialize
    ???
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/application.py:92: in catch_config_error
    return method(app, *args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:332: in initialize
    self.init_shell()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:348: in init_shell
    ipython_dir=self.ipython_dir, user_ns=self.user_ns)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/configurable.py:354: in instance
    inst = cls(*args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/interactiveshell.py:328: in __init__
    **kwargs
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:483: in __init__
    self.init_readline()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1884: in init_readline
    self.refill_readline_hist()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <IPython.terminal.interactiveshell.TerminalInteractiveShell object at 0x7f33a92e03d0>

    def refill_readline_hist(self):
        # Load the last 1000 lines from history
        self.readline.clear_history()
>       stdin_encoding = sys.stdin.encoding or "utf-8"
E       AttributeError: DontReadFromInput instance has no attribute 'encoding'

../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1893: AttributeError
_____________________________ test_int_to_Integer ______________________________

    def test_int_to_Integer():
        # XXX: Warning, don't test with == here.  0.5 == Rational(1, 2) is True!
>       app = init_ipython_session()

sympy/interactive/tests/test_ipython.py:65: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sympy/interactive/session.py:290: in init_ipython_session
    app.initialize(argv)
<string>:2: in initialize
    ???
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/application.py:92: in catch_config_error
    return method(app, *args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:332: in initialize
    self.init_shell()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:348: in init_shell
    ipython_dir=self.ipython_dir, user_ns=self.user_ns)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/configurable.py:354: in instance
    inst = cls(*args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/interactiveshell.py:328: in __init__
    **kwargs
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:483: in __init__
    self.init_readline()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1884: in init_readline
    self.refill_readline_hist()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <IPython.terminal.interactiveshell.TerminalInteractiveShell object at 0x7f33a84f3b10>

    def refill_readline_hist(self):
        # Load the last 1000 lines from history
        self.readline.clear_history()
>       stdin_encoding = sys.stdin.encoding or "utf-8"
E       AttributeError: DontReadFromInput instance has no attribute 'encoding'

../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1893: AttributeError
_____________________________ test_ipythonprinting _____________________________

    def test_ipythonprinting():
        # Initialize and setup IPython session
>       app = init_ipython_session()

sympy/interactive/tests/test_ipythonprinting.py:27: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sympy/interactive/session.py:290: in init_ipython_session
    app.initialize(argv)
<string>:2: in initialize
    ???
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/application.py:92: in catch_config_error
    return method(app, *args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:332: in initialize
    self.init_shell()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:348: in init_shell
    ipython_dir=self.ipython_dir, user_ns=self.user_ns)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/configurable.py:354: in instance
    inst = cls(*args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/interactiveshell.py:328: in __init__
    **kwargs
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:483: in __init__
    self.init_readline()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1884: in init_readline
    self.refill_readline_hist()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <IPython.terminal.interactiveshell.TerminalInteractiveShell object at 0x7f33a8533890>

    def refill_readline_hist(self):
        # Load the last 1000 lines from history
        self.readline.clear_history()
>       stdin_encoding = sys.stdin.encoding or "utf-8"
E       AttributeError: DontReadFromInput instance has no attribute 'encoding'

../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1893: AttributeError
__________________________ test_print_builtin_option ___________________________

    def test_print_builtin_option():
        # Initialize and setup IPython session
>       app = init_ipython_session()

sympy/interactive/tests/test_ipythonprinting.py:61: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sympy/interactive/session.py:290: in init_ipython_session
    app.initialize(argv)
<string>:2: in initialize
    ???
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/application.py:92: in catch_config_error
    return method(app, *args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:332: in initialize
    self.init_shell()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:348: in init_shell
    ipython_dir=self.ipython_dir, user_ns=self.user_ns)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/configurable.py:354: in instance
    inst = cls(*args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/interactiveshell.py:328: in __init__
    **kwargs
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:483: in __init__
    self.init_readline()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1884: in init_readline
    self.refill_readline_hist()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <IPython.terminal.interactiveshell.TerminalInteractiveShell object at 0x7f33a80fb210>

    def refill_readline_hist(self):
        # Load the last 1000 lines from history
        self.readline.clear_history()
>       stdin_encoding = sys.stdin.encoding or "utf-8"
E       AttributeError: DontReadFromInput instance has no attribute 'encoding'

../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1893: AttributeError
__________________________ test_matplotlib_bad_latex ___________________________

    def test_matplotlib_bad_latex():
        # Initialize and setup IPython session
>       app = init_ipython_session()

sympy/interactive/tests/test_ipythonprinting.py:112: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sympy/interactive/session.py:290: in init_ipython_session
    app.initialize(argv)
<string>:2: in initialize
    ???
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/application.py:92: in catch_config_error
    return method(app, *args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:332: in initialize
    self.init_shell()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/ipapp.py:348: in init_shell
    ipython_dir=self.ipython_dir, user_ns=self.user_ns)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/config/configurable.py:354: in instance
    inst = cls(*args, **kwargs)
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/terminal/interactiveshell.py:328: in __init__
    **kwargs
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:483: in __init__
    self.init_readline()
../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1884: in init_readline
    self.refill_readline_hist()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <IPython.terminal.interactiveshell.TerminalInteractiveShell object at 0x7f33a85d9210>

    def refill_readline_hist(self):
        # Load the last 1000 lines from history
        self.readline.clear_history()
>       stdin_encoding = sys.stdin.encoding or "utf-8"
E       AttributeError: DontReadFromInput instance has no attribute 'encoding'

../../miniconda3/envs/py27/lib/python2.7/site-packages/IPython/core/interactiveshell.py:1893: AttributeError
```
- On master with pytest=2.6.2 and pytest run with the `-s` option

``` bash
$ py.test sympy/interactive/tests -s
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.24 -- pytest-2.6.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 6 items 

sympy/interactive/tests/test_interactive.py .
sympy/interactive/tests/test_ipython.py ..
sympy/interactive/tests/test_ipythonprinting.py ...

=========================== 6 passed in 0.50 seconds ===========================
```
- On master with pytest=2.6.3

``` bash
$ conda install pytest=2.6.3
$ py.test sympy/interactive/tests
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 6 items 

sympy/interactive/tests/test_interactive.py .
sympy/interactive/tests/test_ipython.py ..
sympy/interactive/tests/test_ipythonprinting.py ...

=========================== 6 passed in 0.59 seconds ===========================
```
- with `-s` option

``` bash
$ py.test sympy/interactive/tests -s
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 6 items 

sympy/interactive/tests/test_interactive.py .
sympy/interactive/tests/test_ipython.py ..
sympy/interactive/tests/test_ipythonprinting.py ...

=========================== 6 passed in 0.76 seconds ===========================
```

This PR adds the logic to skip the failing tests (when running under pytest) if the version is less than 2.6.3 and the user is running without `-s`
- PR with pytest=2.6.2

``` bash
$ py.test sympy/interactive/tests
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.24 -- pytest-2.6.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 6 items 

sympy/interactive/tests/test_interactive.py .
sympy/interactive/tests/test_ipython.py ss
sympy/interactive/tests/test_ipythonprinting.py sss

===================== 1 passed, 5 skipped in 0.22 seconds ======================
```
- PR with pytest=2.6.2 and `-s`

``` bash
$ py.test sympy/interactive/tests -s
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.24 -- pytest-2.6.2
architecture: 64-bit
cache:        yes
ground types: python 

collected 6 items 

sympy/interactive/tests/test_interactive.py .
sympy/interactive/tests/test_ipython.py ..
sympy/interactive/tests/test_ipythonprinting.py ...

=========================== 6 passed in 0.65 seconds ===========================
```
- PR with pytest=2.6.3

``` bash
$ py.test sympy/interactive/tests
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 6 items 

sympy/interactive/tests/test_interactive.py .
sympy/interactive/tests/test_ipython.py ..
sympy/interactive/tests/test_ipythonprinting.py ...

=========================== 6 passed in 0.52 seconds ===========================
```
