### PR TITLE
Update .mailmap and AUTHORS

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -108,6 +108,7 @@ Marek Šuppa <mr@shu.io> mr.Shu <mr@shu.io>
 Prasoon Shukla <prasoon92.iitr@gmail.com> prasoon2211 <prasoon92.iitr@gmail.com>
 Sachin Joglekar <srjoglekar246@gmail.com> srjoglekar246 <srjoglekar246@gmail.com>
 Sachin Joglekar <srjoglekar246@gmail.com> root <root@sachin-Inspiron-5520.(none)>
+Sachin Joglekar <srjoglekar246@gmail.com> Sachin <srjoglekar246@gmail.com>
 Stefen Yin <zqyin@ucdavis.edu> StefenYin <zqyin@ucdavis.edu>
 Manoj Kumar <manojkumarsivaraj334@gmail.com> Manoj-Kumar-S <manojkumarsivaraj334@gmail.com>
 Benjamin Fishbein <fishbeinb@gmail.com> fishbeinb <fishbeinb@gmail.com>
@@ -152,6 +153,7 @@ Aditya Shah <adityashah30@gmail.com> adityashah30 <adityashah30@gmail.com>
 Rajat Aggarwal <rajataggarwal1975@gmail.com> rajat974 <rajataggarwal1975@gmail.com>
 Patrick Poitras <acebulf@gmail.com> Acebulf <acebulf@gmail.com>
 Thomas Hisch <t.hisch@gmail.com> Thomas Hisch <thomas.hisch@ims.co.at>
+Thomas Hisch <t.hisch@gmail.com> Thomas Hisch <thomas.hisch@tuwien.ac.at>
 Sushant Hiray <hiraysushant@gmail.com> sushant <hiraysushant@gmail.com>
 Anurag Sharma <anurags92@gmail.com> anurags92 <sharmaan@iitk.ac.in>
 Jim Crist <crist042@umn.edu> jcrist <crist042@umn.edu>
@@ -190,3 +192,28 @@ Jayesh Lahori <jlahori92@gmail.com> jayesh92 <jlahori92@gmail.com>
 Lokesh Sharma <lokeshhsharma@gmail.com> Firstname Lastname <your_email@youremail.com>
 Aaditya Nair <aadityanair6494@gmail.com> Aaditya M Nair <aadityanair6494@gmail.com>
 AMiT Kumar <dtu.amit@gmail.com> Amit Kumar <dtu.amit@gmail.com>
+Shivam Vats <shivamvats.iitkgp@gmail.com> Shivam Vats <aries@aries-Inspiron-3521.(none)>
+Ramana Venkata <idlike2dream@gmail.com> Ramana Venkata <vramana@users.noreply.github.com>
+Peleg Michaeli <freepeleg@gmail.com> Peleg Michaeli <peleg@palgo-at.com>
+Kyle McDaniel <mcdanie5@illinois.edu> Kyle McDaniel <mcdaniel221@gmail.com>
+Kaushik Varanasi <kaushik.varanasi1@gmail.com> kaushik94 <kaushik.varanasi1@gmail.com>
+Kalevi Suominen <jksuom@gmail.com> Kalevi Suominen <kalevi.suominen@helsinki.fi>
+Dustin Gadal <Dustin.Gadal@gmail.com> Gadal <Dustin.Gadal@gmail.com>
+Francesco Bonazzi <franz.bonazzi@gmail.com> Francesco Bonazzi <francesco.bonazzi@mpikg.mpg.de>
+Colin B. Macdonald <macdonald@maths.ox.ac.uk> Colin Macdonald <cbm@m.fsf.org>
+Chai Wah Wu <cwwuieee@gmail.com> Chai Wah Wu <postvakje@users.noreply.github.com>
+Adam Bloomston <adam@glitterfram.es> Adam Bloomston <mail@adambloomston>
+Alex Lindsay <adlinds3@ncsu.edu> Alex Lindsay <lindsayad@users.noreply.github.com>
+Devyani Kota <devyanikota@gmail.com> Devyani Kota <divs.passion.18@gmail.com>
+Alec Kalinin <alec.kalinin@gmail.com> Alexander Kalinin <alec.kalinin@gmail.com>
+Konstantin Togoi <konstantin.togoi@gmail.com> Konstantin Togoi <togoi.konstantin@outlook.com>
+Longqi Wang <iqgnol@gmail.com> WANG Longqi <iqgnol@gmail.com>
+Jennifer White <jcrw122@googlemail.com> jennifercw <jcrw122@googlemail.com>
+Jack Kemp <metaknightdrake-git@yahoo.co.uk> Jack Kemp <kempj@tplxdt003.nat.physics.ox.ac.uk>
+Guillaume Gay <contact@damcb.com> Guillaume Gay <guillaume@mitotic-machine.org>
+Gregory Ashton <gash789@gmail.com> Greg Ashton - LianLi <ga7g08@soton.ac.uk>
+Prashant Tyagi <prashanttyagi221295@gmail.com> tyagi-prashant <prashanttyagi221295@gmail.com>
+Philippe Bouafia <philippe.bouafia@ensea.fr> vizietto <philippe.bouafia@ensea.fr>
+Juha Remes <jremes@outlook.com> newman101 <jremes@outlook.com>
+Matthew Davis <davisml.md@gmail.com> mlda065 <mlda065@cse.unsw.edu.au>
+Vinay <csvinay.d@gmail.com> Vinay <vinay.035.kumar@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -108,79 +108,81 @@ Cristóvão Sousa <crisjss@gmail.com>
 Andre de Fortier Smit <freevryheid@gmail.com>
 Mark Dewing <markdewing@gmail.com>
 Alexey U. Gudchenko <proga@goodok.ru>
