### PR TITLE
Cut/Paste the 10 slowest integral tests into test_slow_integrals.py

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,10 +1,10 @@
 from sympy import (
-    Abs, acos, acosh, Add, asin, asinh, atan, Ci, cos, sinh, cosh, tanh,
-    Derivative, diff, DiracDelta, E, exp, erf, erfi, EulerGamma, factor, Function,
+    Abs, acos, acosh, Add, asin, asinh, atan, cos, sinh, cosh, tanh,
+    Derivative, diff, DiracDelta, E, exp, erf, factor, Function,
     I, Integral, integrate, Interval, Lambda, LambertW, log,
     Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify, sin, tan, sqrt,
     sstr, Sum, Symbol, symbols, sympify, trigsimp,
-    Tuple, nan, And, Eq, Ne, re, im, polar_lift, meijerg
+    Tuple, And, Eq, Ne, re, im, polar_lift, meijerg
 )
 from sympy.functions.elementary.complexes import periodic_argument
 from sympy.integrals.risch import NonElementaryIntegral
@@ -355,57 +355,6 @@ def test_issue_4052():
 
 def NS(e, n=15, **options):
     return sstr(sympify(e).evalf(n, **options), full_prec=True)
-
-
-def test_evalf_integrals():
-    assert NS(Integral(x, (x, 2, 5)), 15) == '10.5000000000000'
-    gauss = Integral(exp(-x**2), (x, -oo, oo))
-    assert NS(gauss, 15) == '1.77245385090552'
-    assert NS(gauss**2 - pi + E*Rational(
-        1, 10**20), 15) in ('2.71828182845904e-20', '2.71828182845905e-20')
-    # A monster of an integral from http://mathworld.wolfram.com/DefiniteIntegral.html
-    t = Symbol('t')
-    a = 8*sqrt(3)/(1 + 3*t**2)
-    b = 16*sqrt(2)*(3*t + 1)*sqrt(4*t**2 + t + 1)**3
-    c = (3*t**2 + 1)*(11*t**2 + 2*t + 3)**2
-    d = sqrt(2)*(249*t**2 + 54*t + 65)/(11*t**2 + 2*t + 3)**2
-    f = a - b/c - d
-    assert NS(Integral(f, (t, 0, 1)), 50) == \
-        NS((3*sqrt(2) - 49*pi + 162*atan(sqrt(2)))/12, 50)
-    # http://mathworld.wolfram.com/VardisIntegral.html
-    assert NS(Integral(log(log(1/x))/(1 + x + x**2), (x, 0, 1)), 15) == \
-        NS('pi/sqrt(3) * log(2*pi**(5/6) / gamma(1/6))', 15)
-    # http://mathworld.wolfram.com/AhmedsIntegral.html
-    assert NS(Integral(atan(sqrt(x**2 + 2))/(sqrt(x**2 + 2)*(x**2 + 1)), (x,
-              0, 1)), 15) == NS(5*pi**2/96, 15)
-    # http://mathworld.wolfram.com/AbelsIntegral.html
-    assert NS(Integral(x/((exp(pi*x) - exp(
-        -pi*x))*(x**2 + 1)), (x, 0, oo)), 15) == NS('log(2)/2-1/4', 15)
-    # Complex part trimming
-    # http://mathworld.wolfram.com/VardisIntegral.html
-    assert NS(Integral(log(log(sin(x)/cos(x))), (x, pi/4, pi/2)), 15, chop=True) == \
-        NS('pi/4*log(4*pi**3/gamma(1/4)**4)', 15)
-    #
-    # Endpoints causing trouble (rounding error in integration points -> complex log)
-    assert NS(
-        2 + Integral(log(2*cos(x/2)), (x, -pi, pi)), 17, chop=True) == NS(2, 17)
-    assert NS(
-        2 + Integral(log(2*cos(x/2)), (x, -pi, pi)), 20, chop=True) == NS(2, 20)
-    assert NS(
-        2 + Integral(log(2*cos(x/2)), (x, -pi, pi)), 22, chop=True) == NS(2, 22)
-    # Needs zero handling
-    assert NS(pi - 4*Integral(
-        'sqrt(1-x**2)', (x, 0, 1)), 15, maxn=30, chop=True) in ('0.0', '0')
-    # Oscillatory quadrature
-    a = Integral(sin(x)/x**2, (x, 1, oo)).evalf(maxn=15)
-    assert 0.49 < a < 0.51
-    assert NS(
-        Integral(sin(x)/x**2, (x, 1, oo)), quad='osc') == '0.504067061906928'
-    assert NS(Integral(
-        cos(pi*x + 1)/x, (x, -oo, -1)), quad='osc') == '0.276374705640365'
-    # indefinite integrals aren't evaluated
-    assert NS(Integral(x, x)) == 'Integral(x, x)'
-    assert NS(Integral(x, (x, y))) == 'Integral(x, (x, y))'
 
 
 def test_evalf_issue_939():
