### PR TITLE
Add Support for negative numbers in round function

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3070,9 +3070,15 @@ class Expr(Basic, EvalfMixin):
         if dps is not None and allow > dps:
             allow = dps
         mag = Pow(10, p)  # magnitude needed to bring digit p to units place
+        xwas = x
         x += 1/(2*mag)  # add the half for rounding
         i10 = 10*mag*x.n((dps if dps is not None else digits_needed) + 1)
-        rv = Integer(i10)//10
+        if i10.is_negative:
+            x = xwas - 1/(2*mag)  # should have gone the other way
+            i10 = 10*mag*x.n((dps if dps is not None else digits_needed) + 1)
+            rv = -(Integer(-i10)//10)
+        else:
+            rv = Integer(i10)//10
         q = 1
         if p > 0:
             q = mag

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1609,6 +1609,12 @@ def test_round():
     # issue 6914
     assert (I**(I + 3)).round(3) == Float('-0.208', '')*I
 
+    # issue 8720
+    assert S(-123.6).round() == -124.
+    assert S(-1.5).round() == -2.
+    assert S(-100.5).round() == -101.
+    assert S(-1.5 - 10.5*I).round() == -2.0 - 11.0*I
+
     # issue 7961
     assert str(S(0.006).round(2)) == '0.01'
     assert str(S(0.00106).round(4)) == '0.0011'


### PR DESCRIPTION
The round function does not expect negative numbers, which often gives in wrong results.

With This PR, round function will be able to deal with negative numbers easily.
Fixes #8720 
@smichr Please have a look.
