### PR TITLE
Codegen: Use prefix as the function name in simple cases

### DIFF
--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1,6 +1,7 @@
 from sympy.core import symbols, Eq, pi, Catalan, Lambda, Dummy
 from sympy.core.compatibility import StringIO
 from sympy import erf, Integral
+from sympy.matrices import Matrix
 from sympy.utilities.codegen import (CCodeGen, Routine, InputArgument,
     CodeGenError, FCodeGen, codegen, CodeGenArgumentListError, OutputArgument,
     InOutArgument)
@@ -1183,3 +1184,21 @@ def test_check_case_false_positive():
     except CodeGenError as e:
         if e.args[0].startswith("Fortran ignores case."):
             raise AssertionError("This exception should not be raised!")
+
+
+def test_c_fortran_omit_routine_name():
+    x, y = symbols("x,y")
+    name_expr = [("foo", 2*x)]
+    result = codegen(name_expr, "F95", header=False, empty=False)
+    expresult = codegen(name_expr, "F95", "foo", header=False, empty=False)
+    assert result[0][1] == expresult[0][1]
+
+    name_expr = ("foo", x*y)
+    result = codegen(name_expr, "F95", header=False, empty=False)
+    expresult = codegen(name_expr, "F95", "foo", header=False, empty=False)
+    assert result[0][1] == expresult[0][1]
+
+    name_expr = ("foo", Matrix([[x, y], [x+y, x-y]]))
+    result = codegen(name_expr, "C", header=False, empty=False)
+    expresult = codegen(name_expr, "C", "foo", header=False, empty=False)
+    assert result[0][1] == expresult[0][1]


### PR DESCRIPTION
[updated: just this one change on top of master now]

```
Codegen: Use the first function name as a default for prefix

Allow an abbreviated call to codegen:
codegen(("foo", 2*x*y), "F95")
rather than specifying "foo" twice:
codegen(("foo", 2*x*y), "F95", "foo")

This is particularly nice for languages such as Octave where the
filename (prefix) should match the function name.
```
