### PR TITLE
Vpretty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,12 @@ matrix:
         - TEST_AUTOWRAP="true"
       virtualenv:
         system_site_packages: true
+    - python: 2.7
+      env:
+        - TEST_ASCII="true"
+    - python: 3.4
+      env:
+        - TEST_ASCII="true"
   allow_failures:
     - python: 3.3 # Dummy value
       env:

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -17,6 +17,16 @@ if [[ "${TEST_SPHINX}" == "true" ]]; then
 elif [[ "${TEST_SAGE}" == "true" ]]; then
     sage -v
     sage -python bin/test sympy/external/tests/test_sage.py
+elif [[ "${TEST_ASCII}" == "true" ]]; then
+    export LANG=c
+    mkdir empty
+    cd empty
+    cat <<EOF | python
+import sympy
+sympy.test('print')
+EOF
+    cd ..
+    bin/doctest
 else
     # We change directories to make sure that we test the installed version of
     # sympy.

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -7,6 +7,7 @@
 import os
 import re
 import warnings
+import io
 
 from sympy import Basic, S, symbols, sqrt, sin, oo, Interval, exp
 from sympy.utilities.pytest import XFAIL, SKIP
@@ -34,7 +35,7 @@ def test_all_classes_are_tested():
             if not file.endswith(".py"):
                 continue
 
-            with open(os.path.join(root, file), "r") as f:
+            with io.open(os.path.join(root, file), "r", encoding='utf-8') as f:
                 text = f.read()
 
             submodule = module + '.' + file[:-3]

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -67,7 +67,8 @@ def test_print_builtin_option():
         text = app.user_ns['a'][0]['text/plain']
         raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
     # Note : In Python 3 the text is unicode, but in 2 it is a string.
-    assert text in ("{pi: 3.14, n_i: 3}", u('{n\u1d62: 3, \u03c0: 3.14}'))
+    assert text in ("{pi: 3.14, n_i: 3}", u('{n\u1d62: 3, \u03c0: 3.14}'),
+        "{n_i: 3, pi: 3.14}", u('{\u03c0: 3.14, n\u1d62: 3}'))
 
     # If we enable the default printing, then the dictionary's should render
     # as a LaTeX version of the whole dict: ${\pi: 3.14, n_i: 3}$
@@ -81,7 +82,8 @@ def test_print_builtin_option():
     else:
         text = app.user_ns['a'][0]['text/plain']
         latex = app.user_ns['a'][0]['text/latex']
-    assert text == u('{n\u1d62: 3, \u03c0: 3.14}')
+    assert text in ("{pi: 3.14, n_i: 3}", u('{n\u1d62: 3, \u03c0: 3.14}'),
+        "{n_i: 3, pi: 3.14}", u('{\u03c0: 3.14, n\u1d62: 3}'))
     assert latex == r'$$\left \{ n_{i} : 3, \quad \pi : 3.14\right \}$$'
 
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -67,6 +67,8 @@ def test_print_builtin_option():
         text = app.user_ns['a'][0]['text/plain']
         raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
     # Note : In Python 3 the text is unicode, but in 2 it is a string.
+    # XXX: How can we make this ignore the terminal width? This test fails if
+    # the terminal is too narrow.
     assert text in ("{pi: 3.14, n_i: 3}", u('{n\u1d62: 3, \u03c0: 3.14}'),
         "{n_i: 3, pi: 3.14}", u('{\u03c0: 3.14, n\u1d62: 3}'))
 

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -207,33 +207,22 @@ class Dyadic(object):
                 mpp = printer if printer else VectorPrettyPrinter(settings)
                 if len(ar) == 0:
                     return unicode(0)
+                bar = u("\u2297") if use_unicode else "|"
                 ol = []  # output list, to be concatenated to a string
                 for i, v in enumerate(ar):
                     # if the coef of the dyadic is 1, we skip the 1
                     if ar[i][0] == 1:
