### PR TITLE
Logic.fromstring: add single-level paren support and func attribute

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -103,7 +103,7 @@ _assume_rules = FactRules([
 
     'irrational     ==  real & !rational',
 
-    'imaginary      ->  !real',
+    'imaginary      ->  zero | !real',
 
     'infinite       ->  !finite',
     'complex        ->  finite',

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -105,6 +105,8 @@ _assume_rules = FactRules([
     'imaginary      ->  !real',
 
     'infinite       ->  !finite',
+    'complex        ->  finite',
+
     'noninteger     ==  real & !integer',
     'nonzero        ==  real & !zero',
 ])

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -104,7 +104,7 @@ _assume_rules = FactRules([
 
     'imaginary      ->  !real',
 
-    '!finite        ==  infinite',
+    'infinite       ->  !finite',
     'noninteger     ==  real & !integer',
     '!zero        ==  nonzero',
 ])

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -106,7 +106,7 @@ _assume_rules = FactRules([
 
     'infinite       ->  !finite',
     'noninteger     ==  real & !integer',
-    '!zero        ==  nonzero',
+    'nonzero        ==  real & !zero',
 ])
 
 _assume_defined = _assume_rules.defined_facts.copy()

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -74,6 +74,7 @@ _assume_rules = FactRules([
 
     'integer        ->  rational',
     'rational       ->  real',
+    'real           ==  finite & extended_real',
     'rational       ->  algebraic',
     'algebraic      ->  complex',
     'real           ->  complex',
@@ -85,15 +86,15 @@ _assume_rules = FactRules([
     'odd            ==  integer & !even',
     'even           ==  integer & !odd',
 
-    'real           ==  negative | zero | positive',
+    'extended_real  ==  negative | zero | positive',
     'transcendental ==  complex & !algebraic',
 
     'negative       ==  nonpositive & nonzero',
     'positive       ==  nonnegative & nonzero',
     'zero           ==  nonnegative & nonpositive',
 
-    'nonpositive    ==  real & !positive',
-    'nonnegative    ==  real & !negative',
+    'nonpositive    ==  extended_real & !positive',
+    'nonnegative    ==  extended_real & !negative',
 
     'zero           ->  even',
 

--- a/sympy/core/tests/test_logic.py
+++ b/sympy/core/tests/test_logic.py
@@ -144,6 +144,9 @@ def test_logic_fromstring():
     raises(ValueError, lambda: S('a | & b'))
     raises(ValueError, lambda: S('a & & b'))
     raises(ValueError, lambda: S('a |'))
+    raises(ValueError, lambda: S('a|b'))
+    raises(ValueError, lambda: S('!'))
+    raises(ValueError, lambda: S('! a'))
 
 
 def test_logic_not():
@@ -154,3 +157,20 @@ def test_logic_not():
     # functionality into some method.
     assert Not(And('a', 'b')) == Or(Not('a'), Not('b'))
     assert Not(Or('a', 'b')) == And(Not('a'), Not('b'))
+
+def test_func():
+    S = Logic.fromstring
+    assert S('a & b').func == And
+    assert S('a | b').func == Or
+    assert S('!a').func == Not
+
+def test_paren():
+    S = Logic.fromstring
+    assert S('!a & (!b | c)') == And(Not('a'), Or(Not('b'), 'c'))
+    assert S('(a | b) | (b | c)') == Or(Or('a', 'b'), Or('b', 'c'))
+    raises(ValueError, lambda: S('a)'))  # missing (
+    raises(ValueError, lambda: S('(a'))  # missing )
+    raises(ValueError, lambda: S('(a & (b | c))'))  # nested
+    raises(ValueError, lambda: S('a ) & ( b'))  # malformed
+    raises(ValueError, lambda: S('a () &  b'))  # malformed
+    raises(ValueError, lambda: S('( ) &  b'))  # empty


### PR DESCRIPTION
Also, errors are raised if there are not spaces around
& and | or if there _is_ a space after '!'. This inflexibility
enforces readability on the input strings.

For sake of simplicity it's probably best not to support more than one level of parentheses?
