### PR TITLE
Symbol: record the user specified assumptions for srepr output

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -196,19 +196,14 @@ class StdFactKB(FactKB):
     """
     rules = _assume_rules
 
-    def __init__(self, facts=None, extra_facts=None):
-        # save a copy of the facts dict, then add the extra facts
+    def __init__(self, facts=None):
+        # save a copy of the facts dict
         if not facts:
             self._generator = {};
         elif not isinstance(facts, FactKB):
             self._generator = facts.copy()
         else:
             self._generator = facts.generator
-        if extra_facts:
-            if facts:
-                facts.update(extra_facts)
-            else:
-                facts = extra_facts
         if facts:
             self.deduce_all_facts(facts)
 

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -196,7 +196,16 @@ class StdFactKB(FactKB):
     """
     rules = _assume_rules
 
-    def __init__(self, facts=None):
+    def __init__(self, facts=None, nonuser_facts=None):
+        # save a copy of the facts dict, then add the extra facts
+        #print((facts, type(facts), nonuser_facts))
+        if type(facts) is dict:  # not a subclass
+            self._saved_user_facts = facts.copy()
+        if nonuser_facts:
+            if facts:
+                facts.update(nonuser_facts)
+            else:
+                facts = nonuser_facts
         if facts:
             self.deduce_all_facts(facts)
 

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -196,21 +196,28 @@ class StdFactKB(FactKB):
     """
     rules = _assume_rules
 
-    def __init__(self, facts=None, nonuser_facts=None):
+    def __init__(self, facts=None, extra_facts=None):
         # save a copy of the facts dict, then add the extra facts
-        #print((facts, type(facts), nonuser_facts))
-        if type(facts) is dict:  # not a subclass
-            self._saved_user_facts = facts.copy()
-        if nonuser_facts:
+        if not facts:
+            self._generator = {};
+        elif not isinstance(facts, FactKB):
+            self._generator = facts.copy()
+        else:
+            self._generator = facts.generator
+        if extra_facts:
             if facts:
-                facts.update(nonuser_facts)
+                facts.update(extra_facts)
             else:
-                facts = nonuser_facts
+                facts = extra_facts
         if facts:
             self.deduce_all_facts(facts)
 
     def copy(self):
         return self.__class__(self)
+
+    @property
+    def generator(self):
+        return self._generator.copy()
 
 
 def as_property(fact):

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -106,10 +106,19 @@ class Symbol(AtomicExpr, Boolean):
 
         obj = Expr.__new__(cls)
         obj.name = name
+
+        # FIXME: bit horrid: to avoid having "commutative=True" show up in
+        # Symbol's srepr, keep a copy...
+        tmpasmcopy = assumptions.copy()
+
         # be strict about commutativity
         is_commutative = fuzzy_bool(assumptions.get('commutative', True))
-        extra = {'commutative': is_commutative};
-        obj._assumptions = StdFactKB(assumptions, extra)
+        assumptions['commutative'] = is_commutative
+        obj._assumptions = StdFactKB(assumptions)
+
+        # FIXME: ... then use the copy overwrite the generator
+        obj._assumptions._generator = tmpasmcopy
+
         return obj
 
     __xnew__ = staticmethod(

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -107,18 +107,21 @@ class Symbol(AtomicExpr, Boolean):
         obj = Expr.__new__(cls)
         obj.name = name
 
-        # FIXME: bit horrid: to avoid having "commutative=True" show up in
-        # Symbol's srepr, keep a copy...
-        tmpasmcopy = assumptions.copy()
+        # TODO: Issue #8873: Forcing the commutative assumption here means
+        # later code such as ``srepr()`` cannot tell whether the user
+        # specified ``commutative=True`` or omitted it.  To workaround this,
+        # we keep a copy of the assumptions dict, then create the StdFactKB,
+        # and finally overwrite its ``._generator`` with the dict copy.  This
+        # is a bit of a hack because we assume StdFactKB merely copies the
+        # given dict as ``._generator``, but future modification might, e.g.,
+        # compute a minimal equivalent assumption set.
+        tmp_asm_copy = assumptions.copy()
 
         # be strict about commutativity
         is_commutative = fuzzy_bool(assumptions.get('commutative', True))
         assumptions['commutative'] = is_commutative
         obj._assumptions = StdFactKB(assumptions)
-
-        # FIXME: ... then use the copy overwrite the generator
-        obj._assumptions._generator = tmpasmcopy
-
+        obj._assumptions._generator = tmp_asm_copy  # Issue #8873
         return obj
 
     __xnew__ = staticmethod(

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -132,11 +132,6 @@ class Symbol(AtomicExpr, Boolean):
         return dict((key, value) for key, value
                 in self._assumptions.items() if value is not None)
 
-    @property
-    def assumptions0(self):
-        return dict((key, value) for key, value
-                in self._assumptions.items() if value is not None)
-
     @cacheit
     def sort_key(self, order=None):
         return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -140,7 +140,13 @@ class ReprPrinter(Printer):
                                            self._print(expr.a), self._print(expr.b))
 
     def _print_Symbol(self, expr):
-        return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+        d = expr._assumptions._saved_user_facts
+        if d == {}:
+            return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+        else:
+            attr = ['%s=%s' % (k, v) for k, v in d.items()]
+            return "%s(%s, %s)" % (expr.__class__.__name__,
+                                   self._print(expr.name), ', '.join(attr))
 
     def _print_Predicate(self, expr):
         return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -140,7 +140,7 @@ class ReprPrinter(Printer):
                                            self._print(expr.a), self._print(expr.b))
 
     def _print_Symbol(self, expr):
-        d = expr._assumptions._saved_user_facts
+        d = expr._assumptions.generator
         if d == {}:
             return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
         else:

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -124,6 +124,14 @@ def test_Symbol_two_assumptions():
     assert eval(srepr(x), ENV) == x
 
 
+def test_Symbol_no_special_commutative_treatment():
+    sT(Symbol('x'), "Symbol('x')")
+    sT(Symbol('x', commutative=False), "Symbol('x', commutative=False)")
+    sT(Symbol('x', commutative=0), "Symbol('x', commutative=False)")
+    sT(Symbol('x', commutative=True), "Symbol('x', commutative=True)")
+    sT(Symbol('x', commutative=1), "Symbol('x', commutative=True)")
+
+
 def test_Wild():
     sT(Wild('x', even=True), "Wild('x', even=True)")
 

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -117,7 +117,7 @@ def test_Symbol():
 
 def test_Symbol_two_assumptions():
     x = Symbol('x', negative=0, integer=1)
-    # order can and does vary (FIXME: is this a caching issue?)
+    # order could vary
     s1 = "Symbol('x', integer=True, negative=False)"
     s2 = "Symbol('x', negative=False, integer=True)"
     assert srepr(x) in (s1, s2)

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,7 @@
 from sympy.utilities.pytest import raises
-from sympy import symbols, Function, Integer, Matrix, Abs, \
-    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false, ones
+from sympy import (symbols, Function, Integer, Matrix, Abs,
+    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false, ones,
+    Symbol, Dummy, Wild)
 from sympy.core.compatibility import exec_
 from sympy.geometry import Point, Ellipse
 from sympy.printing import srepr
@@ -111,6 +112,33 @@ def test_Float():
 def test_Symbol():
     sT(x, "Symbol('x')")
     sT(y, "Symbol('y')")
+    sT(Symbol('x', negative=True), "Symbol('x', negative=True)")
+
+
+def test_Symbol_two_assumptions():
+    x = Symbol('x', negative=0, integer=1)
+    # order can and does vary (FIXME: is this a caching issue?)
+    s1 = "Symbol('x', integer=True, negative=False)"
+    s2 = "Symbol('x', negative=False, integer=True)"
+    assert srepr(x) in (s1, s2)
+    assert eval(srepr(x), ENV) == x
+
+
+def test_Wild():
+    sT(Wild('x', even=True), "Wild('x', even=True)")
+
+
+def test_Dummy():
+    # cannot use sT here
+    d = Dummy('d', nonzero=True)
+    assert srepr(d) == "Dummy('d', nonzero=True)"
+
+
+def test_Dummy_from_Symbol():
+    # should not get the full dictionary of assumptions
+    n = Symbol('n', integer=True)
+    d = n.as_dummy()
+    assert srepr(d) == "Dummy('n', integer=True)"
 
 
 def test_tuple():


### PR DESCRIPTION
> Store the user input as a private variable in StdFactKB.
> Add tests.  Test that srepr(x.as_dummy()) should only have the
> user-specified assumptions, not the fully dictionary.

Another attempt at #8042.  Perhaps this is this less messy than #8812.
