### PR TITLE
Geometry: closest and farthest pair of points algorithm

### DIFF
--- a/sympy/geometry/__init__.py
+++ b/sympy/geometry/__init__.py
@@ -23,6 +23,6 @@ from sympy.geometry.plane import Plane
 from sympy.geometry.ellipse import Ellipse, Circle
 from sympy.geometry.polygon import Polygon, RegularPolygon, Triangle, rad, deg
 from sympy.geometry.util import are_similar, centroid, convex_hull, idiff, \
-    intersection
+    intersection, closest_points, farthest_points
 from sympy.geometry.exceptions import GeometryError
 from sympy.geometry.curve import Curve

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -93,9 +93,9 @@ def test_farthest_points_closest_points():
         a.distance(b) == d
         assert ans == _ordered_points(ans)
 
-    a, b, c = list(
-        _ordered_points((
-        Point2D(0, 0), Point2D(1, 0), Point2D(1/2, sqrt(3)/2))))
+    # equidistant points
+    a, b, c = (
+        Point2D(0, 0), Point2D(1, 0), Point2D(1/2, sqrt(3)/2))
     ans = set([_ordered_points((i, j))
         for i, j in subsets((a, b, c), 2)])
     assert closest_points(b, c, a) == ans

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -27,7 +27,14 @@ def test_util():
     # coverage for some leftover functions in sympy.geometry.util
     assert intersection(Point(0, 0)) == []
     raises(ValueError, lambda: intersection(Point(0, 0), 3))
+
+
+def test_convex_hull():
     raises(ValueError, lambda: convex_hull(Point(0, 0), 3))
+    points = [(1, -1), (1, -2), (3, -1), (-5, -2), (15, -4)]
+    assert convex_hull(*points, **dict(polygon=False)) == (
+        [Point2D(-5, -2), Point2D(1, -1), Point2D(3, -1), Point2D(15, -4)],
+        [Point2D(-5, -2), Point2D(15, -4)])
 
 
 def test_util_centroid():
@@ -93,3 +100,14 @@ def test_farthest_points_closest_points():
         for i, j in subsets((a, b, c), 2)])
     assert closest_points(b, c, a) == ans
     assert farthest_points(b, c, a) == ans
+
+    # unique to farthest
+    points = [(1, 1), (1, 2), (3, 1), (-5, 2), (15, 4)]
+    assert farthest_points(*points) == set(
+        [(Point2D(-5, 2), Point2D(15, 4))])
+    points = [(1, -1), (1, -2), (3, -1), (-5, -2), (15, -4)]
+    assert farthest_points(*points) == set(
+        [(Point2D(-5, -2), Point2D(15, -4))])
+    assert farthest_points((1, 1), (0, 0)) == set(
+        [(Point2D(0, 0), Point2D(1, 1))])
+    raises(ValueError, lambda: farthest_points((1, 1)))

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -1,8 +1,8 @@
 from __future__ import division
 
 from sympy import Symbol, sqrt, Derivative
-from sympy.geometry import Point, Polygon, Segment, convex_hull, intersection, centroid
-from sympy.geometry.util import idiff
+from sympy.geometry import Point, Point2D, Polygon, Segment, convex_hull, intersection, centroid
+from sympy.geometry.util import idiff, closest_points, farthest_points
 from sympy.solvers.solvers import solve
 from sympy.utilities.pytest import raises
 
@@ -39,3 +39,21 @@ def test_util_centroid():
     assert centroid(p, q) == Point(1, -sqrt(2) + 2)
     assert centroid(Point(0, 0), Point(2, 0)) == Point(2, 0)/2
     assert centroid(Point(0, 0), Point(0, 0), Point(2, 0)) == Point(2, 0)/3
