### PR TITLE
[WIP] Fix #7259 - LambertW has no series expansion at x=0 (nan)

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -504,6 +504,27 @@ class Function(Application, Expr):
             l.append(df * da)
         return Add(*l)
 
+    def _eval_heurisch_derivative(self, s):
+        i = 0
+        l = []
+        for a in self.args:
+            i += 1
+            if hasattr(a, 'fdiff_heurisch'):
+                da = a._eval_heurisch_derivative(s)
+            else:
+                da = a.diff(s)
+            if da is S.Zero:
+                continue
+            try:
+                try:
+                    df = self.fdiff_heurisch(i)
+                except AttributeError:
+                    df = self.fdiff(i)
+            except ArgumentIndexError:
+                df = Function.fdiff(self, i)
+            l.append(df * da)
+        return Add(*l)
+
     def _eval_is_commutative(self):
         return fuzzy_and(a.is_commutative for a in self.args)
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -790,11 +790,28 @@ class LambertW(Function):
 
         if len(self.args) == 1:
             if argindex == 1:
-                return LambertW(x)/(x*(1 + LambertW(x)))
+                return 1/(LambertW(x) + 1)/exp(LambertW(x))
         else:
             k = self.args[1]
             if argindex == 1:
-                return LambertW(x, k)/(x*(1 + LambertW(x, k)))
+                return 1/(LambertW(x, k) + 1)/exp(LambertW(x, k))
+
+        raise ArgumentIndexError(self, argindex)
+
+    def fdiff_heurisch(self, argindex=1):
+        """
+        Return the first derivative of this function.
+        Derivative is heurisch specific.
+        """
+        x = self.args[0]
+
+        if len(self.args) == 1:
+            if argindex == 1:
+                return LambertW(x)/(x*(LambertW(x)+1))
+        else:
+            k = self.args[1]
+            if argindex == 1:
+                return LambertW(x, k)/(x*(LambertW(x, k)+1))
 
         raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -351,8 +351,8 @@ def test_lambertw():
     assert LambertW(-1/E, -1) == -1
     assert LambertW(-2*exp(-2), -1) == -2
 
-    assert LambertW(x**2).diff(x) == 2*LambertW(x**2)/x/(1 + LambertW(x**2))
-    assert LambertW(x, k).diff(x) == LambertW(x, k)/x/(1 + LambertW(x, k))
+    assert LambertW(x**2).diff(x) == 2*x*exp(-LambertW(x**2))/(1 + LambertW(x**2))
+    assert LambertW(x, k).diff(x) == exp(-LambertW(x, k))/(1 + LambertW(x, k))
 
     assert LambertW(sqrt(2)).evalf(30).epsilon_eq(
         Float("0.701338383413663009202120278965", 30), 1e-29)

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -1,5 +1,5 @@
 from sympy import sin, cos, exp, E, series, oo, S, Derivative, O, Integral, \
-    Function, log, sqrt, Symbol, Subs, pi, symbols
+    Function, log, sqrt, Symbol, Subs, pi, symbols, LambertW
 from sympy.abc import x, y, n, k
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
@@ -126,6 +126,10 @@ def test_issue_4583():
 def test_issue_6318():
     eq = (1/x)**(S(2)/3)
     assert (eq + 1).as_leading_term(x) == eq
+
+
+def test_lambertw_issue_7259():
+    assert series(LambertW(x)) == x - x**2 + 3*x**3/2 - 8*x**4/3 + 125*x**5/24 + O(x**6)
 
 
 def test_x_is_base_detection():


### PR DESCRIPTION
I Have made the following changes:
- `fdiff` of `LambertW` now returns the derivative mentioned in issue #7259.
- `_eval_heurisch_derivative` method has been added in Function class. It checks if heurisch specific derivative exists and evaluates accordingly.
- `fdiff_heurisch` method (returns heurisch specific derivative) added in `LambertW` to be used by `_eval_heurisch_derivative`.
- `heurisch_diff` function added in heurisch. To be used when differentiating a function.
- Added tests in `test_series` for series expansion of `LambertW`.
