### PR TITLE
Remove unnecessary simplify from Line.equation()

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1119,7 +1119,7 @@ class Line(LinearEntity):
             return y - p1.y
 
         a, b, c = self.coefficients
-        return simplify(a*x + b*y + c)
+        return a*x + b*y + c
 
     def contains(self, o):
         """


### PR DESCRIPTION
The call to simplify is not needed, and costs a lot of time.

before:

```
python -m timeit -n 1000 "from sympy import Line; l = Line([0,0],[1,2])" "s = l.equation()"
1000 loops, best of 3: 7.64 msec per loop
```

after:

```
python -m timeit -n 1000 "from sympy import Line; l = Line([0,0],[1,2])" "s = l.equation()"
1000 loops, best of 3: 358 usec per loop
```
