### PR TITLE
Remove Expr._eval_is_composite

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -676,10 +676,6 @@ class Expr(Basic, EvalfMixin):
             return diff
         return None
 
-    def _eval_is_composite(self):
-        if self.is_integer and self.is_positive and self.is_prime is False:
-            return True
-
     def _eval_is_positive(self):
         from sympy.polys.numberfields import minimal_polynomial
         from sympy.polys.polyerrors import NotAlgebraic

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -479,7 +479,7 @@ def test_composite():
     assert S(17).is_composite is False
     assert S(4).is_composite is True
     x = Dummy(integer=True, positive=True, prime=False)
-    assert x.is_composite
+    assert x.is_composite is None # x could be 1
     assert (x + 1).is_composite is None
 
 


### PR DESCRIPTION
The logic was wrong, since 1 is not composite, composite -> integer & positive
& !prime, but the reverse implication is not true. Since this fact is already
in assumptions.py, the method is not needed.  Also fixed test.

See #8860.
