### PR TITLE
Tuple constructor should not take the argument **assumptions

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -32,9 +32,9 @@ class Tuple(Basic):
 
     """
 
-    def __new__(cls, *args, **assumptions):
+    def __new__(cls, *args):
         args = [ sympify(arg) for arg in args ]
-        obj = Basic.__new__(cls, *args, **assumptions)
+        obj = Basic.__new__(cls, *args)
         return obj
 
     def __getitem__(self, i):


### PR DESCRIPTION
Because `Basic.__new__()` does not take the argument `**assumptions`,
Tuple constructor should not take the argument `**assumptions`.
