### PR TITLE
10401b: simplification of Relationals

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -836,7 +836,7 @@ def test_issue_2787():
     s = Sum(binomial_dist*k, (k, 0, n))
     res = s.doit().simplify()
     assert res == Piecewise(
-        (n*p, And(Or(-n + 1 < 0, Ne(p/(p - 1), 1)), p/Abs(p - 1) <= 1)),
+        (n*p, 1/Abs(p - 1) <= 1/p),
         (Sum(k*p**k*(-p + 1)**(-k)*(-p + 1)**n*binomial(n, k), (k, 0, n)),
         True))
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -608,7 +608,6 @@ def test_simplify_relational():
             try:
                 assert str(val_ans) == str(val_eq)
             except:
-                print(val_ans, val_eq)
                 rv = False
         return rv
 
@@ -660,7 +659,7 @@ def test_simplify_relational():
     eq = Lt(1/p + 1/p/x, 1)
     assert check(eq, 1/x < p - 1)
     eq = Lt((1 + 1/x)/r, 1)
-    assert check(eq, eq)
+    assert check(eq, (x  + 1)/(r*x) < 1)
     eq = Lt(1/p + 1/p/x, 0)
     assert check(eq, 1/x < -1)
     assert check(Ne(p/(p - 1), 1), S.true)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,12 +1,15 @@
 from sympy.utilities.pytest import XFAIL, raises
-from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
-                   Implies, Xor, zoo, sqrt, Rational, simplify, Function)
+from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
+    Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function,
+    cos, sin)
 from sympy.core.compatibility import range
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
                                    Gt, Ge, Ne)
 from sympy.sets.sets import Interval, FiniteSet
+from sympy.utilities.misc import filldedent
+
 
 x, y, z, t = symbols('x,y,z,t')
 
@@ -573,9 +576,103 @@ def test_issue_8449():
     assert Le(oo, -p) is S.false
 
 
