### PR TITLE
Possible replacement of findpoly(xv,1) by pslq([xv,1]) in nsimplify

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1166,7 +1166,7 @@ def nsimplify(expr, constants=[], tolerance=None, full=False, rational=None):
             # We'll be happy with low precision if a simple fraction
             if not (tolerance or full):
                 mpmath.mp.dps = 15
-                rat = mpmath.findpoly(xv, 1)
+                rat = mpmath.pslq([xv, 1])
                 if rat is not None:
                     return Rational(-int(rat[1]), int(rat[0]))
             mpmath.mp.dps = prec


### PR DESCRIPTION
Just noticed that nsimplify contains the line:

```
rat = mpmath.findpoly(xv, 1)
```

which may easely be replaced by

```
rat = mpmath.pslq([xv, 1])
```

with exactly the same precision, returned results, etc. without the need of an useless extra call. While I agree that findpoly may be (slightly) clearer when reading the code, I think that computing PSLQ([x,1]) for detecting a rational number (which is what findpoly will do anyway) is a very common operation which should be understandable at this location.

Of course, this doesn't make it really quicker from the user-point-of-view, but why not take the simplest version?
