### PR TITLE
Partial solution to #8578 + test

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -560,15 +560,16 @@ class binomial(CombinatorialFunction):
                         result /= i
                     return result
 
-        elif k.is_negative:
+        if k.is_negative:
             return S.Zero
-        elif (n - k).simplify().is_negative:
-            return S.Zero
-        else:
-            d = n - k
 
-            if d.is_Integer:
-                return cls.eval(n, d)
+        if (n - k).simplify().is_negative:
+            return S.Zero
+
+        d = n - k
+
+        if d.is_Integer:
+            return cls.eval(n, d)
 
     def _eval_expand_func(self, **hints):
         """

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,4 +1,4 @@
-from sympy import (Symbol, symbols, factorial, factorial2, binomial,
+from sympy import (S, Symbol, symbols, factorial, factorial2, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func)
 from sympy.functions.combinatorial.factorials import subfactorial
@@ -189,6 +189,7 @@ def test_binomial():
     assert binomial(-1, 1) == -1
     assert binomial(-10, 1) == -10
     assert binomial(-10, 7) == -11440
+    assert binomial(S.Half, S.Half) == 1
     assert binomial(n, -1) == 0
     assert binomial(n, 0) == 1
     assert expand_func(binomial(n, 1)) == n


### PR DESCRIPTION
Fixed the logic a little bit. This provides a solution to `binomial(S.Half, S.Half)`, for example (the solution that has existed for `binomial(x, x)` was not applied, since `S.Half` is a `Number`), but does not provide a solution for `binomial(-1, -1)`, as when `k` is a negative integer, there's a line that returns 0, which is not true in all cases.
