### PR TITLE
Add support for ITE in ccode

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -211,6 +211,9 @@ class CCodePrinter(CodePrinter):
             last_line = ": (\n%s\n)" % self._print(expr.args[-1].expr)
             return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
+    def _print_ITE(self, expr):
+        return "((%s) ? (\n%s\n) : (\n%s\n))" % tuple(map(self._print, expr.args))
+
     def _print_MatrixElement(self, expr):
         return "{0}[{1}]".format(expr.parent, expr.j +
                 expr.i*expr.parent.shape[1])

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -212,7 +212,9 @@ class CCodePrinter(CodePrinter):
             return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
     def _print_ITE(self, expr):
-        return "((%s) ? (\n%s\n) : (\n%s\n))" % tuple(map(self._print, expr.args))
+        from sympy.functions import Piecewise
+        _piecewise = Piecewise((expr.args[1], expr.args[0]), (expr.args[2], True))
+        return self._print(_piecewise)
 
     def _print_MatrixElement(self, expr):
         return "{0}[{1}]".format(expr.parent, expr.j +

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -194,7 +194,8 @@ def test_ccode_ITE():
     assert ccode(expr) == (
             "((x < 1) ? (\n"
             "   x\n"
-            ") : (\n"
+            ")\n"
+            ": (\n"
             "   pow(x, 2)\n"
             "))")
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -2,6 +2,7 @@ from sympy.core import (pi, oo, symbols, Rational, Integer,
                         GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq)
 from sympy.functions import (Piecewise, sin, cos, Abs, exp, ceiling, sqrt,
                              gamma, sign)
+from sympy.logic import ITE
 from sympy.utilities.pytest import raises
 from sympy.printing.ccode import CCodePrinter
 from sympy.utilities.lambdify import implemented_function
@@ -186,6 +187,16 @@ def test_ccode_Piecewise_deep():
             ": (\n"
             "   1\n"
             ")) + cos(z) - 1;")
+
+
+def test_ccode_ITE():
+    expr = ITE(x < 1, x, x**2)
+    assert ccode(expr) == (
+            "((x < 1) ? (\n"
+            "   x\n"
+            ") : (\n"
+            "   pow(x, 2)\n"
+            "))")
 
 
 def test_ccode_settings():


### PR DESCRIPTION
See e.g. http://stackoverflow.com/questions/34121023/generate-c-code-for-sympy-expression-e1-op-e2-where-op-is-an-arithmetic-compar
