### PR TITLE
Issue #8891: Added a check in cse_main for matrices.

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -422,6 +422,16 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     if isinstance(exprs, Basic):
         exprs = [exprs]
 
+    temp = []
+    for e in exprs:
+        if isinstance(e, Matrix):
+            for subexp in e:
+                temp.append(subexp)
+        else:
+            temp.append(e)
+    exprs = temp
+    del temp
+
     if optimizations is None:
         optimizations = list()
     elif optimizations == 'basic':

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -422,6 +422,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     if isinstance(exprs, Basic):
         exprs = [exprs]
 
+    copy = exprs
     temp = []
     for e in exprs:
         if isinstance(e, Matrix):
@@ -460,6 +461,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
                                            order)
 
     # Postprocess the expressions to return the expressions to canonical form.
+    exprs = copy
     for i, (sym, subtree) in enumerate(replacements):
         subtree = postprocess_for_cse(subtree, optimizations)
         replacements[i] = (sym, subtree)
@@ -468,6 +470,19 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
 
     if isinstance(exprs, Matrix):
         reduced_exprs = [Matrix(exprs.rows, exprs.cols, reduced_exprs)]
+    else:
+        temp = []
+        i = 0
+        for e in exprs:
+            if isinstance(e, Matrix):
+                temp.append([Matrix(e.rows, e.cols, reduced_exprs[i:i+e.rows*e.cols])])
+                i = e.rows*e.cols + i
+            else:
+                temp.append(reduced_exprs[i])
+                i = i + 1
+        reduced_exprs = temp
+        del temp
+
     if postprocess is None:
         return replacements, reduced_exprs
     return postprocess(replacements, reduced_exprs)

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -416,7 +416,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     reduced_exprs : list of sympy expressions
         The reduced expressions with all of the replacements above.
     """
-    from sympy.matrices import Matrix
+    from sympy.matrices import Matrix, SparseMatrix
 
     # Handle the case if just one expression was passed.
     if isinstance(exprs, Basic):
@@ -425,7 +425,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     copy = exprs
     temp = []
     for e in exprs:
-        if isinstance(e, Matrix):
+        if isinstance(e, Matrix) or isinstance(e, SparseMatrix):
             for subexp in e:
                 temp.append(subexp)
         else:
@@ -474,8 +474,8 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
         temp = []
         i = 0
         for e in exprs:
-            if isinstance(e, Matrix):
-                temp.append([Matrix(e.rows, e.cols, reduced_exprs[i:i+e.rows*e.cols])])
+            if isinstance(e, Matrix) or isinstance(e, SparseMatrix):
+                temp.append([e.__class__(e.rows, e.cols, reduced_exprs[i:i+e.rows*e.cols])])
                 i = e.rows*e.cols + i
             else:
                 temp.append(reduced_exprs[i])
@@ -485,4 +485,5 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
 
     if postprocess is None:
         return replacements, reduced_exprs
+
     return postprocess(replacements, reduced_exprs)

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -361,4 +361,5 @@ def test_issue_7840():
 def test_issue_8891():
     m1 = Matrix([w + x, w + x])
     m2 = Matrix([y + z, y + z])
-    assert cse([m1, m2]) == cse(m1[:] + m2[:])
+    ans = '([(x0, w + x), (x1, y + z)], [[Matrix([\n[x0],\n[x0]])], [Matrix([\n[x1],\n[x1]])]])'
+    assert str(cse([m1, m2])) == ans

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -7,6 +7,7 @@ from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.functions.special.hyper import meijerg
 from sympy.simplify import cse_main, cse_opts
 from sympy.utilities.pytest import XFAIL, raises
+from sympy.matrices import eye, SparseMatrix
 
 w, x, y, z = symbols('w,x,y,z')
 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12 = symbols('x:13')
@@ -359,7 +360,14 @@ def test_issue_7840():
     assert len(substitutions) < 1
 
 def test_issue_8891():
-    m1 = Matrix([w + x, w + x])
-    m2 = Matrix([y + z, y + z])
-    ans = '([(x0, w + x), (x1, y + z)], [[Matrix([\n[x0],\n[x0]])], [Matrix([\n[x1],\n[x1]])]])'
-    assert str(cse([m1, m2])) == ans
+    m1 = eye(2)*(x + y)
+    m2 = SparseMatrix.zeros(2)
+    m2[0, 0] = x + y
+    m = [x + y, m1, m2]
+    r,e = cse(m)
+
+    ans = ([(x0, x + y)], [x0, [Matrix([[x0, 0], [0, x0]])], [Matrix([[x0, 0], [0, 0]])]])
+    assert cse(m) == ans
+
+    ans = ['MutableDenseMatrix', 'MutableSparseMatrix']
+    assert [e[1][0].__class__.__name__, e[2][0].__class__.__name__] == ans

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -357,3 +357,8 @@ def test_issue_7840():
     assert new_eqn[0] == expr
     # there should not be any replacements
     assert len(substitutions) < 1
+
+def test_issue_8891():
+    m1 = Matrix([w + x, w + x])
+    m2 = Matrix([y + z, y + z])
+    assert cse([m1, m2]) == cse(m1[:] + m2[:])

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -7,7 +7,8 @@ from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.functions.special.hyper import meijerg
 from sympy.simplify import cse_main, cse_opts
 from sympy.utilities.pytest import XFAIL, raises
-from sympy.matrices import eye, SparseMatrix
+from sympy.matrices import eye, SparseMatrix, MutableDenseMatrix, MutableSparseMatrix
+
 
 w, x, y, z = symbols('w,x,y,z')
 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12 = symbols('x:13')
@@ -68,7 +69,7 @@ def test_cse_single2():
     substs, reduced = cse(e)
     assert substs == [(x0, x + y)]
     assert reduced == [sqrt(x0) + x0**2]
-    assert isinstance(cse(Matrix([[1]]))[1][0], Matrix)
+    assert isinstance(cse(Matrix([[1]]))[1], Matrix)
 
 
 def test_cse_not_possible():
@@ -366,8 +367,7 @@ def test_issue_8891():
     m = [x + y, m1, m2]
     r,e = cse(m)
 
-    ans = ([(x0, x + y)], [x0, [Matrix([[x0, 0], [0, x0]])], [Matrix([[x0, 0], [0, 0]])]])
+    ans = ([(x0, x + y)], [x0, Matrix([[x0, 0], [0, x0]]), Matrix([[x0, 0], [0, 0]])])
     assert cse(m) == ans
 
-    ans = ['MutableDenseMatrix', 'MutableSparseMatrix']
-    assert [e[1][0].__class__.__name__, e[2][0].__class__.__name__] == ans
+    assert isinstance(e[1], MutableDenseMatrix) and isinstance(e[2], MutableSparseMatrix)


### PR DESCRIPTION
`cse_main` was taking matrices as one whole unit (instead of breaking them down) if they occurred in lists. So I added a snippet in `cse_main` which checks whether any sub-expression is a matrix and then accordingly breaks it, finally appending it to `exprs`.

Edit: Changed postprocessing.

Fixes #8891 
@moorepants please review.
