### PR TITLE
fix #8167 - zero=True assumption is ignored

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -159,7 +159,7 @@ class Pow(Expr):
         b = _sympify(b)
         e = _sympify(e)
         if evaluate:
-            if e is S.Zero:
+            if e.is_zero:
                 return S.One
             elif e is S.One:
                 return b

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -118,10 +118,6 @@ class Limit(Expr):
         if e == z:
             return z0
 
-        for s in e.atoms(Symbol):
-            if s.is_zero:
-                e = e.subs(s, 0)
-
         if not e.has(z):
             return e
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -118,6 +118,10 @@ class Limit(Expr):
         if e == z:
             return z0
 
+        for s in e.atoms(Symbol):
+            if s.is_zero:
+                e = e.subs(s, 0)
+
         if not e.has(z):
             return e
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -106,6 +106,11 @@ def test_issue_3885():
     assert limit(x*y + x*z, z, 2) == x*y + 2*x
 
 
+def test_issue_8167():
+    a = Symbol('a', zero=True)
+    assert limit(exp(x)**a, x, oo) == 1
+
+
 def test_Limit():
     assert Limit(sin(x)/x, x, 0) != 1
     assert Limit(sin(x)/x, x, 0).doit() == 1

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1087,8 +1087,6 @@ def test_nsimplify():
     assert nsimplify(pi/1e-7) == 10000000*pi
     assert not nsimplify(
         factor(-3.0*z**2*(z**2)**(-2.5) + 3*(z**2)**(-1.5))).atoms(Float)
-    e = x**0.0
-    assert e.is_Pow and nsimplify(x**0.0) == 1
     assert nsimplify(3.333333, tolerance=0.1, rational=True) == Rational(10, 3)
     assert nsimplify(3.333333, tolerance=0.01, rational=True) == Rational(10, 3)
     assert nsimplify(3.666666, tolerance=0.1, rational=True) == Rational(11, 3)


### PR DESCRIPTION
I have added a simple check in doit method of Limit, to substitute all the symbols that are zero in the expression. Now 

```
>>> a = Symbol('a', zero=True)
>>> limit((E**a)**x, x, oo)
1
```
