### PR TITLE
Fixes 8875 and more

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1491,7 +1491,9 @@ class totient(Function):
     @classmethod
     def eval(cls, n):
         n = sympify(n)
-        if n.is_Integer:
+        if n==S.NegativeInfinity: raise ValueError("n must be a positive integer")
+        elif n==S.Infinity: return S.Infinity
+        elif n.is_Integer:
             if n < 1:
                 raise ValueError("n must be a positive integer")
             factors = factorint(n)
@@ -1499,6 +1501,8 @@ class totient(Function):
             for p, k in factors.items():
                 t *= (p - 1) * p**(k - 1)
             return t
+        elif n.is_Float:
+            raise ValueError("n must be a positive integer")
 
     def _eval_is_integer(self):
         return fuzzy_and([self.args[0].is_integer, self.args[0].is_positive])

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -282,6 +282,10 @@ def test_totient():
 
     n = Symbol("n", integer=True, positive=True)
     assert totient(n).is_integer
+    from sympy import oo
+    raises(ValueError, lambda: totient(-oo))
+    raises(ValueError, lambda: totient(12.31))
+    assert totient(oo)==oo
 
 
 def test_divisor_sigma():


### PR DESCRIPTION
Fixes [#8875](https://github.com/sympy/sympy/issues/8875)
1. Handles infinity properly instead of treating it as a symbol. 
2. Raises value error for -ve infinity
3. Raises value error for float 
4. Added Tests 
[Definition](https://en.wikipedia.org/wiki/Euler%27s_totient_function)
