### PR TITLE
Make _rewrite_gamma() raise IntegralTransformError (fixes #8882)

### DIFF
--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -727,3 +727,23 @@ def test_hankel_transform():
 
 def test_issue_7181():
     assert mellin_transform(1/(1 - x), x, s) != None
+
+def test_issue_8882():
+    from sympy import atan
+    from sympy.utilities.pytest import raises
+    from sympy.integrals.transforms import IntegralTransformError
+    a0 = Symbol('a0')
+
+    # This is the original test.
+    # from sympy import diff, Integral, integrate
+    # r = Symbol('r')
+    # psi = 1/r*sin(r)*exp(-(a0*r))
+    # h = -1/2*diff(psi, r, r) - 1/r*psi
+    # f = 4*pi*psi*h*r**2
+    # assert integrate(f, (r, -oo, 3), meijerg=True).has(Integral) == True
+
+    # To save time, only the critical part is included.
+    F = -a0**(-s + 1)*(4 + a0**(-2))**(-s/2)*sqrt(a0**(-2))*exp(-s*I*pi)*sin(s*atan(sqrt(a0**(-2))/2))*gamma(s)
+    hints = {'as_meijerg': True, 'needeval': True}
+    code = lambda: inverse_mellin_transform(F, s, x, (-1, oo), **hints)
+    raises(IntegralTransformError, code)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -6,14 +6,14 @@ from sympy.integrals.transforms import (mellin_transform,
     hankel_transform, inverse_hankel_transform,
     LaplaceTransform, FourierTransform, SineTransform, CosineTransform,
     InverseLaplaceTransform, InverseFourierTransform,
-    InverseSineTransform, InverseCosineTransform)
+    InverseSineTransform, InverseCosineTransform, IntegralTransformError)
 from sympy import (
     gamma, exp, oo, Heaviside, symbols, Symbol, re, factorial, pi,
     cos, S, And, sin, sqrt, I, log, tan, hyperexpand, meijerg,
     EulerGamma, erf, besselj, bessely, besseli, besselk,
     exp_polar, polar_lift, unpolarify, Function, expint, expand_mul,
-    combsimp, trigsimp)
-from sympy.utilities.pytest import XFAIL, slow, skip
+    combsimp, trigsimp, atan)
+from sympy.utilities.pytest import XFAIL, slow, skip, raises
 from sympy.matrices import Matrix, eye
 from sympy.abc import x, s, a, b, c, d
 nu, beta, rho = symbols('nu beta rho')
@@ -728,12 +728,8 @@ def test_hankel_transform():
 def test_issue_7181():
     assert mellin_transform(1/(1 - x), x, s) != None
 
-def test_issue_8882():
-    from sympy import atan
-    from sympy.utilities.pytest import raises
-    from sympy.integrals.transforms import IntegralTransformError
-    a0 = Symbol('a0')
 
+def test_issue_8882():
     # This is the original test.
     # from sympy import diff, Integral, integrate
     # r = Symbol('r')
@@ -743,7 +739,8 @@ def test_issue_8882():
     # assert integrate(f, (r, -oo, 3), meijerg=True).has(Integral) == True
 
     # To save time, only the critical part is included.
-    F = -a0**(-s + 1)*(4 + a0**(-2))**(-s/2)*sqrt(a0**(-2))*exp(-s*I*pi)*sin(s*atan(sqrt(a0**(-2))/2))*gamma(s)
-    hints = {'as_meijerg': True, 'needeval': True}
-    code = lambda: inverse_mellin_transform(F, s, x, (-1, oo), **hints)
-    raises(IntegralTransformError, code)
+    F = -a**(-s + 1)*(4 + 1/a**2)**(-s/2)*sqrt(1/a**2)*exp(-s*I*pi)* \
+        sin(s*atan(sqrt(1/a**2)/2))*gamma(s)
+    raises(IntegralTransformError, lambda:
+        inverse_mellin_transform(F, s, x, (-1, oo),
+        **{'as_meijerg': True, 'needeval': True}))

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -506,15 +506,16 @@ def _rewrite_gamma(f, s, a, b):
             arg = arg.as_independent(s)[1]
         coeff, _ = arg.as_coeff_mul(s)
         s_multipliers += [coeff/pi]
-    s_multipliers = [abs(x) for x in s_multipliers if x.is_real]
+    s_multipliers = [abs(x) if x.is_real else x for x in s_multipliers]
     common_coefficient = S(1)
     for x in s_multipliers:
         if not x.is_Rational:
             common_coefficient = x
             break
     s_multipliers = [x/common_coefficient for x in s_multipliers]
-    if any(not x.is_Rational for x in s_multipliers):
-        raise NotImplementedError
+    if (any(not x.is_Rational for x in s_multipliers) or
+        not common_coefficient.is_real):
+        raise IntegralTransformError("Gamma", None, "Nonrational multiplier")
     s_multiplier = common_coefficient/reduce(ilcm, [S(x.q)
                                              for x in s_multipliers], S(1))
     if s_multiplier == common_coefficient:


### PR DESCRIPTION
inverse_mellin_transform() applies _rewrite_gamma() to check whether
the transform can be expressed in terms of Meijer G-functions.
A failure is indicated by raising IntegralTransformError.

For the rewrite it is necessary that the arguments of trigonometric
and gamma functions are of the form `a*pi*s + b` or `a*s + b`,
respectively, where all the multipliers `a` are rational multiples of
a single real number (which can be absorbed into `s`).

The code is modified in phase 1) to test this for all multipliers
instead of only manifestly real ones.
