### PR TITLE
Clean up Elementary function docs & add missing functions

### DIFF
--- a/doc/src/modules/functions/elementary.rst
+++ b/doc/src/modules/functions/elementary.rst
@@ -1,8 +1,8 @@
 Elementary
 ==========
 
-This module implements elementary functions such as trigonometric, hyperbolic
-as well as functions like ``Abs``, ``Max``, ``sqrt`` etc.
+This module implements elementary functions such as trigonometric, hyperbolic, and
+sqrt, as well as functions like ``Abs``, ``Max``, ``Min`` etc.
 
 
 sympy.functions.elementary.complexes
@@ -44,6 +44,24 @@ conjugate
 .. autoclass:: sympy.functions.elementary.complexes.conjugate
    :members:
 
+polar_lift
+----------
+
+.. autoclass:: sympy.functions.elementary.complexes.polar_lift
+   :members:
+
+periodic_argument
+-----------------
+
+.. autoclass:: sympy.functions.elementary.complexes.periodic_argument
+   :members:
+
+principal_branch
+-----------------
+
+.. autoclass:: sympy.functions.elementary.complexes.principal_branch
+   :members:
+
 
 sympy.functions.elementary.trigonometric
 ========================================
@@ -75,6 +93,24 @@ cot
 .. autoclass:: sympy.functions.elementary.trigonometric.cot
    :members:
 
+sec
+---
+
+.. autoclass:: sympy.functions.elementary.trigonometric.sec
+   :members:
+
+csc
+---
+
+.. autoclass:: sympy.functions.elementary.trigonometric.csc
+   :members:
+
+sinc
+----
+
+.. autoclass:: sympy.functions.elementary.trigonometric.sinc
+   :members:
+
 
 Trigonometric Inverses
 ======================
@@ -101,6 +137,18 @@ acot
 ----
 
 .. autoclass:: sympy.functions.elementary.trigonometric.acot
+   :members:
+
+asec
+----
+
+.. autoclass:: sympy.functions.elementary.trigonometric.asec
+   :members:
+
+acsc
+----
+
+.. autoclass:: sympy.functions.elementary.trigonometric.acsc
    :members:
 
 atan2
@@ -147,6 +195,18 @@ coth
 .. autoclass:: sympy.functions.elementary.hyperbolic.coth
    :members:
 
+sech
+----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.sech
+   :members:
+
+csch
+----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.csch
+   :members:
+
 
 Hyperbolic Inverses
 ===================
@@ -175,6 +235,11 @@ acoth
 .. autoclass:: sympy.functions.elementary.hyperbolic.acoth
    :members:
 
+asech
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.asech
+   :members:
 
 sympy.functions.elementary.integers
 ===================================

--- a/doc/src/modules/functions/elementary.rst
+++ b/doc/src/modules/functions/elementary.rst
@@ -1,38 +1,35 @@
 Elementary
 ==========
 
-This module implements elementary functions, as well as functions like ``Abs``,
-``Max``, etc.
+This module implements elementary functions such as trigonometric, hyperbolic
+as well as functions like ``Abs``, ``Max``, ``sqrt`` etc.
 
+
+sympy.functions.elementary.complexes
+====================================
+
+re
+--
+
+.. autoclass:: sympy.functions.elementary.complexes.re
+   :members:
+
+im
+--
+
+.. autoclass:: sympy.functions.elementary.complexes.im
+   :members:
+
+sign
+----
+
+.. autoclass:: sympy.functions.elementary.complexes.sign
+   :members:
 
 Abs
 ---
 
 .. autoclass:: sympy.functions.elementary.complexes.Abs
-   :members:
-
-acos
-----
-
-.. autoclass:: sympy.functions.elementary.trigonometric.acos
-   :members:
-
-acosh
------
-
-.. autoclass:: sympy.functions.elementary.hyperbolic.acosh
-   :members:
-
-acot
-----
-
-.. autoclass:: sympy.functions.elementary.trigonometric.acot
-   :members:
-
-acoth
------
-
-.. autoclass:: sympy.functions.elementary.hyperbolic.acoth
    :members:
 
 arg
@@ -41,46 +38,23 @@ arg
 .. autoclass:: sympy.functions.elementary.complexes.arg
    :members:
 
