### PR TITLE
Docstring Python escaping backslash in latex strings sdded

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1907,6 +1907,12 @@ def latex(expr, **settings):
     >>> print(latex((2*tau)**Rational(7,2)))
     8 \sqrt{2} \tau^{\frac{7}{2}}
 
+    Not using a print statement for printing, results in double backslashes for
+    latex commands since that's the way Python escapes backslashes in strings.
+
+    >>> latex((2*tau)**Rational(7,2))
+    '8 \\sqrt{2} \\tau^{\\frac{7}{2}}'
+
     order: Any of the supported monomial orderings (currently "lex", "grlex", or
     "grevlex"), "old", and "none". This parameter does nothing for Mul objects.
     Setting order to "old" uses the compatibility ordering for Add defined in


### PR DESCRIPTION
To see why i am doing this, see my [question here](https://gitter.im/sympy/sympy?at=560a1c54519547fc1e3aef0b), and [this response](https://gitter.im/sympy/sympy?at=560abc04ff22c70f6fab2e7d)
