### PR TITLE
Fix 9324: count_ops and simplify crashes for MatrixElement expr

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2287,6 +2287,10 @@ def count_ops(expr, visual=False):
         ADD = Symbol('ADD')
         while args:
             a = args.pop()
+
+            if isinstance(a, str):
+                continue
+
             if a.is_Rational:
                 #-1/3 = NEG + DIV
                 if a is not S.One:

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -1,5 +1,6 @@
 from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
-    count_ops, S, And, I, pi, Eq, Or, Not, Xor ,Nand ,Nor, Implies,Equivalent, ITE
+    count_ops, S, And, I, pi, Eq, Or, Not, Xor, Nand, Nor, Implies, \
+    Equivalent, MatrixSymbol, Symbol, ITE
 from sympy.core.containers import Tuple
 
 x, y, z = symbols('x,y,z')
@@ -25,6 +26,7 @@ def test_count_ops_non_visual():
     assert count(Equivalent(x,y)) == 1
     assert count(ITE(x,y,z)) == 1
     assert count(ITE(True,x,y)) == 0
+
 
 def test_count_ops_visual():
     ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(
@@ -109,3 +111,19 @@ def test_count_ops_visual():
     #It checks that TUPLE is counted as an operation.
 
     assert count(Eq(x + y, S(2))) == ADD
+
+
+def test_issue_9324():
+    def count(val):
+        return count_ops(val, visual=False)
+
+    M = MatrixSymbol('M', 10, 10)
+    assert count(M[0, 0]) == 0
+    assert count(2 * M[0, 0] + M[5, 7]) == 2
+    P = MatrixSymbol('P', 3, 3)
+    Q = MatrixSymbol('Q', 3, 3)
+    assert count(P + Q) == 9
+    m = Symbol('m', integer=True)
+    n = Symbol('n', integer=True)
+    M = MatrixSymbol('M', m + n, m * m)
+    assert count(M[0, 1]) == 2

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2530,6 +2530,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
     x*y*sqrt(x*sqrt(y))
 
     """
+    from sympy.matrices.expressions.matexpr import MatrixSymbol
 
     def recurse(arg, **kwargs):
         _deep = kwargs.get('deep', deep)
@@ -2540,8 +2541,8 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
 
     expr = sympify(expr)
 
-    if not isinstance(expr, Basic) or expr.is_Atom or expr in (
-            exp_polar(0), exp_polar(1)):
+    if (not isinstance(expr, Basic) or isinstance(expr, MatrixSymbol) or (
+            expr.is_Atom or expr in (exp_polar(0), exp_polar(1)))):
         return expr
 
     if deep or expr.is_Add or expr.is_Mul and _y not in expr.args:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -4,7 +4,7 @@ from sympy import (
     Derivative, diff, Dummy, E, Eq, erf, exp, exp_polar, expand,
     expand_multinomial, exptrigsimp, factor, factorial, FallingFactorial,
     Float, fraction, Function, gamma, GoldenRatio, hyper,
-    hypersimp, I, Integral, integrate, log, logcombine, Matrix,
+    hypersimp, I, Integral, integrate, log, logcombine, Matrix, MatrixSymbol,
     Mul, nsimplify, O, oo, pi, Piecewise,
     posify, powdenest, powsimp, rad, radsimp, Rational, ratsimp,
     ratsimpmodprime, rcollect, RisingFactorial, root, S, separatevars,
@@ -1913,3 +1913,16 @@ def test_inequality_no_auto_simplify():
     e = Lt(lhs, rhs)
     assert e == Lt(lhs, rhs, evaluate=False)
     assert simplify(e)
+
+
+def test_issue_9324_simplify():
+    M = MatrixSymbol('M', 10, 10)
+    e = M[0, 0] + M[5, 4] + 1304
+    assert simplify(e) == e
+
+
+def test_issue_9324_powsimp_on_matrix_symbol():
+    M = MatrixSymbol('M', 10, 10)
+    expr = powsimp(M, deep=True)
+    assert expr == M
+    assert expr.args[0] == 'M'


### PR DESCRIPTION
Refer to issue: https://github.com/sympy/sympy/issues/9324

Problem: `count_ops` crashes with expressions involving MatrixElement, so is `simplify` (because `simplify` uses `count_ops` in its code)

```
>>> from sympy import *
>>> M = MatrixSymbol('M', 7, 7)
>>> count_ops(M[0,0] + 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy/core/function.py", line 2290, in count_ops
    if a.is_Rational:
AttributeError: 'str' object has no attribute 'is_Rational'
```

Proposed solution: Add is_MatrixSymbol attribute to Basic (Detail on the cause is in https://github.com/sympy/sympy/issues/9324). Then make function `count_ops` and `simplify` handle MatrixSymbol appropriately
