### PR TITLE
Fix the link to the SymPy logo svg in the docs

### DIFF
--- a/doc/src/outreach.rst
+++ b/doc/src/outreach.rst
@@ -15,7 +15,7 @@ SymPy logos
 
 SymPy has a collection of official logos, which can
 be generated from
-`sympy.svg <https://github.com/sympy/sympy/tree/master/doc/src/sympy.svg>`
+`sympy.svg <https://github.com/sympy/sympy/blob/master/doc/src/logo/sympy.svg>`_
 in your local copy of SymPy by::
 
     $ cd doc


### PR DESCRIPTION
It turns out I can't build the docs (don't have rsvg-convert) and I don't have time to figure it out right now, so someone should check this before merging. 