+
+
+def test_closest_points():
+    points = [(1, 1), (2, 2), (11, 11)]
+    assert closest_points(*points) == ((1, 1), (2, 2))
+    points = [(38, 40), (83, 89), (74, 46), (76, 73), (75, 13), (98, 87), (5, 73), (75, 18), (30, 7)]
+    assert closest_points(*points) == ((75, 18), (75, 13))
+    points = [(34, 54), (92, 10), (99, 2), (29, 4), (4, 51), (2, 40), (18, 60), (30, 69), (10, 32)]
+    assert closest_points(*points) == ((99, 2), (92, 10))
+
+
+def test_farthest_points():
+    points = [(1, 1), (2, 2), (11, 11)]
+    assert farthest_points(*points) == ((1, 1), (11, 11))
+    points = [(38, 40), (83, 89), (74, 46), (76, 73), (75, 13), (98, 87), (5, 73), (75, 18), (30, 7)]
+    assert farthest_points(*points) == ((98, 87), (30, 7))
+    points = [(34, 54), (92, 10), (99, 2), (29, 4), (4, 51), (2, 40), (18, 60), (30, 69), (10, 32)]
+    assert farthest_points(*points) == ((4, 51), (99, 2))

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -50,6 +50,9 @@ def test_farthest_points_closest_points():
             func = closest_points
         else:
             func = farthest_points
+
+        raises(ValueError, lambda: func(Point2D(0, 0), Point2D(0, 0)))
+
         # 3rd pt dx is close and pt is closer to 1st pt
         p1 = [Point2D(0, 0), Point2D(3, 0), Point2D(1, 1)]
         # 3rd pt dx is close and pt is closer to 2nd pt
@@ -60,11 +63,13 @@ def test_farthest_points_closest_points():
         p4 = [Point2D(0, 0), Point2D(3, 0), Point2D(4, 0)]
         # 3rd pt dx is not closer and it's closer to 1st pt
         p5 = [Point2D(0, 0), Point2D(3, 0), Point2D(-1, 0)]
+        # duplicate point doesn't affect outcome
+        dup = [Point2D(0, 0), Point2D(3, 0), Point2D(3, 0), Point2D(-1, 0)]
         # symbolic
         x = Symbol('x', positive=True)
         s = [Point2D(a) for a in ((x, 1), (x + 3, 2), (x + 2, 2))]
 
-        for points in (p1, p2, p3, p4, p5, s):
+        for points in (p1, p2, p3, p4, p5, s, dup):
             d = how(i.distance(j) for i, j in subsets(points, 2))
             ans = a, b = list(func(*points))[0]
             a.distance(b) == d

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 from sympy import Symbol, sqrt, Derivative
 from sympy.geometry import Point, Point2D, Polygon, Segment, convex_hull, intersection, centroid
-from sympy.geometry.util import idiff, closest_points, farthest_points
+from sympy.geometry.util import idiff, closest_points, farthest_points, _ordered_points
 from sympy.solvers.solvers import solve
 from sympy.utilities.pytest import raises
 
@@ -41,19 +41,50 @@ def test_util_centroid():
     assert centroid(Point(0, 0), Point(0, 0), Point(2, 0)) == Point(2, 0)/3
 
 
-def test_closest_points():
-    points = [Point2D(1, 1), Point2D(2, 2), Point2D(11, 11)]
-    assert closest_points(*points) == (Point2D(1, 1), Point2D(2, 2))
-    points = [Point2D(38, 40), Point2D(83, 89), Point2D(74, 46), Point2D(76, 73), Point2D(75, 13), Point2D(98, 87), Point2D(5, 73), Point2D(75, 18), Point2D(30, 7)]
-    assert closest_points(*points) == (Point2D(75, 18), Point2D(75, 13))
-    points = [Point2D(34, 54), Point2D(92, 10), Point2D(99, 2), Point2D(29, 4), Point2D(4, 51), Point2D(2, 40), Point2D(18, 60), Point2D(30, 69), Point2D(10, 32)]
-    assert closest_points(*points) == (Point2D(99, 2), Point2D(92, 10))
+def test_farthest_points_closest_points():
+    from random import randint
+    from sympy.utilities.iterables import subsets
 
