### PR TITLE
(Nested)Integral of (Nested)summations works. fixes #7827

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -396,10 +396,8 @@ class Integral(AddWithLimits):
 
         # now compute and check the function
         if isinstance(self.function, Sum):
-            for limit in self.function.limits:
-                if self.variables[0] in limit:
-                        break
-            else:
+            if self.variables[0] not in self.function.limits[0] \
+            and self.function.variables[0] not in self.limits[0]:
                 return Sum(integrate(self.function.function, self.variables[0]), self.function.limits)
         function = self.function
         if deep:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -396,7 +396,10 @@ class Integral(AddWithLimits):
 
         # now compute and check the function
         if isinstance(self.function, Sum):
-	    if self.variables[0] not in self.function.limits[0]:
+            for limit in self.function.limits:
+                if self.variables[0] in limit:
+                        break
+            else:
                 return Sum(integrate(self.function.function, self.variables[0]), self.function.limits)
         function = self.function
         if deep:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -401,7 +401,7 @@ class Integral(AddWithLimits):
                 or variable in self.limits[0]:
                     break
             else:
-                return Sum(integrate(self.function.function.doit(), self.variables[0]).doit(), self.function.limits).doit()
+                return Sum(Integral(self.function.function.doit(), self.variables[0]), self.function.limits).doit()
         function = self.function
         if deep:
             function = function.doit(**hints)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -396,9 +396,12 @@ class Integral(AddWithLimits):
 
         # now compute and check the function
         if isinstance(self.function, Sum):
-            if self.variables[0] not in self.function.limits[0] \
-            and self.function.variables[0] not in self.limits[0]:
-                return Sum(integrate(self.function.function, self.variables[0]), self.function.limits)
+            for variable in self.variables:
+                if variable in self.function.limits[0] \
+                or variable in self.limits[0]:
+                    break
+            else:
+                return Sum(integrate(self.function.function.doit(), self.variables[0]).doit(), self.function.limits).doit()
         function = self.function
         if deep:
             function = function.doit(**hints)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -397,8 +397,7 @@ class Integral(AddWithLimits):
         # now compute and check the function
         if isinstance(self.function, Sum):
             for variable in self.variables:
-                if variable in self.function.limits[0] \
-                or variable in self.limits[0]:
+                if variable in self.function.limits[0]:
                     break
             else:
                 return Sum(Integral(self.function.function.doit(), self.variables[0]), self.function.limits).doit()

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -396,7 +396,8 @@ class Integral(AddWithLimits):
 
         # now compute and check the function
         if isinstance(self.function, Sum):
-            return Sum(integrate(self.function.function, self.variables[0]), self.function.limits)
+	    if self.variables[0] not in self.function.limits[0]:
+                return Sum(integrate(self.function.function, self.variables[0]), self.function.limits)
         function = self.function
         if deep:
             function = function.doit(**hints)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -25,6 +25,7 @@ from sympy.solvers.solvers import solve, posify
 from sympy.functions import Piecewise, sqrt, sign
 from sympy.geometry import Curve
 from sympy.series import limit
+from sympy.concrete.summations import Sum
 
 
 class Integral(AddWithLimits):
@@ -394,6 +395,8 @@ class Integral(AddWithLimits):
             return S.Zero
 
         # now compute and check the function
+        if isinstance(self.function, Sum):
+            return Sum(integrate(self.function.function, self.variables[0]), self.function.limits)
         function = self.function
         if deep:
             function = function.doit(**hints)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -4,11 +4,8 @@ from sympy import (
     I, Integral, integrate, Interval, Lambda, LambertW, log,
     Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify, sin, tan, sqrt,
     sstr, Sum, Symbol, symbols, sympify, trigsimp,
-<<<<<<< HEAD
     Tuple, nan, And, Eq, re, im, summation, Sum
-=======
     Tuple, nan, And, Eq, Ne, re, im, polar_lift, meijerg
->>>>>>> master
 )
 from sympy.functions.elementary.complexes import periodic_argument
 from sympy.integrals.risch import NonElementaryIntegral

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1071,3 +1071,4 @@ def test_issue_7827():
         Sum(Piecewise((0, Eq(n, 0)), (-cos(n*x)/n, True)), (n, 1, N))
     assert integrate(integrate(summation(sin(n*x), (n,1,N)), x), x) == \
         Piecewise((0, Eq(n, 0)), (Sum(Piecewise((-x/n, Eq(n, 0)), (-sin(n*x)/n**2, True)), (n, 1, N)), True))
+    assert integrate(Sum(x, (x, 1, n)), n) == Integral(Sum(x, (x, 1, n)), n)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -4,8 +4,7 @@ from sympy import (
     I, Integral, integrate, Interval, Lambda, LambertW, log,
     Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify, sin, tan, sqrt,
     sstr, Sum, Symbol, symbols, sympify, trigsimp,
-    Tuple, nan, And, Eq, re, im, summation, Sum
-    Tuple, nan, And, Eq, Ne, re, im, polar_lift, meijerg
+    Tuple, nan, And, Eq, Ne, re, im, polar_lift, meijerg, summation, Sum
 )
 from sympy.functions.elementary.complexes import periodic_argument
 from sympy.integrals.risch import NonElementaryIntegral

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1070,8 +1070,6 @@ def test_issue_2708():
     assert integrate(f + exp(z), (z, 2, 3)) == integral_f - exp(2) + exp(3)
 
 
