### PR TITLE
polys: Borderline cases in complex root isolation

### DIFF
--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -738,6 +738,12 @@ A3 = 'A3'  # Axis #3 (-0): re < 0 and im = 0
 A4 = 'A4'  # Axis #4 (0-): re = 0 and im < 0
 
 _rules_simple = {
+    # Q --> Q (same) => no change
+    (Q1, Q1): 0,
+    (Q2, Q2): 0,
+    (Q3, Q3): 0,
+    (Q4, Q4): 0,
+
     # A -- CCW --> Q => +1/4 (CCW)
     (A1, Q1): 1,
     (A2, Q2): 1,
@@ -914,6 +920,7 @@ _rules_ambiguous = {
 }
 
 _values = {
+    0: [( 0, 1)],
     1: [(+1, 4)],
     2: [(-1, 4)],
     3: [(+1, 4)],
@@ -1272,7 +1279,7 @@ def _vertical_bisection(N, a, b, I, Q, F1, F2, f1, f2, F):
     f1L1F, f1L2F, f1L3F, f1L4F = F1
     f2L1F, f2L2F, f2L3F, f2L4F = F2
 
-    x = (u + s) / 2 or u + (s - u) / 3  # keep off the y-axis
+    x = (u + s) / 2
 
     f1V = dmp_eval_in(f1, x, 0, 1, F)
     f2V = dmp_eval_in(f2, x, 0, 1, F)
@@ -1305,7 +1312,7 @@ def _vertical_bisection(N, a, b, I, Q, F1, F2, f1, f2, F):
 
                 if b <= x:
                     I_L1_L.append(((a, b), indices, h))
-                else:
+                if a >= x:
                     I_L1_R.append(((a, b), indices, h))
 
     for I in I_L3:
@@ -1329,7 +1336,7 @@ def _vertical_bisection(N, a, b, I, Q, F1, F2, f1, f2, F):
 
                 if b <= x:
                     I_L3_L.append(((b, a), indices, h))
-                else:
+                if a >= x:
                     I_L3_R.append(((b, a), indices, h))
 
     Q_L1_L = _intervals_to_quadrants(I_L1_L, f1L1F, f2L1F, u, x, F)
@@ -1411,7 +1418,7 @@ def _horizontal_bisection(N, a, b, I, Q, F1, F2, f1, f2, F):
 
                 if b <= y:
                     I_L2_B.append(((a, b), indices, h))
-                else:
+                if a >= y:
                     I_L2_U.append(((a, b), indices, h))
 
     for I in I_L4:
@@ -1435,7 +1442,7 @@ def _horizontal_bisection(N, a, b, I, Q, F1, F2, f1, f2, F):
 
                 if b <= y:
                     I_L4_B.append(((b, a), indices, h))
-                else:
+                if a >= y:
                     I_L4_U.append(((b, a), indices, h))
 
     Q_L1_B = Q_L1

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2518,9 +2518,8 @@ def test_intervals():
     assert all(re(a) < re(r) < re(b) and im(
         a) < im(r) < im(b) for (a, b), r in zip(complex_part, nroots(f)))
 
-    a, b, c, d = [S(20)/7, S(10)/7, S(40)/63, S(40)/21]
-    ans = [(-I*b - c, d), (-c, I*b + d), (-I*a - c, -I*b + d), (I*b - c, I*a + d)]
-    assert complex_part == ans
+    assert complex_part == [(-S(40)/7 - 40*I/7, 0), (-S(40)/7, 40*I/7),
+                            (-40*I/7, S(40)/7), (0, S(40)/7 + 40*I/7)]
 
     real_part, complex_part = intervals(f, all=True, sqf=True, eps=S(1)/10)
 

--- a/sympy/polys/tests/test_rootisolation.py
+++ b/sympy/polys/tests/test_rootisolation.py
@@ -22,7 +22,7 @@ def test_dup_refine_real_root():
     assert R.dup_refine_real_root(f, QQ(1), QQ(1), steps=1) == (QQ(1), QQ(1))
     assert R.dup_refine_real_root(f, QQ(1), QQ(1), steps=9) == (QQ(1), QQ(1))
 
-    raises(ValueError, lambda: R.dup_refine_real_root(f, -QQ(2), QQ(2)))
+    raises(ValueError, lambda: R.dup_refine_real_root(f, QQ(-2), QQ(2)))
 
     s, t = QQ(1, 1), QQ(2, 1)
 
@@ -48,7 +48,7 @@ def test_dup_refine_real_root():
     assert R.dup_refine_real_root(f, s, t, steps=3) == (QQ(7, 5), QQ(13, 9))
     assert R.dup_refine_real_root(f, s, t, steps=4) == (QQ(7, 5), QQ(27, 19))
 
-    s, t = -QQ(1, 1), -QQ(2, 1)
+    s, t = QQ(-1, 1), QQ(-2, 1)
 
     assert R.dup_refine_real_root(f, s, t, steps=0) == (-QQ(2, 1), -QQ(1, 1))
     assert R.dup_refine_real_root(f, s, t, steps=1) == (-QQ(3, 2), -QQ(1, 1))
@@ -67,9 +67,9 @@ def test_dup_refine_real_root():
     assert R.dup_refine_real_root(f, s, t, eps=QQ(1, 100), steps=6) == (u, v)
     assert R.dup_refine_real_root(f, s, t, eps=QQ(1, 100), steps=7) == (u, v)
 
-    s, t, u, v = -QQ(2), -QQ(1), -QQ(3, 2), -QQ(4, 3)
+    s, t, u, v = QQ(-2), QQ(-1), QQ(-3, 2), QQ(-4, 3)
 
-    assert R.dup_refine_real_root(f, s, t, disjoint=-QQ(5)) == (s, t)
+    assert R.dup_refine_real_root(f, s, t, disjoint=QQ(-5)) == (s, t)
     assert R.dup_refine_real_root(f, s, t, disjoint=-v) == (s, t)
     assert R.dup_refine_real_root(f, s, t, disjoint=v) == (u, v)
 
@@ -170,17 +170,17 @@ def test_dup_isolate_real_roots_sqf():
         [(-1, 0), (0, 1)]
 
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 10)) == \
-        [(-QQ(1, 2), -QQ(3, 7)), (QQ(3, 7), QQ(1, 2))]
+        [(QQ(-1, 2), QQ(-3, 7)), (QQ(3, 7), QQ(1, 2))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 100)) == \
-        [(-QQ(9, 19), -QQ(8, 17)), (QQ(8, 17), QQ(9, 19))]
+        [(QQ(-9, 19), QQ(-8, 17)), (QQ(8, 17), QQ(9, 19))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 1000)) == \
-        [(-QQ(33, 70), -QQ(8, 17)), (QQ(8, 17), QQ(33, 70))]
+        [(QQ(-33, 70), QQ(-8, 17)), (QQ(8, 17), QQ(33, 70))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 10000)) == \
-        [(-QQ(33, 70), -QQ(107, 227)), (QQ(107, 227), QQ(33, 70))]
+        [(QQ(-33, 70), QQ(-107, 227)), (QQ(107, 227), QQ(33, 70))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 100000)) == \
-        [(-QQ(305, 647), -QQ(272, 577)), (QQ(272, 577), QQ(305, 647))]
+        [(QQ(-305, 647), QQ(-272, 577)), (QQ(272, 577), QQ(305, 647))]
     assert R.dup_isolate_real_roots_sqf(f, eps=QQ(1, 1000000)) == \
