### PR TITLE
POC: Fix "flip" of arguments in relational expressions

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -25,7 +25,7 @@ def _process_limits(*symbols):
     limits = []
     orientation = 1
     for V in symbols:
-        if isinstance(V, Symbol):
+        if isinstance(V, (Symbol, Dummy)):
             limits.append(Tuple(V))
             continue
         elif is_sequence(V, Tuple):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -545,7 +545,7 @@ class Basic(with_metaclass(ManagedProperties)):
                     return cls != Basic
 
         if callable(expr_to_call) and the_call_method_is_overridden(expr_to_call):
-            if isinstance(expr_to_call, C.Symbol):  # XXX When you call a Symbol it is
+            if isinstance(expr_to_call, (C.Symbol, C.Dummy)):  # XXX When you call a Symbol it is
                 return expr_to_call               # transformed into an UndefFunction
             else:
                 return expr_to_call(*on_args)

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -17,7 +17,7 @@ import string
 import re as _re
 
 
-class Symbol(AtomicExpr, Boolean):
+class BaseSymbol(AtomicExpr, Boolean):
     """
     Assumptions:
        commutative = True
@@ -99,7 +99,7 @@ class Symbol(AtomicExpr, Boolean):
 
         """
         cls._sanitize(assumptions, cls)
-        return Symbol.__xnew_cached_(cls, name, **assumptions)
+        return BaseSymbol.__xnew_cached_(cls, name, **assumptions)
 
     def __new_stage2__(cls, name, **assumptions):
         if not isinstance(name, string_types):
@@ -161,7 +161,11 @@ class Symbol(AtomicExpr, Boolean):
         return set([self])
 
 
-class Dummy(Symbol):
+class Symbol(BaseSymbol):
+    pass
+
+
+class Dummy(BaseSymbol):
     """Dummy symbols are each unique, identified by an internal count index:
 
     >>> from sympy import Dummy
@@ -203,10 +207,10 @@ class Dummy(Symbol):
             2, (str(self), self.dummy_index)), S.One.sort_key(), S.One
 
     def _hashable_content(self):
-        return Symbol._hashable_content(self) + (self.dummy_index,)
+        return BaseSymbol._hashable_content(self) + (self.dummy_index,)
 
 
-class Wild(Symbol):
+class Wild(BaseSymbol):
     """
     A Wild symbol matches anything, or anything
     without whatever is explicitly excluded.
@@ -290,7 +294,7 @@ class Wild(Symbol):
     @staticmethod
     @cacheit
     def __xnew__(cls, name, exclude, properties, **assumptions):
-        obj = Symbol.__xnew__(cls, name, **assumptions)
+        obj = BaseSymbol.__xnew__(cls, name, **assumptions)
         obj.exclude = exclude
         obj.properties = properties
         return obj

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -899,6 +899,12 @@ def test_sympy__stats__drv_types__GeometricDistribution():
     from sympy.stats.drv_types import GeometricDistribution
     assert _test_args(GeometricDistribution(.5))
 
+
+@SKIP("abstract class")
+def test_sympy__core__symbol__BaseSymbol():
+    pass
+
+
 def test_sympy__core__symbol__Dummy():
     from sympy.core.symbol import Dummy
     assert _test_args(Dummy('t'))

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,6 +1,6 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
-                   Implies, Xor, zoo, sqrt, Rational, simplify, Function)
+                   Implies, Xor, zoo, sqrt, Rational, simplify, Function, Wild)
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
@@ -629,3 +629,9 @@ def test_issue_8444():
     i = symbols('i', integer=True)
     assert (i > floor(i)) == False
     assert (i < ceiling(i)) == False
+
+
+def test_issue_7951():
+    p = Wild('p')
+    x = Symbol('x')
+    assert str(x < p) == 'x < p_'

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -57,7 +57,7 @@ def idiff(eq, y, x, n=1):
     if is_sequence(y):
         dep = set(y)
         y = y[0]
-    elif isinstance(y, Symbol):
+    elif isinstance(y, (Symbol, Dummy)):
         dep = set([y])
     else:
         raise ValueError("expecting x-dependent symbol(s) but got: %s" % y)
