### PR TITLE
Modified default range to interpret the assumptions of free_vars

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1732,6 +1732,9 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
     >>> check_arguments([x, x**2], 1, 1)
         [(x, (x, -10, 10)), (x**2, (x, -10, 10))]
     """
+    default_range = Tuple(-10, 10)
+    positive_range = Tuple(0, 10)
+    negative_range = Tuple(-10, 0)
     if expr_len > 1 and isinstance(args[0], Expr):
         # Multiple expressions same range.
         # The arguments are tuples when the expression length is
@@ -1750,10 +1753,14 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
             #Ranges given
             plots = [exprs + Tuple(*args[expr_len:])]
         else:
-            default_range = Tuple(-10, 10)
             ranges = []
             for symbol in free_symbols:
-                ranges.append(Tuple(symbol) + default_range)
+                if symbol.is_positive:
+                    ranges.append(Tuple(symbol) + positive_range)
+                elif symbol.is_negative:
+                    ranges.append(Tuple(symbol) + negative_range)
+                else:
+                    ranges.append(Tuple(symbol) + default_range)
 
             for i in range(len(free_symbols) - nb_of_free_symbols):
                 ranges.append(Tuple(Dummy()) + default_range)
@@ -1789,10 +1796,14 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
             return plots
         else:
             #Use default ranges.
-            default_range = Tuple(-10, 10)
             ranges = []
             for symbol in free_symbols:
-                ranges.append(Tuple(symbol) + default_range)
+                if symbol.is_positive:
+                    ranges.append(Tuple(symbol) + positive_range)
+                elif symbol.is_negative:
+                    ranges.append(Tuple(symbol) + negative_range)
+                else:
+                    ranges.append(Tuple(symbol) + default_range)
 
             for i in range(len(free_symbols) - nb_of_free_symbols):
                 ranges.append(Tuple(Dummy()) + default_range)

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -324,9 +324,16 @@ def plot_implicit(expr, x_var=None, y_var=None, **kwargs):
 
     #Create default ranges if the range is not provided.
     default_range = Tuple(-5, 5)
+    positive_range = Tuple(0, 5)
+    negative_range = Tuple(-5, 0)
     def _range_tuple(s):
         if isinstance(s, Symbol):
-            return Tuple(s) + default_range
+            if s.is_positive:
+                return Tuple(s) + positive_range
+            elif s.is_negative:
+                return Tuple(s) + negative_range
+            else:
+                return Tuple(s) + default_range
         if len(s) == 3:
             return Tuple(*s)
         raise ValueError('symbol or `(symbol, min, max)` expected but got %s' % s)


### PR DESCRIPTION
Currently plot has a default range of (-10,10) when user doesn't provide a range. However this default behaviour doesn't care about the properties/assumptions of the free_variables. This commit corrects
this situation for two such cases, ie, when the variable is positive and when it is negative.

I'm still working to figure out a general method to do it. Perhaps a function that calculates the range over which a variable is defined(taking into account its assumptions) will do. I couldn't find such a function in the assumptions module. @skirpichev  
