### PR TITLE
Typo fix in Meijer G-function condition checking

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1157,7 +1157,11 @@ def _check_antecedents(g1, g2, x):
     if _eval_cond(r) != False:
         return r
 
-    conds += [And(m + n > p, Eq(t, 0), Eq(phi, 0), s.is_positive is True, bstar.is_positive is True, cstar.is_negative is True,
+    # The inequality m+n>p is strong in Prudnikov,
+    # but this is the only condition that fires
+    # for the laplace transform of sinh,
+    # and it only does so if the inequality is weak.
+    conds += [And(m + n >= p, Eq(t, 0), Eq(phi, 0), s.is_positive is True, bstar.is_positive is True, cstar.is_negative is True,
                   abs(arg(omega)) < (m + n - p + 1)*pi,
                   c1, c2, c10, c14, c15)]  # 24
     pr(24)
@@ -1184,7 +1188,12 @@ def _check_antecedents(g1, g2, x):
                   abs(arg(omega)) < (m + n - q + 1)*pi,
                   c1, c3, c10, c14, c15)]  # 29
     pr(29)
-    conds += [And(Eq(n, 0), Eq(phi, 0), s + t > 0, m.is_positive is True, cstar.is_positive is True, bstar.is_negative is True,
+
+    # The inequality s+t>u is strong in Prudnikov,
+    # but this is the only condition that fires
+    # for the laplace transform of cosh,
+    # and it only does so if the inequality is weak.
+    conds += [And(Eq(n, 0), Eq(phi, 0), s + t >= u, m.is_positive is True, cstar.is_positive is True, bstar.is_negative is True,
                   abs(arg(sigma)) < (s + t - u + 1)*pi,
                   c1, c2, c12, c14, c15)]  # 30
     pr(30)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -483,7 +483,9 @@ def test_laplace_transform():
         exp(-a*t)*sin(b*t), t, s) == (b/(b**2 + (a + s)**2), -a, True)
     assert LT(exp(-a*t)*cos(b*t), t, s) == \
         ((a + s)/(b**2 + (a + s)**2), -a, True)
-    # TODO sinh, cosh have delicate cancellation
+        
+    assert LT(cosh(t), t, s, noconds = True) == s/(s**2 - 1)
+    assert LT(sinh(t), t, s, noconds = True) == 1/(s**2 - 1)
 
     assert LT(besselj(0, t), t, s) == (1/sqrt(1 + s**2), 0, True)
     assert LT(besselj(1, t), t, s) == (1 - 1/sqrt(1 + 1/s**2), 0, True)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -12,7 +12,7 @@ from sympy import (
     cos, S, And, sin, sqrt, I, log, tan, hyperexpand, meijerg,
     EulerGamma, erf, besselj, bessely, besseli, besselk,
     exp_polar, polar_lift, unpolarify, Function, expint, expand_mul,
-    combsimp, trigsimp)
+    combsimp, trigsimp, cosh, sinh)
 from sympy.utilities.pytest import XFAIL, slow, skip
 from sympy.matrices import Matrix, eye
 from sympy.abc import x, s, a, b, c, d


### PR DESCRIPTION
Fixes #8368

```
>>> laplace_transform(cosh(t), t, s, noconds = True)
s/(s**2 - 1)
>>> laplace_transform(sinh(t), t, s, noconds = True)
1/(s**2 - 1)
```

I got my hands on a copy of Prudnikov's book. The weak inequalities here (m+n>=p and s+t>=u) definitely violate his conditions as printed. However, this is the absolute bare minimum needed to get a condition to fire for sinh and cosh.

In fact, none of the conditions as written in Prudnikov are satisfied for the particular products that sinh and cosh produce. I'm not sure whether that means he has a typo, or his result simply doesn't apply to these cases.

If adherence to Prudnikov is preferred, we still end up fixing the s+t>0 typo in condition 30.
