### PR TITLE
Use io.open to enable encoding kwarg in Py2 open()

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -1,9 +1,9 @@
-from __future__ import print_function, division
+from __future__ import print_function, division, unicode_literals
 
 from os.path import join
 import tempfile
 import shutil
-from io import BytesIO
+from io import BytesIO, open
 
 try:
     from subprocess import STDOUT, CalledProcessError

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -1,9 +1,9 @@
-from __future__ import print_function, division, unicode_literals
+from __future__ import print_function, division
 
 from os.path import join
 import tempfile
 import shutil
-from io import BytesIO, open
+from io import BytesIO
 
 try:
     from subprocess import STDOUT, CalledProcessError
@@ -183,8 +183,12 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     try:
         workdir = tempfile.mkdtemp()
 
-        with open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
-            fh.write(latex_main % latex_string)
+        try:
+            with open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
+                fh.write(latex_main % latex_string)
+        except TypeError:  # Python 2's open() does not support encoding
+            with open(join(workdir, 'texput.tex'), 'w') as fh:
+                fh.write(latex_main % latex_string)
 
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from os.path import join
 import tempfile
 import shutil
+import io
 from io import BytesIO
 
 try:
@@ -10,6 +11,8 @@ try:
     from sympy.core.compatibility import check_output
 except ImportError:
     pass
+
+from sympy.core.compatibility import u
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import find_executable
@@ -183,12 +186,9 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     try:
         workdir = tempfile.mkdtemp()
 
-        try:
-            with open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
-                fh.write(latex_main % latex_string)
-        except TypeError:  # Python 2's open() does not support encoding
-            with open(join(workdir, 'texput.tex'), 'w') as fh:
-                fh.write(latex_main % latex_string)
+        with io.open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
+            rendered = latex_main % latex_string
+            fh.write(u(rendered.replace(r'\u', r'\\u')))
 
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)

--- a/sympy/printing/tests/test_preview.py
+++ b/sympy/printing/tests/test_preview.py
@@ -7,4 +7,7 @@ from io import BytesIO
 def test_preview():
     x = Symbol('x')
     obj = BytesIO()
-    preview(x, output='png', viewer='BytesIO', outputbuffer=obj)
+    try:
+        preview(x, output='png', viewer='BytesIO', outputbuffer=obj)
+    except RuntimeError:
+        pass  # latex not installed on CI server

--- a/sympy/printing/tests/test_preview.py
+++ b/sympy/printing/tests/test_preview.py
@@ -1,0 +1,10 @@
+from sympy import Symbol
+from sympy.printing.preview import preview
+
+from io import BytesIO
+
+
+def test_preview():
+    x = Symbol('x')
+    obj = BytesIO()
+    preview(x, output='png', viewer='BytesIO', outputbuffer=obj)

--- a/sympy/printing/tests/test_preview.py
+++ b/sympy/printing/tests/test_preview.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from sympy import Symbol
 from sympy.printing.preview import preview
 
@@ -9,5 +11,13 @@ def test_preview():
     obj = BytesIO()
     try:
         preview(x, output='png', viewer='BytesIO', outputbuffer=obj)
+    except RuntimeError:
+        pass  # latex not installed on CI server
+
+    # issue 9107
+    a = Symbol('α')
+    obj = BytesIO()
+    try:
+        preview(a, output='png', viewer='BytesIO', outputbuffer=obj)
     except RuntimeError:
         pass  # latex not installed on CI server


### PR DESCRIPTION
This was failing in my Python 2 jupyter notebook when using sympy git master:

```
from IPython.display import display, Latex
from sympy.interactive import printing
printing.init_printing()

from sympy import *
params = symbols('k l m'.split())
display(params)
```

encoding='utf-8' kwarg passed to open() was to blame. This commit should fix this bug and adds a test for `sympy.printing.preview` (maybe there was some other test(s) somewhere but I failed to find those).

Note the use of `unicode_literals`. There maybe gotchas associated with this method if people try to pass str objects (in e.g. `packages` or `preamble` kwarg in preview) which will not mix with unicode.

The encoding kwarg was added by @dustyrockpyle in 723289c8 introduced in #9108 which fixed #9107
