### PR TITLE
Body class for creating Joints

### DIFF
--- a/doc/src/modules/physics/mechanics/api/body.rst
+++ b/doc/src/modules/physics/mechanics/api/body.rst
@@ -1,0 +1,9 @@
+=================
+Body (Docstrings)
+=================
+
+Body
+====
+
+.. automodule:: sympy.physics.mechanics.body
+   :members:

--- a/doc/src/modules/physics/mechanics/index.rst
+++ b/doc/src/modules/physics/mechanics/index.rst
@@ -92,3 +92,4 @@ Mechanics API
     api/linearize.rst
     api/expr_manip.rst
     api/printing.rst
+    api/body.rst

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -38,3 +38,7 @@ __all__.extend(vector.__all__)
 from . import linearize
 from .linearize import *
 __all__.extend(linearize.__all__)
+
+from . import body
+from .body import *
+__all__.extend(body.__all__)

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,6 +1,6 @@
 from sympy import Symbol
-from sympy.physics.mechanics import RigidBody, Particle, ReferenceFrame, \
-    inertia
+from sympy.physics.mechanics import (RigidBody, Particle, ReferenceFrame,
+                                     inertia)
 from sympy.physics.vector import Point, Vector
 
 __all__ = ['Body']
@@ -16,25 +16,25 @@ class Body(RigidBody, Particle):
     either of them based on the arguments passed.
 
     Parameters
-    ---------
+    ----------
     name: string
         defines the name of the body. It is used as the base for defining body
         specific properties.
-    masscenter : Point (optional)
+    masscenter : Point, optional
         The point which represents the center of mass of the rigid body.
     frame : ReferenceFrame (optional)
         The ReferenceFrame which the rigid body is fixed in.
-    mass : Sympifyable (optional)
+    mass : Sympifyable, optional
         The body's mass.
     body_inertia : Dyadic (instance of inertia)
         The body's inertia about center of mass.
 
-    Example:
+    Examples
     --------
     1. Default behaviour. It creates a RigidBody after defining mass,
      masscenter, frame and inertia.
 
-    >>> from pydy.bodies import Body
+    >>> from sympy.physics.mechanics import Body
     >>> body = Body('name_of_body')
 
     2. Passing attributes of Rigidbody. All the arguments needed to create a
@@ -53,7 +53,7 @@ class Body(RigidBody, Particle):
      not then a Particle is created.
 
     >>> from sympy import Symbol
-    >>> from sympy import Point
+    >>> from sympy.physics.vector import Point
     >>> from sympy.physics.mechanics import Body
     >>> mass = Symbol('mass')
     >>> masscenter = Point('masscenter')
@@ -111,12 +111,14 @@ class Body(RigidBody, Particle):
             tuple defines the values of vector in x, y and z directions of the
             frame.
         point: Point
-            Defines the point on which the force must be applied.
+            Defines the point on which the force must be applied. Default is
+            Body's masscenter.
         frame: ReferenceFrame
-            Defines the frame w.r.t which force vector must be defined.
+            Defines the frame w.r.t which force vector must be defined. Default
+            is Body's frame.
 
         Example
-        --------
+        -------
         To add a force of magnitude 1 in y direction on a point at distance of
         1 in x direction. All the directions are w.r.t body's frame.
 
@@ -124,7 +126,7 @@ class Body(RigidBody, Particle):
         >>> from sympy.physics.mechanics import Body
         >>> body = Body('body')
         >>> g = Symbol('g')
-        >>> body.add_force((body.get_mass() * g, 0, 0), body.get_masscenter())
+        >>> body.add_force((body.mass * g, 0, 0), body.masscenter)
 
         To define the force_vector w.r.t some other frame, pass the frame as well.
 
@@ -133,9 +135,9 @@ class Body(RigidBody, Particle):
         >>> parent = Body('parent')
         >>> child = Body('child')
         >>> g = Symbol('g')
