### PR TITLE
[unify] Remove Basic.__new__ direct call

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -416,3 +416,4 @@ Richard Otis <richard.otis@outlook.com>
 Michael Zingale <michael.zingale@stonybrook.edu>
 Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
 Dustin Gadal <Dustin.Gadal@gmail.com>
+Yu Kobayashi <yukoba@accelart.jp>

--- a/sympy/strategies/branch/traverse.py
+++ b/sympy/strategies/branch/traverse.py
@@ -4,15 +4,15 @@ from __future__ import print_function, division
 
 from itertools import product
 
-from sympy.strategies.util import basic_fns
+from sympy.strategies.util import expr_fns
 from .core import chain, identity, do_one
 
-def top_down(brule, fns=basic_fns):
+def top_down(brule, fns=expr_fns):
     """ Apply a rule down a tree running it on the top nodes first """
     return chain(do_one(brule, identity),
                  lambda expr: sall(top_down(brule, fns), fns)(expr))
 
-def sall(brule, fns=basic_fns):
+def sall(brule, fns=expr_fns):
     """ Strategic all - apply rule to args """
     op, new, children, leaf = map(fns.get, ('op', 'new', 'children', 'leaf'))
     def all_rl(expr):

--- a/sympy/strategies/traverse.py
+++ b/sympy/strategies/traverse.py
@@ -4,23 +4,23 @@ from __future__ import print_function, division
 from .util import basic_fns, expr_fns
 from sympy.strategies.core import chain, do_one
 
-def top_down(rule, fns=basic_fns):
+def top_down(rule, fns=expr_fns):
     """ Apply a rule down a tree running it on the top nodes first """
     return chain(rule, lambda expr: sall(top_down(rule, fns), fns)(expr))
 
-def bottom_up(rule, fns=basic_fns):
+def bottom_up(rule, fns=expr_fns):
     """ Apply a rule down a tree running it on the bottom nodes first """
     return chain(lambda expr: sall(bottom_up(rule, fns), fns)(expr), rule)
 
-def top_down_once(rule, fns=basic_fns):
+def top_down_once(rule, fns=expr_fns):
     """ Apply a rule down a tree - stop on success """
     return do_one(rule, lambda expr: sall(top_down(rule, fns), fns)(expr))
 
-def bottom_up_once(rule, fns=basic_fns):
+def bottom_up_once(rule, fns=expr_fns):
     """ Apply a rule up a tree - stop on success """
     return do_one(lambda expr: sall(bottom_up(rule, fns), fns)(expr), rule)
 
-def sall(rule, fns=basic_fns):
+def sall(rule, fns=expr_fns):
     """ Strategic all - apply rule to args """
     op, new, children, leaf = map(fns.get, ('op', 'new', 'children', 'leaf'))
     def all_rl(expr):

--- a/sympy/strategies/util.py
+++ b/sympy/strategies/util.py
@@ -9,6 +9,7 @@ def assoc(d, k, v):
     d[k] = v
     return d
 
