### PR TITLE
8247: use minpoly in Expr._eval_is_zero

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -663,42 +663,39 @@ class Expr(Basic, EvalfMixin):
             return diff
         return None
 
-    def _eval_is_zero(self):
+    def _eval_is_positive(self):
         from sympy.polys import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic
         if self.is_number:
-            if self.is_algebraic:
+            if self.is_real is False:
+                return False
+            try:
+                # check to see that we can get a value
+                n2 = self._eval_evalf(2)
+                if n2 is None:
+                    raise AttributeError
+                if n2._prec == 1:  # no significance
+                    raise AttributeError
+                if n2 == S.NaN:
+                    raise AttributeError
+            except (AttributeError, ValueError):
+                return None
+            n, i = self.evalf(2).as_real_imag()
+            if not i.is_Number or not n.is_Number:
+                return False
+            if n._prec != 1 and i._prec != 1:
+                return bool(not i and n > 0)
+            elif n._prec == 1 and (not i or i._prec == 1) and \
+                    self.is_algebraic:
                 try:
                     if minimal_polynomial(self).is_Symbol:
-                        return True
+                        return False
                 except (NotAlgebraic, NotImplementedError):
                     pass
 
-    def _eval_is_positive(self):
-        if self.is_number:
-            if self.is_real is False:
-                return False
-            try:
-                # check to see that we can get a value
-                n2 = self._eval_evalf(2)
-                if n2 is None:
-                    raise AttributeError
-                if n2._prec == 1:  # no significance
-                    raise AttributeError
-                if n2 == S.NaN:
-                    raise AttributeError
-            except (AttributeError, ValueError):
-                return None
-            n, i = self.evalf(2).as_real_imag()
-            if not i.is_Number or not n.is_Number:
-                return False
-            if i:
-                if i._prec != 1:
-                    return False
-            elif n._prec != 1:
-                return n > 0
-
     def _eval_is_negative(self):
+        from sympy.polys import minimal_polynomial
+        from sympy.polys.polyerrors import NotAlgebraic
         if self.is_number:
             if self.is_real is False:
                 return False
@@ -716,11 +713,15 @@ class Expr(Basic, EvalfMixin):
             n, i = self.evalf(2).as_real_imag()
             if not i.is_Number or not n.is_Number:
                 return False
