### PR TITLE
solveset consolidation and related changes

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1784,9 +1784,11 @@ def check_nonlinear_2eq_order1(eq, func, func_coef):
         return 'type3'
     r1 = eq[0].match(diff(x(t),t) - f)
     r2 = eq[1].match(diff(y(t),t) - g)
-    num, denum = ((r1[f].subs(x(t),u).subs(y(t),v))/(r2[g].subs(x(t),u).subs(y(t),v))).as_numer_denom()
+    num, den = (
+        (r1[f].subs(x(t),u).subs(y(t),v))/
+        (r2[g].subs(x(t),u).subs(y(t),v))).as_numer_denom()
     R1 = num.match(f1*g1)
-    R2 = denum.match(f2*g2)
+    R2 = den.match(f2*g2)
     phi = (r1[f].subs(x(t),u).subs(y(t),v))/num
     if R1 and R2:
         return 'type4'
@@ -3558,8 +3560,8 @@ def ode_2nd_power_series_ordinary(eq, func, order, match):
     seriesdict = {}
     recurr = Function("r")
 
-    # Generating the recurrence relation which works this way
-    # a] For the second order term the summation begins at n = 2. The coefficients
+    # Generating the recurrence relation which works this way:
+    # for the second order term the summation begins at n = 2. The coefficients
     # p is multiplied with an*(n - 1)*(n - 2)*x**n-2 and a substitution is made such that
     # the exponent of x becomes n.
     # For example, if p is x, then the second degree recurrence term is
@@ -3635,8 +3637,7 @@ def ode_2nd_power_series_ordinary(eq, func, order, match):
     # Checking how many values are already present
     tcounter = len([t for t in finaldict.values() if t])
 
-    for count in range(tcounter, terms - 3):  # Assuming c0 and c1 to be arbitrary
-    #while tcounter < terms - 2:  # Assuming c0 and c1 to be arbitrary
+    for _ in range(tcounter, terms - 3):  # Assuming c0 and c1 to be arbitrary
         check = rhs.subs(n, startiter)
         nlhs = lhs.subs(n, startiter)
         nrhs = check.subs(finaldict)
