### PR TITLE
Completing ring_series 

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -419,21 +419,22 @@ def rs_integrate(self, x):
     return p1
 
 def fun(p, f, *args):
-    """function of a multivariate series computed by substitution
+    """
+    Function of a multivariate series computed by substitution
 
-      p multivariate series
-      f method name or function
+      p: multivariate series
+      f: method name or function
       args[:-2] arguments of f, apart from the first one
-      args[-2] = iv names of the series variables
-      args[-1] = prec list of the precisions of the series variables
+      args[-2] = iv: names of the series variables
+      args[-1] = prec: list of the precisions of the series variables
 
     The case with f method name is used to compute tan and nth_root
     of a multivariate series:
 
-      p.fun('tan', iv, prec)
+      fun(p, tan, iv, prec)
       compute _x.tan(iv, prec), then substitute _x with p
 
-      p.fun('nth_root', n, iv, prec)
+      fun(p, nth_root, n, iv, prec)
       compute (_x + p[0]).nth_root(n, '_x', prec)), then substitute _x
       with p - p[0]
 
@@ -441,10 +442,10 @@ def fun(p, f, *args):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x, y = lgens('x, y', QQ)
+    >>> from sympy.polys.rings import ring
+    >>> R, x, y = ring('x, y', QQ)
     >>> p = x + x*y + x**2*y + x**3*y**2
-    >>> p.fun('_tan1', 'x', 4)
+    >>> fun(p, _tan1, 'x', 4)
     1/3*x**3*y**3 + 2*x**3*y**2 + x**3*y + 1/3*x**3 + x**2*y + x*y + x
     """
     _ring = p.ring

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -419,58 +419,60 @@ def rs_integrate(self, x):
     return p1
 
 def fun(p, f, *args):
-        """Function of a multivariate series computed by substitution
+    """
+    Function of a multivariate series computed by substitution
 
-          p: multivariate series
-          f: method name or function
-          args[:-2]: arguments of f, apart from the first one
-          args[-2] = iv: names of the series variables
-          args[-1] = prec: list of the precisions of the series variables
+      p: multivariate series
+      f: method name or function
+      args[:-2]: arguments of f, apart from the first one
+      args[-2] = iv: names of the series variables
+      args[-1] = prec: list of the precisions of the series variables
 
-        The case with f method name is used to compute tan and nth_root
-        of a multivariate series:
+    The case with f method name is used to compute tan and nth_root
+    of a multivariate series:
 
-          fun(p, 'tan', iv, prec)
-          compute tan(_x, iv, prec), then substitute _x with p
+      fun(p, 'tan', iv, prec)
+      compute tan(_x, iv, prec), then substitute _x with p
 
-          fun(p, 'nth_root', n, iv, prec)
-          compute (_x + p[0]).nth_root(n, '_x', prec)), then substitute _x
-          with p - p[0]
+      fun(p, 'nth_root', n, iv, prec)
+      compute (_x + p[0]).nth_root(n, '_x', prec)), then substitute _x
+      with p - p[0]
 
-        Examples
-        ========
+    Examples
+    ========
 
-        >>> from sympy.polys.domains import QQ
-        >>> from sympy.polys.lpoly import lgens
-        >>> lp, x, y = lgens('x, y', QQ)
-        >>> p = x + x*y + x**2*y + x**3*y**2
-        >>> p.fun('_tan1', 'x', 4)
-        1/3*x**3*y**3 + 2*x**3*y**2 + x**3*y + 1/3*x**3 + x**2*y + x*y + x
-        """
-        ring = p.ring
-        ring1, _x = ring([_x], ring.ring, ring.order)
-        h = int(args[-1])
-        args1 = args[:-2] + ('_x', h)
-        zm = ring1(0)
-        # separate the constant term of the series
-        # compute the univariate series f(_x, .., 'x', sum(nv))
-        # or _x.f(..., 'x', sum(nv)
-        if zm in p:
-            x1 = _x + p[zm]
-            p1 = p - p[zm]
-        else:
-            x1 = _x
-            p1 = p
-        if isinstance(f, str):
-            q = getattr(x1, f)(*args1)
-        else:
-            q = f(x1, *args1)
-        a = sorted(q.iteritems())
-        c = [0]*h
-        for x in a:
-            c[x[0][0]] = x[1]
-        p1 = _series_from_list(p, c, args[-2], args[-1])
-        return p1
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import fun
+    >>> R, x, y = ring('x, y', QQ)
+    >>> p = x + x*y + x**2*y + x**3*y**2
+    >>> fun(p, '_tan1', 'x', 4)
+    1/3*x**3*y**3 + 2*x**3*y**2 + x**3*y + 1/3*x**3 + x**2*y + x*y + x
+    """
+    ring = p.ring
+    ring1, _x = ring([_x], ring.ring, ring.order)
+    h = int(args[-1])
+    args1 = args[:-2] + ('_x', h)
+    zm = ring1(0)
+    # separate the constant term of the series
+    # compute the univariate series f(_x, .., 'x', sum(nv))
+    # or _x.f(..., 'x', sum(nv)
+    if zm in p:
+        x1 = _x + p[zm]
+        p1 = p - p[zm]
+    else:
+        x1 = _x
+        p1 = p
+    if isinstance(f, str):
+        q = getattr(x1, f)(*args1)
+    else:
+        q = f(x1, *args1)
+    a = sorted(q.iteritems())
+    c = [0]*h
+    for x in a:
+        c[x[0][0]] = x[1]
+    p1 = _series_from_list(p, c, args[-2], args[-1])
+    return p1
 
 def rs_log(p, x, prec):
     """
@@ -555,15 +557,17 @@ def _atan_series(p, iv, prec):
     return s
 
 def rs_atan(p, x, prec):
-    """arctangent of a series
+    """
+    arctangent of a series
 
     Examples
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.atan(x, 8)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_atan
+    >>> R, x = ring('x', QQ)
+    >>> rs_atan(x, x, 8)
     -1/7*x**7 + 1/5*x**5 - 1/3*x**3 + x
     """
     if _has_constant_term(p, x):
@@ -579,6 +583,10 @@ def rs_atan(p, x, prec):
         return _atan_series(p, x, prec)
 
 def _tan1(p, x, prec):
+    """
+    Helper function of ``rs_tan``
+    """
+
     ring = p.ring
     p1 = ring(0)
     for precx in _giant_steps(prec):
@@ -588,15 +596,17 @@ def _tan1(p, x, prec):
     return p1
 
 def rs_tan(p, x, prec):
-    """tangent of a series
+    """
+    Tangent of a series
 
     Examples
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.tan(x, 8)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_tan
+    >>> R, x = ring('x', QQ)
+    >>> rs_tan(x, x, 8)
     17/315*x**7 + 2/15*x**5 + 1/3*x**3 + x
     """
     ring = p.ring
@@ -609,13 +619,15 @@ def rs_tan(p, x, prec):
 def rs_sin(p, x, prec):
     """
     sine of a series
+
     Examples
     ========
 
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
-    >>> lp, x = lgens('x', QQ)
-    >>> x.sin(x, 6)
+    >>> from sympy.polys.ring_series import rs_sin
+    >>> R, x = ring('x', QQ)
+    >>> rs_sin(x, x, 6)
     1/120*x**5 - 1/6*x**3 + x
     """
     ring = x.ring

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -514,91 +514,6 @@ def mul_xin(p, i, n):
         q[tuple(k1)] = v
     return q
 
