### PR TITLE
Implementing algorithm for computing formal power series

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3127,6 +3127,11 @@ def test_sympy__series__formal__FormalPowerSeries():
     assert _test_args(fps(log(1 + x), x))
 
 
+def test_sympy__series__formal__FormalPowerSeries():
+    from sympy.series.formal import fps
+    assert _test_args(fps(log(1 + x), x))
+
+
 def test_sympy__simplify__hyperexpand__Hyper_Function():
     from sympy.simplify.hyperexpand import Hyper_Function
     assert _test_args(Hyper_Function([2], [1]))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -9,7 +9,8 @@ import re
 import warnings
 import io
 
-from sympy import Basic, S, symbols, sqrt, sin, oo, Interval, exp, Lambda, pi
+from sympy import (Basic, S, symbols, sqrt, sin, oo, Interval, exp, Lambda, pi,
+                   log)
 from sympy.core.compatibility import range
 from sympy.utilities.pytest import XFAIL, SKIP
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -3119,6 +3120,11 @@ def test_sympy__series__series_class__SeriesBase():
 def test_sympy__series__fourier__FourierSeries():
     from sympy.series.fourier import fourier_series
     assert _test_args(fourier_series(x, (x, -pi, pi)))
+
+
+def test_sympy__series__formal__FormalPowerSeries():
+    from sympy.series.formal import fps
+    assert _test_args(fps(log(1 + x), x))
 
 
 def test_sympy__simplify__hyperexpand__Hyper_Function():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3127,11 +3127,6 @@ def test_sympy__series__formal__FormalPowerSeries():
     assert _test_args(fps(log(1 + x), x))
 
 
-def test_sympy__series__formal__FormalPowerSeries():
-    from sympy.series.formal import fps
-    assert _test_args(fps(log(1 + x), x))
-
-
 def test_sympy__simplify__hyperexpand__Hyper_Function():
     from sympy.simplify.hyperexpand import Hyper_Function
     assert _test_args(Hyper_Function([2], [1]))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1573,6 +1573,9 @@ class LatexPrinter(Printer):
     def _print_FourierSeries(self, s):
         return self._print_Add(s.truncate()) + self._print(' + \ldots')
 
+    def _print_FormalPowerSeries(self, s):
+        return self._print_Add(s.truncate())
+
     def _print_FiniteField(self, expr):
         return r"\mathbb{F}_{%s}" % expr.mod
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1576,6 +1576,9 @@ class LatexPrinter(Printer):
     def _print_FormalPowerSeries(self, s):
         return self._print_Add(s.truncate())
 
+    def _print_FormalPowerSeries(self, s):
+        return self._print_Add(s.truncate())
+
     def _print_FiniteField(self, expr):
         return r"\mathbb{F}_{%s}" % expr.mod
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1526,6 +1526,9 @@ class PrettyPrinter(Printer):
             dots = '...'
         return self._print_Add(s.truncate()) + self._print(dots)
 
+    def _print_FormalPowerSeries(self, s):
+        return self._print_Add(s.truncate())
+
     def _print_SeqFormula(self, s):
         if self._use_unicode:
             dots = u("\N{HORIZONTAL ELLIPSIS}")

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7,7 +7,7 @@ from sympy import (
     Pow, Product, QQ, RR, Rational, Ray, RootOf, RootSum, S,
     Segment, Subs, Sum, Symbol, Tuple, Xor, ZZ, conjugate,
     groebner, oo, pi, symbols, ilex, grlex, Range, Contains,
-    SeqPer, SeqFormula, SeqAdd, SeqMul, Interval, Union, fourier_series)
+    SeqPer, SeqFormula, SeqAdd, SeqMul, Interval, Union, fourier_series, fps)
 
 from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
     Piecewise, Shi, Si, atan2, binomial, catalan, ceiling, cos,
@@ -3204,6 +3204,29 @@ u("""\
                       2⋅sin(3⋅x)    \n\
 2⋅sin(x) - sin(2⋅x) + ────────── + …\n\
                           3         \
+""")
+
+    assert pretty(f) == ascii_str
+    assert upretty(f) == ucode_str
+
+
+def test_pretty_FormalPowerSeries():
+    f = fps(log(1 + x))
+
+    ascii_str = \
+"""\
+     2    3    4    5        \n\
+    x    x    x    x     / 6\\\n\
+x - -- + -- - -- + -- + O\\x /\n\
+    2    3    4    5         \
+"""
+
+    ucode_str = \
+u("""\
+     2    3    4    5        \n\
+    x    x    x    x     ⎛ 6⎞\n\
+x - ── + ── - ── + ── + O⎝x ⎠\n\
+    2    3    4    5         \
 """)
 
     assert pretty(f) == ascii_str

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -548,6 +548,11 @@ def test_latex_FormalPowerSeries():
     assert latex(fps(log(1 + x))) == latex_str
 
 
+def test_latex_FormalPowerSeries():
+    latex_str = r'x - \frac{x^{2}}{2} + \frac{x^{3}}{3} - \frac{x^{4}}{4} + \frac{x^{5}}{5} + \mathcal{O}\left(x^{6}\right)'
+    assert latex(fps(log(1 + x))) == latex_str
+
+
 def test_latex_intervals():
     a = Symbol('a', real=True)
     assert latex(Interval(0, 0)) == r"\left\{0\right\}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -15,7 +15,7 @@ from sympy import (
     uppergamma, zeta, subfactorial, totient, elliptic_k, elliptic_f,
     elliptic_e, elliptic_pi, cos, tan, Wild, true, false, Equivalent, Not,
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
-    SeqAdd, SeqMul, fourier_series, pi)
+    SeqAdd, SeqMul, fourier_series, pi, fps)
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
@@ -541,6 +541,11 @@ def test_latex_sequences():
 def test_latex_FourierSeries():
     latex_str = r'2 \sin{\left (x \right )} - \sin{\left (2 x \right )} + \frac{2}{3} \sin{\left (3 x \right )} + \ldots'
     assert latex(fourier_series(x, (x, -pi, pi))) == latex_str
+
+
+def test_latex_FormalPowerSeries():
+    latex_str = r'x - \frac{x^{2}}{2} + \frac{x^{3}}{3} - \frac{x^{4}}{4} + \frac{x^{5}}{5} + \mathcal{O}\left(x^{6}\right)'
+    assert latex(fps(log(1 + x))) == latex_str
 
 
 def test_latex_intervals():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -548,11 +548,6 @@ def test_latex_FormalPowerSeries():
     assert latex(fps(log(1 + x))) == latex_str
 
 
-def test_latex_FormalPowerSeries():
-    latex_str = r'x - \frac{x^{2}}{2} + \frac{x^{3}}{3} - \frac{x^{4}}{4} + \frac{x^{5}}{5} + \mathcal{O}\left(x^{6}\right)'
-    assert latex(fps(log(1 + x))) == latex_str
-
-
 def test_latex_intervals():
     a = Symbol('a', real=True)
     assert latex(Interval(0, 0)) == r"\left\{0\right\}"

--- a/sympy/series/__init__.py
+++ b/sympy/series/__init__.py
@@ -8,9 +8,10 @@ from .residues import residue
 from .sequences import (EmptySequence, SeqPer, SeqFormula, sequence, SeqAdd,
                         SeqMul)
 from .fourier import fourier_series
+from .formal import fps
 
 O = Order
 
 __all__ = ['Order', 'O', 'limit', 'Limit', 'gruntz', 'series', 'residue',
            'EmptySequence', 'SeqPer', 'SeqFormula', 'sequence',
-           'SeqAdd', 'SeqMul', 'fourier_series']
+           'SeqAdd', 'SeqMul', 'fourier_series', 'fps']

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -273,6 +273,16 @@ class FormalPowerSeries(SeriesBase):
     def length(self):
         return oo
 
