### PR TITLE
modify as_independent: quicker exit and preserve zero property of dependent part

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1456,16 +1456,17 @@ class Expr(Basic, EvalfMixin):
         * .expand(log=True) to change log expr into an Add
 
         The only non-naive thing that is done here is to respect noncommutative
-        ordering of variables.
+        ordering of variables and to always return (0, 0) for `self` of zero
+        regardless of hints.
 
-        The returned tuple (i, d) has the following interpretation:
+        For nonzero `self`, the returned tuple (i, d) has the
+        following interpretation:
 
         * i will has no variable that appears in deps
         * d will be 1 or else have terms that contain variables that are in deps
         * if self is an Add then self = i + d
         * if self is a Mul then self = i*d
-        * if self is anything else, either tuple (self, S.One) or (S.One, self)
-          is returned.
+        * otherwise (self, S.One) or (S.One, self) is returned.
 
         To force the expression to be treated as an Add, use the hint as_Add=True
 
@@ -1575,6 +1576,9 @@ class Expr(Basic, EvalfMixin):
         from .add import _unevaluated_Add
         from .mul import _unevaluated_Mul
         from sympy.utilities.iterables import sift
+
+        if self.is_zero:
+            return S.Zero, S.Zero
 
         func = self.func
         if hint.get('as_Add', func is Add):

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -614,6 +614,11 @@ def test_as_independent():
     assert (x + Integral(x, (x, 1, 2))).as_independent(x, strict=True) == \
            (Integral(x, (x, 1, 2)), x)
 
+    eq = Add(x, -x, 2, -3, evaluate=False)
+    assert eq.as_independent(x) == (-1, Add(x, -x, evaluate=False))
+    eq = Mul(x, 1/x, 2, -3, evaluate=False)
+    eq.as_independent(x) == (-6, Mul(x, 1/x, evaluate=False))
+
 
 @XFAIL
 def test_call_2():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -567,6 +567,8 @@ def test_as_numer_denom():
 
 
 def test_as_independent():
+    assert S.Zero.as_independent(x, as_Add=True) == (0, 0)
+    assert S.Zero.as_independent(x, as_Add=False) == (0, 0)
     assert (2*x*sin(x) + y + x).as_independent(x) == (y, x + 2*x*sin(x))
     assert (2*x*sin(x) + y + x).as_independent(y) == (x + 2*x*sin(x), y)
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -655,12 +655,17 @@ class ComplexRootOf(RootOf):
                     # verification by findroot will raise a ValueError in this
                     # case and the interval will then be tightened -- and
                     # eventually the root will be found.
+                    #
+                    # It is also possible that findroot will not have any
+                    # successful iterations to process (in which case it
+                    # will fail to initialize a variable that is tested
+                    # after the iterations and raise an UnboundLocalError).
                     if self.is_real:
                         if (a <= root <= b):
                             break
                     elif (ax <= root.real <= bx and ay <= root.imag <= by):
                         break
-                except ValueError:
+                except (UnboundLocalError, ValueError):
                     pass
                 interval = interval.refine()
 

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -242,6 +242,10 @@ def test_CRootOf_evalf():
     # make sure verification is used in case a max/min traps the "root"
     assert str(rootof(4*x**5 + 16*x**3 + 12*x**2 + 7, 0).n(3)) == '-0.976'
 
+    # watch out for UnboundLocalError
+    c = CRootOf(90720*x**6 - 4032*x**4 + 84*x**2 - 1, 0)
+    assert str(c._eval_evalf(2)) == '-0.e-1'
+
 
 def test_CRootOf_evalf_caching_bug():
     r = rootof(x**5 - 5*x + 12, 1)


### PR DESCRIPTION
Whereas `S(0).as_independent(x, as_Add=False)` formerly gave `(0, 1)` it now gives `(0, 0)` regardless of the `as_Add` flag so that the dependent part retains the character of the original 0. The faster exit also makes unnecessary pre-testing the expression before calling as in 

``` python
if expr.is_Mul:
    ii, d = expr.as_independent(foo)
```

Instead,  just use

``` python
i, d = expr.as_independent(foo, as_Add=False)
```
