### PR TITLE
Resolved issue #9980

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -626,6 +626,7 @@ class ComplexRegion(Set):
     is_ComplexRegion = True
 
     def __new__(cls, sets, polar=False):
+        global obj
         from sympy import symbols, Dummy
 
         x, y, r, theta = symbols('x, y, r, theta', cls=Dummy)


### PR DESCRIPTION
Local variable 'obj' at fancysets.py was be referenced before assignment. Resolved the issue by adding global statement. Tested locally, this seemed to resolve the issue and now the statement mentioned in the issue works, the UnboundLocalError is gone.

```
In [1]: from sympy import *
In [2]: c1 = ComplexRegion(Interval(1, 2)*Interval(2, 3))
In [3]: c2 = ComplexRegion(Interval(1, 5)*Interval(1, 3))
In [4]: simplify(Union(c1, c2))
Out[4]: ComplexRegion(Lambda((_x, _y), _x + _y*I), [1, 2] x [2, 3] U [1, 5] x [1, 3])
```
