### PR TITLE
support for spherical hankel funcs

### DIFF
--- a/doc/src/aboutus.rst
+++ b/doc/src/aboutus.rst
@@ -236,7 +236,7 @@ want to be mentioned here, so see our repository history for a full list).
 #. Marek Šuppa: Improvements to symbols, tests
 #. Prasoon Shukla: Bug fixes
 #. Stefen Yin: Fixes to the mechanics module
-#. Thomas Hisch: Improvements to the printing module, Spherical Bessel functions, Improvements to the doctester
+#. Thomas Hisch: Spherical Hankel functions, Improvements to the printing module, Improvements to the doctesting system
 #. Matthew Hoff: Addition to quantum module
 #. Madeleine Ball: Bug fix
 #. Case Van Horsen: Fixes to gmpy support

--- a/doc/src/aboutus.rst
+++ b/doc/src/aboutus.rst
@@ -236,7 +236,7 @@ want to be mentioned here, so see our repository history for a full list).
 #. Marek Šuppa: Improvements to symbols, tests
 #. Prasoon Shukla: Bug fixes
 #. Stefen Yin: Fixes to the mechanics module
-#. Thomas Hisch: Improvements to the printing module
+#. Thomas Hisch: Improvements to the printing module, Spherical Bessel functions, Improvements to the doctester
 #. Matthew Hoff: Addition to quantum module
 #. Madeleine Ball: Bug fix
 #. Case Van Horsen: Fixes to gmpy support

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1351,6 +1351,11 @@ def test_sympy__functions__special__bessel__SphericalBesselBase():
     pass
 
 
+@SKIP("abstract class")
+def test_sympy__functions__special__bessel__SphericalHankelBase():
+    pass
+
+
 def test_sympy__functions__special__bessel__besseli():
     from sympy.functions.special.bessel import besseli
     assert _test_args(besseli(x, 1))
@@ -1389,6 +1394,16 @@ def test_sympy__functions__special__bessel__jn():
 def test_sympy__functions__special__bessel__yn():
     from sympy.functions.special.bessel import yn
     assert _test_args(yn(0, x))
