### PR TITLE
Issue 9464

### DIFF
--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -86,3 +86,8 @@ Range
 ^^^^^
 .. autoclass:: Range
    :members:
+
+ComplexPlane
+^^^^^^^^^^^^
+.. autoclass:: ComplexPlane
+   :members:

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -108,7 +108,7 @@ Examples
 ========
 
     >>> from sympy import Symbol
-    >>> x = Symbol('x', real = True); x
+    >>> x = Symbol('x', real=True); x
     x
     >>> x.is_real
     True

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -188,6 +188,8 @@ class Basic(with_metaclass(ManagedProperties)):
             r = Basic(*r) if isinstance(r, frozenset) else r
             if isinstance(l, Basic):
                 c = l.compare(r)
+            elif l is None or r is None:
+                c = (l is not None) - (r is not None)
             else:
                 c = (l > r) - (l < r)
             if c:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -187,6 +187,8 @@ class Basic(with_metaclass(ManagedProperties)):
             r = Basic(*r) if isinstance(r, frozenset) else r
             if isinstance(l, Basic):
                 c = l.compare(r)
+            elif l is None or r is None:
+                c = (l is not None) - (r is not None)
             else:
                 c = (l > r) - (l < r)
             if c:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -655,9 +655,10 @@ class Expr(Basic, EvalfMixin):
                         if sol:
                             if s in sol:
                                 return True
-                            if any(nsimplify(si, [s]) == s and simplify(si) == s
-                                    for si in sol):
-                                return True
+                            if s.is_real:
+                                if any(nsimplify(si, [s]) == s and simplify(si) == s
+                                        for si in sol):
+                                    return True
                     except NotImplementedError:
                         pass
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -535,6 +535,17 @@ def test_sympy__sets__fancysets__Reals():
     assert _test_args(Reals())
 
 
+def test_sympy__sets__fancysets__ComplexPlane():
+    from sympy.sets.fancysets import ComplexPlane
+    from sympy import S
+    from sympy.sets import Interval
+    a = Interval(0, 1)
+    b = Interval(2, 3)
+    theta = Interval(0, 2*S.Pi)
+    assert _test_args(ComplexPlane(a, b))
+    assert _test_args(ComplexPlane(a, theta, polar=True))
+
+
 def test_sympy__sets__fancysets__ImageSet():
     from sympy.sets.fancysets import ImageSet
     from sympy import S, Symbol

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -542,8 +542,8 @@ def test_sympy__sets__fancysets__ComplexPlane():
     a = Interval(0, 1)
     b = Interval(2, 3)
     theta = Interval(0, 2*S.Pi)
-    assert _test_args(ComplexPlane(a, b))
-    assert _test_args(ComplexPlane(a, theta, polar=True))
+    assert _test_args(ComplexPlane(a*b))
+    assert _test_args(ComplexPlane(a*theta, polar=True))
 
 
 def test_sympy__sets__fancysets__ImageSet():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -535,6 +535,11 @@ def test_sympy__sets__fancysets__Reals():
     assert _test_args(Reals())
 
 
+def test_sympy__sets__fancysets__Complex():
+    from sympy.sets.fancysets import Complex
+    assert _test_args(Complex())
+
+
 def test_sympy__sets__fancysets__ComplexPlane():
     from sympy.sets.fancysets import ComplexPlane
     from sympy import S

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -36,6 +36,18 @@ def test_equality():
     assert not(Basic() == 0)
 
 
+def test_compare_issue_9464_a():
+    assert(Basic(1).compare(Basic(None)) > 0)
+
+
+def test_compare_issue_9464_b():
+    assert(Basic(None).compare(Basic(1)) < 0)
+
+
+def test_compare_issue_9464_c():
+    assert(Basic(None).compare(Basic(None)) == 0)
+
+
 def test_matches_basic():
     instances = [Basic(b1, b1, b2), Basic(b1, b2, b1), Basic(b2, b1, b1),
                  Basic(b1, b2), Basic(b2, b1), b2, b1]

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -36,15 +36,9 @@ def test_equality():
     assert not(Basic() == 0)
 
 
-def test_compare_issue_9464_a():
+def test_compare_issue_9464():
     assert(Basic(1).compare(Basic(None)) > 0)
-
-
-def test_compare_issue_9464_b():
     assert(Basic(None).compare(Basic(1)) < 0)
