### PR TITLE
GramSchmidt: rename kwarg to "orthonormal"

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1471,7 +1471,7 @@ def hessian(f, varlist, constraints=[]):
     return out
 
 
-def GramSchmidt(vlist, orthog=False):
+def GramSchmidt(vlist, orthonormal=False):
     """
     Apply the Gram-Schmidt process to a set of vectors.
 
@@ -1487,7 +1487,7 @@ def GramSchmidt(vlist, orthog=False):
             raise ValueError(
                 "GramSchmidt: vector set not linearly independent")
         out.append(tmp)
-    if orthog:
+    if orthonormal:
         for i in range(len(out)):
             out[i] = out[i].normalized()
     return out


### PR DESCRIPTION
"orthog" was misleading as Gram-Schmidt always gives orthogonal vectors.
This kwarg is supposed to control whether the resulting vectors are
normalized or not.  (Confusingly, an "orthogonal matrix" has orthonormal
columns but when referring to a list of vectors, the term should be
"orthonormal".)
