### PR TITLE
add a left_eigenvectors() method

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3035,7 +3035,7 @@ class MatrixBase(object):
 
         left = []
         for (ev, mult, ltmp) in left_transpose:
-            left.append( (ev, mult, ltmp[0].transpose()) )
+            left.append( (ev, mult, [l.transpose() for l in ltmp]) )
 
         return left
             

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3025,6 +3025,21 @@ class MatrixBase(object):
                 out.append((r, k, [mat._new(b) for b in basis]))
         return out
 
+    def left_eigenvects(self, **flags):
+        """Return list of triples (eigenval, multiplicity, basis).
+           for the left eigenvectors.  Options are the same as
+           for eigenvects()
+        """
+        mat = self
+        left_transpose = mat.transpose().eigenvects(**flags)
+
+        left = []
+        
+        for (ev, mult, ltmp) in left_transpose:
+            left.append( (ev, mult, ltmp[0].transpose()) )
+
+        return left
+            
     def singular_values(self):
         """Compute the singular values of a Matrix
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3025,6 +3025,20 @@ class MatrixBase(object):
                 out.append((r, k, [mat._new(b) for b in basis]))
         return out
 
+    def left_eigenvects(self, **flags):
+        """Return list of triples (eigenval, multiplicity, basis).
+           for the left eigenvectors.  Options are the same as
+           for eigenvects()
+        """
+        mat = self
+        left_transpose = mat.transpose().eigenvects(**flags)
+
+        left = []
+        for (ev, mult, ltmp) in left_transpose:
+            left.append( (ev, mult, [l.transpose() for l in ltmp]) )
+
+        return left
+
     def singular_values(self):
         """Compute the singular values of a Matrix
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3038,7 +3038,7 @@ class MatrixBase(object):
             left.append( (ev, mult, [l.transpose() for l in ltmp]) )
 
         return left
