### PR TITLE
Unifying future imports

### DIFF
--- a/bin/ask_update.py
+++ b/bin/ask_update.py
@@ -9,6 +9,8 @@ Should be run from sympy root directory
 $ python bin/ask_update.py
 """
 
+from __future__ import division, print_function
+
 # hook in-tree SymPy into Python path, if possible
 import os
 import sys

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -17,7 +17,7 @@ or
 If no arguments are given, all files in sympy/ are checked.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -22,7 +22,7 @@ command with
 $ bin/coverage_report.py -c
 
 """
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import re

--- a/bin/generate_test_list.py
+++ b/bin/generate_test_list.py
@@ -28,7 +28,7 @@ tests = [
 
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from glob import glob
 

--- a/bin/get_sympy.py
+++ b/bin/get_sympy.py
@@ -1,6 +1,6 @@
 """Functions to get the correct sympy version to run tests."""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys

--- a/bin/mailmap_update.py
+++ b/bin/mailmap_update.py
@@ -7,8 +7,8 @@ A tool to help keep .mailmap and AUTHORS up-to-date.
 # - Check doc/src/aboutus.rst
 # - Make it easier to update .mailmap or AUTHORS with the correct entries.
 
+from __future__ import division, print_function
 from __future__ import unicode_literals
-from __future__ import print_function
 
 import os
 import sys

--- a/bin/sympy_time.py
+++ b/bin/sympy_time.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import division, print_function
 
 import time
 from get_sympy import path_hack

--- a/bin/sympy_time_cache.py
+++ b/bin/sympy_time_cache.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import division, print_function
 
 import time
 import timeit

--- a/bin/test_import.py
+++ b/bin/test_import.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import division, print_function
 
 from timeit import default_timer as clock
 from get_sympy import path_hack

--- a/examples/advanced/autowrap_integrators.py
+++ b/examples/advanced/autowrap_integrators.py
@@ -25,6 +25,8 @@ http://ojensen.wordpress.com/2010/08/10/fast-ufunc-ish-hydrogen-solutions/
 ----
 """
 
+from __future__ import division, print_function
+
 import sys
 from sympy.external import import_module
 

--- a/examples/advanced/autowrap_ufuncify.py
+++ b/examples/advanced/autowrap_ufuncify.py
@@ -17,6 +17,8 @@ working fortran compiler.
 http://ojensen.wordpress.com/2010/08/10/fast-ufunc-ish-hydrogen-solutions/
 """
 
+from __future__ import division, print_function
+
 import sys
 
 from sympy.external import import_module

--- a/examples/advanced/curvilinear_coordinates.py
+++ b/examples/advanced/curvilinear_coordinates.py
@@ -9,6 +9,8 @@ and calculates all kinds of interesting properties, like Jacobian, metric
 tensor, Laplace operator, ...
 """
 
+from __future__ import division, print_function
+
 from sympy import var, sin, cos, pprint, Matrix, eye, trigsimp, Eq, \
     Function, simplify, sinh, cosh, expand, symbols
 

--- a/examples/advanced/dense_coding_example.py
+++ b/examples/advanced/dense_coding_example.py
@@ -2,6 +2,8 @@
 
 """Demonstration of quantum dense coding."""
 
+from __future__ import division, print_function
+
 from sympy import sqrt, pprint
 from sympy.physics.quantum import qapply
 from sympy.physics.quantum.gate import H, X, Z, CNOT

--- a/examples/advanced/fem.py
+++ b/examples/advanced/fem.py
@@ -15,6 +15,8 @@ $ python fem.py
 
 """
 
+from __future__ import division, print_function
+
 from sympy import symbols, Symbol, factorial, Rational, zeros, div, eye, \
     integrate, diff, pprint, reduced
 

--- a/examples/advanced/gibbs_phenomenon.py
+++ b/examples/advanced/gibbs_phenomenon.py
@@ -13,6 +13,8 @@ See:
  * http://en.wikipedia.org/wiki/Gibbs_phenomena
 """
 
+from __future__ import division, print_function
+
 from sympy import var, sqrt, integrate, conjugate, seterr, Abs, pprint, I, pi,\
     sin, cos, sign, lambdify, Integral, S
 

--- a/examples/advanced/grover_example.py
+++ b/examples/advanced/grover_example.py
@@ -2,6 +2,8 @@
 
 """Grover's quantum search algorithm example."""
 
+from __future__ import division, print_function
+
 from sympy import pprint
 from sympy.physics.quantum import qapply
 from sympy.physics.quantum.qubit import IntQubit

--- a/examples/advanced/hydrogen.py
+++ b/examples/advanced/hydrogen.py
@@ -4,6 +4,8 @@
 This example shows how to work with the Hydrogen radial wavefunctions.
 """
 
+from __future__ import division, print_function
+
 from sympy import Eq, Integral, oo, pprint, symbols
 from sympy.physics.hydrogen import R_nl
 

--- a/examples/advanced/pidigits.py
+++ b/examples/advanced/pidigits.py
@@ -6,6 +6,8 @@ Example shows arbitrary precision using mpmath with the
 computation of the digits of pi.
 """
 
+from __future__ import division, print_function
+
 from mpmath import libmp, pi
 from mpmath import functions as mpf_funs
 

--- a/examples/advanced/pyglet_plotting.py
+++ b/examples/advanced/pyglet_plotting.py
@@ -6,6 +6,7 @@ Plotting Examples
 Suggested Usage:    python -i plotting.py
 """
 
+from __future__ import division, print_function
 
 from sympy import symbols
 from sympy.plotting.pygletplot import PygletPlot

--- a/examples/advanced/qft.py
+++ b/examples/advanced/qft.py
@@ -15,6 +15,8 @@ SymPy, but that's a long journey.
 
 """
 
+from __future__ import division, print_function
+
 from sympy import Basic, exp, Symbol, sin, Rational, I, Mul, Matrix, \
     ones, sqrt, pprint, simplify, Eq, sympify
 

--- a/examples/advanced/relativity.py
+++ b/examples/advanced/relativity.py
@@ -13,6 +13,8 @@ something is not clear, like what the Ricci tensor is, etc.
 
 """
 
+from __future__ import division, print_function
+
 from sympy import (exp, Symbol, sin, Rational, Derivative, dsolve, Function,
                   Matrix, Eq, pprint, Pow, classify_ode, solve)
 

--- a/examples/all.py
+++ b/examples/all.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
+from __future__ import division, print_function
 
 DESCRIPTION = """
 Runs all the examples for testing purposes and reports successes and failures

--- a/examples/beginner/basic.py
+++ b/examples/beginner/basic.py
@@ -5,6 +5,8 @@
 Demonstrates how to create symbols and print some algebra operations.
 """
 
+from __future__ import division, print_function
+
 import sympy
 from sympy import pprint
 

--- a/examples/beginner/differentiation.py
+++ b/examples/beginner/differentiation.py
@@ -5,6 +5,8 @@
 Demonstrates some differentiation operations.
 """
 
+from __future__ import division, print_function
+
 import sympy
 from sympy import pprint
 

--- a/examples/beginner/expansion.py
+++ b/examples/beginner/expansion.py
@@ -5,6 +5,8 @@
 Demonstrates how to expand expressions.
 """
 
+from __future__ import division, print_function
+
 import sympy
 from sympy import pprint
 

--- a/examples/beginner/functions.py
+++ b/examples/beginner/functions.py
@@ -5,6 +5,8 @@
 Demonstrates sympy defined functions.
 """
 
+from __future__ import division, print_function
+
 import sympy
 from sympy import pprint
 

--- a/examples/beginner/limits_examples.py
+++ b/examples/beginner/limits_examples.py
@@ -5,6 +5,8 @@
 Demonstrates limits.
 """
 
+from __future__ import division, print_function
+
 from sympy import exp, log, Symbol, Rational, sin, limit, sqrt, oo
 
 

--- a/examples/beginner/plot_examples.py
+++ b/examples/beginner/plot_examples.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 # Check the plot docstring
 
+from __future__ import division, print_function
+
 from sympy import Symbol, exp, sin, cos
 from sympy.plotting import (plot, plot_parametric,
                             plot3d_parametric_surface, plot3d_parametric_line,

--- a/examples/beginner/plotting_nice_plot.py
+++ b/examples/beginner/plotting_nice_plot.py
@@ -5,6 +5,8 @@
 Demonstrates simple plotting.
 """
 
+from __future__ import division, print_function
+
 from sympy import Symbol, cos, sin, log, tan
 from sympy.plotting import PygletPlot
 from sympy.abc import x, y

--- a/examples/beginner/precision.py
+++ b/examples/beginner/precision.py
@@ -5,6 +5,8 @@
 Demonstrates SymPy's arbitrary integer precision abilities
 """
 
+from __future__ import division, print_function
+
 import sympy
 from sympy import Mul, Pow, S
 

--- a/examples/beginner/print_pretty.py
+++ b/examples/beginner/print_pretty.py
@@ -5,6 +5,8 @@
 Demonstrates pretty printing.
 """
 
+from __future__ import division, print_function
+
 from sympy import Symbol, pprint, sin, cos, exp, sqrt
 
 

--- a/examples/beginner/series.py
+++ b/examples/beginner/series.py
@@ -5,6 +5,8 @@
 Demonstrates series.
 """
 
+from __future__ import division, print_function
+
 from sympy import Symbol, cos, sin, pprint
 
 

--- a/examples/beginner/substitution.py
+++ b/examples/beginner/substitution.py
@@ -5,6 +5,8 @@
 Demonstrates substitution.
 """
 
+from __future__ import division, print_function
+
 import sympy
 from sympy import pprint
 

--- a/examples/galgebra/eval_check.py
+++ b/examples/galgebra/eval_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols
 from sympy.galgebra import MV, ReciprocalFrame

--- a/examples/galgebra/exp_check.py
+++ b/examples/galgebra/exp_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols, sin, cos
 from sympy.galgebra import MV

--- a/examples/galgebra/latex_check.py
+++ b/examples/galgebra/latex_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import Symbol, symbols, sin, cos, Rational, expand, simplify, collect, S
 from sympy.galgebra import xdvi, Get_Program, Print_Function

--- a/examples/galgebra/manifold_check.py
+++ b/examples/galgebra/manifold_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols, log, simplify, diff, cos, sin
 from sympy.galgebra.ga import MV, ReciprocalFrame

--- a/examples/galgebra/manifold_check_latex.py
+++ b/examples/galgebra/manifold_check_latex.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols, log, simplify, diff, cos, sin
 from sympy.galgebra import MV, ReciprocalFrame, Format

--- a/examples/galgebra/matrix_latex.py
+++ b/examples/galgebra/matrix_latex.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols, Matrix
 from sympy.galgebra import xdvi

--- a/examples/galgebra/mv_setup_options.py
+++ b/examples/galgebra/mv_setup_options.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols
 from sympy.galgebra import MV

--- a/examples/galgebra/physics_check_latex.py
+++ b/examples/galgebra/physics_check_latex.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols, sin, cos
 from sympy.galgebra import xdvi, Get_Program, Print_Function

--- a/examples/galgebra/print_check_latex.py
+++ b/examples/galgebra/print_check_latex.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import sin, cos, sinh, cosh, symbols, expand, simplify
 from sympy.galgebra import xdvi

--- a/examples/galgebra/prob_not_solenoidal.py
+++ b/examples/galgebra/prob_not_solenoidal.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols, sin, cos, factor_terms, simplify
 from sympy.galgebra import enhance_print

--- a/examples/galgebra/products_latex.py
+++ b/examples/galgebra/products_latex.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols
 from sympy.galgebra import MV, Format

--- a/examples/galgebra/simple_check.py
+++ b/examples/galgebra/simple_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols, sin, cos, simplify
 from sympy.galgebra.ga import MV

--- a/examples/galgebra/simple_check_latex.py
+++ b/examples/galgebra/simple_check_latex.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy.galgebra import xdvi, Get_Program, Print_Function
 from sympy.galgebra import MV, Format

--- a/examples/galgebra/spherical_latex.py
+++ b/examples/galgebra/spherical_latex.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import symbols, sin, cos
 from sympy.galgebra import MV, Format

--- a/examples/galgebra/terminal_check.py
+++ b/examples/galgebra/terminal_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy import Symbol, symbols, sin, cos, Rational, expand, simplify, collect, S
 from sympy.galgebra import enhance_print, Get_Program, Print_Function

--- a/examples/intermediate/coupled_cluster.py
+++ b/examples/intermediate/coupled_cluster.py
@@ -7,6 +7,8 @@ T. Daniel Crawford and Henry F. Schaefer III.
 http://www.ccc.uga.edu/lec_top/cc/html/review.html
 """
 
+from __future__ import division, print_function
+
 from sympy.physics.secondquant import (AntiSymmetricTensor, wicks,
         F, Fd, NO, evaluate_deltas, substitute_dummies, Commutator,
         simplify_index_permutations, PermutationOperator)

--- a/examples/intermediate/differential_equations.py
+++ b/examples/intermediate/differential_equations.py
@@ -6,6 +6,8 @@ Demonstrates solving 1st and 2nd degree linear ordinary differential
 equations.
 """
 
+from __future__ import division, print_function
+
 from sympy import dsolve, Eq, Function, sin, Symbol
 
 

--- a/examples/intermediate/infinite_1d_box.py
+++ b/examples/intermediate/infinite_1d_box.py
@@ -6,6 +6,8 @@ of the infinite 1D box of width ``a`` with a perturbation
 which is linear in ``x``, up to second order in perturbation
 """
 
+from __future__ import division, print_function
+
 from sympy.core import pi
 from sympy import Integral, var, S
 from sympy.functions import sin, sqrt

--- a/examples/intermediate/mplot2d.py
+++ b/examples/intermediate/mplot2d.py
@@ -5,6 +5,8 @@
 Demonstrates plotting with matplotlib.
 """
 
+from __future__ import division, print_function
+
 import sys
 
 from sample import sample

--- a/examples/intermediate/mplot3d.py
+++ b/examples/intermediate/mplot3d.py
@@ -5,6 +5,8 @@
 Demonstrates plotting with matplotlib.
 """
 
+from __future__ import division, print_function
+
 import sys
 
 from sample import sample

--- a/examples/intermediate/partial_differential_eqs.py
+++ b/examples/intermediate/partial_differential_eqs.py
@@ -5,6 +5,8 @@
 Demonstrates various ways to solve partial differential equations
 """
 
+from __future__ import division, print_function
+
 from sympy import symbols, Eq, Function, pde_separate, pprint, sin, cos, latex
 from sympy import Derivative as D
 

--- a/examples/intermediate/print_gtk.py
+++ b/examples/intermediate/print_gtk.py
@@ -5,6 +5,8 @@
 Demonstrates printing with gtkmathview using mathml
 """
 
+from __future__ import division, print_function
+
 from sympy import Integral, Limit, print_gtk, sin, Symbol
 
 

--- a/examples/intermediate/sample.py
+++ b/examples/intermediate/sample.py
@@ -5,6 +5,8 @@ See examples\mplot2d.py and examples\mplot3d.py for usable 2d and 3d
 graphing functions using matplotlib.
 """
 
+from __future__ import division, print_function
+
 from sympy.core.sympify import sympify, SympifyError
 from sympy.external import import_module
 np = import_module('numpy')

--- a/examples/intermediate/trees.py
+++ b/examples/intermediate/trees.py
@@ -12,6 +12,8 @@ and paste in the sequence returned by this script:
 and it will shows you the A000055
 """
 
+from __future__ import division, print_function
+
 from sympy import Symbol, Poly
 
 

--- a/examples/intermediate/vandermonde.py
+++ b/examples/intermediate/vandermonde.py
@@ -6,6 +6,8 @@ Demonstrates matrix computations using the Vandermonde matrix.
   * http://en.wikipedia.org/wiki/Vandermonde_matrix
 """
 
+from __future__ import division, print_function
+
 from sympy import Matrix, pprint, Rational, sqrt, symbols, Symbol, zeros
 from sympy.core.compatibility import range
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ Or, if all else fails, feel free to write to the sympy list at
 sympy@googlegroups.com and ask for help.
 """
 
+from __future__ import division, print_function
+
 import sys
 import subprocess
 import os

--- a/setupegg.py
+++ b/setupegg.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 import setuptools
 
 exec(open('setup.py').read())

--- a/sympy/assumptions/__init__.py
+++ b/sympy/assumptions/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from .assume import AppliedPredicate, Predicate, AssumptionsContext, assuming
 from .ask import Q, ask, register_handler, remove_handler
 from .refine import refine

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -1,5 +1,6 @@
 """Module for querying SymPy objects about assumptions."""
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import sympify
 from sympy.core.cache import cacheit
@@ -166,7 +167,8 @@ def ask(proposition, assumptions=True, context=global_assumptions):
 
     # See if there's a straight-forward conclusion we can make for the inference
     if local_facts.is_Atom:
-        if key in known_facts_dict[local_facts]:
+        if key in known_facts_dict[local_facts]:from __future__ import print_function, division
+
             return True
         if Not(key) in known_facts_dict[local_facts]:
             return False
@@ -270,6 +272,8 @@ def compute_known_facts(known_facts, known_facts_keys):
     Do NOT manually edit this file.
     Instead, run ./bin/ask_update.py.
     """
+
+    from __future__ import division, print_function
 
     from sympy.core.cache import cacheit
     from sympy.logic.boolalg import And, Not, Or

--- a/sympy/assumptions/ask_generated.py
+++ b/sympy/assumptions/ask_generated.py
@@ -6,6 +6,8 @@ Do NOT manually edit this file.
 Instead, run ./bin/ask_update.py.
 """
 
+from __future__ import division, print_function
+
 from sympy.core.cache import cacheit
 from sympy.logic.boolalg import And, Not, Or
 from sympy.assumptions.ask import Q

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import inspect
 from sympy.core.cache import cacheit

--- a/sympy/assumptions/handlers/__init__.py
+++ b/sympy/assumptions/handlers/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import division, print_function
+
 from .common import (AskHandler, CommonHandler, AskCommutativeHandler,
     TautologicalHandler, test_closed_group)

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -2,7 +2,8 @@
 This module contains query handlers responsible for calculus queries:
 infinitesimal, finite, etc.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.logic.boolalg import conjuncts
 from sympy.assumptions import Q, ask

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.logic import _fuzzy_group
 from sympy.logic.boolalg import conjuncts
 from sympy.assumptions import Q, ask

--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -2,7 +2,8 @@
 This module contains query handlers responsible for calculus queries:
 infinitesimal, bounded, etc.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.logic.boolalg import conjuncts
 from sympy.assumptions import Q, ask

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -1,7 +1,8 @@
 """
 Handlers for keys related to number theory: prime, even, odd, etc.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -1,7 +1,8 @@
 """
 AskHandlers related to order relations: positive, negative, etc.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -1,7 +1,8 @@
 """
 Handlers for predicates related to set membership: integer, rational, etc.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler, test_closed_group

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, Add, Expr, Basic
 from sympy.assumptions import Q, ask

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import oo, Tuple
 

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from collections import MutableMapping, defaultdict
 

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -1,6 +1,9 @@
 """
 rename this to test_assumptions.py when the old assumptions system is deleted
 """
+
+from __future__ import division, print_function
+
 from sympy.abc import x, y
 from sympy.assumptions.assume import global_assumptions, Predicate
 from sympy.assumptions.ask import _extract_facts, Q

--- a/sympy/assumptions/tests/test_context.py
+++ b/sympy/assumptions/tests/test_context.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.assumptions import ask, Q
 from sympy.assumptions.assume import assuming, global_assumptions
 from sympy.abc import x, y

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Q, ask, Symbol
 from sympy.matrices.expressions import (MatrixSymbol, Identity, ZeroMatrix,
         Trace, MatrixSlice, Determinant)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.abc import t, w, x, y, z, n, k, m, p, i
 from sympy.assumptions import (ask, AssumptionsContext, Q, register_handler,
         remove_handler)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (Abs, exp, Expr, I, pi, Q, Rational, refine, S, sqrt,
                    atan, atan2)
 from sympy.abc import x, y, z

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.assumptions.satask import satask
 
 from sympy import symbols, Q, assuming, Implies, MatrixSymbol, I, pi, Rational

--- a/sympy/assumptions/tests/test_sathandlers.py
+++ b/sympy/assumptions/tests/test_sathandlers.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Mul, Basic, Q, Expr, And, symbols, Equivalent, Implies, Or
 
 from sympy.assumptions.sathandlers import (ClassFactRegistry, AllArgs,

--- a/sympy/benchmarks/bench_meijerint.py
+++ b/sympy/benchmarks/bench_meijerint.py
@@ -1,5 +1,6 @@
 # conceal the implicit import from the code quality tester
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 exec("from sympy import *")
 

--- a/sympy/benchmarks/bench_symbench.py
+++ b/sympy/benchmarks/bench_symbench.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-from __future__ import print_function, division
+
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 
 from random import random

--- a/sympy/calculus/__init__.py
+++ b/sympy/calculus/__init__.py
@@ -2,6 +2,8 @@
 SymPy modules tree.
 """
 
+from __future__ import division, print_function
+
 from .euler import euler_equations
 from .singularities import singularities
 from .finite_diff import finite_diff_weights, apply_finite_diff, as_finite_diff

--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Function, sympify, diff, Eq, S, Symbol, Derivative
 from sympy.core.compatibility import (
     combinations_with_replacement, iterable, range)

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -17,6 +17,8 @@ for:
 
 """
 
+from __future__ import division, print_function
+
 from sympy import S
 from sympy.core.compatibility import iterable, range
 

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.solvers import solve
 from sympy.simplify import simplify
 

--- a/sympy/calculus/tests/test_euler.py
+++ b/sympy/calculus/tests/test_euler.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Symbol, Function, Derivative as D, Eq, cos, sin
 from sympy.utilities.pytest import raises
 from sympy.calculus.euler import euler_equations as euler

--- a/sympy/calculus/tests/test_finite_diff.py
+++ b/sympy/calculus/tests/test_finite_diff.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 from sympy import S, symbols, Function
 from sympy.calculus.finite_diff import (

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Symbol, exp, log
 from sympy.calculus.singularities import singularities
 

--- a/sympy/categories/__init__.py
+++ b/sympy/categories/__init__.py
@@ -17,6 +17,8 @@ from
 
 """
 
+from __future__ import division, print_function
+
 from .baseclasses import (Object, Morphism, IdentityMorphism,
                          NamedMorphism, CompositeMorphism, Category,
                          Diagram)

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, Basic, Dict, Symbol, Tuple
 from sympy.core.compatibility import range, iterable

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -82,7 +82,8 @@ References
 [Xypic] http://xy-pic.sourceforge.net/
 
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import Dict, Symbol
 from sympy.sets import FiniteSet

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.categories import (Object, Morphism, IdentityMorphism,
                               NamedMorphism, CompositeMorphism,
                               Diagram, Category)

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.categories.diagram_drawing import _GrowableGrid, ArrowStringDescription
 from sympy.categories import (DiagramGrid, Object, NamedMorphism,
                               Diagram, XypicDiagramDrawer, xypic_draw_diagram)

--- a/sympy/combinatorics/__init__.py
+++ b/sympy/combinatorics/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.combinatorics.permutations import Permutation, Cycle
 from sympy.combinatorics.prufer import Prufer
 from sympy.combinatorics.generators import cyclic, alternating, symmetric, dihedral

--- a/sympy/combinatorics/generators.py
+++ b/sympy/combinatorics/generators.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.combinatorics.permutations import Permutation
 from sympy.utilities.iterables import variations, rotate_left

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Basic
 from sympy.core.compatibility import range

--- a/sympy/combinatorics/group_constructs.py
+++ b/sympy/combinatorics/group_constructs.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.combinatorics.permutations import Permutation

--- a/sympy/combinatorics/named_groups.py
+++ b/sympy/combinatorics/named_groups.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 from sympy.combinatorics.perm_groups import PermutationGroup

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Basic, Dict, sympify
 from sympy.core.compatibility import as_int, default_sort_key, range

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from random import randrange, choice
 from math import log

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import random
 from collections import defaultdict

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Basic, Tuple
 from sympy.sets import FiniteSet

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Basic
 from sympy.core.compatibility import iterable, as_int, range

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from itertools import combinations
 

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Permutation, _af_rmul, \

--- a/sympy/combinatorics/tests/test_generators.py
+++ b/sympy/combinatorics/tests/test_generators.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.combinatorics.generators import symmetric, cyclic, alternating, dihedral
 from sympy.combinatorics.permutations import Permutation
 

--- a/sympy/combinatorics/tests/test_graycode.py
+++ b/sympy/combinatorics/tests/test_graycode.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.combinatorics.graycode import (GrayCode, bin_to_gray,
     random_bitstring, get_subset_from_bitstring, graycode_subsets)
 

--- a/sympy/combinatorics/tests/test_group_constructs.py
+++ b/sympy/combinatorics/tests/test_group_constructs.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.combinatorics.group_constructs import DirectProduct
 from sympy.combinatorics.named_groups import CyclicGroup, DihedralGroup
 

--- a/sympy/combinatorics/tests/test_named_groups.py
+++ b/sympy/combinatorics/tests/test_named_groups.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.combinatorics.named_groups import (SymmetricGroup, CyclicGroup,
 DihedralGroup, AlternatingGroup, AbelianGroup)
 

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 from sympy.combinatorics.partitions import (Partition, IntegerPartition,
                                             RGS_enum, RGS_unrank, RGS_rank,

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.combinatorics.named_groups import SymmetricGroup, CyclicGroup,\

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from itertools import permutations
 
 from sympy.core.compatibility import range

--- a/sympy/combinatorics/tests/test_polyhedron.py
+++ b/sympy/combinatorics/tests/test_polyhedron.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 from sympy import symbols, FiniteSet
 from sympy.combinatorics.polyhedron import (Polyhedron,

--- a/sympy/combinatorics/tests/test_prufer.py
+++ b/sympy/combinatorics/tests/test_prufer.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.combinatorics.prufer import Prufer
 from sympy.utilities.pytest import raises
 

--- a/sympy/combinatorics/tests/test_subsets.py
+++ b/sympy/combinatorics/tests/test_subsets.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.combinatorics import Subset
 
 

--- a/sympy/combinatorics/tests/test_tensor_can.py
+++ b/sympy/combinatorics/tests/test_tensor_can.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Permutation, Perm
 from sympy.combinatorics.tensor_can import (perm_af_direct_product, dummy_sgs,

--- a/sympy/combinatorics/tests/test_testutil.py
+++ b/sympy/combinatorics/tests/test_testutil.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.combinatorics.named_groups import SymmetricGroup, AlternatingGroup,\
     CyclicGroup
 from sympy.combinatorics.testutil import _verify_bsgs, _cmp_perm_lists,\

--- a/sympy/combinatorics/tests/test_util.py
+++ b/sympy/combinatorics/tests/test_util.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 from sympy.combinatorics.named_groups import SymmetricGroup, DihedralGroup,\
     AlternatingGroup

--- a/sympy/combinatorics/testutil.py
+++ b/sympy/combinatorics/testutil.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 from sympy.combinatorics.util import _distribute_gens_by_base

--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.ntheory import isprime
 from sympy.combinatorics.permutations import Permutation, _af_invert, _af_rmul

--- a/sympy/concrete/__init__.py
+++ b/sympy/concrete/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import division, print_function
+
 from .products import product, Product
 from .summations import summation, Sum

--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Add, Mul, S, Dummy
 from sympy.core.cache import cacheit

--- a/sympy/concrete/expr_with_intlimits.py
+++ b/sympy/concrete/expr_with_intlimits.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.concrete.expr_with_limits import ExprWithLimits
 from sympy.core.singleton import S

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.add import Add
 from sympy.core.expr import Expr

--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -1,5 +1,6 @@
 """Gosper's algorithm for hypergeometric summation. """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import S, Dummy, symbols
 from sympy.core.compatibility import is_sequence, range

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.mul import Mul
 from sympy.core.singleton import S

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.concrete.expr_with_intlimits import ExprWithIntLimits

--- a/sympy/concrete/tests/test_delta.py
+++ b/sympy/concrete/tests/test_delta.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.concrete import Sum
 from sympy.concrete.delta import deltaproduct as dp, deltasummation as ds
 from sympy.core import Eq, S, symbols, oo

--- a/sympy/concrete/tests/test_gosper.py
+++ b/sympy/concrete/tests/test_gosper.py
@@ -1,5 +1,7 @@
 """Tests for Gosper's algorithm for hypergeometric summation. """
 
+from __future__ import division, print_function
+
 from sympy import binomial, factorial, gamma, Poly, S, simplify, sqrt, exp, log, Symbol, pi
 from sympy.abc import a, b, j, k, m, n, r, x
 from sympy.concrete.gosper import gosper_normal, gosper_sum, gosper_term

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (symbols, Symbol, product, factorial, rf, sqrt, cos,
                    Function, Product, Rational, Sum, oo, exp, log, S)
 from sympy.utilities.pytest import raises

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     Abs, And, binomial, Catalan, cos, Derivative, E, Eq, exp, EulerGamma,
     factorial, Function, harmonic, I, Integral, KroneckerDelta, log,

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -1,6 +1,8 @@
 """Core module. Provides the basic operations needed in sympy.
 """
 
+from __future__ import division, print_function
+
 from .sympify import sympify, SympifyError
 from .cache import cacheit
 from .basic import Basic, Atom, preorder_traversal

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from collections import defaultdict
 

--- a/sympy/core/alphabets.py
+++ b/sympy/core/alphabets.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 greeks = ('alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta',
                     'eta', 'theta', 'iota', 'kappa', 'lambda', 'mu', 'nu',

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -148,7 +148,8 @@ References
 .. [11] http://en.wikipedia.org/wiki/Algebraic_number
 
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core.facts import FactRules, FactKB
 from sympy.core.core import BasicMeta

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,5 +1,6 @@
 """Base class for all the objects in SymPy"""
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit

--- a/sympy/core/benchmarks/bench_arit.py
+++ b/sympy/core/benchmarks/bench_arit.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Add, Mul, symbols
 

--- a/sympy/core/benchmarks/bench_assumptions.py
+++ b/sympy/core/benchmarks/bench_assumptions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Symbol, Integer
 

--- a/sympy/core/benchmarks/bench_basic.py
+++ b/sympy/core/benchmarks/bench_basic.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import symbols, S
 

--- a/sympy/core/benchmarks/bench_expand.py
+++ b/sympy/core/benchmarks/bench_expand.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import symbols, I
 

--- a/sympy/core/benchmarks/bench_numbers.py
+++ b/sympy/core/benchmarks/bench_numbers.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.numbers import Integer, Rational, integer_nthroot, igcd
 from sympy import S, pi, oo

--- a/sympy/core/benchmarks/bench_sympify.py
+++ b/sympy/core/benchmarks/bench_sympify.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import sympify, Symbol
 

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -1,5 +1,6 @@
 """ Caching facility for SymPy """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from distutils.version import LooseVersion as V
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -3,7 +3,8 @@ Reimplementations of constructs introduced in later versions of Python than
 we support. Also some functions that are needed SymPy-wide and are located
 here for easy import.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 import operator
 from collections import defaultdict

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -6,7 +6,7 @@
     They are supposed to work seamlessly within the SymPy framework.
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, range

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -1,5 +1,6 @@
 """ The core's core. """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 # used for canonical ordering of symbolic sequences
 # via __cmp__ method:

--- a/sympy/core/coreerrors.py
+++ b/sympy/core/coreerrors.py
@@ -1,6 +1,6 @@
 """Definitions of common exceptions for :mod:`sympy.core` module. """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 
 class BaseCoreError(Exception):

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -5,7 +5,7 @@ The purpose of this module is to expose decorators without any other
 dependencies, so that they can be easily imported anywhere in sympy/core.
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from functools import wraps
 from .sympify import SympifyError, sympify

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -2,7 +2,8 @@
 Adaptive numerical evaluation of SymPy expressions, using mpmath
 for mathematical functions.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 import math
 

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from .cache import clear_cache
 from contextlib import contextmanager
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from .sympify import sympify, _sympify, SympifyError
 from .basic import Basic, Atom

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1,6 +1,6 @@
 """Tools for manipulating of large commutative expressions. """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.add import Add
 from sympy.core.compatibility import iterable, is_sequence, SYMPY_INTS, range

--- a/sympy/core/facts.py
+++ b/sympy/core/facts.py
@@ -47,7 +47,8 @@ http://en.wikipedia.org/wiki/Propositional_formula
 http://en.wikipedia.org/wiki/Inference_rule
 http://en.wikipedia.org/wiki/List_of_rules_of_inference
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from collections import defaultdict
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -29,7 +29,8 @@ There are three types of functions implemented in SymPy:
     (x,)
 
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from .add import Add
 from .assumptions import ManagedProperties

--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -6,7 +6,8 @@ NOTE
 at present this is mainly needed for facts.py , feel free however to improve
 this stuff for general purpose.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from .function import Function
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from collections import defaultdict
 import operator

--- a/sympy/core/multidimensional.py
+++ b/sympy/core/multidimensional.py
@@ -3,7 +3,8 @@ Provides functionality for multidimensional usage of scalar-functions.
 
 Read the vectorize docstring for more details.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core.decorators import wraps
 from sympy.core.compatibility import range

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import decimal
 import fractions

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.sympify import _sympify, sympify
 from sympy.core.basic import Basic, _aresame

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from math import log as _log
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from .basic import S
 from .compatibility import ordered

--- a/sympy/core/rules.py
+++ b/sympy/core/rules.py
@@ -2,7 +2,7 @@
 Replacement rules.
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 
 class Transform(object):

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -1,6 +1,6 @@
 """Singleton mechanism"""
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from .core import Registry
 from .assumptions import ManagedProperties

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.assumptions import StdFactKB
 from sympy.core.compatibility import string_types, range

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -1,6 +1,6 @@
 """sympify -- convert objects SymPy internal format"""
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from inspect import getmro
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1,5 +1,7 @@
 """Test whether all elements of cls.args are instances of Basic. """
 
+from __future__ import division, print_function
+
 # NOTE: keep tests sorted by (module, class name) key. If a class can't
 # be instantiated, add it here anyway with @SKIP("abstract class) (see
 # e.g. Function).

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 
 from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, Integer,

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import I, sqrt, log, exp, sin, asin, factorial
 from sympy.core import Symbol, S, Rational, Integer, Dummy, Wild, Pow
 from sympy.core.facts import InconsistentAssumptions

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -1,6 +1,8 @@
 """This tests sympy/core/basic.py with (ideally) no reference to subclasses
 of Basic or Atom."""
 
+from __future__ import division, print_function
+
 from sympy.core.basic import Basic, Atom, preorder_traversal
 from sympy.core.singleton import S, Singleton
 from sympy.core.symbol import symbols

--- a/sympy/core/tests/test_cache.py
+++ b/sympy/core/tests/test_cache.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.cache import cacheit
 
 

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.compatibility import default_sort_key, as_int, ordered, iterable
 from sympy.core.singleton import S
 from sympy.utilities.pytest import raises

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (S, Symbol, sqrt, I, Integer, Rational, cos, sin, im, re, Abs,
         exp, sinh, cosh, tan, tanh, conjugate, sign, cot, coth, pi, symbols,
         expand_complex)

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet, Integer
 from sympy.core.containers import tuple_wrapper
 from sympy.utilities.pytest import raises

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
     count_ops, S, And, I, pi, Eq, Or, Not, Xor, Nand, Nor, Implies, \
     Equivalent, MatrixSymbol, Symbol, ITE

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Symbol, Rational, cos, sin, tan, cot, exp, log, Function, \
     Derivative, Expr, symbols, pi, I, S
 from sympy.utilities.pytest import raises

--- a/sympy/core/tests/test_equal.py
+++ b/sympy/core/tests/test_equal.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Symbol, Dummy, Rational, exp
 
 

--- a/sympy/core/tests/test_eval.py
+++ b/sympy/core/tests/test_eval.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Symbol, Function, exp, sqrt, Rational, I, cos, tan
 from sympy.utilities.pytest import XFAIL
 

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import (
     Rational, Symbol, S, Float, Integer, Number, Pow,
     Basic, I, nan, pi, symbols, oo, zoo)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factorial,
                    fibonacci, floor, Function, GoldenRatio, I, Integral,
                    integrate, log, Mul, N, oo, pi, Pow, product, Product,

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.abc import x, y
 from sympy.core.evaluate import evaluate
 from sympy.core import Mul, Add

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (log, sqrt, Rational as R, Symbol, I, exp, pi, S,
     cos, sin, Mul, Pow, O)
 from sympy.simplify.radsimp import expand_numer

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 
 from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
     sin, cos, tan, exp, log, nan, oo, sqrt, symbols, Integral, sympify,

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -1,5 +1,7 @@
 """Tests for tools for manipulating of large commutative expressions. """
 
+from __future__ import division, print_function
+
 from sympy import (S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple, I,
                    Interval, O, symbols, simplify, collect, Sum, Basic, Dict,
                    root, exp, cos, sin, oo, Dummy, log)

--- a/sympy/core/tests/test_facts.py
+++ b/sympy/core/tests/test_facts.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.facts import (deduce_alpha_implications,
         apply_beta_to_alpha_route, rules_2prereq, FactRules, FactKB)
 from sympy.core.logic import And, Not

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         E, expand, pi, O, Sum, S, polygamma, loggamma, expint,

--- a/sympy/core/tests/test_logic.py
+++ b/sympy/core/tests/test_logic.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.logic import (fuzzy_not, Logic, And, Or, Not, fuzzy_and,
     fuzzy_or, _fuzzy_group)
 from sympy.utilities.pytest import raises

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (abc, Add, cos, Derivative, diff, exp, Float, Function,
     I, Integer, log, Mul, oo, Poly, Rational, S, sin, sqrt, Symbol, symbols,
     Wild, pi, meijerg

--- a/sympy/core/tests/test_noncommutative.py
+++ b/sympy/core/tests/test_noncommutative.py
@@ -1,5 +1,7 @@
 """Tests for noncommutative symbols and expressions."""
 
+from __future__ import division, print_function
+
 from sympy import (
     adjoint,
     cancel,

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 import decimal
 from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Integer, S
 from sympy.core.operations import LatticeOp
 from sympy.utilities.pytest import raises

--- a/sympy/core/tests/test_priority.py
+++ b/sympy/core/tests/test_priority.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Expr, Symbol
 from sympy.core.decorators import call_highest_priority
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
                    Implies, Xor, zoo, sqrt, Rational, simplify, Function)

--- a/sympy/core/tests/test_rules.py
+++ b/sympy/core/tests/test_rules.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.rules import Transform
 
 from sympy.utilities.pytest import raises

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -1,4 +1,5 @@
-from __future__ import division
+from __future__ import division, print_function
+
 from sympy import (Symbol, Wild, sin, cos, exp, sqrt, pi, Function, Derivative,
         abc, Integer, Eq, symbols, Add, I, Float, log, Rational, Lambda, atan2,
         cse, cot, tan, S, Tuple, Basic, Dict, Piecewise, oo, Mul,

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (Symbol, Wild, GreaterThan, LessThan, StrictGreaterThan,
     StrictLessThan, pi, I, Rational, sympify, symbols, Dummy
 )

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
     Function, I, S, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,
     Pow, Or, true, false, Abs, pi)

--- a/sympy/core/tests/test_trace.py
+++ b/sympy/core/tests/test_trace.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import symbols, Matrix, Tuple
 from sympy.core.trace import Tr
 from sympy.utilities.pytest import raises

--- a/sympy/core/tests/test_truediv.py
+++ b/sympy/core/tests/test_truediv.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 
 #this module tests that sympy works with true division turned on
 

--- a/sympy/core/tests/test_var.py
+++ b/sympy/core/tests/test_var.py
@@ -1,5 +1,7 @@
 # Tests for var are in their own file, because var pollutes global namespace.
 
+from __future__ import division, print_function
+
 from sympy import Symbol, var, Function, FunctionClass
 from sympy.utilities.pytest import raises
 

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -6,6 +6,8 @@ See also http://math.unm.edu/~wester/cas_review.html for detailed output of
 each tested system.
 """
 
+from __future__ import division, print_function
+
 from sympy import (Rational, symbols, factorial, sqrt, log, exp, oo, zoo,
     product, binomial, rf, pi, gamma, igcd, factorint, radsimp, combsimp,
     npartitions, totient, primerange, factor, simplify, gcd, resultant, expand,

--- a/sympy/core/trace.py
+++ b/sympy/core/trace.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import Expr, Add, Mul, Pow, sympify, Matrix, Tuple
 from sympy.core.compatibility import range

--- a/sympy/crypto/__init__.py
+++ b/sympy/crypto/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.crypto.crypto import (alphabet_of_cipher, cycle_list,
       encipher_shift, encipher_affine, encipher_substitution,
       encipher_vigenere, decipher_vigenere,

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -4,7 +4,7 @@
 Classical ciphers and LFSRs
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from random import randrange
 

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import symbols
 from sympy.core.compatibility import range
 from sympy.crypto.crypto import (alphabet_of_cipher, cycle_list,

--- a/sympy/deprecated/__init__.py
+++ b/sympy/deprecated/__init__.py
@@ -9,4 +9,6 @@ Since no modules in SymPy ever depend on deprecated code, SymPy always imports
 this last, after all other modules have been imported.
 """
 
+from __future__ import division, print_function
+
 from sympy.deprecated.class_registry import C, ClassRegistry

--- a/sympy/deprecated/class_registry.py
+++ b/sympy/deprecated/class_registry.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.decorators import deprecated
 from sympy.core.core import BasicMeta, Registry, all_classes
 

--- a/sympy/deprecated/tests/test_class_registry.py
+++ b/sympy/deprecated/tests/test_class_registry.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.deprecated.class_registry import C
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.pytest import raises

--- a/sympy/diffgeom/__init__.py
+++ b/sympy/diffgeom/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from .diffgeom import (
     BaseCovarDerivativeOp, BaseScalarField, BaseVectorField, Commutator,
     contravariant_order, CoordSystem, CovarDerivativeOp, covariant_order,

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from itertools import permutations
 

--- a/sympy/diffgeom/rn.py
+++ b/sympy/diffgeom/rn.py
@@ -8,7 +8,7 @@ as attributes of the coordinate systems (eg `R2_r.x` and `R2_p.theta`), or by
 using the usual `coord_sys.coord_function(index, name)` interface.
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from .diffgeom import Manifold, Patch, CoordSystem
 from sympy import sqrt, atan2, acos, sin, cos, Dummy

--- a/sympy/diffgeom/tests/test_class_structure.py
+++ b/sympy/diffgeom/tests/test_class_structure.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.diffgeom import Manifold, Patch, CoordSystem, Point
 from sympy import symbols, Function
 

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r, R3_c, R3_s
 from sympy.diffgeom import (Commutator, Differential, TensorProduct,
         WedgeProduct, BaseCovarDerivativeOp, CovarDerivativeOp, LieDerivative,

--- a/sympy/diffgeom/tests/test_function_diffgeom_book.py
+++ b/sympy/diffgeom/tests/test_function_diffgeom_book.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.diffgeom.rn import R2, R2_p, R2_r, R3_r
 from sympy.diffgeom import intcurve_series, Differential, WedgeProduct
 from sympy.core import symbols, Function, Derivative

--- a/sympy/diffgeom/tests/test_hyperbolic_space.py
+++ b/sympy/diffgeom/tests/test_hyperbolic_space.py
@@ -12,6 +12,9 @@ It has constant negative scalar curvature = -2
 
 https://en.wikipedia.org/wiki/Poincare_half-plane_model
 '''
+
+from __future__ import division, print_function
+
 from sympy import diag
 from sympy.diffgeom import (twoform_to_matrix,
                             metric_to_Christoffel_1st, metric_to_Christoffel_2nd,

--- a/sympy/external/__init__.py
+++ b/sympy/external/__init__.py
@@ -15,4 +15,6 @@ import_module() for more information.
 
 """
 
+from __future__ import division, print_function
+
 from sympy.external.importtools import import_module

--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -1,6 +1,6 @@
 """Tools to assist importing optional external modules."""
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import sys
 

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import symbols, Eq
 from sympy.external import import_module
 from sympy.tensor import IndexedBase, Idx

--- a/sympy/external/tests/test_codegen.py
+++ b/sympy/external/tests/test_codegen.py
@@ -21,7 +21,7 @@
 # incorporation in various projects. The tests below assume that the binary cc
 # is somewhere in the path and that it can compile ANSI C code.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import skip

--- a/sympy/external/tests/test_importtools.py
+++ b/sympy/external/tests/test_importtools.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.external import import_module
 
 # fixes issue that arose in addressing issue 6533

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -5,7 +5,7 @@
 # Python (without numpy). Here we test everything, that a user may need when
 # using SymPy with NumPy
 
-from __future__ import division
+from __future__ import division, print_function
 
 from sympy.external import import_module
 

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -15,6 +15,8 @@
 # Python (without Sage). Here we test everything, that a user may need when
 # using SymPy with Sage.
 
+from __future__ import division, print_function
+
 import os
 import re
 import sys

--- a/sympy/external/tests/test_scipy.py
+++ b/sympy/external/tests/test_scipy.py
@@ -5,6 +5,8 @@
 # Python (without scipy). Here we test everything, that a user may need when
 # using SymPy with SciPy
 
+from __future__ import division, print_function
+
 from sympy.external import import_module
 
 scipy = import_module('scipy')

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -5,6 +5,8 @@ Elementary - hyperbolic, trigonometric, exponential, floor and ceiling, sqrt...
 Special - gamma, zeta,spherical harmonics...
 """
 
+from __future__ import division, print_function
+
 from sympy.functions.combinatorial.factorials import (factorial, factorial2,
         rf, ff, binomial, RisingFactorial, FallingFactorial, subfactorial)
 from sympy.functions.combinatorial.numbers import (fibonacci, lucas, harmonic,

--- a/sympy/functions/combinatorial/__init__.py
+++ b/sympy/functions/combinatorial/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import division, print_function
+
 from . import factorials
 from . import numbers

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, sympify, Dummy
 from sympy.core.function import Function, ArgumentIndexError

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -7,7 +7,7 @@ Factorials, binomial coefficients and related functions are located in
 the separate 'factorials' module.
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, Symbol, Rational, Integer, Add, Dummy
 from sympy.core.compatibility import as_int, SYMPY_INTS, range

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (S, Symbol, symbols, factorial, factorial2, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func, Product)

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 import string
 
 from sympy import (

--- a/sympy/functions/elementary/__init__.py
+++ b/sympy/functions/elementary/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from . import complexes
 from . import exponential
 from . import hyperbolic

--- a/sympy/functions/elementary/benchmarks/bench_exp.py
+++ b/sympy/functions/elementary/benchmarks/bench_exp.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import exp, symbols
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, Add, Mul, sympify, Symbol, Dummy
 from sympy.core.compatibility import u

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import sympify
 from sympy.core.add import Add

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, sympify, cacheit
 from sympy.core.function import Function, ArgumentIndexError, _coeff_isneg

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.singleton import S
 from sympy.core.function import Function

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, sympify
 from sympy.core.add import Add

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Basic, S, Function, diff, Tuple
 from sympy.core.relational import Equality, Relational

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     Abs, adjoint, arg, atan2, conjugate, cos, DiracDelta, E, exp, expand,
     Expr, Function, Heaviside, I, im, log, nan, oo, pi, Rational, re, S,

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     symbols, log, ln, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
     LambertW, sqrt, Rational, expand_log, S, sign, conjugate,

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import symbols, Symbol, sinh, nan, oo, zoo, pi, asinh, acosh, log, sqrt, \
     coth, I, cot, E, tanh, tan, cosh, cos, S, sin, Rational, atanh, acoth, \
     Integer, O, exp, sech, sec, csch, asech, acos, expand_mul

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Symbol, floor, nan, oo, E, symbols, ceiling, pi, Rational, \
     Float, I, sin, exp, log, factorial, frac
 

--- a/sympy/functions/elementary/tests/test_interface.py
+++ b/sympy/functions/elementary/tests/test_interface.py
@@ -1,5 +1,8 @@
 # This test file tests the SymPy function interface, that people use to create
 # their own new functions. It should be as easy as possible.
+
+from __future__ import division, print_function
+
 from sympy import Function, sympify, sin, cos, limit, tanh
 from sympy.abc import x
 

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.function import Function
 from sympy.core.numbers import I, oo, Rational
 from sympy.core.singleton import S

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     adjoint, And, Basic, conjugate, diff, expand, Eq, Function, I,
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, pi, atan,
         acos, Rational, sqrt, asin, acot, coth, E, S, tan, tanh, cos,
         cosh, atan2, exp, log, asinh, acoth, atanh, O, cancel, Matrix, re, im,

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.add import Add
 from sympy.core.basic import sympify, cacheit

--- a/sympy/functions/special/__init__.py
+++ b/sympy/functions/special/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from . import gamma_functions
 from . import error_functions
 from . import zeta_functions

--- a/sympy/functions/special/benchmarks/bench_special.py
+++ b/sympy/functions/special/benchmarks/bench_special.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import symbols
 from sympy.functions.special.spherical_harmonics import Ynm

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import S, pi, I, Rational, Wild, cacheit, sympify
 from sympy.core.function import Function, ArgumentIndexError

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.functions.special.gamma_functions import gamma, digamma

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, sympify
 from sympy.core.compatibility import range

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, sympify, diff
 from sympy.core.function import Function, ArgumentIndexError

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -1,6 +1,6 @@
 """ Elliptic integrals. """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, pi, I
 from sympy.core.function import Function, ArgumentIndexError

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1,7 +1,7 @@
 """ This module contains various functions that are special cases
     of incomplete gamma functions. It should probably be renamed. """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Add, S, sympify, cacheit, pi, I
 from sympy.core.function import Function, ArgumentIndexError

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Add, S, sympify, oo, pi, Dummy
 from sympy.core.function import Function, ArgumentIndexError

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -1,6 +1,6 @@
 """Hypergeometric and Meijer G-functions"""
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, I, pi, oo, ilcm, Mod
 from sympy.core.function import Function, Derivative, ArgumentIndexError

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -6,7 +6,7 @@ combinatorial polynomials.
 
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.singleton import S
 from sympy.core import Rational

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import pi, I
 from sympy.core.singleton import S

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.function import Function
 from sympy.core import S, Integer

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (jn, yn, symbols, Symbol, sin, cos, pi, S, jn_zeros, besselj,
                    bessely, besseli, besselk, hankel1, hankel2, expand_func,
                    sqrt, sinh, cosh, diff, series, gamma, hyper, Abs, I, O, oo,

--- a/sympy/functions/special/tests/test_beta_functions.py
+++ b/sympy/functions/special/tests/test_beta_functions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (Symbol, gamma, expand_func, beta, digamma, diff)
 
 

--- a/sympy/functions/special/tests/test_bsplines.py
+++ b/sympy/functions/special/tests/test_bsplines.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.functions import bspline_basis_set
 from sympy.core.compatibility import range
 from sympy import Piecewise, Interval

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     adjoint, conjugate, DiracDelta, Heaviside, nan, pi, sign, sqrt,
     symbols, transpose, Symbol, Piecewise, I, S, Eq

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (S, Symbol, pi, I, oo, zoo, sin, sqrt, tan, gamma,
     atanh, hyper, meijerg, O)
 from sympy.functions.special.elliptic_integrals import (elliptic_k as K,

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     symbols, expand, expand_func, nan, oo, Float, conjugate, diff,
     re, im, Abs, O, exp_polar, polar_lift, gruntz, limit,

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     Symbol, gamma, I, oo, nan, zoo, factorial, sqrt, Rational, log,
     polygamma, EulerGamma, pi, uppergamma, S, expand_func, loggamma, sin,

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (hyper, meijerg, S, Tuple, pi, I, exp, log,
                    cos, sqrt, symbols, oo, Derivative, gamma, O)
 from sympy.series.limits import limit

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     Symbol, Dummy, diff, Derivative, Rational, roots, S, sqrt, hyper,
     cos, gamma, conjugate, factorial, pi, oo, zoo, binomial, RisingFactorial,

--- a/sympy/functions/special/tests/test_spherical_harmonics.py
+++ b/sympy/functions/special/tests/test_spherical_harmonics.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Symbol, sqrt, pi, sin, cos, cot, exp, I, diff, conjugate
 from sympy.functions.special.spherical_harmonics import Ynm, Znm, Ynm_c
 

--- a/sympy/functions/special/tests/test_tensor_functions.py
+++ b/sympy/functions/special/tests/test_tensor_functions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     adjoint, conjugate, Dummy, Eijk, KroneckerDelta, LeviCivita, Symbol,
     symbols, transpose,

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log,
                    zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I,
                    exp_polar, polar_lift, O, stieltjes)

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -1,5 +1,6 @@
 """ Riemann zeta and related function. """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import Function, S, sympify, pi
 from sympy.core.function import ArgumentIndexError

--- a/sympy/galgebra/__init__.py
+++ b/sympy/galgebra/__init__.py
@@ -2,6 +2,9 @@
 A module for geometric algebra
 
 """
+
+from __future__ import division, print_function
+
 from sympy.galgebra.ga import MV, Com, DD, Format, Nga, ReciprocalFrame, ScalarFunction, \
     cross, dual, ga_print_off, ga_print_on, inv, proj, refl, rot, rotor
 

--- a/sympy/galgebra/debug.py
+++ b/sympy/galgebra/debug.py
@@ -1,6 +1,6 @@
 # sympy/galgebra/debug.py
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from itertools import islice
 

--- a/sympy/galgebra/ga.py
+++ b/sympy/galgebra/ga.py
@@ -21,7 +21,7 @@ For more information on the details of geometric algebra please look
 at the documentation for the module.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from sympy.core.compatibility import reduce
 from itertools import combinations

--- a/sympy/galgebra/manifold.py
+++ b/sympy/galgebra/manifold.py
@@ -15,7 +15,7 @@ versions of the code will allow manifolds defined purely in terms of
 a metric.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from itertools import combinations
 from os import system

--- a/sympy/galgebra/ncutil.py
+++ b/sympy/galgebra/ncutil.py
@@ -9,6 +9,8 @@ also contains "half_angle_reduce" which is probably not needed any more
 due to the improvements in trigsimp.
 """
 
+from __future__ import division, print_function
+
 from sympy import expand, Mul, Add, Symbol, S, Pow, diff, trigsimp, \
     simplify, sin, cos, symbols
 from sympy.core.compatibility import range

--- a/sympy/galgebra/precedence.py
+++ b/sympy/galgebra/precedence.py
@@ -8,7 +8,7 @@ operation.  The default precedence used (high to low) is <,>, and | have
 an have the highest precedence, then comes ^, and finally *.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import re as regrep
 from sympy.core.compatibility import range

--- a/sympy/galgebra/printing.py
+++ b/sympy/galgebra/printing.py
@@ -26,7 +26,7 @@ multivector functions, and multivector derivatives to print out
 in different colors on ansi terminals.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys

--- a/sympy/galgebra/stringarrays.py
+++ b/sympy/galgebra/stringarrays.py
@@ -6,6 +6,8 @@ input to vector and multivector class function to arrays of SymPy
 symbols.
 """
 
+from __future__ import division, print_function
+
 import operator
 
 from sympy.core.compatibility import reduce

--- a/sympy/galgebra/tests/test_ga.py
+++ b/sympy/galgebra/tests/test_ga.py
@@ -4,6 +4,8 @@
 The reference D&L is "Geometric Algebra for Physicists" by Doran and Lasenby
 """
 
+from __future__ import division, print_function
+
 from sympy.core import expand, Rational, S, Symbol, symbols
 from sympy.core.compatibility import range
 from sympy.functions import sin, cos

--- a/sympy/galgebra/vector.py
+++ b/sympy/galgebra/vector.py
@@ -6,6 +6,8 @@ vectors and metric and calulates derivatives of the basis vectors for
 the MV class.
 """
 
+from __future__ import division, print_function
+
 import itertools
 import copy
 

--- a/sympy/geometry/__init__.py
+++ b/sympy/geometry/__init__.py
@@ -16,6 +16,9 @@ Examples
 ========
 
 """
+
+from __future__ import division, print_function
+
 from sympy.geometry.point import Point, Point2D, Point3D
 from sympy.geometry.line import Line, Ray, Segment
 from sympy.geometry.line3d import Line3D, Segment3D, Ray3D

--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -6,7 +6,7 @@ Curve
 
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import sympify
 from sympy.core.compatibility import is_sequence

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -6,7 +6,7 @@ Contains
 
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, sympify, pi
 from sympy.core.logic import fuzzy_bool

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -20,7 +20,7 @@ R3 are currently the only ambient spaces implemented.
 
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple

--- a/sympy/geometry/exceptions.py
+++ b/sympy/geometry/exceptions.py
@@ -1,6 +1,6 @@
 """Geometry Errors."""
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 
 class GeometryError(ValueError):

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -8,7 +8,8 @@ Ray
 Segment
 
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import S, sympify, Dummy
 from sympy.core.exprtools import factor_terms

--- a/sympy/geometry/line3d.py
+++ b/sympy/geometry/line3d.py
@@ -8,7 +8,8 @@ Ray3D
 Segment3D
 
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import S, Dummy, nan
 from sympy.functions.elementary.trigonometric import acos

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -5,7 +5,8 @@ Contains
 Plane
 
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import S, Dummy, Symbol, Rational
 from sympy.core.compatibility import is_sequence

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -8,7 +8,7 @@ Point3D
 
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, sympify
 from sympy.core.compatibility import iterable, range

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Expr, S, sympify, oo, pi, Symbol
 from sympy.core.compatibility import as_int, range

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -1,4 +1,5 @@
-from __future__ import division
+from __future__ import division, print_function
+
 import warnings
 
 from sympy import (Abs, I, Dummy, Rational, Float, S, Symbol, cos, oo, pi,

--- a/sympy/geometry/tests/test_geometrysets.py
+++ b/sympy/geometry/tests/test_geometrysets.py
@@ -1,4 +1,5 @@
-from __future__ import division
+from __future__ import division, print_function
+
 import warnings
 
 from sympy import (Abs, I, Dummy, Rational, Float, S, Symbol, cos, oo, pi,

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -8,7 +8,8 @@ are_coplanar
 are_similar
 
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy import Symbol, Function, solve
 from sympy.core.compatibility import string_types, is_sequence, range

--- a/sympy/integrals/__init__.py
+++ b/sympy/integrals/__init__.py
@@ -10,6 +10,9 @@
     >>> integrate(sin(x),x)
     -cos(x)
 """
+
+from __future__ import division, print_function
+
 from .integrals import integrate, Integral, line_integrate
 from .transforms import (mellin_transform, inverse_mellin_transform,
                         MellinTransform, InverseMellinTransform,

--- a/sympy/integrals/benchmarks/bench_integrate.py
+++ b/sympy/integrals/benchmarks/bench_integrate.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import integrate, Symbol, sin
 

--- a/sympy/integrals/benchmarks/bench_trigintegrate.py
+++ b/sympy/integrals/benchmarks/bench_trigintegrate.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import Symbol, sin
 from sympy.integrals.trigonometry import trigintegrate

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Mul
 from sympy.functions import DiracDelta, Heaviside

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from itertools import permutations
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.core.add import Add

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -16,7 +16,8 @@ match, add the key and call to the antiderivative function to integral_steps.
 To enable simple substitutions, add the match to find_substitutions.
 
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from collections import namedtuple
 

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -25,7 +25,8 @@ The main references for this are:
     Integrals and Series: More Special Functions, Vol. 3,.
     Gordon and Breach Science Publisher
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import oo, S, pi, Expr
 from sympy.core.exprtools import factor_terms

--- a/sympy/integrals/meijerint_doc.py
+++ b/sympy/integrals/meijerint_doc.py
@@ -1,7 +1,7 @@
 """ This module cooks up a docstring when imported. Its only purpose is to
     be displayed in the sphinx documentation. """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.integrals.meijerint import _create_lookup_table
 from sympy import latex, Eq, Add, Symbol

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -14,7 +14,8 @@ right hand side of the equation (i.e., gi in k(t)), and Q is a list of terms on
 the right hand side of the equation (i.e., qi in k[t]).  See the docstring of
 each function for more information.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core import Dummy, ilcm, Add, Mul, Pow, S
 

--- a/sympy/integrals/quadrature.py
+++ b/sympy/integrals/quadrature.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S, Dummy, pi
 from sympy.functions.combinatorial.factorials import factorial

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -1,6 +1,6 @@
 """This module implements tools for integrating rational functions. """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import S, Symbol, symbols, I, log, atan, \
     roots, RootSum, Lambda, cancel, Dummy

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -20,7 +20,8 @@ k[t].
 See Chapter 6 of "Symbolic Integration I: Transcendental Functions" by
 Manuel Bronstein.  See also the docstring of risch.py.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from operator import mul
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -23,7 +23,8 @@ which case it will just return a Poly in t, or in k(t), in which case it
 will return the fraction (fa, fd). Other variable names probably come
 from the names used in Bronstein's book.
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy import real_roots
 from sympy.abc import z

--- a/sympy/integrals/tests/test_deltafunctions.py
+++ b/sympy/integrals/tests/test_deltafunctions.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 from sympy import cos, DiracDelta, Heaviside, Function, pi, S, sin, symbols
 from sympy.integrals.deltafunctions import change_mul, deltaintegrate

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -1,6 +1,6 @@
 # A collection of failing integrals from the issues.
 
-from __future__ import division
+from __future__ import division, print_function
 
 from sympy import (
     integrate, Integral, exp, oo, pi, sign, sqrt, sin, cos,

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, erf, tan, asin, asinh, acos, Function, Derivative, diff, simplify, \
     LambertW, Eq, Piecewise, Symbol, Add, ratsimp, Integral, Sum, \

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (
     Abs, acos, acosh, Add, asin, asinh, atan, Ci, cos, sinh, cosh, tanh,
     Derivative, diff, DiracDelta, E, exp, erf, erfi, EulerGamma, factor, Function,

--- a/sympy/integrals/tests/test_lineintegrals.py
+++ b/sympy/integrals/tests/test_lineintegrals.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import symbols, E, ln, Curve, line_integrate, sqrt
 
 s, t, x, y, z = symbols('s,t,x,y,z')

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Integral, integrate, pi, Dummy, Derivative,
                    diff, I, sqrt, erf, Piecewise, Eq, symbols,

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (meijerg, I, S, integrate, Integral, oo, gamma, cosh,
                    hyperexpand, exp, simplify, sqrt, pi, erf, sin, cos,
                    exp_polar, polygamma, hyper, log, expand_func)

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -1,4 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
+
+from __future__ import division, print_function
+
 from sympy import Poly, Matrix, S, symbols
 from sympy.integrals.risch import DifferentialExtension
 from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,

--- a/sympy/integrals/tests/test_quadrature.py
+++ b/sympy/integrals/tests/test_quadrature.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import S
 from sympy.integrals.quadrature import (gauss_legendre, gauss_laguerre,
                                         gauss_hermite, gauss_gen_laguerre,

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import S, symbols, I, atan, log, Poly, sqrt, simplify, integrate
 
 from sympy.integrals.rationaltools import ratint, ratint_logpart, log_to_atan

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -1,4 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
+
+from __future__ import division, print_function
+
 from sympy import Poly, S, symbols, oo, I
 from sympy.integrals.risch import (DifferentialExtension,
     NonElementaryIntegralException)

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1,4 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
+
+from __future__ import division, print_function
+
 from sympy import (Poly, I, S, Function, log, symbols, exp, tan, sqrt,
     Symbol, Lambda, sin, Eq, Piecewise, factor)
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.integrals.transforms import (mellin_transform,
     inverse_mellin_transform, laplace_transform, inverse_laplace_transform,
     fourier_transform, inverse_fourier_transform,

--- a/sympy/integrals/tests/test_trigonometry.py
+++ b/sympy/integrals/tests/test_trigonometry.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import Eq, Rational, Symbol
 from sympy.functions import sin, cos, tan, csc, sec, cot, log, Piecewise
 from sympy.integrals.trigonometry import trigintegrate

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1,6 +1,6 @@
 """ Integral Transforms """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import S
 from sympy.core.compatibility import reduce, range

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 from sympy.core import cacheit, Dummy, Eq, Integer, Rational, S, Wild

--- a/sympy/interactive/__init__.py
+++ b/sympy/interactive/__init__.py
@@ -1,4 +1,6 @@
 """Helper module for setting up interactive SymPy sessions. """
 
+from __future__ import division, print_function
+
 from .printing import init_printing
 from .session import init_session

--- a/sympy/interactive/ipythonprinting.py
+++ b/sympy/interactive/ipythonprinting.py
@@ -26,7 +26,7 @@ notebook.
 # Imports
 #-----------------------------------------------------------------------------
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import warnings
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -1,6 +1,6 @@
 """Tools for setting up printing in interactive sessions. """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import sys
 from distutils.version import LooseVersion as V

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -1,6 +1,6 @@
 """Tools for setting up interactive sessions. """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from distutils.version import LooseVersion as V
 

--- a/sympy/interactive/tests/test_interactive.py
+++ b/sympy/interactive/tests/test_interactive.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 import sys
 
 from sympy.interactive.session import int_to_Integer

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -1,5 +1,7 @@
 """Tests of tools for setting up interactive IPython sessions. """
 
+from __future__ import division, print_function
+
 from sympy.interactive.session import (init_ipython_session,
     enable_automatic_symbols, enable_automatic_int_sympification)
 

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -1,5 +1,7 @@
 """Tests that the IPython printing module is properly loaded. """
 
+from __future__ import division, print_function
+
 from sympy.core.compatibility import u
 from sympy.interactive.session import init_ipython_session
 from sympy.external import import_module

--- a/sympy/liealgebras/__init__.py
+++ b/sympy/liealgebras/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType

--- a/sympy/liealgebras/cartan_matrix.py
+++ b/sympy/liealgebras/cartan_matrix.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from .cartan_type import CartanType
 
 def CartanMatrix(ct):

--- a/sympy/liealgebras/cartan_type.py
+++ b/sympy/liealgebras/cartan_type.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Basic
 

--- a/sympy/liealgebras/dynkin_diagram.py
+++ b/sympy/liealgebras/dynkin_diagram.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from .cartan_type import CartanType
 
 

--- a/sympy/liealgebras/root_system.py
+++ b/sympy/liealgebras/root_system.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
 from .cartan_type import CartanType
 from sympy.core import Basic
 from sympy.core.compatibility import range

--- a/sympy/liealgebras/tests/test_cartan_matrix.py
+++ b/sympy/liealgebras/tests/test_cartan_matrix.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_matrix import CartanMatrix
 from sympy.matrices import Matrix
 

--- a/sympy/liealgebras/tests/test_cartan_type.py
+++ b/sympy/liealgebras/tests/test_cartan_type.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType, Standard_Cartan
 
 def test_Standard_Cartan():

--- a/sympy/liealgebras/tests/test_dynkin_diagram.py
+++ b/sympy/liealgebras/tests/test_dynkin_diagram.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.dynkin_diagram import DynkinDiagram
 
 def test_DynkinDiagram():

--- a/sympy/liealgebras/tests/test_root_system.py
+++ b/sympy/liealgebras/tests/test_root_system.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.root_system import RootSystem
 from sympy.liealgebras.type_a import TypeA
 from sympy.matrices import Matrix

--- a/sympy/liealgebras/tests/test_type_A.py
+++ b/sympy/liealgebras/tests/test_type_A.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.matrices import Matrix
 

--- a/sympy/liealgebras/tests/test_type_B.py
+++ b/sympy/liealgebras/tests/test_type_B.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.matrices import Matrix
 

--- a/sympy/liealgebras/tests/test_type_C.py
+++ b/sympy/liealgebras/tests/test_type_C.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.matrices import Matrix
 

--- a/sympy/liealgebras/tests/test_type_D.py
+++ b/sympy/liealgebras/tests/test_type_D.py
@@ -1,6 +1,7 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.matrices import Matrix
-
 
 
 def test_type_D():

--- a/sympy/liealgebras/tests/test_type_E.py
+++ b/sympy/liealgebras/tests/test_type_E.py
@@ -1,6 +1,9 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.core.compatibility import range
 from sympy.matrices import Matrix
+
 
 def test_type_E():
     c = CartanType("E6")

--- a/sympy/liealgebras/tests/test_type_F.py
+++ b/sympy/liealgebras/tests/test_type_F.py
@@ -1,7 +1,9 @@
-from __future__ import division
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.core.compatibility import range
 from sympy.matrices import Matrix
+
 
 def test_type_F():
     c = CartanType("F4")

--- a/sympy/liealgebras/tests/test_type_G.py
+++ b/sympy/liealgebras/tests/test_type_G.py
@@ -1,6 +1,10 @@
 # coding=utf-8
+
+from __future__ import division, print_function
+
 from sympy.liealgebras.cartan_type import CartanType
 from sympy.matrices import Matrix
+
 
 def test_type_G():
     c = CartanType("G2")

--- a/sympy/liealgebras/tests/test_weyl_group.py
+++ b/sympy/liealgebras/tests/test_weyl_group.py
@@ -1,5 +1,8 @@
+from __future__ import division, print_function
+
 from sympy.liealgebras.weyl_group import WeylGroup
 from sympy.matrices import Matrix
+
 
 def test_weyl_group():
     c = WeylGroup("A3")

--- a/sympy/liealgebras/type_a.py
+++ b/sympy/liealgebras/type_a.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 from sympy.liealgebras.cartan_type import Standard_Cartan

--- a/sympy/liealgebras/type_b.py
+++ b/sympy/liealgebras/type_b.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from .cartan_type import Standard_Cartan
 from sympy.core.compatibility import range

--- a/sympy/liealgebras/type_c.py
+++ b/sympy/liealgebras/type_c.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from .cartan_type import Standard_Cartan
 from sympy.core.compatibility import range
 from sympy.matrices import eye

--- a/sympy/liealgebras/type_d.py
+++ b/sympy/liealgebras/type_d.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from .cartan_type import Standard_Cartan
 from sympy.matrices import eye
 from sympy.core.compatibility import range

--- a/sympy/liealgebras/type_e.py
+++ b/sympy/liealgebras/type_e.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import Rational
 from sympy.core.compatibility import range
 from .cartan_type import Standard_Cartan

--- a/sympy/liealgebras/type_f.py
+++ b/sympy/liealgebras/type_f.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import Rational
 from sympy.core.compatibility import range
 from .cartan_type import Standard_Cartan

--- a/sympy/liealgebras/type_g.py
+++ b/sympy/liealgebras/type_g.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import division, print_function
+
 from .cartan_type import Standard_Cartan
 from sympy.matrices import Matrix
 

--- a/sympy/liealgebras/weyl_group.py
+++ b/sympy/liealgebras/weyl_group.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import division, print_function
+
 from sympy.core import Basic, Rational
 from sympy.core.compatibility import range
 from sympy.core.numbers import igcd

--- a/sympy/logic/__init__.py
+++ b/sympy/logic/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from .boolalg import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor, Implies,
     Equivalent, ITE, POSform, SOPform, simplify_logic,
     bool_equal, bool_map, true, false)

--- a/sympy/logic/algorithms/dpll.py
+++ b/sympy/logic/algorithms/dpll.py
@@ -7,7 +7,8 @@ References:
   - http://en.wikipedia.org/wiki/DPLL_algorithm
   - http://bioinformatics.louisville.edu/ouyang/MingOuyangThesis.pdf
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 from sympy import default_sort_key

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -8,7 +8,8 @@ Features:
 References:
   - http://en.wikipedia.org/wiki/DPLL_algorithm
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from collections import defaultdict
 from heapq import heappush, heappop

--- a/sympy/logic/benchmarks/run-solvers.py
+++ b/sympy/logic/benchmarks/run-solvers.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 from sympy.logic.utilities import load_file

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1,7 +1,8 @@
 """
 Boolean algebra module for SymPy
 """
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from collections import defaultdict
 from itertools import combinations, product

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -1,5 +1,6 @@
 """Inference in propositional logic"""
-from __future__ import print_function, division
+
+from __future__ import division, print_function
 
 from sympy.logic.boolalg import And, Not, conjuncts, to_cnf
 from sympy.core.compatibility import ordered

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (symbols, Dummy, simplify, Equality, S, Interval,
                    oo, EmptySet, Q)
 from sympy.logic.boolalg import (

--- a/sympy/logic/tests/test_dimacs.py
+++ b/sympy/logic/tests/test_dimacs.py
@@ -3,6 +3,8 @@ You can find lots of cnf files in
 ftp://dimacs.rutgers.edu/pub/challenge/satisfiability/benchmarks/cnf/
 """
 
+from __future__ import division, print_function
+
 from sympy.logic.utilities.dimacs import load
 from sympy.logic.algorithms.dpll import dpll_satisfiable
 

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,5 +1,7 @@
 """For more tests on satisfiability, see test_dimacs"""
 
+from __future__ import division, print_function
+
 from sympy import symbols, Q
 from sympy.core.compatibility import range
 from sympy.logic.boolalg import And, Implies, Equivalent, true, false

--- a/sympy/logic/utilities/__init__.py
+++ b/sympy/logic/utilities/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import division, print_function
+
 from .dimacs import load_file

--- a/sympy/logic/utilities/dimacs.py
+++ b/sympy/logic/utilities/dimacs.py
@@ -4,7 +4,7 @@ www.cs.ubc.ca/~hoos/SATLIB/Benchmarks/SAT/satformat.ps
 
 """
 
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Symbol
 from sympy.logic.boolalg import And, Or

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -3,6 +3,9 @@
 Includes functions for fast creating matrices like zero, one/eye, random
 matrix, etc.
 """
+
+from __future__ import division, print_function
+
 from .matrices import (DeferredVector, ShapeError, NonSquareMatrixError,
     MatrixBase)
 

--- a/sympy/matrices/benchmarks/bench_matrix.py
+++ b/sympy/matrices/benchmarks/bench_matrix.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import eye, zeros, Integer
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import random
 

--- a/sympy/matrices/densearith.py
+++ b/sympy/matrices/densearith.py
@@ -4,7 +4,10 @@ as a list of lists.
 
 """
 
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
+
 
 def add(matlist1, matlist2, K):
     """
@@ -35,6 +38,7 @@ def add(matlist1, matlist2, K):
     addrow
     """
     return [addrow(row1, row2, K) for row1, row2 in zip(matlist1, matlist2)]
+
 
 def addrow(row1, row2, K):
     """

--- a/sympy/matrices/densesolve.py
+++ b/sympy/matrices/densesolve.py
@@ -5,11 +5,14 @@ The dense matrix is stored as a list of lists.
 
 """
 
+from __future__ import division, print_function
+
 from sympy.matrices.densetools import col, eye, augment
 from sympy.matrices.densetools import rowadd, rowmul, conjugate_transpose
 from sympy import sqrt, var
 from sympy.core.compatibility import range
 import copy
+
 
 def row_echelon(matlist, K):
     """

--- a/sympy/matrices/densetools.py
+++ b/sympy/matrices/densetools.py
@@ -4,6 +4,8 @@ The dense matrix is stored as a list of lists
 
 """
 
+from __future__ import division, print_function
+
 from sympy.core.compatibility import range
 
 

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -1,5 +1,7 @@
 """ A module which handles Matrix Expressions """
 
+from __future__ import division, print_function
+
 from .slice import MatrixSlice
 from .blockmatrix import BlockMatrix, BlockDiagMatrix, block_collapse, blockcut
 from .funcmatrix import FunctionMatrix

--- a/sympy/matrices/expressions/adjoint.py
+++ b/sympy/matrices/expressions/adjoint.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Basic
 from sympy.functions import adjoint, conjugate

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import ask, Q
 from sympy.core import Basic, Add, sympify

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import Basic, Expr, S, sympify
 from .matexpr import ShapeError

--- a/sympy/matrices/expressions/diagonal.py
+++ b/sympy/matrices/expressions/diagonal.py
@@ -1,7 +1,8 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.matrices.expressions import MatrixExpr
 from sympy.core import S
+
 
 class DiagonalMatrix(MatrixExpr):
     arg = property(lambda self: self.args[0])
@@ -9,6 +10,7 @@ class DiagonalMatrix(MatrixExpr):
 
     def _entry(self, i, j):
         return S.Zero if i != j else self.arg[i, 0]
+
 
 class DiagonalOf(MatrixExpr):
     arg = property(lambda self: self.args[0])

--- a/sympy/matrices/expressions/factorizations.py
+++ b/sympy/matrices/expressions/factorizations.py
@@ -1,7 +1,8 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.matrices.expressions import MatrixExpr
 from sympy import Q
+
 
 class Factorization(MatrixExpr):
     arg = property(lambda self: self.args[0])

--- a/sympy/matrices/expressions/fourier.py
+++ b/sympy/matrices/expressions/fourier.py
@@ -1,7 +1,8 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.matrices.expressions import MatrixExpr
 from sympy import S, I, sqrt, exp
+
 
 class DFT(MatrixExpr):
     """ Discrete Fourier Transform """

--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from .matexpr import MatrixExpr
 from sympy import Basic, sympify

--- a/sympy/matrices/expressions/hadamard.py
+++ b/sympy/matrices/expressions/hadamard.py
@@ -1,9 +1,10 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Mul, sympify
 from sympy.strategies import unpack, flatten, condition, exhaust, do_one
 
 from sympy.matrices.expressions.matexpr import MatrixExpr, ShapeError
+
 
 def hadamard_product(*matrices):
     """
@@ -68,6 +69,7 @@ class HadamardProduct(MatrixExpr):
     def doit(self, **ignored):
         return canonicalize(self)
 
+
 def validate(*args):
     if not all(arg.is_Matrix for arg in args):
         raise TypeError("Mix of Matrix and Scalar symbols")
@@ -76,8 +78,10 @@ def validate(*args):
         if A.shape != B.shape:
             raise ShapeError("Matrices %s and %s are not aligned" % (A, B))
 
+
 rules = (unpack,
          flatten)
+
 
 canonicalize = exhaust(condition(lambda x: isinstance(x, HadamardProduct),
                                  do_one(*rules)))

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.sympify import _sympify
 from sympy.core import S, Basic

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import reduce
 from operator import add

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from functools import wraps
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import Number
 from sympy.core import Mul, Basic, sympify, Add

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from .matexpr import MatrixExpr, ShapeError, Identity
 from sympy.core.sympify import _sympify

--- a/sympy/matrices/expressions/slice.py
+++ b/sympy/matrices/expressions/slice.py
@@ -1,8 +1,9 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.matrices.expressions.matexpr  import MatrixExpr
 from sympy import Tuple, Basic
 from sympy.functions.elementary.integers import floor
+
 
 def normalize(i, parentsize):
     if isinstance(i, slice):
@@ -28,6 +29,7 @@ def normalize(i, parentsize):
         raise IndexError()
 
     return (start, stop, step)
+
 
 class MatrixSlice(MatrixExpr):
     """ A MatrixSlice of a Matrix Expression

--- a/sympy/matrices/expressions/tests/test_adjoint.py
+++ b/sympy/matrices/expressions/tests/test_adjoint.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import symbols, S
 from sympy.functions import adjoint, conjugate, transpose
 from sympy.matrices.expressions import MatrixSymbol, Adjoint, trace, Transpose

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.matrices.expressions.blockmatrix import (block_collapse, bc_matmul,
         bc_block_plus_ident, BlockDiagMatrix, BlockMatrix, bc_dist, bc_matadd,
         bc_transpose, blockcut, reblock_2x2, deblock)

--- a/sympy/matrices/expressions/tests/test_determinant.py
+++ b/sympy/matrices/expressions/tests/test_determinant.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import S, symbols
 from sympy.matrices import eye, Matrix, ShapeError
 from sympy.matrices.expressions import (

--- a/sympy/matrices/expressions/tests/test_diagonal.py
+++ b/sympy/matrices/expressions/tests/test_diagonal.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.matrices.expressions import MatrixSymbol
 from sympy.matrices.expressions.diagonal import DiagonalMatrix, DiagonalOf
 from sympy import Symbol, ask, Q

--- a/sympy/matrices/expressions/tests/test_factorizations.py
+++ b/sympy/matrices/expressions/tests/test_factorizations.py
@@ -1,5 +1,8 @@
+from __future__ import division, print_function
+
 from sympy.matrices.expressions.factorizations import lu, LofCholesky, qr, svd
 from sympy import Symbol, MatrixSymbol, ask, Q
+
 
 n = Symbol('n')
 X = MatrixSymbol('X', n, n)

--- a/sympy/matrices/expressions/tests/test_fourier.py
+++ b/sympy/matrices/expressions/tests/test_fourier.py
@@ -1,7 +1,11 @@
+from __future__ import division, print_function
+
 from sympy import S, I, ask, Q, Abs, simplify, exp, sqrt
 from sympy.matrices.expressions.fourier import DFT, IDFT
 from sympy.matrices import det, Matrix, Identity
 from sympy.abc import n, i, j
+
+
 def test_dft():
     assert DFT(4).shape == (4, 4)
     assert ask(Q.unitary(DFT(4)))

--- a/sympy/matrices/expressions/tests/test_funcmatrix.py
+++ b/sympy/matrices/expressions/tests/test_funcmatrix.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy import (symbols, FunctionMatrix, MatrixExpr, Lambda, Matrix)
 
 

--- a/sympy/matrices/expressions/tests/test_hadamard.py
+++ b/sympy/matrices/expressions/tests/test_hadamard.py
@@ -1,8 +1,11 @@
+from __future__ import division, print_function
+
 from sympy.core import symbols
 from sympy.utilities.pytest import raises
 
 from sympy.matrices import ShapeError, MatrixSymbol
 from sympy.matrices.expressions import HadamardProduct, hadamard_product
+
 
 n, m, k = symbols('n,m,k')
 Z = MatrixSymbol('Z', n, n)

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -1,6 +1,9 @@
+from __future__ import division, print_function
+
 from sympy import (symbols, MatrixSymbol, MatPow, BlockMatrix,
         Identity, ZeroMatrix, ImmutableMatrix, eye, Sum)
 from sympy.utilities.pytest import raises
+
 
 k, l, m, n = symbols('k l m n', integer=True)
 i, j = symbols('i j', integer=True)

--- a/sympy/matrices/expressions/tests/test_inverse.py
+++ b/sympy/matrices/expressions/tests/test_inverse.py
@@ -1,8 +1,11 @@
+from __future__ import division, print_function
+
 from sympy.core import symbols
 from sympy.matrices.expressions import MatrixSymbol, Inverse
 from sympy.matrices import eye, Identity, ShapeError
 from sympy.utilities.pytest import raises
 from sympy import refine, Q
+
 
 n, m, l = symbols('n m l', integer=True)
 A = MatrixSymbol('A', n, m)

--- a/sympy/matrices/expressions/tests/test_matadd.py
+++ b/sympy/matrices/expressions/tests/test_matadd.py
@@ -1,9 +1,13 @@
+from __future__ import division, print_function
+
 from sympy.matrices.expressions import MatrixSymbol, MatAdd, MatPow, MatMul
 from sympy.matrices import eye, ImmutableMatrix
 from sympy import Basic
 
+
 X = MatrixSymbol('X', 2, 2)
 Y = MatrixSymbol('Y', 2, 2)
+
 
 def test_sort_key():
     assert MatAdd(Y, X).doit().args == (X, Y)

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import I, symbols, Basic
 from sympy.functions import adjoint, transpose
 from sympy.matrices import (Identity, Inverse, Matrix, MatrixSymbol, ZeroMatrix,
@@ -7,6 +9,7 @@ from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
         MatMul, xxinv, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe
 from sympy import refine, Q
+
 
 n, m, l, k = symbols('n m l k', integer=True)
 A = MatrixSymbol('A', n, m)

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -1,8 +1,11 @@
+from __future__ import division, print_function
+
 from sympy.utilities.pytest import raises
 from sympy.core import symbols, pi, S
 from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix
 from sympy.matrices.expressions import MatPow, MatAdd, MatMul
 from sympy.matrices.expressions.matexpr import ShapeError
+
 
 n, m, l, k = symbols('n m l k', integer=True)
 A = MatrixSymbol('A', n, m)

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import S, symbols, Add, Mul
 from sympy.functions import transpose, sin, cos, sqrt
 from sympy.simplify import simplify
@@ -5,6 +7,7 @@ from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
         Transpose, Adjoint)
 from sympy.utilities.pytest import raises
+
 
 n, m, l, k, p = symbols('n m l k p', integer=True)
 x = symbols('x')

--- a/sympy/matrices/expressions/tests/test_slice.py
+++ b/sympy/matrices/expressions/tests/test_slice.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions import MatrixSymbol
 from sympy.abc import a, b, c, d, k, l, m, n
@@ -9,9 +11,11 @@ from sympy.assumptions import assuming, Q
 X = MatrixSymbol('X', n, m)
 Y = MatrixSymbol('Y', m, k)
 
+
 def test_shape():
     B = MatrixSlice(X, (a, b), (c, d))
     assert B.shape == (b - a, d - c)
+
 
 def test_entry():
     B = MatrixSlice(X, (a, b), (c, d))
@@ -22,13 +26,16 @@ def test_entry():
     assert X[1::2, :][1, 3] == X[1+2, 3]
     assert X[:, 1::2][3, 1] == X[3, 1+2]
 
+
 def test_on_diag():
     assert not MatrixSlice(X, (a, b), (c, d)).on_diag
     assert MatrixSlice(X, (a, b), (a, b)).on_diag
 
+
 def test_inputs():
     assert MatrixSlice(X, 1, (2, 5)) == MatrixSlice(X, (1, 2), (2, 5))
     assert MatrixSlice(X, 1, (2, 5)).shape == (1, 3)
+
 
 def test_slicing():
     assert X[1:5, 2:4] == MatrixSlice(X, (1, 5), (2, 4))
@@ -40,11 +47,13 @@ def test_slicing():
     assert X[2, :] == MatrixSlice(X, 2, (0, m))
     assert X[k, :] == MatrixSlice(X, k, (0, m))
 
+
 def test_exceptions():
     X = MatrixSymbol('x', 10, 20)
     raises(IndexError, lambda: X[0:12, 2])
     raises(IndexError, lambda: X[0:9, 22])
     raises(IndexError, lambda: X[-1:5, 2])
+
 
 @XFAIL
 def test_symmetry():
@@ -53,12 +62,14 @@ def test_symmetry():
     with assuming(Q.symmetric(X)):
         assert Y.T == X[5:, :5]
 
+
 def test_slice_of_slice():
     X = MatrixSymbol('x', 10, 10)
     assert X[2, :][:, 3][0, 0] == X[2, 3]
     assert X[:5, :5][:4, :4] == X[:4, :4]
     assert X[1:5, 2:6][1:3, 2] == X[2:4, 4]
     assert X[1:9:2, 2:6][1:3, 2] == X[3:7:2, 4]
+
 
 def test_negative_index():
     X = MatrixSymbol('x', 10, 10)

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.core import Lambda, S, symbols
 from sympy.concrete import Sum
 from sympy.functions import adjoint, conjugate, transpose
@@ -7,6 +9,7 @@ from sympy.matrices.expressions import (
     ZeroMatrix, trace, MatPow, MatAdd, MatMul
 )
 from sympy.utilities.pytest import raises, XFAIL
+
 
 n = symbols('n', integer=True)
 A = MatrixSymbol('A', n, n)

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -1,8 +1,11 @@
+from __future__ import division, print_function
+
 from sympy.functions import adjoint, conjugate, transpose
 from sympy.matrices.expressions import MatrixSymbol, Adjoint, trace, Transpose
 from sympy.matrices import eye, Matrix
 from sympy import symbols, S
 from sympy import refine, Q
+
 
 n, m, l, k, p = symbols('n m l k p', integer=True)
 A = MatrixSymbol('A', n, m)

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import Basic, Expr, sympify
 from sympy.matrices.matrices import MatrixBase

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -1,9 +1,10 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy import Basic
 from sympy.functions import adjoint, conjugate
 
 from sympy.matrices.expressions.matexpr import MatrixExpr
+
 
 class Transpose(MatrixExpr):
     """
@@ -69,6 +70,7 @@ class Transpose(MatrixExpr):
     def _eval_determinant(self):
         from sympy.matrices.expressions.determinant import det
         return det(self.arg)
+
 
 def transpose(expr):
     """ Matrix transpose """

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core import Basic, Integer, Tuple, Dict, S, sympify
 from sympy.core.sympify import converter as sympify_converter
@@ -12,6 +12,7 @@ from sympy.matrices.expressions import MatrixExpr
 def sympify_matrix(arg):
     return arg.as_immutable()
 sympify_converter[MatrixBase] = sympify_matrix
+
 
 class ImmutableMatrix(MatrixExpr, DenseMatrix):
     """Create an immutable version of a matrix.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import collections
 from sympy.core.add import Add

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 import copy
 from collections import defaultdict

--- a/sympy/matrices/sparsetools.py
+++ b/sympy/matrices/sparsetools.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import division, print_function
 
 from sympy.core.compatibility import range
 from sympy import SparseMatrix

--- a/sympy/matrices/tests/test_densearith.py
+++ b/sympy/matrices/tests/test_densearith.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.matrices.densetools import eye
 from sympy.matrices.densearith import add, sub, mulmatmat, mulmatscaler
 from sympy import ZZ

--- a/sympy/matrices/tests/test_densesolve.py
+++ b/sympy/matrices/tests/test_densesolve.py
@@ -1,6 +1,9 @@
+from __future__ import division, print_function
+
 from sympy.matrices.densesolve import LU_solve, rref_solve, cholesky_solve
 from sympy import Dummy
 from sympy import QQ
+
 
 def test_LU_solve():
     x, y, z = Dummy('x'), Dummy('y'), Dummy('z')

--- a/sympy/matrices/tests/test_densetools.py
+++ b/sympy/matrices/tests/test_densetools.py
@@ -1,6 +1,9 @@
+from __future__ import division, print_function
+
 from sympy.matrices.densetools import trace, transpose
 from sympy.matrices.densetools import eye
 from sympy import ZZ
+
 
 def test_trace():
     a = [[ZZ(3), ZZ(7), ZZ(4)], [ZZ(2), ZZ(4), ZZ(5)], [ZZ(6), ZZ(2), ZZ(3)]]

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,7 +1,10 @@
+from __future__ import division, print_function
+
 from sympy import (ImmutableMatrix, Matrix, eye, zeros, S, Equality,
         Unequality, ImmutableSparseMatrix, SparseMatrix, sympify)
 from sympy.abc import x, y
 from sympy.utilities.pytest import raises
+
 
 IM = ImmutableMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 ieye = ImmutableMatrix(eye(3))

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -5,6 +5,8 @@ Matrix, ImmutableMatrix, MatrixExpr
 Here we test the extent to which they cooperate
 """
 
+from __future__ import division, print_function
+
 from sympy import symbols
 from sympy.matrices import (Matrix, MatrixSymbol, eye, Identity,
         ImmutableMatrix)
@@ -12,6 +14,7 @@ from sympy.core.compatibility import range
 from sympy.matrices.expressions import MatrixExpr, MatAdd
 from sympy.matrices.matrices import classof
 from sympy.utilities.pytest import raises
+
 
 SM = MatrixSymbol('X', 3, 3)
 MM = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 import collections
 
 from sympy import (
@@ -17,6 +19,7 @@ from sympy.utilities.pytest import raises, XFAIL, slow, skip
 from sympy.solvers import solve
 
 from sympy.abc import a, b, c, d, x, y, z
+
 
 # don't re-order this list
 classes = (Matrix, SparseMatrix, ImmutableMatrix, ImmutableSparseMatrix)

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -1,6 +1,9 @@
+from __future__ import division, print_function
+
 from sympy import S, Symbol, I, Rational, PurePoly
 from sympy.matrices import Matrix, SparseMatrix, eye, zeros, ShapeError
 from sympy.utilities.pytest import raises
+
 
 def test_sparse_matrix():
     def sparse_eye(n):

--- a/sympy/matrices/tests/test_sparsetools.py
+++ b/sympy/matrices/tests/test_sparsetools.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function
+
 from sympy.matrices.sparsetools import _doktocsr, _csrtodok
 from sympy import SparseMatrix
 


### PR DESCRIPTION
Here, making the `from __future__ import` lines adhere to a common
standard, namely:

1) Always the same in all pertinent files, so no discussion is required
whether it's needed in a particular file or not. Just boilerplate that
can be copied over and be done with it.

2) Individual items on the import are sorted alphabetically. The
actual order isn't that relevant, but having a fixed order helps
avoid needless discussion, and alphabetical is as good as any.

3) Files in code copied from other projects were not touched. These
follow different rules than SymPy's conventions.
I think this applies to the files in build/ and doc/.
I didn't touch release/ either because it's just a deployment script,
no SymPy code; maybe I should have, just for consistency.
I also left the empty `__init__.py` files as they are.

Since I have been accused of being the master of bikeshedding, I lost
interest in pursuing this further. What remains to be done are the
subdirectories in sympy/ that are alphabetically after matrices/ ;
feel free to take over.