+Raymond Wong <rayman_407@yahoo.com>
 Gary Kerr <gary.kerr@blueyonder.co.uk>
 Sherjil Ozair <sherjilozair@gmail.com>
 Oleksandr Gituliar <gituliar@gmail.com>
 Sean Vig <sean.v.775@gmail.com>
 Prafullkumar P. Tale <hector1618@gmail.com>
 Vladimir Perić <vlada.peric@gmail.com>
-Tom Bachmann <e_mc_h2@web.de>
 Yuri Karadzhov <yuri.karadzhov@gmail.com>
+Jeremias Yehdegho <j.yehdegho@gmail.com>
+Tom Bachmann <e_mc_h2@web.de>
 Vladimir Lagunov <werehuman@gmail.com>
+Jack McCaffery <jpmccaffery@gmail.com>
 Matthew Rocklin <mrocklin@cs.uchicago.edu>
 Saptarshi Mandal <sapta.iitkgp@gmail.com>
 Gilbert Gede <gilbertgede@gmail.com>
+Benjamin McDonald <mcdonald.ben@gmail.com>
 Anatolii Koval <weralwolf@gmail.com>
 Tomo Lazovich <lazovich@gmail.com>
 Pavel Fedotov <fedotovp@gmail.com>
 Kibeom Kim <kk1674@nyu.edu>
 Gregory Ksionda <ksiondag846@gmail.com>
 Tomáš Bambas <tomas.bambas@gmail.com>
-Jeremias Yehdegho <j.yehdegho@gmail.com>
-Jack McCaffery <jpmccaffery@gmail.com>
-Raymond Wong <rayman_407@yahoo.com>
 Luca Weihs <astronomicalcuriosity@gmail.com>
+Óscar Nájera <najera.oscar@gmail.com>
 Shai 'Deshe' Wyborski <shaide@cs.huji.ac.il>
 Thomas Wiecki <thomas.wiecki@gmail.com>
-Óscar Nájera <najera.oscar@gmail.com>
 Mario Pernici <mario.pernici@gmail.com>
-Benjamin McDonald <mcdonald.ben@gmail.com>
 Sam Magura <samtheman132@gmail.com>
 Stefan Krastanov <krastanov.stefan@gmail.com>
 Bradley Froehle <brad.froehle@gmail.com>
 Min Ragan-Kelley <benjaminrk@gmail.com>
-Nikhil Sarda <diff.operator@gmail.com>
 Emma Hogan <ehogan@gemini.edu>
-Jason Moore <moorepants@gmail.com>
+Nikhil Sarda <diff.operator@gmail.com>
 Julien Rioux <julien.rioux@gmail.com>
 Roberto Colistete, Jr. <roberto.colistete@gmail.com>
 Raoul Bourquin <raoulb@bluewin.ch>
 Gert-Ludwig Ingold <gert.ingold@physik.uni-augsburg.de>
-Srinivas Vasudevan <srvasude@gmail.com>
+Jason Moore <moorepants@gmail.com>
 Miha Marolt <tloramus@gmail.com>
+Srinivas Vasudevan <srvasude@gmail.com>
 Tim Lahey <tim.lahey@gmail.com>
 Luis Garcia <ppn.online@me.com>
-Matt Rajca <matt.rajca@me.com>
 David Li <l33tnerd.li@gmail.com>
-David Ju <Sgtmook314@gmail.com>
-Alexandr Gudulin <alexandr.gudulin@gmail.com>
 Bilal Akhtar <bilalakhtar@ubuntu.com>
+Matt Rajca <matt.rajca@me.com>
+Alexandr Gudulin <alexandr.gudulin@gmail.com>
 Grzegorz Świrski <sognat@gmail.com>
 Matt Habel <habelinc@gmail.com>
