### PR TITLE
Upgrade pip for cache installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,8 @@ matrix:
       env:
         - SPLIT="4/4"
 before_install:
+  - pip install --upgrade pip
+
   - if [[ "${FASTCACHE}" != "false" ]]; then
       pip install fastcache;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ python:
   - 3.2
   - 3.3
   - 3.4
+cache:
+  directories:
+    - $HOME/.cache/pip
 matrix:
   include:
     - python: 2.7


### PR DESCRIPTION
Travis-CI still has 6.x version of pip. However version 7.0.0 and later cache installed packages automatically in the form of wheels. Subsequent installs are therefore much faster.
