### PR TITLE
10268: make interval pt significantly different

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -565,7 +565,7 @@ class Basic(with_metaclass(ManagedProperties)):
     @property
     def is_comparable(self):
         """Return True if self can be computed to a real number
-        with precision, else False.
+        (or already is a real number) with precision, else False.
 
         Examples
         ========
@@ -582,14 +582,15 @@ class Basic(with_metaclass(ManagedProperties)):
         is_number = self.is_number
         if is_number is False:
             return False
-        if is_real and is_number:
-            return True
-        n, i = [p.evalf(2) for p in self.as_real_imag()]
+        n, i = [p.evalf(2) if not p.is_Number else p
+            for p in self.as_real_imag()]
         if not i.is_Number or not n.is_Number:
             return False
         if i:
             # if _prec = 1 we can't decide and if not,
-            # the answer is False so return False
+            # the answer is False because numbers with
+            # imaginary parts can't be compared
+            # so return False
             return False
         else:
             return n._prec != 1

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -177,6 +177,7 @@ def test_literal_evalf_is_number_is_zero_is_comparable():
     from sympy.integrals.integrals import Integral
     from sympy.core.symbol import symbols
     from sympy.core.function import Function
+    from sympy.functions.elementary.trigonometric import cos, sin
     x = symbols('x')
     f = Function('f')
 
@@ -195,3 +196,9 @@ def test_literal_evalf_is_number_is_zero_is_comparable():
     assert i.is_zero
     assert i.is_number is False
     assert i.evalf(2, strict=False) == 0
+
+    # issue 10268
+    n = sin(1)**2 + cos(1)**2 - 1
+    assert n.is_comparable is False
+    assert n.n(2).is_comparable is False
+    assert n.n(2).n(2).is_comparable

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -454,7 +454,11 @@ def solve_univariate_inequality(expr, gen, relational=True):
                     sol_sets.append(Interval(start, S.Infinity, True, True))
                     break
 
-            if valid((start + end)/2 if start != S.NegativeInfinity else end - 1):
+            pt = ((start + end)/2 if start is not S.NegativeInfinity else
+                (end/2 if end.is_positive else
+                (2*end if end.is_negative else
+                end - 1)))
+            if valid(pt):
                 sol_sets.append(Interval(start, end, True, True))
 
             if x in singularities:
@@ -470,7 +474,11 @@ def solve_univariate_inequality(expr, gen, relational=True):
         # check a point between -oo and oo (e.g. 0) else pick a point
         # past the last solution (which is start after the end of the
         # for-loop above
-        if valid(start + 1 if start is not S.NegativeInfinity else 0):
+        pt = (0 if start is S.NegativeInfinity else
+            (start/2 if start.is_negative else
+            (2*start if start.is_positive else
+            start + 1)))
+        if valid(pt):
             sol_sets.append(Interval(start, end, True, True))
 
         rv = Union(*sol_sets).subs(gen, _gen)

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -2,7 +2,7 @@
 
 from sympy import (And, Eq, FiniteSet, Ge, Gt, Interval, Le, Lt, Ne, oo,
                    Or, S, sin, sqrt, Symbol, Union, Integral, Sum,
-                   Function, Poly, PurePoly, pi, root)
+                   Function, Poly, PurePoly, pi, root, log, exp)
 from sympy.solvers.inequalities import (reduce_inequalities,
                                         solve_poly_inequality as psolve,
                                         reduce_rational_inequalities,
@@ -316,3 +316,7 @@ def test_issue_8974():
 
 def test_issue_10047():
     assert solve(sin(x) < 2) == And(-oo < x, x < oo)
+
+
+def test_issue_10268():
+    assert solve(log(x) < 1000) == And(-oo < x, x < exp(1000))


### PR DESCRIPTION
There were two problems:

1) the pt being tested was too close to the interval
pt and was thus the difference was not distinguished
from zero.

2) the routine 'is_comparable' wasn't set up to handle
numbers that have already been computed; one could insist
that the input NOT be a Number but for now, a Number is
now handled by not re-evaluating it, but simply taking the
value given. A test that failed in master was added: the
troublesome trig identity is 0 but does not evaluate with
precision so it is not comparable (hence, an inequality
involving its comparison to 0 should not be evaluated)

```
>>> n = cos(1)**2 + sin(1)**2 - 1
>>> n < 0
-1 + cos(1)**2 + sin(1)**2 < 0
```