+
+
+def test_sympy__functions__special__bessel__hn1():
+    from sympy.functions.special.bessel import hn1
+    assert _test_args(hn1(0, x))
+
+
+def test_sympy__functions__special__bessel__hn2():
+    from sympy.functions.special.bessel import hn2
+    assert _test_args(hn2(0, x))
 
 
 def test_sympy__functions__special__bessel__AiryBase():

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -34,7 +34,7 @@ from sympy.functions.special.tensor_functions import (Eijk, LeviCivita,
 from sympy.functions.special.delta_functions import DiracDelta, Heaviside
 from sympy.functions.special.bsplines import bspline_basis, bspline_basis_set
 from sympy.functions.special.bessel import (besselj, bessely, besseli, besselk,
-        hankel1, hankel2, jn, yn, jn_zeros, airyai, airybi, airyaiprime, airybiprime)
+        hankel1, hankel2, jn, yn, jn_zeros, hn1, hn2, airyai, airybi, airyaiprime, airybiprime)
 from sympy.functions.special.hyper import hyper, meijerg
 from sympy.functions.special.polynomials import (legendre, assoc_legendre,
         hermite, chebyshevt, chebyshevu, chebyshevu_root, chebyshevt_root,

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -749,6 +749,15 @@ class SphericalHankelBase(SphericalBesselBase):
         if nu.is_integer:
             return jn(nu, z) + hks*I*yn(nu, z).rewrite(jn)
 
+    def _eval_expand_func(self, **hints):
+        if self.order.is_Integer:
+            return self._expand(**hints)
+        else:
+            nu = self.order
+            z = self.argument
+            hks = self._hankel_kind_sign
+            return jn(nu, z) + hks*I*yn(nu, z)
+
     def _expand(self, **hints):
         n = self.order
         z = self.argument
@@ -784,15 +793,23 @@ class hn1(SphericalHankelBase):
     Examples
     ========
 
-    >>> from sympy import Symbol, hn1, hankel1, expand_func
+    >>> from sympy import Symbol, hn1, hankel1, expand_func, yn, jn
     >>> z = Symbol("z")
-    >>> nu = Symbol("nu", integer=True)
+    >>> nu = Symbol("nu")
+    >>> print(expand_func(hn1(nu, z)))
+    jn(nu, z) + I*yn(nu, z)
     >>> print(expand_func(hn1(0, z)))
     sin(z)/z - I*cos(z)/z
     >>> print(expand_func(hn1(1, z)))
     -I*sin(z)/z - cos(z)/z + sin(z)/z**2 - I*cos(z)/z**2
     >>> hn1(nu, z).rewrite(hankel1)
     sqrt(2)*sqrt(pi)*sqrt(1/z)*hankel1(nu, z)/2
+
+    >>> n = Symbol("n", integer=True)
+    >>> hn1(n, z).rewrite(jn)
+    (-1)**(n + 1)*I*jn(-n - 1, z) + jn(n, z)
+    >>> hn1(n, z).rewrite(yn)
+    (-1)**n*yn(-n - 1, z) + I*yn(n, z)
 
     See Also
     ========
@@ -825,15 +842,23 @@ class hn2(SphericalHankelBase):
     Examples
     ========
 
-    >>> from sympy import Symbol, hn2, hankel2, expand_func
+    >>> from sympy import Symbol, hn2, hankel2, expand_func, jn, yn
     >>> z = Symbol("z")
-    >>> nu = Symbol("nu", integer=True)
+    >>> nu = Symbol("nu")
+    >>> print(expand_func(hn2(nu, z)))
+    jn(nu, z) - I*yn(nu, z)
     >>> print(expand_func(hn2(0, z)))
     sin(z)/z + I*cos(z)/z
     >>> print(expand_func(hn2(1, z)))
     I*sin(z)/z - cos(z)/z + sin(z)/z**2 + I*cos(z)/z**2
     >>> hn2(nu, z).rewrite(hankel2)
     sqrt(2)*sqrt(pi)*sqrt(1/z)*hankel2(nu, z)/2
+
+    >>> n = Symbol("n", integer=True)
+    >>> hn2(n, z).rewrite(jn)
+    -(-1)**(n + 1)*I*jn(-n - 1, z) + jn(n, z)
+    >>> hn2(n, z).rewrite(yn)
+    (-1)**n*yn(-n - 1, z) - I*yn(n, z)
 
     See Also
     ========

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -655,6 +655,10 @@ class jn(SphericalBesselBase):
     def _eval_rewrite_as_bessely(self, nu, z):
         return (-1)**nu * sqrt(pi/(2*z)) * bessely(-nu - S.Half, z)
 
+    def _eval_rewrite_as_yn(self, nu, z):
+        if nu.is_integer:
+            return (-1)**(nu) * yn(-nu - 1, z)
+
     def _expand(self, **hints):
         return _jn(self.order, self.argument)
 
@@ -706,6 +710,10 @@ class yn(SphericalBesselBase):
     def _eval_rewrite_as_bessely(self, nu, z):
         return sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
 
+    def _eval_rewrite_as_jn(self, nu, z):
+        if nu.is_integer:
+            return (-1)**(nu + 1) * jn(-nu - 1, z)
+
     def _expand(self, **hints):
         return _yn(self.order, self.argument)
 
@@ -733,11 +741,13 @@ class SphericalHankelBase(SphericalBesselBase):
 
     def _eval_rewrite_as_yn(self, nu, z):
         hks = self._hankel_kind_sign
-        return jn(nu, z).rewrite(yn) + hks*I*yn(nu, z)
+        if nu.is_integer:
+            return jn(nu, z).rewrite(yn) + hks*I*yn(nu, z)
 
     def _eval_rewrite_as_jn(self, nu, z):
         hks = self._hankel_kind_sign
-        return jn(nu, z) + hks*I*yn(nu, z).rewrite(jn)
+        if nu.is_integer:
+            return jn(nu, z) + hks*I*yn(nu, z).rewrite(jn)
 
     def _expand(self, **hints):
         n = self.order

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -656,6 +656,11 @@ class jn(SphericalBesselBase):
 
     besselj, bessely, besselk, yn
 
+    References
+    ==========
+
+    .. [1] http://dlmf.nist.gov/10.47
+
     """
 
     def _rewrite(self):
@@ -713,6 +718,11 @@ class yn(SphericalBesselBase):
     ========
 
     besselj, bessely, besselk, jn
+
+    References
+    ==========
+
+    .. [1] http://dlmf.nist.gov/10.47
 
     """
 
@@ -829,6 +839,11 @@ class hn1(SphericalHankelBase):
 
     hn2, jn, yn, hankel1, hankel2
 
+    References
+    ==========
+
+    .. [1] http://dlmf.nist.gov/10.47
+
     """
 
     _hankel_kind_sign = S.One
@@ -876,6 +891,11 @@ class hn2(SphericalHankelBase):
     ========
 
     hn1, jn, yn, hankel1, hankel2
+
+    References
+    ==========
+
+    .. [1] http://dlmf.nist.gov/10.47
 
     """
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -585,7 +585,6 @@ class SphericalBesselBase(BesselBase):
     def _eval_evalf(self, prec):
         if self.order.is_Integer:
             return self._rewrite()._eval_evalf(prec)
-        return self
 
     def fdiff(self, argindex=2):
         if argindex != 2:

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -655,10 +655,9 @@ class jn(SphericalBesselBase):
         return (-1)**nu * sqrt(pi/(2*z)) * bessely(-nu - S.Half, z)
 
     def _expand(self, **hints):
-        # TODO not valid for non-integral orders
-        n = self.order
+        nu = self.order
         z = self.argument
-        return _jn_orthopoly(n, z)
+        return _jn_orthopoly(nu, z)
 
 
 class yn(SphericalBesselBase):
@@ -710,10 +709,9 @@ class yn(SphericalBesselBase):
         return sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
 
     def _expand(self, **hints):
-        # TODO not valid for non-integral orders
-        n = self.order
+        nu = self.order
         z = self.argument
-        return _yn_orthopoly(n, z)
+        return _yn_orthopoly(nu, z)
 
 
 class SphericalHankelBase(SphericalBesselBase):

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -758,12 +758,15 @@ class hn1(SphericalHankelBase):
     Examples
     ========
 
-    >>> from sympy import Symbol, hn1, expand_func
+    >>> from sympy import Symbol, hn1, hankel1, expand_func
     >>> z = Symbol("z")
+    >>> nu = Symbol("nu", integer=True)
     >>> print(expand_func(hn1(0, z)))
     sin(z)/z - I*cos(z)/z
     >>> print(expand_func(hn1(1, z)))
     -I*sin(z)/z - cos(z)/z + sin(z)/z**2 - I*cos(z)/z**2
+    >>> hn1(nu, z).rewrite(hankel1)
+    sqrt(2)*sqrt(pi)*sqrt(1/z)*hankel1(nu, z)/2
 
     For integral orders :math:`n`, :math:`h_n^(1)` is calculated using the formula:
 
@@ -771,6 +774,9 @@ class hn1(SphericalHankelBase):
     """
 
     _hankel_kind_sign = S.One
+
+    def _eval_rewrite_as_hankel1(self, nu, z):
+        return sqrt(pi/(2*z))*hankel1(nu, z)
 
 
 class hn2(SphericalHankelBase):
@@ -780,12 +786,15 @@ class hn2(SphericalHankelBase):
     Examples
     ========
 
-    >>> from sympy import Symbol, hn2, expand_func
+    >>> from sympy import Symbol, hn2, hankel2, expand_func
     >>> z = Symbol("z")
+    >>> nu = Symbol("nu", integer=True)
     >>> print(expand_func(hn2(0, z)))
     sin(z)/z + I*cos(z)/z
     >>> print(expand_func(hn2(1, z)))
     I*sin(z)/z - cos(z)/z + sin(z)/z**2 + I*cos(z)/z**2
+    >>> hn2(nu, z).rewrite(hankel2)
+    sqrt(2)*sqrt(pi)*sqrt(1/z)*hankel2(nu, z)/2
 
     For integral orders :math:`n`, :math:`h_n^(2)` is calculated using the formula:
 
@@ -793,6 +802,9 @@ class hn2(SphericalHankelBase):
     """
 
     _hankel_kind_sign = -S.One
+
+    def _eval_rewrite_as_hankel2(self, nu, z):
+        return sqrt(pi/(2*z))*hankel2(nu, z)
 
 
 def jn_zeros(n, k, method="sympy", dps=15):

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -640,14 +640,20 @@ class jn(SphericalBesselBase):
     Examples
     ========
 
-    >>> from sympy import Symbol, jn, sin, cos, expand_func
+    >>> from sympy import Symbol, jn, sin, cos, expand_func, besselj, bessely
+    >>> from sympy import simplify
     >>> z = Symbol("z")
-    >>> print(jn(0, z).expand(func=True))
+    >>> nu = Symbol("nu", integer=True)
+    >>> print(expand_func(jn(0, z)))
     sin(z)/z
-    >>> jn(1, z).expand(func=True) == sin(z)/z**2 - cos(z)/z
+    >>> expand_func(jn(1, z)) == sin(z)/z**2 - cos(z)/z
     True
     >>> expand_func(jn(3, z))
     (-6/z**2 + 15/z**4)*sin(z) + (1/z - 15/z**3)*cos(z)
+    >>> jn(nu, z).rewrite(besselj)
+    sqrt(2)*sqrt(pi)*sqrt(1/z)*besselj(nu + 1/2, z)/2
+    >>> jn(nu, z).rewrite(bessely)
+    (-1)**nu*sqrt(2)*sqrt(pi)*sqrt(1/z)*bessely(-nu - 1/2, z)/2
     >>> jn(2, 5.2+0.3j).evalf(20)
     0.099419756723640344491 - 0.054525080242173562897*I
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -784,7 +784,7 @@ class hn1(SphericalHankelBase):
     .. math:: h_\nu^(1)(z) = j_\nu(z) + i y_\nu(z),
 
     where :math:`j_\nu(z)` and :math:`y_\nu(z)` are the spherical
-    Bessel function of the first and second kind.
+    Bessel function of the first and second kinds.
 
     For integral orders :math:`n`, :math:`h_n^(1)` is calculated using the formula:
 
@@ -833,7 +833,7 @@ class hn2(SphericalHankelBase):
     .. math:: h_\nu^(2)(z) = j_\nu(z) - i y_\nu(z),
 
     where :math:`j_\nu(z)` and :math:`y_\nu(z)` are the spherical
-    Bessel function of the first and second kind.
+    Bessel function of the first and second kinds.
 
     For integral orders :math:`n`, :math:`h_n^(2)` is calculated using the formula:
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -593,12 +593,12 @@ class SphericalBesselBase(BesselBase):
             self * (self.order + 1)/self.argument
 
 
-def _jn_orthopoly(n, z):
+def _jn(n, z):
     return fn(n, z)*sin(z) + (-1)**(n + 1)*fn(-n - 1, z)*cos(z)
 
 
-def _yn_orthopoly(n, z):
-    return (-1)**(n + 1) * _jn_orthopoly(-n - 1, z)
+def _yn(n, z):
+    return (-1)**(n + 1) * _jn(-n - 1, z)
 
 
 class jn(SphericalBesselBase):
@@ -655,9 +655,7 @@ class jn(SphericalBesselBase):
         return (-1)**nu * sqrt(pi/(2*z)) * bessely(-nu - S.Half, z)
 
     def _expand(self, **hints):
-        nu = self.order
-        z = self.argument
-        return _jn_orthopoly(nu, z)
+        return _jn(self.order, self.argument)
 
 
 class yn(SphericalBesselBase):
@@ -709,9 +707,7 @@ class yn(SphericalBesselBase):
         return sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
 
     def _expand(self, **hints):
-        nu = self.order
-        z = self.argument
-        return _yn_orthopoly(nu, z)
+        return _yn(self.order, self.argument)
 
 
 class SphericalHankelBase(SphericalBesselBase):
@@ -740,15 +736,16 @@ class SphericalHankelBase(SphericalBesselBase):
         z = self.argument
         hk = self._hankel_kind_sign
 
-        # fully expanded version (valid for hn1)
-        # return (-1)**(n + 1) * \
-        #        (fn(-n - 1, z) * I * sin(z) +
-        #         (-1)**(-n) * fn(n, z) * I * cos(z)) + \
-        #        (fn(n, z) * sin(z) +
-        #         (-1)**(n + 1) * fn(-n - 1, z) * cos(z))
+        # fully expanded version
+        # return ((fn(n, z) * sin(z) +
+        #          (-1)**(n + 1) * fn(-n - 1, z) * cos(z)) +  # jn
+        #         (hk * I * (-1)**(n + 1) *
+        #          (fn(-n - 1, z) * hk * I * sin(z) +
+        #           (-1)**(-n) * fn(n, z) * I * cos(z)))  # +-I*yn
+        #         )
 
         # call expand ?
-        return (_jn_orthopoly(n, z) + hk*I*_yn_orthopoly(n, z)).expand()
+        return (_jn(n, z) + hk*I*_yn(n, z)).expand()
 
 
 class hn1(SphericalHankelBase):

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -598,7 +598,8 @@ def _jn(n, z):
 
 
 def _yn(n, z):
-    return (-1)**(n + 1) * _jn(-n - 1, z)
+    # (-1)**(n + 1) * _jn(-n - 1, z)
+    return (-1)**(n + 1) * fn(-n - 1, z)*sin(z) - fn(n, z)*cos(z)
 
 
 class jn(SphericalBesselBase):

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -1,7 +1,7 @@
 from sympy import (jn, yn, symbols, Symbol, sin, cos, pi, S, jn_zeros, besselj,
-                   bessely, besseli, besselk, hankel1, hankel2, expand_func,
-                   sqrt, sinh, cosh, diff, series, gamma, hyper, Abs, I, O, oo,
-                   conjugate)
+                   bessely, besseli, besselk, hankel1, hankel2, hn1, hn2,
+                   expand_func, sqrt, sinh, cosh, diff, series, gamma, hyper,
+                   Abs, I, O, oo, conjugate)
 from sympy.functions.special.bessel import fn
 from sympy.functions.special.bessel import (airyai, airybi,
                                             airyaiprime, airybiprime)
