### PR TITLE
y*(x*M) != x*(y*M) for non-commutative symbols `x` and `y`

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -516,7 +516,7 @@ class MatrixBase(object):
     def __rmul__(self, a):
         if getattr(a, 'is_Matrix', False):
             return self._new(a)*self
-        return self*a
+        return self._new(self.rows, self.cols, [a*i for i in self._mat])
 
     def __pow__(self, num):
         from sympy.matrices import eye

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2492,3 +2492,13 @@ def test_issue_9457_9467():
     raises(IndexError, lambda: P.col_del(10))
     Q = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     raises(IndexError, lambda: Q.col_del(-10))
+
+def test_issue_9422():
+    x, y = symbols('x y', commutative=False)
+    a, b = symbols('a b')
+    M = eye(2)
+    M1 = Matrix(2, 2, [x, y, y, z])
+    assert y*(x*M) != x*(y*M)
+    assert b*(a*M) == a*(b*M)
+    assert x*M1 != M1*x
+    assert a*M1 == M1*a

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2498,7 +2498,8 @@ def test_issue_9422():
     a, b = symbols('a b')
     M = eye(2)
     M1 = Matrix(2, 2, [x, y, y, z])
-    assert y*(x*M) != x*(y*M)
-    assert b*(a*M) == a*(b*M)
+    assert y*x*M != x*y*M
+    assert b*a*M == a*b*M
     assert x*M1 != M1*x
     assert a*M1 == M1*a
+    assert y*x*M == Matrix([[y*x, 0], [0, y*x]])


### PR DESCRIPTION
fixes issue #9422 .
I have not taken the `MatrixSymbol` into account since they employ `MatMul` instead of `*` operation.
For Matrices

```
>>> x, y = symbol('x, y', commutative=False)
>>> y*(x*M) != x*(y*M)
```

Please have a look