-def test_simplify():
-    assert simplify(x*(y + 1) - x*y - x + 1 < x) == (x > 1)
-    assert simplify(S(1) < -x) == (x < -1)
+def test_simplify_relational():
+    def check(eq, ans):
+        from random import randint as rnd
+        if not eq.is_Relational:
+            raise ValueError(filldedent('''
+    The `check` function expects to see if a Relational
+    simplifies correctly; the expression that was passed
+    (if it was a Relational) simplified at instantiation
+    and was no longer a Relational so it is not something
+    that should be tested in this `test_` function.'''))
+
+        rv = simplify(eq) == ans
+        if eq != ans:
+            free = eq.free_symbols
+            v = [rnd(1, 100) + S.ImaginaryUnit*rnd(1, 100) for i in free]
+            reps = dict(zip(free, v))
+            try:
+                val_eq = eq.xreplace(reps)
+                if val_eq.is_Relational:
+                    val_eq = val_eq.func(*[S(str(i.n(2))) for i in val_eq.args])
+            except TypeError:
+                val_eq = None
+            try:
+                val_ans = ans if not ans.is_Relational else \
+                    ans.xreplace(reps)
+                if val_ans.is_Relational:
+                    val_ans = val_ans.func(*[S(str(i.n(2))) for i in val_ans.args])
+            except TypeError:
+                val_ans = None
+            try:
+                assert str(val_ans) == str(val_eq)
+            except:
+                print(val_ans, val_eq)
+                rv = False
+        return rv
+
+    x = Symbol('x')
+    assert check(x*(y + 1) - x*y - x + 1 < x, x > 1)
+    assert check(S(1) < -x, x < -1)
+
+    # issue 10401
+    r = Symbol('r', real=True)
+    p = Symbol('p', positive=True)
+    n = Symbol('n', negative=True)
+    assert check(Eq(1/(x + 1), 0), S.false)
+    assert check(Eq(x/(x + 1), 1), S.false)
+    assert check(Lt(p/x, 0), Lt(1/x ,0))
+
+    f = x/(x + 1)
+    g = 1/(1 + 1/x)
+    assert simplify(Eq(f, g)) is not S.true
+    f = f.subs(x, r)
+    g = g.subs(x, r)
+    assert simplify(Eq(f, g)) is not S.true
+
+    assert check(Eq(x*(x - 1), x**2 - x), S.true)
+    eq = Lt(x, x - 1)
+    assert check(eq, eq)
+    eq = Eq(x, x - 1)
+    assert check(eq, S.false)
+    eq = Lt(x, x)
+    assert check(eq, eq)
+    assert check(Lt(p, p*x), Gt(x, 1))
+    assert check(Lt(2*x/n, 0), Gt(x, 0))
+    assert check(Lt(-2*x/n, 0), Lt(x, 0))
+    eq = Lt(cos(x)**2, -sin(x)**2)
+    assert check(eq, eq)
+    eq = Lt(cos(r)**2, -sin(r)**2)
+    assert simplify(eq) is S.false
+    eq = Lt(x, x + x**2)
+    assert check(eq, Lt(x, x*(x + 1)))
+    eq = Lt(r, r + r**2)
+    assert check(eq, Gt(r**2, 0))
+    eq = Lt(x + I, y + I)
+    assert check(eq, eq)
+    eq = Lt(1 + p*(1 + x), y)
+    assert check(eq, p*(x + 1) < y - 1)
+    eq = Lt(1 + p + p*x, y)
+    assert check(eq, p*(x + 1) < y - 1)
+    eq = Lt((cos(x)**2 + sin(x)**2)/p, 1)
+    assert check(eq, p > 1)
+    eq = Lt(1/p + 1/p/x, 1)
+    assert check(eq, 1/x < p - 1)
+    eq = Lt((1 + 1/x)/r, 1)
+    assert check(eq, eq)
+    eq = Lt(1/p + 1/p/x, 0)
+    assert check(eq, 1/x < -1)
+    assert check(Ne(p/(p - 1), 1), S.true)
+    assert check(Lt(x, 2*x - 2), x > 2)
+    assert check(Lt(x, 2*x - sqrt(2)), x > sqrt(2))
+    eq = Eq(I/(1 + I), 1)
+    assert check(eq, S.false)
+
+
+@XFAIL
+def test_fail_instantiation():
+    raises(TypeError, lambda: Lt(1 + (1 - 3*I)**2, 1 + (1 - 3*I)**2))
 
 
 def test_equals():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1064,7 +1064,7 @@ def test_issue_4234():
 def test_issue_4492():
     assert simplify(integrate(x**2 * sqrt(5 - x**2), x)) == Piecewise(
         (I*(2*x**5 - 15*x**3 + 25*x - 25*sqrt(x**2 - 5)*acosh(sqrt(5)*x/5)) /
-            (8*sqrt(x**2 - 5)), 1 < Abs(x**2)/5),
+            (8*sqrt(x**2 - 5)), Abs(x**2) > 5),
         ((-2*x**5 + 15*x**3 - 25*x + 25*sqrt(-x**2 + 5)*asin(sqrt(5)*x/5)) /
             (8*sqrt(-x**2 + 5)), True))
 

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -600,7 +600,7 @@ def test_messy():
 
     # NOTE s < 0 can be done, but argument reduction is not good enough yet
     assert fourier_transform(besselj(1, x)/x, x, s, noconds=False) == \
