### PR TITLE
fix(9339) added expr.doit with type checking for numpy error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ sample.tex
 # IPython Notebook Checkpoints
 .ipynb_checkpoints/
 
+# Intellij Idea
+.idea/

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -295,7 +295,12 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     in other namespaces, unless the ``use_imps`` input parameter is False.
     """
     from sympy.core.symbol import Symbol
+    from sympy.core.basic import Basic
+    from sympy.concrete.expr_with_limits import ExprWithLimits
     from sympy.utilities.iterables import flatten
+
+    if issubclass(type(expr), Basic) and not issubclass(type(expr), ExprWithLimits):
+        expr = expr.doit()
 
     # If the user hasn't specified any modules, use what is available.
     module_provided = True

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2,7 +2,7 @@ from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
     Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
-    true, false, And, Or, Not, ITE)
+    true, false, And, Or, Not, ITE, Derivative)
 from sympy.printing.lambdarepr import LambdaPrinter
 import mpmath
 from sympy.utilities.lambdify import implemented_function
@@ -581,3 +581,8 @@ def test_issue_2790():
 def test_ITE():
     assert lambdify((x, y, z), ITE(x, y, z))(True, 5, 3) == 5
     assert lambdify((x, y, z), ITE(x, y, z))(False, 5, 3) == 3
+
+def test_issue_9339():
+    f = lambdify(x, Derivative(sin(x)))
+    assert f(1) > 0.5403
+    assert f(1) < 0.5404


### PR DESCRIPTION
doit() is called when type(expr) is a subclass of Basic and not of ExprWithLimits
