### PR TITLE
_eval_interval checks for zoo

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -744,7 +744,7 @@ class Expr(Basic, EvalfMixin):
             A = 0
         else:
             A = self.subs(x, a)
-            if A.has(S.NaN) or A.has(S.Infinity) or A.has(S.NegativeInfinity):
+            if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
                 A = limit(self, x, a)
                 if A is S.NaN:
                     return A
@@ -755,7 +755,7 @@ class Expr(Basic, EvalfMixin):
             B = 0
         else:
             B = self.subs(x, b)
-            if B.has(S.NaN) or B.has(S.Infinity) or B.has(S.NegativeInfinity):
+            if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
                 B = limit(self, x, b)
                 if isinstance(B, Limit):
                     raise NotImplementedError("Could not compute limit")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -6,7 +6,7 @@ from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
     Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp,
     simplify, together, collect, factorial, apart, combsimp, factor, refine,
     cancel, Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E,
-    exp_polar, Lambda, expand, diff, O, Heaviside)
+    exp_polar, Lambda, expand, diff, O, Heaviside, Si)
 from sympy.core.function import AppliedUndef
 from sympy.physics.secondquant import FockState
 from sympy.physics.units import meter
@@ -1398,6 +1398,9 @@ def test_issue_4199():
     assert a._eval_interval(x, -oo, oo) == -y
     assert a._eval_interval(x, oo, -oo) == y
 
+def test_eval_interval_zoo():
+    # Test that limit is used when zoo is returned
+    assert Si(1/x)._eval_interval(x, 0, 1) == -pi/2 + Si(1)
 
 def test_primitive():
     assert (3*(x + 1)**2).primitive() == (3, (x + 1)**2)


### PR DESCRIPTION
This fixes the integral integrate(x*sin(3/x), (x, 0, 1)) as reported at
http://stackoverflow.com/q/27517233/161801.

The result of the added test was verified by integrating the derivative of
Si(1/x) from x = 0 to 1 in WolframAlpha.