-        >>> frame = parent.get_frame()
-        >>> masscenter = child.get_masscenter()
-        >>> gravity = child.get_mass() * g
+        >>> frame = parent.frame
+        >>> masscenter = child.masscenter
+        >>> gravity = child.mass * g
         >>> body.add_force((gravity, 0, 0), masscenter, frame)
 
         """

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -162,7 +162,7 @@ class Body(RigidBody, Particle):
         Parameters
         ----------
         vec: Vector
-            Defines the force vector. Can be any vector w.r.t any frame or
+        Defines the torque vector. Can be any vector w.r.t any frame or
             combinations of frame.
         """
         if not isinstance(vec, Vector):

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,0 +1,167 @@
+from sympy import Symbol
+from sympy.physics.mechanics import RigidBody, Particle, ReferenceFrame, \
+    inertia
+from sympy.physics.vector import Point, Vector
+
+__all__ = ['Body']
+
+
+class Body(RigidBody, Particle):
+    """
+    A Body which can be connected by joints.
+
+    Instances of Body can be connected using specific joints and can further
+    be used to generate equations of motion. It can be seen as an extension
+    of already present RigidBody and Particle classes and can inherit from
+    either of them based on the arguments passed.
+
+    Parameters
+    ---------
+    name: string
+        defines the name of the body. It is used as the base for defining body
+        specific properties.
+    masscenter : Point (optional)
+        The point which represents the center of mass of the rigid body.
+    frame : ReferenceFrame (optional)
+        The ReferenceFrame which the rigid body is fixed in.
+    mass : Sympifyable (optional)
+        The body's mass.
+    body_inertia : Dyadic (instance of inertia)
+        The body's inertia about center of mass.
+
+    Example:
+    --------
+    1. Default behaviour. It creates a RigidBody after defining mass,
+     masscenter, frame and inertia.
+
+    >>> from pydy.bodies import Body
+    >>> body = Body('name_of_body')
+
+    2. Passing attributes of Rigidbody. All the arguments needed to create a
+     RigidBody can be passed while creating a Body too.
+
+    >>> from sympy import Symbol
+    >>> from sympy.physics.mechanics import ReferenceFrame, Point, inertia
+    >>> from sympy.physics.mechanics import Body
+    >>> mass = Symbol('mass')
+    >>> masscenter = Point('masscenter')
+    >>> frame = ReferenceFrame('frame')
+    >>> body_inertia = inertia(frame, 1, 0, 0)
+    >>> body = Body('name_of_body', masscenter, mass, frame, body_inertia)
+
+    3. Creating a Particle. If masscenter and mass are passed, and inertia is
+     not then a Particle is created.
+
+    >>> from sympy import Symbol
+    >>> from sympy import Point
+    >>> from sympy.physics.mechanics import Body
+    >>> mass = Symbol('mass')
+    >>> masscenter = Point('masscenter')
+    >>> body = Body('name_of_body', masscenter, mass)
+
+    Similarly, A frame can also be passed while creating a Particle.
+
+    """
+    def __init__(self, name, masscenter=None, mass=None, frame=None,
+                 body_inertia=None):
+
+        self.parent = None
+        self.child = None
+        self.force_list = []
+        self._counter = 0
+
+        if masscenter is None:
+            self._masscenter = Point(name + '_masscenter')
+        else:
+            self._masscenter = masscenter
+
+        if mass is None:
+            _mass = Symbol(name + '_mass')
+        else:
+            _mass = mass
+
+        if frame is None:
+            self._frame = ReferenceFrame(name + '_frame')
+        else:
+            self._frame = frame
+
+        if body_inertia is None and mass is None:
+            _inertia = (inertia(self._frame, 1, 1, 1), self._masscenter)
+        else:
+            _inertia = (body_inertia, self._masscenter)
+
+        self._masscenter.set_vel(self._frame, 0)
+
+        # If user passes masscenter and mass then a particle is created
+        # otherwise a rigidbody. As a result a body may or may not have inertia.
+        if body_inertia is None and mass is not None:
+            Particle.__init__(self, name, self._masscenter, _mass)
+        else:
+            RigidBody.__init__(self, name, self._masscenter, self._frame, _mass, _inertia)
+
+    def add_force(self, force_vector, point=None, frame=None):
+        """
+        Adds force to the body by adding a force vector in form of a tuple
+        of length 3 and a point on which the force will be applied.
+
+        Parameters
+        ---------
+        force_vector: A 3-Tuple
+            Defines the force vector w.r.t frame passed (or Body's frame). The
+            tuple defines the values of vector in x, y and z directions of the
+            frame.
+        point: Point
+            Defines the point on which the force must be applied.
+        frame: ReferenceFrame
+            Defines the frame w.r.t which force vector must be defined.
+
+        Example
+        --------
+        To add a force of magnitude 1 in y direction on a point at distance of
+        1 in x direction. All the directions are w.r.t body's frame.
+
+        >>> from sympy import Symbol
+        >>> from sympy.physics.mechanics import Body
+        >>> body = Body('body')
+        >>> g = Symbol('g')
+        >>> body.add_force((body.get_mass() * g, 0, 0), body.get_masscenter())
+
+        To define the force_vector w.r.t some other frame, pass the frame as well.
+
+        >>> from sympy import Symbol
+        >>> from sympy.physics.mechanics import Body
+        >>> parent = Body('parent')
+        >>> child = Body('child')
+        >>> g = Symbol('g')
+        >>> frame = parent.get_frame()
+        >>> masscenter = child.get_masscenter()
+        >>> gravity = child.get_mass() * g
+        >>> body.add_force((gravity, 0, 0), masscenter, frame)
+
+        """
+        if point is None:
+            point = self._masscenter  # masscenter
+
+        if frame is None:
+            frame = self._frame
+
+        if not isinstance(force_vector, tuple):
+            raise TypeError("Force vector must be a tuple of length 3")
+        else:
+            force_vector = self._convert_tuple_to_vector(force_vector, frame)
+        self.force_list.append((point, force_vector))
+        self._counter += 1
+
+    def _convert_tuple_to_vector(self, pos_tuple, frame):
+        """
+        converts 3-Tuple into a vector in given frame. Values of the Tuple
+        corresponds with x, y and z axis of the frame.
+        """
+        if len(pos_tuple) != 3:
+            raise TypeError('position tuple must be of length 3')
+        else:
+            unit_vectors = [frame.x, frame.y, frame.z]
+            vector = Vector(0)
+            for i in range(3):
+                vector += pos_tuple[i] * unit_vectors[i]
+            return vector

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -34,14 +34,14 @@ class Body(RigidBody, Particle):
 
     Examples
     --------
