### PR TITLE
provide Function._sage_; remove superfluous _sage_ methods; add more of them; fixes #3444

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1307,7 +1307,7 @@ class Derivative(Expr):
 
     def _eval_as_leading_term(self, x):
         return self.args[0].as_leading_term(x)
-    
+
     def _sage_(self):
         import sage.all as sage
         args = [arg._sage_() for arg in self.args]

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -673,6 +673,13 @@ class Function(Application, Expr):
         else:
             return self.func(*args)
 
+    def _sage_(self):
+        import sage.all as sage
+        fname = self.func.__name__
+        func = getattr(sage, fname)
+        args = [arg._sage_() for arg in self.args]
+        return func(*args)
+
 
 class AppliedUndef(Function):
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1307,6 +1307,11 @@ class Derivative(Expr):
 
     def _eval_as_leading_term(self, x):
         return self.args[0].as_leading_term(x)
+    
+    def _sage_(self):
+        import sage.all as sage
+        args = [arg._sage_() for arg in self.args]
+        return sage.derivative(*args)
 
 
 class Lambda(Expr):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -695,6 +695,12 @@ class AppliedUndef(Function):
     def _eval_as_leading_term(self, x):
         return self
 
+    def _sage_(self):
+        import sage.all as sage
+        fname = str(self.func)
+        args = [arg._sage_() for arg in self.args]
+        func = sage.function(fname, *args)
+        return func
 
 class UndefinedFunction(FunctionClass):
     """

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2857,7 +2857,7 @@ class ComplexInfinity(with_metaclass(Singleton, AtomicExpr)):
                     return S.ComplexInfinity
                 else:
                     return S.Zero
-    
+
     def _sage_(self):
         import sage.all as sage
         return sage.UnsignedInfinityRing.gen()

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2857,6 +2857,11 @@ class ComplexInfinity(with_metaclass(Singleton, AtomicExpr)):
                     return S.ComplexInfinity
                 else:
                     return S.Zero
+    
+    def _sage_(self):
+        import sage.all as sage
+        return sage.UnsignedInfinityRing.gen()
+
 
 zoo = S.ComplexInfinity
 

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -36,7 +36,9 @@ from sympy.utilities.pytest import XFAIL
 
 
 def check_expression(expr, var_symbols):
-    """Does eval(expr) both in Sage and SymPy and does other checks."""
+    """
+    Does eval(expr) both in Sage and SymPy and does other checks.
+    """
 
     # evaluate the expression in the context of Sage:
     if var_symbols:
@@ -169,7 +171,7 @@ def test_functions():
     check_expression("abs(x)", "x")
     check_expression("arg(x)", "x")
     check_expression("conjugate(x)", "x")
-    
+
     # The following tests differently named functions
     check_expression("besselj(y, x)", "x, y")
     check_expression("bessely(y, x)", "x, y")
@@ -186,11 +188,13 @@ def test_functions():
     check_expression("Ynm(n,m,x,y)", "n, m, x, y")
     check_expression("hyper((n,m),(m,n),x)", "n, m, x")
 
+@XFAIL
+def check_expression_failing():
     #missing bindings in Sage (ticket 17475 opened)
-    #check_expression("Heaviside(x)", "x")
-    #check_expression("elliptic_k(x)", "x")
-    #check_expression("rising_factorial(x,y)", "x,y")
-    #check_expression("falling_factorial(x,y)", "x,y")
+    check_expression("Heaviside(x)", "x")
+    check_expression("elliptic_k(x)", "x")
+    check_expression("rising_factorial(x,y)", "x,y")
+    check_expression("falling_factorial(x,y)", "x,y")
 
 def test_issue_4023():
     sage.var("a x")
@@ -199,6 +203,11 @@ def test_issue_4023():
     i2 = sympy.simplify(i)
     s = sage.SR(i2)
     assert s == (a*log(1 + a) - a*log(a) + log(1 + a) - 1)/a
+
+def test_integral():
+#    In [18]: sympy.sympify(sage.integral(x*y,x,hold=True))
+#Out[18]: Integral(x*y, x)
+
 
 # This string contains Sage doctests, that execute all the functions above.
 # When you add a new function, please add it here as well.

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -43,7 +43,6 @@ def check_expression(expr, var_symbols):
         sage.var(var_symbols)
     a = globals().copy()
     # safety checks...
-    assert not "sin" in a
     a.update(sage.__dict__)
     assert "sin" in a
     e_sage = eval(expr, a)
@@ -53,7 +52,6 @@ def check_expression(expr, var_symbols):
     if var_symbols:
         sympy.var(var_symbols)
     b = globals().copy()
-    assert not "sin" in b
     b.update(sympy.__dict__)
     assert "sin" in b
     b.update(sympy.__dict__)

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -183,8 +183,9 @@ def test_functions():
     check_expression("Chi(x)", "x")
     check_expression("loggamma(x)", "x")
     check_expression("Ynm(n,m,x,y)", "n, m, x, y")
+    check_expression("hyper((n,m),(m,n),x)", "n, m, x")
 
-    #missing bindings in Sage
+    #missing bindings in Sage (ticket 17475 opened)
     #check_expression("Heaviside(x)", "x")
     #check_expression("elliptic_k(x)", "x")
 

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -176,8 +176,6 @@ def test_functions():
     check_expression("besselk(y, x)", "x, y")
     check_expression("DiracDelta(x)", "x")
     check_expression("KroneckerDelta(x, y)", "x, y")
-    check_expression("Heaviside(x)", "x")
-    check_expression("elliptic_k(x)", "x")
     check_expression("expint(y, x)", "x, y")
     check_expression("Si(x)", "x")
     check_expression("Ci(x)", "x")
@@ -186,6 +184,9 @@ def test_functions():
     check_expression("loggamma(x)", "x")
     check_expression("Ynm(n,m,x,y)", "n, m, x, y")
 
+    #missing bindings in Sage
+    #check_expression("Heaviside(x)", "x")
+    #check_expression("elliptic_k(x)", "x")
 
 def test_issue_4023():
     sage.var("a x")

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -189,6 +189,8 @@ def test_functions():
     #missing bindings in Sage (ticket 17475 opened)
     #check_expression("Heaviside(x)", "x")
     #check_expression("elliptic_k(x)", "x")
+    #check_expression("rising_factorial(x,y)", "x,y")
+    #check_expression("falling_factorial(x,y)", "x,y")
 
 def test_issue_4023():
     sage.var("a x")

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -168,6 +168,23 @@ def test_functions():
     check_expression("abs(x)", "x")
     check_expression("arg(x)", "x")
     check_expression("conjugate(x)", "x")
+    
+    # The following tests differently named functions
+    check_expression("besselj(y, x)", "x, y")
+    check_expression("bessely(y, x)", "x, y")
+    check_expression("besseli(y, x)", "x, y")
+    check_expression("besselk(y, x)", "x, y")
+    check_expression("DiracDelta(x)", "x")
+    check_expression("KroneckerDelta(x, y)", "x, y")
+    check_expression("Heaviside(x)", "x")
+    check_expression("elliptic_k(x)", "x")
+    check_expression("expint(y, x)", "x, y")
+    check_expression("Si(x)", "x")
+    check_expression("Ci(x)", "x")
+    check_expression("Shi(x)", "x")
+    check_expression("Chi(x)", "x")
+    check_expression("loggamma(x)", "x")
+    check_expression("Ynm(n,m,x,y)", "n, m, x, y")
 
 
 def test_issue_4023():

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -218,6 +218,14 @@ def test_integral_failing():
     check_expression("Integral(x*y, (x,), (y, 0))", "x,y", only_from_sympy=True)
     check_expression("Integral(x*y, (x, 0, 1), (y, 0))", "x,y", only_from_sympy=True)
 
+def test_undefined_function():
+    f = sympy.Function('f')
+    sf = sage.function('f')
+    x = sympy.symbols('x')
+    sx = sage.var('x')
+    assert bool(sf(sx) == f(x)._sage_())
+    #assert bool(f == sympy.sympify(sf))
+
 # This string contains Sage doctests, that execute all the functions above.
 # When you add a new function, please add it here as well.
 """
