### PR TITLE
vector: sympy.vector del prints as .del but is accessed as .del

### DIFF
--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -142,7 +142,7 @@ class CoordSysCartesian(Basic):
 
         #Assign a Del operator instance
         from sympy.vector.deloperator import Del
-        obj._del = Del(obj)
+        obj._delop = Del(obj)
 
         #Assign params
         obj._parent = parent
@@ -172,7 +172,7 @@ class CoordSysCartesian(Basic):
 
     @property
     def delop(self):
-        return self._del
+        return self._delop
 
     @property
     def i(self):

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -19,7 +19,7 @@ class Del(Basic):
         obj._x, obj._y, obj._z = system.x, system.y, system.z
         obj._i, obj._j, obj._k = system.i, system.j, system.k
         obj._system = system
-        obj._name = system.__str__() + ".del"
+        obj._name = system.__str__() + ".delop"
         return obj
 
     @property


### PR DESCRIPTION
initially:
    >>> from sympy.vector import *
    >>> M = CoordSysCartesian('M')
    >>> M.delop
    M.del
After fixed:
    >>> from sympy.vector import *
    >>> M = CoordSysCartesian('M')
    >>> M.delop
    M.delop
