### PR TITLE
unrad: 2 non-pow-of-2 rads,const; 2 cube roots,const,rad (pow < 5)

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2961,7 +2961,7 @@ def unrad(eq, *syms, **flags):
             cov = [p.xreplace(rep), e.xreplace(rep)]
 
         # remove constants and powers of factors since these don't change
-        # the location of the root
+        # the location of the root; XXX should factor or factor_terms be used?
         eq = factor_terms(_mexpand(eq.as_numer_denom()[0], recursive=True))
         if eq.is_Mul:
             args = []
@@ -2972,9 +2972,7 @@ def unrad(eq, *syms, **flags):
                     args.append(f.base)
                 else:
                     args.append(f)
-            eq = Mul(*args)
-        # fully expand the result
-        eq = _mexpand(eq)
+            eq = Mul(*args)  # leave as Mul for more efficient solving
 
         # make the sign canonical
         free = eq.free_symbols
@@ -3168,7 +3166,7 @@ def unrad(eq, *syms, **flags):
         elif len(rterms) == 3:
             # two cube roots and another with order less than 5
             # (so an analytical solution can be found) or a base
-            # that matches one of the cubr root bases
+            # that matches one of the cube root bases
             info = [_rads_bases_lcm(i.as_poly()) for i in rterms]
             RAD = 0
             BASES = 1

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -915,9 +915,8 @@ def test_unrad1():
     # if it's not then this next test will take a long time
     assert solve(root(x, 3) + root(x, 5) - 2) == [1]
     eq = (sqrt(x) + sqrt(x + 1) + sqrt(1 - x) - 6*sqrt(5)/5)
-    assert unrad(eq) in [
-        (5*x**4 - 72*x**3 + 330*x**2 - 504*x + 241, []),  # as special case
-        (15625*x**4 + 173000*x**3 + 355600*x**2 - 817920*x + 331776, [])]  # normal
+    assert check(unrad(eq),
+        ((5*x - 4)*(3125*x**3 + 37100*x**2 + 100800*x - 82944), []))
     ans = S('''
         [4/5, -1484/375 + 172564/(140625*(114*sqrt(12657)/78125 +
         12459439/52734375)**(1/3)) +


### PR DESCRIPTION
These are some extended unrad methods. I'm not sure if they are of interest or not. I haven't found a good reference for advanced radical removal (but did see two cube roots handled somewhere at math.stackexchange.com but cannot find the url now and it wasn't [this one](http://math.stackexchange.com/questions/799562/solving-implicit-equation-for-x-or-y)). 

Although polynomials can be obtained from the equations with radicals, the resulting polynomial is of high order. (The nice thing is that from that polynomial one can get a good rational approximation for the root.) 

One thing I noticed when trying to use nsolve to find the roots is that sometimes it needs a small imaginary component in the initial guess to find the root.

```
>>> expr1 = root(x, 3)*root(-1, 3)**2 - root(x, 5)*root(-1, 5)**2
>>> v = expr1.subs(x, -3)
>>> eq=expr1-v
>>> eq.subs(x,-3)
0
>>> nsolve(eq, -3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\solvers\solvers.py", line 2691, in nsolve
    return findroot(f, x0, **kwargs)
  File "c:\Python26\lib\site-packages\mpmath\calculus\optimization.py", line 975
, in findroot
    % (norm(f(*xl))**2, tol))
ValueError: Could not find root within given tolerance. (581.199 > 2.1684e-19)
Try another starting point or tweak arguments.
>>> nsolve(eq, -3+.01j)
Traceback (most recent call last):
...
ValueError: Could not find root within given tolerance. (3.48915 > 2.1684e-19)
Try another starting point or tweak arguments.
>>> nsolve(eq, -3+.001j)
Traceback (most recent call last):
...
ValueError: Could not find root within given tolerance. (3.48915 > 2.1684e-19)
Try another starting point or tweak arguments.
>>> nsolve(eq, -3+.0001j)
mpc(real='-2.9999999999998855', imag='1.4631617279617564e-13')
>>>
```

Also, the solver='bisect' sometimes will generate an imaginary part to the number and not be able to continue. (So either a different solver must be employed or the non-mpmath bisection routine, `bisect` in `sympy.polys.rootoftools` can be tried.)
