### PR TITLE
Added orthogonalize and project functions to the vector module

### DIFF
--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -517,6 +517,8 @@ def orthogonalize(vlist, orthonormal=False):
     for i, term in enumerate(vlist):
         for j in range(i):
             term -= ortho_vlist[j].projection(vlist[i])
+        # TODO : The following line introduces a performance issue
+        # and needs to be changed once a good solution for issue #10279 is found.
         if simplify(term).equals(Vector.zero):
             raise ValueError("Vector set not linearly independent")
         ortho_vlist.append(term)

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -475,7 +475,7 @@ def _path(from_object, to_object):
         i -= 1
     return index, from_path
 
-def orthogonalize(vlist, orthonormal=False):
+def orthogonalize(*vlist, **kwargs):
     """
     Takes a sequence of independent vectors and orthogonalizes them
     using the Gram - Schmidt process. Returns a list of
@@ -509,6 +509,7 @@ def orthogonalize(vlist, orthonormal=False):
     .. [1] https://en.wikipedia.org/wiki/Gram-Schmidt_process
 
     """
+    orthonormal = kwargs.get('orthonormal', False)
 
     if not all(isinstance(vec, Vector) for vec in vlist):
         raise TypeError('Each element must be of Type Vector')

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -516,9 +516,8 @@ def orthogonalize(*vlist, **kwargs):
 
     ortho_vlist = []
     for i, term in enumerate(vlist):
-        term = vlist[i]
         for j in range(i):
-            term -= ortho_vlist[j].vec_project(vlist[i])
+            term -= ortho_vlist[j].projection(vlist[i])
         if simplify(term).equals(Vector.zero):
             raise ValueError("Vector set not linearly independent")
         ortho_vlist.append(term)

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -500,7 +500,7 @@ def orthogonalize(*vlist, **kwargs):
     >>> i, j, k = C.base_vectors()
     >>> v1 = i + 2*j
     >>> v2 = 2*i + 3*j
-    >>> orthogonalize([v1, v2])
+    >>> orthogonalize(v1, v2)
     [C.i + 2*C.j, 2/5*C.i + (-1/5)*C.j]
 
     References

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -474,3 +474,54 @@ def _path(from_object, to_object):
         from_path.append(other_path[i])
         i -= 1
     return index, from_path
+
+def orthogonalize(vlist, orthonormal=False):
+    """
+    Takes a set of independent vectors and orthogonalizes them
+    using the Gram - Schmidt process. Returns a set of
+    orthogonal or orthonormal vectors.
+
+    Parameters
+    ==========
+
+    vlist : list of independent vectors to be made orthogonal.
+
+    orthonormal : Optional parameter
+    Set to True if the the vectors returned should be orthonormal.
+    Default: False
+
+    Examples
+    ========
+
+    >>> from sympy.vector.coordsysrect import CoordSysCartesian
+    >>> from sympy.vector.vector import Vector, BaseVector
+    >>> from sympy.vector.functions import orthogonalize
+    >>> C = CoordSysCartesian('C')
+    >>> i, j, k = C.base_vectors()
+    >>> v1 = i + 2*j
+    >>> v2 = 2*i + 3*j
+    >>> orthogonalize([v1, v2])
+    [C.i + 2*C.j, 2/5*C.i + (-1/5)*C.j]
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Gram-Schmidt_process
+
+    """
+    if not all(isinstance(vec, Vector) for vec in vlist):
+        raise TypeError('Each element must be of Type Vector')
+
+    ortho_vlist = []
+    for i in range(len(vlist)):
+        term = vlist[i]
+        for j in range(i):
+            term -= ortho_vlist[j].vec_project(vlist[i])
+        if term == Vector.zero:
+            raise ValueError("Vector set not linearly independent")
+        ortho_vlist.append(term)
+
+    if orthonormal:
+        ortho_vlist = [vec.normalize() for vec in ortho_vlist]
+
+    return ortho_vlist

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -484,11 +484,11 @@ def orthogonalize(*vlist, **kwargs):
     Parameters
     ==========
 
-    vlist : list of independent vectors to be made orthogonal.
+    vlist : sequence of independent vectors to be made orthogonal.
 
     orthonormal : Optional parameter
