### PR TITLE
Code quality: don't assign to self #8362

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -687,7 +687,6 @@ class Add(Expr, AssocOp):
 
         old = self
 
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = expand_mul(self)
         if not expr.is_Add:
             return expr.as_leading_term(x)

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -687,30 +687,31 @@ class Add(Expr, AssocOp):
 
         old = self
 
-        self = expand_mul(self)
-        if not self.is_Add:
-            return self.as_leading_term(x)
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr = expand_mul(self)
+        if not expr.is_Add:
+            return expr.as_leading_term(x)
 
-        infinite = [t for t in self.args if t.is_infinite]
+        infinite = [t for t in expr.args if t.is_infinite]
 
-        self = self.func(*[t.as_leading_term(x) for t in self.args]).removeO()
-        if not self:
+        expr = expr.func(*[t.as_leading_term(x) for t in expr.args]).removeO()
+        if not expr:
             # simple leading term analysis gave us 0 but we have to send
             # back a term, so compute the leading term (via series)
             return old.compute_leading_term(x)
-        elif self is S.NaN:
+        elif expr is S.NaN:
             return old.func._from_args(infinite)
-        elif not self.is_Add:
-            return self
+        elif not expr.is_Add:
+            return expr
         else:
-            plain = self.func(*[s for s, _ in self.extract_leading_order(x)])
+            plain = expr.func(*[s for s, _ in expr.extract_leading_order(x)])
             rv = factor_terms(plain, fraction=False)
             rv_simplify = rv.simplify()
             # if it simplifies to an x-free expression, return that;
             # tests don't fail if we don't but it seems nicer to do this
             if x not in rv_simplify.free_symbols:
                 if rv_simplify.is_zero and plain.is_zero is not True:
-                    return (self - plain)._eval_as_leading_term(x)
+                    return (expr - plain)._eval_as_leading_term(x)
                 return rv_simplify
             return rv
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -308,7 +308,6 @@ class Basic(with_metaclass(ManagedProperties)):
             else:
                 return False
 
-        # issue 8362 avoid assign to self, introduce a temp variable this here
         this = self
         if type(self) is not type(other):
             # issue 6100 a**1.0 == a like a**2.0 == a**2

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -307,10 +307,12 @@ class Basic(with_metaclass(ManagedProperties)):
                 return True
             else:
                 return False
-        if type(self) is not type(other):
+
+        this = self
+        if type(this) is not type(other):
             # issue 6100 a**1.0 == a like a**2.0 == a**2
-            while isinstance(self, C.Pow) and self.exp == 1:
-                self = self.base
+            while isinstance(this, C.Pow) and this.exp == 1:
+                this = this.base
             while isinstance(other, C.Pow) and other.exp == 1:
                 other = other.base
             try:
@@ -318,14 +320,14 @@ class Basic(with_metaclass(ManagedProperties)):
             except SympifyError:
                 return False    # sympy != other
 
-            if isinstance(self, AppliedUndef) and isinstance(other,
+            if isinstance(this, AppliedUndef) and isinstance(other,
                                                              AppliedUndef):
-                if self.class_key() != other.class_key():
+                if this.class_key() != other.class_key():
                     return False
-            elif type(self) is not type(other):
+            elif type(this) is not type(other):
                 return False
 
-        return self._hashable_content() == other._hashable_content()
+        return this._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):
         """a != b  -> Compare two symbolic trees and see whether they are different

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -307,12 +307,10 @@ class Basic(with_metaclass(ManagedProperties)):
                 return True
             else:
                 return False
-
-        this = self
         if type(self) is not type(other):
             # issue 6100 a**1.0 == a like a**2.0 == a**2
-            while isinstance(this, C.Pow) and this.exp == 1:
-                this = this.base
+            while isinstance(self, C.Pow) and self.exp == 1:
+                self = self.base
             while isinstance(other, C.Pow) and other.exp == 1:
                 other = other.base
             try:
@@ -320,14 +318,14 @@ class Basic(with_metaclass(ManagedProperties)):
             except SympifyError:
                 return False    # sympy != other
 
-            if isinstance(this, AppliedUndef) and isinstance(other,
+            if isinstance(self, AppliedUndef) and isinstance(other,
                                                              AppliedUndef):
-                if this.class_key() != other.class_key():
+                if self.class_key() != other.class_key():
                     return False
-            elif type(this) is not type(other):
+            elif type(self) is not type(other):
                 return False
 
-        return this._hashable_content() == other._hashable_content()
+        return self._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):
         """a != b  -> Compare two symbolic trees and see whether they are different

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -307,10 +307,13 @@ class Basic(with_metaclass(ManagedProperties)):
                 return True
             else:
                 return False
+
+        # issue 8362 avoid assign to self, introduce a temp variable this here
+        this = self
         if type(self) is not type(other):
             # issue 6100 a**1.0 == a like a**2.0 == a**2
-            while isinstance(self, C.Pow) and self.exp == 1:
-                self = self.base
+            while isinstance(this, C.Pow) and this.exp == 1:
+                this = this.base
             while isinstance(other, C.Pow) and other.exp == 1:
                 other = other.base
             try:
