### PR TITLE
Make diffgeom objects work with simplify( )

### DIFF
--- a/examples/intermediate/schwarzschild.ipynb
+++ b/examples/intermediate/schwarzschild.ipynb
@@ -3,75 +3,88 @@
   "name": "schwarzschild"
  },
  "nbformat": 3,
+ "nbformat_minor": 0,
  "worksheets": [
   {
    "cells": [
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "# Schwarzschild Solution to the Einstein's equation"
      ]
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
-      "We will rederive the equations from *General Theory of Relativity*, chapter 18, by Dirac. They describe a spherically symetric solution to the Einstein's equation in vacuum.",
-      "",
-      "We will not try to solve the resulting equations.",
-      "",
+      "We will rederive the equations from *General Theory of Relativity*, chapter 18, by Dirac. They describe a spherically symetric solution to the Einstein's equation in vacuum.\n",
+      "\n",
+      "We will not try to solve the resulting equations.\n",
+      "\n",
       "This verion of the notebook uses funtions that explicitly calculate the Christoffel symbols, hence the work is coordinate-system-dependent."
      ]
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "Import the necessary modules."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
-      "from sympy.diffgeom import *",
+      "from sympy.diffgeom import *\n",
       "TP = TensorProduct"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [],
      "prompt_number": 1
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "Define a 4D manifold with a patch and a coordinate chart on which we will work."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
-      "m = Manifold('Schwarzschild', 4)",
-      "p = Patch('origin', m)",
+      "m = Manifold('Schwarzschild', 4)\n",
+      "p = Patch('origin', m)\n",
       "cs = CoordSystem('spherical', p, ['t', 'r', 'theta', 'phi'])"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [],
      "prompt_number": 2
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "m, p, cs"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\begin{pmatrix}\\mathbb{Schwarzschild}, & \\mathrm{origin}_{\\mathbb{Schwarzschild}}, & \\mathrm{spherical}^{\\mathrm{origin}}_{\\mathbb{Schwarzschild}}\\end{pmatrix}$$"
+        "$$\\left ( \\mathrm{Schwarzschild}, \\quad \\mathrm{origin}_{\\mathrm{Schwarzschild}}, \\quad \\mathrm{spherical}^{\\mathrm{origin}}_{\\mathrm{Schwarzschild}}\\right )$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAhgAAAAmBAMAAAB0Rf/XAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAZnbNRO8QMquZIt27\nVInfsDh2AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAIDElEQVRoBe2Zf4xUVxXHvzPz5r3Z+d01ViuG\nDkO0pC3jllJTLdBJCIamjbsSsws1kEcNYbXIjBQsGuu8UtO6aLoD/yhp3D5tkLbWztiW/sDUnVJr\nNoRmxyaSGLG8QlW20WEWYX8gMJ5z39vZ2fmxM7sYDdO9u/t+3Pu95537uefed+9bALAF6fAhT7Jm\nAVj4IQchmr/ShCB1zsEA7JqgsCnerDBsadGyeQ217xah6mlIezWKJE14vboh31MqyZSRhrRNL3Jp\n1ERHsmnbKZsTwOaGGiiCIqU3pL26ROGI+tTSfVvy+Nqi8KODeKorotVtwBJSPFFXdfUJvFk5LX35\neTmPh+URPQb3JSyv24qPkmJNXdW0Anm7Om35/6UwARxW8iAYL6ELBGMEu+o6korCPUoqed++rJg6\nlDeNepUsyY6Q8ghrfYPZWjUUi/PEuZZuNvnfXTGl1o7Q5O3OFaBO7lE6GEbOnWYY+QZgOA3Y8mTm\n/jhWtglz92uTVmtcmZKEAfMiVhvGZdOCYp1r2JtVtvzqlGrkTTFRkYgMAaM1pzYKw9WGljRZ2Ucr\nMBOGVysarXVRlJgXtWHUMvBfyR+obWUA3qC704yMH6toFIY9D0+GrH6ORkozwUBuSH9uXO8eR3th\nTO5Nbhmzf6VmAE9Q9V1AIEk3b6mAITKL3S7uqh5MyYE46kWG+0Gz/sS5qrXZZk6NDPJmMpUUKUfw\ntDFZMu2VcgmBECnaN0TpKPflst7d4V2Y9+8/9C91nQ+2RkJYuebdzwdWhPv1be8sFAoIiXtQYxhy\nLpyoQL41/L6o9twYsHqo9WY6P7Bu2yJ+0BUmZXG4beWG604HgYGfs8Fn5u+Wblt86lnyhr0He4wS\nGJIGm4HGkjyMGBmGrVBYCuzPKvd630BKl88iFsUR3yH8BFh3bNgB5aycgUcoICRMgn43ZXGmHIZy\nCN4QVyOvpBH82s7eLQu5LzTm03SqLUAaB6Pya8DRIBmUXsYq1fnTWJBcYe9Nj+lxxfSn8Mnidb2L\ns0gxDGx8ohDErfCNejsQCOIRODUYvi60q7gD2IpNGdro+4UCpoQeT7+3AqlyGB4DyihXIwiuNH4o\nuuotYLieM+Xl8i/Kc1apNJpvB05EIQzS29AZcqRhuuIbNT0uhVFuYbr7y5iI8h15eZyU3jYeOCf0\nd/JSFErkSZ2f7eZJpf+wLhSWRMCQ6aVZAYMtXuZqBKOlw4LxJnAWiAx9j715OsPHqsn9I8q2pWU+\n2S+VSzwXbwRbjiUhDCb2XPPxoENjGKZvwuOZw/i6yk8aR4IjwwCkcxJ5C2+GYTgNY70f8jI9Eec3\nDWznKDzuHBcKSyJgcEYFDOo2XBTVBmhJJ68XkXGUYfij4EZCyvOxemqnbEkDnyqX0PKpQpJhBDIQ\nBq8n7mKn6dWEb6bHBKM+dbNH5qE7QyY+w3YIhhgmnDEq2JowWl4O/WMrKP4S31IZRsJQvqPj+i9w\n7JTCoMmlEgZHxvgEjEgkPgnDCWxhC7QgrJlSZkmMT8vLVc9yt5iRIWAkQqTgbbcVGabHAw1RFz2y\n2uwYB7nM4Rxje6/TZ408TwA+E4YypiduRMzAie1xhvEibA8ZcAVZUQoDy6rAcCYpzCwYvijV5glU\n+O7Jws739WDIcVooUaqA8S7wMMM4EbUMtkEOmTCE96bHA2iEuuUELdmJp4AxjIBBNy9m8dUg9gfx\ngQmDWu9pgzODM99UXwNcF+D4Rie8OismYGT4Yn8UvUH5X2RiMildcBigauSwtPRBXZAQMGwXPwH4\nc4+5RyPa3V13H3K8Ir23B7TXju09k10wP4Tc6Xhq22nQ1ptgRMLLUWb6jyqO4DZd3mDRVYbRono4\nMsgV8s30+CgaoS5gbOb9iwWDtrb02gC0u37wO1pn9EQO9I49NLgWWAB7EO6e8H1L7im8jfYVQ/3S\newveZ4WuCAkdN/eO6XJfa2It+lWyMZmeyX0fXG1n4VHcWTifpPPOwmPHz2s4XvgsHsfjvKP2pe0Z\nW9weckRpr/08jkqG23DRTyrryJKDMbQYWI8y019snR/F7a2LomRbGOze+zdp8GKWvFHZN+HxzsLu\nUurSwe2/0e/YXkGde0QeZBj2kws5MpRz/G644iTptUzQh4VfvVBSqCyj3bS5ox71d/qBbTeFaIAe\nsHe6x4+pKZVGneoKCRgxlYdJFdM0TOqmEur4M27Gxyqpi28cMYbRByfD8I3A31HXcl2BrabiOJV8\nslhKE0aA5y2K0F3o+9mejfD/3hVSyINEVL2nEG0nZQoWDLohGFVMNwIDJdQD8b+qRiV18Y2DYcgj\n5pxBJIjHFaeNNS3QtwG8XSx1AB5eiAoYqz79wLUI6N7FDOO3+LvuS6f0EhgUJgSjiulXi/ZqXkyh\n3vLBddcGK6kLJxgGdY8jS6a8tKSf8cKw0oVgZZaVQ3uXIeJhpUAId6EH9wk/nJoziZjuCRMMV5u0\nOImMKymHipHhCrm/BFSaXl3YPWGv5nkKdWnN5lvUSupFGBQiAgatvPm9979KLd8eMuDfa4gdtT/r\nz8J2+IYltNdu73vyLycjOoYi8qD2qde7x+VeDbnwwewsPZtCHWuxrgr1IgwasvuZeUIHfyJrujSF\nOv5JPxXUwT1yrDfZPQb/yZvovYVT9BebLf5mQ0iDcuJ7X7M1bcbt8XVwla4Z12vKCh6eN/CRpmzb\njBtlYqDPUnMJ7nsFBPmVORb0ryPrPfJLfY4G3rAYuONzMOQoMfgPYUL/y7wMCjoAAAAASUVORK5C\nYII=\n",
        "prompt_number": 3,
        "text": [
-        "(Manifold(Schwarzschild, 4),",
-        " Patch(origin, Manifold(Schwarzschild, 4)),",
-        " CoordSystem(spherical, Patch(origin, Manifold(Schwarzschild, 4))))"
+        "(Manifold(Schwarzschild, 4), Patch(origin, Manifold(Schwarzschild, 4)), CoordS\n",
+        "ystem(spherical, Patch(origin, Manifold(Schwarzschild, 4)), (t, r, theta, phi)\n",
+        "))"
        ]
       }
      ],
@@ -79,23 +92,28 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "Prepare the variables containing the scalar fields and the 1-form fields."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
-      "t, r, theta, phi = cs.coord_functions()",
+      "t, r, theta, phi = cs.coord_functions()\n",
       "t, r, theta, phi"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\begin{pmatrix}\\boldsymbol{\\mathrm{t}}, & \\boldsymbol{\\mathrm{r}}, & \\boldsymbol{\\mathrm{\\theta}}, & \\boldsymbol{\\mathrm{\\phi}}\\end{pmatrix}$$"
+        "$$\\left ( \\boldsymbol{\\mathrm{t}}, \\quad \\boldsymbol{\\mathrm{r}}, \\quad \\boldsymbol{\\mathrm{\\theta}}, \\quad \\boldsymbol{\\mathrm{\\phi}}\\right )$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAJQAAAAVBAMAAABS/tqaAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMmYiu80QdonvRN2Z\nVKvu110NAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAB3ElEQVQ4EaWUv2sTYRjHP3dnfjSBJovzBaGb\naKQuThELbiVV0UEpydLJoVkKbn1nES9dlNYhAUeH+g9Ig6tKCo46VJycNJTWYMXX5y6HNM+9hRYf\nuPe5+zzf58vzvtwdnCW8C22X/EoKvZqr6mbfLm24Cm/Br0rhKhSNS5BlK6P8QZbCLYFf5LoH54zk\nU8RwQK/t0P0QloOCgYZcp4iSrWPjjagoXRcgPjN1Sj2jiu7H2QPytp+txdOQ7/IKhtaOlcCzo7Xn\nilEZ48lgKoJ3O3e/Clvmiaw7RpUhHD+2bUUv/6JgFYP1hQrDPmJ0Q2oOq9xR8EJ3fbfWHmno/+E8\nlS7M8eYEq9+6B1p35hv6JGgc8ojKPnxi6wSrn1mrniEcaRztsciqWIVnsbK7REvaqtnhGduywTDd\n4IxW5FxTVen1tbC5G7ymaZBXIT72lnmoFS6rZrWQPcGo4w/8+HOa46ms0dJFVqdHT6wUC832HlpY\n3pj9GMnHx/v4FaW4eZPyodz8C89aOeBpRunBbREoyFprczHuu0+5nva/TPPx5GJoeC3pCLr4g7S3\nlubjycXQ8HPSUezAwqQ3rxWCXSwLPyQGK7LKry8Of5KmVhfLCuMzn0wU1JLb/1z8On8BryB67lhP\nHhEAAAAASUVORK5CYII=\n",
        "prompt_number": 4,
        "text": [
         "(t, r, \u03b8, \u03c6)"
@@ -106,17 +124,21 @@
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
-      "dt, dr, dtheta, dphi = cs.base_oneforms()",
+      "dt, dr, dtheta, dphi = cs.base_oneforms()\n",
       "dt, dr, dtheta, dphi"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\begin{pmatrix}\\mathbb{d}t, & \\mathbb{d}r, & \\mathbb{d}\\theta, & \\mathbb{d}\\phi\\end{pmatrix}$$"
+        "$$\\left ( \\mathrm{d}t, \\quad \\mathrm{d}r, \\quad \\mathrm{d}\\theta, \\quad \\mathrm{d}\\phi\\right )$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAALsAAAAVBAMAAADsqILHAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMmYiu80QdonvRN2Z\nVKvu110NAAAACXBIWXMAAA7EAAAOxAGVKw4bAAACaUlEQVQ4EbVVTWgTQRT+NptMt/lpctVLR3rw\nGsRLT5WKFUFsDv5cYy9VKCQ9VVBw9VJBsQVvAXVFkELBBkXw4E9QRC/Cgh4Fc/LYhoJahYLv7WzD\n7swk4KHvsPvmfT/z5mcTYJ/DkTTBxSf2WcTB+jBgTppoLHGBQwwe5cfXXX6aUZoNzSJXIiA/881E\nY4kHjFUIPc8MQfbiuclFY4B9BByol+umRknIHjVgxGcC25d6nGkx1P4ZypbZlWSejK4Ao1U2ZPsi\nTWbEMPvMKsrSUMQLfkTAZWA9wtm+4JvUoZtT6GB8YPdslgtxh16Xlhd38XT2TFPzF7eWSL/2Y23J\nCmwEuB5YETiV918Ar4Np2pn78Kj77xqTFhdiJYR/IjylQQrY2tx8qAGxBJ9dmasiU8NrWkMNLtl/\n0Kk4B0yFTvgGvJHJiAC8AH4mq5wrJCszVa+LUhstoOFH9i91qthheyH+2gHswKGuUqEkuAoPxTac\nHttvNNnedMn/ZnvLhVUAXYfiasociCWvyD53jO1pcxqRfb6HeposlL15YRVA/ZSNy6Ak2zjCjeXb\nfLQ0D3Xv1UqVtD3ORt2P+loZMdDC7QHIBUzgNPho7wJuC2PbKHbn0ail+JMBtiSmArpc6TNUwEf3\nHi3dJlmHn+3Qh9qJPquFm4t/uu7JJgq/Uvbi0+HxB+rDe1tPIgpYuEZFq8R5N32D+LkAhSq9+/G4\nn2lJPkVLglaJK5kySfvT4WQv5F6ivzN6oT+W/SyRZKJulqlyPFEVMjFIpXOpUWJgl/DPMQQfS/R3\nEvP/s0dW2SUjDGV5Ca7kdD9iAvgHv9m2uFa43G4AAAAASUVORK5CYII=\n",
        "prompt_number": 5,
        "text": [
         "(\u2146 t, \u2146 r, \u2146 \u03b8, \u2146 \u03c6)"
@@ -127,30 +149,34 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "The most general spherically-symmetric metric has the following form."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
-      "metric = exp(2*f(r))*TP(dt, dt) - exp(2*g(r))*TP(dr, dr) - r**2*TP(dtheta, dtheta) - r**2*sin(theta)**2*TP(dphi, dphi)",
+      "metric = exp(2*f(r))*TP(dt, dt) - exp(2*g(r))*TP(dr, dr) - r**2*TP(dtheta, dtheta) - r**2*sin(theta)**2*TP(dphi, dphi)\n",
       "metric"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$e^{2 \\operatorname{f}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} \\mathbb{d}t\\otimes\\mathbb{d}t - e^{2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} \\mathbb{d}r\\otimes\\mathbb{d}r - \\left(\\boldsymbol{\\mathrm{r}}\\right)^{2} \\sin^{2}{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )} \\mathbb{d}\\phi\\otimes\\mathbb{d}\\phi - \\left(\\boldsymbol{\\mathrm{r}}\\right)^{2} \\mathbb{d}\\theta\\otimes\\mathbb{d}\\theta$$"
+        "$$e^{2 f{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} \\mathrm{d}t\\otimes\\mathrm{d}t - e^{2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} \\mathrm{d}r\\otimes\\mathrm{d}r - \\sin^{2}{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )} \\left(\\boldsymbol{\\mathrm{r}}\\right)^{2} \\mathrm{d}\\phi\\otimes\\mathrm{d}\\phi - \\left(\\boldsymbol{\\mathrm{r}}\\right)^{2} \\mathrm{d}\\theta\\otimes\\mathrm{d}\\theta$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAlQAAAAaBAMAAACDe98vAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEIl2mSJE3e9UMqtm\nzbsXyEShAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAIQ0lEQVRYCdVYb4xcVRX/vdn5szM7szuhm4Ca\nsi+71cRq48jWECkfHqUbJWJ8JlZrJO1YjTWidDQQY/xgjYQEMenEaPyDwkSMHyhlhpiYBo2MJSRG\nQIcYVIjSJZZEpLgFpbbQ9nn+3PfunTczlJn9YHqSue+c3z33d889997z3i5wMcum49X1hz8xyU6e\nu7i+AHIhj2+uj+QNjM6EM7034Pb6LuOSSGa97TV4PhOXutyOK8n2XCIj7xt3fMo/oUvh1iyEpVes\nNaE2JolmNnOFj1k90ZsnmNduz7MyOtOagMQOsXQWS2nT9dypFDS+OSaJZrZSBz6lc10+/pRItidf\nk9He6gQkdkhCZ6FBrfjSIDY2MhaJZnaOTtRzOtFsa+wJkWzPbKiD/zk+hzMioWOs9Jiedqdf1ILu\nShoezx6ThDJbXrseaKB95kgHUxyC97Oh8b35k6MiYZKlbSigFN15B7DMfiNIRsB9zLrbUjePPPpN\n/E47TR0tt9jcpJhhy6nltCbW0IFEHUYivt5jaVekcc7s47R7PRTP3f8Sih0aUVxrDowj4K4zw1DG\niGQbjuMwcPfTa1XcydgIkhEwRfANHiWiu72b9I2veucw0xKUbZYH6VcOWEsmyajltCZW34FEHUYi\nvje9KUj7pnHenh1AfhWl87k6P0kWKFWXhqy54lGqvFtcJNY3IfcKnsdNQHv1o+AnCZMMkREwSi8n\nznpkniD7QwEOVtGTHrZZKvTbi8+JbiYZTBXHSuJL6zTDSNi39HUMVL8ULttzglLV0VjpdJHwcu6W\nCbyti0tVMxUPLZ40hvsgknKDprqRUuVTB50uEicnLosDi9tgIzFhyqeoohBRC1ewD9sipJSe+sGz\naijbBjU2bF98t2rQVHk1Y8aPoSTsW+hCkutG6uJEINtzG2WVThVvK6WMhAP4ICv4dBXe20WjE0Vk\n2Z4x3AeRZDqlA7jfpIpSRuLkxGVxYJfD0fXITIfAzDl4UR2XcSfbIt4BTEfRSTWUTY9Y/hrgkqZx\nkoXnW2ol7VASXtdvgbPs5Ubq4pQh3h6Pjp7X0FSVfR7AAXyJlfyT1FzuTF/wGe4XJil2Zjq41KTq\nqPTbnPSxWLifJXevsc2R2Ufm3Mv0oghR4QDIbkf3/KUGPOUMVDZfkC+EtI7ntZOXCWTUsO1QEva9\nGSUe0Repxb2lraFsT75BTl/Ex04HtI91eIvL7Wb+1+d/TuhMNoQX0G7Rfi1ddQY3rr1AsTqSkFy7\npYtCNfe1W6nzFxQyk2DvA3v5bWhZ+mBLU3rvcm/3azh86z3bavGR4YL1h1OYimjFAelkl6LF/bSt\nWsoIUjaUWivfJQudFWA+WyVNYgXuzX6csufKEBLxzdNE/FFrI1UOg+8Lc77QSG24WhkrwGVNvKtp\nitIjWME8uBR4tyNDedcKpr7cJiSYbmGqqx29mMR/sfkPgiyLchtYnbmlD98GXgCeqdHrwQgVUDwU\nRdF/6X1HhGD7WGNXQ17Y6qNsuC7XrVBKymE29AIuTybWbPMG8K1wZJBEfWde++WRk+RnI3Xx3O2Y\nbzFL5VF+zLIK/Aj4G7CnaYpSgOyHAznHlR5ylCqtYOpLbULyCfyYzFXpKHYNSan5VXlTWRbhjmFx\nluazVficKsqrVAwGv0K/Y0/u3EMVtEj5UTsgBd/jhkUjne2Ww0yHyiiwMi8vPRPrCVr5O9QzboU0\nYCsmUd9CD3M9Qm2kLj7zreXf8Bhk+I4g36UGXgcexUap0qLky5cEX/kFX1IlFWzjl1meJjQhObzM\nt/Tz9APeQjxC4nn6l5ofs/TDlqZw/j3gVL0I/FsoqKF3DQ76aL9KF483nO1jNWrQ5obERHolbWW2\nQeugbAWSKo11qkH5fx/52XmGkKjvHE3UJFc/jtSsV/G5DnU58kPWp6rIU7CUqoU62wG8HSHvF/bX\nOFVm7dwlkiIpthilF7YhMZ8WCUs/LAzSeFuigFP1r1SqIqoFvZGpMmw3U5Iqq3Kq5qlaBXGshYBW\n/oydhLXBfOu6Fpp4P/cnkZr1Kk4JGyqepmo/PBk6T9WKU7UgqcqfRNUddQES82kRUL0TFsM98MWx\nE+VT6VTxXTnYwsE6Jb5ButydGk9OrzERw3YWN/DeUpReQG+hII51rpvrcs1wZZBE10UHQ45zEqlZ\nr+LTPiAzu1Ss00bQzFvAx+wzOapU4X2k0b7RvJmeHhz2Y7kACXeTWBblNrD0SfNt4FfpVJ2gnrXW\n1H/oYcu6BPx4PFDZ/kgl6ThB+fpHgLeWunGslVo5nA1iX30yqd7imETXNV3PNNjDRuriUz3Mh0rQ\n3+6q46EuPiBfulmaHZs71ORuw8xZZDsb+pwvQLKnLt6WRbkNbJm+X6X/bNDtcy8gF+S2v5/n5hIk\nBVpXuYMsEWXbB18zshJQwTpEPRprvpGRFKqvtkzaT2LWVdslubCR9uFbr+66LInubX+4fQd2LzPg\nPUENv4npi+WdV53u5P5eY93K65OYq2JZlDu+QQnN3oeP1g9FDxyKHrzrNOeGhZ3yf/4rq5U6NWS3\no6hF2p/oJ6JspetPbBZzY5Ue8nUgseKnvz/akg7bDCERX+/aa8TJRqrrjXHLMFqbpy8sqpXrlElY\nCrJBMvEubhM7d0BA2+S6qnvXAd+xo0A1LC2jSYznJJHGk/xk8W2xuo7nBCzlIJlvibXEztSSDlXK\ncXpKi4t1t+8R1xB9NEnsOkGk8dD/3/O5eGqvJ1psb4zx+JmJlfTTTwPJP3sxQDLoehEhu+NYZ/XU\nxHacsrgbU4mWUtLHj7pHkqSGXlxmXILoW0DE2Ml1m2g1k5D8D+WWqIkCxW0zAAAAAElFTkSuQmCC\n",
        "prompt_number": 6,
        "text": [
-        "",
-        " 2\u22c5f(r)                          2\u22c5g(r)                          2    2       ",
-        "\u212f      \u22c5TensorProduct(dt, dt) - \u212f      \u22c5TensorProduct(dr, dr) - r \u22c5sin (\u03b8)\u22c5Ten",
-        "",
-        "                          2                              ",
+        " 2\u22c5f(r)                          2\u22c5g(r)                            2     2    \n",
+        "\u212f      \u22c5TensorProduct(dt, dt) - \u212f      \u22c5TensorProduct(dr, dr) - sin (\u03b8)\u22c5r \u22c5Ten\n",
+        "\n",
+        "                          2                              \n",
         "sorProduct(dphi, dphi) - r \u22c5TensorProduct(dtheta, dtheta)"
        ]
       }