-    Set to True if the the vectors returned should be orthonormal.
-    Default: False
+                  Set to True if the the vectors returned should be orthonormal.
+                  Default: False
 
     Examples
     ========

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -475,10 +475,10 @@ def _path(from_object, to_object):
         i -= 1
     return index, from_path
 
-def orthogonalize(vlist, orthonormal=False):
+def orthogonalize(*vlist, **kwargs):
     """
-    Takes a set of independent vectors and orthogonalizes them
-    using the Gram - Schmidt process. Returns a set of
+    Takes a list of independent vectors and orthogonalizes them
+    using the Gram - Schmidt process. Returns a list of
     orthogonal or orthonormal vectors.
 
     Parameters
@@ -509,6 +509,8 @@ def orthogonalize(vlist, orthonormal=False):
     .. [1] https://en.wikipedia.org/wiki/Gram-Schmidt_process
 
     """
+    orthonormal = kwargs.get('orthonormal', False)
+
     if not all(isinstance(vec, Vector) for vec in vlist):
         raise TypeError('Each element must be of Type Vector')
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -2,7 +2,7 @@ from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.dyadic import Dyadic
 from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.scalar import BaseScalar
-from sympy import sympify, diff, integrate, S
+from sympy import sympify, diff, integrate, S, simplify
 
 
 def express(expr, system, system2=None, variables=False):
@@ -477,7 +477,7 @@ def _path(from_object, to_object):
 
 def orthogonalize(*vlist, **kwargs):
     """
-    Takes a list of independent vectors and orthogonalizes them
+    Takes a sequence of independent vectors and orthogonalizes them
     using the Gram - Schmidt process. Returns a list of
     orthogonal or orthonormal vectors.
 
@@ -515,11 +515,11 @@ def orthogonalize(*vlist, **kwargs):
         raise TypeError('Each element must be of Type Vector')
 
     ortho_vlist = []
-    for i in range(len(vlist)):
+    for i, term in enumerate(vlist):
         term = vlist[i]
         for j in range(i):
             term -= ortho_vlist[j].vec_project(vlist[i])
-        if term == Vector.zero:
+        if simplify(term).equals(Vector.zero):
             raise ValueError("Vector set not linearly independent")
         ortho_vlist.append(term)
 

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -475,7 +475,7 @@ def _path(from_object, to_object):
         i -= 1
     return index, from_path
 
-def orthogonalize(*vlist, **kwargs):
+def orthogonalize(vlist, orthonormal=False):
     """
     Takes a sequence of independent vectors and orthogonalizes them
     using the Gram - Schmidt process. Returns a list of
