### PR TITLE
Coherent state support for 1d quantum harmonic oscillator

### DIFF
--- a/sympy/physics/qho_1d.py
+++ b/sympy/physics/qho_1d.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import S, pi, Rational
-from sympy.functions import hermite, sqrt, exp, factorial
+from sympy.functions import hermite, sqrt, exp, factorial, Abs
 from sympy.physics.quantum.constants import hbar
 
 
@@ -66,3 +66,18 @@ def E_n(n, omega):
     """
 
     return hbar * omega*(n + Rational(1, 2))
+
+
+def coherent_state(n,alpha):
+    """
+    Returns <n|alpha> for the coherent states of 1D harmonic oscillator.
+    See http://en.wikipedia.org/wiki/Coherent_states
+
+    ``n``
+        the "nodal" quantum number
+    ``alpha``
+        the eigen value of annihilation operator
+    """
+
+    return exp(-Abs(alpha)**2/2)*(alpha**n)/sqrt(factorial(n))
+

--- a/sympy/physics/qho_1d.py
+++ b/sympy/physics/qho_1d.py
@@ -79,5 +79,5 @@ def coherent_state(n,alpha):
         the eigen value of annihilation operator
     """
 
-    return exp(-Abs(alpha)**2/2)*(alpha**n)/sqrt(factorial(n))
+    return exp(- Abs(alpha) ** 2 / 2) * (alpha ** n) / sqrt(factorial(n))
 

--- a/sympy/physics/qho_1d.py
+++ b/sympy/physics/qho_1d.py
@@ -80,4 +80,3 @@ def coherent_state(n, alpha):
     """
 
     return exp(- Abs(alpha)**2/2)*(alpha**n)/sqrt(factorial(n))
-

--- a/sympy/physics/qho_1d.py
+++ b/sympy/physics/qho_1d.py
@@ -68,7 +68,7 @@ def E_n(n, omega):
     return hbar * omega*(n + Rational(1, 2))
 
 
-def coherent_state(n,alpha):
+def coherent_state(n, alpha):
     """
     Returns <n|alpha> for the coherent states of 1D harmonic oscillator.
     See http://en.wikipedia.org/wiki/Coherent_states
@@ -79,5 +79,5 @@ def coherent_state(n,alpha):
         the eigen value of annihilation operator
     """
 
-    return exp(- Abs(alpha) ** 2 / 2) * (alpha ** n) / sqrt(factorial(n))
+    return exp(- Abs(alpha)**2/2)*(alpha**n)/sqrt(factorial(n))
 

--- a/sympy/physics/tests/test_qho_1d.py
+++ b/sympy/physics/tests/test_qho_1d.py
@@ -41,5 +41,5 @@ def test_coherent_state(n=10):
     # Maximum "n" which is tested:
     # test whether coherent state is the eigenstate of annihilation operator
     alpha = Symbol("alpha")
-    for i in range(n+1):
-        assert simplify(sqrt(n+1)*coherent_state(n+1,alpha))==simplify(alpha*coherent_state(n,alpha))
+    for i in range(n + 1):
+        assert simplify(sqrt(n + 1) * coherent_state(n + 1, alpha)) == simplify(alpha * coherent_state(n, alpha))

--- a/sympy/physics/tests/test_qho_1d.py
+++ b/sympy/physics/tests/test_qho_1d.py
@@ -1,4 +1,4 @@
-from sympy import exp, integrate, oo, Rational, pi, S, simplify, sqrt
+from sympy import exp, integrate, oo, Rational, pi, S, simplify, sqrt, Symbol
 from sympy.core.compatibility import range
 from sympy.abc import omega, m, x
 from sympy.physics.qho_1d import psi_n, E_n
@@ -36,3 +36,10 @@ def test_energies(n=1):
     # Maximum "n" which is tested:
     for i in range(n + 1):
         assert E_n(i, omega) == hbar * omega * (i + Rational(1, 2))
+
+def test_coherent_state(n=10):
+    # Maximum "n" which is tested:
+    # test whether coherent state is the eigenstate of annihilation operator
+    alpha = Symbol("alpha")
+    for i in range(n+1):
+        assert simplify(sqrt(n+1)*coherent_state(n+1,alpha))==simplify(alpha*coherent_state(n,alpha))

--- a/sympy/physics/tests/test_qho_1d.py
+++ b/sympy/physics/tests/test_qho_1d.py
@@ -1,7 +1,7 @@
 from sympy import exp, integrate, oo, Rational, pi, S, simplify, sqrt, Symbol
 from sympy.core.compatibility import range
 from sympy.abc import omega, m, x
-from sympy.physics.qho_1d import psi_n, E_n
+from sympy.physics.qho_1d import psi_n, E_n, coherent_state
 from sympy.physics.quantum.constants import hbar
 
 nu = m * omega / hbar


### PR DESCRIPTION
This pull request is used to satisfy the requirement that each applicant of GSoC 2015 must send a patch to sympy.

In this patch, I implement coherent state support for 1d quantum harmonic oscillator.

See http://en.wikipedia.org/wiki/Coherent_states for more detail about coherent state of quantum harmonic oscillator.

In my application, I also proposed a more systematic way of implementing sympy.physics.quantum, this patch will be migrated to the new structure if I'm approved for GSoC.
