### PR TITLE
Fix LaTeX rendering bug in IPython notebook (fixes #9799)

### DIFF
--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -125,3 +125,7 @@ def test_matplotlib_bad_latex():
 
     # This should not raise an exception
     app.run_cell("a = format(Matrix([1, 2, 3]))")
+
+    # issue 9799
+    app.run_cell("from sympy import Piecewise, Symbol, Eq")
+    app.run_cell("x = Symbol('x'); pw = format(Piecewise((1, Eq(x, 0)), (0, True)))")

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -1,8 +1,10 @@
 from __future__ import print_function, division
 
 from os.path import join
+from itertools import chain
 import tempfile
 import shutil
+import sys
 import io
 from io import BytesIO
 
@@ -12,7 +14,7 @@ try:
 except ImportError:
     pass
 
-from sympy.core.compatibility import unicode
+from sympy.core.compatibility import unicode, u
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import find_executable
@@ -187,7 +189,14 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         workdir = tempfile.mkdtemp()
 
         with io.open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
-            fh.write(unicode(latex_main % latex_string))
+            if sys.version_info[0] == 2:
+                # Work around for issue 9107
+                for esc in chain([r'\\'], 'abfnrtuvxNU01234567'):
+                    latex_string = latex_string.replace('\\'+esc, '\\\\'+esc)
+                latex_string = u(latex_string)
+                fh.write(unicode(latex_main) % latex_string)
+            else:
+                fh.write(latex_main % latex_string)
 
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -188,7 +188,8 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
         with io.open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
             rendered = latex_main % latex_string
-            fh.write(u(rendered.replace(r'\u', r'\\u')))
+            # escape \ before calling u():
+            fh.write(u(rendered.replace('\\', '\\\\')))
 
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -189,7 +189,9 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
         with io.open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
             rendered = latex_main % latex_string
-            fh.write(unicode(rendered))
+            if sys.version_info[0] == 2:  # Python 2
+                rendered = unicode(rendered)
+            fh.write(rendered)
 
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division
 from os.path import join
 import tempfile
 import shutil
-import sys
 import io
 from io import BytesIO
 
@@ -13,7 +12,7 @@ try:
 except ImportError:
     pass
 
-from sympy.core.compatibility import u
+from sympy.core.compatibility import unicode
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import find_executable
@@ -188,10 +187,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         workdir = tempfile.mkdtemp()
 
         with io.open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
-            rendered = latex_main % latex_string
-            if sys.version_info[0] == 2:  # Python 2
-                rendered = unicode(rendered)
-            fh.write(rendered)
+            fh.write(unicode(latex_main % latex_string))
 
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from os.path import join
 import tempfile
 import shutil
+import sys
 import io
 from io import BytesIO
 
@@ -188,8 +189,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
         with io.open(join(workdir, 'texput.tex'), 'w', encoding='utf-8') as fh:
             rendered = latex_main % latex_string
-            # escape \ before calling u():
-            fh.write(u(rendered.replace('\\', '\\\\')))
+            fh.write(unicode(rendered))
 
         if outputTexFile is not None:
             shutil.copyfile(join(workdir, 'texput.tex'), outputTexFile)

--- a/sympy/printing/tests/test_preview.py
+++ b/sympy/printing/tests/test_preview.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from sympy import Symbol
+from sympy import Symbol, Piecewise, Eq
 from sympy.printing.preview import preview
 
 from io import BytesIO
@@ -14,10 +14,23 @@ def test_preview():
     except RuntimeError:
         pass  # latex not installed on CI server
 
+
+def test_preview_unicode_symbol():
     # issue 9107
     a = Symbol('α')
     obj = BytesIO()
     try:
         preview(a, output='png', viewer='BytesIO', outputbuffer=obj)
+    except RuntimeError:
+        pass  # latex not installed on CI server
+
+
+def test_preview_latex_construct_in_expr():
+    # see PR 9801
+    x = Symbol('x')
+    pw = Piecewise((1, Eq(x, 0)), (0, True))
+    obj = BytesIO()
+    try:
+        preview(pw, output='png', viewer='BytesIO', outputbuffer=obj)
     except RuntimeError:
         pass  # latex not installed on CI server


### PR DESCRIPTION
This commit makes `sympy.printing.preview.preview` escape all backslashed before calling `u()`.
It should fix #9799

Edit: note that the exception was raised in matplotlib's code base, (encoding issue). I am unsure how to add a regression test for this. Any suggestions welcome.
