### PR TITLE
pretty print: use single-char square root symbol in simple cases

### DIFF
--- a/doc/src/modules/polys/wester.rst
+++ b/doc/src/modules/polys/wester.rst
@@ -228,11 +228,11 @@ We would like to reduce degrees of the numerator and the denominator of a
 rational function ``f/g``. Do do this we employ :func:`cancel` function::
 
     >>> cancel(f/g)
-     3      2     ___  2             ___         ___
-    x  - 2⋅x  + ╲╱ 2 ⋅x  - 3⋅x - 2⋅╲╱ 2 ⋅x - 3⋅╲╱ 2
-    ────────────────────────────────────────────────
-                          2
-                         x  - 2
+     3      2       2
+    x  - 2⋅x  + √2⋅x  - 3⋅x - 2⋅√2⋅x - 3⋅√2
+    ───────────────────────────────────────
+                      2
+                     x  - 2
 
 Unfortunately nothing interesting happened. This is because by default SymPy
 treats `\sqrt{2}` as a generator, obtaining a bivariate polynomial for the
@@ -243,8 +243,7 @@ one needs to use ``extension`` keyword::
      2
     x  - 2⋅x - 3
     ────────────
-           ___
-     x - ╲╱ 2
+       x - √2
 
 Setting ``extension=True`` tells :func:`cancel` to find minimal algebraic
 number domain for the coefficients of ``f/g``. The automatically inferred
@@ -256,8 +255,7 @@ keyword with an explicit algebraic number::
      2
     x  - 2⋅x - 3
     ────────────
-           ___
-     x - ╲╱ 2
+       x - √2
 
 Univariate factoring over various domains
 -----------------------------------------
@@ -412,10 +410,9 @@ in univariate case. For example consider the following factorization over
 `\mathbb{Q}(\sqrt{-3})`::
 
     >>> factor(x**3 + y**3, extension=sqrt(-3))
-            ⎛      ⎛        ___  ⎞⎞ ⎛      ⎛        ___  ⎞⎞
-            ⎜      ⎜  1   ╲╱ 3 ⋅ⅈ⎟⎟ ⎜      ⎜  1   ╲╱ 3 ⋅ⅈ⎟⎟
-    (x + y)⋅⎜x + y⋅⎜- ─ - ───────⎟⎟⋅⎜x + y⋅⎜- ─ + ───────⎟⎟
-            ⎝      ⎝  2      2   ⎠⎠ ⎝      ⎝  2      2   ⎠⎠
+            ⎛      ⎛  1   √3⋅ⅈ⎞⎞ ⎛      ⎛  1   √3⋅ⅈ⎞⎞
+    (x + y)⋅⎜x + y⋅⎜- ─ - ────⎟⎟⋅⎜x + y⋅⎜- ─ + ────⎟⎟
+            ⎝      ⎝  2    2  ⎠⎠ ⎝      ⎝  2    2  ⎠⎠
 
 .. note:: Currently multivariate polynomials over finite fields aren't supported.
 

--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -182,14 +182,11 @@ definite integrals.  Here is a sampling of some of the power of ``integrate``.
     ⎮ sin⎝x ⎠ dx
     ⌡
     >>> integ.doit()
-                          ⎛  ___  ⎞
-        ___   ___         ⎜╲╱ 2 ⋅x⎟
-    3⋅╲╱ 2 ⋅╲╱ π ⋅fresnels⎜───────⎟⋅Γ(3/4)
-                          ⎜   ___ ⎟
-                          ⎝ ╲╱ π  ⎠
-    ──────────────────────────────────────
-                   8⋅Γ(7/4)
-
+                    ⎛√2⋅x⎞
+    3⋅√2⋅√π⋅fresnels⎜────⎟⋅Γ(3/4)
+                    ⎝ √π ⎠
+    ─────────────────────────────
+               8⋅Γ(7/4)
 
     >>> integ = Integral(x**y*exp(-x), (x, 0, oo))
     >>> integ

--- a/doc/src/tutorial/intro.rst
+++ b/doc/src/tutorial/intro.rst
@@ -135,10 +135,9 @@ Compute `\int(e^x\sin{(x)} + e^x\cos{(x)})\,dx`.
 Compute `\int_{-\infty}^\infty \sin{(x^2)}\,dx`.
 
  >>> integrate(sin(x**2), (x, -oo, oo))
