### PR TITLE
Remove duplicate classifiers list from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -302,21 +302,6 @@ tests = [
     'sympy.vector.tests',
     ]
 
-classifiers = [
-    'License :: OSI Approved :: BSD License',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Topic :: Scientific/Engineering',
-    'Topic :: Scientific/Engineering :: Mathematics',
-    'Topic :: Scientific/Engineering :: Physics',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
-]
-
 long_description = '''SymPy is a Python library for symbolic mathematics. It aims
 to become a full-featured computer algebra system (CAS) while keeping the code
 as simple as possible in order to be comprehensible and easily extensible.


### PR DESCRIPTION
The classifiers list was set up as a constant before setup(), but setup() uses its own list of classifiers. Furthermore, the two lists had diverged—the external (unused) one didn't have Python 3.4 as a language, for instance.

Since the external list was unused, just cut it.