-#TODO Needs to be fixed
-"""
-def nth_root(p, n, iv, prec):
-    
-    Multivariate series of nth root of p
-    Computes p**(1/n)
-
-    n: Integer
-    iv: List of variable names or variable indices
-    prec: List of truncations for these variables
-
-    In the case of one variable it can also be used as:
-
-    iv: Variable name or variable index (0)
-    prec: Truncation value for the variable
-
-    p is a series with O(x_1**n_1*..x_m**n_m) in
-    variables x_k with index or name iv[k - 1]
-
-    Examples
-    ========
-
-    >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x, y = lgens('x, y', QQ)
-    >>> (1 + x + x*y).nth_root(-3, x, 3)
-    2/9*x**2*y**2 + 4/9*x**2*y + 2/9*x**2 - 1/3*x*y - 1/3*x + 1
-   
-    if n == 0:
-        if p == 0:
-            raise ValueError('0**0 expression')
-        else:
-            return p.ring(1)
-    if n == 1:
-        return rs_trunc(p, iv, prec)
-    ring = p.ring
-    ii = ring.gens.index(iv)
-    m = min(p, key=lambda k: k[ii])[ii]
-    try:
-        mq, mr = divmod(m, n)
-    except TypeError:
-        if not gmpy_mode:
-            raise ValueError
-    if mr:
-        raise TaylorEvalError('Not analytic in the series variable')
-    p = mul_xin(p, ii, -m)
-    prec -= mq
-    if _has_constant_term(p-1, iv):
-        if ring.zero_monom in p:
-            c = p[ring.zero_monom]
-    #####
-            if isinstance(c, PythonRationalType):
-                c1 = Rational(c.p, c.q)
-                cn = Pow(c1, S.One/n)
-            else:
-                cn = Pow(c, S.One/n)
-            if cn.is_Rational:
-                if not lp.SR:
-                    cn = lp.ring(cn.p, cn.q)
-                res = cn*(p/c).nth_root(n, iv, prec)
-                if mq:
-                    res = res.mul_xin(iv, mq)
-                return res
-        if not lp.SR:
-            raise TaylorEvalError('p - 1 must not have a constant term in the series variables')
-        else:
-            if lp.zero_mon in p:
-                c = p[lp.zero_mon]
-                if c.is_positive:
-                    res = (p/c).nth_root(n, iv, prec)*c**Rational(1, n)
-                    if mq:
-                        res = res.mul_xin(iv, mq)
-                    return res
-                else:
-                    raise NotImplementedError
-    if lp.commuting and lp.ngens == 1:
-        res = p._nth_root1(n, iv, prec)
-    else:
-        res = p.fun('_nth_root1', n, iv, prec)
-    if mq:
-        res = res.mul_xin(ii, mq)
-    return res
-#######
-"""
-
 def rs_log(p, x, prec):
     """
     logarithm of ``p`` modulo ``O(x**prec)``
@@ -629,8 +544,8 @@ def rs_log(p, x, prec):
 
 def rs_LambertW(p, iv, prec):
     """
-    Calculates the series expansion of principal branch of the Lambert W function. For further
-    imformation, refer to the doc of LambertW function.
+    Calculates the series expansion of principal branch of the Lambert W
+    function. For further imformation, refer to the doc of LambertW function.
 
     Examples
     ========
@@ -702,46 +617,6 @@ def rs_exp(p, x, prec):
     r = rs_series_from_list(p, c, x, prec)
     return r
 
-#TODO
-#Ucomment after fixing nth_root
-"""
-def asin(p, iv, prec):
-    
-    arcsine of a series
-
-    Examples
-    ========
-
-    >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.rings import ring
-    >>> from sympy.polys.ring_series import rs_asin
-    >>> R, x = ring('x', QQ)
-    >>> rs_asin(x, x, 8)
-    5/112*x**7 + 3/40*x**5 + 1/6*x**3 + x
-    
-    if _has_constant_term(p, iv):
-        raise NotImplementedError('Polynomial must not have constant term in \
-              the series variables')
-    ring = p.ring
-    if iv in ring.gens:
-        # get a good value
-        if len(p) > 20:
-            dp = p.diff(iv)
-            p1 = 1 - rs_square(p, iv, prec - 1)
-           ##### p1 = p1.nth_root(-2, iv, prec - 1)
-            p1 = rs_mul(dp, p1, iv, prec - 1)
-            return rs_integrate(p1, iv)
-        one = ring(1)
-        c = [0, one, 0]
-        for k in range(3, prec, 2):
-            c.append((k - 2)**2*c[-2]/(k*(k - 1)))
-            c.append(0)
-        return rs_series_from_list(p, c, iv, prec)
-
-    else:
-        raise NotImplementedError
-
-"""
 def _atan_series(p, iv, prec):
     ring = p.ring
     mo = ring(-1)
@@ -900,41 +775,11 @@ def rs_cos_sin(p, iv, prec):
     return (rs_mul(p1, 1 - t2, iv, prec), rs_mul(p1, 2*t, iv, prec))
 
 def check_series_var(p, iv):
-    # TODO 
+    # TODO
     #Double check whether an error needs to be raised
     ii = p.ring.gens.index(iv)
     m = min(p, key=lambda k: k[ii])[ii]
     return ii, m
-
-def rs_cot(p, iv, prec):
-    """
-    cotangent of a series
-
-    Examples
-    ========
-
-    >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.rings import ring
-    >>> from sympy.polys.ring_series import rs_cot
-    >>> R, x = ring('x', QQ)
-    >>> rs_cot(x, x, 6)
-    -2/945*x**5 - 1/45*x**3 - 1/3*x + x**-1
-    """
-
-    # i, m = p.check_series_var(iv, PoleError, 'cot')
-    # TODO Raising error Probably not needed
-    # TODO Error in series_inversion in multivariate case
-    i, m = check_series_var(p, iv)
-    # see _taylor_term1 comment  sin(x**m) = x**pw*sin(x**m)/x**n0
-    # prec1 = prec + pw + n0, with pw = n0 = m
-    prec1 = prec + 2*m
-    c, s = rs_cos_sin(p, iv, prec1)
-    s = mul_xin(s, i, -1)
-    s = rs_series_inversion(s, iv, prec1)
-    res = rs_mul(c, s, iv, prec1)
-    res = mul_xin(res, i, -1)
-    res = rs_trunc(res, iv, prec)
-    return res
 
 def _atanh(p, iv, prec):
     ring = p.ring

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -399,10 +399,11 @@ def rs_diff(p, x):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x, y = lgens('x, y', QQ)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_diff
+    >>> R, x, y = ring('x, y', QQ)
     >>> p = x + x**2*y**3
-    >>> p.diff(x)
+    >>> rs_diff(p, x)
     2*x*y**3 + 1
     """
     ring = p.ring
@@ -513,8 +514,10 @@ def mul_xin(p, i, n):
         q[tuple(k1)] = v
     return q
 
+#TODO Needs to be fixed
+"""
 def nth_root(p, n, iv, prec):
-    """
+    
     Multivariate series of nth root of p
     Computes p**(1/n)
 
@@ -538,7 +541,7 @@ def nth_root(p, n, iv, prec):
     >>> lp, x, y = lgens('x, y', QQ)
     >>> (1 + x + x*y).nth_root(-3, x, 3)
     2/9*x**2*y**2 + 4/9*x**2*y + 2/9*x**2 - 1/3*x*y - 1/3*x + 1
-    """
+   
     if n == 0:
         if p == 0:
             raise ValueError('0**0 expression')
@@ -594,6 +597,7 @@ def nth_root(p, n, iv, prec):
         res = res.mul_xin(ii, mq)
     return res
 #######
+"""
 
 def rs_log(p, x, prec):
     """
@@ -632,9 +636,10 @@ def rs_LambertW(p, iv, prec):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.lambert(x, 8)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_LambertW
+    >>> R, x = ring('x', QQ)
+    >>> rs_LambertW(x, x, 8)
     16807/720*x**7 - 54/5*x**6 + 125/24*x**5 - 8/3*x**4 + 3/2*x**3 - x**2 + x
     """
     ring = p.ring
@@ -697,19 +702,23 @@ def rs_exp(p, x, prec):
     r = rs_series_from_list(p, c, x, prec)
     return r
 
+#TODO
+#Ucomment after fixing nth_root
+"""
 def asin(p, iv, prec):
-    """
+    
     arcsine of a series
 
     Examples
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.asin(x, 8)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_asin
+    >>> R, x = ring('x', QQ)
+    >>> rs_asin(x, x, 8)
     5/112*x**7 + 3/40*x**5 + 1/6*x**3 + x
-    """
+    
     if _has_constant_term(p, iv):
         raise NotImplementedError('Polynomial must not have constant term in \
               the series variables')
