### PR TITLE
`solveset(1/exp(x), x)` returns `S.EmptySet`

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -221,7 +221,7 @@ def _invert_complex(f, g_ys, symbol):
         if isinstance(g_ys, FiniteSet):
             exp_invs = Union(*[imageset(Lambda(n, I*(2*n*pi + arg(g_y)) +
                                                log(Abs(g_y))), S.Integers)
-                               for g_y in g_ys])
+                               for g_y in g_ys if g_y != S.Zero])
             return _invert_complex(f.args[0], exp_invs, symbol)
     return (f, g_ys)
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -221,7 +221,7 @@ def _invert_complex(f, g_ys, symbol):
         if isinstance(g_ys, FiniteSet):
             exp_invs = Union(*[imageset(Lambda(n, I*(2*n*pi + arg(g_y)) +
                                                log(Abs(g_y))), S.Integers)
-                               for g_y in g_ys if g_y != S.Zero])
+                               for g_y in g_ys if g_y != 0])
             return _invert_complex(f.args[0], exp_invs, symbol)
     return (f, g_ys)
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -647,6 +647,9 @@ def test_solveset_complex_exp():
         imageset(Lambda(n, I*2*n*pi), S.Integers)
     assert solveset_complex(exp(x) - I, x) == \
         imageset(Lambda(n, I*(2*n*pi + pi/2)), S.Integers)
+    assert solveset_complex(1/exp(x), x) == S.EmptySet
+    assert solveset_complex(sinh(x).rewrite(exp), x) == \
+        imageset(Lambda(n, n*pi*I), S.Integers)
 
 
 def test_solve_complex_log():


### PR DESCRIPTION
Fixes #9733 

As @hargup  pointed out:

> nans are produced by unhandled intermediate forms #1, we don't want to mask such cases and let them pass silently.

So i closed the PR #9734 . 
As the patch made by @hargup [here](https://github.com/sympy/sympy/issues/9733#issuecomment-125020990)  and @aktech is [here](https://github.com/sympy/sympy/issues/9733#issuecomment-125022775) . Thanks to both

I think it better to return `ImageSet(Lamnda(n, nan), any_set)` un-evaluated.
