### PR TITLE
Fix solve_univariate_inequality to handle infinity

### DIFF
--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -684,3 +684,9 @@ def test_issue_8777():
     assert And(x >= 1, x < oo).as_set() == Interval(1, oo)
     assert (x < oo).as_set() == Interval(-oo, oo)
     assert (x > -oo).as_set() == Interval(-oo, oo)
+
+
+def test_issue_8975():
+    x = symbols('x')
+    assert Or(And(-oo < x, x <= -2), And(2 <= x, x < oo)).as_set() == \
+        Interval(-oo, -2) + Interval(2, oo)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -410,6 +410,7 @@ def solve_univariate_inequality(expr, gen, relational=True):
             singularities.extend(solve(d, gen))
 
     include_x = expr.func(0, 0)
+
     def valid(x):
         v = e.subs(gen, x)
         r = expr.func(v, 0)
@@ -432,10 +433,10 @@ def solve_univariate_inequality(expr, gen, relational=True):
     for x in reals:
         end = x
 
-        if ((end is S.NegativeInfinity and expr.rel_op in ['>', '>=']) or
-           (end is S.Infinity and expr.rel_op in ['<', '<='])):
-            sol_sets.append(Interval(start, S.Infinity, True, True))
-            break
+        if end in [S.NegativeInfinity, S.Infinity]:
+            if valid(S(0)):
+                sol_sets.append(Interval(start, S.Infinity, True, True))
+                break
 
         if valid((start + end)/2 if start != S.NegativeInfinity else end - 1):
             sol_sets.append(Interval(start, end, True, True))

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -297,3 +297,8 @@ def test_issue_8545():
     assert reduce_abs_inequality(eq, '<', x) == ans
     eq = 1 - x - sqrt((1 - x)**2)
     assert reduce_inequalities(eq < 0) == ans
+
+
+def test_issue_8974():
+    assert isolve(-oo < x, x) == And(-oo < x, x < oo)
+    assert isolve(oo > x, x) == And(-oo < x, x < oo)


### PR DESCRIPTION
fixes #8974 
fixes #8975 

``` python
In [1]:Or(And(-oo < x, x <= -2), And(2 <= x, x < oo)).as_set()
Out[1]: (-oo, -2] U [2, oo)
```

Fix for infinite Inequality:

``` python
In [9]: solveset(-oo < x)
Out[9]:  (-oo, oo)

In [10]: solveset(oo > x)
Out[10]:  (-oo, oo)
```

Earlier both these returned EmptySet(), and as_set() returned wrong result.
