### PR TITLE
printing: fix srepr of empty Matrix with nonzero dimension

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -79,7 +79,7 @@ class ReprPrinter(Printer):
         return "[%s]" % self.reprify(expr, ", ")
 
     def _print_MatrixBase(self, expr):
-        # special case if either dimension is 0
+        # special case for some empty matrices
         if (expr.rows == 0) ^ (expr.cols == 0):
             return '%s(%s, %s, %s)' % (expr.__class__.__name__,
                                        self._print(expr.rows),

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -79,6 +79,12 @@ class ReprPrinter(Printer):
         return "[%s]" % self.reprify(expr, ", ")
 
     def _print_MatrixBase(self, expr):
+        # special case if either dimension is 0
+        if (expr.shape[0] == 0) ^ (expr.shape[1] == 0):
+            return '%s(%s, %s, %s)' % (expr.__class__.__name__,
+                                       self._print(expr.shape[0]),
+                                       self._print(expr.shape[1]),
+                                       self._print([]))
         l = []
         for i in range(expr.rows):
             l.append([])

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -80,10 +80,10 @@ class ReprPrinter(Printer):
 
     def _print_MatrixBase(self, expr):
         # special case if either dimension is 0
-        if (expr.shape[0] == 0) ^ (expr.shape[1] == 0):
+        if (expr.rows == 0) ^ (expr.cols == 0):
             return '%s(%s, %s, %s)' % (expr.__class__.__name__,
-                                       self._print(expr.shape[0]),
-                                       self._print(expr.shape[1]),
+                                       self._print(expr.rows),
+                                       self._print(expr.cols),
                                        self._print([]))
         l = []
         for i in range(expr.rows):

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,6 @@
 from sympy.utilities.pytest import raises
 from sympy import symbols, Function, Integer, Matrix, Abs, \
-    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false
+    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false, ones
 from sympy.core.compatibility import exec_
 from sympy.geometry import Point, Ellipse
 from sympy.printing import srepr
@@ -86,6 +86,12 @@ def test_Matrix():
         sT(cls(), "%s([])" % name)
 
         sT(cls([[x**+1, 1], [y, x + y]]), "%s([[Symbol('x'), Integer(1)], [Symbol('y'), Add(Symbol('x'), Symbol('y'))]])" % name)
+
+
+def test_empty_Matrix():
+    sT(ones(0, 3), "MutableDenseMatrix(0, 3, [])")
+    sT(ones(4, 0), "MutableDenseMatrix(4, 0, [])")
+    sT(ones(0, 0), "MutableDenseMatrix([])")
 
 
 def test_Rational():


### PR DESCRIPTION
`zeros(0, 3)`, `zeros(3, 0)`, and `zeros(0, 0)` all have srepr of
"MutableDenseMatrix([])".  This violates the "eval(srepr(expr))==expr"
idea.  Fix the ReprPrinter to instead produce e.g.,
"MutableDenseMatrix(0, 3, [])" which is consistent with StrPrinter (which
does distinguish between various empty matrices.)

Add tests.