@@ -159,36 +185,40 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "The matrix $M$ representing the two-form as a bilinear map $V,U\\to V^tMU$ over the column vectors $V$ and $U$ in the canonical basis of the choosen coordinate system is:"
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "twoform_to_matrix(metric)"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\left[\\begin{smallmatrix}e^{2 \\operatorname{f}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} & 0 & 0 & 0\\\\0 & - e^{2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} & 0 & 0\\\\0 & 0 & - \\left(\\boldsymbol{\\mathrm{r}}\\right)^{2} & 0\\\\0 & 0 & 0 & - \\left(\\boldsymbol{\\mathrm{r}}\\right)^{2} \\sin^{2}{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )}\\end{smallmatrix}\\right]$$"
+        "$$\\left[\\begin{matrix}e^{2 f{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} & 0 & 0 & 0\\\\0 & - e^{2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} & 0 & 0\\\\0 & 0 & - \\left(\\boldsymbol{\\mathrm{r}}\\right)^{2} & 0\\\\0 & 0 & 0 & - \\sin^{2}{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )} \\left(\\boldsymbol{\\mathrm{r}}\\right)^{2}\\end{matrix}\\right]$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAABpCAMAAAAdgiiQAAAAP1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADFBd4eAAAAFHRS\nTlMAMquZdlQQQO0wRIki3e9mzbt8bDjT79EAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAonSURBVHgB\n7Z3rgps4DIUhAdoFwmWX93/WlSVfuUQDHNJOCz8yBIMkPhzZ4DMmy762tG3Yrwyr9xqMQPMcn5VY\nq55NQWtVExnP++jLvYoh0FCtfgxiqykaw3u018BuzDGObiuBwIug55Pkk6E222tT28NSjWH9XjtA\nIJ94eUSHdgS6nZh2NnEVH6OMbnYc76oe8fry6ktYmyr9LGiZN44l0+7H6WkS+MvYpctTPjq+OkVa\n87/o1bQPT+DlQttTTuO8u96QfkwG5SqGl2DtObXnkuDLachHvhhl/MNQYg3FA13ZyuQu0IK2p4QF\nctdvQm+eEsGT/9aSw/NpzFrJ8UeSet8Zm41toZUz/EIx2p7iEuVuE3pvmWcj9w5rqdj55DqOtuor\nYc6KR7YieWtWdOgr2p4SBMrdFvSa4NacdUybSinI1XQH3V4FJcxZ8cTQ62nefMx2+/JXtD3FMcrd\nDHrVFMXTdBeHsiy5Z15J56XihpTSv4PeuxUl0Li4miRVTYca4diSrKPtLT0kW2DuUui1aeNawtlx\nz8a4rIV29jIdx/Y1dTbtPKQ/mUSlfWnlkoUrpx2glKPtfcpdAr3tTOci7dK53F7MbvyPNIZoSGh7\nvwT6o6NuZB/f7g/9w3Un095KObsGSrxSXElNr3HphXMczJ5yErDwk5ouDUXsmlK8+1rHmKtDvfRM\ncnqJa0g51+HsuXPd+IsKP4X+tnEsXZ2nkIr457AR4srmF/9cemmbV8r3bkLbU/yj3CXQO4HuK7cS\nw/7igm+Onkfag1VnaHurTsJGlLsEemFoVKbLeNXyMi11F/1kTjpC21PCAblLoGfFs+jj1K3EsL/Y\n3Af4pnn/4Ysj0PYWDtINIHcp9NTF/e0iAjf0i8C+M3tDf0fnorIb+kVg35m9ob+jc1HZDf0isO/M\n3tDf0bmo7JdDj3RjqKGNi1DhzH4WeqQbs6cQ68b+GtnYR6HHujELPdGNNbjnA7hqeYGlj0KPdWNy\nLqlu7G+RjX0UeqwbE+gz3dhfIhtToZ8XNaW/T6sbMw++qMAMwJ6RjaGjS2NdfAO5U6GDRE0+ftaN\nGeAjjfqIeOaEbAwdnQ9zfQXkToOOEjW5k2DdWGv0wCP1EEU3dlw2ho7ORbnxF+VOg44SNdnTEG1B\nb7KKGbMTxVKQZOyVjYGj22DtN6PcadBRoiYJ3OrGGsouuRm5E91YgL5XNoaNzsPdWkG5U6BjRE1z\n3ZhR/D5MOyq6sQB9p2wME90W4sV2mDsFOkTOs9SNPYtm4GFBoxs7LhuDRLdgu7kB5u4D0Nd0YyTc\n47vPmW5sp0wARmGTc1IAc6dAPyJqqoaXXwZCu9CNtZRZSss30Y3tlY0diS7BuO8LzJ0CHaHJWujG\n8oGkwVatFOvG9svGUJKrL8JHuTPQq3JbrwUQNXl19eqpRbqx/bIxQHSrQW1sRLlr6RZl43+O2DNA\n1HShbgwQ3Qbf1c0od1p6yc6Lmq7UjZ2PbpXu1kaQOxU6QNR0oW4MEN0W4LXtIHcq9DXf97ZzBG7o\n5/gdOvqGfgjbuYNu6Of4HTr6hn4I27mDbujn+B06+g+FvhTYHKJz0UF/JvQVgc1F/A6Z/TOhLwU2\nh+BcdZCB/mP6cZX5X2R3KbD5RYGsu/13c76X9f2/z1bcBCfwc/4z04vBZCdmghMDGPzu0FOlbx8U\nqG5iJgAjuAkVOkhJZgPHWqNB7WS4j4YGHXU3eQcWGCh8FTpISWZPHmsty4b5mJcdeg0TM0Gpg8LX\noKOUZHLuWGs0L8RiBgnZEiZmgjJHha9BRynJ5OSx1kjHsZjGoOIpH8LETFDoqPA16CglmZw81pqd\n6spMoJoXQyeTd5gMcNWCCl+BDlOSMQesNZrgUeYTI+pNU08yi8yFvRZY+Ap0mKiJoWOtkdraztgx\nTK+s7WSGN5kw9ZK6Dgv/W0M3g/NmGUQFxOulnV2Pv2A/oNB//PxnKzqYkowdnLA21+qxPZmn00AP\nkzHl9FzjouVE+GlE//18LzZCKcnEK9Za9mHoCI0hc1DSS4ZSkgl0rDUWQhnDcU13k3eKQ+wnKnwN\nOkpJJmePtRY1pCG9XNiQZqjwNegAWV1c20C6NGvS/BuNWeKaLjOPy3b4Jyh8FTpISWbPH2tNUom5\nOaLbI+tB3uABxy0GQeGr0C8KH2N2+c6Blh8DYKxfZuV7Q18+wOVXMl1GC2T4e0PPZnMLZNXO/1oC\nUdxp5ptDnw9izC/CThof2v2bQ8/aZMLUfvGo90MY97n57tD3ne1vsvcN/TMXItH53dA/Aj3V+d3Q\nNehJHdV23ipPdX439C1OdntaR5WdN4tTnd8NfROUFKR1VNn5bXHQ+d3Q34IiwQG9z8m9JFTZVSkO\nOr8buoLKFIc6Gu+c98nbieKitfVoxPyGvgZoti3UUSpw6kma3ONh5k+J9JPmMFcsJkJh/JhIhQ6S\n70kM9JaT3/slsLlVz9hw5U9UR716shroYXI1mUc9Xj9p9p4/l3CFic5PhQ6S70n4GdYaDV+QHgD5\nUtkws5UNmP7EdZQ8inryycO9HWtt4odsG+LKVOenQUfJ9+QcsNaIBz89x71UNpAOa0kddepJkjaZ\nxzwydhIpKqNVa0G2pDo/DTpKvichYK2R2ojH69bbuYDt1FpaR5168sGJpZr43eein2QvW+LKNAQN\nOkq+J16x1qimMXTcS2WzNnfDfg5TWked1oCEfLQDDRTyY02vn7TFibrSFzqL9AN9/z9HMPkee8Ra\no2wuOhrAWxrzoixoXpp2NJcxH7pnTnMBB4mB52Xb1F6qeDGJssm3tG4lVle6bd6GCh2mJGOXWGvm\npoX16WutX3SKX1iVOcSNIE8S1jAScJ6cdnawVU8+eCycPmb6SSeuJH2CV1euaEKUmg47LQ4eaw0I\nve5Mn8RcQYE+cgM9JQMkfAZWPTlMQ0uLJBm6eXL6SSeuJOj2BcVRIRvgDwU6TL7HzrDWTHrhmr43\nvazoIl/TWHB6ttC5FxgpJB0wK+TrXEqXFsDrJ53OL1bi+EJnQ00vMPmeeARrGXHRVc0wcXAWOv//\n2Db0iV9j23AXhs7McwVBR8n3BDrWGv2vKOilsvwKmt70/xToNn90rG3quMNIZ+b6NF5cGdd0XygI\nzKeSXmDyPfGIEgO6+FH2Sk5TD8rhCnTbUo4GeuHztm8ro4bUd318oQtah/5baxmpqpvHAOdfKlty\nQ2r0GyP/duRzJb1Y9aTpL9Vyk2BQev2kE1fGNd0X7oAOku9Zj1hrBBzzUtm66Yu+qbOc+oKPij/z\ncpw6K1ANuFyuqIeXTIvNRV4/Gd0ceXWlLwxWtPQS9rzXDIGlepJ6rkE/uSyOCj3BG7pH8aWV9JGj\nHBLpJ5fFUaF3IND5BmvxW/I73SuBwFK4l+gn58VJIVl5yb0sJcaCF+ow3YtKYD5KQW0v31XZA+fF\nSSHt0wtr1c29Q0IgVU8Sxpg5Jfjk2cGsMBj6Hyubbdmjjw6lAAAAAElFTkSuQmCC\n",
        "prompt_number": 7,
        "text": [
-        "",
-        "\u23a1 2\u22c5f(r)                            \u23a4",
-        "\u23a2\u212f           0       0        0     \u23a5",
-        "\u23a2                                   \u23a5",
-        "\u23a2           2\u22c5g(r)                  \u23a5",
-        "\u23a2   0     -\u212f         0        0     \u23a5",
-        "\u23a2                                   \u23a5",
-        "\u23a2                     2             \u23a5",
-        "\u23a2   0        0      -r        0     \u23a5",
-        "\u23a2                                   \u23a5",
-        "\u23a2                          2    2   \u23a5",
-        "\u23a3   0        0       0   -r \u22c5sin (\u03b8)\u23a6"
+        "\u23a1 2\u22c5f(r)                            \u23a4\n",
+        "\u23a2\u212f           0       0        0     \u23a5\n",
+        "\u23a2                                   \u23a5\n",
+        "\u23a2           2\u22c5g(r)                  \u23a5\n",
+        "\u23a2   0     -\u212f         0        0     \u23a5\n",
+        "\u23a2                                   \u23a5\n",
+        "\u23a2                     2             \u23a5\n",
+        "\u23a2   0        0      -r        0     \u23a5\n",
+        "\u23a2                                   \u23a5\n",
+        "\u23a2                            2     2\u23a5\n",
+        "\u23a3   0        0       0   -sin (\u03b8)\u22c5r \u23a6"
        ]
       }
      ],
