### PR TITLE
Operator: __mul__ exception for identity mul

### DIFF
--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -176,6 +176,13 @@ class Operator(QExpr):
     def _eval_inverse(self):
         return self**(-1)
 
+    def __mul__(self, other):
+
+        if isinstance(other, IdentityOperator):
+            return self
+
+        return Mul(self, other)
+
 
 class HermitianOperator(Operator):
     """A Hermitian operator that satisfies H == Dagger(H).
@@ -304,13 +311,6 @@ class IdentityOperator(Operator):
             return other
 
         return Mul(self, other)
-
-    def __rmul__(self, other):
-
-        if isinstance(other, Operator):
-            return other
-
-        return Mul(other, self)
 
     def _represent_default_basis(self, **options):
         if not self.N or self.N == oo:

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -50,6 +50,7 @@ def test_operator():
     assert t_op.label[0] == Symbol(t_op.default_args()[0])
 
     assert Operator() == Operator("O")
+    assert A*IdentityOperator() == A
 
 
 def test_operator_inv():


### PR DESCRIPTION
From `__rmul__` of IdentityOperator, the intentions were :

```
In [2]: A = HermitianOperator('A')

In [3]: IdentityOperator()*A
Out[3]: A

In [4]: A*IdentityOperator()
Out[4]: A
```

But since in `In[4]` the`__mul__` of A is called before `__rmul__` of identity, these intentions were not acheived i.e.

```
In [2]: A = HermitianOperator('A')

In [3]: IdentityOperator()*A
Out[3]: A

In [4]: A*IdentityOperator()
Out[4]: A.I
```

This PR adds exception to `Operator.__mul__()` so as to fix this. Also fixes #9056 .
