### PR TITLE
Made tm_sympy compatable with python2 and 3

### DIFF
--- a/data/TeXmacs/bin/tm_sympy
+++ b/data/TeXmacs/bin/tm_sympy
@@ -69,7 +69,7 @@ _greek = 'alpha beta gamma delta epsilon zeta eta '  \
          'sigma tau upsilon phi chi psi omega'
 
 for _symbol in _greek.split(' '):
-    exec "%s = Symbol('%s')" % (_symbol, _symbol)
+    exec("%s = Symbol('%s')" % (_symbol, _symbol))
 
 del _symbol
 """


### PR DESCRIPTION
exec requires parenthesis in python3 and they are optional in python2.  This change makes the texmacs plugin work for both python2 and python3.
