### PR TITLE
M.row_insert() and M.col_insert() now act in-place for all indices

### DIFF
--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -102,12 +102,12 @@ operations **do not** operate in place.
 
     >>> M
     [2  3]
-    >>> M = M.row_insert(1, Matrix([[0, 4]]))
+    >>> M.row_insert(1, Matrix([[0, 4]]))
     >>> M
     ⎡2  3⎤
     ⎢    ⎥
     ⎣0  4⎦
-    >>> M = M.col_insert(0, Matrix([1, -2]))
+    >>> M.col_insert(0, Matrix([1, -2]))
     >>> M
     ⎡1   2  3⎤
     ⎢        ⎥

--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -98,7 +98,7 @@ will modify the Matrix **in place**.
 .. TODO: This is a mess. See issue 6992.
 
 To insert rows or columns, use ``row_insert`` or ``col_insert``.  These
-operations **do not** operate in place.
+operations will modify the Matrix **in place**.
 
     >>> M
     [2  3]

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3957,6 +3957,8 @@ class MatrixBase(object):
         row
         col_insert
         """
+        if not isinstance(pos, (int, Integer)):
+            raise TypeError("Index value must be 'int' or 'Integer': 'pos = %s'" % (pos))
         if pos == 0:
             return mti.col_join(self)
         elif pos < 0:
@@ -3998,6 +4000,8 @@ class MatrixBase(object):
         col
         row_insert
         """
+        if not isinstance(pos, (int, Integer)):
+            raise TypeError("Index value must be 'int' or 'Integer': 'pos = %s'" % (pos))
         if pos == 0:
             return mti.row_join(self)
         elif pos < 0:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4032,8 +4032,8 @@ class MatrixBase(object):
                 self[:,k1:self.cols] = mti[:,:]
             else:
                 self.cols += mti.cols
-                self[:,pos + mti.cols:self.cols:] = self[:,pos:self.cols - mti.cols:]
-                self[:,pos:pos + mti.cols:] = mti[:,:]
+                self[:,pos + mti.cols:self.cols] = self[:,pos:self.cols - mti.cols]
+                self[:,pos:pos + mti.cols] = mti[:,:]
 
     def replace(self, F, G, map=False):
         """Replaces Function F in Matrix entries with Function G.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3957,27 +3957,18 @@ class MatrixBase(object):
         row
         col_insert
         """
-        if not isinstance(pos, (int, Integer)):
-            raise TypeError("Index value must be 'int' or 'Integer': 'pos = %s'" % (pos))
-        if pos == 0:
-            return mti.col_join(self)
-        elif pos < 0:
-            pos = self.rows + pos
+        i = pos
         if pos < 0:
-            pos = 0
-        elif pos > self.rows:
-            pos = self.rows
-
-        if self.cols != mti.cols:
+            pos = self.rows + pos
+        if pos < 0 or pos > self.rows:
+            raise IndexError("Index out of bounds: 'pos = %s', valid -%s <= pos <= %s" 
+                % (i, self.rows, self.rows))
+        elif self.cols != mti.cols:
             raise ShapeError(
-                "`self` and `mti` must have the same number of columns.")
-
-        newmat = self.zeros(self.rows + mti.rows, self.cols)
-        i, j = pos, pos + mti.rows
-        newmat[:i, :] = self[:i, :]
-        newmat[i: j, :] = mti
-        newmat[j:, :] = self[i:, :]
-        return newmat
+                    "`self` and `mti` must have the same number of columns.")
+        else:
+            self._mat[pos*self.rows:pos*self.rows] = mti._mat
+        self.rows += mti.rows
 
     def col_insert(self, pos, mti):
         """Insert one or more columns at the given column position.
@@ -4000,27 +3991,19 @@ class MatrixBase(object):
         col
         row_insert
         """
-        if not isinstance(pos, (int, Integer)):
-            raise TypeError("Index value must be 'int' or 'Integer': 'pos = %s'" % (pos))
-        if pos == 0:
-            return mti.row_join(self)
-        elif pos < 0:
-            pos = self.cols + pos
+        i = pos
         if pos < 0:
-            pos = 0
-        elif pos > self.cols:
-            pos = self.cols
-
-        if self.rows != mti.rows:
-            raise ShapeError("self and mti must have the same number of rows.")
-
-        from sympy.matrices import MutableMatrix
-        newmat = MutableMatrix.zeros(self.rows, self.cols + mti.cols)
-        i, j = pos, pos + mti.cols
-        newmat[:, :i] = self[:, :i]
-        newmat[:, i:j] = mti
-        newmat[:, j:] = self[:, i:]
-        return type(self)(newmat)
+            pos = self.cols + pos
+        if pos < 0 or pos > self.cols:
+            raise IndexError("Index out of bounds: 'pos = %s', valid -%s <= pos <= %s" 
+                % (i, self.cols, self.cols))
+        elif self.rows != mti.rows:
+            raise ShapeError(
+                    "`self` and `mti` must have the same number of rows.")
+        else:
+            for j in range(self.rows - 1, -1, -1):
+                self._mat[pos + j*self.cols:pos + j*self.cols] = mti._mat[j*mti.cols:(j + 1)*mti.cols]
+        self.cols += mti.cols
 
     def replace(self, F, G, map=False):
         """Replaces Function F in Matrix entries with Function G.

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -535,12 +535,12 @@ class SparseMatrix(MatrixBase):
             for i, r in enumerate(rowsList):
                 i_previous = rowsList.index(r)
                 if i_previous != i:
-                    rv = rv.row_insert(i, rv.row(i_previous))
+                    rv.row_insert(i, rv.row(i_previous))
         if len(colsList) != len(ucol):
             for i, c in enumerate(colsList):
                 i_previous = colsList.index(c)
                 if i_previous != i:
-                    rv = rv.col_insert(i, rv.col(i_previous))
+                    rv.col_insert(i, rv.col(i_previous))
         return rv
     extract.__doc__ = MatrixBase.extract.__doc__
 

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1363,7 +1363,8 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         Joining at row ends is the same as appending columns at the end
         of the matrix:
 
-        >>> C == A.col_insert(A.cols, B)
+        >>> A.col_insert(A.cols, B)
+        >>> C == A
         True
         """
         A, B = self, other
@@ -1421,7 +1422,8 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         Joining along columns is the same as appending rows at the end
         of the matrix:
 
