### PR TITLE
MatrixExpr: add MatPow doit(), changes to doit for MatAdd, MatMul, Trace

### DIFF
--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -53,8 +53,13 @@ class MatAdd(MatrixExpr):
         from trace import Trace
         return MatAdd(*[Trace(arg) for arg in self.args]).doit()
 
-    def doit(self, **ignored):
-        return canonicalize(self)
+    def doit(self, **kwargs):
+        deep = kwargs.get('deep', True)
+        if deep:
+            args = [arg.doit(**kwargs) for arg in self.args]
+        else:
+            args = self.args
+        return canonicalize(MatAdd(*args))
 
 def validate(*args):
     if not all(arg.is_Matrix for arg in args):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -104,7 +104,7 @@ class MatMul(MatrixExpr):
             return Inverse(self)
 
     def doit(self, **kwargs):
-        deep = kwargs.get('deep', False)
+        deep = kwargs.get('deep', True)
         if deep:
             args = [arg.doit(**kwargs) for arg in self.args]
         else:

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -61,8 +61,16 @@ class MatPow(MatrixExpr):
             args = self.args
         base = args[0]
         exp = args[1]
-        if isinstance(base, MatrixBase) and exp.is_Rational:
+        if isinstance(base, MatrixBase) and exp.is_number:
+            if exp is S.One:
+                return base
             return base**exp
+        # Note: just evaluate cases we know, return unevaluated on others.
+        # E.g., MatrixSymbol('x', n, m) to power 0 is not an error.
+        if exp.is_zero and base.is_square:
+            return Identity(base.shape[0])
+        elif exp is S.One:
+            return base
         return MatPow(base, exp)
 
 

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -53,4 +53,17 @@ class MatPow(MatrixExpr):
         return T._entry(i, j)
 
 
+    def doit(self, **kwargs):
+        deep = kwargs.get('deep', True)
+        if deep:
+            args = [arg.doit(**kwargs) for arg in self.args]
+        else:
+            args = self.args
+        base = args[0]
+        exp = args[1]
+        if isinstance(base, MatrixBase) and exp.is_Rational:
+            return base**exp
+        return MatPow(base, exp)
+
+
 from .matmul import MatMul

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -1,4 +1,4 @@
-from sympy.matrices.expressions import MatrixSymbol, MatAdd
+from sympy.matrices.expressions import MatrixSymbol, MatAdd, MatPow, MatMul
 from sympy.matrices import eye, ImmutableMatrix
 from sympy import Basic
 
@@ -15,3 +15,12 @@ def test_matadd_sympify():
 
 def test_matadd_of_matrices():
     assert MatAdd(eye(2), 4*eye(2), eye(2)).doit() == ImmutableMatrix(6*eye(2))
+
+
+def test_doit_args():
+    A = ImmutableMatrix([[1, 2], [3, 4]])
+    B = ImmutableMatrix([[2, 3], [4, 5]])
+    assert MatAdd(A, MatPow(B, 2)).doit() == A + B**2
+    assert MatAdd(A, MatMul(A, B)).doit() == A + A*B
+    assert (MatAdd(A, X, MatMul(A, B), Y, MatAdd(2*A, B)).doit() ==
+            MatAdd(3*A + A*B + B, X, Y))

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -2,7 +2,7 @@ from sympy.core import I, symbols, Basic
 from sympy.functions import adjoint, transpose
 from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
         eye, ImmutableMatrix)
-from sympy.matrices.expressions import Adjoint, Transpose, det
+from sympy.matrices.expressions import Adjoint, Transpose, det, MatPow
 from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
         MatMul, xxinv, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe
@@ -85,6 +85,18 @@ def test_doit():
     assert MatMul(C, 2, D).doit().args == (2, C, D)
     assert MatMul(C, Transpose(D*C)).args == (C, Transpose(D*C))
     assert MatMul(C, Transpose(D*C)).doit(deep=True).args == (C, C.T, D.T)
