### PR TITLE
Intersection(Interval, FiniteSet(m, n), FiniteSet(n)) now works correct

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1438,7 +1438,8 @@ class Intersection(Set):
                              if all(other.contains(x) == True for other in other_args)])
                 unk = [x for x in s
                        if any(other.contains(x) not in (True, False) for other in other_args)]
-                other_args = [elm - FiniteSet(*unk) if elm.is_FiniteSet else elm for elm in other_args]
+                other_args = [elm - FiniteSet(*unk) if elm.is_FiniteSet and
+                                not FiniteSet(*unk).is_EmptySet else elm for elm in other_args]
                 if unk:
                     other_sets = Intersection(*other_args)
                     if other_sets.is_EmptySet:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1438,6 +1438,7 @@ class Intersection(Set):
                              if all(other.contains(x) == True for other in other_args)])
                 unk = [x for x in s
                        if any(other.contains(x) not in (True, False) for other in other_args)]
+                other_args = [elm - FiniteSet(*unk) if elm.is_FiniteSet else elm for elm in other_args]
                 if unk:
                     other_sets = Intersection(*other_args)
                     if other_sets.is_EmptySet:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1438,9 +1438,9 @@ class Intersection(Set):
                              if all(other.contains(x) == True for other in other_args)])
                 unk = [x for x in s
                        if any(other.contains(x) not in (True, False) for other in other_args)]
-                other_args = [elm - FiniteSet(*unk) if elm.is_FiniteSet and
-                                not FiniteSet(*unk).is_EmptySet else elm for elm in other_args]
                 if unk:
+                    other_args = [elm - FiniteSet(*unk) if elm.is_FiniteSet
+                                    else elm for elm in other_args]
                     other_sets = Intersection(*other_args)
                     if other_sets.is_EmptySet:
                         return EmptySet()

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -869,3 +869,10 @@ def test_issue_9536():
     from sympy.functions.elementary.exponential import log
     a = Symbol('a', real=True)
     assert FiniteSet(log(a)).intersect(S.Reals) == Intersection(S.Reals, FiniteSet(log(a)))
+
+
+def test_issue_FiniteInterUnion():
+    from sympy import symbols
+    m, n = symbols('m n')
+    assert Intersection(S.Reals, Interval(0, oo), FiniteSet(m), FiniteSet(m, n)) == \
+        Intersection(Interval(0, oo), FiniteSet(m), FiniteSet(n))


### PR DESCRIPTION
Earlier

```
In [1]: Intersection(S.Reals, Interval(0, oo), FiniteSet(m), FiniteSet(m, n))
Out [1]: Intersection(Interval(0, oo), FiniteSet(m), FiniteSet(m, n))
```

Now

```
Out [2]: Intersection(Interval(0, oo), FiniteSet(m), FiniteSet(n))
```

This issue emerged while discussing PR #9627 
