### PR TITLE
Fixing integer assumptions for factorial

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -165,7 +165,7 @@ class factorial(CombinatorialFunction):
         return C.gamma(n + 1)
 
     def _eval_is_integer(self):
-        if self.args[0].is_integer:
+        if self.args[0].is_integer and self.args[0].is_nonnegative:
             return True
 
     def _eval_is_positive(self):

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -99,14 +99,15 @@ def test_factorial():
     assert factorial(2*n).func == factorial
 
     assert factorial(x).is_integer is None
-    assert factorial(n).is_integer
+    assert factorial(n).is_integer is None
+    assert factorial(k).is_integer
     assert factorial(r).is_integer is None
 
     assert factorial(n).is_positive is None
     assert factorial(k).is_positive
 
     assert factorial(x).is_real is None
-    assert factorial(n).is_real
+    assert factorial(n).is_real is None
     assert factorial(k).is_real is True
     assert factorial(r).is_real is None
     assert factorial(s).is_real is True


### PR DESCRIPTION
This is related to #8723, but fixes a different bug - `factorial(n)` was assumed to be an integer (and therefore a real), even without the assumption of nonnegativity of `n`, which is wrong. This PR fixes that, fixes the relevant test, and adds a new test.

I've also made some minor PEP8 corrections.
