### PR TITLE
fixes #7183: rewrite as sqrt, fibonacci(n) and lucas(n)

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -19,6 +19,7 @@ from sympy.functions.combinatorial.factorials import binomial, factorial
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.trigonometric import sin, cos, cot
+from sympy.functions.elementary.miscellaneous import sqrt
 
 from mpmath import bernfrac, workprec
 from mpmath.libmp import ifib as _ifib
@@ -111,6 +112,9 @@ class fibonacci(Function):
                        "only for positive integer indices.")
                 return cls._fibpoly(n).subs(_sym, sym)
 
+    def _eval_rewrite_as_sqrt(self, n):
+        return 2**(-n)*sqrt(5)*((1 + sqrt(5))**n - (-sqrt(5) + 1)**n) / 5
+
 
 class lucas(Function):
     """
@@ -151,6 +155,8 @@ class lucas(Function):
         if n.is_Integer:
             return fibonacci(n + 1) + fibonacci(n - 1)
 
+    def _eval_rewrite_as_sqrt(self, n):
+        return 2**(-n)*((1 + sqrt(5))**n + (-sqrt(5) + 1)**n)
 
 #----------------------------------------------------------------------------#
 #                                                                            #

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -65,6 +65,13 @@ def test_fibonacci():
     assert fibonacci(n).limit(n, S.Infinity) == S.Infinity
     assert lucas(n).limit(n, S.Infinity) == S.Infinity
 
+    assert fibonacci(n).rewrite(sqrt) == \
+        2**(-n)*sqrt(5)*((1 + sqrt(5))**n - (-sqrt(5) + 1)**n) / 5
+    assert fibonacci(n).rewrite(sqrt).subs(n, 10).expand() == fibonacci(10)
+    assert lucas(n).rewrite(sqrt) == \
+        (fibonacci(n-1).rewrite(sqrt) + fibonacci(n+1).rewrite(sqrt)).simplify()
+    assert lucas(n).rewrite(sqrt).subs(n, 10).expand() == lucas(10)
+
 
 def test_bell():
     assert [bell(n) for n in range(8)] == [1, 1, 2, 5, 15, 52, 203, 877]


### PR DESCRIPTION
`Fibonacci` and `Lucas` can now be rewritten using `sqrt`.

```
>>> fibonacci(n).rewrite(sqrt)
2**(-n)*sqrt(5)*((1 + sqrt(5))**n - (-sqrt(5) + 1)**n) / 5
>>> lucas(n).rewrite(sqrt)
2**(-n)*((1 + sqrt(5))**n + (-sqrt(5) + 1)**n)
```

Fixes #7183
