### PR TITLE
Multiplication of PermGroup with Permutation works(implementing cosets). Fixes #7127

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -217,6 +217,8 @@ class PermutationGroup(Basic):
 
         """
         gens1 = [perm._array_form for perm in self.generators]
+        if isinstance(other, Permutation) or isinstance(other, Cycle):
+            return [perm._array_form*other for perm in self.generators]
         gens2 = [perm._array_form for perm in other.generators]
         n1 = self._degree
         n2 = other._degree

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1243,8 +1243,11 @@ class Permutation(Basic):
         Cycle(1, 3, 2)
 
         """
+        from sympy.combinatorics.perm_groups import PermutationGroup
         a = self.array_form
         # __rmul__ makes sure the other is a Permutation
+        if isinstance(other, PermutationGroup):
+            return [a*i for i in other.generators]
         b = other.array_form
         if not b:
             perm = a

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -685,3 +685,11 @@ def test_make_perm():
         Permutation([4, 7, 6, 5, 0, 3, 2, 1])
     assert cube.pgroup.make_perm(7, seed=list(range(7))) == \
         Permutation([6, 7, 3, 2, 5, 4, 0, 1])
+
+
+def test_cosets():
+    a = Permutation(1, 2)
+    b = Permutation(0, 1)
+    G = PermutationGroup([Permutation(1, 2), Permutation(2)(0, 1)])
+    assert a*G == [Permutation(2), Permutation(0, 1, 2)]
+    assert G*a == [Permutation(2), Permutation(0, 2, 1)]

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -687,7 +687,7 @@ def test_make_perm():
         Permutation([6, 7, 3, 2, 5, 4, 0, 1])
 
 
-def test_cosets():
+def test_issue_7127():
     a = Permutation(1, 2)
     b = Permutation(0, 1)
     G = PermutationGroup([Permutation(1, 2), Permutation(2)(0, 1)])


### PR DESCRIPTION
This enables `a*G` and `G*a` for group `G` and permutation `a`. fixes #7127 .closes #8734 