-        [(-QQ(1121, 2378), -QQ(272, 577)), (QQ(272, 577), QQ(1121, 2378))]
+        [(QQ(-1121, 2378), QQ(-272, 577)), (QQ(272, 577), QQ(1121, 2378))]
 
     f = 200100012*x**5 - 700390052*x**4 + 700490079*x**3 - 200240054*x**2 + 40017*x - 2
 
@@ -745,25 +745,22 @@ def test_dup_isolate_complex_roots_sqf():
     f = x**2 - 2*x + 3
 
     assert R.dup_isolate_complex_roots_sqf(f) == \
-        [((-2, -6), (6, 0)), ((-2, 0), (6, 6))]
-    assert [ r.as_tuple() for r in
-        R.dup_isolate_complex_roots_sqf(f, blackbox=True) ] == \
-        [((-2, -6), (6, 0)), ((-2, 0), (6, 6))]
+        [((0, -6), (6, 0)), ((0, 0), (6, 6))]
+    assert [ r.as_tuple() for r in R.dup_isolate_complex_roots_sqf(f, blackbox=True) ] == \
+        [((0, -6), (6, 0)), ((0, 0), (6, 6))]
 
     assert R.dup_isolate_complex_roots_sqf(f, eps=QQ(1, 10)) == \
-        [((1, -QQ(3, 2)), (QQ(13, 12), -QQ(45, 32))),
-         ((1, QQ(45, 32)), (QQ(13, 12), QQ(3, 2)))]
+        [((QQ(15, 16), -QQ(3, 2)), (QQ(33, 32), -QQ(45, 32))),
+         ((QQ(15, 16), QQ(45, 32)), (QQ(33, 32), QQ(3, 2)))]
     assert R.dup_isolate_complex_roots_sqf(f, eps=QQ(1, 100)) == \
-        [((1, -QQ(363, 256)), (QQ(193, 192), -QQ(723, 512))),
-         ((1, QQ(723, 512)), (QQ(193, 192), QQ(363, 256)))]
+        [((QQ(255, 256), -QQ(363, 256)), (QQ(513, 512), -QQ(723, 512))),
+         ((QQ(255, 256), QQ(723, 512)), (QQ(513, 512), QQ(363, 256)))]
 
     f = 7*x**4 - 19*x**3 + 20*x**2 + 17*x + 20
 
     assert R.dup_isolate_complex_roots_sqf(f) == \
