### PR TITLE
Float: make some tests stricter when comparing two Floats

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -638,6 +638,8 @@ class Float(Number):
 
         if prec is None:
             dps = 15
+            if isinstance(num, Float):
+                return num
             if isinstance(num, string_types) and _literal_float(num):
                 try:
                     Num = decimal.Decimal(num)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -14,6 +14,11 @@ a, c, x, y, z = symbols('a,c,x,y,z')
 b = Symbol("b", positive=True)
 
 
+def same_and_same_prec(a, b):
+    # stricter matching for Floats
+    return a == b and a._prec == b._prec
+
+
 def test_bug1():
     assert re(x) != x
     x.series(x, 0, 1)
@@ -1687,8 +1692,8 @@ def test_float_int():
         112345678901234567890123456789000192
     assert Integer(Float('123456789012345678901234567890e5', '')) == \
         12345678901234567890123456789000000
-    assert Float('123000e-2','') == Float('1230.00', '')
-    assert Float('123000e2','') == Float('12300000', '')
+    assert same_and_same_prec(Float('123000e-2',''), Float('1230.00', ''))
+    assert same_and_same_prec(Float('123000e2',''), Float('12300000', ''))
 
     assert int(1 + Rational('.9999999999999999999999999')) == 1
     assert int(pi/1e20) == 0

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -3,13 +3,17 @@ from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
                    AlgebraicNumber, simplify)
-from sympy.core.basic import _aresame
 from sympy.core.compatibility import long, u
 from sympy.core.power import integer_nthroot
 from sympy.core.numbers import igcd, ilcm, igcdex, seterr, _intcache, mpf_norm
 from mpmath import mpf
 from sympy.utilities.pytest import XFAIL, raises
 import mpmath
+
+
+def same_and_same_prec(a, b):
+    # stricter matching for Floats
+    return a == b and a._prec == b._prec
 
 
 def test_integers_cache():
@@ -405,11 +409,11 @@ def test_Float():
 
     # long integer
     i = 12345678901234567890
-    assert _aresame(Float(12, ''), Float('12', ''))
-    assert _aresame(Float(Integer(i), ''), Float(i, ''))
-    assert _aresame(Float(i, ''), Float(str(i), 20))
-    assert _aresame(Float(str(i)), Float(i, ''))
-    assert _aresame(Float(i), Float(i, ''))
+    assert same_and_same_prec(Float(12, ''), Float('12', ''))
+    assert same_and_same_prec(Float(Integer(i), ''), Float(i, ''))
+    assert same_and_same_prec(Float(i, ''), Float(str(i), 20))
+    assert same_and_same_prec(Float(str(i)), Float(i, ''))
+    assert same_and_same_prec(Float(i), Float(i, ''))
 
     # inexact floats (repeating binary = denom not multiple of 2)
     # cannot have precision greater than 15
@@ -455,7 +459,7 @@ def test_Float():
 
 def test_Float_default_to_highprec_from_str():
     s = str(pi.evalf(128))
-    assert _aresame(Float(s), Float(s, ''))
+    assert same_and_same_prec(Float(s), Float(s, ''))
 
 
 def test_Float_eval():
@@ -1454,11 +1458,10 @@ def test_Float_idempotence():
     x = Float('1.23', '')
     y = Float(x)
     z = Float(x, 15)
-    # _aresame not enough here
-    assert str(y) == str(x)
-    assert str(z) != str(x)
+    assert same_and_same_prec(y, x)
+    assert not same_and_same_prec(z, x)
     x = Float(10**20)
     y = Float(x)
     z = Float(x, 15)
-    assert str(y) == str(x)
-    assert str(z) != str(x)
+    assert same_and_same_prec(y, x)
+    assert not same_and_same_prec(z, x)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1448,3 +1448,17 @@ def test_simplify_AlgebraicNumber():
 
     e = (3 + 4*I)**(Rational(3, 2))
     assert simplify(A(e)) == A(2 + 11*I)  # issue 4401
+
+
+def test_Float_idempotence():
+    x = Float('1.23', '')
+    y = Float(x)
+    z = Float(x, 15)
+    # _aresame not enough here
+    assert str(y) == str(x)
+    assert str(z) != str(x)
+    x = Float(10**20)
+    y = Float(x)
+    z = Float(x, 15)
+    assert str(y) == str(x)
+    assert str(z) != str(x)


### PR DESCRIPTION
``````
For `==` and `basic._aresame` are rather weak tests of two Floats
being equal.  Both are False if args have different precisions.
In these tests, we want more than that.  We make sure they are
structurally equal (`==`) and that they have the same `_prec`.
An example for insufficiency of `_aresame` is:
````
p = Float('1.23', '')
q = Float(p, 15)
_aresame(p, q)   # True
````
(maybe sometimes those should be considered equal, but not in
these tests).

We add a new `same_and_same_prec` function (local to the test file).
``````

On top of #8843.  This cleans up the tests in #8843 as well as some other tests.
