### PR TITLE
generate simpler expressions for sin, cos, tan, cot(k*pi/n) , etc, for s...

### DIFF
--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -144,8 +144,7 @@ def test_harmonic_rational():
              + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 + 1/S(4))*log(1/S(4) + sqrt(5)/4)
-             + 11818877030/S(4286604231) - pi*sqrt(sqrt(5)/8 + 5/S(8))/(-sqrt(5)/2 + 1/S(2)) )
-
+             + 11818877030/S(4286604231) + pi*(sqrt(5)/8 + 5/S(8))/sqrt(-sqrt(5)/8 + 5/S(8)))
 
     Heoo = harmonic(ne + po/qo)
     Aeoo = (-log(26) + 2*log(sin(3*pi/13))*cos(54*pi/13) + 2*log(sin(4*pi/13))*cos(6*pi/13)
@@ -170,7 +169,7 @@ def test_harmonic_rational():
              + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
              + 2*(-sqrt(5)/4 + 1/S(4))*log(1/S(4) + sqrt(5)/4)
-             + 486853480/S(186374097) - pi*sqrt(sqrt(5)/8 + 5/S(8))/(2*(-sqrt(5)/4 + 1/S(4))))
+             + 486853480/S(186374097) + pi*(sqrt(5)/8 + 5/S(8))/sqrt(-sqrt(5)/8 + 5/S(8)))
 
     Hooo = harmonic(no + po/qo)
     Aooo = (-log(26) + 2*log(sin(3*pi/13))*cos(54*pi/13) + 2*log(sin(4*pi/13))*cos(6*pi/13)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -82,6 +82,13 @@ def test_sin():
 
     assert sin(pi/8) == sqrt((2 - sqrt(2))/4)
 
+    assert sin(pi/10) == -1/4 + sqrt(5)/4
+
+    assert sin(pi/12) == -sqrt(2)/4 + sqrt(6)/4
+    assert sin(5*pi/12) == sqrt(2)/4 + sqrt(6)/4
+    assert sin(-7*pi/12) == -sqrt(2)/4 - sqrt(6)/4
+    assert sin(-11*pi/12) == sqrt(2)/4 - sqrt(6)/4
+
     assert sin(104*pi/105) == sin(pi/105)
     assert sin(106*pi/105) == -sin(pi/105)
 
@@ -117,7 +124,7 @@ def test_sin():
 
 
 def test_sin_cos():
-    for d in [1, 2, 3, 4, 5, 6, 10, 12]:  # list is not exhaustive...
+    for d in [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 24, 30, 40, 60, 120]:  # list is not exhaustive...
         for n in xrange(-2*d, d*2):
             x = n*pi/d
             assert sin(x + pi/2) == cos(x), "fails for %d*pi/%d" % (n, d)
@@ -268,6 +275,11 @@ def test_cos():
 
     assert cos(pi/8) == sqrt((2 + sqrt(2))/4)
 
+    assert cos(pi/12) == sqrt(2)/4 + sqrt(6)/4
+    assert cos(5*pi/12) == -sqrt(2)/4 + sqrt(6)/4
+    assert cos(7*pi/12) == sqrt(2)/4 - sqrt(6)/4
+    assert cos(11*pi/12) == -sqrt(2)/4 - sqrt(6)/4
+
     assert cos(104*pi/105) == -cos(pi/105)
     assert cos(106*pi/105) == -cos(pi/105)
 
@@ -385,6 +397,27 @@ def test_tan():
     assert tan(7*pi/6) == 1/sqrt(3)
     assert tan(-5*pi/6) == 1/sqrt(3)
 
+    assert tan(pi/8).expand() == -1 + sqrt(2)
+    assert tan(3*pi/8).expand() == 1 + sqrt(2)
+    assert tan(5*pi/8).expand() == -1 - sqrt(2)
+    assert tan(7*pi/8).expand() == 1 - sqrt(2)
+
+    assert tan(pi/12) == -sqrt(3) + 2
+    assert tan(5*pi/12) == sqrt(3) + 2
+    assert tan(7*pi/12) == -sqrt(3) - 2
+    assert tan(11*pi/12) == sqrt(3) - 2
+
+    assert tan(pi/24).radsimp() == -2 - sqrt(3) + sqrt(2) + sqrt(6)
+    assert tan(5*pi/24).radsimp() == -2 + sqrt(3) - sqrt(2) + sqrt(6)
+    assert tan(7*pi/24).radsimp() == 2 - sqrt(3) - sqrt(2) + sqrt(6)
+    assert tan(11*pi/24).radsimp() == 2 + sqrt(3) + sqrt(2) + sqrt(6)
+    assert tan(13*pi/24).radsimp() == -2 - sqrt(3) - sqrt(2) - sqrt(6)
+    assert tan(17*pi/24).radsimp() == -2 + sqrt(3) + sqrt(2) - sqrt(6)
+    assert tan(19*pi/24).radsimp() == 2 - sqrt(3) + sqrt(2) - sqrt(6)
+    assert tan(23*pi/24).radsimp() == 2 + sqrt(3) - sqrt(2) - sqrt(6)
+
+    assert 1 == (tan(8*pi/15)*cos(8*pi/15)/sin(8*pi/15)).ratsimp()
+
     assert tan(x*I) == tanh(x)*I
 
     assert tan(k*pi) == 0
@@ -401,6 +434,9 @@ def test_tan():
     assert tan(10*pi/7) == tan(3*pi/7)
     assert tan(11*pi/7) == -tan(3*pi/7)
     assert tan(-11*pi/7) == tan(3*pi/7)
+
+    assert tan(15*pi/14) == tan(pi/14)
+    assert tan(-15*pi/14) == -tan(pi/14)
 
 
 def test_tan_series():
@@ -431,7 +467,8 @@ def test_tan_rewrite():
     assert tan(cot(x)).rewrite(
         exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, cot(3)).n()
     assert tan(log(x)).rewrite(Pow) == I*(x**-I - x**I)/(x**-I + x**I)
-    assert 0 == (cos(pi/15)*tan(pi/15) - sin(pi/15)).rewrite(pow)
+    assert 0 == (cos(pi/34)*tan(pi/34) - sin(pi/34)).rewrite(pow)
+    assert 0 == (cos(pi/17)*tan(pi/17) - sin(pi/17)).rewrite(pow)
     assert tan(pi/19).rewrite(pow) == tan(pi/19)
     assert tan(8*pi/19).rewrite(sqrt) == tan(8*pi/19)
 
@@ -495,6 +532,27 @@ def test_cot():
     assert cot(7*pi/6) == sqrt(3)
     assert cot(-5*pi/6) == sqrt(3)
 
+    assert cot(pi/8).expand() == 1 + sqrt(2)
+    assert cot(3*pi/8).expand() == -1 + sqrt(2)
+    assert cot(5*pi/8).expand() == 1 - sqrt(2)
+    assert cot(7*pi/8).expand() == -1 - sqrt(2)
+
+    assert cot(pi/12) == sqrt(3) + 2
+    assert cot(5*pi/12) == -sqrt(3) + 2
+    assert cot(7*pi/12) == sqrt(3) - 2
+    assert cot(11*pi/12) == -sqrt(3) - 2
+
+    assert cot(pi/24).radsimp() == sqrt(2) + sqrt(3) + 2 + sqrt(6)
+    assert cot(5*pi/24).radsimp() == -sqrt(2) - sqrt(3) + 2 + sqrt(6)
+    assert cot(7*pi/24).radsimp() == -sqrt(2) + sqrt(3) - 2 + sqrt(6)
+    assert cot(11*pi/24).radsimp() == sqrt(2) - sqrt(3) - 2 + sqrt(6)
+    assert cot(13*pi/24).radsimp() == -sqrt(2) + sqrt(3) + 2 - sqrt(6)
+    assert cot(17*pi/24).radsimp() == sqrt(2) - sqrt(3) + 2 - sqrt(6)
+    assert cot(19*pi/24).radsimp() == sqrt(2) + sqrt(3) - 2 - sqrt(6)
+    assert cot(23*pi/24).radsimp() == -sqrt(2) - sqrt(3) - 2 - sqrt(6)
+
+    assert 1 == (cot(4*pi/15)*sin(4*pi/15)/cos(4*pi/15)).ratsimp()
+
     assert cot(x*I) == -coth(x)*I
     assert cot(k*pi*I) == -coth(k*pi)*I
 
@@ -506,6 +564,9 @@ def test_cot():
     assert cot(10*pi/7) == cot(3*pi/7)
     assert cot(11*pi/7) == -cot(3*pi/7)
     assert cot(-11*pi/7) == cot(3*pi/7)
+
+    assert cot(39*pi/34) == cot(5*pi/34)
+    assert cot(-41*pi/34) == -cot(7*pi/34)
 
     assert cot(x).is_finite is None
     assert cot(r).is_finite is None
@@ -542,7 +603,8 @@ def test_cot_rewrite():
     assert cot(tan(x)).rewrite(
         exp).subs(x, 3).n() == cot(x).rewrite(exp).subs(x, tan(3)).n()
     assert cot(log(x)).rewrite(Pow) == -I*(x**-I + x**I)/(x**-I - x**I)
-    assert cot(4*pi/15).rewrite(pow) == (cos(4*pi/15)/sin(4*pi/15)).rewrite(pow)
+    assert cot(4*pi/34).rewrite(pow).ratsimp() == (cos(4*pi/34)/sin(4*pi/34)).rewrite(pow).ratsimp()
+    assert cot(4*pi/17).rewrite(pow) == (cos(4*pi/17)/sin(4*pi/17)).rewrite(pow)
     assert cot(pi/19).rewrite(pow) == cot(pi/19)
     assert cot(pi/19).rewrite(sqrt) == cot(pi/19)
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -189,6 +189,9 @@ class sin(TrigonometricFunction):
     1
     >>> sin(pi/6)
     1/2
+    >>> sin(pi/12)
+    -sqrt(2)/4 + sqrt(6)/4
+
 
     See Also
     ========
@@ -417,6 +420,8 @@ class cos(TrigonometricFunction):
     0
     >>> cos(2*pi/3)
     -1/2
+    >>> cos(pi/12)
+    sqrt(2)/4 + sqrt(6)/4
 
     See Also
     ========
@@ -483,8 +488,8 @@ class cos(TrigonometricFunction):
             # cosine formula #####################
             # https://github.com/sympy/sympy/issues/6048
             # explicit calculations are preformed for
-            # cos(k pi / 8), cos(k pi /10), and cos(k pi / 12)
-            # Some other exact values like cos(k pi/15) can be
+            # cos(k pi/n) for n = 8,10,12,15,20,24,30,40,60,120
+            # Some other exact values like cos(k pi/240) can be
             # calculated using a partial-fraction decomposition
             # by calling cos( X ).rewrite(sqrt)
             cst_table_some = {
@@ -502,8 +507,26 @@ class cos(TrigonometricFunction):
                     return -cls(narg)
 
                 # If nested sqrt's are worse than un-evaluation
-                # you can require q in (1, 2, 3, 4, 6)
-                # q <= 12 returns expressions with 2 or fewer nestings.
+                # you can require q to be in (1, 2, 3, 4, 6, 12)
+                # q <= 12, q=15, q=20, q=24, q=30, q=40, q=60, q=120 return
+                # expressions with 2 or fewer sqrt nestings.
+                table2 = {
+                    12: (3, 4),
+                    20: (4, 5),
+                    30: (5, 6),
+                    15: (6, 10),
+                    24: (6, 8),
+                    40: (8, 10),
+                    60: (20, 30),
+                    120: (40, 60)
+                    }
+                if q in table2:
+                    a, b = p*S.Pi/table2[q][0], p*S.Pi/table2[q][1]
+                    nvala, nvalb = cls(a), cls(b)
+                    if None == nvala or None == nvalb:
+                        return None
+                    return nvala*nvalb + cls(S.Pi/2 - a)*cls(S.Pi/2 - b)
+
                 if q > 12:
                     return None
 
@@ -754,12 +777,14 @@ class tan(TrigonometricFunction):
     Examples
     ========
 
-    >>> from sympy import tan
+    >>> from sympy import tan, pi
     >>> from sympy.abc import x
     >>> tan(x**2).diff(x)
     2*x*(tan(x**2)**2 + 1)
     >>> tan(1).diff(x)
     0
+    >>> tan(pi/8).expand()
+    -1 + sqrt(2)
 
     See Also
     ========
@@ -814,6 +839,31 @@ class tan(TrigonometricFunction):
                 return None
 
             if pi_coeff.is_Rational:
+                if not pi_coeff.q % 2:
+                    narg = pi_coeff*S.Pi*2
+                    cresult, sresult = cos(narg), cos(narg - S.Pi/2)
+                    if not isinstance(cresult, cos) \
+                            and not isinstance(sresult, cos):
+                        if sresult == 0:
+                            return S.ComplexInfinity
+                        return (1 - cresult)/sresult
+                table2 = {
+                    12: (3, 4),
+                    20: (4, 5),
+                    30: (5, 6),
+                    15: (6, 10),
+                    24: (6, 8),
+                    40: (8, 10),
+                    60: (20, 30),
+                    120: (40, 60)
+                    }
+                q = pi_coeff.q
+                p = pi_coeff.p % q
+                if q in table2:
+                    nvala, nvalb = cls(p*S.Pi/table2[q][0]), cls(p*S.Pi/table2[q][1])
+                    if None == nvala or None == nvalb:
+                        return None
+                    return (nvala - nvalb)/(1 + nvala*nvalb)
                 narg = ((pi_coeff + S.Half) % 1 - S.Half)*S.Pi
                 # see cos() to specify which expressions should  be
                 # expanded automatically in terms of radicals
@@ -987,12 +1037,14 @@ class cot(TrigonometricFunction):
     Examples
     ========
 
-    >>> from sympy import cot
+    >>> from sympy import cot, pi
     >>> from sympy.abc import x
     >>> cot(x**2).diff(x)
     2*x*(-cot(x**2)**2 - 1)
     >>> cot(1).diff(x)
     0
+    >>> cot(pi/12)
+    sqrt(3) + 2
 
     See Also
     ========
@@ -1047,6 +1099,29 @@ class cot(TrigonometricFunction):
                 return None
 
             if pi_coeff.is_Rational:
+                if pi_coeff.q > 2 and not pi_coeff.q % 2:
+                    narg = pi_coeff*S.Pi*2
+                    cresult, sresult = cos(narg), cos(narg - S.Pi/2)
+                    if not isinstance(cresult, cos) \
+                            and not isinstance(sresult, cos):
+                        return (1 + cresult)/sresult
+                table2 = {
+                    12: (3, 4),
+                    20: (4, 5),
+                    30: (5, 6),
+                    15: (6, 10),
+                    24: (6, 8),
+                    40: (8, 10),
+                    60: (20, 30),
+                    120: (40, 60)
+                    }
+                q = pi_coeff.q
+                p = pi_coeff.p % q
+                if q in table2:
+                    nvala, nvalb = cls(p*S.Pi/table2[q][0]), cls(p*S.Pi/table2[q][1])
+                    if None == nvala or None == nvalb:
+                        return None
+                    return (1 + nvala*nvalb)/(nvalb - nvala)
                 narg = (((pi_coeff + S.Half) % 1) - S.Half)*S.Pi
                 # see cos() to specify which expressions should be
                 # expanded automatically in terms of radicals

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -337,7 +337,9 @@ def test_line_geom():
     assert Ray((1, 1), angle=4.0*pi) == Ray((1, 1), (2, 1))
     assert Ray((1, 1), angle=0) == Ray((1, 1), (2, 1))
     assert Ray((1, 1), angle=4.05*pi) == Ray(Point(1, 1),
-               Point(2, 1 + C.tan(4.05*pi)))
+               Point(2, -sqrt(5)*sqrt(2*sqrt(5) + 10)/4 - sqrt(2*sqrt(5) + 10)/4 + 2 + sqrt(5)))
+    assert Ray((1, 1), angle=4.02*pi) == Ray(Point(1, 1),
+               Point(2, 1 + C.tan(4.02*pi)))
     assert Ray((1, 1), angle=5) == Ray((1, 1), (2, 1 + C.tan(5)))
     raises(ValueError, lambda: Ray((1, 1), 1))
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4297,8 +4297,8 @@ atan2⎜───────, ╲╱ x ⎟\n\
 def test_pretty_geometry():
     e = Segment((0, 1), (0, 2))
     assert pretty(e) == 'Segment(Point(0, 1), Point(0, 2))'
-    e = Ray((1, 1), angle=4.05*pi)
-    assert pretty(e) == 'Ray(Point(1, 1), Point(2, tan(pi/20) + 1))'
+    e = Ray((1, 1), angle=4.02*pi)
+    assert pretty(e) == 'Ray(Point(1, 1), Point(2, tan(pi/50) + 1))'
 
 
 def test_expint():


### PR DESCRIPTION
...ome values of n

For n=12, 15, 40, and some other values, generate expressions with
smaller number of nested sqrt.   For example currently cos(pi/12),
tan(pi/8), and cot(pi/12) return 
sqrt(sqrt(3)/4 + 1/2), 
sqrt(-sqrt(2)/4 + 1/2)/sqrt(sqrt(2)/4 + 1/2) and 
sqrt(sqrt(3)/4 + 1/2)/sqrt(-sqrt(3)/4 + 1/2) resp.  
The current patch returns 
sqrt(2)/4 + sqrt(6)/4,
sqrt(2)*(-sqrt(2)/2 + 1) and 
sqrt(3) + 2 resp.