+
+
+def test_doit_drills_down():
+    X = ImmutableMatrix([[1, 2], [3, 4]])
+    Y = ImmutableMatrix([[2, 3], [4, 5]])
+    assert MatMul(X, MatPow(Y, 2)).doit() == X*Y**2
+    assert MatMul(C, Transpose(D*C)).doit().args == (C, C.T, D.T)
+
+
+def test_doit_deep_false_still_canonical():
+    assert (MatMul(C, Transpose(D*C), 2).doit(deep=False).args ==
+            (2, C, Transpose(D*C)))
 
 
 def test_matmul_sympify():

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -44,47 +44,43 @@ def test_factor_in_front():
     assert factor_in_front(MatMul(A, 2, B, evaluate=False)) ==\
                            MatMul(2, A, B, evaluate=False)
 
+
 def test_remove_ids():
     assert remove_ids(MatMul(A, Identity(m), B, evaluate=False)) == \
                       MatMul(A, B, evaluate=False)
     assert null_safe(remove_ids)(MatMul(Identity(n), evaluate=False)) == \
                                  MatMul(Identity(n), evaluate=False)
 
+
 def test_xxinv():
     assert xxinv(MatMul(D, Inverse(D), D, evaluate=False)) == \
                  MatMul(Identity(n), D, evaluate=False)
 
+
 def test_any_zeros():
     assert any_zeros(MatMul(A, ZeroMatrix(m, k), evaluate=False)) == \
                      ZeroMatrix(n, k)
+
 
 def test_unpack():
     assert unpack(MatMul(A, evaluate=False)) == A
     x = MatMul(A, B)
     assert unpack(x) == x
 
-def test_only_squares():
-    A = MatrixSymbol('A', n, m)
-    C = MatrixSymbol('C', n, n)
-    D = MatrixSymbol('D', n, n)
 
+def test_only_squares():
     assert only_squares(C) == [C]
     assert only_squares(C, D) == [C, D]
     assert only_squares(C, A, A.T, D) == [C, A*A.T, D]
 
-def test_determinant():
-    A = MatrixSymbol('A', n, m)
-    C = MatrixSymbol('C', n, n)
-    D = MatrixSymbol('D', n, n)
 
+def test_determinant():
     assert det(2*C) == 2**n*det(C)
     assert det(2*C*D) == 2**n*det(C)*det(D)
     assert det(3*C*A*A.T*D) == 3**n*det(C)*det(A*A.T)*det(D)
 
-def test_doit():
-    C = MatrixSymbol('C', n, n)
-    D = MatrixSymbol('D', n, n)
 
+def test_doit():
     assert MatMul(C, 2, D).args == (C, 2, D)
     assert MatMul(C, 2, D).doit().args == (2, C, D)
     assert MatMul(C, Transpose(D*C)).args == (C, Transpose(D*C))

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -20,6 +20,20 @@ def test_entry():
     assert isinstance(MatPow(C, 2)[0, 0], Sum)
 
 
+def test_as_explicit_symbol():
+    X = MatrixSymbol('X', 2, 2)
+    assert MatPow(X, 0).as_explicit() == ImmutableMatrix(Identity(2))
+    assert MatPow(X, 1).as_explicit() == X.as_explicit()
+    assert MatPow(X, 2).as_explicit() == (X.as_explicit())**2
+
+
+def test_as_explicit_nonsquare_symbol():
+    X = MatrixSymbol('X', 2, 3)
+    assert MatPow(X, 1).as_explicit() == X.as_explicit()
+    for r in [0, 2, S.Half, S.Pi]:
+        raises(ShapeError, lambda: MatPow(X, r).as_explicit())
+
+
 def test_as_explicit():
     A = ImmutableMatrix([[1, 2], [3, 4]])
     assert MatPow(A, 0).as_explicit() == ImmutableMatrix(Identity(2))

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -4,7 +4,7 @@ from sympy.functions import adjoint, conjugate, transpose
 from sympy.matrices import eye, Matrix, ShapeError
 from sympy.matrices.expressions import (
     Adjoint, Identity, FunctionMatrix, MatrixExpr, MatrixSymbol, Trace,
-    ZeroMatrix, trace
+    ZeroMatrix, trace, MatPow
 )
 from sympy.utilities.pytest import raises, XFAIL
 
