### PR TITLE
Added reserved words functionality to CodePrinter.

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -214,10 +214,13 @@ class CCodePrinter(CodePrinter):
                 expr.i*expr.parent.shape[1])
 
     def _print_Symbol(self, expr):
+
+        name = super(CCodePrinter, self)._print_Symbol(expr)
+
         if expr in self._dereference:
-            return '(*{0})'.format(expr.name)
+            return '(*{0})'.format(name)
         else:
-            return super(CCodePrinter, self)._print_Symbol(expr)
+            return name
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -102,7 +102,7 @@ class CCodePrinter(CodePrinter):
         userfuncs = settings.get('user_functions', {})
         self.known_functions.update(userfuncs)
         self._dereference = set(settings.get('dereference', []))
-        self.reserved_words.update(reserved_words)
+        self.reserved_words = set(reserved_words)
 
     def _rate_index_position(self, p):
         return p*5

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -102,7 +102,7 @@ class CCodePrinter(CodePrinter):
         userfuncs = settings.get('user_functions', {})
         self.known_functions.update(userfuncs)
         self._dereference = set(settings.get('dereference', []))
-        self.reserved_words = reserved_words
+        self.reserved_words.update(reserved_words)
 
     def _rate_index_position(self, p):
         return p*5
@@ -212,18 +212,6 @@ class CCodePrinter(CodePrinter):
     def _print_MatrixElement(self, expr):
         return "{0}[{1}]".format(expr.parent, expr.j +
                 expr.i*expr.parent.shape[1])
-
-    def _print_Symbol(self, expr):
-
-        if expr.name in self.reserved_words:
-            name = '_' + expr.name
-        else:
-            name = expr.name
-
-        if expr in self._dereference:
-            return '(*{0})'.format(name)
-        else:
-            return name
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -13,7 +13,7 @@ source code files that are compilable without further modifications.
 
 from __future__ import print_function, division
 
-from sympy.core import S, C
+from sympy.core import S
 from sympy.core.compatibility import string_types
 from sympy.printing.codeprinter import CodePrinter, Assignment
 from sympy.printing.precedence import precedence
@@ -43,6 +43,43 @@ known_functions = {
     "ceiling": "ceil",
 }
 
+# These are the core reserved words in the C language. Taken from:
+# http://crasseux.com/books/ctutorial/Reserved-words-in-C.html
+
+reserved_words = ['auto',
+                  'if',
+                  'break',
+                  'int',
+                  'case',
+                  'long',
+                  'char',
+                  'register',
+                  'continue',
+                  'return',
+                  'default',
+                  'short',
+                  'do',
+                  'sizeof',
+                  'double',
+                  'static',
+                  'else',
+                  'struct',
+                  'entry',
+                  'switch',
+                  'extern',
+                  'typedef',
+                  'float',
+                  'union',
+                  'for',
+                  'unsigned',
+                  'goto',
+                  'while',
+                  'enum',
+                  'void',
+                  'const',
+                  'signed',
+                  'volatile']
+
 
 class CCodePrinter(CodePrinter):
     """A printer to convert python expressions to strings of c code"""
@@ -65,6 +102,7 @@ class CCodePrinter(CodePrinter):
         userfuncs = settings.get('user_functions', {})
         self.known_functions.update(userfuncs)
         self._dereference = set(settings.get('dereference', []))
+        self.reserved_words = reserved_words
 
     def _rate_index_position(self, p):
         return p*5
@@ -176,10 +214,16 @@ class CCodePrinter(CodePrinter):
                 expr.i*expr.parent.shape[1])
 
     def _print_Symbol(self, expr):
-        if expr in self._dereference:
-            return '(*{0})'.format(expr.name)
+
+        if expr.name in self.reserved_words:
+            name = '_' + expr.name
         else:
-            return expr.name
+            name = expr.name
+
+        if expr in self._dereference:
+            return '(*{0})'.format(name)
+        else:
+            return name
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -93,7 +93,9 @@ class CCodePrinter(CodePrinter):
         'user_functions': {},
         'human': True,
         'contract': True,
-        'dereference': set()
+        'dereference': set(),
+        'error_on_reserved': False,
+        'reserved_word_suffix': '_',
     }
 
     def __init__(self, settings={}):

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -213,6 +213,12 @@ class CCodePrinter(CodePrinter):
         return "{0}[{1}]".format(expr.parent, expr.j +
                 expr.i*expr.parent.shape[1])
 
+    def _print_Symbol(self, expr):
+        if expr in self._dereference:
+            return '(*{0})'.format(expr.name)
+        else:
+            return super(CCodePrinter, self)._print_Symbol(expr)
+
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
 

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -330,10 +330,12 @@ class CodePrinter(StrPrinter):
 
     def _print_Symbol(self, expr):
 
-        if expr.name in self.reserved_words:
-            return self._reserved_word_prefix + expr.name
+        name = super(CodePrinter, self)._print_Symbol(expr)
+
+        if name in self.reserved_words:
+            return self._reserved_word_prefix + name
         else:
-            return super(CodePrinter, self)._print_Symbol(expr)
+            return name
 
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -88,6 +88,9 @@ class CodePrinter(StrPrinter):
         'not': '!',
     }
 
+    reserved_words = set()
+    _reserved_word_prefix = '_'
+
     def doprint(self, expr, assign_to=None):
         """
         Print the expression as code.
@@ -324,6 +327,13 @@ class CodePrinter(StrPrinter):
             lhs_code = self._print(lhs)
             rhs_code = self._print(rhs)
             return self._get_statement("%s = %s" % (lhs_code, rhs_code))
+
+    def _print_Symbol(self, expr):
+
+        if expr.name in self.reserved_words:
+            return self._reserved_word_prefix + expr.name
+        else:
+            return super(CodePrinter, self)._print_Symbol(expr)
 
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -88,10 +88,15 @@ class CodePrinter(StrPrinter):
         'not': '!',
     }
 
-    _reserved_word_prefix = '_'
+    _default_settings = {'order': None,
+                         'full_prec': 'auto',
+                         'error_on_reserved': False,
+                         'reserved_word_suffix': '_'}
 
     def __init__(self, settings=None):
+
         super(CodePrinter, self).__init__(settings=settings)
+
         self.reserved_words = set()
 
     def doprint(self, expr, assign_to=None):
@@ -336,7 +341,11 @@ class CodePrinter(StrPrinter):
         name = super(CodePrinter, self)._print_Symbol(expr)
 
         if name in self.reserved_words:
-            return self._reserved_word_prefix + name
+            if self._settings['error_on_reserved']:
+                msg = ('This expression includes the symbol "{}" which is a '
+                       'reserved keyword in this language.')
+                raise ValueError(msg.format(name))
+            return name + self._settings['reserved_word_suffix']
         else:
             return name
 

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -88,8 +88,11 @@ class CodePrinter(StrPrinter):
         'not': '!',
     }
 
-    reserved_words = set()
     _reserved_word_prefix = '_'
+
+    def __init__(self, settings=None):
+        super(CodePrinter, self).__init__(settings=settings)
+        self.reserved_words = set()
 
     def doprint(self, expr, assign_to=None):
         """

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -447,8 +447,14 @@ def test_ccode_reserved_words():
 
     x, y = symbols('x, if')
 
-    assert ccode(y**2) == 'pow(_if, 2)'
-    assert ccode(x * y**2, dereference=[y]) == 'pow((*_if), 2)*x'
+    assert ccode(y**2) == 'pow(if_, 2)'
+    assert ccode(x * y**2, dereference=[y]) == 'pow((*if_), 2)*x'
+
+    expected = 'pow(if_unreserved, 2)'
+    assert ccode(y**2, reserved_word_suffix='_unreserved') == expected
+
+    with raises(ValueError):
+        ccode(y**2, error_on_reserved=True)
 
 
 def test_ccode_sign():

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -442,6 +442,7 @@ def test_Matrix_printing():
 
 def test_ccode_reserved_words():
 
