### PR TITLE
[Retracted] Remove sympy.abc imports in assumptions

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -100,8 +100,8 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     Examples
     ========
 
-    >>> from sympy import ask, Q, pi
-    >>> from sympy.abc import x, y
+    >>> from sympy import ask, Q, pi, symbols
+    >>> x, y = symbols('x y')
     >>> ask(Q.rational(pi))
     False
     >>> ask(Q.even(x*y), Q.even(x) & Q.integer(y))

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -19,11 +19,11 @@ class AssumptionsContext(set):
     Examples
     ========
 
-    >>> from sympy import AppliedPredicate, Q
+    >>> from sympy import AppliedPredicate, Q, Symbol
     >>> from sympy.assumptions.assume import global_assumptions
     >>> global_assumptions
     AssumptionsContext()
-    >>> from sympy.abc import x
+    >>> x = Symbol('x')
     >>> global_assumptions.add(Q.real(x))
     >>> global_assumptions
     AssumptionsContext([Q.real(x)])
@@ -195,7 +195,8 @@ def assuming(*assumptions):
     ========
 
     >>> from sympy.assumptions import assuming, Q, ask
-    >>> from sympy.abc import x, y
+    >>> from sympy import symbols
+    >>> x, y = symbols('x y')
 
     >>> print(ask(Q.integer(x + y)))
     None

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -65,7 +65,7 @@ class AskBoundedHandler(CommonHandler):
 
     >>> from sympy import Symbol, Q
     >>> from sympy.assumptions.handlers.calculus import AskBoundedHandler
-    >>> from sympy.abc import x
+    >>> x = Symbol('x')
     >>> a = AskBoundedHandler()
     >>> a.Symbol(x, Q.positive(x)) == None
     True
@@ -83,7 +83,7 @@ class AskBoundedHandler(CommonHandler):
 
         >>> from sympy import Symbol, Q
         >>> from sympy.assumptions.handlers.calculus import AskBoundedHandler
-        >>> from sympy.abc import x
+        >>> x = Symbol('x')
         >>> a = AskBoundedHandler()
         >>> a.Symbol(x, Q.positive(x)) == None
         True

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -16,8 +16,8 @@ def refine(expr, assumptions=True):
     Examples
     ========
 
-        >>> from sympy import refine, sqrt, Q
-        >>> from sympy.abc import x
+        >>> from sympy import refine, sqrt, Q, Symbol
+        >>> x = Symbol('x')
         >>> refine(sqrt(x**2), Q.real(x))
         Abs(x)
         >>> refine(sqrt(x**2), Q.positive(x))
@@ -51,7 +51,7 @@ def refine_abs(expr, assumptions):
 
     >>> from sympy import Symbol, Q, refine, Abs
     >>> from sympy.assumptions.refine import refine_abs
-    >>> from sympy.abc import x
+    >>> x = Symbol('x')
     >>> refine_abs(Abs(x), Q.real(x))
     >>> refine_abs(Abs(x), Q.positive(x))
     x
@@ -72,9 +72,9 @@ def refine_Pow(expr, assumptions):
     """
     Handler for instances of Pow.
 
-    >>> from sympy import Symbol, Q
+    >>> from sympy import Q, Symbol, symbols
     >>> from sympy.assumptions.refine import refine_Pow
-    >>> from sympy.abc import x,y,z
+    >>> x, y, z = symbols('x y z')
     >>> refine_Pow((-1)**x, Q.real(x))
     >>> refine_Pow((-1)**x, Q.even(x))
     1
@@ -172,7 +172,7 @@ def refine_exp(expr, assumptions):
 
     >>> from sympy import Symbol, Q, exp, I, pi
     >>> from sympy.assumptions.refine import refine_exp
-    >>> from sympy.abc import x
+    >>> x = Symbol('x')
     >>> refine_exp(exp(pi*I*2*x), Q.real(x))
     >>> refine_exp(exp(pi*I*2*x), Q.integer(x))
     1
@@ -200,9 +200,9 @@ def refine_atan2(expr, assumptions):
     Examples
     ========
 
-    >>> from sympy import Symbol, Q, refine, atan2
+    >>> from sympy import Q, Symbol, symbols, refine, atan2
     >>> from sympy.assumptions.refine import refine_atan2
-    >>> from sympy.abc import x, y
+    >>> x, y = symbols('x y')
     >>> refine_atan2(atan2(y,x), Q.real(y) & Q.positive(x))
     atan(y/x)
     >>> refine_atan2(atan2(y,x), Q.negative(y) & Q.negative(x))
@@ -229,7 +229,8 @@ def refine_Relational(expr, assumptions):
 
     >>> from sympy.assumptions.refine import refine_Relational
     >>> from sympy.assumptions.ask import Q
-    >>> from sympy.abc import x
+    >>> from sympy import Symbol
+    >>> x = Symbol('x')
     >>> refine_Relational(x<0, ~Q.is_true(x<0))
     False
     """

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -1,12 +1,14 @@
 """
 rename this to test_assumptions.py when the old assumptions system is deleted
 """
-from sympy.abc import x, y
 from sympy.assumptions.assume import global_assumptions, Predicate
 from sympy.assumptions.ask import _extract_facts, Q
-from sympy.core import symbols
+from sympy.core.symbol import symbols
 from sympy.logic.boolalg import Or
 from sympy.printing import pretty
+
+
+x, y = symbols('x y')
 
 
 def test_equal():

--- a/sympy/assumptions/tests/test_context.py
+++ b/sympy/assumptions/tests/test_context.py
@@ -1,6 +1,10 @@
 from sympy.assumptions import ask, Q
 from sympy.assumptions.assume import assuming, global_assumptions
-from sympy.abc import x, y
+from sympy.core.symbol import symbols
+
+
+x, y = symbols('x y')
+
 
 def test_assuming():
     with assuming(Q.integer(x)):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1,4 +1,3 @@
-from sympy.abc import t, w, x, y, z, n, k, m, p, i
 from sympy.assumptions import (ask, AssumptionsContext, Q, register_handler,
         remove_handler)
 from sympy.assumptions.assume import global_assumptions
@@ -20,6 +19,9 @@ from sympy.functions.elementary.trigonometric import (
 from sympy.logic.boolalg import Equivalent, Implies, Xor, And, to_cnf
 from sympy.utilities.pytest import raises, XFAIL, slow
 from sympy.assumptions.assume import assuming
+
+
+t, w, x, y, z, n, k, m, p, i = symbols('t w x y z n k m p i')
 
 
 def test_int_1():

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,8 +1,11 @@
 from sympy import (Abs, exp, Expr, I, pi, Q, Rational, refine, S, sqrt,
                    atan, atan2)
-from sympy.abc import x, y, z
 from sympy.core.relational import Eq, Ne
+from sympy.core.symbol import symbols
 from sympy.functions.elementary.piecewise import Piecewise
+
+
+x, y, z = symbols('x y z')
 
 
 def test_Abs():


### PR DESCRIPTION
This is a toe-in-the-water commit to apply
https://github.com/sympy/sympy/wiki/Idioms-and-Antipatterns#creating-symbols

If this is +1, I'll apply this to the other SymPy modules.
