### PR TITLE
Add naive algorithm for computing conjugacy classes in permutation groups

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1940,7 +1940,7 @@ class PermutationGroup(Basic):
         r"""Return the conjugacy class of an element in the group.
 
         The conjugacy class of an element ``g`` in a group ``G`` is the set of
-        elements ``x`` in ``G`` that are conjugate with ``g``, i.e. for which 
+        elements ``x`` in ``G`` that are conjugate with ``g``, i.e. for which
 
             ``g = xax^{-1}``
 
@@ -1968,7 +1968,7 @@ class PermutationGroup(Basic):
 
         Notes
         =====
-        
+
         This procedure computes the conjugacy class directly by finding the
         orbit of the element under conjugation in G. This algorithm is only
         feasible for permutation groups of relatively small order, but is like
@@ -1984,7 +1984,7 @@ class PermutationGroup(Basic):
 
             for y in last_iteration:
                 for s in self.generators:
-                    conjugated = s * y * (~s) 
+                    conjugated = s * y * (~s)
                     if conjugated not in new_class:
                         this_iteration.add(conjugated)
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1963,8 +1963,8 @@ class PermutationGroup(Basic):
         >>> from sympy.combinatorics.permutations import Permutation
         >>> from sympy.combinatorics.named_groups import SymmetricGroup
         >>> S3 = SymmetricGroup(3)
-        >>> S3.conjugacy_class(Permutation(1, 2, 3))
-        [Permutation(1, 2, 3), Permutation(1, 3, 2)]
+        >>> S3.conjugacy_class(Permutation(0, 1, 2))
+        set([Permutation(0, 1, 2), Permutation(0, 2, 1)])
 
         Notes
         =====

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -686,3 +686,23 @@ def test_make_perm():
         Permutation([4, 7, 6, 5, 0, 3, 2, 1])
     assert cube.pgroup.make_perm(7, seed=list(range(7))) == \
         Permutation([6, 7, 3, 2, 5, 4, 0, 1])
+
+def test_conjugacy_class():
+    S = SymmetricGroup(4)
+    x = Permutation(1, 2, 3)
+    C = set([Permutation(0, 1, 2, size = 4), Permutation(0, 1, 3),
+             Permutation(0, 2, 1, size = 4), Permutation(0, 2, 3),
+             Permutation(0, 3, 1), Permutation(0, 3, 2),
+             Permutation(1, 2, 3), Permutation(1, 3, 2)])
+    assert S.conjugacy_class(x) == C
+
+def test_conjugacy_classes():
+    S = SymmetricGroup(3)
+    expected = [set([Permutation(size = 3)]),
+         set([Permutation(0, 1, size = 3), Permutation(0, 2), Permutation(1, 2)]),
+         set([Permutation(0, 1, 2), Permutation(0, 2, 1)])]
+    computed = S.conjugacy_classes()
+
+    assert len(expected) == len(computed)
+    assert all(e in computed for e in expected)
+

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -705,4 +705,3 @@ def test_conjugacy_classes():
 
     assert len(expected) == len(computed)
     assert all(e in computed for e in expected)
-


### PR DESCRIPTION
This pull request adds `conjugacy_class` and `conjugacy_classes` methods to the `PermutationGroup` class, which compute respectively the set of all elements conjugate to an element of a group, and the list of all these equivalence classes.

This implementation finds the conjugacy classes in a relatively naïve way: by directly computing the orbit of each element under conjugation. [1](http://dl.acm.org/citation.cfm?id=258855), written in 2006, states that this is efficient for groups up to order 10^4. The naïve algorithm is also very general, in that it doesn't rely on any properties of the underlying group representation.

There are more complex algorithms which make equivalent computation more feasible (see [2](https://books.google.co.uk/books?id=md8eE8DSDUoC&lpg=PA80&ots=6yTJr6NvRR&pg=PA80), or [3](http://ebooks.cambridge.org/chapter.jsf?bid=CBO9780511629280&cid=CBO9780511629280A018) for an unredacted version behind a paywall) for larger groups. These would require in particular that `conjugacy_classes` did not simply return a list of all the elements in each conjugacy class; however, it is debatable whether this is even a worthwhile representation for the naïve implementation. Should the patch be amended to have it return only, say, a list of representatives?
