### PR TITLE
pretty print: use a proper unicode prime symbol

### DIFF
--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -208,7 +208,6 @@ modifier_dict = {
     'hat': lambda s: s+u('\N{COMBINING CIRCUMFLEX ACCENT}'),
     'bar': lambda s: s+u('\N{COMBINING OVERLINE}'),
     'vec': lambda s: s+u('\N{COMBINING RIGHT ARROW ABOVE}'),
-    # alternatively: MODIFIER LETTER PRIME or even plain old APOSTROPHE
     'prime': lambda s: s+u('\N{PRIME}'),
     'prm': lambda s: s+u('\N{PRIME}'),
     # # Faces -- these are here for some compatibility with latex printing

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -208,8 +208,9 @@ modifier_dict = {
     'hat': lambda s: s+u('\N{COMBINING CIRCUMFLEX ACCENT}'),
     'bar': lambda s: s+u('\N{COMBINING OVERLINE}'),
     'vec': lambda s: s+u('\N{COMBINING RIGHT ARROW ABOVE}'),
-    'prime': lambda s: s+u(' \N{COMBINING VERTICAL LINE ABOVE}'),
-    'prm': lambda s: s+u(' \N{COMBINING VERTICAL LINE ABOVE}'),
+    # alternatively: MODIFIER LETTER PRIME or even plain old APOSTROPHE
+    'prime': lambda s: s+u('\N{PRIME}'),
+    'prm': lambda s: s+u('\N{PRIME}'),
     # # Faces -- these are here for some compatibility with latex printing
     # 'bold': lambda s: s,
     # 'bm': lambda s: s,

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -306,8 +306,8 @@ def test_upretty_modifiers():
     assert upretty( Symbol('Fhat') ) == u('F̂')
     assert upretty( Symbol('Fbar') ) == u('F̅')
     assert upretty( Symbol('Fvec') ) == u('F⃗')
-    assert upretty( Symbol('Fprime') ) == u('F ̍')
-    assert upretty( Symbol('Fprm') ) == u('F ̍')
+    assert upretty( Symbol('Fprime') ) == u('F′')
+    assert upretty( Symbol('Fprm') ) == u('F′')
     # No faces are actually implemented, but test to make sure the modifiers are stripped
     assert upretty( Symbol('Fbold') ) == u('Fbold')
     assert upretty( Symbol('Fbm') ) == u('Fbm')
@@ -323,8 +323,8 @@ def test_upretty_modifiers():
     assert upretty( Symbol('xvecdot') ) == u('x⃗̇')
     assert upretty( Symbol('xDotVec') ) == u('ẋ⃗')
     assert upretty( Symbol('xHATNorm') ) == u('‖x̂‖')
-    assert upretty( Symbol('xMathring_yCheckPRM__zbreveAbs') ) == u('x̊_y̌ ̍__|z̆|')
-    assert upretty( Symbol('alphadothat_nVECDOT__tTildePrime') ) == u('α̇̂_n⃗̇__t̃ ̍')
+    assert upretty( Symbol('xMathring_yCheckPRM__zbreveAbs') ) == u('x̊_y̌′__|z̆|')
+    assert upretty( Symbol('alphadothat_nVECDOT__tTildePrime') ) == u('α̇̂_n⃗̇__t̃′')
     assert upretty( Symbol('x_dot') ) == u('x_dot')
     assert upretty( Symbol('x__dot') ) == u('x__dot')
 


### PR DESCRIPTION
Previous approach used a combining character with a space: not sure
if that is allowed but at least on my system (standard Fedora)
it didn't look good (prime was separated from the symbol, often
running into the next character).
