### PR TITLE
subresultants_pg_amv.py contains functions for computing

### DIFF
--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -1,0 +1,1771 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Dec 28 13:25:02 2015
+
+@author: alkis
+"""
+
+from __future__ import print_function, division
+
+from sympy import (Abs, degree, expand, floor, LC, Matrix, nan, Poly)
+from sympy import (pprint, QQ, rem, S, sign, simplify, summation, var, zeros)
+
+def sylvester(f, g, x, method = 1):
+    '''
+      f, g polys in x, m = deg(f) >= deg(g) = n.
+
+      a. If method = 1 (default), computes sylvester1, Sylvester's matrix of 1840
+          of dimension (m + n) x (m + n). The determinants of properly chosen
+          submatrices of this matrix (a.k.a. subresultants) can be
+          used to compute the coefficients of the Euclidean PRS of f, g.
+
+      b. If method = 2, computes sylvester2, Sylvester's matrix of 1853
+          of dimension (2*m) x (2*m). The determinants of properly chosen
+          submatrices of this matrix (a.k.a. ``modified'' subresultants) can be
+          used to compute the coefficients of the Sturmian PRS of f, g.
+
+      Applications of these Matrices can be found in the references below.
+      Especially, for applications of sylvester2, see the first reference!!
+
+      References:
+      ===========
+      1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
+      by Van Vleck Regarding Sturm Sequences. Serdica Journal of Computing,
+      Vol. 7, No 4, 101–134, 2013.
+
+      2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+      and Modified Subresultant Polynomial Remainder Sequences.''
+      Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
+
+    '''
+    # obtain degrees of polys
+    m, n = degree( Poly(f, x), x), degree( Poly(g, x), x)
+
+    # Special cases:
+    # A:: case m = n < 0 (i.e. both polys are 0)
+    if m == n and n < 0:
+        return Matrix([])
+
+    # B:: case m = n = 0  (i.e. both polys are constants)
+    if m == n and n == 0:
+        return Matrix([])
+
+    # C:: m == 0 and n < 0 or m < 0 and n == 0
+    # (i.e. one poly is constant and the other is 0)
+    if m == 0 and n < 0:
+        return Matrix([])
+    elif m < 0 and n == 0:
+        return Matrix([])
+
+    # D:: m >= 1 and n < 0 or m < 0 and n >=1
+    # (i.e. one poly is of degree >=1 and the other is 0)
+    if m >= 1 and n < 0:
+        return Matrix([0])
+    elif m < 0 and n >= 1:
+        return Matrix([0])
+
+    fp = Poly(f, x).all_coeffs()
+    gp = Poly(g, x).all_coeffs()
+
+    # order lists of poly coeffs according to degree
+    if m < n:
+        fp, gp = gp, fp
+        m, n = n, m
+
+    # Sylvester's matrix of 1840 (default; a.k.a. sylvester1)
+    if method <= 1:
+        M = zeros(m + n)
+        k = 0
+        for i in range(n):
+            j = k
+            for coeff in fp:
+                M[i, j] = coeff
+                j = j + 1
+            k = k + 1
+        k = 0
+        for i in range(n, m + n):
+            j = k
+            for coeff in gp:
+                M[i, j] = coeff
+                j = j + 1
+            k = k + 1
+        return M
+
+    # Sylvester's matrix of 1853 (a.k.a sylvester2)
+    if method >= 2:
+        dim = 2*m
+        M = zeros( dim )
+        k = 0
+        for i in range( m ):
+            j = k
+            for coeff in fp:
+                if i == 0:
+                    M[i, j] = coeff
+                else:
+                    M[2*i, j] = coeff
+                j = j + 1
+            j = m - n + k
+            for coeff in gp:
+                if i == 0:
+                    M[i+1, j] = coeff
+                else:
+                    M[2*i + 1, j] = coeff
+                j = j + 1
+            k = k + 1
+        return M
+
+def sturm_pg(p, q, x, method=0):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the (generalized) Sturm sequence of p and q in Z[x] or Q[x].
+    If q = diff(p, x, 1) it is the usual Sturm sequence.
+
+    A. If method == 0, default, the remainder coefficients of the sequence
+       are (in absolute value) ``modified'' subresultants, which for non-monic
+       polynomials are greater than the coefficients of the corresponding
+       subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
+
+    B. If method == 1, the remainder coefficients of the sequence are (in
+       absolute value) subresultants, which for non-monic polynomials are
+       smaller than the coefficients of the corresponding ``modified''
+       subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
+
+    If the Sturm sequence is complete, method=0 and LC( p ) > 0, the coefficients
+    of the polynomials in the sequence are ``modified'' subresultants.
+    That is, they are  determinants of appropriately selected submatrices of
+    sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence
+    coincides with the ``modified'' subresultant prs, of the polynomials
+    p, q.
+
+    If the Sturm sequence is incomplete and method=0 then the signs of the
+    coefficients of the polynomials in the sequence may differ from the signs
+    of the coefficients of the corresponding polynomials in the ``modified''
+    subresultant prs; however, the absolute values are the same.
+
+    To compute the coefficients, no determinant evaluation takes place. Instead,
+    polynomial divisions in Q[x] are performed, using the function rem(p, q, x);
+    the coefficients of the remainders computed this way become (``modified'')
+    subresultants with the help of the Pell-Gordon Theorem of 1917.
+    See also the function euclid_pg(p, q, x).
+
+    References:
+    ===========
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
+    Second Series, 18 (1917), No. 4, 188–193.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    d0 =  degree(p, x)
+    d1 =  degree(q, x)
+    if d0 == 0 and d1 == 0:
+        return [p, q]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p,q]
+
+    # make sure LC(p) > 0
+    flag = 0
+    if  LC(p,x) < 0:
+        flag = 1
+        p = -p
+        q = -q
+
+    # initialize
+    lcf = LC(p, x)**(d0 - d1)               # lcf * subr = modified subr
+    a0, a1 = p, q                           # the input polys
+    sturm_seq = [a0, a1]                    # the output list
+    del0 = d0 - d1                          # degree difference
+    rho1 =  LC(a1, x)                       # leading coeff of a1
+    exp_deg = d1 - 1                        # expected degree of a2
+    a2 = - rem(a0, a1, domain=QQ)           # first remainder
+    rho2 =  LC(a2,x)                        # leading coeff of a2
+    d2 =  degree(a2, x)                     # actual degree of a2
+    deg_diff_new = exp_deg - d2             # expected - actual degree
+    del1 = d1 - d2                          # degree difference
+
+    # mul_fac is the factor by which a2 is multiplied to
+    # get integer coefficients
+    mul_fac_old = rho1**(del0 + del1 - deg_diff_new)
+
+    # append accordingly
+    if method == 0:
+        sturm_seq.append( simplify(lcf * a2 *  Abs(mul_fac_old)))
+    else:
+        sturm_seq.append( simplify( a2 *  Abs(mul_fac_old)))
+
+    # main loop
+    deg_diff_old = deg_diff_new
+    while d2 > 0:
+        a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
+        del0 = del1                          # update degree difference
+        exp_deg = d1 - 1                     # new expected degree
+        a2 = - rem(a0, a1, domain=QQ)        # new remainder
+        rho3 =  LC(a2, x)                    # leading coeff of a2
+        d2 =  degree(a2, x)                  # actual degree of a2
+        deg_diff_new = exp_deg - d2          # expected - actual degree
+        del1 = d1 - d2                       # degree difference
+
+        # take into consideration the power
+        # rho1**deg_diff_old that was "left out"
+        expo_old = deg_diff_old               # rho1 raised to this power
+        expo_new = del0 + del1 - deg_diff_new # rho2 raised to this power
+
+        # update variables and append
+        mul_fac_new = rho2**(expo_new) * rho1**(expo_old) * mul_fac_old
+        deg_diff_old, mul_fac_old = deg_diff_new, mul_fac_new
+        rho1, rho2 = rho2, rho3
+        if method == 0:
+            sturm_seq.append( simplify(lcf * a2 *  Abs(mul_fac_old)))
+        else:
+            sturm_seq.append( simplify( a2 *  Abs(mul_fac_old)))
+
+    if flag:          # change the sign of the sequence
+        sturm_seq = [-i for i in sturm_seq]
+
+    # gcd is of degree > 0 ?
+    m = len(sturm_seq)
+    if sturm_seq[m - 1] == nan or sturm_seq[m - 1] == 0:
+        sturm_seq.pop(m - 1)
+
+    return sturm_seq
+
+def sturm_q(p, q, x):
+    """
+    p, q are polynomials in Z[x] or Q[x];
+
+    Computes the (generalized) Sturm sequence of p and q in Q[x].
+    Polynomial divisions in Q[x] are performed, using the function rem(p, q, x).
+
+    The coefficients of the polynomials in the Sturm sequence can be uniquely
+    determined from the corresponding coefficients of the polynomials found
+    either in:
+
+        (a) the ``modified'' subresultant prs, (references 1, 2)
+
+    or in
+
+        (b) the subresultant prs (reference 3).
+
+    References:
+    ===========
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
+    Second Series, 18 (1917), No. 4, 188–193.
+
+    2 Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    d0 =  degree(p, x)
+    d1 =  degree(q, x)
+    if d0 == 0 and d1 == 0:
+        return [p, q]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p,q]
+
+    # make sure LC(p) > 0
+    flag = 0
+    if  LC(p,x) < 0:
+        flag = 1
+        p = -p
+        q = -q
+
+    # initialize
+    a0, a1 = p, q                           # the input polys
+    sturm_seq = [a0, a1]                    # the output list
+    a2 = -rem(a0, a1, domain=QQ)            # first remainder
+    d2 =  degree(a2, x)                     # degree of a2
+    sturm_seq.append( a2 )
+
+    # main loop
+    while d2 > 0:
+        a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
+        a2 = -rem(a0, a1, domain=QQ)         # new remainder
+        d2 =  degree(a2, x)                  # actual degree of a2
+        sturm_seq.append( a2 )
+
+    if flag:          # change the sign of the sequence
+        sturm_seq = [-i for i in sturm_seq]
+
+    # gcd is of degree > 0 ?
+    m = len(sturm_seq)
+    if sturm_seq[m - 1] == nan or sturm_seq[m - 1] == 0:
+        sturm_seq.pop(m - 1)
+
+    return sturm_seq
+
+def sturm_amv(p, q, x, method=0):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the (generalized) Sturm sequence of p and q in Z[x] or Q[x].
+    If q = diff(p, x, 1) it is the usual Sturm sequence.
+
+    A. If method == 0, default, the remainder coefficients of the
+       sequence are (in absolute value) ``modified'' subresultants, which
+       for non-monic polynomials are greater than the coefficients of the
+       corresponding subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
+
+    B. If method == 1, the remainder coefficients of the sequence are (in
+       absolute value) subresultants, which for non-monic polynomials are
+       smaller than the coefficients of the corresponding ``modified''
+       subresultants by the factor Abs( LC(p)**( deg(p)- deg(q)) ).
+
+    If the Sturm sequence is complete, method=0 and LC( p ) > 0, then the 
+    coefficients of the polynomials in the sequence are ``modified'' subresultants.
+    That is, they are  determinants of appropriately selected submatrices of
+    sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence
+    coincides with the ``modified'' subresultant prs, of the polynomials
+    p, q.
+
+    If the Sturm sequence is incomplete and method=0 then the signs of the
+    coefficients of the polynomials in the sequence may differ from the signs
+    of the coefficients of the corresponding polynomials in the ``modified''
+    subresultant prs; however, the absolute values are the same.
+
+    To compute the coefficients, no determinant evaluation takes place.
+    Instead, we first compute the euclidean sequence  of p and q using
+    euclid_amv(p, q, x) and then: (a) change the signs of the remainders in the
+    Euclidean sequence according to the pattern "-, -, +, +, -, -, +, +,..."
+    (see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference)
+    and (b) if method=0, assuming deg(p) > deg(q), we multiply the remainder
+    coefficients of the Euclidean sequence times the factor
+    Abs( LC(p)**( deg(p)- deg(q)) ) to make them modified subresultants.
+    See also the function sturm_pg(p, q, x).
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica
+    Journal of Computing, to appear.
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
+    Submitted for publication.
+
+    """
+    # compute the euclidean sequence
+    prs = euclid_amv(p, q, x)
+
+    # defensive
+    if prs == [] or len(prs) == 2:
+        return prs
+
+    # the coefficients in prs are subresultants and hence are smaller
+    # than the corresponding subresultants by the factor
+    # Abs( LC(prs[0])**( deg(prs[0]) - deg(prs[1])) ); Theorem 2, 2nd reference.
+    lcf = Abs( LC(prs[0])**( degree(prs[0], x) - degree(prs[1], x) ) )
+
+    # the signs of the first two polys in the sequence stay the same
+    sturm_seq = [prs[0], prs[1]]
+
+    # change the signs according to "-, -, +, +, -, -, +, +,..."
+    # and multiply times lcf if needed
+    flag = 0
+    m = len(prs)
+    i = 2
+    while i <= m-1:
+        if  flag == 0:
+            sturm_seq.append( - prs[i] )
+            i = i + 1
+            if i == m:
+                break
+            sturm_seq.append( - prs[i] )
+            i = i + 1
+            flag = 1
+        elif flag == 1:
+            sturm_seq.append( prs[i] )
+            i = i + 1
+            if i == m:
+                break
+            sturm_seq.append( prs[i] )
+            i = i + 1
+            flag = 0
+
+    # subresultants or modified subresultants?
+    if method == 0 and lcf > 1:
+        aux_seq = [sturm_seq[0], sturm_seq[1]]
+        for i in range(2, m):
+            aux_seq.append(simplify(sturm_seq[i] * lcf ))
+        sturm_seq = aux_seq
+
+    return sturm_seq
+
+def euclid_pg(p, q, x):
+    """
+    p, q are polynomials in Z[x] or Q[x];
+
+    Computes the Euclidean sequence of p and q in Z[x] or Q[x].
+
+    If the Euclidean sequence is complete the coefficients of the polynomials
+    in the sequence are subresultants. That is, they are  determinants of
+    appropriately selected submatrices of sylvester1, Sylvester's matrix of 1840.
+    In this case the Euclidean sequence coincides with the subresultant prs
+    of the polynomials p, q.
+
+    If the Euclidean sequence is incomplete the signs of the coefficients of the
+    polynomials in the sequence may differ from the signs of the coefficients of
+    the corresponding polynomials in the subresultant prs; however, the absolute
+    values are the same.
+
+    To compute the Euclidean sequence, no determinant evaluation takes place.
+    We first compute the (generalized) Sturm sequence  of p and q using
+    sturm_pg(p, q, x, 1), in which case the coefficients are (in absolute value)
+    equal to subresultants. Then we change the signs of the remainders in the
+    Sturm sequence according to the pattern "-, -, +, +, -, -, +, +,..." ;
+    see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference as well as
+    the function sturm_pg(p, q, x).
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica
+    Journal of Computing, to appear.
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
+    Submitted for publication.
+
+    """
+    # compute the sturmian sequence using the Pell-Gordon (or AMV) theorem
+    # with the coefficients in the prs being (in absolute value) subresultants
+    prs = sturm_pg(p, q, x, 1)  ## any other method would do
+
+    # defensive
+    if prs == [] or len(prs) == 2:
+        return prs
+
+    # the signs of the first two polys in the sequence stay the same
+    euclid_seq = [prs[0], prs[1]]
+
+    # change the signs according to "-, -, +, +, -, -, +, +,..."
+    flag = 0
+    m = len(prs)
+    i = 2
+    while i <= m-1:
+        if  flag == 0:
+            euclid_seq.append(- prs[i] )
+            i = i + 1
+            if i == m:
+                break
+            euclid_seq.append(- prs[i] )
+            i = i + 1
+            flag = 1
+        elif flag == 1:
+            euclid_seq.append(prs[i] )
+            i = i + 1
+            if i == m:
+                break
+            euclid_seq.append(prs[i] )
+            i = i + 1
+            flag = 0
+
+    return euclid_seq
+
+def euclid_q(p, q, x):
+    """
+    p, q are polynomials in Z[x] or Q[x];
+
+    Computes the Euclidean sequence of p and q in Q[x].
+    Polynomial divisions in Q[x] are performed, using the function rem(p, q, x).
+
+    The coefficients of the polynomials in the Euclidean sequence can be uniquely
+    determined from the corresponding coefficients of the polynomials found
+    either in:
+
+        (a) the ``modified'' subresultant polynomial remainder sequence,
+    (references 1, 2)
+
+    or in
+
+        (b) the subresultant polynomial remainder sequence (references 3).
+
+    References:
+    ===========
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
+    Second Series, 18 (1917), No. 4, 188–193.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    d0 =  degree(p, x)
+    d1 =  degree(q, x)
+    if d0 == 0 and d1 == 0:
+        return [p, q]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p,q]
+
+    # make sure LC(p) > 0
+    flag = 0
+    if  LC(p,x) < 0:
+        flag = 1
+        p = -p
+        q = -q
+
+    # initialize
+    a0, a1 = p, q                           # the input polys
+    euclid_seq = [a0, a1]                   # the output list
+    a2 = rem(a0, a1, domain=QQ)             # first remainder
+    d2 =  degree(a2, x)                     # degree of a2
+    euclid_seq.append( a2 )
+
+    # main loop
+    while d2 > 0:
+        a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
+        a2 = rem(a0, a1, domain=QQ)          # new remainder
+        d2 =  degree(a2, x)                  # actual degree of a2
+        euclid_seq.append( a2 )
+
+    if flag:          # change the sign of the sequence
+        euclid_seq = [-i for i in euclid_seq]
+
+    # gcd is of degree > 0 ?
+    m = len(euclid_seq)
+    if euclid_seq[m - 1] == nan or euclid_seq[m - 1] == 0:
+        euclid_seq.pop(m - 1)
+
+    return euclid_seq
+
+def euclid_amv(f, g, x):
+    """
+    f, g are polynomials in Z[x] or Q[x].
+
+    Computes the Euclidean sequence of p and q in Z[x] or Q[x].
+
+    If the Euclidean sequence is complete the coefficients of the polynomials
+    in the sequence are subresultants. That is, they are  determinants of
+    appropriately selected submatrices of sylvester1, Sylvester's matrix of 1840.
+    In this case the Euclidean sequence coincides with the subresultant prs,
+    of the polynomials p, q.
+
+    If the Euclidean sequence is incomplete the signs of the coefficients of the
+    polynomials in the sequence may differ from the signs of the coefficients of
+    the corresponding polynomials in the subresultant prs; however, the absolute
+    values are the same.
+
+    To compute the coefficients, no determinant evaluation takes place.
+    Instead, polynomial divisions in Z[x] or Q[x] are performed, using
+    the function rem_z(f, g, x);  the coefficients of the remainders
+    computed this way become subresultants with the help of the
+    Collins-Brown-Traub formula for coefficient reduction.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
+    Submitted for publication.
+
+    """
+    # make sure neither f nor g is 0
+    if f == 0 or g == 0:
+        return [f, g]
+
+    # make sure proper degrees
+    d0 =  degree(f, x)
+    d1 =  degree(g, x)
+    if d0 == 0 and d1 == 0:
+        return [f, g]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        f, g = g, f
+    if d0 > 0 and d1 == 0:
+        return [f, g]
+
+    # initialize
+    a0 = f
+    a1 = g
+    euclid_seq = [a0, a1]
+    deg_dif_p1, c = degree(a0, x) - degree(a1, x) + 1, -1
+
+    # compute the first polynomial of the prs
+    i = 1
+    a2 = rem_z(a0, a1, x) / Abs( (-1)**deg_dif_p1 )     # first remainder
+    euclid_seq.append( a2 )
+    d2 =  degree(a2, x)                              # actual degree of a2
+
+    # main loop
+    while d2 >= 1:
+        a0, a1, d0, d1 = a1, a2, d1, d2       # update polys and degrees
+        i += 1
+        sigma0 = -LC(a0)
+        c = (sigma0**(deg_dif_p1 - 1)) / (c**(deg_dif_p1 - 2))
+        deg_dif_p1 = degree(a0, x) - d2 + 1
+        a2 = rem_z(a0, a1, x) / Abs( ((c**(deg_dif_p1 - 1)) * sigma0) )
+        euclid_seq.append( a2 )
+        d2 =  degree(a2, x)                   # actual degree of a2
+
+    # gcd is of degree > 0 ?
+    m = len(euclid_seq)
+    if euclid_seq[m - 1] == nan or euclid_seq[m - 1] == 0:
+        euclid_seq.pop(m - 1)
+
+    return euclid_seq
+
+def modified_subresultants_pg(p,q,x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the ``modified'' subresultant prs of p and q in Z[x] or Q[x];
+    the coefficients of the polynomials in the sequence are
+    ``modified'' subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester2, Sylvester's matrix of 1853.
+
+    To compute the coefficients, no determinant evaluation takes place. Instead,
+    polynomial divisions in Q[x] are performed, using the function rem(p, q, x);
+    the coefficients of the remainders computed this way become ``modified''
+    subresultants with the help of the Pell-Gordon Theorem of 1917.
+
+    If the ``modified'' subresultant prs is complete, and LC( p ) > 0, it coincides 
+    with the (generalized) Sturm sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
+    Second Series, 18 (1917), No. 4, 188–193.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    d0 =  degree(p,x)
+    d1 =  degree(q,x)
+    if d0 == 0 and d1 == 0:
+        return [p, q]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p,q]
+
+    # initialize
+    k =  var('k')                               # index in summation formula
+    u_list = []                                 # of elements (-1)**u_i
+    subres_l = [p, q]                           # mod. subr. prs output list
+    a0, a1 = p, q                               # the input polys
+    del0 = d0 - d1                              # degree difference
+    degdif = del0                               # save it
+    rho_1 = LC(a0)                              # lead. coeff (a0)
+
+    # Initialize Pell-Gordon variables
+    rho_list_minus_1 =  sign( LC(a0, x))      # sign of LC(a0)
+    rho1 =  LC(a1, x)                         # leading coeff of a1
+    rho_list = [ sign(rho1)]                  # of signs
+    p_list = [del0]                           # of degree differences
+    u =  summation(k, (k, 1, p_list[0]))      # value of u
+    u_list.append(u)                          # of u values
+    v = sum(p_list)                           # v value
+
+    # first remainder
+    exp_deg = d1 - 1                          # expected degree of a2
+    a2 = - rem(a0, a1, domain=QQ)             # first remainder
+    rho2 =  LC(a2, x)                         # leading coeff of a2
+    d2 =  degree(a2, x)                       # actual degree of a2
+    deg_diff_new = exp_deg - d2               # expected - actual degree
+    del1 = d1 - d2                            # degree difference
+
+    # mul_fac is the factor by which a2 is multiplied to
+    # get integer coefficients
+    mul_fac_old = rho1**(del0 + del1 - deg_diff_new)
+
+    # update Pell-Gordon variables
+    p_list.append(1 + deg_diff_new)              # deg_diff_new is 0 for complete seq
+
+    # apply Pell-Gordon formula (7) in second reference
+    num = 1                                     # numerator of fraction
+    for k in range(len(u_list)):
+        num *= (-1)**u_list[k]
+    num = num * (-1)**v
+
+    # denominator depends on complete / incomplete seq
+    if deg_diff_new == 0:                        # complete seq
+        den = 1
+        for k in range(len(rho_list)):
+            den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+        den = den * rho_list_minus_1
+    else:                                       # incomplete seq
+        den = 1
+        for k in range(len(rho_list)-1):
+            den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+        den = den * rho_list_minus_1
+        expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
+        den = den * rho_list[len(rho_list) - 1]**expo
+
+    # the sign of the determinant depends on sg(num / den)
+    if  sign(num / den) > 0:
+        subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+    else:
+        subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+
+    # update Pell-Gordon variables
+    k =  var('k')
+    rho_list.append( sign(rho2))
+    u =  summation(k, (k, 1, p_list[len(p_list) - 1]))
+    u_list.append(u)
+    v = sum(p_list)
+    deg_diff_old=deg_diff_new
+
+    # main loop
+    while d2 > 0:
+        a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
+        del0 = del1                          # update degree difference
+        exp_deg = d1 - 1                     # new expected degree
+        a2 = - rem(a0, a1, domain=QQ)        # new remainder
+        rho3 =  LC(a2, x)                    # leading coeff of a2
+        d2 =  degree(a2, x)                  # actual degree of a2
+        deg_diff_new = exp_deg - d2          # expected - actual degree
+        del1 = d1 - d2                       # degree difference
+
+        # take into consideration the power
+        # rho1**deg_diff_old that was "left out"
+        expo_old = deg_diff_old               # rho1 raised to this power
+        expo_new = del0 + del1 - deg_diff_new # rho2 raised to this power
+
+        mul_fac_new = rho2**(expo_new) * rho1**(expo_old) * mul_fac_old
+
+        # update variables
+        deg_diff_old, mul_fac_old = deg_diff_new, mul_fac_new
+        rho1, rho2 = rho2, rho3
+
+        # update Pell-Gordon variables
+        p_list.append(1 + deg_diff_new)       # deg_diff_new is 0 for complete seq
+
+        # apply Pell-Gordon formula (7) in second reference
+        num = 1                              # numerator
+        for k in range(len(u_list)):
+            num *= (-1)**u_list[k]
+        num = num * (-1)**v
+
+        # denominator depends on complete / incomplete seq
+        if deg_diff_new == 0:                 # complete seq
+            den = 1
+            for k in range(len(rho_list)):
+                den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+            den = den * rho_list_minus_1
+        else:                                # incomplete seq
+            den = 1
+            for k in range(len(rho_list)-1):
+                den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+            den = den * rho_list_minus_1
+            expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
+            den = den * rho_list[len(rho_list) - 1]**expo
+
+        # the sign of the determinant depends on sg(num / den)
+        if  sign(num / den) > 0:
+            subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+        else:
+            subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+
+        # update Pell-Gordon variables
+        k =  var('k')
+        rho_list.append( sign(rho2))
+        u =  summation(k, (k, 1, p_list[len(p_list) - 1]))
+        u_list.append(u)
+        v = sum(p_list)
+
+    # gcd is of degree > 0 ?
+    m = len(subres_l)
+    if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
+        subres_l.pop(m - 1)
+
+    # LC( p ) < 0
+    m = len(subres_l)   # list may be shorter now due to deg(gcd ) > 0
+    if LC( p ) < 0:
+        aux_seq = [subres_l[0], subres_l[1]]
+        for i in range(2, m):
+            aux_seq.append(simplify(subres_l[i] * (-1) ))
+        subres_l = aux_seq
+
+    return  subres_l
+
+def subresultants_pg(p,q,x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the subresultant prs of p and q in Z[x] or Q[x], from
+    the modified subresultant prs of p and q.
+
+    The coefficients of the polynomials in these two sequences differ only
+    in sign and the factor LC(p)**( deg(p)- deg(q)) as stated in
+    Theorem 2 of the reference.
+
+    The coefficients of the polynomials in the output sequence are
+    subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester1, Sylvester's matrix of 1840.
+
+    If the subresultant prs is complete, then it coincides with the
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
+    Serdica Journal of Computing, to appear.
+
+    """
+    # compute the modified subresultant prs
+    lst = modified_subresultants_pg(p,q,x)  ## any other method would do
+
+    # defensive
+    if lst == [] or len(lst) == 2:
+        return lst
+
+    # the coefficients in lst are modified subresultants and, hence, are
+    # greater than those of the corresponding subresultants by the factor
+    # LC(lst[0])**( deg(lst[0]) - deg(lst[1])); see Theorem 2 in reference.
+    lcf = LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) ) 
+
+    # Initialize the subresultant prs list
+    subr_seq = [lst[0], lst[1]]
+
+    # compute the degree sequences m_i and j_i of Theorem 2 in reference.
+    deg_seq = [degree(Poly(poly, x), x) for poly in lst]
+    deg = deg_seq[0]
+    deg_seq_s = deg_seq[1:-1]
+    m_seq = [m-1 for m in deg_seq_s]
+    j_seq = [deg - m for m in m_seq]
+
+    # compute the AMV factors of Theorem 2 in reference.
+    fact = [(-1)**( j*(j-1)/S(2) ) for j in j_seq]
+
+    # shortened list without the first two polys
+    lst_s = lst[2:]
+
+    # poly lst_s[k] is multiplied times fact[k], divided by lcf
+    # and appended to the subresultant prs list
+    m = len(fact)
+    for k in range(m):
+        if sign(fact[k]) == -1:
+            subr_seq.append(-lst_s[k] / lcf)
+        else:
+            subr_seq.append(lst_s[k] / lcf)
+
+    return subr_seq
+
+def subresultants_amv_q(p,q,x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the subresultant prs of p and q in Q[x];
+    the coefficients of the polynomials in the sequence are
+    subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester1, Sylvester's matrix of 1840.
+
+    To compute the coefficients, no determinant evaluation takes place.
+    Instead, polynomial divisions in Q[x] are performed, using the
+    function rem(p, q, x);  the coefficients of the remainders
+    computed this way become subresultants with the help of the
+    Akritas-Malaschonok-Vigklas Theorem of 2015.
+
+    If the subresultant prs is complete, then it coincides with the
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
+    Submitted for publication.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    d0 =  degree(p, x)
+    d1 =  degree(q, x)
+    if d0 == 0 and d1 == 0:
+        return [p, q]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p, q]
+
+    # initialize
+    i, s = 0, 0                              # counters for remainders & odd elements
+    p_odd_index_sum = 0                      # contains the sum of p_1, p_3, etc
+    subres_l = [p, q]                        # subresultant prs output list
+    a0, a1 = p, q                            # the input polys
+    sigma1 =  LC(a1, x)                      # leading coeff of a1
+    p0 = d0 - d1                             # degree difference
+    if p0 % 2 == 1:
+        s += 1
+    phi = floor( (s + 1) / 2 )
+    mul_fac = 1
+    d2 = d1
+
+    # main loop
+    while d2 > 0:
+        i += 1
+        a2 = rem(a0, a1, domain= QQ)          # new remainder
+        if i == 1:
+            sigma2 =  LC(a2, x)
+        else:
+            sigma3 =  LC(a2, x)
+            sigma1, sigma2 = sigma2, sigma3
+        d2 =  degree(a2, x)
+        p1 = d1 - d2
+        psi = i + phi + p_odd_index_sum
+
+        # new mul_fac
+        mul_fac = sigma1**(p0 + 1) * mul_fac
+
+        ## compute the sign of the first fraction in formula (9) of the paper
+        # numerator
+        num = (-1)**psi
+        # denominator
+        den = sign(mul_fac)
+
+        # the sign of the determinant depends on sign( num / den ) != 0
+        if  sign(num / den) > 0:
+            subres_l.append( simplify(expand(a2* Abs(mul_fac))))
+        else:
+            subres_l.append(- simplify(expand(a2* Abs(mul_fac))))
+
+        ## bring into mul_fac the missing power of sigma if there was a degree gap
+        if p1 - 1 > 0:
+            mul_fac = mul_fac * sigma1**(p1 - 1)
+
+       # update AMV variables
+        a0, a1, d0, d1 = a1, a2, d1, d2
+        p0 = p1
+        if p0 % 2 ==1:
+            s += 1
+        phi = floor( (s + 1) / 2 )
+        if i%2 == 1:
+            p_odd_index_sum += p0             # p_i has odd index
+
+    # gcd is of degree > 0 ?
+    m = len(subres_l)
+    if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
+        subres_l.pop(m - 1)
+
+    return  subres_l
+
+def compute_sign(base, expo):
+    '''
+    base != 0 and expo >= 0 are integers;
+
+    returns the sign of base**expo without
+    evaluating the power itself!
+    '''
+    sb = sign(base)
+    if sb == 1:
+        return 1
+    pe = expo % 2
+    if pe == 0:
+        return -sb
+    else:
+        return sb
+
+def rem_z(p, q, x):
+    '''
+    Intended mainly for p, q polynomials in Z[x] so that,
+    on dividing p by q, the remainder will also be in Z[x]. (However,
+    it also works fine for polynomials in Q[x].)
+
+    It premultiplies p by the _absolute_ value of the leading coefficient
+    of q, raised to the power deg(p) - deg(q) + 1 and then performs
+    polynomial division in Q[x], using the function rem(p, q, x).
+
+    By contrast the function prem(p, q, x) does _not_ use the absolute
+    value of the leading coefficient of q.
+    This results not only in ``messing up the signs'' of the Euclidean and
+    Sturmian prs's as mentioned in the second reference,
+    but also in violation of the main results of the first and third
+    references --- Theorem 4 and Theorem 1 respectively. Theorems 4 and 1
+    establish a one-to-one correspondence between the Euclidean and the
+    Sturmian prs of p, q, on one hand, and the subresultant prs of p, q,
+    on the other.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
+    Serdica Journal of Computing, to appear.
+
+    2. http://planetMath.org/sturmstheorem
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result on
+    the Theory of Subresultants.'' Submitted for publication.
+
+    '''
+    delta = (degree(p, x) - degree(q, x) + 1)
+    return rem(Abs(LC(q, x))**delta  *  p, q, x)
+
+def subresultants_amv(f, g, x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the subresultant prs of p and q in Z[x] or Q[x];
+    the coefficients of the polynomials in the sequence are
+    subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester1, Sylvester's matrix of 1840.
+
+    To compute the coefficients, no determinant evaluation takes place.
+    Instead, polynomial divisions in Z[x] or Q[x] are performed, using
+    the function rem_z(p, q, x);  the coefficients of the remainders
+    computed this way become subresultants with the help of the
+    Akritas-Malaschonok-Vigklas Theorem of 2015 and the Collins-Brown-
+    Traub formula for coefficient reduction.
+
+    If the subresultant prs is complete, then it coincides with the
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
+    Submitted for publication.
+
+    """
+    # make sure neither f nor g is 0
+    if f == 0 or g == 0:
+        return [f, g]
+
+    # make sure proper degrees
+    d0 =  degree(f, x)
+    d1 =  degree(g, x)
+    if d0 == 0 and d1 == 0:
+        return [f, g]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        f, g = g, f
+    if d0 > 0 and d1 == 0:
+        return [f, g]
+
+    # initialize
+    a0 = f
+    a1 = g
+    subres_l = [a0, a1]
+    deg_dif_p1, c = degree(a0, x) - degree(a1, x) + 1, -1
+
+    # initialize AMV variables
+    sigma1 =  LC(a1, x)                      # leading coeff of a1
+    i, s = 0, 0                              # counters for remainders & odd elements
+    p_odd_index_sum = 0                      # contains the sum of p_1, p_3, etc
+    p0 = deg_dif_p1 - 1
+    if p0 % 2 == 1:
+        s += 1
+    phi = floor( (s + 1) / 2 )
+
+    # compute the first polynomial of the prs
+    i += 1
+    a2 = rem_z(a0, a1, x) / Abs( (-1)**deg_dif_p1 )     # first remainder
+    sigma2 =  LC(a2, x)                       # leading coeff of a2
+    d2 =  degree(a2, x)                       # actual degree of a2
+    p1 = d1 - d2                              # degree difference
+
+    # sgn_den is the factor, the denominator 1st fraction of (9),
+    # by which a2 is multiplied to get integer coefficients
+    sgn_den = compute_sign( sigma1, p0 + 1 )
+
+    ## compute sign of the 1st fraction in formula (9) of the paper
+    # numerator
+    psi = i + phi + p_odd_index_sum
+    num = (-1)**psi
+    # denominator
+    den = sgn_den
+
+    # the sign of the determinant depends on sign(num / den) != 0
+    if  sign(num / den) > 0:
+        subres_l.append( a2 )
+    else:
+        subres_l.append( -a2 )
+
+    # update AMV variable
+    if p1 % 2 == 1:
+        s += 1
+
+    # bring in the missing power of sigma if there was gap
+    if p1 - 1 > 0:
+        sgn_den = sgn_den * compute_sign( sigma1, p1 - 1 )
+
+    # main loop
+    while d2 >= 1:
+        phi = floor( (s + 1) / 2 )
+        if i%2 == 1:
+            p_odd_index_sum += p1             # p_i has odd index
+        a0, a1, d0, d1 = a1, a2, d1, d2       # update polys and degrees
+        p0 = p1                               # update degree difference
+        i += 1
+        sigma0 = -LC(a0)
+        c = (sigma0**(deg_dif_p1 - 1)) / (c**(deg_dif_p1 - 2))
+        deg_dif_p1 = degree(a0, x) - d2 + 1
+        a2 = rem_z(a0, a1, x) / Abs( ((c**(deg_dif_p1 - 1)) * sigma0) )
+        sigma3 =  LC(a2, x)                   # leading coeff of a2
+        d2 =  degree(a2, x)                   # actual degree of a2
+        p1 = d1 - d2                          # degree difference
+        psi = i + phi + p_odd_index_sum
+
+        # update variables
+        sigma1, sigma2 = sigma2, sigma3
+
+        # new sgn_den
+        sgn_den = compute_sign( sigma1, p0 + 1 ) * sgn_den
+
+        # compute the sign of the first fraction in formula (9) of the paper
+        # numerator
+        num = (-1)**psi
+        # denominator
+        den = sgn_den
+
+        # the sign of the determinant depends on sign( num / den ) != 0
+        if  sign(num / den) > 0:
+            subres_l.append( a2 )
+        else:
+            subres_l.append( -a2 )
+
+        # update AMV variable
+        if p1 % 2 ==1:
+            s += 1
+
+        # bring in the missing power of sigma if there was gap
+        if p1 - 1 > 0:
+            sgn_den = sgn_den * compute_sign( sigma1, p1 - 1 )
+
+    # gcd is of degree > 0 ?
+    m = len(subres_l)
+    if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
+        subres_l.pop(m - 1)
+
+    return subres_l
+
+def modified_subresultants_amv(p,q,x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the modified subresultant prs of p and q in Z[x] or Q[x],
+    from the subresultant prs of p and q.
+    The coefficients of the polynomials in the two sequences differ only
+    in sign and the factor LC(p)**( deg(p)- deg(q)) as stated in
+    Theorem 2 of the reference.
+
+    The coefficients of the polynomials in the output sequence are
+    modified subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester2, Sylvester's matrix of 1853.
+
+    If the modified subresultant prs is complete, and LC( p ) > 0, it coincides 
+    with the (generalized) Sturm's sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
+    Serdica Journal of Computing, to appear.
+
+    """
+    # compute the subresultant prs
+    lst = subresultants_amv(p,q,x)     ## any other method would do
+
+    # defensive
+    if lst == [] or len(lst) == 2:
+        return lst
+
+    # the coefficients in lst are subresultants and, hence, smaller than those
+    # of the corresponding modified subresultants by the factor
+    # LC(lst[0])**( deg(lst[0]) - deg(lst[1])); see Theorem 2.
+    lcf = LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) )
+
+    # Initialize the modified subresultant prs list
+    subr_seq = [lst[0], lst[1]]
+
+    # compute the degree sequences m_i and j_i of Theorem 2
+    deg_seq = [degree(Poly(poly, x), x) for poly in lst]
+    deg = deg_seq[0]
+    deg_seq_s = deg_seq[1:-1]
+    m_seq = [m-1 for m in deg_seq_s]
+    j_seq = [deg - m for m in m_seq]
+
+    # compute the AMV factors of Theorem 2
+    fact = [(-1)**( j*(j-1)/S(2) ) for j in j_seq]
+
+    # shortened list without the first two polys
+    lst_s = lst[2:]
+
+    # poly lst_s[k] is multiplied times fact[k] and times lcf
+    # and appended to the subresultant prs list
+    m = len(fact)
+    for k in range(m):
+        if sign(fact[k]) == -1:
+            subr_seq.append( simplify(-lst_s[k] * lcf) )
+        else:
+            subr_seq.append( simplify(lst_s[k] * lcf) )
+
+    return subr_seq
+
+def correct_sign(deg_f, deg_g, s1, rdel, cdel):
+    """
+    Used in various subresultant prs algorithms.
+
+    Evaluates the determinant, (a.k.a. subresultant) of a properly selected
+    submatrix of s1, Sylvester's matrix of 1840, to get the correct sign
+    and value of the leading coefficient of a given polynomial remainder.
+
+    deg_f, deg_g are the degrees of the original polynomials p, q for which the
+    matrix s1 = sylvester(p, q, x, 1) was constructed.
+
+    rdel denotes the expected degree of the remainder; it is the number of
+    rows to be deleted from each group of rows in s1 as described in the
+    reference below.
+
+    cdel denotes the expected degree minus the actual degree of the remainder;
+    it is the number of columns to be deleted --- starting with the last column
+    forming the square matrix --- from the matrix resulting after the row deletions.
+
+    References:
+    ===========
+    Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
+
+    """
+    M = s1[:, :]   # copy of matrix s1
+
+    # eliminate rdel rows from the first deg_g rows
+    for i in range(M.rows - deg_f - 1, M.rows - deg_f - rdel - 1, -1):
+        M.row_del(i)
+
+    # eliminate rdel rows from the last deg_f rows
+    for i in range(M.rows - 1, M.rows - rdel - 1, -1):
+        M.row_del(i)
+
+    # eliminate cdel columns
+    for i in range(cdel):
+        M.col_del(M.rows - 1)
+
+    # define submatrix
+    Md = M[:, 0: M.rows]
+
+    return Md.det()
+
+def subresultants_rem(p, q, x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the subresultant prs of p and q in Z[x] or Q[x];
+    the coefficients of the polynomials in the sequence are
+    subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester1, Sylvester's matrix of 1840.
+
+    To compute the coefficients polynomial divisions in Q[x] are
+    performed, using the function rem(p, q, x). The coefficients
+    of the remainders computed this way become subresultants by evaluating
+    one subresultant per remainder --- that of the leading coefficient.
+    This way we obtain the correct sign and value of the leading coefficient
+    of the remainder and we easily ``force'' the rest of the coefficients
+    to become subresultants.
+
+    If the subresultant prs is complete, then it coincides with the
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G.:``Three New Methods for Computing Subresultant
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing,
+    to appear.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    f, g = p, q
+    n = deg_f = degree(f, x)
+    m = deg_g = degree(g, x)
+    if n == 0 and m == 0:
+        return [f, g]
+    if n < m:
+        n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
+    if n > 0 and m == 0:
+        return [f, g]
+
+    # initialize
+    s1 = sylvester(f, g, x, 1)
+    sr_list = [f, g]      # subresultant list
+
+    # main loop
+    while deg_g > 0:
+        r = rem(p, q, x)
+        d = degree(r, x)
+        if d < 0:
+            return sr_list
+
+        # make coefficients subresultants evaluating ONE determinant
+        exp_deg = deg_g - 1          # expected degree
+        sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
+        r = simplify((r / LC(r, x)) * sign_value)
+
+        # append poly with subresultant coeffs
+        sr_list.append(r)
+
+        # update degrees and polys
+        deg_f, deg_g = deg_g, d
+        p, q = q, r
+
+    # gcd is of degree > 0 ?
+    m = len(sr_list)
+    if sr_list[m - 1] == nan or sr_list[m - 1] == 0:
+        sr_list.pop(m - 1)
+
+    return sr_list
+
+def pivot(M, i, j):
+    '''
+    M is a matrix, and M[i, j] specifies the pivot element.
+
+    All elements below M[i, j], in the j-th column, will
+    be zeroed, if they are not already 0, according to
+    Dodgson-Bareiss' integer preserving transformations.
+
+    References:
+    ===========
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest
+    common divisors and polynomial remainder sequences.''
+    Numerische MatheMatik 52, 119-127, 1988.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
+    by Van Vleck Regarding Sturm Sequences.''
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013.
+
+    '''
+    ma = M[:, :] # copy of matrix M
+    rs = ma.rows # No. of rows
+    cs = ma.cols # No. of cols
+    for r in range(i+1, rs):
+        if ma[r, j] != 0:
+            for c in range(j + 1, cs):
+                ma[r, c] = ma[i, j] * ma[r, c] - ma[i, c] * ma[r, j]
+            ma[r, j] = 0
+    return ma
+
+def rotate_r(L, k):
+    '''
+    Rotates right by k. L is a row of a matrix or a list.
+
+    '''
+    ll = list(L)
+    if ll == []:
+        return []
+    for i in range(k):
+        el = ll.pop(len(ll) - 1)
+        ll.insert(0, el)
+    return ll if type(L) is list else Matrix([ll])
+
+def rotate_l(L, k):
+    '''
+    Rotates left by k. L is a row of a matrix or a list.
+
+    '''
+    ll = list(L)
+    if ll == []:
+        return []
+    for i in range(k):
+        el = ll.pop(0)
+        ll.insert(len(ll) - 1, el)
+    return ll if type(L) is list else Matrix([ll])
+
+def row2poly(row, deg, x):
+    '''
+    Converts the row of a matrix to a poly of degree deg and variable x.
+    Some entries at the beginning and/or at the end of the row may be zero.
+
+    '''
+    k = 0
+    poly = []
+    leng = len(row)
+
+    # find the beginning of the poly ; i.e. the first
+    # non-zero element of the row
+    while row[k] == 0:
+        k = k + 1
+
+    # append the next deg + 1 elements to poly
+    for j in range( deg + 1):
+        if k + j <= leng:
+            poly.append(row[k + j])
+
+    return Poly(poly, x)
+
+def create_ma(deg_f, deg_g, row1, row2, col_num):
+    '''
+    Creates a ``small'' matrix M to be triangularized.
+
+    deg_f, deg_g are the degrees of the divident and of the
+    divisor polynomials respectively, deg_g > deg_f.
+
+    The coefficients of the divident poly are the elements
+    in row2 and those of the divisor poly are the elements
+    in row1.
+
+    col_num defines the number of columns of the matrix M.
+
+    '''
+    if deg_g - deg_f >= 1:
+        print('Reverse degrees')
+        return
+
+    m = zeros(deg_f - deg_g + 2, col_num)
+
+    for i in range(deg_f - deg_g + 1):
+        m[i, :] = rotate_r(row1, i)
+    m[deg_f - deg_g + 1, :] = row2
+
+    return m
+
+def find_degree(M, deg_f):
+    '''
+    Finds the degree of the poly corresponding (after triangularization)
+    to the _last_ row of the ``small'' matrix M, created by create_ma().
+
+    deg_f is the degree of the divident poly.
+    If _last_ row is all 0's returns None.
+
+    '''
+    j = deg_f
+    for i in range(0, M.cols):
+        if M[M.rows - 1, i] == 0:
+            j = j - 1
+        else:
+            return j if j >= 0 else 0
+
+def final_touches(s2, r, deg_g):
+    """
+    s2 is sylvester2, r is the row pointer in s2,
+    deg_g is the degree of the poly last inserted in s2.
+
+    After a gcd of degree > 0 has been found with Van Vleck's
+    method, and was inserted into s2, if its last term is not
+    in the last column of s2, then it is inserted as many
+    times as needed, rotated right by one each time, until
+    the condition is met.
+
+    """
+    R = s2.row(r-1)
+
+    # find the first non zero term
+    for i in range(s2.cols):
+        if R[0,i] == 0:
+            continue
+        else:
+            break
+
+    # missing rows until last term is in last column
+    mr = s2.cols - (i + deg_g + 1)
+
+    # insert them by replacing the existing entries in the row
+    i = 0
+    while mr != 0 and r + i < s2.rows :
+        s2[r + i, : ] = rotate_r(R, i + 1)
+        i += 1
+        mr -= 1
+
+    return s2
+
+def subresultants_vv(p, q, x, method = 0):
+    """
+    p, q are polynomials in Z[x] (intended) or Q[x].
+
+    Computes the subresultant prs of p, q by triangularizing,
+    in Z[x] or in Q[x], all the smaller matrices encountered in the
+    process of triangularizing sylvester2, Sylvester's matrix of 1853;
+    see references 1 and 2 for Van Vleck's method. With each remainder,
+    sylvester2 gets updated and is prepared to be printed if requested.
+
+    If sylvester2 has small dimensions and you want to see the final,
+    triangularized matrix use this version with method=1; otherwise,
+    use either this version with method=0 (default) or the faster version,
+    subresultants_vv_2(p, q, x), where sylvester2 is used implicitly.
+
+    Sylvester's matrix sylvester1  is also used to compute one
+    subresultant per remainder; namely, that of the leading
+    coefficient, in order to obtain the correct sign and to
+    force the remainder coefficients to become subresultants.
+
+    If the subresultant prs is complete, then it coincides with the
+    Euclidean sequence of the polynomials p, q.
+
+    If the final, triangularized matrix s2 is printed, then:
+        (a) if deg(p) - deg(q) > 1 or deg( gcd(p, q) ) > 0, several
+            of the last rows in s2 will remain unprocessed;
+        (b) if deg(p) - deg(q) == 0, p will not appear in the final matrix.
+
+    References:
+    ===========
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest
+    common divisors and polynomial remainder sequences.''
+    Numerische MatheMatik 52, 119-127, 1988.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
+    by Van Vleck Regarding Sturm Sequences.''
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013.
+
+    3. Akritas, A. G.:``Three New Methods for Computing Subresultant
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing,
+    to appear.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    f, g = p, q
+    n = deg_f = degree(f, x)
+    m = deg_g = degree(g, x)
+    if n == 0 and m == 0:
+        return [f, g]
+    if n < m:
+        n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
+    if n > 0 and m == 0:
+        return [f, g]
+
+    # initialize
+    s1 = sylvester(f, g, x, 1)
+    s2 = sylvester(f, g, x, 2)
+    sr_list = [f, g]
+    col_num = 2 * n         # columns in s2
+
+    # make two rows (row0, row1) of poly coefficients
+    row0 = Poly(f, x, domain = QQ).all_coeffs()
+    leng0 = len(row0)
+    for i in range(col_num - leng0):
+        row0.append(0)
+    row0 = Matrix([row0])
+    row1 = Poly(g,x, domain = QQ).all_coeffs()
+    leng1 = len(row1)
+    for i in range(col_num - leng1):
+        row1.append(0)
+    row1 = Matrix([row1])
+
+    # row pointer for deg_f - deg_g == 1; may be reset below
+    r = 2
+
+    # modify first rows of s2 matrix depending on poly degrees
+    if deg_f - deg_g > 1:
+        r = 1
+        # replacing the existing entries in the rows of s2,
+        # insert row0 (deg_f - deg_g - 1) times, rotated each time
+        for i in range(deg_f - deg_g - 1):
+            s2[r + i, : ] = rotate_r(row0, i + 1)
+        r = r + deg_f - deg_g - 1
+        # insert row1 (deg_f - deg_g) times, rotated each time
+        for i in range(deg_f - deg_g):
+            s2[r + i, : ] = rotate_r(row1, r + i)
+        r = r + deg_f - deg_g
+
+    if deg_f - deg_g == 0:
+        r = 0
+
+    # main loop
+    while deg_g > 0:
+        # create a small matrix M, and triangularize it;
+        M = create_ma(deg_f, deg_g, row1, row0, col_num)
+        # will need only the first and last rows of M
+        for i in range(deg_f - deg_g + 1):
+            M1 = pivot(M, i, i)
+            M = M1[:, :]
+
+        # treat last row of M as poly; find its degree
+        d = find_degree(M, deg_f)
+        if d == None:
+            break
+        exp_deg = deg_g - 1
+
+        # evaluate one determinant & make coefficients subresultants
+        sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
+        poly = row2poly(M[M.rows - 1, :], d, x)
+        temp2 = LC(poly, x)
+        poly = simplify((poly / temp2) * sign_value)
+
+        # update s2 by inserting first row of M as needed
+        row0 = M[0, :]
+        for i in range(deg_g - d):
+            s2[r + i, :] = rotate_r(row0, r + i)
+        r = r + deg_g - d
+
+        # update s2 by inserting last row of M as needed
+        row1 = rotate_l(M[M.rows - 1, :], deg_f - d)
+        row1 = (row1 / temp2) * sign_value
+        for i in range(deg_g - d):
+            s2[r + i, :] = rotate_r(row1, r + i)
+        r = r + deg_g - d
+
+        # update degrees
+        deg_f, deg_g = deg_g, d
+
+        # append poly with subresultant coeffs
+        sr_list.append(poly)
+
+    # final touches to print the s2 matrix
+    if method != 0 and s2.rows > 2:
+        s2 = final_touches(s2, r, deg_g)
+        pprint(s2)
+    elif method != 0 and s2.rows == 2:
+        s2[1, :] = rotate_r(s2.row(1), 1)
+        pprint(s2)
+
+    return sr_list
+
+def subresultants_vv_2(p, q, x):
+    """
+    p, q are polynomials in Z[x] (intended) or Q[x].
+
+    Computes the subresultant prs of p, q by triangularizing,
+    in Z[x] or in Q[x], all the smaller matrices encountered in the
+    process of triangularizing sylvester2, Sylvester's matrix of 1853;
+    see references 1 and 2 for Van Vleck's method.
+
+    If the sylvester2 matrix has big dimensions use this version,
+    where sylvester2 is used implicitly. If you want to see the final,
+    triangularized matrix sylvester2, then use the first version,
+    subresultants_vv(p, q, x, 1).
+
+    sylvester1, Sylvester's matrix of 1840, is also used to compute
+    one subresultant per remainder; namely, that of the leading
+    coefficient, in order to obtain the correct sign and to
+    ``force'' the remainder coefficients to become subresultants.
+
+    If the subresultant prs is complete, then it coincides with the
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest
+    common divisors and polynomial remainder sequences.''
+    Numerische MatheMatik 52, 119-127, 1988.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
+    by Van Vleck Regarding Sturm Sequences.''
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013.
+
+    3. Akritas, A. G.:``Three New Methods for Computing Subresultant
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing,
+    to appear.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    f, g = p, q
+    n = deg_f = degree(f, x)
+    m = deg_g = degree(g, x)
+    if n == 0 and m == 0:
+        return [f, g]
+    if n < m:
+        n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
+    if n > 0 and m == 0:
+        return [f, g]
+
+    # initialize
+    s1 = sylvester(f, g, x, 1)
+    sr_list = [f, g]      # subresultant list
+    col_num = 2 * n       # columns in sylvester2
+
+    # make two rows (row0, row1) of poly coefficients
+    row0 = Poly(f, x, domain = QQ).all_coeffs()
+    leng0 = len(row0)
+    for i in range(col_num - leng0):
+        row0.append(0)
+    row0 = Matrix([row0])
+    row1 = Poly(g,x, domain = QQ).all_coeffs()
+    leng1 = len(row1)
+    for i in range(col_num - leng1):
+        row1.append(0)
+    row1 = Matrix([row1])
+
+    # main loop
+    while deg_g > 0:
+        # create a small matrix M, and triangularize it
+        M = create_ma(deg_f, deg_g, row1, row0, col_num)
+        for i in range(deg_f - deg_g + 1):
+            M1 = pivot(M, i, i)
+            M = M1[:, :]
+
+        # treat last row of M as poly; find its degree
+        d = find_degree(M, deg_f)
+        if d == None:
+            return sr_list
+        exp_deg = deg_g - 1
+
+        # evaluate one determinant & make coefficients subresultants
+        sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
+        poly = row2poly(M[M.rows - 1, :], d, x)
+        poly = simplify((poly / LC(poly, x)) * sign_value)
+
+        # append poly with subresultant coeffs
+        sr_list.append(poly)
+
+        # update degrees and rows
+        deg_f, deg_g = deg_g, d
+        row0 = row1
+        row1 = Poly(poly, x, domain = QQ).all_coeffs()
+        leng1 = len(row1)
+        for i in range(col_num - leng1):
+            row1.append(0)
+        row1 = Matrix([row1])
+
+    return sr_list

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -335,7 +335,7 @@ def sturm_amv(p, q, x, method=0):
        smaller than the coefficients of the corresponding ``modified''
        subresultants by the factor Abs( LC(p)**( deg(p)- deg(q)) ).
 
-    If the Sturm sequence is complete, method=0 and LC( p ) > 0, then the 
+    If the Sturm sequence is complete, method=0 and LC( p ) > 0, then the
     coefficients of the polynomials in the sequence are ``modified'' subresultants.
     That is, they are  determinants of appropriately selected submatrices of
     sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence
@@ -662,7 +662,7 @@ def modified_subresultants_pg(p,q,x):
     the coefficients of the remainders computed this way become ``modified''
     subresultants with the help of the Pell-Gordon Theorem of 1917.
 
-    If the ``modified'' subresultant prs is complete, and LC( p ) > 0, it coincides 
+    If the ``modified'' subresultant prs is complete, and LC( p ) > 0, it coincides
     with the (generalized) Sturm sequence of the polynomials p, q.
 
     References:
@@ -866,7 +866,7 @@ def subresultants_pg(p,q,x):
     # the coefficients in lst are modified subresultants and, hence, are
     # greater than those of the corresponding subresultants by the factor
     # LC(lst[0])**( deg(lst[0]) - deg(lst[1])); see Theorem 2 in reference.
-    lcf = LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) ) 
+    lcf = LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) )
 
     # Initialize the subresultant prs list
     subr_seq = [lst[0], lst[1]]
@@ -1205,7 +1205,7 @@ def modified_subresultants_amv(p,q,x):
     modified subresultants. That is, they are  determinants of appropriately
     selected submatrices of sylvester2, Sylvester's matrix of 1853.
 
-    If the modified subresultant prs is complete, and LC( p ) > 0, it coincides 
+    If the modified subresultant prs is complete, and LC( p ) > 0, it coincides
     with the (generalized) Sturm's sequence of the polynomials p, q.
 
     References:

--- a/sympy/polys/tests/test_subresultants_qq_zz.py
+++ b/sympy/polys/tests/test_subresultants_qq_zz.py
@@ -1,0 +1,248 @@
+from sympy.polys.subresultants_qq_zz import sylvester, sturm_pg, sturm_q, sturm_amv
+from sympy.polys.subresultants_qq_zz import (euclid_pg, euclid_q, 
+    euclid_amv, modified_subresultants_pg, subresultants_pg,
+    subresultants_amv_q, rem_z, subresultants_amv, 
+    modified_subresultants_amv, subresultants_rem, 
+    subresultants_vv, subresultants_vv_2)
+from sympy import var, sturm, subresultants, prem
+from sympy.matrices import Matrix
+
+
+def test_sylvester():
+    x = var('x')
+
+    assert sylvester(x**3 -7, 0, x) == sylvester(x**3 -7, 0, x, 1) == Matrix([[0]])
+    assert sylvester(0, x**3 -7, x) == sylvester(0, x**3 -7, x, 1) == Matrix([[0]])
+    assert sylvester(x**3 -7, 0, x, 2) == Matrix([[0]])
+    assert sylvester(0, x**3 -7, x, 2) == Matrix([[0]])
+
+    assert sylvester(x**3 -7, 7, x).det() == sylvester(x**3 -7, 7, x, 1).det() == 343
+    assert sylvester(7, x**3 -7, x).det() == sylvester(7, x**3 -7, x, 1).det() == 343
+    assert sylvester(x**3 -7, 7, x, 2).det() == -343
+    assert sylvester(7, x**3 -7, x, 2).det() == -343
+
+    assert sylvester(3, 7, x).det() == sylvester(3, 7, x, 1).det() == sylvester(3, 7, x, 2).det() == 1
+
+    assert sylvester(3, 0, x).det() == sylvester(3, 0, x, 1).det() == sylvester(3, 0, x, 2).det() == 1
+
+    assert sylvester(x - 3, x - 8, x) == sylvester(x - 3, x - 8, x, 1) == sylvester(x - 3, x - 8, x, 2) == Matrix([[1, -3], [1, -8]])
+
+    assert sylvester(x**3 - 7*x + 7, 3*x**2 - 7, x) == sylvester(x**3 - 7*x + 7, 3*x**2 - 7, x, 1) == Matrix([[1, 0, -7,  7,  0], [0, 1,  0, -7,  7], [3, 0, -7,  0,  0], [0, 3,  0, -7,  0], [0, 0,  3,  0, -7]])
+
+    assert sylvester(x**3 - 7*x + 7, 3*x**2 - 7, x, 2) == Matrix([
+[1, 0, -7,  7,  0,  0], [0, 3,  0, -7,  0,  0], [0, 1,  0, -7,  7,  0], [0, 0,  3,  0, -7,  0], [0, 0,  1,  0, -7,  7], [0, 0,  0,  3,  0, -7]])
+
+
+def test_sturm_pg():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert sturm_pg(p, q, x)[-1] != sylvester(p, q, x, 2).det()
+    sam_factors = [1, 1, -1, -1, 1, 1]
+    assert sturm_pg(p, q, x) == [i*j for i,j in zip(sam_factors, euclid_pg(p, q, x))]
+
+    p = -9*x**5 - 5*x**3 - 9
+    q = -45*x**4 - 15*x**2
+    assert sturm_pg(p, q, x, 1)[-1] == sylvester(p, q, x, 1).det()
+    assert sturm_pg(p, q, x)[-1] != sylvester(p, q, x, 2).det()
+    assert sturm_pg(-p, q, x)[-1] == sylvester(-p, q, x, 2).det()
+
+
+def test_sturm_q():
+    x = var('x')
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert sturm_q(p, q, x) == sturm(p)
+    assert sturm_q(-p, -q, x) != sturm(-p)
+
+
+def test_sturm_amv():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert sturm_amv(p, q, x)[-1] != sylvester(p, q, x, 2).det()
+    sam_factors = [1, 1, -1, -1, 1, 1]
+    assert sturm_amv(p, q, x) == [i*j for i,j in zip(sam_factors, euclid_amv(p, q, x))]
+
+    p = -9*x**5 - 5*x**3 - 9
+    q = -45*x**4 - 15*x**2
+    assert sturm_amv(p, q, x, 1)[-1] == sylvester(p, q, x, 1).det()
+    assert sturm_amv(p, q, x)[-1] != sylvester(p, q, x, 2).det()
+    assert sturm_amv(-p, q, x)[-1] == sylvester(-p, q, x, 2).det()
+
+
+def test_euclid_pg():
+    x = var('x')
+
+    p = x**6+x**5-x**4-x**3+x**2-x+1
+    q = 6*x**5+5*x**4-4*x**3-3*x**2+2*x-1
+    assert euclid_pg(p, q, x)[-1] == sylvester(p, q, x).det()
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert euclid_pg(p, q, x)[-1] != sylvester(p, q, x, 2).det()
+    sam_factors = [1, 1, -1, -1, 1, 1]
+    assert euclid_pg(p, q, x) == [i*j for i,j in zip(sam_factors, sturm_pg(p, q, x))]
+
+
+def test_euclid_q():
+    x = var('x')
+    
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert euclid_q(p, q, x)[-1] == -sturm(p)[-1]
+
+
+def test_euclid_amv():
+    x = var('x')
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert euclid_amv(p, q, x)[-1] == sylvester(p, q, x).det()
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert euclid_amv(p, q, x)[-1] != sylvester(p, q, x, 2).det()
+    sam_factors = [1, 1, -1, -1, 1, 1]
+    assert euclid_amv(p, q, x) == [i*j for i,j in zip(sam_factors, sturm_amv(p, q, x))]
+
+
+def test_modified_subresultants_pg():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    amv_factors = [1, 1, -1, 1, -1, 1]
+    assert modified_subresultants_pg(p, q, x) == [i*j for i, j in zip(amv_factors, subresultants_pg(p, q, x))]
+    assert modified_subresultants_pg(p, q, x)[-1] != sylvester(p + x**8, q, x).det()
+    assert modified_subresultants_pg(p, q, x) != sturm_pg(p, q, x)
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert modified_subresultants_pg(p, q, x) == sturm_pg(p, q, x)
+    assert modified_subresultants_pg(-p, q, x) != sturm_pg(-p, q, x)
+
+
+def test_subresultants_pg():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert subresultants_pg(p, q, x) == subresultants(p, q, x)
+    assert subresultants_pg(p, q, x)[-1] == sylvester(p, q, x).det()
+    assert subresultants_pg(p, q, x) != euclid_pg(p, q, x)
+    amv_factors = [1, 1, -1, 1, -1, 1]
+    assert subresultants_pg(p, q, x) == [i*j for i, j in zip(amv_factors, modified_subresultants_amv(p, q, x))]
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert subresultants_pg(p, q, x) == euclid_pg(p, q, x)
+
+
+def test_subresultants_amv_q():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert subresultants_amv_q(p, q, x) == subresultants(p, q, x)
+    assert subresultants_amv_q(p, q, x)[-1] == sylvester(p, q, x).det()
+    assert subresultants_amv_q(p, q, x) != euclid_amv(p, q, x)
+    amv_factors = [1, 1, -1, 1, -1, 1]
+    assert subresultants_amv_q(p, q, x) == [i*j for i, j in zip(amv_factors, modified_subresultants_amv(p, q, x))]
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert subresultants_amv(p, q, x) == euclid_amv(p, q, x)
+
+
+def test_rem_z():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert rem_z(p, -q, x) != prem(p, -q, x)
+
+
+def test_subresultants_amv():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert subresultants_amv(p, q, x) == subresultants(p, q, x)
+    assert subresultants_amv(p, q, x)[-1] == sylvester(p, q, x).det()
+    assert subresultants_amv(p, q, x) != euclid_amv(p, q, x)
+    amv_factors = [1, 1, -1, 1, -1, 1]
+    assert subresultants_amv(p, q, x) == [i*j for i, j in zip(amv_factors, modified_subresultants_amv(p, q, x))]
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert subresultants_amv(p, q, x) == euclid_amv(p, q, x)
+
+
+def test_modified_subresultants_amv():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    amv_factors = [1, 1, -1, 1, -1, 1]
+    assert modified_subresultants_amv(p, q, x) == [i*j for i, j in zip(amv_factors, subresultants_amv(p, q, x))]
+    assert modified_subresultants_amv(p, q, x)[-1] != sylvester(p + x**8, q, x).det()
+    assert modified_subresultants_amv(p, q, x) != sturm_amv(p, q, x)
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert modified_subresultants_amv(p, q, x) == sturm_amv(p, q, x)
+    assert modified_subresultants_amv(-p, q, x) != sturm_amv(-p, q, x)
+
+
+def test_subresultants_rem():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert subresultants_rem(p, q, x) == subresultants(p, q, x)
+    assert subresultants_rem(p, q, x)[-1] == sylvester(p, q, x).det()
+    assert subresultants_rem(p, q, x) != euclid_amv(p, q, x)
+    amv_factors = [1, 1, -1, 1, -1, 1]
+    assert subresultants_rem(p, q, x) == [i*j for i, j in zip(amv_factors, modified_subresultants_amv(p, q, x))]
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert subresultants_rem(p, q, x) == euclid_amv(p, q, x)
+
+
+def test_subresultants_vv():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert subresultants_vv(p, q, x) == subresultants(p, q, x)
+    assert subresultants_vv(p, q, x)[-1] == sylvester(p, q, x).det()
+    assert subresultants_vv(p, q, x) != euclid_amv(p, q, x)
+    amv_factors = [1, 1, -1, 1, -1, 1]
+    assert subresultants_vv(p, q, x) == [i*j for i, j in zip(amv_factors, modified_subresultants_amv(p, q, x))]
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert subresultants_vv(p, q, x) == euclid_amv(p, q, x)
+
+
+def test_subresultants_vv_2():
+    x = var('x')
+
+    p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+    assert subresultants_vv_2(p, q, x) == subresultants(p, q, x)
+    assert subresultants_vv_2(p, q, x)[-1] == sylvester(p, q, x).det()
+    assert subresultants_vv_2(p, q, x) != euclid_amv(p, q, x)
+    amv_factors = [1, 1, -1, 1, -1, 1]
+    assert subresultants_vv_2(p, q, x) == [i*j for i, j in zip(amv_factors, modified_subresultants_amv(p, q, x))]
+
+    p = x**3 - 7*x + 7
+    q = 3*x**2 - 7
+    assert subresultants_vv_2(p, q, x) == euclid_amv(p, q, x)
+
+

--- a/sympy/polys/tests/test_subresultants_qq_zz.py
+++ b/sympy/polys/tests/test_subresultants_qq_zz.py
@@ -1,8 +1,8 @@
 from sympy.polys.subresultants_qq_zz import sylvester, sturm_pg, sturm_q, sturm_amv
-from sympy.polys.subresultants_qq_zz import (euclid_pg, euclid_q, 
+from sympy.polys.subresultants_qq_zz import (euclid_pg, euclid_q,
     euclid_amv, modified_subresultants_pg, subresultants_pg,
-    subresultants_amv_q, rem_z, subresultants_amv, 
-    modified_subresultants_amv, subresultants_rem, 
+    subresultants_amv_q, rem_z, subresultants_amv,
+    modified_subresultants_amv, subresultants_rem,
     subresultants_vv, subresultants_vv_2)
 from sympy import var, sturm, subresultants, prem
 from sympy.matrices import Matrix
@@ -90,7 +90,7 @@ def test_euclid_pg():
 
 def test_euclid_q():
     x = var('x')
-    
+
     p = x**3 - 7*x + 7
     q = 3*x**2 - 7
     assert euclid_q(p, q, x)[-1] == -sturm(p)[-1]
@@ -244,5 +244,3 @@ def test_subresultants_vv_2():
     p = x**3 - 7*x + 7
     q = 3*x**2 - 7
     assert subresultants_vv_2(p, q, x) == euclid_amv(p, q, x)
-
-

--- a/sympy/polys/tests/test_subresultants_qq_zz.py
+++ b/sympy/polys/tests/test_subresultants_qq_zz.py
@@ -1,11 +1,11 @@
-from sympy.polys.subresultants_qq_zz import sylvester, sturm_pg, sturm_q, sturm_amv
-from sympy.polys.subresultants_qq_zz import (euclid_pg, euclid_q,
+from sympy import var, sturm, subresultants, prem
+from sympy.matrices import Matrix
+from sympy.polys.subresultants_qq_zz import (sylvester,
+    sturm_pg, sturm_q, sturm_amv, euclid_pg, euclid_q,
     euclid_amv, modified_subresultants_pg, subresultants_pg,
     subresultants_amv_q, rem_z, subresultants_amv,
     modified_subresultants_amv, subresultants_rem,
     subresultants_vv, subresultants_vv_2)
-from sympy import var, sturm, subresultants, prem
-from sympy.matrices import Matrix
 
 
 def test_sylvester():
@@ -47,7 +47,7 @@ def test_sturm_pg():
     assert sturm_pg(p, q, x, 1)[-1] == sylvester(p, q, x, 1).det()
     assert sturm_pg(p, q, x)[-1] != sylvester(p, q, x, 2).det()
     assert sturm_pg(-p, q, x)[-1] == sylvester(-p, q, x, 2).det()
-
+    assert sturm_pg(-p, q, x) == modified_subresultants_pg(-p, q, x)
 
 def test_sturm_q():
     x = var('x')
@@ -72,6 +72,7 @@ def test_sturm_amv():
     assert sturm_amv(p, q, x, 1)[-1] == sylvester(p, q, x, 1).det()
     assert sturm_amv(p, q, x)[-1] != sylvester(p, q, x, 2).det()
     assert sturm_amv(-p, q, x)[-1] == sylvester(-p, q, x, 2).det()
+    assert sturm_pg(-p, q, x) == modified_subresultants_pg(-p, q, x)
 
 
 def test_euclid_pg():
@@ -80,6 +81,7 @@ def test_euclid_pg():
     p = x**6+x**5-x**4-x**3+x**2-x+1
     q = 6*x**5+5*x**4-4*x**3-3*x**2+2*x-1
     assert euclid_pg(p, q, x)[-1] == sylvester(p, q, x).det()
+    assert euclid_pg(p, q, x) == subresultants_pg(p, q, x)
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
@@ -102,6 +104,7 @@ def test_euclid_amv():
     p = x**3 - 7*x + 7
     q = 3*x**2 - 7
     assert euclid_amv(p, q, x)[-1] == sylvester(p, q, x).det()
+    assert euclid_amv(p, q, x) == subresultants_amv(p, q, x)
 
     p = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
     q = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -1598,7 +1598,7 @@ def subresultants_vv(p, q, x, method = 0):
         # insert row0 (deg_f - deg_g - 1) times, rotated each time
         for i in range(deg_f - deg_g - 1):
             s2[r + i, : ] = rotate_r(row0, i + 1)
-            r = r + 1
+        r = r + 1
         # insert row1 (deg_f - deg_g) times, rotated each time
         for i in range(deg_f - deg_g):
             s2[r + i, : ] = rotate_r(row1, r + i)

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -7,6 +7,8 @@ Created on Mon Dec 28 13:25:02 2015
 
 from __future__ import print_function, division
 
+from sympy import (Abs, degree, expand, floor, LC, Matrix, nan, Poly, pprint, QQ, rem, S, sign, simplify, summation, var, zeros)
+
 def sylvester(f, g, x, method = 1):
     '''
       f, g polys in x, m = deg(f) >= deg(g) = n.
@@ -1635,13 +1637,13 @@ def subresultants_vv(p, q, x, method = 0):
         r = r + deg_g - d
 
         # update s2 by inserting last row of M as needed
-        row1 = rotate_l(M[M.rows - 1, :], deg_f - d)  # last row rotated
+        row1 = rotate_l(M[M.rows - 1, :], deg_f - d)
         row1 = (row1 / temp2) * sign_value
         for i in range(deg_g - d):
             s2[r + i, :] = rotate_r(row1, r + i)
-
-        # update row and degrees
         r = r + deg_g - d
+
+        # update degrees
         deg_f, deg_g = deg_g, d
 
         # append poly with subresultant coeffs

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -41,26 +41,26 @@ def sylvester(f, g, x, method = 1):
     m, n = degree( Poly(f, x), x), degree( Poly(g, x), x)
 
     # Special cases:
-    # A:: case m = n = -oo (i.e. both polys are 0)
-    if m == n and n == -oo:
+    # A:: case m = n < 0 (i.e. both polys are 0)
+    if m == n and n < 0:
         return Matrix([])
 
     # B:: case m = n = 0  (i.e. both polys are constants)
     if m == n and n == 0:
         return Matrix([])
 
-    # C:: m == 0 and n == -oo or m == -oo and n == 0
-    # (i.e. one polys is constant and the other is 0)
-    if m == 0 and n == -oo:
+    # C:: m == 0 and n < 0 or m < 0 and n == 0
+    # (i.e. one poly is constant and the other is 0)
+    if m == 0 and n < 0:
         return Matrix([])
-    elif m == -oo and n == 0:
+    elif m < 0 and n == 0:
         return Matrix([])
 
-    # D:: m >= 1 and n == -oo or m == -oo and n >=1
+    # D:: m >= 1 and n < 0 or m < 0 and n >=1
     # (i.e. one poly is of degree >=1 and the other is 0)
-    if m >= 1 and n == -oo:
+    if m >= 1 and n < 0:
         return Matrix([0])
-    elif m == -oo and n >= 1:
+    elif m < 0 and n >= 1:
         return Matrix([0])
 
     fp = Poly(f, x).all_coeffs()
@@ -167,7 +167,7 @@ def sturm_pg(p, q, x, method=0):
     d0 =  degree(p, x)
     d1 =  degree(q, x)
     if d0 == 0 and d1 == 0:
-        return []
+        return [p, q]
     if d1 > d0:
         d0, d1 = d1, d0
         p, q = q, p
@@ -279,7 +279,7 @@ def sturm_q(p, q, x):
     d0 =  degree(p, x)
     d1 =  degree(q, x)
     if d0 == 0 and d1 == 0:
-        return []
+        return [p, q]
     if d1 > d0:
         d0, d1 = d1, d0
         p, q = q, p
@@ -380,7 +380,7 @@ def sturm_amv(p, q, x, method=0):
     # the coefficients in prs are subresultants and hence are smaller
     # than the corresponding subresultants by the factor
     # |LC(prs[0])**( deg(prs[0]) - deg(prs[1]))|; Theorem 2, 2nd reference.
-    lcf = Abs( LC(prs[0])**( degree(prs[0]) - degree(prs[1]) ) )
+    lcf = Abs( LC(prs[0])**( degree(prs[0], x) - degree(prs[1], x) ) )
 
     # the signs of the first two polys in the sequence stay the same
     sturm_seq = [prs[0], prs[1]]
@@ -531,7 +531,7 @@ def euclid_q(p, q, x):
     d0 =  degree(p, x)
     d1 =  degree(q, x)
     if d0 == 0 and d1 == 0:
-        return []
+        return [p, q]
     if d1 > d0:
         d0, d1 = d1, d0
         p, q = q, p
@@ -610,20 +610,20 @@ def euclid_amv(f, g, x):
     d0 =  degree(f, x)
     d1 =  degree(g, x)
     if d0 == 0 and d1 == 0:
-        return []
-    if d0 > 0 and d1 == 0:
         return [f, g]
     if d1 > d0:
         d0, d1 = d1, d0
         f, g = g, f
-    if d0 == 1:
+    if d0 > 0 and d1 == 0:
         return [f, g]
+#    if d0 == 1:
+#        return [f, g]
 
     # initialize
     a0 = f
     a1 = g
     euclid_seq = [a0, a1]
-    deg_dif_p1, c = degree(a0) - degree(a1) + 1, -1
+    deg_dif_p1, c = degree(a0, x) - degree(a1, x) + 1, -1
 
     # compute the first polynomial of the prs
     i = 1
@@ -685,7 +685,7 @@ def modified_subresultants_pg(p,q,x):
     d0 =  degree(p,x)
     d1 =  degree(q,x)
     if d0 == 0 and d1 == 0:
-        return []
+        return [p, q]
     if d1 > d0:
         d0, d1 = d1, d0
         p, q = q, p
@@ -831,7 +831,7 @@ def subresultants_pg(p,q,x):
     Computes the subresultant prs of p and q in Z[x] or Q[x], from
     the modified subresultant prs of p and q.
 
-    The coefficients of the polynomials in these two ßsequences differ only
+    The coefficients of the polynomials in these two sequences differ only
     in sign and the factor Abs(LC(p)**( deg(p)- deg(q))) as stated in
     Theorem 2 of the reference.
 
@@ -854,18 +854,18 @@ def subresultants_pg(p,q,x):
 
     # defensive
     if lst == [] or len(lst) == 2:
-        return let
+        return lst
 
     # the coefficients in lst are modified subresultants and, hence, are
     # greater than those of the corresponding subresultants by the factor
     # |LC(lst[0])**( deg(lst[0]) - deg(lst[1]))|; see Theorem 2 in reference.
-    lcf = Abs( LC(lst[0])**( degree(lst[0]) - degree(lst[1]) ) )
+    lcf = Abs( LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) ) )
 
     # Initialize the subresultant prs list
     subr_seq = [lst[0], lst[1]]
 
     # compute the degree sequences m_i and j_i of Theorem 2 in reference.
-    deg_seq = [degree(Poly(poly, x)) for poly in lst]
+    deg_seq = [degree(Poly(poly, x), x) for poly in lst]
     deg = deg_seq[0]
     deg_seq_s = deg_seq[1:-1]
     m_seq = [m-1 for m in deg_seq_s]
@@ -924,12 +924,12 @@ def subresultants_amv_q(p,q,x):
     d0 =  degree(p, x)
     d1 =  degree(q, x)
     if d0 == 0 and d1 == 0:
-        return []
-    if d0 > 0 and d1 == 0:
         return [p, q]
     if d1 > d0:
         d0, d1 = d1, d0
         p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p, q]
 
     # initialize
     i, s = 0, 0                              # counters for remainders & odd elements
@@ -1080,20 +1080,20 @@ def subresultants_amv(f, g, x):
     d0 =  degree(f, x)
     d1 =  degree(g, x)
     if d0 == 0 and d1 == 0:
-        return []
-    if d0 > 0 and d1 == 0:
         return [f, g]
     if d1 > d0:
         d0, d1 = d1, d0
         f, g = g, f
-    if d0 == 1:
+    if d0 > 0 and d1 == 0:
         return [f, g]
+#    if d0 == 1:
+#        return [f, g]
 
     # initialize
     a0 = f
     a1 = g
     subres_l = [a0, a1]
-    deg_dif_p1, c = degree(a0) - degree(a1) + 1, -1
+    deg_dif_p1, c = degree(a0, x) - degree(a1, x) + 1, -1
 
     # initialize AMV variables
     sigma1 =  LC(a1, x)                      # leading coeff of a1
@@ -1220,13 +1220,13 @@ def modified_subresultants_amv(p,q,x):
     # the coefficients in lst are subresultants and, hence, smaller than those
     # of the corresponding modified subresultants by the factor
     # Abs(LC(lst[0])**( deg(lst[0]) - deg(lst[1]))); see Theorem 2.
-    lcf = Abs( LC(lst[0])**( degree(lst[0]) - degree(lst[1]) ) )
+    lcf = Abs( LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) ) )
 
     # Initialize the modified subresultant prs list
     subr_seq = [lst[0], lst[1]]
 
     # compute the degree sequences m_i and j_i of Theorem 2
-    deg_seq = [degree(Poly(poly, x)) for poly in lst]
+    deg_seq = [degree(Poly(poly, x), x) for poly in lst]
     deg = deg_seq[0]
     deg_seq_s = deg_seq[1:-1]
     m_seq = [m-1 for m in deg_seq_s]
@@ -1330,11 +1330,11 @@ def subresultants_rem(p, q, x):
     n = deg_f = degree(f, x)
     m = deg_g = degree(g, x)
     if n == 0 and m == 0:
-        return []
-    if n > 0 and m == 0:
         return [f, g]
     if n < m:
         n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
+    if n > 0 and m == 0:
+        return [f, g]
 
     # initialize
     s1 = sylvester(f, g, x, 1)
@@ -1344,7 +1344,7 @@ def subresultants_rem(p, q, x):
     while deg_g > 0:
         r = rem(p, q, x)
         d = degree(r, x)
-        if d == -oo:
+        if d < 0:
             return sr_list
 
         # make coefficients subresultants evaluating ONE determinant
@@ -1509,10 +1509,10 @@ def final_touches(s2, r, deg_g):
     # missing rows until last term is in last column
     mr = s2.cols - (i + deg_g + 1)
 
-    # insert them
+    # insert them by replacing the existing entries in the row
     i = 0
-    while mr != 0:
-        s2 = s2.row_insert(r + i, rotate_r(R, i+1))
+    while mr != 0 and r + i < s2.rows :
+        s2[r + i, : ] = rotate_r(R, i + 1)
         i += 1
         mr -= 1
 
@@ -1570,11 +1570,11 @@ def subresultants_vv(p, q, x, method = 0):
     n = deg_f = degree(f, x)
     m = deg_g = degree(g, x)
     if n == 0 and m == 0:
-        return []
-    if n > 0 and m == 0:
         return [f, g]
     if n < m:
         n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
+    if n > 0 and m == 0:
+        return [f, g]
 
     # initialize
     s1 = sylvester(f, g, x, 1)
@@ -1600,13 +1600,14 @@ def subresultants_vv(p, q, x, method = 0):
     # modify first rows of s2 matrix depending on poly degrees
     if deg_f - deg_g > 1:
         r = 1
+        # replacing the existing entries in the rows of s2,
         # insert row0 (deg_f - deg_g - 1) times, rotated each time
         for i in range(deg_f - deg_g - 1):
-            s2 = s2.row_insert(i + 1, rotate_r(row0, i + 1) )
+            s2[r + i, : ] = rotate_r(row0, i + 1)
             r = r + 1
         # insert row1 (deg_f - deg_g) times, rotated each time
         for i in range(deg_f - deg_g):
-            s2 = s2.row_insert(r + i, rotate_r(row1, r + i) )
+            s2[r + i, : ] = rotate_r(row1, r + i)
         r = r + deg_f - deg_g
 
     if deg_f - deg_g == 0:
@@ -1706,11 +1707,11 @@ def subresultants_vv_2(p, q, x):
     n = deg_f = degree(f, x)
     m = deg_g = degree(g, x)
     if n == 0 and m == 0:
-        return []
-    if n > 0 and m == 0:
         return [f, g]
     if n < m:
         n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
+    if n > 0 and m == 0:
+        return [f, g]
 
     # initialize
     s1 = sylvester(f, g, x, 1)

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -5,7 +5,7 @@ Created on Mon Dec 28 13:25:02 2015
 @author: alkis
 """
 
-# from __future__ import print_function, division
+from __future__ import print_function, division
 
 from sympy import *
 
@@ -23,7 +23,7 @@ def sylvester(f, g, x, method = 1):
           submatrices of this matrix (a.k.a. ``modified'' subresultants) can be 
           used to compute the coefficients of the Sturmian PRS of f, g.
 
-      Applications of these matrices can be found in the references below.
+      Applications of these Matrices can be found in the references below.
       Especially, for applications of sylvester2, see the first reference!!
 
       References: 
@@ -33,7 +33,7 @@ def sylvester(f, g, x, method = 1):
       Vol. 7, No 4, 101–134, 2013. 
 
       2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-      and Modified Subresultant Polynomial Remainder Sequences.'' 
+      and Modified Subresultant Polynomial remainder Sequences.'' 
       Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
 
     '''
@@ -113,7 +113,7 @@ def sylvester(f, g, x, method = 1):
             k = k + 1
         return M
 
-def sturm_PG(p,q,x, method=0):
+def sturm_pg(p,q,x, method=0):
     """
     p, q are polynomials in Z[x] or Q[x].
 
@@ -147,27 +147,27 @@ def sturm_PG(p,q,x, method=0):
     polynomial divisions in Q[x] are performed, using the function rem(p, q, x);  
     the coefficients of the remainders computed this way become (``modified'') 
     subresultants with the help of the Pell-Gordon Theorem of 1917.
-    See also the function euclid_PG(p, q, x).
+    See also the function euclid_pg(p, q, x).
     
     References:
     =========== 
-    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
-    the Highest Common Factor of Two Polynomials. Annals of Mathematics,
+    1. Pell A. J., R. L. Gordon. The Modified remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    and Modified Subresultant Polynomial remainder Sequences.'' 
     Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
      
     """
-    # make sure neither p nor q is 0
+    # Make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
-    FLAG = 0
+    flag = 0
     d0 =  degree(p, x)
     d1 =  degree(q, x)
-    # make sure proper degrees  
+    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d1 > d0:
@@ -176,72 +176,72 @@ def sturm_PG(p,q,x, method=0):
     if d0 > 0 and d1 == 0:
         return [p,q]
         
-    # make sure LC(p) > 0
+    # Make sure LC(p) > 0
     if  LC(p,x) < 0:
-        FLAG = 1
+        flag = 1
         p = -p
         q = -q
         
     # initialize
     lcf = LC(p, x)**(d0 - d1)               # lcf * subr = modified subr 
     a0, a1 = p, q                           # the input polys
-    sturmSeq = [a0, a1]                     # the output list 
+    sturm_seq = [a0, a1]                    # the output list 
     del0 = d0 - d1                          # degree difference
     rho1 =  LC(a1, x)                       # leading coeff of a1
-    expDeg = d1 - 1                         # expected degree of a2
+    exp_deg = d1 - 1                        # expected degree of a2
     a2 = - rem(a0, a1, domain=QQ)           # first remainder
     rho2 =  LC(a2,x)                        # leading coeff of a2
     d2 =  degree(a2, x)                     # actual degree of a2
-    degDiff_NEW = expDeg - d2               # expected - actual degree
+    deg_diff_new = exp_deg - d2             # expected - actual degree
     del1 = d1 - d2                          # degree difference
 
-    # mulFac is the factor by which a2 is multiplied to 
+    # mul_fac is the factor by which a2 is multiplied to 
     # get integer coefficients
-    mulFac_OLD = rho1**(del0 + del1 - degDiff_NEW) 
+    mul_fac_old = rho1**(del0 + del1 - deg_diff_new) 
 
     # update variable and append
-    degDiff_OLD = degDiff_NEW 
+    deg_diff_old = deg_diff_new 
     if method == 0:
-        sturmSeq.append( simplify(lcf * a2 *  Abs(mulFac_OLD)))
+        sturm_seq.append( simplify(lcf * a2 *  Abs(mul_fac_old)))
     else:
-        sturmSeq.append( simplify( a2 *  Abs(mulFac_OLD)))
-    # main loop
+        sturm_seq.append( simplify( a2 *  Abs(mul_fac_old)))
+    # Main loop
     while d2 > 0:     
         a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
         del0 = del1                          # update degree difference
-        expDeg = d1 - 1                      # new expected degree 
+        exp_deg = d1 - 1                     # new expected degree 
         a2 = - rem(a0, a1, domain=QQ)        # new remainder
         rho3 =  LC(a2, x)                    # leading coeff of a2
         d2 =  degree(a2, x)                  # actual degree of a2
-        degDiff_NEW = expDeg - d2            # expected - actual degree
+        deg_diff_new = exp_deg - d2          # expected - actual degree
         del1 = d1 - d2                       # degree difference
 
         # take into consideration the power 
-        # rho1**degDiff_OLD that was "left out"
-        expo_OLD = degDiff_OLD               # rho1 raised to this power
-        expo_NEW = del0 + del1 - degDiff_NEW # rho2 raised to this power
+        # rho1**deg_diff_old that was "left out"
+        expo_old = deg_diff_old               # rho1 raised to this power
+        expo_new = del0 + del1 - deg_diff_new # rho2 raised to this power
 
-        mulFac_NEW = rho2**(expo_NEW) * rho1**(expo_OLD) * mulFac_OLD 
+        mul_fac_new = rho2**(expo_new) * rho1**(expo_old) * mul_fac_old 
 
         # update variables and append
-        degDiff_OLD, mulFac_OLD = degDiff_NEW, mulFac_NEW
+        deg_diff_old, mul_fac_old = deg_diff_new, mul_fac_new
         rho1, rho2 = rho2, rho3
         if method == 0:
-            sturmSeq.append( simplify(lcf * a2 *  Abs(mulFac_OLD)))
+            sturm_seq.append( simplify(lcf * a2 *  Abs(mul_fac_old)))
         else:
-            sturmSeq.append( simplify( a2 *  Abs(mulFac_OLD)))
+            sturm_seq.append( simplify( a2 *  Abs(mul_fac_old)))
 
-    if FLAG:          # change the sign of the sequence
-        sturmSeq = [-i for i in sturmSeq]
+    if flag:          # change the sign of the sequence
+        sturm_seq = [-i for i in sturm_seq]
     
     # gcd is of degree > 0 ?   
-    m = len(sturmSeq)
-    if sturmSeq[m - 1] == nan or sturmSeq[m - 1] == 0:
-        sturmSeq.pop(m - 1)
+    m = len(sturm_seq)
+    if sturm_seq[m - 1] == nan or sturm_seq[m - 1] == 0:
+        sturm_seq.pop(m - 1)
 
-    return sturmSeq
+    return sturm_seq
 
-def sturm_Q(p, q, x):
+def sturm_q(p, q, x):
     """
     p, q are polynomials in Z[x] or Q[x];
 
@@ -260,27 +260,27 @@ def sturm_Q(p, q, x):
 
     References:
     =========== 
-    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
-    the Highest Common Factor of Two Polynomials. Annals of Mathematics,
+    1. Pell A. J., R. L. Gordon. The Modified remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
 
     2 Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    and Modified Subresultant Polynomial remainder Sequences.'' 
     Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
 
     3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
     on the Theory of Subresultants.'' Submitted for publication.
 
     """
-    # make sure neither p nor q is 0
+    # Make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
-    FLAG = 0
+    flag = 0
     d0 =  degree(p, x)
     d1 =  degree(q, x)
 
-    # make sure proper degrees  
+    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d1 > d0:
@@ -289,38 +289,38 @@ def sturm_Q(p, q, x):
     if d0 > 0 and d1 == 0:
         return [p,q]
         
-    # make sure LC(p) > 0
+    # Make sure LC(p) > 0
     if  LC(p,x) < 0:
-        FLAG = 1
+        flag = 1
         p = -p
         q = -q
 
     # initialize
     a0, a1 = p, q                           # the input polys
-    sturmSeq = [a0, a1]                     # the output list 
+    sturm_seq = [a0, a1]                     # the output list 
     a2 = -rem(a0, a1, domain=QQ)            # first remainder
     d2 =  degree(a2, x)                     # degree of a2
-    sturmSeq.append( a2 ) 
+    sturm_seq.append( a2 ) 
 
 
-    # main loop
+    # Main loop
     while d2 > 0:     
         a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
         a2 = -rem(a0, a1, domain=QQ)         # new remainder
         d2 =  degree(a2, x)                  # actual degree of a2
-        sturmSeq.append( a2 ) 
+        sturm_seq.append( a2 ) 
     
-    if FLAG:          # change the sign of the sequence
-        sturmSeq = [-i for i in sturmSeq]
+    if flag:          # change the sign of the sequence
+        sturm_seq = [-i for i in sturm_seq]
 
     # gcd is of degree > 0 ?   
-    m = len(sturmSeq)
-    if sturmSeq[m - 1] == nan or sturmSeq[m - 1] == 0:
-        sturmSeq.pop(m - 1)
+    m = len(sturm_seq)
+    if sturm_seq[m - 1] == nan or sturm_seq[m - 1] == 0:
+        sturm_seq.pop(m - 1)
 
-    return sturmSeq
+    return sturm_seq
 
-def sturm_AMV(p, q, x, method=0):
+def sturm_amv(p, q, x, method=0):
     """
     p, q are polynomials in Z[x] or Q[x].
 
@@ -351,30 +351,30 @@ def sturm_AMV(p, q, x, method=0):
 
     To compute the coefficients, no determinant evaluation takes place.    
     Instead, we first compute the euclidean sequence  of p and q using 
-    euclid_AMV(p, q, x) and then: (a) change the signs of the remainders in the 
+    euclid_amv(p, q, x) and then: (a) change the signs of the remainders in the 
     Euclidean sequence according to the pattern "-, -, +, +, -, -, +, +,..." 
-    (see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference)
+    (see LemMa 1 in the 1st reference or Theorem 3 in the 2nd reference)
     and (b) if method=0, assuming deg(p) > deg(q), we multiply the remainder 
     coefficients of the Euclidean sequence times the factor 
-    Abs(LC(p)**( deg(p)- deg(q))) to make them modified subresultants.
-    See also the function sturm_PG(p, q, x).
+    Abs(LC(p)**( deg(p)- deg(q))) to Make them modified subresultants.
+    See also the function sturm_pg(p, q, x).
 
     References:
     ===========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
     on the Theory of Subresultants.'' Submitted for publication.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders 
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the remainders 
     Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica 
     Journal of Computing, to appear.
 
     3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
     Submitted for publication.
    
     """
     # compute the euclidean sequence 
-    prs = euclid_AMV(p, q, x)
+    prs = euclid_amv(p, q, x)
 
     # defensive
     if prs == [] or len(prs) == 2:
@@ -386,7 +386,7 @@ def sturm_AMV(p, q, x, method=0):
     lcf = Abs( LC(prs[0])**( degree(prs[0]) - degree(prs[1]) ) )
     
     # the signs of the first two polys in the sequence stay the same
-    sturmSeq = [prs[0], prs[1]]
+    sturm_seq = [prs[0], prs[1]]
     flag = 0
     m = len(prs)
     i = 2
@@ -394,32 +394,32 @@ def sturm_AMV(p, q, x, method=0):
     # and multiply times lcf if needed
     while i <= m-1:
         if  flag == 0:
-            sturmSeq.append( - prs[i] )
+            sturm_seq.append( - prs[i] )
             i = i + 1
             if i == m: 
                 break
-            sturmSeq.append( - prs[i] )
+            sturm_seq.append( - prs[i] )
             i = i + 1
             flag = 1
         elif flag == 1:
-            sturmSeq.append( prs[i] )
+            sturm_seq.append( prs[i] )
             i = i + 1
             if i == m: 
                 break
-            sturmSeq.append( prs[i] )
+            sturm_seq.append( prs[i] )
             i = i + 1
             flag = 0
 
     # subresultants or modified subresultants?  
     if method == 0 and lcf > 1:
-        auxSeq = [sturmSeq[0], sturmSeq[1]]
+        aux_seq = [sturm_seq[0], sturm_seq[1]]
         for i in range(2, m):
-            auxSeq.append(simplify(sturmSeq[i] * lcf ))
-        sturmSeq = auxSeq
+            aux_seq.append(simplify(sturm_seq[i] * lcf ))
+        sturm_seq = aux_seq
 
-    return sturmSeq
+    return sturm_seq
 
-def euclid_PG(p, q, x):
+def euclid_pg(p, q, x):
     """
     p, q are polynomials in Z[x] or Q[x];
 
@@ -438,37 +438,37 @@ def euclid_PG(p, q, x):
 
     To compute the Euclidean sequence, no determinant evaluation takes place. 
     We first compute the (generalized) Sturm sequence  of p and q using 
-    sturm_PG(p, q, x, 1), in which case the coefficients are (in absolute value) 
+    sturm_pg(p, q, x, 1), in which case the coefficients are (in absolute value) 
     equal to subresultants. Then we change the signs of the remainders in the 
     Sturm sequence according to the pattern "-, -, +, +, -, -, +, +,..." ;
-    see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference as well as
-    the function sturm_PG(p, q, x).
+    see LemMa 1 in the 1st reference or Theorem 3 in the 2nd reference as well as
+    the function sturm_pg(p, q, x).
     
     References:
     ===========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
     on the Theory of Subresultants.'' Submitted for publication.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders 
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the remainders 
     Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica 
     Journal of Computing, to appear.
 
     3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
     Submitted for publication.
    
     """
     
     # compute the sturmian sequence using the Pell-Gordon theorem
     # with the coefficients in the prs being (in absolute value) subresultants
-    prs = sturm_PG(p, q, x, 1)  ## or prs = sturm_AMV(p, q, x, 1)
+    prs = sturm_pg(p, q, x, 1)  ## or prs = sturm_amv(p, q, x, 1)
 
     # defensive
     if prs == [] or len(prs) == 2:
         return prs
 
     # the signs of the first two polys in the sequence stay the same
-    euclidSeq = [prs[0], prs[1]]
+    euclid_seq = [prs[0], prs[1]]
     flag = 0
     m = len(prs)
     i = 2
@@ -476,25 +476,25 @@ def euclid_PG(p, q, x):
     # change the signs according to "-, -, +, +, -, -, +, +,..."
     while i <= m-1:
         if  flag == 0:
-            euclidSeq.append(- prs[i] )
+            euclid_seq.append(- prs[i] )
             i = i + 1
             if i == m: 
                 break
-            euclidSeq.append(- prs[i] )
+            euclid_seq.append(- prs[i] )
             i = i + 1
             flag = 1
         elif flag == 1:
-            euclidSeq.append(prs[i] )
+            euclid_seq.append(prs[i] )
             i = i + 1
             if i == m: 
                 break
-            euclidSeq.append(prs[i] )
+            euclid_seq.append(prs[i] )
             i = i + 1
             flag = 0
 
-    return euclidSeq
+    return euclid_seq
 
-def euclid_Q(p, q, x):
+def euclid_q(p, q, x):
     """
     p, q are polynomials in Z[x] or Q[x];
 
@@ -514,26 +514,26 @@ def euclid_Q(p, q, x):
 
     References:
     =========== 
-    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
-    the Highest Common Factor of Two Polynomials. Annals of Mathematics,
+    1. Pell A. J., R. L. Gordon. The Modified remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    and Modified Subresultant Polynomial remainder Sequences.'' 
     Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
 
     3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
     on the Theory of Subresultants.'' Submitted for publication.
 
     """
-    # make sure neither p nor q is 0
+    # Make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
-    FLAG = 0
+    flag = 0
     d0 =  degree(p, x)
     d1 =  degree(q, x)
-    # make sure proper degrees  
+    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d1 > d0:
@@ -542,38 +542,38 @@ def euclid_Q(p, q, x):
     if d0 > 0 and d1 == 0:
         return [p,q]
         
-    # make sure LC(p) > 0
+    # Make sure LC(p) > 0
     if  LC(p,x) < 0:
-        FLAG = 1
+        flag = 1
         p = -p
         q = -q
 
     # initialize
     a0, a1 = p, q                           # the input polys
-    euclidSeq = [a0, a1]                    # the output list 
+    euclid_seq = [a0, a1]                   # the output list 
     a2 = rem(a0, a1, domain=QQ)             # first remainder
     d2 =  degree(a2, x)                     # degree of a2
-    euclidSeq.append( a2 ) 
+    euclid_seq.append( a2 ) 
 
-    # main loop
+    # Main loop
     while d2 > 0:     
         a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
         a2 = rem(a0, a1, domain=QQ)          # new remainder
         d2 =  degree(a2, x)                  # actual degree of a2
-        euclidSeq.append( a2 ) 
+        euclid_seq.append( a2 ) 
 
     
-    if FLAG:          # change the sign of the sequence
-        euclidSeq = [-i for i in euclidSeq]
+    if flag:          # change the sign of the sequence
+        euclid_seq = [-i for i in euclid_seq]
 
     # gcd is of degree > 0 ?   
-    m = len(euclidSeq)
-    if euclidSeq[m - 1] == nan or euclidSeq[m - 1] == 0:
-        euclidSeq.pop(m - 1)
+    m = len(euclid_seq)
+    if euclid_seq[m - 1] == nan or euclid_seq[m - 1] == 0:
+        euclid_seq.pop(m - 1)
 
-    return euclidSeq
+    return euclid_seq
 
-def euclid_AMV(f, g, x):
+def euclid_amv(f, g, x):
     """
     f, g are polynomials in Z[x] or Q[x].
 
@@ -592,7 +592,7 @@ def euclid_AMV(f, g, x):
 
     To compute the coefficients, no determinant evaluation takes place. 
     Instead, polynomial divisions in Z[x] or Q[x] are performed, using 
-    the function remZ(f, g, x);  the coefficients of the remainders 
+    the function rem_z(f, g, x);  the coefficients of the remainders 
     computed this way become subresultants with the help of the 
     Collins-Brown-Traub formula for coefficient reduction.
    
@@ -602,18 +602,18 @@ def euclid_AMV(f, g, x):
     on the Theory of Subresultants.'' Submitted for publication.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
     Submitted for publication.
     
     """
-    # make sure neither f nor g is 0
+    # Make sure neither f nor g is 0
     if f == 0 or g == 0:
         return [f, g]
 
     d0 =  degree(f, x)
     d1 =  degree(g, x)
 
-        # make sure proper degrees  
+        # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d0 > 0 and d1 == 0:
@@ -627,36 +627,36 @@ def euclid_AMV(f, g, x):
     a0 = f
     a1 = g
 
-    euclidSeq = [a0, a1]
-    degdifP1, c = degree(a0) - degree(a1) + 1, -1
+    euclid_seq = [a0, a1]
+    deg_dif_p1, c = degree(a0) - degree(a1) + 1, -1
     
     i = 0                                          # counter for remainders 
 
         # compute the first polynomial of the prs
     i += 1
-    a2 = remZ(a0, a1, x) / Abs( (-1)**degdifP1 )     # first remainder
-    euclidSeq.append( a2 )
+    a2 = rem_z(a0, a1, x) / Abs( (-1)**deg_dif_p1 )     # first remainder
+    euclid_seq.append( a2 )
     d2 =  degree(a2, x)                              # actual degree of a2
 
     while d2 >= 1:
         a0, a1, d0, d1 = a1, a2, d1, d2       # update polys and degrees
         i += 1
         sigma0 = -LC(a0)
-        c = (sigma0**(degdifP1 - 1)) / (c**(degdifP1 - 2))
-        degdifP1 = degree(a0, x) - d2 + 1
-        a2 = remZ(a0, a1, x) / Abs( ((c**(degdifP1 - 1)) * sigma0) )
-        euclidSeq.append( a2 )
+        c = (sigma0**(deg_dif_p1 - 1)) / (c**(deg_dif_p1 - 2))
+        deg_dif_p1 = degree(a0, x) - d2 + 1
+        a2 = rem_z(a0, a1, x) / Abs( ((c**(deg_dif_p1 - 1)) * sigma0) )
+        euclid_seq.append( a2 )
         d2 =  degree(a2, x)                   # actual degree of a2
         
     # gcd is of degree > 0 ? 
-    m = len(euclidSeq)  
-    if euclidSeq[m - 1] == nan or euclidSeq[m - 1] == 0:
-        euclidSeq.pop(m - 1)
+    m = len(euclid_seq)  
+    if euclid_seq[m - 1] == nan or euclid_seq[m - 1] == 0:
+        euclid_seq.pop(m - 1)
         
-    return euclidSeq
+    return euclid_seq
 
 
-def modified_subresultants_PG(p,q,x):
+def modified_subresultants_pg(p,q,x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
@@ -675,32 +675,32 @@ def modified_subresultants_PG(p,q,x):
 
     References:
     ===========  
-    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
-    the Highest Common Factor of Two Polynomials. Annals of Mathematics,
+    1. Pell A. J., R. L. Gordon. The Modified remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    and Modified Subresultant Polynomial remainder Sequences.'' 
     Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
     
     """
-    # make sure neither p nor q is 0
+    # Make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
     k =  var('k')                              # index in summation formula
-    u_List = []                                # of elements (-1)**u_i 
-    subresL = [p, q]                           # mod. subr. prs output list    
+    u_list = []                                # of elements (-1)**u_i 
+    subres_l = [p, q]                           # mod. subr. prs output list    
     d0 =  degree(p,x)
     d1 =  degree(q,x)
 
-    # make sure proper degrees  
+    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d1 > d0:
         d0, d1 = d1, d0
         p, q = q, p
-        subresL = [p, q]                       # mod. subr. prs output list    
+        subres_l = [p, q]                       # mod. subr. prs output list    
     if d0 > 0 and d1 == 0:
         return [p,q]
                 
@@ -711,130 +711,130 @@ def modified_subresultants_PG(p,q,x):
     rho_1 = LC(a0)                              # lead. coeff (a0)
 
     # Initialize Pell-Gordon variables
-    rho_List_Minus_1 =  sign( LC(a0, x))      # sign of LC(a0)
+    rho_list_minus_1 =  sign( LC(a0, x))      # sign of LC(a0)
     rho1 =  LC(a1, x)                         # leading coeff of a1
-    rho_List = [ sign(rho1)]                  # of signs
-    p_List = [del0]                           # of degree differences
-    u =  summation(k, (k, 1, p_List[0]))      # value of u
-    u_List.append(u)                          # of u values
-    v = sum(p_List)                           # v value
+    rho_list = [ sign(rho1)]                  # of signs
+    p_list = [del0]                           # of degree differences
+    u =  summation(k, (k, 1, p_list[0]))      # value of u
+    u_list.append(u)                          # of u values
+    v = sum(p_list)                           # v value
 
-    expDeg = d1 - 1                           # expected degree of a2
+    exp_deg = d1 - 1                           # expected degree of a2
     a2 = - rem(a0, a1, domain=QQ)             # first remainder
     rho2 =  LC(a2, x)                         # leading coeff of a2
     d2 =  degree(a2, x)                       # actual degree of a2
-    degDiff_NEW = expDeg - d2                 # expected - actual degree
+    deg_diff_new = exp_deg - d2                 # expected - actual degree
     del1 = d1 - d2                            # degree difference
 
-    # mulFac is the factor by which a2 is multiplied to 
+    # mul_fac is the factor by which a2 is multiplied to 
     # get integer coefficients
-    mulFac_OLD = rho1**(del0 + del1 - degDiff_NEW) 
+    mul_fac_old = rho1**(del0 + del1 - deg_diff_new) 
         
     # update Pell-Gordon variables
-    p_List.append(1 + degDiff_NEW)              # degDiff_NEW is 0 for complete seq
+    p_list.append(1 + deg_diff_new)              # deg_diff_new is 0 for complete seq
 
     # apply Pell-Gordon formula (7) in second reference
     num = 1                                     # numerator of fraction
-    for k in range(len(u_List)):
-        num *= (-1)**u_List[k]
+    for k in range(len(u_list)):
+        num *= (-1)**u_list[k]
     num = num * (-1)**v
 
     # denominator depends on complete / incomplete seq
-    if degDiff_NEW == 0:                        # complete seq
+    if deg_diff_new == 0:                        # complete seq
         den = 1
-        for k in range(len(rho_List)):
-            den *= rho_List[k]**(p_List[k] + p_List[k + 1])
-        den = den * rho_List_Minus_1
+        for k in range(len(rho_list)):
+            den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+        den = den * rho_list_minus_1
     else:                                       # incomplete seq
         den = 1
-        for k in range(len(rho_List)-1):
-            den *= rho_List[k]**(p_List[k] + p_List[k + 1])
-        den = den * rho_List_Minus_1 
-        expo = (p_List[len(rho_List) - 1] + p_List[len(rho_List)] - degDiff_NEW)
-        den = den * rho_List[len(rho_List) - 1]**expo 
+        for k in range(len(rho_list)-1):
+            den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+        den = den * rho_list_minus_1 
+        expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
+        den = den * rho_list[len(rho_list) - 1]**expo 
     
     # the sign of the determinant depends on sg(num / den)
     if  sign(num / den) > 0:
-        subresL.append( simplify(rho_1**degdif*a2* Abs(mulFac_OLD) ) ) 
+        subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) ) 
     else:
-        subresL.append(- simplify(rho_1**degdif*a2* Abs(mulFac_OLD) ) )      
+        subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )      
   
     # update Pell-Gordon variables
     k =  var('k')
-    rho_List.append( sign(rho2))
-    u =  summation(k, (k, 1, p_List[len(p_List) - 1]))   
-    u_List.append(u)   
-    v = sum(p_List)
+    rho_list.append( sign(rho2))
+    u =  summation(k, (k, 1, p_list[len(p_list) - 1]))   
+    u_list.append(u)   
+    v = sum(p_list)
     
-    degDiff_OLD=degDiff_NEW
+    deg_diff_old=deg_diff_new
     
-    # main loop
+    # Main loop
     while d2 > 0:     
         a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
         del0 = del1                          # update degree difference
-        expDeg = d1 - 1                      # new expected degree 
+        exp_deg = d1 - 1                      # new expected degree 
         a2 = - rem(a0, a1, domain=QQ)        # new remainder
         rho3 =  LC(a2, x)                    # leading coeff of a2
         d2 =  degree(a2, x)                  # actual degree of a2
-        degDiff_NEW = expDeg - d2            # expected - actual degree
+        deg_diff_new = exp_deg - d2            # expected - actual degree
         del1 = d1 - d2                       # degree difference
 
         # take into consideration the power 
-        # rho1**degDiff_OLD that was "left out"
-        expo_OLD = degDiff_OLD               # rho1 raised to this power
-        expo_NEW = del0 + del1 - degDiff_NEW # rho2 raised to this power
+        # rho1**deg_diff_old that was "left out"
+        expo_old = deg_diff_old               # rho1 raised to this power
+        expo_new = del0 + del1 - deg_diff_new # rho2 raised to this power
 
-        mulFac_NEW = rho2**(expo_NEW) * rho1**(expo_OLD) * mulFac_OLD 
+        mul_fac_new = rho2**(expo_new) * rho1**(expo_old) * mul_fac_old 
 
         # update variables and append
-        degDiff_OLD, mulFac_OLD = degDiff_NEW, mulFac_NEW
+        deg_diff_old, mul_fac_old = deg_diff_new, mul_fac_new
         rho1, rho2 = rho2, rho3
         
         # update Pell-Gordon variables
-        p_List.append(1 + degDiff_NEW)       # degDiff_NEW is 0 for complete seq
+        p_list.append(1 + deg_diff_new)       # deg_diff_new is 0 for complete seq
             
         # apply Pell-Gordon formula (7) in second reference
         num = 1                              # numerator 
-        for k in range(len(u_List)): 
-            num *= (-1)**u_List[k]
+        for k in range(len(u_list)): 
+            num *= (-1)**u_list[k]
         num = num * (-1)**v
 
         # denominator depends on complete / incomplete seq
-        if degDiff_NEW == 0:                 # complete seq
+        if deg_diff_new == 0:                 # complete seq
             den = 1
-            for k in range(len(rho_List)):
-                den *= rho_List[k]**(p_List[k] + p_List[k + 1])
-            den = den * rho_List_Minus_1
+            for k in range(len(rho_list)):
+                den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+            den = den * rho_list_minus_1
         else:                                # incomplete seq
             den = 1
-            for k in range(len(rho_List)-1):
-                den *= rho_List[k]**(p_List[k] + p_List[k + 1])
-            den = den * rho_List_Minus_1 
-            expo = (p_List[len(rho_List) - 1] + p_List[len(rho_List)] - degDiff_NEW)
-            den = den * rho_List[len(rho_List) - 1]**expo 
+            for k in range(len(rho_list)-1):
+                den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+            den = den * rho_list_minus_1 
+            expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
+            den = den * rho_list[len(rho_list) - 1]**expo 
 
                     
         # the sign of the determinant depends on sg(num / den)          
         if  sign(num / den) > 0:
-            subresL.append( simplify(rho_1**degdif*a2* Abs(mulFac_OLD) ) ) 
+            subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) ) 
         else:
-            subresL.append(- simplify(rho_1**degdif*a2* Abs(mulFac_OLD) ) )
+            subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
             
         # update Pell-Gordon variables
         k =  var('k')
-        rho_List.append( sign(rho2))
-        u =  summation(k, (k, 1, p_List[len(p_List) - 1]))   
-        u_List.append(u)   
-        v = sum(p_List)
+        rho_list.append( sign(rho2))
+        u =  summation(k, (k, 1, p_list[len(p_list) - 1]))   
+        u_list.append(u)   
+        v = sum(p_list)
 
     # gcd is of degree > 0 ?   
-    m = len(subresL)
-    if subresL[m - 1] == nan or subresL[m - 1] == 0:
-        subresL.pop(m - 1)
+    m = len(subres_l)
+    if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
+        subres_l.pop(m - 1)
 
-    return  subresL 
+    return  subres_l 
 
-def subresultants_PG(p,q,x):
+def subresultants_pg(p,q,x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
@@ -853,13 +853,13 @@ def subresultants_PG(p,q,x):
 
     References:
     ===========
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders 
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the remainders 
     Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
     Serdica Journal of Computing, to appear.
     
     """
     # compute the modified subresultant prs 
-    lst = modified_subresultants_PG(p,q,x)  ## or lst = modified_subresultants_AMV(p,q,x)
+    lst = modified_subresultants_pg(p,q,x)  ## or lst = modified_subresultants_amv(p,q,x)
 
     # defensive
     if lst == [] or len(lst) == 2:
@@ -871,32 +871,32 @@ def subresultants_PG(p,q,x):
     lcf = Abs( LC(lst[0])**( degree(lst[0]) - degree(lst[1]) ) )
 
     # Initialize the subresultant prs list 
-    subrSeq = [lst[0], lst[1]]
+    subr_seq = [lst[0], lst[1]]
 
     # compute the degree sequences m_i and j_i of Theorem 2 in reference.
-    degSeq = [degree(Poly(poly, x)) for poly in lst]
-    deg = degSeq[0]
-    degSeqS = degSeq[1:-1]
-    mSeq = [m-1 for m in degSeqS]
-    jSeq = [deg - m for m in mSeq]
+    deg_seq = [degree(Poly(poly, x)) for poly in lst]
+    deg = deg_seq[0]
+    deg_seq_s = deg_seq[1:-1]
+    m_seq = [m-1 for m in deg_seq_s]
+    j_seq = [deg - m for m in m_seq]
     
     # compute the AMV factors of Theorem 2 in reference.
-    fact = [(-1)**( j*(j-1)/S(2) ) for j in jSeq]
+    fact = [(-1)**( j*(j-1)/S(2) ) for j in j_seq]
 
     # shortened list without the first two polys
-    lstS = lst[2:]
+    lst_s = lst[2:]
 
-    # poly lstS[k] is multiplied times fact[k], divided by lcf
+    # poly lst_s[k] is multiplied times fact[k], divided by lcf
     # and appended to the subresultant prs list
     m = len(fact)
     for k in range(m):
         if sign(fact[k]) == -1:
-            subrSeq.append(-lstS[k] / lcf)
+            subr_seq.append(-lst_s[k] / lcf)
         else:
-            subrSeq.append(lstS[k] / lcf)
-    return subrSeq
+            subr_seq.append(lst_s[k] / lcf)
+    return subr_seq
 
-def subresultants_AMV_Q(p,q,x):
+def subresultants_amv_q(p,q,x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
@@ -920,18 +920,18 @@ def subresultants_AMV_Q(p,q,x):
     on the Theory of Subresultants.'' Submitted for publication.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
     Submitted for publication.
     
     """
-    # make sure neither p nor q is 0
+    # Make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
     d0 =  degree(p, x)
     d1 =  degree(q, x)
 
-    # make sure proper degrees  
+    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d0 > 0 and d1 == 0:
@@ -944,17 +944,17 @@ def subresultants_AMV_Q(p,q,x):
     # initialize
     i, s = 0, 0                              # counters for remainders & odd elements
     p_odd_index_sum = 0                      # contains the sum of p_1, p_3, etc
-    subresL = [p, q]                         # subresultant prs output list
+    subres_l = [p, q]                         # subresultant prs output list
     a0, a1 = p, q                            # the input polys
     sigma1 =  LC(a1, x)                      # leading coeff of a1
     p0 = d0 - d1                             # degree difference
     if p0 % 2 == 1:
         s += 1       
     phi = floor( (s + 1) / 2 )     
-    mulFac = 1
+    mul_fac = 1
     d2 = d1
 
-    # main loop
+    # Main loop
     while d2 > 0:   
         i += 1
         a2 = rem(a0, a1, domain= QQ)          # new remainder
@@ -969,25 +969,25 @@ def subresultants_AMV_Q(p,q,x):
         p1 = d1 - d2                                       
         psi = i + phi + p_odd_index_sum
 
-        # new mulFac
-        mulFac = sigma1**(p0 + 1) * mulFac
+        # new mul_fac
+        mul_fac = sigma1**(p0 + 1) * mul_fac
             
         ## compute the sign of the first fraction in formula (9) of the paper
         # numerator 
         num = (-1)**psi     
         # denominator 
-        den = sign(mulFac)
+        den = sign(mul_fac)
          
         # the sign of the determinant depends on sign( num / den ) != 0          
         if  sign(num / den) > 0:
-            subresL.append( simplify(expand(a2* Abs(mulFac))))
+            subres_l.append( simplify(expand(a2* Abs(mul_fac))))
         else:
-            subresL.append(- simplify(expand(a2* Abs(mulFac))))
+            subres_l.append(- simplify(expand(a2* Abs(mul_fac))))
         
 
-        ## bring into mulFac the missing power of sigma if there was a degree gap
+        ## bring into mul_fac the missing power of sigma if there was a degree gap
         if p1 - 1 > 0:       
-            mulFac = mulFac * sigma1**(p1 - 1)
+            mul_fac = mul_fac * sigma1**(p1 - 1)
 
        # update AMV variables
         a0, a1, d0, d1 = a1, a2, d1, d2       
@@ -999,14 +999,14 @@ def subresultants_AMV_Q(p,q,x):
             p_odd_index_sum += p0             # p_i has odd index
        
     # gcd is of degree > 0 ?   
-    m = len(subresL)
-    if subresL[m - 1] == nan or subresL[m - 1] == 0:
-        subresL.pop(m - 1)
+    m = len(subres_l)
+    if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
+        subres_l.pop(m - 1)
 
-    return  subresL 
+    return  subres_l 
 
 
-def computeSign(base, expo):
+def compute_sign(base, expo):
     '''
     base != 0 and expo >= 0 are integers;
     
@@ -1022,9 +1022,9 @@ def computeSign(base, expo):
     else:
         return sb
 
-def remZ(p, q, x):
+def rem_z(p, q, x):
     '''
-    Intended mainly for p, q polynomials in Z[x] so that,
+    Intended Mainly for p, q polynomials in Z[x] so that,
     on dividing p by q, the remainder will also be in Z[x]. (However,
     it also works fine for polynomials in Q[x].) 
 
@@ -1036,7 +1036,7 @@ def remZ(p, q, x):
     value of the leading coefficient of q. 
     This results not only in ``messing up the signs'' of the Euclidean and 
     Sturmian prs's as mentioned in the second reference, 
-    but also in violation of the main results of the first and third 
+    but also in violation of the Main results of the first and third 
     references --- Theorem 4 and Theorem 1 respectively. Theorems 4 and 1 
     establish a one-to-one correspondence between the Euclidean and the 
     Sturmian prs of p, q, on one hand, and the subresultant prs of p, q, 
@@ -1044,11 +1044,11 @@ def remZ(p, q, x):
 
     References:
     ===========
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders 
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the remainders 
     Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
     Serdica Journal of Computing, to appear.
 
-    2. http://planetmath.org/sturmstheorem
+    2. http://planetMath.org/sturmstheorem
 
     3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result on 
     the Theory of Subresultants.'' Submitted for publication.
@@ -1058,7 +1058,7 @@ def remZ(p, q, x):
     return rem(Abs(LC(q, x))**delta  *  p, q, x) 
 
  
-def subresultants_AMV(f, g, x):
+def subresultants_amv(f, g, x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
@@ -1069,7 +1069,7 @@ def subresultants_AMV(f, g, x):
 
     To compute the coefficients, no determinant evaluation takes place. 
     Instead, polynomial divisions in Z[x] or Q[x] are performed, using 
-    the function remZ(p, q, x);  the coefficients of the remainders 
+    the function rem_z(p, q, x);  the coefficients of the remainders 
     computed this way become subresultants with the help of the 
     Akritas-Malaschonok-Vigklas Theorem of 2015 and the Collins-Brown-
     Traub formula for coefficient reduction.
@@ -1083,18 +1083,18 @@ def subresultants_AMV(f, g, x):
     on the Theory of Subresultants.'' Submitted for publication.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
     Submitted for publication.
     
     """
-    # make sure neither f nor g is 0
+    # Make sure neither f nor g is 0
     if f == 0 or g == 0:
         return [f, g]
 
     d0 =  degree(f, x)
     d1 =  degree(g, x)
 
-        # make sure proper degrees  
+        # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d0 > 0 and d1 == 0:
@@ -1108,43 +1108,43 @@ def subresultants_AMV(f, g, x):
     a0 = f
     a1 = g
 
-    subresL = [a0, a1]
-    degdifP1, c = degree(a0) - degree(a1) + 1, -1
+    subres_l = [a0, a1]
+    deg_dif_p1, c = degree(a0) - degree(a1) + 1, -1
     
         # initialize AMV variables
     sigma1 =  LC(a1, x)                      # leading coeff of a1
     i, s = 0, 0                              # counters for remainders & odd elements
     p_odd_index_sum = 0                      # contains the sum of p_1, p_3, etc
-    p0 = degdifP1 - 1
+    p0 = deg_dif_p1 - 1
     if p0 % 2 == 1:
         s += 1       
     phi = floor( (s + 1) / 2 )
         # compute the first polynomial of the prs
     i += 1
-    a2 = remZ(a0, a1, x) / Abs( (-1)**degdifP1 )     # first remainder
+    a2 = rem_z(a0, a1, x) / Abs( (-1)**deg_dif_p1 )     # first remainder
     sigma2 =  LC(a2, x)                       # leading coeff of a2
     d2 =  degree(a2, x)                       # actual degree of a2
     p1 = d1 - d2                              # degree difference
-        # sgnDen is the factor, the denominator 1st fraction of (9),  
+        # sgn_den is the factor, the denominator 1st fraction of (9),  
         # by which a2 is multiplied to get integer coefficients
-    sgnDen = computeSign( sigma1, p0 + 1 )
+    sgn_den = compute_sign( sigma1, p0 + 1 )
         ## compute sign of the 1st fraction in formula (9) of the paper 
     # numerator
     psi = i + phi + p_odd_index_sum 
     num = (-1)**psi  
     # denominator
-    den = sgnDen
+    den = sgn_den
         # the sign of the determinant depends on sign(num / den) != 0
     if  sign(num / den) > 0:
-        subresL.append( a2 )
+        subres_l.append( a2 )
     else:
-        subresL.append( -a2 )
+        subres_l.append( -a2 )
         # update AMV variables
     if p1 % 2 == 1:
         s += 1       
     ## bring in the missing power of sigma if there was gap
     if p1 - 1 > 0:
-        sgnDen = sgnDen * computeSign( sigma1, p1 - 1 )
+        sgn_den = sgn_den * compute_sign( sigma1, p1 - 1 )
 
     while d2 >= 1:
         phi = floor( (s + 1) / 2 )
@@ -1155,44 +1155,44 @@ def subresultants_AMV(f, g, x):
         i += 1
 
         sigma0 = -LC(a0)
-        c = (sigma0**(degdifP1 - 1)) / (c**(degdifP1 - 2))
-        degdifP1 = degree(a0, x) - d2 + 1
-        a2 = remZ(a0, a1, x) / Abs( ((c**(degdifP1 - 1)) * sigma0) )
+        c = (sigma0**(deg_dif_p1 - 1)) / (c**(deg_dif_p1 - 2))
+        deg_dif_p1 = degree(a0, x) - d2 + 1
+        a2 = rem_z(a0, a1, x) / Abs( ((c**(deg_dif_p1 - 1)) * sigma0) )
         sigma3 =  LC(a2, x)                   # leading coeff of a2
         d2 =  degree(a2, x)                   # actual degree of a2
         p1 = d1 - d2                          # degree difference
         psi = i + phi + p_odd_index_sum
         # update variables 
         sigma1, sigma2 = sigma2, sigma3       
-        # new sgnDen
-        sgnDen = computeSign( sigma1, p0 + 1 ) * sgnDen            
+        # new sgn_den
+        sgn_den = compute_sign( sigma1, p0 + 1 ) * sgn_den            
         ## compute the sign of the first fraction in formula (9) of the paper
         # numerator 
         num = (-1)**psi     
         # denominator 
-        den = sgnDen
+        den = sgn_den
          
         # the sign of the determinant depends on sign( num / den ) != 0          
         if  sign(num / den) > 0:
-            subresL.append( a2 )
+            subres_l.append( a2 )
         else:
-            subresL.append( -a2 )
+            subres_l.append( -a2 )
         
         # update AMV variables
         if p1 % 2 ==1:
             s += 1        
         ## bring in the missing power of sigma if there was gap
         if p1 - 1 > 0:       
-            sgnDen = sgnDen * computeSign( sigma1, p1 - 1 )
+            sgn_den = sgn_den * compute_sign( sigma1, p1 - 1 )
         
     # gcd is of degree > 0 ?   
-    m = len(subresL)
-    if subresL[m - 1] == nan or subresL[m - 1] == 0:
-        subresL.pop(m - 1)
+    m = len(subres_l)
+    if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
+        subres_l.pop(m - 1)
 
-    return subresL
+    return subres_l
 
-def modified_subresultants_AMV(p,q,x):
+def modified_subresultants_amv(p,q,x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
@@ -1211,13 +1211,13 @@ def modified_subresultants_AMV(p,q,x):
 
     References:
     ===========
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders 
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the remainders 
     Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
     Serdica Journal of Computing, to appear.
     
     """
     # compute the subresultant prs 
-    lst = subresultants_AMV(p,q,x)     ## or lst = subresultants_AMV_Q(p, q, x)
+    lst = subresultants_amv(p,q,x)     ## or lst = subresultants_amv_q(p, q, x)
 
     # defensive
     if lst == [] or len(lst) == 2:
@@ -1229,44 +1229,44 @@ def modified_subresultants_AMV(p,q,x):
     lcf = Abs( LC(lst[0])**( degree(lst[0]) - degree(lst[1]) ) )
 
     # Initialize the modified subresultant prs list 
-    subrSeq = [lst[0], lst[1]]
+    subr_seq = [lst[0], lst[1]]
 
     # compute the degree sequences m_i and j_i of Theorem 2
-    degSeq = [degree(Poly(poly, x)) for poly in lst]
-    deg = degSeq[0]
-    degSeqS = degSeq[1:-1]
-    mSeq = [m-1 for m in degSeqS]
-    jSeq = [deg - m for m in mSeq]
+    deg_seq = [degree(Poly(poly, x)) for poly in lst]
+    deg = deg_seq[0]
+    deg_seq_s = deg_seq[1:-1]
+    m_seq = [m-1 for m in deg_seq_s]
+    j_seq = [deg - m for m in m_seq]
     
     # compute the AMV factors of Theorem 2
-    fact = [(-1)**( j*(j-1)/S(2) ) for j in jSeq]
+    fact = [(-1)**( j*(j-1)/S(2) ) for j in j_seq]
 
     # shortened list without the first two polys
-    lstS = lst[2:]
+    lst_s = lst[2:]
 
-    # poly lstS[k] is multiplied times fact[k] and times lcf
+    # poly lst_s[k] is multiplied times fact[k] and times lcf
     # and appended to the subresultant prs list
     m = len(fact)
     for k in range(m):
         if sign(fact[k]) == -1:
-            subrSeq.append( simplify(-lstS[k] * lcf) )
+            subr_seq.append( simplify(-lst_s[k] * lcf) )
         else:
-            subrSeq.append( simplify(lstS[k] * lcf) )
-    return subrSeq
+            subr_seq.append( simplify(lst_s[k] * lcf) )
+    return subr_seq
 
-def correctSign(degF, degG, S1, rdel, cdel):
+def correct_sign(deg_f, deg_g, s1, rdel, cdel):
     """
     Used in various subresultant prs algorithms.
 
     Evaluates the determinant, (a.k.a. subresultant) of a properly selected
-    submatrix of S1, Sylvester's matrix of 1840, to get the correct sign 
+    submatrix of s1, Sylvester's matrix of 1840, to get the correct sign 
     and value of the leading coefficient of a given polynomial remainder.
 
-    degF, degG are the degrees of the original polynomials p, q for which the
-    matrix S1 = sylvester(p, q, x, 1) was constructed.
+    deg_f, deg_g are the degrees of the original polynomials p, q for which the
+    matrix s1 = sylvester(p, q, x, 1) was constructed.
     
     rdel denotes the expected degree of the remainder; it is the number of 
-    rows to be deleted from each group of rows in S1 as described in the 
+    rows to be deleted from each group of rows in s1 as described in the 
     reference below.
 
     cdel denotes the expected degree minus the actual degree of the remainder; 
@@ -1276,17 +1276,17 @@ def correctSign(degF, degG, S1, rdel, cdel):
     References:
     ===========
     Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    and Modified Subresultant Polynomial remainder Sequences.'' 
     Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
 
     """
-    M = S1[:, :]   # copy of matrix S1
+    M = s1[:, :]   # copy of matrix s1
 
-    # eliminate rdel rows from the first degG rows
-    for i in range(M.rows - degF - 1, M.rows - degF - rdel - 1, -1):
+    # eliminate rdel rows from the first deg_g rows
+    for i in range(M.rows - deg_f - 1, M.rows - deg_f - rdel - 1, -1):
         M.row_del(i)
     
-    # eliminate rdel rows from the last degF rows
+    # eliminate rdel rows from the last deg_f rows
     for i in range(M.rows - 1, M.rows - rdel - 1, -1):
         M.row_del(i)
 
@@ -1322,59 +1322,59 @@ def subresultants_rem(p, q, x):
     References:
     ===========  
     1. Akritas, A. G.:``Three New Methods for Computing Subresultant 
-    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
+    Polynomial remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
     to appear.
 
     """
-    # make sure neither p nor q is 0
+    # Make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
     f, g = p, q
 
-    n = degF = degree(f, x)
-    m = degG = degree(g, x)
+    n = deg_f = degree(f, x)
+    m = deg_g = degree(g, x)
 
-    # make sure proper degrees
+    # Make sure proper degrees
     if n == 0 and m == 0:
         return []
     if n > 0 and m == 0:
         return [f, g]
     if n < m:
-        n, m, degF, degG, f, g = m, n, degG, degF, g, f
+        n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
 
-    S1 = sylvester(f, g, x, 1)
-    SR_list = [f, g]      # subresultant list
+    s1 = sylvester(f, g, x, 1)
+    sr_list = [f, g]      # subresultant list
 
     
-    while degG > 0:
+    while deg_g > 0:
         # compute the remainder in Z[x] by doing division in Z[x]
         r = rem(p, q, x)        
         # actual degree
         d = degree(r, x)
         # deg(0) == -oo
         if d == -oo:
-            return SR_list
+            return sr_list
         # expected degree
-        expDeg = degG - 1
-        # make coefficients subresultants
+        exp_deg = deg_g - 1
+        # Make coefficients subresultants
         # by evaluating ONE determinant
-        signValue = correctSign(n, m, S1, expDeg, expDeg - d)
-        r = simplify((r / LC(r, x)) * signValue)
+        sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
+        r = simplify((r / LC(r, x)) * sign_value)
 
         # append poly with subresultant coeffs
-        SR_list.append(r)
+        sr_list.append(r)
                     
         # update degrees and polys
-        degF, degG = degG, d
+        deg_f, deg_g = deg_g, d
         p, q = q, r
         
     # gcd is of degree > 0 ? 
-    m = len(SR_list)
-    if SR_list[m - 1] == nan or SR_list[m - 1] == 0:
-        SR_list.pop(m - 1)
+    m = len(sr_list)
+    if sr_list[m - 1] == nan or sr_list[m - 1] == 0:
+        sr_list.pop(m - 1)
 
-    return SR_list
+    return sr_list
 
 def pivot(M, i, j):
     ''' 
@@ -1382,54 +1382,54 @@ def pivot(M, i, j):
     
     All elements below M[i, j], in the j-th column, will       
     be zeroed, if they are not already 0, according to       
-    Dodgson-Bareiss' integer preserving transormation. 
+    Dodgson-Bareiss' integer preserving transorMation. 
 
     References:
     ===========
     1. Akritas, A. G.: ``A new method for computing polynomial greatest 
     common divisors and polynomial remainder sequences.''  
-    Numerische Mathematik 52, 119-127, 1988.
+    Numerische MatheMatik 52, 119-127, 1988.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
     by Van Vleck Regarding Sturm Sequences.'' 
     Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
 
     '''
-    Ma = M[:, :] # copy of matrix M
-    rs = Ma.rows # No. of rows
-    cs = Ma.cols # No. of cols
+    ma = M[:, :] # copy of matrix M
+    rs = ma.rows # No. of rows
+    cs = ma.cols # No. of cols
     for r in range(i+1, rs):
-        if Ma[r, j] != 0:
+        if ma[r, j] != 0:
             for c in range(j + 1, cs):
-                Ma[r, c] = Ma[i, j] * Ma[r, c] - Ma[i, c] * Ma[r, j]
-            Ma[r, j] = 0
-    return Ma
+                ma[r, c] = ma[i, j] * ma[r, c] - ma[i, c] * ma[r, j]
+            ma[r, j] = 0
+    return ma
 
-def rotateR(L, k):
+def rotate_r(L, k):
     ''' 
     Rotates right by k. L is a row of a matrix or a list.
  
     '''
-    LL = list(L)
-    if LL == []:
+    ll = list(L)
+    if ll == []:
         return []
     for i in range(k):
-        el = LL.pop(len(LL) - 1)
-        LL.insert(0, el)
-    return LL if type(L) is list else Matrix([LL])
+        el = ll.pop(len(ll) - 1)
+        ll.insert(0, el)
+    return ll if type(L) is list else Matrix([ll])
 
-def rotateL(L, k):
+def rotate_l(L, k):
     ''' 
     Rotates left by k. L is a row of a matrix or a list.
 
     '''
-    LL = list(L)
-    if LL == []:
+    ll = list(L)
+    if ll == []:
         return []
     for i in range(k):
-        el = LL.pop(0)
-        LL.insert(len(LL) - 1, el)
-    return LL if type(L) is list else Matrix([LL])
+        el = ll.pop(0)
+        ll.insert(len(ll) - 1, el)
+    return ll if type(L) is list else Matrix([ll])
 
 
 def row2poly(row, deg, x):
@@ -1454,52 +1454,50 @@ def row2poly(row, deg, x):
 
     return Poly(poly, x)        
     
-def createM(degF, degG, row1, row2, colNum):
+def create_ma(deg_f, deg_g, row1, row2, col_num):
     '''
     Creates a ``small'' matrix M to be triangularized.
     
-    degF, degG are the degrees of the divident and of the 
-    divisor polynomials respectively, degG > degF.
+    deg_f, deg_g are the degrees of the divident and of the 
+    divisor polynomials respectively, deg_g > deg_f.
     
     The coefficients of the divident poly are the elements  
     in row2 and those of the divisor poly are the elements 
     in row1.
     
-    colNum indicates the number of columns of the matrix M.
+    col_num indicates the number of columns of the matrix M.
 
     '''
-    if degG - degF >= 1:
+    if deg_g - deg_f >= 1:
         return "ERROR! Reverse input degrees"
-        # print "ERROR! Reverse input degrees"
-        # return
 
-    M = zeros(degF - degG + 2, colNum)
+    m = zeros(deg_f - deg_g + 2, col_num)
     
-    for i in range(degF - degG + 1):
-        M[i, :] = rotateR(row1, i)
-    M[degF - degG + 1, :] = row2
+    for i in range(deg_f - deg_g + 1):
+        m[i, :] = rotate_r(row1, i)
+    m[deg_f - deg_g + 1, :] = row2
 
-    return M
+    return m
 
 
-def findDegree(M, degF):
+def find_degree(M, deg_f):
     '''
     Finds the degree of the poly corresponding 
     to the _last_ row of the ``small'' matrix M.
 
-    degF is the degree of the divident poly.
+    deg_f is the degree of the divident poly.
 
     If row is all 0's returns None.
 
     '''
-    j = degF
+    j = deg_f
     for i in range(0, M.cols):
         if M[M.rows - 1, i] == 0:
             j = j - 1
         else:
             return j if j >= 0 else 0
 
-def subresultants_VanVleck(p, q, x, method = 0):
+def subresultants_van_vleck(p, q, x, method = 0):
     """
     p, q are polynomials in Z[x] (intended) or Q[x].
 
@@ -1508,7 +1506,7 @@ def subresultants_VanVleck(p, q, x, method = 0):
     See references 1 and 2 for Van Vleck's method. 
 
     Use this version if sylvester2 has small dimensions; otherwise,
-    use the second version, subresultants_VanVleck2(p, q, x),
+    use the second version, subresultants_van_vleck_2(p, q, x),
     where sylvester2 is used implicitly.
 
     Sylvester's matrix sylvester1  is also used to compute one 
@@ -1527,129 +1525,129 @@ def subresultants_VanVleck(p, q, x, method = 0):
     ===========
     1. Akritas, A. G.: ``A new method for computing polynomial greatest 
     common divisors and polynomial remainder sequences.''  
-    Numerische Mathematik 52, 119-127, 1988.
+    Numerische MatheMatik 52, 119-127, 1988.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
     by Van Vleck Regarding Sturm Sequences.'' 
     Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
 
     3. Akritas, A. G.:``Three New Methods for Computing Subresultant 
-    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
+    Polynomial remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
     to appear.
 
 
     """
-    # make sure neither p nor q is 0
+    # Make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
     f, g = p, q
 
-    n = degF = degree(f, x)
-    m = degG = degree(g, x)
+    n = deg_f = degree(f, x)
+    m = deg_g = degree(g, x)
 
-    # make sure proper degrees
+    # Make sure proper degrees
     if n == 0 and m == 0:
         return []
     if n > 0 and m == 0:
         return [f, g]
     if n < m:
-        n, m, degF, degG, f, g = m, n, degG, degF, g, f
+        n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
 
-    S1 = sylvester(f, g, x, 1)
-    S2 = sylvester(f, g, x, 2)
+    s1 = sylvester(f, g, x, 1)
+    s2 = sylvester(f, g, x, 2)
 
-    SR_list = [f, g]      # subresultant list
-    colNum = 2 * n
+    sr_list = [f, g]      # subresultant list
+    col_num = 2 * n
                 
     row0 = Poly(f, x, domain = QQ).all_coeffs()
     leng0 = len(row0)
-    for i in range(colNum - leng0):
+    for i in range(col_num - leng0):
         row0.append(0)
     row0 = Matrix([row0])
 
     row1 = Poly(g,x, domain = QQ).all_coeffs()
     leng1 = len(row1)
-    for i in range(colNum - leng1):
+    for i in range(col_num - leng1):
         row1.append(0)
     row1 = Matrix([row1]) 
     
     r = 2    
-    if degF - degG > 1:
-        # Several last rows in S2 will remain unprocessed
+    if deg_f - deg_g > 1:
+        # Several last rows in s2 will remain unprocessed
         # Same thing happens when gcd is of deg > 0        
         r = 1
-        # insert first poly shifted degF - degG - 1 times
-        for i in range(degF - degG - 1):
-            S2 = S2.row_insert(i + 1, rotateR(row0, i + 1) )
+        # insert first poly shifted deg_f - deg_g - 1 times
+        for i in range(deg_f - deg_g - 1):
+            s2 = s2.row_insert(i + 1, rotate_r(row0, i + 1) )
             r = r + 1
-        # insert second poly shifted degF - degG times
-        for i in range(degF - degG):
-            S2 = S2.row_insert(r + i, rotateR(row1, r + i) )
-        r = r + degF - degG
+        # insert second poly shifted deg_f - deg_g times
+        for i in range(deg_f - deg_g):
+            s2 = s2.row_insert(r + i, rotate_r(row1, r + i) )
+        r = r + deg_f - deg_g
 
-    if degF - degG == 0:
-        # the first poly will disappear from S2
+    if deg_f - deg_g == 0:
+        # the first poly will disappear from s2
         r = 0
    
-    while degG > 0:
+    while deg_g > 0:
         
-        M = createM(degF, degG, row1, row0, colNum)
+        M = create_ma(deg_f, deg_g, row1, row0, col_num)
         
-        # pivot as many times as needed
-        for i in range(degF - degG + 1):
+        # pivot as Many times as needed
+        for i in range(deg_f - deg_g + 1):
             M1 = pivot(M, i, i)
             M = M1[:, :]
             
-        d = findDegree(M, degF)
+        d = find_degree(M, deg_f)
         if d == None:
             if method != 0:
-                pprint(S2)
-            return SR_list
-        expDeg = degG - 1
+                pprint(s2)
+            return sr_list
+        exp_deg = deg_g - 1
 
-        # compute subresultant & make poly coeffs subresultants
+        # compute subresultant & Make poly coeffs subresultants
         poly = row2poly(M[M.rows - 1, :], d, x)
-        signValue = correctSign(n, m, S1, expDeg, expDeg - d)
+        sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
         temp2 = LC(poly, x)
-        poly = simplify((poly / LC(poly, x)) * signValue)
+        poly = simplify((poly / LC(poly, x)) * sign_value)
         
-        # update S2
-        for i in range(degG - d):
+        # update s2
+        for i in range(deg_g - d):
             # insert first row of M
-            S2[r + i, :] = rotateR(M[0, :], r + i)
-        r = r + degG - d
+            s2[r + i, :] = rotate_r(M[0, :], r + i)
+        r = r + deg_g - d
         row0 = M[0, :]   
 
-        row1 = rotateL(M[M.rows - 1, :], degF - d)
-        row1 = (row1 / temp2) * signValue
-        for i in range(degG - d):
+        row1 = rotate_l(M[M.rows - 1, :], deg_f - d)
+        row1 = (row1 / temp2) * sign_value
+        for i in range(deg_g - d):
             # insert last row of M
-            S2[r + i, :] = rotateR(row1, r + i)
-        r = r + degG - d
+            s2[r + i, :] = rotate_r(row1, r + i)
+        r = r + deg_g - d
 
         # update degrees 
-        degF, degG = degG, d
+        deg_f, deg_g = deg_g, d
         # append poly with subresultant coeffs
-        SR_list.append(poly)
+        sr_list.append(poly)
                     
     if method != 0:
-        pprint(S2)
-    return SR_list
+        pprint(s2)
+    return sr_list
 
-def subresultants_VanVleck2(p, q, x):
+def subresultants_van_vleck_2(p, q, x):
     """
     p, q are polynomials in Z[x] (intended) or Q[x].
 
     Computes the subresultant prs of p, q by triangularizing, 
-    in Z[x] or in Q[x], all the smaller matrices encountered in the 
+    in Z[x] or in Q[x], all the smaller Matrices encountered in the 
     process of triangularizing sylvester2, Sylvester's matrix of 1853. 
     See references 1 and 2 for Van Vleck's method. 
 
     If the sylvester2 matrix has big dimensions use this version,
     where sylvester2 is used implicitly. If you want to see the final,
     triangularized matrix sylvester2, then use the first version,
-    subresultants_VanVleck(p, q, x).
+    subresultants_van_vleck(p, q, x).
 
     sylvester1, Sylvester's matrix of 1840, is also used to compute 
     one subresultant per remainder; namely, that of the leading 
@@ -1663,81 +1661,81 @@ def subresultants_VanVleck2(p, q, x):
     ===========
     1. Akritas, A. G.: ``A new method for computing polynomial greatest 
     common divisors and polynomial remainder sequences.''  
-    Numerische Mathematik 52, 119-127, 1988.
+    Numerische MatheMatik 52, 119-127, 1988.
 
     2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
     by Van Vleck Regarding Sturm Sequences.'' 
     Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
 
     3. Akritas, A. G.:``Three New Methods for Computing Subresultant 
-    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
+    Polynomial remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
     to appear.
 
     """
-    # make sure neither p nor q is 0
+    # Make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
     f, g = p, q
 
-    n = degF = degree(f, x)
-    m = degG = degree(g, x)
+    n = deg_f = degree(f, x)
+    m = deg_g = degree(g, x)
 
-    # make sure proper degrees
+    # Make sure proper degrees
     if n == 0 and m == 0:
         return []
     if n > 0 and m == 0:
         return [f, g]
     if n < m:
-        n, m, degF, degG, f, g = m, n, degG, degF, g, f
+        n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
 
-    S1 = sylvester(f, g, x, 1)
+    s1 = sylvester(f, g, x, 1)
 
-    SR_list = [f, g]      # subresultant list
+    sr_list = [f, g]      # subresultant list
     # cols of sylvester2
-    colNum = 2 * n
+    col_num = 2 * n
 
     row0 = Poly(f, x, domain = QQ).all_coeffs()
     leng0 = len(row0)
-    for i in range(colNum - leng0):
+    for i in range(col_num - leng0):
         row0.append(0)
     row0 = Matrix([row0])
 
     row1 = Poly(g,x, domain = QQ).all_coeffs()
     leng1 = len(row1)
-    for i in range(colNum - leng1):
+    for i in range(col_num - leng1):
         row1.append(0)
     row1 = Matrix([row1])
     
-    while degG > 0:
+    while deg_g > 0:
         
-        M = createM(degF, degG, row1, row0, colNum)
+        M = create_ma(deg_f, deg_g, row1, row0, col_num)
             
-        for i in range(degF - degG + 1):
+        for i in range(deg_f - deg_g + 1):
             M1 = pivot(M, i, i)
             M = M1[:, :]
             
-        d = findDegree(M, degF)
+        d = find_degree(M, deg_f)
         if d == None:
-            return SR_list
-        expDeg = degG - 1
-        # make entries of S2[r + 1, :] subresultants
+            return sr_list
+        exp_deg = deg_g - 1
+        # Make entries of s2[r + 1, :] subresultants
         poly = row2poly(M[M.rows - 1, :], d, x)
-        signValue = correctSign(n, m, S1, expDeg, expDeg - d)
-        poly = simplify((poly / LC(poly, x)) * signValue)
+        sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
+        poly = simplify((poly / LC(poly, x)) * sign_value)
 
         # append poly with subresultant coeffs
-        SR_list.append(poly)
+        sr_list.append(poly)
                     
         # update degrees and rows
-        degF, degG = degG, d
+        deg_f, deg_g = deg_g, d
         row0 = row1
         row1 = Poly(poly, x, domain = QQ).all_coeffs()
         leng1 = len(row1)
-        for i in range(colNum - leng1):
+        for i in range(col_num - leng1):
             row1.append(0)
         row1 = Matrix([row1])
 
-    return SR_list
+    return sr_list
  
 

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -7,7 +7,7 @@ Created on Mon Dec 28 13:25:02 2015
 
 from __future__ import print_function, division
 
-from sympy import *
+# from sympy import *
 
 def sylvester(f, g, x, method = 1):
     '''
@@ -616,8 +616,6 @@ def euclid_amv(f, g, x):
         f, g = g, f
     if d0 > 0 and d1 == 0:
         return [f, g]
-#    if d0 == 1:
-#        return [f, g]
 
     # initialize
     a0 = f
@@ -1086,8 +1084,6 @@ def subresultants_amv(f, g, x):
         f, g = g, f
     if d0 > 0 and d1 == 0:
         return [f, g]
-#    if d0 == 1:
-#        return [f, g]
 
     # initialize
     a0 = f
@@ -1762,5 +1758,3 @@ def subresultants_vv_2(p, q, x):
         row1 = Matrix([row1])
 
     return sr_list
-
-

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -13,28 +13,28 @@ def sylvester(f, g, x, method = 1):
     '''
       f, g polys in x, m = deg(f) >= deg(g) = n.
 
-      a. If method = 1 (default), computes sylvester1, Sylvester's matrix of 1840 
-          of dimension (m + n) x (m + n). The determinants of properly chosen 
-          submatrices of this matrix (a.k.a. subresultants) can be 
-          used to compute the coefficients of the Euclidean PRS of f, g.     
- 
+      a. If method = 1 (default), computes sylvester1, Sylvester's matrix of 1840
+          of dimension (m + n) x (m + n). The determinants of properly chosen
+          submatrices of this matrix (a.k.a. subresultants) can be
+          used to compute the coefficients of the Euclidean PRS of f, g.
+
       b. If method = 2, computes sylvester2, Sylvester's matrix of 1853
-          of dimension (2*m) x (2*m). The determinants of properly chosen 
-          submatrices of this matrix (a.k.a. ``modified'' subresultants) can be 
+          of dimension (2*m) x (2*m). The determinants of properly chosen
+          submatrices of this matrix (a.k.a. ``modified'' subresultants) can be
           used to compute the coefficients of the Sturmian PRS of f, g.
 
       Applications of these Matrices can be found in the references below.
       Especially, for applications of sylvester2, see the first reference!!
 
-      References: 
+      References:
       ===========
-      1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
-      by Van Vleck Regarding Sturm Sequences. Serdica Journal of Computing, 
-      Vol. 7, No 4, 101–134, 2013. 
+      1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
+      by Van Vleck Regarding Sturm Sequences. Serdica Journal of Computing,
+      Vol. 7, No 4, 101–134, 2013.
 
-      2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-      and Modified Subresultant Polynomial remainder Sequences.'' 
-      Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+      2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+      and Modified Subresultant Polynomial Remainder Sequences.''
+      Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
 
     '''
     # obtain degrees of polys
@@ -56,14 +56,14 @@ def sylvester(f, g, x, method = 1):
     elif m == -oo and n == 0:
         return Matrix([])
 
-    # D:: m >= 1 and n == -oo or m == -oo and n >=1  
-    # (i.e. one poly is of degree >=1 and the other is 0) 
+    # D:: m >= 1 and n == -oo or m == -oo and n >=1
+    # (i.e. one poly is of degree >=1 and the other is 0)
     if m >= 1 and n == -oo:
         return Matrix([0])
     elif m == -oo and n >= 1:
         return Matrix([0])
 
-    fp = Poly(f, x).all_coeffs()  
+    fp = Poly(f, x).all_coeffs()
     gp = Poly(g, x).all_coeffs()
 
     # order lists of poly coeffs according to degree
@@ -107,67 +107,65 @@ def sylvester(f, g, x, method = 1):
             for coeff in gp:
                 if i == 0:
                     M[i+1, j] = coeff
-                else:   
+                else:
                     M[2*i + 1, j] = coeff
                 j = j + 1
             k = k + 1
         return M
 
-def sturm_pg(p,q,x, method=0):
+def sturm_pg(p, q, x, method=0):
     """
     p, q are polynomials in Z[x] or Q[x].
 
-    Computes the (generalized) Sturm sequence of p and q in Z[x] or Q[x]. 
+    Computes the (generalized) Sturm sequence of p and q in Z[x] or Q[x].
     If q = diff(p, x, 1) it is the usual Sturm sequence.
 
-    A. If method == 0, default, the remainder coefficients of the sequence 
-       are (in absolute value) ``modified'' subresultants, which for non-monic 
-       polynomials are greater than the coefficients of the corresponding 
-       subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))). 
-       
-
-    B. If method == 1, the remainder coefficients of the sequence are (in 
-       absolute value) subresultants, which for non-monic polynomials are 
-       smaller than the coefficients of the corresponding ``modified'' 
+    A. If method == 0, default, the remainder coefficients of the sequence
+       are (in absolute value) ``modified'' subresultants, which for non-monic
+       polynomials are greater than the coefficients of the corresponding
        subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
 
-    If the Sturm sequence is complete and method=0 then the coefficients 
-    of the polynomials in the sequence are ``modified'' subresultants. 
+    B. If method == 1, the remainder coefficients of the sequence are (in
+       absolute value) subresultants, which for non-monic polynomials are
+       smaller than the coefficients of the corresponding ``modified''
+       subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
+
+    If the Sturm sequence is complete and method=0 then the coefficients
+    of the polynomials in the sequence are ``modified'' subresultants.
     That is, they are  determinants of appropriately selected submatrices of
-    sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence 
-    coincides with the ``modified'' subresultant prs, of the polynomials 
+    sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence
+    coincides with the ``modified'' subresultant prs, of the polynomials
     p, q.
 
-    If the Sturm sequence is incomplete and method=0 then the signs of the 
-    coefficients of the polynomials in the sequence may differ from the signs 
-    of the coefficients of the corresponding polynomials in the ``modified'' 
-    subresultant prs; however, the absolute values are the same. 
+    If the Sturm sequence is incomplete and method=0 then the signs of the
+    coefficients of the polynomials in the sequence may differ from the signs
+    of the coefficients of the corresponding polynomials in the ``modified''
+    subresultant prs; however, the absolute values are the same.
 
-    To compute the coefficients, no determinant evaluation takes place. Instead, 
-    polynomial divisions in Q[x] are performed, using the function rem(p, q, x);  
-    the coefficients of the remainders computed this way become (``modified'') 
+    To compute the coefficients, no determinant evaluation takes place. Instead,
+    polynomial divisions in Q[x] are performed, using the function rem(p, q, x);
+    the coefficients of the remainders computed this way become (``modified'')
     subresultants with the help of the Pell-Gordon Theorem of 1917.
     See also the function euclid_pg(p, q, x).
-    
+
     References:
-    =========== 
-    1. Pell A. J., R. L. Gordon. The Modified remainders Obtained in Finding
+    ===========
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
     the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial remainder Sequences.'' 
-    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
-     
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
+
     """
-    # Make sure neither p nor q is 0
+    # make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
-    flag = 0
+    # make sure proper degrees
     d0 =  degree(p, x)
     d1 =  degree(q, x)
-    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d1 > d0:
@@ -175,17 +173,18 @@ def sturm_pg(p,q,x, method=0):
         p, q = q, p
     if d0 > 0 and d1 == 0:
         return [p,q]
-        
-    # Make sure LC(p) > 0
+
+    # make sure LC(p) > 0
+    flag = 0
     if  LC(p,x) < 0:
         flag = 1
         p = -p
         q = -q
-        
+
     # initialize
-    lcf = LC(p, x)**(d0 - d1)               # lcf * subr = modified subr 
+    lcf = LC(p, x)**(d0 - d1)               # lcf * subr = modified subr
     a0, a1 = p, q                           # the input polys
-    sturm_seq = [a0, a1]                    # the output list 
+    sturm_seq = [a0, a1]                    # the output list
     del0 = d0 - d1                          # degree difference
     rho1 =  LC(a1, x)                       # leading coeff of a1
     exp_deg = d1 - 1                        # expected degree of a2
@@ -195,35 +194,35 @@ def sturm_pg(p,q,x, method=0):
     deg_diff_new = exp_deg - d2             # expected - actual degree
     del1 = d1 - d2                          # degree difference
 
-    # mul_fac is the factor by which a2 is multiplied to 
+    # mul_fac is the factor by which a2 is multiplied to
     # get integer coefficients
-    mul_fac_old = rho1**(del0 + del1 - deg_diff_new) 
+    mul_fac_old = rho1**(del0 + del1 - deg_diff_new)
 
-    # update variable and append
-    deg_diff_old = deg_diff_new 
+    # append accordingly
     if method == 0:
         sturm_seq.append( simplify(lcf * a2 *  Abs(mul_fac_old)))
     else:
         sturm_seq.append( simplify( a2 *  Abs(mul_fac_old)))
-    # Main loop
-    while d2 > 0:     
+
+    # main loop
+    deg_diff_old = deg_diff_new
+    while d2 > 0:
         a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
         del0 = del1                          # update degree difference
-        exp_deg = d1 - 1                     # new expected degree 
+        exp_deg = d1 - 1                     # new expected degree
         a2 = - rem(a0, a1, domain=QQ)        # new remainder
         rho3 =  LC(a2, x)                    # leading coeff of a2
         d2 =  degree(a2, x)                  # actual degree of a2
         deg_diff_new = exp_deg - d2          # expected - actual degree
         del1 = d1 - d2                       # degree difference
 
-        # take into consideration the power 
+        # take into consideration the power
         # rho1**deg_diff_old that was "left out"
         expo_old = deg_diff_old               # rho1 raised to this power
         expo_new = del0 + del1 - deg_diff_new # rho2 raised to this power
 
-        mul_fac_new = rho2**(expo_new) * rho1**(expo_old) * mul_fac_old 
-
         # update variables and append
+        mul_fac_new = rho2**(expo_new) * rho1**(expo_old) * mul_fac_old
         deg_diff_old, mul_fac_old = deg_diff_new, mul_fac_new
         rho1, rho2 = rho2, rho3
         if method == 0:
@@ -233,8 +232,8 @@ def sturm_pg(p,q,x, method=0):
 
     if flag:          # change the sign of the sequence
         sturm_seq = [-i for i in sturm_seq]
-    
-    # gcd is of degree > 0 ?   
+
+    # gcd is of degree > 0 ?
     m = len(sturm_seq)
     if sturm_seq[m - 1] == nan or sturm_seq[m - 1] == 0:
         sturm_seq.pop(m - 1)
@@ -245,12 +244,12 @@ def sturm_q(p, q, x):
     """
     p, q are polynomials in Z[x] or Q[x];
 
-    Computes the (generalized) Sturm sequence of p and q in Q[x]. 
-    Polynomial divisions in Q[x] are performed, using the function rem(p, q, x).  
+    Computes the (generalized) Sturm sequence of p and q in Q[x].
+    Polynomial divisions in Q[x] are performed, using the function rem(p, q, x).
 
-    The coefficients of the polynomials in the Sturm sequence can be uniquely 
-    determined from the corresponding coefficients of the polynomials found 
-    either in: 
+    The coefficients of the polynomials in the Sturm sequence can be uniquely
+    determined from the corresponding coefficients of the polynomials found
+    either in:
 
         (a) the ``modified'' subresultant prs, (references 1, 2)
 
@@ -259,28 +258,26 @@ def sturm_q(p, q, x):
         (b) the subresultant prs (reference 3).
 
     References:
-    =========== 
-    1. Pell A. J., R. L. Gordon. The Modified remainders Obtained in Finding
+    ===========
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
     the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
 
-    2 Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial remainder Sequences.'' 
-    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+    2 Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
 
-    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
     """
-    # Make sure neither p nor q is 0
+    # make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
-    flag = 0
+    # make sure proper degrees
     d0 =  degree(p, x)
     d1 =  degree(q, x)
-
-    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d1 > d0:
@@ -288,8 +285,9 @@ def sturm_q(p, q, x):
         p, q = q, p
     if d0 > 0 and d1 == 0:
         return [p,q]
-        
-    # Make sure LC(p) > 0
+
+    # make sure LC(p) > 0
+    flag = 0
     if  LC(p,x) < 0:
         flag = 1
         p = -p
@@ -297,23 +295,22 @@ def sturm_q(p, q, x):
 
     # initialize
     a0, a1 = p, q                           # the input polys
-    sturm_seq = [a0, a1]                     # the output list 
+    sturm_seq = [a0, a1]                    # the output list
     a2 = -rem(a0, a1, domain=QQ)            # first remainder
     d2 =  degree(a2, x)                     # degree of a2
-    sturm_seq.append( a2 ) 
+    sturm_seq.append( a2 )
 
-
-    # Main loop
-    while d2 > 0:     
+    # main loop
+    while d2 > 0:
         a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
         a2 = -rem(a0, a1, domain=QQ)         # new remainder
         d2 =  degree(a2, x)                  # actual degree of a2
-        sturm_seq.append( a2 ) 
-    
+        sturm_seq.append( a2 )
+
     if flag:          # change the sign of the sequence
         sturm_seq = [-i for i in sturm_seq]
 
-    # gcd is of degree > 0 ?   
+    # gcd is of degree > 0 ?
     m = len(sturm_seq)
     if sturm_seq[m - 1] == nan or sturm_seq[m - 1] == 0:
         sturm_seq.pop(m - 1)
@@ -324,56 +321,56 @@ def sturm_amv(p, q, x, method=0):
     """
     p, q are polynomials in Z[x] or Q[x].
 
-    Computes the (generalized) Sturm sequence of p and q in Z[x] or Q[x]. 
+    Computes the (generalized) Sturm sequence of p and q in Z[x] or Q[x].
     If q = diff(p, x, 1) it is the usual Sturm sequence.
 
-    A. If method == 0, default, the remainder coefficients of the 
-       sequence are (in absolute value) ``modified'' subresultants, which 
-       for non-monic polynomials are greater than the coefficients of the 
-       corresponding subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))). 
+    A. If method == 0, default, the remainder coefficients of the
+       sequence are (in absolute value) ``modified'' subresultants, which
+       for non-monic polynomials are greater than the coefficients of the
+       corresponding subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
 
-    B. If method == 1, the remainder coefficients of the sequence are (in 
-       absolute value) subresultants, which for non-monic polynomials are 
+    B. If method == 1, the remainder coefficients of the sequence are (in
+       absolute value) subresultants, which for non-monic polynomials are
        smaller than the coefficients of the corresponding ``modified''
        subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
 
-    If the Sturm sequence is complete and method=0 then the coefficients 
-    of the polynomials in the sequence are ``modified'' subresultants. 
+    If the Sturm sequence is complete and method=0 then the coefficients
+    of the polynomials in the sequence are ``modified'' subresultants.
     That is, they are  determinants of appropriately selected submatrices of
-    sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence 
-    coincides with the ``modified'' subresultant prs, of the polynomials 
+    sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence
+    coincides with the ``modified'' subresultant prs, of the polynomials
     p, q.
 
-    If the Sturm sequence is incomplete and method=0 then the signs of the 
-    coefficients of the polynomials in the sequence may differ from the signs 
-    of the coefficients of the corresponding polynomials in the ``modified'' 
-    subresultant prs; however, the absolute values are the same. 
+    If the Sturm sequence is incomplete and method=0 then the signs of the
+    coefficients of the polynomials in the sequence may differ from the signs
+    of the coefficients of the corresponding polynomials in the ``modified''
+    subresultant prs; however, the absolute values are the same.
 
-    To compute the coefficients, no determinant evaluation takes place.    
-    Instead, we first compute the euclidean sequence  of p and q using 
-    euclid_amv(p, q, x) and then: (a) change the signs of the remainders in the 
-    Euclidean sequence according to the pattern "-, -, +, +, -, -, +, +,..." 
-    (see LemMa 1 in the 1st reference or Theorem 3 in the 2nd reference)
-    and (b) if method=0, assuming deg(p) > deg(q), we multiply the remainder 
-    coefficients of the Euclidean sequence times the factor 
-    Abs(LC(p)**( deg(p)- deg(q))) to Make them modified subresultants.
+    To compute the coefficients, no determinant evaluation takes place.
+    Instead, we first compute the euclidean sequence  of p and q using
+    euclid_amv(p, q, x) and then: (a) change the signs of the remainders in the
+    Euclidean sequence according to the pattern "-, -, +, +, -, -, +, +,..."
+    (see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference)
+    and (b) if method=0, assuming deg(p) > deg(q), we multiply the remainder
+    coefficients of the Euclidean sequence times the factor
+    Abs(LC(p)**( deg(p)- deg(q))) to make them modified subresultants.
     See also the function sturm_pg(p, q, x).
 
     References:
     ===========
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the remainders 
-    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica 
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica
     Journal of Computing, to appear.
 
-    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
     Submitted for publication.
-   
+
     """
-    # compute the euclidean sequence 
+    # compute the euclidean sequence
     prs = euclid_amv(p, q, x)
 
     # defensive
@@ -381,22 +378,23 @@ def sturm_amv(p, q, x, method=0):
         return prs
 
     # the coefficients in prs are subresultants and hence are smaller
-    # than the corresponding subresultants by the factor 
+    # than the corresponding subresultants by the factor
     # |LC(prs[0])**( deg(prs[0]) - deg(prs[1]))|; Theorem 2, 2nd reference.
     lcf = Abs( LC(prs[0])**( degree(prs[0]) - degree(prs[1]) ) )
-    
+
     # the signs of the first two polys in the sequence stay the same
     sturm_seq = [prs[0], prs[1]]
+
+    # change the signs according to "-, -, +, +, -, -, +, +,..."
+    # and multiply times lcf if needed
     flag = 0
     m = len(prs)
     i = 2
-    # change the signs according to "-, -, +, +, -, -, +, +,..."
-    # and multiply times lcf if needed
     while i <= m-1:
         if  flag == 0:
             sturm_seq.append( - prs[i] )
             i = i + 1
-            if i == m: 
+            if i == m:
                 break
             sturm_seq.append( - prs[i] )
             i = i + 1
@@ -404,13 +402,13 @@ def sturm_amv(p, q, x, method=0):
         elif flag == 1:
             sturm_seq.append( prs[i] )
             i = i + 1
-            if i == m: 
+            if i == m:
                 break
             sturm_seq.append( prs[i] )
             i = i + 1
             flag = 0
 
-    # subresultants or modified subresultants?  
+    # subresultants or modified subresultants?
     if method == 0 and lcf > 1:
         aux_seq = [sturm_seq[0], sturm_seq[1]]
         for i in range(2, m):
@@ -423,45 +421,44 @@ def euclid_pg(p, q, x):
     """
     p, q are polynomials in Z[x] or Q[x];
 
-    Computes the Euclidean sequence of p and q in Z[x] or Q[x]. 
- 
-    If the Euclidean sequence is complete the coefficients of the polynomials 
-    in the sequence are subresultants. That is, they are  determinants of 
-    appropriately selected submatrices of sylvester1, Sylvester's matrix of 1840. 
-    In this case the Euclidean sequence coincides with the subresultant prs 
+    Computes the Euclidean sequence of p and q in Z[x] or Q[x].
+
+    If the Euclidean sequence is complete the coefficients of the polynomials
+    in the sequence are subresultants. That is, they are  determinants of
+    appropriately selected submatrices of sylvester1, Sylvester's matrix of 1840.
+    In this case the Euclidean sequence coincides with the subresultant prs
     of the polynomials p, q.
 
-    If the Euclidean sequence is incomplete the signs of the coefficients of the 
+    If the Euclidean sequence is incomplete the signs of the coefficients of the
     polynomials in the sequence may differ from the signs of the coefficients of
-    the corresponding polynomials in the subresultant prs; however, the absolute 
-    values are the same. 
+    the corresponding polynomials in the subresultant prs; however, the absolute
+    values are the same.
 
-    To compute the Euclidean sequence, no determinant evaluation takes place. 
-    We first compute the (generalized) Sturm sequence  of p and q using 
-    sturm_pg(p, q, x, 1), in which case the coefficients are (in absolute value) 
-    equal to subresultants. Then we change the signs of the remainders in the 
+    To compute the Euclidean sequence, no determinant evaluation takes place.
+    We first compute the (generalized) Sturm sequence  of p and q using
+    sturm_pg(p, q, x, 1), in which case the coefficients are (in absolute value)
+    equal to subresultants. Then we change the signs of the remainders in the
     Sturm sequence according to the pattern "-, -, +, +, -, -, +, +,..." ;
-    see LemMa 1 in the 1st reference or Theorem 3 in the 2nd reference as well as
+    see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference as well as
     the function sturm_pg(p, q, x).
-    
+
     References:
     ===========
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the remainders 
-    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica 
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica
     Journal of Computing, to appear.
 
-    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
     Submitted for publication.
-   
+
     """
-    
-    # compute the sturmian sequence using the Pell-Gordon theorem
+    # compute the sturmian sequence using the Pell-Gordon (or AMV) theorem
     # with the coefficients in the prs being (in absolute value) subresultants
-    prs = sturm_pg(p, q, x, 1)  ## or prs = sturm_amv(p, q, x, 1)
+    prs = sturm_pg(p, q, x, 1)  ## any other method would do
 
     # defensive
     if prs == [] or len(prs) == 2:
@@ -469,16 +466,16 @@ def euclid_pg(p, q, x):
 
     # the signs of the first two polys in the sequence stay the same
     euclid_seq = [prs[0], prs[1]]
+
+    # change the signs according to "-, -, +, +, -, -, +, +,..."
     flag = 0
     m = len(prs)
     i = 2
-
-    # change the signs according to "-, -, +, +, -, -, +, +,..."
     while i <= m-1:
         if  flag == 0:
             euclid_seq.append(- prs[i] )
             i = i + 1
-            if i == m: 
+            if i == m:
                 break
             euclid_seq.append(- prs[i] )
             i = i + 1
@@ -486,7 +483,7 @@ def euclid_pg(p, q, x):
         elif flag == 1:
             euclid_seq.append(prs[i] )
             i = i + 1
-            if i == m: 
+            if i == m:
                 break
             euclid_seq.append(prs[i] )
             i = i + 1
@@ -499,41 +496,40 @@ def euclid_q(p, q, x):
     p, q are polynomials in Z[x] or Q[x];
 
     Computes the Euclidean sequence of p and q in Q[x].
-    Polynomial divisions in Q[x] are performed, using the function rem(p, q, x).  
+    Polynomial divisions in Q[x] are performed, using the function rem(p, q, x).
 
-    The coefficients of the polynomials in the Euclidean sequence can be uniquely 
-    determined from the corresponding coefficients of the polynomials found 
-    either in: 
+    The coefficients of the polynomials in the Euclidean sequence can be uniquely
+    determined from the corresponding coefficients of the polynomials found
+    either in:
 
         (a) the ``modified'' subresultant polynomial remainder sequence,
-    (references 1, 2) 
+    (references 1, 2)
 
     or in
 
         (b) the subresultant polynomial remainder sequence (references 3).
 
     References:
-    =========== 
-    1. Pell A. J., R. L. Gordon. The Modified remainders Obtained in Finding
+    ===========
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
     the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial remainder Sequences.'' 
-    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
 
-    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
     """
-    # Make sure neither p nor q is 0
+    # make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
-    flag = 0
+    # make sure proper degrees
     d0 =  degree(p, x)
     d1 =  degree(q, x)
-    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d1 > d0:
@@ -541,8 +537,9 @@ def euclid_q(p, q, x):
         p, q = q, p
     if d0 > 0 and d1 == 0:
         return [p,q]
-        
-    # Make sure LC(p) > 0
+
+    # make sure LC(p) > 0
+    flag = 0
     if  LC(p,x) < 0:
         flag = 1
         p = -p
@@ -550,23 +547,22 @@ def euclid_q(p, q, x):
 
     # initialize
     a0, a1 = p, q                           # the input polys
-    euclid_seq = [a0, a1]                   # the output list 
+    euclid_seq = [a0, a1]                   # the output list
     a2 = rem(a0, a1, domain=QQ)             # first remainder
     d2 =  degree(a2, x)                     # degree of a2
-    euclid_seq.append( a2 ) 
+    euclid_seq.append( a2 )
 
-    # Main loop
-    while d2 > 0:     
+    # main loop
+    while d2 > 0:
         a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
         a2 = rem(a0, a1, domain=QQ)          # new remainder
         d2 =  degree(a2, x)                  # actual degree of a2
-        euclid_seq.append( a2 ) 
+        euclid_seq.append( a2 )
 
-    
     if flag:          # change the sign of the sequence
         euclid_seq = [-i for i in euclid_seq]
 
-    # gcd is of degree > 0 ?   
+    # gcd is of degree > 0 ?
     m = len(euclid_seq)
     if euclid_seq[m - 1] == nan or euclid_seq[m - 1] == 0:
         euclid_seq.pop(m - 1)
@@ -577,43 +573,42 @@ def euclid_amv(f, g, x):
     """
     f, g are polynomials in Z[x] or Q[x].
 
-    Computes the Euclidean sequence of p and q in Z[x] or Q[x]. 
- 
-    If the Euclidean sequence is complete the coefficients of the polynomials 
-    in the sequence are subresultants. That is, they are  determinants of 
-    appropriately selected submatrices of sylvester1, Sylvester's matrix of 1840. 
-    In this case the Euclidean sequence coincides with the subresultant prs, 
+    Computes the Euclidean sequence of p and q in Z[x] or Q[x].
+
+    If the Euclidean sequence is complete the coefficients of the polynomials
+    in the sequence are subresultants. That is, they are  determinants of
+    appropriately selected submatrices of sylvester1, Sylvester's matrix of 1840.
+    In this case the Euclidean sequence coincides with the subresultant prs,
     of the polynomials p, q.
 
-    If the Euclidean sequence is incomplete the signs of the coefficients of the 
+    If the Euclidean sequence is incomplete the signs of the coefficients of the
     polynomials in the sequence may differ from the signs of the coefficients of
-    the corresponding polynomials in the subresultant prs; however, the absolute 
-    values are the same. 
+    the corresponding polynomials in the subresultant prs; however, the absolute
+    values are the same.
 
-    To compute the coefficients, no determinant evaluation takes place. 
-    Instead, polynomial divisions in Z[x] or Q[x] are performed, using 
-    the function rem_z(f, g, x);  the coefficients of the remainders 
-    computed this way become subresultants with the help of the 
+    To compute the coefficients, no determinant evaluation takes place.
+    Instead, polynomial divisions in Z[x] or Q[x] are performed, using
+    the function rem_z(f, g, x);  the coefficients of the remainders
+    computed this way become subresultants with the help of the
     Collins-Brown-Traub formula for coefficient reduction.
-   
+
     References:
-    ===========  
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
     Submitted for publication.
-    
+
     """
-    # Make sure neither f nor g is 0
+    # make sure neither f nor g is 0
     if f == 0 or g == 0:
         return [f, g]
 
+    # make sure proper degrees
     d0 =  degree(f, x)
     d1 =  degree(g, x)
-
-        # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d0 > 0 and d1 == 0:
@@ -624,20 +619,19 @@ def euclid_amv(f, g, x):
     if d0 == 1:
         return [f, g]
 
+    # initialize
     a0 = f
     a1 = g
-
     euclid_seq = [a0, a1]
     deg_dif_p1, c = degree(a0) - degree(a1) + 1, -1
-    
-    i = 0                                          # counter for remainders 
 
-        # compute the first polynomial of the prs
-    i += 1
+    # compute the first polynomial of the prs
+    i = 1
     a2 = rem_z(a0, a1, x) / Abs( (-1)**deg_dif_p1 )     # first remainder
     euclid_seq.append( a2 )
     d2 =  degree(a2, x)                              # actual degree of a2
 
+    # main loop
     while d2 >= 1:
         a0, a1, d0, d1 = a1, a2, d1, d2       # update polys and degrees
         i += 1
@@ -647,64 +641,61 @@ def euclid_amv(f, g, x):
         a2 = rem_z(a0, a1, x) / Abs( ((c**(deg_dif_p1 - 1)) * sigma0) )
         euclid_seq.append( a2 )
         d2 =  degree(a2, x)                   # actual degree of a2
-        
-    # gcd is of degree > 0 ? 
-    m = len(euclid_seq)  
+
+    # gcd is of degree > 0 ?
+    m = len(euclid_seq)
     if euclid_seq[m - 1] == nan or euclid_seq[m - 1] == 0:
         euclid_seq.pop(m - 1)
-        
-    return euclid_seq
 
+    return euclid_seq
 
 def modified_subresultants_pg(p,q,x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
-    Computes the ``modified'' subresultant prs of p and q in Z[x] or Q[x]; 
-    the coefficients of the polynomials in the sequence are 
-    ``modified'' subresultants. That is, they are  determinants of appropriately 
-    selected submatrices of sylvester2, Sylvester's matrix of 1853. 
+    Computes the ``modified'' subresultant prs of p and q in Z[x] or Q[x];
+    the coefficients of the polynomials in the sequence are
+    ``modified'' subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester2, Sylvester's matrix of 1853.
 
-    To compute the coefficients, no determinant evaluation takes place. Instead,   
-    polynomial divisions in Q[x] are performed, using the function rem(p, q, x);  
-    the coefficients of the remainders computed this way become ``modified'' 
+    To compute the coefficients, no determinant evaluation takes place. Instead,
+    polynomial divisions in Q[x] are performed, using the function rem(p, q, x);
+    the coefficients of the remainders computed this way become ``modified''
     subresultants with the help of the Pell-Gordon Theorem of 1917.
-   
-    If the ``modified'' subresultant prs is complete, then it coincides with the 
+
+    If the ``modified'' subresultant prs is complete, then it coincides with the
     (generalized) Sturm sequence of the polynomials p, q.
 
     References:
-    ===========  
-    1. Pell A. J., R. L. Gordon. The Modified remainders Obtained in Finding
+    ===========
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
     the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial remainder Sequences.'' 
-    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
-    
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
+
     """
-    # Make sure neither p nor q is 0
+    # make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
-    k =  var('k')                              # index in summation formula
-    u_list = []                                # of elements (-1)**u_i 
-    subres_l = [p, q]                           # mod. subr. prs output list    
+    # make sure proper degrees
     d0 =  degree(p,x)
     d1 =  degree(q,x)
-
-    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d1 > d0:
         d0, d1 = d1, d0
         p, q = q, p
-        subres_l = [p, q]                       # mod. subr. prs output list    
     if d0 > 0 and d1 == 0:
         return [p,q]
-                
+
     # initialize
+    k =  var('k')                               # index in summation formula
+    u_list = []                                 # of elements (-1)**u_i
+    subres_l = [p, q]                           # mod. subr. prs output list
     a0, a1 = p, q                               # the input polys
     del0 = d0 - d1                              # degree difference
     degdif = del0                               # save it
@@ -719,17 +710,18 @@ def modified_subresultants_pg(p,q,x):
     u_list.append(u)                          # of u values
     v = sum(p_list)                           # v value
 
-    exp_deg = d1 - 1                           # expected degree of a2
+    # first remainder
+    exp_deg = d1 - 1                          # expected degree of a2
     a2 = - rem(a0, a1, domain=QQ)             # first remainder
     rho2 =  LC(a2, x)                         # leading coeff of a2
     d2 =  degree(a2, x)                       # actual degree of a2
-    deg_diff_new = exp_deg - d2                 # expected - actual degree
+    deg_diff_new = exp_deg - d2               # expected - actual degree
     del1 = d1 - d2                            # degree difference
 
-    # mul_fac is the factor by which a2 is multiplied to 
+    # mul_fac is the factor by which a2 is multiplied to
     # get integer coefficients
-    mul_fac_old = rho1**(del0 + del1 - deg_diff_new) 
-        
+    mul_fac_old = rho1**(del0 + del1 - deg_diff_new)
+
     # update Pell-Gordon variables
     p_list.append(1 + deg_diff_new)              # deg_diff_new is 0 for complete seq
 
@@ -749,53 +741,52 @@ def modified_subresultants_pg(p,q,x):
         den = 1
         for k in range(len(rho_list)-1):
             den *= rho_list[k]**(p_list[k] + p_list[k + 1])
-        den = den * rho_list_minus_1 
+        den = den * rho_list_minus_1
         expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
-        den = den * rho_list[len(rho_list) - 1]**expo 
-    
+        den = den * rho_list[len(rho_list) - 1]**expo
+
     # the sign of the determinant depends on sg(num / den)
     if  sign(num / den) > 0:
-        subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) ) 
+        subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
     else:
-        subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )      
-  
+        subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+
     # update Pell-Gordon variables
     k =  var('k')
     rho_list.append( sign(rho2))
-    u =  summation(k, (k, 1, p_list[len(p_list) - 1]))   
-    u_list.append(u)   
+    u =  summation(k, (k, 1, p_list[len(p_list) - 1]))
+    u_list.append(u)
     v = sum(p_list)
-    
     deg_diff_old=deg_diff_new
-    
-    # Main loop
-    while d2 > 0:     
+
+    # main loop
+    while d2 > 0:
         a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
         del0 = del1                          # update degree difference
-        exp_deg = d1 - 1                      # new expected degree 
+        exp_deg = d1 - 1                     # new expected degree
         a2 = - rem(a0, a1, domain=QQ)        # new remainder
         rho3 =  LC(a2, x)                    # leading coeff of a2
         d2 =  degree(a2, x)                  # actual degree of a2
-        deg_diff_new = exp_deg - d2            # expected - actual degree
+        deg_diff_new = exp_deg - d2          # expected - actual degree
         del1 = d1 - d2                       # degree difference
 
-        # take into consideration the power 
+        # take into consideration the power
         # rho1**deg_diff_old that was "left out"
         expo_old = deg_diff_old               # rho1 raised to this power
         expo_new = del0 + del1 - deg_diff_new # rho2 raised to this power
 
