### PR TITLE
Printing support for directional limits

### DIFF
--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -244,9 +244,9 @@ counterpart, ``Limit``.  To evaluate it, use ``doit``.
 
     >>> expr = Limit((cos(x) - 1)/x, x, 0)
     >>> expr
-        cos(x) - 1
-    lim ──────────
-    x->0    x
+         cos(x) - 1
+     lim ──────────
+    x->0⁺    x
     >>> expr.doit()
     0
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -562,8 +562,11 @@ class LatexPrinter(Printer):
     def _print_Limit(self, expr):
         e, z, z0, dir = expr.args
 
-        tex = r"\lim_{%s \to %s}" % (self._print(z),
-                                     self._print(z0))
+        tex = r"\lim_{%s \to " % self._print(z)
+        if z0 in (S.Infinity, S.NegativeInfinity):
+            tex += r"%s}" % self._print(z0)
+        else:
+            tex += r"%s^%s}" % (self._print(z0), self._print(dir))
 
         if isinstance(e, C.AssocOp):
             return r"%s\left(%s\right)" % (tex, self._print(e))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -544,7 +544,6 @@ class PrettyPrinter(Printer):
         return prettyF
 
     def _print_Limit(self, l):
-        # XXX we do not print dir ...
         e, z, z0, dir = l.args
 
         E = self._print(e)
@@ -553,6 +552,14 @@ class PrettyPrinter(Printer):
         LimArg = self._print(z)
         LimArg = prettyForm(*LimArg.right('->'))
         LimArg = prettyForm(*LimArg.right(self._print(z0)))
+
+        if z0 in (S.Infinity, S.NegativeInfinity):
+            dir = ""
+        else:
+            if self._use_unicode:
+                dir = u('\u207A') if str(dir) == "+" else u('\u207B')
+
+        LimArg = prettyForm(*LimArg.right(self._print(dir)))
 
         Lim = prettyForm(*Lim.below(LimArg))
         Lim = prettyForm(*Lim.right(E))

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3024,15 +3024,15 @@ x->∞ \
     expr = Limit(x**2, x, 0)
     ascii_str = \
 """\
-     2\n\
-lim x \n\
-x->0  \
+      2\n\
+ lim x \n\
+x->0+  \
 """
     ucode_str = \
 u("""\
-     2\n\
-lim x \n\
-x->0  \
+      2\n\
+ lim x \n\
+x->0⁺  \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3040,15 +3040,15 @@ x->0  \
     expr = Limit(1/x, x, 0)
     ascii_str = \
 """\
-    1\n\
-lim -\n\
-x->0x\
+     1\n\
+ lim -\n\
+x->0+x\
 """
     ucode_str = \
 u("""\
-    1\n\
-lim ─\n\
-x->0x\
+     1\n\
+ lim ─\n\
+x->0⁺x\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3056,15 +3056,31 @@ x->0x\
     expr = Limit(sin(x)/x, x, 0)
     ascii_str = \
 """\
-    sin(x)\n\
-lim ------\n\
-x->0  x   \
+     sin(x)\n\
+ lim ------\n\
+x->0+  x   \
 """
     ucode_str = \
 u("""\
-    sin(x)\n\
-lim ──────\n\
-x->0  x   \
+     sin(x)\n\
+ lim ──────\n\
+x->0⁺  x   \
+""")
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = Limit(sin(x)/x, x, 0, "-")
+    ascii_str = \
+"""\
+     sin(x)\n\
+ lim ------\n\
+x->0-  x   \
+"""
+    ucode_str = \
+u("""\
+     sin(x)\n\
+ lim ──────\n\
+x->0⁻  x   \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -553,6 +553,11 @@ def test_latex_product():
 def test_latex_limits():
     assert latex(Limit(x, x, oo)) == r"\lim_{x \to \infty} x"
 
+    # issue 8175
+    f = Function('f')
+    assert latex(Limit(f(x), x, 0)) == r"\lim_{x \to 0^+} f{\left (x \right )}"
+    assert latex(Limit(f(x), x, 0, "-")) == r"\lim_{x \to 0^-} f{\left (x \right )}"
+
 
 def test_issue_3568():
     beta = Symbol(r'\beta')

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -638,9 +638,9 @@ def gruntz(e, z, z0, dir="+"):
     elif z0 == -oo:
         r = limitinf(e.subs(z, -z), z)
     else:
-        if dir == "-":
+        if str(dir) == "-":
             e0 = e.subs(z, z0 - 1/z)
-        elif dir == "+":
+        elif str(dir) == "+":
             e0 = e.subs(z, z0 + 1/z)
         else:
             raise NotImplementedError("dir must be '+' or '-'")

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -13,8 +13,9 @@ def limit(e, z, z0, dir="+"):
     z0 can be any expression, including oo and -oo.
 
     For dir="+" (default) it calculates the limit from the right
-    (z->z0+) and for dir="-" the limit from the left (z->z0-). For infinite z0
-    (oo or -oo), the dir argument doesn't matter.
+    (z->z0+) and for dir="-" the limit from the left (z->z0-).  For infinite
+    z0 (oo or -oo), the dir argument is determined from the direction
+    of the infinity (i.e., dir="-" for oo).
 
     Examples
     ========
@@ -91,6 +92,11 @@ class Limit(Expr):
         e = sympify(e)
         z = sympify(z)
         z0 = sympify(z0)
+
+        if z0 is S.Infinity:
+            dir = "-"
+        elif z0 is S.NegativeInfinity:
+            dir = "+"
 
         if isinstance(dir, string_types):
             dir = Symbol(dir)


### PR DESCRIPTION
Now:

```
In [1]: Limit(x, x, 0)
Out[1]: 
 lim x
x->0⁺ 

In [2]: Limit(x, x, 0, dir='-')
Out[2]: 
 lim x
x->0⁻ 

In [3]: init_printing(use_unicode=False)

In [4]: Limit(x, x, 0)
Out[4]: 
 lim x
x->0+ 

In [5]: Limit(x, x, 0, dir='-')
Out[5]: 
 lim x
x->0- 

```
