### PR TITLE
Improved lambdify printing for numpy

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -69,6 +69,59 @@ class LambdaPrinter(StrPrinter):
     def _print_BooleanFalse(self, expr):
         return "False"
 
+class NumPyPrinter(LambdaPrinter):
+    """
+    Numpy printer which handles vectorized piecewise functions,
+    logical operators, etc.
+    """
+    _default_settings = {
+        "order": "none",
+        "full_prec": "auto",
+    }
+
+    def _print_seq(self, seq, delimiter=', '):
+        "General sequence printer: converts to tuple"
+        # Print tuples here instead of lists because numba supports
+        #     tuples in nopython mode.
+        return '({},)'.format(delimiter.join(self._print(item) for item in seq))
+
+    def _print_MatMul(self, expr):
+        "Matrix multiplication printer"
+        return '({0})'.format(').dot('.join(self._print(i) for i in expr.args))
+
+    def _print_Piecewise(self, expr):
+        "Piecewise function printer"
+        # Print tuples here instead of lists because numba may add support
+        #     for select in nopython mode; see numba#1313 on github.
+        exprs = '({0},)'.format(','.join(self._print(arg.expr) for arg in expr.args))
+        conds = '({0},)'.format(','.join(self._print(arg.cond) for arg in expr.args))
+        # If (default_value, True) is a (expr, cond) tuple in a Piecewise object
+        #     it will behave the same as passing the 'default' kwarg to select()
+        #     *as long as* it is the last element in expr.args.
+        # If this is not the case, it may be triggered prematurely.
+        return 'select({0}, {1})'.format(conds, exprs)
+
+    def _print_And(self, expr):
+        "Logical And printer"
+        # We have to override LambdaPrinter because it uses Python 'and' keyword.
+        # If LambdaPrinter didn't define it, we could use StrPrinter's
+        # version of the function and add 'logical_and' to NUMPY_TRANSLATIONS.
+        return '{0}({1})'.format('logical_and', ','.join(self._print(i) for i in expr.args))
+
+    def _print_Or(self, expr):
+        "Logical Or printer"
+        # We have to override LambdaPrinter because it uses Python 'or' keyword.
+        # If LambdaPrinter didn't define it, we could use StrPrinter's
+        # version of the function and add 'logical_or' to NUMPY_TRANSLATIONS.
+        return '{0}({1})'.format('logical_or', ','.join(self._print(i) for i in expr.args))
+
+    def _print_Not(self, expr):
+        "Logical Not printer"
+        # We have to override LambdaPrinter because it uses Python 'not' keyword.
+        # If LambdaPrinter didn't define it, we would still have to define our
+        #     own because StrPrinter doesn't define it.
+        return '{0}({1})'.format('logical_not', ','.join(self._print(i) for i in expr.args))
+
 # numexpr works by altering the string passed to numexpr.evaluate
 # rather than by populating a namespace.  Thus a special printer...
 class NumExprPrinter(LambdaPrinter):

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -99,7 +99,7 @@ class NumPyPrinter(LambdaPrinter):
         #     it will behave the same as passing the 'default' kwarg to select()
         #     *as long as* it is the last element in expr.args.
         # If this is not the case, it may be triggered prematurely.
-        return 'select({0}, {1})'.format(conds, exprs)
+        return 'select({0}, {1}, default=nan)'.format(conds, exprs)
 
     def _print_And(self, expr):
         "Logical And printer"

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -335,6 +335,10 @@ def test_numpy_piecewise():
     f = lambdify(x, pieces, modules="numpy")
     numpy.testing.assert_array_equal(f(numpy.arange(10)),
                                      numpy.array([0, 1, 2, 0, 0, 0, 36, 49, 64, 81]))
+    # If we evaluate somewhere all conditions are False, we should get back NaN
+    nodef_func = lambdify(x, Piecewise((x, x > 0), (-x, x < 0)))
+    numpy.testing.assert_array_equal(nodef_func(numpy.array([-1, 0, 1])),
+                                     numpy.array([1, numpy.nan, 1]))
 
 def test_numpy_logical_ops():
     if not numpy:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,7 +1,8 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
-    Float, Matrix, Lambda, exp, Integral, oo, I, Abs, Function, true, false)
+    Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
+    true, false, And, Or, Not)
 from sympy.printing.lambdarepr import LambdaPrinter
 import mpmath
 from sympy.utilities.lambdify import implemented_function
