### PR TITLE
Fix Pow._eval_subs giving wrong results when no-cache

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -520,7 +520,7 @@ class Pow(Expr):
         if old == self.base:
             return new**self.exp._subs(old, new)
 
-        if old.func is self.func and self.base is old.base:
+        if old.func is self.func and self.base == old.base:
             if self.exp.is_Add is False:
                 ct1 = self.exp.as_independent(Symbol, as_Add=False)
                 ct2 = old.exp.as_independent(Symbol, as_Add=False)

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -643,10 +643,17 @@ def test_issue_5217():
 
 
 def test_pow_eval_subs_no_cache():
+    # Tests pull request 9376 is working
     from sympy.core.cache import clear_cache
     from sympy.abc import x, y
 
     s = 1/sqrt(x**2)
+    # This bug only appeared when the cache was turned off.
+    # We need to approximate running this test without the cache.
+    # This creates approximately the same situation.
     clear_cache()
+
+    # This used to fail with a wrong result.
+    # It incorrectly returned 1/sqrt(x**2) before this pull request.
     result = s.subs(sqrt(x**2), y)
     assert result == 1/y

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -640,3 +640,13 @@ def test_issue_5217():
     assert z.subs(sub) == 1 - s
     assert q == 4*x**2*y**2
     assert q.subs(sub) == 2*y**2*s
+
+
+def test_pow_eval_subs_no_cache():
+    from sympy.core.cache import clear_cache
+    from sympy.abc import x, y
+
+    s = 1/sqrt(x**2)
+    clear_cache()
+    result = s.subs(sqrt(x**2), y)
+    assert result == 1/y


### PR DESCRIPTION
Just a simple fix, change an 'is' to a '=='.

Example: `(1/sqrt(-x**2+16)).subs(sqrt(-x**2+16), y)` didn't do the substitution when SYMPY_USE_CACHE='no'. It worked with the cache on, however.