-
-
-def test_compare_issue_9464_c():
     assert(Basic(None).compare(Basic(None)) == 0)
 
 

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -3,9 +3,8 @@
 The module implements a data series called ImplicitSeries which is used by
 ``Plot`` class to plot implicit plots for different backends. The module,
 by default, implements plotting using interval arithmetic. It switches to a
-fall back algorithm if the expression cannot be plotted used interval
-interval arithmetic. It is also possible to specify to use the fall back
-algorithm for all plots.
+fall back algorithm if the expression cannot be plotted using interval arithmetic.
+It is also possible to specify to use the fall back algorithm for all plots.
 
 Boolean combinations of expressions cannot be plotted by the fall back
 algorithm.

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1558,6 +1558,9 @@ class LatexPrinter(Printer):
     def _print_Reals(self, i):
         return r"\mathbb{R}"
 
+    def _print_Complex(self, i):
+        return r"\mathbb{C}"
+
     def _print_ImageSet(self, s):
         return r"\left\{%s\; |\; %s \in %s\right\}" % (
             self._print(s.lamda.expr),

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1425,7 +1425,8 @@ class PrettyPrinter(Printer):
         else:
             prod_char = u('\xd7')
             return self._print_seq(p.sets, None, None, ' %s ' % prod_char,
-                parenthesize=lambda set: set.is_Union or set.is_Intersection)
+                                   parenthesize=lambda set: set.is_Union or
+                                   set.is_Intersection or set.is_ProductSet)
 
     def _print_FiniteSet(self, s):
         items = sorted(s.args, key=default_sort_key)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -94,6 +94,7 @@ class PrettyPrinter(Printer):
     _print_Naturals = _print_Atom
     _print_Integers = _print_Atom
     _print_Reals = _print_Atom
+    _print_Complex = _print_Atom
 
     def _print_subfactorial(self, e):
         x = e.args[0]

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -470,6 +470,7 @@ atoms_table = {
     'Naturals':                U('DOUBLE-STRUCK CAPITAL N'),
     'Integers':                U('DOUBLE-STRUCK CAPITAL Z'),
     'Reals':                   U('DOUBLE-STRUCK CAPITAL R'),
+    'Complex':                 U('DOUBLE-STRUCK CAPITAL C'),
     'Union':                   U('UNION'),
     'SymmetricDifference':     U('INCREMENT'),
     'Intersection':            U('INTERSECTION'),

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7,7 +7,8 @@ from sympy import (
     Pow, Product, QQ, RR, Rational, Ray, RootOf, RootSum, S,
     Segment, Subs, Sum, Symbol, Tuple, Xor, ZZ, conjugate,
     groebner, oo, pi, symbols, ilex, grlex, Range, Contains,
-    SeqPer, SeqFormula, SeqAdd, SeqMul)
+    SeqPer, SeqFormula, SeqAdd, SeqMul, Interval, Union)
+
 from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
     Piecewise, Shi, Si, atan2, binomial, catalan, ceiling, cos,
     euler, exp, expint, factorial, factorial2, floor, gamma, hyper, log,
@@ -3098,6 +3099,14 @@ def test_pretty_sets():
     ucode_str = u('{-∞, …, -3, -2}')
     assert pretty(Range(-2, -oo, -1)) == ascii_str
     assert upretty(Range(-2, -oo, -1)) == ucode_str
+
+
+def test_ProductSet_paranthesis():
+    from sympy import Interval, Union, FiniteSet
+    ucode_str = u('([4, 7] × {1, 2}) ∪ ([2, 3] × [4, 7])')
+
+    a, b, c = Interval(2, 3), Interval(4, 7), Interval(1, 9)
+    assert upretty(Union(a*b, b*FiniteSet(1, 2))) == ucode_str
 
 
 def test_pretty_sequences():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -568,6 +568,10 @@ def test_latex_Complement():
     assert latex(Complement(S.Reals, S.Naturals)) == r"\mathbb{R} \setminus \mathbb{N}"
 
 
+def test_latex_Complex():
+    assert latex(S.Complex) == r"\mathbb{C}"
+
+
 def test_latex_productset():
     line = Interval(0, 1)
     bigline = Interval(0, 10)

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,4 +1,4 @@
 from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
         Intersection, imageset, Complement, SymmetricDifference)
