### PR TITLE
[WIP] Expanded vector module -- spherical coordinate system and laplacian

### DIFF
--- a/doc/src/modules/vector/api/classes.rst
+++ b/doc/src/modules/vector/api/classes.rst
@@ -2,13 +2,13 @@
 Essential Classes in sympy.vector (doctrings)
 =============================================
 
-CoordSysCartesian
-=================
+CoordSystem3D
+=============
 
-.. autoclass:: sympy.vector.coordsysrect.CoordSysCartesian
+.. autoclass:: sympy.vector.coordsysrect.CoordSystem3D
    :members:
 
-   .. automethod:: sympy.vector.coordsysrect.CoordSysCartesian.__init__
+   .. automethod:: sympy.vector.coordsysrect.CoordSystem3D.__init__
 
 
 Vector

--- a/doc/src/modules/vector/basics.rst
+++ b/doc/src/modules/vector/basics.rst
@@ -9,13 +9,13 @@ As of now, :mod:`sympy.vector` only deals with the Cartesian (also called
 rectangular) coordinate systems. A 3D Cartesian coordinate system can
 be initialized in :mod:`sympy.vector` as
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> N = CoordSysCartesian('N')
+  >>> from sympy.vector import CoordSystem3D
+  >>> N = CoordSystem3D('N')
 
 The string parameter to the constructor denotes the name assigned to the
 system, and will primarily be used for printing purposes.
 
-Once a coordinate system (in essence, a ``CoordSysCartesian`` instance)
+Once a coordinate system (in essence, a ``CoordSystem3D`` instance)
 has been defined, we can access the orthonormal unit vectors (i.e. the 
 :math:`\mathbf{\hat{i}}`, :math:`\mathbf{\hat{j}}` and 
 :math:`\mathbf{\hat{k}}` vectors) and coordinate variables/base 
@@ -76,7 +76,7 @@ All the classes shown above - ``BaseVector``, ``VectorMul``,
 
 You should never have to instantiate objects of any of the
 subclasses of ``Vector``. Using the ``BaseVector`` instances assigned to a
-``CoordSysCartesian`` instance and (if needed) ``Vector.zero``
+``CoordSystem3D`` instance and (if needed) ``Vector.zero``
 as building blocks, any sort of vectorial expression can be constructed
 with the basic mathematical operators ``+``, ``-``, ``*``.
 and ``/``.
@@ -164,10 +164,10 @@ point. Points, in general, have been implemented in :mod:`sympy.vector` in the
 form of the ``Point`` class.
 
 To access the origin of system, use the ``origin`` property of the
-``CoordSysCartesian`` class.
+``CoordSystem3D`` class.
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> N = CoordSysCartesian('N')
+  >>> from sympy.vector import CoordSystem3D
+  >>> N = CoordSystem3D('N')
   >>> N.origin
   N.origin
   >>> type(N.origin)
@@ -184,7 +184,7 @@ new ``Point``, and its position vector with respect to the
 
 Like ``Vector``, a user never has to expressly instantiate an object of
 ``Point``. This is because any location in space (albeit relative) can be 
-pointed at by using the ``origin`` of a ``CoordSysCartesian`` as the 
+pointed at by using the ``origin`` of a ``CoordSystem3D`` as the
 reference, and then using ``locate_new`` on it and subsequent 
 ``Point`` instances.
 
@@ -197,7 +197,7 @@ be computed using the ``position_wrt`` method.
   a*N.i + c*N.k
 
 Additionally, it is possible to obtain the :math:`X`, :math:`Y` and :math:`Z`
-coordinates of a ``Point`` with respect to a ``CoordSysCartesian``
+coordinates of a ``Point`` with respect to a ``CoordSystem3D``
 in the form of a tuple. This is done using the ``express_coordinates``
 method.
 
@@ -218,8 +218,8 @@ The outer products of vectors can be computed using the ``outer``
 method of ``Vector``. The ``|`` operator has been overloaded for
 ``outer``.
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> N = CoordSysCartesian('N')
+  >>> from sympy.vector import CoordSystem3D
+  >>> N = CoordSystem3D('N')
   >>> N.i.outer(N.j)
   (N.i|N.j)
   >>> N.i|N.j

--- a/doc/src/modules/vector/coordsys.rst
+++ b/doc/src/modules/vector/coordsys.rst
@@ -10,7 +10,7 @@ Locating new systems
 ====================
 
 We already know that the ``origin`` property of a 
-``CoordSysCartesian`` corresponds to the ``Point`` instance
+``CoordSystem3D`` corresponds to the ``Point`` instance
 denoting its origin reference point.
 
 Consider a coordinate system :math:`N`. Suppose we want to define
@@ -23,8 +23,8 @@ would be :math:`(-3, -4, -5)`.
 
 This can be achieved programatically as follows -
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> N = CoordSysCartesian('N')
+  >>> from sympy.vector import CoordSystem3D
+  >>> N = CoordSystem3D('N')
   >>> M = N.locate_new('M', 3*N.i + 4*N.j + 5*N.k)
   >>> M.position_wrt(N)
   3*N.i + 4*N.j + 5*N.k
@@ -35,7 +35,7 @@ It is worth noting that :math:`M`'s orientation is the same as that of
 :math:`N`. This means that the rotation matrix of :math: `N` with respect 
 to :math:`M`, and also vice versa, is equal to the identity matrix of
 dimensions 3x3.
-The ``locate_new`` method initializes a ``CoordSysCartesian`` that
+The ``locate_new`` method initializes a ``CoordSystem3D`` that
 is only translated in space, not re-oriented, relative to the 'parent'
 system.
 
@@ -43,13 +43,13 @@ Orienting new systems
 =====================
 
 Similar to 'locating' new systems, :mod:`sympy.vector` also allows for
-initialization of new ``CoordSysCartesian`` instances that are oriented
+initialization of new ``CoordSystem3D`` instances that are oriented
 in user-defined ways with respect to existing systems.
 
 Suppose you have a coordinate system :math:`A`.
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> A = CoordSysCartesian('A')
+  >>> from sympy.vector import CoordSystem3D
+  >>> A = CoordSystem3D('A')
 
 You want to initialize a new coordinate system :math:`B`, that is rotated with 
 respect to :math:`A`'s Z-axis by an angle :math:`\theta`.
@@ -66,8 +66,8 @@ The orientation is shown in the diagram below:
 
 There are two ways to achieve this.
 
-Using a method of CoordSysCartesian directly
---------------------------------------------
+Using a method of CoordSystem3D directly
+----------------------------------------
 
 This is the easiest, cleanest, and hence the recommended way of doing
 it.
@@ -77,7 +77,7 @@ it.
 This initialzes :math:`B` with the required orientation information with
 respect to :math:`A`.
 
-``CoordSysCartesian`` provides the following direct orientation methods
+``CoordSystem3D`` provides the following direct orientation methods
 in its API-
 
 1. ``orient_new_axis``
@@ -88,7 +88,7 @@ in its API-
 
 4. ``orient_new_quaternion``
 
-Please look at the ``CoordSysCartesian`` class API given in the docs
+Please look at the ``CoordSystem3D`` class API given in the docs
 of this module, to know their functionality and required arguments 
 in detail.
 
@@ -193,9 +193,9 @@ in different coordinate systems using the ``express`` function.
 
 For purposes of this section, assume the following initializations-
 
-  >>> from sympy.vector import CoordSysCartesian, express
+  >>> from sympy.vector import CoordSystem3D, express
   >>> from sympy.abc import a, b, c
-  >>> N = CoordSysCartesian('N')
+  >>> N = CoordSystem3D('N')
   >>> M = N.orient_new_axis('M', a, N.k)
 
 ``Vector`` instances can be expressed in user defined systems using 

--- a/doc/src/modules/vector/examples.rst
+++ b/doc/src/modules/vector/examples.rst
@@ -23,8 +23,8 @@ and basic operations on ``Vector``.
 
 Define a coordinate system
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> Sys = CoordSysCartesian('Sys')
+  >>> from sympy.vector import CoordSystem3D
+  >>> Sys = CoordSystem3D('Sys')
 
 Define point O to be Sys' origin. We can do this without
 loss of generality
@@ -88,8 +88,8 @@ Solution
 
 Start with a coordinate system
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> C = CoordSysCartesian('C')
+  >>> from sympy.vector import CoordSystem3D
+  >>> C = CoordSystem3D('C')
 
 The scalar field :math:`f` and the measure numbers of the vector field 
 :math:`\vec v` are all functions of the coordinate variables of the 

--- a/doc/src/modules/vector/fields.rst
+++ b/doc/src/modules/vector/fields.rst
@@ -8,7 +8,7 @@ Implementation in sympy.vector
 Scalar and vector fields
 ------------------------
 
-In :mod:`sympy.vector`, every ``CoordSysCartesian`` instance is assigned basis
+In :mod:`sympy.vector`, every ``CoordSystem3D`` instance is assigned basis
 vectors corresponding to the :math:`X`, :math:`Y` and
 :math:`Z` axes. These can be accessed using the properties
 named ``i``, ``j`` and ``k`` respectively. Hence, to define a vector
@@ -16,8 +16,8 @@ named ``i``, ``j`` and ``k`` respectively. Hence, to define a vector
 :math:`3\mathbf{\hat{i}} + 4\mathbf{\hat{j}} + 5\mathbf{\hat{k}}` with
 respect to a given frame :math:`\mathbf{R}`, you would do
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> R = CoordSysCartesian('R')
+  >>> from sympy.vector import CoordSystem3D
+  >>> R = CoordSystem3D('R')
   >>> v = 3*R.i + 4*R.j + 5*R.k
 
 Vector math and basic calculus operations with respect to vectors have
@@ -36,8 +36,8 @@ and ``R.z`` expressions respectively.
 Therefore, to generate the expression for the aforementioned electric
 potential field :math:`2{x}^{2}y`, you would have to do
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> R = CoordSysCartesian('R')
+  >>> from sympy.vector import CoordSystem3D
+  >>> R = CoordSystem3D('R')
   >>> electric_potential = 2*R.x**2*R.y
   >>> electric_potential
   2*R.x**2*R.y
@@ -51,8 +51,8 @@ for any math/calculus functionality. Hence, to differentiate the above
 electric potential with respect to :math:`x` (i.e. ``R.x``), you would
 use the ``diff`` method.
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> R = CoordSysCartesian('R')
+  >>> from sympy.vector import CoordSystem3D
+  >>> R = CoordSystem3D('R')
   >>> electric_potential = 2*R.x**2*R.y
   >>> from sympy import diff
   >>> diff(electric_potential, R.x)
@@ -66,8 +66,8 @@ constant.
 Like scalar fields, vector fields that vary with position can also be 
 constructed using ``BaseScalar`` s in the measure-number expressions.
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> R = CoordSysCartesian('R')
+  >>> from sympy.vector import CoordSystem3D
+  >>> R = CoordSystem3D('R')
   >>> v = R.x**2*R.i + 2*R.x*R.z*R.k
 
 The Del operator
