### PR TITLE
Added the sympy.series.approximants function (Pade approximants).

### DIFF
--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -173,6 +173,10 @@ def guess_generating_function_rational(v, X=Symbol('x'), maxcoeff=1024):
     >>> guess_generating_function_rational(l)
     (3*x + 5)/(-x**2 - x + 1)
 
+    See also
+    ========
+    See function sympy.series.approximants and mpmath.pade
+
     """
     #   a) compute the denominator as q
     q = find_simple_recurrence_vector(v, maxcoeff=maxcoeff)

--- a/sympy/series/__init__.py
+++ b/sympy/series/__init__.py
@@ -4,6 +4,7 @@ from .order import Order
 from .limits import limit, Limit
 from .gruntz import gruntz
 from .series import series
+from .approximants import approximants
 from .residues import residue
 from .sequences import (EmptySequence, SeqPer, SeqFormula, sequence, SeqAdd,
                         SeqMul)

--- a/sympy/series/approximants.py
+++ b/sympy/series/approximants.py
@@ -1,0 +1,100 @@
+from __future__ import print_function, division
+
+from sympy.utilities import public
+
+from sympy.core.compatibility import range
+from sympy import Integer
+from sympy.core import Symbol
+
+@public
+def approximants(l, X=Symbol('x'), simplify=False):
+    """
+    Return a generator for consecutive Pade approximants for a series.
+    It can also be used for computing the rational generating function of a
+    series when possible, since the last approximant returned by the generator
+    will be the generating function (if any).
+
+    The input list can contain more complex expressions than integer or rational
+    numbers; symbols may also be involved in the computation. An example below
+    show how to compute the generating function of the whole Pascal triangle.
+
+    The generator can be asked to apply the sympy.simplify function on each
+    generated term, which will make the computation slower; however it may be
+    useful when symbols are involved in the expressions.
+
+    Examples
+    ========
+
+    >>> from sympy.series import approximants
+    >>> from sympy import lucas, fibonacci, symbols, binomial
+    >>> g = [lucas(k) for k in range(16)]
+    >>> [x for x in approximants(g)]
+    [2, -4/(x - 2), (5*x - 2)/(3*x - 1), (x - 2)/(x**2 + x - 1)]
+
+    >>> h = [fibonacci(k) for k in range(16)]
+    >>> [x for x in approximants(h)]
+    [x, -x/(x - 1), (x**2 - x)/(2*x - 1), -x/(x**2 + x - 1)]
+
+    >>> x, t = symbols("x,t")
+    >>> p=[sum(binomial(k,i)*x**i for i in range(k+1)) for k in range(16)]
+    >>> y = approximants(p, t)
+    >>> for k in range(3): print(y.next())
+    1
+    (x + 1)/((-x - 1)*(t*(x + 1) + (x + 1)/(-x - 1)))
+    nan
+
+    >>> y = approximants(p, t, simplify=True)
+    >>> for k in range(3): print(y.next())
+    1
+    -1/(t*(x + 1) - 1)
+    nan
+
+    See also
+    ========
+    See function sympy.concrete.guess.guess_generating_function_rational and
+    function mpmath.pade
+
+    """
+    p1, q1 = [Integer(1)], [Integer(0)]
+    p2, q2 = [Integer(0)], [Integer(1)]
+    while len(l):
+        b = 0
+        while l[b]==0:
+            b += 1
+            if b == len(l):
+                return
+        m = [Integer(1)/l[b]]
+        for k in range(b+1, len(l)):
+            s = 0
+            for j in range(b, k):
+                s -= l[j+1] * m[b-j-1]
+            m.append(s/l[b])
+        l = m
+        a, l[0] = l[0], 0
+        p = [0] * max(len(p2), b+len(p1))
+        q = [0] * max(len(q2), b+len(q1))
+        for k in range(len(p2)):
+            p[k] = a*p2[k]
+        for k in range(b, b+len(p1)):
+            p[k] += p1[k-b]
+        for k in range(len(q2)):
+            q[k] = a*q2[k]
+        for k in range(b, b+len(q1)):
+            q[k] += q1[k-b]
+        while p[-1]==0: p.pop()
+        while q[-1]==0: q.pop()
+        p1, p2 = p2, p
+        q1, q2 = q2, q
+
+        # yield result
+        from sympy import denom, lcm, simplify as simp
+        c = 1
+        for x in p:
+            c = lcm(c, denom(x))
+        for x in q:
+            c = lcm(c, denom(x))
+        out = ( sum(c*e*X**k for k, e in enumerate(p))
+              / sum(c*e*X**k for k, e in enumerate(q)) )
+        if simplify: yield(simp(out))
+        else: yield out
+    return

--- a/sympy/series/approximants.py
+++ b/sympy/series/approximants.py
@@ -28,11 +28,11 @@ def approximants(l, X=Symbol('x'), simplify=False):
     >>> from sympy.series import approximants
     >>> from sympy import lucas, fibonacci, symbols, binomial
     >>> g = [lucas(k) for k in range(16)]
-    >>> [x for x in approximants(g)]
+    >>> [e for e in approximants(g)]
     [2, -4/(x - 2), (5*x - 2)/(3*x - 1), (x - 2)/(x**2 + x - 1)]
 
     >>> h = [fibonacci(k) for k in range(16)]
-    >>> [x for x in approximants(h)]
+    >>> [e for e in approximants(h)]
     [x, -x/(x - 1), (x**2 - x)/(2*x - 1), -x/(x**2 + x - 1)]
 
     >>> x, t = symbols("x,t")

--- a/sympy/series/approximants.py
+++ b/sympy/series/approximants.py
@@ -38,13 +38,13 @@ def approximants(l, X=Symbol('x'), simplify=False):
     >>> x, t = symbols("x,t")
     >>> p=[sum(binomial(k,i)*x**i for i in range(k+1)) for k in range(16)]
     >>> y = approximants(p, t)
-    >>> for k in range(3): print(y.next())
+    >>> for k in range(3): print(next(y))
     1
     (x + 1)/((-x - 1)*(t*(x + 1) + (x + 1)/(-x - 1)))
     nan
 
     >>> y = approximants(p, t, simplify=True)
-    >>> for k in range(3): print(y.next())
+    >>> for k in range(3): print(next(y))
     1
     -1/(t*(x + 1) - 1)
     nan

--- a/sympy/series/tests/test_approximants.py
+++ b/sympy/series/tests/test_approximants.py
@@ -1,0 +1,13 @@
+from sympy.core.compatibility import range
+
+from sympy.series import approximants
+from sympy import fibonacci, lucas
+
+
+def test_approximants():
+    g = [lucas(k) for k in range(16)]
+    assert len([x for x in approximants(g)]) == 4
+    g = [lucas(k)+fibonacci(k+2) for k in range(16)]
+    assert len([x for x in approximants(g)]) == 4
+    g = [lucas(k)**2 for k in range(16)]
+    assert len([x for x in approximants(g)]) == 6

--- a/sympy/series/tests/test_approximants.py
+++ b/sympy/series/tests/test_approximants.py
@@ -1,13 +1,23 @@
 from sympy.core.compatibility import range
 
 from sympy.series import approximants
-from sympy import fibonacci, lucas
+from sympy import lucas, fibonacci, symbols, binomial
 
 
 def test_approximants():
+    x, t = symbols("x,t")
     g = [lucas(k) for k in range(16)]
-    assert len([x for x in approximants(g)]) == 4
+    assert [e for e in approximants(g)] == (
+        [2, -4/(x - 2), (5*x - 2)/(3*x - 1), (x - 2)/(x**2 + x - 1)] )
     g = [lucas(k)+fibonacci(k+2) for k in range(16)]
-    assert len([x for x in approximants(g)]) == 4
+    assert [e for e in approximants(g)] == (
+        [3, -3/(x - 1), (3*x - 3)/(2*x - 1), -3/(x**2 + x - 1)] )
     g = [lucas(k)**2 for k in range(16)]
-    assert len([x for x in approximants(g)]) == 6
+    assert [e for e in approximants(g)] == (
+        [4, -16/(x - 4), (35*x - 4)/(9*x - 1), (37*x - 28)/(13*x**2 + 11*x - 7),
+        (50*x**2 + 63*x - 52)/(37*x**2 + 19*x - 13),
+        (-x**2 - 7*x + 4)/(x**3 - 2*x**2 - 2*x + 1)] )
+    p = [sum(binomial(k,i)*x**i for i in range(k+1)) for k in range(16)]
+    y = approximants(p, t, simplify=True)
+    assert next(y) == 1
+    assert next(y) == -1/(t*(x + 1) - 1)


### PR DESCRIPTION
I implemented the algorithm for Padé approximants. It allows to compute consecutive approximants for a given series (which is already possible with mp.math or functions from sympy.concrete.guess). This new function has two special features:
- it is a generator; consecutive approximants are computed one by one (while other functions more or less jump to the last one which is the best one);
- it works on numbers as well as on symbolic expressions; thus computing approximants for a series involving other variables is also possible (an example is provided in the doctests for finding the generating function of the Pascal triangle).

Please, @certik and @mattpap , could you have a look and tell me if it is worth adding it? Regards.
