### PR TITLE
Added various from __future__ statements to placate pytest

### DIFF
--- a/sympy/liealgebras/tests/test_type_F.py
+++ b/sympy/liealgebras/tests/test_type_F.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.matrices import Matrix
 

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from sympy import symbols, Matrix, solve, simplify, cos, sin, atan, sqrt
 from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
     dot, cross, inertia, KanesMethod, Particle, RigidBody, Lagrangian,\

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from sympy.stats import (P, E, where, density, variance, covariance, skewness,
                          given, pspace, cdf, ContinuousRV, sample,
                          Arcsin, Benini, Beta, BetaPrime, Cauchy,

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from textwrap import dedent
 
 from sympy import (


### PR DESCRIPTION
These may be the last of the py2 errors.
- On master

``` bash
$ py.test -k "test_linearize_rolling_disc_kane or test_studentt or test_kbins or test_type_F"
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3
collected 6406 items / 1 errors 

sympy/liealgebras/tests/test_type_F.py F
sympy/physics/mechanics/tests/test_linearize.py F
sympy/stats/tests/test_continuous_rv.py F
sympy/utilities/tests/test_iterables.py F

==================================== ERRORS ====================================
___________ ERROR collecting sympy/liealgebras/tests/test_type_G.py ____________
../../miniconda3/envs/py27/lib/python2.7/site-packages/_pytest/python.py:463: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=True)
../../miniconda3/envs/py27/lib/python2.7/site-packages/py/_path/local.py:642: in pyimport
    __import__(modname)
E     File "/home/ptb/gitrepos/sympy/sympy/liealgebras/tests/test_type_G.py", line 12
E   SyntaxError: Non-ASCII character '\xe2' in file /home/ptb/gitrepos/sympy/sympy/liealgebras/tests/test_type_G.py on line 12, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
=================================== FAILURES ===================================
_________________________________ test_type_F __________________________________

    def test_type_F():
        c = CartanType("F4")
        m = Matrix(4, 4, [2, -1, 0, 0, -1, 2, -2, 0, 0, -1, 2, -1, 0, 0, -1, 2])
        assert c.cartan_matrix() == m
        assert c.dimension() == 4
        assert c.simple_root(3) == [0, 0, 0, 1]
        assert c.simple_root(4) == [-0.5, -0.5, -0.5, -0.5]
        assert c.roots() == 48
        assert c.basis() == 52
        diag = "0---0=>=0---0\n" + "   ".join(str(i) for i in range(1, 5))
        assert c.dynkin_diagram() == diag
>       assert c.positive_roots() == {1: [1, -1, 0, 0], 2: [1, 1, 0, 0], 3: [1, 0, -1, 0],
                4: [1, 0, 1, 0], 5: [1, 0, 0, -1], 6: [1, 0, 0, 1], 7: [0, 1, -1, 0],
                8: [0, 1, 1, 0], 9: [0, 1, 0, -1], 10: [0, 1, 0, 1], 11: [0, 0, 1, -1],
                12: [0, 0, 1, 1], 13: [1, 0, 0, 0], 14: [0, 1, 0, 0], 15: [0, 0, 1, 0],
                16: [0, 0, 0, 1], 17: [1/2, 1/2, 1/2, 1/2], 18: [1/2, -1/2, 1/2, 1/2],
                19: [1/2, 1/2, -1/2, 1/2], 20: [1/2, 1/2, 1/2, -1/2], 21: [1/2, 1/2, -1/2, -1/2],
                22: [1/2, -1/2, 1/2, -1/2], 23: [1/2, -1/2, -1/2, 1/2], 24: [1/2, -1/2, -1/2, -1/2]}
E       assert {1: [1, -1, 0...0, 1, 0], ...} == {1: [1, -1, 0,...0, 1, 0], ...}
E         Omitting 16 identical items, use -v to show
E         Differing items:
E         {17: [1/2, 1/2, 1/2, 1/2]} != {17: [0, 0, 0, 0]}
E         {18: [1/2, -1/2, 1/2, 1/2]} != {18: [0, -1, 0, 0]}
E         {19: [1/2, 1/2, -1/2, 1/2]} != {19: [0, 0, -1, 0]}
E         {20: [1/2, 1/2, 1/2, -1/2]} != {20: [0, 0, 0, -1]}
E         {21: [1/2, 1/2, -1/2, -1/2]} != {21: [0, 0, -1, -1]}
E         {22: [1/2, -1/2, 1/2, -1/2]} != {22: [0, -1, 0, -1]}
E         {23: [1/2, -1/2, -1/2, 1/2]} != {23: [0, -1, -1, 0]}
E         {24: [1/2, -1/2, -1/2, -1/2]} != {24: [0, -1, -1, -1]}

sympy/liealgebras/tests/test_type_F.py:15: AssertionError
_______________________ test_linearize_rolling_disc_kane _______________________

    def test_linearize_rolling_disc_kane():
        # Symbols for time and constant parameters
        t, r, m, g, v = symbols('t r m g v')

        # Configuration variables and their time derivatives
        q1, q2, q3, q4, q5, q6 = q = dynamicsymbols('q1:7')
        q1d, q2d, q3d, q4d, q5d, q6d = qd = [qi.diff(t) for qi in q]

        # Generalized speeds and their time derivatives
        u = dynamicsymbols('u:6')
        u1, u2, u3, u4, u5, u6 = u = dynamicsymbols('u1:7')
        u1d, u2d, u3d, u4d, u5d, u6d = [ui.diff(t) for ui in u]

        # Reference frames
        N = ReferenceFrame('N')                   # Inertial frame
        NO = Point('NO')                          # Inertial origin
        A = N.orientnew('A', 'Axis', [q1, N.z])   # Yaw intermediate frame
        B = A.orientnew('B', 'Axis', [q2, A.x])   # Lean intermediate frame
        C = B.orientnew('C', 'Axis', [q3, B.y])   # Disc fixed frame
        CO = NO.locatenew('CO', q4*N.x + q5*N.y + q6*N.z)      # Disc center

        # Disc angular velocity in N expressed using time derivatives of coordinates
        w_c_n_qd = C.ang_vel_in(N)
        w_b_n_qd = B.ang_vel_in(N)

        # Inertial angular velocity and angular acceleration of disc fixed frame
        C.set_ang_vel(N, u1*B.x + u2*B.y + u3*B.z)

        # Disc center velocity in N expressed using time derivatives of coordinates
        v_co_n_qd = CO.pos_from(NO).dt(N)

        # Disc center velocity in N expressed using generalized speeds
        CO.set_vel(N, u4*C.x + u5*C.y + u6*C.z)

        # Disc Ground Contact Point
        P = CO.locatenew('P', r*B.z)
        P.v2pt_theory(CO, N, C)

        # Configuration constraint
        f_c = Matrix([q6 - dot(CO.pos_from(P), N.z)])

        # Velocity level constraints
        f_v = Matrix([dot(P.vel(N), uv) for uv in C])

        # Kinematic differential equations
        kindiffs = Matrix([dot(w_c_n_qd - C.ang_vel_in(N), uv) for uv in B] +
                            [dot(v_co_n_qd - CO.vel(N), uv) for uv in N])
        qdots = solve(kindiffs, qd)

        # Set angular velocity of remaining frames
        B.set_ang_vel(N, w_b_n_qd.subs(qdots))
        C.set_ang_acc(N, C.ang_vel_in(N).dt(B) + cross(B.ang_vel_in(N), C.ang_vel_in(N)))

        # Active forces
        F_CO = m*g*A.z

        # Create inertia dyadic of disc C about point CO
        I = (m * r**2) / 4
        J = (m * r**2) / 2
        I_C_CO = inertia(C, I, J, I)

        Disc = RigidBody('Disc', CO, C, m, (I_C_CO, CO))
        BL = [Disc]
        FL = [(CO, F_CO)]
        KM = KanesMethod(N, [q1, q2, q3, q4, q5], [u1, u2, u3], kd_eqs=kindiffs,
                q_dependent=[q6], configuration_constraints=f_c,
                u_dependent=[u4, u5, u6], velocity_constraints=f_v)
        (fr, fr_star) = KM.kanes_equations(FL, BL)

        # Test generalized form equations
        linearizer = KM.to_linearizer()
        assert linearizer.f_c == f_c
        assert linearizer.f_v == f_v
        assert linearizer.f_a == f_v.diff(t)
        sol = solve(linearizer.f_0 + linearizer.f_1, qd)
        for qi in qd:
            assert sol[qi] == qdots[qi]
        assert simplify(linearizer.f_2 + linearizer.f_3 - fr - fr_star) == Matrix([0, 0, 0])

        # Perform the linearization
        # Precomputed operating point
        q_op = {q6: -r*cos(q2)}
        u_op = {u1: 0,
                u2: sin(q2)*q1d + q3d,
                u3: cos(q2)*q1d,
                u4: -r*(sin(q2)*q1d + q3d)*cos(q3),
                u5: 0,
                u6: -r*(sin(q2)*q1d + q3d)*sin(q3)}
        qd_op = {q2d: 0,
                 q4d: -r*(sin(q2)*q1d + q3d)*cos(q1),
                 q5d: -r*(sin(q2)*q1d + q3d)*sin(q1),
                 q6d: 0}
        ud_op = {u1d: 4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5,
                 u2d: 0,
                 u3d: 0,
                 u4d: r*(sin(q2)*sin(q3)*q1d*q3d + sin(q3)*q3d**2),
                 u5d: r*(4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5),
                 u6d: -r*(sin(q2)*cos(q3)*q1d*q3d + cos(q3)*q3d**2)}

        A, B = linearizer.linearize(op_point=[q_op, u_op, qd_op, ud_op], A_and_B=True, simplify=True)

        upright_nominal = {q1d: 0, q2: 0, m: 1, r: 1, g: 1}

        # Precomputed solution
        A_sol = Matrix([[0, 0, 0, 0, 0, 0, 0, 1],
                        [0, 0, 0, 0, 0, 1, 0, 0],
                        [0, 0, 0, 0, 0, 0, 1, 0],
                        [sin(q1)*q3d, 0, 0, 0, 0, -sin(q1), -cos(q1), 0],
                        [-cos(q1)*q3d, 0, 0, 0, 0, cos(q1), -sin(q1), 0],
                        [0, 4/5, 0, 0, 0, 0, 0, 6*q3d/5],
                        [0, 0, 0, 0, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0, -2*q3d, 0, 0]])
        B_sol = Matrix([])

        # Check that linearization is correct
>       assert A.subs(upright_nominal) == A_sol
E       assert Matrix([\n[                               0,   0, 0, 0, 0,                     ...  0, 0, 0, 0, -2*Derivative(q3(t), t),           0,                        0]]) == Matrix([\n[                               0, 0, 0, 0, 0,                       ..., 0, 0, 0, 0, -2*Derivative(q3(t), t),           0,                        0]])
E        +  where Matrix([\n[                               0,   0, 0, 0, 0,                     ...  0, 0, 0, 0, -2*Derivative(q3(t), t),           0,                        0]]) = <bound method MutableDenseMatrix.subs of Matrix([\n[                           ...          0,                                                              0]])>({q2(t): 0, m: 1, g: 1, r: 1, ...})
E        +    where <bound method MutableDenseMatrix.subs of Matrix([\n[                           ...          0,                                                              0]])> = Matrix([\n[                                                                    ...           0,                                                              0]]).subs

sympy/physics/mechanics/tests/test_linearize.py:121: AssertionError
________________________________ test_studentt _________________________________

    def test_studentt():
        nu = Symbol("nu", positive=True)

        X = StudentT('x', nu)
>       assert density(X)(x) == (1 + x**2/nu)**(-nu/2 - 1/2)/(sqrt(nu)*beta(1/2, nu/2))
E       assert (1 + x**2/nu)**(-nu/2 - 1/2)/(sqrt(nu)*beta(1/2, nu/2)) == (((1 + ((x ** 2) / nu)) ** ((-nu / 2) - (1 / 2))) / (sqrt(nu) * beta(0, nu/2)))
E        +  where (1 + x**2/nu)**(-nu/2 - 1/2)/(sqrt(nu)*beta(1/2, nu/2)) = StudentTDistribution(nu)(x)
E        +    where StudentTDistribution(nu) = density(x)
E        +  and   sqrt(nu) = sqrt(nu)
E        +  and   beta(0, nu/2) = beta((1 / 2), (nu / 2))

sympy/stats/tests/test_continuous_rv.py:437: AssertionError
__________________________________ test_kbins __________________________________

    def test_kbins():
        assert len(list(kbins('1123', 2, ordered=1))) == 24
        assert len(list(kbins('1123', 2, ordered=11))) == 36
        assert len(list(kbins('1123', 2, ordered=10))) == 10
        assert len(list(kbins('1123', 2, ordered=0))) == 5
        assert len(list(kbins('1123', 2, ordered=None))) == 3

        def test():
            for ordered in [None, 0, 1, 10, 11]:
                print('ordered =', ordered)
                for p in kbins([0, 0, 1], 2, ordered=ordered):
                    print('   ', p)
>       assert capture(lambda : test()) == dedent('''\
            ordered = None
                [[0], [0, 1]]
                [[0, 0], [1]]
            ordered = 0
                [[0, 0], [1]]
                [[0, 1], [0]]
            ordered = 1
                [[0], [0, 1]]
                [[0], [1, 0]]
                [[1], [0, 0]]
            ordered = 10
                [[0, 0], [1]]
                [[1], [0, 0]]
                [[0, 1], [0]]
                [[0], [0, 1]]
            ordered = 11
                [[0], [0, 1]]
                [[0, 0], [1]]
                [[0], [1, 0]]
                [[0, 1], [0]]
                [[1], [0, 0]]
                [[1, 0], [0]]\n''')
E       assert "('ordered ='..., 0], [0]])\n" == 'ordered = Non...1, 0], [0]]\n'
E         Detailed information truncated, use "-vv" to show

sympy/utilities/tests/test_iterables.py:629: AssertionError
                                DO *NOT* COMMIT!                                
 6402 tests deselected by '-ktest_linearize_rolling_disc_kane or test_studentt or test_kbins or test_type_F' 
======= 4 failed, 6402 deselected, 1 warnings, 1 error in 25.89 seconds ========
```
- PR

``` bash
$ py.test sympy/liealgebras/tests/test_type_F.py 
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3
architecture: 64-bit
cache:        yes
ground types: python 

collected 1 items 

sympy/liealgebras/tests/test_type_F.py F

=================================== FAILURES ===================================
_________________________________ test_type_F __________________________________

    def test_type_F():
        c = CartanType("F4")
        m = Matrix(4, 4, [2, -1, 0, 0, -1, 2, -2, 0, 0, -1, 2, -1, 0, 0, -1, 2])
        assert c.cartan_matrix() == m
        assert c.dimension() == 4
        assert c.simple_root(3) == [0, 0, 0, 1]
        assert c.simple_root(4) == [-0.5, -0.5, -0.5, -0.5]
        assert c.roots() == 48
        assert c.basis() == 52
        diag = "0---0=>=0---0\n" + "   ".join(str(i) for i in range(1, 5))
        assert c.dynkin_diagram() == diag
>       assert c.positive_roots() == {1: [1, -1, 0, 0], 2: [1, 1, 0, 0], 3: [1, 0, -1, 0],
                4: [1, 0, 1, 0], 5: [1, 0, 0, -1], 6: [1, 0, 0, 1], 7: [0, 1, -1, 0],
                8: [0, 1, 1, 0], 9: [0, 1, 0, -1], 10: [0, 1, 0, 1], 11: [0, 0, 1, -1],
                12: [0, 0, 1, 1], 13: [1, 0, 0, 0], 14: [0, 1, 0, 0], 15: [0, 0, 1, 0],
                16: [0, 0, 0, 1], 17: [1/2, 1/2, 1/2, 1/2], 18: [1/2, -1/2, 1/2, 1/2],
                19: [1/2, 1/2, -1/2, 1/2], 20: [1/2, 1/2, 1/2, -1/2], 21: [1/2, 1/2, -1/2, -1/2],
                22: [1/2, -1/2, 1/2, -1/2], 23: [1/2, -1/2, -1/2, 1/2], 24: [1/2, -1/2, -1/2, -1/2]}
E       assert {1: [1, -1, 0...0, 1, 0], ...} == {1: [1, -1, 0,...0, 1, 0], ...}
E         Omitting 16 identical items, use -v to show
E         Differing items:
E         {17: [1/2, 1/2, 1/2, 1/2]} != {17: [0, 0, 0, 0]}
E         {18: [1/2, -1/2, 1/2, 1/2]} != {18: [0, -1, 0, 0]}
E         {19: [1/2, 1/2, -1/2, 1/2]} != {19: [0, 0, -1, 0]}
E         {20: [1/2, 1/2, 1/2, -1/2]} != {20: [0, 0, 0, -1]}
E         {21: [1/2, 1/2, -1/2, -1/2]} != {21: [0, 0, -1, -1]}
E         {22: [1/2, -1/2, 1/2, -1/2]} != {22: [0, -1, 0, -1]}
E         {23: [1/2, -1/2, -1/2, 1/2]} != {23: [0, -1, -1, 0]}
E         {24: [1/2, -1/2, -1/2, -1/2]} != {24: [0, -1, -1, -1]}

sympy/liealgebras/tests/test_type_F.py:15: AssertionError
                                DO *NOT* COMMIT!                                
=========================== 1 failed in 0.04 seconds ===========================

```
- PR

``` bash
$ py.test -k "test_linearize_rolling_disc_kane or test_studentt or test_kbins or test_type_F"
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3
collected 6406 items / 1 errors 

sympy/liealgebras/tests/test_type_F.py .
sympy/physics/mechanics/tests/test_linearize.py .
sympy/stats/tests/test_continuous_rv.py .
sympy/utilities/tests/test_iterables.py .

==================================== ERRORS ====================================
___________ ERROR collecting sympy/liealgebras/tests/test_type_G.py ____________
../../miniconda3/envs/py27/lib/python2.7/site-packages/_pytest/python.py:463: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=True)
../../miniconda3/envs/py27/lib/python2.7/site-packages/py/_path/local.py:642: in pyimport
    __import__(modname)
E     File "/home/ptb/gitrepos/sympy/sympy/liealgebras/tests/test_type_G.py", line 12
E   SyntaxError: Non-ASCII character '\xe2' in file /home/ptb/gitrepos/sympy/sympy/liealgebras/tests/test_type_G.py on line 12, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
                                DO *NOT* COMMIT!                                
 6402 tests deselected by '-ktest_linearize_rolling_disc_kane or test_studentt or test_kbins or test_type_F' 
======= 4 passed, 6402 deselected, 1 warnings, 1 error in 25.86 seconds ========
```

The encoding error is already handled via #8174 