@@ -732,6 +741,7 @@ def asin(p, iv, prec):
     else:
         raise NotImplementedError
 
+"""
 def _atan_series(p, iv, prec):
     ring = p.ring
     mo = ring(-1)
@@ -847,9 +857,10 @@ def rs_cos(p, iv, prec):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.cos(x, 6)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_cos
+    >>> R, x = ring('x', QQ)
+    >>> rs_cos(x, x, 6)
     1/24*x**4 - 1/2*x**2 + 1
     """
     ring = p.ring
@@ -903,14 +914,15 @@ def rs_cot(p, iv, prec):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.cot(x, 6)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_cot
+    >>> R, x = ring('x', QQ)
+    >>> rs_cot(x, x, 6)
     -2/945*x**5 - 1/45*x**3 - 1/3*x + x**-1
     """
 
     # i, m = p.check_series_var(iv, PoleError, 'cot')
-    # TODO Raisine error Probably not needed
+    # TODO Raising error Probably not needed
     # TODO Error in series_inversion in multivariate case
     i, m = check_series_var(p, iv)
     # see _taylor_term1 comment  sin(x**m) = x**pw*sin(x**m)/x**n0
@@ -918,7 +930,6 @@ def rs_cot(p, iv, prec):
     prec1 = prec + 2*m
     c, s = rs_cos_sin(p, iv, prec1)
     s = mul_xin(s, i, -1)
-    print(s)
     s = rs_series_inversion(s, iv, prec1)
     res = rs_mul(c, s, iv, prec1)
     res = mul_xin(res, i, -1)
@@ -944,9 +955,10 @@ def rs_atanh(p, iv, prec):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.atanh(x, 8)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_atanh
+    >>> R, x = ring('x', QQ)
+    >>> rs_atanh(x, x, 8)
     1/7*x**7 + 1/5*x**5 + 1/3*x**3 + x
     """
     if _has_constant_term(p, iv):
@@ -970,10 +982,10 @@ def rs_sinh(p, iv, prec):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> p = x.sinh(x, 8)
-    >>> p
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_sinh
+    >>> R, x = ring('x', QQ)
+    >>> rs_sinh(x, x, 8)
     1/5040*x**7 + 1/120*x**5 + 1/6*x**3 + x
     """
     #self.check_series_var(iv, NotImplementedError, 'sinh')
@@ -989,9 +1001,10 @@ def rs_cosh(p, iv, prec):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.cosh(x, 8)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_cosh
+    >>> R, x = ring('x', QQ)
+    >>> rs_cosh(x, x, 8)
     1/720*x**6 + 1/24*x**4 + 1/2*x**2 + 1
     """
     #p.check_series_var(iv, NotImplementedError, 'cosh')
@@ -1016,9 +1029,10 @@ def rs_tanh(p, iv, prec):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.lpoly import lgens
-    >>> lp, x = lgens('x', QQ)
-    >>> x.tanh(x, 8)
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_tanh
+    >>> R, x = ring('x', QQ)
+    >>> rs_tanh(x, x, 8)
     -17/315*x**7 + 2/15*x**5 - 1/3*x**3 + x
     """
     ring = p.ring

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -622,6 +622,8 @@ def rs_exp(p, x, prec):
     r = rs_series_from_list(p, c, x, prec)
     return r
 
+# TODO
+# Needs to be benchmarked before use in rs_atan
 def _atan_series(p, iv, prec):
     ring = p.ring
     mo = ring(-1)
@@ -662,18 +664,24 @@ def rs_atan(p, x, prec):
     # Instead of using a closed form formula, we differentiate atan(p) to get
     # `1/(1+p**2) * dp`, whose series expansion is much easier to calculate.
     # Finally we integrate to get back atan
-    if x in ring.gens:
-        dp = p.diff(x)
-        p1 = rs_square(p, x, prec) + ring(1)
-        p1 = rs_series_inversion(p1, x, prec - 1)
-        p1 = rs_mul(dp, p1, x, prec - 1)
-        return rs_integrate(p1, x)
-    else:
-        return _atan_series(p, x, prec)
+    dp = p.diff(x)
+    p1 = rs_square(p, x, prec) + ring(1)
+    p1 = rs_series_inversion(p1, x, prec - 1)
+    p1 = rs_mul(dp, p1, x, prec - 1)
+    return rs_integrate(p1, x)
 
 def _tan1(p, x, prec):
     """
     Helper function of ``rs_tan``
+
+    Returns the series expansion of tan of a univariate series using Newton's
+    method. It takes advantage of the fact that series expansion of atan is
+    easier than that of tan.
+
+    Consider `f(x) = y - atan(x)`
+    Let r be a root of f(x) found using Newton's method.
+    Then `f(r) = 0`
+    Or `y  = atan(x)` where `x = tan(y)` as required.
     """
     ring = p.ring
     p1 = ring(0)
@@ -818,6 +826,8 @@ def check_series_var(p, iv):
     m = min(p, key=lambda k: k[ii])[ii]
     return ii, m
 
+# TODO
+# Needs to be benchmarked before use in rs_atanh
 def _atanh(p, iv, prec):
     ring = p.ring
     one = ring(1)
@@ -858,14 +868,11 @@ def rs_atanh(p, iv, prec):
     # Instead of using a closed form formula, we differentiate atanh(p) to get
     # `1/(1-p**2) * dp`, whose series expansion is much easier to calculate.
     # Finally we integrate to get back atanh
-    if iv in ring.gens:
-        dp = rs_diff(p, iv)
-        p1 = - rs_square(p, iv, prec) + 1
-        p1 = rs_series_inversion(p1, iv, prec - 1)
-        p1 = rs_mul(dp, p1, iv, prec - 1)
-        return rs_integrate(p1, iv)
-    else:
-        return _atanh(iv, prec)
+    dp = rs_diff(p, iv)
+    p1 = - rs_square(p, iv, prec) + 1
+    p1 = rs_series_inversion(p1, iv, prec - 1)
+    p1 = rs_mul(dp, p1, iv, prec - 1)
+    return rs_integrate(p1, iv)
 
 def rs_sinh(p, iv, prec):
     """
@@ -920,6 +927,18 @@ def rs_cosh(p, iv, prec):
     return (t + t1)/2
 
 def _tanh(p, iv, prec):
+    """
+    Helper function of ``rs_tanh``
+
+    Returns the series expansion of tanh of a univariate series using Newton's
+    method. It takes advantage of the fact that series expansion of atanh is
+    easier than that of tanh.
+
+    See Also
+    ========
+
+    _tanh
+    """
     ring = p.ring
     p1 = ring(0)
     for precx in _giant_steps(prec):

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -581,13 +581,13 @@ def rs_atan(p, x, prec):
 def _tan1(p, x, prec):
     ring = p.ring
     p1 = ring(0)
-    for precx in giant_steps(prec):
-        tmp = p - p1.rs_atan(x, precx)
-        tmp = tmp.rs_mul(1 + p1.rs_square(), x, precx)
+    for precx in _giant_steps(prec):
+        tmp = p - rs_atan(p1, x, precx)
+        tmp = rs_mul(tmp, 1 + p1.square(), x, precx)
         p1 += tmp
     return p1
 
-def tan(p, x, prec):
+def rs_tan(p, x, prec):
     """tangent of a series
 
     Examples
@@ -606,7 +606,7 @@ def tan(p, x, prec):
         return _tan1(p, x, prec)
     return fun(p, 'tan', x, prec)
 
-def sin(p, x, prec):
+def rs_sin(p, x, prec):
     """
     sine of a series
     Examples