@@ -240,7 +248,7 @@ TESTS::
     sage: test_issue_4023()
     sage: test_functions_only_from_sympy()
     sage: test_integral()
-    sage: test_integral_failing()
+    sage: test_undefined_function()
 
 Sage has no symbolic Lucas function at the moment::
 

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -132,6 +132,9 @@ def test_GoldenRation():
 
 
 def test_functions():
+    # Test at least one Function without own _sage_ method
+    assert not "_sage_" in sympy.factorial.__dict__
+    check_expression("factorial(x)", "x")
     check_expression("sin(x)", "x")
     check_expression("cos(x)", "x")
     check_expression("tan(x)", "x")
@@ -183,5 +186,5 @@ TESTS::
     sage: test_GoldenRation()
     sage: test_functions()
     sage: test_issue_4023()
-
+    
 """

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -122,7 +122,8 @@ def test_oo():
     assert sage.oo == sage.SR(sympy.oo)
     assert sympy.sympify(-sage.oo) == -sympy.oo
     assert -sage.oo == sage.SR(-sympy.oo)
-
+    #assert sympy.sympify(sage.UnsignedInfinityRing.gen()) == sympy.zoo
+    #assert sage.UnsignedInfinityRing.gen() == sage.SR(sympy.zoo)
 
 def test_NaN():
     assert sympy.sympify(sage.NaN) == sympy.nan

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -356,7 +356,7 @@ class RisingFactorial(CombinatorialFunction):
     def _eval_is_integer(self):
         return fuzzy_and((self.args[0].is_integer, self.args[1].is_integer,
                           self.args[1].is_nonnegative))
-    
+
     def _sage_(self):
         import sage.all as sage
         return sage.rising_factorial(self.args[0]._sage_(), self.args[1]._sage_())

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -356,6 +356,10 @@ class RisingFactorial(CombinatorialFunction):
     def _eval_is_integer(self):
         return fuzzy_and((self.args[0].is_integer, self.args[1].is_integer,
                           self.args[1].is_nonnegative))
+    
+    def _sage_(self):
+        import sage.all as sage
+        return sage.rising_factorial(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 class FallingFactorial(CombinatorialFunction):
@@ -424,6 +428,10 @@ class FallingFactorial(CombinatorialFunction):
     def _eval_is_integer(self):
         return fuzzy_and((self.args[0].is_integer, self.args[1].is_integer,
                           self.args[1].is_nonnegative))
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.falling_factorial(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 rf = RisingFactorial

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -419,10 +419,6 @@ class exp(ExpBase):
     def _eval_rewrite_as_tanh(self, arg):
         return (1 + C.tanh(arg/2))/(1 - C.tanh(arg/2))
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.exp(self.args[0]._sage_())
-
 
 class log(Function):
     """