-asin
-----
-
-.. autoclass:: sympy.functions.elementary.trigonometric.asin
-   :members:
-
-asinh
------
-
-.. autoclass:: sympy.functions.elementary.hyperbolic.asinh
-   :members:
-
-atan
-----
-
-.. autoclass:: sympy.functions.elementary.trigonometric.atan
-   :members:
-
-atan2
------
-
-.. autoclass:: sympy.functions.elementary.trigonometric.atan2
-   :members:
-
-atanh
------
-
-.. autoclass:: sympy.functions.elementary.hyperbolic.atanh
-   :members:
-
-ceiling
--------
-
-.. autoclass:: sympy.functions.elementary.integers.ceiling
-   :members:
-
 conjugate
 ---------
 
 .. autoclass:: sympy.functions.elementary.complexes.conjugate
+   :members:
+
+
+sympy.functions.elementary.trigonometric
+========================================
+
+Trionometric Functions
+======================
+
+sin
+---
+
+.. autoclass:: sympy.functions.elementary.trigonometric.sin
    :members:
 
 cos
@@ -89,9 +63,10 @@ cos
 .. autoclass:: sympy.functions.elementary.trigonometric.cos
    :members:
 
-cosh
-----
-.. autoclass:: sympy.functions.elementary.hyperbolic.cosh
+tan
+---
+
+.. autoclass:: sympy.functions.elementary.trigonometric.tan
    :members:
 
 cot
@@ -100,29 +75,47 @@ cot
 .. autoclass:: sympy.functions.elementary.trigonometric.cot
    :members:
 
-coth
+
+Trigonometric Inverses
+======================
+
+asin
 ----
 
-.. autoclass:: sympy.functions.elementary.hyperbolic.coth
+.. autoclass:: sympy.functions.elementary.trigonometric.asin
    :members:
 
-exp
----
+acos
+----
 
-.. autoclass:: sympy.functions.elementary.exponential.exp
+.. autoclass:: sympy.functions.elementary.trigonometric.acos
    :members:
 
-ExprCondPair
-------------
+atan
+----
 
-.. autoclass:: sympy.functions.elementary.piecewise.ExprCondPair
+.. autoclass:: sympy.functions.elementary.trigonometric.atan
    :members:
 
-floor
+acot
+----
+
+.. autoclass:: sympy.functions.elementary.trigonometric.acot
+   :members:
+
+atan2
 -----
 
-.. autoclass:: sympy.functions.elementary.integers.floor
+.. autoclass:: sympy.functions.elementary.trigonometric.atan2
    :members:
+
+
+sympy.functions.elementary.hyperbolic
+======================================
+
+Hyperbolic Functions
+====================
+
 
 HyperbolicFunction
 ------------------
@@ -130,16 +123,89 @@ HyperbolicFunction
 .. autoclass:: sympy.functions.elementary.hyperbolic.HyperbolicFunction
    :members:
 
-IdentityFunction
-----------------
+sinh
+----
 
-.. autoclass:: sympy.functions.elementary.miscellaneous.IdentityFunction
+.. autoclass:: sympy.functions.elementary.hyperbolic.sinh
    :members:
 
-im
---
+cosh
+----
 
-.. autoclass:: sympy.functions.elementary.im
+.. autoclass:: sympy.functions.elementary.hyperbolic.cosh
+   :members:
+
+tanh
+----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.tanh
+   :members:
+
+coth
+----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.coth
+   :members:
+
+
+Hyperbolic Inverses
+===================
+
+asinh
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.asinh
+   :members:
+
+acosh
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.acosh
+   :members:
+
+atanh
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.atanh
+   :members:
+
+acoth
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.acoth
+   :members:
+
+
+sympy.functions.elementary.integers
+===================================
+
+ceiling
+-------
+
+.. autoclass:: sympy.functions.elementary.integers.ceiling
+   :members:
+
+
+floor
+-----
+
+.. autoclass:: sympy.functions.elementary.integers.floor
+   :members:
+
+
+RoundFunction
+-------------
+
+.. autoclass:: sympy.functions.elementary.integers.RoundFunction
+
+
+sympy.functions.elementary.exponential
+======================================
+
+exp
+---
+
+.. autoclass:: sympy.functions.elementary.exponential.exp
    :members:
 
 LambertW
@@ -154,17 +220,16 @@ log
 .. autoclass:: sympy.functions.elementary.exponential.log
    :members:
 
-Min
----
 
-.. autoclass:: sympy.functions.elementary.miscellaneous.Min
+sympy.functions.elementary.piecewise
+====================================
+
+ExprCondPair
+------------
+
+.. autoclass:: sympy.functions.elementary.piecewise.ExprCondPair
    :members:
 
