### PR TITLE
Trace: shallow doit evaluates only explicit matrices

### DIFF
--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -73,7 +73,6 @@ def test_Trace_MutableMatrix_plus():
     assert Trace(X) + Trace(X) == 2*Trace(X)
 
 
-@XFAIL
 def test_Trace_doit_deep_False():
     X = Matrix([[1, 2], [3, 4]])
     q = MatPow(X, 2)

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Basic, Expr, sympify
+from sympy.matrices.matrices import MatrixBase
 from .matexpr import ShapeError
 
 
@@ -40,12 +41,17 @@ class Trace(Expr):
     def doit(self, **kwargs):
         if kwargs.get('deep', True):
             arg = self.arg.doit(**kwargs)
+            try:
+                return arg._eval_trace()
+            except (AttributeError, NotImplementedError):
+                return Trace(arg)
         else:
-            arg = self.arg
-        try:
-            return arg._eval_trace()
-        except (AttributeError, NotImplementedError):
-            return Trace(arg)
+            # _eval_trace would go too deep here
+            if isinstance(self.arg, MatrixBase):
+                return trace(self.arg)
+            else:
+                return Trace(self.arg)
+
 
     def _eval_rewrite_as_Sum(self):
         from sympy import Sum, Dummy


### PR DESCRIPTION
```
Maybe not the cleanest approach to maintain this list of objects here
(so far MatrixBase) but I don't see another way without adding
_eval_trace_shallow (or kwargs to _eval_trace) on various other
objects.
```

This is on top of #9063: _just the final commit is new_.

This may not be a good idea: I guess an alternative is for `deep=False` to always return Trace().
- [x] Wait for merge of #9063.
