### PR TITLE
asec(0), acos(zoo) is zoo

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -713,6 +713,7 @@ def test_asin_rewrite():
 
 def test_acos():
     assert acos(nan) == nan
+    assert acos(zoo) == zoo
 
     assert acos.nargs == FiniteSet(1)
     assert acos(oo) == I*oo
@@ -1367,7 +1368,7 @@ def test_csc():
 
 def test_asec():
     z = Symbol('z', zero=True)
-    assert asec(z) == nan
+    assert asec(z) == zoo
     assert asec(nan) == nan
     assert asec(1) == 0
     assert asec(-1) == pi

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1894,6 +1894,9 @@ class acos(InverseTrigonometricFunction):
             elif arg is S.NegativeOne:
                 return S.Pi
 
+        if arg is S.ComplexInfinity:
+            return S.ComplexInfinity
+
         if arg.is_number:
             cst_table = {
                 S.Half: S.Pi/3,
@@ -2308,7 +2311,7 @@ class asec(InverseTrigonometricFunction):
     @classmethod
     def eval(cls, arg):
         if arg.is_zero:
-            return S.NaN
+            return S.ComplexInfinity
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1832,8 +1832,11 @@ class acos(InverseTrigonometricFunction):
     Notes
     =====
 
-    acos(x) will evaluate automatically in the cases
-    oo, -oo, 0, 1, -1.
+    ``acos(x)`` will evaluate automatically in the cases
+    ``oo``, ``-oo``, ``0``, ``1``, ``-1``.
+
+    ``acos(zoo)`` evaluates to ``zoo``
+    (see note in :py:class`sympy.functions.elementary.trigonometric.asec`)
 
     Examples
     ========
@@ -2282,8 +2285,26 @@ class asec(InverseTrigonometricFunction):
     Notes
     =====
 
-    asec(x) will evaluate automatically in the cases
-    oo, -oo, 0, 1, -1.
+    ``asec(x)`` will evaluate automatically in the cases
+    ``oo``, ``-oo``, ``0``, ``1``, ``-1``.
+
+    ``asec(x)`` has branch cut in the interval [-1, 1]. For complex arguments,
+    it can be defined [4]_ as
+
+    .. math::
+        sec^{-1}(z) = -i*(log(\sqrt{1 - z^2} + 1) / z)
+
+    At ``x = 0``, for positive branch cut, the limit evaluates to ``zoo``. For
+    negative branch cut, the limit
+
+    .. math::
+        \lim_{z \to 0}-i*(log(-\sqrt{1 - z^2} + 1) / z)
+
+    simplifies to :math:`-i*log(z/2 + O(z^3))` which ultimately evaluates to
+    ``zoo``.
+
+    As ``asex(x)`` = ``asec(1/x)``, a similar argument can be given for
+    ``acos(x)``.
 
     Examples
     ========
@@ -2306,6 +2327,7 @@ class asec(InverseTrigonometricFunction):
     .. [1] http://en.wikipedia.org/wiki/Inverse_trigonometric_functions
     .. [2] http://dlmf.nist.gov/4.23
     .. [3] http://functions.wolfram.com/ElementaryFunctions/ArcSec
+    .. [4] http://refrence.wolfram.com/language/ref/ArcSec.html
     """
 
     @classmethod


### PR DESCRIPTION
According to wolfram `acos(zoo)` and `asec(0)` should be `zoo`. It was also pointed out by @skirpichev in #9223.
