### PR TITLE
Make dynamicsymbols real by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
         - TEST_THEANO="true"
         - TEST_ASCII="true"
         - TEST_AUTOWRAP="true"
-        - TEST_SYMENGINE="true"
       addons:
         apt:
           packages:
@@ -42,7 +41,6 @@ matrix:
         - TEST_THEANO="true"
         - TEST_ASCII="true"
         - TEST_AUTOWRAP="true"
-        - TEST_SYMENGINE="true"
       addons:
         apt:
           packages:
@@ -103,6 +101,7 @@ matrix:
         - TEST_SAGE="true"
         - FASTCACHE="false"
         - TEST_TENSORFLOW="true"
+        - TEST_SYMENGINE="true"
       sudo: true
       dist: trusty
 
@@ -164,11 +163,14 @@ matrix:
 
   allow_failures:
     # The apt installation of sage fails sometimes
+    # Symengine failures would require SymPy devs to fix them to complete a PR,
+    # which is too steep a requirement.
     - python: 3.5 # Dummy value
       env:
         - TEST_SAGE="true"
         - FASTCACHE="false"
         - TEST_TENSORFLOW="true"
+        - TEST_SYMENGINE="true"
       sudo: true
       dist: trusty
     # PyPy randomly fails because of some PyPy bugs (Fatal RPython error: AssertionError)

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -129,7 +129,7 @@ printing derivatives. ::
   >>> q1 = dynamicsymbols('q1')
   >>> q1
   q1(t)
-  >>> dynamicsymbols._t = symbols('T')
+  >>> dynamicsymbols.t = symbols('T')
   >>> q2 = dynamicsymbols('q2')
   >>> q2
   q2(T)
@@ -142,7 +142,7 @@ printing derivatives. ::
   >>> vprint(q1d)
   q1d
   >>> dynamicsymbols._str = '\''
-  >>> dynamicsymbols._t = symbols('t')
+  >>> dynamicsymbols.t = symbols('t')
 
 
 Note that only dynamic symbols created after the change are different. The same

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -151,6 +151,6 @@ so dynamic symbols created before or after will print the same way.
 The default symbol for time can also be accessed and changed with the
 ``get_time()`` and ``set_time()`` functions.
 
-Also note that ``Vector``'s ``.dt`` method uses the ``._t`` attribute of
+Also note that ``Vector``'s ``.dt`` method uses the ``.t`` attribute of
 ``dynamicsymbols``, along with a number of other important functions and
 methods. Don't mix and match symbols representing time.

