### PR TITLE
Print Limit arrows with unicode

### DIFF
--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -246,7 +246,7 @@ counterpart, ``Limit``.  To evaluate it, use ``doit``.
     >>> expr
          cos(x) - 1
      lim ──────────
-    x->0⁺    x
+    x─→0⁺    x
     >>> expr.doit()
     0
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -550,7 +550,10 @@ class PrettyPrinter(Printer):
         Lim = prettyForm('lim')
 
         LimArg = self._print(z)
-        LimArg = prettyForm(*LimArg.right('->'))
+        if self._use_unicode:
+            LimArg = prettyForm(*LimArg.right(u('\u2500\u2192')))
+        else:
+            LimArg = prettyForm(*LimArg.right('->'))
         LimArg = prettyForm(*LimArg.right(self._print(z0)))
 
         if z0 in (S.Infinity, S.NegativeInfinity):

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3016,7 +3016,7 @@ x->oo \
     ucode_str = \
 u("""\
 lim x\n\
-x->∞ \
+x─→∞ \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3032,7 +3032,7 @@ x->0+  \
 u("""\
       2\n\
  lim x \n\
-x->0⁺  \
+x─→0⁺  \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3048,7 +3048,7 @@ x->0+x\
 u("""\
      1\n\
  lim ─\n\
-x->0⁺x\
+x─→0⁺x\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3064,7 +3064,7 @@ x->0+  x   \
 u("""\
      sin(x)\n\
  lim ──────\n\
-x->0⁺  x   \
+x─→0⁺  x   \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3080,7 +3080,7 @@ x->0-  x   \
 u("""\
      sin(x)\n\
  lim ──────\n\
-x->0⁻  x   \
+x─→0⁻  x   \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str


### PR DESCRIPTION
```
In [1]: Limit(sin(x)/x, x, 0)
Out[1]: 
     sin(x)
 lim ──────
x─→0⁺  x   
```
