### PR TITLE
Fix args invariants in sympy.strategies 

### DIFF
--- a/sympy/strategies/rl.py
+++ b/sympy/strategies/rl.py
@@ -155,6 +155,6 @@ def rebuild(expr):
     Basic.__new__
     """
     try:
-        return type(expr)(*list(map(rebuild, expr.args)))
+        return expr.func(*list(map(rebuild, expr.args)))
     except Exception:
         return expr

--- a/sympy/strategies/tests/test_rl.py
+++ b/sympy/strategies/tests/test_rl.py
@@ -1,6 +1,6 @@
 from sympy.strategies.rl import (rm_id, glom, flatten, unpack, sort, distribute,
         subs, rebuild)
-from sympy import Basic
+from sympy import Basic, Q, symbols
 
 def test_rm_id():
     rmzeros = rm_id(lambda x: x == 0)
@@ -57,3 +57,8 @@ def test_rebuild():
     from sympy import Add
     expr = Basic.__new__(Add, 1, 2)
     assert rebuild(expr) == 3
+
+def test_rebuild_func():
+    x = symbols('x')
+    # rebuild uses expr.func
+    assert rebuild(Q.positive(x)) == Q.positive(x)

--- a/sympy/strategies/util.py
+++ b/sympy/strategies/util.py
@@ -11,7 +11,7 @@ def assoc(d, k, v):
 
 basic_fns = {'op': type,
              'new': Basic.__new__,
-             'leaf': lambda x: not isinstance(x, Basic) or x.is_Atom,
+             'leaf': lambda x: not isinstance(x, Basic) or not x.args,
              'children': lambda x: x.args}
 
 expr_fns = assoc(basic_fns, 'new', lambda op, *args: op(*args))


### PR DESCRIPTION
The args invariants should be that you rebuild an expression with `expr.func`, not `type(expr)`, and that a leaf expression has empty args (not `is_Atom`). 
