### PR TITLE
Extend the guess_generating_function in sympy.concrete.guess (more types of g.f.).

### DIFF
--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -209,16 +209,23 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
     Only a few patterns are implemented yet.
 
     The function returns a dictionary where keys are the name of a given type of
-    generating function (the most basic type being 'ogf'). Currently implemented
-    types are: 'ogf' (ordinary g.f.), 'egf' (exponential g.f.), 'lgf'
-    (logarithmic g.f.), 'hlgf' (hyperbolic logarithmic g.f.), 'lgdogf'
-    (logarithmic derivative of generating function), 'lgdegf' (logarithmic
-    derivative of exponential generating function).
+    generating function. Six types are currently implemented:
+
+         type  |  formal definition
+        -------+----------------------------------------------------------------
+        ogf    | f(x) = Sum(            a_k * x^k       ,  k: 0..infinity )
+        egf    | f(x) = Sum(            a_k * x^k / k!  ,  k: 0..infinity )
+        lgf    | f(x) = Sum( (-1)^(k+1) a_k * x^k / k   ,  k: 1..infinity )
+               |        (with initial index being hold as 1 rather than 0)
+        hlgf   | f(x) = Sum(            a_k * x^k / k   ,  k: 1..infinity )
+               |        (with initial index being hold as 1 rather than 0)
+        lgdogf | f(x) = derivate( log(Sum( a_k * x^k, k: 0..infinity )), x)
+        lgdegf | f(x) = derivate( log(Sum( a_k * x^k / k!, k: 0..infinity )), x)
 
     In order to spare time, the user can select only some types of generating
     functions (default being ['all']). While forgetting to use a list in the
     case of a single type may seem to work most of the time as in: types='ogf'
-    this (convenient) syntax may leed to unexpected extra results in some cases.
+    this (convenient) syntax may lead to unexpected extra results in some cases.
 
     Discarding a type when calling the function does not mean that the type will
     not be present in the returned dictionary; it only means that no extra

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -222,8 +222,8 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
 
     Discarding a type when calling the function does not mean that the type will
     not be present in the returned dictionary; it only means that no extra
-    computation will be performed for that type but the function may still add
-    it whenever it can be easily computed from another type.
+    computation will be performed for that type, but the function may still add
+    it in the result when it can be easily converted from another type.
 
     Two generating functions (lgdogf and lgdegf) are not even computed if the
     initial term of the sequence is 0; it may be useful in that case to try
@@ -234,7 +234,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
 
     >>> from sympy.concrete.guess import guess_generating_function as ggf
     >>> ggf([k+1 for k in range(12)], types=['ogf', 'lgf', 'hlgf'])
-    {'hlgf': 1/(-x + 1), 'lgf': 1/(x + 1), 'ogf': 1/(x**2 - 2*x + 1)}
+    {'hlgf': 1/(-x + 1), 'lgf': -1/(x + 1), 'ogf': 1/(x**2 - 2*x + 1)}
 
     >>> from sympy import sympify
     >>> l = sympify("[3/2, 11/2, 0, -121/2, -363/2, 121]")
@@ -301,7 +301,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
     # Logarithmic Generating Function (lgf)
     if 'lgf' in types:
         # Transform sequence (multiplication by (-1)^(n+1) / n)
-        w, f = [], Integer(-1)
+        w, f = [], Integer(1)
         for i, k in enumerate(v):
             f = -f
             w.append(f*k/Integer(i+1))

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -9,7 +9,7 @@ from sympy.core.numbers import Zero
 from sympy import sympify, floor, sqrt, lcm, denom, Integer, Rational
 
 @public
-def find_simple_recurrence_vector(l, maxcoeff=1024):
+def find_simple_recurrence_vector(l):
     """
     This function is used internally by other functions from the
     sympy.concrete.guess module. While most users may want to rather use the
@@ -76,7 +76,7 @@ def find_simple_recurrence_vector(l, maxcoeff=1024):
     return [0]
 
 @public
-def find_simple_recurrence(v, A=Function('a'), N=Symbol('n'), maxcoeff=1024):
+def find_simple_recurrence(v, A=Function('a'), N=Symbol('n')):
     """
     Detects and returns a recurrence relation from a sequence of several integer
     (or rational) terms. The name of the function in the returned expression is
@@ -98,7 +98,7 @@ def find_simple_recurrence(v, A=Function('a'), N=Symbol('n'), maxcoeff=1024):
     -8*f(i) + 3*f(i + 1) - 5*f(i + 2) + f(i + 3)
 
     """
-    p = find_simple_recurrence_vector(v, maxcoeff=maxcoeff)
+    p = find_simple_recurrence_vector(v)
     n = len(p)
     if n <= 1: return Zero()
 
@@ -171,7 +171,7 @@ def rationalize(x, maxcoeff=10000):
 
 
 @public
-def guess_generating_function_rational(v, X=Symbol('x'), maxcoeff=1024):
+def guess_generating_function_rational(v, X=Symbol('x')):
     """
     Tries to "guess" a rational generating function for a sequence of rational
     numbers v.
