### PR TITLE
Evaluate powers of Identity, ZeroMatrix matrices

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -415,6 +415,11 @@ class Identity(MatrixExpr):
     def shape(self):
         return (self.args[0], self.args[0])
 
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rpow__')
+    def __pow__(self, other):
+        return self
+
     def _eval_transpose(self):
         return self
 

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from .matexpr import MatrixExpr, ShapeError, Identity
+from .matexpr import MatrixExpr, ShapeError, Identity, ZeroMatrix
 from sympy.core.sympify import _sympify
 from sympy.core.compatibility import range
 from sympy.matrices import MatrixBase
@@ -56,7 +56,8 @@ class MatPow(MatrixExpr):
             args = self.args
         base = args[0]
         exp = args[1]
-        if isinstance(base, MatrixBase) and exp.is_number:
+        if (isinstance(base, (MatrixBase, Identity, ZeroMatrix)) and
+            exp.is_number):
             if exp is S.One:
                 return base
             return base**exp

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -1,6 +1,6 @@
 from sympy.utilities.pytest import raises
 from sympy.core import symbols, pi, S
-from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix
+from sympy.matrices import Identity, MatrixSymbol, ImmutableMatrix, ZeroMatrix
 from sympy.matrices.expressions import MatPow, MatAdd, MatMul
 from sympy.matrices.expressions.matexpr import ShapeError
 
@@ -93,3 +93,33 @@ def test_doit_nested_MatrixExpr():
     Y = ImmutableMatrix([[2, 3], [4, 5]])
     assert MatPow(MatMul(X, Y), 2).doit() == (X*Y)**2
     assert MatPow(MatAdd(X, Y), 2).doit() == (X + Y)**2
+
+
+def test_ZeroMatrix():
+    M = ZeroMatrix(n, n)
+    assert MatPow(M, 2).doit() == M
+    assert MatPow(M, 1).doit() == M
+    assert MatPow(M, 0).doit() == Identity(n)
+    assert MatPow(M, -1).doit() == M
+    assert MatPow(M, -2).doit() == M
+    N = ZeroMatrix(3, 3)
+    assert MatPow(N, 2).doit() == N
+    assert MatPow(N, 1).doit() == N
+    assert MatPow(N, 0).doit() == Identity(3)
+    assert MatPow(N, -1).doit() == N
+    assert MatPow(N, -2).doit() == N
+
+
+def test_Identity():
+    M = Identity(n)
+    assert MatPow(M, 2).doit() == M
+    assert MatPow(M, 1).doit() == M
+    assert MatPow(M, 0).doit() == M
+    assert MatPow(M, -1).doit() == M
+    assert MatPow(M, -2).doit() == M
+    N = Identity(3)
+    assert MatPow(N, 2).doit() == N
+    assert MatPow(N, 1).doit() == N
+    assert MatPow(N, 0).doit() == N
+    assert MatPow(N, -1).doit() == N
+    assert MatPow(N, -2).doit() == N


### PR DESCRIPTION
Powers of Identity, ZeroMatrix are not explicitly evaluated resulting in:

``` python
In [1]: import sympy as s

In [2]: M = s.Identity(3)

In [3]: A = (M**2)

In [4]: A.as_explicit()
Out[4]: 
Matrix([
[0, 0, 0],
[0, 0, 0],
[0, 0, 0]])
```

This fixes #9823
