### PR TITLE
Don't use evaluate kwarg for eval methods: fix catalan and euler

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -12,7 +12,6 @@ from __future__ import print_function, division
 from sympy.core.function import Function, expand_mul
 from sympy.core import S, Symbol, Rational, oo, Integer, C, Add, Dummy
 from sympy.core.compatibility import as_int, SYMPY_INTS, xrange
-from sympy.core.evaluate import global_evaluate
 from sympy.core.cache import cacheit
 from sympy.core.numbers import pi
 from sympy.core.relational import LessThan, StrictGreaterThan
@@ -698,11 +697,7 @@ class euler(Function):
     """
 
     @classmethod
-    def eval(cls, m, evaluate=None):
-        if evaluate is None:
-            evaluate = global_evaluate[0]
-        if not evaluate:
-            return
+    def eval(cls, m):
         if m.is_odd:
             return S.Zero
         if m.is_Integer and m.is_nonnegative:
@@ -821,9 +816,7 @@ class catalan(Function):
     """
 
     @classmethod
-    def eval(cls, n, evaluate=None):
-        if evaluate is None:
-            evaluate = global_evaluate[0]
+    def eval(cls, n):
         if n.is_Integer and n.is_nonnegative:
             return 4**n*C.gamma(n + S.Half)/(C.gamma(S.Half)*C.gamma(n + 2))
 

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -436,3 +436,11 @@ def test_nC_nP_nT():
     t = (3, 9, 4, 6, 6, 5, 5, 2, 10, 4)
     assert sum(_AOP_product(t)[i] for i in range(55)) == 58212000
     raises(ValueError, lambda: _multiset_histogram({1:'a'}))
+
+
+def test_issue_8496():
+    n = Symbol("n")
+    k = Symbol("k")
+
+    raises(TypeError, lambda: catalan(n, k))
+    raises(TypeError, lambda: euler(n, k))


### PR DESCRIPTION
fixes #8496
