### PR TITLE
Add test to ensure integral in #7130 doesn't depend on x

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1087,3 +1087,9 @@ def test_issue_8901():
     assert integrate(sinh(1.0*x)) == 1.0*cosh(1.0*x)
     assert integrate(tanh(1.0*x)) == 1.0*x - 1.0*log(tanh(1.0*x) + 1)
     assert integrate(tanh(x)) == x - log(tanh(x) + 1)
+
+
+def test_issue_7130():
+    i, L, a, b = symbols('i L a b')
+    integrand = (cos(pi*i*x/L)**2 / (a + b*x)).rewrite(exp)
+    assert x not in integrate(integrand, (x, 0, L)).free_symbols


### PR DESCRIPTION
This patch adds a test which, as described in the issue, makes sure that the integral in #7130 does not depend on `x`. Is the criterion in the test case sufficient? I was not sure whether the result of the integral should be tested directly; if so, I can certainly make that change.
