### PR TITLE
Set iterable(MatrixExpr) to False

### DIFF
--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -39,6 +39,8 @@ class AskSymmetricHandler(CommonHandler):
         if all(ask(Q.symmetric(arg), assumptions) for arg in mmul.args):
             return True
         if len(mmul.args) >= 2 and mmul.args[0] == mmul.args[-1].T:
+            if len(mmul.args) == 2:
+                return True
             return ask(Q.symmetric(MatMul(*mmul.args[1:-1])), assumptions)
 
     @staticmethod

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -209,6 +209,12 @@ def iterable(i, exclude=(string_types, dict, NotIterable)):
     You can also set the _iterable attribute to True or False on your class,
     which will override the checks here, including the exclude test.
 
+    As a rule of thumb, some SymPy functions use this to check if they should
+    recursively map over an object. If an object is technically iterable in
+    the Python sense but does not desire this behavior (e.g., because its
+    iteration is not finite, or because iteration might induce an unwanted
+    computation), it should disable it by setting the _iterable attribute to False.
+
     See also: is_sequence
 
     Examples

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -206,6 +206,9 @@ def iterable(i, exclude=(string_types, dict, NotIterable)):
     by default. If you want a pure Python definition, make exclude=None. To
     exclude multiple items, pass them as a tuple.
 
+    You can also set the _iterable attribute to True or False on your class,
+    which will override the checks here, including the exclude test.
+
     See also: is_sequence
 
     Examples
@@ -233,6 +236,8 @@ def iterable(i, exclude=(string_types, dict, NotIterable)):
     False
 
     """
+    if hasattr(i, '_iterable'):
+        return i._iterable
     try:
         iter(i)
     except TypeError:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2390,6 +2390,11 @@ def count_ops(expr, visual=False):
             args = [expr]
             while args:
                 a = args.pop()
+
+                # XXX: This is a hack to support non-Basic args
+                if isinstance(a, string_types):
+                    continue
+
                 if a.args:
                     o = Symbol(a.func.__name__.upper())
                     if a.is_Boolean:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2300,7 +2300,8 @@ def count_ops(expr, visual=False):
         while args:
             a = args.pop()
 
-            if isinstance(a, str):
+            # XXX: This is a hack to support non-Basic args
+            if isinstance(a, string_types):
                 continue
 
             if a.is_Rational:

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -1,4 +1,5 @@
-from sympy.core.compatibility import default_sort_key, as_int, ordered, iterable
+from sympy.core.compatibility import (default_sort_key, as_int, ordered,
+    iterable, NotIterable)
 from sympy.core.singleton import S
 from sympy.utilities.pytest import raises
 
@@ -24,6 +25,36 @@ def test_iterable():
     assert iterable(1) is False
     assert iterable(None) is False
 
+    class Test1(NotIterable):
+        pass
+
+    assert iterable(Test1()) is False
+
+    class Test2(NotIterable):
+        _iterable = True
+
+    assert iterable(Test2()) is True
+
+    class Test3(object):
+        pass
+
+    assert iterable(Test3()) is False
+
+    class Test4(object):
+        _iterable = True
+
+    assert iterable(Test4()) is True
+
+    class Test5(object):
+        def __iter__(self):
+            yield 1
+
+    assert iterable(Test5()) is True
+
+    class Test6(Test5):
+        _iterable = False
+
+    assert iterable(Test6()) is False
 
 def test_ordered():
     # Issue 7210 - this had been failing with python2/3 problems

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -122,7 +122,7 @@ def test_issue_9324():
     assert count(2 * M[0, 0] + M[5, 7]) == 2
     P = MatrixSymbol('P', 3, 3)
     Q = MatrixSymbol('Q', 3, 3)
-    assert count(P + Q) == 9
+    assert count(P + Q) == 3
     m = Symbol('m', integer=True)
     n = Symbol('n', integer=True)
     M = MatrixSymbol('M', m + n, m * m)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -50,6 +50,11 @@ class MatrixExpr(Basic):
         Inverse
     """
 
+    # Should not be considered iterable by the
+    # sympy.core.compatibility.iterable function. Subclass that actually are
+    # iterable (i.e., explicit matrices) should set this to True.
+    _iterable = False
+
     _op_priority = 11.0
 
     is_Matrix = True

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -36,6 +36,8 @@ class MatMul(MatrixExpr):
         factor, matrices = obj.as_coeff_matrices()
         if check:
             validate(*matrices)
+        if not matrices:
+            return factor
         return obj
 
     @property

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -114,6 +114,15 @@ class MatMul(MatrixExpr):
             args = self.args
         return canonicalize(MatMul(*args))
 
+    # Needed for partial compatibility with Mul
+    def args_cnc(self, **kwargs):
+        coeff, matrices = self.as_coeff_matrices()
+        # I don't know how coeff could have noncommutative factors, but this
+        # handles it.
+        coeff_c, coeff_nc = coeff.args_cnc(**kwargs)
+
+        return coeff_c, coeff_nc + matrices
+
 def validate(*matrices):
     """ Checks for valid shapes for args of MatMul """
     for i in range(len(matrices)-1):

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -122,3 +122,8 @@ def test_matmul_no_matrices():
     assert MatMul(1) == 1
     assert MatMul(n, m) == n*m
     assert not isinstance(MatMul(n, m), MatMul)
