### PR TITLE
Removed C from solvers and broke import cycles

### DIFF
--- a/doc/src/modules/integrals/integrals.rst
+++ b/doc/src/modules/integrals/integrals.rst
@@ -91,23 +91,15 @@ Details are described here:
 API reference
 -------------
 
-.. automethod:: sympy.integrals.integrate
-
-.. automethod:: sympy.integrals.line_integrate
-
-.. automethod:: sympy.integrals.deltaintegrate
-
-.. automethod:: sympy.integrals.ratint
-
-.. automethod:: sympy.integrals.heurisch
-
-.. automethod:: sympy.integrals.heurisch_wrapper
-
-.. automethod:: sympy.integrals.trigintegrate
-
-.. automethod:: sympy.integrals.manualintegrate
-
-.. automethod:: sympy.integrals.manualintegrate.integral_steps
+.. autofunction:: sympy.integrals.integrate
+.. autofunction:: sympy.integrals.line_integrate
+.. autofunction:: sympy.integrals.deltaintegrate
+.. autofunction:: sympy.integrals.ratint
+.. autofunction:: sympy.integrals.heurisch
+.. autofunction:: sympy.integrals.heurisch_wrapper
+.. autofunction:: sympy.integrals.trigintegrate
+.. autofunction:: sympy.integrals.manualintegrate
+.. autofunction:: sympy.integrals.manualintegrate.integral_steps
 
 The class `Integral` represents an unevaluated integral and has some methods that help in the integration of an expression.
 

--- a/sympy/integrals/__init__.py
+++ b/sympy/integrals/__init__.py
@@ -9,7 +9,11 @@
     >>> integrate(sin(x),x)
     -cos(x)
 """
+from .deltafunctions import deltaintegrate
+from .heurisch import heurisch, heurisch_wrapper
 from .integrals import integrate, Integral, line_integrate
+from .manualintegrate import manualintegrate, integral_steps
+from .rationaltools import ratint
 from .transforms import (mellin_transform, inverse_mellin_transform,
                         MellinTransform, InverseMellinTransform,
                         laplace_transform, inverse_laplace_transform,
@@ -22,3 +26,4 @@ from .transforms import (mellin_transform, inverse_mellin_transform,
                         CosineTransform, InverseCosineTransform,
                         hankel_transform, inverse_hankel_transform,
                         HankelTransform, InverseHankelTransform)
+from .trigonometry import trigintegrate

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division
 
 from sympy.core import Mul
 from sympy.functions import DiracDelta, Heaviside
-from sympy.solvers import solve
 from sympy.core.compatibility import default_sort_key
 
 
@@ -136,6 +135,7 @@ def deltaintegrate(f, x):
         return None
 
     from sympy.integrals import Integral, integrate
+    from sympy.solvers import solve
 
     # g(x) = DiracDelta(h(x))
     if f.func == DiracDelta:

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -20,7 +20,6 @@ from sympy.functions.elementary.exponential import LambertW
 from sympy.functions.elementary.piecewise import Piecewise
 
 from sympy.logic.boolalg import And
-from sympy.solvers.solvers import solve, denoms
 from sympy.utilities.iterables import uniq
 
 from sympy.polys import quo, gcd, lcm, factor, cancel, PolynomialError
@@ -122,6 +121,7 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
 
     heurisch
     """
+    from sympy.solvers.solvers import solve, denoms
     f = sympify(f)
     if x not in f.free_symbols:
         return f*x

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.core.add import Add
-from sympy.core.basic import Basic, C
+from sympy.core.basic import Basic
 from sympy.core.compatibility import is_sequence, range
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
@@ -14,17 +14,12 @@ from sympy.core.symbol import (Dummy, Symbol, Wild)
 from sympy.core.sympify import sympify
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
-from sympy.integrals.deltafunctions import deltaintegrate
-from sympy.integrals.rationaltools import ratint
-from sympy.integrals.heurisch import heurisch, heurisch_wrapper
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
 from sympy.utilities import xthreaded
 from sympy.utilities.misc import filldedent
 from sympy.polys import Poly, PolynomialError
-from sympy.solvers.solvers import solve, posify
 from sympy.functions import Piecewise, sqrt, sign
 from sympy.functions.elementary.exponential import log
-from sympy.geometry import Curve
 from sympy.series import limit
 from sympy.series.order import Order
 
