### PR TITLE
Fix wrong evaluation of acosh(-x)

### DIFF
--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -922,15 +922,12 @@ class acosh(Function):
         if arg is S.ComplexInfinity:
             return S.Infinity
 
-        i_coeff = arg.as_coefficient(S.ImaginaryUnit)
-
-        if i_coeff is not None:
-            if _coeff_isneg(i_coeff):
-                return S.ImaginaryUnit * acos(i_coeff)
-            return S.ImaginaryUnit * acos(-i_coeff)
         else:
-            if _coeff_isneg(arg):
-                return -cls(-arg)
+            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
+            if i_coeff is not None:
+                if _coeff_isneg(i_coeff):
+                    return S.ImaginaryUnit * acos(i_coeff)
+                return S.ImaginaryUnit * acos(-i_coeff)
 
     @staticmethod
     @cacheit

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -446,6 +446,10 @@ def test_acosh():
     # TODO please write more tests  -- see issue 3751
     # From http://functions.wolfram.com/ElementaryFunctions/ArcCosh/03/01/
     # at specific points
+    x = Symbol('x')
+
+    assert acosh(-x) == acosh(-x)
+
     assert acosh(1) == 0
     assert acosh(-1) == pi*I
     assert acosh(0) == I*pi/2


### PR DESCRIPTION
As pointed out by **Arnaud Usciati** on mailing list:

> Bug with Inverse hyperbolic cosine `acosh`

https://groups.google.com/forum/#!topic/sympy/-Z1GeHN88gM

**References**: 
http://functions.wolfram.com/ElementaryFunctions/ArcCosh/02/
http://www.wolframalpha.com/input/?i=ArcCosh%5B-z%5D

@smichr 
@toolforger
