### PR TITLE
Added condition for base_vectors() pretty printing 

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1590,8 +1590,8 @@ class PrettyPrinter(Printer):
         s = None
 
         for item in seq:
-	    if str(type(item))=="<class 'sympy.vector.vector.BaseVector'>" :
-	    	item=str(item)
+            if str(type(item))=="<class 'sympy.vector.vector.BaseVector'>" :
+                item=str(item)
 
             pform = self._print(item)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1590,6 +1590,9 @@ class PrettyPrinter(Printer):
         s = None
 
         for item in seq:
+	    if str(type(item))=="<class 'sympy.vector.vector.BaseVector'>" :
+	    	item=str(item)
+
             pform = self._print(item)
 
             if parenthesize(item):


### PR DESCRIPTION
issue #10044. pprint for base_vectors() handled by adding condition for base_vectors() in which case output for pretty printing is first converted to string so that height function in https://github.com/manipalsingh013/sympy/blob/master/sympy/printing/pretty/stringpict.py#L47 does not have to evaluate for fake object.

Output getting after adding condition:

> > > from sympy.vector import *
> > > from sympy import *
> > > N=CoordSysCartesian('N')
> > > pprint(N.base_vectors())
> > > (N.i, N.j, N.k)
