### PR TITLE
Deleted unreachable code in class jacobi in polynomial.py

### DIFF
--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -145,9 +145,7 @@ class jacobi(OrthogonalPolynomial):
         elif b == -a:
             # P^{a, -a}_n(x)
             return gamma(n + a + 1) / gamma(n + 1) * (1 + x)**(a/2) / (1 - x)**(a/2) * assoc_legendre(n, -a, x)
-        elif a == -b:
-            # P^{-b, b}_n(x)
-            return gamma(n - b + 1) / gamma(n + 1) * (1 - x)**(b/2) / (1 + x)**(b/2) * assoc_legendre(n, b, x)
+
 
         if not n.is_Number:
             # Symbolic result P^{a,b}_n(x)


### PR DESCRIPTION
The deleted condition a == -b is the exactly the same as the its above if else condition b == -a. b == -a condition check whether or not two symbols are opposite so is a == -b. Since b == -a is a condition before a == -b, then a == -b condition is never reached. Thus, that condition statement is unreachable.
