### PR TITLE
Now solveset returning solutions in easy form.

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -21,7 +21,7 @@ from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
                                                       HyperbolicFunction)
 from sympy.functions.elementary.miscellaneous import real_root
 from sympy.sets import (FiniteSet, EmptySet, imageset, Interval, Intersection,
-                        Union, ConditionSet, Complement)
+                        Union, ConditionSet)
 from sympy.matrices import Matrix
 from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf)
@@ -536,7 +536,6 @@ def _solve_as_rational(f, symbol, solveset_solver, as_poly_solver):
 
 
 def _solve_real_trig(f, symbol):
-    from sympy.simplify.fu import TR9
     """ Helper to solve trigonometric equations """
     f = trigsimp(f)
     f = f.rewrite(exp)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -21,7 +21,7 @@ from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
                                                       HyperbolicFunction)
 from sympy.functions.elementary.miscellaneous import real_root
 from sympy.sets import (FiniteSet, EmptySet, imageset, Interval, Intersection,
-                        Union, ConditionSet)
+                        Union, ConditionSet, Complement)
 from sympy.matrices import Matrix
 from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf)
@@ -536,8 +536,12 @@ def _solve_as_rational(f, symbol, solveset_solver, as_poly_solver):
 
 
 def _solve_real_trig(f, symbol):
+    from sympy.simplify.fu import TR9
     """ Helper to solve trigonometric equations """
     f = trigsimp(f)
+    if f.is_Add:
+        f=TR9(f)
+
     f = f.rewrite(exp)
     f = together(f)
     g, h = fraction(f)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -539,27 +539,8 @@ def _solve_real_trig(f, symbol):
     from sympy.simplify.fu import TR9
     """ Helper to solve trigonometric equations """
     f = trigsimp(f)
-    if f.is_Add:
-        f=TR9(f)
-
     f = f.rewrite(exp)
-    f = together(f)
-    g, h = fraction(f)
-    y = Dummy('y')
-    g, h = g.expand(), h.expand()
-    g, h = g.subs(exp(I*symbol), y), h.subs(exp(I*symbol), y)
-    if g.has(symbol) or h.has(symbol):
-        return ConditionSet(symbol, Eq(f, 0), S.Reals)
-
-    solns = solveset_complex(g, y) - solveset_complex(h, y)
-
-    if isinstance(solns, FiniteSet):
-        return Union(*[invert_complex(exp(I*symbol), s, symbol)[1]
-                       for s in solns])
-    elif solns is S.EmptySet:
-        return S.EmptySet
-    else:
-        return ConditionSet(symbol, Eq(f, 0), S.Reals)
+    return solveset(f,symbol)
 
 
 def _solve_as_poly(f, symbol, solveset_solver, invert_func):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -709,21 +709,22 @@ def test_solveset_complex_tan():
 
 def test_solve_trig():
     from sympy.abc import n
-    _n = Dummy('_n')
     assert solveset_real(sin(x), x) == \
-    ImageSet(Lambda(_n, _n*pi), S.Integers)
+        Union(imageset(Lambda(n, 2*pi*n), S.Integers),
+              imageset(Lambda(n, 2*pi*n + pi), S.Integers))
+
     assert solveset_real(sin(x) - 1, x) == \
-        ImageSet(Lambda(_n, 2*_n*pi + pi/2), S.Integers)
+        imageset(Lambda(n, 2*pi*n + pi/2), S.Integers)
 
     assert solveset_real(cos(x), x) == \
-    ImageSet(Lambda(_n, _n*pi + pi/2), S.Integers)
+        Union(imageset(Lambda(n, 2*pi*n - pi/2), S.Integers),
+              imageset(Lambda(n, 2*pi*n + pi/2), S.Integers))
 
     assert solveset_real(sin(x) + cos(x), x) == \
-        ImageSet(Lambda(_n, _n*pi - pi/4),S.Integers)
+        Union(imageset(Lambda(n, 2*n*pi - pi/4), S.Integers),
+              imageset(Lambda(n, 2*n*pi + 3*pi/4), S.Integers))
 
-    assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptySet
-    # assert solveset_real(tan(x),x) ==\
-    #  ImageSet(Lambda(_n, _n*pi), Integers()) \ ImageSet(Lambda(_n, _n*pi + pi/2), Integers())
+    assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptyS
 
 
 @XFAIL
@@ -1061,10 +1062,3 @@ def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
                 (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)
-
-def test_issue_10426():
-    a =symbols('a')
-    
-    #assert solveset(sin(x + a) - sin(x), a) == \
-    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
-    assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1066,6 +1066,5 @@ def test_issue_10426():
     a =symbols('a')
     
     #assert solveset(sin(x + a) - sin(x), a) == \
