### PR TITLE
test for solveset(Piecewise(((x - 2)**2, x >= 0), (0, True)), x, S.Reals)

### DIFF
--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -603,6 +603,7 @@ def test_atan2():
 
 def test_piecewise():
     eq = Piecewise((x - 2, Gt(x, 2)), (2 - x, True)) - 3
+    f = Piecewise(((x - 2)**2, x >= 0), (0, True))
     assert set(solveset_real(eq, x)) == set(FiniteSet(-1, 5))
     absxm3 = Piecewise(
         (x - 3, S(0) <= x - 3),
@@ -610,6 +611,7 @@ def test_piecewise():
     )
     y = Symbol('y', positive=True)
     assert solveset_real(absxm3 - y, x) == FiniteSet(-y + 3, y + 3)
+    assert solveset(f, x, domain=S.Reals) == Union(FiniteSet(2), Interval(-oo, 0, True, True))
 
 
 def test_solveset_complex_polynomial():


### PR DESCRIPTION
Test added. See issue #9742 .

This test was somewhere failing and then later on fixed. I tried using `git bisect` to find. Going back in git-history it looks like it was working fine back in time. So i think it was introduced very near to when the issue itself was reported and the fixed also quickly by some commit. I am not sure which commit fixed this.

But i am quite sure that when the issue was reported i was able to re-produce the `bug` on my machine locally then.

I tried but could not find which commit introduced and fixed this.