-Max
----
-
-.. autoclass:: sympy.functions.elementary.miscellaneous.Max
-   :members:
 
 Piecewise
 ---------
@@ -174,10 +239,27 @@ Piecewise
 
 .. autofunction:: sympy.functions.elementary.piecewise.piecewise_fold
 
-re
---
 
-.. autoclass:: sympy.functions.elementary.complexes.re
+sympy.functions.elementary.miscellaneous
+========================================
+
+IdentityFunction
+----------------
+
+.. autoclass:: sympy.functions.elementary.miscellaneous.IdentityFunction
+   :members:
+
+Min
+---
+
+.. autoclass:: sympy.functions.elementary.miscellaneous.Min
+   :members:
+
+
+Max
+---
+
+.. autoclass:: sympy.functions.elementary.miscellaneous.Max
    :members:
 
 root
@@ -185,42 +267,8 @@ root
 
 .. autofunction:: sympy.functions.elementary.miscellaneous.root
 
-RoundFunction
--------------
-
-.. autoclass:: sympy.functions.elementary.integers.RoundFunction
-
-sin
----
-
-.. autoclass:: sympy.functions.elementary.trigonometric.sin
-   :members:
-
-sinh
-----
-
-.. autoclass:: sympy.functions.elementary.hyperbolic.sinh
-   :members:
 
 sqrt
 ----
 
 .. autofunction:: sympy.functions.elementary.miscellaneous.sqrt
-
-sign
-----
-
-.. autoclass:: sympy.functions.elementary.complexes.sign
-   :members:
-
-tan
----
-
-.. autoclass:: sympy.functions.elementary.trigonometric.tan
-   :members:
-
-tanh
-----
-
-.. autoclass:: sympy.functions.elementary.hyperbolic.tanh
-   :members:

--- a/doc/src/modules/functions/elementary.rst
+++ b/doc/src/modules/functions/elementary.rst
@@ -8,14 +8,6 @@ This module implements elementary functions, as well as functions like ``Abs``,
 Abs
 ---
 
-Returns the absolute value of the argument.
-
-Examples::
-
-    >>> from sympy.functions import Abs
-    >>> Abs(-1)
-    1
-
 .. autoclass:: sympy.functions.elementary.complexes.Abs
    :members:
 
@@ -46,20 +38,6 @@ acoth
 arg
 ---
 
-Returns the argument (in radians) of a complex number. For a real
-number, the argument is always 0.
-
-Examples::
-
-    >>> from sympy.functions import arg
-    >>> from sympy import I, sqrt
-    >>> arg(2.0)
-    0
-    >>> arg(I)
-    pi/2
-    >>> arg(sqrt(2) + I*sqrt(2))
-    pi/4
-
 .. autoclass:: sympy.functions.elementary.complexes.arg
    :members:
 
@@ -84,9 +62,6 @@ atan
 atan2
 -----
 
-This function is like `\operatorname{atan}`, but considers the sign of both
-arguments in order to correctly determine the quadrant of its result.
-
 .. autoclass:: sympy.functions.elementary.trigonometric.atan2
    :members:
 
@@ -104,25 +79,6 @@ ceiling
 
 conjugate
 ---------
-
-Returns the `complex conjugate <http://en.wikipedia.org/wiki/Complex_conjugation>`_
-of an argument. In mathematics, the complex conjugate of a complex number is given
-by changing the sign of the imaginary part. Thus, the conjugate of the complex number
-
-    :math:`a + ib`
-
-(where a and b are real numbers) is
-
-    :math:`a - ib`
-
-Examples::
-
-    >>> from sympy.functions import conjugate
-    >>> from sympy import I
-    >>> conjugate(2)
-    2
-    >>> conjugate(I)
-    -I
 
 .. autoclass:: sympy.functions.elementary.complexes.conjugate
    :members:
@@ -156,8 +112,6 @@ exp
 .. autoclass:: sympy.functions.elementary.exponential.exp
    :members:
 
-.. seealso:: classes :py:class:`sympy.functions.elementary.exponential.log`
-
 ExprCondPair
 ------------
 
@@ -185,21 +139,8 @@ IdentityFunction
 im
 --
 
-Returns the imaginary part of an expression.
-
-Examples::
-
-
-    >>> from sympy.functions import im
-    >>> from sympy import I
-    >>> im(2+3*I)
-    3
-
-.. autoclass: sympy.functions.elementary.im
+.. autoclass:: sympy.functions.elementary.im
    :members:
-
-.. seealso::
-   :py:class:`sympy.functions.elementary.complexes.re`
 
 LambertW
 --------