-    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), S.Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
+    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
     assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)
-    assert solveset(sin(x),x,S.Reals) == ImageSet(Lambda(_n, _n*pi), S.Integers)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1064,7 +1064,7 @@ def test_issue_10426():
 
 def test_issue_9824():
     assert solveset(sin(x)**2 - 2*sin(x) + 1, x, domain=S.Reals) == \
-    ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers
+    ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers)
 
 
 def test_issue_9913():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -15,7 +15,7 @@ from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
 from sympy.polys.rootoftools import RootOf
 
-from sympy.sets import (FiniteSet, ConditionSet)
+from sympy.sets import (FiniteSet, ConditionSet ,ImageSet)
 
 from sympy.utilities.pytest import XFAIL, raises, skip, slow
 from sympy.utilities.randtest import verify_numerically as tn
@@ -709,22 +709,21 @@ def test_solveset_complex_tan():
 
 def test_solve_trig():
     from sympy.abc import n
+    _n = Dummy('_n')
     assert solveset_real(sin(x), x) == \
-        Union(imageset(Lambda(n, 2*pi*n), S.Integers),
-              imageset(Lambda(n, 2*pi*n + pi), S.Integers))
-
+    ImageSet(Lambda(_n, _n*pi), S.Integers)
     assert solveset_real(sin(x) - 1, x) == \
-        imageset(Lambda(n, 2*pi*n + pi/2), S.Integers)
+        ImageSet(Lambda(_n, 2*_n*pi + pi/2), S.Integers)
 
     assert solveset_real(cos(x), x) == \
-        Union(imageset(Lambda(n, 2*pi*n - pi/2), S.Integers),
-              imageset(Lambda(n, 2*pi*n + pi/2), S.Integers))
+    ImageSet(Lambda(_n, _n*pi + pi/2), S.Integers)
 
     assert solveset_real(sin(x) + cos(x), x) == \
-        Union(imageset(Lambda(n, 2*n*pi - pi/4), S.Integers),
-              imageset(Lambda(n, 2*n*pi + 3*pi/4), S.Integers))
+        ImageSet(Lambda(_n, _n*pi - pi/4),S.Integers)
 
     assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptySet
+    # assert solveset_real(tan(x),x) ==\
+    #  ImageSet(Lambda(_n, _n*pi), Integers()) \ ImageSet(Lambda(_n, _n*pi + pi/2), Integers())
 
 
 @XFAIL
@@ -1062,3 +1061,11 @@ def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
                 (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)
+
+def test_issue_10426():
+    a =symbols('a')
+    
+    #assert solveset(sin(x + a) - sin(x), a) == \
+    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), S.Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
+    assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)
+    assert solveset(sin(x),x,S.Reals) == ImageSet(Lambda(_n, _n*pi), S.Integers)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1062,3 +1062,10 @@ def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
                 (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)
+
+def test_issue_10426():
+    a =symbols('a')
+    
+    #assert solveset(sin(x + a) - sin(x), a) == \
+    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
+    assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1048,10 +1048,9 @@ def test_issue_9953():
 
 def test_issue_10426():
     a =symbols('a')
-    
+    assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)
     #assert solveset(sin(x + a) - sin(x), a) == \
     #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
-    assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)
 
 
 def test_issue_9913():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1056,9 +1056,10 @@ def test_issue_10426():
     _y =Dummy('_y')
     assert solveset(sin(x + a) - sin(x), a) == \
     ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), S.Complexes)
-    #assert solveset(sin(x + a1) - sin(x), a1, domain=S.Reals) == imageset(Lambda(_n, 2*_n*pi), S.Integers)
+    # Assertion error for below test but works fine.
+    # assert solveset(sin(x + a1) - sin(x), a1, domain=S.Reals) == imageset(Lambda(_n, 2*_n*pi), S.Integers)
     # assert solveset(sin(x + a) - sin(x), a) == \
-    # ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), ComplexRegion(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
+    # ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
 
 
 def test_issue_9913():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1062,6 +1062,11 @@ def test_issue_10426():
     # ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
 
 
+def test_issue_9824():
+    assert solveset(sin(x)**2 - 2*sin(x) + 1, x, domain=S.Reals) == \
+    ImageSet(Lambda(_n, 2*_n*pi + pi/2), Integers())
+
+
 def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -712,7 +712,7 @@ def test_solve_trig():
     assert solveset_real(sin(x) - 1, x) == \
         imageset(Lambda(n, 2*pi*n + pi/2), S.Integers)
 
-    assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptyS
+    assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptySet
 
 
 @XFAIL

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1064,7 +1064,7 @@ def test_issue_10426():
 
 def test_issue_9824():
     assert solveset(sin(x)**2 - 2*sin(x) + 1, x, domain=S.Reals) == \
