### PR TITLE
Fixed incompatiblity with latest version of pyglet (1.2alpha1)

### DIFF
--- a/sympy/plotting/pygletplot/plot_rotation.py
+++ b/sympy/plotting/pygletplot/plot_rotation.py
@@ -1,5 +1,10 @@
 from __future__ import print_function, division
 
+try:
+    from pyglet.gl.gl import c_float
+except ImportError:
+    pass
+
 from pyglet.gl import *
 from math import sqrt as _sqrt, acos as _acos
 

--- a/sympy/plotting/pygletplot/util.py
+++ b/sympy/plotting/pygletplot/util.py
@@ -1,5 +1,10 @@
 from __future__ import print_function, division
 
+try:
+    from pyglet.gl.gl import c_float
+except ImportError:
+    pass
+
 from pyglet.gl import *
 from sympy.core import S
 from sympy.core.compatibility import xrange


### PR DESCRIPTION
In earlier version of pyglet, `c_float` was defined in `pyglet.gl`
but in the latest version of pyglet (**_1.2alpha1**_) it is defined in
`pyglet.gl.gl`. This commit addresses this issue by adding a
try-except block that imports `cfloat` from this module.

fixes #8915 