@@ -191,7 +191,7 @@ def guess_generating_function_rational(v, X=Symbol('x'), maxcoeff=1024):
 
     """
     #   a) compute the denominator as q
-    q = find_simple_recurrence_vector(v, maxcoeff=maxcoeff)
+    q = find_simple_recurrence_vector(v)
     n = len(q)
     if n <= 1: return None
     #   b) compute the numerator as p
@@ -202,8 +202,7 @@ def guess_generating_function_rational(v, X=Symbol('x'), maxcoeff=1024):
 
 
 @public
-def guess_generating_function(v, X=Symbol('x'), types=['all'],
-                              maxcoeff=1024, maxsqrtn=2):
+def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
     """
     Tries to "guess" a generating function for a sequence of rational numbers v.
     Only a few patterns are implemented yet.
@@ -214,7 +213,9 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'],
     (logarithmic g.f.), 'hlgf' (hyperbolic logarithmic g.f.).
 
     In order to spare time, the user can select only some types of generating
-    functions (default being ['all']).
+    functions (default being ['all']). While forgetting to use a list in the
+    case of a single type may seem to work most of the time as in: types='ogf'
+    this (convenient) syntax may leed to unexpected extra results in some cases.
 
     Examples
     ========
@@ -246,6 +247,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'],
     References
     ==========
     "Concrete Mathematics", R.L. Graham, D.E. Knuth, O. Patashnik
