### PR TITLE
Add xreplace method to matrices

### DIFF
--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -158,6 +158,8 @@ class ImmutableSparseMatrix(Basic, SparseMatrix):
 
     subs = MatrixBase.subs
 
+    xreplace = MatrixBase.xreplace
+
     def __hash__(self):
         return hash((type(self).__name__,) + (self.shape, tuple(self._smat)))
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1169,6 +1169,23 @@ class MatrixBase(object):
         """
         return self.applyfunc(lambda x: x.subs(*args, **kwargs))
 
+    def xreplace(self, rule):  # should mirror core.basic.xreplace
+        """Return a new matrix with xreplace applied to each entry.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import x, y
+        >>> from sympy.matrices import SparseMatrix, Matrix
+        >>> SparseMatrix(1, 1, [x])
+        Matrix([[x]])
+        >>> _.xreplace({x: y})
+        Matrix([[y]])
+        >>> Matrix(_).xreplace({y: x})
+        Matrix([[x]])
+        """
+        return self.applyfunc(lambda x: x.xreplace(rule))
+
     def expand(self, deep=True, modulus=None, power_base=True, power_exp=True,
             mul=True, log=True, multinomial=True, basic=True, **hints):
         """Apply core.function.expand to each entry of the matrix.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -942,6 +942,13 @@ def test_subs():
     for cls in classes:
         assert Matrix([[2, 0], [0, 2]]) == cls.eye(2).subs(1, 2)
 
+def test_xreplace():
+    assert Matrix([[1, x], [x, 4]]).xreplace({x: 5}) == \
+        Matrix([[1, 5], [5, 4]])
+    assert Matrix([[x, 2], [x + y, 4]]).xreplace({x: -1, y: -2}) == \
+        Matrix([[-1, 2], [-3, 4]])
+    for cls in classes:
+        assert Matrix([[2, 0], [0, 2]]) == cls.eye(2).xreplace({1: 2})
 
 def test_simplify():
     f, n = symbols('f, n')


### PR DESCRIPTION
Add xreplace method to matrices which applies xreplace to each of the matrix elements, like the already implemented subs method (in fact the code is just a copy paste of the subs method _mutatis mutandis_).

@moorepants 
