### PR TITLE
Fix `__eq__` method of S.Reals

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -179,8 +179,7 @@ class Reals(with_metaclass(Singleton, Interval)):
         return Interval.__new__(cls, -S.Infinity, S.Infinity)
 
     def __eq__(self, other):
-        if other == Interval(-S.Infinity, S.Infinity):
-            return True
+        return other == Interval(-S.Infinity, S.Infinity)
 
     def __hash__(self):
         return hash(Interval(-S.Infinity, S.Infinity))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -186,6 +186,7 @@ def test_Reals():
     assert (2, 5) not in S.Reals
     assert sqrt(-1) not in S.Reals
     assert S.Reals == Interval(-oo, oo)
+    assert S.Reals != Interval(0, oo)
 
 
 def test_Complex():


### PR DESCRIPTION
Currently `S.Reals == Interval(0, oo)` returns `None`.