@@ -61,6 +61,25 @@ def test_rewrite():
     assert tn(besselk(nu, z), besselk(nu, z).rewrite(besseli), z)
     assert tn(besselk(nu, z), besselk(nu, z).rewrite(bessely), z)
 
+    for f in (jn, yn):
+        # check that the following functions can't be rewritten to 'f'
+        # when nu is non-integral
+        assert yn(nu, z) == yn(nu, z).rewrite(f)
+        assert jn(nu, z) == jn(nu, z).rewrite(f)
+        assert hn1(nu, z) == hn1(nu, z).rewrite(f)
+        assert hn2(nu, z) == hn2(nu, z).rewrite(f)
+
+    N = Symbol('n', integer=True)
+    assert yn(N, z) != yn(N, z).rewrite(jn)
+    assert jn(N, z) != jn(N, z).rewrite(yn)
+    assert hn1(N, z) != hn1(N, z).rewrite(yn)
+    assert hn2(N, z) != hn2(N, z).rewrite(yn)
+
+    for func, refunc in ((yn, jn), (jn, yn),
+                         (hn1, jn), (hn1, yn),
+                         (hn2, jn), (hn2, yn)):
+        assert tn(func(4, z), func(4, z).rewrite(refunc), z)
+        assert tn(func(-4, z), func(-4, z).rewrite(refunc), z)
 
 def test_expand():
     from sympy import besselsimp, Symbol, exp, exp_polar, I

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1053,6 +1053,12 @@ class LatexPrinter(Printer):
     def _print_hankel2(self, expr, exp=None):
         return self._hprint_BesselBase(expr, exp, 'H^{(2)}')
 
