### PR TITLE
Catch AttributeError in as_terms

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -910,7 +910,10 @@ class Expr(Basic, EvalfMixin):
         gens, terms = set([]), []
 
         for term in Add.make_args(self):
-            coeff, _term = term.as_coeff_Mul()
+            try:
+                coeff, _term = term.as_coeff_Mul()
+            except AttributeError:
+                coeff, _term = S.One, term
 
             coeff = complex(coeff)
             cpart, ncpart = {}, []

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2469,3 +2469,7 @@ def test_doit():
     a = Matrix([[Add(x,x, evaluate=False)]])
     assert a[0] != 2*x
     assert a.doit() == Matrix([[2*x]])
+
+def test_issue_9396():
+    M = (x + y).subs(x, Matrix([[1, 2]]))
+    assert Matrix([[1, 2]]) in [t[0] for t in M.as_terms()[0]]


### PR DESCRIPTION
Printing of Add-expressions having arguments with no as_coeff_Mul- method currently raises an AttributeError in as_terms.

This commit makes it possible to examine such expressions by catching the exception.

There is also a simplified test for the original issue.

Fixes #9396
