### PR TITLE
Fix Non-general conversions in acosh

### DIFF
--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -919,15 +919,8 @@ class acosh(Function):
                     return cst_table[arg]*S.ImaginaryUnit
                 return cst_table[arg]
 
-        if arg is S.ComplexInfinity:
+        if arg.is_infinite:
             return S.Infinity
-
-        else:
-            i_coeff = arg.as_coefficient(S.ImaginaryUnit)
-            if i_coeff is not None:
-                if _coeff_isneg(i_coeff):
-                    return S.ImaginaryUnit * acos(i_coeff)
-                return S.ImaginaryUnit * acos(-i_coeff)
 
     @staticmethod
     @cacheit

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -475,6 +475,9 @@ def test_acosh():
     assert acosh((sqrt(5) + 1)/4) == I*pi/5
     assert acosh(-(sqrt(5) + 1)/4) == 4*I*pi/5
 
+    assert str(acosh(5*I).n(6)) == '2.31244 + 1.5708*I'
+    assert str(acosh(-5*I).n(6)) == '2.31244 - 1.5708*I'
+
 
 def test_acosh_infinities():
     assert acosh(oo) == oo


### PR DESCRIPTION
Currently `acosh()` have some non-general conversions, due to which it renders some wrong results.

The following is non-general:

``` python
In [10]: acosh(I*x)
Out[10]: I*acos(-x)

In [11]: acosh(-I*x)
Out[11]: I*acos(-x)

```

**Wrong Numerical Results**

``` python
In [5]: acosh(-5*I).n(5)
Out[5]: 2.2924 + 3.1416*I

In [6]: acosh(5*I).n(5)
Out[6]: 2.2924 + 3.1416*I

```

**References**:
1. WolframAlpha Results:
   - [`ArcCosh(-5*I)`](http://www.wolframalpha.com/input/?i=ArcCosh%28-5i%29)
   - [`ArcCosh(5*I)`](http://www.wolframalpha.com/input/?i=ArcCosh%285i%29)
   - [`I*ArcCos(-5)`](http://www.wolframalpha.com/input/?i=iArcCos%28-5%29)
2. StackOverflow: http://stackoverflow.com/questions/4788411/how-to-ask-mathematica-to-convert-arccosh-to-arccos
3. http://www.math10.com/en/algebra/hyperbolic-functions/hyperbolic-functions.html

@smichr  @asmeurer  Please have a look.
