### PR TITLE
subs cannot target RootOf args

### DIFF
--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -2,7 +2,7 @@ from __future__ import division
 from sympy import (Symbol, Wild, sin, cos, exp, sqrt, pi, Function, Derivative,
         abc, Integer, Eq, symbols, Add, I, Float, log, Rational, Lambda, atan2,
         cse, cot, tan, S, Tuple, Basic, Dict, Piecewise, oo, Mul,
-        factor, nsimplify, zoo, Subs)
+        factor, nsimplify, zoo, Subs, RootOf)
 from sympy.core.basic import _aresame
 from sympy.utilities.pytest import XFAIL
 from sympy.abc import x, y, z
@@ -657,3 +657,10 @@ def test_pow_eval_subs_no_cache():
     # It incorrectly returned 1/sqrt(x**2) before this pull request.
     result = s.subs(sqrt(x**2), y)
     assert result == 1/y
+
+
+def test_RootOf_issue_10092():
+    x = Symbol('x', real=True)
+    eq = x**3 - 17*x**2 + 81*x - 118
+    r = RootOf(eq, 0)
+    assert (x < r).subs(x, r) is S.false

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -530,6 +530,10 @@ class RootOf(Expr):
             reals_count = len(_reals_cache[self.poly])
             _complexes_cache[self.poly][self.index - reals_count] = interval
 
+    def _eval_subs(self, old, new):
+        # don't allow subs to change anything
+        return self
+
     def _eval_evalf(self, prec):
         """Evaluate this complex root to the given precision. """
         with workprec(prec):

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -291,7 +291,6 @@ def test_issue_9954():
     assert isolve(x**2 < 0, x, relational=True) == S.EmptySet.as_relational(x)
 
 
-@slow
 def test_slow_general_univariate():
     r = RootOf(x**5 - x**2 + 1, 0)
     assert solve(sqrt(x) + 1/root(x, 3) > 1) == \
@@ -299,12 +298,11 @@ def test_slow_general_univariate():
 
 
 def test_issue_8545():
-    from sympy import refine
     eq = 1 - x - abs(1 - x)
     ans = And(Lt(1, x), Lt(x, oo))
     assert reduce_abs_inequality(eq, '<', x) == ans
     eq = 1 - x - sqrt((1 - x)**2)
-    assert reduce_inequalities(refine(eq) < 0) == ans
+    assert reduce_inequalities(eq < 0) == ans
 
 
 def test_issue_8974():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -17,7 +17,7 @@ from sympy.polys.rootoftools import RootOf
 
 from sympy.sets import (FiniteSet, ConditionSet)
 
-from sympy.utilities.pytest import XFAIL, raises, skip
+from sympy.utilities.pytest import XFAIL, raises, skip, slow
 from sympy.utilities.randtest import verify_numerically as tn
 from sympy.physics.units import cm
 
@@ -421,6 +421,7 @@ def test_solve_sqrt_fail():
     assert solveset_real(eq, x) == FiniteSet(S(1)/3)
 
 
+@slow
 def test_solve_sqrt_3():
     R = Symbol('R')
     eq = sqrt(2)*R*sqrt(1/(R + 1)) + (R + 1)*(sqrt(2)*sqrt(1/(R + 1)) - 1)
@@ -439,7 +440,10 @@ def test_solve_sqrt_3():
     eq = -sqrt((m - q)**2 + (-m/(2*q) + S(1)/2)**2) + sqrt((-m**2/2 - sqrt(
         4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2 + (m**2/2 - m - sqrt(
             4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2)
-    unsolved_object = ConditionSet(q, Eq((-2*sqrt(4*q**2*(m - q)**2 + (-m + q)**2) + sqrt((-2*m**2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1) - 1)**2 + (2*m**2 - 4*m - sqrt(4*m**4 - 4*m**2 + 8*m + 1) - 1)**2)*Abs(q))/Abs(q), 0), S.Reals)
+    unsolved_object = ConditionSet(q, Eq((-2*sqrt(4*q**2*(m - q)**2 +
+        (-m + q)**2) + sqrt((-2*m**2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1) -
+        1)**2 + (2*m**2 - 4*m - sqrt(4*m**4 - 4*m**2 + 8*m + 1) - 1)**2
+        )*Abs(q))/Abs(q), 0), S.Reals)
     assert solveset_real(eq, q) == unsolved_object
 
 


### PR DESCRIPTION
TODO
- [ ] check that `r = RootOf(..); r.subs(r, foo)` still works

closes #10092 

RootOf should be treated like a literal and should not allow subs to target any of its args. Even a change of variables is meaningless since RootOf caches the expression used at instantiation:

in master:

```
>>> RootOf(x**3-2*x**2+x-1,0)
RootOf(x**3 - 2*x**2 + x - 1, 0)
>>> RootOf((x**3-2*x**2+x-1).subs(x,var('y')),0)
RootOf(x**3 - 2*x**2 + x - 1, 0)
```

It would be possible to allow targetting of the root number with an integer (but if the integer is wrong, an error will be raised). Please feel free to make suggestions.
