### PR TITLE
`Interval - FiniteSet(x)` is now returned unevaluated

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1755,7 +1755,7 @@ class FiniteSet(Set, EvalfMixin):
                     intervals.append(Interval(a, b, True, True))  # both open
                 intervals.append(Interval(nums[-1], S.Infinity, True, True))
 
-                if not syms == []:
+                if not syms:
                     return Complement(Union(intervals, evaluate=False),
                             FiniteSet(*syms), evaluate=False)
                 else:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1755,7 +1755,7 @@ class FiniteSet(Set, EvalfMixin):
                     intervals.append(Interval(a, b, True, True))  # both open
                 intervals.append(Interval(nums[-1], S.Infinity, True, True))
 
-                if not syms:
+                if syms != []:
                     return Complement(Union(intervals, evaluate=False),
                             FiniteSet(*syms), evaluate=False)
                 else:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -910,7 +910,7 @@ class Interval(Set, EvalfMixin):
 
 
     def _complement(self, other):
-        if other is S.Reals:
+        if other == S.Reals:
             a = Interval(S.NegativeInfinity, self.start,
                          True, not self.left_open)
             b = Interval(self.end, S.Infinity, not self.right_open, True)
@@ -1745,7 +1745,7 @@ class FiniteSet(Set, EvalfMixin):
     def _complement(self, other):
         if isinstance(other, Interval):
             nums = sorted(m for m in self.args if m.is_number)
-            if other is S.Reals and nums != []:
+            if other == S.Reals and nums != []:
                 syms = [m for m in self.args if m.is_Symbol]
                 # Reals cannot contain elements other than numbers and symbols.
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -916,6 +916,11 @@ class Interval(Set, EvalfMixin):
             b = Interval(self.end, S.Infinity, not self.right_open, True)
             return Union(a, b)
 
+        if isinstance(other, FiniteSet):
+            nums = [m for m in other.args if m.is_number]
+            if nums == []:
+                return None
+
         return Set._complement(self, other)
 
 
@@ -1750,7 +1755,7 @@ class FiniteSet(Set, EvalfMixin):
                     intervals.append(Interval(a, b, True, True))  # both open
                 intervals.append(Interval(nums[-1], S.Infinity, True, True))
 
-                if syms != []:
+                if not syms == []:
                     return Complement(Union(intervals, evaluate=False),
                             FiniteSet(*syms), evaluate=False)
                 else:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1738,23 +1738,25 @@ class FiniteSet(Set, EvalfMixin):
         return self.__class__(el for el in self if el in other)
 
     def _complement(self, other):
-        if other is S.Reals:
+        if isinstance(other, Interval):
             nums = sorted(m for m in self.args if m.is_number)
-            syms = [m for m in self.args if m.is_Symbol]
-            # Reals cannot contain elements other than numbers and symbols.
+            if other is S.Reals and nums != []:
+                syms = [m for m in self.args if m.is_Symbol]
+                # Reals cannot contain elements other than numbers and symbols.
 
-            intervals = []  # Build up a list of intervals between the elements
-            if nums != []:
+                intervals = []  # Build up a list of intervals between the elements
                 intervals += [Interval(S.NegativeInfinity, nums[0], True, True)]
                 for a, b in zip(nums[:-1], nums[1:]):
                     intervals.append(Interval(a, b, True, True))  # both open
                 intervals.append(Interval(nums[-1], S.Infinity, True, True))
 
-            if syms != []:
-                return Complement(Union(intervals, evaluate=False),
-                    FiniteSet(*syms), evaluate=False)
-            else:
-                return Union(intervals, evaluate=False)
+                if syms != []:
+                    return Complement(Union(intervals, evaluate=False),
+                            FiniteSet(*syms), evaluate=False)
+                else:
+                    return Union(intervals, evaluate=False)
+            elif nums == []:
+                return None
 
         return Set._complement(self, other)
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -869,3 +869,13 @@ def test_issue_9536():
     from sympy.functions.elementary.exponential import log
     a = Symbol('a', real=True)
     assert FiniteSet(log(a)).intersect(S.Reals) == Intersection(S.Reals, FiniteSet(log(a)))
+
+
+def test_issue_9637():
+    n = Symbol('n')
+    a = FiniteSet(n)
+    b = FiniteSet(2, n)
+    assert Complement(S.Reals, a) == Complement(S.Reals, a, evaluate=False)
+    assert Complement(Interval(1, 3), a) == Complement(Interval(1, 3), a, evaluate=False)
+    assert Complement(Interval(1, 3), b) == \
+        Complement(Union(Interval(1, 2, False, True), Interval(2, 3, True, False)), a)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -879,3 +879,5 @@ def test_issue_9637():
     assert Complement(Interval(1, 3), a) == Complement(Interval(1, 3), a, evaluate=False)
     assert Complement(Interval(1, 3), b) == \
         Complement(Union(Interval(1, 2, False, True), Interval(2, 3, True, False)), a)
+    assert Complement(a, S.Reals) == Complement(a, S.Reals, evaluate=False)
+    assert Complement(a, Interval(1, 3)) == Complement(a, Interval(1, 3), evaluate=False)


### PR DESCRIPTION
Now the Complement for the `Interval, FiniteSet` works correctly

@hargup  , @aktech  please have a look.
Fixes #9637 
