### PR TITLE
_sage_ method for exp_polar

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -184,6 +184,10 @@ class exp_polar(ExpBase):
             return self, S(1)
         return ExpBase.as_base_exp(self)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.exp(self.args[0]._sage_())
+
 
 class exp(ExpBase):
     """


### PR DESCRIPTION
Sage does not know `exp_polar` function and so the [`_sage_` method of the Function class](https://github.com/kalvotom/sympy/blob/master/sympy/core/function.py#L679) fails when encountering `exp_polar`.

This should eventually fix http://trac.sagemath.org/ticket/18085
