### PR TITLE
Add rational kwarg for Mul.as_coeff_mul, like for as_coeff_Mul

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -645,7 +645,8 @@ class Mul(Expr, AssocOp):
             return args[0], self._new_rawargs(*args[1:])
 
     @cacheit
-    def as_coeff_mul(self, *deps):
+    def as_coeff_mul(self, *deps, **kwargs):
+        rational = kwargs.pop('rational', True)
         if deps:
             l1 = []
             l2 = []
@@ -656,7 +657,7 @@ class Mul(Expr, AssocOp):
                     l1.append(f)
             return self._new_rawargs(*l1), tuple(l2)
         args = self.args
-        if args[0].is_Rational:
+        if args[0].is_Number and not (rational and not args[0].is_Rational):
             return args[0], args[1:]
         elif args[0] is S.NegativeInfinity:
             return S.NegativeOne, (-args[0],) + args[1:]

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -935,6 +935,8 @@ def test_as_coeff_mul():
     assert e.as_coeff_mul(y) == (1, (e,))
     e = 2**(x + y)
     assert e.as_coeff_mul(y) == (1, (e,))
+    assert (1.1*x).as_coeff_mul(rational=False) == (1.1, (x,))
+    assert (1.1*x).as_coeff_mul() == (1, (1.1, x))
 
 
 def test_as_coeff_exponent():

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1234,7 +1234,7 @@ class PrettyPrinter(Printer):
 
         for i, term in enumerate(terms):
             if term.is_Mul and _coeff_isneg(term):
-                coeff, other = term.as_coeff_mul()
+                coeff, other = term.as_coeff_mul(rational=False)
                 pform = self._print(C.Mul(-coeff, *other, evaluate=False))
                 pforms.append(pretty_negative(pform, i))
             elif term.is_Rational and term.q > 1:


### PR DESCRIPTION
this fix the printing problem, mentioned [here](https://github.com/sympy/sympy/issues/8398#issuecomment-62069573).  The problem was introduced in #8305.
