### PR TITLE
9956: do not test `contains` result against S.true 

### DIFF
--- a/sympy/geometry/tests/test_geometrysets.py
+++ b/sympy/geometry/tests/test_geometrysets.py
@@ -55,6 +55,8 @@ def test_booleans():
     assert Intersection(Union(l1, l4), l3) == FiniteSet(Point(-1/3, -1/3), Point(5, 1))
     assert Intersection(l1, FiniteSet(Point(7,-7))) == EmptySet()
     assert Intersection(Circle(Point(0,0), 3), Line(p1,p2)) == FiniteSet(Point(-3,0), Point(3,0))
+    assert Intersection(l1, FiniteSet(p1)) == FiniteSet(p1)
+    assert Union(l1, FiniteSet(p1)) == l1
 
     fs = FiniteSet(Point(1/3, 1), Point(2/3, 0), Point(9/5, 1/5), Point(7/3, 1))
     # test the intersection of polygons

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -212,7 +212,7 @@ class Set(Basic):
             return S.EmptySet
 
         elif isinstance(other, FiniteSet):
-            return FiniteSet(*[el for el in other if self.contains(el) is not true])
+            return FiniteSet(*[el for el in other if self.contains(el) != True])
 
     def symmetric_difference(self, other):
         return SymmetricDifference(self, other)
@@ -512,7 +512,7 @@ class Set(Basic):
 
     def __contains__(self, other):
         symb = self.contains(other)
-        if symb not in (true, false):
+        if symb not in (True, False):
             raise TypeError('contains did not evaluate to a bool: %r' % symb)
         return bool(symb)
 
@@ -949,8 +949,8 @@ class Interval(Set, EvalfMixin):
                 return Interval(start, end, left_open, right_open)
 
         # If I have open end points and these endpoints are contained in other
-        if ((self.left_open and other.contains(self.start) is true) or
-                (self.right_open and other.contains(self.end) is true)):
+        if ((self.left_open and other.contains(self.start) == True) or
+                (self.right_open and other.contains(self.end) == True)):
             # Fill in my end points and return
             open_left = self.left_open and self.start not in other
             open_right = self.right_open and self.end not in other
@@ -1001,7 +1001,7 @@ class Interval(Set, EvalfMixin):
             result = S.EmptySet
             domain_set = self
             for (p_expr, p_cond) in expr.args:
-                if p_cond is S.true:
+                if p_cond is true:
                     intrvl = domain_set
                 else:
                     intrvl = p_cond.as_set()
@@ -1247,8 +1247,7 @@ class Union(Set, EvalfMixin):
         return Max(*[set.sup for set in self.args])
 
     def _contains(self, other):
-        or_args = [the_set.contains(other) for the_set in self.args]
-        return Or(*or_args)
+        return Or(*[set.contains(other) for set in self.args])
 
     @property
     def _measure(self):
@@ -1425,7 +1424,6 @@ class Intersection(Set):
         return Intersection(imageset(f, arg) for arg in self.args)
 
     def _contains(self, other):
-        from sympy.logic.boolalg import And
         return And(*[set.contains(other) for set in self.args])
 
     def __iter__(self):
@@ -1454,15 +1452,15 @@ class Intersection(Set):
         if any(s.is_EmptySet for s in args):
             return S.EmptySet
 
-        # If any FiniteSets see which elements of that finite set occur within
-        # all other sets in the intersection
         for s in args:
             if s.is_FiniteSet:
+                # see which elements of the FiniteSet occur within
+                # all other sets in the intersection
                 other_args = [a for a in args if a != s]
-                res = FiniteSet(*[x for x in s
-                             if all(other.contains(x) is true for other in other_args)])
-                unk = [x for x in s
-                       if any(other.contains(x) not in (True, False) for other in other_args)]
+                res = FiniteSet(*[x for x in s if all(
+                    o.contains(x) == True for o in other_args)])
+                unk = [x for x in s if any(
+                    o.contains(x) not in (True, False) for o in other_args)]
                 if unk:
                     new_other = []
                     del_other = []
@@ -1497,7 +1495,8 @@ class Intersection(Set):
                     other_sets = Intersection(*(other_args + new_other))
                     if other_sets.is_EmptySet:
                         return EmptySet()
-                    res += Intersection(s.func(*unk), other_sets, evaluate=False)
+                    res += Intersection(
+                        s.func(*unk), other_sets, evaluate=False)
                 return res
 
         # If any of the sets are unions, return a Union of Intersections
@@ -1814,10 +1813,12 @@ class FiniteSet(Set, EvalfMixin):
                 return None
 
         elif isinstance(other, FiniteSet):
