### PR TITLE
multiplicity(n, 0) raises error for any `n`

### DIFF
--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -167,6 +167,8 @@ def test_log_values():
 
     assert log(oo*I) == oo
     assert log(-oo*I) == oo
+    assert log(0, 2) == zoo
+    assert log(0, 5) == zoo
 
     assert exp(-log(3))**(-1) == 3
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -230,6 +230,8 @@ def multiplicity(p, n):
                 pass
         raise ValueError('expecting ints or fractions, got %s and %s' % (p, n))
 
+    if n == 0:
+        raise ValueError('no such integer exists: n must be non-zero')
     if p == 2:
         return trailing(n)
     if p < 2:

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -231,7 +231,7 @@ def multiplicity(p, n):
         raise ValueError('expecting ints or fractions, got %s and %s' % (p, n))
 
     if n == 0:
-        raise ValueError('no such integer exists: n must be non-zero')
+        raise ValueError('no such integer exists: multiplicity of %s is not-defined' %(n))
     if p == 2:
         return trailing(n)
     if p < 2:

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -65,6 +65,8 @@ def test_multiplicity():
     raises(ValueError, lambda: multiplicity(1, 1))
     raises(ValueError, lambda: multiplicity(1, 2))
     raises(ValueError, lambda: multiplicity(1.3, 2))
+    raises(ValueError, lambda: multiplicity(2, 0))
+    raises(ValueError, lambda: multiplicity(1.3, 0))
 
     # handles Rationals
     assert multiplicity(10, Rational(30, 7)) == 0


### PR DESCRIPTION
fixes issue #8159 and #9066

multiplicity(n, 0) used to go in a endless recursion. It now raises an `ValueError`
log(0, n) now returns `zoo`
