### PR TITLE
[WIP] Fixing ImageSet when an EmptySet is returned

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -236,10 +236,10 @@ class ImageSet(Set):
         from sympy.solvers.solveset import solveset, linsolve
         L = self.lamda
         if self._is_multivariate():
-            solns = list(linsolve([expr - val for val, expr in zip(other, L.expr)],
-                         L.variables).args[0])
+            solns = linsolve([expr - val for val, expr in zip(other, L.expr)],
+                             L.variables).args
         else:
-            solns = list(solveset(L.expr - other, L.variables[0]))
+            solns = solveset(L.expr - other, L.variables[0])
 
         for soln in solns:
             try:


### PR DESCRIPTION
fixes #10287 
- Removed the typecasting of set of `tuples` returned by `linsolve` to `list` as it was redundant (possibly)
- `arg[0]` is replaced by `arg` for the case when an `EmptySet` is returned.
- [ ] Tests [here](https://github.com/sympy/sympy/blob/master/sympy/sets/tests/test_fancysets.py#L81-L94) pass
