### PR TITLE
#8331 - Removed Error in catalan function for negative number (especially -1)

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -826,6 +826,8 @@ class catalan(Function):
             evaluate = global_evaluate[0]
         if n.is_Integer and n.is_nonnegative:
             return 4**n*C.gamma(n + S.Half)/(C.gamma(S.Half)*C.gamma(n + 2))
+        if n.is_Integer and n.is_negative:
+            raise ValueError('The number has to be greater than 0')
 
     def fdiff(self, argindex=1):
         n = self.args[0]


### PR DESCRIPTION
This is according to issue https://github.com/sympy/sympy/issues/8331
