### PR TITLE
8438: implement general cubic solution

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -96,7 +96,13 @@ def roots_quadratic(f):
 
 
 def roots_cubic(f, trig=False):
-    """Returns a list of roots of a cubic polynomial."""
+    """Returns a list of roots of a cubic polynomial.
+
+    References
+    ==========
+    [1] https://en.wikipedia.org/wiki/Cubic_function, General formula for roots,
+    (accessed November 17, 2014).
+    """
     if trig:
         a, b, c, d = f.all_coeffs()
         p = (3*a*c - b**2)/3/a**2
@@ -120,26 +126,31 @@ def roots_cubic(f, trig=False):
     pon3 = p/3
     aon3 = a/3
 
+    u1 = None
     if p is S.Zero:
         if q is S.Zero:
             return [-aon3]*3
-        else:
-            if q.is_real:
-                if (q > 0) == True:
-                    u1 = -root(q, 3)
-                else:
-                    u1 = root(-q, 3)
-            else:
+        if q.is_real:
+            if q.is_positive:
+                u1 = -root(q, 3)
+            elif q.is_negative:
                 u1 = root(-q, 3)
     elif q is S.Zero:
         y1, y2 = roots([1, 0, p], multiple=True)
         return [tmp - aon3 for tmp in [y1, S.Zero, y2]]
-    elif q.is_real and q < 0:
+    elif q.is_real and q.is_negative:
         u1 = -root(-q/2 + sqrt(q**2/4 + pon3**3), 3)
-    else:
-        u1 = root(q/2 + sqrt(q**2/4 + pon3**3), 3)
 
     coeff = I*sqrt(3)/2
+    if u1 is None:
+        u1 = S(1)
+        u2 = -S.Half + coeff
+        u3 = -S.Half - coeff
+        a, b, c, d = S(1), a, b, c
+        D0 = b**2 - 3*a*c
+        D1 = 2*b**3 - 9*a*b*c + 27*a**2*d
+        C = root((D1 + sqrt(D1**2 - 4*D0**3))/2, 3)
+        return [-(b + uk*C + D0/C/uk)/3/a for uk in [u1, u2, u3]]
 
     u2 = u1*(-S.Half + coeff)
     u3 = u1*(-S.Half - coeff)


### PR DESCRIPTION
The approach below cannot be used without special handling
to make sure that a valid pair of roots for _S and T are chosen
such that _S*T = -Q. [Thanks to Kalevi Suominen for noting why
the formulas below did not work as written for all cases].

*\* eqns (54)-(56) from http://mathworld.wolfram.com/CubicFormula.html

``` python
f = Poly([1, -S(3)/2 - 7*I/2, -2, -3], x)
_, a2, a1, a0 = f.monic().all_coeffs()
coeff = I*sqrt(3)/2
Q = (3*a1 - a2**2)/9
R = (9*a2*a1 - 27*a0 - 2*a2**3)/54
D = Q**3 + R**2
_S = root(R + sqrt(D), 3)
T = root(R - sqrt(D), 3)
B = _S + T
A = _S - T
r = -a2/3 - B/2
bad = [-a2/3 + B, r + coeff*A, r - coeff*A]
```
