### PR TITLE
Removing deprecated code

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -6,7 +6,6 @@ from .cache import cacheit
 from .sympify import _sympify, sympify, SympifyError
 from .compatibility import (iterable, Iterator, ordered,
     string_types, with_metaclass, zip_longest, range)
-from .decorators import deprecated
 from .singleton import S
 
 from inspect import getmro
@@ -675,12 +674,6 @@ class Basic(with_metaclass(ManagedProperties)):
         """
         return self.args
 
-    @deprecated(useinstead="iter(self.args)", issue=7717, deprecated_since_version="0.7.6")
-    def iter_basic_args(self):
-        """
-        Iterates arguments of ``self``.
-        """
-        return iter(self.args)
 
     def as_poly(self, *gens, **args):
         """Converts ``self`` to a polynomial or returns ``None``.
@@ -1609,20 +1602,6 @@ class Basic(with_metaclass(ManagedProperties)):
                     return self._eval_rewrite(tuple(pattern), rule, **hints)
                 else:
                     return self
-
-    @property
-    @deprecated(useinstead="is_finite", issue=8071, deprecated_since_version="0.7.6")
-    def is_bounded(self):
-        return super(Basic, self).__getattribute__('is_finite')
-
-    @property
-    @deprecated(useinstead="is_infinite", issue=8071, deprecated_since_version="0.7.6")
-    def is_unbounded(self):
-        return super(Basic, self).__getattribute__('is_infinite')
-
-    @deprecated(useinstead="is_zero", issue=8071, deprecated_since_version="0.7.6")
-    def is_infinitesimal(self):
-        return super(Basic, self).__getattribute__('is_zero')
 
 
 class Atom(Basic):

--- a/sympy/galgebra/printing.py
+++ b/sympy/galgebra/printing.py
@@ -32,7 +32,6 @@ import os
 import sys
 
 from sympy.core.compatibility import StringIO, range
-from sympy.core.decorators import deprecated
 from sympy.core.operations import AssocOp
 from sympy.core.power import Pow
 
@@ -231,16 +230,6 @@ class GA_Printer(StrPrinter):
         return self
 
     def __exit__(self, type, value, traceback):
-        GA_Printer._off()
-
-    @staticmethod
-    @deprecated(useinstead="with GA_Printer()", issue=7141, deprecated_since_version="0.7.4")
-    def on():
-        GA_Printer._on()
-
-    @staticmethod
-    @deprecated(useinstead="with GA_Printer()", issue=7141, deprecated_since_version="0.7.4")
-    def off():
         GA_Printer._off()
 
 

--- a/sympy/logic/__init__.py
+++ b/sympy/logic/__init__.py
@@ -1,4 +1,3 @@
 from .boolalg import (to_cnf, to_dnf, to_nnf, And, Or, Not, Xor, Nand, Nor, Implies,
-    Equivalent, ITE, POSform, SOPform, simplify_logic,
-    bool_equal, bool_map, true, false)
+    Equivalent, ITE, POSform, SOPform, simplify_logic, bool_map, true, false)
 from .inference import satisfiable

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -9,7 +9,6 @@ from itertools import combinations, product
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
 from sympy.core.numbers import Number
-from sympy.core.decorators import deprecated
 from sympy.core.operations import LatticeOp
 from sympy.core.function import Application, Derivative
 from sympy.core.compatibility import ordered, range, with_metaclass, as_int
@@ -1288,20 +1287,6 @@ def is_literal(expr):
         return not isinstance(expr, BooleanFunction)
 
 
-@deprecated(
-    useinstead="sympify", issue=6550, deprecated_since_version="0.7.3")
-def compile_rule(s):
-    """
-    Transforms a rule into a SymPy expression
-    A rule is a string of the form "symbol1 & symbol2 | ..."
-
-    Note: This function is deprecated.  Use sympify() instead.
-
-    """
-    import re
-    return sympify(re.sub(r'([a-zA-Z_][a-zA-Z0-9_]*)', r'Symbol("\1")', s))
-
-
 def to_int_repr(clauses, symbols):
     """
     Takes clauses in CNF format and puts them into an integer representation.
@@ -1856,22 +1841,3 @@ def bool_map(bool1, bool2):
     if m:
         return a, m
     return m is not None
-
-
-@deprecated(
-    useinstead="bool_map", issue=7197, deprecated_since_version="0.7.4")
-def bool_equal(bool1, bool2, info=False):
-    """Return True if the two expressions represent the same logical
-    behaviour for some correspondence between the variables of each
-    (which may be different). For example, And(x, y) is logically
-    equivalent to And(a, b) for {x: a, y: b} (or vice versa). If the
-    mapping is desired, then set ``info`` to True and the simplified
-    form of the functions and mapping of variables will be returned.
-    """
-
-    mapping = bool_map(bool1, bool2)
-    if not mapping:
-        return False
-    if info:
-        return mapping
-    return True

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,5 +1,5 @@
 from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
         Intersection, imageset, Complement, SymmetricDifference)
-from .fancysets import TransformationSet, ImageSet, Range, ComplexRegion
+from .fancysets import ImageSet, Range, ComplexRegion
 from .contains import Contains
 from .conditionset import ConditionSet

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -8,7 +8,6 @@ from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
                              FiniteSet)
 from sympy.core.singleton import Singleton, S
 from sympy.core.sympify import _sympify
-from sympy.core.decorators import deprecated
 from sympy.core.function import Lambda
 
 
@@ -298,12 +297,6 @@ class ImageSet(Set):
             return imageset(Lambda(n_, re),
                             self.base_set.intersect(
                                 solveset_real(im, n_)))
-
-
-@deprecated(useinstead="ImageSet", issue=7057, deprecated_since_version="0.7.4")
-def TransformationSet(*args, **kwargs):
-    """Deprecated alias for the ImageSet constructor."""
-    return ImageSet(*args, **kwargs)
 
 
 class Range(Set):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -288,13 +288,6 @@ class Set(Basic):
     def _contains(self, other):
         raise NotImplementedError("(%s)._contains(%s)" % (self, other))
 
-    @deprecated(useinstead="is_subset", issue=7460, deprecated_since_version="0.7.6")
-    def subset(self, other):
-        """
-        Returns True if 'other' is a subset of 'self'.
-        """
-        return other.is_subset(self)
-
     def is_subset(self, other):
         """
         Returns True if 'self' is a subset of 'other'.

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -9,7 +9,6 @@ from sympy.core.evalf import EvalfMixin
 from sympy.core.numbers import Float
 from sympy.core.compatibility import iterable, with_metaclass, ordered, range
 from sympy.core.evaluate import global_evaluate