-    1. Default behaviour. It creates a RigidBody after defining mass,
-     mass center, frame and inertia.
+    Default behaviour. It creates a RigidBody after defining mass,
+    mass center, frame and inertia.
 
     >>> from sympy.physics.mechanics import Body
     >>> body = Body('name_of_body')
 
-    2. Passing attributes of Rigidbody. All the arguments needed to create a
-     RigidBody can be passed while creating a Body too.
+    Passing attributes of Rigidbody. All the arguments needed to create a
+    RigidBody can be passed while creating a Body too.
 
     >>> from sympy import Symbol
     >>> from sympy.physics.mechanics import ReferenceFrame, Point, inertia
@@ -53,8 +53,8 @@ class Body(RigidBody, Particle):
     >>> body_inertia = inertia(frame, ixx, 0, 0)
     >>> body = Body('name_of_body',masscenter,mass,frame,body_inertia)
 
-    3. Creating a Particle. If masscenter and mass are passed, and inertia is
-     not then a Particle is created.
+    Creating a Particle. If masscenter and mass are passed, and inertia is
+    not then a Particle is created.
 
     >>> from sympy import Symbol
     >>> from sympy.physics.vector import Point

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -65,8 +65,7 @@ class Body(RigidBody, Particle):
     def __init__(self, name, masscenter=None, mass=None, frame=None,
                  body_inertia=None):
 
-        self.parent = None
-        self.child = None
+        self.name = name
         self.force_list = []
         self._counter = 0
 

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,4 +1,4 @@
-from sympy import Symbol
+from sympy import Symbol, symbols
 from sympy.physics.mechanics import (RigidBody, Particle, ReferenceFrame,
                                      inertia)
 from sympy.physics.vector import Point, Vector
