### PR TITLE
Add new test to test_qubit and refactor test_qubit.py

### DIFF
--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -25,6 +25,7 @@ def test_Qubit():
     assert qb.flip(0) == Qubit('00111')
     assert qb.flip(1) == Qubit('00100')
     assert qb.flip(4) == Qubit('10110')
+    assert qb.qubit_values == (0, 0, 1, 1, 0)
     assert qb.dimension == 5
     for i in range(5):
         assert qb[i] == array[4 - i]

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -110,8 +110,8 @@ def test_matrix_to_qubits():
     mat = Matrix([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
     assert matrix_to_qubit(mat) == qb
     assert qubit_to_matrix(qb) == mat
-    
-    state = 2*sqrt(2)*(Qubit(0, 0, 0) + Qubit(0, 0, 1) + Qubit(0, 1, 0) + 
+
+    state = 2*sqrt(2)*(Qubit(0, 0, 0) + Qubit(0, 0, 1) + Qubit(0, 1, 0) +
                        Qubit(0, 1, 1) + Qubit(1, 0, 0) + Qubit(1, 0, 1) +
                        Qubit(1, 1, 0) + Qubit(1, 1, 1))
     ones = sqrt(2)*2*Matrix([1, 1, 1, 1, 1, 1, 1, 1])

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -34,38 +34,54 @@ def test_Qubit():
 
 
 def test_QubitBra():
-    assert Qubit(0).dual_class() == QubitBra
-    assert QubitBra(0).dual_class() == Qubit
-    assert represent(Qubit(1, 1, 0), nqubits=3).H == \
-        represent(QubitBra(1, 1, 0), nqubits=3)
-    assert Qubit(
-        0, 1)._eval_innerproduct_QubitBra(QubitBra(1, 0)) == Integer(0)
-    assert Qubit(
-        0, 1)._eval_innerproduct_QubitBra(QubitBra(0, 1)) == Integer(1)
+    qb = Qubit(0)
+    qb_bra = QubitBra(0)
+    assert qb.dual_class() == QubitBra
+    assert qb_bra.dual_class() == Qubit
+
+    qb = Qubit(1, 1, 0)
+    qb_bra = QubitBra(1, 1, 0)
+    assert represent(qb, nqubits=3).H == represent(qb_bra, nqubits=3)
+
+    qb = Qubit(0, 1)
+    qb_bra = QubitBra(1,0)
+    assert qb._eval_innerproduct_QubitBra(qb_bra) == Integer(0)
+
+    qb_bra = QubitBra(0, 1)
+    assert qb._eval_innerproduct_QubitBra(qb_bra) == Integer(1)
 
 
 def test_IntQubit():
-    assert IntQubit(8).as_int() == 8
-    assert IntQubit(8).qubit_values == (1, 0, 0, 0)
-    assert IntQubit(7, 4).qubit_values == (0, 1, 1, 1)
+    iqb = IntQubit(8)
+    assert iqb.as_int() == 8
+    assert iqb.qubit_values == (1, 0, 0, 0)
+
+    iqb = IntQubit(7, 4)
+    assert iqb.qubit_values == (0, 1, 1, 1)
     assert IntQubit(3) == IntQubit(3, 2)
 
     #test Dual Classes
-    assert IntQubit(3).dual_class() == IntQubitBra
-    assert IntQubitBra(3).dual_class() == IntQubit
+    iqb = IntQubit(3)
+    iqb_bra = IntQubitBra(3)
+    assert iqb.dual_class() == IntQubitBra
+    assert iqb_bra.dual_class() == IntQubit
 
-    assert IntQubit(5)._eval_innerproduct_IntQubitBra(IntQubitBra(5)) == Integer(1)
-    assert IntQubit(4)._eval_innerproduct_IntQubitBra(IntQubitBra(5)) == Integer(0)
+    iqb = IntQubit(5)
+    iqb_bra = IntQubitBra(5)
+    assert iqb._eval_innerproduct_IntQubitBra(iqb_bra) == Integer(1)
+
+    iqb = IntQubit(4)
+    iqb_bra = IntQubitBra(5)
+    assert iqb._eval_innerproduct_IntQubitBra(iqb_bra) == Integer(0)
     raises(ValueError, lambda: IntQubit(4, 1))
 
 
 def test_superposition_of_states():
-    assert qapply(CNOT(0, 1)*HadamardGate(0)*(1/sqrt(2)*Qubit('01') + 1/sqrt(2)*Qubit('10'))).expand() == (Qubit('01')/2 + Qubit('00')/2 - Qubit('11')/2 +
-     Qubit('10')/2)
-
-    assert matrix_to_qubit(represent(CNOT(0, 1)*HadamardGate(0)
-        *(1/sqrt(2)*Qubit('01') + 1/sqrt(2)*Qubit('10')), nqubits=2)) == \
-        (Qubit('01')/2 + Qubit('00')/2 - Qubit('11')/2 + Qubit('10')/2)
+    state = 1/sqrt(2)*Qubit('01') + 1/sqrt(2)*Qubit('10')
+    state_gate = CNOT(0, 1)*HadamardGate(0)*state
+    state_expanded = Qubit('01')/2 + Qubit('00')/2 - Qubit('11')/2 + Qubit('10')/2
+    assert qapply(state_gate).expand() == state_expanded
+    assert matrix_to_qubit(represent(state_gate, nqubits=2)) == state_expanded
 
 
 #test apply methods
@@ -90,19 +106,17 @@ def test_apply_represent_equality():
 
 
 def test_matrix_to_qubits():
-    assert matrix_to_qubit(
-        Matrix([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])) == \
-        Qubit(0, 0, 0, 0)
-    assert qubit_to_matrix(Qubit(0, 0, 0, 0)) == \
-        Matrix([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-    assert matrix_to_qubit(sqrt(2)*2*Matrix([1, 1, 1, 1, 1, 1, 1, 1])) == \
-        (2*sqrt(2)*(Qubit(0, 0, 0) + Qubit(0, 0, 1) + Qubit(0, 1, 0) +
-        Qubit(0, 1, 1) + Qubit(1, 0, 0) + Qubit(1, 0, 1) + Qubit(1, 1, 0) +
-         Qubit(1, 1, 1))).expand()
-    assert qubit_to_matrix(2*sqrt(2)*(Qubit(0, 0, 0) + Qubit(0, 0, 1) +
-        Qubit(0, 1, 0) + Qubit(0, 1, 1) + Qubit(1, 0, 0) + Qubit(1, 0, 1) +
-        Qubit(1, 1, 0) + Qubit(1, 1, 1))) == \
-        sqrt(2)*2*Matrix([1, 1, 1, 1, 1, 1, 1, 1])
+    qb = Qubit(0, 0, 0, 0)
+    mat = Matrix([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    assert matrix_to_qubit(mat) == qb
+    assert qubit_to_matrix(qb) == mat
+    
+    state = 2*sqrt(2)*(Qubit(0, 0, 0) + Qubit(0, 0, 1) + Qubit(0, 1, 0) + 
+                       Qubit(0, 1, 1) + Qubit(1, 0, 0) + Qubit(1, 0, 1) +
+                       Qubit(1, 1, 0) + Qubit(1, 1, 1))
+    ones = sqrt(2)*2*Matrix([1, 1, 1, 1, 1, 1, 1, 1])
+    assert matrix_to_qubit(ones) == state.expand()
+    assert qubit_to_matrix(state) == ones
 
 
 def test_measure_normalize():


### PR DESCRIPTION
There are two commits here:
1) The unit test for Qubit doesn't explicitly test qubit_values (they are tested for IntQubit). Add an assertion for this
2) Refactor much of the code in test_qubit to make it easier to read

This replaces pull request #8278
