### PR TITLE
codegen: use vectorized and/or for octave code

### DIFF
--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -45,8 +45,8 @@ class OctaveCodePrinter(CodePrinter):
     language = "Octave"
 
     _operators = {
-        'and': '&&',
-        'or': '||',
+        'and': '&',
+        'or': '|',
         'not': '~',
     }
 

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -129,13 +129,13 @@ def test_constants_other():
 
 
 def test_boolean():
-    assert mcode(x & y) == "x && y"
-    assert mcode(x | y) == "x || y"
+    assert mcode(x & y) == "x & y"
+    assert mcode(x | y) == "x | y"
     assert mcode(~x) == "~x"
-    assert mcode(x & y & z) == "x && y && z"
-    assert mcode(x | y | z) == "x || y || z"
-    assert mcode((x & y) | z) == "z || x && y"
-    assert mcode((x | y) & z) == "z && (x || y)"
+    assert mcode(x & y & z) == "x & y & z"
+    assert mcode(x | y | z) == "x | y | z"
+    assert mcode((x & y) | z) == "z | x & y"
+    assert mcode((x | y) & z) == "z & (x | y)"
 
 
 def test_Matrices():


### PR DESCRIPTION
Previously it generated code using && and ||.  These are fine
for scalar operations (and in some cases preferable as they
shortcircuit).  But for numerical code, & and | are better as
they are vectorized.  Since we are probably generated code do use
in numerical work, this is preferred.

Fixes #9533.
