### PR TITLE
Don't evaluate arbitrary text coming from SYMPY_DEBUG variable

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -26,7 +26,12 @@ del sys
 def __sympy_debug():
     # helper function so we don't import os globally
     import os
-    return eval(os.getenv('SYMPY_DEBUG', 'False'))
+    debug_str = os.getenv('SYMPY_DEBUG', 'False')
+    if debug_str in ('True', 'False'):
+        return eval(debug_str)
+    else:
+        raise RuntimeError("unrecognized value for SYMPY_DEBUG: %s" %
+                           debug_str)
 SYMPY_DEBUG = __sympy_debug()
 
 from .core import *

--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -17,7 +17,12 @@ def __sympy_debug():
     # We don't just import SYMPY_DEBUG from that file because we don't want to
     # import all of sympy just to use this module.
     import os
-    return eval(os.getenv('SYMPY_DEBUG', 'False'))
+    debug_str = os.getenv('SYMPY_DEBUG', 'False')
+    if debug_str in ('True', 'False'):
+        return eval(debug_str)
+    else:
+        raise RuntimeError("unrecognized value for SYMPY_DEBUG: %s" %
+                           debug_str)
 
 if __sympy_debug():
     WARN_OLD_VERSION = True


### PR DESCRIPTION
With all the talks about recent shellshock vulnerability discovery in
Bash I've remembered encountering similar unguarded execution of
arbitrary text coming from the environment in sympy.  It is not that
critical, but it may be used to gain root privileges if there's a
script importing sympy with setuid bit on it:

```
$ SYMPY_DEBUG='os.sys.stdout.write("Hello\n")' python -c 'import sympy'
Hello
Hello
```

This PR should fix the issue.

I'm not sure where to put tests for it, though, as there's no test
suite in the root directory, maybe into `sympy.core`?
