### PR TITLE
Settling minmax assumptions + tests

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -419,6 +419,49 @@ class MinMaxBase(Expr, LatticeOp):
     def is_real(self):
         return fuzzy_and(arg.is_real for arg in self.args)
 
+    def _eval_is_algebraic(self):
+        if all(arg.is_algebraic for arg in self.args):
+            return True
+        if all(arg.is_algebraic is False for arg in self.args):
+            return False
+
+    def _eval_is_even(self):
+        if all(arg.is_even for arg in self.args):
+            return True
+        if all(arg.is_even is False for arg in self.args):
+            return False
+
+    def _eval_is_integer(self):
+        if all(arg.is_integer for arg in self.args):
+            return True
+        if all(arg.is_integer is False for arg in self.args):
+            return False
+
+    def _eval_is_irrational(self):
+        if all(arg.is_irrational for arg in self.args):
+            return True
+        if all(arg.is_irrational is False for arg in self.args):
+            return False
+
+    def _eval_is_noninteger(self):
+        if all(arg.is_noninteger for arg in self.args):
+            return True
+        if all(arg.is_noninteger is False for arg in self.args):
+            return False
+
+    def _eval_is_odd(self):
+        if all(arg.is_odd for arg in self.args):
+            return True
+        if all(arg.is_odd is False for arg in self.args):
+            return False
+
+    def _eval_is_rational(self):
+        if all(arg.is_rational for arg in self.args):
+            return True
+        if all(arg.is_rational is False for arg in self.args):
+            return False
+
+
 class Max(MinMaxBase, Application):
     """
     Return, if possible, the maximum value of the list.

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -455,6 +455,12 @@ class MinMaxBase(Expr, LatticeOp):
         if all(arg.is_odd is False for arg in self.args):
             return False
 
+    def _eval_is_prime(self):
+        if all(arg.is_prime for arg in self.args):
+            return True
+        if all(arg.is_prime is False for arg in self.args):
+            return False
+
     def _eval_is_rational(self):
         if all(arg.is_rational for arg in self.args):
             return True

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -11,6 +11,9 @@ from sympy.functions.special.delta_functions import Heaviside
 
 from sympy.utilities.pytest import raises
 
+import itertools as it
+
+
 def test_Min():
     from sympy.abc import x, y, z
     n = Symbol('n', negative=True)
@@ -103,10 +106,6 @@ def test_Min():
     assert Min(0, -x, 1 - 2*x).diff(x) == -Heaviside(x + Min(0, -2*x + 1)) \
         - 2*Heaviside(2*x + Min(0, -x) - 1)
 
-    a, b = Symbol('a', real=True), Symbol('b', real=True)
-    # a and b are both real, Min(a, b) should be real
-    assert Min(a, b).is_real
-
     # issue 7619
     f = Function('f')
     assert Min(1, 2*Min(f(1), 2))  # doesn't fail
@@ -163,14 +162,69 @@ def test_Max():
         2*x*Heaviside(x**2 - Max(1, x + 1)) \
         + Heaviside(x - Max(1, x**2) + 1)
 
-    a, b = Symbol('a', real=True), Symbol('b', real=True)
-    # a and b are both real, Max(a, b) should be real
-    assert Max(a, b).is_real
-
     # issue 7233
     e = Max(0, x)
     assert e.evalf == e.n
     assert e.n().args == (0, x)
+
+
+def test_minmax_assumptions():
+    r = Symbol('r', real=True)
+    a = Symbol('a', real=True, algebraic=True)
+    t = Symbol('t', real=True, transcendental=True)
+    q = Symbol('q', rational=True)
+    p = Symbol('p', real=True, rational=False)
+    n = Symbol('n', rational=True, integer=False)
+    i = Symbol('i', integer=True)
+    o = Symbol('o', odd=True)
+    e = Symbol('e', even=True)
+    reals = [r, a, t, q, p, n, i, o, e]
+
+    for ext in (Max, Min):
+        for x, y in it.product(reals, repeat=2):
+
+            # Must be real
+            assert ext(x, y).is_real
+
+            # Algebraic?
+            if x.is_algebraic and y.is_algebraic:
+                assert ext(x, y).is_algebraic
+            elif x.is_transcendental and y.is_transcendental:
+                assert ext(x, y).is_transcendental
+            else:
+                assert ext(x, y).is_algebraic is None
+
+            # Rational?
+            if x.is_rational and y.is_rational:
+                assert ext(x, y).is_rational
+            elif x.is_irrational and y.is_irrational:
+                assert ext(x, y).is_irrational
+            else:
+                assert ext(x, y).is_rational is None
+
+            # Integer?
+            if x.is_integer and y.is_integer:
+                assert ext(x, y).is_integer
+            elif x.is_noninteger and y.is_noninteger:
+                assert ext(x, y).is_noninteger
+            else:
+                assert ext(x, y).is_integer is None
+
+            # Odd?
+            if x.is_odd and y.is_odd:
+                assert ext(x, y).is_odd
+            elif x.is_odd is False and y.is_odd is False:
+                assert ext(x, y).is_odd is False
+            else:
+                assert ext(x, y).is_odd is None
+
+            # Even?
+            if x.is_even and y.is_even:
+                assert ext(x, y).is_even
+            elif x.is_even is False and y.is_even is False:
+                assert ext(x, y).is_even is False
+            else:
+                assert ext(x, y).is_even is None
 
 
 def test_issue_8413():

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -178,7 +178,8 @@ def test_minmax_assumptions():
     i = Symbol('i', integer=True)
     o = Symbol('o', odd=True)
     e = Symbol('e', even=True)
-    reals = [r, a, t, q, p, n, i, o, e]
+    k = Symbol('k', prime=True)
+    reals = [r, a, t, q, p, n, i, o, e, k]
 
     for ext in (Max, Min):
         for x, y in it.product(reals, repeat=2):
@@ -225,6 +226,14 @@ def test_minmax_assumptions():
                 assert ext(x, y).is_even is False
             else:
                 assert ext(x, y).is_even is None
+
+            # Prime?
+            if x.is_prime and y.is_prime:
+                assert ext(x, y).is_prime
+            elif x.is_prime is False and y.is_prime is False:
+                assert ext(x, y).is_prime is False
+            else:
+                assert ext(x, y).is_prime is None
 
 
 def test_issue_8413():


### PR DESCRIPTION
I've added some relevant assumption methods for minmax, including tests. It was weird, but I had to add the method `_eval_is_irrational` and `_eval_is_noninteger` - for some reason, there's no proper mixin here, and even if the max was evaluated to be `real=True` and `rational=False`, it didn't conclude that it is `irrational=True` - so I've added it manually.
