### PR TITLE
Fix ZeroDivisionError for stty columns=0

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1857,9 +1857,11 @@ class PyTestReporter(Reporter):
                         columns = match.group('columns')
 
                         try:
-                            return int(columns)
+                            width = int(columns)
                         except ValueError:
                             pass
+                        if width != 0:
+                            return width
 
             return self._default_width
 


### PR DESCRIPTION
The PyTestReporter object fetches terminal width using `stty`.  This can be
reported as zero, giving later confusing errors.  If the width is zero, use
the default instead.

Fixes bug running tests on new incarnation of travis OSX test VMS: https://s3.amazonaws.com/archive.travis-ci.org/jobs/39770605/log.txt
