### PR TITLE
Fixed a typo in qubit_to_matrix documentation

### DIFF
--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -481,7 +481,7 @@ def matrix_to_density(mat):
 
 
 def qubit_to_matrix(qubit, format='sympy'):
-    """Coverts an Add/Mul of Qubit objects into it's matrix representation
+    """Converts an Add/Mul of Qubit objects into it's matrix representation
 
     This function is the inverse of ``matrix_to_qubit`` and is a shorthand
     for ``represent(qubit)``.


### PR DESCRIPTION
Fixed a typo in documentation of qubit_to_matrix. 
