### PR TITLE
[skip ci] Fixed typos in prufer.py

### DIFF
--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -33,8 +33,8 @@ class Prufer(Basic):
         """Returns Prufer sequence for the Prufer object.
 
         This sequence is found by removing the highest numbered vertex,
-        recording the node it was attached to, and continuuing until only
-        two verices remain. The Prufer sequence is the list of recorded nodes.
+        recording the node it was attached to, and continuing until only
+        two vertices remain. The Prufer sequence is the list of recorded nodes.
 
         Examples
         ========


### PR DESCRIPTION
Few more typo fixes...

verices -> vertices 
continuuing -> continuing

Thank you. :)
