### PR TITLE
Fixes to some predicates in new assumptions regarding float arguments

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -218,8 +218,8 @@ def register_handler(key, handler):
         ...     # Mersenne numbers are in the form 2**n + 1, n integer
         ...     @staticmethod
         ...     def Integer(expr, assumptions):
-        ...         import math
-        ...         return ask(Q.integer(math.log(expr + 1, 2)))
+        ...         from sympy import log
+        ...         return ask(Q.integer(log(expr + 1, 2)))
         >>> register_handler('mersenne', MersenneHandler)
         >>> ask(Q.mersenne(7))
         True

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -6,7 +6,7 @@ from __future__ import print_function, division
 from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler
 from sympy.ntheory import isprime
-from sympy.core import S
+from sympy.core import S, Float
 
 
 class AskPrimeHandler(CommonHandler):
@@ -30,7 +30,7 @@ class AskPrimeHandler(CommonHandler):
                 raise TypeError
         except TypeError:
             return False
-        return isprime(i)
+        return isprime(expr)
 
     @staticmethod
     def Basic(expr, assumptions):
@@ -120,6 +120,8 @@ class AskEvenHandler(CommonHandler):
                 raise TypeError
         except TypeError:
             return False
+        if isinstance(expr, (float, Float)):
+            return False
         return i % 2 == 0
 
     @staticmethod
@@ -206,10 +208,6 @@ class AskEvenHandler(CommonHandler):
         return not bool(expr.p & 1)
 
     Rational, Infinity, NegativeInfinity, ImaginaryUnit = [staticmethod(CommonHandler.AlwaysFalse)]*4
-
-    @staticmethod
-    def Float(expr, assumptions):
-        return expr % 2 == 0
 
     @staticmethod
     def NumberSymbol(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -84,10 +84,6 @@ class AskIntegerHandler(CommonHandler):
         return False
 
     @staticmethod
-    def Float(expr, assumptions):
-        return int(expr) == expr
-
-    @staticmethod
     def Abs(expr, assumptions):
         return ask(Q.integer(expr.args[0]), assumptions)
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -87,7 +87,7 @@ def test_int_12():
 def test_float_1():
     z = 1.0
     assert ask(Q.commutative(z)) is True
-    assert ask(Q.integer(z)) is True
+    assert ask(Q.integer(z)) is False
     assert ask(Q.rational(z)) is True
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
@@ -96,7 +96,7 @@ def test_float_1():
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
     assert ask(Q.even(z)) is False
-    assert ask(Q.odd(z)) is True
+    assert ask(Q.odd(z)) is False
     assert ask(Q.finite(z)) is True
     assert ask(Q.infinitesimal(z)) is False
     assert ask(Q.prime(z)) is False
@@ -2218,3 +2218,11 @@ def test_check_old_assumption():
     x = symbols('x', irrational=True)
     assert ask(Q.irrational(x)) is True
     assert ask(Q.rational(x)) is False
+
+
+def test_issue_9636():
+    assert ask(Q.integer(1.0)) is False
+    assert ask(Q.prime(3.0)) is False
+    assert ask(Q.composite(4.0)) is False
+    assert ask(Q.even(2.0)) is False
+    assert ask(Q.odd(3.0)) is False

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -204,6 +204,9 @@ def isprime(n):
     sympy.ntheory.generate.prime : Return the nth prime
 
     """
+    from sympy.core.numbers import Float
+    if isinstance(n, (Float, float)):
+        return False
     n = int(n)
     if n < 2:
         return False

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -141,6 +141,7 @@ def test_isprime():
     assert _mr_safe_helper(
         "if n < 3474749660383: return mr(n, [2, 3, 5, 7, 11, 13])") == \
         ' # [2, 3, 5, 7, 11, 13] stot = 7 clear == bases'
+    assert isprime(5.0) is False
 
 
 def test_prime():


### PR DESCRIPTION
Fixes #9636 
- `isprime(Float)` now returns `False`
- `ask(Q.integer(Float))` now returns `False`
- `ask(Q.prime(Float))` now returns `False`
- `ask(Q.composite(Float))` now returns `False`
- `ask(Q.even(Float))` now returns `False`
- `ask(Q.odd(Float))` now returns `False`

`satask` already behaves as expected.

@asmeurer please review.