@@ -318,14 +321,14 @@ class Basic(with_metaclass(ManagedProperties)):
             except SympifyError:
                 return False    # sympy != other
 
-            if isinstance(self, AppliedUndef) and isinstance(other,
+            if isinstance(this, AppliedUndef) and isinstance(other,
                                                              AppliedUndef):
-                if self.class_key() != other.class_key():
+                if this.class_key() != other.class_key():
                     return False
-            elif type(self) is not type(other):
+            elif type(this) is not type(other):
                 return False
 
-        return self._hashable_content() == other._hashable_content()
+        return this._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):
         """a != b  -> Compare two symbolic trees and see whether they are different

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -498,13 +498,15 @@ class Expr(Basic, EvalfMixin):
         wrt = wrt or free
 
         # simplify unless this has already been done
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        this = self
         if simplify:
-            self = self.simplify()
+            expr = self.simplify()
 
         # is_zero should be a quick assumptions check; it can be wrong for
         # numbers (see test_is_not_constant test), giving False when it
         # shouldn't, but hopefully it will never give True unless it is sure.
-        if self.is_zero:
+        if expr.is_zero:
             return True
 
         # try numerical evaluation to see if we get two different values
@@ -512,30 +514,30 @@ class Expr(Basic, EvalfMixin):
         if wrt == free:
             # try 0 (for a) and 1 (for b)
             try:
-                a = self.subs(list(zip(free, [0]*len(free))),
+                a = expr.subs(list(zip(free, [0]*len(free))),
                     simultaneous=True)
                 if a is S.NaN:
                     # evaluation may succeed when substitution fails
-                    a = self._random(None, 0, 0, 0, 0)
+                    a = expr._random(None, 0, 0, 0, 0)
             except ZeroDivisionError:
                 a = None
             if a is not None and a is not S.NaN:
                 try:
-                    b = self.subs(list(zip(free, [1]*len(free))),
+                    b = expr.subs(list(zip(free, [1]*len(free))),
                         simultaneous=True)
                     if b is S.NaN:
                         # evaluation may succeed when substitution fails
-                        b = self._random(None, 1, 0, 1, 0)
+                        b = expr._random(None, 1, 0, 1, 0)
                 except ZeroDivisionError:
                     b = None
                 if b is not None and b is not S.NaN and b.equals(a) is False:
                     return False
                 # try random real
-                b = self._random(None, -1, 0, 1, 0)
+                b = expr._random(None, -1, 0, 1, 0)
                 if b is not None and b is not S.NaN and b.equals(a) is False:
                     return False
                 # try random complex
-                b = self._random()
+                b = expr._random()
                 if b is not None and b is not S.NaN:
                     if b.equals(a) is False:
                         return False
@@ -546,7 +548,7 @@ class Expr(Basic, EvalfMixin):
         # not sufficient for all expressions, however, so we don't return
         # False if we get a derivative other than 0 with free symbols.
         for w in wrt:
-            deriv = self.diff(w)
+            deriv = expr.diff(w)
             if simplify:
                 deriv = deriv.simplify()
             if deriv != 0:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -498,10 +498,9 @@ class Expr(Basic, EvalfMixin):
         wrt = wrt or free
 
         # simplify unless this has already been done
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = self
         if simplify:
-            expr = self.simplify()
+            expr = expr.simplify()
 
         # is_zero should be a quick assumptions check; it can be wrong for
         # numbers (see test_is_not_constant test), giving False when it

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2029,18 +2029,19 @@ class Expr(Basic, EvalfMixin):
             return (xa0 + (diff.extract_additively(c) or diff)) or None
         # term-wise
         coeffs = []
+        terms = self
         for a in Add.make_args(c):
             ac, at = a.as_coeff_Mul()
-            co = self.coeff(at)
+            co = terms.coeff(at)
             if not co:
                 return None
             coc, cot = co.as_coeff_Add()
             xa = coc.extract_additively(ac)
             if xa is None:
                 return None
-            self -= co*at
+            terms -= co*at
             coeffs.append((cot + xa)*at)
-        coeffs.append(self)
+        coeffs.append(terms)
         return Add(*coeffs)
 
     def could_extract_minus_sign(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -499,7 +499,7 @@ class Expr(Basic, EvalfMixin):
 
         # simplify unless this has already been done
         # issue 8362 avoid assign to self, introduce a temp variable expr here
-        this = self
+        expr = self
         if simplify:
             expr = self.simplify()
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1246,6 +1246,7 @@ class Mul(Expr, AssocOp):
 
         # give Muls in the denominator a chance to be changed (see issue 5651)
         # rv will be the default return value
+        # issue 8362 avoid assign to self, rv is used as temp variable 
         rv = None
         n, d = fraction(self)
         if d is not S.One:
@@ -1253,7 +1254,10 @@ class Mul(Expr, AssocOp):
             if not self2.is_Mul:
                 return self2._subs(old, new)
             if self2 != self:
-                self = rv = self2
+                rv = self2
+        
+        if rv == None:
+            rv = self
 
         # Now continue with regular substitution.
 
@@ -1261,7 +1265,7 @@ class Mul(Expr, AssocOp):
         # should even be started; we always know where to find the Rational
         # so it's a quick test
 
-        co_self = self.args[0]
+        co_self = rv.args[0]
         co_old = old.args[0]
         co_xmul = None
         if co_old.is_Rational and co_self.is_Rational:
@@ -1274,7 +1278,7 @@ class Mul(Expr, AssocOp):
 
         # break self and old into factors
 
-        (c, nc) = breakup(self)
+        (c, nc) = breakup(rv)
         (old_c, old_nc) = breakup(old)
 
         # update the coefficients if we had an extraction
@@ -1440,7 +1444,7 @@ class Mul(Expr, AssocOp):
             # rest of this routine
 
             margs = [Pow(new, cdid)] + margs
-        return co_residual*self.func(*margs)*self.func(*nc)
+        return co_residual*rv.func(*margs)*rv.func(*nc)
 
     def _eval_nseries(self, x, n, logx):
         from sympy import powsimp

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1246,7 +1246,6 @@ class Mul(Expr, AssocOp):
 
         # give Muls in the denominator a chance to be changed (see issue 5651)
         # rv will be the default return value
-        # issue 8362 avoid assign to self, rv is used as temp variable 
         rv = None
         n, d = fraction(self)
         if d is not S.One:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1253,7 +1253,7 @@ class Mul(Expr, AssocOp):
             if not self2.is_Mul:
                 return self2._subs(old, new)
             if self2 != self:
-                self = rv = self2
+                rv = self2
 
         # Now continue with regular substitution.
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1253,10 +1253,7 @@ class Mul(Expr, AssocOp):
             if not self2.is_Mul:
                 return self2._subs(old, new)
             if self2 != self:
-                rv = self2
-        
-        if rv == None:
-            rv = self
+                self = rv = self2
 
         # Now continue with regular substitution.
 
@@ -1264,7 +1261,7 @@ class Mul(Expr, AssocOp):
         # should even be started; we always know where to find the Rational
         # so it's a quick test
 
-        co_self = rv.args[0]
+        co_self = self.args[0]
         co_old = old.args[0]
         co_xmul = None
         if co_old.is_Rational and co_self.is_Rational:
@@ -1277,7 +1274,7 @@ class Mul(Expr, AssocOp):
 
         # break self and old into factors
 
-        (c, nc) = breakup(rv)
+        (c, nc) = breakup(self)
         (old_c, old_nc) = breakup(old)
 
         # update the coefficients if we had an extraction
@@ -1443,7 +1440,7 @@ class Mul(Expr, AssocOp):
             # rest of this routine
 
             margs = [Pow(new, cdid)] + margs
-        return co_residual*rv.func(*margs)*rv.func(*nc)
+        return co_residual*self.func(*margs)*self.func(*nc)
 
     def _eval_nseries(self, x, n, logx):
         from sympy import powsimp

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1358,7 +1358,7 @@ class Rational(Number):
             if other is S.NaN:
                 return other.__le__(self)
         elif other.is_number and other.is_real:
-            self, other = Integer(self.p), self.q*other
+            return Expr.__gt__(Integer(self.p), self.q*other)
         return Expr.__gt__(self, other)
 
     def __ge__(self, other):
@@ -1377,7 +1377,7 @@ class Rational(Number):
             if other is S.NaN:
                 return other.__lt__(self)
         elif other.is_number and other.is_real:
-            self, other = Integer(self.p), self.q*other
+            return Expr.__ge__(Integer(self.p), self.q*other)
         return Expr.__ge__(self, other)
 
     def __lt__(self, other):
@@ -1396,7 +1396,7 @@ class Rational(Number):
             if other is S.NaN:
                 return other.__ge__(self)
         elif other.is_number and other.is_real:
-            self, other = Integer(self.p), self.q*other
+            return Expr.__lt__(Integer(self.p), self.q*other)
         return Expr.__lt__(self, other)
 
     def __le__(self, other):
@@ -1415,7 +1415,7 @@ class Rational(Number):
             if other is S.NaN:
                 return other.__gt__(self)
         elif other.is_number and other.is_real:
-            self, other = Integer(self.p), self.q*other
+            return Expr.__lt__(Integer(self.p), self.q*other)
         return Expr.__le__(self, other)
 
     def __hash__(self):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -835,13 +835,13 @@ class Float(Number):
                 return Float._new(
                     mlib.mpf_pow_int(self._mpf_, expt.p, prec, rnd), prec)
             expt, prec = expt._as_mpf_op(self._prec)
-            self = self._mpf_
+            mpfself = self._mpf_
             try:
-                y = mpf_pow(self, expt, prec, rnd)
+                y = mpf_pow(mpfself, expt, prec, rnd)
                 return Float._new(y, prec)
             except mlib.ComplexResult:
                 re, im = mlib.mpc_pow(
-                    (self, _mpf_zero), (expt, _mpf_zero), prec, rnd)
+                    (mpfself, _mpf_zero), (expt, _mpf_zero), prec, rnd)
                 return Float._new(re, prec) + \
                     Float._new(im, prec)*S.ImaginaryUnit
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1386,13 +1386,15 @@ class Pow(Expr):
         return S.One, self.func(b, e)
 
     def is_constant(self, *wrt, **flags):
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr=self
         if flags.get('simplify', True):
-            self = self.simplify()
-        b, e = self.as_base_exp()
+            expr = self.simplify()
+        b, e = expr.as_base_exp()
         bz = b.equals(0)
         if bz:  # recalculate with assumptions in case it's unevaluated
             new = b**e
-            if new != self:
+            if new != expr:
                 return new.is_constant()
         econ = e.is_constant(*wrt)
         bcon = b.is_constant(*wrt)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1386,10 +1386,9 @@ class Pow(Expr):
         return S.One, self.func(b, e)
 
     def is_constant(self, *wrt, **flags):
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr=self
         if flags.get('simplify', True):
-            expr = self.simplify()
+            expr = expr.simplify()
         b, e = expr.as_base_exp()
         bz = b.equals(0)
         if bz:  # recalculate with assumptions in case it's unevaluated

--- a/sympy/galgebra/ga.py
+++ b/sympy/galgebra/ga.py
@@ -464,7 +464,7 @@ class MV(object):
                     self.igrade = 0
                 else:
                     if isinstance(base, (Add, Mul)):  # Complex expression
-                        self = MV.characterize_expression(self, base)
+                        MV.characterize_expression(self, base)
                     elif isinstance(base, Symbol):
                         if not base.is_commutative:
                             if base == MV.ONE:
@@ -491,7 +491,7 @@ class MV(object):
                         self.igrade = 0
                         self.blade_rep = True
         else:  # Preconfigured multivector types
-            self = MVtypes[mvtype](self, base)
+            MVtypes[mvtype](self, base)
 
     def Fmt(self, fmt=1, title=None):
         self.fmt = fmt

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -774,23 +774,24 @@ class LinearEntity(GeometryEntity):
                         sray.ydirection == self.ydirection:
                     return True
 
+            p = self
             prec = (Line, Ray, Segment)
-            if prec.index(self.func) > prec.index(o.func):
-                self, o = o, self
+            if prec.index(p.func) > prec.index(o.func):
+                p, o = o, p
             rv = [inter]
-            if isinstance(self, Line):
+            if isinstance(p, Line):
                 if isinstance(o, Line):
                     return rv
                 elif isinstance(o, Ray) and inray(o):
                     return rv
                 elif isinstance(o, Segment) and inseg(o):
                     return rv
-            elif isinstance(self, Ray) and inray(self):
+            elif isinstance(p, Ray) and inray(p):
                 if isinstance(o, Ray) and inray(o):
                     return rv
                 elif isinstance(o, Segment) and inseg(o):
                     return rv
-            elif isinstance(self, Segment) and inseg(self):
+            elif isinstance(p, Segment) and inseg(p):
                 if isinstance(o, Segment) and inseg(o):
                     return rv
             return []

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -518,15 +518,17 @@ class Polygon(GeometryEntity):
             lit.append(v - p)  # the difference is simplified
             if lit[-1].free_symbols:
                 return None
-        self = Polygon(*lit)
+
+        # issue 8362 avoid assign to self, introduce a temp variable poly here                
+        poly = Polygon(*lit)
 
         # polygon closure is assumed in the following test but Polygon removes duplicate pts so
         # the last point has to be added so all sides are computed. Using Polygon.sides is
         # not good since Segments are unordered.
-        args = self.args
+        args = poly.args
         indices = range(-len(args), 1)
 
-        if self.is_convex():
+        if poly.is_convex():
             orientation = None
             for i in indices:
                 a = args[i]

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -519,7 +519,6 @@ class Polygon(GeometryEntity):
             if lit[-1].free_symbols:
                 return None
 
-        # issue 8362 avoid assign to self, introduce a temp variable poly here                
         poly = Polygon(*lit)
 
         # polygon closure is assumed in the following test but Polygon removes duplicate pts so

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -930,25 +930,27 @@ class Integral(AddWithLimits):
         return Add(*parts)
 
     def _eval_lseries(self, x, logx):
-        self = self.as_dummy()
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr = self.as_dummy()
         symb = x
-        for l in self.limits:
+        for l in expr.limits:
             if x in l[1:]:
                 symb = l[0]
                 break
-        for term in self.function.lseries(symb, logx):
-            yield integrate(term, *self.limits)
+        for term in expr.function.lseries(symb, logx):
+            yield integrate(term, *expr.limits)
 
     def _eval_nseries(self, x, n, logx):
-        self = self.as_dummy()
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr = self.as_dummy()
         symb = x
-        for l in self.limits:
+        for l in expr.limits:
             if x in l[1:]:
                 symb = l[0]
                 break
-        terms, order = self.function.nseries(
+        terms, order = expr.function.nseries(
             x=symb, n=n, logx=logx).as_coeff_add(C.Order)
-        return integrate(terms, *self.limits) + Add(*order)*x
+        return integrate(terms, *expr.limits) + Add(*order)*x
 
     def as_sum(self, n, method="midpoint"):
         """

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -930,7 +930,6 @@ class Integral(AddWithLimits):
         return Add(*parts)
 
     def _eval_lseries(self, x, logx):
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = self.as_dummy()
         symb = x
         for l in expr.limits:
