### PR TITLE
Add support for bidirectional limits (dir="real")

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -597,7 +597,7 @@ class LatexPrinter(Printer):
         e, z, z0, dir = expr.args
 
         tex = r"\lim_{%s \to " % self._print(z)
-        if z0 in (S.Infinity, S.NegativeInfinity):
+        if str(dir) == "real" or z0 in (S.Infinity, S.NegativeInfinity):
             tex += r"%s}" % self._print(z0)
         else:
             tex += r"%s^%s}" % (self._print(z0), self._print(dir))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -556,7 +556,7 @@ class PrettyPrinter(Printer):
             LimArg = prettyForm(*LimArg.right('->'))
         LimArg = prettyForm(*LimArg.right(self._print(z0)))
 
-        if z0 in (S.Infinity, S.NegativeInfinity):
+        if str(dir) == "real" or z0 in (S.Infinity, S.NegativeInfinity):
             dir = ""
         else:
             if self._use_unicode:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3116,6 +3116,22 @@ x─→0⁻  x   \
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+    expr = Limit(sin(x)/x, x, 0, "real")
+    ascii_str = \
+"""\
+    sin(x)\n\
+lim ------\n\
+x->0  x   \
+"""
+    ucode_str = \
+u("""\
+    sin(x)\n\
+lim ──────\n\
+x─→0  x   \
+""")
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
 
 def test_pretty_RootOf():
     expr = RootOf(x**5 + 11*x - 2, 0)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -558,6 +558,7 @@ def test_latex_limits():
     f = Function('f')
     assert latex(Limit(f(x), x, 0)) == r"\lim_{x \to 0^+} f{\left (x \right )}"
     assert latex(Limit(f(x), x, 0, "-")) == r"\lim_{x \to 0^-} f{\left (x \right )}"
+    assert latex(Limit(f(x), x, 0, "real")) == r"\lim_{x \to 0} f{\left (x \right )}"
 
 
 def test_issue_3568():

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -98,9 +98,9 @@ class Limit(Expr):
             dir = Symbol(dir)
         elif not isinstance(dir, Symbol):
             raise TypeError("direction must be of type basestring or Symbol, not %s" % type(dir))
-        if str(dir) not in ('+', '-'):
+        if str(dir) not in ('+', '-', 'real'):
             raise ValueError(
-                "direction must be either '+' or '-', not %s" % dir)
+                "direction must be either '+' or '-' or 'real', not %s" % dir)
 
         obj = Expr.__new__(cls)
         obj._args = (e, z, z0, dir)
@@ -114,6 +114,15 @@ class Limit(Expr):
             e = e.doit(**hints)
             z = z.doit(**hints)
             z0 = z0.doit(**hints)
+
+        if str(dir) == 'real':
+            right = limit(e, z, z0, "+")
+            left = limit(e, z, z0, "-")
+            if not (left - right).equals(0):
+                raise PoleError("left and right limits for expression %s at "
+                                "point %s=%s seems to be not equal" % (e, z, z0))
+            else:
+                return right
 
         if e == z:
             return z0

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -3,7 +3,7 @@ from itertools import product as cartes
 from sympy import (
     limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
     atan, gamma, Symbol, S, pi, Integral, cot, Rational, I, zoo,
-    tan, cot, integrate, Sum, sign, Function, subfactorial)
+    tan, cot, integrate, Sum, sign, Function, subfactorial, PoleError)
 
 from sympy.series.limits import heuristics
 from sympy.series.order import Order
@@ -67,6 +67,10 @@ def test_basic1():
     assert limit(sqrt(x), x, 0, dir='-') == 0
     assert limit(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
     assert limit((1 + cos(x))**oo, x, 0) == oo
+
+    assert limit(x**2, x, 0, dir='real') == 0
+    assert limit(exp(x), x, 0, dir='real') == 1
+    raises(PoleError, lambda: limit(1/x, x, 0, dir='real'))
 
 
 def test_basic2():


### PR DESCRIPTION
- [ ] Do we need this at all? 1) We don't have specific algorithms for bidirectional limits yet.  2) Not all CAS support this conception, see e.g. [Mathematica](http://reference.wolfram.com/language/ref/Limit.html).
- [ ] Better name for dir value? (variants: "0", "both" or just None); "real" is [from the Maple](http://www.maplesoft.com/support/help/Maple/view.aspx?path=limit/dir).
- [ ] Raise different errors for [discontinuities of different type](http://en.wikipedia.org/wiki/Classification_of_discontinuities).
