### PR TITLE
solve and unrad update

### DIFF
--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2359,8 +2359,7 @@ def test_V13():
 @XFAIL
 def test_V14():
     r1 = integrate(log(abs(x**2 - y**2)), x)
-    # I.simplify() raises AttributeError
-    # https://github.com/sympy/sympy/issues/7158
+    # Piecewise result does not simplify to the desired result.
     assert (r1.simplify() == x*log(abs(x**2  - y**2))
                             + y*log(x + y) - y*log(x - y) - 2*x)
 

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -931,7 +931,7 @@ def test_M15():
 
 
 def test_M16():
-    assert solve(sin(x) - tan(x), x) == [0, 2*pi]
+    assert solve(sin(x) - tan(x), x) == [0, -pi, pi, 2*pi]
 
 
 @XFAIL

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -965,9 +965,7 @@ def test_M23():
     x = symbols('x', complex=True)
 
     assert solve(x - 1/sqrt(1 + x**2)) == [
-        simplify(-I*sqrt((sqrt(5) + 1)/2)),
-        simplify(   sqrt((sqrt(5) - 1)/2)),
-    ]
+        -I*sqrt(S.Half + sqrt(5)/2), sqrt(-S.Half + sqrt(5)/2)]
 
 
 def test_M24():

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -620,3 +620,7 @@ def test_nroots2():
     assert [str(r) for r in roots] == \
             ['-0.33199', '-0.83907 - 0.94385*I', '-0.83907 + 0.94385*I',
               '1.0051 - 0.93726*I', '1.0051 + 0.93726*I']
+
+
+def test_roots_composite():
+    assert len(roots(Poly(y**3 + y**2*sqrt(x) + y + x, y, composite=True))) == 3

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -760,6 +760,7 @@ def test_powsimp_nc():
     assert powsimp(B**x*A**x*C**x, combine='base') == (B*A*C)**x
     assert powsimp(B**x*A**x*C**x, combine='exp') == B**x*A**x*C**x
 
+
 def test_nthroot():
     assert nthroot(90 + 34*sqrt(7), 3) == sqrt(7) + 3
     q = 1 + sqrt(2) - 2*sqrt(3) + sqrt(6) + sqrt(7)
@@ -776,6 +777,7 @@ def test_nthroot():
     assert nthroot(expand_multinomial(q**3), 3) == q
     assert nthroot(expand_multinomial(q**6), 6) == q
 
+
 @slow
 def test_nthroot1():
     q = 1 + sqrt(2) + sqrt(3) + S(1)/10**20
@@ -783,7 +785,8 @@ def test_nthroot1():
     assert nthroot(p, 5) == q
     q = 1 + sqrt(2) + sqrt(3) + S(1)/10**30
     p = expand_multinomial(q**5)
-    assert nthroot(p, 5) == p**Rational(1, 5)
+    assert nthroot(p, 5) == q
+
 
 def test_collect_1():
     """Collect with respect to a Symbol"""

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -562,10 +562,8 @@ def dsolve(eq, func=None, hint="default", simplify=True,
     >>> dsolve(eq, hint='1st_exact')
     [f(x) == -acos(C1/cos(x)) + 2*pi, f(x) == acos(C1/cos(x))]
     >>> dsolve(eq, hint='almost_linear')
-    [f(x) == -acos(-sqrt(C1/cos(x)**2)) + 2*pi,
-    f(x) == -acos(sqrt(C1/cos(x)**2)) + 2*pi,
-    f(x) == acos(-sqrt(C1/cos(x)**2)),
-    f(x) == acos(sqrt(C1/cos(x)**2))]
+    [f(x) == -acos(C1/sqrt(-cos(x)**2)) + 2*pi,
+    f(x) == acos(C1/sqrt(-cos(x)**2))]
     >>> t = symbols('t')
     >>> x, y = symbols('x, y', function=True)
     >>> eq = (Eq(Derivative(x(t),t), 12*t*x(t) + 8*y(t)), Eq(Derivative(y(t),t), 21*x(t) + 7*t*y(t)))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -299,10 +299,8 @@ def test_nonlinear_2eq_order1():
     eq3 = (Eq(diff(x(t),t), y(t)*x(t)), Eq(diff(y(t),t), x(t)**3))
     tt = S(2)/3
     sol3 = [
-        Eq(x(t), 6**tt/(6*(sinh(sqrt(C1*(C2 + t)**2)/2)/sqrt(C1))**tt)),
-        Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1*(C2 + t)**2)/2)**2)/3),
-        Eq(x(t), 6**tt/(6*(-sinh(sqrt(C1*(C2 + t)**2)/2)/sqrt(C1))**tt)),
-        Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1*(C2 + t)**2)/2)**2)/3)]
+        Eq(x(t), 6**tt/(6*(-sinh(sqrt(C1)*(C2 + t)/2)/sqrt(C1))**tt)),
+        Eq(y(t), sqrt(C1 + C1/sinh(sqrt(C1)*(C2 + t)/2)**2)/3)]
     assert dsolve(eq3) == sol3
 
     eq4 = (Eq(diff(x(t),t),x(t)*y(t)*sin(t)**2), Eq(diff(y(t),t),y(t)**2*sin(t)**2))
@@ -2150,10 +2148,10 @@ def test_exact_enhancement():
     eq = (x + 2)*sin(f) + df*x*cos(f)
     rhs = [sol.rhs for sol in dsolve(eq, f)]
     assert rhs == [
-        -acos(-sqrt(C1*exp(-2*x) + x**4)/x**2) + 2*pi,
-        -acos(sqrt(C1*exp(-2*x) + x**4)/x**2) + 2*pi,
-        acos(-sqrt(C1*exp(-2*x) + x**4)/x**2),
-        acos(sqrt(C1*exp(-2*x) + x**4)/x**2)]
+        -acos(-sqrt(C1*exp(-2*x)/x**4 + 1)) + 2*pi,
+        -acos(sqrt(C1*exp(-2*x)/x**4 + 1)) + 2*pi,
+        acos(-sqrt(C1*exp(-2*x)/x**4 + 1)),
+        acos(sqrt(C1*exp(-2*x)/x**4 + 1))]
 
 
 def test_separable_reduced():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -778,8 +778,6 @@ def test_unrad1():
 
     def s_check(rv, ans):
         # get the dummy
-        was = rv, ans
-        was = was[:]
         rv = list(rv)
         d = rv[0].atoms(Dummy)
         reps = list(zip(d, [s]*len(d)))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -326,7 +326,7 @@ def test_solveset_sqrt_2():
     assert solveset_real(eq, x) == FiniteSet(16)
 
     assert solveset_real(sqrt(x) + sqrt(sqrt(x)) - 4, x) == \
-        FiniteSet(-9*sqrt(17)/2 + 49*S.Half)
+        FiniteSet((-S.Half + sqrt(17)/2)**4)
 
     eq = sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))
     assert solveset_real(eq, x) == FiniteSet()


### PR DESCRIPTION
closes #8780 as an alternative to that PR
fixes #8679 
fixes #8755 
fixes #8591 

MASTER:

``` python
>>> y=root(x,3);solve(y**2+y-x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\solvers\solvers.py", line 912, in solve
    solution = _solve(f[0], *symbols, **flags)
  File "sympy\solvers\solvers.py", line 1423, in _solve
    "\nNo algorithms are implemented to solve equation %s" % f)
NotImplementedError:
No algorithms are implemented to solve equation x**(2/3) + x**(1/3) - x
```

NOW:

```
>>> y=root(x,3);solve(y**2+y-x)
[0, (1/2 + sqrt(5)/2)**3]
```
