### PR TITLE
Integer raised to Float power should evaluate to Float

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1869,7 +1869,7 @@ class Integer(Rational):
                 return (-self)**expt
         if isinstance(expt, Float):
             # Rational knows how to exponentiate by a Float
-            return Rational._eval_power(self, expt)
+            return super(Integer, self)._eval_power(expt)
         if not isinstance(expt, Rational):
             return
         if expt is S.Half and self.is_negative:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1867,6 +1867,9 @@ class Integer(Rational):
             # (-2)**k --> 2**k
             if self.is_negative and expt.is_even:
                 return (-self)**expt
+        if isinstance(expt, Float):
+            # Rational knows how to exponentiate by a Float
+            return Rational._eval_power(self, expt)
         if not isinstance(expt, Rational):
             return
         if expt is S.Half and self.is_negative:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1499,3 +1499,7 @@ def test_comp():
 
 def test_issue_9491():
     assert oo**zoo == nan
+
+
+def test_issue_10063():
+    assert 2**Float(3) == Float(8)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -396,7 +396,7 @@ x    \
     assert upretty(expr) == ucode_str
 
     # see issue #2860
-    expr = S(2)**-1.0
+    expr = Pow(S(2), -1.0, evaluate=False)
     ascii_str = \
 """\
  -1.0\n\

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     factorial, factorial2, Function, GoldenRatio, I, Integer, Integral,
-    Interval, Lambda, Limit, Matrix, nan, O, oo, pi, Rational, Float, Rel,
+    Interval, Lambda, Limit, Matrix, nan, O, oo, pi, Pow, Rational, Float, Rel,
     S, sin, SparseMatrix, sqrt, summation, Sum, Symbol, symbols, Wild,
     WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference)
@@ -409,7 +409,7 @@ def test_Pow():
     # not the same as x**-1
     assert str(x**-1.0) == 'x**(-1.0)'
     # see issue #2860
-    assert str(S(2)**-1.0) == '2**(-1.0)'
+    assert str(Pow(S(2), -1.0, evaluate=False)) == '2**(-1.0)'
 
 
 def test_sqrt():


### PR DESCRIPTION
Previously it remained unevaluated.

Rational class has specific code to deal with Rational raised to
Float power, so we call Rational._eval_power() (our superclass).

Fixes #10063
