### PR TITLE
factor.py: ntheory, multiplicity(n, 0) is not defined

### DIFF
--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -170,6 +170,8 @@ def test_log_values():
     assert log(2*3).func is log
     assert log(2*3**2).func is log
 
+    assert log(0 ,2) == zoo
+    assert log(0 ,10) == zoo
 
 def test_log_base():
     assert log(1, 2) == 0

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -237,6 +237,9 @@ def multiplicity(p, n):
     if p == n:
         return 1
 
+    if n == 0:
+        raise ValueError('n cannot be zero, but got %s' % n)
+
     m = 0
     n, rem = divmod(n, p)
     while not rem:

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -64,6 +64,7 @@ def test_multiplicity():
     raises(ValueError, lambda: multiplicity(1, 1))
     raises(ValueError, lambda: multiplicity(1, 2))
     raises(ValueError, lambda: multiplicity(1.3, 2))
+    raises(ValueError, lambda: multiplicity(5, 0))
 
     # handles Rationals
     assert multiplicity(10, Rational(30, 7)) == 0


### PR DESCRIPTION
Before: multiplicity(n, 0) used to go in a endless recursion, e.g.
multiplicity(5, 0) which also led to log(0, n) to hit endless recursion,
e.g.log(0, 5).

After: multiplicity(n, 0) raises value error. And log(0, n) returns
the expected S.ComplexInfinity
fixes issue #9066 
