### PR TITLE
Idx instances can be used as limits in a Sum or in a sequence

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -14,6 +14,7 @@ from sympy.functions.elementary.piecewise import piecewise_fold
 from sympy.utilities import flatten
 from sympy.utilities.iterables import sift
 from sympy.matrices import Matrix
+from sympy.tensor.indexed import Idx
 
 
 def _process_limits(*symbols):
@@ -25,12 +26,12 @@ def _process_limits(*symbols):
     limits = []
     orientation = 1
     for V in symbols:
-        if isinstance(V, Symbol):
+        if isinstance(V, (Symbol, Idx)):
             limits.append(Tuple(V))
             continue
         elif is_sequence(V, Tuple):
             V = sympify(flatten(V))
-            if V[0].is_Symbol:
+            if isinstance(V[0], (Symbol, Idx)):
                 newsymbol = V[0]
                 if len(V) == 2 and isinstance(V[1], Interval):
                     V[1:] = [V[1].start, V[1].end]

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -11,6 +11,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.polys import apart, PolynomialError
 from sympy.solvers import solve
 from sympy.core.compatibility import range
+from sympy.tensor.indexed import Idx
 
 
 class Sum(AddWithLimits, ExprWithIntLimits):
@@ -176,6 +177,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             if dif.is_integer and (dif < 0) == True:
                 a, b = b + 1, a - 1
                 f = -f
+            if isinstance(i, Idx):
+                i = i.label
 
             newf = eval_sum(f, (i, a, b))
             if newf is None:

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -2,8 +2,8 @@ from sympy import (
     Abs, And, binomial, Catalan, cos, Derivative, E, Eq, exp, EulerGamma,
     factorial, Function, harmonic, I, Integral, KroneckerDelta, log,
     nan, Ne, Or, oo, pi, Piecewise, Product, product, Rational, S, simplify,
-    sqrt, Sum, summation, Symbol, symbols, sympify, zeta, gamma, Le
-)
+    sqrt, Sum, summation, Symbol, symbols, sympify, zeta, gamma, Le, Indexed,
+    Idx)
 from sympy.abc import a, b, c, d, f, k, m, x, y, z
 from sympy.concrete.summations import telescopic
 from sympy.utilities.pytest import XFAIL, raises
@@ -831,3 +831,9 @@ def test_issue_4668():
 def test_matrix_sum():
     A = Matrix([[0,1],[n,0]])
     assert Sum(A,(n,0,3)).doit() == Matrix([[0, 4], [6, 0]])
+
+
+def test_issue_9594():
+    i = symbols('i', cls=Idx)
+    r = Indexed('r', i)
+    Sum(r, (i, 0, 3)).doit() == [r.subs(i, j) for j in range(4)]

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -14,6 +14,7 @@ from sympy.core.evaluate import global_evaluate
 from sympy.polys import lcm
 from sympy.sets.sets import Interval, Intersection
 from sympy.utilities.iterables import flatten
+from sympy.tensor.indexed import Idx
 
 
 ###############################################################################
