### PR TITLE
Correctly handle Eq in experimental_lambdify

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -281,6 +281,7 @@ class Lambdifier(object):
         # and sympy_expression_namespace can not catch it.
         from sympy import sqrt
         namespace.update({'sqrt': sqrt})
+        namespace.update({'Eq': lambda x, y: x == y})
         # End workaround.
         if use_python_math:
             namespace.update({'math': __import__('math')})


### PR DESCRIPTION
experimental_lambdify does a str on the expression, but it can't find Eq
because the str of Eq.func is Equation.

Fixes #9652.
