### PR TITLE
mpmath dependency: Fixed 'sys' NameError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ import os
 import shutil
 import glob
 
-PY3 = sys.version_info[0] > 2
 mpmath_version = '0.19'
 
 try:
@@ -53,6 +52,7 @@ except ImportError:
         print("Please install the mpmath package with a version >= %s" % mpmath_version)
         sys.exit(-1)
 
+PY3 = sys.version_info[0] > 2
 
 # Make sure I have the right Python version.
 if sys.version_info[:2] < (2, 6):

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,13 @@ Or, if all else fails, feel free to write to the sympy list at
 sympy@googlegroups.com and ask for help.
 """
 
+import sys
+import subprocess
+import os
+import shutil
+import glob
+
+PY3 = sys.version_info[0] > 2
 mpmath_version = '0.19'
 
 try:
@@ -46,13 +53,6 @@ except ImportError:
         print("Please install the mpmath package with a version >= %s" % mpmath_version)
         sys.exit(-1)
 
-import sys
-import subprocess
-import os
-import shutil
-import glob
-
-PY3 = sys.version_info[0] > 2
 
 # Make sure I have the right Python version.
 if sys.version_info[:2] < (2, 6):


### PR DESCRIPTION
Fixed unwanted 'sys' NameError when mpmath dependency is not met 
by placing 'import sys' before mpmath dependency check.
