### PR TITLE
Delay singleton instance creation

### DIFF
--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -9,12 +9,45 @@ from .sympify import sympify
 
 class SingletonRegistry(Registry):
     """
-    A map between singleton classes and the corresponding instances.
+    A map from singleton classes to the corresponding instances.
     E.g. S.Exp == Exp()
     """
     __slots__ = []
 
+    # Also allow things like S(5)
     __call__ = staticmethod(sympify)
+
+    def __init__(self):
+        self._classes_to_install = {}
+        # Dict of classes that have been registered, but that have not have been
+        # installed as an attribute of this SingletonRegistry.
+        # Installation automatically happens at the first attempt to access the
+        # attribute.
+        # The purpose of this is to allow registration during class
+        # initialization during import, but not trigger object creation until
+        # actual use (which should not happen until after all imports are
+        # finished).
+
+    def register(self, cls):
+        self._classes_to_install[cls.__name__] = cls
+
+    def __getattr__(self, name):
+        """Python calls __getattr__ if no attribute of that name was installed
+        yet.
+
+        This __getattr__ checks whether a class with the requested name was
+        already registered but not installed; if no, raises an AttributeError.
+        Otherwise, retrieves the class, calculates its singleton value, installs
+        it as an attribute of the given name, and unregisters the class."""
+        if name not in self._classes_to_install:
+            raise AttributeError(
+                "Attribute '%s' was not installed on SymPy registry %s" % (
+                name, self))
+        class_to_install = self._classes_to_install[name]
+        value_to_install = class_to_install()
+        self.__setattr__(name, value_to_install)
+        del self._classes_to_install[name]
+        return value_to_install
 
     def __repr__(self):
         return "S"
@@ -45,37 +78,38 @@ class Singleton(ManagedProperties):
         >>> S.MySingleton is MySingleton()
         True
 
-    ** Developer notes **
-        The class is instantiated immediately at the point where it is defined
-        by calling cls.__new__(cls). This instance is cached and cls.__new__ is
-        rebound to return it directly.
+    Notes
+    =====
 
-        The original constructor is also cached to allow subclasses to access it
-        and have their own instance.
+    Instance creation is delayed until the first time the value is accessed.
+    (SymPy versions before 0.7.7 would create the instance during class
+    creation time, which would be prone to import cycles.)
 
+    This metaclass is a subclass of ManagedProperties because that is the
+    metaclass of many classes that need to be Singletons (Python does not allow
+    subclasses to have a different metaclass than the superclass, except the
+    subclass may use a subclassed metaclass).
     """
 
-    def __init__(cls, name, bases, dict_):
-        super(Singleton, cls).__init__(cls, name, bases, dict_)
+    _instances = {}
+    "Maps singleton classes to their instances."
 
-        for ancestor in cls.mro():
-            if '__new__' in ancestor.__dict__:
-                break
-        if isinstance(ancestor, Singleton) and ancestor is not cls:
-            ctor = ancestor._new_instance
-        else:
-            ctor = cls.__new__
-        cls._new_instance = staticmethod(ctor)
+    def __new__(cls, *args, **kwargs):
+        result = super(Singleton, cls).__new__(cls, *args, **kwargs)
+        S.register(result)
+        return result
 
-        the_instance = ctor(cls)
-
-        def __new__(cls):
-            return the_instance
-        cls.__new__ = staticmethod(__new__)
-
-        setattr(S, name, the_instance)
+    def __call__(self, *args, **kwargs):
+        # Called when application code says SomeClass(), where SomeClass is a
+        # class of which Singleton is the metaclas.
+        # __call__ is invoked first, before __new__() and __init__().
+        if self not in Singleton._instances:
+            Singleton._instances[self] = \
+                super(Singleton, self).__call__(*args, **kwargs)
+                # Invokes the standard constructor of SomeClass.
+        return Singleton._instances[self]
 
         # Inject pickling support.
         def __getnewargs__(self):
             return ()
-        cls.__getnewargs__ = __getnewargs__
+        self.__getnewargs__ = __getnewargs__

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -107,6 +107,8 @@ def test_Singleton():
             instantiated += 1
             return Basic.__new__(cls)
 
+    assert instantiated == 0
+    MySingleton() # force instantiation
     assert instantiated == 1
     assert MySingleton() is not Basic()
     assert MySingleton() is MySingleton()
@@ -115,6 +117,8 @@ def test_Singleton():
 
     class MySingleton_sub(MySingleton):
         pass
+    assert instantiated == 1
+    MySingleton_sub()
     assert instantiated == 2
     assert MySingleton_sub() is not MySingleton()
     assert MySingleton_sub() is MySingleton_sub()


### PR DESCRIPTION
Singleton classes used to create their instance during class
initialization, so we got calls into SymPy code during import, which
meant more import cycles.
With this, the instance will not be created until it is accessed for
the first time.