@@ -714,10 +710,6 @@ class log(Function):
         if arg is S.One:
             return (self.args[0] - 1).as_leading_term(x)
         return self.func(arg)
-
-    def _sage_(self):
-        import sage.all as sage
-        return sage.log(self.args[0]._sage_())
 
 
 class LambertW(Function):

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -182,10 +182,6 @@ class sinh(HyperbolicFunction):
         if arg.is_imaginary:
             return True
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.sinh(self.args[0]._sage_())
-
 
 class cosh(HyperbolicFunction):
     r"""
@@ -330,10 +326,6 @@ class cosh(HyperbolicFunction):
         if arg.is_imaginary:
             return True
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.cosh(self.args[0]._sage_())
-
 
 class tanh(HyperbolicFunction):
     r"""
@@ -467,10 +459,6 @@ class tanh(HyperbolicFunction):
         if arg.is_real:
             return True
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.tanh(self.args[0]._sage_())
-
 
 class coth(HyperbolicFunction):
     r"""
@@ -591,10 +579,6 @@ class coth(HyperbolicFunction):
         else:
             return self.func(arg)
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.coth(self.args[0]._sage_())
-
 
 ###############################################################################
 ############################# HYPERBOLIC INVERSES #############################
@@ -678,10 +662,6 @@ class asinh(Function):
         Returns the inverse of this function.
         """
         return sinh
-
-    def _sage_(self):
-        import sage.all as sage
-        return sage.asinh(self.args[0]._sage_())
 
 
 class acosh(Function):
@@ -794,10 +774,6 @@ class acosh(Function):
         """
         return cosh
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.acosh(self.args[0]._sage_())
-
 
 class atanh(Function):
     """
