### PR TITLE
Addition of Traces of MutableDenseMatrix

### DIFF
--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -53,6 +53,12 @@ def test_Trace_doit():
     assert Trace(q).doit(deep=False).arg == q
 
 
+def test_Trace_MutableMatrix_plus():
+    # See issue #9043
+    X = Matrix([[1, 2], [3, 4]])
+    assert Trace(X) + Trace(X) == 2*Trace(X)
+
+
 @XFAIL
 def test_Trace_MatAdd_doit():
     # FIXME: Issue #9028.

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy import Basic, Expr
+from sympy import Basic, Expr, sympify
 from .matexpr import ShapeError
 
 
@@ -20,6 +20,8 @@ class Trace(Expr):
     is_Trace = True
 
     def __new__(cls, mat):
+        mat = sympify(mat)
+
         if not mat.is_Matrix:
             raise TypeError("input to Trace, %s, is not a matrix" % str(mat))
 


### PR DESCRIPTION
Addition of Trace(X) returned TypeError when X was
MutableDenseMatrix. This was because MutableDenseMatrix
wasn't hashable. This has been fixed by introducing
hashable_content function for Trace. This function
returns sympify(X) which is hashable and hence making
MutableDenseMatrix hashable.

Fixes: #9043 