+    for how in (min, max):
+        if how is min:
+            func = closest_points
+        else:
+            func = farthest_points
+        # 3rd pt dx is close and pt is closer to 1st pt
+        p1 = [Point2D(0, 0), Point2D(3, 0), Point2D(1, 1)]
+        # 3rd pt dx is close and pt is closer to 2nd pt
+        p2 = [Point2D(0, 0), Point2D(3, 0), Point2D(2, 1)]
+        # 3rd pt dx is close and but pt is not closer
+        p3 = [Point2D(0, 0), Point2D(3, 0), Point2D(1, 10)]
+        # 3rd pt dx is not closer and it's closer to 2nd pt
+        p4 = [Point2D(0, 0), Point2D(3, 0), Point2D(4, 0)]
+        # 3rd pt dx is not closer and it's closer to 1st pt
+        p5 = [Point2D(0, 0), Point2D(3, 0), Point2D(-1, 0)]
+        # symbolic
+        x = Symbol('x', positive=True)
+        s = [Point2D(a) for a in ((x, 1), (x + 3, 2), (x + 2, 2))]
 
-def test_farthest_points():
-    points = [Point2D(1, 1), Point2D(2, 2), Point2D(11, 11)]
-    assert farthest_points(*points) == (Point2D(1, 1), Point2D(11, 11))
-    points = [Point2D(38, 40), Point2D(83, 89), Point2D(74, 46), Point2D(76, 73), Point2D(75, 13), Point2D(98, 87), Point2D(5, 73), Point2D(75, 18), Point2D(30, 7)]
-    assert farthest_points(*points) == (Point2D(98, 87), Point2D(30, 7))
-    points = [Point2D(34, 54), Point2D(92, 10), Point2D(99, 2), Point2D(29, 4), Point2D(4, 51), Point2D(2, 40), Point2D(18, 60), Point2D(30, 69), Point2D(10, 32)]
-    assert farthest_points(*points) == (Point2D(4, 51), Point2D(99, 2))
+        for points in (p1, p2, p3, p4, p5, s):
+            d = how(i.distance(j) for i, j in subsets(points, 2))
+            ans = a, b = list(func(*points))[0]
+            a.distance(b) == d
+            assert ans == _ordered_points(ans)
+
+        # if the following ever fails, the above tests were not sufficient
+        # and the logical error in the routine should be fixed
+        points = set()
+        while len(points) != 7:
+            points.add(Point2D(randint(1, 100), randint(1, 100)))
+        points = list(points)
+        d = how(i.distance(j) for i, j in subsets(points, 2))
+        ans = a, b = list(func(*points))[0]
+        a.distance(b) == d
+        assert ans == _ordered_points(ans)
+
+    a, b, c = list(
+        _ordered_points((
+        Point2D(0, 0), Point2D(1, 0), Point2D(1/2, sqrt(3)/2))))
+    ans = set([_ordered_points((i, j))
+        for i, j in subsets((a, b, c), 2)])
+    assert closest_points(b, c, a) == ans
+    assert farthest_points(b, c, a) == ans

--- a/sympy/geometry/tests/test_util.py
+++ b/sympy/geometry/tests/test_util.py
@@ -42,18 +42,18 @@ def test_util_centroid():
 
 
 def test_closest_points():
-    points = [(1, 1), (2, 2), (11, 11)]
-    assert closest_points(*points) == ((1, 1), (2, 2))
-    points = [(38, 40), (83, 89), (74, 46), (76, 73), (75, 13), (98, 87), (5, 73), (75, 18), (30, 7)]
-    assert closest_points(*points) == ((75, 18), (75, 13))
-    points = [(34, 54), (92, 10), (99, 2), (29, 4), (4, 51), (2, 40), (18, 60), (30, 69), (10, 32)]
-    assert closest_points(*points) == ((99, 2), (92, 10))
+    points = [Point2D(1, 1), Point2D(2, 2), Point2D(11, 11)]
+    assert closest_points(*points) == (Point2D(1, 1), Point2D(2, 2))
+    points = [Point2D(38, 40), Point2D(83, 89), Point2D(74, 46), Point2D(76, 73), Point2D(75, 13), Point2D(98, 87), Point2D(5, 73), Point2D(75, 18), Point2D(30, 7)]
+    assert closest_points(*points) == (Point2D(75, 18), Point2D(75, 13))
+    points = [Point2D(34, 54), Point2D(92, 10), Point2D(99, 2), Point2D(29, 4), Point2D(4, 51), Point2D(2, 40), Point2D(18, 60), Point2D(30, 69), Point2D(10, 32)]
+    assert closest_points(*points) == (Point2D(99, 2), Point2D(92, 10))
 
 
 def test_farthest_points():
