### PR TITLE
Updates to Line3D and Plane

### DIFF
--- a/sympy/geometry/line3d.py
+++ b/sympy/geometry/line3d.py
@@ -839,12 +839,7 @@ class Line3D(LinearEntity3D):
         else:
             p1 = Point3D(p1)
         if pt is not None and len(direction_ratio) == 0:
-            try:
-                pt = Point3D(pt)
-            except NotImplementedError:
-                raise ValueError('The 2nd argument was not a valid Point. '
-                'If it was the direction_ratio of the desired line, enter it '
-                'with keyword "direction_ratio".')
+            pt = Point3D(pt)
         elif len(direction_ratio) == 3 and pt is None:
             pt = Point3D(p1.x + direction_ratio[0], p1.y + direction_ratio[1],
                          p1.z + direction_ratio[2])
@@ -1045,12 +1040,7 @@ class Ray3D(LinearEntity3D):
         else:
             p1 = Point3D(p1)
         if pt is not None and len(direction_ratio) == 0:
-            try:
-                pt = Point3D(pt)
-            except NotImplementedError:
-                raise ValueError('The 2nd argument was not a valid Point. '
-                'If it was the direction_ratio of the desired line, enter it '
-                'with keyword "direction_ratio".')
+            pt = Point3D(pt)
         elif len(direction_ratio) == 3 and pt is None:
             pt = Point3D(p1.x + direction_ratio[0], p1.y + direction_ratio[1],
                          p1.z + direction_ratio[2])

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -441,11 +441,11 @@ class Plane(GeometryEntity):
 
         """
         planes = set(planes)
-        if len(planes) < 2:
-            return False
         for i in planes:
             if not isinstance(i, Plane):
                 raise ValueError('All objects should be Planes but got %s' % i.func)
+        if len(planes) < 2:
+            return False
         planes = list(planes)
         first = planes.pop(0)
         sol = first.intersection(planes[0])

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -728,8 +728,6 @@ class Point3D(Point):
     Raises
     ======
 
-    NotImplementedError
-        When trying to create a point other than 2 or 3 dimensions.
     TypeError
         When trying to add or subtract points with different dimensions.
         When `intersection` is called with object other than a Point.

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -683,6 +683,9 @@ def test_line3d():
     assert Line3D.are_concurrent(l1) is False
     assert Line3D.are_concurrent(l1, l2)
     assert Line3D.are_concurrent(l1, l1_1, l3) is False
+    parallel_1 = Line3D(Point3D(0, 0, 0), Point3D(1, 0, 0))
+    parallel_2 = Line3D(Point3D(0, 1, 0), Point3D(1, 1, 0))
+    assert Line3D.are_concurrent(parallel_1, parallel_2) == False
 
     # Finding angles
     l1_1 = Line3D(p1, Point3D(5, 0, 0))
@@ -796,6 +799,64 @@ def test_line3d():
         [Point3D(t, t, 0)]
     assert Line3D((0, 0, 0), (x, y, z)).contains((2*x, 2*y, 2*z))
 
+    # Test is_perpendicular
+    perp_1 = Line3D(p1, Point3D(0, 1, 0))
+    assert Line3D.is_perpendicular(parallel_1, perp_1) is True
+    assert Line3D.is_perpendicular(parallel_1, parallel_2) is False
+
+    # Test projection
+    assert parallel_1.projection(Point3D(5, 5, 0)) == Point3D(5, 0, 0)
+    assert parallel_1.projection(parallel_2) == [parallel_1]
+    raises(GeometryError, lambda: parallel_1.projection(Plane(p1, p2, p6)))
+
+    # Test __new__
+    assert Line3D(perp_1) == perp_1
+    raises(ValueError, lambda: Line3D(p1))
+
+    # Test contains
+    pt2d = Point(1.0, 1.0)
+    assert perp_1.contains(pt2d) is False
+
+    # Test equals
+    assert perp_1.equals(pt2d) is False
+    col1 = Line3D(Point3D(0, 0, 0), Point3D(1, 0, 0))
+    col2 = Line3D(Point3D(-5, 0, 0), Point3D(-1, 0, 0))
+    assert col1.equals(col2) is True
+    assert col1.equals(perp_1) is False
+
+    # Begin ray
+    # Test __new__
+    assert Ray3D(col1) == Ray3D(p1, Point3D(1, 0, 0))
+    raises(ValueError, lambda: Ray3D(pt2d))
+
+    # Test zdirection
+    negz = Ray3D(p1, Point3D(0, 0, -1))
+    assert negz.zdirection == S.NegativeInfinity
+
+    # Test contains
+    assert negz.contains(Segment3D(p1, Point3D(0, 0, -10))) is True
+    assert negz.contains(Segment3D(Point3D(1, 1, 1), Point3D(2, 2, 2))) is False
+    posy = Ray3D(p1, Point3D(0, 1, 0))
+    posz = Ray3D(p1, Point3D(0, 0, 1))
+    assert posy.contains(p1) is True
+    assert posz.contains(p1) is True
+    assert posz.contains(pt2d) is False
+    ray1 = Ray3D(Point3D(1, 1, 1), Point3D(1, 0, 0))
+    raises(TypeError, lambda: ray1.contains([]))
+
+    # Test equals
+    assert negz.equals(pt2d) is False
+    assert negz.equals(negz) is True
+
+    assert ray1.is_similar(Line3D(Point3D(1, 1, 1), Point3D(1, 0, 0))) is True
+    assert ray1.is_similar(perp_1) is False
+    raises(NotImplementedError, lambda: ray1.is_similar(ray1))
+
+    # Begin Segment
+    seg1 = Segment3D(p1, Point3D(1, 0, 0))
+    raises(TypeError, lambda: seg1.contains([]))
+    seg2= Segment3D(Point3D(2, 2, 2), Point3D(3, 2, 2))
+    assert seg1.contains(seg2) is False
 
 @slow
 def test_plane():
@@ -893,6 +954,7 @@ def test_plane():
     assert are_coplanar(Plane(p1, p2, p3), Plane(p1, p3, p2))
     assert Plane.are_concurrent(pl3, pl4, pl5) is False
     assert Plane.are_concurrent(pl6) is False
+    raises(ValueError, lambda: Plane.are_concurrent(Point3D(0, 0, 0)))
 
     assert pl3.parallel_plane(Point3D(1, 2, 5)) == Plane(Point3D(1, 2, 5), \
                                                       normal_vector=(1, -2, 1))


### PR DESCRIPTION
There was a bug in `Plane.are_concurrent()`. The bug causes the function to return False when we call the function with a single argument which is not a plane. 

Here is an example of the bug:

```
> from sympy.geometry import Point, Plane
> Plane.are_concurrent(Point(0, 0))
False
```

With the updated implementation, the function raises a ValueError, which seems to be the desired behavior. I think this is the desired behavior, because if we called `Plane.are_concurrent` with two Point3D arguments, we get the raised ValueError.

I also removed a try/except block from the Line3D and Ray3D constructor. The block was checking for a NotImplementedError in Point3D. Point3D does not have a NotImplementedError, despite what the documentation states. I updated the documentation for Point3D to reflect this as well.

I also added a significant number of tests for Line3D.
