### PR TITLE
Change default value of rref simplify flag to True

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2685,12 +2685,13 @@ class MatrixBase(object):
 
         return self.adjugate() / d
 
-    def rref(self, iszerofunc=_iszero, simplify=False):
+    def rref(self, iszerofunc=_iszero, simplify=True):
         """Return reduced row-echelon form of matrix and indices of pivot vars.
 
-        To simplify elements before finding nonzero pivots set simplify=True
-        (to use the default SymPy simplify function) or pass a custom
-        simplify function.
+        By default, simplifies elements before finding nonzero pivots,
+        using the default SymPy simplify function. You may also pass a
+        custom simplifyfunction, or set simplify=False if you know
+        simplification is unnecessary.
 
         Examples
         ========

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2212,10 +2212,11 @@ def test_invertible_check():
         [ x,  1,  1],
         [ 1,  x, -1],
     ])
-    assert len(m.rref()[1]) == m.rows
-    # in addition, unless simplify=True in the call to rref, the identity
+    assert len(m.rref(simplify=False)[1]) == m.rows
+    # in addition, if simplify=False in the call to rref, the identity
     # matrix will be returned even though m is not invertible
-    assert m.rref()[0] == eye(3)
+    assert m.rref(simplify=False)[0] == eye(3)
+    assert m.rref()[0] != eye(3)
     assert m.rref(simplify=signsimp)[0] != eye(3)
     raises(ValueError, lambda: m.inv(method="ADJ"))
     raises(ValueError, lambda: m.inv(method="GE"))


### PR DESCRIPTION
Fixes #10120 . See discussion in that issue. 

To summarise:

Without `simplify=True`, `rref` will silently return wrong results for symbolic matrices. Although simplification is slow, until a better zero-testing method is implemented (which is the real solution, see #10279) the default value of the flag should be true.

The other possible solution, put forth by @moorepants is to leave the default value, but have `rref` output a warning when run that if you suspect the results to be wrong to rerun with `simplify=True`.

I favour changing the default value of the flag because:

a) It is more new-user friendly. Most new users will probably be using small matrices and won't be affected by the slowness of simplification, but will be confused by wrong answers, e.g [this stackoverflow question](http://stackoverflow.com/questions/19072700/why-does-sympy-give-me-the-wrong-answer-when-i-row-reduce-a-symbolic-matrix). 'Power' users with large expressions are more likely to look at the docs when their code runs slowly.

b) It is more dev-friendly! Several functions like `gauss_jordan_solve` use `rref` internally. I only ran into this problem because `linear_solve` was not working because the flag was not set correctly. Also, in some functions (which only deal with numerics, say) it might be known that the simplify flag is not needed -- do we then add another to suppress the warning? 
