### PR TITLE
fixes #9075: sympy.limit yields incorrect result

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1302,7 +1302,14 @@ class Pow(Expr):
         from sympy import exp, log
         if not self.exp.has(x):
             return self.func(self.base.as_leading_term(x), self.exp)
-        return exp(self.exp * log(self.base)).as_leading_term(x)
+        sep, e = 1, self.exp
+        # separate out the independent terms
+        if self.exp.is_Add:
+            for t in self.exp.args:
+                if not t.has(x):
+                    sep *= self.base**t
+                    e -= t
+        return sep * exp(e * log(self.base)).as_leading_term(x)
 
     @cacheit
     def _taylor_term(self, n, x, *previous_terms): # of (1+x)**e

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -293,6 +293,12 @@ def test_as_leading_term4():
     assert r.as_leading_term(x).cancel() == n/2
 
 
+def test_as_leading_term5():
+    # see issue 9075
+    assert (6**(n+1)).as_leading_term(n) == 6
+    assert (6**(n+x)).as_leading_term(n) == 6**x
+
+
 def test_as_leading_term_stub():
     class foo(Function):
         pass

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -7,7 +7,7 @@ from sympy import (
 
 from sympy.series.limits import heuristics
 from sympy.series.order import Order
-from sympy.abc import x, y, z
+from sympy.abc import x, y, z, n
 from sympy.utilities.pytest import XFAIL, raises
 
 
@@ -187,6 +187,11 @@ def test_issue_3871():
     f = -1/z*exp(-z*x)
     assert limit(f, x, oo) == 0
     assert f.limit(x, oo) == 0
+
+
+def test_issue_9075():
+    assert ((6**(n+1)+n+1)/(6**n+1)).limit(n, oo) == 6
+    assert ((6**(n+x)+n+1)/(6**n+1)).limit(n, oo) == 6**x
 
 
 def test_exponential():


### PR DESCRIPTION
fixed the limit,

```
>>> ((6**(n+1)+n+1)/(6**n+n)).limit(n, oo)
6
```

In general,

```
>>> ((6**(n+x)+n+1)/(6**n+n)).limit(n, oo)
6**x
```

Fixes #9075 
@raoulb @smichr