@@ -871,10 +847,6 @@ class atanh(Function):
         """
         return tanh
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.atanh(self.args[0]._sage_())
-
 
 class acoth(Function):
     """
@@ -944,7 +916,3 @@ class acoth(Function):
         Returns the inverse of this function.
         """
         return coth
-
-    def _sage_(self):
-        import sage.all as sage
-        return sage.acoth(self.args[0]._sage_())

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -386,10 +386,6 @@ class sin(TrigonometricFunction):
         if arg.is_real:
             return True
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.sin(self.args[0]._sage_())
-
 
 class cos(TrigonometricFunction):
     """
@@ -735,10 +731,6 @@ class cos(TrigonometricFunction):
         if arg.is_real:
             return True
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.cos(self.args[0]._sage_())
-
 
 class tan(TrigonometricFunction):
     """
@@ -967,10 +959,6 @@ class tan(TrigonometricFunction):
 
         if arg.is_imaginary:
             return True
-
-    def _sage_(self):
-        import sage.all as sage
-        return sage.tan(self.args[0]._sage_())
 
 
 class cot(TrigonometricFunction):
@@ -1212,10 +1200,6 @@ class cot(TrigonometricFunction):
             return S.ComplexInfinity
         return cot(argnew)
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.cot(self.args[0]._sage_())
-
 
 class ReciprocalTrigonometricFunction(TrigonometricFunction):
     """Base class for reciprocal functions of trigonometric functions. """
@@ -1388,10 +1372,6 @@ class sec(ReciprocalTrigonometricFunction):
             k = n//2
             return (-1)**k*C.euler(2*k)/C.factorial(2*k)*x**(2*k)
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.sec(self.args[0]._sage_())
-
 
 class csc(ReciprocalTrigonometricFunction):
     """
@@ -1459,10 +1439,6 @@ class csc(ReciprocalTrigonometricFunction):
             k = n//2 + 1
             return ((-1)**(k - 1)*2*(2**(2*k - 1) - 1)*
                     C.bernoulli(2*k)*x**(2*k - 1)/C.factorial(2*k))
-
-    def _sage_(self):
-        import sage.all as sage
-        return sage.csc(self.args[0]._sage_())
 
 
 ###############################################################################
@@ -1632,10 +1608,6 @@ class asin(InverseTrigonometricFunction):
         """
         return sin
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.asin(self.args[0]._sage_())
-
 
 class acos(InverseTrigonometricFunction):
     """
@@ -1785,10 +1757,6 @@ class acos(InverseTrigonometricFunction):
             return r
         elif z.is_real and (z + 1).is_nonnegative and (z - 1).is_nonpositive:
             return r
-
-    def _sage_(self):
-        import sage.all as sage
-        return sage.acos(self.args[0]._sage_())
 
 
 class atan(InverseTrigonometricFunction):
@@ -1941,10 +1909,6 @@ class atan(InverseTrigonometricFunction):
     def _eval_rewrite_as_acsc(self, arg):
         return sqrt(arg**2)/arg*(S.Pi/2 - acsc(sqrt(1 + arg**2)))
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.atan(self.args[0]._sage_())
-
 
 class acot(InverseTrigonometricFunction):
     """
@@ -2085,10 +2049,6 @@ class acot(InverseTrigonometricFunction):
     def _eval_rewrite_as_acsc(self, arg):
         return arg*sqrt(1/arg**2)*(S.Pi/2 - acsc(sqrt((1 + arg**2)/arg**2)))
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.acot(self.args[0]._sage_())
-
 
 class asec(InverseTrigonometricFunction):
     """
@@ -2174,10 +2134,6 @@ class asec(InverseTrigonometricFunction):
     def _eval_rewrite_as_acsc(self, arg):
         return S.Pi/2 - acsc(arg)
 
