### PR TITLE
zeta(x) for (Re(x) - 1) nonzero is Finite

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -178,3 +178,9 @@ def test_stieltjes_evalf():
     assert abs(stieltjes(0).evalf() - 0.577215664) < 1E-9
     assert abs(stieltjes(0, 0.5).evalf() - 1.963510026) < 1E-9
     assert abs(stieltjes(1, 2).evalf() + 0.072815845 ) < 1E-9
+
+
+def test_issue_10475():
+    assert zeta(2 + I).is_finite
+    assert zeta(1).is_finite
+    assert zeta(x).is_finite is None

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -463,6 +463,10 @@ class zeta(Function):
     def _eval_rewrite_as_lerchphi(self, s, a=1):
         return lerchphi(1, s, a)
 
+    def _eval_is_finite(self):
+        arg = self.args[0]
+        return (arg - 1).is_nonzero
+
     def fdiff(self, argindex=1):
         if len(self.args) == 2:
             s, a = self.args


### PR DESCRIPTION
The (analytically continued) Riemann zeta function is finite in
the whole plane except at 1 where it has a simple pole.
# Now

In [1]: zeta(2 + I).is_finite
True

fixes #10475
