### PR TITLE
lambdify fixes: #9474 & #9871

### DIFF
--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -507,7 +507,7 @@ def test_roots_inexact():
     R2 = roots(x**2 + x + 1.0, x, multiple=True)
 
     for r1, r2 in zip(R1, R2):
-        assert abs(r1 - r2) < 1e-12
+        assert abs(r1 - r2).n() < 1e-12
 
     f = x**4 + 3.0*sqrt(2.0)*x**3 - (78.0 + 24.0*sqrt(3.0))*x**2 \
         + 144.0*(2*sqrt(3.0) + 9.0)
@@ -517,7 +517,7 @@ def test_roots_inexact():
           4.89897948556636, 7.46155167569183)
 
     for r1, r2 in zip(R1, R2):
-        assert abs(r1 - r2) < 1e-10
+        assert abs(r1 - r2).n() < 1e-10
 
 
 def test_roots_preprocessed():

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -507,7 +507,7 @@ def test_roots_inexact():
     R2 = roots(x**2 + x + 1.0, x, multiple=True)
 
     for r1, r2 in zip(R1, R2):
-        assert abs(r1 - r2).n() < 1e-12
+        assert abs(r1 - r2) < 1e-12
 
     f = x**4 + 3.0*sqrt(2.0)*x**3 - (78.0 + 24.0*sqrt(3.0))*x**2 \
         + 144.0*(2*sqrt(3.0) + 9.0)
@@ -517,7 +517,7 @@ def test_roots_inexact():
           4.89897948556636, 7.46155167569183)
 
     for r1, r2 in zip(R1, R2):
-        assert abs(r1 - r2).n() < 1e-10
+        assert abs(r1 - r2) < 1e-10
 
 
 def test_roots_preprocessed():

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -244,7 +244,7 @@ class NumExprPrinter(LambdaPrinter):
 
     def doprint(self, expr):
         lstr = super(NumExprPrinter, self).doprint(expr)
-        return "evaluate('%s')" % lstr
+        return "evaluate('%s', truediv=True)" % lstr
 
 def lambdarepr(expr, **settings):
     """

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -31,14 +31,12 @@ NUMEXPR_DEFAULT = {}
 
 # Mappings between sympy and other modules function names.
 MATH_TRANSLATIONS = {
-    "Abs": "fabs",
     "ceiling": "ceil",
     "E": "e",
     "ln": "log",
 }
 
 MPMATH_TRANSLATIONS = {
-    "Abs": "fabs",
     "elliptic_k": "ellipk",
     "elliptic_f": "ellipf",
     "elliptic_e": "ellipe",
@@ -65,7 +63,6 @@ MPMATH_TRANSLATIONS = {
 }
 
 NUMPY_TRANSLATIONS = {
-    "Abs": "abs",
     "acos": "arccos",
     "acosh": "arccosh",
     "arg": "angle",
@@ -150,11 +147,12 @@ def _import(module, reload="False"):
     # Add translated names to namespace
     for sympyname, translation in translations.items():
         namespace[sympyname] = namespace[translation]
+    namespace['Abs'] = abs
 
 
 @doctest_depends_on(modules=('numpy'))
 def lambdify(args, expr, modules=None, printer=None, use_imps=True,
-        dummify=True):
+             dummify=True):
     """
     Returns a lambda function for fast calculation of numerical values.
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -37,6 +37,7 @@ MATH_TRANSLATIONS = {
 }
 
 MPMATH_TRANSLATIONS = {
+    "Abs": "fabs",
     "elliptic_k": "ellipk",
     "elliptic_f": "ellipf",
     "elliptic_e": "ellipe",
@@ -151,8 +152,12 @@ def _import(module, reload="False"):
     # For computing the modulus of a sympy expression we use the builtin abs
     # function, instead of the previously used fabs function for all
     # translation modules. This is because the fabs function in the math
-    # module does not accept complex valued arguments. (see issue 9474)
-    namespace['Abs'] = abs
+    # module does not accept complex valued arguments. (see issue 9474). The
+    # only exception, where we don't use the builtin abs function is the
+    # mpmath translation module, because mpmath.fabs returns mpf objects in
+    # contrast to abs().
+    if 'Abs' not in namespace:
+        namespace['Abs'] = abs
 
 
 @doctest_depends_on(modules=('numpy'))

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -147,6 +147,11 @@ def _import(module, reload="False"):
     # Add translated names to namespace
     for sympyname, translation in translations.items():
         namespace[sympyname] = namespace[translation]
+
+    # For computing the modulus of a sympy expression we use the builtin abs
+    # function, instead of the previously used fabs function for all
+    # translation modules. This is because the fabs function in the math
+    # module does not accept complex valued arguments. (see issue 9474)
     namespace['Abs'] = abs
 
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,15 +1,18 @@
+from itertools import product
+import math
+
+import mpmath
+
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
     Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
-    true, false, And, Or, Not, ITE, Min, Max)
+    true, false, And, Or, Not, ITE, Min, Max, floor, diff)
 from sympy.printing.lambdarepr import LambdaPrinter
