### PR TITLE
Infinity/NegativeInfinity: simplify relational code

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2390,54 +2390,42 @@ class Infinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s < %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             return S.false
-        return C.StrictLessThan(self, other, evaluate=False)
+        return Expr.__lt__(self, other)
 
     def __le__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             if other.is_finite or other is S.NegativeInfinity:
                 return S.false
             elif other is S.Infinity:
                 return S.true
-        return C.LessThan(self, other, evaluate=False)
+        return Expr.__le__(self, other)
 
     def __gt__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s > %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             if other.is_finite or other is S.NegativeInfinity:
                 return S.true
             elif other is S.Infinity:
                 return S.false
-        return C.StrictGreaterThan(self, other, evaluate=False)
+        return Expr.__gt__(self, other)
 
     def __ge__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             return S.true
-        return C.GreaterThan(self, other, evaluate=False)
+        return Expr.__ge__(self, other)
 
     def __mod__(self, other):
         return S.NaN
@@ -2609,54 +2597,42 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s < %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             if other.is_finite or other is S.Infinity:
                 return S.true
             elif other is S.NegativeInfinity:
                 return S.false
-        return C.StrictLessThan(self, other, evaluate=False)
+        return Expr.__lt__(self, other)
 
     def __le__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             return S.true
-        return C.LessThan(self, other, evaluate=False)
+        return Expr.__le__(self, other)
 
     def __gt__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s > %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             return S.false
-        return C.StrictGreaterThan(self, other, evaluate=False)
+        return Expr.__gt__(self, other)
 
     def __ge__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
             raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        if other.is_complex and other.is_real is False:
-            raise TypeError("Invalid complex comparison: %s and %s" %
-                            (self, other))
         if other.is_real:
             if other.is_finite or other is S.Infinity:
                 return S.false
             elif other is S.NegativeInfinity:
                 return S.true
-        return C.GreaterThan(self, other, evaluate=False)
+        return Expr.__ge__(self, other)
 
     def __mod__(self, other):
         return S.NaN


### PR DESCRIPTION
> If we call `Expr.__lt__` then we do not need as much error checking
> here.  In particular, can drop the "compare to nonreal" error.

This is also makes #7834 bit nicer, but seems reasonable change on its own too.
