### PR TITLE
Issue #9910 removing sin(x) in order as x tends to infinity

### DIFF
--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -211,6 +211,9 @@ class Order(Expr):
 
             if expr.is_Add:
                 lst = expr.extract_leading_order(args)
+                if point[0] is S.Infinity:
+                    if any(f.expr.subs(value,S.Infinity)==S.Infinity for (e,f) in lst for value in s.itervalues()):
+                        lst = [(e,f) for (e,f) in lst for value in s.itervalues() if f.expr.subs(value,S.Infinity) == S.Infinity]
                 expr = Add(*[f.expr for (e, f) in lst])
 
             elif expr:

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -212,7 +212,7 @@ class Order(Expr):
             if expr.is_Add:
                 lst = expr.extract_leading_order(args)
                 if point[0] is S.Infinity:
-                    if any(f.expr.subs(value,S.Infinity)==S.Infinity for (e,f) in lst for value in s.itervalues()):
+                    if any(f.expr.subs(value,S.Infinity)==S.Infinity or S.Infinity in f.expr.subs(value,S.Infinity).args for (e,f) in lst for value in s.itervalues()):
                         lst = [(e,f) for (e,f) in lst for value in s.itervalues() if f.expr.subs(value,S.Infinity) == S.Infinity]
                 expr = Add(*[f.expr for (e, f) in lst])
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -213,7 +213,7 @@ class Order(Expr):
                 lst = expr.extract_leading_order(args)
                 if point[0] is S.Infinity:
                     if any(f.expr.subs(value,S.Infinity)==S.Infinity or S.Infinity in f.expr.subs(value,S.Infinity).args for (e,f) in lst for value in s.itervalues()):
-                        lst = [(e,f) for (e,f) in lst for value in s.itervalues() if f.expr.subs(value,S.Infinity) == S.Infinity]
+                        lst = [(e,f) for (e,f) in lst for value in s.itervalues() if f.expr.subs(value,S.Infinity) == S.Infinity  or S.Infinity in f.expr.subs(value,S.Infinity).args and f.expr.is_Mul]
                 expr = Add(*[f.expr for (e, f) in lst])
 
             elif expr:

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -410,3 +410,7 @@ def test_order_subs_limits():
 def test_issue_9192():
     assert O(1)*O(1) == O(1)
     assert O(1)**O(1) == O(1)
+
+def test_issue_9910():
+    assert Order(x*log(x) + sin(x), (x, oo)) == Order(x*log(x), (x, oo))
+    assert Order(x*log(x) + sin(x) + y*log(y) + sin(y), (x, oo), (y,oo)) == Order(x*log(x) + y*log(y), (x, oo), (y,oo))

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -414,4 +414,4 @@ def test_issue_9192():
 def test_issue_9910():
     assert Order(x*log(x) + sin(x), (x, oo)) == Order(x*log(x), (x, oo))
     assert Order(x*log(x) + sin(x) + y*log(y) + sin(y), (x, oo), (y,oo)) == Order(x*log(x) + y*log(y), (x, oo), (y,oo))
-    assert Order(x*log(x) + x**2*sin(x), (x, oo)) == Order(x*log(x), (x, oo))
+    assert Order(x*log(x) + x**2*sin(x), (x, oo)) == Order(x*log(x)+ x**2*sin(x), (x, oo))

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -414,3 +414,4 @@ def test_issue_9192():
 def test_issue_9910():
     assert Order(x*log(x) + sin(x), (x, oo)) == Order(x*log(x), (x, oo))
     assert Order(x*log(x) + sin(x) + y*log(y) + sin(y), (x, oo), (y,oo)) == Order(x*log(x) + y*log(y), (x, oo), (y,oo))
+    assert Order(x*log(x) + x**2*sin(x), (x, oo)) == Order(x*log(x), (x, oo))


### PR DESCRIPTION
Fixes Issue #9910. I have added a couple of tests to verify that it fixes the issue. 
The problem here seems to be that extract_leading_term never removes sin(x). So I've added some conditions which check for terms which do not go to infinity when there are other terms which goes to infinity (if the order is to be evaluated at infinity). Please correct me if I have missed something.
