### PR TITLE
allow hklmnpst symbol subscripts as unicode

### DIFF
--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -164,11 +164,8 @@ sub = {}    # symb -> subscript symbol
 sup = {}    # symb -> superscript symbol
 
 # latin subscripts
-for l in 'aeioruvx':
+for l in 'aeioruvxhklmnpst':
     sub[l] = LSUB(l)
-# subscripts from ftp://ftp.unicode.org/Public/6.3.0/ucd/UnicodeData.txt
-for n, l in enumerate('hklmnpst'):
-    sub[l] = u('\u' + hex(int('2095', base = 16) + n).upper()[2:])
 
 for l in 'in':
     sup[l] = LSUP(l)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -166,6 +166,9 @@ sup = {}    # symb -> superscript symbol
 # latin subscripts
 for l in 'aeioruvx':
     sub[l] = LSUB(l)
+# subscripts from ftp://ftp.unicode.org/Public/6.3.0/ucd/UnicodeData.txt
+for n, l in enumerate('hklmnpst'):
+    sub[l] = u('\u' + hex(int('2095', base = 16) + n).upper()[2:])
 
 for l in 'in':
     sup[l] = LSUP(l)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -273,6 +273,8 @@ def test_upretty_subs_missingin_24():
     assert upretty( Symbol('F_r') ) == u('Fᵣ')
     assert upretty( Symbol('F_v') ) == u('Fᵥ')
     assert upretty( Symbol('F_x') ) == u('Fₓ')
+    assert upretty( Symbol('F_h') ) == u('Fₕ')
+    assert upretty( Symbol('F_t') ) == u('Fₜ')
 
 def test_upretty_modifiers():
     # Accents

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -273,7 +273,14 @@ def test_upretty_subs_missingin_24():
     assert upretty( Symbol('F_r') ) == u('Fᵣ')
     assert upretty( Symbol('F_v') ) == u('Fᵥ')
     assert upretty( Symbol('F_x') ) == u('Fₓ')
+
     assert upretty( Symbol('F_h') ) == u('Fₕ')
+    assert upretty( Symbol('F_k') ) == u('Fₖ')
+    assert upretty( Symbol('F_l') ) == u('Fₗ')
+    assert upretty( Symbol('F_m') ) == u('Fₘ')
+    assert upretty( Symbol('F_n') ) == u('Fₙ')
+    assert upretty( Symbol('F_p') ) == u('Fₚ')
+    assert upretty( Symbol('F_s') ) == u('Fₛ')
     assert upretty( Symbol('F_t') ) == u('Fₜ')
 
 def test_upretty_modifiers():


### PR DESCRIPTION
Fill in a few missing unicode subscripts.

fixes #9047