@@ -4265,7 +4266,7 @@ def _linear_coeff_match(expr, func):
         if eq is a*x + b*f(x) + c, else None.
         '''
         eq = _mexpand(eq)
-        c = eq.as_independent(x, f(x), as_Add = True)[0]
+        c = eq.as_independent(x, f(x), as_Add=True)[0]
         if not c.is_Rational:
             return
         a = eq.coeff(x)
@@ -6800,10 +6801,10 @@ def sysode_linear_2eq_order2(match_):
     r = dict()
     t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
     for i in range(2):
-        eqs = 0
+        eqs = []
         for terms in Add.make_args(eq[i]):
-            eqs += terms/fc[i,func[i],2]
-        eq[i] = eqs
+            eqs.append(terms/fc[i,func[i],2])
+        eq[i] = Add(*eqs)
     # for equations Eq(diff(x(t),t,t), a1*diff(x(t),t)+b1*diff(y(t),t)+c1*x(t)+d1*y(t)+e1)
     # and Eq(a2*diff(y(t),t,t), a2*diff(x(t),t)+b2*diff(y(t),t)+c2*x(t)+d2*y(t)+e2)
     r['a1'] = -fc[0,x(t),1]/fc[0,x(t),2] ; r['a2'] = -fc[1,x(t),1]/fc[1,y(t),2]
@@ -7184,14 +7185,16 @@ def _linear_2eq_order2_type6(x, y, t, r, eq):
     C1, C2, C3, C4 = get_numbered_constants(eq, num=4)
     k = Symbol('k')
     z = Function('z')
-    num, denum = cancel((r['c1']*x(t) + r['d1']*y(t))/(r['c2']*x(t) + r['d2']*y(t))).as_numer_denom()
+    num, den = cancel(
+        (r['c1']*x(t) + r['d1']*y(t))/
+        (r['c2']*x(t) + r['d2']*y(t))).as_numer_denom()
     f = r['c1']/num.coeff(x(t))
     a1 = num.coeff(x(t))
     b1 = num.coeff(y(t))
-    a2 = denum.coeff(x(t))
-    b2 = denum.coeff(y(t))
+    a2 = den.coeff(x(t))
+    b2 = den.coeff(y(t))
     chareq = k**2 - (a1 + b2)*k + a1*b2 - a2*b1
-    [k1, k2] = [rootof(chareq, k) for k in range(Poly(chareq).degree())]
+    k1, k2 = [rootof(chareq, k) for k in range(Poly(chareq).degree())]
     z1 = dsolve(diff(z(t),t,t) - k1*f*z(t)).rhs
     z2 = dsolve(diff(z(t),t,t) - k2*f*z(t)).rhs
     sol1 = (k1*z2 - k2*z1 + a1*(z1 - z2))/(a2*(k1-k2))
@@ -7229,12 +7232,14 @@ def _linear_2eq_order2_type7(x, y, t, r, eq):
     """
     C1, C2, C3, C4 = get_numbered_constants(eq, num=4)
     k = Symbol('k')
-    num, denum = cancel((r['a1']*x(t) + r['b1']*y(t))/(r['a2']*x(t) + r['b2']*y(t))).as_numer_denom()
+    num, den = cancel(
+        (r['a1']*x(t) + r['b1']*y(t))/
+        (r['a2']*x(t) + r['b2']*y(t))).as_numer_denom()
     f = r['a1']/num.coeff(x(t))
     a1 = num.coeff(x(t))
     b1 = num.coeff(y(t))
-    a2 = denum.coeff(x(t))
-    b2 = denum.coeff(y(t))
+    a2 = den.coeff(x(t))
+    b2 = den.coeff(y(t))
     chareq = k**2 - (a1 + b2)*k + a1*b2 - a2*b1
     [k1, k2] = [rootof(chareq, k) for k in range(Poly(chareq).degree())]
     F = Integral(f, t)
@@ -7283,10 +7288,10 @@ def _linear_2eq_order2_type8(x, y, t, r, eq):
 
     """
     C1, C2, C3, C4 = get_numbered_constants(eq, num=4)
-    num, denum = cancel(r['d1']/r['c2']).as_numer_denom()
+    num, den = cancel(r['d1']/r['c2']).as_numer_denom()
     f = -r['d1']/num
     a = num
-    b = denum
+    b = den
     mul = sqrt(abs(a*b))
     Igral = Integral(t*f, t)
     if a*b > 0:
@@ -7386,8 +7391,8 @@ def _linear_2eq_order2_type10(x, y, t, r, eq):
     q = Wild('q', exclude=[t, t**2])
     s = Wild('s', exclude=[t, t**2])
     n = Wild('n', exclude=[t, t**2])
-    num, denum = r['c1'].as_numer_denom()
-    dic = denum.match((n*(p*t**2+q*t+s)**2).expand())
+    num, den = r['c1'].as_numer_denom()
+    dic = den.match((n*(p*t**2+q*t+s)**2).expand())
     eqz = dic[p]*t**2 + dic[q]*t + dic[s]
     a = num/dic[n]
     b = cancel(r['d1']*eqz**2)
@@ -7938,9 +7943,11 @@ def _nonlinear_2eq_order1_type4(x, y, t, eq):
     g2 = Wild('g2', exclude=[u,t])
     r1 = eq[0].match(diff(x(t),t) - f)
     r2 = eq[1].match(diff(y(t),t) - g)
-    num, denum = ((r1[f].subs(x(t),u).subs(y(t),v))/(r2[g].subs(x(t),u).subs(y(t),v))).as_numer_denom()
+    num, den = (
+        (r1[f].subs(x(t),u).subs(y(t),v))/
+        (r2[g].subs(x(t),u).subs(y(t),v))).as_numer_denom()
     R1 = num.match(f1*g1)
-    R2 = denum.match(f2*g2)
+    R2 = den.match(f2*g2)
     phi = (r1[f].subs(x(t),u).subs(y(t),v))/num
     F1 = R1[f1]; F2 = R2[f2]
     G1 = R1[g1]; G2 = R2[g2]

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -655,14 +655,13 @@ def solveset(f, symbol=None, domain=S.Complexes, check=True, _first=True, ):
         It is a bug, please report to the github issue tracker.
 
 
-    `solveset` uses two underlying functions `solveset_real` and
-    `solveset_complex` to solve equations. They are the solvers for real and
-    complex domain respectively. `solveset` ignores the assumptions on the
-    variable being solved for and instead, uses the `domain` parameter to
-    decide which solver to use.
-
     Notes
     =====
+
+    The output of `solveset` depends on the requested domain. It
+    ignores assumptions on the symbol procided by design: it will
+    always be clear what domain is being used without need to
+    reference to the assumptions used to ceate the symbol.
 
     Python interprets 0 and 1 as False and True, respectively, but
     in this function they refer to solutions of an expression. So 0 and 1
@@ -693,16 +692,17 @@ def solveset(f, symbol=None, domain=S.Complexes, check=True, _first=True, ):
       interface, then specify that the domain is real. Alternatively use
       `solveset\_real`.
 
+    >>> R = S.Reals
     >>> x = Symbol('x')
-    >>> solveset(exp(x) - 1, x, S.Reals)
+    >>> solveset(exp(x) - 1, x, R)
     {0}
-    >>> solveset(Eq(exp(x), 1), x, S.Reals)
+    >>> solveset(Eq(exp(x), 1), x, R)
     {0}
 
     * Inequalities can be solved over the real domain only. Use of a complex
       domain leads to a NotImplementedError.
 
-    >>> solveset(exp(x) > 1, x, S.Reals)
+    >>> solveset(exp(x) > 1, x, R)
     (0, oo)
 
     """

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -85,7 +85,7 @@ def _invert_real(f, g_ys, symbol):
     if not f.has(symbol):
         raise ValueError("Inverse of constant function doesn't exist")
 
-    if f is symbol:
+    if f == symbol:
         return (f, g_ys)
 
     n = Dummy('n', real=True)
@@ -217,7 +217,7 @@ def _invert_complex(f, g_ys, symbol):
     if not f.has(symbol):
         raise ValueError("Inverse of constant function doesn't exist")
 
-    if f is symbol:
+    if f == symbol:
         return (f, g_ys)
 
     n = Dummy('n')
@@ -434,7 +434,7 @@ def _solve_as_poly(f, symbol, solveset_solver, invert_func, domain=S.Complexes):
             if gen != symbol:
                 y = Dummy('y')
                 lhs, rhs_s = invert_func(gen, y, symbol)
-                if lhs is symbol:
+                if lhs == symbol:
                     result = Union(*[rhs_s.subs(y, s) for s in poly_solns])
                 else:
                     result = ConditionSet(symbol, Eq(f, 0), domain)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -604,7 +604,7 @@ def _solveset(f, symbol, domain):
     return result
 
 
-def solveset(f, symbol=None, domain=S.Complexes, check=True, _first=True, ):
+def solveset(f, symbol=None, domain=S.Complexes, _check=True, _first=True, ):
     """Solves a given inequality or equation with set as output
 
     Parameters
@@ -643,10 +643,9 @@ def solveset(f, symbol=None, domain=S.Complexes, check=True, _first=True, ):
     Notes
     =====
 
-    The output of `solveset` depends on the requested domain. It
-    ignores assumptions on the symbol procided by design: it will
-    always be clear what domain is being used without need to
-    reference to the assumptions used to ceate the symbol.
+    The output of `solveset` depends on the requested domain rather
+    than on the assumptions a symbol may have. Assumptions on symbols
+    are ignored.
 
     Python interprets 0 and 1 as False and True, respectively, but
     in this function they refer to solutions of an expression. So 0 and 1
@@ -700,7 +699,7 @@ def solveset(f, symbol=None, domain=S.Complexes, check=True, _first=True, ):
             # -- leave it alone
             return result
 
-        if check:
+        if _check:
             # whittle away all but the symbol-containing core
             # to use this for testing
             fx = f.as_independent(symbol, as_Add=True)[1]
@@ -770,7 +769,7 @@ def solveset(f, symbol=None, domain=S.Complexes, check=True, _first=True, ):
 def _invalid_solutions(f, symbol, domain):
     bad = S.EmptySet
     for d in denoms(f):
-        bad += solveset(d, symbol, domain, _first=False, check=False)
+        bad += solveset(d, symbol, domain, _first=False, _check=False)
     return result
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -784,7 +784,9 @@ def solveset(f, symbol=None, domain=S.Complexes):
                 setting domain=S.Reals'''))
         try:
             result = solve_univariate_inequality(
-            f, symbol, relational=False).intersection(domain)
+            f, symbol, relational=False)
+            for d in denoms(f, [symbol]):
+                result -= solveset(d, symbol, domain)
         except NotImplementedError:
             result = ConditionSet(symbol, f, domain)
         return result

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1089,3 +1089,11 @@ def test_issue_10555():
     f = Function('f')
     assert solveset(f(x) - pi/2, x, S.Reals) == \
         ConditionSet(x, Eq(2*f(x) - pi, 0), S.Reals)
