### PR TITLE
pprint: lift the baseline for Pow in Func**Pow

### DIFF
--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -479,7 +479,7 @@ class prettyForm(stringPict):
         if a.binding == prettyForm.FUNC:
             #         2
             #  sin  +   + (x)
-            b.baseline = a.prettyFunc.baseline + 1
+            b.baseline = a.prettyFunc.baseline + b.height()
             func = stringPict(*a.prettyFunc.right(b))
             return prettyForm(*func.right(a.prettyArgs))
         else:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4915,6 +4915,28 @@ u("""\
     assert upretty(e) == ucode_str
 
 
+def test_issue_7927():
+    e = sin(x/2)**cos(x/2)
+    ucode_str = \
+u("""\
+      ⎛x⎞   \n\
+   cos⎜─⎟   \n\
+      ⎝2⎠⎛x⎞\n\
+sin      ⎜─⎟\n\
+         ⎝2⎠\
+""")
+    assert upretty(e) == ucode_str
+    e = sin(x)**(S(11)/13)
+    ucode_str = \
+u("""\
+   11   \n\
+   ──   \n\
+   13   \n\
+sin  (x)\
+""")
+    assert upretty(e) == ucode_str
+
+
 def test_issue_6134():
     from sympy.abc import lamda, phi, t
 


### PR DESCRIPTION
If Pow has height larger than 1, it will need lifted further.  So
lift its baseline according to its height.  Add tests.

Fixes #7927.
