### PR TITLE
[skip ci] Amended the rest of whitespace to consistent form

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -118,9 +118,9 @@ def _af_parity(pi):
     ========
 
     >>> from sympy.combinatorics.permutations import _af_parity
-    >>> _af_parity([0,1,2,3])
+    >>> _af_parity([0, 1, 2, 3])
     0
-    >>> _af_parity([3,2,0,1])
+    >>> _af_parity([3, 2, 0, 1])
     1
 
     See Also
@@ -175,7 +175,7 @@ def _af_pow(a, n):
 
     >>> from sympy.combinatorics.permutations import Permutation, _af_pow
     >>> Permutation.print_cyclic = False
-    >>> p = Permutation([2,0,3,1])
+    >>> p = Permutation([2, 0, 3, 1])
     >>> p.order()
     4
     >>> _af_pow(p._array_form, 4)
@@ -219,7 +219,7 @@ def _af_commutes_with(a, b):
     ========
 
     >>> from sympy.combinatorics.permutations import _af_commutes_with
-    >>> _af_commutes_with([1,2,0], [0,2,1])
+    >>> _af_commutes_with([1, 2, 0], [0, 2, 1])
     False
 
     See Also
@@ -248,7 +248,7 @@ class Cycle(dict):
 
     The identity cycle, Cycle(), can be used to start a product:
 
-    >>> Cycle()(1, 2)(2,3)
+    >>> Cycle()(1, 2)(2, 3)
     Cycle(1, 3, 2)
 
     The array form of a Cycle can be obtained by calling the list
@@ -265,7 +265,7 @@ class Cycle(dict):
     provide the desired size -- but the Cycle cannot be truncated to
     a size smaller than the largest element that is out of place:
 
-    >>> b = Cycle(2,4)(1,2)(3,1,4)(1,3)
+    >>> b = Cycle(2, 4)(1, 2)(3, 1, 4)(1, 3)
     >>> b.list()
     [0, 2, 1, 3, 4]
     >>> b.list(b.size + 1)
@@ -284,7 +284,7 @@ class Cycle(dict):
     The array form can be used to instantiate a Permutation so other
     properties of the permutation can be investigated:
 
-    >>> Perm(Cycle(1,2)(3,4).list()).transpositions()
+    >>> Perm(Cycle(1, 2)(3, 4).list()).transpositions()
     [(1, 2), (3, 4)]
 
     Notes
@@ -939,12 +939,12 @@ class Permutation(Basic):
 
         >>> from sympy.combinatorics.permutations import Permutation
         >>> Permutation.print_cyclic = False
-        >>> p = Permutation([[2,0], [3,1]])
+        >>> p = Permutation([[2, 0], [3, 1]])
         >>> p.array_form
         [2, 3, 0, 1]
-        >>> Permutation([[2,0,3,1]]).array_form
+        >>> Permutation([[2, 0, 3, 1]]).array_form
         [3, 2, 0, 1]
-        >>> Permutation([2,0,3,1]).array_form
+        >>> Permutation([2, 0, 3, 1]).array_form
         [2, 0, 3, 1]
         >>> Permutation([[1, 2], [4, 5]]).array_form
         [0, 2, 1, 3, 5, 4]
@@ -1262,11 +1262,11 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> a = Permutation([1,4,3,0,2,5])
-        >>> b = Permutation([0,1,2,3,4,5])
+        >>> a = Permutation([1, 4, 3, 0, 2, 5])
+        >>> b = Permutation([0, 1, 2, 3, 4, 5])
         >>> a.commutes_with(b)
         True
