### PR TITLE
Mutable N-dim arrays

### DIFF
--- a/sympy/tensor/array/__init__.py
+++ b/sympy/tensor/array/__init__.py
@@ -1,0 +1,2 @@
+from .dense_ndim_array import MutableDenseNDimArray
+from .sparse_ndim_array import MutableSparseNDimArray

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -50,7 +50,7 @@ class DenseNDimArray(NDimArray):
 
         """
         if self.rank() != 2:
-            raise ValueError('Dimensions must be of size of 2')
+            raise ValueError('Only rank 2 arrays can be converted to matrices')
 
         return Matrix(self.shape[0], self.shape[1], self._array)
 

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -1,0 +1,123 @@
+from __future__ import print_function, division
+import functools
+from sympy import sympify, Matrix, flatten
+from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
+from sympy.tensor.array.ndim_array import NDimArray
+
+
+class DenseNDimArray(NDimArray):
+
+    def __getitem__(self, index):
+        """
+        Allows to get items from N-dim array.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray(2, 2, [0, 1, 2, 3])
+        >>> a
+        [[0, 1], [2, 3]]
+        >>> a[0, 0]
+        0
+        >>> a[1, 1]
+        3
+
+        """
+        index = self._parse_index(index)
+        return self._array[index]
+
+    @classmethod
+    def zeros(cls, *shape):
+        list_length = functools.reduce(lambda x, y: x*y, shape)
+        return cls._new(*(shape + ([0]*list_length,)))
+
+    def tomatrix(self):
+        """
+        Converts MutableDenseNDimArray to Matrix. Can convert only 2-dim array, else will raise error.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray(3, 3, [1 for i in range(9)])
+        >>> b = a.tomatrix()
+        >>> b
+        Matrix([
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1]])
+
+        """
+        if self.rank() != 2:
+            raise ValueError('Dimensions must be of size of 2')
+
+        return Matrix(self.shape[0], self.shape[1], self._array)
+
+    def __iter__(self):
+        return self._array.__iter__()
+
+    def reshape(self, *newshape):
+        """
+        Returns MutableDenseNDimArray instance with new shape. Elements number
+        must be        suitable to new shape. The only argument of method sets
+        new shape.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray(2, 3, [1, 2, 3, 4, 5, 6])
+        >>> a.shape
+        (2, 3)
+        >>> a
+        [[1, 2, 3], [4, 5, 6]]
+        >>> b = a.reshape(3, 2)
+        >>> b.shape
+        (3, 2)
+        >>> b
+        [[1, 2], [3, 4], [5, 6]]
+
+        """
+        new_total_size = functools.reduce(lambda x,y: x*y, newshape)
+        if new_total_size != self._loop_size:
+            raise ValueError("Invalid reshape parameters " + newshape)
+
+        return type(self)(*(newshape + (self._array,)))
+
+
+class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):
+
+    def __new__(cls, *args, **kwargs):
+        return cls._new(*args, **kwargs)
+
+    @classmethod
+    def _new(cls, *args, **kwargs):
+        shape, flat_list = cls._handle_ndarray_creation_inputs(*args, **kwargs)
+        flat_list = flatten(flat_list)
+        self = object.__new__(cls)
+        self._shape = shape
+        self._array = list(flat_list)
+        self._rank = len(shape)
+        self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else 0
+        return self
+
+    def __setitem__(self, index, value):
+        """Allows to set items to MutableDenseNDimArray.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray.zeros(2,2)
+        >>> a[0,0] = 1
+        >>> a[1,1] = 1
+        >>> a
+        [[1, 0], [0, 1]]
+
+        """
+        index = self._parse_index(index)
+        self._setter_iterable_check(value)
+        value = sympify(value)
+
+        self._array[index] = value

--- a/sympy/tensor/array/mutable_ndim_array.py
+++ b/sympy/tensor/array/mutable_ndim_array.py
@@ -1,0 +1,59 @@
+import collections
+
+from sympy import Integer
+from sympy.matrices import Matrix
+from sympy.tensor.array.ndim_array import NDimArray
+
+
+class MutableNDimArray(NDimArray):
+
+    @classmethod
+    def _scan_iterable_shape(cls, iterable):
+        def f(pointer):
+            if not isinstance(pointer, collections.Iterable):
+                return [pointer], ()
+
+            result = []
+            elems, shapes = zip(*[f(i) for i in pointer])
+            if len(set(shapes)) != 1:
+                raise ValueError("could not determine shape unambiguously")
+            for i in elems:
+                result.extend(i)
+            return result, (len(shapes),)+shapes[0]
+
+        return f(iterable)
+
+    @classmethod
+    def _handle_ndarray_creation_inputs(cls, *args, **kwargs):
+
+        # Construct N-dim array from an iterable (numpy arrays included):
+        if len(args) == 1 and isinstance(args[0], collections.Iterable):
+            iterable, shape = cls._scan_iterable_shape(args[0])
+
+        # Construct N-dim array from a Matrix:
+        elif len(args) == 1 and isinstance(args[0], Matrix):
+            shape = args[0].shape
+            iterable = args[0]
+
+        # Construct N-dim array from another N-dim array:
+        elif len(args) == 1 and isinstance(args[0], NDimArray):
+            shape = args[0].shape
+            iterable = args[0]
+
+        # Construct NDimArray(dim1, dim2, dim3, ... , optional_iterable)
+        elif len(args) > 1:
+            shape = []
+            for arg in args:
+                if not isinstance(arg, (int, Integer)):
+                    iterable = arg
+                    break
+                shape.append(arg)
+            assert len(args) == len(shape) + 1
+
+        elif len(args) == 0:
+            shape = ()
+            iterable = ()
+        else:
+            raise TypeError("Data type not understood")
+
+        return tuple(shape), iterable

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -1,0 +1,278 @@
+from __future__ import print_function, division
+import collections
+from sympy import Matrix, Integer, sympify
+
+
+class NDimArray(object):
+    """
+
+    Examples
+    ========
+
+    Create an N-dim array of zeros:
+
+    >>> from sympy.tensor.array import MutableDenseNDimArray
+    >>> a = MutableDenseNDimArray.zeros(2, 3, 4)
+    >>> a
+    [[[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]], [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]]
+
+    Create an N-dim array from a list;
+
+    >>> a = MutableDenseNDimArray([[2, 3], [4, 5]])
+    >>> a
+    [[2, 3], [4, 5]]
+
+    >>> b = MutableDenseNDimArray([[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]])
+    >>> b
+    [[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]
+
+    Create an N-dim array from a flat list with dimension shape:
+
+    >>> a = MutableDenseNDimArray(2, 3, [1, 2, 3, 4, 5, 6])
+    >>> a
+    [[1, 2, 3], [4, 5, 6]]
+
+    Create an N-dim array from a matrix:
+
+    >>> from sympy import Matrix
+    >>> a = Matrix([[1,2],[3,4]])
+    >>> a
+    Matrix([
+    [1, 2],
+    [3, 4]])
+    >>> b = MutableDenseNDimArray(a)
+    >>> b
+    [[1, 2], [3, 4]]
+
+    Arithmetic operations on N-dim arrays
+
+    >>> a = MutableDenseNDimArray(2, 2, [1, 1, 1, 1])
+    >>> b = MutableDenseNDimArray(2, 2, [4, 4, 4, 4])
+    >>> c = a + b
+    >>> c
+    [[5, 5], [5, 5]]
+    >>> a - b
+    [[-3, -3], [-3, -3]]
+
+    """
+    def __new__(cls, *args, **kwargs):
+        from sympy.tensor.array import MutableDenseNDimArray
+        return MutableDenseNDimArray(*args, **kwargs)
+
+    def _parse_index(self, index):
+
+        if isinstance(index, (int, Integer)):
+            if index >= self._loop_size:
+                raise ValueError("index out of range")
+            return index
+
+        if len(index) != self._rank:
+            raise ValueError('Wrong number of array axes')
+
+        real_index = 0
+        # check if input index can exist in current indexing
+        for i in range(self._rank):
+            if index[i] > self.shape[i]:
+                raise ValueError('Index ' + str(index) + ' out of border')
+            real_index = real_index*self.shape[i] + index[i]
+
+        return real_index
+
+    def _get_tuple_index(self, integer_index):
+        index = []
+        for i, sh in enumerate(reversed(self.shape)):
+            index.append(integer_index % sh)
+            integer_index //= sh
+        index.reverse()
+        return tuple(index)
+
+    def _setter_iterable_check(self, value):
+        if isinstance(value, (collections.Iterable, Matrix, NDimArray)):
+            raise NotImplementedError
+
+    def __len__(self):
+        """Overload common function len(). Returns number of elements in array.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray.zeros(3,3)
+        >>> a
+        [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        >>> len(a)
+        9
+
+        """
+        return self._loop_size
+
+    @property
+    def shape(self):
+        """
+        Returns array shape (dimension).
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray.zeros(3,3)
+        >>> a.shape
+        (3, 3)
+
+        """
+        return self._shape
+
+    def rank(self):
+        """
+        Returns rank of array.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray.zeros(3,4,5,6,3)
+        >>> a.rank()
+        5
+
+        """
+        return self._rank
+
+    def __str__(self):
+        """Returns string, allows to use standart functions print() and str().
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray.zeros(2, 2)
+        >>> a
+        [[0, 0], [0, 0]]
+
+        """
+        def f(sh, shape_left, i, j):
+            if len(shape_left) == 1:
+                return "["+", ".join([str(self[e]) for e in range(i, j)])+"]"
+
+            sh //= shape_left[0]
+            return "[" + ", ".join([f(sh, shape_left[1:], i+e*sh, i+(e+1)*sh) for e in range(shape_left[0])]) + "]" # + "\n"*len(shape_left)
+
+        return f(self._loop_size, self.shape, 0, self._loop_size)
+
+        out_str = ''
+
+        # forming output string
+        for i, el in enumerate(self):
+
+            out_str += str(el) + '  '
+            chidx = i+1
+            for sh in reversed(self.shape):
+                if chidx % sh == 0:
+                    out_str += '\n'
+                    chidx //= sh
+
+        return out_str
+
+    def __repr__(self):
+        return self.__str__()
+
+    def tolist(self):
+        """
+        Conveting MutableDenseNDimArray to one-dim list
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray(2, 2, [1, 2, 3, 4])
+        >>> a
+        [[1, 2], [3, 4]]
+        >>> b = a.tolist()
+        >>> b
+        [[1, 2], [3, 4]]
+        """
+
+        def f(sh, shape_left, i, j):
+            if len(shape_left) == 1:
+                return [self[e] for e in range(i, j)]
+            result = []
+            sh //= shape_left[0]
+            for e in range(shape_left[0]):
+                result.append(f(sh, shape_left[1:], i+e*sh, i+(e+1)*sh))
+            return result
+
+        return f(self._loop_size, self.shape, 0, self._loop_size)
+
+    def __add__(self, other):
+        if not isinstance(other, NDimArray):
+            raise TypeError(str(other))
+
+        if self.shape != other.shape:
+            raise ValueError("array shape mismatch")
+        result_list = [i+j for i,j in zip(self, other)]
+
+        return type(self)(*(self.shape + (result_list,)))
+
+    def __sub__(self, other):
+        if not isinstance(other, NDimArray):
+            raise TypeError(str(other))
+
+        if self.shape != other.shape:
+            raise ValueError("array shape mismatch")
+        result_list = [i-j for i,j in zip(self, other)]
+
+        return type(self)(*(self.shape + (result_list,)))
+
+    def __mul__(self, other):
+        if isinstance(other, (collections.Iterable,NDimArray, Matrix)):
+            raise ValueError("scalar expected")
+        other = sympify(other)
+        result_list = [i*other for i in self]
+        return type(self)(*(self.shape + (result_list,)))
+
+    def __rmul__(self, other):
+        if isinstance(other, (collections.Iterable,NDimArray, Matrix)):
+            raise ValueError("scalar expected")
+        other = sympify(other)
+        result_list = [other*i for i in self]
+        return type(self)(*(self.shape + (result_list,)))
+
+    def __div__(self, other):
+        if isinstance(other, (collections.Iterable,NDimArray, Matrix)):
+            raise ValueError("scalar expected")
+        other = sympify(other)
+        result_list = [i/other for i in self]
+        return type(self)(*(self.shape + (result_list,)))
+
+    def __rdiv__(self, other):
+        raise TypeError('unsupported operation on NDimArray')
+
+    def __eq__(self, other):
+        """
+        NDimArray instances can be compared to each other.
+        Instances equal if they have same shape and data.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableDenseNDimArray
+        >>> a = MutableDenseNDimArray.zeros(2, 3)
+        >>> b = MutableDenseNDimArray.zeros(2, 3)
+        >>> a == b
+        True
+        >>> c = a.reshape(3, 2)
+        >>> c == b
+        False
+        >>> a[0,0] = 1
+        >>> b[0,0] = 2
+        >>> a == b
+        False
+        """
+        if not isinstance(other, NDimArray):
+            return False
+        return (self.shape == other.shape) and (list(self) == list(other))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    __truediv__ = __div__
+    __rtruediv__ = __rdiv__

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -1,0 +1,134 @@
+from __future__ import print_function, division
+import functools
+from sympy import sympify, Matrix, S, Dict, flatten, SparseMatrix
+from sympy.tensor.array.mutable_ndim_array import MutableNDimArray
+from sympy.tensor.array.ndim_array import NDimArray
+
+
+class SparseNDimArray(NDimArray):
+
+    def __getitem__(self, index):
+        """
+        Get an element from a sparse N-dim array.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableSparseNDimArray
+        >>> a = MutableSparseNDimArray(2, 2, range(4))
+        >>> a
+        [[0, 1], [2, 3]]
+        >>> a[0, 0]
+        0
+        >>> a[1, 1]
+        3
+        >>> a[0]
+        0
+        >>> a[2]
+        2
+
+        """
+        index = self._parse_index(index)
+
+        if index in self._sparse_array:
+            return self._sparse_array[index]
+        else:
+            return S.Zero
+
+    @classmethod
+    def zeros(cls, *shape):
+        """
+        Return a sparse N-dim array of zeros.
+        """
+        return cls(*(shape + ({},)))
+
+    def tomatrix(self):
+        """
+        Converts MutableDenseNDimArray to Matrix. Can convert only 2-dim array, else will raise error.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableSparseNDimArray
+        >>> a = MutableSparseNDimArray(3, 3, [1 for i in range(9)])
+        >>> b = a.tomatrix()
+        >>> b
+        Matrix([
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1]])
+        """
+        if self.rank() != 2:
+            raise ValueError('Dimensions must be of size of 2')
+
+        mat_sparse = {}
+        for key, value in self._sparse_array.items():
+            mat_sparse[self._get_tuple_index(key)] = value
+
+        return SparseMatrix(self.shape[0], self.shape[1], mat_sparse)
+
+    def __iter__(self):
+        def iterator():
+            for i in range(self._loop_size):
+                yield self[i]
+        return iterator()
+
+    def reshape(self, *newshape):
+        new_total_size = functools.reduce(lambda x,y: x*y, newshape)
+        if new_total_size != self._loop_size:
+            raise ValueError("Invalid reshape parameters " + newshape)
+
+        return type(self)(*(newshape + (self._array,)))
+
+
+
+
+class MutableSparseNDimArray(MutableNDimArray, SparseNDimArray):
+
+    def __new__(cls, *args, **kwargs):
+
+        shape, flat_list = cls._handle_ndarray_creation_inputs(*args, **kwargs)
+        self = object.__new__(cls)
+        self._shape = shape
+        self._rank = len(shape)
+        self._loop_size = functools.reduce(lambda x,y: x*y, shape) if shape else 0
+
+        # Sparse array:
+        if isinstance(flat_list, (dict, Dict)):
+            self._sparse_array = args[-1]
+            return self
+
+        self._sparse_array = {}
+
+        for i, el in enumerate(flatten(flat_list)):
+            if el != 0:
+                self._sparse_array[i] = sympify(el)
+
+        return self
+
+    def __setitem__(self, index, value):
+        """Allows to set items to MutableDenseNDimArray.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import MutableSparseNDimArray
+        >>> a = MutableSparseNDimArray.zeros(2, 2)
+        >>> a[0, 0] = 1
+        >>> a[1, 1] = 1
+        >>> a
+        [[1, 0], [0, 1]]
+
+
+        """
+        index = self._parse_index(index)
+        if not isinstance(value, MutableNDimArray):
+            value = sympify(value)
+
+        if isinstance(value, NDimArray):
+            return NotImplementedError
+
+        if value == 0 and index in self._sparse_array:
+            self._sparse_array.pop(index)
+        else:
+            self._sparse_array[index] = value

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -1,0 +1,240 @@
+from copy import copy
+
+from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
+from sympy import Symbol, Rational, SparseMatrix
+from sympy.matrices import Matrix
+from sympy.tensor.array.sparse_ndim_array import MutableSparseNDimArray
+
+
+def test_ndim_array_initiation():
+    arr_with_one_element = MutableDenseNDimArray([23])
+    assert len(arr_with_one_element) == 1
+    assert arr_with_one_element[0] == 23
+    assert arr_with_one_element.rank() == 1
+
+    arr_with_symbol_element = MutableDenseNDimArray([Symbol('x')])
+    assert len(arr_with_symbol_element) == 1
+    assert arr_with_symbol_element[0] == Symbol('x')
+    assert arr_with_symbol_element.rank() == 1
+
+    number5 = 5
+    vector = MutableDenseNDimArray.zeros(number5)
+    assert len(vector) == number5
+    assert vector.shape == (number5,)
+    assert vector.rank() == 1
+
+    vector = MutableSparseNDimArray.zeros(number5)
+    assert len(vector) == number5
+    assert vector.shape == (number5,)
+    assert vector._sparse_array == {}
+    assert vector.rank() == 1
+
+    n_dim_array = MutableDenseNDimArray(3, 3, 3, 3, range(3**4))
+    assert len(n_dim_array) == 3 * 3 * 3 * 3
+    assert n_dim_array.shape == (3, 3, 3, 3)
+    assert n_dim_array.rank() == 4
+
+    array_shape = (3, 3, 3, 3)
+    sparse_array = MutableSparseNDimArray.zeros(*array_shape)
+    assert len(sparse_array._sparse_array) == 0
+    assert len(sparse_array) == 3 * 3 * 3 * 3
+    assert n_dim_array.shape == array_shape
+    assert n_dim_array.rank() == 4
+
+    one_dim_array = MutableDenseNDimArray([2, 3, 1])
+    assert len(one_dim_array) == 3
+    assert one_dim_array.shape == (3,)
+    assert one_dim_array.rank() == 1
+    assert one_dim_array.tolist() == [2, 3, 1]
+
+    shape = (3, 3)
+    array_with_many_args = MutableSparseNDimArray.zeros(*shape)
+    assert len(array_with_many_args) == 3 * 3
+    assert array_with_many_args.shape == shape
+    assert array_with_many_args[0, 0] == 0
+    assert array_with_many_args.rank() == 2
+
+
+def test_reshape():
+    array = MutableDenseNDimArray(50, range(50))
+    assert array.shape == (50,)
+    assert array.rank() == 1
+
+    array = array.reshape(5, 5, 2)
+    assert array.shape == (5, 5, 2)
+    assert array.rank() == 3
+    assert len(array) == 50
+
+
+def test_iterator():
+    array = MutableDenseNDimArray(2, 2, range(4))
+    j = 0
+    for i in array:
+        assert i == j
+        j += 1
+
+    array = array.reshape(4)
+    j = 0
+    for i in array:
+        assert i == j
+        j += 1
+
+
+def test_sparse():
+    sparse_array = MutableSparseNDimArray(2, 2, [0, 0, 0, 1])
+    assert len(sparse_array) == 2 * 2
+    # dictionary where all data is, only non-zero entries are actually stored:
+    assert len(sparse_array._sparse_array) == 1
+
+    assert list(sparse_array) == [0, 0, 0, 1]
+
+    for i, j in zip(sparse_array, [0, 0, 0, 1]):
+        assert i == j
+
+    sparse_array[0, 0] = 123
+    assert len(sparse_array._sparse_array) == 2
+    assert sparse_array[0, 0] == 123
+
+    # when element in sparse array become zero it will disappear from
+    # dictionary
+    sparse_array[0, 0] = 0
+    assert len(sparse_array._sparse_array) == 1
+    sparse_array[1, 1] = 0
+    assert len(sparse_array._sparse_array) == 0
+    assert sparse_array[0, 0] == 0
+
+
+def test_calculation():
+
+    a = MutableDenseNDimArray(3, 3, [1]*9)
+    b = MutableDenseNDimArray(3, 3, [9]*9)
+
+    c = a + b
+    for i in c:
+        assert i == 10
+
+    assert c == MutableDenseNDimArray(3, 3, [10]*9)
+    assert c == MutableSparseNDimArray(3, 3, [10]*9)
+
+    c = b - a
+    for i in c:
+        assert i == 8
+
+    assert c == MutableDenseNDimArray(3, 3, [8]*9)
+    assert c == MutableSparseNDimArray(3, 3, [8]*9)
+
+
+def test_ndim_array_converting():
+    dense_array = MutableDenseNDimArray(2, 2, [1, 2, 3, 4])
+    alist = dense_array.tolist()
+
+    alist == [[1, 2], [3, 4]]
+
+    matrix = dense_array.tomatrix()
+    assert (isinstance(matrix, Matrix))
+
+    for i in range(len(dense_array)):
+        assert dense_array[i] == matrix[i]
+    assert matrix.shape == dense_array.shape
+
+    sparse_array = MutableSparseNDimArray(2, 2, [1, 2, 3, 4])
+    alist = sparse_array.tolist()
+
+    assert alist == [[1, 2], [3, 4]]
+
+    matrix = sparse_array.tomatrix()
+    assert(isinstance(matrix, SparseMatrix))
+
+    for i in range(len(sparse_array)):
+        assert sparse_array[i] == matrix[i]
+    assert matrix.shape == sparse_array.shape
+
+
+def test_converting_functions():
+    arr_list = [1, 2, 3, 4]
+    arr_matrix = Matrix(((1, 2), (3, 4)))
+
+    # list
+    arr_ndim_array = MutableDenseNDimArray(2, 2, arr_list)
+    assert (isinstance(arr_ndim_array, MutableDenseNDimArray))
+    assert arr_matrix.tolist() == arr_ndim_array.tolist()
+
+    # Matrix
+    arr_ndim_array = MutableDenseNDimArray(arr_matrix)
+    assert (isinstance(arr_ndim_array, MutableDenseNDimArray))
+    assert arr_matrix.tolist() == arr_ndim_array.tolist()
+    assert arr_matrix.shape == arr_ndim_array.shape
+
+
+def test_equality():
+    first_list = [1, 2, 3, 4]
+    second_list = [1, 2, 3, 4]
+    third_list = [4, 3, 2, 1]
+    assert first_list == second_list
+    assert first_list != third_list
+
+    first_ndim_array = MutableDenseNDimArray(2, 2, first_list)
+    second_ndim_array = MutableDenseNDimArray(2, 2, second_list)
+    third_ndim_array = MutableDenseNDimArray(2, 2, third_list)
+    fourth_ndim_array = MutableDenseNDimArray(2, 2, first_list)
+
+    assert first_ndim_array == second_ndim_array
+    second_ndim_array[0, 0] = 0
+    assert first_ndim_array != second_ndim_array
+    assert first_ndim_array != third_ndim_array
+    assert first_ndim_array == fourth_ndim_array
+
+
+def test_arithmetic():
+    a = MutableDenseNDimArray(3, 3, [3 for i in range(9)])
+    b = MutableDenseNDimArray(3, 3, [7 for i in range(9)])
+
+    c1 = a + b
+    c2 = b + a
+    assert c1 == c2
+
+    d1 = a - b
+    d2 = b - a
+    assert d1 == d2 * (-1)
+
+    e1 = a * 5
+    e2 = 5 * a
+    e3 = copy(a)
+    e3 *= 5
+    assert e1 == e2 == e3
+
+    f1 = a / 5
+    f2 = copy(a)
+    f2 /= 5
+    assert f1 == f2
+    assert f1[0, 0] == f1[0, 1] == f1[0, 2] == f1[1, 0] == f1[1, 1] == \
+    f1[1, 2] == f1[2, 0] == f1[2, 1] == f1[2, 2] == Rational(3, 5)
+
+    assert type(a) == type(b) == type(c1) == type(c2) == type(d1) == type(d2) \
+        == type(e1) == type(e2) == type(e3) == type(f1)
+
+
+def test_higher_dimenions():
+    m3 = MutableDenseNDimArray(2, 3, 4, range(10, 34))
+
+    assert m3.tolist() == [[[10, 11, 12, 13],
+            [14, 15, 16, 17],
+            [18, 19, 20, 21]],
+
+           [[22, 23, 24, 25],
+            [26, 27, 28, 29],
+            [30, 31, 32, 33]]]
+
+    assert m3._get_tuple_index(0) == (0, 0, 0)
+    assert m3._get_tuple_index(1) == (0, 0, 1)
+    assert m3._get_tuple_index(4) == (0, 1, 0)
+    assert m3._get_tuple_index(12) == (1, 0, 0)
+
+    assert str(m3) == '[[[10, 11, 12, 13], [14, 15, 16, 17], [18, 19, 20, 21]], [[22, 23, 24, 25], [26, 27, 28, 29], [30, 31, 32, 33]]]'
+
+    m3_rebuilt = MutableDenseNDimArray([[[10, 11, 12, 13], [14, 15, 16, 17], [18, 19, 20, 21]], [[22, 23, 24, 25], [26, 27, 28, 29], [30, 31, 32, 33]]])
+    assert m3 == m3_rebuilt
+
+    m3_other = MutableDenseNDimArray(2, 3, 4, [[[10, 11, 12, 13], [14, 15, 16, 17], [18, 19, 20, 21]], [[22, 23, 24, 25], [26, 27, 28, 29], [30, 31, 32, 33]]])
+
+    assert m3 == m3_other


### PR DESCRIPTION
Step 1 in porting PR https://github.com/sympy/sympy/pull/9112 into SymPy.

This PR adds various classes, all derived from _NDimArray_. The class structure is meant to resemble that of the matrices (sparse/dense, mutable/immutable), though immutable N-dim arrays are not implemented.

I have rewritten most of the code, as the indexing of dense matrices in https://github.com/sympy/sympy/pull/9112 was quite confusing and cumbersome.
