### PR TITLE
In parse_expr with implicit multiplication, check if parentheses match.

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -161,6 +161,8 @@ def _group_parentheses(recursor):
                 stacks[-1].append(token)
             else:
                 result.append(token)
+        if stacklevel:
+            raise TokenError("Mismatched parentheses")
         return result
     return _inner
 

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -111,3 +111,8 @@ def test_split_symbols_function():
     assert parse_expr("ay(x+1)", transformations=transformations) == a*y*(x+1)
     assert parse_expr("af(x+1)", transformations=transformations,
                       local_dict={'f':f}) == a*f(x+1)
+
+def test_match_parentheses_implicit_multiplication():
+    transformations = standard_transformations + \
+                      (implicit_multiplication,)
+    raises(TokenError, lambda: parse_expr('(1,2),(3,4]',transformations=transformations))


### PR DESCRIPTION
Fixes problem that

parse_expr("(1,2),(3,4]", transformations=standard_transformations + (implicit_multiplication,))

does not raise exception but returns ((1,2),)
