### PR TITLE
Make ring_series work with symbolic coefficients

### DIFF
--- a/sympy/polys/domains/pythonrational.py
+++ b/sympy/polys/domains/pythonrational.py
@@ -8,6 +8,7 @@ from sympy.polys.polyutils import PicklableWithSlots
 from sympy.polys.domains.domainelement import DomainElement
 
 from sympy.core.compatibility import integer_types
+from sympy.core.numbers import Rational
 from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
 
@@ -241,6 +242,9 @@ class PythonRational(DefaultPrinting, PicklableWithSlots, DomainElement):
     @property
     def denom(self):
         return self.q
+
+    def _sympy_(self):
+        return Rational(self.p, self.q)
 
     numerator = numer
     denominator = denom

--- a/sympy/polys/domains/pythonrational.py
+++ b/sympy/polys/domains/pythonrational.py
@@ -8,6 +8,7 @@ from sympy.polys.polyutils import PicklableWithSlots
 from sympy.polys.domains.domainelement import DomainElement
 
 from sympy.core.compatibility import integer_types
+from sympy.core.sympify import converter
 from sympy.core.numbers import Rational
 from sympy.printing.defaults import DefaultPrinting
 from sympy.utilities import public
@@ -243,8 +244,10 @@ class PythonRational(DefaultPrinting, PicklableWithSlots, DomainElement):
     def denom(self):
         return self.q
 
-    def _sympy_(self):
-        return Rational(self.p, self.q)
-
     numerator = numer
     denominator = denom
+
+
+def sympify_pythonrational(arg):
+    return Rational(arg.p, arg.q)
+converter[PythonRational] = sympify_pythonrational

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -32,8 +32,8 @@ def _invert_monoms(p1):
     terms = list(p1.items())
     terms.sort()
     deg = p1.degree()
-    ring = p1.ring
-    p = ring.zero
+    R = p1.ring
+    p = R.zero
     cv = p1.listcoeffs()
     mv = p1.listmonoms()
     for i in range(len(mv)):
@@ -68,9 +68,9 @@ def rs_trunc(p1, x, prec):
     >>> rs_trunc(p, x, 10)
     x**5 + x + 1
     """
-    ring = p1.ring
-    p = ring.zero
-    i = ring.gens.index(x)
+    R = p1.ring
+    p = R.zero
+    i = R.gens.index(x)
     for exp1 in p1:
         if exp1[i] >= prec:
             continue
@@ -95,18 +95,18 @@ def rs_mul(p1, p2, x, prec):
     >>> rs_mul(p1, p2, x, 3)
     3*x**2 + 3*x + 1
     """
-    ring = p1.ring
-    p = ring.zero
-    if ring.__class__ != p2.ring.__class__ or ring != p2.ring:
+    R = p1.ring
+    p = R.zero
+    if R.__class__ != p2.ring.__class__ or R != p2.ring:
         raise ValueError('p1 and p2 must have the same ring')
-    iv = ring.gens.index(x)
+    iv = R.gens.index(x)
     if not isinstance(p2, PolyElement):
         raise ValueError('p1 and p2 must have the same ring')
-    if ring == p2.ring:
+    if R == p2.ring:
         get = p.get
         items2 = list(p2.items())
         items2.sort(key=lambda e: e[0][iv])
-        if ring.ngens == 1:
+        if R.ngens == 1:
             for exp1, v1 in p1.items():
                 for exp2, v2 in items2:
                     exp = exp1[0] + exp2[0]
@@ -116,7 +116,7 @@ def rs_mul(p1, p2, x, prec):
                     else:
                         break
         else:
-            monomial_mul = ring.monomial_mul
+            monomial_mul = R.monomial_mul
             for exp1, v1 in p1.items():
                 for exp2, v2 in items2:
                     if exp1[iv] + exp2[iv] < prec:
@@ -143,13 +143,13 @@ def rs_square(p1, x, prec):
     >>> rs_square(p, x, 3)
     6*x**2 + 4*x + 1
     """
-    ring = p1.ring
-    p = ring.zero
-    iv = ring.gens.index(x)
+    R = p1.ring
+    p = R.zero
+    iv = R.gens.index(x)
     get = p.get
     items = list(p1.items())
     items.sort(key=lambda e: e[0][iv])
-    monomial_mul = ring.monomial_mul
+    monomial_mul = R.monomial_mul
     for i in range(len(items)):
         exp1, v1 = items[i]
         for j in range(i):
@@ -230,10 +230,10 @@ def _has_constant_term(p, x):
     >>> _has_constant_term(p, x)
     True
     """
-    ring = p.ring
-    iv = ring.gens.index(x)
-    zm = ring.zero_monom
-    a = [0]*ring.ngens
+    R = p.ring
+    iv = R.gens.index(x)
+    zm = R.zero_monom
+    a = [0]*R.ngens
     a[iv] = 1
     miv = tuple(a)
     for expv in p:
