### PR TITLE
matrices: trace of MatAdd

### DIFF
--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -50,8 +50,8 @@ class MatAdd(MatrixExpr):
         return MatAdd(*[adjoint(arg) for arg in self.args]).doit()
 
     def _eval_trace(self):
-        from trace import Trace
-        return MatAdd(*[Trace(arg) for arg in self.args]).doit()
+        from .trace import trace
+        return Add(*[trace(arg) for arg in self.args]).doit()
 
     def doit(self, **kwargs):
         deep = kwargs.get('deep', True)

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -7,6 +7,7 @@ from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
         MatMul, xxinv, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe
 from sympy import refine, Q
+from sympy.utilities.pytest import XFAIL
 
 n, m, l, k = symbols('n m l k', integer=True)
 A = MatrixSymbol('A', n, m)
@@ -97,6 +98,13 @@ def test_doit_drills_down():
 def test_doit_deep_false_still_canonical():
     assert (MatMul(C, Transpose(D*C), 2).doit(deep=False).args ==
             (2, C, Transpose(D*C)))
+
+
+@XFAIL
+def test_matmul_scalar_Matrix_doit():
+    # Issue 9053
+    X = Matrix([[1, 2], [3, 4]])
+    assert MatMul(2, X).doit() == 2*X
 
 
 def test_matmul_sympify():

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -30,7 +30,7 @@ def test_Trace():
     # Some easy simplifications
     assert trace(Identity(5)) == 5
     assert trace(ZeroMatrix(5, 5)) == 0
-    assert trace(2*A*B) == 2 * trace(A*B)
+    assert trace(2*A*B) == 2*Trace(A*B)
     assert trace(A.T) == trace(A)
 
     i, j = symbols('i j')
@@ -51,10 +51,6 @@ def test_Trace_doit():
     assert Trace(q).arg == q
     assert Trace(q).doit() == 29
     assert Trace(q).doit(deep=False).arg == q
-
-
-def test_Trace_MatMul():
-    assert not trace(A*B) == trace(A)*trace(B)
 
 
 def test_Trace_MatAdd_doit():

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -4,7 +4,7 @@ from sympy.functions import adjoint, conjugate, transpose
 from sympy.matrices import eye, Matrix, ShapeError, ImmutableMatrix
 from sympy.matrices.expressions import (
     Adjoint, Identity, FunctionMatrix, MatrixExpr, MatrixSymbol, Trace,
-    ZeroMatrix, trace, MatPow, MatAdd
+    ZeroMatrix, trace, MatPow, MatAdd, MatMul
 )
 from sympy.utilities.pytest import raises, XFAIL
 
@@ -44,13 +44,10 @@ def test_Trace():
     assert str(trace(A)) == str(Trace(A).doit())
 
 
-def test_Trace_doit():
-    X = Matrix([[1, 2], [3, 4]])
-    assert Trace(X).doit() == 5
-    q = MatPow(X, 2)
-    assert Trace(q).arg == q
-    assert Trace(q).doit() == 29
-    assert Trace(q).doit(deep=False).arg == q
+def test_Trace_A_plus_B():
+    assert trace(A + B) == Trace(A) + Trace(B)
+    assert Trace(A + B).arg == MatAdd(A, B)
+    assert Trace(A + B).doit() == Trace(A) + Trace(B)
 
 
 def test_Trace_MatAdd_doit():
@@ -59,6 +56,42 @@ def test_Trace_MatAdd_doit():
     q = MatAdd(X, 2*X, Y, -3*Y)
     assert Trace(q).arg == q
     assert Trace(q).doit() == 18 - 2*Trace(Y)
