### PR TITLE
#6430 unicode names

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -662,7 +662,7 @@ class adjoint(Function):
         from sympy.printing.pretty.stringpict import prettyForm
         pform = printer._print(self.args[0], *args)
         if printer._use_unicode:
-            pform = pform**prettyForm(u('\u2020'))
+            pform = pform**prettyForm(u('\N{DAGGER}'))
         else:
             pform = pform**prettyForm('+')
         return pform

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -69,8 +69,10 @@ def test_print_builtin_option():
     # Note : In Python 3 the text is unicode, but in 2 it is a string.
     # XXX: How can we make this ignore the terminal width? This test fails if
     # the terminal is too narrow.
-    assert text in ("{pi: 3.14, n_i: 3}", u('{n\N{GREEK SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}'),
-        "{n_i: 3, pi: 3.14}", u('{\N{GREEK SMALL LETTER PI}: 3.14, n\N{GREEK SMALL LETTER I}: 3}'))
+    assert text in ("{pi: 3.14, n_i: 3}",
+                    u('{n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}'),
+                    "{n_i: 3, pi: 3.14}",
+                    u('{\N{GREEK SMALL LETTER PI}: 3.14, n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3}'))
 
     # If we enable the default printing, then the dictionary's should render
     # as a LaTeX version of the whole dict: ${\pi: 3.14, n_i: 3}$
@@ -84,8 +86,10 @@ def test_print_builtin_option():
     else:
         text = app.user_ns['a'][0]['text/plain']
         latex = app.user_ns['a'][0]['text/latex']
-    assert text in ("{pi: 3.14, n_i: 3}", u('{n\N{GREEK SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}'),
-        "{n_i: 3, pi: 3.14}", u('{\N{GREEK SMALL LETTER PI}: 3.14, n\N{GREEK SMALL LETTER I}: 3}'))
+    assert text in ("{pi: 3.14, n_i: 3}",
+                    u('{n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}'),
+                    "{n_i: 3, pi: 3.14}",
+                    u('{\N{GREEK SMALL LETTER PI}: 3.14, n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3}'))
     assert latex == r'$$\left \{ n_{i} : 3, \quad \pi : 3.14\right \}$$'
 
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -42,11 +42,11 @@ def test_ipythonprinting():
     app.run_cell("a2 = format(Symbol('pi')**2)")
     # Deal with API change starting at IPython 1.0
     if int(ipython.__version__.split(".")[0]) < 1:
-        assert app.user_ns['a']['text/plain'] in (u('\u03c0'), 'pi')
-        assert app.user_ns['a2']['text/plain'] in (u(' 2\n\u03c0 '), '  2\npi ')
+        assert app.user_ns['a']['text/plain'] in (u('\N{GREEK SMALL LETTER PI}'), 'pi')
+        assert app.user_ns['a2']['text/plain'] in (u(' 2\n\N{GREEK SMALL LETTER PI} '), '  2\npi ')
     else:
-        assert app.user_ns['a'][0]['text/plain'] in (u('\u03c0'), 'pi')
-        assert app.user_ns['a2'][0]['text/plain'] in (u(' 2\n\u03c0 '), '  2\npi ')
+        assert app.user_ns['a'][0]['text/plain'] in (u('\N{GREEK SMALL LETTER PI}'), 'pi')
+        assert app.user_ns['a2'][0]['text/plain'] in (u(' 2\n\N{GREEK SMALL LETTER PI} '), '  2\npi ')
 
 
 def test_print_builtin_option():
@@ -69,8 +69,8 @@ def test_print_builtin_option():
     # Note : In Python 3 the text is unicode, but in 2 it is a string.
     # XXX: How can we make this ignore the terminal width? This test fails if
     # the terminal is too narrow.
-    assert text in ("{pi: 3.14, n_i: 3}", u('{n\u1d62: 3, \u03c0: 3.14}'),
-        "{n_i: 3, pi: 3.14}", u('{\u03c0: 3.14, n\u1d62: 3}'))
+    assert text in ("{pi: 3.14, n_i: 3}", u('{n\N{GREEK SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}'),
+        "{n_i: 3, pi: 3.14}", u('{\N{GREEK SMALL LETTER PI}: 3.14, n\N{GREEK SMALL LETTER I}: 3}'))
 
     # If we enable the default printing, then the dictionary's should render
     # as a LaTeX version of the whole dict: ${\pi: 3.14, n_i: 3}$
