### PR TITLE
check for integer case in polytools.invert

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -9,7 +9,7 @@ from .expr import Expr, AtomicExpr
 from .symbol import Symbol, Wild, Dummy, symbols, var
 from .numbers import Number, Float, Rational, Integer, NumberSymbol, \
     RealNumber, igcd, ilcm, seterr, E, I, nan, oo, pi, zoo, \
-    AlgebraicNumber, comp
+    AlgebraicNumber, comp, mod_inverse
 from .power import Pow, integer_nthroot
 from .mul import Mul, prod
 from .add import Add

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3067,9 +3067,7 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy.polys.polytools import invert
         from sympy.core.numbers import mod_inverse
-        from sympy.core.symbol import Symbol
-        if self.is_number and not \
-                getattr(g, 'has', lambda x: False)(Symbol):
+        if self.is_number and getattr(g, 'is_number', True):
             return mod_inverse(self, g)
         return invert(self, g, *gens, **args)
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3057,10 +3057,21 @@ class Expr(Basic, EvalfMixin):
         from sympy.polys import cancel
         return cancel(self, *gens, **args)
 
-    def invert(self, g):
-        """See the invert function in sympy.polys"""
-        from sympy.polys import invert
-        return invert(self, g)
+    def invert(self, g, *gens, **args):
+        """Return the multiplicative inverse of ``self`` mod ``g``
+        where ``self`` (and ``g``) may be symbolic expressions).
+
+        See Also
+        ========
+        sympy.core.numbers.mod_inverse, sympy.polys.polytools.invert
+        """
+        from sympy.polys.polytools import invert
+        from sympy.core.numbers import mod_inverse
+        from sympy.core.symbol import Symbol
+        if self.is_number and not \
+                getattr(g, 'has', lambda x: False)(Symbol):
+            return mod_inverse(self, g)
+        return invert(self, g, *gens, **args)
 
     def round(self, p=0):
         """Return x rounded to the given decimal place.

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -243,6 +243,63 @@ def igcdex(a, b):
     return (x*x_sign, y*y_sign, a)
 
 
+def mod_inverse(a, m):
+    """
+    Return the number c such that, ( a * c ) % m == 1 where
+    c has the same sign as a. If no such value exists, a
+    ValueError is raised.
+
+    Examples
+    ========
+
+    >>> from sympy import S
+    >>> from sympy.core.numbers import mod_inverse
+
+    Suppose we wish to find multiplicative inverse x of
+    3 modulo 11. This is the same as finding x such
+    that 3 * x = 1 (mod 11). One value of x that satisfies
+    this congruence is 4. Because 3 * 4 = 12 and 12 = 1 mod(11).
+    This is the value return by mod_inverse:
+
+    >>> mod_inverse(3, 11)
+    4
+    >>> mod_inverse(-3, 11)
+    -4
+
+    When there is a commono factor between the numerators of
+    ``a`` and ``m`` the inverse does not exist:
+
+    >>> mod_inverse(2, 4)
+    Traceback (most recent call last):
+    ...
+    ValueError: inverse of 2 mod 4 does not exist
+
+    >>> mod_inverse(S(2)/7, S(5)/2)
+    7/2
+
+    References
+    ==========
+    - https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
+    - https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
+    """
+    c = None
+    try:
+        a, m = as_int(a), as_int(m)
+        if m > 1:
+            x, y, g = igcdex(a, m)
+            if g == 1:
+                c = x % m
+            if a < 0:
+                c -= m
+    except ValueError:
+        a, m = sympify(a), sympify(m)
+        if not m.is_number or m > 1:
+            c = 1/a
+    if c is None:
+        raise ValueError('inverse of %s (mod %s) does not exist' % (a, m))
+    return c
+
+
 class Number(AtomicExpr):
     """
     Represents any kind of number in sympy.
@@ -286,6 +343,9 @@ class Number(AtomicExpr):
                 return obj
         msg = "expected str|int|long|float|Decimal|Number object but got %r"
         raise TypeError(msg % type(obj).__name__)
+
+    def invert(self, other, *gens, **args):
+        return mod_inverse(self, other)
 
     def __divmod__(self, other):
         from .containers import Tuple

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2,7 +2,7 @@ import decimal
 from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
-                   AlgebraicNumber, simplify)
+                   AlgebraicNumber, simplify, sin)
 from sympy.core.compatibility import long, u
 from sympy.core.power import integer_nthroot
 from sympy.core.logic import fuzzy_not
@@ -1541,5 +1541,7 @@ def test_mod_inverse():
     assert mod_inverse(2, 5) == 3
     assert mod_inverse(-2, 5) == -3
     x = Symbol('x')
-    assert mod_inverse(2, x) == S(1)/2
+    assert S(2).invert(x) == S.Half
+    raises(TypeError, lambda: mod_inverse(2, x))
     raises(ValueError, lambda: mod_inverse(2, S.Half))
+    raises(ValueError, lambda: mod_inverse(2, cos(1)**2 + sin(1)**2))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -7,7 +7,7 @@ from sympy.core.compatibility import long, u
 from sympy.core.power import integer_nthroot
 from sympy.core.logic import fuzzy_not
 from sympy.core.numbers import (igcd, ilcm, igcdex, seterr, _intcache,
-    mpf_norm, comp)
+    mpf_norm, comp, mod_inverse)
 from mpmath import mpf
 from sympy.utilities.pytest import XFAIL, raises
 import mpmath
@@ -1518,3 +1518,28 @@ def test_issue_10020():
     assert (-oo)**(-1 + I) is S.Zero
     assert oo**t == Pow(oo, t, evaluate=False)
     assert (-oo)**t == Pow(-oo, t, evaluate=False)