@@ -298,11 +299,67 @@ def test_numpy_matrix():
         skip("numpy not installed.")
     A = Matrix([[x, x*y], [sin(z) + 4, x**z]])
     sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
-    #Lambdify array first, to ensure return to matrix as default
-    f = lambdify((x, y, z), A, [{'ImmutableMatrix': numpy.array}, 'numpy'])
+    #Lambdify array first, to ensure return to array as default
+    f = lambdify((x, y, z), A, ['numpy'])
     numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
     #Check that the types are arrays and matrices
     assert isinstance(f(1, 2, 3), numpy.ndarray)
+
+def test_numpy_transpose():
+    if not numpy:
+        skip("numpy not installed.")
+    A = Matrix([[1, x], [0, 1]])
+    f = lambdify((x), A.T, modules="numpy")
+    numpy.testing.assert_array_equal(f(2), numpy.array([[1, 0], [2, 1]]))
+
+def test_numpy_inverse():
+    if not numpy:
+        skip("numpy not installed.")
+    A = Matrix([[1, x], [0, 1]])
+    f = lambdify((x), A**-1, modules="numpy")
+    numpy.testing.assert_array_equal(f(2), numpy.array([[1, -2], [0,  1]]))
+
+def test_numpy_old_matrix():
+    if not numpy:
+        skip("numpy not installed.")
+    A = Matrix([[x, x*y], [sin(z) + 4, x**z]])
+    sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
+    f = lambdify((x, y, z), A, [{'ImmutableMatrix': numpy.matrix}, 'numpy'])
+    numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
+    assert isinstance(f(1, 2, 3), numpy.matrix)
+
+def test_numpy_piecewise():
+    if not numpy:
+        skip("numpy not installed.")
+    pieces = Piecewise((x, x < 3), (x**2, x > 5), (0, True))
+    f = lambdify(x, pieces, modules="numpy")
+    numpy.testing.assert_array_equal(f(numpy.arange(10)),
+                                     numpy.array([0, 1, 2, 0, 0, 0, 36, 49, 64, 81]))
+
+def test_numpy_logical_ops():
+    if not numpy:
+        skip("numpy not installed.")
+    and_func = lambdify((x, y), And(x, y), modules="numpy")
+    or_func = lambdify((x, y), Or(x, y), modules="numpy")
+    not_func = lambdify((x), Not(x), modules="numpy")
+    arr1 = numpy.array([True, True])
+    arr2 = numpy.array([False, True])
+    numpy.testing.assert_array_equal(and_func(arr1, arr2), numpy.array([False, True]))
+    numpy.testing.assert_array_equal(or_func(arr1, arr2), numpy.array([True, True]))
+    numpy.testing.assert_array_equal(not_func(arr2), numpy.array([True, False]))
+
+def test_numpy_matmul():
+    if not numpy:
+        skip("numpy not installed.")
+    xmat = Matrix([[x, y], [z, 1+z]])
+    ymat = Matrix([[x**2], [Abs(x)]])
+    mat_func = lambdify((x, y, z), xmat*ymat, modules="numpy")
+    numpy.testing.assert_array_equal(mat_func(0.5, 3, 4), numpy.array([[1.625], [3.5]]))
+    numpy.testing.assert_array_equal(mat_func(-0.5, 3, 4), numpy.array([[1.375], [3.5]]))
+    # Multiple matrices chained together in multiplication
+    f = lambdify((x, y, z), xmat*xmat*xmat, modules="numpy")
+    numpy.testing.assert_array_equal(f(0.5, 3, 4), numpy.array([[72.125, 119.25],
+                                                                [159, 251]]))
 
 def test_numpy_numexpr():
     if not numpy:


### PR DESCRIPTION
This PR adds a `NumPyPrinter` class. It adds the following features to `lambdify()` when using the `numpy` module:
- Prints `Piecewise` objects as `numpy.select()` calls
- Matrix multiplication as chained `ndarray.dot()` calls (thanks @jcrist)
- Proper logical operator handling (`logical_and`, `logical_or`, etc.)

After discussion with @asmeurer and @certik, this PR also ends the deprecation cycle started by sympy/sympy#7853 so that `ImmutableMatrix` now prints as `numpy.array` by default. It is possible to get the old behavior by passing `[{'ImmutableMatrix': numpy.matrix}, 'numpy']` to the `modules` kwarg. Tests for this and everything listed above are included.

Feedback/review is very desirable. It was a pleasure sprinting with many members of the SymPy team, and I look forward to ongoing collaboration.
