### PR TITLE
8907: improve comp for testing for (in)significant difference

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -9,7 +9,7 @@ from .expr import Expr, AtomicExpr
 from .symbol import Symbol, Wild, Dummy, symbols, var
 from .numbers import Number, Float, Rational, Integer, NumberSymbol, \
     RealNumber, igcd, ilcm, seterr, E, I, nan, oo, pi, zoo, \
-    AlgebraicNumber
+    AlgebraicNumber, comp
 from .power import Pow, integer_nthroot
 from .mul import Mul, prod
 from .add import Add

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, Integer,
-        sign, im, nan, Dummy, factorial
+        sign, im, nan, Dummy, factorial, comp
 )
 from sympy.core.compatibility import long, range
 from sympy.utilities.iterables import cartes
@@ -1476,17 +1476,15 @@ def test_Mod():
     assert Mod(-3.3, 1) == 1 - point3
     assert Mod(0.7, 1) == Float(0.7)
     e = Mod(1.3, 1)
-    point3 = Float._new(Float(.3)._mpf_, 51)
-    assert e == point3 and e.is_Float
+    assert comp(e, .3) and e.is_Float
     e = Mod(1.3, .7)
-    point6 = Float._new(Float(.6)._mpf_, 51)
-    assert e == point6 and e.is_Float
+    assert comp(e, .6) and e.is_Float
     e = Mod(1.3, Rational(7, 10))
-    assert e == point6 and e.is_Float
+    assert comp(e, .6) and e.is_Float
     e = Mod(Rational(13, 10), 0.7)
-    assert e == point6 and e.is_Float
+    assert comp(e, .6) and e.is_Float
     e = Mod(Rational(13, 10), Rational(7, 10))
-    assert e == .6 and e.is_Rational
+    assert comp(e, .6) and e.is_Rational
 
     # check that sign is right
     r2 = sqrt(2)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -5,7 +5,8 @@ from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    AlgebraicNumber, simplify)
 from sympy.core.compatibility import long, u
 from sympy.core.power import integer_nthroot
-from sympy.core.numbers import igcd, ilcm, igcdex, seterr, _intcache, mpf_norm
+from sympy.core.numbers import (igcd, ilcm, igcdex, seterr, _intcache,
+    mpf_norm, comp)
 from mpmath import mpf
 from sympy.utilities.pytest import XFAIL, raises
 import mpmath
@@ -1465,3 +1466,16 @@ def test_Float_idempotence():
     z = Float(x, 15)
     assert same_and_same_prec(y, x)
     assert not same_and_same_prec(z, x)
+
+
+def test_comp():
+    # sqrt(2) = 1.414213 5623730950...
+    a = sqrt(2).n(7)
+    assert comp(a, 1.41421346) is False
+    assert comp(a, 1.41421347)
+    assert comp(a, 1.41421366)
+    assert comp(a, 1.41421367) is False
+    assert comp(sqrt(2).n(2), '1.4')
+    assert comp(sqrt(2).n(2), Float(1.4, 2), '')
+    raises(ValueError, lambda: comp(sqrt(2).n(2), 1.4, ''))
+    assert comp(sqrt(2).n(2), Float(1.4, 3), '') is False

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -1,13 +1,10 @@
 from sympy import (
     Abs, adjoint, arg, atan2, conjugate, cos, DiracDelta, E, exp, expand,
-    Expr, Function, Heaviside, I,
-    Interval,
-    im, log, nan, oo, pi, Rational, re, S,
-    sign, sin, sqrt, Symbol, symbols, transpose, zoo, exp_polar, Piecewise
+    Expr, Function, Heaviside, I, im, log, nan, oo, pi, Rational, re, S,
+    sign, sin, sqrt, Symbol, symbols, transpose, zoo, exp_polar, Piecewise,
+    Interval, comp
 )
 from sympy.utilities.pytest import XFAIL, raises
-
-from sympy.utilities.randtest import comp
 
 
 def N_equals(a, b):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -11,7 +11,7 @@ from sympy.core.mul import expand_2arg, Mul
 from sympy.core.power import Pow
 from sympy.core.relational import Eq
 from sympy.core.sympify import sympify
-from sympy.core.numbers import Rational, igcd
+from sympy.core.numbers import Rational, igcd, comp
 from sympy.core.exprtools import factor_terms
 
 from sympy.ntheory import divisors, isprime, nextprime
@@ -20,7 +20,8 @@ from sympy.functions.elementary.miscellaneous import root
 
 from sympy.polys.polytools import Poly, cancel, factor, gcd_list, discriminant
 from sympy.polys.specialpolys import cyclotomic_poly
-from sympy.polys.polyerrors import PolynomialError, GeneratorsNeeded, DomainError
+from sympy.polys.polyerrors import (PolynomialError, GeneratorsNeeded,
+    DomainError)
 from sympy.polys.polyquinticconst import PolyQuintic
 from sympy.polys.rationaltools import together
 
@@ -554,8 +555,6 @@ def roots_quintic(f):
     order = quintic.order(theta, d)
     test = (order*delta.n()) - ( (l1.n() - l4.n())*(l2.n() - l3.n()) )
     # Comparing floats
-    # Problems importing on top
-    from sympy.utilities.randtest import comp
     if not comp(test, 0, tol):
         l2, l3 = l3, l2
 

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -5,7 +5,12 @@ from __future__ import print_function, division
 from random import uniform
 import random
 
-from sympy import I, nsimplify, Tuple, Symbol
+from sympy.core.numbers import I
+from sympy.simplify.simplify import nsimplify
+from sympy.core.containers import Tuple
+from sympy.core.numbers import comp
+from sympy.core.symbol import Symbol
+from sympy.core.sympify import sympify
 from sympy.core.compatibility import is_sequence, as_int
 
 
@@ -20,24 +25,6 @@ def random_complex_number(a=2, b=-1, c=3, d=1, rational=False):
     if not rational:
         return A + I*B
     return nsimplify(A, rational=True) + I*nsimplify(B, rational=True)
-
-
-def comp(z1, z2, tol):
-    """Return a bool indicating whether the error between z1 and z2 is <= tol.
-
-    If z2 is non-zero and ``|z1| > 1`` the error is normalized by ``|z1|``, so
-    if you want the absolute error, call this as ``comp(z1 - z2, 0, tol)``.
-    """
-    if not z1:
-        z1, z2 = z2, z1
-    if not z1:
-        return True
-    diff = abs(z1 - z2)
-    az1 = abs(z1)
-    if z2 and az1 > 1:
-        return diff/az1 <= tol
-    else:
-        return diff <= tol
 
 
 def verify_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
@@ -89,6 +76,7 @@ def test_derivative_numerically(f, z, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     f1 = f.diff(z).subs(z, z0)
     f2 = Derivative(f, z).doit_numerically(z0)
     return comp(f1.n(), f2.n(), tol)
+
 
 def _randrange(seed=None):
     """Return a randrange generator. ``seed`` can be


### PR DESCRIPTION
A test as simple as Mod(1.3, 1) == .3 fails in SymPy because the
underlying Floats that end up being compared are not exactly the
same. To fascillitate such comparisons, changes were made to the
comp function. To compare such numbers the comp function can be
used as comp(Mod(1.3, 1), .3) and the result will be True.

fixes #8815, closes #8907 
