### PR TITLE
fixes #7258

### DIFF
--- a/examples/advanced/pyglet_plotting.py
+++ b/examples/advanced/pyglet_plotting.py
@@ -10,6 +10,7 @@ Suggested Usage:    python -i plotting.py
 from sympy import symbols
 from sympy.plotting.pygletplot import PygletPlot
 from sympy import sin, cos, pi, sqrt, exp
+from sympy.core.compatibility import range
 
 from time import sleep, clock
 
@@ -197,7 +198,7 @@ def main():
         s = ("\nPlot p has been created. Useful commands: \n"
              "    help(p), p[1] = x**2, print p, p.clear() \n\n"
              "Available examples (see source in plotting.py):\n\n")
-        for i in xrange(len(examples)):
+        for i in range(len(examples)):
             s += "(%i) %s\n" % (i, examples[i].__name__)
         s += "\n"
         s += "e.g. >>> example(2)\n"

--- a/examples/intermediate/vandermonde.py
+++ b/examples/intermediate/vandermonde.py
@@ -7,7 +7,7 @@ Demonstrates matrix computations using the Vandermonde matrix.
 """
 
 from sympy import Matrix, pprint, Rational, sqrt, symbols, Symbol, zeros
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def symbol_gen(sym_str):
@@ -100,7 +100,7 @@ def gen_poly(points, order, syms):
     V_pts = V.subs(subs_dict)
     V_inv = V_pts.inv()
 
-    coeffs = V_inv.multiply(Matrix([points[i][-1] for i in xrange(num_pts)]))
+    coeffs = V_inv.multiply(Matrix([points[i][-1] for i in range(num_pts)]))
 
     f = 0
     for j, term in enumerate(terms):

--- a/sympy/benchmarks/bench_symbench.py
+++ b/sympy/benchmarks/bench_symbench.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function, division
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 from random import random
 from sympy import factor, I, Integer, pi, simplify, sin, sqrt, Symbol, sympify
@@ -53,14 +53,14 @@ def bench_R5():
 
 
 def bench_R6():
-    "sum(simplify((x+sin(i))/x+(x-sin(i))/x) for i in xrange(100))"
-    s = sum(simplify((x + sin(i))/x + (x - sin(i))/x) for i in xrange(100))
+    "sum(simplify((x+sin(i))/x+(x-sin(i))/x) for i in range(100))"
+    s = sum(simplify((x + sin(i))/x + (x - sin(i))/x) for i in range(100))
 
 
 def bench_R7():
-    "[f.subs(x, random()) for _ in xrange(10**4)]"
+    "[f.subs(x, random()) for _ in range(10**4)]"
     f = x**24 + 34*x**12 + 45*x**3 + 9*x**18 + 34*x**10 + 32*x**21
-    a = [f.subs(x, random()) for _ in xrange(10**4)]
+    a = [f.subs(x, random()) for _ in range(10**4)]
 
 
 def bench_R8():

--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -1,6 +1,6 @@
 from sympy import Function, sympify, diff, Eq, S, Symbol, Derivative
 from sympy.core.compatibility import (
-    combinations_with_replacement, iterable)
+    combinations_with_replacement, iterable, range)
 
 
 def euler_equations(L, funcs=(), vars=()):

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -18,7 +18,7 @@ for:
 """
 
 from sympy import S
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, range
 
 
 def finite_diff_weights(order, x_list, x0):

--- a/sympy/calculus/tests/test_finite_diff.py
+++ b/sympy/calculus/tests/test_finite_diff.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy import S, symbols, Function
 from sympy.calculus.finite_diff import (
     apply_finite_diff, finite_diff_weights, as_finite_diff

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import S, Basic, Dict, Symbol, Tuple
-from sympy.core.compatibility import xrange, iterable
+from sympy.core.compatibility import range, iterable
 from sympy.sets import Set, FiniteSet, EmptySet
 
 
@@ -274,7 +274,7 @@ class CompositeMorphism(Morphism):
         normalised_components = Tuple()
 
         # TODO: Fix the unpythonicity.
-        for i in xrange(len(components) - 1):
+        for i in range(len(components) - 1):
             current = components[i]
             following = components[i + 1]
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -90,7 +90,7 @@ from sympy.categories import (CompositeMorphism, IdentityMorphism,
                               NamedMorphism, Diagram)
 from sympy.utilities import default_sort_key
 from itertools import chain
-from sympy.core.compatibility import iterable, xrange
+from sympy.core.compatibility import iterable, range
 from sympy.printing import latex
 from sympy.utilities.decorator import doctest_depends_on
 
@@ -111,7 +111,7 @@ class _GrowableGrid(object):
         self._width = width
         self._height = height
 
-        self._array = [[None for j in xrange(width)] for i in xrange(height)]
+        self._array = [[None for j in range(width)] for i in range(height)]
 
     @property
     def width(self):
@@ -142,14 +142,14 @@ class _GrowableGrid(object):
         Appends an empty row to the grid.
         """
         self._height += 1
-        self._array.append([None for j in xrange(self._width)])
+        self._array.append([None for j in range(self._width)])
 
     def append_column(self):
         """
         Appends an empty column to the grid.
         """
         self._width += 1
-        for i in xrange(self._height):
+        for i in range(self._height):
             self._array[i].append(None)
 
     def prepend_row(self):
@@ -157,14 +157,14 @@ class _GrowableGrid(object):
         Prepends the grid with an empty row.
         """
         self._height += 1
-        self._array.insert(0, [None for j in xrange(self._width)])
+        self._array.insert(0, [None for j in range(self._width)])
 
     def prepend_column(self):
         """
         Prepends the grid with an empty column.
         """
         self._width += 1
-        for i in xrange(self._height):
+        for i in range(self._height):
             self._array[i].insert(0, None)
 
 
@@ -504,7 +504,7 @@ class DiagramGrid(object):
             grid.prepend_row()
             i = 0
             offset = (1, 0)
-            for k in xrange(len(fringe)):
+            for k in range(len(fringe)):
                 ((i1, j1), (i2, j2)) = fringe[k]
                 fringe[k] = ((i1 + 1, j1), (i2 + 1, j2))
         elif i == grid.height:
@@ -514,7 +514,7 @@ class DiagramGrid(object):
             j = 0
             offset = (offset[0], 1)
             grid.prepend_column()
-            for k in xrange(len(fringe)):
+            for k in range(len(fringe)):
                 ((i1, j1), (i2, j2)) = fringe[k]
                 fringe[k] = ((i1, j1 + 1), (i2, j2 + 1))
         elif j == grid.width:
@@ -711,8 +711,8 @@ class DiagramGrid(object):
         This method should be applied when ``_weld_triangle`` cannot
         find weldings any more.
         """
-        for i in xrange(grid.height):
-            for j in xrange(grid.width):
+        for i in range(grid.height):
+            for j in range(grid.width):
                 obj = grid[i, j]
                 if not obj:
                     continue
@@ -885,27 +885,27 @@ class DiagramGrid(object):
                 return (1, 1)
 
         row_heights = [max(group_size(top_grid[i, j])[0]
-                           for j in xrange(top_grid.width))
-                       for i in xrange(top_grid.height)]
+                           for j in range(top_grid.width))
+                       for i in range(top_grid.height)]
 
         column_widths = [max(group_size(top_grid[i, j])[1]
-                             for i in xrange(top_grid.height))
-                         for j in xrange(top_grid.width)]
+                             for i in range(top_grid.height))
+                         for j in range(top_grid.width)]
 
         grid = _GrowableGrid(sum(column_widths), sum(row_heights))
 
         real_row = 0
         real_column = 0
-        for logical_row in xrange(top_grid.height):
-            for logical_column in xrange(top_grid.width):
+        for logical_row in range(top_grid.height):
+            for logical_column in range(top_grid.width):
                 obj = top_grid[logical_row, logical_column]
 
                 if obj in groups_grids:
                     # This is a group.  Copy the corresponding grid in
                     # place.
                     local_grid = groups_grids[obj]
-                    for i in xrange(local_grid.height):
-                        for j in xrange(local_grid.width):
+                    for i in range(local_grid.height):
+                        for j in range(local_grid.width):
                             grid[real_row + i,
                                 real_column + j] = local_grid[i, j]
                 else:
@@ -997,13 +997,13 @@ class DiagramGrid(object):
                     final_height = max(grid.height, remaining_grid.height)
                     final_grid = _GrowableGrid(final_width, final_height)
 
-                    for i in xrange(grid.width):
-                        for j in xrange(grid.height):
+                    for i in range(grid.width):
+                        for j in range(grid.height):
                             final_grid[i, j] = grid[i, j]
 
                     start_j = grid.width
-                    for i in xrange(remaining_grid.height):
-                        for j in xrange(remaining_grid.width):
+                    for i in range(remaining_grid.height):
+                        for j in range(remaining_grid.width):
                             final_grid[i, start_j + j] = remaining_grid[i, j]
 
                     return final_grid
@@ -1137,7 +1137,7 @@ class DiagramGrid(object):
                 current_index += 1
 
         # List the objects of the components.
-        component_objects = [[] for i in xrange(current_index)]
+        component_objects = [[] for i in range(current_index)]
         for o, idx in component_index.items():
             component_objects[idx].append(o)
 
@@ -1208,8 +1208,8 @@ class DiagramGrid(object):
             grid = _GrowableGrid(total_width, total_height)
             start_j = 0
             for g in grids:
-                for i in xrange(g.height):
-                    for j in xrange(g.width):
+                for i in range(g.height):
+                    for j in range(g.width):
                         grid[i, start_j + j] = g[i, j]
 
                 start_j += g.width
@@ -1225,8 +1225,8 @@ class DiagramGrid(object):
         if hints.get("transpose"):
             # Transpose the resulting grid.
             grid = _GrowableGrid(self._grid.height, self._grid.width)
-            for i in xrange(self._grid.height):
-                for j in xrange(self._grid.width):
+            for i in range(self._grid.height):
+                for j in range(self._grid.width):
                     grid[j, i] = self._grid[i, j]
             self._grid = grid
 
@@ -1819,7 +1819,7 @@ class XypicDiagramDrawer(object):
         up = []
         down = []
         straight_horizontal = []
-        for k in xrange(start + 1, end):
+        for k in range(start + 1, end):
             obj = grid[i, k]
             if not obj:
                 continue
@@ -1926,7 +1926,7 @@ class XypicDiagramDrawer(object):
         left = []
         right = []
         straight_vertical = []
-        for k in xrange(start + 1, end):
+        for k in range(start + 1, end):
             obj = grid[k, j]
             if not obj:
                 continue
@@ -2119,14 +2119,14 @@ class XypicDiagramDrawer(object):
             free_up = True
         else:
             free_up = all([grid[dom_i - 1, j] for j in
-                           xrange(start, end + 1)])
+                           range(start, end + 1)])
 
         # Check for free space below.
         if dom_i == grid.height - 1:
             free_down = True
         else:
             free_down = all([not grid[dom_i + 1, j] for j in
-                             xrange(start, end + 1)])
+                             range(start, end + 1)])
 
         return (free_up, free_down, backwards)
 
@@ -2149,13 +2149,13 @@ class XypicDiagramDrawer(object):
             free_left = True
         else:
             free_left = all([not grid[i, dom_j - 1] for i in
-                             xrange(start, end + 1)])
+                             range(start, end + 1)])
 
         if dom_j == grid.width - 1:
             free_right = True
         else:
             free_right = all([not grid[i, dom_j + 1] for i in
-                              xrange(start, end + 1)])
+                              range(start, end + 1)])
 
         return (free_left, free_right, backwards)
 
@@ -2168,9 +2168,9 @@ class XypicDiagramDrawer(object):
         """
         def abs_xrange(start, end):
             if start < end:
-                return xrange(start, end + 1)
+                return range(start, end + 1)
             else:
-                return xrange(end, start + 1)
+                return range(end, start + 1)
 
         if dom_i < cod_i and dom_j < cod_j:
             # This morphism goes from top-left to
@@ -2360,8 +2360,8 @@ class XypicDiagramDrawer(object):
 
         result = "\\xymatrix%s{\n" % diagram_format
 
-        for i in xrange(grid.height):
-            for j in xrange(grid.width):
+        for i in range(grid.height):
+            for j in range(grid.width):
                 obj = grid[i, j]
                 if obj:
                     result += latex(obj) + " "
@@ -2475,8 +2475,8 @@ class XypicDiagramDrawer(object):
         # Build the mapping between objects and their position in the
         # grid.
         object_coords = {}
-        for i in xrange(grid.height):
-            for j in xrange(grid.width):
+        for i in range(grid.height):
+            for j in range(grid.width):
                 if grid[i, j]:
                     object_coords[grid[i, j]] = (i, j)
 

--- a/sympy/combinatorics/generators.py
+++ b/sympy/combinatorics/generators.py
@@ -4,7 +4,7 @@ from sympy.combinatorics.permutations import Permutation
 from sympy.utilities.iterables import variations, rotate_left
 from sympy.core.symbol import symbols
 from sympy.matrices import Matrix
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def symmetric(n):
@@ -44,7 +44,7 @@ def cyclic(n):
     dihedral
     """
     gen = list(range(n))
-    for i in xrange(n):
+    for i in range(n):
         yield Permutation(gen)
         gen = rotate_left(gen, 1)
 
@@ -100,7 +100,7 @@ def dihedral(n):
         yield Permutation([3, 2, 1, 0])
     else:
         gen = list(range(n))
-        for i in xrange(n):
+        for i in range(n):
             yield Permutation(gen)
             yield Permutation(gen[::-1])
             gen = rotate_left(gen, 1)

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 import random
 
@@ -184,7 +184,7 @@ class GrayCode(Basic):
             'not be greater than %i' % (len(graycode_bin), bits))
         self._current = int(current, 2)
         graycode_int = int(''.join(graycode_bin), 2)
-        for i in xrange(graycode_int, 1 << bits):
+        for i in range(graycode_int, 1 << bits):
             if self._skip:
                 self._skip = False
             else:
@@ -318,7 +318,7 @@ def random_bitstring(n):
     >>> random_bitstring(3) # doctest: +SKIP
     100
     """
-    return ''.join([random.choice('01') for i in xrange(n)])
+    return ''.join([random.choice('01') for i in range(n)])
 
 
 def gray_to_bin(bin_list):
@@ -339,7 +339,7 @@ def gray_to_bin(bin_list):
     bin_to_gray
     """
     b = [bin_list[0]]
-    for i in xrange(1, len(bin_list)):
+    for i in range(1, len(bin_list)):
         b += str(int(b[i - 1] != bin_list[i]))
     return ''.join(b)
 
@@ -362,7 +362,7 @@ def bin_to_gray(bin_list):
     gray_to_bin
     """
     b = [bin_list[0]]
-    for i in xrange(0, len(bin_list) - 1):
+    for i in range(0, len(bin_list) - 1):
         b += str(int(bin_list[i]) ^ int(b[i - 1]))
     return ''.join(b)
 

--- a/sympy/combinatorics/group_constructs.py
+++ b/sympy/combinatorics/group_constructs.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.combinatorics.permutations import Permutation
 from sympy.utilities.iterables import uniq
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 _af_new = Permutation._af_new
 
@@ -49,8 +49,8 @@ def DirectProduct(*groups):
         array_gens.append(list(range(total_degree)))
     current_gen = 0
     current_deg = 0
-    for i in xrange(len(gens_count)):
-        for j in xrange(current_gen, current_gen + gens_count[i]):
+    for i in range(len(gens_count)):
+        for j in range(current_gen, current_gen + gens_count[i]):
             gen = ((groups[i].generators)[j - current_gen]).array_form
             array_gens[j][current_deg:current_deg + degrees[i]] = \
                 [ x + current_deg for x in gen]

--- a/sympy/combinatorics/named_groups.py
+++ b/sympy/combinatorics/named_groups.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.combinatorics.group_constructs import DirectProduct
 from sympy.combinatorics.permutations import Permutation

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic, C, Dict, sympify
-from sympy.core.compatibility import as_int, default_sort_key, xrange
+from sympy.core.compatibility import as_int, default_sort_key, range
 from sympy.functions.combinatorial.numbers import bell
 from sympy.matrices import zeros
 from sympy.utilities.iterables import has_dups, flatten, group
@@ -261,7 +261,7 @@ class Partition(C.FiniteSet):
         if len(rgs) != len(elements):
             raise ValueError('mismatch in rgs and element lengths')
         max_elem = max(rgs) + 1
-        partition = [[] for i in xrange(max_elem)]
+        partition = [[] for i in range(max_elem)]
         j = 0
         for i in rgs:
             partition[i].append(elements[j])
@@ -594,11 +594,11 @@ def RGS_generalized(m):
     [203,   0,   0,  0,  0, 0, 0]])
     """
     d = zeros(m + 1)
-    for i in xrange(0, m + 1):
+    for i in range(0, m + 1):
         d[0, i] = 1
 
-    for i in xrange(1, m + 1):
-        for j in xrange(m):
+    for i in range(1, m + 1):
+        for j in range(m):
             if j <= m - i:
                 d[i, j] = j * d[i - 1, j] + d[i - 1, j + 1]
             else:
@@ -665,7 +665,7 @@ def RGS_unrank(rank, m):
     L = [1] * (m + 1)
     j = 1
     D = RGS_generalized(m)
-    for i in xrange(2, m + 1):
+    for i in range(2, m + 1):
         v = D[m - i, j]
         cr = j*v
         if cr <= rank:
@@ -694,7 +694,7 @@ def RGS_rank(rgs):
     rgs_size = len(rgs)
     rank = 0
     D = RGS_generalized(rgs_size)
-    for i in xrange(1, rgs_size):
+    for i in range(1, rgs_size):
         n = len(rgs[(i + 1):])
         m = max(rgs[0:i])
         rank += D[n, m + 1] * rgs[i]

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4,6 +4,7 @@ from random import randrange, choice
 from math import log
 
 from sympy.core import Basic
+from sympy.core.compatability import range
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert,
     _af_rmul, _af_rmuln, _af_pow, Cycle)

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -4,7 +4,7 @@ from random import randrange, choice
 from math import log
 
 from sympy.core import Basic
-from sympy.core.compatability import range
+from sympy.core.compatibility import range
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert,
     _af_rmul, _af_rmuln, _af_pow, Cycle)

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -4,7 +4,7 @@ import random
 from collections import defaultdict
 
 from sympy.core import Basic
-from sympy.core.compatibility import is_sequence, reduce, xrange
+from sympy.core.compatibility import is_sequence, reduce, range
 from sympy.utilities.iterables import (flatten, has_variety, minlex,
     has_dups, runs)
 from sympy.polys.polytools import lcm
@@ -1880,7 +1880,7 @@ class Permutation(Basic):
         order
         """
         af = self.array_form
-        return not af or all(i == af[i] for i in xrange(self.size))
+        return not af or all(i == af[i] for i in range(self.size))
 
     def ascents(self):
         """

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core import Basic, Tuple
 from sympy.sets import FiniteSet
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, range
 from sympy.combinatorics import Permutation as Perm
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.utilities.iterables import (minlex, unflatten, flatten)

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic
-from sympy.core.compatibility import iterable, as_int, xrange
+from sympy.core.compatibility import iterable, as_int, range
 from sympy.utilities.iterables import flatten
 
 from collections import defaultdict
@@ -167,9 +167,9 @@ class Prufer(Basic):
             # edge involving it.
             d[edge[0]] += 1
             d[edge[1]] += 1
-        for i in xrange(n - 2):
+        for i in range(n - 2):
             # find the smallest leaf
-            for x in xrange(n):
+            for x in range(n):
                 if d[x] == 1:
                     break
             # find the node it was connected to
@@ -221,7 +221,7 @@ class Prufer(Basic):
         for p in prufer:
             d[p] += 1
         for i in prufer:
-            for j in xrange(n):
+            for j in range(n):
             # find the smallest leaf (degree = 1)
                 if d[j] == 1:
                     break
@@ -230,7 +230,7 @@ class Prufer(Basic):
             d[i] -= 1
             d[j] -= 1
             tree.append(sorted([i, j]))
-        last = [i for i in xrange(n) if d[i] == 1] or [0, 1]
+        last = [i for i in range(n) if d[i] == 1] or [0, 1]
         tree.append(last)
 
         return tree
@@ -309,7 +309,7 @@ class Prufer(Basic):
         """
         r = 0
         p = 1
-        for i in xrange(self.nodes - 3, -1, -1):
+        for i in range(self.nodes - 3, -1, -1):
             r += p*self.prufer_repr[i]
             p *= self.nodes
         return r
@@ -328,10 +328,10 @@ class Prufer(Basic):
         """
         n, rank = as_int(n), as_int(rank)
         L = defaultdict(int)
-        for i in xrange(n - 3, -1, -1):
+        for i in range(n - 3, -1, -1):
             L[i] = rank % n
             rank = (rank - L[i])//n
-        return Prufer([L[i] for i in xrange(len(L))])
+        return Prufer([L[i] for i in range(len(L))])
 
     def __new__(cls, *args, **kw_args):
         """The constructor for the Prufer object.

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -4,7 +4,7 @@ from itertools import combinations
 
 from sympy.core import Basic
 from sympy.combinatorics.graycode import GrayCode
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 class Subset(Basic):
@@ -466,7 +466,7 @@ class Subset(Basic):
         if len(super_set) != len(bitlist):
             raise ValueError("The sizes of the lists are not equal")
         ret_set = []
-        for i in xrange(len(bitlist)):
+        for i in range(len(bitlist)):
             if bitlist[i] == '1':
                 ret_set.append(super_set[i])
         return Subset(ret_set, super_set)

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Permutation, _af_rmul, \
     _af_invert, _af_new
 from sympy.combinatorics.perm_groups import PermutationGroup, _orbit, \

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy.combinatorics.partitions import (Partition, IntegerPartition,
                                             RGS_enum, RGS_unrank, RGS_rank,
                                             random_integer_partition)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.combinatorics.named_groups import SymmetricGroup, CyclicGroup,\
     DihedralGroup, AlternatingGroup, AbelianGroup, RubikGroup

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -1,5 +1,6 @@
 from itertools import permutations
 
+from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import (Permutation, _af_parity,
     _af_rmul, _af_rmuln, Cycle)
 from sympy.utilities.pytest import raises

