### PR TITLE
Added 'global_vars' option to codegen.

### DIFF
--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -122,7 +122,7 @@ class Routine(object):
 
     """
 
-    def __init__(self, name, arguments, results, local_vars):
+    def __init__(self, name, arguments, results, local_vars, global_vars):
         """Initialize a Routine instance.
 
         Parameters
@@ -146,6 +146,9 @@ class Routine(object):
 
         local_vars : list of Symbols
             These are used internally by the routine.
+
+        global_vars : list of Symbols
+            Variables which will not be passed into the function.
 
         """
 
@@ -171,7 +174,8 @@ class Routine(object):
         # Check that all symbols in the expressions are covered by
         # InputArguments/InOutArguments---subset because user could
         # specify additional (unused) InputArguments or local_vars.
-        notcovered = symbols.difference(input_symbols.union(local_vars))
+        notcovered = symbols.difference(
+            input_symbols.union(local_vars).union(global_vars))
         if notcovered != set([]):
             raise ValueError("Symbols needed for output are not in input " +
                              ", ".join([str(x) for x in notcovered]))
@@ -180,6 +184,7 @@ class Routine(object):
         self.arguments = arguments
         self.results = results
         self.local_vars = local_vars
+        self.global_vars = global_vars
 
     @property
     def variables(self):
@@ -465,7 +470,7 @@ class CodeGen(object):
         """
         self.project = project
 
-    def routine(self, name, expr, argument_sequence):
+    def routine(self, name, expr, argument_sequence, global_vars):
         """Creates an Routine object that is appropriate for this language.
 
         This implementation is appropriate for at least C/Fortran.  Subclasses
@@ -490,9 +495,11 @@ class CodeGen(object):
         # local variables
         local_vars = set([i.label for i in expressions.atoms(Idx)])
 
-        # symbols that should be arguments
-        symbols = expressions.free_symbols - local_vars
+        # global variables
+        global_vars = set() if global_vars is None else set(global_vars)
 
+        # symbols that should be arguments
+        symbols = expressions.free_symbols - local_vars - global_vars
         # Decide whether to use output argument or return value
         return_val = []
         output_args = []
@@ -580,7 +587,7 @@ class CodeGen(object):
                     new_args.append(InputArgument(symbol))
             arg_list = new_args
 
-        return Routine(name, arg_list, return_val, local_vars)
+        return Routine(name, arg_list, return_val, local_vars, global_vars)
 
     def write(self, routines, prefix, to_files=False, header=True, empty=True):
         """Writes all the source code files for the given routines.
@@ -1098,7 +1105,7 @@ class OctaveCodeGen(CodeGen):
 
     code_extension = "m"
 
-    def routine(self, name, expr, argument_sequence):
+    def routine(self, name, expr, argument_sequence, global_vars):
         """Specialized Routine creation for Octave."""
 
         # FIXME: this is probably general enough for other high-level
@@ -1114,8 +1121,11 @@ class OctaveCodeGen(CodeGen):
         # local variables
         local_vars = set([i.label for i in expressions.atoms(Idx)])
 
+        # global variables
+        global_vars = set() if global_vars is None else set(global_vars)
+
         # symbols that should be arguments
-        symbols = expressions.free_symbols - local_vars
+        symbols = expressions.free_symbols - local_vars - global_vars
 
         # Octave supports multiple return values
         return_vals = []
@@ -1176,7 +1186,7 @@ class OctaveCodeGen(CodeGen):
                     new_args.append(InputArgument(symbol))
             arg_list = new_args
 
-        return Routine(name, arg_list, return_vals, local_vars)
+        return Routine(name, arg_list, return_vals, local_vars, global_vars)
 
     def _get_symbol(self, s):
         """Print the symbol appropriately."""
@@ -1325,7 +1335,8 @@ def get_code_generator(language, project):
 
 
 def codegen(name_expr, language, prefix=None, project="project",
-            to_files=False, header=True, empty=True, argument_sequence=None):
+            to_files=False, header=True, empty=True, argument_sequence=None,
+            global_vars=None):
     """Generate source code for expressions in a given language.
 
     Parameters
@@ -1371,6 +1382,10 @@ def codegen(name_expr, language, prefix=None, project="project",
         Redundant arguments are used without warning.  If omitted,
         arguments will be ordered alphabetically, but with all input
         aguments first, and then output or in-out arguments.
+
+    global_vars : iterable, optional
+        Sequence of global variables used by the routine.  Variables
+        listed here will not show up as function arguments.
 
     Examples
     ========
@@ -1420,6 +1435,23 @@ def codegen(name_expr, language, prefix=None, project="project",
        (*g) = y;
     }
 
+    If the generated function(s) will be part of a larger project where various
+    global variables have been defined, the 'global_vars' option can be used
+    to remove the specified variables from the function signature
+
+    >>> from sympy.utilities.codegen import codegen
+    >>> from sympy.abc import x, y, z
+    >>> [(f_name, f_code), header] = codegen(
+    ...     ("f", x+y*z), "F95", header=False, empty=False,
+    ...     argument_sequence=(x, y), global_vars=(z,))
+    >>> print(f_code)
+    REAL*8 function f(x, y)
+    implicit none
+    REAL*8, intent(in) :: x
+    REAL*8, intent(in) :: y
+    f = x + y*z
+    end function
+
     """
 
     # Initialize the code generator.