@@ -8,22 +8,21 @@ __all__ = ['Body']
 
 class Body(RigidBody, Particle):
     """
-    A Body which can be connected by joints.
+    Body is a common representation of RigidBody or a Particle.
 
-    Instances of Body can be connected using specific joints and can further
-    be used to generate equations of motion. It can be seen as an extension
-    of already present RigidBody and Particle classes and can inherit from
-    either of them based on the arguments passed.
+    A Body represents either a rigid body or particle in classical mechanics.
+    Bodies have a body-fixed reference frame, a mass, a mass center and
+    possibly a body-fixed inertia.
 
     Parameters
     ----------
-    name: string
-        defines the name of the body. It is used as the base for defining body
+    name: String
+        Defines the name of the body. It is used as the base for defining body
         specific properties.
     masscenter : Point, optional
         The point which represents the center of mass of the rigid body.
     frame : ReferenceFrame (optional)
-        The ReferenceFrame which the rigid body is fixed in.
+        The ReferenceFrame in which the rigid body is fixed.
     mass : Sympifyable, optional
         The body's mass.
     body_inertia : Dyadic (instance of inertia)
@@ -32,7 +31,7 @@ class Body(RigidBody, Particle):
     Examples
     --------
     1. Default behaviour. It creates a RigidBody after defining mass,
-     masscenter, frame and inertia.
+     mass center, frame and inertia.
 
     >>> from sympy.physics.mechanics import Body
     >>> body = Body('name_of_body')
@@ -46,7 +45,8 @@ class Body(RigidBody, Particle):
     >>> mass = Symbol('mass')
     >>> masscenter = Point('masscenter')
     >>> frame = ReferenceFrame('frame')
-    >>> body_inertia = inertia(frame, 1, 0, 0)
+    >>> ixx = Symbol('ixx')
+    >>> body_inertia = inertia(frame, ixx, 0, 0)
     >>> body = Body('name_of_body', masscenter, mass, frame, body_inertia)
 
     3. Creating a Particle. If masscenter and mass are passed, and inertia is
@@ -66,13 +66,12 @@ class Body(RigidBody, Particle):
                  body_inertia=None):
 
         self.name = name
-        self.force_list = []
-        self._counter = 0
+        self.loads = []
 
         if masscenter is None:
-            self._masscenter = Point(name + '_masscenter')
+            _masscenter = Point(name + '_masscenter')
         else:
-            self._masscenter = masscenter
+            _masscenter = masscenter
 
         if mass is None:
             _mass = Symbol(name + '_mass')
@@ -80,54 +79,54 @@ class Body(RigidBody, Particle):
             _mass = mass
 
         if frame is None:
-            self._frame = ReferenceFrame(name + '_frame')
+            _frame = ReferenceFrame(name + '_frame')
         else:
-            self._frame = frame
+            _frame = frame
 
         if body_inertia is None and mass is None:
-            _inertia = (inertia(self._frame, 1, 1, 1), self._masscenter)
+            ixx, iyy, izz, ixz, ixy, iyz = symbols('ixx iyy izz ixz ixy iyz')
+            _inertia = (inertia(_frame, ixx, iyy, izz, ixz, ixy, iyz),
+                        _masscenter)
         else:
-            _inertia = (body_inertia, self._masscenter)
+            _inertia = (body_inertia, _masscenter)
 
-        self._masscenter.set_vel(self._frame, 0)
+        _masscenter.set_vel(_frame, 0)
 
         # If user passes masscenter and mass then a particle is created
         # otherwise a rigidbody. As a result a body may or may not have inertia.
         if body_inertia is None and mass is not None:
-            Particle.__init__(self, name, self._masscenter, _mass)
+            self.frame = _frame
+            self.masscenter = _masscenter
+            Particle.__init__(self, name, _masscenter, _mass)
         else:
-            RigidBody.__init__(self, name, self._masscenter, self._frame, _mass, _inertia)
+            RigidBody.__init__(self, name, _masscenter, _frame, _mass, _inertia)
 
-    def add_force(self, force_vector, point=None, frame=None):
+    def apply_force(self, vec, point=None):
         """
-        Adds force to the body by adding a force vector in form of a tuple
-        of length 3 and a point on which the force will be applied.
+        Adds the force to the point (masscenter by default) on the body.
 
         Parameters