+
+
+def test_issue_8715():
+    eq = x + 1/x > -2 + 1/x
+    assert solveset(eq, x, S.Reals) == \
+        (Interval.open(-2, oo) - FiniteSet(0))
+    assert solveset(eq.subs(x,log(x)), x, S.Reals) == \
+        Interval.open(exp(-2), oo) - FiniteSet(1)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -635,6 +635,9 @@ def test_piecewise():
     f = Piecewise(((x - 2)**2, x >= 0), (0, True))
     assert solveset(f, x, domain=S.Reals) == Union(FiniteSet(2), Interval(-oo, 0, True, True))
 
+    assert solveset(Piecewise((x + 1, x > 0), (I, True)) - I, x) == \
+        Interval(-oo, 0)
+
 
 def test_solveset_complex_polynomial():
     from sympy.abc import x, a, b, c

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -577,6 +577,8 @@ def test_solve_abs():
     assert solveset_real(eq, x) == u
     assert solveset(eq, x, domain=S.Reals) == u
 
+    raises(ValueError, lambda: solveset(abs(x) - 1, x))
+
 
 @XFAIL
 def test_rewrite_trigh():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -163,8 +163,9 @@ def test_invert_complex():
 
     assert invert_complex(log(x), y, x) == (x, FiniteSet(exp(y)))
 
