### PR TITLE
Return TWave on multiplication with scalar

### DIFF
--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -37,3 +37,8 @@ def test_twave():
     assert w3.rewrite('exp') == sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2)
     + A2**2)*exp(I*(pi*f*n*x*s/(149896229*m) - 2*pi*f*t
     + atan2(A1*cos(phi1) + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2))))
+    w4 = 2*w1
+    assert w4.amplitude == 2*A1
+    assert w4.frequency == f
+    assert w4.phase == phi1
+    

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -246,6 +246,9 @@ class TWave(Expr):
 
     __repr__ = __str__
 
+    def __mul__(self, float):
+        return TWave(self._amplitude*float, self._frequency, self._phase)
+
     def __add__(self, other):
         """
         Addition of two waves will result in their superposition.

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -24,7 +24,7 @@ class TWave(Expr):
     they can be changed later with respective methods provided.
 
     It has been represented as :math:`A \times cos(k*x - \omega \times t + \phi )`
-    where :math:`A` is amplitude, :math:`\omega` is angular velocity, :math:`k`is
+    where :math:`A` is amplitude, :math:`\omega` is angular frequency, :math:`k`is
     wavenumber, :math:`x` is a spatial variable to represent the position on the
     dimension on which the wave propagates and :math:`\phi` is phase angle of the wave.
 
@@ -71,6 +71,12 @@ class TWave(Expr):
     299792458*m/(n*s)
     >>> w3.angular_velocity
     2*pi*f
+    >>>w4 = 2*w1
+    >>>w4.amplitude
+    2*A1
+    >>>w4.phase
+    phi1
+    
 
     """
 


### PR DESCRIPTION
On trying to multiply `TWave` object from `sympy.physics.optics` module with a scalar, `sympy.core.mul.Mul` was returned. 
PR to return `TWave` with amplitude scaled.  
