### PR TITLE
sort quadratic and binomial roots; reverse (don't sort) roots in inequality handler

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -356,3 +356,4 @@ Mridul Seth <seth.mridul@gmail.com>
 Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
 ck Lux <lux.r.ck@gmail.com>
 leonidb <leonidbl91@gmail.com>
+Michael Gallaspy <gallaspy.michael@gmail.com>

--- a/doc/src/aboutus.rst
+++ b/doc/src/aboutus.rst
@@ -361,6 +361,7 @@ want to be mentioned here, so see our repository history for a full list).
 #. Mihai A. Ionescu: Improvement to LaplaceTransform
 #. ck Lux: handle zoo, oo, nan in as_int and round
 #. leonidb: check input to Binomial
+#. Michael Gallaspy: improve handling of inequalities involving RootOf
 
 Up-to-date list in the order of the first contribution is given in the `AUTHORS
 <https://github.com/sympy/sympy/blob/master/AUTHORS>`_ file.

--- a/sympy/integrals/tests/test_quadrature.py
+++ b/sympy/integrals/tests/test_quadrature.py
@@ -361,10 +361,10 @@ def test_jacobi():
     assert [str(r) for r in w] == ['3.1415926535897932']
 
     x, w = gauss_jacobi(2, -S.Half, S.Half, 17)
