### PR TITLE
FIX issue#8147 Recursion depth exceeded in as_int(Rational(0, 0))

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -180,6 +180,8 @@ class Expr(Basic, EvalfMixin):
         r = self.round(2)
         if not r.is_Number:
             raise TypeError("can't convert complex to int")
+        if r in (S.NaN, S.Infinity, S.NegativeInfinity):
+            raise TypeError("can't convert %s to int" % r)
         i = int(r)
         if not i:
             return 0
@@ -3020,6 +3022,8 @@ class Expr(Basic, EvalfMixin):
         x = self
         if not x.is_number:
             raise TypeError('%s is not a number' % x)
+        if x in (S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
+            return x
         if not x.is_real:
             i, r = x.as_real_imag()
             return i.round(p) + S.ImaginaryUnit*r.round(p)

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -13,6 +13,10 @@ def test_default_sort_key():
 def test_as_int():
     raises(ValueError, lambda : as_int(1.1))
     raises(ValueError, lambda : as_int([]))
+    raises(ValueError, lambda : as_int(S.NaN))
+    raises(ValueError, lambda : as_int(S.Infinity))
+    raises(ValueError, lambda : as_int(S.NegativeInfinity))
+    raises(ValueError, lambda : as_int(S.ComplexInfinity))
 
 
 def test_iterable():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1601,6 +1601,12 @@ def test_round():
     assert str(S(0.006).round(2)) == '0.01'
     assert str(S(0.00106).round(4)) == '0.0011'
 
+    # issue 8147
+    assert S.NaN.round() == S.NaN
+    assert S.Infinity.round() == S.Infinity
+    assert S.NegativeInfinity.round() == S.NegativeInfinity
+    assert S.ComplexInfinity.round() == S.ComplexInfinity
+
 
 def test_extract_branch_factor():
     assert exp_polar(2.0*I*pi).extract_branch_factor() == (1, 1)


### PR DESCRIPTION
update test_as_int in test_compatibility.py
