### PR TITLE
add _sage_() method to many Functions; fixes part of #3444

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -172,6 +172,9 @@ class factorial(CombinatorialFunction):
         if self.args[0].is_integer and self.args[0].is_nonnegative:
             return True
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.factorial(self.args[0]._sage_())
 
 class MultiFactorial(CombinatorialFunction):
     pass
@@ -602,3 +605,7 @@ class binomial(CombinatorialFunction):
 
     def _eval_is_integer(self):
         return self.args[0].is_integer and self.args[1].is_integer
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.binomial(self.args[0]._sage_(), self.args[1]._sage_())

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -564,6 +564,10 @@ class arg(Function):
         x, y = re(self.args[0]), im(self.args[0])
         return atan2(y, x)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.arg(self.args[0]._sage_())
+
 class conjugate(Function):
     """
     Changes the sign of the imaginary part of a complex number.
@@ -606,6 +610,9 @@ class conjugate(Function):
     def _eval_transpose(self):
         return adjoint(self.args[0])
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.conjugate(self.args[0]._sage_())
 
 class transpose(Function):
     """

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -820,5 +820,12 @@ class LambertW(Function):
         else:
             return s.is_algebraic
 
+    def _sage_(self):
+        import sage.all as sage
+        if len(self.args) == 1:
+            return sage.lambert_w(self.args[0]._sage_())
+        else:
+            return sage.lambert_w(self.args[0]._sage_(), self.args[1]._sage_())
+
 
 from sympy.core.function import _coeff_isneg

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -140,6 +140,9 @@ class floor(RoundFunction):
             return S.false
         return Gt(self, other, evaluate=False)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.floor(self.args[0]._sage_())
 
 class ceiling(RoundFunction):
     """
@@ -203,3 +206,7 @@ class ceiling(RoundFunction):
         if self.args[0] == other and other.is_real:
             return S.true
         return Ge(self, other, evaluate=False)
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.ceil(self.args[0]._sage_())

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -195,6 +195,10 @@ class besselj(BesselBase):
         if nu.is_integer and z.is_real:
             return True
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.bessel_J(self.args[0]._sage_(), self.args[1]._sage_())
+
 
 class bessely(BesselBase):
     r"""
