### PR TITLE
Parser for relational and logical expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ sample.tex
 # IPython Notebook Checkpoints
 .ipynb_checkpoints/
 
+.project
+.pydevproject

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -229,6 +229,15 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     >>> kernS(s)
     -2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x))) - 1
 
+    See Also
+    ========
+
+    sympy.parsing.sympy_parser.parse_relationals: permits the parsing of <,
+        <=, ==, => and > into SymPy relational objects for use with solvers and
+        other. In future versions similar capabilities that differ too much
+        from python's ``eval`` (after which ``sympify`` is modeled) will be
+        consolidated in a complete parsing module.
+
     """
     if evaluate is None:
         evaluate = global_evaluate[0]

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -4,6 +4,7 @@ from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError, kernS
 from sympy.core.decorators import _sympifyit
+from sympy.core.relational import Rel
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
@@ -471,6 +472,18 @@ def test_kernS():
     assert kernS(['2*(x + y)*y', ('2*(x + y)*y',)]) == [e, (e,)]
     assert kernS('-(2*sin(x)**2 + 2*sin(x)*cos(x))*y/2') == \
         -y*(2*sin(x)**2 + 2*sin(x)*cos(x))/2
+
+
+def test_relationals():
+    from sympy.parsing.sympy_parser import parse_relationals
+    pr = parse_relationals
+    assert S(pr('sin(x)*x <= y')) == Rel(sin(x) * x, y, '<=')
+    assert S(pr('sin(x)*x != y')) == Rel(sin(x) * x, y, '!=')
+    assert S(pr('sin(x)*x <> y')) == Rel(sin(x) * x, y, '<>')
+    assert S(pr('sin(x)*x == y')) == Rel(sin(x) * x, y, '==')
+    assert S(pr('sin(x)*x >= y')) == Rel(sin(x) * x, y, '>=')
+    assert S(pr('sin(x)*x > y')) == Rel(sin(x) * x, y, '>')
+    assert S(pr('sin(x)*x < y')) == Rel(sin(x) * x, y, '<')
 
 
 def test_issue_6540_6552():

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -206,7 +206,8 @@ def parse_relationals(expr_string):
         if len([1 for t in tokens
                 if t.strip().endswith('(')]) != tokens.count(')'):
             raise TokenError(
-                "Unbalanced parentheses in expression: {}".format(expr_string))
+                "Unbalanced parentheses in expression: {0}"
+                .format(expr_string))
         tokens = tokens
         operators = []  # stack (in SY algorithm terminology)
         operands = []  # output stream
@@ -240,7 +241,7 @@ def parse_relationals(expr_string):
                         assert i < -1
                     except StopIteration:
                         raise TokenError(
-                            "Unbalanced parentheses in expression: {}"
+                            "Unbalanced parentheses in expression: {0}"
                             .format(expr_string))
                     # Get lists of operators and operands at this level
                     # (i.e. after the last left paren)
@@ -259,8 +260,8 @@ def parse_relationals(expr_string):
                         # Pop the highest precedence operator
                         op = relational_operators[level_operators.pop(i)][0]
                         # Create the parsed sub-expression
-                        sub = '{}({}, {})'.format(op, level_operands.pop(i),
-                                                  level_operands.pop(i))
+                        sub = '{0}({1}, {2})'.format(
+                            op, level_operands.pop(i), level_operands.pop(i))
                         # Insert the parsed sub-expression back into the
                         # operands in place of the two combined expressions
                         level_operands.insert(i, str(sub))
@@ -275,7 +276,7 @@ def parse_relationals(expr_string):
                         operands[-1] = operators.pop() + operands[-1] + ')'
                     except IndexError:
                         raise TokenError(
-                            "Unbalanced parentheses in expression: {}"
+                            "Unbalanced parentheses in expression: {0}"
                             .format(expr_string))
                 num_args[-1] += 1
             # If the token is one of ('&', '|', '<', '>', '<=', '>=' or '==')
@@ -290,7 +291,7 @@ def parse_relationals(expr_string):
                 if n == 0:
                     raise TokenError(
                         "Logical/relational operator directly after a "
-                        "parenthesis or start of expression: {}"
+                        "parenthesis or start of expression: {0}"
                         .format(expr_string))
                 elif n > 1:
                     operands = operands[:-n] + [''.join(operands[-n:])]


### PR DESCRIPTION
Added `parse_relationals` function to sympy_parser.py to provide improved
parsing of relational expressions, which translates '==', '<>', '&&',
'||', '!' operators to into SymPy friendly strings.

Also, the requirement (I think) that sub-expressions of boolean expressions are enclosed in
parenthesis is removed.

This PR is an alternative to #1541 and addresses issue #1378.

NB: Some additional test cases to test more complicated expressions are still required