@@ -196,64 +226,74 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "Now we will calculate the components in the same basis of the Ricci tensor."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "ricci = metric_to_Ricci_components(metric)"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [],
      "prompt_number": 8
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
-      "# TODO: Fix the issue requiring this workaround (simplify unhappy about the fields)",
-      "diffgeom_simplify = lambda a: a.subs(zip(cs.coord_functions(), cs._dummies)).simplify().subs(zip(cs._dummies, cs.coord_functions()))",
-      "ricci = [[diffgeom_simplify(ricci[i][j])",
-      "            for j in range(4)] for i in range(4)]",
-      ""
+      "ricci = [[simplify(ricci[i][j])\n",
+      "            for j in range(4)] for i in range(4)]\n"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [],
      "prompt_number": 9
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "The diagonal components give the equations we are interested in."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "ricci[0][0]"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\left(\\boldsymbol{\\mathrm{r}}\\right)^{-1} \\left(\\left(\\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right)^{2} \\boldsymbol{\\mathrm{r}} - \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{g}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\boldsymbol{\\mathrm{r}} + 2 \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} + \\left. \\frac{\\partial^{2}}{\\partial^{2} \\xi_{1}}  \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\boldsymbol{\\mathrm{r}}\\right) e^{2 \\operatorname{f}{\\left (\\boldsymbol{\\mathrm{r}} \\right )} - 2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}$$"
+        "$$\\frac{1}{\\boldsymbol{\\mathrm{r}}} \\left(\\boldsymbol{\\mathrm{r}} \\left(\\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right)^{2} - \\boldsymbol{\\mathrm{r}} \\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\left. \\frac{d}{d \\xi_{1}} g{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} + \\boldsymbol{\\mathrm{r}} \\left. \\frac{d^{2}}{d \\xi_{1}^{2}}  f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} + 2 \\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right) e^{2 f{\\left (\\boldsymbol{\\mathrm{r}} \\right )} - 2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAA8cAAABMCAMAAAB3TjXuAAAAOVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACXHtMAAAAEnRSTlMAzRAi\nu5mrdu/dZjKJRFTz+71ileTvAAAACXBIWXMAAA7EAAAOxAGVKw4bAAATaklEQVR4Ae2d14KEKhKG\nzdrdtrvr+z/skiUUoRBa5xz7YsZA+PixJGPTRH7jN+Lguf0o8CigFOgndXing7m9E00ayzoOY5fm\n9HH1KFBYgWktHGCJ4D57XyKYn4axEuTpD75+firSE1ktBbrlhjXY1x1fLpEceBE7/ovvn0iyntt/\nRIH3crvK4Pr6I9rpmPR92O83fCnqkM/xP1eB9m5N5H5//1G1t/1278Q/quSDjVbgu3/Qfqp6GJaq\nwVcM/DVXDPwJ+lEgqEB7r96ZT7w4ni+3l+8ISLpCFwF3z6VHgQoKfPetQqjZQcaL4+0G7efBfZW8\nHzPOzvTHYwEFXjewC5WMfo91VvfLDRoCbj//l3B/b0CmlHwO/mUKvO/UzTpGx47v0Qr9LuYY96fd\ntm14+rn+ZbZzp+R2+3AfnD1WOVhv0pwfTY5lp7/76PiPJnnmzoHZO0TLQNBbjYvb7jY8jXiqjtFi\nqsXdvboVmEgYfkPVYic/ITg/d+4nmOdFRWJGjec8UWoIU+yVMtSsO6BGvFaU61QBTrm7nugnBOfn\nzv0E81RWMs9YzGhl9jxSYgh7BH2rOtodidxMQxerOpjOf3GG4q8C9BOC83PnfoJ5XmAsZhsrBc8j\nASG0bq/QtkcGb4KD3d9hiXgHKPRLON3W0tO3fsyvp1wen0XAKShjTf+v+M7NnauNyRKkWNOTZ7nE\nYq4XFC39AJjBFGl0xiaJRLxbMjmnON0qTCD9Kb+TfHbhHAJOQZggfFXwnRu1qI9ZQMumwWJ+drPz\nNaxkibvdME6AHb+Aa3p0U7hH+BvxrgcFHSN1C1YOoPBj137MD+GcREAqCBGErwm+k3PnqmOyRJzU\nEm/HzRUjJrNrdF2kedzt4UUdZ1dKIbN3Lt0c+TE/ZDEnEZAKQgTha5zv7Ny56pgsESe1zLDjtmr3\nEZwzgB1/IyPZsRkr7bnmMbYe00XnnsEp9179MT/EcRKhuoEwvtNz56pjMmlPaplhx2N8cQKU6aeu\nAXa8Rgxj8Fer+2mdP+fadnjd2nLPwyX8Zv6VQCgniMlGzxTf+blzNTEZuGJ1k4G4gsacIxVWRNzJ\nTgE7HiKvE38znk2ThHrOknGoQ6xua7FqzDX8hjhFELAKGgThk4Pv/Ny5ipgsEQdrOE2Ru2jM7wUj\nyIAdL2G7+HqL626hew9YUyUjIgG3sboVm0BzEb8uQRkErII6Qfi4DJ+Iox4mi6AUKxqzu6CjC7Dj\n3e360jN39S7oGJnH0/t6YXUrNjP9In5d3DIIWAV1gvBxGT4RRz1MFkEpVjzmjuh67Y+VPqkrlyEv\nrh33kbdJ6zXzhc7W7LxmHn5Cjrv/OQ7Tjha80mDAV/FrMGUQ0ApqBOHDMnwijnqYLIJSrHjMxWMD\n2sqSblzZGoZOWyD8gbbS0vwI2UAvrh1/I8NO3so/7zjeSC+YO0Us/HSYd/9rnsbPotPB40FQF5fx\nH3iFENAKHgTho0J8IpJqmCz8Yqx4zBbuYdJXlqzzyizYWGS7uksydD9CNtCLa8dvfz8WDaj3jkrx\ntUdD22xHVUFEjfqHLl1XWDZUpMTxZfwHaCEEtIIHQfioEJ+IpBomC78YKx5zgruQ9JUlLd/U9Wss\nLOzc5Ue6Hy4b7MW149VrqCycwOTrlkC9X1OjVRVEjqH+oXV7w7KhIqWOr+LXQMsgoBXUCMKHZfhE\nHPUwWQSlWPGYIzzwpK8sEY3TwSzyBqdA1v1w2SAv47Tsr8mslnsgZP7O/lng3TSvn36aw/tHq1ZA\nZ1S/3yoJaN2+sGySOPl/Gn8jE1CMXwNMQogBoEfuNIDIYRKfCAPGbE5kdATOup3IWgEzUBTylSXv\nYR+Z1bH9Oj77vk0LnSQJ710p/KzzTN1QL4cPjxfiZghbReZklW6cR/bu6VXd4W2+iyZpyGg77sMt\nAZKm8z/F36gEFONH0kUBKtpxHFUJ5cNs8jMaiL0fx8EtxQCH1qWqmKv/gRQrS958KcWH/9v29sOm\nXWzgjGfmh9rwQGZKci/KRwN7Ialtw6sWB09fnKWTfTqtG5/npdZJdispvvUiWa4SQdtxE+mZs1ly\nzhV/IxNQkB8HFAW41I6VUF7MJj+jHaE6+uD7R0Id9+pCVczZ2xcsV5aMfO7ylxdqH9KU7WktVpwr\nSnbA/PR0KGsgI1PcifIBe6H+2nBrM2+VNBmN6lh1e5aN5/c+zmY1Qt7KsGP/TFFTkuwzxd9IypL8\nKKw4QJYdd2btCIWkOVZC+TGVhPiMJhGZnBMrCPADj3UxvXasVpYMvC375eXvR5ocK2y3Qf5Y4rif\nN61O00Y196J8iPJZywF5+JKBygvm/8U7fGy6M8/oaBT7yQ0ugUlYnchXfPbmMZmE4TPF34gEFOUP\nx23djQNk2fFm9JxacaafKqH8mE1+RhMOk3NhDcwpPAMRoK+L+fZUEI+VJbT7ivw+sjwWpZuwax1Y\n+FmJxX+oZXAvhx0DXrj3l96RRRrU+2dulyOTI7NEdATtWC4e+zLdyQ1ocUPLJ7Tg7fiVPH/GTY8G\nGTiU/I1MQFH+QMTOrQSAAnacq1MjhQphNtkZTdQw7ZhPSsLbcV3MDTaSY2VJJwrDjpuDssq3rK2q\nbJd+aDN4oqU396J8NK4X4XfR7Zj2jK3rV5uqCSOqeMGD97S8JtYikO2DppUGrXkQN2vasZseLX7v\n4cHfyAQU5fdGfNzYSG/lRt/eCQAF7DhPp+YQKoQp04DPaJJ+0465QLGNLw4Z+VFtTMuOO5J3tJP3\nWFki33LNi1ad+9cutsKanKEe5Wec15Z3cRMvh4/G9SJSu5izKlrSZu959YU5yLFjUrMXBbpoF5Dq\nAW0eMy5RtyCBi048fPZiFm7b6RGpjvyT/I1MQFH+SOTk9kpMuGcdkAkAJeyYdJOY+R5nZC6kUCHM\n/IwmUQB27F+544Wui0nKPS3mL53L0RslrWoncxNQjmUPoLpgHPBPuKR6IYNZum+r+zpvLUcvGzAv\nGXY/0AKG2PM4qZJZfDIqx46d95ieBOPYSo9xz3ui+BuZgKL83njlDT6CyDImAaCQHedsB6GECmE2\n2RlN9ADs+MVbmVKshP+VMfX6KykEyWPejXJUldC1bzX01hjoG+/9AhLQkyr1Jqzc8cI+vsD/aF4n\ncziula8u7sTZ9EcLBDgU4R7dCsLgPrSqz3/HB98+/C32P3kn+T88Fta1L/VrlYxWeshmSqGfZFTv\nV9lBUZQ/RMBe7WzK/4f1AiQANHgFXfvA6ST1sTMazGdSGWO65mACdjwaD3ZUSxp1Zcxe3999Wt6k\n5sm6nsXTREowcUS6nzXTZYNo6o5x8GlJ1VyEkejFKY+PSEnQjh0b0flOZLdCI55CNQhLPDh2jC+P\nYTuGYeznE3ZlXVX8MgFycLQMvxWbc8o3KJ1ZxUUoGAJAlsdrS3+vhf1ThXCWTqqbK6iTtGNkRsOc\nDZvk5EgWvqDyM6RmJiaJmXQqHXYbnlbVbKqEaebDUxA/zUvMjuWrNxiVdXOQxZeobumTUA47Fq1/\nZPaSqKrbseIX9erC/JZazumblcR0Ng+ZlsdaJkEApB3z6Oz6aqIdW8vqlFAhTNnpj89ogmpzblQV\nbUUuT03kb2VM046NlnEErODtxW4fG+Vx3qaeatxKdH/MWlXosOMT/VyY9rGZniTlFL/o5yrMH2Pg\n1UCeL1zBIMAP7dheVqeECmGW7Of6sJfbjJzEUhnT6OdauB1nPHWxxyJ8/2X3V5sERldcOCR1l8ye\nEcd0OJv89B7Gw47FZDX8axrXX22mR4AF/x38DU9AYf5g5ORmR8tjsco6AeCHdmwtqzuECmE22RlN\ntDDL4/61rqvWVRpTkt+vjWnY8Uy7pzq+uCANr4wrw47pfAAyE0QLOWbH5iog7vHYClwOnK37Lnvw\nDjsWazLxdvwyCDVY59BNj+0kzC+rhGX5owxfMhVdtOmEgiGAAnacqhNtX2of33QyGsRssjOaCGXa\nccu7tdSQh60ksSCg0Vkb07DjZh7nt9ab5SLWueLZzEBG5pkDqT6jY60CYt7o6Kf40Rc4/fUrWTHJ\n3g/KjnthwDl2jKxXcQb9byp/IxJQlF+ABBnYYhfqMA5QwI51aYxjgFH7yJOb0YBOZCSGB4nPaOLP\ntGODTT8BOI/btTGteSBHxL88GsyBJjtq79wZ3nxzVgHRhVV8IgoLSY2Akxx5sQGxTWYn37AIv+8t\nnShjU2acp/E3RwLK8StaDwN936m6YBwgy4710QzFAx04jPIjT76MtnVq8jOa8ORzisT8ANM3vxqS\ns9q1IbxOYvDUYXldxV0F1LwGMYuUE8vtDEh1500ay/342ifWYu3kZBZp1+kpjNX1U0JK5W9EAkry\nSz4PA/ukpOpijQNk2bFkiP13GOUMTE9GOzo1JzI6BqfddzjlPfh5LIrpXe8kGX7xfwqvPx75+9gh\nYc03YBVQ8xYbCAgfcnl5T3Y3IOIdP2ng+Kew8y73PEKPHqXyy30ECvIrNg/DNhEN5UQ48urjrRQ/\nAF5BRRA/sBmP6gGc0Q6mfA/lVLzieMqFzalu/AAzsI+Awih4QDszzMVMNPDMfX3YZ3SgVUA2cA+3\n+Y92Nbo8pouqT/+S+Rs4ASf4FXsiQwygqh1bjMdSPJUKeQBjNiWEklEE/lucfpcVMMcSD6Sf2LlD\nDNlczERdzGGIza12H5/RgVYBObHGLqDteItMmYlFeDU/5SvKgFYwphC/DzDKZXVpAViuKmGW1TKn\n2jCdfCAtneKn0KIWsvVPyOPHYdQ+owOtAgoFBt5D7/sd2PoPjMC6eDk/4SnLgFbQUgQ+hRjVsjrY\nS/hqHczCWjYNHjPSxRRWJecutPjn49nMQITf2Wauf0YHWgWE5kLv+z16ut7SYr6en3RGa1/GKqAh\nWsEUpSDGFH9+N1UwS2vZNHjM1tOH5Jfi5B1oEm1sZeLLGuTRPqMDr27BMqKrW61FhIvwen7aJ0G7\n/NiXsUpoiFYwRTGYMcWnz00VzNJa5tSrI1869OmRfx2yYzKDOjirwi79tM/ogItw0HTo7D3XXX09\nP3lUaEcdHyEuoSFawZQ8ghmPXSBSwjDdVMEsrWWGHZOS0BiJMVNd4wy045eaDQ1GuZnzr7XP6MCL\ncMBAQhdl9sL92q5P0ih3LyZfuZ6fWjCdS09XQ3RFNBQKpgqYpBXIqO8CkRSK4Qib0YZn3wnISScd\n+TxEr6MxSfdxNNCyDkA7nkxDtWPszY4u7TM68CIc23/0XOjWfd/HmGnI03yqNXI9P7VjmlL2Zawi\nGnIFkwUMiavulWYkAWMzWrGEDspzojEjX0gL0WfeA+14jpRv2mZdNNrjMzrwKiA0GtdtS162OZ17\n+13OX15DpmC6gGk5VFwnYce358Q+j2Rf/DMVxLTc0F15FrV87B5p3Q85Xs32s/YZHXh1i+U9esp0\n69L7oJfgOFk0usv5CWFhBqogQsCoRMxBYUYSJjajL+JEYw6nKohpqUxxFane9+5MEBkqtLpF3kv+\nz3T7BLoKyPtHfNeKhvkNr+tIjpY6vILfBizAQBVMF9AGSDgvwEhiiWW0mc8JWI6TIpxozPTt1B3g\nohdiHMFZW87qFjQa043Mul/515/4LOyJ7R5F/5Dem+MrVSTwKWDx6LjdVVj4IJD8QARnNWQEyQIC\nAAmXJGN+/5GoV5uc/nxOYIKcSE6eK5CL2DUoP0OYeVvYxSgy7se+C/7213ndZSP4+Llu48g+2P5d\n5ZdktICOr1SRi0UbIxfwa+nih+cZmILJAjoACRcE46l+YGHHAU4jnxOoXCfntZTdcemYZ6cJu6nI\nvPINz7AmpuPtg3JXt+AZ2FM4qTFsufOAFtDxVQyy+NH/UtF8pB7+nt8lO89AFUwW0AVIuKIYT4zn\ncDsOcer5nAAFOFGcwL3US9Hn0cKcbtI8Jm+gSA8wWxCbKgPaHdWtP3r8uB0fFRmyWFkXrj3Xy4Wm\ni3vA8cfDw7sgBOkC4oPXfahdIPSLiceQUN58TgyzgjMsZsx6KiB6grSnbDnOxB6AzvUiF+hWfOxT\nRjy0cHn8LVoc/56/SIx2IETBZAFtv6jzYxcIlDfhOJrR+vs6J4IyfpCYfaw2W4YqJRR9IBh0/y7b\nt+TG0b0WuqUq/bl2rH2lqmmpyvf7JfPXQr8cIDFhIU49nxODq+UMgXluWlLZBEQ/DM2m9JeN0wrt\n3e58qrFrx5pLbY837eodDtP4K5JeDpCYtj/CmYyZspdGojSnnc3hKda0har6oU5H5gugp9ujfsjs\nssD0TLbezxfAxddT+KsiXg6QmLo/wpmGeY+2gFC+M+dQA/nxPjFuCAQHXHrTbfgiv6nAhj6RKLJv\np/BnB57i8XKAFEji5o9wJmLy5Z2JSa/uLE7Dv0teHSQYwZlBj2DAz81HgTwF4iVgXriZvvjqr6Dn\nNlDdDXosdrMHpogUC/wJ6FEgQ4H5Bw1ODNYc7ZHu9K/FYIIu5hb7lb1iET8BPQp4FFiOiQ8eFz++\nXHWI+MdpeaJ7FPiNAtUHZNHJuO+IDjopj4dHgd8o0BVce1eK+M59waXS+ITzKFBSgel2k4RJ6vgn\n5Usm8wnrUeCfrMD3Zp1cXOvPQlZ9Pb9HgUeBRAVeZOLSDX/f+nO2bpjqB+lRIE+B/pqR2P8DFo22\n0BqbFtkAAAAASUVORK5CYII=\n",
        "prompt_number": 10,
        "text": [
-        "",
-        "    \u239b                 2                                                       ",
-        " -1 \u239c\u239b d        \u239e\u2502          \u239b d        \u239e\u2502     \u239b d        \u239e\u2502           \u239b d     ",
-        "r  \u22c5\u239c\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502     \u22c5r - \u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u22c5\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502    \u22c5r + 2\u22c5\u239c\u2500\u2500\u2500(f(\u03be",
-        "    \u239c\u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r      \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r       \u239dd\u03be\u2081    ",
-        "    \u239d                                                                         ",
-        "",
-        "            \u239b  2        \u239e\u2502      \u239e                 ",
-        "   \u239e\u2502       \u239c d         \u239f\u2502      \u239f  2\u22c5f(r) - 2\u22c5g(r)",
-        "\u2081))\u239f\u2502     + \u239c\u2500\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u22c5r\u239f\u22c5\u212f               ",
-        "   \u23a0\u2502\u03be\u2081=r   \u239c   2       \u239f\u2502      \u239f                 ",
-        "            \u239dd\u03be\u2081        \u23a0\u2502\u03be\u2081=r  \u23a0                 "
+        "\u239b                   2                                             \u239b  2        \n",
+        "\u239c  \u239b d        \u239e\u2502          \u239b d        \u239e\u2502     \u239b d        \u239e\u2502         \u239c d         \n",
+        "\u239cr\u22c5\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502      - r\u22c5\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u22c5\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502     + r\u22c5\u239c\u2500\u2500\u2500\u2500(f(\u03be\u2081))\n",
+        "\u239c  \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r      \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r     \u239c   2       \n",
+        "\u239d                                                                 \u239dd\u03be\u2081        \n",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
+        "                                                             r                \n",
+        "\n",
+        "\u239e\u2502                          \u239e                 \n",
+        "\u239f\u2502         \u239b d        \u239e\u2502    \u239f  2\u22c5f(r) - 2\u22c5g(r)\n",
+        "\u239f\u2502     + 2\u22c5\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u239f\u22c5\u212f               \n",
+        "\u239f\u2502         \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r\u239f                 \n",
+        "\u23a0\u2502\u03be\u2081=r                      \u23a0                 \n",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
+        "                                              "
        ]
       }
      ],
