### PR TITLE
Inequalities: make sure both sides are real when looking at difference

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -237,10 +237,12 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
-        dif = self - other
-        if dif.is_nonnegative is not None and \
-                dif.is_nonnegative is not dif.is_negative:
-            return sympify(dif.is_nonnegative)
+        # Note: may want to investigate making sure both are finite too
+        if self.is_real and other.is_real:
+            dif = self - other
+            if dif.is_nonnegative is not None and \
+                    dif.is_nonnegative is not dif.is_negative:
+                return sympify(dif.is_nonnegative)
         return C.GreaterThan(self, other, evaluate=False)
 
     def __le__(self, other):
@@ -251,10 +253,11 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
-        dif = self - other
-        if dif.is_nonpositive is not None and \
-                dif.is_nonpositive is not dif.is_positive:
-            return sympify(dif.is_nonpositive)
+        if self.is_real and other.is_real:
+            dif = self - other
+            if dif.is_nonpositive is not None and \
+                    dif.is_nonpositive is not dif.is_positive:
+                return sympify(dif.is_nonpositive)
         return C.LessThan(self, other, evaluate=False)
 
     def __gt__(self, other):
@@ -265,10 +268,11 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
-        dif = self - other
-        if dif.is_positive is not None and \
-                dif.is_positive is not dif.is_nonpositive:
-            return sympify(dif.is_positive)
+        if self.is_real and other.is_real:
+            dif = self - other
+            if dif.is_positive is not None and \
+                    dif.is_positive is not dif.is_nonpositive:
+                return sympify(dif.is_positive)
         return C.StrictGreaterThan(self, other, evaluate=False)
 
     def __lt__(self, other):
@@ -279,10 +283,11 @@ class Expr(Basic, EvalfMixin):
         for me in (self, other):
             if me.is_complex and me.is_real is False:
                 raise TypeError("Invalid comparison of complex %s" % me)
-        dif = self - other
-        if dif.is_negative is not None and \
-                dif.is_negative is not dif.is_nonnegative:
-            return sympify(dif.is_negative)
+        if self.is_real and other.is_real:
+            dif = self - other
+            if dif.is_negative is not None and \
+                    dif.is_negative is not dif.is_nonnegative:
+                return sympify(dif.is_negative)
         return C.StrictLessThan(self, other, evaluate=False)
 
     @staticmethod

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -169,7 +169,8 @@ def test_relational():
     assert (-pi <= 3) is S.true
     assert (-pi > 3) is S.false
     assert (-pi >= 3) is S.false
-    assert (x - 2 < x - 3) is S.false
+    r = Symbol('r', real=True, finite=True)
+    assert (r - 2 < r - 3) is S.false
 
 
 def test_relational_assumptions():
@@ -198,10 +199,10 @@ def test_relational_assumptions():
     assert (m2 <= 0) is S.true
     assert (m3 > 0) is S.true
     assert (m4 >= 0) is S.true
-    m1 = Symbol("m1", negative=False)
-    m2 = Symbol("m2", nonpositive=False)
-    m3 = Symbol("m3", positive=False)
-    m4 = Symbol("m4", nonnegative=False)
+    m1 = Symbol("m1", negative=False, real=True)
+    m2 = Symbol("m2", nonpositive=False, real=True)
+    m3 = Symbol("m3", positive=False, real=True)
+    m4 = Symbol("m4", nonnegative=False, real=True)
     assert (m1 < 0) is S.false
     assert (m2 <= 0) is S.false
     assert (m3 > 0) is S.false

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -508,6 +508,24 @@ def test_ineq_avoid_wild_symbol_flip():
     assert e == Ge(x, p, evaluate=False)
 
 
+def test_ineq_cannot_determine_if_real():
+    # issue #8288
+    lhs = x + I
+    rhs = x + I + 2
+    e = Lt(lhs, rhs)
+    assert e == Lt(lhs, rhs, evaluate=False)
+    # Similarly:
+    assert Gt(x, x + 2) == Gt(x, x + 2, evaluate=False)
+    # Substitution can cause evaluation:
+    assert e.subs(x, -I)
+    raises(TypeError, lambda: e.subs(x, 0))
+    # With some assumptions, can evaluate.  Here we make no comment
+    # what should happen with real, possibly infinite r.
+    r = Symbol('r', real=True, finite=True)
+    assert Ge(r + 2, r)
+    assert Le(r, r + 2)
+
+
 def test_issue_8245():
     a = S("6506833320952669167898688709329/5070602400912917605986812821504")
     q = a.n(10)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1894,3 +1894,12 @@ def test_issue_2827_trigsimp_methods():
 
 def test_powsimp_on_numbers():
     assert 2**(S(1)/3 - 2) == 2**(S(1)/3)/4
+
+
+@XFAIL
+def test_ineq_cannot_determine_if_real():
+    # issue #8288
+    from sympy import simplify
+    lhs = x + I
+    rhs = x + I + 2
+    assert simplify(Ge(lhs, rhs)) == Ge(lhs, rhs, evaluate=False)


### PR DESCRIPTION
```
    Fixes #8288.  When subtracting lhs - rhs we should be careful they
    are real, otherwise could cancel non-real bits.  Add tests.

    Also, these should not simplify, add a XFAIL test for that.
```