--- a/doc/src/modules/physics/vector/advanced.rst
+++ b/doc/src/modules/physics/vector/advanced.rst
@@ -80,7 +80,6 @@ Using the acceleration level methods can result in shorted expressions at this
 point, which will result in shorter expressions later (such as when forming
 Kane's equations).
 
-
 Advanced Interfaces
 ===================
 
@@ -148,6 +147,9 @@ printing derivatives. ::
 Note that only dynamic symbols created after the change are different. The same
 is not true for the `._str` attribute; this affects the printing output only,
 so dynamic symbols created before or after will print the same way.
+
+The default symbol for time can also be accessed and changed with the
+``get_time()`` and ``set_time()`` functions.
 
 Also note that ``Vector``'s ``.dt`` method uses the ``._t`` attribute of
 ``dynamicsymbols``, along with a number of other important functions and

--- a/doc/src/modules/physics/vector/vectors.rst
+++ b/doc/src/modules/physics/vector/vectors.rst
@@ -694,7 +694,7 @@ derivative of such a 'dynamicsymbol' is shown below. ::
 
   >>> from sympy import diff
   >>> q1, q2, q3 = dynamicsymbols('q1 q2 q3')
-  >>> diff(q1, Symbol('t'))
+  >>> diff(q1, dynamicsymbols.t)
   Derivative(q1(t), t)
 
 The 'dynamicsymbol' printing is not very clear above; we will also introduce a
@@ -703,7 +703,7 @@ non-interactive sessions. ::
 
   >>> q1
   q1(t)
-  >>> q1d = diff(q1, Symbol('t'))
+  >>> q1d = diff(q1, dynamicsymbols.t)
   >>> vprint(q1)
   q1
   >>> vprint(q1d)

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -414,7 +414,7 @@ def find_dynamicsymbols(expression, exclude=None):
     >>> find_dynamicsymbols(expr, [x, y])
     {Derivative(x(t), t)}
     """
-    t_set = {dynamicsymbols._t}
+    t_set = {dynamicsymbols.t}
     if exclude:
         if iterable(exclude):
             exclude_set = set(exclude)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -152,7 +152,7 @@ class KanesMethod(object):
         q_ind = Matrix(q_ind)
         self._qdep = q_dep
         self._q = Matrix([q_ind, q_dep])
-        self._qdot = self.q.diff(dynamicsymbols._t)
+        self._qdot = self.q.diff(dynamicsymbols.t)
 
         # Initialize generalized speeds
         u_dep = none_handler(u_dep)
@@ -163,7 +163,7 @@ class KanesMethod(object):
         u_ind = Matrix(u_ind)
         self._udep = u_dep
         self._u = Matrix([u_ind, u_dep])
-        self._udot = self.u.diff(dynamicsymbols._t)
+        self._udot = self.u.diff(dynamicsymbols.t)
         self._uaux = none_handler(u_aux)
 
     def _initialize_constraint_matrices(self, config, vel, acc):
@@ -207,8 +207,8 @@ class KanesMethod(object):
             self._k_nh = (vel - self._f_nh).jacobian(self.u)
             # If no acceleration constraints given, calculate them.
             if not acc:
-                self._f_dnh = (self._k_nh.diff(dynamicsymbols._t) * self.u +
-                               self._f_nh.diff(dynamicsymbols._t))
+                self._f_dnh = (self._k_nh.diff(dynamicsymbols.t) * self.u +
+                               self._f_nh.diff(dynamicsymbols.t))
                 self._k_dnh = self._k_nh
             else:
                 if self._qdot_u_map is not None:
@@ -303,7 +303,7 @@ class KanesMethod(object):
         if not iterable(bl):
             raise TypeError('Bodies must be supplied in an iterable.')
 
-        t = dynamicsymbols._t
+        t = dynamicsymbols.t
         N = self._inertial
         # Dicts setting things to zero
         udot_zero = dict((i, 0) for i in self._udot)
@@ -443,7 +443,7 @@ class KanesMethod(object):
 
         # Form dictionary to set auxiliary speeds & their derivatives to 0.
         uaux = self._uaux
-        uauxdot = uaux.diff(dynamicsymbols._t)
+        uauxdot = uaux.diff(dynamicsymbols.t)
         uaux_zero = dict((i, 0) for i in Matrix([uaux, uauxdot]))
 
         # Checking for dynamic symbols outside the dynamic differential
@@ -461,7 +461,7 @@ class KanesMethod(object):
 
         # Check for any derivatives of variables in r that are also found in r.
         for i in r:
-            if diff(i, dynamicsymbols._t) in r:
+            if diff(i, dynamicsymbols.t) in r:
                 raise ValueError('Cannot have derivatives of specified \
                                  quantities when linearizing forcing terms.')
         return Linearizer(f_0, f_1, f_2, f_3, f_4, f_c, f_v, f_a, q, u, q_i,

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -158,13 +158,13 @@ class LagrangesMethod(object):
         if not iterable(qs):
             raise TypeError('Generalized coordinates must be an iterable')
         self._q = Matrix(qs)
-        self._qdots = self.q.diff(dynamicsymbols._t)
-        self._qdoubledots = self._qdots.diff(dynamicsymbols._t)
+        self._qdots = self.q.diff(dynamicsymbols.t)
+        self._qdoubledots = self._qdots.diff(dynamicsymbols.t)
 
         mat_build = lambda x: Matrix(x) if x else Matrix()
         hol_coneqs = mat_build(hol_coneqs)
         nonhol_coneqs = mat_build(nonhol_coneqs)
-        self.coneqs = Matrix([hol_coneqs.diff(dynamicsymbols._t),
+        self.coneqs = Matrix([hol_coneqs.diff(dynamicsymbols.t),
                 nonhol_coneqs])
         self._hol_coneqs = hol_coneqs
 
@@ -184,7 +184,7 @@ class LagrangesMethod(object):
 
         # First term
         self._term1 = self._L.jacobian(qds)
-        self._term1 = self._term1.diff(dynamicsymbols._t).T
+        self._term1 = self._term1.diff(dynamicsymbols.t).T
 
         # Second term
         self._term2 = self._L.jacobian(self.q).T
@@ -198,7 +198,7 @@ class LagrangesMethod(object):
             self.lam_coeffs = -coneqs.jacobian(qds)
             self._term3 = self.lam_coeffs.T * self.lam_vec
             # Extracting the coeffecients of the qdds from the diff coneqs
-            diffconeqs = coneqs.diff(dynamicsymbols._t)
+            diffconeqs = coneqs.diff(dynamicsymbols.t)
             self._m_cd = diffconeqs.jacobian(self._qdoubledots)
             # The remaining terms i.e. the 'forcing' terms in diff coneqs
             self._f_cd = -diffconeqs.subs(qdd_zero)
@@ -295,7 +295,7 @@ class LagrangesMethod(object):
         """
 
         # Compose vectors
-        t = dynamicsymbols._t
+        t = dynamicsymbols.t
         q = self.q
         u = self._qdots
         ud = u.diff(t)
@@ -337,7 +337,7 @@ class LagrangesMethod(object):
         r.sort(key=default_sort_key)
         # Check for any derivatives of variables in r that are also found in r.
         for i in r:
-            if diff(i, dynamicsymbols._t) in r:
+            if diff(i, dynamicsymbols.t) in r:
                 raise ValueError('Cannot have derivatives of specified \
                                  quantities when linearizing forcing terms.')
 

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -76,8 +76,8 @@ class Linearizer(object):
         self.lams = none_handler(lams)
 
         # Derivatives of generalized equation variables
-        self._qd = self.q.diff(dynamicsymbols._t)
-        self._ud = self.u.diff(dynamicsymbols._t)
+        self._qd = self.q.diff(dynamicsymbols.t)
+        self._ud = self.u.diff(dynamicsymbols.t)
         # If the user doesn't actually use generalized variables, and the
         # qd and u vectors have any intersecting variables, this can cause
         # problems. We'll fix this with some hackery, and Dummy variables

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -424,7 +424,7 @@ class SymbolicSystem(object):
         constants = set()
         for expr in eom_expressions:
             constants = constants.union(expr.free_symbols)
-        constants.remove(dynamicsymbols._t)
+        constants.remove(dynamicsymbols.t)
 
         return tuple(constants)
 

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -8,7 +8,7 @@ from sympy.physics.mechanics import (angular_momentum, dynamicsymbols,
                                      find_dynamicsymbols)
 
 Vector.simp = True
-q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
+q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5', real=True)
 N = ReferenceFrame('N')
 A = N.orientnew('A', 'Axis', [q1, N.z])
 B = A.orientnew('B', 'Axis', [q2, A.x])
@@ -17,8 +17,8 @@ C = B.orientnew('C', 'Axis', [q3, B.y])
 
 def test_inertia():
     N = ReferenceFrame('N')
-    ixx, iyy, izz = symbols('ixx iyy izz')
-    ixy, iyz, izx = symbols('ixy iyz izx')
+    ixx, iyy, izz = symbols('ixx iyy izz', real=True)
+    ixy, iyz, izx = symbols('ixy iyz izx', real=True)
     assert inertia(N, ixx, iyy, izz) == (ixx * (N.x | N.x) + iyy *
             (N.y | N.y) + izz * (N.z | N.z))
     assert inertia(N, 0, 0, 0) == 0 * (N.x | N.x)
@@ -29,7 +29,7 @@ def test_inertia():
 
 
 def test_inertia_of_point_mass():
-    r, s, t, m = symbols('r s t m')
+    r, s, t, m = symbols('r s t m', real=True)
     N = ReferenceFrame('N')
 
     px = r * N.x
@@ -74,7 +74,7 @@ def test_angular_momentum_and_linear_momentum():
     particle of mass m fixed to the end of the rod rotate with an angular rate
     of omega about point O which is fixed to the non-particle end of the rod.
     The rod's reference frame is A and the inertial frame is N."""
-    m, M, l, I = symbols('m, M, l, I')
+    m, M, l, I = symbols('m, M, l, I', real=True)
     omega = dynamicsymbols('omega')
     N = ReferenceFrame('N')
     a = ReferenceFrame('a')
@@ -94,7 +94,7 @@ def test_angular_momentum_and_linear_momentum():
 
 
 def test_kinetic_energy():
-    m, M, l1 = symbols('m M l1')
+    m, M, l1 = symbols('m M l1', real=True)
     omega = dynamicsymbols('omega')
     N = ReferenceFrame('N')
     O = Point('O')
@@ -113,7 +113,7 @@ def test_kinetic_energy():
 
 
 def test_potential_energy():
-    m, M, l1, g, h, H = symbols('m M l1 g h H')
+    m, M, l1, g, h, H = symbols('m M l1 g h H', real=True)
     omega = dynamicsymbols('omega')
     N = ReferenceFrame('N')
     O = Point('O')
@@ -133,7 +133,7 @@ def test_potential_energy():
 
 
 def test_msubs():
-    a, b = symbols('a, b')
+    a, b = symbols('a, b', real=True)
     x, y, z = dynamicsymbols('x, y, z')
     # Test simple substitution
     expr = Matrix([[a*x + b, x*y.diff() + y],
@@ -157,7 +157,7 @@ def test_msubs():
 
 
 def test_find_dynamicsymbols():
-    a, b = symbols('a, b')
+    a, b = symbols('a, b', real=True)
     x, y, z = dynamicsymbols('x, y, z')
     expr = Matrix([[a*x + b, x*y.diff() + y],
                    [x.diff().diff(), z + sin(z.diff())]])

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -14,7 +14,7 @@ def test_one_dof():
     # It is described in more detail in the KanesMethod docstring.
     q, u = dynamicsymbols('q u')
     qd, ud = dynamicsymbols('q u', 1)
-    m, c, k = symbols('m c k')
+    m, c, k = symbols('m c k', real=True)
     N = ReferenceFrame('N')
     P = Point('P')
     P.set_vel(N, u * N.x)
@@ -49,7 +49,7 @@ def test_two_dof():
     # particles. Speeds are defined as the time derivatives of the particles.
     q1, q2, u1, u2 = dynamicsymbols('q1 q2 u1 u2')
     q1d, q2d, u1d, u2d = dynamicsymbols('q1 q2 u1 u2', 1)
-    m, c1, c2, k1, k2 = symbols('m c1 c2 k1 k2')
+    m, c1, c2, k1, k2 = symbols('m c1 c2 k1 k2', real=True)
     N = ReferenceFrame('N')
     P1 = Point('P1')
     P2 = Point('P2')
@@ -88,7 +88,7 @@ def test_two_dof():
 def test_pend():
     q, u = dynamicsymbols('q u')
     qd, ud = dynamicsymbols('q u', 1)
-    m, l, g = symbols('m l g')
+    m, l, g = symbols('m l g', real=True)
     N = ReferenceFrame('N')
     P = Point('P')
     P.set_vel(N, -l * u * sin(q) * N.x + l * u * cos(q) * N.y)
@@ -119,7 +119,7 @@ def test_rolling_disc():
     # mass and radius, and the local gravity (note that mass will drop out).
     q1, q2, q3, u1, u2, u3 = dynamicsymbols('q1 q2 q3 u1 u2 u3')
     q1d, q2d, q3d, u1d, u2d, u3d = dynamicsymbols('q1 q2 q3 u1 u2 u3', 1)
-    r, m, g = symbols('r m g')
+    r, m, g = symbols('r m g', real=True)
 
     # The kinematics are formed by a series of simple rotations. Each simple
     # rotation creates a new frame, and the next rotation is defined by the new
@@ -197,7 +197,7 @@ def test_aux():
     q1d, q2d, q3d, u1d, u2d, u3d = dynamicsymbols('q1 q2 q3 u1 u2 u3', 1)
     u4, u5, f1, f2 = dynamicsymbols('u4, u5, f1, f2')
     u4d, u5d = dynamicsymbols('u4, u5', 1)
-    r, m, g = symbols('r m g')
+    r, m, g = symbols('r m g', real=True)
 
     N = ReferenceFrame('N')
     Y = N.orientnew('Y', 'Axis', [q1, N.z])
@@ -249,11 +249,11 @@ def test_parallel_axis():
     # pendulum is defined about the hinge, not about the center of mass.
 
     # Defining the constants and knowns of the system
-    gravity = symbols('g')
-    k, ls = symbols('k ls')
-    a, mA, mC = symbols('a mA mC')
+    gravity = symbols('g', real=True)
+    k, ls = symbols('k ls', real=True)
+    a, mA, mC = symbols('a mA mC', real=True)
     F = dynamicsymbols('F')
-    Ix, Iy, Iz = symbols('Ix Iy Iz')
+    Ix, Iy, Iz = symbols('Ix Iy Iz', real=True)
 
     # Declaring the Generalized coordinates and speeds
     q1, q2 = dynamicsymbols('q1 q2')

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -26,8 +26,8 @@ def test_aux_dep():
 
     # Symbols for time and constant parameters.
     # Symbols for contact forces: Fx, Fy, Fz.
-    t, r, m, g, I, J = symbols('t r m g I J')
-    Fx, Fy, Fz = symbols('Fx Fy Fz')
+    t, r, m, g, I, J = symbols('t r m g I J', real=True)
+    Fx, Fy, Fz = symbols('Fx Fy Fz', real=True)
 
     # Configuration variables and their time derivatives:
     # q[0] -- yaw
@@ -202,10 +202,10 @@ def test_non_central_inertia():
     q1, q2, q3 = dynamicsymbols('q1:4')
     q1d, q2d, q3d = dynamicsymbols('q1:4', level=1)
     u1, u2, u3, u4, u5 = dynamicsymbols('u1:6')
-    u_prime, R, M, g, e, f, theta = symbols('u\' R, M, g, e, f, theta')
-    a, b, mA, mB, IA, J, K, t = symbols('a b mA mB IA J K t')
-    Q1, Q2, Q3 = symbols('Q1, Q2 Q3')
-    IA22, IA23, IA33 = symbols('IA22 IA23 IA33')
+    u_prime, R, M, g, e, f, theta = symbols('u\' R, M, g, e, f, theta', real=True)
+    a, b, mA, mB, IA, J, K, t = symbols('a b mA mB IA J K t', real=True)
+    Q1, Q2, Q3 = symbols('Q1, Q2 Q3', real=True)
+    IA22, IA23, IA33 = symbols('IA22 IA23 IA33', real=True)
 
     # Reference Frames
     F = ReferenceFrame('F')
@@ -304,10 +304,10 @@ def test_sub_qdot():
     q1, q2, q3 = dynamicsymbols('q1:4')
     q1d, q2d, q3d = dynamicsymbols('q1:4', level=1)
     u1, u2, u3 = dynamicsymbols('u1:4')
-    u_prime, R, M, g, e, f, theta = symbols('u\' R, M, g, e, f, theta')
-    a, b, mA, mB, IA, J, K, t = symbols('a b mA mB IA J K t')
-    IA22, IA23, IA33 = symbols('IA22 IA23 IA33')
-    Q1, Q2, Q3 = symbols('Q1 Q2 Q3')
+    u_prime, R, M, g, e, f, theta = symbols('u\' R, M, g, e, f, theta', real=True)
+    a, b, mA, mB, IA, J, K, t = symbols('a b mA mB IA J K t', real=True)
+    IA22, IA23, IA33 = symbols('IA22 IA23 IA33', real=True)
+    Q1, Q2, Q3 = symbols('Q1 Q2 Q3', real=True)
 
     # --- Reference Frames ---
     F = ReferenceFrame('F')
@@ -397,7 +397,7 @@ def test_sub_qdot2():
     # the B matrix will be poorly formed and inversion of the dependent part
     # will fail.
 
-    g, m, Px, Py, Pz, R, t = symbols('g m Px Py Pz R t')
+    g, m, Px, Py, Pz, R, t = symbols('g m Px Py Pz R t', real=True)
     q = dynamicsymbols('q:5')
     qd = dynamicsymbols('q:5', level=1)
     u = dynamicsymbols('u:5')

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -34,13 +34,13 @@ def test_bicycle():
     u1d, u2d, u3d, u4d, u5d, u6d = dynamicsymbols('u1 u2 u3 u4 u5 u6', 1)
 
     # Declare System's Parameters
-    WFrad, WRrad, htangle, forkoffset = symbols('WFrad WRrad htangle forkoffset')
-    forklength, framelength, forkcg1 = symbols('forklength framelength forkcg1')
-    forkcg3, framecg1, framecg3, Iwr11 = symbols('forkcg3 framecg1 framecg3 Iwr11')
-    Iwr22, Iwf11, Iwf22, Iframe11 = symbols('Iwr22 Iwf11 Iwf22 Iframe11')
-    Iframe22, Iframe33, Iframe31, Ifork11 = symbols('Iframe22 Iframe33 Iframe31 Ifork11')
-    Ifork22, Ifork33, Ifork31, g = symbols('Ifork22 Ifork33 Ifork31 g')
-    mframe, mfork, mwf, mwr = symbols('mframe mfork mwf mwr')
+    WFrad, WRrad, htangle, forkoffset = symbols('WFrad WRrad htangle forkoffset', real=True)
+    forklength, framelength, forkcg1 = symbols('forklength framelength forkcg1', real=True)
+    forkcg3, framecg1, framecg3, Iwr11 = symbols('forkcg3 framecg1 framecg3 Iwr11', real=True)
+    Iwr22, Iwf11, Iwf22, Iframe11 = symbols('Iwr22 Iwf11 Iwf22 Iframe11', real=True)
+    Iframe22, Iframe33, Iframe31, Ifork11 = symbols('Iframe22 Iframe33 Iframe31 Ifork11', real=True)
+    Ifork22, Ifork33, Ifork31, g = symbols('Ifork22 Ifork33 Ifork31 g', real=True)
+    mframe, mfork, mwf, mwr = symbols('mframe mfork mwf mwr', real=True)
 
     # Set up reference frames for the system
     # N - inertial
@@ -211,7 +211,7 @@ def test_bicycle():
     # later be substituted in. Again the sign on the *product* of inertia
     # values is flipped here, due to different orientations of coordinate
     # systems.
-    v = symbols('v')
+    v = symbols('v', real=True)
     val_dict = {WFrad: PaperRadFront,
                 WRrad: PaperRadRear,
                 htangle: HTA,

--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -211,19 +211,20 @@ def test_rolling_disc():
     BodyD.potential_energy = - m * g * r * cos(q2)
     Lag = Lagrangian(N, BodyD)
     q = [q1, q2, q3]
-    q1 = Function('q1')
-    q2 = Function('q2')
-    q3 = Function('q3')
+    q1 = Function('q1', real=True)
+    q2 = Function('q2', real=True)
+    q3 = Function('q3', real=True)
     l = LagrangesMethod(Lag, q)
     l.form_lagranges_equations()
     RHS = l.rhs()
     RHS.simplify()
-    t = symbols('t', real=True)
+    t = dynamicsymbols.t
 
     assert (l.mass_matrix[3:6] == [0, 5*m*r**2/4, 0])
-    assert RHS[4].simplify() == (
-        (-8*g*sin(q2(t)) + r*(5*sin(2*q2(t))*Derivative(q1(t), t) +
-        12*cos(q2(t))*Derivative(q3(t), t))*Derivative(q1(t), t))/(10*r))
-    assert RHS[5] == (-5*cos(q2(t))*Derivative(q1(t), t) + 6*tan(q2(t)
-        )*Derivative(q3(t), t) + 4*Derivative(q1(t), t)/cos(q2(t))
-        )*Derivative(q2(t), t)
+    assert RHS[4].simplify() == ((-8*g*sin(q2(t)) +
+                                  r*(5*sin(2*q2(t))*Derivative(q1(t), t) +
+                                  12*cos(q2(t))*Derivative(q3(t), t)) *
+                                  Derivative(q1(t), t))/(10*r))
+    assert RHS[5] == (-5*cos(q2(t))*Derivative(q1(t), t) +
+                      6*tan(q2(t))*Derivative(q3(t), t) +
+                      4*Derivative(q1(t), t)/cos(q2(t)))*Derivative(q2(t), t)

--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -15,7 +15,7 @@ def test_disc_on_an_incline_plane():
     # gravitational constant.
     y, theta = dynamicsymbols('y theta')
     yd, thetad = dynamicsymbols('y theta', 1)
-    m, g, R, l, alpha = symbols('m g R l alpha')
+    m, g, R, l, alpha = symbols('m g R l alpha', real=True)
 
     # Next, we create the inertial reference frame 'N'. A reference frame 'A'
     # is attached to the inclined plane. Finally a frame is created which is attached to the disk.
@@ -64,7 +64,7 @@ def test_simp_pen():
     # inertial frame.
     q, u = dynamicsymbols('q u')
     qd, ud = dynamicsymbols('q u ', 1)
-    l, m, g = symbols('l m g')
+    l, m, g = symbols('l m g', real=True)
 
     # We then create the inertial frame and a frame attached to the massless
     # string following which we define the inertial angular velocity of the
@@ -97,7 +97,7 @@ def test_simp_pen():
 def test_nonminimal_pendulum():
     q1, q2 = dynamicsymbols('q1:3')
     q1d, q2d = dynamicsymbols('q1:3', level=1)
-    L, m, t = symbols('L, m, t')
+    L, m, t = symbols('L, m, t', real=True)
     g = 9.8
     # Compose World Frame
     N = ReferenceFrame('N')
@@ -138,7 +138,7 @@ def test_dub_pen():
     q1dd, q2dd = dynamicsymbols('q1 q2', 2)
     u1, u2 = dynamicsymbols('u1 u2')
     u1d, u2d = dynamicsymbols('u1 u2', 1)
-    l, m, g = symbols('l m g')
+    l, m, g = symbols('l m g', real=True)
 
     N = ReferenceFrame('N')
     A = N.orientnew('A', 'Axis', [q1, N.z])
@@ -181,7 +181,7 @@ def test_rolling_disc():
     # disc's mass and radius, and the local gravity.
     q1, q2, q3 = dynamicsymbols('q1 q2 q3')
     q1d, q2d, q3d = dynamicsymbols('q1 q2 q3', 1)
-    r, m, g = symbols('r m g')
+    r, m, g = symbols('r m g', real=True)
 
     # The kinematics are formed by a series of simple rotations. Each simple
     # rotation creates a new frame, and the next rotation is defined by the new
@@ -218,7 +218,7 @@ def test_rolling_disc():
     l.form_lagranges_equations()
     RHS = l.rhs()
     RHS.simplify()
-    t = symbols('t')
+    t = symbols('t', real=True)
 
     assert (l.mass_matrix[3:6] == [0, 5*m*r**2/4, 0])
     assert RHS[4].simplify() == (

--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -1,8 +1,8 @@
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
                                     RigidBody, LagrangesMethod, Particle,
                                     inertia, Lagrangian)
-from sympy import symbols, pi, sin, cos, tan, simplify, Function, \
-        Derivative, Matrix
+from sympy.core.backend import symbols, pi, sin, cos, tan
+from sympy import simplify, Function, Derivative, Matrix
 
 
 def test_disc_on_an_incline_plane():

--- a/sympy/physics/mechanics/tests/test_lagrange2.py
+++ b/sympy/physics/mechanics/tests/test_lagrange2.py
@@ -15,7 +15,7 @@ def test_lagrange_2forces():
     qds = q1d, q2d = dynamicsymbols('q1, q2', 1)
 
     ### Mass, spring strength, friction coefficient
-    m, k, nu = symbols('m, k, nu')
+    m, k, nu = symbols('m, k, nu', real=True)
 
     N = ReferenceFrame('N')
     O = Point('O')

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -12,7 +12,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 @slow
 def test_linearize_rolling_disc_kane():
     # Symbols for time and constant parameters
-    t, r, m, g, v = symbols('t r m g v')
+    t, r, m, g, v = symbols('t r m g v', real=True)
 
     # Configuration variables and their time derivatives
     q1, q2, q3, q4, q5, q6 = q = dynamicsymbols('q1:7')
@@ -137,7 +137,7 @@ def test_linearize_pendulum_kane_minimal():
     q1 = dynamicsymbols('q1')                     # angle of pendulum
     u1 = dynamicsymbols('u1')                     # Angular velocity
     q1d = dynamicsymbols('q1', 1)                 # Angular velocity
-    L, m, t = symbols('L, m, t')
+    L, m, t = symbols('L, m, t', real=True)
     g = 9.8
 
     # Compose world frame
@@ -180,7 +180,7 @@ def test_linearize_pendulum_kane_nonminimal():
     q1d, q2d = dynamicsymbols('q1:3', level=1)
     u1, u2 = dynamicsymbols('u1:3')
     u1d, u2d = dynamicsymbols('u1:3', level=1)
-    L, m, t = symbols('L, m, t')
+    L, m, t = symbols('L, m, t', real=True)
     g = 9.8
 
     # Compose world frame
@@ -241,7 +241,7 @@ def test_linearize_pendulum_kane_nonminimal():
 def test_linearize_pendulum_lagrange_minimal():
     q1 = dynamicsymbols('q1')                     # angle of pendulum
     q1d = dynamicsymbols('q1', 1)                 # Angular velocity
-    L, m, t = symbols('L, m, t')
+    L, m, t = symbols('L, m, t', real=True)
     g = 9.8
 
     # Compose world frame
@@ -272,7 +272,7 @@ def test_linearize_pendulum_lagrange_minimal():
 def test_linearize_pendulum_lagrange_nonminimal():
     q1, q2 = dynamicsymbols('q1:3')
     q1d, q2d = dynamicsymbols('q1:3', level=1)
-    L, m, t = symbols('L, m, t')
+    L, m, t = symbols('L, m, t', real=True)
     g = 9.8
     # Compose World Frame
     N = ReferenceFrame('N')
@@ -305,7 +305,7 @@ def test_linearize_pendulum_lagrange_nonminimal():
 def test_linearize_rolling_disc_lagrange():
     q1, q2, q3 = q = dynamicsymbols('q1 q2 q3')
     q1d, q2d, q3d = qd = dynamicsymbols('q1 q2 q3', 1)
-    r, m, g = symbols('r m g')
+    r, m, g = symbols('r m g', real=True)
 
     N = ReferenceFrame('N')
     Y = N.orientnew('Y', 'Axis', [q1, N.z])

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -3,7 +3,7 @@ from sympy.physics.mechanics import Point, Particle, ReferenceFrame
 
 
 def test_particle():
-    m, m2, v1, v2, v3, r, g, h = symbols('m m2 v1 v2 v3 r g h')
+    m, m2, v1, v2, v3, r, g, h = symbols('m m2 v1 v2 v3 r g h', real=True)
     P = Point('P')
     P2 = Point('P2')
     p = Particle('pa', P, m)

--- a/sympy/physics/mechanics/tests/test_particle.py
+++ b/sympy/physics/mechanics/tests/test_particle.py
@@ -1,4 +1,4 @@
-from sympy import symbols
+from sympy.core.backend import symbols
 from sympy.physics.mechanics import Point, Particle, ReferenceFrame
 
 

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -1,4 +1,4 @@
-from sympy import symbols
+from sympy.core.backend import symbols
 from sympy.physics.mechanics import Point, ReferenceFrame, Dyadic, RigidBody
 from sympy.physics.mechanics import dynamicsymbols, outer, inertia
 from sympy.physics.mechanics import inertia_of_point_mass

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -6,7 +6,7 @@ from sympy.core.backend import expand
 
 
 def test_rigidbody():
-    m, m2, v1, v2, v3, omega = symbols('m m2 v1 v2 v3 omega')
+    m, m2, v1, v2, v3, omega = symbols('m m2 v1 v2 v3 omega', real=True)
     A = ReferenceFrame('A')
     A2 = ReferenceFrame('A2')
     P = Point('P')
@@ -57,8 +57,8 @@ def test_rigidbody2():
 
 def test_rigidbody3():
     q1, q2, q3, q4 = dynamicsymbols('q1:5')
-    p1, p2, p3 = symbols('p1:4')
-    m = symbols('m')
+    p1, p2, p3 = symbols('p1:4', real=True)
+    m = symbols('m', real=True)
 
     A = ReferenceFrame('A')
     B = A.orientnew('B', 'axis', [q1, A.x])

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -259,7 +259,7 @@ class ReferenceFrame(object):
         """Angular velocity from time differentiating the DCM. """
         from sympy.physics.vector.functions import dynamicsymbols
         dcm2diff = self.dcm(otherframe)
-        diffed = dcm2diff.diff(dynamicsymbols._t)
+        diffed = dcm2diff.diff(dynamicsymbols.t)
         angvelmat = diffed * dcm2diff.T
         w1 = trigsimp(expand(angvelmat[7]), recursive=True)
         w2 = trigsimp(expand(angvelmat[2]), recursive=True)
@@ -600,7 +600,7 @@ class ReferenceFrame(object):
         self._dcm_cache.update({parent: parent_orient.T})
         parent._dcm_cache.update({self: parent_orient})
         if rot_type == 'QUATERNION':
-            t = dynamicsymbols._t
+            t = dynamicsymbols.t
             q0, q1, q2, q3 = amounts
             q0d = diff(q0, t)
             q1d = diff(q1, t)
@@ -611,7 +611,7 @@ class ReferenceFrame(object):
             w3 = 2 * (q3d * q0 + q1d * q2 - q2d * q1 - q0d * q3)
             wvec = Vector([(Matrix([w1, w2, w3]), self)])
         elif rot_type == 'AXIS':
-            thetad = (amounts[0]).diff(dynamicsymbols._t)
+            thetad = (amounts[0]).diff(dynamicsymbols.t)
             wvec = thetad * amounts[1].express(parent).normalize()
         elif rot_type == 'DCM':
             wvec = self._w_diff_dcm(parent)

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -572,21 +572,29 @@ def partial_velocity(vel_vecs, gen_speeds, frame):
     return vec_partials
 
 
-def dynamicsymbols(names, level=0):
-    """Uses symbols and Function for functions of time.
+def dynamicsymbols(names, level=0, real=True, **kwargs):
+    """Returns a tuple of functions of time or their derivatives. This is a
+    convenience function that is analogous to ``symbols()``. It allows the
+    user to avoid typing::
 
-    Creates a SymPy UndefinedFunction, which is then initialized as a function
-    of a variable, the default being Symbol('t').
+        >>> t = symbols('t', real=True)
+        >>> F = symbols('F', real=True, cls=Function)(t)
+
+    and simply type::
+
+        >>> F = dynamicsymbols('F')
 
     Parameters
     ==========
-
     names : str
-        Names of the dynamic symbols you want to create; works the same way as
-        inputs to symbols
+        Names of the dynamic symbols you want to create. This works the same
+        way as inputs to ``symbols()``.
     level : int
-        Level of differentiation of the returned function; d/dt once of t,
-        twice of t, etc.
+        Order of differentiation of the returned function(s).
+    real : boolean, optional
+        By default the functions are assumed to be real.
+    kwargs : key value pairs
+        Any options that can be passed to ``symbols()`` except for ``cls``.
 
     Examples
     ========
@@ -596,18 +604,34 @@ def dynamicsymbols(names, level=0):
     >>> q1 = dynamicsymbols('q1')
     >>> q1
     q1(t)
-    >>> diff(q1, Symbol('t'))
+    >>> diff(q1, Symbol('t', real=True))
+    Derivative(q1(t), t)
+    >>> q1d = dynamicsymbols('q1', level=1)
     Derivative(q1(t), t)
 
+    Notes
+    =====
+
+    The default time symbol is stored on the function, i.e.::
+
+        >>> dynamicsymbols._t
+        t
+
+    It can be changed by simply overriding the attribute::
+
+        >>> dynamicsymbols._t = symbols('T', real=False)
+
     """
-    esses = symbols(names, cls=Function)
+    kwargs.pop('cls', None)
+
+    esses = symbols(names, cls=Function, real=real, **kwargs)
+
     t = dynamicsymbols._t
+
     if iterable(esses):
-        esses = [reduce(diff, [t] * level, e(t)) for e in esses]
-        return esses
+        return tuple([reduce(diff, [t] * level, e(t)) for e in esses])
     else:
         return reduce(diff, [t] * level, esses(t))
 
-
-dynamicsymbols._t = Symbol('t')
+dynamicsymbols._t = Symbol('t', real=True)
 dynamicsymbols._str = '\''

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -14,7 +14,19 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 __all__ = ['cross', 'dot', 'express', 'time_derivative', 'outer',
            'kinematic_equations', 'get_motion_params', 'partial_velocity',
            'dynamicsymbols', 'vprint', 'vsprint', 'vpprint', 'vlatex',
-           'init_vprinting']
+           'init_vprinting', 'get_time', 'set_time']
+
+
+def get_time():
+    """Returns the symbol used for time dependence in the physics vectors and
+    dyadics."""
+    return dynamicsymbols.t
+
+
+def set_time(sym=Symbol('t', real=True)):
+    """Sets the symbol used for time dependence in the physics vectors and
+    dyadics."""
+    dynamicsymbols.t = sym
 
 
 def cross(vec1, vec2):
@@ -572,32 +584,33 @@ def partial_velocity(vel_vecs, gen_speeds, frame):
 
     return vec_partials
 
-class __dynamicsymbols_class(object):
+
+class _dynamicsymbols_class(object):
     """The class used to manage the dynamicsymbols time symbol attribute.
     """
 
     def __init__(self):
-        self.__time_symbol = Symbol('t', real=True)
+        self._time_symbol = Symbol('t', real=True)
         self._str = '\''
 
     def _get_time_symbol(self):
-        return self.__time_symbol
+        return self._time_symbol
 
     def _set_time_symbol(self, value):
-        self.__time_symbol = value
+        self._time_symbol = value
 
     def _get_time_symbol_dep(self):
         SymPyDeprecationWarning(
                 feature="Attribute sympy.physics.vector.dynamicsymbols._t",
                 useinstead="attribute sympy.physics.vector.dynamicsymbols.t",
-                deprecated_since_version="0.7.7").warn()
+                deprecated_since_version="1.1.0").warn()
         return self._get_time_symbol()
 
     def _set_time_symbol_dep(self, value):
         SymPyDeprecationWarning(
                 feature="Attribute sympy.physics.vector.dynamicsymbols._t",
                 useinstead="attribute sympy.physics.vector.dynamicsymbols.t",
-                deprecated_since_version="0.7.7").warn()
+                deprecated_since_version="1.1.0").warn()
         return self._set_time_symbol(value)
 
     t = property(_get_time_symbol, _set_time_symbol)
@@ -630,12 +643,12 @@ class __dynamicsymbols_class(object):
         Examples
         ========
 
-        >>> from sympy.physics.vector import dynamicsymbols
+        >>> from sympy.physics.vector import dynamicsymbols, get_time
         >>> from sympy import diff, Symbol
         >>> q1 = dynamicsymbols('q1')
         >>> q1
         q1(t)
-        >>> diff(q1, Symbol('t', real=True))
+        >>> diff(q1, get_time())
         Derivative(q1(t), t)
         >>> q1d = dynamicsymbols('q1', level=1)
         >>> q1d
@@ -649,20 +662,23 @@ class __dynamicsymbols_class(object):
             >>> dynamicsymbols.t #doctest: +SKIP
             t
 
-        It can be changed by simply overriding the attribute::
+        It can be changed by overriding the attribute::
 
             >>> dynamicsymbols.t = symbols('T', real=False) #doctest: +SKIP
+
+        The functions ``get_time()`` and ``set_time`` can also be used to do
+        this.
 
         """
         kwargs.pop('cls', None)
 
         esses = symbols(names, cls=Function, real=real, **kwargs)
 
-        t = self.__time_symbol
+        t = self._time_symbol
 
         if iterable(esses):
             return tuple([reduce(diff, [t] * level, e(t)) for e in esses])
         else:
             return reduce(diff, [t] * level, esses(t))
 
-dynamicsymbols = __dynamicsymbols_class()
+dynamicsymbols = _dynamicsymbols_class()

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -608,12 +608,12 @@ class __dynamicsymbols_class(object):
         convenience function that is analogous to ``symbols()``. It allows the
         user to avoid typing::
 
-            >>> t = symbols('t', real=True)
-            >>> F = symbols('F', real=True, cls=Function)(t)
+            >>> t = symbols('t', real=True) #doctest: +SKIP
+            >>> F = symbols('F', real=True, cls=Function)(t) #doctest: +SKIP
 
         and simply type::
 
-            >>> F = dynamicsymbols('F')
+            >>> F = dynamicsymbols('F') #doctest: +SKIP
 
         Parameters
         ==========
@@ -638,6 +638,7 @@ class __dynamicsymbols_class(object):
         >>> diff(q1, Symbol('t', real=True))
         Derivative(q1(t), t)
         >>> q1d = dynamicsymbols('q1', level=1)
+        >>> q1d
         Derivative(q1(t), t)
 
         Notes
@@ -645,12 +646,12 @@ class __dynamicsymbols_class(object):
 
         The default time symbol is stored on the function, i.e.::
 
-            >>> dynamicsymbols.t
+            >>> dynamicsymbols.t #doctest: +SKIP
             t
 
         It can be changed by simply overriding the attribute::
 
-            >>> dynamicsymbols.t = symbols('T', real=False)
+            >>> dynamicsymbols.t = symbols('T', real=False) #doctest: +SKIP
 
         """
         kwargs.pop('cls', None)

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -179,7 +179,7 @@ def time_derivative(expr, frame, order=1):
 
     """
 
-    t = dynamicsymbols._t
+    t = dynamicsymbols.t
     _check_frame(frame)
 
     if order == 0:
@@ -276,7 +276,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
             raise ValueError('Need 3 coordinates for body or space')
         # Actual hard-coded kinematic differential equations
         q1, q2, q3 = coords
-        q1d, q2d, q3d = [diff(i, dynamicsymbols._t) for i in coords]
+        q1d, q2d, q3d = [diff(i, dynamicsymbols.t) for i in coords]
         w1, w2, w3 = speeds
         s1, s2, s3 = [sin(q1), sin(q2), sin(q3)]
         c1, c2, c3 = [cos(q1), cos(q2), cos(q3)]
@@ -364,7 +364,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
         w = Matrix(speeds + [0])
         E = Matrix([[e0, -e3, e2, e1], [e3, e0, -e1, e2], [-e2, e1, e0, e3],
             [-e1, -e2, -e3, e0]])
-        edots = Matrix([diff(i, dynamicsymbols._t) for i in [e1, e2, e3, e0]])
+        edots = Matrix([diff(i, dynamicsymbols.t) for i in [e1, e2, e3, e0]])
         return list(edots.T - 0.5 * w.T * E.T)
     else:
         raise ValueError('Not an approved rotation type for this function')
@@ -387,7 +387,7 @@ def get_motion_params(frame, **kwargs):
     If any of the boundary conditions are not provided, they are taken
     to be zero by default (zero vectors, in case of vectorial inputs). If
     the boundary conditions are also functions of time, they are converted
-    to constants by substituting the time values in the dynamicsymbols._t
+    to constants by substituting the time values in the dynamicsymbols.t
     time Symbol.
 
     This function can also be used for calculating rotational motion
@@ -501,16 +501,16 @@ def get_motion_params(frame, **kwargs):
     if mode == 2:
         vel = _process_vector_differential(kwargs['acceleration'],
                                            kwargs['velocity'],
-                                           dynamicsymbols._t,
+                                           dynamicsymbols.t,
                                            kwargs['timevalue2'], frame)[2]
         pos = _process_vector_differential(vel, kwargs['position'],
-                                           dynamicsymbols._t,
+                                           dynamicsymbols.t,
                                            kwargs['timevalue1'], frame)[2]
         return (kwargs['acceleration'], vel, pos)
     elif mode == 1:
         return _process_vector_differential(kwargs['velocity'],
                                             kwargs['position'],
-                                            dynamicsymbols._t,
+                                            dynamicsymbols.t,
                                             kwargs['timevalue1'], frame)
     else:
         vel = time_derivative(kwargs['position'], frame)
@@ -614,24 +614,24 @@ def dynamicsymbols(names, level=0, real=True, **kwargs):
 
     The default time symbol is stored on the function, i.e.::
 
-        >>> dynamicsymbols._t
+        >>> dynamicsymbols.t
         t
 
     It can be changed by simply overriding the attribute::
 
-        >>> dynamicsymbols._t = symbols('T', real=False)
+        >>> dynamicsymbols.t = symbols('T', real=False)
 
     """
     kwargs.pop('cls', None)
 
     esses = symbols(names, cls=Function, real=real, **kwargs)
 
-    t = dynamicsymbols._t
+    t = dynamicsymbols.t
 
     if iterable(esses):
         return tuple([reduce(diff, [t] * level, e(t)) for e in esses])
     else:
         return reduce(diff, [t] * level, esses(t))
 
-dynamicsymbols._t = Symbol('t', real=True)
+dynamicsymbols.t = Symbol('t', real=True)
 dynamicsymbols._str = '\''

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -9,6 +9,7 @@ from .frame import CoordinateSym, _check_frame
 from .dyadic import Dyadic
 from .printing import vprint, vsprint, vpprint, vlatex, init_vprinting
 from sympy.utilities.iterables import iterable
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 __all__ = ['cross', 'dot', 'express', 'time_derivative', 'outer',
            'kinematic_equations', 'get_motion_params', 'partial_velocity',
@@ -571,67 +572,96 @@ def partial_velocity(vel_vecs, gen_speeds, frame):
 
     return vec_partials
 
-
-def dynamicsymbols(names, level=0, real=True, **kwargs):
-    """Returns a tuple of functions of time or their derivatives. This is a
-    convenience function that is analogous to ``symbols()``. It allows the
-    user to avoid typing::
-
-        >>> t = symbols('t', real=True)
-        >>> F = symbols('F', real=True, cls=Function)(t)
-
-    and simply type::
-
-        >>> F = dynamicsymbols('F')
-
-    Parameters
-    ==========
-    names : str
-        Names of the dynamic symbols you want to create. This works the same
-        way as inputs to ``symbols()``.
-    level : int
-        Order of differentiation of the returned function(s).
-    real : boolean, optional
-        By default the functions are assumed to be real.
-    kwargs : key value pairs
-        Any options that can be passed to ``symbols()`` except for ``cls``.
-
-    Examples
-    ========
-
-    >>> from sympy.physics.vector import dynamicsymbols
-    >>> from sympy import diff, Symbol
-    >>> q1 = dynamicsymbols('q1')
-    >>> q1
-    q1(t)
-    >>> diff(q1, Symbol('t', real=True))
-    Derivative(q1(t), t)
-    >>> q1d = dynamicsymbols('q1', level=1)
-    Derivative(q1(t), t)
-
-    Notes
-    =====
-
-    The default time symbol is stored on the function, i.e.::
-
-        >>> dynamicsymbols.t
-        t
-
-    It can be changed by simply overriding the attribute::
-
-        >>> dynamicsymbols.t = symbols('T', real=False)
-
+class __dynamicsymbols_class(object):
+    """The class used to manage the dynamicsymbols time symbol attribute.
     """
-    kwargs.pop('cls', None)
 
-    esses = symbols(names, cls=Function, real=real, **kwargs)
+    def __init__(self):
+        self.__time_symbol = Symbol('t', real=True)
+        self._str = '\''
 
-    t = dynamicsymbols.t
+    def _get_time_symbol(self):
+        return self.__time_symbol
 
-    if iterable(esses):
-        return tuple([reduce(diff, [t] * level, e(t)) for e in esses])
-    else:
-        return reduce(diff, [t] * level, esses(t))
+    def _set_time_symbol(self, value):
+        self.__time_symbol = value
 
-dynamicsymbols.t = Symbol('t', real=True)
-dynamicsymbols._str = '\''
+    def _get_time_symbol_dep(self):
+        SymPyDeprecationWarning(
+                feature="Attribute sympy.physics.vector.dynamicsymbols._t",
+                useinstead="attribute sympy.physics.vector.dynamicsymbols.t",
+                deprecated_since_version="0.7.7").warn()
+        return self._get_time_symbol()
+
+    def _set_time_symbol_dep(self, value):
+        SymPyDeprecationWarning(
+                feature="Attribute sympy.physics.vector.dynamicsymbols._t",
+                useinstead="attribute sympy.physics.vector.dynamicsymbols.t",
+                deprecated_since_version="0.7.7").warn()
+        return self._set_time_symbol(value)
+
+    t = property(_get_time_symbol, _set_time_symbol)
+    _t = property(_get_time_symbol_dep, _set_time_symbol_dep)
+
+    def __call__(self, names, level=0, real=True, **kwargs):
+        """Returns a tuple of functions of time or their derivatives. This is a
+        convenience function that is analogous to ``symbols()``. It allows the
+        user to avoid typing::
+
+            >>> t = symbols('t', real=True)
+            >>> F = symbols('F', real=True, cls=Function)(t)
+
+        and simply type::
+
+            >>> F = dynamicsymbols('F')
+
+        Parameters
+        ==========
+        names : str
+            Names of the dynamic symbols you want to create. This works the same
+            way as inputs to ``symbols()``.
+        level : int
+            Order of differentiation of the returned function(s).
+        real : boolean, optional
+            By default the functions are assumed to be real.
+        kwargs : key value pairs
+            Any options that can be passed to ``symbols()`` except for ``cls``.
+
+        Examples
+        ========
+
+        >>> from sympy.physics.vector import dynamicsymbols
+        >>> from sympy import diff, Symbol
+        >>> q1 = dynamicsymbols('q1')
+        >>> q1
+        q1(t)
+        >>> diff(q1, Symbol('t', real=True))
+        Derivative(q1(t), t)
+        >>> q1d = dynamicsymbols('q1', level=1)
+        Derivative(q1(t), t)
+
+        Notes
+        =====
+
+        The default time symbol is stored on the function, i.e.::
+
+            >>> dynamicsymbols.t
+            t
+
+        It can be changed by simply overriding the attribute::
+
+            >>> dynamicsymbols.t = symbols('T', real=False)
+
+        """
+        kwargs.pop('cls', None)
+
+        esses = symbols(names, cls=Function, real=real, **kwargs)
+
+        t = self.__time_symbol
+
+        if iterable(esses):
+            return tuple([reduce(diff, [t] * level, e(t)) for e in esses])
+        else:
+            return reduce(diff, [t] * level, esses(t))
+
+dynamicsymbols = __dynamicsymbols_class()

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -18,7 +18,7 @@ class VectorStrPrinter(StrPrinter):
 
     def _print_Derivative(self, e):
         from sympy.physics.vector.functions import dynamicsymbols
-        t = dynamicsymbols._t
+        t = dynamicsymbols.t
         if (bool(sum([i == t for i in e.variables])) &
                 isinstance(type(e.args[0]), UndefinedFunction)):
             ol = str(e.args[0].func)
@@ -30,7 +30,7 @@ class VectorStrPrinter(StrPrinter):
 
     def _print_Function(self, e):
         from sympy.physics.vector.functions import dynamicsymbols
-        t = dynamicsymbols._t
+        t = dynamicsymbols.t
         if isinstance(type(e), UndefinedFunction):
             return StrPrinter().doprint(e).replace("(%s)" % t, '')
         return e.func.__name__ + "(%s)" % self.stringify(e.args, ", ")
@@ -48,7 +48,7 @@ class VectorLatexPrinter(LatexPrinter):
     def _print_Function(self, expr, exp=None):
         from sympy.physics.vector.functions import dynamicsymbols
         func = expr.func.__name__
-        t = dynamicsymbols._t
+        t = dynamicsymbols.t
 
         if hasattr(self, '_print_' + func):
             return getattr(self, '_print_' + func)(expr, exp)
@@ -127,7 +127,7 @@ class VectorLatexPrinter(LatexPrinter):
 
         # check if expr is a dynamicsymbol
         from sympy.core.function import AppliedUndef
-        t = dynamicsymbols._t
+        t = dynamicsymbols.t
         expr = der_expr.expr
         red = expr.atoms(AppliedUndef)
         syms = der_expr.variables
@@ -165,7 +165,7 @@ class VectorPrettyPrinter(PrettyPrinter):
     def _print_Derivative(self, deriv):
         from sympy.physics.vector.functions import dynamicsymbols
         # XXX use U('PARTIAL DIFFERENTIAL') here ?
-        t = dynamicsymbols._t
+        t = dynamicsymbols.t
         dot_i = 0
         can_break = True
         syms = list(reversed(deriv.variables))
@@ -209,7 +209,7 @@ class VectorPrettyPrinter(PrettyPrinter):
 
     def _print_Function(self, e):
         from sympy.physics.vector.functions import dynamicsymbols
-        t = dynamicsymbols._t
+        t = dynamicsymbols.t
         # XXX works only for applied functions
         func = e.func
         args = e.args

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -397,7 +397,7 @@ def init_vprinting(**kwargs):
 
     >>> from sympy import Function, symbols
     >>> from sympy.physics.vector import init_vprinting
-    >>> t, x = symbols('t, x')
+    >>> t, x = symbols('t, x', real=True)
     >>> omega = Function('omega')
     >>> omega(x).diff()
     Derivative(omega(x), x)

--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -376,7 +376,7 @@ def test_time_derivative():
 
 def test_get_motion_methods():
     #Initialization
-    t = dynamicsymbols._t
+    t = dynamicsymbols.t
     s1, s2, s3 = symbols('s1 s2 s3')
     S1, S2, S3 = symbols('S1 S2 S3')
     S4, S5, S6 = symbols('S4 S5 S6')

--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -1,10 +1,11 @@
-from sympy import S, Integral, sin, cos, pi, sqrt, symbols
+from sympy import S, Integral, sin, cos, pi, sqrt, symbols, Symbol
 from sympy.physics.vector import Dyadic, Point, ReferenceFrame, Vector
 from sympy.physics.vector.functions import (cross, dot, express,
                                             time_derivative,
                                             kinematic_equations, outer,
                                             partial_velocity,
-                                            get_motion_params, dynamicsymbols)
+                                            get_motion_params, dynamicsymbols,
+                                            get_time, set_time)
 from sympy.utilities.pytest import raises
 
 Vector.simp = True
@@ -13,6 +14,28 @@ N = ReferenceFrame('N')
 A = N.orientnew('A', 'Axis', [q1, N.z])
 B = A.orientnew('B', 'Axis', [q2, A.x])
 C = B.orientnew('C', 'Axis', [q3, B.y])
+
+
+def test_get_set_time():
+    T = Symbol('T')
+    t = Symbol('t', real=True)
+
+    assert get_time() == t
+
+    set_time(T)
+    assert get_time() == T
+    q = dynamicsymbols('q')
+    q.diff(T)
+
+    set_time(t)
+    assert get_time() == t
+    q = dynamicsymbols('q')
+    q.diff(t)
+
+    set_time()
+    assert get_time() == t
+    q = dynamicsymbols('q')
+    q.diff(t)
 
 
 def test_dot():

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -28,7 +28,8 @@ def unicode_vpretty(expr):
     return vpprint(expr, use_unicode=True, wrap_line=False)
 
 def test_latex_printer():
-    r = Function('r')('t')
+    t = dynamicsymbols.t
+    r = Function('r')(t)
     assert VectorLatexPrinter().doprint(r ** 2) == "r^{2}"
 
 def test_vector_pretty_print():

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -515,7 +515,7 @@ class Vector(object):
         >>> from sympy.physics.vector import dynamicsymbols, ReferenceFrame
         >>> from sympy.physics.vector import Vector
         >>> Vector.simp = True
-        >>> t = Symbol('t')
+        >>> t = dynamicsymbols.t
         >>> q1 = dynamicsymbols('q1')
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])


### PR DESCRIPTION
SymPy treats all variables as complex by default, but variables used in
sympy/physics/mechanics never need to be complex. The fact that they are
complex by default often causes trouble on differentiation of the resulting
equations of motion because some expressions, e.g. abs(), return different
results for real and complex valued arguments. This changed both time and the
functions to have the real assumption set by default.

dynamicsymbols._t is renamed to dynamicsymbols.t
dynamicsymbols.t is real by default
all functions produced by dynamicsymbols are real by default
dynamicsymbols() returns a tuple instead of list to match symbols()
any additional assumptions can be passed in as kwargs to be passed to symbols()
