### PR TITLE
Asymmetry in roots result of quadratic expressions

### DIFF
--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2871,8 +2871,7 @@ def test_Y2():
     w = symbols('w', real=True)
     s = symbols('s')
     f = inverse_laplace_transform(s/(s**2 + (w - 1)**2), s, t)
-    assert f == cos(t*abs(w - 1))
-
+    assert f == cos(t*w - t)
 
 @slow
 @XFAIL

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2873,6 +2873,7 @@ def test_Y2():
     f = inverse_laplace_transform(s/(s**2 + (w - 1)**2), s, t)
     assert f == cos(t*w - t)
 
+
 @slow
 @XFAIL
 def test_Y3():

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -7,7 +7,8 @@ import math
 from sympy.core.symbol import Dummy, Symbol, symbols
 from sympy.core import S, I, pi
 from sympy.core.compatibility import ordered
-from sympy.core.mul import expand_2arg
+from sympy.core.mul import expand_2arg, Mul
+from sympy.core.power import Pow
 from sympy.core.relational import Eq
 from sympy.core.sympify import sympify
 from sympy.core.numbers import Rational, igcd
@@ -53,6 +54,20 @@ def roots_quadratic(f):
     a, b, c = f.all_coeffs()
     dom = f.get_domain()
 
+    def _sqrt(d):
+        co = []
+        other = []
+        for di in Mul.make_args(d):
+            if di.is_Pow and di.exp.is_Integer and di.exp % 2 ==0:
+                co.append(Pow(di.base,di.exp/2))
+            else:
+                other.append(di)
+        if co:
+            d = Mul(*other)
+            co = Mul(*co)
+            return co*sqrt(d)
+        return sqrt(d)
+
     def _simplify(expr):
         if dom.is_Composite:
             return factor(expr)
@@ -71,7 +86,7 @@ def roots_quadratic(f):
         if not dom.is_Numerical:
             r = _simplify(r)
 
-        R = sqrt(r)
+        R = _sqrt(r)
         r0 = -R
         r1 = R
     else:
@@ -83,7 +98,7 @@ def roots_quadratic(f):
             d = _simplify(d)
             B = _simplify(B)
 
-        D = sqrt(d)/A
+        D = _sqrt(d)/A
         r0 = B - D
         r1 = B + D
         if a.is_negative:

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -56,6 +56,9 @@ def roots_quadratic(f):
     dom = f.get_domain()
 
     def _sqrt(d):
+        # remove squares from square root since both will be represented
+        # in the results; a similar thing is happening in roots() but
+        # must be duplicated here because not all quadratics are binomials
         co = []
         other = []
         for di in Mul.make_args(d):
@@ -872,13 +875,13 @@ def roots(f, *gens, **flags):
         f = Poly(poly, x, field=True)
     else:
         try:
-            expr = f
             f = Poly(f, *gens, **flags)
-            if not isinstance(expr, Poly) and f.length == 2 and f.degree() !=1:
-                # see if there are powers in the constant that match the degree
-                con = expr.as_independent(*gens)[0]
+            if f.length == 2 and f.degree() != 1:
+                # check for foo**n factors in the constant
                 n = f.degree()
                 npow_bases = []
+                expr = f.as_expr()
+                con = expr.as_independent(*gens)[0]
                 for p in Mul.make_args(con):
                     if p.is_Pow and not p.exp % n:
                         npow_bases.append(p.base**(p.exp/n))
@@ -887,7 +890,8 @@ def roots(f, *gens, **flags):
                     if npow_bases:
                         b = Mul(*npow_bases)
                         B = Dummy()
-                        d = roots(Poly(expr - con + B**n*Mul(*others), *gens, **flags), *gens, **flags)
+                        d = roots(Poly(expr - con + B**n*Mul(*others), *gens,
+                            **flags), *gens, **flags)
                         rv = {}
                         for k, v in d.items():
                             rv[k.subs(B, b)] = v

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -12,6 +12,7 @@ from sympy.core.power import Pow
 from sympy.core.relational import Eq
 from sympy.core.sympify import sympify
 from sympy.core.numbers import Rational, igcd
+from sympy.core.exprtools import factor_terms
 
 from sympy.ntheory import divisors, isprime, nextprime
 from sympy.functions import exp, sqrt, im, cos, acos, Piecewise
@@ -98,7 +99,7 @@ def roots_quadratic(f):
             d = _simplify(d)
             B = _simplify(B)
 
-        D = _sqrt(d)/A
+        D = factor_terms(_sqrt(d)/A)
         r0 = B - D
         r1 = B + D
         if a.is_negative:

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -33,10 +33,9 @@ def test_roots_quadratic():
     assert roots_quadratic(Poly(2*x**2 + 4*x + 3, x)) == [-1 - I*sqrt(2)/2, -1 + I*sqrt(2)/2]
 
     f = x**2 + (2*a*e + 2*c*e)/(a - c)*x + (d - b + a*e**2 - c*e**2)/(a - c)
-
     assert roots_quadratic(Poly(f, x)) == \
