### PR TITLE
Give Inequality an additional level of evaluation with keyword `check`

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -233,61 +233,67 @@ class Expr(Basic, EvalfMixin):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        for me in (self, other):
-            if me.is_complex and me.is_real is False:
-                raise TypeError("Invalid comparison of complex %s" % me)
-        if self.is_real and other.is_real:
-            dif = self - other
-            if dif.is_nonnegative is not None and \
-                    dif.is_nonnegative is not dif.is_negative:
-                return sympify(dif.is_nonnegative)
-        return C.GreaterThan(self, other, evaluate=False)
+            raise TypeError("Invalid comparison of %s" % type(other))
+        _compare(self, other, 0)  # check that args are not non-real
+        try:
+            c = _compare(self, other, 2)
+            if c.is_Symbol:
+                if c.is_nonpositive:
+                    raise TypeError
+                c = 0
+            return _sympify(int(c) >= 0)
+        except TypeError:
+            return C.GreaterThan(self, other, evaluate=False)
 
     def __le__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        for me in (self, other):
-            if me.is_complex and me.is_real is False:
-                raise TypeError("Invalid comparison of complex %s" % me)
-        if self.is_real and other.is_real:
-            dif = self - other
-            if dif.is_nonpositive is not None and \
-                    dif.is_nonpositive is not dif.is_positive:
-                return sympify(dif.is_nonpositive)
-        return C.LessThan(self, other, evaluate=False)
+            raise TypeError("Invalid comparison of %s" % type(other))
+        _compare(self, other, 0)  # check that args are not non-real
+        try:
+            c = _compare(self, other, 2)
+            if c.is_Symbol:
+                if c.is_nonnegative:
+                    raise TypeError
+                c = 0
+            return _sympify(int(c) <= 0)
+        except TypeError:
+            return C.LessThan(self, other, evaluate=False)
 
     def __gt__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
-        for me in (self, other):
-            if me.is_complex and me.is_real is False:
-                raise TypeError("Invalid comparison of complex %s" % me)
-        if self.is_real and other.is_real:
-            dif = self - other
-            if dif.is_positive is not None and \
-                    dif.is_positive is not dif.is_nonpositive:
-                return sympify(dif.is_positive)
-        return C.StrictGreaterThan(self, other, evaluate=False)
+            raise TypeError("Invalid comparison of %s" % type(other))
+        _compare(self, other, 0)  # check that args are not non-real
+        try:
+            c = _compare(self, other, 2)
+            if c.is_Symbol:
+                if c.is_nonpositive:
+                    return S.false
+                else:
+                    raise TypeError
+            return _sympify(int(c) > 0)
+        except TypeError:
+            return C.StrictGreaterThan(self, other, evaluate=False)
 
     def __lt__(self, other):
         try:
             other = _sympify(other)
         except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
-        for me in (self, other):
-            if me.is_complex and me.is_real is False:
-                raise TypeError("Invalid comparison of complex %s" % me)
-        if self.is_real and other.is_real:
-            dif = self - other
-            if dif.is_negative is not None and \
-                    dif.is_negative is not dif.is_nonnegative:
-                return sympify(dif.is_negative)
-        return C.StrictLessThan(self, other, evaluate=False)
+            raise TypeError("Invalid comparison of %s" % type(other))
+        _compare(self, other, 0)  # check that args are not non-real
+        try:
+            c = _compare(self, other, 2)
+            if c.is_Symbol:
+                if c.is_nonnegative:
+                    return S.false
+                else:
+                    raise TypeError
+            return _sympify(int(c) < 0)
+        except TypeError:
+            return C.StrictLessThan(self, other, evaluate=False)
 
     @staticmethod
     def _from_mpmath(x, prec):
@@ -3145,3 +3151,4 @@ from .function import Derivative, expand_mul
 from .mod import Mod
 from .exprtools import factor_terms
 from .numbers import Integer, Rational
+from .relational import _compare

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -369,8 +369,6 @@ class _Inequality(Relational):
         else:
             if evaluate is None:
                 evaluate = global_evaluate[0]
-            if evaluate is not False:
-                _compare(lhs, rhs, 0)  # check that args are not non-real
 
         if evaluate:
             # First we invoke the appropriate inequality method of `lhs`

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -268,6 +268,83 @@ class Unequality(Relational):
 Ne = Unequality
 
 
+_compare_dict = {
+        (True, False): S.NegativeOne,
+        (False, None): Symbol('nonneg', nonnegative=True),
+        (False, True): S.One,
+        (None, False): Symbol('nonpos', nonpositive=True),
+        (False, False): S.Zero,
+    }
+def _compare(a, b, check):
+    """Raise an error if either arg fails the initial test,
+    `i.is_imaginary and i.is_real is False`. Otherwise, return a value
+    depending on the value of ``check``.
+
+    Parameters
+    ==========
+
+    a : Basic object
+    b : Basic object
+    check : int, controls the level of testing of the arguments
+        0 - return None if the initial test is performed
+        1 - check that a - b is real and return the sign if it is known or
+            None if the difference is known to be nonpositive or nonnegative
+        2 - check that a and b are real and return the sign if it is known or
+            None if the difference is known to be nonpositive or nonnegative
+
+    Examples
+    ========
+
+    >>> from sympy.core.relational import _compare as compare
+    >>> from sympy import S, symbols
+    >>> from sympy.abc import x, y
+    >>> compare(S.Zero, S.One, check=2)
+    -1
+
+    >>> compare(x, x + 1, check=2)
+    Traceback (most recent call last):
+    ...
+    TypeError: cannot compare unless both values are real
+
+    >>> compare(x, x + 1, check=1)
+    -1
+
+    >>> compare(x, y, check=1)
+    Traceback (most recent call last):
+    ...
+    TypeError: cannot compare unless the difference is real
+
+    >>> compare(x, y, check=0) is None
+    True
+
+    >>> x, y = symbols("x y", real=True)
+    >>> compare(x, x + y, check=1) is None
+    Traceback (most recent call last):
+    ...
+    TypeError: could not determine the sign of the difference
+
+    >>> nn = symbols('nn', nonnegative=True)
+    >>> compare(nn, S.Zero, check=2)
+    nonneg
+    """
+    for me in (a, b):
+        if me.is_complex and me.is_real is False:
+            raise TypeError("cannot compare non-reals")
+    if not check:
+        return
+    if check == 2:
+        if not all(i.is_real for i in (a, b)):
+            raise TypeError("cannot compare unless both values are real")
+    diff = a - b
+    if check == 1 and not diff.is_real:
+        raise TypeError("cannot compare unless the difference is real")
+    key=(diff.is_negative, diff.is_positive)
+    rv = _compare_dict.get(key, None)
+    if rv is None:
+        raise TypeError("could not determine the sign of the difference")
+    return rv
+
+
 class _Inequality(Relational):
     """Internal base class for all *Than types.
 
@@ -277,11 +354,23 @@ class _Inequality(Relational):
     """
     __slots__ = []
 
