### PR TITLE
fix(9339) added expr.doit to avoid numpy error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ sample.tex
 # IPython Notebook Checkpoints
 .ipynb_checkpoints/
 
+# Intellij Idea
+.idea/

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -297,6 +297,20 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     from sympy.core.symbol import Symbol
     from sympy.utilities.iterables import flatten
 
+    
+    print('+++++++++++++++')
+    print(type(expr))
+    print('---------------')
+    blacklist = [tuple, list, int, str, dict]
+    blacklisted = False
+    for x in blacklist:
+        if issubclass(type(expr), x):
+            blacklisted = True
+            break
+
+    if not blacklisted:
+        expr = expr.doit()
+
     # If the user hasn't specified any modules, use what is available.
     module_provided = True
     if modules is None:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -295,20 +295,11 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     in other namespaces, unless the ``use_imps`` input parameter is False.
     """
     from sympy.core.symbol import Symbol
+    from sympy.core.basic import Basic
+    from sympy.concrete.expr_with_limits import ExprWithLimits
     from sympy.utilities.iterables import flatten
 
-    
-    print('+++++++++++++++')
-    print(type(expr))
-    print('---------------')
-    blacklist = [tuple, list, int, str, dict]
-    blacklisted = False
-    for x in blacklist:
-        if issubclass(type(expr), x):
-            blacklisted = True
-            break
-
-    if not blacklisted:
+    if issubclass(type(expr), Basic) and not issubclass(type(expr), ExprWithLimits):
         expr = expr.doit()
 
     # If the user hasn't specified any modules, use what is available.

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -580,6 +580,5 @@ def test_issue_2790():
 
 def test_issue_9339():
     f = lambdify(x, Derivative(sin(x)))
-    #assert f == cos(x)
     assert f(1) > 0.5403
     assert f(1) < 0.5404

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2,7 +2,7 @@ from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
     Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
-    true, false, And, Or, Not)
+    true, false, And, Or, Not, Derivative)
 from sympy.printing.lambdarepr import LambdaPrinter
 import mpmath
 from sympy.utilities.lambdify import implemented_function
@@ -577,3 +577,9 @@ def test_issue_2790():
     assert lambdify((x, (y, z)), x + y)(1, (2, 4)) == 3
     assert lambdify((x, (y, (w, z))), w + x + y + z)(1, (2, (3, 4))) == 10
     assert lambdify(x, x + 1, dummify=False)(1) == 2
+
+def test_issue_9339():
+    f = lambdify(x, Derivative(sin(x)))
+    #assert f == cos(x)
+    assert f(1) > 0.5403
+    assert f(1) < 0.5404


### PR DESCRIPTION
@shivamvats @hargup adding expr.doit() was resulting in failures of other tests. Its kind of hacky the way I have handled it. Have a look and suggest if other possibilities exist for handling errors when expr is actually an int, list, tuple etc.