@@ -619,32 +619,24 @@ def sin(p, x, prec):
     1/120*x**5 - 1/6*x**3 + x
     """
     ring = x.ring
-    #if not p:
-    #    return lp(0)
-    if _.has_constant_term(p, x):
+    if not p:
+        return ring(0)
+    if _has_constant_term(p, x):
         raise NotImplementedError
-       # if not lp.SR:
-       #     raise TaylorEvalError
-       # zm = lp.zero_mon
-       # c = p[zm]
-        #if c.is_number and not c.is_real:
-        #    raise TaylorEvalError
-        #p1 = p - c
-        #return sympy.functions.cos(c)*p1.sin(iv, prec) + sympy.functions.sin(c)*p1.cos(iv, prec)
     # get a good value
     if len(p) > 20 and p.ngens == 1:
-        t = (p/2).tan(iv, prec)
-        t2 = t.square_trunc(iv, prec)
-        p1 = (1 + t2).series_inversion(iv, prec)
-        return p1.mul_trunc(2*t, iv, prec)
-    one = lp.ring(1)
+        t = rs_tan(p/2, x, prec)
+        t2 = rs_square(t, x, prec)
+        p1 = rs_series_inversion(1 + t2, x, prec)
+        return rs_mul(p1, 2*t, x, prec)
+    one = ring(1)
     n = 1
     c = [0]
     for k in range(2, prec + 2, 2):
         c.append(one/n)
         c.append(0)
         n *= -k*(k + 1)
-    return p.series_from_list(c, iv, prec)
+    return rs_series_from_list(p, c, x, prec)
 
 def rs_newton(p, x, prec):
     """

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1,7 +1,7 @@
 """Power series manipulating functions acting on polys.ring.PolyElement()"""
 
 from sympy.polys.domains import QQ
-from sympy.polys.rings import PolyElement
+from sympy.polys.rings import PolyElement, ring
 from sympy.polys.monomials import monomial_min, monomial_mul
 from mpmath.libmp.libintmath import ifac
 from sympy.core.numbers import Rational
@@ -419,22 +419,21 @@ def rs_integrate(self, x):
     return p1
 
 def fun(p, f, *args):
-    """
-    Function of a multivariate series computed by substitution
+    """function of a multivariate series computed by substitution
 
-      p: multivariate series
-      f: method name or function
-      args[:-2]: arguments of f, apart from the first one
-      args[-2] = iv: names of the series variables
-      args[-1] = prec: list of the precisions of the series variables
+      p multivariate series
+      f method name or function
+      args[:-2] arguments of f, apart from the first one
+      args[-2] = iv names of the series variables
+      args[-1] = prec list of the precisions of the series variables
 
     The case with f method name is used to compute tan and nth_root
     of a multivariate series:
 
-      fun(p, 'tan', iv, prec)
-      compute tan(_x, iv, prec), then substitute _x with p
+      p.fun('tan', iv, prec)
+      compute _x.tan(iv, prec), then substitute _x with p
 
-      fun(p, 'nth_root', n, iv, prec)
+      p.fun('nth_root', n, iv, prec)
       compute (_x + p[0]).nth_root(n, '_x', prec)), then substitute _x
       with p - p[0]
 
@@ -442,18 +441,17 @@ def fun(p, f, *args):
     ========
 
     >>> from sympy.polys.domains import QQ
-    >>> from sympy.polys.rings import ring
-    >>> from sympy.polys.ring_series import fun
-    >>> R, x, y = ring('x, y', QQ)
+    >>> from sympy.polys.lpoly import lgens
+    >>> lp, x, y = lgens('x, y', QQ)
     >>> p = x + x*y + x**2*y + x**3*y**2
-    >>> fun(p, '_tan1', 'x', 4)
+    >>> p.fun('_tan1', 'x', 4)
     1/3*x**3*y**3 + 2*x**3*y**2 + x**3*y + 1/3*x**3 + x**2*y + x*y + x
     """
-    ring = p.ring
-    ring1, _x = ring([_x], ring.ring, ring.order)
+    _ring = p.ring
+    ring1, _x = ring('_x', _ring)
     h = int(args[-1])
-    args1 = args[:-2] + ('_x', h)
-    zm = ring1(0)
+    args1 = args[:-2] + (_x, h)
+    zm = _ring.zero_monom
     # separate the constant term of the series
     # compute the univariate series f(_x, .., 'x', sum(nv))
     # or _x.f(..., 'x', sum(nv)
@@ -471,7 +469,7 @@ def fun(p, f, *args):
     c = [0]*h
     for x in a:
         c[x[0][0]] = x[1]
-    p1 = _series_from_list(p, c, args[-2], args[-1])
+    p1 = rs_series_from_list(p1, c, args[-2], args[-1])
     return p1
 
 def rs_log(p, x, prec):
@@ -614,7 +612,7 @@ def rs_tan(p, x, prec):
         raise NotImplementedError('p must not have constant part in series variables')
     if ring.ngens == 1:
         return _tan1(p, x, prec)
-    return fun(p, 'tan', x, prec)
+    return fun(p, rs_tan, x, prec)
 
 def rs_sin(p, x, prec):
     """

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -836,7 +836,7 @@ def rs_cos(p, iv, prec):
         t = rs_tan(p/2, iv, prec)
         t2 = rs_square(t, iv, prec)
         p1 = rs_series_inversion(1+t2, iv, prec)
