### PR TITLE
Fix Intersection's of FiniteSet with symbolic elements 

### DIFF
--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -19,7 +19,7 @@ from sympy import (Rational, symbols, factorial, sqrt, log, exp, oo, zoo,
     continued_fraction_periodic as cf_p, continued_fraction_convergents as cf_c,
     continued_fraction_reduce as cf_r, FiniteSet, elliptic_e, elliptic_f,
     powsimp, hessian, wronskian, fibonacci, sign, Lambda, Piecewise, Subs,
-    residue, Derivative, logcombine, Symbol)
+    residue, Derivative, logcombine, Symbol, Intersection, Union)
 
 import mpmath
 from sympy.functions.combinatorial.numbers import stirling
@@ -70,8 +70,13 @@ def test_B1():
 
 
 def test_B2():
+    a, b, c = FiniteSet(j), FiniteSet(m), FiniteSet(j, k)
+    d, e = FiniteSet(i), FiniteSet(j, k, l)
+
     assert (FiniteSet(i, j, j, k, k, k) & FiniteSet(l, k, j) &
-            FiniteSet(j, m, j)) == FiniteSet(j)
+            FiniteSet(j, m, j)) == Union(a, Intersection(b, Union(c, Intersection(d, e))))
+    # {j} U Intersection({m}, {j, k} U Intersection({i}, {j, k, l}))
+
 
 
 def test_B3():

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1374,11 +1374,11 @@ class Intersection(Set):
         if len(args) == 0:
             raise TypeError("Intersection expected at least one argument")
 
+        args = list(ordered(args, Set._infimum_key))
+
         # Reduce sets using known rules
         if evaluate:
             return Intersection.reduce(args)
-
-        args = list(ordered(args, Set._infimum_key))
 
         return Basic.__new__(cls, *args)
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1431,8 +1431,14 @@ class Intersection(Set):
         # all other sets in the intersection
         for s in args:
             if s.is_FiniteSet:
-                return s.func(*[x for x in s
-                    if all(other.contains(x) == True for other in args)])
+                args = [a for a in args if a != s]
+                res = s.func(*[x for x in s
+                             if all(other.contains(x) == True for other in args)])
+                unk = [x for x in s
+                       if any(other.contains(x) not in (True, False) for other in args)]
+                if unk:
+                    res += Intersection(*([s.func(*unk)] + args), evaluate=False)
+                return res
 
         # If any of the sets are unions, return a Union of Intersections
         for s in args:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1374,7 +1374,9 @@ class Intersection(Set):
         if len(args) == 0:
             raise TypeError("Intersection expected at least one argument")
 
-        args = list(ordered(args, Set._infimum_key))
+        # args can't be ordered for Partition see issue #9608
+        if 'Partition' not in [type(a).__name__ for a in args]:
+            args = list(ordered(args, Set._infimum_key))
 
         # Reduce sets using known rules
         if evaluate:
@@ -1431,13 +1433,13 @@ class Intersection(Set):
         # all other sets in the intersection
         for s in args:
             if s.is_FiniteSet:
-                args = [a for a in args if a != s]
-                res = s.func(*[x for x in s
-                             if all(other.contains(x) == True for other in args)])
+                other_args = [a for a in args if a != s]
+                res = FiniteSet(*[x for x in s
+                             if all(other.contains(x) == True for other in other_args)])
                 unk = [x for x in s
-                       if any(other.contains(x) not in (True, False) for other in args)]
+                       if any(other.contains(x) not in (True, False) for other in other_args)]
                 if unk:
-                    res += Intersection(*([s.func(*unk)] + args), evaluate=False)
+                    res += Intersection(*([s.func(*unk)] + other_args), evaluate=False)
                 return res
 
         # If any of the sets are unions, return a Union of Intersections

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -857,4 +857,4 @@ def test_SymmetricDifference():
 def test_issue_9536():
     from sympy.functions.elementary.exponential import log
     a = Symbol('a', real=True)
-    assert FiniteSet(log(a)).intersect(S.Reals) == Intersection((-oo, oo), {log(a)})
+    assert FiniteSet(log(a)).intersect(S.Reals) == Intersection(S.Reals, FiniteSet(log(a)))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -852,3 +852,9 @@ def test_SymmetricDifference():
           Set(2, 3, 4) - Set(1, 2, 3))
    assert Interval(0, 4) ^ Interval(2, 5) == Union(Interval(0, 4) - \
           Interval(2, 5), Interval(2, 5) - Interval(0, 4))