+    @property
+    def infinite(self):
+        """returns an infinite representation of the series"""
+        from sympy.concrete import Sum
+
+        ak, xk = self.ak, self.xk
+        k = ak.variables[0]
+
+        return self.ind + Sum(ak.formula * xk.formula, (k, ak.start, ak.stop))
+
     def truncate(self, n=6):
         """Returns truncated series
         expansion of f upto order O(x**n)
@@ -293,15 +303,6 @@ class FormalPowerSeries(SeriesBase):
             x0 = S.Infinity
 
         return Add(*terms) + Order(pt_xk, (x, x0))
-
-    def as_infinite(self):
-        """returns an infinite representation of the series"""
-        from sympy.concrete import Sum
-
-        ak, xk = self.ak, self.xk
-        k = ak.variables[0]
-
-        return self.ind + Sum(ak.formula * xk.formula, (k, ak.start, ak.stop))
 
     def _eval_term(self, pt):
         pt_xk = self.xk.coeff(pt)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1,0 +1,435 @@
+"""Formal Power Series"""
+
+from __future__ import print_function, division
+
+from sympy import oo, zoo, nan
+from sympy.core.expr import Expr
+from sympy.core.add import Add
+from sympy.core.mul import Mul
+from sympy.core.singleton import S
+from sympy.core.sympify import sympify
+from sympy.core.symbol import Wild, Dummy, symbols
+from sympy.sets.sets import Interval
+from sympy.functions.combinatorial.factorials import binomial, factorial
+from sympy.series.sequences import sequence
+from sympy.series.series_class import SeriesBase
+from sympy.series.order import Order
+
+
+def rational_algorithm(f, x, k, order=4, full=False):
+    """Rational algorithm for computing
+    formula of coefficients of Formal Power Series
+    of a function.
+
+    Applicable when f(x) or some derivative of f(x)
+    is a rational function in x.
+
+    ``rational_algorithm`` uses :func:`apart` function for partial fraction
+    decomposition. ``apart`` by default uses 'undetermined coefficients method'.
+    By setting full=True, 'Bronstein's algorithm' can be used instead.
+
+    Looks for derivative of a function upto 4'th order(by default).
+    This can be overrided using order option.
+
+    returns a Tuple of (formula, series independent terms, order) if successful
+    otherwise None.
+
+    Examples
+    ========
+
+    >>> from sympy import log, atan, I
+    >>> from sympy.series.formal import rational_algorithm as ra
+    >>> from sympy.abc import x, k
+
+    >>> ra(1 / (1 - x), x, k)
+    (1, 0, 0)
+    >>> ra(log(1 + x), x, k)
+    (-(-1)**(-k)/k, 0, 1)
+
+    >>> ra(atan(x), x, k, full=True)
+    ((-I*(-I)**(-k)/2 + I*I**(-k)/2)/k, 0, 1)
+
+    Notes
+    =====
+
+    By setting full=True, range of admissible functions increases.
+    This option should be used carefully as it can signifcantly
+    slow down the computation as ``doit`` is performed on the :class:`RootSum`
+    object returned by the ``apart`` function. Use full=False whenever
+    possible.
+
+    See Also
+    ========
+
+    sympy.polys.partfrac.apart
+
+    References
+    ==========
+
+    .. [1] Formal Power Series - Dominik Gruntz, Wolfram Koepf
+    .. [2] Power Series in Computer Algebra - Wolfram Koepf
+    """
+
+    from sympy.polys import RootSum, apart
+
+    diff = f
+    ds = [] # list of diff
+
+    for i in range(order + 1):
+        if i:
+            diff = diff.diff(x)
+
+        if diff.is_rational_function(x):
+            coeff, sep = S.Zero, S.Zero
+
+            terms = apart(diff, x, full=full)
+            if terms.has(RootSum):
+                terms = terms.doit()
+
+            for t in Add.make_args(terms):
+                num, den = t.as_numer_denom()
+                if not den.has(x):
+                    sep += t
+                else:
+                    if isinstance(den, Mul):
+                        # m*(n*x - a)**j -> (n*x - a)**j
+                        ind = den.as_independent(x)
+                        den = ind[1]
+                        num /= ind[0]
+
+                    # (n*x - a)**j -> (x - b)
+                    den, j = den.as_base_exp()
+                    a, xterm = den.as_coeff_add(x)
+
+                    # term -> m/x**n
+                    if not a:
+                        sep += t
+                        continue
+
+                    xc = xterm[0].coeff(x)
+                    a /= -xc
+                    num /= xc**j
+
+                    ak = ((-1)**j * num * binomial(j + k - 1, k)
+                          .rewrite(factorial) / a**(j + k))
+                    coeff += ak
+
+            # Hacky, better way?
+            if coeff is S.Zero:
+                return None
+            if coeff.has(x) or coeff.has(zoo) or coeff.has(oo) or coeff.has(nan):
+                return None
+
+            from sympy.integrals import integrate
+            for j in range(i):
+                coeff = (coeff / (k + j + 1))
+                sep = integrate(sep, x)
+                c = ds.pop().limit(x, 0) - sep.limit(x, 0)
+                if c.is_finite is False:
+                    return None
+                sep += c
+            return (coeff.subs(k, k - i), sep, i)
+
+        else:
+            ds.append(diff)
+
+    return None
+
+
+def compute_fps(f, x, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
+    """Computes the formula for Formal Power Series of a function
+
+    returns (sequence of coefficients, sequence of x, independent terms)
+
+    Tries to compute the formula by applying the following techniques
+    (in order)
+
+    * rational_algorithm
+    * Hypergeomitric algorithm (TODO)
+
+    Arguments
+    =========
+
+    * x0 = series expansion around ``x = x0``(Default = 0).
+
+    * dir = For ``dir=1`` (default) the series is calculated from the right and
+    for ``dir=-1`` the series from the left. For smooth functions this
+    flag will not alter the results.
+
+    * hyper = set hyper=False, for not using hypergeometric algorithm.
+
+    * order = Order of the derivative of f, till which algorithms
+    are run.
+
+    * rational = set rational=False to skip rational algorithm
+
+    * full = full by default is False. Try setting full to True
+    to increase the range of rational algorithm. See :func:`rational_algorithm`
+    for details.
+
+    See Also
+    ========
+
+    sympy.series.rational_algorithm
+    """
+    if x0 in [S.Infinity, -S.Infinity]:
+        dir = {S.Infinity: S.One, S.NegativeInfinity: -S.One}[x0]
+        temp = f.subs(x, 1/x)
+        result = compute_fps(temp, x, 0, dir, hyper, order, rational, full)
+        if result is None:
+            return None
+        return result[0], result[1].subs(x, 1/x), result[2].subs(x, 1/x)
+    elif x0 or dir == -S.One:
+        if dir == -S.One:
+            rep = -x + x0
+            rep2 = -x
+            rep2b = x0
+        else:
+            rep = x + x0
+            rep2 = x
+            rep2b = -x0
+        temp = f.subs(x, rep)
+        result = compute_fps(temp, x, 0, S.One, hyper, order, rational, full)
+        if result is None:
+            return None
+        return (result[0], result[1].subs(x, rep2 + rep2b),
+                result[2].subs(x, rep2 + rep2b))
+
+    result = None
+
+    # from here on it's x0=0 and dir=1 handling
+    if rational:
+        k = Dummy('k')
+        result = rational_algorithm(f, x, k, order, full)
+
+    if result is None and hyper:
+        return None # TODO
+
+    if result is None:
+        return None
+
+    ak = sequence(result[0], (k, result[2], oo))
+    xk = sequence(x**k, (k, 0, oo))
+    ind = result[1]
+
+    return ak, xk, ind
+
+
+class FormalPowerSeries(SeriesBase):
+    """Represents Formal Power Series
+
+    see :func:`fps` for details
+
+    See Also
+    ========
+
+    sympy.series.formal.fps
+    sympy.series.formal.compute_fps
+    """
+    def __new__(cls, f, *args):
+        f= sympify(f)
+
+        if args[0] is None:
+            free = f.free_symbols
+            if len(free) == 1:
+                x = free.pop()
+            elif not free:
+                return f
+            else:
+                raise NotImplementedError("multivariate formal power series")
+        else:
+            x = sympify(args[0])
+
+        if not f.has(x):
+            return f
+
+        x0 = sympify(args[1])
+        dir = sympify(args[2])
+        hyper = sympify(args[3])
+        order = sympify(args[4])
+        rational = sympify(args[5])
+        full = sympify(args[6])
+
+        if dir not in [S.One, -S.One]:
+            raise ValueError("Dir must be 1 or -1")
+
+        if len(args) != 10:
+            result = compute_fps(f, x, x0, dir, hyper, order, rational, full)
+
+            if result is None:
+                return f
+
+            ak, xk, ind = result
+        else:
+            ak, xk, ind = args[7:]
+
+        return Expr.__new__(cls, f, x, x0, dir, hyper, order, rational, full,
+                            ak, xk, ind)
+
+    @property
+    def function(self):
+        return self.args[0]
+
+    @property
+    def x(self):
+        return self.args[1]
+
+    @property
+    def x0(self):
+        return self.args[2]
+
+    @property
+    def ak(self):
+        return self.args[8]
+
+    @property
+    def xk(self):
+        return self.args[9]
+
+    @property
+    def ind(self):
+        return self.args[10]
+
+    @property
+    def interval(self):
+        return Interval(0, oo)
+
+    @property
+    def start(self):
+        return self.interval.inf
+
+    @property
+    def stop(self):
+        return self.interval.sup
+
+    @property
+    def length(self):
+        return oo
+
+    def truncate(self, n=6):
+        """Returns truncated series
+        expansion of f upto order O(x**n)
+        """
+        if n is None:
+            return iter(self)
+
+        terms = []
+        for i, t in enumerate(self):
+            if i >= n:
+                break
+            if t is not S.Zero:
+                terms.append(t)
+
+        x, x0 = self.x, self.x0
+        pt_xk = self.xk.coeff(i)
+        if x0 is S.NegativeInfinity:
+            x0 = S.Infinity
+
+        return Add(*terms) + Order(pt_xk, (x, x0))
+
+    def as_infinite(self):
+        """returns an infinite representation of the series"""
+        from sympy.concrete import Sum
+
+        ak, xk = self.ak, self.xk
+        k = ak.variables[0]
+
+        return self.ind + Sum(ak.formula * xk.formula, (k, ak.start, ak.stop))
+
+    def _eval_term(self, pt):
+        pt_xk = self.xk.coeff(pt)
+
+        def _get_xterm(t):
+            if self.x0 in [S.Infinity, -S.Infinity]:
+                t = t.as_numer_denom()[1]
+            else:
+                t = t.as_numer_denom()[0]
+            return t.as_independent(self.x)[1]
+
+        ind = S.Zero
+        if self.ind:
+            for t in Add.make_args(self.ind):
+                xterm = _get_xterm(t)
+                if pt_xk == 1 and xterm == 1:
+                    ind += t
+                elif xterm != 1 and pt_xk != 1:
+                    j = xterm.as_base_exp()[1]
+                    if j == pt:
+                        ind += t
+
+        try:
+            pt_ak = self.ak.coeff(pt).simplify() # TODO: Thoughts?
+        except IndexError:
+            pt_ak = S.Zero
+
+        term = (pt_ak * pt_xk) + ind
+
+        return term.collect(self.x)
+
+    def _eval_subs(self, old, new):
+        x = self.x
+        if old.has(x):
+            return self
+
+    def _eval_as_leading_term(self, x):
+        for t in self:
+            if t is not S.Zero:
+                return t
+
+
+def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
+    """Generates Formal Power Series of f
+
+    returns the formal series expansion of ``f`` around ``x = x0``
+    with respect to ``x`` in the form of a ``FormalPowerSeries`` object
+
+    Formal Power Series is represented using an explicit formula
+    computed using different algorithms.
+
+    See :func:`compute_fps` for the more details regarding the computation
+    of formula.
+
+    Arguments
+    =========
+
+    * x = if ``x=None`` and ``f`` is univariate, the univariate
+    symbols will be supplied, otherwise an error will be raised.
+
+    * x0 = series expansion around ``x = x0``(Default = 0).
+
+    * dir = For ``dir=1`` (default) the series is calculated from the right and
+    for ``dir=-1`` the series from the left. For smooth functions this
+    flag will not alter the results.
+
+    * hyper = set hyper=False, for not using hypergeometric algorithm.
+
+    * order = Order of the derivative of f, till which algorithms
+    are run.
+
+    * rational = set rational=False to skip rational algorithm
+
+    * full = full by default is False. Try setting full to True
+    to increase the range of rational algorithm. See :func:`rational_algorithm`
+    for details.
+
+    Examples
+    ========
+
+    >>> from sympy import fps, O, ln, atan
+    >>> from sympy.abc import x
+
+    Rational Functions
+
+    >>> fps(ln(1 + x)).truncate()
+    x - x**2/2 + x**3/3 - x**4/4 + x**5/5 + O(x**6)
+
+    >>> fps(atan(x), full=True).truncate()
+    x - x**3/3 + x**5/5 + O(x**6)
+
+    See Also
+    ========
+
+    sympy.series.formal.FormalPowerSeries
+    sympy.series.formal.compute_fps
+    """
+    return FormalPowerSeries(f, x, x0, dir, hyper, order, rational, full)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -193,19 +193,6 @@ def simpleDE(f, x, g, order=4):
     By increasing order, higher order DE's can be found.
 
     Yields a tuple of (DE, order).
-
-    Examples
-    ========
-
-    >>> from sympy import Function, exp, ln
-    >>> from sympy.series.formal import simpleDE
-    >>> from sympy.abc import x
-    >>> f = Function('f')
-
-    >>> simpleDE(exp(x), x, f)
-    -f(x) + Derivative(f(x), x)
-    >>> simpleDE(ln(1 + x), x, f)
-    (x + 1)*Derivative(f(x), x, x) + Derivative(f(x), x)
     """
     from sympy.solvers import solve
     a = symbols('a:%d' % (order))
@@ -644,10 +631,10 @@ def solve_de(f, x, DE, order, g, k):
     >>> from sympy.series.formal import solve_de
     >>> from sympy.abc import x, k, f
 
-    >>> solve_de(exp(x), x, D(f(x), x) - f(x), f, k)
+    >>> solve_de(exp(x), x, D(f(x), x) - f(x), 1, f, k)
     (Piecewise((1/(factorial(k)), Eq(Mod(k, 1), 0)), (0, True)), 1, 1)
 
-    >>> solve_de(ln(1 + x), x, (x + 1)*D(f(x), x, 2) + D(f(x)), f, k)
+    >>> solve_de(ln(1 + x), x, (x + 1)*D(f(x), x, 2) + D(f(x)), 2, f, k)
     (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
      Eq(Mod(k, 1), 0)), (0, True)), x, 2)
 
@@ -766,7 +753,7 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full, extract=True):
 
     #  extract x**n from f(x)
     mul = S.One
-    if extract:
+    if extract and f.free_symbols.difference(set([x])):
         m = Wild('m')
         n = Wild('n', exclude=[m])
         f = f.factor().powsimp()
@@ -775,7 +762,10 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full, extract=True):
             for t in Add.make_args(s[n]):
                 if t.has(Symbol):
                     mul *= (x)**t