-from .fancysets import TransformationSet, ImageSet, Range
+from .fancysets import TransformationSet, ImageSet, Range, ComplexPlane
 from .contains import Contains

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -780,6 +780,27 @@ class ComplexPlane(Set):
         """
         return self.args[0].args[1].is_Mul
 
+    @property
+    def _measure(self):
+        """
+        The measure of self.sets.
+
+        Examples
+        ========
+
+        >>> from sympy import Interval, ComplexPlane, S
+        >>> a, b = Interval(2, 5), Interval(4, 8)
+        >>> c = Interval(0, 2*S.Pi)
+        >>> c1 = ComplexPlane(a*b)
+        >>> c1.measure
+        12
+        >>> c2 = ComplexPlane(a*c, polar=True)
+        >>> c2.measure
+        6*pi
+
+        """
+        return self.sets._measure
+
     def _contains(self, other):
         from sympy.functions import arg, Abs
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -453,7 +453,19 @@ def normalize_theta_set(theta):
     supports Interval and FiniteSet. It Returns a the normalized value
     of theta in the Set. For Interval, a maximum of one cycle [0, 2*pi],
     is returned i.e. for theta equal to [0, 10*pi], returned normalized
-    value would be [0, 2*pi).
+    value would be [0, 2*pi). As of now it supports theta as FiniteSet
+    and Interval.
+
+    Raises
+    ======
+
+    NotImplementedError
+        The algorithms for Normalizing theta Set are not yet
+        implemented.
+    ValueError
+        The input is not valid, i.e. the input is not a real set.
+    RuntimeError
+        It is a bug, please report to the github issue tracker.
 
     Examples
     ========
@@ -524,7 +536,7 @@ def normalize_theta_set(theta):
         raise NotImplementedError("Normalizing theta when, its %s is not"
                                   "Implemented" % type(theta))
     else:
-        raise ValueError(" %s does not a belongs to S.Reals" % (theta))
+        raise ValueError(" %s is not a real set" % (theta))
 
 
 class ComplexPlane(Set):
@@ -814,6 +826,9 @@ class ComplexPlane(Set):
                 return ComplexPlane(new_r_interval*new_theta_interval,
                                     polar=True)
 
+        if other is S.Reals:
+            return other
+
         if other.is_subset(S.Reals):
             new_interval = []
 
@@ -845,6 +860,10 @@ class ComplexPlane(Set):
             # self in polar form
             elif self.polar and other.polar:
                 return ComplexPlane(Union(self.sets, other.sets), polar=True)
+
+        if other is S.Reals:
+            return self
+
         return None
 
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -490,6 +490,7 @@ def normalize_theta_set(theta):
     from sympy.functions.elementary.complexes import Abs
 
     if theta.is_Interval:
+        # one complete circle
         if Abs(theta.args[0] - theta.args[1]) >= 2*S.Pi:
             return Interval(0, 2*S.Pi, False, True)
 
@@ -507,9 +508,6 @@ def normalize_theta_set(theta):
                     new_theta.append(2*S.Pi)
             else:
                 new_theta.append(k*S.Pi)
-        # one complete circle
-        if (new_theta[0] == new_theta[1]):
-            return Interval(0, 2*S.Pi, False, True)
 
         # for negative theta
         if new_theta[0] > new_theta[1]:
@@ -868,7 +866,6 @@ class ComplexPlane(Set):
                         new_interval.append(element.args[0])
                 new_interval = Union(*new_interval)
                 return Intersection(new_interval, other)
-            return None
 
     def _union(self, other):
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -617,8 +617,7 @@ class ComplexPlane(Set):
 
         # Rectangular Form
         if polar is False:
-            obj = ImageSet.__new__(cls, Lambda((x, y), x + I*y),
-                                   sets)
+            obj = ImageSet.__new__(cls, Lambda((x, y), x + I*y), sets)
 
         # Polar Form
         elif polar is True:
@@ -847,3 +846,10 @@ class ComplexPlane(Set):
             elif self.polar and other.polar:
                 return ComplexPlane(Union(self.sets, other.sets), polar=True)
         return None
+
+
+class Complex(with_metaclass(Singleton, ComplexPlane)):
+
+    def __new__(cls):
+        from sympy import oo
+        return ComplexPlane.__new__(cls, Interval(-oo, oo)*Interval(-oo, oo))

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -719,7 +719,7 @@ class ComplexPlane(Set):
                 return ComplexPlane(new_r_interval*new_theta_interval,
                                     polar=True)
 
-        if other.is_Interval:
+        if other.is_subset(S.Reals):
             new_interval = []
 
             # self in rectangular form

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -680,7 +680,7 @@ class ComplexPlane(Set):
         from sympy.functions import arg, Abs
 
         # self in rectangular form
-        if self.polar is False:
+        if not self.polar:
             re, im = other.as_real_imag()
             for element in self.psets:
                 if And(element.args[0]._contains(re),
@@ -723,9 +723,9 @@ class ComplexPlane(Set):
             new_interval = []
 
             # self in rectangular form
-            if self.polar is False:
+            if not self.polar:
                 for element in self.psets:
-                    if (S.Zero, S.Zero) in element:
+                    if S.Zero in element.args[0]:
                         new_interval.append(element.args[0])
                 new_interval = Union(*new_interval)
                 return Intersection(new_interval, other)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -699,3 +699,55 @@ class ComplexPlane(Set):
                         element.args[1]._contains(theta)):
                     return True
                 return False
+
+    def _intersect(self, other):
+
+        if other.is_ComplexPlane:
+            # self in rectangular form
+            if (not self.polar) and (not other.polar):
+                return ComplexPlane(Intersection(self.sets, other.sets))
+
+            # self in polar form
+            elif self.polar and other.polar:
+                r1, theta1 = self.a_interval, self.b_interval
+                r2, theta2 = other.a_interval, other.b_interval
+                new_r_interval = Intersection(r1, r2)
+                new_theta_interval = Intersection(theta1, theta2)
+                # 0 and 2*Pi means the same
+                if (2*S.Pi in theta1 and S(0) in theta2) or (2*S.Pi in theta2 and S(0) in theta1):
+                    new_theta_interval = Union(new_theta_interval, FiniteSet(0))
+                return ComplexPlane(new_r_interval*new_theta_interval,
+                                    polar=True)
+
+        if other.is_Interval:
+            new_interval = []
+
+            # self in rectangular form
+            if self.polar is False:
+                for element in self.psets:
+                    if (S.Zero, S.Zero) in element:
+                        new_interval.append(element.args[0])
+                new_interval = Union(*new_interval)
+                return Intersection(new_interval, other)
+
+            # self in polar form
+            elif self.polar:
+                for element in self.psets:
+                    if (0 in element.args[1]) or (S.Pi in element.args[1]):
+                        new_interval.append(element.args[0])
+                new_interval = Union(*new_interval)
+                return Intersection(new_interval, other)
+            return None
+
+    def _union(self, other):
+
+        if other.is_ComplexPlane:
+
+            # self in rectangular form
+            if (not self.polar) and (not other.polar):
+                return ComplexPlane(Union(self.sets, other.sets))
+
+            # self in polar form
+            elif self.polar and other.polar:
+                return ComplexPlane(Union(self.sets, other.sets), polar=True)
+        return None

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -42,6 +42,7 @@ class Set(Basic):
     is_EmptySet = None
     is_UniversalSet = None
     is_Complement = None
+    is_ComplexPlane = False
 
     @staticmethod
     def _infimum_key(expr):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1628,6 +1628,10 @@ class FiniteSet(Set, EvalfMixin):
     >>> 3 in FiniteSet(1, 2, 3, 4)
     True
 
+    >>> members = [1, 2, 3, 4]
+    >>> FiniteSet(*members)
+    {1, 2, 3, 4}
+
     References
     ==========
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,5 +1,6 @@
 from sympy.core.compatibility import range
-from sympy.sets.fancysets import ImageSet, Range, ComplexPlane
+from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
+                                  ComplexPlane)
 from sympy.sets.sets import FiniteSet, Interval, imageset, EmptySet, Union
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
                    Rational, sqrt, tan, log, Abs, I)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -352,3 +352,26 @@ def test_ComplexPlane_union():
 
     assert c5.union(c6) == ComplexPlane(p3)
     assert c7.union(c8) == ComplexPlane(p4)
+
+
+def test_normalize_theta_set():
+
+    # Interval
+    assert normalize_theta_set(Interval(9*pi/2, 5*pi)) == Interval(pi/2, pi)
+    assert normalize_theta_set(Interval(-3*pi/2, pi/2)) == \
+        Interval(0, 2*pi, False, True)
+    assert normalize_theta_set(Interval(-pi/2, pi/2)) == \
+        Union(Interval(0, pi/2), Interval(3*pi/2, 2*pi, False, True))
+    assert normalize_theta_set(Interval(-4*pi, 3*pi)) == \
+        Interval(0, 2*pi, False, True)
+    assert normalize_theta_set(Interval(-3*pi/2, -pi/2)) == \
+        Interval(pi/2, 3*pi/2)
+
+    # FiniteSet
+    assert normalize_theta_set(FiniteSet(0, pi, 3*pi)) == FiniteSet(0, pi)
+    assert normalize_theta_set(FiniteSet(0, pi/2, pi, 2*pi)) == \
+        FiniteSet(0, pi/2, pi)
+    assert normalize_theta_set(FiniteSet(0, -pi/2, -pi, -2*pi)) == \
+        FiniteSet(0, pi, 3*pi/2)
+    assert normalize_theta_set(FiniteSet(-3*pi/2, pi/2)) == \
+        FiniteSet(pi/2)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -365,6 +365,16 @@ def test_ComplexPlane_union():
     assert c7.union(c8) == ComplexPlane(p4)
 
 
+def test_ComplexPlane_measure():
+    a, b = Interval(2, 5), Interval(4, 8)
+    theta1, theta2 = Interval(0, 2*S.Pi), Interval(0, S.Pi)
+    c1 = ComplexPlane(a*b)
+    c2 = ComplexPlane(Union(a*theta1, b*theta2), polar=True)
+
+    assert c1.measure == 12
+    assert c2.measure == 9*pi
+
+
 def test_normalize_theta_set():
 
     # Interval

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -186,6 +186,15 @@ def test_reals():
     assert sqrt(-1) not in S.Reals
 
 
+def test_Complex():
+    assert 5 in S.Complex
+    assert 5 + 4*I in S.Complex
+    assert S.Pi in S.Complex
+    assert -sqrt(2) in S.Complex
+    assert -I in S.Complex
+    assert sqrt(-1) in S.Complex
+
+
 def take(n, iterable):
     "Return first n items of the iterable as a list"
     return list(itertools.islice(iterable, n))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -260,7 +260,6 @@ def test_ImageSet_simplification():
             imageset(Lambda(m, sin(tan(m))), S.Integers)
 
 
-@XFAIL
 def test_ComplexPlane_contains():
 
     # contains in ComplexPlane
@@ -284,7 +283,6 @@ def test_ComplexPlane_contains():
     assert 1 - I not in c2
 
 
-@XFAIL
 def test_ComplexPlane_intersect():
 
     # Polar form
@@ -328,7 +326,6 @@ def test_ComplexPlane_intersect():
     assert c1.intersect(Interval(6, 9)) == EmptySet()
 
 
-@XFAIL
 def test_ComplexPlane_union():
 
     # Polar form

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -178,7 +178,7 @@ def test_fun():
         Range(-10, 11))) == FiniteSet(-1, -sqrt(2)/2, 0, sqrt(2)/2, 1))
 
 
-def test_reals():
+def test_Reals():
     assert 5 in S.Reals
     assert S.Pi in S.Reals
     assert -sqrt(2) in S.Reals
@@ -193,6 +193,8 @@ def test_Complex():
     assert -sqrt(2) in S.Complex
     assert -I in S.Complex
     assert sqrt(-1) in S.Complex
+    assert S.Complex.intersect(S.Reals) == S.Reals
+    assert S.Complex.union(S.Reals) == S.Complex
 
 
 def take(n, iterable):
@@ -282,9 +284,9 @@ def test_ComplexPlane_contains():
     assert 2.5 + 6.1*I not in c1
     assert 4.5 + 3.2*I not in c1
 
-    r = Interval(0, 1)
-    theta = Interval(0, 2*S.Pi)
-    c2 = ComplexPlane(r*theta, polar=True)
+    r1 = Interval(0, 1)
+    theta1 = Interval(0, 2*S.Pi)
+    c2 = ComplexPlane(r1*theta1, polar=True)
     assert 0.5 + 0.6*I in c2
     assert I in c2
     assert 1 in c2
@@ -384,3 +386,6 @@ def test_normalize_theta_set():
         FiniteSet(0, pi, 3*pi/2)
     assert normalize_theta_set(FiniteSet(-3*pi/2, pi/2)) == \
         FiniteSet(pi/2)
+
+    # ValueError for non-real sets
+    raises(ValueError, lambda: normalize_theta_set(S.Complex))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,7 +1,8 @@
 from sympy.core.compatibility import range
 from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
                                   ComplexPlane)
-from sympy.sets.sets import FiniteSet, Interval, imageset, EmptySet, Union
+from sympy.sets.sets import (FiniteSet, Interval, imageset, EmptySet, Union,
+                             Intersection)
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
                    Rational, sqrt, tan, log, Abs, I)
 from sympy.utilities.pytest import XFAIL, raises
@@ -277,22 +278,25 @@ def test_ComplexPlane_contains():
     # contains in ComplexPlane
     a = Interval(2, 3)
     b = Interval(4, 6)
+    c = Interval(7, 9)
     c1 = ComplexPlane(a*b)
+    c2 = ComplexPlane(Union(a*b, c*a))
     assert 2.5 + 4.5*I in c1
     assert 2 + 4*I in c1
     assert 3 + 4*I in c1
+    assert 8 + 2.5*I in c2
     assert 2.5 + 6.1*I not in c1
     assert 4.5 + 3.2*I not in c1
 
     r1 = Interval(0, 1)
     theta1 = Interval(0, 2*S.Pi)
-    c2 = ComplexPlane(r1*theta1, polar=True)
-    assert 0.5 + 0.6*I in c2
-    assert I in c2
-    assert 1 in c2
-    assert 0 in c2
-    assert 1 + I not in c2
-    assert 1 - I not in c2
+    c3 = ComplexPlane(r1*theta1, polar=True)
+    assert 0.5 + 0.6*I in c3
+    assert I in c3
+    assert 1 in c3
+    assert 0 in c3
+    assert 1 + I not in c3
+    assert 1 - I not in c3
 
 
 def test_ComplexPlane_intersect():
@@ -337,6 +341,11 @@ def test_ComplexPlane_intersect():
     assert c1.intersect(Interval(5, 7)) == FiniteSet(5)
     assert c1.intersect(Interval(6, 9)) == EmptySet()
 
+    # unevaluated object
+    C1 = ComplexPlane(Interval(0, 1)*Interval(0, 2*S.Pi), polar=True)
+    C2 = ComplexPlane(Interval(-1, 1)*Interval(-1, 1))
+    assert C1.intersect(C2) == Intersection(C1, C2)
+
 
 def test_ComplexPlane_union():
 
@@ -363,6 +372,9 @@ def test_ComplexPlane_union():
 
     assert c5.union(c6) == ComplexPlane(p3)
     assert c7.union(c8) == ComplexPlane(p4)
+
+    assert c1.union(Interval(2, 4)) == Union(c1, Interval(2, 4))
+    assert c5.union(Interval(2, 4)) == Union(c5, Interval(2, 4))
 
 
 def test_ComplexPlane_measure():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1106,6 +1106,9 @@ def test_nsimplify():
     # issue 7322 direct test
     assert nsimplify(1e-42, rational=True) != 0
 
+def test_issue_9448():
+    tmp = sympify("1/(1 - (-1)**(2/3) - (-1)**(1/3)) + 1/(1 + (-1)**(2/3) + (-1)**(1/3))")
+    assert nsimplify(tmp) == S(1)/2
 
 def test_extract_minus_sign():
     x = Symbol("x")

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -122,7 +122,7 @@ class Routine(object):
 
     """
 
