### PR TITLE
subfactorial is an integer

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core import S, C, sympify
 from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.logic import fuzzy_and
 from sympy.ntheory import sieve
 from math import sqrt as _sqrt
 
@@ -226,6 +227,10 @@ class subfactorial(CombinatorialFunction):
         except ValueError:
             if sympify(arg).is_Number:
                 raise ValueError("argument must be a nonnegative integer")
+
+    def _eval_is_integer(self):
+        return fuzzy_and((self.args[0].is_integer,
+                          self.args[0].is_nonnegative))
 
 
 class factorial2(CombinatorialFunction):

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -185,3 +185,22 @@ def test_subfactorial():
         [1, 0, 1, 2, 9, 44, 265, 1854, 14833, 133496]))
     raises(ValueError, lambda: subfactorial(0.1))
     raises(ValueError, lambda: subfactorial(-2))
+
+    tt = Symbol('tt', integer=True, nonnegative=True)
+    tf = Symbol('tf', integer=True, nonnegative=False)
+    tn = Symbol('tf', integer=True)
+    ft = Symbol('ft', integer=False, nonnegative=True)
+    ff = Symbol('ff', integer=False, nonnegative=False)
+    fn = Symbol('ff', integer=False)
+    nt = Symbol('nt', nonnegative=True)
+    nf = Symbol('nf', nonnegative=False)
+    nn = Symbol('nf')
+    assert subfactorial(tt).is_integer
+    assert subfactorial(tf).is_integer is False
+    assert subfactorial(tn).is_integer is None
+    assert subfactorial(ft).is_integer is False
+    assert subfactorial(ff).is_integer is False
+    assert subfactorial(fn).is_integer is False
+    assert subfactorial(nt).is_integer is None
+    assert subfactorial(nf).is_integer is False
+    assert subfactorial(nn).is_integer is None


### PR DESCRIPTION
I have implemented `_eval_is_integer` in `subfactorial`, so that the output of this function is considered to be an integer. Since the input of this function must be an integer, perhaps `return True` would have been better - but I have chosen this alternative, as I would like to see this:

``` python
>>> k = Symbol('k', integer=True, nonnegative=True)
>>> floor(subfactorial(k))
subfactorial(k)
>>> x = Symbol('x', real=True)
>>> floor(subfactorial(x))
floor(subfactorial(x))
```