-    def _sage_(self):
-        import sage.all as sage
-        return sage.arcsec(self.args[0]._sage_())
-
 
 class acsc(InverseTrigonometricFunction):
     """
@@ -2262,10 +2218,6 @@ class acsc(InverseTrigonometricFunction):
 
     def _eval_rewrite_as_asec(self, arg):
         return S.Pi/2 - asec(arg)
-
-    def _sage_(self):
-        import sage.all as sage
-        return sage.arccsc(self.args[0]._sage_())
 
 
 class atan2(InverseTrigonometricFunction):
@@ -2432,7 +2384,3 @@ class atan2(InverseTrigonometricFunction):
         y, x = self.args
         if x.is_real and y.is_real:
             super(atan2, self)._eval_evalf(prec)
-
-    def _sage_(self):
-        import sage.all as sage
-        return sage.atan2(self.args[0]._sage_(), self.args[1]._sage_())

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -195,6 +195,10 @@ class besselj(BesselBase):
         if nu.is_integer and z.is_real:
             return True
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.bessel_J(self.args[0]._sage_(), self.args[1]._sage_())
+
 
 class bessely(BesselBase):
     r"""
@@ -269,6 +273,10 @@ class bessely(BesselBase):
         nu, z = self.args
         if nu.is_integer and z.is_positive:
             return True
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.bessel_Y(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 class besseli(BesselBase):
@@ -366,6 +374,10 @@ class besseli(BesselBase):
         if nu.is_integer and z.is_real:
             return True
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.bessel_I(self.args[0]._sage_(), self.args[1]._sage_())
+
 
 class besselk(BesselBase):
     r"""
@@ -445,6 +457,10 @@ class besselk(BesselBase):
         nu, z = self.args
         if nu.is_integer and z.is_positive:
             return True
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.bessel_K(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 class hankel1(BesselBase):

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -162,6 +162,10 @@ class DiracDelta(Function):
     def _latex_no_arg(printer):
         return r'\delta'
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.dirac_delta(self.args[0]._sage_())
+
 
 ###############################################################################
 ############################## HEAVISIDE FUNCTION #############################
@@ -244,3 +248,7 @@ class Heaviside(Function):
     def _eval_rewrite_as_sign(self, arg):
         if arg.is_real:
             return (sign(arg)+1)/2
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.heaviside(self.args[0]._sage_())

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -80,6 +80,10 @@ class elliptic_k(Function):
     def _eval_rewrite_as_meijerg(self, z):
         return meijerg(((S.Half, S.Half), []), ((S.Zero,), (S.Zero,)), -z)/2
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.elliptic_kc(self.args[0]._sage_())
+
 
 class elliptic_f(Function):
     r"""

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -209,6 +209,7 @@ class erf(Function):
                     self.func(x + x*sqrt(sq)))
         return (re, im)
 
+
 class erfc(Function):
     r"""
     Complementary Error Function. The function is defined as:
@@ -1266,6 +1267,10 @@ class expint(Function):
                 return f._eval_nseries(x, n, logx)
         return super(expint, self)._eval_nseries(x, n, logx)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.exp_integral_e(self.args[0]._sage_(), self.args[1]._sage_())
+
 
 def E1(z):
     """
@@ -1661,6 +1666,9 @@ class Si(TrigonometricIntegral):
         # XXX should we polarify z?
         return pi/2 + (E1(polar_lift(I)*z) - E1(polar_lift(-I)*z))/2/I
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.sin_integral(self.args[0]._sage_())
 
 class Ci(TrigonometricIntegral):
     r"""
@@ -1754,6 +1762,10 @@ class Ci(TrigonometricIntegral):
     def _eval_rewrite_as_expint(self, z):
         return -(E1(polar_lift(I)*z) + E1(polar_lift(-I)*z))/2
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.cos_integral(self.args[0]._sage_())
+
 
 class Shi(TrigonometricIntegral):
     r"""
@@ -1832,6 +1844,10 @@ class Shi(TrigonometricIntegral):
         from sympy import exp_polar
         # XXX should we polarify z?
         return (E1(z) - E1(exp_polar(I*pi)*z))/2 - I*pi/2
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.sinh_integral(self.args[0]._sage_())
 
 
 class Chi(TrigonometricIntegral):
@@ -1935,6 +1951,11 @@ class Chi(TrigonometricIntegral):
     @staticmethod
     def _latex_no_arg(printer):
         return r'\operatorname{Chi}'
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.cosh_integral(self.args[0]._sage_())
+
 
 ###############################################################################
 #################### FRESNEL INTEGRALS ########################################

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -917,6 +917,10 @@ class loggamma(Function):
         else:
             raise ArgumentIndexError(self, argindex)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.log_gamma(self.args[0]._sage_())