-    def __init__(self, name, arguments, results, local_vars):
+    def __init__(self, name, arguments, results, local_vars, global_vars):
         """Initialize a Routine instance.
 
         Parameters
@@ -146,6 +146,9 @@ class Routine(object):
 
         local_vars : list of Symbols
             These are used internally by the routine.
+
+        global_vars : list of Symbols
+            Variables which will not be passed into the function.
 
         """
 
@@ -171,7 +174,8 @@ class Routine(object):
         # Check that all symbols in the expressions are covered by
         # InputArguments/InOutArguments---subset because user could
         # specify additional (unused) InputArguments or local_vars.
-        notcovered = symbols.difference(input_symbols.union(local_vars))
+        notcovered = symbols.difference(
+            input_symbols.union(local_vars).union(global_vars))
         if notcovered != set([]):
             raise ValueError("Symbols needed for output are not in input " +
                              ", ".join([str(x) for x in notcovered]))
@@ -180,6 +184,7 @@ class Routine(object):
         self.arguments = arguments
         self.results = results
         self.local_vars = local_vars
+        self.global_vars = global_vars
 
     @property
     def variables(self):
@@ -465,7 +470,7 @@ class CodeGen(object):
         """
         self.project = project
 
-    def routine(self, name, expr, argument_sequence):
+    def routine(self, name, expr, argument_sequence, global_vars):
         """Creates an Routine object that is appropriate for this language.
 
         This implementation is appropriate for at least C/Fortran.  Subclasses