@@ -259,17 +259,17 @@ def _series_inversion1(p, x, prec):
     -x**3 + x**2 - x + 1
 
     """
-    ring = p.ring
-    zm = ring.zero_monom
+    R = p.ring
+    zm = R.zero_monom
     if zm not in p:
         raise ValueError('no constant term in series')
     if _has_constant_term(p - p[zm], x):
         raise ValueError('p cannot contain a constant term depending on parameters')
-    if p[zm] != ring(1):
+    if p[zm] != R(1):
         # TODO add check that it is a unit
-        p1 = ring(1)/p[zm]
+        p1 = R(1)/p[zm]
     else:
-        p1 = ring(1)
+        p1 = R(1)
     for precx in _giant_steps(prec):
         tmp = p1.square()
         tmp = rs_mul(tmp, p, x, precx)
@@ -292,9 +292,9 @@ def rs_series_inversion(p, x, prec):
     >>> rs_series_inversion(1 + x*y**2, y, 4)
     -x*y**2 + 1
     """
-    ring = p.ring
-    zm = ring.zero_monom
-    ii = ring.gens.index(x)
+    R = p.ring
+    zm = R.zero_monom
+    ii = R.gens.index(x)
     m = min(p, key=lambda k: k[ii])[ii]
     if m:
         raise NotImplementedError('no constant term in series')
@@ -336,10 +336,10 @@ def rs_series_from_list(p, c, x, prec, concur=1):
     sympy.polys.ring.compose
 
     """
-    ring = p.ring
+    R = p.ring
     n = len(c)
     if not concur:
-        q = ring(1)
+        q = R(1)
         s = c[0]*q
         for i in range(1, n):
             q = rs_mul(q, p, x, prec)
@@ -349,9 +349,9 @@ def rs_series_from_list(p, c, x, prec, concur=1):
     K, r = divmod(n, J)
     if r:
         K += 1
-    ax = [ring(1)]
+    ax = [R(1)]
     b = 1
-    q = ring(1)
+    q = R(1)
     if len(p) < 20:
         for i in range(1, J):
             q = rs_mul(q, p, x, prec)
@@ -365,8 +365,8 @@ def rs_series_from_list(p, c, x, prec, concur=1):
             ax.append(q)
     # optimize using rs_square
     pj = rs_mul(ax[-1], p, x, prec)
-    b = ring(1)
-    s = ring(0)
+    b = R(1)
+    s = R(0)
     for k in range(K - 1):
         r = J*k
         s1 = c[r]
@@ -380,7 +380,7 @@ def rs_series_from_list(p, c, x, prec, concur=1):
     k = K - 1
     r = J*k
     if r < n:
-        s1 = c[r]*ring(1)
+        s1 = c[r]*R(1)
         for j in range(1, J):
             if r + j >= n:
                 break
@@ -406,10 +406,10 @@ def rs_diff(p, x):
     >>> rs_diff(p, x)
     2*x*y**3 + 1
     """
-    ring = p.ring
-    n = ring.gens.index(x)
-    p1 = ring.zero
-    mn = [0]*ring.ngens
+    R = p.ring
+    n = R.gens.index(x)
+    p1 = R.zero
+    mn = [0]*R.ngens
     mn[n] = 1
     mn = tuple(mn)
     for expv in p:
@@ -433,10 +433,10 @@ def rs_integrate(p, x):
     >>> rs_integrate(p, x)
     1/3*x**3*y**3 + 1/2*x**2
     """
-    ring = p.ring
-    p1 = ring.zero
-    n = ring.gens.index(x)
-    mn = [0]*ring.ngens
+    R = p.ring
+    p1 = R.zero
+    n = R.gens.index(x)
+    mn = [0]*R.ngens
     mn[n] = 1
     mn = tuple(mn)
 
@@ -474,11 +474,11 @@ def fun(p, f, *args):
     1/3*x**3*y**3 + 2*x**3*y**2 + x**3*y + 1/3*x**3 + x**2*y + x*y + x
 
     """
-    _ring = p.ring
-    ring1, _x = ring('_x', _ring)
+    _R = p.ring
+    R1, _x = ring('_x', _R)
     h = int(args[-1])
     args1 = args[:-2] + (_x, h)
-    zm = _ring.zero_monom
+    zm = _R.zero_monom
     # separate the constant term of the series
     # compute the univariate series f(_x, .., 'x', sum(nv))
     # or _x.f(..., 'x', sum(nv)
@@ -506,8 +506,8 @@ def mul_xin(p, i, n):
     x_i is the ith variable in p
     """
     n = as_int(n)
-    ring = p.ring
-    q = ring(0)
+    R = p.ring
+    q = R(0)
     for k, v in p.items():
         k1 = list(k)
         k1[i] += n
@@ -533,7 +533,7 @@ def rs_log(p, x, prec):
     >>> rs_log(1 + x, x, 8)
     1/7*x**7 - 1/6*x**6 + 1/5*x**5 - 1/4*x**4 + 1/3*x**3 - 1/2*x**2 + x
     """
-    ring = p.ring
+    R = p.ring
     if p == 1:
         return 0
     if _has_constant_term(p - 1, x):
