### PR TITLE
Allow Vectors and Dyadics as expressions in msubs

### DIFF
--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -2,7 +2,8 @@ from __future__ import print_function, division
 
 from sympy.utilities import dict_merge
 from sympy.utilities.iterables import iterable
-from sympy.physics.vector import Vector, ReferenceFrame, Point, dynamicsymbols
+from sympy.physics.vector import (Dyadic, Vector, ReferenceFrame,
+                                  Point, dynamicsymbols)
 from sympy.physics.vector.printing import (vprint, vsprint, vpprint, vlatex,
                                            init_vprinting)
 from sympy.physics.mechanics.particle import Particle
@@ -462,7 +463,7 @@ def msubs(expr, *sub_dicts, **kwargs):
         func = _smart_subs
     else:
         func = lambda expr, sub_dict: _crawl(expr, _sub_func, sub_dict)
-    if isinstance(expr, Matrix):
+    if isinstance(expr, (Matrix, Vector, Dyadic)):
         return expr.applyfunc(lambda x: func(x, sub_dict))
     else:
         return func(expr, sub_dict)

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -143,6 +143,14 @@ def test_msubs():
     expr = cos(x + y)*tan(x + y) + b*x.diff()
     sd = {x: 0, y: pi/2, x.diff(): 1}
     assert msubs(expr, sd, smart=True) == b + 1
+    N = ReferenceFrame('N')
+    v = x*N.x + y*N.y
+    d = x*(N.x|N.x) + y*(N.y|N.y)
+    v_sol = 1*N.y
+    d_sol = 1*(N.y|N.y)
+    sd = {x: 0, y: 1}
+    assert msubs(v, sd) == v_sol
+    assert msubs(d, sd) == d_sol
 
 
 def test_find_dynamicsymbols():

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -525,8 +525,8 @@ class Dyadic(object):
             raise TypeError("`f` must be callable.")
 
         out = Dyadic(0)
-        a, b, c = zip(*self.args)
-        out.args = list(zip(list(map(f, a)), b, c))
+        for a, b, c in self.args:
+            out += f(a) * (b|c)
         return out
 
     dot = __and__

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -519,6 +519,16 @@ class Dyadic(object):
         return sum([Dyadic([(v[0].subs(*args, **kwargs), v[1], v[2])])
                     for v in self.args], Dyadic(0))
 
+    def applyfunc(self, f):
+        """Apply a function to each component of a Dyadic."""
+        if not callable(f):
+            raise TypeError("`f` must be callable.")
+
+        out = Dyadic(0)
+        a, b, c = zip(*self.args)
+        out.args = list(zip(list(map(f, a)), b, c))
+        return out
+
     dot = __and__
     cross = __xor__
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -656,6 +656,16 @@ class Vector(object):
         """Returns a Vector of magnitude 1, codirectional with self."""
         return Vector(self.args + []) / self.magnitude()
 
+    def applyfunc(self, f):
+        """Apply a function to each component of a vector."""
+        if not callable(f):
+            raise TypeError("`f` must be callable.")
+
+        ov = Vector(0)
+        for v in self.args:
+            ov += Vector([(v[0].applyfunc(f), v[1])])
+        return ov
+
 
 class VectorTypeError(TypeError):
 


### PR DESCRIPTION
Both Vector and Dyadic classes have subs methods implemented. However, if we want to perform substitutions for expressions involving Vectors and Dyadics while ignoring terms inside Derivatives, there is no easy way to do so as msubs has not been implemented for these classes.

This will also make it easier to replace subs with msubs in the kane/lagrange classes and result in small improvement in the time it takes to derive equation of motion.

@moorepants 
