### PR TITLE
Extend Catalan number to negative numbers

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -841,7 +841,7 @@ class catalan(Function):
         if (n.is_integer and n.is_negative):
             if (n + 1).is_negative:
                 return S.Zero
-            if n == -S.One:
+            if (n + 1).is_zero:
                 return -S.Half
 
     def fdiff(self, argindex=1):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -834,8 +834,15 @@ class catalan(Function):
 
     @classmethod
     def eval(cls, n):
-        if n.is_Integer and n.is_nonnegative:
+        if (n.is_Integer and n.is_nonnegative) or \
+           (n.is_noninteger and n.is_negative):
             return 4**n*C.gamma(n + S.Half)/(C.gamma(S.Half)*C.gamma(n + 2))
+
+        if (n.is_integer and n.is_negative):
+            if (n + 1).is_negative:
+                return S.Zero
+            if n == -S.One:
+                return -S.Half
 
     def fdiff(self, argindex=1):
         n = self.args[0]

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -495,3 +495,15 @@ def test_issue_8496():
 
     raises(TypeError, lambda: catalan(n, k))
     raises(TypeError, lambda: euler(n, k))
+
+
+def test_issue_8601():
+    n = Symbol('n', integer=True, negative=True)
+
+    assert catalan(n - 1) == S.Zero
+    assert catalan(-S.Half) == S.ComplexInfinity
+    assert catalan(-S.One) == -S.Half
+    c1 = catalan(-5.6).evalf()
+    assert str(c1) == '6.93334070531408e-5'
+    c2 = catalan(-35.4).evalf()
+    assert str(c2) == '-4.14189164517449e-24'


### PR DESCRIPTION
fixes #8601 

`catalan` of negative one is `-1/2` and for all negative integers its zero.

Ref:
[1] http://reference.wolfram.com/language/ref/CatalanNumber.html
[2] http://www.wolframalpha.com/input/?i=catalannumber%5B-1%2F2%5D
[3] http://www.wolframalpha.com/input/?i=catalannumber%5B-5%5D