@@ -562,12 +562,12 @@ def rs_LambertW(p, iv, prec):
 
     LambertW
     """
-    ring = p.ring
-    p1 = ring(0)
+    R = p.ring
+    p1 = R(0)
     if _has_constant_term(p, iv):
         raise NotImplementedError('Polynomial must not have constant term in \
               the series variables')
-    if iv in ring.gens:
+    if iv in R.gens:
         for precx in _giant_steps(prec):
             e = rs_exp(p1, iv, precx)
             p2 = rs_mul(e, p1, iv, precx) - p
@@ -583,8 +583,8 @@ def _exp1(p, x, prec):
     """
     Helper function for ``rs_exp``
     """
-    ring = p.ring
-    p1 = ring(1)
+    R = p.ring
+    p1 = R(1)
     for precx in _giant_steps(prec):
         pt = p - rs_log(p1, x, precx)
         tmp = rs_mul(pt, p1, x, precx)
@@ -605,7 +605,7 @@ def rs_exp(p, x, prec):
     >>> rs_exp(x**2, x, 7)
     1/6*x**6 + 1/2*x**4 + x**2 + 1
     """
-    ring = p.ring
+    R = p.ring
     if _has_constant_term(p, x):
         zm = R.zero_monom
         c = p[zm]
@@ -631,7 +631,7 @@ def rs_exp(p, x, prec):
 
     if len(p) > 20:
         return _exp1(p, x, prec)
-    one = ring(1)
+    one = R(1)
     n = 1
     k = 1
     c = []
@@ -646,8 +646,8 @@ def rs_exp(p, x, prec):
 # TODO
 # Needs to be benchmarked before use in rs_atan
 def _atan_series(p, iv, prec):
-    ring = p.ring
-    mo = ring(-1)
+    R = p.ring
+    mo = R(-1)
     c = [-mo]
     p2 = rs_square(p, iv, prec)
     for k in range(1, prec):
@@ -680,13 +680,13 @@ def rs_atan(p, x, prec):
     if _has_constant_term(p, x):
         raise NotImplementedError('Polynomial must not have constant term in \
               the series variables')
-    ring = p.ring
+    R = p.ring
 
     # Instead of using a closed form formula, we differentiate atan(p) to get
     # `1/(1+p**2) * dp`, whose series expansion is much easier to calculate.
     # Finally we integrate to get back atan
     dp = p.diff(x)
-    p1 = rs_square(p, x, prec) + ring(1)
+    p1 = rs_square(p, x, prec) + R(1)
     p1 = rs_series_inversion(p1, x, prec - 1)
     p1 = rs_mul(dp, p1, x, prec - 1)
     return rs_integrate(p1, x)
@@ -704,8 +704,8 @@ def _tan1(p, x, prec):
     Then `f(r) = 0`
     Or `y  = atan(x)` where `x = tan(y)` as required.
     """
-    ring = p.ring
-    p1 = ring(0)
+    R = p.ring
+    p1 = R(0)
     for precx in _giant_steps(prec):
         tmp = p - rs_atan(p1, x, precx)
         tmp = rs_mul(tmp, 1 + p1.square(), x, precx)
@@ -760,7 +760,7 @@ def rs_tan(p, x, prec):
         t = rs_series_inversion(1 - t1*t2, x, prec)
         return rs_mul(t1 + t2, t, x, prec)
 
-    if ring.ngens == 1:
+    if R.ngens == 1:
         return _tan1(p, x, prec)
     return fun(p, rs_tan, x, prec)
 
@@ -787,7 +787,7 @@ def rs_sin(p, x, prec):
     """
     R = x.ring
     if not p:
-        return ring(0)
+        return R(0)
     # Support for constant term can be extended on the lines of rs_cos
     if _has_constant_term(p, x):
         zm = R.zero_monom
@@ -905,8 +905,8 @@ def check_series_var(p, iv):
 # TODO
 # Needs to be benchmarked before use in rs_atanh
 def _atanh(p, iv, prec):
-    ring = p.ring
-    one = ring(1)
+    R = p.ring
+    one = R(1)
     c = [one]
     p2 = rs_square(p, iv, prec)
     for k in range(1, prec):
@@ -939,7 +939,7 @@ def rs_atanh(p, iv, prec):
     if _has_constant_term(p, iv):
         raise NotImplementedError('Polynomial must not have constant term in \
               the series variables')
-    ring = p.ring
+    R = p.ring
 
     # Instead of using a closed form formula, we differentiate atanh(p) to get
     # `1/(1-p**2) * dp`, whose series expansion is much easier to calculate.
@@ -1015,8 +1015,8 @@ def _tanh(p, iv, prec):
 
     _tanh
     """
-    ring = p.ring
-    p1 = ring(0)
+    R = p.ring
+    p1 = R(0)
     for precx in _giant_steps(prec):
         tmp = p - rs_atanh(p1, iv, precx)
         tmp = rs_mul(tmp, 1 - p1.square(), iv, precx)
@@ -1044,11 +1044,11 @@ def rs_tanh(p, iv, prec):
 
     tanh
     """
-    ring = p.ring
+    R = p.ring
     if _has_constant_term(p, iv):
         raise NotImplementedError('Polynomial must not have constant term in \
               the series variables')