@@ -213,34 +154,14 @@ log
 .. autoclass:: sympy.functions.elementary.exponential.log
    :members:
 
-.. seealso:: classes :py:class:`sympy.functions.elementary.exponential.exp`
-
 Min
 ---
-
-Returns the minimum of two (comparable) expressions.
-
-Examples::
-
-    >>> from sympy.functions import Min
-    >>> Min(1,2)
-    1
-    >>> from sympy.abc import x
-    >>> Min(1, x)
-    Min(1, x)
-
-It is named ``Min`` and not ``min`` to avoid conflicts with the built-in function ``min``.
 
 .. autoclass:: sympy.functions.elementary.miscellaneous.Min
    :members:
 
-
 Max
 ---
-
-Returns the maximum of two (comparable) expressions
-
-It is named ``Max`` and not ``max`` to avoid conflicts with the built-in function ``max``.
 
 .. autoclass:: sympy.functions.elementary.miscellaneous.Max
    :members:
@@ -256,20 +177,8 @@ Piecewise
 re
 --
 
-Return the real part of an expression.
-
-Examples::
-
-    >>> from sympy.functions import re
-    >>> from sympy import I
-    >>> re(2+3*I)
-    2
-
 .. autoclass:: sympy.functions.elementary.complexes.re
    :members:
-
-.. seealso::
-   :py:class:`sympy.functions.elementary.complexes.im`
 
 root
 ----
@@ -295,13 +204,6 @@ sinh
 
 sqrt
 ----
-
-Returns the square root of an expression. It is equivalent to raise to ``Rational(1,2)``.
-
-    >>> from sympy.functions import sqrt
-    >>> from sympy import Rational
-    >>> sqrt(2) == 2**Rational(1,2)
-    True
 
 .. autofunction:: sympy.functions.elementary.miscellaneous.sqrt
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -613,7 +613,7 @@ class conjugate(Function):
     """
     Returns the `complex conjugate` Ref[1] of an argument.
     In mathematics, the complex conjugate of a complex number
-    is givenby changing the sign of the imaginary part.
+    is given by changing the sign of the imaginary part.
 
     Thus, the conjugate of the complex number
     :math:`a + ib` (where a and b are real numbers) is :math:`a - ib`

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -19,31 +19,30 @@ from sympy.functions.elementary.trigonometric import atan2
 
 
 class re(Function):
-    """Returns real part of expression. This function performs only
-       elementary analysis and so it will fail to decompose properly
-       more complicated expressions. If completely simplified result
-       is needed then use Basic.as_real_imag() or perform complex
-       expansion on instance of this function.
+    """
+    Returns real part of expression. This function performs only
+    elementary analysis and so it will fail to decompose properly
+    more complicated expressions. If completely simplified result
+    is needed then use Basic.as_real_imag() or perform complex
+    expansion on instance of this function.
 
-       >>> from sympy import re, im, I, E
-       >>> from sympy.abc import x, y
+    Examples
+    ========
 
-       >>> re(2*E)
-       2*E
+    >>> from sympy import re, im, I, E
+    >>> from sympy.abc import x, y
+    >>> re(2*E)
+    2*E
+    >>> re(2*I + 17)
+    17
+    >>> re(2*I)
+    0
+    >>> re(im(x) + x*I + 2)
+    2
 
-       >>> re(2*I + 17)
-       17
-
-       >>> re(2*I)
-       0
-
-       >>> re(im(x) + x*I + 2)
-       2
-
-       See Also
-       ========
-
-       im
+    See Also
+    ========
+    im
     """
 
     is_real = True
@@ -123,16 +122,12 @@ class im(Function):
 
     >>> from sympy import re, im, E, I
     >>> from sympy.abc import x, y
-
     >>> im(2*E)
     0
-
     >>> re(2*I + 17)
     17
-
     >>> im(x*I)
     re(x)
-
     >>> im(re(x) + y)
     im(y)
 
@@ -566,7 +561,23 @@ class Abs(Function):
 
 
 class arg(Function):
-    """Returns the argument (in radians) of a complex number"""
+    """
+    Returns the argument (in radians) of a complex number. For a real
+    number, the argument is always 0.
+
+    Examples
+    ========
+
+    >>> from sympy.functions import arg
+    >>> from sympy import I, sqrt
+    >>> arg(2.0)
+    0
+    >>> arg(I)
+    pi/2
+    >>> arg(sqrt(2) + I*sqrt(2))
+    pi/4
+
+    """
 
     is_real = True
     is_finite = True
