### PR TITLE
Avoid string comparison of versions

### DIFF
--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 import sys
 sys._running_pytest = True
+from distutils.version import LooseVersion as V
 
 import pytest
 from sympy.core.cache import clear_cache
@@ -71,6 +72,6 @@ def check_disabled(request):
         pytest.skip("test requirements not met.")
     elif getattr(request.module, 'ipython', False):
         # need to check version and options for ipython tests
-        if (pytest.__version__ < '2.6.3' and
+        if (V(pytest.__version__) < '2.6.3' and
             pytest.config.getvalue('-s') != 'no'):
             pytest.skip("run py.test with -s or upgrade to newer version.")

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -1,6 +1,8 @@
 """ Caching facility for SymPy """
 from __future__ import print_function, division
 
+from distutils.version import LooseVersion as V
+
 class _cache(list):
     """ List of cached functions """
 
@@ -49,7 +51,7 @@ try:
         warn("fastcache version >= 0.4.0 required", UserWarning)
         raise ImportError
         # ensure minimum required version of fastcache is present
-    if fastcache.__version__ < '0.4.0':
+    if V(fastcache.__version__) < '0.4.0':
         warn("fastcache version >= 0.4.0 required, detected {}"\
              .format(fastcache.__version__), UserWarning)
         raise ImportError

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, division
 
+from distutils.version import LooseVersion as V
 from io import BytesIO
 
 from sympy import latex as default_latex
@@ -166,7 +167,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             print(repr(arg))
 
     import IPython
-    if IPython.__version__ >= '0.11':
+    if V(IPython.__version__) >= '0.11':
         from sympy.core.basic import Basic
         from sympy.matrices.matrices import MatrixBase
         from sympy.physics.vector import Vector, Dyadic
@@ -350,7 +351,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
             # IPython 1.0 deprecates the frontend module, so we import directly
             # from the terminal module to prevent a deprecation message from being
             # shown.
-            if IPython.__version__ >= '1.0':
+            if V(IPython.__version__) >= '1.0':
                 from IPython.terminal.interactiveshell import TerminalInteractiveShell
             else:
                 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -2,6 +2,8 @@
 
 from __future__ import print_function, division
 
+from distutils.version import LooseVersion as V
+
 from sympy.core.compatibility import range
 from sympy.external import import_module
 from sympy.interactive.printing import init_printing
@@ -245,12 +247,12 @@ def init_ipython_session(argv=[], auto_symbols=False, auto_int_to_Integer=False)
     """Construct new IPython session. """
     import IPython
 
-    if IPython.__version__ >= '0.11':
+    if V(IPython.__version__) >= '0.11':
         # use an app to parse the command line, and init config
         # IPython 1.0 deprecates the frontend module, so we import directly
         # from the terminal module to prevent a deprecation message from being
         # shown.
-        if IPython.__version__ >= '1.0':
+        if V(IPython.__version__) >= '1.0':
             from IPython.terminal import ipapp
         else:
             from IPython.frontend.terminal import ipapp
@@ -404,7 +406,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 raise RuntimeError("IPython is not available on this system")
             ip = None
         else:
-            if IPython.__version__ >= '0.11':
+            if V(IPython.__version__) >= '0.11':
                 try:
                     ip = get_ipython()
                 except NameError:
@@ -425,7 +427,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
             ip = init_ipython_session(argv=argv, auto_symbols=auto_symbols,
                 auto_int_to_Integer=auto_int_to_Integer)
 
-        if IPython.__version__ >= '0.11':
+        if V(IPython.__version__) >= '0.11':
             # runsource is gone, use run_cell instead, which doesn't
             # take a symbol arg.  The second arg is `store_history`,
             # and False means don't add the line to IPython's history.
@@ -444,9 +446,9 @@ def init_session(ipython=None, pretty_print=True, order=None,
             mainloop = ip.mainloop
 
     readline = import_module("readline")
-    if auto_symbols and (not ipython or IPython.__version__ < '0.11' or not readline):
+    if auto_symbols and (not ipython or V(IPython.__version__) < '0.11' or not readline):
         raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above with readline support")
-    if auto_int_to_Integer and (not ipython or IPython.__version__ < '0.11'):
+    if auto_int_to_Integer and (not ipython or V(IPython.__version__) < '0.11'):
         raise RuntimeError("automatic int to Integer transformation is possible only in IPython 0.11 or above")
 
     _preexec_source = preexec_source


### PR DESCRIPTION
Use distutils.version.LooseVersion to parse version strings.

String comparison often gives incorrect results, e.g. `'0.9' > '0.10'`.
