### PR TITLE
WIP: Manualintegrate infinite recursion

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -150,7 +150,7 @@ def find_substitutions(integrand, symbol, u_var):
         return []
 
     for u in possible_subterms(integrand):
-        if u == symbol:
+        if u == symbol or u == -symbol:
             continue
         u_diff = manual_diff(u, symbol)
         new_integrand = test_subterm(u, u_diff)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -259,5 +259,13 @@ def test_issue_2850():
             log(x**2 + 1)/2)*log(x) + log(x**2 + 1)/2 + Integral(log(x**2 + 1)/x, x)/2
 
 
+def test_issue_9841():
+    # This used to cause a RuntimeError: maximum recursion depth exceeded.
+    # This doesn't error anymore but the answer is still "manually" integrable.
+    # TODO: make this return (3/5)**x/(-log(5) + log(3))
+    manualintegrate(3**x/5**x, x)
+    manualintegrate((3**x+4**x)/5**x, x)
+
+
 def test_constant_independent_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/9841

`manualintegrate(3**x/5**x, x)` causes an infinite recursion where it would call:

`integral_steps` L930 -> `do_one_rl` L86 -> `do_one_rl` L86 -> `null_safe_rl` L66 -> `_alternatives L208` -> `substitution_rule` L743 -> `integral_steps` again

This is because the "possible subterm" flips between u and -u.