-    def __new__(cls, lhs, rhs, **options):
+    def __new__(cls, lhs, rhs, check=None, evaluate=None, **options):
         lhs = _sympify(lhs)
         rhs = _sympify(rhs)
 
-        evaluate = options.pop('evaluate', global_evaluate[0])
+        if check:
+            if check not in (1, 2):
+                raise ValueError('invalid check value: %s' % check)
+            c = _compare(lhs, rhs, check)
+            if c is not None:
+                lhs = c
+                rhs = S.Zero
+            evaluate = True
+        else:
+            if evaluate is None:
+                evaluate = global_evaluate[0]
+            if evaluate is not False:
+                _compare(lhs, rhs, 0)  # check that args are not non-real
 
         if evaluate:
             # First we invoke the appropriate inequality method of `lhs`

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -538,3 +538,12 @@ def test_issue_8245():
     assert (r < a) == True
     assert (r >= a) == False
     assert (r <= a) == True
+
+
+def test_inequality_check():
+    # any inequality will traverse the new code, so just use Lt here
+    x, y = symbols('x y')
+    assert Lt(x, y, 0).func == Lt
+    raises(TypeError, lambda: Lt(x, y, 1))
+    assert Lt(x, x + 1, 1)
+    raises(TypeError, lambda: Lt(x, x + 1, 2))

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -11,6 +11,7 @@ from __future__ import print_function, division
 from sympy.core import S, C, sympify, pi, Dummy
 from sympy.core.logic import fuzzy_bool
 from sympy.core.numbers import oo, zoo, Rational
+from sympy.core.relational import Le
 from sympy.simplify import simplify, trigsimp
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
 from sympy.functions.elementary.complexes import im
@@ -260,12 +261,10 @@ class Ellipse(GeometryEntity):
         if len(ab) == 1:
             return ab[0]
         a, b = ab
-        o = a - b < 0
-        if o == True:
-            return a
-        elif o == False:
-            return b
-        return self.vradius
+        try:
+           return a if Le(a, b, 1) else b
+        except TypeError:
+            return self.vradius
 
     @property
     def major(self):
@@ -307,12 +306,10 @@ class Ellipse(GeometryEntity):
         if len(ab) == 1:
             return ab[0]
         a, b = ab
-        o = b - a < 0
-        if o == True:
-            return a
-        elif o == False:
-            return b
-        return self.hradius
+        try:
+           return a if Le(b, a, 1) else b
+        except TypeError:
+            return self.hradius
 
     @property
     def area(self):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -8,7 +8,7 @@ from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import diff
 from sympy.core.numbers import oo
-from sympy.core.relational import Eq
+from sympy.core.relational import Eq, Lt
 from sympy.sets.sets import Interval
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, Wild)
@@ -341,7 +341,7 @@ class Integral(AddWithLimits):
                 if len(xab) == 3:
                     a, b = xab[1:]
                     a, b = _calc_limit(a, b), _calc_limit(b, a)
-                    if a - b > 0:
+                    if Lt(b, a, 1):
                         a, b = b, a
                         newfunc = -newfunc
                     newlimits.append((uvar, a, b))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -315,6 +315,10 @@ def test_integrate_derivatives():
 
 
 def test_transform():
+    a = Integral(x**2 + 1, (x, z, z + 2))
+    fx = x
+    fy = 3*y + 1
+    assert a.doit().equals(a.transform(fx, fy).doit())
     a = Integral(x**2 + 1, (x, -1, 2))
     fx = x
     fy = 3*y + 1


### PR DESCRIPTION
From commit message:

```
Both Lt(x, 1) and x < 1 behave the same in returning an unevaluated
relational, even if evaluate=True. The only checking that occurs is
a check that x.is_real is not False. Since the value of x is unknown
the unevaluated relation "x < 1" is returned. This means that code
that wants to test if an actual value was returned must test it
explicitly as 'if (x < 1) == True'. Even applying doit() does not
cause an unevaluate form like x < y (with vanilla symbols) to raise
an error.

With the new keyword, checking that the result was obtained is
part of the function call itself. If a result was not (or could not)
be obtained an error is raised. There are 3 levels of checking as
described in the function's docstring.

var('x y')
Lt(x, y, 0) -> x < y
Lt(x, y, 1) -> error
Lt(x, x + 1, 1) -> True
Lt(x, x + 1, 2) -> error
```

This also helps to consolidate and standardize error messages associated with the errors. Some examples of usage are visible in the diff view (see `ellipse` and `integrals`).
