### PR TITLE
Fixed #8836: Added a check for same tuples from bkey() function

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2704,7 +2704,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         for b, e in c_powers:
             b, e = bkey(b, e)
             if b in common_b.keys():
-                common_b[b] = common_b[b]+e
+                common_b[b] = common_b[b] + e
             else:
                 common_b[b] = e
             if b[1] != 1 and b[0].is_Mul:

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2703,9 +2703,13 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         bases = []
         for b, e in c_powers:
             b, e = bkey(b, e)
-            common_b[b] = e
+            if b in common_b.keys():
+                common_b[b] = common_b[b]+e
+            else:
+                common_b[b] = e
             if b[1] != 1 and b[0].is_Mul:
                 bases.append(b)
+        c_powers = [(b, e) for b, e in common_b.items() if e]
         bases.sort(key=default_sort_key)  # this makes tie-breaking canonical
         bases.sort(key=measure, reverse=True)  # handle longest first
         for base in bases:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -682,6 +682,8 @@ def test_powsimp():
 
     assert all(powsimp(e) == e for e in (sqrt(x**a), sqrt(x**2)))
 
+    # issue 8836
+    assert str( powsimp(exp(I*pi/3)*root(-1,3)) ) == '(-1)**(2/3)'
 
 def test_issue_6367():
     z = -5*sqrt(2)/(2*sqrt(2*sqrt(29) + 29)) + sqrt(-sqrt(29)/29 + S(1)/2)


### PR DESCRIPTION
`bkey` function returns same tuple for both `exp(I*pi/3)` and `root(-1,3)`. This causes overwriting of exponents in   dictionary `common_b` and subsequent dropping of a factor in #8836. 
Hence added a check whether the returning tuple is already present or not. Accordingly changed `common_b` and `c_powers`.
@smichr please review this.
