### PR TITLE
Fast `series` method for ring series

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1814,6 +1814,9 @@ def _series_fast(expr, rs_series, a, prec):
             return series
         else:
             return rs_series
+    elif isinstance(expr, Expr):
+        if expr.is_constant:
+            return sring(expr, domain=QQ)[1]
     elif expr.is_Function:
         arg = args[0]
         R, series = sring(arg, domain=QQ)
@@ -1829,6 +1832,11 @@ def _series_fast(expr, rs_series, a, prec):
     elif expr.is_Mul:
         n = len(args)
         R = rs_series.ring
+        #syms = set(R.symbols)
+        #for arg in args:
+        #    R1, _ = sring(arg)
+        #    syms = syms.union(set(R1.symbols))
+        #R = R.clone(symbols=list(syms))
         min_pows = list(map(rs_min_pow, args, [R(arg) for arg in args], [a]*len(args)))
         sum_pows = sum(min_pows)
         series = R(1)
@@ -1841,7 +1849,7 @@ def _series_fast(expr, rs_series, a, prec):
                 R = R.clone(symbols=list(syms))
                 _series = _series.set_ring(R)
                 series = series.set_ring(R)
-            series += _series
+            series *= _series
         series = rs_trunc(series, R(a), prec)
         return series
     elif expr.is_Add:

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -7,7 +7,7 @@ from mpmath.libmp.libintmath import ifac
 from sympy.core import PoleError, Function, Expr
 from sympy.core.numbers import Rational, igcd
 from sympy.core.compatibility import as_int, range
-from sympy.functions import sin, cos, tan, atan, exp, atanh, tanh, log
+from sympy.functions import sin, cos, tan, atan, exp, atanh, tanh, log, ceiling
 from mpmath.libmp.libintmath import giant_steps
 import math
 
@@ -1797,7 +1797,6 @@ _convert_func = {
 def rs_min_pow(expr, rs_series, a):
     series = 0
     n = 2
-    #R, series = sring(rs_series, domain=QQ)
     while series == 0:
         series = _series_fast(expr, rs_series, a, n)
         n *= 2
@@ -1830,13 +1829,14 @@ def _series_fast(expr, rs_series, a, prec):
         return rs_series
     elif expr.is_Function:
         arg = args[0]
+        if len(args) > 1:
+            raise NotImplementedError
         R, series = sring(arg, domain=QQ)
         series_inner = _series_fast(arg, series, a, prec)
         R = (R.compose(series_inner.ring)).compose(rs_series.ring)
         series_inner = series_inner.set_ring(R)
-        a = R(a)
         series = eval(_convert_func[str(expr.func)])(series_inner,
-            a, prec)
+            R(a), prec)
         return series
     elif expr.is_Mul:
         n = len(args)
@@ -1896,7 +1896,7 @@ def series_fast(expr, a, prec):
             gen = gen.set_ring(p1.ring)
             if new_prec != prec_got:
                 prec_do = prec + (prec - prec_got)*more/(new_prec - prec_got)
-                p1 = _series_fast(expr, series, a, prec=prec_do)
+                p1 = _series_fast(expr, series, a, prec=ceiling(prec_do))
                 while p1.degree(gen) + 1 < prec:
                     p1 = _series_fast(expr, series, a, prec=prec_do)
                     gen = gen.set_ring(p1.ring)

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1779,14 +1779,19 @@ def rs_compose_add(p1, p2):
     return q
 
 
+_convert_func = {
+        'sin': 'rs_sin',
+        'cos': 'rs_cos',
+        'exp': 'rs_exp'
+        }
+
 def series_fast(expr, x, prec):
-    R, series = sring(expr, domain=QQ)
-    gens = list(R.gens)
-    try:
-        R(a)
-    except ValueError:
-            gens = 3
-    x = R(x)
     if expr.is_Function:
-        return eval(_convert_func[str(expr.func)])(R(expr.args),
+        R, series = sring(expr.args[0], domain=QQ)
+        syms = set(R.symbols)
+        syms = syms.union(set((x,)))
+        R = R.clone(symbols=list(syms))
+        series = series.set_ring(R)
+        x = R(x)
+        return eval(_convert_func[str(expr.func)])(series,
             x, prec)

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1254,9 +1254,8 @@ def rs_tan(p, x, prec):
         return r
     R = p.ring
     const = 0
-    if _has_constant_term(p, x):
-        zm = R.zero_monom
-        c = p[zm]
+    c = _get_constant_term(p, x)
+    if c:
         if R.domain is EX:
             c_expr = c.as_expr()
             const = tan(c_expr)
@@ -1265,8 +1264,13 @@ def rs_tan(p, x, prec):
                 c_expr = c.as_expr()
                 const = R(tan(c_expr))
             except ValueError:
-                    raise DomainError("The given series can't be expanded in "
-                                      "this domain.")
+                R = R.add_gens([tan(c_expr, )])
+                #gens = list(R.gens).remove(x.set_ring(R))
+                #R.drop_to_ground(gens)
+                p = p.set_ring(R)
+                x = x.set_ring(R)
+                c = c.set_ring(R)
+                const = R(tan(c_expr))
         else:
             try:
                 const = R(tan(c))

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1267,8 +1267,6 @@ def rs_tan(p, x, prec):
                 const = R(tan(c_expr))
             except ValueError:
                 R = R.add_gens([tan(c_expr, )])
-                #gens = list(R.gens).remove(x.set_ring(R))
-                #R.drop_to_ground(gens)
                 p = p.set_ring(R)
                 x = x.set_ring(R)
                 c = c.set_ring(R)
@@ -1367,8 +1365,6 @@ def rs_sin(p, x, prec):
                 t1, t2 = R(sin(c_expr)), R(cos(c_expr))
             except ValueError:
                 R = R.add_gens([sin(c_expr), cos(c_expr)])
-                #gens = list(R.gens).remove(x.set_ring(R))
-                #R.drop_to_ground(gens)
                 p = p.set_ring(R)
                 x = x.set_ring(R)
                 c = c.set_ring(R)
@@ -1437,8 +1433,6 @@ def rs_cos(p, x, prec):
                 t1, t2 = R(sin(c_expr)), R(cos(c_expr))
             except ValueError:
                 R = R.add_gens([sin(c_expr), cos(c_expr)])
-                #gens = list(R.gens).remove(x.set_ring(R))
-                #R.drop_to_ground(gens)
                 p = p.set_ring(R)
                 x = x.set_ring(R)
                 c = c.set_ring(R)
@@ -1797,6 +1791,7 @@ _convert_func = {
         }
 
 def rs_min_pow(expr, series_rs, a):
+    """Finds the minimum power of `a` in the series expansion of expr"""
     series = 0
     n = 2
     while series == 0:
@@ -1809,7 +1804,8 @@ def rs_min_pow(expr, series_rs, a):
 
 
 def _rs_series(expr, series_rs, a, prec):
-    # XXX Use _parallel_dict_from_expr instead of sring.
+    # TODO Use _parallel_dict_from_expr instead of sring as sring is
+    # inefficient. For details, read the todo in sring.
 
     args = expr.args
     R = series_rs.ring
@@ -1868,6 +1864,32 @@ def _rs_series(expr, series_rs, a, prec):
         raise NotImplementedError
 
 def rs_series(expr, a, prec):
+    """Return the series expansion of an expression
+
+    Parameters
+    ----------
+    expr : :class:`Expr`
+    a : :class:`Symbol` with respect to which expr is to be expanded
+    prec : order of the series expansion
+
+    Currently supports multivariate Taylor series expansion. This is much
+    faster that Sympy's series method as it uses sparse polynomial operations.
+
+    It automatically creates the simplest ring required to represent the series
+    expansion through repeated calls to sring.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.ring_series import rs_series
+    >>> from sympy.abc import a, b
+
+    >>> rs_series(sin(a) + exp(a), a, 5)
+    1/24*a**4 + 1/2*a**2 + 2*a + 1
+    >>> rs_series(tan(a**2 + 1)*cos(a), a, 3)
+    tan(1)**2*a**2 - 1/2*tan(1)*a**2 + tan(1) + a**2
+
+    """
     R, series = sring(expr, domain=QQ, expand=False)
     if a not in R.symbols:
         R = R.add_gens([a, ])

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1885,11 +1885,12 @@ def rs_series(expr, a, prec):
         # many additional terms are needed
         for more in range(1, 9):
             p1 = _rs_series(expr, series, a, prec=prec + more)
-            new_prec = p1.degree(gen) + 1
             gen = gen.set_ring(p1.ring)
+            new_prec = p1.degree(gen) + 1
             if new_prec != prec_got:
-                prec_do = prec + (prec - prec_got)*more/(new_prec - prec_got)
-                p1 = _rs_series(expr, series, a, prec=ceiling(prec_do))
+                prec_do = ceiling(prec + (prec - prec_got)*more/(new_prec -
+                    prec_got))
+                p1 = _rs_series(expr, series, a, prec=prec_do)
                 while p1.degree(gen) + 1 < prec:
                     p1 = _rs_series(expr, series, a, prec=prec_do)
                     gen = gen.set_ring(p1.ring)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -508,6 +508,17 @@ class PolyRing(DefaultPrinting, IPolys):
         else:
             return self.clone(symbols=symbols, domain=self.drop(*gens))
 
+    def compose(self, other):
+        if self != other:
+            syms = set(self.symbols).union(set(other.symbols))
+            return self.clone(symbols=list(syms))
+        else:
+            return self
+
+    def add_gens(self, symbols):
+        syms = set(self.symbols).union(set(symbols))
+        return self.clone(symbols=list(syms))
+
 
 class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     """Element of multivariate distributed polynomial ring. """

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -5,7 +5,7 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_series_from_list, rs_exp, rs_log, rs_newton, rs_series_inversion,
     rs_compose_add, rs_asin, rs_atan, rs_atanh, rs_tan, rs_cot, rs_sin, rs_cos,
     rs_cos_sin, rs_sinh, rs_cosh, rs_tanh, _tan1, rs_fun, rs_nth_root,
-    rs_LambertW, rs_series_reversion, rs_is_puiseux, series_fast)
+    rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.core.symbol import symbols
@@ -581,36 +581,36 @@ def test_puiseux2():
         y)*x**QQ(11,5) + (y**9/9 + y**4)*x**QQ(9,5) - (y**7/7 +
         y**2)*x**QQ(7,5) + (y**5/5 + 1)*x - y**3*x**QQ(3,5)/3 + y*x**QQ(1,5)
 
