### PR TITLE
Beware of non-orthogonal Jordan blocks

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1621,6 +1621,19 @@ def test_jordan_form_complex_issue_9274():
     assert J == Jmust1 or J == Jmust2
     assert simplify(P*J*P.inv()) == A
 
+def test_issue_10220():
+    # two non-orthogonal Jordan blocks with eigenvalue 1
+    M = Matrix([[1, 0, 0, 1],
+                [0, 1, 1, 0],
+                [0, 0, 1, 1],
+                [0, 0, 0, 1]])
+    P, C = M.jordan_cells()
+    assert P == Matrix([[0, 1, 0, 1],
+                        [1, 0, 0, 0],
+                        [0, 1, 0, 0],
+                        [0, 0, 1, 0]])
+    assert len(C) == 2
+
 
 def test_Matrix_berkowitz_charpoly():
     UA, K_i, K_w = symbols('UA K_i K_w')


### PR DESCRIPTION
The matrix

```
M = Matrix([[1, 0, 0, 1],
         [0, 1, 1, 0],
         [0, 0, 1, 1],
         [0, 0, 0, 1]])
```

has a single fourfold eigenvalue 1 and only two eigenvectors
`[1, 0. 0, 0]` and `[0, 1, 0, 0]` considered as column vectors.
(The first two columns of `M`.) The latter belongs to a Jordan block
of dimension three generated by (the columns of)

```
[0, 1, 0]
[1, 0, 0]
[0, 1, 0]
[0, 0, 1]
```

These vectors form a Jordan chain with the last column as the chain leader.
The others are obtained by repeatedly applying `M - I` (where `I` is
the identity matrix) so that they are on different "levels". The first one
is in the kernel of `M - I` (together with `[1, 0, 0, 0]`). The middle
column is in the kernel of `(M - I)**2` while the last column is annulled
only by `(M - I)**3`. The first eigenvector is also a chain leader and
spans a block of dimension one.

The Jordan chains belonging to the eigenvalue 1 are found by first
constructing the increasing sequence `Ns[s]` of kernels of
`(M - I)**s` for `s = 1, 2, 3`. The chain leaders belonging to
`Ns[3]` are among those that do not belong to `Ns[2]`. They can be
found by searching vectors that are orthogonal to the subspace `Ns[2]`.
In this case the orthogonal subspace is one-dimensional, generated by
`[0, 0, 0, 1]`. The corresponding chain is 3-dimensional.

There remains only a single one-dimensional block generated by a vector
of `Ns[1]` not belonging to the first-found chain. Such a vector
`[1, 0, 0, 0]` is again found by orthogonality, but one must be
careful to not demand orthogonality with respect to all chain vectors
found previously. Only the one on the same level, namely `[0, 1, 0, 0]`,
is to be used. If also the second chain vector `[1, 0, 1, 0]` on the
next level is taken into account, no vectors remain to be found.

Fixes #10220
