### PR TITLE
Improve error message when mpmath is not installed

### DIFF
--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -3,89 +3,58 @@
 Installation
 ------------
 
-The SymPy CAS can be installed on virtually any computer with Python
-2.6 or above. SymPy does require `mpmath`_ Python library to be
-installed first.  The current recommended method of installation is
-directly from the source files.  Alternatively, executables are
-available for Windows, and some Linux distributions have SymPy
-packages available.
+The SymPy CAS can be installed on virtually any computer with Python 2.6 or
+above. SymPy does require `mpmath`_ Python library to be installed first.  The
+current recommended method of installation is through Anaconda, which includes
+mpmath, as well as several other useful libraries.  Alternatively, executables
+are available for Windows, and some Linux distributions have SymPy packages
+available.
 
 SymPy officially supports Python 2.6, 2.7, 3.2, 3.3, 3.4, and PyPy.
-
-Source
-======
-
-SymPy currently recommends that users install directly from the source files.
-You will first have to download the source files via the archive. Download the
-latest release (tar.gz) from the `downloads site`_ and open it with your
-operating system's standard decompression utility.
-
-After the download is complete, you should have a folder called "sympy". From
-your favorite command line terminal, change directory into that folder and
-execute the following::
-
-    $ python setup.py install
-
-Alternatively, if you don't want to install the package onto your computer, you
-may run SymPy with the "isympy" console (which automatically imports SymPy
-packages and defines common symbols) by executing within the "sympy" folder::
-
-    $ ./bin/isympy
-
-You may now run SymPy statements directly within the Python shell::
-
-    >>> from __future__ import division
-    >>> from sympy import *
-    >>> x, y, z, t = symbols('x y z t')
-    >>> k, m, n = symbols('k m n', integer=True)
-    >>> f, g, h = symbols('f g h', cls=Function)
-    >>> diff(x**2/2, x)
-    x
-
-Git
-===
-
-If you are a developer or like to get the latest updates as they come, be sure
-to install from git. To download the repository, execute the following from the
-command line::
-
-    $ git clone git://github.com/sympy/sympy.git
-
-Then, execute either the `setup.py` or the `bin/isympy` scripts as demonstrated
-above.
-
-To update to the latest version, go into your repository and execute::
-
-    $ git pull origin master
-
-If you want to install SymPy, but still want to use the git version, you can run
-from your repository::
-
-    $ setupegg.py develop
-
-This will cause the installed version to always point to the version in the git
-directory.
 
 Anaconda
 ========
 
-Although SymPy does not have any hard dependencies, many nice features are
-only enabled when certain libraries are installed.  For example, without
-Matplotlib, only simple text-based plotting is enabled.  With the IPython
-notebook or qtconsole, you can get nicer `\LaTeX` printing by running
-``init_printing()``.  An easy way to get all these libraries in addition to
-SymPy is to install `Anaconda <http://continuum.io/downloads>`_, which is
-a free Python distribution from Continuum Analytics that includes SymPy,
-Matplotlib, IPython, NumPy, and many more useful packages for scientific
-computing.
+`Anaconda <http://continuum.io/downloads>`_ is a free Python a free Python
+distribution from Continuum Analytics that includes SymPy, Matplotlib,
+IPython, NumPy, and many more useful packages for scientific computing. This
+is recommended because many nice features of SymPy are only enabled when
+certain libraries are installed.  For example, without Matplotlib, only simple
+text-based plotting is enabled.  With the IPython notebook or qtconsole, you
+can get nicer `\LaTeX` printing by running ``init_printing()``.
+
+If you already have Anaconda and want to update SymPy to the latest version,
+use::
+
+    conda update sympy
+
+Git
+===
+
+If you wish to contribute to SymPy or like to get the latest updates as they
+come, install SymPy from git. To download the repository, execute the
+following from the command line::
+
+    git clone git://github.com/sympy/sympy.git
+
+To update to the latest version, go into your repository and execute::
+
+    git pull origin master
+
+If you want to install SymPy, but still want to use the git version, you can run
+from your repository::
+
+    setupegg.py develop
+
+This will cause the installed version to always point to the version in the git
+directory.
 
 Other Methods
 =============
 
 An installation executable (.exe) is available for Windows users at the
 `downloads site`_. In addition, various Linux distributions have SymPy
