### PR TITLE
Implementing SymmetricDifference class, #8179

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -465,6 +465,12 @@ def test_sympy__sets__sets__Complement():
     assert _test_args(Complement(Interval(0, 2), Interval(0, 1)))
 
 
+def test_sympy__sets__sets__SymmetricDifference():
+    from sympy.sets.sets import FiniteSet, SymmetricDifference
+    assert _test_args(SymmetricDifference(FiniteSet(1, 2, 3), \
+           FiniteSet(2, 3, 4)))
+
+
 def test_sympy__core__trace__Tr():
     from sympy.core.trace import Tr
     a, b = symbols('a b')

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,4 +1,4 @@
 from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
-        Intersection, imageset, Complement)
+        Intersection, imageset, Complement, SymmetricDifference)
 from .fancysets import TransformationSet, ImageSet, Range
 from .contains import Contains

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -206,6 +206,12 @@ class Set(Basic):
         elif isinstance(other, FiniteSet):
             return FiniteSet(*[el for el in other if self.contains(el) != True])
 
+    def symmetric_difference(self, other):
+         return SymmetricDifference(self, other)
+
+    def _symmetric_difference(self, other):
+        return Union(Complement(self, other), Complement(other, self))
+
     @property
     def inf(self):
         """
@@ -486,6 +492,9 @@ class Set(Basic):
 
     def __mul__(self, other):
         return ProductSet(self, other)
+
+    def __xor__(self, other):
+        return SymmetricDifference(self, other)
 
     def __pow__(self, exp):
         if not sympify(exp).is_Integer and exp >= 0:
@@ -1562,6 +1571,9 @@ class EmptySet(with_metaclass(Singleton, Set)):
     def _complement(self, other):
         return other
 
+    def _symmetric_difference(self, other):
+        return other
+
 
 class UniversalSet(with_metaclass(Singleton, Set)):
     """
@@ -1596,6 +1608,9 @@ class UniversalSet(with_metaclass(Singleton, Set)):
 
     def _complement(self, other):
         return S.EmptySet
+
+    def _symmetric_difference(self, other):
+        return other
 
     @property
     def _measure(self):
@@ -1716,6 +1731,7 @@ class FiniteSet(Set, EvalfMixin):
 
         return None
 
+
     def _contains(self, other):
         """
         Tests whether an element, other, is in the set.
@@ -1805,6 +1821,45 @@ class FiniteSet(Set, EvalfMixin):
 
     def __lt__(self, other):
         return self.is_proper_subset(other)
+
+
+class SymmetricDifference(Set):
+    """Represents the set of elements which are in either of the
+    sets and not in their intersection.
+
+    Examples
+    ========
+
+    >>> from sympy import SymmetricDifference, FiniteSet
+    >>> SymmetricDifference(FiniteSet(1, 2, 3), FiniteSet(3, 4, 5))
+    {1, 2, 4, 5}
+
+    See Also
+    ========
+
+    Complement, Union
+
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Symmetric_difference
+    """
+
+    is_SymmetricDifference = True
+
+    def __new__(cls, a, b, evaluate=True):
+        if evaluate:
+            return SymmetricDifference.reduce(a, b)
+
+        return Basic.__new__(cls, a, b)
+
+    @staticmethod
+    def reduce(A, B):
+        result = B._symmetric_difference(A)
+        if result is not None:
+            return result
+        else:
+            return SymmetricDifference(A, B, evaluate=False)
 
 
 def imageset(*args):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1,10 +1,11 @@
 from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
-    LessThan, Max, Min, And, Or, Eq, Le, Lt, Float,
-    FiniteSet, Intersection, imageset, I, true, false, ProductSet,
+    GreaterThan, LessThan, Max, Min, And, Or, Eq, Ge, Le, Gt, Lt, Float,
+    FiniteSet, Intersection, imageset, I, true, false, ProductSet, E,
     sqrt, Complement, EmptySet, sin, cos, Lambda, ImageSet, pi,
-    Pow, Contains, Sum, RootOf)
+    Eq, Pow, Contains, Sum, RootOf, SymmetricDifference)
 from mpmath import mpi
 
+from sympy.utilities.pytest import raises
 from sympy.utilities.pytest import raises, XFAIL
 
 from sympy.abc import x, y, z
@@ -830,3 +831,16 @@ def test_Eq():
 
     assert Eq(s1*s2, s1*s2)
     assert Eq(s1*s2, s2*s1) == False
+
+
+def test_SymmetricDifference():
+   assert SymmetricDifference(FiniteSet(0, 1, 2, 3, 4, 5), \
+          FiniteSet(2, 4, 6, 8, 10)) == FiniteSet(0, 1, 3, 5, 6, 8, 10)
+   assert SymmetricDifference(FiniteSet(2, 3, 4), FiniteSet(2, 3 ,4 ,5 )) \
+          == FiniteSet(5)
+   assert FiniteSet(1, 2, 3, 4, 5) ^ FiniteSet(1, 2, 5, 6) == \
+          FiniteSet(3, 4, 6)
+   assert Set(1, 2 ,3) ^ Set(2, 3, 4) == Union(Set(1, 2, 3) - Set(2, 3, 4), \
+          Set(2, 3, 4) - Set(1, 2, 3))
+   assert Interval(0, 4) ^ Interval(2, 5) == Union(Interval(0, 4) - \
+          Interval(2, 5), Interval(2, 5) - Interval(0, 4))


### PR DESCRIPTION
Created a class to calculate the Symmetric Difference of two finite sets(see #8179) . This class structure is similar to that of already implemented `Complement` class. `__xor__` method in `FiniteSet` class is overridden to call `SymmetricDifference` class. 
Usage Example

```
In [1]: from sympy import FiniteSet, SymmetricDifference
In [2]: SymmetricDifference(FiniteSet(1,2,3,4), FiniteSet(3,4,5))
Out[2]: {1, 2, 5}
```
