### PR TITLE
Add support for diff in ITE

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -11,7 +11,7 @@ from sympy.core.cache import cacheit
 from sympy.core.numbers import Number
 from sympy.core.decorators import deprecated
 from sympy.core.operations import LatticeOp
-from sympy.core.function import Application
+from sympy.core.function import Application, Derivative
 from sympy.core.compatibility import ordered, range, with_metaclass, as_int
 from sympy.core.sympify import converter, _sympify, sympify
 from sympy.core.singleton import Singleton, S
@@ -913,6 +913,16 @@ class ITE(BooleanFunction):
     def to_nnf(self, simplify=True):
         a, b, c = self.args
         return And._to_nnf(Or(~a, b), Or(a, c), simplify=simplify)
+
+    def _eval_derivative(self, x):
+        return self.func(self.args[0], *[a.diff(x) for a in self.args[1:]])
+
+    # the diff method below is copied from Expr class
+    def diff(self, *symbols, **assumptions):
+        new_symbols = list(map(sympify, symbols))  # e.g. x, 2, y, z
+        assumptions.setdefault("evaluate", True)
+        return Derivative(self, *new_symbols, **assumptions)
+
 
 ### end class definitions. Some useful methods
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -482,6 +482,12 @@ def test_ITE():
     assert ITE(Or(A, False), And(B, True), False) is false
 
 
+def test_ITE_diff():
+    # analogous to Piecewise.diff
+    x = symbols('x')
+    assert ITE(x > 0, x**2, x).diff(x) == ITE(x > 0, 2*x, 1)
+
+
 def test_is_literal():
     assert is_literal(True) is True
     assert is_literal(False) is True


### PR DESCRIPTION
This commit adds support for differentiation of ITE objects. cf. Piecewise:

```
In [1]: import sympy
In [2]: x = sympy.Symbol('x')
In [3]: pw = sympy.Piecewise((x**2, x>0), (x, True))
In [4]: pw.diff(x)
Out[4]: Piecewise((2*x, x > 0), (1, True))
In [6]: ite = sympy.ITE(x > 0, x**2, x)
In [7]: ite.diff(x)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-6a41bf889b7c> in <module>()
----> 1 ite.diff(x)
```
