### PR TITLE
Fix solve(x < oo) & handle infinity for as_set() issue 8783 & 8777

### DIFF
--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -667,3 +667,11 @@ def test_all_or_nothing():
 def test_canonical_atoms():
     assert true.canonical == true
     assert false.canonical == false
+
+
+def test_issue_8777():
+    x = symbols('x')
+    assert And(x > 2, x < oo).as_set() == Interval(2, oo, left_open=True)
+    assert And(x >= 1, x < oo).as_set() == Interval(1, oo)
+    assert (x < oo).as_set() == Interval(-oo, oo)
+    assert (x > -oo).as_set() == Interval(-oo, oo)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -432,6 +432,12 @@ def solve_univariate_inequality(expr, gen, relational=True):
         raise NotImplementedError('sorting of these roots is not supported')
     for x in reals:
         end = x
+
+        if ((end is S.NegativeInfinity and expr.rel_op in ['>', '>=']) or
+           (end is S.Infinity and expr.rel_op in ['<', '<='])):
+            sol_sets.append(Interval(start, S.Infinity, True, True))
+            break
+
         if valid((start + end)/2 if start != S.NegativeInfinity else end - 1):
             sol_sets.append(Interval(start, end, True, True))
 

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -304,3 +304,11 @@ def test_issue_8545():
     assert reduce_abs_inequality(eq, '<', x) == ans
     eq = 1 - x - sqrt((1 - x)**2)
     assert reduce_inequalities(eq < 0) == ans
+
+
+def test_issue_8783():
+    x = Symbol('x')
+    assert solve(x > -oo) == And(-oo < x, x < oo)
+    assert solve(x < oo) == And(-oo < x, x < oo)
+    assert solve(x > oo) == False
+    assert solve(x < -oo) == False


### PR DESCRIPTION
At the time: 
- `And(x > 2,x < oo).as_set()` returns `EmptySet()` &
- `solve(x < oo)` and `solve(x > -oo)` returns `False`

With this PR these two Issues are addressed.
- [x] Fixes #8783 
- [x] Fixes #8777 
- [x] Fixes #8613 
- [x] Fixes #8252 

@smichr 
@skirpichev 
Please have a look.
