### PR TITLE
Shortcut cancelling fractions with integer one for issue #9341

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6284,6 +6284,12 @@ def cancel(f, *gens, **args):
             return f
         f = factor_terms(f, radical=True)
         p, q = f.as_numer_denom()
+        # Integer unity is the multiplication unit in both the ring of
+        # integers and the ring of polynomials, hence cannot possibly be
+        # canceled.
+        one = Integer(1)
+        if p == one or q == one:
+            return p / q
 
     elif len(f) == 2:
         p, q = f


### PR DESCRIPTION
Fractions with integer one in either the numerator or the denominator
would make it possible to cancel out any common factor from the
numerator and the denominator.  However, in the current implementation,
there is no special treatment for this situation.  The computation of
the GCD with integer one would take a long time by using the Euclidean
algorithm, as in the issue #9341.

As a result, in this commit, when called with expressions, the cancel
function will directly return the quotient when an integer unity is
found.  This could solve issue #9314.  And when the function is called
with polynomials directly or called with tuples, this short-cut will not
be invoked to better preserve its original behaviour in internal use.