+
+def test_matmul_args_cnc():
+    a, b = symbols('a b', commutative=False)
+    assert MatMul(n, a, b, A, A.T).args_cnc() == ([n], [a, b, A, A.T])
+    assert MatMul(A, A.T).args_cnc() == ([1], [A, A.T])

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -117,3 +117,8 @@ def test_collapse_MatrixBase():
 
 def test_refine():
     assert refine(C*C.T*D, Q.orthogonal(C)).doit() == D
+
+def test_matmul_no_matrices():
+    assert MatMul(1) == 1
+    assert MatMul(n, m) == n*m
+    assert not isinstance(MatMul(n, m), MatMul)

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -32,6 +32,10 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     TypeError: Cannot set values of ImmutableDenseMatrix
     """
 
+    # MatrixExpr is set as NotIterable, but we want explicit matrices to be
+    # iterable
+    _iterable = True
+
     _class_priority = 8
 
     @classmethod

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -87,7 +87,7 @@ def apart(f, x=None, full=False, **options):
         # non-commutative
         if f.is_Mul:
             c, nc = f.args_cnc(split_1=False)
-            nc = f.func(*[apart(i, x=x, full=full, **_options) for i in nc])
+            nc = f.func(*nc)
             if c:
                 c = apart(f.func._from_args(c), x=x, full=full, **_options)
                 return c*nc

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -9,7 +9,7 @@ from sympy.polys.partfrac import (
 
 from sympy import (S, Poly, E, pi, I, Matrix, Eq, RootSum, Lambda,
                    Symbol, Dummy, factor, together, sqrt, Expr)
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, XFAIL
 from sympy.abc import x, y, a, b, c
 
 
@@ -147,7 +147,9 @@ def test_assemble_partfrac_list():
     assert assemble_partfrac_list(pfd) == -1/(sqrt(2)*(x + sqrt(2))) + 1/(sqrt(2)*(x - sqrt(2)))
 
 
+@XFAIL
 def test_noncommutative_pseudomultivariate():
+    # apart doesn't go inside noncommutative expressions
     class foo(Expr):
         is_commutative=False
     e = x/(x + x*y)
@@ -155,6 +157,12 @@ def test_noncommutative_pseudomultivariate():
     assert apart(e + foo(e)) == c + foo(c)
     assert apart(e*foo(e)) == c*foo(c)
 
+def test_noncommutative():
+    class foo(Expr):
+        is_commutative=False
+    e = x/(x + x*y)
+    c = 1/(1 + y)
+    assert apart(e + foo()) == c + foo()
 
 def test_issue_5798():
     assert apart(

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -171,6 +171,9 @@ def opt_cse(exprs, order='canonical'):
 
     def _find_opts(expr):
 
+        if not isinstance(expr, Basic):
+            return
+
         if expr.is_Atom or expr.is_Order:
             return
 
@@ -286,6 +289,9 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
     seen_subexp = set()
 
     def _find_repeated(expr):
+        if not isinstance(expr, Basic):
+            return
+
         if expr.is_Atom or expr.is_Order:
             return
 
@@ -317,6 +323,8 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
     subs = dict()
 
     def _rebuild(expr):
+        if not isinstance(expr, Basic):
+            return expr
 
         if not expr.args:
             return expr

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -162,6 +162,7 @@ def opt_cse(exprs, order='canonical'):
     >>> print(opt_subs)
     {x**(-2): 1/(x**2)}
     """
+    from sympy.matrices.expressions import MatAdd, MatMul, MatPow
     opt_subs = dict()
 
     adds = set()
@@ -194,13 +195,13 @@ def opt_cse(exprs, order='canonical'):
                 seen_subexp.add(neg_expr)
                 expr = neg_expr
 
-        if expr.is_Mul:
+        if isinstance(expr, (Mul, MatMul)):
             muls.add(expr)
 
-        elif expr.is_Add:
+        elif isinstance(expr, (Add, MatAdd)):
             adds.add(expr)
 
-        elif expr.is_Pow:
+        elif isinstance(expr, (Pow, MatPow)):
             if _coeff_isneg(expr.exp):
                 opt_subs[expr] = Pow(Pow(expr.base, -expr.exp), S.NegativeOne,
                                      evaluate=False)
@@ -250,9 +251,13 @@ def opt_cse(exprs, order='canonical'):
     for m in muls:
         c, nc = m.args_cnc(cset=True)
         if c:
-            c_mul = Mul(*c)
+            c_mul = m.func(*c)
             if nc:
