### PR TITLE
Dict: Added support for collections.defaultdict

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -194,8 +194,7 @@ class Dict(Basic):
     """
 
     def __new__(cls, *args):
-        if len(args) == 1 and (isinstance(args[0], dict) or
-            isinstance(args[0], Dict)):
+        if len(args) == 1 and isinstance(args[0], (dict, Dict)):
             items = [Tuple(k, v) for k, v in args[0].items()]
         elif iterable(args) and all(len(arg) == 2 for arg in args):
             items = [Tuple(k, v) for k, v in args]

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,6 +8,7 @@
 
 from __future__ import print_function, division
 
+from collections import defaultdict
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, range
 from sympy.core.sympify import sympify, converter
@@ -194,8 +195,9 @@ class Dict(Basic):
     """
 
     def __new__(cls, *args):
-        if len(args) == 1 and ((args[0].__class__ is dict) or
-                             (args[0].__class__ is Dict)):
+        if len(args) == 1 and (isinstance(args[0], dict) or
+            isinstance(args[0], Dict) or
+            isinstance(args[0], defaultdict)):
             items = [Tuple(k, v) for k, v in args[0].items()]
         elif iterable(args) and all(len(arg) == 2 for arg in args):
             items = [Tuple(k, v) for k, v in args]

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,7 +8,6 @@
 
 from __future__ import print_function, division
 
-from collections import defaultdict
 from sympy.core.basic import Basic
 from sympy.core.compatibility import as_int, range
 from sympy.core.sympify import sympify, converter

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -196,8 +196,7 @@ class Dict(Basic):
 
     def __new__(cls, *args):
         if len(args) == 1 and (isinstance(args[0], dict) or
-            isinstance(args[0], Dict) or
-            isinstance(args[0], defaultdict)):
+            isinstance(args[0], Dict)):
             items = [Tuple(k, v) for k, v in args[0].items()]
         elif iterable(args) and all(len(arg) == 2 for arg in args):
             items = [Tuple(k, v) for k, v in args]

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet, Integer
 from sympy.core.containers import tuple_wrapper
 from sympy.utilities.pytest import raises
@@ -153,6 +154,17 @@ def test_Dict():
     # Test creating a Dict from a Dict.
     d = Dict({x: 1, y: 2, z: 3})
     assert d == Dict(d)
+
+    # Test for supporting defaultdict
+    d = defaultdict(int)
+    assert d[x] == 0
+    assert d[y] == 0
+    assert d[z] == 0
+    assert Dict(d)
+    d = Dict(d)
+    assert len(d) == 3
+    assert set(d.keys()) == set((x, y, z))
+    assert set(d.values()) == set((S(0), S(0), S(0)))
 
 
 def test_issue_5788():


### PR DESCRIPTION
This commit should fix #10433 
- Added support for `collections.defaultdict` which was previously not
  available
- Used `isinstance` for comparing class types instead of direct class
  comparison

Example:

Previously sympy didn't support `collections.defaultdict`:

```
In [1]: from sympy import Dict

In [2]: from collections import defaultdict

In [3]: d = defaultdict(int)

In [4]: d[0]
Out[4]: 0

In [5]: Dict(d)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-3ed73043b7a9> in <module>()
----> 1 Dict(d)

/usr/local/lib/python2.7/dist-packages/sympy/core/containers.pyc in __new__(cls, *args)
    201             items = [Tuple(k, v) for k, v in args]
    202         else:
--> 203             raise TypeError('Pass Dict args as Dict((k1, v1), ...) or Dict({k1: v1, ...})')
    204         elements = frozenset(items)
    205         obj = Basic.__new__(cls, elements)

TypeError: Pass Dict args as Dict((k1, v1), ...) or Dict({k1: v1, ...})
```

Now:

```
In [1]: from sympy import Dict

In [2]: from collections import defaultdict

In [3]: d = defaultdict(int)

In [4]: d[0]
Out[4]: 0

In [5]: Dict(d)
Out[5]: {0: 0}

In [6]: a = Dict(d)

In [7]: a.items()
Out[7]: [(0, 0)]
```
