### PR TITLE
Document False usage for old assumptions

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -4,10 +4,22 @@ This module contains the machinery handling assumptions.
 All symbolic objects have assumption attributes that can be accessed via
 .is_<assumption name> attribute.
 
-Assumptions determine certain properties of symbolic objects. Assumptions
-can have 3 possible values: True, False, None.  None is returned when it is
-impossible to say something about the property. For example, a generic Symbol
-is not known beforehand to be positive.
+Assumptions determine certain properties of symbolic objects and can
+have 3 possible values: True, False, None.  True is returned if the
+object has the property and False is returned if it doesn't or can't
+(i.e. doesn't make sense):
+
+    >>> from sympy import I
+    >>> I.is_algebraic
+    True
+    >>> I.is_real
+    False
+    >>> I.is_prime
+    False
+
+When the property cannot be determined (or when a method is not
+implemented) None will be returned, e.g. a generic symbol, x, may or
+may not be positive so a value of None is returned for x.is_positive.
 
 By default, all symbolic values are in the largest set in the given context
 without specifying the property. For example, a symbol that has a property


### PR DESCRIPTION
See #8045 and [this question](https://github.com/sympy/sympy/issues/8487#issuecomment-69242730).  I think, there are better source for discussion about False vs None usage, but this is what I've found so far.