+    https://oeis.org/wiki/Generating_functions
 
     """
     # List of all types of all g.f. known by the algorithm
@@ -260,7 +262,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'],
         t = [1 if k==0 else 0 for k in range(len(v))]
         for d in range(max(1, maxsqrtn)):
             t = [sum(t[n-i]*v[i] for i in range(n+1)) for n in range(len(v))]
-            g = guess_generating_function_rational(t, X=X, maxcoeff=maxcoeff)
+            g = guess_generating_function_rational(t, X=X)
             if g:
                 result['ogf'] = g**Rational(1, d+1)
                 break
@@ -276,7 +278,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'],
         t = [1 if k==0 else 0 for k in range(len(w))]
         for d in range(max(1, maxsqrtn)):
             t = [sum(t[n-i]*w[i] for i in range(n+1)) for n in range(len(w))]
-            g = guess_generating_function_rational(t, X=X, maxcoeff=maxcoeff)
+            g = guess_generating_function_rational(t, X=X)
             if g:
                 result['egf'] = g**Rational(1, d+1)
                 break
@@ -292,7 +294,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'],
         t = [1 if k==0 else 0 for k in range(len(w))]
         for d in range(max(1, maxsqrtn)):
             t = [sum(t[n-i]*w[i] for i in range(n+1)) for n in range(len(w))]
-            g = guess_generating_function_rational(t, X=X, maxcoeff=maxcoeff)
+            g = guess_generating_function_rational(t, X=X)
             if g:
                 result['lgf'] = g**Rational(1, d+1)
                 break
@@ -307,7 +309,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'],
         t = [1 if k==0 else 0 for k in range(len(w))]
         for d in range(max(1, maxsqrtn)):
             t = [sum(t[n-i]*w[i] for i in range(n+1)) for n in range(len(w))]
-            g = guess_generating_function_rational(t, X=X, maxcoeff=maxcoeff)
+            g = guess_generating_function_rational(t, X=X)
             if g:
                 result['hlgf'] = g**Rational(1, d+1)
                 break

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -249,6 +249,9 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
     >>> ggf([factorial(k) for k in range(12)], types=['ogf', 'egf', 'lgf'])
     {'egf': 1/(-x + 1)}
 
+    >>> ggf([k+1 for k in range(12)], types=['egf'])
+    {'egf': (x + 1)*exp(x), 'lgdegf': (x + 2)/(x + 1)}
+
     N-th root of a rational function can also be detected (below is an example
     coming from the sequence A108626 from http://oeis.org ).
     The greatest n-th root to be tested is specified as maxsqrtn (default 2).
@@ -327,7 +330,8 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
                 break
 
     # Logarithmic derivative of ordinary generating Function (lgdogf)
-    if 'lgdogf' in types and v[0] != 0:
+    if v[0] != 0 and ('lgdogf' in types
+                       or ('ogf' in types and 'ogf' not in result)):
         # Transform sequence by computing f'(x)/f(x)
         # because log(f(x)) = integrate( f'(x)/f(x) )
         a, w = sympify(v[0]), []
@@ -346,7 +350,8 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
                 break
 
     # Logarithmic derivative of exponential generating Function (lgdegf)
-    if 'lgdegf' in types and v[0] != 0:
+    if v[0] != 0 and ('lgdegf' in types
+                       or ('egf' in types and 'egf' not in result)):
         # Transform sequence / step 1 (division by factorial)
         z, f = [], Integer(1)
         for i, k in enumerate(v):

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -253,7 +253,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
     {'egf': (x + 1)*exp(x), 'lgdegf': (x + 2)/(x + 1)}
 
     N-th root of a rational function can also be detected (below is an example
-    coming from the sequence A108626 from http://oeis.org ).
+    coming from the sequence A108626 from http://oeis.org).
     The greatest n-th root to be tested is specified as maxsqrtn (default 2).
 
     >>> ggf([1, 2, 5, 14, 41, 124, 383, 1200, 3799, 12122, 38919])['ogf']
@@ -337,7 +337,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
         a, w = sympify(v[0]), []
         for n in range(len(v)-1):
             w.append(
-               (v[n+1]*(n+1) - sum( w[-i-1]*v[i+1] for i in range(n) ))/a)
+               (v[n+1]*(n+1) - sum(w[-i-1]*v[i+1] for i in range(n)))/a)
         # Perform some convolutions of the sequence with itself
         t = [1 if k==0 else 0 for k in range(len(w))]
         for d in range(max(1, maxsqrtn)):
@@ -362,7 +362,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
         a, w = z[0], []
         for n in range(len(z)-1):
             w.append(
-               (z[n+1]*(n+1) - sum( w[-i-1]*z[i+1] for i in range(n) ))/a)
+               (z[n+1]*(n+1) - sum(w[-i-1]*z[i+1] for i in range(n)))/a)
         # Perform some convolutions of the sequence with itself
         t = [1 if k==0 else 0 for k in range(len(w))]
         for d in range(max(1, maxsqrtn)):

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -301,7 +301,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
     # Logarithmic Generating Function (lgf)
     if 'lgf' in types:
         # Transform sequence (multiplication by (-1)^(n+1) / n)
-        w, f = [], Integer(1)
+        w, f = [], Integer(-1)
         for i, k in enumerate(v):
             f = -f
             w.append(f*k/Integer(i+1))

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -234,7 +234,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
 
     >>> from sympy.concrete.guess import guess_generating_function as ggf
     >>> ggf([k+1 for k in range(12)], types=['ogf', 'lgf', 'hlgf'])
-    {'hlgf': 1/(-x + 1), 'lgf': -1/(x + 1), 'ogf': 1/(x**2 - 2*x + 1)}
+    {'hlgf': 1/(-x + 1), 'lgf': 1/(x + 1), 'ogf': 1/(x**2 - 2*x + 1)}
 
     >>> from sympy import sympify
     >>> l = sympify("[3/2, 11/2, 0, -121/2, -363/2, 121]")

--- a/sympy/concrete/tests/test_guess.py
+++ b/sympy/concrete/tests/test_guess.py
@@ -5,8 +5,8 @@ from sympy.concrete.guess import (
             guess_generating_function_rational,
             guess_generating_function
         )
-from sympy import Function, Symbol, sympify, Rational
-from sympy import fibonacci, factorial
+from sympy import (Function, Symbol, sympify, Rational,
+                   fibonacci, factorial, exp)
 
 def test_find_simple_recurrence_vector():
     assert find_simple_recurrence_vector(
@@ -53,4 +53,6 @@ def test_guess_generating_function():
        "[3/2, 11/2, 0, -121/2, -363/2, 121, 4719/2, 11495/2, -8712, -178717/2]")
        )['ogf'] == (x + Rational(3, 2))/(11*x**2 - 3*x + 1)
     assert guess_generating_function([factorial(k) for k in range(12)],
-              types=['egf'])['egf'] == 1/(-x + 1)
+       types=['egf'])['egf'] == 1/(-x + 1)
+    assert guess_generating_function([k+1 for k in range(12)],
+       types=['egf']) == {'egf': (x + 1)*exp(x), 'lgdegf': (x + 2)/(x + 1)}

--- a/sympy/concrete/tests/test_guess.py
+++ b/sympy/concrete/tests/test_guess.py
@@ -5,7 +5,7 @@ from sympy.concrete.guess import (
             guess_generating_function_rational,
             guess_generating_function
         )
-from sympy import Function, Symbol, sympify, simplify, Rational
+from sympy import Function, Symbol, sympify, Rational
 from sympy import fibonacci, factorial
 
 def test_find_simple_recurrence_vector():
@@ -52,6 +52,5 @@ def test_guess_generating_function():
     assert guess_generating_function(sympify(
        "[3/2, 11/2, 0, -121/2, -363/2, 121, 4719/2, 11495/2, -8712, -178717/2]")
        )['ogf'] == (x + Rational(3, 2))/(11*x**2 - 3*x + 1)
-    assert simplify(
-        guess_generating_function([factorial(k) for k in range(12)],
-              type=['egf'])['egf']) == -1/(x - 1)
+    assert guess_generating_function([factorial(k) for k in range(12)],
+              types=['egf'])['egf'] == 1/(-x + 1)

--- a/sympy/concrete/tests/test_guess.py
+++ b/sympy/concrete/tests/test_guess.py
@@ -5,8 +5,8 @@ from sympy.concrete.guess import (
             guess_generating_function_rational,
             guess_generating_function
         )
-from sympy import Function, Symbol, sympify
-from sympy import fibonacci
+from sympy import Function, Symbol, sympify, simplify, Rational
+from sympy import fibonacci, factorial
 
 def test_find_simple_recurrence_vector():
     assert find_simple_recurrence_vector(
@@ -30,10 +30,10 @@ def test_find_simple_recurrence():
 
 def test_rationalize():
     from mpmath import cos, pi, mpf
-    assert rationalize(cos(pi/3)) == sympify("1/2")
-    assert rationalize(mpf("0.333333333333333")) == sympify("1/3")
-    assert rationalize(mpf("-0.333333333333333")) == sympify("-1/3")
-    assert rationalize(pi, maxcoeff = 250) == sympify("355/113")
+    assert rationalize(cos(pi/3)) == Rational(1, 2)
+    assert rationalize(mpf("0.333333333333333")) == Rational(1, 3)
+    assert rationalize(mpf("-0.333333333333333")) == Rational(-1, 3)
+    assert rationalize(pi, maxcoeff = 250) == Rational(355, 113)
 
 
 def test_guess_generating_function_rational():
@@ -45,10 +45,13 @@ def test_guess_generating_function_rational():
 def test_guess_generating_function():
     x = Symbol('x')
     assert guess_generating_function([fibonacci(k)
-        for k in range(5, 15)]) == ((3*x + 5)/(-x**2 - x + 1))
+        for k in range(5, 15)])['ogf'] == ((3*x + 5)/(-x**2 - x + 1))
     assert guess_generating_function(
-     [1, 2, 5, 14, 41, 124, 383, 1200, 3799, 12122, 38919]) == (
-       (1/(x**4 + 2*x**2 - 4*x + 1))**(sympify("1/2")))
+        [1, 2, 5, 14, 41, 124, 383, 1200, 3799, 12122, 38919])['ogf'] == (
+        (1/(x**4 + 2*x**2 - 4*x + 1))**Rational(1, 2))
     assert guess_generating_function(sympify(
-     "[3/2, 11/2, 0, -121/2, -363/2, 121, 4719/2, 11495/2, -8712, -178717/2]")
-     ) == (x + sympify("3/2"))/(11*x**2 - 3*x + 1)
+       "[3/2, 11/2, 0, -121/2, -363/2, 121, 4719/2, 11495/2, -8712, -178717/2]")
+       )['ogf'] == (x + Rational(3, 2))/(11*x**2 - 3*x + 1)
+    assert simplify(
+        guess_generating_function([factorial(k) for k in range(12)],
+              type=['egf'])['egf']) == -1/(x - 1)


### PR DESCRIPTION
```
Changed returned type of guess_generating_function to dictionary.
Mapped previous returned type to 'ogf' key (ordinary generating func.).
Added 'egf' key as a new type (exponential generating function).
```

In order to be on par with other software (see for instance the Superseeker server described at https://oeis.org/ol.html which is able to scan very deeply submitted sequences by using modules for Maple, Mathematica, etc.), I decided to change the returned type of the `guess_generating_function` in sympy.concrete.guess. Now it is a dictionary where keys are labels like "ogf" or "egf", etc. (see https://oeis.org/wiki/Generating_functions for understanding what they are).

Right now, I implemented "egf" (previous function actually was "ogf"). Now the function returns things like {'ogf':stuff1, 'egf':stuff2} while most often, only one will be found for a given sequence (if someone can provide an example where two different g.f. are returned at the same time, I would appreciate and put it in the docstring).

I am asking here to @certik @mattpap and others if they agree with the first change (since the function is very new, I strongly doubt anybody would complain). If you agree, I will add (in this very same pull request) more types of g.f. coming from https://oeis.org/wiki/Generating_functions

Regards, tb.
