### PR TITLE
Explicitly test physics/quantum/qubit/qubit_values

### DIFF
--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -25,6 +25,7 @@ def test_Qubit():
     assert qb.flip(0) == Qubit('00111')
     assert qb.flip(1) == Qubit('00100')
     assert qb.flip(4) == Qubit('10110')
+    assert qb.qubit_values == (0, 0, 1, 1, 0)
     assert qb.dimension == 5
     for i in range(5):
         assert qb[i] == array[4 - i]


### PR DESCRIPTION
The unit test for Qubit doesn't explicitly test qubit_values (they are tested for IntQubit). Add an assertion for this

(I'm not sure how fine-grained the owners like pull requests - I have some other changes to make to test_qubit.py which are really just refactorings to make it easier to read, I'll add them as a separate pull request)

Give me a yell if there are any issues with this, ta
