### PR TITLE
Fixes #8710

### DIFF
--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -258,7 +258,7 @@ class GeometryEntity(Basic):
         elif isinstance(o, Ray) or isinstance(o, Line):
             return False
         elif isinstance(o, Ellipse):
-            return self.encloses_point(o.center) and not self.intersection(o)
+            return self.encloses_point(o.center) and not self.intersection(o) and self.encloses_point(Point(o.center.x+o.hradius,o.center.y))
         elif isinstance(o, Polygon):
             if isinstance(o, RegularPolygon):
                 if not self.encloses_point(o.center):

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -3,7 +3,7 @@ import warnings
 
 from sympy import Abs, Rational, Float, S, Symbol, cos, pi, sqrt, oo
 from sympy.functions.elementary.trigonometric import tan
-from sympy.geometry import (Circle, GeometryError, Point, Polygon, Ray, RegularPolygon, Segment, Triangle, are_similar,
+from sympy.geometry import (Circle, Ellipse, GeometryError, Point, Polygon, Ray, RegularPolygon, Segment, Triangle, are_similar,
                             convex_hull, intersection, Line)
 from sympy.utilities.pytest import raises
 from sympy.utilities.randtest import verify_numerically
@@ -78,6 +78,8 @@ def test_polygon():
     assert p5.encloses_point(Point(1, 3))
     assert p5.encloses_point(Point(0, 0)) is False
     assert p5.encloses_point(Point(4, 0)) is False
+    assert p1.encloses(Circle(Point(2.5,2.5),5)) is False
+    assert p1.encloses(Ellipse(Point(2.5,2),5,6)) is False
     p5.plot_interval('x') == [x, 0, 1]
     assert p5.distance(
         Polygon(Point(10, 10), Point(14, 14), Point(10, 14))) == 6 * sqrt(2)


### PR DESCRIPTION
Fixes [#8710](https://github.com/sympy/sympy/issues/8710)
 circle is a subset of ellipse, so we focus on ellipse.
The problem occurred  because  of 

```
   elif isinstance(o, Ellipse):
            return self.encloses_point(o.center) and not self.intersection(o)
```

This means that in order to check if an ellipse is enclosed inside a geometric entity there are only 2 checks 
1. If center of ellipse is inside geometric entity
2. The geometric entity does not intersect with ellipse

But these checks are incomplete because the ellipse could actually satisfy these checks if its center is inside the entity and it encloses the rest of the geometry.
Hence i added another check
3. To ensure that a vertex of the ellipse is enclosed inside the geometric entity

This is an image to showing the bug 
![bug](https://cloud.githubusercontent.com/assets/11155207/12047867/ba04e496-aef8-11e5-8cba-034655319bae.png)
Since we had only checked for the center this one returns true, instead of returning false.

This is an image showing that enclosing the vertex of the ellipse will solve our problem 

![fix](https://cloud.githubusercontent.com/assets/11155207/12047871/cd8d2cb2-aef8-11e5-88c1-ae09b8a38a80.png)

This one returns false as the vertex of the ellipse is not enclosed.
This is the fix i made.

@smichr  Please take a look.