+    def _print_hn1(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'h^{(1)}')
+
+    def _print_hn2(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'h^{(2)}')
+
     def _hprint_airy(self, expr, exp=None, notation=""):
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -127,6 +127,7 @@ def test_latex_builtins():
     assert latex(true) == r"\mathrm{True}"
     assert latex(false) == r'\mathrm{False}'
 
+
 def test_latex_Float():
     assert latex(Float(1.0e100)) == r"1.0 \cdot 10^{100}"
     assert latex(Float(1.0e-100)) == r"1.0 \cdot 10^{-100}"
@@ -352,6 +353,7 @@ def test_latex_functions():
     # even when it is referred to without an argument
     assert latex(fjlkd) == r'\operatorname{fjlkd}'
 
+
 def test_hyper_printing():
     from sympy import pi
     from sympy.abc import x, z
@@ -371,7 +373,7 @@ def test_hyper_printing():
 
 def test_latex_bessel():
     from sympy.functions.special.bessel import (besselj, bessely, besseli,
-            besselk, hankel1, hankel2, jn, yn)
+            besselk, hankel1, hankel2, jn, yn, hn1, hn2)
     from sympy.abc import z
     assert latex(besselj(n, z**2)**k) == r'J^{k}_{n}\left(z^{2}\right)'
     assert latex(bessely(n, z)) == r'Y_{n}\left(z\right)'
@@ -382,6 +384,8 @@ def test_latex_bessel():
     assert latex(hankel2(n, z)) == r'H^{(2)}_{n}\left(z\right)'
     assert latex(jn(n, z)) == r'j_{n}\left(z\right)'
     assert latex(yn(n, z)) == r'y_{n}\left(z\right)'
+    assert latex(hn1(n, z)) == r'h^{(1)}_{n}\left(z\right)'
+    assert latex(hn2(n, z)) == r'h^{(2)}_{n}\left(z\right)'
 
 
 def test_latex_fresnel():


### PR DESCRIPTION
This PR adds spherical hankel functions to `sympy/functions/special/bessel.py`. 

TODO
- [x] more rewrite methods in `hn1` and `hn2`
  - [x] hankel1
  - [x] hankel2
  - [x] yn
  - [x] jn
- [x] docstrings
- [x] printing tests
