### PR TITLE
Added np.get_include() to Cython autowrapper, fixes #8847.

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -93,7 +93,7 @@ class CodeWrapError(Exception):
     pass
 
 
-class CodeWrapper:
+class CodeWrapper(object):
     """Base Class for code wrappers"""
     _filename = "wrapped_code"
     _module_basename = "wrapper_module"
@@ -211,30 +211,35 @@ class CythonCodeWrapper(CodeWrapper):
     """Wrapper that uses Cython"""
 
     setup_template = (
-            "from distutils.core import setup\n"
-            "from distutils.extension import Extension\n"
-            "from Cython.Distutils import build_ext\n"
-            "\n"
-            "setup(\n"
-            "    cmdclass = {{'build_ext': build_ext}},\n"
-            "    ext_modules = [Extension({ext_args}, extra_compile_args=['-std=c99'])]\n"
-            "        )")
+        "from distutils.core import setup\n"
+        "from distutils.extension import Extension\n"
+        "from Cython.Distutils import build_ext\n"
+        "{np_import}"
+        "\n"
+        "setup(\n"
+        "    cmdclass = {{'build_ext': build_ext}},\n"
+        "    ext_modules = [Extension({ext_args},\n"
+        "                             extra_compile_args=['-std=c99'])],\n"
+        "{np_includes}"
+        "        )")
 
     pyx_imports = (
-            "import numpy as np\n"
-            "cimport numpy as np\n\n")
+        "import numpy as np\n"
+        "cimport numpy as np\n\n")
 
     pyx_header = (
-            "cdef extern from '{header_file}.h':\n"
-            "    {prototype}\n\n")
+        "cdef extern from '{header_file}.h':\n"
+        "    {prototype}\n\n")
 
     pyx_func = (
-            "def {name}_c({arg_string}):\n"
-            "\n"
-            "{declarations}"
-            "{body}")
+        "def {name}_c({arg_string}):\n"
+        "\n"
+        "{declarations}"
+        "{body}")
 
-    _need_numpy = False
+    def __init__(self, *args, **kwargs):
+        super(CythonCodeWrapper, self).__init__(*args, **kwargs)
+        self._need_numpy = False
 
     @property
     def command(self):
@@ -251,8 +256,16 @@ class CythonCodeWrapper(CodeWrapper):
 
         # setup.py
         ext_args = [repr(self.module_name), repr([pyxfilename, codefilename])]
+        if self._need_numpy:
+            np_import = 'import numpy as np\n'
+            np_includes = '    include_dirs = [np.get_include()],\n'
+        else:
+            np_import = ''
+            np_includes = ''
         with open('setup.py', 'w') as f:
-            f.write(self.setup_template.format(ext_args=", ".join(ext_args)))
+            f.write(self.setup_template.format(ext_args=", ".join(ext_args),
+                                               np_import=np_import,
+                                               np_includes=np_includes))
 
     @classmethod
     def _get_wrapped_function(cls, mod, name):


### PR DESCRIPTION
@jcrist This fixes this issue for MacOSX (and probably anyone that has the NumPy headers in an odd place). But after doing this, I was wondering why we have numpy calls in the CythonWrapper. Seems like you should be able to Cythonize sympy expressions without having numpy installed. Did the CythonWrapper always require numpy? Maybe we really need two Cython wrappers, one with the numpy headers and another without.
