### PR TITLE
Add README to examples/notebooks, fixes #8443

### DIFF
--- a/examples/notebooks/README.txt
+++ b/examples/notebooks/README.txt
@@ -1,0 +1,7 @@
+This directory contains `IPython`_ Notebooks. To open them, run ``ipython
+notebook`` in this directory. This command will start IPython `notebook`_
+server, and let your default browser connect to it.
+
+
+.. _ipython: http://ipython.org/
+.. _notebook: http://ipython.org/notebook.html


### PR DESCRIPTION
Tell users to run `ipython notebook`, not just `ipython`.
