### PR TITLE
Q.nonzero(non-real) now returns False

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -135,6 +135,8 @@ class AskNonZeroHandler(CommonHandler):
 
     @staticmethod
     def Basic(expr, assumptions):
+        if ask(Q.real(expr)) is False:
+            return False
         if expr.is_number:
             # if there are no symbols just evalf
             i = expr.evalf(2)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1600,7 +1600,7 @@ def test_nonzero():
     assert ask(Q.nonzero(Abs(x))) is None
     assert ask(Q.nonzero(Abs(x)), Q.nonzero(x)) is True
 
-    assert ask(Q.nonzero(log(exp(2*I)))) is True
+    assert ask(Q.nonzero(log(exp(2*I)))) is False
     # although this could be False, it is representative of expressions
     # that don't evaluate to a zero with precision
     assert ask(Q.nonzero(cos(1)**2 + sin(1)**2 - 1)) is None


### PR DESCRIPTION
`Q.nonzero` as per the new definition.

<hr/>

`ask(Q.nonzero(x))` is true iff `x` is real and `x` is not zero.  Note in
particular that `Q.nonzero(x)` is false if `x` is not real.  Use
`~Q.zero(x)` if you want the negation of being zero without any real
assumptions.
