### PR TITLE
Fixes #10484 : added the warning about Integer wrapping used in SymPy Live

### DIFF
--- a/doc/src/tutorial/gotchas.rst
+++ b/doc/src/tutorial/gotchas.rst
@@ -239,6 +239,11 @@ object and a Python object, you get a SymPy object, but whenever you combine
 two Python objects, SymPy never comes into play, and so you get a Python
 object.
 
+.. warning:: SymPy Live wraps both 1s in the expression ``1 + 1`` by Integer,
+so the example doesn't show what it is supposed to show. Similar issue occurs
+in few following examples as well. This occurs doesn't occur in actual desktop
+environment.
+
     >>> type(Integer(1) + 1)
     <class 'sympy.core.numbers.Integer'>
     >>> type(1 + 1)

--- a/doc/src/tutorial/gotchas.rst
+++ b/doc/src/tutorial/gotchas.rst
@@ -240,9 +240,9 @@ two Python objects, SymPy never comes into play, and so you get a Python
 object.
 
 .. warning:: SymPy Live wraps both 1s in the expression ``1 + 1`` by Integer,
-so the example doesn't show what it is supposed to show. Similar issue occurs
-in few following examples as well. This occurs doesn't occur in actual desktop
-environment.
+   so the example doesn't show what it is supposed to show. Similar issue occurs
+   in few following examples as well. This occurs doesn't occur in actual desktop
+   environment.
 
     >>> type(Integer(1) + 1)
     <class 'sympy.core.numbers.Integer'>

--- a/doc/src/tutorial/gotchas.rst
+++ b/doc/src/tutorial/gotchas.rst
@@ -239,10 +239,7 @@ object and a Python object, you get a SymPy object, but whenever you combine
 two Python objects, SymPy never comes into play, and so you get a Python
 object.
 
-.. warning:: SymPy Live wraps both 1s in the expression ``1 + 1`` by Integer,
-   so the example doesn't show what it is supposed to show. Similar issue occurs
-   in few following examples as well. This occurs doesn't occur in actual desktop
-   environment.
+.. warning:: SymPy Live wraps both 1s in the expression ``1 + 1`` by Integer, so the example doesn't show what it is supposed to show. Similar issue occurs in few following examples as well. This occurs doesn't occur in actual desktop environment.
 
     >>> type(Integer(1) + 1)
     <class 'sympy.core.numbers.Integer'>


### PR DESCRIPTION
Updated Gotchas docs for 1/2 and SymPy Live.
[http://docs.sympy.org/latest/tutorial/gotchas.html#two-final-notes-and](http://docs.sympy.org/latest/tutorial/gotchas.html#two-final-notes-and)
SymPy Live uses Integer Wrapping for constants like 1, 1/2 etc.
This was causing unexpected output in 3 examples in the given page:
1. type(1+1) example
2. two examples related to 1/2

So Added an appropriate warning message.
