### PR TITLE
issue #8972: patches for two failures in pypy

### DIFF
--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -334,8 +334,6 @@ def _remove_gens(base, strong_gens, basic_orbits=None, strong_gens_distr=None):
     >>> from sympy.combinatorics.testutil import _verify_bsgs
     >>> S = SymmetricGroup(15)
     >>> base, strong_gens = S.schreier_sims_incremental()
-    >>> len(strong_gens)
-    26
     >>> new_gens = _remove_gens(base, strong_gens)
     >>> len(new_gens)
     14

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -632,13 +632,13 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         ring = p1.ring
 
         if isinstance(p2, ring.dtype):
-            if list(p1.keys()) != list(p2.keys()):
+            if set(p1.keys()) != set(p2.keys()):
                 return False
 
             almosteq = ring.domain.almosteq
 
-            for c1, c2 in zip(p1.itercoeffs(), p2.itercoeffs()):
-                if not almosteq(c1, c2, tolerance):
+            for k in p1.keys():
+                if not almosteq(p1[k], p2[k], tolerance):
                     return False
             else:
                 return True


### PR DESCRIPTION
There are two recurring failures that are caused by different
implementations of dictionaries in cpython and pypy.

almosteq() in rings.py is changed to compare two polynomials by
looping over keys even if their orders differ.

The example of _remove_gens() in combinatorics/utils.py is changed
by not checking the result of the Schreier-Sims algorithm which
depends on the implementation of dictionaries.
This is harmless since only the result of removing redundant
generators is interesting.