-            
+
     def singular_values(self):
         """Compute the singular values of a Matrix
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3034,7 +3034,6 @@ class MatrixBase(object):
         left_transpose = mat.transpose().eigenvects(**flags)
 
         left = []
-        
         for (ev, mult, ltmp) in left_transpose:
             left.append( (ev, mult, ltmp[0].transpose()) )
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -780,6 +780,11 @@ def test_eigen():
                  Matrix([0, 1, 0]),
                  Matrix([0, 0, 1])])])
 
+    assert M.left_eigenvects() == (
+        [(1, 3, [Matrix([[1, 0, 0]]),
+                 Matrix([[0, 1, 0]]),
+                 Matrix([[0, 0, 1]])])])
+
     M = Matrix([[0, 1, 1],
                 [1, 0, 0],
                 [1, 1, 1]])
@@ -793,6 +798,13 @@ def test_eigen():
             ( 2, 1, [Matrix([R(2, 3), R(1, 3), 1])])
         ])
 
+    assert M.left_eigenvects() == (
+        [
+            (-1, 1, [Matrix([[-2, 1, 1]])]),
+            (0, 1, [Matrix([[-1, -1, 1]])]),
+            (2, 1, [Matrix([[1, 1, 1]])])
+        ])
+
     a = Symbol('a')
     M = Matrix([[a, 0],
                 [0, 1]])
@@ -802,6 +814,7 @@ def test_eigen():
     M = Matrix([[1, -1],
                 [1,  3]])
     assert M.eigenvects() == ([(2, 2, [Matrix(2, 1, [-1, 1])])])
+    assert M.left_eigenvects() == ([(2, 2, [Matrix([[1, 1]])])])
 
     M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     a = R(15, 2)
@@ -835,6 +848,12 @@ def test_eigen():
         [
             ( 0, 1, [Matrix([[-I*eps/abs(eps)], [1]])]),
             ( 2*abs(eps), 1, [ Matrix([[I*eps/abs(eps)], [1]]) ] ),
+        ])
+
+    assert M.left_eigenvects() == (
+        [
+            (0, 1, [Matrix([[I*eps/Abs(eps), 1]])]),
+            (2*Abs(eps), 1, [Matrix([[-I*eps/Abs(eps), 1]])])
         ])
 
     M = Matrix(3, 3, [1, 2, 0, 0, 3, 0, 2, -4, 2])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -783,8 +783,8 @@ def test_eigen():
     assert M.left_eigenvects() == (
         [(1, 3, [Matrix([[1, 0, 0]]),
                  Matrix([[0, 1, 0]]),
-                 Matrix([[0, 0, 1]])])])        
-        
+                 Matrix([[0, 0, 1]])])])
+
     M = Matrix([[0, 1, 1],
                 [1, 0, 0],
                 [1, 1, 1]])
@@ -804,7 +804,7 @@ def test_eigen():
             (0, 1, [Matrix([[-1, -1, 1]])]),
             (2, 1, [Matrix([[1, 1, 1]])])
         ])
-    
+
     a = Symbol('a')
     M = Matrix([[a, 0],
                 [0, 1]])
@@ -814,8 +814,8 @@ def test_eigen():
     M = Matrix([[1, -1],
                 [1,  3]])
     assert M.eigenvects() == ([(2, 2, [Matrix(2, 1, [-1, 1])])])
-    assert M.left_eigenvects() == ([(2, 2, [Matrix([[1, 1]])])])    
-    
+    assert M.left_eigenvects() == ([(2, 2, [Matrix([[1, 1]])])])
+
     M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     a = R(15, 2)
     b = 3*33**R(1, 2)
@@ -855,7 +855,7 @@ def test_eigen():
             (0, 1, [Matrix([[I*eps/Abs(eps), 1]])]),
             (2*Abs(eps), 1, [Matrix([[-I*eps/Abs(eps), 1]])])
         ])
-            
+
     M = Matrix(3, 3, [1, 2, 0, 0, 3, 0, 2, -4, 2])
     M._eigenvects = M.eigenvects(simplify=False)
     assert max(i.q for i in M._eigenvects[0][2][0]) > 1

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -780,6 +780,11 @@ def test_eigen():
                  Matrix([0, 1, 0]),
                  Matrix([0, 0, 1])])])
 
+    assert M.left_eigenvects() == (
+        [(1, 3, [Matrix([[1, 0, 0]]),
+                 Matrix([[0, 1, 0]]),
+                 Matrix([[0, 0, 1]])])])        
+        
     M = Matrix([[0, 1, 1],
                 [1, 0, 0],
                 [1, 1, 1]])
@@ -793,6 +798,13 @@ def test_eigen():
             ( 2, 1, [Matrix([R(2, 3), R(1, 3), 1])])
         ])
 
+    assert M.left_eigenvects() == (
+        [
+            (-1, 1, [Matrix([[-2, 1, 1]])]),
+            (0, 1, [Matrix([[-1, -1, 1]])]),
+            (2, 1, [Matrix([[1, 1, 1]])])
+        ])
+    
     a = Symbol('a')
     M = Matrix([[a, 0],
                 [0, 1]])
@@ -802,7 +814,8 @@ def test_eigen():
     M = Matrix([[1, -1],
                 [1,  3]])
     assert M.eigenvects() == ([(2, 2, [Matrix(2, 1, [-1, 1])])])
-
+    assert M.left_eigenvects() == ([(2, 2, [Matrix([[1, 1]])])])    
+    
     M = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     a = R(15, 2)
     b = 3*33**R(1, 2)
@@ -837,6 +850,12 @@ def test_eigen():
             ( 2*abs(eps), 1, [ Matrix([[I*eps/abs(eps)], [1]]) ] ),
         ])
 
+    assert M.left_eigenvects() == (
+        [
+            (0, 1, [Matrix([[I*eps/Abs(eps), 1]])]),
+            (2*Abs(eps), 1, [Matrix([[-I*eps/Abs(eps), 1]])])
+        ])
+            
     M = Matrix(3, 3, [1, 2, 0, 0, 3, 0, 2, -4, 2])
     M._eigenvects = M.eigenvects(simplify=False)
     assert max(i.q for i in M._eigenvects[0][2][0]) > 1


### PR DESCRIPTION
add a left_eigenvectors() method that is a wrapper around eigenvectors().
It finds the left eigenvectors of a matrix (l A = lambda l) by taking the transpose of the system,
finding the eigenvectors of A^T, and transposing back.