-    raises(ValueError, lambda: invert_real(S.One, y, x))
+    raises(ValueError, lambda: invert_real(1, y, x))
     raises(ValueError, lambda: invert_complex(x, x, x))
+    raises(ValueError, lambda: invert_complex(x, x, 1))
 
 
 def test_domain_check():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,5 +1,5 @@
 from sympy import (
-    Abs, Dummy, Eq, Gt,
+    Abs, Dummy, Eq, Gt, Function,
     LambertW, Piecewise, Poly, Rational, S, Symbol, Matrix,
     asin, acos, acsc, asec, atan, atanh, cos, csc, erf, erfinv, erfc, erfcinv,
     exp, log, pi, sin, sinh, sec, sqrt, symbols,
@@ -1083,3 +1083,9 @@ def test_simplification():
     eq = x + (a - b)/(-2*a + 2*b)
     assert solveset(eq, x) == FiniteSet(S.Half)
     assert solveset(eq, x, S.Reals) == FiniteSet(S.Half)
+
+
+def test_issue_10555():
+    f = Function('f')
+    assert solveset(f(x) - pi/2, x, S.Reals) == \
+        ConditionSet(x, Eq(2*f(x) - pi, 0), S.Reals)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -624,14 +624,15 @@ def test_atan2():
 
 def test_piecewise():
     eq = Piecewise((x - 2, Gt(x, 2)), (2 - x, True)) - 3
-    f = Piecewise(((x - 2)**2, x >= 0), (0, True))
     assert set(solveset_real(eq, x)) == set(FiniteSet(-1, 5))
+
     absxm3 = Piecewise(
         (x - 3, S(0) <= x - 3),
-        (3 - x, S(0) > x - 3)
-    )
+        (3 - x, S(0) > x - 3))
     y = Symbol('y', positive=True)
     assert solveset_real(absxm3 - y, x) == FiniteSet(-y + 3, y + 3)
