### PR TITLE
Interleaving for unions with infinite sets

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1235,7 +1235,7 @@ class Union(Set, EvalfMixin):
                         yield next()
                 except StopIteration:
                     pending -= 1
-                    nexts = itertools.cycle(islice(nexts, pending))
+                    nexts = itertools.cycle(itertools.islice(nexts, pending))
 
         if all(set.is_iterable for set in self.args):
             if any((not set.is_FiniteSet) for set in self.args):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1224,6 +1224,8 @@ class Union(Set, EvalfMixin):
     def __iter__(self):
         import itertools
 
+        # roundrobin recipe taken from itertools documentation:
+        # https://docs.python.org/2/library/itertools.html#recipes
         def roundrobin(*iterables):
             "roundrobin('ABC', 'D', 'EF') --> A D E B F C"
             # Recipe credited to George Sakkis
@@ -1238,10 +1240,7 @@ class Union(Set, EvalfMixin):
                     nexts = itertools.cycle(itertools.islice(nexts, pending))
 
         if all(set.is_iterable for set in self.args):
-            if any((not set.is_FiniteSet) for set in self.args):
-                return roundrobin(*(iter(arg) for arg in self.args))
-            else:
-                return itertools.chain(*(iter(arg) for arg in self.args))
+            return roundrobin(*(iter(arg) for arg in self.args))
         else:
             raise TypeError("Not all constituent sets are iterable")
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1223,8 +1223,25 @@ class Union(Set, EvalfMixin):
 
     def __iter__(self):
         import itertools
+
+        def roundrobin(*iterables):
+            "roundrobin('ABC', 'D', 'EF') --> A D E B F C"
+            # Recipe credited to George Sakkis
+            pending = len(iterables)
+            nexts = itertools.cycle(iter(it).next for it in iterables)
+            while pending:
+                try:
+                    for next in nexts:
+                        yield next()
+                except StopIteration:
+                    pending -= 1
+                    nexts = itertools.cycle(islice(nexts, pending))
+
         if all(set.is_iterable for set in self.args):
-            return itertools.chain(*(iter(arg) for arg in self.args))
+            if any((not set.is_FiniteSet) for set in self.args):
+                return roundrobin(*(iter(arg) for arg in self.args))
+            else:
+                return itertools.chain(*(iter(arg) for arg in self.args))
         else:
             raise TypeError("Not all constituent sets are iterable")
 


### PR DESCRIPTION
Fixes #8342 
Unions with infinite elements now interleave.
Uses the roundrobin recipe from the documentation for itertools:
https://docs.python.org/2/library/itertools.html#recipes

```
>>> solns = solve_univariate_real(sin(x), x)
>>> solns
ImageSet(Lambda(_n, 2*_n*pi), Integers()) U ImageSet(Lambda(_n, 2*_n*pi + pi), Integers())
>>> for i in zip(solns, range(10)):
...  print i
... 
(0, 0)
(pi, 1)
(2*pi, 2)
(3*pi, 3)
(-2*pi, 4)
(-pi, 5)
(4*pi, 6)
(5*pi, 7)
(-4*pi, 8)
(-3*pi, 9)
```