-        [-e*(a + c)/(a - c) - sqrt((a*b + c*d - a*d - b*c + 4*a*c*e**2)/(a - c)**2),
-         -e*(a + c)/(a - c) + sqrt((a*b + c*d - a*d - b*c + 4*a*c*e**2)/(a - c)**2)]
+        [-e*(a + c)/(a - c) - sqrt((a*b + c*d - a*d - b*c + 4*a*c*e**2))/(a - c),
+         -e*(a + c)/(a - c) + sqrt((a*b + c*d - a*d - b*c + 4*a*c*e**2))/(a - c)]
 
     # check for simplification
     f = Poly(y*x**2 - 2*x - 2*y, x)
@@ -44,7 +43,7 @@ def test_roots_quadratic():
         [-sqrt(2*y**2 + 1)/y + 1/y, sqrt(2*y**2 + 1)/y + 1/y]
     f = Poly(x**2 + (-y**2 - 2)*x + y**2 + 1, x)
     assert roots_quadratic(f) == \
-        [y**2/2 - sqrt(y**4)/2 + 1, y**2/2 + sqrt(y**4)/2 + 1]
+        [1,y**2 + 1]
 
     f = Poly(sqrt(2)*x**2 - 1, x)
     r = roots_quadratic(f)
@@ -58,7 +57,6 @@ def test_roots_quadratic():
         f = Poly(_a*x**2 + _b*x + _c)
         roots = roots_quadratic(f)
         assert roots == _nsort(roots)
-
 
 def test_issue_8438():
     p = Poly([1, y, -2, -3], x).as_expr()

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -241,8 +241,14 @@ def test_roots_binomial():
         if a == b and a != 1:  # a == b == 1 is sufficient
             continue
         p = Poly(a*x**n + s*b)
-        roots = roots_binomial(p)
-        assert roots == _nsort(roots)
+        ans = roots_binomial(p)
+        assert ans == _nsort(ans)
+
+    # issue 8813
+    assert roots(Poly(2*x**3 - 16*y**3, x)) == {
+        2*y*(-S(1)/2 - sqrt(3)*I/2): 1,
+        2*y: 1,
+        2*y*(-S(1)/2 + sqrt(3)*I/2): 1}
 
 
 def test_roots_preprocessing():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1302,8 +1302,7 @@ def test_nth_linear_constant_coeff_homogeneous():
         C4*exp(-x*sqrt(a)))
     sol11 = Eq(f(x),
         C1*exp(x*(k - sqrt(k**2 + 2))) + C2*exp(x*(k + sqrt(k**2 + 2))))
-    sol12 = Eq(f(x),
-        C1*exp(2*x*(-2*abs(k) - k)) + C2*exp(2*x*(2*abs(k) - k)))
+    sol12 = Eq(f(x), C1*exp(-6*k*x) + C2*exp(2*k*x))
     sol13 = Eq(f(x), C1 + C2*x + C3*x**2 + C4*x**3)
     sol14 = Eq(f(x), (C1 + C2*x)*exp(-2*x))
     sol15 = Eq(f(x), (C1 + C2*x)*exp(-x) + C3*exp(x/3))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -676,8 +676,8 @@ def test_issue_5132():
     r, t = symbols('r,t')
     assert set(solve([r - x**2 - y**2, tan(t) - y/x], [x, y])) == \
         set([(
-            -sqrt(r*sin(t)**2)/tan(t), -sqrt(r*sin(t)**2)),
-            (sqrt(r*sin(t)**2)/tan(t), sqrt(r*sin(t)**2))])
+            -sqrt(r*cos(t)**2), -1*sqrt(r*cos(t)**2)*tan(t)),
+            (sqrt(r*cos(t)**2), sqrt(r*cos(t)**2)*tan(t))])
     assert solve([exp(x) - sin(y), 1/y - 3], [x, y]) == \
         [(log(sin(S(1)/3)), S(1)/3)]
     assert solve([exp(x) - sin(y), 1/exp(y) - 3], [x, y]) == \
@@ -1076,8 +1076,8 @@ def test_issue_5901():
     assert solve(-f(a)**2*g(a)**2 + f(a)**2*h(a)**2 + g(a).diff(a),
                 h(a), g(a), set=True) == \
         ([g(a)], set([
-        (-sqrt(h(a)**2 + G/f(a)**2),),
-        (sqrt(h(a)**2 + G/f(a)**2),)]))
+        (-sqrt(h(a)**2*f(a)**2 + G)/f(a),),
+        (sqrt(h(a)**2*f(a)**2+ G)/f(a),)]))
     args = [f(x).diff(x, 2)*(f(x) + g(x)) - g(x)**2 + 2, f(x), g(x)]
     assert set(solve(*args)) == \
         set([(-sqrt(2), sqrt(2)), (sqrt(2), -sqrt(2))])


### PR DESCRIPTION
Asymmetry in roots result of quadratic expressions were removed.
like roots(z^2-y^2,y) were +/-z but roots((z+1)^2-y^2,y) were  +/-(z^2-2z+1)^(0.5)

fixes #8813