@@ -243,7 +238,7 @@ class Integral(AddWithLimits):
         variables : Lists the integration variables
         as_dummy : Replace integration variables with dummy ones
         """
-
+        from sympy.solvers.solvers import solve, posify
         d = Dummy('d')
 
         xfree = x.free_symbols.intersection(self.variables)
@@ -709,6 +704,9 @@ class Integral(AddWithLimits):
              so that this can be deleted.
 
         """
+        from sympy.integrals.deltafunctions import deltaintegrate
+        from sympy.integrals.heurisch import heurisch, heurisch_wrapper
+        from sympy.integrals.rationaltools import ratint
         from sympy.integrals.risch import risch_integrate
 
         if risch:
@@ -1278,6 +1276,7 @@ def line_integrate(field, curve, vars):
 
     integrate, Integral
     """
+    from sympy.geometry import Curve
     F = sympify(field)
     if not F:
         raise ValueError(

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy import S, Symbol, symbols, I, log, atan, \
-    roots, collect, solve, RootSum, Lambda, cancel, Dummy
+    roots, RootSum, Lambda, cancel, Dummy
 
 from sympy.polys import Poly, resultant, ZZ
 from sympy.polys.polytools import count_roots
@@ -138,6 +138,8 @@ def ratint_ratpart(f, g, x):
 
     ratint, ratint_logpart
     """
+    from sympy import solve
+
     f = Poly(f, x)
     g = Poly(g, x)
 
@@ -328,6 +330,7 @@ def log_to_real(h, q, x, t):
 
     log_to_atan
     """
+    from sympy import collect
     u, v = symbols('u,v', cls=Dummy)
 
     H = h.as_expr().subs({t: u + I*v}).expand()

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -233,7 +233,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 from itertools import islice
 
-from sympy.core import Add, C, S, Mul, Pow, oo
+from sympy.core import Add, S, Mul, Pow, oo
 from sympy.core.compatibility import ordered, iterable, is_sequence, range
 from sympy.core.containers import Tuple
 from sympy.core.exprtools import factor_terms
@@ -250,6 +250,7 @@ from sympy.logic.boolalg import BooleanAtom
 from sympy.functions import cos, exp, im, log, re, sin, tan, sqrt, \
     atan2, conjugate
 from sympy.functions.combinatorial.factorials import factorial
+from sympy.integrals.integrals import Integral, integrate
 from sympy.matrices import wronskian, Matrix, eye, zeros
 from sympy.polys import Poly, RootOf, terms_gcd, PolynomialError, lcm
 from sympy.polys.polyroots import roots_quartic
@@ -260,6 +261,7 @@ from sympy.simplify import collect, logcombine, powsimp, separatevars, \
     simplify, trigsimp, denom, posify, cse
 from sympy.simplify.simplify import collect_const, powdenest
 from sympy.solvers import solve
+from sympy.solvers.pde import pdsolve
 
 from sympy.utilities import numbered_symbols, default_sort_key, sift
 from sympy.solvers.deutils import _preprocess, ode_order, _desolve
@@ -808,7 +810,6 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
 
     """
     prep = kwargs.pop('prep', True)