@@ -269,6 +273,10 @@ class bessely(BesselBase):
         nu, z = self.args
         if nu.is_integer and z.is_positive:
             return True
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.bessel_Y(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 class besseli(BesselBase):
@@ -366,6 +374,10 @@ class besseli(BesselBase):
         if nu.is_integer and z.is_real:
             return True
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.bessel_I(self.args[0]._sage_(), self.args[1]._sage_())
+
 
 class besselk(BesselBase):
     r"""
@@ -445,6 +457,10 @@ class besselk(BesselBase):
         nu, z = self.args
         if nu.is_integer and z.is_positive:
             return True
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.bessel_K(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 class hankel1(BesselBase):

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -109,3 +109,7 @@ class beta(Function):
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate(), self.args[1].conjugate())
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.beta(self.args[0]._sage_(), self.args[1]._sage_())

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -162,6 +162,10 @@ class DiracDelta(Function):
     def _latex_no_arg(printer):
         return r'\delta'
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.dirac_delta(self.args[0]._sage_())
+
 
 ###############################################################################
 ############################## HEAVISIDE FUNCTION #############################
@@ -244,3 +248,7 @@ class Heaviside(Function):
     def _eval_rewrite_as_sign(self, arg):
         if arg.is_real:
             return (sign(arg)+1)/2
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.heaviside(self.args[0]._sage_())

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -80,6 +80,10 @@ class elliptic_k(Function):
     def _eval_rewrite_as_meijerg(self, z):
         return meijerg(((S.Half, S.Half), []), ((S.Zero,), (S.Zero,)), -z)/2
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.elliptic_kc(self.args[0]._sage_())
+
 
 class elliptic_f(Function):
     r"""
@@ -142,6 +146,10 @@ class elliptic_f(Function):
         z, m = self.args
         if (m.is_real and (m - 1).is_positive) is False:
             return self.func(z.conjugate(), m.conjugate())
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.elliptic_f(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 class elliptic_e(Function):
@@ -248,6 +256,10 @@ class elliptic_e(Function):
             z = args[0]
             return -meijerg(((S.Half, S(3)/2), []), \
                             ((S.Zero,), (S.Zero,)), -z)/4
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.elliptic_e(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 class elliptic_pi(Function):
@@ -358,3 +370,9 @@ class elliptic_pi(Function):
             elif argindex == 2:
                 return (elliptic_e(m)/(m - 1) + elliptic_pi(n, m))/(2*(n - m))
         raise ArgumentIndexError(self, argindex)
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.elliptic_pi(self.args[0]._sage_(),
+                                self.args[1]._sage_(),
+                                self.args[2]._sage_())

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -209,6 +209,10 @@ class erf(Function):
                     self.func(x + x*sqrt(sq)))
         return (re, im)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.erf(self.args[0]._sage_())
+
 class erfc(Function):
     r"""
     Complementary Error Function. The function is defined as:
@@ -1092,6 +1096,9 @@ class Ei(Function):
             return f._eval_nseries(x, n, logx)
         return super(Ei, self)._eval_nseries(x, n, logx)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.Ei(self.args[0]._sage_())
 
 class expint(Function):
     r"""
@@ -1266,6 +1273,10 @@ class expint(Function):
                 return f._eval_nseries(x, n, logx)
         return super(expint, self)._eval_nseries(x, n, logx)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.exp_integral_e(self.args[0]._sage_(), self.args[1]._sage_())
+
 
 def E1(z):
     """
@@ -1433,6 +1444,10 @@ class li(Function):
     def _eval_rewrite_as_tractable(self, z):
         return z * _eis(C.log(z))
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.li(self.args[0]._sage_())
+
 
 class Li(Function):
     r"""
@@ -1517,6 +1532,10 @@ class Li(Function):
 
     def _eval_rewrite_as_tractable(self, z):
         return self.rewrite(li).rewrite("tractable", deep=True)
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.Li(self.args[0]._sage_())
 
 ###############################################################################
 #################### TRIGONOMETRIC INTEGRALS ##################################
@@ -1661,6 +1680,9 @@ class Si(TrigonometricIntegral):
         # XXX should we polarify z?
         return pi/2 + (E1(polar_lift(I)*z) - E1(polar_lift(-I)*z))/2/I
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.sin_integral(self.args[0]._sage_())
 
 class Ci(TrigonometricIntegral):
     r"""
@@ -1754,6 +1776,10 @@ class Ci(TrigonometricIntegral):
     def _eval_rewrite_as_expint(self, z):
         return -(E1(polar_lift(I)*z) + E1(polar_lift(-I)*z))/2
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.cos_integral(self.args[0]._sage_())
+
 
 class Shi(TrigonometricIntegral):
     r"""
@@ -1832,6 +1858,10 @@ class Shi(TrigonometricIntegral):
         from sympy import exp_polar
         # XXX should we polarify z?
         return (E1(z) - E1(exp_polar(I*pi)*z))/2 - I*pi/2
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.sinh_integral(self.args[0]._sage_())
 
 
 class Chi(TrigonometricIntegral):
@@ -1935,6 +1965,11 @@ class Chi(TrigonometricIntegral):
     @staticmethod
     def _latex_no_arg(printer):
         return r'\operatorname{Chi}'
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.cosh_integral(self.args[0]._sage_())
+
 
 ###############################################################################
 #################### FRESNEL INTEGRALS ########################################

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -182,6 +182,10 @@ class gamma(Function):
     def _latex_no_arg(printer):
         return r'\Gamma'
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.gamma(self.args[0]._sage_())
+
 
 ###############################################################################
 ################## LOWER and UPPER INCOMPLETE GAMMA FUNCTIONS #################
@@ -916,6 +920,10 @@ class loggamma(Function):
             return polygamma(0, self.args[0])
         else:
             raise ArgumentIndexError(self, argindex)
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.log_gamma(self.args[0]._sage_())
 
 
 def digamma(x):

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -229,6 +229,13 @@ class Ynm(Function):
             res = mp.spherharm(n, m, theta, phi)
         return Expr._from_mpmath(res, prec)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.spherical_harmonic(self.args[0]._sage_(),
+                                       self.args[1]._sage_(),
+                                       self.args[2]._sage_(),
+                                       self.args[3]._sage_())
+
 
 def Ynm_c(n, m, theta, phi):
     r"""Conjugate spherical harmonics defined as

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -444,3 +444,7 @@ class KroneckerDelta(Function):
     @staticmethod
     def _latex_no_arg(printer):
         return r'\delta'
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.kronecker_delta(self.args[0]._sage_(), self.args[1]._sage_())

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -297,6 +297,10 @@ class polylog(Function):
             return expand_mul(start).subs(u, z)
         return polylog(s, z)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.polylog(self.args[0]._sage_(), self.args[1]._sage_())
+
 ###############################################################################
 ###################### HURWITZ GENERALIZED ZETA FUNCTION ######################
 ###############################################################################
@@ -469,6 +473,14 @@ class zeta(Function):
             return -s*zeta(s + 1, a)
         else:
             raise ArgumentIndexError
+
+    def _sage_(self):
+        import sage.all as sage
+        if len(self.args) == 2:
+            s, a = self.args
+        else:
+            s, a = self.args + (1,)
+        return sage.zeta(s._sage_(), a._sage_())
 
 
 class dirichlet_eta(Function):


### PR DESCRIPTION
This adds `_sage_` methods to those symbolic functions where it's a trivial three-liner. Important missing "functions" needing this are `diff`, `integral`, and `hyper`; they should come in a later commit. Part of #3444