@@ -84,8 +84,8 @@ def test_print_builtin_option():
     else:
         text = app.user_ns['a'][0]['text/plain']
         latex = app.user_ns['a'][0]['text/latex']
-    assert text in ("{pi: 3.14, n_i: 3}", u('{n\u1d62: 3, \u03c0: 3.14}'),
-        "{n_i: 3, pi: 3.14}", u('{\u03c0: 3.14, n\u1d62: 3}'))
+    assert text in ("{pi: 3.14, n_i: 3}", u('{n\N{GREEK SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}'),
+        "{n_i: 3, pi: 3.14}", u('{\N{GREEK SMALL LETTER PI}: 3.14, n\N{GREEK SMALL LETTER I}: 3}'))
     assert latex == r'$$\left \{ n_{i} : 3, \quad \pi : 3.14\right \}$$'
 
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")

--- a/sympy/physics/quantum/boson.py
+++ b/sympy/physics/quantum/boson.py
@@ -123,7 +123,7 @@ class BosonOp(Operator):
         if self.is_annihilation:
             return pform
         else:
-            return pform**prettyForm(u('\u2020'))
+            return pform**prettyForm(u('\N{DAGGER}'))
 
 
 class BosonFockKet(Ket):

--- a/sympy/physics/quantum/constants.py
+++ b/sympy/physics/quantum/constants.py
@@ -51,7 +51,7 @@ class HBar(with_metaclass(Singleton, NumberSymbol)):
 
     def _pretty(self, printer, *args):
         if printer._use_unicode:
-            return prettyForm(u('\u210f'))
+            return prettyForm(u('\N{PLANCK CONSTANT OVER TWO PI}'))
         return prettyForm('hbar')
 
     def _latex(self, printer, *args):

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -202,7 +202,7 @@ class Density(HermitianOperator):
         return printer._print(r'\rho', *args)
 
     def _print_operator_name_pretty(self, printer, *args):
-        return prettyForm(unichr('\u03C1'))
+        return prettyForm(unichr('\N{GREEK SMALL LETTER RHO}'))
 
     def _eval_trace(self, **kwargs):
         indices = kwargs.get('indices', [])

--- a/sympy/physics/quantum/fermion.py
+++ b/sympy/physics/quantum/fermion.py
@@ -109,7 +109,7 @@ class FermionOp(Operator):
         if self.is_annihilation:
             return pform
         else:
-            return pform**prettyForm(u('\u2020'))
+            return pform**prettyForm(u('\N{DAGGER}'))
 
 
 class FermionFockKet(Ket):

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -100,7 +100,7 @@ class HilbertSpace(Basic):
 
     def _pretty(self, printer, *args):
         # u = u('\u2108') # script
-        ustr = u('\u0048')
+        ustr = u('\N{LATIN CAPITAL LETTER H}')
         return prettyForm(ustr)
 
     def _latex(self, printer, *args):
@@ -175,7 +175,7 @@ class ComplexSpace(HilbertSpace):
 
     def _pretty(self, printer, *args):
         # u = u('\u2102') # script
-        ustr = u('\u0043')
+        ustr = u('\N{LATIN CAPITAL LETTER C}')
         pform_exp = printer._print(self.dimension, *args)
         pform_base = prettyForm(ustr)
         return pform_base**pform_exp
@@ -275,7 +275,7 @@ class FockSpace(HilbertSpace):
 
     def _pretty(self, printer, *args):
         # u = u('\u2131') # script
-        ustr = u('\u0046')
+        ustr = u('\N{LATIN CAPITAL LETTER F}')
         return prettyForm(ustr)
 
     def _latex(self, printer, *args):
@@ -420,7 +420,7 @@ class TensorProductHilbertSpace(HilbertSpace):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u(' ') + u('\u2a02') + u(' ')))
+                    pform = prettyForm(*pform.right(u(' ') + u('\N{N-ARY CIRCLED TIMES OPERATOR}') + u(' ')))
                 else:
                     pform = prettyForm(*pform.right(' x '))
         return pform
