### PR TITLE
pprint: if exponent b is too high, use (func(x))**b form instead

### DIFF
--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -471,12 +471,19 @@ class prettyForm(stringPict):
         """Make a pretty power.
         """
         a = self
-        if a.binding > prettyForm.FUNC:
-            a = stringPict(*a.parens())
+        use_inline_func_form = False
         if b.binding == prettyForm.POW:
             b = stringPict(*b.parens())
+        if a.binding > prettyForm.FUNC:
+            a = stringPict(*a.parens())
+        elif a.binding == prettyForm.FUNC:
+            # heuristic for when to use inline power
+            if b.height() > 1:
+                a = stringPict(*a.parens())
+            else:
+                use_inline_func_form = True
 
-        if a.binding == prettyForm.FUNC:
+        if use_inline_func_form:
             #         2
             #  sin  +   + (x)
             b.baseline = a.prettyFunc.baseline + b.height()

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -479,7 +479,7 @@ class prettyForm(stringPict):
         if a.binding == prettyForm.FUNC:
             #         2
             #  sin  +   + (x)
-            b.baseline = a.prettyFunc.baseline + 1
+            b.baseline = a.prettyFunc.baseline + b.height()
             func = stringPict(*a.prettyFunc.right(b))
             return prettyForm(*func.right(a.prettyArgs))
         else:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4915,6 +4915,28 @@ u("""\
     assert upretty(e) == ucode_str
 
 
+def test_issue_7927():
+    e = sin(x/2)**cos(x/2)
+    ucode_str = \
+u("""\
+      ⎛x⎞   \n\
+   cos⎜─⎟   \n\
+      ⎝2⎠⎛x⎞\n\
+sin      ⎜─⎟\n\
+         ⎝2⎠\
+""")
+    assert upretty(e) == ucode_str
+    e = sin(x)**(S(11)/13)
+    ucode_str = \
+u("""\
+   11   \n\
+   ──   \n\
+   13   \n\
+sin  (x)\
+""")
+    assert upretty(e) == ucode_str
+
+
 def test_issue_6134():
     from sympy.abc import lamda, phi, t
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4919,20 +4919,21 @@ def test_issue_7927():
     e = sin(x/2)**cos(x/2)
     ucode_str = \
 u("""\
-      ⎛x⎞   \n\
-   cos⎜─⎟   \n\
-      ⎝2⎠⎛x⎞\n\
-sin      ⎜─⎟\n\
-         ⎝2⎠\
+           ⎛x⎞\n\
+        cos⎜─⎟\n\
+           ⎝2⎠\n\
+⎛   ⎛x⎞⎞      \n\
+⎜sin⎜─⎟⎟      \n\
+⎝   ⎝2⎠⎠      \
 """)
     assert upretty(e) == ucode_str
     e = sin(x)**(S(11)/13)
     ucode_str = \
 u("""\
-   11   \n\
-   ──   \n\
-   13   \n\
-sin  (x)\
+        11\n\
+        ──\n\
+        13\n\
+(sin(x))  \
 """)
     assert upretty(e) == ucode_str
 


### PR DESCRIPTION
Usually we want this:

```
   2
sin (x)
```

But if the exponent is large or generally too high we probably
prefer:

```
        11
        ──
        13
(sin(x))
```

The idea here is to have some heuristic: in this patch, its simply
if the exponent height bigger than one.
