### PR TITLE
Added support for lux (Illuminance) to units.py

### DIFF
--- a/sympy/physics/units.py
+++ b/sympy/physics/units.py
@@ -185,6 +185,7 @@ speed = m/s
 acceleration = m/s**2
 density = kg/m**3
 optical_power = dioptre = D = 1/m
+illuminance = lux = lx = sr*cd/m**2
 
 # Common length units
 


### PR DESCRIPTION
Illuminance (lux) was missing from derived SI units. This has been added. Thank you.
