### PR TITLE
empty dimensions are represented as dimension objects instead of 1

### DIFF
--- a/sympy/physics/unitsystems/dimensions.py
+++ b/sympy/physics/unitsystems/dimensions.py
@@ -264,12 +264,8 @@ class Dimension(Expr):
                 d[key] = other[key]
         d = Dimension(d)
 
-        # if all dimensions are zero, then return 1 so that there is no more
-        # dimensions
-        if d.is_dimensionless:
-            return 1
-        else:
-            return d
+
+        return d
 
     def div(self, other):
         if not isinstance(other, Dimension):
@@ -284,10 +280,7 @@ class Dimension(Expr):
                 d[key] = -other[key]
         d = Dimension(d)
 
-        if d.is_dimensionless:
-            return 1
-        else:
-            return d
+        return d
 
     def rdiv(self, other):
         return other * pow(self, -1)

--- a/sympy/physics/unitsystems/simplifiers.py
+++ b/sympy/physics/unitsystems/simplifiers.py
@@ -27,17 +27,25 @@ def dim_simplify(expr):
             arg = dim_simplify(arg)
         args.append(arg)
 
+    if all([arg.is_number or (isinstance(arg, Dimension) and arg.is_dimensionless) for arg in args]):
+        return Dimension({})
+
     if isinstance(expr, Pow):
-        return args[0].pow(args[1])
+        if isinstance(args[0], Dimension):
+            return args[0].pow(args[1])
+        else:
+            raise ValueError("Basis of Pow is not a Dimension: %s" % args[0])
     elif isinstance(expr, Add):
-        args = [arg for arg in args if isinstance(arg, Dimension)]
-        return reduce(lambda x, y: x.add(y), args)
+        if (all(isinstance(arg, Dimension) for arg in args) or
+            all(arg.is_dimensionless() for arg in args if isinstance(arg, Dimension))):
+            return reduce(lambda x, y: x.add(y), args)
+        else:
+            raise ValueError("Dimensions cannot be added: %s" % expr)
     elif isinstance(expr, Mul):
         args = [arg for arg in args if isinstance(arg, Dimension)]
         return reduce(lambda x, y: x.mul(y), args)
-    else:
-        return expr
 
+    raise ValueError("Cannot be simplifed: %s", expr)
 
 def qsimplify(expr):
     """

--- a/sympy/physics/unitsystems/tests/test_simplifiers.py
+++ b/sympy/physics/unitsystems/tests/test_simplifiers.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from sympy import Add, Pow, Mul
+from sympy import Add, Pow, Mul, sin
 
 from sympy.physics.unitsystems.simplifiers import dim_simplify, qsimplify
 from sympy.physics.unitsystems.quantities import Quantity as Q
@@ -25,6 +25,9 @@ def test_dim_simplify_pow():
 
 def test_dim_simplify_rec():
     assert dim_simplify(Mul(Add(L, L), T)) == L.mul(T)
+
+def test_dim_simplify_dimless():
+    assert dim_simplify(Mul(Pow(sin(Mul(L, Pow(L,-1))), 2),L)) == L
 
 
 m, s = mks["m"], mks["s"]

--- a/sympy/physics/unitsystems/units.py
+++ b/sympy/physics/unitsystems/units.py
@@ -167,7 +167,7 @@ class Unit(Expr):
             else:
                 factor = (self.factor**other).evalf()
                 dim = self.dim.pow(other)
-                if dim == 1:
+                if dim.is_dimensionless:
                     return factor
                 else:
                     return Unit(dim, factor=factor)
@@ -182,7 +182,7 @@ class Unit(Expr):
         elif isinstance(other, Unit):
             factor = self.factor * other.factor
             dim = self.dim.mul(other.dim)
-            if dim == 1:
+            if dim.is_dimensionless:
                 return factor
             else:
                 return Unit(dim, factor=factor)
@@ -204,7 +204,7 @@ class Unit(Expr):
         elif isinstance(other, Unit):
             factor = self.factor / other.factor
             dim = self.dim.div(other.dim)
-            if dim == 1:
+            if dim.is_dimensionless:
                 return factor
             else:
                 return Unit(dim, factor=factor)


### PR DESCRIPTION
This resolves the following problem:

```
>>> dim_simplify(Dimension({"length":-2})*Dimension({"length":2})+1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files\Miniconda\lib\site-packages\sympy\physics\unitsystems\simplifiers.py", line 34, in dim_simplify
    return reduce(lambda x, y: x.add(y), args)
TypeError: reduce() of empty sequence with no initial value
```

@melsophos I can understand that it makes sense to return simple numbers instead of quantities or units if they are dimensionless. This is because both are a combination of a dimension and a number, if there is no dimension all that rests is a number. But for dimensions, representing the "empty dimension" as 1 does imho not make sense, because other numbers like 0 or 2 would also be plausible representatives of the empty dimension.

So I propose the approach followed in this pull request: dimensionless units or quantities are represented as simple numbers like before, but the empty dimension is represented as a dimension object.
