### PR TITLE
watch for leading negative on number in mathematica parser

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -39,7 +39,7 @@ def parse(s):
         (r"\A\((.+)\)([\w\.].*)\Z",  # Implied multiplication - (a)b
         lambda m: "(" + parse(m.group(1)) + ")*" + parse(m.group(2))),
 
-        (r"\A([\d\.]+)([a-zA-Z].*)\Z",  # Implied multiplicatin - 2a
+        (r"\A(-? *[\d\.]+)([a-zA-Z].*)\Z",  # Implied multiplication - 2a
         lambda m: parse(m.group(1)) + "*" + parse(m.group(2))),
 
         (r"\A([^=]+)([\^\-\*/\+=]=?)(.+)\Z",  # Infix operator

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -3,7 +3,9 @@ from sympy import sympify
 
 
 def test_mathematica():
-    d = {'Sin[x]^2': 'sin(x)**2',
+    d = {
+        '- 6x': '-6*x',
+        'Sin[x]^2': 'sin(x)**2',
         '2(x-1)': '2*(x-1)',
         '3y+8': '3*y+8',
         'Arcsin[2x+9(4-x)^2]/x': 'asin(2*x+9*(4-x)**2)/x',


### PR DESCRIPTION
issue identified at http://stackoverflow.com/questions/26249993/tex-commands-as-input-in-sympy/26261553

Before:

```
>>> mathematica('-6x')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\parsing\mathematica.py", line 8, in mathematica
    return sympify(parse(s))
  File "sympy\core\sympify.py", line 319, in sympify
    raise SympifyError('could not parse %r' % a, exc)
sympy.core.sympify.SympifyError: Sympify of expression 'could not parse u'-6x''
failed, because of exception being raised:
SyntaxError: invalid syntax (<string>, line 1)
```

After

```
>>> mathematica('-6x')
-6*x
```
