### PR TITLE
Changed doit() in HadamardProduct to be used by hadamard_product() (fixes #8557 )

### DIFF
--- a/sympy/matrices/expressions/tests/test_hadamard.py
+++ b/sympy/matrices/expressions/tests/test_hadamard.py
@@ -1,7 +1,8 @@
 from sympy.core import symbols
 from sympy.utilities.pytest import raises
 
-from sympy.matrices import ShapeError, MatrixSymbol
+from sympy.matrices import (ShapeError, Matrix, MatrixSymbol, MatrixExpr,
+    randMatrix)
 from sympy.matrices.expressions import HadamardProduct, hadamard_product
 
 n, m, k = symbols('n,m,k')
@@ -9,9 +10,14 @@ Z = MatrixSymbol('Z', n, n)
 A = MatrixSymbol('A', n, m)
 B = MatrixSymbol('B', n, m)
 C = MatrixSymbol('C', m, k)
+M = randMatrix(3)
+N = randMatrix(3)
+P = MatrixSymbol('P', 3, 3)
+Q = MatrixSymbol('Q', 3, 3)
 
 def test_HadamardProduct():
     assert HadamardProduct(A, B, A).shape == A.shape
+    assert HadamardProduct(P, M, Q).shape == Q.shape
 
     raises(ShapeError, lambda: HadamardProduct(A, B.T))
     raises(TypeError,  lambda: HadamardProduct(A, n))
@@ -19,9 +25,13 @@ def test_HadamardProduct():
 
     assert HadamardProduct(A, 2*B, -A)[1, 1] == \
             -2 * A[1, 1] * B[1, 1] * A[1, 1]
+    assert HadamardProduct(M, 3*P, N)[0, 1] == \
+            3 * M[0, 1] * N[0, 1] * P[0, 1]
 
     mix = HadamardProduct(Z*A, B)*C
     assert mix.shape == (n, k)
+    mix = HadamardProduct(M*N, P)*Q
+    assert mix.shape == P.shape
 
     assert set(HadamardProduct(A, B, A).T.args) == set((A.T, A.T, B.T))
 
@@ -35,6 +45,9 @@ def test_mixed_indexing():
 
     assert (X*HadamardProduct(Y, Z))[0, 0] == \
             X[0, 0]*Y[0, 0]*Z[0, 0] + X[0, 1]*Y[1, 0]*Z[1, 0]
+    assert (P*HadamardProduct(M, Q))[1, 1] == \
+            P[1, 0]*M[0, 1]*Q[0, 1] + P[1, 1]*M[1, 1]*Q[1, 1] + \
+            P[1, 2]*M[2, 1]*Q[2, 1]
 
 def test_canonicalize():
     X = MatrixSymbol('X', 2, 2)
@@ -42,6 +55,16 @@ def test_canonicalize():
     assert isinstance(expr, HadamardProduct)
     expr2 = expr.doit() # unpack is called
     assert isinstance(expr2, MatrixSymbol)
+
+    expr = HadamardProduct(M, check=False)
+    assert isinstance(expr, HadamardProduct)
+    expr2 = expr.doit()
+    assert isinstance(expr2, MatrixExpr)
+
+    expr = HadamardProduct(M, P)
+    assert isinstance(expr, HadamardProduct)
+    expr2 = expr.doit()
+    assert isinstance(expr2, MatrixExpr)
 
 def test_hadamard():
     m, n, p = symbols('m, n, p', integer=True)
@@ -55,3 +78,6 @@ def test_hadamard():
     assert hadamard_product(A, B).doit() == hadamard_product(A, B)
     with raises(ShapeError):
         hadamard_product(A, C)
+
+    assert isinstance(hadamard_product(M, N, P), HadamardProduct)
+    assert hadamard_product(M, N, P) == hadamard_product(P, M, N).doit()


### PR DESCRIPTION
fixes #8557.`hadamard_product()` now returns elementwise multiplication for `Matrix` objects and returns unevaluated hadamard product in case of `MatrixSymbol`.

``` python
>>> a = Matrix([1, 1])
>>> b = Matrix([2, 2])
>>> h = hadamard_product(a, b)
>>> h
Matrix([
[2],
[2]])
>>> X = MatrixSymbol('X', 2, 1)
>>> Y = MatrixSymbol('Y', 2, 1)
>>> hadamard_product(X, Y)
X.*Y
>>> hadamard_product(a, X, b, Y)
Matrix([
[2],
[2]]).*X.*Y
```
