### PR TITLE
Mod(zoo, 0) now returns `nan` and fixed one typo

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy.core.numbers import nan
 from .function import Function
 
 
@@ -32,9 +33,11 @@ class Mod(Function):
 
         def doit(p, q):
             """Try to return p % q if both are numbers or +/-p is known
-            to be less than q.
+            to be less than or equal q.
             """
 
+            if p.is_infinite or q.is_infinite:
+                return nan
             if (p == q or p == -q or
                     p.is_Pow and p.exp.is_Integer and p.base == q or
                     p.is_integer and q == 1):
@@ -62,7 +65,7 @@ class Mod(Function):
                         rv += q
                     return rv
 
-            # by differencec
+            # by difference
             d = p - q
             if d.is_negative:
                 if q.is_negative:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -67,6 +67,14 @@ def test_mod():
     assert (a % 2).round(15) == 0.6
     assert (a % 0.5).round(15) == 0.1
 
+    p = Symbol('p', infinite=True)
+
+    assert zoo % 0 == nan
+    assert oo % oo == nan
+    assert zoo % oo == nan
+    assert 5 % oo == nan
+    assert p % 5 == nan
+
     # In these two tests, if the precision of m does
     # not match the precision of the ans, then it is
     # likely that the change made now gives an answer


### PR DESCRIPTION
fixes issue #9545 
Now

```
>>> Mod(zoo, 0)
nan
>>> Mod(oo, oo)
nan
```

I think it is better to return `nan` instead of raising `TypeError` since `zoo*0` and these type of expressions return `nan`
Please have a look.
