### PR TITLE
8294: keep sorting of roots but remove sorting in private methods of polyroots

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -262,13 +262,15 @@ class Product(ExprWithIntLimits):
 
             A = B = Q = S.One
 
-            all_roots = roots(poly, multiple=True)
+            all_roots = roots(poly)
 
-            for r in all_roots:
-                A *= C.RisingFactorial(a - r, n - a + 1)
-                Q *= n - r
+            M = 0
+            for r, m in all_roots.items():
+                M += m
+                A *= C.RisingFactorial(a - r, n - a + 1)**m
+                Q *= (n - r)**m
 
-            if len(all_roots) < poly.degree():
+            if M < poly.degree():
                 arg = quo(poly, Q.as_poly(k))
                 B = self.func(arg, (k, a, n)).doit()
 

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -101,15 +101,17 @@ class DiracDelta(Function):
         if not self.args[0].has(x) or (len(self.args) > 1 and self.args[1] != 0 ):
             return self
         try:
-            argroots = roots(self.args[0], x, multiple=True)
+            argroots = roots(self.args[0], x)
             result = 0
             valid = True
-            darg = diff(self.args[0], x)
-            for r in argroots:
-                #should I care about multiplicities of roots?
-                if r.is_real is not False and not darg.subs(x, r).is_zero:
-                    result += self.func(x - r)/abs(darg.subs(x, r))
+            darg = abs(diff(self.args[0], x))
+            for r, m in argroots.items():
+                if r.is_real is not False and m == 1:
+                    result += self.func(x - r)/darg.subs(x, r)
                 else:
+                    # don't handle non-real and if m != 1 then
+                    # a polynomial will have a zero in the derivative (darg)
+                    # at r
                     valid = False
                     break
             if valid:

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -39,6 +39,8 @@ def test_DiracDelta():
     assert DiracDelta(x*y).simplify(y) == DiracDelta(y)/abs(x)
     assert DiracDelta(x**2*y).simplify(x) == DiracDelta(x**2*y)
     assert DiracDelta(y).simplify(x) == DiracDelta(y)
+    assert DiracDelta((x - 1)*(x - 2)*(x - 3)).simplify(x) == \
+        DiracDelta(x - 3)/2 + DiracDelta(x - 2) + DiracDelta(x - 1)/2
 
     raises(ArgumentIndexError, lambda: DiracDelta(x).fdiff(2))
     raises(ValueError, lambda: DiracDelta(x, -1))

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -138,7 +138,7 @@ def roots_cubic(f, trig=False):
     else:
         u1 = root(q/2 + sqrt(q**2/4 + pon3**3), 3)
 
-    coeff = S.ImaginaryUnit*sqrt(3)/2
+    coeff = I*sqrt(3)/2
 
     u2 = u1*(-S.Half + coeff)
     u3 = u1*(-S.Half - coeff)
@@ -383,7 +383,7 @@ def roots_binomial(f):
                 pair = list(reversed(pair))
 
     # compute the roots
-    roots, d = [], 2*S.Pi*S.ImaginaryUnit/n
+    roots, d = [], 2*I*pi/n
     for k in ks:
         zeta = exp(k*d).expand(complex=True)
         roots.append((alpha*zeta).expand(power_base=False))
@@ -456,7 +456,7 @@ def roots_cyclotomic(f, factor=False):
         h = n//2
         ks = [i for i in xrange(1, n + 1) if igcd(i, n) == 1]
         ks.sort(key=lambda x: (x, -1) if x <= h else (abs(x - n), 1))