-        mul_fac_new = rho2**(expo_new) * rho1**(expo_old) * mul_fac_old 
+        mul_fac_new = rho2**(expo_new) * rho1**(expo_old) * mul_fac_old
 
-        # update variables and append
+        # update variables
         deg_diff_old, mul_fac_old = deg_diff_new, mul_fac_new
         rho1, rho2 = rho2, rho3
-        
+
         # update Pell-Gordon variables
         p_list.append(1 + deg_diff_new)       # deg_diff_new is 0 for complete seq
-            
+
         # apply Pell-Gordon formula (7) in second reference
-        num = 1                              # numerator 
-        for k in range(len(u_list)): 
+        num = 1                              # numerator
+        for k in range(len(u_list)):
             num *= (-1)**u_list[k]
         num = num * (-1)**v
 
@@ -809,68 +800,68 @@ def modified_subresultants_pg(p,q,x):
             den = 1
             for k in range(len(rho_list)-1):
                 den *= rho_list[k]**(p_list[k] + p_list[k + 1])
-            den = den * rho_list_minus_1 
+            den = den * rho_list_minus_1
             expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
-            den = den * rho_list[len(rho_list) - 1]**expo 
+            den = den * rho_list[len(rho_list) - 1]**expo
 
-                    
-        # the sign of the determinant depends on sg(num / den)          
+        # the sign of the determinant depends on sg(num / den)
         if  sign(num / den) > 0:
-            subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) ) 
+            subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
         else:
             subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
-            
+
         # update Pell-Gordon variables
         k =  var('k')
         rho_list.append( sign(rho2))
-        u =  summation(k, (k, 1, p_list[len(p_list) - 1]))   
-        u_list.append(u)   
+        u =  summation(k, (k, 1, p_list[len(p_list) - 1]))
+        u_list.append(u)
         v = sum(p_list)
 
-    # gcd is of degree > 0 ?   
+    # gcd is of degree > 0 ?
     m = len(subres_l)
     if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
         subres_l.pop(m - 1)
 
-    return  subres_l 
+    return  subres_l
 
 def subresultants_pg(p,q,x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
-    Computes the subresultant prs of p and q in Z[x] or Q[x], from 
+    Computes the subresultant prs of p and q in Z[x] or Q[x], from
     the modified subresultant prs of p and q.
-    The coefficients of the polynomials in the two sequences differ only 
-    in sign and a power of the absolute value of the leading coefficient 
-    of p, as stated in Theorem 2 of the reference.
 
-    The coefficients of the polynomials in the output sequence are 
-    subresultants. That is, they are  determinants of appropriately 
-    selected submatrices of sylvester1, Sylvester's matrix of 1840. 
-  
-    If the subresultant prs is complete, then it coincides with the 
+    The coefficients of the polynomials in these two ßsequences differ only
+    in sign and the factor Abs(LC(p)**( deg(p)- deg(q))) as stated in
+    Theorem 2 of the reference.
+
+    The coefficients of the polynomials in the output sequence are
+    subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester1, Sylvester's matrix of 1840.
+
+    If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
     References:
     ===========
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the remainders 
-    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
     Serdica Journal of Computing, to appear.
-    
+
     """
-    # compute the modified subresultant prs 
-    lst = modified_subresultants_pg(p,q,x)  ## or lst = modified_subresultants_amv(p,q,x)
+    # compute the modified subresultant prs
+    lst = modified_subresultants_pg(p,q,x)  ## any other method would do
 
     # defensive
     if lst == [] or len(lst) == 2:
-        return lst
+        return let
 
-    # the coefficients in lst are modified subresultants and, hence, are 
-    # greater than those of the corresponding subresultants by the factor 
+    # the coefficients in lst are modified subresultants and, hence, are
+    # greater than those of the corresponding subresultants by the factor
     # |LC(lst[0])**( deg(lst[0]) - deg(lst[1]))|; see Theorem 2 in reference.
     lcf = Abs( LC(lst[0])**( degree(lst[0]) - degree(lst[1]) ) )
 
-    # Initialize the subresultant prs list 
+    # Initialize the subresultant prs list
     subr_seq = [lst[0], lst[1]]
 
     # compute the degree sequences m_i and j_i of Theorem 2 in reference.
@@ -879,7 +870,7 @@ def subresultants_pg(p,q,x):
     deg_seq_s = deg_seq[1:-1]
     m_seq = [m-1 for m in deg_seq_s]
     j_seq = [deg - m for m in m_seq]
-    
+
     # compute the AMV factors of Theorem 2 in reference.
     fact = [(-1)**( j*(j-1)/S(2) ) for j in j_seq]
 
@@ -894,44 +885,44 @@ def subresultants_pg(p,q,x):
             subr_seq.append(-lst_s[k] / lcf)
         else:
             subr_seq.append(lst_s[k] / lcf)
+
     return subr_seq
 
 def subresultants_amv_q(p,q,x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
-    Computes the subresultant prs of p and q in Q[x]; 
-    the coefficients of the polynomials in the sequence are 
-    subresultants. That is, they are  determinants of appropriately 
-    selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+    Computes the subresultant prs of p and q in Q[x];
+    the coefficients of the polynomials in the sequence are
+    subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester1, Sylvester's matrix of 1840.
 
-    To compute the coefficients, no determinant evaluation takes place. 
+    To compute the coefficients, no determinant evaluation takes place.
     Instead, polynomial divisions in Q[x] are performed, using the
-    function rem(p, q, x);  the coefficients of the remainders 
-    computed this way become subresultants with the help of the 
+    function rem(p, q, x);  the coefficients of the remainders
+    computed this way become subresultants with the help of the
     Akritas-Malaschonok-Vigklas Theorem of 2015.
-   
-    If the subresultant prs is complete, then it coincides with the 
+
+    If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
     References:
-    ===========  
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
     Submitted for publication.
-    
+
     """
-    # Make sure neither p nor q is 0
+    # make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
+    # make sure proper degrees
     d0 =  degree(p, x)
     d1 =  degree(q, x)
-
-    # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d0 > 0 and d1 == 0:
@@ -939,78 +930,73 @@ def subresultants_amv_q(p,q,x):
     if d1 > d0:
         d0, d1 = d1, d0
         p, q = q, p
-        
-        
+
     # initialize
     i, s = 0, 0                              # counters for remainders & odd elements
     p_odd_index_sum = 0                      # contains the sum of p_1, p_3, etc
-    subres_l = [p, q]                         # subresultant prs output list
+    subres_l = [p, q]                        # subresultant prs output list
     a0, a1 = p, q                            # the input polys
     sigma1 =  LC(a1, x)                      # leading coeff of a1
     p0 = d0 - d1                             # degree difference
     if p0 % 2 == 1:
-        s += 1       
-    phi = floor( (s + 1) / 2 )     
+        s += 1
+    phi = floor( (s + 1) / 2 )
     mul_fac = 1
     d2 = d1
 
-    # Main loop
-    while d2 > 0:   
+    # main loop
+    while d2 > 0:
         i += 1
         a2 = rem(a0, a1, domain= QQ)          # new remainder
         if i == 1:
-            sigma2 =  LC(a2, x)                       
+            sigma2 =  LC(a2, x)
         else:
-            sigma3 =  LC(a2, x)                       
+            sigma3 =  LC(a2, x)
             sigma1, sigma2 = sigma2, sigma3
-
-            
-        d2 =  degree(a2, x)                         
-        p1 = d1 - d2                                       
+        d2 =  degree(a2, x)
+        p1 = d1 - d2
         psi = i + phi + p_odd_index_sum
 
         # new mul_fac
         mul_fac = sigma1**(p0 + 1) * mul_fac
-            
+
         ## compute the sign of the first fraction in formula (9) of the paper
-        # numerator 
-        num = (-1)**psi     
-        # denominator 
+        # numerator
+        num = (-1)**psi
+        # denominator
         den = sign(mul_fac)
-         
-        # the sign of the determinant depends on sign( num / den ) != 0          
+
+        # the sign of the determinant depends on sign( num / den ) != 0
         if  sign(num / den) > 0:
             subres_l.append( simplify(expand(a2* Abs(mul_fac))))
         else:
             subres_l.append(- simplify(expand(a2* Abs(mul_fac))))
-        
 
         ## bring into mul_fac the missing power of sigma if there was a degree gap
-        if p1 - 1 > 0:       
+        if p1 - 1 > 0:
             mul_fac = mul_fac * sigma1**(p1 - 1)
 
        # update AMV variables
-        a0, a1, d0, d1 = a1, a2, d1, d2       
-        p0 = p1                                           
+        a0, a1, d0, d1 = a1, a2, d1, d2
+        p0 = p1
         if p0 % 2 ==1:
-            s += 1        
+            s += 1
         phi = floor( (s + 1) / 2 )
-        if i%2 == 1: 
+        if i%2 == 1:
             p_odd_index_sum += p0             # p_i has odd index
-       
-    # gcd is of degree > 0 ?   
+
+    # gcd is of degree > 0 ?
     m = len(subres_l)
     if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
         subres_l.pop(m - 1)
 
-    return  subres_l 
-
+    return  subres_l
 
 def compute_sign(base, expo):
     '''
     base != 0 and expo >= 0 are integers;
-    
-    returns the sign of base**expo without 
+
+    returns the sign of base**expo without
     evaluating the power itself!
     '''
     sb = sign(base)
@@ -1024,77 +1010,75 @@ def compute_sign(base, expo):
 
 def rem_z(p, q, x):
     '''
-    Intended Mainly for p, q polynomials in Z[x] so that,
+    Intended mainly for p, q polynomials in Z[x] so that,
     on dividing p by q, the remainder will also be in Z[x]. (However,
-    it also works fine for polynomials in Q[x].) 
+    it also works fine for polynomials in Q[x].)
 
-    It premultiplies p by the _absolute_ value of the leading coefficient 
-    of q, raised to the power deg(p) - deg(q) + 1 and then performs 
-    polynomial division in Q[x], using the function rem(p, q, x). 
+    It premultiplies p by the _absolute_ value of the leading coefficient
+    of q, raised to the power deg(p) - deg(q) + 1 and then performs
+    polynomial division in Q[x], using the function rem(p, q, x).
 
-    By contrast the function prem(p, q, x) does _not_ use the absolute 
-    value of the leading coefficient of q. 
-    This results not only in ``messing up the signs'' of the Euclidean and 
-    Sturmian prs's as mentioned in the second reference, 
-    but also in violation of the Main results of the first and third 
-    references --- Theorem 4 and Theorem 1 respectively. Theorems 4 and 1 
-    establish a one-to-one correspondence between the Euclidean and the 
-    Sturmian prs of p, q, on one hand, and the subresultant prs of p, q, 
+    By contrast the function prem(p, q, x) does _not_ use the absolute
+    value of the leading coefficient of q.
+    This results not only in ``messing up the signs'' of the Euclidean and
+    Sturmian prs's as mentioned in the second reference,
+    but also in violation of the main results of the first and third
+    references --- Theorem 4 and Theorem 1 respectively. Theorems 4 and 1
+    establish a one-to-one correspondence between the Euclidean and the
+    Sturmian prs of p, q, on one hand, and the subresultant prs of p, q,
     on the other.
 
     References:
     ===========
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the remainders 
-    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
     Serdica Journal of Computing, to appear.
 
     2. http://planetMath.org/sturmstheorem
 
-    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result on 
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result on
     the Theory of Subresultants.'' Submitted for publication.
 
     '''
     delta = (degree(p, x) - degree(q, x) + 1)
-    return rem(Abs(LC(q, x))**delta  *  p, q, x) 
+    return rem(Abs(LC(q, x))**delta  *  p, q, x)
 
- 
 def subresultants_amv(f, g, x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
-    Computes the subresultant prs of p and q in Z[x] or Q[x]; 
-    the coefficients of the polynomials in the sequence are 
-    subresultants. That is, they are  determinants of appropriately 
-    selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+    Computes the subresultant prs of p and q in Z[x] or Q[x];
+    the coefficients of the polynomials in the sequence are
+    subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester1, Sylvester's matrix of 1840.
 
-    To compute the coefficients, no determinant evaluation takes place. 
-    Instead, polynomial divisions in Z[x] or Q[x] are performed, using 
-    the function rem_z(p, q, x);  the coefficients of the remainders 
-    computed this way become subresultants with the help of the 
+    To compute the coefficients, no determinant evaluation takes place.
+    Instead, polynomial divisions in Z[x] or Q[x] are performed, using
+    the function rem_z(p, q, x);  the coefficients of the remainders
+    computed this way become subresultants with the help of the
     Akritas-Malaschonok-Vigklas Theorem of 2015 and the Collins-Brown-
     Traub formula for coefficient reduction.
-   
-    If the subresultant prs is complete, then it coincides with the 
+
+    If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
     References:
-    ===========  
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
-    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial
+    remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''
     Submitted for publication.
-    
+
     """
-    # Make sure neither f nor g is 0
+    # make sure neither f nor g is 0
     if f == 0 or g == 0:
         return [f, g]
 
+    # make sure proper degrees
     d0 =  degree(f, x)
     d1 =  degree(g, x)
-
-        # Make sure proper degrees  
     if d0 == 0 and d1 == 0:
         return []
     if d0 > 0 and d1 == 0:
@@ -1105,55 +1089,61 @@ def subresultants_amv(f, g, x):
     if d0 == 1:
         return [f, g]
 
+    # initialize
     a0 = f
     a1 = g
-
     subres_l = [a0, a1]
     deg_dif_p1, c = degree(a0) - degree(a1) + 1, -1
-    
-        # initialize AMV variables
+
+    # initialize AMV variables
     sigma1 =  LC(a1, x)                      # leading coeff of a1
     i, s = 0, 0                              # counters for remainders & odd elements
     p_odd_index_sum = 0                      # contains the sum of p_1, p_3, etc
     p0 = deg_dif_p1 - 1
     if p0 % 2 == 1:
-        s += 1       
+        s += 1
     phi = floor( (s + 1) / 2 )
-        # compute the first polynomial of the prs
+
+    # compute the first polynomial of the prs
     i += 1
     a2 = rem_z(a0, a1, x) / Abs( (-1)**deg_dif_p1 )     # first remainder
     sigma2 =  LC(a2, x)                       # leading coeff of a2
     d2 =  degree(a2, x)                       # actual degree of a2
     p1 = d1 - d2                              # degree difference
-        # sgn_den is the factor, the denominator 1st fraction of (9),  
-        # by which a2 is multiplied to get integer coefficients
+
+    # sgn_den is the factor, the denominator 1st fraction of (9),
+    # by which a2 is multiplied to get integer coefficients
     sgn_den = compute_sign( sigma1, p0 + 1 )
-        ## compute sign of the 1st fraction in formula (9) of the paper 
+
+    ## compute sign of the 1st fraction in formula (9) of the paper
     # numerator
-    psi = i + phi + p_odd_index_sum 
-    num = (-1)**psi  
+    psi = i + phi + p_odd_index_sum
+    num = (-1)**psi
     # denominator
     den = sgn_den
-        # the sign of the determinant depends on sign(num / den) != 0
+
+    # the sign of the determinant depends on sign(num / den) != 0
     if  sign(num / den) > 0:
         subres_l.append( a2 )
     else:
         subres_l.append( -a2 )
-        # update AMV variables
+
+    # update AMV variable
     if p1 % 2 == 1:
-        s += 1       
-    ## bring in the missing power of sigma if there was gap
+        s += 1
+
+    # bring in the missing power of sigma if there was gap
     if p1 - 1 > 0:
         sgn_den = sgn_den * compute_sign( sigma1, p1 - 1 )
 
+    # main loop
     while d2 >= 1:
         phi = floor( (s + 1) / 2 )
-        if i%2 == 1: 
+        if i%2 == 1:
             p_odd_index_sum += p1             # p_i has odd index
         a0, a1, d0, d1 = a1, a2, d1, d2       # update polys and degrees
         p0 = p1                               # update degree difference
         i += 1
-
         sigma0 = -LC(a0)
         c = (sigma0**(deg_dif_p1 - 1)) / (c**(deg_dif_p1 - 2))
         deg_dif_p1 = degree(a0, x) - d2 + 1
@@ -1162,30 +1152,34 @@ def subresultants_amv(f, g, x):
         d2 =  degree(a2, x)                   # actual degree of a2
         p1 = d1 - d2                          # degree difference
         psi = i + phi + p_odd_index_sum
-        # update variables 
-        sigma1, sigma2 = sigma2, sigma3       
+
+        # update variables
+        sigma1, sigma2 = sigma2, sigma3
+
         # new sgn_den
-        sgn_den = compute_sign( sigma1, p0 + 1 ) * sgn_den            
-        ## compute the sign of the first fraction in formula (9) of the paper
-        # numerator 
-        num = (-1)**psi     
-        # denominator 
+        sgn_den = compute_sign( sigma1, p0 + 1 ) * sgn_den
+
+        # compute the sign of the first fraction in formula (9) of the paper
+        # numerator
+        num = (-1)**psi
+        # denominator
         den = sgn_den
-         
-        # the sign of the determinant depends on sign( num / den ) != 0          
+
+        # the sign of the determinant depends on sign( num / den ) != 0
         if  sign(num / den) > 0:
             subres_l.append( a2 )
         else:
             subres_l.append( -a2 )
-        
-        # update AMV variables
+
+        # update AMV variable
         if p1 % 2 ==1:
-            s += 1        
-        ## bring in the missing power of sigma if there was gap
-        if p1 - 1 > 0:       
+            s += 1
+
+        # bring in the missing power of sigma if there was gap
+        if p1 - 1 > 0:
             sgn_den = sgn_den * compute_sign( sigma1, p1 - 1 )
-        
-    # gcd is of degree > 0 ?   
+
+    # gcd is of degree > 0 ?
     m = len(subres_l)
     if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
         subres_l.pop(m - 1)
@@ -1196,39 +1190,39 @@ def modified_subresultants_amv(p,q,x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
-    Computes the modified subresultant prs of p and q in Z[x] or Q[x], 
+    Computes the modified subresultant prs of p and q in Z[x] or Q[x],
     from the subresultant prs of p and q.
-    The coefficients of the polynomials in the two sequences differ only 
-    in sign and a power of the absolute value of the leading coefficient 
-    of p, as stated in Theorem 2 of the reference.
+    The coefficients of the polynomials in the two sequences differ only
+    in sign and the factor Abs(LC(p)**( deg(p)- deg(q))) as stated in
+    Theorem 2 of the reference.
 
-    The coefficients of the polynomials in the output sequence are 
-    modified subresultants. That is, they are  determinants of appropriately 
-    selected submatrices of sylvester2, Sylvester's matrix of 1853. 
-  
-    If the modified subresultant prs is complete, then it coincides with the 
+    The coefficients of the polynomials in the output sequence are
+    modified subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester2, Sylvester's matrix of 1853.
+
+    If the modified subresultant prs is complete, then it coincides with the
     (generalized) Sturm's sequence of the polynomials p, q.
 
     References:
     ===========
-    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the remainders 
-    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
     Serdica Journal of Computing, to appear.
-    
+
     """
-    # compute the subresultant prs 
-    lst = subresultants_amv(p,q,x)     ## or lst = subresultants_amv_q(p, q, x)
+    # compute the subresultant prs
+    lst = subresultants_amv(p,q,x)     ## any other method would do
 
     # defensive
     if lst == [] or len(lst) == 2:
         return lst
 
-    # the coefficients in lst are subresultants and, hence, smaller than those 
-    # of the corresponding modified subresultants by the factor 
+    # the coefficients in lst are subresultants and, hence, smaller than those
+    # of the corresponding modified subresultants by the factor
     # Abs(LC(lst[0])**( deg(lst[0]) - deg(lst[1]))); see Theorem 2.
     lcf = Abs( LC(lst[0])**( degree(lst[0]) - degree(lst[1]) ) )
 
-    # Initialize the modified subresultant prs list 
+    # Initialize the modified subresultant prs list
     subr_seq = [lst[0], lst[1]]
 
     # compute the degree sequences m_i and j_i of Theorem 2
@@ -1237,7 +1231,7 @@ def modified_subresultants_amv(p,q,x):
     deg_seq_s = deg_seq[1:-1]
     m_seq = [m-1 for m in deg_seq_s]
     j_seq = [deg - m for m in m_seq]
-    
+
     # compute the AMV factors of Theorem 2
     fact = [(-1)**( j*(j-1)/S(2) ) for j in j_seq]
 
@@ -1252,6 +1246,7 @@ def modified_subresultants_amv(p,q,x):
             subr_seq.append( simplify(-lst_s[k] * lcf) )
         else:
             subr_seq.append( simplify(lst_s[k] * lcf) )
+
     return subr_seq
 
 def correct_sign(deg_f, deg_g, s1, rdel, cdel):
@@ -1259,25 +1254,25 @@ def correct_sign(deg_f, deg_g, s1, rdel, cdel):
     Used in various subresultant prs algorithms.
 
     Evaluates the determinant, (a.k.a. subresultant) of a properly selected
-    submatrix of s1, Sylvester's matrix of 1840, to get the correct sign 
+    submatrix of s1, Sylvester's matrix of 1840, to get the correct sign
     and value of the leading coefficient of a given polynomial remainder.
 
     deg_f, deg_g are the degrees of the original polynomials p, q for which the
     matrix s1 = sylvester(p, q, x, 1) was constructed.
-    
-    rdel denotes the expected degree of the remainder; it is the number of 
-    rows to be deleted from each group of rows in s1 as described in the 
+
+    rdel denotes the expected degree of the remainder; it is the number of
+    rows to be deleted from each group of rows in s1 as described in the
     reference below.
 
-    cdel denotes the expected degree minus the actual degree of the remainder; 
-    it is the number of columns to be deleted --- starting with the last column 
+    cdel denotes the expected degree minus the actual degree of the remainder;
+    it is the number of columns to be deleted --- starting with the last column
     forming the square matrix --- from the matrix resulting after the row deletions.
 
     References:
     ===========
-    Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
-    and Modified Subresultant Polynomial remainder Sequences.'' 
-    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+    Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
+    and Modified Subresultant Polynomial Remainder Sequences.''
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
 
     """
     M = s1[:, :]   # copy of matrix s1
@@ -1285,7 +1280,7 @@ def correct_sign(deg_f, deg_g, s1, rdel, cdel):
     # eliminate rdel rows from the first deg_g rows
     for i in range(M.rows - deg_f - 1, M.rows - deg_f - rdel - 1, -1):
         M.row_del(i)
-    
+
     # eliminate rdel rows from the last deg_f rows
     for i in range(M.rows - 1, M.rows - rdel - 1, -1):
         M.row_del(i)
@@ -1293,8 +1288,8 @@ def correct_sign(deg_f, deg_g, s1, rdel, cdel):
     # eliminate cdel columns
     for i in range(cdel):
         M.col_del(M.rows - 1)
-    
-    # define submatrix        
+
+    # define submatrix
     Md = M[:, 0: M.rows]
 
     return Md.det()
@@ -1303,39 +1298,37 @@ def subresultants_rem(p, q, x):
     """
     p, q are polynomials in Z[x] or Q[x].
 
-    Computes the subresultant prs of p and q in Z[x] or Q[x]; 
-    the coefficients of the polynomials in the sequence are 
-    subresultants. That is, they are  determinants of appropriately 
-    selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+    Computes the subresultant prs of p and q in Z[x] or Q[x];
+    the coefficients of the polynomials in the sequence are
+    subresultants. That is, they are  determinants of appropriately
+    selected submatrices of sylvester1, Sylvester's matrix of 1840.
 
-    To compute the coefficients polynomial divisions in Q[x] are 
-    performed, using the function rem(p, q, x). The coefficients 
+    To compute the coefficients polynomial divisions in Q[x] are
+    performed, using the function rem(p, q, x). The coefficients
     of the remainders computed this way become subresultants by evaluating
-    one subresultant per remainder --- that of the leading coefficient. 
-    This way we obtain the correct sign and value of the leading coefficient 
-    of the remainder and we easily ``force'' the rest of the coefficients 
+    one subresultant per remainder --- that of the leading coefficient.
+    This way we obtain the correct sign and value of the leading coefficient
+    of the remainder and we easily ``force'' the rest of the coefficients
     to become subresultants.
-   
-    If the subresultant prs is complete, then it coincides with the 
+
+    If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
     References:
-    ===========  
-    1. Akritas, A. G.:``Three New Methods for Computing Subresultant 
-    Polynomial remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
+    ===========
+    1. Akritas, A. G.:``Three New Methods for Computing Subresultant
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing,
     to appear.
 
     """
-    # Make sure neither p nor q is 0
+    # make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
+    # make sure proper degrees
     f, g = p, q
-
     n = deg_f = degree(f, x)
     m = deg_g = degree(g, x)
-
-    # Make sure proper degrees
     if n == 0 and m == 0:
         return []
     if n > 0 and m == 0:
@@ -1343,33 +1336,30 @@ def subresultants_rem(p, q, x):
     if n < m:
         n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
 
+    # initialize
     s1 = sylvester(f, g, x, 1)
     sr_list = [f, g]      # subresultant list
 
-    
+    # main loop
     while deg_g > 0:
-        # compute the remainder in Z[x] by doing division in Z[x]
-        r = rem(p, q, x)        
-        # actual degree
+        r = rem(p, q, x)
         d = degree(r, x)
-        # deg(0) == -oo
         if d == -oo:
             return sr_list
-        # expected degree
-        exp_deg = deg_g - 1
-        # Make coefficients subresultants
-        # by evaluating ONE determinant
+
+        # make coefficients subresultants evaluating ONE determinant
+        exp_deg = deg_g - 1          # expected degree
         sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
         r = simplify((r / LC(r, x)) * sign_value)
 
         # append poly with subresultant coeffs
         sr_list.append(r)
-                    
+
         # update degrees and polys
         deg_f, deg_g = deg_g, d
         p, q = q, r
-        
-    # gcd is of degree > 0 ? 
+
+    # gcd is of degree > 0 ?
     m = len(sr_list)
     if sr_list[m - 1] == nan or sr_list[m - 1] == 0:
         sr_list.pop(m - 1)
@@ -1377,22 +1367,22 @@ def subresultants_rem(p, q, x):
     return sr_list
 
 def pivot(M, i, j):
-    ''' 
+    '''
     M is a matrix, and M[i, j] specifies the pivot element.
-    
-    All elements below M[i, j], in the j-th column, will       
-    be zeroed, if they are not already 0, according to       
-    Dodgson-Bareiss' integer preserving transorMation. 
+
+    All elements below M[i, j], in the j-th column, will
+    be zeroed, if they are not already 0, according to
+    Dodgson-Bareiss' integer preserving transformations.
 
     References:
     ===========
-    1. Akritas, A. G.: ``A new method for computing polynomial greatest 
-    common divisors and polynomial remainder sequences.''  
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest
+    common divisors and polynomial remainder sequences.''
     Numerische MatheMatik 52, 119-127, 1988.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
-    by Van Vleck Regarding Sturm Sequences.'' 
-    Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
+    by Van Vleck Regarding Sturm Sequences.''
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013.
 
     '''
     ma = M[:, :] # copy of matrix M
@@ -1406,9 +1396,9 @@ def pivot(M, i, j):
     return ma
 
 def rotate_r(L, k):
-    ''' 
+    '''
     Rotates right by k. L is a row of a matrix or a list.
- 
+
     '''
     ll = list(L)
     if ll == []:
@@ -1419,7 +1409,7 @@ def rotate_r(L, k):
     return ll if type(L) is list else Matrix([ll])
 
 def rotate_l(L, k):
-    ''' 
+    '''
     Rotates left by k. L is a row of a matrix or a list.
 
     '''
@@ -1431,63 +1421,61 @@ def rotate_l(L, k):
         ll.insert(len(ll) - 1, el)
     return ll if type(L) is list else Matrix([ll])
 
-
 def row2poly(row, deg, x):
     '''
-    Converts the row of a matrix to a poly of degree deg and variable x.    
+    Converts the row of a matrix to a poly of degree deg and variable x.
     Some entries at the beginning and/or at the end of the row may be zero.
 
     '''
     k = 0
     poly = []
     leng = len(row)
-    
-    # find the beginning of the poly ; i.e. the first non-    
-    # zero element of the row
+
+    # find the beginning of the poly ; i.e. the first
+    # non-zero element of the row
     while row[k] == 0:
         k = k + 1
-    
+
     # append the next deg + 1 elements to poly
     for j in range( deg + 1):
         if k + j <= leng:
             poly.append(row[k + j])
 
-    return Poly(poly, x)        
-    
+    return Poly(poly, x)
+
 def create_ma(deg_f, deg_g, row1, row2, col_num):
     '''
     Creates a ``small'' matrix M to be triangularized.
-    
-    deg_f, deg_g are the degrees of the divident and of the 
+
+    deg_f, deg_g are the degrees of the divident and of the
     divisor polynomials respectively, deg_g > deg_f.
-    
-    The coefficients of the divident poly are the elements  
-    in row2 and those of the divisor poly are the elements 
+
+    The coefficients of the divident poly are the elements
+    in row2 and those of the divisor poly are the elements
     in row1.
-    
-    col_num indicates the number of columns of the matrix M.
+
+    col_num defines the number of columns of the matrix M.
 
     '''
     if deg_g - deg_f >= 1:
-        return "ERROR! Reverse input degrees"
+        print('Reverse degrees')
+        return
 
     m = zeros(deg_f - deg_g + 2, col_num)
-    
+
     for i in range(deg_f - deg_g + 1):
         m[i, :] = rotate_r(row1, i)
     m[deg_f - deg_g + 1, :] = row2
 
     return m
 
-
 def find_degree(M, deg_f):
     '''
-    Finds the degree of the poly corresponding 
-    to the _last_ row of the ``small'' matrix M.
+    Finds the degree of the poly corresponding (after triangularization)
+    to the _last_ row of the ``small'' matrix M, created by create_ma().
 
     deg_f is the degree of the divident poly.
-
-    If row is all 0's returns None.
+    If _last_ row is all 0's returns None.
 
     '''
     j = deg_f
@@ -1497,56 +1485,90 @@ def find_degree(M, deg_f):
         else:
             return j if j >= 0 else 0
 
-def subresultants_van_vleck(p, q, x, method = 0):
+def final_touches(s2, r, deg_g):
+    """
+    s2 is sylvester2, r is the row pointer in s2,
+    deg_g is the degree of the poly last inserted in s2.
+
+    After a gcd of degree > 0 has been found with Van Vleck's
+    method, and was inserted into s2, if its last term is not
+    in the last column of s2, then it is inserted as many
+    times as needed, rotated right by one each time, until
+    the condition is met.
+
+    """
+    R = s2.row(r-1)
+
+    # find the first non zero term
+    for i in range(s2.cols):
+        if R[0,i] == 0:
+            continue
+        else:
+            break
+
+    # missing rows until last term is in last column
+    mr = s2.cols - (i + deg_g + 1)
+
+    # insert them
+    i = 0
+    while mr != 0:
+        s2 = s2.row_insert(r + i, rotate_r(R, i+1))
+        i += 1
+        mr -= 1
+
+    return s2
+
+def subresultants_vv(p, q, x, method = 0):
     """
     p, q are polynomials in Z[x] (intended) or Q[x].
 
     Computes the subresultant prs of p, q by triangularizing,
-    in Z[x] or in Q[x], sylvester2, Sylvester's matrix of 1853.
-    See references 1 and 2 for Van Vleck's method. 
+    in Z[x] or in Q[x], all the smaller matrices encountered in the
+    process of triangularizing sylvester2, Sylvester's matrix of 1853;
+    see references 1 and 2 for Van Vleck's method. With each remainder,
+    sylvester2 gets updated and is prepared to be printed if requested.
 
-    Use this version if sylvester2 has small dimensions; otherwise,
-    use the second version, subresultants_van_vleck_2(p, q, x),
-    where sylvester2 is used implicitly.
+    If sylvester2 has small dimensions and you want to see the final,
+    triangularized matrix use this version with method=1; otherwise,
+    use either this version with method=0 (default) or the faster version,
+    subresultants_vv_2(p, q, x), where sylvester2 is used implicitly.
 
-    Sylvester's matrix sylvester1  is also used to compute one 
-    subresultant per remainder; namely, that of the leading 
-    coefficient, in order to obtain the correct sign and to  
+    Sylvester's matrix sylvester1  is also used to compute one
+    subresultant per remainder; namely, that of the leading
+    coefficient, in order to obtain the correct sign and to
     force the remainder coefficients to become subresultants.
-    
-    If the dimensions of sylvester2 are big use method=0 to not 
-    print the final, triangularized matrix sylvester2. 
-    Use method=1 to print the final matrix.
 
-    If the subresultant prs is complete, then it coincides with the 
+    If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
+
+    If the final, triangularized matrix s2 is printed, then:
+        (a) if deg(p) - deg(q) > 1 or deg( gcd(p, q) ) > 0, several
+            of the last rows in s2 will remain unprocessed;
+        (b) if deg(p) - deg(q) == 0, p will not appear in the final matrix.
 
     References:
     ===========
-    1. Akritas, A. G.: ``A new method for computing polynomial greatest 
-    common divisors and polynomial remainder sequences.''  
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest
+    common divisors and polynomial remainder sequences.''
     Numerische MatheMatik 52, 119-127, 1988.
 
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
-    by Van Vleck Regarding Sturm Sequences.'' 
-    Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
+    by Van Vleck Regarding Sturm Sequences.''
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013.
 
-    3. Akritas, A. G.:``Three New Methods for Computing Subresultant 
-    Polynomial remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
+    3. Akritas, A. G.:``Three New Methods for Computing Subresultant
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing,
     to appear.
 
-
     """
-    # Make sure neither p nor q is 0
+    # make sure neither p nor q is 0
     if p == 0 or q == 0:
         return [p, q]
 
+    # make sure proper degrees
     f, g = p, q
-
     n = deg_f = degree(f, x)
     m = deg_g = degree(g, x)
-
-    # Make sure proper degrees
     if n == 0 and m == 0:
         return []
     if n > 0 and m == 0:
@@ -1554,179 +1576,181 @@ def subresultants_van_vleck(p, q, x, method = 0):
     if n < m:
         n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
 
+    # initialize
     s1 = sylvester(f, g, x, 1)
     s2 = sylvester(f, g, x, 2)
+    sr_list = [f, g]
+    col_num = 2 * n         # columns in s2
 
-    sr_list = [f, g]      # subresultant list
-    col_num = 2 * n
-                
+    # make two rows (row0, row1) of poly coefficients
     row0 = Poly(f, x, domain = QQ).all_coeffs()
     leng0 = len(row0)
     for i in range(col_num - leng0):
         row0.append(0)
     row0 = Matrix([row0])
-
-    row1 = Poly(g,x, domain = QQ).all_coeffs()
-    leng1 = len(row1)
-    for i in range(col_num - leng1):
-        row1.append(0)
-    row1 = Matrix([row1]) 
-    
-    r = 2    
-    if deg_f - deg_g > 1:
-        # Several last rows in s2 will remain unprocessed
-        # Same thing happens when gcd is of deg > 0        
-        r = 1
-        # insert first poly shifted deg_f - deg_g - 1 times
-        for i in range(deg_f - deg_g - 1):
-            s2 = s2.row_insert(i + 1, rotate_r(row0, i + 1) )
-            r = r + 1
-        # insert second poly shifted deg_f - deg_g times
-        for i in range(deg_f - deg_g):
-            s2 = s2.row_insert(r + i, rotate_r(row1, r + i) )
-        r = r + deg_f - deg_g
-
-    if deg_f - deg_g == 0:
-        # the first poly will disappear from s2
-        r = 0
-   
-    while deg_g > 0:
-        
-        M = create_ma(deg_f, deg_g, row1, row0, col_num)
-        
-        # pivot as Many times as needed
-        for i in range(deg_f - deg_g + 1):
-            M1 = pivot(M, i, i)
-            M = M1[:, :]
-            
-        d = find_degree(M, deg_f)
-        if d == None:
-            if method != 0:
-                pprint(s2)
-            return sr_list
-        exp_deg = deg_g - 1
-
-        # compute subresultant & Make poly coeffs subresultants
-        poly = row2poly(M[M.rows - 1, :], d, x)
-        sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
-        temp2 = LC(poly, x)
-        poly = simplify((poly / LC(poly, x)) * sign_value)
-        
-        # update s2
-        for i in range(deg_g - d):
-            # insert first row of M
-            s2[r + i, :] = rotate_r(M[0, :], r + i)
-        r = r + deg_g - d
-        row0 = M[0, :]   
-
-        row1 = rotate_l(M[M.rows - 1, :], deg_f - d)
-        row1 = (row1 / temp2) * sign_value
-        for i in range(deg_g - d):
-            # insert last row of M
-            s2[r + i, :] = rotate_r(row1, r + i)
-        r = r + deg_g - d
-
-        # update degrees 
-        deg_f, deg_g = deg_g, d
-        # append poly with subresultant coeffs
-        sr_list.append(poly)
-                    
-    if method != 0:
-        pprint(s2)
-    return sr_list
-
-def subresultants_van_vleck_2(p, q, x):
-    """
-    p, q are polynomials in Z[x] (intended) or Q[x].
-
-    Computes the subresultant prs of p, q by triangularizing, 
-    in Z[x] or in Q[x], all the smaller Matrices encountered in the 
-    process of triangularizing sylvester2, Sylvester's matrix of 1853. 
-    See references 1 and 2 for Van Vleck's method. 
-
-    If the sylvester2 matrix has big dimensions use this version,
-    where sylvester2 is used implicitly. If you want to see the final,
-    triangularized matrix sylvester2, then use the first version,
-    subresultants_van_vleck(p, q, x).
-
-    sylvester1, Sylvester's matrix of 1840, is also used to compute 
-    one subresultant per remainder; namely, that of the leading 
-    coefficient, in order to obtain the correct sign and to  
-    ``force'' the remainder coefficients to become subresultants.
-    
-    If the subresultant prs is complete, then it coincides with the 
-    Euclidean sequence of the polynomials p, q.
-
-    References:
-    ===========
-    1. Akritas, A. G.: ``A new method for computing polynomial greatest 
-    common divisors and polynomial remainder sequences.''  
-    Numerische MatheMatik 52, 119-127, 1988.
-
-    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
-    by Van Vleck Regarding Sturm Sequences.'' 
-    Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
-
-    3. Akritas, A. G.:``Three New Methods for Computing Subresultant 
-    Polynomial remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
-    to appear.
-
-    """
-    # Make sure neither p nor q is 0
-    if p == 0 or q == 0:
-        return [p, q]
-
-    f, g = p, q
-
-    n = deg_f = degree(f, x)
-    m = deg_g = degree(g, x)
-
-    # Make sure proper degrees
-    if n == 0 and m == 0:
-        return []
-    if n > 0 and m == 0:
-        return [f, g]
-    if n < m:
-        n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
-
-    s1 = sylvester(f, g, x, 1)
-
-    sr_list = [f, g]      # subresultant list
-    # cols of sylvester2
-    col_num = 2 * n
-
-    row0 = Poly(f, x, domain = QQ).all_coeffs()
-    leng0 = len(row0)
-    for i in range(col_num - leng0):
-        row0.append(0)
-    row0 = Matrix([row0])
-
     row1 = Poly(g,x, domain = QQ).all_coeffs()
     leng1 = len(row1)
     for i in range(col_num - leng1):
         row1.append(0)
     row1 = Matrix([row1])
-    
+
+    # row pointer for deg_f - deg_g == 1; may be reset below
+    r = 2
+
+    # modify first rows of s2 matrix depending on poly degrees
+    if deg_f - deg_g > 1:
+        r = 1
+        # insert row0 (deg_f - deg_g - 1) times, rotated each time
+        for i in range(deg_f - deg_g - 1):
+            s2 = s2.row_insert(i + 1, rotate_r(row0, i + 1) )
+            r = r + 1
+        # insert row1 (deg_f - deg_g) times, rotated each time
+        for i in range(deg_f - deg_g):
+            s2 = s2.row_insert(r + i, rotate_r(row1, r + i) )
+        r = r + deg_f - deg_g
+
+    if deg_f - deg_g == 0:
+        r = 0
+
+    # main loop
     while deg_g > 0:
-        
+        # create a small matrix M, and triangularize it;
         M = create_ma(deg_f, deg_g, row1, row0, col_num)
-            
+        # will need only the first and last rows of M
         for i in range(deg_f - deg_g + 1):
             M1 = pivot(M, i, i)
             M = M1[:, :]
-            
+
+        # treat last row of M as poly; find its degree
+        d = find_degree(M, deg_f)
+        if d == None:
+            if method != 0:
+                s2 = final_touches(s2, r, deg_g)
+                pprint(s2)
+            return sr_list
+        exp_deg = deg_g - 1
+
+        # evaluate one determinant & make coefficients subresultants
+        sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
+        poly = row2poly(M[M.rows - 1, :], d, x)
+        temp2 = LC(poly, x)
+        poly = simplify((poly / temp2) * sign_value)
+
+        # update s2 by inserting first row of M as needed
+        for i in range(deg_g - d):
+            s2[r + i, :] = rotate_r(M[0, :], r + i)
+        r = r + deg_g - d
+        row0 = M[0, :]
+
+        # update s2 by inserting last row of M as needed
+        row1 = rotate_l(M[M.rows - 1, :], deg_f - d)
+        row1 = (row1 / temp2) * sign_value
+        for i in range(deg_g - d):
+            s2[r + i, :] = rotate_r(row1, r + i)
+
+        # update row and degrees
+        r = r + deg_g - d
+        deg_f, deg_g = deg_g, d
+
+        # append poly with subresultant coeffs
+        sr_list.append(poly)
+
+    if method != 0:
+        pprint(s2)
+
+    return sr_list
+
+def subresultants_vv_2(p, q, x):
+    """
+    p, q are polynomials in Z[x] (intended) or Q[x].
+
+    Computes the subresultant prs of p, q by triangularizing,
+    in Z[x] or in Q[x], all the smaller matrices encountered in the
+    process of triangularizing sylvester2, Sylvester's matrix of 1853;
+    see references 1 and 2 for Van Vleck's method.
+
+    If the sylvester2 matrix has big dimensions use this version,
+    where sylvester2 is used implicitly. If you want to see the final,
+    triangularized matrix sylvester2, then use the first version,
+    subresultants_vv(p, q, x, 1).
+
+    sylvester1, Sylvester's matrix of 1840, is also used to compute
+    one subresultant per remainder; namely, that of the leading
+    coefficient, in order to obtain the correct sign and to
+    ``force'' the remainder coefficients to become subresultants.
+
+    If the subresultant prs is complete, then it coincides with the
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest
+    common divisors and polynomial remainder sequences.''
+    Numerische MatheMatik 52, 119-127, 1988.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
+    by Van Vleck Regarding Sturm Sequences.''
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013.
+
+    3. Akritas, A. G.:``Three New Methods for Computing Subresultant
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing,
+    to appear.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    # make sure proper degrees
+    f, g = p, q
+    n = deg_f = degree(f, x)
+    m = deg_g = degree(g, x)
+    if n == 0 and m == 0:
+        return []
+    if n > 0 and m == 0:
+        return [f, g]
+    if n < m:
+        n, m, deg_f, deg_g, f, g = m, n, deg_g, deg_f, g, f
+
+    # initialize
+    s1 = sylvester(f, g, x, 1)
+    sr_list = [f, g]      # subresultant list
+    col_num = 2 * n       # columns in sylvester2
+
+    # make two rows (row0, row1) of poly coefficients
+    row0 = Poly(f, x, domain = QQ).all_coeffs()
+    leng0 = len(row0)
+    for i in range(col_num - leng0):
+        row0.append(0)
+    row0 = Matrix([row0])
+    row1 = Poly(g,x, domain = QQ).all_coeffs()
+    leng1 = len(row1)
+    for i in range(col_num - leng1):
+        row1.append(0)
+    row1 = Matrix([row1])
+
+    # main loop
+    while deg_g > 0:
+        # create a small matrix M, and triangularize it
+        M = create_ma(deg_f, deg_g, row1, row0, col_num)
+        for i in range(deg_f - deg_g + 1):
+            M1 = pivot(M, i, i)
+            M = M1[:, :]
+
+        # treat last row of M as poly; find its degree
         d = find_degree(M, deg_f)
         if d == None:
             return sr_list
         exp_deg = deg_g - 1
-        # Make entries of s2[r + 1, :] subresultants
-        poly = row2poly(M[M.rows - 1, :], d, x)
+
+        # evaluate one determinant & make coefficients subresultants
         sign_value = correct_sign(n, m, s1, exp_deg, exp_deg - d)
+        poly = row2poly(M[M.rows - 1, :], d, x)
         poly = simplify((poly / LC(poly, x)) * sign_value)
 
         # append poly with subresultant coeffs
         sr_list.append(poly)
-                    
+
         # update degrees and rows
         deg_f, deg_g = deg_g, d
         row0 = row1
@@ -1737,5 +1761,5 @@ def subresultants_van_vleck_2(p, q, x):
         row1 = Matrix([row1])
 
     return sr_list
- 
+
 

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -7,7 +7,8 @@ Created on Mon Dec 28 13:25:02 2015
 
 from __future__ import print_function, division
 
-from sympy import (Abs, degree, expand, floor, LC, Matrix, nan, Poly, pprint, QQ, rem, S, sign, simplify, summation, var, zeros)
+from sympy import (Abs, degree, expand, floor, LC, Matrix, nan, Poly)
+from sympy import (pprint, QQ, rem, S, sign, simplify, summation, var, zeros)
 
 def sylvester(f, g, x, method = 1):
     '''
@@ -130,7 +131,7 @@ def sturm_pg(p, q, x, method=0):
        smaller than the coefficients of the corresponding ``modified''
        subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
 
-    If the Sturm sequence is complete and method=0 then the coefficients
+    If the Sturm sequence is complete, method=0 and LC( p ) > 0, the coefficients
     of the polynomials in the sequence are ``modified'' subresultants.
     That is, they are  determinants of appropriately selected submatrices of
     sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence
@@ -332,10 +333,10 @@ def sturm_amv(p, q, x, method=0):
     B. If method == 1, the remainder coefficients of the sequence are (in
        absolute value) subresultants, which for non-monic polynomials are
        smaller than the coefficients of the corresponding ``modified''
-       subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
+       subresultants by the factor Abs( LC(p)**( deg(p)- deg(q)) ).
 
-    If the Sturm sequence is complete and method=0 then the coefficients
-    of the polynomials in the sequence are ``modified'' subresultants.
+    If the Sturm sequence is complete, method=0 and LC( p ) > 0, then the
+    coefficients of the polynomials in the sequence are ``modified'' subresultants.
     That is, they are  determinants of appropriately selected submatrices of
     sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence
     coincides with the ``modified'' subresultant prs, of the polynomials
@@ -353,7 +354,7 @@ def sturm_amv(p, q, x, method=0):
     (see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference)
     and (b) if method=0, assuming deg(p) > deg(q), we multiply the remainder
     coefficients of the Euclidean sequence times the factor
-    Abs(LC(p)**( deg(p)- deg(q))) to make them modified subresultants.
+    Abs( LC(p)**( deg(p)- deg(q)) ) to make them modified subresultants.
     See also the function sturm_pg(p, q, x).
 
     References:
@@ -379,7 +380,7 @@ def sturm_amv(p, q, x, method=0):
 
     # the coefficients in prs are subresultants and hence are smaller
     # than the corresponding subresultants by the factor
-    # |LC(prs[0])**( deg(prs[0]) - deg(prs[1]))|; Theorem 2, 2nd reference.
+    # Abs( LC(prs[0])**( deg(prs[0]) - deg(prs[1])) ); Theorem 2, 2nd reference.
     lcf = Abs( LC(prs[0])**( degree(prs[0], x) - degree(prs[1], x) ) )
 
     # the signs of the first two polys in the sequence stay the same
@@ -661,8 +662,8 @@ def modified_subresultants_pg(p,q,x):
     the coefficients of the remainders computed this way become ``modified''
     subresultants with the help of the Pell-Gordon Theorem of 1917.
 
-    If the ``modified'' subresultant prs is complete, then it coincides with the
-    (generalized) Sturm sequence of the polynomials p, q.
+    If the ``modified'' subresultant prs is complete, and LC( p ) > 0, it coincides
+    with the (generalized) Sturm sequence of the polynomials p, q.
 
     References:
     ===========
@@ -820,6 +821,14 @@ def modified_subresultants_pg(p,q,x):
     if subres_l[m - 1] == nan or subres_l[m - 1] == 0:
         subres_l.pop(m - 1)
 
+    # LC( p ) < 0
+    m = len(subres_l)   # list may be shorter now due to deg(gcd ) > 0
+    if LC( p ) < 0:
+        aux_seq = [subres_l[0], subres_l[1]]
+        for i in range(2, m):
+            aux_seq.append(simplify(subres_l[i] * (-1) ))
+        subres_l = aux_seq
+
     return  subres_l
 
 def subresultants_pg(p,q,x):
@@ -830,7 +839,7 @@ def subresultants_pg(p,q,x):
     the modified subresultant prs of p and q.
 
     The coefficients of the polynomials in these two sequences differ only
-    in sign and the factor Abs(LC(p)**( deg(p)- deg(q))) as stated in
+    in sign and the factor LC(p)**( deg(p)- deg(q)) as stated in
     Theorem 2 of the reference.
 
     The coefficients of the polynomials in the output sequence are
@@ -856,8 +865,8 @@ def subresultants_pg(p,q,x):
 
     # the coefficients in lst are modified subresultants and, hence, are
     # greater than those of the corresponding subresultants by the factor
-    # |LC(lst[0])**( deg(lst[0]) - deg(lst[1]))|; see Theorem 2 in reference.
-    lcf = Abs( LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) ) )
+    # LC(lst[0])**( deg(lst[0]) - deg(lst[1])); see Theorem 2 in reference.
+    lcf = LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) )
 
     # Initialize the subresultant prs list
     subr_seq = [lst[0], lst[1]]
@@ -1189,15 +1198,15 @@ def modified_subresultants_amv(p,q,x):
     Computes the modified subresultant prs of p and q in Z[x] or Q[x],
     from the subresultant prs of p and q.
     The coefficients of the polynomials in the two sequences differ only
-    in sign and the factor Abs(LC(p)**( deg(p)- deg(q))) as stated in
+    in sign and the factor LC(p)**( deg(p)- deg(q)) as stated in
     Theorem 2 of the reference.
 
     The coefficients of the polynomials in the output sequence are
     modified subresultants. That is, they are  determinants of appropriately
     selected submatrices of sylvester2, Sylvester's matrix of 1853.
 
-    If the modified subresultant prs is complete, then it coincides with the
-    (generalized) Sturm's sequence of the polynomials p, q.
+    If the modified subresultant prs is complete, and LC( p ) > 0, it coincides
+    with the (generalized) Sturm's sequence of the polynomials p, q.
 
     References:
     ===========
@@ -1215,8 +1224,8 @@ def modified_subresultants_amv(p,q,x):
 
     # the coefficients in lst are subresultants and, hence, smaller than those
     # of the corresponding modified subresultants by the factor
-    # Abs(LC(lst[0])**( deg(lst[0]) - deg(lst[1]))); see Theorem 2.
-    lcf = Abs( LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) ) )
+    # LC(lst[0])**( deg(lst[0]) - deg(lst[1])); see Theorem 2.
+    lcf = LC(lst[0])**( degree(lst[0], x) - degree(lst[1], x) )
 
     # Initialize the modified subresultant prs list
     subr_seq = [lst[0], lst[1]]

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -1598,7 +1598,7 @@ def subresultants_vv(p, q, x, method = 0):
         # insert row0 (deg_f - deg_g - 1) times, rotated each time
         for i in range(deg_f - deg_g - 1):
             s2[r + i, : ] = rotate_r(row0, i + 1)
-        r = r + 1
+        r = r + deg_f - deg_g - 1
         # insert row1 (deg_f - deg_g) times, rotated each time
         for i in range(deg_f - deg_g):
             s2[r + i, : ] = rotate_r(row1, r + i)
@@ -1629,13 +1629,13 @@ def subresultants_vv(p, q, x, method = 0):
         poly = simplify((poly / temp2) * sign_value)
 
         # update s2 by inserting first row of M as needed
-        for i in range(deg_g - d):
-            s2[r + i, :] = rotate_r(M[0, :], r + i)
-        r = r + deg_g - d
         row0 = M[0, :]
+        for i in range(deg_g - d):
+            s2[r + i, :] = rotate_r(row0, r + i)
+        r = r + deg_g - d
 
         # update s2 by inserting last row of M as needed
-        row1 = rotate_l(M[M.rows - 1, :], deg_f - d)
+        row1 = rotate_l(M[M.rows - 1, :], deg_f - d)  # last row rotated
         row1 = (row1 / temp2) * sign_value
         for i in range(deg_g - d):
             s2[r + i, :] = rotate_r(row1, r + i)

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -1,0 +1,1743 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Dec 28 13:25:02 2015
+
+@author: alkis
+"""
+
+# from __future__ import print_function, division
+
+from sympy import *
+
+def sylvester(f, g, x, method = 1):
+    '''
+      f, g polys in x, m = deg(f) >= deg(g) = n.
+
+      a. If method = 1 (default), computes sylvester1, Sylvester's matrix of 1840 
+          of dimension (m + n) x (m + n). The determinants of properly chosen 
+          submatrices of this matrix (a.k.a. subresultants) can be 
+          used to compute the coefficients of the Euclidean PRS of f, g.     
+ 
+      b. If method = 2, computes sylvester2, Sylvester's matrix of 1853
+          of dimension (2*m) x (2*m). The determinants of properly chosen 
+          submatrices of this matrix (a.k.a. ``modified'' subresultants) can be 
+          used to compute the coefficients of the Sturmian PRS of f, g.
+
+      Applications of these matrices can be found in the references below.
+      Especially, for applications of sylvester2, see the first reference!!
+
+      References: 
+      ===========
+      1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
+      by Van Vleck Regarding Sturm Sequences. Serdica Journal of Computing, 
+      Vol. 7, No 4, 101–134, 2013. 
+
+      2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
+      and Modified Subresultant Polynomial Remainder Sequences.'' 
+      Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+
+    '''
+    # obtain degrees of polys
+    m, n = degree( Poly(f, x), x), degree( Poly(g, x), x)
+
+    # Special cases:
+    # A:: case m = n = -oo (i.e. both polys are 0)
+    if m == n and n == -oo:
+        return Matrix([])
+
+    # B:: case m = n = 0  (i.e. both polys are constants)
+    if m == n and n == 0:
+        return Matrix([])
+
+    # C:: m == 0 and n == -oo or m == -oo and n == 0
+    # (i.e. one polys is constant and the other is 0)
+    if m == 0 and n == -oo:
+        return Matrix([])
+    elif m == -oo and n == 0:
+        return Matrix([])
+
+    # D:: m >= 1 and n == -oo or m == -oo and n >=1  
+    # (i.e. one poly is of degree >=1 and the other is 0) 
+    if m >= 1 and n == -oo:
+        return Matrix([0])
+    elif m == -oo and n >= 1:
+        return Matrix([0])
+
+    fp = Poly(f, x).all_coeffs()  
+    gp = Poly(g, x).all_coeffs()
+
+    # order lists of poly coeffs according to degree
+    if m < n:
+        fp, gp = gp, fp
+        m, n = n, m
+
+    # Sylvester's matrix of 1840 (default; a.k.a. sylvester1)
+    if method <= 1:
+        M = zeros(m + n)
+        k = 0
+        for i in range(n):
+            j = k
+            for coeff in fp:
+                M[i, j] = coeff
+                j = j + 1
+            k = k + 1
+        k = 0
+        for i in range(n, m + n):
+            j = k
+            for coeff in gp:
+                M[i, j] = coeff
+                j = j + 1
+            k = k + 1
+        return M
+
+    # Sylvester's matrix of 1853 (a.k.a sylvester2)
+    if method >= 2:
+        dim = 2*m
+        M = zeros( dim )
+        k = 0
+        for i in range( m ):
+            j = k
+            for coeff in fp:
+                if i == 0:
+                    M[i, j] = coeff
+                else:
+                    M[2*i, j] = coeff
+                j = j + 1
+            j = m - n + k
+            for coeff in gp:
+                if i == 0:
+                    M[i+1, j] = coeff
+                else:   
+                    M[2*i + 1, j] = coeff
+                j = j + 1
+            k = k + 1
+        return M
+
+def sturm_PG(p,q,x, method=0):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the (generalized) Sturm sequence of p and q in Z[x] or Q[x]. 
+    If q = diff(p, x, 1) it is the usual Sturm sequence.
+
+    A. If method == 0, default, the remainder coefficients of the sequence 
+       are (in absolute value) ``modified'' subresultants, which for non-monic 
+       polynomials are greater than the coefficients of the corresponding 
+       subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))). 
+       
+
+    B. If method == 1, the remainder coefficients of the sequence are (in 
+       absolute value) subresultants, which for non-monic polynomials are 
+       smaller than the coefficients of the corresponding ``modified'' 
+       subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
+
+    If the Sturm sequence is complete and method=0 then the coefficients 
+    of the polynomials in the sequence are ``modified'' subresultants. 
+    That is, they are  determinants of appropriately selected submatrices of
+    sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence 
+    coincides with the ``modified'' subresultant prs, of the polynomials 
+    p, q.
+
+    If the Sturm sequence is incomplete and method=0 then the signs of the 
+    coefficients of the polynomials in the sequence may differ from the signs 
+    of the coefficients of the corresponding polynomials in the ``modified'' 
+    subresultant prs; however, the absolute values are the same. 
+
+    To compute the coefficients, no determinant evaluation takes place. Instead, 
+    polynomial divisions in Q[x] are performed, using the function rem(p, q, x);  
+    the coefficients of the remainders computed this way become (``modified'') 
+    subresultants with the help of the Pell-Gordon Theorem of 1917.
+    See also the function euclid_PG(p, q, x).
+    
+    References:
+    =========== 
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of Mathematics,
+    Second Series, 18 (1917), No. 4, 188–193.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
+    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+     
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    FLAG = 0
+    d0 =  degree(p, x)
+    d1 =  degree(q, x)
+    # make sure proper degrees  
+    if d0 == 0 and d1 == 0:
+        return []
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p,q]
+        
+    # make sure LC(p) > 0
+    if  LC(p,x) < 0:
+        FLAG = 1
+        p = -p
+        q = -q
+        
+    # initialize
+    lcf = LC(p, x)**(d0 - d1)               # lcf * subr = modified subr 
+    a0, a1 = p, q                           # the input polys
+    sturmSeq = [a0, a1]                     # the output list 
+    del0 = d0 - d1                          # degree difference
+    rho1 =  LC(a1, x)                       # leading coeff of a1
+    expDeg = d1 - 1                         # expected degree of a2
+    a2 = - rem(a0, a1, domain=QQ)           # first remainder
+    rho2 =  LC(a2,x)                        # leading coeff of a2
+    d2 =  degree(a2, x)                     # actual degree of a2
+    degDiff_NEW = expDeg - d2               # expected - actual degree
+    del1 = d1 - d2                          # degree difference
+
+    # mulFac is the factor by which a2 is multiplied to 
+    # get integer coefficients
+    mulFac_OLD = rho1**(del0 + del1 - degDiff_NEW) 
+
+    # update variable and append
+    degDiff_OLD = degDiff_NEW 
+    if method == 0:
+        sturmSeq.append( simplify(lcf * a2 *  Abs(mulFac_OLD)))
+    else:
+        sturmSeq.append( simplify( a2 *  Abs(mulFac_OLD)))
+    # main loop
+    while d2 > 0:     
+        a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
+        del0 = del1                          # update degree difference
+        expDeg = d1 - 1                      # new expected degree 
+        a2 = - rem(a0, a1, domain=QQ)        # new remainder
+        rho3 =  LC(a2, x)                    # leading coeff of a2
+        d2 =  degree(a2, x)                  # actual degree of a2
+        degDiff_NEW = expDeg - d2            # expected - actual degree
+        del1 = d1 - d2                       # degree difference
+
+        # take into consideration the power 
+        # rho1**degDiff_OLD that was "left out"
+        expo_OLD = degDiff_OLD               # rho1 raised to this power
+        expo_NEW = del0 + del1 - degDiff_NEW # rho2 raised to this power
+
+        mulFac_NEW = rho2**(expo_NEW) * rho1**(expo_OLD) * mulFac_OLD 
+
+        # update variables and append
+        degDiff_OLD, mulFac_OLD = degDiff_NEW, mulFac_NEW
+        rho1, rho2 = rho2, rho3
+        if method == 0:
+            sturmSeq.append( simplify(lcf * a2 *  Abs(mulFac_OLD)))
+        else:
+            sturmSeq.append( simplify( a2 *  Abs(mulFac_OLD)))
+
+    if FLAG:          # change the sign of the sequence
+        sturmSeq = [-i for i in sturmSeq]
+    
+    # gcd is of degree > 0 ?   
+    m = len(sturmSeq)
+    if sturmSeq[m - 1] == nan or sturmSeq[m - 1] == 0:
+        sturmSeq.pop(m - 1)
+
+    return sturmSeq
+
+def sturm_Q(p, q, x):
+    """
+    p, q are polynomials in Z[x] or Q[x];
+
+    Computes the (generalized) Sturm sequence of p and q in Q[x]. 
+    Polynomial divisions in Q[x] are performed, using the function rem(p, q, x).  
+
+    The coefficients of the polynomials in the Sturm sequence can be uniquely 
+    determined from the corresponding coefficients of the polynomials found 
+    either in: 
+
+        (a) the ``modified'' subresultant prs, (references 1, 2)
+
+    or in
+
+        (b) the subresultant prs (reference 3).
+
+    References:
+    =========== 
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of Mathematics,
+    Second Series, 18 (1917), No. 4, 188–193.
+
+    2 Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
+    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    FLAG = 0
+    d0 =  degree(p, x)
+    d1 =  degree(q, x)
+
+    # make sure proper degrees  
+    if d0 == 0 and d1 == 0:
+        return []
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p,q]
+        
+    # make sure LC(p) > 0
+    if  LC(p,x) < 0:
+        FLAG = 1
+        p = -p
+        q = -q
+
+    # initialize
+    a0, a1 = p, q                           # the input polys
+    sturmSeq = [a0, a1]                     # the output list 
+    a2 = -rem(a0, a1, domain=QQ)            # first remainder
+    d2 =  degree(a2, x)                     # degree of a2
+    sturmSeq.append( a2 ) 
+
+
+    # main loop
+    while d2 > 0:     
+        a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
+        a2 = -rem(a0, a1, domain=QQ)         # new remainder
+        d2 =  degree(a2, x)                  # actual degree of a2
+        sturmSeq.append( a2 ) 
+    
+    if FLAG:          # change the sign of the sequence
+        sturmSeq = [-i for i in sturmSeq]
+
+    # gcd is of degree > 0 ?   
+    m = len(sturmSeq)
+    if sturmSeq[m - 1] == nan or sturmSeq[m - 1] == 0:
+        sturmSeq.pop(m - 1)
+
+    return sturmSeq
+
+def sturm_AMV(p, q, x, method=0):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the (generalized) Sturm sequence of p and q in Z[x] or Q[x]. 
+    If q = diff(p, x, 1) it is the usual Sturm sequence.
+
+    A. If method == 0, default, the remainder coefficients of the 
+       sequence are (in absolute value) ``modified'' subresultants, which 
+       for non-monic polynomials are greater than the coefficients of the 
+       corresponding subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))). 
+
+    B. If method == 1, the remainder coefficients of the sequence are (in 
+       absolute value) subresultants, which for non-monic polynomials are 
+       smaller than the coefficients of the corresponding ``modified''
+       subresultants by the factor Abs(LC(p)**( deg(p)- deg(q))).
+
+    If the Sturm sequence is complete and method=0 then the coefficients 
+    of the polynomials in the sequence are ``modified'' subresultants. 
+    That is, they are  determinants of appropriately selected submatrices of
+    sylvester2, Sylvester's matrix of 1853. In this case the Sturm sequence 
+    coincides with the ``modified'' subresultant prs, of the polynomials 
+    p, q.
+
+    If the Sturm sequence is incomplete and method=0 then the signs of the 
+    coefficients of the polynomials in the sequence may differ from the signs 
+    of the coefficients of the corresponding polynomials in the ``modified'' 
+    subresultant prs; however, the absolute values are the same. 
+
+    To compute the coefficients, no determinant evaluation takes place.    
+    Instead, we first compute the euclidean sequence  of p and q using 
+    euclid_AMV(p, q, x) and then: (a) change the signs of the remainders in the 
+    Euclidean sequence according to the pattern "-, -, +, +, -, -, +, +,..." 
+    (see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference)
+    and (b) if method=0, assuming deg(p) > deg(q), we multiply the remainder 
+    coefficients of the Euclidean sequence times the factor 
+    Abs(LC(p)**( deg(p)- deg(q))) to make them modified subresultants.
+    See also the function sturm_PG(p, q, x).
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders 
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica 
+    Journal of Computing, to appear.
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    Submitted for publication.
+   
+    """
+    # compute the euclidean sequence 
+    prs = euclid_AMV(p, q, x)
+
+    # defensive
+    if prs == [] or len(prs) == 2:
+        return prs
+
+    # the coefficients in prs are subresultants and hence are smaller
+    # than the corresponding subresultants by the factor 
+    # |LC(prs[0])**( deg(prs[0]) - deg(prs[1]))|; Theorem 2, 2nd reference.
+    lcf = Abs( LC(prs[0])**( degree(prs[0]) - degree(prs[1]) ) )
+    
+    # the signs of the first two polys in the sequence stay the same
+    sturmSeq = [prs[0], prs[1]]
+    flag = 0
+    m = len(prs)
+    i = 2
+    # change the signs according to "-, -, +, +, -, -, +, +,..."
+    # and multiply times lcf if needed
+    while i <= m-1:
+        if  flag == 0:
+            sturmSeq.append( - prs[i] )
+            i = i + 1
+            if i == m: 
+                break
+            sturmSeq.append( - prs[i] )
+            i = i + 1
+            flag = 1
+        elif flag == 1:
+            sturmSeq.append( prs[i] )
+            i = i + 1
+            if i == m: 
+                break
+            sturmSeq.append( prs[i] )
+            i = i + 1
+            flag = 0
+
+    # subresultants or modified subresultants?  
+    if method == 0 and lcf > 1:
+        auxSeq = [sturmSeq[0], sturmSeq[1]]
+        for i in range(2, m):
+            auxSeq.append(simplify(sturmSeq[i] * lcf ))
+        sturmSeq = auxSeq
+
+    return sturmSeq
+
+def euclid_PG(p, q, x):
+    """
+    p, q are polynomials in Z[x] or Q[x];
+
+    Computes the Euclidean sequence of p and q in Z[x] or Q[x]. 
+ 
+    If the Euclidean sequence is complete the coefficients of the polynomials 
+    in the sequence are subresultants. That is, they are  determinants of 
+    appropriately selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+    In this case the Euclidean sequence coincides with the subresultant prs 
+    of the polynomials p, q.
+
+    If the Euclidean sequence is incomplete the signs of the coefficients of the 
+    polynomials in the sequence may differ from the signs of the coefficients of
+    the corresponding polynomials in the subresultant prs; however, the absolute 
+    values are the same. 
+
+    To compute the Euclidean sequence, no determinant evaluation takes place. 
+    We first compute the (generalized) Sturm sequence  of p and q using 
+    sturm_PG(p, q, x, 1), in which case the coefficients are (in absolute value) 
+    equal to subresultants. Then we change the signs of the remainders in the 
+    Sturm sequence according to the pattern "-, -, +, +, -, -, +, +,..." ;
+    see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference as well as
+    the function sturm_PG(p, q, x).
+    
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders 
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' Serdica 
+    Journal of Computing, to appear.
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    Submitted for publication.
+   
+    """
+    
+    # compute the sturmian sequence using the Pell-Gordon theorem
+    # with the coefficients in the prs being (in absolute value) subresultants
+    prs = sturm_PG(p, q, x, 1)  ## or prs = sturm_AMV(p, q, x, 1)
+
+    # defensive
+    if prs == [] or len(prs) == 2:
+        return prs
+
+    # the signs of the first two polys in the sequence stay the same
+    euclidSeq = [prs[0], prs[1]]
+    flag = 0
+    m = len(prs)
+    i = 2
+
+    # change the signs according to "-, -, +, +, -, -, +, +,..."
+    while i <= m-1:
+        if  flag == 0:
+            euclidSeq.append(- prs[i] )
+            i = i + 1
+            if i == m: 
+                break
+            euclidSeq.append(- prs[i] )
+            i = i + 1
+            flag = 1
+        elif flag == 1:
+            euclidSeq.append(prs[i] )
+            i = i + 1
+            if i == m: 
+                break
+            euclidSeq.append(prs[i] )
+            i = i + 1
+            flag = 0
+
+    return euclidSeq
+
+def euclid_Q(p, q, x):
+    """
+    p, q are polynomials in Z[x] or Q[x];
+
+    Computes the Euclidean sequence of p and q in Q[x].
+    Polynomial divisions in Q[x] are performed, using the function rem(p, q, x).  
+
+    The coefficients of the polynomials in the Euclidean sequence can be uniquely 
+    determined from the corresponding coefficients of the polynomials found 
+    either in: 
+
+        (a) the ``modified'' subresultant polynomial remainder sequence,
+    (references 1, 2) 
+
+    or in
+
+        (b) the subresultant polynomial remainder sequence (references 3).
+
+    References:
+    =========== 
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of Mathematics,
+    Second Series, 18 (1917), No. 4, 188–193.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
+    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    FLAG = 0
+    d0 =  degree(p, x)
+    d1 =  degree(q, x)
+    # make sure proper degrees  
+    if d0 == 0 and d1 == 0:
+        return []
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+    if d0 > 0 and d1 == 0:
+        return [p,q]
+        
+    # make sure LC(p) > 0
+    if  LC(p,x) < 0:
+        FLAG = 1
+        p = -p
+        q = -q
+
+    # initialize
+    a0, a1 = p, q                           # the input polys
+    euclidSeq = [a0, a1]                    # the output list 
+    a2 = rem(a0, a1, domain=QQ)             # first remainder
+    d2 =  degree(a2, x)                     # degree of a2
+    euclidSeq.append( a2 ) 
+
+    # main loop
+    while d2 > 0:     
+        a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
+        a2 = rem(a0, a1, domain=QQ)          # new remainder
+        d2 =  degree(a2, x)                  # actual degree of a2
+        euclidSeq.append( a2 ) 
+
+    
+    if FLAG:          # change the sign of the sequence
+        euclidSeq = [-i for i in euclidSeq]
+
+    # gcd is of degree > 0 ?   
+    m = len(euclidSeq)
+    if euclidSeq[m - 1] == nan or euclidSeq[m - 1] == 0:
+        euclidSeq.pop(m - 1)
+
+    return euclidSeq
+
+def euclid_AMV(f, g, x):
+    """
+    f, g are polynomials in Z[x] or Q[x].
+
+    Computes the Euclidean sequence of p and q in Z[x] or Q[x]. 
+ 
+    If the Euclidean sequence is complete the coefficients of the polynomials 
+    in the sequence are subresultants. That is, they are  determinants of 
+    appropriately selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+    In this case the Euclidean sequence coincides with the subresultant prs, 
+    of the polynomials p, q.
+
+    If the Euclidean sequence is incomplete the signs of the coefficients of the 
+    polynomials in the sequence may differ from the signs of the coefficients of
+    the corresponding polynomials in the subresultant prs; however, the absolute 
+    values are the same. 
+
+    To compute the coefficients, no determinant evaluation takes place. 
+    Instead, polynomial divisions in Z[x] or Q[x] are performed, using 
+    the function remZ(f, g, x);  the coefficients of the remainders 
+    computed this way become subresultants with the help of the 
+    Collins-Brown-Traub formula for coefficient reduction.
+   
+    References:
+    ===========  
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    Submitted for publication.
+    
+    """
+    # make sure neither f nor g is 0
+    if f == 0 or g == 0:
+        return [f, g]
+
+    d0 =  degree(f, x)
+    d1 =  degree(g, x)
+
+        # make sure proper degrees  
+    if d0 == 0 and d1 == 0:
+        return []
+    if d0 > 0 and d1 == 0:
+        return [f, g]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        f, g = g, f
+    if d0 == 1:
+        return [f, g]
+
+    a0 = f
+    a1 = g
+
+    euclidSeq = [a0, a1]
+    degdifP1, c = degree(a0) - degree(a1) + 1, -1
+    
+    i = 0                                          # counter for remainders 
+
+        # compute the first polynomial of the prs
+    i += 1
+    a2 = remZ(a0, a1, x) / Abs( (-1)**degdifP1 )     # first remainder
+    euclidSeq.append( a2 )
+    d2 =  degree(a2, x)                              # actual degree of a2
+
+    while d2 >= 1:
+        a0, a1, d0, d1 = a1, a2, d1, d2       # update polys and degrees
+        i += 1
+        sigma0 = -LC(a0)
+        c = (sigma0**(degdifP1 - 1)) / (c**(degdifP1 - 2))
+        degdifP1 = degree(a0, x) - d2 + 1
+        a2 = remZ(a0, a1, x) / Abs( ((c**(degdifP1 - 1)) * sigma0) )
+        euclidSeq.append( a2 )
+        d2 =  degree(a2, x)                   # actual degree of a2
+        
+    # gcd is of degree > 0 ? 
+    m = len(euclidSeq)  
+    if euclidSeq[m - 1] == nan or euclidSeq[m - 1] == 0:
+        euclidSeq.pop(m - 1)
+        
+    return euclidSeq
+
+
+def modified_subresultants_PG(p,q,x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the ``modified'' subresultant prs of p and q in Z[x] or Q[x]; 
+    the coefficients of the polynomials in the sequence are 
+    ``modified'' subresultants. That is, they are  determinants of appropriately 
+    selected submatrices of sylvester2, Sylvester's matrix of 1853. 
+
+    To compute the coefficients, no determinant evaluation takes place. Instead,   
+    polynomial divisions in Q[x] are performed, using the function rem(p, q, x);  
+    the coefficients of the remainders computed this way become ``modified'' 
+    subresultants with the help of the Pell-Gordon Theorem of 1917.
+   
+    If the ``modified'' subresultant prs is complete, then it coincides with the 
+    (generalized) Sturm sequence of the polynomials p, q.
+
+    References:
+    ===========  
+    1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
+    the Highest Common Factor of Two Polynomials. Annals of Mathematics,
+    Second Series, 18 (1917), No. 4, 188–193.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
+    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+    
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    k =  var('k')                              # index in summation formula
+    u_List = []                                # of elements (-1)**u_i 
+    subresL = [p, q]                           # mod. subr. prs output list    
+    d0 =  degree(p,x)
+    d1 =  degree(q,x)
+
+    # make sure proper degrees  
+    if d0 == 0 and d1 == 0:
+        return []
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+        subresL = [p, q]                       # mod. subr. prs output list    
+    if d0 > 0 and d1 == 0:
+        return [p,q]
+                
+    # initialize
+    a0, a1 = p, q                               # the input polys
+    del0 = d0 - d1                              # degree difference
+    degdif = del0                               # save it
+    rho_1 = LC(a0)                              # lead. coeff (a0)
+
+    # Initialize Pell-Gordon variables
+    rho_List_Minus_1 =  sign( LC(a0, x))      # sign of LC(a0)
+    rho1 =  LC(a1, x)                         # leading coeff of a1
+    rho_List = [ sign(rho1)]                  # of signs
+    p_List = [del0]                           # of degree differences
+    u =  summation(k, (k, 1, p_List[0]))      # value of u
+    u_List.append(u)                          # of u values
+    v = sum(p_List)                           # v value
+
+    expDeg = d1 - 1                           # expected degree of a2
+    a2 = - rem(a0, a1, domain=QQ)             # first remainder
+    rho2 =  LC(a2, x)                         # leading coeff of a2
+    d2 =  degree(a2, x)                       # actual degree of a2
+    degDiff_NEW = expDeg - d2                 # expected - actual degree
+    del1 = d1 - d2                            # degree difference
+
+    # mulFac is the factor by which a2 is multiplied to 
+    # get integer coefficients
+    mulFac_OLD = rho1**(del0 + del1 - degDiff_NEW) 
+        
+    # update Pell-Gordon variables
+    p_List.append(1 + degDiff_NEW)              # degDiff_NEW is 0 for complete seq
+
+    # apply Pell-Gordon formula (7) in second reference
+    num = 1                                     # numerator of fraction
+    for k in range(len(u_List)):
+        num *= (-1)**u_List[k]
+    num = num * (-1)**v
+
+    # denominator depends on complete / incomplete seq
+    if degDiff_NEW == 0:                        # complete seq
+        den = 1
+        for k in range(len(rho_List)):
+            den *= rho_List[k]**(p_List[k] + p_List[k + 1])
+        den = den * rho_List_Minus_1
+    else:                                       # incomplete seq
+        den = 1
+        for k in range(len(rho_List)-1):
+            den *= rho_List[k]**(p_List[k] + p_List[k + 1])
+        den = den * rho_List_Minus_1 
+        expo = (p_List[len(rho_List) - 1] + p_List[len(rho_List)] - degDiff_NEW)
+        den = den * rho_List[len(rho_List) - 1]**expo 
+    
+    # the sign of the determinant depends on sg(num / den)
+    if  sign(num / den) > 0:
+        subresL.append( simplify(rho_1**degdif*a2* Abs(mulFac_OLD) ) ) 
+    else:
+        subresL.append(- simplify(rho_1**degdif*a2* Abs(mulFac_OLD) ) )      
+  
+    # update Pell-Gordon variables
+    k =  var('k')
+    rho_List.append( sign(rho2))
+    u =  summation(k, (k, 1, p_List[len(p_List) - 1]))   
+    u_List.append(u)   
+    v = sum(p_List)
+    
+    degDiff_OLD=degDiff_NEW
+    
+    # main loop
+    while d2 > 0:     
+        a0, a1, d0, d1 = a1, a2, d1, d2      # update polys and degrees
+        del0 = del1                          # update degree difference
+        expDeg = d1 - 1                      # new expected degree 
+        a2 = - rem(a0, a1, domain=QQ)        # new remainder
+        rho3 =  LC(a2, x)                    # leading coeff of a2
+        d2 =  degree(a2, x)                  # actual degree of a2
+        degDiff_NEW = expDeg - d2            # expected - actual degree
+        del1 = d1 - d2                       # degree difference
+
+        # take into consideration the power 
+        # rho1**degDiff_OLD that was "left out"
+        expo_OLD = degDiff_OLD               # rho1 raised to this power
+        expo_NEW = del0 + del1 - degDiff_NEW # rho2 raised to this power
+
+        mulFac_NEW = rho2**(expo_NEW) * rho1**(expo_OLD) * mulFac_OLD 
+
+        # update variables and append
+        degDiff_OLD, mulFac_OLD = degDiff_NEW, mulFac_NEW
+        rho1, rho2 = rho2, rho3
+        
+        # update Pell-Gordon variables
+        p_List.append(1 + degDiff_NEW)       # degDiff_NEW is 0 for complete seq
+            
+        # apply Pell-Gordon formula (7) in second reference
+        num = 1                              # numerator 
+        for k in range(len(u_List)): 
+            num *= (-1)**u_List[k]
+        num = num * (-1)**v
+
+        # denominator depends on complete / incomplete seq
+        if degDiff_NEW == 0:                 # complete seq
+            den = 1
+            for k in range(len(rho_List)):
+                den *= rho_List[k]**(p_List[k] + p_List[k + 1])
+            den = den * rho_List_Minus_1
+        else:                                # incomplete seq
+            den = 1
+            for k in range(len(rho_List)-1):
+                den *= rho_List[k]**(p_List[k] + p_List[k + 1])
+            den = den * rho_List_Minus_1 
+            expo = (p_List[len(rho_List) - 1] + p_List[len(rho_List)] - degDiff_NEW)
+            den = den * rho_List[len(rho_List) - 1]**expo 
+
+                    
+        # the sign of the determinant depends on sg(num / den)          
+        if  sign(num / den) > 0:
+            subresL.append( simplify(rho_1**degdif*a2* Abs(mulFac_OLD) ) ) 
+        else:
+            subresL.append(- simplify(rho_1**degdif*a2* Abs(mulFac_OLD) ) )
+            
+        # update Pell-Gordon variables
+        k =  var('k')
+        rho_List.append( sign(rho2))
+        u =  summation(k, (k, 1, p_List[len(p_List) - 1]))   
+        u_List.append(u)   
+        v = sum(p_List)
+
+    # gcd is of degree > 0 ?   
+    m = len(subresL)
+    if subresL[m - 1] == nan or subresL[m - 1] == 0:
+        subresL.pop(m - 1)
+
+    return  subresL 
+
+def subresultants_PG(p,q,x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the subresultant prs of p and q in Z[x] or Q[x], from 
+    the modified subresultant prs of p and q.
+    The coefficients of the polynomials in the two sequences differ only 
+    in sign and a power of the absolute value of the leading coefficient 
+    of p, as stated in Theorem 2 of the reference.
+
+    The coefficients of the polynomials in the output sequence are 
+    subresultants. That is, they are  determinants of appropriately 
+    selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+  
+    If the subresultant prs is complete, then it coincides with the 
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders 
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
+    Serdica Journal of Computing, to appear.
+    
+    """
+    # compute the modified subresultant prs 
+    lst = modified_subresultants_PG(p,q,x)  ## or lst = modified_subresultants_AMV(p,q,x)
+
+    # defensive
+    if lst == [] or len(lst) == 2:
+        return lst
+
+    # the coefficients in lst are modified subresultants and, hence, are 
+    # greater than those of the corresponding subresultants by the factor 
+    # |LC(lst[0])**( deg(lst[0]) - deg(lst[1]))|; see Theorem 2 in reference.
+    lcf = Abs( LC(lst[0])**( degree(lst[0]) - degree(lst[1]) ) )
+
+    # Initialize the subresultant prs list 
+    subrSeq = [lst[0], lst[1]]
+
+    # compute the degree sequences m_i and j_i of Theorem 2 in reference.
+    degSeq = [degree(Poly(poly, x)) for poly in lst]
+    deg = degSeq[0]
+    degSeqS = degSeq[1:-1]
+    mSeq = [m-1 for m in degSeqS]
+    jSeq = [deg - m for m in mSeq]
+    
+    # compute the AMV factors of Theorem 2 in reference.
+    fact = [(-1)**( j*(j-1)/S(2) ) for j in jSeq]
+
+    # shortened list without the first two polys
+    lstS = lst[2:]
+
+    # poly lstS[k] is multiplied times fact[k], divided by lcf
+    # and appended to the subresultant prs list
+    m = len(fact)
+    for k in range(m):
+        if sign(fact[k]) == -1:
+            subrSeq.append(-lstS[k] / lcf)
+        else:
+            subrSeq.append(lstS[k] / lcf)
+    return subrSeq
+
+def subresultants_AMV_Q(p,q,x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the subresultant prs of p and q in Q[x]; 
+    the coefficients of the polynomials in the sequence are 
+    subresultants. That is, they are  determinants of appropriately 
+    selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+
+    To compute the coefficients, no determinant evaluation takes place. 
+    Instead, polynomial divisions in Q[x] are performed, using the
+    function rem(p, q, x);  the coefficients of the remainders 
+    computed this way become subresultants with the help of the 
+    Akritas-Malaschonok-Vigklas Theorem of 2015.
+   
+    If the subresultant prs is complete, then it coincides with the 
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========  
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    Submitted for publication.
+    
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    d0 =  degree(p, x)
+    d1 =  degree(q, x)
+
+    # make sure proper degrees  
+    if d0 == 0 and d1 == 0:
+        return []
+    if d0 > 0 and d1 == 0:
+        return [p, q]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        p, q = q, p
+        
+        
+    # initialize
+    i, s = 0, 0                              # counters for remainders & odd elements
+    p_odd_index_sum = 0                      # contains the sum of p_1, p_3, etc
+    subresL = [p, q]                         # subresultant prs output list
+    a0, a1 = p, q                            # the input polys
+    sigma1 =  LC(a1, x)                      # leading coeff of a1
+    p0 = d0 - d1                             # degree difference
+    if p0 % 2 == 1:
+        s += 1       
+    phi = floor( (s + 1) / 2 )     
+    mulFac = 1
+    d2 = d1
+
+    # main loop
+    while d2 > 0:   
+        i += 1
+        a2 = rem(a0, a1, domain= QQ)          # new remainder
+        if i == 1:
+            sigma2 =  LC(a2, x)                       
+        else:
+            sigma3 =  LC(a2, x)                       
+            sigma1, sigma2 = sigma2, sigma3
+
+            
+        d2 =  degree(a2, x)                         
+        p1 = d1 - d2                                       
+        psi = i + phi + p_odd_index_sum
+
+        # new mulFac
+        mulFac = sigma1**(p0 + 1) * mulFac
+            
+        ## compute the sign of the first fraction in formula (9) of the paper
+        # numerator 
+        num = (-1)**psi     
+        # denominator 
+        den = sign(mulFac)
+         
+        # the sign of the determinant depends on sign( num / den ) != 0          
+        if  sign(num / den) > 0:
+            subresL.append( simplify(expand(a2* Abs(mulFac))))
+        else:
+            subresL.append(- simplify(expand(a2* Abs(mulFac))))
+        
+
+        ## bring into mulFac the missing power of sigma if there was a degree gap
+        if p1 - 1 > 0:       
+            mulFac = mulFac * sigma1**(p1 - 1)
+
+       # update AMV variables
+        a0, a1, d0, d1 = a1, a2, d1, d2       
+        p0 = p1                                           
+        if p0 % 2 ==1:
+            s += 1        
+        phi = floor( (s + 1) / 2 )
+        if i%2 == 1: 
+            p_odd_index_sum += p0             # p_i has odd index
+       
+    # gcd is of degree > 0 ?   
+    m = len(subresL)
+    if subresL[m - 1] == nan or subresL[m - 1] == 0:
+        subresL.pop(m - 1)
+
+    return  subresL 
+
+
+def computeSign(base, expo):
+    '''
+    base != 0 and expo >= 0 are integers;
+    
+    returns the sign of base**expo without 
+    evaluating the power itself!
+    '''
+    sb = sign(base)
+    if sb == 1:
+        return 1
+    pe = expo % 2
+    if pe == 0:
+        return -sb
+    else:
+        return sb
+
+def remZ(p, q, x):
+    '''
+    Intended mainly for p, q polynomials in Z[x] so that,
+    on dividing p by q, the remainder will also be in Z[x]. (However,
+    it also works fine for polynomials in Q[x].) 
+
+    It premultiplies p by the _absolute_ value of the leading coefficient 
+    of q, raised to the power deg(p) - deg(q) + 1 and then performs 
+    polynomial division in Q[x], using the function rem(p, q, x). 
+
+    By contrast the function prem(p, q, x) does _not_ use the absolute 
+    value of the leading coefficient of q. 
+    This results not only in ``messing up the signs'' of the Euclidean and 
+    Sturmian prs's as mentioned in the second reference, 
+    but also in violation of the main results of the first and third 
+    references --- Theorem 4 and Theorem 1 respectively. Theorems 4 and 1 
+    establish a one-to-one correspondence between the Euclidean and the 
+    Sturmian prs of p, q, on one hand, and the subresultant prs of p, q, 
+    on the other.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders 
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
+    Serdica Journal of Computing, to appear.
+
+    2. http://planetmath.org/sturmstheorem
+
+    3. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result on 
+    the Theory of Subresultants.'' Submitted for publication.
+
+    '''
+    delta = (degree(p, x) - degree(q, x) + 1)
+    return rem(Abs(LC(q, x))**delta  *  p, q, x) 
+
+ 
+def subresultants_AMV(f, g, x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the subresultant prs of p and q in Z[x] or Q[x]; 
+    the coefficients of the polynomials in the sequence are 
+    subresultants. That is, they are  determinants of appropriately 
+    selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+
+    To compute the coefficients, no determinant evaluation takes place. 
+    Instead, polynomial divisions in Z[x] or Q[x] are performed, using 
+    the function remZ(p, q, x);  the coefficients of the remainders 
+    computed this way become subresultants with the help of the 
+    Akritas-Malaschonok-Vigklas Theorem of 2015 and the Collins-Brown-
+    Traub formula for coefficient reduction.
+   
+    If the subresultant prs is complete, then it coincides with the 
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========  
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result 
+    on the Theory of Subresultants.'' Submitted for publication.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Subresultant Polynomial   
+    Remainder Sequences Obtained by Polynomial Divisions in Q[x] or in Z[x].''  
+    Submitted for publication.
+    
+    """
+    # make sure neither f nor g is 0
+    if f == 0 or g == 0:
+        return [f, g]
+
+    d0 =  degree(f, x)
+    d1 =  degree(g, x)
+
+        # make sure proper degrees  
+    if d0 == 0 and d1 == 0:
+        return []
+    if d0 > 0 and d1 == 0:
+        return [f, g]
+    if d1 > d0:
+        d0, d1 = d1, d0
+        f, g = g, f
+    if d0 == 1:
+        return [f, g]
+
+    a0 = f
+    a1 = g
+
+    subresL = [a0, a1]
+    degdifP1, c = degree(a0) - degree(a1) + 1, -1
+    
+        # initialize AMV variables
+    sigma1 =  LC(a1, x)                      # leading coeff of a1
+    i, s = 0, 0                              # counters for remainders & odd elements
+    p_odd_index_sum = 0                      # contains the sum of p_1, p_3, etc
+    p0 = degdifP1 - 1
+    if p0 % 2 == 1:
+        s += 1       
+    phi = floor( (s + 1) / 2 )
+        # compute the first polynomial of the prs
+    i += 1
+    a2 = remZ(a0, a1, x) / Abs( (-1)**degdifP1 )     # first remainder
+    sigma2 =  LC(a2, x)                       # leading coeff of a2
+    d2 =  degree(a2, x)                       # actual degree of a2
+    p1 = d1 - d2                              # degree difference
+        # sgnDen is the factor, the denominator 1st fraction of (9),  
+        # by which a2 is multiplied to get integer coefficients
+    sgnDen = computeSign( sigma1, p0 + 1 )
+        ## compute sign of the 1st fraction in formula (9) of the paper 
+    # numerator
+    psi = i + phi + p_odd_index_sum 
+    num = (-1)**psi  
+    # denominator
+    den = sgnDen
+        # the sign of the determinant depends on sign(num / den) != 0
+    if  sign(num / den) > 0:
+        subresL.append( a2 )
+    else:
+        subresL.append( -a2 )
+        # update AMV variables
+    if p1 % 2 == 1:
+        s += 1       
+    ## bring in the missing power of sigma if there was gap
+    if p1 - 1 > 0:
+        sgnDen = sgnDen * computeSign( sigma1, p1 - 1 )
+
+    while d2 >= 1:
+        phi = floor( (s + 1) / 2 )
+        if i%2 == 1: 
+            p_odd_index_sum += p1             # p_i has odd index
+        a0, a1, d0, d1 = a1, a2, d1, d2       # update polys and degrees
+        p0 = p1                               # update degree difference
+        i += 1
+
+        sigma0 = -LC(a0)
+        c = (sigma0**(degdifP1 - 1)) / (c**(degdifP1 - 2))
+        degdifP1 = degree(a0, x) - d2 + 1
+        a2 = remZ(a0, a1, x) / Abs( ((c**(degdifP1 - 1)) * sigma0) )
+        sigma3 =  LC(a2, x)                   # leading coeff of a2
+        d2 =  degree(a2, x)                   # actual degree of a2
+        p1 = d1 - d2                          # degree difference
+        psi = i + phi + p_odd_index_sum
+        # update variables 
+        sigma1, sigma2 = sigma2, sigma3       
+        # new sgnDen
+        sgnDen = computeSign( sigma1, p0 + 1 ) * sgnDen            
+        ## compute the sign of the first fraction in formula (9) of the paper
+        # numerator 
+        num = (-1)**psi     
+        # denominator 
+        den = sgnDen
+         
+        # the sign of the determinant depends on sign( num / den ) != 0          
+        if  sign(num / den) > 0:
+            subresL.append( a2 )
+        else:
+            subresL.append( -a2 )
+        
+        # update AMV variables
+        if p1 % 2 ==1:
+            s += 1        
+        ## bring in the missing power of sigma if there was gap
+        if p1 - 1 > 0:       
+            sgnDen = sgnDen * computeSign( sigma1, p1 - 1 )
+        
+    # gcd is of degree > 0 ?   
+    m = len(subresL)
+    if subresL[m - 1] == nan or subresL[m - 1] == 0:
+        subresL.pop(m - 1)
+
+    return subresL
+
+def modified_subresultants_AMV(p,q,x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the modified subresultant prs of p and q in Z[x] or Q[x], 
+    from the subresultant prs of p and q.
+    The coefficients of the polynomials in the two sequences differ only 
+    in sign and a power of the absolute value of the leading coefficient 
+    of p, as stated in Theorem 2 of the reference.
+
+    The coefficients of the polynomials in the output sequence are 
+    modified subresultants. That is, they are  determinants of appropriately 
+    selected submatrices of sylvester2, Sylvester's matrix of 1853. 
+  
+    If the modified subresultant prs is complete, then it coincides with the 
+    (generalized) Sturm's sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders 
+    Obtained in Finding the Greatest Common Divisor of Two Polynomials.'' 
+    Serdica Journal of Computing, to appear.
+    
+    """
+    # compute the subresultant prs 
+    lst = subresultants_AMV(p,q,x)     ## or lst = subresultants_AMV_Q(p, q, x)
+
+    # defensive
+    if lst == [] or len(lst) == 2:
+        return lst
+
+    # the coefficients in lst are subresultants and, hence, smaller than those 
+    # of the corresponding modified subresultants by the factor 
+    # Abs(LC(lst[0])**( deg(lst[0]) - deg(lst[1]))); see Theorem 2.
+    lcf = Abs( LC(lst[0])**( degree(lst[0]) - degree(lst[1]) ) )
+
+    # Initialize the modified subresultant prs list 
+    subrSeq = [lst[0], lst[1]]
+
+    # compute the degree sequences m_i and j_i of Theorem 2
+    degSeq = [degree(Poly(poly, x)) for poly in lst]
+    deg = degSeq[0]
+    degSeqS = degSeq[1:-1]
+    mSeq = [m-1 for m in degSeqS]
+    jSeq = [deg - m for m in mSeq]
+    
+    # compute the AMV factors of Theorem 2
+    fact = [(-1)**( j*(j-1)/S(2) ) for j in jSeq]
+
+    # shortened list without the first two polys
+    lstS = lst[2:]
+
+    # poly lstS[k] is multiplied times fact[k] and times lcf
+    # and appended to the subresultant prs list
+    m = len(fact)
+    for k in range(m):
+        if sign(fact[k]) == -1:
+            subrSeq.append( simplify(-lstS[k] * lcf) )
+        else:
+            subrSeq.append( simplify(lstS[k] * lcf) )
+    return subrSeq
+
+def correctSign(degF, degG, S1, rdel, cdel):
+    """
+    Used in various subresultant prs algorithms.
+
+    Evaluates the determinant, (a.k.a. subresultant) of a properly selected
+    submatrix of S1, Sylvester's matrix of 1840, to get the correct sign 
+    and value of the leading coefficient of a given polynomial remainder.
+
+    degF, degG are the degrees of the original polynomials p, q for which the
+    matrix S1 = sylvester(p, q, x, 1) was constructed.
+    
+    rdel denotes the expected degree of the remainder; it is the number of 
+    rows to be deleted from each group of rows in S1 as described in the 
+    reference below.
+
+    cdel denotes the expected degree minus the actual degree of the remainder; 
+    it is the number of columns to be deleted --- starting with the last column 
+    forming the square matrix --- from the matrix resulting after the row deletions.
+
+    References:
+    ===========
+    Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences 
+    and Modified Subresultant Polynomial Remainder Sequences.'' 
+    Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014. 
+
+    """
+    M = S1[:, :]   # copy of matrix S1
+
+    # eliminate rdel rows from the first degG rows
+    for i in range(M.rows - degF - 1, M.rows - degF - rdel - 1, -1):
+        M.row_del(i)
+    
+    # eliminate rdel rows from the last degF rows
+    for i in range(M.rows - 1, M.rows - rdel - 1, -1):
+        M.row_del(i)
+
+    # eliminate cdel columns
+    for i in range(cdel):
+        M.col_del(M.rows - 1)
+    
+    # define submatrix        
+    Md = M[:, 0: M.rows]
+
+    return Md.det()
+
+def subresultants_rem(p, q, x):
+    """
+    p, q are polynomials in Z[x] or Q[x].
+
+    Computes the subresultant prs of p and q in Z[x] or Q[x]; 
+    the coefficients of the polynomials in the sequence are 
+    subresultants. That is, they are  determinants of appropriately 
+    selected submatrices of sylvester1, Sylvester's matrix of 1840. 
+
+    To compute the coefficients polynomial divisions in Q[x] are 
+    performed, using the function rem(p, q, x). The coefficients 
+    of the remainders computed this way become subresultants by evaluating
+    one subresultant per remainder --- that of the leading coefficient. 
+    This way we obtain the correct sign and value of the leading coefficient 
+    of the remainder and we easily ``force'' the rest of the coefficients 
+    to become subresultants.
+   
+    If the subresultant prs is complete, then it coincides with the 
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========  
+    1. Akritas, A. G.:``Three New Methods for Computing Subresultant 
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
+    to appear.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    f, g = p, q
+
+    n = degF = degree(f, x)
+    m = degG = degree(g, x)
+
+    # make sure proper degrees
+    if n == 0 and m == 0:
+        return []
+    if n > 0 and m == 0:
+        return [f, g]
+    if n < m:
+        n, m, degF, degG, f, g = m, n, degG, degF, g, f
+
+    S1 = sylvester(f, g, x, 1)
+    SR_list = [f, g]      # subresultant list
+
+    
+    while degG > 0:
+        # compute the remainder in Z[x] by doing division in Z[x]
+        r = rem(p, q, x)        
+        # actual degree
+        d = degree(r, x)
+        # deg(0) == -oo
+        if d == -oo:
+            return SR_list
+        # expected degree
+        expDeg = degG - 1
+        # make coefficients subresultants
+        # by evaluating ONE determinant
+        signValue = correctSign(n, m, S1, expDeg, expDeg - d)
+        r = simplify((r / LC(r, x)) * signValue)
+
+        # append poly with subresultant coeffs
+        SR_list.append(r)
+                    
+        # update degrees and polys
+        degF, degG = degG, d
+        p, q = q, r
+        
+    # gcd is of degree > 0 ? 
+    m = len(SR_list)
+    if SR_list[m - 1] == nan or SR_list[m - 1] == 0:
+        SR_list.pop(m - 1)
+
+    return SR_list
+
+def pivot(M, i, j):
+    ''' 
+    M is a matrix, and M[i, j] specifies the pivot element.
+    
+    All elements below M[i, j], in the j-th column, will       
+    be zeroed, if they are not already 0, according to       
+    Dodgson-Bareiss' integer preserving transormation. 
+
+    References:
+    ===========
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest 
+    common divisors and polynomial remainder sequences.''  
+    Numerische Mathematik 52, 119-127, 1988.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
+    by Van Vleck Regarding Sturm Sequences.'' 
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
+
+    '''
+    Ma = M[:, :] # copy of matrix M
+    rs = Ma.rows # No. of rows
+    cs = Ma.cols # No. of cols
+    for r in range(i+1, rs):
+        if Ma[r, j] != 0:
+            for c in range(j + 1, cs):
+                Ma[r, c] = Ma[i, j] * Ma[r, c] - Ma[i, c] * Ma[r, j]
+            Ma[r, j] = 0
+    return Ma
+
+def rotateR(L, k):
+    ''' 
+    Rotates right by k. L is a row of a matrix or a list.
+ 
+    '''
+    LL = list(L)
+    if LL == []:
+        return []
+    for i in range(k):
+        el = LL.pop(len(LL) - 1)
+        LL.insert(0, el)
+    return LL if type(L) is list else Matrix([LL])
+
+def rotateL(L, k):
+    ''' 
+    Rotates left by k. L is a row of a matrix or a list.
+
+    '''
+    LL = list(L)
+    if LL == []:
+        return []
+    for i in range(k):
+        el = LL.pop(0)
+        LL.insert(len(LL) - 1, el)
+    return LL if type(L) is list else Matrix([LL])
+
+
+def row2poly(row, deg, x):
+    '''
+    Converts the row of a matrix to a poly of degree deg and variable x.    
+    Some entries at the beginning and/or at the end of the row may be zero.
+
+    '''
+    k = 0
+    poly = []
+    leng = len(row)
+    
+    # find the beginning of the poly ; i.e. the first non-    
+    # zero element of the row
+    while row[k] == 0:
+        k = k + 1
+    
+    # append the next deg + 1 elements to poly
+    for j in range( deg + 1):
+        if k + j <= leng:
+            poly.append(row[k + j])
+
+    return Poly(poly, x)        
+    
+def createM(degF, degG, row1, row2, colNum):
+    '''
+    Creates a ``small'' matrix M to be triangularized.
+    
+    degF, degG are the degrees of the divident and of the 
+    divisor polynomials respectively, degG > degF.
+    
+    The coefficients of the divident poly are the elements  
+    in row2 and those of the divisor poly are the elements 
+    in row1.
+    
+    colNum indicates the number of columns of the matrix M.
+
+    '''
+    if degG - degF >= 1:
+        return "ERROR! Reverse input degrees"
+        # print "ERROR! Reverse input degrees"
+        # return
+
+    M = zeros(degF - degG + 2, colNum)
+    
+    for i in range(degF - degG + 1):
+        M[i, :] = rotateR(row1, i)
+    M[degF - degG + 1, :] = row2
+
+    return M
+
+
+def findDegree(M, degF):
+    '''
+    Finds the degree of the poly corresponding 
+    to the _last_ row of the ``small'' matrix M.
+
+    degF is the degree of the divident poly.
+
+    If row is all 0's returns None.
+
+    '''
+    j = degF
+    for i in range(0, M.cols):
+        if M[M.rows - 1, i] == 0:
+            j = j - 1
+        else:
+            return j if j >= 0 else 0
+
+def subresultants_VanVleck(p, q, x, method = 0):
+    """
+    p, q are polynomials in Z[x] (intended) or Q[x].
+
+    Computes the subresultant prs of p, q by triangularizing,
+    in Z[x] or in Q[x], sylvester2, Sylvester's matrix of 1853.
+    See references 1 and 2 for Van Vleck's method. 
+
+    Use this version if sylvester2 has small dimensions; otherwise,
+    use the second version, subresultants_VanVleck2(p, q, x),
+    where sylvester2 is used implicitly.
+
+    Sylvester's matrix sylvester1  is also used to compute one 
+    subresultant per remainder; namely, that of the leading 
+    coefficient, in order to obtain the correct sign and to  
+    force the remainder coefficients to become subresultants.
+    
+    If the dimensions of sylvester2 are big use method=0 to not 
+    print the final, triangularized matrix sylvester2. 
+    Use method=1 to print the final matrix.
+
+    If the subresultant prs is complete, then it coincides with the 
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest 
+    common divisors and polynomial remainder sequences.''  
+    Numerische Mathematik 52, 119-127, 1988.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
+    by Van Vleck Regarding Sturm Sequences.'' 
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
+
+    3. Akritas, A. G.:``Three New Methods for Computing Subresultant 
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
+    to appear.
+
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    f, g = p, q
+
+    n = degF = degree(f, x)
+    m = degG = degree(g, x)
+
+    # make sure proper degrees
+    if n == 0 and m == 0:
+        return []
+    if n > 0 and m == 0:
+        return [f, g]
+    if n < m:
+        n, m, degF, degG, f, g = m, n, degG, degF, g, f
+
+    S1 = sylvester(f, g, x, 1)
+    S2 = sylvester(f, g, x, 2)
+
+    SR_list = [f, g]      # subresultant list
+    colNum = 2 * n
+                
+    row0 = Poly(f, x, domain = QQ).all_coeffs()
+    leng0 = len(row0)
+    for i in range(colNum - leng0):
+        row0.append(0)
+    row0 = Matrix([row0])
+
+    row1 = Poly(g,x, domain = QQ).all_coeffs()
+    leng1 = len(row1)
+    for i in range(colNum - leng1):
+        row1.append(0)
+    row1 = Matrix([row1]) 
+    
+    r = 2    
+    if degF - degG > 1:
+        # Several last rows in S2 will remain unprocessed
+        # Same thing happens when gcd is of deg > 0        
+        r = 1
+        # insert first poly shifted degF - degG - 1 times
+        for i in range(degF - degG - 1):
+            S2 = S2.row_insert(i + 1, rotateR(row0, i + 1) )
+            r = r + 1
+        # insert second poly shifted degF - degG times
+        for i in range(degF - degG):
+            S2 = S2.row_insert(r + i, rotateR(row1, r + i) )
+        r = r + degF - degG
+
+    if degF - degG == 0:
+        # the first poly will disappear from S2
+        r = 0
+   
+    while degG > 0:
+        
+        M = createM(degF, degG, row1, row0, colNum)
+        
+        # pivot as many times as needed
+        for i in range(degF - degG + 1):
+            M1 = pivot(M, i, i)
+            M = M1[:, :]
+            
+        d = findDegree(M, degF)
+        if d == None:
+            if method != 0:
+                pprint(S2)
+            return SR_list
+        expDeg = degG - 1
+
+        # compute subresultant & make poly coeffs subresultants
+        poly = row2poly(M[M.rows - 1, :], d, x)
+        signValue = correctSign(n, m, S1, expDeg, expDeg - d)
+        temp2 = LC(poly, x)
+        poly = simplify((poly / LC(poly, x)) * signValue)
+        
+        # update S2
+        for i in range(degG - d):
+            # insert first row of M
+            S2[r + i, :] = rotateR(M[0, :], r + i)
+        r = r + degG - d
+        row0 = M[0, :]   
+
+        row1 = rotateL(M[M.rows - 1, :], degF - d)
+        row1 = (row1 / temp2) * signValue
+        for i in range(degG - d):
+            # insert last row of M
+            S2[r + i, :] = rotateR(row1, r + i)
+        r = r + degG - d
+
+        # update degrees 
+        degF, degG = degG, d
+        # append poly with subresultant coeffs
+        SR_list.append(poly)
+                    
+    if method != 0:
+        pprint(S2)
+    return SR_list
+
+def subresultants_VanVleck2(p, q, x):
+    """
+    p, q are polynomials in Z[x] (intended) or Q[x].
+
+    Computes the subresultant prs of p, q by triangularizing, 
+    in Z[x] or in Q[x], all the smaller matrices encountered in the 
+    process of triangularizing sylvester2, Sylvester's matrix of 1853. 
+    See references 1 and 2 for Van Vleck's method. 
+
+    If the sylvester2 matrix has big dimensions use this version,
+    where sylvester2 is used implicitly. If you want to see the final,
+    triangularized matrix sylvester2, then use the first version,
+    subresultants_VanVleck(p, q, x).
+
+    sylvester1, Sylvester's matrix of 1840, is also used to compute 
+    one subresultant per remainder; namely, that of the leading 
+    coefficient, in order to obtain the correct sign and to  
+    ``force'' the remainder coefficients to become subresultants.
+    
+    If the subresultant prs is complete, then it coincides with the 
+    Euclidean sequence of the polynomials p, q.
+
+    References:
+    ===========
+    1. Akritas, A. G.: ``A new method for computing polynomial greatest 
+    common divisors and polynomial remainder sequences.''  
+    Numerische Mathematik 52, 119-127, 1988.
+
+    2. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem 
+    by Van Vleck Regarding Sturm Sequences.'' 
+    Serdica Journal of Computing, 7, No 4, 101–134, 2013. 
+
+    3. Akritas, A. G.:``Three New Methods for Computing Subresultant 
+    Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing, 
+    to appear.
+
+    """
+    # make sure neither p nor q is 0
+    if p == 0 or q == 0:
+        return [p, q]
+
+    f, g = p, q
+
+    n = degF = degree(f, x)
+    m = degG = degree(g, x)
+
+    # make sure proper degrees
+    if n == 0 and m == 0:
+        return []
+    if n > 0 and m == 0:
+        return [f, g]
+    if n < m:
+        n, m, degF, degG, f, g = m, n, degG, degF, g, f
+
+    S1 = sylvester(f, g, x, 1)
+
+    SR_list = [f, g]      # subresultant list
+    # cols of sylvester2
+    colNum = 2 * n
+
+    row0 = Poly(f, x, domain = QQ).all_coeffs()
+    leng0 = len(row0)
+    for i in range(colNum - leng0):
+        row0.append(0)
+    row0 = Matrix([row0])
+
+    row1 = Poly(g,x, domain = QQ).all_coeffs()
+    leng1 = len(row1)
+    for i in range(colNum - leng1):
+        row1.append(0)
+    row1 = Matrix([row1])
+    
+    while degG > 0:
+        
+        M = createM(degF, degG, row1, row0, colNum)
+            
+        for i in range(degF - degG + 1):
+            M1 = pivot(M, i, i)
+            M = M1[:, :]
+            
+        d = findDegree(M, degF)
+        if d == None:
+            return SR_list
+        expDeg = degG - 1
+        # make entries of S2[r + 1, :] subresultants
+        poly = row2poly(M[M.rows - 1, :], d, x)
+        signValue = correctSign(n, m, S1, expDeg, expDeg - d)
+        poly = simplify((poly / LC(poly, x)) * signValue)
+
+        # append poly with subresultant coeffs
+        SR_list.append(poly)
+                    
+        # update degrees and rows
+        degF, degG = degG, d
+        row0 = row1
+        row1 = Poly(poly, x, domain = QQ).all_coeffs()
+        leng1 = len(row1)
+        for i in range(colNum - leng1):
+            row1.append(0)
+        row1 = Matrix([row1])
+
+    return SR_list
+ 
+

--- a/sympy/subresultants_pg_amv.py
+++ b/sympy/subresultants_pg_amv.py
@@ -7,8 +7,6 @@ Created on Mon Dec 28 13:25:02 2015
 
 from __future__ import print_function, division
 
-# from sympy import *
-
 def sylvester(f, g, x, method = 1):
     '''
       f, g polys in x, m = deg(f) >= deg(g) = n.
@@ -1621,10 +1619,7 @@ def subresultants_vv(p, q, x, method = 0):
         # treat last row of M as poly; find its degree
         d = find_degree(M, deg_f)
         if d == None:
-            if method != 0:
-                s2 = final_touches(s2, r, deg_g)
-                pprint(s2)
-            return sr_list
+            break
         exp_deg = deg_g - 1
 
         # evaluate one determinant & make coefficients subresultants
@@ -1652,7 +1647,12 @@ def subresultants_vv(p, q, x, method = 0):
         # append poly with subresultant coeffs
         sr_list.append(poly)
 
-    if method != 0:
+    # final touches to print the s2 matrix
+    if method != 0 and s2.rows > 2:
+        s2 = final_touches(s2, r, deg_g)
+        pprint(s2)
+    elif method != 0 and s2.rows == 2:
+        s2[1, :] = rotate_r(s2.row(1), 1)
         pprint(s2)
 
     return sr_list


### PR DESCRIPTION
(a) euclidean/sturmian sequences in Q[x] and Z[x],
(b) subresultant polynomial sequences

It does NOT use the function prem which "messes up" the signs
in the euclidean/sturmian sequences. Instead it uses rem and remZ.