-    points = [(1, 1), (2, 2), (11, 11)]
-    assert farthest_points(*points) == ((1, 1), (11, 11))
-    points = [(38, 40), (83, 89), (74, 46), (76, 73), (75, 13), (98, 87), (5, 73), (75, 18), (30, 7)]
-    assert farthest_points(*points) == ((98, 87), (30, 7))
-    points = [(34, 54), (92, 10), (99, 2), (29, 4), (4, 51), (2, 40), (18, 60), (30, 69), (10, 32)]
-    assert farthest_points(*points) == ((4, 51), (99, 2))
+    points = [Point2D(1, 1), Point2D(2, 2), Point2D(11, 11)]
+    assert farthest_points(*points) == (Point2D(1, 1), Point2D(11, 11))
+    points = [Point2D(38, 40), Point2D(83, 89), Point2D(74, 46), Point2D(76, 73), Point2D(75, 13), Point2D(98, 87), Point2D(5, 73), Point2D(75, 18), Point2D(30, 7)]
+    assert farthest_points(*points) == (Point2D(98, 87), Point2D(30, 7))
+    points = [Point2D(34, 54), Point2D(92, 10), Point2D(99, 2), Point2D(29, 4), Point2D(4, 51), Point2D(2, 40), Point2D(18, 60), Point2D(30, 69), Point2D(10, 32)]
+    assert farthest_points(*points) == (Point2D(4, 51), Point2D(99, 2))

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -318,7 +318,7 @@ def closest_points(*args):
     Parameters
     ==========
 
-    args : a collection of Points on 2-d plane.
+    args : a collection of Points on 2D plane.
 
     Returns
     =======
@@ -342,49 +342,48 @@ def closest_points(*args):
     ========
 
     >>> from sympy.geometry.util import closest_points
-    >>> points = [(5, 2), (7, 6), (3, 9), (9, 4), (8, 5)]
+    >>> points = [Point2D(5, 2), Point2D(7, 6), Point2D(3, 9), Point2D(9, 4), Point2D(8, 5)]
     >>> closest_points(*points)
-    ((8, 5), (7, 6))
+    (Point2D(8, 5), Point2D(7, 6))
 
     >>> from sympy.geometry.util import closest_points
-    >>> points = [(80, 89), (11, 85), (32, 51), (59, 59), (39, 80), (62, 73)]
+    >>> points = [Point2D(80, 89), Point2D(11, 85), Point2D(32, 51), Point2D(59, 59), Point2D(39, 80), Point2D(62, 73)]
     >>> closest_points(*points)
