### PR TITLE
expr: never multiplicatively/additively extract from a NaN

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1877,6 +1877,8 @@ class Expr(Basic, EvalfMixin):
 
         """
         c = sympify(c)
+        if self is S.NaN:
+            return None
         if c is S.One:
             return self
         elif c == self:
@@ -1903,8 +1905,6 @@ class Expr(Basic, EvalfMixin):
             elif self is S.ComplexInfinity:
                 if not c.is_zero:
                     return S.ComplexInfinity
-            elif self is S.NaN:
-                return S.NaN
             elif self.is_Integer:
                 if not quotient.is_Integer:
                     return None
@@ -1996,6 +1996,8 @@ class Expr(Basic, EvalfMixin):
         """
 
         c = sympify(c)
+        if self is S.NaN:
+            return None
         if c is S.Zero:
             return self
         elif c == self:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1044,6 +1044,12 @@ def test_extractions():
     assert (-x + y).could_extract_minus_sign() is True
 
 
+def test_nan_extractions():
+    for r in (1, 0, I, nan):
+        assert nan.extract_additively(r) is None
+        assert nan.extract_multiplicatively(r) is None
+
+
 def test_coeff():
     assert (x + 1).coeff(x + 1) == 1
     assert (3*x).coeff(0) == 0

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -271,6 +271,12 @@ def test_bessel_eval():
     assert besselj(3, I*z) == -I*besseli(3, z)
 
 
+def test_bessel_nan():
+    # FIXME: could have these return NaN; for now just fix infinite recursion
+    for f in [besselj, bessely, besseli, besselk, hankel1, hankel2, yn, jn]:
+        assert f(1, S.NaN) == f(1, S.NaN, evaluate=False)
+
+
 def test_conjugate():
     from sympy import conjugate, I, Symbol
     n, z, x = Symbol('n'), Symbol('z', real=False), Symbol('x', real=True)


### PR DESCRIPTION
You can multiplicatively extract nan from anything... but the docs
for these functions note "in a nice way".  Consider:

```
(5*I).extract_multiplicatively(I)    # 5
(S.One).extract_multiplicatively(I)  # None
```

Notable, latter does not give `1/I`.  However:

```
nan.extract_multiplicatively(I)   # was nan, now None
```

The fix is to always return None when self is NaN.

This fixes an infinite recursion in Bessel functions with NaN
arguments: test added.

Other inconsistencies that are fixed and tested:

```
nan.extract_multiplicatively(nan)   # was 1
nan.extract_additively(1)           # was an error
nan.extract_additively(nan)         # was 0
```
