### PR TITLE
Separate metaclass hierarchy from class hierarchy

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -308,7 +308,7 @@ def _ask(fact, obj):
     return None
 
 
-class ManagedProperties(with_metaclass(BasicMeta, BasicMeta)):
+class ManagedProperties(BasicMeta):
     """Metaclass for classes with old-style assumptions"""
     def __init__(cls, *args, **kws):
         BasicMeta.__init__(cls, *args, **kws)

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,9 +1,8 @@
 """Base class for all the objects in SymPy"""
 from __future__ import print_function, division
 
-from .assumptions import ManagedProperties
+from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit
-from .core import BasicType
 from .sympify import _sympify, sympify, SympifyError
 from .compatibility import (iterable, Iterator, ordered,
     string_types, with_metaclass, zip_longest, range)
@@ -1126,7 +1125,7 @@ class Basic(with_metaclass(ManagedProperties)):
             for f in self.atoms(Function, UndefinedFunction))
 
         pattern = sympify(pattern)
-        if isinstance(pattern, BasicType):
+        if isinstance(pattern, BasicMeta):
             return any(isinstance(arg, pattern)
             for arg in preorder_traversal(self))
 

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -43,10 +43,6 @@ ordering_of_classes = [
 ]
 
 
-class BasicType(type):
-    pass
-
-
 class Registry(object):
     """
     Base class for registry objects.
@@ -69,7 +65,7 @@ class Registry(object):
 all_classes = set()
 
 
-class BasicMeta(BasicType):
+class BasicMeta(type):
 
     def __init__(cls, *args, **kws):
         all_classes.add(cls)
@@ -77,7 +73,7 @@ class BasicMeta(BasicType):
     def __cmp__(cls, other):
         # If the other object is not a Basic subclass, then we are not equal to
         # it.
-        if not isinstance(other, BasicType):
+        if not isinstance(other, BasicMeta):
             return -1
         n1 = cls.__name__
         n2 = other.__name__

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -92,7 +92,7 @@ class ArgumentIndexError(ValueError):
                (self.args[1], self.args[0]))
 
 
-class FunctionClass(with_metaclass(BasicMeta, ManagedProperties)):
+class FunctionClass(ManagedProperties):
     """
     Base class for function classes. FunctionClass is a subclass of type.
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -233,6 +233,11 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     if evaluate is None:
         evaluate = global_evaluate[0]
     try:
+        if a in sympy_classes:
+            return a
+    except TypeError: # Type of a is unhashable
+        pass
+    try:
         cls = a.__class__
     except AttributeError:  # a is probably an old-style class object
         cls = type(a)

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -4,7 +4,7 @@ import warnings
 from sympy.utilities.pytest import XFAIL
 
 from sympy.core.basic import Atom, Basic
-from sympy.core.core import BasicType
+from sympy.core.core import BasicMeta
 from sympy.core.singleton import SingletonRegistry
 from sympy.core.symbol import Dummy, Symbol, Wild
 from sympy.core.numbers import (E, I, pi, oo, zoo, nan, Integer,
@@ -42,7 +42,7 @@ def check(a, exclude=[], check_attr=True):
             continue
 
         if callable(protocol):
-            if isinstance(a, BasicType):
+            if isinstance(a, BasicMeta):
                 # Classes can't be copied, but that's okay.
                 return
             b = protocol(a)
@@ -78,7 +78,7 @@ def test_core_basic():
     for c in (Atom, Atom(),
               Basic, Basic(),
               # XXX: dynamically created types are not picklable
-              # BasicType, BasicType("test", (), {}),
+              # BasicMeta, BasicMeta("test", (), {}),
               SingletonRegistry, SingletonRegistry()):
         check(c)
 


### PR DESCRIPTION
ManagedProperties would use BasicMeta both as metaclass and superclass,
so `__init__` and `__new__` are called both for class and for object
creation. Such a situation confuses maintainers, libraries, and tools
alike.
FunctionClass had a similar condition, it used BasicMeta as metaclass
and ManagedProperties as superclass; it is now firmly a subclass of
ManagedProperties, i.e. a metaclass.

Also, BasicType served no real purpose anymore, so it was removed,
leaving BasicMeta as the root of the metaclass hierarchy.

The only non-metaclass code that needed a concomitant change was
`sympify()`: Metaclasses are not a "standard sympifiable class"
anymore, which it was assuming in a test.
