### PR TITLE
codegen: generate Octave code for heaviside and dirac

### DIFF
--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -31,6 +31,8 @@ known_fcns_src2 = {
     "Abs": "abs",
     "ceiling": "ceil",
     "conjugate": "conj",
+    "DiracDelta": "dirac",
+    "Heaviside": "heaviside",
 }
 
 


### PR DESCRIPTION
On Octave, the resulting code will currently depend on the
"specfun" Octave-Forge package (from Octave command prompt:
"pkg install -forge specfun").  Eventually, support should land
in core Octave.

On Matlab, it will depend---for unknown reasons---on the Symbolic
Math Toolbox which provides @double/heaviside and @double/dirac.

I considered just generating inline vectorized one-liners for these
functions but I cannot figure out how to deal with NaN correctly
(`Heaviside(nan) -> nan`) when doing so.