@@ -490,9 +495,11 @@ class CodeGen(object):
         # local variables
         local_vars = set([i.label for i in expressions.atoms(Idx)])
 
-        # symbols that should be arguments
-        symbols = expressions.free_symbols - local_vars
+        # global variables
+        global_vars = set() if global_vars is None else set(global_vars)
 
+        # symbols that should be arguments
+        symbols = expressions.free_symbols - local_vars - global_vars
         # Decide whether to use output argument or return value
         return_val = []
         output_args = []
@@ -580,7 +587,7 @@ class CodeGen(object):
                     new_args.append(InputArgument(symbol))
             arg_list = new_args
 
-        return Routine(name, arg_list, return_val, local_vars)
+        return Routine(name, arg_list, return_val, local_vars, global_vars)
 
     def write(self, routines, prefix, to_files=False, header=True, empty=True):
         """Writes all the source code files for the given routines.
@@ -1098,7 +1105,7 @@ class OctaveCodeGen(CodeGen):
 
     code_extension = "m"
 
-    def routine(self, name, expr, argument_sequence):
+    def routine(self, name, expr, argument_sequence, global_vars):
         """Specialized Routine creation for Octave."""
 
         # FIXME: this is probably general enough for other high-level
@@ -1114,8 +1121,11 @@ class OctaveCodeGen(CodeGen):
         # local variables
         local_vars = set([i.label for i in expressions.atoms(Idx)])
 
+        # global variables
+        global_vars = set() if global_vars is None else set(global_vars)
+
         # symbols that should be arguments
-        symbols = expressions.free_symbols - local_vars
+        symbols = expressions.free_symbols - local_vars - global_vars
 
         # Octave supports multiple return values
         return_vals = []
@@ -1176,7 +1186,7 @@ class OctaveCodeGen(CodeGen):
                     new_args.append(InputArgument(symbol))
             arg_list = new_args
 
-        return Routine(name, arg_list, return_vals, local_vars)
+        return Routine(name, arg_list, return_vals, local_vars, global_vars)
 
     def _get_symbol(self, s):
         """Print the symbol appropriately."""
@@ -1325,7 +1335,8 @@ def get_code_generator(language, project):
 
 
 def codegen(name_expr, language, prefix=None, project="project",
-            to_files=False, header=True, empty=True, argument_sequence=None):
+            to_files=False, header=True, empty=True, argument_sequence=None,
+            global_vars=None):
     """Generate source code for expressions in a given language.
 
     Parameters
