### PR TITLE
_random: added ValueError to handled exceptions (fixes #8662)

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -369,7 +369,7 @@ class Expr(Basic, EvalfMixin):
                            for zi in free])))
             try:
                 nmag = abs(self.evalf(2, subs=reps))
-            except TypeError:
+            except (ValueError, TypeError):
                 # if an out of range value resulted in evalf problems
                 # then return None -- XXX is there a way to know how to
                 # select a good random number for a given expression?

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -6,7 +6,7 @@ from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
     Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp,
     simplify, together, collect, factorial, apart, combsimp, factor, refine,
     cancel, Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E,
-    exp_polar, Lambda, expand, diff, O, Heaviside, Si)
+    exp_polar, Lambda, expand, diff, O, Heaviside, Si, Max)
 from sympy.core.function import AppliedUndef
 from sympy.physics.secondquant import FockState
 from sympy.physics.units import meter
@@ -1530,6 +1530,9 @@ def test_random():
     from sympy import posify, lucas
     assert posify(x)[0]._random() is not None
     assert lucas(n)._random(2, -2, 0, -1, 1) is None
+
+    # issue 8662
+    assert Piecewise((Max(x, y), z))._random() is None
 
 
 def test_round():


### PR DESCRIPTION
I think this completely resolves the issue, and it does not break any tests. I'm not sure it is the best solution because I'm not overwhelmingly familiar with the codebase. I could have also fixed this by making the _new_args_filter() function in miscellaneous.py throw a TypeError - which _random already handles - instead of a ValueError.
