### PR TITLE
xreplace check for rebuild is faster

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1077,7 +1077,7 @@ class Basic(with_metaclass(ManagedProperties)):
               themselves.
 
         """
-        (value, changed) = self._xreplace(rule)
+        (value, _) = self._xreplace(rule)
         return value
 
     def _xreplace(self, rule):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1077,7 +1077,7 @@ class Basic(with_metaclass(ManagedProperties)):
               themselves.
 
         """
-        (value, _) = self._xreplace(rule)
+        value, _ = self._xreplace(rule)
         return value
 
     def _xreplace(self, rule):
@@ -1085,7 +1085,7 @@ class Basic(with_metaclass(ManagedProperties)):
         Helper for xreplace. Tracks whether a replacement actually occurred.
         """
         if self in rule:
-            return (rule[self], True)
+            return rule[self], True
         elif rule:
             args = []
             changed = False
@@ -1098,8 +1098,8 @@ class Basic(with_metaclass(ManagedProperties)):
                     args.append(a)
             args = tuple(args)
             if changed:
-                return (self.func(*args), True)
-        return (self, False)
+                return self.func(*args), True
+        return self, False
 
     @cacheit
     def has(self, *patterns):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1077,19 +1077,29 @@ class Basic(with_metaclass(ManagedProperties)):
               themselves.
 
         """
+        (value, changed) = self._xreplace(rule)
+        return value
+
+    def _xreplace(self, rule):
+        """
+        Helper for xreplace. Tracks whether a replacement actually occurred.
+        """
         if self in rule:
-            return rule[self]
+            return (rule[self], True)
         elif rule:
             args = []
+            changed = False
             for a in self.args:
                 try:
-                    args.append(a.xreplace(rule))
+                    a_xr = a._xreplace(rule)
+                    args.append(a_xr[0])
+                    changed |= a_xr[1]
                 except AttributeError:
                     args.append(a)
             args = tuple(args)
-            if not _aresame(args, self.args):
-                return self.func(*args)
-        return self
+            if changed:
+                return (self.func(*args), True)
+        return (self, False)
 
     @cacheit
     def has(self, *patterns):


### PR DESCRIPTION
Rather than an intensive call to _aresame, xreplace simply tracks whether a rule has been applied (via helper function _xreplace). In applications where xreplace is called frequently on expressions with complicated argument trees, this optimization can have a considerable impact.

See https://github.com/sympy/sympy/issues/5999 for the original optimization to xreplace.