-from sympy.core.decorators import deprecated
 from sympy.core.mul import Mul
 from sympy.core.relational import Eq
 from sympy.core.symbol import Symbol
@@ -510,11 +509,6 @@ class Set(Basic):
             raise TypeError('contains did not evaluate to a bool: %r' % symb)
         return bool(symb)
 
-    @property
-    @deprecated(useinstead="is_subset(S.Reals)", issue=6212, deprecated_since_version="0.7.6")
-    def is_real(self):
-        return None
-
 
 class ProductSet(Set):
     """
@@ -648,11 +642,6 @@ class ProductSet(Set):
 
 
     @property
-    @deprecated(useinstead="is_subset(S.Reals)", issue=6212, deprecated_since_version="0.7.6")
-    def is_real(self):
-        return all(set.is_real for set in self.sets)
-
-    @property
     def is_iterable(self):
         return all(set.is_iterable for set in self.sets)
 
@@ -716,11 +705,6 @@ class Interval(Set, EvalfMixin):
     .. [1] http://en.wikipedia.org/wiki/Interval_%28mathematics%29
     """
     is_Interval = True
-
-    @property
-    @deprecated(useinstead="is_subset(S.Reals)", issue=6212, deprecated_since_version="0.7.6")
-    def is_real(self):
-        return True
 
     def __new__(cls, start, end, left_open=False, right_open=False):
 
@@ -1339,12 +1323,6 @@ class Union(Set, EvalfMixin):
         else:
             raise TypeError("Not all constituent sets are iterable")
 
-    @property
-    @deprecated(useinstead="is_subset(S.Reals)", issue=6212, deprecated_since_version="0.7.6")
-    def is_real(self):
-        return all(set.is_real for set in self.args)
-
-
 class Intersection(Set):
     """
     Represents an intersection of sets as a :class:`Set`.
@@ -1934,11 +1912,6 @@ class FiniteSet(Set, EvalfMixin):
         """Rewrite a FiniteSet in terms of equalities and logic operators. """
         from sympy.core.relational import Eq
         return Or(*[Eq(symbol, elem) for elem in self])
-
-    @property
-    @deprecated(useinstead="is_subset(S.Reals)", issue=6212, deprecated_since_version="0.7.6")
-    def is_real(self):
-        return all(el.is_real for el in self)
 
     def compare(self, other):
         return (hash(self) - hash(other))

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -739,40 +739,6 @@ class TIDS(CantSympify):
         return tids, sign
 
 
-class VTIDS(TIDS):
-    """
-    DEPRECATED: DO NOT USE.
-    """
-
-    @deprecated(useinstead="TIDS")
-    def __init__(self, components, free, dum, data):
-        super(VTIDS, self).__init__(components, free, dum)
-        self.data = data
-
-    @staticmethod
-    @deprecated(useinstead="TIDS")
-    def parse_data(data):
-        """
-        DEPRECATED: DO NOT USE.
-        """
-        return _TensorDataLazyEvaluator.parse_data(data)
-
-    @deprecated(useinstead="TIDS")
-    def correct_signature_from_indices(self, data, indices, free, dum):
-        """
-        DEPRECATED: DO NOT USE.
-        """
-        return _TensorDataLazyEvaluator._correct_signature_from_indices(data, indices, free, dum)
-
-    @staticmethod
-    @deprecated(useinstead="TIDS")
-    def flip_index_by_metric(data, metric, pos):
-        """
-        DEPRECATED: DO NOT USE.
-        """
-        return _TensorDataLazyEvaluator._flip_index_by_metric(data, metric, pos)
-
-
 class _TensorDataLazyEvaluator(CantSympify):
     """
     EXPERIMENTAL: do not rely on this class, it may change without deprecation

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -5,7 +5,6 @@ from itertools import combinations, permutations, product, product as cartes
 import random
 from operator import gt
 
-from sympy.core.decorators import deprecated
 from sympy.core import Basic
 
 # this is the logical location of these functions
@@ -1751,13 +1750,6 @@ def generate_derangements(perm):
     for pi in p:
         if all(pi[i] != p0[i] for i in indices):
             yield pi
-
-
-@deprecated(
-    useinstead="bracelets", deprecated_since_version="0.7.3")
-def unrestricted_necklace(n, k):
-    """Wrapper to necklaces to return a free (unrestricted) necklace."""
-    return necklaces(n, k, free=True)
 
 
 def necklaces(n, k, free=False):


### PR DESCRIPTION
I have removed a few deprecated methods.
As suggested by @moorepants in #10392 , I have tried to remove the deprecated code which was introduced before 0.7.6
- [x] closes #6550
- [x] closes #7057
- [x] closes #7141
- [x] closes #7197
- [x] closes #7460
- [x] closes #7717
