### PR TITLE
Use xreplace instead of subs in sub_pre

### DIFF
--- a/sympy/simplify/cse_opts.py
+++ b/sympy/simplify/cse_opts.py
@@ -17,7 +17,7 @@ def sub_pre(e):
     # make it canonical
     reps.sort(key=default_sort_key)
 
-    e = e.subs([(a, Mul._from_args([S.NegativeOne, -a])) for a in reps])
+    e = e.xreplace({a: Mul._from_args([S.NegativeOne, -a]) for a in reps})
     # repeat again for persisting Adds but mark these with a leading 1, -1
     # e.g. y - x -> 1*-1*(x - y)
     if isinstance(e, Basic):

--- a/sympy/simplify/cse_opts.py
+++ b/sympy/simplify/cse_opts.py
@@ -17,7 +17,7 @@ def sub_pre(e):
     # make it canonical
     reps.sort(key=default_sort_key)
 
-    e = e.xreplace({a: Mul._from_args([S.NegativeOne, -a]) for a in reps})
+    e = e.xreplace(dict((a, Mul._from_args([S.NegativeOne, -a])) for a in reps))
     # repeat again for persisting Adds but mark these with a leading 1, -1
     # e.g. y - x -> 1*-1*(x - y)
     if isinstance(e, Basic):


### PR DESCRIPTION
As `sub_pre` uses `atoms` to find elements to replace, it is doing exact matching and so only needs the faster `xreplace` method rather than `subs`.
