### PR TITLE
Sympy abs is better for handling complex number #9474

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -305,7 +305,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         # Use either numpy (if available) or python.math where possible.
         # XXX: This leads to different behaviour on different systems and
         #      might be the reason for irreproducible errors.
-        modules = ["mpmath", "math", "sympy"]
+        modules = ["sympy", "math", "mpmath"]
 
         #Attempt to import numpy
         try:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -297,7 +297,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     """
     from sympy.core.symbol import Symbol
     from sympy.utilities.iterables import flatten
-    
 
     # If the user hasn't specified any modules, use what is available.
     module_provided = True

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -12,6 +12,7 @@ from sympy.external import import_module
 from sympy.core.compatibility import exec_, is_sequence, iterable, string_types, range, builtins
 from sympy.utilities.decorator import doctest_depends_on
 
+
 # These are the namespaces the lambda functions will use.
 MATH = {}
 MPMATH = {}
@@ -31,7 +32,6 @@ NUMEXPR_DEFAULT = {}
 
 # Mappings between sympy and other modules function names.
 MATH_TRANSLATIONS = {
-    "Abs": "fabs",
     "ceiling": "ceil",
     "E": "e",
     "ln": "log",
@@ -297,6 +297,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     """
     from sympy.core.symbol import Symbol
     from sympy.utilities.iterables import flatten
+    
 
     # If the user hasn't specified any modules, use what is available.
     module_provided = True
@@ -305,7 +306,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         # Use either numpy (if available) or python.math where possible.
         # XXX: This leads to different behaviour on different systems and
         #      might be the reason for irreproducible errors.
-        modules = ["sympy", "math", "mpmath"]
+        modules = ["math", "mpmath", "sympy"]
 
         #Attempt to import numpy
         try:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -305,7 +305,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
         # Use either numpy (if available) or python.math where possible.
         # XXX: This leads to different behaviour on different systems and
         #      might be the reason for irreproducible errors.
-        modules = ["math", "mpmath", "sympy"]
+        modules = ["mpmath", "math", "sympy"]
 
         #Attempt to import numpy
         try:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -581,3 +581,7 @@ def test_issue_2790():
 def test_ITE():
     assert lambdify((x, y, z), ITE(x, y, z))(True, 5, 3) == 5
     assert lambdify((x, y, z), ITE(x, y, z))(False, 5, 3) == 3
+
+
+def test_issue_9474():
+    assert lambdify([k], abs(k**2))(10.01+0.1j) == 100.2101

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -584,4 +584,5 @@ def test_ITE():
 
 
 def test_issue_9474():
+    k = symbols('k', complex=True)
     assert lambdify([k], abs(k**2))(10.01+0.1j) == 100.2101

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -585,4 +585,4 @@ def test_ITE():
 
 def test_issue_9474():
     k = symbols('k', complex=True)
-    assert lambdify([k], abs(k**2))(10.01+0.1j) == 100.2101
+    assert lambdify([k], abs(k**2))(10.01+0.1j) == 100.210100000000

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -585,4 +585,5 @@ def test_ITE():
 
 def test_issue_9474():
     k = symbols('k', complex=True)
-    assert lambdify([k], abs(k**2))(10.01+0.1j) == 100.210100000000
+    f = lambdify([k], abs(k**2))
+    assert f(10.01+0.1j) == 100.2101


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/9474
module should be default.
I think math module  can handle only complex number that contains I(Iota).

math.fabs() converts its argument to float if it can (if it can't, it throws an exception). It then takes the absolute value, and returns the result as a float.

```
>>> type(abs(-2))
<type 'int'>
>>> type(abs(-2j))
<type 'float'>
>>> import math
>>> type(math.fabs(-2j))
Traceback (most recent call last):
  File "<console>", line 1, in <module>
TypeError: can't convert complex to float
```
