### PR TITLE
Added _eval_diff to both matrices and N-dim arrays

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 import random
+from sympy import Derivative
 
 from sympy.core.basic import Basic
 from sympy.core.compatibility import is_sequence, as_int, range
@@ -314,6 +315,12 @@ class DenseMatrix(MatrixBase):
             # if a new method is added.
             raise ValueError("Inversion method unrecognized")
         return self._new(rv)
+
+    def _eval_diff(self, *args, **kwargs):
+        if kwargs.pop("evaluate", True):
+            return self.diff(*args)
+        else:
+            return Derivative(self, *args, **kwargs)
 
     def equals(self, other, failing_expression=False):
         """Applies ``equals`` to corresponding elements of the matrices,

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -98,6 +98,7 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     _eval_adjoint = DenseMatrix._eval_adjoint
     _eval_inverse = DenseMatrix._eval_inverse
     _eval_simplify = DenseMatrix._eval_simplify
+    _eval_diff = DenseMatrix._eval_diff
 
     equals = DenseMatrix.equals
     is_Identity = DenseMatrix.is_Identity

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -4,14 +4,14 @@ import random
 from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
     S, Symbol, cos, exp, oo, pi, signsimp, simplify, sin, sqrt, symbols,
-    sympify, trigsimp, sstr)
+    sympify, trigsimp, sstr, diff)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
     NonSquareMatrixError, DeferredVector)
 from sympy.matrices import (
     GramSchmidt, ImmutableMatrix, ImmutableSparseMatrix, Matrix,
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
-    rot_axis3, wronskian, zeros)
+    rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix)
 from sympy.core.compatibility import long, iterable, u, range
 from sympy.utilities.iterables import flatten, capture
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
@@ -1769,9 +1769,19 @@ def test_limit():
 
 
 def test_diff():
-    A = Matrix(((1, 4, x), (y, 2, 4), (10, 5, x**2 + 1)))
-    assert A.diff(x) == Matrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
-    assert A.diff(y) == Matrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
+    A = MutableDenseMatrix(((1, 4, x), (y, 2, 4), (10, 5, x**2 + 1)))
+    assert A.diff(x) == MutableDenseMatrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
+    assert A.diff(y) == MutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
+
+    assert diff(A, x) == MutableDenseMatrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
+    assert diff(A, y) == MutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
+
+    A_imm = A.as_immutable()
+    assert A_imm.diff(x) == ImmutableDenseMatrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
+    assert A_imm.diff(y) == ImmutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
+
+    assert diff(A_imm, x) == ImmutableDenseMatrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
+    assert diff(A_imm, y) == ImmutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
 
 
 def test_getattr():

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 import collections
-from sympy import Matrix, Integer, sympify, Basic
+from sympy import Matrix, Integer, sympify, Basic, Derivative
 
 
 class NDimArray(object):
@@ -360,6 +360,12 @@ class NDimArray(object):
 
     __truediv__ = __div__
     __rtruediv__ = __rdiv__
+
+    def _eval_diff(self, *args, **kwargs):
+        if kwargs.pop("evaluate", True):
+            return self.diff(*args)
+        else:
+            return Derivative(self, *args, **kwargs)
 
 
 class ImmutableNDimArray(NDimArray, Basic):

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
-from sympy import Symbol, Rational, SparseMatrix, Dict
+from sympy import Symbol, Rational, SparseMatrix, Dict, diff
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import ImmutableSparseNDimArray
 from sympy.utilities.pytest import raises
@@ -273,10 +273,12 @@ def test_diff_and_applyfunc():
     from sympy.abc import x, y, z
     md = ImmutableDenseNDimArray([[x, y], [x*z, x*y*z]])
     assert md.diff(x) == ImmutableDenseNDimArray([[1, 0], [z, y*z]])
+    assert diff(md, x) == ImmutableDenseNDimArray([[1, 0], [z, y*z]])
 
     sd = ImmutableSparseNDimArray(md)
     assert sd == ImmutableSparseNDimArray([x, y, x*z, x*y*z], (2, 2))
     assert sd.diff(x) == ImmutableSparseNDimArray([[1, 0], [z, y*z]])
+    assert diff(sd, x) == ImmutableSparseNDimArray([[1, 0], [z, y*z]])
 
     mdn = md.applyfunc(lambda x: x*3)
     assert mdn == ImmutableDenseNDimArray([[3*x, 3*y], [3*x*z, 3*x*y*z]])

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
-from sympy import Symbol, Rational, SparseMatrix
+from sympy import Symbol, Rational, SparseMatrix, diff
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import MutableSparseNDimArray
 
@@ -264,7 +264,9 @@ def test_diff():
     from sympy.abc import x, y, z
     md = MutableDenseNDimArray([[x, y], [x*z, x*y*z]])
     assert md.diff(x) == MutableDenseNDimArray([[1, 0], [z, y*z]])
+    assert diff(md, x) == MutableDenseNDimArray([[1, 0], [z, y*z]])
 
     sd = MutableSparseNDimArray(md)
     assert sd == MutableSparseNDimArray([x, y, x*z, x*y*z], (2, 2))
     assert sd.diff(x) == MutableSparseNDimArray([[1, 0], [z, y*z]])
+    assert diff(sd, x) == MutableSparseNDimArray([[1, 0], [z, y*z]])


### PR DESCRIPTION
With this, you can call `diff(M, x)` as an alternative to `M.diff(x)`.