-Nikolay Lazarov <qwerqwerqwer@abv.bg>
-Nichita Utiu <nikita.utiu+github@gmail.com>
-Tristan Hume <tris.hume@gmail.com>
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
-Steve Anton <anxuiz.nx@gmail.com>
-Sam Sleight <samuel.sleight@gmail.com>
-tsmars15 <ts_borisova@abv.bg>
+David Ju <Sgtmook314@gmail.com>
+Nichita Utiu <nikita.utiu+github@gmail.com>
+Nikolay Lazarov <qwerqwerqwer@abv.bg>
 Chancellor Arkantos <Chancellor_Arkantos@hotmail.co.uk>
-Stepan Simsa <simsa.st@gmail.com>
-Tobias Lenz <t_lenz94@web.de>
 Siddhanathan Shanmugam <siddhanathan@gmail.com>
+Sam Sleight <samuel.sleight@gmail.com>
+Steve Anton <anxuiz.nx@gmail.com>
+Ljubiša Moćić <3rdslasher@gmail.com>
+Piotr Korgul <p.korgul@gmail.com>
+Tobias Lenz <t_lenz94@web.de>
+tsmars15 <ts_borisova@abv.bg>
+Stepan Simsa <simsa.st@gmail.com>
 Tiffany Zhu <bubble.wubble.303@gmail.com>
-Alexey Subach <alexey.subach@gmail.com>
+Tristan Hume <tris.hume@gmail.com>
 Joan Creus <joan.creus.c@gmail.com>
 Geoffry Song <goffrie@gmail.com>
+Alexey Subach <alexey.subach@gmail.com>
 Puneeth Chaganti <punchagan@gmail.com>
 Marcin Kostrzewa <>
 Jim Zhang <Hyriodula@gmail.com>
+Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
 Natalia Nawara <fankalemura@gmail.com>
+Kendhia <kendhia@gmail.com>
 vishal <vishal.panjwani15@gmail.com>
 Shruti Mangipudi <shruti2395@gmail.com>
-Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
-Kendhia <kendhia@gmail.com>
 jerryma1121 <jerryma1121@gmail.com>
 Joachim Durchholz <jo@durchholz.org>
 Martin Povišer <martin.povik@gmail.com>
@@ -190,240 +192,267 @@ Michael Mayorov <marchael@kb.csu.ru>
 Nathan Alison <nathan.f.alison@gmail.com>
 Christian Bühler <christian@cbuehler.de>
 Carsten Knoll <CarstenKnoll@gmx.de>
-Bharath M R <catchmrbharath@gmail.com>
 Matthias Toews <mat.toews@googlemail.com>
+Bharath M R <catchmrbharath@gmail.com>
 Sergiu Ivanov <unlimitedscolobb@gmail.com>
+Rom le Clair <jacen.guardian@gmail.com>
 Jorge E. Cardona <jorgeecardona@gmail.com>
 Sanket Agarwal <sanket@sanketagarwal.com>
+Raphael Michel <webmaster@raphaelmichel.de>
 Manoj Babu K. <manoj.babu2378@gmail.com>
 Sai Nikhil <tsnlegend@gmail.com>
 Aleksandar Makelov <amakelov@college.harvard.edu>
-Raphael Michel <webmaster@raphaelmichel.de>
+Prateek Papriwal <papriwalprateek@gmail.com>
 Sachin Irukula <sachin.irukula@gmail.com>
+marshall2389 <marshall2389@gmail.com>
+Angadh Nanjangud <angadh.n@gmail.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
 Andreas Kloeckner <inform@tiker.net>
-Prateek Papriwal <papriwalprateek@gmail.com>
 Arpit Goyal <agmps18@gmail.com>
-Angadh Nanjangud <angadh.n@gmail.com>
+Alexandr Popov <alexandr.s.popov@gmail.com>
+Guru Devanla <grdvnl@gmail.com>
 Comer Duncan <comer.duncan@gmail.com>
 Jens H. Nielsen <jenshnielsen@gmail.com>
 Joseph Dougherty <Github@JWDougherty.com>
-marshall2389 <marshall2389@gmail.com>
-Guru Devanla <grdvnl@gmail.com>
 George Waksman <waksman@gwax.com>
-Angus Griffith <16sn6uv@gmail.com>
-Timothy Reluga <treluga@math.psu.edu>
-Brian Stephanik <xoedusk@gmail.com>
-Ljubiša Moćić <3rdslasher@gmail.com>
-Piotr Korgul <p.korgul@gmail.com>
-Rom le Clair <jacen.guardian@gmail.com>
-Alexandr Popov <alexandr.s.popov@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
 Tarun Gaba <tarun.gaba7@gmail.com>
 Takafumi Arakaki <aka.tkf@gmail.com>
