### PR TITLE
Renamed _test_f to test_f in sympy/series/tests/test_residues.py

### DIFF
--- a/sympy/series/tests/test_residues.py
+++ b/sympy/series/tests/test_residues.py
@@ -25,7 +25,7 @@ def test_basic2():
     assert residue(x**2, x, 5) == 0
 
 
-def _test_f():
+def test_f():
     f = Function("f")
     assert residue(f(x)/x**5, x, 0) == f(x).diff(x, 4).subs(x, 0)/24
 


### PR DESCRIPTION
Because of the prefix '_' the test was not being run by the test runner.

See https://github.com/sympy/sympy/pull/9162