@@ -111,7 +111,7 @@ def _symbol(s, matching_symbol=None):
         if matching_symbol and matching_symbol.name == s:
             return matching_symbol
         return Symbol(s, real=True)
-    elif isinstance(s, Symbol):
+    elif isinstance(s, (Symbol, Dummy)):
         return s
     else:
         raise ValueError('symbol must be string for symbol name or Symbol')

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -227,11 +227,11 @@ def power_rule(integral):
     integrand, symbol = integral
     base, exp = integrand.as_base_exp()
 
-    if symbol not in exp.free_symbols and isinstance(base, sympy.Symbol):
+    if symbol not in exp.free_symbols and isinstance(base, (sympy.Symbol, sympy.Dummy)):
         if sympy.simplify(exp + 1) == 0:
             return ReciprocalRule(base, integrand, symbol)
         return PowerRule(base, exp, integrand, symbol)
-    elif symbol not in base.free_symbols and isinstance(exp, sympy.Symbol):
+    elif symbol not in base.free_symbols and isinstance(exp, (sympy.Symbol, sympy.Dummy)):
         rule = ExpRule(base, exp, integrand, symbol)
 
         if sympy.log(base).is_nonzero:
@@ -246,7 +246,7 @@ def power_rule(integral):
 
 def exp_rule(integral):
     integrand, symbol = integral
-    if isinstance(integrand.args[0], sympy.Symbol):
+    if isinstance(integrand.args[0], (sympy.Symbol, sympy.Dummy)):
         return ExpRule(sympy.E, integrand.args[0], integrand, symbol)
 
 def inverse_trig_rule(integral):
@@ -454,7 +454,7 @@ def trig_rule(integral):
     if isinstance(integrand, sympy.sin) or isinstance(integrand, sympy.cos):
         arg = integrand.args[0]
 
-        if not isinstance(arg, sympy.Symbol):
+        if not isinstance(arg, (sympy.Symbol, sympy.Dummy)):
             return  # perhaps a substitution can deal with it
 
         if isinstance(integrand, sympy.sin):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -61,10 +61,10 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*pform.left('atan2'))
         return pform
 
-    def _print_Symbol(self, e):
+    def _print_BaseSymbol(self, e):
         symb = pretty_symbol(e.name)
         return prettyForm(symb)
-    _print_RandomSymbol = _print_Symbol
+    _print_RandomSymbol = _print_BaseSymbol
 
     def _print_Float(self, e):
         # we will use StrPrinter's Float printer, but we need to handle the
@@ -749,7 +749,7 @@ class PrettyPrinter(Printer):
         return self._print_seq(expr.args, None, None, delim,
                 parenthesize=lambda x: isinstance(x, (MatAdd, MatMul)))
 
-    _print_MatrixSymbol = _print_Symbol
+    _print_MatrixSymbol = _print_BaseSymbol
 
     def _print_FunctionMatrix(self, X):
         D = self._print(X.lamda.expr)

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -632,7 +632,7 @@ def gruntz(e, z, z0, dir="+"):
     file. It relies heavily on the series expansion. Most frequently, gruntz()
     is only used if the faster limit() function (which uses heuristics) fails.
     """
-    if not isinstance(z, Symbol):
+    if not isinstance(z, (Dummy, Symbol)):
         raise NotImplementedError("Second argument must be a Symbol")
 
     #convert all limits to the limit z->oo; sign of z is handled in limitinf

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -147,7 +147,7 @@ class Order(Expr):
                 variables = list(map(sympify, args))
                 point = [S.Zero]*len(variables)
 
-        if not all(isinstance(v, Symbol) for v in variables):
+        if not all(isinstance(v, (Dummy, Symbol)) for v in variables):
             raise TypeError('Variables are not symbols, got %s' % variables)
 
         if len(list(uniq(variables))) != len(variables):


### PR DESCRIPTION
Closes #7951

I'm not sure if that's a good way to go, but it seems to be working...  Is there any more similar problems for other classes?

Any better suggestions?
