### PR TITLE
Fixes issue in `dsolve` when using system of equations with symbols  

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -6475,10 +6475,10 @@ def _linear_2eq_order1_type1(x, y, t, r):
     .. math:: x = C_1 (bk t - 1) + b C_2 t , y = k^{2} b C_1 t + (b k^{2} t + 1) C_2
 
     """
-    l = Symbol('l')
+    l = Dummy('l')
     C1, C2, C3, C4 = symbols('C1:5')
-    l1 = RootOf(l**2 - (r['a']+r['d'])*l + r['a']*r['d'] - r['b']*r['c'], 0)
-    l2 = RootOf(l**2 - (r['a']+r['d'])*l + r['a']*r['d'] - r['b']*r['c'], 1)
+    l1 = RootOf(l**2 - (r['a']+r['d'])*l + r['a']*r['d'] - r['b']*r['c'], l, 0)
+    l2 = RootOf(l**2 - (r['a']+r['d'])*l + r['a']*r['d'] - r['b']*r['c'], l, 1)
     D = (r['a'] - r['d'])**2 + 4*r['b']*r['c']
     if (r['a']*r['d'] - r['b']*r['c']) != 0:
         if D > 0:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2552,3 +2552,11 @@ def test_issue_7093():
     sol = Eq(f(x), C1 - 2*x*sqrt(x**3)/5)
     eq = Derivative(f(x), x)**2 - x**3
     assert dsolve(eq) == sol and checkodesol(eq, sol) == (True, 0)
+
+
+def test_dsolve_linsystem_symbol():
+    eps = Symbol('epsilon', positive=True)
+    eq1 = (Eq(diff(f(x), x), -eps*g(x)), Eq(diff(g(x), x), eps*f(x)))
+    sol1 = [Eq(f(x), -eps*(C1*sin(eps*x) + C2*cos(eps*x))),
+            Eq(g(x), C1*eps*cos(eps*x) - C2*eps*sin(eps*x))]
+    assert dsolve(eq1) == sol1


### PR DESCRIPTION
## The issue

When using `dsolve` and a system of equations, if the equations has a symbol (e.g. a constant), then `dsolve` produces a rather unhelpful error message:
### Example

``` python
from sympy import symbols, Function, Derivative, dsolve
t = symbols('t')
eps = symbols('epsilon', real=True, positive=True)

x = Function('x') 
y = Function('y')

eqs = (Derivative(x(t), t) + eps*y(t), 
       Derivative(y(t), t) - eps*x(t))

soln = dsolve(eqs)

print soln
```

Output:

``` python
---------------------------------------------------------------------------
PolynomialError                           Traceback (most recent call last)
<ipython-input-3-5e84f7768202> in <module>()
     12        Derivative(wy(t), t) - eps*wx(t))
     13 
---> 14 soln = dsolve(eqs)
     15 
     16 soln

/usr/local/lib/python2.7/dist-packages/sympy-0.7.6_git-py2.7.egg/sympy/solvers/ode.pyc in dsolve(eq, func, hint, simplify, ics, xi, eta, x0, n, **kwargs)
    611             else:
    612                 solvefunc = globals()['sysode_nonlinear_%(no_of_equation)seq_order%(order)s' % match]
--> 613             sols = solvefunc(match)
    614             return sols
    615     else:

/usr/local/lib/python2.7/dist-packages/sympy-0.7.6_git-py2.7.egg/sympy/solvers/ode.pyc in sysode_linear_2eq_order1(match_)
   6387     r['k2'] = const[1]
   6388     if match_['type_of_equation'] == 'type1':
-> 6389         sol = _linear_2eq_order1_type1(x, y, t, r)
   6390     if match_['type_of_equation'] == 'type2':
   6391         gsol = _linear_2eq_order1_type1(x, y, t, r)

/usr/local/lib/python2.7/dist-packages/sympy-0.7.6_git-py2.7.egg/sympy/solvers/ode.pyc in _linear_2eq_order1_type1(x, y, t, r)
   6478     l = Symbol('l')
   6479     C1, C2, C3, C4 = symbols('C1:5')
-> 6480     l1 = RootOf(l**2 - (r['a']+r['d'])*l + r['a']*r['d'] - r['b']*r['c'], 0)
   6481     l2 = RootOf(l**2 - (r['a']+r['d'])*l + r['a']*r['d'] - r['b']*r['c'], 1)
   6482     D = (r['a'] - r['d'])**2 + 4*r['b']*r['c']

/usr/local/lib/python2.7/dist-packages/sympy-0.7.6_git-py2.7.egg/sympy/polys/rootoftools.pyc in __new__(cls, f, x, index, radicals, expand)
     69 
     70         if not poly.is_univariate:
---> 71             raise PolynomialError("only univariate polynomials are allowed")
     72 
     73         degree = poly.degree()

PolynomialError: only univariate polynomials are allowed
```
## The fix

I think I have solved this issue by converting the `chareq` into a `Poly` object before finding the roots, this way the symbols (in this case `eps`) get handled correctly. The test case above will now work correctly, although it is worth noting a different (and correct) error is thrown up if `eps` is not defined to be positive definite. The error message produced in this case is not particularly illuminating either, but that is a separate issue. 

Note: This is the first time I've submitted a PR to `sympy`, so apologies if I have made any errors in how I have submitted the issue and fix. 