@@ -84,7 +84,7 @@ but a convenient mathematical notation to denote any one of the
 aforementioned field operations.
 
 In :mod:`sympy.vector`, :math:`\mathbf{\nabla}` has been implemented
-as the ``delop`` property of the ``CoordSysCartesian`` class.
+as the ``delop`` property of the ``CoordSystem3D`` class.
 Hence, assuming ``C`` is a coordinate system, the 
 :math:`\mathbf{\nabla}` operator corresponding to the vector
 differentials wrt ``C``'s coordinate variables and basis vectors
@@ -92,8 +92,8 @@ would be accessible as ``C.delop``.
 
 Given below is an example of usage of the ``delop`` object.
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> C = CoordSysCartesian('C')
+  >>> from sympy.vector import CoordSystem3D
+  >>> C = CoordSystem3D('C')
   >>> gradient_field = C.delop(C.x*C.y*C.z)
   >>> gradient_field
   (Derivative(C.x*C.y*C.z, C.x))*C.i + (Derivative(C.x*C.y*C.z, C.y))*C.j + (Derivative(C.x*C.y*C.z, C.z))*C.k
@@ -137,8 +137,8 @@ accomplished in two ways.
 
 One, by using the ``delop`` property
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> C = CoordSysCartesian('C')
+  >>> from sympy.vector import CoordSystem3D
+  >>> C = CoordSystem3D('C')
   >>> C.delop.cross(C.x*C.y*C.z*C.i).doit()
   C.x*C.y*C.j + (-C.x*C.z)*C.k
   >>> (C.delop ^ C.x*C.y*C.z*C.i).doit()
@@ -174,8 +174,8 @@ accomplished in two ways.
 
 One, by using the ``delop`` property
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> C = CoordSysCartesian('C')
+  >>> from sympy.vector import CoordSystem3D
+  >>> C = CoordSystem3D('C')
   >>> C.delop.dot(C.x*C.y*C.z*(C.i + C.j + C.k)).doit()
   C.x*C.y + C.x*C.z + C.y*C.z
   >>> (C.delop & C.x*C.y*C.z*(C.i + C.j + C.k)).doit()
@@ -207,8 +207,8 @@ accomplished in two ways.
 
 One, by using the ``delop`` property
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> C = CoordSysCartesian('C')
+  >>> from sympy.vector import CoordSystem3D
+  >>> C = CoordSystem3D('C')
   >>> C.delop.gradient(C.x*C.y*C.z).doit()
   C.y*C.z*C.i + C.x*C.z*C.j + C.x*C.y*C.k
   >>> C.delop(C.x*C.y*C.z).doit()
@@ -235,10 +235,10 @@ velocity :math:`v`. It is represented mathematically as:
 
 Directional derivatives of vector and scalar fields can be computed in
 :mod:`sympy.vector` using the ``delop`` property of
-``CoordSysCartesian``.
+``CoordSystem3D``.
 
-  >>> from sympy.vector import CoordSysCartesian
-  >>> C = CoordSysCartesian('C')
+  >>> from sympy.vector import CoordSystem3D
+  >>> C = CoordSystem3D('C')
   >>> vel = C.i + C.j + C.k
   >>> scalar_field = C.x*C.y*C.z
   >>> vector_field = C.x*C.y*C.z*C.i
@@ -263,8 +263,8 @@ energy is conserved.
 To check if a vector field is conservative in :mod:`sympy.vector`, the 
 ``is_conservative`` function can be used.
 
-  >>> from sympy.vector import CoordSysCartesian, is_conservative
-  >>> R = CoordSysCartesian('R')
+  >>> from sympy.vector import CoordSystem3D, is_conservative
+  >>> R = CoordSystem3D('R')
   >>> field = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
   >>> is_conservative(field)
   True
@@ -277,8 +277,8 @@ is zero at all points in space.
 To check if a vector field is solenoidal in :mod:`sympy.vector`, the 
 ``is_solenoidal`` function can be used.
 
-  >>> from sympy.vector import CoordSysCartesian, is_solenoidal
-  >>> R = CoordSysCartesian('R')
+  >>> from sympy.vector import CoordSystem3D, is_solenoidal
+  >>> R = CoordSystem3D('R')
   >>> field = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
   >>> is_solenoidal(field)
   True
@@ -298,8 +298,8 @@ scalar potential field corresponding to a given conservative vector field in
 
 Example of usage -
 
-  >>> from sympy.vector import CoordSysCartesian, scalar_potential
-  >>> R = CoordSysCartesian('R')
+  >>> from sympy.vector import CoordSystem3D, scalar_potential
+  >>> R = CoordSystem3D('R')
   >>> conservative_field = 4*R.x*R.y*R.z*R.i + 2*R.x**2*R.z*R.j + 2*R.x**2*R.y*R.k
   >>> scalar_potential(conservative_field, R)
   2*R.x**2*R.y*R.z
@@ -315,9 +315,9 @@ function, since it depends only on the endpoints of the path.
 
 This computation is performed as follows in :mod:`sympy.vector`.
 
-  >>> from sympy.vector import CoordSysCartesian, Point
+  >>> from sympy.vector import CoordSystem3D, Point
   >>> from sympy.vector import scalar_potential_difference
-  >>> R = CoordSysCartesian('R')
+  >>> R = CoordSystem3D('R')
   >>> P = R.origin.locate_new('P', 1*R.i + 2*R.j + 3*R.k)
   >>> vectfield = 4*R.x*R.y*R.i + 2*R.x**2*R.j
   >>> scalar_potential_difference(vectfield, R, R.origin, P)

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3562,7 +3562,7 @@ def test_sympy__printing__codeprinter__Assignment():
     assert _test_args(Assignment(x, y))
 
 
-def test_sympy__vector__coordsysrect__CoordSysCartesian():
+def test_sympy__vector__coordsysrect__CoordSystem3D():
     from sympy.vector.coordsysrect import CoordSystem3D
     assert _test_args(CoordSystem3D('C'))
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3563,8 +3563,8 @@ def test_sympy__printing__codeprinter__Assignment():
 
 
 def test_sympy__vector__coordsysrect__CoordSysCartesian():
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    assert _test_args(CoordSysCartesian('C'))
+    from sympy.vector.coordsysrect import CoordSystem3D
+    assert _test_args(CoordSystem3D('C'))
 
 
 def test_sympy__vector__point__Point():
@@ -3598,15 +3598,15 @@ def test_sympy__vector__basisdependent__BasisDependentZero():
 
 def test_sympy__vector__vector__BaseVector():
     from sympy.vector.vector import BaseVector
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     assert _test_args(BaseVector('Ci', 0, C, ' ', ' '))
 
 
 def test_sympy__vector__vector__VectorAdd():
     from sympy.vector.vector import VectorAdd, VectorMul
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     from sympy.abc import a, b, c, x, y, z
     v1 = a*C.i + b*C.j + c*C.k
     v2 = x*C.i + y*C.j + z*C.k
@@ -3616,8 +3616,8 @@ def test_sympy__vector__vector__VectorAdd():
 
 def test_sympy__vector__vector__VectorMul():
     from sympy.vector.vector import VectorMul
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     from sympy.abc import a
     assert _test_args(VectorMul(a, C.i))
 
@@ -3641,22 +3641,22 @@ def test_sympy__vector__dyadic__Dyadic():
 
 def test_sympy__vector__dyadic__BaseDyadic():
     from sympy.vector.dyadic import BaseDyadic
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     assert _test_args(BaseDyadic(C.i, C.j))
 
 
 def test_sympy__vector__dyadic__DyadicMul():
     from sympy.vector.dyadic import BaseDyadic, DyadicMul
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     assert _test_args(DyadicMul(3, BaseDyadic(C.i, C.j)))
 
 
 def test_sympy__vector__dyadic__DyadicAdd():
     from sympy.vector.dyadic import BaseDyadic, DyadicAdd
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     assert _test_args(2 * DyadicAdd(BaseDyadic(C.i, C.i),
                                     BaseDyadic(C.i, C.j)))
 