-            if i:
-                if i._prec != 1:
-                    return False
-            elif n._prec != 1:
-                return n < 0
+            if n._prec != 1 and i._prec != 1:
+                return bool(not i and n < 0)
+            elif n._prec == 1 and (not i or i._prec == 1) and \
+                    self.is_algebraic:
+                try:
+                    if minimal_polynomial(self).is_Symbol:
+                        return False
+                except (NotAlgebraic, NotImplementedError):
+                    pass
 
     def _eval_interval(self, x, a, b):
         """

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -686,7 +686,7 @@ class Expr(Basic, EvalfMixin):
             if n._prec != 1 and i._prec != 1:
                 return bool(not i and n > 0)
             elif n._prec == 1 and (not i or i._prec == 1) and \
-                    self.is_algebraic:
+                    self.is_algebraic and not self.has(Function):
                 try:
                     if minimal_polynomial(self).is_Symbol:
                         return False
@@ -716,7 +716,7 @@ class Expr(Basic, EvalfMixin):
             if n._prec != 1 and i._prec != 1:
                 return bool(not i and n < 0)
             elif n._prec == 1 and (not i or i._prec == 1) and \
-                    self.is_algebraic:
+                    self.is_algebraic and not self.has(Function):
                 try:
                     if minimal_polynomial(self).is_Symbol:
                         return False
@@ -3149,7 +3149,7 @@ def _mag(x):
 from .mul import Mul
 from .add import Add
 from .power import Pow
-from .function import Derivative, expand_mul
+from .function import Derivative, expand_mul, Function
 from .mod import Mod
 from .exprtools import factor_terms
 from .numbers import Integer, Rational

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -664,7 +664,7 @@ class Expr(Basic, EvalfMixin):
         return None
 
     def _eval_is_positive(self):
-        from sympy.polys import minimal_polynomial
+        from sympy.polys.numberfields import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic
         if self.is_number:
             if self.is_real is False:
@@ -694,7 +694,7 @@ class Expr(Basic, EvalfMixin):
                     pass
 
     def _eval_is_negative(self):
-        from sympy.polys import minimal_polynomial
+        from sympy.polys.numberfields import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic
         if self.is_number:
             if self.is_real is False:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1967,6 +1967,22 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True,
     hints['basic'] = basic
     return sympify(e).expand(deep=deep, modulus=modulus, **hints)
 
+# This is a special application of two hints
+
+def _mexpand(expr, recursive=False):
+    # expand multinomials and then expand products; this may not always
+    # be sufficient to give a fully expanded expression (see
+    # test_issue_8247_8354 in test_arit)
+    if expr is None:
+        return
+    was = None
+    while was != expr:
+        was, expr = expr, expand_mul(expand_multinomial(expr))
+        if not recursive:
+            break
+    return expr
+
+
 # These are simple wrappers around single hints.
 
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1774,3 +1774,9 @@ def test_issue_8247_8354():
     z = 2*(-3*tan(19*pi/90) + sqrt(3))*cos(11*pi/90)*cos(19*pi/90) - \
         sqrt(3)*(-3 + 4*cos(19*pi/90)**2)
     assert z.is_positive is not True  # it's zero and it shouldn't hang
+    z = S('''9*(3*sqrt(93) + 29)**(2/3)*((3*sqrt(93) +
+        29)**(1/3)*(-2**(2/3)*(3*sqrt(93) + 29)**(1/3) - 2) - 2*2**(1/3))**3 +
+        72*(3*sqrt(93) + 29)**(2/3)*(81*sqrt(93) + 783) + (162*sqrt(93) +
+        1566)*((3*sqrt(93) + 29)**(1/3)*(-2**(2/3)*(3*sqrt(93) + 29)**(1/3) -
+        2) - 2*2**(1/3))**2''')
+    assert z.is_positive is False  # it's 0 (and a single _mexpand isn't enough)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1764,9 +1764,13 @@ def test_mul_zero_detection():
 
 
 def test_issue_8247_8354():
+    from sympy import tan
     z = sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3)) - sqrt(10 + 6*sqrt(3))
     assert z.is_positive is False  # it's 0
     z = S('''-2**(1/3)*(3*sqrt(93) + 29)**2 - 4*(3*sqrt(93) + 29)**(4/3) +
         12*sqrt(93)*(3*sqrt(93) + 29)**(1/3) + 116*(3*sqrt(93) + 29)**(1/3) +
         174*2**(1/3)*sqrt(93) + 1678*2**(1/3)''')
     assert z.is_positive is False  # it's 0
+    z = 2*(-3*tan(19*pi/90) + sqrt(3))*cos(11*pi/90)*cos(19*pi/90) - \
+        sqrt(3)*(-3 + 4*cos(19*pi/90)**2)
+    assert z.is_positive is not True  # it's zero and it shouldn't hang

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -803,8 +803,10 @@ def test_Add_is_negative_positive():
     assert (n + x).is_positive is None
     assert (n + x - k).is_positive is None
 
-    assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).is_zero is not False
-
+    z = (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2)
+    assert z.is_zero
+    z = sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3)) - sqrt(10 + 6*sqrt(3))
+    assert z.is_zero
 
 def test_Add_is_nonpositive_nonnegative():
     x = Symbol('x', real=True)
@@ -1759,3 +1761,12 @@ def test_mul_zero_detection():
         b = Dummy('b', finite=ib, real=True)
         e = Mul(b, z, evaluate=False)
         test(z, b, e)
+
+
+def test_issue_8247_8354():
+    z = sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3)) - sqrt(10 + 6*sqrt(3))
+    assert z.is_positive is False  # it's 0
+    z = S('''-2**(1/3)*(3*sqrt(93) + 29)**2 - 4*(3*sqrt(93) + 29)**(4/3) +
+        12*sqrt(93)*(3*sqrt(93) + 29)**(1/3) + 116*(3*sqrt(93) + 29)**(1/3) +
+        174*2**(1/3)*sqrt(93) + 1678*2**(1/3)''')
+    assert z.is_positive is False  # it's 0

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -285,7 +285,7 @@ def test_factor_nc():
     n, m, o = symbols('n,m,o', commutative=False)
 
     # mul and multinomial expansion is needed
-    from sympy.simplify.simplify import _mexpand
+    from sympy.core.function import _mexpand
     e = x*(1 + y)**2
     assert _mexpand(e) == x + x*2*y + x*y**2
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -4,7 +4,7 @@ from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         Tuple, Dummy, Eq, Expr, symbols, nfloat)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import t, w, x, y, z
-from sympy.core.function import PoleError
+from sympy.core.function import PoleError, _mexpand
 from sympy.sets.sets import FiniteSet
 from sympy.solvers import solve
 from sympy.utilities.iterables import subsets, variations
@@ -651,6 +651,7 @@ def test_issue_7231():
     ans2 = f(x).series(x, a)
     assert res == ans2
 
+
 def test_issue_7687():
     from sympy.core.function import Function
     from sympy.abc import x
@@ -663,6 +664,7 @@ def test_issue_7687():
     assert isinstance(f, type(ff))
     assert match_with_cache == ff.matches(f)
 
+
 def test_issue_7688():
     from sympy.core.function import Function, UndefinedFunction
     from sympy.abc import x
@@ -673,3 +675,10 @@ def test_issue_7688():
         pass
     a = A('f')
     assert isinstance(a, type(f))
+
+
+def test_mexpand():
+    from sympy.abc import x
+    assert _mexpand(None) is None
+    assert _mexpand(1) is S.One
+    assert _mexpand(x*(x + 1)**2) == (x*(x + 1)**2).expand()

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -44,7 +44,8 @@ from sympy.utilities import (
 )
 
 from sympy.core.exprtools import Factors
-from sympy.simplify.simplify import _mexpand, _is_sum_surds, _split_gcd
+from sympy.core.function import _mexpand
+from sympy.simplify.simplify import _is_sum_surds, _split_gcd
 from sympy.ntheory import sieve
 from sympy.ntheory.factor_ import divisors
 from sympy.mpmath import pslq, mp
@@ -638,7 +639,7 @@ def minimal_polynomial(ex, x=None, **args):
     ex = sympify(ex)
     if ex.is_number:
         # not sure if it's always needed but try it for numbers (issue 8354)
-        ex = _mexpand(ex)
+        ex = _mexpand(ex, recursive=True)
     for expr in preorder_traversal(ex):
         if expr.is_AlgebraicNumber:
             compose = False

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -44,7 +44,7 @@ from sympy.utilities import (
 )
 
 from sympy.core.exprtools import Factors
-from sympy.simplify.simplify import _mexpand, _is_sum_surds
+from sympy.simplify.simplify import _mexpand, _is_sum_surds, _split_gcd
 from sympy.ntheory import sieve
 from sympy.ntheory.factor_ import divisors
 from sympy.mpmath import pslq, mp
@@ -117,7 +117,6 @@ def _separate_sq(p):
     -x**8 + 48*x**6 - 536*x**4 + 1728*x**2 - 400
 
     """
