### PR TITLE
Function unicode compatiblity

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -707,10 +707,10 @@ class UndefinedFunction(FunctionClass):
     The (meta)class of undefined functions.
     """
     def __new__(mcl, name, **kwargs):
-        name=name.encode('ascii') # if user provides an UNICODE name
         if PY3:
-            # in python3, above command produces a binary string. To correct it,
-            name=name.decode('ascii')
+            name=str(name)
+        elif isinstance(name, unicode):
+            name=name.encode('utf-8')
 
         ret = BasicMeta.__new__(mcl, name, (AppliedUndef,), kwargs)
         ret.__module__ = None

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -707,9 +707,7 @@ class UndefinedFunction(FunctionClass):
     The (meta)class of undefined functions.
     """
     def __new__(mcl, name, **kwargs):
-        if PY3:
-            name=str(name)
-        elif isinstance(name, unicode):
+        if not PY3 and isinstance(name, unicode):
             name=name.encode('utf-8')
 
         ret = BasicMeta.__new__(mcl, name, (AppliedUndef,), kwargs)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -707,6 +707,7 @@ class UndefinedFunction(FunctionClass):
     The (meta)class of undefined functions.
     """
     def __new__(mcl, name, **kwargs):
+        name=name.encode('ascii') # if user provides an UNICODE name
         ret = BasicMeta.__new__(mcl, name, (AppliedUndef,), kwargs)
         ret.__module__ = None
         return ret

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -35,7 +35,7 @@ from .add import Add
 from .assumptions import ManagedProperties
 from .basic import Basic
 from .cache import cacheit
-from .compatibility import iterable, is_sequence, as_int, ordered
+from .compatibility import iterable, is_sequence, as_int, ordered, PY3
 from .core import BasicMeta, C
 from .decorators import _sympifyit
 from .expr import Expr, AtomicExpr
@@ -708,6 +708,10 @@ class UndefinedFunction(FunctionClass):
     """
     def __new__(mcl, name, **kwargs):
         name=name.encode('ascii') # if user provides an UNICODE name
+        if PY3:
+            # in python3, above command produces a binary string. To correct it,
+            name=name.decode('ascii')
+
         ret = BasicMeta.__new__(mcl, name, (AppliedUndef,), kwargs)
         ret.__module__ = None
         return ret

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -29,15 +29,18 @@ def test_unicode_name_support():
     # check if unicoded function is same as its ascii counterpart
     assert Function('k') == Function(u('k'))
 
-def test_greek_name_support():
+def test_unicode_characters_support():
+    # For single character names (unicode)
     Function('α')
     Function(u('α'))
     Function('α') == Function(u('α'))
-
+    
+    # For multi-character names (all unicode)
     Function('αβ')
     Function(u('αβ'))
     Function('αβ') == Function(u('αβ'))
 
+    # For a combination of unicode and ASCII characters
     Function('aαβ')
     Function(u('aαβ'))
     Function('aαβ') == Function(u('aαβ'))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -29,6 +29,20 @@ def test_unicode_name_support():
     # check if unicoded function is same as its ascii counterpart
     assert Function('k') == Function(u('k'))
 
+def test_greek_name_support():
+    Function('α')
+    Function(u('α'))
+    Function('α') == Function(u('α'))
+
+    Function('αβ')
+    Function(u('αβ'))
+    Function('αβ') == Function(u('αβ'))
+
+    Function('aαβ')
+    Function(u('aαβ'))
+    Function('aαβ') == Function(u('aαβ'))
+
+
 def test_bug1():
     e = sqrt(-log(w))
     assert e.subs(log(w), -x) == sqrt(x)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -23,6 +23,11 @@ def test_f_expand_complex():
     assert exp(z).expand(complex=True) == cos(im(z))*exp(re(z)) + \
         I*sin(im(z))*exp(re(z))
 
+def test_unicode_name_support():
+    Function(u'k') # check if unicoded function names can be created
+
+    # check if unicoded function is same as its ascii counterpart
+    assert Function('k') == Function(u'k')
 
 def test_bug1():
     e = sqrt(-log(w))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -9,7 +9,7 @@ from sympy.sets.sets import FiniteSet
 from sympy.solvers import solve
 from sympy.utilities.iterables import subsets, variations
 from sympy.core.cache import clear_cache
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, u
 
 f, g, h = symbols('f g h', cls=Function)
 
@@ -24,10 +24,10 @@ def test_f_expand_complex():
         I*sin(im(z))*exp(re(z))
 
 def test_unicode_name_support():
-    Function(u'k') # check if unicoded function names can be created
+    Function(u('k')) # check if unicoded function names can be created
 
     # check if unicoded function is same as its ascii counterpart
-    assert Function('k') == Function(u'k')
+    assert Function('k') == Function(u('k'))
 
 def test_bug1():
     e = sqrt(-log(w))


### PR DESCRIPTION
Make undefined functions accept unicoded names. Fixes #8960.
