### PR TITLE
`singularities((x**2 - 1)/(x**3 - 1), x) returns `(1,)`

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -31,4 +31,4 @@ def singularities(expr, sym):
                                   " non rational functions are not yet"
                                   " implemented")
     else:
-        return tuple(sorted(solveset(simplify(1/expr), sym)))
+        return tuple(sorted(solveset(simplify(expr).as_numer_denom()[1], sym)))

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -9,6 +9,7 @@ def test_singularities():
 
     assert singularities(x**2, x) == ()
     assert singularities(x/(x**2 + 3*x + 2), x) == (-2, -1)
+    assert singularities((x**2 - 1)/(x**3 - 1), x) == (1,)
 
 
 @XFAIL


### PR DESCRIPTION
Since singularities for rational function should for the `expr.denominator`
being `zero` and not for the place where `1/expr` becomes zero

Fixes issue #9739 .
