### PR TITLE
Revert "`solveset_real(Eq(x, 1), x)` fixed"

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -393,16 +393,6 @@ def solveset_real(f, symbol):
         raise ValueError(" %s is not a symbol" % (symbol))
 
     f = sympify(f)
-    if isinstance(f, Eq):
-        from sympy.core import Add
-        f = Add(f.lhs, - f.rhs, evaluate=False)
-
-    if f is S.true:
-        return S.Reals
-
-    if f is S.false:
-        return EmptySet()
-
     if not isinstance(f, (Expr, Number)):
         raise ValueError(" %s is not a valid sympy expression" % (f))
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -898,10 +898,3 @@ def test_issue_9557():
 
     assert solveset(x**2 + a, x) == Intersection(S.Reals,
         FiniteSet(-sqrt(-a), sqrt(-a)))
-
-
-def test_issue_9686():
-    x = Symbol('x')
-    assert solveset_real(Eq(x, 1), x) == FiniteSet(1)
-    assert solveset_real(Eq(1, 1), x) == S.Reals
-    assert solveset_real(Eq(2, 1), x) == S.EmptySet


### PR DESCRIPTION
Reverts sympy/sympy#9688

@hargup  writes:

> We(I) don't want to support more than one input interface in solveset_real or solveset_complex. We have the solveset method for the "naive" user.

See https://github.com/sympy/sympy/issues/9686#issuecomment-122189448
