### PR TITLE
Added JointsMethod implementation

### DIFF
--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -38,3 +38,7 @@ __all__.extend(vector.__all__)
 from . import linearize
 from .linearize import *
 __all__.extend(linearize.__all__)
+
+from . import jointsmethod
+from .jointsmethod import *
+__all__.extend(jointsmethod.__all__)

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -116,20 +116,8 @@ class JointsMethod(object):
         return self._KM.forcing_full
 
     @property
-    def forcing(self):
-        return self._KM.forcing
-
-    @property
     def mass_matrix_full(self):
         return self._KM.mass_matrix_full
-
-    @property
-    def mass_matrix(self):
-        return self._KM.mass_matrix
-
-    @property
-    def auxiliary_eqs(self):
-        return self._KM.auxiliary_eqs
 
     def _set_kanes(self):
         self._KM = KanesMethod(self.root_body.get_frame(), q_ind=self.q, u_ind=self.u,

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -71,7 +71,7 @@ class JointsMethod(object):
     def _generate_forcelist(self):
         force_list = []
         for body in self.bodylist:
-            for force in body.force_list:
+            for force in body.loads:
                 force_list.append(force)
         return force_list
 
@@ -120,7 +120,7 @@ class JointsMethod(object):
         return self._KM.mass_matrix_full
 
     def _set_kanes(self):
-        self._KM = KanesMethod(self.root_body.get_frame(), q_ind=self.q, u_ind=self.u,
+        self._KM = KanesMethod(self.root_body.frame, q_ind=self.q, u_ind=self.u,
                                kd_eqs=self.kd)
         self._KM.kanes_equations(self.forcelist, self.bodylist)
         # TODO Removing call to private attributes in pydy.System and fix this.

--- a/sympy/physics/mechanics/jointsmethod.py
+++ b/sympy/physics/mechanics/jointsmethod.py
@@ -1,0 +1,144 @@
+from sympy.physics.mechanics import KanesMethod
+
+__all__ = ['JointsMethod']
+
+
+class JointsMethod(object):
+    """
+    Joints method object.
+
+    This object is used to form the equations of motion of a system created
+    using Joints.
+
+    Parameters
+    ----------
+    joints: List of Joints
+        List of all the joints created must be passed as argument.
+    root_body: Body
+        Root body w.r.t which equations of motion much be generated.
+        Is necessary to remove the  ambiguity since user may not
+        connect all bodies using joints and thus, there is not
+        way to find the root_body.
+
+    Examples
+    --------
+    >>> from sympy import Symbol
+    >>> from sympy.physics.mechanics import (Body, PinJoint, SphericalJoint, \
+                                             JointsMethod)
+    >>> root_body = Body('root_body')
+    >>> parent = Body('parent')
+    >>> child = Body('child')
+    >>> l1 = Symbol('l1')
+    >>> joints = []
+    >>> pin_joint = PinJoint('pin_joint' root_body, parent, \
+                             child_point_pos=(0, l1, 0))
+    >>> joints.append(pin_joint)
+    >>> l2 = Symbol('l2')
+    >>> spherical_joint = SphericalJoint('spherical_joint', parent, child, \
+                                         child_point_pos=(0, l2, 0))
+    >>> joints.append(spherical_joint)
+    >>> JM = JointsMethod(joints, root_body)
+    >>> JM.rhs()
+
+    """
+    def __init__(self, joints, root_body):
+        self.joints = joints
+        self.root_body = root_body
+        self._bodylist = self._generate_bodylist()
+        self._forcelist = self._generate_forcelist()
+        self._q = self._generate_q()
+        self._u = self._generate_u()
+        self._kds = self._generate_kds()
+        self._set_kanes()
+
+    @property
+    def bodylist(self):
+        return self._bodylist
+
+    def _generate_bodylist(self):
+        bodies = []
+        for joint in self.joints:
+            if joint.child not in bodies:
+                bodies.append(joint.child)
+            if joint.parent not in bodies:
+                bodies.append(joint.parent)
+        return bodies
+
+    @property
+    def forcelist(self):
+        return self._forcelist
+
+    def _generate_forcelist(self):
+        force_list = []
+        for body in self.bodylist:
+            for force in body.force_list:
+                force_list.append(force)
+        return force_list
+
+    @property
+    def q(self):
+        return self._q
+
+    def _generate_q(self):
+        q_ind = []
+        for joint in self.joints:
+            coordinates = joint.coordinates
+            for coordinate in coordinates:
+                q_ind.append(coordinate)
+        return q_ind
+
+    @property
+    def u(self):
+        return self._u
+
+    def _generate_u(self):
+        u_ind = []
+        for joint in self.joints:
+            speeds = joint.speeds
+            for speed in speeds:
+                u_ind.append(speed)
+        return u_ind
+
+    @property
+    def kd(self):
+        return self._kds
+
+    def _generate_kds(self):
+        kd_ind = []
+        for joint in self.joints:
+            kds = joint.kds
+            for kd in kds:
+                kd_ind.append(kd)
+        return kd_ind
+
+    @property
+    def forcing_full(self):
+        return self._KM.forcing_full
+
+    @property
+    def forcing(self):
+        return self._KM.forcing
+
+    @property
+    def mass_matrix_full(self):
+        return self._KM.mass_matrix_full
+
+    @property
+    def mass_matrix(self):
+        return self._KM.mass_matrix
+
+    @property
+    def auxiliary_eqs(self):
+        return self._KM.auxiliary_eqs
+
+    def _set_kanes(self):
+        self._KM = KanesMethod(self.root_body.get_frame(), q_ind=self.q, u_ind=self.u,
+                               kd_eqs=self.kd)
+        self._KM.kanes_equations(self.forcelist, self.bodylist)
+        # TODO Removing call to private attributes in pydy.System and fix this.
+        self._qdot = self._KM._qdot
+        self._udot = self._KM._udot
+        self._uaux = self._KM._uaux
+
+    def rhs(self, inv_method=None):
+        return self._KM.rhs(inv_method)

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -1,5 +1,31 @@
-from sympy.physics.mechanics import
+from sympy import Symbol, ImmutableMatrix as Matrix
+from sympy.physics.mechanics import (Body, PinJoint, SphericalJoint,
+                                     JointsMethod)
 
 
-def test_joint_method():
+def test_joint_method_simple():
+    parent = Body('parent')
+    child = Body('child')
+    joints = []
+    gravity = Symbol('gravity')
+    child.apply_force(gravity * parent.frame.y)
+    pin_joint = PinJoint('pinjoint', parent, child)
+    joints.append(pin_joint)
 
+    JM = JointsMethod(joints, parent)
+    assert JM.rhs() == Matrix([
+        [pin_joint.speeds[0]], [0]])
+    assert JM.forcelist == child.loads
+    assert JM.forcelist == [(child.masscenter, gravity*parent.frame.y)]
+    assert JM.bodylist == [child, parent]
+    assert JM.q == pin_joint.coordinates
+    assert JM.u == pin_joint.speeds
+    assert JM.kd == pin_joint.kds
+    assert JM.forcing_full == Matrix([
+        [pin_joint.speeds[0]], [0]])
+    assert JM.mass_matrix_full == Matrix([
+        [1,         0],
+        [0, Symbol('child_ixx')]])
+    assert hasattr(JM, '_qdot')
+    assert hasattr(JM, '_udot')
+    assert hasattr(JM, '_uaux')

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -1,0 +1,5 @@
+from sympy.physics.mechanics import
+
+
+def test_joint_method():
+

--- a/sympy/physics/mechanics/tests/test_jointsmethod.py
+++ b/sympy/physics/mechanics/tests/test_jointsmethod.py
@@ -1,6 +1,5 @@
-from sympy import Symbol, ImmutableMatrix as Matrix
-from sympy.physics.mechanics import (Body, PinJoint, SphericalJoint,
-                                     JointsMethod)
+from sympy import Symbol, symbols, ImmutableMatrix as Matrix
+from sympy.physics.mechanics import *
 
 
 def test_joint_method_simple():
@@ -29,3 +28,60 @@ def test_joint_method_simple():
     assert hasattr(JM, '_qdot')
     assert hasattr(JM, '_udot')
     assert hasattr(JM, '_uaux')
+
+
+def test_joint_method_simple_pendulum():
+    # simple pendulum
+    theta = dynamicsymbols('theta')
+    thetad = dynamicsymbols('theta', 1)
+    omega = dynamicsymbols('omega')
+    length, gravity = symbols('length gravity')
+    child_mass, parent_mass = symbols('child_mass parent_mass')
+
+    parent_frame = ReferenceFrame('parent_frame')
+    child_frame = parent_frame.orientnew('child_frame', 'Axis',
+                                         [theta, parent_frame.z])
+
+    child_frame.set_ang_vel(parent_frame, omega * parent_frame.z)
+
+    parent_masscenter= Point('parent_masscenter')
+    child_masscenter = parent_masscenter.locatenew('child_masscenter',
+                                                   length * child_frame.x)
+
+    parent_masscenter.set_vel(parent_frame, 0)
+    child_masscenter.v2pt_theory(parent_masscenter, parent_frame, child_frame)
+
+    parent_ixx, parent_iyy, parent_izz = symbols('parent_ixx parent_iyy parent_izz')
+    parent_izx, parent_ixy, parent_iyz = symbols('parent_izx parent_ixy parent__iyz')
+    parent_inertia = (inertia(parent_frame, parent_ixx, parent_iyy, parent_izz,
+                      parent_ixy, parent_iyz, parent_izx), parent_masscenter)
+
+    child_ixx, child_iyy, child_izz = symbols('child_ixx child_iyy child_izz')
+    child_izx, child_ixy, child_iyz = symbols('child_izx child_ixy child__iyz')
+    child_inertia = (inertia(child_frame, child_ixx, child_iyy, child_izz,
+                     child_ixy, child_iyz, child_izx), child_masscenter)
+
+    parent = RigidBody('parent', parent_masscenter, parent_frame, parent_mass,
+                       parent_inertia)
+    child = RigidBody('child', parent_masscenter, child_frame, parent_mass,
+                      child_inertia)
+
+    kd = [thetad - omega]
+    FL = [(child_masscenter, child_mass * gravity * parent_frame.x)]
+    BL = [parent, child]
+
+    KM = KanesMethod(parent_frame, q_ind=[theta], u_ind=[omega], kd_eqs=kd)
+    KM.kanes_equations(FL, BL)
+
+    # Simple pendulum using joints method.
+    parent = Body('parent')
+    child = Body('child')
+    length = Symbol('length')
+    gravity = Symbol('gravity')
+    child.apply_force(child.mass * gravity * child.frame.x)
+    pin_joint = PinJoint('pin_joint', parent, child,
+                         child_point_pos=(0, length, 0),
+                         parent_axis='Z', child_axis='Z')
+    JM = JointsMethod([pin_joint], parent)
+
+    assert KM.rhs() == JM.rhs()


### PR DESCRIPTION
- [ ] There are no merge conflicts.
- [ ] If there is a related issue, a reference to that issue is in the
  commit message.
- [ ] Unit tests have been added for the new feature.
- [ ] The PR passes tests both locally (run `nosetests`) and on Travis CI.
- [ ] All public methods and classes have docstrings. (We use the [numpydoc
  format](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).)
- [ ] An explanation has been added to the online documentation. (`docs`
  directory)
- [ ] The code follows PEP8 guidelines. (use a linter, e.g.
  [pylint](http://www.pylint.org), to check your code)
- [ ] The new feature is documented in the [Release
  Notes](https://github.com/pydy/pydy#release-notes).
- [ ] The code is backwards compatible. (All public methods/classes must
  follow deprecation cycles.)
- [ ] All reviewer comments have been addressed.
- [ ] Add the body class to the Sphinx api docs so that the docstrings are rendered in the sphinx docs.