@@ -531,7 +531,7 @@ class DirectSumHilbertSpace(HilbertSpace):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u(' ') + u('\u2295') + u(' ')))
+                    pform = prettyForm(*pform.right(u(' ') + u('\N{CIRCLED PLUS}') + u(' ')))
                 else:
                     pform = prettyForm(*pform.right(' + '))
         return pform
@@ -642,7 +642,7 @@ class TensorPowerHilbertSpace(HilbertSpace):
     def _pretty(self, printer, *args):
         pform_exp = printer._print(self.exp, *args)
         if printer._use_unicode:
-            pform_exp = prettyForm(*pform_exp.left(prettyForm(u('\u2a02'))))
+            pform_exp = prettyForm(*pform_exp.left(prettyForm(u('\N{N-ARY CIRCLED TIMES OPERATOR}'))))
         else:
             pform_exp = prettyForm(*pform_exp.left(prettyForm('x')))
         pform_base = printer._print(self.base, *args)

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -157,7 +157,7 @@ class RaisingOp(SHOOp):
     def _print_contents_pretty(self, printer, *args):
         from sympy.printing.pretty.stringpict import prettyForm
         pform = printer._print(self.args[0], *args)
-        pform = pform**prettyForm(u('\u2020'))
+        pform = pform**prettyForm(u('\N{DAGGER}'))
         return pform
 
     def _print_contents_latex(self, printer, *args):

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -501,7 +501,7 @@ class Rotation(UnitaryOperator):
 
     def _print_operator_name_pretty(self, printer, *args):
         if printer._use_unicode:
-            return prettyForm(u('\u211B') + u(' '))
+            return prettyForm(u('\N{SCRIPT CAPITAL R}') + u(' '))
         else:
             return prettyForm("R ")
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -34,10 +34,10 @@ _straight_bracket = "|"
 
 # Unicode brackets
 # MATHEMATICAL ANGLE BRACKETS
-_lbracket_ucode = u("\u27E8")
-_rbracket_ucode = u("\u27E9")
+_lbracket_ucode = u("\N{MATHEMATICAL LEFT ANGLE BRACKET}")
+_rbracket_ucode = u("\N{MATHEMATICAL RIGHT ANGLE BRACKET}")
 # LIGHT VERTICAL BAR
-_straight_bracket_ucode = u("\u2758")
+_straight_bracket_ucode = u("\N{LIGHT VERTICAL BAR}")
 
 # Other options for unicode printing of <, > and | for Dirac notation.
 
@@ -133,7 +133,9 @@ class StateBase(QExpr):
         # Setup for unicode vs ascii
         if use_unicode:
             lbracket, rbracket = self.lbracket_ucode, self.rbracket_ucode
