### PR TITLE
as_solution_set to convert solution of multivariate solvers (in relationals and logic) into ProductSet

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -239,7 +239,7 @@ class Relational(Boolean, Expr, EvalfMixin):
             if is_ineq_gt:
                 return Interval(gen - e, S.Infinity, strict)
             else:
-                return Interval(S.NegativeInfinity, gen -e, False, strict)
+                return Interval(-S.Infinity, gen -e, False, strict)
 
     def as_set(self):
         """

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -203,7 +203,7 @@ class Relational(Boolean, Expr, EvalfMixin):
 
     __bool__ = __nonzero__
 
-    def as_set(self, gen=False):
+    def as_solution_set(self, gen=False):
         """
         Rewrites the simplified (solution) inequality in terms of real set
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -343,7 +343,7 @@ class And(LatticeOp, BooleanFunction):
         >>> And(x<2, x>-2).as_solution__set()
         (-2, 2)
 
-        For multivariate logic expressions:
+        For multivariate logical expressions:
 
         >>> And(x>0, y>x).as_solution_set(x, y)
         (0, ∞) x (x, ∞)
@@ -357,7 +357,7 @@ class And(LatticeOp, BooleanFunction):
         """
         from sympy.sets.sets import Intersection, Interval, ProductSet
         if len(self.free_symbols) == 1:
-            return Intersection(*[arg.as_set() for arg in self.args])
+            return Intersection(*[arg.as_solution_set() for arg in self.args])
         else:
             result = defaultdict(lambda: Interval(S.NegativeInfinity, S.Infinity))
             for ineq in self.args:
@@ -367,7 +367,8 @@ class And(LatticeOp, BooleanFunction):
                 if len(variables) == 1:
                     variable = variables.pop()
                     u_variables.append(variable)
-                    result[variable] = Intersection(result[variable], ineq.as_set())
+                    result[variable] = Intersection(result[variable],
+                                                    ineq.as_solution_set())
                 else:
                     e = ineq.lhs - ineq.rhs
                     index = 0
@@ -376,8 +377,7 @@ class And(LatticeOp, BooleanFunction):
                             index = args.index(i) if args.index(i) > index else index
                             variable = args[index]
 
-                    result[variable] = Intersection(result[variable], ineq.as_set(variable))
-
+                    result[variable] = Intersection(result[variable], ineq.as_solution_set(variable))
 
             return ProductSet(*[result[arg] for arg in args])
 


### PR DESCRIPTION
These additions are for future coming multivariate solvers. The solution for those solvers will be in terms of logic and relational operators. That will be converted to `ProductSet` (or `union of ProductSet`) by using as_set. Currently I have not written Or.as_solution_set

for relational.as_solution_set: assumed that the coeff of gen in inequality will be 1 as this inequality is from solution of `gen`

for And.as_solution_set:
In []: And(x>0, y>x**2+1).as_solution_set(x, y)
Out[]: (0, oo) x (x**2 + 1, oo)
Output is ProductSet of solution of x and y. If some inequality has more than one variable then it is used to find the solution of the variable (in terms of other variables) which has the coeff as 1 and is rightmost to as_solution_set args list.