-    if ring.ngens == 1:
+    if R.ngens == 1:
         return _tanh(p, iv, prec)
     return fun(p, _tanh, iv, prec)
 

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -607,7 +607,28 @@ def rs_exp(p, x, prec):
     """
     ring = p.ring
     if _has_constant_term(p, x):
-        raise NotImplementedError
+        zm = R.zero_monom
+        c = p[zm]
+        if isinstance(c, ExpressionDomain.Expression):
+            pass
+        elif isinstance(c, PolyElement):
+            try:
+                R(c)
+            except ValueError:
+                raise DomainError("The given series can't be expanded in this"
+                "domain.")
+        elif not c.is_real:
+            raise NotImplementedError
+        else:
+            raise NotImplementedError
+        p1 = p - c
+
+        from sympy.functions import exp
+    # Makes use of sympy fuctions to evaluate the values of the cos/sin
+    # of the constant term.
+        c = c.as_expr()
+        return exp(c)*rs_exp(p1, x, prec)
+
     if len(p) > 20:
         return _exp1(p, x, prec)
     one = ring(1)
@@ -712,10 +733,33 @@ def rs_tan(p, x, prec):
 
    tan
    """
-    ring = p.ring
+    R = p.ring
     if _has_constant_term(p, x):
-        raise NotImplementedError('Polynomial must not have constant term in \
-              series variables')
+        zm = R.zero_monom
+        c = p[zm]
+        if isinstance(c, ExpressionDomain.Expression):
+            pass
+        elif isinstance(c, PolyElement):
+            try:
+                R(c)
+            except ValueError:
+                raise DomainError("The given series can't be expanded in this"
+                "domain.")
+        elif not c.is_real:
+            raise NotImplementedError
+        else:
+            raise NotImplementedError
+        p1 = p - c
+
+        from sympy.functions import tan
+    # Makes use of sympy fuctions to evaluate the values of the cos/sin
+    # of the constant term.
+        c = c.as_expr()
+        t1 = tan(c)
+        t2 = rs_tan(p1, x, prec)
+        t = rs_series_inversion(1 - t1*t2, x, prec)
+        return rs_mul(t1 + t2, t, x, prec)
+
     if ring.ngens == 1:
         return _tan1(p, x, prec)
     return fun(p, rs_tan, x, prec)

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -263,16 +263,18 @@ def _series_inversion1(p, x, prec):
     """
     R = p.ring
     zm = R.zero_monom
+    c = p[zm]
     if zm not in p:
         raise ValueError('no constant term in series')
-    if _has_constant_term(p - p[zm], x):
-        raise ValueError('p cannot contain a constant term depending on parameters')
+    if _has_constant_term(p - c, x):
+        raise ValueError('p cannot contain a constant term depending on '
+            'parameters')
     one = R(1)
-    if isinstance(p[zm], ExpressionDomain.Expression):
+    if R.domain is EX:
         one = 1
-    if p[zm] != one:
+    if c != one:
         # TODO add check that it is a unit
-        p1 = R(1)/p[zm]
+        p1 = R(1)/c
     else:
         p1 = R(1)
     for precx in _giant_steps(prec):
@@ -826,7 +828,7 @@ def rs_sin(p, x, prec):
     # of the constant term.
         return rs_sin(p1, x, prec)*t2 + rs_cos(p1, x, prec)*t1
 
-    # Series is calcualed in terms of tan as its evaluation is fast.
+    # Series is calculated in terms of tan as its evaluation is fast.
     if len(p) > 20 and p.ngens == 1:
         t = rs_tan(p/2, x, prec)
         t2 = rs_square(t, x, prec)

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -616,7 +616,7 @@ def rs_exp(p, x, prec):
     if _has_constant_term(p, x):
         zm = R.zero_monom
         c = p[zm]
-        c_expr = (p[zm]).as_expr()
+        c_expr = c.as_expr()
         if R.domain is EX:
             const = exp(c_expr)
         elif isinstance(c, PolyElement):
@@ -687,7 +687,7 @@ def rs_atan(p, x, prec):
     if _has_constant_term(p, x):
         zm = R.zero_monom
         c = p[zm]
-        c_expr = (p[zm]).as_expr()
+        c_expr = c.as_expr()
         if R.domain is EX:
             const = atan(c_expr)
         elif isinstance(c, PolyElement):
@@ -756,7 +756,7 @@ def rs_tan(p, x, prec):
     if _has_constant_term(p, x):
         zm = R.zero_monom
         c = p[zm]
-        c_expr = (p[zm]).as_expr()
+        c_expr = c.as_expr()
         if R.domain is EX:
             const = tan(c_expr)
         elif isinstance(c, PolyElement):
@@ -777,8 +777,8 @@ def rs_tan(p, x, prec):
         t = rs_series_inversion(1 - const*t2, x, prec)
         return rs_mul(const + t2, t, x, prec)
 
-    #if R.ngens == 1:
-    return _tan1(p, x, prec)
+    if R.ngens == 1:
+        return _tan1(p, x, prec)
     return fun(p, rs_tan, x, prec)
 
 def rs_sin(p, x, prec):
@@ -955,7 +955,7 @@ def rs_atanh(p, x, prec):
     if _has_constant_term(p, x):
         zm = R.zero_monom
         c = p[zm]
-        c_expr = (p[zm]).as_expr()
+        c_expr = c.as_expr()
         if R.domain is EX:
             const = atanh(c_expr)
         elif isinstance(c, PolyElement):
@@ -1050,7 +1050,7 @@ def _tanh(p, iv, prec):
         p1 += tmp
     return p1
 
-def rs_tanh(p, iv, prec):
+def rs_tanh(p, x, prec):
     """
     Hyperbolic tangent of a series
 
