### PR TITLE
Fix is_positive for gamma and floor & ceiling is_even Bug.

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -320,7 +320,7 @@ def get_integer_part(expr, no, options, return_ints=False):
     def calc_part(expr, nexpr):
         nint = int(to_int(nexpr, rnd))
         n, c, p, b = nexpr
-        if c != 1 and p != 0:
+        if (c != 1 and p != 0) or p < 0:
             expr = C.Add(expr, -nint, evaluate=False)
             x, _, x_acc, _ = evalf(expr, 10, options)
             try:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,8 +1,9 @@
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factorial,
                    fibonacci, floor, Function, GoldenRatio, I, Integral,
                    integrate, log, Mul, N, oo, pi, Pow, product, Product,
-                   Rational, S, Sum, sin, sqrt, sstr, sympify)
-from sympy.core.evalf import complex_accuracy, PrecisionExhausted, scaled_zero
+                   Rational, S, Sum, sin, sqrt, sstr, sympify, Symbol)
+from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
+    scaled_zero, get_integer_part)
 from sympy.core.compatibility import long
 from mpmath import inf, ninf
 from sympy.abc import n, x, y
@@ -455,3 +456,16 @@ def test_issue_8821_highprec_from_str():
     assert Abs(sin(p)) < 1e-15
     p = N(s, 64)
     assert Abs(sin(p)) < 1e-64
+
+
+def test_issue_8853():
+    p = Symbol('x', even=True, positive=True)
+    assert floor(-p - S.Half).is_even == False
+    assert floor(-p + S.Half).is_even == True
+    assert ceiling(p - S.Half).is_even == True
+    assert ceiling(p + S.Half).is_even == False
+
+    assert get_integer_part(S.Half, -1, {}, True) == (0, 0)
+    assert get_integer_part(S.Half, 1, {}, True) == (1, 0)
+    assert get_integer_part(-S.Half, -1, {}, True) == (-1, 0)
+    assert get_integer_part(-S.Half, 1, {}, True) == (0, 0)

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -160,6 +160,13 @@ class gamma(Function):
         if x.is_positive or x.is_noninteger:
             return True
 
+    def _eval_is_positive(self):
+        x = self.args[0]
+        if x.is_positive:
+            return True
+        elif x.is_noninteger:
+            return floor(x).is_even
+
     def _eval_rewrite_as_tractable(self, z):
         return C.exp(loggamma(z))
 

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -400,3 +400,21 @@ def test_issue_8657():
     assert gamma(o).is_real is True
     assert gamma(p).is_real is True
     assert gamma(w).is_real is None
+
+
+def test_issue_8524():
+    x = Symbol('x', positive=True)
+    y = Symbol('y', negative=True)
+    z = Symbol('z', positive=False)
+    p = Symbol('p', negative=False)
+    q = Symbol('q', integer=True)
+    r = Symbol('r', integer=False)
+    e = Symbol('e', even=True, negative=True)
+    assert gamma(x).is_positive is True
+    assert gamma(y).is_positive is None
+    assert gamma(z).is_positive is None
+    assert gamma(p).is_positive is None
+    assert gamma(q).is_positive is None
+    assert gamma(r).is_positive is None
+    assert gamma(e + S.Half).is_positive is True
+    assert gamma(e - S.Half).is_positive is False


### PR DESCRIPTION
The Positive assumption helper for gamma function is missing:
For Reference (Proof) : (See graph of Gamma Function)
http://mathworld.wolfram.com/GammaFunction.html

Gamma Function is positive for: 
- Positive value of x & 
- Alternately unit ranges between -ve integers where the floor of x is even. (see graph in link above)

&
This should return False.

``` python
In [7]: x =Symbol('x', even=True, negative=True)

In [8]: floor(x - S.Half).is_even
Out[8]: True
```

Fixes #8524
closes #8864
@smichr  Please have a look.
