### PR TITLE
Function to Rewrite Gamma as Factorial #8621

### DIFF
--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -162,6 +162,9 @@ class gamma(Function):
     def _eval_rewrite_as_tractable(self, z):
         return C.exp(loggamma(z))
 
+    def _eval_rewrite_as_factorial(self, z):
+        return C.factorial(z - 1)
+
     def _eval_nseries(self, x, n, logx):
         x0 = self.args[0].limit(x, 0)
         if not (x0.is_Integer and x0 <= 0):

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -70,6 +70,10 @@ def test_gamma():
     assert gamma(3*exp_polar(I*pi)/4).is_nonpositive is True
 
 
+def test_gamma_rewrite():
+    assert gamma(n).rewrite(factorial) == factorial(n - 1)
+
+
 def test_gamma_series():
     assert gamma(x + 1).series(x, 0, 3) == \
         1 - EulerGamma*x + x**2*(EulerGamma**2/2 + pi**2/12) + O(x**3)


### PR DESCRIPTION
Rewrite of this kind is very useful in case of combinatorial simplification.

Earlier we could only rewrite factorial in terms of gamma, but with the help of this PR, we can do vice-versa also.

Example:

``` python
>> from sympy import *
>> n = symbols('n')
>> gamma(n).rewrite(factorial)
>> factorial(n - 1)
```

Also added test.

This closes #8621 