@@ -941,7 +940,6 @@ class Integral(AddWithLimits):
             yield integrate(term, *expr.limits)
 
     def _eval_nseries(self, x, n, logx):
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = self.as_dummy()
         symb = x
         for l in expr.limits:

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -585,11 +585,11 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
     @classmethod
     def _new(cls, *args, **kwargs):
         rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
-        cls = object.__new__(cls)
-        cls.rows = rows
-        cls.cols = cols
-        cls._mat = list(flat_list)  # create a shallow copy
-        return cls
+        obj = object.__new__(cls)
+        obj.rows = rows
+        obj.cols = cols
+        obj._mat = list(flat_list)  # create a shallow copy
+        return obj
 
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -585,11 +585,11 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
     @classmethod
     def _new(cls, *args, **kwargs):
         rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
-        self = object.__new__(cls)
-        self.rows = rows
-        self.cols = cols
-        self._mat = list(flat_list)  # create a shallow copy
-        return self
+        cls = object.__new__(cls)
+        cls.rows = rows
+        cls.cols = cols
+        cls._mat = list(flat_list)  # create a shallow copy
+        return cls
 
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1709,7 +1709,7 @@ class MatrixBase(object):
                 raise TypeError("`b` must be an ordered iterable or Matrix, not %s." %
                 type(b))
 