-   ___   ___
- ╲╱ 2 ⋅╲╱ π
- ───────────
-      2
+ √2⋅√π
+ ─────
+   2
 
 Find :math:`\lim_{x\to 0}\frac{\sin{(x)}}{x}`.
 
@@ -148,8 +147,7 @@ Find :math:`\lim_{x\to 0}\frac{\sin{(x)}}{x}`.
 Solve `x^2 - 2 = 0`.
 
  >>> solve(x**2 - 2, x)
- ⎡   ___    ___⎤
- ⎣-╲╱ 2 , ╲╱ 2 ⎦
+ [-√2, √2]
 
 Solve the differential equation `y'' - y = e^t`.
 
@@ -163,21 +161,17 @@ Find the eigenvalues of `\left[\begin{smallmatrix}1 & 2\\2 &
 2\end{smallmatrix}\right]`.
 
  >>> Matrix([[1, 2], [2, 2]]).eigenvals()
- ⎧      ____         ____       ⎫
- ⎪3   ╲╱ 17        ╲╱ 17    3   ⎪
- ⎨─ + ──────: 1, - ────── + ─: 1⎬
- ⎪2     2            2      2   ⎪
- ⎩                              ⎭
+ ⎧3   √17       √17   3   ⎫
+ ⎨─ + ───: 1, - ─── + ─: 1⎬
+ ⎩2    2         2    2   ⎭
 
 Rewrite the Bessel function `J_{\nu}\left(z\right)` in terms of the
 spherical Bessel function `j_\nu(z)`.
 
   >>> besselj(nu, z).rewrite(jn)
-    ___   ___
-  ╲╱ 2 ⋅╲╱ z ⋅jn(ν - 1/2, z)
-  ──────────────────────────
-              ___
-            ╲╱ π
+  √2⋅√z⋅jn(ν - 1/2, z)
+  ────────────────────
+           √π
 
 Print `\int_{0}^{\pi} \cos^{2}{\left (x \right )}\, dx` using `\LaTeX`.
 

--- a/doc/src/tutorial/simplification.rst
+++ b/doc/src/tutorial/simplification.rst
@@ -400,8 +400,7 @@ rational numbers, and identity 2 holds, it will be applied automatically
      2  2
     t ⋅z
    >>> sqrt(x*y)
-      ___   ___
-    ╲╱ x ⋅╲╱ y
+    √x⋅√y
 
 This means that it will be impossible to undo this identity with
 ``powsimp()``, because even if ``powsimp()`` were to put the bases together,
@@ -411,8 +410,7 @@ they would be automatically split apart again.
      2  2
     t ⋅z
    >>> powsimp(sqrt(x)*sqrt(y))
-      ___   ___
-    ╲╱ x ⋅╲╱ y
+    √x⋅√y
 
 expand_power_exp / expand_power_base
 ------------------------------------

--- a/doc/src/tutorial/solvers.rst
+++ b/doc/src/tutorial/solvers.rst
@@ -80,8 +80,7 @@ list of variables to solve for.
     >>> solve([x - y + 2, x + y - 3], [x, y])
     {x: 1/2, y: 5/2}
     >>> solve([x*y - 7, x + y - 6], [x, y])
-    ⎡⎛    ___        ___    ⎞  ⎛  ___          ___    ⎞⎤
-    ⎣⎝- ╲╱ 2  + 3, ╲╱ 2  + 3⎠, ⎝╲╱ 2  + 3, - ╲╱ 2  + 3⎠⎦
+    [(-√2 + 3, √2 + 3), (√2 + 3, -√2 + 3)]
 
 .. note::
 
@@ -92,9 +91,7 @@ list of variables to solve for.
    >>> solve([x - y + 2, x + y - 3], [x, y], dict=True)
    [{x: 1/2, y: 5/2}]
    >>> solve([x*y - 7, x + y - 6], [x, y], dict=True)