-        >>> C == A.row_insert(A.rows, Matrix(B))
+        >>> A.row_insert(A.rows, Matrix(B))
+        >>> C == A
         True
         """
         A, B = self, other

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2494,7 +2494,49 @@ def test_issue_9457_9467():
     raises(IndexError, lambda: Q.col_del(-10))
 
 def test_issue_9476():
-    M = Matrix([[1, 2, 3], [2, 3,4]])
-    raises(TypeError, lambda: M.row_insert(1.5, Matrix([[1, 1, 1]])))
-    raises(TypeError, lambda: M.row_insert(2.5, Matrix([[1, 1, 1]])))
-    raises(TypeError, lambda: M.row_insert(-2.5, Matrix([[1, 1, 1]])))
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    V = Matrix([[10, 10, 10]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.row_insert(1, V)
+    assert M == Matrix([[1, 2, 3], [10, 10, 10], [2, 3, 4], [3, 4, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.row_insert(2, V)
+    assert M == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.row_insert(3, V)
+    assert M == Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5], [10, 10, 10]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(4, V))
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(5.5, V))
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(4, V))
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.row_insert(-1, V)
+    assert M == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
+
+    V = Matrix([10, 10, 10])
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(1, V)
+    assert M == Matrix([[1, 10, 2, 3], [2, 10, 3, 4], [3, 10, 4, 5]])
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(2, V)
+    assert M == Matrix([[1, 2, 10, 3], [2, 3, 10, 4], [3, 4, 10, 5]])
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(3, V)
+    assert M == Matrix([[1, 2, 3, 10], [2, 3, 4, 10], [3, 4, 5, 10]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(-1, V)
+    assert M == Matrix([[1, 2, 10, 3], [2, 3, 10, 4], [3, 4, 10, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(0, V)
+    assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2492,3 +2492,9 @@ def test_issue_9457_9467():
     raises(IndexError, lambda: P.col_del(10))
     Q = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     raises(IndexError, lambda: Q.col_del(-10))
+
+def test_issue_9476():
+    M = Matrix([[1, 2, 3], [2, 3,4]])
+    raises(TypeError, lambda: M.row_insert(1.5, Matrix([[1, 1, 1]])))
+    raises(TypeError, lambda: M.row_insert(2.5, Matrix([[1, 1, 1]])))
+    raises(TypeError, lambda: M.row_insert(-2.5, Matrix([[1, 1, 1]])))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2514,7 +2514,8 @@ def test_issue_9476():
     assert M == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.row_insert(-4, V))
+    M.row_insert(-4, V)
+    assert M == Matrix([[10, 10, 10], [1, 2, 3], [2, 3, 4], [3, 4, 5]])
 
     # for col_insert(index)
     V = Matrix([10, 10, 10])
@@ -2531,4 +2532,5 @@ def test_issue_9476():
     assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.col_insert(-4, V))
+    M.col_insert(-4, V)
+    assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1987,18 +1987,22 @@ def test_col_join():
 
 def test_row_insert():
     r4 = Matrix([[4, 4, 4]])
-    for i in range(-4, 5):
+    for i in range(-3, 3):
         l = [1, 0, 0]
         l.insert(i, 4)
-        assert flatten(eye(3).row_insert(i, r4).col(0).tolist()) == l
+        a = eye(3)
+        a.row_insert(i, r4)
+        assert flatten(a.col(0).tolist()) == l
 
 
 def test_col_insert():
     c4 = Matrix([4, 4, 4])
-    for i in range(-4, 5):
+    for i in range(-3, 3):
         l = [0, 0, 0]
         l.insert(i, 4)
-        assert flatten(zeros(3).col_insert(i, c4).row(0).tolist()) == l
+        a = zeros(3)
+        a.col_insert(i, c4)
+        assert flatten(a.row(0).tolist()) == l
 
 
 def test_normalized():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2494,16 +2494,13 @@ def test_issue_9457_9467():
     raises(IndexError, lambda: Q.col_del(-10))
 
 def test_issue_9476():
+    # for row_insert(index)
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     V = Matrix([[10, 10, 10]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     M.row_insert(1, V)
     assert M == Matrix([[1, 2, 3], [10, 10, 10], [2, 3, 4], [3, 4, 5]])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    M.row_insert(2, V)
-    assert M == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     M.row_insert(3, V)
@@ -2513,25 +2510,17 @@ def test_issue_9476():
     raises(IndexError, lambda: M.row_insert(4, V))
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.row_insert(5.5, V))
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.row_insert(4, V))
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     M.row_insert(-1, V)
     assert M == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
 
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(-4, V))
+
+    # for col_insert(index)
     V = Matrix([10, 10, 10])
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     M.col_insert(1, V)
     assert M == Matrix([[1, 10, 2, 3], [2, 10, 3, 4], [3, 10, 4, 5]])
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    M.col_insert(2, V)
-    assert M == Matrix([[1, 2, 10, 3], [2, 3, 10, 4], [3, 4, 10, 5]])
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    M.col_insert(3, V)
-    assert M == Matrix([[1, 2, 3, 10], [2, 3, 4, 10], [3, 4, 5, 10]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     M.col_insert(-1, V)
@@ -2540,3 +2529,6 @@ def test_issue_9476():
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     M.col_insert(0, V)
     assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.col_insert(-4, V))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2499,7 +2499,6 @@ def test_issue_9457_9467():
 
 def test_issue_9476():
     # for row_insert(index)
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     V = Matrix([[10, 10, 10]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
@@ -2518,8 +2517,7 @@ def test_issue_9476():
     assert M == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    M.row_insert(-4, V)
-    assert M == Matrix([[10, 10, 10], [1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(-4, V))
 
     # for col_insert(index)
     V = Matrix([10, 10, 10])
@@ -2536,5 +2534,4 @@ def test_issue_9476():
     assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    M.col_insert(-4, V)
-    assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
+    raises(IndexError, lambda: M.col_insert(-4, V))

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -567,7 +567,6 @@ def test_hermitian():
 
 def test_issue_9476():
     # for row_insert(index)
-    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     V = Matrix([[10, 10, 10]])
 
     M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
@@ -586,8 +585,7 @@ def test_issue_9476():
     assert M == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
 
     M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    M.row_insert(-4, V)
-    assert M == Matrix([[10, 10, 10], [1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(-4, V))
 
     # for col_insert(index)
     V = SparseMatrix([10, 10, 10])
@@ -604,5 +602,4 @@ def test_issue_9476():
     assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
 
     M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    M.col_insert(-4, V)
-    assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
+    raises(IndexError, lambda: M.col_insert(-4, V))

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -564,3 +564,45 @@ def test_hermitian():
     assert a.is_hermitian is None
     a[0, 1] = a[1, 0]*I
     assert a.is_hermitian is False
+
+def test_issue_9476():
+    # for row_insert(index)
+    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    V = Matrix([[10, 10, 10]])
+
+    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.row_insert(1, V)
+    assert M == Matrix([[1, 2, 3], [10, 10, 10], [2, 3, 4], [3, 4, 5]])
+
+    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.row_insert(3, V)
+    assert M == Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5], [10, 10, 10]])
+
+    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(4, V))
+
+    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.row_insert(-1, V)
+    assert M == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
+
+    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.row_insert(-4, V)
+    assert M == Matrix([[10, 10, 10], [1, 2, 3], [2, 3, 4], [3, 4, 5]])
+
+    # for col_insert(index)
+    V = SparseMatrix([10, 10, 10])
+    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(1, V)
+    assert M == Matrix([[1, 10, 2, 3], [2, 10, 3, 4], [3, 10, 4, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(-1, V)
+    assert M == Matrix([[1, 2, 10, 3], [2, 3, 10, 4], [3, 4, 10, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(0, V)
+    assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
+
+    M = SparseMatrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    M.col_insert(-4, V)
+    assert M == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -700,10 +700,11 @@ class Formula(object):
         self.C = Matrix([[1] + [0]*n])
 
         m = eye(n)
-        m = m.col_insert(0, zeros(n, 1))
+        m.col_insert(0, zeros(n, 1))
         l = poly.all_coeffs()[1:]
         l.reverse()
-        self.M = m.row_insert(n, -Matrix([l])/poly.all_coeffs()[0])
+        m.row_insert(n, -Matrix([l])/poly.all_coeffs()[0])
+        self.M = m
 
     def __init__(self, func, z, res, symbols, B=None, C=None, M=None):
         z = sympify(z)


### PR DESCRIPTION
Refer to issue: #9476 

**Problem** : Right now `M.row_insert()` and `M.col_insert()` does not raise error for some non-int indices

```
>>> M = Matrix([ [1, 2, 3], [2, 3, 4], [3, 4, 5] ])
>>> M.row_insert(5.5,  Matrix([ [10, 10, 10] ])               #for float indices index < -M.rows, index > M.rows
Matrix([ [1, 2, 3], [2, 3, 4], [3, 4, 5], [10, 10, 10] ])
```

same is for the `col_insert()`

**Fix**:  As was raised raised in one of the issues by _`asmeurer`_ that to make the all the operations like `row_insert()` and `row_del()` the same way ( whether in-place or returning new matrices ). I find it better if they all operate `in-place` instead of `returning new matrices`.

**Fix Attempt** : I have also avoided assigning the `self [: , : ]` to `zeros` of that order for `SparseMatrix` ( that is done in stable version ) since just by increasing its rows we can puts zeros at those places.
