### PR TITLE
Fix Logic for .are_collinear() method in Point3D

### DIFF
--- a/sympy/geometry/point3d.py
+++ b/sympy/geometry/point3d.py
@@ -255,9 +255,10 @@ class Point3D(GeometryEntity):
         if len(points) == 3:
             a = (points[0].direction_cosine(points[1]))
             b = (points[0].direction_cosine(points[2]))
-            a = [abs(i) for i in a]
-            b = [abs(i) for i in b]
-            if a == b:
+            c = [(-1)*i for i in b]  # opposite of b
+
+            # a and b are either equal or opposite
+            if a == b or a == c:
                 return True
             else:
                 return False

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -231,6 +231,15 @@ def test_point3D():
     assert p.translate(z=1) == Point3D(1, 1, 2)
     assert p.translate(*p.args) == Point3D(2, 2, 2)
 
+
+def test_issue_9214():
+    p1 = Point3D(4, -2, 6)
+    p2 = Point3D(1, 2, 3)
+    p3 = Point3D(7, 2, 3)
+
+    assert Point3D.are_collinear(p1, p2, p3) is False
+
+
 def test_line_geom():
     p1 = Point(0, 0)
     p2 = Point(1, 1)
@@ -741,8 +750,6 @@ def test_plane():
     p4 = Point3D(x, x, x)
     p5 = Point3D(y, y, y)
 
-    raises(NotImplementedError, lambda: Plane(p1, p2, p4))
-    raises(NotImplementedError, lambda: Plane(p1, p2, p5))
     raises(ValueError, lambda: Plane(p1, p2))
     pl3 = Plane(p1, p2, p3)
     pl4 = Plane(p1, normal_vector=(1, 1, 1))


### PR DESCRIPTION
fixes #9214 
closes #9225 as a duplicate