+
+
+def test_issue_9536():
+    from sympy.functions.elementary.exponential import log
+    a = Symbol('a', real=True)
+    assert FiniteSet(log(a)).intersect(S.Reals) == Intersection((-oo, oo), {log(a)})

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -238,9 +238,7 @@ def test_intersect():
     assert Union(Interval(0, 1), Interval(2, 3)).intersect(S.EmptySet) == \
         S.EmptySet
     assert Union(Interval(0, 5), FiniteSet('ham')).intersect(FiniteSet(2, 3, 4, 5, 6)) == \
-        Union(FiniteSet(2, 3, 4, 5),
-              Intersection(FiniteSet(6), Union(Interval(0, 5),
-                                               FiniteSet('ham'))))
+        Union(FiniteSet(2, 3, 4, 5), Intersection(FiniteSet(6), Union(Interval(0, 5), FiniteSet('ham'))))
 
     # issue 8217
     assert Intersection(FiniteSet(x), FiniteSet(y)) == \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -238,7 +238,15 @@ def test_intersect():
     assert Union(Interval(0, 1), Interval(2, 3)).intersect(S.EmptySet) == \
         S.EmptySet
     assert Union(Interval(0, 5), FiniteSet('ham')).intersect(FiniteSet(2, 3, 4, 5, 6)) == \
-        FiniteSet(2, 3, 4, 5)
+        Union(FiniteSet(2, 3, 4, 5),
+              Intersection(FiniteSet(6), Union(Interval(0, 5),
+                                               FiniteSet('ham'))))
+
+    # issue 8217
+    assert Intersection(FiniteSet(x), FiniteSet(y)) == \
+        Intersection(FiniteSet(x), FiniteSet(y), evaluate=False)
+    assert FiniteSet(x).intersect(S.Reals) == \
+        Intersection(S.Reals, FiniteSet(x), evaluate=False)
 
     # tests for the intersection alias
     assert Interval(0, 5).intersection(FiniteSet(1, 3)) == FiniteSet(1, 3)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -4,7 +4,8 @@ from sympy import (
     acos, atan, atanh, cos, erf, erfinv, erfc, erfcinv,
     exp, log, pi, sin, sinh, sqrt, symbols,
     tan, tanh, atan2, arg,
-    Lambda, imageset, cot, acot, I, EmptySet, Union, E, Interval, oo)
+    Lambda, imageset, cot, acot, I, EmptySet, Union, E, Interval, Intersection,
+    oo)
 
 from sympy.core.function import nfloat
 from sympy.functions.elementary.complexes import im, re
@@ -40,7 +41,7 @@ def test_invert_real():
     x = Dummy(real=True)
     n = Symbol('n')
     d = Dummy()
-    assert solveset(abs(x) - n, x) == solveset(abs(x) - d, x) == EmptySet()
+    assert solveset(abs(x) - n, x) == Intersection(S.Reals, FiniteSet(-n, n))
 
     n = Symbol('n', real=True)
     assert invert_real(x + 3, y, x) == (x, FiniteSet(y - 3))

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1037,9 +1037,10 @@ def pspace_independent(a, b):
     pspace_independent(a, b) implies independent(a, b)
     independent(a, b) does not imply pspace_independent(a, b)
     """
-    a_symbols = pspace(b).symbols
-    b_symbols = pspace(a).symbols
-    if len(a_symbols.intersect(b_symbols)) == 0:
+    a_symbols = set(pspace(b).symbols)
+    b_symbols = set(pspace(a).symbols)
+
+    if len(a_symbols.intersection(b_symbols)) == 0:
         return True
     return None
 


### PR DESCRIPTION
On Top of #8508
- [x] Fixes #8217
- [x] Fixes #9536 
- [x] Test for #9536 

TODO Failing Tests:
- [x] [sympy/solvers/tests/test_solveset.py](https://github.com/aktech/sympy/commit/a5ee04b5bd37df93e76c1918eee2fa297a9773fb)
- [x] [sympy/core/tests/test_wester.py](https://github.com/aktech/sympy/commit/e8e6a0bb9285c315e9bade2bcd10b954760d4965)
- [x] [sympy/stats/tests/test_rv.py](https://travis-ci.org/sympy/sympy/jobs/67831123)
- [x] [sympy/combinatorics/tests/test_partitions.py](https://travis-ci.org/sympy/sympy/jobs/67831130) [Though partitions can't be ordered (See issue #9608) ]

@hargup @flacjacket 
