### PR TITLE
Add Printer for ComplexPlane with custom Intervals

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1578,9 +1578,9 @@ class LatexPrinter(Printer):
     def _print_ComplexPlane(self, s):
         vars_print = ', '.join([self._print(var) for var in s.args[0].variables])
         return r"\left\{%s\; |\; %s \in %s \right\}" % (
-            self._print(s.args[0].expr),  # expression: x+iy or ri(cos(theta) + i*sin(theta))
-            vars_print,                   # variable: (x, y) or (r, theta)
-            self._print(s.sets))       # ProductSet
+            self._print(s.args[0].expr),
+            vars_print,
+            self._print(s.sets))
 
     def _print_Contains(self, e):
         return r"%s \in %s" % tuple(self._print(a) for a in e.args)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1575,6 +1575,13 @@ class LatexPrinter(Printer):
             self._print(s.base_set),
             self._print(s.condition.expr))
 
+    def _print_ComplexPlane(self, s):
+        vars_print = ', '.join([self._print(var) for var in s.args[0].variables])
+        return r"\left\{%s\; |\; %s \in %s \right\}" % (
+            self._print(s.args[0].expr),  # expression: x+iy or ri(cos(theta) + i*sin(theta))
+            vars_print,                   # variable: (x, y) or (r, theta)
+            self._print(s.sets))       # ProductSet
+
     def _print_Contains(self, e):
         return r"%s \in %s" % tuple(self._print(a) for a in e.args)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1530,6 +1530,18 @@ class PrettyPrinter(Printer):
         return self._print_seq((variables, bar, variables, inn,
                                 base, _and, cond), "{", "}", ' ')
 
+    def _print_ComplexPlane(self, ts):
+        if self._use_unicode:
+            inn = u("\N{SMALL ELEMENT OF}")
+        else:
+            inn = 'in'
+        variables = self._print_seq(ts.args[0].variables)
+        expr = self._print(ts.args[0].expr)
+        bar = self._print("|")
+        prodsets = self._print(ts.sets)
+
+        return self._print_seq((expr, bar, variables, inn, prodsets), "{", "}", ' ')
+
     def _print_Contains(self, e):
         var, set = e.args
         if self._use_unicode:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3108,6 +3108,15 @@ def test_pretty_ConditionSet():
     assert upretty(ConditionSet(Lambda(x, Eq(sin(x), 0)), S.Reals)) == ucode_str
 
 
+def test_pretty_ComplexPlane():
+    from sympy import ComplexPlane
+    ucode_str = u('{x + ⅈ⋅y | x, y ∊ [3, 5] × [4, 6]}')
+    assert upretty(ComplexPlane(Interval(3, 5)*Interval(4, 6))) == ucode_str
+
+    ucode_str = u('{r⋅(ⅈ⋅sin(θ) + cos(θ)) | r, θ ∊ [0, 1] × [0, 2⋅π)}')
+    assert upretty(ComplexPlane(Interval(0, 1)*Interval(0, 2*pi), polar=True)) == ucode_str
+
+
 def test_ProductSet_paranthesis():
     from sympy import Interval, Union, FiniteSet
     ucode_str = u('([4, 7] × {1, 2}) ∪ ([2, 3] × [4, 7])')

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -15,7 +15,7 @@ from sympy import (
     uppergamma, zeta, subfactorial, totient, elliptic_k, elliptic_f,
     elliptic_e, elliptic_pi, cos, tan, Wild, true, false, Equivalent, Not,
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
-    SeqAdd, SeqMul, fourier_series, pi, ConditionSet, fps)
+    SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexPlane, fps)
 
 
 from sympy.ntheory.factor_ import udivisor_sigma
@@ -607,6 +607,13 @@ def test_latex_ConditionSet():
     x = Symbol('x')
     assert latex(ConditionSet(Lambda(x, Eq(x**2, 1)), S.Reals)) == \
         r"\left\{x\; |\; x \in \mathbb{R} \wedge x^{2} = 1 \right\}"
+
+
+def test_latex_ComplexPlane():
+    assert latex(ComplexPlane(Interval(3, 5)*Interval(4, 6))) == \
+        r"\left\{x + i y\; |\; x, y \in \left[3, 5\right] \times \left[4, 6\right] \right\}"
+    assert latex(ComplexPlane(Interval(0, 1)*Interval(0, 2*pi), polar=True)) == \
+        r"\left\{r \left(i \sin{\left (\theta \right )} + \cos{\left (\theta \right )}\right)\; |\; r, \theta \in \left[0, 1\right] \times \left[0, 2 \pi\right) \right\}"
 
 
 def test_latex_Contains():


### PR DESCRIPTION
Printer for `ComplexPlane` : 
Fixes #9632 

``` python
In [4]: complex_polar = ComplexPlane(Interval(0, 1)*Interval(0, 2*pi), polar=True)

In [5]: complex_rect = ComplexPlane(Interval(0, 1)*Interval(0, 2*pi))

In [6]: init_printing()

In [7]: complex_polar
Out[7]: {r⋅(ⅈ⋅sin(θ) + cos(θ)) | r, θ ∊ [0, 1] × [0, 2⋅π)}

In [8]: complex_rect
Out[8]: {x + ⅈ⋅y | x, y ∊ [0, 1] × [0, 2⋅π]}
```

**TODO**
- [x] Add Printer
- [x] Tests

Open to suggestions, for anything better.

@hargup @flacjacket 
