### PR TITLE
Tested Point3D

### DIFF
--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -54,7 +54,7 @@ class Plane(GeometryEntity):
             p2 = Point3D(a)
             p3 = Point3D(b)
             if Point3D.are_collinear(p1, p2, p3):
-                raise NotImplementedError('Enter three non-collinear points')
+                raise ValueError('Enter three non-collinear points')
             a = p1.direction_ratio(p2)
             b = p1.direction_ratio(p3)
             normal_vector = tuple(Matrix(a).cross(Matrix(b)))

--- a/sympy/geometry/point3d.py
+++ b/sympy/geometry/point3d.py
@@ -41,9 +41,9 @@ class Point3D(GeometryEntity):
 
     NotImplementedError
         When trying to create a point other than 2 or 3 dimensions.
-        When `intersection` is called with object other than a Point.
     TypeError
         When trying to add or subtract points with different dimensions.
+        When `intersection` is called with object other than a Point.
 
     Notes
     =====
@@ -77,8 +77,7 @@ class Point3D(GeometryEntity):
             if not eval:
                 return args[0]
             args = args[0].args
-        elif isinstance(args[0], Point):
-            args = args[0].args
+        # elif was satisfied by the initial if statement and thus redundant
         else:
             if iterable(args[0]):
                 args = args[0]
@@ -320,7 +319,7 @@ class Point3D(GeometryEntity):
                 for j in (0, 1, i):
                     points.pop(j)
                 return all(p.is_coplanar(i) for i in points)
-            except NotImplementedError:  # XXX should be ValueError
+            except ValueError:
                 pass
         raise ValueError('At least 3 non-collinear points needed to define plane.')
 
@@ -479,8 +478,7 @@ class Point3D(GeometryEntity):
         """
         if pt:
             pt = Point3D(pt)
-            return
-            self.translate(*(-pt).args).scale(x, y, z).translate(*pt.args)
+            return self.translate(*(-pt).args).scale(x, y, z).translate(*pt.args)
         return Point3D(self.x*x, self.y*y, self.z*z)
 
     def translate(self, x=0, y=0, z=0):
@@ -508,7 +506,7 @@ class Point3D(GeometryEntity):
 
     def transform(self, matrix):
         """Return the point after applying the transformation described
-        by the 3x3 Matrix, ``matrix``.
+        by the 4x4 Matrix, ``matrix``.
 
         See Also
         ========
