### PR TITLE
Add example for imageset intersection in docs

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -92,6 +92,12 @@ class Set(Basic):
         >>> Interval(1, 3).intersect(Interval(1, 2))
         [1, 2]
 
+        >>> from sympy import imageset, Lambda, symbols, S
+        >>> n, m = symbols('n m')
+        >>> a = imageset(Lambda(n, 2*n), S.Integers)
+        >>> a.intersect(imageset(Lambda(m, 2*m + 1), S.Integers))
+        EmptySet()
+
         """
         return Intersection(self, other)
 


### PR DESCRIPTION
Added an example of ImageSet ImageSet intersection. But there are other type of sets also whose example of intersection is not explicitly mentioned. For ex. `ProductSet(Interval(2, 5), FiniteSet(1, 2, 3)).intersect(ProductSet(Interval(0, 5), FiniteSet(2, 4)))` outputs `[2, 5] × {2}`. Should I add some of these cases and others in which intersection can't be calculated to the documentation.
 #8763
