### PR TITLE
rootof: fix numerical evaluation of RootOf

### DIFF
--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -593,9 +593,9 @@ class RootOf(Expr):
                     # case and the interval will then be tightened -- and
                     # eventually the root will be found.
                     if self.is_real:
-                        if (a < root < b):
+                        if (a <= root <= b):
                             break
-                    elif (ax < root.real < bx and ay < root.imag < by):
+                    elif (ax <= root.real <= bx and ay <= root.imag <= by):
                         break
                 except ValueError:
                     pass

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -233,6 +233,11 @@ def test_RootOf_evalf():
     # issue 8617
     ans = [w.n(2) for w in solve(x**3 - x - 4)]
     assert RootOf(exp(x)**3 - exp(x) - 4, 0).n(2) in ans
+    # issue 9019
+    r0 = RootOf(x**2 + 1, 0, radicals=False)
+    r1 = RootOf(x**2 + 1, 1, radicals=False)
+    assert r0.n(4) == -1.0*I
+    assert r1.n(4) == 1.0*I
 
     # make sure verification is used in case a max/min traps the "root"
     assert str(RootOf(4*x**5 + 16*x**3 + 12*x**2 + 7, 0).n(3)) == '-0.976'


### PR DESCRIPTION
`RootOf._eval_evalf()` hangs in the case when the computed root lies on the boundary of the interval containing it. This occurs even in the following simple example.

```
In [1]: r = RootOf(x**2 + 1, 0, radicals=False)
In [2]: r.evalf()   # hangs indefinitely
```

The solution is to allow for such boundary interval values. Fixes #9019. The above example is included as a test.
