### PR TITLE
add --slow option in bin/coverage_report.py

### DIFF
--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -14,9 +14,9 @@ argument. For example:
 $ bin/coverage_report.py sympy/logic
 
 runs only the tests in sympy/logic/ and reports only on the modules in
-sympy/logic/. You can also get a report on the parts of the whole sympy
-code covered by the tests in sympy/logic/ by following up the previous
-command with
+sympy/logic/. To also run slow tests use --slow option. You can also get a
+report on the parts of the whole sympy code covered by the tests in
+sympy/logic/ by following up the previous command with
 
 
 $ bin/coverage_report.py -c
@@ -60,15 +60,16 @@ def generate_covered_files(top_dir):
                 yield os.path.join(dirpath, filename)
 
 
-def make_report(source_dir, report_dir, use_cache=False):
-    #code adapted from /bin/test
-    bin_dir = os.path.abspath(os.path.dirname(__file__))         # bin/
-    sympy_top = os.path.split(bin_dir)[0]      # ../
+def make_report(source_dir, report_dir, use_cache=False, slow=False):
+    # code adapted from /bin/test
+    bin_dir = os.path.abspath(os.path.dirname(__file__))  # bin/
+    sympy_top = os.path.split(bin_dir)[0]  # ../
     sympy_dir = os.path.join(sympy_top, 'sympy')  # ../sympy/
     if os.path.isdir(sympy_dir):
         sys.path.insert(0, sympy_top)
     os.chdir(sympy_top)
 
+    import sympy
     cov = coverage.coverage()
     cov.exclude("raise NotImplementedError")
     cov.exclude("def canonize")  # this should be "@decorated"
@@ -78,8 +79,9 @@ def make_report(source_dir, report_dir, use_cache=False):
     else:
         cov.erase()
         cov.start()
-        import sympy
         sympy.test(source_dir, subprocess=False)
+        if slow:
+            sympy.test(source_dir, subprocess=False, slow=slow)
         #sympy.doctest()  # coverage doesn't play well with doctests
         cov.stop()
         cov.save()
@@ -99,6 +101,8 @@ if __name__ == '__main__':
                       help='Use cached data.')
     parser.add_option('-d', '--report-dir', default='covhtml',
                       help='Directory to put the generated report in.')
+    parser.add_option("--slow", action="store_true", dest="slow",
+                      default=False, help="Run slow functions also.")
 
     options, args = parser.parse_args()
 


### PR DESCRIPTION
There were two options:
1. Run only slow tests.
2. Run all the tests.

I went with 2nd option. As this is coverage report it made sense to run all the tests when used with `--slow` option.

Ping @aktech @moorepants 

closes #9746 
