### PR TITLE
Fix bug in gaunt: it should now vanish when sum of l's is odd

### DIFF
--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -1,6 +1,6 @@
 from sympy import S, sqrt, pi, Dummy, Sum, Ynm, symbols
 from sympy.physics.wigner import (clebsch_gordan, wigner_9j, wigner_6j, gaunt,
-        racah, dot_rot_grad_Ynm, Wigner3j)
+        racah, dot_rot_grad_Ynm, Wigner3j, wigner_3j)
 from sympy.core.numbers import Rational
 
 # Todo: more tests should be added from:
@@ -121,6 +121,30 @@ def test_gaunt():
     assert gaunt(1, 0, 1, 1, 0, -1) == -1/(2*sqrt(pi))
     assert tn(gaunt(
         10, 10, 12, 9, 3, -12, prec=64), (-S(98)/62031) * sqrt(6279)/sqrt(pi))
+    def gaunt_ref(l1, l2, l3, m1, m2, m3):
+        return (
+            sqrt((2 * l1 + 1) * (2 * l2 + 1) * (2 * l3 + 1) / (4 * pi)) *
+            wigner_3j(l1, l2, l3, 0, 0, 0) *
+            wigner_3j(l1, l2, l3, m1, m2, m3)
+        )
+    threshold = 1e-10
+    l_max = 3
+    l3_max = 24
+    for l1 in range(l_max + 1):
+        for l2 in range(l_max + 1):
+            for l3 in range(l3_max + 1):
+                for m1 in range(-l1, l1 + 1):
+                    for m2 in range(-l2, l2 + 1):
+                        for m3 in range(-l3, l3 + 1):
+                            args = l1, l2, l3, m1, m2, m3
+                            g  = gaunt(*args)
+                            g0 = gaunt_ref(*args)
+                            assert abs(g - g0) < threshold
+                            if m1 + m2 + m3 != 0:
+                                assert abs(g) < threshold
+                            if (l1 + l2 + l3) % 2:
+                                assert abs(g) < threshold
+
 
 def test_racah():
     assert racah(3,3,3,3,3,3) == Rational(-1,14)

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -642,7 +642,8 @@ def gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
     if int(m_1) != m_1 or int(m_2) != m_2 or int(m_3) != m_3:
         raise ValueError("m values must be integer")
 
-    bigL = (l_1 + l_2 + l_3) // 2
+    sumL = l_1 + l_2 + l_3
+    bigL = sumL // 2
     a1 = l_1 + l_2 - l_3
     if a1 < 0:
         return 0
@@ -652,7 +653,7 @@ def gaunt(l_1, l_2, l_3, m_1, m_2, m_3, prec=None):
     a3 = -l_1 + l_2 + l_3
     if a3 < 0:
         return 0
-    if (2 * bigL) % 2 != 0:
+    if sumL % 2:
         return 0
     if (m_1 + m_2 + m_3) != 0:
         return 0


### PR DESCRIPTION
The Gaunt coefficient must vanish if `l1 + l2 + l3` is odd.  This wasn't the case previously (#7586) due to a buggy condition check.  A regression test has been added for this.

In addition, a series of tests to ensure the consistency of Gaunt coefficients and Wigner 3j symbols have been added.  Remark: these tests are kind of slow (~10 sec).