@@ -1371,6 +1382,10 @@ def codegen(name_expr, language, prefix=None, project="project",
         Redundant arguments are used without warning.  If omitted,
         arguments will be ordered alphabetically, but with all input
         aguments first, and then output or in-out arguments.
+
+    global_vars : iterable, optional
+        Sequence of global variables used by the routine.  Variables
+        listed here will not show up as function arguments.
 
     Examples
     ========
@@ -1420,6 +1435,23 @@ def codegen(name_expr, language, prefix=None, project="project",
        (*g) = y;
     }
 
+    If the generated function(s) will be part of a larger project where various
+    global variables have been defined, the 'global_vars' option can be used
+    to remove the specified variables from the function signature
+
+    >>> from sympy.utilities.codegen import codegen
+    >>> from sympy.abc import x, y, z
+    >>> [(f_name, f_code), header] = codegen(
+    ...     ("f", x+y*z), "F95", header=False, empty=False,
+    ...     argument_sequence=(x, y), global_vars=(z,))
+    >>> print(f_code)
+    REAL*8 function f(x, y)
+    implicit none
+    REAL*8, intent(in) :: x
+    REAL*8, intent(in) :: y
+    f = x + y*z
+    end function
+
     """
 
     # Initialize the code generator.
@@ -1435,13 +1467,15 @@ def codegen(name_expr, language, prefix=None, project="project",
     # Construct Routines appropriate for this code_gen from (name, expr) pairs.
     routines = []
     for name, expr in name_expr:
-        routines.append(code_gen.routine(name, expr, argument_sequence))
+        routines.append(code_gen.routine(name, expr, argument_sequence,
+                                         global_vars))
 
     # Write the code.
     return code_gen.write(routines, prefix, to_files, header, empty)
 
 
-def make_routine(name, expr, argument_sequence=None, language="F95"):
+def make_routine(name, expr, argument_sequence=None,
+                 global_vars=None, language="F95"):
     """A factory that makes an appropriate Routine from an expression.
 
     Parameters
@@ -1459,6 +1493,10 @@ def make_routine(name, expr, argument_sequence=None, language="F95"):
         List arguments for the routine in a preferred order.  If omitted,
         the results are language dependent, for example, alphabetical order
         or in the same order as the given expressions.
+
+    global_vars : iterable, optional
+        Sequence of global variables used by the routine.  Variables
+        listed here will not show up as function arguments.
 
     language : string, optional
         Specify a target language.  The Routine itself should be
@@ -1522,4 +1560,4 @@ def make_routine(name, expr, argument_sequence=None, language="F95"):
     # initialize a new code generator
     code_gen = get_code_generator(language, "nothingElseMatters")
 
-    return code_gen.routine(name, expr, argument_sequence)
+    return code_gen.routine(name, expr, argument_sequence, global_vars)

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1399,3 +1399,31 @@ def test_fcode_matrixsymbol_slice_autoname():
     out = b[1]
     expected = expected % {'hash': out}
     assert source == expected
+
+def test_global_vars():
+    x, y, z, t = symbols("x y z t")
+    result = codegen(('f', x*y), "F95", header=False, empty=False,
+                     global_vars=(y,))
+    source = result[0][1]
+    expected = (
+        "REAL*8 function f(x)\n"
+        "implicit none\n"
+        "REAL*8, intent(in) :: x\n"
+        "f = x*y\n"
+        "end function\n"
+        )
+    assert source == expected
+
+    result = codegen(('f', x*y+z), "C", header=False, empty=False,
+                     global_vars=(z, t))
+    source = result[0][1]
+    expected = (
+        '#include "f.h"\n'
+        '#include <math.h>\n'
+        'double f(double x, double y) {\n'
+        '   double f_result;\n'
+        '   f_result = x*y + z;\n'
+        '   return f_result;\n'
+        '}\n'
+    )
+    assert source == expected

--- a/sympy/utilities/tests/test_codegen_octave.py
+++ b/sympy/utilities/tests/test_codegen_octave.py
@@ -565,3 +565,25 @@ def test_m_not_supported():
         "end\n"
     )
     assert source == expected