-    a_symbol = symbols('if')
+    x, y = symbols('x, if')
 
-    assert ccode(a_symbol**2) == 'pow(_if, 2)'
+    assert ccode(y**2) == 'pow(_if, 2)'
+    assert ccode(x * y**2, dereference=[y]) == 'pow((*_if), 2)*x'

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -439,3 +439,9 @@ def test_Matrix_printing():
         "M[6] = 2*q[4]*1.0/q[1];\n"
         "M[7] = 4 + sqrt(q[0]);\n"
         "M[8] = 0;")
+
+def test_ccode_reserved_words():
+
+    a_symbol = symbols('if')
+
+    assert ccode(a_symbol**2) == 'pow(_if, 2)'

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -1,9 +1,9 @@
 from sympy.printing.codeprinter import CodePrinter, Assignment
-from sympy.printing.ccode import ccode
 from sympy.core import C, symbols
 from sympy.matrices import MatrixSymbol, Matrix
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.pytest import raises
+
 
 def setup_test_printer(*args, **kwargs):
     p = CodePrinter(*args, **kwargs)
@@ -11,14 +11,12 @@ def setup_test_printer(*args, **kwargs):
     p._number_symbols = set()
     return p
 
+
 def test_print_Dummy():
     d = C.Dummy('d')
     p = setup_test_printer()
     assert p._print_Dummy(d) == "d_%i" % d.dummy_index
 
-def test_print_Mul():
-    x, y = symbols("x y")
-    s = ccode(x ** (-3) * y ** (-2))
 
 def test_Assignment():
     x, y = symbols("x, y")
@@ -52,9 +50,16 @@ def test_Assignment():
     raises(TypeError, lambda: Assignment(A + A, mat))
     raises(TypeError, lambda: Assignment(B, 0))
 
+
 def test_print_Symbol():
     x, y = symbols('x, if')
     p = setup_test_printer()
+    print(p.reserved_words)
+    # If I include the following two line the tests fail because
+    # p.reserved_words somehow obtains those from the CCodePrinter.
+    from sympy import ccode
+    ccode(x)
+    print(p.reserved_words)
     assert p._print(x) == 'x'
     assert p._print(y) == 'if'
     p.reserved_words.update(['if'])

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -51,3 +51,11 @@ def test_Assignment():
     raises(TypeError, lambda: Assignment(x*x, 1))
     raises(TypeError, lambda: Assignment(A + A, mat))
     raises(TypeError, lambda: Assignment(B, 0))
+
+def test_print_Symbol():
+    x, y = symbols('x, if')
+    p = setup_test_printer()
+    assert p._print(x) == 'x'
+    assert p._print(y) == 'if'
+    p.reserved_words.update(['if'])
+    assert p._print(y) == '_if'

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -54,12 +54,6 @@ def test_Assignment():
 def test_print_Symbol():
     x, y = symbols('x, if')
     p = setup_test_printer()
-    print(p.reserved_words)
-    # If I include the following two line the tests fail because
-    # p.reserved_words somehow obtains those from the CCodePrinter.
-    from sympy import ccode
-    ccode(x)
-    print(p.reserved_words)
     assert p._print(x) == 'x'
     assert p._print(y) == 'if'
     p.reserved_words.update(['if'])

--- a/sympy/printing/tests/test_codeprinter.py
+++ b/sympy/printing/tests/test_codeprinter.py
@@ -5,8 +5,8 @@ from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.pytest import raises
 
 
-def setup_test_printer(*args, **kwargs):
-    p = CodePrinter(*args, **kwargs)
+def setup_test_printer(**kwargs):
+    p = CodePrinter(settings=kwargs)
     p._not_supported = set()
     p._number_symbols = set()
     return p
