### PR TITLE
Fixes #8729: nan is a rational function

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2307,7 +2307,7 @@ class Expr(Basic, EvalfMixin):
         See also is_algebraic_expr().
 
         """
-        if self is S.NaN:
+        if self in [S.NaN, S.Infinity, -S.Infinity, S.ComplexInfinity]:
             return False
 
         if syms:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2307,6 +2307,9 @@ class Expr(Basic, EvalfMixin):
         See also is_algebraic_expr().
 
         """
+        if self is S.NaN:
+            return False
+
         if syms:
             syms = set(map(sympify, syms))
         else:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -418,6 +418,9 @@ def test_is_rational_function():
     assert (sin(y)/x).is_rational_function(x, y) is False
 
     assert (S.NaN).is_rational_function() is False
+    assert (S.Infinity).is_rational_function() is False
+    assert (-S.Infinity).is_rational_function() is False
+    assert (S.ComplexInfinity).is_rational_function() is False
 
 
 def test_is_algebraic_expr():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -417,6 +417,8 @@ def test_is_rational_function():
     assert (sin(y)/x).is_rational_function(x) is True
     assert (sin(y)/x).is_rational_function(x, y) is False
 
+    assert (S.NaN).is_rational_function() is False
+
 
 def test_is_algebraic_expr():
     assert sqrt(3).is_algebraic_expr(x) is True


### PR DESCRIPTION
Now, 

```
>>> (nan).is_rational_function()
False
```

Fixes #8729 
