### PR TITLE
Don't assume that match result is not None in manualintegrate

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -687,6 +687,8 @@ def trig_substitution_rule(integral):
     if matches:
         for expr in matches:
             match = expr.match(a + b*symbol**2)
+            if not match:
+                continue
             a = match[a]
             b = match[b]
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -261,3 +261,7 @@ def test_issue_2850():
 
 def test_constant_independent_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))
+
+def test_issue_9687():
+    assert manualintegrate(1/((x**2+4)*sqrt(4*x**2+1)), x) == \
+        Integral(1/((x**2 + 4)*sqrt(4*x**2 + 1)), x)


### PR DESCRIPTION
Quick patch for #9687 - it doesn't attempt to do the integral, just prevent it from failing.
