### PR TITLE
Don't put the string of the expression in the round() exception

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3035,7 +3035,7 @@ class Expr(Basic, EvalfMixin):
         """
         x = self
         if not x.is_number:
-            raise TypeError('%s is not a number' % x)
+            raise TypeError('%s is not a number' % type(x))
         if x in (S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
             return x
         if not x.is_real:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1617,7 +1617,7 @@ def test_round_exception_nostr():
         assert 'bad' not in str(e)
     else:
         # Did not raise
-        raise Exception
+        raise AssertionError("Did not raise")
 
 def test_extract_branch_factor():
     assert exp_polar(2.0*I*pi).extract_branch_factor() == (1, 1)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1607,6 +1607,17 @@ def test_round():
     assert S.NegativeInfinity.round() == S.NegativeInfinity
     assert S.ComplexInfinity.round() == S.ComplexInfinity
 
+def test_round_exception_nostr():
+    # Don't use the string form of the expression in the round exception, as
+    # it's too slow
+    s = Symbol('bad')
+    try:
+        s.round()
+    except TypeError as e:
+        assert 'bad' not in str(e)
+    else:
+        # Did not raise
+        raise Exception
 
 def test_extract_branch_factor():
     assert exp_polar(2.0*I*pi).extract_branch_factor() == (1, 1)


### PR DESCRIPTION
This fixes the specific issue from #8309, but there are likely more cases that
should be fixed as well. This leads to great speed improvements for large
expressions in any function that tries to call int() on it to see if it is an
integer.

In the future, we may want to keep the expression on the exception object as
well, like on a .expr attribute of the exception object, but I have not done
this for now, as we should decide on a uniform way to approach this problem.
