### PR TITLE
sorting in roots_quadratic should be same as in Poly.all_roots(radicals=False)

### DIFF
--- a/sympy/integrals/tests/test_quadrature.py
+++ b/sympy/integrals/tests/test_quadrature.py
@@ -361,10 +361,10 @@ def test_jacobi():
     assert [str(r) for r in w] == ['3.1415926535897932']
 
     x, w = gauss_jacobi(2, -S.Half, S.Half, 17)
-    assert [str(r) for r in x] == ['0.80901699437494742',
-                                   '-0.30901699437494742']
-    assert [str(r) for r in w] == ['2.2732777998989693',
-                                   '0.86831485369082398']
+    assert [str(r) for r in x] == ['-0.30901699437494742',
+                                   '0.80901699437494742']
+    assert [str(r) for r in w] == ['0.86831485369082398',
+                                   '2.2732777998989693']
 
     x, w = gauss_jacobi(3, -S.Half, S.Half, 17)
     assert [str(r) for r in x] == ['-0.62348980185873353',
@@ -401,10 +401,10 @@ def test_jacobi():
     assert [str(r) for r in w] == ['1.0666666666666667']
 
     x, w = gauss_jacobi(2, 2, 3, 17)
-    assert [str(r) for r in x] == ['0.46247529557426437',
-                                   '-0.24025307335204215']
-    assert [str(r) for r in w] == ['0.58152042148828007',
-                                   '0.48514624517838660']
+    assert [str(r) for r in x] == ['-0.24025307335204215',
+                                   '0.46247529557426437']
+    assert [str(r) for r in w] == ['0.48514624517838660',
+                                   '0.58152042148828007']
 
     x, w = gauss_jacobi(3, 2, 3, 17)
     assert [str(r) for r in x] == ['-0.46115870378089762',

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -84,7 +84,16 @@ def roots_quadratic(f):
             r0 = E + F
             r1 = E - F
 
-    return sorted([expand_2arg(i) for i in (r0, r1)], key=default_sort_key)
+    r0, r1 = sorted([expand_2arg(i) for i in (r0, r1)], key=default_sort_key)
+
+    if dom.is_Numerical:
+        d = r0 - r1
+        if d.is_imaginary:
+            d = im(d)
+        if d.is_positive:
+            r0, r1 = r1, r0
+
+    return [r0, r1]
 
 
 def roots_cubic(f, trig=False):

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -37,6 +37,11 @@ def test_roots_quadratic():
         [-e*(a + c)/(a - c) - sqrt((a*b + c*d - a*d - b*c + 4*a*c*e**2)/(a - c)**2),
          -e*(a + c)/(a - c) + sqrt((a*b + c*d - a*d - b*c + 4*a*c*e**2)/(a - c)**2)]
 
+    # issue 8255:
+    f = -24*x**2 - 180*x + 264
+    assert roots_quadratic(Poly(f, x)) == \
+        [-sqrt(401)/4 - Rational(15, 4), Rational(-15, 4) + sqrt(401)/4]
+
 
 def test_roots_cubic():
     assert roots_cubic(Poly(2*x**3, x)) == [0, 0, 0]

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -141,21 +141,21 @@ def test_linear_2eq_order2():
     assert dsolve(eq7) == sol7
 
     eq8 = (Eq(diff(x(t),t,t), t*(4*x(t) + 9*y(t))), Eq(diff(y(t),t,t), t*(12*x(t) - 6*y(t))))
-    sol8 = ("[x(t) == sqrt(133)*(-(-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
-    "C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) + (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + "
-    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) + 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) - "
-    "4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) - "
-    "4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192, y(t) == sqrt(133)*(C2*(133*t**8/24 - t**3/6 + "
-    "sqrt(133)*t**3/2 + 1) - C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) - "
+    sol8 = ("[x(t) == -sqrt(133)*((-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
+    "C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) - (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + "
+    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) - 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
+    "4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
+    "4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192, y(t) == -sqrt(133)*(-C2*(133*t**8/24 - t**3/6 + "
+    "sqrt(133)*t**3/2 + 1) + C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
     "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/266]")
     assert str(dsolve(eq8)) == sol8
 
     eq9 = (Eq(diff(x(t),t,t), t*(4*diff(x(t),t) + 9*diff(y(t),t))), Eq(diff(y(t),t,t), t*(12*diff(x(t),t) - 6*diff(y(t),t))))
-    sol9 = [Eq(x(t), sqrt(133)*(4*C1*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) + 4*C2 - \
-    4*C3*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) - 4*C4 - (-sqrt(133) - 1)*(C1*Integral(exp((-1 + \
-    sqrt(133))*Integral(t, t)), t) + C2) + (-1 + sqrt(133))*(C3*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) + \
-    C4))/3192), Eq(y(t), sqrt(133)*(C1*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) + C2 - \
-    C3*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) - C4)/266)]
+    sol9 = [Eq(x(t), -sqrt(133)*(4*C1*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) + 4*C2 - \
+    4*C3*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) - 4*C4 - (-1 + sqrt(133))*(C1*Integral(exp((-sqrt(133) - \
+    1)*Integral(t, t)), t) + C2) + (-sqrt(133) - 1)*(C3*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) + \
+    C4))/3192), Eq(y(t), -sqrt(133)*(C1*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) + C2 - \
+    C3*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) - C4)/266)]
     assert dsolve(eq9) == sol9
 
     eq10 = (t**2*diff(x(t),t,t) + 3*t*diff(x(t),t) + 4*t*diff(y(t),t) + 12*x(t) + 9*y(t), \


### PR DESCRIPTION
fixes #8255 

Reasons to change here (e.g. not in `RootOf._roots_trivial`): we should sort numerical roots consistently.

retracted ~~Position summary and counterpositions [here](https://github.com/sympy/sympy/pull/8237#discussion_r18917067)~~

TODO
- [ ] check other roots_\* functions, e.g. roots_cubic
