### PR TITLE
Fix is_imaginary for z**n with n.is_negative

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -485,7 +485,12 @@ class Pow(Expr):
 
         if self.base.is_real is False:  # we already know it's not imag
             i = arg(self.base)*self.exp/S.Pi
-            return (2*i).is_odd
+            isodd = (2*i).is_odd
+            if isodd is not None:
+                return isodd
+
+        if self.exp.is_negative:
+            return (1/self).is_imaginary
 
     def _eval_is_odd(self):
         if self.exp.is_integer:

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1000,3 +1000,6 @@ def test_issue_10302():
     assert (a + I).is_imaginary
     assert (a + x + I).is_imaginary is None
     assert (a + r*I + I).is_imaginary is None
+
+def test_complex_reciprocal_imaginary():
+    assert (1 / (4 + 3*I)).is_imaginary is False


### PR DESCRIPTION
Currently (1/(4+3*I)).is_imaginary returns None.

Since z is imaginary iff 1/z is imaginary this patch adds a fallback to Pow.is_imaginary. If the other checks are inconclusive and the exponent is negative then it will check to see if 1/self is_imaginary.
