### PR TITLE
solve(x-oo) now returns []

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -401,7 +401,14 @@ def solve_univariate_inequality(expr, gen, relational=True):
     e = expr.lhs - expr.rhs
     parts = n, d = e.as_numer_denom()
     if all(i.is_polynomial(gen) for i in parts):
-        solns = solve(n, gen, check=False)
+        if S.Infinity in n.args or S.NegativeInfinity in n.args:
+            pop1 = Symbol('pop1')
+            pop2 = Symbol('pop2')
+            n1 = n.subs({S.Infinity: pop1, S.NegativeInfinity: pop2})
+            solns = solve(n1, gen, check=False)
+            solns = [i.subs({pop1: S.Infinity, pop2: S.NegativeInfinity}) for i in solns]
+        else:
+            solns = solve(n, gen, check=False)
         singularities = solve(d, gen, check=False)
     else:
         solns = solve(e, gen, check=False)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1112,10 +1112,16 @@ def solve(f, *symbols, **flags):
         no_False = []  # solutions for which no symbols gave False
         if type(solution) is tuple:
             # this has already been checked and is in as_set form
-            return solution
+            if S.Infinity in solution or S.NegativeInfinity in solution:
+                return ()
+            else:
+                return solution
         elif type(solution) is list:
             if type(solution[0]) is tuple:
                 for sol in solution:
+                    if S.Infinity in sol or S.NegativeInfinity in sol:
+                        solution.remove(sol)
+                        continue
                     for symb, val in zip(symbols, sol):
                         test = check_assumptions(val, **symb.assumptions0)
                         if test is False:
@@ -1128,6 +1134,9 @@ def solve(f, *symbols, **flags):
                 for sol in solution:
                     a_None = False
                     for symb, val in sol.items():
+                        if val == S.Infinity or val == S.NegativeInfinity:
+                            solution.remove(sol)
+                            continue
                         test = check_assumptions(val, **symb.assumptions0)
                         if test:
                             continue
@@ -1140,6 +1149,9 @@ def solve(f, *symbols, **flags):
                             got_None.append(sol)
             else:  # list of expressions
                 for sol in solution:
+                    if sol == S.Infinity or sol == S.NegativeInfinity:
+                        solution = []
+                        break
                     test = check_assumptions(sol, **symbols[0].assumptions0)
                     if test is False:
                         continue
@@ -1150,6 +1162,9 @@ def solve(f, *symbols, **flags):
         elif type(solution) is dict:
             a_None = False
             for symb, val in solution.items():
+                if val == S.Infinity or val == S.NegativeInfinity:
+                    solution = dict()
+                    break
                 test = check_assumptions(val, **symb.assumptions0)
                 if test:
                     continue

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -302,3 +302,10 @@ def test_issue_8545():
 def test_issue_8974():
     assert isolve(-oo < x, x) == And(-oo < x, x < oo)
     assert isolve(oo > x, x) == And(-oo < x, x < oo)
+
+def test_issue_8260():
+    assert isolve( x < -oo, x) == False
+    assert isolve( x > oo, x) == False
+    assert isolve( x >= oo, x) == Eq(x, oo)
+    assert isolve( x <= -oo, x) == Eq(x, -oo)
+    assert solve([oo < x, y > 4]) == False

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1771,3 +1771,9 @@ def test_issue_2840_8155():
     assert solve(2*sin(x) - 2*sin(2*x)) == [
         0, -pi, pi, -2*I*log(-sqrt(3)/2 - I/2), -2*I*log(-sqrt(3)/2 + I/2),
         -2*I*log(sqrt(3)/2 - I/2), -2*I*log(sqrt(3)/2 + I/2)]
+
+def test_issue_8260():
+    assert solve(x-oo , x) == []
+    assert solve(x+oo , x) == []
+    assert solve([x+oo, y+4], x, y) == []
+    assert solve([x+oo, y+4], y) == {y: -4}


### PR DESCRIPTION
@hargup , @toolforger  I have made this new PR for the issue 8260 with the same code but only one additional test has been added. I could not figure why it was failing tests on Travis
fixes the issue #8260
I substituted symbols for oo and -oo in the solve_univariate_inequality() function in inequalities.py before processing them to solve() function and then substituted for symbols the value of oo and -oo back into them. I changed solve() function to return no solution for the system of solution containing oo or -oo as value for any of the args in the equation system.
