### PR TITLE
[skip ci] PEP8 cleanup for combinatorics/util.py

### DIFF
--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -8,9 +8,9 @@ rmul = Permutation.rmul
 _af_new = Permutation._af_new
 
 ############################################
-###
-### Utilities for computational group theory
-###
+#
+# Utilities for computational group theory
+#
 ############################################
 
 
@@ -81,10 +81,10 @@ def _check_cycles_alt_sym(perm):
 
     >>> from sympy.combinatorics.util import _check_cycles_alt_sym
     >>> from sympy.combinatorics.permutations import Permutation
-    >>> a = Permutation([[0,1,2,3,4,5,6,7,8,9,10], [11, 12]])
+    >>> a = Permutation([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11, 12]])
     >>> _check_cycles_alt_sym(a)
     False
-    >>> b = Permutation([[0,1,2,3,4,5,6], [7,8,9,10]])
+    >>> b = Permutation([[0, 1, 2, 3, 4, 5, 6], [7, 8, 9, 10]])
     >>> _check_cycles_alt_sym(b)
     True
 
@@ -177,6 +177,7 @@ def _distribute_gens_by_base(base, gens):
     for i in range(max_stab_index + 1, base_len):
         stabs[i].append(_af_new(list(range(degree))))
     return stabs
+
 
 def _handle_precomputed_bsgs(base, strong_gens, transversals=None,
                              basic_orbits=None, strong_gens_distr=None):
@@ -379,6 +380,7 @@ def _remove_gens(base, strong_gens, basic_orbits=None, strong_gens_distr=None):
                     res.remove(gen)
     return res
 
+
 def _strip(g, base, orbits, transversals):
     """
     Attempt to decompose a permutation using a (possibly partial) BSGS
@@ -456,6 +458,7 @@ def _strip(g, base, orbits, transversals):
         h = _af_rmul(_af_invert(u), h)
     return _af_new(h), base_len + 1
 
+
 def _strip_af(h, base, orbits, transversals, j):
     """
     optimized _strip, with h, transversals and result in array form
@@ -475,6 +478,7 @@ def _strip_af(h, base, orbits, transversals, j):
             return False, base_len + 1
         h = _af_rmul(_af_invert(u), h)
     return h, base_len + 1
+
 
 def _strong_gens_from_distr(strong_gens_distr):
     """


### PR DESCRIPTION
PEP8 clean up for combinatorics/util.py - block comments and white spaces after comma.

Thank you.