-        (Piecewise((0, 4*abs(pi**2*s**2) > 1),
+        (Piecewise((0, (1/pi**2/4 < abs(s**2)).canonical),
                    (2*sqrt(-4*pi**2*s**2 + 1), True)), s > 0)
     # TODO FT(besselj(0,x)) - conditions are messy (but for acceptable reasons)
     #                       - folding could be better

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -39,6 +39,18 @@ import mpmath
 
 
 
+# a transform to remove hollow 2-arg
+# mul factoring: 2*(1 + x) -> 2 + 2*x
+hollow_mul = Transform(
+    lambda x: Mul(*x.args),
+    lambda x:
+    x.is_Mul and
+    len(x.args) == 2 and
+    x.args[0].is_Number and
+    x.args[1].is_Add and
+    x.is_commutative)
+
+
 def separatevars(expr, symbols=[], dict=False, force=False):
     """
     Separates variables in an expression, if possible.  By
@@ -586,14 +598,6 @@ def simplify(expr, ratio=1.7, measure=count_ops, fu=False):
         short = exptrigsimp(short, simplify=False)
 
     # get rid of hollow 2-arg Mul factorization
-    hollow_mul = Transform(
-        lambda x: Mul(*x.args),
-        lambda x:
-        x.is_Mul and
-        len(x.args) == 2 and
-        x.args[0].is_Number and
-        x.args[1].is_Add and
-        x.is_commutative)
     expr = short.xreplace(hollow_mul)
 
     numer, denom = expr.as_numer_denom()

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -101,8 +101,12 @@ def test_simplify_other():
     assert simplify(sin(x)**2 + cos(x)**2) == 1
     assert simplify(gamma(x + 1)/gamma(x)) == x
     assert simplify(sin(x)**2 + cos(x)**2 + factorial(x)/gamma(x)) == 1 + x
+    # XXX this should go to Eq(x, 1) but it is not known that these
+    # two are equivalent -- perhaps each needs an _eval_Eq method to
+    # recognize the other?
     assert simplify(
-        Eq(sin(x)**2 + cos(x)**2, factorial(x)/gamma(x))) == Eq(x, 1)
+        Eq(sin(x)**2 + cos(x)**2, factorial(x)/gamma(x))) == \
+        Eq(factorial(x), gamma(x))
     nc = symbols('nc', commutative=False)
     assert simplify(x + x*nc) == x*(1 + nc)
     # issue 6123

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4138,8 +4138,8 @@ def ode_nth_linear_euler_eq_nonhomogeneous_variation_of_parameters(eq, func, ord
     >>> f = Function('f')
     >>> eq = x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x) - x**4
     >>> dsolve(eq, f(x),
-    ... hint='nth_linear_euler_eq_nonhomogeneous_variation_of_parameters').expand()
-    Eq(f(x), C1*x + C2*x**2 + x**4/6)
+    ... hint='nth_linear_euler_eq_nonhomogeneous_variation_of_parameters')
+    Eq(f(x), x*(C1 + C2*x + x**3/6))
 
     """
     x = func.args[0]

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -576,18 +576,18 @@ def test_checkodesol():
     assert checkodesol(diff(sol1.lhs, x, 3), sol1) == (True, 0)
     assert checkodesol(diff(sol1.lhs, x, 3)*exp(f(x)), sol1) == (True, 0)
     assert checkodesol(diff(sol1.lhs, x, 3), Eq(f(x), x*log(x))) == \
-        (False, 60*x**4*((log(x) + 1)**2 + log(x))*(
-        log(x) + 1)*log(x)**2 - 5*x**4*log(x)**4 - 9)
+        (False,
+        x**4*(60*log(x)**3 + 235*log(x)**2 + 240*log(x) + 60)*log(x)**2 - 9)
     assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x)) == \
         (True, 0)
     assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x),
         solve_for_func=False) == (True, 0)
     assert checkodesol(f(x).diff(x, 2), [Eq(f(x), C1 + C2*x),
         Eq(f(x), C2 + C1*x), Eq(f(x), C1*x + C2*x**2)]) == \
-        [(True, 0), (True, 0), (False, 2*C2)]
+        [(True, 0), (True, 0), (False, C2)]
     assert checkodesol(f(x).diff(x, 2), set([Eq(f(x), C1 + C2*x),
         Eq(f(x), C2 + C1*x), Eq(f(x), C1*x + C2*x**2)])) == \
-        set([(True, 0), (True, 0), (False, 2*C2)])
+        set([(True, 0), (True, 0), (False, C2)])
     assert checkodesol(f(x).diff(x) - 1/f(x)/2, Eq(f(x)**2, x)) == \
         [(True, 0), (True, 0)]
     assert checkodesol(f(x).diff(x) - f(x), Eq(C1*exp(x), f(x))) == (True, 0)