+
+
+def test_Trace_MatPow_doit():
+    X = Matrix([[1, 2], [3, 4]])
+    assert Trace(X).doit() == 5
+    q = MatPow(X, 2)
+    assert Trace(q).arg == q
+    assert Trace(q).doit() == 29
+
+
+@XFAIL
+def test_Trace_doit_deep_False():
+    X = Matrix([[1, 2], [3, 4]])
+    q = MatPow(X, 2)
+    assert Trace(q).doit(deep=False).arg == q
+    q = MatAdd(X, 2*X)
+    assert Trace(q).doit(deep=False).arg == q
+    q = MatMul(X, 2*X)
+    assert Trace(q).doit(deep=False).arg == q
+
+
+@XFAIL
+def test_trace_constant_factor():
+    # Issue 9052: LHS gives Trace(MatMul(A))
+    assert trace(2*A) == 2*Trace(A)
+    X = ImmutableMatrix([[1, 2], [3, 4]])
+    assert trace(MatMul(2, X)) == 10
+
+
+@XFAIL
+def test_Trace_MutableMatrix_plus():
+    # Issue #9043, Trace(X) plus anything raises type error
+    X = Matrix([[1, 2], [3, 4]])
+    Y = MatrixSymbol('Y', 2, 2)
+    q = Trace(X) + Trace(Y)
+    assert Trace(X) + Trace(X) == 2*Trace(X)
 
 
 @XFAIL

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -1,7 +1,7 @@
 from sympy.core import Lambda, S, symbols
 from sympy.concrete import Sum
 from sympy.functions import adjoint, conjugate, transpose
-from sympy.matrices import eye, Matrix, ShapeError
+from sympy.matrices import eye, Matrix, ShapeError, ImmutableMatrix
 from sympy.matrices.expressions import (
     Adjoint, Identity, FunctionMatrix, MatrixExpr, MatrixSymbol, Trace,
     ZeroMatrix, trace, MatPow, MatAdd
@@ -53,12 +53,16 @@ def test_Trace_doit():
     assert Trace(q).doit(deep=False).arg == q
 
 
-@XFAIL
+def test_Trace_MatMul():
+    assert not trace(A*B) == trace(A)*trace(B)
+
+
 def test_Trace_MatAdd_doit():
-    # FIXME: Issue #9028.
-    X = Matrix([[1, 2], [3, 4]])
-    q = MatAdd(X, 2*X)
-    assert Trace(q).doit(deep=False).arg == q
+    X = ImmutableMatrix([[1, 2, 3]]*3)
+    Y = MatrixSymbol('Y', 3, 3)
+    q = MatAdd(X, 2*X, Y, -3*Y)
+    assert Trace(q).arg == q
+    assert Trace(q).doit() == 18 - 2*Trace(Y)
 
 
 @XFAIL

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -51,6 +51,7 @@ def test_Trace_A_plus_B():
 
 
 def test_Trace_MatAdd_doit():
+    # See issue #9028
     X = ImmutableMatrix([[1, 2, 3]]*3)
     Y = MatrixSymbol('Y', 3, 3)
     q = MatAdd(X, 2*X, Y, -3*Y)
@@ -89,15 +90,6 @@ def test_trace_constant_factor():
     assert trace(2*A) == 2*Trace(A)
     X = ImmutableMatrix([[1, 2], [3, 4]])
     assert trace(MatMul(2, X)) == 10
-
-
-@XFAIL
-def test_Trace_MutableMatrix_plus():
-    # Issue #9043, Trace(X) plus anything raises type error
-    X = Matrix([[1, 2], [3, 4]])
-    Y = MatrixSymbol('Y', 2, 2)
-    q = Trace(X) + Trace(Y)
-    assert Trace(X) + Trace(X) == 2*Trace(X)
 
 
 @XFAIL


### PR DESCRIPTION
```
matrices: trace of MatAdd

Earlier trace(MatAdd(X, Y)) was failing with type error
'mix of Matrix and Scalar symbols'. This was because
trace(MatAdd(X, Y)) evaluated to MatAdd(trace(X), trace(Y))
and since validate function would reject trace(X) as Matrix
object it was throwing an exception.

It has been fixed by evaluating trace(MatAdd(X, Y)) to
trace(Z) where Z is what we have after evaluating
MatAdd(X, Y).

Fixes #9028.  Adds tests.
```

This is a squash of the work of @lokeshh in #9031.  It looks like the squashed commit remains attributed @lokeshh, so I'm +1 for merging this.  But as it also has some tests added by me, someone else should +1 one before I merge.