-            slash, bslash, vert = u('\u2571'), u('\u2572'), u('\u2502')
+            slash, bslash, vert = u('\N{BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT}'), \
+                                  u('\N{BOX DRAWINGS LIGHT DIAGONAL UPPER LEFT TO LOWER RIGHT}'), \
+                                  u('\N{BOX DRAWINGS LIGHT VERTICAL}')
         else:
             lbracket, rbracket = self.lbracket, self.rbracket
             slash, bslash, vert = '/', '\\', '|'

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -201,7 +201,7 @@ class TensorProduct(Expr):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u('\u2a02') + u(' ')))
+                    pform = prettyForm(*pform.right(u('\N{N-ARY CIRCLED TIMES OPERATOR}') + u(' ')))
                 else:
                     pform = prettyForm(*pform.right('x' + ' '))
         return pform

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -879,5 +879,5 @@ u("""\
 
 def _test_sho1d():
     ad = RaisingOp('a')
-    assert pretty(ad) == u(' \u2020\na ')
+    assert pretty(ad) == u(' \N{DAGGER}\na ')
     assert latex(ad) == 'a^{\\dag}'

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -207,7 +207,7 @@ class Dyadic(object):
                 mpp = printer if printer else VectorPrettyPrinter(settings)
                 if len(ar) == 0:
                     return unicode(0)
-                bar = u("\u2297") if use_unicode else "|"
+                bar = u("\N{CIRCLED TIMES}") if use_unicode else "|"
                 ol = []  # output list, to be concatenated to a string
                 for i, v in enumerate(ar):
                     # if the coef of the dyadic is 1, we skip the 1

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -183,10 +183,10 @@ class VectorPrettyPrinter(PrettyPrinter):
             return super(VectorPrettyPrinter, self)._print_Derivative(deriv)
 
         dots = {0 : u(""),
-                1 : u("\u0307"),
-                2 : u("\u0308"),
-                3 : u("\u20db"),
-                4 : u("\u20dc")}
+                1 : u("\N{COMBINING DOT ABOVE}"),
+                2 : u("\N{COMBINING DIAERESIS}"),
+                3 : u("\N{COMBINING THREE DOTS ABOVE}"),
+                4 : u("\N{COMBINING FOUR DOTS ABOVE}")}
 
         d = pform.__dict__
         pic = d['picture'][0]

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -196,7 +196,7 @@ class MathMLPrinter(Printer):
         """We use unicode #x3c6 for Greek letter phi as defined here
         http://www.w3.org/2003/entities/2007doc/isogrk1.html"""
         x = self.dom.createElement('cn')
-        x.appendChild(self.dom.createTextNode(u("\u03c6")))
+        x.appendChild(self.dom.createTextNode(u("\N{GREEK SMALL LETTER PHI}")))
         return x
 
     def _print_Exp1(self, e):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -146,14 +146,14 @@ class PrettyPrinter(Printer):
             arg = e.args[0]
             pform = self._print(arg)
             if isinstance(arg, Equivalent):
-                return self._print_Equivalent(arg, altchar=u("\u2262"))
+                return self._print_Equivalent(arg, altchar=u("\N{NOT IDENTICAL TO}"))
             if isinstance(arg, Implies):
-                return self._print_Implies(arg, altchar=u("\u219b"))
+                return self._print_Implies(arg, altchar=u("\N{RIGHTWARDS ARROW WITH STROKE}"))
 
             if arg.is_Boolean and not arg.is_Not:
                 pform = prettyForm(*pform.parens())
 
-            return prettyForm(*pform.left(u("\u00ac")))
+            return prettyForm(*pform.left(u("\N{NOT SIGN}")))
         else:
             return self._print_Function(e)
 
@@ -180,43 +180,43 @@ class PrettyPrinter(Printer):
 
     def _print_And(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\u2227"))
+            return self.__print_Boolean(e, u("\N{LOGICAL AND}"))
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Or(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\u2228"))
+            return self.__print_Boolean(e, u("\N{LOGICAL OR}"))
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Xor(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\u22bb"))
+            return self.__print_Boolean(e, u("\N{XOR}"))
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Nand(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\u22bc"))
+            return self.__print_Boolean(e, u("\N{NAND}"))
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Nor(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\u22bd"))
+            return self.__print_Boolean(e, u("\N{NOR}"))
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Implies(self, e, altchar=None):
         if self._use_unicode:
-            return self.__print_Boolean(e, altchar or u("\u2192"), sort=False)
+            return self.__print_Boolean(e, altchar or u("\N{RIGHTWARDS ARROW}"), sort=False)
         else:
             return self._print_Function(e)
 
     def _print_Equivalent(self, e, altchar=None):
         if self._use_unicode:
-            return self.__print_Boolean(e, altchar or u("\u2261"))
+            return self.__print_Boolean(e, altchar or u("\N{IDENTICAL TO}"))
         else:
             return self._print_Function(e, sort=True)
 
@@ -396,7 +396,7 @@ class PrettyPrinter(Printer):
         if self._use_unicode:
             # use unicode corners
             horizontal_chr = xobj('-', 1)
-            corner_chr = u('\u252c')
+            corner_chr = u('\N{BOX DRAWINGS LIGHT DOWN AND HORIZONTAL}')
 
         func_height = pretty_func.height()
 
@@ -551,7 +551,7 @@ class PrettyPrinter(Printer):
 
         LimArg = self._print(z)
         if self._use_unicode:
-            LimArg = prettyForm(*LimArg.right(u('\u2500\u2192')))
+            LimArg = prettyForm(*LimArg.right(u('\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{RIGHTWARDS ARROW}')))
         else:
             LimArg = prettyForm(*LimArg.right('->'))
         LimArg = prettyForm(*LimArg.right(self._print(z0)))
@@ -560,7 +560,7 @@ class PrettyPrinter(Printer):
             dir = ""
         else:
             if self._use_unicode:
-                dir = u('\u207A') if str(dir) == "+" else u('\u207B')
+                dir = u('\N{SUPERSCRIPT PLUS SIGN}') if str(dir) == "+" else u('\N{SUPERSCRIPT MINUS}')
 
         LimArg = prettyForm(*LimArg.right(self._print(dir)))
 
@@ -703,7 +703,7 @@ class PrettyPrinter(Printer):
     def _print_Adjoint(self, expr):
         pform = self._print(expr.arg)
         if self._use_unicode:
-            dag = prettyForm(u('\u2020'))
+            dag = prettyForm(u('\N{DAGGER}'))
         else:
             dag = prettyForm('+')
         from sympy.matrices import MatrixSymbol
@@ -810,8 +810,8 @@ class PrettyPrinter(Printer):
                     if '\n' in partstr:
                         tempstr = partstr
                         tempstr = tempstr.replace(vectstrs[i], '')
-                        tempstr = tempstr.replace(u('\u239e'),
-                                                  u('\u239e')
+                        tempstr = tempstr.replace(u('\N{RIGHT PARENTHESIS UPPER HOOK}'),
+                                                  u('\N{RIGHT PARENTHESIS UPPER HOOK}')
                                                   + ' ' + vectstrs[i])
                         o1[i] = tempstr
                 o1 = [x.split('\n') for x in o1]
@@ -1084,7 +1084,7 @@ class PrettyPrinter(Printer):
     def _print_Lambda(self, e):
         vars, expr = e.args
         if self._use_unicode:
-            arrow = u(" \u21a6 ")
+            arrow = u(" \N{RIGHTWARDS ARROW FROM BAR} ")
         else:
             arrow = " -> "
         if len(vars) == 1:
@@ -1104,7 +1104,7 @@ class PrettyPrinter(Printer):
             elif len(expr.variables):
                 pform = prettyForm(*pform.right(self._print(expr.variables[0])))
             if self._use_unicode:
-                pform = prettyForm(*pform.right(u(" \u2192 ")))
+                pform = prettyForm(*pform.right(u(" \N{RIGHTWARDS ARROW} ")))
             else:
                 pform = prettyForm(*pform.right(" -> "))
             if len(expr.point) > 1:
@@ -1426,7 +1426,7 @@ class PrettyPrinter(Printer):
     def _print_Range(self, s):
 
         if self._use_unicode:
-            dots = u("\u2026")
+            dots = u("\N{HORIZONTAL ELLIPSIS}")
         else:
             dots = '...'
 
@@ -1483,7 +1483,7 @@ class PrettyPrinter(Printer):
 
     def _print_ImageSet(self, ts):
         if self._use_unicode:
-            inn = u("\u220a")
+            inn = u("\N{SMALL ELEMENT OF}")
         else:
             inn = 'in'
         variables = self._print_seq(ts.lamda.variables)
@@ -1496,7 +1496,7 @@ class PrettyPrinter(Printer):
     def _print_Contains(self, e):
         var, set = e.args
         if self._use_unicode:
-            el = u(" \u2208 ")
+            el = u(" \N{ELEMENT OF} ")
             return prettyForm(*stringPict.next(self._print(var),
                                                el, self._print(set)), binding=8)
         else:
@@ -1614,7 +1614,7 @@ class PrettyPrinter(Printer):
 
     def _print_FiniteField(self, expr):
         if self._use_unicode:
-            form = u('\u2124_%d')
+            form = u('\N{DOUBLE-STRUCK CAPITAL Z}_%d')
         else:
             form = 'GF(%d)'
 
@@ -1622,19 +1622,19 @@ class PrettyPrinter(Printer):
 
     def _print_IntegerRing(self, expr):
         if self._use_unicode:
-            return prettyForm(u('\u2124'))
+            return prettyForm(u('\N{DOUBLE-STRUCK CAPITAL Z}'))
         else:
             return prettyForm('ZZ')
 
     def _print_RationalField(self, expr):
         if self._use_unicode:
-            return prettyForm(u('\u211A'))
+            return prettyForm(u('\N{DOUBLE-STRUCK CAPITAL Q}'))
         else:
             return prettyForm('QQ')
 
     def _print_RealField(self, domain):
         if self._use_unicode:
-            prefix = u('\u211D')
+            prefix = u('\N{DOUBLE-STRUCK CAPITAL R}')
         else:
             prefix = 'RR'
 
@@ -1645,7 +1645,7 @@ class PrettyPrinter(Printer):
 
     def _print_ComplexField(self, domain):
         if self._use_unicode:
-            prefix = u('\u2102')
+            prefix = u('\N{DOUBLE-STRUCK CAPITAL C}')
         else:
             prefix = 'CC'
 
@@ -1887,11 +1887,11 @@ class PrettyPrinter(Printer):
         field = diff._form_field
         if hasattr(field, '_coord_sys'):
             string = field._coord_sys._names[field._index]
-            return self._print(u('\u2146 ') + pretty_symbol(string))
+            return self._print(u('\N{DOUBLE-STRUCK ITALIC SMALL D} ') + pretty_symbol(string))
         else:
             pform = self._print(field)
             pform = prettyForm(*pform.parens())
-            return prettyForm(*pform.left(u("\u2146")))
+            return prettyForm(*pform.left(u("\N{DOUBLE-STRUCK ITALIC SMALL D}")))
 
     def _print_Tr(self, p):
         #TODO: Handle indices

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -118,7 +118,7 @@ greek_unicode.update((L[0].upper() + L[1:], G(L)) for L in greek_letters)
 # aliases
 greek_unicode['lambda'] = greek_unicode['lamda']
 greek_unicode['Lambda'] = greek_unicode['Lamda']
-greek_unicode['varsigma'] = u('\u03c2')
+greek_unicode['varsigma'] = u('\N{GREEK SMALL LETTER FINAL SIGMA}')
 
 digit_2txt = {
     '0':    'ZERO',
@@ -186,21 +186,21 @@ for s in '+-=()':
 # TODO: Make brackets adjust to height of contents
 modifier_dict = {
     # Accents
-    'mathring': lambda s: s+u('\u030A'),
-    'ddddot': lambda s: s+u('\u0308\u0308'),
-    'dddot': lambda s: s+u('\u0308\u0307'),
-    'ddot': lambda s: s+u('\u0308'),
-    'dot': lambda s: s+u('\u0307'),
-    'check': lambda s: s+u('\u030C'),
-    'breve': lambda s: s+u('\u0306'),
-    'acute': lambda s: s+u('\u0301'),
-    'grave': lambda s: s+u('\u0300'),
-    'tilde': lambda s: s+u('\u0303'),
-    'hat': lambda s: s+u('\u0302'),
-    'bar': lambda s: s+u('\u0305'),
-    'vec': lambda s: s+u('\u20D7'),
-    'prime': lambda s: s+u(' \u030D'),
-    'prm': lambda s: s+u(' \u030D'),
+    'mathring': lambda s: s+u('\N{COMBINING RING ABOVE}'),
+    'ddddot': lambda s: s+u('\N{COMBINING DIAERESIS}\N{COMBINING DIAERESIS}'),
+    'dddot': lambda s: s+u('\N{COMBINING DIAERESIS}\N{COMBINING DOT ABOVE}'),
+    'ddot': lambda s: s+u('\N{COMBINING DIAERESIS}'),
+    'dot': lambda s: s+u('\N{COMBINING DOT ABOVE}'),
+    'check': lambda s: s+u('\N{COMBINING CARON}'),
+    'breve': lambda s: s+u('\N{COMBINING BREVE}'),
+    'acute': lambda s: s+u('\N{COMBINING ACUTE ACCENT}'),
+    'grave': lambda s: s+u('\N{COMBINING GRAVE ACCENT}'),
+    'tilde': lambda s: s+u('\N{COMBINING TILDE}'),
+    'hat': lambda s: s+u('\N{COMBINING CIRCUMFLEX ACCENT}'),
+    'bar': lambda s: s+u('\N{COMBINING OVERLINE}'),
+    'vec': lambda s: s+u('\N{COMBINING RIGHT ARROW ABOVE}'),
+    'prime': lambda s: s+u(' \N{COMBINING VERTICAL LINE ABOVE}'),
+    'prm': lambda s: s+u(' \N{COMBINING VERTICAL LINE ABOVE}'),
     # # Faces -- these are here for some compatibility with latex printing
     # 'bold': lambda s: s,
     # 'bm': lambda s: s,
@@ -208,10 +208,10 @@ modifier_dict = {
     # 'scr': lambda s: s,
     # 'frak': lambda s: s,
     # Brackets
-    'norm': lambda s: u('\u2016')+s+u('\u2016'),
-    'avg': lambda s: u('\u27E8')+s+u('\u27E9'),
-    'abs': lambda s: u('\u007C')+s+u('\u007C'),
-    'mag': lambda s: u('\u007C')+s+u('\u007C'),
+    'norm': lambda s: u('\N{DOUBLE VERTICAL LINE}')+s+u('\N{DOUBLE VERTICAL LINE}'),
+    'avg': lambda s: u('\N{MATHEMATICAL LEFT ANGLE BRACKET}')+s+u('\N{MATHEMATICAL RIGHT ANGLE BRACKET}'),
+    'abs': lambda s: u('\N{VERTICAL LINE}')+s+u('\N{VERTICAL LINE}'),
+    'mag': lambda s: u('\N{VERTICAL LINE}')+s+u('\N{VERTICAL LINE}'),
 }
 
 # VERTICAL OBJECTS
@@ -544,9 +544,13 @@ def annotated(letter):
     information.
     """
     ucode_pics = {
-        'F': (2, 0, 2, 0, u('\u250c\u2500\n\u251c\u2500\n\u2575')),
+        'F': (2, 0, 2, 0, u('\N{BOX DRAWINGS LIGHT DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
+                            '\N{BOX DRAWINGS LIGHT VERTICAL AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
+                            '\N{BOX DRAWINGS LIGHT UP}')),
         'G': (3, 0, 3, 1,
-              u('\u256d\u2500\u256e\n\u2502\u2576\u2510\n\u2570\u2500\u256f'))
+              u('\N{BOX DRAWINGS LIGHT ARC DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC DOWN AND LEFT}\n'
+                '\N{BOX DRAWINGS LIGHT VERTICAL}\N{BOX DRAWINGS LIGHT RIGHT}\N{BOX DRAWINGS LIGHT DOWN AND LEFT}\n'
+                '\N{BOX DRAWINGS LIGHT ARC UP AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC UP AND LEFT}'))
     }
     ascii_pics = {
         'F': (3, 0, 3, 0, ' _\n|_\n|\n'),

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -333,7 +333,7 @@ def test_symbol():
 def test_mathml_greek():
     mml = mp._print(Symbol('alpha'))
     assert mml.nodeName == 'ci'
-    assert mml.childNodes[0].nodeValue == u('\u03b1')
+    assert mml.childNodes[0].nodeValue == u('\N{GREEK SMALL LETTER ALPHA}')
 
     assert mp.doprint(Symbol('alpha')) == '<ci>&#945;</ci>'
     assert mp.doprint(Symbol('beta')) == '<ci>&#946;</ci>'

--- a/sympy/utilities/timeutils.py
+++ b/sympy/utilities/timeutils.py
@@ -8,7 +8,7 @@ import math
 from sympy.core.compatibility import u
 
 _scales = [1e0, 1e3, 1e6, 1e9]
-_units = [u('s'), u('ms'), u('\u03bcs'), u('ns')]
+_units = [u('s'), u('ms'), u('\N{GREEK SMALL LETTER MU}s'), u('ns')]
 
 
 def timed(func, setup="pass", limit=None):


### PR DESCRIPTION
This merge simply replaces hex encoded unicode characters with named unicode characters for clarity.  It does not change any logic or functionality.  Names were obtained by checking them against unicodedata.name() so all replacements are functionally equivalent.  Any notations in comments were not changed.  Changes also limited to python files and tests within sympy/.  

Example:

``` python
>>> import unicodedata
>>> print unicodedata.name(u'\u03c0')
GREEK SMALL LETTER PI
>>> u'\N{GREEK SMALL LETTER PI}'
u'\u03c0'
>>> u'\N{GREEK SMALL LETTER PI}' == u'\u03c0'
True
>>> u'\N{GREEK SMALL LETTER PI}' == u'\u03c1'
False
```
