### PR TITLE
Interval(-oo,oo) contains oo and -oo

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -964,13 +964,12 @@ class Interval(Set, EvalfMixin):
         return FiniteSet(self.start, self.end)
 
     def _contains(self, other):
-        if other.is_real is False:
+        if other.is_real is False or other is S.NegativeInfinity or other is S.Infinity:
             return false
+
 
         if self.start is S.NegativeInfinity and self.end is S.Infinity:
             if not other.is_real is None:
-                if other is S.NegativeInfinity or other is S.Infinity:
-                    return false
                 return other.is_real
 
         if self.left_open:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -969,6 +969,8 @@ class Interval(Set, EvalfMixin):
 
         if self.start is S.NegativeInfinity and self.end is S.Infinity:
             if not other.is_real is None:
+                if other is S.NegativeInfinity or other is S.Infinity:
+                    return false
                 return other.is_real
 
         if self.left_open:

--- a/sympy/sets/tests/test_contains.py
+++ b/sympy/sets/tests/test_contains.py
@@ -15,3 +15,9 @@ def test_issue_6194():
     assert Contains(x, FiniteSet(0)) != S.false
     assert Contains(x, Interval(1, 1)) != S.false
     assert Contains(x, S.Integers) != S.false
+
+def test_issue_10326():
+    assert Contains(S.Infinity, Interval(S.NegativeInfinity, S.Infinity)) == False
+    assert Contains(S.NegativeInfinity, Interval(S.NegativeInfinity, S.Infinity)) == False
+
+

--- a/sympy/sets/tests/test_contains.py
+++ b/sympy/sets/tests/test_contains.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, Contains, S, Interval, FiniteSet
+from sympy import Symbol, Contains, S, Interval, FiniteSet, oo
 
 
 def test_contains_basic():
@@ -16,8 +16,7 @@ def test_issue_6194():
     assert Contains(x, Interval(1, 1)) != S.false
     assert Contains(x, S.Integers) != S.false
 
+
 def test_issue_10326():
-    assert Contains(S.Infinity, Interval(S.NegativeInfinity, S.Infinity)) == False
-    assert Contains(S.NegativeInfinity, Interval(S.NegativeInfinity, S.Infinity)) == False
-
-
+    assert Contains(oo, Interval(-oo, oo)) == False
+    assert Contains(-oo, Interval(-oo, oo)) == False


### PR DESCRIPTION
Fix #10326 issue
Just add 2 lines to handle (-oo,oo) case