@@ -261,30 +301,35 @@
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "ricci[1][1]"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$- \\left(\\boldsymbol{\\mathrm{r}}\\right)^{-1} \\left(\\left(\\left(\\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right)^{2} - \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{g}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} + \\left. \\frac{\\partial^{2}}{\\partial^{2} \\xi_{1}}  \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right) \\boldsymbol{\\mathrm{r}} - 2 \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{g}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right)$$"
+        "$$- \\left(\\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right)^{2} + \\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\left. \\frac{d}{d \\xi_{1}} g{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} - \\left. \\frac{d^{2}}{d \\xi_{1}^{2}}  f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} + \\frac{2}{\\boldsymbol{\\mathrm{r}}} \\left. \\frac{d}{d \\xi_{1}} g{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAv8AAABFCAMAAADq63kqAAAAOVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACXHtMAAAAEnRSTlMAEM3d\nMnZUIu+JRLtmq5nz+70bbQ4wAAAACXBIWXMAAA7EAAAOxAGVKw4bAAANoUlEQVR4Ae2d2QKjIBJF\n0SQu2WbG///YYd8LgSqTdLc+JKIIx0tFWSuM/Ynb+n68hz8R/GQ+FcArsM6MvUZ8OmcKpwJ/ogIX\nbv/XjX+c26nAP6jAcmds3vjHuZ0K/KMKTNvZAPhHi/68ba7A5XbKcCpwvAK3r9vZ/Z25yzV3MBPv\nPHQqgFFgumCuprn2kf4En6f502h7plJUYF6uxfMfOTmI9m6w3VfG7j9AFkCdgb9Pgd+oZd+XsK/z\nOk7T9Djbv3+fvf3YHa0/Msj0DjmWTWw/ptWfhHOOn1eV1qF97C3Vl2GbqoCPidRCeggBNQB6/Jwa\niFw1GsDHgxzMJbi43f29tSn2fnpNMb6ZtwSlBkCPn1MDNRVHTWQSwGmj+RnlgZsQhy3tA8one8DR\nJtID8mfUAOjxc2ogctFIAMew1h1C3h8Lrg+yDXHtHu5FgxKYH5KhTaqwnKKQJUGNn+OA5vf78Sg/\nWi1mhF8bxAGqXK7bs5gdsk7ehjjvwJRIkaAE9s8YiqFNqpIU/JwmQfXsoYCGF6dY96ZvoQQjKbJX\nuYfl3v1EVgXUqGHxZVQsciwohZg4hkapatTAjZ+jgF6y43opp4ETjKLIhk38TuFtRY4Ml+8/yffW\nPd8ZC0ohJo6hUapEO/+AIkGOn6OAFmk4r3LjEicYRZE9d95QI67634o4bHzMt2vDgraS5iBxDChz\ni3AkCXb8HAU0yorDjv3jBKMosgdc/Zlf6+2Kq6CxZsSxQ3QS0GbS0OIIGDruPGRQIUuCHj8nALqA\n1WeLmbuHymMEgBvY+yOnIzxA/oMQ1/ILM5crDSjO/ikYCEqTy+NI0OPneKA7+Dp3mLkirTx2JOCw\niH6haEpCJZcXrRVxah4CIAJF2T8JQ6tUnspul4REJ4cHukBDqzSYeEC4g+otn/yX3uq4KZFWxGGD\nJDMpxt9EoCj7J2FolSoWQoZJSHTKaKA3WJY0mGhAplopOSUXwT7stI5zF4bH/hMG90M7PWZpAkSg\nrJnUQyFhwABYFhISnRoW6AZ3LdJgYgH5MAnUvak6YibeOsZNQP6vLZnKnVdjDygVKGsmdTdEw4AA\nsCg0JDo5JNAkug7ncE67TpkIEwko3CtAbyg1F/Mxsil7A1bwvZ3mV9TaOARMBYqp/9AwNEuV0Z6G\nRCeMA7rKnvNb1nyIMHGA/C6nDezeH/lUtOflxZANgGbEJ9hlkClucYgIFGP/NAzNUuUEoVJDpI0C\nmi/rur5fQP2CBhMFKO7wBve2DK/bep1ft3hRorjM26569tAQVJOedt5TM+J9Z0Day1vtokAZgtQj\nqWIgl8oDsLtVJDr2oUCjXL0E1a/rMA8FFCK8GysbWrjhfXur99ps6k/P8D33Mj+AZvuf4REJnXvL\nlyWFQFk/aQsHjwsRfAxA8VpFfgUIlvF4xR59/TuvddLjwqN+7A8rf134rwAzrNZs/2xrvwSW0JKC\noKyfFM42dwYk+BSAgrKKsB8Bymmljh0PODZ2tigu3is6qGrRTbcOntv7FroQMmfajRla8juEbxhY\nNu+MJTU4KSgzp9pJvYz2d002KYE5czCAQrSK2PumA+opoYJwRhc6wCSzpWt6g+gVVZv22JAZtB10\nabYXKsQ0dawNs6QwKOsnNSpUfcMEHwJQlFYRRg/UU0IF7egBk8ygZ20SMThgZ63edes+N2ltVGvZ\n2+3/AryTetQ1pCVQ1k0aiLITKBF8BEDzGUXYAUA9JQTLdgBgklmP/T9fy+Wluk3N8oox08ulz33T\n/h1pCZR1kyZypgem9XabRB9BieBIgBDJKXIEEIn9f1SxHvvng8amJvLQnZ9XUf2X+1fTH8SeqlnX\nbv8jMAO0R11DWgLtJw1tKxdauRyzHGMpEXRLlcty55hRhB0A1FNCMe5HFRu67H+2BnrR/nrmh3jM\n8X+r8MY7tEvRHvvPDzl0qGtJS6CsmzQuuySsVp/LrrISwXEACZFVhB0A1FFCMeBRig3jxW6j6Zvn\n09ti81SDFtCnovWaUMpSr26ek3Oke1WN5P/Fd7gbhvpkQ3UhRHVcZ2JJtWvRLCj/jxkZvZl0H0HO\n8lJ/YVMiaAbIlmYZR3dZWEUYKZDS2y8hj8aVuHcwsyviHaWYY/D3Uvv3z0L7tgllNDT9tPyCxP7j\nHxiUqDue2v86iu2yyC9wwoZLwe5ZUl3YWVBj/+2kNh9gR7nWuMnGUYlA2z89QMplFaEtu+4Sigg/\nrFhf/edhH/fqHTrZsG//uvneXqip/SuR/KdLJBsUtKQlUNMT0k4KZWuOP2VP1kP+YksE3VKZjArf\nkQ9Qq4iu/5CWXUcJReSfVqyr/r+Y5q9uQ91sm9e3/+5G3QiMSXeoa0lVYy8Pelz7V1U21Eh5iaBb\nqsh6MsHYB6hV5Iiy6yihCPnTivXYv7cmZpVPfn+Rp6v/vFVFpf2pStf/40hLoKybNCq8JDiI579e\nz1AiOAyA/38UJ/D+Q9Mpwg4Awtv/pxXbtf9wWqcsYc9nkX5xr9v21m1qZ/+jahu32//Fdi+FBlVW\nNwPKHGkJlHWThnwsRbjzSVG6xl0ioAIIeSSOaHZ4/r2dIqbWR1l25RIK6WTo64pBcw2sY8ZoWqeg\nFj20ZhOPF77N67Jd5C/A2v+sDb/H/vMTfbLqlkB9UhiU9ZMqFYoIjKnqv3oSU0ulAMLPFMfzAXps\n2WVLKKSToRQxiPRBxWD3LKrWmkzr5O2lUQ96CWbnYGy6yPGuydj7qhsJJhzcYTGw2NlFYbS7l693\nBgBlISkMyvpJDQWEIJ4ItsYBE+ABDIj6jnGMD9BQkQPKDiihkE6GYkQT5dOKPYC6hq46pDPvLo8h\nmOvwUM9qPvP5ydsC8/uyvaThD/2TenfrZEYs+a3e6Ckoi0ghUIYg1SAQgnRm7TpcIAI8QCBIUnRm\n5kWsCPsUUIgnQj+j2Fv9EFNCWWvNTOt8moUv+hK9RGG+3ZS/U5OS1rZjDd0ALRkySYffECiLSCFQ\nYwUdpAYEQphenMH9ow1E0C+VAQi/Ixz33okUMetfCMsuBIFDEaKN+HHFwPWP0jFjblqnZdU7c7ZW\n4poNzfWfK7gkP85ahpGgDEFqeGoRyKUyAOF3iFPyAXok0JUP8F5vo+tv9SFDRP9MuH8koMxpyiw2\nd44Zc9M6Q8D9ULP9T9Xrf2lBu1Z7kyI0S5Won+KgfICigPgPYF3vW7zAJEVM7qL+AApQZHNNjc1z\nzJib1lkPp2I2uygCX0lxzsSgPf6vaBGapapQBOUDFAc08orsrLygO9AfU2xIFpv7jhlz0zrdrdTt\nNbsoekNN8ig/atAO/1fECM1SVSgSRWkL4oDGjG+dH1OM90rHnY2eY8b8bMk2CdtrFWNMBGRIDdpO\nyr1niBX/0kUqhVbYt3keB5Cv5jAOaLRLDVxeeUQ7aOQi1u3hAEUeydPWc8yYny1ZR2ZjNSPWdv9Q\ng3bYPzFCs1RWZLWTx3ErkqLo+0EcUM7+84hftP8pcgDkOWbMTw3cVy2MYTTMdhOFUWWItzkyR9ND\n5KDW/mtJ+dCW8H4hpmwNJFq1ShWJksXxVyRF8feDOKCM/WcR/UmT+0xBDBygSGqOGsCeY0ZgtmQA\nsB/QiMP96XrCS1fdoBGJ6CJyUGP/1aTc/sUtSRepJFq1SvV7igREWfv/KcUEbtxAd44Z89M6g1us\nCKhCnaq9iO78HaXLkRpU2389qe95lESrVqmcFmrvBxTxkTL27/lJ/QnFOO4aeRvxHDNmpwb6d1iz\nLwt1qOzT4QkuZuLEXuLUoMr+G0h5tce5SKXQqlWqWCFiHD0i3qSIQxLjX3wEzB2Qe8SIWMU405wZ\nATPQmWmd5lT1t0S8xqMg3uVcqOm1mCVk90yngRcZ2KUAVfZfIA1BYxIChEapYoIgTICj7b+gCB8+\n8ssuANgPECBSKFYe5I2nde7fVhRDIvKpV6vyDqpmCb3kSl7xwRub0zZe7d/svQq/lCjlMIgG1fWf\nkBQGDXOXISxCo1QZguCQwQnmKwYx9gLEQGl2BlFllJ7fO0IB+ExeUi7XZFqnO1W7pxDf71W0AO6r\n9mnnXy0m/MzG5Ull749/vdgnANX2XyANQGMCAoRGqRKC4IBWBNG5op//fHlcZdkF+VcE8IVGolip\nAhRP66y4qyiKRHzZFS16HYof6eoBlH6M/jXxfjKHMY5QEd4l9UHT9PAIuwC8vlHdj2BxujvXtf1X\nl10qyc4Ri7gTDz5Nopicpg7ngTwjEGfXpa/s31Ur+GIBv1DH2tYvkip3eY4UBM0lgD2WA2BoArsi\nqR3vGKB2DvAKGsCl+qECgsAnRMNWOsBUUcrP/3uhLgZnQXRml9T/oRLlGSSzCxA8KoJLwYBbkQRG\ngU8cAQTn1nGGBvDZ2+asJR4ui/DDIbbU/ufLtpj3wyhu6JtbidQHPYyxBMA+QhDd2s8BRXyMABD9\nJ9cxUxJ+jpuaTZTavxfXW6jtHf3sbh3pgUxfB4jv7eeAyAE9BzFx2mThWTj5uN42b0FgkvZSPfUm\nuZTwQA0pYXZpUl8HiJF+Doga8NnfRxyjAOGnWB6/s708xyo7UQ88XUN6YPbckUCFVIcCxIn/HBA9\noP4/izjhj4YRHXUf5Twz+wsV0H/B88U7mzNDY1/EObP+pxQY4plKH7/72Y6RfTzrM8O/XYH/A61h\niJXg9gmbAAAAAElFTkSuQmCC\n",
        "prompt_number": 11,
        "text": [
-        "",
-        "     \u239b\u239b                 2                                         \u239b  2        ",
-        "  -1 \u239c\u239c\u239b d        \u239e\u2502        \u239b d        \u239e\u2502     \u239b d        \u239e\u2502       \u239c d         ",
-        "-r  \u22c5\u239c\u239c\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502      - \u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u22c5\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502     + \u239c\u2500\u2500\u2500\u2500(f(\u03be\u2081))",
-        "     \u239c\u239c\u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r    \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r   \u239c   2       ",
-        "     \u239d\u239d                                                           \u239dd\u03be\u2081        ",
-        "",
-        "\u239e\u2502    \u239e                        \u239e",
-        "\u239f\u2502    \u239f       \u239b d        \u239e\u2502    \u239f",
-        "\u239f\u2502    \u239f\u22c5r - 2\u22c5\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502    \u239f",
-        "\u239f\u2502    \u239f       \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r\u239f",
-        "\u23a0\u2502\u03be\u2081=r\u23a0                        \u23a0"
+        "                                                                              \n",
+        "                   2                                         \u239b  2        \u239e\u2502   \n",
+        "  \u239b d        \u239e\u2502        \u239b d        \u239e\u2502     \u239b d        \u239e\u2502       \u239c d         \u239f\u2502   \n",
+        "- \u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502      + \u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u22c5\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502     - \u239c\u2500\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502   \n",
+        "  \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r    \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r   \u239c   2       \u239f\u2502   \n",
+        "                                                             \u239dd\u03be\u2081        \u23a0\u2502\u03be\u2081=\n",
+        "\n",
+        "      \u239b d        \u239e\u2502    \n",
+        "    2\u22c5\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502    \n",
+        "      \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r\n",
+        "  + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
+        "             r         \n",
+        "r                      "
        ]
       }
      ],