@@ -1072,12 +1072,31 @@ def rs_tanh(p, iv, prec):
     tanh
     """
     R = p.ring
-    if _has_constant_term(p, iv):
-        raise NotImplementedError('Polynomial must not have constant term in \
-              the series variables')
+    const = 0
+    if _has_constant_term(p, x):
+        zm = R.zero_monom
+        c = p[zm]
+        c_expr = c.as_expr()
+        if R.domain is EX:
+            const = tanh(c_expr)
+        elif isinstance(c, PolyElement):
+            try:
+                const = R(tanh(c_expr))
+            except ValueError:
+                raise DomainError("The given series can't be expanded in this "
+                    "domain.")
+        else:
+            raise DomainError("The given series can't be expanded in this "
+                "domain")
+            raise NotImplementedError
+        p1 = p - c
+        t1 = rs_tanh(p1, x, prec)
+        t = rs_series_inversion(1 + const*t1, x, prec)
+        return rs_mul(const + t1, t, x, prec)
+
     if R.ngens == 1:
-        return _tanh(p, iv, prec)
-    return fun(p, _tanh, iv, prec)
+        return _tanh(p, x, prec)
+    return fun(p, _tanh, x, prec)
 
 def rs_newton(p, x, prec):
     """

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -765,9 +765,8 @@ def rs_sin(p, x, prec):
         from sympy.functions import cos, sin
     # Makes use of sympy cos, sin fuctions to evaluate the values of the cos/sin
     # of the constant term.
-        with evaluate(True):
-            return rs_sin(p1, x, prec)*cos(c.as_expr()) + \
-                rs_cos(p1, x, prec)*sin(c.as_expr())
+        c = c.as_expr()
+        return rs_sin(p1, x, prec)*cos(c) + rs_cos(p1, x, prec)*sin(c)
 
     # Series is calcualed in terms of tan as its evaluation is fast.
     if len(p) > 20 and p.ngens == 1:
@@ -826,9 +825,8 @@ def rs_cos(p, iv, prec):
         from sympy.functions import cos, sin
     # Makes use of sympy cos, sin fuctions to evaluate the values of the cos/sin
     # of the constant term.
-        with evaluate(True):
-            return cos(c.as_expr())*rs_cos(p1, iv, prec) - \
-                sin(c.as_expr())*rs_sin(p1, iv, prec)
+        c = c.as_expr()
+        return cos(c)*rs_cos(p1, iv, prec) - sin(c)*rs_sin(p1, iv, prec)
 
     # Series is calculated in terms of tan as its evaluation is fast.
     if len(p) > 20 and R.ngens == 1:

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -265,7 +265,10 @@ def _series_inversion1(p, x, prec):
         raise ValueError('no constant term in series')
     if _has_constant_term(p - p[zm], x):
         raise ValueError('p cannot contain a constant term depending on parameters')
-    if p[zm] != R(1):
+    one = R(1)
+    if isinstance(p[zm], ExpressionDomain.Expression):
+        one = 1
+    if p[zm] != one:
         # TODO add check that it is a unit
         p1 = R(1)/p[zm]
     else:
@@ -760,8 +763,8 @@ def rs_tan(p, x, prec):
         t = rs_series_inversion(1 - t1*t2, x, prec)
         return rs_mul(t1 + t2, t, x, prec)
 
-    if R.ngens == 1:
-        return _tan1(p, x, prec)
+    #if R.ngens == 1:
+    return _tan1(p, x, prec)
     return fun(p, rs_tan, x, prec)
 
 def rs_sin(p, x, prec):

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -6,7 +6,7 @@ from mpmath.libmp.libintmath import ifac
 from sympy.core.numbers import Rational
 from sympy.core.compatibility import as_int, range
 from sympy.core import S, evaluate
-from sympy.functions import sin, cos, tan, atan, exp, atanh
+from sympy.functions import sin, cos, tan, atan, exp, atanh, tanh
 from mpmath.libmp.libintmath import giant_steps
 import math
 
@@ -777,9 +777,7 @@ def rs_tan(p, x, prec):
         t = rs_series_inversion(1 - const*t2, x, prec)
         return rs_mul(const + t2, t, x, prec)
 
-    if R.ngens == 1:
-        return _tan1(p, x, prec)
-    return fun(p, rs_tan, x, prec)
+    return _tan1(p, x, prec)
 
 def rs_sin(p, x, prec):
     """
@@ -1094,9 +1092,7 @@ def rs_tanh(p, x, prec):
         t = rs_series_inversion(1 + const*t1, x, prec)
         return rs_mul(const + t1, t, x, prec)
 
-    if R.ngens == 1:
-        return _tanh(p, x, prec)
-    return fun(p, _tanh, x, prec)
+    return _tanh(p, x, prec)
 
 def rs_newton(p, x, prec):
     """

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -8,7 +8,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.core.symbol import symbols
-from sympy.functions import sin, cos, exp, tan, atan
+from sympy.functions import sin, cos, exp, tan, atan, atanh
 
 def test_ring_series1():
     R, x = ring('x', QQ)
