### PR TITLE
Replaced 'repr' with 'srepr' in the tutorial 

### DIFF
--- a/doc/src/tutorial/printing.rst
+++ b/doc/src/tutorial/printing.rst
@@ -120,7 +120,7 @@ exactly the same as the expression as you would enter it.
     Integral(sqrt(1/x), x)
 
 srepr
-----
+-----
 
 The srepr form of an expression is designed to show the exact form of an
 expression.  It will be discussed more in the :ref:`tutorial-manipulation`

--- a/doc/src/tutorial/printing.rst
+++ b/doc/src/tutorial/printing.rst
@@ -14,7 +14,7 @@ Printers
 There are several printers available in SymPy.  The most common ones are
 
 - str
-- repr
+- srepr
 - ASCII pretty printer
 - Unicode pretty printer
 - LaTeX
@@ -119,17 +119,17 @@ exactly the same as the expression as you would enter it.
     >>> print(Integral(sqrt(1/x), x))
     Integral(sqrt(1/x), x)
 
-repr
+srepr
 ----
 
-The repr form of an expression is designed to show the exact form of an
+The srepr form of an expression is designed to show the exact form of an
 expression.  It will be discussed more in the :ref:`tutorial-manipulation`
 section.  To get it, use ``srepr()`` [#srepr-fn]_.
 
     >>> srepr(Integral(sqrt(1/x), x))
     "Integral(Pow(Pow(Symbol('x'), Integer(-1)), Rational(1, 2)), Tuple(Symbol('x')))"
 
-The repr form is mostly useful for understanding how an expression is built
+The srepr form is mostly useful for understanding how an expression is built
 internally.
 
 
@@ -231,8 +231,8 @@ printer.
 
 .. rubric:: Footnotes
 
-.. [#srepr-fn] SymPy does not use the Python builtin ``repr()`` function for
-   repr printing, because in Python ``str(list)`` calls ``repr()`` on the
+.. [#srepr-fn] SymPy does not use the Python builtin ``srepr()`` function for
+   srepr printing, because in Python ``str(list)`` calls ``srepr()`` on the
    elements of the list, and some SymPy functions return lists (such as
    ``solve()``).  Since ``srepr()`` is so verbose, it is unlikely that anyone
    would want it called by default on the output of ``solve()``.

--- a/doc/src/tutorial/printing.rst
+++ b/doc/src/tutorial/printing.rst
@@ -231,8 +231,8 @@ printer.
 
 .. rubric:: Footnotes
 
-.. [#srepr-fn] SymPy does not use the Python builtin ``srepr()`` function for
-   srepr printing, because in Python ``str(list)`` calls ``srepr()`` on the
+.. [#srepr-fn] SymPy does not use the Python builtin ``repr()`` function for
+   repr printing, because in Python ``str(list)`` calls ``repr()`` on the
    elements of the list, and some SymPy functions return lists (such as
    ``solve()``).  Since ``srepr()`` is so verbose, it is unlikely that anyone
    would want it called by default on the output of ``solve()``.


### PR DESCRIPTION
Fixes #10185