+Timothy Reluga <treluga@math.psu.edu>
+Angus Griffith <16sn6uv@gmail.com>
+Brian Stephanik <xoedusk@gmail.com>
 Alexander Eberspächer <alex.eberspaecher@gmail.com>
+Matthew Hoff <mhoff14@gmail.com>
 Sachin Joglekar <srjoglekar246@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Colleen Lee <colleenclee@gmail.com>
-Niklas Thörne <notrupertthorne@gmail.com>
 Huijun Mai <m.maihuijun@gmail.com>
+Niklas Thörne <notrupertthorne@gmail.com>
+Ramana Venkata <idlike2dream@gmail.com>
 Marek Šuppa <mr@shu.io>
-Prasoon Shukla <prasoon92.iitr@gmail.com>
 Stefen Yin <zqyin@ucdavis.edu>
-Thomas Hisch <t.hisch@gmail.com>
-Matthew Hoff <mhoff14@gmail.com>
-Madeleine Ball <mpball@gmail.com>
-Case Van Horsen <casevh@gmail.com>
-Mary Clark <mary.spriteling@gmail.com>
-Rishabh Dixit <rishabhdixit11@gmail.com>
-Patrick Poitras <acebulf@gmail.com>
-Manoj Kumar <manojkumarsivaraj334@gmail.com>
-Akshit Agarwal <akshit.jiit@gmail.com>
+Prasoon Shukla <prasoon92.iitr@gmail.com>
 CJ Carey <perimosocordiae@gmail.com>
+Case Van Horsen <casevh@gmail.com>
+Chris Conley <chrisconley15@gmail.com>
+Thomas Hisch <t.hisch@gmail.com>
 Patrick Lacasse <patrick.m.lacasse@gmail.com>
+Rishabh Dixit <rishabhdixit11@gmail.com>
+Madeleine Ball <mpball@gmail.com>
+Manoj Kumar <manojkumarsivaraj334@gmail.com>
+Mary Clark <mary.spriteling@gmail.com>
+Akshit Agarwal <akshit.jiit@gmail.com>
 Ananya H <ananyaha93@gmail.com>
-Tarang Patel <tarangrockr@gmail.com>
 Christopher Dembia <cld72@cornell.edu>
-Benjamin Fishbein <fishbeinb@gmail.com>
+Tarang Patel <tarangrockr@gmail.com>
+David Joyner <wdjoyner@gmail.com>
+Manish Gill <gill.manish90@gmail.com>
 Sean Ge <seange727@gmail.com>
+Benjamin Fishbein <fishbeinb@gmail.com>
 Ankit Agrawal <aaaagrawal@iitb.ac.in>
 Amit Jamadagni <bitsjamadagni@gmail.com>
-Björn Dahlgren <bjodah@gmail.com>
 Christophe Saint-Jean <christophe.saint-jean@univ-lr.fr>
+Björn Dahlgren <bjodah@gmail.com>
+Yuriy Demidov <iurii.demidov@gmail.com>
 Demian Wassermann <demian@bwh.harvard.edu>
 Khagesh Patel <khageshpatel93@gmail.com>
-Stephen Loo <shikil@yahoo.com>
 hm <hacman0@gmail.com>
+Stephen Loo <shikil@yahoo.com>
+Patrick Poitras <acebulf@gmail.com>
+Thilina Rathnayake <thilinarmtb@gmail.com>
+Roland Puntaier <roland.puntaier@chello.at>
 Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
 Varun Joshi <joshi.142@osu.edu>
-Chetna Gupta <cheta.gup@gmail.com>
-Thilina Rathnayake <thilinarmtb@gmail.com>
 Shravas K Rao <shravas@gmail.com>
+Chetna Gupta <cheta.gup@gmail.com>
 Max Hutchinson <maxhutch@gmail.com>
+Oliver Lee <oliverzlee@gmail.com>
+Fawaz Alazemi <Mba7eth@gmail.com>
 Matthew Tadd <matt.tadd@gmail.com>
 Alexander Hirzel <alex@hirzel.us>
 Randy Heydon <randy.heydon@clockworklab.net>
-Ramana Venkata <idlike2dream@gmail.com>
-Oliver Lee <oliverzlee@gmail.com>
+Dmitry Batkovich <batya239@gmail.com>
+Eric Nelson <eric.the.red.XLII@gmail.com>
 Seshagiri Prabhu <seshagiriprabhu@gmail.com>
+Rick Muller <rpmuller@gmail.com>
 Pradyumna <pradyu1993@gmail.com>
 Erik Welch <erik.n.welch@gmail.com>
-Eric Nelson <eric.the.red.XLII@gmail.com>
-Roland Puntaier <roland.puntaier@chello.at>
-Chris Conley <chrisconley15@gmail.com>
 Tim Swast <tswast@gmail.com>
