### PR TITLE
Fix evalf of unevaluated log expression

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -767,6 +767,9 @@ def evalf_trig(v, prec, options):
 
 def evalf_log(expr, prec, options):
     from sympy import Abs, Add, log
+    if len(expr.args)>1:
+        expr = expr.doit()
+        return evalf(expr, prec, options)
     arg = expr.args[0]
     workprec = prec + 10
     xre, xim, xacc, _ = evalf(arg, workprec, options)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -128,6 +128,7 @@ def test_evalf_logs():
     assert NS("log(3+pi*I)", 15) == '1.46877619736226 + 0.808448792630022*I'
     assert NS("log(pi*I)", 15) == '1.14472988584940 + 1.57079632679490*I'
     assert NS('log(-1 + 0.00001)', 2) == '-1.0e-5 + 3.1*I'
+    assert NS('log(2,4,evaluate=False)', 2) == '0.50'
 
 
 def test_evalf_trig():

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -128,7 +128,7 @@ def test_evalf_logs():
     assert NS("log(3+pi*I)", 15) == '1.46877619736226 + 0.808448792630022*I'
     assert NS("log(pi*I)", 15) == '1.14472988584940 + 1.57079632679490*I'
     assert NS('log(-1 + 0.00001)', 2) == '-1.0e-5 + 3.1*I'
-    assert NS('log(2,4,evaluate=False)', 2) == '0.50'
+    assert NS('log(100, 10, evaluate=False)', 15) == '2.00000000000000'
 
 
 def test_evalf_trig():


### PR DESCRIPTION
A simple fix, just evaluate the expression first. This hopefully will fix #9469. 
