### PR TITLE
solveset(Abs(x) + 1, x) now returns EmptySet() typo fixed

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -76,6 +76,7 @@ def _invert_real(f, g_ys, symbol):
                             imageset(Lambda(n, f.inverse()(n)), g_ys), symbol)
 
     if isinstance(f, Abs):
+        g_ys = g_ys - FiniteSet(*[g_y for g_y in g_ys if g_y.is_negative])
         return _invert_real(f.args[0],
                             Union(g_ys, imageset(Lambda(n, -n), g_ys)), symbol)
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -856,6 +856,9 @@ def solveset(f, symbol=None):
 
     f = sympify(f)
 
+    if f is S.false:
+        return EmptySet()
+
     if isinstance(f, Eq):
         from sympy.core import Add
         f = Add(f.lhs, - f.rhs, evaluate=False)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -411,8 +411,8 @@ def solveset_real(f, symbol):
         # if f(x) and g(x) are both finite we can say that the solution of
         # f(x)*g(x) == 0 is same as Union(f(x) == 0, g(x) == 0) is not true in
         # general. g(x) can grow to infinitely large for the values where
-        # f(x) == 0. To be sure that we not are silently allowing any
-        # wrong solutions we are using this technique only if both f and g and
+        # f(x) == 0. To be sure that we are not silently allowing any
+        # wrong solutions we are using this technique only if both f and g are
         # finite for a finite input.
         result = Union(*[solveset_real(m, symbol) for m in f.args])
     elif _is_function_class_equation(TrigonometricFunction, f, symbol) or \

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -877,7 +877,8 @@ def test_linsolve():
 
 def test_issue_9556():
     x = Symbol('x', real=True)
-    b = Symbol('b', real=True, positive=True)
+    b = Symbol('b', positive=True)
 
     assert solveset(Abs(x) + 1, x) == EmptySet()
     assert solveset(Abs(x) + b, x) == EmptySet()
+    assert solveset(Eq(b, -1), b) == EmptySet()

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -873,3 +873,11 @@ def test_linsolve():
     sol = FiniteSet((-b*(f - c*e/a)/(a*(d - b*c/a)) + e/a,
                     (f - c*e/a)/(d - b*c/a)))
     assert linsolve(system, [x, y]) == sol
+
+
+def test_issue_9556():
+    x = Symbol('x', real=True)
+    b = Symbol('b', real=True, positive=True)
+
+    assert solveset(Abs(x) + 1, x) == EmptySet()
+    assert solveset(Abs(x) + b, x) == EmptySet()


### PR DESCRIPTION
Earlier

```
>>> x = Symbol('x', real=True)
>>> b = Symbol('b', real=True, positive=True)
>>> solveset(Abs(x) + b, x)
{b, -b}
>>> solveset(Eq(Abs(x), -1), x)
False
```

Now

```
>>> x = Symbol('x', real=True)
>>> b = Symbol('b', real=True, positive=True)
>>> solveset(Abs(x) + b, x)
EmptySet()
>>> solveset(Eq(Abs(x), -1), x)
EmptySet()
```

Fixes issue #9556 and typo fixed.