-available as a package. Others are strongly encouraged to download from source
-(details above).
+available as a package. You may also install SymPy from source or using pip.
 
 Run SymPy
 =========

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -75,6 +75,19 @@ From here, execute some simple SymPy statements like the ones below::
 
 For a starter guide on using SymPy effectively, refer to the :ref:`tutorial`.
 
+Mpmath
+======
+
+Versions of SymPy prior to 0.7.7 included `mpmath`_, but it now depends on it as
+an external dependency.  If you installed SymPy with Anaconda, it will already
+include mpmath. Use::
+
+  conda install mpmath
+
+to ensure that it is installed.
+
+If you do not wish to use Anaconda, you can use ``pip install mpmath``.
+
 Questions
 =========
 

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -88,6 +88,17 @@ to ensure that it is installed.
 
 If you do not wish to use Anaconda, you can use ``pip install mpmath``.
 
+If you use mpmath via ``sympy.mpmath`` in your code, you will need to change
+this to use just ``mpmath``. If you depend on code that does this that you
+cannot easily change, you can work around it by doing::
+
+    import sys
+    import mpmath
+    sys.modules['sympy.mpmath'] = mpmath
+
+before the code that imports ``sympy.mpmath``. It is recommended to change
+code that uses ``sympy.mpmath`` to use ``mpmath`` directly wherever possible.
+
 Questions
 =========
 

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -15,13 +15,13 @@ SymPy officially supports Python 2.6, 2.7, 3.2, 3.3, 3.4, and PyPy.
 Anaconda
 ========
 
-`Anaconda <http://continuum.io/downloads>`_ is a free Python a free Python
-distribution from Continuum Analytics that includes SymPy, Matplotlib,
-IPython, NumPy, and many more useful packages for scientific computing. This
-is recommended because many nice features of SymPy are only enabled when
-certain libraries are installed.  For example, without Matplotlib, only simple
-text-based plotting is enabled.  With the IPython notebook or qtconsole, you
-can get nicer `\LaTeX` printing by running ``init_printing()``.
+`Anaconda <http://continuum.io/downloads>`_ is a free Python distribution from
+Continuum Analytics that includes SymPy, Matplotlib, IPython, NumPy, and many
+more useful packages for scientific computing. This is recommended because
+many nice features of SymPy are only enabled when certain libraries are
+installed.  For example, without Matplotlib, only simple text-based plotting
+is enabled.  With the IPython notebook or qtconsole, you can get nicer
+`\LaTeX` printing by running ``init_printing()``.
 
 If you already have Anaconda and want to update SymPy to the latest version,
 use::

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -16,7 +16,7 @@ try:
     import mpmath
 except ImportError:
     raise ImportError("SymPy now depends on mpmath as an external library. "
-    "You can install mpmath with 'pip install mpmath'.")
+    "See http://docs.sympy.org/latest/install.html#mpmath for more information.")
 
 from sympy.release import __version__
 

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -27,8 +27,6 @@ else:  # Python 3
     pass
     # Here we can also check for specific Python 3 versions, if needed
 
-sys.modules['sympy.mpmath'] = mpmath
-
 del sys
 
 

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -10,6 +10,7 @@ See the webpage for more information and documentation:
 """
 
 from __future__ import absolute_import, print_function
+del absolute_import, print_function
 
 from sympy.release import __version__
 

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -18,8 +18,6 @@ except ImportError:
     raise ImportError("SymPy now depends on mpmath as an external library. "
     "You can install mpmath with 'pip install mpmath'.")
 
-del mpmath
-
 from sympy.release import __version__
 
 import sys
@@ -28,6 +26,8 @@ if sys.version_info[0] == 2 and sys.version_info[1] < 6:
 else:  # Python 3
     pass
     # Here we can also check for specific Python 3 versions, if needed
+
+sys.modules['sympy.mpmath'] = mpmath
 
 del sys
 

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -12,6 +12,14 @@ See the webpage for more information and documentation:
 from __future__ import absolute_import, print_function
 del absolute_import, print_function
 
+try:
+    import mpmath
+except ImportError:
+    raise ImportError("SymPy now depends on mpmath as an external library. "
+    "You can install mpmath with 'pip install mpmath'.")
+
+del mpmath
+
 from sympy.release import __version__
 
 import sys


### PR DESCRIPTION
Another idea that I hadn't considered would be to include `sympy.mpmath` as a backwards compatible import (that maps to the external mpmath). I think a lot of code uses sympy.mpmath and it would ease transition. I'm not sure how to do it, though. 