@@ -516,8 +514,10 @@ class Point3D(GeometryEntity):
         geometry.entity.scale
         geometry.entity.translate
         """
+        from sympy.matrices.expressions import Transpose
         x, y, z = self.args
-        return Point3D(*(Matrix(1, 3, [x, y, z])*matrix).tolist()[0][:2])
+        m = Transpose(matrix)
+        return Point3D(*(Matrix(1, 4, [x, y, z, 1])*m).tolist()[0][:3])
 
     def dot(self, p2):
         """Return dot product of self with another Point."""

--- a/sympy/geometry/point3d.py
+++ b/sympy/geometry/point3d.py
@@ -77,7 +77,6 @@ class Point3D(GeometryEntity):
             if not eval:
                 return args[0]
             args = args[0].args
-        # elif was satisfied by the initial if statement and thus redundant
         else:
             if iterable(args[0]):
                 args = args[0]

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -14,7 +14,7 @@ from sympy.geometry.entity import rotate, scale, translate
 from sympy.geometry.polygon import _asa as asa, rad, deg
 from sympy.geometry.util import idiff, are_coplanar
 from sympy.integrals.integrals import Integral
-from sympy.matrices import Identity, Matrix
+from sympy.matrices import Matrix
 from sympy.solvers.solvers import solve
 from sympy.utilities.iterables import cartes
 from sympy.utilities.randtest import verify_numerically

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -14,6 +14,7 @@ from sympy.geometry.entity import rotate, scale, translate
 from sympy.geometry.polygon import _asa as asa, rad, deg
 from sympy.geometry.util import idiff, are_coplanar
 from sympy.integrals.integrals import Integral
+from sympy.matrices import *
 from sympy.solvers.solvers import solve
 from sympy.utilities.iterables import cartes
 from sympy.utilities.randtest import verify_numerically
@@ -230,6 +231,49 @@ def test_point3D():
     assert p.translate(1) == Point3D(2, 1, 1)
     assert p.translate(z=1) == Point3D(1, 1, 2)
     assert p.translate(*p.args) == Point3D(2, 2, 2)
+
+    # Test __new__
+    assert Point3D(Point3D(1, 2, 3), 4, 5, evaluate=False) ==  Point3D(1, 2, 3)
+
+
+    # Test length property returns correctly
+    assert p.length == 0
+    assert p1_1.length == 0
+    assert p1_2.length == 0
+
+    # Test are_colinear type error
+    raises(TypeError, lambda: Point3D.are_collinear(p, x))
+
+    # Test are_coplanar
+    planar2 = Point3D(1, -1, 1)
+    planar3 = Point3D(-1, 1, 1)
+    assert Point3D.are_coplanar(p, planar2, planar3) == True
+    assert Point3D.are_coplanar(p, planar2, planar3, p3) == False
+    raises(ValueError, lambda: Point3D.are_coplanar(p, planar2))
+    planar2 = Point3D(1, 1, 2)
+    planar3 = Point3D(1, 1, 3)
+    raises(ValueError, lambda: Point3D.are_coplanar(p, planar2, planar3))
+
+    # Test Intersection
+    assert planar2.intersection(Line3D(p, planar3)) == [Point3D(1, 1, 2)]
+
+    # Test Scale
+    assert planar2.scale(1, 1, 1) == planar2
+    assert planar2.scale(2, 2, 2, planar3) == Point3D(1, 1, 1)
+    assert planar2.scale(1, 1, 1, p3) == planar2
+
+    # Test Transform
+    identity = Matrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+    assert p.transform(identity) == p
+    trans = Matrix([[1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1], [0, 0, 0, 1]])
+    assert p.transform(trans) == Point3D(2, 2, 2)
+
+    # Test Equals
+    assert p.equals(x1) == False
+
+    # Test __sub__
+    p_2d = Point(0, 0)
+    raises(ValueError, lambda: (p - p_2d))
 
 
 def test_issue_9214():

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -14,7 +14,7 @@ from sympy.geometry.entity import rotate, scale, translate
 from sympy.geometry.polygon import _asa as asa, rad, deg
 from sympy.geometry.util import idiff, are_coplanar
 from sympy.integrals.integrals import Integral
-from sympy.matrices import *
+from sympy.matrices import Identity, Matrix
 from sympy.solvers.solvers import solve
 from sympy.utilities.iterables import cartes
 from sympy.utilities.randtest import verify_numerically
@@ -267,7 +267,7 @@ def test_point3D():
     assert p.transform(identity) == p
     trans = Matrix([[1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1], [0, 0, 0, 1]])
     assert p.transform(trans) == Point3D(2, 2, 2)
-    
+
     # Test Equals
     assert p.equals(x1) == False
 

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -267,7 +267,7 @@ def test_point3D():
     assert p.transform(identity) == p
     trans = Matrix([[1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1], [0, 0, 0, 1]])
     assert p.transform(trans) == Point3D(2, 2, 2)
-
+    
     # Test Equals
     assert p.equals(x1) == False
 


### PR DESCRIPTION
(in geometry/plane.py)
Changed the NotImplementedError for collinear points to a ValueError.

(in geometry/point3d.py)
Removed elif statement from Point3D constructor which was satisfied by the initial if statement.

Changed the NotImplementedError to TypeError in the are_coplanar function, as suggested by comments.

Fixed a bug in the scale function, which caused the function to return without scaling.

Fixed a bug in the transformation function. It should take a 4x4 transformation matrix, and apply it to the 3d point with a homogeneous coordinate added. Previously, the function caused the z coordinate to be zeroed.

Added tests to bring the line coverage of point3d up to 99%
