### PR TITLE
Added code to remove pdfs during setup.py clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ doc/sphinx/
 
 # pdf files generated from svg files (cd doc; make latex)
 doc/src/modules/physics/mechanics/*.pdf
+doc/src/modules/physics/vector/*.pdf
 
 # Mac OS X Junk
 .DS_Store

--- a/setup.py
+++ b/setup.py
@@ -190,6 +190,12 @@ class clean(Command):
             elif os.path.isdir(f):
                 shutil.rmtree(f)
 
+        os.chdir(dir_setup + "/doc/src/modules/physics/vector")
+
+        for f in os.listdir(os.getcwd()):
+            if os.path.isfile(f) and f.endswith(".pdf"):
+                os.remove(f)
+
         os.chdir(curr_dir)
 
 


### PR DESCRIPTION
Corresponding Issue: #8966 
Added *.pdf in the corresponding dir in .gitignore and also wrote the
corresponding code in setup.py.
#8968 addresses the same issue