-def test_series_fast():
+def test_rs_series():
     x, a, b, c = symbols('x, a, b, c')
 
-    assert (series_fast(a, a, 5)).as_expr() == a
-    assert series_fast(sin(1/a), a, 5).as_expr() == sin(1/a)
-    assert (series_fast(sin(a), a, 5)).as_expr() == (sin(a).series(a, 0,
+    assert (rs_series(a, a, 5)).as_expr() == a
+    assert rs_series(sin(1/a), a, 5).as_expr() == sin(1/a)
+    assert (rs_series(sin(a), a, 5)).as_expr() == (sin(a).series(a, 0,
         5)).removeO()
-    assert (series_fast(sin(a) + cos(a), a, 5)).as_expr() == ((sin(a) +
+    assert (rs_series(sin(a) + cos(a), a, 5)).as_expr() == ((sin(a) +
         cos(a)).series(a, 0, 5)).removeO()
-    assert (series_fast(sin(a)*cos(a), a, 5)).as_expr() == ((sin(a)*
+    assert (rs_series(sin(a)*cos(a), a, 5)).as_expr() == ((sin(a)*
         cos(a)).series(a, 0, 5)).removeO()
 
     p = (sin(a) - a)*(cos(a**2) + a**4/2)
-    assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
+    assert expand(rs_series(p, a, 10).as_expr()) == expand(p.series(a, 0,
         10).removeO())
 
     p = sin(a**2/2 + a/3) + cos(a/5)*sin(a/2)**3
-    assert expand(series_fast(p, a, 5).as_expr()) == expand(p.series(a, 0,
+    assert expand(rs_series(p, a, 5).as_expr()) == expand(p.series(a, 0,
         5).removeO())
 
     p = sin(x**2 + a)*(cos(x**3 - 1) - a - a**2)
-    assert expand(series_fast(p, a, 5).as_expr()) == expand(p.series(a, 0,
+    assert expand(rs_series(p, a, 5).as_expr()) == expand(p.series(a, 0,
         5).removeO())
 
 
     p = sin(a**2 - a/3 + 2)**5*exp(a**3 - a/2)
-    assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
+    assert expand(rs_series(p, a, 10).as_expr()) == expand(p.series(a, 0,
         10).removeO())
 
     p = sin(a + b + c)
-    assert expand(series_fast(p, a, 5).as_expr()) == expand(p.series(a, 0,
+    assert expand(rs_series(p, a, 5).as_expr()) == expand(p.series(a, 0,
         5).removeO())
 

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -607,3 +607,5 @@ def test_series_fast():
     p = sin(x**2 + a)*(cos(x**3 - 1) - a - a**2)
     assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
         10).removeO())
+
+    assert series_fast(sin(1/x), x, 5).as_expr() == sin(1/x)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -584,13 +584,13 @@ def test_puiseux2():
 def test_rs_series():
     x, a, b, c = symbols('x, a, b, c')
 
-    assert (rs_series(a, a, 5)).as_expr() == a
+    assert rs_series(a, a, 5).as_expr() == a
     assert rs_series(sin(1/a), a, 5).as_expr() == sin(1/a)
-    assert (rs_series(sin(a), a, 5)).as_expr() == (sin(a).series(a, 0,
+    assert rs_series(sin(a), a, 5).as_expr() == (sin(a).series(a, 0,
         5)).removeO()
-    assert (rs_series(sin(a) + cos(a), a, 5)).as_expr() == ((sin(a) +
+    assert rs_series(sin(a) + cos(a), a, 5).as_expr() == ((sin(a) +
         cos(a)).series(a, 0, 5)).removeO()
-    assert (rs_series(sin(a)*cos(a), a, 5)).as_expr() == ((sin(a)*
+    assert rs_series(sin(a)*cos(a), a, 5).as_expr() == ((sin(a)*
         cos(a)).series(a, 0, 5)).removeO()
 
     p = (sin(a) - a)*(cos(a**2) + a**4/2)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -605,7 +605,6 @@ def test_rs_series():
     assert expand(rs_series(p, a, 5).as_expr()) == expand(p.series(a, 0,
         5).removeO())
 
-
     p = sin(a**2 - a/3 + 2)**5*exp(a**3 - a/2)
     assert expand(rs_series(p, a, 10).as_expr()) == expand(p.series(a, 0,
         10).removeO())
@@ -614,3 +613,6 @@ def test_rs_series():
     assert expand(rs_series(p, a, 5).as_expr()) == expand(p.series(a, 0,
         5).removeO())
 
+    p = tan(sin(a**2 + 4) + b + c)
+    assert expand(rs_series(p, a, 6).as_expr()) == expand(p.series(a, 0,
+        6).removeO())

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -582,9 +582,10 @@ def test_puiseux2():
         y**2)*x**QQ(7,5) + (y**5/5 + 1)*x - y**3*x**QQ(3,5)/3 + y*x**QQ(1,5)
 
 def test_series_fast():
-    x, a = symbols('x, a')
+    x, a, b, c = symbols('x, a, b, c')
 
     assert (series_fast(a, a, 5)).as_expr() == a
+    assert series_fast(sin(1/a), a, 5).as_expr() == sin(1/a)
     assert (series_fast(sin(a), a, 5)).as_expr() == (sin(a).series(a, 0,
         5)).removeO()
     assert (series_fast(sin(a) + cos(a), a, 5)).as_expr() == ((sin(a) +
@@ -596,16 +597,20 @@ def test_series_fast():
     assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
         10).removeO())
 
-    p = sin(a**2 - a + 2)**5*cos(a**3 - a)
-    assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
-        10).removeO())
-
     p = sin(a**2/2 + a/3) + cos(a/5)*sin(a/2)**3
-    assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
-        10).removeO())
+    assert expand(series_fast(p, a, 5).as_expr()) == expand(p.series(a, 0,
+        5).removeO())
 
     p = sin(x**2 + a)*(cos(x**3 - 1) - a - a**2)
+    assert expand(series_fast(p, a, 5).as_expr()) == expand(p.series(a, 0,
+        5).removeO())
+
+
+    p = sin(a**2 - a/3 + 2)**5*exp(a**3 - a/2)
     assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
         10).removeO())
 
-    assert series_fast(sin(1/x), x, 5).as_expr() == sin(1/x)
+    p = sin(a + b + c)
+    assert expand(series_fast(p, a, 5).as_expr()) == expand(p.series(a, 0,
+        5).removeO())
+

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -5,13 +5,15 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_series_from_list, rs_exp, rs_log, rs_newton, rs_series_inversion,
     rs_compose_add, rs_asin, rs_atan, rs_atanh, rs_tan, rs_cot, rs_sin, rs_cos,
     rs_cos_sin, rs_sinh, rs_cosh, rs_tanh, _tan1, rs_fun, rs_nth_root,
-    rs_LambertW, rs_series_reversion, rs_is_puiseux)
+    rs_LambertW, rs_series_reversion, rs_is_puiseux, series_fast)
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.core.symbol import symbols
 from sympy.functions import (sin, cos, exp, tan, cot, atan, asin, atanh,
     tanh, log, sqrt)
 from sympy.core.numbers import Rational
+from sympy.core import expand
+
 
 def is_close(a, b):
     tol = 10**(-10)
@@ -578,3 +580,10 @@ def test_puiseux2():
     assert r == (y**13/13 + y**8 + 2*y**3)*x**QQ(13,5) - (y**11/11 + y**6 +
         y)*x**QQ(11,5) + (y**9/9 + y**4)*x**QQ(9,5) - (y**7/7 +
         y**2)*x**QQ(7,5) + (y**5/5 + 1)*x - y**3*x**QQ(3,5)/3 + y*x**QQ(1,5)
+
+def test_series_fast():
+    x, a = symbols('x, a')
+
+    p = sin(x**2 + a)*(cos(x**3 - 1) - a - a**2)
+    assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
+        10).removeO())

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -584,6 +584,26 @@ def test_puiseux2():
 def test_series_fast():
     x, a = symbols('x, a')
 
+    assert (series_fast(a, a, 5)).as_expr() == a
+    assert (series_fast(sin(a), a, 5)).as_expr() == (sin(a).series(a, 0,
+        5)).removeO()
+    assert (series_fast(sin(a) + cos(a), a, 5)).as_expr() == ((sin(a) +
+        cos(a)).series(a, 0, 5)).removeO()
+    assert (series_fast(sin(a)*cos(a), a, 5)).as_expr() == ((sin(a)*
+        cos(a)).series(a, 0, 5)).removeO()
+
+    p = (sin(a) - a)*(cos(a**2) + a**4/2)
+    assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
+        10).removeO())
+
+    p = sin(a**2 - a + 2)**5*cos(a**3 - a)
+    assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
+        10).removeO())
+
+    p = sin(a**2/2 + a/3) + cos(a/5)*sin(a/2)**3
+    assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
+        10).removeO())
+
     p = sin(x**2 + a)*(cos(x**3 - 1) - a - a**2)
     assert expand(series_fast(p, a, 10).as_expr()) == expand(p.series(a, 0,
         10).removeO())