-        d = 2*I*S.Pi/n
+        d = 2*I*pi/n
         for k in reversed(ks):
             roots.append(exp(k*d).expand(complex=True))
     else:

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -46,9 +46,10 @@ def roots_linear(f):
 def roots_quadratic(f):
     """Returns a list of roots of a quadratic polynomial. If the domain is ZZ
     then the roots will be sorted with negatives coming before positives.
-    Otherwise the ordering is not guaranteed to be that way but as long as
-    the coefficients are numbers they will be if the assumption system does
-    not fail."""
+    The ordering will be the same for any numerical coefficients as long as
+    the assumptions tested are correct, otherwise the ordering will not be
+    sorted (but will be canonical).
+    """
 
     a, b, c = f.all_coeffs()
     dom = f.get_domain()
@@ -336,9 +337,9 @@ def roots_quartic(f):
 def roots_binomial(f):
     """Returns a list of roots of a binomial polynomial. If the domain is ZZ
     then the roots will be sorted with negatives coming before positives.
-    Otherwise the ordering is not guaranteed to be that way but as long as
-    the coefficients are numbers they will be if the assumption system does
-    not fail.
+    The ordering will be the same for any numerical coefficients as long as
+    the assumptions tested are correct, otherwise the ordering will not be
+    sorted (but will be canonical).
     """
     n = f.degree()
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -48,6 +48,7 @@ from sympy.utilities import group, sift, public
 
 import sympy.polys
 import sympy.mpmath
+from sympy.mpmath.libmp.libhyper import NoConvergence
 
 from sympy.polys.domains import FF, QQ, ZZ
 from sympy.polys.constructor import construct_domain
@@ -3408,6 +3409,10 @@ class Poly(Expr):
             # so we make sure this convention holds here, too.
             roots = list(map(sympify,
                 sorted(roots, key=lambda r: (1 if r.imag else 0, r.real, r.imag))))
+        except NoConvergence:
+            raise NoConvergence(
+                'convergence to root failed; try n < %s or maxsteps > %s' % (
+                n, maxsteps))
         finally:
             sympy.mpmath.mp.dps = dps
 

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -1272,7 +1272,7 @@ def _vertical_bisection(N, a, b, I, Q, F1, F2, f1, f2, F):
     f1L1F, f1L2F, f1L3F, f1L4F = F1
     f2L1F, f2L2F, f2L3F, f2L4F = F2
 
-    x = (u + s) / 2
+    x = (u + s) / 2 or u + (s - u) / 3  # keep off the y-axis
 
     f1V = dmp_eval_in(f1, x, 0, 1, F)
     f2V = dmp_eval_in(f2, x, 0, 1, F)

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -247,23 +247,13 @@ class RootOf(Expr):
             assert not isift
             if not mixed:
                 continue
-            # only 2 of the mixed ones are actually imaginary
-            # issue 8316 indicates that there may be a problem
-            # in identifying the imaginary ones so we limit
-            # the iterations. If everything is working then
-            # the loop should just be controlled with "while True";
-            # for now it allows 4 iterations per element with
-            # hopes that that will be sufficient to allow all
-            # x-values to have refined from 0 if they are going
-            # to do so.
-            missing = f.degree() - 2 - len(mixed)
-            for i in range(len(mixed)*4):
-                # see if the non-imaginary ones can be identified
-                # as having no 0 in the x coordinates
+            while True:
+                # the non-imaginary ones will be on one side or the other
+                # of the y-axis
                 i = 0
                 while i < len(mixed):
                     u, f, k = mixed[i]
-                    if u.ax != 0 and u.bx != 0:
+                    if u.ax*u.bx > 0:
                         complexes.append(mixed.pop(i))
                     else:
                         i += 1
@@ -274,16 +264,6 @@ class RootOf(Expr):
                 for i, (u, f, k) in enumerate(mixed):
                     u = u._inner_refine()
                     mixed[i] = u, f, k
-            else:
-                from sympy.utilities import filldedent
-                raise NotImplementedError(filldedent('''
-                    Known issue 8316: the imaginary roots have not been
-                    identified because no intervals has refined
-                    to give a nonzero x value.%s Poly.nroots should
-                    be able to give numerical approximations of the roots;
-                    roots() should be able to give all the unsorted
-                    roots.''' % ('' if not missing else ''' %s
-                    of the roots were missing, too.''' % missing)))
         return imag, complexes
 
     @classmethod

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -486,9 +486,9 @@ class RootOf(Expr):
             return None
 
         if poly.degree() == 2:
-            return roots_quadratic(poly, _sort=False)
+            return roots_quadratic(poly)
         elif poly.length() == 2 and poly.TC():
-            return roots_binomial(poly, _sort=False)
+            return roots_binomial(poly)
         else:
             return None
 

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -80,10 +80,6 @@ def test_issue_8285():
     # imaginary ones
     roots = Poly(2*x**8 - 1).all_roots()
     assert roots == _nsort(roots)
-
-
-@XFAIL
-def test_Issue_8255_fail():
     assert len(Poly(2*x**10 - 1).all_roots()) == 10  # doesn't fail
 
 

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -57,8 +57,6 @@ def test_roots_quadratic():
     f = Poly(sqrt(2)*x**2 - 1, x)
     r = roots_quadratic(f)
     assert r == _nsort(r)
-    r = roots_quadratic(f, _sort=True)
-    assert r == sorted(r, key=default_sort_key)
 
     # issue 8255
     f = Poly(-24*x**2 - 180*x + 264)
@@ -66,7 +64,7 @@ def test_roots_quadratic():
            [w.n(2) for w in f.all_roots(radicals=False)]
     for _a, _b, _c in cartes((-2, 2), (-2, 2), (0, -1)):
         f = Poly(_a*x**2 + _b*x + _c)
-        roots = roots_quadratic(f, _sort=False)
+        roots = roots_quadratic(f)
         assert roots == _nsort(roots)
 
 
@@ -110,12 +108,12 @@ def test_roots_cubic():
     assert roots_cubic(Poly(2*x**3 - 3*x**2 - 3*x - 1, x))[0] == \
          S.Half + 3**Rational(1, 3)/2 + 3**Rational(2, 3)/2
     eq = -x**3 + 2*x**2 + 3*x - 2
-    assert list(sorted((
-        roots(eq, trig=True, multiple=True)))) == \
-        roots_cubic(Poly(eq, x), trig=True) == [
-        -2*sqrt(13)*cos(-acos(8*sqrt(13)/169)/3 + pi/3)/3 + S(2)/3,
+    assert roots(eq, trig=True, multiple=True) == \
+           roots_cubic(Poly(eq, x), trig=True) == [
+        S(2)/3 + 2*sqrt(13)*cos(acos(8*sqrt(13)/169)/3)/3,
         -2*sqrt(13)*sin(-acos(8*sqrt(13)/169)/3 + pi/6)/3 + S(2)/3,
-        S(2)/3 + 2*sqrt(13)*cos(acos(8*sqrt(13)/169)/3)/3]
+        -2*sqrt(13)*cos(-acos(8*sqrt(13)/169)/3 + pi/3)/3 + S(2)/3,
+        ]
 
 
 def test_roots_quartic():
@@ -188,10 +186,10 @@ def test_roots_cyclotomic():
     assert roots_cyclotomic(cyclotomic_poly(7, x, polys=True)) == [
         -cos(pi/7) - I*sin(pi/7),
         -cos(pi/7) + I*sin(pi/7),
-        cos(2*pi/7) - I*sin(2*pi/7),
-        cos(2*pi/7) + I*sin(2*pi/7),
         -cos(3*pi/7) - I*sin(3*pi/7),
         -cos(3*pi/7) + I*sin(3*pi/7),
+        cos(2*pi/7) - I*sin(2*pi/7),
+        cos(2*pi/7) + I*sin(2*pi/7),
     ]
 
     assert roots_cyclotomic(cyclotomic_poly(8, x, polys=True)) == [
@@ -214,12 +212,12 @@ def test_roots_cyclotomic():
         cyclotomic_poly(2, x, polys=True), factor=True) == [-1]
 
     assert roots_cyclotomic(cyclotomic_poly(3, x, polys=True), factor=True) == \
-        [-(-1)**(S(1)/3), -1 + (-1)**(S(1)/3)]
+        [-1 + (-1)**(S(1)/3), -(-1)**(S(1)/3)]
     assert roots_cyclotomic(cyclotomic_poly(4, x, polys=True), factor=True) == \
-        [-I, I]
+        [I, -I]
     assert roots_cyclotomic(cyclotomic_poly(5, x, polys=True), factor=True) == \
-        [-(-1)**(S(1)/5), (-1)**(S(2)/5), -(-1)**(S(3)/5),
-         -1 + (-1)**(S(1)/5) - (-1)**(S(2)/5) + (-1)**(S(3)/5)]
+        [(-1)**(S(2)/5), -1 + (-1)**(S(1)/5) - (-1)**(S(2)/5) + (-1)**(S(3)/5), -(-1)**(S(1)/5), -(-1)**(S(3)/5)]
+
     assert roots_cyclotomic(cyclotomic_poly(6, x, polys=True), factor=True) == \
         [(-1)**(S(1)/3), 1 - (-1)**(S(1)/3)]
 
@@ -246,10 +244,8 @@ def test_roots_binomial():
         if a == b and a != 1:  # a == b == 1 is sufficient
             continue
         p = Poly(a*x**n + s*b)
-        roots = roots_binomial(p, _sort=False)
+        roots = roots_binomial(p)
         assert roots == _nsort(roots)
-        roots = roots_binomial(p, _sort=True)
-        assert roots == sorted(roots, key=default_sort_key)
 
 
 def test_roots_preprocessing():
@@ -425,7 +421,7 @@ def test_roots():
         (x - 1)*(x + 1), x, predicate=lambda r: r.is_positive) == {S.One: 1}
 
     assert roots(x**4 - 1, x, filter='Z', multiple=True) == [-S.One, S.One]
-    assert roots(x**4 - 1, x, filter='I', multiple=True) == [-I, I]
+    assert roots(x**4 - 1, x, filter='I', multiple=True) == [I, -I]
 
     assert roots(x**3, x, multiple=True) == [S.Zero, S.Zero, S.Zero]
     assert roots(1234, x, multiple=True) == []
@@ -577,14 +573,14 @@ def test_root_factors():
     assert root_factors(Poly(1, x)) == [Poly(1, x)]
     assert root_factors(Poly(x, x)) == [Poly(x, x)]
 
-    assert root_factors(x**2 - 1, x) == [x - 1, x + 1]
+    assert root_factors(x**2 - 1, x) == [x + 1, x - 1]
     assert root_factors(x**2 - y, x) == [x - sqrt(y), x + sqrt(y)]
 
     assert root_factors((x**4 - 1)**2) == \
-        [x - 1, x - 1, x + 1, x + 1, x - I, x - I, x + I, x + I]
+        [x + 1, x + 1, x - 1, x - 1, x - I, x - I, x + I, x + I]
 
     assert root_factors(Poly(x**4 - 1, x), filter='Z') == \
-        [Poly(x - 1, x), Poly(x + 1, x), Poly(x**2 + 1, x)]
+        [Poly(x + 1, x), Poly(x - 1, x), Poly(x**2 + 1, x)]
     assert root_factors(8*x**2 + 12*x**4 + 6*x**6 + x**8, x, filter='Q') == \
         [x, x, x**6 + 6*x**4 + 12*x**2 + 8]
 

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -2,7 +2,7 @@
 
 from sympy import (S, symbols, Symbol, Wild, Integer, Rational, sqrt,
     powsimp, Lambda, sin, cos, pi, I, Interval, re, im, exp, ZZ, Piecewise,
-    acos, default_sort_key)
+    acos, default_sort_key, root)
 
 from sympy.polys import (Poly, cyclotomic_poly, intervals, nroots, RootOf,
     PolynomialError)
@@ -212,14 +212,14 @@ def test_roots_cyclotomic():
         cyclotomic_poly(2, x, polys=True), factor=True) == [-1]
 
     assert roots_cyclotomic(cyclotomic_poly(3, x, polys=True), factor=True) == \
-        [-1 + (-1)**(S(1)/3), -(-1)**(S(1)/3)]
+        [-root(-1, 3), -1 + root(-1, 3)]
     assert roots_cyclotomic(cyclotomic_poly(4, x, polys=True), factor=True) == \
-        [I, -I]
+        [-I, I]
     assert roots_cyclotomic(cyclotomic_poly(5, x, polys=True), factor=True) == \
-        [(-1)**(S(2)/5), -1 + (-1)**(S(1)/5) - (-1)**(S(2)/5) + (-1)**(S(3)/5), -(-1)**(S(1)/5), -(-1)**(S(3)/5)]
+        [-root(-1, 5), -root(-1, 5)**3, root(-1, 5)**2, -1 - root(-1, 5)**2 + root(-1, 5) + root(-1, 5)**3]
 
     assert roots_cyclotomic(cyclotomic_poly(6, x, polys=True), factor=True) == \
-        [(-1)**(S(1)/3), 1 - (-1)**(S(1)/3)]
+        [1 - root(-1, 3), root(-1, 3)]
 
 
 def test_roots_binomial():
@@ -452,7 +452,7 @@ def test_roots():
     r = roots(x**3 + 40*x + 64)
     real_root = [rx for rx in r if rx.is_real][0]
     cr = 4 + 2*sqrt(1074)/9
-    assert real_root == -2*cr**(S(1)/3) + 20/(3*cr**(S(1)/3))
+    assert real_root == -2*root(cr, 3) + 20/(3*root(cr, 3))
 
     eq = Poly((7 + 5*sqrt(2))*x**3 + (-6 - 4*sqrt(2))*x**2 + (-sqrt(2) - 1)*x + 2, x, domain='EX')
     assert roots(eq) == {-1 + sqrt(2): 1, -2 + 2*sqrt(2): 1, -sqrt(2) + 1: 1}
@@ -468,9 +468,9 @@ def test_roots():
     assert roots(eq) == {-2*sqrt(2) + 2: 1, -2*sqrt(2) + 1: 1, -2*sqrt(2) - 1: 1}
 
     assert roots(Poly((x + sqrt(2))**3 - 7, x, domain='EX')) == \
-        {-sqrt(2) - 7**(S(1)/3)/2 - sqrt(3)*7**(S(1)/3)*I/2: 1,
-         -sqrt(2) - 7**(S(1)/3)/2 + sqrt(3)*7**(S(1)/3)*I/2: 1,
-         -sqrt(2) + 7**(S(1)/3): 1}
+        {-sqrt(2) - root(7, 3)/2 - sqrt(3)*root(7, 3)*I/2: 1,
+         -sqrt(2) - root(7, 3)/2 + sqrt(3)*root(7, 3)*I/2: 1,
+         -sqrt(2) + root(7, 3): 1}
 
 def test_roots_slow():
     """Just test that calculating these roots does not hang. """

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2518,8 +2518,9 @@ def test_intervals():
     assert all(re(a) < re(r) < re(b) and im(
         a) < im(r) < im(b) for (a, b), r in zip(complex_part, nroots(f)))
 
-    assert complex_part == [(-S(40)/7 - 40*I/7, 0), (-S(40)/7, 40*I/7),
-                            (-40*I/7, S(40)/7), (0, S(40)/7 + 40*I/7)]
+    a, b, c, d = [S(20)/7, S(10)/7, S(40)/63, S(40)/21]
+    ans = [(-I*b - c, d), (-c, I*b + d), (-I*a - c, -I*b + d), (I*b - c, I*a + d)]
+    assert complex_part == ans
 
     real_part, complex_part = intervals(f, all=True, sqf=True, eps=S(1)/10)
 

--- a/sympy/polys/tests/test_rootisolation.py
+++ b/sympy/polys/tests/test_rootisolation.py
@@ -22,7 +22,7 @@ def test_dup_refine_real_root():
     assert R.dup_refine_real_root(f, QQ(1), QQ(1), steps=1) == (QQ(1), QQ(1))
     assert R.dup_refine_real_root(f, QQ(1), QQ(1), steps=9) == (QQ(1), QQ(1))
 
-    raises(ValueError, lambda: R.dup_refine_real_root(f, QQ(-2), QQ(2)))
+    raises(ValueError, lambda: R.dup_refine_real_root(f, -QQ(2), QQ(2)))
 
     s, t = QQ(1, 1), QQ(2, 1)
 
@@ -48,7 +48,7 @@ def test_dup_refine_real_root():
     assert R.dup_refine_real_root(f, s, t, steps=3) == (QQ(7, 5), QQ(13, 9))
     assert R.dup_refine_real_root(f, s, t, steps=4) == (QQ(7, 5), QQ(27, 19))
 
-    s, t = QQ(-1, 1), QQ(-2, 1)
+    s, t = -QQ(1, 1), -QQ(2, 1)
 
     assert R.dup_refine_real_root(f, s, t, steps=0) == (-QQ(2, 1), -QQ(1, 1))
     assert R.dup_refine_real_root(f, s, t, steps=1) == (-QQ(3, 2), -QQ(1, 1))
@@ -67,9 +67,9 @@ def test_dup_refine_real_root():
     assert R.dup_refine_real_root(f, s, t, eps=QQ(1, 100), steps=6) == (u, v)
     assert R.dup_refine_real_root(f, s, t, eps=QQ(1, 100), steps=7) == (u, v)
 
-    s, t, u, v = QQ(-2), QQ(-1), QQ(-3, 2), QQ(-4, 3)
+    s, t, u, v = -QQ(2), -QQ(1), -QQ(3, 2), -QQ(4, 3)
 
-    assert R.dup_refine_real_root(f, s, t, disjoint=QQ(-5)) == (s, t)
+    assert R.dup_refine_real_root(f, s, t, disjoint=-QQ(5)) == (s, t)
     assert R.dup_refine_real_root(f, s, t, disjoint=-v) == (s, t)
     assert R.dup_refine_real_root(f, s, t, disjoint=v) == (u, v)
 
@@ -170,17 +170,17 @@ def test_dup_isolate_real_roots_sqf():
         [(-1, 0), (0, 1)]
 
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 10)) == \
-        [(QQ(-1, 2), QQ(-3, 7)), (QQ(3, 7), QQ(1, 2))]
+        [(-QQ(1, 2), -QQ(3, 7)), (QQ(3, 7), QQ(1, 2))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 100)) == \
-        [(QQ(-9, 19), QQ(-8, 17)), (QQ(8, 17), QQ(9, 19))]
+        [(-QQ(9, 19), -QQ(8, 17)), (QQ(8, 17), QQ(9, 19))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 1000)) == \
-        [(QQ(-33, 70), QQ(-8, 17)), (QQ(8, 17), QQ(33, 70))]
+        [(-QQ(33, 70), -QQ(8, 17)), (QQ(8, 17), QQ(33, 70))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 10000)) == \
-        [(QQ(-33, 70), QQ(-107, 227)), (QQ(107, 227), QQ(33, 70))]
+        [(-QQ(33, 70), -QQ(107, 227)), (QQ(107, 227), QQ(33, 70))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 100000)) == \
-        [(QQ(-305, 647), QQ(-272, 577)), (QQ(272, 577), QQ(305, 647))]
+        [(-QQ(305, 647), -QQ(272, 577)), (QQ(272, 577), QQ(305, 647))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 1000000)) == \
-        [(QQ(-1121, 2378), QQ(-272, 577)), (QQ(272, 577), QQ(1121, 2378))]
+        [(-QQ(1121, 2378), -QQ(272, 577)), (QQ(272, 577), QQ(1121, 2378))]
 
     f = 200100012*x**5 - 700390052*x**4 + 700490079*x**3 - 200240054*x**2 + 40017*x - 2
 
@@ -745,22 +745,25 @@ def test_dup_isolate_complex_roots_sqf():
     f = x**2 - 2*x + 3
 
     assert R.dup_isolate_complex_roots_sqf(f) == \
-        [((0, -6), (6, 0)), ((0, 0), (6, 6))]
-    assert [ r.as_tuple() for r in R.dup_isolate_complex_roots_sqf(f, blackbox=True) ] == \
-        [((0, -6), (6, 0)), ((0, 0), (6, 6))]
+        [((-2, -6), (6, 0)), ((-2, 0), (6, 6))]
+    assert [ r.as_tuple() for r in
+        R.dup_isolate_complex_roots_sqf(f, blackbox=True) ] == \
+        [((-2, -6), (6, 0)), ((-2, 0), (6, 6))]
 
     assert R.dup_isolate_complex_roots_sqf(f, eps=QQ(1, 10)) == \
-        [((QQ(15, 16), -QQ(3, 2)), (QQ(33, 32), -QQ(45, 32))),
-         ((QQ(15, 16), QQ(45, 32)), (QQ(33, 32), QQ(3, 2)))]
+        [((1, -QQ(3, 2)), (QQ(13, 12), -QQ(45, 32))),
+         ((1, QQ(45, 32)), (QQ(13, 12), QQ(3, 2)))]
     assert R.dup_isolate_complex_roots_sqf(f, eps=QQ(1, 100)) == \
-        [((QQ(255, 256), -QQ(363, 256)), (QQ(513, 512), -QQ(723, 512))),
-         ((QQ(255, 256), QQ(723, 512)), (QQ(513, 512), QQ(363, 256)))]
+        [((1, -QQ(363, 256)), (QQ(193, 192), -QQ(723, 512))),
+         ((1, QQ(723, 512)), (QQ(193, 192), QQ(363, 256)))]
 
     f = 7*x**4 - 19*x**3 + 20*x**2 + 17*x + 20
 
     assert R.dup_isolate_complex_roots_sqf(f) == \
-        [((-QQ(40, 7), -QQ(40, 7)), (0, 0)), ((-QQ(40, 7), 0), (0, QQ(40, 7))),
-         ((0, -QQ(40, 7)), (QQ(40, 7), 0)), ((0, 0), (QQ(40, 7), QQ(40, 7)))]
+        [((-QQ(40, 63), -QQ(10, 7)), (QQ(40, 21), 0)), ((-QQ(40, 63), 0),
+        (QQ(40, 21), QQ(10, 7))), ((-QQ(40, 63), -QQ(20, 7)),
+        (QQ(40, 21), -QQ(10, 7))), ((-QQ(40, 63), QQ(10, 7)),
+        (QQ(40, 21), QQ(20, 7)))]
 
 
 def test_dup_isolate_all_roots_sqf():
@@ -769,11 +772,13 @@ def test_dup_isolate_all_roots_sqf():
 
     assert R.dup_isolate_all_roots_sqf(f) == \
         ([(-1, 0), (0, 0)],
-         [((0, -QQ(5, 2)), (QQ(5, 2), 0)), ((0, 0), (QQ(5, 2), QQ(5, 2)))])
+         [((-QQ(5, 6), -QQ(5, 2)), (QQ(5, 2), 0)),
+         ((-QQ(5, 6), 0), (QQ(5, 2), QQ(5, 2)))])
 
     assert R.dup_isolate_all_roots_sqf(f, eps=QQ(1, 10)) == \
-        ([(QQ(-7, 8), QQ(-6, 7)), (0, 0)],
-         [((QQ(35, 64), -QQ(35, 32)), (QQ(5, 8), -QQ(65, 64))), ((QQ(35, 64), QQ(65, 64)), (QQ(5, 8), QQ(35, 32)))])
+        ([(-QQ(7, 8), -QQ(6, 7)), (0, 0)],
+         [((QQ(35, 72), -QQ(35, 32)), (QQ(5, 9), -QQ(65, 64))),
+         ((QQ(35, 72), QQ(65, 64)), (QQ(5, 9), QQ(35, 32)))])
 
 
 def test_dup_isolate_all_roots():
@@ -782,13 +787,13 @@ def test_dup_isolate_all_roots():
 
     assert R.dup_isolate_all_roots(f) == \
         ([((-1, 0), 1), ((0, 0), 1)],
-         [(((0, -QQ(5, 2)), (QQ(5, 2), 0)), 1),
-          (((0, 0), (QQ(5, 2), QQ(5, 2))), 1)])
+         [(((-QQ(5, 6), -QQ(5, 2)), (QQ(5, 2), 0)), 1),
+          (((-QQ(5, 6), 0), (QQ(5, 2), QQ(5, 2))), 1)])
 
     assert R.dup_isolate_all_roots(f, eps=QQ(1, 10)) == \
-        ([((QQ(-7, 8), QQ(-6, 7)), 1), ((0, 0), 1)],
-         [(((QQ(35, 64), -QQ(35, 32)), (QQ(5, 8), -QQ(65, 64))), 1),
-          (((QQ(35, 64), QQ(65, 64)), (QQ(5, 8), QQ(35, 32))), 1)])
+        ([((-QQ(7, 8), -QQ(6, 7)), 1), ((0, 0), 1)],
+         [(((QQ(35, 72), -QQ(35, 32)), (QQ(5, 9), -QQ(65, 64))), 1),
+          (((QQ(35, 72), QQ(65, 64)), (QQ(5, 9), QQ(35, 32))), 1)])
 
     f = x**5 + x**4 - 2*x**3 - 2*x**2 + x + 1
     raises(NotImplementedError, lambda: R.dup_isolate_all_roots(f))

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -382,9 +382,8 @@ def test_issue_7876():
     assert frozenset(l1) == frozenset(l2)
 
 
-@XFAIL
 def test_issue_8316():
-    f = Poly(7*x**8 - 9)  # error: 2 missing, 4 don't refine
+    f = Poly(7*x**8 - 9)
     assert len(f.all_roots()) == 8
-    f = Poly(7*x**8 - 10)  # error: 0 missing, 4 don't refine
+    f = Poly(7*x**8 - 10)
     assert len(f.all_roots()) == 8


### PR DESCRIPTION
closes #8294 
fixes #8285 - although there are things that are not implemented, e.g.

```
>>> p=Poly([-8, -7, -9, 1, -6, -5, -4, -6, -5, -4],x)
>>> p.all_roots()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\polys\polytools.py", line 3341, in all_roots
    roots = sympy.polys.rootoftools.RootOf.all_roots(f, radicals=radicals)
  File "sympy\polys\rootoftools.py", line 148, in all_roots
    return cls._get_roots("_all_roots", poly, radicals)
  File "sympy\polys\rootoftools.py", line 512, in _get_roots
    for root in getattr(cls, method)(poly):
  File "sympy\polys\rootoftools.py", line 450, in _all_roots
    complexes = cls._complexes_sorted(complexes)
  File "sympy\polys\rootoftools.py", line 319, in _complexes_sorted
    complexes = cls._refine_complexes(complexes)
  File "sympy\polys\rootoftools.py", line 299, in _refine_complexes
    u = u._inner_refine()
  File "sympy\polys\rootisolation.py", line 1846, in _inner_refine
    D_L, D_R = _vertical_bisection(1, (u, v), (s, t), I, Q, F1, F2, f1, f2, dom)

  File "sympy\polys\rootisolation.py", line 1345, in _vertical_bisection
    T_L = _traverse_quadrants(Q_L1_L, Q_L2_L, Q_L3_L, Q_L4_L, exclude=True)
  File "sympy\polys\rootisolation.py", line 1170, in _traverse_quadrants
    raise NotImplementedError("2 element rule (inside): " + str(qq))
NotImplementedError: 2 element rule (inside): ('Q3', 'Q3')
```

there are expressions that formerly failed that can be handled successfully now so I am marking the issue as closed
fixes #8316
closes #8306
