### PR TITLE
Catches the deprecation warning in the bicycle test.

### DIFF
--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -39,7 +39,7 @@ def test_one_dof():
     # The old linearizer raises a deprecation warning, so catch it here so
     # it doesn't cause py.test to fail.
     with warnings.catch_warnings():
-        warnings.filterwarnings('always')
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
         F_A_old, F_B_old, r_old = KM.linearize()
     M_new, F_A_new, F_B_new, r_new = KM.linearize(new_method=True)
     assert simplify(M_new.inv() * F_A_new - M_old.inv() * F_A_old) == zeros(2)

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -1,3 +1,5 @@
+import warnings
+
 from sympy.core.compatibility import range
 from sympy import evalf, symbols, pi, sin, cos, sqrt, acos, Matrix
 from sympy.physics.mechanics import (ReferenceFrame, dynamicsymbols, inertia,
@@ -253,7 +255,9 @@ def test_bicycle():
     # many rows as *total* coordinates and speeds, but only as many columns as
     # independent coordinates and speeds.
 
-    forcing_lin = KM.linearize()[0]
+    with warnings.catch_warnings():
+        warnings.filterwarnings('always')
+        forcing_lin = KM.linearize()[0]
 
     # As mentioned above, the size of the linearized forcing terms is expanded
     # to include both q's and u's, so the mass matrix must have this done as

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -4,7 +4,9 @@ from sympy.core.compatibility import range
 from sympy import evalf, symbols, pi, sin, cos, sqrt, acos, Matrix
 from sympy.physics.mechanics import (ReferenceFrame, dynamicsymbols, inertia,
                                      KanesMethod, RigidBody, Point, dot)
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.pytest import slow, ON_TRAVIS, skip
+
 
 @slow
 def test_bicycle():
@@ -125,7 +127,6 @@ def test_bicycle():
     BodyFork = RigidBody('BodyFork', Fork_mc, Fork, mfork, Fork_I)
     BodyWR = RigidBody('BodyWR', WR_mc, WR, mwr, WR_I)
     BodyWF = RigidBody('BodyWF', WF_mc, WF, mwf, WF_I)
-
 
     # The kinematic differential equations; they are defined quite simply. Each
     # entry in this list is equal to zero.
@@ -256,7 +257,7 @@ def test_bicycle():
     # independent coordinates and speeds.
 
     with warnings.catch_warnings():
-        warnings.filterwarnings('always')
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
         forcing_lin = KM.linearize()[0]
 
     # As mentioned above, the size of the linearized forcing terms is expanded


### PR DESCRIPTION
This allows us to continue testing the deprecated linearize method. The test_kane3.py test is broken in master, see #9641.