-    ((62, 73), (59, 59))
+    (Point2D(62, 73), Point2D(59, 59))
 
     """
-    from .point import Point
+    from .point import Point,Point2D
     from collections import deque
     import numbers
+    from math import sqrt,pow
 
     points = list(args)
+    for point in points:
+        if not isinstance(point,Point2D):
+            raise NotImplementedError('The input must be a set of 2D points')
     if len(points) < 2:
         raise NotImplementedError('At-least 2 points must be inserted')
-    # make sure all our points are of the same dimension
-    for i in range(0, len(points)):
-        if isinstance(points[i][0], (int, float)) == False or isinstance(points[i][1], (int, float)) == False or len(points[i]) != 2:
-            raise NotImplementedError('The input must be a set of 2-d points')
-
     p = points
-    p.sort()
+    p.sort(key=lambda x: x.args)
 
     box = deque()
     box.append(p[0])
 
-    best_dist = (pow(p[1][1]-box[0][1], 2)+pow(p[1][0]-box[0][0], 2))
+    best_dist = sqrt(pow(p[1].y-box[0].y, 2)+pow(p[1].x-box[0].x, 2))
     left = 0
     i = 1
     best_pair = (p[0], p[1])
 
-    while(i < len(p)):
+    while i < len(p):
         j = 0
-        while left < i and p[i][0]-p[left][0] > best_dist:
+        while left < i and p[i].x-p[left].x > best_dist:
             box.remove(p[left])
             left = left+1
 
         for j in range(len(box)):
-            if best_dist != min(best_dist, (pow(p[i][1]-box[j][1], 2)+pow(p[i][0]-box[j][0], 2))):
+            if best_dist != min(best_dist, sqrt(pow(p[i].y-box[j].y, 2)+pow(p[i].x-box[j].x, 2))):
                 best_pair = (p[i], box[j])
-                best_dist = min(best_dist, (pow(p[i][1]-box[j][1], 2)+pow(p[i][0]-box[j][0], 2)))
+                best_dist = min(best_dist, sqrt(pow(p[i].y-box[j].y, 2)+pow(p[i].x-box[j].x, 2)))
         box.append(p[i])
         i = i+1
 
@@ -421,25 +420,24 @@ def farthest_points(*args):
     ========
 
     >>> from sympy.geometry.util import farthest_points
-    >>> points = [(5, 2), (7, 6), (3, 9), (9, 4), (8, 5)]
+    >>> points = [Point2D(5, 2), Point2D(7, 6), Point2D(3, 9), Point2D(9, 4), Point2D(8, 5)]
     >>> farthest_points(*points)
-    ((3, 9), (9, 4))
+    (Point2D(3, 9), Point2D(9, 4))
 
     >>> from sympy.geometry.util import farthest_points
-    >>> points = [(80, 89), (11, 85), (32, 51), (59, 59), (39, 80), (62, 73)]
+    >>> points = [Point2D(80, 89), Point2D(11, 85), Point2D(32, 51), Point2D(59, 59), Point2D(39, 80), Point2D(62, 73)]
     >>> farthest_points(*points)
-    ((11, 85), (80, 89))
+    (Point2D(11, 85), Point2D(80, 89))
 
     """
-    from .point import Point
+    from .point import Point,Point2D
 
     def rotatingCalipers(Points):
         def hulls(Points):
             def orientation(p, q, r):
-                return (q[1]-p[1]) * (r[0]-p[0]) - (q[0]-p[0]) * (r[1]-p[1])
+                return (q.y-p.y) * (r.x-p.x) - (q.x-p.x) * (r.y-p.y)
             U = []
             L = []
-            Points.sort()
             for p in Points:
                 while len(U) > 1 and orientation(U[-2], U[-1], p) <= 0:
                     U.pop()
@@ -460,24 +458,21 @@ def farthest_points(*args):
                 i += 1
             # still points left on both lists, compare slopes of next hull edges
             # being careful to avoid divide-by-zero in slope calculation
-            elif (U[i+1][1]-U[i][1]) * (L[j][0]-L[j-1][0]) > \
-                    (L[j][1]-L[j-1][1]) * (U[i+1][0]-U[i][0]):
+            elif (U[i+1].y-U[i].y) * (L[j].x-L[j-1].x) > \
+                    (L[j].y-L[j-1].y) * (U[i+1].x-U[i].x):
                 i += 1
             else:
                 j -= 1
 
     points = list(args)
+    for point in points:
+        if not isinstance(point,Point2D):
+            raise NotImplementedError('The input must be a set of 2D points')
     if len(points) < 2:
         raise NotImplementedError('At-least 2 points must be inserted')
