### PR TITLE
Union of set containing UniversalSet with non-intersecting Interval

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1574,6 +1574,14 @@ class Complement(Set, EvalfMixin):
         B = self.args[1]
         return And(A.contains(other), Not(B.contains(other)))
 
+    def _union(self, other):
+        if self.args[0] is S.UniversalSet:
+            if Intersection(self.args[1], other).is_EmptySet:
+                return self
+            if self.args[1].is_subset(other):
+                return S.UniversalSet
+        return None
+
 
 class EmptySet(with_metaclass(Singleton, Set)):
     """

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -894,3 +894,10 @@ def test_issue_9808():
     assert Complement(FiniteSet(y), FiniteSet(1)) == Complement(FiniteSet(y), FiniteSet(1), evaluate=False)
     assert Complement(FiniteSet(1, 2, x), FiniteSet(x, y, 2, 3)) == \
         Complement(FiniteSet(1), FiniteSet(y), evaluate=False)
+
+
+def test_issue_9577():
+    un = S.UniversalSet
+    assert Union(Complement(un, Interval(1, 2)), Interval(3, 4)) == \
+            Complement(un, Interval(1, 2))
+    assert Union(Complement(un, Interval(1, 2)), Interval(1, 3)) == un


### PR DESCRIPTION
Earlier

```
>>> Union(S.UniversalSet - Interval(1, 2), Interval(3, 4)) == Complement(S.UniversalSet, Interval(1, 2))
False
```

Now it returns `True`
Fixes #9577 
