### PR TITLE
adding a special case for factorial

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -172,6 +172,19 @@ class factorial(CombinatorialFunction):
         if self.args[0].is_integer and self.args[0].is_nonnegative:
             return True
 
+    def __mod__(self, other):
+        from sympy.core.numbers import Integer
+        if other == 1:
+            return 0
+        if isinstance(self.args[0], int) or isinstance(self.args[0], Integer):
+            if isinstance(other, int) or isinstance(other, Integer):
+                if abs(other) <= self.args[0] and not other == 0:
+                    return 0
+        elif other in self.args[0].free_symbols:
+            if self.args[0] == other:
+                return 0
+        return super(factorial, self).__mod__(other)
+
 
 class MultiFactorial(CombinatorialFunction):
     pass

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, symbols, factorial, factorial2, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
-                   oo, zoo, simplify, expand_func)
+                   oo, zoo, simplify, expand_func, Mod)
 from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -260,3 +260,12 @@ def test_subfactorial():
     assert subfactorial(nt).is_integer is None
     assert subfactorial(nf).is_integer is False
     assert subfactorial(nn).is_integer is None
+
+
+def test_issue_8677():
+    n = Symbol('n', integer=True)
+    x = factorial(n)
+    assert x%n == 0
+    assert x%6 == Mod(factorial(n), 6)
+    assert factorial(7)%5 == 0
+    assert factorial(8)%8 == 0


### PR DESCRIPTION
Adding special case to detecting when modulo of a factorial is 0. currently if we ask for `factorial(n)%k`, we have no way to know if k lies in the category `(1, n]`, so could only implement for the special case `k == n`.
