### PR TITLE
Bessel functions: raise error more/less than two inputs

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -49,6 +49,10 @@ class BesselBase(Function):
         """ The argument of the bessel-type function. """
         return self.args[1]
 
+    @classmethod
+    def eval(cls, nu, z):
+        return
+
     def fdiff(self, argindex=2):
         if argindex != 2:
             raise ArgumentIndexError(self, argindex)

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -9,6 +9,7 @@ from sympy.utilities.randtest import (random_complex_number as randcplx,
                                       verify_numerically as tn,
                                       test_derivative_numerically as td,
                                       _randint)
+from sympy.utilities.pytest import raises
 
 from sympy.abc import z, n, k, x
 
@@ -18,6 +19,12 @@ randint = _randint()
 def test_bessel_rand():
     for f in [besselj, bessely, besseli, besselk, hankel1, hankel2, jn, yn]:
         assert td(f(randcplx(), z), z)
+
+
+def test_bessel_twoinputs():
+    for f in [besselj, bessely, besseli, besselk, hankel1, hankel2, jn, yn]:
+        raises(TypeError, lambda: f(1))
+        raises(TypeError, lambda: f(1, 2, 3))
 
 
 def test_diff():


### PR DESCRIPTION
Previously a command like `h = hankel(x)` seemed to succeed but would
fail in unclear ways when used (e.g., `h.argument`).

To fix, we define a generic `eval` method in the `BesselBase` class,
which serves to mark these functions as taking two inputs.

Add tests.
