### PR TITLE
Fixes the old version of KanesMethod.linearize()

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -530,11 +530,13 @@ class KanesMethod(object):
         uaux = self._uaux
         uauxdot = [diff(i, t) for i in uaux]
         # dictionary of auxiliary speeds & derivatives which are equal to zero
-        subdict = dict(list(zip(uaux + uauxdot, [0] * (len(uaux) + len(uauxdot)))))
+        subdict = dict(zip(uaux[:] + uauxdot[:],
+                           [0] * (len(uaux) + len(uauxdot))))
 
         # Checking for dynamic symbols outside the dynamic differential
         # equations; throws error if there is.
-        insyms = set(Matrix([self.q, self._qdot, self.u, self._udot, uaux, uauxdot]))
+        insyms = set(self.q[:] + self._qdot[:] + self.u[:] + self._udot[:] +
+                     uaux[:] + uauxdot)
         if any(find_dynamicsymbols(i, insyms) for i in [self._k_kqdot,
                 self._k_ku, self._f_k, self._k_dnh, self._f_dnh, self._k_d]):
             raise ValueError('Cannot have dynamicsymbols outside dynamic \

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -1,5 +1,8 @@
+import warnings
+
 from sympy import (cos, expand, Matrix, sin, symbols, tan, sqrt, S,
                    simplify, zeros)
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
                                      RigidBody, KanesMethod, inertia, Particle,
                                      dot)
@@ -33,7 +36,11 @@ def test_one_dof():
     # gives the same results. The old linearizer is deprecated and should be
     # removed in >= 0.7.7.
     M_old = KM.mass_matrix_full
-    F_A_old, F_B_old, r_old = KM.linearize()
+    # The old linearizer raises a deprecation warning, so catch it here so
+    # it doesn't cause py.test to fail.
+    with warnings.catch_warnings():
+        warnings.filterwarnings('always')
+        F_A_old, F_B_old, r_old = KM.linearize()
     M_new, F_A_new, F_B_new, r_new = KM.linearize(new_method=True)
     assert simplify(M_new.inv() * F_A_new - M_old.inv() * F_A_old) == zeros(2)
 

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -1,4 +1,5 @@
-from sympy import cos, expand, Matrix, sin, symbols, tan, sqrt, S
+from sympy import (cos, expand, Matrix, sin, symbols, tan, sqrt, S,
+                   simplify, zeros)
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
                                      RigidBody, KanesMethod, inertia, Particle,
                                      dot)
@@ -25,7 +26,16 @@ def test_one_dof():
     forcing = KM.forcing
     rhs = MM.inv() * forcing
     assert expand(rhs[0]) == expand(-(q * k + u * c) / m)
-    assert KM.linearize(A_and_B=True, new_method=True)[0] == Matrix([[0, 1], [-k/m, -c/m]])
+    assert (KM.linearize(A_and_B=True, new_method=True)[0] ==
+            Matrix([[0, 1], [-k/m, -c/m]]))
+
+    # Ensure that the old linearizer still works and that the new linearizer
+    # gives the same results. The old linearizer is deprecated and should be
+    # removed in >= 0.7.7.
+    M_old = KM.mass_matrix_full
+    F_A_old, F_B_old, r_old = KM.linearize()
+    M_new, F_A_new, F_B_new, r_new = KM.linearize(new_method=True)
+    assert simplify(M_new.inv() * F_A_new - M_old.inv() * F_A_old) == zeros(2)
 
 
 def test_two_dof():


### PR DESCRIPTION
Fixes issue #8244.

I added a test that ensures that the old linearizer works and that the new
linearizer gives the same results. I fixed the the old linearizer by updating
the statements that used variables that used to be lists and are now matrices.
