### PR TITLE
normalizing an open Interval now works

### DIFF
--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -393,15 +393,39 @@ def test_ComplexRegion_measure():
 def test_normalize_theta_set():
 
     # Interval
+    assert normalize_theta_set(Interval(pi, 2*pi)) == \
+        Union(FiniteSet(0), Interval(pi, 2*pi, False, True))
     assert normalize_theta_set(Interval(9*pi/2, 5*pi)) == Interval(pi/2, pi)
     assert normalize_theta_set(Interval(-3*pi/2, pi/2)) == \
         Interval(0, 2*pi, False, True)
+    assert normalize_theta_set(Interval(-3*pi/2, pi/2, True, True)) == \
+        Union(Interval(0, pi/2, False, True), Interval(pi/2, 2*pi, True, True))
+    assert normalize_theta_set(Interval(-7*pi/2, -3*pi/2, True, True)) == \
+        Union(Interval(0, pi/2, False, True), Interval(pi/2, 2*pi, True, True))
     assert normalize_theta_set(Interval(-pi/2, pi/2)) == \
         Union(Interval(0, pi/2), Interval(3*pi/2, 2*pi, False, True))
+    assert normalize_theta_set(Interval(-pi/2, pi/2, True, True)) == \
+        Union(Interval(0, pi/2, False, True), Interval(3*pi/2, 2*pi, True, True))
     assert normalize_theta_set(Interval(-4*pi, 3*pi)) == \
         Interval(0, 2*pi, False, True)
     assert normalize_theta_set(Interval(-3*pi/2, -pi/2)) == \
         Interval(pi/2, 3*pi/2)
+    assert normalize_theta_set(Interval(0, 2*pi, True, True)) == \
+        Interval(0, 2*pi, True, True)
+    assert normalize_theta_set(Interval(-pi/2, pi/2, False, True)) == \
+        Union(Interval(0, pi/2, False, True), Interval(3*pi/2, 2*pi, False, True))
+    assert normalize_theta_set(Interval(-pi/2, pi/2, True, False)) == \
+        Union(Interval(0, pi/2), Interval(3*pi/2, 2*pi, True, True))
+    assert normalize_theta_set(Interval(-pi/2, pi/2, False, False)) == \
+        Union(Interval(0, pi/2), Interval(3*pi/2, 2*pi, False, True))
+    assert normalize_theta_set(Interval(4*pi, 9*pi/2, True, True)) == \
+        Interval(0, pi/2, True, True)
+    assert normalize_theta_set(Interval(4*pi, 9*pi/2, True, False)) == \
+        Interval(0, pi/2, True, False)
+    assert normalize_theta_set(Interval(4*pi, 9*pi/2,False, True)) == \
+        Interval(0, pi/2, False, True)
+    assert normalize_theta_set(Interval(3*pi, 5*pi, True, True)) == \
+        Union(Interval(0, pi, False, True), Interval(pi, 2*pi, True, True))
 
     # FiniteSet
     assert normalize_theta_set(FiniteSet(0, pi, 3*pi)) == FiniteSet(0, pi)
@@ -411,6 +435,13 @@ def test_normalize_theta_set():
         FiniteSet(0, pi, 3*pi/2)
     assert normalize_theta_set(FiniteSet(-3*pi/2, pi/2)) == \
         FiniteSet(pi/2)
+    assert normalize_theta_set(FiniteSet(2*pi)) == FiniteSet(0)
+
+    # Unions
+    assert normalize_theta_set(Union(Interval(0, pi/3), Interval(pi/2, pi))) == \
+        Union(Interval(0, pi/3), Interval(pi/2, pi))
+    assert normalize_theta_set(Union(Interval(0, pi), Interval(2*pi, 7*pi/3))) == \
+        Interval(0, pi)
 
     # ValueError for non-real sets
     raises(ValueError, lambda: normalize_theta_set(S.Complexes))


### PR DESCRIPTION
One of the tests still fail

```
>>> normalize_theta_set(Interval(4*pi, 9*pi/2, True, True))
[0, pi/2)
```
