### PR TITLE
Substitution in order should take care of NegativeInfinity

### DIFF
--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -179,7 +179,7 @@ class Order(Expr):
         if variables:
             if any(p != point[0] for p in point):
                 raise NotImplementedError
-            if point[0] is S.Infinity:
+            if point[0] in [S.Infinity, S.NegativeInfinity]:
                 s = dict([(k, 1/Dummy()) for k in variables])
                 rs = dict([(1/v, 1/k) for k, v in s.items()])
             elif point[0] is not S.Zero:

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -334,6 +334,10 @@ def test_issue_6753():
     assert (1 + x**2)**10000*O(x) == O(x)
 
 
+def test_issue_7872():
+    assert Order(x**3).subs(x, exp(-x**2)) == O(exp(-3*x**2), (x, -oo))
+
+
 def test_order_at_infinity():
     assert Order(1 + x, (x, oo)) == Order(x, (x, oo))
     assert Order(3*x, (x, oo)) == Order(x, (x, oo))


### PR DESCRIPTION
Fixes #7872 

The following substiution now works:

```
In [1]: O(x**3).subs(x, exp(-x**2))
Out[1]: 
 ⎛     2        ⎞
 ⎜ -3⋅x         ⎟
O⎝ℯ     ; x → -∞⎠
```
