### PR TITLE
Make integrate work with _diff_wrt expressions

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -26,7 +26,7 @@ def _process_limits(*symbols):
     limits = []
     orientation = 1
     for V in symbols:
-        if isinstance(V, Symbol):
+        if isinstance(V, Symbol) or getattr(V, '_diff_wrt', False):
             limits.append(Tuple(V))
             continue
         elif isinstance(V, Idx):
@@ -37,7 +37,7 @@ def _process_limits(*symbols):
             continue
         elif is_sequence(V, Tuple):
             V = sympify(flatten(V))
-            if isinstance(V[0], (Symbol, Idx)):
+            if isinstance(V[0], (Symbol, Idx)) or getattr(V[0], '_diff_wrt', False):
                 newsymbol = V[0]
                 if len(V) == 2 and isinstance(V[1], Interval):
                     V[1:] = [V[1].start, V[1].end]

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,10 +1,10 @@
 from sympy import (
-    Abs, acos, acosh, Add, asin, asinh, atan, Ci, cos, sinh, cosh, tanh,
-    Derivative, diff, DiracDelta, E, exp, erf, erfi, EulerGamma, factor, Function,
-    I, Integral, integrate, Interval, Lambda, LambertW, log,
-    Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify, sin, tan, sqrt,
-    sstr, Sum, Symbol, symbols, sympify, trigsimp,
-    Tuple, nan, And, Eq, Ne, re, im, polar_lift, meijerg
+    Abs, acos, acosh, Add, asin, asinh, atan, Ci, cos, sinh,
+    cosh, tanh, Derivative, diff, DiracDelta, E, exp, erf, erfi, EulerGamma,
+    Expr, factor, Function, I, Integral, integrate, Interval, Lambda,
+    LambertW, log, Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify,
+    sin, tan, sqrt, sstr, Sum, Symbol, symbols, sympify, trigsimp, Tuple, nan,
+    And, Eq, Ne, re, im, polar_lift, meijerg,
 )
 from sympy.functions.elementary.complexes import periodic_argument
 from sympy.integrals.risch import NonElementaryIntegral
@@ -95,6 +95,18 @@ def test_basics():
     n = Symbol('n', commutative=False)
     assert Integral(n + x, x).is_commutative is False
 
+
+def test_diff_wrt():
+    class Test(Expr):
+        _diff_wrt = True
+        is_commutative = True
+
+    t = Test()
+    assert integrate(t + 1, t) == t**2/2 + t
+    assert integrate(t + 1, (t, 0, 1)) == S(3)/2
+
+    raises(ValueError, lambda: integrate(x + 1, x + 1))
+    raises(ValueError, lambda: integrate(x + 1, (x + 1, 0, 1)))
 
 def test_basics_multiple():
 


### PR DESCRIPTION
They work with diff, so it makes sense that they should also work with
integrate().
