### PR TITLE
fix encoding error in test_type_G.py 

### DIFF
--- a/sympy/liealgebras/tests/test_type_G.py
+++ b/sympy/liealgebras/tests/test_type_G.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.matrices import Matrix
 


### PR DESCRIPTION
test_type_G.py uses utf-8 characters and should therefore specify the proper encoding.  Discovered the error using pytest (Python 2)
- On master

``` bash
$ py.test sympy/liealgebras/tests/test_type_G.py 
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 0 items / 1 errors 

==================================== ERRORS ====================================
___________ ERROR collecting sympy/liealgebras/tests/test_type_G.py ____________
../../miniconda3/envs/py27/lib/python2.7/site-packages/_pytest/python.py:463: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=True)
../../miniconda3/envs/py27/lib/python2.7/site-packages/py/_path/local.py:642: in pyimport
    __import__(modname)
E     File "/home/ptb/gitrepos/sympy/sympy/liealgebras/tests/test_type_G.py", line 12
E   SyntaxError: Non-ASCII character '\xe2' in file /home/ptb/gitrepos/sympy/sympy/liealgebras/tests/test_type_G.py on line 12, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
                                DO *NOT* COMMIT!                                
=========================== 1 error in 0.05 seconds ============================
```
- PR

``` bash
$ py.test sympy/liealgebras/tests/test_type_G.py 
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 1 items 

sympy/liealgebras/tests/test_type_G.py .

=========================== 1 passed in 0.02 seconds ===========================
```
