### PR TITLE
Eliminate superfluous intermediate variable in __cacheit

### DIFF
--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -96,8 +96,8 @@ except ImportError:
             wrapper.__wrapped__ = cfunc.__wrapped__
             wrapper.cache_info = cfunc.cache_info
             wrapper.cache_clear = cfunc.cache_clear
-            uw = update_wrapper(wrapper, func)
-            CACHE.append(uw)
+            update_wrapper(wrapper, func)
+            CACHE.append(wrapper)
             return wrapper
 
         return func_wrapper


### PR DESCRIPTION
update_wrapper never returns anything but its wrapper parameter.
The docstring essentially says so ("Updates a _wrapper_ function").
