### PR TITLE
Implementing #10318 feature determinant of jacobian non-square matrix

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1549,7 +1549,9 @@ class MatrixBase(object):
         return self._new(m, n, lambda j, i: self[j].diff(X[i]))
 
     def jacobian_det(self,X):
-        """Calculates determinant of jacobian matrix. Matrix can be non-square
+        """Calculates determinant of jacobian matrix. Matrix can be non-square.
+        Returns determinant of jacobian matrix if it's square, else square root
+        of determinant of product matrix and transposed matrix
 
         Parameters
         ========
@@ -1559,9 +1561,6 @@ class MatrixBase(object):
 
         Both self and X can be a row or a column matrix in any order
         (i.e., jacobian_det() should always work).
-
-        Returns det of jacobian matrix if it's square, else square root
-        of determinant multiplie matrix and transposed matrix
 
         Examples
         ========
@@ -1574,13 +1573,21 @@ class MatrixBase(object):
         >>> X = Matrix([r*cos(a),r*sin(a)])
         >>> X.jacobian_det([a,r])
         -r*sin(a)**2 - r*cos(a)**2
+
+        See Also
+        ========
+
+        jacobian
+        determinant
         """
 
         mat = self.jacobian(X)
         if mat.cols == mat.rows:
             return mat.det()
+        elif mat.cols > mat.rows:
+            return sqrt((mat*mat.T).det())
         else:
-            return sqrt((mat.T*mat).det())
+            return sqrt((mat*mat.T).det())
 
     def QRdecomposition(self):
         """Return Q, R where A = Q*R, Q is orthogonal and R is upper triangular.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1548,6 +1548,40 @@ class MatrixBase(object):
         # computing the Jacobian is now easy:
         return self._new(m, n, lambda j, i: self[j].diff(X[i]))
 
+    def jacobian_det(self,X):
+        """Calculates determinant of jacobian matrix. Matrix can be non-square
+
+        Parameters
+        ========
+
+        self : vector of expressions representing functions f_i(x_1, ..., x_n).
+        X : set of x_i's in order, it can be a list or a Matrix
+
+        Both self and X can be a row or a column matrix in any order
+        (i.e., jacobian_det() should always work).
+
+        Returns det of jacobian matrix if it's square, else square root
+        of determinant multiplie matrix and transposed matrix
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix, sin, cos
+        >>> from sympy.abc import a, b, r
+        >>> X = Matrix([a*b,a,b])
+        >>> X.jacobian_det([a,b])
+        sqrt(a**2 + b**2 + 1)
+        >>> X = Matrix([r*cos(a),r*sin(a)])
+        >>> X.jacobian_det([a,r])
+        -r*sin(a)**2 - r*cos(a)**2
+        """
+
+        mat = self.jacobian(X)
+        if mat.cols == mat.rows:
+            return mat.det()
+        else:
+            return sqrt((mat.T*mat).det())
+
     def QRdecomposition(self):
         """Return Q, R where A = Q*R, Q is orthogonal and R is upper triangular.
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1554,7 +1554,7 @@ class MatrixBase(object):
         of determinant of product matrix and transposed matrix
 
         Parameters
-        ========
+        ==========
 
         self : vector of expressions representing functions f_i(x_1, ..., x_n).
         X : set of x_i's in order, it can be a list or a Matrix
@@ -1587,7 +1587,7 @@ class MatrixBase(object):
         elif mat.cols > mat.rows:
             return sqrt((mat*mat.T).det())
         else:
-            return sqrt((mat*mat.T).det())
+            return sqrt((mat.T*mat).det())
 
     def QRdecomposition(self):
         """Return Q, R where A = Q*R, Q is orthogonal and R is upper triangular.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2668,3 +2668,10 @@ def test_issue_9422():
     assert x*M1 != M1*x
     assert a*M1 == M1*a
     assert y*x*M == Matrix([[y*x, 0], [0, y*x]])
+
+def test_jacobian_det():
+    y = Matrix([b*sin(a), b*sin(a), b])
+    x = Matrix([a, b])
+    assert y.jacobian_det(x) == sqrt(2)*sqrt(b**2*cos(a)**2)
+    y = Matrix([a*b])
+    assert y.jacobian_det(x) == sqrt(a**2 + b**2)


### PR DESCRIPTION
Request #10318
In jacobian interpretation determinant of non-square matrices defined
as sqrt(det(matix*matrix.T) makes a sense. So added it
