### PR TITLE
[unify] Support And, Or, and Xor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -416,3 +416,4 @@ Richard Otis <richard.otis@outlook.com>
 Michael Zingale <michael.zingale@stonybrook.edu>
 Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
 Dustin Gadal <Dustin.Gadal@gmail.com>
+Yu Kobayashi <yukoba@accelart.jp>

--- a/sympy/unify/rewrite.py
+++ b/sympy/unify/rewrite.py
@@ -3,9 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.unify.usympy import unify
-from sympy.unify.usympy import rebuild
-from sympy.strategies.tools import subs
-from sympy import Expr
+from sympy import sympify
 from sympy.assumptions import ask
 
 def rewriterule(source, target, variables=(), condition=None, assume=None):
@@ -42,14 +40,12 @@ def rewriterule(source, target, variables=(), condition=None, assume=None):
     """
 
     def rewrite_rl(expr, assumptions=True):
+        starget = sympify(target)
         for match in unify(source, expr, {}, variables=variables):
             if (condition and
                 not condition(*[match.get(var, var) for var in variables])):
                 continue
             if (assume and not ask(assume.xreplace(match), assumptions)):
                 continue
-            expr2 = subs(match)(target)
-            if isinstance(expr2, Expr):
-                expr2 = rebuild(expr2)
-            yield expr2
+            yield starget.subs(match)
     return rewrite_rl

--- a/sympy/unify/tests/test_rewrite.py
+++ b/sympy/unify/tests/test_rewrite.py
@@ -1,10 +1,7 @@
 from sympy.unify.rewrite import rewriterule
-from sympy import sin, Basic, Symbol, S
-from sympy.abc import x, y
-from sympy.strategies.rl import rebuild
+from sympy import sin, Basic, Symbol, S, MatrixSymbol
+from sympy.abc import p, q, r, x, y, z
 from sympy.assumptions import Q
-
-p, q = Symbol('p'), Symbol('q')
 
 def test_simple():
     rl = rewriterule(Basic(p, 1), Basic(p, 2), variables=(p,))
@@ -40,6 +37,21 @@ def test_sincos():
     assert list(rl(sin(x)**2 + sin(x)**2)) == [1]
     assert list(rl(sin(y)**2 + sin(y)**2)) == [1]
 
+def test_logic():
+    rl = rewriterule((p | q) & r, p & r, (p, q, r))
+    assert set(rl((x | y) & (z | x))) == set([(x | y) & x, (x | y) & z, (x | z) & x, (x | z) & y])
+
+def test_matrix():
+    A = MatrixSymbol('A', 3, 3)
+    B = MatrixSymbol('B', 3, 3)
+    C = MatrixSymbol('C', 3, 3)
+    X = MatrixSymbol('X', 3, 3)
+    Y = MatrixSymbol('Y', 3, 3)
+    Z = MatrixSymbol('Z', 3, 3)
+
+    rl = rewriterule(A * B + C, A + C, (A, B, C))
+    assert set([m.doit() for m in rl(X * Y + Z * X)]) == set([X + Z * X, Z + X * Y])
+
 def test_Exprs_ok():
     rl = rewriterule(p+q, q+p, (p, q))
     next(rl(x+y)).is_commutative
@@ -48,7 +60,7 @@ def test_Exprs_ok():
 def test_condition_simple():
     rl = rewriterule(x, x+1, [x], lambda x: x < 10)
     assert not list(rl(S(15)))
-    assert rebuild(next(rl(S(5)))) == 6
+    assert next(rl(S(5))) == 6
 
 
 def test_condition_multiple():

--- a/sympy/unify/usympy.py
+++ b/sympy/unify/usympy.py
@@ -6,6 +6,7 @@ See sympy.unify.core for algorithmic docstring """
 from __future__ import print_function, division
 
 from sympy.core import Basic, Add, Mul, Pow
+from sympy.logic.boolalg import And, Or, Xor, Nand, Nor
 from sympy.matrices import MatAdd, MatMul, MatrixExpr
 from sympy.sets.sets import Union, Intersection, FiniteSet
 from sympy.core.operations import AssocOp, LatticeOp
@@ -14,14 +15,13 @@ from sympy.unify import core
 
 basic_new_legal = [MatrixExpr]
 eval_false_legal = [AssocOp, Pow, FiniteSet]
-illegal = [LatticeOp]
 
 def sympy_associative(op):
     assoc_ops = (AssocOp, MatAdd, MatMul, Union, Intersection, FiniteSet)
     return any(issubclass(op, aop) for aop in assoc_ops)
 
 def sympy_commutative(op):
-    comm_ops = (Add, MatAdd, Union, Intersection, FiniteSet)
+    comm_ops = (Add, MatAdd, Union, Intersection, FiniteSet, And, Or, Xor, Nand, Nor)
     return any(issubclass(op, cop) for cop in comm_ops)
 
 def is_associative(x):


### PR DESCRIPTION
Support And, Or, Xor, Nand and Nor in `sympy.unify`.

I modified the following things.
1. I added `And, Or, Xor, Nand, Nor` to sympy_commutative() of usympy.py.
2. I changed to use `Basic.subs()` in rewriterule() of rewrite.py. I will write the reason later.
3. I added test_logic() and test_matrix() to test_rewrite.py. Adding test_matrix() is for just in case.
4. Because rebuild() is unnecessarily in  test_condition_simple() of test_rewrite.py, I removed.
5. I removed `illegal` of usympy.py, because it is unused and LatticeOp (And, Or) is legal now.

The reason for 2. is that there is a problem https://github.com/sympy/sympy/pull/1633#issuecomment-10585331 as @mrocklin said, so I changed to use `Basic.subs()`.

Please merge this and also https://github.com/sympy/sympy/pull/9886 !
