### PR TITLE
Expanded complex domain for singularities

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -32,7 +32,7 @@ def singularities(expr, sym):
                                   " non rational functions are not yet"
                                   " implemented")
     else:
-        return tuple(sorted(solveset(simplify(1/expr), sym)))
+        return solveset(simplify(1/expr), sym)
 
 ###########################################################################
 ###################### DIFFERENTIAL CALCULUS METHODS ######################

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -8,18 +8,23 @@ def singularities(expr, sym):
     """
     Finds singularities for a function.
     Currently supported functions are:
-    - univariate real rational functions
+    - univariate rational(real or complex) functions
 
     Examples
     ========
 
     >>> from sympy.calculus.singularities import singularities
-    >>> from sympy import Symbol
+    >>> from sympy import Symbol, I, sqrt
     >>> x = Symbol('x', real=True)
+    >>> y = Symbol('y', real=False)
     >>> singularities(x**2 + x + 1, x)
-    ()
+    EmptySet()
     >>> singularities(1/(x + 1), x)
-    (-1,)
+    {-1}
+    >>> singularities(1/(y**2 + 1), y)
+    {-I, I}
+    >>> singularities(1/(y**3 + 1), y)
+    {-1, 1/2 - sqrt(3)*I/2, 1/2 + sqrt(3)*I/2}
 
     References
     ==========

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -2,8 +2,8 @@ from sympy import Symbol, exp, log
 from sympy.calculus.singularities import (singularities, is_increasing,
                                           is_strictly_increasing, is_decreasing,
                                           is_strictly_decreasing, is_monotonic)
-from sympy.sets import Interval
-from sympy import oo, S
+from sympy.sets import Interval, FiniteSet, EmptySet
+from sympy import oo, S, I, sqrt
 
 from sympy.utilities.pytest import XFAIL
 
@@ -11,12 +11,17 @@ from sympy.abc import x, y
 a = Symbol('a', negative=True)
 b = Symbol('b', positive=True)
 
+
 def test_singularities():
-    x = Symbol('x', real=True)
+    x = Symbol('x')
+    y = Symbol('y')
 
-    assert singularities(x**2, x) == ()
-    assert singularities(x/(x**2 + 3*x + 2), x) == (-2, -1)
-
+    assert singularities(x**2, x) == S.EmptySet
+    assert singularities(x/(x**2 + 3*x + 2), x) == FiniteSet(-2, -1)
+    assert singularities(1/(x**2 + 1), x) == FiniteSet(I, -I)
+    assert singularities(x/(x**3 + 1), x) == FiniteSet(-1, (1 - sqrt(3)*I)/2,
+                                                       (1 + sqrt(3)*I)/2)
+    assert singularities(1/(y**2 + 2*I*y + 1), y) == FiniteSet(-I + sqrt(2)*I, -I - sqrt(2)*I)
 
 @XFAIL
 def test_singularities_non_rational():


### PR DESCRIPTION
Since, the `solveset` module can solve complex expressions, I think we can work on expanding the domain of `singularities` module from `real` expressions to the `complex` ones.

Ping @hargup @aktech 
I would really like if you can help me with this.
