### PR TITLE
Trace: doit should pass on the kwargs

### DIFF
--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -39,7 +39,7 @@ class Trace(Expr):
 
     def doit(self, **kwargs):
         if kwargs.get('deep', True):
-            arg = self.arg.doit()
+            arg = self.arg.doit(**kwargs)
         else:
             arg = self.arg
         try:


### PR DESCRIPTION
This is a minor change that I missed in a previous commit
(9a9c64d8d56c60010a402eacb2dc93d940663546)
