### PR TITLE
Speed up GCD evaluation of unity DMP

### DIFF
--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -898,6 +898,7 @@ def _dmp_rr_trivial_gcd(f, g, u, K):
     """Handle trivial cases in GCD algorithm over a ring. """
     zero_f = dmp_zero_p(f, u)
     zero_g = dmp_zero_p(g, u)
+    if_contain_one = dmp_one_p(f, u, K) or dmp_one_p(g, u, K)
 
     if zero_f and zero_g:
         return tuple(dmp_zeros(3, u, K))
@@ -911,6 +912,8 @@ def _dmp_rr_trivial_gcd(f, g, u, K):
             return f, dmp_one(u, K), dmp_zero(u)
         else:
             return dmp_neg(f, u, K), dmp_ground(-K.one, u), dmp_zero(u)
+    elif if_contain_one:
+        return dmp_one(u, K), f, g
     elif query('USE_SIMPLIFY_GCD'):
         return _dmp_simplify_gcd(f, g, u, K)
     else:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6284,6 +6284,12 @@ def cancel(f, *gens, **args):
             return f
         f = factor_terms(f, radical=True)
         p, q = f.as_numer_denom()
+        # Integer unity is the multiplication unit in both the ring of
+        # integers and the ring of polynomials, hence cannot possibly be
+        # canceled.
+        one = Integer(1)
+        if p == one or q == one:
+            return p / q
 
     elif len(f) == 2:
         p, q = f

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6284,12 +6284,6 @@ def cancel(f, *gens, **args):
             return f
         f = factor_terms(f, radical=True)
         p, q = f.as_numer_denom()
-        # Integer unity is the multiplication unit in both the ring of
-        # integers and the ring of polynomials, hence cannot possibly be
-        # canceled.
-        one = Integer(1)
-        if p == one or q == one:
-            return p / q
 
     elif len(f) == 2:
         p, q = f


### PR DESCRIPTION
Using cancel on large polynomials could be very slow due to the evaluation of the GCD of the numerator and the denominator (issue #9341).  Now in the existing trivial case treatment function of GCD computation for DMPs, unity is added as a special case as well to speed it up.  Different from the flawed solution in PR #10108, this solution does not seem to affect the result in any way, and does pass all the tests.
