### PR TITLE
clean up checkodesol and checkpdesol

### DIFF
--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -387,7 +387,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     else:
         return tuple(retlist)
 
-def checkpdesol(pde, sol, func=None, order=None, solve_for_func=True):
+def checkpdesol(pde, sol, func=None, solve_for_func=True):
     """
     Checks if the given solution satisfies the partial differential
     equation.
@@ -449,7 +449,7 @@ def checkpdesol(pde, sol, func=None, order=None, solve_for_func=True):
     # then return a list or set of tuples.
     if is_sequence(sol, set):
         return type(sol)([checkpdesol(
-            pde, i, func=func, order=order,
+            pde, i, func=func,
             solve_for_func=solve_for_func) for i in sol])
 
     # Convert solution into an equation
@@ -465,10 +465,10 @@ def checkpdesol(pde, sol, func=None, order=None, solve_for_func=True):
         if solved:
             if len(solved) == 1:
                 return checkpdesol(pde, Eq(func, solved[0]),
-                    func=func, order=order, solve_for_func=False)
+                    func=func, solve_for_func=False)
             else:
                 return checkpdesol(pde, [Eq(func, t) for t in solved],
-                    func=func, order=order, solve_for_func=False)
+                    func=func, solve_for_func=False)
 
     # The first method includes direct substitution of the solution in
     # the PDE and simplifying.

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -470,17 +470,14 @@ def checkpdesol(pde, sol, func=None, solve_for_func=True):
                 return checkpdesol(pde, [Eq(func, t) for t in solved],
                     func=func, solve_for_func=False)
 
-    # The first method includes direct substitution of the solution in
-    # the PDE and simplifying.
+    # try direct substitution of the solution into the PDE and simplify
     if sol.lhs == func:
         pde = pde.lhs - pde.rhs
         s = simplify(pde.subs(func, sol.rhs).doit())
         return s is S.Zero, s
-    else:
-        raise NotImplementedError(filldedent('''
-    There is no method implemented for checking the equation
-    when solve_for_func is False and the sol does not have
-    the function on the left or right hand side.'''))
+
+    raise NotImplementedError(filldedent('''
+        Unable to test if %s is a solution to %s.''' % (sol, pde)))
 
 
 def pde_1st_linear_constant_coeff_homogeneous(eq, func, order, match, solvefun):

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -44,11 +44,14 @@ from sympy.core.symbol import Symbol, Wild, symbols
 from sympy.functions import exp
 from sympy.integrals.integrals import Integral
 from sympy.utilities.iterables import has_dups
+from sympy.utilities.misc import filldedent
 
 from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 from sympy.solvers.solvers import solve
 from sympy.simplify.radsimp import collect
+
 import operator
+
 
 allhints = (
     "1st_linear_constant_coeff_homogeneous",
@@ -384,7 +387,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     else:
         return tuple(retlist)
 
-def checkpdesol(pde, sol, func=None, solve_for_func=True):
+def checkpdesol(pde, sol, func=None, order=None, solve_for_func=True):
     """
     Checks if the given solution satisfies the partial differential
     equation.
@@ -445,44 +448,40 @@ def checkpdesol(pde, sol, func=None, solve_for_func=True):
     # If the given solution is in the form of a list or a set
     # then return a list or set of tuples.
     if is_sequence(sol, set):
-        return type(sol)([checkpdesol(pde, i, solve_for_func=solve_for_func) for i in sol])
+        return type(sol)([checkpdesol(
+            pde, i, func=func, order=order,
+            solve_for_func=solve_for_func) for i in sol])
 
     # Convert solution into an equation
     if not isinstance(sol, Equality):
         sol = Eq(func, sol)
+    elif sol.rhs == func:
+        sol = sol.reversed
 
     # Try solving for the function
-    if solve_for_func and not (sol.lhs == func and not sol.rhs.has(func)) and not \
-            (sol.rhs == func and not sol.lhs.has(func)):
-        try:
-            solved = solve(sol, func)
-            if not solved:
-                raise NotImplementedError
-        except NotImplementedError:
-            pass
-        else:
+    solved = sol.lhs == func and not sol.rhs.has(func)
+    if solve_for_func and not solved:
+        solved = solve(sol, func)
+        if solved:
             if len(solved) == 1:
-                result = checkpdesol(pde, Eq(func, solved[0]),
-                    order=order, solve_for_func=False)
+                return checkpdesol(pde, Eq(func, solved[0]),
+                    func=func, order=order, solve_for_func=False)
             else:
-                result = checkpdesol(pde, [Eq(func, t) for t in solved],
-                order=order, solve_for_func=False)
+                return checkpdesol(pde, [Eq(func, t) for t in solved],
+                    func=func, order=order, solve_for_func=False)
 
     # The first method includes direct substitution of the solution in
     # the PDE and simplifying.
-    pde = pde.lhs - pde.rhs
     if sol.lhs == func:
-        s = pde.subs(func, sol.rhs).doit()
-    elif sol.rhs == func:
-        s = pde.subs(func, sol.lhs).doit()
-    if s:
-        ss = simplify(s)
-        if ss:
-            return False, ss
-        else:
-            return True, 0
+        pde = pde.lhs - pde.rhs
+        s = simplify(pde.subs(func, sol.rhs).doit())
+        return s is S.Zero, s
     else:
-        return True, 0
+        raise NotImplementedError(filldedent('''
+    There is no method implemented for checking the equation
+    when solve_for_func is False and the sol does not have
+    the function on the left or right hand side.'''))
+
 
 def pde_1st_linear_constant_coeff_homogeneous(eq, func, order, match, solvefun):
     r"""

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -94,6 +94,11 @@ def test_checkpdesol():
          (False, (x - 1)*F(3*x - y)*exp(-x/S(10) - 3*y/S(10)))]
     for eq in [eq4, eq5, eq6]:
         assert checkpdesol(eq, pdsolve(eq))[0]
+    sol = pdsolve(eq4)
+    sol4 = Eq(sol.lhs - sol.rhs, 0)
+    raises(NotImplementedError, lambda:
+        checkpdesol(eq4, sol4, solve_for_func=False))
+
 
 def test_solvefun():
     f, F, G, H = map(Function, ['f', 'F', 'G', 'H'])


### PR DESCRIPTION
- get func on the lhs to simplify code that follows
- include order arg in checkpdesol; this is passed but
  not defined in the recursive calls so I added an
  arg in the same position as the argument in checkodesol
- watch out for undefined s in checkpdesol; if func
  was not on the left or right then s would have been undefined;
  raise an error if func has not been isolated and was not
  requested to be solved for.
