### PR TITLE
Improved handling of failed cases in recurr.rsolve_hyper

### DIFF
--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -51,7 +51,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 
 from sympy.core.singleton import S
-from sympy.core.numbers import Rational
+from sympy.core.numbers import Rational, I
 from sympy.core.symbol import Symbol, Wild, Dummy
 from sympy.core.relational import Equality
 from sympy.core.add import Add
@@ -605,7 +605,10 @@ def rsolve_hyper(coeffs, f, n, **hints):
             if not poly.is_zero:
                 degrees.append(polys[i].degree())
 
-        d, poly = max(degrees), S.Zero
+        if degrees:
+            d, poly = max(degrees), S.Zero
+        else:
+            return None
 
         for i in range(0, r + 1):
             coeff = polys[i].nth(d)
@@ -629,7 +632,9 @@ def rsolve_hyper(coeffs, f, n, **hints):
                 # start the product with the term y(n_root + 1).
                 n0 = 0
                 for n_root in roots(ratio.as_numer_denom()[1], n).keys():
-                    if (n0 < (n_root + 1)) == True:
+                    if n_root.has(I):
+                        return None
+                    elif (n0 < (n_root + 1)) == True:
                         n0 = n_root + 1
                 K = product(ratio, (n, n0, n - 1))
                 if K.has(factorial, FallingFactorial, RisingFactorial):

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -72,7 +72,7 @@ def test_rsolve_hyper():
     assert rsolve_hyper([1, 1, 1], 0, n).expand() == \
         C0*(-S(1)/2 - sqrt(3)*I/2)**n + C1*(-S(1)/2 + sqrt(3)*I/2)**n
 
-    assert rsolve_hyper([1, -2*n/a - 2/a, 1], 0, n) == None
+    assert rsolve_hyper([1, -2*n/a - 2/a, 1], 0, n) is None
 
 
 def recurrence_term(c, f):
@@ -183,6 +183,10 @@ def test_rsolve():
     assert (rsolve(y(n) + a*(y(n + 1) + y(n - 1))/2, y(n)) -
             (C0*((sqrt(-a**2 + 1) - 1)/a)**n +
              C1*((-sqrt(-a**2 + 1) - 1)/a)**n)).simplify() == 0
+
+    assert rsolve((k + 1)*y(k), y(k)) is None
+    assert (rsolve((k + 1)*y(k) + (k + 3)*y(k + 1) + (k + 5)*y(k + 2), y(k))
+            is None)
 
 
 def test_rsolve_raises():


### PR DESCRIPTION
Previously, following cases raised error, now they return `None`

```
In [1]: r1 = (k + 1)*g(k)

In [2]: rsolve(r1, g(k))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-9a0672b637aa> in <module>()
----> 1 rsolve(r, g(k))

/home/leosartaj/projects/sympy/sympy/solvers/recurr.pyc in rsolve(f, y, init)
    785     coeffs = [H_part[i] for i in range(K_max + 1)]
    786 
--> 787     result = rsolve_hyper(coeffs, -i_part, n, symbols=True)
    788 
    789     if result is None:

/home/leosartaj/projects/sympy/sympy/solvers/recurr.pyc in rsolve_hyper(coeffs, f, n, **hints)
    606                 degrees.append(polys[i].degree())
    607 
--> 608         d, poly = max(degrees), S.Zero
    609 
    610         for i in range(0, r + 1):

ValueError: max() arg is an empty sequence
```

```
In [3]: r2 = (k + 1)*g(k) + (k + 3)*g(k + 1) + (k + 5)*g(k + 2)

In [4]: rsolve(r2, g(k))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-20f69c2be462> in <module>()
----> 1 rsolve(r2, g(k))

/home/leosartaj/projects/sympy/sympy/solvers/recurr.pyc in rsolve(f, y, init)
    785     coeffs = [H_part[i] for i in range(K_max + 1)]
    786 
--> 787     result = rsolve_hyper(coeffs, -i_part, n, symbols=True)
    788 
    789     if result is None:

/home/leosartaj/projects/sympy/sympy/solvers/recurr.pyc in rsolve_hyper(coeffs, f, n, **hints)
    630                 n0 = 0
    631                 for n_root in roots(ratio.as_numer_denom()[1], n).keys():
--> 632                     if (n0 < (n_root + 1)) == True:
    633                         n0 = n_root + 1
    634                 K = product(ratio, (n, n0, n - 1))

/home/leosartaj/projects/sympy/sympy/core/expr.pyc in __gt__(self, other)
    278             if (me.is_complex and me.is_real is False) or \
    279                     me.has(S.ComplexInfinity):
--> 280                 raise TypeError("Invalid comparison of complex %s" % me)
    281             if me is S.NaN:
    282                 raise TypeError("Invalid NaN comparison")

TypeError: Invalid comparison of complex -1 - sqrt(3)*I/3

```

Now, 

```
>>> rsolve(r1, g(k))
None
>>> rsolve(r2, g(k))
None
```

Ping @flacjacket @jcrist
