### PR TITLE
#8943: All equations without constants return trivial solution.(diophantine)

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -77,6 +77,10 @@ def diophantine(eq, param=symbols("t", integer=True)):
 
     terms = factor_list(eq)[1]
 
+    has_constant = True
+    if eq.as_coefficients_dict()[1] == 0:
+        has_constant = False
+
     sols = set([])
 
     for term in terms:
@@ -94,6 +98,9 @@ def diophantine(eq, param=symbols("t", integer=True)):
             for sol in solution:
                 if merge_solution(var, var_t, sol) != ():
                     sols.add(merge_solution(var, var_t, sol))
+
+        if not sols and not has_constant:
+            sols = set([(0,)*len(var)])
 
     return sols
 

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -427,6 +427,10 @@ def test_diophantine():
     #assert check_solutions(y**2 - 7*x*y + 4*y*z)
     assert check_solutions(x**2 - 2*x + 1)
 
+    #Issue #8943
+    assert diophantine((3*(x**2 + y**2 + z**2) - 14*(x*y + y*z + z*x))) == set([(0, 0, 0)])
+    assert diophantine( x**2 + 4*x*y + 8*z ) == set([(0, 0, 0)])
+
 
 def test_general_pythagorean():
 


### PR DESCRIPTION
Homogeneous ternary quadratic solutions have a different solver. I thought of making the solver return trivial solution but as @kevinventullo pointed out, the solver is not intended to return trivial solution.

Also the check for constants is generic in nature. Equations can be of type other than homogeneous ternary and still don't report trivial solution.

@asmeurer I know you wrote that you wanted to investigate the code first, but since I was nearly done, I made the PR.
Can change this code to return 0 as a special case rather than returning it always.

Also the commit's name is wrong. Not only homogeneous equations, all equations without constants return trivial solution. Will change that.

Fixes #8943 
