### PR TITLE
Parenthesize printing of ProductSets

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1425,7 +1425,8 @@ class PrettyPrinter(Printer):
         else:
             prod_char = u('\xd7')
             return self._print_seq(p.sets, None, None, ' %s ' % prod_char,
-                parenthesize=lambda set: set.is_Union or set.is_Intersection)
+                                   parenthesize=lambda set: set.is_Union or
+                                   set.is_Intersection or set.is_ProductSet)
 
     def _print_FiniteSet(self, s):
         items = sorted(s.args, key=default_sort_key)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7,7 +7,8 @@ from sympy import (
     Pow, Product, QQ, RR, Rational, Ray, RootOf, RootSum, S,
     Segment, Subs, Sum, Symbol, Tuple, Xor, ZZ, conjugate,
     groebner, oo, pi, symbols, ilex, grlex, Range, Contains,
-    SeqPer, SeqFormula, SeqAdd, SeqMul)
+    SeqPer, SeqFormula, SeqAdd, SeqMul, Interval, Union)
+
 from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
     Piecewise, Shi, Si, atan2, binomial, catalan, ceiling, cos,
     euler, exp, expint, factorial, factorial2, floor, gamma, hyper, log,
@@ -3098,6 +3099,14 @@ def test_pretty_sets():
     ucode_str = u('{-∞, …, -3, -2}')
     assert pretty(Range(-2, -oo, -1)) == ascii_str
     assert upretty(Range(-2, -oo, -1)) == ucode_str
+
+
+def test_ProductSet_paranthesis():
+    from sympy import Interval, Union, FiniteSet
+    ucode_str = u('([4, 7] × {1, 2}) ∪ ([2, 3] × [4, 7])')
+
+    a, b, c = Interval(2, 3), Interval(4, 7), Interval(1, 9)
+    assert upretty(Union(a*b, b*FiniteSet(1, 2))) == ucode_str
 
 
 def test_pretty_sequences():


### PR DESCRIPTION
- [x] Fixes #7486 
- [x] Tests
- [x] Fix Merge Conflicts
- Output

``` python
In [2]: a, b, c = Interval(2, 3), Interval(4, 7), Interval(1, 9)
In [3]: init_printing()

In [4]: Union(a*b, b*FiniteSet(1,2))
Out[4]: ([4, 7] × {1, 2}) ∪ ([2, 3] × [4, 7])

In [5]: Union(a*b, b*c)
Out[5]: ([2, 3] × [4, 7]) ∪ ([4, 7] × [1, 9])

```