@@ -312,6 +312,22 @@ def test_atanh():
     assert rs_atanh(x*y + x**2*y**3, x, 9) == 2*x**8*y**11 + x**8*y**9 + \
         2*x**7*y**9 + 1/7*x**7*y**7 + 1/3*x**6*y**9 + x**6*y**7 + x**5*y**7 + \
         1/5*x**5*y**5 + x**4*y**5 + 1/3*x**3*y**3 + x**2*y**3 + x*y
+
+    # Constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', EX)
+    assert rs_atanh(x + a, x, 5) == EX((a**3 + a)/(a**8 - 4*a**6 + 6*a**4 - \
+        4*a**2 + 1))*x**4 - EX((3*a**2 + 1)/(3*a**6 - 9*a**4 + \
+        9*a**2 - 3))*x**3 + EX(a/(a**4 - 2*a**2 + 1))*x**2 - EX(1/(a**2 - \
+        1))*x + EX(atanh(a))
+    assert rs_atanh(x + x**2*y + a, x, 4) == EX(2*a/(a**4 - 2*a**2 + \
+        1))*x**3*y - EX((3*a**2 + 1)/(3*a**6 - 9*a**4 + 9*a**2 - 3))*x**3 - \
+        EX(1/(a**2 - 1))*x**2*y + EX(a/(a**4 - 2*a**2 + 1))*x**2 - \
+        EX(1/(a**2 - 1))*x + EX(atanh(a))
+
+    p = x + x**2 + 5
+    assert rs_atanh(p, x, 10).compose(x, 10) == EX(-733442653682135/5079158784 \
+        + atanh(5))
 
 def test_sinh():
     R, x, y = ring('x, y', QQ)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -1,4 +1,4 @@
-from sympy.polys.domains import QQ
+from sympy.polys.domains import QQ, EX
 from sympy.polys.rings import ring
 from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
   rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term, rs_series_inversion,
@@ -7,6 +7,8 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
   rs_sinh, rs_cosh, rs_tanh, _tan1, fun)
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
+from sympy.core.symbol import symbols
+from sympy.functions import sin, cos
 
 def test_ring_series1():
     R, x = ring('x', QQ)
@@ -199,6 +201,23 @@ def test_sin():
         + 1/24*x**6*y**7 - 1/2*x**5*y**7 + 1/120*x**5*y**5 - 1/2*x**4*y**5 \
         - 1/6*x**3*y**3 + x**2*y**3 + x*y
 
+    # Constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', QQ[sin(a), cos(a), a])
+    assert rs_sin(x + a, x, 5) == sin(a)*x**4/24 - cos(a)*x**3/6 - \
+        sin(a)*x**2/2 + cos(a)*x + sin(a)
+    assert rs_sin(x + x**2*y + a, x, 5) == -sin(a)*x**4*y**2/2 - \
+        cos(a)*x**4*y/2 + sin(a)*x**4/24 - sin(a)*x**3*y - cos(a)*x**3/6 + \
+        cos(a)*x**2*y - sin(a)*x**2/2 + cos(a)*x + sin(a)
+
+    R, x, y = ring('x, y', EX)
+    assert rs_sin(x + a, x, 5) == EX(sin(a)/24)*x**4 - EX(cos(a)/6)*x**3 - \
+        EX(sin(a)/2)*x**2 + EX(cos(a))*x + EX(sin(a))
+    assert rs_sin(x + x**2*y + a, x, 5) == -EX(sin(a)/2)*x**4*y**2 - \
+        EX(cos(a)/2)*x**4*y + EX(sin(a)/24)*x**4 - EX(sin(a))*x**3*y - \
+        EX(cos(a)/6)*x**3 + EX(cos(a))*x**2*y - EX(sin(a)/2)*x**2 + \
+        EX(cos(a))*x + EX(sin(a))
+
 def test_cos():
     R, x, y = ring('x, y', QQ)
     assert rs_cos(x, x, 9) == \
@@ -207,6 +226,23 @@ def test_cos():
         1/48*x**8*y**10 + 1/40320*x**8*y**8 + 1/6*x**7*y**10 - \
         1/120*x**7*y**8 + 1/4*x**6*y**8 - 1/720*x**6*y**6 + 1/6*x**5*y**6 \
         - 1/2*x**4*y**6 + 1/24*x**4*y**4 - x**3*y**4 - 1/2*x**2*y**2 + 1
+
+    # Constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', QQ[sin(a), cos(a), a])
+    assert rs_cos(x + a, x, 5) == cos(a)*x**4/24 + sin(a)*x**3/6 - \
+        cos(a)*x**2/2 - sin(a)*x + cos(a)
+    assert rs_cos(x + x**2*y + a, x, 5) == -cos(a)*x**4*y**2/2 + \
+        sin(a)*x**4*y/2 + cos(a)*x**4/24 - cos(a)*x**3*y + sin(a)*x**3/6 - \
+        sin(a)*x**2*y - cos(a)*x**2/2 - sin(a)*x + cos(a)
+
+    R, x, y = ring('x, y', EX)
+    assert rs_cos(x + a, x, 5) == EX(cos(a)/24)*x**4 + EX(sin(a)/6)*x**3 - \
+        EX(cos(a)/2)*x**2 - EX(sin(a))*x + EX(cos(a))
+    assert rs_cos(x + x**2*y + a, x, 5) == -EX(cos(a)/2)*x**4*y**2 + \
+        EX(sin(a)/2)*x**4*y + EX(cos(a)/24)*x**4 - EX(cos(a))*x**3*y + \
+        EX(sin(a)/6)*x**3 - EX(sin(a))*x**2*y - EX(cos(a)/2)*x**2 - \
+        EX(sin(a))*x + EX(cos(a))
 
 def test_cos_sin():
     R, x, y = ring('x, y', QQ)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -8,7 +8,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.core.symbol import symbols