-        mat = self 
+        mat = self
         if mat.cols == b.rows:
             if b.cols != 1:
                 mat = mat.T

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1570,7 +1570,6 @@ class MatrixBase(object):
         QRsolve
         """
         cls = self.__class__
-        # issue 8362 avoid assign to self, introduce a temp variable mat here
         mat = self.as_mutable()
 
         if not mat.rows >= mat.cols:
@@ -1709,7 +1708,7 @@ class MatrixBase(object):
             else:
                 raise TypeError("`b` must be an ordered iterable or Matrix, not %s." %
                 type(b))
-        # issue 8362 avoid assign to self, introduce a temp variable mat here
+
         mat = self 
         if mat.cols == b.rows:
             if b.cols != 1:
@@ -2947,7 +2946,6 @@ class MatrixBase(object):
         # roots doesn't like Floats, so replace them with Rationals
         # unless the nsimplify flag indicates that this has already
         # been done, e.g. in eigenvects
-        # issue 8362 avoid assign to self, introduce a temp variable mat here
         mat = self
         if flags.pop('rational', True):
             if any(v.has(Float) for v in mat):
@@ -2982,7 +2980,6 @@ class MatrixBase(object):
 
         # roots doesn't like Floats, so replace them with Rationals
         float = False
-        # issue 8362 avoid assign to self, introduce a temp variable mat here
         mat = self
         if any(v.has(Float) for v in self):
             float = True
@@ -3045,7 +3042,6 @@ class MatrixBase(object):
 
         condition_number
         """