@@ -509,7 +509,6 @@ def orthogonalize(*vlist, **kwargs):
     .. [1] https://en.wikipedia.org/wiki/Gram-Schmidt_process
 
     """
-    orthonormal = kwargs.get('orthonormal', False)
 
     if not all(isinstance(vec, Vector) for vec in vlist):
         raise TypeError('Each element must be of Type Vector')

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -1,7 +1,8 @@
 from sympy.vector.vector import Vector
 from sympy.vector.coordsysrect import CoordSysCartesian
-from sympy.vector.functions import express, matrix_to_vector
-from sympy import symbols, S, sin, cos, ImmutableMatrix as Matrix
+from sympy.vector.functions import express, matrix_to_vector, orthogonalize
+from sympy import symbols, S, sqrt, sin, cos, ImmutableMatrix as Matrix
+from sympy.utilities.pytest import raises
 
 N = CoordSysCartesian('N')
 q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
@@ -157,3 +158,18 @@ def test_matrix_to_vector():
            Vector.zero
     m = Matrix([[q1], [q2], [q3]])
     assert matrix_to_vector(m, N) == q1*N.i + q2*N.j + q3*N.k
+
+
+def test_orthogonalize():
+    C = CoordSysCartesian('C')
+    i, j, k = C.base_vectors()
+    v1 = i + 2*j
+    v2 = 2*i + 3*j
+    v3 = 3*i + 5*j
+    v4 = 3*i + j
+    v5 = 2*i + 2*j
+    assert orthogonalize([v1, v2]) == [C.i + 2*C.j, 2*C.i/5 + -C.j/5]
+    # from wikipedia
+    assert orthogonalize([v4, v5], True) == \
+        [(3*sqrt(10))*C.i/10 + (sqrt(10))*C.j/10, (-sqrt(10))*C.i/10 + (3*sqrt(10))*C.j/10]
+    raises(ValueError, lambda: orthogonalize([v1, v2, v3]))

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -171,9 +171,9 @@ def test_orthogonalize():
     v5 = 2*i + 2*j
     v6 = a*i + b*j
     v7 = 4*a*i + 4*b*j
-    assert orthogonalize([v1, v2]) == [C.i + 2*C.j, 2*C.i/5 + -C.j/5]
+    assert orthogonalize(v1, v2) == [C.i + 2*C.j, 2*C.i/5 + -C.j/5]
     # from wikipedia
-    assert orthogonalize([v4, v5], orthonormal=True) == \
+    assert orthogonalize(v4, v5, orthonormal=True) == \
         [(3*sqrt(10))*C.i/10 + (sqrt(10))*C.j/10, (-sqrt(10))*C.i/10 + (3*sqrt(10))*C.j/10]
-    raises(ValueError, lambda: orthogonalize([v1, v2, v3]))
-    raises(ValueError, lambda: orthogonalize([v6, v7]))
+    raises(ValueError, lambda: orthogonalize(v1, v2, v3))
+    raises(ValueError, lambda: orthogonalize(v6, v7))

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -168,8 +168,8 @@ def test_orthogonalize():
     v3 = 3*i + 5*j
     v4 = 3*i + j
     v5 = 2*i + 2*j
-    assert orthogonalize([v1, v2]) == [C.i + 2*C.j, 2*C.i/5 + -C.j/5]
+    assert orthogonalize(v1, v2) == [C.i + 2*C.j, 2*C.i/5 + -C.j/5]
     # from wikipedia
-    assert orthogonalize([v4, v5], True) == \
+    assert orthogonalize(v4, v5, orthonormal=True) == \
         [(3*sqrt(10))*C.i/10 + (sqrt(10))*C.j/10, (-sqrt(10))*C.i/10 + (3*sqrt(10))*C.j/10]
-    raises(ValueError, lambda: orthogonalize([v1, v2, v3]))
+    raises(ValueError, lambda: orthogonalize(v1, v2, v3))

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -162,14 +162,18 @@ def test_matrix_to_vector():
 
 def test_orthogonalize():
     C = CoordSysCartesian('C')
+    a, b = symbols('a b', integer=True);
     i, j, k = C.base_vectors()
     v1 = i + 2*j
     v2 = 2*i + 3*j
     v3 = 3*i + 5*j
     v4 = 3*i + j
     v5 = 2*i + 2*j
+    v6 = a*i + b*j
+    v7 = 4*a*i + 4*b*j
     assert orthogonalize(v1, v2) == [C.i + 2*C.j, 2*C.i/5 + -C.j/5]
     # from wikipedia
     assert orthogonalize(v4, v5, orthonormal=True) == \
         [(3*sqrt(10))*C.i/10 + (sqrt(10))*C.j/10, (-sqrt(10))*C.i/10 + (3*sqrt(10))*C.j/10]
     raises(ValueError, lambda: orthogonalize(v1, v2, v3))
+    raises(ValueError, lambda: orthogonalize(v6, v7))

--- a/sympy/vector/tests/test_functions.py
+++ b/sympy/vector/tests/test_functions.py
@@ -171,9 +171,9 @@ def test_orthogonalize():
     v5 = 2*i + 2*j
     v6 = a*i + b*j
     v7 = 4*a*i + 4*b*j
-    assert orthogonalize(v1, v2) == [C.i + 2*C.j, 2*C.i/5 + -C.j/5]
+    assert orthogonalize([v1, v2]) == [C.i + 2*C.j, 2*C.i/5 + -C.j/5]
     # from wikipedia
-    assert orthogonalize(v4, v5, orthonormal=True) == \
+    assert orthogonalize([v4, v5], orthonormal=True) == \
         [(3*sqrt(10))*C.i/10 + (sqrt(10))*C.j/10, (-sqrt(10))*C.i/10 + (3*sqrt(10))*C.j/10]
-    raises(ValueError, lambda: orthogonalize(v1, v2, v3))
-    raises(ValueError, lambda: orthogonalize(v6, v7))
+    raises(ValueError, lambda: orthogonalize([v1, v2, v3]))
+    raises(ValueError, lambda: orthogonalize([v6, v7]))

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -190,7 +190,7 @@ def test_vec_project():
     v1 = i + j + k
     v2 = 3*i + 4*j
     assert v1.vec_project(v1) == i + j + k
-    assert v1.vec_project(v2) == 7/3*i + 7/3*j + 7/3*k
+    assert v1.vec_project(v2) == 7/3*C.i + 7/3*C.j + 7/3*C.k
 
 
 def test_scalar_project():

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -191,6 +191,8 @@ def test_vec_project():
     v2 = 3*i + 4*j
     assert v1.vec_project(v1) == i + j + k
     assert v1.vec_project(v2) == 7/3*C.i + 7/3*C.j + 7/3*C.k
+    assert v1.vec_project(v1, scalar=True) == 1
+    assert v1.vec_project(v2, scalar=True) == 7/3
 
 
 def test_scalar_project():

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -186,13 +186,15 @@ def test_vector_cross():
     assert k ^ k == Vector.zero
 
 
-def test_vec_project():
+def test_projection():
     v1 = i + j + k
     v2 = 3*i + 4*j
-    assert v1.vec_project(v1) == i + j + k
-    assert v1.vec_project(v2) == 7/3*C.i + 7/3*C.j + 7/3*C.k
-    assert v1.vec_project(v1, scalar=True) == 1
-    assert v1.vec_project(v2, scalar=True) == 7/3
+    v3 = 0*i + 0*j
+    assert v1.projection(v1) == i + j + k
+    assert v1.projection(v2) == 7/3*C.i + 7/3*C.j + 7/3*C.k
+    assert v1.projection(v1, scalar=True) == 1
+    assert v1.projection(v2, scalar=True) == 7/3
+    assert v3.projection(v1) == Vector.zero
 
 
 def test_vector_diff_integrate():

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -195,13 +195,6 @@ def test_vec_project():
     assert v1.vec_project(v2, scalar=True) == 7/3
 
 
-def test_scalar_project():
-    v1 = i + j + k
-    v2 = 3*i + 4*j
-    assert v1.scalar_project(v1) == 1
-    assert v1.scalar_project(v2) == 7/3
-
-
 def test_vector_diff_integrate():
     f = Function('f')
     v = f(a)*C.i + a**2*C.j - C.k

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -186,6 +186,20 @@ def test_vector_cross():
     assert k ^ k == Vector.zero
 
 
+def test_vec_project():
+    v1 = i + j + k
+    v2 = 3*i + 4*j
+    assert v1.vec_project(v1) == i + j + k
+    assert v1.vec_project(v2) == 7/3*i + 7/3*j + 7/3*k
+
+
+def test_scalar_project():
+    v1 = i + j + k
+    v2 = 3*i + 4*j
+    assert v1.scalar_project(v1) == 1
+    assert v1.scalar_project(v2) == 7/3
+
+
 def test_vector_diff_integrate():
     f = Function('f')
     v = f(a)*C.i + a**2*C.j - C.k

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -250,7 +250,7 @@ class Vector(BasisDependent):
 
         return DyadicAdd(*args)
 
-    def vec_project(self, other, scalar=False):
+    def projection(self, other, scalar=False):
         """
         Returns the vector or scalar projection of the 'other' on 'self'.
 