-        [((-QQ(40, 63), -QQ(10, 7)), (QQ(40, 21), 0)), ((-QQ(40, 63), 0),
-        (QQ(40, 21), QQ(10, 7))), ((-QQ(40, 63), -QQ(20, 7)),
-        (QQ(40, 21), -QQ(10, 7))), ((-QQ(40, 63), QQ(10, 7)),
-        (QQ(40, 21), QQ(20, 7)))]
+        [((-QQ(40, 7), -QQ(40, 7)), (0, 0)), ((-QQ(40, 7), 0), (0, QQ(40, 7))),
+         ((0, -QQ(40, 7)), (QQ(40, 7), 0)), ((0, 0), (QQ(40, 7), QQ(40, 7)))]
 
 
 def test_dup_isolate_all_roots_sqf():
@@ -772,13 +769,11 @@ def test_dup_isolate_all_roots_sqf():
 
     assert R.dup_isolate_all_roots_sqf(f) == \
         ([(-1, 0), (0, 0)],
-         [((-QQ(5, 6), -QQ(5, 2)), (QQ(5, 2), 0)),
-         ((-QQ(5, 6), 0), (QQ(5, 2), QQ(5, 2)))])
+         [((0, -QQ(5, 2)), (QQ(5, 2), 0)), ((0, 0), (QQ(5, 2), QQ(5, 2)))])
 
     assert R.dup_isolate_all_roots_sqf(f, eps=QQ(1, 10)) == \
-        ([(-QQ(7, 8), -QQ(6, 7)), (0, 0)],
-         [((QQ(35, 72), -QQ(35, 32)), (QQ(5, 9), -QQ(65, 64))),
-         ((QQ(35, 72), QQ(65, 64)), (QQ(5, 9), QQ(35, 32)))])
+        ([(QQ(-7, 8), QQ(-6, 7)), (0, 0)],
+         [((QQ(35, 64), -QQ(35, 32)), (QQ(5, 8), -QQ(65, 64))), ((QQ(35, 64), QQ(65, 64)), (QQ(5, 8), QQ(35, 32)))])
 
 
 def test_dup_isolate_all_roots():
@@ -787,13 +782,13 @@ def test_dup_isolate_all_roots():
 
     assert R.dup_isolate_all_roots(f) == \
         ([((-1, 0), 1), ((0, 0), 1)],
-         [(((-QQ(5, 6), -QQ(5, 2)), (QQ(5, 2), 0)), 1),
-          (((-QQ(5, 6), 0), (QQ(5, 2), QQ(5, 2))), 1)])
+         [(((0, -QQ(5, 2)), (QQ(5, 2), 0)), 1),
+          (((0, 0), (QQ(5, 2), QQ(5, 2))), 1)])
 
     assert R.dup_isolate_all_roots(f, eps=QQ(1, 10)) == \
-        ([((-QQ(7, 8), -QQ(6, 7)), 1), ((0, 0), 1)],
-         [(((QQ(35, 72), -QQ(35, 32)), (QQ(5, 9), -QQ(65, 64))), 1),
-          (((QQ(35, 72), QQ(65, 64)), (QQ(5, 9), QQ(35, 32))), 1)])
+        ([((QQ(-7, 8), QQ(-6, 7)), 1), ((0, 0), 1)],
+         [(((QQ(35, 64), -QQ(35, 32)), (QQ(5, 8), -QQ(65, 64))), 1),
+          (((QQ(35, 64), QQ(65, 64)), (QQ(5, 8), QQ(35, 32))), 1)])
 
     f = x**5 + x**4 - 2*x**3 - 2*x**2 + x + 1
     raises(NotImplementedError, lambda: R.dup_isolate_all_roots(f))


### PR DESCRIPTION
Complex polynomial root isolation works by subdividing rectangles
in the complex plane and searching for _axial points_ on their
boundaries, i.e., points at which the value of the polynomial lies
on one (or both) of the coordinate axes.

The majority of the axial points are of the 'generic type'. They are
in the middle of a boundary edge, their image is on one axis only, and
the image of the edge under the polynomial map passes from one side to
the other.

However, as the coefficients of the polynomial and the subdivision
points are rational, these conditions are occasionally not met.
The case where an axial point is a root of the polynomial is well
cared for (and quite rare), but there are other situations where
roots are lost or the algorithm is interrupted.
(Changing the subdivision strategy may help but not for all polynomials.)

This commit deals with two exceptional cases.

1) If the image of edge is tangent to the axis and returns to
the same quadrant (axial point of 'even order') there will be
no contribution to the winding number. This is what happens in #8285.

2) If an axial point is also a subdivision point, it has to be
included in both parts of the divided edge (a 'double corner case').
Otherwise roots may be lost as in #8316.
