### PR TITLE
`invert_complex` added for trigonometric func.

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -9,8 +9,8 @@ from sympy.core.numbers import I, Number, Rational
 from sympy.core.function import (Lambda, expand, expand_complex)
 from sympy.core.relational import Eq
 from sympy.simplify.simplify import fraction, trigsimp
-from sympy.functions import (log, Abs, tan, cot, exp,
-                             arg, Piecewise, piecewise_fold)
+from sympy.functions import (log, Abs, sin, cos, sec, csc, tan, cot,
+                            exp, arg, Piecewise, piecewise_fold)
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
                                                       HyperbolicFunction)
 from sympy.sets import FiniteSet, EmptySet, imageset, Union
@@ -209,6 +209,32 @@ def _invert_complex(f, g_ys, symbol):
                                                log(Abs(g_y))), S.Integers)
                                for g_y in g_ys])
             return _invert_complex(f.args[0], exp_invs, symbol)
+
+    if isinstance(f, (sin, csc)):
+        n = Dummy('n')
+        if isinstance(g_ys, FiniteSet):
+            fi = sympify('a' + f.func.__name__)
+            sin_csc_invs = Union(*[imageset(Lambda(n, n*pi + (-1)**n*fi(g_y)),
+                                            S.Integers) for g_y in g_ys])
+            return _invert_complex(f.args[0], sin_csc_invs, symbol)
+
+    if isinstance(f, (cos, sec)):
+        n = Dummy('n')
+        if isinstance(g_ys, FiniteSet):
+            fi = sympify('a' + f.func.__name__)
+            cos_sec_invs_f1 = Union(*[imageset(Lambda(n, 2*n*pi + fi(g_y)),
+                                            S.Integers) for g_y in g_ys])
+            cos_sec_invs_f2 = Union(*[imageset(Lambda(n, 2*n*pi -fi(g_y)),
+                                            S.Integers) for g_y in g_ys])
+            cos_sec_invs = Union(cos_sec_invs_f1, cos_sec_invs_f2)
+            return _invert_complex(f.args[0], cos_sec_invs, symbol)
+
+    if isinstance(f, (tan, cot)):
+        n = Dummy('n')
+        if isinstance(g_ys, FiniteSet):
+            tan_cot_invs = Union(*[imageset(Lambda(n, n*pi + f.inverse()(g_y)),
+                                            S.Integers) for g_y in g_ys])
+            return _invert_complex(f.args[0], tan_cot_invs, symbol)
     return (f, g_ys)
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,7 +1,7 @@
 from sympy import (
     Abs, Dummy, Eq, Gt,
     LambertW, Piecewise, Poly, Rational, S, Symbol, Matrix,
-    acos, atan, atanh, cos, erf, erfinv, erfc, erfcinv,
+    acos, asin, atan, atanh, cos, erf, erfinv, erfc, erfcinv,
     exp, log, pi, sin, sinh, sqrt, symbols,
     tan, tanh, atan2, arg,
     Lambda, imageset, cot, acot, I, EmptySet, Union, E, Interval, oo)
@@ -100,6 +100,13 @@ def test_invert_complex():
         (x, imageset(Lambda(n, I*(2*pi*n + arg(y)) + log(Abs(y))), S.Integers))
 
     assert invert_complex(log(x), y, x) == (x, FiniteSet(exp(y)))
+    assert invert_complex(sin(x), y, x) == \
+        (x, imageset(Lambda(n, n*pi + (-1)**n*asin(y)), S.Integers))
+    assert invert_complex(cos(x), y, x) == \
+        (x, Union(imageset(Lambda(n, 2*n*pi + acos(y)), S.Integers), \
+                imageset(Lambda(n, 2*n*pi - acos(y)), S.Integers)))
+    assert invert_complex(tan(x), y, x) == \
+        (x, imageset(Lambda(n, n*pi + atan(y)), S.Integers))
 
     raises(ValueError, lambda: invert_real(S.One, y, x))
     raises(ValueError, lambda: invert_complex(x, x, x))
@@ -670,8 +677,17 @@ def test_solve_invalid_sol():
     assert 0 not in solveset_complex((exp(x) - 1)/x, x)
 
 
-def test_solve_complex_unsolvable():
-    raises(NotImplementedError, lambda: solveset_complex(cos(x) - S.Half, x))
+def test_solve_complex_trig():
+    from sympy.abc import n
+    assert solveset_complex(cos(x) - S.Half, x) == \
+        Union(imageset(Lambda(n, 2*n*pi - pi/3), S.Integers), \
+            imageset(Lambda(n, 2*n*pi + pi/3), S.Integers))
+    assert solveset_complex(sin(x), x) == \
+        imageset(Lambda(n, n*pi), S.Integers)
+    assert solveset_complex(sin(x) - S.Half, x) == \
+        imageset(Lambda(n, n*pi + (-1)**n*pi/6), S.Integers)
+    assert solveset_complex(tan(x) - S.One, x) == \
+        imageset(Lambda(n, n*pi + pi/4), S.Integers)
 
 
 @XFAIL


### PR DESCRIPTION
I have implemented the `invert_complex` for trigonometric basic functions.
Its enables to solve `trigonometric equations`

```
>>> x = Symbol('x')
>>> solveset(sin(x) - 1, x)
ImageSet(Lambda(_n, (-1)**_n*pi/2 + _n*pi), Integers())
>>> solveset(sin(x), x)
ImageSet(Lambda(_n, _n*pi), Integers())
```