-    from sympy.simplify.simplify import _split_gcd, _mexpand
     from sympy.utilities.iterables import sift
     def is_sqrt(expr):
         return expr.is_Pow and expr.exp is S.Half
@@ -637,6 +636,9 @@ def minimal_polynomial(ex, x=None, **args):
     dom = args.get('domain', None)
 
     ex = sympify(ex)
+    if ex.is_number:
+        # not sure if it's always needed but try it for numbers (issue 8354)
+        ex = _mexpand(ex)
     for expr in preorder_traversal(ex):
         if expr.is_AlgebraicNumber:
             compose = False

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -488,9 +488,14 @@ def test_roots_slow():
     f = x**3 + 2*x**2 + 8
     R = list(roots(f).keys())
 
-    assert f.subs(x, R[0]).is_zero
-    assert f.subs(x, R[1]).is_zero
-    assert f.subs(x, R[2]).is_zero
+    # these 3 tests *can* be done symboliccaly but they are very slow
+    # the issue was to affirm that the numerical calculation did not
+    # fail
+    assert not any(i for i in [f.subs(x, ri).n(chop=True) for ri in R])
+
+    assert f.subs(x, R[0]).simplify() == 0
+    assert f.subs(x, R[1]).simplify() == 0
+    assert f.subs(x, R[2]).is_zero  # simplify is very slow on this!
 
 
 def test_roots_inexact():

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -488,9 +488,9 @@ def test_roots_slow():
     f = x**3 + 2*x**2 + 8
     R = list(roots(f).keys())
 
