### PR TITLE
[WIP] dsolve fixes for systems

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -6422,20 +6422,23 @@ def sysode_linear_order1_jordan(match_):
     eq = match_['eq']
     n = len(eq)
 
+    # todo: inhomog test?
+
     t = func[0].args[0]
     # FIXME: check all same: add test, or maybe this is dealt with higher up?
     if not all([f.args[0] == t for f in func]):
         raise ValueError("The ODEs must all be in the same variables")
 
+    # TODO: M = r['M']
     M = Matrix(n, n, lambda i,j: fc[i, func[j], 1])
     L = Matrix(n, n, lambda i,j: -fc[i, func[j], 0])
+    # todo: where/what to raise if M not invertible
     A = M.inv() * L
-    pprint(A)
 
     T, JJ = A.jordan_cells()
-    if len(JJ) != T.rows:
+    if sum([J.rows for J in JJ]) != T.cols:
+        pprint(("A, T, JJ:", A, T, JJ))
         raise NotImplementedError("Too many Jordan blocks: probably #9274")
-    pprint(("orig T, JJ:", T, JJ))
 
     if not all(a.is_real for a in flatten(A.tolist())):
         # Cannot tell if matrix A is real: matrix exponential of each block
@@ -6463,7 +6466,7 @@ def sysode_linear_order1_jordan(match_):
             expm = Matrix(2*m, 2*m, lambda r,c: 0)
             for i in range(m):
                 for j in range(i, m):
-                    r = j-i
+                    r = j - i
                     expm[2*i:2*i+2, 2*j:2*j+2] = t**r/factorial(r)*R
             expm = exp(a*t)*expm
             T2 = []
@@ -6505,7 +6508,7 @@ def sysode_linear_order1_jordan(match_):
         for evs in ev_lol:
             for ev in evs:
                 T = T.row_join(ev)
-        pprint(("TT,JJ,T,expm:",TT,JJ,T,expm))
+        #print(); pprint(("A,TT,JJ,T,expm:",A,TT,JJ,T,expm))
     q = T*expm*T.inv()
     Cvec = Matrix(get_numbered_constants(eq, num=n))
     q = q*Cvec

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -6374,7 +6374,7 @@ def sysode_linear_order1_jordan(match_):
     # FIXME: support M in higher-up code
     # M x' = L x  +  f
     # x' = inv(M) L x  +  f
-    from sympy import BlockDiagMatrix, DiagonalMatrix, ones
+    from sympy import BlockDiagMatrix, DiagonalMatrix, ones, flatten
     from sympy import pprint
     func = match_['func']
     fc = match_['func_coeff']
@@ -6386,18 +6386,88 @@ def sysode_linear_order1_jordan(match_):
     if not all([f.args[0] == t for f in func]):
         raise ValueError("The ODEs must all be in the same variables")
 
-    M = Matrix(n, n, lambda i,j: -fc[i, func[j], 1])
+    M = Matrix(n, n, lambda i,j: fc[i, func[j], 1])
     L = Matrix(n, n, lambda i,j: -fc[i, func[j], 0])
     A = M.inv() * L
     pprint(A)
 
     T, JJ = A.jordan_cells()
