### PR TITLE
Add is_real functionality for factorial, Fix issue #8658

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -172,6 +172,11 @@ class factorial(CombinatorialFunction):
         if self.args[0].is_integer and self.args[0].is_nonnegative:
             return True
 
+    def _eval_is_real(self):
+        if ((self.args[0].is_negative and self.args[0].is_noninteger) or
+           self.args[0].is_nonnegative):
+            return True
+
 
 class MultiFactorial(CombinatorialFunction):
     pass

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -88,6 +88,8 @@ def test_factorial():
     n = Symbol('n', integer=True)
     k = Symbol('k', integer=True, nonnegative=True)
     r = Symbol('r', integer=False)
+    s = Symbol('s', integer = False, negative = True)
+    t = Symbol('t', nonnegative=True)
 
     assert factorial(-2) == zoo
     assert factorial(0) == 1
@@ -101,6 +103,13 @@ def test_factorial():
 
     assert factorial(n).is_positive is None
     assert factorial(k).is_positive
+
+    assert factorial(x).is_real is None
+    assert factorial(n).is_real
+    assert factorial(k).is_real is True
+    assert factorial(r).is_real is None
+    assert factorial(s).is_real is True
+    assert factorial(t).is_real is True
 
     assert factorial(oo) == oo
 


### PR DESCRIPTION
Factorial function don't have the is_real functionality (check or real) to check this Assumption.
factorial(x) is not known to be real when  'x' is non-negative.

With this PR, user can check if the given factorial is real or not.
Fixes #8658 
