### PR TITLE
Rewrite factorial as a product fix 8757

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy.core import S, C, sympify
+from sympy.core import S, C, sympify, Dummy
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.logic import fuzzy_and
 from sympy.ntheory import sieve
@@ -163,6 +163,11 @@ class factorial(CombinatorialFunction):
 
     def _eval_rewrite_as_gamma(self, n):
         return C.gamma(n + 1)
+
+    def _eval_rewrite_as_Product(self, n):
+        if n.is_nonnegative and n.is_integer:
+            i = Dummy('i', integer=True)
+            return C.Product(i, (i, 1, n))
 
     def _eval_is_integer(self):
         if self.args[0].is_integer and self.args[0].is_nonnegative:

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, symbols, factorial, factorial2, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
-                   oo, zoo, simplify, expand_func, C, S)
+                   oo, zoo, simplify, expand_func, C, S, Product)
 from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -146,8 +146,10 @@ def test_factorial_series():
 
 def test_factorial_rewrite():
     n = Symbol('n', integer=True)
+    k = Symbol('k', integer=True, nonnegative=True)
 
     assert factorial(n).rewrite(gamma) == gamma(n + 1)
+    assert str(factorial(k).rewrite(Product)) == 'Product(_i, (_i, 1, k))'
 
 
 def test_factorial2():


### PR DESCRIPTION
fixes #8757 

``` python
>>> k = Symbol('k', integer=True, nonnegative=True)
>>> factorial(k).rewrite(Product)
Product(i, (i, 1, k)
```