+
+    f = Piecewise(((x - 2)**2, x >= 0), (0, True))
     assert solveset(f, x, domain=S.Reals) == Union(FiniteSet(2), Interval(-oo, 0, True, True))
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1072,3 +1072,9 @@ def test_issue_9913():
 
 def test_issue_10397():
     assert solveset(sqrt(x), x, S.Complexes) == FiniteSet(0)
+
+
+def test_simplification():
+    eq = x + (a - b)/(-2*a + 2*b)
+    assert solveset(eq, x) == FiniteSet(S.Half)
+    assert solveset(eq, x, S.Reals) == FiniteSet(S.Half)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -741,6 +741,12 @@ def test_solve_trig():
         Union(imageset(Lambda(n, 2*n*pi + pi/3), S.Integers),
               imageset(Lambda(n, 2*n*pi - pi/3), S.Integers))
 
+    y, a = symbols('y,a')
+    assert solveset(sin(y + a) - sin(y), a, domain=S.Reals) == \
+        Union(imageset(Lambda(n, 2*n*pi), S.Integers),
+        imageset(Lambda(n,
+        -I*(I*(2*n*pi +arg(-exp(-2*I*y))) + 2*im(y))), S.Integers))
+
 
 @XFAIL
 def test_solve_trig_abs():
@@ -897,10 +903,6 @@ def test_conditionset():
 
     assert solveset(x + sin(x) > 1, x, domain=S.Reals) == \
         ConditionSet(x, x + sin(x) > 1, S.Reals)
-
-    y,a = symbols('y,a')
-    assert solveset(sin(y + a) - sin(y), a, domain=S.Reals) == \
-        ConditionSet(a, Eq(-sin(y) + sin(y + a), 0), S.Reals)
 
 
 @XFAIL

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -41,7 +41,7 @@ def test_single_normal():
     pdf = density(Y)
     x = Symbol('x')
     assert (pdf(x) ==
-            2**S.Half*exp(-(x - mu)**2/(2*sigma**2))/(2*pi**S.Half*sigma))
+            2**S.Half*exp(-(mu - x)**2/(2*sigma**2))/(2*pi**S.Half*sigma))
 
     assert P(X**2 < 1) == erf(2**S.Half/2)
 


### PR DESCRIPTION
closes #10555 
closes #10579 

@MSeeker , it also bothered me that the code for solveset_real and solveset_complex was _so similar_ and yet existed as two functions. As to the reason for the expansion code, it is attempting to get the equations into a standardized form and not (as the inline note said) oscillating between related forms. It could be that the complex functions didn't attempt the same sort of simplification as the real form so that's why it appeared only in the real form. Anyway, it's a lot more unified now with a less destructive expansion being used.

It was interesting to see a failing test pass after reconstruction.

I also discovered a very nasty sort of simple mistake (`foo is x` instead of `foo == x` that was causing different code paths to be taken). That didn't show up until after reconstruction: sometimes tests would pass and sometimes they would fail. This is what necessitated the "minimal simplification" that I added: when the poly-solver was handling the equations (instead of the inverter) the simplification was being done; after the changes the poly-solver was being detected as unnecessary so that special simplification was added in an unobtrusive place.

This does not yet resolve issue #10430 

``` python
>>> from sympy import *
>>> x = var('x'); eq = (x-1)*sin(x)

>>> solveset(eq, x)
ConditionSet(x, Eq((x - 1)*sin(x), 0), Complexes((-oo, oo) x (-oo, oo), False))

>>> solveset(sin(x), x)
ImageSet(Lambda(_n, 2*_n*pi), Integers()) U ImageSet(Lambda(_n, 2*_n*pi + pi), Integers())
```
