### PR TITLE
Don't add parentheses when splitting symbols to objects in dictionaries.

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -760,6 +760,10 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
         undefined variables into SymPy symbols, and allow the use of standard
         mathematical factorial notation (e.g. ``x!``).
 
+    evaluate : bool, optional
+        When False, the order of the arguments will remain as they were in the
+        string and automatic simplification that would normally occur is
+        suppressed. (see examples)
 
     Examples
     ========
@@ -775,6 +779,23 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
     ...     (implicit_multiplication_application,))
     >>> parse_expr("2x", transformations=transformations)
     2*x
+
+    When evaluate=False, some automatic simplifications will not occur:
+
+    >>> parse_expr("2**3"), parse_expr("2**3", evaluate=False)
+    (8, 2**3)
+
+    In addition the order of the arguments will not be made canonical.
+    This feature allows one to tell exactly how the expression was entered:
+
+    >>> a = parse_expr('1 + x', evaluate=False)
+    >>> b = parse_expr('x + 1', evaluate=0)
+    >>> a == b
+    False
+    >>> a.args
+    (1, x)
+    >>> b.args
+    (x, 1)
 
     See Also
     ========

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -379,7 +379,13 @@ def split_symbols_custom(predicate):
     def _split_symbols(tokens, local_dict, global_dict):
         result = []
         split = False
+        split_previous=False
         for tok in tokens:
+            if split_previous:
+                # throw out closing parenthesis of Symbol that was split
+                split_previous=False
+                continue
+            split_previous=False
             if tok[0] == NAME and tok[1] == 'Symbol':
                 split = True
             elif split and tok[0] == NAME:
@@ -389,17 +395,18 @@ def split_symbols_custom(predicate):
                         if char in local_dict or char in global_dict:
                             # Get rid of the call to Symbol
                             del result[-2:]
-                            result.extend([(OP, '('), (NAME, "%s" % char), (OP, ')'),
+                            result.extend([(NAME, "%s" % char),
                                            (NAME, 'Symbol'), (OP, '(')])
                         else:
                             result.extend([(NAME, "'%s'" % char), (OP, ')'),
                                            (NAME, 'Symbol'), (OP, '(')])
-                    # Delete the last three tokens: get rid of the extraneous
-                    # Symbol( we just added, and also get rid of the last )
-                    # because the closing parenthesis of the original Symbol is
-                    # still there
-                    del result[-3:]
+                    # Delete the last two tokens: get rid of the extraneous
+                    # Symbol( we just added
+                    # Also, set split_previous=True so will skip
+                    # the closing parenthesis of the original Symbol
+                    del result[-2:]
                     split = False
+                    split_previous = True
                     continue
                 else:
                     split = False

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -104,10 +104,10 @@ def test_split_symbols_function():
     transformations = standard_transformations + \
                       (split_symbols, implicit_multiplication,)
     x = Symbol('x')
+    y = Symbol('y')
     a = Symbol('a')
     f = Function('f')
-    fsym= Symbol('f')
 
-    assert parse_expr("af(x)", transformations=transformations) == a*fsym*x
-    assert parse_expr("af(x)", transformations=transformations,
-                      local_dict={'f':f}) == a*f(x)
+    assert parse_expr("ay(x+1)", transformations=transformations) == a*y*(x+1)
+    assert parse_expr("af(x+1)", transformations=transformations,
+                      local_dict={'f':f}) == a*f(x+1)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -1,11 +1,11 @@
-from sympy.core import Symbol, Float, Rational, Integer, I, Mul, Pow
+from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow
 from sympy.functions import exp, factorial, sin
 from sympy.logic import And
 from sympy.series import Limit
 from sympy.utilities.pytest import raises
 
 from sympy.parsing.sympy_parser import (
-    parse_expr, standard_transformations, rationalize, TokenError
+    parse_expr, standard_transformations, rationalize, TokenError, split_symbols, implicit_multiplication,
 )
 
 
@@ -85,3 +85,25 @@ def test_issue_2515():
 def test_issue_7663():
     x = Symbol('x')
     parse_expr('2*(x+1)', evaluate=0) == Mul(2, x + 1, evaluate=False)
+
+def test_split_symbols():
+    transformations = standard_transformations + \
+                      (split_symbols, implicit_multiplication,)
+    x = Symbol('x')
+    y = Symbol('y')
+    xy = Symbol('xy')
+
+    assert parse_expr("xy") == xy
+    assert parse_expr("xy", transformations=transformations) == x*y
+
+def test_split_symbols_function():
+    transformations = standard_transformations + \
+                      (split_symbols, implicit_multiplication,)
+    x = Symbol('x')
+    a = Symbol('a')
+    f = Function('f')
+    fsym= Symbol('f')
+
+    assert parse_expr("af(x)", transformations=transformations) == a*fsym*x
+    assert parse_expr("af(x)", transformations=transformations,
+                      local_dict={'f':f}) == a*f(x)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -5,7 +5,8 @@ from sympy.series import Limit
 from sympy.utilities.pytest import raises
 
 from sympy.parsing.sympy_parser import (
-    parse_expr, standard_transformations, rationalize, TokenError, split_symbols, implicit_multiplication,
+    parse_expr, standard_transformations, rationalize, TokenError,
+    split_symbols, implicit_multiplication,
 )
 
 
@@ -84,7 +85,9 @@ def test_issue_2515():
 
 def test_issue_7663():
     x = Symbol('x')
-    parse_expr('2*(x+1)', evaluate=0) == Mul(2, x + 1, evaluate=False)
+    e = '2*(x+1)'
+    assert parse_expr(e, evaluate=0) == Mul(e, evaluate=False)
+
 
 def test_split_symbols():
     transformations = standard_transformations + \
@@ -95,6 +98,7 @@ def test_split_symbols():
 
     assert parse_expr("xy") == xy
     assert parse_expr("xy", transformations=transformations) == x*y
+
 
 def test_split_symbols_function():
     transformations = standard_transformations + \

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -86,7 +86,7 @@ def test_issue_2515():
 def test_issue_7663():
     x = Symbol('x')
     e = '2*(x+1)'
-    assert parse_expr(e, evaluate=0) == Mul(e, evaluate=False)
+    assert parse_expr(e, evaluate=0) == parse_expr(e, evaluate=False)
 
 
 def test_split_symbols():


### PR DESCRIPTION
Crucial when object is a function so that it is not multiplied by its argument.

c.f. https://groups.google.com/forum/#!topic/sympy/MKhZdgB_Sg4
