### PR TITLE
refactor Intersection.reduce for efficiency and correctness

### DIFF
--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -64,11 +64,23 @@ def fuzzy_bool(x):
     """Return True, False or None according to x.
 
     Whereas bool(x) returns True or False, fuzzy_bool allows
-    for the None value.
+    for the None value and non-false values (which become None), too.
+
+    Examples
+    ========
+
+    >>> from sympy.core.logic import fuzzy_bool
+    >>> from sympy.abc import x
+    >>> fuzzy_bool(x), fuzzy_bool(None)
+    (None, None)
+    >>> bool(x), bool(None)
+    (True, False)
+
     """
     if x is None:
         return None
-    return bool(x)
+    if x in (True, False):
+        return bool(x)
 
 
 def fuzzy_and(args):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1813,7 +1813,7 @@ class FiniteSet(Set, EvalfMixin):
         """
         if isinstance(other, self.__class__):
             return self.__class__(*(self._elements & other._elements))
-        return self.__class__(el for el in self if el in other)
+        return self.__class__(*[el for el in self if el in other])
 
     def _complement(self, other):
         if isinstance(other, Interval):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -919,7 +919,7 @@ def test_issue_Symbol_inter():
     assert Intersection(FiniteSet(m, n, x), FiniteSet(m, z), r) == \
         Intersection(r, FiniteSet(m, z), FiniteSet(n, x))
     assert Intersection(FiniteSet(m, n, 3), FiniteSet(m, n, x), r) == \
-        Intersection(r, FiniteSet(x), FiniteSet(3, m, n), evaluate=False)
+        Intersection(r, FiniteSet(3, m, n), evaluate=False)
     assert Intersection(FiniteSet(m, n, 3), FiniteSet(m, n, 2, 3), r) == \
         Union(FiniteSet(3), Intersection(r, FiniteSet(m, n)))
     assert Intersection(r, FiniteSet(mat, 2, n), FiniteSet(0, mat, n)) == \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -222,6 +222,7 @@ def test_intersect():
     assert Interval(0, 2).intersect(Union(Interval(0, 1), Interval(2, 3))) == \
         Union(Interval(0, 1), Interval(2, 2))
 
+    assert FiniteSet(1, 2)._intersect((1, 2, 3)) == FiniteSet(1, 2)
     assert FiniteSet(1, 2, x).intersect(FiniteSet(x)) == FiniteSet(x)
     assert FiniteSet('ham', 'eggs').intersect(FiniteSet('ham')) == \
         FiniteSet('ham')


### PR DESCRIPTION
fixes #10165 and avoids over-computing `contains` for elements