-            elms_unknown = FiniteSet(*[el for el in self if other.contains(el) not in (True, False)])
-            if elms_unknown == self:
+            unk = FiniteSet(*[el for el in self if other.contains(el)
+                not in (True, False)])
+            if unk == self:
                 return
-            return Complement(FiniteSet(*[el for el in other if self.contains(el) is not true]), elms_unknown)
+            return Complement(FiniteSet(*[el for el in other if
+                self.contains(el) != True]), unk)
 
         return Set._complement(self, other)
 
@@ -1832,10 +1833,10 @@ class FiniteSet(Set, EvalfMixin):
             return FiniteSet(*(self._elements | other._elements))
 
         # If other set contains one of my elements, remove it from myself
-        if any(other.contains(x) is true for x in self):
+        if any(other.contains(x) == True for x in self):
             return set((
-                FiniteSet(*[x for x in self if other.contains(x) is not true]),
-                other))
+                FiniteSet(*[x for x in self
+                    if other.contains(x) != True]), other))
 
         return None
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -454,6 +454,12 @@ def test_contains():
     assert RootOf(x**5 + x**3 + 1, 0) in S.Reals
     assert not RootOf(x**5 + x**3 + 1, 1) in S.Reals
 
+    # non-bool results
+    assert Union(Interval(1, 2), Interval(3, 4)).contains(x) == \
+        Or(And(x <= 2, x >= 1), And(x <= 4, x >= 3))
+    assert Intersection(Interval(1, x), Interval(2, 3)).contains(y) == \
+        And(y <= 3, y <= x, y >= 1, y >= 2)
+
 
 def test_interval_symbolic():
     x = Symbol('x')

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -291,7 +291,6 @@ def test_issue_9954():
     assert isolve(x**2 < 0, x, relational=True) == S.EmptySet.as_relational(x)
 
 
-@slow
 def test_slow_general_univariate():
     r = RootOf(x**5 - x**2 + 1, 0)
     assert solve(sqrt(x) + 1/root(x, 3) > 1) == \
@@ -299,12 +298,11 @@ def test_slow_general_univariate():
 
 
 def test_issue_8545():
-    from sympy import refine
     eq = 1 - x - abs(1 - x)
     ans = And(Lt(1, x), Lt(x, oo))
     assert reduce_abs_inequality(eq, '<', x) == ans
     eq = 1 - x - sqrt((1 - x)**2)
-    assert reduce_inequalities(refine(eq) < 0) == ans
+    assert reduce_inequalities(eq < 0) == ans
 
 
 def test_issue_8974():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -17,7 +17,7 @@ from sympy.polys.rootoftools import RootOf
 
 from sympy.sets import (FiniteSet, ConditionSet)
 
-from sympy.utilities.pytest import XFAIL, raises, skip
+from sympy.utilities.pytest import XFAIL, raises, skip, slow
 from sympy.utilities.randtest import verify_numerically as tn
 from sympy.physics.units import cm
 
@@ -421,6 +421,7 @@ def test_solve_sqrt_fail():
     assert solveset_real(eq, x) == FiniteSet(S(1)/3)
 
 
+@slow
 def test_solve_sqrt_3():
     R = Symbol('R')
     eq = sqrt(2)*R*sqrt(1/(R + 1)) + (R + 1)*(sqrt(2)*sqrt(1/(R + 1)) - 1)
@@ -439,7 +440,10 @@ def test_solve_sqrt_3():
     eq = -sqrt((m - q)**2 + (-m/(2*q) + S(1)/2)**2) + sqrt((-m**2/2 - sqrt(
         4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2 + (m**2/2 - m - sqrt(
             4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2)
-    unsolved_object = ConditionSet(q, Eq((-2*sqrt(4*q**2*(m - q)**2 + (-m + q)**2) + sqrt((-2*m**2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1) - 1)**2 + (2*m**2 - 4*m - sqrt(4*m**4 - 4*m**2 + 8*m + 1) - 1)**2)*Abs(q))/Abs(q), 0), S.Reals)
+    unsolved_object = ConditionSet(q, Eq((-2*sqrt(4*q**2*(m - q)**2 +
+        (-m + q)**2) + sqrt((-2*m**2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1) -
+        1)**2 + (2*m**2 - 4*m - sqrt(4*m**4 - 4*m**2 + 8*m + 1) - 1)**2
+        )*Abs(q))/Abs(q), 0), S.Reals)
     assert solveset_real(eq, q) == unsolved_object
 
 


### PR DESCRIPTION
The test added identifies and issue with testing with "is true" instead of "== True" in the sets module. 
In master, the Intersection gives EmptySet because geometry returns True rather than true.

I have tried to change all such cases in sets to use True/False instead of assume that the `true` value will be returned by any comparison.
