### PR TITLE
Revert "Set IPython printing defaults"

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -9,7 +9,7 @@ from io import BytesIO
 from sympy import latex as default_latex
 from sympy import preview
 from sympy.core.compatibility import integer_types
-from sympy.utilities.misc import debug, find_executable
+from sympy.utilities.misc import debug
 
 
 def _init_python_printing(stringify_func):
@@ -394,18 +394,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                     debug("init_printing: Setting use_unicode to True")
                     use_unicode = True
                 if use_latex is None:
-                    if find_executable('latex') and find_executable('dvipng'):
-                        debug("init_printing: Setting use_latex to True")
-                        use_latex = True
-                    else:
-                        try:
-                            import matplotlib
-                        except ImportError:
-                            debug("init_printing: Setting use_latex to False")
-                            use_latex = False
-                        else:
-                            debug("init_printing: Setting use_latex to 'matplotlib'")
-                            use_latex = 'matplotlib'
+                    debug("init_printing: Setting use_latex to True")
+                    use_latex = True
 
     if not no_global:
         Printer.set_global_settings(order=order, use_unicode=use_unicode,


### PR DESCRIPTION
Reverts sympy/sympy#9976

See the discussion on the pull request. The pull request worked around a printing issue in the IPython qtconsole, but as a consequence, disabled MathJax printing in the notebook by default. Since more people use the notebook than the qtconsole, this is preferred. 

The qtconsole issue only occurs if latex is not installed, matplotlib is installed, and you try printing something that matplotlib does not support, like a Matrix (after `init_printing()` of course). A workaround would be to install latex, in which case it will be used instead of matplotlib, or to use `init_printing(use_latex='matplotlib')`, which will bypass enabling the LaTeX printer and cause the qtconsole to correctly fallback to Unicode pretty printing for matrices. 
