### PR TITLE
Fix dimension of C_1 matrix in no-constraint case

### DIFF
--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -161,11 +161,11 @@ class Linearizer(object):
                 f_v_jac_q = self.f_v.jacobian(self.q)
                 self._C_1 = -self._Pud * temp.LUsolve(f_v_jac_q)
             else:
-                self._C_1 = 0
+                self._C_1 = zeros(o, n)
             self._C_2 = (eye(o) - self._Pud *
                     temp.LUsolve(f_v_jac_u)) * self._Pui
         else:
-            self._C_1 = 0
+            self._C_1 = zeros(o, n)
             self._C_2 = eye(o)
 
     def _form_block_matrices(self):


### PR DESCRIPTION
The C_1 matrix is of shape o x n, where o is the number of generalized
speeds and n is the number of generalized coordinates (including any
dependent speeds or dependent coordinates). Using the literal 0 results
in matrix size mismatches on operations involving C_1 in cases where
there are no explicit constraints present (i.e., when m == 0).
