### PR TITLE
Simplify ComplexPlane({x}*{y}) to FiniteSet(x + I*y)

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -634,7 +634,18 @@ class ComplexPlane(Set):
 
         # Rectangular Form
         if polar is False:
-            obj = ImageSet.__new__(cls, Lambda((x, y), x + I*y), sets)
+
+            if all(_a.is_FiniteSet and len(_a) == 1 for _a in sets.args) and \
+                  (len(sets.args) == 2):
+
+                # ** Single Element in the Complex Plane. **
+                # For Cases like ComplexPlane({2}*{3}), which
+                # should return {2 + 3*I}
+                complex_num = sets.args[0].args[0] + I*sets.args[1].args[0]
+                obj = FiniteSet(complex_num)
+
+            else:
+                obj = ImageSet.__new__(cls, Lambda((x, y), x + I*y), sets)
 
         # Polar Form
         elif polar is True:

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -635,14 +635,16 @@ class ComplexPlane(Set):
         # Rectangular Form
         if polar is False:
 
-            if all(_a.is_FiniteSet and len(_a) == 1 for _a in sets.args) and \
-                  (len(sets.args) == 2):
+            if all(_a.is_FiniteSet for _a in sets.args) and (len(sets.args) == 2):
 
-                # ** Single Element in the Complex Plane. **
-                # For Cases like ComplexPlane({2}*{3}), which
-                # should return {2 + 3*I}
-                complex_num = sets.args[0].args[0] + I*sets.args[1].args[0]
-                obj = FiniteSet(complex_num)
+                # ** ProductSet of FiniteSets in the Complex Plane. **
+                # For Cases like ComplexPlane({2, 4}*{3}), It
+                # would return {2 + 3*I, 4 + 3*I}
+                complex_num = []
+                for x in sets.args[0]:
+                    for y in sets.args[1]:
+                        complex_num.append(x + I*y)
+                obj = FiniteSet(*complex_num)
 
             else:
                 obj = ImageSet.__new__(cls, Lambda((x, y), x + I*y), sets)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -650,12 +650,17 @@ class ComplexPlane(Set):
         # Polar Form
         elif polar is True:
             new_sets = []
+
+            # sets is Union of ProductSets
             if not sets.is_ProductSet:
                 for k in sets.args:
                     new_sets.append(k)
+
+            # sets is ProductSets
             else:
                 new_sets.append(sets)
 
+            # Normalize input theta
             for k, v in enumerate(new_sets):
                 from sympy.sets import ProductSet
                 new_sets[k] = ProductSet(v.args[0],

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -415,8 +415,11 @@ def test_normalize_theta_set():
     raises(ValueError, lambda: normalize_theta_set(S.Complexes))
 
 
-def test_ComplexPlane_single_element():
-    x, y = symbols('x, y')
+def test_ComplexPlane_FiniteSet():
+    x, y, z, a, b, c = symbols('x y z a b c')
 
     # Issue #9669
-    assert ComplexPlane(FiniteSet(x)*FiniteSet(y)) == FiniteSet(x + I*y)
+    assert ComplexPlane(FiniteSet(a, b, c)*FiniteSet(x, y, z)) == \
+        FiniteSet(a + I*x, a + I*y, a + I*z, b + I*x, b + I*y,
+                  b + I*z, c + I*x, c + I*y, c + I*z)
+    assert ComplexPlane(FiniteSet(2)*FiniteSet(3)) == FiniteSet(2 + 3*I)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -413,3 +413,10 @@ def test_normalize_theta_set():
 
     # ValueError for non-real sets
     raises(ValueError, lambda: normalize_theta_set(S.Complexes))
+
+
+def test_ComplexPlane_single_element():
+    x, y = symbols('x, y')
+
+    # Issue #9669
+    assert ComplexPlane(FiniteSet(x)*FiniteSet(y)) == FiniteSet(x + I*y)


### PR DESCRIPTION
Simplify singleton Element in Complex Plane `ComplexPlane({x}*{y})`.

fixes #9669 

Earlier:

``` python
In [6]: ComplexPlane(FiniteSet(x)*FiniteSet(y))
Out[6]: ComplexPlane(Lambda((x, y), x + I*y), {x} x {y})
```

Now:

``` python
In [4]: ComplexPlane(FiniteSet(x)*FiniteSet(y))
Out[4]: {x + I*y}
```

**EDIT TODO**
- [x] Implement this for ProductSet of FiniteSet's of any length.
- [x] Add Tests

@hargup  @flacjacket  @jksuom 
