### PR TITLE
solveset: Fixed issue #10397

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -804,7 +804,8 @@ def solveset_complex(f, symbol):
             for equation in equations:
                 if equation == f:
                     if any(_has_rational_power(g, symbol)[0]
-                           for g in equation.args):
+                           for g in equation.args) or _has_rational_power(
+                           equation, symbol)[0]:
                         result += _solve_radical(equation,
                                                  symbol,
                                                  solveset_complex)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1062,3 +1062,7 @@ def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
                 (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)
+
+
+def test_issue_10397():
+    assert solveset(sqrt(x), x, S.Complexes) == FiniteSet(0)


### PR DESCRIPTION
Resolved `solveset_complex`'s inability to account `sqrt(x) == 0` as a
radical equation by looking for rational powers not only in the equation's
`args`, but also in the equation itself. `solveset_complex` should now be
able to handle `x**p == 0` correctly for rational `p`.

``` Python
>>> solveset(sqrt(x), x, S.Complexes)
{0}
>>> solveset(x**(S(2)/3), x, S.Complexes)
{0}
```