-import mpmath
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import skip
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.external import import_module
-import math
 import sympy
 
 
@@ -327,6 +330,25 @@ def test_numpy_old_matrix():
     f = lambdify((x, y, z), A, [{'ImmutableMatrix': numpy.matrix}, 'numpy'])
     numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
     assert isinstance(f(1, 2, 3), numpy.matrix)
+
+
+def test_issue9474():
+    mods = [None, 'math']
+    if numpy:
+        mods.append('numpy')
+
+    for mod in mods:
+        f = lambdify(x, sympy.S(1)/x, modules=mod)
+        assert f(2) == 0.5
+        f = lambdify(x, floor(sympy.S(1)/x), modules=mod)
+        assert f(2) == 0
+
+    for absfunc, modules in product([Abs, abs], mods):
+        f = lambdify(x, absfunc(x), modules=modules)
+        assert f(-1) == 1
+        assert f(1) == 1
+        assert f(3+4j) == 5
+
 
 def test_numpy_piecewise():
     if not numpy:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -350,6 +350,21 @@ def test_issue9474():
         assert f(3+4j) == 5
 
 
+def test_issue_9871():
+    if not numexpr:
+        skip("numexpr not installed.")
+    if not numpy:
+        skip("numpy not installed.")
+
+    r = sqrt(x**2 + y**2)
+    expr = diff(1/r, x)
+
+    xn = yn = numpy.arange(1, 10)
+    fv_numpy = lambdify((x, y), expr, modules='numpy')(xn, yn)
+    fv_numexpr = lambdify((x, y), expr, modules='numexpr')(xn, yn)
+    numpy.testing.assert_allclose(fv_numexpr, fv_numpy, rtol=1e-10)
+
+
 def test_numpy_piecewise():
     if not numpy:
         skip("numpy not installed.")

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -344,6 +344,10 @@ def test_issue9474():
         f = lambdify(x, floor(sympy.S(1)/x), modules=mod)
         assert f(2) == 0
 
+    if mpmath:
+        f = lambdify(x, sympy.S(1)/sympy.Abs(x), modules=['mpmath'])
+        assert isinstance(f(2), mpmath.mpf)
+
     for absfunc, modules in product([Abs, abs], mods):
         f = lambdify(x, absfunc(x), modules=modules)
         assert f(-1) == 1

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -359,10 +359,14 @@ def test_issue_9871():
     r = sqrt(x**2 + y**2)
     expr = diff(1/r, x)
 
-    xn = yn = numpy.arange(1, 10)
+    xn = yn = numpy.linspace(1, 10, 16)
+    # expr(xn, xn) = -xn/(sqrt(2)*xn)^3
+    fv_exact = -numpy.sqrt(2.)**-3 * xn**-2
+
     fv_numpy = lambdify((x, y), expr, modules='numpy')(xn, yn)
     fv_numexpr = lambdify((x, y), expr, modules='numexpr')(xn, yn)
-    numpy.testing.assert_allclose(fv_numexpr, fv_numpy, rtol=1e-10)
+    numpy.testing.assert_allclose(fv_numpy, fv_exact, rtol=1e-10)
+    numpy.testing.assert_allclose(fv_numexpr, fv_exact, rtol=1e-10)
 
 
 def test_numpy_piecewise():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -336,7 +336,8 @@ def test_issue9474():
     mods = [None, 'math']
     if numpy:
         mods.append('numpy')
-
+    if mpmath:
+        mods.append('mpmath')
     for mod in mods:
         f = lambdify(x, sympy.S(1)/x, modules=mod)
         assert f(2) == 0.5


### PR DESCRIPTION
This supersedes #7779. 

It turns out that the simplest solution to compute the magnitude of a complex number in a lambda expression returned by lambdify (e.g., `lambdify(x, Abs(x))(3+4j)`) is to always use `__builtin__.abs` instead of the module specific fabs functions.  The TyperError in #9474 is raised because `fabs` only supports arguments that can be converted to a float.  This is in contrast to the more general `__builtin__.abs`.

Since the lambdify module imports `division` from `__future__`, the returned lambda expressions always (?) do floating point divisions. If one wants to do integer divisions one needs to use the `sympy.floor` function.

@moorepants 

closes #9474, #9871 
