### PR TITLE
Make threaded_factory dispatch on MatrixBase instead of Matrix (fixes #9712)

### DIFF
--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,5 +1,8 @@
+from itertools import product
+
 from sympy import (ImmutableMatrix, Matrix, eye, zeros, S, Equality,
-        Unequality, ImmutableSparseMatrix, SparseMatrix, sympify)
+        Unequality, ImmutableSparseMatrix, SparseMatrix, sympify,
+        integrate)
 from sympy.abc import x, y
 from sympy.utilities.pytest import raises
 
@@ -110,3 +113,10 @@ def test_Equality():
     assert Unequality(M, M.subs(x, 2)).subs(x, 2) is S.false
     assert Equality(M, M.subs(x, 2)).subs(x, 3) is S.false
     assert Unequality(M, M.subs(x, 2)).subs(x, 3) is S.true
+
+
+def test_integrate():
+    intIM = integrate(IM, x)
+    assert intIM.shape == IM.shape
+    assert all([intIM[i, j] == (1 + j + 3*i)*x for i, j in
+                product(range(3), range(3))])

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -12,11 +12,11 @@ from sympy.core.compatibility import class_types, get_function_globals, get_func
 def threaded_factory(func, use_add):
     """A factory for ``threaded`` decorators. """
     from sympy.core import sympify
-    from sympy.matrices import Matrix
+    from sympy.matrices import MatrixBase
 
     @wraps(func)
     def threaded_func(expr, *args, **kwargs):
-        if isinstance(expr, Matrix):
+        if isinstance(expr, MatrixBase):
             return expr.applyfunc(lambda f: func(f, *args, **kwargs))
         elif iterable(expr):
             try:


### PR DESCRIPTION
This commit extends the special behaviour of `sympy.utilities.decorators.threaded_factory` to not only `Matrix` but `MatrixBase`, this way `ImmutableMatrix` is also included. This fixes issue #9712 (a regression test was added for this issue as well).
