### PR TITLE
[WIP] Fix bugs when running with no cache

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -500,7 +500,7 @@ class Add(Expr, AssocOp):
             v = _monotonic_sign(a)
             if v is not None:
                 s = v + c
-                if s.is_positive and a.is_nonnegative:
+                if self != s and s.is_positive and a.is_nonnegative:
                     return True
                 if len(self.free_symbols) == 1:
                     v = _monotonic_sign(self)
@@ -553,7 +553,7 @@ class Add(Expr, AssocOp):
                 v = _monotonic_sign(a)
                 if v is not None:
                     s = v + c
-                    if s.is_nonnegative:
+                    if self != s and s.is_nonnegative:
                         return True
                     if len(self.free_symbols) == 1:
                         v = _monotonic_sign(self)
@@ -568,7 +568,7 @@ class Add(Expr, AssocOp):
                 v = _monotonic_sign(a)
                 if v is not None:
                     s = v + c
-                    if s.is_nonpositive:
+                    if self != s and s.is_nonpositive:
                         return True
                     if len(self.free_symbols) == 1:
                         v = _monotonic_sign(self)
@@ -584,7 +584,7 @@ class Add(Expr, AssocOp):
             v = _monotonic_sign(a)
             if v is not None:
                 s = v + c
-                if s.is_negative and a.is_nonpositive:
+                if self != s and s.is_negative and a.is_nonpositive:
                     return True
                 if len(self.free_symbols) == 1:
                     v = _monotonic_sign(self)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -520,7 +520,7 @@ class Pow(Expr):
         if old == self.base:
             return new**self.exp._subs(old, new)
 
-        if old.func is self.func and self.base is old.base:
+        if old.func is self.func and self.base == old.base:
             if self.exp.is_Add is False:
                 ct1 = self.exp.as_independent(Symbol, as_Add=False)
                 ct2 = old.exp.as_independent(Symbol, as_Add=False)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1248,7 +1248,7 @@ def test_Mul_hermitian_antihermitian():
     assert e3.is_antihermitian is None
     assert e4.is_antihermitian is None
     assert e5.is_antihermitian is None
-    assert e6.is_antihermitian is None
+    assert e6.is_antihermitian is False
 
 
 def test_Add_is_comparable():


### PR DESCRIPTION
When you run the test suite with SYMPY_USE_CACHE='no' there are tens or hundreds of errors. This branch should fix all of these errors.

Most of these errors are due to infinite recursion. I made some changes to the Mul._eval_is_\* and Add._eval_is_\* methods to fix these.

Another no-cache related error was in Pow._eval_subs. You would get different results depending whether the cache was on or off. This was using the 'is' operator instead of the '==' operator.

~~There is one test in test_assumptions.py that I needed to regress. I'm not sure if it really used to work properly or it was just a coincidence and/or bad implementation. This needs further investigation.~~
Should be fixed now

There is another test in test_arit.py that has also regressed. I'm not an expert in hermitian/antihermitian properties. Could someone please check that regression?

It would be nice if there was automated tests on Travis CI that tests without the cache so these errors don't creep in again.

Related:
https://github.com/sympy/sympy/issues/8266
