### PR TITLE
Crypto: Add raise before calling ValueError

### DIFF
--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1557,7 +1557,7 @@ def encipher_elgamal(m, puk):
 
     """
     if m > puk[0]:
-        ValueError('Message {} should be less than prime {}'.format(m, puk[0]))
+        raise ValueError('Message {} should be less than prime {}'.format(m, puk[0]))
     r = randrange(2, puk[0])
     return pow(puk[1], r, puk[0]), m * pow(puk[2], r, puk[0]) % puk[0]
 
@@ -1708,6 +1708,6 @@ def dh_shared_key(puk, b):
     """
     p, _, x = puk
     if 1 >= b or b >= p:
-        ValueError('Value of b should be greater 1 and less than prime {}'\
+        raise ValueError('Value of b should be greater 1 and less than prime {}'\
                 .format(p))
     return pow(x, b, p)

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -255,6 +255,7 @@ def test_elgamal():
     ek = elgamal_public_key(dk)
     m = 12345
     assert m == decipher_elgamal(encipher_elgamal(m, ek), dk)
+    raises(ValueError, lambda: encipher_elgamal(2000, (1031, 14, 212)))
 
 def test_dh_private_key():
     p, g, _ = dh_private_key(digit = 100)
@@ -275,3 +276,4 @@ def test_dh_shared_key():
     b = randrange(2, p)
     sk = dh_shared_key((p, _, ga), b)
     assert sk == pow(ga, b, p)
+    raises(ValueError, lambda: dh_shared_key((1031, 14, 565), 2000))


### PR DESCRIPTION
`encipher_elgamal` and `dh_shared_key` call `ValueError` without a raise. This means that even when the functions are used with wrong values for example as in:

`encipher_elgamal(2000, (1031, 14, 212))` [here `m = 2000` is greater than `puk[0] = 1031` which is not allowed]

or

`dh_shared_key((1031, 14, 565), 2000)` [here `b = 2000` is greater than `p = 1031` which is also restricted]

both functions still return a result and the error is not shown to the user. I simply added the `raise` before the two `ValueError`-calls.
