### PR TITLE
add is_hermitian to Matrix and SparseMatrix

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -5,6 +5,7 @@ from sympy.core.add import Add
 from sympy.core.basic import Basic, C, Atom
 from sympy.core.expr import Expr
 from sympy.core.function import count_ops
+from sympy.core.logic import _fuzzy_group_inverse, fuzzy_and
 from sympy.core.power import Pow
 from sympy.core.symbol import Symbol, Dummy, symbols
 from sympy.core.numbers import Integer, ilcm, Rational, Float
@@ -2122,6 +2123,45 @@ class MatrixBase(object):
         return all(self[i, j].is_zero
             for i in range(self.rows)
             for j in range(i + 1, self.cols))
+
+    @property
+    def is_hermitian(self):
+        """Checks if the matrix is Hermitian.
+
+        In a Hermitian matrix element i,j is the complex conjugate of
+        element j,i.
+
+        Examples
+        ========
+
+        >>> from sympy.matrices import Matrix
+        >>> from sympy import I
+        >>> from sympy.abc import x
+        >>> a = Matrix([[1, I], [-I, 1]])
+        >>> a
+        Matrix([
+        [ 1, I],
+        [-I, 1]])
+        >>> a.is_hermitian
+        True
+        >>> a[0, 0] = 2*I
+        >>> a.is_hermitian
+        False
+        >>> a[0, 0] = x
+        >>> a.is_hermitian
+        >>> a[0, 1] = a[1, 0]*I
+        >>> a.is_hermitian
+        False
+        """
+        def cond():
+            yield self.is_square
+            yield _fuzzy_group_inverse(
+                    self[i, i].is_real for i in range(self.rows))
+            yield _fuzzy_group_inverse(
+                    (self[i, j] - self[j, i].conjugate()).is_zero
+                    for i in range(self.rows)
+                    for j in range(i + 1, self.cols))
+        return fuzzy_and(i for i in cond())
 
     @property
     def is_upper_hessenberg(self):

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 from sympy.core.containers import Dict
 from sympy.core.compatibility import is_sequence, as_int
+from sympy.core.logic import fuzzy_and, _fuzzy_group_inverse
 from sympy.core.singleton import S
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.utilities.iterables import uniq
@@ -538,6 +539,49 @@ class SparseMatrix(MatrixBase):
                     rv = rv.col_insert(i, rv.col(i_previous))
         return rv
     extract.__doc__ = MatrixBase.extract.__doc__
+
+    @property
+    def is_hermitian(self):
+        """Checks if the matrix is Hermitian.
+
+        In a Hermitian matrix element i,j is the complex conjugate of
+        element j,i.
+
+        Examples
+        ========
+
+        >>> from sympy.matrices import SparseMatrix
+        >>> from sympy import I
+        >>> from sympy.abc import x
+        >>> a = SparseMatrix([[1, I], [-I, 1]])
+        >>> a
+        Matrix([
+        [ 1, I],
+        [-I, 1]])
+        >>> a.is_hermitian
+        True
+        >>> a[0, 0] = 2*I
+        >>> a.is_hermitian
+        False
+        >>> a[0, 0] = x
+        >>> a.is_hermitian
+        >>> a[0, 1] = a[1, 0]*I
+        >>> a.is_hermitian
+        False
+        """
+        def cond():
+            d = self._smat
+            yield self.is_square
+            if len(d) <= self.rows:
+                yield _fuzzy_group_inverse(
+                    d[i, i].is_real for i, j in d if i == j)
+            else:
+                yield _fuzzy_group_inverse(
+                    d[i, i].is_real for i in range(self.rows) if (i, i) in d)
+            yield _fuzzy_group_inverse(
+                    ((self[i, j] - self[j, i].conjugate()).is_zero
+                    if (j, i) in d else False) for (i, j) in d)
+        return fuzzy_and(i for i in cond())
 
     def is_symmetric(self, simplify=True):
         """Return True if self is symmetric.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2398,3 +2398,13 @@ def test_from_ndarray():
     assert Matrix(array([x, y, z])) == Matrix([x, y, z])
     raises(NotImplementedError, lambda: Matrix(array([[
         [1, 2], [3, 4]], [[5, 6], [7, 8]]])))
+
+def test_hermitian():
+    a = Matrix([[1, I], [-I, 1]])
+    assert a.is_hermitian
+    a[0, 0] = 2*I
+    assert a.is_hermitian is False
+    a[0, 0] = x
+    assert a.is_hermitian is None
+    a[0, 1] = a[1, 0]*I
+    assert a.is_hermitian is False

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -552,3 +552,16 @@ def test_sparse_solve():
     assert A*s == A[:, 0]
     s = A.solve_least_squares(A[:, 0], 'LDL')
     assert A*s == A[:, 0]
+
+def test_hermitian():
+    x = Symbol('x')
+    a = SparseMatrix([[0, I], [-I, 0]])
+    assert a.is_hermitian
+    a = SparseMatrix([[1, I], [-I, 1]])
+    assert a.is_hermitian
+    a[0, 0] = 2*I
+    assert a.is_hermitian is False
+    a[0, 0] = x
+    assert a.is_hermitian is None
+    a[0, 1] = a[1, 0]*I
+    assert a.is_hermitian is False


### PR DESCRIPTION
There are several `is_*` methods for matrices:

```
is_anti_symmetric
is_diagonal
is_diagonalizable
is_hermitian  <---- this is being added in this PR
is_lower
is_lower_hessenberg
is_nilpotent
is_square
is_symbolic
is_symmetric
is_upper
is_upper_hessenberg
is_zero
```

The `is_hermitian` defined here is not part of the assumptions system since Matrix doesn't subclass from Expr but it gives the same sort of answer: True, False or None.

All lines are covered.
