### PR TITLE
fixes #7840

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -326,7 +326,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
 
     def _rebuild(expr):
 
-        if expr.is_Atom:
+        if not expr.args:
             return expr
 
         if iterable(expr):

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -321,3 +321,39 @@ def test_symbols_exhausted_error():
     sym = [x, y, z]
     with raises(ValueError) as excinfo:
         cse(l, symbols=sym)
+
+def test_issue_7840():
+    # daveknippers' example
+    C393 = sympify( \
+        'Piecewise((C391 - 1.65, C390 < 0.5), (Piecewise((C391 - 1.65, \
+        C391 > 2.35), (C392, True)), True))'
+    )
+    C391 = sympify( \
+        'Piecewise((2.05*C390**(-1.03), C390 < 0.5), (2.5*C390**(-0.625), True))'
+    )
+    C393 = C393.subs('C391',C391)
+    # simple substitution
+    sub = {}
+    sub['C390'] = 0.703451854
+    sub['C392'] = 1.01417794
+    ss_answer = C393.subs(sub)
+    # cse
+    substitutions,new_eqn = cse(C393)
+    for pair in substitutions:
+        sub[pair[0].name] = pair[1].subs(sub)
+    cse_answer = new_eqn[0].subs(sub)
+    # both methods should be the same
+    assert ss_answer == cse_answer
+
+    # GitRay's example
+    expr = sympify(
+        "Piecewise((Symbol('ON'), Equality(Symbol('mode'), Symbol('ON'))), \
+        (Piecewise((Piecewise((Symbol('OFF'), StrictLessThan(Symbol('x'), \
+        Symbol('threshold'))), (Symbol('ON'), S.true)), Equality(Symbol('mode'), \
+        Symbol('AUTO'))), (Symbol('OFF'), S.true)), S.true))"
+    )
+    substitutions, new_eqn = cse(expr)
+    # this Piecewise should be exactly the same
+    assert new_eqn[0] == expr
+    # there should not be any replacements
+    assert len(substitutions) < 1


### PR DESCRIPTION
Be gentle, I've never done this before. This fixes a problem where cse subs out the final "True" statement in a Piecewise. This fix prevents cse from ever creating a "x0 == True" or "x0 == False" replacement, which I don't think is ever helpful.
