### PR TITLE
Piecewise lambdify printing for select uses lists instead of tuples.

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -91,11 +91,9 @@ class NumPyPrinter(LambdaPrinter):
 
     def _print_Piecewise(self, expr):
         "Piecewise function printer"
-        # Print tuples here instead of lists because numba may add support
-        #     for select in nopython mode; see numba#1313 on github.
-        exprs = '({0},)'.format(','.join(self._print(arg.expr) for arg in expr.args))
-        conds = '({0},)'.format(','.join(self._print(arg.cond) for arg in expr.args))
-        # If (default_value, True) is a (expr, cond) tuple in a Piecewise object
+        exprs = '[{0}]'.format(','.join(self._print(arg.expr) for arg in expr.args))
+        conds = '[{0}]'.format(','.join(self._print(arg.cond) for arg in expr.args))
+        # If [default_value, True] is a (expr, cond) sequence in a Piecewise object
         #     it will behave the same as passing the 'default' kwarg to select()
         #     *as long as* it is the last element in expr.args.
         # If this is not the case, it may be triggered prematurely.

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -1,0 +1,12 @@
+from sympy import Piecewise
+from sympy.abc import x
+from sympy.printing.lambdarepr import NumPyPrinter
+
+def test_numpy_piecewise_regression():
+    """
+    NumPyPrinter needs to print Piecewise()'s choicelist as a list to avoid
+    breaking compatibility with numpy 1.8. This is not necessary in numpy 1.9+.
+    See gh-9747 and gh-9749 for details.
+    """
+    p = Piecewise((1, x < 0), (0, True))
+    assert NumPyPrinter().doprint(p) == 'select([x < 0,True], [1,0], default=nan)'


### PR DESCRIPTION
Resolves sympy/sympy#9747

CC @aktech @asmeurer 