@@ -292,22 +337,25 @@
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "ricci[2][2]"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\left(- \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\boldsymbol{\\mathrm{r}} + \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{g}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\boldsymbol{\\mathrm{r}} -1 + e^{2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}\\right) e^{- 2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}$$"
+        "$$\\left(e^{2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} - \\boldsymbol{\\mathrm{r}} \\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} + \\boldsymbol{\\mathrm{r}} \\left. \\frac{d}{d \\xi_{1}} g{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} - 1\\right) e^{- 2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAfsAAAA/CAMAAADQW5H2AAAAOVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACXHtMAAAAEnRSTlMAdlTd\nIu8yic1Eu2arEJm98/tBGNu2AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAJ40lEQVR4Ae1ciZKtKAx1\nQXHDN+P/f+ywBUFQWcLtfjXXqm4VIRxyWEKA2zTmalvz+H34jRqY91qour6W5K9cJA0slVonGUYk\nhF8xtTTAhrmK6L5SnaoC9v8qdB5IhaLTqYLQr0hsDewVaCJHnd4Eu+y2vL9ijEIGyY7OVgHK87Kg\niPmokOGjuWVmhg2SYgtsugO5fmZqKikZuhaSco+MjA2SHdh22VRhGHlTzrwMZfNVbLUGAZeiRAdJ\nDxYEmhs4Hmtu0pJ0hWMXulrDZSlDiQ6SIHO1HeFi1w2dC2swulqDxS1EiQ8St49mxxYsduVAWuhI\nxFdrqMCFKPFBtgfmHH/9mQneVDbcN/hqDXFfiBIfJDtoCGdm2PLxLp9stB3LBtKmPvcYKPG5byZM\nmcenrXzpmlwKh/vq3KOgxORJN22KOCGfUTuRiL6HDWJaUeyerKBWGzwOygogO8QpPo0d7ollZJS4\nFnfZ4vvSYauCWm3ucVBWAMmOTCdsgL8p3PnSfdkdNwKzyRoLPAKDwM5ia5zNh/NcQa22fByUNUAO\nUUKj+DuCcy3KG/nmGAKLUxNothdYGaodNzAdgbbeo57/RMXKjYSEsgbILWaWF8UfCXchPed+tDOZ\nXUcyy+x4RIsXA8YyNZ01hmRQFFX7M+SqJEgoa4CkMa69KP66IzjPFltEnJXd5cLUkt3wJ16L1n5r\n7DEkg6MaarVg4KCsAXKNMc6j+GvvzcZOWgIrbVvu+JMjw3gc3TZIN2D+1k62tXQkW/uyZQBMCuYM\nDaupcjXUanEfhRIwNp8EOcf6YV/52+97ELmPS/C+7M2oxv7umEY1M++qOILZ3u6qgyEwqKxuh7MB\n+ZW5t6rB7aPB2FQGOdn1n8Q6ZF75W24NbioGAyLG/KVrZkXFyK0DIhusDrjVS96HjXba3wfFZZR3\nE3bRwQD9BdwDxqYuSHLxgx1xRX/nb7INOpuwVdoBq+jred8/q2Y+mrFGdwR2ivJnPvNjaihotTWw\nHnvrDi/wJU4BF0zM7UQuXxNfAUmDDNKFwZZ9c6fhR9gJ3y1wyaYSwd/gyjX5zlz589hQzvnI1TxC\nuwcLTVcGEx/lQcz81KV3pAacWEyTnsV9585WILe8O+yaxQbpoWldju4oc9LF8HdTicap6zo+pRfD\n+sb/mPICnO1+hUrg5KhfuE14jO00pGrarJjO2ukQWriYlFMRgftcmKqUgDG4ulIC0tPohfv+rqu2\nEkbxd+GecateWFsDZ09+2ls6CSdeLzoS0h+w02p7NNO5VimdD7e+WtCCj+s29JuaccqxikeadB2w\n4+tvCNxzD0YGzI6rqOPdIGBEB2kXVj4/cw+UOcmi+HO5n4VPgFyatDyy0168uGByOTmeLxN3F5Ih\nwNwZJfBk5puLzm0Uw7181oMOT7SqrDG4bzJgUk47EU4RwMhrEC5ITzEX7idnJS9ImSPijj/mcE8G\n3p+yHaZRvJC8u++UrtWAD0K7S1WAcLhPYZcRfA7fiSlUrxeLyCIaGTc39s3UI31yEIl71c+E8YRC\n1aRZTEYAY4MN0svW497qcz3KnNSP/DFnwrANK29m1oxqnPgQoN5nm23G6wRcbOrNNUG1mUwT1tHk\nGHL7T0WyTD1VuvHM5jwrOiqD8B/IP+V+tfWuMG8Byg8iJ7nGI73dcDoOEWRQlU1z4d6ZlnuUOep4\n5M/l/tFj1AGvXHpr1Q8nM3i5KhXCH+/G1Gu0Xs0Emvc+pt1r7v99FOV9pJO4+kHeTGNPhqn2NLcC\nDHCPCNJDrQKeuH+kzJHn8ef2+Wb27iTKeUlWqshkMc1c9ae27/DkXtvXSH1+4lRklTY2d3SaPh8f\npKfvR+4vxpmX+CHAGe8HJShRHyHpWdyfc0JlR7WWjXFyj2vrJZZVDUtqKVINgvggPX1euJ9sV2wJ\nZQ73rTDrmPaoexBSAnK4t/ZzCJcS9y1Z/dDJ/a567J9p90y0e7WCrjBWAOnp2ePeHn0LKHO4b9q9\nXW2bzoMRFyCcJty78xTZXfmSMa1zELpfp8cBk46T+0nZgQjcv8P0Uc58eUHZJeDbQQd5Udu+DUe/\nWaz0jmYLKItyEF7QFLyaA26XlS8hUsyc4RJ+Bn4Rysst65DhnmjSEbiHzLz7E0oeWQ73fMBXGNFB\nenAuATF+vUuS8Guf5nsLC0kJVet03soXN5mk/1CLUisR4qXrpX+hA66pHqHhPSXvxpmoPqW8QdmI\neghj04kRF+QTLvFtMKsebzFfvi9OB/ISGeGz6tj9la9+0UsGOg+9T4jPJVc+9pO9PzZJOlOeJq4B\nBDC3Iu5QymOwZjoCe5k+DNIdpm/L8P5hVzX8PSJSDDlWBla+Vti0ofPR+yII3zTk+BJA33W5v0PZ\nbRyn9jnyGqkHqc+CZOHdtRn8POzZypD2nkQecAstz12TEsu6Ob+dZkLVdh+JMozR2sVTA6TYP4Nz\nddY8CkfirZTzgFtoee422c2HGmoVWaGirAGyi3fl3agOgkc0SSDx7m4dcDtXvu4iv4dn+fPfxeKi\nrAESr6dmsTv/3tX2HMM+4AYrX2Y/0HPS4NdEf35Qhh+IjLIGyB3POu+xZgy+Ip0Q64CbWfmyl2ad\nyBEvNbpTfkRUTnnlYUEMlDVATniEIVajR8asA27Bla/HxIGPNdSql2jVBB4DZQ2QaGY+953cb9AP\naDw7yDrgFl75SpUMag1OB1KFQXxslBVAclsJ0BbfyWeMPeuAW3jlK7UgWq1sXs18O1WEHx8bZQWQ\nLaZDJnlXna+ymJDzgFt4eS5Ghh1HqbUrWL62pcEzMsoKIFF/FY1GbPkF1RTcrQNuwZWvVNFSrQzP\n5lX5I6OsAHIAp3aqwkLxyee8O5B9YHkOPkXfpVrHh5UovkILB0ejhToREVDig5yvGyEdyMkvGF62\n5Exhec5sw0uVINXa9AtVp/WU13+T2/HEP24CngdHU2Wb+KUo8UFezmcZpJkPK3bH+Y5Dr3xxfpR2\n3lN4MVTCfadixJ8pHJCy4p0HR63AlMdylPggEa18qYof6PTV8ty5NJtCiYor1brp7RPnRgpL0HmA\nzApMedTrcwUo0UGit1PsH2dO0W92XKFWck511Saas8/ni/3F3GdjMwnRQeL+nK7AqTd7Gsh/w4PY\nzSmOxekLNlDBO7//Au6xQc74w/P6YC5byvx1j6wfxA9Kicvn3jo4qqL80H9MkJPcv4xbkOJfOsSF\nEy9tnQ7ld/e5jxdSOyYaSHUYEBmu83NqyLIriyNiz/bYHudWqsoZ5ohHAil/jTYn/8c08rdVHmP8\n0o+r2Mr52y8kkNtp3qCWWP/oAarMrzBUDZgjCqhShTD9KyHocr8CkTRAAu4rJNHs8QgVUiZfMfka\nsH8HO1/KmfI/H2lQy4ZnQV8AAAAASUVORK5CYII=\n",
        "prompt_number": 12,
        "text": [
-        "",
-        "\u239b  \u239b d        \u239e\u2502         \u239b d        \u239e\u2502              2\u22c5g(r)\u239e  -2\u22c5g(r)",
-        "\u239c- \u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u22c5r + \u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502    \u22c5r - 1 + \u212f      \u239f\u22c5\u212f       ",
-        "\u239d  \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r     \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r                \u23a0         "
+        "\u239b 2\u22c5g(r)     \u239b d        \u239e\u2502         \u239b d        \u239e\u2502        \u239e  -2\u22c5g(r)\n",
+        "\u239c\u212f       - r\u22c5\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502     + r\u22c5\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502     - 1\u239f\u22c5\u212f       \n",
+        "\u239d            \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r     \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r    \u23a0         "
        ]
       }
      ],
@@ -315,22 +363,25 @@
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "ricci[3][3]"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\sin^{2}{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )} \\left(- \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\boldsymbol{\\mathrm{r}} + \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{g}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} \\boldsymbol{\\mathrm{r}} -1 + e^{2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}\\right) e^{- 2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}$$"
+        "$$\\left(e^{2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} - \\boldsymbol{\\mathrm{r}} \\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} + \\boldsymbol{\\mathrm{r}} \\left. \\frac{d}{d \\xi_{1}} g{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} - 1\\right) e^{- 2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} \\sin^{2}{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )}$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAkEAAAA/CAMAAADQbewHAAAAOVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACXHtMAAAAEnRSTlMAdlTd\nIu8yic1Eu2arEJnz+71sehXRAAAACXBIWXMAAA7EAAAOxAGVKw4bAAALw0lEQVR4Ae1dibKlIA51\nxw1nxv//2EkCCAgqClztqmdVv4uIeMKJIQSwi2I7ynJL/iW+2ALD8kVUGlNV6/Rf6pMtMH76HW/a\n7pOt9gdKtwBvB33yuVT9af3+XHO9A2hom3ceHPBU1gcU+ivydgssn6WpWb9sH9/m7TvP52v1HTAW\nknG0Tv+Jk3/Cb0sNkrXf5KZaU0v6Azk/2pa25KlB8vWb/mr/2e7V5sM6S02OVXmqk+Qg2cpTYUtY\nT7dOCWsLrGoY27gIWXJyfMBjUSYH2bzBla9lrLx5tU5/dRLpFSYnxy93HMr0IL/YX/B19jde3twh\n0h6nJ8cnbyTK9CDL9XsxoemdoTyLnEZJT45PgyJRpgfJV+bD+Wre+E4n1se5QUV6cnwsRKLMALLP\nUKdP8ht5689HYs3Myi7OwSjya1AKlBnYZp8LvQw/N4s0vTNGukHZNSgJygwaVH0uJMRC3aDGcOFi\nguu8xeBB9BRPBnJMw50GZQaQfH04gWDwF0Of2Ugi3fuNAVvGxQpecdOD6yIiSAs9sDarc1Fd52Qg\nx3xoGpQ5QLZBlZ7yF0afU4XZPkZ69Y6JGBic2XKQRkuf2PN5kBbfIR5q+QykdvI/9mnqszQoc4Cc\nQ8bzF/yF0OdW4W/jxm8Ua9CgzoQ62BMy/KEpRd1B61PBANBSST+6k9z/nlyLv5QIZQ6QLCQsfcFf\nCH1OFQetWq3eUTUuh7PWfIyGF4RVjU+NkFihMPZFtavxAOBRdpAtP7r5Mj8Ryhwgp5ChzxV/AfQ5\nVRw0Wnns2lfksEysLCFoTX1dt67V3FII+/nC/B6s2VTPRaQjlIMco43SoMwBcgidQzjjL5A+UYXR\nLJTspsnoP5Zjm0grX1F7xqXohE9UrX0nxuHV46kQPpesa+byYlGb8va4ARZUbzN9OcgxmioIpR9j\nZpBNaADvjL9A+qzFz0rauZ1mXFYvuRgPXVqG3VuDvtBYFYPwezrwmhqiXmYYbZ4iyZdyEZ1boxyt\nye7sZqVCmTUoRJojjEVqkL31Fq1hop/y59DXtbajS/JTFaolpLS8h5AmJy0WYvamu6wK4+9E/tGE\nvRf0ZoMwOd3WB0ujZN6RID2zSsaqVaNxBibLbEA1QAxrxgSYjqs4xFgkBdnsoq+rfxqqGtVBzXXO\nn0OfZlbLK6pQ51LahRznljwcElMkVSn9O4CbMnQFA83pgKxO2SDlvUiV0jekSMEYn4vOrZTPmdal\ntPtsdeWRBnHboMVhVkhcjIW69AikjYqPy0x0bdlHlG0FMHHBXwh9sgpZrRRpWMnkrDS3QnkHCt31\nVVVBCAj7yxn+cRE10po6KVWycEee4BhfHHJfiyeEzyUrj8ipPKZaPfL27zHGIgqkA6S0Nag+6jaM\nG6/4C6BPVSFrldLO1H/xlZwfEvNAg9oVD7h5KVmPAegaTWNTr2pl4XzmCMOYbe3K3te1Sjz+n20t\nxSDDnL6J6F7E5BNo0FOYAvwZxiIGpNM2DzToij+HvqZTDqZ6/FYFZShpV/JjoOXImqOYOw3iMHaX\nvqyqqaDtrOVuHkP19FspKwFPYAwMnunAWAV8J+Dh17OITikXrpeaZBaX1xJoEMRMH8CsoIkq6NTP\nMKqLj0CawlJ6p0HoyhqHjzLjMqxiwOI7/jb6urIqy74AXwv9lb5dOgjeeCy1lHYSxqeUagO5YI7M\npw0YiGx0B9VAtZV4mhobieLVTqHMSjDdw2RJ03r43xe0zrfY1Cir79ANorR0xKD4JPA8Imffiz2A\nyaAhGvQmzzBGgbSaBE8cDTLt/54y6+4j/jb6RHAaeRqBauANN+fTANyqZ5N2pr4J/ghqgQtuDQ2b\nFqwSX7SKdz2YJGFIBlNnOD1u9xDztPeHus0ibrrZXq5azh43I77w8HIs86aN8hsRiTRI2DwXy1GO\niLHhgPEMYxED0nn0ToOsAIxDmXX3AX+avqFFdtFkCA0aqVk9MUIpbb/2DRyiLwPrUu80CGJF8Mof\ndD2VVqyiNMrwvt6OXpXpN3MiJVK66/8VhQxHWrxlnVZU/W2RTljN/8mKb/24Nsg22H50KhcfRTOu\nNGMov4PgxQj9I+G6CdLblI4NsjTolDKrbQz+DPrqdSzJpZEaRAZ+Tx7KLRhplRskiAYx7V4sNF5u\nIfOeOBrkLbXL3BxphVcFXKCco0E3bRDr8ahb+tkMz22YYmdUiQZRtqkXo9KgmyB37aFOz2xQLGWc\n9Sv1F1KDyFk51iCY1gJUTIXF8UWx/KAtXqiwP/69TQ0+SQiBKWEzzdC71iA5KnhEzpUNwmefHhON\nQWCa5xxjEQPSAbDToN6cRoikjJad0V6LCw2SvVhLjkarEKCYlga1woe2LbsjUEjGIw3So3/hpZaG\n9641KK0nfVNW0dHSi3iGMbMnrXwFYCKSsooYn8HHvdAgOW4YUYPKzclFLiwNgmEdetIJArdPNMhY\ndYahcIirGi+Y1qBF9EHv2CCONkis8TrDWMSARNGtY2eD6m3AAaUiKavIk8alO+LrG+KvpxcT0kLv\nzICWzT1FMe0QebmUkznmsgQJP8FQnYh7H95jT7lTMWN3n+wEGHTR8n3TGtRLn+6w6pMLdi92DdNF\nOcA0nfDXzjAWMSB3+Je5XWu0EuqwY9JxlA1sKic2FB0M02dOf7tqXMUKHvVA/JXSFkNfU4RZXEMx\n63tRP7PSJ+ltI/puyh3rwkiLOjAuBUfDoPVIhzYNaqTxSWKD1ON2v2cooSi5QdB0hxghFCZqfARy\nB8Y5ba0QnnM5U4aU1qqdxKSOzcrOfCLm3p0pd/CaDd2WKwMQSlXTALNSZDDpuajzW3CtoNbZnQco\nC9Rm1dvqqes9xiIK5BkuvGY5HleFk13X0uoqScxFtJXOzZwSXZU7nV2PcvJWPl+uqoW40wS9brPU\nq4i1c9InKPRIg0KFO0JJH1/ZhoxHGIusILl/b0SoaI/L7dc5w6tEXJyscn38rLMbyYfwTLlPu+k4\nuZ6pgVkaI3oJPYjoOjJr0BHKagacMl4Oei26XQdjXpC4yu+NY1tPtz1ccFEZ453tUsYEbUT3Tbnv\nn9kYvqO+pt2nrDYoEKUfY5EXZKWHQrpdfpHaSyvF7H6HR29E9025322DXBqUFGUOkL/uNa6IESte\nr0qluG5sRPdNud99RI7NfIAhLcocIBczHHS31XKUr380NjQ3ovum3O/KlmMzHziHxqb+BChzgOx/\nRFgwIb9SaWMjun86OxixKJijg4AlmRQeo039KVDmAPnSUOyYnsqzGOS49PMrxkZ0/3T2zapzkAMj\nPBzniIBPCpQZQIIHcLOlchdvfuNKGxvR/VPud+VU5HiHbHcrU+VTo8wAsvxxAE81zcnv7bWoJ3Ud\nXzI2ovun3I9v9V+R5PBh2uIz/oJ3clOjzADypS/vnrUiC9g8cnZ/4DW9Ed0/5R5YzVZMkCNWJ2yZ\n0YnEKDOAbFVQPlrWZBU0v4kpGhvRvVPud+UhcnjqkW1ilOlBDp6VF3ebLnn5FPG9e6A8U+73KoDS\nRE53srIA1m6oD43crpxuSIDyCuR9jLv9q88kS33XlPpFDgHoTGeH3GSWIXKKemRiV72YPZtpGTT+\nAQdbf2jEvO9WOhalD2Qcxs+NxKg9f9ONmdQ5U+7mxbC0IGdZGK7THJjnv//THxoJq9EpFY/yEuRd\njK+87U7DOBm//w9j3OlsB9RVBpEzq5l6tdzLvEtv8jdzb6TjUV6CvIvxi/+tBraoXK59o3HfL4rk\nNDq4JpbQ6R4C1qHdZSeDTD6QMRiHNxyOkHaZThzSkPvfKIOrvXH7ujw8izA/oEGXIG9i7Lc17kru\nr/xGf935HUF43eI3a/FwNcj40Igo8tLfM5A3Mfo/a/iSXPZjrQ//2pe+fTbBRm5aw+hq0HeAJwNJ\nCwe+I5eFhL52Z+X8KycN7jjpYBNcwsmN5LKnATnrTjs5wvgK5Yd74iv6cQ0TLsT/+pEG5Lbh6aPi\nyq9ufRTdHyzYg7aFLr7ZGlxuDv0muj9UhfF/83yoNf4PrtJeNRRCo24AAAAASUVORK5CYII=\n",
        "prompt_number": 13,
        "text": [
-        "",
-        "   2    \u239b  \u239b d        \u239e\u2502         \u239b d        \u239e\u2502              2\u22c5g(r)\u239e  -2\u22c5g(r)",
-        "sin (\u03b8)\u22c5\u239c- \u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u22c5r + \u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502    \u22c5r - 1 + \u212f      \u239f\u22c5\u212f       ",
-        "        \u239d  \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r     \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r                \u23a0         "
+        "\u239b 2\u22c5g(r)     \u239b d        \u239e\u2502         \u239b d        \u239e\u2502        \u239e  -2\u22c5g(r)    2   \n",
+        "\u239c\u212f       - r\u22c5\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502     + r\u22c5\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502     - 1\u239f\u22c5\u212f       \u22c5sin (\u03b8)\n",
+        "\u239d            \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r     \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r    \u23a0                 "
        ]
       }
      ],