@@ -1061,7 +1061,8 @@ def test_separable1():
     assert dsolve(eq2, hint='separable') == sol2
     assert dsolve(eq3, hint='separable') == sol3
     assert dsolve(eq4, hint='separable', simplify=False) == sol4
-    assert dsolve(eq5, hint='separable') == simplify(sol5).expand()
+    assert dsolve(eq5, hint='separable').simplify() == \
+        sol5.simplify()
     assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
@@ -1104,7 +1105,8 @@ def test_separable3():
     sol11 = Eq(f(x), C1*sqrt(1 + tan(x)**2))
     sol12 = Eq(log(-1 + cos(f(x))**2)/2, C1 + 2*x + 2*log(x - 1))
     sol13 = Eq(log(log(f(x))), C1 + log(cos(x)**2 - 1)/2)
-    assert dsolve(eq11, hint='separable') == simplify(sol11)
+    assert dsolve(eq11, hint='separable').simplify() == \
+        sol11.simplify()
     assert dsolve(eq12, hint='separable', simplify=False) == sol12
     assert dsolve(eq13, hint='separable', simplify=False) == sol13
     assert checkodesol(eq11, sol11, order=1, solve_for_func=False)[0]
@@ -2119,14 +2121,14 @@ def test_nth_order_linear_euler_eq_nonhomogeneous_undetermined_coefficients():
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x), x**3)
-    sol = x*(C1 + C2*x + Rational(1, 2)*x**2)
+    sol = x*(C1 + C2*x + x**2/2)
     sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) - x*diff(f(x), x) - 3*f(x), log(x)/x)
-    sol =  C1/x + C2*x**3 - Rational(1, 16)*log(x)/x - Rational(1, 8)*log(x)**2/x
+    sol =  C1/x + C2*x**3 - log(x)**2/(8*x) - log(x)/(16*x)
     sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
@@ -2159,10 +2161,10 @@ def test_nth_order_linear_euler_eq_nonhomogeneous_variation_of_parameters():
     assert our_hint in classify_ode(eq, f(x))
 
     eq = Eq(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x), x**4)
-    sol = C1*x + C2*x**2 + x**4/6
+    sol = Eq(f(x), x*(C1 + C2*x + x**3/6))
     sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq)
-    assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
+    assert dsolve(eq, f(x), hint=our_hint) in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(3*x**2*diff(f(x), x, x) + 6*x*diff(f(x), x) - 6*f(x), x**3*exp(x))

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -139,32 +139,32 @@ def test_pde_1st_linear_constant_coeff():
     f, F = map(Function, ['f', 'F'])
     u = f(x,y)
     eq = -2*u.diff(x) + 4*u.diff(y) + 5*u - exp(x + 3*y)
-    sol = pdsolve(eq)
-    assert sol == Eq(f(x,y),
-    (F(4*x + 2*y) + exp(x/S(2) + 4*y)/S(15))*exp(x/S(2) - y))
+    sol = Eq(f(x,y),
+        (F(4*x + 2*y) + exp(x/2 + 4*y)/S(15))*exp(x/2 - y))
+    assert pdsolve(eq).simplify() == sol.simplify()
     assert classify_pde(eq) == ('1st_linear_constant_coeff',
     '1st_linear_constant_coeff_Integral')
     assert checkpdesol(eq, sol)[0]
 
     eq = (u.diff(x)/u) + (u.diff(y)/u) + 1 - (exp(x + y)/u)
-    sol = pdsolve(eq)
-    assert sol == Eq(f(x, y), F(x - y)*exp(-x/2 - y/2) + exp(x + y)/S(3))
+    sol = Eq(f(x, y), F(x - y)*exp(-x/2 - y/2) + exp(x + y)/S(3))
+    assert pdsolve(eq).simplify() == sol.simplify()
     assert classify_pde(eq) == ('1st_linear_constant_coeff',
     '1st_linear_constant_coeff_Integral')
     assert checkpdesol(eq, sol)[0]
 
     eq = 2*u + -u.diff(x) + 3*u.diff(y) + sin(x)
