### PR TITLE
Fixing conventions of LaTeX printing for rf/ff

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -981,14 +981,24 @@ class LatexPrinter(Printer):
             return tex
 
     def _print_RisingFactorial(self, expr, exp=None):
-        tex = r"{\left(%s\right)}^{\left(%s\right)}" % \
-            (self._print(expr.args[0]), self._print(expr.args[1]))
+        n, k = expr.args
+        if self._needs_brackets(n):
+            base = r"\left(%s\right)" % self._print(n)
+        else:
+            base = self._print(n)
+
+        tex = r"{%s}^{\left(%s\right)}" % (base, self._print(k))
 
         return self._do_exponent(tex, exp)
 
     def _print_FallingFactorial(self, expr, exp=None):
-        tex = r"{\left(%s\right)}_{\left(%s\right)}" % \
-            (self._print(expr.args[0]), self._print(expr.args[1]))
+        n, k = expr.args
+        if self._needs_brackets(k):
+            sub = r"\left(%s\right)" % self._print(k)
+        else:
+            sub = self._print(k)
+
+        tex = r"{\left(%s\right)}_{%s}" % (self._print(n), sub)
 
         return self._do_exponent(tex, exp)
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -222,9 +222,8 @@ def test_latex_functions():
 
     assert latex(binomial(2, k)) == r"{\binom{2}{k}}"
 
-    assert latex(
-        FallingFactorial(3, k)) == r"{\left(3\right)}_{\left(k\right)}"
-    assert latex(RisingFactorial(3, k)) == r"{\left(3\right)}^{\left(k\right)}"
+    assert latex(FallingFactorial(3, k)) == r"{\left(3\right)}_{k}"
+    assert latex(RisingFactorial(3, k)) == r"{3}^{\left(k\right)}"
 
     assert latex(floor(x)) == r"\lfloor{x}\rfloor"
     assert latex(ceiling(x)) == r"\lceil{x}\rceil"


### PR DESCRIPTION
This now follows the conventions from [Wikipedia](https://en.wikipedia.org/wiki/Pochhammer_symbol) and [Wolfram (1)](http://mathworld.wolfram.com/PochhammerSymbol.html), [Wolfram (2)](http://mathworld.wolfram.com/RisingFactorial.html).
