### PR TITLE
Extended support for matrix power to non-diagonalizable matrices

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -540,6 +540,7 @@ class MatrixBase(object):
                 n //= 2
             return self._new(a)
         elif isinstance(num, (Expr, float)):
+
             def jordan_cell_power(jc, n):
                 N = jc.shape[0]
                 l = jc[0, 0]
@@ -549,6 +550,7 @@ class MatrixBase(object):
                                 if isinstance(bn, binomial):
                                         bn = bn._eval_expand_func()
                                 jc[j, i+j] = l**(n-i)*bn
+
             P, jordan_cells = self.jordan_cells()
             # Make sure jordan_cells matrices are mutable:
             jordan_cells = [MutableMatrix(j) for j in jordan_cells]
@@ -557,7 +559,7 @@ class MatrixBase(object):
             return self._new(P*diag(*jordan_cells)*P.inv())
         else:
             raise TypeError(
-                "Only SymPy expressions or int objects are supported")
+                "Only SymPy expressions or int objects are supported as exponent for matrices")
 
     def __add__(self, other):
         """Return self + other, raising ShapeError if shapes don't match."""

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -539,7 +539,7 @@ class MatrixBase(object):
                 s *= s
                 n //= 2
             return self._new(a)
-        elif isinstance(num, (Basic, float)):
+        elif isinstance(num, (Expr, float)):
             def jordan_cell_power(jc, n):
                 N = jc.shape[0]
                 l = jc[0, 0]

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -519,7 +519,8 @@ class MatrixBase(object):
         return self._new(self.rows, self.cols, [a*i for i in self._mat])
 
     def __pow__(self, num):
-        from sympy.matrices import eye
+        from sympy.matrices import eye, diag, MutableMatrix
+        from sympy import binomial
 
         if not self.is_square:
             raise NonSquareMatrixError()
@@ -538,18 +539,25 @@ class MatrixBase(object):
                 s *= s
                 n //= 2
             return self._new(a)
-        elif isinstance(num, Rational):
-            try:
-                P, D = self.diagonalize()
-            except MatrixError:
-                raise NotImplementedError(
-                    "Implemented only for diagonalizable matrices")
-            for i in range(D.rows):
-                D[i, i] = D[i, i]**num
-            return self._new(P*D*P.inv())
+        elif isinstance(num, (Basic, float)):
+            def jordan_cell_power(jc, n):
+                N = jc.shape[0]
+                l = jc[0, 0]
+                for i in range(N):
+                        for j in range(N-i):
+                                bn = binomial(n, i)
+                                if isinstance(bn, binomial):
+                                        bn = bn._eval_expand_func()
+                                jc[j, i+j] = l**(n-i)*bn
+            P, jordan_cells = self.jordan_cells()
+            # Make sure jordan_cells matrices are mutable:
+            jordan_cells = [MutableMatrix(j) for j in jordan_cells]
+            for j in jordan_cells:
+                jordan_cell_power(j, num)
+            return self._new(P*diag(*jordan_cells)*P.inv())
         else:
-            raise NotImplementedError(
-                "Only integer and rational values are supported")
+            raise TypeError(
+                "Only SymPy or int objects are supported")
 
     def __add__(self, other):
         """Return self + other, raising ShapeError if shapes don't match."""

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -557,7 +557,7 @@ class MatrixBase(object):
             return self._new(P*diag(*jordan_cells)*P.inv())
         else:
             raise TypeError(
-                "Only SymPy or int objects are supported")
+                "Only SymPy expressions or int objects are supported")
 
     def __add__(self, other):
         """Return self + other, raising ShapeError if shapes don't match."""

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -175,6 +175,12 @@ def test_power():
     A = Matrix([[0, 4], [-1, 5]])
     assert (A**(S(1)/2))**2 == A
 
+    assert Matrix([[1, 0], [1, 1]])**(S(1)/2) == Matrix([[1, 0], [S.Half, 1]])
+    assert Matrix([[1, 0], [1, 1]])**0.5 == Matrix([[1.0, 0], [0.5, 1.0]])
+    from sympy.abc import a, n
+    assert Matrix([[1, a], [0, 1]])**n == Matrix([[1, a*n], [0, 1]])
+    assert Matrix([[b, a], [0, b]])**n == Matrix([[b**n, a*b**(n-1)*n], [0, b**n]])
+
 
 def test_creation():
     raises(ValueError, lambda: Matrix(5, 5, range(20)))
@@ -1696,9 +1702,6 @@ def test_errors():
     raises(ValueError,
         lambda: Matrix([[5, 10, 7], [0, -1, 2], [8, 3, 4]]
         ).LUdecomposition_Simple(iszerofunc=lambda x: abs(x) <= 4))
-    raises(NotImplementedError, lambda: Matrix([[1, 0], [1, 1]])**(S(1)/2))
-    raises(NotImplementedError,
-        lambda: Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])**(0.5))
     raises(IndexError, lambda: eye(3)[5, 2])
     raises(IndexError, lambda: eye(3)[2, 5])
     M = Matrix(((1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12), (13, 14, 15, 16)))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -177,9 +177,17 @@ def test_power():
 
     assert Matrix([[1, 0], [1, 1]])**(S(1)/2) == Matrix([[1, 0], [S.Half, 1]])
     assert Matrix([[1, 0], [1, 1]])**0.5 == Matrix([[1.0, 0], [0.5, 1.0]])
-    from sympy.abc import a, n
+    from sympy.abc import a, b, n
     assert Matrix([[1, a], [0, 1]])**n == Matrix([[1, a*n], [0, 1]])
     assert Matrix([[b, a], [0, b]])**n == Matrix([[b**n, a*b**(n-1)*n], [0, b**n]])
+    assert Matrix([[a, 1, 0], [0, a, 1], [0, 0, a]])**n == Matrix([
+        [a**n, a**(n-1)*n, a**(n-2)*(n-1)*n/2],
+        [0, a**n, a**(n-1)*n],
+        [0, 0, a**n]])
+    assert Matrix([[a, 1, 0], [0, a, 0], [0, 0, b]])**n == Matrix([
+        [a**n, a**(n-1)*n, 0],
+        [0, a**n, 0],
+        [0, 0, b**n]])
 
 
 def test_creation():


### PR DESCRIPTION
Use the Jordan form instead of the diagonalizable form to perform power of matrix (except for integer power, which is a trivial case).

This also enables symbolic exponents, through the usage of some combinatorics.

The Jordan form always exists, while the diagonalized form may not exist.
