### PR TITLE
solver, solveset changes

### DIFF
--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -847,10 +847,10 @@ def test_M1():
 
 
 def test_M2():
-    # The roots of this equation should all be real. Note that this doesn't test
-    # that they are correct.
+    # The roots of this equation should all be real. Note that this
+    # doesn't test that they are correct.
     sol = solve(3*x**3 - 18*x**2 + 33*x - 19, x)
-    assert all(expand(x, complex=True).is_real for x in sol)
+    assert all(s.expand(complex=True).is_real for s in sol)
 
 
 @XFAIL
@@ -859,22 +859,26 @@ def test_M5():
 
 
 def test_M6():
-    assert set(solve(x**7 - 1, x)) == set([cos(n*2*pi/7) + I*sin(n*2*pi/7) for n in range(0, 7)])
-    # The paper asks for exp terms, but sin's and cos's may be acceptable
+    assert set(solve(x**7 - 1, x)) == \
+        set([cos(n*2*pi/7) + I*sin(n*2*pi/7) for n in range(0, 7)])
+    # The paper asks for exp terms, but sin's and cos's may be acceptable;
+    # if the results are simplified, exp terms appear for all but
+    # -sin(pi/14) - I*cos(pi/14) and -sin(pi/14) + I*cos(pi/14) which
+    # will simplify if you apply the transformation foo.rewrite(exp).expand()
 
 
 def test_M7():