-        return rs_mul_trunc([p1 ,1 - t2, iv, prec)
+        return rs_mul(p1 ,1 - t2, iv, prec)
     one = ring(1)
     n = 1
     c = []
@@ -878,16 +878,18 @@ def rs_cot(p, iv, prec):
     """
 
     # i, m = p.check_series_var(iv, PoleError, 'cot')
-    # Probably not needed
+    # TODO Raisine error Probably not needed
+    # TODO Error in series_inversion in multivariate case
     i, m = check_series_var(p, iv)
     # see _taylor_term1 comment  sin(x**m) = x**pw*sin(x**m)/x**n0
     # prec1 = prec + pw + n0, with pw = n0 = m
     prec1 = prec + 2*m
     c, s = rs_cos_sin(p, iv, prec1)
     s = mul_xin(s, i, -1)
+    print(s)
     s = rs_series_inversion(s, iv, prec1)
     res = rs_mul(c, s, iv, prec1)
-    res = rs_mul(res, i, -1)
+    res = mul_xin(res, i, -1)
     res = rs_trunc(res, iv, prec)
     return res
 
@@ -989,7 +991,7 @@ def tanh(p, iv, prec):
     ring = p.ring
     if _has_constant_term(p, iv):
         raise NotImplementedError('Polynomial must not have constant term in the series variables')
-    if and ring.ngens == 1:
+    if ring.ngens == 1:
         return _tanh(p, iv, prec)
     return fun(p, '_tanh', iv, prec)
 

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -4,12 +4,13 @@ from sympy.polys.monomials import monomial_min, monomial_mul, monomial_div
 from mpmath.libmp.libintmath import ifac
 from sympy.core.numbers import Rational
 from sympy.core.compatibility import as_int, range
+from sympy.core import S
 from mpmath.libmp.libintmath import giant_steps
 import math
 
 def _invert_monoms(p1):
     """
-    Compute ``x**n * p1(1/x)`` for ``p1`` univariate polynomial.
+    Compute ``x**n * p1(1/x)`` for a univariate polynomial ``p1`` in x.
 
     Examples
     ========
@@ -24,6 +25,7 @@ def _invert_monoms(p1):
 
     See Also
     ========
+
     sympy.polys.densebasic.dup_reverse
 
     """
@@ -40,7 +42,7 @@ def _invert_monoms(p1):
 
 def _giant_steps(target):
     """
-    list of precision steps for the Newton's method
+    Return a list of precision steps for the Newton's method
 
     """
     res = giant_steps(2, target)
@@ -51,7 +53,7 @@ def _giant_steps(target):
 def rs_trunc(p1, x, prec):
     """
     Truncate the series in the ``x`` variable with precision ``prec``,
-    that is modulo ``O(x**prec)``
+    that is, modulo ``O(x**prec)``
 
     Examples
     ========
@@ -66,7 +68,6 @@ def rs_trunc(p1, x, prec):
     >>> rs_trunc(p, x, 10)
     x**5 + x + 1
     """
-
     ring = p1.ring
     p = ring.zero
     i = ring.gens.index(x)
@@ -78,7 +79,7 @@ def rs_trunc(p1, x, prec):
 
 def rs_mul(p1, p2, x, prec):
     """
-    Product of the given two series, modulo ``O(x**prec)``
+    Return the product of the given two series, modulo ``O(x**prec)``
 
     ``x`` is the series variable or its position in the generators.
 
@@ -94,7 +95,6 @@ def rs_mul(p1, p2, x, prec):
     >>> rs_mul(p1, p2, x, 3)
     3*x**2 + 3*x + 1
     """
-
     ring = p1.ring
     p = ring.zero
     if ring.__class__ != p2.ring.__class__ or ring != p2.ring:
@@ -130,7 +130,7 @@ def rs_mul(p1, p2, x, prec):
 
 def rs_square(p1, x, prec):
     """
-    square modulo ``O(x**prec)``
+    Square the series modulo ``O(x**prec)``
 
     Examples
     ========
@@ -243,7 +243,7 @@ def _has_constant_term(p, x):
 
 def _series_inversion1(p, x, prec):
     """
-    univariate series inversion ``1/p`` modulo ``O(x**prec)``
+    Univariate series inversion ``1/p`` modulo ``O(x**prec)``
 
     The Newton method is used.
 
@@ -278,7 +278,7 @@ def _series_inversion1(p, x, prec):
 
 def rs_series_inversion(p, x, prec):
     """
-    multivariate series inversion ``1/p`` modulo ``O(x**prec)``
+    Multivariate series inversion ``1/p`` modulo ``O(x**prec)``
 
     Examples
     ========
@@ -306,11 +306,11 @@ def rs_series_inversion(p, x, prec):
 
 def rs_series_from_list(p, c, x, prec, concur=1):
     """
-    series ``sum c[n]*p**n`` modulo ``O(x**prec)``
+    Return a series ``sum c[n]*p**n`` modulo ``O(x**prec)``
 
-    reduce the number of multiplication summing concurrently
+    It reduces the number of multiplications by summing concurrently
     ``ax = [1, p, p**2, .., p**(J - 1)]``
-    ``s = sum(c[i]*ax[i] for i in range(r, (r + 1)*J))*p**((K - 1)*J)``
+    ``s = sum(c[i]*ax[i] for i in range(r, (r + 1)*J)) * p**((K - 1)*J)``
     with ``K >= (n + 1)/J``
 
     Examples
@@ -332,10 +332,10 @@ def rs_series_from_list(p, c, x, prec, concur=1):
 
     See Also
     ========
+
     sympy.polys.ring.compose
 
     """
-
     ring = p.ring
     n = len(c)
     if not concur:
@@ -391,9 +391,9 @@ def rs_series_from_list(p, c, x, prec, concur=1):
 
 def rs_diff(p, x):
     """
-    Computes partial derivative of p with respect to n
+    Computes partial derivative of p with respect to x
 
-      `n`: variable with respect to which p is differentiated,
+      `x`: variable with respect to which p is differentiated,
 
     Examples
     ========
@@ -418,9 +418,9 @@ def rs_diff(p, x):
             p1[e] = p[expv]*expv[n]
     return p1
 
-def rs_integrate(self, x):
+def rs_integrate(p, x):
     """
-    integrate ``p`` with respect to ``x``
+    Integrate ``p`` with respect to ``x``
 
     Examples
     ========
@@ -433,16 +433,16 @@ def rs_integrate(self, x):
     >>> rs_integrate(p, x)
     1/3*x**3*y**3 + 1/2*x**2
     """
-    ring = self.ring
+    ring = p.ring
     p1 = ring.zero
     n = ring.gens.index(x)
     mn = [0]*ring.ngens
     mn[n] = 1
     mn = tuple(mn)
 
-    for expv in self:
+    for expv in p:
         e = monomial_mul(expv, mn)
-        p1[e] = self[expv]/(expv[n] + 1)
+        p1[e] = p[expv]/(expv[n] + 1)
     return p1
 
 def fun(p, f, *args):
@@ -458,7 +458,7 @@ def fun(p, f, *args):
     The case with f method name is used to compute tan and nth_root
     of a multivariate series:
 
-      fun(p, tan, iv, prec):
+      fun(p, tan, iv, prec)
       tan series is first computed for a dummy variable _x, ie, tan(_x, iv, prec)
       Then we substitute _x with p to get the desired series
 
@@ -472,6 +472,7 @@ def fun(p, f, *args):
     >>> p = x + x*y + x**2*y + x**3*y**2
     >>> fun(p, _tan1, x, 4)
     1/3*x**3*y**3 + 2*x**3*y**2 + x**3*y + 1/3*x**3 + x**2*y + x*y + x
+
     """
     _ring = p.ring
     ring1, _x = ring('_x', _ring)
@@ -502,9 +503,8 @@ def mul_xin(p, i, n):
     """
     Computes p*x_i**n
 
-    x_i is the ith variable
+    x_i is the ith variable in p
     """
-
     n = as_int(n)
     ring = p.ring
     q = ring(0)
@@ -516,7 +516,7 @@ def mul_xin(p, i, n):
 
 def rs_log(p, x, prec):
     """
-    logarithm of ``p`` modulo ``O(x**prec)``
+    The Logarithm of ``p`` modulo ``O(x**prec)``
 
     Notes
     =====
@@ -544,8 +544,8 @@ def rs_log(p, x, prec):
 
 def rs_LambertW(p, iv, prec):
     """
-    Calculates the series expansion of principal branch of the Lambert W
-    function. For further imformation, refer to the doc of LambertW function.
+    Calculates the series expansion of the principal branch of the Lambert W
+    function.
 
     Examples
     ========
@@ -556,6 +556,11 @@ def rs_LambertW(p, iv, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_LambertW(x, x, 8)
     16807/720*x**7 - 54/5*x**6 + 125/24*x**5 - 8/3*x**4 + 3/2*x**3 - x**2 + x
+
+    See Also
+    ========
+
+    LambertW
     """
     ring = p.ring
     p1 = ring(0)
@@ -576,7 +581,7 @@ def rs_LambertW(p, iv, prec):
 
 def _exp1(p, x, prec):
     """
-    helper function for ``rs_exp``
+    Helper function for ``rs_exp``
     """
     ring = p.ring
     p1 = ring(1)
@@ -588,7 +593,7 @@ def _exp1(p, x, prec):
 
 def rs_exp(p, x, prec):
     """
-    exponentiation of a series modulo ``O(x**prec)``
+    Exponentiation of a series modulo ``O(x**prec)``
 
     Examples
     ========
@@ -630,7 +635,9 @@ def _atan_series(p, iv, prec):
 
 def rs_atan(p, x, prec):
     """
-    arctangent of a series
+    The arctangent of a series
+
+    Returns the series expansion of the atan of p, about 0.
 
     Examples
     ========
@@ -641,11 +648,20 @@ def rs_atan(p, x, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_atan(x, x, 8)
     -1/7*x**7 + 1/5*x**5 - 1/3*x**3 + x
+
+    See Also
+    ========
+
+    atan
     """
     if _has_constant_term(p, x):
         raise NotImplementedError('Polynomial must not have constant term in \
               the series variables')
     ring = p.ring
+
+    # Instead of using a closed form formula, we differentiate atan(p) to get
+    # `1/(1+p**2) * dp`, whose series expansion is much easier to calculate.
+    # Finally we integrate to get back atan
     if x in ring.gens:
         dp = p.diff(x)
         p1 = rs_square(p, x, prec) + ring(1)
@@ -659,7 +675,6 @@ def _tan1(p, x, prec):
     """
     Helper function of ``rs_tan``
     """
-
     ring = p.ring
     p1 = ring(0)
     for precx in _giant_steps(prec):
@@ -672,6 +687,8 @@ def rs_tan(p, x, prec):
     """
     Tangent of a series
 
+    Returns the series expansion of the tan of p, about 0.
+
     Examples
     ========
 
@@ -681,7 +698,12 @@ def rs_tan(p, x, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_tan(x, x, 8)
     17/315*x**7 + 2/15*x**5 + 1/3*x**3 + x
-    """
+
+   See Also
+   ========
+
+   tan
+   """
     ring = p.ring
     if _has_constant_term(p, x):
         raise NotImplementedError('Polynomial must not have constant term in \
@@ -692,7 +714,9 @@ def rs_tan(p, x, prec):
 
 def rs_sin(p, x, prec):
     """
-    sine of a series
+    Sine of a series
+
+    Returns the series expansion of the sin of p, about 0.
 
     Examples
     ========
@@ -703,13 +727,19 @@ def rs_sin(p, x, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_sin(x, x, 6)
     1/120*x**5 - 1/6*x**3 + x
+
+    See Also
+    ========
+
+    sin
     """
     ring = x.ring
     if not p:
         return ring(0)
+    # Support for constant term can be extended on the lines of rs_cos
     if _has_constant_term(p, x):
         raise NotImplementedError
-    # get a good value
+    # Series is calcualed in terms of tan as its evaluation is fast.
     if len(p) > 20 and p.ngens == 1:
         t = rs_tan(p/2, x, prec)
         t2 = rs_square(t, x, prec)
@@ -726,7 +756,9 @@ def rs_sin(p, x, prec):
 
 def rs_cos(p, iv, prec):
     """
-    cosine of a series
+    Cosine of a series
+
+    Returns the series expansion of the cos of p, about 0.
 
     Examples
     ========
@@ -737,19 +769,26 @@ def rs_cos(p, iv, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_cos(x, x, 6)
     1/24*x**4 - 1/2*x**2 + 1
+
+    See Also
+    ========
+
+    cos
     """
     ring = p.ring
     if _has_constant_term(p, iv):
         zm = ring.zero_monom
-        #if not lp.SR:    Needs to be checked
-        #    raise TaylorEvalError
-        c = p[zm]
+        c = S(p[zm])
         if not c.is_real:
             raise NotImplementedError
         p1 = p - c
-        return sympy.functions.cos(c)*p1.cos(iv, prec) - \
-                sympy.functions.sin(c)*p1.sin(iv, prec)
-    # get a good value
+
+    # Makes use of sympy cos, sin fuctions to evaluate the values of the cos/sin
+    # of the constant term. Should it be left unevaluated?
+        from sympy.functions import cos, sin
+        return cos(c)*rs_cos(p1, iv, prec) -  sin(c)*rs_sin(p1, iv, prec)
+
+    # Series is calculated in terms of tan as its evaluation is fast.
     if len(p) > 20 and ring.ngens == 1:
         t = rs_tan(p/2, iv, prec)
         t2 = rs_square(t, iv, prec)
@@ -775,8 +814,6 @@ def rs_cos_sin(p, iv, prec):
     return (rs_mul(p1, 1 - t2, iv, prec), rs_mul(p1, 2*t, iv, prec))
 
 def check_series_var(p, iv):
-    # TODO
-    #Double check whether an error needs to be raised
     ii = p.ring.gens.index(iv)
     m = min(p, key=lambda k: k[ii])[ii]
     return ii, m
@@ -796,6 +833,8 @@ def rs_atanh(p, iv, prec):
     """
     Hyperbolic arctangent of a series
 
+    Returns the series expansion of the atanh of p, about 0.
+
     Examples
     ========
 
@@ -805,11 +844,20 @@ def rs_atanh(p, iv, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_atanh(x, x, 8)
     1/7*x**7 + 1/5*x**5 + 1/3*x**3 + x
+
+    See Also
+    ========
+
+    atanh
     """
     if _has_constant_term(p, iv):
         raise NotImplementedError('Polynomial must not have constant term in \
               the series variables')
     ring = p.ring
+
+    # Instead of using a closed form formula, we differentiate atanh(p) to get
+    # `1/(1-p**2) * dp`, whose series expansion is much easier to calculate.
+    # Finally we integrate to get back atanh
     if iv in ring.gens:
         dp = rs_diff(p, iv)
         p1 = - rs_square(p, iv, prec) + 1
@@ -823,6 +871,8 @@ def rs_sinh(p, iv, prec):
     """
     Hyperbolic sine of a series
 
+    Returns the series expansion of the sinh of p, about 0.
+
     Examples
     ========
 
@@ -832,8 +882,13 @@ def rs_sinh(p, iv, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_sinh(x, x, 8)
     1/5040*x**7 + 1/120*x**5 + 1/6*x**3 + x
+
+    See Also
+    ========
+
+    sinh
     """
-    #self.check_series_var(iv, NotImplementedError, 'sinh')
+    # Check for negative exponent
     t = rs_exp(p, iv, prec)
     t1 = rs_series_inversion(t, iv, prec)
     return (t - t1)/2
@@ -841,6 +896,8 @@ def rs_sinh(p, iv, prec):
 def rs_cosh(p, iv, prec):
     """
     Hyperbolic cosine of a series
+
+    Returns the series expansion of the cosh of p, about 0.
 
     Examples
     ========
@@ -851,8 +908,13 @@ def rs_cosh(p, iv, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_cosh(x, x, 8)
     1/720*x**6 + 1/24*x**4 + 1/2*x**2 + 1
+
+    See Also
+    ========
+
+    cosh
     """
-    #p.check_series_var(iv, NotImplementedError, 'cosh')
+    # Check for negative exponent
     t = rs_exp(p, iv, prec)
     t1 = rs_series_inversion(t, iv, prec)
     return (t + t1)/2
@@ -870,6 +932,8 @@ def rs_tanh(p, iv, prec):
     """
     Hyperbolic tangent of a series
 
+    Returns the series expansion of the tanh of p, about 0.
+
     Examples
     ========
 
@@ -879,6 +943,11 @@ def rs_tanh(p, iv, prec):
     >>> R, x = ring('x', QQ)
     >>> rs_tanh(x, x, 8)
     -17/315*x**7 + 2/15*x**5 - 1/3*x**3 + x
+
+    See Also
+    ========
+
+    tanh
     """
     ring = p.ring
     if _has_constant_term(p, iv):
@@ -912,7 +981,7 @@ def rs_newton(p, x, prec):
 
 def rs_hadamard_exp(p1, inverse=False):
     """
-    return ``sum f_i/i!*x**i`` from ``sum f_i*x**i``,
+    Return ``sum f_i/i!*x**i`` from ``sum f_i*x**i``,
     where ``x`` is the first variable.
 
     If ``invers=True`` return ``sum f_i*i!*x**i``

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -553,9 +553,9 @@ def rs_LambertW(p, iv, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_LambertW
-    >>> R, x = ring('x', QQ)
-    >>> rs_LambertW(x, x, 8)
-    16807/720*x**7 - 54/5*x**6 + 125/24*x**5 - 8/3*x**4 + 3/2*x**3 - x**2 + x
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_LambertW(x + x*y, x, 3)
+    -x**2*y**2 - 2*x**2*y - x**2 + x*y + x
 
     See Also
     ========
@@ -645,9 +645,9 @@ def rs_atan(p, x, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_atan
-    >>> R, x = ring('x', QQ)
-    >>> rs_atan(x, x, 8)
-    -1/7*x**7 + 1/5*x**5 - 1/3*x**3 + x
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_atan(x + x*y, x, 4)
+    -1/3*x**3*y**3 - x**3*y**2 - x**3*y - 1/3*x**3 + x*y + x
 
     See Also
     ========
@@ -695,9 +695,9 @@ def rs_tan(p, x, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_tan
-    >>> R, x = ring('x', QQ)
-    >>> rs_tan(x, x, 8)
-    17/315*x**7 + 2/15*x**5 + 1/3*x**3 + x
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_tan(x + x*y, x, 4)
+    1/3*x**3*y**3 + x**3*y**2 + x**3*y + 1/3*x**3 + x*y + x
 
    See Also
    ========
@@ -724,9 +724,9 @@ def rs_sin(p, x, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_sin
-    >>> R, x = ring('x', QQ)
-    >>> rs_sin(x, x, 6)
-    1/120*x**5 - 1/6*x**3 + x
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_sin(x + x*y, x, 4)
+    -1/6*x**3*y**3 - 1/2*x**3*y**2 - 1/2*x**3*y - 1/6*x**3 + x*y + x
 
     See Also
     ========
@@ -766,9 +766,9 @@ def rs_cos(p, iv, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_cos
-    >>> R, x = ring('x', QQ)
-    >>> rs_cos(x, x, 6)
-    1/24*x**4 - 1/2*x**2 + 1
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_cos(x + x*y, x, 4)
+    -1/2*x**2*y**2 - x**2*y - 1/2*x**2 + 1
 
     See Also
     ========
@@ -841,9 +841,9 @@ def rs_atanh(p, iv, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_atanh
-    >>> R, x = ring('x', QQ)
-    >>> rs_atanh(x, x, 8)
-    1/7*x**7 + 1/5*x**5 + 1/3*x**3 + x
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_atanh(x + x*y, x, 4)
+    1/3*x**3*y**3 + x**3*y**2 + x**3*y + 1/3*x**3 + x*y + x
 
     See Also
     ========
@@ -879,9 +879,9 @@ def rs_sinh(p, iv, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_sinh
-    >>> R, x = ring('x', QQ)
-    >>> rs_sinh(x, x, 8)
-    1/5040*x**7 + 1/120*x**5 + 1/6*x**3 + x
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_sinh(x + x*y, x, 4)
+    1/6*x**3*y**3 + 1/2*x**3*y**2 + 1/2*x**3*y + 1/6*x**3 + x*y + x
 
     See Also
     ========
@@ -905,9 +905,9 @@ def rs_cosh(p, iv, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_cosh
-    >>> R, x = ring('x', QQ)
-    >>> rs_cosh(x, x, 8)
-    1/720*x**6 + 1/24*x**4 + 1/2*x**2 + 1
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_cosh(x + x*y, x, 4)
+    1/2*x**2*y**2 + x**2*y + 1/2*x**2 + 1
 
     See Also
     ========
@@ -940,9 +940,9 @@ def rs_tanh(p, iv, prec):
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
     >>> from sympy.polys.ring_series import rs_tanh
-    >>> R, x = ring('x', QQ)
-    >>> rs_tanh(x, x, 8)
-    -17/315*x**7 + 2/15*x**5 - 1/3*x**3 + x
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_tanh(x + x*y, x, 4)
+    -1/3*x**3*y**3 - x**3*y**2 - x**3*y - 1/3*x**3 + x*y + x
 
     See Also
     ========

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -431,21 +431,19 @@ def fun(p, f, *args):
     The case with f method name is used to compute tan and nth_root
     of a multivariate series:
 
-      fun(p, tan, iv, prec)
-      compute _x.tan(iv, prec), then substitute _x with p
-
-      fun(p, nth_root, n, iv, prec)
-      compute (_x + p[0]).nth_root(n, '_x', prec)), then substitute _x
-      with p - p[0]
+      fun(p, tan, iv, prec):
+      tan series is first computed for a dummy variable _x, ie, tan(_x, iv, prec)
+      Then we substitute _x with p to get the desired series
 
     Examples
     ========
 
     >>> from sympy.polys.domains import QQ
     >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import fun, _tan1
     >>> R, x, y = ring('x, y', QQ)
     >>> p = x + x*y + x**2*y + x**3*y**2
-    >>> fun(p, _tan1, 'x', 4)
+    >>> fun(p, _tan1, x, 4)
     1/3*x**3*y**3 + 2*x**3*y**2 + x**3*y + 1/3*x**3 + x**2*y + x*y + x
     """
     _ring = p.ring
@@ -466,7 +464,7 @@ def fun(p, f, *args):
         q = getattr(x1, f)(*args1)
     else:
         q = f(x1, *args1)
-    a = sorted(q.iteritems())
+    a = sorted(q.items())
     c = [0]*h
     for x in a:
         c[x[0][0]] = x[1]

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -3,7 +3,7 @@ from sympy.polys.rings import ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
   rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_series_inversion,
   rs_series_from_list, rs_exp, rs_log, rs_newton, rs_hadamard_exp,
-  rs_compose_add, rs_atan, rs_atanh, rs_tan, rs_cot, rs_sin, rs_cos, rs_cos_sin,
+  rs_compose_add, rs_atan, rs_atanh, rs_tan, rs_sin, rs_cos, rs_cos_sin,
   rs_sinh, rs_cosh, rs_tanh, _tan1, fun)
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -1,9 +1,9 @@
 from sympy.polys.domains import QQ
 from sympy.polys.rings import ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
-  rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term,
-  rs_series_inversion, rs_series_from_list, rs_exp, rs_log, rs_newton,
-  rs_hadamard_exp, rs_compose_add)
+  rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_series_inversion,
+  rs_series_from_list, rs_exp, rs_log, rs_newton, rs_hadamard_exp,
+  rs_compose_add, rs_atan, rs_tan, rs_sin, _tan1, fun)
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 
@@ -168,3 +168,33 @@ def test_compose_add():
     p1 = x**3 - 1
     p2 = x**2 - 2
     assert rs_compose_add(p1, p2) == x**6 - 6*x**4 - 2*x**3 + 12*x**2 - 12*x - 7
+
+def test_fun():
+    R, x, y = ring('x, y', QQ)
+    p = x*y + x**2*y**3 + x**5*y
+    assert fun(p, rs_tan, x, 10) == rs_tan(p, x, 10)
+    assert fun(p, _tan1, x, 10) == _tan1(p, x, 10)
+
+def test_atan():
+    R, x, y = ring('x, y', QQ)
+    assert rs_atan(x, x, 9) == -1/7*x**7 + 1/5*x**5 - 1/3*x**3 + x
+    assert rs_atan(x*y + x**2*y**3, x, 9) == 2*x**8*y**11 - x**8*y**9 + \
+        2*x**7*y**9 - 1/7*x**7*y**7 - 1/3*x**6*y**9 + x**6*y**7 - x**5*y**7 + \
+        1/5*x**5*y**5 - x**4*y**5 - 1/3*x**3*y**3 + x**2*y**3 + x*y
+
+def test_tan():
+    R, x, y = ring('x, y', QQ)
+    assert rs_tan(x, x, 9) == \
+        x + x**3/3 + 2*x**5/15 + 17*x**7/315
+    assert rs_tan(x*y + x**2*y**3, x, 9) == 4/3*x**8*y**11 + 17/45*x**8*y**9 + \
+        4/3*x**7*y**9 + 17/315*x**7*y**7 + 1/3*x**6*y**9 + 2/3*x**6*y**7 + \
+        x**5*y**7 + 2/15*x**5*y**5 + x**4*y**5 + 1/3*x**3*y**3 + x**2*y**3 + x*y
+
+def test_sin():
+    R, x, y = ring('x, y', QQ)
+    assert rs_sin(x, x, 9) == \
+        x - x**3/6 + x**5/120 - x**7/5040
+    assert rs_sin(x*y + x**2*y**3, x, 9) == 1/12*x**8*y**11 - \
+        1/720*x**8*y**9 + 1/12*x**7*y**9 - 1/5040*x**7*y**7 - 1/6*x**6*y**9 \
+        + 1/24*x**6*y**7 - 1/2*x**5*y**7 + 1/120*x**5*y**5 - 1/2*x**4*y**5 \
+        - 1/6*x**3*y**3 + x**2*y**3 + x*y

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -3,7 +3,8 @@ from sympy.polys.rings import ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
   rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_series_inversion,
   rs_series_from_list, rs_exp, rs_log, rs_newton, rs_hadamard_exp,
-  rs_compose_add, rs_atan, rs_tan, rs_sin, _tan1, fun)
+  rs_compose_add, rs_atan, rs_atanh, rs_tan, rs_cot, rs_sin, rs_cos, rs_cos_sin,
+  rs_sinh, rs_cosh, rs_tanh, _tan1, fun)
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 
@@ -217,22 +218,47 @@ def test_cos_sin():
     R, x, y = ring('x, y', QQ)
     cos, sin = rs_cos_sin(x, x, 9)
     assert cos == rs_cos(x, x, 9)
-    assert sin = rs_sin(x, x, 9)
+    assert sin == rs_sin(x, x, 9)
     cos, sin = rs_cos_sin(x + x*y, x, 5)
     assert cos == rs_cos(x + x*y, x, 5)
     assert sin == rs_sin(x + x*y, x, 5)
 
-def test_cot():
-    R, x, y = ring('x, y', QQ)
-    assert rs_cot(x, x, 9) == -1/4725*x**7 - 2/945*x**5 - 1/45*x**3 - \
-        1/3*x + x**-1
+#def test_cot():
+#    R, x, y = ring('x, y', QQ)
+#    assert rs_cot(x, x, 9) == -1/4725*x**7 - 2/945*x**5 - 1/45*x**3 - \
+#        1/3*x + x**-1
    #TODO
    # Add test  for multivariate expansion
+   # Output is a laurent series. Make appropriate changes
 
 def test_atanh():
+    R, x, y = ring('x, y', QQ)
+    assert rs_atanh(x, x, 9) == 1/7*x**7 + 1/5*x**5 + 1/3*x**3 + x
+    assert rs_atanh(x*y + x**2*y**3, x, 9) == 2*x**8*y**11 + x**8*y**9 + \
+        2*x**7*y**9 + 1/7*x**7*y**7 + 1/3*x**6*y**9 + x**6*y**7 + x**5*y**7 + \
+        1/5*x**5*y**5 + x**4*y**5 + 1/3*x**3*y**3 + x**2*y**3 + x*y
 
 def test_sinh():
+    R, x, y = ring('x, y', QQ)
+    assert rs_sinh(x, x, 9) == 1/5040*x**7 + 1/120*x**5 + 1/6*x**3 + x
+    assert rs_sinh(x*y + x**2*y**3, x, 9) == 1/12*x**8*y**11 + \
+        1/720*x**8*y**9 + 1/12*x**7*y**9 + 1/5040*x**7*y**7 + 1/6*x**6*y**9 + \
+        1/24*x**6*y**7 + 1/2*x**5*y**7 + 1/120*x**5*y**5 + 1/2*x**4*y**5 + \
+        1/6*x**3*y**3 + x**2*y**3 + x*y
 
 def test_cosh():
+    R, x, y = ring('x, y', QQ)
+    assert rs_cosh(x, x, 9) == 1/40320*x**8 + 1/720*x**6 + 1/24*x**4 + \
+        1/2*x**2 + 1
+    assert rs_cosh(x*y + x**2*y**3, x, 9) == 1/24*x**8*y**12 + \
+        1/48*x**8*y**10 + 1/40320*x**8*y**8 + 1/6*x**7*y**10 + \
+        1/120*x**7*y**8 + 1/4*x**6*y**8 + 1/720*x**6*y**6 + 1/6*x**5*y**6 + \
+        1/2*x**4*y**6 + 1/24*x**4*y**4 + x**3*y**4 + 1/2*x**2*y**2 + 1
 
 def test_tanh():
+    R, x, y = ring('x, y', QQ)
+    assert rs_tanh(x, x, 9) == -17/315*x**7 + 2/15*x**5 - 1/3*x**3 + x
+    assert rs_tanh(x*y + x**2*y**3 , x, 9) == 4/3*x**8*y**11 - \
+        17/45*x**8*y**9 + 4/3*x**7*y**9 - 17/315*x**7*y**7 - 1/3*x**6*y**9 + \
+        2/3*x**6*y**7 - x**5*y**7 + 2/15*x**5*y**5 - x**4*y**5 - \
+        1/3*x**3*y**3 + x**2*y**3 + x*y

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -156,7 +156,6 @@ def test_exp():
     p1 = rs_exp(p, x, prec)
     assert p1 == x + 1
 
-
 def test_newton():
     R, x = ring('x', QQ)
     p = x**2 - 2
@@ -200,11 +199,6 @@ def test_sin():
         + 1/24*x**6*y**7 - 1/2*x**5*y**7 + 1/120*x**5*y**5 - 1/2*x**4*y**5 \
         - 1/6*x**3*y**3 + x**2*y**3 + x*y
 
-#TODO
-#def test_nth_root()
-#def test_LambertW():
-#def test_asin():
-
 def test_cos():
     R, x, y = ring('x, y', QQ)
     assert rs_cos(x, x, 9) == \
@@ -222,14 +216,6 @@ def test_cos_sin():
     cos, sin = rs_cos_sin(x + x*y, x, 5)
     assert cos == rs_cos(x + x*y, x, 5)
     assert sin == rs_sin(x + x*y, x, 5)
-
-#def test_cot():
-#    R, x, y = ring('x, y', QQ)
-#    assert rs_cot(x, x, 9) == -1/4725*x**7 - 2/945*x**5 - 1/45*x**3 - \
-#        1/3*x + x**-1
-   #TODO
-   # Add test  for multivariate expansion
-   # Output is a laurent series. Make appropriate changes
 
 def test_atanh():
     R, x, y = ring('x, y', QQ)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -198,3 +198,41 @@ def test_sin():
         1/720*x**8*y**9 + 1/12*x**7*y**9 - 1/5040*x**7*y**7 - 1/6*x**6*y**9 \
         + 1/24*x**6*y**7 - 1/2*x**5*y**7 + 1/120*x**5*y**5 - 1/2*x**4*y**5 \
         - 1/6*x**3*y**3 + x**2*y**3 + x*y
+
+#TODO
+#def test_nth_root()
+#def test_LambertW():
+#def test_asin():
+
+def test_cos():
+    R, x, y = ring('x, y', QQ)
+    assert rs_cos(x, x, 9) == \
+        1/40320*x**8 - 1/720*x**6 + 1/24*x**4 - 1/2*x**2 + 1
+    assert rs_cos(x*y + x**2*y**3, x, 9) == 1/24*x**8*y**12 - \
+        1/48*x**8*y**10 + 1/40320*x**8*y**8 + 1/6*x**7*y**10 - \
+        1/120*x**7*y**8 + 1/4*x**6*y**8 - 1/720*x**6*y**6 + 1/6*x**5*y**6 \
+        - 1/2*x**4*y**6 + 1/24*x**4*y**4 - x**3*y**4 - 1/2*x**2*y**2 + 1
+
+def test_cos_sin():
+    R, x, y = ring('x, y', QQ)
+    cos, sin = rs_cos_sin(x, x, 9)
+    assert cos == rs_cos(x, x, 9)
+    assert sin = rs_sin(x, x, 9)
+    cos, sin = rs_cos_sin(x + x*y, x, 5)
+    assert cos == rs_cos(x + x*y, x, 5)
+    assert sin == rs_sin(x + x*y, x, 5)
+
+def test_cot():
+    R, x, y = ring('x, y', QQ)
+    assert rs_cot(x, x, 9) == -1/4725*x**7 - 2/945*x**5 - 1/45*x**3 - \
+        1/3*x + x**-1
+   #TODO
+   # Add test  for multivariate expansion
+
+def test_atanh():
+
+def test_sinh():
+
+def test_cosh():
+
+def test_tanh():


### PR DESCRIPTION
This PR ports part of #609. I have not yet added tests, but speed comparisons look very promising.

```
In [27]: %timeit t = rs_atan(x,x,500)
10 loops, best of 3: 41.4 ms per loop

In [28]: %timeit s= atan(z).series(z,0,500)
1 loops, best of 3: 9.89 s per loop

In [29]: %timeit t = rs_sin(x, x, 500)
100 loops, best of 3: 13.7 ms per loop

In [30]: %timeit s = sin(z).series(z, 0, 500)
1 loops, best of 3: 10 s per loop

In [17]: %timeit t = rs_tan(x, x, 100)
1 loops, best of 3: 178 ms per loop

In [18]: %timeit s = tan(z).series(z, 0, 100)
1 loops, best of 3: 1.68 s per loop
```

@certik @smichr @pernici Please review.
