### PR TITLE
parser: Added support for parsing `=` in parse_expr.

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -701,6 +701,72 @@ def rationalize(tokens, local_dict, global_dict):
     return result
 
 
+def _transform_equals_sign(tokens, local_dict, global_dict):
+    """Transforms the equals sign ``=`` to instances of Eq.
+
+    This is a helper function for `convert_equals_signs`.
+    Works with expressions containing one equals sign and no
+    nesting. Expressions like `(1=2)=False` won't work with this
+    and should be used with `convert_equals_signs`.
+
+    Examples: 1=2     to Eq(1,2)
+              1*2=x   to Eq(1*2, x)
+
+    This does not deal with function arguments yet.
+
+    """
+    result = []
+    if (OP, "=") in tokens:
+        result.append((NAME, "Eq"))
+        result.append((OP, "("))
+        for index, token in enumerate(tokens):
+            if token == (OP, "="):
+                result.append((OP, ","))
+                continue
+            result.append(token)
+        result.append((OP, ")"))
+    else:
+        result = tokens
+    return result
+
+
+def convert_equals_signs(result, local_dict, global_dict):
+    """ Transforms all the equals signs ``=`` to instances of Eq.
+
+    Parses the equals signs in the expression and replaces them with
+    appropriate Eq instances.Also works with nested equals signs.
+
+    Does not yet play well with function arguments.
+    For example, the expression `(x=y)` is ambiguous and can be interpreted
+    as x being an argument to a function and `convert_equals_signs` won't
+    work for this.
+
+    See also
+    ========
+    convert_equality_operators
+
+    Examples:
+    =========
+
+    >>> from sympy.parsing.sympy_parser import (parse_expr,
+    ... standard_transformations, convert_equals_signs)
+    >>> parse_expr("1*2=x", transformations=(
+    ... standard_transformations + (convert_equals_signs,)))
+    Eq(2, x)
+    >>> parse_expr("(1*2=x)=False", transformations=(
+    ... standard_transformations + (convert_equals_signs,)))
+    Eq(Eq(2, x), False)
+
+    """
+    for step in (_group_parentheses(convert_equals_signs),
+                  _apply_functions,
+                  _transform_equals_sign):
+        result = step(result, local_dict, global_dict)
+
+    result = _flatten(result)
+    return result
+
+
 #: Standard transformations for :func:`parse_expr`.
 #: Inserts calls to :class:`Symbol`, :class:`Integer`, and other SymPy
 #: datatypes and allows the use of standard factorial notation (e.g. ``x!``).

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -1,4 +1,4 @@
-from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow
+from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq
 from sympy.functions import exp, factorial, sin
 from sympy.logic import And
 from sympy.series import Limit
@@ -6,7 +6,7 @@ from sympy.utilities.pytest import raises
 
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError,
-    split_symbols, implicit_multiplication,
+    split_symbols, implicit_multiplication, convert_equals_signs,
 )
 
 
@@ -116,3 +116,13 @@ def test_match_parentheses_implicit_multiplication():
     transformations = standard_transformations + \
                       (implicit_multiplication,)
     raises(TokenError, lambda: parse_expr('(1,2),(3,4]',transformations=transformations))
+
+def test_convert_equals_signs():
+    transformations = standard_transformations + \
+                        (convert_equals_signs, )
+    x = Symbol('x')
+    y = Symbol('y')
+    assert parse_expr("1*2=x", transformations=transformations) == Eq(2, x)
+    assert parse_expr("y = x", transformations=transformations) == Eq(y, x)
+    assert parse_expr("(2*y = x) = False",
+        transformations=transformations) == Eq(Eq(2*y, x), False)


### PR DESCRIPTION
Wrote a transformer function `convert_equals_signs`
which when passed to `parse_expr` as a transformation parses
expressions containing `=` and returns instances of Eq. Also
wrote some tests for said transformation.

Example:

```
>>> from sympy.parsing.sympy_parser import (parse_expr,
... standard_transformations,
... convert_equals_signs)
>>> t = standard_transformations + (convert_equals_signs,)
>>> parse_expr("1=x", transformations=t)
Eq(1, x)
```

Fixes #8844.
There has been some discussion about this feature and whether 
this should be added or not in #9026. I felt that creating a different pull
request was the logical thing to do, because `=` was blocking the 
other feature from being merged.
