### PR TITLE
Set IPython printing defaults

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -9,7 +9,7 @@ from io import BytesIO
 from sympy import latex as default_latex
 from sympy import preview
 from sympy.core.compatibility import integer_types
-from sympy.utilities.misc import debug
+from sympy.utilities.misc import debug, find_executable
 
 
 def _init_python_printing(stringify_func):
@@ -394,8 +394,18 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                     debug("init_printing: Setting use_unicode to True")
                     use_unicode = True
                 if use_latex is None:
-                    debug("init_printing: Setting use_latex to True")
-                    use_latex = True
+                    if find_executable('latex') and find_executable('dvipng'):
+                        debug("init_printing: Setting use_latex to True")
+                        use_latex = True
+                    else:
+                        try:
+                            import matplotlib
+                        except ImportError:
+                            debug("init_printing: Setting use_latex to False")
+                            use_latex = False
+                        else:
+                            debug("init_printing: Setting use_latex to 'matplotlib'")
+                            use_latex = 'matplotlib'
 
     if not no_global:
         Printer.set_global_settings(order=order, use_unicode=use_unicode,


### PR DESCRIPTION
Implements IPython printing default settings as suggested in [this comment](https://github.com/sympy/sympy/issues/9962#issuecomment-145869863).

More details in the commit message.
