### PR TITLE
Fix unreferenced args in ReciprocalHyperbolicFunction Class

### DIFF
--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -670,10 +670,10 @@ class ReciprocalHyperbolicFunction(HyperbolicFunction):
         return (1/self._reciprocal_of(self.args[0]))._eval_as_leading_term(x)
 
     def _eval_is_real(self):
-        return self._reciprocal_of(args[0]).is_real
+        return self._reciprocal_of(self.args[0]).is_real
 
     def _eval_is_finite(self):
-        return (1/self._reciprocal_of(args[0])).is_finite
+        return (1/self._reciprocal_of(self.args[0])).is_finite
 
 
 class csch(ReciprocalHyperbolicFunction):

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -283,6 +283,7 @@ def test_csch():
     x, y = symbols('x,y')
 
     k = Symbol('k', integer=True)
+    n = Symbol('n', positive=True)
 
     assert csch(nan) == nan
     assert csch(zoo) == nan
@@ -334,6 +335,8 @@ def test_csch():
 
     assert csch(k*pi*I/2) == -1/sin(k*pi/2)*I
 
+    assert csch(n).is_real is True
+
 
 def test_csch_series():
     x = Symbol('x')
@@ -346,6 +349,7 @@ def test_sech():
     x, y = symbols('x, y')
 
     k = Symbol('k', integer=True)
+    n = Symbol('n', positive=True)
 
     assert sech(nan) == nan
     assert sech(zoo) == nan
@@ -393,6 +397,8 @@ def test_sech():
 
     assert sech(k*pi*I) == 1/cos(k*pi)
     assert sech(17*k*pi*I) == 1/cos(17*k*pi)
+
+    assert sech(n).is_real is True
 
 
 def test_sech_series():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -503,7 +503,7 @@ def test_solve_abs():
 def test_rewrite_trigh():
     # if this import passes then the test below should also pass
     from sympy import sech
-    assert solveset_real(sinh(x) + sech(x)) == FiniteSet(
+    assert solveset_real(sinh(x) + sech(x), x) == FiniteSet(
         2*atanh(-S.Half + sqrt(5)/2 - sqrt(-2*sqrt(5) + 2)/2),
         2*atanh(-S.Half + sqrt(5)/2 + sqrt(-2*sqrt(5) + 2)/2),
         2*atanh(-sqrt(5)/2 - S.Half + sqrt(2 + 2*sqrt(5))/2),


### PR DESCRIPTION
The XFAIL in solveset [here](https://github.com/sympy/sympy/blob/master/sympy/solvers/tests/test_solveset.py#L506), and it gave this error:

``` python
NameError: global name 'args' is not defined
```

Though this PR doesn't aims to un-XFAIL the mentioned  test in `solveset`, but it certainly fixes the two unreferenced args in `ReciprocalHyperbolicFunction` class.

@hargup  @jksuom 
