### PR TITLE
gaussopt: corrected the definition of BeamParameter.radius

### DIFF
--- a/sympy/physics/optics/gaussopt.py
+++ b/sympy/physics/optics/gaussopt.py
@@ -510,6 +510,7 @@ class BeamParameter(Expr):
     ==========
 
     .. [1] http://en.wikipedia.org/wiki/Complex_beam_parameter
+    .. [2] http://en.wikipedia.org/wiki/Gaussian_beam
     """
     #TODO A class Complex may be implemented. The BeamParameter may
     # subclass it. See:
@@ -558,7 +559,7 @@ class BeamParameter(Expr):
         >>> from sympy.physics.optics import BeamParameter
         >>> p = BeamParameter(530e-9, 1, w=1e-3)
         >>> p.radius
-        0.2809/pi**2 + 1
+        1 + 3.55998576005696*pi**2
         """
         return self.z*(1 + (self.z_r/self.z)**2)
 

--- a/sympy/physics/optics/gaussopt.py
+++ b/sympy/physics/optics/gaussopt.py
@@ -560,7 +560,7 @@ class BeamParameter(Expr):
         >>> p.radius
         0.2809/pi**2 + 1
         """
-        return self.z*(1 + (self.z/self.z_r)**2)
+        return self.z*(1 + (self.z_r/self.z)**2)
 
     @property
     def w(self):

--- a/sympy/physics/optics/tests/test_gaussopt.py
+++ b/sympy/physics/optics/tests/test_gaussopt.py
@@ -83,7 +83,7 @@ def test_gauss_opt():
 
     z, l, w = symbols('z l r', positive=True)
     p = BeamParameter(l, z, w=w)
-    assert p.radius == z*(l**2*z**2/(pi**2*w**4) + 1)
+    assert p.radius == z*(pi**2*w**4/(l**2*z**2) + 1)
     assert p.w == w*sqrt(l**2*z**2/(pi**2*w**4) + 1)
     assert p.w_0 == w
     assert p.divergence == l/(pi*w)


### PR DESCRIPTION
BeamParameter.radius was defined incorrectly. Previously it was
defined as self.z_(1 + (self.z/self.z_r)__2), but it should be
self.z_(1 + (self.z_r/self.z)**2).