@@ -263,12 +263,15 @@ class Vector(BasisDependent):
         >>> i, j, k = C.base_vectors()
         >>> v1 = i + j + k
         >>> v2 = 3*i + 4*j
-        >>> v1.vec_project(v2)
+        >>> v1.projection(v2)
         7/3*C.i + 7/3*C.j + 7/3*C.k
-        >>> v1.vec_project(v2, scalar=True)
+        >>> v1.projection(v2, scalar=True)
         7/3
 
         """
+        if self.equals(Vector.zero):
+            return S.zero if scalar else Vector.zero
+
         if scalar:
             return self.dot(other) / self.dot(self)
         else:

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -250,9 +250,9 @@ class Vector(BasisDependent):
 
         return DyadicAdd(*args)
 
-    def vec_project(self, other):
+    def vec_project(self, other, scalar=False):
         """
-        Returns the vector projection of the 'other' on 'self'.
+        Returns the vector or scalar projection of the 'other' on 'self'.
 
         Examples
         ========
@@ -265,9 +265,14 @@ class Vector(BasisDependent):
         >>> v2 = 3*i + 4*j
         >>> v1.vec_project(v2)
         7/3*C.i + 7/3*C.j + 7/3*C.k
+        >>> v1.vec_project(v2, scalar=True)
+        7/3
 
         """
-        return self.dot(other) / self.dot(self) * self
+        if scalar:
+            return self.dot(other) / self.dot(self)
+        else:
+            return self.dot(other) / self.dot(self) * self
 
     def scalar_project(self, other):
         """

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -274,25 +274,6 @@ class Vector(BasisDependent):
         else:
             return self.dot(other) / self.dot(self) * self
 
