### PR TITLE
Change subs to xreplace in linsolve

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1251,7 +1251,7 @@ def linsolve(system, *symbols):
     if params:
         for s in sol:
             for k, v in enumerate(params):
-                s = s.subs(v, symbols[free_syms[k]])
+                s = s.xreplace({v: symbols[free_syms[k]]})
             solution.append(s)
 
     else:


### PR DESCRIPTION
`linsolve` currently uses subs to replace the dummy free variables from `gauss_jordan_solve` by the input free variables, where all that is needed is the faster `xreplace`.

@moorepants  @aktech 