-    # FIXME: need special treatment for complex_conj pairs
-    expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
+    if len(JJ) != T.rows:
+        raise NotImplementedError("Too many Jordan blocks: probably #9274")
+    pprint(("orig T, JJ:", T, JJ))
+
+    if not all(a.is_real for a in flatten(A.tolist())):
+        # Cannot tell if matrix A is real: matrix exponential of each block
+        expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
+    else:
+        # If matrix A is real: special treatment for conj pairs
+        def imag(q):
+            return (q - q.conjugate())/(2*I)
+        def real(q):
+            return (q + q.conjugate())/2
+        def extract_eigenvector_blocks(JJ, evs):
+            TT = []
+            c = 0
+            for J in JJ:
+                mult = J.rows
+                TT.append([evs.col(i) for i in range(c, c + mult)])
+                c = c + mult
+            assert len(TT) == len(JJ)
+            assert c == evs.cols
+            return TT
+        def make_exp_real_jordan_block(m, a, b, t, T):
+            """Given a Jordan block... FIXME"""
+
+            R = Matrix([[cos(b*t), sin(b*t)], [-sin(b*t), cos(b*t)]])
+            expm = Matrix(2*m, 2*m, lambda r,c: 0)
+            for i in range(m):
+                for j in range(i, m):
+                    r = j-i
+                    expm[2*i:2*i+2, 2*j:2*j+2] = t**r/factorial(r)*R
+            expm = exp(a*t)*expm
+            T2 = []
+            for ev in T:
+                T2.extend([real(ev), imag(ev)])
+            return (expm, T2)
+
+
+        TT = extract_eigenvector_blocks(JJ, T)
+
+        # list of eigenvalues
+        ll = [J[0,0] for J in JJ]
+
+        expm_list = []
+        ev_lol = []
+        for i in range(len(JJ)):
+            J = JJ[i]
+            evs = TT[i]
+            l = J[0,0]
+            if l.is_complex and l.is_real is False:
+                a = real(l)
+                b = imag(l)
+                if b.is_positive:
+                    m = J.rows
+                    myexpm, myevs = make_exp_real_jordan_block(m, a, b, t, evs)
+                    expm_list.append(myexpm)
+                    ev_lol.append(myevs)
+                    pprint(("old/new J:", J, myexpm))
+                    pprint(("old/new T:", evs, myevs))
+                elif b.is_negative:
+                    # FIXME: do some assertions
+                    pprint(("ignoring: i/J/ev_list", i, J, evs))
+            else:
+                expm_list.append((J*t).exp())
+                ev_lol.append(evs)
+        expm = Matrix(BlockDiagMatrix(*expm_list))
+        # rebuild matrix with eigenvector columns
+        T = Matrix(n, 0, [])
+        for evs in ev_lol:
+            for ev in evs:
+                T = T.row_join(ev)
+        pprint(("TT,JJ,T,expm:",TT,JJ,T,expm))
     q = T*expm*T.inv()
     Cvec = Matrix(get_numbered_constants(eq, num=n))
     q = q*Cvec
-
     # fixme: can simplify to cosh/sinh sometimes, or let user do this?
     out = []
     for i in range(0, n):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -606,10 +606,11 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             raise NotImplementedError
         else:
             if match['is_linear'] == True:
-                if match['no_of_equation'] > 3:
-                    solvefunc = globals()['sysode_linear_neq_order%(order)s' % match]
-                else:
-                    solvefunc = globals()['sysode_linear_%(no_of_equation)seq_order%(order)s' % match]
+                solvefunc = globals()['sysode_linear_order%(order)s_jordan' % match]
+                #if match['no_of_equation'] > 3:
+                #    solvefunc = globals()['sysode_linear_neq_order%(order)s' % match]
+                #else:
+                #    solvefunc = globals()['sysode_linear_%(no_of_equation)seq_order%(order)s' % match]
             else:
                 solvefunc = globals()['sysode_nonlinear_%(no_of_equation)seq_order%(order)s' % match]
             sols = solvefunc(match)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -26,6 +26,13 @@ h = Function('h')
 # constant_renumber because it will normalize it (constant_renumber causes
 # dsolve() to return different results on different machines)
 
+
+def solves(s, eq):
+    s = [(l.lhs, l.rhs) for l in s]
+    for i in range(len(eq)):
+        assert (eq[i].lhs - eq[i].rhs).subs(s).doit().simplify().doit() == 0
+
+
 def test_linear_2eq_order1():
     x, y, z = symbols('x, y, z', function=True)
     k, l, m, n = symbols('k, l, m, n', Integer=True)
@@ -99,10 +106,8 @@ def test_linear_2eq_order1_type2_degen():
          Eq(diff(g(x), x), f(x) + 7)]
     s1 = [Eq(f(x), C2*exp(x) - 5), Eq(g(x), C2*exp(x) - C1 + 2*x - 5)]
     s = dsolve(e)
+    solves(s, e)
     assert s == s1
-    s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
 
 
 def test_dsolve_linear_2eq_order1_diag_triangular():
@@ -110,20 +115,16 @@ def test_dsolve_linear_2eq_order1_diag_triangular():
          Eq(diff(g(x), x), g(x))]
     s1 = [Eq(f(x), C2*exp(x)), Eq(g(x), C1*exp(x))]
     s = dsolve(e)
+    solves(s, e)
     assert s == s1
-    s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
 
     e = [Eq(diff(f(x), x), 2*f(x)),
          Eq(diff(g(x), x), 3*f(x) + 7*g(x))]
     s1 = [Eq(f(x), -5*C1*exp(2*x)),
           Eq(g(x), 3*C1*exp(2*x) + 8*C2*exp(7*x))];
     s = dsolve(e)
+    solves(s, e)
     assert s == s1
-    s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
 
 
 @XFAIL
