### PR TITLE
Add Positive assumption helper for gamma function, Fixes #8524 

### DIFF
--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -161,6 +161,13 @@ class gamma(Function):
         if x.is_positive or x.is_noninteger:
             return True
 
+    def _eval_is_positive(self):
+        x = self.args[0]
+        if x.is_positive:
+            return True
+        elif x.is_noninteger:
+            return floor(x).is_even
+
     def _eval_rewrite_as_tractable(self, z):
         return C.exp(loggamma(z))
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -400,3 +400,38 @@ def test_issue_8657():
     assert gamma(o).is_real is True
     assert gamma(p).is_real is True
     assert gamma(w).is_real is None
+
+
+def test_issue_8524():
+    a = Symbol('a')
+    x = Symbol('x', integer=True)
+    y = Symbol('y', positive=True)
+    z = Symbol('z', negative=True)
+    m = Symbol('m', integer=False)
+    n = Symbol('n', positive=False)
+    o = Symbol('o', negative=False)
+    p = Symbol('p', real=True)
+    q = Symbol('q', negative=True, integer=False)
+    r = Symbol('r', negative=False, integer=True)
+    s = Symbol('s', positive=True, integer=False)
+    t = Symbol('t', positive=False, integer=True)
+    u = Symbol('u', positive=True, integer=True)
+    v = Symbol('v', nonnegative=True)
+    assert gamma(a).is_positive is None
+    assert gamma(x).is_positive is None
+    assert gamma(y).is_positive is True
+    assert gamma(z).is_positive is None
+    assert gamma(m).is_positive is None
+    assert gamma(n).is_positive is None
+    assert gamma(o).is_positive is None
+    assert gamma(p).is_positive is None
+    assert gamma(q).is_positive is None
+    assert gamma(r).is_positive is None
+    assert gamma(s).is_positive is True
+    assert gamma(t).is_positive is None
+    assert gamma(u).is_positive is True
+    assert gamma(v).is_positive is None
+    assert gamma(-2*pi).is_positive is False
+    assert gamma(-pi/4).is_positive is False
+    assert gamma(-pi/3).is_positive is True
+    assert gamma(0).is_positive is None


### PR DESCRIPTION
The Positive assumption helper for gamma function is missing:
So the the following code returns None:

``` python
>>> n = Symbol('n', real=True, positive=True)
>>> gamma(n).is_positive
```

With this PR, Positive assumption works well for gamma function.

Fixes #8524 