@@ -92,11 +93,8 @@ class SeqBase(Basic):
         >>> SeqFormula(m*n**2, (n, 0, 5)).free_symbols
         set([m])
         """
-        fsyms = set().union(*[a.free_symbols for a in self.args])
-        for d in self.variables:
-            if d in fsyms:
-                fsyms.remove(d)
-        return fsyms
+        return (set(j for i in self.args for j in i.free_symbols
+                   .difference(self.variables)))
 
     @cacheit
     def coeff(self, pt):
@@ -452,7 +450,7 @@ class SeqPer(SeqExpr):
                 x = _find_x(periodical)
                 start, stop = limits
 
-        if not isinstance(x, Symbol) or start is None or stop is None:
+        if not isinstance(x, (Symbol, Idx)) or start is None or stop is None:
             raise ValueError('Invalid limits given: %s' % str(limits))
 
         if start is S.NegativeInfinity and stop is S.Infinity:
@@ -594,7 +592,7 @@ class SeqFormula(SeqExpr):
                 x = _find_x(formula)
                 start, stop = limits
 
-        if not isinstance(x, Symbol) or start is None or stop is None:
+        if not isinstance(x, (Symbol, Idx)) or start is None or stop is None:
             raise ValueError('Invalid limits given: %s' % str(limits))
 
         if start is S.NegativeInfinity and stop is S.Infinity:

--- a/sympy/series/tests/test_sequences.py
+++ b/sympy/series/tests/test_sequences.py
@@ -1,5 +1,5 @@
 from sympy import (S, Tuple, symbols, Interval, EmptySequence, oo, SeqPer,
-                   SeqFormula, sequence, SeqAdd, SeqMul)
+                   SeqFormula, sequence, SeqAdd, SeqMul, Indexed, Idx)
 from sympy.series.sequences import SeqExpr, SeqExprOp
 from sympy.utilities.pytest import raises
 
@@ -246,3 +246,11 @@ def test_operations():
 
     assert form.coeff_mul(m) == SeqFormula(m*n**2, (n, 0, oo))
     assert per.coeff_mul(m) == SeqPer((m, 2*m), (n, 0, oo))
+
+
+def test_Idx_limits():
+    i = symbols('i', cls=Idx)
+    r = Indexed('r', i)
+
+    assert SeqFormula(r, (i, 0, 5))[:] == [r.subs(i, j) for j in range(6)]
+    assert SeqPer((1, 2), (i, 0, 5))[:] == [1, 2, 1, 2, 1, 2]

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -134,7 +134,7 @@ class Indexed(Expr):
     """
     is_commutative = True
 
-    def __new__(cls, base, *args, **kw_args):
+    def __new__(cls, base, *args):
         from sympy.utilities.misc import filldedent
 
         if not args:
@@ -145,7 +145,11 @@ class Indexed(Expr):
             raise TypeError(filldedent("""
                 Indexed expects string, Symbol or IndexedBase as base."""))
         args = list(map(sympify, args))
-        return Expr.__new__(cls, base, *args, **kw_args)
+        return Expr.__new__(cls, base, *args)
+
+    @property
+    def free_symbols(self):
+        return set(self.args)
 
     @property
     def base(self):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -148,10 +148,6 @@ class Indexed(Expr):
         return Expr.__new__(cls, base, *args)
 
     @property
-    def free_symbols(self):
-        return set(self.args)
-
-    @property
     def base(self):
         """Returns the IndexedBase of the Indexed object.
 

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -192,9 +192,3 @@ def test_Indexed_coeff():
     a = (1/y[i+1]*y[i]).coeff(y[i])
     b = (y[i]/y[i+1]).coeff(y[i])
     assert a == b
-
-
-def test_Indexed_free_symbols():
-    i, j = symbols('i j', cls=Idx)
-    r = IndexedBase('r')
-    assert Indexed(r, i, j).free_symbols.difference(set([i, r, j])) == set()

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -177,6 +177,7 @@ def test_complex_indices():
     assert A.rank == 2
     assert A.indices == (i, i + j)
 
+
 def test_not_interable():
     i, j = symbols('i j', integer=True)
     A = Indexed('A', i, i + j)
@@ -191,3 +192,9 @@ def test_Indexed_coeff():
     a = (1/y[i+1]*y[i]).coeff(y[i])
     b = (y[i]/y[i+1]).coeff(y[i])
     assert a == b
+
+
+def test_Indexed_free_symbols():
+    i, j = symbols('i j', cls=Idx)
+    r = IndexedBase('r')
+    assert Indexed(r, i, j).free_symbols.difference(set([i, r, j])) == set()


### PR DESCRIPTION
This works now

```
>>> i = symbols('i', cls=Idx)
>>> r = Indexed('r', i)
>>> Sum(r, (i, 1, 3))
Sum(r[i], (i, 1, 3))
```

I have also added support for `Idx` in `sequences`

```
>>> sequence(r, (i, 1, 3))
SeqFormula(r, (i, 1, 3))
```

closes #9594 
