### PR TITLE
Add Theano printing support for And/Or logical operators.

### DIFF
--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -262,6 +262,13 @@ def test_Piecewise():
     expected = tt.switch(xt < 0, xt, np.nan)
     assert theq(result, expected)
 
+    expr = sy.Piecewise((0, sy.And(x>0, x<2)), \
+        (x, sy.Or(x>2, x<0)))
+    result = theano_code(expr)
+    expected = tt.switch(tt.and_(xt>0,xt<2), 0, \
+        tt.switch(tt.or_(xt>2, xt<0), xt, np.nan))
+    assert theq(result, expected)
+
 def test_Relationals():
     xt, yt = theano_code(x), theano_code(y)
     assert theq(theano_code(x > y), xt > yt)

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -50,9 +50,10 @@ if theano:
             sympy.StrictLessThan: tt.lt,
             sympy.LessThan: tt.le,
             sympy.GreaterThan: tt.ge,
+            sympy.And: tt.and_,
+            sympy.Or: tt.or_,
             sympy.Max: tt.maximum,  # Sympy accept >2 inputs, Theano only 2
             sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
-
             # Matrices
             sympy.MatAdd: tt.Elemwise(ts.add),
             sympy.HadamardProduct: tt.Elemwise(ts.mul),


### PR DESCRIPTION
This PR builds on #2366 and #2370 to add support for Theano translation of piecewise functions containing logical operators in their conditions. This is useful for specifying conditions that are the intersection of sets of numbers, e.g., c_1 <= x < c_2, or the union, e.g., x < c_1 or x > c_2.

Example (from included test):

``` python
    expr = sy.Piecewise((0, sy.And(x>0, x<2)), (x, sy.Or(x>2, x<0)))
    result = theano_code(expr)
    expected = tt.switch(tt.and_(xt>0, xt<2), 0, tt.switch(tt.or_(xt>2, xt<0), xt, np.nan))
    assert theq(result, expected)
```
