### PR TITLE
Implemented Partial Pivoting #9060

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2678,25 +2678,11 @@ class MatrixBase(object):
             if simplify:
                 r[pivot, i] = simpfunc(r[pivot, i])
             if iszerofunc(r[pivot, i]):
-<<<<<<< HEAD
-                max1, ind = 0, 0
-                for k in range(pivot, r.rows):
-                    if simplify and k > pivot:
-                        r[k, i] = simpfunc(r[k, i])
-                    if max1 < abs(r[k, i]):
-=======
-                """for k in range(pivot, r.rows):
-                    if simplify and k > pivot:
-                        r[k, i] = simpfunc(r[k, i])
-                    if not iszerofunc(r[k, i]):
-                        r.row_swap(pivot, k)
-                        break"""
                 max1, ind = 0, 0
                 for k in range(pivot, r.rows):
                     if simplify and k > pivot:
                         r[k, i] = simpfunc(r[k, i])
                     if max1 < r[k, i]:
->>>>>>> e106b5c63775cd858c086704fb45897e9b12b349
                         max1 = r[k, i]
                         ind = k
                 if not iszerofunc(r[ind, i]):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2678,12 +2678,15 @@ class MatrixBase(object):
             if simplify:
                 r[pivot, i] = simpfunc(r[pivot, i])
             if iszerofunc(r[pivot, i]):
+                max1, ind = 0, 0
                 for k in range(pivot, r.rows):
                     if simplify and k > pivot:
                         r[k, i] = simpfunc(r[k, i])
-                    if not iszerofunc(r[k, i]):
-                        r.row_swap(pivot, k)
-                        break
+                    if max1 < abs(r[k, i]):
+                        max1 = r[k, i]
+                        ind = k
+                if not iszerofunc(r[ind, i]):
+                    r.row_swap(pivot, ind)
                 else:
                     continue
             scale = r[pivot, i]

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2678,12 +2678,21 @@ class MatrixBase(object):
             if simplify:
                 r[pivot, i] = simpfunc(r[pivot, i])
             if iszerofunc(r[pivot, i]):
-                for k in range(pivot, r.rows):
+                """for k in range(pivot, r.rows):
                     if simplify and k > pivot:
                         r[k, i] = simpfunc(r[k, i])
                     if not iszerofunc(r[k, i]):
                         r.row_swap(pivot, k)
-                        break
+                        break"""
+                max1, ind = 0, 0
+                for k in range(pivot, r.rows):
+                    if simplify and k > pivot:
+                        r[k, i] = simpfunc(r[k, i])
+                    if max1 < r[k, i]:
+                        max1 = r[k, i]
+                        ind = k
+                if not iszerofunc(r[ind, i]):
+                    r.row_swap(pivot, ind)
                 else:
                     continue
             scale = r[pivot, i]


### PR DESCRIPTION
Sympy currently uses trivial pivoting i.e. it selects the first non-zero term in the column.
However that is numerically unstable.
This PR implements partial pivoting i.e. swap with the largest term in the column.