-        f = (f / mul).expand()
+        if mul is not S.One:
+            f = (f / mul)
+
+    f = f.expand()
 
     #  Break instances of Add
     #  this allows application of different

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -218,7 +218,11 @@ def compute_fps(f, x, x0=0, dir=1, hyper=True, order=4, rational=True, full=Fals
 class FormalPowerSeries(SeriesBase):
     """Represents Formal Power Series
 
-    see :func:`fps` for details
+    No computation is performed.
+    This class should only to be used to represent
+    a series. No checks are performed.
+
+    For computing a series use :func:`fps`.
 
     See Also
     ========
@@ -226,45 +230,8 @@ class FormalPowerSeries(SeriesBase):
     sympy.series.formal.fps
     sympy.series.formal.compute_fps
     """
-    def __new__(cls, f, *args):
-        f= sympify(f)
-
-        if args[0] is None:
-            free = f.free_symbols
-            if len(free) == 1:
-                x = free.pop()
-            elif not free:
-                return f
-            else:
-                raise NotImplementedError("multivariate formal power series")
-        else:
-            x = sympify(args[0])
-
-        if not f.has(x):
-            return f
-
-        x0 = sympify(args[1])
-        dir = sympify(args[2])
-        hyper = sympify(args[3])
-        order = sympify(args[4])
-        rational = sympify(args[5])
-        full = sympify(args[6])
-
-        if dir not in [S.One, -S.One]:
-            raise ValueError("Dir must be 1 or -1")
-
-        if len(args) != 10:
-            result = compute_fps(f, x, x0, dir, hyper, order, rational, full)
-
-            if result is None:
-                return f
-
-            ak, xk, ind = result
-        else:
-            ak, xk, ind = args[7:]
-
-        return Expr.__new__(cls, f, x, x0, dir, hyper, order, rational, full,
-                            ak, xk, ind)
+    def __new__(cls, *args):
+        return Expr.__new__(cls, *args)
 
     @property
     def function(self):
@@ -280,15 +247,15 @@ class FormalPowerSeries(SeriesBase):
 
     @property
     def ak(self):
-        return self.args[8]
+        return self.args[4]
 
     @property
     def xk(self):
-        return self.args[9]
+        return self.args[5]
 
     @property
     def ind(self):
-        return self.args[10]
+        return self.args[6]
 
     @property
     def interval(self):
@@ -432,4 +399,31 @@ def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
     sympy.series.formal.FormalPowerSeries
     sympy.series.formal.compute_fps
     """
-    return FormalPowerSeries(f, x, x0, dir, hyper, order, rational, full)
+    f= sympify(f)
+
+    if x is None:
+        free = f.free_symbols
+        if len(free) == 1:
+            x = free.pop()
+        elif not free:
+            return f
+        else:
+            raise NotImplementedError("multivariate formal power series")
+    else:
+        x = sympify(x)
+
+    if not f.has(x):
+        return f
+
+    x0 = sympify(x0)
+    dir = sympify(dir)
+
+    if dir not in [S.One, -S.One]:
+        raise ValueError("Dir must be 1 or -1")
+
+    result = compute_fps(f, x, x0, dir, hyper, order, rational, full)
+
+    if result is None:
+        return f
+
+    return FormalPowerSeries(f, x, x0, dir, *result)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -428,8 +428,16 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
         sol.append((res, Eq(k % c, j % m)))
 
     sol.append((S.Zero, True))
+    sol = Piecewise(*sol)
+    s = k_max + 1 + shift + m
 
-    return (Piecewise(*sol), ind, k_max + m + 1 + shift)
+    #  save all the terms of
+    #  form 1/x**k in ind
+    if s < 0:
+        ind += sum(sequence(sol * x**k, (k, s, -1)))
+        s = S.Zero
+
+    return (sol, ind, s)
 
 
 def solve_de(f, x, DE, g, k):

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -645,14 +645,6 @@ def solve_de(f, x, DE, order, g, k):
     >>> solve_de(ln(1 + x), x, (x + 1)*D(f(x), x, 2) + D(f(x)), 2, f, k)
     (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
      Eq(Mod(k, 1), 0)), (0, True)), x, 2)
-
-    See Also
-    ========
-
-    sympy.series.formal.hyper_re
-    sympy.series.formal.exp_re
-    sympy.series.formal.rsolve_hypergeometric
-    sympy.solvers.recurr.rsolve
     """
     sol = None
     syms = DE.free_symbols.difference(set([g, x]))
@@ -703,7 +695,6 @@ def hyper_algorithm(f, x, k, order=4):
     ========
 
     sympy.series.formal.simpleDE
-    sympy.series.formal.hyper_re
     sympy.series.formal.solve_de
     """
     g = Function('g')
@@ -841,30 +832,40 @@ def compute_fps(f, x, x0=0, dir=1, hyper=True, order=4, rational=True,
     Parameters
     ==========
 
-    * x : if ``x=None`` and ``f`` is univariate, the univariate
-    symbols will be supplied, otherwise an error will be raised.
+    * x : Symbol, optional
+        If x is None and ``f`` is univariate, the univariate symbols will be
+        supplied, otherwise an error will be raised.
 
-    * x0 : series expansion around ``x = x0``(Default = 0).
+    * x0 : numbers, optional
+        Point to perform series expansion about. Default is 0.
 
-    * dir : For ``dir=1`` (default) the series is calculated from the right and
-    for ``dir=-1`` the series from the left. For smooth functions this
-    flag will not alter the results.
+    * dir : {1, -1, '+', '-'}, optional
+        If dir is 1 or '+' the series is calculated from the right and
+        for -1 or '-' the series is calculated from the left. For smooth
+        functions this flag will not alter the results. Default is 1.
 
-    * hyper : set ``hyper=False``, for not using hypergeometric algorithm.
+    * hyper : {True, False}, optional
+        Set hyper to False to skip the hypergeometric algorithm.
+        By default it is set to False.
 
-    * order : Order of the derivative of ``f``, till which algorithms
-    are run.
+    * order : int, optional
+        Order of the derivative of ``f``, till which algorithms are run.
+        Default is 4.
 
-    * rational : set ``rational=False`` to skip rational algorithm.
+    * rational : {True, False}, optional
+        Set rational to False to skip rational algorithm. By default it is set
+        to True.
 
-    * full : ``full`` by default is ``False``. Try setting ``full`` to ``True``
-    to increase the range of rational algorithm. See :func:`rational_algorithm`
-    for details.
+    * full : {True, False}, optional
+        Set full to True to increase the range of rational algorithm.
+        See :func:`rational_algorithm` for details. By default it is set to
+        False.
 
     See Also
     ========
 
     sympy.series.rational_algorithm
+    sympy.series.hyper_algorithm
     """
     f = sympify(f)
     x = sympify(x)
@@ -898,7 +899,6 @@ class FormalPowerSeries(SeriesBase):
     ========
 
     sympy.series.formal.fps
-    sympy.series.formal.compute_fps
     """
     def __new__(cls, *args):
         args = map(sympify, args)
@@ -1051,25 +1051,34 @@ def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
     Parameters
     ==========
 
-    * x : if ``x=None`` and ``f`` is univariate, the univariate
-    symbols will be supplied, otherwise an error will be raised.
+    * x : Symbol, optional
+        If x is None and ``f`` is univariate, the univariate symbols will be
+        supplied, otherwise an error will be raised.
 
-    * x0 : series expansion around ``x = x0``(Default = 0).
+    * x0 : numbers, optional
+        Point to perform series expansion about. Default is 0.
 
-    * dir : For ``dir=1`` (default) the series is calculated from the right and
-    for ``dir=-1`` the series from the left. For smooth functions this
-    flag will not alter the results.
+    * dir : {1, -1, '+', '-'}, optional
+        If dir is 1 or '+' the series is calculated from the right and
+        for -1 or '-' the series is calculated from the left. For smooth
+        functions this flag will not alter the results. Default is 1.
 
-    * hyper : set ``hyper=False``, for not using hypergeometric algorithm.
+    * hyper : {True, False}, optional
+        Set hyper to False to skip the hypergeometric algorithm.
+        By default it is set to False.
 
-    * order : Order of the derivative of ``f``, till which algorithms
-    are run.
+    * order : int, optional
+        Order of the derivative of ``f``, till which algorithms are run.
+        Default is 4.
 
-    * rational : set ``rational=False`` to skip rational algorithm.
+    * rational : {True, False}, optional
+        Set rational to False to skip rational algorithm. By default it is set
+        to True.
 
-    * full : ``full`` by default is ``False``. Try setting ``full`` to ``True``
-    to increase the range of rational algorithm. See :func:`rational_algorithm`
-    for details.
+    * full : {True, False}, optional
+        Set full to True to increase the range of rational algorithm.
+        See :func:`rational_algorithm` for details. By default it is set to
+        False.
 
     Examples
     ========

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -38,8 +38,8 @@ def rational_algorithm(f, x, k, order=4, full=False):
     method'. By setting ``full=True``, 'Bronstein's algorithm' can be used
     instead.
 
-    Looks for derivative of a function upto 4'th order(by default).
-    This can be overrided using order option.
+    Looks for derivative of a function up to 4'th order (by default).
+    This can be overriden using order option.
 
     Returns a Tuple of (formula, series independent terms, order) if successful
     otherwise ``None``.
@@ -832,31 +832,22 @@ def compute_fps(f, x, x0=0, dir=1, hyper=True, order=4, rational=True,
     Parameters
     ==========
 
-    * x : Symbol, optional
-        If x is None and ``f`` is univariate, the univariate symbols will be
-        supplied, otherwise an error will be raised.
-
-    * x0 : numbers, optional
+    x : Symbol
+    x0 : number, optional
         Point to perform series expansion about. Default is 0.
-
-    * dir : {1, -1, '+', '-'}, optional
+    dir : {1, -1, '+', '-'}, optional
         If dir is 1 or '+' the series is calculated from the right and
         for -1 or '-' the series is calculated from the left. For smooth
         functions this flag will not alter the results. Default is 1.
-
-    * hyper : {True, False}, optional
+    hyper : {True, False}, optional
         Set hyper to False to skip the hypergeometric algorithm.
         By default it is set to False.
-
-    * order : int, optional
-        Order of the derivative of ``f``, till which algorithms are run.
-        Default is 4.
-
-    * rational : {True, False}, optional
+    order : int, optional
+        Order of the derivative of ``f``, Default is 4.
+    rational : {True, False}, optional
         Set rational to False to skip rational algorithm. By default it is set
         to True.
-
-    * full : {True, False}, optional
+    full : {True, False}, optional
         Set full to True to increase the range of rational algorithm.
         See :func:`rational_algorithm` for details. By default it is set to
         False.
@@ -1051,31 +1042,24 @@ def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
     Parameters
     ==========
 
-    * x : Symbol, optional
+    x : Symbol, optional
         If x is None and ``f`` is univariate, the univariate symbols will be
         supplied, otherwise an error will be raised.
-
-    * x0 : numbers, optional
+    x0 : number, optional
         Point to perform series expansion about. Default is 0.
-
-    * dir : {1, -1, '+', '-'}, optional
+    dir : {1, -1, '+', '-'}, optional
         If dir is 1 or '+' the series is calculated from the right and
         for -1 or '-' the series is calculated from the left. For smooth
         functions this flag will not alter the results. Default is 1.
-
-    * hyper : {True, False}, optional
+    hyper : {True, False}, optional
         Set hyper to False to skip the hypergeometric algorithm.
         By default it is set to False.
-
-    * order : int, optional
-        Order of the derivative of ``f``, till which algorithms are run.
-        Default is 4.
-
-    * rational : {True, False}, optional
+    order : int, optional
+        Order of the derivative of ``f``, Default is 4.
+    rational : {True, False}, optional
         Set rational to False to skip rational algorithm. By default it is set
         to True.
-
-    * full : {True, False}, optional
+    full : {True, False}, optional
         Set full to True to increase the range of rational algorithm.
         See :func:`rational_algorithm` for details. By default it is set to
         False.

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -390,10 +390,11 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
     qroots = roots(Q, k)
     k_max = Max(*qroots.keys())
     ind = S.Zero
-    if k_max >= 0:
+    if k_max + m >= 0:
         for i in range(k_max + m + 1):
             r = f.diff(x, i).limit(x, 0) / factorial(i)
-            ind += r*x**i
+            ind += r*x**(i + shift)
+        ind = ind.subs(x, x**(1/scale))
         s, e = k_max + 1, m + k_max + 1
     else:
         s, e = 0, m
@@ -435,8 +436,9 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
 
     sol.append((S.Zero, True))
 
-    if k_max >= 0:
-        return (Piecewise(*sol), ind, k_max + m + 1)
+
+    if k_max + m >= 0:
+        return (Piecewise(*sol), ind, k_max + m + 1 + shift)
     else:
         return (Piecewise(*sol), S.Zero, S.Zero)
 

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -584,7 +584,7 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
     if x0 in [S.Infinity, -S.Infinity]:
         dir = {S.Infinity: S.One, S.NegativeInfinity: -S.One}[x0]
         temp = f.subs(x, 1/x)
-        result = compute_fps(temp, x, 0, dir, hyper, order, rational, full)
+        result = _compute_fps(temp, x, 0, dir, hyper, order, rational, full)
         if result is None:
             return None
         return result[0], result[1].subs(x, 1/x), result[2].subs(x, 1/x)
@@ -598,7 +598,7 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
             rep2 = x
             rep2b = -x0
         temp = f.subs(x, rep)
-        result = compute_fps(temp, x, 0, S.One, hyper, order, rational, full)
+        result = _compute_fps(temp, x, 0, S.One, hyper, order, rational, full)
         if result is None:
             return None
         return (result[0], result[1].subs(x, rep2 + rep2b),
@@ -616,7 +616,7 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
         ak = sequence(S.Zero, (0, oo))
         ind, xk = S.Zero, None
         for t in Add.make_args(f):
-            res = compute_fps(t, x, 0, S.One, hyper, order, rational, full)
+            res = _compute_fps(t, x, 0, S.One, hyper, order, rational, full)
             if res:
                 if not result:
                     result = True

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -29,15 +29,16 @@ def rational_algorithm(f, x, k, order=4, full=False):
     Applicable when f(x) or some derivative of f(x)
     is a rational function in x.
 
-    ``rational_algorithm`` uses :func:`apart` function for partial fraction
-    decomposition. ``apart`` by default uses 'undetermined coefficients method'.
-    By setting full=True, 'Bronstein's algorithm' can be used instead.
+    :func:`rational_algorithm` uses :func:`apart` function for partial fraction
+    decomposition. :func`apart` by default uses 'undetermined coefficients
+    method'. By setting ``full=True``, 'Bronstein's algorithm' can be used
+    instead.
 
     Looks for derivative of a function upto 4'th order(by default).
     This can be overrided using order option.
 
-    returns a Tuple of (formula, series independent terms, order) if successful
-    otherwise None.
+    Returns a Tuple of (formula, series independent terms, order) if successful
+    otherwise ``None``.
 
     Examples
     ========
@@ -57,11 +58,11 @@ def rational_algorithm(f, x, k, order=4, full=False):
     Notes
     =====
 
-    By setting full=True, range of admissible functions increases.
-    This option should be used carefully as it can signifcantly
-    slow down the computation as ``doit`` is performed on the :class:`RootSum`
-    object returned by the ``apart`` function. Use full=False whenever
-    possible.
+    By setting full=True, range of admissible functions to be solved using
+    rational_algorithm can be increased. This option should be used carefully
+    as it can signifcantly slow down the computation as ``doit`` is performed
+    on the :class:`RootSum` object returned by the ``apart`` function.
+    Use full=False whenever possible.
 
     See Also
     ========
@@ -143,7 +144,7 @@ def rational_algorithm(f, x, k, order=4, full=False):
 
 
 def rational_independent(terms, x):
-    """returns a list of all the rationally independent terms
+    """Returns a list of all the rationally independent terms.
 
     Examples
     ========
@@ -178,8 +179,9 @@ def rational_independent(terms, x):
 
 
 def simpleDE(f, x, g, order=4):
-    """
-    Computes a simple DE of the form
+    """Computes a simple DE.
+
+    DE is of the form
 
     .. math::
         f^k(x) + \sum\limits\_{j=0}^{k-1} A_j f^j(x) = 0
@@ -221,21 +223,17 @@ def simpleDE(f, x, g, order=4):
         if len(ind) == k:
             sol = solve(ind, a, dict=True)
             if sol:
-                for k, v in sol[0].items():
-                    DE = DE.subs(k, v)
+                DE = DE.subs(sol[0])
                 DE = DE.as_numer_denom()[0]
                 DE = DE.factor().as_coeff_mul(Derivative)[1][0]
                 return DE.collect(Derivative(g(x)))
 
 
 def exp_re(DE, r, k):
-    """
-    Converts a DE with constant coefficients (explike)
-    into a RE
+    """Converts a DE with constant coefficients (explike) into a RE.
 
-    substitutes :math:`f^j(x) \to r(k + j)`
-
-    Normalises so that lowest term is always r(k).
+    Substitutes :math:`f^j(x) \to r(k + j)`. Normalises the terms
+    so that lowest order of a term is always r(k).
 
     Examples
     ========
@@ -263,7 +261,7 @@ def exp_re(DE, r, k):
     for t in Add.make_args(DE):
         coeff, d = t.as_independent(g)
         if isinstance(d, Derivative):
-            j = len(d.args[1:])
+            j = len(d.args) - 1
         else:
             j = 0
         if mini is None or j < mini:
@@ -275,12 +273,10 @@ def exp_re(DE, r, k):
 
 
 def hyper_re(DE, r, k):
-    """
-    Converts a DE into a RE
+    """Converts a DE into a RE.
 
-    substitutes :math:`x^l f^j(x) \to (k + 1 - l)_j . a_{k + j - l}`
-
-    Normalises so that lowest term is always r(k).
+    Substitutes :math:`x^l f^j(x) \to (k + 1 - l)_j . a_{k + j - l}`.
+    Normalises the terms so that lowest order of a term is always r(k).
 
     Examples
     ========
@@ -325,23 +321,24 @@ def hyper_re(DE, r, k):
 
 
 def rsolve_hypergeometric(f, x, P, Q, k, m):
-    """
+    """Solves RE of hypergeometric type.
+
     Attempts to solve RE of the form
 
     Q(k)*a(k + m) - P(k)*a(k)
 
     Transformations that preserve Hypergeometric type:
+
         a. x**n*f(x): b(k + m) = R(k - n)*b(k)
         b. f(A*x): b(k + m) = A**m*R(k)*b(k)
         c. f(x**n): b(k + n*m) = R(k/n)*b(k)
         d. f(x**(1/m)): b(k + 1) = R(k*m)*b(k)
         e. f'(x): b(k + m) = ((k + m + 1)/(k + 1))*R(k + 1)*b(k)
 
-    Some of these transformations have been used to solve
-    the RE
+    Some of these transformations have been used to solve the RE.
 
-    returns a Tuple of (formula, series independent terms, order) if successful
-    otherwise None.
+    Returns a Tuple of (formula, series independent terms, order) if successful
+    otherwise ``None``.
 
     Examples
     ========
@@ -456,20 +453,20 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
 
 
 def solve_de(f, x, DE, g, k):
-    """Solves the DE
+    """Solves the DE.
 
-    First converts the DE into a RE using :func:`hyper_re`
+    First converts the DE into a RE using :func:`hyper_re`.
 
-    If The RE is of the form Q(k)*a(k + m) - P(k)*a(k),
-    uses :func:`rsolve_hypergeometric` to solve
+    If the RE is of the form Q(k)*a(k + m) - P(k)*a(k),
+    uses :func:`rsolve_hypergeometric` to solve.
 
     Checks if DE is explike, if yes again forms RE
     using :func:`exp_re`.
 
-    Tries to solve RE using :func:`rsolve`
+    Tries to solve RE using :func:`rsolve`.
 
-    returns a Tuple of (formula, series independent terms, order) if successful
-    otherwise None.
+    Returns a Tuple of (formula, series independent terms, order) if successful
+    otherwise ``None``.
 
     Examples
     ========
@@ -535,12 +532,12 @@ def solve_de(f, x, DE, g, k):
 
 
 def hyper_algorithm(f, x, k, order=4):
-    """Hypergeometric algorithm
+    """Hypergeometric algorithm for computing Formal Power Series.
 
     Steps:
         * Compute a simpleDE
         * Convert the DE into RE
-        * Solves The RE
+        * Solves the RE
 
     Examples
     ========
@@ -579,46 +576,12 @@ def hyper_algorithm(f, x, k, order=4):
     return sol
 
 
-def compute_fps(f, x, x0=0, dir=1, hyper=True, order=4, rational=True,
-                full=False):
-    """Computes the formula for Formal Power Series of a function
+def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
+    """Recursive wrapper to compute fps.
 
-    returns (sequence of coefficients, sequence of x, independent terms)
-
-    Tries to compute the formula by applying the following techniques
-    (in order)
-
-    * rational_algorithm
-    * Hypergeomitric algorithm (TODO)
-
-    Arguments
-    =========
-
-    * x0 = series expansion around ``x = x0``(Default = 0).
-
-    * dir = For ``dir=1`` (default) the series is calculated from the right and
-    for ``dir=-1`` the series from the left. For smooth functions this
-    flag will not alter the results.
-
-    * hyper = set hyper=False, for not using hypergeometric algorithm.
-
-    * order = Order of the derivative of f, till which algorithms
-    are run.
-
-    * rational = set rational=False to skip rational algorithm
-
-    * full = full by default is False. Try setting full to True
-    to increase the range of rational algorithm. See :func:`rational_algorithm`
-    for details.
-
-    See Also
-    ========
-
-    sympy.series.rational_algorithm
+    See :func:`compute_fps` for details.
     """
-    if not f.has(x):
-        return None
-    elif x0 in [S.Infinity, -S.Infinity]:
+    if x0 in [S.Infinity, -S.Infinity]:
         dir = {S.Infinity: S.One, S.NegativeInfinity: -S.One}[x0]
         temp = f.subs(x, 1/x)
         result = compute_fps(temp, x, 0, dir, hyper, order, rational, full)
@@ -693,11 +656,70 @@ def compute_fps(f, x, x0=0, dir=1, hyper=True, order=4, rational=True,
     return ak, xk, ind
 
 
-class FormalPowerSeries(SeriesBase):
-    """Represents Formal Power Series
+def compute_fps(f, x, x0=0, dir=1, hyper=True, order=4, rational=True,
+                full=False):
+    """Computes the formula for Formal Power Series of a function.
 
-    No computation is performed.
-    This class should only to be used to represent
+    Returns (sequence of coefficients, sequence of x, independent terms).
+
+    Tries to compute the formula by applying the following techniques
+    (in order)
+
+    * rational_algorithm
+    * Hypergeomitric algorithm
+
+    Parameters
+    ==========
+
+    * x : if ``x=None`` and ``f`` is univariate, the univariate
+    symbols will be supplied, otherwise an error will be raised.
+
+    * x0 : series expansion around ``x = x0``(Default = 0).
+
+    * dir : For ``dir=1`` (default) the series is calculated from the right and
+    for ``dir=-1`` the series from the left. For smooth functions this
+    flag will not alter the results.
+
+    * hyper : set hyper=False, for not using hypergeometric algorithm.
+
+    * order : Order of the derivative of f, till which algorithms
+    are run.
+
+    * rational : set rational=False to skip rational algorithm
+
+    * full : full by default is False. Try setting full to True
+    to increase the range of rational algorithm. See :func:`rational_algorithm`
+    for details.
+
+    See Also
+    ========
+
+    sympy.series.rational_algorithm
+    """
+    f = sympify(f)
+    x = sympify(x)
+
+    if not f.has(x):
+        return None
+
+    x0 = sympify(x0)
+
+    if dir == '+':
+        dir = S.One
+    elif dir == '-':
+        dir = -S.One
+    elif dir not in [S.One, -S.One]:
+        raise ValueError("Dir must be '+' or '-'")
+    else:
+        dir = sympify(dir)
+
+    return _compute_fps(f, x, x0, dir, hyper, order, rational, full)
+
+
+class FormalPowerSeries(SeriesBase):
+    """Represents Formal Power Series of a function.
+
+    No computation is performed. This class should only to be used to represent
     a series. No checks are performed.
 
     For computing a series use :func:`fps`.
@@ -754,7 +776,7 @@ class FormalPowerSeries(SeriesBase):
 
     @property
     def infinite(self):
-        """returns an infinite representation of the series"""
+        """Returns an infinite representation of the series"""
         from sympy.concrete import Sum
 
         ak, xk = self.ak, self.xk
@@ -763,10 +785,10 @@ class FormalPowerSeries(SeriesBase):
         return self.ind + Sum(ak.formula * xk.formula, (k, ak.start, ak.stop))
 
     def polynomial(self, n=6):
-        """truncated series as polynomial.
+        """Truncated series as polynomial.
 
-        returns series sexpansion of f upto order ``O(x**n)``
-        as a polynomial (without ``O`` term)
+        Returns series sexpansion of ``f`` upto order ``O(x**n)``
+        as a polynomial(without ``O`` term).
         """
         terms = []
         for i, t in enumerate(self):
@@ -778,12 +800,12 @@ class FormalPowerSeries(SeriesBase):
         return Add(*terms)
 
     def truncate(self, n=6):
-        """truncated series.
+        """Truncated series.
 
-        returns truncated series expansion of f upto
-        order ``O(x**n)``
+        Returns truncated series expansion of f upto
+        order ``O(x**n)``.
 
-        if n is ``None``, returns an infinite iterator
+        If n is ``None``, returns an infinite iterator.
         """
         if n is None:
             return iter(self)
@@ -837,10 +859,10 @@ class FormalPowerSeries(SeriesBase):
 
 
 def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
-    """Generates Formal Power Series of f
+    """Generates Formal Power Series of f.
 
-    returns the formal series expansion of ``f`` around ``x = x0``
-    with respect to ``x`` in the form of a ``FormalPowerSeries`` object
+    Returns the formal series expansion of ``f`` around ``x = x0``
+    with respect to ``x`` in the form of a ``FormalPowerSeries`` object.
 
     Formal Power Series is represented using an explicit formula
     computed using different algorithms.
@@ -848,26 +870,26 @@ def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
     See :func:`compute_fps` for the more details regarding the computation
     of formula.
 
-    Arguments
-    =========
+    Parameters
+    ==========
 
-    * x = if ``x=None`` and ``f`` is univariate, the univariate
+    * x : if ``x=None`` and ``f`` is univariate, the univariate
     symbols will be supplied, otherwise an error will be raised.
 
-    * x0 = series expansion around ``x = x0``(Default = 0).
+    * x0 : series expansion around ``x = x0``(Default = 0).
 
-    * dir = For ``dir=1`` (default) the series is calculated from the right and
+    * dir : For ``dir=1`` (default) the series is calculated from the right and
     for ``dir=-1`` the series from the left. For smooth functions this
     flag will not alter the results.
 
-    * hyper = set hyper=False, for not using hypergeometric algorithm.
+    * hyper : set hyper=False, for not using hypergeometric algorithm.
 
-    * order = Order of the derivative of f, till which algorithms
+    * order : Order of the derivative of f, till which algorithms
     are run.
 
-    * rational = set rational=False to skip rational algorithm
+    * rational : set rational=False to skip rational algorithm
 
-    * full = full by default is False. Try setting full to True
+    * full : full by default is False. Try setting full to True
     to increase the range of rational algorithm. See :func:`rational_algorithm`
     for details.
 
@@ -901,19 +923,6 @@ def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
             return f
         else:
             raise NotImplementedError("multivariate formal power series")
-    else:
-        x = sympify(x)
-
-    x0 = sympify(x0)
-
-    if dir == '+':
-        dir = S.One
-    elif dir == '-':
-        dir = -S.One
-    elif dir not in [S.One, -S.One]:
-        raise ValueError("Dir must be '+' or '-'")
-    else:
-        dir = sympify(dir)
 
     result = compute_fps(f, x, x0, dir, hyper, order, rational, full)
 

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -284,13 +284,12 @@ class FormalPowerSeries(SeriesBase):
 
         return self.ind + Sum(ak.formula * xk.formula, (k, ak.start, ak.stop))
 
-    def truncate(self, n=6):
-        """Returns truncated series
-        expansion of f upto order O(x**n)
-        """
-        if n is None:
-            return iter(self)
+    def polynomial(self, n=6):
+        """truncated series as polynomial.
 
+        returns series sexpansion of f upto order ``O(x**n)``
+        as a polynomial (without ``O`` term)
+        """
         terms = []
         for i, t in enumerate(self):
             if i >= n:
@@ -298,12 +297,25 @@ class FormalPowerSeries(SeriesBase):
             if t is not S.Zero:
                 terms.append(t)
 
+        return Add(*terms)
+
+    def truncate(self, n=6):
+        """truncated series.
+
+        returns truncated series expansion of f upto
+        order ``O(x**n)``
+
+        if n is ``None``, returns an infinite iterator
+        """
+        if n is None:
+            return iter(self)
+
         x, x0 = self.x, self.x0
-        pt_xk = self.xk.coeff(i)
+        pt_xk = self.xk.coeff(n)
         if x0 is S.NegativeInfinity:
             x0 = S.Infinity
 
-        return Add(*terms) + Order(pt_xk, (x, x0))
+        return self.polynomial(n) + Order(pt_xk, (x, x0))
 
     def _eval_term(self, pt):
         pt_xk = self.xk.coeff(pt)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -231,6 +231,7 @@ class FormalPowerSeries(SeriesBase):
     sympy.series.formal.compute_fps
     """
     def __new__(cls, *args):
+        args = map(sympify, args)
         return Expr.__new__(cls, *args)
 
     @property
@@ -247,15 +248,15 @@ class FormalPowerSeries(SeriesBase):
 
     @property
     def ak(self):
-        return self.args[4]
+        return self.args[4][0]
 
     @property
     def xk(self):
-        return self.args[5]
+        return self.args[4][1]
 
     @property
     def ind(self):
-        return self.args[6]
+        return self.args[4][2]
 
     @property
     def interval(self):
@@ -427,4 +428,6 @@ def fps(f, x=None, x0=0, dir=1, hyper=True, order=4, rational=True, full=False):
     if result is None:
         return f
 
-    return FormalPowerSeries(f, x, x0, dir, *result)
+    ak, xk, ind = result
+
+    return FormalPowerSeries(f, x, x0, dir, (ak, xk, ind))

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -378,7 +378,10 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
 
     # transformation - a
     qroots = roots(Q, k)
-    k_min = Min(*qroots.keys())
+    if qroots:
+        k_min = Min(*qroots.keys())
+    else:
+        k_min = S.Zero
     shift = k_min + m
     f *= x**(-shift)
     P = P.subs(k, k + shift)
@@ -388,7 +391,10 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
         return None
 
     qroots = roots(Q, k)
-    k_max = Max(*qroots.keys())
+    if qroots:
+        k_max = Max(*qroots.keys())
+    else:
+        k_max = S.Zero
     ind = S.Zero
     for i in range(k_max + m + 1):
         r = f.diff(x, i).limit(x, 0) / factorial(i)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -610,7 +610,11 @@ def _transform_DE_RE(DE, g, k, order, syms):
         m = Wild('m')
         RE = RE.subs(sol[0])
         RE = RE.factor().as_numer_denom()[0].collect(g(k + m))
-        RE = RE.as_coeff_mul()[1][0]
+        RE = RE.as_coeff_mul(g)[1][0]
+        for i in range(order):  # smallest order should be g(k)
+            if RE.coeff(g(k + i)) and i:
+                RE = RE.subs(k, k - i)
+                break
     return RE
 
 

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -70,7 +70,7 @@ def test_fps():
     assert f.as_leading_term(x) == x
 
     k = f.ak.variables[0]
-    assert f.as_infinite() == Sum((-(-1)**(-k)*x**k)/k, (k, 1, oo))
+    assert f.infinite == Sum((-(-1)**(-k)*x**k)/k, (k, 1, oo))
 
 
 def test_fps__rational():

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -68,6 +68,7 @@ def test_fps():
     assert f.subs(x, y) == f
     assert f[:5] == [0, x, -x**2/2, x**3/3, -x**4/4]
     assert f.as_leading_term(x) == x
+    assert f.polynomial(6) == x - x**2/2 + x**3/3 - x**4/4 + x**5/5
 
     k = f.ak.variables[0]
     assert f.infinite == Sum((-(-1)**(-k)*x**k)/k, (k, 1, oo))

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -249,10 +249,6 @@ def test_fps__hyper():
     f = x*exp(x)*sin(2*x)  # TODO: solved using rsolve, improve simpleDE
     assert fps(f, x).truncate() == 2*x**2 + 2*x**3 - x**4/3 - x**5 + O(x**6)
 
-    f = x**2*atan(x)
-    assert fps(f, x, rational=False).truncate() == \
-        x**3 - x**5/3 + O(x**6)
-
     f = airyai(x**2)
     assert fps(f, x).truncate() == \
         (3**Rational(5, 6)*gamma(Rational(1, 3))/(6*pi) -
@@ -260,6 +256,16 @@ def test_fps__hyper():
 
     f = exp(x)*sin(x)
     assert fps(f, x).truncate() == x + x**2 + x**3/3 - x**5/30 + O(x**6)
+
+
+def test_fps_shift():
+    f = x**-5*sin(x)
+    assert fps(f, x).truncate() == \
+        1/x**4 - 1/(6*x**2) + S.One/120 - x**2/5040 + x**4/362880 + O(x**6)
+
+    f = x**2*atan(x)
+    assert fps(f, x, rational=False).truncate() == \
+        x**3 - x**5/3 + O(x**6)
 
 
 def test_fps__Add_expr():
@@ -289,6 +295,3 @@ def test_xfail_fps__hyper():
 
     f = exp(x)*sin(x)/x
     assert fps(f, x).truncate() == 1 + x + x**2/3 - x**4/30 - x**5/90 + O(x**6)
-
-    f = x**-5*sin(x)
-    assert fps(f, x).truncate() == 1/x**4 - 1/(x*6) + 1/120 + O(x**6)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -293,6 +293,10 @@ def test_fps__Add_expr():
     f = 1/x + sin(x)
     assert fps(f, x).truncate() == 1/x + x - x**3/6 + x**5/120 + O(x**6)
 
+    f = sin(x) - cos(x) + 1/(x - 1)
+    assert fps(f, x).truncate() == \
+        -2 - x**2/2 - 7*x**3/6 - 25*x**4/24 - 119*x**5/120 + O(x**6)
+
 
 def test_fps__asymptotic():
     f = exp(x)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -2,7 +2,8 @@ from sympy import (symbols, factorial, sqrt, Rational, atan, I, log, fps, O,
                    Sum, oo, S, pi, cos, sin, Function, exp, Derivative, asin,
                    airyai)
 from sympy.series.formal import (rational_algorithm, FormalPowerSeries,
-                                 rational_independent, simpleDE, exp_re)
+                                 rational_independent, simpleDE, exp_re,
+                                 hyper_re)
 from sympy.utilities.pytest import raises
 
 x, y, z = symbols('x y z')
@@ -98,6 +99,26 @@ def test_exp_re():
 
     d = Derivative(f(x), x, 3) + Derivative(f(x), x, 4) + Derivative(f(x))
     assert exp_re(d, r, k) == r(k) + r(k + 2) + r(k + 3)
+
+
+def test_hyper_re():
+    d = f(x) + Derivative(f(x), x, x)
+    assert hyper_re(d, r, k) == r(k) + (k+1)*(k+2)*r(k + 2)
+
+    d = -x*f(x) + Derivative(f(x), x, x)
+    assert hyper_re(d, r, k) == (k + 2)*(k + 3)*r(k + 3) - r(k)
+
+    d = 2*f(x) - 2*Derivative(f(x), x) + Derivative(f(x), x, x)
+    assert hyper_re(d, r, k) == \
+        (-2*k - 2)*r(k + 1) + (k + 1)*(k + 2)*r(k + 2) + 2*r(k)
+
+    d = 2*n*f(x) + (x**2 - 1)*Derivative(f(x), x)
+    assert hyper_re(d, r, k) == \
+        k*r(k) + 2*n*r(k + 1) + (-k - 2)*r(k + 2)
+
+    d = (x**10 + 4)*Derivative(f(x), x) + x*(x**10 - 1)*Derivative(f(x), x, x)
+    assert hyper_re(d, r, k) == \
+        (k*(k - 1) + k)*r(k) + (4*k - (k + 9)*(k + 10) + 40)*r(k + 10)
 
 
 def test_fps():

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, factorial, sqrt, Rational, atan, I, log, fps, O,
                    Sum, oo, S, pi, cos, sin, Function, exp, Derivative, asin,
-                   airyai, acos, acosh, gamma)
+                   airyai, acos, acosh, gamma, erf)
 from sympy.series.formal import (rational_algorithm, FormalPowerSeries,
                                  rational_independent, simpleDE, exp_re,
                                  hyper_re)
@@ -202,10 +202,6 @@ def test_fps__rational():
         (atan(2) - Rational(2, 5) - 2*(-x + 2)**2/25 - 11*(-x + 2)**3/375
          - 6*(-x + 2)**4/625 - 41*(-x + 2)**5/15625 + x/5 + O((x - 2)**6,
                                                               (x, 2)))
-    assert fps(f, x, oo, full=True).truncate() == \
-        -1/(5*x**5) + 1/(3*x**3) - 1/x + pi/2 + O(1/x**6, (x, oo))
-    assert fps(f, x, -oo, full=True).truncate() == \
-        -1/(5*x**5) + 1/(3*x**3) - 1/x - pi/2 + O(1/x**6, (x, oo))
 
     f = x*atan(x) - log(1 + x**2) / 2
     assert fps(f, x, full=True).truncate() == x**2/2 - x**4/12 + O(x**6)
@@ -279,11 +275,24 @@ def test_fps__Add_expr():
     assert fps(f, x).truncate() == 1/x + x - x**3/6 + x**5/120 + O(x**6)
 
 
-@XFAIL
-def test_xfail_fps__hyper():
+def test_fps__asymptotic():
     f = exp(x)
+    assert fps(f, x, oo) == f
     assert fps(f, x, -oo).truncate() == O(1/x**6, (x, oo))
 
+    f = erf(x)
+    assert fps(f, x, oo).truncate() == 1 + O(1/x**6, (x, oo))
+    assert fps(f, x, -oo).truncate() == -1 + O(1/x**6, (x, oo))
+
+    f = atan(x)
+    assert fps(f, x, oo, full=True).truncate() == \
+        -1/(5*x**5) + 1/(3*x**3) - 1/x + pi/2 + O(1/x**6, (x, oo))
+    assert fps(f, x, -oo, full=True).truncate() == \
+        -1/(5*x**5) + 1/(3*x**3) - 1/x - pi/2 + O(1/x**6, (x, oo))
+
+
+@XFAIL
+def test_xfail_fps__hyper():
     f = sin(sqrt(x)) / x
     assert fps(f, x).truncate() == \
         (1/sqrt(x) - sqrt(x)/6 + x**Rational(3, 2)/120 - x**Rational(5, 2)/5040

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -1,6 +1,8 @@
 from sympy import (symbols, factorial, sqrt, Rational, atan, I, log, fps, O,
-                   Sum, oo, S, pi, cos)
-from sympy.series.formal import rational_algorithm, FormalPowerSeries
+                   Sum, oo, S, pi, cos, sin, Function, exp, Derivative, asin,
+                   airyai)
+from sympy.series.formal import (rational_algorithm, FormalPowerSeries,
+                                 rational_independent, simpleDE)
 from sympy.utilities.pytest import raises
 
 x, y, z = symbols('x y z')
@@ -55,6 +57,31 @@ def test_rational_algorithm():
           Rational(1, 2)) / k, 0, 1)
 
     assert rational_algorithm(cos(x), x, k) is None
+
+
+def test_rational_independent():
+    ri = rational_independent
+    assert ri([cos(x), sin(x)], x) == [cos(x), sin(x)]
+    assert ri([x**2, sin(x), x*sin(x), x**3], x) == \
+        [x**3 + x**2, x*sin(x) + sin(x)]
+    assert ri([S.One, x*log(x), log(x), sin(x)/x, cos(x), sin(x), x], x) == \
+        [x + 1, x*log(x) + log(x), sin(x)/x + sin(x), cos(x)]
+
+
+def test_simpleDE():
+    f = Function('f')
+
+    assert simpleDE(exp(x), x, f) == -f(x) + Derivative(f(x), x)
+    assert simpleDE(sin(x), x, f) == f(x) + Derivative(f(x), x, x)
+    assert simpleDE(log(1 + x), x, f) == \
+        (x + 1)*Derivative(f(x), x, 2) + Derivative(f(x), x)
+    assert simpleDE(asin(x), x, f) == \
+        x*Derivative(f(x), x) + (x**2 - 1)*Derivative(f(x), x, x)
+    assert simpleDE(exp(x)*sin(x), x, f) == \
+        2*f(x) - 2*Derivative(f(x)) + Derivative(f(x), x, x)
+    assert simpleDE(((1 + x)/(1 - x))**n, x, f) == \
+        2*n*f(x) + (x**2 - 1)*Derivative(f(x), x)
+    assert simpleDE(airyai(x), x, f) == -x*f(x) + Derivative(f(x), x, x)
 
 
 def test_fps():

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -222,15 +222,22 @@ def test_fps__hyper():
     f = exp(acosh(x))
     assert fps(f, x).truncate() == I + x - I*x**2/2 - I*x**4/8 + O(x**6)
 
-
-@XFAIL
-def test_xfail_fps__hyper():
-    f = x*atan(x) - log(1 + x**2) / 2
-    assert fps(f, x, rational=False).truncate() == x**2/2 - x**4/12 + O(x**6)
-
     f = atan(1/x)
     assert fps(f, x).truncate() == pi/2 - x + x**3/3 - x**5/5 + O(x**6)
 
+    f = x*atan(x) - log(1 + x**2) / 2
+    assert fps(f, x, rational=False).truncate() == x**2/2 - x**4/12 + O(x**6)
+
+    f = log(1 + x)
+    assert fps(f, x, rational=False).truncate() == \
+        x - x**2/2 + x**3/3 - x**4/4 + x**5/5 + O(x**6)
+
+    f = x*exp(x)*sin(2*x)  # TODO: solved using rsolve, improve algo
+    assert fps(f, x).truncate() == 2*x**2 + 2*x**3 - x**4/3 - x**5 + O(x**6)
+
+
+@XFAIL
+def test_xfail_fps__hyper():
     f = exp(x)
     assert fps(f, x, -oo).truncate() == O(1/x**6, (x, oo))
 
@@ -239,10 +246,3 @@ def test_xfail_fps__hyper():
         (1/sqrt(x) - sqrt(x)/6 + x**Rational(3, 2)/120 - x**Rational(5, 2)/5040
          + x**Rational(7, 2)/362880 - x**Rational(9, 2)/39916800
          + x**Rational(11, 2)/6227020800 + O(x**6))
-
-    f = log(1 + x)
-    assert fps(f, x, rational=False).truncate() == \
-        x - x**2/2 + x**3/3 - x**4/4 + x**5/5 + O(x**6)
-
-    f = x*exp(x)*sin(2*x)
-    assert fps(f, x).truncate() == 2*x**2 + 2*x**3 - x**4/3 - x**5 + O(x**6)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -263,6 +263,14 @@ def test_fps_shift():
     assert fps(f, x, rational=False).truncate() == \
         x**3 - x**5/3 + O(x**6)
 
+    f = cos(sqrt(x))*x
+    assert fps(f, x).truncate() == \
+        x - x**2/2 + x**3/24 - x**4/720 + x**5/40320 + O(x**6)
+
+    f = x**2*cos(sqrt(x))
+    assert fps(f, x).truncate() == \
+        x**2 - x**3/2 + x**4/24 - x**5/720 + O(x**6)
+
 
 def test_fps__Add_expr():
     f = x*atan(x) - log(1 + x**2) / 2

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -299,16 +299,44 @@ def test_fps__asymptotic():
         -1/(5*x**5) + 1/(3*x**3) - 1/x - pi/2 + O(1/x**6, (x, oo))
 
 
-@XFAIL
-def test_xfail_fps__hyper():
+def test_fps__fractional():
     f = sin(sqrt(x)) / x
     assert fps(f, x).truncate() == \
         (1/sqrt(x) - sqrt(x)/6 + x**Rational(3, 2)/120 - x**Rational(5, 2)/5040
          + x**Rational(7, 2)/362880 - x**Rational(9, 2)/39916800
          + x**Rational(11, 2)/6227020800 + O(x**6))
 
+    f = sin(sqrt(x)) * x
+    assert fps(f, x).truncate() == \
+        (x**Rational(3, 2) - x**Rational(5, 2)/6 + x**Rational(7, 2)/120
+         - x**Rational(9, 2)/5040 + x**Rational(11, 2)/362880 + O(x**6))
+
+    f = atan(sqrt(x)) / x**2
+    assert fps(f, x).truncate() == \
+        (x**Rational(-3, 2) - x**Rational(-1, 2)/3 + x**Rational(1, 2)/5
+         - x**Rational(3, 2)/7 + x**Rational(5, 2)/9 - x**Rational(7, 2)/11
+         + x**Rational(9, 2)/13 - x**Rational(11, 2)/15 + O(x**6))
+
+    f = exp(sqrt(x))
+    assert fps(f, x).truncate().expand() == \
+        (1 + x/2 + x**2/24 + x**3/720 + x**4/40320 + x**5/3628800 + sqrt(x)
+         + x**Rational(3, 2)/6 + x**Rational(5, 2)/120 + x**Rational(7, 2)/5040
+         + x**Rational(9, 2)/362880 + x**Rational(11, 2)/39916800 + O(x**6))
+
+    f = exp(sqrt(x))*x
+    assert fps(f, x).truncate().expand() == \
+        (x + x**2/2 + x**3/24 + x**4/720 + x**5/40320 + x**Rational(3, 2)
+         + x**Rational(5, 2)/6 + x**Rational(7, 2)/120 + x**Rational(9, 2)/5040
+         + x**Rational(11, 2)/362880 + O(x**6))
+
+
+@XFAIL
+def test_fps__symbolic():
     f = x**n*sin(x**2)
     assert fps(f, x).truncate() == x**n*(x**2 + O(x**6))
 
+
+@XFAIL
+def test_xfail_fps__simpleDE():
     f = exp(x)*sin(x)/x
     assert fps(f, x).truncate() == 1 + x + x**2/3 - x**4/30 - x**5/90 + O(x**6)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -298,6 +298,14 @@ def test_fps__asymptotic():
     assert fps(f, x, -oo, full=True).truncate() == \
         -1/(5*x**5) + 1/(3*x**3) - 1/x - pi/2 + O(1/x**6, (x, oo))
 
+    f = log(1 + x)
+    assert fps(f, x, oo) != \
+        (-1/(5*x**5) - 1/(4*x**4) + 1/(3*x**3) - 1/(2*x**2) + 1/x - log(1/x)
+         + O(1/x**6, (x, oo)))
+    assert fps(f, x, -oo) != \
+        (-1/(5*x**5) - 1/(4*x**4) + 1/(3*x**3) - 1/(2*x**2) + 1/x + I*pi
+         - log(-1/x) + O(1/x**6, (x, oo)))
+
 
 def test_fps__fractional():
     f = sin(sqrt(x)) / x
@@ -328,6 +336,20 @@ def test_fps__fractional():
         (x + x**2/2 + x**3/24 + x**4/720 + x**5/40320 + x**Rational(3, 2)
          + x**Rational(5, 2)/6 + x**Rational(7, 2)/120 + x**Rational(9, 2)/5040
          + x**Rational(11, 2)/362880 + O(x**6))
+
+
+def test_fps__logarithmic_singularity():
+    f = log(1 + 1/x)
+    assert fps(f, x) != \
+        -log(x) + x - x**2/2 + x**3/3 - x**4/4 + x**5/5 + O(x**6)
+    assert fps(f, x, rational=False) != \
+        -log(x) + x - x**2/2 + x**3/3 - x**4/4 + x**5/5 + O(x**6)
+
+
+@XFAIL
+def test_fps__logarithmic_singularity_fail():
+    f = asech(x)  # Algorithms for computing limits needs improvemnts
+    assert fps(f, x) != log(2) - log(x) - x**2/4 - 3*x**4/64 + O(x**6)
 
 
 @XFAIL

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -264,6 +264,9 @@ def test_fps__hyper():
     f = exp(x)*sin(x)/x
     assert fps(f, x).truncate() == 1 + x + x**2/3 - x**4/30 - x**5/90 + O(x**6)
 
+    f = sin(x) * cos(x)
+    assert fps(f, x).truncate() == x - 2*x**3/3 + 2*x**5/15 + O(x**6)
+
 
 def test_fps_shift():
     f = x**-5*sin(x)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -7,7 +7,7 @@ from sympy.series.formal import (rational_algorithm, FormalPowerSeries,
 from sympy.utilities.pytest import raises, XFAIL
 
 x, y, z = symbols('x y z')
-n, m, k = symbols('n m k')
+n, m, k = symbols('n m k', integer=True)
 f, r = Function('f'), Function('r')
 
 

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -232,12 +232,20 @@ def test_fps__hyper():
     assert fps(f, x, rational=False).truncate() == \
         x - x**2/2 + x**3/3 - x**4/4 + x**5/5 + O(x**6)
 
-    f = x*exp(x)*sin(2*x)  # TODO: solved using rsolve, improve algo
+    f = x*exp(x)*sin(2*x)  # TODO: solved using rsolve, improve simpleDE
     assert fps(f, x).truncate() == 2*x**2 + 2*x**3 - x**4/3 - x**5 + O(x**6)
 
     f = x**2*atan(x)
     assert fps(f, x, rational=False).truncate() == \
         x**3 - x**5/3 + O(x**6)
+
+
+def test_fps__Add_expr():
+    f = x*atan(x) - log(1 + x**2) / 2
+    assert fps(f, x).truncate() == x**2/2 - x**4/12 + O(x**6)
+
+    f = sin(x) + cos(x) - exp(x) + log(1 + x)
+    assert fps(f, x).truncate() == x - 3*x**2/2 - x**4/4 + x**5/5 + O(x**6)
 
 
 @XFAIL

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -2,11 +2,12 @@ from sympy import (symbols, factorial, sqrt, Rational, atan, I, log, fps, O,
                    Sum, oo, S, pi, cos, sin, Function, exp, Derivative, asin,
                    airyai)
 from sympy.series.formal import (rational_algorithm, FormalPowerSeries,
-                                 rational_independent, simpleDE)
+                                 rational_independent, simpleDE, exp_re)
 from sympy.utilities.pytest import raises
 
 x, y, z = symbols('x y z')
 n, m, k = symbols('n m k')
+f, r = Function('f'), Function('r')
 
 
 def test_rational_algorithm():
@@ -69,8 +70,6 @@ def test_rational_independent():
 
 
 def test_simpleDE():
-    f = Function('f')
-
     assert simpleDE(exp(x), x, f) == -f(x) + Derivative(f(x), x)
     assert simpleDE(sin(x), x, f) == f(x) + Derivative(f(x), x, x)
     assert simpleDE(log(1 + x), x, f) == \
@@ -82,6 +81,23 @@ def test_simpleDE():
     assert simpleDE(((1 + x)/(1 - x))**n, x, f) == \
         2*n*f(x) + (x**2 - 1)*Derivative(f(x), x)
     assert simpleDE(airyai(x), x, f) == -x*f(x) + Derivative(f(x), x, x)
+
+
+def test_exp_re():
+    d = -f(x) + Derivative(f(x), x)
+    assert exp_re(d, r, k) == -r(k) + r(k + 1)
+
+    d = f(x) + Derivative(f(x), x, x)
+    assert exp_re(d, r, k) == r(k) + r(k + 2)
+
+    d = f(x) + Derivative(f(x), x) + Derivative(f(x), x, x)
+    assert exp_re(d, r, k) == r(k) + r(k + 1) + r(k + 2)
+
+    d = Derivative(f(x), x) + Derivative(f(x), x, x)
+    assert exp_re(d, r, k) == r(k) + r(k + 1)
+
+    d = Derivative(f(x), x, 3) + Derivative(f(x), x, 4) + Derivative(f(x))
+    assert exp_re(d, r, k) == r(k) + r(k + 2) + r(k + 3)
 
 
 def test_fps():

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -1,0 +1,128 @@
+from sympy import (symbols, factorial, sqrt, Rational, atan, I, log, fps, O,
+                   Sum, oo, S, pi, cos)
+from sympy.series.formal import rational_algorithm, FormalPowerSeries
+from sympy.utilities.pytest import raises
+
+x, y, z = symbols('x y z')
+n, m, k = symbols('n m k')
+
+
+def test_rational_algorithm():
+    f = 1 / ((x - 1)**2 * (x - 2))
+    assert rational_algorithm(f, x, k) == \
+        (-2**(-k - 1) + 1 - (factorial(k + 1) / factorial(k)), 0, 0)
+
+    f = (1 + x + x**2 + x**3) / ((x - 1) * (x - 2))
+    assert rational_algorithm(f, x, k) == \
+        (-15*2**(-k - 1) + 4, x + 4, 0)
+
+    f = z / (y*m - m*x - y*x + x**2)
+    assert rational_algorithm(f, x, k) == \
+        (((-y**(-k - 1)*z) / (y - m)) + ((m**(-k - 1)*z) / (y - m)), 0, 0)
+
+    f = x / (1 - x - x**2)
+    assert rational_algorithm(f, x, k) is None
+    assert rational_algorithm(f, x, k, full=True) == \
+        (((-Rational(1, 2) + sqrt(5)/2)**(-k - 1) *
+        (-sqrt(5)/10 + Rational(1,2))) +
+        ((-sqrt(5)/2 - Rational(1,2))**(-k - 1) *
+        (sqrt(5)/10 + Rational(1,2))), 0, 0)
+
+    f = 1 / (x**2 + 2*x + 2)
+    assert rational_algorithm(f, x, k) is None
+    assert rational_algorithm(f, x, k, full=True) == \
+        ((I*(-1 + I)**(-k - 1)) / 2 - (I*(-1 - I)**(-k - 1)) / 2, 0, 0)
+
+    f = log(1 + x)
+    assert rational_algorithm(f, x, k) == \
+        (-(-1)**(-k) / k, 0, 1)
+
+    f = atan(x)
+    assert rational_algorithm(f, x, k) is None
+    assert rational_algorithm(f, x, k, full=True) == \
+        (((I*I**(-k)) / 2 - (I*(-I)**(-k)) / 2) / k, 0, 1)
+
+    f = x*atan(x) - log(1 + x**2) / 2
+    assert rational_algorithm(f, x, k) is None
+    assert rational_algorithm(f, x, k, full=True) == \
+        (((I*I**(-k + 1)) / 2 - (I*(-I)**(-k + 1)) / 2) /
+         (k*(k - 1)), 0, 2)
+
+    f = log((1 + x) / (1 - x)) / 2 - atan(x)
+    assert rational_algorithm(f, x, k) is None
+    assert rational_algorithm(f, x, k, full=True) == \
+        ((-(-1)**(-k) / 2 - (I*I**(-k)) / 2 + (I*(-I)**(-k)) / 2 +
+          Rational(1, 2)) / k, 0, 1)
+
+    assert rational_algorithm(cos(x), x, k) is None
+
+
+def test_fps():
+    raises(NotImplementedError, lambda: fps(y*x))
+
+    assert fps(2) == 2
+    assert fps(log(1 + x), hyper=False, rational=False) == log(1 + x)
+
+    f = fps(log(1 + x))
+    assert isinstance(f, FormalPowerSeries)
+    assert f.subs(x, y) == f
+    assert f[:5] == [0, x, -x**2/2, x**3/3, -x**4/4]
+    assert f.as_leading_term(x) == x
+
+    k = f.ak.variables[0]
+    assert f.as_infinite() == Sum((-(-1)**(-k)*x**k)/k, (k, 1, oo))
+
+
+def test_fps__rational():
+    assert fps(1/x) == (1/x)
+    assert fps((x**2 + x + 1) / x**3) == (x**2 + x + 1) / x**3
+
+    f = 1 / ((x - 1)**2 * (x - 2))
+    assert fps(f, x).truncate() == \
+        (-Rational(1, 2) - 5*x/4 - 17*x**2/8 - 49*x**3/16 - 129*x**4/32
+         - 321*x**5/64 + O(x**6))
+
+    f = (1 + x + x**2 + x**3) / ((x - 1) * (x - 2))
+    assert fps(f, x).truncate() == \
+        (Rational(1, 2) + 5*x/4 + 17*x**2/8 + 49*x**3/16 + 113*x**4/32
+         + 241*x**5/64 + O(x**6))
+
+    f = x / (1 - x - x**2)
+    assert fps(f, x, full=True).truncate() == \
+        x + x**2 + 2*x**3 + 3*x**4 + 5*x**5 + O(x**6)
+
+    f = 1 / (x**2 + 2*x + 2)
+    assert fps(f, x, full=True).truncate() == \
+        Rational(1, 2) - x/2 + x**2/4 - x**4/8 + x**5/8 + O(x**6)
+
+    f = log(1 + x)
+    assert fps(f, x).truncate() == \
+        x - x**2/2 + x**3/3 - x**4/4 + x**5/5 + O(x**6)
+    assert fps(f, x, dir=1).truncate() == fps(f, x, dir=-1).truncate()
+    assert fps(f, x, 2).truncate() == \
+        (log(3) - Rational(2, 3) - (x - 2)**2/18 + (x - 2)**3/81
+         - (x - 2)**4/324 + (x -2)**5/1215 + x/3 + O((x - 2)**6, (x, 2)))
+    assert fps(f, x, 2, dir=-1).truncate() == \
+        (log(3) - Rational(2, 3) - (-x + 2)**2/18 - (-x + 2)**3/81
+         - (-x + 2)**4/324 - (-x + 2)**5/1215 + x/3 + O((x - 2)**6, (x, 2)))
+
+    f = atan(x)
+    assert fps(f, x, full=True).truncate() == x - x**3/3 + x**5/5 + O(x**6)
+    assert fps(f, x, full=True, dir=1).truncate() == \
+        fps(f, x, full=True, dir=-1).truncate()
+    assert fps(f, x, 2, full=True).truncate() == \
+        (atan(2) - Rational(2, 5) - 2*(x - 2)**2/25 + 11*(x - 2)**3/375
+         - 6*(x - 2)**4/625 + 41*(x - 2)**5/15625 + x/5 + O((x - 2)**6, (x, 2)))
+    assert fps(f, x, 2, full=True, dir=-1).truncate() == \
+        (atan(2) - Rational(2, 5) - 2*(-x + 2)**2/25 - 11*(-x + 2)**3/375
+         - 6*(-x + 2)**4/625 - 41*(-x + 2)**5/15625 + x/5 + O((x - 2)**6, (x, 2)))
+    assert fps(f, x, oo, full=True).truncate() == \
+        -1/(5*x**5) + 1/(3*x**3) - 1/x + pi/2 + O(1/x**6, (x, oo))
+    assert fps(f, x, -oo, full=True).truncate() == \
+        -1/(5*x**5) + 1/(3*x**3) - 1/x - pi/2 + O(1/x**6, (x, oo))
+
+    f = x*atan(x) - log(1 + x**2) / 2
+    assert fps(f, x, full=True).truncate() == x**2/2 - x**4/12 + O(x**6)
+
+    f = log((1 + x) / (1 - x)) / 2 - atan(x)
+    assert fps(f, x, full=True).truncate(n=10) == 2*x**3/3 + 2*x**7/7 + O(x**10)

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, factorial, sqrt, Rational, atan, I, log, fps, O,
                    Sum, oo, S, pi, cos, sin, Function, exp, Derivative, asin,
-                   airyai, acos, acosh, gamma, erf)
+                   airyai, acos, acosh, gamma, erf, asech)
 from sympy.series.formal import (rational_algorithm, FormalPowerSeries,
                                  rational_independent, simpleDE, exp_re,
                                  hyper_re)
@@ -164,13 +164,13 @@ def test_fps__rational():
 
     f = 1 / ((x - 1)**2 * (x - 2))
     assert fps(f, x).truncate() == \
-        (-Rational(1, 2) - 5*x/4 - 17*x**2/8 - 49*x**3/16 - 129*x**4/32
-         - 321*x**5/64 + O(x**6))
+        (-Rational(1, 2) - 5*x/4 - 17*x**2/8 - 49*x**3/16 - 129*x**4/32 -
+         321*x**5/64 + O(x**6))
 
     f = (1 + x + x**2 + x**3) / ((x - 1) * (x - 2))
     assert fps(f, x).truncate() == \
-        (Rational(1, 2) + 5*x/4 + 17*x**2/8 + 49*x**3/16 + 113*x**4/32
-         + 241*x**5/64 + O(x**6))
+        (Rational(1, 2) + 5*x/4 + 17*x**2/8 + 49*x**3/16 + 113*x**4/32 +
+         241*x**5/64 + O(x**6))
 
     f = x / (1 - x - x**2)
     assert fps(f, x, full=True).truncate() == \
@@ -185,23 +185,22 @@ def test_fps__rational():
         x - x**2/2 + x**3/3 - x**4/4 + x**5/5 + O(x**6)
     assert fps(f, x, dir=1).truncate() == fps(f, x, dir=-1).truncate()
     assert fps(f, x, 2).truncate() == \
-        (log(3) - Rational(2, 3) - (x - 2)**2/18 + (x - 2)**3/81
-         - (x - 2)**4/324 + (x - 2)**5/1215 + x/3 + O((x - 2)**6, (x, 2)))
+        (log(3) - Rational(2, 3) - (x - 2)**2/18 + (x - 2)**3/81 -
+         (x - 2)**4/324 + (x - 2)**5/1215 + x/3 + O((x - 2)**6, (x, 2)))
     assert fps(f, x, 2, dir=-1).truncate() == \
-        (log(3) - Rational(2, 3) - (-x + 2)**2/18 - (-x + 2)**3/81
-         - (-x + 2)**4/324 - (-x + 2)**5/1215 + x/3 + O((x - 2)**6, (x, 2)))
+        (log(3) - Rational(2, 3) - (-x + 2)**2/18 - (-x + 2)**3/81 -
+         (-x + 2)**4/324 - (-x + 2)**5/1215 + x/3 + O((x - 2)**6, (x, 2)))
 
     f = atan(x)
     assert fps(f, x, full=True).truncate() == x - x**3/3 + x**5/5 + O(x**6)
     assert fps(f, x, full=True, dir=1).truncate() == \
         fps(f, x, full=True, dir=-1).truncate()
     assert fps(f, x, 2, full=True).truncate() == \
-        (atan(2) - Rational(2, 5) - 2*(x - 2)**2/25 + 11*(x - 2)**3/375
-         - 6*(x - 2)**4/625 + 41*(x - 2)**5/15625 + x/5 + O((x - 2)**6, (x, 2)))
+        (atan(2) - Rational(2, 5) - 2*(x - 2)**2/25 + 11*(x - 2)**3/375 -
+         6*(x - 2)**4/625 + 41*(x - 2)**5/15625 + x/5 + O((x - 2)**6, (x, 2)))
     assert fps(f, x, 2, full=True, dir=-1).truncate() == \
-        (atan(2) - Rational(2, 5) - 2*(-x + 2)**2/25 - 11*(-x + 2)**3/375
-         - 6*(-x + 2)**4/625 - 41*(-x + 2)**5/15625 + x/5 + O((x - 2)**6,
-                                                              (x, 2)))
+        (atan(2) - Rational(2, 5) - 2*(-x + 2)**2/25 - 11*(-x + 2)**3/375 -
+         6*(-x + 2)**4/625 - 41*(-x + 2)**5/15625 + x/5 + O((x - 2)**6, (x, 2)))
 
     f = x*atan(x) - log(1 + x**2) / 2
     assert fps(f, x, full=True).truncate() == x**2/2 - x**4/12 + O(x**6)
@@ -300,42 +299,42 @@ def test_fps__asymptotic():
 
     f = log(1 + x)
     assert fps(f, x, oo) != \
-        (-1/(5*x**5) - 1/(4*x**4) + 1/(3*x**3) - 1/(2*x**2) + 1/x - log(1/x)
-         + O(1/x**6, (x, oo)))
+        (-1/(5*x**5) - 1/(4*x**4) + 1/(3*x**3) - 1/(2*x**2) + 1/x - log(1/x) +
+         O(1/x**6, (x, oo)))
     assert fps(f, x, -oo) != \
-        (-1/(5*x**5) - 1/(4*x**4) + 1/(3*x**3) - 1/(2*x**2) + 1/x + I*pi
-         - log(-1/x) + O(1/x**6, (x, oo)))
+        (-1/(5*x**5) - 1/(4*x**4) + 1/(3*x**3) - 1/(2*x**2) + 1/x + I*pi -
+         log(-1/x) + O(1/x**6, (x, oo)))
 
 
 def test_fps__fractional():
     f = sin(sqrt(x)) / x
     assert fps(f, x).truncate() == \
-        (1/sqrt(x) - sqrt(x)/6 + x**Rational(3, 2)/120 - x**Rational(5, 2)/5040
-         + x**Rational(7, 2)/362880 - x**Rational(9, 2)/39916800
-         + x**Rational(11, 2)/6227020800 + O(x**6))
+        (1/sqrt(x) - sqrt(x)/6 + x**Rational(3, 2)/120 -
+         x**Rational(5, 2)/5040 + x**Rational(7, 2)/362880 -
+         x**Rational(9, 2)/39916800 + x**Rational(11, 2)/6227020800 + O(x**6))
 
     f = sin(sqrt(x)) * x
     assert fps(f, x).truncate() == \
-        (x**Rational(3, 2) - x**Rational(5, 2)/6 + x**Rational(7, 2)/120
-         - x**Rational(9, 2)/5040 + x**Rational(11, 2)/362880 + O(x**6))
+        (x**Rational(3, 2) - x**Rational(5, 2)/6 + x**Rational(7, 2)/120 -
+         x**Rational(9, 2)/5040 + x**Rational(11, 2)/362880 + O(x**6))
 
     f = atan(sqrt(x)) / x**2
     assert fps(f, x).truncate() == \
-        (x**Rational(-3, 2) - x**Rational(-1, 2)/3 + x**Rational(1, 2)/5
-         - x**Rational(3, 2)/7 + x**Rational(5, 2)/9 - x**Rational(7, 2)/11
-         + x**Rational(9, 2)/13 - x**Rational(11, 2)/15 + O(x**6))
+        (x**Rational(-3, 2) - x**Rational(-1, 2)/3 + x**Rational(1, 2)/5 -
+         x**Rational(3, 2)/7 + x**Rational(5, 2)/9 - x**Rational(7, 2)/11 +
+         x**Rational(9, 2)/13 - x**Rational(11, 2)/15 + O(x**6))
 
     f = exp(sqrt(x))
     assert fps(f, x).truncate().expand() == \
-        (1 + x/2 + x**2/24 + x**3/720 + x**4/40320 + x**5/3628800 + sqrt(x)
-         + x**Rational(3, 2)/6 + x**Rational(5, 2)/120 + x**Rational(7, 2)/5040
-         + x**Rational(9, 2)/362880 + x**Rational(11, 2)/39916800 + O(x**6))
+        (1 + x/2 + x**2/24 + x**3/720 + x**4/40320 + x**5/3628800 + sqrt(x) +
+         x**Rational(3, 2)/6 + x**Rational(5, 2)/120 + x**Rational(7, 2)/5040 +
+         x**Rational(9, 2)/362880 + x**Rational(11, 2)/39916800 + O(x**6))
 
     f = exp(sqrt(x))*x
     assert fps(f, x).truncate().expand() == \
-        (x + x**2/2 + x**3/24 + x**4/720 + x**5/40320 + x**Rational(3, 2)
-         + x**Rational(5, 2)/6 + x**Rational(7, 2)/120 + x**Rational(9, 2)/5040
-         + x**Rational(11, 2)/362880 + O(x**6))
+        (x + x**2/2 + x**3/24 + x**4/720 + x**5/40320 + x**Rational(3, 2) +
+         x**Rational(5, 2)/6 + x**Rational(7, 2)/120 + x**Rational(9, 2)/5040 +
+         x**Rational(11, 2)/362880 + O(x**6))
 
 
 def test_fps__logarithmic_singularity():
@@ -348,14 +347,41 @@ def test_fps__logarithmic_singularity():
 
 @XFAIL
 def test_fps__logarithmic_singularity_fail():
-    f = asech(x)  # Algorithms for computing limits needs improvemnts
-    assert fps(f, x) != log(2) - log(x) - x**2/4 - 3*x**4/64 + O(x**6)
+    f = asech(x)  # Algorithms for computing limits probably needs improvemnts
+    assert fps(f, x) == log(2) - log(x) - x**2/4 - 3*x**4/64 + O(x**6)
 
 
-@XFAIL
 def test_fps__symbolic():
     f = x**n*sin(x**2)
-    assert fps(f, x).truncate() == x**n*(x**2 + O(x**6))
+    assert fps(f, x).truncate(8) == x**2*x**n - x**6*x**n/6 + O(x**(n + 8), x)
+
+    f = x**(n - 2)*cos(x)
+    assert fps(f, x).truncate() == \
+        (x**n*(-S(1)/2 + x**(-2)) + x**2*x**n/24 - x**4*x**n/720 +
+         O(x**(n + 6), x))
+
+    f = x**n*log(1 + x)
+    fp = fps(f, x)
+    k = fp.ak.variables[0]
+    assert fp.infinite == \
+        Sum((-(-1)**(-k)*x**k*x**n)/k, (k, 1, oo))
+
+    f = x**(n - 2)*sin(x) + x**n*exp(x)
+    assert fps(f, x).truncate() == \
+        (x**n*(1 + 1/x) + 5*x*x**n/6 + x**2*x**n/2 + 7*x**3*x**n/40 +
+         x**4*x**n/24 + 41*x**5*x**n/5040 + O(x**(n + 6), x))
+
+    f = (x - 2)**n*log(1 + x)
+    assert fps(f, x, 2).truncate() == \
+        ((x - 2)**n*log(3) - (x - 2)**2*(x - 2)**n/18 +
+         (x - 2)**3*(x - 2)**n/81 - (x - 2)**4*(x - 2)**n/324 +
+         (x - 2)**5*(x - 2)**n/1215 + (x/3 - S(2)/3)*(x - 2)**n +
+         O((x - 2)**(n + 6), (x, 2)))
+
+    f = x**n*atan(x)
+    assert fps(f, x, oo).truncate() == \
+        (-x**n/(5*x**5) + x**n/(3*x**3) + x**n*(pi/2 - 1/x) +
+         O(x**(n - 6), (x, oo)))
 
 
 @XFAIL

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -235,6 +235,10 @@ def test_fps__hyper():
     f = x*exp(x)*sin(2*x)  # TODO: solved using rsolve, improve algo
     assert fps(f, x).truncate() == 2*x**2 + 2*x**3 - x**4/3 - x**5 + O(x**6)
 
+    f = x**2*atan(x)
+    assert fps(f, x, rational=False).truncate() == \
+        x**3 - x**5/3 + O(x**6)
+
 
 @XFAIL
 def test_xfail_fps__hyper():


### PR DESCRIPTION
Series of many functions are now computable using `fps`.
### TODO:
- [x] Move input checks from `fps` to `compute_fps`
- [x] Support for fractional powers of x.
- [x] improve `rsolve_hypergeometric` to better handle singularities.
- [x] Series of  functions of the form `x**n*f(x)`
- [x]  Improve `simpleDE` to find higher order DE's.

This PR builds over #9572 and uses the commits in #9615. Both are under review.

Ping @jcrist @flacjacket 