-        # issue 8362 avoid assign to self, introduce a temp variable mat here
         mat = self.as_mutable()
         # Compute eigenvalues of A.H A
         valmultpairs = (mat.H*mat).eigenvals()

--- a/sympy/mpmath/ctx_iv.py
+++ b/sympy/mpmath/ctx_iv.py
@@ -278,9 +278,10 @@ ivmpc.__truediv__ = ivmpc.__div__; ivmpc.__rtruediv__ = ivmpc.__rdiv__
 
 class ivmpf_constant(ivmpf):
     def __new__(cls, f):
-        self = new(cls)
-        self._f = f
-        return self
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr = new(cls)
+        expr._f = f
+        return expr
     def _get_mpi_(self):
         prec = self.ctx._prec[0]
         a = self._f(prec, round_floor)

--- a/sympy/mpmath/ctx_iv.py
+++ b/sympy/mpmath/ctx_iv.py
@@ -278,7 +278,6 @@ ivmpc.__truediv__ = ivmpc.__div__; ivmpc.__rtruediv__ = ivmpc.__rdiv__
 
 class ivmpf_constant(ivmpf):
     def __new__(cls, f):
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = new(cls)
         expr._f = f
         return expr

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -196,8 +196,7 @@ class Dyadic(object):
             baseline = 0
 
             def render(self, *args, **kwargs):
-                self = e
-                ar = self.args  # just to shorten things
+                ar = e.args  # just to shorten things
                 mpp = VectorPrettyPrinter()
                 if len(ar) == 0:
                     return unicode(0)

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -258,8 +258,7 @@ class Vector(object):
             baseline = 0
 
             def render(self, *args, **kwargs):
