### PR TITLE
PEP8 cleanup - ask.py

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -81,7 +81,7 @@ def _extract_facts(expr, symbol):
         args = [x for x in args if x is not None]
         if args:
             return expr.func(*args)
-    if args and all(x != None for x in args):
+    if args and all(x is not None for x in args):
         return expr.func(*args)
 
 
@@ -142,7 +142,7 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     if res is not None:
         return bool(res)
 
-    if assumptions == True:
+    if assumptions is True:
         return
 
     if local_facts is None:


### PR DESCRIPTION
Lines 84 and 145 had some PEP8 issues, as the use of "==" and "is" comparisons were inconsistent. These have been amended. There was also some under-intended lines and long lines, but I am not sure what is the official line of these - are the lines allowed to be over 79 characters? If not, I can start amending these on separate PR. Thanks. 