@@ -1435,13 +1467,15 @@ def codegen(name_expr, language, prefix=None, project="project",
     # Construct Routines appropriate for this code_gen from (name, expr) pairs.
     routines = []
     for name, expr in name_expr:
-        routines.append(code_gen.routine(name, expr, argument_sequence))
+        routines.append(code_gen.routine(name, expr, argument_sequence,
+                                         global_vars))
 
     # Write the code.
     return code_gen.write(routines, prefix, to_files, header, empty)
 
 
-def make_routine(name, expr, argument_sequence=None, language="F95"):
+def make_routine(name, expr, argument_sequence=None,
+                 global_vars=None, language="F95"):
     """A factory that makes an appropriate Routine from an expression.
 
     Parameters
@@ -1459,6 +1493,10 @@ def make_routine(name, expr, argument_sequence=None, language="F95"):
         List arguments for the routine in a preferred order.  If omitted,
         the results are language dependent, for example, alphabetical order
         or in the same order as the given expressions.
+
+    global_vars : iterable, optional
+        Sequence of global variables used by the routine.  Variables
+        listed here will not show up as function arguments.
 
     language : string, optional
         Specify a target language.  The Routine itself should be
@@ -1522,4 +1560,4 @@ def make_routine(name, expr, argument_sequence=None, language="F95"):
     # initialize a new code generator
     code_gen = get_code_generator(language, "nothingElseMatters")
 
-    return code_gen.routine(name, expr, argument_sequence)
+    return code_gen.routine(name, expr, argument_sequence, global_vars)

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1399,3 +1399,31 @@ def test_fcode_matrixsymbol_slice_autoname():
     out = b[1]
     expected = expected % {'hash': out}
     assert source == expected
+
+def test_global_vars():
+    x, y, z, t = symbols("x y z t")
+    result = codegen(('f', x*y), "F95", header=False, empty=False,
+                     global_vars=(y,))
+    source = result[0][1]
+    expected = (
+        "REAL*8 function f(x)\n"
+        "implicit none\n"
+        "REAL*8, intent(in) :: x\n"
+        "f = x*y\n"
+        "end function\n"
+        )
+    assert source == expected
+
+    result = codegen(('f', x*y+z), "C", header=False, empty=False,
+                     global_vars=(z, t))
+    source = result[0][1]
+    expected = (
+        '#include "f.h"\n'
+        '#include <math.h>\n'
+        'double f(double x, double y) {\n'
+        '   double f_result;\n'
+        '   f_result = x*y + z;\n'
+        '   return f_result;\n'
+        '}\n'
+    )
+    assert source == expected

--- a/sympy/utilities/tests/test_codegen_octave.py
+++ b/sympy/utilities/tests/test_codegen_octave.py
@@ -565,3 +565,25 @@ def test_m_not_supported():
         "end\n"
     )
     assert source == expected
+
+def test_global_vars_octave():
+    x, y, z, t = symbols("x y z t")
+    result = codegen(('f', x*y), "Octave", header=False, empty=False,
+                     global_vars=(y,))
+    source = result[0][1]
+    expected = (
+        "function out1 = f(x)\n"
+        "  out1 = x.*y;\n"
+        "end\n"
+        )
+    assert source == expected
+
+    result = codegen(('f', x*y+z), "Octave", header=False, empty=False,
+                     argument_sequence=(x, y), global_vars=(z, t))
+    source = result[0][1]
+    expected = (
+        "function out1 = f(x, y)\n"
+        "  out1 = x.*y + z;\n"
+        "end\n"
+    )
+    assert source == expected


### PR DESCRIPTION
Previously, all symbols in a given expression were converted to function
arguments. However, sometimes the generated function is part of a larger
module where global variables are defined and it is not desirable to
pass these in as arguments to the function.

With this commit the behavior is now:

``` python
 >>> from sympy.utilities.codegen import codegen
 >>> from sympy.abc import x, y, z
 >>> [(f_name, f_code), header] = codegen(
 ...     ("f", x+y*z), "F95", header=False, empty=False,
 ...     argument_sequence=(x, y), global_vars=(z,))
 >>> print(f_code)
 REAL*8 function f(x, y)
 implicit none
 REAL*8, intent(in) :: x
 REAL*8, intent(in) :: y
 f = x + y*z
 end function
```

This makes it much easier to generate uniform function signatures.

CC: The codegen gurus (aka @jcrist @moorepants)
