### PR TITLE
Add support for 'Add' in AskNonPositiveHandler and AskNonNegativeHandler

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -134,6 +134,21 @@ class AskNonNegativeHandler(CommonHandler):
                 return ask(Q.real(expr), assumptions)
             else:
                 return notnegative
+        if expr.is_Add:
+            eval_args = [
+                    fuzzy_and(
+                        [
+                            ask(Q.real(arg), assumptions),
+                            fuzzy_or(
+                                [
+                                    ask(Q.positive(arg), assumptions),
+                                    ask(Q.zero(arg), assumptions)
+                                ]
+                            )
+                        ]
+                    ) for arg in expr.args
+                ]
+            return fuzzy_and(eval_args)
 
 
 class AskNonZeroHandler(CommonHandler):
@@ -213,6 +228,22 @@ class AskNonPositiveHandler(CommonHandler):
                 return ask(Q.real(expr), assumptions)
             else:
                 return notpositive
+        if expr.is_Add:
+            eval_args = [
+                    fuzzy_and(
+                        [
+                            ask(Q.real(arg), assumptions),
+                            fuzzy_or(
+                                [
+                                    ask(Q.negative(arg), assumptions),
+                                    ask(Q.zero(arg), assumptions)
+                                ]
+                            )
+                        ]
+                    ) for arg in expr.args
+                ]
+            return fuzzy_and(eval_args)
+
 
 class AskPositiveHandler(CommonHandler):
     """

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2131,12 +2131,6 @@ def test_issue_7246():
     assert ask(Q.positive(acot(x)), Q.real(x)) is True
     assert ask(Q.positive(acot(x)), Q.imaginary(x)) is False
     assert ask(Q.positive(acot(x))) is None
-
-
-@XFAIL
-def test_issue_7246_failing():
-    #Move this test to test_issue_7246 once
-    #the new assumptions module is improved.
     assert ask(Q.positive(acos(x)), Q.zero(x)) is True
 
 


### PR DESCRIPTION
Although it's a positive step, but it broke the following

```
    assert ask(Q.positive(asin(x)), Q.positive(x) & Q.nonpositive(x - 1)) is True
    assert ask(Q.positive(asin(x)), Q.negative(x) & Q.nonnegative(x + 1)) is False
```

@asmeurer I can't figure out what's wrong here.
