### PR TITLE
Implemented stieltjes constants

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1671,6 +1671,11 @@ def test_sympy__functions__special__zeta_functions__polylog():
     assert _test_args(polylog(x, y))
 
 
+def test_sympy__functions__special__zeta_functions__stieltjes():
+    from sympy.functions.special.zeta_functions import stieltjes
+    assert _test_args(stieltjes(x, y))
+
+
 def test_sympy__integrals__integrals__Integral():
     from sympy.integrals.integrals import Integral
     assert _test_args(Integral(2, (x, 0, 1)))

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -28,7 +28,7 @@ from sympy.functions.special.error_functions import (erf, erfc, erfi, erf2,
 from sympy.functions.special.gamma_functions import (gamma, lowergamma,
         uppergamma, polygamma, loggamma, digamma, trigamma)
 from sympy.functions.special.zeta_functions import (dirichlet_eta, zeta,
-        lerchphi, polylog)
+        lerchphi, polylog, stieltjes)
 from sympy.functions.special.tensor_functions import (Eijk, LeviCivita,
         KroneckerDelta)
 from sympy.functions.special.delta_functions import DiracDelta, Heaviside

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log,
                    zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I,
-                   exp_polar, polar_lift, O)
+                   exp_polar, polar_lift, O, stieltjes)
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically as tn)
 
@@ -139,7 +139,6 @@ def test_lerchphi_expansion():
     # direct summation
     assert myexpand(lerchphi(z, -1, a), a/(1 - z) + z/(1 - z)**2)
     assert myexpand(lerchphi(z, -3, a), None)
-
     # polylog reduction
     assert myexpand(lerchphi(z, s, S(1)/2),
                     2**(s - 1)*(polylog(s, sqrt(z))/sqrt(z)
@@ -156,3 +155,25 @@ def test_lerchphi_expansion():
     assert myexpand(lerchphi(I, s, a), None)
     assert myexpand(lerchphi(-I, s, a), None)
     assert myexpand(lerchphi(exp(2*I*pi/5), s, a), None)
+
+
+def test_stieltjes():
+
+    # Zero'th constant EulerGamma
+    assert stieltjes(0) == S.EulerGamma
+    assert stieltjes(0, 1) == S.EulerGamma
+
+    # Not defined
+    assert stieltjes(nan) == nan
+    assert stieltjes(0, nan) == nan
+    assert stieltjes(-1) == S.ComplexInfinity
+    assert stieltjes(1.5) == S.ComplexInfinity
+    assert stieltjes(z, 0) == S.ComplexInfinity
+    assert stieltjes(z, -1) == S.ComplexInfinity
+
+
+def test_stieltjes_evalf():
+
+    assert abs(stieltjes(0).evalf() - 0.577215664) < 1E-9
+    assert abs(stieltjes(0, 0.5).evalf() - 1.963510026) < 1E-9
+    assert abs(stieltjes(1, 2).evalf() + 0.072815845 ) < 1E-9

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -158,6 +158,8 @@ def test_lerchphi_expansion():
 
 
 def test_stieltjes():
+    assert isinstance(stieltjes(x), stieltjes)
+    assert isinstance(stieltjes(x, a), stieltjes)
 
     # Zero'th constant EulerGamma
     assert stieltjes(0) == S.EulerGamma
@@ -173,7 +175,6 @@ def test_stieltjes():
 
 
 def test_stieltjes_evalf():
-
     assert abs(stieltjes(0).evalf() - 0.577215664) < 1E-9
     assert abs(stieltjes(0, 0.5).evalf() - 1.963510026) < 1E-9
     assert abs(stieltjes(1, 2).evalf() + 0.072815845 ) < 1E-9

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -517,3 +517,69 @@ class dirichlet_eta(Function):
 
     def _eval_rewrite_as_zeta(self, s):
         return (1 - 2**(1 - s)) * zeta(s)
+
+
+class stieltjes(Function):
+    """
+    Represents Stieltjes constants, :math: `\gamma_{k}` that occur in Laurent
+    Series expansion of the Riemann zeta function.
+
+    Examples
+    ========
+
+    >>> from sympy import stieltjes
+    >>> from sympy.abc import n
+
+    >>> stieltjes(n)
+    stieltjes(n)
+
+    The zero'th constant is the Euler-Mascheroni constant
+
+    >>> from sympy import stieltjes
+
+    >>> stieltjes(0)
+    EulerGamma
+    >>> stieltjes(0, 1)
+    EulerGamma
+
+    For generalized stieltjes constants
+
+    >>> from sympy import stieltjes
+    >>> from sympy.abc import n, m
+
+    >>> stieltjes(n, m)
+    stieltjes(n, m)
+
+    Constants are only defined for integers >= 0
+
+    >>> from sympy import stieltjes
+
+    >>> stieltjes(-1)
+    zoo
+
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Stieltjes_constants
+    """
+
+    @classmethod
+    def eval(cls, n, a=None):
+        n = sympify(n)
+
+        if a != None:
+            a = sympify(a)
+            if a is S.NaN:
+                return S.NaN
+            if a.is_Integer and a.is_nonpositive:
+                return S.ComplexInfinity
+
+        if n.is_Number:
+            if n is S.NaN:
+                return S.NaN
+            elif n < 0:
+                return S.ComplexInfinity
+            elif not n.is_Integer:
+                return S.ComplexInfinity
+            elif n == 0 and a in [None, 1]:
+                return S.EulerGamma

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -520,22 +520,18 @@ class dirichlet_eta(Function):
 
 
 class stieltjes(Function):
-    """
-    Represents Stieltjes constants, :math: `\gamma_{k}` that occur in Laurent
-    Series expansion of the Riemann zeta function.
+    r"""Represents Stieltjes constants, :math:`\gamma_{k}` that occur in
+    Laurent Series expansion of the Riemann zeta function.
 
     Examples
     ========
 
     >>> from sympy import stieltjes
-    >>> from sympy.abc import n
-
+    >>> from sympy.abc import n, m
     >>> stieltjes(n)
     stieltjes(n)
 
-    The zero'th constant is the Euler-Mascheroni constant
-
-    >>> from sympy import stieltjes
+    zero'th stieltjes constant
 
     >>> stieltjes(0)
     EulerGamma
@@ -544,15 +540,10 @@ class stieltjes(Function):
 
     For generalized stieltjes constants
 
-    >>> from sympy import stieltjes
-    >>> from sympy.abc import n, m
-
     >>> stieltjes(n, m)
     stieltjes(n, m)
 
     Constants are only defined for integers >= 0
-
-    >>> from sympy import stieltjes
 
     >>> stieltjes(-1)
     zoo


### PR DESCRIPTION
Implemented `class stieltjes`, that represents, Stieltjes constants,  that occur in Laurent Series expansion of the Riemann zeta function.

```
>>> from sympy import stieltjes
>>> from sympy.abc import n

>>> stieltjes(n)
stieltjes(n)
```

The zero'th constant is the Euler-Mascheroni constant

```
>>> from sympy import stieltjes

>>> stieltjes(0)
EulerGamma
>>> stieltjes(0, 1)
EulerGamma
```

For generalized stieltjes constants

```
>>> from sympy import stieltjes
>>> from sympy.abc import n, m

>>> stieltjes(n, m)
stieltjes(n, m)
```

Constants are only defined for integers >= 0

```
>>> from sympy import stieltjes

>>> stieltjes(-1)
zoo
```

Fixes #4186 

@asmeurer @certik 