+
+def test_global_vars_octave():
+    x, y, z, t = symbols("x y z t")
+    result = codegen(('f', x*y), "Octave", header=False, empty=False,
+                     global_vars=(y,))
+    source = result[0][1]
+    expected = (
+        "function out1 = f(x)\n"
+        "  out1 = x.*y;\n"
+        "end\n"
+        )
+    assert source == expected
+
+    result = codegen(('f', x*y+z), "Octave", header=False, empty=False,
+                     argument_sequence=(x, y), global_vars=(z, t))
+    source = result[0][1]
+    expected = (
+        "function out1 = f(x, y)\n"
+        "  out1 = x.*y + z;\n"
+        "end\n"
+    )
+    assert source == expected


### PR DESCRIPTION
Resolution of issue #9464

1) 3 additional test cases reproducing this issue were added to sympy/core/tests/test_basic.py

All these test cases (test_compare_issue_9464_a, test_compare_issue_9464_b and  test_compare_issue_9464_c) initially crash with TypeError exception in the Basic.compare method if using Python 3.4.3. Error occurs in logical comparison if at least one operand is None.

2) Method Basic.compare in the file sympy/core/basic.py patched to correct error

Now added in previous commit test cases do not crash with Python 3.4.3, sample program from issue #9464 also finishes successfully. Please, use script below to launch added tests only:

import sympy

sympy.test('sympy/core/tests/test_basic.py', kw='test_compare_issue_9464_a')
sympy.test('sympy/core/tests/test_basic.py', kw='test_compare_issue_9464_b')
sympy.test('sympy/core/tests/test_basic.py', kw='test_compare_issue_9464_c')

Best regards

Andrew
