### PR TITLE
Complement of UniversalSet with Union of Sets works

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1524,6 +1524,10 @@ class Complement(Set, EvalfMixin):
             return EmptySet()
 
         if isinstance(B, Union):
+            if A.has(S.UniversalSet):
+                if A is S.UniversalSet:
+                    return Complement(A, B, evaluate=False)
+                return Complement(S.UniversalSet, Union(A.args[1], B))
             return Intersection(s.complement(A) for s in B.args)
 
         result = B._complement(A)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -846,3 +846,11 @@ def test_SymmetricDifference():
           Set(2, 3, 4) - Set(1, 2, 3))
    assert Interval(0, 4) ^ Interval(2, 5) == Union(Interval(0, 4) - \
           Interval(2, 5), Interval(2, 5) - Interval(0, 4))
+
+
+def test_issue_9447():
+    a = Interval(1, 2) + Interval(3, 4)
+    assert Complement(S.UniversalSet, a) == Complement(S.UniversalSet, \
+            Union(Interval(1, 2), Interval(3, 4)))
+    assert Complement(Complement(S.UniversalSet, Interval(1, 2)), \
+            Union(Interval(3, 4), Interval(5, 6)))


### PR DESCRIPTION
Earlier

```
>>> a = Union(Interval(0,1), Interval(2,3))
>>> Complement( S.UniversalSet, a)
RunTimeError
```

Now 

```
>>> Complement( S.UniversalSet, a)
UniversalSet() \ [0,1] U [2,3]
```

Fixes Issue #9447 
