### PR TITLE
[RFC] real_roots mods

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -834,6 +834,10 @@ class Float(Number):
                 prec = self._prec
                 return Float._new(
                     mlib.mpf_pow_int(self._mpf_, expt.p, prec, rnd), prec)
+            elif isinstance(expt, Rational) and \
+                    expt.p == 1 and expt.q % 2 and self.is_negative:
+                return Pow(S.NegativeOne, expt, evaluate=False)*(
+                    -self)._eval_power(expt)
             expt, prec = expt._as_mpf_op(self._prec)
             mpfself = self._mpf_
             try:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -268,10 +268,9 @@ def real_root(arg, n=None):
     """
     if n is not None:
         n = as_int(n)
-        args = arg, Rational(1, n)
+        rv = C.Pow(arg, Rational(1, n))
         if n % 2 == 0:
-            return C.Pow(*args)
-        rv = C.Pow(*args, evaluate=False)
+            return rv
     else:
         rv = sympify(arg)
     n1pow = Transform(lambda x: -(-x.base)**x.exp,

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -268,9 +268,10 @@ def real_root(arg, n=None):
     """
     if n is not None:
         n = as_int(n)
-        rv = C.Pow(arg, Rational(1, n))
+        args = arg, Rational(1, n)
         if n % 2 == 0:
-            return rv
+            return C.Pow(*args)
+        rv = C.Pow(*args, evaluate=False)
     else:
         rv = sympify(arg)
     n1pow = Transform(lambda x: -(-x.base)**x.exp,

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -218,6 +218,7 @@ def test_real_root():
     r3 = root(-1, 4)
     assert real_root(r1 + r2 + r3) == -1 + r2 + r3
     assert real_root(root(-2, 3)) == -root(2, 3)
+    assert real_root(-8., 3) == -2
 
 
 def test_rewrite_MaxMin_as_Heaviside():


### PR DESCRIPTION
Something has to be done to allow one to compute real_root(float, odd) as real. At first I thought to handle this in real_root, but then I thought it might be better to catch it in _eval_power itself. Which do you think is better:

``` python
# This is how a negative rational base behaves:

>>> root(S('-1/10'),3)
(-1)**(1/3)*10**(2/3)/10

# Now, for a negative float...

>>> root(S('-.1'),3)
0.464158883361278*(-1)**(1/3)  # <-- should a negative float give this (a)
>>> _.n()
0.232079441680639 + 0.401973384383085*I  # <-- or this (b)?
```

The trend is to fully evaluate an expression if args are numbers, but by selecting the principle root in the case of Pow, the user looses the option to select the real branch post-calc.