-   ⎡⎧       ___           ___    ⎫  ⎧     ___             ___    ⎫⎤
-   ⎢⎨x: - ╲╱ 2  + 3, y: ╲╱ 2  + 3⎬, ⎨x: ╲╱ 2  + 3, y: - ╲╱ 2  + 3⎬⎥
-   ⎣⎩                            ⎭  ⎩                            ⎭⎦
+   [{x: -√2 + 3, y: √2 + 3}, {x: √2 + 3, y: -√2 + 3}]
 
 .. _tutorial-roots:
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -38,7 +38,7 @@ class PrettyPrinter(Printer):
         "use_unicode": None,
         "wrap_line": True,
         "num_columns": None,
-        "unicode_square_roots": True,
+        "use_unicode_sqrt_char": True,
     }
 
     def __init__(self, settings=None):
@@ -1330,7 +1330,7 @@ class PrettyPrinter(Printer):
         bpretty = self._print(base)
 
         # In very simple cases, use a single-char root sign
-        if (self._settings['unicode_square_roots'] and self._use_unicode
+        if (self._settings['use_unicode_sqrt_char'] and self._use_unicode
             and expt is S.Half and bpretty.height() == 1
             and (bpretty.width() == 1
                  or (base.is_Integer and base.is_nonnegative))):
@@ -1962,7 +1962,7 @@ def pretty_print(expr, **settings):
         use full precision. Default to "auto"
     order : bool or string, optional
         set to 'none' for long expressions if slow; default is None
-    unicode_square_roots : bool, optional
+    use_unicode_sqrt_char : bool, optional
         use compact single-character square root symbol (when unambiguous);
         default is True.
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -38,6 +38,7 @@ class PrettyPrinter(Printer):
         "use_unicode": None,
         "wrap_line": True,
         "num_columns": None,
+        "unicode_square_roots": True,
     }
 
     def __init__(self, settings=None):
@@ -1329,9 +1330,10 @@ class PrettyPrinter(Printer):
         bpretty = self._print(base)
 
         # In very simple cases, use a single-char root sign
-        if (self._use_unicode and expt is S.Half
-            and bpretty.height() == 1 and (bpretty.width() == 1
-            or (base.is_Integer and base.is_nonnegative))):
+        if (self._settings['unicode_square_roots'] and self._use_unicode
+            and expt is S.Half and bpretty.height() == 1
+            and (bpretty.width() == 1
+                 or (base.is_Integer and base.is_nonnegative))):
             return prettyForm(*bpretty.left(u('\N{SQUARE ROOT}')))
 
         # Construct root sign, start with the \/ shape
@@ -1960,6 +1962,9 @@ def pretty_print(expr, **settings):
         use full precision. Default to "auto"
     order : bool or string, optional
         set to 'none' for long expressions if slow; default is None
+    unicode_square_roots : bool, optional
+        use compact single-character square root symbol (when unambiguous);
+        default is True.
 
     """
     print(pretty(expr, **settings))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1328,6 +1328,12 @@ class PrettyPrinter(Printer):
     def _print_nth_root(self, base, expt):
         bpretty = self._print(base)
 
+        # In very simple cases, use a single-char root sign
+        if (self._use_unicode and expt is S.Half
+            and bpretty.height() == 1 and (bpretty.width() == 1
+            or (base.is_Integer and base.is_nonnegative))):
+            return prettyForm(*bpretty.left(u('\N{SQUARE ROOT}')))
+
         # Construct root sign, start with the \/ shape
         _zZ = xobj('/', 1)
         rootsign = xobj('\\', 1) + _zZ

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1709,6 +1709,22 @@ u("√2")
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+
+def test_pretty_sqrt_symbol_knob():
+    expr = sqrt(2)
+    ucode_str1 = \
+u"""\
+  ___\n\
+╲╱ 2 \
+"""
+    ucode_str2 = \
+u("√2")
+    assert xpretty(expr, use_unicode=True,
+                   unicode_square_roots=False) == ucode_str1
+    assert xpretty(expr, use_unicode=True,
+                   unicode_square_roots=True) == ucode_str2
+
+
     expr = 2**Rational(1, 3)
     ascii_str = \
 """\

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1709,22 +1709,6 @@ u("√2")
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-
-def test_pretty_sqrt_symbol_knob():
-    expr = sqrt(2)
-    ucode_str1 = \
-u"""\
-  ___\n\
-╲╱ 2 \
-"""
-    ucode_str2 = \
-u("√2")
-    assert xpretty(expr, use_unicode=True,
-                   unicode_square_roots=False) == ucode_str1
-    assert xpretty(expr, use_unicode=True,
-                   unicode_square_roots=True) == ucode_str2
-
-
     expr = 2**Rational(1, 3)
     ascii_str = \
 """\
@@ -1837,18 +1821,31 @@ u("""\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+
+def test_pretty_sqrt_char_knob():
+    # See PR #9234.
+    expr = sqrt(2)
+    ucode_str1 = \
+u("""\
+  ___\n\
+╲╱ 2 \
+""")
+    ucode_str2 = \
+u("√2")
+    assert xpretty(expr, use_unicode=True,
+                   use_unicode_sqrt_char=False) == ucode_str1
+    assert xpretty(expr, use_unicode=True,
+                   use_unicode_sqrt_char=True) == ucode_str2
+
+
+def test_pretty_sqrt_longsymbol_no_sqrt_char():
+    # Do not use unicode sqrt char for long symbols (see PR #9234).
     expr = sqrt(Symbol('C1'))
