### PR TITLE
clear the cache at the start of file [pytest]

### DIFF
--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -24,11 +24,6 @@ def pytest_report_header(config):
     return s
 
 
-def pytest_runtest_setup(item):
-    if not isinstance(item, pytest.Function):
-        return
-
-
 def pytest_terminal_summary(terminalreporter):
     if (terminalreporter.stats.get('error', None) or
             terminalreporter.stats.get('failed', None)):
@@ -36,5 +31,6 @@ def pytest_terminal_summary(terminalreporter):
             ' ', 'DO *NOT* COMMIT!', red=True, bold=True)
 
 
-def pytest_runtest_teardown():
+@pytest.fixture(autouse=True, scope='module')
+def file_clear_cache():
     clear_cache()


### PR DESCRIPTION
On master, the cache is cleared after _every_ test when using pytest.  It is only cleared at the start of a testing file with `bin/test`.  This PR changes the behavior of pytest to match our native test runner.
- On master (with a print statement before the call to clear_cache)

``` bash
sympy/assumptions/tests/test_assumptions_2.py .clearing cache
.clearing cache
.clearing cache
.clearing cache
.clearing cache

sympy/assumptions/tests/test_context.py .clearing cache
.clearing cache
.clearing cache
.clearing cache

sympy/assumptions/tests/test_matrices.py .clearing cache
.clearing cache
.clearing cache
xclearing cache
.clearing cache
.clearing cache
.clearing cache
.clearing cache
.clearing cache
.clearing cache
.clearing cache
.clearing cache
xclearing cache
.clearing cache
```
- This PR (with a print statement before the call to clear_cache)

``` bash
sympy/assumptions/tests/test_assumptions_2.py clear cache
.....
sympy/assumptions/tests/test_context.py clear cache
....
sympy/assumptions/tests/test_matrices.py clear cache
...x........x......
sympy/assumptions/tests/test_query.py clear cache
...............x............x......
```
