### PR TITLE
[WIP] Added `timeout_after` context manager

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -141,6 +141,7 @@ from __future__ import print_function, division
 from sympy.core.facts import FactRules, FactKB
 from sympy.core.core import BasicMeta
 from sympy.core.compatibility import integer_types, with_metaclass
+from sympy.core.timeout import timeoutable
 
 from random import shuffle
 
@@ -224,6 +225,7 @@ def make_property(fact):
     return property(getit)
 
 
+@timeoutable
 def _ask(fact, obj):
     """
     Find the truth value for a property of an object.

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -93,6 +93,7 @@ if PY3:
     exec_ = getattr(builtins, "exec")
 
     xrange = range
+    TimeoutError = TimeoutError
 else:
     import codecs
     import types
@@ -137,6 +138,9 @@ else:
         exec("exec _code_ in _globs_, _locs_")
 
     xrange = xrange
+
+    class TimeoutError(Exception):
+        pass
 
 def with_metaclass(meta, *bases):
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1639,7 +1639,7 @@ def diff(f, *symbols, **kwargs):
 
 
 def expand(e, deep=True, modulus=None, power_base=True, power_exp=True,
-        mul=True, log=True, multinomial=True, basic=True, **hints):
+        mul=True, log=True, multinomial=True, basic=True, timeout=None, **hints):
     """
     Expand an expression using methods given as hints.
 
@@ -1965,7 +1965,7 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True,
     hints['log'] = log
     hints['multinomial'] = multinomial
     hints['basic'] = basic
-    return sympify(e).expand(deep=deep, modulus=modulus, **hints)
+    return sympify(e).expand(deep=deep, modulus=modulus, timeout=timeout, **hints)
 
 # These are simple wrappers around single hints.
 

--- a/sympy/core/timeout.py
+++ b/sympy/core/timeout.py
@@ -1,0 +1,46 @@
+from functools import wraps
+import contextlib
+import time
+
+class _global_timeout(list):
+    def __setitem__(self, key, value):
+        super(_global_timeout, self).__setitem__(key, value)
+
+TIMEOUT = _global_timeout([None])
+
+
+@contextlib.contextmanager
+def timeout_after(sec):
+    """Context manager for controlling timeouts on sympy function calls.
+
+    Raises a ``TimeoutError`` if the contained codeblock takes longer than
+    `sec`. Note that calls not decorated with `timeoutable` will block.
+
+    Nested `timeout_after` managers will not change the timeout. Once set at
+    the top level, it will remain until the top level context is released.
+
+    Parameters:
+    -----------
+    sec : number
+        Maximum time in seconds that the containing code block can take.
+    """
+    nested = TIMEOUT[0] is not None
+    try:
+        if not nested and sec is not None:
+            TIMEOUT[0] = time.time() + sec
+        yield
+    finally:
+        if not nested:
+            TIMEOUT[0] = None
+
+
+def timeoutable(func):
+    """Decorator indicating that the containing function allows timeouts to
+    occur. To be used with `timeout_after` context-manager."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not TIMEOUT[0] or TIMEOUT[0] > time.time():
+            return func(*args, **kwargs)
+        else:
+            raise TimeoutError()
+    return wrapper


### PR DESCRIPTION
_Note: This is just a proof of concept. See #8295 for another option of implementing. I like this one better, but both attempt to solve the same issue._

Added contextmanager to make timeouts on sympy calls available.

Example:

```
>>> # Timeout after 3 seconds
>>> with timeout_after(3):
        expr = simplify(expr)
```

Also added a `timeout` kwarg to `Expr.expand` and `expand` as an example
of how the manager can be used to apply to functions.

**caveats**
- I picked `_ask` as a good function to check, because it's called a lot. However, this may (probably will) add considerable overhead to sympy. The best option would be to find a set of functions that are called often enough, but not too often.
- This uses a global variable, and is thus not threadsafe. However, other things (`evaluate`, etc...) also use globals for the same effect, so sympy already isn't threadsafe.
- This doesn't allow for the resolution that #8295 does, but is _incredibly_ easier to use. 
