### PR TITLE
Simplification of an expression with exponent containing assumption symbol

### DIFF
--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -242,6 +242,8 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                 else:
                     c, m = e.as_coeff_Mul(rational=True)
                     if c is not S.One:
+                        if m.is_even or m.is_odd:
+                            return (b, Integer(c.q)), m*Integer(c.p)
                         return (b**m, Integer(c.q)), Integer(c.p)
                     else:
                         return (b**e, S.One), S.One

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -242,7 +242,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                 else:
                     c, m = e.as_coeff_Mul(rational=True)
                     if c is not S.One:
-                        if m.is_even or m.is_odd:
+                        if m.is_integer:
                             return (b, Integer(c.q)), m*Integer(c.p)
                         return (b**m, Integer(c.q)), Integer(c.p)
                     else:

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -285,6 +285,7 @@ def test_issue_from_PR1599():
 
 
 def test_issue_10195():
+    a = Symbol('a', integer=True)
     l = Symbol('l', even=True, nonzero=True)
     n = Symbol('n', odd=True)
     e_x = (-1)**(n/2 - Rational(1, 2)) - (-1)**(3*n/2 - Rational(1, 2))
@@ -293,3 +294,4 @@ def test_issue_10195():
     assert powsimp((-1)**(3*n/2)) == -I**n
     assert powsimp(e_x) == (-1)**(n/2 - Rational(1, 2)) + (-1)**(3*n/2 +
             Rational(1,2))
+    assert powsimp((-1)**(3*a/2)) == (-I)**a

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -1,6 +1,7 @@
 from sympy import (
     symbols, powsimp, symbols, MatrixSymbol, sqrt, pi, Mul, gamma, Function,
-    S, I, exp, simplify, sin, E, log, hyper, Symbol, Dummy, powdenest, root)
+    S, I, exp, simplify, sin, E, log, hyper, Symbol, Dummy, powdenest, root,
+    Rational)
 
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 
@@ -281,3 +282,14 @@ def test_issue_from_PR1599():
     assert (powsimp(root(n1, 3)*root(n2, 3)*root(n3, 3)*root(n4, 3)) ==
         -(-1)**(S(1)/3)*
         (-n1)**(S(1)/3)*(-n2)**(S(1)/3)*(-n3)**(S(1)/3)*(-n4)**(S(1)/3))
+
+
+def test_issue_10195():
+    l = Symbol('l', even=True, nonzero=True)
+    n = Symbol('n', odd=True)
+    e_x = (-1)**(n/2 - Rational(1, 2)) - (-1)**(3*n/2 - Rational(1, 2))
+    assert powsimp((-1)**(l/2)) == I**l
+    assert powsimp((-1)**(n/2)) == I**n
+    assert powsimp((-1)**(3*n/2)) == -I**n
+    assert powsimp(e_x) == (-1)**(n/2 - Rational(1, 2)) + (-1)**(3*n/2 +
+            Rational(1,2))


### PR DESCRIPTION
I don't know if these are the best changes but these seem to work good. On the basis of assumptions on symbols provided.

(As a side note: i have not seen skirpichev's commit code, so if there is any similarity in code, then that is a mere coincidence)

fixes #10195 
Also i am first time making a PR on github "itself".

[Edit]: Also no need to make `n = Symbol('n', odd=True)` with `nonzero=True`, i.e is automatically true.
