### PR TITLE
Add ``prng`` parameter to randMatrix

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1578,11 +1578,22 @@ def casoratian(seqs, n, zero=True):
     return Matrix(k, k, f).det()
 
 
-def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False, percent=100):
+def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
+               percent=100, prng=None):
     """Create random matrix with dimensions ``r`` x ``c``. If ``c`` is omitted
     the matrix will be square. If ``symmetric`` is True the matrix must be
     square. If ``percent`` is less than 100 then only approximately the given
     percentage of elements will be non-zero.
+
+    The pseudo-random number generator used to generate matrix is chosen in the
+    following way.
+
+    * If ``prng`` is supplied, it will be used as random number generator.
+      It should be an instance of :class:`random.Random`, or at least have
+      ``randint`` and ``shuffle`` methods with same signatures.
+    * if ``prng`` is not supplied but ``seed`` is supplied, then new
+      :class:`random.Random` with given ``seed`` will be created;
+    * otherwise, a new :class:`random.Random` with default seed will be used.
 
     Examples
     ========
@@ -1617,10 +1628,8 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False, percent=100
     """
     if c is None:
         c = r
-    if seed is None:
-        prng = random.Random()  # use system time
-    else:
-        prng = random.Random(seed)
+    # Note that ``Random()`` is equivalent to ``Random(None)``
+    prng = prng or random.Random(seed)
     if symmetric and r != c:
         raise ValueError(
             'For symmetric matrices, r must equal c, but %i != %i' % (r, c))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,4 +1,5 @@
 import collections
+import random
 
 from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
@@ -482,11 +483,18 @@ def test_expand():
 def test_random():
     M = randMatrix(3, 3)
     M = randMatrix(3, 3, seed=3)
+    assert M == randMatrix(3, 3, seed=3)
+
     M = randMatrix(3, 4, 0, 150)
-    M = randMatrix(3, symmetric=True)
+    M = randMatrix(3, seed=4, symmetric=True)
+    assert M == randMatrix(3, seed=4, symmetric=True)
+
     S = M.copy()
     S.simplify()
     assert S == M  # doesn't fail when elements are Numbers, not int
+
+    rng = random.Random(4)
+    assert M == randMatrix(3, symmetric=True, prng=rng)
 
 
 def test_LUdecomp():


### PR DESCRIPTION
This can be useful, e.g., to generate a Matrix with known seed, then use the
new state of prng to generate other objects.
