### PR TITLE
Fix the "is_symmetric()" function of SparseMatrix

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1882,12 +1882,37 @@ def test_sympy__matrices__expressions__matexpr__MatrixBase():
 
 def test_sympy__matrices__immutable__ImmutableMatrix():
     from sympy.matrices.immutable import ImmutableMatrix
-    assert _test_args(ImmutableMatrix([[1, 2], [3, 4]]))
+    m = ImmutableMatrix([[1, 2], [3, 4]])
+    assert _test_args(m)
+    assert _test_args(Basic(*list(m)))
+    m = ImmutableMatrix(1, 1, [1])
+    assert _test_args(m)
+    assert _test_args(Basic(*list(m)))
+    m = ImmutableMatrix(2, 2, lambda i, j: 1)
+    assert m[0, 0] is S.One
+    m = ImmutableMatrix(2, 2, lambda i, j: 1/(1 + i) + 1/(1 + j))
+    assert m[1, 1] is S.One  # true div. will give 1.0 if i,j not sympified
+    assert _test_args(m)
+    assert _test_args(Basic(*list(m)))
 
 
 def test_sympy__matrices__immutable__ImmutableSparseMatrix():
     from sympy.matrices.immutable import ImmutableSparseMatrix
-    assert _test_args(ImmutableSparseMatrix([[1, 2], [3, 4]]))
+    m = ImmutableSparseMatrix([[1, 2], [3, 4]])
+    assert _test_args(m)
+    assert _test_args(Basic(*list(m)))
+    m = ImmutableSparseMatrix(1, 1, {(0, 0): 1})
+    assert _test_args(m)
+    assert _test_args(Basic(*list(m)))
+    m = ImmutableSparseMatrix(1, 1, [1])
+    assert _test_args(m)
+    assert _test_args(Basic(*list(m)))
+    m = ImmutableSparseMatrix(2, 2, lambda i, j: 1)
+    assert m[0, 0] is S.One
+    m = ImmutableSparseMatrix(2, 2, lambda i, j: 1/(1 + i) + 1/(1 + j))
+    assert m[1, 1] is S.One  # true div. will give 1.0 if i,j not sympified
+    assert _test_args(m)
+    assert _test_args(Basic(*list(m)))
 
 
 def test_sympy__matrices__expressions__slice__MatrixSlice():

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -55,7 +55,8 @@ class SparseMatrix(MatrixBase):
                 op = args[2]
                 for i in range(self.rows):
                     for j in range(self.cols):
-                        value = self._sympify(op(i, j))
+                        value = self._sympify(
+                            op(self._sympify(i), self._sympify(j)))
                         if value:
                             self._smat[(i, j)] = value
             elif isinstance(args[2], (dict, Dict)):
@@ -63,7 +64,7 @@ class SparseMatrix(MatrixBase):
                 for key in args[2].keys():
                     v = args[2][key]
                     if v:
-                        self._smat[key] = v
+                        self._smat[key] = self._sympify(v)
             elif is_sequence(args[2]):
                 if len(args[2]) != self.rows*self.cols:
                     raise ValueError(
@@ -221,7 +222,8 @@ class SparseMatrix(MatrixBase):
         row_op
         col_list
         """
-        return [tuple(k + (self[k],)) for k in sorted(list(self._smat.keys()), key=lambda k: list(k))]
+        return [tuple(k + (self[k],)) for k in
+            sorted(list(self._smat.keys()), key=lambda k: list(k))]
 
     RL = property(row_list, None, None, "Alternate faster representation")
 

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -2,7 +2,6 @@ from sympy import S, Symbol, I, Rational, PurePoly
 from sympy.matrices import Matrix, SparseMatrix, eye, zeros, ShapeError
 from sympy.utilities.pytest import raises
 
-
 def test_sparse_matrix():
     def sparse_eye(n):
         return SparseMatrix.eye(n)


### PR DESCRIPTION
I found some error in the "is_symmetric()" function of SparseMatrix. For example:

``` python
>>> from sympy import *
>>> aMatrix = SparseMatrix (3,3,{(0,1):3, (1,0):3})
>>> aMatrix.is_symmetric()

Traceback (most recent call last):
  File "<pyshell#2>", line 1, in <module>
    aMatrix.is_symmetric()
  File "/usr/lib/python2.7/dist-packages/sympy/matrices/sparse.py", line 602, in is_symmetric
    for k in self._smat)
  File "/usr/lib/python2.7/dist-packages/sympy/matrices/sparse.py", line 602, in <genexpr>
    for k in self._smat)
AttributeError: 'int' object has no attribute 'simplify'
>>> 
```

So my solution is that before the return statement, if there is some value in self._smat that has Python number type (long,int,...), I convert it to SymPy number type. I also have added one test of symmetry for SparseMatrix to the file test_matrices.py