-        >>> b = Permutation([2,3,5,4,1,0])
+        >>> b = Permutation([2, 3, 5, 4, 1, 0])
         >>> a.commutes_with(b)
         False
         """
@@ -1336,7 +1336,7 @@ class Permutation(Basic):
 
         The expression q^p^r is equivalent to q^(p*r):
 
-        >>> r = Permutation(9)(4,6,8)
+        >>> r = Permutation(9)(4, 6, 8)
         >>> q^p^r == q^(p*r)
         True
 
@@ -1494,7 +1494,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([[2,0], [3,1]])
+        >>> p = Permutation([[2, 0], [3, 1]])
         >>> p.array_form
         [2, 3, 0, 1]
         >>> [p(i) for i in range(4)]
@@ -1625,7 +1625,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2,3])
+        >>> p = Permutation([0, 1, 2, 3])
         >>> p.rank_nonlex()
         23
 
@@ -1724,7 +1724,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2,3])
+        >>> p = Permutation([0, 1, 2, 3])
         >>> p.cardinality
         24
 
@@ -1747,10 +1747,10 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2,3])
+        >>> p = Permutation([0, 1, 2, 3])
         >>> p.parity()
         0
-        >>> p = Permutation([3,2,0,1])
+        >>> p = Permutation([3, 2, 0, 1])
         >>> p.parity()
         1
 
@@ -1773,10 +1773,10 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2,3])
+        >>> p = Permutation([0, 1, 2, 3])
         >>> p.is_even
         True
-        >>> p = Permutation([3,2,1,0])
+        >>> p = Permutation([3, 2, 1, 0])
         >>> p.is_even
         True
 
@@ -1796,10 +1796,10 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2,3])
+        >>> p = Permutation([0, 1, 2, 3])
         >>> p.is_odd
         False
-        >>> p = Permutation([3,2,0,1])
+        >>> p = Permutation([3, 2, 0, 1])
         >>> p.is_odd
         True
 
@@ -1892,7 +1892,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([4,0,1,3,2])
+        >>> p = Permutation([4, 0, 1, 3, 2])
         >>> p.ascents()
         [1, 2]
 
@@ -1914,7 +1914,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([4,0,1,3,2])
+        >>> p = Permutation([4, 0, 1, 3, 2])
         >>> p.descents()
         [0, 3]
 
@@ -1935,7 +1935,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([1,0,2,3,4])
+        >>> p = Permutation([1, 0, 2, 3, 4])
         >>> p.max()
         1
 
@@ -1959,7 +1959,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,4,3,2])
+        >>> p = Permutation([0, 1, 4, 3, 2])
         >>> p.min()
         2
 
@@ -1995,10 +1995,10 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2,3,4,5])
+        >>> p = Permutation([0, 1, 2, 3, 4, 5])
         >>> p.inversions()
         0
-        >>> Permutation([3,2,1,0]).inversions()
+        >>> Permutation([3, 2, 1, 0]).inversions()
         6
 
         See Also
@@ -2090,7 +2090,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2])
+        >>> p = Permutation([0, 1, 2])
         >>> p.inversions()
         0
         >>> p.signature()
@@ -2238,7 +2238,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([2,5,7,3,6,0,1,4,8])
+        >>> p = Permutation([2, 5, 7, 3, 6, 0, 1, 4, 8])
         >>> p.runs()
         [[2, 5, 7], [3, 6], [0, 1, 4, 8]]
         >>> q = Permutation([1,3,2,0])
@@ -2308,10 +2308,10 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2,3])
+        >>> p = Permutation([0, 1, 2, 3])
         >>> p.rank_trotterjohnson()
         0
-        >>> p = Permutation([0,2,1,3])
+        >>> p = Permutation([0, 2, 1, 3])
         >>> p.rank_trotterjohnson()
         7
 
@@ -2440,7 +2440,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation.josephus(3,6,1)
+        >>> p = Permutation.josephus(3, 6, 1)
         >>> p
         Permutation([2, 5, 3, 1, 4, 0])
         >>> p.get_precedence_matrix()
@@ -2514,7 +2514,7 @@ class Permutation(Basic):
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation.josephus(3,6,1)
+        >>> p = Permutation.josephus(3, 6, 1)
         >>> p.get_adjacency_matrix()
         Matrix([
         [0, 0, 0, 0, 0, 0],


### PR DESCRIPTION
The whitespace consistency in permutations.py is now amended. Thanks.