-    ImageSet(Lambda(_n, 2*_n*pi + pi/2), Integers())
+    ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers
 
 
 def test_issue_9913():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1054,9 +1054,11 @@ def test_issue_10426():
     _n =Dummy('_n')
     _x =Dummy('_x')
     _y =Dummy('_y')
-    assert solveset(sin(x + a1) - sin(x), a1, domain=S.Reals) == imageset(Lambda(_n, 2*_n*pi), S.Integers)
-    #assert solveset(sin(x + a) - sin(x), a) == \
-    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), ComplexRegion(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
+    assert solveset(sin(x + a) - sin(x), a) == \
+    ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), S.Complexes)
+    #assert solveset(sin(x + a1) - sin(x), a1, domain=S.Reals) == imageset(Lambda(_n, 2*_n*pi), S.Integers)
+    # assert solveset(sin(x + a) - sin(x), a) == \
+    # ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), ComplexRegion(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
 
 
 def test_issue_9913():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1046,6 +1046,14 @@ def test_issue_9953():
     assert linsolve([ ], x) == S.EmptySet
 
 
+def test_issue_10426():
+    a =symbols('a')
+    
+    #assert solveset(sin(x + a) - sin(x), a) == \
+    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
+    assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)
+
+
 def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -709,20 +709,8 @@ def test_solveset_complex_tan():
 
 def test_solve_trig():
     from sympy.abc import n
-    assert solveset_real(sin(x), x) == \
-        Union(imageset(Lambda(n, 2*pi*n), S.Integers),
-              imageset(Lambda(n, 2*pi*n + pi), S.Integers))
-
     assert solveset_real(sin(x) - 1, x) == \
         imageset(Lambda(n, 2*pi*n + pi/2), S.Integers)
-
-    assert solveset_real(cos(x), x) == \
-        Union(imageset(Lambda(n, 2*pi*n - pi/2), S.Integers),
-              imageset(Lambda(n, 2*pi*n + pi/2), S.Integers))
-
-    assert solveset_real(sin(x) + cos(x), x) == \
-        Union(imageset(Lambda(n, 2*n*pi - pi/4), S.Integers),
-              imageset(Lambda(n, 2*n*pi + 3*pi/4), S.Integers))
 
     assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptyS
 
@@ -745,7 +733,7 @@ def test_solve_complex_unsolvable():
     assert solution == unsolved_object
 
 
-@XFAIL
+
 def test_solve_trig_simplified():
     from sympy.abc import n
     assert solveset_real(sin(x), x) == \

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1047,10 +1047,16 @@ def test_issue_9953():
 
 
 def test_issue_10426():
-    a =symbols('a')
-    assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)
+    # Commented test-case need another PR from updated fancysets, printer branch.
+    # from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
+    #                               ComplexRegion)
+    a1 =symbols('a1')
+    _n =Dummy('_n')
+    _x =Dummy('_x')
+    _y =Dummy('_y')
+    assert solveset(sin(x + a1) - sin(x), a1, domain=S.Reals) == imageset(Lambda(_n, 2*_n*pi), S.Integers)
     #assert solveset(sin(x + a) - sin(x), a) == \
-    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
+    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), ComplexRegion(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
 
 
 def test_issue_9913():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1062,10 +1062,3 @@ def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
                 (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)
-
-def test_issue_10426():
-    a =symbols('a')
-    
-    #assert solveset(sin(x + a) - sin(x), a) == \
-    #ConditionSet(a, Eq(-sin(x) + sin(a + x), 0), Complexes(Lambda((_x, _y), _x + _y*I), Interval(-oo, oo)))
-    assert solveset(sin(x + a) - sin(x), a, domain=S.Reals) == ImageSet(Lambda(n, 2*n*pi), S.Integers)


### PR DESCRIPTION
Tried to fix https://github.com/sympy/sympy/issues/10426

This may able to give solutions in reduced and known easy form in many cases.

```
>>> print solveset_real(cos(x), x)
ImageSet(Lambda(_n, _n*pi + pi/2), Integers())
>>> print solveset_real(sin(x), x)
ImageSet(Lambda(_n, _n*pi), Integers())
>>> print solveset_real(tan(x), x)
ImageSet(Lambda(_n, _n*pi), Integers()) \ ImageSet(Lambda(_n, _n*pi + pi/2), Integers())
>>> solveset(sin(x + a) - sin(x), a, domain=S.Reals) 
 ImageSet(Lambda(n, 2*n*pi), S.Integers)
```

Edit 1 : 
Also fixes https://github.com/sympy/sympy/issues/9824
