### PR TITLE
Handle arg.is_positive/negative = False in Mul._eval_is_positive

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1138,7 +1138,7 @@ class Mul(Expr, AssocOp):
         return self._eval_pos_neg(1)
 
     def _eval_pos_neg(self, sign):
-        saw_NON = False
+        saw_NON = saw_NOT = False
         for t in self.args:
             if t.is_positive:
                 continue
@@ -1153,9 +1153,18 @@ class Mul(Expr, AssocOp):
                 saw_NON = True
             elif t.is_nonnegative:
                 saw_NON = True
+            elif t.is_positive is False:
+                sign = -sign
+                if saw_NOT:
+                    return
+                saw_NOT = True
+            elif t.is_negative is False:
+                if saw_NOT:
+                    return
+                saw_NOT = True
             else:
                 return
-        if sign == 1 and saw_NON is False:
+        if sign == 1 and saw_NON is False and saw_NOT is False:
             return True
         if sign < 0:
             return False

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -388,11 +388,35 @@ def test_symbol_falsepositive():
     assert x.is_nonzero is None
 
 
+def test_symbol_falsepositive_mul():
+    # To test pull request 9379
+    # Explicit handling of arg.is_positive=False was added to Mul._eval_is_positive
+    x = 2*Symbol('x', positive=False)
+    assert x.is_positive is False  # This was None before
+    assert x.is_nonpositive is None
+    assert x.is_negative is None
+    assert x.is_nonnegative is None
+    assert x.is_zero is None
+    assert x.is_nonzero is None
+
+
 def test_neg_symbol_falsepositive():
     x = -Symbol('x', positive=False)
     assert x.is_positive is None
     assert x.is_nonpositive is None
     assert x.is_negative is False
+    assert x.is_nonnegative is None
+    assert x.is_zero is None
+    assert x.is_nonzero is None
+
+
+def test_neg_symbol_falsenegative():
+    # To test pull request 9379
+    # Explicit handling of arg.is_negative=False was added to Mul._eval_is_positive
+    x = -Symbol('x', negative=False)
+    assert x.is_positive is False  # This was None before
+    assert x.is_nonpositive is None
+    assert x.is_negative is None
     assert x.is_nonnegative is None
     assert x.is_zero is None
     assert x.is_nonzero is None


### PR DESCRIPTION
This branch makes Mul._eval_is_positive handle args which have the assumption is_positive/negative=False.

This can handle seeing one arg which is_positive/is_negative=False in Mul._eval_is_positive. If there's more than one is_positive/is_negative=False arg, all bets are off. This is because it becomes a multiplication between non-reals. The result of the Mul could then be positive, negative, not real etc. This is why I count the number of non-reals.

This is also one of the changes needed to fix the infinite recursion bug (https://github.com/sympy/sympy/pull/9374) when the cache is turned off. The (-self).is_positive call actually has side effects that causes Mul._eval_is_negative to perform these is_positive/is_negative = False checks for some reason (without this commit). This is why I explicitly add it to the _eval_is_positive case.

Example:

```
mx = -Symbol('x', negative=False)
assert mx.is_positive is False  # will pass now
```

```
px = 2*Symbol('x', positive=False)
assert px.is_positive is False  # will pass now
```
