### PR TITLE
Make the development version identifier PEP 440 compliant.

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -20,7 +20,7 @@ First, make sure that you have done the following things
 - Change the version in the release branch in sympy/release.py. If you want to
   do a release candidate, change it to a [PEP
   440](https://www.python.org/dev/peps/pep-0440) compliant version like
-  0.7.3rc1.
+  0.7.3.rc1.
 
 - Change the version in master. This way, any additional changes made in master
   will be shown as coming from the right place. The master release should be

--- a/release/README.md
+++ b/release/README.md
@@ -17,13 +17,16 @@ First, make sure that you have done the following things
 - Create a release branch. Usually this branch is the same name as the release
   (e.g., "0.7.3"), although no naming convention is enforced on it.
 
-- Change the version in the release branch in sympy/release.py.  If you want
-  to do a release candidate, change it to something like 0.7.3.rc1.
+- Change the version in the release branch in sympy/release.py. If you want to
+  do a release candidate, change it to a [PEP
+  440](https://www.python.org/dev/peps/pep-0440) compliant version like
+  0.7.3rc1.
 
 - Change the version in master. This way, any additional changes made in master
   will be shown as coming from the right place. The master release should be
-  like "0.7.4.dev1", see [PEP 440](https://www.python.org/dev/peps/pep-0440/)
-  for version numbers.
+  e.g. `0.7.4.dev`, see [PEP 440](https://www.python.org/dev/peps/pep-0440) for
+  rules about development version numbers. Note that this version number should
+  the next projected version plus the `.dev`.
 
 - Push the release branch up to origin, and make a pull request for it against
   master.
@@ -40,7 +43,7 @@ If you want to test the release process without pushing a branch to the
 official repo, you can push a branch to your fork and use `fab vagrant
 release:fork='username'`, where `username` is your GitHub username.  Note that
 once you do the actual release, you should do it in a branch in the official
-GitHub repo.  **NOTE**: If your fork does not have all the tags of the
+GitHub repo. **NOTE**: If your fork does not have all the tags of the
 official repo, then the code that finds the previous version will not work
 correctly.  Hence, you may see things like more authors in the authors list
 than you should.  To remedy this, be sure to do `git fetch origin --tags` and

--- a/release/README.md
+++ b/release/README.md
@@ -20,9 +20,10 @@ First, make sure that you have done the following things
 - Change the version in the release branch in sympy/release.py.  If you want
   to do a release candidate, change it to something like 0.7.3.rc1.
 
-- Change the version in master.  This way, any additional changes made in
-  master will be shown as coming from the right place. The master release
-  should be like "0.7.3-git".
+- Change the version in master. This way, any additional changes made in master
+  will be shown as coming from the right place. The master release should be
+  like "0.7.4.dev1", see [PEP 440](https://www.python.org/dev/peps/pep-0440/)
+  for version numbers.
 
 - Push the release branch up to origin, and make a pull request for it against
   master.

--- a/release/fabfile.py
+++ b/release/fabfile.py
@@ -198,7 +198,7 @@ def gitrepos(branch=None, fork='sympy'):
 @task
 def get_sympy_version(version_cache=[]):
     """
-    Get the full version of SymPy being released (like 0.7.3rc1)
+    Get the full version of SymPy being released (like 0.7.3.__weakrefoffset__rc1)
     """
     if version_cache:
         return version_cache[0]

--- a/release/fabfile.py
+++ b/release/fabfile.py
@@ -198,7 +198,7 @@ def gitrepos(branch=None, fork='sympy'):
 @task
 def get_sympy_version(version_cache=[]):
     """
-    Get the full version of SymPy being released (like 0.7.3.rc1)
+    Get the full version of SymPy being released (like 0.7.3rc1)
     """
     if version_cache:
         return version_cache[0]

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -71,7 +71,7 @@ def _make_message(ipython=True, quiet=False, source=None):
                 _source += '>>> ' + line + '\n'
 
         doc_version = sympy_version
-        if doc_version.find('-git') >= 0:
+        if doc_version.find('-git') >= 0 or doc_version.find('dev') >= 0:
             doc_version = "dev"
         else:
             doc_version = "%s.%s.%s/" % tuple(doc_version.split('.')[:3])

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -71,7 +71,7 @@ def _make_message(ipython=True, quiet=False, source=None):
                 _source += '>>> ' + line + '\n'
 
         doc_version = sympy_version
-        if doc_version.find('-git') >= 0 or doc_version.find('dev') >= 0:
+        if 'dev' in doc_version:
             doc_version = "dev"
         else:
             doc_version = "%s.%s.%s/" % tuple(doc_version.split('.')[:3])

--- a/sympy/release.py
+++ b/sympy/release.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.6-git"
+__version__ = "0.7.7.dev1"

--- a/sympy/release.py
+++ b/sympy/release.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.7.dev1"
+__version__ = "0.7.7.dev"


### PR DESCRIPTION
Fixes #8953.