-                        if use_unicode:
-                            ol.append(u(" + ") +
-                                      mpp.doprint(ar[i][1]) +
-                                      u("\u2297") +
-                                      mpp.doprint(ar[i][2]))
-                        else:
-                            ol.append(" + " +
-                                      mpp.doprint(ar[i][1]) +
-                                      "|" +
-                                      mpp.doprint(ar[i][2]))
+                        ol.extend([u(" + "),
+                                  mpp.doprint(ar[i][1]),
+                                  bar,
+                                  mpp.doprint(ar[i][2])])
 
                     # if the coef of the dyadic is -1, we skip the 1
                     elif ar[i][0] == -1:
-                        if use_unicode:
-                            ol.append(u(" - ") +
-                                      mpp.doprint(ar[i][1]) +
-                                      u("\u2297") +
-                                      mpp.doprint(ar[i][2]))
-                        else:
-                            ol.append(" - " +
-                                  mpp.doprint(ar[i][1]) +
-                                  "|" +
-                                  mpp.doprint(ar[i][2]))
+                        ol.extend([u(" - "),
+                                  mpp.doprint(ar[i][1]),
+                                  bar,
+                                  mpp.doprint(ar[i][2])])
 
                     # If the coefficient of the dyadic is not 1 or -1,
                     # we might wrap it in parentheses, for readability.
@@ -248,16 +237,10 @@ class Dyadic(object):
                             str_start = u(" - ")
                         else:
                             str_start = u(" + ")
-                        if use_unicode:
-                            ol.append(str_start + arg_str + u(" ") +
-                                      mpp.doprint(ar[i][1]) +
-                                      u("\u2297") +
-                                      mpp.doprint(ar[i][2]))
-                        else:
-                            ol.append(str_start + arg_str + u(" ") +
-                                      mpp.doprint(ar[i][1]) +
-                                      "|" +
-                                      mpp.doprint(ar[i][2]))
+                        ol.extend([str_start, arg_str, u(" "),
+                                  mpp.doprint(ar[i][1]),
+                                  bar,
+                                  mpp.doprint(ar[i][2])])
 
                 outstr = u("").join(ol)
                 if outstr.startswith(u(" + ")):

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,5 +1,5 @@
 from sympy import sympify, Add, ImmutableMatrix as Matrix
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, unicode
 from .printing import (VectorLatexPrinter, VectorPrettyPrinter,
                        VectorStrPrinter)
 
@@ -198,28 +198,48 @@ class Dyadic(object):
             def render(self, *args, **kwargs):
                 self = e
                 ar = self.args  # just to shorten things
-                mpp = VectorPrettyPrinter()
+                settings = printer._settings if printer else {}
+                if printer:
+                    use_unicode = printer._use_unicode
+                else:
+                    from sympy.printing.pretty.pretty_symbology import pretty_use_unicode
+                    use_unicode = pretty_use_unicode()
+                mpp = VectorPrettyPrinter(settings)
                 if len(ar) == 0:
                     return unicode(0)
                 ol = []  # output list, to be concatenated to a string
                 for i, v in enumerate(ar):
                     # if the coef of the dyadic is 1, we skip the 1
                     if ar[i][0] == 1:
-                        ol.append(u(" + ") +
-                                  mpp.doprint(ar[i][1]) +
-                                  u("\u2297") +
-                                  mpp.doprint(ar[i][2]))
+                        if use_unicode:
+                            ol.append(u(" + ") +
+                                      mpp.doprint(ar[i][1]) +
+                                      u("\u2297") +
+                                      mpp.doprint(ar[i][2]))
+                        else:
+                            ol.append(" + " +
+                                      mpp.doprint(ar[i][1]) +
+                                      "|" +
+                                      mpp.doprint(ar[i][2]))
+
                     # if the coef of the dyadic is -1, we skip the 1
                     elif ar[i][0] == -1:
-                        ol.append(u(" - ") +
+                        if use_unicode:
+                            ol.append(u(" - ") +
+                                      mpp.doprint(ar[i][1]) +
+                                      u("\u2297") +
+                                      mpp.doprint(ar[i][2]))
+                        else:
+                            ol.append(" - " +
                                   mpp.doprint(ar[i][1]) +
-                                  u("\u2297") +
+                                  "|" +
                                   mpp.doprint(ar[i][2]))
+
                     # If the coefficient of the dyadic is not 1 or -1,
                     # we might wrap it in parentheses, for readability.
                     elif ar[i][0] != 0:
                         if isinstance(ar[i][0], Add):
-                            arg_str = VectorPrettyPrinter()._print(
+                            arg_str = mpp._print(
                                 ar[i][0]).parens()[0]
                         else:
                             arg_str = mpp.doprint(ar[i][0])
@@ -228,10 +248,17 @@ class Dyadic(object):
                             str_start = u(" - ")
                         else:
                             str_start = u(" + ")
-                        ol.append(str_start + arg_str + u(" ") +
-                                  mpp.doprint(ar[i][1]) +
-                                  u("\u2297") +
-                                  mpp.doprint(ar[i][2]))
+                        if use_unicode:
+                            ol.append(str_start + arg_str + u(" ") +
+                                      mpp.doprint(ar[i][1]) +
+                                      u("\u2297") +
+                                      mpp.doprint(ar[i][2]))
+                        else:
+                            ol.append(str_start + arg_str + u(" ") +
+                                      mpp.doprint(ar[i][1]) +
+                                      "|" +
+                                      mpp.doprint(ar[i][2]))
+
                 outstr = u("").join(ol)
                 if outstr.startswith(u(" + ")):
                     outstr = outstr[3:]

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -204,7 +204,7 @@ class Dyadic(object):
                 else:
                     from sympy.printing.pretty.pretty_symbology import pretty_use_unicode
                     use_unicode = pretty_use_unicode()
-                mpp = VectorPrettyPrinter(settings)
+                mpp = printer if printer else VectorPrettyPrinter(settings)
                 if len(ar) == 0:
                     return unicode(0)
                 ol = []  # output list, to be concatenated to a string

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -3,8 +3,7 @@
 from sympy import symbols, sin, cos, sqrt, Function
 from sympy.core.compatibility import u_decode as u
 from sympy.physics.vector import ReferenceFrame, dynamicsymbols
-from sympy.physics.vector.printing import (VectorPrettyPrinter,
-                                           VectorLatexPrinter)
+from sympy.physics.vector.printing import (VectorLatexPrinter, vpprint)
 
 # TODO : Figure out how to make the pretty printing tests readable like the
 # ones in sympy.printing.pretty.tests.test_printing.
@@ -21,11 +20,15 @@ w = alpha * N.x + sin(omega) * N.y + alpha * beta * N.z
 y = a ** 2 * (N.x | N.y) + b * (N.y | N.y) + c * sin(alpha) * (N.z | N.y)
 x = alpha * (N.x | N.x) + sin(omega) * (N.y | N.z) + alpha * beta * (N.z | N.x)
 
+def ascii_vpretty(expr):
+    return vpprint(expr, use_unicode=False)
+
+def unicode_vpretty(expr):
+    return vpprint(expr, use_unicode=True)
 
 def test_latex_printer():
     r = Function('r')('t')
     assert VectorLatexPrinter().doprint(r ** 2) == "r^{2}"
-
 
 def test_vector_pretty_print():
 
@@ -35,21 +38,23 @@ def test_vector_pretty_print():
     # TODO : The pretty print division does not print correctly here:
     # w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z
 
-    pp = VectorPrettyPrinter()
-
-    expected = u("""\
+    expected = """\
+ 2
+a  n_x + b n_y + c*sin(alpha) n_z\
+"""
+    uexpected = u("""\
  2
 a  n_x + b n_y + c⋅sin(α) n_z\
 """)
 
-    assert expected == pp.doprint(v)
-    assert expected == v._pretty().render()
+    assert ascii_vpretty(v) == expected
+    assert unicode_vpretty(v) == uexpected
 
-    expected = u('α n_x + sin(ω) n_y + α⋅β n_z')
+    expected = u('alpha n_x + sin(omega) n_y + alpha*beta n_z')
+    uexpected = u('α n_x + sin(ω) n_y + α⋅β n_z')
 
-    assert expected == pp.doprint(w)
-    assert expected == w._pretty().render()
-
+    assert ascii_vpretty(w) == expected
+    assert unicode_vpretty(w) == uexpected
 
 def test_vector_latex():
 
@@ -129,19 +134,22 @@ def test_vector_latex_with_functions():
 
 def test_dyadic_pretty_print():
 
-    expected = u("""\
+    expected = """\
+ 2
+a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\
+"""
+
+    uexpected = u("""\
  2
 a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
 """)
-    result = y._pretty().render()
+    assert ascii_vpretty(y) == expected
+    assert unicode_vpretty(y) == uexpected
 
-    assert expected == result
-
-    expected = u('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x')
-    result = x._pretty().render()
-
-    assert expected == result
-
+    expected = u('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x')
+    uexpected = u('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x')
+    assert ascii_vpretty(x) == expected
+    assert unicode_vpretty(x) == uexpected
 
 def test_dyadic_latex():
 

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -21,10 +21,10 @@ y = a ** 2 * (N.x | N.y) + b * (N.y | N.y) + c * sin(alpha) * (N.z | N.y)
 x = alpha * (N.x | N.x) + sin(omega) * (N.y | N.z) + alpha * beta * (N.z | N.x)
 
 def ascii_vpretty(expr):
-    return vpprint(expr, use_unicode=False)
+    return vpprint(expr, use_unicode=False, wrap_line=False)
 
 def unicode_vpretty(expr):
-    return vpprint(expr, use_unicode=True)
+    return vpprint(expr, use_unicode=True, wrap_line=False)
 
 def test_latex_printer():
     r = Function('r')('t')
@@ -46,6 +46,7 @@ a  n_x + b n_y + c*sin(alpha) n_z\
  2
 a  n_x + b n_y + c⋅sin(α) n_z\
 """)
+
 
     assert ascii_vpretty(v) == expected
     assert unicode_vpretty(v) == uexpected

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -262,6 +262,8 @@ class Vector(object):
                 ar = self.args  # just to shorten things
                 if len(ar) == 0:
                     return unicode(0)
+                settings = printer._settings if printer else {}
+                vp = printer if printer else VectorPrettyPrinter(settings)
                 ol = []  # output list, to be concatenated to a string
                 for i, v in enumerate(ar):
                     for j in 0, 1, 2:
@@ -275,10 +277,10 @@ class Vector(object):
                             # If the basis vector coeff is not 1 or -1,
                             # we might wrap it in parentheses, for readability.
                             if isinstance(ar[i][0][j], Add):
-                                arg_str = VectorPrettyPrinter()._print(
+                                arg_str = vp._print(
                                     ar[i][0][j]).parens()[0]
                             else:
-                                arg_str = (VectorPrettyPrinter().doprint(
+                                arg_str = (vp.doprint(
                                     ar[i][0][j]))
 
                             if arg_str[0] == u("-"):

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,6 +1,6 @@
 from sympy import (S, sympify, trigsimp, expand, sqrt, Add, zeros,
                    ImmutableMatrix as Matrix)
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, unicode
 from sympy.utilities.misc import filldedent
 
 __all__ = ['Vector']

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -758,21 +758,22 @@ class PrettyPrinter(Printer):
 
     def _print_BasisDependent(self, expr):
         from sympy.vector import Vector
-        e = expr
 
+        if not self._use_unicode:
+            raise NotImplementedError("ASCII pretty printing of BasisDependent is not implemented")
         class Fake(object):
             baseline = 0
 
-            def render(self, *args, **kwargs):
-                self = e
-                if self == e.zero:
-                    return e.zero._pretty_form
+            # slf to distinguish from self from _print_BasisDependent
+            def render(slf, *args, **kwargs):
+                if expr == expr.zero:
+                    return expr.zero._pretty_form
                 o1 = []
                 vectstrs = []
-                if isinstance(self, Vector):
-                    items = self.separate().items()
+                if isinstance(expr, Vector):
+                    items = expr.separate().items()
                 else:
-                    items = [(0, self)]
+                    items = [(0, expr)]
                 for system, vect in items:
                     inneritems = list(vect.components.items())
                     inneritems.sort(key = lambda x: x[0].__str__())
@@ -789,8 +790,8 @@ class PrettyPrinter(Printer):
                         #For a general expr
                         else:
                             #We always wrap the measure numbers in
-                            #parantheses
-                            arg_str = PrettyPrinter()._print(
+                            #parentheses
+                            arg_str = self._print(
                                 v).parens()[0]
 
                             o1.append(arg_str + ' ' + k._pretty_form)
@@ -805,6 +806,7 @@ class PrettyPrinter(Printer):
                 lengths = []
                 strs = ['']
                 for i, partstr in enumerate(o1):
+                    # XXX: What is this hack?
                     if '\n' in partstr:
                         tempstr = partstr
                         tempstr = tempstr.replace(vectstrs[i], '')

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3301,18 +3301,18 @@ def test_pretty_Domain():
 
 
 def test_pretty_prec():
-    assert xpretty(S("0.3"), full_prec=True) == "0.300000000000000"
-    assert xpretty(S("0.3"), full_prec="auto") == "0.300000000000000"
-    assert xpretty(S("0.3"), full_prec=False) == "0.3"
-    assert xpretty(S("0.3")*x, full_prec=True, use_unicode=False) in [
+    assert xpretty(S("0.3"), full_prec=True, wrap_line=False) == "0.300000000000000"
+    assert xpretty(S("0.3"), full_prec="auto", wrap_line=False) == "0.300000000000000"
+    assert xpretty(S("0.3"), full_prec=False, wrap_line=False) == "0.3"
+    assert xpretty(S("0.3")*x, full_prec=True, use_unicode=False, wrap_line=False) in [
         "0.300000000000000*x",
         "x*0.300000000000000"
     ]
-    assert xpretty(S("0.3")*x, full_prec="auto", use_unicode=False) in [
+    assert xpretty(S("0.3")*x, full_prec="auto", use_unicode=False, wrap_line=False) in [
         "0.3*x",
         "x*0.3"
     ]
-    assert xpretty(S("0.3")*x, full_prec=False, use_unicode=False) in [
+    assert xpretty(S("0.3")*x, full_prec=False, use_unicode=False, wrap_line=False) in [
         "0.3*x",
         "x*0.3"
     ]
@@ -3325,7 +3325,7 @@ def test_pprint():
     sso = sys.stdout
     sys.stdout = fd
     try:
-        pprint(pi, use_unicode=False)
+        pprint(pi, use_unicode=False, wrap_line=False)
     finally:
         sys.stdout = sso
     assert fd.getvalue() == 'pi\n'

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -1,9 +1,19 @@
 # -*- coding: utf-8 -*-
-from sympy import Integral, pretty, latex, Function
+from sympy import Integral, latex, Function
+from sympy import pretty as xpretty
 from sympy.vector import CoordSysCartesian, Vector, Dyadic, express
 from sympy.abc import a, b, c
 from sympy.core.compatibility import u_decode as u
+from sympy.utilities.pytest import XFAIL
 
+def pretty(expr):
+    """ASCII pretty-printing"""
+    return xpretty(expr, use_unicode=False, wrap_line=False)
+
+
+def upretty(expr):
+    """Unicode pretty-printing"""
+    return xpretty(expr, use_unicode=True, wrap_line=False)
 
 #Initialize the basic and tedious vector/dyadic expressions
 #needed for testing.
@@ -23,35 +33,63 @@ v.append((a**2 + N.x)*N.i + N.k)
 v.append((a**2 + b)*N.i + 3*(C.y - c)*N.k)
 f = Function('f')
 v.append(N.j - (Integral(f(b)) - C.x**2)*N.k)
-pretty_v_8 = u(
+upretty_v_8 = u(
 """\
 N_j + ⎛   2   ⌠        ⎞ N_k\n\
       ⎜C_x  - ⎮ f(b) db⎟    \n\
       ⎝       ⌡        ⎠    \
 """)
+pretty_v_8 = u(
+"""\
+N_j + /         /       \\\n\
+      |   2    |        |\n\
+      |C_x  -  | f(b) db|\n\
+      |        |        |\n\
+      \\       /         / \
+""")
+
 v.append(N.i + C.k)
 v.append(express(N.i, C))
 v.append((a**2 + b)*N.i + (Integral(f(b)))*N.k)
-pretty_v_11 = u(
+upretty_v_11 = u(
 """\
 ⎛ 2    ⎞ N_i + ⎛⌠        ⎞ N_k\n\
 ⎝a  + b⎠       ⎜⎮ f(b) db⎟    \n\
                ⎝⌡        ⎠    \
 """)
+pretty_v_11 = u(
+"""\
+/ 2    \\ + /  /       \\\n\
+\\a  + b/ N_i| |        |\n\
+           | | f(b) db|\n\
+           | |        |\n\
+           \\/         / \
+""")
+
 for x in v:
     d.append(x | N.k)
 s = 3*N.x**2*C.y
-pretty_s = u(
+upretty_s = u(
 """\
          2\n\
 3⋅C_y⋅N_x \
 """)
+pretty_s = u(
+"""\
+         2\n\
+3*C_y*N_x \
+""")
 
 #This is the pretty form for ((a**2 + b)*N.i + 3*(C.y - c)*N.k) | N.k
-pretty_d_7 = u(
+upretty_d_7 = u(
 """\
 ⎛ 2    ⎞ (N_i|N_k) + (3⋅C_y - 3⋅c) (N_k|N_k)\n\
 ⎝a  + b⎠                                    \
+""")
+pretty_d_7 = u(
+"""\
+/ 2    \\ (N_i|N_k) + (3*C_y - 3*c) (N_k|N_k)\n\
+\\a  + b/                                    \
 """)
 
 

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -122,7 +122,7 @@ def test_pretty_printing_ascii():
     assert pretty(d[7]) == pretty_d_7
     assert pretty(d[10]) == u('(cos(a)) (C_i|N_k) + (-sin(a)) (C_j|N_k)')
 
-def pretty_print_unicode():
+def test_pretty_print_unicode():
     assert upretty(v[0]) == u('0')
     assert upretty(v[1]) == u('N_i')
     assert upretty(v[5]) == u('(a) N_i + (-b) N_j')

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -70,8 +70,8 @@ def test_str_printing():
     assert str(d[8]) == ('(N.j|N.k) + (C.x**2 - ' +
                          'Integral(f(b), b))*(N.k|N.k)')
 
-
-def test_pretty_printing():
+@XFAIL
+def test_pretty_printing_ascii():
     assert pretty(v[0]) == u('0')
     assert pretty(v[1]) == u('N_i')
     assert pretty(v[5]) == u('(a) N_i + (-b) N_j')
@@ -83,6 +83,19 @@ def test_pretty_printing():
     assert pretty(d[5]) == u('(a) (N_i|N_k) + (-b) (N_j|N_k)')
     assert pretty(d[7]) == pretty_d_7
     assert pretty(d[10]) == u('(cos(a)) (C_i|N_k) + (-sin(a)) (C_j|N_k)')
+
+def pretty_print_unicode():
+    assert upretty(v[0]) == u('0')
+    assert upretty(v[1]) == u('N_i')
+    assert upretty(v[5]) == u('(a) N_i + (-b) N_j')
+    assert upretty(v[8]) == upretty_v_8
+    assert upretty(v[2]) == u('(-1) N_i')
+    assert upretty(v[11]) == upretty_v_11
+    assert upretty(s) == upretty_s
+    assert upretty(d[0]) == u('(0|0)')
+    assert upretty(d[5]) == u('(a) (N_i|N_k) + (-b) (N_j|N_k)')
+    assert upretty(d[7]) == upretty_d_7
+    assert upretty(d[10]) == u('(cos(a)) (C_i|N_k) + (-sin(a)) (C_j|N_k)')
 
 
 def test_latex_printing():


### PR DESCRIPTION
CC @sympy/mechanics. I had to punt on the ASCII printer for the sympy.vector module, because it was using some awful hacks and I wasn't sure how it was supposed to work. So now it just raises NotImplementedError. Anyway this removes all test failures and so fixes https://github.com/sympy/sympy/issues/7679. 

To test this on Unix, set `LANG=C`, like

```
LANG=C bin/test print
```

On Windows, this already happens, at least for me using the cmd shell. 

I plan to add the above to the Travis tests. 
