### PR TITLE
Fix incorrect assignment of free variables in linsolve

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4338,7 +4338,7 @@ class MatrixBase(object):
 
         # Get index of free symbols (free parameters)
         free_var_index = permutation[len(pivots):]  # non-pivots columns are free variables
-        
+
         # Free parameters
         dummygen = numbered_symbols("tau", Dummy)
         tau = Matrix([next(dummygen) for k in range(col - rank)]).reshape(col - rank, 1)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4336,12 +4336,9 @@ class MatrixBase(object):
         if not v[rank:, 0].is_zero:
             raise ValueError("Linear system has no solution")
 
-        # Get index of free symbols (free parameter)
-        free_var_index = []
-        for r in range(col):
-            if r not in pivots:
-                free_var_index.append(r)  # non-pivots columns are free variables
-
+        # Get index of free symbols (free parameters)
+        free_var_index = permutation[len(pivots):]  # non-pivots columns are free variables
+        
         # Free parameters
         dummygen = numbered_symbols("tau", Dummy)
         tau = Matrix([next(dummygen) for k in range(col - rank)]).reshape(col - rank, 1)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -976,6 +976,11 @@ def test_linsolve():
     b = Matrix([0, 0, 1])
     assert linsolve((A, b), (x, y, z)) == EmptySet()
 
+    # Issue #10121 - Assignment of free variables
+    a, b, c, d, e = symbols('a, b, c, d, e')
+    Augmatrix = Matrix([[0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0]])
+    assert linsolve(Augmatrix, a, b, c, d, e) == FiniteSet((a, 0, c, 0, e))
+
 
 def test_issue_9556():
     x = Symbol('x')


### PR DESCRIPTION
Fixes #10121. 

To briefly summarise that issue: For certain undetermined systems `linsolve` was incorrectly assigning free variables to each other:

``` python
a, b, c, d, e = symbols('a, b, c, d, e')
Augmatrix = Matrix([[0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0]])
linsolve(Augmatrix, a, b, c, d, e)
```

would give `{(c, 0, a, 0, e)}` whereas the correct answer is of course `{(a, 0, c, 0, e)}`.

The first commit solves this problem by setting the `free_var_index` to be the correctly permuted free variable indices in `gauss_jordan_solve`, and the second adds in the test above.