@@ -131,10 +132,7 @@ def test_sysode_linear_2eq_order1_type1_D_lt_0():
     e = [Eq(diff(f(x), x), -9*I*f(x) - 4*g(x)),
          Eq(diff(g(x), x), -4*I*g(x))]
     s = dsolve(e)
-    s = [(l.lhs, l.rhs) for l in s]
-    # bit of a hassle to get these to clean up
-    assert (e[0].lhs - e[0].rhs).subs(s).doit().simplify().doit() == 0
-    assert (e[1].lhs - e[1].rhs).subs(s).doit().simplify().doit() == 0
+    solves(s, e)
 
 
 @XFAIL
@@ -143,10 +141,8 @@ def test_sysode_linear_2eq_order1_type1_D_lt_0_b_eq_0():
          Eq(diff(g(x), x), -4*I*g(x))]
     s1 = [Eq(f(x), C1*exp(-9*I*x)), Eq(g(x), C2*exp(-4*I*x))]
     s = dsolve(e)
+    solves(s, e)
     assert s == s1
-    s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
 
 
 def test_linear_2eq_order2():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -113,7 +113,7 @@ def test_linear_2eq_order1_type2_degen():
 def test_dsolve_linear_2eq_order1_diag_triangular():
     e = [Eq(diff(f(x), x), f(x)),
          Eq(diff(g(x), x), g(x))]
-    s1 = [Eq(f(x), C2*exp(x)), Eq(g(x), C1*exp(x))]
+    s1 = [Eq(f(x), C1*exp(x)), Eq(g(x), C2*exp(x))]
     s = dsolve(e)
     solves(s, e)
     assert s == s1
@@ -127,7 +127,6 @@ def test_dsolve_linear_2eq_order1_diag_triangular():
     assert s == s1
 
 
-@XFAIL
 def test_sysode_linear_2eq_order1_type1_D_lt_0():
     e = [Eq(diff(f(x), x), -9*I*f(x) - 4*g(x)),
          Eq(diff(g(x), x), -4*I*g(x))]
@@ -135,7 +134,6 @@ def test_sysode_linear_2eq_order1_type1_D_lt_0():
     solves(s, e)
 
 
-@XFAIL
 def test_sysode_linear_2eq_order1_type1_D_lt_0_b_eq_0():
     e = [Eq(diff(f(x), x), -9*I*f(x)),
          Eq(diff(g(x), x), -4*I*g(x))]
@@ -340,9 +338,8 @@ def test_linear_3eq_order1_nonhomog():
     raises(NotImplementedError, lambda: dsolve(e))
 
 
-@XFAIL
 def test_linear_3eq_order1_diagonal():
-    # code makes assumptions about coefficients being nonzero, breaks when assumptions are not true
+    # older code made assumptions about coefficients being nonzero
     e = [Eq(diff(f(x), x), f(x)),
          Eq(diff(g(x), x), g(x)),
          Eq(diff(h(x), x), h(x))]
@@ -2650,6 +2647,8 @@ def test_issue_7093():
 def test_dsolve_linsystem_symbol():
     eps = Symbol('epsilon', positive=True)
     eq1 = (Eq(diff(f(x), x), -eps*g(x)), Eq(diff(g(x), x), eps*f(x)))
-    sol1 = [Eq(f(x), -eps*(C1*sin(eps*x) + C2*cos(eps*x))),
-            Eq(g(x), C1*eps*cos(eps*x) - C2*eps*sin(eps*x))]
-    assert dsolve(eq1) == sol1
+    sol1 = [Eq(f(x), C1*cos(eps*x) - C2*sin(eps*x)),
+            Eq(g(x), C2*cos(eps*x) + C1*sin(eps*x))]
+    s = dsolve(eq1)
+    solves(s, eq1)
+    assert s == sol1


### PR DESCRIPTION
Solving systems of equations is a mess: lots of things silently give wrong answers.  Here's my slow attempts to clean it up.
- [ ] current implementation uses formulas that assume e.g., bits are nonzero.
- [x] above "fixed" for "type1".
- [ ] actually there are other cases in type1
- [x] fixes to "linear_2eq_order1_type2".
- [ ] nonhomog/forcings/rhs are almost totally ignored
- [x] nonhomog silently ignored given wrong answers
- [ ] nonhomog in `..._2eq_...order2`, as above.
- [ ] All of the above for 3x3 and nxn systems.
- [ ] Wrong statements in docs.

Instead---or as well as---I want:
- [x] expm/jordan solver
- [ ] which special case real jordan blocks for real matrices (get sin/cos pairs)
- [x] fix #9274
- [ ] decide whether I trust the jordan code after seeing (#9274).

I reserve the right to frequently rebasing ;-)
