### PR TITLE
fix infinite recursion issue by replacing the checking expression

### DIFF
--- a/sympy/series/tests/test_residues.py
+++ b/sympy/series/tests/test_residues.py
@@ -25,10 +25,9 @@ def test_basic2():
     assert residue(x**2, x, 5) == 0
 
 
-def _test_f():
-    # FIXME: we get infinite recursion here:
+def test_f():
     f = Function("f")
-    assert residue(f(x)/x**5, x, 0) == f.diff(x, 4)/24
+    assert residue(f(x)/x**5, x, 0) == Subs(Derivative(f(x), x, x, x, x), (x,), (0,))/24
 
 
 def test_functions():


### PR DESCRIPTION
original `f.diff(x, 4)/24` will trigger the following error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: unbound method diff() must be called with f instance as first argument (got Symbol instance instead)
```

The correct result of `residue(f(x)/x**5, x, 0)` should be

```
Subs(Derivative(f(_x), _x, _x, _x, _x), (_x,), (0,))/24
```
