### PR TITLE
[RFC] srepr displays assumptions used to create a Symbol

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -45,7 +45,7 @@ class Basic(with_metaclass(ManagedProperties)):
     __slots__ = ['_mhash',              # hash value
                  '_args',               # arguments
                  '_assumptions',
-                 '_user_assumptions'
+                 '_user_assumptions',   # FIXME: _raw_assumptions or better?
                 ]
 
     # To be overridden with True in the appropriate subclasses

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -44,7 +44,8 @@ class Basic(with_metaclass(ManagedProperties)):
     """
     __slots__ = ['_mhash',              # hash value
                  '_args',               # arguments
-                 '_assumptions'
+                 '_assumptions',
+                 '_user_assumptions'
                 ]
 
     # To be overridden with True in the appropriate subclasses

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -150,8 +150,7 @@ class Symbol(AtomicExpr, Boolean):
 
     def as_dummy(self):
         """Return a Dummy having the same name and same assumptions as self."""
-        # FIXME: copy the user-specified assumptions instead/too?
-        return Dummy(self.name, **self.assumptions0)
+        return Dummy(self.name, **self._user_assumptions)
 
     def __call__(self, *args):
         from .function import Function

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -134,9 +134,11 @@ class Symbol(AtomicExpr, Boolean):
         return (self.name,)
 
     def __getstate__(self):
-        return {'_assumptions': self._assumptions}
+        return {'_assumptions': self._assumptions,
+                '_user_assumptions': self._user_assumptions}
 
     def _hashable_content(self):
+        # FIXME: _user_assumptions?
         return (self.name,) + tuple(sorted(self.assumptions0.items()))
 
     @property
@@ -210,7 +212,9 @@ class Dummy(Symbol):
         return obj
 
     def __getstate__(self):
-        return {'_assumptions': self._assumptions, 'dummy_index': self.dummy_index}
+        return {'_assumptions': self._assumptions,
+                '_user_assumptions': self._user_assumptions,
+                'dummy_index': self.dummy_index}
 
     @cacheit
     def sort_key(self, order=None):

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -64,7 +64,8 @@ class Symbol(AtomicExpr, Boolean):
             whose = '%s ' % obj.__name__ if obj else ''
             raise ValueError(
                 '%scommutativity must be True or False.' % whose)
-        assumptions['commutative'] = is_commutative
+        # FIXME: what goes wrong if I drop this?
+        #assumptions['commutative'] = is_commutative
 
         # sanitize other assumptions so 1 -> True and 0 -> False
         for key in list(assumptions.keys()):
@@ -98,8 +99,13 @@ class Symbol(AtomicExpr, Boolean):
         False
 
         """
+        # FIXME: could make copy before sanitizing, avoid commutative=T/F.
+        # Easier to drop that from _sanitize as I did above...
+        #acpy = assumptions.copy()
         cls._sanitize(assumptions, cls)
-        return Symbol.__xnew_cached_(cls, name, **assumptions)
+        obj = Symbol.__xnew_cached_(cls, name, **assumptions)
+        #obj._user_assumptions = acpy
+        return obj
 
     def __new_stage2__(cls, name, **assumptions):
         if not isinstance(name, string_types):
@@ -107,6 +113,8 @@ class Symbol(AtomicExpr, Boolean):
 
         obj = Expr.__new__(cls)
         obj.name = name
+        # FIXME: _raw_assumptions better name?
+        obj._user_assumptions = assumptions.copy()
         obj._assumptions = StdFactKB(assumptions)
         return obj
 
@@ -135,6 +143,7 @@ class Symbol(AtomicExpr, Boolean):
 
     def as_dummy(self):
         """Return a Dummy having the same name and same assumptions as self."""
+        # FIXME: copy the user-specified assumptions instead/too?
         return Dummy(self.name, **self.assumptions0)
 
     def __call__(self, *args):

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -140,7 +140,13 @@ class ReprPrinter(Printer):
                                            self._print(expr.a), self._print(expr.b))
 
     def _print_Symbol(self, expr):
