### PR TITLE
  Float: losslessly convert strings to high-precision Floats

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -469,16 +469,26 @@ class Float(Number):
     >>> Float(3)
     3.00000000000000
 
-    Floats can be created from a string representations of Python floats
-    to force ints to Float or to enter high-precision (> 15 significant
-    digits) values:
+    Creating Floats from strings (and Python ``int`` and ``long`` types)
+    typically uses approximately 15 significant digits of precision; however
+    the default behaviour is to automatically increase this when the string
+    contains high-precision values:
 
     >>> Float('.0010')
     0.00100000000000000
     >>> Float('1e-3')
     0.00100000000000000
+    >>> Float('123456789.123456789123456789')
+    123456789.123456789123456789
+    >>> Float(12345678901234567890)
+    12345678901234567890.
+
+    The number of digits can also be specified:
+
     >>> Float('1e-3', 3)
     0.00100
+    >>> Float(100, 4)
+    100.0
 
     Float can automatically count significant figures if a null string
     is sent for the precision; space are also allowed in the string. (Auto-
@@ -502,25 +512,21 @@ class Float(Number):
     >>> Float('600e-2', '')  # 3 digits significant
     6.00
 
-    When converting from a string, the default behaviour is to automatically
-    count significant digits, unless that number would be less than 15.  That
-    is, the precision of the resulting Float is at least 15.
-
-    >>> Float('123456789.123456789123456789')
-    123456789.123456789123456789
-    >>> Float('123456789.123456789123456789', 'min15')
-    123456789.123456789123456789
-
-    This default ``min15`` behaviour can be subtly different than using the
-    null string ``''`` as the second argument:
-
-    >>> 2/Float('2.6')
-    0.769230769230769
-    >>> 2/Float('2.6','')
-    0.77
-
     Notes
     =====
+
+    The behaviour when using the null string argument with low-precision can
+    be subtly different from Python double-precision floats.  The default
+    behaviour is closer to Python:
+
+    >>> 2/2.6
+    0.7692307692307692
+    >>> 2/Float('2.6')
+    0.769230769230769
+    >>> 2/Float('2.6', '')
+    0.77
+    >>> 2.0/Float('2.6', '')
+    0.768554687500000
 
     Floats are inexact by their nature unless their value is a binary-exact
     value.
@@ -619,7 +625,7 @@ class Float(Number):
 
     is_Float = True
 
-    def __new__(cls, num, prec='min15'):
+    def __new__(cls, num, prec=None):
         if isinstance(num, string_types):
             num = num.replace(' ', '')
             if num.startswith('.') and len(num) > 1:
@@ -633,7 +639,7 @@ class Float(Number):
         elif isinstance(num, mpmath.mpf):
             num = num._mpf_
 
-        if prec == 'min15':
+        if prec is None:
             dps = 15
             if isinstance(num, string_types) and _literal_float(num):
                 try:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -456,9 +456,7 @@ class Number(AtomicExpr):
 
 
 class Float(Number):
-    """
-    Represents a floating point number. It is capable of representing
-    arbitrary-precision floating-point numbers.
+    """Represent a floating-point number of arbitrary precision.
 
     Examples
     ========

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -467,21 +467,33 @@ class Float(Number):
     >>> Float(3)
     3.00000000000000
 
-    Creating Floats from strings (and Python ``int`` and ``long`` types)
-    typically uses approximately 15 significant digits of precision; however
-    the default behaviour is to automatically increase this when the string
-    contains high-precision values:
+    Creating Floats from strings (and Python ``int`` and ``long``
+    types) will give a minimum precision of 15 digits, but the
+    precision will automatically increase to capture all digits
+    entered.
 
-    >>> Float('.0010')
-    0.00100000000000000
-    >>> Float('1e-3')
-    0.00100000000000000
-    >>> Float('123456789.123456789123456789')
-    123456789.123456789123456789
-    >>> Float(12345678901234567890)
-    12345678901234567890.
+    >>> Float(1)
+    1.00000000000000
+    >>> Float(10**20)
+    100000000000000000000.
+    >>> Float('1e20')
+    100000000000000000000.
 
-    The number of digits can also be specified:
+    However, *floating-point* numbers (Python ``float`` types) retain
+    only 15 digits of precision:
+
+    >>> Float(1e20)
+    1.00000000000000e+20
+    >>> Float(1.23456789123456789)
+    1.23456789123457
+
+    It may be preferable to enter high-precision decimal numbers
+    as strings:
+
+    Float('1.23456789123456789')
+    1.23456789123456789
+
+    The desired number of digits can also be specified:
 
     >>> Float('1e-3', 3)
     0.00100

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -513,19 +513,6 @@ class Float(Number):
     Notes
     =====
 
-    The behaviour when using the null string argument with low-precision can
-    be subtly different from Python double-precision floats.  The default
-    behaviour is closer to Python:
-
-    >>> 2/2.6
-    0.7692307692307692
-    >>> 2/Float('2.6')
-    0.769230769230769
-    >>> 2/Float('2.6', '')
-    0.77
-    >>> 2.0/Float('2.6', '')
-    0.768554687500000
-
     Floats are inexact by their nature unless their value is a binary-exact
     value.
 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,7 +1,7 @@
-from sympy import (Add, ceiling, cos, E, Eq, exp, factorial, fibonacci, floor,
-                   Function, GoldenRatio, I, log, Mul, oo, pi, Pow, Rational,
-                   sin, sqrt, sstr, sympify, S, integrate, atan, product,
-                   Sum, Product, Integral)
+from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factorial,
+                   fibonacci, floor, Function, GoldenRatio, I, Integral,
+                   integrate, log, Mul, N, oo, pi, Pow, product, Product,
+                   Rational, S, Sum, sin, sqrt, sstr, sympify)
 from sympy.core.evalf import complex_accuracy, PrecisionExhausted, scaled_zero
 from sympy.core.compatibility import long
 from mpmath import inf, ninf
