### PR TITLE
Eq(x/(x + 1), 1) outputs False

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -822,7 +822,7 @@ def test_issue_2787():
     s = Sum(binomial_dist*k, (k, 0, n))
     res = s.doit().simplify()
     assert res == Piecewise(
-        (n*p, p/Abs(p - 1) <= 1),
+        (n*p, (p - Abs(p - 1))/Abs(p - 1) <= 0),
         (Sum(k*p**k*(-p + 1)**(-k)*(-p + 1)**n*binomial(n, k), (k, 0, n)),
         True))
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -822,7 +822,7 @@ def test_issue_2787():
     s = Sum(binomial_dist*k, (k, 0, n))
     res = s.doit().simplify()
     assert res == Piecewise(
-        (n*p, And(Or(-n + 1 < 0, Ne(p/(p - 1), 1)), p/Abs(p - 1) <= 1)),
+        (n*p, p/Abs(p - 1) <= 1),
         (Sum(k*p**k*(-p + 1)**(-k)*(-p + 1)**n*binomial(n, k), (k, 0, n)),
         True))
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -194,7 +194,8 @@ class Relational(Boolean, Expr, EvalfMixin):
                 if r.func not in (Gt, Ge, Lt, Le):
                     return r.func(numer, S.Zero)
                 if numer.is_positive is not None and denom.is_positive is not None:
-                    return not xor(numer.is_positive, denom.is_positive)
+                    sign = -1 if denom.is_positive is True else 1
+                    return r.func(sign * numer, S.Zero)
 
         r = r.canonical
         if measure(r) < ratio*measure(self):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -171,6 +171,10 @@ class Relational(Boolean, Expr, EvalfMixin):
                 return l
 
     def _eval_simplify(self, ratio, measure):
+        from sympy.simplify import simplify
+        from sympy.simplify.simplify import fraction
+        from sympy import Tuple, Basic
+
         r = self
         r = r.func(*[i.simplify(ratio=ratio, measure=measure)
             for i in r.args])
@@ -185,6 +189,10 @@ class Relational(Boolean, Expr, EvalfMixin):
                 v = S.Zero
             if v is not None:
                 r = r.func._eval_relation(v, S.Zero)
+
+            numer, denom = fraction(simplify(dif))
+            if numer.is_zero is False and numer.is_number is True:
+                return r.func(numer, S.Zero)
 
         r = r.canonical
         if measure(r) < ratio*measure(self):
@@ -310,16 +318,6 @@ class Equality(Relational):
                 r = (lhs - rhs).is_zero
                 if r is not None:
                     return _sympify(r)
-
-            from sympy.simplify import simplify
-            from sympy.simplify.simplify import fraction
-            from sympy import Tuple, Basic
-            if isinstance(lhs, Basic) and isinstance(rhs, Basic) and (not isinstance(lhs, Tuple)) and (not isinstance(rhs, Tuple)):
-                if lhs.is_Boolean is False and rhs.is_Boolean is False:
-                    r = simplify(lhs - rhs)
-                    numer, denom = fraction(r)
-                    if numer.is_zero is False and numer.is_number == True:
-                        return S.false
 
         return Relational.__new__(cls, lhs, rhs, **options)
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -311,6 +311,16 @@ class Equality(Relational):
                 if r is not None:
                     return _sympify(r)
 
+            from sympy.simplify import simplify
+            from sympy.simplify.simplify import fraction
+            from sympy import Tuple, Basic
+            if isinstance(lhs, Basic) and isinstance(rhs, Basic) and (not isinstance(lhs, Tuple)) and (not isinstance(rhs, Tuple)):
+                if lhs.is_Boolean is False and rhs.is_Boolean is False:
+                    r = simplify(lhs - rhs)
+                    numer, denom = fraction(r)
+                    if numer.is_zero is False and numer.is_number == True:
+                        return S.false
+
         return Relational.__new__(cls, lhs, rhs, **options)
 
     @classmethod

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -171,10 +171,8 @@ class Relational(Boolean, Expr, EvalfMixin):
                 return l
 
     def _eval_simplify(self, ratio, measure):
