### PR TITLE
Remove obsolete doctest skip from nonzero predicate

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -521,11 +521,11 @@ class AssumptionKeys(object):
         False
         >>> ask(Q.nonzero(0))
         False
-        >>> ask(Q.nonzero(I)) # doctest: +SKIP
+        >>> ask(Q.nonzero(I))
         False
         >>> ask(~Q.zero(I))
         True
-        >>> ask(Q.nonzero(oo)) # doctest: +SKIP
+        >>> ask(Q.nonzero(oo))
         False
 
         """


### PR DESCRIPTION
Since we've merged https://github.com/sympy/sympy/pull/9490 and https://github.com/sympy/sympy/pull/9582. These skips are no longer necessary.