@@ -52,9 +52,21 @@ def test_Assignment():
 
 
 def test_print_Symbol():
+
     x, y = symbols('x, if')
+
     p = setup_test_printer()
     assert p._print(x) == 'x'
     assert p._print(y) == 'if'
+
     p.reserved_words.update(['if'])
-    assert p._print(y) == '_if'
+    assert p._print(y) == 'if_'
+
+    p = setup_test_printer(error_on_reserved=True)
+    p.reserved_words.update(['if'])
+    with raises(ValueError):
+        p._print(y)
+
+    p = setup_test_printer(reserved_word_suffix='_He_Man')
+    p.reserved_words.update(['if'])
+    assert p._print(y) == 'if_He_Man'

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -112,9 +112,9 @@ def test_c_code_reserved_words():
     expected = (
         "#include \"file.h\"\n"
         "#include <math.h>\n"
-        "double test(double _if, double _typedef, double _while) {\n"
+        "double test(double if_, double typedef_, double while_) {\n"
         "   double test_result;\n"
-        "   test_result = _while*(_if + _typedef);\n"
+        "   test_result = while_*(if_ + typedef_);\n"
         "   return test_result;\n"
         "}\n"
     )
@@ -497,10 +497,10 @@ def test_output_arg_c_reserved_words():
     expected = (
         '#include "test.h"\n'
         '#include <math.h>\n'
-        'double foo(double _if, double *_while) {\n'
-        '   (*_while) = sin(_if);\n'
+        'double foo(double if_, double *while_) {\n'
+        '   (*while_) = sin(if_);\n'
         '   double foo_result;\n'
-        '   foo_result = cos(_if);\n'
+        '   foo_result = cos(if_);\n'
         '   return foo_result;\n'
         '}\n'
     )

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -102,6 +102,24 @@ def test_simple_c_code():
     assert source == expected
 
 
+def test_c_code_reserved_words():
+    x, y, z = symbols('if, typedef, while')
+    expr = (x + y) * z
+    routine = Routine("test", expr)
+    code_gen = CCodeGen()
+    source = get_string(code_gen.dump_c, [routine])
+    expected = (
+        "#include \"file.h\"\n"
+        "#include <math.h>\n"
+        "double test(double _if, double _typedef, double _while) {\n"
+        "   double test_result;\n"
+        "   test_result = _while*(_if + _typedef);\n"
+        "   return test_result;\n"
+        "}\n"
+    )
+    assert source == expected
+
+
 def test_numbersymbol_c_code():
     routine = Routine("test", pi**Catalan)
     code_gen = CCodeGen()

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -486,6 +486,26 @@ def test_output_arg_c():
     assert result[0][1] == expected
 
 
+def test_output_arg_c_reserved_words():
+    from sympy import sin, cos, Equality
+    x, y, z = symbols("if, while, z")
+    r = Routine("foo", [Equality(y, sin(x)), cos(x)])
+    c = CCodeGen()
+    result = c.write([r], "test", header=False, empty=False)
+    assert result[0][0] == "test.c"
+    expected = (
+        '#include "test.h"\n'
+        '#include <math.h>\n'
+        'double foo(double _if, double *_while) {\n'
+        '   (*_while) = sin(_if);\n'
+        '   double foo_result;\n'
+        '   foo_result = cos(_if);\n'
+        '   return foo_result;\n'
+        '}\n'
+    )
+    assert result[0][1] == expected
+
+
 def test_empty_f_code():
     code_gen = FCodeGen()
     source = get_string(code_gen.dump_f95, [])


### PR DESCRIPTION
This fixes issue #8190 for the C code printer. If the user has a symbol name
that matches a core reserved word in the C language it gets an underscore as a
prefix.
- [x] make the prefix a suffix
- [x] make the suffix easily configurable