-    from sympy import expand
 
     if func and len(func.args) != 1:
         raise ValueError("dsolve() and classify_ode() only "
@@ -990,7 +991,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
                         factor = simplify(numerator/r[e])
                         variables = factor.free_symbols
                         if len(variables) == 1 and x == variables.pop():
-                            factor = exp(C.Integral(factor).doit())
+                            factor = exp(Integral(factor).doit())
                             r[d] *= factor
                             r[e] *= factor
                             matching_hints["1st_exact"] = r
@@ -1001,7 +1002,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
                             factor = simplify(-numerator/r[d])
                             variables = factor.free_symbols
                             if len(variables) == 1 and y == variables.pop():
-                                factor = exp(C.Integral(factor).doit())
+                                factor = exp(Integral(factor).doit())
                                 r[d] *= factor
                                 r[e] *= factor
                                 matching_hints["1st_exact"] = r
@@ -2437,7 +2438,7 @@ def ode_sol_simplicity(sol, func, trysolving=True):
 
         return len(str(sol))
 
-    if sol.has(C.Integral):
+    if sol.has(Integral):
         return oo
 
     # Next, try to solve for func.  This code will change slightly when RootOf
@@ -2488,7 +2489,7 @@ def _get_constant_subexpressions(expr, Cs):
                     x = expr.func(*d[True])
                     if not x.is_number:
                         Ces.append(x)
-            elif isinstance(expr, C.Integral):
+            elif isinstance(expr, Integral):
                 if expr.free_symbols.issubset(Cs) and \
                             all(len(x) == 3 for x in expr.limits):
                     Ces.append(expr)
@@ -2872,7 +2873,7 @@ def ode_1st_exact(eq, func, order, match):
     # Refer Joel Moses, "Symbolic Integration - The Stormy Decade",
     # Communications of the ACM, Volume 14, Number 8, August 1971, pp. 558
     # which gives the method to solve an exact differential equation.
-    sol = C.Integral(d, x) + C.Integral((e - (C.Integral(d, x).diff(y))), y)
+    sol = Integral(d, x) + Integral((e - (Integral(d, x).diff(y))), y)
     return Eq(sol, C1)
 
 
@@ -3024,7 +3025,7 @@ def ode_1st_homogeneous_coeff_subs_dep_div_indep(eq, func, order, match):
     C1 = get_numbered_constants(eq, num=1)
     xarg = match.get('xarg', 0)
     yarg = match.get('yarg', 0)
-    int = C.Integral(
+    int = Integral(
         (-r[r['e']]/(r[r['d']] + u1*r[r['e']])).subs({x: 1, r['y']: u1}),
         (u1, None, f(x)/x))
     sol = logcombine(Eq(log(x), int + log(C1)), force=True)
@@ -3120,7 +3121,7 @@ def ode_1st_homogeneous_coeff_subs_indep_div_dep(eq, func, order, match):
     C1 = get_numbered_constants(eq, num=1)
     xarg = match.get('xarg', 0)  # If xarg present take xarg, else zero
     yarg = match.get('yarg', 0)  # If yarg present take yarg, else zero
-    int = C.Integral(
+    int = Integral(
         simplify(
             (-r[r['d']]/(r[r['e']] + u2*r[r['d']])).subs({x: u2, r['y']: 1})),
         (u2, None, x/f(x)))
@@ -3172,7 +3173,6 @@ def homogeneous_order(eq, *symbols):
     True
 
     """
-    from sympy.simplify.simplify import separatevars
 
     if not symbols:
         raise ValueError("homogeneous_order: no symbols were given.")
@@ -3278,8 +3278,8 @@ def ode_1st_linear(eq, func, order, match):
     f = func.func
     r = match  # a*diff(f(x),x) + b*f(x) + c
     C1 = get_numbered_constants(eq, num=1)
-    t = exp(C.Integral(r[r['b']]/r[r['a']], x))
-    tt = C.Integral(t*(-r[r['c']]/r[r['a']]), x)
+    t = exp(Integral(r[r['b']]/r[r['a']], x))
+    tt = Integral(t*(-r[r['c']]/r[r['a']]), x)
     f = match.get('u', f(x))  # take almost-linear u if present, else f(x)
     return Eq(f, (tt + C1)/t)
 
@@ -3364,8 +3364,8 @@ def ode_Bernoulli(eq, func, order, match):
     f = func.func
     r = match  # a*diff(f(x),x) + b*f(x) + c*f(x)**n, n != 1
     C1 = get_numbered_constants(eq, num=1)
-    t = exp((1 - r[r['n']])*C.Integral(r[r['b']]/r[r['a']], x))
-    tt = (r[r['n']] - 1)*C.Integral(t*r[r['c']]/r[r['a']], x)
+    t = exp((1 - r[r['n']])*Integral(r[r['b']]/r[r['a']], x))
+    tt = (r[r['n']] - 1)*Integral(t*r[r['c']]/r[r['a']], x)
     return Eq(f(x), ((tt + C1)/t)**(1/(1 - r[r['n']])))
 
 
@@ -3485,8 +3485,8 @@ def ode_Liouville(eq, func, order, match):
     r = match  # f(x).diff(x, 2) + g*f(x).diff(x)**2 + h*f(x).diff(x)
     y = r['y']
     C1, C2 = get_numbered_constants(eq, num=2)
-    int = C.Integral(exp(C.Integral(r['g'], y)), (y, None, f(x)))
-    sol = Eq(int + C1*C.Integral(exp(-C.Integral(r['h'], x)), x) + C2, 0)
+    int = Integral(exp(Integral(r['g'], y)), (y, None, f(x)))
+    sol = Eq(int + C1*Integral(exp(-Integral(r['h'], x)), x) + C2, 0)
     return sol
 
 
@@ -4849,7 +4849,6 @@ def _undetermined_coefficients_match(expr, x):
     {'test': False}
 
     """
-    from sympy import S
     a = Wild('a', exclude=[x])
     b = Wild('b', exclude=[x])
     expr = powsimp(expr, combine='exp')  # exp(x)*exp(2*x + 1) => exp(3*x + 1)
@@ -5083,7 +5082,7 @@ def _solve_variation_of_parameters(eq, func, order, match):
         str(eq) + " (number of terms != order)")
     negoneterm = (-1)**(order)
     for i in gensols:
-        psol += negoneterm*C.Integral(wronskian([sol for sol in gensols if sol != i], x)*r[-1]/wr, x)*i/r[order]
+        psol += negoneterm*Integral(wronskian([sol for sol in gensols if sol != i], x)*r[-1]/wr, x)*i/r[order]
         negoneterm *= -1
 
     if r.get('simplify', True):
@@ -5152,8 +5151,8 @@ def ode_separable(eq, func, order, match):
     C1 = get_numbered_constants(eq, num=1)
     r = match  # {'m1':m1, 'm2':m2, 'y':y}
     u = r.get('hint', f(x))  # get u from separable_reduced else get f(x)
-    return Eq(C.Integral(r['m2']['coeff']*r['m2'][r['y']]/r['m1'][r['y']],
-        (r['y'], None, u)), C.Integral(-r['m1']['coeff']*r['m1'][x]/
+    return Eq(Integral(r['m2']['coeff']*r['m2'][r['y']]/r['m1'][r['y']],
+        (r['y'], None, u)), Integral(-r['m1']['coeff']*r['m1'][x]/
         r['m2'][x], x) + C1)
 
 
@@ -5282,8 +5281,6 @@ def ode_lie_group(eq, func, order, match):
       John Starrett, pp. 1 - pp. 14
 
     """
-    from sympy.integrals.integrals import integrate
-    from sympy.solvers.pde import pdsolve
 
     heuristics = lie_heuristics
     inf = {}
@@ -5630,7 +5627,6 @@ def lie_heuristic_abaco1_simple(match, comp=False):
 
 
     """
-    from sympy.integrals.integrals import integrate
 
     xieta = []
     y = match['y']
@@ -5730,7 +5726,6 @@ def lie_heuristic_abaco1_product(match, comp=False):
       ODE Patterns, pp. 7 - pp. 8
 
     """
-    from sympy.integrals.integrals import integrate
 
     xieta = []
     y = match['y']
@@ -5955,7 +5950,7 @@ def lie_heuristic_function_sum(match, comp=False):
       ODE Patterns, pp. 7 - pp. 8
 
     """
-    from sympy.integrals.integrals import integrate
+
     xieta = []
     h = match['h']
     hx = match['hx']
@@ -6047,8 +6042,6 @@ def lie_heuristic_abaco2_similar(match, comp=False):
       ODE Patterns, pp. 10 - pp. 12
 
     """
-
-    from sympy.integrals.integrals import integrate
 
     xieta = []
     h = match['h']
@@ -6577,8 +6570,8 @@ def _linear_2eq_order1_type3(x, y, t, r):
 
     """
     C1, C2, C3, C4 = symbols('C1:5')
-    F = C.Integral(r['a'], t)
-    G = C.Integral(r['b'], t)
+    F = Integral(r['a'], t)
+    G = Integral(r['b'], t)
     sol1 = exp(F)*(C1*exp(G) + C2*exp(-G))
     sol2 = exp(F)*(C1*exp(G) - C2*exp(-G))
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
@@ -6602,13 +6595,13 @@ def _linear_2eq_order1_type4(x, y, t, r):
     """
     C1, C2, C3, C4 = symbols('C1:5')
     if r['b'] == -r['c']:
-        F = exp(C.Integral(r['a'], t))
-        G = C.Integral(r['b'], t)
+        F = exp(Integral(r['a'], t))
+        G = Integral(r['b'], t)
         sol1 = F*(C1*cos(G) + C2*sin(G))
         sol2 = F*(-C1*sin(G) + C2*cos(G))
     elif r['d'] == -r['a']:
-        F = exp(C.Integral(r['c'], t))
-        G = C.Integral(r['d'], t)
+        F = exp(Integral(r['c'], t))
+        G = Integral(r['d'], t)
         sol1 = F*(-C1*sin(G) + C2*cos(G))
         sol2 = F*(C1*cos(G) + C2*sin(G))
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
@@ -6638,14 +6631,14 @@ def _linear_2eq_order1_type5(x, y, t, r):
         q = cancel((r['d']-r['a'])/r['b'])
         eq = (Eq(diff(u(T),T), v(T)), Eq(diff(v(T),T), p*u(T)+q*v(T)))
         sol = dsolve(eq)
-        sol1 = exp(C.Integral(r['a'], t))*sol[0].rhs.subs(T, C.Integral(r['b'],t))
-        sol2 = exp(C.Integral(r['a'], t))*sol[1].rhs.subs(T, C.Integral(r['b'],t))
+        sol1 = exp(Integral(r['a'], t))*sol[0].rhs.subs(T, Integral(r['b'],t))
+        sol2 = exp(Integral(r['a'], t))*sol[1].rhs.subs(T, Integral(r['b'],t))
     if not cancel(r['a']/r['d']).has(t):
         p = cancel(r['a']/r['d'])
         q = cancel((r['b']-r['c'])/r['d'])
         sol = dsolve(Eq(diff(u(T),T), v(T)), Eq(diff(v(T),T), p*u(T)+q*v(T)))
-        sol1 = exp(C.Integral(r['c'], t))*sol[1].rhs.subs(T, C.Integral(r['d'],t))
-        sol2 = exp(C.Integral(r['c'], t))*sol[0].rhs.subs(T, C.Integral(r['d'],t))
+        sol1 = exp(Integral(r['c'], t))*sol[1].rhs.subs(T, Integral(r['d'],t))
+        sol2 = exp(Integral(r['c'], t))*sol[0].rhs.subs(T, Integral(r['d'],t))
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
 
 def _linear_2eq_order1_type6(x, y, t, r):
@@ -6689,15 +6682,15 @@ def _linear_2eq_order1_type6(x, y, t, r):
                     s = j
                     break
     if p == 1:
-        equ = diff(x(t),t) - r['a']*x(t) - r['b']*(s*x(t) + C1*exp(-s*C.Integral(r['b'] - r['d']/s, t)))
+        equ = diff(x(t),t) - r['a']*x(t) - r['b']*(s*x(t) + C1*exp(-s*Integral(r['b'] - r['d']/s, t)))
         hint1 = classify_ode(equ)[1]
         sol1 = dsolve(equ, hint=hint1+'_Integral').rhs
-        sol2 = s*sol1 + C1*exp(-s*C.Integral(r['b'] - r['d']/s, t))
+        sol2 = s*sol1 + C1*exp(-s*Integral(r['b'] - r['d']/s, t))
     elif p ==2:
-        equ = diff(y(t),t) - r['c']*y(t) - r['d']*s*y(t) + C1*exp(-s*C.Integral(r['d'] - r['b']/s, t))
+        equ = diff(y(t),t) - r['c']*y(t) - r['d']*s*y(t) + C1*exp(-s*Integral(r['d'] - r['b']/s, t))
         hint1 = classify_ode(equ)[1]
         sol2 = dsolve(equ, hint=hint1+'_Integral').rhs
-        sol1 = s*sol2 + C1*exp(-s*C.Integral(r['d'] - r['b']/s, t))
+        sol1 = s*sol2 + C1*exp(-s*Integral(r['d'] - r['b']/s, t))
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
 
 def _linear_2eq_order1_type7(x, y, t, r):
@@ -6754,10 +6747,10 @@ def _linear_2eq_order1_type7(x, y, t, r):
         sol1 = dsolve(diff(x(t),t) - r['a']*x(t) - r['b']*sol2).rhs
     else:
         x0, y0 = symbols('x0, y0')              #x0 and y0 being particular solutions
-        F = exp(C.Integral(r['a'],t))
-        P = exp(C.Integral(r['d'],t))
-        sol1 = C1*x0 + C2*x0*C.Integral(r['b']*F*P/x0**2, t)
-        sol2 = C1*y0 + C2(F*P/x0 + y0*C.Integral(r['b']*F*P/x0**2, t))
+        F = exp(Integral(r['a'],t))
+        P = exp(Integral(r['d'],t))
+        sol1 = C1*x0 + C2*x0*Integral(r['b']*F*P/x0**2, t)
+        sol2 = C1*y0 + C2(F*P/x0 + y0*Integral(r['b']*F*P/x0**2, t))
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
 
 
@@ -7123,8 +7116,8 @@ def _linear_2eq_order2_type5(x, y, t, r):
     else:
         u = C1*r['a']*cos(mul*t**2/2) + C2*r['a']*sin(mul*t**2/2)
         v = -C1*mul*sin(mul*t**2/2) + C2*mul*cos(mul*t**2/2)
-    sol1 = C3*t + t*C.Integral(u/t**2, t)
-    sol2 = C4*t + t*C.Integral(v/t**2, t)
+    sol1 = C3*t + t*Integral(u/t**2, t)
+    sol2 = C4*t + t*Integral(v/t**2, t)
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
 
 def _linear_2eq_order2_type6(x, y, t, r):
@@ -7206,9 +7199,9 @@ def _linear_2eq_order2_type7(x, y, t, r):
     b2 = denum.coeff(y(t))
     chareq = k**2 - (a1 + b2)*k + a1*b2 - a2*b1
     [k1, k2] = [RootOf(chareq, k) for k in range(Poly(chareq).degree())]
-    F = C.Integral(f, t)
-    z1 = C1*C.Integral(exp(k1*F), t) + C2
-    z2 = C3*C.Integral(exp(k2*F), t) + C4
+    F = Integral(f, t)
+    z1 = C1*Integral(exp(k1*F), t) + C2
+    z2 = C3*Integral(exp(k2*F), t) + C4
     sol1 = (k1*z2 - k2*z1 + a1*(z1 - z2))/(a2*(k1-k2))
     sol2 = (z1 - z2)/(k1 - k2)
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
@@ -7257,15 +7250,15 @@ def _linear_2eq_order2_type8(x, y, t, r):
     a = num
     b = denum
     mul = sqrt(abs(a*b))
-    Igral = C.Integral(t*f, t)
+    Igral = Integral(t*f, t)
     if a*b > 0:
         u = C1*a*exp(mul*Igral) + C2*a*exp(-mul*Igral)
         v = C1*mul*exp(mul*Igral) - C2*mul*exp(-mul*Igral)
     else:
         u = C1*a*cos(mul*Igral) + C2*a*sin(mul*Igral)
         v = -C1*mul*sin(mul*Igral) + C2*mul*cos(mul*Igral)
-    sol1 = C3*t + t*C.Integral(u/t**2, t)
-    sol2 = C4*t + t*C.Integral(v/t**2, t)
+    sol1 = C3*t + t*Integral(u/t**2, t)
+    sol2 = C4*t + t*Integral(v/t**2, t)
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
 
 def _linear_2eq_order2_type9(x, y, t, r):
@@ -7364,8 +7357,8 @@ def _linear_2eq_order2_type10(x, y, t, r):
     d = cancel(r['d2']*eqz**2)
     [msol1, msol2] = dsolve([Eq(diff(u(t), t, t), (a - dic[p]*dic[s] + dic[q]**2/4)*u(t) \
     + b*v(t)), Eq(diff(v(t),t,t), c*u(t) + (d - dic[p]*dic[s] + dic[q]**2/4)*v(t))])
-    sol1 = (msol1.rhs*sqrt(abs(eqz))).subs(t, C.Integral(1/eqz, t))
-    sol2 = (msol2.rhs*sqrt(abs(eqz))).subs(t, C.Integral(1/eqz, t))
+    sol1 = (msol1.rhs*sqrt(abs(eqz))).subs(t, Integral(1/eqz, t))
+    sol2 = (msol2.rhs*sqrt(abs(eqz))).subs(t, Integral(1/eqz, t))
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
 
 def _linear_2eq_order2_type11(x, y, t, r):
@@ -7396,8 +7389,8 @@ def _linear_2eq_order2_type11(x, y, t, r):
     f = -r['c1'] ; g = -r['d1']
     h = -r['c2'] ; p = -r['d2']
     [msol1, msol2] = dsolve([Eq(diff(u(t),t), t*f*u(t) + t*g*v(t)), Eq(diff(v(t),t), t*h*u(t) + t*p*v(t))])
-    sol1 = C3*t + t*C.Integral(msol1.rhs/t**2, t)
-    sol2 = C4*t + t*C.Integral(msol2.rhs/t**2, t)
+    sol1 = C3*t + t*Integral(msol1.rhs/t**2, t)
+    sol2 = C4*t + t*Integral(msol2.rhs/t**2, t)
     return [Eq(x(t), sol1), Eq(y(t), sol2)]
 
 def sysode_linear_3eq_order1(match_):
@@ -7596,9 +7589,9 @@ def _linear_3eq_order1_type4(x, y, z, t, r):
     trans_eq = (diff(u(t),t)-a1*u(t)-a2*v(t)-a3*w(t), diff(v(t),t)-b1*u(t)-\
     b2*v(t)-b3*w(t), diff(w(t),t)-c1*u(t)-c2*v(t)-c3*w(t))
     sol = dsolve(trans_eq)
-    sol1 = exp(C.Integral(g,t))*((sol[0].rhs).subs(t, C.Integral(f,t)))
-    sol2 = exp(C.Integral(g,t))*((sol[1].rhs).subs(t, C.Integral(f,t)))
-    sol3 = exp(C.Integral(g,t))*((sol[2].rhs).subs(t, C.Integral(f,t)))
+    sol1 = exp(Integral(g,t))*((sol[0].rhs).subs(t, Integral(f,t)))
+    sol2 = exp(Integral(g,t))*((sol[1].rhs).subs(t, Integral(f,t)))
+    sol3 = exp(Integral(g,t))*((sol[2].rhs).subs(t, Integral(f,t)))
     return [Eq(x(t), sol1), Eq(y(t), sol2), Eq(z(t), sol3)]
 
 def sysode_linear_neq_order1(match_):
@@ -7779,11 +7772,11 @@ def _nonlinear_2eq_order1_type1(x, y, t, eq):
     F = r[f].subs(x(t),u).subs(y(t),v)
     n = r[n]
     if n!=1:
-        phi = (C1 + (1-n)*C.Integral(1/g, v))**(1/(1-n))
+        phi = (C1 + (1-n)*Integral(1/g, v))**(1/(1-n))
     else:
-        phi = C1*exp(C.Integral(1/g, v))
+        phi = C1*exp(Integral(1/g, v))
     phi = phi.doit()
-    sol2 = solve(C.Integral(1/(g*F.subs(u,phi)), v).doit() - t - C2, v)
+    sol2 = solve(Integral(1/(g*F.subs(u,phi)), v).doit() - t - C2, v)
     sol = []
     for sols in sol2:
         sol.append(Eq(x(t),phi.subs(v, sols)))
@@ -7824,11 +7817,11 @@ def _nonlinear_2eq_order1_type2(x, y, t, eq):
     F = r[f].subs(x(t),u).subs(y(t),v)
     n = r[n]
     if n:
-        phi = -1/n*log(C1 - n*C.Integral(1/g, v))
+        phi = -1/n*log(C1 - n*Integral(1/g, v))
     else:
-        phi = C1 + C.Integral(1/g, v)
+        phi = C1 + Integral(1/g, v)
     phi = phi.doit()
-    sol2 = solve(C.Integral(1/(g*F.subs(u,phi)), v).doit() - t - C2, v)
+    sol2 = solve(Integral(1/(g*F.subs(u,phi)), v).doit() - t - C2, v)
     sol = []
     for sols in sol2:
         sol.append(Eq(x(t),phi.subs(v, sols)))
@@ -7863,7 +7856,7 @@ def _nonlinear_2eq_order1_type3(x, y, t, eq):
     G = r2[g].subs(x(t),u).subs(y(t),v)
     sol2r = dsolve(Eq(diff(v(u),u), G.subs(v,v(u))/F.subs(v,v(u))))
     for sol2s in sol2r:
-        sol1 = solve(C.Integral(1/F.subs(v, sol2s.rhs), u).doit() - t - C2, u)
+        sol1 = solve(Integral(1/F.subs(v, sol2s.rhs), u).doit() - t - C2, u)
     sol = []
     for sols in sol1:
         sol.append(Eq(x(t), sols))
@@ -7905,8 +7898,8 @@ def _nonlinear_2eq_order1_type4(x, y, t, eq):
     phi = (r1[f].subs(x(t),u).subs(y(t),v))/num
     F1 = R1[f1]; F2 = R2[f2]
     G1 = R1[g1]; G2 = R2[g2]
-    sol1r = solve(C.Integral(F2/F1, u).doit() - C.Integral(G1/G2,v).doit() - C1, u)
-    sol2r = solve(C.Integral(F2/F1, u).doit() - C.Integral(G1/G2,v).doit() - C1, v)
+    sol1r = solve(Integral(F2/F1, u).doit() - Integral(G1/G2,v).doit() - C1, u)
+    sol2r = solve(Integral(F2/F1, u).doit() - Integral(G1/G2,v).doit() - C1, v)
     sol = []
     for sols in sol1r:
         sol.append(Eq(y(t), dsolve(diff(v(t),t) - F2.subs(u,sols).subs(v,v(t))*G2.subs(v,v(t))*phi.subs(u,sols).subs(v,v(t))).rhs))

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -35,13 +35,14 @@ more information on each (run help(pde)):
 from __future__ import print_function, division
 
 from sympy.simplify import simplify
-from sympy.core import Add, C, S
+from sympy.core import Add, S
 from sympy.core.compatibility import (reduce, combinations_with_replacement,
     is_sequence, range)
 from sympy.core.function import Function, expand, AppliedUndef, Subs
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, symbols
 from sympy.functions import exp
+from sympy.integrals.integrals import Integral
 from sympy.utilities.iterables import has_dups
 
 from sympy.solvers.deutils import _preprocess, ode_order, _desolve
@@ -636,7 +637,6 @@ def pde_1st_linear_constant_coeff(eq, func, order, match, solvefun):
     # TODO : For now homogeneous first order linear PDE's having
     # two variables are implemented. Once there is support for
     # solving systems of ODE's, this can be extended to n variables.
-
     xi, eta = symbols("xi eta")
     f = func.func
     x = func.args[0]
@@ -650,7 +650,7 @@ def pde_1st_linear_constant_coeff(eq, func, order, match, solvefun):
     solvedict = solve((b*x + c*y - xi, c*x - b*y - eta), x, y)
     # Integral should remain as it is in terms of xi,
     # doit() should be done in _handle_Integral.
-    genterm = (1/S(b**2 + c**2))*C.Integral(
+    genterm = (1/S(b**2 + c**2))*Integral(
         (1/expterm*e).subs(solvedict), (xi, b*x + c*y))
     return Eq(f(x,y), Subs(expterm*(functerm + genterm),
         (eta, xi), (c*x - b*y, b*x + c*y)))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -17,11 +17,12 @@ from __future__ import print_function, division
 from sympy.core.compatibility import (iterable, is_sequence, ordered,
     default_sort_key, range)
 from sympy.core.sympify import sympify
-from sympy.core import C, S, Add, Symbol, Equality, Dummy, Expr, Mul, Pow
+from sympy.core import S, Add, Symbol, Equality, Dummy, Expr, Mul, Pow
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import (expand_mul, expand_multinomial, expand_log,
                           Derivative, AppliedUndef, UndefinedFunction, nfloat,
                           Function, expand_power_exp, Lambda, _mexpand)
+from sympy.integrals.integrals import Integral
 from sympy.core.numbers import ilcm, Float
 from sympy.core.relational import Relational, Ge
 from sympy.logic.boolalg import And, Or, BooleanAtom
@@ -36,8 +37,7 @@ from sympy.simplify import (simplify, collect, powsimp, posify, powdenest,
 from sympy.simplify.sqrtdenest import sqrt_depth
 from sympy.simplify.fu import TR1
 from sympy.matrices import Matrix, zeros
-from sympy.polys import (roots, cancel, factor, Poly, together, RootOf,
-    degree)
+from sympy.polys import roots, cancel, factor, Poly, together, degree
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 
@@ -1891,7 +1891,6 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     If only x was excluded then a solution for y or z might be obtained.
 
     """
-    from sympy import Equality
     if isinstance(lhs, Equality):
         if rhs:
             raise ValueError(filldedent('''
@@ -1952,7 +1951,7 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
                     if not any(checksol(di, {xi: vi}, minimal=True) is True
                               for di in dens):
                         # simplify any trivial integral
-                        irep = [(i, i.doit()) for i in vi.atoms(C.Integral) if
+                        irep = [(i, i.doit()) for i in vi.atoms(Integral) if
                                 i.function.is_number]
                         # do a slight bit of simplification
                         vi = expand_mul(vi.subs(irep))


### PR DESCRIPTION
Breaking cycles involved moving some imports into functions.
It also involved replacing class variables _a and _b with overridable
member functions a() and b(), because initializing the class variables
with SymPy symbols would require a more fully initialized SymPy than is
available at class variable initialization time.