+
 
 def digamma(x):
     r"""

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -301,6 +301,12 @@ class hyper(TupleParametersBase):
         from sympy.simplify.hyperexpand import hyperexpand
         return hyperexpand(self)
 
+    def _sage_(self):
+        import sage.all as sage
+        ap = [arg._sage_() for arg in self.args[0]]
+        bq = [arg._sage_() for arg in self.args[1]]
+        return sage.hypergeometric(ap, bq, self.argument._sage_())
+
 
 class meijerg(TupleParametersBase):
     r"""

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -229,6 +229,13 @@ class Ynm(Function):
             res = mp.spherharm(n, m, theta, phi)
         return Expr._from_mpmath(res, prec)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.spherical_harmonic(self.args[0]._sage_(),
+                                       self.args[1]._sage_(),
+                                       self.args[2]._sage_(),
+                                       self.args[3]._sage_())
+
 
 def Ynm_c(n, m, theta, phi):
     r"""Conjugate spherical harmonics defined as

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -444,3 +444,7 @@ class KroneckerDelta(Function):
     @staticmethod
     def _latex_no_arg(printer):
         return r'\delta'
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.kronecker_delta(self.args[0]._sage_(), self.args[1]._sage_())

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1070,6 +1070,27 @@ class Integral(AddWithLimits):
             result += self.function.subs(sym, xi)
         return result*dx
 
+    def _sage_(self, ):
+        import sage.all as sage
+        f, limits = self.function, list(self.limits)
+        limit = limits.pop(-1)
+        if len(limit) >= 2:
+            if len(limit) == 2:
+                x, b = limit
+                a = None
+            else:
+                x, a, b = limit
+            return sage.symbolic.integration.integral.definite_integral(f._sage_(),
+                                                                          x._sage_(),
+                                                                          a._sage_(),
+                                                                          b._sage_(),
+                                                                          hold=True)
+        else:
+            x = limit[0]
+            return sage.symbolic.integration.integral.indefinite_integral(f._sage_(),
+                                                                          x._sage_(),
+                                                                          hold=True)
+
 
 @xthreaded
 def integrate(*args, **kwargs):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1071,7 +1071,7 @@ class Integral(AddWithLimits):
         return result*dx
 
     def _sage_(self, ):
-        import sage.all as sage
+        from sage.symbolic.integration.integral import definite_integral, indefinite_integral
         f, limits = self.function, list(self.limits)
         limit = limits.pop(-1)
         if len(limit) >= 2:
@@ -1080,16 +1080,16 @@ class Integral(AddWithLimits):
                 a = None
             else:
                 x, a, b = limit
-            return sage.symbolic.integration.integral.definite_integral(f._sage_(),
-                                                                          x._sage_(),
-                                                                          a._sage_(),
-                                                                          b._sage_(),
-                                                                          hold=True)
+            return definite_integral(f._sage_(),
+                                        x._sage_(),
+                                        a._sage_(),
+                                        b._sage_(),
+                                        hold=True)
         else:
             x = limit[0]
-            return sage.symbolic.integration.integral.indefinite_integral(f._sage_(),
-                                                                          x._sage_(),
-                                                                          hold=True)
+            return indefinite_integral(f._sage_(),
+                                       x._sage_(),
+                                       hold=True)
 
 
 @xthreaded

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1071,7 +1071,7 @@ class Integral(AddWithLimits):
     def _sage_(self):
         import sage.all as sage
         f, limits = self.function._sage_(), list(self.limits)
-        for limit in limits[::-1]:
+        for limit in limits:
             if len(limit) == 1:
                 x = limit[0]
                 f = sage.integral(f,
@@ -1081,7 +1081,8 @@ class Integral(AddWithLimits):
                 x, b = limit
                 f = sage.integral(f,
                                     x._sage_(),
-                                    hold=True).subs({x._sage_(): b._sage_()})
+                                    b._sage_(),
+                                    hold=True)
             else:
                 x, a, b = limit
                 f = sage.integral(f,


### PR DESCRIPTION
this should enable all bindings between symbolic functions in SymPy and Sage which are possible at the moment and, for identical names, in the future; so it fixes #3444 for the moment

depends on #8585

also fixes http://trac.sagemath.org/ticket/14723 and http://trac.sagemath.org/ticket/14446 and http://trac.sagemath.org/ticket/17493