@@ -338,20 +389,23 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "The off-diagonal components are zero."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "all(ricci[i][j]==0 for i in range(4) for j in range(4) if i!=j)"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
+       "metadata": {},
        "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACsAAAASCAYAAADCKCelAAAABHNCSVQICAgIfAhkiAAAAjJJREFU\nSInt1Vtoz2EYB/DPThiNslIa0syFHNpKc8qiqU2Klhs3oiV3SOLKhQuUQ9wop5Q55UJJEW7YyI0i\nFE3LULhgKdzMqbl437/99vM/JG0lvjfv7/d9n8P3fXre5+UvQlHieyYe4hMe4yPK0YAvuI1vkatD\nBSrxfgj1/sQuHMaIBDcdfTiRsp2Md0Mjqx+lie9aLMf3BNcQ1xspvxe4M3iysqM4rnVoN1Ao/WJv\npfgi9AyerPxYhvFZ+Nd4noUfiVWDqug3USP0a1uWvZU4hEuC8DXYg7OojzZTos1lvx5sI67lyFuL\nYzHeAZwSLnNetEaxrSl+OPbG7y5cwUJhMryMAotxBGXYhEepGPdwOkvOtcJEqkpw27CikNiTUWxN\nim9CC4ahFzsjPxEPsAhLhOrDVVxI+FcII3BdKu48fMWCBFcvFGNcIbHdQs+mMRdjhMvXh1lZbKri\nYaqES9uS2GuOflNTPtfxFvuwHwexHqMLCZ0QA57PY7NDmAhFeWw244PQOhnsxpuUXZlQ7aP5RBXn\n4HONrCQWo0M4VC404SY+p2Jn4lbHtRIlePYnYjty7JcL7dCeLzgm4WnKb7bwdMOWuPYIz3vykcpg\nmtjf2cQWo1F485/kEDFf6MlCYrswNvG/PQp6jhnojHymBZoNbKtGbMUZiY0SXMQooRqZGXtX6Lk2\nnEsEWY0NmCN/G1QLI6wz5jqOpcLE6BYq2xttS4XZWoVXQjHux9z5cvzHv4UfsudwW40c0GcAAAAA\nSUVORK5CYII=\n",
        "prompt_number": 14,
        "text": [
         "True"
@@ -362,49 +416,50 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "For completeness we can also check out the Christoffel symbol of 2nd kind. We will print only the non-zero components, and only one of the symmetric components (symmetric in the last two indices)."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
-      "ch_2nd = metric_to_Christoffel_2nd(metric)",
-      "filt = [((i,j,k), diffgeom_simplify(ch_2nd[i][j][k]))",
-      "            for i in range(4) for j in range(4) for k in range(j,4)",
+      "ch_2nd = metric_to_Christoffel_2nd(metric)\n",
+      "filt = [((i,j,k), simplify(ch_2nd[i][j][k]))\n",
+      "            for i in range(4) for j in range(4) for k in range(j,4)\n",
       "            if ch_2nd[i][j][k]!=0]"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [],
      "prompt_number": 15
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "filt[0:3]"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\begin{bmatrix}\\begin{pmatrix}\\begin{pmatrix}0, & 0, & 1\\end{pmatrix}, & \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\end{pmatrix}, & \\begin{pmatrix}\\begin{pmatrix}1, & 0, & 0\\end{pmatrix}, & \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{f}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }} e^{2 \\operatorname{f}{\\left (\\boldsymbol{\\mathrm{r}} \\right )} - 2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}\\end{pmatrix}, & \\begin{pmatrix}\\begin{pmatrix}1, & 1, & 1\\end{pmatrix}, & \\left. \\frac{\\partial}{\\partial \\xi_{1}} \\operatorname{g}{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\end{pmatrix}\\end{bmatrix}$$"
+        "$$\\left [ \\left ( \\left ( 0, \\quad 0, \\quad 1\\right ), \\quad \\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right ), \\quad \\left ( \\left ( 1, \\quad 0, \\quad 0\\right ), \\quad e^{2 f{\\left (\\boldsymbol{\\mathrm{r}} \\right )} - 2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} \\left. \\frac{d}{d \\xi_{1}} f{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right ), \\quad \\left ( \\left ( 1, \\quad 1, \\quad 1\\right ), \\quad \\left. \\frac{d}{d \\xi_{1}} g{\\left (\\xi_{1} \\right )} \\right|_{\\substack{ \\xi_{1}=\\boldsymbol{\\mathrm{r}} }}\\right )\\right ]$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAABD4AAAA/CAMAAAA/mvhRAAAAOVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACXHtMAAAAEnRSTlMARM1U\nEHbdIu8yibtmq5nz+73gcdcAAAAACXBIWXMAAA7EAAAOxAGVKw4bAAASHElEQVR4Ae1d24LCqg5F\nrVar9Zzt/3/sDpcUQmlJgLrtaB9mbEuArAUphJs6vPR1VOQ6n8ntt98cnlUI/NCsgq9UuJI19aMt\nQD4G827MxkkdXie4DkFIpU4Xcvu7udeY0x+a/1EBqmLtVwkoaxGYB201Xtp80GBw119vs2ff/aC7\nUvsqQeOHpgStlmFrWPtVgoiJFJjXpPm41Hxro1T/yO3h2pdq8kOzFLlquQrW1I+2CP4EmEnzMUSO\nkCia77x9loLyQ/M/LDDFrKkfbTPa5mCmzEf/Km+oz5L8Mw866OeVXD80S1BrJVPKmvrRNqdgDmbK\nfNzvc8k/+UTm4BmuRSB8DZpF6JQIiWgrZE19C211YCbMx+klirKkAHyIjMwedK8Sj9D3oPk2UkW0\nlbGmvoa2OjAT5uNY2sl/W/lplZAIOqWGVydP+XvQlGNTKCGjrYg19TW01YE5Nx+316OQ1neLHe7X\nutlcMuigOyxHZj9ovou9ataUjLYS1tR+aKuFsw7MufkY59NA3lWyxOkUejMxHRl0quSTtCc0EZat\n/1eyJjQfJaypPdFWB6ewDkStspn56F7j1sWnWfyHkt5EkLoQOnV+Sed+7AnNAJhNf9ayJjUfctbU\nnmirhFNYByIwZ+bjsaNR26Fyar0QOihVg7Bi7QlNoWrFwWtZk5oPOWtqT7RVwimsAxGYM/Nx31Hf\n5Vjn+pCWQ+i9CMFWe0Kz2B4IBWtZE9MmZm1XtFXCKS3RFMyZ+YiX3grLxruC9+NwvtX1+pS4HMLY\ni3BMeydo7oo1MW1i1tROaGtRCaTmg4IZm4+DuH3+rqJH0jHT7++Vrg9xOYTZALKpHztBk0C74U0b\n1sS0SVmDRaTSTuqGoC1H3QROqfmgYMbmY9iF66O76iHU+RT8ZaiTb6TQgfNDNiF3H2jOsOm9h5g7\nUZ8j0og1sfmQsgaNzD2s2mgDp7QOUDBj83Gs/aLPyuIWD54ml5fab4QUOujuyET2gObwvD/ddLju\nOejWVRfgektNdQlEHLtZER2uEWti8yFlTe2BtlZwygo0sEiqQGw+XpWDGa44bfzvqhsBXfU34n/i\nbI6yodsdoDlAS2N084yH86Atxz2cXDvMvT2hiEMwJ2KCNWJNiWkTsqZ2QBsA2gbOOjAj89ELW+eu\n9Lz5nx09OsEYUVjQ5Zn4v1hkEE083QOaFzAfN2cUj6bNfiD+nW7eXQtFLIJZER2sFWtKTJuMNZhd\nPNdZXFI2F2gEZx2Ykfk4vSrHQjdHTSdgFw7fj+rkO+klCYsbbjAhIGjYZ5PcA5p6FzVcnG47rncK\n6n3W/AhFLAZZER2sFWvyzouMNXCQf1ElENcBAmZkPs7CoYVsDdomwBE+kI/LqCR1OZETMXTgk5fM\nyd0JmlBfdCvucX89tafDdF9vr9dpvGpl0/sFO5HhfNZhtIiXWBBRjViTmw8ZazC5mLS/QLePvNrA\nKa4DBMzIfDyjxnnSc9YOzMfsy8aLuxvPw60fzxkHOea+I30cn6gYOvhOS5Yjx2gqzBBPS3Eor5lM\n1G3L9zC63ayGp9fxZkbGT0mDaUS06bjDl9qKTBIqLaKqWFNeOTFtMtbAxUv9xR/KGgtOzDutAs3A\njMzHnboje9MJ1A75J6eiswPC/E1bo0dOtLK6oLrn+Wna3zb3IP2gzfEpUXE5VOolkYnQVFOGnPbr\nirHR9AEnzdZjjt4Orq3+NP8PtuN/AwdAr82zu6cyRqTXLpM7DO3aIJNEWoRGMLvLsqYm5SQU2HRE\nrMGcU/JZkrGmE2TR68NNitnMtvw75T2qAq3AjMzHkY4sWByOUEI67S/LXeyA/TTjS/IxzyXv3o+D\n3j8eLmSxG6CxEjZAMFF5OVQvyZz+CE3MkNd+VSM2mkFA1Gw14ujlA3v6d/PRPdjWxg29PKZpcbrj\nZXC0Ig/dZ9H9HisySbjWSJRM5jbPmkLl5LSJWINxW1LWXTFisgaepKlwr6vsw6Fi6+FL3i5WgUZg\nRubjar1nLqdn41t4GLoYO8dyA3b354jp2CRKkFmSgfHcznw9MOrH63mmHXh8Iy+HigK0lAf3PAps\nkw21X5PnoqnCgKjZWsTRuwOQfDCNQHsWxQ1bH86x5MxJKOVEBjA0N42hFfHmIyESiqd+M1hTqJyc\ntoiIVAaCZzS0jDXFpTcMh4oFeWjzEyOeV4FGYEbmg5ppezbB3XyOrK9sVSt2QPDHofno5GVhNQ9w\nwhW2D9zJCnSWrRHGRAvSvtAv03peKJpqOuph0n5NnI1mGBA1W4uYvrsd4bQfM22js5x0dubPZAwe\nM/80imgXx6gLhxWZJNRchKaZuGOwplA5OW0i1qIWpow1rRqL3jAcKpbApe7RchVoBOaa+TjYgmQH\nG+Asupwq7IAhwrrl3fTCBcwu98lVsi5ReTlUooJIzQdmKNR+RXM2miSgGM6rOWtQ5wPzd9H9k/7y\nclu5jcQRoANOIs/zcDQdHi3iJdRcRIutXhzWVDFtItao+UBUmKxpJcXmAxVbRajgJeadrpJ1ETUB\nc818WJdaZ0fBD9nRLHZAgjD67QrQSYk8xutlNJ15jPhojSAJ7N4VmI+jZM0tNR+YIV75YqNJA/pE\niMLzmw7GXK2HGd+hD+RMxx3WO+b2OEKRCKYX/OexpoppE7FGzYcHlGsVCsyHTyQApfjnCag96S4o\nRpuqAvhSXgdCMKn56EiBt6603vrQfNN0SS12QIjAU2FHC5fiLHiOZs7mXs9HANeHqRGuVw9xukTl\n0IFbbfYxXswjRVNhhkLtF2VhiNh0GqSwc+E8aFd4H/RLjo9pAMA6P1zWTtSYBBnuod9ycsaFKRJI\nRz85rJXTJmENprdh91fnUcaa0coX7kjJ6NaH47IWRZC+HYCM3nzzMe+pKtAGzNh8hDXqYvoVheU4\nrRo+9ci1Pj66x+aBzT0gedfGGMzIc5zaIS7RUFnMWeZ/NKi3Grqj44WYoU3NBxPOHniHEe5g2BxA\nQmUOgcXojOML35D/tyO0X8xADHR8eCJEPrxhsYZnVstpk7AG5iNMQMaa0ckX7lDF+W8fjsnaPIrE\nE+ukNK4GzHuqCrQBc818WE+8256M03kxH7N8QNDZI3cLTX0CjeCR6aUv/nEBvQ/ONhNuvvx7klyi\n/wSRM39KCiIth8rCqdPx2i+nWgg7E87x+oAmmav7s0ycvFk5L4WJhJZFFgmbnC4QFYs1aEiaVOW0\nSViLzIeMNZM/Dr06oA/HZE0LZeE0K+nsKiaX92QVaANmbD7CyuxSt74PN5dCa7B0sQMWIreULnmO\nPjisrTjyDYFm5iP8ypBIlm8kBZG2gjFDELcvN8sJKTaaJCCzIFp360rqb37FYg1LvJw2CWtR5+XT\nzEeOGHvExNk0tF3ek1WgDZjUfFCvkWv7XEzH9oFDrcv5ZwcMKxB6h5ejlb2xw5ggY3Mfzp/25sMl\nKi+HIt8HRdNlSGvDMh9sNElAJpw4J0yG7XahWazh2JCcNpHvg9KGHQAma2x6STFgssbB/2FmFuil\nBOtVoA2Ya+bDeV7Ohi7G1l7sgCEVTb1GANkVu/A29+fAqefNR43r1Dfss2wSH5zUCcdGkwRkwnm1\nTlPEKqvJ1gFYrNV4+wSsUfOB7sewzGbQYH0dIA4fjslaJl3z2nYD7SyLtSrQBsw186FnFepLG+BO\nj9B1mQVj7IABcnahBaSSi9xkJfvH7yFkcx9uW+nNh0tU/hmDeR9TQcxnmJoPhHMqN5kI2GhOAQEd\nJpxnPWLS0YHbLLbbBeCxhsrJaQtYY5QzQpuUNQDJmYUMvVM4kGCyxiGg060Ptz/SWhXANOvAjMwH\nma+LTSo9RcCO6l3WezDcgM/x+rqM1llvt6jRwGQin2MXrSI0AfyhOS73w+uFAwzefLhE5dCRaWPZ\nDBM0sbWovPbrEXDRhM0FkR9Y5zONK69Hfn6eH8FoyRzczZ6Us4bKyWkj08bWgQG9CW1YCbissen1\nEfJZS5Ayg/MAC7ycK2mtCrQBMzIfFNr5MrkDWUyU0AYfcQP2QVlgykynesarCHXaetDbXS73/QC2\nyjQZJvOBiQZpo1Du/zX0LecyTNFU5XDmEppyjZrpB2yhSXrLH/WsKVROThthLQsMpa2ctWxCiDcq\npu+ZrK3CaXZR0JEtV4FGYEbm4+7b5pA6zkPUObEX+4PFDWj25pVGbnt2s4W0ep8JO4naROhzf7qY\n2U0nLHeYKN679Dn/SMM2pyRFswLOXEJTzlEz/YAtNElv+6OWNYXKyWkjrGWBobT5YoTwsIHlBkTF\ndAJcGbUAp/5QTn1Bn/e4CjQCMzIfT5spBCrahE51XOW4AbtgSjRXBrb80pMREqsIL3e33svm3+Ue\nAj/Ai9M/L6/R+AqnROXlsAt30c1mOEJTlcKZTQj5mjSDB2whFN74fy1ralJOTBthLQ9MRFspa/mE\nHOKTYhLWFuAcdN2YxrGwxM2qQCswI/MR7dM27TbiFOVaD7YNDalhR256domFtOpBV3G43PfgGdD2\nZrqmRMXlEAbLfecor2SEpt8uyGWFqzE3HJYWEz1baMJl2x+1rHnlxLQR1sS07aoSnEaoBGa2uGFz\nqQq0AjMyH6doQkC/bSFMeS/yhdic6plcRRjJpnPvExWXQ5gd6SexRoklbmM0VTpDCcmyR16zMvlN\npSpZC7aME9MmYw1IDtYCASYfyRoTzoW8+5JSB2ZkPm6i6rFpcUtG7k/1TK4iTMosPxRDB2NykqkS\nn47mMjJt37RlTb5Vsow1aGJKvhFtoeLE1hROcR0gYEbmIztWzVFvuzDBqZ7JVYTClMVH5MAuutO0\nD0ZaH44mQ4MmQRqzJj8mSsYaY2ZIE1hKI2kLp7gOEDAj8wHzGkq1eoNceKpnchWhMA/iI3Jgzroo\niY9GU6RJReDWrMmPiRKy9lWVQFwHCJix+SC2paLMbCIaHJKaXkUoTFXccJMeX/jRaArBKg7emjV5\n5yUcLuOo8dG0NYZTXAcImLH5OEVnXHDQfluY4FTP9CpCYU7E0EGPSZTER6Mp0qQicGvWxOZDyhr4\nTrcdMagAkxxt26ISSOsABTM2H/0Hu42CUz3TC2mltCB07MJyptNisul9MprZzDcK0Jy1yXxwaZOy\nBnt1fa7vtDWc0jpAwYzNh7pOW3I1Kj7togkOSU0vpJUm5aDrDg8/Ur4axyhzfcCn4nPRXFW04cvm\nrKH5YNMmZu2TaWsNp7QOUDBn5mOQnETQsJRxovKneqYX0nLiCMNY6E50lD8MEP++BpNk43fJ+09G\nM5nhDR62Zs2ZDz5tYtbUJ9PWGE5pHaBgzsyH29p0g2JUH2VwqmdyIa00BQNdxx+LZe3DSDLxyWiS\njG5405o1az74tMlZw32qNwSlPOrGcArrQATmzHyoFvOxysFhSyYW0rJlMaCB7rayCUFwaryWmc7G\nwwjy/3eCZl6RNiFasGbNxwpt9ax9USXI1YF1MOfm48H/GrcpUsWxzFYRSmMy0KnLfbAn4NqVMeMR\nL3DN+VPjddzCcRctsh80dW7fcVWz5jovlLa2rO2Itlo4U3WAD+bcfKhoxv87ilRJGvNVhOJYLHTP\n56C9H4dhOo7QR+RPjYdnRaZgJ2h6lbf91YA1Zz5WaKtn7XsqQbYOrIKZMB9mze+2hahF7LOFtPJI\nDXTjtAPSfGMYWP4Q+FWPUsepztFO0JSDVybRgDVrPtZoq2dtL7TVw5mtA6tgJsyHcvvolpWPPUlp\n6Ho/EcyaD99yg9VxIXaHsl7d16D5NuZTtLVm7WsqQR2YKfPBOJPhbUVl04T05CBzGKhNJdP6OJbN\nJfoaNDelKow8S1to9AtZg54q2SMmTP9P/a4DM2U+1CVosf8prBLKdJfr4Lovc/MRnBoPXtTC8vRN\naCYA3ubRGm1NWPumSlAOZtJ82CPutuH982J9HF928cDcfISZvXLnSIdC+vd3oRlrv9k9j7Zi1r6L\ntlIwk+ZDPb5rrnWvjze4nV/BLm+zUj8GuxTOXq4/+DI018Fo+JZBWwVrX1YJysBMmw81eodiQ74/\nNKqH3kk5c02HPGTCJV9/FZpJBLZ4yKCtirWvqgSFYBrzoU/tjgYlj8xFZFuUiw+Ms0/MCRFk84em\nAKx2QStZUz/aAi5iMO/aasAK9O6kr+l0MivRSTblCxL5oz/7aXJIkYI/NItgqxWqZE39aAsYiME8\nGLPR/wvQqqJqrheD7AAAAABJRU5ErkJggg==\n",
        "prompt_number": 16,
        "text": [
-        "[((0, 0, 1), ",
-        "\u239b d        \u239e\u2502    ",
-        "\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    ",
-        "\u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r),",
-        " ((1, 0, 0),",
-        "  ",
-        "\u239b d        \u239e\u2502      2\u22c5f(r) - 2\u22c5g(r)",
-        "\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u22c5\u212f               ",
-        "\u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r                 ),",
-        " ((1, 1, 1), ",
-        "\u239b d        \u239e\u2502    ",
-        "\u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502    ",
-        "\u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r)]"
+        "\u23a1\u239b           \u239b d        \u239e\u2502    \u239e  \u239b            2\u22c5f(r) - 2\u22c5g(r) \u239b d        \u239e\u2502   \n",
+        "\u23a2\u239c(0, 0, 1), \u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502    \u239f, \u239c(1, 0, 0), \u212f               \u22c5\u239c\u2500\u2500\u2500(f(\u03be\u2081))\u239f\u2502   \n",
+        "\u23a3\u239d           \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r\u23a0  \u239d                            \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=\n",
+        "\n",
+        " \u239e  \u239b           \u239b d        \u239e\u2502    \u239e\u23a4\n",
+        " \u239f, \u239c(1, 1, 1), \u239c\u2500\u2500\u2500(g(\u03be\u2081))\u239f\u2502    \u239f\u23a5\n",
+        "r\u23a0  \u239d           \u239dd\u03be\u2081       \u23a0\u2502\u03be\u2081=r\u23a0\u23a6"
        ]
       }
      ],