-
-    for i in range(0, len(points)):
-        if isinstance(points[i][0], (int, float)) == False or isinstance(points[i][1], (int, float)) == False or len(points[i]) != 2:
-            raise NotImplementedError('The input must be a set of 2-d points')
-
-    # make sure all our points are of the same dimension
-    Points = points
-    diam, pair = max([((h[0]-q[0])**2 + (h[1]-q[1])**2, (h, q))
-                     for h, q in rotatingCalipers(Points)])
+    points.sort(key=lambda x: x.args)
+    diam, pair = max([((h.x-q.x)**2 + (h.y-q.y)**2, (h, q))
+                     for h, q in rotatingCalipers(points)])
     return pair
 
 

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -354,13 +354,15 @@ def closest_points(*args):
     """
     from .point import Point, Point2D
     from collections import deque
-    import numbers
     from math import sqrt, pow
 
     points = list(args)
     for point in points:
+        if not isinstance(point, Point2D):
+            raise NotImplementedError('The point must be an instance of Point2D.')
         if not all([point.x.is_number, point.y.is_number]):
-            raise NotImplementedError('The input must be a set of 2D points')
+            raise NotImplementedError('The point co-ordinates must be real numbers.')
+
     if len(points) < 2:
         raise NotImplementedError('At-least 2 points must be inserted')
     p = points
@@ -369,23 +371,24 @@ def closest_points(*args):
     box = deque()
     box.append(p[0])
 
-    best_dist = sqrt(pow(p[1].y-box[0].y, 2)+pow(p[1].x-box[0].x, 2))
+    best_dist = sqrt(pow(p[1].y - box[0].y, 2) + pow(p[1].x - box[0].x, 2))
+
     left = 0
     i = 1
     best_pair = (p[0], p[1])
 
     while i < len(p):
         j = 0
-        while left < i and p[i].x-p[left].x > best_dist:
+        while left < i and p[i].x - p[left].x > best_dist:
             box.remove(p[left])
-            left = left+1
+            left = left + 1
 
         for j in range(len(box)):
-            if best_dist != min(best_dist, sqrt(pow(p[i].y-box[j].y, 2)+pow(p[i].x-box[j].x, 2))):
+            if best_dist != min(best_dist, sqrt(pow(p[i].y - box[j].y, 2) + pow(p[i].x - box[j].x, 2))):
                 best_pair = (p[i], box[j])
-                best_dist = min(best_dist, sqrt(pow(p[i].y-box[j].y, 2)+pow(p[i].x-box[j].x, 2)))
+                best_dist = min(best_dist, sqrt(pow(p[i].y - box[j].y, 2) + pow(p[i].x - box[j].x, 2)))
         box.append(p[i])
-        i = i+1
+        i = i + 1
 
     return best_pair
 
@@ -435,7 +438,7 @@ def farthest_points(*args):
     def rotatingCalipers(Points):
         def hulls(Points):
             def orientation(p, q, r):
-                return (q.y-p.y) * (r.x-p.x) - (q.x-p.x) * (r.y-p.y)
+                return (q.y - p.y) * (r.x - p.x) - (q.x - p.x) * (r.y - p.y)
             U = []
             L = []
             for p in Points:
@@ -458,20 +461,22 @@ def farthest_points(*args):
                 i += 1
             # still points left on both lists, compare slopes of next hull edges
             # being careful to avoid divide-by-zero in slope calculation
-            elif (U[i+1].y-U[i].y) * (L[j].x-L[j-1].x) > \
-                    (L[j].y-L[j-1].y) * (U[i+1].x-U[i].x):
+            elif (U[i+1].y - U[i].y) * (L[j].x - L[j-1].x) > \
+                    (L[j].y - L[j-1].y) * (U[i+1].x - U[i].x):
                 i += 1
             else:
                 j -= 1
 
     points = list(args)
     for point in points:
+        if not isinstance(point, Point2D):
+            raise NotImplementedError('The point must be an instance of Point2D.')
         if not all([point.x.is_number, point.y.is_number]):
-            raise NotImplementedError('The input must be a set of 2D points')
+            raise NotImplementedError('The point co-ordinates must be real numbers.')
     if len(points) < 2:
         raise NotImplementedError('At-least 2 points must be inserted')
     points.sort(key=lambda x: x.args)
-    diam, pair = max([((h.x-q.x)**2 + (h.y-q.y)**2, (h, q))
+    diam, pair = max([((h.x - q.x)**2 + (h.y - q.y)**2, (h, q))
                      for h, q in rotatingCalipers(points)])
     return pair
 

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -14,7 +14,7 @@ from __future__ import division, print_function
 
 from sympy import Function, Symbol, solve
 from sympy.core.compatibility import is_sequence, range, string_types
-
+from .point import Point, Point2D
 
 def idiff(eq, y, x, n=1):
     """Return ``dy/dx`` assuming that ``eq == 0``.
@@ -352,7 +352,6 @@ def closest_points(*args):
     (Point2D(62, 73), Point2D(59, 59))
 
     """
-    from .point import Point, Point2D
     from collections import deque
     from math import sqrt, pow
 
@@ -433,7 +432,6 @@ def farthest_points(*args):
     (Point2D(11, 85), Point2D(80, 89))
 
     """
