### PR TITLE
Fix plot piecewise function

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1086,6 +1086,10 @@ def centers_of_faces(array):
 def flat(x, y, z, eps=1e-3):
     """Checks whether three points are almost collinear"""
     np = import_module('numpy')
+    # Workaround plotting piecewise (#8577):
+    #   workaround for `lambdify` in `.experimental_lambdify` fails
+    #   to return numerical values in some cases. Lower-level fix
+    #   in `lambdify` is possible.
     vector_a = (x - y).astype(np.float)
     vector_b = (z - y).astype(np.float)
     dot_product = np.dot(vector_a, vector_b)

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1086,8 +1086,8 @@ def centers_of_faces(array):
 def flat(x, y, z, eps=1e-3):
     """Checks whether three points are almost collinear"""
     np = import_module('numpy')
-    vector_a = x - y
-    vector_b = z - y
+    vector_a = (x - y).astype(np.float)
+    vector_b = (z - y).astype(np.float)
     dot_product = np.dot(vector_a, vector_b)
     vector_a_norm = np.linalg.norm(vector_a)
     vector_b_norm = np.linalg.norm(vector_b)

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -91,7 +91,7 @@ def plot_and_save(name):
 
     p = plot(Piecewise((1, x > 0), (0, True)),(x,-1,1))
     p.save(tmp_file('%s_plot_piecewise' % name))
-    
+
     #parametric 2d plots.
     #Single plot with default range.
     plot_parametric(sin(x), cos(x)).save(tmp_file())

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -1,5 +1,5 @@
 from sympy import (pi, sin, cos, Symbol, Integral, summation, sqrt, log,
-                   oo, LambertW, I, meijerg, exp_polar, Max)
+                   oo, LambertW, I, meijerg, exp_polar, Max, Piecewise)
 from sympy.plotting import (plot, plot_parametric, plot3d_parametric_line,
                             plot3d, plot3d_parametric_surface)
 from sympy.plotting.plot import unset_show
@@ -89,6 +89,9 @@ def plot_and_save(name):
 
     raises(ValueError, lambda: plot(x, y))
 
+    p = plot(Piecewise((1, x > 0), (0, True)),(x,-1,1))
+    p.save(tmp_file('%s_plot_piecewise' % name))
+    
     #parametric 2d plots.
     #Single plot with default range.
     plot_parametric(sin(x), cos(x)).save(tmp_file())


### PR DESCRIPTION
flat function in `plot.py` does not convert the vector to float type, thus numpy return AttributeError: sqrt.

Convert the vector explicitly to np.float will fix this bug.