-Dmitry Batkovich <batya239@gmail.com>
 Francesco Bonazzi <franz.bonazzi@gmail.com>
-Yuriy Demidov <iurii.demidov@gmail.com>
-Rick Muller <rpmuller@gmail.com>
-Manish Gill <gill.manish90@gmail.com>
 Markus Müller <markus.mueller.1.g@googlemail.com>
 Amit Saha <amitsaha.in@gmail.com>
 Jeremy <twobitlogic@gmail.com>
 QuaBoo <kisonchristian@gmail.com>
+David P. Sanders <dpsanders@gmail.com>
+rathmann <rathmann.os@gmail.com>
 Stefan van der Walt <stefan@sun.ac.za>
-David Joyner <wdjoyner@gmail.com>
-Lars Buitinck <larsmans@gmail.com>
 Alkiviadis G. Akritas <akritas@uth.gr>
-Vinit Ravishankar <vinit.ravishankar@gmail.com>
-Mike Boyle <boyle@astro.cornell.edu>
-Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com>
+Lars Buitinck <larsmans@gmail.com>
 Pablo Puente <ppuedom@gmail.com>
 James Fiedler <jrfiedler@gmail.com>
+Mike Boyle <boyle@astro.cornell.edu>
+Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com>
+Vinit Ravishankar <vinit.ravishankar@gmail.com>
 Harsh Gupta <gupta.harsh96@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
-rathmann <rathmann.os@gmail.com>
 Paul Strickland <p.e.strickland@gmail.com>
 James Goppert <james.goppert@gmail.com>
-Avichal Dayal <avichal.dayal@gmail.com>
-Paul Scott <paul.scott@nicta.com.au>
 Shipra Banga <bangashipra@gmail.com>
+Paul Scott <paul.scott@nicta.com.au>
+Venkatesh Halli <venkatesh.fatality@gmail.com>
+Avichal Dayal <avichal.dayal@gmail.com>
+Robert Johansson <jrjohansson@gmail.com>
+Jonathan Miller <jdmiller93@gmail.com>
 Pramod Ch <pramodch14@gmail.com>
 Akshay <akshaynukala95@gmail.com>
 Buck Shlegeris <buck2@bruceh15.anu.edu.au>
-Jonathan Miller <jdmiller93@gmail.com>
 Edward <eschemb1@jhu.edu>
+Dammina Sahabandu <dmsahabandu@gmail.com>
 Rajath S <rajaths.rajaths@gmail.com>
-Aditya Shah <adityashah30@gmail.com>
-Sambuddha Basu <sammygamer@live.com>
+Anurag Sharma <anurags92@gmail.com>
+Vlad Seghete <vlad.seghete@gmail.com>
 Zeel Shah <kshah215@gmail.com>
+Aditya Shah <adityashah30@gmail.com>
+Rajat Aggarwal <rajataggarwal1975@gmail.com>
+Sambuddha Basu <sammygamer@live.com>
 Abhinav Chanda <abhinavchanda01@gmail.com>
 Jim Crist <crist042@umn.edu>
 Sudhanshu Mishra <mrsud94@gmail.com>
-Rajat Aggarwal <rajataggarwal1975@gmail.com>
-Soumya Dipta Biswas <sdb1323@gmail.com>
-Anurag Sharma <anurags92@gmail.com>
-Sushant Hiray <hiraysushant@gmail.com>
-Ben Lucato <ben.lucato@gmail.com>
-Kunal Arora <kunalarora.135@gmail.com>
 Henry Gebhardt <hsggebhardt@gmail.com>
-Dammina Sahabandu <dmsahabandu@gmail.com>
+Kunal Arora <kunalarora.135@gmail.com>
+Juan Luis Cano Rodríguez <juanlu001@gmail.com>
+Soumya Dipta Biswas <sdb1323@gmail.com>
+Ben Lucato <ben.lucato@gmail.com>
+Sushant Hiray <hiraysushant@gmail.com>
+John Connor <john.theman.connor@gmail.com>
+Sahil Shekhawat <sahilshekhawat01@gmail.com>
+Stas Kelvich <stanconn@gmail.com>
+Maciej Baranski <getrox.sc@gmail.com>
+Kalevi Suominen <jksuom@gmail.com>
+shashank-agg <shashank.agarwal94@gmail.com>
+sevaader <sevaader@gmail.com>
+Zamrath Nizam <zamiguy_ni@yahoo.com>
 Shukla <shukla@ubuntu.ubuntu-domain>
 Ralph Bean <rbean@redhat.com>
 richierichrawr <richierichrawr@users.noreply.github.com>
