### PR TITLE
Return with_metaclass to the definition given in six

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -172,14 +172,14 @@ def with_metaclass(meta, *bases):
     <class 'Meta'>
 
     """
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    # Code copied from the 'six' library.
     class metaclass(meta):
-        __call__ = type.__call__
-        __init__ = type.__init__
         def __new__(cls, name, this_bases, d):
-            if this_bases is None:
-                return type.__new__(cls, name, (), d)
             return meta(name, bases, d)
-    return metaclass("NewBase", None, {})
+    return type.__new__(metaclass, "NewBase", (), {})
 
 
 # These are in here because telling if something is an iterable just by calling


### PR DESCRIPTION
Specifically:

Do not hardcode `__call__` and `__init__` to be the versions from the
`type` metaclass.
ALL metaclasses in SymPy derive from `type` anyway, so those that want
and need these versions can have them anyway, and those that want to
override them can do so, too.
(Singleton will want to override `__call__`.)

Do not check for `this_bases is None`.
It cannot be `None` anyway, it can only be `()`.
(Actually not a single `with_metaclass` makes use of that "you can omit
'object'" featurem, so coding for that case is just potential bugs for
no gain.)

Use `type.__new__(metaclass, ...)` instead of `metaclass(...)`.
I am not 100% sure about the consequences of this, but I'm simply going
with the wisdom of the six guys.
Might be necessary to avoid endless recursion in some cases.
