### PR TITLE
Make sympy.polys.polyoptions.Options sympify gens

### DIFF
--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -284,7 +284,7 @@ class Gens(with_metaclass(OptionType, Option)):
             gens = (gens,)
         elif len(gens) == 1 and hasattr(gens[0], '__iter__'):
             gens = gens[0]
-
+        gens = sympify(gens)
         if gens == (None,):
             gens = ()
         elif has_dups(gens):

--- a/sympy/polys/tests/test_polyoptions.py
+++ b/sympy/polys/tests/test_polyoptions.py
@@ -10,7 +10,7 @@ from sympy.polys.domains import FF, GF, ZZ, QQ, EX
 
 from sympy.polys.polyerrors import OptionError, GeneratorsError
 
-from sympy import Integer, Symbol, I, sqrt
+from sympy import Integer, Symbol, I, sqrt, sympify
 from sympy.utilities.pytest import raises
 from sympy.abc import x, y, z
 
@@ -54,6 +54,7 @@ def test_Gens_preprocess():
     assert Gens.preprocess((None,)) == ()
     assert Gens.preprocess((x, y, z)) == (x, y, z)
     assert Gens.preprocess(((x, y, z),)) == (x, y, z)
+    assert Gens.preprocess((1,)) == (sympify(1),)
 
     a = Symbol('a', commutative=False)
 


### PR DESCRIPTION
Fixes #9963 .

Changes the preprocessing of `gens` to includes sympification, and adds a test.