-John Connor <john.theman.connor@gmail.com>
-Juan Luis Cano Rodríguez <juanlu001@gmail.com>
-Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Kundan Kumar <kundankumar18581@gmail.com>
-Stas Kelvich <stanconn@gmail.com>
-sevaader <sevaader@gmail.com>
 Dhruvesh Vijay Parikh <parikhdhruvesh1@gmail.com>
-Venkatesh Halli <venkatesh.fatality@gmail.com>
 Lennart Fricke <lennart@die-frickes.eu>
-Vlad Seghete <vlad.seghete@gmail.com>
-shashank-agg <shashank.agarwal94@gmail.com>
+Peter Brady <petertbrady@gmail.com>
 carstimon <carstimon@gmail.com>
 Pierre Haessig <pierre.haessig@crans.org>
-Maciej Baranski <getrox.sc@gmail.com>
-Zamrath Nizam <zamiguy_ni@yahoo.com>
 Benjamin Gudehus <hastebrot@gmail.com>
 Faisal Anees <faisal.iiit@gmail.com>
-Robert Johansson <jrjohansson@gmail.com>
-Kalevi Suominen <jksuom@gmail.com>
-Kaushik Varanasi <kaushik.varanasi1@gmail.com>
-Fawaz Alazemi <Mba7eth@gmail.com>
-Ambar Mehrotra <mehrotraambar@gmail.com>
 Mark Shoulson <mark@kli.org>
-David P. Sanders <dpsanders@gmail.com>
-Peter Brady <petertbrady@gmail.com>
+Kaushik Varanasi <kaushik.varanasi1@gmail.com>
+Ambar Mehrotra <mehrotraambar@gmail.com>
 John V. Siratt <jvsiratt@gmail.com>
 Sarwar Chahal <chahal.sarwar98@gmail.com>
-Nathan Woods <charlesnwoods@gmail.com>
 Colin B. Macdonald <macdonald@maths.ox.ac.uk>
+Nathan Woods <charlesnwoods@gmail.com>
 Marcus Näslund <naslundx@gmail.com>
-Clemens Novak <clemens@familie-novak.net>
 Craig A. Stoudt <craig.stoudt@gmail.com>
+Clemens Novak <clemens@familie-novak.net>
 Mridul Seth <seth.mridul@gmail.com>
 Raj <raj454raj@gmail.com>
 Mihai A. Ionescu <ionescu.a.mihai@gmail.com>
-immerrr <immerrr@gmail.com>
-Leonid Blouvshtein <leonidbl91@gmail.com>
 Peleg Michaeli <freepeleg@gmail.com>
+immerrr <immerrr@gmail.com>
 Chai Wah Wu <cwwuieee@gmail.com>
-ck Lux <lux.r.ck@gmail.com>
+Leonid Blouvshtein <leonidbl91@gmail.com>
 zsc347 <zsc347@gmail.com>
-Hamish Dickson <hamish.dickson@gmail.com>
-Michael Gallaspy <gallaspy.michael@gmail.com>
+ck Lux <lux.r.ck@gmail.com>
 Roman Inflianskas <infroma@gmail.com>
+Hamish Dickson <hamish.dickson@gmail.com>
 Duane Nykamp <nykamp@umn.edu>
+Michael Gallaspy <gallaspy.michael@gmail.com>
 Ted Dokos <tdokos@gmail.com>
+Victor Brebenar <v.brebenar@gmail.com>
 Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
-Akshat Jain <akshat.jain@students.iiit.ac.in>
 Shivam Vats <shivamvats.iitkgp@gmail.com>
+Akshat Jain <akshat.jain@students.iiit.ac.in>
+Longqi Wang <iqgnol@gmail.com>
+Juan Felipe Osorio <jfosorio@gmail.com>
+GitRay <pix2@_nospam_.cathcart.us>
+Eric Miller <emiller42@gmail.com>
+lukas <lukas.zorich@gmail.com>
+Venkata Ramana <idlike2dream@gmail.com>
 Cody Herbst <cyherbst@gmail.com>
+Richard Otis <richard.otis@outlook.com>
 AMiT Kumar <dtu.amit@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
+Yury G. Kudryashov <urkud.urkud@gmail.com>
 Guillaume Gay <contact@damcb.com>
 Ray Cathcart <github@cathcart.us>
+Ralf Stephan <ralf@ark.in-berlin.de>
 Mihir Wadwekar <m.mihirw@gmail.com>
+kaichogami <asishrocks95@gmail.com>
 Tuan Manh Lai <laituan245@gmail.com>
 Darshan Chaudhary <deathbullet@gmail.com>
 Alec Kalinin <alec.kalinin@gmail.com>
+Luv Agarwal <agarwal.iiit@gmail.com>
 Aaditya Nair <aadityanair6494@gmail.com>
 Jayesh Lahori <jlahori92@gmail.com>
 harshil goel <harshil158@gmail.com>
