### PR TITLE
[WIP] Added `timeout` argument to `fu`

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -93,6 +93,8 @@ if PY3:
     exec_ = getattr(builtins, "exec")
 
     xrange = range
+    TimeoutError = TimeoutError
+
 else:
     import codecs
     import types
@@ -137,6 +139,9 @@ else:
         exec("exec _code_ in _globs_, _locs_")
 
     xrange = xrange
+
+    class TimeoutError(Exception):
+        pass
 
 def with_metaclass(meta, *bases):
     """

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2087,3 +2087,9 @@ def kbins(l, k, ordered=None):
     else:
         raise ValueError(
             'ordered must be one of 00, 01, 10 or 11, not %s' % ordered)
+
+def nestmap(func, itbl, exceptions=()):
+    if iterable(itbl) and not isinstance(itbl, exceptions):
+        return type(itbl)(nestmap(func, i) for i in itbl)
+    else:
+        return func(itbl)

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -212,3 +212,16 @@ def find_executable(executable, path=None):
                     return f
     else:
         return None
+
+
+def make_timeout_callback(timeout):
+    """Creates a timeout callback function. Function will return True if
+    the time is up, otherwise returns False."""
+
+    TIME = time.time() + timeout
+    def callback():
+        if time.time() > TIME:
+            return True
+        else:
+            return False
+    return callback

--- a/sympy/utilities/timeout.py
+++ b/sympy/utilities/timeout.py
@@ -1,0 +1,53 @@
+import time
+from sympy.core.compatibility import TimeoutError
+from functools import partial
+
+
+def make_timeout_callback(timeout):
+    """Creates a timeout callback function. Function will return True if
+    the time is up, otherwise returns False."""
+
+    TIME = time.time() + timeout
+    def callback():
+        """Return true if time is up, else False"""
+        if time.time() > TIME:
+            return True
+        else:
+            return False
+    return callback
+
+no_timeout = lambda: False
+
+def init_timeout(arg):
+    """Initiliaze the timeout callback.
+
+    Parameters:
+    -----------
+    arg
+        arg can be either a time in seconds, an existing callback function,
+        or None. If None, returns a callback that always returns False.
+
+    Returns:
+    --------
+    tcb : callable
+        Timeout callback. Returns True if the time is up, else False.
+    """
+
+    if arg is None:
+        return no_timeout
+    elif callable(arg):
+        return arg
+    else:
+        return make_timeout_callback(arg)
+
+def check_timeout(tcb):
+    """Throws TimeoutError if timeout callback is expired."""
+    if tcb and tcb():
+        raise TimeoutError()
+
+def safe_partial_tcb(func, tcb):
+    """Apply partial to a rule only if that rule has a tcb as a kwarg"""
+    if 'tcb' in func.__code__.co_varnames:
+        return partial(func, tcb=tcb)
+    else:
+        return func


### PR DESCRIPTION
**Do not merge - proof of concept for discussion only**
## Rational

For the large expressions that we see in `mechanics`, calls to `simplify` can take an extremely long time. However, for simple expressions, simplification is desirable. Currently we don't simplify by default inside any of our library code, as it's impossible to tell whether the expression can be reasonably simplified or not. If a `timeout` argument was added to such functions though, one could simply run

```
>>> simplify(expr, timeout=some_reasonable_max_time)
```

and get the best of both worlds.
## Implementation

Just a proof of concept, still has lots of issues. `fu` isn't even the main culprit for time consuming operations, but it was self contained so I tried it here first. See [here](https://groups.google.com/forum/#!topic/sympy/qsPImy6WqcI) for some relevant discussion.

The `timeout` kwarg only implements a "pseudo-timeout". It relys on cooperative checking in each called function. Functions that don't implement timeout will result in blocking until a function with timeout gets control. Still, it works for simple test cases.

Actual timeouts can't easily be implemented robustly in a cross-platform way. The most common suggestion is to use `signal.alarm`, but that only works for `*NIX` systems. This is a (somewhat hackish) attempt at getting around that.

Another option is to use decorators and a global `TIMEOUT` parameter, but this will prevent using sympy in separate threads or setting different timeouts for different functions. It would be more composable though.

After some profiling, it seems that `expand` and friends are really the main culprit here. That would take some more work though, so I'd like to get some validation on this before working on that.
