### PR TITLE
Add rational kwarg for Mul.as_coeff_mul, like for as_coeff_Mul

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1666,7 +1666,7 @@ class Expr(Basic, EvalfMixin):
         # a -> b ** e
         return self, S.One
 
-    def as_coeff_mul(self, *deps):
+    def as_coeff_mul(self, *deps, **kwargs):
         """Return the tuple (c, args) where self is written as a Mul, ``m``.
 
         c should be a Rational multiplied by any terms of the Mul that are

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -657,7 +657,7 @@ class Mul(Expr, AssocOp):
                     l1.append(f)
             return self._new_rawargs(*l1), tuple(l2)
         args = self.args
-        if args[0].is_Number and not (rational and not args[0].is_Rational):
+        if args[0].is_Number and (not rational or args[0].is_Rational):
             return args[0], args[1:]
         elif args[0] is S.NegativeInfinity:
             return S.NegativeOne, (-args[0],) + args[1:]
@@ -667,11 +667,13 @@ class Mul(Expr, AssocOp):
         """Efficiently extract the coefficient of a product. """
         coeff, args = self.args[0], self.args[1:]
 
-        if coeff.is_Number and not (rational and not coeff.is_Rational):
+        if coeff.is_Number and (not rational or coeff.is_Rational):
             if len(args) == 1:
                 return coeff, args[0]
             else:
                 return coeff, self._new_rawargs(*args)
+        elif coeff is S.NegativeInfinity:
+            return S.NegativeOne, self._new_rawargs(*((-coeff,) + args))
         else:
             return S.One, self
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -645,7 +645,8 @@ class Mul(Expr, AssocOp):
             return args[0], self._new_rawargs(*args[1:])
 
     @cacheit
-    def as_coeff_mul(self, *deps):
+    def as_coeff_mul(self, *deps, **kwargs):
+        rational = kwargs.pop('rational', True)
         if deps:
             l1 = []
             l2 = []
@@ -656,7 +657,7 @@ class Mul(Expr, AssocOp):
                     l1.append(f)
             return self._new_rawargs(*l1), tuple(l2)
         args = self.args
-        if args[0].is_Rational:
+        if args[0].is_Number and not (rational and not args[0].is_Rational):
             return args[0], args[1:]
         elif args[0] is S.NegativeInfinity:
             return S.NegativeOne, (-args[0],) + args[1:]

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -657,10 +657,11 @@ class Mul(Expr, AssocOp):
                     l1.append(f)
             return self._new_rawargs(*l1), tuple(l2)
         args = self.args
-        if args[0].is_Number and (not rational or args[0].is_Rational):
-            return args[0], args[1:]
-        elif args[0] is S.NegativeInfinity:
-            return S.NegativeOne, (-args[0],) + args[1:]
+        if args[0].is_Number:
+            if (not rational or args[0].is_Rational):
+                return args[0], args[1:]
+            elif args[0].is_negative:
+                return S.NegativeOne, (-args[0],) + args[1:]
         return S.One, args
 
     def as_coeff_Mul(self, rational=False):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -415,9 +415,9 @@ class Number(AtomicExpr):
     def is_constant(self, *wrt, **flags):
         return True
 
-    def as_coeff_mul(self, *deps):
+    def as_coeff_mul(self, *deps, **kwargs):
         # a -> c*t
-        if self.is_Rational:
+        if self.is_Rational or not kwargs.pop('rational', True):
             return self, tuple()
         elif self.is_negative:
             return S.NegativeOne, (-self,)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -938,6 +938,8 @@ def test_as_coeff_mul():
     assert e.as_coeff_mul(y) == (1, (e,))
     e = 2**(x + y)
     assert e.as_coeff_mul(y) == (1, (e,))
+    assert (1.1*x).as_coeff_mul(rational=False) == (1.1, (x,))
+    assert (1.1*x).as_coeff_mul() == (1, (1.1, x))
 
 
 def test_as_coeff_exponent():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -928,10 +928,12 @@ def test_as_coeff_mul():
     assert S(2).as_coeff_mul() == (2, ())
     assert S(3.0).as_coeff_mul() == (1, (S(3.0),))
     assert S(-3.0).as_coeff_mul() == (-1, (S(3.0),))
+    assert S(-3.0).as_coeff_mul(rational=False) == (-S(3.0), ())
     assert x.as_coeff_mul() == (1, (x,))
     assert (-x).as_coeff_mul() == (-1, (x,))
     assert (2*x).as_coeff_mul() == (2, (x,))
     assert (x*y).as_coeff_mul(y) == (x, (y,))
+    assert (3 + x).as_coeff_mul() == (1, (3 + x,))
     assert (3 + x).as_coeff_mul(y) == (3 + x, ())
     # don't do expansion
     e = exp(x + y)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -940,6 +940,7 @@ def test_as_coeff_mul():
     assert e.as_coeff_mul(y) == (1, (e,))
     assert (1.1*x).as_coeff_mul(rational=False) == (1.1, (x,))
     assert (1.1*x).as_coeff_mul() == (1, (1.1, x))
+    assert (-oo*x).as_coeff_mul(rational=True) == (-1, (oo, x))
 
 
 def test_as_coeff_exponent():
@@ -1262,6 +1263,7 @@ def test_as_coeff_Mul():
 
     assert (x).as_coeff_Mul() == (S.One, x)
     assert (x*y).as_coeff_Mul() == (S.One, x*y)
+    assert (-oo*x).as_coeff_Mul(rational=True) == (-1, oo*x)
 
 
 def test_as_coeff_Add():

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1232,7 +1232,7 @@ class PrettyPrinter(Printer):
 
         for i, term in enumerate(terms):
             if term.is_Mul and _coeff_isneg(term):
-                coeff, other = term.as_coeff_mul()
+                coeff, other = term.as_coeff_mul(rational=False)
                 pform = self._print(C.Mul(-coeff, *other, evaluate=False))
                 pforms.append(pretty_negative(pform, i))
             elif term.is_Rational and term.q > 1:


### PR DESCRIPTION
see #8399 (same pr, against the release branch)
## 

this fix the printing problem, mentioned [here](https://github.com/sympy/sympy/issues/8398#issuecomment-62069573).  The problem was introduced in #8305.
