### PR TITLE
Fixes issue #9334

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -325,7 +325,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         namespaces.append(modules)
     else:
         # consistency check
-        if 'numexpr' in modules and len(modules) > 1:
+        if _module_present('numexpr', modules) and len(modules) > 1:
             raise TypeError("numexpr must be the only item in 'modules'")
         namespaces += list(modules)
     # fill namespace with first having highest priority
@@ -342,7 +342,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         for term in syms:
             namespace.update({str(term): term})
 
-    if 'numexpr' in namespaces and printer is None:
+    if _module_present('numexpr',namespaces) and printer is None:
         #XXX: This has to be done here because of circular imports
         from sympy.printing.lambdarepr import NumExprPrinter as printer
 
@@ -405,6 +405,16 @@ def _issue_7853_dep_check(namespaces, namespace, expr):
                 "The old behavior can be retained in future versions by "
                 "supplying `modules=[{'ImmutableMatrix': numpy.matrix}, "
                 "'numpy']`.", issue=7853).warn()
+
+
+def _module_present(modname, modlist):
+    if modname in modlist:
+        return True
+    for m in modlist:
+        if hasattr(m, '__name__') and m.__name__ == modname:
+            return True
+    return False
+
 
 def _get_namespace(m):
     """

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -180,6 +180,17 @@ def test_numexpr_printer():
         f = lambdify(args, ssym(*args), modules='numexpr')
         assert f(*(1, )*nargs) is not None
 
+def test_issue_9334():
+    if not numexpr:
+        skip("numexpr not installed.")
+    if not numpy:
+        skip("numpy not installed.")
+    expr = sympy.S('b*a - sqrt(a**2)')
+    a, b = sorted(expr.free_symbols, key=lambda s: s.name)
+    func_numexpr = lambdify((a,b), expr, modules=[numexpr], dummify=False)
+    foo, bar = numpy.random.random((2, 4))
+    func_numexpr(foo, bar)
+
 #================== Test some functions ============================
 
 


### PR DESCRIPTION
Fixes issue #9334: the numexpr printer was only activated if the string 'numexpr' was found
in the modules list.  This commit adds the function `_module_present`
which also checks for a module with `module.__name__ == 'numexpr'` to
activate the numexpr printer
