### PR TITLE
Fixes #10326

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -967,6 +967,9 @@ class Interval(Set, EvalfMixin):
         if other.is_real is False:
             return false
 
+        if other is S.NegativeInfinity or other is S.Infinity:
+            return false
+
         if self.start is S.NegativeInfinity and self.end is S.Infinity:
             if not other.is_real is None:
                 return other.is_real


### PR DESCRIPTION
Fixes [#10326](https://github.com/sympy/sympy/issues/10326)
The problem occurred  because  of 

```
    if self.start is S.NegativeInfinity and self.end is S.Infinity:
        if not other.is_real is None:
            return other.is_real
```

So if the interval is (-oo, oo) then every real number is contained inside it, but as mentioned in 
[#8203](https://github.com/sympy/sympy/pull/8203), being real means being **extended real**,which means both negative and positive **infinity** are a part of it .I have added a simple check to ensure that if the value to be checked is either  positive or negative infinity then the output is always **false**. As it is impossible to create an interval containing oo  .

@kshitij10496 @asmeurer  have a look.