### PR DESCRIPTION
This PR implements a `series_fast` method that takes an arbitrary `Basic` expression and expands it using sparse ring manipulations. We tried using `EX` domain for all expansion in #9614, but that proved to be too slow for our liking. This PR starts expanding over the `QQ` domain and keeps adding generators as and when required. Thus, we always work on the simplest (almost) possible domain, resulting in considerable speed-up.

The timings are extremely encouraging:

```
In [31]: %timeit series_fast(sin(a**2) + cos(a)*sin(a),a,100)
1 loops, best of 3: 303 ms per loop

In [32]: %timeit (sin(a**2) + cos(a)*sin(a)).series(a,0,100)
1 loops, best of 3: 5.42 s per loop
```

Because of the way we add generators, there is a constant overhead in expanding a given expression(irrespective of the asked order), depending on the complexity of the expression. So, for small orders, `series_fast` (yes, we need a new name!) might seem slow, but soon far outperforms `series` for even medium sized orders:

```
In [34]: %timeit series_fast(p, a, 10)
1 loops, best of 3: 764 ms per loop

In [35]: %timeit p.series(a,0,10)
1 loops, best of 3: 561 ms per loop
```

Here `series_fast` is actually slower than `series` for 10 terms, but once we expand till the 100th order:

```
In [36]: %timeit series_fast(p, a, 100)
1 loops, best of 3: 917 ms per loop

In [37]: %timeit p.series(a,0,100)
1 loops, best of 3: 6.67 s per loop
```

Clearly, the performance advantage will grow larger with larger orders.

There is a lot of scope for optimising the code (my priority was to make it work). It also needs to be played with to find bugs. However, I feel this is the way to go.

cc @certik @pernici @jksuom @thilinarmtb

ToDo
Fix wrong expansion of 
- [x]  `sin(a**2 - a + 2)**5*cos(a**3 - a/2)`
- [x] `sin(x + a + b)` 
- [ ] Rational exponent in argument: `sin(x**QQ(1,2))`. `_parallel_dict_from_expr_if_gens` etc need to be modified 