-    assert f.subs(x, R[0]).simplify() == 0
-    assert f.subs(x, R[1]).simplify() == 0
-    assert f.subs(x, R[2]).simplify() == 0
+    assert f.subs(x, R[0]).is_zero
+    assert f.subs(x, R[1]).is_zero
+    assert f.subs(x, R[2]).is_zero
 
 
 def test_roots_inexact():

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -488,14 +488,7 @@ def test_roots_slow():
     f = x**3 + 2*x**2 + 8
     R = list(roots(f).keys())
 
-    # these 3 tests *can* be done symboliccaly but they are very slow
-    # the issue was to affirm that the numerical calculation did not
-    # fail
     assert not any(i for i in [f.subs(x, ri).n(chop=True) for ri in R])
-
-    assert f.subs(x, R[0]).simplify() == 0
-    assert f.subs(x, R[1]).simplify() == 0
-    assert f.subs(x, R[2]).is_zero  # simplify is very slow on this!
 
 
 def test_roots_inexact():

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -14,7 +14,7 @@ from sympy.core.cache import cacheit
 from sympy.core.compatibility import iterable, reduce, default_sort_key, ordered, xrange
 from sympy.core.exprtools import Factors, gcd_terms
 from sympy.core.numbers import Float, Number, I
-from sympy.core.function import expand_log, count_ops
+from sympy.core.function import expand_log, count_ops, _mexpand
 from sympy.core.mul import _keep_coeff, prod
 from sympy.core.rules import Transform
 from sympy.core.evaluate import global_evaluate
@@ -36,9 +36,6 @@ from sympy.polys import (Poly, together, reduced, cancel, factor,
 
 import sympy.mpmath as mpmath
 
-
-def _mexpand(expr):
-    return expand_mul(expand_multinomial(expr))
 
 
 def fraction(expr, exact=False):

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -5,12 +5,8 @@ from sympy.core import S, Wild, sympify, Mul, Add, Expr
 from sympy.core.function import expand_multinomial, expand_mul
 from sympy.core.symbol import Dummy
 from sympy.polys import Poly, PolynomialError
-from sympy.core.function import count_ops
+from sympy.core.function import count_ops, _mexpand
 from sympy.utilities import default_sort_key
-
-
-def _mexpand(expr):
-    return expand_mul(expand_multinomial(expr))
 
 
 def is_sqrt(expr):

--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -10,7 +10,8 @@ from sympy.core.symbol import (Dummy, Wild)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.miscellaneous import root
 from sympy.polys.polytools import (Poly, primitive, factor)
-from sympy.simplify.simplify import (_mexpand, collect, separatevars)
+from sympy.core.function import _mexpand
+from sympy.simplify.simplify import (collect, separatevars)
 from sympy.solvers.solvers import solve, _invert
 
 

--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -4,7 +4,8 @@ from sympy import (degree_list, Poly, igcd, divisors, sign, symbols, S, Integer,
     Add, Mul, solve, ceiling, floor, sqrt, sympify, Subs, ilcm, Matrix, factor_list, perfect_power,
     isprime, nextprime, integer_nthroot, Expr, Pow)
 
-from sympy.simplify.simplify import rad_rationalize, _mexpand
+from sympy.core.function import _mexpand
+from sympy.simplify.simplify import rad_rationalize
 from sympy.ntheory.modular import solve_congruence
 from sympy.utilities import default_sort_key, numbered_symbols
 from sympy.core.numbers import igcdex

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -237,7 +237,7 @@ from sympy.core import Add, C, S, Mul, Pow, oo
 from sympy.core.compatibility import ordered, iterable, is_sequence, xrange
 from sympy.core.exprtools import factor_terms, gcd_terms
 from sympy.core.function import (Function, Derivative, AppliedUndef, diff,
-    expand, expand_mul, Subs)
+    expand, expand_mul, Subs, _mexpand)
 from sympy.core.multidimensional import vectorize
 from sympy.core.numbers import Rational, NaN, zoo, I
 from sympy.core.relational import Equality, Eq
