### PR TITLE
Fix 9363: Bug in cancel MatrixElement expressions

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6288,7 +6288,7 @@ def cancel(f, *gens, **args):
             raise PolynomialError(msg)
         # Handling of noncommutative and/or piecewise expressions
         if f.is_Add or f.is_Mul:
-            sifted = sift(f.args, lambda x: x.is_commutative and not x.has(Piecewise))
+            sifted = sift(f.args, lambda x: bool(x.is_commutative) and not x.has(Piecewise))
             c, nc = sifted[True], sifted[False]
             nc = [cancel(i) for i in nc]
             return f.func(cancel(f.func._from_args(c)), *nc)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6288,7 +6288,7 @@ def cancel(f, *gens, **args):
             raise PolynomialError(msg)
         # Handling of noncommutative and/or piecewise expressions
         if f.is_Add or f.is_Mul:
-            sifted = sift(f.args, lambda x: bool(x.is_commutative) and not x.has(Piecewise))
+            sifted = sift(f.args, lambda x: x.is_commutative is True and not x.has(Piecewise))
             c, nc = sifted[True], sifted[False]
             nc = [cancel(i) for i in nc]
             return f.func(cancel(f.func._from_args(c)), *nc)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -59,7 +59,7 @@ from sympy.core.mul import _keep_coeff
 from sympy.utilities.pytest import raises, XFAIL
 
 from sympy.abc import a, b, c, d, p, q, t, w, x, y, z
-
+from sympy import MatrixSymbol
 
 def _epsilon_eq(a, b):
     for x, y in zip(a, b):
@@ -2868,6 +2868,12 @@ def test_cancel():
     assert cancel(1 + p3) == 1 + p4
     assert cancel((x**2 - 1)/(x + 1)*p3) == (x - 1)*p4
     assert cancel((x**2 - 1)/(x + 1) + p3) == (x - 1) + p4
+
+    # issue 9363
+    M = MatrixSymbol('M', 5, 5)
+    assert cancel(M[0,0] + 7) == M[0,0] + 7
+    expr = sin(M[1, 4] + M[2, 1] * 5 * M[4, 0]) - 5 * M[1, 2] / z
+    assert cancel(expr) = expr
 
 
 def test_reduced():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2873,7 +2873,7 @@ def test_cancel():
     M = MatrixSymbol('M', 5, 5)
     assert cancel(M[0,0] + 7) == M[0,0] + 7
     expr = sin(M[1, 4] + M[2, 1] * 5 * M[4, 0]) - 5 * M[1, 2] / z
-    assert cancel(expr) = expr
+    assert cancel(expr) == expr
 
 
 def test_reduced():


### PR DESCRIPTION
Refer to issue: https://github.com/sympy/sympy/issues/9363

Problem: When applying cancel function with expression involving MatrixElement (e.g. M[0,0] + 10), the result is not correct (MatrixElement disappears). See the following program:

```
 >>> from sympy import *
 >>> X = Symbol('X', commutative=False)
 >>> M = MatrixSymbol('M', 3, 3)
 >>> cancel(X + 1)
X + 1
>>> cancel(M[0,0] + 1)
1
```

Fix Attempt: In the condition at line https://github.com/sympy/sympy/blob/master/sympy/polys/polytools.py#L6291-L6292, use 

```
bool(x.is_commutative) 
```

instead of

```
x.is_commutative
```

So if x.is_commutative is None, we treat x as non-commutative. Note that in Python, strangely (None and True) is None, similar to (None and False)) (which is the cause of the bug)