-        from sympy.simplify import simplify
-        from sympy.simplify.simplify import fraction
         from sympy import Tuple, Basic
-
+        from sympy.logic.boolalg import Xor
         r = self
         r = r.func(*[i.simplify(ratio=ratio, measure=measure)
             for i in r.args])
@@ -191,8 +189,12 @@ class Relational(Boolean, Expr, EvalfMixin):
                 r = r.func._eval_relation(v, S.Zero)
 
             numer, denom = dif.as_numer_denom()
-            if numer.is_zero is False and numer.is_number is True:
-                return r.func(numer, S.Zero)
+
+            if numer.is_zero is False:
+                if r.func not in (Gt, Ge, Lt, Le):
+                    return r.func(numer, S.Zero)
+                if numer.is_positive is not None and denom.is_positive is not None:
+                    return not xor(numer.is_positive, denom.is_positive)
 
         r = r.canonical
         if measure(r) < ratio*measure(self):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -190,7 +190,7 @@ class Relational(Boolean, Expr, EvalfMixin):
             if v is not None:
                 r = r.func._eval_relation(v, S.Zero)
 
-            numer, denom = fraction(simplify(dif))
+            numer, denom = dif.as_numer_denom()
             if numer.is_zero is False and numer.is_number is True:
                 return r.func(numer, S.Zero)
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -665,5 +665,5 @@ def test_issue_10304():
 
 def test_issue_10401():
     x = Symbol('x')
-    assert Eq(1/(x+1), 0) == False
-    assert Eq(x/(x + 1), 1) == False
+    assert simplify(Eq(1 / (x+1), 0)) == False
+    assert simplify(Eq(x / (x+1), 1)) == False

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -665,5 +665,12 @@ def test_issue_10304():
 
 def test_issue_10401():
     x = Symbol('x')
-    assert simplify(Eq(1 / (x+1), 0)) == False
-    assert simplify(Eq(x / (x+1), 1)) == False
+    y = Symbol('y', positive=True)
+    z = Symbol('z', negative=True)
+    assert simplify(Eq(1 / (x+1), 0)) is S.false
+    assert simplify(Eq(x / (x+1), 1)) is S.false
+    assert simplify(Lt(y/z ,0) ) is S.true
+    assert simplify(Lt(y/x ,0) ) == Lt(y/x ,0)
+    f = x/(x + 1)
+    g = 1/(1 + 1/x)
+    assert Eq(f, g) is not S.true

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -661,3 +661,9 @@ def test_issue_10304():
     assert d.is_comparable is False  # if this fails, find a new d
     e = 1 + d*I
     assert simplify(Eq(e, 0)) is S.false
+
+
+def test_issue_10401():
+    x = Symbol('x')
+    assert Eq(1/(x+1), 0) == False
+    assert Eq(x/(x + 1), 1) == False

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -665,12 +665,14 @@ def test_issue_10304():
 
 def test_issue_10401():
     x = Symbol('x')
-    y = Symbol('y', positive=True)
-    z = Symbol('z', negative=True)
+    p = Symbol('p', positive=True)
+    n = Symbol('n', negative=True)
     assert simplify(Eq(1 / (x+1), 0)) is S.false
     assert simplify(Eq(x / (x+1), 1)) is S.false
-    assert simplify(Lt(y/z ,0) ) is S.true
-    assert simplify(Lt(y/x ,0) ) == Lt(y/x ,0)
+    assert simplify(Lt(p/n ,0) ) is S.true
+    assert simplify(Lt(p/x ,0) ) == (x < 0)
+    assert simplify(Lt(p*x, 0) ) == (x < 0)
+    assert simplify(Lt(-p*x, p) ) == (x > -1)
     f = x/(x + 1)
     g = 1/(1 + 1/x)
     assert Eq(f, g) is not S.true


### PR DESCRIPTION
This PR fixes #10401. @smichr. I added some logic in relational.py to check for cases in which the (lhs - rhs) is a fraction which has a non-zero number in its numerator. Such fractions when equated to zero have no solution, so 'False' should be returned. Please let me know if there is a better fix.