-    assert [str(r) for r in x] == ['0.80901699437494742',
-                                   '-0.30901699437494742']
-    assert [str(r) for r in w] == ['2.2732777998989693',
-                                   '0.86831485369082398']
+    assert [str(r) for r in x] == ['-0.30901699437494742',
+                                   '0.80901699437494742']
+    assert [str(r) for r in w] == ['0.86831485369082398',
+                                   '2.2732777998989693']
 
     x, w = gauss_jacobi(3, -S.Half, S.Half, 17)
     assert [str(r) for r in x] == ['-0.62348980185873353',
@@ -401,10 +401,10 @@ def test_jacobi():
     assert [str(r) for r in w] == ['1.0666666666666667']
 
     x, w = gauss_jacobi(2, 2, 3, 17)
-    assert [str(r) for r in x] == ['0.46247529557426437',
-                                   '-0.24025307335204215']
-    assert [str(r) for r in w] == ['0.58152042148828007',
-                                   '0.48514624517838660']
+    assert [str(r) for r in x] == ['-0.24025307335204215',
+                                   '0.46247529557426437']
+    assert [str(r) for r in w] == ['0.48514624517838660',
+                                   '0.58152042148828007']
 
     x, w = gauss_jacobi(3, 2, 3, 17)
     assert [str(r) for r in x] == ['-0.46115870378089762',

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -14,6 +14,7 @@ from sympy.core.numbers import Rational, igcd
 from sympy.ntheory import divisors, isprime, nextprime
 from sympy.functions import exp, sqrt, re, im, Abs, cos, acos, sin, Piecewise
 from sympy.functions.elementary.miscellaneous import root
+from sympy.functions.elementary.complexes import sign
 
 from sympy.polys.polytools import Poly, cancel, factor, gcd_list, discriminant
 from sympy.polys.specialpolys import cyclotomic_poly
@@ -41,8 +42,17 @@ def roots_linear(f):
     return [r]
 
 
-def roots_quadratic(f):
+def roots_quadratic(f, _sort=True):
     """Returns a list of roots of a quadratic polynomial."""
+    # If _sort is True, roots are sorted with defaut_sort_key. Otherwise,
+    # an attempt will be made to sort the roots
+    # with reals before non-real roots and non-real sorted according
+    # to real part and imaginary part, e.g. -1, 1, -1 + I, 2 - I;
+    # this will always work if the domain is ZZ.
+    # XXX remove the _sort option if issue 8294 is implemented since
+    # the user can sort the roots however is desired.
+
+
     a, b, c = f.all_coeffs()
     dom = f.get_domain()
 
@@ -57,35 +67,36 @@ def roots_quadratic(f):
 
         if not dom.is_Numerical:
             r1 = _simplify(r1)
+        elif not _sort and r1.is_negative:
+            r0, r1 = r1, r0
     elif b is S.Zero:
         r = -c/a
-
         if not dom.is_Numerical:
-            R = sqrt(_simplify(r))
-        else:
-            R = sqrt(r)
+            r = _simplify(r)
 
-        r0 = R
-        r1 = -R
+        R = sqrt(r)
+        r0 = -R
+        r1 = R
     else:
         d = b**2 - 4*a*c
+        A = 2*a
+        B = -b/A
 
-        if dom.is_Numerical:
-            D = sqrt(d)
+        if not dom.is_Numerical:
+            d = _simplify(d)
+            B = _simplify(B)
 
-            r0 = (-b + D) / (2*a)
-            r1 = (-b - D) / (2*a)
-        else:
-            D = sqrt(_simplify(d))
-            A = 2*a
+        D = sqrt(d)/A
+        r0 = B - D
+        r1 = B + D
+        if not _sort and a.is_negative:
+            r0, r1 = r1, r0
+        elif not dom.is_Numerical:
+            r0, r1 = [expand_2arg(i) for i in (r0, r1)]
 
-            E = _simplify(-b/A)
-            F = D/A
-
-            r0 = E + F
-            r1 = E - F
-
-    return sorted([expand_2arg(i) for i in (r0, r1)], key=default_sort_key)
+    if not _sort:
+        return [r0, r1]
+    return sorted((r0, r1), key=default_sort_key)
 
 
 def roots_cubic(f, trig=False):
@@ -327,23 +338,62 @@ def roots_quartic(f):
                 for a1, a2 in zip(_ans(y1), _ans(y2))]
 
 
-def roots_binomial(f):
+def roots_binomial(f, _sort=True):
     """Returns a list of roots of a binomial polynomial."""
     n = f.degree()
 
     a, b = f.nth(n), f.nth(0)
-    alpha = (-cancel(b/a))**Rational(1, n)
+    base = -cancel(b/a)
+    alpha = root(base, n)
 
     if alpha.is_number:
         alpha = alpha.expand(complex=True)
 
-    roots, I = [], S.ImaginaryUnit
+    if _sort:
+        ks = list(range(n))
+    else:
+        # define some parameters that will allow us to order the roots.
+        # If the domain is ZZ this is guaranteed to return roots sorted
+        # with reals before non-real roots and non-real sorted according
+        # to real part and imaginary part, e.g. -1, 1, -1 + I, 2 - I
+        neg = base.is_negative
+        even = n % 2 == 0
+        if neg:
+            if even == True and (base + 1).is_positive:
+                big = True
+            else:
+                big = False
 
-    for k in xrange(n):
-        zeta = exp(2*k*S.Pi*I/n).expand(complex=True)
+        # get the indices in the right order so the computed
+        # roots will be sorted when the domain is ZZ
+        ks = []
+        imax = n//2
+        if even:
+            ks.append(imax)
+            imax -= 1
+        if not neg:
+            ks.append(0)
+        for i in range(imax, 0, -1):
+            if neg:
+                ks.extend([i, -i])
+            else:
+                ks.extend([-i, i])
+        if neg:
+            ks.append(0)
+            if big:
+                for i in range(0, len(ks), 2):
+                    pair = ks[i: i + 2]
+                    pair = list(reversed(pair))
+
+    # compute the roots
+    roots, d = [], 2*S.Pi*S.ImaginaryUnit/n
+    for k in ks:
+        zeta = exp(k*d).expand(complex=True)
         roots.append((alpha*zeta).expand(power_base=False))
 
-    return sorted(roots, key=default_sort_key)
+    if _sort:
+        roots.sort(key=default_sort_key)
+    return roots
 
 
 def _inv_totient_estimate(m):

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -32,6 +32,7 @@ from sympy.polys.polyerrors import (
 
 from sympy.core.compatibility import xrange
 
+
 def dup_sturm(f, K):
     """
     Computes the Sturm sequence of ``f`` in ``F[x]``.
@@ -1752,11 +1753,13 @@ class RealInterval(object):
         return self._inner_refine()
 
 class ComplexInterval(object):
-    """A fully qualified representation of a complex isolation interval. """
+    """A fully qualified representation of a complex isolation interval.
+    The printed form is shown as (x1, y1) x (x2, y2): the southwest x northeast
+    coordinates of the interval's rectangle."""
 
     def __init__(self, a, b, I, Q, F1, F2, f1, f2, dom, conj=False):
         """Initialize new complex interval with complete information. """
-        self.a, self.b = a, b
+        self.a, self.b = a, b  # the southwest and northeast corner: (x1, y1), (x2, y2)
         self.I, self.Q = I, Q
 
         self.f1, self.F1 = f1, F1
@@ -1820,8 +1823,13 @@ class ComplexInterval(object):
 
     def is_disjoint(self, other):
         """Return ``True`` if two isolation intervals are disjoint. """
-        return ((self.conj != other.conj) or ((self.bx <= other.ax or other.bx <= self.ax) or
-                                              (self.by <= other.ay or other.by <= self.ay)))
+        if self.conj != other.conj:
+            return True
+        re_distinct = (self.bx <= other.ax or other.bx <= self.ax)
+        if re_distinct:
+            return True
+        im_distinct = (self.by <= other.ay or other.by <= self.ay)
+        return im_distinct
 
     def _inner_refine(self):
         """Internal one step complex root refinement procedure. """

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -341,9 +341,9 @@ class RootOf(Expr):
             return None
 
         if poly.degree() == 2:
-            return roots_quadratic(poly)
+            return roots_quadratic(poly, _sort=False)
         elif poly.length() == 2 and poly.TC():
-            return roots_binomial(poly)
+            return roots_binomial(poly, _sort=False)
         else:
             return None
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -4,6 +4,7 @@ from __future__ import print_function, division
 
 from sympy.core import (S, Expr, Integer, Float, I, Add, Lambda, symbols,
         sympify, Rational)
+from sympy.core.cache import cacheit
 
 from sympy.polys.polytools import Poly, PurePoly, factor
 from sympy.polys.rationaltools import together
@@ -332,6 +333,7 @@ class RootOf(Expr):
         return roots
 
     @classmethod
+    @cacheit
     def _roots_trivial(cls, poly, radicals):
         """Compute roots in linear, quadratic and binomial cases. """
         if poly.degree() == 1:

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -4,7 +4,7 @@ from sympy import (S, symbols, Symbol, Wild, Integer, Rational, sqrt,
     powsimp, Lambda, sin, cos, pi, I, Interval, re, im, exp, ZZ, Piecewise,
     acos, default_sort_key)
 
-from sympy.polys import (Poly, cyclotomic_poly, intervals, nroots,
+from sympy.polys import (Poly, cyclotomic_poly, intervals, nroots, RootOf,
     PolynomialError)
 
 from sympy.polys.polyroots import (root_factors, roots_linear,
@@ -70,9 +70,34 @@ def test_roots_quadratic():
         assert roots == _nsort(roots)
 
 
+def test_issue_8285():
+    roots = (Poly(4*x**8 - 1, x)*Poly(x**2 + 1)).all_roots()
+    assert roots == _nsort(roots)
+    f = Poly(x**4 + 5*x**2 + 6, x)
+    ro = [RootOf(f, i) for i in range(4)]
+    roots = Poly(x**4 + 5*x**2 + 6, x).all_roots()
+    assert roots == ro
+    assert roots == _nsort(roots)
+    # more than 2 complex roots from which to identify the
+    # imaginary ones
+    roots = Poly(2*x**8 - 1).all_roots()
+    assert roots == _nsort(roots)
+
+
 @XFAIL
+def test_Issue_8255_fail():
+    assert len(Poly(2*x**10 - 1).all_roots()) == 10  # doesn't fail
+
+
 def test_issue_8289():
     roots = (Poly(x**2 + 2)*Poly(x**4 + 2)).all_roots()
+    assert roots == _nsort(roots)
+    roots = Poly(x**6 + 3*x**3 + 2, x).all_roots()
+    assert roots == _nsort(roots)
+    roots = Poly(x**6 - x + 1).all_roots()
+    assert roots == _nsort(roots)
+    # all imaginary roots
+    roots = Poly(x**4 + 4*x**2 + 4, x).all_roots()
     assert roots == _nsort(roots)
 
 

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -14,9 +14,11 @@ from sympy import (
     S, symbols, sqrt, I, Rational, Float, Lambda, log, exp, tan,
 )
 
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, XFAIL
 
 from sympy.abc import a, b, c, d, x, y, z, r
+
+import warnings
 
 
 def test_RootOf___new__():
@@ -187,6 +189,7 @@ def test_RootOf_evalf():
     assert re.epsilon_eq(Float("+1.272897223922499190910"))
     assert im.epsilon_eq(Float("+0.719798681483861386681"))
 
+
 def test_RootOf_evalf_caching_bug():
     r = RootOf(x**5 - 5*x + 12, 1)
     r.n()
@@ -195,6 +198,7 @@ def test_RootOf_evalf_caching_bug():
     r.n()
     b = r._get_interval()
     assert a == b
+
 
 def test_RootOf_real_roots():
     assert Poly(x**5 + x + 1).real_roots() == [RootOf(x**3 - x**2 + 1, 0)]
@@ -219,6 +223,7 @@ def test_RootOf_all_roots():
         RootOf(x**3 - x**2 + 1, 2),
     ]
 
+
 def test_RootOf_eval_rational():
     p = legendre_poly(4, x, polys=True)
     roots = [r.eval_rational(S(1)/10**20) for r in p.real_roots()]
@@ -234,6 +239,7 @@ def test_RootOf_eval_rational():
              "0.33998104358485626",
              "0.86113631159405258",
              ]
+
 
 def test_RootSum___new__():
     f = x**3 + x + 3
@@ -374,3 +380,11 @@ def test_issue_7876():
     l1 = Poly(x**6 - x + 1, x).all_roots()
     l2 = [RootOf(x**6 - x + 1, i) for i in range(6)]
     assert frozenset(l1) == frozenset(l2)
+
+
+@XFAIL
+def test_issue_8316():
+    f = Poly(7*x**8 - 9)  # error: 2 missing, 4 don't refine
+    assert len(f.all_roots()) == 8
+    f = Poly(7*x**8 - 10)  # error: 0 missing, 4 don't refine
+    assert len(f.all_roots()) == 8

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -71,8 +71,7 @@ def solve_poly_inequality(poly, rel):
 
         right, right_open = S.Infinity, True
 
-        reals.sort(key=lambda w: w[0], reverse=True)
-        for left, multiplicity in reals:
+        for left, multiplicity in reversed(reals):
             if multiplicity % 2:
                 if sign == eq_sign:
                     intervals.insert(

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -7,6 +7,8 @@ from sympy.solvers.inequalities import (reduce_inequalities,
                                         reduce_rational_inequalities,
                                         solve_univariate_inequality as isolve)
 from sympy.utilities.pytest import raises
+from sympy.polys.rootoftools import RootOf
+from sympy.solvers.solvers import solve
 
 inf = oo.evalf()
 
@@ -243,6 +245,24 @@ def test_issue_6343():
     eq = -3*x**2/2 - 45*x/4 + S(33)/2 > 0
     assert reduce_inequalities(eq) == \
         And(x < -S(15)/4 + sqrt(401)/4, -sqrt(401)/4 - S(15)/4 < x)
+
+
+def test_issue_8235():
+    x = Symbol('x', real=True)
+    assert reduce_inequalities(x**2 - 1 < 0) == \
+        And(S(-1) < x, x < S(1))
+    assert reduce_inequalities(x**2 - 1 <= 0) == \
+        And(S(-1) <= x, x <= 1)
+    assert reduce_inequalities(x**2 - 1 > 0) == \
+        Or(And(-oo < x, x < -1), And(x < oo, S(1) < x))
+    assert reduce_inequalities(x**2 - 1 >= 0) == \
+        Or(And(-oo < x, x <= S(-1)), And(S(1) <= x, x < oo))
+
+    eq = x**8 + x**2 - 9
+    sol = solve(eq >= 0)
+    known_sol = Or(And(-oo < x, RootOf(x**8 + x**2 - 9, 1) <= x, x < oo), \
+            And(-oo < x, x < oo, x <= RootOf(x**8 + x**2 - 9, 0)))
+    assert sol == known_sol
 
 
 def test_issue_5526():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -141,21 +141,21 @@ def test_linear_2eq_order2():
     assert dsolve(eq7) == sol7
 
     eq8 = (Eq(diff(x(t),t,t), t*(4*x(t) + 9*y(t))), Eq(diff(y(t),t,t), t*(12*x(t) - 6*y(t))))
-    sol8 = ("[x(t) == sqrt(133)*(-(-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
-    "C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) + (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + "
-    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) + 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) - "
-    "4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) - "
-    "4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192, y(t) == sqrt(133)*(C2*(133*t**8/24 - t**3/6 + "
-    "sqrt(133)*t**3/2 + 1) - C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) - "
+    sol8 = ("[x(t) == -sqrt(133)*((-sqrt(133) - 1)*(C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
+    "C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + O(t**6)) - (-1 + sqrt(133))*(C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) + "
+    "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6)) - 4*C2*(133*t**8/24 - t**3/6 + sqrt(133)*t**3/2 + 1) + "
+    "4*C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - 4*C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
+    "4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192, y(t) == -sqrt(133)*(-C2*(133*t**8/24 - t**3/6 + "
+    "sqrt(133)*t**3/2 + 1) + C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
     "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/266]")
     assert str(dsolve(eq8)) == sol8
 
     eq9 = (Eq(diff(x(t),t,t), t*(4*diff(x(t),t) + 9*diff(y(t),t))), Eq(diff(y(t),t,t), t*(12*diff(x(t),t) - 6*diff(y(t),t))))
-    sol9 = [Eq(x(t), sqrt(133)*(4*C1*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) + 4*C2 - \
-    4*C3*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) - 4*C4 - (-sqrt(133) - 1)*(C1*Integral(exp((-1 + \
-    sqrt(133))*Integral(t, t)), t) + C2) + (-1 + sqrt(133))*(C3*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) + \
-    C4))/3192), Eq(y(t), sqrt(133)*(C1*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) + C2 - \
-    C3*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) - C4)/266)]
+    sol9 = [Eq(x(t), -sqrt(133)*(4*C1*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) + 4*C2 - \
+    4*C3*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) - 4*C4 - (-1 + sqrt(133))*(C1*Integral(exp((-sqrt(133) - \
+    1)*Integral(t, t)), t) + C2) + (-sqrt(133) - 1)*(C3*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) + \
+    C4))/3192), Eq(y(t), -sqrt(133)*(C1*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) + C2 - \
+    C3*Integral(exp((-1 + sqrt(133))*Integral(t, t)), t) - C4)/266)]
     assert dsolve(eq9) == sol9
 
     eq10 = (t**2*diff(x(t),t,t) + 3*t*diff(x(t),t) + 4*t*diff(y(t),t) + 12*x(t) + 9*y(t), \


### PR DESCRIPTION
-fixes #8235 - now that the roots are sorted, no additional sorting needs to be done
-fixes #8255 - this fixes the registry of roots when the radicals is True or False. 
-avoids issues like the NotImplementedError of #8285 (tests added) but does not fix that issue
-fixes #8289 - consistent sorting of all_roots
-fixes #8296 - sorting of nroots consistent with all_roots

No other private (i.e. not @public) routines are modified. These two are given special attention because the order of the returned roots needs to agree with RootOf instances because these routines are called from `_roots_trivial`. Roots are not sorted in `_roots_trivial` because it is much more efficient to do so at the point of calculation.

I think sorting was added when we sorted Add args by hash. Since that is no longer true, I believe all sorting of polyroots routines can be removed. This will make them all run faster but may require some tweaking once to get all tests in agreement with them. For purposes of this PR a `_sort` flag was added to the quadratic and binomial routines; all tests pass with that flag set to False but it is left True until issue #8294 is decided.

If agreeable this closes #8256 and includes and thus closes #8237

Some other minor code modifications were made in the process and are also included as discrete commits.

The modifications also result in the runtime being 50% less and 35% less for quadratic and binomial root calculations, respectively, based on the tests:

```
from timeit import timeit

sum([timeit('[rq(Poly([r() or 1,r(),r()],x))for i in xrange(1000)]',
'from sympy.polys.polyroots import roots_quadratic as rq\n
from sympy import Poly\nfrom sympy.abc import x\n
import random\nr=lambda :random.randint(-10,10)', number=1) for i in range(5)])
sum([timeit('[rq(Poly((r() or 1)*x**abs(r() or 1)+(r() or 1),x)) for i in xrange(1000)]',
'from sympy.polys.polyroots import roots_binomial as rq\n
from sympy import Poly\nfrom sympy.abc import x\n
import random\nr=lambda :random.randint(-10,10)',number=1) for i in range(1)])
```