-from sympy.functions import sin, cos, exp, tan
+from sympy.functions import sin, cos, exp, tan, atan
 
 def test_ring_series1():
     R, x = ring('x', QQ)
@@ -201,6 +201,19 @@ def test_atan():
         2*x**7*y**9 - 1/7*x**7*y**7 - 1/3*x**6*y**9 + x**6*y**7 - x**5*y**7 + \
         1/5*x**5*y**5 - x**4*y**5 - 1/3*x**3*y**3 + x**2*y**3 + x*y
 
+    # Constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', EX)
+    assert rs_atan(x + a, x, 5) == -EX((a**3 - a)/(a**8 + 4*a**6 + 6*a**4 + \
+        4*a**2 + 1))*x**4 + EX((3*a**2 - 1)/(3*a**6 + 9*a**4 + \
+        9*a**2 + 3))*x**3 - EX(a/(a**4 + 2*a**2 + 1))*x**2 + \
+        EX(1/(a**2 + 1))*x + EX(atan(a))
+    assert rs_atan(x + x**2*y + a, x, 4) == -EX(2*a/(a**4 + 2*a**2 + 1)) \
+        *x**3*y + EX((3*a**2 - 1)/(3*a**6 + 9*a**4 + 9*a**2 + 3))*x**3 + \
+        EX(1/(a**2 + 1))*x**2*y - EX(a/(a**4 + 2*a**2 + 1))*x**2 + EX(1/(a**2 \
+        + 1))*x + EX(atan(a))
+
+
 def test_tan():
     R, x, y = ring('x, y', QQ)
     assert rs_tan(x, x, 9) == \
@@ -227,6 +240,10 @@ def test_tan():
         2*tan(a))*x**3*y + EX(tan(a)**4 + 4*tan(a)**2/3 + EX(1)/3)*x**3 + \
         EX(tan(a)**2 + 1)*x**2*y + EX(tan(a)**3 + tan(a))*x**2 + \
         EX(tan(a)**2 + 1)*x + EX(tan(a))
+
+    p = x + x**2 + 5
+    assert rs_atan(p, x, 10).compose(x, 10) == EX(atan(5) + 67701870330562640/ \
+        668083460499)
 
 def test_sin():
     R, x, y = ring('x, y', QQ)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -8,7 +8,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.core.symbol import symbols
-from sympy.functions import sin, cos, exp, tan, atan, atanh, tanh
+from sympy.functions import sin, cos, exp, tan, atan, atanh, tanh, log
 
 def test_ring_series1():
     R, x = ring('x', QQ)
@@ -142,6 +142,18 @@ def test_log():
     p1 = rs_log(p, x, 6)
     assert p1 == (4*x**5*y**2 - 2*x**5*y - 2*x**4*y**2 + x**5/5 + 2*x**4*y -
                   x**4/4 - 2*x**3*y + x**3/3 + 2*x**2*y - x**2/2 + x)
+
+    # Constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', EX)
+    assert rs_log(x + a, x, 5) == -EX(1/(4*a**4))*x**4 + EX(1/(3*a**3))*x**3 \
+        - EX(1/(2*a**2))*x**2 + EX(1/a)*x + EX(log(a))
+    assert rs_log(x + x**2*y + a, x, 4) == -EX(a**(-2))*x**3*y + \
+        EX(1/(3*a**3))*x**3 + EX(1/a)*x**2*y - EX(1/(2*a**2))*x**2 + \
+        EX(1/a)*x + EX(log(a))
+
+    p = x + x**2 + 3
+    assert rs_log(p, x, 10).compose(x, 5) == EX(log(3) + 19281291595/9920232)
 
 def test_exp():
     R, x = ring('x', QQ)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -8,7 +8,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.core.symbol import symbols
-from sympy.functions import sin, cos, exp, tan, atan, atanh
+from sympy.functions import sin, cos, exp, tan, atan, atanh, tanh
 
 def test_ring_series1():
     R, x = ring('x', QQ)
@@ -353,3 +353,14 @@ def test_tanh():
         17/45*x**8*y**9 + 4/3*x**7*y**9 - 17/315*x**7*y**7 - 1/3*x**6*y**9 + \
         2/3*x**6*y**7 - x**5*y**7 + 2/15*x**5*y**5 - x**4*y**5 - \
         1/3*x**3*y**3 + x**2*y**3 + x*y
