### PR TITLE
removing this line beacause the logic behind this line is

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -280,8 +280,6 @@ class Set(Basic):
         other = sympify(other, strict=True)
         ret = sympify(self._contains(other))
         if ret is None:
-            if all(Eq(i, other) == False for i in self):
-                return false
             ret = Contains(other, self, evaluate=False)
         return ret
 


### PR DESCRIPTION
 wrong,beacause no subclasses return None for _contain.
it seems that this should check for every finite set but
simpify return none for this line to be tested,but for finite
set simpify does not return none.so both statement are controductory
to each other.