-        ---------
-        force_vector: A 3-Tuple
-            Defines the force vector w.r.t frame passed (or Body's frame). The
-            tuple defines the values of vector in x, y and z directions of the
-            frame.
-        point: Point
+        ----------
+        vec: Vector
+            Defines the force vector. Can be any vector w.r.t any frame or
+            combinations of frame.
+        point: Point, optional
             Defines the point on which the force must be applied. Default is
             Body's masscenter.
-        frame: ReferenceFrame
-            Defines the frame w.r.t which force vector must be defined. Default
-            is Body's frame.
 
         Example
         -------
-        To add a force of magnitude 1 in y direction on a point at distance of
-        1 in x direction. All the directions are w.r.t body's frame.
+        To apply a unit force in x direction of body's frame to body's
+        masscenter.
 
         >>> from sympy import Symbol
         >>> from sympy.physics.mechanics import Body
         >>> body = Body('body')
         >>> g = Symbol('g')
-        >>> body.add_force((body.mass * g, 0, 0), body.masscenter)
+        >>> body.apply_force(body.mass * g * body.frame.x)
 
-        To define the force_vector w.r.t some other frame, pass the frame as well.
+        To apply force to any other point than masscenter, pass that point
+        as well.
 
         >>> from sympy import Symbol
         >>> from sympy.physics.mechanics import Body
@@ -135,34 +134,32 @@ class Body(RigidBody, Particle):
         >>> child = Body('child')
         >>> g = Symbol('g')
         >>> frame = parent.frame
-        >>> masscenter = child.masscenter
+        >>> l = Symbol('l')
+        >>> point = child.masscenter.locatenew('force_point', l * body.frame.y)
         >>> gravity = child.mass * g
-        >>> body.add_force((gravity, 0, 0), masscenter, frame)
+        >>> body.apply_force(gravity * body.frame.x, point)
 
         """
-        if point is None:
-            point = self._masscenter  # masscenter
+        if not isinstance(point, Point):
+            if point is None:
+                point = self.masscenter  # masscenter
+            else:
+                raise TypeError("A Point must be supplied to apply force to.")
+        if not isinstance(vec, Vector):
+            raise TypeError("A Vector must be supplied to apply force.")
 
-        if frame is None:
-            frame = self._frame
+        self.loads.append((point, vec))
 
-        if not isinstance(force_vector, tuple):
-            raise TypeError("Force vector must be a tuple of length 3")
-        else:
-            force_vector = self._convert_tuple_to_vector(force_vector, frame)
-        self.force_list.append((point, force_vector))
-        self._counter += 1
-
-    def _convert_tuple_to_vector(self, pos_tuple, frame):
+    def apply_torque(self, vec):
         """
-        converts 3-Tuple into a vector in given frame. Values of the Tuple
-        corresponds with x, y and z axis of the frame.
+        Adds torque to the body.
+
+        Parameters
+        ----------
+        vec: Vector
+            Defines the force vector. Can be any vector w.r.t any frame or
+            combinations of frame.
         """
-        if len(pos_tuple) != 3:
-            raise TypeError('position tuple must be of length 3')
-        else:
-            unit_vectors = [frame.x, frame.y, frame.z]
-            vector = Vector(0)
-            for i in range(3):
-                vector += pos_tuple[i] * unit_vectors[i]
-            return vector
+        if not isinstance(vec, Vector):
+            raise TypeError("A Vector must be supplied to add torque.")
+        self.loads.append((self.frame, vec))

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -13,8 +13,9 @@ def test_default():
     frame = body.frame
     assert com.vel(frame) == point.vel(frame)
     assert body.mass == Symbol('body_mass')
-    ixx, iyy, izz, ixz, ixy, iyz = symbols('ixx iyy izz ixz ixy iyz')
-    assert body.inertia == (inertia(body.frame, ixx, iyy, izz, ixz, ixy, iyz),
+    ixx, iyy, izz = symbols('body_ixx body_iyy body_izz')
+    ixy, iyz, izx = symbols('body_ixy body_iyz body_izx')
+    assert body.inertia == (inertia(body.frame, ixx, iyy, izz, ixy, iyz, izx),
                             body.masscenter)
 
 
@@ -25,7 +26,7 @@ def test_custom_rigid_body():
     rigidbody_frame = ReferenceFrame('rigidbody_frame')
     body_inertia = inertia(rigidbody_frame, 1, 0, 0)
     rigid_body = Body('rigidbody_body', rigidbody_masscenter, rigidbody_mass,
-               rigidbody_frame, body_inertia)
+                      rigidbody_frame, body_inertia)
     com = rigid_body.masscenter
     frame = rigid_body.frame
     rigidbody_masscenter.set_vel(rigidbody_frame, 0)
@@ -67,7 +68,7 @@ def test_particle_body_add_force():
     particle_mass = Symbol('particle_mass')
     particle_frame = ReferenceFrame('particle_frame')
     particle_body = Body('particle_body', particle_masscenter, particle_mass,
-                  particle_frame)
+                         particle_frame)
 
     a = Symbol('a')
     force_vector = a * particle_body.frame.x
@@ -92,7 +93,7 @@ def test_body_add_force():
     rigidbody_frame = ReferenceFrame('rigidbody_frame')
     body_inertia = inertia(rigidbody_frame, 1, 0, 0)
     rigid_body = Body('rigidbody_body', rigidbody_masscenter, rigidbody_mass,
-               rigidbody_frame, body_inertia)
+                      rigidbody_frame, body_inertia)
 
     l = Symbol('l')
     Fa = Symbol('Fa')

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from sympy import Symbol
 from sympy.physics.vector import Point, ReferenceFrame
 from sympy.physics.mechanics import inertia, Body
@@ -25,13 +22,13 @@ def test_default():
     assert body.child is None
     assert body.force_list == []
     point = Point('body_masscenter')
-    point.set_vel(body.get_frame(), 0)
-    com = body.get_masscenter()
-    frame = body.get_frame()
+    point.set_vel(body.frame, 0)
+    com = body.masscenter
+    frame = body.frame
     assert com.vel(frame) == point.vel(frame)
-    assert body.get_mass() == Symbol('body_mass')
-    # check_reference_frames(body.get_frame(), ReferenceFrame('body_frame'))
-    assert body.get_inertia() == (inertia(body.get_frame(), 1, 1, 1), body.get_masscenter())
+    assert body.mass == Symbol('body_mass')
+    # check_reference_frames(body.frame, ReferenceFrame('body_frame'))
+    assert body.inertia == (inertia(body.frame, 1, 1, 1), body.masscenter)
 
 
 def test_custom_rigid_body():
@@ -42,15 +39,15 @@ def test_custom_rigid_body():
     body_inertia = inertia(rigidbody_frame, 1, 0, 0)
     rigid_body = Body('rigidbody_body', rigidbody_masscenter, rigidbody_mass,
                rigidbody_frame, body_inertia)
-    com = rigid_body.get_masscenter()
-    frame = rigid_body.get_frame()
+    com = rigid_body.masscenter
+    frame = rigid_body.frame
     rigidbody_masscenter.set_vel(rigidbody_frame, 0)
     assert com.vel(frame) == rigidbody_masscenter.vel(frame)
     assert com.pos_from(com) == rigidbody_masscenter.pos_from(com)
 
-    assert rigid_body.get_mass() == rigidbody_mass
-    # check_reference_frames(rigid_body.get_frame(), rigidbody_frame)
-    assert rigid_body.get_inertia() == (body_inertia, rigidbody_masscenter)
+    assert rigid_body.mass == rigidbody_mass
+    # check_reference_frames(rigid_body.frame, rigidbody_frame)
+    assert rigid_body.inertia == (body_inertia, rigidbody_masscenter)
 
 
 def test_particle_body():
@@ -60,14 +57,14 @@ def test_particle_body():
     particle_frame = ReferenceFrame('particle_frame')
     particle_body = Body('particle_body', particle_masscenter, particle_mass,
                   particle_frame)
-    com = particle_body.get_masscenter()
-    frame = particle_body.get_frame()
+    com = particle_body.masscenter
+    frame = particle_body.frame
     particle_masscenter.set_vel(particle_frame, 0)
     assert com.vel(frame) == particle_masscenter.vel(frame)
     assert com.pos_from(com) == particle_masscenter.pos_from(com)
 
-    assert particle_body.get_mass() == particle_mass
-    # check_reference_frames(particle_body.get_frame(), particle_frame)
+    assert particle_body.mass == particle_mass
+    # check_reference_frames(particle_body.frame, particle_frame)
     assert not hasattr(particle_body, "_inertia")
 
 
@@ -80,15 +77,15 @@ def test_particle_body_add_force():
                   particle_frame)
 
     a = Symbol('a')
-    particle_body.add_force((a, 0, 0), particle_body.get_masscenter())
+    particle_body.add_force((a, 0, 0), particle_body.masscenter)
     assert len(particle_body.force_list) == 1
-    point = particle_body.get_masscenter().locatenew(
+    point = particle_body.masscenter.locatenew(
         particle_body._name + '_point0', 0)
-    point.set_vel(particle_body.get_frame(), 0)
-    force_vector = a * particle_body.get_frame().x
+    point.set_vel(particle_body.frame, 0)
+    force_vector = a * particle_body.frame.x
     force_point = particle_body.force_list[0][0]
 
-    frame = particle_body.get_frame()
+    frame = particle_body.frame
     assert force_point.vel(frame) == point.vel(frame)
     assert force_point.pos_from(force_point) == point.pos_from(force_point)
 
@@ -106,15 +103,15 @@ def test_body_add_force():
 
     l = Symbol('l')
     Fa = Symbol('Fa')
-    point = rigid_body.get_masscenter().locatenew(
+    point = rigid_body.masscenter.locatenew(
         'rigidbody_body_point0',
-        l * rigid_body.get_frame().x)
-    point.set_vel(rigid_body.get_frame(), 0)
+        l * rigid_body.frame.x)
+    point.set_vel(rigid_body.frame, 0)
     rigid_body.add_force((0, 0, Fa), point)
     assert len(rigid_body.force_list) == 1
-    force_vector = Fa * rigid_body.get_frame().z
+    force_vector = Fa * rigid_body.frame.z
     force_point = rigid_body.force_list[0][0]
-    frame = rigid_body.get_frame()
+    frame = rigid_body.frame
     assert force_point.vel(frame) == point.vel(frame)
     assert force_point.pos_from(force_point) == point.pos_from(force_point)
 

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -17,9 +17,7 @@ def check_reference_frames(frame1, frame2):
 
 def test_default():
     body = Body('body')
-    assert body._name == 'body'
-    assert body.parent is None
-    assert body.child is None
+    assert body.name == 'body'
     assert body.force_list == []
     point = Point('body_masscenter')
     point.set_vel(body.frame, 0)
@@ -27,7 +25,6 @@ def test_default():
     frame = body.frame
     assert com.vel(frame) == point.vel(frame)
     assert body.mass == Symbol('body_mass')
-    # check_reference_frames(body.frame, ReferenceFrame('body_frame'))
     assert body.inertia == (inertia(body.frame, 1, 1, 1), body.masscenter)
 
 
@@ -46,7 +43,6 @@ def test_custom_rigid_body():
     assert com.pos_from(com) == rigidbody_masscenter.pos_from(com)
 
     assert rigid_body.mass == rigidbody_mass
-    # check_reference_frames(rigid_body.frame, rigidbody_frame)
     assert rigid_body.inertia == (body_inertia, rigidbody_masscenter)
 
 
@@ -64,7 +60,6 @@ def test_particle_body():
     assert com.pos_from(com) == particle_masscenter.pos_from(com)
 
     assert particle_body.mass == particle_mass
-    # check_reference_frames(particle_body.frame, particle_frame)
     assert not hasattr(particle_body, "_inertia")
 
 

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -1,7 +1,7 @@
 from sympy import Symbol, symbols
 from sympy.physics.vector import Point, ReferenceFrame
 from sympy.physics.mechanics import inertia, Body
-
+from sympy.utilities.pytest import raises
 
 def test_default():
     body = Body('body')
@@ -102,6 +102,7 @@ def test_body_add_force():
         l * rigid_body.frame.x)
     point.set_vel(rigid_body.frame, 0)
     force_vector = Fa * rigid_body.frame.z
+    # apply_force with point
     rigid_body.apply_force(force_vector, point)
     assert len(rigid_body.loads) == 1
     force_point = rigid_body.loads[0][0]
@@ -109,7 +110,13 @@ def test_body_add_force():
     assert force_point.vel(frame) == point.vel(frame)
     assert force_point.pos_from(force_point) == point.pos_from(force_point)
     assert rigid_body.loads[0][1] == force_vector
-
+    # apply_force without point
+    rigid_body.apply_force(force_vector)
+    assert len(rigid_body.loads) == 2
+    assert rigid_body.loads[1][1] == force_vector
+    # passing something else than point
+    raises(TypeError, lambda: rigid_body.apply_force(force_vector,  0))
+    raises(TypeError, lambda: rigid_body.apply_force(0))
 
 def test_body_add_torque():
     body = Body('body')
@@ -118,3 +125,4 @@ def test_body_add_torque():
 
     assert len(body.loads) == 1
     assert body.loads[0] == (body.frame, torque_vector)
+    raises(TypeError, lambda: body.apply_torque(0))

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from sympy import Symbol
+from sympy.physics.vector import Point, ReferenceFrame
+from sympy.physics.mechanics import inertia, Body
+
+
+# To test if two frames were created the same way.
+def check_reference_frames(frame1, frame2):
+    assert frame1.name == frame2.name
+    assert frame1.str_vecs == frame2.str_vecs
+    assert frame1.indices == frame2.indices
+    assert frame1.varlist == frame2.varlist
+    assert frame1._dlist == frame2._dlist
+    assert frame1._ang_vel_dict == frame2._ang_vel_dict
+    assert frame1._ang_acc_dict == frame2._ang_acc_dict
+    assert frame1._dcm_dict == frame2._dcm_dict
+
+
+def test_default():
+    body = Body('body')
+    assert body._name == 'body'
+    assert body.parent is None
+    assert body.child is None
+    assert body.force_list == []
+    point = Point('body_masscenter')
+    point.set_vel(body.get_frame(), 0)
+    com = body.get_masscenter()
+    frame = body.get_frame()
+    assert com.vel(frame) == point.vel(frame)
+    assert body.get_mass() == Symbol('body_mass')
+    # check_reference_frames(body.get_frame(), ReferenceFrame('body_frame'))
+    assert body.get_inertia() == (inertia(body.get_frame(), 1, 1, 1), body.get_masscenter())
+
+
+def test_custom_rigid_body():
+    # Body with RigidBody.
+    rigidbody_masscenter = Point('rigidbody_masscenter')
+    rigidbody_mass = Symbol('rigidbody_mass')
+    rigidbody_frame = ReferenceFrame('rigidbody_frame')
+    body_inertia = inertia(rigidbody_frame, 1, 0, 0)
+    rigid_body = Body('rigidbody_body', rigidbody_masscenter, rigidbody_mass,
+               rigidbody_frame, body_inertia)
+    com = rigid_body.get_masscenter()
+    frame = rigid_body.get_frame()
+    rigidbody_masscenter.set_vel(rigidbody_frame, 0)
+    assert com.vel(frame) == rigidbody_masscenter.vel(frame)
+    assert com.pos_from(com) == rigidbody_masscenter.pos_from(com)
+
+    assert rigid_body.get_mass() == rigidbody_mass
+    # check_reference_frames(rigid_body.get_frame(), rigidbody_frame)
+    assert rigid_body.get_inertia() == (body_inertia, rigidbody_masscenter)
+
+
+def test_particle_body():
+    #  Body with Particle
+    particle_masscenter = Point('particle_masscenter')
+    particle_mass = Symbol('particle_mass')
+    particle_frame = ReferenceFrame('particle_frame')
+    particle_body = Body('particle_body', particle_masscenter, particle_mass,
+                  particle_frame)
+    com = particle_body.get_masscenter()
+    frame = particle_body.get_frame()
+    particle_masscenter.set_vel(particle_frame, 0)
+    assert com.vel(frame) == particle_masscenter.vel(frame)
+    assert com.pos_from(com) == particle_masscenter.pos_from(com)
+
+    assert particle_body.get_mass() == particle_mass
+    # check_reference_frames(particle_body.get_frame(), particle_frame)
+    assert not hasattr(particle_body, "_inertia")
+
+
+def test_particle_body_add_force():
+    #  Body with Particle
+    particle_masscenter = Point('particle_masscenter')
+    particle_mass = Symbol('particle_mass')
+    particle_frame = ReferenceFrame('particle_frame')
+    particle_body = Body('particle_body', particle_masscenter, particle_mass,
+                  particle_frame)
+
+    a = Symbol('a')
+    particle_body.add_force((a, 0, 0), particle_body.get_masscenter())
+    assert len(particle_body.force_list) == 1
+    point = particle_body.get_masscenter().locatenew(
+        particle_body._name + '_point0', 0)
+    point.set_vel(particle_body.get_frame(), 0)
+    force_vector = a * particle_body.get_frame().x
+    force_point = particle_body.force_list[0][0]
+
+    frame = particle_body.get_frame()
+    assert force_point.vel(frame) == point.vel(frame)
+    assert force_point.pos_from(force_point) == point.pos_from(force_point)
+
+    assert particle_body.force_list[0][1] == force_vector
+
+
+def test_body_add_force():
+    # Body with RigidBody.
+    rigidbody_masscenter = Point('rigidbody_masscenter')
+    rigidbody_mass = Symbol('rigidbody_mass')
+    rigidbody_frame = ReferenceFrame('rigidbody_frame')
+    body_inertia = inertia(rigidbody_frame, 1, 0, 0)
+    rigid_body = Body('rigidbody_body', rigidbody_masscenter, rigidbody_mass,
+               rigidbody_frame, body_inertia)
+
+    l = Symbol('l')
+    Fa = Symbol('Fa')
+    point = rigid_body.get_masscenter().locatenew(
+        'rigidbody_body_point0',
+        l * rigid_body.get_frame().x)
+    point.set_vel(rigid_body.get_frame(), 0)
+    rigid_body.add_force((0, 0, Fa), point)
+    assert len(rigid_body.force_list) == 1
+    force_vector = Fa * rigid_body.get_frame().z
+    force_point = rigid_body.force_list[0][0]
+    frame = rigid_body.get_frame()
+    assert force_point.vel(frame) == point.vel(frame)
+    assert force_point.pos_from(force_point) == point.pos_from(force_point)
+
+    assert rigid_body.force_list[0][1] == force_vector


### PR DESCRIPTION
Body class for creating Joints using new JointsMethod.
- [x] There are no merge conflicts.
- [x] If there is a related issue, a reference to that issue is in the
  commit message.
- [x] Unit tests have been added for the new feature.
- [x] The PR passes tests both locally (run `nosetests`) and on Travis CI.
- [x] All public methods and classes have docstrings. (We use the [numpydoc
  format](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).)
- [ ] An explanation has been added to the online documentation. (`docs`
  directory)
- [x] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The new feature is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [x] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [x] All reviewer comments have been addressed.
- [x] Add the body class to the Sphinx api docs so that the docstrings are rendered in the sphinx docs.
- [x] Add the ability to apply torques.
