### PR TITLE
Fixed trivial typo

### DIFF
--- a/doc/src/tutorial/basic_operations.rst
+++ b/doc/src/tutorial/basic_operations.rst
@@ -190,7 +190,7 @@ dictionary of ``sympy_name:numerical_function`` pairs.  For example
 
     >>> def mysin(x):
     ...     """
-    ...     My sine. Not only accurate for small x.
+    ...     My sine. Note that this is only accurate for small x.
     ...     """
     ...     return x
     >>> f = lambdify(x, expr, {"sin":mysin})


### PR DESCRIPTION
The comment in the last code sample was wrong.

It said sin(x) == x is not valid for small x, but the opposite is true.
