### PR TITLE
fix row_del function in MutableDenseMatrix

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -884,7 +884,7 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
             raise IndexError("Index out of range: 'i = %s', valid -%s <= i"
                              " < %s" % (i, self.rows, self.rows))
         if i < 0:
-            i = self.rows - abs(i)
+            i += self.rows
         del self._mat[i*self.cols:(i+1)*self.cols]
         self.rows -= 1
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -881,7 +881,10 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         col_del
         """
         if i < -self.rows or i >= self.rows:
-            raise IndexError("Index out of range: 'i = %s', valid -%s <= i < %s" % (i, self.rows, self.rows))
+            raise IndexError("Index out of range: 'i = %s', valid -%s <= i"
+                             " < %s" % (i, self.rows, self.rows))
+        if i < 0:
+            i = self.rows - abs(i)
         del self._mat[i*self.cols:(i+1)*self.cols]
         self.rows -= 1
 
@@ -907,7 +910,8 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         row_del
         """
         if i < -self.cols or i >= self.cols:
-            raise IndexError("Index out of range: 'i=%s', valid -%s <= i < %s" % (i, self.cols, self.cols))
+            raise IndexError("Index out of range: 'i=%s', valid -%s <= i < %s"
+                             % (i, self.cols, self.cols))
         for j in range(self.rows - 1, -1, -1):
             del self._mat[i + j*self.cols]
         self.cols -= 1

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2591,7 +2591,7 @@ def test_doit():
     assert a[0] != 2*x
     assert a.doit() == Matrix([[2*x]])
 
-def test_issue_9457_9467():
+def test_issue_9457_9467_9876():
     # for row_del(index)
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     M.row_del(1)
@@ -2599,6 +2599,9 @@ def test_issue_9457_9467():
     N = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     N.row_del(-2)
     assert N == Matrix([[1, 2, 3], [3, 4, 5]])
+    O = Matrix([[1, 2, 3], [5, 6, 7], [9, 10, 11]])
+    O.row_del(-1)
+    assert O == Matrix([[1, 2, 3], [5, 6, 7]])
     P = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     raises(IndexError, lambda: P.row_del(10))
     Q = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])


### PR DESCRIPTION
```
>>> A = Matrix([[1, 2, 3], [5, 6, 7], [9, 10, 11]])
>>> A.row_del(-1)
>>> A._mat
[1, 2, 3, 5, 6, 7, 9, 10, 11]
```

Last row was not deleted. This was due to how indexing is done in python. As pointed out by @jksuom [here](https://github.com/sympy/sympy/issues/9876#issuecomment-136021664).

eg.

```
>>> A._mat[-3:0]
[]
```

fixes #9876 

Ping @gxyd 