@@ -3668,8 +3668,8 @@ def test_sympy__vector__dyadic__DyadicZero():
 
 def test_sympy__vector__deloperator__Del():
     from sympy.vector.deloperator import Del
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     assert _test_args(Del(C))
 
 
@@ -3685,8 +3685,8 @@ def test_sympy__vector__orienters__ThreeAngleOrienter():
 
 def test_sympy__vector__orienters__AxisOrienter():
     from sympy.vector.orienters import AxisOrienter
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     assert _test_args(AxisOrienter(x, C.i))
 
 
@@ -3708,8 +3708,8 @@ def test_sympy__vector__orienters__QuaternionOrienter():
 
 def test_sympy__vector__scalar__BaseScalar():
     from sympy.vector.scalar import BaseScalar
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
+    from sympy.vector.coordsysrect import CoordSystem3D
+    C = CoordSystem3D('C')
     assert _test_args(BaseScalar('Cx', 0, C, ' ', ' '))
 
 def test_sympy__physics__wigner__Wigner3j():

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -4,7 +4,7 @@ from sympy.vector.dyadic import (Dyadic, DyadicAdd, DyadicMul,
                                  BaseDyadic, DyadicZero)
 from sympy.vector.scalar import BaseScalar
 from sympy.vector.deloperator import Del
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.vector.functions import (express, matrix_to_vector,
                                     curl, divergence, gradient,
                                     is_conservative, is_solenoidal,

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -6,7 +6,7 @@ from sympy.vector.scalar import BaseScalar
 from sympy.vector.deloperator import Del
 from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.vector.functions import (express, matrix_to_vector,
-                                    curl, divergence, gradient,
+                                    curl, divergence, gradient, laplacian,
                                     is_conservative, is_solenoidal,
                                     scalar_potential,
                                     scalar_potential_difference)

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -138,8 +138,10 @@ class CoordSystem3D(Basic):
             pretty_scalars = [(name + '_' + x) for x in variable_names]
 
         if differential_class is None:
+            # If not specified, assume it's cartesian, i.e. that
+            # its differential factors are 1.
             from sympy.abc import x, y, z
-            differential_class = Lambda((x, y, z), (x, y, z))
+            differential_class = Lambda((x, y, z), (1, 1, 1))
         elif not isinstance(differential_class, Lambda):
             raise TypeError("expected Lambda expression")
 
@@ -389,7 +391,8 @@ class CoordSystem3D(Basic):
 
         """
 
-        return CoordSystem3D(name, location=position,
+        return CoordSystem3D(name, self._differential_class,
+                             location=position,
                              vector_names=vector_names,
                              variable_names=variable_names,
                              parent=self)
@@ -474,7 +477,8 @@ class CoordSystem3D(Basic):
                 else:
                     final_matrix *= orienter.rotation_matrix()
 
-        return CoordSystem3D(name, rotation_matrix=final_matrix,
+        return CoordSystem3D(name, self._differential_class,
+                             rotation_matrix=final_matrix,
                              vector_names=vector_names,
                              variable_names=variable_names,
                              location=location,
@@ -717,7 +721,7 @@ class CoordSystem3D(Basic):
                                vector_names=vector_names,
                                variable_names=variable_names)
 
-    def __init__(self, name, location=None, rotation_matrix=None,
+    def __init__(self, name, differential_class=None, location=None, rotation_matrix=None,
                  parent=None, vector_names=None, variable_names=None,
                  latex_vects=None, pretty_vects=None, latex_scalars=None,
                  pretty_scalars=None):

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -1,6 +1,8 @@
+import types
+from sympy.simplify import simplify
 from sympy.core.basic import Basic
 from sympy.vector.scalar import BaseScalar
-from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol
+from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol, sympify, symbols, Dummy, sqrt, Derivative, S, Tuple
 from sympy.core.compatibility import string_types, range
 from sympy.core.cache import cacheit
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
@@ -8,12 +10,49 @@ from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
 import sympy.vector
 
 
-class CoordSysCartesian(Basic):
+class DifferentialClass(Basic):
+    """
+    TODO
+    """
+
+    def __new__(cls, grad_coeff, metric_det_sqrt):
+        grad_coeff = Tuple(*grad_coeff)
+        metric_det_sqrt = sympify(metric_det_sqrt)
+        return Basic.__new__(cls, grad_coeff, metric_det_sqrt)
+
+    @property
+    def grad_coeff(self):
+        return self.args[0]
+
+    @property
+    def metric_det_sqrt(self):
+        return self.args[1]
+
+    @staticmethod
+    def build_instance_from_lambda(fun=lambda x, y, z: (x, y, z), variable_names=['x', 'y', 'z']):
+        dv = symbols(variable_names, positive=True)
+        mv = fun(*dv)
+        # get jacobian matrix
+        jacobian = Matrix([[miter.diff(diter) for diter in dv] for miter in mv])
+        inverse_jacobian = simplify(jacobian.inv())
+        metric = simplify(inverse_jacobian * inverse_jacobian.T)
+        scale_factors = [sqrt(metric[i, i]) for i in range(3)]
+        unscaled_grad = metric * Matrix([1, 1, 1])
+
+        # These are the coefficients to the derivation operations for the gradient:
+        scaled_grad_coeff = [unscaled_grad[i] / scale_factors[i] for i in range(3)]
+
+        metric_det_sqrt = simplify(sqrt(metric.det()))
+
+        return DifferentialClass(scaled_grad_coeff, metric_det_sqrt)
+
+
+class CoordSystem3D(Basic):
     """
     Represents a coordinate system in 3-D space.
     """
 
-    def __new__(cls, name, location=None, rotation_matrix=None,
+    def __new__(cls, name, differential_class=None, location=None, rotation_matrix=None,
                 parent=None, vector_names=None, variable_names=None):
         """
         The orientation/location parameters are necessary if this system
@@ -23,7 +62,7 @@ class CoordSysCartesian(Basic):
         ==========
 
         name : str
-            The name of the new CoordSysCartesian instance.
+            The name of the new CoordSystem3D instance.
 
         location : Vector
             The position vector of the new system's origin wrt the parent
@@ -34,7 +73,7 @@ class CoordSysCartesian(Basic):
             to the parent. In other words, the output of
             new_system.rotation_matrix(parent).
 
-        parent : CoordSysCartesian
+        parent : CoordSystem3D
             The coordinate system wrt which the orientation/location
             (or both) is being defined.
 
@@ -44,10 +83,8 @@ class CoordSysCartesian(Basic):
             Used for simple str printing.
 
         """
+        from sympy.vector import Vector, BaseVector, Point
 
-        Vector = sympy.vector.Vector
-        BaseVector = sympy.vector.BaseVector
-        Point = sympy.vector.Point
         if not isinstance(name, string_types):
             raise TypeError("name should be a string")
 
@@ -64,9 +101,9 @@ class CoordSysCartesian(Basic):
         #If location information is not given, adjust the default
         #location as Vector.zero
         if parent is not None:
-            if not isinstance(parent, CoordSysCartesian):
+            if not isinstance(parent, CoordSystem3D):
                 raise TypeError("parent should be a " +
-                                "CoordSysCartesian/None")
+                                "CoordSystem3D/None")
             if location is None:
                 location = Vector.zero
             else:
@@ -85,19 +122,6 @@ class CoordSysCartesian(Basic):
             arg_parent = Symbol('default')
             arg_self = Symbol(name)
 
-        #All systems that are defined as 'roots' are unequal, unless
-        #they have the same name.
-        #Systems defined at same orientation/position wrt the same
-        #'parent' are equal, irrespective of the name.
-        #This is true even if the same orientation is provided via
-        #different methods like Axis/Body/Space/Quaternion.
-        #However, coincident systems may be seen as unequal if
-        #positioned/oriented wrt different parents, even though
-        #they may actually be 'coincident' wrt the root system.
-        obj = super(CoordSysCartesian, cls).__new__(
-            cls, arg_self, parent_orient, origin, arg_parent)
-        obj._name = name
-
         #Initialize the base vectors
         if vector_names is None:
             vector_names = (name + '.i', name + '.j', name + '.k')
@@ -112,13 +136,6 @@ class CoordSysCartesian(Basic):
                            x in vector_names]
             pretty_vects = [(name + '_' + x) for x in vector_names]
 
-        obj._i = BaseVector(vector_names[0], 0, obj,
-                            pretty_vects[0], latex_vects[0])
-        obj._j = BaseVector(vector_names[1], 1, obj,
-                            pretty_vects[1], latex_vects[1])
-        obj._k = BaseVector(vector_names[2], 2, obj,
-                            pretty_vects[2], latex_vects[2])
-
         #Initialize the base scalars
         if variable_names is None:
             variable_names = (name + '.x', name + '.y', name + '.z')
@@ -130,8 +147,41 @@ class CoordSysCartesian(Basic):
             _check_strings('variable_names', vector_names)
             variable_names = list(variable_names)
             latex_scalars = [(r"\mathbf{{%s}_{%s}}" % (x, name)) for
-                           x in variable_names]
+                             x in variable_names]
             pretty_scalars = [(name + '_' + x) for x in variable_names]
+
+        if differential_class is None:
+            differential_class = DifferentialClass.build_instance_from_lambda(
+                lambda x, y, z: (x, y, z),
+                variable_names
+            )
+        elif isinstance(differential_class, types.FunctionType):
+            differential_class = DifferentialClass.build_instance_from_lambda(
+                differential_class,
+                variable_names
+            )
+
+        #All systems that are defined as 'roots' are unequal, unless
+        #they have the same name.
+        #Systems defined at same orientation/position wrt the same
+        #'parent' are equal, irrespective of the name.
+        #This is true even if the same orientation is provided via
+        #different methods like Axis/Body/Space/Quaternion.
+        #However, coincident systems may be seen as unequal if
+        #positioned/oriented wrt different parents, even though
+        #they may actually be 'coincident' wrt the root system.
+
+        obj = super(CoordSystem3D, cls).__new__(
+            cls, differential_class, arg_self, parent_orient, origin, arg_parent)
+        obj._name = name
+        obj._differential_class = differential_class
+
+        obj._i = BaseVector(vector_names[0], 0, obj,
+                            pretty_vects[0], latex_vects[0])
+        obj._j = BaseVector(vector_names[1], 1, obj,
+                            pretty_vects[1], latex_vects[1])
+        obj._k = BaseVector(vector_names[2], 2, obj,
+                            pretty_vects[2], latex_vects[2])
 
         obj._x = BaseScalar(variable_names[0], 0, obj,
                             pretty_scalars[0], latex_scalars[0])
@@ -220,16 +270,16 @@ class CoordSysCartesian(Basic):
         Parameters
         ==========
 
-        other : CoordSysCartesian
+        other : CoordSystem3D
             The system which the DCM is generated to.
 
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import symbols
         >>> q1 = symbols('q1')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
         >>> A = N.orient_new_axis('A', q1, N.i)
         >>> N.rotation_matrix(A)
         Matrix([
@@ -240,9 +290,9 @@ class CoordSysCartesian(Basic):
         """
 
         from sympy.vector.functions import _path
-        if not isinstance(other, CoordSysCartesian):
+        if not isinstance(other, CoordSystem3D):
             raise TypeError(str(other) +
-                            " is not a CoordSysCartesian")
+                            " is not a CoordSystem3D")
         #Handle special cases
         if other == self:
             return eye(3)
@@ -266,12 +316,12 @@ class CoordSysCartesian(Basic):
     def position_wrt(self, other):
         """
         Returns the position vector of the origin of this coordinate
-        system with respect to another Point/CoordSysCartesian.
+        system with respect to another Point/CoordSystem3D.
 
         Parameters
         ==========
 
-        other : Point/CoordSysCartesian
+        other : Point/CoordSystem3D
             If other is a Point, the position of this system's origin
             wrt it is returned. If its an instance of CoordSyRect,
             the position wrt its origin is returned.
@@ -279,8 +329,8 @@ class CoordSysCartesian(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import Point, CoordSysCartesian
-        >>> N = CoordSysCartesian('N')
+        >>> from sympy.vector import Point, CoordSystem3D
+        >>> N = CoordSystem3D('N')
         >>> N1 = N.locate_new('N1', 10 * N.i)
         >>> N.position_wrt(N1)
         (-10)*N.i
@@ -297,15 +347,15 @@ class CoordSysCartesian(Basic):
         Parameters
         ==========
 
-        otherframe : CoordSysCartesian
+        otherframe : CoordSystem3D
             The other system to map the variables to.
 
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import Symbol
-        >>> A = CoordSysCartesian('A')
+        >>> A = CoordSystem3D('A')
         >>> q = Symbol('q')
         >>> B = A.orient_new_axis('B', q, A.k)
         >>> A.scalar_map(B)
@@ -328,14 +378,14 @@ class CoordSysCartesian(Basic):
     def locate_new(self, name, position, vector_names=None,
                    variable_names=None):
         """
-        Returns a CoordSysCartesian with its origin located at the given
+        Returns a CoordSystem3D with its origin located at the given
         position wrt this coordinate system's origin.
 
         Parameters
         ==========
 
         name : str
-            The name of the new CoordSysCartesian instance.
+            The name of the new CoordSystem3D instance.
 
         position : Vector
             The position vector of the new system's origin wrt this
