### PR TITLE
Piecewise: input should work whether its tuple or ExprCondPair

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -94,7 +94,14 @@ class Piecewise(Function):
         # (Try to) sympify args first
         newargs = []
         for ec in args:
-            pair = ExprCondPair(*ec)
+            print("Debug: ec is type: " + str(type(ec)))
+            print("  Debug: isinstance: " + str(isinstance(ec, ExprCondPair)))
+            if isinstance(ec, ExprCondPair):
+                print('  Debug: already an ExprCondPair')
+                pair = ec
+            else:
+                print('  Debug: converting tuple to ExprCondPair')
+                pair = ExprCondPair(*ec)
             cond = pair.cond
             if cond == false:
                 continue

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -94,14 +94,8 @@ class Piecewise(Function):
         # (Try to) sympify args first
         newargs = []
         for ec in args:
-            print("Debug: ec is type: " + str(type(ec)))
-            print("  Debug: isinstance: " + str(isinstance(ec, ExprCondPair)))
-            if isinstance(ec, ExprCondPair):
-                print('  Debug: already an ExprCondPair')
-                pair = ec
-            else:
-                print('  Debug: converting tuple to ExprCondPair')
-                pair = ExprCondPair(*ec)
+            # ec could be a ExprCondPair or a tuple
+            pair = ExprCondPair(*getattr(ec, 'args', ec))
             cond = pair.cond
             if cond == false:
                 continue

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -2,8 +2,9 @@ from sympy import (
     adjoint, And, Basic, conjugate, diff, expand, Eq, Function, I, im,
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, re, solve, symbols, transpose,
-    cos, exp, Abs, Not, Symbol
+    cos, exp, Abs, Not, Symbol, S
 )
+from sympy.printing import srepr
 from sympy.utilities.pytest import XFAIL, raises
 
 x, y = symbols('x y')
@@ -489,3 +490,9 @@ def test_as_expr_set_pairs():
 
     assert Piecewise(((x - 2)**2, x >= 0), (0, True)).as_expr_set_pairs() == \
         [((x - 2)**2, Interval(0, oo)), (0, Interval(-oo, 0, True, True))]
+
+
+def test_S_srepr_is_identity():
+    p = Piecewise((10, Eq(x, 0)), (12, True))
+    q = S(srepr(p))
+    assert p == q


### PR DESCRIPTION
Should fix `S(srepr(p)) == p` where `p` is a Piecewise.

If the Piecewise() gets an existing ExprCondPair it should not try
to deference it like a Tuple to build a new ExprCondPair.  Rather
it should just use the ExprCondPair.

But help!  It doesn't work...