@@ -412,27 +467,25 @@
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "filt[3:6]"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\begin{bmatrix}\\begin{pmatrix}\\begin{pmatrix}1, & 2, & 2\\end{pmatrix}, & - \\boldsymbol{\\mathrm{r}} e^{- 2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}\\end{pmatrix}, & \\begin{pmatrix}\\begin{pmatrix}1, & 3, & 3\\end{pmatrix}, & - \\sin^{2}{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )} \\boldsymbol{\\mathrm{r}} e^{- 2 \\operatorname{g}{\\left (\\boldsymbol{\\mathrm{r}} \\right )}}\\end{pmatrix}, & \\begin{pmatrix}\\begin{pmatrix}2, & 1, & 2\\end{pmatrix}, & \\left(\\boldsymbol{\\mathrm{r}}\\right)^{-1}\\end{pmatrix}\\end{bmatrix}$$"
+        "$$\\left [ \\left ( \\left ( 1, \\quad 2, \\quad 2\\right ), \\quad - e^{- 2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} \\boldsymbol{\\mathrm{r}}\\right ), \\quad \\left ( \\left ( 1, \\quad 3, \\quad 3\\right ), \\quad - e^{- 2 g{\\left (\\boldsymbol{\\mathrm{r}} \\right )}} \\sin^{2}{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )} \\boldsymbol{\\mathrm{r}}\\right ), \\quad \\left ( \\left ( 2, \\quad 1, \\quad 2\\right ), \\quad \\frac{1}{\\boldsymbol{\\mathrm{r}}}\\right )\\right ]$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAA0kAAAAyBAMAAAB7Wo3sAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMA74lUMhBmds1Eq5ki\n3bvZob9JAAAACXBIWXMAAA7EAAAOxAGVKw4bAAALL0lEQVR4Ae1cfYhcVxU/8/Fmd3ZnP6yfaYwZ\n80+rEbux/iGVZgeNbajgTvqH1EC7Q9FUqNBFsQlB2JFUUAR3WkSDWHcCba2CZASlkLTJRETQxmSt\n+IFNm/GjKiYmMd00Tdvkec659755775733y8584fzoF999zzdX/vnPfuu+++3YWN7kUYUhIZSNeS\niOLFcOqCTbvuNLx528c8xZCJk4HNcZwNvvuFzNn20Wl4i0E/FPWRgXS9D6col1xVarPDKkXlqSfd\nlnJP5tHGXyH1X6TNsErRyepB66zrwbiT6YlLZLFjRtgNq9QpX13rJxtdm3Y0vOcQVykzLSyHVeqY\nsW4NZpOc8Ea4SvBcqEq7uoWTnN3OiFADgBOBRqkiED+vbJJoZZVmmxysfS+NVJOI3luMvH3MQcDp\nArwdce6NLty7NpFVmhCzaLtKDyd5w3aLZq/VcCBwrGjaCiviiVbbKD4nq5QTE59XJWdtXpuO8wnM\nqNMYrShOa9cITqFJ43pwNBCmrhXxXM1k3q9MVsm5zAG8Ko01+g3Yjd/mM2U2c4rc3KZ8CuJaUd12\nuzZw4M4gHG/89JGfenyQsSL+cdAuZk9WCb7KcbwqzYk0xgxucU83x6qsmhSjpEvcw8MPFaO1awMH\nXuJh0yVtdHgfPKmLVN+G+HplkEirqrTYpHBelb6eSHBLkIlmVjxbvy0MnJYytFVjbeDkFxhHG46C\ndQrmmorXWgvi7CuaXbyuqtJJRqiqVEh0haIjTNUKV1h2Vmr+pixGRZ5UV7VrBGeyKQb04Kjx18HJ\nmuK11oJ4JNkEqiqlWjS8qtL4igYm4W7mEuRu2AsrkHVvwblhtwqfm1ZcoF0jOBM6nDYI3zvqbZ9p\niwEsiCfNJ+L37IVXVRJhVZVSCxQjW+klEsCnuzafWIC9cCZbBZh96HwZblGO8h5TXdWuDRzYrsNR\n4wP8gVlKyNjbDpRyJU9jQ9wSFt7CyHOIZHyB/XbjB64+wf0036KqSidLJDyBP6Nl4gL07JHQlACF\nw+dKMFYK2EV0NgNOYn/NtwDmWr8E+J5nep3H+ZlIOIVN75/xGxPPsl7hEIwAnOzbVdx0gzlMiLNU\nmq/CY0oBYEY8LxwKLQBTuqxp9QVuD9HmcvykUFV6gBW4XV7AK10jpw431TQZ7IQ0BqjqYr2/9RxS\nGXINyK3ApXwd01JEG7yIJT2pmEAbBQeehUzoUS1k1UAQQycIB76jwcleVD73CwYTMv46pC7BqFKA\nZfW3vMAWeI07pnRZ0+oL3B6izWUvE6+q9Ax1RorgnDkYqtJYGVLTpPfT4wBvAvi8XxTBPwLfTNez\n09mWTAumR9KiYgJtFBxYnIGrAWvsCFmPcOATITgybr6YLyGLCYHlN2BqlTmpMyOenWE1IjCly55W\nGiKCnNdJqar0InVSTTwshqqUWoGxVdL7aQPAwRLs8IvsfHbfzS9l6mN1Z0Wm5V7PdrbpsT4mCg48\nXHNe9dkyK2Q9woG7Q3Bk3O03b6U0UEIOVmH+CjjTUoNPMhSGabHEsneikyld1rT6AoeDouQ1kqoq\ncckeJUm4SqOXDFVaKlOVRmfIpSOlXPcCPHVjBX4HhdPr0fwHMOfe/uUF5OaMEaLgoFN4xhOyXuFM\nlBUccQqFbaKFja5LHCXELcIcPsL34XJwdQ89t8yIjzZRBfkVfLCb0mVP6z7ys9M1Uqkq8fS3mSTh\nKqFwwrSTc7oM8iFLfmG6c/fTAWGqBA9KQRXPedMyBZ2vBGxkpwOc0UbYiWS9whmRg1cxXPYLu6sn\nXoPt62/fu6CiY0Jybg0WLwAgO3fxPW7ZhlhUSQIwpMuaVk66GjDcvoNEskoOP47/ThJjuOUiqYKU\nx0dtrhqU+Xv5U/AzX/9X8CGASSHIVACWVo6tYG/KS4lQ8bEDnI8877OVLMt6hQMt9s5UsLkH8G3u\nXwDfWGi/UmNCxlwkBPpZvEmuFjagoRExiMf5JEXCZ1mRG//BmlYMHEU0oqpSgav0W5IYw71IGo0m\nWjjNUKItdGzG+YlPtX03bmDmKyzZicelBrNTRW6Ch05w0oYNfJL1Cge+xeMSHMBPJUWq0p8BOBkk\nw4SMvnr8uFsEuBVZnofBiBgOkj1MzHBjSJc1rRg4in5DSnkvZV+mzjo6mMKNt0ij0RHsZy9oQuze\n9QLRQ3DgvgfLIe0HWfJFPC4tMDvVCNlg2Gg4uLwMRyZZz3AyJRqd4MDEtS8BVemfADzfkgwTkrqI\nk3MJpzuskpAbEcsqpWrkZkqXNa0YOERTdAPzkxECVeLLx1qlvaE4uEqto9CUFmXLqxPVCbeRVYqE\ncxzg/IwWUMhiwAHnRrdBVToXrNLUy5CmFWWnKh3l60ZUyZQuU5XYzlQl38m9QLy8l6KnmEwDMAsa\nfRgKTV7TaHKvi4+tKFJVKhqMouG4ZThf0byEjJZYNuoAB88Q3/O1KuGMl1qF1BWM+Wj7Xiqahrip\nSVKe8YzpMlRJ2GHgKNpASrV64JvZtnr4OADOBkHKNmCkGbl6uA7vt6BPoKeqVAlIRUd8orTBeRfA\n6abmJWRRq4cOcOADAE/oVUIEk6uw2MDBaPUgZ7yKNjZ3F0vU8OrBlC7Tg0TYdVg9+Nd4wFfae2kg\nLLr20lh4btOhFU0Gv960+Uc4A9MJzFfJL0R7wAmuxIMWskonZ1CsB4+EA7sgc1kflGVx4MCWMpyl\n6c4/42FCshfzPHUf9qpkRvxAjU4vXcc9NlO6bGkFwMDh86dYgq5RI+8luJ46dPMd2vinCpwuU1fR\nKK9FgzJYct2rCJywGd4OyHXkqV0qgqGdc90Sief47LTgkXAgf/hITR+UZTHgADxy3721O9zH73Af\n2/qfOiFDooTs/2OF2K/hIsJdJc6MeJbPg99qTemyphUDI+nnTzKm4A4Rrmww3U3W4IJZMbJPjUkG\nx9jguz6zXtlZviD04J3hgGnQ+HCC8L2EQGHa05gRy93WU8pMPyOSm2QisEnDkYK7re8mWa7BGmRk\n629MMriBLSp+ux55Hjg0YGc4YBo0Ppwgei8hkF7wNGbE8svF/crMlC6TTAQ2aThSht9J1IwnLpCz\ncoxPqrF8rUnmVMnAqdCxT8JVFZIevDMc06AJwNHOQiUE7morzIhTVbaYbEpD/YxIbJKJwCYNBwp+\nBZyvkPAEa8B4nbKB1KtGYLJeCMosqn2FlRXNpDMc06AJwNFwqITgwsIjM+LJC2xQaEm7imz9jUkm\nAps07DnGYdW9NFknYaFCx+7pc92bWizl7xbp2kHB0XGohOSansaCWP2iwi88w66YXNNkprbf8XWt\nRXpVpdy0yfp/L0tXjWMMCo4RTFBoQSw2tYKm/ffk9jvASX4eqio5/JTqP2y/nqmK0XNQcIxggkIL\nYvHyEDTtvye33/HttUlBVJVgT/8h43husTgPCI4FjV9sQ3zUbxSXl9vvAP/mSF6V8BPdIOj3lkEH\nBMeCxi+2IV6u+a1i8nIzSm38elWK2gKLOWSEu3VUqyIi2JqorMDknxolA0JVSf/LGPhHMvF7i3Ks\nabMfCBwbGJ/cilgm1Gcag1VVGq1zEO9egrtLMaL26ergpwELDQKOBYpfHIF4vd8uJq+qtNzkQO0q\nFbwtqJgj9ODOG/1m+0HAMSMJSCMQi/2SgHXfHVWlMyJCu0rw875j9u34qQjPAcCJQKNUEYhNv9ik\n3Hps1fZ75q3C0VelHiMNzbUMFPi7hiaM190h143DKsXLo9/7Vn8nEV5OeO232kSi/n8HGa8nfP65\nlgyI99LwP68lldzvJxVIxtkvWv7Pa8P/YphUcseT3H7A73b4dy1E9F8M/wsWBQw0hqNbYgAAAABJ\nRU5ErkJggg==\n",
        "prompt_number": 17,
        "text": [
-        "[((1, 2, 2), ",
-        "    -2\u22c5g(r)",
-        "-r\u22c5\u212f       ),",
-        " ((1, 3, 3), ",
-        "    2       -2\u22c5g(r)",
-        "-sin (\u03b8)\u22c5r\u22c5\u212f       ),",
-        " ((2, 1, 2), ",
-        " -1",
-        "r  )]"
+        "\u23a1\u239b             -2\u22c5g(r)  \u239e  \u239b             -2\u22c5g(r)    2     \u239e  \u239b           1\u239e\u23a4\n",
+        "\u23a2\u239d(1, 2, 2), -\u212f       \u22c5r\u23a0, \u239d(1, 3, 3), -\u212f       \u22c5sin (\u03b8)\u22c5r\u23a0, \u239c(2, 1, 2), \u2500\u239f\u23a5\n",
+        "\u23a3                                                            \u239d           r\u23a0\u23a6"
        ]
       }
      ],
@@ -440,25 +493,25 @@
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "filt[6:9]"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
        "latex": [
-        "$$\\begin{bmatrix}\\begin{pmatrix}\\begin{pmatrix}2, & 3, & 3\\end{pmatrix}, & - \\cos{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )} \\sin{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )}\\end{pmatrix}, & \\begin{pmatrix}\\begin{pmatrix}3, & 1, & 3\\end{pmatrix}, & \\left(\\boldsymbol{\\mathrm{r}}\\right)^{-1}\\end{pmatrix}, & \\begin{pmatrix}\\begin{pmatrix}3, & 2, & 3\\end{pmatrix}, & \\frac{1}{\\tan{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )}}\\end{pmatrix}\\end{bmatrix}$$"
+        "$$\\left [ \\left ( \\left ( 2, \\quad 3, \\quad 3\\right ), \\quad - \\frac{1}{2} \\sin{\\left (2 \\boldsymbol{\\mathrm{\\theta}} \\right )}\\right ), \\quad \\left ( \\left ( 3, \\quad 1, \\quad 3\\right ), \\quad \\frac{1}{\\boldsymbol{\\mathrm{r}}}\\right ), \\quad \\left ( \\left ( 3, \\quad 2, \\quad 3\\right ), \\quad \\frac{1}{\\tan{\\left (\\boldsymbol{\\mathrm{\\theta}} \\right )}}\\right )\\right ]$$"
        ],
