### PR TITLE
pretty_symbology: Don't assume the output of U() is not None

### DIFF
--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -424,10 +424,14 @@ _xsym = {
     '!=':  ('!=', U('NOT EQUAL TO')),
     '*':   ('*', U('DOT OPERATOR')),
     '-->': ('-->', U('EM DASH') + U('EM DASH') +
-            U('BLACK RIGHT-POINTING TRIANGLE')),
+            U('BLACK RIGHT-POINTING TRIANGLE') if U('EM DASH')
+            and U('BLACK RIGHT-POINTING TRIANGLE') else None),
     '==>': ('==>', U('BOX DRAWINGS DOUBLE HORIZONTAL') +
             U('BOX DRAWINGS DOUBLE HORIZONTAL') +
-            U('BLACK RIGHT-POINTING TRIANGLE')),
+            U('BLACK RIGHT-POINTING TRIANGLE') if
+            U('BOX DRAWINGS DOUBLE HORIZONTAL') and
+            U('BOX DRAWINGS DOUBLE HORIZONTAL') and
+            U('BLACK RIGHT-POINTING TRIANGLE') else None),
     '.':   ('*', U('RING OPERATOR')),
 }
 


### PR DESCRIPTION
U() returns None when unicodedata can't be imported. I'm not sure how to test
this because it's only reproducible if unicodedata from the standard library
can't be imported.  I suppose we could add a hook to test it. It won't be
straight-forward though because the key thing is to make sure it works
correctly at import time.

Fixes #8163.
