### PR TITLE
Fix heurisch with floating point numbers

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -559,7 +559,8 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         if solution is None:
             return None
         else:
-            solution = [ (k.as_expr(), v.as_expr()) for k, v in solution.items() ]
+            # If the ring is RR k.as_expr() will be 1.0*A
+            solution = [ (k.as_expr().as_coeff_Mul()[1], v.as_expr()) for k, v in solution.items() ]
             return candidate.subs(solution).subs(list(zip(coeffs, [S.Zero]*len(coeffs))))
 
     if not (F.free_symbols - set(V)):

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -277,6 +277,12 @@ def test_pmint_WrightOmega():
 
     assert heurisch(f, x) == g
 
+def test_RR():
+    # Make sure the algorithm does the right thing if the ring is RR. See
+    # issue 8685.
+    assert heurisch(sqrt(1 + 0.25*x**2), x, hints=[]) == \
+        0.5*x*sqrt(0.25*x**2 + 1) + 1.0*asinh(0.5*x)
+
 # TODO: convert the rest of PMINT tests:
 # Airy functions
 # f = (x - AiryAi(x)*AiryAi(1, x)) / (x**2 - AiryAi(x)**2)


### PR DESCRIPTION
The code was incorrectly assuming that PolyElement.as_expr() would give a
Symbol for a single monomial, but if the ring is RR, it would give something
like 1.0_x, and x.subs(1.0_x, y) doesn't do the replacement.  This prevented
it from correctly substituting in the solution, giving a wrong result of 0,
since all unsubstituted symbols are replaced with 0.

The fix was to guard against this using as_coeff_Mul().

Fixes #8685.