+# Basically do not use basic_fns. Use expr_fns.
 basic_fns = {'op': type,
              'new': Basic.__new__,
              'leaf': lambda x: not isinstance(x, Basic) or x.is_Atom,

--- a/sympy/unify/__init__.py
+++ b/sympy/unify/__init__.py
@@ -5,5 +5,5 @@ See sympy.unify.core docstring for algorithmic details
 See http://matthewrocklin.com/blog/work/2012/11/01/Unification/ for discussion
 """
 
-from .usympy import unify, rebuild
+from .usympy import unify
 from .rewrite import rewriterule

--- a/sympy/unify/rewrite.py
+++ b/sympy/unify/rewrite.py
@@ -3,9 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.unify.usympy import unify
-from sympy.unify.usympy import rebuild
-from sympy.strategies.tools import subs
-from sympy import Expr
+from sympy import sympify
 from sympy.assumptions import ask
 
 def rewriterule(source, target, variables=(), condition=None, assume=None):
@@ -42,14 +40,12 @@ def rewriterule(source, target, variables=(), condition=None, assume=None):
     """
 
     def rewrite_rl(expr, assumptions=True):
+        starget = sympify(target)
         for match in unify(source, expr, {}, variables=variables):
             if (condition and
                 not condition(*[match.get(var, var) for var in variables])):
                 continue
             if (assume and not ask(assume.xreplace(match), assumptions)):
                 continue
-            expr2 = subs(match)(target)
-            if isinstance(expr2, Expr):
-                expr2 = rebuild(expr2)
-            yield expr2
+            yield starget.subs(match)
     return rewrite_rl

--- a/sympy/unify/tests/test_rewrite.py
+++ b/sympy/unify/tests/test_rewrite.py
@@ -52,6 +52,9 @@ def test_matrix():
     rl = rewriterule(A * B + C, A + C, (A, B, C))
     assert set([m.doit() for m in rl(X * Y + Z * X)]) == set([X + Z * X, Z + X * Y])
 
+    rl = rewriterule(A * B + C, A.T + B.T, (A, B, C))
+    assert set([m.doit() for m in rl(X * Y + Z * X)]) == set([X.T + Y.T, Z.T + X.T])
+
 def test_Exprs_ok():
     rl = rewriterule(p+q, q+p, (p, q))
     next(rl(x+y)).is_commutative

--- a/sympy/unify/tests/test_rewrite.py
+++ b/sympy/unify/tests/test_rewrite.py
@@ -1,10 +1,7 @@
 from sympy.unify.rewrite import rewriterule
-from sympy import sin, Basic, Symbol, S
-from sympy.abc import x, y
-from sympy.strategies.rl import rebuild
+from sympy import sin, Basic, Symbol, S, MatrixSymbol
+from sympy.abc import p, q, r, x, y, z
 from sympy.assumptions import Q
-
-p, q = Symbol('p'), Symbol('q')
 
 def test_simple():
     rl = rewriterule(Basic(p, 1), Basic(p, 2), variables=(p,))
@@ -40,6 +37,21 @@ def test_sincos():
     assert list(rl(sin(x)**2 + sin(x)**2)) == [1]
     assert list(rl(sin(y)**2 + sin(y)**2)) == [1]
 
+def test_logic():
+    rl = rewriterule((p | q) & r, p & r, (p, q, r))
+    assert set(rl((x | y) & (z | x))) == set([(x | y) & x, (x | y) & z, (x | z) & x, (x | z) & y])
+
+def test_matrix():
+    A = MatrixSymbol('A', 3, 3)
+    B = MatrixSymbol('B', 3, 3)
+    C = MatrixSymbol('C', 3, 3)
+    X = MatrixSymbol('X', 3, 3)
+    Y = MatrixSymbol('Y', 3, 3)
+    Z = MatrixSymbol('Z', 3, 3)
+
+    rl = rewriterule(A * B + C, A + C, (A, B, C))
+    assert set([m.doit() for m in rl(X * Y + Z * X)]) == set([X + Z * X, Z + X * Y])
+
 def test_Exprs_ok():
     rl = rewriterule(p+q, q+p, (p, q))
     next(rl(x+y)).is_commutative
@@ -48,7 +60,7 @@ def test_Exprs_ok():
 def test_condition_simple():
     rl = rewriterule(x, x+1, [x], lambda x: x < 10)
     assert not list(rl(S(15)))
-    assert rebuild(next(rl(S(5)))) == 6
+    assert next(rl(S(5))) == 6
 
 
 def test_condition_multiple():

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -97,12 +97,24 @@ def test_hard_match():
     assert list(unify(expr, pattern, {}, (p, q))) == [{p: x}]
 
 def test_matrix():
-    from sympy import MatrixSymbol
+    from sympy import MatrixSymbol, ZeroMatrix, Identity
     X = MatrixSymbol('X', n, n)
     Y = MatrixSymbol('Y', 2, 2)
     Z = MatrixSymbol('Z', 2, 3)
     assert list(unify(X, Y, {}, variables=[n, 'X'])) == [{'X': 'Y', n: 2}]
     assert list(unify(X, Z, {}, variables=[n, 'X'])) == []
+
+    A = MatrixSymbol('A', 3, 3)
+    B = MatrixSymbol('B', 3, 3)
+    C = MatrixSymbol('C', 3, 3)
+    D = ZeroMatrix(3, 3)
+    I = Identity(3)
+
+    assert list(unify(C, A, {}, variables=[A])) == [{A: C}]
+    assert list(unify(D, A, {}, variables=[A])) == [{A: D}]
+
+    list1 = list(unify(C + I, A + B, {}, variables=[A, B]))
+    assert len(list1) == 2 and {A: C, B: I} in list1 and {A: I, B: C} in list1
 
 def test_non_frankenAdds():
     # the is_commutative property used to fail because of Basic.__new__

--- a/sympy/unify/usympy.py
+++ b/sympy/unify/usympy.py
@@ -6,6 +6,7 @@ See sympy.unify.core for algorithmic docstring """
 from __future__ import print_function, division
 
 from sympy.core import Basic, Add, Mul, Pow
+from sympy.logic.boolalg import And, Or, Xor, Nand, Nor
 from sympy.matrices import MatAdd, MatMul, MatrixExpr
 from sympy.sets.sets import Union, Intersection, FiniteSet
 from sympy.core.operations import AssocOp, LatticeOp
@@ -14,14 +15,13 @@ from sympy.unify import core
 
 basic_new_legal = [MatrixExpr]
 eval_false_legal = [AssocOp, Pow, FiniteSet]
-illegal = [LatticeOp]
 
 def sympy_associative(op):
     assoc_ops = (AssocOp, MatAdd, MatMul, Union, Intersection, FiniteSet)
     return any(issubclass(op, aop) for aop in assoc_ops)
 
 def sympy_commutative(op):
-    comm_ops = (Add, MatAdd, Union, Intersection, FiniteSet)
+    comm_ops = (Add, MatAdd, Union, Intersection, FiniteSet, And, Or, Xor, Nand, Nor)
     return any(issubclass(op, cop) for cop in comm_ops)
 
 def is_associative(x):

--- a/sympy/unify/usympy.py
+++ b/sympy/unify/usympy.py
@@ -62,13 +62,6 @@ def construct(t):
     else:
         return t.op(*map(construct, t.args))
 
-def rebuild(s):
-    """ Rebuild a SymPy expression
-
-    This removes harm caused by Expr-Rules interactions
-    """
-    return construct(deconstruct(s))
-
 def unify(x, y, s=None, variables=(), **kwargs):
     """ Structural unification of two expressions/patterns
 

--- a/sympy/unify/usympy.py
+++ b/sympy/unify/usympy.py
@@ -7,13 +7,12 @@ from __future__ import print_function, division
 
 from sympy.core import Basic, Add, Mul, Pow
 from sympy.logic.boolalg import And, Or, Xor, Nand, Nor
-from sympy.matrices import MatAdd, MatMul, MatrixExpr
+from sympy.matrices import MatAdd, MatMul
 from sympy.sets.sets import Union, Intersection, FiniteSet
-from sympy.core.operations import AssocOp, LatticeOp
+from sympy.core.operations import AssocOp
 from sympy.unify.core import Compound, Variable, CondVariable
 from sympy.unify import core
 
-basic_new_legal = [MatrixExpr]
 eval_false_legal = [AssocOp, Pow, FiniteSet]
 
 def sympy_associative(op):
@@ -60,8 +59,6 @@ def construct(t):
         return t
     if any(issubclass(t.op, cls) for cls in eval_false_legal):
         return t.op(*map(construct, t.args), evaluate=False)
-    elif any(issubclass(t.op, cls) for cls in basic_new_legal):
-        return Basic.__new__(t.op, *map(construct, t.args))
     else:
         return t.op(*map(construct, t.args))
 


### PR DESCRIPTION
There is an argument of removing `Basic.__new__()` direct call at https://github.com/sympy/sympy/pull/1633 .
`Basic.__new__()` direct call can be removed after https://github.com/sympy/sympy/pull/1670 modification.
Using `Basic.__new__()` direct call is not a good idea, and if it is possible is should be removed.
Current SymPy can remove `Basic.__new__()`direct call.

So I modified the following things.
1. Removed `Basic.__new__()` direct call from `construct()` in sympy/unify/usympy.py.
2. Added matrix tests more.
3. There are `basic_fns` and `expr_fns` in sympy/strategies/util.py, and `basic_fns` calls `Basic.__new__()`. But this is currently meaningless so I changed the default of sympy/strategies/*.py from `basic_fns` to `expr_fns`.
4. When `Basic.__new__()` direct call is removed, `rebuild()` in sympy/unify/usympy.py is meaningless and I removed it.

This patch depends on https://github.com/sympy/sympy/pull/9879 .
Please merge https://github.com/sympy/sympy/pull/9879 first and after that please merge this pull request.
