### PR TITLE
Limit(x, x, a).free_symbols now returns set([a])

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -109,6 +109,16 @@ class Limit(Expr):
         obj._args = (e, z, z0, dir)
         return obj
 
+
+    @property
+    def free_symbols(self):
+        e = self.args[0]
+        isyms = e.free_symbols
+        isyms.difference_update(self.args[1].free_symbols)
+        isyms.update(self.args[2].free_symbols)
+        return isyms
+
+
     def doit(self, **hints):
         """Evaluates limit"""
         e, z, z0, dir = self.args

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -3,7 +3,7 @@ from itertools import product as cartes
 from sympy import (
     limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
     atan, gamma, Symbol, S, pi, Integral, Rational, I,
-    tan, cot, integrate, Sum, sign, Function, subfactorial)
+    tan, cot, integrate, Sum, sign, Function, subfactorial, symbols)
 
 from sympy.series.limits import heuristics
 from sympy.series.order import Order
@@ -433,3 +433,11 @@ def test_issue_4503():
 
 def test_issue_8730():
     assert limit(subfactorial(x), x, oo) == oo
+
+
+def test_issue_9205():
+    x, y, a = symbols('x, y, a')
+    assert Limit(x, x, a).free_symbols == set([a])
+    assert Limit(x, x, a, '-').free_symbols == set([a])
+    assert Limit(x + y, x + y, a).free_symbols == set([a])
+    assert Limit(-x**2 + y, x**2, a).free_symbols == set([y, a])


### PR DESCRIPTION
fixes issue #9205

```
>>> Limit(x, x, a).free_symbols
set([a])               # instead of set([a, x, '+'])
```

I looked into the code base for definition of `free_symbols` in `Integration.free_symbols` and found the definition different from the one stated in documentation. Though i think that is also an issue. After my comment on the issue #9205 i realised that.
