### PR TITLE
Fix printing of functions with tall arguments

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1061,10 +1061,6 @@ class PrettyPrinter(Printer):
 
         prettyFunc = self._print(Symbol(func_name))
         prettyArgs = prettyForm(*self._print_seq(args).parens())
-        #postioning func_name
-        mid = prettyArgs.height()//2
-        if mid > 2:
-            prettyFunc.baseline = -mid + 1
 
         pform = prettyForm(
             binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -97,6 +97,7 @@ conjugate(f(x+1)) #
 f(x)
 f(x, y)
 f(x/(y+1), y) #
+f(x**x**x**x**x**x)
 sin(x)**2
 conjugate(a+b*I)
 conjugate(exp(a+b*I))
@@ -1522,6 +1523,28 @@ f⎜─────, y⎟\n\
 """)
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
+
+    expr = f(x**x**x**x**x**x)
+    ascii_str = \
+"""\
+ / / / / / x\\\\\\\\\\
+ | | | | \\x /||||
+ | | | \\x    /|||
+ | | \\x       /||
+ | \\x          /|
+f\\x             /\
+"""
+    ucode_str = \
+u("""\
+ ⎛ ⎛ ⎛ ⎛ ⎛ x⎞⎞⎞⎞⎞
+ ⎜ ⎜ ⎜ ⎜ ⎝x ⎠⎟⎟⎟⎟
+ ⎜ ⎜ ⎜ ⎝x    ⎠⎟⎟⎟
+ ⎜ ⎜ ⎝x       ⎠⎟⎟
+ ⎜ ⎝x          ⎠⎟
+f⎝x             ⎠\
+""")
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
 
     expr = sin(x)**2
     ascii_str = \


### PR DESCRIPTION
Previously, the baseline of the function name for tall function
arguments was set in the wrong direction.  Such as::

```
In [1]: log(n**(log((1+1/n)*n, 2)))
Out[1]:
   ⎛    ⎛  ⎛    1⎞⎞⎞
   ⎜ log⎜n⋅⎜1 + ─⎟⎟⎟
   ⎜    ⎝  ⎝    n⎠⎠⎟
   ⎜ ──────────────⎟
   ⎜     log(2)    ⎟
   ⎝n              ⎠

log
```

This fixes the offset to print as::

```
In [1]: log(n**(log((1+1/n)*n, 2)))
Out[1]:
   ⎛    ⎛  ⎛    1⎞⎞⎞
   ⎜ log⎜n⋅⎜1 + ─⎟⎟⎟
   ⎜    ⎝  ⎝    n⎠⎠⎟
   ⎜ ──────────────⎟
   ⎜     log(2)    ⎟
log⎝n              ⎠
```

Closes #9034
