### PR TITLE
Rename Sum.is_absolute_convergent to Sum.is_absolutely_converent

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -385,7 +385,7 @@ class Product(ExprWithIntLimits):
         try:
             is_conv = Sum(log_sum, *lim).is_convergent()
         except NotImplementedError:
-            if Sum(sequence_term - 1, *lim).is_absolute_convergent() is S.true:
+            if Sum(sequence_term - 1, *lim).is_absolutely_convergent() is S.true:
                 return S.true
             raise NotImplementedError("The algorithm to find the product convergence of %s "
                                         "is not yet implemented" % (sequence_term))

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -323,7 +323,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         See Also
         ========
 
-        Sum.is_absolute_convergent()
+        Sum.is_absolutely_convergent()
 
         Product.is_convergent()
         """
@@ -470,9 +470,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         raise NotImplementedError("The algorithm to find the Sum convergence of %s "
                                     "is not yet implemented" % (sequence_term))
 
-    def is_absolute_convergent(self):
+    def is_absolutely_convergent(self):
         """
         Checks for the absolute convergence of an infinite series.
+
         Same as checking convergence of absolute value of sequence_term of
         an infinite series.
 
@@ -486,9 +487,9 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         >>> from sympy import Sum, Symbol, sin, oo
         >>> n = Symbol('n', integer=True)
-        >>> Sum((-1)**n, (n, 1, oo)).is_absolute_convergent()
+        >>> Sum((-1)**n, (n, 1, oo)).is_absolutely_convergent()
         False
-        >>> Sum((-1)**n/n**2, (n, 1, oo)).is_absolute_convergent()
+        >>> Sum((-1)**n/n**2, (n, 1, oo)).is_absolutely_convergent()
         True
 
         See Also

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -908,9 +908,9 @@ def test_is_convergent():
     assert Sum(f, (n, -oo, 1)).is_convergent() is S.true
 
 
-def test_is_absolute_convergent():
-    assert Sum((-1)**n, (n, 1, oo)).is_absolute_convergent() is S.false
-    assert Sum((-1)**n/n**2, (n, 1, oo)).is_absolute_convergent() is S.true
+def test_is_absolutely_convergent():
+    assert Sum((-1)**n, (n, 1, oo)).is_absolutely_convergent() is S.false
+    assert Sum((-1)**n/n**2, (n, 1, oo)).is_absolutely_convergent() is S.true
 
 
 @XFAIL


### PR DESCRIPTION
The latter is more grammatically correct.

This has not yet been included in a released version of SymPy, so no
deprecations are needed.

@gxyd @jksuom 