-                opt_subs[m] = Mul(c_mul, Mul(*nc), evaluate=False)
+                if c_mul == 1:
+                    new_obj = m.func(*nc)
+                else:
+                    new_obj = m.func(c_mul, m.func(*nc), evaluate=False)
+                opt_subs[m] = new_obj
             if len(c) > 1:
                 comutative_muls.add(c_mul)
 
@@ -279,6 +284,8 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
         The order by which Mul and Add arguments are processed. For large
         expressions where speed is a concern, use the setting order='none'.
     """
+    from sympy.matrices.expressions import MatrixExpr, MatrixSymbol, MatMul, MatAdd
+
     if opt_subs is None:
         opt_subs = dict()
 
@@ -343,10 +350,13 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
         # If enabled, parse Muls and Adds arguments by order to ensure
         # replacement order independent from hashes
         if order != 'none':
-            if expr.is_Mul:
+            if isinstance(expr, (Mul, MatMul)):
                 c, nc = expr.args_cnc()
-                args = list(ordered(c)) + nc
-            elif expr.is_Add:
+                if c == [1]:
+                    args = nc
+                else:
+                    args = list(ordered(c)) + nc
+            elif isinstance(expr, (Add, MatAdd)):
                 args = list(ordered(expr.args))
             else:
                 args = expr.args
@@ -364,6 +374,11 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
                 sym = next(symbols)
             except StopIteration:
                 raise ValueError("Symbols iterator ran out of symbols.")
+
+            if isinstance(orig_expr, MatrixExpr):
+                sym = MatrixSymbol(sym.name, orig_expr.rows,
+                    orig_expr.cols)
+
             subs[orig_expr] = sym
             replacements.append((sym, new_expr))
             return sym

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -9,6 +9,7 @@ from sympy.simplify import cse_main, cse_opts
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.matrices import (eye, SparseMatrix, MutableDenseMatrix,
     MutableSparseMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix)
+from sympy.matrices.expressions import MatrixSymbol
 
 from sympy.core.compatibility import range
 
@@ -293,8 +294,17 @@ def test_cse_Indexed():
     assert len(replacements) > 0
 
 
-@XFAIL
 def test_cse_MatrixSymbol():
+    # MatrixSymbols have non-Basic args, so make sure that works
+    A = MatrixSymbol("A", 3, 3)
+    assert cse(A) == ([], [A])
+
+    n = symbols('n', integer=True)
+    B = MatrixSymbol("B", n, n)
+    assert cse(B) == ([], [B])
+
+@XFAIL
+def test_cse_MatrixExpr():
     from sympy import MatrixSymbol
     A = MatrixSymbol('A', 3, 3)
     y = MatrixSymbol('y', 3, 1)

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -303,7 +303,6 @@ def test_cse_MatrixSymbol():
     B = MatrixSymbol("B", n, n)
     assert cse(B) == ([], [B])
 
-@XFAIL
 def test_cse_MatrixExpr():
     from sympy import MatrixSymbol
     A = MatrixSymbol('A', 3, 3)
@@ -314,6 +313,11 @@ def test_cse_MatrixExpr():
     replacements, reduced_exprs = cse([expr1, expr2])
     assert len(replacements) > 0
 
+    replacements, reduced_exprs = cse([expr1 + expr2, expr1])
+    assert replacements
+
+    replacements, reduced_exprs = cse([A**2, A + A**2])
+    assert replacements
 
 def test_Piecewise():
     f = Piecewise((-z + x*y, Eq(y, 0)), (-z - x*y, True))


### PR DESCRIPTION
And various related fixes.

The ultimate goal here is to fix

```
In [1]: cse(MatrixSymbol('x', n, n))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-7e35fd07952a> in <module>()
----> 1 cse(MatrixSymbol('x', n, n))

/Users/aaronmeurer/Documents/Python/sympy/sympy-scratch/sympy/simplify/cse_main.py in cse(exprs, symbols, optimizations, postprocess, order)
    486     # Main CSE algorithm.
    487     replacements, reduced_exprs = tree_cse(reduced_exprs, symbols, opt_subs,
--> 488                                            order)
    489
    490     # Postprocess the expressions to return the expressions to canonical form.

/Users/aaronmeurer/Documents/Python/sympy/sympy-scratch/sympy/simplify/cse_main.py in tree_cse(exprs, symbols, opt_subs, order)
    367     for e in exprs:
    368         if isinstance(e, Basic):
--> 369             reduced_e = _rebuild(e)
    370         else:
    371             reduced_e = e

/Users/aaronmeurer/Documents/Python/sympy/sympy-scratch/sympy/simplify/cse_main.py in _rebuild(expr)
    324         if iterable(expr):
    325             new_args = [_rebuild(arg) for arg in expr]
--> 326             return expr.func(*new_args)
    327
    328         if expr in subs:

TypeError: __new__() missing 3 required positional arguments: 'name', 'n', and 'm'
```

However, this change required many other fixes, as many functions were only working with MatrixSymbol objects because they thought it was iterable, and `list(MatrixSymbol)` gave `[]`. 

@smichr the first commit here partly reverts a change you made a while ago. 
