### PR TITLE
solve_univariate_inequality(x**2>=0, x) returns (-oo, oo)

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -401,7 +401,7 @@ def solve_univariate_inequality(expr, gen, relational=True):
     # This keeps the function independent of the assumptions about `gen`.
     # `solveset` makes sure this function is called only when the domain is
     # real.
-    d = Dummy(real=True)
+    d = Dummy()
     expr = expr.subs(gen, d)
     _gen = gen
     gen = d

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -303,3 +303,10 @@ def test_issue_8545():
 def test_issue_8974():
     assert isolve(-oo < x, x) == And(-oo < x, x < oo)
     assert isolve(oo > x, x) == And(-oo < x, x < oo)
+
+
+@XFAIL
+def test_issue_9954():
+    # this will pass after issue #9958 is fixed
+    # currently this returns Or(And(-oo < x, x < oo), Eq(x, 0))
+    assert solve_univariate_inequality(x**2 >= 0, x) == And(-oo < x, x < oo)


### PR DESCRIPTION
fixed #9954 

Since `d` with assumption of being `real`, converts `d**2 >= 0` to `True`, which is not an `inequality`.