-    from .point import Point, Point2D
 
     def rotatingCalipers(Points):
         def hulls(Points):

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -313,7 +313,7 @@ def convex_hull(*args):
 
 
 def closest_points(*args):
-    """The closest pair of points among a given set of points in 2-d plane.
+    """The closest pair of points among a given set of points in 2D plane.
 
     Parameters
     ==========
@@ -359,8 +359,8 @@ def closest_points(*args):
 
     points = list(args)
     for point in points:
-        if not isinstance(point,Point2D):
-            raise NotImplementedError('The input must be a set of 2D points')
+     if not all([point.x.is_number, point.y.is_number]):
+         raise NotImplementedError('The input must be a set of 2D points')
     if len(points) < 2:
         raise NotImplementedError('At-least 2 points must be inserted')
     p = points
@@ -391,12 +391,12 @@ def closest_points(*args):
 
 
 def farthest_points(*args):
-    """The farthest pair of points among a given set of points in 2-d plane.
+    """The farthest pair of points among a given set of points in 2D plane.
 
     Parameters
     ==========
 
-    args : a collection of Points on 2-d plane.
+    args : a collection of Points on 2D plane.
 
     Returns
     =======
@@ -466,8 +466,8 @@ def farthest_points(*args):
 
     points = list(args)
     for point in points:
-        if not isinstance(point,Point2D):
-            raise NotImplementedError('The input must be a set of 2D points')
+     if not all([point.x.is_number, point.y.is_number]):
+         raise NotImplementedError('The input must be a set of 2D points')
     if len(points) < 2:
         raise NotImplementedError('At-least 2 points must be inserted')
     points.sort(key=lambda x: x.args)

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -352,15 +352,15 @@ def closest_points(*args):
     (Point2D(62, 73), Point2D(59, 59))
 
     """
-    from .point import Point,Point2D
+    from .point import Point, Point2D
     from collections import deque
     import numbers
-    from math import sqrt,pow
+    from math import sqrt, pow
 
     points = list(args)
     for point in points:
-     if not all([point.x.is_number, point.y.is_number]):
-         raise NotImplementedError('The input must be a set of 2D points')
+        if not all([point.x.is_number, point.y.is_number]):
+            raise NotImplementedError('The input must be a set of 2D points')
     if len(points) < 2:
         raise NotImplementedError('At-least 2 points must be inserted')
     p = points
@@ -430,7 +430,7 @@ def farthest_points(*args):
     (Point2D(11, 85), Point2D(80, 89))
 
     """
-    from .point import Point,Point2D
+    from .point import Point, Point2D
 
     def rotatingCalipers(Points):
         def hulls(Points):
@@ -466,8 +466,8 @@ def farthest_points(*args):
 
     points = list(args)
     for point in points:
-     if not all([point.x.is_number, point.y.is_number]):
-         raise NotImplementedError('The input must be a set of 2D points')
+        if not all([point.x.is_number, point.y.is_number]):
+            raise NotImplementedError('The input must be a set of 2D points')
     if len(points) < 2:
         raise NotImplementedError('At-least 2 points must be inserted')
     points.sort(key=lambda x: x.args)

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -368,7 +368,8 @@ def closest_points(*args):
 
     """
     from collections import deque
-    from math import hypot
+    from math import hypot, sqrt as _sqrt
+    from sympy.functions.elementary.miscellaneous import sqrt
 
     p = [Point2D(i) for i in set(args)]
     if len(p) < 2:
@@ -378,6 +379,13 @@ def closest_points(*args):
         p.sort(key=lambda x: x.args)
     except TypeError:
         raise ValueError("The points could not be sorted.")
+
+    if any(not i.is_Rational for j in p for i in j.args):
+        def hypot(x, y):
+            arg = x*x + y*y
+            if arg.is_Rational:
+                return _sqrt(arg)
+            return sqrt(arg)
 
     rv = [(0, 1)]
     best_dist = hypot(p[1].x - p[0].x, p[1].y - p[0].y)
@@ -438,7 +446,7 @@ def farthest_points(*args):
     set([(Point2D(0, 0), Point2D(3, 4))])
 
     """
-    from math import hypot
+    from math import hypot, sqrt as _sqrt
 
     def rotatingCalipers(Points):
         U, L = convex_hull(*Points, **dict(polygon=False))
