### PR TITLE
Add is_composite for factorial function fix 8724

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -172,6 +172,11 @@ class factorial(CombinatorialFunction):
         if self.args[0].is_integer and self.args[0].is_nonnegative:
             return True
 
+    def _eval_is_composite(self):
+        x = self.args[0]
+        if x.is_integer:
+            return (x - 3).is_nonnegative
+
     def _eval_is_real(self):
         x = self.args[0]
         if x.is_nonnegative or x.is_noninteger:

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -91,6 +91,7 @@ def test_factorial():
     s = Symbol('s', integer=False, negative=True)
     t = Symbol('t', nonnegative=True)
     u = Symbol('u', noninteger=True)
+    v = Symbol('v', integer=True, negative=True)
 
     assert factorial(-2) == zoo
     assert factorial(0) == 1
@@ -112,6 +113,16 @@ def test_factorial():
     assert factorial(s).is_real is True
     assert factorial(t).is_real is True
     assert factorial(u).is_real is True
+
+    assert factorial(x).is_composite is None
+    assert factorial(n).is_composite is None
+    assert factorial(k).is_composite is None
+    assert factorial(k + 3).is_composite is True
+    assert factorial(r).is_composite is None
+    assert factorial(s).is_composite is None
+    assert factorial(t).is_composite is None
+    assert factorial(u).is_composite is None
+    assert factorial(v).is_composite is False
 
     assert factorial(oo) == oo
 


### PR DESCRIPTION
Currently If n is a nonnegative integer, factorial(n+3).is_composite returns None.

This PR Fixes this issue.
Fix #8724 