+
+    # Constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', EX)
+    assert rs_tanh(x + a, x, 5) == EX(tanh(a)**5 - 5*tanh(a)**3/3 + \
+        2*tanh(a)/3)*x**4 + EX(-tanh(a)**4 + 4*tanh(a)**2/3 - QQ(1, 3))*x**3 + \
+        EX(tanh(a)**3 - tanh(a))*x**2 + EX(-tanh(a)**2 + 1)*x + EX(tanh(a))
+
+    p = rs_tanh(x + x**2*y + a, x, 4)
+    assert (p.compose(x, 10)).compose(y, 5) == EX(-1000*tanh(a)**4 + \
+        10100*tanh(a)**3 + 2470*tanh(a)**2/3 - 10099*tanh(a) + QQ(530, 3))

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -8,7 +8,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.core.symbol import symbols
-from sympy.functions import sin, cos
+from sympy.functions import sin, cos, exp, tan
 
 def test_ring_series1():
     R, x = ring('x', QQ)
@@ -158,6 +158,23 @@ def test_exp():
     p1 = rs_exp(p, x, prec)
     assert p1 == x + 1
 
+    # Constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', QQ[exp(a), a])
+    assert rs_exp(x + a, x, 5) == exp(a)*x**4/24 + exp(a)*x**3/6 + \
+        exp(a)*x**2/2 + exp(a)*x + exp(a)
+    assert rs_exp(x + x**2*y + a, x, 5) == exp(a)*x**4*y**2/2 + \
+            exp(a)*x**4*y/2 + exp(a)*x**4/24 + exp(a)*x**3*y + \
+            exp(a)*x**3/6 + exp(a)*x**2*y + exp(a)*x**2/2 + exp(a)*x + exp(a)
+
+    R, x, y = ring('x, y', EX)
+    assert rs_exp(x + a, x, 5) ==  EX(exp(a)/24)*x**4 + EX(exp(a)/6)*x**3 + \
+        EX(exp(a)/2)*x**2 + EX(exp(a))*x + EX(exp(a))
+    assert rs_exp(x + x**2*y + a, x, 5) == EX(exp(a)/2)*x**4*y**2 + \
+        EX(exp(a)/2)*x**4*y + EX(exp(a)/24)*x**4 + EX(exp(a))*x**3*y + \
+        EX(exp(a)/6)*x**3 + EX(exp(a))*x**2*y + EX(exp(a)/2)*x**2 + \
+        EX(exp(a))*x + EX(exp(a))
+
 def test_newton():
     R, x = ring('x', QQ)
     p = x**2 - 2
@@ -191,6 +208,25 @@ def test_tan():
     assert rs_tan(x*y + x**2*y**3, x, 9) == 4/3*x**8*y**11 + 17/45*x**8*y**9 + \
         4/3*x**7*y**9 + 17/315*x**7*y**7 + 1/3*x**6*y**9 + 2/3*x**6*y**7 + \
         x**5*y**7 + 2/15*x**5*y**5 + x**4*y**5 + 1/3*x**3*y**3 + x**2*y**3 + x*y
+
+    # Constant term in series
+    a = symbols('a')
+    R, x, y = ring('x, y', QQ[tan(a), a])
+    assert rs_tan(x + a, x, 5) == (tan(a)**5 + 5*tan(a)**3/3 + \
+        2*tan(a)/3)*x**4 + (tan(a)**4 + 4*tan(a)**2/3 + 1/3)*x**3 + \
+        (tan(a)**3 + tan(a))*x**2 + (tan(a)**2 + 1)*x + tan(a)
+    assert rs_tan(x + x**2*y + a, x, 4) == (2*tan(a)**3 + 2*tan(a))*x**3*y + \
+        (tan(a)**4 + 4/3*tan(a)**2 + 1/3)*x**3 + (tan(a)**2 + 1)*x**2*y + \
+        (tan(a)**3 + tan(a))*x**2 + (tan(a)**2 + 1)*x + tan(a)
+
+    R, x, y = ring('x, y', EX)
+    assert rs_tan(x + a, x, 5) == EX(tan(a)**5 + 5*tan(a)**3/3 + \
+        2*tan(a)/3)*x**4 + EX(tan(a)**4 + 4*tan(a)**2/3 + EX(1)/3)*x**3 + \
+        EX(tan(a)**3 + tan(a))*x**2 + EX(tan(a)**2 + 1)*x + EX(tan(a))
+    assert rs_tan(x + x**2*y + a, x, 4) ==  EX(2*tan(a)**3 + \
+        2*tan(a))*x**3*y + EX(tan(a)**4 + 4*tan(a)**2/3 + EX(1)/3)*x**3 + \
+        EX(tan(a)**2 + 1)*x**2*y + EX(tan(a)**3 + tan(a))*x**2 + \
+        EX(tan(a)**2 + 1)*x + EX(tan(a))
 
 def test_sin():
     R, x, y = ring('x, y', QQ)


### PR DESCRIPTION
@certik @thilinarmtb This PR allows the use of symbolic coefficients.
The `EX` domain is around 20 times slower than `QQ`

```
In [37]: R,x  =ring('x', QQ[sin(a),cos(a),a])

In [38]: S,y=ring('y', EX)

In [39]: %timeit rs_sin(x+a,x,1000)
10 loops, best of 3: 113 ms per loop

In [40]: %timeit rs_sin(y+a,y,1000)
1 loops, best of 3: 2.34 s per loop

In [41]: %timeit rs_cos(x+a,x,1000)
10 loops, best of 3: 118 ms per loop

In [42]: %timeit rs_cos(y+a,y,1000)
1 loops, best of 3: 2.43 s per loop
```

What do you think?
