### PR TITLE
Refactor setup_module methods [pytest] 

### DIFF
--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -38,3 +38,13 @@ def pytest_terminal_summary(terminalreporter):
 
 def pytest_runtest_teardown():
     clear_cache()
+
+@pytest.fixture(autouse=True, scope='module')
+def check_disabled(request):
+    if getattr(request.module, 'disabled', False):
+        pytest.skip("test requirements not met.")
+    elif getattr(request.module, 'ipython', False):
+        # need to check version and options for ipython tests
+        if (pytest.__version__ < '2.6.3' and
+            pytest.config.getvalue('-s') != 'no'):
+            pytest.skip("run py.test with -s or upgrade to newer version.")

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -17,12 +17,6 @@ else:
     disabled = True
 
 
-def setup_module(module):
-    """py.test support"""
-    if getattr(module, 'disabled', False):
-        import pytest
-        pytest.skip("numpy isn't available.")
-
 from sympy import (Rational, Symbol, list2numpy, matrix2numpy, sin, Float,
         Matrix, lambdify, symarray, symbols, Integer)
 import sympy

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -30,13 +30,6 @@ if sys.version_info[0] == 3:
     # Sage does not support Python 3 currently
     disabled = True
 
-
-def setup_module(module):
-    """py.test support"""
-    if getattr(module, 'disabled', False):
-        import pytest
-        pytest.skip("Sage isn't available.")
-
 import sympy
 
 from sympy.utilities.pytest import XFAIL

--- a/sympy/external/tests/test_scipy.py
+++ b/sympy/external/tests/test_scipy.py
@@ -12,13 +12,6 @@ if not scipy:
     #bin/test will not execute any tests now
     disabled = True
 
-
-def setup_module(module):
-    """py.test support"""
-    if getattr(module, 'disabled', False):
-        import pytest
-        pytest.skip("scipy isn't available.")
-
 from sympy import jn_zeros
 
 

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -21,20 +21,6 @@ if not ipython:
     disabled = True
 
 
-def setup_module(module):
-    """py.test support"""
-    import pytest
-    if getattr(module, 'disabled', False):
-        pytest.skip("ipython isn't available.")
-    else:
-        # versions of pytest prior to 2.6.3 will raise
-        # AttributeError: DontReadFromInput instance has no attribute 'encoding'
-        # This can be fixed by running py.test with the `-s` option
-        if (pytest.__version__ < '2.6.3' and
-            pytest.config.getvalue('-s') != 'no'):
-            pytest.skip("run py.test with -s or upgrade to newer version")
-
-
 def test_automatic_symbols():
     # this implicitly requires readline
     if not readline:

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -15,19 +15,6 @@ if not ipython:
     disabled = True
 
 
-def setup_module(module):
-    """py.test support"""
-    import pytest
-    if getattr(module, 'disabled', False):
-        pytest.skip("ipython isn't available.")
-    else:
-        # versions of pytest prior to 2.6.3 will raise
-        # AttributeError: DontReadFromInput instance has no attribute 'encoding'
-        # This can be fixed by running py.test with the `-s` option
-        if (pytest.__version__ < '2.6.3' and
-            pytest.config.getvalue('-s') != 'no'):
-            pytest.skip("run py.test with -s or upgrade to newer version")
-
 def test_ipythonprinting():
     # Initialize and setup IPython session
     app = init_ipython_session()

--- a/sympy/plotting/intervalmath/tests/test_interval_functions.py
+++ b/sympy/plotting/intervalmath/tests/test_interval_functions.py
@@ -12,12 +12,6 @@ if not np:
     disabled = True
 
 
-def setup_module(module):
-    """py.test support"""
-    if getattr(module, 'disabled', False):
-        import pytest
-        pytest.skip("numpy isn't available.")
-
 #requires Numpy. Hence included in interval_functions
 
 

--- a/sympy/plotting/pygletplot/tests/test_plotting.py
+++ b/sympy/plotting/pygletplot/tests/test_plotting.py
@@ -9,12 +9,6 @@ if not pyglet_gl or not pyglet_window:
     disabled = True
 
 
-def setup_module(module):
-    """py.test support"""
-    if module.disabled:
-        import pytest
-        pytest.skip("Pyglet and/or OpenGL are unavailable.")
-
 from sympy import symbols, sin, cos
 x, y, z = symbols('x, y, z')
 

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -11,12 +11,6 @@ else:
     #bin/test will not execute any tests now
     disabled = True
 
-def setup_module(module):
-    """py.test support"""
-    if getattr(module, 'disabled', False):
-        import pytest
-        pytest.skip("theano isn't available.")
-
 import sympy
 from sympy import S
 sy = sympy


### PR DESCRIPTION
Rather than adding repetitive `setup_module` methods to the sympy code base, we can make use of a single module level fixture to skip tests marked with `disabled = True` as is done for `bin/test`.  The fixture also checks for `ipython` as those tests can only be run with the most recent version of pytest or with the -s flag.

``` bash
$ py.test sympy/external/tests/ sympy/interactive/tests/ sympy/plotting/ sympy/printing/
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.23 -- pytest-2.6.1
architecture: 64-bit
cache:        yes
ground types: python 

collected 531 items 

sympy/external/tests/test_autowrap.py sssss.sssss
sympy/external/tests/test_codegen.py .s.s....
sympy/external/tests/test_importtools.py ...
sympy/external/tests/test_numpy.py sssssssssssssssssssssss
sympy/external/tests/test_sage.py ssssssssssssss
sympy/external/tests/test_scipy.py s
sympy/interactive/tests/test_interactive.py .
sympy/interactive/tests/test_ipython.py ss
sympy/interactive/tests/test_ipythonprinting.py sss
sympy/plotting/intervalmath/tests/test_interval_functions.py ssssssssssssssssssssssss
sympy/plotting/intervalmath/tests/test_intervalmath.py .......
sympy/plotting/pygletplot/tests/test_plotting.py sssssssssss
sympy/plotting/tests/test_plot.py .s.
sympy/plotting/tests/test_plot_implicit.py s
sympy/printing/pretty/tests/test_pretty.py .................................................................
sympy/printing/tests/test_ccode.py .........................
sympy/printing/tests/test_codeprinter.py ...
sympy/printing/tests/test_conventions.py ..
sympy/printing/tests/test_dot.py .........
sympy/printing/tests/test_fcode.py ................................
sympy/printing/tests/test_gtk.py x.
sympy/printing/tests/test_jscode.py ......................
sympy/printing/tests/test_lambdarepr.py ....
sympy/printing/tests/test_latex.py .....x.........................................................................x.....
sympy/printing/tests/test_mathematica.py .........
sympy/printing/tests/test_mathml.py .................
sympy/printing/tests/test_precedence.py ............
sympy/printing/tests/test_python.py .....x....
sympy/printing/tests/test_repr.py ....................
sympy/printing/tests/test_str.py ........................................................................
sympy/printing/tests/test_tableform.py ..
sympy/printing/tests/test_theanocode.py ssssssssssssssssssssssssssss

============= 407 passed, 120 skipped, 4 xfailed in 52.75 seconds ==============
```