-    def scalar_project(self, other):
-        """
-        Returns the scalar projection of the 'other' on 'self'.
-
-        Examples
-        ========
-
-        >>> from sympy.vector.coordsysrect import CoordSysCartesian
-        >>> from sympy.vector.vector import Vector, BaseVector
-        >>> C = CoordSysCartesian('C')
-        >>> i, j, k = C.base_vectors()
-        >>> v1 = i + j + k
-        >>> v2 = 3*i + 4*j
-        >>> v1.scalar_project(v2)
-        7/3
-
-        """
-        return self.dot(other) / self.dot(self)
-
     def __or__(self, other):
         return self.outer(other)
     __or__.__doc__ = outer.__doc__

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -264,7 +264,7 @@ class Vector(BasisDependent):
         >>> v1 = i + j + k
         >>> v2 = 3*i + 4*j
         >>> v1.vec_project(v2)
-        7/3*i + 7/3*j + 7/3*k
+        7/3*C.i + 7/3*C.j + 7/3*C.k
 
         """
         return self.dot(other) / self.dot(self) * self

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -250,6 +250,44 @@ class Vector(BasisDependent):
 
         return DyadicAdd(*args)
 
+    def vec_project(self, other):
+        """
+        Returns the vector projection of the 'other' on 'self'.
+
+        Examples
+        ========
+
+        >>> from sympy.vector.coordsysrect import CoordSysCartesian
+        >>> from sympy.vector.vector import Vector, BaseVector
+        >>> C = CoordSysCartesian('C')
+        >>> i, j, k = C.base_vectors()
+        >>> v1 = i + j + k
+        >>> v2 = 3*i + 4*j
+        >>> v1.vec_project(v2)
+        7/3*i + 7/3*j + 7/3*k
+
+        """
+        return self.dot(other) / self.dot(self) * self
+
+    def scalar_project(self, other):
+        """
+        Returns the scalar projection of the 'other' on 'self'.
+
+        Examples
+        ========
+
+        >>> from sympy.vector.coordsysrect import CoordSysCartesian
+        >>> from sympy.vector.vector import Vector, BaseVector
+        >>> C = CoordSysCartesian('C')
+        >>> i, j, k = C.base_vectors()
+        >>> v1 = i + j + k
+        >>> v2 = 3*i + 4*j
+        >>> v1.scalar_project(v2)
+        7/3
+
+        """
+        return self.dot(other) / self.dot(self)
+
     def __or__(self, other):
         return self.outer(other)
     __or__.__doc__ = outer.__doc__


### PR DESCRIPTION
I noticed that the sympy vector module didn't have a function to orthogonalize a given set of linearly independent vectors using the Gram - Schmidt process. This function is present in many other CASs. (Such a function seems to exist in the linear algebra module but it works only with matrix inputs and doesn't seem to work with vector inputs ). I added a function `orthogonalize` to compute this. The functions `vec_project` and `scalar_project` compute the vector and scalar projections of two vectors respectively. 
Ping @asmeurer @srjoglekar246 @aktech @moorepants 