-    assert set(solve(x**8 - 8*x**7 + 34*x**6 - 92*x**5 + 175*x**4 - 236*x**3 +
-        226*x**2 - 140*x + 46, x)) == set([
-        1 + sqrt(2)*I*sqrt(sqrt(-3 + 4*sqrt(3)) + 3)/2,
-        1 + sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*sqrt(-3 + I*sqrt(3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*I*sqrt(sqrt(-3 + 4*sqrt(3)) + 3)/2,
-        1 + sqrt(2)*sqrt(-3 - I*sqrt(3 + 4*sqrt(3)))/2,
-        1 + sqrt(2)*sqrt(-3 + I*sqrt(3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*sqrt(-3 - I*sqrt(3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
-        ])
+    sol = solve(x**8 - 8*x**7 + 34*x**6 - 92*x**5 + 175*x**4 - 236*x**3 +
+        226*x**2 - 140*x + 46, x)
+    assert [s.simplify() for s in sol] == [
+        1 - sqrt(-6 - 2*I*sqrt(3 + 4*sqrt(3)))/2,
+        1 + sqrt(-6 - 2*I*sqrt(3 + 4*sqrt(3)))/2,
+        1 - sqrt(-6 + 2*I*sqrt(3 + 4*sqrt(3)))/2,
+        1 + sqrt(-6 + 2*I*sqrt(3 + 4*sqrt (3)))/2,
+        1 - sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
+        1 + sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
+        1 - sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
+        1 + sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2]
 
 
 @XFAIL  # There are an infinite number of solutions.

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -244,7 +244,7 @@ def root(arg, n):
 
 def real_root(arg, n=None):
     """Return the real nth-root of arg if possible. If n is omitted then
-    all instances of -1**(1/odd) will be changed to -1.
+    all instances of (-n)**(1/odd) will be changed to -n**(1/odd).
 
     Examples
     ========
@@ -273,10 +273,10 @@ def real_root(arg, n=None):
             return rv
     else:
         rv = sympify(arg)
-    n1pow = Transform(lambda x: S.NegativeOne,
+    n1pow = Transform(lambda x: -(-x.base)**x.exp,
                       lambda x:
                       x.is_Pow and
-                      x.base is S.NegativeOne and
+                      x.base.is_negative and
                       x.exp.is_Rational and
                       x.exp.p == 1 and x.exp.q % 2)
     return rv.xreplace(n1pow)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -208,7 +208,7 @@ def test_root():
     assert root(x, -n) == x**(-1/n)
 
 
-def test_nthroot():
+def test_real_root():
     assert real_root(-8, 3) == -2
     assert real_root(-16, 4) == root(-16, 4)
     r = root(-7, 4)
@@ -217,6 +217,8 @@ def test_nthroot():
     r2 = r1**2
     r3 = root(-1, 4)
     assert real_root(r1 + r2 + r3) == -1 + r2 + r3
+    assert real_root(root(-2, 3)) == -root(2, 3)
+
 
 def test_rewrite_MaxMin_as_Heaviside():
     from sympy.abc import x, y, z

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -1664,9 +1664,8 @@ def test_idiff():
     assert ans == idiff(circ, [y], x, 3).simplify()
     assert idiff(circ, y, x, 3).simplify() == ans
     explicit  = 12*x/sqrt(-x**2 + 4)**5
-    assert ans.subs(y, solve(circ, y)[0]).simplify() == \
-        explicit
-    assert explicit in [sol.diff(x, 3).simplify() for sol in solve(circ, y)]
+    assert ans.subs(y, solve(circ, y)[0]).equals(explicit)
+    assert True in [sol.diff(x, 3).equals(explicit) for sol in solve(circ, y)]
     assert idiff(x + t + y, [y, t], x) == -Derivative(t, x) - 1
 
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -633,33 +633,37 @@ class RootOf(Expr):
         if not other.is_finite:
             return S.false
         z = self.expr.subs(self.expr.free_symbols.pop(), other).is_zero
-        if z is False:
+        if z is False:  # all roots will make z True but we don't know
+                        # whether this is the right root if z is True
             return S.false
         o = other.is_real, other.is_imaginary
         s = self.is_real, self.is_imaginary
         if o != s and None not in o and None not in s:
             return S.false
-        if z:
-            i = self._get_interval()
-            was = i.a, i.b
-            need = [1, 1]
-            # make sure it would be distinct from others
-            while any(need):
-                i = i.refine()
-                a, b = i.a, i.b
-                if need[0] and a != was[0]:
-                    need[0] = 0
-                if need[1] and b != was[1]:
-                    need[1] = 0
+        i = self._get_interval()
+        was = i.a, i.b
+        need = [True]*2
+        # make sure it would be distinct from others
+        while any(need):
+            i = i.refine()
+            a, b = i.a, i.b
+            if need[0] and a != was[0]:
+                need[0] = False
+            if need[1] and b != was[1]:
+                need[1] = False
+        re, im = other.as_real_imag()
+        if not im:
             if self.is_real:
                 a, b = [Rational(str(i)) for i in (a, b)]
                 return sympify(a < other and other < b)
-            re, im = other.as_real_imag()
-            z = r1, r2, i1, i2 = [Rational(str(j)) for j in (
-                i.ax, i.bx, i.ay, i.by)]
-            return sympify((
-                r1 < re and re < r2) and (
-                i1 < im and im < i2))
+            return S.false
+        if self.is_real:
+            return S.false
+        z = r1, r2, i1, i2 = [Rational(str(j)) for j in (
+            i.ax, i.bx, i.ay, i.by)]
+        return sympify((
+            r1 < re and re < r2) and (
+            i1 < im and im < i2))
 
 
 @public

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -151,6 +151,10 @@ def test_RootOf___eval_Eq__():
     for s in sol:
         if s.is_real:
             assert Eq(r, s) is S.true
+    eq = (x**3 + x + 1)
+    assert [Eq(RootOf(eq,i), j) for i in range(3) for j in solve(eq)] == [
+        False, False, True, False, True, False, True, False, False]
+    assert Eq(RootOf(eq, 0), 1 + S.ImaginaryUnit) == False
 
 
 def test_RootOf_is_real():

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -562,8 +562,10 @@ def dsolve(eq, func=None, hint="default", simplify=True,
     >>> dsolve(eq, hint='1st_exact')
     [f(x) == -acos(C1/cos(x)) + 2*pi, f(x) == acos(C1/cos(x))]
     >>> dsolve(eq, hint='almost_linear')
-    [f(x) == -acos(-sqrt(C1/cos(x)**2)) + 2*pi, f(x) == -acos(sqrt(C1/cos(x)**2)) + 2*pi,
-    f(x) == acos(-sqrt(C1/cos(x)**2)), f(x) == acos(sqrt(C1/cos(x)**2))]
+    [f(x) == -acos(-sqrt(C1/cos(x)**2)) + 2*pi,
+    f(x) == -acos(sqrt(C1/cos(x)**2)) + 2*pi,
+    f(x) == acos(-sqrt(C1/cos(x)**2)),
+    f(x) == acos(sqrt(C1/cos(x)**2))]
     >>> t = symbols('t')
     >>> x, y = symbols('x, y', function=True)
     >>> eq = (Eq(Derivative(x(t),t), 12*t*x(t) + 8*y(t)), Eq(Derivative(y(t),t), 21*x(t) + 7*t*y(t)))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1170,12 +1170,14 @@ def _solve(f, *symbols, **flags):
         result = set()
         for n, (expr, cond) in enumerate(f.args):
             candidates = _solve(expr, *symbols, **flags)
-
             for candidate in candidates:
                 if candidate in result:
                     continue
-                conds = (cond == True) or cond.subs(symbol, candidate)
-                if conds != False:
+                try:
+                    v = (cond == True) or cond.subs(symbol, candidate)
+                except:
+                    v = False
+                if v != False:
                     # Only include solutions that do not match the condition
                     # of any previous pieces.
                     matches_other_piece = False
@@ -1184,12 +1186,18 @@ def _solve(f, *symbols, **flags):
                             break
                         if other_cond == False:
                             continue
-                        if other_cond.subs(symbol, candidate) == True:
-                            matches_other_piece = True
-                            break
+                        try:
+                            if other_cond.subs(symbol, candidate) == True:
+                                matches_other_piece = True
+                                break
+                        except:
+                            pass
                     if not matches_other_piece:
+                        v = v == True or v.doit()
+                        if isinstance(v, Relational):
+                            v = v.canonical
                         result.add(Piecewise(
-                            (candidate, conds == True or conds.doit()),
+                            (candidate, v),
                             (S.NaN, True)
                         ))
         check = False

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1215,7 +1215,6 @@ def _solve(f, *symbols, **flags):
 
         result = False  # no solution was obtained
         msg = ''  # there is no failure message
-        dens = denoms(f, symbols)  # store these for checking later
 
         # Poly is generally robust enough to convert anything to
         # a polynomial and tell us the different generators that it
@@ -1235,8 +1234,7 @@ def _solve(f, *symbols, **flags):
                     u = None  # hope for best with original equation
             if u:
                 flags['unrad'] = False  # don't unrad next time
-                eq, cov, dens2 = u
-                dens.update(dens2)
+                eq, cov, _ = u
                 if cov:
                     if len(cov) > 1:
                         raise NotImplementedError('Not sure how to handle this.')
@@ -1435,7 +1433,7 @@ def _solve(f, *symbols, **flags):
         # if in doubt, keep it
         result = [s for s in result if isinstance(s, RootOf) or
                   all(not checksol(den, {symbol: s}, **flags)
-                    for den in dens)]
+                    for den in denoms(f, symbols))]
         # keep only results if the check is not False
         result = [r for r in result if isinstance(r, RootOf) or
                   checksol(f_num, {symbol: r}, **flags) is not False]

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -529,12 +529,11 @@ def _solve_as_poly(f, symbol, solveset_solver, invert_func):
             if gen != symbol:
                 y = Dummy('y')
                 lhs, rhs_s = invert_func(gen, y, symbol)
-                result = Union(*[rhs_s.subs(y, s) for s in poly_solns])
-                if lhs is not symbol and lhs is not gen:
-                    result = Union(*[solveset_solver(lhs - rhs, symbol)
-                                     for rhs in result])
+                if lhs is symbol:
+                    result = Union(*[rhs_s.subs(y, s) for s in poly_solns])
                 else:
-                    raise NotImplementedError
+                    raise NotImplementedError(
+                        "inversion of %s not handled" % gen)
         else:
             raise NotImplementedError("multiple generators not handled"
                                       " by solveset")
@@ -737,7 +736,13 @@ def solveset_complex(f, symbol):
             result = EmptySet()
             for equation in equations:
                 if equation == f:
-                    result += _solve_as_rational(equation, symbol,
+                    if any(_has_rational_power(g, symbol)[0]
+                           for g in equation.args):
+                        result += _solve_radical(equation,
+                                                 symbol,
+                                                 solveset_complex)
+                    else:
+                        result += _solve_as_rational(equation, symbol,
                                                  solveset_solver=solveset_complex,
                                                  as_poly_solver=_solve_as_poly_complex)
                 else:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -273,24 +273,36 @@ def test_nonlinear_2eq_order1():
     x, y, z = symbols('x, y, z', function=True)
     t = Symbol('t')
     eq1 = (Eq(diff(x(t),t),x(t)*y(t)**3), Eq(diff(y(t),t),y(t)**5))
-    sol1 = [Eq(x(t), C1*exp((-1/(4*C2 + 4*t))**(-S(1)/4))), Eq(y(t), -(-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), C1*exp(-1/(-1/(4*C2 + 4*t))**(S(1)/4))), Eq(y(t), (-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), C1*exp(-I/(-1/(4*C2 + 4*t))**(S(1)/4))), Eq(y(t), -I*(-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), C1*exp(I/(-1/(4*C2 + 4*t))**(S(1)/4))), Eq(y(t), I*(-1/(4*C2 + 4*t))**(S(1)/4))]
+    sol1 = [
+        Eq(x(t), C1*exp((-1/(4*C2 + 4*t))**(-S(1)/4))),
+        Eq(y(t), -(-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), C1*exp(-1/(-1/(4*C2 + 4*t))**(S(1)/4))),
+        Eq(y(t), (-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), C1*exp(-I/(-1/(4*C2 + 4*t))**(S(1)/4))),
+        Eq(y(t), -I*(-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), C1*exp(I/(-1/(4*C2 + 4*t))**(S(1)/4))),
+        Eq(y(t), I*(-1/(4*C2 + 4*t))**(S(1)/4))]
     assert dsolve(eq1) == sol1
 
     eq2 = (Eq(diff(x(t),t), exp(3*x(t))*y(t)**3),Eq(diff(y(t),t), y(t)**5))
-    sol2 = [Eq(x(t), -log(C1 - 3/(-1/(4*C2 + 4*t))**(S(1)/4))/3), Eq(y(t), -(-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), -log(C1 + 3/(-1/(4*C2 + 4*t))**(S(1)/4))/3), Eq(y(t), (-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), -log(C1 + 3*I/(-1/(4*C2 + 4*t))**(S(1)/4))/3), Eq(y(t), -I*(-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), -log(C1 - 3*I/(-1/(4*C2 + 4*t))**(S(1)/4))/3), Eq(y(t), I*(-1/(4*C2 + 4*t))**(S(1)/4))]
+    sol2 = [
+        Eq(x(t), -log(C1 - 3/(-1/(4*C2 + 4*t))**(S(1)/4))/3),
+        Eq(y(t), -(-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), -log(C1 + 3/(-1/(4*C2 + 4*t))**(S(1)/4))/3),
+        Eq(y(t), (-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), -log(C1 + 3*I/(-1/(4*C2 + 4*t))**(S(1)/4))/3),
+        Eq(y(t), -I*(-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), -log(C1 - 3*I/(-1/(4*C2 + 4*t))**(S(1)/4))/3),
+        Eq(y(t), I*(-1/(4*C2 + 4*t))**(S(1)/4))]
     assert dsolve(eq2) == sol2
 
     eq3 = (Eq(diff(x(t),t), y(t)*x(t)), Eq(diff(y(t),t), x(t)**3))
-    sol3 = [Eq(x(t), 6**(S(2)/3)/(6*(sinh(sqrt(C1*(C2 + t)**2)/2)/sqrt(C1))**(S(2)/3))), \
-    Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1*(C2 + t)**2)/2)**2)/3), \
-    Eq(x(t), 6**(S(2)/3)/(6*(-sinh(sqrt(C1*(C2 + t)**2)/2)/sqrt(C1))**(S(2)/3))), \
-    Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1*(C2 + t)**2)/2)**2)/3)]
+    tt = S(2)/3
+    sol3 = [
+        Eq(x(t), 6**tt/(6*(sinh(sqrt(C1*(C2 + t)**2)/2)/sqrt(C1))**tt)),
+        Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1*(C2 + t)**2)/2)**2)/3),
+        Eq(x(t), 6**tt/(6*(-sinh(sqrt(C1*(C2 + t)**2)/2)/sqrt(C1))**tt)),
+        Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1*(C2 + t)**2)/2)**2)/3)]
     assert dsolve(eq3) == sol3
 
     eq4 = (Eq(diff(x(t),t),x(t)*y(t)*sin(t)**2), Eq(diff(y(t),t),y(t)**2*sin(t)**2))
@@ -302,10 +314,15 @@ def test_nonlinear_2eq_order1():
     assert dsolve(eq5) == sol5
 
     eq6 = (Eq(diff(x(t),t),x(t)**2*y(t)**3), Eq(diff(y(t),t),y(t)**5))
-    sol6 = [Eq(x(t), 1/(C1 - 1/(-1/(4*C2 + 4*t))**(S(1)/4))), Eq(y(t), -(-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), 1/(C1 + (-1/(4*C2 + 4*t))**(-S(1)/4))), Eq(y(t), (-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), 1/(C1 + I/(-1/(4*C2 + 4*t))**(S(1)/4))), Eq(y(t), -I*(-1/(4*C2 + 4*t))**(S(1)/4)), \
-    Eq(x(t), 1/(C1 - I/(-1/(4*C2 + 4*t))**(S(1)/4))), Eq(y(t), I*(-1/(4*C2 + 4*t))**(S(1)/4))]
+    sol6 = [
+        Eq(x(t), 1/(C1 - 1/(-1/(4*C2 + 4*t))**(S(1)/4))),
+        Eq(y(t), -(-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), 1/(C1 + (-1/(4*C2 + 4*t))**(-S(1)/4))),
+        Eq(y(t), (-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), 1/(C1 + I/(-1/(4*C2 + 4*t))**(S(1)/4))),
+        Eq(y(t), -I*(-1/(4*C2 + 4*t))**(S(1)/4)),
+        Eq(x(t), 1/(C1 - I/(-1/(4*C2 + 4*t))**(S(1)/4))),
+        Eq(y(t), I*(-1/(4*C2 + 4*t))**(S(1)/4))]
     assert dsolve(eq6) == sol6
 
 
@@ -1830,7 +1847,8 @@ def test_Liouville_ODE():
     sol1a = Eq(C1 + C2/x - exp(-f(x)), 0)
     sol2 = sol1
     sol3 = set(
-        [Eq(f(x), -sqrt(C1 + C2*log(x))), Eq(f(x), sqrt(C1 + C2*log(x)))])
+        [Eq(f(x), -sqrt(C1 + C2*log(x))),
+        Eq(f(x), sqrt(C1 + C2*log(x)))])
     sol4 = set([Eq(f(x), sqrt(C1 + C2*exp(x))*exp(-x/2)),
                 Eq(f(x), -sqrt(C1 + C2*exp(x))*exp(-x/2))])
     sol5 = Eq(f(x), log(C1 + C2/x))
@@ -2091,7 +2109,7 @@ def test_almost_linear():
     d = f(x).diff(x)
     eq = x**2*f(x)**2*d + f(x)**3 + 1
     sol = dsolve(eq, f(x), hint = 'almost_linear')
-    assert sol[0].rhs == (C1*exp(3/x) - 1)**(1/3)
+    assert sol[0].rhs == (C1*exp(3/x) - 1)**(S(1)/3)
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*f(x)*d + 2*x*f(x)**2 + 1
@@ -2230,7 +2248,7 @@ def test_constantsimp_take_problem():
 def test_issue_6879():
     f = Function('f')
     eq = Eq(Derivative(f(x), x, 2) - 2*Derivative(f(x), x) + f(x), sin(x))
-    sol = (C1 + C2*x)*exp(x) + cos(x)/S(2)
+    sol = (C1 + C2*x)*exp(x) + cos(x)/2
     assert dsolve(eq).rhs == sol
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
@@ -2410,11 +2428,11 @@ def test_series():
     C1 = Symbol("C1")
     eq = f(x).diff(x) - f(x)
     assert dsolve(eq, hint='1st_power_series') == Eq(f(x),
-        C1 + C1*x + C1*x**2/S(2) + C1*x**3/S(6) + C1*x**4/S(24) +
-        C1*x**5/S(120) + O(x**6))
+        C1 + C1*x + C1*x**2/2 + C1*x**3/6 + C1*x**4/24 +
+        C1*x**5/120 + O(x**6))
     eq = f(x).diff(x) - x*f(x)
     assert dsolve(eq, hint='1st_power_series') == Eq(f(x),
-        C1*x**4/S(8) + C1*x**2/S(2) + C1 + O(x**6))
+        C1*x**4/8 + C1*x**2/2 + C1 + O(x**6))
     eq = f(x).diff(x) - sin(x*f(x))
     sol = Eq(f(x), (x - 2)**2*(1+ sin(4))*cos(4) + (x - 2)*sin(4) + 2 + O(x**3))
     assert dsolve(eq, hint='1st_power_series', ics={f(2): 2}, n=3) == sol
@@ -2430,7 +2448,7 @@ def test_lie_group():
 
     eq = Eq(f(x).diff(x), x**2*f(x))
     sol = dsolve(eq, f(x), hint='lie_group')
-    assert sol == Eq(f(x), C1*exp(x**3)**(1/S(3)))
+    assert sol == Eq(f(x), C1*exp(x**3)**(1/3))
     assert checkodesol(eq, sol)[0]
 
     eq = f(x).diff(x) + a*f(x) - c*exp(b*x)
@@ -2439,7 +2457,7 @@ def test_lie_group():
 
     eq = f(x).diff(x) + 2*x*f(x) - x*exp(-x**2)
     sol = dsolve(eq, f(x), hint='lie_group')
-    actual_sol = Eq(f(x), (C1 + x**2/S(2))*exp(-x**2))
+    actual_sol = Eq(f(x), (C1 + x**2/2)*exp(-x**2))
     errstr = str(eq)+' : '+str(sol)+' == '+str(actual_sol)
     assert sol == actual_sol, errstr
     assert checkodesol(eq, sol)[0]
@@ -2481,58 +2499,58 @@ def test_2nd_power_series_ordinary():
     eq = f(x).diff(x, 2) - x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
     assert dsolve(eq) == Eq(f(x),
-        C2*(x**3/S(6) + 1) + C1*x*(x**3/S(12) + 1) + O(x**6))
+        C2*(x**3/6 + 1) + C1*x*(x**3/12 + 1) + O(x**6))
     assert dsolve(eq, x0=-2) == Eq(f(x),
-        C2*((x + 2)**4/S(6) + (x + 2)**3/S(6) - (x + 2)**2 + 1)
-        + C1*(x + (x + 2)**4/S(12) - (x + 2)**3/3 + S(2))
+        C2*((x + 2)**4/6 + (x + 2)**3/6 - (x + 2)**2 + 1)
+        + C1*(x + (x + 2)**4/12 - (x + 2)**3/3 + S(2))
         + O(x**6))
     assert dsolve(eq, n=2) == Eq(f(x), C2*x + C1 + O(x**2))
 
     eq = (1 + x**2)*(f(x).diff(x, 2)) + 2*x*(f(x).diff(x)) -2*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C2*(-x**4/S(3) + x**2 + 1) + C1*x
+    assert dsolve(eq) == Eq(f(x), C2*(-x**4/3 + x**2 + 1) + C1*x
         + O(x**6))
 
     eq = f(x).diff(x, 2) + x*(f(x).diff(x)) + f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
     assert dsolve(eq) == Eq(f(x), C2*(
-        x**4/S(8) - x**2/S(2) + 1) + C1*x*(-x**2/S(3) + 1) + O(x**6))
+        x**4/8 - x**2/2 + 1) + C1*x*(-x**2/3 + 1) + O(x**6))
 
     eq = f(x).diff(x, 2) + f(x).diff(x) - x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
     assert dsolve(eq) == Eq(f(x), C2*(
-        -x**4/S(24) + x**3/S(6) + 1) + C1*x*(x**3/S(24) + x**2/S(6) - x/S(2)
+        -x**4/24 + x**3/6 + 1) + C1*x*(x**3/24 + x**2/6 - x/2
         + 1) + O(x**6))
 
     eq = f(x).diff(x, 2) + x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
     assert dsolve(eq, n=7) == Eq(f(x), C2*(
-        x**6/S(180) - x**3/S(6) + 1) + C1*x*(-x**3/S(12) + 1) + O(x**7))
+        x**6/180 - x**3/6 + 1) + C1*x*(-x**3/12 + 1) + O(x**7))
 
 
 def test_2nd_power_series_regular():
     C1, C2 = symbols("C1 C2")
     eq = x**2*(f(x).diff(x, 2)) - 3*x*(f(x).diff(x)) + (4*x + 4)*f(x)
-    assert dsolve(eq) == Eq(f(x), C1*x**2*(-16*x**3/S(9) +
+    assert dsolve(eq) == Eq(f(x), C1*x**2*(-16*x**3/9 +
         4*x**2 - 4*x + 1) + O(x**6))
 
     eq = 4*x**2*(f(x).diff(x, 2)) -8*x**2*(f(x).diff(x)) + (4*x**2 +
         1)*f(x)
     assert dsolve(eq) == Eq(f(x), C1*sqrt(x)*(
-        x**4/S(24) + x**3/S(6) + x**2/S(2) + x + 1) + O(x**6))
+        x**4/24 + x**3/6 + x**2/2 + x + 1) + O(x**6))
 
     eq = x**2*(f(x).diff(x, 2)) - x**2*(f(x).diff(x)) + (
         x**2 - 2)*f(x)
-    assert dsolve(eq) == Eq(f(x), C1*(-x**6/S(720) - 3*x**5/S(80) - x**4/S(8) +
-        x**2/S(2) + x/S(2) + 1)/x + C2*x**2*(-x**3/S(60) + x**2/S(20) + x/S(2) + 1)
+    assert dsolve(eq) == Eq(f(x), C1*(-x**6/720 - 3*x**5/80 - x**4/8 +
+        x**2/2 + x/2 + 1)/x + C2*x**2*(-x**3/60 + x**2/20 + x/2 + 1)
         + O(x**6))
 
-    eq = x**2*(f(x).diff(x, 2)) + x*(f(x).diff(x)) + (x**2 - 1/S(4))*f(x)
-    assert dsolve(eq) == Eq(f(x), C1*(x**4/S(24) - x**2/S(2) + 1)/sqrt(x) +
-        C2*sqrt(x)*(x**4/S(120) - x**2/S(6) + 1) + O(x**6))
+    eq = x**2*(f(x).diff(x, 2)) + x*(f(x).diff(x)) + (x**2 - S(1)/4)*f(x)
+    assert dsolve(eq) == Eq(f(x), C1*(x**4/24 - x**2/2 + 1)/sqrt(x) +
+        C2*sqrt(x)*(x**4/120 - x**2/6 + 1) + O(x**6))
 
     eq = x*(f(x).diff(x, 2)) - f(x).diff(x) + 4*x**3*f(x)
-    assert dsolve(eq) == Eq(f(x), C2*(-x**4/S(2) + 1) + C1*x**2 + O(x**6))
+    assert dsolve(eq) == Eq(f(x), C2*(-x**4/2 + 1) + C1*x**2 + O(x**6))
 
 def test_issue_7093():
     x = Symbol("x") # assuming x is real leads to an error

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -244,7 +244,6 @@ def test_highorder_poly():
     assert all(isinstance(i, RootOf) for i in sol) and len(sol) == 6
 
 
-@XFAIL
 @slow
 def test_quintics_2():
     f = x**5 + 15*x + 12

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -858,7 +858,6 @@ def test_unrad():
     assert solve(Eq(sqrt(x + 7) + 2, sqrt(3 - x))) == [-6]
     # http://www.purplemath.com/modules/solverad.htm
     assert solve((2*x - 5)**Rational(1, 3) - 3) == [16]
-    assert solve((x**3 - 3*x**2)**Rational(1, 3) + 1 - x) == []
     assert set(solve(x + 1 - (x**4 + 4*x**3 - x)**Rational(1, 4))) == \
         set([-S(1)/2, -S(1)/3])
     assert set(solve(sqrt(2*x**2 - 7) - (3 - x))) == set([-S(8), S(2)])
@@ -888,6 +887,13 @@ def test_unrad():
         solve(sqrt(x) + root(x, 3) + root(x + 1, 5) - 2))
     # fails through a different code path
     raises(NotImplementedError, lambda: solve(-sqrt(2) + cosh(x)/x))
+
+
+@XFAIL
+def test_unrad_fail():
+    # this only works if we check real_root(eq.subs(x, S(1)/3))
+    # but checksol doesn't work like that
+    assert solve((x**3 - 3*x**2)**Rational(1, 3) + 1 - x) == [S(1)/3]
 
 
 @slow

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -33,6 +33,7 @@ def test_swap_back():
     assert solve(fx + gx**2*x - y, [fx, gx]) == [{fx: y - gx**2*x}]
     assert solve([f(1) - 2, x + 2]) == [{x: -2, f(1): 2}]
 
+
 def guess_solve_strategy(eq, symbol):
     try:
         solve(eq, symbol)
@@ -154,12 +155,9 @@ def test_solve_polynomial1():
     assert set(solve(Eq(x**2, 1), x)) == set([-S(1), S(1)])
 
     assert solve(x - y**3, x) == [y**3]
-    assert set(solve(x - y**3, y)) == set([
-        (-x**Rational(1, 3))/2 + I*sqrt(3)*x**Rational(1, 3)/2,
-        x**Rational(1, 3),
-        (-x**Rational(1, 3))/2 - I*sqrt(3)*x**Rational(1, 3)/2,
-    ])
-
+    rx = root(x, 3)
+    assert solve(x - y**3, y) == [
+        rx, -rx/2 - sqrt(3)*I*rx/2, -rx/2 +  sqrt(3)*I*rx/2]
     a11, a12, a21, a22, b1, b2 = symbols('a11,a12,a21,a22,b1,b2')
 
     assert solve([a11*x + a12*y - b1, a21*x + a22*y - b2], x, y) == \
@@ -203,7 +201,7 @@ def test_solve_polynomial_cv_1a():
 
 def test_solve_polynomial_cv_1b():
     assert set(solve(4*x*(1 - a*sqrt(x)), x)) == set([S(0), 1/a**2])
-    assert set(solve(x * (x**(S(1)/3) - 3), x)) == set([S(0), S(27)])
+    assert set(solve(x*(root(x, 3) - 3), x)) == set([S(0), S(27)])
 
 
 def test_solve_polynomial_cv_2():
@@ -353,7 +351,7 @@ def test_solve_transcendental():
     assert solve(x + 2**x, x) == [-LambertW(log(2))/log(2)]
     ans = solve(3*x + 5 + 2**(-5*x + 3), x)
     assert len(ans) == 1 and ans[0].expand() == \
-        -Rational(5, 3) + LambertW(-10240*2**(S(1)/3)*log(2)/3)/(5*log(2))
+        -Rational(5, 3) + LambertW(-10240*root(2, 3)*log(2)/3)/(5*log(2))
     assert solve(5*x - 1 + 3*exp(2 - 7*x), x) == \
         [Rational(1, 5) + LambertW(-21*exp(Rational(3, 5))/5)/7]
     assert solve(2*x + 5 + log(3*x - 2), x) == \
@@ -583,7 +581,7 @@ def test_PR1964():
     f = Function('f')
     assert solve((3 - 5*x/f(x))*f(x), f(x)) == [5*x/3]
     # issue 4497
-    assert solve(1/(5 + x)**(S(1)/5) - 9, x) == [-295244/S(59049)]
+    assert solve(1/root(5 + x, 5) - 9, x) == [-295244/S(59049)]
 
     assert solve(sqrt(x) + sqrt(sqrt(x)) - 4) == [-9*sqrt(17)/2 + 49*S.Half]
     assert set(solve(Poly(sqrt(exp(x)) + sqrt(exp(-x)) - 4))) in \
@@ -599,13 +597,11 @@ def test_PR1964():
     assert solve(exp(x/y)*exp(-z/y) - 2, y) == [(x - z)/log(2)]
     assert solve(
         x**z*y**z - 2, z) in [[log(2)/(log(x) + log(y))], [log(2)/(log(x*y))]]
-    # if you do inversion too soon then multiple roots as for the following will
-    # be missed, e.g. if exp(3*x) = exp(3) -> 3*x = 3
+    # if you do inversion too soon then multiple roots (as for the following)
+    # will be missed, e.g. if exp(3*x) = exp(3) -> 3*x = 3
     E = S.Exp1
-    assert set(solve(exp(3*x) - exp(3), x)) in [
-        set([S(1), log(-E/2 - sqrt(3)*E*I/2), log(-E/2 + sqrt(3)*E*I/2)]),
-        set([S(1), log(E*(-S(1)/2 - sqrt(3)*I/2)), log(E*(-S(1)/2 + sqrt(3)*I/2))]),
-    ]
+    assert solve(exp(3*x) - exp(3), x) == [
+        1, log(E*(-S.Half - sqrt(3)*I/2)), log(E*(-S.Half + sqrt(3)*I/2))]
 
     # coverage test
     p = Symbol('p', positive=True)
@@ -644,9 +640,9 @@ def test_checking():
 def test_issue_4671_4463_4467():
     assert solve((sqrt(x**2 - 1) - 2)) in ([sqrt(5), -sqrt(5)],
                                            [-sqrt(5), sqrt(5)])
-    assert set(solve((2**exp(y**2/x) + 2)/(x**2 + 15), y)) == set([
+    assert solve((2**exp(y**2/x) + 2)/(x**2 + 15), y) == [
         -sqrt(x)*sqrt(-log(log(2)) + log(log(2) + I*pi)),
-        sqrt(x)*sqrt(-log(log(2)) + log(log(2) + I*pi))])
+        sqrt(x)*sqrt(-log(log(2)) + log(log(2) + I*pi))]
 
     C1, C2 = symbols('C1 C2')
     f = Function('f')
@@ -1247,6 +1243,7 @@ def test__ispow():
     assert not _ispow(True)
 
 
+@slow
 def test_issue_6644():
     eq = -sqrt((m - q)**2 + (-m/(2*q) + S(1)/2)**2) + sqrt((-m**2/2 - sqrt(
     4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2 + (m**2/2 - m - sqrt(
@@ -1342,12 +1339,16 @@ def test_lambert_multivariate():
 
     # if sign is unknown then only this one solution is obtained
     assert solve(3*log(a**(3*x + 5)) + a**(3*x + 5), x) == [
-        -((log(a**5) + LambertW(S(1)/3))/(3*log(a)))]  # tested numerically
+        -((log(a**5) + LambertW(S(1)/3))/(3*log(a)))]
     p = symbols('p', positive=True)
+    _13 = S(1)/3
+    _56 = S(5)/6
+    _53 = S(5)/3
     assert solve(3*log(p**(3*x + 5)) + p**(3*x + 5), x) == [
-        log((-3**(S(1)/3) - 3**(S(5)/6)*I)*LambertW(S(1)/3)**(S(1)/3)/(2*p**(S(5)/3)))/log(p),
-        log((-3**(S(1)/3) + 3**(S(5)/6)*I)*LambertW(S(1)/3)**(S(1)/3)/(2*p**(S(5)/3)))/log(p),
-        log((3*LambertW(S(1)/3)/p**5)**(1/(3*log(p)))),]  # checked numerically
+        log((-3**_13 - 3**_56*I)*LambertW(_13)**_13/(2*p**_53))/log(p),
+        log((-3**_13 + 3**_56*I)*LambertW(_13)**_13/(2*p**_53))/log(p),
+        log((3*LambertW(_13)/p**5)**(1/(3*log(p))))]
+
     # check collection
     assert solve(3*log(a**(3*x + 5)) + b*log(a**(3*x + 5)) + a**(3*x + 5), x) == [
         -((log(a**5) + LambertW(1/(b + 3)))/(3*log(a)))]
@@ -1358,7 +1359,7 @@ def test_lambert_multivariate():
 
     # issue 4271
     assert solve((a/x + exp(x/2)).diff(x, 2), x) == [
-        6*LambertW((-1)**(S(1)/3)*a**(S(1)/3)/3)]
+        6*LambertW(root(-1, 3)*root(a, 3)/3)]
 
     assert solve((log(x) + x).subs(x, x**2 + 1)) == [
         -I*sqrt(-LambertW(1) + 1), sqrt(-1 + LambertW(1))]
@@ -1434,12 +1435,12 @@ def test_issue_2725():
     R = Symbol('R')
     eq = sqrt(2)*R*sqrt(1/(R + 1)) + (R + 1)*(sqrt(2)*sqrt(1/(R + 1)) - 1)
     sol = solve(eq, R, set=True)[1]
-    assert sol == set([(S(5)/3 + 40/(3*(251 + 3*sqrt(111)*I)**(S(1)/3)) +
-                       (251 + 3*sqrt(111)*I)**(S(1)/3)/3,), ((-160 + (1 +
-                       sqrt(3)*I)*(10 - (1 + sqrt(3)*I)*(251 +
-                       3*sqrt(111)*I)**(S(1)/3))*(251 +
-                       3*sqrt(111)*I)**(S(1)/3))/Mul(6, (1 +
-                       sqrt(3)*I), (251 + 3*sqrt(111)*I)**(S(1)/3),
+    assert sol == set([(S(5)/3 + 40/(3*root(251 + 3*sqrt(111)*I, 3)) +
+                       root(251 + 3*sqrt(111)*I, 3)/3,), ((-160 + (1 +
+                       sqrt(3)*I)*(10 - (1 + sqrt(3)*I)*root(251 +
+                       3*sqrt(111)*I, 3))*root(251 +
+                       3*sqrt(111)*I, 3))/Mul(6, (1 +
+                       sqrt(3)*I), root(251 + 3*sqrt(111)*I, 3),
                        evaluate=False),)])
 
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1133,7 +1133,7 @@ def test_issue_6060():
     y = Symbol('y')
     assert solve(absxm3 - y, x) == [
         Piecewise((-y + 3, y > 0), (S.NaN, True)),
-        Piecewise((y + 3, S(0) <= y), (S.NaN, True))
+        Piecewise((y + 3, 0 <= y), (S.NaN, True))
     ]
     y = Symbol('y', positive=True)
     assert solve(absxm3 - y, x) == [-y + 3, y + 3]
@@ -1262,12 +1262,16 @@ def test_issue_6792():
     RootOf(x**6 - x + 1, 5)]
 
 
-def test_issues_6819_6820_6821_6248():
+def test_issues_6819_6820_6821_6248_8692():
     # issue 6821
     x, y = symbols('x y', real=True)
     assert solve(abs(x + 3) - 2*abs(x - 3)) == [1, 9]
     assert solve([abs(x) - 2, arg(x) - pi], x) == [(-2,), (2,)]
     assert set(solve(abs(x - 7) - 8)) == set([-S(1), S(15)])
+
+    # issue 8692
+    assert solve(Eq(Abs(x + 1) + Abs(x**2 - 7), 9), x) == [
+        -S(1)/2 + sqrt(61)/2, -sqrt(69)/2 + S(1)/2]
 
     # issue 7145
     assert solve(2*abs(x) - abs(x - 1)) == [-1, Rational(1, 3)]

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -312,6 +312,10 @@ def test_solveset_sqrt_2():
     eq = sqrt(x - 3) + sqrt(x) - 3
     assert solveset_real(eq, x) == FiniteSet(4)
 
+    eq = sqrt(2*x**2 - 7) - (3 - x)
+    assert solveset_real(eq, x) == FiniteSet(-S(8), S(2))
+
+    # others
     eq = sqrt(9*x**2 + 4) - (3*x + 2)
     assert solveset_real(eq, x) == FiniteSet(0)
 
@@ -322,9 +326,6 @@ def test_solveset_sqrt_2():
 
     assert solveset_real(sqrt(x) + sqrt(sqrt(x)) - 4, x) == \
         FiniteSet(-9*sqrt(17)/2 + 49*S.Half)
-
-    eq = sqrt(2*x**2 - 7) - (3 - x)
-    assert solveset_real(eq, x) == FiniteSet(-S(8), S(2))
 
     eq = sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))
     assert solveset_real(eq, x) == FiniteSet()

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -355,26 +355,25 @@ def test_solveset_sqrt_2():
         FiniteSet(-295244/S(59049))
 
 
-@XFAIL
 def test_solve_sqrt_3():
     R = Symbol('R')
     eq = sqrt(2)*R*sqrt(1/(R + 1)) + (R + 1)*(sqrt(2)*sqrt(1/(R + 1)) - 1)
     sol = solveset_complex(eq, R)
 
-    assert sol == FiniteSet(*[(S(5)/3 + 40/(3*(251 + 3*sqrt(111)*I)**(S(1)/3)) +
-                       (251 + 3*sqrt(111)*I)**(S(1)/3)/3,), ((-160 + (1 +
-                       sqrt(3)*I)*(10 - (1 + sqrt(3)*I)*(251 +
-                       3*sqrt(111)*I)**(S(1)/3))*(251 +
-                       3*sqrt(111)*I)**(S(1)/3))/Mul(6, (1 +
-                       sqrt(3)*I), (251 + 3*sqrt(111)*I)**(S(1)/3),
-                       evaluate=False),)])
+    assert sol == FiniteSet(*[S(5)/3 + 4*sqrt(10)*cos(atan(3*sqrt(111)/251)/3)/3,
+        -sqrt(10)*cos(atan(3*sqrt(111)/251)/3)/3 + 40*re(1/((-S(1)/2 -
+        sqrt(3)*I/2)*(S(251)/27 + sqrt(111)*I/9)**(S(1)/3)))/9 +
+        sqrt(30)*sin(atan(3*sqrt(111)/251)/3)/3 + S(5)/3 +
+        I*(-sqrt(30)*cos(atan(3*sqrt(111)/251)/3)/3 -
+        sqrt(10)*sin(atan(3*sqrt(111)/251)/3)/3 + 40*im(1/((-S(1)/2 -
+        sqrt(3)*I/2)*(S(251)/27 + sqrt(111)*I/9)**(S(1)/3)))/9)])
 
+    # the number of real roots will depend on the value of m: for m=1 there are 4
+    # and for m=-1 there are none.
     eq = -sqrt((m - q)**2 + (-m/(2*q) + S(1)/2)**2) + sqrt((-m**2/2 - sqrt(
         4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2 + (m**2/2 - m - sqrt(
             4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2)
-    assert solveset_real(eq, q) == FiniteSet(
-        m**2/2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4,
-        m**2/2 + sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)
+    raises(NotImplementedError, lambda: solveset_real(eq, q))
 
 
 def test_solve_polynomial_symbolic_param():
@@ -621,10 +620,11 @@ def test_solve_complex_log():
         FiniteSet(-sqrt(-a/4 + E/4), sqrt(-a/4 + E/4))
 
 
-@XFAIL
 def test_solve_complex_sqrt():
     assert solveset_complex(sqrt(5*x + 6) - 2 - x, x) == \
         FiniteSet(-S(1), S(2))
+    assert solveset_complex(sqrt(5*x + 6) - (2 + 2*I) - x, x) == \
+        FiniteSet(-S(2), 3 - 4*I)
     assert solveset_complex(4*x*(1 - a * sqrt(x)), x) == \
         FiniteSet(S(0), 1 / a ** 2)
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -292,10 +292,11 @@ def test_solveset_sqrt_2():
         FiniteSet(S(5), S(13))
     assert solveset_real(sqrt(x + 7) + 2 - sqrt(3 - x), x) == \
         FiniteSet(-6)
+
+    # http://www.purplemath.com/modules/solverad.htm
     assert solveset_real(sqrt(17*x - sqrt(x**2 - 5)) - 7, x) == \
         FiniteSet(3)
 
-    # http://www.purplemath.com/modules/solverad.htm
     eq = x + 1 - (x**4 + 4*x**3 - x)**Rational(1, 4)
     assert solveset_real(eq, x) == FiniteSet(-S(1)/2, -S(1)/3)
 
@@ -315,9 +316,6 @@ def test_solveset_sqrt_2():
     assert solveset_real(eq, x) == FiniteSet(0)
 
     assert solveset_real(sqrt(x - 3) - sqrt(x) - 3, x) == FiniteSet()
-
-    eq = (x**3 - 3*x**2)**Rational(1, 3) + 1 - x
-    assert solveset_real(eq, x) == FiniteSet()
 
     eq = (2*x - 5)**Rational(1, 3) - 3
     assert solveset_real(eq, x) == FiniteSet(16)
@@ -353,6 +351,14 @@ def test_solveset_sqrt_2():
     # issue 4497
     assert solveset_real(1/(5 + x)**(S(1)/5) - 9, x) == \
         FiniteSet(-295244/S(59049))
+
+
+@XFAIL
+def test_solve_sqrt_fail():
+    # this only works if we check real_root(eq.subs(x, S(1)/3))
+    # but checksol doesn't work like that
+    eq = (x**3 - 3*x**2)**Rational(1, 3) + 1 - x
+    assert solveset_real(eq, x) == FiniteSet(S(1)/3)
 
 
 def test_solve_sqrt_3():

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -150,13 +150,13 @@ def public(obj):
 
     By using this decorator on functions or classes you achieve the same goal
     as by filling ``__all__`` variables manually, you just don't have to repeat
-    your self (object's name). You also know if object is public at definition
+    yourself (object's name). You also know if object is public at definition
     site, not at some random location (where ``__all__`` was set).
 
-    Note that in multiple decorator setup, in almost all cases, ``@public``
+    Note that in multiple decorator setup (in almost all cases) ``@public``
     decorator must be applied before any other decorators, because it relies
     on the pointer to object's global namespace. If you apply other decorators
-    first, ``@public`` may end up modifying wrong namespace.
+    first, ``@public`` may end up modifying the wrong namespace.
 
     Example::
 


### PR DESCRIPTION
A variety of changes made while working on improving unrad. The unrad changes are not included other than a tweaking of solveset so it uses unrad better:

```
solveset(sqrt(x + 2) + sqrt(x + 3) - 1)  # should be -2
...
NotImplementedError

>>> solveset(sqrt(x)-I)  # should be -1
...
NotImplementedError
```

Also fixes #8692 
