### PR TITLE
fixes #8800: fibonacci(n).limit(n, oo) should be oo rather than fibonacci(oo)

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -96,6 +96,9 @@ class fibonacci(Function):
 
     @classmethod
     def eval(cls, n, sym=None):
+        if n is S.Infinity:
+            return S.Infinity
+
         if n.is_Integer:
             n = int(n)
             if n < 0:
@@ -142,6 +145,9 @@ class lucas(Function):
 
     @classmethod
     def eval(cls, n):
+        if n is S.Infinity:
+            return S.Infinity
+
         if n.is_Integer:
             return fibonacci(n + 1) + fibonacci(n - 1)
 

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -60,6 +60,11 @@ def test_fibonacci():
     assert fibonacci(3, x) == x**2 + 1
     assert fibonacci(4, x) == x**3 + 2*x
 
+    # issue #8800
+    n = Dummy('n')
+    assert fibonacci(n).limit(n, S.Infinity) == S.Infinity
+    assert lucas(n).limit(n, S.Infinity) == S.Infinity
+
 
 def test_bell():
     assert [bell(n) for n in range(8)] == [1, 1, 2, 5, 15, 52, 203, 877]


### PR DESCRIPTION
`fibonacci(n).limit(n, oo)` and `lucas(n).limit(n, oo)` now returns `oo`. The result is consistent with `factorial(n).limit(n, oo)` and `subfactorial(n).limit(n oo)`.

Fixes #8800 

@smichr
