### PR TITLE
Mod._eval_is_integer returns a false negative

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -143,7 +143,8 @@ class Mod(Function):
     def _eval_is_integer(self):
         from sympy.core.logic import fuzzy_and, fuzzy_not
         p, q = self.args
-        return fuzzy_and([p.is_integer, q.is_integer, fuzzy_not(q.is_zero)])
+        if fuzzy_and([p.is_integer, q.is_integer, fuzzy_not(q.is_zero)]):
+            return True
 
     def _eval_is_nonnegative(self):
         if self.args[1].is_positive:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1594,6 +1594,9 @@ def test_Mod():
     n = Symbol('n', odd=True)
     assert Mod(n, 2) == 1
 
+    # issue 10024
+    assert Mod(x, 2*pi).is_zero == None
+
 
 def test_Mod_is_integer():
     p = Symbol('p', integer=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1594,9 +1594,6 @@ def test_Mod():
     n = Symbol('n', odd=True)
     assert Mod(n, 2) == 1
 
-    # issue 10024
-    assert Mod(x, 2*pi).is_zero == None
-
 
 def test_Mod_is_integer():
     p = Symbol('p', integer=True)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,4 +1,4 @@
-from sympy import I, sqrt, log, exp, sin, asin, factorial, Mod
+from sympy import I, sqrt, log, exp, sin, asin, factorial, Mod, pi
 from sympy.core import Symbol, S, Rational, Integer, Dummy, Wild, Pow
 from sympy.core.facts import InconsistentAssumptions
 from sympy import simplify

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,4 +1,4 @@
-from sympy import I, sqrt, log, exp, sin, asin, factorial
+from sympy import I, sqrt, log, exp, sin, asin, factorial, Mod
 from sympy.core import Symbol, S, Rational, Integer, Dummy, Wild, Pow
 from sympy.core.facts import InconsistentAssumptions
 from sympy import simplify
@@ -967,3 +967,7 @@ def test_issue_9165():
     assert 0/z == S.NaN
     assert 0*(1/z) == S.NaN
     assert 0*f == S.NaN
+
+def test_issue_10024():
+    x = Dummy('x')
+    assert Mod(x, 2*pi).is_zero is None


### PR DESCRIPTION
When Mod._eval_is_integer cannot determine it is an integer, it should return None, and not False. 
This fixes issue #10024.
