### PR TITLE
[Need Review] Test and Fix Issue #9324. Set is_Symbol to True for MatrixSymbol

### DIFF
--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -1,9 +1,12 @@
 from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
-    count_ops, S, And, I, pi, Eq, Or, Not, Xor ,Nand ,Nor, Implies,Equivalent, ITE
+    count_ops, S, And, I, pi, Eq, Or, Not, Xor ,Nand ,Nor, Implies,Equivalent, \
+    ITE, MatrixSymbol \
+
 from sympy.core.containers import Tuple
 
 x, y, z = symbols('x,y,z')
 a, b, c = symbols('a,b,c')
+M = MatrixSymbol('M', 10, 10)
 
 def test_count_ops_non_visual():
     def count(val):
@@ -25,6 +28,8 @@ def test_count_ops_non_visual():
     assert count(Equivalent(x,y)) == 1
     assert count(ITE(x,y,z)) == 1
     assert count(ITE(True,x,y)) == 0
+    assert count(M[5, 8]) == 0
+    assert count(M[0,0] + 5) == 1
 
 def test_count_ops_visual():
     ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -346,6 +346,7 @@ class MatrixSymbol(MatrixExpr):
     I + 2*A*B
     """
     is_commutative = False
+    is_Symbol = True
 
     def __new__(cls, name, n, m):
         n, m = sympify(n), sympify(m)


### PR DESCRIPTION
My attempt to fix issue : https://github.com/sympy/sympy/issues/9324 in which count_ops fails for expressions such as count_ops(M[0,0] + 1)

```
>>> from sympy import *
>>> M = MatrixSymbol('M', 7, 7)
>>> count_ops(M[0,0] + 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy/core/function.py", line 2290, in count_ops
    if a.is_Rational:
AttributeError: 'str' object has no attribute 'is_Rational'
```

By setting is_Symbol = True for MatrixSymbol instances (it quite make senes to me), the problem is fixed. I also added new test cases to count_ops for these cases.