+
+
+def test_invert_numbers():
+    assert S(2).invert(5) == 3
+    assert S(2).invert(S(5)/2) == S.Half
+    assert S(2).invert(5.) == 3
+    assert S(2).invert(S(5)) == 3
+    assert S(2.).invert(5) == 3
+    assert S(sqrt(2)).invert(5) == 1/sqrt(2)
+    assert S(sqrt(2)).invert(sqrt(3)) == 1/sqrt(2)
+
+
+def test_mod_inverse():
+    assert mod_inverse(3, 11) == 4
+    assert mod_inverse(5, 11) == 9
+    assert mod_inverse(21124921, 521512) == 7713
+    assert mod_inverse(124215421, 5125) == 2981
+    assert mod_inverse(214, 12515) == 1579
+    assert mod_inverse(5823991, 3299) == 1442
+    assert mod_inverse(123, 44) == 39
+    assert mod_inverse(2, 5) == 3
+    assert mod_inverse(-2, 5) == -3
+    x = Symbol('x')
+    assert mod_inverse(2, x) == S(1)/2
+    raises(ValueError, lambda: mod_inverse(2, S.Half))

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core.numbers import igcdex, igcd
 from sympy.core.mul import prod
+from sympy.core.sympify import sympify
 from sympy.core.compatibility import as_int, reduce
 from sympy.ntheory.primetest import isprime
 from sympy.polys.domains import ZZ
@@ -250,50 +251,3 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         if symmetric:
             return symmetric_residue(n, m), m
         return n, m
-
-
-def mod_inverse(a, m):
-    """
-    Return the number c such that, ( a * c ) % m == 1.
-    This means that if a is multiplied by c
-    then the remainder obtained on division with m is 1.
-    The value of m need not be a prime.
-    Return the value of c if some c exists.
-    Otherwise, raise an exception stating that the
-    modular inverse does not exist.
-
-    Examples
-    ========
-
-    >>> from sympy.ntheory.modular import mod_inverse
-    >>> mod_inverse(3,11)
-    4
-
-    Suppose we wish to find multiplicative inverse x of
-    3 modulo 11. This is the same as finding x such
-    that 3 * x = 1 (mod 11). One value of x that satisfies
-    this congruence is 4. Because 3 * 4 = 12 and 12 = 1 mod(11).
-
-    Similarly
-
-    >>> mod_inverse(5,11)
-    9
-
-    Exception Cases
-
-    >>> mod_inverse(2,4)
-    Traceback (most recent call last):
-    ...
-    ValueError: modular inverse does not exist
-
-    References
-    ==========
-    - https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
-    - https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
-    """
-    a, m = as_int(a), as_int(m)
-    x, y, g = igcdex(a, m)
-    if g != 1:
-        raise ValueError('modular inverse does not exist')
-    else:
-        return x % m

--- a/sympy/ntheory/tests/test_modular.py
+++ b/sympy/ntheory/tests/test_modular.py
@@ -1,4 +1,6 @@
-from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence, mod_inverse
+from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
+from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence
 from sympy.utilities.pytest import raises
 
 
@@ -32,13 +34,3 @@ def test_modular():
     assert solve_congruence(*list(zip((1, 1, 2), (3, 2, 4)))) is None
     raises(
         ValueError, lambda: solve_congruence(*list(zip([3, 4, 2], [12.1, 35, 17]))))
-
-def test_mod_inverse():
-    assert mod_inverse(3,11) == 4
-    assert mod_inverse(5,11) == 9
-    assert mod_inverse(21124921,521512) == 7713
-    assert mod_inverse(124215421,5125) == 2981
-    assert mod_inverse(214,12515) == 1579
-    assert mod_inverse(5823991,3299) == 1442
-    assert mod_inverse(123,44) == 39
-    assert mod_inverse(2,5) == 3

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -13,6 +13,7 @@ from sympy.core.relational import Relational
 from sympy.core.sympify import sympify
 from sympy.core.decorators import _sympifyit
 from sympy.core.function import Derivative
+from sympy.core.compatibility import as_int, SYMPY_INTS
 
 from sympy.logic.boolalg import BooleanAtom
 
@@ -4738,7 +4739,8 @@ def invert(f, g, *gens, **args):
     Examples
     ========
 
-    >>> from sympy import invert
+    >>> from sympy import invert, S
+    >>> from sympy.core.numbers import mod_inverse
     >>> from sympy.abc import x
 
     >>> invert(x**2 - 1, 2*x - 1)
@@ -4749,6 +4751,17 @@ def invert(f, g, *gens, **args):
     ...
     NotInvertible: zero divisor
 
+    For more efficient inversion of Rationals,
+    use the ``mod_inverse`` function:
+
+    >>> mod_inverse(3, 5)
+    2
+    >>> (S(2)/5).invert(S(7)/3)
+    5/2
+
+    See Also
+    ========
+    sympy.core.numbers.mod_inverse
     """
     options.allowed_flags(args, ['auto', 'polys'])
 
@@ -5611,7 +5624,8 @@ def _symbolic_factor_list(expr, opt, method):
     """Helper function for :func:`_symbolic_factor`. """
     coeff, factors = S.One, []
 
-    args = [i._eval_factor() if hasattr(i, '_eval_factor') else i for i in Mul.make_args(expr)]
+    args = [i._eval_factor() if hasattr(i, '_eval_factor') else i
+        for i in Mul.make_args(expr)]
     for arg in args:
         if arg.is_Number:
             coeff *= arg


### PR DESCRIPTION
This function is called because it is in the SymPy
'from sympy import *' namespace but when the arguments
are integers they can be handled more efficiently with
the mod_inverse routine.

This is about 50 times faster when handling ints.
