### PR TITLE
Make sympy.abc more understandable

### DIFF
--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -6,16 +6,17 @@ from .core import Symbol, symbols
 from .core.alphabets import greeks
 from .core.compatibility import exec_
 
-a, b, c, d, e = symbols('a, b, c, d, e')
-f, g, h, i, j = symbols('f, g, h, i, j')
-k, l, m, n, o = symbols('k, l, m, n, o')
-p, q, r, s, t = symbols('p, q, r, s, t')
+##### Symbol definitions #####
+
+# Implementation note: The easiest way to avoid typos in the symbols()
+# parameter is to copy it from the left-hand side of the assignment.
+
+a, b, c, d, e, f, g, h, i, j = symbols('a, b, c, d, e, f, g, h, i, j')
+k, l, m, n, o, p, q, r, s, t = symbols('k, l, m, n, o, p, q, r, s, t')
 u, v, w, x, y, z = symbols('u, v, w, x, y, z')
 
-A, B, C, D, E = symbols('A, B, C, D, E')
-F, G, H, I, J = symbols('F, G, H, I, J')
-K, L, M, N, O = symbols('K, L, M, N, O')
-P, Q, R, S, T = symbols('P, Q, R, S, T')
+A, B, C, D, E, F, G, H, I, J = symbols('A, B, C, D, E, F, G, H, I, J')
+K, L, M, N, O, P, Q, R, S, T = symbols('K, L, M, N, O, P, Q, R, S, T')
 U, V, W, X, Y, Z = symbols('U, V, W, X, Y, Z')
 
 alpha, beta, gamma, delta = symbols('alpha, beta, gamma, delta')
@@ -24,6 +25,12 @@ iota, kappa, lamda, mu = symbols('iota, kappa, lamda, mu')
 nu, xi, omicron, pi = symbols('nu, xi, omicron, pi')
 rho, sigma, tau, upsilon = symbols('rho, sigma, tau, upsilon')
 phi, chi, psi, omega = symbols('phi, chi, psi, omega')
+
+
+##### Clashing-symbols diagnostics #####
+
+# We want to know which names in SymPy collide with those in here.
+# This is mostly for diagnosing SymPy's namespace during SymPy development.
 
 _latin = list(string.ascii_letters)
 # COSINEQ should not be imported as they clash; gamma, pi and zeta clash, too

--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -2,9 +2,28 @@ from __future__ import print_function, division
 
 import string
 
-from .core import Symbol
+from .core import Symbol, symbols
 from .core.alphabets import greeks
 from .core.compatibility import exec_
+
+a, b, c, d, e = symbols('a, b, c, d, e')
+f, g, h, i, j = symbols('f, g, h, i, j')
+k, l, m, n, o = symbols('k, l, m, n, o')
+p, q, r, s, t = symbols('p, q, r, s, t')
+u, v, w, x, y, z = symbols('u, v, w, x, y, z')
+
+A, B, C, D, E = symbols('A, B, C, D, E')
+F, G, H, I, J = symbols('F, G, H, I, J')
+K, L, M, N, O = symbols('K, L, M, N, O')
+P, Q, R, S, T = symbols('P, Q, R, S, T')
+U, V, W, X, Y, Z = symbols('U, V, W, X, Y, Z')
+
+alpha, beta, gamma, delta = symbols('alpha, beta, gamma, delta')
+epsilon, zeta, eta, theta = symbols('epsilon, zeta, eta, theta')
+iota, kappa, lamda, mu = symbols('iota, kappa, lamda, mu')
+nu, xi, omicron, pi = symbols('nu, xi, omicron, pi')
+rho, sigma, tau, upsilon = symbols('rho, sigma, tau, upsilon')
+phi, chi, psi, omega = symbols('phi, chi, psi, omega')
 
 _latin = list(string.ascii_letters)
 # COSINEQ should not be imported as they clash; gamma, pi and zeta clash, too
@@ -12,9 +31,6 @@ _greek = list(greeks) # make a copy, so we can mutate it
 # Note: We import lamda since lambda is a reserved keyword in Python
 _greek.remove("lambda")
 _greek.append("lamda")
-
-for _s in _latin + _greek:
-    exec_("%s = Symbol('%s')" % (_s, _s))
 
 def clashing():
     """Return the clashing-symbols dictionaries.
@@ -62,4 +78,4 @@ def clashing():
 
 _clash1, _clash2, _clash = clashing()
 
-del _latin, _greek, _s, clashing, Symbol
+del _latin, _greek, clashing, Symbol


### PR DESCRIPTION
Generating symbols through the compiler is not understood by analysis tools,
so they will generate an error for every use of something imported from
sympy.abc.
