### PR TITLE
N-dim arrays: missing slicing for sparse, diff and applyfunc for all.

### DIFF
--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -112,6 +112,10 @@ class NDimArray(object):
         if shape is None and iterable is None:
             shape = ()
             iterable = ()
+        # Construction from another `NDimArray`:
+        elif shape is None and isinstance(iterable, NDimArray):
+            shape = iterable.shape
+            iterable = list(iterable)
         # Construct N-dim array from an iterable (numpy arrays included):
         elif shape is None and isinstance(iterable, collections.Iterable):
             iterable, shape = cls._scan_iterable_shape(iterable)
@@ -185,6 +189,37 @@ class NDimArray(object):
 
         """
         return self._rank
+
+    def diff(self, *args):
+        """
+        Calculate the derivative of each element in the array.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import ImmutableDenseNDimArray
+        >>> from sympy.abc import x, y
+        >>> M = ImmutableDenseNDimArray([[x, y], [1, x*y]])
+        >>> M.diff(x)
+        [[1, 0], [0, y]]
+
+        """
+        return type(self)(map(lambda x: x.diff(*args), self), self.shape)
+
+    def applyfunc(self, f):
+        """Apply a function to each element of the N-dim array.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.array import ImmutableDenseNDimArray
+        >>> m = ImmutableDenseNDimArray([i*2+j for i in range(2) for j in range(2)], (2, 2))
+        >>> m
+        [[0, 1], [2, 3]]
+        >>> m.applyfunc(lambda i: 2*i)
+        [[0, 2], [4, 6]]
+        """
+        return type(self)(map(f, self), self.shape)
 
     def __str__(self):
         """Returns string, allows to use standard functions print() and str().

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -257,3 +257,31 @@ def test_slices():
     assert md[0, 1:2, :].tomatrix() == Matrix([[14, 15, 16, 17]])
     assert md[0, 1:3, :].tomatrix() == Matrix([[14, 15, 16, 17], [18, 19, 20, 21]])
     assert md[:, :, :] == md
+
+    sd = ImmutableSparseNDimArray(range(10, 34), (2, 3, 4))
+    assert sd == ImmutableSparseNDimArray(md)
+
+    assert sd[:] == md._array
+    assert sd[:] == list(sd)
+    assert sd[:, :, 0].tomatrix() == Matrix([[10, 14, 18], [22, 26, 30]])
+    assert sd[0, 1:2, :].tomatrix() == Matrix([[14, 15, 16, 17]])
+    assert sd[0, 1:3, :].tomatrix() == Matrix([[14, 15, 16, 17], [18, 19, 20, 21]])
+    assert sd[:, :, :] == sd
+
+
+def test_diff_and_applyfunc():
+    from sympy.abc import x, y, z
+    md = ImmutableDenseNDimArray([[x, y], [x*z, x*y*z]])
+    assert md.diff(x) == ImmutableDenseNDimArray([[1, 0], [z, y*z]])
+
+    sd = ImmutableSparseNDimArray(md)
+    assert sd == ImmutableSparseNDimArray([x, y, x*z, x*y*z], (2, 2))
+    assert sd.diff(x) == ImmutableSparseNDimArray([[1, 0], [z, y*z]])
+
+    mdn = md.applyfunc(lambda x: x*3)
+    assert mdn == ImmutableDenseNDimArray([[3*x, 3*y], [3*x*z, 3*x*y*z]])
+    assert md != mdn
+
+    sdn = sd.applyfunc(lambda x: x/2)
+    assert sdn == ImmutableSparseNDimArray([[x/2, y/2], [x*z/2, x*y*z/2]])
+    assert sd != sdn

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -238,3 +238,33 @@ def test_higher_dimenions():
     m3_other = MutableDenseNDimArray([[[10, 11, 12, 13], [14, 15, 16, 17], [18, 19, 20, 21]], [[22, 23, 24, 25], [26, 27, 28, 29], [30, 31, 32, 33]]], (2, 3, 4))
 
     assert m3 == m3_other
+
+
+def test_slices():
+    md = MutableDenseNDimArray(range(10, 34), (2, 3, 4))
+
+    assert md[:] == md._array
+    assert md[:, :, 0].tomatrix() == Matrix([[10, 14, 18], [22, 26, 30]])
+    assert md[0, 1:2, :].tomatrix() == Matrix([[14, 15, 16, 17]])
+    assert md[0, 1:3, :].tomatrix() == Matrix([[14, 15, 16, 17], [18, 19, 20, 21]])
+    assert md[:, :, :] == md
+
+    sd = MutableSparseNDimArray(range(10, 34), (2, 3, 4))
+    assert sd == MutableSparseNDimArray(md)
+
+    assert sd[:] == md._array
+    assert sd[:] == list(sd)
+    assert sd[:, :, 0].tomatrix() == Matrix([[10, 14, 18], [22, 26, 30]])
+    assert sd[0, 1:2, :].tomatrix() == Matrix([[14, 15, 16, 17]])
+    assert sd[0, 1:3, :].tomatrix() == Matrix([[14, 15, 16, 17], [18, 19, 20, 21]])
+    assert sd[:, :, :] == sd
+
+
+def test_diff():
+    from sympy.abc import x, y, z
+    md = MutableDenseNDimArray([[x, y], [x*z, x*y*z]])
+    assert md.diff(x) == MutableDenseNDimArray([[1, 0], [z, y*z]])
+
+    sd = MutableSparseNDimArray(md)
+    assert sd == MutableSparseNDimArray([x, y, x*z, x*y*z], (2, 2))
+    assert sd.diff(x) == MutableSparseNDimArray([[1, 0], [z, y*z]])


### PR DESCRIPTION
- fixed bug: allow N-dim array constructors to accept another N-dim array as unique argument.
- sprase arrays now support element access through slicing (previous PR added this support to dense N-dim arrays only).
- `applyfunc` for N-dim arrays, works exactly as with matrices.
- `diff` for N-dim arrays, works exactly as with matrices.
- added more tests and docstrings.
