### PR TITLE
Fix infinite recursion in Add._is_* methods

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -500,7 +500,7 @@ class Add(Expr, AssocOp):
             v = _monotonic_sign(a)
             if v is not None:
                 s = v + c
-                if s.is_positive and a.is_nonnegative:
+                if self != s and s.is_positive and a.is_nonnegative:
                     return True
                 if len(self.free_symbols) == 1:
                     v = _monotonic_sign(self)
@@ -553,7 +553,7 @@ class Add(Expr, AssocOp):
                 v = _monotonic_sign(a)
                 if v is not None:
                     s = v + c
-                    if s.is_nonnegative:
+                    if self != s and s.is_nonnegative:
                         return True
                     if len(self.free_symbols) == 1:
                         v = _monotonic_sign(self)
@@ -568,7 +568,7 @@ class Add(Expr, AssocOp):
                 v = _monotonic_sign(a)
                 if v is not None:
                     s = v + c
-                    if s.is_nonpositive:
+                    if self != s and s.is_nonpositive:
                         return True
                     if len(self.free_symbols) == 1:
                         v = _monotonic_sign(self)
@@ -584,7 +584,7 @@ class Add(Expr, AssocOp):
             v = _monotonic_sign(a)
             if v is not None:
                 s = v + c
-                if s.is_negative and a.is_nonpositive:
+                if self != s and s.is_negative and a.is_nonpositive:
                     return True
                 if len(self.free_symbols) == 1:
                     v = _monotonic_sign(self)


### PR DESCRIPTION
When SYMPY_USE_CACHE='no', an infinite recursion can be triggered with
Add._eval_is_positive/negative/nonnegative/nonpositive. You can see a
lot of errors from this in the test suite.

The original bug was introduced in:
d1a454a58a9a9bc15980d731ff0f6cbef33c3d77

The fix simply checks whether 's' is equal to self before calling the
recursive function.

To test this, run:
./bin/test -C test_assumptions -k test_issue_4149
./bin/test -C test_assumptions -k test_issues_8632_8633_8638_8675_8992