@@ -256,7 +256,7 @@ from sympy.series import Order
 from sympy.series.series import series
 from sympy.simplify import collect, logcombine, powsimp, separatevars, \
     simplify, trigsimp, denom, fraction, posify, cse
-from sympy.simplify.simplify import _mexpand, collect_const, powdenest
+from sympy.simplify.simplify import collect_const, powdenest
 from sympy.solvers import solve
 
 from sympy.utilities import numbered_symbols, default_sort_key, sift

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -23,7 +23,8 @@ from sympy.core import (C, S, Add, Symbol, Wild, Equality, Dummy, Basic,
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import (expand_mul, expand_multinomial, expand_log,
                           Derivative, AppliedUndef, UndefinedFunction, nfloat,
-                          count_ops, Function, expand_power_exp, Lambda)
+                          count_ops, Function, expand_power_exp, Lambda,
+                          _mexpand)
 from sympy.core.numbers import ilcm, Float
 from sympy.core.relational import Relational, Ge
 from sympy.logic.boolalg import And, Or
@@ -36,7 +37,7 @@ from sympy.functions import (log, exp, LambertW, cos, sin, tan, cot, cosh,
 from sympy.functions.elementary.miscellaneous import real_root
 from sympy.simplify import (simplify, collect, powsimp, posify, powdenest,
                             nsimplify, denom, logcombine)
-from sympy.simplify.sqrtdenest import sqrt_depth, _mexpand
+from sympy.simplify.sqrtdenest import sqrt_depth
 from sympy.simplify.fu import TR1, hyper_as_trig
 from sympy.matrices import Matrix, zeros
 from sympy.polys import (roots, cancel, factor, Poly, together, RootOf,

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -4,10 +4,10 @@ from sympy.solvers.diophantine import (diop_solve, diop_DN, diop_bf_DN, length, 
     prime_as_sum_of_two_squares, partition, power_representation)
 
 from sympy import symbols, Integer, Matrix, simplify, Subs, S, factorint, factor_list
+from sympy.core.function import _mexpand
+from sympy.functions.elementary.trigonometric import sin
 from sympy.utilities.pytest import XFAIL, slow, raises
 from sympy.utilities import default_sort_key
-from sympy.simplify.simplify import _mexpand
-from sympy.functions.elementary.trigonometric import sin
 
 x, y, z, w, t, X, Y, Z = symbols("x, y, z, w, t, X, Y, Z", integer=True)
 


### PR DESCRIPTION
closes #8274 
closes #8354

Put a guard on try/minpoly to watch for NotImplemented and NotAlgebraic:

sympy/integrals/transforms.py", line 1818, in
sympy.integrals.transforms.inverse_hankel_transform
Failed example:
    inverse_hankel_transform(ht, k, r, 0)
    Exception raised:
        Traceback (most recent call last):
        ...
    NotAlgebraic: exp_polar(0) doesn't seem to be an algebraic element

See also issues #8349, #8352, #8353, #8354.
