### PR TITLE
pretty printing: improved `Trace`

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -639,6 +639,14 @@ class PrettyPrinter(Printer):
         D = self._print_matrix_contents(e)
         D = prettyForm(*D.parens('[', ']'))
         return D
+
+    def _print_Trace(self, e):
+        mat = e._args[0]
+        D = self._print_MatrixBase(mat)
+        D = prettyForm(*D.parens('(', ')'))
+        D = prettyForm(*D.left('\n'*(D.height()//2) + 'tr'))
+        return D
+
     _print_ImmutableMatrix = _print_MatrixBase
     _print_Matrix = _print_MatrixBase
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -640,12 +640,13 @@ class PrettyPrinter(Printer):
         D = prettyForm(*D.parens('[', ']'))
         return D
 
+
     def _print_Trace(self, e):
-        mat = e._args[0]
-        D = self._print_MatrixBase(mat)
+        D = self._print(e.arg)
         D = prettyForm(*D.parens('(', ')'))
         D = prettyForm(*D.left('\n'*(D.height()//2) + 'tr'))
         return D
+
 
     _print_ImmutableMatrix = _print_MatrixBase
     _print_Matrix = _print_MatrixBase


### PR DESCRIPTION
Attempts to fix #9044 
Defined a function _print_Trace in sympy.printing.pretty.pretty.PrettyPrinter
so that this function is used to print the Trace rather than the
emptyPrinter.

Example:

Before:

```
In [70]: X = ImmutableMatrix([[1, 2], [3, 4]])

In [71]: w = Trace(X) + Trace(2*X)

In [72]: pprint(w)
Trace(Matrix([ + Trace(Matrix([
   [1, 2],          [2, 4],
  [3, 4]]))        [6, 8]]))
```

After:

```
In [70]: X = ImmutableMatrix([[1, 2], [3, 4]])

In [71]: w = Trace(X) + Trace(2*X)

In [72]: pprint(w)
  ⎛⎡1  2⎤⎞ +   ⎛⎡2  4⎤⎞
tr⎜⎢    ⎥⎟   tr⎜⎢    ⎥⎟
  ⎝⎣3  4⎦⎠     ⎝⎣6  8⎦⎠
```

The position of the operators ('+' in the above example) in between the Traces are off position.
Still need to figure out how to fix that.
