### PR TITLE
factorial of non-integer may be integer

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -165,7 +165,8 @@ class factorial(CombinatorialFunction):
         return C.gamma(n + 1)
 
     def _eval_is_integer(self):
-        return self.args[0].is_integer
+        if self.args[0].is_integer:
+            return True
 
     def _eval_is_positive(self):
         if self.args[0].is_integer and self.args[0].is_positive:

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -84,8 +84,10 @@ def test_ff_eval_apply():
 
 
 def test_factorial():
+    x = Symbol('x')
     n = Symbol('n', integer=True)
     k = Symbol('k', integer=True, positive=True)
+    r = Symbol('r', integer=False)
 
     assert factorial(-2) == zoo
     assert factorial(0) == 1
@@ -93,7 +95,10 @@ def test_factorial():
     assert factorial(n).func == factorial
     assert factorial(2*n).func == factorial
 
+    assert factorial(x).is_integer is None
     assert factorial(n).is_integer
+    assert factorial(r).is_integer is None
+
     assert factorial(n).is_positive is None
     assert factorial(k).is_positive
 


### PR DESCRIPTION
Before this fix, the following code:

``` python
>>> r = Symbol('r', integer=True)
>>> factorial(r).is_integer
```

would have returned `False`. However, a factorial of a non-integer number may indeed be integer, it's just hard to figure out when exactly. For example,

``` python
>>> factorial(2.8523554580317278316429981)
5.00000000000000
```

means that there is a (probably non-rational) number whose image under the factorial function is _exactly_ the integer 5.