@@ -806,16 +755,6 @@ def test_issue_5167():
         y*(x - 1)*Integral(f(x), (x, 1, 2)) - (x - 1)*Integral(f(x), (x, 1, 2))
 
 
-def test_issue_4890():
-    z = Symbol('z', positive=True)
-    assert integrate(exp(-log(x)**2), x) == \
-        sqrt(pi)*exp(S(1)/4)*erf(log(x)-S(1)/2)/2
-    assert integrate(exp(log(x)**2), x) == \
-        sqrt(pi)*exp(-S(1)/4)*erfi(log(x)+S(1)/2)/2
-    assert integrate(exp(-z*log(x)**2), x) == \
-        sqrt(pi)*exp(1/(4*z))*erf(sqrt(z)*log(x) - 1/(2*sqrt(z)))/(2*sqrt(z))
-
-
 def test_issue_4376():
     n = Symbol('n', integer=True, positive=True)
     assert simplify(integrate(n*(x**(1/n) - 1), (x, 0, S.Half)) -
@@ -828,41 +767,11 @@ def test_issue_4517():
         6*x**Rational(7, 6)/7 - 3*x**Rational(11, 3)/11
 
 
-def test_issue_4527():
-    k, m = symbols('k m', integer=True)
-    assert integrate(sin(k*x)*sin(m*x), (x, 0, pi)) == Piecewise(
-        (0, And(Eq(k, 0), Eq(m, 0))),
-        (-pi/2, Eq(k, -m)),
-        (pi/2, Eq(k, m)),
-        (0, True))
-    assert integrate(sin(k*x)*sin(m*x), (x,)) == Piecewise(
-        (0, And(Eq(k, 0), Eq(m, 0))),
-        (-x*sin(m*x)**2/2 - x*cos(m*x)**2/2 + sin(m*x)*cos(m*x)/(2*m), Eq(k, -m)),
-        (x*sin(m*x)**2/2 + x*cos(m*x)**2/2 - sin(m*x)*cos(m*x)/(2*m), Eq(k, m)),
-        (m*sin(k*x)*cos(m*x)/(k**2 - m**2) -
-         k*sin(m*x)*cos(k*x)/(k**2 - m**2), True))
-
 def test_issue_4199():
     ypos = Symbol('y', positive=True)
     # TODO: Remove conds='none' below, let the assumption take care of it.
     assert integrate(exp(-I*2*pi*ypos*x)*x, (x, -oo, oo), conds='none') == \
         Integral(exp(-I*2*pi*ypos*x)*x, (x, -oo, oo))
-
-
-def test_issue_3940():
-    a, b, c, d = symbols('a:d', positive=True, finite=True)
-    assert integrate(exp(-x**2 + I*c*x), x) == \
-        -sqrt(pi)*exp(-c**2/4)*erf(I*c/2 - x)/2
-    assert integrate(exp(a*x**2 + b*x + c), x) == \
-        sqrt(pi)*exp(c)*exp(-b**2/(4*a))*erfi(sqrt(a)*x + b/(2*sqrt(a)))/(2*sqrt(a))
-
-    from sympy import expand_mul
-    from sympy.abc import k
-    assert expand_mul(integrate(exp(-x**2)*exp(I*k*x), (x, -oo, oo))) == \
-        sqrt(pi)*exp(-k**2/4)
-    a, d = symbols('a d', positive=True)
-    assert expand_mul(integrate(exp(-a*x**2 + 2*d*x), (x, -oo, oo))) == \
-        sqrt(pi)*exp(d**2/a)/sqrt(a)
 
 
 def test_issue_5413():
@@ -926,13 +835,6 @@ def test_atom_bug():
     assert heurisch(meijerg([], [], [1], [], x), x) is None
 
 
-def test_limit_bug():
-    z = Symbol('z', nonzero=True)
-    assert integrate(sin(x*y*z), (x, 0, pi), (y, 0, pi)) == \
-        (log(z**2) + 2*EulerGamma + 2*log(pi))/(2*z) - \
-        (-log(pi*z) + log(pi**2*z**2)/2 + Ci(pi**2*z))/z + log(pi)/z
-
-
 def test_issue_4703():
     g = Function('g')
     assert integrate(exp(x)*g(x), x).has(Integral)
@@ -943,11 +845,6 @@ def test_issue_1888():
     assert integrate(f(x).diff(x)**2, x).has(Integral)
 
 # The following tests work using meijerint.
-
-
-def test_issue_3558():
-    from sympy import Si
-    assert integrate(cos(x*y), (x, -pi/2, pi/2), (y, 0, pi)) == 2*Si(pi**2/2)
 
 
 def test_issue_4422():
@@ -991,25 +888,11 @@ def test_issue_4400():
         x*x**n/(n**2 + 2*n + 1)
 
 
-def test_issue_6253():
-    # Note: this used to raise NotImplementedError
-    # Note: psi in _check_antecedents becomes NaN.
-    assert integrate((sqrt(1 - x) + sqrt(1 + x))**2/x, x, meijerg=True) == \
-        Integral((sqrt(-x + 1) + sqrt(x + 1))**2/x, x)
-
-
 def test_issue_4153():
     assert integrate(1/(1 + x + y + z), (x, 0, 1), (y, 0, 1), (z, 0, 1)) in [
         -12*log(3) - 3*log(6)/2 + 3*log(8)/2 + 5*log(2) + 7*log(4),
         6*log(2) + 8*log(4) - 27*log(3)/2, 22*log(2) - 27*log(3)/2,
         -12*log(3) - 3*log(6)/2 + 47*log(2)/2]
-
-
-def test_issue_4326():
-    R, b, h = symbols('R b h')
-    # It doesn't matter if we can do the integral.  Just make sure the result
-    # doesn't contain nan.  This is really a test against _eval_interval.
-    assert not integrate(((h*(x - R + b))/b)*sqrt(R**2 - x**2), (x, R - b, R)).has(nan)
 
 
 def test_powers():
@@ -1051,14 +934,6 @@ def test_issue_4234():
     assert integrate(1/sqrt(1 + tan(x)**2)) == tan(x) / sqrt(1 + tan(x)**2)
 
 
-def test_issue_4492():
-    assert simplify(integrate(x**2 * sqrt(5 - x**2), x)) == Piecewise(
-        (I*(2*x**5 - 15*x**3 + 25*x - 25*sqrt(x**2 - 5)*acosh(sqrt(5)*x/5)) /
-            (8*sqrt(x**2 - 5)), 1 < Abs(x**2)/5),
-        ((-2*x**5 + 15*x**3 - 25*x + 25*sqrt(-x**2 + 5)*asin(sqrt(5)*x/5)) /
-            (8*sqrt(-x**2 + 5)), True))
-
-
 def test_issue_2708():
     # This test needs to use an integration function that can
     # not be evaluated in closed form.  Update as needed.
@@ -1087,9 +962,3 @@ def test_issue_8901():
     assert integrate(sinh(1.0*x)) == 1.0*cosh(1.0*x)
     assert integrate(tanh(1.0*x)) == 1.0*x - 1.0*log(tanh(1.0*x) + 1)
     assert integrate(tanh(x)) == x - log(tanh(x) + 1)
-
-
-def test_issue_7130():
-    i, L, a, b = symbols('i L a b')
-    integrand = (cos(pi*i*x/L)**2 / (a + b*x)).rewrite(exp)
-    assert x not in integrate(integrand, (x, 0, L)).free_symbols

--- a/sympy/integrals/tests/test_slow_integrals.py
+++ b/sympy/integrals/tests/test_slow_integrals.py
@@ -1,0 +1,149 @@
+from sympy import (
+    Abs, acosh, asin, atan, Ci, cos,
+    E, exp, erf, erfi, EulerGamma, Function,
+    I, Integral, integrate, log,
+    oo, pi, Piecewise, Rational, S, simplify, sin, sqrt,
+    sstr, Symbol, symbols, sympify,
+    nan, And, Eq,
+)
+
+
+x, y, a, t, x_1, x_2, z, s = symbols('x y a t x_1 x_2 z s')
+n = Symbol('n', integer=True)
+f = Function('f')
+
+
+def NS(e, n=15, **options):
+    return sstr(sympify(e).evalf(n, **options), full_prec=True)
+
+
+def test_evalf_integrals():
+    assert NS(Integral(x, (x, 2, 5)), 15) == '10.5000000000000'
+    gauss = Integral(exp(-x**2), (x, -oo, oo))
+    assert NS(gauss, 15) == '1.77245385090552'
+    assert NS(gauss**2 - pi + E*Rational(
+        1, 10**20), 15) in ('2.71828182845904e-20', '2.71828182845905e-20')
+    # A monster of an integral from http://mathworld.wolfram.com/DefiniteIntegral.html
+    t = Symbol('t')
+    a = 8*sqrt(3)/(1 + 3*t**2)
+    b = 16*sqrt(2)*(3*t + 1)*sqrt(4*t**2 + t + 1)**3
+    c = (3*t**2 + 1)*(11*t**2 + 2*t + 3)**2
+    d = sqrt(2)*(249*t**2 + 54*t + 65)/(11*t**2 + 2*t + 3)**2
+    f = a - b/c - d
+    assert NS(Integral(f, (t, 0, 1)), 50) == \
+        NS((3*sqrt(2) - 49*pi + 162*atan(sqrt(2)))/12, 50)
+    # http://mathworld.wolfram.com/VardisIntegral.html
+    assert NS(Integral(log(log(1/x))/(1 + x + x**2), (x, 0, 1)), 15) == \
+        NS('pi/sqrt(3) * log(2*pi**(5/6) / gamma(1/6))', 15)
+    # http://mathworld.wolfram.com/AhmedsIntegral.html
+    assert NS(Integral(atan(sqrt(x**2 + 2))/(sqrt(x**2 + 2)*(x**2 + 1)), (x,
+              0, 1)), 15) == NS(5*pi**2/96, 15)
+    # http://mathworld.wolfram.com/AbelsIntegral.html
+    assert NS(Integral(x/((exp(pi*x) - exp(
+        -pi*x))*(x**2 + 1)), (x, 0, oo)), 15) == NS('log(2)/2-1/4', 15)
+    # Complex part trimming
+    # http://mathworld.wolfram.com/VardisIntegral.html
+    assert NS(Integral(log(log(sin(x)/cos(x))), (x, pi/4, pi/2)), 15, chop=True) == \
+        NS('pi/4*log(4*pi**3/gamma(1/4)**4)', 15)
+    #
+    # Endpoints causing trouble (rounding error in integration points -> complex log)
+    assert NS(
+        2 + Integral(log(2*cos(x/2)), (x, -pi, pi)), 17, chop=True) == NS(2, 17)
+    assert NS(
+        2 + Integral(log(2*cos(x/2)), (x, -pi, pi)), 20, chop=True) == NS(2, 20)
+    assert NS(
+        2 + Integral(log(2*cos(x/2)), (x, -pi, pi)), 22, chop=True) == NS(2, 22)
+    # Needs zero handling
+    assert NS(pi - 4*Integral(
+        'sqrt(1-x**2)', (x, 0, 1)), 15, maxn=30, chop=True) in ('0.0', '0')
+    # Oscillatory quadrature
+    a = Integral(sin(x)/x**2, (x, 1, oo)).evalf(maxn=15)
+    assert 0.49 < a < 0.51
+    assert NS(
+        Integral(sin(x)/x**2, (x, 1, oo)), quad='osc') == '0.504067061906928'
+    assert NS(Integral(
+        cos(pi*x + 1)/x, (x, -oo, -1)), quad='osc') == '0.276374705640365'
+    # indefinite integrals aren't evaluated
+    assert NS(Integral(x, x)) == 'Integral(x, x)'
+    assert NS(Integral(x, (x, y))) == 'Integral(x, (x, y))'
+
+
+def test_issue_4890():
+    z = Symbol('z', positive=True)
+    assert integrate(exp(-log(x)**2), x) == \
+        sqrt(pi)*exp(S(1)/4)*erf(log(x)-S(1)/2)/2
+    assert integrate(exp(log(x)**2), x) == \
+        sqrt(pi)*exp(-S(1)/4)*erfi(log(x)+S(1)/2)/2
+    assert integrate(exp(-z*log(x)**2), x) == \
+        sqrt(pi)*exp(1/(4*z))*erf(sqrt(z)*log(x) - 1/(2*sqrt(z)))/(2*sqrt(z))
+
+
+def test_issue_4527():
+    k, m = symbols('k m', integer=True)
+    assert integrate(sin(k*x)*sin(m*x), (x, 0, pi)) == Piecewise(
+        (0, And(Eq(k, 0), Eq(m, 0))),
+        (-pi/2, Eq(k, -m)),
+        (pi/2, Eq(k, m)),
+        (0, True))
+    assert integrate(sin(k*x)*sin(m*x), (x,)) == Piecewise(
+        (0, And(Eq(k, 0), Eq(m, 0))),
+        (-x*sin(m*x)**2/2 - x*cos(m*x)**2/2 + sin(m*x)*cos(m*x)/(2*m), Eq(k, -m)),
+        (x*sin(m*x)**2/2 + x*cos(m*x)**2/2 - sin(m*x)*cos(m*x)/(2*m), Eq(k, m)),
+        (m*sin(k*x)*cos(m*x)/(k**2 - m**2) -
+         k*sin(m*x)*cos(k*x)/(k**2 - m**2), True))
+
+
+def test_issue_3940():
+    a, b, c, d = symbols('a:d', positive=True, finite=True)
+    assert integrate(exp(-x**2 + I*c*x), x) == \
+        -sqrt(pi)*exp(-c**2/4)*erf(I*c/2 - x)/2
+    assert integrate(exp(a*x**2 + b*x + c), x) == \
+        sqrt(pi)*exp(c)*exp(-b**2/(4*a))*erfi(sqrt(a)*x + b/(2*sqrt(a)))/(2*sqrt(a))
+
+    from sympy import expand_mul
+    from sympy.abc import k
+    assert expand_mul(integrate(exp(-x**2)*exp(I*k*x), (x, -oo, oo))) == \
+        sqrt(pi)*exp(-k**2/4)
+    a, d = symbols('a d', positive=True)
+    assert expand_mul(integrate(exp(-a*x**2 + 2*d*x), (x, -oo, oo))) == \
+        sqrt(pi)*exp(d**2/a)/sqrt(a)
+
+
+def test_limit_bug():
+    z = Symbol('z', nonzero=True)
+    assert integrate(sin(x*y*z), (x, 0, pi), (y, 0, pi)) == \
+        (log(z**2) + 2*EulerGamma + 2*log(pi))/(2*z) - \
+        (-log(pi*z) + log(pi**2*z**2)/2 + Ci(pi**2*z))/z + log(pi)/z
+
+
+def test_issue_3558():
+    from sympy import Si
+    assert integrate(cos(x*y), (x, -pi/2, pi/2), (y, 0, pi)) == 2*Si(pi**2/2)
+
+
+def test_issue_6253():
+    # Note: this used to raise NotImplementedError
+    # Note: psi in _check_antecedents becomes NaN.
+    assert integrate((sqrt(1 - x) + sqrt(1 + x))**2/x, x, meijerg=True) == \
+        Integral((sqrt(-x + 1) + sqrt(x + 1))**2/x, x)
+
+
+def test_issue_4326():
+    R, b, h = symbols('R b h')
+    # It doesn't matter if we can do the integral.  Just make sure the result
+    # doesn't contain nan.  This is really a test against _eval_interval.
+    assert not integrate(((h*(x - R + b))/b)*sqrt(R**2 - x**2), (x, R - b, R)).has(nan)
+
+
+def test_issue_4492():
+    assert simplify(integrate(x**2 * sqrt(5 - x**2), x)) == Piecewise(
+        (I*(2*x**5 - 15*x**3 + 25*x - 25*sqrt(x**2 - 5)*acosh(sqrt(5)*x/5)) /
+            (8*sqrt(x**2 - 5)), 1 < Abs(x**2)/5),
+        ((-2*x**5 + 15*x**3 - 25*x + 25*sqrt(-x**2 + 5)*asin(sqrt(5)*x/5)) /
+            (8*sqrt(-x**2 + 5)), True))
+
+
+def test_issue_7130():
+    i, L, a, b = symbols('i L a b')
+    integrand = (cos(pi*i*x/L)**2 / (a + b*x)).rewrite(exp)
+    assert x not in integrate(integrand, (x, 0, L)).free_symbols


### PR DESCRIPTION
Just pulling out a change that made it easier to detect another issue that looked like a hang until it turned out to just be a severe performance regression I will need to find another way around.

There were 103 tests in `test_integrals.py` before, there should be 93 after, with the remaining 10 moved to `test_slow_integrals.py`.
