### PR TITLE
Fixes the angular momentum equation for a rigid body.

### DIFF
--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -224,24 +224,23 @@ class RigidBody(object):
         return self.mass * self.masscenter.vel(frame)
 
     def angular_momentum(self, point, frame):
-        """ Angular momentum of the rigid body.
+        """Returns the angular momentum of the rigid body about a point in the
+        given frame.
 
-        The angular momentum H, about some point O, of a rigid body B, in a
-        frame N is given by
+        The angular momentum H of a rigid body B about some point O in a frame
+        N is given by:
 
-        H = I* . omega + r* x (M * v)
+            H = I.w + r x Mv
 
-        where I* is the central inertia dyadic of B, omega is the angular
-        velocity of body B in the frame, N, r* is the position vector from
-        point O to the mass center of B, and v is the velocity of point O in
-        the frame, N.
+        where I is the central inertia dyadic of B, w is the angular velocity
+        of body B in the frame, N, r is the position vector from point O to the
+        mass center of B, and v is the velocity of the mass center in the
+        frame, N.
 
         Parameters
         ==========
-
         point : Point
             The point about which angular momentum is desired.
-
         frame : ReferenceFrame
             The frame in which angular momentum is desired.
 
@@ -256,17 +255,19 @@ class RigidBody(object):
         >>> b.set_ang_vel(N, omega * b.x)
         >>> P = Point('P')
         >>> P.set_vel(N, 1 * N.x)
-        >>> I = outer (b.x, b.x)
-        >>> Inertia_tuple = (I, P)
-        >>> B = RigidBody('B', P, b, M, Inertia_tuple)
+        >>> I = outer(b.x, b.x)
+        >>> B = RigidBody('B', P, b, M, (I, P))
         >>> B.angular_momentum(P, N)
         omega*b.x
 
         """
+        I = self.central_inertia
+        w = self.frame.ang_vel_in(frame)
+        m = self.mass
+        r = self.masscenter.pos_from(point)
+        v = self.masscenter.vel(frame)
 
-        return ((self.central_inertia & self.frame.ang_vel_in(frame)) +
-                (point.vel(frame) ^ -self.masscenter.pos_from(point)) *
-                self.mass)
+        return I.dot(w) + r.cross(m * v)
 
     def kinetic_energy(self, frame):
         """Kinetic energy of the rigid body

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf8 -*-
 from __future__ import print_function, division
 
 __all__ = ['RigidBody']
@@ -230,7 +231,7 @@ class RigidBody(object):
         The angular momentum H of a rigid body B about some point O in a frame
         N is given by:
 
-            H = I.w + r x Mv
+            H = I·w + r×Mv
 
         where I is the central inertia dyadic of B, w is the angular velocity
         of body B in the frame, N, r is the position vector from point O to the

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -70,24 +70,27 @@ def test_linear_momentum():
 
 
 def test_angular_momentum_and_linear_momentum():
-    m, M, l1 = symbols('m M l1')
-    q1d = dynamicsymbols('q1d')
+    """A rod with length 2l, centroidal inertia I, and mass M along with a
+    particle of mass m fixed to the end of the rod rotate with an angular rate
+    of omega about point O which is fixed to the non-particle end of the rod.
+    The rod's reference frame is A and the inertial frame is N."""
+    m, M, l, I = symbols('m, M, l, I')
+    omega = dynamicsymbols('omega')
     N = ReferenceFrame('N')
-    O = Point('O')
-    O.set_vel(N, 0 * N.x)
-    Ac = O.locatenew('Ac', l1 * N.x)
-    P = Ac.locatenew('P', l1 * N.x)
     a = ReferenceFrame('a')
-    a.set_ang_vel(N, q1d * N.z)
+    O = Point('O')
+    Ac = O.locatenew('Ac', l * N.x)
+    P = Ac.locatenew('P', l * N.x)
+    O.set_vel(N, 0 * N.x)
+    a.set_ang_vel(N, omega * N.z)
     Ac.v2pt_theory(O, N, a)
     P.v2pt_theory(O, N, a)
     Pa = Particle('Pa', P, m)
-    I = outer(N.z, N.z)
-    A = RigidBody('A', Ac, a, M, (I, Ac))
-    assert linear_momentum(
-        N, A, Pa) == 2 * m * q1d* l1 * N.y + M * l1 * q1d * N.y
-    assert angular_momentum(
-        O, N, A, Pa) == 4 * m * q1d * l1**2 * N.z + q1d * N.z
+    A = RigidBody('A', Ac, a, M, (I * outer(N.z, N.z), Ac))
+    expected = 2 * m * omega * l * N.y + M * l * omega * N.y
+    assert (linear_momentum(N, A, Pa) - expected) == Vector(0)
+    expected = (I + M * l**2 + 4 * m * l**2) * omega * N.z
+    assert (angular_momentum(O, N, A, Pa) - expected).simplify() == Vector(0)
 
 
 def test_kinetic_energy():

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -1,6 +1,6 @@
 from sympy import symbols
 from sympy.physics.mechanics import Point, ReferenceFrame, Dyadic, RigidBody
-from sympy.physics.mechanics import dynamicsymbols, outer
+from sympy.physics.mechanics import dynamicsymbols, outer, inertia
 from sympy.physics.mechanics import inertia_of_point_mass
 
 
@@ -64,6 +64,7 @@ def test_rigidbody3():
     O = Point('O')
     O.set_vel(A, q2*A.x + q3*A.y + q4*A.z)
     P = O.locatenew('P', p1*B.x + p2*B.y + p3*B.z)
+    P.v2pt_theory(O, A, B)
     I = outer(B.x, B.x)
 
     rb1 = RigidBody('rb1', P, B, m, (I, P))
@@ -73,3 +74,33 @@ def test_rigidbody3():
 
     assert rb1.central_inertia == rb2.central_inertia
     assert rb1.angular_momentum(O, A) == rb2.angular_momentum(O, A)
+
+
+def test_pendulum_angular_momentum():
+    """Consider a pendulum of length OA = 2a, of mass m as a rigid body of
+    center of mass G (OG = a) which turn around (O,z). The angle between the
+    reference frame R and the rod is q.  The inertia of the body is I =
+    (G,0,ma^2/3,ma^2/3). """
+
+    m, a = symbols('m, a')
+    q = dynamicsymbols('q')
+
+    R = ReferenceFrame('R')
+    R1 = R.orientnew('R1', 'Axis', [q, R.z])
+    R1.set_ang_vel(R, q.diff() * R.z)
+
+    I = inertia(R1, 0, m * a**2 / 3, m * a**2 / 3)
+
+    O = Point('O')
+
+    A = O.locatenew('A', 2*a * R1.x)
+    G = O.locatenew('G', a * R1.x)
+
+    S = RigidBody('S', G, R1, m, (I, G))
+
+    O.set_vel(R, 0)
+    A.v2pt_theory(O, R, R1)
+    G.v2pt_theory(O, R, R1)
+
+    assert (4 * m * a**2 / 3 * q.diff() * R.z -
+            S.angular_momentum(O, R).express(R)) == 0


### PR DESCRIPTION
The angular momentum was incorrectly computed because the velocity of the
specified point was used instead of the velocity of the mass center of the
body. This fixes the computation and adds a test based on the mailing list
report of Philippe Fichou.
