### PR TITLE
New refine entry for the atan2 function

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -192,6 +192,37 @@ def refine_exp(expr, assumptions):
                 elif ask(Q.odd(coeff + S.Half), assumptions):
                     return S.ImaginaryUnit
 
+
+def refine_atan2(expr, assumptions):
+    """
+    Handler for the atan2 function
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, Q, refine, atan2
+    >>> from sympy.assumptions.refine import refine_atan2
+    >>> from sympy.abc import x, y
+    >>> refine_atan2(atan2(y,x), Q.real(y) & Q.positive(x))
+    atan(y/x)
+    >>> refine_atan2(atan2(y,x), Q.negative(y) & Q.negative(x))
+    atan(y/x) - pi
+    >>> refine_atan2(atan2(y,x), Q.positive(y) & Q.negative(x))
+    atan(y/x) + pi
+    """
+    from sympy.functions.elementary.complexes import atan
+    from sympy.core import S
+    y, x = expr.args
+    if ask(Q.real(y) & Q.positive(x), assumptions):
+        return atan(y / x)
+    elif ask(Q.negative(y) & Q.negative(x), assumptions):
+        return atan(y / x) - S.Pi
+    elif ask(Q.positive(y) & Q.negative(x), assumptions):
+        return atan(y / x) + S.Pi
+    else:
+        return expr
+
+
 def refine_Relational(expr, assumptions):
     """
     Handler for Relational
@@ -209,10 +240,11 @@ handlers_dict = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
     'exp': refine_exp,
-    'Equality' : refine_Relational,
-    'Unequality' : refine_Relational,
-    'GreaterThan' : refine_Relational,
-    'LessThan' : refine_Relational,
-    'StrictGreaterThan' : refine_Relational,
-    'StrictLessThan' : refine_Relational
+    'atan2': refine_atan2,
+    'Equality': refine_Relational,
+    'Unequality': refine_Relational,
+    'GreaterThan': refine_Relational,
+    'LessThan': refine_Relational,
+    'StrictGreaterThan': refine_Relational,
+    'StrictLessThan': refine_Relational
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,4 +1,5 @@
-from sympy import Abs, exp, Expr, I, pi, Q, Rational, refine, S, sqrt
+from sympy import (Abs, exp, Expr, I, pi, Q, Rational, refine, S, sqrt,
+                   atan, atan2)
 from sympy.abc import x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
@@ -59,45 +60,55 @@ def test_exp():
 
 
 def test_Relational():
-    assert refine(x < 0, ~Q.is_true(x < 0)) == False
-    assert refine(x < 0, Q.is_true(x < 0)) == True
+    assert not refine(x < 0, ~Q.is_true(x < 0))
+    assert refine(x < 0, Q.is_true(x < 0))
     assert refine(x < 0, Q.is_true(y < 0)) == (x < 0)
-    assert refine(x <= 0, ~Q.is_true(x <= 0)) == False
-    assert refine(x <= 0,  Q.is_true(x <= 0)) == True
+    assert not refine(x <= 0, ~Q.is_true(x <= 0))
+    assert refine(x <= 0,  Q.is_true(x <= 0))
     assert refine(x <= 0,  Q.is_true(y <= 0)) == (x <= 0)
-    assert refine(x > 0, ~Q.is_true(x > 0)) == False
-    assert refine(x > 0,  Q.is_true(x > 0)) == True
+    assert not refine(x > 0, ~Q.is_true(x > 0))
+    assert refine(x > 0,  Q.is_true(x > 0))
     assert refine(x > 0,  Q.is_true(y > 0)) == (x > 0)
-    assert refine(x >= 0, ~Q.is_true(x >= 0)) == False
-    assert refine(x >= 0,  Q.is_true(x >= 0)) == True
+    assert not refine(x >= 0, ~Q.is_true(x >= 0))
+    assert refine(x >= 0,  Q.is_true(x >= 0))
     assert refine(x >= 0,  Q.is_true(y >= 0)) == (x >= 0)
-    assert refine(Eq(x, 0), ~Q.is_true(Eq(x, 0))) == False
-    assert refine(Eq(x, 0),  Q.is_true(Eq(x, 0))) == True
+    assert not refine(Eq(x, 0), ~Q.is_true(Eq(x, 0)))
+    assert refine(Eq(x, 0),  Q.is_true(Eq(x, 0)))
     assert refine(Eq(x, 0),  Q.is_true(Eq(y, 0))) == Eq(x, 0)
-    assert refine(Ne(x, 0), ~Q.is_true(Ne(x, 0))) == False
-    assert refine(Ne(x, 0),  Q.is_true(Ne(x, 0))) == True
+    assert not refine(Ne(x, 0), ~Q.is_true(Ne(x, 0)))
+    assert refine(Ne(x, 0),  Q.is_true(Ne(x, 0)))
     assert refine(Ne(x, 0),  Q.is_true(Ne(y, 0))) == (Ne(x, 0))
 
 
 def test_Piecewise():
-   assert refine(Piecewise((1, x < 0), (3, True)),  Q.is_true(x < 0)) == 1
-   assert refine(Piecewise((1, x < 0), (3, True)), ~Q.is_true(x < 0)) == 3
-   assert refine(Piecewise((1, x < 0), (3, True)),  Q.is_true(y < 0)) == Piecewise((1, x < 0), (3, True))
-   assert refine(Piecewise((1, x > 0), (3, True)),  Q.is_true(x > 0)) == 1
-   assert refine(Piecewise((1, x > 0), (3, True)), ~Q.is_true(x > 0)) == 3
-   assert refine(Piecewise((1, x > 0), (3, True)),  Q.is_true(y > 0)) == Piecewise((1, x > 0), (3, True))
-   assert refine(Piecewise((1, x <= 0), (3, True)),  Q.is_true(x <= 0)) == 1
-   assert refine(Piecewise((1, x <= 0), (3, True)), ~Q.is_true(x <= 0)) == 3
-   assert refine(Piecewise((1, x <= 0), (3, True)),  Q.is_true(y <= 0)) == Piecewise((1, x <= 0), (3, True))
-   assert refine(Piecewise((1, x >= 0), (3, True)),  Q.is_true(x >= 0)) == 1
-   assert refine(Piecewise((1, x >= 0), (3, True)), ~Q.is_true(x >= 0)) == 3
-   assert refine(Piecewise((1, x >= 0), (3, True)),  Q.is_true(y >= 0)) == Piecewise((1, x >= 0), (3, True))
-   assert refine(Piecewise((1, Eq(x, 0)), (3, True)),  Q.is_true(Eq(x, 0))) == 1
-   assert refine(Piecewise((1, Eq(x, 0)), (3, True)), ~Q.is_true(Eq(x, 0))) == 3
-   assert refine(Piecewise((1, Eq(x, 0)), (3, True)),  Q.is_true(Eq(y, 0))) == Piecewise((1, Eq(x, 0)), (3, True))
-   assert refine(Piecewise((1, Ne(x, 0)), (3, True)),  Q.is_true(Ne(x, 0))) == 1
-   assert refine(Piecewise((1, Ne(x, 0)), (3, True)), ~Q.is_true(Ne(x, 0))) == 3
-   assert refine(Piecewise((1, Ne(x, 0)), (3, True)),  Q.is_true(Ne(y, 0))) == Piecewise((1, Ne(x, 0)), (3, True))
+    assert refine(Piecewise((1, x < 0), (3, True)), Q.is_true(x < 0)) == 1
+    assert refine(Piecewise((1, x < 0), (3, True)), ~Q.is_true(x < 0)) == 3
+    assert refine(Piecewise((1, x < 0), (3, True)), Q.is_true(y < 0)) == \
+        Piecewise((1, x < 0), (3, True))
+    assert refine(Piecewise((1, x > 0), (3, True)), Q.is_true(x > 0)) == 1
+    assert refine(Piecewise((1, x > 0), (3, True)), ~Q.is_true(x > 0)) == 3
+    assert refine(Piecewise((1, x > 0), (3, True)), Q.is_true(y > 0)) == \
+        Piecewise((1, x > 0), (3, True))
+    assert refine(Piecewise((1, x <= 0), (3, True)), Q.is_true(x <= 0)) == 1
+    assert refine(Piecewise((1, x <= 0), (3, True)), ~Q.is_true(x <= 0)) == 3
+    assert refine(Piecewise((1, x <= 0), (3, True)), Q.is_true(y <= 0)) == \
+        Piecewise((1, x <= 0), (3, True))
+    assert refine(Piecewise((1, x >= 0), (3, True)), Q.is_true(x >= 0)) == 1
+    assert refine(Piecewise((1, x >= 0), (3, True)), ~Q.is_true(x >= 0)) == 3
+    assert refine(Piecewise((1, x >= 0), (3, True)), Q.is_true(y >= 0)) == \
+        Piecewise((1, x >= 0), (3, True))
+    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), Q.is_true(Eq(x, 0)))\
+        == 1
+    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), ~Q.is_true(Eq(x, 0)))\
+        == 3
+    assert refine(Piecewise((1, Eq(x, 0)), (3, True)), Q.is_true(Eq(y, 0)))\
+        == Piecewise((1, Eq(x, 0)), (3, True))
+    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), Q.is_true(Ne(x, 0)))\
+        == 1
+    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), ~Q.is_true(Ne(x, 0)))\
+        == 3
+    assert refine(Piecewise((1, Ne(x, 0)), (3, True)), Q.is_true(Ne(y, 0)))\
+        == Piecewise((1, Ne(x, 0)), (3, True))
 
 
 def test_func_args():

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -111,6 +111,13 @@ def test_Piecewise():
         == Piecewise((1, Ne(x, 0)), (3, True))
 
 
+def test_atan2():
+    assert refine(atan2(y, x), Q.real(y) & Q.positive(x)) == atan(y/x)
+    assert refine(atan2(y, x), Q.negative(y) & Q.positive(x)) == atan(y/x)
+    assert refine(atan2(y, x), Q.negative(y) & Q.negative(x)) == atan(y/x) - pi
+    assert refine(atan2(y, x), Q.positive(y) & Q.negative(x)) == atan(y/x) + pi
+
+
 def test_func_args():
     class MyClass(Expr):
         # A class with nontrivial .func


### PR DESCRIPTION
This PR adds the function refine_atan2. Compared with  PR #8476 in this one the functions is more clearly written with consisten variable names y, x. The doc string function is also corrected. 
