### PR TITLE
10368: make sure result of int(Rational) is an int (if possible)

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1403,8 +1403,8 @@ class Rational(Number):
     def __int__(self):
         p, q = self.p, self.q
         if p < 0:
-            return -(-p//q)
-        return p//q
+            return -int(-p//q)
+        return int(p//q)
 
     __long__ = __int__
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1027,6 +1027,10 @@ def test_int():
     assert int(pi) == 3
     assert int(E) == 2
     assert int(GoldenRatio) == 1
+    # issue 10368
+    a = S(32442016954)/78058255275
+    assert type(int(a)) is type(int(-a)) is int
+
 
 def test_long():
     a = Rational(5)


### PR DESCRIPTION
The expression `int(S(32442016954)/78058255275)` formerly gave `0L`.
The actual values are immaterial; the long is obtained because
**operations** involving longs are used to obtain the result. Since
the result may be small enough to be represented as an int, the
return value is now wrapped in `int`.

closes #10368 
