### PR TITLE
Increase default cache size from 500 to 1000

### DIFF
--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -179,7 +179,7 @@ USE_CACHE = _getenv('SYMPY_USE_CACHE', 'yes').lower()
 # special cases :
 #  SYMPY_CACHE_SIZE=0    -> No caching
 #  SYMPY_CACHE_SIZE=None -> Unbounded caching
-scs = _getenv('SYMPY_CACHE_SIZE','500')
+scs = _getenv('SYMPY_CACHE_SIZE','1000')
 if scs.lower() == 'none':
     SYMPY_CACHE_SIZE = None
 else:


### PR DESCRIPTION
The default cache size is currently set at 500.  It turns that this may be overly conservative as discussed in #8191 where the default cache size leads to a Jacobian calculation takings 60 min+ while increasing the cache size to 1000 leads to a tremendous speedup:

``` bash
$ SYMPY_CACHE_SIZE=1000 ipython
Python 3.4.1 |Continuum Analytics, Inc.| (default, Sep 10 2014, 17:10:18) 
Type "copyright", "credits" or "license" for more information.

IPython 2.2.0 -- An enhanced Interactive Python.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from sympy import sympify

In [2]: A = sympify(open("dis_eom.txt").read())

In [3]: x = sympify(open("partials.txt").read())

In [4]: %time A_jac = A.jacobian(x)
CPU times: user 1min 50s, sys: 1.03 s, total: 1min 51s
Wall time: 1min 51s

In [5]: 
```

I've run a few of the more intensive tests (i.e., test_wester.py) and haven't noticed a significant change in the memory foot print.
