### PR TITLE
matrices: convert empty matrices to immutable correctly

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -503,9 +503,9 @@ class DenseMatrix(MatrixBase):
         """Returns an Immutable version of this Matrix
         """
         from .immutable import ImmutableMatrix as cls
-        if self.rows:
+        if self.rows and self.cols:
             return cls._new(self.tolist())
-        return cls._new(0, self.cols, [])
+        return cls._new(self.rows, self.cols, [])
 
     @classmethod
     def zeros(cls, r, c=None):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -230,6 +230,7 @@ def test_tolist():
 def test_as_mutable():
     assert zeros(0, 3).as_mutable() == zeros(0, 3)
     assert zeros(0, 3).as_immutable() == ImmutableMatrix(zeros(0, 3))
+    assert zeros(3, 0).as_immutable() == ImmutableMatrix(zeros(3, 0))
 
 
 def test_determinant():


### PR DESCRIPTION
Previously `ones(3, 0).as_immutable` gave a `0x0` instead of a
`3x0` matrix.  The `0x3` case was already working: add a new test
next to the existing one.