-Lokesh Sharma <lokeshhsharma@gmail.com>
+Jason Ly <jason.ly@gmail.com>
 Sartaj Singh <singhsartaj94@gmail.com>
-Chris Swierczewski <cswiercz@gmail.com>
 Sumith <sumith1896@gmail.com>
+Lokesh Sharma <lokeshhsharma@gmail.com>
+Chris Swierczewski <cswiercz@gmail.com>
+Kevin Ventullo <kevin.ventullo@gmail.com>
 Konstantin Togoi <konstantin.togoi@gmail.com>
 Param Singh <paramsingh258@gmail.com>
+dustyrockpyle <dustyrockpyle@gmail.com>
+Alistair Lynn <arplynn@gmail.com>
+mao8 <thisisma08@gmail.com>
 Philippe Bouafia <philippe.bouafia@ensea.fr>
 Juha Remes <jremes@outlook.com>
 Lucas Jones <lucas@lucasjones.co.uk>
+Jennifer White <jcrw122@googlemail.com>
 Peter Schmidt <peter@peterjs.com>
 Jiaxing Liang <liangjiaxing57@gmail.com>
 Gregory Ashton <gash789@gmail.com>
+Gao, Xiang <qasdfgtyuiop@gmail.com>
+Sebastian Koslowski <koslowski@kit.edu>
 Renato Orsino <renato.orsino@gmail.com>
-Jennifer White <jcrw122@googlemail.com>
-Alistair Lynn <arplynn@gmail.com>
+Michael Boyle <michael.oliver.boyle@gmail.com>
 Govind Sahai <gsiitbhu@gmail.com>
-Adam Bloomston <adam@glitterfram.es>
 Kyle McDaniel <mcdanie5@illinois.edu>
+Adam Bloomston <adam@glitterfram.es>
 Nguyen Truong Duy <truongduy134@yahoo.com>
 Alex Lindsay <adlinds3@ncsu.edu>
-Jason Siefken <siefkenj@gmail.com>
 Mathew Chong <mathewchong.dev@gmail.com>
+Jason Siefken <siefkenj@gmail.com>
 Gaurav Dhingra <axyd0000@gmail.com>
-Kevin Ventullo <kevin.ventullo@gmail.com>
-Longqi Wang <iqgnol@gmail.com>
 Isuru Fernando <isuruf@gmail.com>
 Shivam Tyagi <shivam.tyagi.apm13@itbhu.ac.in>
-Rich LaSota <rjlasota@gmail.com>
-Anton Akhmerov <anton.akhmerov@gmail.com>
-Richard Otis <richard.otis@outlook.com>
 Michael Zingale <michael.zingale@stonybrook.edu>
-Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
+Rich LaSota <rjlasota@gmail.com>
+Chak-Pong Chung <chakpongchung@gmail.com>
+Anton Akhmerov <anton.akhmerov@gmail.com>
 Dustin Gadal <Dustin.Gadal@gmail.com>
+David T <derDavidT@users.noreply.github.com>
+Phil Ruffwind <rf@rufflewind.com>
+Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
+operte <operte@gmail.com>
 Yu Kobayashi <yukoba@accelart.jp>
-Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
-Devyani Kota <devyanikota@gmail.com>
 Keval Shah <kevalshah_96@yahoo.co.in>
+Shashank Kumar <shashank.kumar.apc13@iitbhu.ac.in>
+Timothy Cyrus <tcyrus@users.noreply.github.com>
+Devyani Kota <devyanikota@gmail.com>
 Dzhelil Rufat <drufat@caltech.edu>
+Pastafarianist <mr.pastafarianist@gmail.com>
+Sourav Singh <souravsingh@users.noreply.github.com>
 Jacob Garber <jgarber1@ualberta.ca>
 Vinay <csvinay.d@gmail.com>
+GolimarOurHero <metalera94@hotmail.com>
 Prashant Tyagi <prashanttyagi221295@gmail.com>
 Matthew Davis <davisml.md@gmail.com>
+Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
+Alexander Bentkamp <bentkamp@gmail.com>
+Moo VI <metaknightdrake-git@yahoo.co.uk>
 Jack Kemp <metaknightdrake-git@yahoo.co.uk>
+Thomas Baruchel <baruchel@gmx.com>
 Kshitij Saraogi <KshitijSaraogi@gmail.com>
+Nicolás Guarín-Zapata <nicoguarin@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -387,7 +387,7 @@ Lokesh Sharma <lokeshhsharma@gmail.com>
 Sartaj Singh <singhsartaj94@gmail.com>
 Chris Swierczewski <cswiercz@gmail.com>
 Sumith <sumith1896@gmail.com>
