### PR TITLE
Equate S.Reals with Interval(-oo, oo)

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -181,6 +181,9 @@ class Reals(with_metaclass(Singleton, Interval)):
         if other == Interval(-S.Infinity, S.Infinity):
             return True
 
+    def __hash__(self):
+        return hash(Interval(-S.Infinity, S.Infinity))
+
 
 class ImageSet(Set):
     """

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -177,6 +177,10 @@ class Reals(with_metaclass(Singleton, Interval)):
     def __new__(cls):
         return Interval.__new__(cls, -S.Infinity, S.Infinity)
 
+    def __eq__(self, other):
+        if other == Interval(-S.Infinity, S.Infinity):
+            return True
+
 
 class ImageSet(Set):
     """

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -185,6 +185,7 @@ def test_Reals():
     assert -sqrt(2) in S.Reals
     assert (2, 5) not in S.Reals
     assert sqrt(-1) not in S.Reals
+    assert S.Reals == Interval(-oo, oo)
 
 
 def test_Complex():


### PR DESCRIPTION
Fixes #9624 

``` python
In [3]: S.Reals == Interval(-oo, oo)
Out[3]: True
```