@@ -597,22 +608,34 @@ class arg(Function):
         x, y = re(self.args[0]), im(self.args[0])
         return atan2(y, x)
 
+
 class conjugate(Function):
     """
-    Changes the sign of the imaginary part of a complex number.
+    Returns the `complex conjugate` Ref[1] of an argument.
+    In mathematics, the complex conjugate of a complex number
+    is givenby changing the sign of the imaginary part.
+
+    Thus, the conjugate of the complex number
+    :math:`a + ib` (where a and b are real numbers) is :math:`a - ib`
 
     Examples
     ========
 
     >>> from sympy import conjugate, I
-
-    >>> conjugate(1 + I)
-    1 - I
+    >>> conjugate(2)
+    2
+    >>> conjugate(I)
+    -I
 
     See Also
     ========
 
     sign, Abs
+
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Complex_conjugation
     """
 
     @classmethod

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -108,13 +108,11 @@ def sqrt(arg):
     References
     ==========
 
-    * http://en.wikipedia.org/wiki/Square_root
-    * http://en.wikipedia.org/wiki/Principal_value
-
+    .. [1] http://en.wikipedia.org/wiki/Square_root
+    .. [2] http://en.wikipedia.org/wiki/Principal_value
     """
     # arg = sympify(arg) is handled by Pow
     return Pow(arg, S.Half)
-
 
 
 def cbrt(arg):
@@ -456,6 +454,7 @@ class MinMaxBase(Expr, LatticeOp):
     def is_real(self):
         return fuzzy_and(arg.is_real for arg in self.args)
 
+
 class Max(MinMaxBase, Application):
     """
     Return, if possible, the maximum value of the list.
@@ -477,6 +476,10 @@ class Max(MinMaxBase, Application):
 
     Also, only comparable arguments are permitted.
 
+    It is named ``Max`` and not ``max`` to avoid conflicts
+    with the built-in function ``max``.
+
+
     Examples
     ========
 
@@ -487,29 +490,22 @@ class Max(MinMaxBase, Application):
 
     >>> Max(x, -2)                  #doctest: +SKIP
     Max(x, -2)
-
     >>> Max(x, -2).subs(x, 3)
     3
-
     >>> Max(p, -2)
     p
-
     >>> Max(x, y)                   #doctest: +SKIP
     Max(x, y)
-
     >>> Max(x, y) == Max(y, x)
     True
-
     >>> Max(x, Max(y, z))           #doctest: +SKIP
     Max(x, y, z)
-
     >>> Max(n, 8, p, 7, -oo)        #doctest: +SKIP
     Max(8, p)
-
     >>> Max (1, x, oo)
     oo
 
-    Algorithm
+    * Algorithm
 
     The task can be considered as searching of supremums in the
     directed complete partial orders [1]_.
@@ -568,6 +564,8 @@ class Max(MinMaxBase, Application):
 class Min(MinMaxBase, Application):
     """
     Return, if possible, the minimum value of the list.
+    It is named ``Min`` and not ``min`` to avoid conflicts
+    with the built-in function ``min``.
 
     Examples
     ========
@@ -579,16 +577,12 @@ class Min(MinMaxBase, Application):
 
     >>> Min(x, -2)                  #doctest: +SKIP
     Min(x, -2)
-
     >>> Min(x, -2).subs(x, 3)
     -2
-
     >>> Min(p, -3)
     -3
-
     >>> Min(x, y)                   #doctest: +SKIP
     Min(x, y)
-
     >>> Min(n, 8, p, -7, p, oo)     #doctest: +SKIP
     Min(n, -7)
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1466,7 +1466,7 @@ class sec(ReciprocalTrigonometricFunction):
 
     .. [1] http://en.wikipedia.org/wiki/Trigonometric_functions
     .. [2] http://dlmf.nist.gov/4.14
-    .. [2] http://functions.wolfram.com/ElementaryFunctions/Sec
+    .. [3] http://functions.wolfram.com/ElementaryFunctions/Sec
     """
 
     _reciprocal_of = cos


### PR DESCRIPTION
The Docs of **Elementary functions** in **`sympy.functions.elementary`**  are:
- Useless
- Messy
- Unordered
- Incomplete

Elementary Functions are the most used functions in any Computer Algebra System, So it's very important to have proper docs for them.

This **PR** cleans up the docs of elementary functions by making them ordered, adding missing functions and formatting it so that further additions could be more intuitive and user friendly.

@jcrist  @debugger22  @jksuom 
