### PR TITLE
Dense N-dim arrays now support slicing

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -16,6 +16,7 @@ from sympy.combinatorics import Permutation
 # TODO dummy point, literal field
 # TODO too often one needs to call doit or simplify on the output, check the
 # tests and find out why
+from sympy.tensor.array import ImmutableDenseNDimArray
 
 
 class Manifold(Basic):
@@ -990,7 +991,7 @@ class BaseCovarDerivativeOp(Expr):
     >>> TP = TensorProduct
     >>> ch = metric_to_Christoffel_2nd(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
     >>> ch
-    (((0, 0), (0, 0)), ((0, 0), (0, 0)))
+    [[[0, 0], [0, 0]], [[0, 0], [0, 0]]]
     >>> cvd = BaseCovarDerivativeOp(R2_r, 0, ch)
     >>> cvd(R2.x)
     1
@@ -1035,7 +1036,7 @@ class BaseCovarDerivativeOp(Expr):
         # Third step: evaluate the derivatives of the vectors
         derivs = []
         for v in vectors:
-            d = Add(*[(self._christoffel[k][wrt_vector._index][v._index]
+            d = Add(*[(self._christoffel[k, wrt_vector._index, v._index]
                        *v._coord_sys.base_vector(k))
                       for k in range(v._coord_sys.dim)])
             derivs.append(d)
@@ -1057,7 +1058,7 @@ class CovarDerivativeOp(Expr):
     >>> TP = TensorProduct
     >>> ch = metric_to_Christoffel_2nd(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
     >>> ch
-    (((0, 0), (0, 0)), ((0, 0), (0, 0)))
+    [[[0, 0], [0, 0]], [[0, 0], [0, 0]]]
     >>> cvd = CovarDerivativeOp(R2.x*R2.e_x, ch)
     >>> cvd(R2.x)
     x
@@ -1299,13 +1300,6 @@ def dummyfy(args, exprs):
     return d_args, d_exprs
 
 
-def list_to_tuple_rec(the_list):
-    # TODO remove in favor of tensor classes
-    if isinstance(the_list, list):
-        return tuple(list_to_tuple_rec(e) for e in the_list)
-    return the_list
-
-
 ###############################################################################
 # Helpers
 ###############################################################################
@@ -1484,9 +1478,9 @@ def metric_to_Christoffel_1st(expr):
     >>> from sympy.diffgeom import metric_to_Christoffel_1st, TensorProduct
     >>> TP = TensorProduct
     >>> metric_to_Christoffel_1st(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
-    (((0, 0), (0, 0)), ((0, 0), (0, 0)))
+    [[[0, 0], [0, 0]], [[0, 0], [0, 0]]]
     >>> metric_to_Christoffel_1st(R2.x*TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
-    (((1/2, 0), (0, 0)), ((0, 0), (0, 0)))
+    [[[1/2, 0], [0, 0]], [[0, 0], [0, 0]]]
 
     """
     matrix = twoform_to_matrix(expr)
@@ -1501,7 +1495,7 @@ def metric_to_Christoffel_1st(expr):
                      for k in indices]
                     for j in indices]
                    for i in indices]
-    return list_to_tuple_rec(christoffel)
+    return ImmutableDenseNDimArray(christoffel)
 
 
 def metric_to_Christoffel_2nd(expr):
@@ -1517,9 +1511,9 @@ def metric_to_Christoffel_2nd(expr):
     >>> from sympy.diffgeom import metric_to_Christoffel_2nd, TensorProduct
     >>> TP = TensorProduct
     >>> metric_to_Christoffel_2nd(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
-    (((0, 0), (0, 0)), ((0, 0), (0, 0)))
+    [[[0, 0], [0, 0]], [[0, 0], [0, 0]]]
     >>> metric_to_Christoffel_2nd(R2.x*TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
-    (((1/(2*x), 0), (0, 0)), ((0, 0), (0, 0)))
+    [[[1/(2*x), 0], [0, 0]], [[0, 0], [0, 0]]]
 
     """
     ch_1st = metric_to_Christoffel_1st(expr)
@@ -1536,11 +1530,11 @@ def metric_to_Christoffel_2nd(expr):
     dums = coord_sys._dummies
     matrix = matrix.subs(list(zip(s_fields, dums))).inv().subs(list(zip(dums, s_fields)))
     # XXX end of workaround
-    christoffel = [[[Add(*[matrix[i, l]*ch_1st[l][j][k] for l in indices])
+    christoffel = [[[Add(*[matrix[i, l]*ch_1st[l, j, k] for l in indices])
                      for k in indices]
                     for j in indices]
                    for i in indices]
-    return list_to_tuple_rec(christoffel)
+    return ImmutableDenseNDimArray(christoffel)
 
 
 def metric_to_Riemann_components(expr):
@@ -1558,24 +1552,23 @@ def metric_to_Riemann_components(expr):
     >>> from sympy.diffgeom import metric_to_Riemann_components, TensorProduct
     >>> TP = TensorProduct
     >>> metric_to_Riemann_components(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
-    ((((0, 0), (0, 0)), ((0, 0), (0, 0))), (((0, 0), (0, 0)), ((0, 0),
-     (0, 0))))
+    [[[[0, 0], [0, 0]], [[0, 0], [0, 0]]], [[[0, 0], [0, 0]], [[0, 0], [0, 0]]]]
 
     >>> non_trivial_metric = exp(2*R2.r)*TP(R2.dr, R2.dr) + \
         R2.r**2*TP(R2.dtheta, R2.dtheta)
     >>> non_trivial_metric
     exp(2*r)*TensorProduct(dr, dr) + r**2*TensorProduct(dtheta, dtheta)
     >>> riemann = metric_to_Riemann_components(non_trivial_metric)
-    >>> riemann[0]
-    (((0, 0), (0, 0)), ((0, exp(-2*r)*r), (-exp(-2*r)*r, 0)))
-    >>> riemann[1]
-    (((0, -1/r), (1/r, 0)), ((0, 0), (0, 0)))
+    >>> riemann[0, :, :, :]
+    [[[0, 0], [0, 0]], [[0, exp(-2*r)*r], [-exp(-2*r)*r, 0]]]
+    >>> riemann[1, :, :, :]
+    [[[0, -1/r], [1/r, 0]], [[0, 0], [0, 0]]]
 
     """
     ch_2nd = metric_to_Christoffel_2nd(expr)
     coord_sys = expr.atoms(CoordSystem).pop()
     indices = list(range(coord_sys.dim))
-    deriv_ch = [[[[d(ch_2nd[i][j][k])
+    deriv_ch = [[[[d(ch_2nd[i, j, k])
                    for d in coord_sys.base_vectors()]
                   for k in indices]
                  for j in indices]
@@ -1585,7 +1578,7 @@ def metric_to_Riemann_components(expr):
                    for mu in indices]
                   for sig in indices]
                      for rho in indices]
-    riemann_b = [[[[Add(*[ch_2nd[rho][l][mu]*ch_2nd[l][sig][nu] - ch_2nd[rho][l][nu]*ch_2nd[l][sig][mu] for l in indices])
+    riemann_b = [[[[Add(*[ch_2nd[rho, l, mu]*ch_2nd[l, sig, nu] - ch_2nd[rho, l, nu]*ch_2nd[l, sig, mu] for l in indices])
                     for nu in indices]
                    for mu in indices]
                   for sig in indices]
@@ -1595,7 +1588,7 @@ def metric_to_Riemann_components(expr):
                      for mu in indices]
                 for sig in indices]
                for rho in indices]
-    return list_to_tuple_rec(riemann)
+    return ImmutableDenseNDimArray(riemann)
 
 
 def metric_to_Ricci_components(expr):
@@ -1613,20 +1606,20 @@ def metric_to_Ricci_components(expr):
     >>> from sympy.diffgeom import metric_to_Ricci_components, TensorProduct
     >>> TP = TensorProduct
     >>> metric_to_Ricci_components(TP(R2.dx, R2.dx) + TP(R2.dy, R2.dy))
-    ((0, 0), (0, 0))
+    [[0, 0], [0, 0]]
 
     >>> non_trivial_metric = exp(2*R2.r)*TP(R2.dr, R2.dr) + \
                              R2.r**2*TP(R2.dtheta, R2.dtheta)
     >>> non_trivial_metric
     exp(2*r)*TensorProduct(dr, dr) + r**2*TensorProduct(dtheta, dtheta)
     >>> metric_to_Ricci_components(non_trivial_metric)
-    ((1/r, 0), (0, exp(-2*r)*r))
+    [[1/r, 0], [0, exp(-2*r)*r]]
 
     """
     riemann = metric_to_Riemann_components(expr)
     coord_sys = expr.atoms(CoordSystem).pop()
     indices = list(range(coord_sys.dim))
-    ricci = [[Add(*[riemann[k][i][k][j] for k in indices])
+    ricci = [[Add(*[riemann[k, i, k, j] for k in indices])
               for j in indices]
              for i in indices]
-    return list_to_tuple_rec(ricci)
+    return ImmutableDenseNDimArray(ricci)

--- a/sympy/diffgeom/tests/test_hyperbolic_space.py
+++ b/sympy/diffgeom/tests/test_hyperbolic_space.py
@@ -17,6 +17,8 @@ from sympy.diffgeom import (twoform_to_matrix,
                             metric_to_Christoffel_1st, metric_to_Christoffel_2nd,
                             metric_to_Riemann_components, metric_to_Ricci_components)
 import sympy.diffgeom.rn
+from sympy.tensor.array import ImmutableDenseNDimArray
+
 
 def test_H2():
     TP = sympy.diffgeom.TensorProduct
@@ -30,57 +32,59 @@ def test_H2():
     assert mat == automat
 
     gamma1 = metric_to_Christoffel_1st(g)
-    assert gamma1[0][0][0] == 0
-    assert gamma1[0][0][1] == -y**(-3)
-    assert gamma1[0][1][0] == -y**(-3)
-    assert gamma1[0][1][1] == 0
+    assert gamma1[0, 0, 0] == 0
+    assert gamma1[0, 0, 1] == -y**(-3)
+    assert gamma1[0, 1, 0] == -y**(-3)
+    assert gamma1[0, 1, 1] == 0
 
-    assert gamma1[1][1][1] == -y**(-3)
-    assert gamma1[1][1][0] == 0
-    assert gamma1[1][0][1] == 0
-    assert gamma1[1][0][0] == y**(-3)
+    assert gamma1[1, 1, 1] == -y**(-3)
+    assert gamma1[1, 1, 0] == 0
+    assert gamma1[1, 0, 1] == 0
+    assert gamma1[1, 0, 0] == y**(-3)
 
     gamma2 = metric_to_Christoffel_2nd(g)
-    assert gamma2[0][0][0] == 0
-    assert gamma2[0][0][1] == -y**(-1)
-    assert gamma2[0][1][0] == -y**(-1)
-    assert gamma2[0][1][1] == 0
+    assert gamma2[0, 0, 0] == 0
+    assert gamma2[0, 0, 1] == -y**(-1)
+    assert gamma2[0, 1, 0] == -y**(-1)
+    assert gamma2[0, 1, 1] == 0
 
-    assert gamma2[1][1][1] == -y**(-1)
-    assert gamma2[1][1][0] == 0
-    assert gamma2[1][0][1] == 0
-    assert gamma2[1][0][0] == y**(-1)
+    assert gamma2[1, 1, 1] == -y**(-1)
+    assert gamma2[1, 1, 0] == 0
+    assert gamma2[1, 0, 1] == 0
+    assert gamma2[1, 0, 0] == y**(-1)
 
     Rm = metric_to_Riemann_components(g)
-    assert Rm[0][0][0][0] == 0
-    assert Rm[0][0][0][1] == 0
-    assert Rm[0][0][1][0] == 0
-    assert Rm[0][0][1][1] == 0
+    assert Rm[0, 0, 0, 0] == 0
+    assert Rm[0, 0, 0, 1] == 0
+    assert Rm[0, 0, 1, 0] == 0
+    assert Rm[0, 0, 1, 1] == 0
 
-    assert Rm[0][1][0][0] == 0
-    assert Rm[0][1][0][1] == -y**(-2)
-    assert Rm[0][1][1][0] == y**(-2)
-    assert Rm[0][1][1][1] == 0
+    assert Rm[0, 1, 0, 0] == 0
+    assert Rm[0, 1, 0, 1] == -y**(-2)
+    assert Rm[0, 1, 1, 0] == y**(-2)
+    assert Rm[0, 1, 1, 1] == 0
 
-    assert Rm[1][0][0][0] == 0
-    assert Rm[1][0][0][1] == y**(-2)
-    assert Rm[1][0][1][0] == -y**(-2)
-    assert Rm[1][0][1][1] == 0
+    assert Rm[1, 0, 0, 0] == 0
+    assert Rm[1, 0, 0, 1] == y**(-2)
+    assert Rm[1, 0, 1, 0] == -y**(-2)
+    assert Rm[1, 0, 1, 1] == 0
 
-    assert Rm[1][1][0][0] == 0
-    assert Rm[1][1][0][1] == 0
-    assert Rm[1][1][1][0] == 0
-    assert Rm[1][1][1][1] == 0
+    assert Rm[1, 1, 0, 0] == 0
+    assert Rm[1, 1, 0, 1] == 0
+    assert Rm[1, 1, 1, 0] == 0
+    assert Rm[1, 1, 1, 1] == 0
 
     Ric = metric_to_Ricci_components(g)
-    assert Ric[0][0] == -y**(-2)
-    assert Ric[0][1] == 0
-    assert Ric[1][0] == 0
-    assert Ric[0][0] == -y**(-2)
+    assert Ric[0, 0] == -y**(-2)
+    assert Ric[0, 1] == 0
+    assert Ric[1, 0] == 0
+    assert Ric[0, 0] == -y**(-2)
+
+    assert Ric == ImmutableDenseNDimArray([-y**(-2), 0, 0, -y**(-2)], (2, 2))
 
     ## scalar curvature is -2
     #TODO - it would be nice to have index contraction built-in
-    R = (Ric[0][0] + Ric[1][1])*y**2
+    R = (Ric[0, 0] + Ric[1, 1])*y**2
     assert R == -2
 
     ## Gauss curvature is -1

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -492,6 +492,12 @@ class StrPrinter(Printer):
         return '%s**%s' % (self.parenthesize(expr.base, PREC),
                          self.parenthesize(expr.exp, PREC))
 
+    def _print_ImmutableDenseNDimArray(self, expr):
+        return str(expr)
+
+    def _print_ImmutableSparseNDimArray(self, expr):
+        return str(expr)
+
     def _print_Integer(self, expr):
         return str(expr.p)
 

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division
 import functools
 
+import itertools
+
 from sympy.core.sympify import _sympify
 
 from sympy import Matrix, flatten, Basic, Tuple
@@ -30,8 +32,25 @@ class DenseNDimArray(NDimArray):
         3
 
         """
-        index = self._parse_index(index)
-        return self._array[index]
+        if isinstance(index, tuple) and any([isinstance(i, slice) for i in index]):
+
+            def slice_expand(s, dim):
+                if not isinstance(s, slice):
+                        return (s,)
+                start, stop, step = s.indices(dim)
+                return [start + i*step for i in range((stop-start)//step)]
+
+            sl_factors = [slice_expand(i, dim) for (i, dim) in zip(index, self.shape)]
+            eindices = itertools.product(*sl_factors)
+            array = [self._array[self._parse_index(i)] for i in eindices]
+            nshape = [len(el) for i, el in enumerate(sl_factors) if isinstance(index[i], slice)]
+            return type(self)(array, nshape)
+        else:
+            if isinstance(index, slice):
+                return self._array[index]
+            else:
+                index = self._parse_index(index)
+                return self._array[index]
 
     @classmethod
     def zeros(cls, *shape):
@@ -94,6 +113,9 @@ class DenseNDimArray(NDimArray):
 
 
 class ImmutableDenseNDimArray(DenseNDimArray, Basic):
+    """
+
+    """
 
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -11,11 +11,13 @@ def test_ndim_array_initiation():
     arr_with_one_element = ImmutableDenseNDimArray([23])
     assert len(arr_with_one_element) == 1
     assert arr_with_one_element[0] == 23
+    assert arr_with_one_element[:] == [23]
     assert arr_with_one_element.rank() == 1
 
     arr_with_symbol_element = ImmutableDenseNDimArray([Symbol('x')])
     assert len(arr_with_symbol_element) == 1
     assert arr_with_symbol_element[0] == Symbol('x')
+    assert arr_with_symbol_element[:] == [Symbol('x')]
     assert arr_with_symbol_element.rank() == 1
 
     number5 = 5
@@ -245,3 +247,13 @@ def test_rebuild_immutable_arrays():
 
     assert sparr == sparr.func(*sparr.args)
     assert densarr == densarr.func(*densarr.args)
+
+
+def test_slices():
+    md = ImmutableDenseNDimArray(range(10, 34), (2, 3, 4))
+
+    assert md[:] == md._array
+    assert md[:, :, 0].tomatrix() == Matrix([[10, 14, 18], [22, 26, 30]])
+    assert md[0, 1:2, :].tomatrix() == Matrix([[14, 15, 16, 17]])
+    assert md[0, 1:3, :].tomatrix() == Matrix([[14, 15, 16, 17], [18, 19, 20, 21]])
+    assert md[:, :, :] == md


### PR DESCRIPTION
Added slicing support for dense N-dim arrays (still missing it in sparse ones).

_sympy.diffgeom_ doesn't use list of lists of lists anymore: they got replaced by N-dim arrays.
