### PR TITLE
sinc added to the meijerg tables.

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -94,7 +94,7 @@ def _create_lookup_table(table):
                 return arg <= 0
 
     # Section 8.4.2
-    from sympy import (gamma, pi, cos, exp, re, sin, sqrt, sinh, cosh,
+    from sympy import (gamma, pi, cos, exp, re, sin, sinc, sqrt, sinh, cosh,
                        factorial, log, erf, erfc, erfi, polar_lift)
     # TODO this needs more polar_lift (c/f entry for exp)
     add(Heaviside(t - b)*(t - b)**(a - 1), [a], [], [], [0], t/b,
@@ -150,6 +150,9 @@ def _create_lookup_table(table):
     # TODO can do t + a. but can also do by expansion... (XXX not really)
     add(sin(t), [], [], [S(1)/2], [0], t**2/4, sqrt(pi))
     add(cos(t), [], [], [0], [S(1)/2], t**2/4, sqrt(pi))
+
+    # Section 8.4.6 (sinc function)
+    add(sinc(t), [], [], [0], [S(-1)/2], t**2/4, sqrt(pi)/2)
 
     # Section 8.5.5
     def make_log1(subs):

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -1,4 +1,4 @@
-from sympy import (meijerg, I, S, integrate, Integral, oo, gamma, cosh,
+from sympy import (meijerg, I, S, integrate, Integral, oo, gamma, cosh, sinc,
                    hyperexpand, exp, simplify, sqrt, pi, erf, erfc, sin, cos,
                    exp_polar, polygamma, hyper, log, expand_func)
 from sympy.integrals.meijerint import (_rewrite_single, _rewrite1,

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -168,6 +168,7 @@ def test_meijerint():
     assert meijerint_definite(exp(-abs(2*x - 3)), x, -oo, oo) == (1, True)
     assert meijerint_definite(exp(-((x - mu)/sigma)**2/2)/sqrt(2*pi*sigma**2),
                               x, -oo, oo) == (1, True)
+    assert meijerint_definite(sinc(x)**2, x, -oo, oo) == (pi, True)
 
     # Test one of the extra conditions for 2 g-functinos
     assert meijerint_definite(exp(-x)*sin(x), x, 0, oo) == (S(1)/2, True)


### PR DESCRIPTION
FIX #10464 integrate(sinc(x)**2, (x, -oo, oo)) can't do it

Added sinc to the meijerg tables, Now `integrate(sinc(x)**2, (x, -oo, oo))` gives `pi`