--- a/sympy/combinatorics/tests/test_polyhedron.py
+++ b/sympy/combinatorics/tests/test_polyhedron.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility
 from sympy import symbols, FiniteSet
 from sympy.combinatorics.polyhedron import (Polyhedron,
     tetrahedron, cube as square, octahedron, dodecahedron, icosahedron,

--- a/sympy/combinatorics/tests/test_polyhedron.py
+++ b/sympy/combinatorics/tests/test_polyhedron.py
@@ -1,4 +1,4 @@
-from sympy.core.compatibility
+from sympy.core.compatibility import range
 from sympy import symbols, FiniteSet
 from sympy.combinatorics.polyhedron import (Polyhedron,
     tetrahedron, cube as square, octahedron, dodecahedron, icosahedron,

--- a/sympy/combinatorics/tests/test_tensor_can.py
+++ b/sympy/combinatorics/tests/test_tensor_can.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Permutation, Perm
 from sympy.combinatorics.tensor_can import (perm_af_direct_product, dummy_sgs,
     riemann_bsgs, get_symmetric_group_sgs, canonicalize, bsgs_direct_product)

--- a/sympy/combinatorics/tests/test_util.py
+++ b/sympy/combinatorics/tests/test_util.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy.combinatorics.named_groups import SymmetricGroup, DihedralGroup,\
     AlternatingGroup
 from sympy.combinatorics.permutations import Permutation

--- a/sympy/combinatorics/testutil.py
+++ b/sympy/combinatorics/testutil.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy.combinatorics.util import _distribute_gens_by_base
 from sympy.combinatorics import Permutation
 

--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.ntheory import isprime
 from sympy.combinatorics.permutations import Permutation, _af_invert, _af_rmul
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 rmul = Permutation.rmul
 _af_new = Permutation._af_new
@@ -59,10 +59,10 @@ def _base_ordering(base, degree):
     """
     base_len = len(base)
     ordering = [0]*degree
-    for i in xrange(base_len):
+    for i in range(base_len):
         ordering[base[i]] = i
     current = base_len
-    for i in xrange(degree):
+    for i in range(degree):
         if i not in base:
             ordering[i] = current
             current += 1
@@ -99,7 +99,7 @@ def _check_cycles_alt_sym(perm):
     current_len = 0
     total_len = 0
     used = set()
-    for i in xrange(n//2):
+    for i in range(n//2):
         if not i in used and i < n//2 - total_len:
             current_len = 1
             used.add(i)
@@ -164,7 +164,7 @@ def _distribute_gens_by_base(base, gens):
     """
     base_len = len(base)
     degree = gens[0].size
-    stabs = [[] for _ in xrange(base_len)]
+    stabs = [[] for _ in range(base_len)]
     max_stab_index = 0
     for gen in gens:
         j = 0
@@ -172,7 +172,7 @@ def _distribute_gens_by_base(base, gens):
             j += 1
         if j > max_stab_index:
             max_stab_index = j
-        for k in xrange(j + 1):
+        for k in range(j + 1):
             stabs[k].append(gen)
     for i in range(max_stab_index + 1, base_len):
         stabs[i].append(_af_new(list(range(degree))))
@@ -295,7 +295,7 @@ def _orbits_transversals_from_bsgs(base, strong_gens_distr,
     transversals = [None]*base_len
     if transversals_only is False:
         basic_orbits = [None]*base_len
-    for i in xrange(base_len):
+    for i in range(base_len):
         transversals[i] = dict(_orbit_transversal(degree, strong_gens_distr[i],
                                  base[i], pairs=True))
         if transversals_only is False:

--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core import Add, Mul, S, Dummy
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import default_sort_key
+from sympy.core.compatibility import default_sort_key, range
 from sympy.functions import KroneckerDelta, Piecewise, piecewise_fold
 from sympy.sets import Interval
 

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -6,7 +6,7 @@ from sympy.sets.sets import Interval
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
-from sympy.core.compatibility import is_sequence, xrange
+from sympy.core.compatibility import is_sequence, range
 from sympy.core.containers import Tuple
 from sympy.functions.elementary.piecewise import piecewise_fold
 from sympy.utilities import flatten
@@ -231,7 +231,7 @@ class ExprWithLimits(Expr):
         reps = {}
         f = self.function
         limits = list(self.limits)
-        for i in xrange(-1, -len(limits) - 1, -1):
+        for i in range(-1, -len(limits) - 1, -1):
             xab = list(limits[i])
             if len(xab) == 1:
                 continue

--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division
 
 from sympy.core import S, Dummy, symbols
-from sympy.core.compatibility import is_sequence, xrange
+from sympy.core.compatibility import is_sequence, range
 from sympy.polys import Poly, parallel_poly_from_expr, factor
 from sympy.solvers import solve
 from sympy.simplify import hypersimp
@@ -67,7 +67,7 @@ def gosper_normal(f, g, n, polys=True):
         A = A.quo(d)
         B = B.quo(d.shift(-i))
 
-        for j in xrange(1, i + 1):
+        for j in range(1, i + 1):
             C *= d.shift(-j)
 
     A = A.mul_ground(Z)

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -7,7 +7,7 @@ from sympy.concrete.expr_with_intlimits import ExprWithIntLimits
 from sympy.functions.elementary.exponential import exp, log
 from sympy.polys import quo, roots
 from sympy.simplify import powsimp
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 class Product(ExprWithIntLimits):
@@ -253,7 +253,7 @@ class Product(ExprWithIntLimits):
 
         dif = n - a
         if dif.is_Integer:
-            return Mul(*[term.subs(k, a + i) for i in xrange(dif + 1)])
+            return Mul(*[term.subs(k, a + i) for i in range(dif + 1)])
 
         elif term.is_polynomial(k):
             poly = term.as_poly(k)

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -11,7 +11,7 @@ from sympy.concrete.gosper import gosper_sum
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.polys import apart, PolynomialError
 from sympy.solvers import solve
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 class Sum(AddWithLimits,ExprWithIntLimits):
@@ -328,7 +328,7 @@ class Sum(AddWithLimits,ExprWithIntLimits):
         fa, fb = fpoint(f)
         iterm = (fa + fb)/2
         g = f.diff(i)
-        for k in xrange(1, n + 2):
+        for k in range(1, n + 2):
             ga, gb = fpoint(g)
             term = C.bernoulli(2*k)/C.factorial(2*k)*(gb - ga)
             if (eps and term and abs(term.evalf(3)) < eps) or (k > n):
@@ -480,7 +480,7 @@ def telescopic_direct(L, R, n, limits):
     """
     (i, a, b) = limits
     s = 0
-    for m in xrange(n):
+    for m in range(n):
         s += L.subs(i, a + m) + R.subs(i, b - m)
     return s
 
@@ -577,7 +577,7 @@ def eval_sum_direct(expr, limits):
     (i, a, b) = limits
 
     dif = b - a
-    return C.Add(*[expr.subs(i, a + j) for j in xrange(dif + 1)])
+    return C.Add(*[expr.subs(i, a + j) for j in range(dif + 1)])
 
 
 def eval_sum_symbolic(f, limits):

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -8,6 +8,7 @@ from sympy.abc import a, b, c, d, f, k, m, x, y, z
 from sympy.concrete.summations import telescopic
 from sympy.utilities.pytest import raises
 from sympy.core.mod import Mod
+from sympy.core.compatibility import range
 
 n = Symbol('n', integer=True)
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 
 from .basic import C, Basic
-from .compatibility import cmp_to_key, reduce, is_sequence
+from .compatibility import cmp_to_key, reduce, is_sequence, range
 from .logic import _fuzzy_group, fuzzy_or, fuzzy_not
 from .singleton import S
 from .operations import AssocOp

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -6,7 +6,7 @@ from .cache import cacheit
 from .core import BasicType, C
 from .sympify import _sympify, sympify, SympifyError
 from .compatibility import (iterable, Iterator, ordered,
-    string_types, with_metaclass, zip_longest)
+    string_types, with_metaclass, zip_longest, range)
 from .decorators import deprecated
 from .singleton import S
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -90,10 +90,9 @@ if PY3:
     from io import StringIO
     cStringIO = StringIO
 
-    exec_ = getattr(builtins, "exec")
+    exec_=getattr(builtins, "exec")
 
-    xrange = range
-    range = range
+    range=range
 else:
     import codecs
     import types
@@ -136,9 +135,7 @@ else:
         elif _locs_ is None:
             _locs_ = _globs_
         exec("exec _code_ in _globs_, _locs_")
-    
     range=xrange
-    xrange=xrange
 
 def with_metaclass(meta, *bases):
     """

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -93,6 +93,7 @@ if PY3:
     exec_ = getattr(builtins, "exec")
 
     xrange = range
+    range = range
 else:
     import codecs
     import types
@@ -135,8 +136,9 @@ else:
         elif _locs_ is None:
             _locs_ = _globs_
         exec("exec _code_ in _globs_, _locs_")
-
-    xrange = xrange
+    
+    range=xrange
+    xrange=xrange
 
 def with_metaclass(meta, *bases):
     """

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -9,7 +9,7 @@
 from __future__ import print_function, division
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, range
 from sympy.core.sympify import sympify, converter
 from sympy.utilities.iterables import iterable
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -21,7 +21,7 @@ from mpmath.libmp.libmpc import _infs_nan
 from mpmath.libmp.libmpf import dps_to_prec, prec_to_dps
 from mpmath.libmp.gammazeta import mpf_bernoulli
 
-from .compatibility import SYMPY_INTS
+from .compatibility import SYMPY_INTS, range
 from .sympify import sympify
 from .core import C
 from .singleton import S

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -7,7 +7,7 @@ from .singleton import S
 from .evalf import EvalfMixin, pure_complex
 from .decorators import _sympifyit, call_highest_priority
 from .cache import cacheit
-from .compatibility import reduce, as_int, default_sort_key, xrange
+from .compatibility import reduce, as_int, default_sort_key, range
 from mpmath.libmp import mpf_log, prec_to_dps
 
 from collections import defaultdict
@@ -1205,7 +1205,7 @@ class Expr(Basic, EvalfMixin):
             if not l1 or not l2:
                 return []
             n = min(len(l1), len(l2))
-            for i in xrange(n):
+            for i in range(n):
                 if l1[i] != l2[i]:
                     return l1[:i]
             return l1[:]
@@ -1230,7 +1230,7 @@ class Expr(Basic, EvalfMixin):
             if not first:
                 l.reverse()
                 sub.reverse()
-            for i in xrange(0, len(l) - n + 1):
+            for i in range(0, len(l) - n + 1):
                 if all(l[i + j] == sub[j] for j in range(n)):
                     break
             else:
@@ -1301,7 +1301,7 @@ class Expr(Basic, EvalfMixin):
                 if ii is not None:
                     if not right:
                         gcdc = co[0][0]
-                        for i in xrange(1, len(co)):
+                        for i in range(1, len(co)):
                             gcdc = gcdc.intersection(co[i][0])
                             if not gcdc:
                                 break

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core.add import Add
-from sympy.core.compatibility import iterable, is_sequence, SYMPY_INTS
+from sympy.core.compatibility import iterable, is_sequence, SYMPY_INTS, range
 from sympy.core.mul import Mul, _keep_coeff
 from sympy.core.power import Pow
 from sympy.core.basic import Basic, preorder_traversal

--- a/sympy/core/facts.py
+++ b/sympy/core/facts.py
@@ -52,7 +52,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 
 from .logic import Logic, And, Or, Not
-from sympy.core.compatibility import string_types
+from sympy.core.compatibility import string_types, range
 
 
 def _base_fact(atom):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -46,7 +46,7 @@ from .sympify import sympify
 
 from sympy.core.containers import Tuple, Dict
 from sympy.core.logic import fuzzy_and
-from sympy.core.compatibility import string_types, with_metaclass, xrange
+from sympy.core.compatibility import string_types, with_metaclass, range
 from sympy.utilities import default_sort_key
 from sympy.utilities.iterables import uniq
 from sympy.core.evaluate import global_evaluate
@@ -625,7 +625,7 @@ class Function(Application, Expr):
         cf = C.Order(arg.as_leading_term(x), x).getn()
         if cf != 0:
             nterms = int(nterms / cf)
-        for i in xrange(nterms):
+        for i in range(nterms):
             g = self.taylor_term(i, arg, g)
             g = g.nseries(x, n=n, logx=logx)
             l.append(g)
@@ -1060,7 +1060,7 @@ class Derivative(Expr):
         # We make a generator so as to only generate a variable when necessary.
         # If a high order of derivative is requested and the expr becomes 0
         # after a few differentiations, then we won't need the other variables.
-        variablegen = (v for v, count in variable_count for i in xrange(count))
+        variablegen = (v for v, count in variable_count for i in range(count))
 
         # If we can't compute the derivative of expr (but we wanted to) and
         # expr is itself not a Derivative, finish building an unevaluated

--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -8,6 +8,8 @@ this stuff for general purpose.
 """
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
+
 
 def _fuzzy_group(args, quick_exit=False):
     """Return True if all args are True, None if there is any None else False

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -9,7 +9,7 @@ from .singleton import S
 from .operations import AssocOp
 from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group
-from .compatibility import cmp_to_key, reduce, xrange
+from .compatibility import cmp_to_key, reduce, range
 from .expr import Expr
 
 # internal marker to indicate:
@@ -791,7 +791,7 @@ class Mul(Expr, AssocOp):
     def _eval_derivative(self, s):
         args = list(self.args)
         terms = []
-        for i in xrange(len(args)):
+        for i in range(len(args)):
             d = args[i].diff(s)
             if d:
                 terms.append(self.func(*(args[:i] + [d] + args[i + 1:])))

--- a/sympy/core/multidimensional.py
+++ b/sympy/core/multidimensional.py
@@ -6,6 +6,7 @@ Read the vectorize docstring for more details.
 from __future__ import print_function, division
 
 from sympy.core.decorators import wraps
+from sympy.core.compatibility import range
 
 
 def apply_on_element(f, args, kwargs, n):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -4,7 +4,7 @@ from sympy.core.core import C
 from sympy.core.sympify import _sympify, sympify
 from sympy.core.basic import Basic, _aresame
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import ordered, xrange
+from sympy.core.compatibility import ordered, range
 from sympy.core.logic import fuzzy_and
 from sympy.core.evaluate import global_evaluate
 
@@ -285,7 +285,7 @@ class AssocOp(Basic):
                     if not nc:
                         return True
                     elif len(nc) <= len(_nc):
-                        for i in xrange(len(_nc) - len(nc)):
+                        for i in range(len(_nc) - len(nc)):
                             if _nc[i:i + len(nc)] == nc:
                                 return True
             return False

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -11,7 +11,7 @@ from .evalf import PrecisionExhausted
 from .function import (_coeff_isneg, expand_complex, expand_multinomial,
     expand_mul)
 from .logic import fuzzy_bool
-from .compatibility import as_int, xrange
+from .compatibility import as_int, range
 from .evaluate import global_evaluate
 
 from mpmath.libmp import sqrtrem as mpmath_sqrtrem
@@ -1142,7 +1142,7 @@ class Pow(Expr):
                     dn = 0
 
                 terms = [1/prefactor]
-                for m in xrange(1, ceiling((n - dn)/l*cf)):
+                for m in range(1, ceiling((n - dn)/l*cf)):
                     new_term = terms[-1]*(-rest)
                     if new_term.is_Pow:
                         new_term = new_term._eval_expand_multinomial(
@@ -1285,7 +1285,7 @@ class Pow(Expr):
         else:
             l = []
             g = None
-            for i in xrange(n + 2):
+            for i in range(n + 2):
                 g = self._taylor_term(i, z, g)
                 g = g.nseries(x, n=n, logx=logx)
                 l.append(g)

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.assumptions import StdFactKB
-from sympy.core.compatibility import string_types
+from sympy.core.compatibility import string_types, range
 from .basic import Basic
 from .core import C
 from .sympify import sympify

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from inspect import getmro
 
 from .core import all_classes as sympy_classes
-from .compatibility import iterable, string_types
+from .compatibility import iterable, string_types, range
 from .evaluate import global_evaluate
 
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -10,6 +10,7 @@ import warnings
 import io
 
 from sympy import Basic, S, symbols, sqrt, sin, oo, Interval, exp
+from sympy.core.compatibility import range
 from sympy.utilities.pytest import XFAIL, SKIP
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -4,7 +4,7 @@ from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, Integer,
         sign, im, nan, Dummy, factorial
 )
-from sympy.core.compatibility import long
+from sympy.core.compatibility import long, range
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.randtest import verify_numerically

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -2,6 +2,7 @@ from sympy import I, sqrt, log, exp, sin, asin
 from sympy.core import Symbol, S, Rational, Integer, Dummy, Wild, Pow
 from sympy.core.facts import InconsistentAssumptions
 from sympy import simplify
+from sympy.core.compatibility import range
 
 from sympy.utilities.pytest import raises, XFAIL
 

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,7 +1,7 @@
 from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet, Integer
 from sympy.core.containers import tuple_wrapper
 from sympy.utilities.pytest import raises
-from sympy.core.compatibility import is_sequence, iterable, u
+from sympy.core.compatibility import is_sequence, iterable, u, range
 
 
 def test_Tuple():

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -4,7 +4,7 @@ from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factorial,
                    Rational, S, Sum, sin, sqrt, sstr, sympify, Symbol)
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
     scaled_zero, get_integer_part)
-from sympy.core.compatibility import long
+from sympy.core.compatibility import long, range
 from mpmath import inf, ninf
 from sympy.abc import n, x, y
 from mpmath.libmp.libmpf import from_float

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -2,6 +2,7 @@ from sympy import (log, sqrt, Rational as R, Symbol, I, exp, pi, S,
     cos, sin, Mul, Pow, O)
 from sympy.simplify.simplify import expand_numer, expand
 from sympy.core.function import expand_multinomial, expand_power_base
+from sympy.core.compatibility import range
 
 from sympy.utilities.pytest import raises
 from sympy.utilities.randtest import verify_numerically

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -10,7 +10,7 @@ from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
 from sympy.core.function import AppliedUndef
 from sympy.physics.secondquant import FockState
 from sympy.physics.units import meter
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 from sympy.utilities.pytest import raises, XFAIL
 
@@ -539,7 +539,7 @@ def test_as_numer_denom():
     assert (a/x + b/2/x + c/.5/x).as_numer_denom() == \
         (2*a + b + 4.0*c, 2*x)
     # this should take no more than a few seconds
-    assert int(log(Add(*[Dummy()/i/x for i in xrange(1, 705)]
+    assert int(log(Add(*[Dummy()/i/x for i in range(1, 705)]
                        ).as_numer_denom()[1]/x).n(4)) == 705
     for i in [S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
         assert (i + x/3).as_numer_denom() == \

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -9,6 +9,7 @@ from sympy.sets.sets import FiniteSet
 from sympy.solvers import solve
 from sympy.utilities.iterables import subsets, variations
 from sympy.core.cache import clear_cache
+from sympy.core.compatibility import range
 
 f, g, h = symbols('f g h', cls=Function)
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,5 +1,6 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
+from sympy.core.compatibility import range
                    Implies, Xor, zoo, sqrt, Rational, simplify, Function)
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,7 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
-from sympy.core.compatibility import range
                    Implies, Xor, zoo, sqrt, Rational, simplify, Function)
+from sympy.core.compatibility import range
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -48,6 +48,7 @@ from sympy.functions.special.delta_functions import Heaviside
 from sympy.solvers.recurr import rsolve
 from sympy.solvers.ode import dsolve
 from sympy.core.relational import Equality
+from sympy.core.compatibility import range
 from itertools import islice, takewhile
 
 

--- a/sympy/core/trace.py
+++ b/sympy/core/trace.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Expr, Add, Mul, Pow, sympify, Matrix, Tuple
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 from sympy.utilities import default_sort_key
 
 
@@ -46,7 +46,7 @@ def _cycle_permute(l):
     # in each of the sublist is item just before the next occurence of
     # minitem in the cycle formed.
     sublist = [[le[indices[i]:indices[i + 1]]] for i in
-               xrange(len(indices) - 1)]
+               range(len(indices) - 1)]
 
     # we do comparison of strings by comparing elements
     # in each sublist

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -11,6 +11,7 @@ from random import randrange
 from sympy import nextprime
 from sympy.core import Rational, S, Symbol
 from sympy.core.numbers import igcdex
+from sympy.core.compatibility import range
 from sympy.matrices import Matrix
 from sympy.ntheory import isprime, totient, primitive_root
 from sympy.polys.domains import FF

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -1,4 +1,5 @@
 from sympy.core import symbols
+from sympy.core.compatibility import range
 from sympy.crypto.crypto import (alphabet_of_cipher, cycle_list,
       encipher_shift, encipher_affine, encipher_substitution,
       encipher_vigenere, decipher_vigenere,

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -4,6 +4,7 @@ from itertools import permutations
 
 from sympy.matrices import Matrix
 from sympy.core import Basic, Expr, Dummy, Function, sympify, diff, Pow, Mul, Add, symbols, Tuple
+from sympy.core.compatibility import range
 from sympy.core.numbers import Zero
 from sympy.solvers import solve
 from sympy.functions import factorial

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -6,7 +6,7 @@ from sympy.core.logic import fuzzy_and
 from sympy.ntheory import sieve
 from math import sqrt as _sqrt
 
-from sympy.core.compatibility import reduce, as_int, xrange
+from sympy.core.compatibility import reduce, as_int, range
 from sympy.core.cache import cacheit
 
 
@@ -436,14 +436,14 @@ class RisingFactorial(CombinatorialFunction):
                         else:
                             return S.Infinity
                     else:
-                        return reduce(lambda r, i: r*(x + i), xrange(0, int(k)), 1)
+                        return reduce(lambda r, i: r*(x + i), range(0, int(k)), 1)
                 else:
                     if x is S.Infinity:
                         return S.Infinity
                     elif x is S.NegativeInfinity:
                         return S.Infinity
                     else:
-                        return 1/reduce(lambda r, i: r*(x - i), xrange(1, abs(int(k)) + 1), 1)
+                        return 1/reduce(lambda r, i: r*(x - i), range(1, abs(int(k)) + 1), 1)
 
     def _eval_rewrite_as_gamma(self, x, k):
         return C.gamma(x + k) / C.gamma(x)
@@ -508,14 +508,14 @@ class FallingFactorial(CombinatorialFunction):
                         else:
                             return S.Infinity
                     else:
-                        return reduce(lambda r, i: r*(x - i), xrange(0, int(k)), 1)
+                        return reduce(lambda r, i: r*(x - i), range(0, int(k)), 1)
                 else:
                     if x is S.Infinity:
                         return S.Infinity
                     elif x is S.NegativeInfinity:
                         return S.Infinity
                     else:
-                        return 1/reduce(lambda r, i: r*(x + i), xrange(1, abs(int(k)) + 1), 1)
+                        return 1/reduce(lambda r, i: r*(x + i), range(1, abs(int(k)) + 1), 1)
 
     def _eval_rewrite_as_gamma(self, x, k):
         return (-1)**k * C.gamma(-x + k) / C.gamma(-x)
@@ -653,7 +653,7 @@ class binomial(CombinatorialFunction):
                     return C.Integer(result)
                 elif n.is_Number:
                     result = n - k + 1
-                    for i in xrange(2, k + 1):
+                    for i in range(2, k + 1):
                         result *= n - k + i
                         result /= i
                     return result
@@ -690,7 +690,7 @@ class binomial(CombinatorialFunction):
             else:
                 n = self.args[0]
                 result = n - k + 1
-                for i in xrange(2, k + 1):
+                for i in range(2, k + 1):
                     result *= n - k + i
                     result /= i
                 return result

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -11,7 +11,7 @@ from __future__ import print_function, division
 
 from sympy.core.function import Function, expand_mul
 from sympy.core import S, Symbol, Rational, Integer, C, Add, Dummy
-from sympy.core.compatibility import as_int, SYMPY_INTS, xrange
+from sympy.core.compatibility import as_int, SYMPY_INTS, range
 from sympy.core.cache import cacheit
 from sympy.core.numbers import E, pi
 from sympy.core.relational import LessThan, StrictGreaterThan
@@ -26,7 +26,7 @@ from mpmath.libmp import ifib as _ifib
 
 def _product(a, b):
     p = 1
-    for k in xrange(a, b + 1):
+    for k in range(a, b + 1):
         p *= k
     return p
 
@@ -234,7 +234,7 @@ class bernoulli(Function):
     def _calc_bernoulli(n):
         s = 0
         a = int(C.binomial(n + 3, n - 6))
-        for j in xrange(1, n//6 + 1):
+        for j in range(1, n//6 + 1):
             s += a * bernoulli(n - 6*j)
             # Avoid computing each binomial coefficient from scratch
             a *= _product(n - 6 - 6*j + 1, n - 6*j)
@@ -277,7 +277,7 @@ class bernoulli(Function):
                     # To avoid excessive recursion when, say, bernoulli(1000) is
                     # requested, calculate and cache the entire sequence ... B_988,
                     # B_994, B_1000 in increasing order
-                    for i in xrange(highest_cached + 6, n + 6, 6):
+                    for i in range(highest_cached + 6, n + 6, 6):
                         b = cls._calc_bernoulli(i)
                         cls._cache[i] = b
                         cls._highest[case] = i
@@ -285,7 +285,7 @@ class bernoulli(Function):
                 # Bernoulli polynomials
                 else:
                     n, result = int(n), []
-                    for k in xrange(n + 1):
+                    for k in range(n + 1):
                         result.append(C.binomial(n, k)*cls(k)*sym**(n - k))
                     return Add(*result)
             else:
@@ -372,7 +372,7 @@ class bell(Function):
     def _bell(n, prev):
         s = 1
         a = 1
-        for k in xrange(1, n):
+        for k in range(1, n):
             a = a * (n - k) // k
             s += a * prev[k]
         return s
@@ -382,7 +382,7 @@ class bell(Function):
     def _bell_poly(n, prev):
         s = 1
         a = 1
-        for k in xrange(2, n + 1):
+        for k in range(2, n + 1):
             a = a * (n - k + 1) // (k - 1)
             s += a * prev[k - 1]
         return expand_mul(_sym * s)
@@ -410,7 +410,7 @@ class bell(Function):
             return S.Zero
         s = S.Zero
         a = S.One
-        for m in xrange(1, n - k + 2):
+        for m in range(1, n - k + 2):
             s += a * bell._bell_incomplete_poly(
                 n - m, k - 1, symbols) * symbols[m - 1]
             a = a * (n - m) / m
@@ -632,10 +632,10 @@ class harmonic(Function):
                 off = n.args[0]
                 nnew = n - off
                 if off.is_Integer and off.is_positive:
-                    result = [S.One/(nnew + i) for i in xrange(off, 0, -1)] + [harmonic(nnew)]
+                    result = [S.One/(nnew + i) for i in range(off, 0, -1)] + [harmonic(nnew)]
                     return Add(*result)
                 elif off.is_Integer and off.is_negative:
-                    result = [-S.One/(nnew + i) for i in xrange(0, off, -1)] + [harmonic(nnew)]
+                    result = [-S.One/(nnew + i) for i in range(0, off, -1)] + [harmonic(nnew)]
                     return Add(*result)
 
             if n.is_Rational:

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -8,6 +8,7 @@ from sympy.functions import (
     gamma, sqrt, hyper, log, digamma, trigamma, polygamma, factorial, sin,
     cos, cot, zeta)
 
+from sympy.core.compatibility import range
 from sympy.utilities.pytest import XFAIL, raises
 
 x = Symbol('x')

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -374,7 +374,7 @@ def test_nC_nP_nT():
         for j in range(1, i + 2):
             check = nT(range(i), j)
             tot += check
-            assert len(list(multiset_partitions(range(i), j))) == check
+            assert len(list(multiset_partitions(list(range(i)), j))) == check
         assert nT(range(i)) == tot
 
     for i in range(100):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -11,7 +11,7 @@ from sympy.core.mul import Mul
 
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import multiplicity, perfect_power
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz
@@ -392,7 +392,7 @@ class exp(ExpBase):
     def _taylor(self, x, n):
         l = []
         g = None
-        for i in xrange(n):
+        for i in range(n):
             g = self.taylor_term(i, self.args[0], g)
             g = g.nseries(x, n=n)
             l.append(g)
@@ -700,7 +700,7 @@ class log(Function):
         p = cancel(s/(a*x**b) - 1)
         g = None
         l = []
-        for i in xrange(n + 2):
+        for i in range(n + 2):
             g = log.taylor_term(i, p, g)
             g = g.nseries(x, n=n, logx=logx)
             l.append(g)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -9,7 +9,7 @@ from sympy.core.function import Application, Lambda, ArgumentIndexError
 from sympy.core.expr import Expr
 from sympy.core.singleton import Singleton
 from sympy.core.rules import Transform
-from sympy.core.compatibility import as_int, with_metaclass, xrange
+from sympy.core.compatibility import as_int, with_metaclass, range
 from sympy.core.logic import fuzzy_and
 
 
@@ -515,7 +515,7 @@ class Max(MinMaxBase, Application):
             argindex -= 1
             if n == 2:
                 return C.Heaviside(self.args[argindex] - self.args[1 - argindex])
-            newargs = tuple([self.args[i] for i in xrange(n) if i != argindex])
+            newargs = tuple([self.args[i] for i in range(n) if i != argindex])
             return C.Heaviside(self.args[argindex] - Max(*newargs))
         else:
             raise ArgumentIndexError(self, argindex)
@@ -566,7 +566,7 @@ class Min(MinMaxBase, Application):
             argindex -= 1
             if n == 2:
                 return C.Heaviside( self.args[1-argindex] - self.args[argindex] )
-            newargs = tuple([ self.args[i] for i in xrange(n) if i != argindex])
+            newargs = tuple([ self.args[i] for i in range(n) if i != argindex])
             return C.Heaviside( Min(*newargs) - self.args[argindex] )
         else:
             raise ArgumentIndexError(self, argindex)

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -5,7 +5,7 @@ from sympy.core.relational import Equality, Relational
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or, Not, Or,
     true, false)
-from sympy.core.compatibility import default_sort_key, xrange
+from sympy.core.compatibility import default_sort_key, range
 
 
 class ExprCondPair(Tuple):
@@ -352,7 +352,7 @@ class Piecewise(Function):
             # part 1b: Reduce (-)infinity to what was passed in.
             lower, upper = Max(a, lower), Min(b, upper)
 
-            for n in xrange(len(int_expr)):
+            for n in range(len(int_expr)):
                 # Part 2: remove any interval overlap.  For any conflicts, the
                 # iterval already there wins, and the incoming interval updates
                 # its bounds accordingly.
@@ -395,7 +395,7 @@ class Piecewise(Function):
         int_expr.sort(key=lambda x: x[0].sort_key(
         ) if x[0].is_number else S.Infinity.sort_key())
 
-        for n in xrange(len(int_expr)):
+        for n in range(len(int_expr)):
             if len(int_expr[n][0].free_symbols) or len(int_expr[n][1].free_symbols):
                 if isinstance(int_expr[n][1], Min) or int_expr[n][1] == b:
                     newval = Min(*int_expr[n][:-1])

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -5,7 +5,7 @@ from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, pi, atan,
         conjugate, series, FiniteSet, asec, acsc)
 
 from sympy.utilities.pytest import XFAIL, slow, raises
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 x, y, z = symbols('x y z')
 r = Symbol('r', real=True)
@@ -110,7 +110,7 @@ def test_sin():
     assert isinstance(sin(-re(x) + im(y)), sin) is False
 
     for d in list(range(1, 22)) + [60, 85]:
-        for n in xrange(0, d*2 + 1):
+        for n in range(0, d*2 + 1):
             x = n*pi/d
             e = abs( float(sin(x)) - sin(float(x)) )
             assert e < 1e-12
@@ -118,7 +118,7 @@ def test_sin():
 
 def test_sin_cos():
     for d in [1, 2, 3, 4, 5, 6, 10, 12]:  # list is not exhaustive...
-        for n in xrange(-2*d, d*2):
+        for n in range(-2*d, d*2):
             x = n*pi/d
             assert sin(x + pi/2) == cos(x), "fails for %d*pi/%d" % (n, d)
             assert sin(x - pi/2) == -cos(x), "fails for %d*pi/%d" % (n, d)
@@ -290,7 +290,7 @@ def test_cos():
     assert cos(2*k*pi) == 1
 
     for d in list(range(1, 22)) + [60, 85]:
-        for n in xrange(0, 2*d + 1):
+        for n in range(0, 2*d + 1):
             x = n*pi/d
             e = abs( float(cos(x)) - cos(float(x)) )
             assert e < 1e-12
@@ -1051,7 +1051,7 @@ def test_sincos_rewrite_sqrt():
     for p in [1, 3, 5, 17]:
         for t in [1, 8]:
             n = t*p
-            for i in xrange(1, (n + 1)//2 + 1):
+            for i in range(1, (n + 1)//2 + 1):
                 if 1 == gcd(i, n):
                     x = i*pi/n
                     s1 = sin(x).rewrite(sqrt)
@@ -1069,7 +1069,7 @@ def test_tancot_rewrite_sqrt():
     for p in [1, 3, 5, 17]:
         for t in [1, 8]:
             n = t*p
-            for i in xrange(1, (n + 1)//2 + 1):
+            for i in range(1, (n + 1)//2 + 1):
                 if 1 == gcd(i, n):
                     x = i*pi/n
                     if  2*i != n and 3*i != 2*n:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.utilities.iterables import numbered_symbols
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################
@@ -896,10 +896,10 @@ class tan(TrigonometricFunction):
                 TX.append(tx)
 
             Yg = numbered_symbols('Y')
-            Y = [ next(Yg) for i in xrange(n) ]
+            Y = [ next(Yg) for i in range(n) ]
 
             p = [0, 0]
-            for i in xrange(n + 1):
+            for i in range(n + 1):
                 p[1 - i % 2] += symmetric_poly(i, Y)*(-1)**((i % 4)//2)
             return (p[0]/p[1]).subs(list(zip(Y, TX)))
 
@@ -1171,10 +1171,10 @@ class cot(TrigonometricFunction):
                 CX.append(cx)
 
             Yg = numbered_symbols('Y')
-            Y = [ next(Yg) for i in xrange(n) ]
+            Y = [ next(Yg) for i in range(n) ]
 
             p = [0, 0]
-            for i in xrange(n, -1, -1):
+            for i in range(n, -1, -1):
                 p[(n - i) % 2] += symmetric_poly(i, Y)*(-1)**(((n - i) % 4)//2)
             return (p[0]/p[1]).subs(list(zip(Y, CX)))
         else:

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -8,7 +8,7 @@ from sympy.functions.elementary.miscellaneous import sqrt, root
 from sympy.functions.elementary.complexes import re, im
 from sympy.functions.special.gamma_functions import gamma
 from sympy.functions.special.hyper import hyper
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 # TODO
 # o Scorer functions G1 and G2
@@ -728,7 +728,7 @@ def jn_zeros(n, k, method="sympy", dps=15):
         prec = dps_to_prec(dps)
         return [Expr._from_mpmath(besseljzero(S(n + 0.5)._to_mpmath(prec),
                                               int(l)), prec)
-                for l in xrange(1, k + 1)]
+                for l in range(1, k + 1)]
     elif method == "scipy":
         from scipy.special import sph_jn
         from scipy.optimize import newton

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import S, sympify
+from sympy.core.compatibility import range
 from sympy.functions import Piecewise, piecewise_fold
 from sympy.sets.sets import Interval
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.miscellaneous import sqrt, root
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.complexes import polar_lift
 from sympy.functions.special.hyper import hyper, meijerg
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 # TODO series expansions
 # TODO see the "Note:" in Ei
@@ -2157,10 +2157,10 @@ class fresnels(FresnelIntegral):
             # expansion of S(x) = S1(x*sqrt(pi/2)), see reference[5] page 1-8
             p = [(-1)**k * C.factorial(4*k + 1) /
                  (2**(2*k + 2) * z**(4*k + 3) * 2**(2*k)*C.factorial(2*k))
-                 for k in xrange(0, n)]
+                 for k in range(0, n)]
             q = [1/(2*z)] + [(-1)**k * C.factorial(4*k - 1) /
                  (2**(2*k + 1) * z**(4*k + 1) * 2**(2*k - 1)*C.factorial(2*k - 1))
-                 for k in xrange(1, n)]
+                 for k in range(1, n)]
 
             p = [-sqrt(2/pi)*t for t in p] + [C.Order(1/z**n, x)]
             q = [-sqrt(2/pi)*t for t in q] + [C.Order(1/z**n, x)]
@@ -2288,10 +2288,10 @@ class fresnelc(FresnelIntegral):
             # expansion of C(x) = C1(x*sqrt(pi/2)), see reference[5] page 1-8
             p = [(-1)**k * C.factorial(4*k + 1) /
                  (2**(2*k + 2) * z**(4*k + 3) * 2**(2*k)*C.factorial(2*k))
-                 for k in xrange(0, n)]
+                 for k in range(0, n)]
             q = [1/(2*z)] + [(-1)**k * C.factorial(4*k - 1) /
                  (2**(2*k + 1) * z**(4*k + 1) * 2**(2*k - 1)*C.factorial(2*k - 1))
-                 for k in xrange(1, n)]
+                 for k in range(1, n)]
 
             p = [-sqrt(2/pi)*t for t in p] + [C.Order(1/z**n, x)]
             q = [ sqrt(2/pi)*t for t in q] + [C.Order(1/z**n, x)]
@@ -2321,7 +2321,7 @@ class _erfs(Function):
         if point is S.Infinity:
             z = self.args[0]
             l = [ 1/sqrt(S.Pi) * C.factorial(2*k)*(-S(
-                4))**(-k)/C.factorial(k) * (1/z)**(2*k + 1) for k in xrange(0, n) ]
+                4))**(-k)/C.factorial(k) * (1/z)**(2*k + 1) for k in range(0, n) ]
             o = C.Order(1/z**(2*n + 1), x)
             # It is very inefficient to first add the order and then do the nseries
             return (Add(*l))._eval_nseries(x, n, logx) + o
@@ -2332,7 +2332,7 @@ class _erfs(Function):
             z = self.args[0]
             # TODO: is the series really correct?
             l = [ 1/sqrt(S.Pi) * C.factorial(2*k)*(-S(
-                4))**(-k)/C.factorial(k) * (1/z)**(2*k + 1) for k in xrange(0, n) ]
+                4))**(-k)/C.factorial(k) * (1/z)**(2*k + 1) for k in range(0, n) ]
             o = C.Order(1/z**(2*n + 1), x)
             # It is very inefficient to first add the order and then do the nseries
             return (Add(*l))._eval_nseries(x, n, logx) + o
@@ -2363,7 +2363,7 @@ class _eis(Function):
             return super(_erfs, self)._eval_aseries(n, args0, x, logx)
 
         z = self.args[0]
-        l = [ C.factorial(k) * (1/z)**(k + 1) for k in xrange(0, n) ]
+        l = [ C.factorial(k) * (1/z)**(k + 1) for k in range(0, n) ]
         o = C.Order(1/z**(n + 1), x)
         # It is very inefficient to first add the order and then do the nseries
         return (Add(*l))._eval_nseries(x, n, logx) + o

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core import Add, S, C, sympify, oo, pi, Dummy, Rational
 from sympy.core.function import Function, ArgumentIndexError
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 from .zeta_functions import zeta
 from .error_functions import erf
 from sympy.functions.elementary.exponential import log
@@ -700,17 +700,17 @@ class polygamma(Function):
                     e = -(n + 1)
                     if coeff > 0:
                         tail = Add(*[C.Pow(
-                            z - i, e) for i in xrange(1, int(coeff) + 1)])
+                            z - i, e) for i in range(1, int(coeff) + 1)])
                     else:
                         tail = -Add(*[C.Pow(
-                            z + i, e) for i in xrange(0, int(-coeff))])
+                            z + i, e) for i in range(0, int(-coeff))])
                     return polygamma(n, z - coeff) + (-1)**n*C.factorial(n)*tail
 
             elif z.is_Mul:
                 coeff, z = z.as_two_terms()
                 if coeff.is_Integer and coeff.is_positive:
                     tail = [ polygamma(n, z + C.Rational(
-                        i, coeff)) for i in xrange(0, int(coeff)) ]
+                        i, coeff)) for i in range(0, int(coeff)) ]
                     if n == 0:
                         return Add(*tail)/coeff + log(coeff)
                     else:

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from sympy.core import S, I, pi, oo, ilcm, Mod, C
 from sympy.core.function import Function, Derivative, ArgumentIndexError
 from sympy.core.containers import Tuple
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, range
 from sympy.core.mul import Mul
 
 from sympy.functions import (sqrt, exp, log, sin, cos, asin, atan,

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -4,7 +4,7 @@ from sympy.core.function import Function, C
 from sympy.core import S, Integer
 from sympy.core.mul import prod
 from sympy.utilities.iterables import (has_dups, default_sort_key)
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 ###############################################################################
 ###################### Kronecker Delta, Levi-Civita etc. ######################
@@ -31,8 +31,8 @@ def eval_levicivita(*args):
     from sympy import factorial
     n = len(args)
     return prod(
-        prod(args[j] - args[i] for j in xrange(i + 1, n))
-        / factorial(i) for i in xrange(n))
+        prod(args[j] - args[i] for j in range(i + 1, n))
+        / factorial(i) for i in range(n))
     # converting factorial(i) to int is slightly faster
 
 

--- a/sympy/functions/special/tests/test_bsplines.py
+++ b/sympy/functions/special/tests/test_bsplines.py
@@ -1,4 +1,5 @@
 from sympy.functions import bspline_basis_set
+from sympy.core.compatibility import range
 from sympy import Piecewise, Interval
 from sympy import symbols, Rational
 

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -4,6 +4,7 @@ from sympy import (
     legendre, assoc_legendre, chebyshevu, chebyshevt, chebyshevt_root, chebyshevu_root,
     laguerre, assoc_laguerre, laguerre_poly, hermite, gegenbauer, jacobi, jacobi_normalized)
 
+from sympy.core.compatibility import range
 from sympy.utilities.pytest import raises, XFAIL
 
 x = Symbol('x')

--- a/sympy/functions/special/tests/test_tensor_functions.py
+++ b/sympy/functions/special/tests/test_tensor_functions.py
@@ -2,6 +2,7 @@ from sympy import (
     adjoint, conjugate, Dummy, Eijk, KroneckerDelta, LeviCivita, Symbol,
     symbols, transpose,
 )
+from sympy.core.compatibility import range
 from sympy.physics.secondquant import evaluate_deltas, F
 
 x, y = symbols('x y')

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 
 from sympy.core import Function, S, C, sympify, pi
 from sympy.core.function import ArgumentIndexError
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 ###############################################################################
 ###################### LERCH TRANSCENDENT #####################################
@@ -142,19 +142,19 @@ class lerchphi(Function):
                     n -= 1
                 a -= n
                 mul = z**(-n)
-                add = Add(*[-z**(k - n)/(a + k)**s for k in xrange(n)])
+                add = Add(*[-z**(k - n)/(a + k)**s for k in range(n)])
             elif a <= 0:
                 n = floor(-a) + 1
                 a += n
                 mul = z**n
-                add = Add(*[z**(n - 1 - k)/(a - k - 1)**s for k in xrange(n)])
+                add = Add(*[z**(n - 1 - k)/(a - k - 1)**s for k in range(n)])
 
             m, n = S([a.p, a.q])
             zet = exp_polar(2*pi*I/n)
             root = z**(1/n)
             return add + mul*n**(s - 1)*Add(
                 *[polylog(s, zet**k*root)._eval_expand_func(**hints)
-                  / (unpolarify(zet)**k*root)**m for k in xrange(n)])
+                  / (unpolarify(zet)**k*root)**m for k in range(n)])
 
         # TODO use minpoly instead of ad-hoc methods when issue 5888 is fixed
         if z.func is exp and (z.args[0]/(pi*I)).is_Rational or z in [-1, I, -I]:
@@ -169,7 +169,7 @@ class lerchphi(Function):
                 arg = z.args[0]/(2*pi*I)
                 p, q = S([arg.p, arg.q])
             return Add(*[exp(2*pi*I*k*p/q)/q**s*zeta(s, (k + a)/q)
-                         for k in xrange(q)])
+                         for k in range(q)])
 
         return lerchphi(z, s, a)
 

--- a/sympy/galgebra/ga.py
+++ b/sympy/galgebra/ga.py
@@ -33,6 +33,7 @@ from sympy import Symbol, Expr, expand, Mul, Add, S, collect, \
     Function, simplify, diff, trigsimp, sqrt, Number, \
     factor_terms, sin, cos, sinh, cosh
 from sympy import N as Nsympy
+from sympy.core.compatibility import range
 
 from sympy.galgebra.printing import GA_Printer, GA_LatexPrinter, enhance_print, latex
 from sympy.galgebra.vector import Vector

--- a/sympy/galgebra/manifold.py
+++ b/sympy/galgebra/manifold.py
@@ -22,6 +22,7 @@ from os import system
 import copy
 
 from sympy import trigsimp, simplify
+from sympy.core.compatibility import range
 
 from sympy.galgebra.ga import MV
 from sympy.galgebra.debug import oprint

--- a/sympy/galgebra/ncutil.py
+++ b/sympy/galgebra/ncutil.py
@@ -11,6 +11,7 @@ due to the improvements in trigsimp.
 
 from sympy import expand, Mul, Add, Symbol, S, Pow, diff, trigsimp, \
     simplify, sin, cos, symbols
+from sympy.core.compatibility import range
 
 try:
     from numpy import matrix

--- a/sympy/galgebra/precedence.py
+++ b/sympy/galgebra/precedence.py
@@ -11,6 +11,7 @@ an have the highest precedence, then comes ^, and finally *.
 from __future__ import print_function
 
 import re as regrep
+from sympy.core.compatibility import range
 
 op_cntrct = regrep.compile(r'(([A-Za-z0-9\_\#]+)(\||<|>)([A-Za-z0-9\_\#]+))')
 op_wedge = regrep.compile(r'(([A-Za-z0-9\_\#]+)[\^]{1}([A-Za-z0-9\_\#]+)([\^]{1}([A-Za-z0-9\_\#]+))*)')

--- a/sympy/galgebra/printing.py
+++ b/sympy/galgebra/printing.py
@@ -30,7 +30,7 @@ from __future__ import print_function
 
 import os
 import sys
-from sympy.core.compatibility import StringIO
+from sympy.core.compatibility import StringIO, range
 from sympy.core.decorators import deprecated
 
 from sympy import C, S, Basic, Symbol, Matrix

--- a/sympy/galgebra/stringarrays.py
+++ b/sympy/galgebra/stringarrays.py
@@ -12,6 +12,7 @@ from sympy.core.compatibility import reduce
 from itertools import combinations
 
 from sympy import S, Symbol, Function
+from sympy.core.compatibility import range
 
 
 def str_array(base, n=None):

--- a/sympy/galgebra/tests/test_ga.py
+++ b/sympy/galgebra/tests/test_ga.py
@@ -5,6 +5,7 @@ The reference D&L is "Geometric Algebra for Physicists" by Doran and Lasenby
 """
 
 from sympy.core import expand, Rational, S, Symbol, symbols
+from sympy.core.compatibility import range
 from sympy.functions import sin, cos
 from sympy.galgebra.ga import MV, Nga, Com
 from sympy.galgebra.printing import GA_Printer

--- a/sympy/galgebra/vector.py
+++ b/sympy/galgebra/vector.py
@@ -10,6 +10,7 @@ import itertools
 import copy
 
 from sympy import Symbol, S, Matrix, trigsimp, diff, expand
+from sympy.core.compatibility import range
 
 from sympy.galgebra.printing import GA_Printer
 from sympy.galgebra.stringarrays import str_array

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -11,6 +11,7 @@ from __future__ import print_function, division
 from sympy.core import S, C, sympify, pi, Dummy
 from sympy.core.logic import fuzzy_bool
 from sympy.core.numbers import oo, Rational
+from sympy.core.compatibility import range
 from sympy.simplify import simplify, trigsimp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.geometry.exceptions import GeometryError

--- a/sympy/geometry/line3d.py
+++ b/sympy/geometry/line3d.py
@@ -17,7 +17,7 @@ from sympy.geometry.exceptions import GeometryError
 from .entity import GeometryEntity
 from .point3d import Point3D
 from .util import _symbol
-from sympy.core.compatibility import is_sequence
+from sympy.core.compatibility import is_sequence, range
 
 class LinearEntity3D(GeometryEntity):
     """An base class for all linear entities (line, ray and segment)

--- a/sympy/geometry/point3d.py
+++ b/sympy/geometry/point3d.py
@@ -9,7 +9,7 @@ Point3D
 from __future__ import print_function, division
 
 from sympy.core import S, sympify
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, range
 from sympy.core.containers import Tuple
 from sympy.simplify import simplify, nsimplify
 from sympy.geometry.point import Point

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -524,7 +524,7 @@ class Polygon(GeometryEntity):
         # the last point has to be added so all sides are computed. Using Polygon.sides is
         # not good since Segments are unordered.
         args = poly.args
-        indices = range(-len(args), 1)
+        indices = list(range(-len(args), 1))
 
         if poly.is_convex():
             orientation = None

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Expr, S, sympify, oo, pi, Symbol
-from sympy.core.compatibility import as_int, xrange
+from sympy.core.compatibility import as_int, range
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import cos, sin, tan
@@ -180,7 +180,7 @@ class Polygon(GeometryEntity):
             for i, si in enumerate(sides):
                 pts = si.args
                 # exclude the sides connected to si
-                for j in xrange(1 if i == len(sides) - 1 else 0, i - 1):
+                for j in range(1 if i == len(sides) - 1 else 0, i - 1):
                     sj = sides[j]
                     if sj.p1 not in pts and sj.p2 not in pts:
                         hit = si.intersection(sj)
@@ -227,7 +227,7 @@ class Polygon(GeometryEntity):
         """
         area = 0
         args = self.args
-        for i in xrange(len(args)):
+        for i in range(len(args)):
             x1, y1 = args[i - 1].args
             x2, y2 = args[i].args
             area += x1*y2 - x2*y1
@@ -278,7 +278,7 @@ class Polygon(GeometryEntity):
         cw = self._isright(args[-1], args[0], args[1])
 
         ret = {}
-        for i in xrange(len(args)):
+        for i in range(len(args)):
             a, b, c = args[i - 2], args[i - 1], args[i]
             ang = Line.angle_between(Line(b, a), Line(b, c))
             if cw ^ self._isright(a, b, c):
@@ -312,7 +312,7 @@ class Polygon(GeometryEntity):
         """
         p = 0
         args = self.vertices
-        for i in xrange(len(args)):
+        for i in range(len(args)):
             p += args[i - 1].distance(args[i])
         return simplify(p)
 
@@ -379,7 +379,7 @@ class Polygon(GeometryEntity):
         A = 1/(6*self.area)
         cx, cy = 0, 0
         args = self.args
-        for i in xrange(len(args)):
+        for i in range(len(args)):
             x1, y1 = args[i - 1].args
             x2, y2 = args[i].args
             v = x1*y2 - x2*y1
@@ -423,7 +423,7 @@ class Polygon(GeometryEntity):
         """
         res = []
         args = self.vertices
-        for i in xrange(-len(args), 0):
+        for i in range(-len(args), 0):
             res.append(Segment(args[i], args[i + 1]))
         return res
 
@@ -458,7 +458,7 @@ class Polygon(GeometryEntity):
         # Determine orientation of points
         args = self.vertices
         cw = self._isright(args[-2], args[-1], args[0])
-        for i in xrange(1, len(args)):
+        for i in range(1, len(args)):
             if cw ^ self._isright(args[i - 2], args[i - 1], args[i]):
                 return False
 
@@ -917,11 +917,11 @@ class Polygon(GeometryEntity):
         oargs = o.args
         n = len(args)
         o0 = oargs[0]
-        for i0 in xrange(n):
+        for i0 in range(n):
             if args[i0] == o0:
-                if all(args[(i0 + i) % n] == oargs[i] for i in xrange(1, n)):
+                if all(args[(i0 + i) % n] == oargs[i] for i in range(1, n)):
                     return True
-                if all(args[(i0 - i) % n] == oargs[i] for i in xrange(1, n)):
+                if all(args[(i0 - i) % n] == oargs[i] for i in range(1, n)):
                     return True
         return False
 
@@ -1578,7 +1578,7 @@ class RegularPolygon(Polygon):
         v = 2*S.Pi/self._n
 
         return [Point(c.x + r*cos(k*v + rot), c.y + r*sin(k*v + rot))
-                for k in xrange(self._n)]
+                for k in range(self._n)]
 
     def __eq__(self, o):
         if not isinstance(o, Polygon):

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -3,6 +3,7 @@ import warnings
 
 from sympy import (Abs, C, I, Dummy, Rational, Float, S, Symbol, cos, oo, pi,
                    simplify, sin, sqrt, symbols, tan, Derivative, asin, acos)
+from sympy.core.compatibility import range
 from sympy.geometry import (Circle, Curve, Ellipse, GeometryError, Line, Point,
                             Polygon, Ray, RegularPolygon, Segment, Triangle,
                             are_similar, convex_hull, intersection,

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -11,7 +11,7 @@ are_similar
 from __future__ import print_function, division
 
 from sympy import Symbol, Function, solve
-from sympy.core.compatibility import string_types, is_sequence
+from sympy.core.compatibility import string_types, is_sequence, range
 
 
 def idiff(eq, y, x, n=1):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.core.add import Add
 from sympy.core.basic import Basic, C
-from sympy.core.compatibility import is_sequence
+from sympy.core.compatibility import is_sequence, range
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import diff

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -31,6 +31,7 @@ from sympy.core import oo, S, pi, Expr
 from sympy.core.function import expand, expand_mul, expand_power_base
 from sympy.core.add import Add
 from sympy.core.mul import Mul
+from sympy.core.compatibility import range
 from sympy.core.cache import cacheit
 from sympy.core.symbol import Dummy, Wild
 from sympy.simplify import hyperexpand, powdenest

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -29,7 +29,7 @@ from sympy.integrals.risch import (gcdex_diophantine, frac_in, derivation,
     residue_reduce_derivation, DecrementLevel, recognize_log_derivative)
 from sympy.integrals.rde import (order_at, order_at_oo, weak_normalizer,
     bound_degree, spde, solve_poly_rde)
-from sympy.core.compatibility import reduce, xrange
+from sympy.core.compatibility import reduce, range
 from sympy.utilities.misc import debug
 
 
@@ -303,7 +303,7 @@ def prde_no_cancel_b_large(b, Q, n, DE):
     m = len(Q)
     H = [Poly(0, DE.t)]*m
 
-    for N in xrange(n, -1, -1):  # [n, ..., 0]
+    for N in range(n, -1, -1):  # [n, ..., 0]
         for i in range(m):
             si = Q[i].nth(N + db)/b.LC()
             sitn = Poly(si*DE.t**N, DE.t)
@@ -337,7 +337,7 @@ def prde_no_cancel_b_small(b, Q, n, DE):
     m = len(Q)
     H = [Poly(0, DE.t)]*m
 
-    for N in xrange(n, 0, -1):  # [n, ..., 1]
+    for N in range(n, 0, -1):  # [n, ..., 1]
         for i in range(m):
             si = Q[i].nth(N + DE.d.degree(DE.t) - 1)/(N*DE.d.LC())
             sitn = Poly(si*DE.t**N, DE.t)
@@ -823,7 +823,7 @@ def is_log_deriv_k_t_radical_in_field(fa, fd, DE, case='auto', z=None):
     respolys, residues = list(zip(*roots)) or [[], []]
     # Note: this might be empty, but everything below should work find in that
     # case (it should be the same as if it were [[1, 1]])
-    residueterms = [(H[j][1].subs(z, i), i) for j in xrange(len(H)) for
+    residueterms = [(H[j][1].subs(z, i), i) for j in range(len(H)) for
         i in residues[j]]
 
     # TODO: finish writing this and write tests

--- a/sympy/integrals/quadrature.py
+++ b/sympy/integrals/quadrature.py
@@ -7,7 +7,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.gamma_functions import gamma
 from sympy.polys.orthopolys import legendre_poly, laguerre_poly, hermite_poly, jacobi_poly
 from sympy.polys.rootoftools import RootOf
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 def gauss_legendre(n, n_digits):
     r"""
@@ -346,7 +346,7 @@ def gauss_chebyshev_t(n, n_digits):
     x = Dummy("x")
     xi = []
     w  = []
-    for i in xrange(1,n+1):
+    for i in range(1,n+1):
         xi.append((cos((2*i-S.One)/(2*n)*S.Pi)).n(n_digits))
         w.append((S.Pi/n).n(n_digits))
     return xi, w
@@ -412,7 +412,7 @@ def gauss_chebyshev_u(n, n_digits):
     x = Dummy("x")
     xi = []
     w  = []
-    for i in xrange(1,n+1):
+    for i in range(1,n+1):
         xi.append((cos(i/(n+S.One)*S.Pi)).n(n_digits))
         w.append((S.Pi/(n+S.One)*sin(i*S.Pi/(n+S.One))**2).n(n_digits))
     return xi, w

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -6,7 +6,7 @@ from sympy import S, Symbol, symbols, I, log, atan, \
     roots, collect, solve, RootSum, Lambda, cancel, Dummy
 
 from sympy.polys import Poly, resultant, ZZ
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def ratint(f, x, **flags):
@@ -145,8 +145,8 @@ def ratint_ratpart(f, g, x):
     n = u.degree()
     m = v.degree()
 
-    A_coeffs = [ Dummy('a' + str(n - i)) for i in xrange(0, n) ]
-    B_coeffs = [ Dummy('b' + str(m - i)) for i in xrange(0, m) ]
+    A_coeffs = [ Dummy('a' + str(n - i)) for i in range(0, n) ]
+    B_coeffs = [ Dummy('b' + str(m - i)) for i in range(0, m) ]
 
     C_coeffs = A_coeffs + B_coeffs
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -34,7 +34,7 @@ from sympy.core.power import Pow
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
-from sympy.core.compatibility import reduce, ordered, xrange
+from sympy.core.compatibility import reduce, ordered, range
 from sympy.integrals.heurisch import _symbols
 
 from sympy.functions import (acos, acot, asin, atan, cos, cot, exp, log,
@@ -1358,7 +1358,7 @@ def integrate_hyperexponential_polynomial(p, DE, z):
         return(qa, qd, b)
 
     with DecrementLevel(DE):
-        for i in xrange(-p.degree(z), p.degree(t1) + 1):
+        for i in range(-p.degree(z), p.degree(t1) + 1):
             if not i:
                 continue
             elif i < 0:

--- a/sympy/integrals/tests/test_deltafunctions.py
+++ b/sympy/integrals/tests/test_deltafunctions.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy import cos, DiracDelta, Heaviside, Function, pi, S, sin, symbols
 from sympy.integrals.deltafunctions import change_mul, deltaintegrate
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -6,6 +6,7 @@ from sympy import (
     sstr, Sum, Symbol, symbols, sympify, trigsimp,
     Tuple, nan, And, Eq, re, im
 )
+from sympy.core.compatibility import range
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.utilities.pytest import XFAIL, raises, slow
 from sympy.physics import units

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy import (meijerg, I, S, integrate, Integral, oo, gamma,
                    hyperexpand, exp, simplify, sqrt, pi, erf, sin, cos,
                    exp_polar, polygamma, hyper, log, expand_func)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core import S
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, range
 from sympy.core.function import Function
 from sympy.core.numbers import oo
 from sympy.core.symbol import Dummy

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy.core import cacheit, Dummy, Eq, Integer, Rational, S, Wild
 from sympy.functions import binomial, sin, cos, Piecewise
 

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy.external import import_module
 from sympy.interactive.printing import init_printing
 

--- a/sympy/liealgebras/root_system.py
+++ b/sympy/liealgebras/root_system.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from .cartan_type import CartanType
 from sympy.core import Basic
+from sympy.core.compatibility import range
 
 class RootSystem(Basic):
     """

--- a/sympy/liealgebras/tests/test_type_E.py
+++ b/sympy/liealgebras/tests/test_type_E.py
@@ -1,4 +1,5 @@
 from sympy.liealgebras.cartan_type import CartanType
+from sympy.core.compatibility import range
 from sympy.matrices import Matrix
 
 def test_type_E():

--- a/sympy/liealgebras/tests/test_type_F.py
+++ b/sympy/liealgebras/tests/test_type_F.py
@@ -1,5 +1,6 @@
 from __future__ import division
 from sympy.liealgebras.cartan_type import CartanType
+from sympy.core.compatibility import range
 from sympy.matrices import Matrix
 
 def test_type_F():

--- a/sympy/liealgebras/type_a.py
+++ b/sympy/liealgebras/type_a.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy.liealgebras.cartan_type import Standard_Cartan
 from sympy.matrices import eye
 

--- a/sympy/liealgebras/type_b.py
+++ b/sympy/liealgebras/type_b.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from .cartan_type import Standard_Cartan
+from sympy.core.compatibility import range
 from sympy.matrices import eye
 
 class TypeB(Standard_Cartan):

--- a/sympy/liealgebras/type_c.py
+++ b/sympy/liealgebras/type_c.py
@@ -1,4 +1,5 @@
 from .cartan_type import Standard_Cartan
+from sympy.core.compatibility import range
 from sympy.matrices import eye
 
 class TypeC(Standard_Cartan):

--- a/sympy/liealgebras/type_d.py
+++ b/sympy/liealgebras/type_d.py
@@ -1,5 +1,6 @@
 from .cartan_type import Standard_Cartan
 from sympy.matrices import eye
+from sympy.core.compatibility import range
 
 class TypeD(Standard_Cartan):
 

--- a/sympy/liealgebras/type_e.py
+++ b/sympy/liealgebras/type_e.py
@@ -1,4 +1,5 @@
 from sympy.core import Rational
+from sympy.core.compatibility import range
 from .cartan_type import Standard_Cartan
 from sympy.matrices import eye
 

--- a/sympy/liealgebras/type_f.py
+++ b/sympy/liealgebras/type_f.py
@@ -1,4 +1,5 @@
 from sympy.core import Rational
+from sympy.core.compatibility import range
 from .cartan_type import Standard_Cartan
 from sympy.matrices import Matrix
 

--- a/sympy/liealgebras/weyl_group.py
+++ b/sympy/liealgebras/weyl_group.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sympy.core import Basic, Rational
+from sympy.core.compatibility import range
 from sympy.core.numbers import igcd
 from .cartan_type import CartanType
 from mpmath import fac

--- a/sympy/logic/algorithms/dpll.py
+++ b/sympy/logic/algorithms/dpll.py
@@ -9,6 +9,7 @@ References:
 """
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy import default_sort_key
 from sympy.logic.boolalg import Or, Not, conjuncts, disjuncts, to_cnf, \
     to_int_repr, _find_predicates

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -13,6 +13,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 from heapq import heappush, heappop
 
+from sympy.core.compatibility import range
 from sympy import default_sort_key, ordered
 from sympy.logic.boolalg import conjuncts, to_cnf, to_int_repr, _find_predicates
 

--- a/sympy/logic/benchmarks/run-solvers.py
+++ b/sympy/logic/benchmarks/run-solvers.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy.logic.utilities import load_file
 from sympy.logic import satisfiable
 import time

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -13,7 +13,7 @@ from sympy.core.numbers import Number
 from sympy.core.decorators import deprecated
 from sympy.core.operations import LatticeOp
 from sympy.core.function import Application
-from sympy.core.compatibility import ordered, xrange, with_metaclass
+from sympy.core.compatibility import ordered, range, with_metaclass
 from sympy.core.sympify import converter, _sympify, sympify
 from sympy.core.singleton import Singleton, S
 
@@ -529,7 +529,7 @@ class Not(BooleanFunction):
 
         if func == Xor:
             result = []
-            for i in xrange(1, len(args)+1, 2):
+            for i in range(1, len(args)+1, 2):
                 for neg in combinations(args, i):
                     clause = [~s if s in neg else s for s in args]
                     result.append(Or(*clause))
@@ -636,7 +636,7 @@ class Xor(BooleanFunction):
 
     def to_nnf(self, simplify=True):
         args = []
-        for i in xrange(0, len(self.args)+1, 2):
+        for i in range(0, len(self.args)+1, 2):
             for neg in combinations(self.args, i):
                 clause = [~s if s in neg else s for s in self.args]
                 args.append(Or(*clause))
@@ -1293,7 +1293,7 @@ def to_int_repr(clauses, symbols):
     """
 
     # Convert the symbol list into a dict
-    symbols = dict(list(zip(symbols, list(xrange(1, len(symbols) + 1)))))
+    symbols = dict(list(zip(symbols, list(range(1, len(symbols) + 1)))))
 
     def append_symbol(arg, symbols):
         if arg.func is Not:

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,6 +1,7 @@
 """For more tests on satisfiability, see test_dimacs"""
 
 from sympy import symbols, Q
+from sympy.core.compatibility import range
 from sympy.logic.boolalg import And, Implies, Equivalent, true, false
 from sympy.logic.inference import literal_symbol, \
      pl_true, satisfiable, valid, entails, PropKB

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -74,13 +74,15 @@ class DenseMatrix(MatrixBase):
                 return self._mat[i*self.cols + j]
             except (TypeError, IndexError):
                 if isinstance(i, slice):
-                    i = range(self.rows)[i]
+                    # XXX remove list() when PY2 support is dropped
+                    i = list(range(self.rows))[i]
                 elif is_sequence(i):
                     pass
                 else:
                     i = [i]
                 if isinstance(j, slice):
-                    j = range(self.cols)[j]
+                    # XXX remove list() when PY2 support is dropped
+                    j = list(range(self.cols))[j]
                 elif is_sequence(j):
                     pass
                 else:

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 import random
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import is_sequence, as_int
+from sympy.core.compatibility import is_sequence, as_int, range
 from sympy.core.function import count_ops
 from sympy.core.decorators import call_highest_priority
 from sympy.core.singleton import S

--- a/sympy/matrices/densearith.py
+++ b/sympy/matrices/densearith.py
@@ -4,7 +4,7 @@ as a list of lists.
 
 """
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 def add(matlist1, matlist2, K):
     """
@@ -242,6 +242,6 @@ def mulrowcol(row, col, K):
 
     """
     result = K.zero
-    for i in xrange(len(row)):
+    for i in range(len(row)):
         result += row[i]*col[i]
     return result

--- a/sympy/matrices/densesolve.py
+++ b/sympy/matrices/densesolve.py
@@ -8,7 +8,7 @@ The dense matrix is stored as a list of lists.
 from sympy.matrices.densetools import col, eye, augment
 from sympy.matrices.densetools import rowadd, rowmul, conjugate_transpose
 from sympy import sqrt, var
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 import copy
 
 def row_echelon(matlist, K):
@@ -100,8 +100,8 @@ def LU(matlist, K, reverse = 0):
     """
     nrow = len(matlist)
     new_matlist1, new_matlist2 = eye(nrow, K), copy.deepcopy(matlist)
-    for i in xrange(nrow):
-        for j in xrange(i + 1, nrow):
+    for i in range(nrow):
+        for j in range(i + 1, nrow):
             if (new_matlist2[j][i] != 0):
                 new_matlist1[j][i] = new_matlist2[j][i]/new_matlist2[i][i]
                 rowadd(new_matlist2, j, i, -new_matlist2[j][i]/new_matlist2[i][i], K)

--- a/sympy/matrices/densetools.py
+++ b/sympy/matrices/densetools.py
@@ -4,7 +4,7 @@ The dense matrix is stored as a list of lists
 
 """
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def trace(matlist, K):
@@ -28,7 +28,7 @@ def trace(matlist, K):
 
     """
     result = K.zero
-    for i in xrange(len(matlist)):
+    for i in range(len(matlist)):
         result += matlist[i][i]
     return result
 
@@ -154,7 +154,7 @@ def eye(n, K):
     [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     """
     result = []
-    for i in xrange(n):
+    for i in range(n):
         result.append([])
         for j in range(n):
             if (i == j):
@@ -216,7 +216,7 @@ def rowmul(matlist, index, k,  K):
     """
     Multiplies index row with k
     """
-    for i in xrange(len(matlist[index])):
+    for i in range(len(matlist[index])):
         matlist[index][i] = k*matlist[index][i]
     return matlist
 
@@ -226,7 +226,7 @@ def rowadd(matlist, index1, index2 , k, K):
     Adds the index1 row with index2 row which in turn is multiplied by k
     """
     result = []
-    for i in xrange(len(matlist[index1])):
+    for i in range(len(matlist[index1])):
         matlist[index1][i] = (matlist[index1][i] + k*matlist[index2][i])
     return matlist
 

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy import ask, Q
 from sympy.core import Basic, Add, sympify
+from sympy.core.compatibility import range
 from sympy.strategies import typed, exhaust, condition, do_one, unpack
 from sympy.strategies.traverse import bottom_up
 from sympy.utilities import sift

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -4,6 +4,7 @@ from functools import wraps
 
 from sympy.core import S, Symbol, Tuple, Integer, Basic, Expr
 from sympy.core.decorators import call_highest_priority
+from sympy.core.compatibility import range
 from sympy.core.sympify import SympifyError, sympify
 from sympy.functions import conjugate, adjoint
 from sympy.matrices import ShapeError

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Mul, Basic, sympify, Add
+from sympy.core.compatibility import range
 from sympy.functions import adjoint
 from sympy.matrices.expressions.transpose import transpose
 from sympy.strategies import (rm_id, unpack, typed, flatten, exhaust,

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from .matexpr import MatrixExpr, ShapeError, Identity
 from sympy.core.sympify import _sympify
+from sympy.core.compatibility import range
 from sympy.matrices import MatrixBase
 from sympy.core import S
 

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -5,6 +5,7 @@ from sympy.matrices.expressions import (MatrixSymbol, Identity,
         Inverse, trace, Transpose, det)
 from sympy.matrices import Matrix, ImmutableMatrix
 from sympy.core import Tuple, symbols, Expr
+from sympy.core.compatibility import range
 from sympy.functions import transpose
 
 i, j, k, l, m, n, p = symbols('i:n, p', integer=True)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -11,7 +11,7 @@ from sympy.core.symbol import Symbol, Dummy, symbols
 from sympy.core.numbers import Integer, ilcm, Rational, Float
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
-from sympy.core.compatibility import is_sequence, default_sort_key, xrange, NotIterable
+from sympy.core.compatibility import is_sequence, default_sort_key, range, NotIterable
 
 from sympy.polys import PurePoly, roots, cancel, gcd
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
@@ -1249,13 +1249,13 @@ class MatrixBase(object):
         n = self.rows
         b = rhs.permuteFwd(perm).as_mutable()
         # forward substitution, all diag entries are scaled to 1
-        for i in xrange(n):
-            for j in xrange(i):
+        for i in range(n):
+            for j in range(i):
                 scale = A[i, j]
                 b.zip_row_op(i, j, lambda x, y: x - y*scale)
         # backward substitution
-        for i in xrange(n - 1, -1, -1):
-            for j in xrange(i + 1, n):
+        for i in range(n - 1, -1, -1):
+            for j in range(i + 1, n):
                 scale = A[i, j]
                 b.zip_row_op(i, j, lambda x, y: x - y*scale)
             scale = A[i, i]
@@ -2672,13 +2672,13 @@ class MatrixBase(object):
         pivot, r = 0, self.as_mutable()
         # pivotlist: indices of pivot variables (non-free)
         pivotlist = []
-        for i in xrange(r.cols):
+        for i in range(r.cols):
             if pivot == r.rows:
                 break
             if simplify:
                 r[pivot, i] = simpfunc(r[pivot, i])
             if iszerofunc(r[pivot, i]):
-                for k in xrange(pivot, r.rows):
+                for k in range(pivot, r.rows):
                     if simplify and k > pivot:
                         r[k, i] = simpfunc(r[k, i])
                     if not iszerofunc(r[k, i]):
@@ -2688,7 +2688,7 @@ class MatrixBase(object):
                     continue
             scale = r[pivot, i]
             r.row_op(pivot, lambda x, _: x / scale)
-            for j in xrange(r.rows):
+            for j in range(r.rows):
                 if j == pivot:
                     continue
                 scale = r[j, i]
@@ -3554,7 +3554,7 @@ class MatrixBase(object):
                 # So we will do the same procedure also for `s-1` and so on until 1 the lowest possible order
                 # where the jordanchain is of lenght 1 and just represented by the eigenvector.
 
-                for s in reversed(xrange(1, smax+1)):
+                for s in reversed(range(1, smax+1)):
                     S = Ms[s]
                     # We want the vectors in `Kernel((self-lI)^s)` (**),
                     # but without those in `Kernel(self-lI)^s-1` so we will add these as additional equations

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -4,7 +4,7 @@ import copy
 from collections import defaultdict
 
 from sympy.core.containers import Dict
-from sympy.core.compatibility import is_sequence, as_int
+from sympy.core.compatibility import is_sequence, as_int, range
 from sympy.core.logic import fuzzy_and
 from sympy.core.singleton import S
 from sympy.functions.elementary.miscellaneous import sqrt

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -96,7 +96,8 @@ class SparseMatrix(MatrixBase):
                 return self._smat.get((i, j), S.Zero)
             except (TypeError, IndexError):
                 if isinstance(i, slice):
-                    i = range(self.rows)[i]
+                    # XXX remove list() when PY2 support is dropped
+                    i = list(range(self.rows))[i]
                 elif is_sequence(i):
                     pass
                 else:
@@ -104,7 +105,8 @@ class SparseMatrix(MatrixBase):
                         raise IndexError('Row index out of bounds')
                     i = [i]
                 if isinstance(j, slice):
-                    j = range(self.cols)[j]
+                    # XXX remove list() when PY2 support is dropped
+                    j = list(range(self.cols))[j]
                 elif is_sequence(j):
                     pass
                 else:

--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy.core.compatibility import range
 from sympy import SparseMatrix
 
 

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -8,6 +8,7 @@ Here we test the extent to which they cooperate
 from sympy import symbols
 from sympy.matrices import (Matrix, MatrixSymbol, eye, Identity,
         ImmutableMatrix)
+from sympy.core.compatibility import range
 from sympy.matrices.expressions import MatrixExpr, MatAdd
 from sympy.matrices.matrices import classof
 from sympy.utilities.pytest import raises

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -11,7 +11,7 @@ from sympy.matrices import (
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros)
-from sympy.core.compatibility import long, iterable, u
+from sympy.core.compatibility import long, iterable, u, range
 from sympy.utilities.iterables import flatten, capture
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
 

--- a/sympy/ntheory/bbp_pi.py
+++ b/sympy/ntheory/bbp_pi.py
@@ -48,6 +48,7 @@ array (perhaps just a matter of preference).
 from __future__ import print_function, division
 
 import math
+from sympy.core.compatibility import range
 
 
 def _series(j, n):

--- a/sympy/ntheory/egyptian_fraction.py
+++ b/sympy/ntheory/egyptian_fraction.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 import sympy.polys
 from sympy import Integer
+from sympy.core.compatibility import range
 from fractions import gcd
 
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -14,7 +14,7 @@ from sympy.core.logic import fuzzy_and
 from sympy.core.numbers import igcd, Rational
 from sympy.core.power import integer_nthroot, Pow
 from sympy.core.mul import Mul
-from sympy.core.compatibility import as_int, SYMPY_INTS, xrange
+from sympy.core.compatibility import as_int, SYMPY_INTS, range
 from sympy.core.singleton import S
 from sympy.core.function import Function
 
@@ -1220,7 +1220,7 @@ def _divisors(n):
             yield 1
         else:
             pows = [1]
-            for j in xrange(factordict[ps[n]]):
+            for j in range(factordict[ps[n]]):
                 pows.append(pows[-1] * ps[n])
             for q in rec_gen(n + 1):
                 for p in pows:

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -11,7 +11,7 @@ from bisect import bisect
 from array import array as _array
 
 from .primetest import isprime
-from sympy.core.compatibility import as_int, xrange
+from sympy.core.compatibility import as_int, range
 
 
 def _arange(a, b):
@@ -77,7 +77,7 @@ class Sieve:
             # Start counting at a multiple of p, offsetting
             # the index to account for the new sieve's base index
             startindex = (-begin) % p
-            for i in xrange(startindex, len(newsieve), p):
+            for i in range(startindex, len(newsieve), p):
                 newsieve[i] = 0
 
         # Merge the sieves

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from collections import defaultdict
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def binomial_coefficients(n):
@@ -22,7 +22,7 @@ def binomial_coefficients(n):
     """
     d = {(0, n): 1, (n, 0): 1}
     a = 1
-    for k in xrange(1, n//2 + 1):
+    for k in range(1, n//2 + 1):
         a = (a * (n - k + 1))//k
         d[k, n - k] = d[n - k, k] = a
     return d
@@ -46,7 +46,7 @@ def binomial_coefficients_list(n):
     """
     d = [1] * (n + 1)
     a = 1
-    for k in xrange(1, n//2 + 1):
+    for k in range(1, n//2 + 1):
         a = (a * (n - k + 1))//k
         d[k] = d[n - k] = a
     return d
@@ -92,9 +92,9 @@ def multinomial_coefficients0(m, n, _tuple=tuple, _zip=zip):
     r = {_tuple(aa*n for aa in s0): 1}
     l = [0] * (n*(m - 1) + 1)
     l[0] = r.items()
-    for k in xrange(1, n*(m - 1) + 1):
+    for k in range(1, n*(m - 1) + 1):
         d = defaultdict(int)
-        for i in xrange(1, min(m, k + 1)):
+        for i in range(1, min(m, k + 1)):
             nn = (n + 1)*i - k
             if not nn:
                 continue
@@ -168,7 +168,7 @@ def multinomial_coefficients(m, n):
             t[j] += 1
         # compute the value
         # NB: the initialization of v was done above
-        for k in xrange(start, m):
+        for k in range(start, m):
             if t[k]:
                 t[k] -= 1
                 v += r[tuple(t)]

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -6,7 +6,7 @@ from mpmath.libmp import (fzero,
     mpf_add, mpf_sqrt, mpf_pi, mpf_cosh_sinh, pi_fixed, mpf_cos)
 from sympy.core.numbers import igcd
 import math
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def _a(n, j, prec):
@@ -15,7 +15,7 @@ def _a(n, j, prec):
         return fone
     s = fzero
     pi = pi_fixed(prec)
-    for h in xrange(1, j):
+    for h in range(1, j):
         if igcd(h, j) != 1:
             continue
         # & with mask to compute fractional part of fixed-point number
@@ -24,7 +24,7 @@ def _a(n, j, prec):
         half = one >> 1
         g = 0
         if j >= 3:
-            for k in xrange(1, j):
+            for k in range(1, j):
                 t = h*k*one//j
                 if t > 0:
                     frac = t & onemask
@@ -83,7 +83,7 @@ def npartitions(n, verbose=False):
     M = max(6, int(0.24*n**0.5 + 4))
     sq23pi = mpf_mul(mpf_sqrt(from_rational(2, 3, p), p), mpf_pi(p), p)
     sqrt8 = mpf_sqrt(from_int(8), p)
-    for q in xrange(1, M):
+    for q in range(1, M):
         a = _a(n, q, p)
         d = _d(n, q, p, sq23pi, sqrt8)
         s = mpf_add(s, mpf_mul(a, d), prec)

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -4,7 +4,7 @@ Primality testing
 """
 
 from __future__ import print_function, division
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 # pseudoprimes that will pass through last mr_safe test
 _pseudos = set([
@@ -53,7 +53,7 @@ def _test(n, base, s, t):
     if b == 1 or b == n - 1:
         return True
     else:
-        for j in xrange(1, s):
+        for j in range(1, s):
             b = pow(b, 2, n)
             if b == n - 1:
                 return True

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from sympy.core.singleton import S
 from sympy.core.numbers import igcd, igcdex
-from sympy.core.compatibility import as_int, xrange
+from sympy.core.compatibility import as_int, range
 from sympy.core.function import Function
 from .primetest import isprime
 from .factor_ import factorint, trailing, totient
@@ -45,7 +45,7 @@ def n_order(a, n):
         a = a % n
     for p, e in factors.items():
         exponent = group_order
-        for f in xrange(e + 1):
+        for f in range(e + 1):
             if pow(a, exponent, n) != 1:
                 order *= p ** (e - f + 1)
                 break
@@ -137,7 +137,7 @@ def primitive_root(p):
             if is_primitive_root(g, p1**2):
                 return g
             else:
-                for i in xrange(2, g + p1 + 1):
+                for i in range(2, g + p1 + 1):
                     if igcd(i, p) == 1 and is_primitive_root(i, p):
                         return i
 
@@ -194,7 +194,7 @@ def _sqrt_mod_tonelli_shanks(a, p):
     A = pow(a, t, p)
     D = pow(d, t, p)
     m = 0
-    for i in xrange(s):
+    for i in range(s):
         adm = A*pow(D, m, p) % p
         adm = pow(adm, 2**(s - 1 - i), p)
         if adm % p == p - 1:
@@ -411,7 +411,7 @@ def _sqrt_mod_prime_power(a, p, k):
                 return None
             if k <= 3:
                s = set()
-               for i in xrange(0, pk, 4):
+               for i in range(0, pk, 4):
                     s.add(1 + i)
                     s.add(-1 + i)
                return list(s)
@@ -665,7 +665,7 @@ def _nthroot_mod1(s, q, p, all_roots):
         # used a naive implementation
         # TODO implement using Ref [1]
         pr = 1
-        for t in xrange(p):
+        for t in range(p):
             if pr == s1:
                 break
             pr = pr*h % p
@@ -761,7 +761,7 @@ def quadratic_residues(p):
     [0, 1, 2, 4]
     """
     r = set()
-    for i in xrange(p // 2 + 1):
+    for i in range(p // 2 + 1):
         r.add(pow(i, 2, p))
     return sorted(list(r))
 

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -3,7 +3,7 @@ from sympy import Sieve, binomial_coefficients, binomial_coefficients_list, \
     multinomial_coefficients, Mul, S, Pow, sieve, Symbol, summation, \
     factorial as fac, pi, GoldenRatio as phi, sqrt
 from sympy.core.numbers import Integer, Rational
-from sympy.core.compatibility import long
+from sympy.core.compatibility import long, range
 
 from sympy.ntheory import isprime, n_order, is_primitive_root, \
     is_quad_residue, legendre_symbol, jacobi_symbol, npartitions, totient, \

--- a/sympy/physics/hep/gamma_matrices.py
+++ b/sympy/physics/hep/gamma_matrices.py
@@ -3,6 +3,7 @@ from sympy.tensor.tensor import TensorIndexType, TensorIndex,\
     TensMul, TensorHead, tensorsymmetry, TensorType,\
     TensAdd, tensor_mul, get_lines, Tensor
 from sympy.core.containers import Tuple
+from sympy.core.compatibility import range
 
 
 DiracSpinorIndex = TensorIndexType('DiracSpinorIndex', dim=4, dummy_fmt="S")

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from sympy import Matrix, I, pi, sqrt
 from sympy.functions import exp
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def msigma(i):
@@ -174,12 +174,12 @@ def mdft(n):
     [sqrt(3)/3, sqrt(3)*exp(-2*I*pi/3)/3, sqrt(3)*exp(-4*I*pi/3)/3],
     [sqrt(3)/3, sqrt(3)*exp(-4*I*pi/3)/3, sqrt(3)*exp(-8*I*pi/3)/3]])
     """
-    mat = [[None for x in xrange(n)] for y in xrange(n)]
+    mat = [[None for x in range(n)] for y in range(n)]
     base = exp(-2*pi*I/n)
     mat[0] = [1]*n
     for i in range(n):
         mat[i][0] = 1
-    for i in xrange(1, n):
-        for j in xrange(i, n):
+    for i in range(1, n):
+        for j in range(i, n):
             mat[i][j] = mat[j][i] = base**(i*j)
     return (1/sqrt(n))*Matrix(mat)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 __all__ = ['KanesMethod']
 
 from sympy import zeros, Matrix, diff, solve_linear_system_LU, eye
+from sympy.core.compatibility import range
 from sympy.utilities import default_sort_key
 from sympy.physics.vector import (ReferenceFrame, dynamicsymbols,
         partial_velocity)

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy import cos, Matrix, simplify, sin, solve
 from sympy import symbols, trigsimp, zeros
 from sympy.physics.mechanics import (cross, dot, dynamicsymbols, KanesMethod,

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy import evalf, symbols, pi, sin, cos, sqrt, acos, Matrix
 from sympy.physics.mechanics import (ReferenceFrame, dynamicsymbols, inertia,
                                      KanesMethod, RigidBody, Point, dot)

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -9,6 +9,7 @@ TODO:
 from __future__ import print_function, division
 
 from sympy import DiracDelta, exp, I, Interval, pi, S, sqrt
+from sympy.core.compatibility import range
 
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.hilbert import L2

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -8,6 +8,7 @@ from __future__ import print_function, division
 
 from sympy import (Add, expand, Eq, Expr, Mul, Piecewise, Pow, sqrt, Sum,
                    symbols, sympify, Wild)
+from sympy.core.compatibility import range
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.functions.special.tensor_functions import KroneckerDelta

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -17,7 +17,7 @@ Todo:
 from __future__ import print_function, division
 
 from sympy import Mul
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from sympy.external import import_module
 from sympy.physics.quantum.gate import Gate, OneQubitGate, CGate, CGateS
 from sympy.core.core import BasicMeta

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -20,7 +20,7 @@ import random
 
 from sympy import Add, I, Integer, Mul, Pow, sqrt, Tuple
 from sympy.core.numbers import Number
-from sympy.core.compatibility import is_sequence, u, unicode, xrange
+from sympy.core.compatibility import is_sequence, u, unicode, range
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
@@ -1145,7 +1145,7 @@ def gate_simp(circuit):
         return circuit
 
     # Iterate through each element in circuit, simplify if possible.
-    for i in xrange(len(circuit_args)):
+    for i in range(len(circuit_args)):
         # H,X,Y or Z squared is 1.
         # T**2 = S, S**2 = Z
         if isinstance(circuit_args[i], Pow):
@@ -1214,7 +1214,7 @@ def gate_sort(circuit):
     while changes:
         changes = False
         circ_array = circuit.args
-        for i in xrange(len(circ_array) - 1):
+        for i in range(len(circ_array) - 1):
             # Go through each element and switch ones that are in wrong order
             if isinstance(circ_array[i], (Gate, Pow)) and \
                     isinstance(circ_array[i + 1], (Gate, Pow)):
@@ -1268,7 +1268,7 @@ def random_circuit(ngates, nqubits, gate_space=(X, Y, Z, S, T, H, CNOT, SWAP)):
     """
     qubit_space = range(nqubits)
     result = []
-    for i in xrange(ngates):
+    for i in range(ngates):
         g = random.choice(gate_space)
         if g == CNotGate or g == SwapGate:
             qubits = random.sample(qubit_space, 2)

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -11,7 +11,7 @@ Todo:
 from __future__ import print_function, division
 
 from sympy import floor, pi, sqrt, sympify
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qexpr import QuantumError
 from sympy.physics.quantum.hilbert import ComplexSpace

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -8,7 +8,7 @@ Authors:
 from __future__ import print_function, division
 
 from sympy import Basic, Interval, oo, sympify
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.qexpr import QuantumError

--- a/sympy/physics/quantum/identitysearch.py
+++ b/sympy/physics/quantum/identitysearch.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from collections import deque
 from random import randint
 
+from sympy.core.compatibility import range
 from sympy.external import import_module
 from sympy import Mul, Basic, Number, Pow, Integer
 from sympy.physics.quantum.represent import represent

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -3,6 +3,7 @@
 from __future__ import print_function, division
 
 from sympy import Matrix, I, Expr, Integer
+from sympy.core.compatibility import range
 from sympy.matrices import eye, zeros
 from sympy.external import import_module
 

--- a/sympy/physics/quantum/operatorordering.py
+++ b/sympy/physics/quantum/operatorordering.py
@@ -3,6 +3,7 @@
 import warnings
 
 from sympy import Add, Mul, Pow, Integer
+from sympy.core.compatibility import range
 from sympy.physics.quantum import Operator, Commutator, AntiCommutator
 from sympy.physics.quantum.boson import BosonOp
 from sympy.physics.quantum.fermion import FermionOp

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -7,6 +7,7 @@ Todo:
 from __future__ import print_function, division
 
 from sympy import Add, Mul, Pow, sympify, S
+from sympy.core.compatibility import range
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator

--- a/sympy/physics/quantum/qft.py
+++ b/sympy/physics/quantum/qft.py
@@ -14,7 +14,7 @@ Todo:
 from __future__ import print_function, division
 
 from sympy import Expr, Matrix, exp, I, pi, Integer, Symbol
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from sympy.functions import sqrt
 
 from sympy.physics.quantum.qapply import qapply

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -12,7 +12,7 @@ import math
 
 from sympy import Integer, log, Mul, Add, Pow, conjugate
 from sympy.core.basic import sympify
-from sympy.core.compatibility import string_types, xrange
+from sympy.core.compatibility import string_types, range
 from sympy.matrices import Matrix, zeros
 from sympy.printing.pretty.stringpict import prettyForm
 
@@ -220,7 +220,7 @@ class Qubit(QubitState, Ket):
 
         #trace out for each of index
         new_mat = self*bra
-        for i in xrange(len(sorted_idx) - 1, -1, -1):
+        for i in range(len(sorted_idx) - 1, -1, -1):
             # start from tracing out from leftmost qubit
             new_mat = self._reduced_density(new_mat, int(sorted_idx[i]))
 
@@ -245,8 +245,8 @@ class Qubit(QubitState, Ket):
         new_size = old_size//2
         new_matrix = Matrix().zeros(new_size)
 
-        for i in xrange(new_size):
-            for j in xrange(new_size):
+        for i in range(new_size):
+            for j in range(new_size):
                 for k in range(2):
                     col = find_index_that_is_projected(j, k, qubit)
                     row = find_index_that_is_projected(i, k, qubit)

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy import sqrt, I, Symbol, Integer, S
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.operator import Operator
 from sympy.physics.quantum.state import Bra, Ket, State

--- a/sympy/physics/quantum/shor.py
+++ b/sympy/physics/quantum/shor.py
@@ -15,6 +15,7 @@ import random
 from sympy import Mul, S
 from sympy import log, sqrt
 from sympy.core.numbers import igcd
+from sympy.core.compatibility import range
 from sympy.ntheory import continued_fraction_periodic as continued_fraction
 from sympy.utilities.iterables import variations
 

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from sympy import (Add, binomial, cos, exp, Expr, factorial, I, Integer, Mul,
                    pi, Rational, S, sin, simplify, sqrt, Sum, symbols, sympify,
                    Tuple, Dummy)
-from sympy.core.compatibility import u, unicode
+from sympy.core.compatibility import u, unicode, range
 from sympy.matrices import zeros
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.pretty.pretty_symbology import pretty_symbol

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from sympy import (cacheit, conjugate, Expr, Function, integrate, oo, sqrt,
                    Tuple)
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from sympy.printing.pretty.stringpict import stringPict
 from sympy.physics.quantum.qexpr import QExpr, dispatch_method
 

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy import Expr, Add, Mul, Matrix, Pow, sympify
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from sympy.core.trace import Tr
 from sympy.printing.pretty.stringpict import prettyForm
 

--- a/sympy/physics/quantum/tests/test_boson.py
+++ b/sympy/physics/quantum/tests/test_boson.py
@@ -1,4 +1,5 @@
 from sympy import sqrt, exp, S, prod
+from sympy.core.compatibility import range
 from sympy.physics.quantum import Dagger, Commutator, qapply
 from sympy.physics.quantum.boson import BosonOp
 from sympy.physics.quantum.boson import (

--- a/sympy/physics/quantum/tests/test_gate.py
+++ b/sympy/physics/quantum/tests/test_gate.py
@@ -1,4 +1,5 @@
 from sympy import exp, symbols, sqrt, I, pi, Mul, Integer, Wild
+from sympy.core.compatibility import range
 from sympy.matrices import Matrix
 
 from sympy.physics.quantum.gate import (XGate, YGate, ZGate, random_circuit,

--- a/sympy/physics/quantum/tests/test_matrixutils.py
+++ b/sympy/physics/quantum/tests/test_matrixutils.py
@@ -6,6 +6,7 @@ from sympy.physics.quantum.matrixutils import (
     to_sympy, to_numpy, to_scipy_sparse, matrix_tensor_product,
     matrix_to_zero, matrix_zeros, numpy_ndarray, scipy_sparse_matrix
 )
+from sympy.core.compatibility import range
 
 from sympy.external import import_module
 from sympy.utilities.pytest import skip

--- a/sympy/physics/quantum/tests/test_qft.py
+++ b/sympy/physics/quantum/tests/test_qft.py
@@ -1,5 +1,6 @@
 from sympy import exp, I, Matrix, pi, sqrt, Symbol
 
+from sympy.core.compatibility import range
 from sympy.physics.quantum.qft import QFT, IQFT, RkGate
 from sympy.physics.quantum.gate import (ZGate, SwapGate, HadamardGate, CGate,
                                         PhaseGate, TGate)

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -1,6 +1,7 @@
 import random
 
 from sympy import Integer, Matrix, Rational, sqrt, symbols
+from sympy.core.compatibility import range
 from sympy.physics.quantum.qubit import (measure_all, measure_partial,
                                          matrix_to_qubit, matrix_to_density,
                                          qubit_to_matrix, IntQubit,

--- a/sympy/physics/quantum/tests/test_sho1d.py
+++ b/sympy/physics/quantum/tests/test_sho1d.py
@@ -1,6 +1,7 @@
 """Tests for sho1d.py"""
 
 from sympy import Integer, Symbol, sqrt, I, S
+from sympy.core.compatibility import range
 from sympy.physics.quantum import Dagger
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum import Commutator

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -13,7 +13,7 @@ from sympy import (Add, Basic, cacheit, Dummy, Expr, Function, I,
                    zeros)
 from sympy.printing.str import StrPrinter
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 from sympy.utilities.iterables import has_dups
 from sympy.utilities import default_sort_key
 
@@ -1985,7 +1985,7 @@ class NO(Expr):
 
         """
         ops = self.args[0].args
-        iter = xrange(len(ops) - 1, -1, -1)
+        iter = range(len(ops) - 1, -1, -1)
         for i in iter:
             if ops[i].is_q_annihilator:
                 yield i
@@ -2015,7 +2015,7 @@ class NO(Expr):
         """
 
         ops = self.args[0].args
-        iter = xrange(0, len(ops))
+        iter = range(0, len(ops))
         for i in iter:
             if ops[i].is_q_creator:
                 yield i

--- a/sympy/physics/tests/test_hydrogen.py
+++ b/sympy/physics/tests/test_hydrogen.py
@@ -1,4 +1,5 @@
 from sympy import exp, integrate, oo, S, simplify, sqrt, symbols
+from sympy.core.compatibility import range
 from sympy.physics.hydrogen import R_nl, E_nl, E_nl_dirac
 from sympy.utilities.pytest import raises
 

--- a/sympy/physics/tests/test_pring.py
+++ b/sympy/physics/tests/test_pring.py
@@ -1,4 +1,5 @@
 from sympy.physics.pring import wavefunction, energy
+from sympy.core.compatibility import range
 from sympy import pi, integrate, sqrt, exp, simplify, I
 from sympy.abc import m, x, r
 from sympy.physics.quantum.constants import hbar

--- a/sympy/physics/tests/test_qho_1d.py
+++ b/sympy/physics/tests/test_qho_1d.py
@@ -1,4 +1,5 @@
 from sympy import exp, integrate, oo, Rational, pi, S, simplify, sqrt
+from sympy.core.compatibility import range
 from sympy.abc import omega, m, x
 from sympy.physics.qho_1d import psi_n, E_n
 from sympy.physics.quantum.constants import hbar

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -12,6 +12,7 @@ from sympy.physics.secondquant import (
 from sympy import (Dummy, expand, Function, I, Rational, simplify, sqrt, Sum,
                    Symbol, symbols)
 
+from sympy.core.compatibility import range
 from sympy.utilities.pytest import XFAIL
 
 

--- a/sympy/physics/tests/test_sho.py
+++ b/sympy/physics/tests/test_sho.py
@@ -1,4 +1,5 @@
 from sympy.core import symbols, Rational, Function, diff
+from sympy.core.compatibility import range
 from sympy.physics.sho import R_nl, E_nl
 from sympy import simplify
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -1,6 +1,6 @@
 from sympy import (diff, trigsimp, expand, sin, cos, solve, Symbol, sympify,
                    eye, ImmutableMatrix as Matrix)
-from sympy.core.compatibility import string_types, u
+from sympy.core.compatibility import string_types, u, range
 from sympy.physics.vector.vector import Vector, _check_vector
 
 __all__ = ['CoordinateSym', 'ReferenceFrame']

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division
+from sympy.core.compatibility import range
 from .vector import Vector, _check_vector
 from .frame import _check_frame
 

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -34,6 +34,7 @@ Copyright (C) 2008 Jens Rasch <jyr2000@gmail.com>
 from __future__ import print_function, division
 
 from sympy import Integer, pi, sqrt, sympify
+from sympy.core.compatibility import range
 
 # This list of precomputed factorials is needed to massively
 # accelerate future calculations of the various coefficients

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -30,6 +30,7 @@ import warnings
 
 from sympy import sympify, Expr, Tuple, Dummy, Symbol
 from sympy.external import import_module
+from sympy.core.compatibility import range
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import is_sequence
 from .experimental_lambdify import (vectorized_lambdify, lambdify)

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy import Basic, Symbol, symbols, lambdify
 from util import interpolate, rinterpolate, create_bounds, update_bounds
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 class ColorGradient(object):
@@ -16,8 +16,8 @@ class ColorGradient(object):
         elif len(args) > 0:
             if len(args) % 2 != 0:
                 raise ValueError("len(args) should be even")
-            self.colors = [args[i] for i in xrange(1, len(args), 2)]
-            self.intervals = [args[i] for i in xrange(0, len(args), 2)]
+            self.colors = [args[i] for i in range(1, len(args), 2)]
+            self.intervals = [args[i] for i in range(0, len(args), 2)]
         assert len(self.colors) == len(self.intervals)
 
     def copy(self):
@@ -243,7 +243,7 @@ class ColorScheme(object):
             set_len(len(u_set)*2)
         # calculate f() = r,g,b for each vert
         # and find the min and max for r,g,b
-        for _u in xrange(len(u_set)):
+        for _u in range(len(u_set)):
             if verts[_u] is None:
                 cverts.append(None)
             else:
@@ -257,7 +257,7 @@ class ColorScheme(object):
             if callable(inc_pos):
                 inc_pos()
         # scale and apply gradient
-        for _u in xrange(len(u_set)):
+        for _u in range(len(u_set)):
             if cverts[_u] is not None:
                 for _c in range(3):
                     # scale from [f_min, f_max] to [0,1]
@@ -281,9 +281,9 @@ class ColorScheme(object):
             set_len(len(u_set)*len(v_set)*2)
         # calculate f() = r,g,b for each vert
         # and find the min and max for r,g,b
-        for _u in xrange(len(u_set)):
+        for _u in range(len(u_set)):
             column = list()
-            for _v in xrange(len(v_set)):
+            for _v in range(len(v_set)):
                 if verts[_u][_v] is None:
                     column.append(None)
                 else:
@@ -298,8 +298,8 @@ class ColorScheme(object):
                     inc_pos()
             cverts.append(column)
         # scale and apply gradient
-        for _u in xrange(len(u_set)):
-            for _v in xrange(len(v_set)):
+        for _u in range(len(u_set)):
+            for _v in range(len(v_set)):
                 if cverts[_u][_v] is not None:
                     # scale from [f_min, f_max] to [0,1]
                     for _c in range(3):

--- a/sympy/plotting/pygletplot/plot_axes.py
+++ b/sympy/plotting/pygletplot/plot_axes.py
@@ -8,7 +8,7 @@ from util import strided_range, billboard_matrix
 from util import get_direction_vectors
 from util import dot_product, vec_sub, vec_mag
 from sympy.core import S
-from sympy.core.compatibility import is_sequence
+from sympy.core.compatibility import is_sequence, range
 
 
 class PlotAxes(PlotObject):

--- a/sympy/plotting/pygletplot/plot_curve.py
+++ b/sympy/plotting/pygletplot/plot_curve.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from pyglet.gl import *
 from plot_mode_base import PlotModeBase
 from sympy.core import S
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 class PlotCurve(PlotModeBase):
@@ -67,7 +67,7 @@ class PlotCurve(PlotModeBase):
     def draw_verts(self, use_cverts):
         def f():
             glBegin(GL_LINE_STRIP)
-            for t in xrange(len(self.t_set)):
+            for t in range(len(self.t_set)):
                 p = self.verts[t]
                 if p is None:
                     glEnd()

--- a/sympy/plotting/pygletplot/plot_interval.py
+++ b/sympy/plotting/pygletplot/plot_interval.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Symbol, Integer, sympify
+from sympy.core.compatibility import range
 
 
 class PlotInterval(object):
@@ -158,7 +159,7 @@ class PlotInterval(object):
         v_min to v_max.
         """
         d = (self.v_max - self.v_min) / self.v_steps
-        for i in xrange(self.v_steps + 1):
+        for i in range(self.v_steps + 1):
             a = self.v_min + (d * Integer(i))
             yield a
 
@@ -170,7 +171,7 @@ class PlotInterval(object):
         """
         d = (self.v_max - self.v_min) / self.v_steps
         a = self.v_min + (d * Integer(0))
-        for i in xrange(self.v_steps):
+        for i in range(self.v_steps):
             b = self.v_min + (d * Integer(i + 1))
             yield a, b
             a = b

--- a/sympy/plotting/pygletplot/plot_mode.py
+++ b/sympy/plotting/pygletplot/plot_mode.py
@@ -5,7 +5,7 @@ from plot_interval import PlotInterval
 from plot_object import PlotObject
 from util import parse_option_string
 from sympy.geometry.entity import GeometryEntity
-from sympy.core.compatibility import is_sequence
+from sympy.core.compatibility import is_sequence, range
 
 
 class PlotMode(PlotObject):

--- a/sympy/plotting/pygletplot/plot_surface.py
+++ b/sympy/plotting/pygletplot/plot_surface.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from pyglet.gl import *
 from plot_mode_base import PlotModeBase
 from sympy.core import S
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 class PlotSurface(PlotModeBase):
@@ -75,9 +75,9 @@ class PlotSurface(PlotModeBase):
 
     def draw_verts(self, use_cverts, use_solid_color):
         def f():
-            for u in xrange(1, len(self.u_set)):
+            for u in range(1, len(self.u_set)):
                 glBegin(GL_QUAD_STRIP)
-                for v in xrange(len(self.v_set)):
+                for v in range(len(self.v_set)):
                     pa = self.verts[u - 1][v]
                     pb = self.verts[u][v]
                     if pa is None or pb is None:

--- a/sympy/plotting/pygletplot/util.py
+++ b/sympy/plotting/pygletplot/util.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from pyglet.gl import *
 from sympy.core import S
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def get_model_matrix(array_type=c_float, glGetMethod=glGetFloatv):
@@ -69,7 +69,7 @@ def model_to_screen(x, y, z):
 
 
 def vec_subs(a, b):
-    return tuple(a[i] - b[i] for i in xrange(len(a)))
+    return tuple(a[i] - b[i] for i in range(len(a)))
 
 
 def billboard_matrix():
@@ -141,7 +141,7 @@ def strided_range(r_min, r_max, stride, max_steps=50):
     if abs(r_min - r_max) < 0.001:
         return []
     try:
-        xrange(int(r_min - r_max))
+        range(int(r_min - r_max))
     except TypeError:
         return []
     if r_min > r_max:
@@ -155,7 +155,7 @@ def strided_range(r_min, r_max, stride, max_steps=50):
     r_steps = int((r_max - r_min)/stride)
     if max_steps and r_steps > max_steps:
         return strided_range(o_min, o_max, stride*2)
-    return [r_min] + list(r_min + e*stride for e in xrange(1, r_steps + 1)) + [r_max]
+    return [r_min] + list(r_min + e*stride for e in range(1, r_steps + 1)) + [r_max]
 
 
 def parse_option_string(s):

--- a/sympy/plotting/textplot.py
+++ b/sympy/plotting/textplot.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.symbol import Dummy
+from sympy.core.compatibility import range
 from sympy.utilities.lambdify import lambdify
 
 

--- a/sympy/polys/agca/homomorphisms.py
+++ b/sympy/polys/agca/homomorphisms.py
@@ -11,6 +11,7 @@ from __future__ import print_function, division
 from sympy.polys.agca.modules import (Module, FreeModule, QuotientModule,
     SubModule, SubQuotientModule)
 from sympy.polys.polyerrors import CoercionFailed
+from sympy.core.compatibility import range
 
 # The main computational task for module homomorphisms is kernels.
 # For this reason, the concrete classes are organised by domain module type.

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -26,7 +26,7 @@ from sympy.polys.orderings import ProductOrder, monomial_key
 from sympy.polys.domains.field import Field
 from sympy.polys.agca.ideals import Ideal
 
-from sympy.core.compatibility import iterable, reduce
+from sympy.core.compatibility import iterable, reduce, range
 
 # TODO
 # - module saturation

--- a/sympy/polys/benchmarks/bench_galoispolys.py
+++ b/sympy/polys/benchmarks/bench_galoispolys.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from sympy.polys.galoistools import gf_from_dict, gf_factor_sqf
 from sympy.polys.domains import ZZ
 from sympy import pi, nextprime
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def gathen_poly(n, p, K):
@@ -14,7 +14,7 @@ def gathen_poly(n, p, K):
 
 def shoup_poly(n, p, K):
     f = [K.one] * (n + 1)
-    for i in xrange(1, n + 1):
+    for i in range(1, n + 1):
         f[i] = (f[i - 1]**2 + K.one) % p
     return f
 

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -12,7 +12,7 @@ from sympy.polys.densebasic import (
     dmp_ground, dmp_zeros)
 
 from sympy.polys.polyerrors import (ExactQuotientFailed, PolynomialDivisionFailed)
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 def dup_add_term(f, c, i, K):
     """
@@ -763,10 +763,10 @@ def dup_mul(f, g, K):
     if n < 100:
         h = []
 
-        for i in xrange(0, df + dg + 1):
+        for i in range(0, df + dg + 1):
             coeff = K.zero
 
-            for j in xrange(max(0, i - dg), min(df, i) + 1):
+            for j in range(max(0, i - dg), min(df, i) + 1):
                 coeff += f[j]*g[i - j]
 
             h.append(coeff)
@@ -824,10 +824,10 @@ def dmp_mul(f, g, u, K):
 
     h, v = [], u - 1
 
-    for i in xrange(0, df + dg + 1):
+    for i in range(0, df + dg + 1):
         coeff = dmp_zero(v)
 
-        for j in xrange(max(0, i - dg), min(df, i) + 1):
+        for j in range(max(0, i - dg), min(df, i) + 1):
             coeff = dmp_add(coeff, dmp_mul(f[j], g[i - j], v, K), v, K)
 
         h.append(coeff)
@@ -851,7 +851,7 @@ def dup_sqr(f, K):
     """
     df, h = len(f) - 1, []
 
-    for i in xrange(0, 2*df + 1):
+    for i in range(0, 2*df + 1):
         c = K.zero
 
         jmin = max(0, i - df)
@@ -861,7 +861,7 @@ def dup_sqr(f, K):
 
         jmax = jmin + n // 2 - 1
 
-        for j in xrange(jmin, jmax + 1):
+        for j in range(jmin, jmax + 1):
             c += f[j]*f[i - j]
 
         c += c
@@ -899,7 +899,7 @@ def dmp_sqr(f, u, K):
 
     h, v = [], u - 1
 
-    for i in xrange(0, 2*df + 1):
+    for i in range(0, 2*df + 1):
         c = dmp_zero(v)
 
         jmin = max(0, i - df)
@@ -909,7 +909,7 @@ def dmp_sqr(f, u, K):
 
         jmax = jmin + n // 2 - 1
 
-        for j in xrange(jmin, jmax + 1):
+        for j in range(jmin, jmax + 1):
             c = dmp_add(c, dmp_mul(f[j], f[i - j], v, K), v, K)
 
         c = dmp_mul_ground(c, K(2), v, K)

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -7,7 +7,7 @@ from sympy import oo
 
 from sympy.polys.monomials import monomial_min, monomial_div
 from sympy.polys.orderings import monomial_key
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 import random
 
@@ -735,7 +735,7 @@ def dmp_zero(u):
     """
     r = []
 
-    for i in xrange(u):
+    for i in range(u):
         r = [r]
 
     return r
@@ -823,7 +823,7 @@ def dmp_ground(c, u):
     if not c:
         return dmp_zero(u)
 
-    for i in xrange(u + 1):
+    for i in range(u + 1):
         c = [c]
 
     return c
@@ -851,7 +851,7 @@ def dmp_zeros(n, u, K):
     if u < 0:
         return [K.zero]*n
     else:
-        return [ dmp_zero(u) for i in xrange(n) ]
+        return [ dmp_zero(u) for i in range(n) ]
 
 
 def dmp_grounds(c, n, u):
@@ -876,7 +876,7 @@ def dmp_grounds(c, n, u):
     if u < 0:
         return [c]*n
     else:
-        return [ dmp_ground(c, u) for i in xrange(n) ]
+        return [ dmp_ground(c, u) for i in range(n) ]
 
 
 def dmp_negative_p(f, u, K):
@@ -939,12 +939,12 @@ def dup_from_dict(f, K):
     n, h = max(f.keys()), []
 
     if type(n) is int:
-        for k in xrange(n, -1, -1):
+        for k in range(n, -1, -1):
             h.append(f.get(k, K.zero))
     else:
         (n,) = n
 
-        for k in xrange(n, -1, -1):
+        for k in range(n, -1, -1):
             h.append(f.get((k,), K.zero))
 
     return dup_strip(h)
@@ -969,7 +969,7 @@ def dup_from_raw_dict(f, K):
 
     n, h = max(f.keys()), []
 
-    for k in xrange(n, -1, -1):
+    for k in range(n, -1, -1):
         h.append(f.get(k, K.zero))
 
     return dup_strip(h)
@@ -1008,7 +1008,7 @@ def dmp_from_dict(f, u, K):
 
     n, v, h = max(coeffs.keys()), u - 1, []
 
-    for k in xrange(n, -1, -1):
+    for k in range(n, -1, -1):
         coeff = coeffs.get(k)
 
         if coeff is not None:
@@ -1039,7 +1039,7 @@ def dup_to_dict(f, K=None, zero=False):
 
     n, result = len(f) - 1, {}
 
-    for k in xrange(0, n + 1):
+    for k in range(0, n + 1):
         if f[n - k]:
             result[(k,)] = f[n - k]
 
@@ -1064,7 +1064,7 @@ def dup_to_raw_dict(f, K=None, zero=False):
 
     n, result = len(f) - 1, {}
 
-    for k in xrange(0, n + 1):
+    for k in range(0, n + 1):
         if f[n - k]:
             result[k] = f[n - k]
 
@@ -1097,7 +1097,7 @@ def dmp_to_dict(f, u, K=None, zero=False):
     if n == -oo:
         n = -1
 
-    for k in xrange(0, n + 1):
+    for k in range(0, n + 1):
         h = dmp_to_dict(f[n - k], v)
 
         for exp, coeff in h.items():
@@ -1189,7 +1189,7 @@ def dmp_nest(f, l, K):
     if not isinstance(f, list):
         return dmp_ground(f, l)
 
-    for i in xrange(l):
+    for i in range(l):
         f = [f]
 
     return f
@@ -1248,7 +1248,7 @@ def dup_deflate(f, K):
 
     g = 0
 
-    for i in xrange(len(f)):
+    for i in range(len(f)):
         if not f[-i - 1]:
             continue
 
@@ -1329,7 +1329,7 @@ def dup_multi_deflate(polys, K):
 
         g = 0
 
-        for i in xrange(len(p)):
+        for i in range(len(p)):
             if not p[-i - 1]:
                 continue
 
@@ -1443,7 +1443,7 @@ def _rec_inflate(g, M, v, i, K):
     result = [g[0]]
 
     for coeff in g[1:]:
-        for _ in xrange(1, M[i]):
+        for _ in range(1, M[i]):
             result.append(dmp_zero(w))
 
         result.append(coeff)
@@ -1499,7 +1499,7 @@ def dmp_exclude(f, u, K):
 
     J, F = [], dmp_to_dict(f, u)
 
-    for j in xrange(0, u + 1):
+    for j in range(0, u + 1):
         for monom in F.keys():
             if monom[j]:
                 break
@@ -1876,7 +1876,7 @@ def dup_random(n, a, b, K):
     [-2, -8, 9, -4]
 
     """
-    f = [ K.convert(random.randint(a, b)) for _ in xrange(0, n + 1) ]
+    f = [ K.convert(random.randint(a, b)) for _ in range(0, n + 1) ]
 
     while not f[0]:
         f[0] = K.convert(random.randint(a, b))

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -39,7 +39,7 @@ from sympy.polys.polyerrors import (
 from sympy.utilities import variations
 
 from math import ceil as _ceil, log as _log
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 def dup_integrate(f, m, K):
     """
@@ -65,7 +65,7 @@ def dup_integrate(f, m, K):
     for i, c in enumerate(reversed(f)):
         n = i + 1
 
-        for j in xrange(1, m):
+        for j in range(1, m):
             n *= i + j + 1
 
         g.insert(0, K.exquo(c, K(n)))
@@ -100,7 +100,7 @@ def dmp_integrate(f, m, u, K):
     for i, c in enumerate(reversed(f)):
         n = i + 1
 
-        for j in xrange(1, m):
+        for j in range(1, m):
             n *= i + j + 1
 
         g.insert(0, dmp_quo_ground(c, K(n), v, K))
@@ -174,7 +174,7 @@ def dup_diff(f, m, K):
         for coeff in f[:-m]:
             k = n
 
-            for i in xrange(n - 1, n - m, -1):
+            for i in range(n - 1, n - m, -1):
                 k *= i
 
             deriv.append(K(k)*coeff)
@@ -221,7 +221,7 @@ def dmp_diff(f, m, u, K):
         for coeff in f[:-m]:
             k = n
 
-            for i in xrange(n - 1, n - m, -1):
+            for i in range(n - 1, n - m, -1):
                 k *= i
 
             deriv.append(dmp_mul_ground(coeff, K(k), v, K))
@@ -844,7 +844,7 @@ def dup_mirror(f, K):
     """
     f, n, a = list(f), len(f) - 1, -K.one
 
-    for i in xrange(n - 1, -1, -1):
+    for i in range(n - 1, -1, -1):
         f[i], a = a*f[i], -a
 
     return f
@@ -866,7 +866,7 @@ def dup_scale(f, a, K):
     """
     f, n, b = list(f), len(f) - 1, a
 
-    for i in xrange(n - 1, -1, -1):
+    for i in range(n - 1, -1, -1):
         f[i], b = b*f[i], b*a
 
     return f
@@ -888,8 +888,8 @@ def dup_shift(f, a, K):
     """
     f, n = list(f), len(f) - 1
 
-    for i in xrange(n, 0, -1):
-        for j in xrange(0, i):
+    for i in range(n, 0, -1):
+        for j in range(0, i):
             f[j + 1] += a*f[j]
 
     return f
@@ -915,7 +915,7 @@ def dup_transform(f, p, q, K):
     n = len(f) - 1
     h, Q = [f[0]], [[K.one]]
 
-    for i in xrange(0, n):
+    for i in range(0, n):
         Q.append(dup_mul(Q[-1], q, K))
 
     for c, q in zip(f[1:], Q[1:]):
@@ -994,10 +994,10 @@ def _dup_right_decompose(f, s, K):
 
     r = n // s
 
-    for i in xrange(1, s):
+    for i in range(1, s):
         coeff = K.zero
 
-        for j in xrange(0, i):
+        for j in range(0, i):
             if not n + j - i in f:
                 continue
 
@@ -1032,7 +1032,7 @@ def _dup_decompose(f, K):
     """Helper function for :func:`dup_decompose`."""
     df = len(f) - 1
 
-    for s in xrange(2, df):
+    for s in range(2, df):
         if df % s != 0:
             continue
 
@@ -1283,7 +1283,7 @@ def dup_revert(f, n, K):
 
     N = int(_ceil(_log(n, 2)))
 
-    for i in xrange(1, N + 1):
+    for i in range(1, N + 1):
         a = dup_mul_ground(g, K(2), K)
         b = dup_mul(f, dup_sqr(g, K), K)
         g = dup_rem(dup_sub(a, b, K), h, K)

--- a/sympy/polys/distributedmodules.py
+++ b/sympy/polys/distributedmodules.py
@@ -37,6 +37,7 @@ from sympy.polys.monomials import (
 from sympy.polys.polytools import Poly
 from sympy.polys.polyutils import parallel_dict_from_expr
 from sympy import S, sympify
+from sympy.core.compatibility import range
 
 # Additional monomial tools.
 

--- a/sympy/polys/domains/old_polynomialring.py
+++ b/sympy/polys/domains/old_polynomialring.py
@@ -16,7 +16,7 @@ from sympy.polys.orderings import monomial_key, build_product_order
 
 from sympy.polys.agca.modules import FreeModulePolyRing
 
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, range
 from sympy.utilities import public
 
 # XXX why does this derive from CharacteristicZero???

--- a/sympy/polys/domains/tests/test_quotientring.py
+++ b/sympy/polys/domains/tests/test_quotientring.py
@@ -6,6 +6,7 @@ from sympy.abc import x, y
 from sympy.polys.polyerrors import NotReversible
 
 from sympy.utilities.pytest import raises
+from sympy.core.compatibility import range
 
 
 def test_QuotientRingElement():

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -52,7 +52,7 @@ from sympy.polys.polyconfig import query
 
 from sympy.ntheory import nextprime
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def dup_half_gcdex(f, g, K):
@@ -1203,7 +1203,7 @@ def dup_zz_heu_gcd(f, g, K):
             2*min(f_norm // abs(dup_LC(f, K)),
                   g_norm // abs(dup_LC(g, K))) + 2)
 
-    for i in xrange(0, HEU_GCD_MAX):
+    for i in range(0, HEU_GCD_MAX):
         ff = dup_eval(f, x, K)
         gg = dup_eval(g, x, K)
 
@@ -1328,7 +1328,7 @@ def dmp_zz_heu_gcd(f, g, u, K):
             2*min(f_norm // abs(dmp_ground_LC(f, u, K)),
                   g_norm // abs(dmp_ground_LC(g, u, K))) + 2)
 
-    for i in xrange(0, HEU_GCD_MAX):
+    for i in range(0, HEU_GCD_MAX):
         ff = dmp_eval(f, x, u, K)
         gg = dmp_eval(g, x, u, K)
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -76,7 +76,7 @@ from sympy.utilities import subsets
 
 from math import ceil as _ceil, log as _log
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def dup_trial_division(f, factors, K):
@@ -276,7 +276,7 @@ def dup_zz_zassenhaus(f, K):
     # choose a prime number `p` such that `f` be square free in Z_p
     # if there are many factors in Z_p, choose among a few different `p`
     # the one with fewer factors
-    for px in xrange(3, bound + 1):
+    for px in range(3, bound + 1):
         if not isprime(px) or b % px == 0:
             continue
 
@@ -419,10 +419,10 @@ def dup_cyclotomic_p(f, K, irreducible=False):
     n = dup_degree(f)
     g, h = [], []
 
-    for i in xrange(n, -1, -2):
+    for i in range(n, -1, -2):
         g.insert(0, f[i])
 
-    for i in xrange(n - 1, -1, -2):
+    for i in range(n - 1, -1, -2):
         h.insert(0, f[i])
 
     g = dup_sqr(dup_strip(g), K)
@@ -470,7 +470,7 @@ def _dup_cyclotomic_decompose(n, K):
         Q = [ dup_quo(dup_inflate(h, p, K), h, K) for h in H ]
         H.extend(Q)
 
-        for i in xrange(1, k):
+        for i in range(1, k):
             Q = [ dup_inflate(q, p, K) for q in Q ]
             H.extend(Q)
 
@@ -676,7 +676,7 @@ def dmp_zz_wang_lead_coeffs(f, T, cs, E, H, A, u, K):
         c = dmp_one(v, K)
         d = dup_LC(h, K)*cs
 
-        for i in reversed(xrange(len(E))):
+        for i in reversed(range(len(E))):
             k, e, (t, _) = 0, E[i], T[i]
 
             while not (d % e):
@@ -811,7 +811,7 @@ def dmp_zz_diophantine(F, c, A, d, p, u, K):
         m = dmp_nest([K.one, -a], n, K)
         M = dmp_one(n, K)
 
-        for k in K.map(xrange(0, d)):
+        for k in K.map(range(0, d)):
             if dmp_zero_p(c, u):
                 break
 
@@ -850,7 +850,7 @@ def dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K):
 
     d = max(dmp_degree_list(f, u)[1:])
 
-    for j, s, a in zip(xrange(2, n + 2), S, A):
+    for j, s, a in zip(range(2, n + 2), S, A):
         G, w = list(H), j - 1
 
         I, J = A[:j - 2], A[j - 1:]
@@ -866,7 +866,7 @@ def dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K):
 
         dj = dmp_degree_in(s, w, w)
 
-        for k in K.map(xrange(0, dj)):
+        for k in K.map(range(0, dj)):
             if dmp_zero_p(c, w):
                 break
 
@@ -956,8 +956,8 @@ def dmp_zz_wang(f, u, K, mod=None, seed=None):
     eez_mod_step = query('EEZ_MODULUS_STEP')
 
     while len(configs) < eez_num_configs:
-        for _ in xrange(eez_num_tries):
-            A = [ K(randint(-mod, mod)) for _ in xrange(u) ]
+        for _ in range(eez_num_tries):
+            A = [ K(randint(-mod, mod)) for _ in range(u) ]
 
             if tuple(A) not in history:
                 history.add(tuple(A))

--- a/sympy/polys/fglmtools.py
+++ b/sympy/polys/fglmtools.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.polys.monomials import monomial_mul, monomial_div
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 def matrix_fglm(F, ring, O_to):
     """
@@ -31,7 +31,7 @@ def matrix_fglm(F, ring, O_to):
     V = [[domain.one] + [domain.zero] * (len(old_basis) - 1)]
     G = []
 
-    L = [(i, 0) for i in xrange(ngens)]  # (i, j) corresponds to x_i * S[j]
+    L = [(i, 0) for i in range(ngens)]  # (i, j) corresponds to x_i * S[j]
     L.sort(key=lambda k_l: O_to(_incr_k(S[k_l[1]], k_l[0])), reverse=True)
     t = L.pop()
 
@@ -42,10 +42,10 @@ def matrix_fglm(F, ring, O_to):
         v = _matrix_mul(M[t[0]], V[t[1]])
         _lambda = _matrix_mul(P, v)
 
-        if all(_lambda[i] == domain.zero for i in xrange(s, len(old_basis))):
+        if all(_lambda[i] == domain.zero for i in range(s, len(old_basis))):
             # there is a linear combination of v by V
             lt = ring.term_new(_incr_k(S[t[1]], t[0]), domain.one)
-            rest = ring.from_dict(dict([ (S[i], _lambda[i]) for i in xrange(s) ]))
+            rest = ring.from_dict(dict([ (S[i], _lambda[i]) for i in range(s) ]))
 
             g = (lt - rest).set_ring(ring_to)
             if g:
@@ -56,7 +56,7 @@ def matrix_fglm(F, ring, O_to):
             S.append(_incr_k(S[t[1]], t[0]))
             V.append(v)
 
-            L.extend([(i, s) for i in xrange(ngens)])
+            L.extend([(i, s) for i in range(ngens)])
             L = list(set(L))
             L.sort(key=lambda k_l: O_to(_incr_k(S[k_l[1]], k_l[0])), reverse=True)
 
@@ -74,29 +74,29 @@ def _incr_k(m, k):
 
 
 def _identity_matrix(n, domain):
-    M = [[domain.zero]*n for _ in xrange(n)]
+    M = [[domain.zero]*n for _ in range(n)]
 
-    for i in xrange(n):
+    for i in range(n):
         M[i][i] = domain.one
 
     return M
 
 
 def _matrix_mul(M, v):
-    return [sum([row[i] * v[i] for i in xrange(len(v))]) for row in M]
+    return [sum([row[i] * v[i] for i in range(len(v))]) for row in M]
 
 
 def _update(s, _lambda, P):
     """
     Update ``P`` such that for the updated `P'` `P' v = e_{s}`.
     """
-    k = min([j for j in xrange(s, len(_lambda)) if _lambda[j] != 0])
+    k = min([j for j in range(s, len(_lambda)) if _lambda[j] != 0])
 
-    for r in xrange(len(_lambda)):
+    for r in range(len(_lambda)):
         if r != k:
-            P[r] = [P[r][j] - (P[k][j] * _lambda[r]) / _lambda[k] for j in xrange(len(P[r]))]
+            P[r] = [P[r][j] - (P[k][j] * _lambda[r]) / _lambda[k] for j in range(len(P[r]))]
 
-    P[k] = [P[k][j] / _lambda[k] for j in xrange(len(P[k]))]
+    P[k] = [P[k][j] / _lambda[k] for j in range(len(P[k]))]
     P[k], P[s] = P[s], P[k]
 
     return P
@@ -114,7 +114,7 @@ def _representing_matrices(basis, G, ring):
         return tuple([0] * i + [1] + [0] * (u - i))
 
     def representing_matrix(m):
-        M = [[domain.zero] * len(basis) for _ in xrange(len(basis))]
+        M = [[domain.zero] * len(basis) for _ in range(len(basis))]
 
         for i, v in enumerate(basis):
             r = ring.term_new(monomial_mul(m, v), domain.one).rem(G)
@@ -125,7 +125,7 @@ def _representing_matrices(basis, G, ring):
 
         return M
 
-    return [representing_matrix(var(i)) for i in xrange(u + 1)]
+    return [representing_matrix(var(i)) for i in range(u + 1)]
 
 
 def _basis(G, ring):
@@ -144,7 +144,7 @@ def _basis(G, ring):
         t = candidates.pop()
         basis.append(t)
 
-        new_candidates = [_incr_k(t, k) for k in xrange(ring.ngens)
+        new_candidates = [_incr_k(t, k) for k in range(ring.ngens)
             if all(monomial_div(_incr_k(t, k), lmg) is None
             for lmg in leading_monomials)]
         candidates.extend(new_candidates)

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from random import uniform
 from math import ceil as _ceil, sqrt as _sqrt
 
-from sympy.core.compatibility import SYMPY_INTS, xrange
+from sympy.core.compatibility import SYMPY_INTS, range
 from sympy.core.mul import prod
 from sympy.polys.polyutils import _sort_factors
 from sympy.polys.polyconfig import query
@@ -265,12 +265,12 @@ def gf_from_dict(f, p, K):
     n, h = max(f.keys()), []
 
     if isinstance(n, SYMPY_INTS):
-        for k in xrange(n, -1, -1):
+        for k in range(n, -1, -1):
             h.append(f.get(k, K.zero) % p)
     else:
         (n,) = n
 
-        for k in xrange(n, -1, -1):
+        for k in range(n, -1, -1):
             h.append(f.get((k,), K.zero) % p)
 
     return gf_trunc(h, p)
@@ -293,7 +293,7 @@ def gf_to_dict(f, p, symmetric=True):
     """
     n, result = gf_degree(f), {}
 
-    for k in xrange(0, n + 1):
+    for k in range(0, n + 1):
         if symmetric:
             a = gf_int(f[n - k], p)
         else:
@@ -544,10 +544,10 @@ def gf_mul(f, g, p, K):
     dh = df + dg
     h = [0]*(dh + 1)
 
-    for i in xrange(0, dh + 1):
+    for i in range(0, dh + 1):
         coeff = K.zero
 
-        for j in xrange(max(0, i - dg), min(i, df) + 1):
+        for j in range(max(0, i - dg), min(i, df) + 1):
             coeff += f[j]*g[i - j]
 
         h[i] = coeff % p
@@ -574,7 +574,7 @@ def gf_sqr(f, p, K):
     dh = 2*df
     h = [0]*(dh + 1)
 
-    for i in xrange(0, dh + 1):
+    for i in range(0, dh + 1):
         coeff = K.zero
 
         jmin = max(0, i - df)
@@ -584,7 +584,7 @@ def gf_sqr(f, p, K):
 
         jmax = jmin + n // 2 - 1
 
-        for j in xrange(jmin, jmax + 1):
+        for j in range(jmin, jmax + 1):
             coeff += f[j]*f[i - j]
 
         coeff += coeff
@@ -698,10 +698,10 @@ def gf_div(f, g, p, K):
 
     h, dq, dr = list(f), df - dg, dg - 1
 
-    for i in xrange(0, df + 1):
+    for i in range(0, df + 1):
         coeff = h[i]
 
-        for j in xrange(max(0, dg - i), min(df - i, dr) + 1):
+        for j in range(max(0, dg - i), min(df - i, dr) + 1):
             coeff -= h[i + j - dg] * g[dg - j]
 
         if i <= dq:
@@ -757,10 +757,10 @@ def gf_quo(f, g, p, K):
 
     h, dq, dr = f[:], df - dg, dg - 1
 
-    for i in xrange(0, dq + 1):
+    for i in range(0, dq + 1):
         coeff = h[i]
 
-        for j in xrange(max(0, dg - i), min(df - i, dr) + 1):
+        for j in range(max(0, dg - i), min(df - i, dr) + 1):
             coeff -= h[i + j - dg] * g[dg - j]
 
         h[i] = (coeff * inv) % p
@@ -1373,7 +1373,7 @@ def gf_random(n, p, K):
     [1, 2, 3, 2, 1, 1, 1, 2, 0, 4, 2]
 
     """
-    return [K.one] + [ K(int(uniform(0, p))) for i in xrange(0, n) ]
+    return [K.one] + [ K(int(uniform(0, p))) for i in range(0, n) ]
 
 
 def gf_irreducible(n, p, K):
@@ -1420,7 +1420,7 @@ def gf_irred_p_ben_or(f, p, K):
     if n < 5:
         H = h = gf_pow_mod([K.one, K.zero], p, f, p, K)
 
-        for i in xrange(0, n//2):
+        for i in range(0, n//2):
             g = gf_sub(h, [K.one, K.zero], p, K)
 
             if gf_gcd(f, g, p, K) == [K.one]:
@@ -1430,7 +1430,7 @@ def gf_irred_p_ben_or(f, p, K):
     else:
         b = gf_frobenius_monomial_base(f, p, K)
         H = h = gf_frobenius_map([K.one, K.zero], f, b, p, K)
-        for i in xrange(0, n//2):
+        for i in range(0, n//2):
             g = gf_sub(h, [K.one, K.zero], p, K)
             if gf_gcd(f, g, p, K) == [K.one]:
                 h = gf_frobenius_map(h, f, b, p, K)
@@ -1470,7 +1470,7 @@ def gf_irred_p_rabin(f, p, K):
     b = gf_frobenius_monomial_base(f, p, K)
     h = b[1]
 
-    for i in xrange(1, n):
+    for i in range(1, n):
         if i in indices:
             g = gf_sub(h, x, p, K)
 
@@ -1637,7 +1637,7 @@ def gf_sqf_list(f, p, K, all=False):
         if not sqf:
             d = gf_degree(f) // r
 
-            for i in xrange(0, d + 1):
+            for i in range(0, d + 1):
                 f[i] = f[i*r]
 
             f, n = f[:d + 1], n*r
@@ -1676,10 +1676,10 @@ def gf_Qmatrix(f, p, K):
     q = [K.one] + [K.zero]*(n - 1)
     Q = [list(q)] + [[]]*(n - 1)
 
-    for i in xrange(1, (n - 1)*r + 1):
+    for i in range(1, (n - 1)*r + 1):
         qq, c = [(-q[-1]*f[-1]) % p], q[-1]
 
-        for j in xrange(1, n):
+        for j in range(1, n):
             qq.append((q[j - 1] - c*f[-j - 1]) % p)
 
         if not (i % r):
@@ -1709,11 +1709,11 @@ def gf_Qbasis(Q, p, K):
     """
     Q, n = [ list(q) for q in Q ], len(Q)
 
-    for k in xrange(0, n):
+    for k in range(0, n):
         Q[k][k] = (Q[k][k] - K.one) % p
 
-    for k in xrange(0, n):
-        for i in xrange(k, n):
+    for k in range(0, n):
+        for i in range(k, n):
             if Q[k][i]:
                 break
         else:
@@ -1721,23 +1721,23 @@ def gf_Qbasis(Q, p, K):
 
         inv = K.invert(Q[k][i], p)
 
-        for j in xrange(0, n):
+        for j in range(0, n):
             Q[j][i] = (Q[j][i]*inv) % p
 
-        for j in xrange(0, n):
+        for j in range(0, n):
             t = Q[j][k]
             Q[j][k] = Q[j][i]
             Q[j][i] = t
 
-        for i in xrange(0, n):
+        for i in range(0, n):
             if i != k:
                 q = Q[k][i]
 
-                for j in xrange(0, n):
+                for j in range(0, n):
                     Q[j][i] = (Q[j][i] - Q[j][k]*q) % p
 
-    for i in xrange(0, n):
-        for j in xrange(0, n):
+    for i in range(0, n):
+        for j in range(0, n):
             if i == j:
                 Q[i][j] = (K.one - Q[i][j]) % p
             else:
@@ -1774,7 +1774,7 @@ def gf_berlekamp(f, p, K):
 
     factors = [f]
 
-    for k in xrange(1, len(V)):
+    for k in range(1, len(V)):
         for f in list(factors):
             s = K.zero
 
@@ -1893,7 +1893,7 @@ def gf_edf_zassenhaus(f, n, p, K):
         if p == 2:
             h = r
 
-            for i in xrange(0, 2**(n*N - 1)):
+            for i in range(0, 2**(n*N - 1)):
                 r = gf_pow_mod(r, 2, f, p, K)
                 h = gf_add(h, r, p, K)
 
@@ -1948,14 +1948,14 @@ def gf_ddf_shoup(f, p, K):
     # U[i] = x**(p**i)
     U = [[K.one, K.zero], h] + [K.zero]*(k - 1)
 
-    for i in xrange(2, k + 1):
+    for i in range(2, k + 1):
         U[i] = gf_frobenius_map(U[i-1], f, b, p, K)
 
     h, U = U[k], U[:k]
     # V[i] = x**(p**(k*(i+1)))
     V = [h] + [K.zero]*(k - 1)
 
-    for i in xrange(1, k):
+    for i in range(1, k):
         V[i] = gf_compose_mod(V[i - 1], h, f, p, K)
 
     factors = []

--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -7,7 +7,7 @@ from sympy.polys.orderings import lex
 from sympy.polys.polyerrors import DomainError
 from sympy.polys.polyconfig import query
 from sympy.core.symbol import Dummy
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 def groebner(seq, ring, method=None):
     """
@@ -609,7 +609,7 @@ def _f5b(F, ring):
         F = B
         B = []
 
-        for i in xrange(len(F)):
+        for i in range(len(F)):
             p = F[i]
             r = p.rem(F[:i])
 
@@ -620,11 +620,11 @@ def _f5b(F, ring):
             break
 
     # basis
-    B = [lbp(sig(ring.zero_monom, i + 1), F[i], i + 1) for i in xrange(len(F))]
+    B = [lbp(sig(ring.zero_monom, i + 1), F[i], i + 1) for i in range(len(F))]
     B.sort(key=lambda f: order(Polyn(f).LM), reverse=True)
 
     # critical pairs
-    CP = [critical_pair(B[i], B[j], ring) for i in xrange(len(B)) for j in xrange(i + 1, len(B))]
+    CP = [critical_pair(B[i], B[j], ring) for i in range(len(B)) for j in range(i + 1, len(B))]
     CP.sort(key=lambda cp: cp_key(cp, ring), reverse=True)
 
     k = len(B)
@@ -731,8 +731,8 @@ def is_groebner(G, ring):
     """
     Check if G is a Groebner basis.
     """
-    for i in xrange(len(G)):
-        for j in xrange(i + 1, len(G)):
+    for i in range(len(G)):
+        for j in range(i + 1, len(G)):
             s = spoly(G[i], G[j])
             s = s.rem(G)
             if s:

--- a/sympy/polys/heuristicgcd.py
+++ b/sympy/polys/heuristicgcd.py
@@ -1,7 +1,7 @@
 """Heuristic polynomial GCD algorithm (HEUGCD). """
 
 from __future__ import print_function, division
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 from .polyerrors import HeuristicGCDFailed
 
 HEU_GCD_MAX = 6
@@ -71,7 +71,7 @@ def heugcd(f, g):
             2*min(f_norm // abs(f.LC),
                   g_norm // abs(g.LC)) + 2)
 
-    for i in xrange(0, HEU_GCD_MAX):
+    for i in range(0, HEU_GCD_MAX):
         ff = f.evaluate(x0, x)
         gg = g.evaluate(x0, x)
 

--- a/sympy/polys/modulargcd.py
+++ b/sympy/polys/modulargcd.py
@@ -6,7 +6,7 @@ from sympy.polys.galoistools import (
 from sympy.polys.polyerrors import ModularGCDFailed
 from sympy.polys.domains import PolynomialRing
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 from mpmath import sqrt
 from sympy import Dummy
 import random
@@ -148,7 +148,7 @@ def _chinese_remainder_reconstruction_univariate(hp, hq, p, q):
     x = hp.ring.gens[0]
     hpq = hp.ring.zero
 
-    for i in xrange(n+1):
+    for i in range(n+1):
         hpq[(i,)] = crt([p, q], [hp.coeff(x**i), hq.coeff(x**i)], symmetric=True)[0]
 
     hpq.strip_zero()
@@ -522,7 +522,7 @@ def _degree_bound_bivariate(f, g):
     # polynomial in Z_p[y]
     delta = _gf_gcd(_LC(fp), _LC(gp), p)
 
-    for a in xrange(p):
+    for a in range(p):
         if not delta.evaluate(0, a) % p:
             continue
         fpa = fp.evaluate(1, a).trunc_ground(p)
@@ -840,7 +840,7 @@ def modgcd_bivariate(f, g):
         hpeval = []
         unlucky = False
 
-        for a in xrange(p):
+        for a in range(p):
             deltaa = delta.evaluate(0, a)
             if not deltaa % p:
                 continue
@@ -997,7 +997,7 @@ def _modgcd_multivariate_p(f, g, p, degbound, contbound):
 
     evaltest = delta
 
-    for i in xrange(k-1):
+    for i in range(k-1):
         evaltest *= _gf_gcd(_LC(_swap(f, i)), _LC(_swap(g, i)), p)
 
     degdelta = delta.degree()
@@ -1157,7 +1157,7 @@ def modgcd_multivariate(f, g):
     gamma = ring.domain.gcd(f.LC, g.LC)
 
     badprimes = ring.domain.one
-    for i in xrange(k):
+    for i in range(k):
         badprimes *= ring.domain.gcd(_swap(f, i).LC, _swap(g, i).LC)
 
     degbound = [min(fdeg, gdeg) for fdeg, gdeg in zip(f.degrees(), g.degrees())]
@@ -2033,7 +2033,7 @@ def _to_ZZ_poly(f, ring):
             m = m.mul_monom(monom[1:])
         n = len(coeff)
 
-        for i in xrange(n):
+        for i in range(n):
             if coeff[i]:
                 c = domain(coeff[i] * den) * m
 
@@ -2116,7 +2116,7 @@ def _primitive_in_x0(f):
     `\mathbb Q(\alpha)[x_0, x_1, \ldots, x_{n-1}] \cong \mathbb Q(\alpha)[x_1, \ldots, x_{n-1}][x_0]`.
     """
     fring = f.ring
-    ring = fring.drop_to_ground(*xrange(1, fring.ngens))
+    ring = fring.drop_to_ground(*range(1, fring.ngens))
     dom = ring.domain.ring
     f_ = ring(f.as_expr())
     cont = dom.zero
@@ -2262,7 +2262,7 @@ def func_field_modgcd(f, g):
         contx0g, g = _primitive_in_x0(g)
         contx0h = func_field_modgcd(contx0f, contx0g)[0]
 
-        ZZring_ = ZZring.drop_to_ground(*xrange(1, n))
+        ZZring_ = ZZring.drop_to_ground(*range(1, n))
 
         f_ = _to_ZZ_poly(f, ZZring_)
         g_ = _to_ZZ_poly(g, ZZring_)

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from textwrap import dedent
 
 from sympy.core import S, C, Mul, Tuple, sympify
-from sympy.core.compatibility import exec_, iterable, xrange
+from sympy.core.compatibility import exec_, iterable, range
 from sympy.polys.polyutils import PicklableWithSlots, dict_from_expr
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.utilities import public
@@ -286,7 +286,7 @@ class MonomialOps(object):
         return ns[name]
 
     def _vars(self, name):
-        return [ "%s%s" % (name, i) for i in xrange(self.ngens) ]
+        return [ "%s%s" % (name, i) for i in range(self.ngens) ]
 
     def mul(self):
         name = "monomial_mul"
@@ -353,7 +353,7 @@ class MonomialOps(object):
         """)
         A = self._vars("a")
         B = self._vars("b")
-        RAB = [ "r%(i)s = a%(i)s - b%(i)s\n    if r%(i)s < 0: return None" % dict(i=i) for i in xrange(self.ngens) ]
+        RAB = [ "r%(i)s = a%(i)s - b%(i)s\n    if r%(i)s < 0: return None" % dict(i=i) for i in range(self.ngens) ]
         R = self._vars("r")
         code = template % dict(name=name, A=", ".join(A), B=", ".join(B), RAB="\n    ".join(RAB), R=", ".join(R))
         return self._build(code, name)
@@ -482,7 +482,7 @@ class Monomial(PicklableWithSlots):
         elif n > 0:
             exponents = self.exponents
 
-            for i in xrange(1, n):
+            for i in range(1, n):
                 exponents = monomial_mul(exponents, self.exponents)
 
             return self.rebuild(exponents)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -47,7 +47,7 @@ from sympy.ntheory.factor_ import divisors
 from mpmath import pslq, mp
 
 from sympy.core.compatibility import reduce
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def _choose_factor(factors, x, v, dom=QQ, prec=200, bound=5):
@@ -927,7 +927,7 @@ def field_isomorphism_pslq(a, b):
         A = a.root.evalf(n)
         B = b.root.evalf(n)
 
-        basis = [1, B] + [ B**i for i in xrange(2, m) ] + [A]
+        basis = [1, B] + [ B**i for i in range(2, m) ] + [A]
 
         dps, mp.dps = mp.dps, n
         coeffs = pslq(basis, maxcoeff=int(1e10), maxsteps=1000)

--- a/sympy/polys/orthopolys.py
+++ b/sympy/polys/orthopolys.py
@@ -16,14 +16,14 @@ from sympy.polys.densearith import (
 
 from sympy.polys.domains import ZZ, QQ
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def dup_jacobi(n, a, b, K):
     """Low-level implementation of Jacobi polynomials. """
     seq = [[K.one], [(a + b + K(2))/K(2), (a - b)/K(2)]]
 
-    for i in xrange(2, n + 1):
+    for i in range(2, n + 1):
         den = K(i)*(a + b + i)*(a + b + K(2)*i - K(2))
         f0 = (a + b + K(2)*i - K.one) * (a*a - b*b) / (K(2)*den)
         f1 = (a + b + K(2)*i - K.one) * (a + b + K(2)*i - K(2)) * (a + b + K(2)*i) / (K(2)*den)
@@ -60,7 +60,7 @@ def dup_gegenbauer(n, a, K):
     """Low-level implementation of Gegenbauer polynomials. """
     seq = [[K.one], [K(2)*a, K.zero]]
 
-    for i in xrange(2, n + 1):
+    for i in range(2, n + 1):
         f1 = K(2) * (i + a - K.one) / i
         f2 = (i + K(2)*a - K(2)) / i
         p1 = dup_mul_ground(dup_lshift(seq[-1], 1, K), f1, K)
@@ -94,7 +94,7 @@ def dup_chebyshevt(n, K):
     """Low-level implementation of Chebyshev polynomials of the 1st kind. """
     seq = [[K.one], [K.one, K.zero]]
 
-    for i in xrange(2, n + 1):
+    for i in range(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2), K)
         seq.append(dup_sub(a, seq[-2], K))
 
@@ -125,7 +125,7 @@ def dup_chebyshevu(n, K):
     """Low-level implementation of Chebyshev polynomials of the 2nd kind. """
     seq = [[K.one], [K(2), K.zero]]
 
-    for i in xrange(2, n + 1):
+    for i in range(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2), K)
         seq.append(dup_sub(a, seq[-2], K))
 
@@ -156,7 +156,7 @@ def dup_hermite(n, K):
     """Low-level implementation of Hermite polynomials. """
     seq = [[K.one], [K(2), K.zero]]
 
-    for i in xrange(2, n + 1):
+    for i in range(2, n + 1):
         a = dup_lshift(seq[-1], 1, K)
         b = dup_mul_ground(seq[-2], K(i - 1), K)
 
@@ -190,7 +190,7 @@ def dup_legendre(n, K):
     """Low-level implementation of Legendre polynomials. """
     seq = [[K.one], [K.one, K.zero]]
 
-    for i in xrange(2, n + 1):
+    for i in range(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2*i - 1, i), K)
         b = dup_mul_ground(seq[-2], K(i - 1, i), K)
 
@@ -222,7 +222,7 @@ def dup_laguerre(n, alpha, K):
     """Low-level implementation of Laguerre polynomials. """
     seq = [[K.zero], [K.one]]
 
-    for i in xrange(1, n + 1):
+    for i in range(1, n + 1):
         a = dup_mul(seq[-1], [-K.one/i, alpha/i + K(2*i - 1)/i], K)
         b = dup_mul_ground(seq[-2], alpha/i + K(i - 1)/i, K)
 
@@ -260,7 +260,7 @@ def dup_spherical_bessel_fn(n, K):
     """ Low-level implementation of fn(n, x) """
     seq = [[K.one], [K.one, K.zero]]
 
-    for i in xrange(2, n + 1):
+    for i in range(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2*i - 1), K)
         seq.append(dup_sub(a, seq[-2], K))
 
@@ -271,7 +271,7 @@ def dup_spherical_bessel_fn_minus(n, K):
     """ Low-level implementation of fn(-n, x) """
     seq = [[K.one, K.zero], [K.zero]]
 
-    for i in xrange(2, n + 1):
+    for i in range(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(3 - 2*i), K)
         seq.append(dup_sub(a, seq[-2], K))
 

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -10,7 +10,7 @@ from sympy.polys.polyerrors import PolynomialError
 from sympy.core import S, Add, sympify, Function, Lambda, Dummy
 from sympy.core.basic import preorder_traversal
 from sympy.utilities import numbered_symbols, take, xthreaded, public
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 @xthreaded
 @public
@@ -159,7 +159,7 @@ def apart_undetermined_coeffs(P, Q):
     for f, k in factors:
         n, q = f.degree(), Q
 
-        for i in xrange(1, k + 1):
+        for i in range(1, k + 1):
             coeffs, q = take(X, n), q.quo(f)
             partial.append((coeffs, q, f, i))
             symbols.extend(coeffs)

--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -17,7 +17,7 @@ from sympy.utilities import numbered_symbols, take, public
 
 from sympy.core import S, Basic, Add, Mul
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 @public
@@ -86,7 +86,7 @@ def symmetrize(F, *gens, **args):
     polys, symbols = [], opt.symbols
     gens, dom = opt.gens, opt.domain
 
-    for i in xrange(0, len(gens)):
+    for i in range(0, len(gens)):
         poly = symmetric_poly(i + 1, gens, polys=True)
         polys.append((next(symbols), poly.set_domain(dom)))
 

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -25,7 +25,7 @@ from sympy.polys.rationaltools import together
 from sympy.simplify import simplify, powsimp
 from sympy.utilities import public
 
-from sympy.core.compatibility import reduce, xrange
+from sympy.core.compatibility import reduce, range
 
 
 def roots_linear(f):
@@ -450,7 +450,7 @@ def roots_cyclotomic(f, factor=False):
     """Compute roots of cyclotomic polynomials. """
     L, U = _inv_totient_estimate(f.degree())
 
-    for n in xrange(L, U + 1):
+    for n in range(L, U + 1):
         g = cyclotomic_poly(n, f.gen, polys=True)
 
         if f == g:
@@ -464,7 +464,7 @@ def roots_cyclotomic(f, factor=False):
         # get the indices in the right order so the computed
         # roots will be sorted
         h = n//2
-        ks = [i for i in xrange(1, n + 1) if igcd(i, n) == 1]
+        ks = [i for i in range(1, n + 1) if igcd(i, n) == 1]
         ks.sort(key=lambda x: (x, -1) if x <= h else (abs(x - n), 1))
         d = 2*I*pi/n
         for k in reversed(ks):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -55,7 +55,7 @@ from sympy.polys.constructor import construct_domain
 
 from sympy.polys import polyoptions as options
 
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, range
 
 
 @public

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -9,7 +9,7 @@ from sympy.core.exprtools import decompose_power
 
 from sympy.core import S, Add, Mul, Pow, expand_mul, expand_multinomial
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 import re
 
@@ -394,7 +394,7 @@ def _dict_reorder(rep, gens, new_gens):
     monoms = rep.keys()
     coeffs = rep.values()
 
-    new_monoms = [ [] for _ in xrange(len(rep)) ]
+    new_monoms = [ [] for _ in range(len(rep)) ]
     used_indices = set()
 
     for gen in new_gens:

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -5,7 +5,7 @@ from sympy.polys.rings import PolyElement
 from sympy.polys.monomials import monomial_min, monomial_mul
 from mpmath.libmp.libintmath import ifac
 from sympy.core.numbers import Rational
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, range
 from mpmath.libmp.libintmath import giant_steps
 import math
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -9,7 +9,7 @@ from sympy.core.expr import Expr
 from sympy.core.symbol import Symbol, symbols as _symbols
 from sympy.core.numbers import igcd, oo
 from sympy.core.sympify import CantSympify, sympify
-from sympy.core.compatibility import is_sequence, reduce, string_types, xrange
+from sympy.core.compatibility import is_sequence, reduce, string_types, range
 from sympy.ntheory.multinomial import multinomial_coefficients
 from sympy.polys.monomials import MonomialOps
 from sympy.polys.orderings import lex
@@ -239,7 +239,7 @@ class PolyRing(DefaultPrinting, IPolys):
         """Return a list of polynomial generators. """
         one = self.domain.one
         _gens = []
-        for i in xrange(self.ngens):
+        for i in range(self.ngens):
             expv = self.monomial_basis(i)
             poly = self.zero
             poly[expv] = one
@@ -759,7 +759,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
                 else:
                     scoeff = ''
             sexpv = []
-            for i in xrange(ngens):
+            for i in range(ngens):
                 exp = expv[i]
                 if not exp:
                     continue

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -30,7 +30,7 @@ from sympy.polys.polyerrors import (
     RefinementFailed,
     DomainError)
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def dup_sturm(f, K):
@@ -87,13 +87,13 @@ def dup_root_upper_bound(f, K):
         f = dup_neg(f, K)
     f = list(reversed(f))
 
-    for i in xrange(0, n):
+    for i in range(0, n):
         if f[i] >= 0:
             continue
 
         a, QL = K.log(-f[i], 2), []
 
-        for j in xrange(i + 1, n):
+        for j in range(i + 1, n):
 
             if f[j] <= 0:
                 continue
@@ -212,7 +212,7 @@ def dup_inner_refine_real_root(f, M, K, eps=None, steps=None, disjoint=None, fas
             d), K, fast=fast)
 
     if eps is not None and steps is not None:
-        for i in xrange(0, steps):
+        for i in range(0, steps):
             if abs(F(a, c) - F(b, d)) >= eps:
                 f, (a, b, c, d) = dup_step_refine_real_root(f, (a, b, c, d), K, fast=fast)
             else:
@@ -223,7 +223,7 @@ def dup_inner_refine_real_root(f, M, K, eps=None, steps=None, disjoint=None, fas
                 f, (a, b, c, d) = dup_step_refine_real_root(f, (a, b, c, d), K, fast=fast)
 
         if steps is not None:
-            for i in xrange(0, steps):
+            for i in range(0, steps):
                 f, (a, b, c, d) = dup_step_refine_real_root(f, (a, b, c, d), K, fast=fast)
 
     if disjoint is not None:
@@ -1755,7 +1755,7 @@ class RealInterval(object):
     def refine_step(self, steps=1):
         """Perform several steps of real root refinement algorithm. """
         expr = self
-        for _ in xrange(steps):
+        for _ in range(steps):
             expr = expr._inner_refine()
 
         return expr
@@ -1892,7 +1892,7 @@ class ComplexInterval(object):
     def refine_step(self, steps=1):
         """Perform several steps of complex root refinement algorithm. """
         expr = self
-        for _ in xrange(steps):
+        for _ in range(steps):
             expr = expr._inner_refine()
 
         return expr

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -33,7 +33,7 @@ from mpmath.libmp.libmpf import prec_to_dps
 
 from sympy.utilities import lambdify, public
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 from math import log as mathlog
 def _ispow2(i):
@@ -427,7 +427,7 @@ class RootOf(Expr):
 
         roots = []
 
-        for index in xrange(0, reals_count):
+        for index in range(0, reals_count):
             roots.append(cls._reals_index(reals, index))
 
         return roots
@@ -443,14 +443,14 @@ class RootOf(Expr):
 
         roots = []
 
-        for index in xrange(0, reals_count):
+        for index in range(0, reals_count):
             roots.append(cls._reals_index(reals, index))
 
         complexes = cls._get_complexes(factors)
         complexes = cls._complexes_sorted(complexes)
         complexes_count = cls._count_roots(complexes)
 
-        for index in xrange(0, complexes_count):
+        for index in range(0, complexes_count):
             roots.append(cls._complexes_index(complexes, index))
 
         return roots

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -30,7 +30,7 @@ from sympy.ntheory import nextprime
 
 from sympy.utilities import subsets, public
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 @public
@@ -49,7 +49,7 @@ def swinnerton_dyer_poly(n, x=None, **args):
     if n > 3:
         p = 2
         a = [sqrt(2)]
-        for i in xrange(2, n + 1):
+        for i in range(2, n + 1):
             p = nextprime(p)
             a.append(sqrt(p))
         return minimal_polynomial(Add(*a), x, polys=args.get('polys', False))
@@ -125,11 +125,11 @@ def interpolating_poly(n, x, X='x', Y='y'):
 
     coeffs = []
 
-    for i in xrange(0, n):
+    for i in range(0, n):
         numer = []
         denom = []
 
-        for j in xrange(0, n):
+        for j in range(0, n):
             if i == j:
                 continue
 
@@ -146,7 +146,7 @@ def interpolating_poly(n, x, X='x', Y='y'):
 
 def fateman_poly_F_1(n):
     """Fateman's GCD benchmark: trivial GCD """
-    Y = [ Symbol('y_' + str(i)) for i in xrange(0, n + 1) ]
+    Y = [ Symbol('y_' + str(i)) for i in range(0, n + 1) ]
 
     y_0, y_1 = Y[0], Y[1]
 
@@ -165,12 +165,12 @@ def dmp_fateman_poly_F_1(n, K):
     """Fateman's GCD benchmark: trivial GCD """
     u = [K(1), K(0)]
 
-    for i in xrange(0, n):
+    for i in range(0, n):
         u = [dmp_one(i, K), u]
 
     v = [K(1), K(0), K(0)]
 
-    for i in xrange(0, n):
+    for i in range(0, n):
         v = [dmp_one(i, K), dmp_zero(i), v]
 
     m = n - 1
@@ -193,7 +193,7 @@ def dmp_fateman_poly_F_1(n, K):
 
 def fateman_poly_F_2(n):
     """Fateman's GCD benchmark: linearly dense quartic inputs """
-    Y = [ Symbol('y_' + str(i)) for i in xrange(0, n + 1) ]
+    Y = [ Symbol('y_' + str(i)) for i in range(0, n + 1) ]
 
     y_0 = Y[0]
 
@@ -211,7 +211,7 @@ def dmp_fateman_poly_F_2(n, K):
     """Fateman's GCD benchmark: linearly dense quartic inputs """
     u = [K(1), K(0)]
 
-    for i in xrange(0, n - 1):
+    for i in range(0, n - 1):
         u = [dmp_one(i, K), u]
 
     m = n - 1
@@ -230,7 +230,7 @@ def dmp_fateman_poly_F_2(n, K):
 
 def fateman_poly_F_3(n):
     """Fateman's GCD benchmark: sparse inputs (deg f ~ vars f) """
-    Y = [ Symbol('y_' + str(i)) for i in xrange(0, n + 1) ]
+    Y = [ Symbol('y_' + str(i)) for i in range(0, n + 1) ]
 
     y_0 = Y[0]
 
@@ -248,7 +248,7 @@ def dmp_fateman_poly_F_3(n, K):
     """Fateman's GCD benchmark: sparse inputs (deg f ~ vars f) """
     u = dup_from_raw_dict({n + 1: K.one}, K)
 
-    for i in xrange(0, n - 1):
+    for i in range(0, n - 1):
         u = dmp_add_term([u], dmp_one(i, K), n + 1, i + 1, K)
 
     v = dmp_add_term(u, dmp_ground(K(2), n - 2), 0, n, K)

--- a/sympy/polys/tests/test_distributedmodules.py
+++ b/sympy/polys/tests/test_distributedmodules.py
@@ -12,6 +12,7 @@ from sympy.polys.orderings import lex, grlex, InverseOrder
 from sympy.polys.domains import QQ
 
 from sympy.abc import x, y, z
+from sympy.core.compatibility import range
 
 
 def test_sdm_monomial_mul():

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -2,6 +2,7 @@
 
 from sympy.polys.rings import ring
 from sympy.polys.domains import ZZ, QQ, RR
+from sympy.core.compatibility import range
 
 from sympy.polys.specialpolys import (
     f_polys,

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -11,7 +11,7 @@ from sympy.polys.specialpolys import f_polys, w_polys
 from sympy import nextprime, sin, sqrt, I
 from sympy.utilities.pytest import raises
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = f_polys()
 w_1, w_2 = w_polys()
@@ -159,7 +159,7 @@ def test_dup_zz_factor():
 
     f = x**4 + x + 1
 
-    for i in xrange(0, 20):
+    for i in range(0, 20):
         assert R.dup_zz_factor(f) == (1, [(f, 1)])
 
     assert R.dup_zz_factor(x**2 + 2*x + 2) == \

--- a/sympy/polys/tests/test_groebnertools.py
+++ b/sympy/polys/tests/test_groebnertools.py
@@ -16,6 +16,7 @@ from sympy.polys.domains import ZZ, QQ
 
 from sympy.utilities.pytest import slow
 from sympy.polys import polyconfig as config
+from sympy.core.compatibility import range
 
 def _do_test_groebner():
     R, x,y = ring("x,y", QQ, lex)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -3,7 +3,8 @@
 from sympy import (S, Rational, Symbol, Poly, sqrt, I, oo, Tuple, expand,
     pi, cos, sin, exp)
 
-from sympy.utilities.pytest import raises, slow, range
+from sympy.utilities.pytest import raises, slow
+from sympy.core.compatibility import range
 
 from sympy.polys.numberfields import (
     minimal_polynomial,

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -3,7 +3,7 @@
 from sympy import (S, Rational, Symbol, Poly, sqrt, I, oo, Tuple, expand,
     pi, cos, sin, exp)
 
-from sympy.utilities.pytest import raises, slow
+from sympy.utilities.pytest import raises, slow, range
 
 from sympy.polys.numberfields import (
     minimal_polynomial,

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -16,6 +16,7 @@ from sympy.polys.polyutils import _nsort
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import raises
 from sympy.utilities.randtest import verify_numerically
+from sympy.core.compatibility import range
 import mpmath
 
 

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -5,6 +5,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
   rs_series_inversion, rs_series_from_list, rs_exp, rs_log, rs_newton,
   rs_hadamard_exp, rs_compose_add)
 from sympy.utilities.pytest import raises
+from sympy.core.compatibility import range
 
 def test_ring_series1():
     R, x = ring('x', QQ)

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -11,7 +11,7 @@ from sympy.polys.polyerrors import GeneratorsError, GeneratorsNeeded, \
 
 from sympy.utilities.pytest import raises
 from sympy.core import Symbol, symbols
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, range
 from sympy import sqrt, pi, oo
 
 def test_PolyRing___init__():

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -14,7 +14,8 @@ from sympy import (
     solve, legendre_poly
 )
 
-from sympy.utilities.pytest import raises, range
+from sympy.utilities.pytest import raises
+from sympy.core.compatibility import range
 
 from sympy.abc import a, b, x, y, z, r
 

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -14,7 +14,7 @@ from sympy import (
     solve, legendre_poly
 )
 
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, range
 
 from sympy.abc import a, b, x, y, z, r
 

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -14,7 +14,7 @@ source code files that are compilable without further modifications.
 from __future__ import print_function, division
 
 from sympy.core import S
-from sympy.core.compatibility import string_types
+from sympy.core.compatibility import string_types, range
 from sympy.printing.codeprinter import CodePrinter, Assignment
 from sympy.printing.precedence import precedence
 

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -22,7 +22,7 @@ from __future__ import print_function, division
 import string
 
 from sympy.core import S, C, Add, N
-from sympy.core.compatibility import string_types
+from sympy.core.compatibility import string_types, range
 from sympy.printing.codeprinter import CodePrinter, Assignment
 from sympy.printing.precedence import precedence
 

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -12,7 +12,7 @@ from __future__ import print_function, division
 from sympy.core import S
 from sympy.printing.codeprinter import CodePrinter, Assignment
 from sympy.printing.precedence import precedence
-from sympy.core.compatibility import string_types
+from sympy.core.compatibility import string_types, range
 
 
 # dictionary mapping sympy function to (argument_conditions, Javascript_function).

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -18,7 +18,7 @@ from .precedence import precedence, PRECEDENCE
 import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps
 
-from sympy.core.compatibility import default_sort_key, xrange
+from sympy.core.compatibility import default_sort_key, range
 from sympy.utilities.iterables import has_variety
 
 import re
@@ -1708,8 +1708,8 @@ class LatexPrinter(Printer):
     def _print_DiagramGrid(self, grid):
         latex_result = "\\begin{array}{%s}\n" % ("c" * grid.width)
 
-        for i in xrange(grid.height):
-            for j in xrange(grid.width):
+        for i in range(grid.height):
+            for j in range(grid.width):
                 if grid[i, j]:
                     latex_result += latex(grid[i, j])
                 latex_result += " "

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division
 from sympy import sympify, S, Mul
 from sympy.core.function import _coeff_isneg
 from sympy.core.alphabets import greeks
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from .printer import Printer
 from .pretty.pretty_symbology import greek_unicode
 from .conventions import split_super_sub, requires_partial

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -12,7 +12,7 @@ complete source code files.
 
 from __future__ import print_function, division
 from sympy.core import C, Mul, Pow, S, Rational
-from sympy.core.compatibility import string_types
+from sympy.core.compatibility import string_types, range
 from sympy.core.mul import _keep_coeff
 from sympy.printing.codeprinter import CodePrinter, Assignment
 from sympy.printing.precedence import precedence

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -5,7 +5,7 @@ from sympy.core.function import _coeff_isneg
 from sympy.utilities import group
 from sympy.utilities.iterables import has_variety
 from sympy.core.sympify import SympifyError
-from sympy.core.compatibility import u, xrange
+from sympy.core.compatibility import u, range
 
 from sympy.printing.printer import Printer
 from sympy.printing.str import sstr
@@ -845,14 +845,14 @@ class PrettyPrinter(Printer):
         len_args = len(pexpr.args)
 
         # max widths
-        maxw = [max([P[i, j].width() for i in xrange(len_args)])
+        maxw = [max([P[i, j].width() for i in range(len_args)])
                 for j in range(2)]
 
         # FIXME: Refactor this code and matrix into some tabular environment.
         # drawing result
         D = None
 
-        for i in xrange(len_args):
+        for i in range(len_args):
             D_row = None
             for j in range(2):
                 p = P[i, j]
@@ -1295,7 +1295,7 @@ class PrettyPrinter(Printer):
 
         # Convert to pretty forms. Add parens to Add instances if there
         # is more than one term in the numer/denom
-        for i in xrange(0, len(a)):
+        for i in range(0, len(a)):
             if (a[i].is_Add and len(a) > 1) or (i != len(a) - 1 and
                     isinstance(a[i], (Integral, Piecewise, Product, Sum))):
                 a[i] = prettyForm(*self._print(a[i]).parens())
@@ -1304,7 +1304,7 @@ class PrettyPrinter(Printer):
             else:
                 a[i] = self._print(a[i])
 
-        for i in xrange(0, len(b)):
+        for i in range(0, len(b)):
             if (b[i].is_Add and len(b) > 1) or (i != len(b) - 1 and
                     isinstance(b[i], (Integral, Piecewise, Product, Sum))):
                 b[i] = prettyForm(*self._print(b[i]).parens())
@@ -1838,8 +1838,8 @@ class PrettyPrinter(Printer):
         from sympy.matrices import Matrix
         from sympy import Symbol
         matrix = Matrix([[grid[i, j] if grid[i, j] else Symbol(" ")
-                          for j in xrange(grid.width)]
-                         for i in xrange(grid.height)])
+                          for j in range(grid.width)]
+                         for i in range(grid.height)])
         return self._print_matrix_contents(matrix)
 
     def _print_FreeModuleElement(self, m):

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 unicode_warnings = ''
 
-from sympy.core.compatibility import u, unicode
+from sympy.core.compatibility import u, unicode, range
 
 # first, setup unicodedate environment
 try:

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -15,7 +15,7 @@ TODO:
 from __future__ import print_function, division
 
 from .pretty_symbology import hobj, vobj, xsym, xobj, pretty_use_unicode
-from sympy.core.compatibility import u, string_types, xrange
+from sympy.core.compatibility import u, string_types, range
 
 
 class stringPict(object):
@@ -443,7 +443,7 @@ class prettyForm(stringPict):
                 arg = stringPict(*arg.parens())
             result.append(arg)
         len_res = len(result)
-        for i in xrange(len_res):
+        for i in range(len_res):
             if i < len_res - 1 and result[i] == '-1' and result[i + 1] == xsym('*'):
                 # substitute -1 by -, like in -1*x -> -x
                 result.pop(i)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -22,6 +22,7 @@ from sympy.utilities.pytest import raises
 from sympy.core.trace import Tr
 
 from sympy.core.compatibility import u_decode as u
+from sympy.core.compatibility import range
 
 a, b, x, y, z, k = symbols('a,b,x,y,z,k')
 th = Symbol('theta')

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -11,6 +11,7 @@ from sympy.core.function import AppliedUndef
 from .printer import Printer
 import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps, repr_dps
+from sympy.core.compatibility import range
 
 
 class ReprPrinter(Printer):

--- a/sympy/printing/tableform.py
+++ b/sympy/printing/tableform.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.containers import Tuple
+from sympy.core.compatibility import range
 
 from types import FunctionType
 

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -9,7 +9,7 @@ from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import raises
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 from sympy.matrices import Matrix, MatrixSymbol
 
 
@@ -368,7 +368,7 @@ def test_fcode_Piecewise():
     )
     a = cos(x)/x
     b = sin(x)/x
-    for i in xrange(10):
+    for i in range(10):
         a = diff(a, x)
         b = diff(b, x)
     expected = (

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -23,6 +23,7 @@ from sympy.functions import DiracDelta, Heaviside, KroneckerDelta, LeviCivita
 from sympy.logic import Implies
 from sympy.logic.boolalg import And, Or, Xor
 from sympy.core.trace import Tr
+from sympy.core.compatibility import range
 
 x, y, z, t, a, b = symbols('x y z t a b')
 k, m, n = symbols('k m n', integer=True)

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -7,6 +7,7 @@ from sympy.utilities.lambdify import implemented_function
 from sympy.matrices import (eye, Matrix, MatrixSymbol, Identity,
                             HadamardProduct, SparseMatrix)
 from sympy.utilities.pytest import XFAIL
+from sympy.core.compatibility import range
 
 from sympy import octave_code as mcode
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -12,6 +12,7 @@ from sympy.polys import Poly, RootOf, RootSum, groebner, ring, field, ZZ, QQ, le
 from sympy.geometry import Point, Circle
 
 from sympy.utilities.pytest import raises
+from sympy.core.compatibility import range
 
 from sympy.printing import sstr, sstrrepr, StrPrinter
 from sympy.core.trace import Tr

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -1,5 +1,6 @@
 from sympy.external import import_module
 from sympy.utilities.pytest import raises, SKIP
+from sympy.core.compatibility import range
 
 theano = import_module('theano')
 if theano:

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -4,6 +4,7 @@ import inspect
 from sympy.external import import_module
 
 from sympy.printing.printer import Printer
+from sympy.core.compatibility import range
 import sympy
 from functools import partial
 

--- a/sympy/series/acceleration.py
+++ b/sympy/series/acceleration.py
@@ -12,6 +12,7 @@ extrapolation: pp. 375-377.)
 from __future__ import print_function, division
 
 from sympy import factorial, Integer, S
+from sympy.core.compatibility import range
 
 
 def richardson(A, k, n, N):

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -2,6 +2,7 @@ from sympy import sin, cos, exp, E, series, oo, S, Derivative, O, Integral, \
     Function, log, sqrt, Symbol, Subs, pi, symbols
 from sympy.abc import x, y, n, k
 from sympy.utilities.pytest import raises
+from sympy.core.compatibility import range
 from sympy.series.gruntz import calculate_series
 
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.basic import Basic
-from sympy.core.compatibility import as_int, with_metaclass
+from sympy.core.compatibility import as_int, with_metaclass, range
 from sympy.sets.sets import Set, Interval, Intersection, EmptySet
 from sympy.core.singleton import Singleton, S
 from sympy.core.sympify import _sympify

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -7,7 +7,7 @@ from sympy.core.basic import Basic
 from sympy.core.singleton import Singleton, S
 from sympy.core.evalf import EvalfMixin
 from sympy.core.numbers import Float
-from sympy.core.compatibility import iterable, with_metaclass, ordered
+from sympy.core.compatibility import iterable, with_metaclass, ordered, range
 from sympy.core.evaluate import global_evaluate
 from sympy.core.decorators import deprecated
 from sympy.core.mul import Mul

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy.sets.fancysets import ImageSet, Range
 from sympy.sets.sets import FiniteSet, Interval, imageset, EmptySet
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -5,6 +5,7 @@ from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
     Eq, Pow, Contains, Sum, RootOf, SymmetricDifference)
 from mpmath import mpi
 
+from sympy.core.compatibility import range
 from sympy.utilities.pytest import raises
 from sympy.utilities.pytest import raises, XFAIL
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -6,7 +6,7 @@ from sympy.core import Basic, Mul, Add, Pow, sympify, Symbol
 from sympy.core.singleton import S
 from sympy.core.function import _coeff_isneg
 from sympy.core.exprtools import factor_terms
-from sympy.core.compatibility import iterable, xrange
+from sympy.core.compatibility import iterable, range
 from sympy.utilities.iterables import filter_symbols, \
     numbered_symbols, sift, topological_sort, ordered
 
@@ -216,8 +216,8 @@ def opt_cse(exprs, order='canonical'):
             funcs = sorted(funcs, key=lambda x: len(x.args))
 
         func_args = [set(e.args) for e in funcs]
-        for i in xrange(len(func_args)):
-            for j in xrange(i + 1, len(func_args)):
+        for i in range(len(func_args)):
+            for j in range(i + 1, len(func_args)):
                 com_args = func_args[i].intersection(func_args[j])
                 if len(com_args) > 1:
                     com_func = Func(*com_args)
@@ -236,7 +236,7 @@ def opt_cse(exprs, order='canonical'):
                     opt_subs[funcs[j]] = Func(Func(*diff_j), com_func,
                                               evaluate=False)
 
-                    for k in xrange(j + 1, len(func_args)):
+                    for k in range(j + 1, len(func_args)):
                         if not com_args.difference(func_args[k]):
                             diff_k = func_args[k].difference(com_args)
                             func_args[k] = diff_k | set([com_func])

--- a/sympy/simplify/epathtools.py
+++ b/sympy/simplify/epathtools.py
@@ -1,7 +1,7 @@
 """Tools for manipulation of expressions using paths. """
 
 from __future__ import print_function, division
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 from sympy.core import Basic
 
@@ -203,7 +203,7 @@ class EPath(object):
                     else:
                         indices = [span]
                 else:
-                    indices = xrange(len(args))
+                    indices = range(len(args))
 
                 for i in indices:
                     try:

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -194,7 +194,7 @@ from sympy.core.sympify import sympify
 from sympy.functions.elementary.trigonometric import (
     cos, sin, tan, cot, sec, csc, sqrt)
 from sympy.functions.elementary.hyperbolic import cosh, sinh, tanh, coth
-from sympy.core.compatibility import ordered
+from sympy.core.compatibility import ordered, range
 from sympy.core.core import C
 from sympy.core.mul import Mul
 from sympy.core.power import Pow

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -65,7 +65,7 @@ from sympy import SYMPY_DEBUG
 from sympy.core import (S, Dummy, symbols, sympify, Tuple, expand, I, pi, Mul,
     EulerGamma, oo, zoo, expand_func, Add, nan, Expr)
 from sympy.core.mod import Mod
-from sympy.core.compatibility import default_sort_key, xrange
+from sympy.core.compatibility import default_sort_key, range
 from sympy.utilities.iterables import sift
 from sympy.functions import (exp, sqrt, root, log, lowergamma, cos,
         besseli, gamma, uppergamma, expint, erf, sin, besselj, Ei, Ci, Si, Shi,
@@ -692,7 +692,7 @@ class Formula(object):
 
         n = poly.degree() - 1
         b = [closed_form]
-        for _ in xrange(n):
+        for _ in range(n):
             b.append(self.z*b[-1].diff(self.z))
 
         self.B = Matrix(b)
@@ -1342,7 +1342,7 @@ class ReduceOrder(Operator):
         expr = Operator.__new__(cls)
 
         p = S(1)
-        for k in xrange(n):
+        for k in range(n):
             p *= (_x + bj + k)/(bj + k)
 
         expr._poly = Poly(p, _x)
@@ -1364,7 +1364,7 @@ class ReduceOrder(Operator):
         expr = Operator.__new__(cls)
 
         p = S(1)
-        for k in xrange(n):
+        for k in range(n):
             p *= (sign*_x + a + k)
 
         expr._poly = Poly(p, _x)
@@ -1403,7 +1403,7 @@ def _reduce_order(ap, bq, gen, key):
     operators = []
     for a in ap:
         op = None
-        for i in xrange(len(bq)):
+        for i in range(len(bq)):
             op = gen(a, bq[i])
             if op is not None:
                 bq.pop(i)
@@ -1545,7 +1545,7 @@ def devise_plan(target, origin, z):
 
     def do_shifts(fro, to, inc, dec):
         ops = []
-        for i in xrange(len(fro)):
+        for i in range(len(fro)):
             if to[i] - fro[i] > 0:
                 sh = inc
                 ch = 1
@@ -1650,7 +1650,7 @@ def try_shifted_sum(func, z):
     nbq = [x - k for x in nbq]
 
     ops = []
-    for n in xrange(r - 1):
+    for n in range(r - 1):
         ops.append(ShiftA(n + 1))
     ops.reverse()
 
@@ -1663,7 +1663,7 @@ def try_shifted_sum(func, z):
     ops += [MultOperator(fac)]
 
     p = 0
-    for n in xrange(k):
+    for n in range(k):
         m = z**n/factorial(n)
         for a in nap:
             m *= rf(a, n)
@@ -1856,7 +1856,7 @@ def build_hypergeometric_formula(func):
         n = poly.degree()
         basis = []
         M = zeros(n)
-        for k in xrange(n):
+        for k in range(n):
             a = func.ap[0] + k
             basis += [hyper([a] + list(func.ap[1:]), func.bq, z)]
             if k < n - 1:
@@ -1865,7 +1865,7 @@ def build_hypergeometric_formula(func):
         B = Matrix(basis)
         C = Matrix([[1] + [0]*(n - 1)])
         derivs = [eye(n)]
-        for k in xrange(n):
+        for k in range(n):
             derivs.append(M*derivs[k])
         l = poly.all_coeffs()
         l.reverse()

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -12,7 +12,7 @@ from sympy.core import (Basic, S, C, Add, Mul, Pow,
 from sympy.core.add import _unevaluated_Add
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import (iterable, reduce, default_sort_key,
-    ordered, xrange, as_int)
+    ordered, range, as_int)
 from sympy.core.exprtools import Factors, gcd_terms
 from sympy.core.numbers import Float, I, Rational, Integer
 from sympy.core.function import expand_log, count_ops, _mexpand
@@ -806,7 +806,7 @@ def ratsimpmodprime(expr, G, *gens, **args):
         if n == 0:
             return [1]
         S = []
-        for mi in combinations_with_replacement(xrange(len(opt.gens)), n):
+        for mi in combinations_with_replacement(range(len(opt.gens)), n):
             m = [0]*len(opt.gens)
             for i in mi:
                 m[i] += 1
@@ -864,9 +864,9 @@ def ratsimpmodprime(expr, G, *gens, **args):
             ng = Cs + Ds
 
             c_hat = Poly(
-                sum([Cs[i] * M1[i] for i in xrange(len(M1))]), opt.gens + ng)
+                sum([Cs[i] * M1[i] for i in range(len(M1))]), opt.gens + ng)
             d_hat = Poly(
-                sum([Ds[i] * M2[i] for i in xrange(len(M2))]), opt.gens + ng)
+                sum([Ds[i] * M2[i] for i in range(len(M2))]), opt.gens + ng)
 
             r = reduced(a * d_hat - b * c_hat, G, opt.gens + ng,
                         order=opt.order, polys=True)[1]
@@ -2735,7 +2735,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                     # find the number of extractions possible
                     # e.g. [(1, 2), (2, 2)] -> min(2/1, 2/2) -> 1
                     min1 = ee[0][1]/ee[0][0]
-                    for i in xrange(len(ee)):
+                    for i in range(len(ee)):
                         rat = ee[i][1]/ee[i][0]
                         if rat < 1:
                             break
@@ -2744,7 +2744,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                         # update base factor counts
                         # e.g. if ee = [(2, 5), (3, 6)] then min1 = 2
                         # and the new base counts will be 5-2*2 and 6-2*3
-                        for i in xrange(len(bb)):
+                        for i in range(len(bb)):
                             common_b[bb[i]] -= min1*ee[i][0]
                             update(bb[i])
                         # update the count of the base
@@ -2821,7 +2821,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
 
         # Pull out numerical coefficients from exponent if assumptions allow
         # e.g., 2**(2*x) => 4**x
-        for i in xrange(len(c_powers)):
+        for i in range(len(c_powers)):
             b, e = c_powers[i]
             if not (all(x.is_nonnegative for x in b.as_numer_denom()) or e.is_integer or force or b.is_polar):
                 continue
@@ -2989,12 +2989,12 @@ class _rf(Function):
             n, result = int(b), S.One
 
             if n > 0:
-                for i in xrange(n):
+                for i in range(n):
                     result *= a + i
 
                 return result
             elif n < 0:
-                for i in xrange(1, -n + 1):
+                for i in range(1, -n + 1):
                     result *= a - i
 
                 return 1/result
@@ -3283,10 +3283,10 @@ def combsimp(expr):
                 ng.remove(x)
                 dg.remove(y)
                 if n > 0:
-                    for k in xrange(n):
+                    for k in range(n):
                         no.append(2*y + k)
                 elif n < 0:
-                    for k in xrange(-n):
+                    for k in range(-n):
                         do.append(2*y - 1 - k)
                 ng.append(y + S(1)/2)
                 no.append(2**(2*y - 1))

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from sympy.functions import sqrt, sign, root
 from sympy.core import S, sympify, Mul, Add, Expr
 from sympy.core.function import expand_mul
+from sympy.core.compatibility import range
 from sympy.core.symbol import Dummy
 from sympy.polys import Poly, PolynomialError
 from sympy.core.function import count_ops, _mexpand

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -7,6 +7,7 @@ from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.functions.special.hyper import meijerg
 from sympy.simplify import cse_main, cse_opts
 from sympy.utilities.pytest import XFAIL, raises
+from sympy.core.compatibility import range
 
 w, x, y, z = symbols('w,x,y,z')
 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12 = symbols('x:13')

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -7,6 +7,7 @@ from sympy.simplify.fu import (
     hyper_as_trig, csc, fu, process_common_addends, sec, trig_split,
     as_f_sign_1)
 from sympy.utilities.randtest import verify_numerically
+from sympy.core.compatibility import range
 from sympy.abc import a, b, c, x, y, z
 
 

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -14,6 +14,7 @@ from sympy.utilities.pytest import raises
 from sympy.abc import z, a, b, c
 from sympy.utilities.randtest import verify_numerically as tn
 from sympy.utilities.pytest import XFAIL, slow
+from sympy.core.compatibility import range
 
 from sympy import (cos, sin, log, exp, asin, lowergamma, atanh, besseli,
                    gamma, sqrt, pi, erf, exp_polar)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -14,6 +14,7 @@ from sympy.core.mul import _keep_coeff, _unevaluated_Mul as umul
 from sympy.simplify.simplify import (
     collect_sqrt, fraction_expand, _unevaluated_Add, nthroot)
 from sympy.utilities.pytest import XFAIL, slow
+from sympy.core.compatibility import range
 
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 

--- a/sympy/solvers/benchmarks/bench_solvers.py
+++ b/sympy/solvers/benchmarks/bench_solvers.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import zeros, eye, Symbol, solve_linear_system
+from sympy.core.compatibility import range
 
 N = 8
 M = zeros(N, N + 1)

--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.add import Add
-from sympy.core.compatibility import ordered
+from sympy.core.compatibility import ordered, range
 from sympy.core.function import expand_log
 from sympy.core.power import Pow
 from sympy.core.singleton import S

--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -9,7 +9,7 @@ from sympy.simplify.simplify import rad_rationalize
 from sympy.utilities import default_sort_key, numbered_symbols
 from sympy.core.numbers import igcdex
 from sympy.ntheory.residue_ntheory import sqrt_mod
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 from sympy.core.relational import Eq
 from sympy.solvers.solvers import check_assumptions
 
@@ -653,7 +653,7 @@ def _diop_quadratic(var, coeff, t):
                 solve_y = lambda u: sqrt(a)*g*(e*sqrt(c)*D - sqrt(a)*E)*t**2 + (D + 2*sqrt(a)*g*u)*t \
                     + (sqrt(a)*g*u**2 + D*u + sqrt(a)*F) // (e*sqrt(c)*D - sqrt(a)*E)
 
-                for z0 in xrange(0, abs(e*sqrt(c)*D - sqrt(a)*E)):
+                for z0 in range(0, abs(e*sqrt(c)*D - sqrt(a)*E)):
                     if divisible(sqrt(a)*g*z0**2 + D*z0 + sqrt(a)*F, e*sqrt(c)*D - sqrt(a)*E):
                         l.add((solve_x(z0), solve_y(z0)))
 
@@ -758,7 +758,7 @@ def _diop_quadratic(var, coeff, t):
 
                     done = False
 
-                    for i in xrange(k):
+                    for i in range(k):
 
                         X_1 = X*T + D*U*Y
                         Y_1 = X*U + Y*T
@@ -885,7 +885,7 @@ def diop_DN(D, N, t=symbols("t", integer=True)):
             else:
                 sol = []
 
-                for y in xrange(floor(sign(N)*(N - 1)/(2*r)) + 1):
+                for y in range(floor(sign(N)*(N - 1)/(2*r)) + 1):
                     if isinstance(sqrt(D*y**2 + N), Integer):
                         sol.append((sqrt(D*y**2 + N), y))
 
@@ -1180,7 +1180,7 @@ def diop_bf_DN(D, N, t=symbols("t", integer=True)):
                 return [(S.Zero, S.Zero)]
 
 
-    for y in xrange(L1, L2):
+    for y in range(L1, L2):
         if isinstance(sqrt(N + D*y**2), Integer):
             x = sqrt(N + D*y**2)
             sol.append((x, y))
@@ -1508,7 +1508,7 @@ def check_param(x, y, a, t):
     q = Wild("q", exclude=[k])
     ok = False
 
-    for i in xrange(a):
+    for i in range(a):
 
         z_x = _mexpand(Subs(x, t, a*k + i).doit()).match(p*k + q)
         z_y = _mexpand(Subs(y, t, a*k + i).doit()).match(p*k + q)
@@ -2341,7 +2341,7 @@ def _diop_general_pythagorean(var, coeff, t):
 
     l.append(ith - 2*m[n - 2]**2)
 
-    for i in xrange(n - 2):
+    for i in range(n - 2):
         l.append(2*m[i]*m[n-2])
 
     sol = l[:index] + [ith] + l[index:]
@@ -2420,7 +2420,7 @@ def _diop_general_sum_of_squares(var, coeff, limit=1):
         m = n // 4
         f = partition(k, m, True)
 
-        for j in xrange(limit):
+        for j in range(limit):
 
             soln = []
             try:
@@ -2498,14 +2498,14 @@ def partition(n, k=None, zeros=False):
 
         elif k > n:
             if zeros:
-                for i in xrange(1, n):
+                for i in range(1, n):
                     for t in partition(n, i):
                         yield (t,) + (0,) * (k - i)
             else:
                 yield tuple()
 
         else:
-            a = [1 for i in xrange(k)]
+            a = [1 for i in range(k)]
             a[0] = n - k + 1
 
             yield tuple(a)
@@ -2525,12 +2525,12 @@ def partition(n, k=None, zeros=False):
                 i = i + 1
 
             if zeros:
-                for m in xrange(1, k):
+                for m in range(1, k):
                     for a in partition(n, m):
                         yield tuple(a) + (0,) * (k - m)
 
     else:
-        a = [0 for i in xrange(n + 1)]
+        a = [0 for i in range(n + 1)]
         l = 1
         y = n - 1
 
@@ -2648,7 +2648,7 @@ def sum_of_three_squares(n):
     if n % 8 == 3:
         l = l if l % 2 else l - 1
 
-        for i in xrange(l, -1, -2):
+        for i in range(l, -1, -2):
             if isprime((n - i**2) // 2):
                 x = i
                 break
@@ -2661,7 +2661,7 @@ def sum_of_three_squares(n):
     else:
         l = l - 1 if l % 2 else l
 
-    for i in xrange(l, -1, -2):
+    for i in range(l, -1, -2):
         if isprime(n - i**2):
             x = i
             break
@@ -2765,7 +2765,7 @@ def power_representation(n, p, k, zeros=False):
                 yield t
 
         if zeros:
-            for i in xrange(2, k):
+            for i in range(2, k):
                 for t in pow_rep_recursive(a, i, n, [], p):
                     yield t + (0,) * (k - i)
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -234,7 +234,7 @@ from collections import defaultdict
 from itertools import islice
 
 from sympy.core import Add, C, S, Mul, Pow, oo
-from sympy.core.compatibility import ordered, iterable, is_sequence, xrange
+from sympy.core.compatibility import ordered, iterable, is_sequence, range
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import (Function, Derivative, AppliedUndef, diff,
     expand, expand_mul, Subs, _mexpand)
@@ -374,7 +374,7 @@ def get_numbered_constants(eq, num=1, start=1, prefix='C'):
 
     atom_set = set().union(*[i.free_symbols for i in eq])
     ncs = numbered_symbols(start=start, prefix=prefix, exclude=atom_set)
-    Cs = [next(ncs) for i in xrange(num)]
+    Cs = [next(ncs) for i in range(num)]
     return (Cs[0] if num == 1 else tuple(Cs))
 
 
@@ -1407,7 +1407,7 @@ def classify_sysode(eq, funcs=None, **kwargs):
                 if func_coef[j,func,k]==0:
                     if k==0:
                         coef = eqs.as_independent(func)[1]
-                        for xr in xrange(1, ode_order(eqs,func)+1):
+                        for xr in range(1, ode_order(eqs,func)+1):
                             coef -= eqs.as_independent(diff(func,t,xr))[1]
                         if coef != 0:
                             is_linear_ = False
@@ -3942,7 +3942,7 @@ def ode_nth_linear_euler_eq_homogeneous(eq, func, order, match, returns='sol'):
             chareq += (r[i]*diff(x**symbol, x, i)*x**-symbol).expand()
 
     chareq = Poly(chareq, symbol)
-    chareqroots = [RootOf(chareq, k) for k in xrange(chareq.degree())]
+    chareqroots = [RootOf(chareq, k) for k in range(chareq.degree())]
 
     # A generator of constants
     constants = list(get_numbered_constants(eq, num=chareq.degree()*2))
@@ -7160,7 +7160,7 @@ def _linear_2eq_order2_type6(x, y, t, r):
     a2 = denum.coeff(x(t))
     b2 = denum.coeff(y(t))
     chareq = k**2 - (a1 + b2)*k + a1*b2 - a2*b1
-    [k1, k2] = [RootOf(chareq, k) for k in xrange(Poly(chareq).degree())]
+    [k1, k2] = [RootOf(chareq, k) for k in range(Poly(chareq).degree())]
     z1 = dsolve(diff(z(t),t,t) - k1*f*z(t)).rhs
     z2 = dsolve(diff(z(t),t,t) - k2*f*z(t)).rhs
     sol1 = (k1*z2 - k2*z1 + a1*(z1 - z2))/(a2*(k1-k2))
@@ -7205,7 +7205,7 @@ def _linear_2eq_order2_type7(x, y, t, r):
     a2 = denum.coeff(x(t))
     b2 = denum.coeff(y(t))
     chareq = k**2 - (a1 + b2)*k + a1*b2 - a2*b1
-    [k1, k2] = [RootOf(chareq, k) for k in xrange(Poly(chareq).degree())]
+    [k1, k2] = [RootOf(chareq, k) for k in range(Poly(chareq).degree())]
     F = C.Integral(f, t)
     z1 = C1*C.Integral(exp(k1*F), t) + C2
     z2 = C3*C.Integral(exp(k2*F), t) + C4

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -37,7 +37,7 @@ from __future__ import print_function, division
 from sympy.simplify import simplify
 from sympy.core import Add, C, S
 from sympy.core.compatibility import (reduce, combinations_with_replacement,
-    is_sequence)
+    is_sequence, range)
 from sympy.core.function import Function, expand, AppliedUndef, Subs
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, symbols

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -64,7 +64,7 @@ from sympy.polys import Poly, quo, gcd, lcm, roots, resultant
 from sympy.functions import binomial, factorial, FallingFactorial, RisingFactorial
 from sympy.matrices import Matrix, casoratian
 from sympy.concrete import product
-from sympy.core.compatibility import default_sort_key, xrange
+from sympy.core.compatibility import default_sort_key, range
 from sympy.utilities.iterables import numbered_symbols
 
 
@@ -134,8 +134,8 @@ def rsolve_poly(coeffs, f, n, **hints):
     polys = [ Poly(0, n) ] * (r + 1)
     terms = [ (S.Zero, S.NegativeInfinity) ] *(r + 1)
 
-    for i in xrange(0, r + 1):
-        for j in xrange(i, r + 1):
+    for i in range(0, r + 1):
+        for j in range(i, r + 1):
             polys[i] += coeffs[j]*binomial(j, i)
 
         if not polys[i].is_zero:
@@ -144,7 +144,7 @@ def rsolve_poly(coeffs, f, n, **hints):
 
     d = b = terms[0][1]
 
-    for i in xrange(1, r + 1):
+    for i in range(1, r + 1):
         if terms[i][1] > d:
             d = terms[i][1]
 
@@ -157,7 +157,7 @@ def rsolve_poly(coeffs, f, n, **hints):
 
     degree_poly = S.Zero
 
-    for i in xrange(0, r + 1):
+    for i in range(0, r + 1):
         if terms[i][1] - i == b:
             degree_poly += terms[i][0]*FallingFactorial(x, i)
 
@@ -189,11 +189,11 @@ def rsolve_poly(coeffs, f, n, **hints):
         C = []
         y = E = S.Zero
 
-        for i in xrange(0, N + 1):
+        for i in range(0, N + 1):
             C.append(Symbol('C' + str(i)))
             y += C[i] * n**i
 
-        for i in xrange(0, r + 1):
+        for i in range(0, r + 1):
             E += coeffs[i].as_expr()*y.subs(n, n + i)
 
         solutions = solve_undetermined_coeffs(E - f, C, n)
@@ -225,7 +225,7 @@ def rsolve_poly(coeffs, f, n, **hints):
             B = S.One
             D = p.subs(n, a + k)
 
-            for i in xrange(1, k + 1):
+            for i in range(1, k + 1):
                 B *= -Rational(k - i + 1, i)
                 D += B * p.subs(n, a + k - i)
 
@@ -233,16 +233,16 @@ def rsolve_poly(coeffs, f, n, **hints):
 
         alpha = {}
 
-        for i in xrange(-A, d + 1):
+        for i in range(-A, d + 1):
             I = _one_vector(d + 1)
 
-            for k in xrange(1, d + 1):
+            for k in range(1, d + 1):
                 I[k] = I[k - 1] * (x + i - k + 1)/k
 
             alpha[i] = S.Zero
 
-            for j in xrange(0, A + 1):
-                for k in xrange(0, d + 1):
+            for j in range(0, A + 1):
+                for k in range(0, d + 1):
                     B = binomial(k, i + j)
                     D = _delta(polys[j].as_expr(), k)
 
@@ -251,66 +251,66 @@ def rsolve_poly(coeffs, f, n, **hints):
         V = Matrix(U, A, lambda i, j: int(i == j))
 
         if homogeneous:
-            for i in xrange(A, U):
+            for i in range(A, U):
                 v = _zero_vector(A)
 
-                for k in xrange(1, A + b + 1):
+                for k in range(1, A + b + 1):
                     if i - k < 0:
                         break
 
                     B = alpha[k - A].subs(x, i - k)
 
-                    for j in xrange(0, A):
+                    for j in range(0, A):
                         v[j] += B * V[i - k, j]
 
                 denom = alpha[-A].subs(x, i)
 
-                for j in xrange(0, A):
+                for j in range(0, A):
                     V[i, j] = -v[j] / denom
         else:
             G = _zero_vector(U)
 
-            for i in xrange(A, U):
+            for i in range(A, U):
                 v = _zero_vector(A)
                 g = S.Zero
 
-                for k in xrange(1, A + b + 1):
+                for k in range(1, A + b + 1):
                     if i - k < 0:
                         break
 
                     B = alpha[k - A].subs(x, i - k)
 
-                    for j in xrange(0, A):
+                    for j in range(0, A):
                         v[j] += B * V[i - k, j]
 
                     g += B * G[i - k]
 
                 denom = alpha[-A].subs(x, i)
 
-                for j in xrange(0, A):
+                for j in range(0, A):
                     V[i, j] = -v[j] / denom
 
                 G[i] = (_delta(f, i - A) - g) / denom
 
         P, Q = _one_vector(U), _zero_vector(A)
 
-        for i in xrange(1, U):
+        for i in range(1, U):
             P[i] = (P[i - 1] * (n - a - i + 1)/i).expand()
 
-        for i in xrange(0, A):
+        for i in range(0, A):
             Q[i] = Add(*[ (v*p).expand() for v, p in zip(V[:, i], P) ])
 
         if not homogeneous:
             h = Add(*[ (g*p).expand() for g, p in zip(G, P) ])
 
-        C = [ Symbol('C' + str(i)) for i in xrange(0, A) ]
+        C = [ Symbol('C' + str(i)) for i in range(0, A) ]
 
         g = lambda i: Add(*[ c*_delta(q, i) for c, q in zip(C, Q) ])
 
         if homogeneous:
-            E = [ g(i) for i in xrange(N + 1, U) ]
+            E = [ g(i) for i in range(N + 1, U) ]
         else:
-            E = [ g(i) + _delta(h, i) for i in xrange(N + 1, U) ]
+            E = [ g(i) + _delta(h, i) for i in range(N + 1, U) ]
 
         if E != []:
             solutions = solve(E, *C)
@@ -427,13 +427,13 @@ def rsolve_ratio(coeffs, f, n, **hints):
     else:
         C, numers = S.One, [S.Zero]*(r + 1)
 
-        for i in xrange(int(max(nni_roots)), -1, -1):
+        for i in range(int(max(nni_roots)), -1, -1):
             d = gcd(A, B.subs(n, n + i), n)
 
             A = quo(A, d, n)
             B = quo(B, d.subs(n, n - i), n)
 
-            C *= Mul(*[ d.subs(n, n - j) for j in xrange(0, i + 1) ])
+            C *= Mul(*[ d.subs(n, n - j) for j in range(0, i + 1) ])
 
         denoms = [ C.subs(n, n + i) for i in range(0, r + 1) ]
 
@@ -443,7 +443,7 @@ def rsolve_ratio(coeffs, f, n, **hints):
             numers[i] = quo(coeffs[i], g, n)
             denoms[i] = quo(denoms[i], g, n)
 
-        for i in xrange(0, r + 1):
+        for i in range(0, r + 1):
             numers[i] *= Mul(*(denoms[:i] + denoms[i + 1:]))
 
         result = rsolve_poly(numers, f * Mul(*denoms), n, **hints)
@@ -548,7 +548,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
 
             s = hypersimp(g, n)
 
-            for j in xrange(1, r + 1):
+            for j in range(1, r + 1):
                 coeff *= s.subs(n, n + j - 1)
 
                 p, q = coeff.as_numer_denom()
@@ -556,7 +556,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
                 polys[j] *= p
                 denoms[j] = q
 
-            for j in xrange(0, r + 1):
+            for j in range(0, r + 1):
                 polys[j] *= Mul(*(denoms[:j] + denoms[j + 1:]))
 
             R = rsolve_poly(polys, Mul(*denoms), n)
@@ -595,9 +595,9 @@ def rsolve_hyper(coeffs, f, n, **hints):
         polys, degrees = [], []
         D = A*B.subs(n, n + r - 1)
 
-        for i in xrange(0, r + 1):
-            a = Mul(*[ A.subs(n, n + j) for j in xrange(0, i) ])
-            b = Mul(*[ B.subs(n, n + j) for j in xrange(i, r) ])
+        for i in range(0, r + 1):
+            a = Mul(*[ A.subs(n, n + j) for j in range(0, i) ])
+            b = Mul(*[ B.subs(n, n + j) for j in range(i, r) ])
 
             poly = quo(coeffs[i]*a*b, D, n)
             polys.append(poly.as_poly(n))
@@ -607,7 +607,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
 
         d, poly = max(degrees), S.Zero
 
-        for i in xrange(0, r + 1):
+        for i in range(0, r + 1):
             coeff = polys[i].nth(d)
 
             if coeff is not S.Zero:
@@ -617,7 +617,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
             if z.is_zero:
                 continue
 
-            (C, s) = rsolve_poly([ polys[i]*z**i for i in xrange(r + 1) ], 0, n, symbols=True)
+            (C, s) = rsolve_poly([ polys[i]*z**i for i in range(r + 1) ], 0, n, symbols=True)
 
             if C is not None and C is not S.Zero:
                 symbols |= set(s)
@@ -782,7 +782,7 @@ def rsolve(f, y, init=None):
         H_part = h_part
 
     K_max = max(H_part.keys())
-    coeffs = [H_part[i] for i in xrange(K_max + 1)]
+    coeffs = [H_part[i] for i in range(K_max + 1)]
 
     result = rsolve_hyper(coeffs, -i_part, n, symbols=True)
 
@@ -796,7 +796,7 @@ def rsolve(f, y, init=None):
 
     if symbols and init is not None:
         if type(init) is list:
-            init = dict([(i, init[i]) for i in xrange(len(init))])
+            init = dict([(i, init[i]) for i in range(len(init))])
 
         equations = []
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -15,7 +15,7 @@ This module contain solvers for all kinds of equations:
 from __future__ import print_function, division
 
 from sympy.core.compatibility import (iterable, is_sequence, ordered,
-    default_sort_key, xrange)
+    default_sort_key, range)
 from sympy.core.sympify import sympify
 from sympy.core import C, S, Add, Symbol, Equality, Dummy, Expr, Mul, Pow
 from sympy.core.exprtools import factor_terms
@@ -2114,7 +2114,7 @@ def solve_linear_system(system, *symbols, **flags):
         if not matrix[i, i]:
             # there is no pivot in current column
             # so try to find one in other columns
-            for k in xrange(i + 1, m):
+            for k in range(i + 1, m):
                 if matrix[i, k]:
                     break
             else:
@@ -2176,7 +2176,7 @@ def solve_linear_system(system, *symbols, **flags):
         # divide all elements in the current row by the pivot
         matrix.row_op(i, lambda x, _: x * pivot_inv)
 
-        for k in xrange(i + 1, matrix.rows):
+        for k in range(i + 1, matrix.rows):
             if matrix[k, i]:
                 coeff = matrix[k, i]
 
@@ -2199,7 +2199,7 @@ def solve_linear_system(system, *symbols, **flags):
             content = matrix[k, m]
 
             # run back-substitution for variables
-            for j in xrange(k + 1, m):
+            for j in range(k + 1, m):
                 content -= matrix[k, j]*solutions[syms[j]]
 
             if do_simplify:
@@ -2219,11 +2219,11 @@ def solve_linear_system(system, *symbols, **flags):
             content = matrix[k, m]
 
             # run back-substitution for variables
-            for j in xrange(k + 1, i):
+            for j in range(k + 1, i):
                 content -= matrix[k, j]*solutions[syms[j]]
 
             # run back-substitution for parameters
-            for j in xrange(i, m):
+            for j in range(i, m):
                 content -= matrix[k, j]*syms[j]
 
             if do_simplify:

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -5,6 +5,7 @@ from sympy.solvers.diophantine import (diop_solve, diop_DN, diop_bf_DN, length, 
 
 from sympy import symbols, Integer, Matrix, simplify, Subs, S, factor_list
 from sympy.core.function import _mexpand
+from sympy.core.compatibility import range
 from sympy.functions.elementary.trigonometric import sin
 from sympy.utilities.pytest import slow, raises
 from sympy.utilities import default_sort_key

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -1,6 +1,7 @@
 from sympy import Eq, factorial, Function, Lambda, rf, S, sqrt, symbols, I, expand_func, binomial, gamma
 from sympy.solvers.recurr import rsolve, rsolve_hyper, rsolve_poly, rsolve_ratio
 from sympy.utilities.pytest import raises
+from sympy.core.compatibility import range
 from sympy.abc import a, b, c
 
 y = Function('y')

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -6,6 +6,7 @@ from sympy import (
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
     root, simplify, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve, oo)
 
+from sympy.core.compatibility import range
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -14,7 +14,7 @@ Hypergeometric
 
 from __future__ import print_function, division
 
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, range
 from sympy.core.logic import fuzzy_not, fuzzy_and
 from sympy.stats.frv import (SingleFinitePSpace, SingleFiniteDistribution)
 from sympy import (S, sympify, Rational, binomial, cacheit, Integer,

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -23,7 +23,7 @@ from sympy.stats.rv import ProductPSpace
 
 from sympy.utilities.pytest import raises, XFAIL, slow
 
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 oo = S.Infinity
 
@@ -549,7 +549,7 @@ def test_prefab_sampling():
     variables = [N, L, E, P, W, U, B, G]
     niter = 10
     for var in variables:
-        for i in xrange(niter):
+        for i in range(niter):
             assert sample(var) in var.pspace.domain.set
 
 

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy import (FiniteSet, S, Symbol, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, Or, Dict, sympify, binomial,
         cancel)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -6,6 +6,7 @@ from sympy.stats import (Die, Normal, Exponential, P, E, variance, covariance,
         random_symbols, sample)
 from sympy.stats.rv import ProductPSpace, rs_swap, Density, NamedArgsMixin
 from sympy.utilities.pytest import raises, XFAIL
+from sympy.core.compatibility import range
 
 
 def test_where():

--- a/sympy/strategies/branch/tests/test_core.py
+++ b/sympy/strategies/branch/tests/test_core.py
@@ -1,7 +1,7 @@
 from sympy.strategies.branch.core import (exhaust, debug, multiplex,
         condition, notempty, chain, onaction, sfilter, yieldify, do_one,
         identity)
-from sympy.core.compatibility import get_function_name
+from sympy.core.compatibility import get_function_name, range
 
 def posdec(x):
     if x > 0:

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -109,7 +109,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Expr, Tuple, Symbol, sympify, S
-from sympy.core.compatibility import is_sequence, string_types, NotIterable
+from sympy.core.compatibility import is_sequence, string_types, NotIterable, range
 
 
 class IndexException(Exception):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -36,7 +36,7 @@ from sympy import Matrix, Rational
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
     bsgs_direct_product, canonicalize, riemann_bsgs
 from sympy.core import Basic, sympify, Add, S
-from sympy.core.compatibility import string_types, reduce
+from sympy.core.compatibility import string_types, reduce, range
 from sympy.core.containers import Tuple
 from sympy.core.decorators import deprecated
 from sympy.core.symbol import Symbol, symbols

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -1,5 +1,5 @@
 from sympy.core import symbols, Symbol, Tuple, oo
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, range
 from sympy.tensor.indexed import IndexException
 from sympy.utilities.pytest import raises
 

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -11,6 +11,7 @@ from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry,
     riemann_cyclic_replace, riemann_cyclic, TensMul, tensorsymmetry, tensorhead, \
     TensorManager, TensExpr, TIDS
 from sympy.utilities.pytest import raises, skip
+from sympy.core.compatibility import range
 
 def _is_equal(arg1, arg2):
     if isinstance(arg1, TensExpr):

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -19,6 +19,7 @@ http://aima.cs.berkeley.edu/python/logic.html
 from __future__ import print_function, division
 
 from sympy.utilities.iterables import kbins
+from sympy.core.compatibility import range
 
 class Compound(object):
     """ A little class to represent an interior node in the tree

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -201,7 +201,7 @@ def allcombinations(A, B, ordered):
     if ordered == "associative":
         ordered = None
     sm, bg = (A, B) if len(A) < len(B) else (B, A)
-    for part in kbins(range(len(bg)), len(sm), ordered=ordered):
+    for part in kbins(list(range(len(bg))), len(sm), ordered=ordered):
         if bg == B:
             yield tuple((a,) for a in A), partition(B, part)
         else:

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -77,7 +77,7 @@ from subprocess import STDOUT, CalledProcessError
 from string import Template
 
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import check_output
+from sympy.core.compatibility import check_output, range
 from sympy.core.function import Lambda
 from sympy.core.relational import Eq
 from sympy.core.symbol import Dummy, Symbol

--- a/sympy/utilities/benchmarking.py
+++ b/sympy/utilities/benchmarking.py
@@ -11,7 +11,7 @@ import timeit
 
 from inspect import getsource
 
-from sympy.core.compatibility import exec_
+from sympy.core.compatibility import exec_, range
 
 
 # from IPython.Magic.magic_timeit

--- a/sympy/utilities/compilef.py
+++ b/sympy/utilities/compilef.py
@@ -86,6 +86,7 @@ import ctypes
 from sympy import Symbol, cse, sympify
 from sympy.utilities.lambdify import lambdastr as getlambdastr
 from sympy.external import import_module
+from sympy.core.compatibility import range
 
 libtccpath = './libtcc.so'
 dps = 17  # decimal places of float precision
@@ -439,7 +440,7 @@ def test_clambdify():
     f1 = sqrt(x*y)
     pf1 = lambdify((x, y), f1, 'math')
     cf1 = clambdify((x, y), f1)
-    for i in xrange(10):
+    for i in range(10):
         if cf1(i, 10 - i) != pf1(i, 10 - i):
             raise ValueError("Values should be equal")
     f2 = (x - y) / z * pi
@@ -457,7 +458,7 @@ def test_frange():
     args = range(30, 168, 3)
     if len(a) != len(args):
         raise ValueError("Lengths should be equal")
-    for i in xrange(len(a)):
+    for i in range(len(a)):
         if a[i] != f(args[i]):
             raise ValueError("Values should be equal")
     if len(frange('lambda x: x', 0, -10000)) != 0:
@@ -468,21 +469,21 @@ def test_frange():
     b = range(-50, 50)
     if len(a) != len(b):
         raise ValueError("Lengths should be equal")
-    for i in xrange(len(a)):
+    for i in range(len(a)):
         if int(round(a[i]*10)) != b[i]:
             raise ValueError("Values should be equal")
     a = frange('lambda x: x', 17, -9, -3)
     b = range(17, -9, -3)
     if len(a) != len(b):
         raise ValueError("Lengths should be equal")
-    for i in xrange(len(a)):
+    for i in range(len(a)):
         if a[i] != b[i]:
             raise ValueError("a and b should be equal")
     a = frange('lambda x: x', 2.7, -3.1, -1.01)
     b = range(270, -310, -101)
     if len(a) != len(b):
         raise ValueError("Lengths should be equal")
-    for i in xrange(len(a)):
+    for i in range(len(a)):
         if int(round(a[i]*100)) != b[i]:
             raise ValueError("Values should be equal")
     assert frange('lambda x: x', 0.2, 0.1, -0.1)[0] == 0.2
@@ -530,7 +531,7 @@ def test_use_cse():
     b = frange(*args, **kwargs)
     if len(a) != len(b):
         raise ValueError("Lengths should be equal")
-    for i in xrange(len(a)):
+    for i in range(len(a)):
         if a[i] != b[i]:
             raise ValueError("a and b should be equal")
 

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, division
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 """
 Algorithms and classes to support enumerative combinatorics.
@@ -225,12 +225,12 @@ def multiset_partitions_taocp(multiplicities):
     # Note: allocation of space for stack is conservative.  Knuth's
     # exercise 7.2.1.5.68 gives some indication of how to tighten this
     # bound, but this is not implemented.
-    pstack = [PartComponent() for i in xrange(n * m + 1)]
+    pstack = [PartComponent() for i in range(n * m + 1)]
     f = [0] * (n + 1)
 
     # Step M1 in Knuth (Initialize)
     # Initial state - entire multiset in one part.
-    for j in xrange(m):
+    for j in range(m):
         ps = pstack[j]
         ps.c = j
         ps.u = multiplicities[j]
@@ -294,7 +294,7 @@ def multiset_partitions_taocp(multiplicities):
                 # Return to M5
             else:
                 pstack[j].v = pstack[j].v - 1
-                for k in xrange(j + 1, b):
+                for k in range(j + 1, b):
                     pstack[k].v = pstack[k].u
                 break  # GOTO M2
 
@@ -332,7 +332,7 @@ def factoring_visitor(state, primes):
     """
     f, lpart, pstack = state
     factoring = []
-    for i in xrange(lpart + 1):
+    for i in range(lpart + 1):
         factor = 1
         for ps in pstack[f[i]: f[i + 1]]:
             if ps.v > 0:
@@ -360,7 +360,7 @@ def list_visitor(state, components):
     f, lpart, pstack = state
 
     partition = []
-    for i in xrange(lpart+1):
+    for i in range(lpart+1):
         part = []
         for ps in pstack[f[i]:f[i+1]]:
             if ps.v > 0:
@@ -448,11 +448,11 @@ class MultisetPartitionTraverser():
         # pstack is the partition stack, which is segmented by
         # f into parts.
         self.pstack = [PartComponent() for i in
-                       xrange(num_components * cardinality + 1)]
+                       range(num_components * cardinality + 1)]
         self.f = [0] * (cardinality + 1)
 
         # Initial state - entire multiset in one part.
-        for j in xrange(num_components):
+        for j in range(num_components):
             ps = self.pstack[j]
             ps.c = j
             ps.u = multiplicities[j]
@@ -484,12 +484,12 @@ class MultisetPartitionTraverser():
 
         """
         plen = len(part)
-        for j in xrange(plen - 1, -1, -1):
+        for j in range(plen - 1, -1, -1):
             if (j == 0 and part[j].v > 1) or (j > 0 and part[j].v > 0):
                 # found val to decrement
                 part[j].v -= 1
                 # Reset trailing parts back to maximum
-                for k in xrange(j + 1, plen):
+                for k in range(j + 1, plen):
                     part[k].v = part[k].u
                 return True
         return False
@@ -549,7 +549,7 @@ class MultisetPartitionTraverser():
             self.p1 += 1  # increment to keep track of usefulness of tests
             return False
         plen = len(part)
-        for j in xrange(plen - 1, -1, -1):
+        for j in range(plen - 1, -1, -1):
             # Knuth's mod, (answer to problem 7.2.1.5.69)
             if (j == 0) and (part[0].v - 1)*(ub - self.lpart) < part[0].u:
                 self.k1 += 1
@@ -559,7 +559,7 @@ class MultisetPartitionTraverser():
                 # found val to decrement
                 part[j].v -= 1
                 # Reset trailing parts back to maximum
-                for k in xrange(j + 1, plen):
+                for k in range(j + 1, plen):
                     part[k].v = part[k].u
 
                 # Have now decremented part, but are we doomed to
@@ -628,7 +628,7 @@ class MultisetPartitionTraverser():
         if deficit <= 0:
             return True
 
-        for i in xrange(len(part) - 1, -1, -1):
+        for i in range(len(part) - 1, -1, -1):
             if i == 0:
                 if part[0].v > deficit:
                     part[0].v -= deficit
@@ -702,7 +702,7 @@ class MultisetPartitionTraverser():
         changed = False  # Set to true when the new part (so far) is
                          # strictly less than (as opposed to less than
                          # or equal) to the old.
-        for j in xrange(self.f[self.lpart], self.f[self.lpart + 1]):
+        for j in range(self.f[self.lpart], self.f[self.lpart + 1]):
             self.pstack[k].u = self.pstack[j].u - self.pstack[j].v
             if self.pstack[k].u == 0:
                 changed = True

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -11,7 +11,7 @@ from sympy.core import Basic, C
 # this is the logical location of these functions
 from sympy.core.compatibility import (
     as_int, combinations_with_replacement, default_sort_key, is_sequence,
-    iterable, ordered, xrange
+    iterable, ordered, range
 )
 
 from sympy.utilities.enumerative import (
@@ -87,7 +87,7 @@ def unflatten(iter, n=2):
     """
     if n < 1 or len(iter) % n:
         raise ValueError('iter length is not a multiple of %i' % n)
-    return list(zip(*(iter[i::n] for i in xrange(n))))
+    return list(zip(*(iter[i::n] for i in range(n))))
 
 
 def reshape(seq, how):
@@ -666,7 +666,7 @@ def sift(seq, keyfunc):
 
 def take(iter, n):
     """Return ``n`` items from ``iter`` iterator. """
-    return [ value for _, value in zip(xrange(n), iter) ]
+    return [ value for _, value in zip(range(n), iter) ]
 
 
 def dict_merge(*dicts):
@@ -698,7 +698,7 @@ def common_prefix(*seqs):
         return seqs[0]
     i = 0
     for i in range(min(len(s) for s in seqs)):
-        if not all(seqs[j][i] == seqs[0][i] for j in xrange(len(seqs))):
+        if not all(seqs[j][i] == seqs[0][i] for j in range(len(seqs))):
             break
     else:
         i += 1
@@ -725,7 +725,7 @@ def common_suffix(*seqs):
         return seqs[0]
     i = 0
     for i in range(-1, -min(len(s) for s in seqs) - 1, -1):
-        if not all(seqs[j][i] == seqs[0][i] for j in xrange(len(seqs))):
+        if not all(seqs[j][i] == seqs[0][i] for j in range(len(seqs))):
             break
     else:
         i -= 1
@@ -750,7 +750,7 @@ def prefixes(seq):
     """
     n = len(seq)
 
-    for i in xrange(n):
+    for i in range(n):
         yield seq[:i + 1]
 
 
@@ -769,7 +769,7 @@ def postfixes(seq):
     """
     n = len(seq)
 
-    for i in xrange(n):
+    for i in range(n):
         yield seq[n - i - 1:]
 
 
@@ -1835,14 +1835,14 @@ def generate_oriented_forest(n):
         if P[n] > 0:
             P[n] = P[P[n]]
         else:
-            for p in xrange(n - 1, 0, -1):
+            for p in range(n - 1, 0, -1):
                 if P[p] != 0:
                     target = P[p] - 1
-                    for q in xrange(p - 1, 0, -1):
+                    for q in range(p - 1, 0, -1):
                         if P[q] == target:
                             break
                     offset = p - q
-                    for i in xrange(p, n + 1):
+                    for i in range(p, n + 1):
                         P[i] = P[i - offset]
                     break
             else:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -9,7 +9,7 @@ import inspect
 import textwrap
 
 from sympy.external import import_module
-from sympy.core.compatibility import exec_, is_sequence, iterable, string_types
+from sympy.core.compatibility import exec_, is_sequence, iterable, string_types, range
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.decorators import wraps
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import range
 
 
 def recurrence_memo(initial):
@@ -18,7 +18,7 @@ def recurrence_memo(initial):
             L = len(cache)
             if n <= L - 1:
                 return cache[n]
-            for i in xrange(L, n + 1):
+            for i in range(L, n + 1):
                 cache.append(f(i, cache))
             return cache[-1]
         return g
@@ -44,7 +44,7 @@ def assoc_recurrence_memo(base_seq):
             if n < L:
                 return cache[n][m]
 
-            for i in xrange(L, n + 1):
+            for i in range(L, n + 1):
                 # get base sequence
                 F_i0 = base_seq(i)
                 F_i_cache = [F_i0]
@@ -52,7 +52,7 @@ def assoc_recurrence_memo(base_seq):
 
                 # XXX only works for m <= n cases
                 # generate assoc sequence
-                for j in xrange(1, i + 1):
+                for j in range(1, i + 1):
                     F_ij = f(i, j, cache)
                     F_i_cache.append(F_ij)
 

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 import sys
 import os
 from textwrap import fill, dedent
-from sympy.core.compatibility import get_function_name
+from sympy.core.compatibility import get_function_name, range
 
 # if you use
 # filldedent('''

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -33,7 +33,7 @@ import stat
 from inspect import isgeneratorfunction
 
 from sympy.core.cache import clear_cache
-from sympy.core.compatibility import exec_, PY3, string_types, xrange
+from sympy.core.compatibility import exec_, PY3, string_types, range
 from sympy.utilities.misc import find_executable
 from sympy.external import import_module
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -424,7 +424,7 @@ def test(*paths, **kwargs):
 
     if subprocess:
         # loop backwards so last i is 0
-        for i in xrange(rerun, -1, -1):
+        for i in range(rerun, -1, -1):
             print_counter(i)
             ret = run_in_subprocess_with_hash_randomization("_test",
                         function_args=paths, function_kwargs=kwargs)
@@ -436,7 +436,7 @@ def test(*paths, **kwargs):
                 return val
 
     # rerun even if hash randomization is not supported
-    for i in xrange(rerun, -1, -1):
+    for i in range(rerun, -1, -1):
         print_counter(i)
         val = not bool(_test(*paths, **kwargs))
         if not val or i == 0:
@@ -568,7 +568,7 @@ def doctest(*paths, **kwargs):
 
     if subprocess:
         # loop backwards so last i is 0
-        for i in xrange(rerun, -1, -1):
+        for i in range(rerun, -1, -1):
             print_counter(i)
             ret = run_in_subprocess_with_hash_randomization("_doctest",
                         function_args=paths, function_kwargs=kwargs)
@@ -580,7 +580,7 @@ def doctest(*paths, **kwargs):
                 return val
 
     # rerun even if hash randomization is not supported
-    for i in xrange(rerun, -1, -1):
+    for i in range(rerun, -1, -1):
         print_counter(i)
         val = not bool(_doctest(*paths, **kwargs))
         if not val or i == 0:

--- a/sympy/utilities/tests/test_enumerative.py
+++ b/sympy/utilities/tests/test_enumerative.py
@@ -1,4 +1,4 @@
-from sympy.core.compatibility import xrange, zip_longest
+from sympy.core.compatibility import range, zip_longest
 from sympy.utilities.enumerative import (
     list_visitor,
     MultisetPartitionTraverser,
@@ -70,8 +70,8 @@ def multiset_partitions_baseline(multiplicities, components):
     cache = set()
     n = len(canon)
     for nc, q in _set_partitions(n):
-        rv = [[] for i in xrange(nc)]
-        for i in xrange(n):
+        rv = [[] for i in range(nc)]
+        for i in range(n):
             rv[q[i]].append(canon[i])
         canonical = tuple(
             sorted([tuple(p) for p in rv]))

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -5,6 +5,7 @@ from sympy import (
     symbols, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
     factorial, true)
 from sympy.combinatorics import RGS_enum, RGS_unrank, Permutation
+from sympy.utilities.core import range
 from sympy.utilities.iterables import (
     _partition, _set_partitions, binary_partitions, bracelets, capture,
     cartes, common_prefix, common_suffix, dict_merge, filter_symbols,

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -5,7 +5,7 @@ from sympy import (
     symbols, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
     factorial, true)
 from sympy.combinatorics import RGS_enum, RGS_unrank, Permutation
-from sympy.utilities.core import range
+from sympy.core.compatibility import range
 from sympy.utilities.iterables import (
     _partition, _set_partitions, binary_partitions, bracelets, capture,
     cartes, common_prefix, common_suffix, dict_merge, filter_symbols,

--- a/sympy/utilities/timeutils.py
+++ b/sympy/utilities/timeutils.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 import timeit
 import math
 
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 
 _scales = [1e0, 1e3, 1e6, 1e9]
 _units = [u('s'), u('ms'), u('\N{GREEK SMALL LETTER MU}s'), u('ns')]

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -1,7 +1,7 @@
 from sympy.core.basic import Basic
 from sympy.vector.scalar import BaseScalar
 from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol
-from sympy.core.compatibility import string_types
+from sympy.core.compatibility import string_types, range
 from sympy.core.cache import cacheit
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)

--- a/sympy/vector/point.py
+++ b/sympy/vector/point.py
@@ -1,3 +1,4 @@
+from sympy.core.compatibility import range
 from sympy.core.basic import Basic
 from sympy.vector.vector import Vector
 from sympy.vector.coordsysrect import CoordSysCartesian

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -1,5 +1,5 @@
 from sympy.core.symbol import Symbol
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, range
 from sympy.printing.pretty.stringpict import prettyForm
 
 

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -1,6 +1,7 @@
 from sympy.core.assumptions import StdFactKB
 from sympy.core import S, Pow
 from sympy.core.expr import AtomicExpr
+from sympy.core.compatibility import range
 from sympy import diff as df, sqrt, ImmutableMatrix as Matrix
 from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.basisdependent import BasisDependent, \


### PR DESCRIPTION
This commit fixes #7258 
As per PY3 xrange is dropped and range is equivalent to PY2 xrange. 
As @asmeurer said in comments we should code as per PY3 and use
backward compatibility to serve PY2. I searched all files which were
using xrange without importing from compatibility (using grep -iR).
Only two were found and I have updated these files accordingly.
Please review this. All tests passed on my machine
