### PR TITLE
Run sage and pypy tests as allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
     - python: "pypy"
       env:
         - SPLIT="4/4"
+        - FASTCACHE="false"
   allow_failures:
     - python: 3.3 # Dummy value
       env:
@@ -123,6 +124,7 @@ matrix:
     - python: "pypy"
       env:
         - SPLIT="4/4"
+        - FASTCACHE="false"
 before_install:
   - if [[ "${FASTCACHE}" != "false" ]]; then
       pip install fastcache;

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,14 @@ matrix:
     - python: 3.4
       env:
         - TEST_ASCII="true"
+    - python: 3.3 # Dummy value
+      env:
+        - TEST_SAGE="true"
+        - FASTCACHE="false"
+      sudo: true
+    - python: "pypy"
+      env:
+        - SPLIT="4/4"
   allow_failures:
     - python: 3.3 # Dummy value
       env:


### PR DESCRIPTION
When adding tests that are allowed to fail, you need to add them to the matrix and then to allow_failures category as well.
