### PR TITLE
Float should be idempotent

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -638,6 +638,8 @@ class Float(Number):
 
         if prec is None:
             dps = 15
+            if isinstance(num, Float):
+                return num
             if isinstance(num, string_types) and _literal_float(num):
                 try:
                     Num = decimal.Decimal(num)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1448,3 +1448,17 @@ def test_simplify_AlgebraicNumber():
 
     e = (3 + 4*I)**(Rational(3, 2))
     assert simplify(A(e)) == A(2 + 11*I)  # issue 4401
+
+
+def test_Float_idempotence():
+    x = Float('1.23', '')
+    y = Float(x)
+    z = Float(x, 15)
+    # _aresame not enough here
+    assert str(y) == str(x)
+    assert str(z) != str(x)
+    x = Float(10**20)
+    y = Float(x)
+    z = Float(x, 15)
+    assert str(y) == str(x)
+    assert str(z) != str(x)


### PR DESCRIPTION
```
`Float(Float('1.23', ''))` should have precision 3, not 15.
Similarly for high-precision Floats.
```

This is on top of #8826.

Do we want this behaviour?  A potential downside is the output of `Float(<single arg>)` could have precision less than 15 (as in the example in the docstring above).

Currently (well, after #8826), `Float(<single arg>)` has at least precision 15 for (I think) any input.

Probably no need for review until #8826 is in.
