### PR TITLE
physics.quantum: Implemented _represent_ZGate in Grover's algorithm

### DIFF
--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -174,12 +174,11 @@ class OracleGate(Gate):
         """
         nbasis = 2**self.nqubits  # compute it only once
         matrixOracle = eye(nbasis)
-        normalizing_factor = 1/sqrt(nbasis)
         # Flip the sign given the output of the oracle function
         for i in range(nbasis):
             if self.search_function(IntQubit(i, self.nqubits)):
                 matrixOracle[i, i] = NegativeOne()
-        return normalizing_factor * matrixOracle
+        return matrixOracle
 
 
 class WGate(Gate):

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -10,8 +10,9 @@ Todo:
 
 from __future__ import print_function, division
 
-from sympy import floor, pi, sqrt, sympify
+from sympy import floor, pi, sqrt, sympify, eye
 from sympy.core.compatibility import u, range
+from sympy.core.numbers import NegativeOne
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qexpr import QuantumError
 from sympy.physics.quantum.hilbert import ComplexSpace
@@ -168,9 +169,17 @@ class OracleGate(Gate):
     #-------------------------------------------------------------------------
 
     def _represent_ZGate(self, basis, **options):
-        raise NotImplementedError(
-            "Represent for the Oracle has not been implemented yet"
-        )
+        """
+        Represent the OracleGate in the computational basis.
+        """
+        nbasis = 2**self.nqubits  # compute it only once
+        matrixOracle = eye(nbasis)
+        normalizing_factor = 1/sqrt(nbasis)
+        # Flip the sign given the output of the oracle function
+        for i in range(nbasis):
+            if self.search_function(IntQubit(i, self.nqubits)):
+                matrixOracle[i, i] = NegativeOne()
+        return normalizing_factor * matrixOracle
 
 
 class WGate(Gate):

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -43,7 +43,7 @@ def test_OracleGate():
     # Due to a bug of IntQubit, this first assertion is buggy
     # assert represent(OracleGate(1, lambda qubits: qubits == IntQubit(0)), nqubits=1) == \
     #     Matrix([[-1/sqrt(2), 0], [0, 1/sqrt(2)]])
-    assert represent(v, nqubits=2) == 1/2 * Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
+    assert represent(v, nqubits=2) == Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
 
 def test_WGate():
     nqubits = 2

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -1,4 +1,5 @@
-from sympy import sqrt
+from sympy import sqrt, Matrix
+from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qubit import IntQubit
 from sympy.physics.quantum.grover import (apply_grover, superposition_basis,
@@ -39,6 +40,10 @@ def test_OracleGate():
     assert qapply(v*IntQubit(2, nbits)) == -IntQubit(2, nbits)
     assert qapply(v*IntQubit(3, nbits)) == IntQubit(3, nbits)
 
+    # Due to a bug of IntQubit, this first assertion is buggy
+    # assert represent(OracleGate(1, lambda qubits: qubits == IntQubit(0)), nqubits=1) == \
+    #     Matrix([[-1/sqrt(2), 0], [0, 1/sqrt(2)]])
+    assert represent(v, nqubits=2) == 1/2 * Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
 
 def test_WGate():
     nqubits = 2


### PR DESCRIPTION
Implemented function _represent_ZGate in grover.py : it computes
the representation of the OracleGate in the computational basis.

There might be a cleverer way of doing it, but currently it just
looks at the oracle answer for every qubit of the computational
basis.