-Konstantin Togoi <togoi.konstantin@outlook.com>
+Konstantin Togoi <konstantin.togoi@gmail.com>
 Param Singh <paramsingh258@gmail.com>
 Philippe Bouafia <philippe.bouafia@ensea.fr>
 Juha Remes <jremes@outlook.com>
@@ -399,7 +399,7 @@ Renato Orsino <renato.orsino@gmail.com>
 Jennifer White <jcrw122@googlemail.com>
 Alistair Lynn <arplynn@gmail.com>
 Govind Sahai <gsiitbhu@gmail.com>
-Adam Bloomston <>
+Adam Bloomston <adam@glitterfram.es>
 Kyle McDaniel <mcdanie5@illinois.edu>
 Nguyen Truong Duy <truongduy134@yahoo.com>
 Alex Lindsay <adlinds3@ncsu.edu>

--- a/bin/authors_update.py
+++ b/bin/authors_update.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+A tool generate AUTHORS. We started tracking authors before moving to git, so
+we have to do some manual rearrangement of the git history authors in order to
+get the order in AUTHORS.
+"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import os
+import sys
+
+from fabric.api import local, env
+from fabric.colors import yellow, blue, green, red
+from fabric.utils import error
+
+mailmap_update_path = os.path.abspath(__file__)
+mailmap_update_dir = os.path.dirname(mailmap_update_path)
+sympy_top = os.path.split(mailmap_update_dir)[0]
+sympy_dir = os.path.join(sympy_top, 'sympy')
+
+if os.path.isdir(sympy_dir):
+    sys.path.insert(0, sympy_top)
+
+from sympy.utilities.misc import filldedent
+
+try:
+    # Only works in newer versions of fabric
+    env.colorize_errors = True
+except AttributeError:
+    pass
+
+git_command = """git log --reverse --format="%aN <%aE>" | awk ' !x[$0]++'"""
+
+git_people = unicode(local(git_command, capture=True), 'utf-8').strip().split("\n")
+
+from distutils.version import LooseVersion
+
+git_ver = local('git --version', capture=True)[12:]
+if LooseVersion(git_ver) < LooseVersion('1.8.4.2'):
+    print(yellow("Please use a newer git version >= 1.8.4.2"))
+
+def move(l, i1, i2):
+    x = l.pop(i1)
+    l.insert(i2, x)
+
+
+# Do the few changes necessary in order to reproduce AUTHORS:
+
+move(git_people, 2, 0) # Ondřej Čertík
+move(git_people, 42, 1) # Fabian Pedregosa
+move(git_people, 22, 2) # Jurjen N.E. Bos
+git_people.insert(4, "*Marc-Etienne M.Leveille <protonyc@gmail.com>")
+move(git_people, 10, 5) # Brian Jorgensen
+git_people.insert(11, "*Ulrich Hecht <ulrich.hecht@gmail.com>")
+git_people.pop(12) # Kirill Smelkov
+move(git_people, 12, 32) # Sebastian Krämer
+git_people.insert(35, "*Case Van Horsen <casevh@gmail.com>")
+git_people.insert(43, "*Dan <coolg49964@gmail.com>")
+move(git_people, 57, 59) # Aaron Meurer
+move(git_people, 58, 57) # Andrew Docherty
+move(git_people, 67, 66) # Chris Smith
+move(git_people, 79, 76) # Kevin Goodsell
+git_people.insert(84, "*Chu-Ching Huang <cchuang@mail.cgu.edu.tw>")
+move(git_people, 94, 92) # James Pearson
+move(git_people, 94, 93) # Matthew Brett
+
+git_people.pop(229) # Sergey B Kirpichev
+
+
+header = """\
+All people who contributed to SymPy by sending at least a patch or more (in
+the order of the date of their first contribution), except those who
+explicitly didn't want to be mentioned.  You can find missing people from this
+file by using git log --reverse --format="%aN <%aE>" | awk ' !x[$0]++' (the
+order from that command will be a little different, but close to the order
+here).  People with a * next to their names are not found in the metadata of
+the git history.
+"""
+
+fd = open(os.path.realpath(os.path.join(__file__, os.path.pardir,
+    os.path.pardir, "AUTHORS")), "w")
+fd.write(header)
+fd.write("\n")
+fd.write("\n".join(git_people).encode("utf8"))
+fd.write("\n")


### PR DESCRIPTION
I've added a script that generates the AUTHORS file from the git history. I have done the necessary modifications to the list of people from git, so that the first 100 or so authors are reproduced exactly. It turns out just 17 simple changes are needed. After that the amount of changes would be higher. I don't know why, if we made mistakes while updating AUTHORS, or if the git order has changed. Either way, I think we should just use the order given by git after the first 100 or so authors. That keeps the update script manageable, and everything is fully automatic.

@asmeurer, @moorepants let me know what you think.
