### PR TITLE
fix #8984 - use \left | instead of \lvert in latex(Abs)

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -89,7 +89,7 @@ modifier_dict = {
     # Brackets
     'norm': lambda s: r'\left\lVert{'+s+r'}\right\rVert',
     'avg': lambda s: r'\left\langle{'+s+r'}\right\rangle',
-    'abs': lambda s: r'\left\|{'+s+r'}\right\|',
+    'abs': lambda s: r'\left|{'+s+r'}\right|',
     'mag': lambda s: r'\left\lvert{'+s+r'}\right\rvert',
 }
 
@@ -753,7 +753,7 @@ class LatexPrinter(Printer):
             return tex
 
     def _print_Abs(self, expr, exp=None):
-        tex = r"\left\|{%s}\right\|" % self._print(expr.args[0])
+        tex = r"\left|{%s}\right|" % self._print(expr.args[0])
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -232,7 +232,7 @@ def test_latex_functions():
     assert latex(Min(x, y)**2) == r"\min\left(x, y\right)^{2}"
     assert latex(Max(x, 2, x**3)) == r"\max\left(2, x, x^{3}\right)"
     assert latex(Max(x, y)**2) == r"\max\left(x, y\right)^{2}"
-    assert latex(Abs(x)) == r"\left\|{x}\right\|"
+    assert latex(Abs(x)) == r"\left|{x}\right|"
     assert latex(re(x)) == r"\Re{x}"
     assert latex(re(x + y)) == r"\Re{x} + \Re{y}"
     assert latex(im(x)) == r"\Im{x}"
@@ -1178,7 +1178,7 @@ def test_modifiers():
     assert latex(symbols("xDot")) == r"\dot{x}"
     assert latex(symbols("xBar")) == r"\bar{x}"
     assert latex(symbols("xVec")) == r"\vec{x}"
-    assert latex(symbols("xAbs")) == r"\left\|{x}\right\|"
+    assert latex(symbols("xAbs")) == r"\left|{x}\right|"
     assert latex(symbols("xMag")) == r"\left\lvert{x}\right\rvert"
     assert latex(symbols("xPrM")) == r"{x}'"
     assert latex(symbols("xBM")) == r"\boldsymbol{x}"
@@ -1208,7 +1208,7 @@ def test_modifiers():
     assert latex(symbols("xDotVec")) == r"\vec{\dot{x}}"
     assert latex(symbols("xHATNorm")) == r"\left\lVert{\hat{x}}\right\rVert"
     # Check a couple big, ugly combinations
-    assert latex(symbols('xMathringBm_yCheckPRM__zbreveAbs')) == r"\boldsymbol{\mathring{x}}^{\left\|{\breve{z}}\right\|}_{{\check{y}}'}"
+    assert latex(symbols('xMathringBm_yCheckPRM__zbreveAbs')) == r"\boldsymbol{\mathring{x}}^{\left|{\breve{z}}\right|}_{{\check{y}}'}"
     assert latex(symbols('alphadothat_nVECDOT__tTildePrime')) == r"\hat{\dot{\alpha}}^{{\tilde{t}}'}_{\dot{\vec{n}}}"
 
 


### PR DESCRIPTION
Removes errors caused by PR #8985. Replaces \lvert by | instead of \|.