@@ -349,23 +399,23 @@ class CoordSysCartesian(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> A = CoordSysCartesian('A')
+        >>> from sympy.vector import CoordSystem3D
+        >>> A = CoordSystem3D('A')
         >>> B = A.locate_new('B', 10 * A.i)
         >>> B.origin.position_wrt(A.origin)
         10*A.i
 
         """
 
-        return CoordSysCartesian(name, location=position,
-                                 vector_names=vector_names,
-                                 variable_names=variable_names,
-                                 parent=self)
+        return CoordSystem3D(name, location=position,
+                             vector_names=vector_names,
+                             variable_names=variable_names,
+                             parent=self)
 
     def orient_new(self, name, orienters, location=None,
                    vector_names=None, variable_names=None):
         """
-        Creates a new CoordSysCartesian oriented in the user-specified way
+        Creates a new CoordSystem3D oriented in the user-specified way
         with respect to this system.
 
         Please refer to the documentation of the orienter classes
@@ -375,7 +425,7 @@ class CoordSysCartesian(Basic):
         ==========
 
         name : str
-            The name of the new CoordSysCartesian instance.
+            The name of the new CoordSystem3D instance.
 
         orienters : iterable/Orienter
             An Orienter or an iterable of Orienters for orienting the
@@ -398,10 +448,10 @@ class CoordSysCartesian(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import symbols
         >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
 
         Using an AxisOrienter
 
@@ -442,11 +492,11 @@ class CoordSysCartesian(Basic):
                 else:
                     final_matrix *= orienter.rotation_matrix()
 
-        return CoordSysCartesian(name, rotation_matrix=final_matrix,
-                                 vector_names=vector_names,
-                                 variable_names=variable_names,
-                                 location = location,
-                                 parent=self)
+        return CoordSystem3D(name, rotation_matrix=final_matrix,
+                             vector_names=vector_names,
+                             variable_names=variable_names,
+                             location=location,
+                             parent=self)
 
     def orient_new_axis(self, name, angle, axis, location=None,
                         vector_names=None, variable_names=None):
@@ -480,10 +530,10 @@ class CoordSysCartesian(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import symbols
         >>> q1 = symbols('q1')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
         >>> B = N.orient_new_axis('B', q1, N.i + 2 * N.j)
 
         """
@@ -529,10 +579,10 @@ class CoordSysCartesian(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import symbols
         >>> q1, q2, q3 = symbols('q1 q2 q3')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
 
         A 'Body' fixed rotation is described by three angles and
         three body-fixed rotation axes. To orient a coordinate system D
@@ -597,16 +647,16 @@ class CoordSysCartesian(Basic):
         See Also
         ========
 
-        CoordSysCartesian.orient_new_body : method to orient via Euler
+        CoordSystem3D.orient_new_body : method to orient via Euler
             angles
 
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import symbols
         >>> q1, q2, q3 = symbols('q1 q2 q3')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
 
         To orient a coordinate system D with respect to N, each
         sequential rotation is always about N's orthogonal unit vectors.
@@ -633,7 +683,7 @@ class CoordSysCartesian(Basic):
     def orient_new_quaternion(self, name, q0, q1, q2, q3, location=None,
                               vector_names=None, variable_names=None):
         """
-        Quaternion orientation orients the new CoordSysCartesian with
+        Quaternion orientation orients the new CoordSystem3D with
         Quaternions, defined as a finite rotation about lambda, a unit
         vector, by some amount theta.
 
@@ -671,10 +721,10 @@ class CoordSysCartesian(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import symbols
         >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
         >>> B = N.orient_new_quaternion('B', q0, q1, q2, q3)
 
         """
@@ -691,6 +741,7 @@ class CoordSysCartesian(Basic):
                  pretty_scalars=None):
         #Dummy initializer for setting docstring
         pass
+
     __init__.__doc__ = __new__.__doc__
 
 

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -56,7 +56,7 @@ class Del(Basic):
 
         scalar_field = express(scalar_field, self.system,
                                variables=True)
-        grad_coeff = self.system._differential_class.grad_coeff
+        grad_coeff = self.system._differential_class(*self.system.base_scalars())
         vx = grad_coeff[0]*Derivative(scalar_field, self._x)
         vy = grad_coeff[1]*Derivative(scalar_field, self._y)
         vz = grad_coeff[2]*Derivative(scalar_field, self._z)
@@ -97,10 +97,11 @@ class Del(Basic):
 
         """
 
-        metric_det_sqrt = self.system._differential_class.metric_det_sqrt
-        vx = _diff_conditional(metric_det_sqrt*vect.dot(self._i), self._x)/metric_det_sqrt
-        vy = _diff_conditional(metric_det_sqrt*vect.dot(self._j), self._y)/metric_det_sqrt
-        vz = _diff_conditional(metric_det_sqrt*vect.dot(self._k), self._z)/metric_det_sqrt
+        diff_coeff = self.system._differential_class(*self.system.base_scalars())
+        dprod = diff_coeff[0] * diff_coeff[1] * diff_coeff[2]
+        vx = dprod*_diff_conditional(diff_coeff[0]/dprod*vect.dot(self._i), self._x)
+        vy = dprod*_diff_conditional(diff_coeff[1]/dprod*vect.dot(self._j), self._y)
+        vz = dprod*_diff_conditional(diff_coeff[2]/dprod*vect.dot(self._k), self._z)
 
         if doit:
             return (vx + vy + vz).doit()

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -139,15 +139,18 @@ class Del(Basic):
 
         """
 
-        vectx = express(vect.dot(self._i), self.system, variables=True)
-        vecty = express(vect.dot(self._j), self.system, variables=True)
-        vectz = express(vect.dot(self._k), self.system, variables=True)
+        diff_coeff = self.system._differential_class(*self.system.base_scalars())
+        dprod = diff_coeff[0] * diff_coeff[1] * diff_coeff[2]
+        vectx = express(vect.dot(self._i), self.system, variables=True)/diff_coeff[0]
+        vecty = express(vect.dot(self._j), self.system, variables=True)/diff_coeff[1]
+        vectz = express(vect.dot(self._k), self.system, variables=True)/diff_coeff[2]
         outvec = Vector.zero
-        outvec += (Derivative(vectz, self._y) -
+        # assert dprod == 1
+        outvec += dprod/diff_coeff[0]*(Derivative(vectz, self._y) -
                    Derivative(vecty, self._z)) * self._i
-        outvec += (Derivative(vectx, self._z) -
+        outvec += dprod/diff_coeff[1]*(Derivative(vectx, self._z) -
                    Derivative(vectz, self._x)) * self._j
-        outvec += (Derivative(vecty, self._x) -
+        outvec += dprod/diff_coeff[2]*(Derivative(vecty, self._x) -
                    Derivative(vectx, self._y)) * self._k
 
         if doit:

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -2,7 +2,7 @@ from sympy.core import Basic
 from sympy.core.function import Derivative
 from sympy.vector.vector import Vector
 from sympy.vector.functions import express
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.core import S
 
 
@@ -13,8 +13,8 @@ class Del(Basic):
     """
 
     def __new__(cls, system):
-        if not isinstance(system, CoordSysCartesian):
-            raise TypeError("system should be a CoordSysCartesian")
+        if not isinstance(system, CoordSystem3D):
+            raise TypeError("system should be a CoordSystem3D")
         obj = super(Del, cls).__new__(cls, system)
         obj._x, obj._y, obj._z = system.x, system.y, system.z
         obj._i, obj._j, obj._k = system.i, system.j, system.k
@@ -45,8 +45,8 @@ class Del(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> C = CoordSysCartesian('C')
+        >>> from sympy.vector import CoordSystem3D
+        >>> C = CoordSystem3D('C')
         >>> C.delop.gradient(9)
         (Derivative(9, C.x))*C.i + (Derivative(9, C.y))*C.j + (Derivative(9, C.z))*C.k
         >>> C.delop(C.x*C.y*C.z).doit()
@@ -56,9 +56,10 @@ class Del(Basic):
 
         scalar_field = express(scalar_field, self.system,
                                variables=True)
-        vx = Derivative(scalar_field, self._x)
-        vy = Derivative(scalar_field, self._y)
-        vz = Derivative(scalar_field, self._z)
+        grad_coeff = self.system._differential_class.grad_coeff
+        vx = grad_coeff[0]*Derivative(scalar_field, self._x)
+        vy = grad_coeff[1]*Derivative(scalar_field, self._y)
+        vz = grad_coeff[2]*Derivative(scalar_field, self._z)
 
         if doit:
             return (vx*self._i + vy*self._j + vz*self._k).doit()
@@ -86,8 +87,8 @@ class Del(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> C = CoordSysCartesian('C')
+        >>> from sympy.vector import CoordSystem3D
+        >>> C = CoordSystem3D('C')
         >>> C.delop.dot(C.x*C.i)
         Derivative(C.x, C.x)
         >>> v = C.x*C.y*C.z * (C.i + C.j + C.k)
@@ -96,9 +97,10 @@ class Del(Basic):
 
         """
 
-        vx = _diff_conditional(vect.dot(self._i), self._x)
-        vy = _diff_conditional(vect.dot(self._j), self._y)
-        vz = _diff_conditional(vect.dot(self._k), self._z)
+        metric_det_sqrt = self.system._differential_class.metric_det_sqrt
+        vx = _diff_conditional(metric_det_sqrt*vect.dot(self._i), self._x)/metric_det_sqrt
+        vy = _diff_conditional(metric_det_sqrt*vect.dot(self._j), self._y)/metric_det_sqrt
+        vz = _diff_conditional(metric_det_sqrt*vect.dot(self._k), self._z)/metric_det_sqrt
 
         if doit:
             return (vx + vy + vz).doit()
@@ -126,8 +128,8 @@ class Del(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> C = CoordSysCartesian('C')
+        >>> from sympy.vector import CoordSystem3D
+        >>> C = CoordSystem3D('C')
         >>> v = C.x*C.y*C.z * (C.i + C.j + C.k)
         >>> C.delop.cross(v, doit = True)
         (-C.x*C.y + C.x*C.z)*C.i + (C.x*C.y - C.y*C.z)*C.j + (-C.x*C.z + C.y*C.z)*C.k

--- a/sympy/vector/dyadic.py
+++ b/sympy/vector/dyadic.py
@@ -49,8 +49,8 @@ class Dyadic(BasisDependent):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> N = CoordSysCartesian('N')
+        >>> from sympy.vector import CoordSystem3D
+        >>> N = CoordSystem3D('N')
         >>> D1 = N.i.outer(N.j)
         >>> D2 = N.j.outer(N.j)
         >>> D1.dot(D2)
@@ -99,8 +99,8 @@ class Dyadic(BasisDependent):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> N = CoordSysCartesian('N')
+        >>> from sympy.vector import CoordSystem3D
+        >>> N = CoordSystem3D('N')
         >>> d = N.i.outer(N.i)
         >>> d.cross(N.j)
         (N.i|N.k)
@@ -133,19 +133,19 @@ class Dyadic(BasisDependent):
         Parameters
         ==========
 
-        system : CoordSysCartesian
+        system : CoordSystem3D
             The coordinate system that the rows and columns of the matrix
             correspond to. If a second system is provided, this
             only corresponds to the rows of the matrix.
-        second_system : CoordSysCartesian, optional, default=None
+        second_system : CoordSystem3D, optional, default=None
             The coordinate system that the columns of the matrix correspond
             to.
 
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> N = CoordSysCartesian('N')
+        >>> from sympy.vector import CoordSystem3D
+        >>> N = CoordSystem3D('N')
         >>> v = N.i + 2*N.j
         >>> d = v.outer(N.i)
         >>> d.to_matrix(N)

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -230,7 +230,7 @@ def gradient(scalar):
 
     """
     # Check input
-    if isinstance(scalar, Zero):
+    if isinstance(scalar, Zero) or scalar == 0:
         return Vector.zero
 
     if not issubclass(type(scalar), Expr) or scalar.is_Vector:
@@ -270,7 +270,7 @@ def laplacian(field):
 
     """
 
-    if isinstance(field, Zero):
+    if isinstance(field, Zero) or field == 0:
         return Zero()
     elif isinstance(field, VectorZero):
         return Vector.zero

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -215,6 +215,44 @@ def gradient(scalar, coord_sys):
 
     return coord_sys.delop(scalar).doit()
 
+def laplacian(field, coord_sys):
+
+    """
+    Returns the laplacian of a scalar or vector field computed wrt the
+    base scalars of the given coordinate system.
+
+    Parameters
+    ==========
+
+    field : Sympy Expr or Vector
+        The scalar or vector field to calculate the gradient of
+
+    coord_sys : CoordSystem3D
+        The coordinate system to calculate the system of 
+
+    Examples
+    ========
+
+    >>> from sympy.vector import CoordSystem3D, laplacian
+    >>> C = CoordSystem3D('C')
+    >>> vect = C.x * C.y * C.z * (C.i + C.j + C.k)
+    >>> laplacian(vect, C)
+    0
+    >>> scalar = C.x ** 2
+    >>> laplacian(scalar, C)
+    2
+
+    """
+
+    if field.is_Vector:
+        return gradient(divergence(field, coord_sys), coord_sys) - \
+        curl(curl(field, coord_sys), coord_sys)
+    else:
+        try:
+            return divergence(gradient(field, coord_sys), coord_sys)
+        except:
+            "Most likely a TypeError." # Will beef this up.
+
 
 def is_conservative(field):
     """

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -1,4 +1,4 @@
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.vector.dyadic import Dyadic
 from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.scalar import BaseScalar
@@ -21,12 +21,12 @@ def express(expr, system, system2=None, variables=False):
     ==========
 
     expr : Vector/Dyadic/scalar(sympyfiable)
-        The expression to re-express in CoordSysCartesian 'system'
+        The expression to re-express in CoordSystem3D 'system'
 
-    system: CoordSysCartesian
+    system: CoordSystem3D
         The coordinate system the expr is to be expressed in
 
-    system2: CoordSysCartesian
+    system2: CoordSystem3D
         The other coordinate system required for re-expression
         (only for a Dyadic Expr)
 
@@ -37,9 +37,9 @@ def express(expr, system, system2=None, variables=False):
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian
+    >>> from sympy.vector import CoordSystem3D
     >>> from sympy import Symbol, cos, sin
-    >>> N = CoordSysCartesian('N')
+    >>> N = CoordSystem3D('N')
     >>> q = Symbol('q')
     >>> B = N.orient_new_axis('B', q, N.k)
     >>> from sympy.vector import express
@@ -56,8 +56,8 @@ def express(expr, system, system2=None, variables=False):
     if expr == 0 or expr == Vector.zero:
         return expr
 
-    if not isinstance(system, CoordSysCartesian):
-        raise TypeError("system should be a CoordSysCartesian \
+    if not isinstance(system, CoordSystem3D):
+        raise TypeError("system should be a CoordSystem3D \
                         instance")
 
     if isinstance(expr, Vector):
@@ -92,8 +92,8 @@ def express(expr, system, system2=None, variables=False):
     elif isinstance(expr, Dyadic):
         if system2 is None:
             system2 = system
-        if not isinstance(system2, CoordSysCartesian):
-            raise TypeError("system2 should be a CoordSysCartesian \
+        if not isinstance(system2, CoordSystem3D):
+            raise TypeError("system2 should be a CoordSystem3D \
                             instance")
         outdyad = Dyadic.zero
         var = variables
@@ -134,14 +134,14 @@ def curl(vect, coord_sys):
     vect : Vector
         The vector operand
 
-    coord_sys : CoordSysCartesian
+    coord_sys : CoordSystem3D
         The coordinate system to calculate the curl in
 
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian, curl
-    >>> R = CoordSysCartesian('R')
+    >>> from sympy.vector import CoordSystem3D, curl
+    >>> R = CoordSystem3D('R')
     >>> v1 = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
     >>> curl(v1, R)
     0
@@ -165,14 +165,14 @@ def divergence(vect, coord_sys):
     vect : Vector
         The vector operand
 
-    coord_sys : CoordSysCartesian
+    coord_sys : CoordSystem3D
         The cooordinate system to calculate the divergence in
 
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian, divergence
-    >>> R = CoordSysCartesian('R')
+    >>> from sympy.vector import CoordSystem3D, divergence
+    >>> R = CoordSystem3D('R')
     >>> v1 = R.x*R.y*R.z * (R.i+R.j+R.k)
     >>> divergence(v1, R)
     R.x*R.y + R.x*R.z + R.y*R.z
@@ -196,14 +196,14 @@ def gradient(scalar, coord_sys):
     scalar : SymPy Expr
         The scalar field to compute the gradient of
 
-    coord_sys : CoordSysCartesian
+    coord_sys : CoordSystem3D
         The coordinate system to calculate the gradient in
 
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian, gradient
-    >>> R = CoordSysCartesian('R')
+    >>> from sympy.vector import CoordSystem3D, gradient
+    >>> R = CoordSystem3D('R')
     >>> s1 = R.x*R.y*R.z
     >>> gradient(s1, R)
     R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
@@ -229,9 +229,9 @@ def is_conservative(field):
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian
+    >>> from sympy.vector import CoordSystem3D
     >>> from sympy.vector import is_conservative
-    >>> R = CoordSysCartesian('R')
+    >>> R = CoordSystem3D('R')
     >>> is_conservative(R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k)
     True
     >>> is_conservative(R.z*R.j)
@@ -263,9 +263,9 @@ def is_solenoidal(field):
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian
+    >>> from sympy.vector import CoordSystem3D
     >>> from sympy.vector import is_solenoidal
-    >>> R = CoordSysCartesian('R')
+    >>> R = CoordSystem3D('R')
     >>> is_solenoidal(R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k)
     True
     >>> is_solenoidal(R.y * R.j)
@@ -296,15 +296,15 @@ def scalar_potential(field, coord_sys):
         The vector field whose scalar potential function is to be
         calculated
 
-    coord_sys : CoordSysCartesian
+    coord_sys : CoordSystem3D
         The coordinate system to do the calculation in
 
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian
+    >>> from sympy.vector import CoordSystem3D
     >>> from sympy.vector import scalar_potential, gradient
-    >>> R = CoordSysCartesian('R')
+    >>> R = CoordSystem3D('R')
     >>> scalar_potential(R.k, R) == R.z
     True
     >>> scalar_field = 2*R.x**2*R.y*R.z
@@ -321,8 +321,8 @@ def scalar_potential(field, coord_sys):
         return S(0)
     #Express the field exntirely in coord_sys
     #Subsitute coordinate variables also
-    if not isinstance(coord_sys, CoordSysCartesian):
-        raise TypeError("coord_sys must be a CoordSysCartesian")
+    if not isinstance(coord_sys, CoordSystem3D):
+        raise TypeError("coord_sys must be a CoordSystem3D")
     field = express(field, coord_sys, variables=True)
     dimensions = coord_sys.base_vectors()
     scalars = coord_sys.base_scalars()
@@ -355,7 +355,7 @@ def scalar_potential_difference(field, coord_sys, point1, point2):
     field : Vector/Expr
         The field to calculate wrt
 
-    coord_sys : CoordSysCartesian
+    coord_sys : CoordSystem3D
         The coordinate system to do the calculations in
 
     point1 : Point
@@ -367,9 +367,9 @@ def scalar_potential_difference(field, coord_sys, point1, point2):
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian, Point
+    >>> from sympy.vector import CoordSystem3D, Point
     >>> from sympy.vector import scalar_potential_difference
-    >>> R = CoordSysCartesian('R')
+    >>> R = CoordSystem3D('R')
     >>> P = R.origin.locate_new('P', R.x*R.i + R.y*R.j + R.z*R.k)
     >>> vectfield = 4*R.x*R.y*R.i + 2*R.x**2*R.j
     >>> scalar_potential_difference(vectfield, R, R.origin, P)
@@ -380,8 +380,8 @@ def scalar_potential_difference(field, coord_sys, point1, point2):
 
     """
 
-    if not isinstance(coord_sys, CoordSysCartesian):
-        raise TypeError("coord_sys must be a CoordSysCartesian")
+    if not isinstance(coord_sys, CoordSystem3D):
+        raise TypeError("coord_sys must be a CoordSystem3D")
     if isinstance(field, Vector):
         #Get the scalar potential function
         scalar_fn = scalar_potential(field, coord_sys)
@@ -418,7 +418,7 @@ def matrix_to_vector(matrix, system):
     matrix : SymPy Matrix, Dimensions: (3, 1)
         The matrix to be converted to a vector
 
-    system : CoordSysCartesian
+    system : CoordSystem3D
         The coordinate system the vector is to be defined in
 
     Examples
@@ -426,8 +426,8 @@ def matrix_to_vector(matrix, system):
 
     >>> from sympy import ImmutableMatrix as Matrix
     >>> m = Matrix([1, 2, 3])
-    >>> from sympy.vector import CoordSysCartesian, matrix_to_vector
-    >>> C = CoordSysCartesian('C')
+    >>> from sympy.vector import CoordSystem3D, matrix_to_vector
+    >>> C = CoordSystem3D('C')
     >>> v = matrix_to_vector(m, C)
     >>> v
     C.i + 2*C.j + 3*C.k

--- a/sympy/vector/orienters.py
+++ b/sympy/vector/orienters.py
@@ -53,10 +53,10 @@ class AxisOrienter(Orienter):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import symbols
         >>> q1 = symbols('q1')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
         >>> from sympy.vector import AxisOrienter
         >>> orienter = AxisOrienter(q1, N.i + 2 * N.j)
         >>> B = N.orient_new('B', (orienter, ))
@@ -74,7 +74,7 @@ class AxisOrienter(Orienter):
         Parameters
         ==========
 
-        system : CoordSysCartesian
+        system : CoordSystem3D
             The coordinate system wrt which the rotation matrix
             is to be computed
         """
@@ -193,10 +193,10 @@ class BodyOrienter(ThreeAngleOrienter):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian, BodyOrienter
+        >>> from sympy.vector import CoordSystem3D, BodyOrienter
         >>> from sympy import symbols
         >>> q1, q2, q3 = symbols('q1 q2 q3')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
 
         A 'Body' fixed rotation is described by three angles and
         three body-fixed rotation axes. To orient a coordinate system D
@@ -265,10 +265,10 @@ class SpaceOrienter(ThreeAngleOrienter):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian, SpaceOrienter
+        >>> from sympy.vector import CoordSystem3D, SpaceOrienter
         >>> from sympy import symbols
         >>> q1, q2, q3 = symbols('q1 q2 q3')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
 
         To orient a coordinate system D with respect to N, each
         sequential rotation is always about N's orthogonal unit vectors.
@@ -329,7 +329,7 @@ class QuaternionOrienter(Orienter):
 
     def __init__(self, angle1, angle2, angle3, rot_order):
         """
-        Quaternion orientation orients the new CoordSysCartesian with
+        Quaternion orientation orients the new CoordSystem3D with
         Quaternions, defined as a finite rotation about lambda, a unit
         vector, by some amount theta.
 
@@ -354,10 +354,10 @@ class QuaternionOrienter(Orienter):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSystem3D
         >>> from sympy import symbols
         >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
-        >>> N = CoordSysCartesian('N')
+        >>> N = CoordSystem3D('N')
         >>> from sympy.vector import QuaternionOrienter
         >>> q_orienter = QuaternionOrienter(q0, q1, q2, q3)
         >>> B = N.orient_new('B', (q_orienter, ))

--- a/sympy/vector/point.py
+++ b/sympy/vector/point.py
@@ -1,7 +1,7 @@
 from sympy.core.compatibility import range
 from sympy.core.basic import Basic
 from sympy.vector.vector import Vector
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.vector.functions import _path
 from sympy import Symbol
 from sympy.core.cache import cacheit
@@ -47,12 +47,12 @@ class Point(Basic):
     def position_wrt(self, other):
         """
         Returns the position vector of this Point with respect to
-        another Point/CoordSysCartesian.
+        another Point/CoordSystem3D.
 
         Parameters
         ==========
 
-        other : Point/CoordSysCartesian
+        other : Point/CoordSystem3D
             If other is a Point, the position of this Point wrt it is
             returned. If its an instance of CoordSyRect, the position
             wrt its origin is returned.
@@ -60,8 +60,8 @@ class Point(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import Point, CoordSysCartesian
-        >>> N = CoordSysCartesian('N')
+        >>> from sympy.vector import Point, CoordSystem3D
+        >>> N = CoordSystem3D('N')
         >>> p1 = N.origin.locate_new('p1', 10 * N.i)
         >>> N.origin.position_wrt(p1)
         (-10)*N.i
@@ -69,10 +69,10 @@ class Point(Basic):
         """
 
         if (not isinstance(other, Point)
-                and not isinstance(other, CoordSysCartesian)):
+                and not isinstance(other, CoordSystem3D)):
             raise TypeError(str(other) +
-                            "is not a Point or CoordSysCartesian")
-        if isinstance(other, CoordSysCartesian):
+                            "is not a Point or CoordSystem3D")
+        if isinstance(other, CoordSystem3D):
             other = other.origin
         #Handle special cases
         if other == self:
@@ -112,8 +112,8 @@ class Point(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import Point, CoordSysCartesian
-        >>> N = CoordSysCartesian('N')
+        >>> from sympy.vector import Point, CoordSystem3D
+        >>> N = CoordSystem3D('N')
         >>> p1 = N.origin.locate_new('p1', 10 * N.i)
         >>> p1.position_wrt(N.origin)
         10*N.i
@@ -124,20 +124,20 @@ class Point(Basic):
     def express_coordinates(self, coordinate_system):
         """
         Returns the Cartesian/rectangular coordinates of this point
-        wrt the origin of the given CoordSysCartesian instance.
+        wrt the origin of the given CoordSystem3D instance.
 
         Parameters
         ==========
 
-        coordinate_system : CoordSysCartesian
+        coordinate_system : CoordSystem3D
             The coordinate system to express the coordinates of this
             Point in.
 
         Examples
         ========
 
-        >>> from sympy.vector import Point, CoordSysCartesian
-        >>> N = CoordSysCartesian('N')
+        >>> from sympy.vector import Point, CoordSystem3D
+        >>> N = CoordSystem3D('N')
         >>> p1 = N.origin.locate_new('p1', 10 * N.i)
         >>> p2 = p1.locate_new('p2', 5 * N.j)
         >>> p2.express_coordinates(N)

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -12,10 +12,10 @@ class BaseScalar(Symbol):
     """
 
     def __new__(cls, name, index, system, pretty_str, latex_str):
-        from sympy.vector.coordsysrect import CoordSysCartesian
+        from sympy.vector.coordsysrect import CoordSystem3D
         obj = super(BaseScalar, cls).__new__(cls, name)
-        if not isinstance(system, CoordSysCartesian):
-            raise TypeError("system should be a CoordSysCartesian")
+        if not isinstance(system, CoordSystem3D):
+            raise TypeError("system should be a CoordSystem3D")
         if index not in range(0, 3):
             raise ValueError("Invalid index specified.")
         #The _id is used for equating purposes, and for hashing

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -1,4 +1,4 @@
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.vector.scalar import BaseScalar
 from sympy import sin, cos, pi, ImmutableMatrix as Matrix, \
      symbols, simplify, zeros
@@ -13,10 +13,10 @@ q1, q2, q3, q4 = symbols('q1 q2 q3 q4')
 
 
 def test_coordsyscartesian_equivalence():
-    A = CoordSysCartesian('A')
-    A1 = CoordSysCartesian('A')
+    A = CoordSystem3D('A')
+    A1 = CoordSystem3D('A')
     assert A1 == A
-    B = CoordSysCartesian('B')
+    B = CoordSystem3D('B')
     assert A != B
     assert A.locate_new('C1', A.i) == A.locate_new('C2', A.i)
     assert A.orient_new_axis('C1', a, A.i) == \
@@ -24,7 +24,7 @@ def test_coordsyscartesian_equivalence():
 
 
 def test_orienters():
-    A = CoordSysCartesian('A')
+    A = CoordSystem3D('A')
     axis_orienter = AxisOrienter(a, A.k)
     body_orienter = BodyOrienter(a, b, c, '123')
     space_orienter = SpaceOrienter(a, b, c, '123')
@@ -60,7 +60,7 @@ def test_coordinate_vars():
     Tests the coordinate variables functionality with respect to
     reorientation of coordinate systems.
     """
-    A = CoordSysCartesian('A')
+    A = CoordSystem3D('A')
     assert BaseScalar('Ax', 0, A, ' ', ' ') == A.x
     assert BaseScalar('Ay', 1, A, ' ', ' ') == A.y
     assert BaseScalar('Az', 2, A, ' ', ' ') == A.z
@@ -117,7 +117,7 @@ def test_coordinate_vars():
 
 
 def test_rotation_matrix():
-    N = CoordSysCartesian('N')
+    N = CoordSystem3D('N')
     A = N.orient_new_axis('A', q1, N.k)
     B = A.orient_new_axis('B', q2, A.i)
     C = B.orient_new_axis('C', q3, B.j)
@@ -171,7 +171,7 @@ def test_vector():
     Tests the effects of orientation of coordinate systems on
     basic vector operations.
     """
-    N = CoordSysCartesian('N')
+    N = CoordSystem3D('N')
     A = N.orient_new_axis('A', q1, N.k)
     B = A.orient_new_axis('B', q2, A.i)
     C = B.orient_new_axis('C', q3, B.j)
@@ -231,7 +231,7 @@ def test_vector():
     assert express(C.k.cross(A.i), C).trigsimp() == cos(q3)*C.j
 
 def test_orient_new_methods():
-    N = CoordSysCartesian('N')
+    N = CoordSystem3D('N')
     orienter1 = AxisOrienter(q4, N.j)
     orienter2 = SpaceOrienter(q1, q2, q3, '123')
     orienter3 = QuaternionOrienter(q1, q2, q3, q4)
@@ -248,9 +248,9 @@ def test_orient_new_methods():
 
 def test_locatenew_point():
     """
-    Tests Point class, and locate_new method in CoordSysCartesian.
+    Tests Point class, and locate_new method in CoordSystem3D.
     """
-    A = CoordSysCartesian('A')
+    A = CoordSystem3D('A')
     assert isinstance(A.origin, Point)
     v = a*A.i + b*A.j + c*A.k
     C = A.locate_new('C', v)
@@ -274,7 +274,7 @@ def test_locatenew_point():
 
 
 def test_evalf():
-    A = CoordSysCartesian('A')
+    A = CoordSystem3D('A')
     v = 3*A.i + 4*A.j + a*A.k
     assert v.n() == v.evalf()
     assert v.evalf(subs={a:1}) == v.subs(a, 1).evalf()

--- a/sympy/vector/tests/test_dyadic.py
+++ b/sympy/vector/tests/test_dyadic.py
@@ -1,11 +1,11 @@
 from sympy import sin, cos, symbols, pi, ImmutableMatrix as Matrix, \
      simplify
-from sympy.vector import (CoordSysCartesian, Vector, Dyadic,
+from sympy.vector import (CoordSystem3D, Vector, Dyadic,
                           DyadicAdd, DyadicMul, DyadicZero,
                           BaseDyadic, express)
 
 
-A = CoordSysCartesian('A')
+A = CoordSystem3D('A')
 
 
 def test_dyadic():
@@ -88,7 +88,7 @@ def test_dyadic():
 
 def test_dyadic_simplify():
     x, y, z, k, n, m, w, f, s, A = symbols('x, y, z, k, n, m, w, f, s, A')
-    N = CoordSysCartesian('N')
+    N = CoordSystem3D('N')
 
     dy = N.i | N.i
     test1 = (1 / x + 1 / y) * dy

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -33,7 +33,7 @@ def test_del_operator():
             (-Derivative(0, cartesian.x) + Derivative(0, cartesian.z))*cartesian.j +
             (Derivative(0, cartesian.x) - Derivative(0, cartesian.y))*cartesian.k)
     assert ((delop ^ Vector.zero).doit() == Vector.zero ==
-            curl(Vector.zero, cartesian))
+            curl(Vector.zero))
     assert delop.cross(Vector.zero) == delop ^ Vector.zero
     assert (delop ^ i).doit() == Vector.zero
     assert delop.cross(2*y**2*j, doit=True) == Vector.zero
@@ -41,48 +41,48 @@ def test_del_operator():
     v = x*y*z * (i + j + k)
     assert ((delop ^ v).doit() ==
             (-x*y + x*z)*i + (x*y - y*z)*j + (-x*z + y*z)*k ==
-            curl(v, cartesian))
+            curl(v))
     assert delop ^ v == delop.cross(v)
     assert (delop.cross(2*x**2*j) ==
             (Derivative(0, cartesian.y) - Derivative(2*cartesian.x**2, cartesian.z))*cartesian.i +
             (-Derivative(0, cartesian.x) + Derivative(0, cartesian.z))*cartesian.j +
             (-Derivative(0, cartesian.y) + Derivative(2*cartesian.x**2, cartesian.x))*cartesian.k)
     assert (delop.cross(2*x**2*j, doit=True) == 4*x*k ==
-            curl(2*x**2*j, cartesian))
+            curl(2*x**2*j))
 
     #Tests for divergence
-    assert delop & Vector.zero == S(0) == divergence(Vector.zero, cartesian)
+    assert delop & Vector.zero == S(0) == divergence(Vector.zero)
     assert (delop & Vector.zero).doit() == S(0)
     assert delop.dot(Vector.zero) == delop & Vector.zero
     assert (delop & i).doit() == S(0)
-    assert (delop & x**2*i).doit() == 2*x == divergence(x**2*i, cartesian)
+    assert (delop & x**2*i).doit() == 2*x == divergence(x**2*i)
     assert (delop.dot(v, doit=True) == x*y + y*z + z*x ==
-            divergence(v, cartesian))
+            divergence(v))
     assert delop & v == delop.dot(v)
     assert delop.dot(1/(x*y*z) * (i + j + k), doit=True) == \
            - 1 / (x*y*z**2) - 1 / (x*y**2*z) - 1 / (x**2*y*z)
     v = x*i + y*j + z*k
     assert (delop & v == Derivative(cartesian.x, cartesian.x) +
             Derivative(cartesian.y, cartesian.y) + Derivative(cartesian.z, cartesian.z))
-    assert delop.dot(v, doit=True) == 3 == divergence(v, cartesian)
+    assert delop.dot(v, doit=True) == 3 == divergence(v)
     assert delop & v == delop.dot(v)
     assert simplify((delop & v).doit()) == 3
 
     #Tests for gradient
     assert (delop.gradient(0, doit=True) == Vector.zero ==
-            gradient(0, cartesian))
+            gradient(0))
     assert delop.gradient(0) == delop(0)
     assert (delop(S(0))).doit() == Vector.zero
     assert (delop(x) == (Derivative(cartesian.x, cartesian.x))*cartesian.i +
             (Derivative(cartesian.x, cartesian.y))*cartesian.j + (Derivative(cartesian.x, cartesian.z))*cartesian.k)
-    assert (delop(x)).doit() == i == gradient(x, cartesian)
+    assert (delop(x)).doit() == i == gradient(x)
     assert (delop(x*y*z) ==
             (Derivative(cartesian.x*cartesian.y*cartesian.z, cartesian.x))*cartesian.i +
             (Derivative(cartesian.x*cartesian.y*cartesian.z, cartesian.y))*cartesian.j +
             (Derivative(cartesian.x*cartesian.y*cartesian.z, cartesian.z))*cartesian.k)
     assert (delop.gradient(x*y*z, doit=True) ==
             y*z*i + z*x*j + x*y*k ==
-            gradient(x*y*z, cartesian))
+            gradient(x*y*z))
     assert delop(x*y*z) == delop.gradient(x*y*z)
     assert (delop(2*x**2)).doit() == 4*x*i
     assert ((delop(a*sin(y) / x)).doit() ==
@@ -161,9 +161,9 @@ def test_product_rules():
 
 P = cartesian.orient_new_axis('P', q, cartesian.k)
 scalar_field = 2*x**2*y*z
-grad_field = gradient(scalar_field, cartesian)
+grad_field = gradient(scalar_field)
 vector_field = y**2*i + 3*x*j + 5*y*z*k
-curl_field = curl(vector_field, cartesian)
+curl_field = curl(vector_field)
 
 
 def test_conservative():

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -1,9 +1,9 @@
 from sympy.core.function import Derivative
 from sympy.vector.vector import Vector
-from sympy.vector.coordsysrect import CoordSystem3D, DifferentialClass
+from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.simplify import simplify
 from sympy.core.symbol import symbols
-from sympy.core import S
+from sympy.core import S, Lambda
 from sympy import sin, cos
 from sympy.vector.functions import (curl, divergence, gradient,
                                     is_conservative, is_solenoidal,
@@ -12,8 +12,13 @@ from sympy.vector.functions import (curl, divergence, gradient,
 from sympy.utilities.pytest import raises
 
 cartesian = CoordSystem3D('C')
-spherical = CoordSystem3D('spherical', DifferentialClass.build_instance_from_lambda(
-    lambda r, theta, phi: (r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta))))
+
+def _get_spherical_diff_parameters():
+    r, theta, phi = symbols('r, theta, phi')
+    return  Lambda((r, theta, phi), (r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta)))
+
+spherical = CoordSystem3D('spherical', _get_spherical_diff_parameters())
+
 i, j, k = cartesian.base_vectors()
 x, y, z = cartesian.base_scalars()
 delop = cartesian.delop

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -1,6 +1,6 @@
 from sympy.core.function import Derivative
 from sympy.vector.vector import Vector
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D, DifferentialClass
 from sympy.simplify import simplify
 from sympy.core.symbol import symbols
 from sympy.core import S
@@ -11,70 +11,73 @@ from sympy.vector.functions import (curl, divergence, gradient,
                                     scalar_potential_difference)
 from sympy.utilities.pytest import raises
 
-C = CoordSysCartesian('C')
-i, j, k = C.base_vectors()
-x, y, z = C.base_scalars()
-delop = C.delop
+cartesian = CoordSystem3D('C')
+spherical = CoordSystem3D('spherical', DifferentialClass.build_instance_from_lambda(
+    lambda r, theta, phi: (r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta))))
+i, j, k = cartesian.base_vectors()
+x, y, z = cartesian.base_scalars()
+delop = cartesian.delop
 a, b, c, q = symbols('a b c q')
+
 
 def test_del_operator():
 
     #Tests for curl
     assert (delop ^ Vector.zero ==
-            (Derivative(0, C.y) - Derivative(0, C.z))*C.i +
-            (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
-            (Derivative(0, C.x) - Derivative(0, C.y))*C.k)
+            (Derivative(0, cartesian.y) - Derivative(0, cartesian.z))*cartesian.i +
+            (-Derivative(0, cartesian.x) + Derivative(0, cartesian.z))*cartesian.j +
+            (Derivative(0, cartesian.x) - Derivative(0, cartesian.y))*cartesian.k)
     assert ((delop ^ Vector.zero).doit() == Vector.zero ==
-            curl(Vector.zero, C))
+            curl(Vector.zero, cartesian))
     assert delop.cross(Vector.zero) == delop ^ Vector.zero
     assert (delop ^ i).doit() == Vector.zero
-    assert delop.cross(2*y**2*j, doit = True) == Vector.zero
+    assert delop.cross(2*y**2*j, doit=True) == Vector.zero
     assert delop.cross(2*y**2*j) == delop ^ 2*y**2*j
     v = x*y*z * (i + j + k)
     assert ((delop ^ v).doit() ==
             (-x*y + x*z)*i + (x*y - y*z)*j + (-x*z + y*z)*k ==
-            curl(v, C))
+            curl(v, cartesian))
     assert delop ^ v == delop.cross(v)
     assert (delop.cross(2*x**2*j) ==
-            (Derivative(0, C.y) - Derivative(2*C.x**2, C.z))*C.i +
-            (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
-            (-Derivative(0, C.y) + Derivative(2*C.x**2, C.x))*C.k)
-    assert (delop.cross(2*x**2*j, doit = True) == 4*x*k ==
-            curl(2*x**2*j, C))
+            (Derivative(0, cartesian.y) - Derivative(2*cartesian.x**2, cartesian.z))*cartesian.i +
+            (-Derivative(0, cartesian.x) + Derivative(0, cartesian.z))*cartesian.j +
+            (-Derivative(0, cartesian.y) + Derivative(2*cartesian.x**2, cartesian.x))*cartesian.k)
+    assert (delop.cross(2*x**2*j, doit=True) == 4*x*k ==
+            curl(2*x**2*j, cartesian))
 
     #Tests for divergence
-    assert delop & Vector.zero == S(0) == divergence(Vector.zero, C)
+    assert delop & Vector.zero == S(0) == divergence(Vector.zero, cartesian)
     assert (delop & Vector.zero).doit() == S(0)
     assert delop.dot(Vector.zero) == delop & Vector.zero
     assert (delop & i).doit() == S(0)
-    assert (delop & x**2*i).doit() == 2*x == divergence(x**2*i, C)
-    assert (delop.dot(v, doit = True) == x*y + y*z + z*x ==
-            divergence(v, C))
+    assert (delop & x**2*i).doit() == 2*x == divergence(x**2*i, cartesian)
+    assert (delop.dot(v, doit=True) == x*y + y*z + z*x ==
+            divergence(v, cartesian))
     assert delop & v == delop.dot(v)
-    assert delop.dot(1/(x*y*z) * (i + j + k), doit = True) == \
+    assert delop.dot(1/(x*y*z) * (i + j + k), doit=True) == \
            - 1 / (x*y*z**2) - 1 / (x*y**2*z) - 1 / (x**2*y*z)
     v = x*i + y*j + z*k
-    assert (delop & v == Derivative(C.x, C.x) +
-            Derivative(C.y, C.y) + Derivative(C.z, C.z))
-    assert delop.dot(v, doit = True) == 3 == divergence(v, C)
+    assert (delop & v == Derivative(cartesian.x, cartesian.x) +
+            Derivative(cartesian.y, cartesian.y) + Derivative(cartesian.z, cartesian.z))
+    assert delop.dot(v, doit=True) == 3 == divergence(v, cartesian)
     assert delop & v == delop.dot(v)
     assert simplify((delop & v).doit()) == 3
 
     #Tests for gradient
-    assert (delop.gradient(0, doit = True) == Vector.zero ==
-            gradient(0, C))
+    assert (delop.gradient(0, doit=True) == Vector.zero ==
+            gradient(0, cartesian))
     assert delop.gradient(0) == delop(0)
     assert (delop(S(0))).doit() == Vector.zero
-    assert (delop(x) == (Derivative(C.x, C.x))*C.i +
-            (Derivative(C.x, C.y))*C.j + (Derivative(C.x, C.z))*C.k)
-    assert (delop(x)).doit() == i == gradient(x, C)
+    assert (delop(x) == (Derivative(cartesian.x, cartesian.x))*cartesian.i +
+            (Derivative(cartesian.x, cartesian.y))*cartesian.j + (Derivative(cartesian.x, cartesian.z))*cartesian.k)
+    assert (delop(x)).doit() == i == gradient(x, cartesian)
     assert (delop(x*y*z) ==
-            (Derivative(C.x*C.y*C.z, C.x))*C.i +
-            (Derivative(C.x*C.y*C.z, C.y))*C.j +
-            (Derivative(C.x*C.y*C.z, C.z))*C.k)
-    assert (delop.gradient(x*y*z, doit = True) ==
+            (Derivative(cartesian.x*cartesian.y*cartesian.z, cartesian.x))*cartesian.i +
+            (Derivative(cartesian.x*cartesian.y*cartesian.z, cartesian.y))*cartesian.j +
+            (Derivative(cartesian.x*cartesian.y*cartesian.z, cartesian.z))*cartesian.k)
+    assert (delop.gradient(x*y*z, doit=True) ==
             y*z*i + z*x*j + x*y*k ==
-            gradient(x*y*z, C))
+            gradient(x*y*z, cartesian))
     assert delop(x*y*z) == delop.gradient(x*y*z)
     assert (delop(2*x**2)).doit() == 4*x*i
     assert ((delop(a*sin(y) / x)).doit() ==
@@ -91,7 +94,7 @@ def test_del_operator():
     assert ((i & delop)(x*y*z)).doit() == y*z
     assert ((v & delop)(x)).doit() == x
     assert ((v & delop)(x*y*z)).doit() == 3*x*y*z
-    assert (v & delop)(x + y + z) == C.x + C.y + C.z
+    assert (v & delop)(x + y + z) == cartesian.x + cartesian.y + cartesian.z
     assert ((v & delop)(x + y + z)).doit() == x + y + z
     assert ((v & delop)(v)).doit() == v
     assert ((i & delop)(v)).doit() == i
@@ -119,7 +122,7 @@ def test_product_rules():
     v = 4*i + x*y*z*k
 
     #First product rule
-    lhs = delop(f * g, doit = True)
+    lhs = delop(f * g, doit=True)
     rhs = (f * delop(g) + g * delop(f)).doit()
     assert simplify(lhs) == simplify(rhs)
 
@@ -151,11 +154,11 @@ def test_product_rules():
     assert simplify(lhs) == simplify(rhs)
 
 
-P = C.orient_new_axis('P', q, C.k)
+P = cartesian.orient_new_axis('P', q, cartesian.k)
 scalar_field = 2*x**2*y*z
-grad_field = gradient(scalar_field, C)
+grad_field = gradient(scalar_field, cartesian)
 vector_field = y**2*i + 3*x*j + 5*y*z*k
-curl_field = curl(vector_field, C)
+curl_field = curl(vector_field, cartesian)
 
 
 def test_conservative():
@@ -187,32 +190,32 @@ def test_solenoidal():
 
 
 def test_scalar_potential():
-    assert scalar_potential(Vector.zero, C) == 0
-    assert scalar_potential(i, C) == x
-    assert scalar_potential(j, C) == y
-    assert scalar_potential(k, C) == z
-    assert scalar_potential(y*z*i + x*z*j + x*y*k, C) == x*y*z
-    assert scalar_potential(grad_field, C) == scalar_field
-    assert scalar_potential(z*P.i + P.x*k, C) == x*z*cos(q) + y*z*sin(q)
+    assert scalar_potential(Vector.zero, cartesian) == 0
+    assert scalar_potential(i, cartesian) == x
+    assert scalar_potential(j, cartesian) == y
+    assert scalar_potential(k, cartesian) == z
+    assert scalar_potential(y*z*i + x*z*j + x*y*k, cartesian) == x*y*z
+    assert scalar_potential(grad_field, cartesian) == scalar_field
+    assert scalar_potential(z*P.i + P.x*k, cartesian) == x*z*cos(q) + y*z*sin(q)
     assert scalar_potential(z*P.i + P.x*k, P) == P.x*P.z
-    raises(ValueError, lambda: scalar_potential(x*j, C))
+    raises(ValueError, lambda: scalar_potential(x*j, cartesian))
 
 
 def test_scalar_potential_difference():
-    point1 = C.origin.locate_new('P1', 1*i + 2*j + 3*k)
-    point2 = C.origin.locate_new('P2', 4*i + 5*j + 6*k)
-    genericpointC = C.origin.locate_new('RP', x*i + y*j + z*k)
+    point1 = cartesian.origin.locate_new('P1', 1*i + 2*j + 3*k)
+    point2 = cartesian.origin.locate_new('P2', 4*i + 5*j + 6*k)
+    genericpointC = cartesian.origin.locate_new('RP', x*i + y*j + z*k)
     genericpointP = P.origin.locate_new('PP', P.x*P.i + P.y*P.j + P.z*P.k)
-    assert scalar_potential_difference(S(0), C, point1, point2) == 0
-    assert (scalar_potential_difference(scalar_field, C, C.origin,
+    assert scalar_potential_difference(S(0), cartesian, point1, point2) == 0
+    assert (scalar_potential_difference(scalar_field, cartesian, cartesian.origin,
                                         genericpointC) ==
             scalar_field)
-    assert (scalar_potential_difference(grad_field, C, C.origin,
+    assert (scalar_potential_difference(grad_field, cartesian, cartesian.origin,
                                         genericpointC) ==
             scalar_field)
-    assert scalar_potential_difference(grad_field, C, point1, point2) == 948
+    assert scalar_potential_difference(grad_field, cartesian, point1, point2) == 948
     assert (scalar_potential_difference(y*z*i + x*z*j +
-                                        x*y*k, C, point1,
+                                        x*y*k, cartesian, point1,
                                         genericpointC) ==
             x*y*z - 6)
     potential_diff_P = (2*P.z*(P.x*sin(q) + P.y*cos(q))*

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -1,9 +1,9 @@
 from sympy.vector.vector import Vector
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.vector.functions import express, matrix_to_vector
 from sympy import symbols, S, sin, cos, ImmutableMatrix as Matrix
 
-N = CoordSysCartesian('N')
+N = CoordSystem3D('N')
 q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
 A = N.orient_new_axis('A', q1, N.k)
 B = A.orient_new_axis('B', q2, A.i)

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from sympy import Integral, latex, Function
 from sympy import pretty as xpretty
-from sympy.vector import CoordSysCartesian, Vector, express
+from sympy.vector import CoordSystem3D, Vector, express
 from sympy.abc import a, b, c
 from sympy.core.compatibility import u_decode as u
 from sympy.utilities.pytest import XFAIL
@@ -19,7 +19,7 @@ def upretty(expr):
 #needed for testing.
 #Some of the pretty forms shown denote how the expressions just
 #above them should look with pretty printing.
-N = CoordSysCartesian('N')
+N = CoordSystem3D('N')
 C = N.orient_new_axis('C', a, N.k)
 v = []
 d = []
@@ -161,7 +161,7 @@ def test_latex_printing():
 
 
 def test_custom_names():
-    A = CoordSysCartesian('A', vector_names=['x', 'y', 'z'],
+    A = CoordSystem3D('A', vector_names=['x', 'y', 'z'],
                           variable_names=['i', 'j', 'k'])
     assert A.i.__str__() == 'x'
     assert A.x.__str__() == 'i'

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -3,9 +3,9 @@ from sympy import pi, sqrt, symbols, ImmutableMatrix as Matrix, \
      sin, cos, Function, Integral, Derivative, diff, integrate
 from sympy.vector.vector import Vector, BaseVector, VectorAdd, \
      VectorMul, VectorZero
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D
 
-C = CoordSysCartesian('C')
+C = CoordSystem3D('C')
 
 i, j, k = C.base_vectors()
 a, b, c = symbols('a b c')

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -3,7 +3,7 @@ from sympy.core import S, Pow
 from sympy.core.expr import AtomicExpr
 from sympy.core.compatibility import range
 from sympy import diff as df, sqrt, ImmutableMatrix as Matrix
-from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.vector.coordsysrect import CoordSystem3D
 from sympy.vector.basisdependent import BasisDependent, \
      BasisDependentAdd, BasisDependentMul, BasisDependentZero
 from sympy.vector.dyadic import BaseDyadic, Dyadic, DyadicAdd
@@ -30,8 +30,8 @@ class Vector(BasisDependent):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> C = CoordSysCartesian('C')
+        >>> from sympy.vector import CoordSystem3D
+        >>> C = CoordSystem3D('C')
         >>> v = 3*C.i + 4*C.j + 5*C.k
         >>> v.components
         {C.i: 3, C.j: 4, C.k: 5}
@@ -74,8 +74,8 @@ class Vector(BasisDependent):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> C = CoordSysCartesian('C')
+        >>> from sympy.vector import CoordSystem3D
+        >>> C = CoordSystem3D('C')
         >>> C.i.dot(C.j)
         0
         >>> C.i & C.i
@@ -150,8 +150,8 @@ class Vector(BasisDependent):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> C = CoordSysCartesian('C')
+        >>> from sympy.vector import CoordSystem3D
+        >>> C = CoordSystem3D('C')
         >>> C.i.cross(C.j)
         C.k
         >>> C.i ^ C.i
@@ -227,8 +227,8 @@ class Vector(BasisDependent):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> N = CoordSysCartesian('N')
+        >>> from sympy.vector import CoordSystem3D
+        >>> N = CoordSystem3D('N')
         >>> N.i.outer(N.j)
         (N.i|N.j)
 
@@ -262,14 +262,14 @@ class Vector(BasisDependent):
         Parameters
         ==========
 
-        system : CoordSysCartesian
+        system : CoordSystem3D
             The system wrt which the matrix form is to be computed
 
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> C = CoordSysCartesian('C')
+        >>> from sympy.vector import CoordSystem3D
+        >>> C = CoordSystem3D('C')
         >>> from sympy.abc import a, b, c
         >>> v = a*C.i + b*C.j + c*C.k
         >>> v.to_matrix(C)
@@ -288,15 +288,15 @@ class Vector(BasisDependent):
         The constituents of this vector in different coordinate systems,
         as per its definition.
 
-        Returns a dict mapping each CoordSysCartesian to the corresponding
+        Returns a dict mapping each CoordSystem3D to the corresponding
         constituent Vector.
 
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
-        >>> R1 = CoordSysCartesian('R1')
-        >>> R2 = CoordSysCartesian('R2')
+        >>> from sympy.vector import CoordSystem3D
+        >>> R1 = CoordSystem3D('R1')
+        >>> R2 = CoordSystem3D('R2')
         >>> v = R1.i + R2.i
         >>> v.separate() == {R1: R1.i, R2: R2.i}
         True
@@ -321,8 +321,8 @@ class BaseVector(Vector, AtomicExpr):
             raise ValueError("index must be 0, 1 or 2")
         if not isinstance(name, str):
             raise TypeError("name must be a valid string")
-        if not isinstance(system, CoordSysCartesian):
-            raise TypeError("system should be a CoordSysCartesian")
+        if not isinstance(system, CoordSystem3D):
+            raise TypeError("system should be a CoordSystem3D")
         #Initialize an object
         obj = super(BaseVector, cls).__new__(cls, S(index),
                                              system)


### PR DESCRIPTION
# Summary

I am working on expanding the vector module (via [Upabjojr PR](https://github.com/sympy/sympy/pull/9937)).  I added a test suite for the new laplacian function and removed the coordinate system dependence for differential functions in _vector/functions.py_.  The tests run and pass with one exception.  The problem there is that if I use the gradient function on a number it is not able to find the system.  I believe that the when creating the Vector instances we should have a system attribute (same for VectorAdd and VectorMul).  This will make allow for some refactoring in _vector/functions.py_.
# ToDo:
- [ ] Possibly have a class per coordinate system.  DRY might be lost in library code, but it would look a lot cleaner in user code, each class could have its own differential method, etc.
- [ ] Have the differential coefficients initialize themselves when making new CoordSystem3D() instance.
- [ ] Carry a copy of CoodSystem3D() instance when creating Vector() instances (Add and Mul included).
- [ ] Add more coordinate systems.
