### PR TITLE
TWave fix

### DIFF
--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -27,13 +27,19 @@ def test_twave():
     assert w3.time_period == 1/f
     assert w3.angular_velocity == 2*pi*f
     assert w3.wavenumber == 2*pi*f*n/c
-    assert simplify(w3.rewrite('sin') - sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2)
-    + A2**2)*sin(pi*f*n*x*s/(149896229*m) - 2*pi*f*t + atan2(A1*cos(phi1)
-    + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2)) + pi/2)) == 0
+    assert simplify(w3.rewrite('sin') - w2.rewrite('sin') - w1.rewrite('sin')) == 0
     assert w3.rewrite('pde') == epsilon*mu*Derivative(E(x, t), t, t) + Derivative(E(x, t), x, x)
     assert w3.rewrite(cos) == sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2)
-    + A2**2)*cos(pi*f*n*x*s/(149896229*m) - 2*pi*f*t + atan2(A1*cos(phi1)
-    + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2)))
+    + A2**2)*cos(pi*f*n*x*s/(149896229*m) - 2*pi*f*t + atan2(A1*sin(phi1)
+    + A2*sin(phi2), A1*cos(phi1) + A2*cos(phi2)))
     assert w3.rewrite('exp') == sqrt(A1**2 + 2*A1*A2*cos(phi1 - phi2)
     + A2**2)*exp(I*(pi*f*n*x*s/(149896229*m) - 2*pi*f*t
-    + atan2(A1*cos(phi1) + A2*cos(phi2), A1*sin(phi1) + A2*sin(phi2))))
+    + atan2(A1*sin(phi1) + A2*sin(phi2), A1*cos(phi1) + A2*cos(phi2))))
+    w4 = 2*w1
+    assert w4.amplitude == 2*A1
+    assert w4.frequency == f
+    assert w4.phase == phi1
+    w5 = -w4
+    assert w5.amplitude == -2*A1
+    assert w5.frequency == f
+    assert w5.phase == phi1


### PR DESCRIPTION
Fixes #8887.

Implements negation, subtraction, and scalar multiplication of TWaves. It looks like @darshanime has already done some work, and I incorporated some fixes and testing he made. 

I also noticed a bug in TWave addition: the sin's and cos's were switched around in the arguments to atan2. You can check this by adding a zero amplitude wave to some wave and using the identity 
`atan2(sin(x), cos(x)) = x (mod 2*pi)`
