### PR TITLE
Added a C code printing method for the sign function.

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -182,7 +182,7 @@ class CCodePrinter(CodePrinter):
             return expr.name
 
     def _print_sign(self, func):
-       return '((({0}) > 0) - (({0}) < 0))'.format(func.args[0])
+        return '((({0}) > 0) - (({0}) < 0))'.format(self._print(func.args[0]))
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -181,6 +181,9 @@ class CCodePrinter(CodePrinter):
         else:
             return expr.name
 
+    def _print_sign(self, func):
+       return '((({0}) > 0) - (({0}) < 0))'.format(func.args[0])
+
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -450,4 +450,7 @@ def test_ccode_sign():
     assert ccode(expr, 'z') == 'z = y*(((x) > 0) - ((x) < 0));'
 
     assert ccode(sign(2 * x + x**2) * x + x**2) == \
-        'pow(x, 2) + x*(((x**2 + 2*x) > 0) - ((x**2 + 2*x) < 0))'
+        'pow(x, 2) + x*(((pow(x, 2) + 2*x) > 0) - ((pow(x, 2) + 2*x) < 0))'
+
+    expr = sign(cos(x))
+    assert ccode(expr) == '(((cos(x)) > 0) - ((cos(x)) < 0))'

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -1,5 +1,7 @@
-from sympy.core import pi, oo, symbols, Function, Rational, Integer, GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq
-from sympy.functions import Piecewise, sin, cos, Abs, exp, ceiling, sqrt, gamma
+from sympy.core import (pi, oo, symbols, Function, Rational, Integer,
+                        GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq)
+from sympy.functions import (Piecewise, sin, cos, Abs, exp, ceiling, sqrt,
+                             gamma, sign)
 from sympy.utilities.pytest import raises
 from sympy.printing.ccode import CCodePrinter
 from sympy.utilities.lambdify import implemented_function
@@ -439,3 +441,13 @@ def test_Matrix_printing():
         "M[6] = 2*q[4]*1.0/q[1];\n"
         "M[7] = 4 + sqrt(q[0]);\n"
         "M[8] = 0;")
+
+
+def test_ccode_sign():
+
+    expr = sign(x) * y
+    assert ccode(expr) == 'y*(((x) > 0) - ((x) < 0))'
+    assert ccode(expr, 'z') == 'z = y*(((x) > 0) - ((x) < 0));'
+
+    assert ccode(sign(2 * x + x**2) * x + x**2) == \
+        'pow(x, 2) + x*(((x**2 + 2*x) > 0) - ((x**2 + 2*x) < 0))'


### PR DESCRIPTION
Is there a better way to specify specific printing for a function that doesn't map to a keyword in the target language? This sign function implementation is also valid in Python and maybe some other languages too. Also, I'm not sure why C doesn't have a sign function in the math library or something. Here is a Stackoverflow showing some implementations: http://stackoverflow.com/questions/1903954/is-there-a-standard-sign-function-signum-sgn-in-c-c