@@ -41,7 +41,17 @@ def test_Trace():
 
     assert Trace(A).arg is A
 
-    assert str(trace(A)) == str(Trace(A).doit(deep=True))
+    assert str(trace(A)) == str(Trace(A).doit())
+
+
+def test_Trace_doit():
+    X = Matrix([[1, 2], [3, 4]])
+    assert Trace(X).doit() == 5
+    q = MatPow(X, 2)
+    assert Trace(q).arg == q
+    assert Trace(q).doit() == 29
+    assert Trace(q).doit(deep=False).arg == q
+
 
 @XFAIL
 def test_rewrite():

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -4,7 +4,7 @@ from sympy.functions import adjoint, conjugate, transpose
 from sympy.matrices import eye, Matrix, ShapeError
 from sympy.matrices.expressions import (
     Adjoint, Identity, FunctionMatrix, MatrixExpr, MatrixSymbol, Trace,
-    ZeroMatrix, trace, MatPow
+    ZeroMatrix, trace, MatPow, MatAdd
 )
 from sympy.utilities.pytest import raises, XFAIL
 
@@ -50,6 +50,14 @@ def test_Trace_doit():
     q = MatPow(X, 2)
     assert Trace(q).arg == q
     assert Trace(q).doit() == 29
+    assert Trace(q).doit(deep=False).arg == q
+
+
+@XFAIL
+def test_Trace_MatAdd_doit():
+    # FIXME: Issue #9028.
+    X = Matrix([[1, 2], [3, 4]])
+    q = MatAdd(X, 2*X)
     assert Trace(q).doit(deep=False).arg == q
 
 

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -36,7 +36,7 @@ class Trace(Expr):
         return self.args[0]
 
     def doit(self, **kwargs):
-        if kwargs.get('deep', False):
+        if kwargs.get('deep', True):
             arg = self.arg.doit()
         else:
             arg = self.arg


### PR DESCRIPTION
I'm been looking at `doit()` support in MatrixExpr.  In particular, I'm interested in cases where these have ImmutableMatrices inside and they could be evaluated (e.g., after a substitution).

Here are some fixes:
- MatPow: added `doit()`.
- MatPow: refactor my older `.as_explicit()` code to use the the `doit()`.
- MatAdd: had rather ineffective `doit()`, improved.
- MatMul: change the default from `deep=False` to `deep=True`.  I cannot find a reason for it, so I've switched it.
- MatMul: clean up test code.
- Trace: change the default to `deep=True`.

The `deep=True` changes might be controversial: if someone knows why it `deep=False` before, I could always revert that (and add a comment to the code!)

Anyway, here is what it does:

```
In [6]: A = Matrix([[1,2],[3,4]])

In [7]: B = Matrix([[2,3],[4,5]])

In [8]: n = Symbol('n', integer=True)

In [9]: w = MatPow(A, n) + MatMul(A, MatPow(B,2*n))

In [10]: pprint(w)
               2⋅n           n
⎡1  2⎤⋅⎛⎡2  3⎤⎞    + ⎛⎡1  2⎤⎞ 
⎢    ⎥ ⎜⎢    ⎥⎟      ⎜⎢    ⎥⎟ 
⎣3  4⎦ ⎝⎣4  5⎦⎠      ⎝⎣3  4⎦⎠ 

In [21]: pprint(w.subs(n, 1))
               2           1
⎡1  2⎤⋅⎛⎡2  3⎤⎞  + ⎛⎡1  2⎤⎞ 
⎢    ⎥ ⎜⎢    ⎥⎟    ⎜⎢    ⎥⎟ 
⎣3  4⎦ ⎝⎣4  5⎦⎠    ⎝⎣3  4⎦⎠ 

In [22]: pprint(w.subs(n, 1).doit())    % these fixes make this work
⎡73   97 ⎤
⎢        ⎥
⎣163  215⎦
```
