### PR TITLE
Shift issue numbers for patterns in #8286

### DIFF
--- a/sympy/core/tests/test_equal.py
+++ b/sympy/core/tests/test_equal.py
@@ -63,7 +63,7 @@ def test_cmp_bug2():
     assert (Symbol != t)
 
 
-def test_cmp_bug1258():
+def test_cmp_issue_4357():
     """ Check that Basic subclasses can be compared with sympifiable objects.
 
     https://github.com/sympy/sympy/issues/4357

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -225,7 +225,7 @@ def test_sage():
     assert hasattr(log(x), "_sage_")
 
 
-def test_bug496():
+def test_issue_3595():
     assert sympify("a_") == Symbol("a_")
     assert sympify("_a") == Symbol("_a")
 

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -33,7 +33,7 @@ def test_Pauli():
 
     assert sigma1*2*sigma1 == 2
 
-    # Check bug 3372
+    # Check issue 6471
     assert evaluate_pauli_product(-I*4*sigma1*sigma2) == 4*sigma3
 
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -435,7 +435,7 @@ class RootOf(Expr):
                     if self.is_real:
                         a = mpf(str(interval.a))
                         b = mpf(str(interval.b))
-                        # This is needed due to the bug #3364:
+                        # This is needed due to the issue 6463:
                         a, b = min(a, b), max(a, b)
                         if not (a < root < b):
                             raise ValueError("Root not in the interval.")
@@ -444,7 +444,7 @@ class RootOf(Expr):
                         bx = mpf(str(interval.bx))
                         ay = mpf(str(interval.ay))
                         by = mpf(str(interval.by))
-                        # This is needed due to the bug #3364:
+                        # This is needed due to the issue 6463:
                         ax, bx = min(ax, bx), max(ax, bx)
                         ay, by = min(ay, by), max(ay, by)
                         if not (ax < root.real < bx and ay < root.imag < by):
@@ -486,7 +486,7 @@ class RootOf(Expr):
         interval = self._get_interval()
         a = Rational(str(interval.a))
         b = Rational(str(interval.b))
-        # This is needed due to the bug #3364:
+        # This is needed due to the issue 6463:
         a, b = min(a, b), max(a, b)
         return bisect(func, a, b, tol)
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -565,14 +565,14 @@ def test_zeta():
     assert str(zeta(3)) == "zeta(3)"
 
 
-def test_bug2():
+def test_issue_3101():
     e = x - y
     a = str(e)
     b = str(e)
     assert a == b
 
 
-def test_bug4():
+def test_issue_3103():
     e = -2*sqrt(x) - y/sqrt(x)/2
     assert str(e) not in ["(-2)*x**1/2(-1/2)*x**(-1/2)*y",
             "-2*x**1/2(-1/2)*x**(-1/2)*y", "-2*x**1/2-1/2*x**-1/2*w"]

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -209,10 +209,6 @@ def test_doit2():
     assert l.doit(deep=False) == l
 
 
-def test_bug693a():
-    assert sin(sin(x + 1) + 1).limit(x, 0) == sin(sin(1) + 1)
-
-
 def test_issue_3792():
     assert limit( (1 - cos(x))/x**2, x, S(1)/2) == 4 - 4*cos(S(1)/2)
     assert limit(sin(sin(x + 1) + 1), x, 0) == sin(1 + sin(1))


### PR DESCRIPTION
- [x] The rest of:

```
$ grep -R 'bug[[:space:]]*[#]\?[0-9]\+' [^.]*|fgrep -v '/spin.ipynb:'
sympy/core/tests/test_equal.py:def test_cmp_bug1():
sympy/core/tests/test_equal.py:def test_cmp_bug2():
sympy/core/tests/test_match.py:def test_derivative_bug1():
sympy/core/tests/test_match.py:def test_match_deriv_bug1():
sympy/core/tests/test_match.py:def test_match_bug2():
sympy/core/tests/test_match.py:def test_match_bug3():
sympy/core/tests/test_match.py:def test_match_bug4():
sympy/core/tests/test_match.py:def test_match_bug5():
sympy/core/tests/test_match.py:def test_match_bug6():
sympy/core/tests/test_match.py:def test_Derivative_bug1():
sympy/core/tests/test_subs.py:def test_subbug1():
sympy/core/tests/test_subs.py:def test_subbug2():
sympy/core/tests/test_subs.py:def test_deriv_sub_bug3():
sympy/core/tests/test_arit.py:def test_bug1():
sympy/core/tests/test_arit.py:def test_bug3():
sympy/core/tests/test_function.py:def test_bug1():
sympy/series/tests/test_nseries.py:def test_seriesbug1():
sympy/series/tests/test_nseries.py:def test_bug2():  # 1/log(0) * log(0) problem
sympy/series/tests/test_nseries.py:def test_bug3():
sympy/series/tests/test_nseries.py:def test_seriesbug2():
sympy/series/tests/test_nseries.py:def test_seriesbug2b():
sympy/series/tests/test_nseries.py:def test_seriesbug2d():
sympy/series/tests/test_nseries.py:def test_seriesbug2c():
sympy/series/tests/test_nseries.py:def test_expbug4():
sympy/series/tests/test_nseries.py:def test_logbug4():
sympy/series/tests/test_nseries.py:def test_expbug5():
sympy/series/tests/test_nseries.py:def test_bug4():
sympy/series/tests/test_nseries.py:def test_bug5():
```
