### PR TITLE
Improve _eval_is_algebraic helper for trigonometric numbers

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -100,6 +100,8 @@ def test_sin():
     assert sin(0, evaluate=False).is_algebraic
     assert sin(a).is_algebraic is None
     assert sin(na).is_algebraic is False
+    q = Symbol('q', rational=True)
+    assert sin(pi*q).is_algebraic
 
     assert isinstance(sin( re(x) - im(y)), sin) is True
     assert isinstance(sin(-re(x) + im(y)), sin) is False
@@ -277,6 +279,9 @@ def test_cos():
     assert cos(0, evaluate=False).is_algebraic
     assert cos(a).is_algebraic is None
     assert cos(na).is_algebraic is False
+    q = Symbol('q', rational=True)
+    assert cos(pi*q).is_algebraic
+    assert cos(2*pi/7).is_algebraic
 
     assert cos(k*pi) == (-1)**k
     assert cos(2*k*pi) == 1

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -34,6 +34,9 @@ class TrigonometricFunction(Function):
         if s.func == self.func:
             if self.args[0].is_nonzero and self.args[0].is_algebraic:
                 return False
+            pi_coeff = _pi_coeff(self.args[0])
+            if pi_coeff is not None and pi_coeff.is_rational:
+                return True
         else:
             return s.is_algebraic
 


### PR DESCRIPTION
Now for sin(pi_rational) or cos(pi_rational) - is_algebraic is True,
see: http://mathworld.wolfram.com/TrigonometryAngles.html

fixes #8349