+       "metadata": {},
        "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAwkAAAAyBAMAAADl4IpMAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMA74lUMhBEmau73WYi\nds1/9lIHAAAACXBIWXMAAA7EAAAOxAGVKw4bAAALJklEQVR4AcVcbYhcVxl+53Pna2e2NGmrFnfc\nH01VSqa/REF2tK0VQpxpERoRu+MvQcRdQUzin51IRVHKblEsResO+iNGQrM/KlZa3WkRSnQhQ34F\ntO4Uqf1Q2ZjsJmFNMr7nPefce8+559y5c3NzPT/uPe/HOc9zzzP3653ZhdnRJaCW7vD9/2F7JBjz\nvuDwpNFk0ezsBI/0aDQDdz78CE88YM+/3ZH8MAghvRQUnTyWLJqdn+CRe/ihGdgn0tJde/5tj/wh\nCOH+oGCUWLJodoaSR9ZV4cG2PT1qpBp2zmLdDpHZb49NHHmLjUgMTaFH0IpH8nBVyN2lJMRiVNbC\nqpC70w74WMcemzRydpeNSApNYcehFZfk4apQjPniyw722ZWwKsCDCj3FeFaxbsn4wjFSISE0haqE\nVpziqF0V5kMvmDJPsLEVetJS3TZThi+cLTyZf5pPlhCawk1AKz7Bw1XhpBKOyQivQua6DbIU50kq\nliIhNOWQTCoIHo4KZesqKFNNaIRXAayfgo3+hKBB6XIpkkFTmEhoxcl5OCqUVpVoTMYEKmzYLl6n\nYuJC08ilSAZNYS6hFSfn4ajQ6ijRmIwJVFgYmDGzV8z+aF65FMmgKRwltOLkPBwVvqEE4zImUKE6\nNINOzZj90bxyKZJBUzhKaMXJeTgq3KME4zImUGHacmNKdeMiw+aRS5EMmsJcQqtOOmqpQva/SjAu\nYwIVKjfMoK11sz+aVy5FMmgKRwmtODkPqYLts6EMmdyYQAV4n3n6rb7ZH83rLEUiaApHB1rxEg+p\nQjHWq6+DM1aFQ79xcp9xekrH4lZywhvOUlimtbjDA9gzHWglhQClCqlVHjukpIw1ys3AlGOzvzJe\nTxyUwgdONOUcB/vGucSHNmucyDiCnC8aQ1Mn9n7IA0mgKRRcaMVNPKQKC0sUq6xC5ehzTSUPjcrc\nhxu6D16b+xHAUz63zfGpgRNBFHj9+I+x0LTdXBjKOTY6ToKnk7vKjbPAAT0h3vVXKoltoenLVByR\n0KxrMw5NgVYM4iFVWORrhJXoI5D2PaG/Dhnf3buyBPPrUFWmDDJadSeKKLkuHOzA1FVI7co5Wq5M\nTiZAXty03wIO6AlR11Cp5GyHeqZqR0Kzr80YNBXbaxEPqcJ8g0LnAb4LcIc3jfW3GrCn+6YvQ60H\n03XdH8JGlEIbUjOweB1qO3IOcTpq4zOXyYE4HFALmyqVnC2CBLVIaPa1GYNmZ0I8pApbTUq8F+D9\nACvccId+uZO76Vq8l78L8GqSm9H9IWxESfWgsAMrQ1i4IueodU1Dp3fIm+oDB9RzDPc8zvYxPVO1\nI6HZ12YMmorttYiHVGG5z0L5HsB2268CGK5ImI5XJPg7Gxem/bEpsxhKdZepMKpD67qco7YqE7z7\nKYxj+yptGaDWDCpwttWGlqmakdDsazMGTcX2WsRDVUF8zX6m7c2jfnXJ5wJ4G30HDH6f6/An/1ZZ\n62bf/OYbT2NMoJR2y6MObF2Uc6SGvnHoECpwGAaoNaMKjK1A0dIdMxoagGVtxqA5sL4O8ZAqrNDC\nF9dZVv6SL/fTJ30uyH4EjxXkF9j+uOvJrUIJil2oPg/n+vitL6HAYr0wwtaTc+BFytAK/GuZn2KI\nA2o5JhWIbXmoZapmNDTr2oxBU7G9FvFwVKBIqcF2piJ3Wv5SwzvDh5oAn/A6LP38fkgzFYozUEMF\nOAqcgurNzU28KIk5SjOm4YWL5P0lbRmg1kwqAGOb6WmZqhkNzbo2Y9BUbK9FPFQVUh2WcNybJft3\ntGXP3af2A7RcU/Zy7/0a2wtNYB/1EVvFM8/3SYUh1AZ4Z+6wzKlVSF2C7Kgp5whcF/7TBAaoNaMK\ngGyzXD4lvUaMyBUNzbo2JjR+/ARp3Lg8pArLtMi0PtNdhTkzNgHWGpq3gguLT5EGFbRENB/fvkoq\nrHpUuABQuwxp9uzF5yj1/ANRLH5FQhUEoJZkUIGzNa6LOzgiWtedQfRCoflGOQ7iIVWgF2l+rfgY\nO161jdqwtq66oLYLRXyV4w8vWkwzcb6NDrsicRXoipRZgs3UDqTYGyKfw3ylTvNnJLwiCUBtboMK\nnG2+p2WqZjQ069qMQVOxvZZyX+DvC+y+mV2C6b43D/tYyzmj+7DyVMIVCnN3ztShsO6qQHfnRwH+\nWtyBrSWcns9hfmoR7wt4dxaAGjWDCpxteahlqmYkNPvajEFTsb0W8ZDnwkaHhdJdgD/NHfgBex/z\ntpchc0P3lddhfgBwFPP8r3TewXij3A/FPp4I4lxgKJVfzB3rZS/lr7FMNgd+1lfZVkOGMi+n3A9A\ngD4opoI2htjCFNNXizAA0SKhWddmHJpEpX325bZrEw+pwnyHBdh5tT0a7UGJX42Zj7X80eMd3Qdf\nOfoTDP2Dxc94pmW21vIf/ct92ZVrn1+59tDaPRyliverHnz9hXWWSnMAryloyJDhKrCLFgFqUFSp\n1MYQW6h2cIgWQY9skdCsazMOTaLCIeydeGkfvCg9SgVjcUDu0zL4Ndnx7E2+ygxLyPdxY2hUOPX7\nHRQe4nNAi1PQUEQ1r9QX0+RlR9i008aQ71VrhALJohEkblg1+ckdPKELTeEiHvJc4B8N+K1MX5cd\nz97kS9PSlT1Zni4vnHocouugcJvPAaKgqKGIynZ5SYw1QmljKPUB2poiFEgELS9IO7tqG2B5CWbb\nMBQ+4iFVSHFvsc+DOQN7kw+epPwv8lH6tkCFU90LeJNQfHwO4I9pPpQP8tyfiSEmKN8YzM0N2QBT\nhPkhGbQnOJa7xdJrftQHfEmSRVg6aqlC8SKlsjOGNdMnzuQDvjgGzdgs+BSGJTt/kygiIhZ4hUwf\nyhrPOiuSTVC+MZjLlTZF+ESJoGknPcC9WNO/CblRB2QRlnhIFeQD35/FwYbclftBibxwashQUOQc\n+IBpaltt8lZMy2/KF75XjLHW6PCbA4okgZa5qpFgTz81VjDogyzCEg+pQpZ/maKNunXT/pCiz239\nbUpDz7wFOzuaW6THv0TQXtr7fgN+f34An7v78AUmPqu8blyB6ZFT8lV/CQP4BHk72mI97Ky23+LE\n+6uw7d6rPcYoGTSsRGdOwzGAdweV64jK3ldX8Bl9D6/5Q0ZD8JDnAiyTM/bNqdAzFnvm1KmLZn80\n7zZ+GllLBo2psA8W2/AMAFZ7qEK0/a/Nc/jVQabHaAgejgqLHfLGvMHCadhWG5gz8/y1zRyc2Lst\nUJJBQxUge365Dz8HuIF9Vi2drUMLH1lEsZHzcFQoiQ/JxMcVOOBCYFQJbrQV0zXYocTWpArJoCH1\n3Lv9VhOec1UYNeDg0FGB83BUKKs1i3gOO4OF07AzvWNLtC6YbUCQX6qQDNpJGFR70HqkLVQoNfBc\naMJsh5dxkCjn4agAdweRjxh7FAunIYfm2d3L2FJxnqVChYTQ3oH6Qh3mP9MUKrC781pzmj3Alofs\nYAUPV4V52xWBZUdrVDgNObRoXetY/7pQqJAQ2rehjvX4g4fkuZDu4lda9UXc8iIsCB6uClXrMoRc\nR38aL5z6/SZPwN+8v23Kj+ZrjbB4gC0ZNCh8p1/53htf+vdnR099/D9dfhnKv/dPxqDaYVvBw1Wh\nYqo1sMxEWtDfvJ9rxk0hWTQP+9NOn0q+koerQqhfUziTxN2xXyKcR+sYIZNF8xB3C0sPMK/k4VFh\nqutJT7r7uyBAfPmMtyWL5uHOa4zo4CVfyQNVcP4zz9Oe9IS7+WEQYGEQFJ08liyal59TTSY5BA/6\nzzzOf6ma6ngHJNo/EvyA9q14ySSLpnCX1eRXmFfwYP+l6n8DOVW+o5MeMAAAAABJRU5ErkJggg==\n",
        "prompt_number": 18,
        "text": [
-        "[((2, 3, 3), -cos(\u03b8)\u22c5sin(\u03b8)),",
-        " ((3, 1, 3), ",
-        " -1",
-        "r  ),",
-        " ((3, 2, 3), ",
-        "   -1   ",
-        "tan  (\u03b8))]"
+        "\u23a1\u239b           -sin(2\u22c5\u03b8) \u239e  \u239b           1\u239e  \u239b             1   \u239e\u23a4\n",
+        "\u23a2\u239c(2, 3, 3), \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u239f, \u239c(3, 1, 3), \u2500\u239f, \u239c(3, 2, 3), \u2500\u2500\u2500\u2500\u2500\u2500\u239f\u23a5\n",
+        "\u23a3\u239d               2     \u23a0  \u239d           r\u23a0  \u239d           tan(\u03b8)\u23a0\u23a6"
        ]
       }
      ],
@@ -466,20 +519,23 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "We can also confirm that the Christoffel symbol is symmetric."
      ]
     },
     {
      "cell_type": "code",
+     "collapsed": false,
      "input": [
       "all([ch_2nd[k][i][j] == ch_2nd[k][j][i] for k in range(4) for i in range(4) for j in range(4)])"
      ],
      "language": "python",
+     "metadata": {},
      "outputs": [
       {
+       "metadata": {},
        "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAACsAAAASCAYAAADCKCelAAAABHNCSVQICAgIfAhkiAAAAjJJREFU\nSInt1Vtoz2EYB/DPThiNslIa0syFHNpKc8qiqU2Klhs3oiV3SOLKhQuUQ9wop5Q55UJJEW7YyI0i\nFE3LULhgKdzMqbl437/99vM/JG0lvjfv7/d9n8P3fXre5+UvQlHieyYe4hMe4yPK0YAvuI1vkatD\nBSrxfgj1/sQuHMaIBDcdfTiRsp2Md0Mjqx+lie9aLMf3BNcQ1xspvxe4M3iysqM4rnVoN1Ao/WJv\npfgi9AyerPxYhvFZ+Nd4noUfiVWDqug3USP0a1uWvZU4hEuC8DXYg7OojzZTos1lvx5sI67lyFuL\nYzHeAZwSLnNetEaxrSl+OPbG7y5cwUJhMryMAotxBGXYhEepGPdwOkvOtcJEqkpw27CikNiTUWxN\nim9CC4ahFzsjPxEPsAhLhOrDVVxI+FcII3BdKu48fMWCBFcvFGNcIbHdQs+mMRdjhMvXh1lZbKri\nYaqES9uS2GuOflNTPtfxFvuwHwexHqMLCZ0QA57PY7NDmAhFeWw244PQOhnsxpuUXZlQ7aP5RBXn\n4HONrCQWo0M4VC404SY+p2Jn4lbHtRIlePYnYjty7JcL7dCeLzgm4WnKb7bwdMOWuPYIz3vykcpg\nmtjf2cQWo1F485/kEDFf6MlCYrswNvG/PQp6jhnojHymBZoNbKtGbMUZiY0SXMQooRqZGXtX6Lk2\nnEsEWY0NmCN/G1QLI6wz5jqOpcLE6BYq2xttS4XZWoVXQjHux9z5cvzHv4UfsudwW40c0GcAAAAA\nSUVORK5CYII=\n",
        "prompt_number": 19,
        "text": [
         "True"
@@ -488,7 +544,8 @@
      ],
      "prompt_number": 19
     }
-   ]
+   ],
+   "metadata": {}
   }
  ]
 }

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -25,13 +25,16 @@ class Manifold(Basic):
     topological characteristics of the manifold that it represents.
 
     """
-    def __init__(self, name, dim):
-        super(Manifold, self).__init__()
-        self.name = name
-        self.dim = dim
-        self.patches = []
+    def __new__(cls, name, dim):
+        name = sympify(name)
+        dim = sympify(dim)
+        obj = Basic.__new__(cls, name, dim)
+        obj.name = name
+        obj.dim = dim
+        obj.patches = []
         # The patches list is necessary if a Patch instance needs to enumerate
         # other Patch instance on the same manifold.
+        return obj
 
     def _latex(self, printer, *args):
         return r'\mathrm{%s}' % self.name
@@ -62,14 +65,16 @@ class Patch(Basic):
     """
     # Contains a reference to the parent manifold in order to be able to access
     # other patches.
-    def __init__(self, name, manifold):
-        super(Patch, self).__init__()
-        self.name = name
-        self.manifold = manifold
-        self.manifold.patches.append(self)
-        self.coord_systems = []
+    def __new__(cls, name, manifold):
+        name = sympify(name)
+        obj = Basic.__new__(cls, name, manifold)
+        obj.name = name
+        obj.manifold = manifold
+        obj.manifold.patches.append(obj)
+        obj.coord_systems = []
         # The list of coordinate systems is necessary for an instance of
         # CoordSystem to enumerate other coord systems on the patch.
+        return obj
 
     @property
     def dim(self):
@@ -170,18 +175,18 @@ class CoordSystem(Basic):
     """
     #  Contains a reference to the parent patch in order to be able to access
     # other coordinate system charts.
-    def __init__(self, name, patch, names=None):
-        super(CoordSystem, self).__init__()
-        self.name = name
-        if not names:
-            names = ['%s_%d' % (name, i) for i in range(patch.dim)]
-        self._names = names
-        self.patch = patch
-        self._args = self.name, self.patch
+    def __new__(cls, name, patch, names=None):
+        name = sympify(name)
         # names is not in args because it is related only to printing, not to
         # identifying the CoordSystem instance.
-        self.patch.coord_systems.append(self)
-        self.transforms = {}
+        obj = Basic.__new__(cls, name, patch)
+        obj.name = name
+        if not names:
+            names = ['%s_%d' % (name, i) for i in range(patch.dim)]
+        obj._names = names
+        obj.patch = patch
+        obj.patch.coord_systems.append(obj)
+        obj.transforms = {}
         # All the coordinate transformation logic is in this dictionary in the
         # form of:
         #  key = other coordinate system
@@ -189,8 +194,9 @@ class CoordSystem(Basic):
         #          - list of `Dummy` coordinates in this coordinate system
         #          - list of expressions as a function of the Dummies giving
         #          the coordinates in another coordinate system
-        self._dummies = [Dummy(str(n)) for n in names]
-        self._dummy = Dummy()
+        obj._dummies = [Dummy(str(n)) for n in names]
+        obj._dummy = Dummy()
+        return obj
 
     @property
     def dim(self):
@@ -449,11 +455,14 @@ class BaseScalarField(Expr):
     g(-pi)
 
     """
-    def __init__(self, coord_sys, index):
-        super(BaseScalarField, self).__init__()
-        self._coord_sys = coord_sys
-        self._index = index
-        self._args = self._coord_sys, self._index
+
+    is_commutative = True
+
+    def __new__(cls, coord_sys, index):
+        obj = Expr.__new__(cls, coord_sys, sympify(index))
+        obj._coord_sys = coord_sys
+        obj._index = index
+        return obj
 
     def __call__(self, *args):
         """Evaluating the field at a point or doing nothing.
@@ -537,11 +546,15 @@ class BaseVectorField(Expr):
     \dxi_2                         /|xi_2=r0*sin(theta0)
 
     """
-    def __init__(self, coord_sys, index):
-        super(BaseVectorField, self).__init__()
-        self._coord_sys = coord_sys
-        self._index = index
-        self._args = self._coord_sys, self._index
+
+    is_commutative = False
+
+    def __new__(cls, coord_sys, index):
+        index = sympify(index)
+        obj = Expr.__new__(cls, coord_sys, index)
+        obj._coord_sys = coord_sys
+        obj._index = index
+        return obj
 
     def __call__(self, scalar_field):
         """Apply on a scalar field.
@@ -609,14 +622,10 @@ class Commutator(Expr):
     >>> c_xr
     Commutator(e_x, e_r)
 
-    """
-    # TODO simplify fails with an error
-    #>>> pprint(simplify(c_xr(R2.y**2).doit()))
-    #              -1
-    #     / 2    2\
-    #-2*y*\x  + y /  *cos(theta)*y
+    >>> simplify(c_xr(R2.y**2).doit())
+    -2*cos(theta)*y**2/(x**2 + y**2)
 
-    #"""
+    """
     def __new__(cls, v1, v2):
         if (covariant_order(v1) or contravariant_order(v1) != 1
                 or covariant_order(v2) or contravariant_order(v2) != 1):
@@ -704,6 +713,9 @@ class Differential(Expr):
     0
 
     """
+
+    is_commutative = False
+
     def __new__(cls, form_field):
         if contravariant_order(form_field):
             raise ValueError(
@@ -1394,7 +1406,7 @@ def vectors_in_basis(expr, to_sys):
     >>> from sympy.diffgeom import vectors_in_basis
     >>> from sympy.diffgeom.rn import R2_r, R2_p
     >>> vectors_in_basis(R2_r.e_x, R2_p)
-    (x**2 + y**2)**(-1/2)*x*e_r - y*(x**2 + y**2)**(-1)*e_theta
+    -y*e_theta/(x**2 + y**2) + x*e_r/sqrt(x**2 + y**2)
     >>> vectors_in_basis(R2_p.e_r, R2_r)
     sin(theta)*e_y + cos(theta)*e_x
     """
@@ -1501,7 +1513,7 @@ def metric_to_Christoffel_2nd(expr):
     >>> metric_to_Christoffel_2nd(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
     (((0, 0), (0, 0)), ((0, 0), (0, 0)))
     >>> metric_to_Christoffel_2nd(R2.x*TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
-    (((x**(-1)/2, 0), (0, 0)), ((0, 0), (0, 0)))
+    (((1/(2*x), 0), (0, 0)), ((0, 0), (0, 0)))
 
     """
     ch_1st = metric_to_Christoffel_1st(expr)
@@ -1549,10 +1561,9 @@ def metric_to_Riemann_components(expr):
     exp(2*r)*TensorProduct(dr, dr) + r**2*TensorProduct(dtheta, dtheta)
     >>> riemann = metric_to_Riemann_components(non_trivial_metric)
     >>> riemann[0]
-    (((0, 0), (0, 0)), ((0, -exp(-2*r)*r + 2*r*exp(-2*r)),
-        (exp(-2*r)*r - 2*r*exp(-2*r), 0)))
+    (((0, 0), (0, 0)), ((0, exp(-2*r)*r), (-exp(-2*r)*r, 0)))
     >>> riemann[1]
-    (((0, -r**(-1)), (r**(-1), 0)), ((0, 0), (0, 0)))
+    (((0, -1/r), (1/r, 0)), ((0, 0), (0, 0)))
 
     """
     ch_2nd = metric_to_Christoffel_2nd(expr)
@@ -1602,8 +1613,8 @@ def metric_to_Ricci_components(expr):
                              R2.r**2*TP(R2.dtheta, R2.dtheta)
     >>> non_trivial_metric
     exp(2*r)*TensorProduct(dr, dr) + r**2*TensorProduct(dtheta, dtheta)
-    >>> metric_to_Ricci_components(non_trivial_metric) #TODO why is this not simpler
-    ((r**(-1), 0), (0, -exp(-2*r)*r + 2*r*exp(-2*r)))
+    >>> metric_to_Ricci_components(non_trivial_metric)
+    ((1/r, 0), (0, exp(-2*r)*r))
 
     """
     riemann = metric_to_Riemann_components(expr)

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from itertools import permutations
 
 from sympy.matrices import Matrix
-from sympy.core import Basic, Expr, Dummy, Function, sympify, diff, Pow, Mul, Add
+from sympy.core import Basic, Expr, Dummy, Function, sympify, diff, Pow, Mul, Add, symbols, Tuple
 from sympy.core.numbers import Zero
 from sympy.solvers import solve
 from sympy.functions import factorial
@@ -179,11 +179,15 @@ class CoordSystem(Basic):
         name = sympify(name)
         # names is not in args because it is related only to printing, not to
         # identifying the CoordSystem instance.
-        obj = Basic.__new__(cls, name, patch)
-        obj.name = name
         if not names:
             names = ['%s_%d' % (name, i) for i in range(patch.dim)]
-        obj._names = names
+        if isinstance(names, Tuple):
+            obj = Basic.__new__(cls, name, patch, names)
+        else:
+            names = Tuple(*symbols(names))
+            obj = Basic.__new__(cls, name, patch, names)
+        obj.name = name
+        obj._names = [str(i) for i in names.args]
         obj.patch = patch
         obj.patch.coord_systems.append(obj)
         obj.transforms = {}
@@ -942,7 +946,7 @@ class LieDerivative(Expr):
     >>> LieDerivative(R2.e_x, tp)
     LieDerivative(e_x, TensorProduct(dx, dy))
     >>> LieDerivative(R2.e_x, tp).doit()
-    LieDerivative(e_rectangular_0, TensorProduct(dx, dy))
+    LieDerivative(e_x, TensorProduct(dx, dy))
     """
     def __new__(cls, v_field, expr):
         expr_form_ord = covariant_order(expr)

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -184,3 +184,13 @@ def test_correct_arguments():
 
     raises(ValueError, lambda: contravariant_order(R2.e_x*R2.e_y))
     raises(ValueError, lambda: covariant_order(R2.dx*R2.dy))
+
+def test_simplify():
+    x, y = R2_r.coord_functions()
+    dx, dy = R2_r.base_oneforms()
+    ex, ey = R2_r.base_vectors()
+    assert simplify(x) == x
+    assert simplify(x*y) == x*y
+    assert simplify(dx*dy) == dx*dy
+    assert simplify(ex*ey) == ex*ey
+    assert ((1-x)*dx)/(1-x)**2 == dx/(1-x)


### PR DESCRIPTION
The only point I'm not so sure is whether scalar fields **always** commute. I suppose they do.

All elements of the arg-trees are now subtypes of Basic (otherwise simplify( ) fails).