@@ -447,3 +447,11 @@ def test_evalf_integral():
     # test that workprec has to increase in order to get a result other than 0
     eps = Rational(1, 1000000)
     assert Integral(sin(x), (x, -pi, pi + eps)).n(2)._prec == 10
+
+
+def test_issue_8821_highprec_from_str():
+    s = str(pi.evalf(128))
+    p = N(s)
+    assert Abs(sin(p)) < 1e-15
+    p = N(s, 64)
+    assert Abs(sin(p)) < 1e-64

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -603,10 +603,11 @@ def test_nfloat():
     eq = x**(S(4)/3) + 4*x**(x/3)/3
     assert _aresame(nfloat(eq), x**(S(4)/3) + (4.0/3)*x**(x/3))
     big = 12345678901234567890
-    Float_big = Float(big)
-    assert _aresame(nfloat(x**big, exponent=True),
-                    x**Float_big)
+    # specify precision to match value used in nfloat
+    Float_big = Float(big, 15)
     assert _aresame(nfloat(big), Float_big)
+    assert _aresame(nfloat(big*x), Float_big*x)
+    assert _aresame(nfloat(x**big, exponent=True), x**Float_big)
     assert nfloat({x: sqrt(2)}) == {x: nfloat(sqrt(2))}
     assert nfloat({sqrt(2): x}) == {sqrt(2): x}
     assert nfloat(cos(x + sqrt(2))) == cos(x + nfloat(sqrt(2)))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2,7 +2,7 @@ import decimal
 from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
-                   AlgebraicNumber, simplify, Abs)
+                   AlgebraicNumber, simplify)
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import long, u
 from sympy.core.power import integer_nthroot

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2,7 +2,7 @@ import decimal
 from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
-                   AlgebraicNumber, simplify)
+                   AlgebraicNumber, simplify, Abs)
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import long, u
 from sympy.core.power import integer_nthroot
@@ -450,6 +450,11 @@ def test_Float():
 
     assert '{0:.3f}'.format(Float(4.236622)) == '4.237'
     assert '{0:.35f}'.format(Float(pi.n(40), 40)) == '3.14159265358979323846264338327950288'
+
+
+def test_Float_default_to_highprec_from_str():
+    s = str(pi.evalf(128))
+    assert _aresame(Float(s), Float(s, ''))
 
 
 def test_Float_eval():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -403,11 +403,12 @@ def test_Float():
     teq(2*pi)
     teq(cos(0.1, evaluate=False))
 
+    # long integer
     i = 12345678901234567890
     assert _aresame(Float(12, ''), Float('12', ''))
     assert _aresame(Float(Integer(i), ''), Float(i, ''))
     assert _aresame(Float(i, ''), Float(str(i), 20))
-    assert not _aresame(Float(str(i)), Float(i, ''))
+    assert _aresame(Float(str(i)), Float(i, ''))
 
     # inexact floats (repeating binary = denom not multiple of 2)
     # cannot have precision greater than 15

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -409,6 +409,7 @@ def test_Float():
     assert _aresame(Float(Integer(i), ''), Float(i, ''))
     assert _aresame(Float(i, ''), Float(str(i), 20))
     assert _aresame(Float(str(i)), Float(i, ''))
+    assert _aresame(Float(i), Float(i, ''))
 
     # inexact floats (repeating binary = denom not multiple of 2)
     # cannot have precision greater than 15

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,6 +1,6 @@
-from sympy import Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda, \
-    Function, I, S, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,\
-    Pow, Or, true, false
+from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
+    Function, I, S, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,
+    Pow, Or, true, false, Abs, pi)
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError, kernS
 from sympy.core.decorators import _sympifyit
@@ -486,3 +486,9 @@ def test_issue_5596():
     locals = {}
     exec_("from sympy.abc import Q, C", locals)
     assert str(S('C&Q', locals)) == 'And(C, Q)'
+
+
+def test_issue_8821_highprec_from_str():
+    s = str(pi.evalf(128))
+    p = sympify(s)
+    assert Abs(sin(p)) < 1e-127


### PR DESCRIPTION
```
Float: losslessly convert strings to high-precision Floats

Previously, the output of `sympify(<str>)` always gave precision
of 15, even if the string was much longer.  `N(<str>)` and Float
were similar.  For Float, a user could always to `Float(str, '')`
to auto select the precision.  This is good but perhaps not ideal
for `sympify(str)` (which ultimately calls `Float(str)` without
the nullstring.

The new behaviour is all of sympify, N, and Float will now default
to a minimum precision of 15 when converting from a string (thus
preserving previous behaviour).  But when given a long string
they can use additional precision automatically.

This is accomplished with a new choice of the `prec` kwarg in the
Float constructor: `prec='min15'` uses a minimum precision of 15
but can use higher for strings, where is behaves like the null
string.  This new choice is made the default.

Fixes #8821.
```