-                self = e
-                ar = self.args  # just to shorten things
+                ar = e.args  # just to shorten things
                 if len(ar) == 0:
                     return unicode(0)
                 ol = []  # output list, to be concatenated to a string

--- a/sympy/plotting/intervalmath/interval_arithmetic.py
+++ b/sympy/plotting/intervalmath/interval_arithmetic.py
@@ -337,16 +337,18 @@ class interval(object):
                     return interval(-float('inf'), float('inf'), is_valid=None)
 
                 # denominator negative
+                # issue 8362 avoid assign to self, introduce a temp variable this here
+                this = self
                 if other.end < 0:
-                    self = -self
+                    this = -this
                     other = -other
 
                 # denominator positive
                 inters = []
-                inters.append(self.start / other.start)
-                inters.append(self.end / other.start)
-                inters.append(self.start / other.end)
-                inters.append(self.end / other.end)
+                inters.append(this.start / other.start)
+                inters.append(this.end / other.start)
+                inters.append(this.start / other.end)
+                inters.append(this.end / other.end)
                 start = max(inters)
                 end = min(inters)
                 return interval(start, end)

--- a/sympy/plotting/intervalmath/interval_arithmetic.py
+++ b/sympy/plotting/intervalmath/interval_arithmetic.py
@@ -337,7 +337,6 @@ class interval(object):
                     return interval(-float('inf'), float('inf'), is_valid=None)
 
                 # denominator negative
-                # issue 8362 avoid assign to self, introduce a temp variable this here
                 this = self
                 if other.end < 0:
                     this = -this

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1126,14 +1126,15 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def _pow_generic(self, n):
         p = self.ring.one
 
+        expr = self
         while True:
             if n & 1:
-                p = p*self
+                p = p*expr
                 n -= 1
                 if not n:
                     break
 
-            self = self.square()
+            expr = expr.square()
             n = n // 2
 
         return p

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1477,7 +1477,6 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         False
 
         """
-        # issue 8362 avoid assign to self, introduce a temp variable cpself here
         if self in self.ring._gens_set:
             cpself = self.copy()
         else:

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1477,19 +1477,22 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         False
 
         """
+        # issue 8362 avoid assign to self, introduce a temp variable cpself here
         if self in self.ring._gens_set:
-            self = self.copy()
+            cpself = self.copy()
+        else:
+            cpself = self
         expv, coeff = mc
-        c = self.get(expv)
+        c = cpself.get(expv)
         if c is None:
-            self[expv] = coeff
+            cpself[expv] = coeff
         else:
             c += coeff
             if c:
-                self[expv] = c
+                cpself[expv] = c
             else:
-                del self[expv]
-        return self
+                del cpself[expv]
+        return cpself
 
     def _iadd_poly_monom(p1, p2, mc):
         """add to self the product of (p)*(coeff*x0**i0*x1**i1*...)

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -1743,7 +1743,6 @@ class RealInterval(object):
 
     def refine_size(self, dx):
         """Refine an isolating interval until it is of sufficiently small size. """
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = self
         while not (expr.dx < dx):
             expr = expr._inner_refine()
@@ -1752,7 +1751,6 @@ class RealInterval(object):
 
     def refine_step(self, steps=1):
         """Perform several steps of real root refinement algorithm. """
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = self
         for _ in xrange(steps):
             expr = expr._inner_refine()
@@ -1881,7 +1879,6 @@ class ComplexInterval(object):
         """Refine an isolating interval until it is of sufficiently small size. """
         if dy is None:
             dy = dx
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = self
         while not (expr.dx < dx and expr.dy < dy):
             expr = expr._inner_refine()
@@ -1890,7 +1887,6 @@ class ComplexInterval(object):
 
     def refine_step(self, steps=1):
         """Perform several steps of complex root refinement algorithm. """
-        # issue 8362 avoid assign to self, introduce a temp variable expr here
         expr = self
         for _ in xrange(steps):
             expr = expr._inner_refine()

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -1736,10 +1736,11 @@ class RealInterval(object):
 
     def refine_disjoint(self, other):
         """Refine an isolating interval until it is disjoint with another one. """
-        while not self.is_disjoint(other):
-            self, other = self._inner_refine(), other._inner_refine()
+        this = self
+        while not this.is_disjoint(other):
+            this, other = this._inner_refine(), other._inner_refine()
 
-        return self, other
+        return this, other
 
     def refine_size(self, dx):
         """Refine an isolating interval until it is of sufficiently small size. """
@@ -1870,10 +1871,11 @@ class ComplexInterval(object):
 
     def refine_disjoint(self, other):
         """Refine an isolating interval until it is disjoint with another one. """
-        while not self.is_disjoint(other):
-            self, other = self._inner_refine(), other._inner_refine()
+        this = self
+        while not this.is_disjoint(other):
+            this, other = this._inner_refine(), other._inner_refine()
 
-        return self, other
+        return this, other
 
     def refine_size(self, dx, dy=None):
         """Refine an isolating interval until it is of sufficiently small size. """

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -1743,17 +1743,21 @@ class RealInterval(object):
 
     def refine_size(self, dx):
         """Refine an isolating interval until it is of sufficiently small size. """
-        while not (self.dx < dx):
-            self = self._inner_refine()
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr = self
+        while not (expr.dx < dx):
+            expr = expr._inner_refine()
 
-        return self
+        return expr
 
     def refine_step(self, steps=1):
         """Perform several steps of real root refinement algorithm. """
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr = self
         for _ in xrange(steps):
-            self = self._inner_refine()
+            expr = expr._inner_refine()
 
-        return self
+        return expr
 
     def refine(self):
         """Perform one step of real root refinement algorithm. """
@@ -1877,18 +1881,21 @@ class ComplexInterval(object):
         """Refine an isolating interval until it is of sufficiently small size. """
         if dy is None:
             dy = dx
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr = self
+        while not (expr.dx < dx and expr.dy < dy):
+            expr = expr._inner_refine()
 
-        while not (self.dx < dx and self.dy < dy):
-            self = self._inner_refine()
-
-        return self
+        return expr
 
     def refine_step(self, steps=1):
         """Perform several steps of complex root refinement algorithm. """
+        # issue 8362 avoid assign to self, introduce a temp variable expr here
+        expr = self
         for _ in xrange(steps):
-            self = self._inner_refine()
+            expr = expr._inner_refine()
 
-        return self
+        return expr
 
     def refine(self):
         """Perform one step of complex root refinement algorithm. """

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -764,15 +764,14 @@ class PrettyPrinter(Printer):
             baseline = 0
 
             def render(self, *args, **kwargs):
-                self = e
-                if self == e.zero:
+                if e == e.zero:
                     return e.zero._pretty_form
                 o1 = []
                 vectstrs = []
-                if isinstance(self, Vector):
-                    items = self.separate().items()
+                if isinstance(e, Vector):
+                    items = e.separate().items()
                 else:
-                    items = [(0, self)]
+                    items = [(0, e)]
                 for system, vect in items:
                     inneritems = list(vect.components.items())
                     inneritems.sort(key = lambda x: x[0].__str__())

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1369,17 +1369,18 @@ class ReduceOrder(Operator):
         if bj.is_integer and bj <= 0 and bj + n - 1 >= 0:
             return None
 
-        self = Operator.__new__(cls)
+        # issue 8362 avoid assign to self
+        expr = Operator.__new__(cls)
 
         p = S(1)
         for k in xrange(n):
             p *= (_x + bj + k)/(bj + k)
 
-        self._poly = Poly(p, _x)
-        self._a = ai
-        self._b = bj
+        expr._poly = Poly(p, _x)
+        expr._a = ai
+        expr._b = bj
 
-        return self
+        return expr
 
     @classmethod
     def _meijer(cls, b, a, sign):
@@ -1391,21 +1392,22 @@ class ReduceOrder(Operator):
         if n.is_negative or not n.is_Integer:
             return None
 
-        self = Operator.__new__(cls)
+        # issue 8362 avoid assign to self
+        expr = Operator.__new__(cls)
 
         p = S(1)
         for k in xrange(n):
             p *= (sign*_x + a + k)
 
-        self._poly = Poly(p, _x)
+        expr._poly = Poly(p, _x)
         if sign == -1:
-            self._a = b
-            self._b = a
+            expr._a = b
+            expr._b = a
         else:
-            self._b = Add(1, a - 1, evaluate=False)
-            self._a = Add(1, b - 1, evaluate=False)
+            expr._b = Add(1, a - 1, evaluate=False)
+            expr._a = Add(1, b - 1, evaluate=False)
 
-        return self
+        return expr
 
     @classmethod
     def meijer_minus(cls, b, a):

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1369,7 +1369,6 @@ class ReduceOrder(Operator):
         if bj.is_integer and bj <= 0 and bj + n - 1 >= 0:
             return None
 
-        # issue 8362 avoid assign to self
         expr = Operator.__new__(cls)
 
         p = S(1)
@@ -1392,7 +1391,6 @@ class ReduceOrder(Operator):
         if n.is_negative or not n.is_Integer:
             return None
 
-        # issue 8362 avoid assign to self
         expr = Operator.__new__(cls)
 
         p = S(1)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3030,7 +3030,6 @@ class TensMul(TensExpr):
         self_matrix_behavior_kinds = self._matrix_behavior_kinds
         other_matrix_behavior_kinds = other._matrix_behavior_kinds
 
-        tensor = self
         for key, v1 in self_matrix_behavior_kinds.items():
             if key in other_matrix_behavior_kinds:
                 v2 = other_matrix_behavior_kinds[key]
@@ -3040,7 +3039,7 @@ class TensMul(TensExpr):
                         matrix_behavior_kinds[key] = (v2[1],)
                 elif len(v1) == 2:
                     auto_index = v1[1]._tensortype.auto_index
-                    tensor = self.substitute_indices((v1[1], -auto_index))
+                    self = self.substitute_indices((v1[1], -auto_index))
                     other = other.substitute_indices((v2[0], auto_index))
                     if len(v2) == 1:
                         matrix_behavior_kinds[key] = (v1[0],)
@@ -3054,8 +3053,8 @@ class TensMul(TensExpr):
                 continue
             matrix_behavior_kinds[key] = v2
 
-        new_tids = tensor._tids*other._tids
-        coeff = tensor._coeff*other._coeff
+        new_tids = self._tids*other._tids
+        coeff = self._coeff*other._coeff
         tmul = TensMul.from_TIDS(coeff, new_tids)
         if isinstance(tmul, TensExpr):
             tmul._matrix_behavior_kinds = matrix_behavior_kinds

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3030,6 +3030,7 @@ class TensMul(TensExpr):
         self_matrix_behavior_kinds = self._matrix_behavior_kinds
         other_matrix_behavior_kinds = other._matrix_behavior_kinds
 
+        tensor = self
         for key, v1 in self_matrix_behavior_kinds.items():
             if key in other_matrix_behavior_kinds:
                 v2 = other_matrix_behavior_kinds[key]
@@ -3039,7 +3040,7 @@ class TensMul(TensExpr):
                         matrix_behavior_kinds[key] = (v2[1],)
                 elif len(v1) == 2:
                     auto_index = v1[1]._tensortype.auto_index
-                    self = self.substitute_indices((v1[1], -auto_index))
+                    tensor = tensor.substitute_indices((v1[1], -auto_index))
                     other = other.substitute_indices((v2[0], auto_index))
                     if len(v2) == 1:
                         matrix_behavior_kinds[key] = (v1[0],)
@@ -3053,8 +3054,8 @@ class TensMul(TensExpr):
                 continue
             matrix_behavior_kinds[key] = v2
 
-        new_tids = self._tids*other._tids
-        coeff = self._coeff*other._coeff
+        new_tids = tensor._tids*other._tids
+        coeff = tensor._coeff*other._coeff
         tmul = TensMul.from_TIDS(coeff, new_tids)
         if isinstance(tmul, TensExpr):
             tmul._matrix_behavior_kinds = matrix_behavior_kinds

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3030,7 +3030,6 @@ class TensMul(TensExpr):
         self_matrix_behavior_kinds = self._matrix_behavior_kinds
         other_matrix_behavior_kinds = other._matrix_behavior_kinds
 
-        # issue 8362 avoid assign to self, introduce a temp variable tensor here
         tensor = self
         for key, v1 in self_matrix_behavior_kinds.items():
             if key in other_matrix_behavior_kinds:
@@ -3055,7 +3054,6 @@ class TensMul(TensExpr):
                 continue
             matrix_behavior_kinds[key] = v2
 
-        # tensor is self here, a little strange.
         new_tids = tensor._tids*other._tids
         coeff = tensor._coeff*other._coeff
         tmul = TensMul.from_TIDS(coeff, new_tids)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3030,6 +3030,8 @@ class TensMul(TensExpr):
         self_matrix_behavior_kinds = self._matrix_behavior_kinds
         other_matrix_behavior_kinds = other._matrix_behavior_kinds
 
+        # issue 8362 avoid assign to self, introduce a temp variable tensor here
+        tensor = self
         for key, v1 in self_matrix_behavior_kinds.items():
             if key in other_matrix_behavior_kinds:
                 v2 = other_matrix_behavior_kinds[key]
@@ -3039,7 +3041,7 @@ class TensMul(TensExpr):
                         matrix_behavior_kinds[key] = (v2[1],)
                 elif len(v1) == 2:
                     auto_index = v1[1]._tensortype.auto_index
-                    self = self.substitute_indices((v1[1], -auto_index))
+                    tensor = self.substitute_indices((v1[1], -auto_index))
                     other = other.substitute_indices((v2[0], auto_index))
                     if len(v2) == 1:
                         matrix_behavior_kinds[key] = (v1[0],)
@@ -3053,8 +3055,9 @@ class TensMul(TensExpr):
                 continue
             matrix_behavior_kinds[key] = v2
 
-        new_tids = self._tids*other._tids
-        coeff = self._coeff*other._coeff
+        # tensor is self here, a little strange.
+        new_tids = tensor._tids*other._tids
+        coeff = tensor._coeff*other._coeff
         tmul = TensMul.from_TIDS(coeff, new_tids)
         if isinstance(tmul, TensExpr):
             tmul._matrix_behavior_kinds = matrix_behavior_kinds


### PR DESCRIPTION
Most fixes are direct, some doubts in patch are 

pretty.py  the code always has `e=self` then `self=e`, unknown reason
tensor.py changing self to tensor is a little strange for codes between line 3058-3060
interval_arithmetic.py the change may influence the readbility

All the rest cases are not suitable to fix in this issue. As they are used intentionally.

sympy/galgebra/ga.py:                        self = MV.characterize_expression(self, base)
sympy/galgebra/ga.py:            self = MVtypes[mvtype](self, base)
sympy/matrices/dense.py:        self = object.**new**(cls)
sympy/polys/rings.py:            self = self.square()
