### PR TITLE
Fix infinite recursion in prime assumptions

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1222,7 +1222,10 @@ class Mul(Expr, AssocOp):
             r = S.One
             for arg in self.args:
                 r *= arg
-            return r.is_prime
+            if self != r:
+                return r.is_prime
+            else:
+                return None
 
         if self.is_integer and self.is_positive:
             """

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -491,7 +491,11 @@ class Pow(Expr):
         if self.exp == S.One:
             return self.base.is_prime
         if self.is_number:
-            return self.doit().is_prime
+            done_it = self.doit()
+            if self != done_it:
+                return done_it.is_prime
+            else:
+                return None
 
         if self.is_integer and self.is_positive:
             """


### PR DESCRIPTION
An infinite recursion can be triggered in Mul._eval_is_prime and also in Pow._eval_is_prime. This is because these function call r.is_prime and self.doit().is_prime respectively. The problem is that r and self.doit() can be equal to self, thus triggering the recursion. The recursion only appears when SYMPY_USE_CACHE='no' because the caching system will return the assumption as None when recursing on itself.

To see the issues, run:
./bin/test -C test_assumptions -k test_issue_4822
./bin/test -C test_assumptions -k special_assumptions

I fix this by adding a check whether the expression is equal to self before calling is_prime.