-    sol = pdsolve(eq)
-    assert sol == Eq(f(x, y),
+    sol = Eq(f(x, y),
          F(3*x + y)*exp(x/S(5) - 3*y/S(5)) - 2*sin(x)/S(5) - cos(x)/S(5))
+    assert pdsolve(eq).simplify() == sol.simplify()
     assert classify_pde(eq) == ('1st_linear_constant_coeff',
     '1st_linear_constant_coeff_Integral')
     assert checkpdesol(eq, sol)[0]
 
     eq = u + u.diff(x) + u.diff(y) + x*y
-    sol = pdsolve(eq)
-    assert sol == Eq(f(x, y),
+    sol = Eq(f(x, y),
         -x*y + x + y + F(x - y)*exp(-x/S(2) - y/S(2)) - 2)
+    assert pdsolve(eq).simplify() == sol.simplify()
     assert classify_pde(eq) == ('1st_linear_constant_coeff',
     '1st_linear_constant_coeff_Integral')
     assert checkpdesol(eq, sol)[0]
@@ -183,8 +183,9 @@ def test_pdsolve_all():
     assert sorted(sol.keys()) == keys
     assert sol['order'] == 1
     assert sol['default'] == '1st_linear_constant_coeff'
-    assert sol['1st_linear_constant_coeff'] == Eq(f(x, y),
-        -x**2*y + x**2 + 2*x*y - 4*x - 2*y + F(x - y)*exp(-x/S(2) - y/S(2)) + 6)
+    assert sol['1st_linear_constant_coeff'].simplify() == Eq(f(x, y),
+        -x**2*y + x**2 + 2*x*y - 4*x - 2*y +
+        F(x - y)*exp(-x/S(2) - y/S(2)) + 6).simplify()
 
 def test_pdsolve_variable_coeff():
     f, F = map(Function, ['f', 'F'])

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -726,6 +726,10 @@ def test_solve_trig():
 
     assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptySet
 
+    y, a = symbols('y,a')
+    assert solveset_real(sin(y + a) - sin(y), a) == \
+        imageset(Lambda(n, 2*n*pi), S.Integers)
+
 
 @XFAIL
 def test_solve_trig_abs():
@@ -873,7 +877,7 @@ def test_solveset():
                                                   S.Integers)
 
 
-def test_conditonset():
+def test_conditionset():
     assert solveset(Eq(sin(x)**2 + cos(x)**2, 1), x, domain=S.Reals) == \
         ConditionSet(x, True, S.Reals)
 
@@ -888,10 +892,6 @@ def test_conditonset():
 
     assert solveset(x + sin(x) > 1, x, domain=S.Reals) == \
         ConditionSet(x, x + sin(x) > 1, S.Reals)
-
-    y,a = symbols('y,a')
-    assert solveset(sin(y + a) - sin(y), a, domain=S.Reals) == \
-        ConditionSet(a, Eq(-sin(y) + sin(y + a), 0), S.Reals)
 
 
 @XFAIL


### PR DESCRIPTION
ugh. The code is not simple. This is much worse than regular simplification if you try to keep a potentially invalid relationship from becoming valid, e.g. `Lt(x, x + 1)` is invalid if `x == I` so we cannot say that this relationship is automatically true. 

Some key features to keep are
1. to not reorganize the left and rhs (else an Eq that had something isolated on the lhs may no longer be that way after simplification, e.g. Eq(y, f(x)) could become Eq(y - f(x), 0))
2. to not return an expression whose character will differ from the original (e.g. not have the same singularities, etc...).

closes #10401 
closes #10404 
- [x] track down why the unrad solution changed

**References**

---
1. https://groups.google.com/forum/#!searchin/sympy/singularities$20limit/sympy/oaoAIp4DOxQ/cGZoWbf-ieUJ
2. https://github.com/sympy/sympy/wiki/Infinities-and-Singularities
3. https://github.com/sympy/sympy/issues/6091
4. https://github.com/sympy/sympy/pull/971
