### PR TITLE
allow k-th n-th root to be selected

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -157,7 +157,11 @@ class exp_polar(ExpBase):
         """ Careful! any evalf of polar numbers is flaky """
         from sympy import im, pi, re
         i = im(self.args[0])
-        if i <= -pi or i > pi:
+        try:
+            bad = (i <= -pi or i > pi)
+        except TypeError:
+            bad = True
+        if bad:
             return self  # cannot evalf for this argument
         res = exp(self.args[0])._eval_evalf(prec)
         if i > 0 and im(res) < 0:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -288,8 +288,20 @@ def real_root(arg, n=None):
     root, sqrt
     """
     if n is not None:
-        n = as_int(n)
-        rv = root(arg, n)
+        try:
+            n = as_int(n)
+            arg = sympify(arg)
+            if arg.is_positive or arg.is_negative:
+                rv = root(arg, n)
+            else:
+                raise ValueError
+        except ValueError:
+            return root(arg, n)*C.Piecewise(
+                (S.One, ~C.Equality(C.im(arg), 0)),
+                (C.Pow(S.NegativeOne, S.One/n)**(2*C.floor(n/2)), C.And(
+                    C.Equality(n % 2, 1),
+                    arg < 0)),
+                (S.One, True))
     else:
         rv = sympify(arg)
     n1pow = Transform(lambda x: -(-x.base)**x.exp,

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -163,9 +163,7 @@ def cbrt(arg):
 
 
 def root(arg, n, k=0):
-    """The n-th root function (a shortcut for ``arg**(1/n)*exp(2*k*I*pi/n)``)
-
-    root(x, n, k) -> Returns the k-th n-th root of x, defaulting to the
+    """root(x, n, k) -> Returns the k-th n-th root of x, defaulting to the
     principle root (k=0).
 
 
@@ -190,7 +188,7 @@ def root(arg, n, k=0):
     To get the k-th n-th root, specify k:
 
     >>> root(-2, 3, 2)
-    (-2)**(1/3)*exp(4*I*pi/3)
+    -(-1)**(2/3)*2**(1/3)
 
     To get all n n-th roots you can use the RootOf function.
     The following examples show the roots of unity for n
@@ -248,18 +246,10 @@ def root(arg, n, k=0):
     * http://mathworld.wolfram.com/CubeRoot.html
 
     """
-    arg = sympify(arg)
-    try:
-        n = as_int(n)
-        k = as_int(k)
-        if arg.is_negative and k == n//2:
-            return -C.Pow(-arg, S.One/n)
-    except ValueError:
-        n = sympify(n)
-        k = sympify(k)
+    n = sympify(n)
     if k:
-        return C.Pow(arg, S.One/n)*C.exp(2*S.ImaginaryUnit*S.Pi*k/n)
-    return C.Pow(arg, S.One/n)
+        return C.Pow(arg, S.One/n)*S.NegativeOne**(2*k/n)
+    return C.Pow(arg, 1/n)
 
 
 def real_root(arg, n=None):
@@ -285,9 +275,9 @@ def real_root(arg, n=None):
     result will not be real (so use with caution):
 
     >>> root(-8, 3, 2)
-    2*(-1)**(1/3)*exp(4*I*pi/3)
+    -2*(-1)**(2/3)
     >>> real_root(_)
-    -2*exp(4*I*pi/3)
+    -2*(-1)**(2/3)
 
 
     See Also
@@ -299,12 +289,9 @@ def real_root(arg, n=None):
     """
     if n is not None:
         n = as_int(n)
-        arg = sympify(arg)
-        k = 0
-        if n % 2:
-            k = n//2
-        return root(arg, n, k)
-    rv = sympify(arg)
+        rv = root(arg, n)
+    else:
+        rv = sympify(arg)
     n1pow = Transform(lambda x: -(-x.base)**x.exp,
                       lambda x:
                       x.is_Pow and

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -221,6 +221,16 @@ def test_real_root():
     assert real_root(r1 + r2 + r3) == -1 + r2 + r3
     assert real_root(root(-2, 3)) == -root(2, 3)
     assert real_root(-8., 3) == -2
+    x = Symbol('x')
+    n = Symbol('n')
+    g = real_root(x, n)
+    assert g.subs(dict(x=-8, n=3)) == -2
+    assert g.subs(dict(x=8, n=3)) == 2
+    # give principle root if there is no real root -- if this is not desired
+    # then maybe a Root class is needed to raise an error instead
+    assert g.subs(dict(x=I, n=3)) == cbrt(I)
+    assert g.subs(dict(x=-8, n=2)) == sqrt(-8)
+    assert g.subs(dict(x=I, n=2)) == sqrt(I)
 
 
 def test_rewrite_MaxMin_as_Heaviside():

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -185,6 +185,7 @@ def test_issue_8413():
 def test_root():
     from sympy.abc import x
     n = Symbol('n', integer=True)
+    k = Symbol('k', integer=True)
 
     assert root(2, 2) == sqrt(2)
     assert root(2, 1) == 2
@@ -205,6 +206,8 @@ def test_root():
 
     assert root(x, n) == x**(1/n)
     assert root(x, -n) == x**(-1/n)
+
+    assert root(x, n, k) == x**(1/n)*(-1)**(2*k/n)
 
 
 def test_real_root():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -741,14 +741,12 @@ def solve(f, *symbols, **flags):
         >>> expr = root(x, 3) - root(x, 5)
 
     We will construct a known value for this expression at x = 3 by selecting
-    a non-principle root for each (i.e. multiplying by a power of the same
-    root of -1):
+    the 1-th root for each radical:
 
-        >>> expr1 = root(x, 3)*root(-1, 3)**2 - root(x, 5)*root(-1, 5)**2
+        >>> expr1 = root(x, 3, 1) - root(x, 5, 1)
         >>> v = expr1.subs(x, -3)
 
-    The solve function is unable to find any exact roots to this equation in
-    either form:
+    The solve function is unable to find any exact roots to this equation:
 
         >>> eq = Eq(expr, v); eq1 = Eq(expr1, v)
         >>> solve(eq, check=False), solve(eq1, check=False)


### PR DESCRIPTION
closes #8789 - instead of creating a new object, a 3rd argument is added to an existing function to allow the selection of an arbitrary kth value of the nth root of an argument.
- [x] add coverage tests in test_miscellaneous.py
- [x] allow for an unevaluated real_root(x, n)
- [x] is there a way to synchronize the kth root in general with the corresponding k-th RootOf value? RootOf sorts roots with real first (so k=0 would always be the real root). The default to the `root` function would be None to select the principle root.  **I think this would be complicated**
