### PR TITLE
ignore Symbol names that are already latex; suppress some unicode warnings

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1240,7 +1240,8 @@ class LatexPrinter(Printer):
         if expr in self._settings['symbol_names']:
             return self._settings['symbol_names'][expr]
 
-        return self._deal_with_super_sub(expr.name)
+        return self._deal_with_super_sub(expr.name) if \
+            '\\' not in expr.name else expr.name
 
     _print_RandomSymbol = _print_Symbol
     _print_MatrixSymbol = _print_Symbol

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -53,6 +53,15 @@ def pretty_use_unicode(flag=None):
     if flag is None:
         return _use_unicode
 
+    # we know that some letters are not supported in Python 2.X so
+    # ignore those warnings. Remove this when 2.X support is dropped.
+    if unicode_warnings:
+        known = ['LATIN SUBSCRIPT SMALL LETTER %s' % i for i in 'HKLMNPST']
+        unicode_warnings = '\n'.join([
+            l for l in unicode_warnings.splitlines() if not any(
+            i in l for i in known)])
+    # ------------ end of 2.X warning filtering
+
     if flag and unicode_warnings:
         # print warnings (if any) on first unicode usage
         warnings.warn(unicode_warnings)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1335,3 +1335,7 @@ def test_issue_7117():
     assert latex(q) == r"6 + \left(x + 1 = 2 x\right)"
     q = Pow(e, 2, evaluate=False)
     assert latex(q) == r"\left(x + 1 = 2 x\right)^{2}"
+
+
+def test_issue_2934():
+    assert latex(Symbol(r'\frac{a_1}{b_1}')) == '\\frac{a_1}{b_1}'


### PR DESCRIPTION
fixes #2934 
closes #9048 as replacement
closes #9082 as replacement