-        return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+        d = expr._user_assumptions
+        if d == {}:
+            return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+        else:
+            attr = ['%s=%s' % (k, v) for k, v in d.iteritems()]
+            return "%s(%s, %s)" % (expr.__class__.__name__,
+                                   self._print(expr.name), ', '.join(attr))
 
     def _print_Predicate(self, expr):
         return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -144,7 +144,7 @@ class ReprPrinter(Printer):
         if d == {}:
             return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
         else:
-            attr = ['%s=%s' % (k, v) for k, v in d.iteritems()]
+            attr = ['%s=%s' % (k, v) for k, v in d.items()]
             return "%s(%s, %s)" % (expr.__class__.__name__,
                                    self._print(expr.name), ', '.join(attr))
 

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,7 @@
 from sympy.utilities.pytest import raises
-from sympy import symbols, Function, Integer, Matrix, Abs, \
-    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false, ones
+from sympy import (symbols, Function, Integer, Matrix, Abs,
+    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false, ones,
+    Symbol)
 from sympy.core.compatibility import exec_
 from sympy.geometry import Point, Ellipse
 from sympy.printing import srepr
@@ -111,6 +112,7 @@ def test_Float():
 def test_Symbol():
     sT(x, "Symbol('x')")
     sT(y, "Symbol('y')")
+    sT(Symbol('x', negative=True), "Symbol('x', negative=True)")
 
 
 def test_tuple():

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,7 +1,7 @@
 from sympy.utilities.pytest import raises
 from sympy import (symbols, Function, Integer, Matrix, Abs,
     Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false, ones,
-    Symbol)
+    Symbol, Dummy, Wild)
 from sympy.core.compatibility import exec_
 from sympy.geometry import Point, Ellipse
 from sympy.printing import srepr
@@ -113,6 +113,25 @@ def test_Symbol():
     sT(x, "Symbol('x')")
     sT(y, "Symbol('y')")
     sT(Symbol('x', negative=True), "Symbol('x', negative=True)")
+
+
+def test_Symbol_two_assumptions():
+    x = Symbol('x', negative=0, integer=1)
+    # order can and does vary (FIXME: is this a caching issue?)
+    s1 = "Symbol('x', integer=True, negative=False)"
+    s2 = "Symbol('x', negative=False, integer=True)"
+    assert srepr(x) in (s1, s2)
+    assert eval(srepr(x), ENV) == x
+
+
+def test_Wild():
+    sT(Wild('x', even=True), "Wild('x', even=True)")
+
+
+def test_Dummy():
+    # cannot use sT here
+    d = Dummy('d', nonzero=True)
+    assert srepr(d) == "Dummy('d', nonzero=True)"
 
 
 def test_tuple():

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -134,6 +134,13 @@ def test_Dummy():
     assert srepr(d) == "Dummy('d', nonzero=True)"
 
 
+def test_Dummy_from_Symbol():
+    # should not get the full dictionary of assumptions
+    n = Symbol('n', integer=True)
+    d = n.as_dummy()
+    assert srepr(d) == "Dummy('n', integer=True)"
+
+
 def test_tuple():
     sT((x,), "(Symbol('x'),)")
     sT((x, y), "(Symbol('x'), Symbol('y'))")


### PR DESCRIPTION
Here's an attempt at #8042, to have those assumptions (and only those assumptions) with which a Symbol was created appear in its srepr.

E.g.,

```
x = Symbol('x', positive=1)
n = Symbol('n', even=True)
srepr(x)   % "Symbol('x', positive=True)"
srepr(n)   % "Symbol('n', even=True)"
```

@smichr: would you like to help?  This is inspired by #8025 and I'd appreciate your broader view!

I keep two dicts in private variables: a lightly sanitized version of the user input, and the `StdFactKB` (latter as it currently done).  This seems dangerous as I'm not convinced they could not diverge.  But its a starting point.  They can't change within a single immutable Symbol but as my `.as_dummy()` changes indicate, one has to be careful elsewhere.