-    ascii_str = \
-"""\
-  ____\n\
-\/ C1 \
-"""
     ucode_str = \
 u("""\
   ____\n\
 ╲╱ C₁ \
 """)
-    assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -894,8 +894,8 @@ def test_issue_5524():
 
     assert upretty(-(-x + 5)*(-x - 2*sqrt(2) + 5) - (-y + 5)*(-y + 5)) == \
 u("""\
-        ⎛         ___    ⎞           2\n\
-(x - 5)⋅⎝-x - 2⋅╲╱ 2  + 5⎠ - (-y + 5) \
+                                  2\n\
+(x - 5)⋅(-x - 2⋅√2 + 5) - (-y + 5) \
 """)
 
 
@@ -1705,10 +1705,7 @@ def test_pretty_sqrt():
 \/ 2 \
 """
     ucode_str = \
-u("""\
-  ___\n\
-╲╱ 2 \
-""")
+u("√2")
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1765,9 +1762,8 @@ u("""\
 """
     ucode_str = \
 u("""\
-   ___________\n\
-3 ╱       ___ \n\
-╲╱  1 + ╲╱ 5  \
+3 ________\n\
+╲╱ 1 + √5 \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1821,6 +1817,20 @@ u("""\
 ╲╱        x + 2        ________\n\
                       ╱  2     \n\
                     ╲╱  x  + 3 \
+""")
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = sqrt(Symbol('C1'))
+    ascii_str = \
+"""\
+  ____\n\
+\/ C1 \
+"""
+    ucode_str = \
+u("""\
+  ____\n\
+╲╱ C₁ \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4302,10 +4312,9 @@ atan2|-------, \\/ x |\n\
 """
     ucode_str = \
 u("""\
-     ⎛  ___         ⎞\n\
-     ⎜╲╱ 2 ⋅y    ___⎟\n\
-atan2⎜───────, ╲╱ x ⎟\n\
-     ⎝   20         ⎠\
+     ⎛√2⋅y    ⎞\n\
+atan2⎜────, √x⎟\n\
+     ⎝ 20     ⎠\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4561,10 +4570,9 @@ def test_issue_6739():
 """
     ucode_str = \
 u("""\
-  1  \n\
-─────\n\
-  ___\n\
-╲╱ x \
+1 \n\
+──\n\
+√x\
 """)
     assert pretty(1/sqrt(x)) == ascii_str
     assert upretty(1/sqrt(x)) == ucode_str


### PR DESCRIPTION
For single-char Symbols and for non-negative integers we use
the unicode square root symbol.  As this doesn't include a top
overline indicated what the root encompasses, we use this only
for simple unambiguous cases like:

```
>>> pprint(exp(3*sqrt(5*x*pi)))
 3⋅√5⋅√π⋅√x
ℯ
```

Update tests for this.

Perhaps slightly more controversial:

```
>>> pprint(sqrt(123))
√123
>>> pprint(sqrt(Symbol('C1')))
  ____
╲╱ C₁
```

Note---as in this last case---we do _not_ simply use "√" for all
Symbols because "√C₁" looks ambiguous.  Add test for this.

An alternative would be to combine the "√" symbol with some
overlining, although at some cost in vertical space.  And the
overline does not connect to the "√" symbol.