@@ -464,6 +472,15 @@ def farthest_points(*args):
                     i += 1
                 else:
                     j -= 1
+
+    p = [Point2D(i) for i in set(args)]
+
+    if any(not i.is_Rational for j in p for i in j.args):
+        def hypot(x, y):
+            arg = x*x + y*y
+            if arg.is_Rational:
+                return _sqrt(arg)
+            return sqrt(arg)
 
     rv = []
     diam = 0

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -341,12 +341,12 @@ def closest_points(*args):
     Examples
     ========
 
-    >>> from sympy.geometry.util import closest_points
+    >>> from sympy.geometry import closest_points, Point2D
     >>> points = [Point2D(5, 2), Point2D(7, 6), Point2D(3, 9), Point2D(9, 4), Point2D(8, 5)]
     >>> closest_points(*points)
     (Point2D(8, 5), Point2D(7, 6))
 
-    >>> from sympy.geometry.util import closest_points
+    >>> from sympy.geometry import closest_points, Point2D
     >>> points = [Point2D(80, 89), Point2D(11, 85), Point2D(32, 51), Point2D(59, 59), Point2D(39, 80), Point2D(62, 73)]
     >>> closest_points(*points)
     (Point2D(62, 73), Point2D(59, 59))
@@ -419,12 +419,12 @@ def farthest_points(*args):
     Examples
     ========
 
-    >>> from sympy.geometry.util import farthest_points
+    >>> from sympy.geometry import farthest_points, Point2D
     >>> points = [Point2D(5, 2), Point2D(7, 6), Point2D(3, 9), Point2D(9, 4), Point2D(8, 5)]
     >>> farthest_points(*points)
     (Point2D(3, 9), Point2D(9, 4))
 
-    >>> from sympy.geometry.util import farthest_points
+    >>> from sympy.geometry import farthest_points, Point2D
     >>> points = [Point2D(80, 89), Point2D(11, 85), Point2D(32, 51), Point2D(59, 59), Point2D(39, 80), Point2D(62, 73)]
     >>> farthest_points(*points)
     (Point2D(11, 85), Point2D(80, 89))

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -361,7 +361,7 @@ def closest_points(*args):
         raise NotImplementedError('At-least 2 points must be inserted')
     # make sure all our points are of the same dimension
     for i in range(0, len(points)):
-        if isinstance(points[i][0], (int, long, float)) == False or isinstance(points[i][1], (int, long, float)) == False or len(points[i]) != 2:
+        if isinstance(points[i][0], (int, float)) == False or isinstance(points[i][1], (int, float)) == False or len(points[i]) != 2:
             raise NotImplementedError('The input must be a set of 2-d points')
 
     p = points
@@ -471,7 +471,7 @@ def farthest_points(*args):
         raise NotImplementedError('At-least 2 points must be inserted')
 
     for i in range(0, len(points)):
-        if isinstance(points[i][0], (int, long, float)) == False or isinstance(points[i][1], (int, long, float)) == False or len(points[i]) != 2:
+        if isinstance(points[i][0], (int, float)) == False or isinstance(points[i][1], (int, float)) == False or len(points[i]) != 2:
             raise NotImplementedError('The input must be a set of 2-d points')
 
     # make sure all our points are of the same dimension


### PR DESCRIPTION
Calculates the closest pair of points in a given set of points in a 2-d plane using [sweepline](https://en.wikipedia.org/wiki/Sweep_line_algorithm) technique and  the farthest  pair of points in a given set of points  using convex hull and [rotating calipers](https://en.wikipedia.org/wiki/Rotating_calipers) technique.
The points are calculated _much_ faster because of **O(n log n)** algorithms. 

For 1000 points the time taken is **0.14 - 0.20** seconds whereas the brute force
takes around **14-17** seconds for the same.
For a _10000 points_ it calculates the result in **1.5-2** seconds on a 4gb ram, i3 processor.

Testing - 
I have attached [example.zip](https://github.com/sympy/sympy/files/100670/example.zip) which helps check the run time of both the algorithms, and also compares that with brute force(for verification). On a number of randomly generated test cases.

 Some discussion on this is also at #10327 
