### PR TITLE
Solve returns correct solution for Equations where denominator becomes 0 (fixes #8666)

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -685,7 +685,10 @@ def solve(f, *symbols, **flags):
     ###########################################################################
     for i, fi in enumerate(f):
         if isinstance(fi, Equality):
-            f[i] = fi.lhs - fi.rhs
+            if type(f[i].lhs).__name__ == 'ImmutableMatrix':
+                f[i] = fi.lhs - fi.rhs
+            else:
+                f[i] = Add(fi.lhs, -fi.rhs, evaluate=False)
         elif isinstance(fi, Poly):
             f[i] = fi.as_expr()
         elif isinstance(fi, (bool, C.BooleanAtom)) or fi.is_Relational:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -685,7 +685,7 @@ def solve(f, *symbols, **flags):
     ###########################################################################
     for i, fi in enumerate(f):
         if isinstance(fi, Equality):
-            if type(f[i].lhs).__name__ == 'ImmutableMatrix':
+            if 'ImmutableMatrix' in [type(a).__name__ for a in fi.args]:
                 f[i] = fi.lhs - fi.rhs
             else:
                 f[i] = Add(fi.lhs, -fi.rhs, evaluate=False)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -272,6 +272,12 @@ def test_solve_nonlinear():
     assert solve(x**2 - y**2/exp(x), y, x) == [{y: -x*sqrt(exp(x))}, {y: x*sqrt(exp(x))}]
 
 
+def test_issue_8666():
+    x = symbols('x')
+    assert solve(Eq(x**2 - 1/(x**2 - 4), 4 - 1/(x**2 - 4)), x) == []
+    assert solve(Eq(x + 1/x, 1/x), x) == []
+
+
 def test_issue_7228():
     assert solve(4**(2*(x**2) + 2*x) - 8, x) == [-Rational(3, 2), S.Half]
 


### PR DESCRIPTION
With Reference to the issue #8666 

For Equations like: `x**2 - 1/(x**2 - 4) == 4 - 1/(x**2 - 4)`     - (1)
                               `x + 1/x == 1/x`                                    - (2) , etc.
(Usually where same terms exists on both sides of the Equation & by cancelling these, solve produces erroneous solution which makes denominator zero )
(Example: earlier solve returned [-2, 2] for Equation (1) & , [0] for Equation: (2))
Now It Returns [] for both of these (as both of them have no solution) and takes care of all such possibilities. 
I have added tests also. 

@smichr  Please have a look.
