### PR TITLE
ask: Don't assume no assumptions means nothing can be deduced

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -160,9 +160,6 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     if res is not None:
         return bool(res)
 
-    if assumptions == True:
-        return
-
     if local_facts is None:
         return satask(proposition, assumptions=assumptions, context=context)
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1981,6 +1981,9 @@ def test_composite_proposition():
     assert ask(Equivalent(Q.positive(x), Q.integer(x)), Q.integer(x)) is None
     assert ask(Q.real(x) | Q.integer(x), Q.real(x) | Q.integer(x)) is True
 
+def test_tautology():
+    assert ask(Q.real(x) | ~Q.real(x)) is True
+    assert ask(Q.real(x) & ~Q.real(x)) is False
 
 def test_composite_assumptions():
     assert ask(Q.real(x), Q.real(x) & Q.real(y)) is True


### PR DESCRIPTION
If the query is a logical tautology or contraction, a deduction can still be
made (typically using satask). This also allows any ask(query, fact) to be
rewritten as ask(fact >> query).