-<<<<<<< HEAD
-=======
 def test_issue_8368():
     assert integrate(exp(-s*x)*cosh(x), (x, 0, oo)) == \
         Piecewise((pi*Piecewise((-s/(pi*(-s**2 + 1)), Abs(s**2) < 1),
@@ -1091,4 +1089,17 @@ def test_issue_8901():
     assert integrate(sinh(1.0*x)) == 1.0*cosh(1.0*x)
     assert integrate(tanh(1.0*x)) == 1.0*x - 1.0*log(tanh(1.0*x) + 1)
     assert integrate(tanh(x)) == x - log(tanh(x) + 1)
->>>>>>> master
+
+
+def test_issue_7827():
+    x, n, N = symbols('x n N')
+    assert integrate(summation(x*n, (n, 1, N)), x) == x**2*(N**2/4 + N/4)
+    assert integrate(summation(x*sin(n), (n,1,N)), x) == \
+        Sum(x**2*sin(n)/2, (n, 1, N))
+    assert integrate(summation(sin(n*x), (n,1,N)), x) == \
+        Sum(Piecewise((0, Eq(n, 0)), (-cos(n*x)/n, True)), (n, 1, N))
+    assert integrate(integrate(summation(sin(n*x), (n,1,N)), x), x) == \
+        Piecewise((0, Eq(n, 0)), (Sum(Piecewise((-x/n, Eq(n, 0)), (-sin(n*x)/n**2, True)), (n, 1, N)), True))
+    assert integrate(Sum(x, (x, 1, n)), n) == Integral(Sum(x, (x, 1, n)), n)
+    assert integrate(Sum(x, (x, 1, y)), x) == x*Sum(x, (x, 1, y))
+    assert integrate(Sum(x, (x, y, n)), y) == Integral(Sum(x, (x, y, n)), y)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -4,7 +4,7 @@ from sympy import (
     I, Integral, integrate, Interval, Lambda, LambertW, log,
     Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify, sin, tan, sqrt,
     sstr, Sum, Symbol, symbols, sympify, trigsimp,
-    Tuple, nan, And, Eq, re, im
+    Tuple, nan, And, Eq, re, im, summation, Sum
 )
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.utilities.pytest import XFAIL, raises, slow
@@ -1060,3 +1060,14 @@ def test_issue_2708():
     integral_f = NonElementaryIntegral(f, (z, 2, 3))
     assert Integral(f, (z, 2, 3)).doit() == integral_f
     assert integrate(f + exp(z), (z, 2, 3)) == integral_f - exp(2) + exp(3)
+
+
+def test_issue_7827():
+    x, n, N = symbols('x n N')
+    assert integrate(summation(x*n, (n, 1, N)), x) == x**2*(N**2/4 + N/4)
+    assert integrate(summation(x*sin(n), (n,1,N)), x) == \
+        Sum(x**2*sin(n)/2, (n, 1, N))
+    assert integrate(summation(sin(n*x), (n,1,N)), x) == \
+        Sum(Piecewise((0, Eq(n, 0)), (-cos(n*x)/n, True)), (n, 1, N))
+    assert integrate(integrate(summation(sin(n*x), (n,1,N)), x), x) == \
+        Piecewise((0, Eq(n, 0)), (Sum(Piecewise((-x/n, Eq(n, 0)), (-sin(n*x)/n**2, True)), (n, 1, N)), True))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1072,3 +1072,5 @@ def test_issue_7827():
     assert integrate(integrate(summation(sin(n*x), (n,1,N)), x), x) == \
         Piecewise((0, Eq(n, 0)), (Sum(Piecewise((-x/n, Eq(n, 0)), (-sin(n*x)/n**2, True)), (n, 1, N)), True))
     assert integrate(Sum(x, (x, 1, n)), n) == Integral(Sum(x, (x, 1, n)), n)
+    assert integrate(Sum(x, (x, 1, y)), x) == x*Sum(x, (x, 1, y))
+    assert integrate(Sum(x, (x, y, n)), y) == Integral(Sum(x, (x, y, n)), y)


### PR DESCRIPTION
This implements integral of summations. Nested integrals and summations are also fixed. Please take a look at the tests. @asmeurer please review. fixes #7827

```
from sympy import *
x, n, N, y = symbols('x n N y')
print integrate(summation(sin(n*x), (n,1,N)), x)
print integrate(Sum(x, (x, 1, y)), x)
print integrate(Sum(x, (x, y, n)), y)
print integrate(Sum(x, (x, n, y)), y)
print integrate(Sum(x, (x, 1, n)), (x, n))
print integrate(Sum(x, (x, y, n)), (x, n, y))
```

output :

```
Sum(Piecewise((0, n == 0), (-cos(n*x)/n, True)), (n, 1, N))
x*Sum(x, (x, 1, y))
Integral(Sum(x, (x, y, n)), y)
Integral(Sum(x, (x, n, y)), y)
n*Sum(x, (x, 1, n))
-n*Sum(x, (x, y, n)) + y*Sum(x, (x, y, n))
```
