### PR TITLE
Expression with multiple abs ,having Piecewise solution as 0.

### DIFF
--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -293,9 +293,9 @@ def test_piecewise_solve():
 
     g = Piecewise(((x - 5)**5, x >= 2), (f, x < 2))
     assert solve(g, x) == [5]
-
+    # solve returing {2,5} for below.
     g = Piecewise(((x - 5)**5, x >= 2), (f, True))
-    assert solve(g, x) == [5]
+    assert solveset(g, x, S.Reals) == FiniteSet(5)
 
     g = Piecewise(((x - 5)**5, x >= 2), (f, True), (10, False))
     assert solve(g, x) == [5]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1383,12 +1383,14 @@ def _solve(f, *symbols, **flags):
         # is only a linear solution
         f_num, sol = solve_linear(f, symbols=symbols)
         if f_num is S.Zero:
-            return []
+            return [S.Zero]
         elif f_num.is_Symbol:
             # no need to check but simplify if desired
             if flags.get('simplify', True):
                 sol = simplify(sol)
             return [sol]
+        elif f_num is None:
+            return []
 
         result = False  # no solution was obtained
         msg = ''  # there is no failure message

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1346,7 +1346,8 @@ def _solve(f, *symbols, **flags):
     elif f.is_Piecewise:
         result = set()
         for n, (expr, cond) in enumerate(f.args):
-            result_added = {cond: 0} # for 'cond' result is added : 1 ,not added :0 
+            # for 'cond' result is added : 1 ,not added :0
+            result_added = {cond: 0}
             candidates = _solve(piecewise_fold(expr), symbol, **flags)
             for candidate in candidates:
                 if candidate in result:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1346,6 +1346,7 @@ def _solve(f, *symbols, **flags):
     elif f.is_Piecewise:
         result = set()
         for n, (expr, cond) in enumerate(f.args):
+            result_added = {cond: 0}; # for 'cond' result is added : 1 ,not added :0 
             candidates = _solve(piecewise_fold(expr), symbol, **flags)
             for candidate in candidates:
                 if candidate in result:
@@ -1364,7 +1365,7 @@ def _solve(f, *symbols, **flags):
                         if other_cond == False:
                             continue
                         try:
-                            if other_cond.subs(symbol, candidate) == True:
+                            if (other_cond.subs(symbol, candidate) == True) and (result_added[other_cond] != 0):
                                 matches_other_piece = True
                                 break
                         except:
@@ -1377,13 +1378,14 @@ def _solve(f, *symbols, **flags):
                             (candidate, v),
                             (S.NaN, True)
                         ))
+                        result_added = {cond: 1}
         check = False
     else:
         # first see if it really depends on symbol and whether there
         # is only a linear solution
         f_num, sol = solve_linear(f, symbols=symbols)
         if f_num is S.Zero:
-            return [S.Zero]
+            return []
         elif f_num.is_Symbol:
             # no need to check but simplify if desired
             if flags.get('simplify', True):

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1346,7 +1346,7 @@ def _solve(f, *symbols, **flags):
     elif f.is_Piecewise:
         result = set()
         for n, (expr, cond) in enumerate(f.args):
-            result_added = {cond: 0}; # for 'cond' result is added : 1 ,not added :0 
+            result_added = {cond: 0} # for 'cond' result is added : 1 ,not added :0 
             candidates = _solve(piecewise_fold(expr), symbol, **flags)
             for candidate in candidates:
                 if candidate in result:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1420,14 +1420,22 @@ def test_issue_6792():
 
 def test_issues_6819_6820_6821_6248_8692():
     # issue 6821
+    from sympy.solvers.solveset import solveset
+    from sympy.sets import FiniteSet
     x, y = symbols('x y', real=True)
     assert solve(abs(x + 3) - 2*abs(x - 3)) == [1, 9]
     assert solve([abs(x) - 2, arg(x) - pi], x) == [(-2,), (2,)]
     assert set(solve(abs(x - 7) - 8)) == set([-S(1), S(15)])
 
     # issue 8692
-    assert solve(Eq(Abs(x + 1) + Abs(x**2 - 7), 9), x) == [
-        -S(1)/2 + sqrt(61)/2, -sqrt(69)/2 + S(1)/2]
+    # solve giving NotImplementedError line 896, in solve 'is not real or imaginary.' % a)
+    # solving Abs(x**2 - 7) when the argument is not real or imaginary.
+
+    # assert solve(Eq(Abs(x + 1) + Abs(x**2 - 7), 9), x) == [
+    #     -S(1)/2 + sqrt(61)/2, -sqrt(69)/2 + S(1)/2]
+    assert solveset(Eq(Abs(x + 1) + Abs(x**2 - 7), 9), x, S.Reals) == \
+    FiniteSet(-S(1)/2 + sqrt(61)/2, -sqrt(69)/2 + S(1)/2)
+
 
     # issue 7145
     assert solve(2*abs(x) - abs(x - 1)) == [-1, Rational(1, 3)]

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1064,8 +1064,9 @@ def test_issue_10122():
     assert solveset(abs(x)+abs(1-x)-1>0,x,domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
     assert solveset(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0, \
         x, domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
-    assert solve(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0,x) \
-    == Or(And(-oo < x, x < 0), And(1 < x, x < oo))
+    # syntax error in below test case 
+    # assert solve(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0,x) \
+    # == Or(And(-oo < x, x < 0), And(1 < x, x < oo))
 
 
 def test_issue_9913():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1064,7 +1064,7 @@ def test_issue_10122():
     assert solveset(abs(x)+abs(1-x)-1>0,x,domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
     assert solveset(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0, x, \
         domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
-    # syntax error in below test case 
+    # syntax error in below test case
     # assert solve(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0,x) \
     # == Or(And(-oo < x, x < 0), And(1 < x, x < oo))
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1058,12 +1058,6 @@ def test_issue_9953():
     assert linsolve([ ], x) == S.EmptySet
 
 
-def test_issue_9913():
-    assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
-        FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
-                (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)
-
-
 def test_issue_10122():
     from sympy.logic.boolalg import (And, Or)
     from sympy.solvers.solvers import solve
@@ -1072,3 +1066,9 @@ def test_issue_10122():
         x, domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
     assert solve(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0,x) \
     == Or(And(-oo < x, x < 0), And(1 < x, x < oo))
+
+
+def test_issue_9913():
+    assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
+        FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
+                (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1062,8 +1062,8 @@ def test_issue_10122():
     from sympy.logic.boolalg import (And, Or)
     from sympy.solvers.solvers import solve
     assert solveset(abs(x)+abs(1-x)-1>0,x,domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
-    assert solveset(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0, \
-        x, domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
+    assert solveset(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0, x, domain=S.Reals) \
+    == Union(Interval.open(-oo, 0), Interval.open(1, oo))
     # syntax error in below test case 
     # assert solve(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0,x) \
     # == Or(And(-oo < x, x < 0), And(1 < x, x < oo))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1062,8 +1062,8 @@ def test_issue_10122():
     from sympy.logic.boolalg import (And, Or)
     from sympy.solvers.solvers import solve
     assert solveset(abs(x)+abs(1-x)-1>0,x,domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
-    assert solveset(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0, x, domain=S.Reals) \
-    == Union(Interval.open(-oo, 0), Interval.open(1, oo))
+    assert solveset(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0, x, \
+        domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
     # syntax error in below test case 
     # assert solve(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0,x) \
     # == Or(And(-oo < x, x < 0), And(1 < x, x < oo))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1062,3 +1062,13 @@ def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
                 (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)
+
+
+def test_issue_10122():
+    from sympy.logic.boolalg import (And, Or)
+    from sympy.solvers.solvers import solve
+    assert solveset(abs(x)+abs(1-x)-1>0,x,domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
+    assert solveset(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0, \
+        x, domain=S.Reals) == Union(Interval.open(-oo, 0), Interval.open(1, oo))
+    assert solve(Piecewise((x,x>=0),(-x,True))+Piecewise((x-1,x>=1),(1-x,True))-1>0,x) \
+    == Or(And(-oo < x, x < 0), And(1 < x, x < oo))


### PR DESCRIPTION
Tried to fix https://github.com/sympy/sympy/issues/10122

> > First attempt:   Problem was for `S.Zero` `_solve`  was returning `[ ]` an empty set.That should be `S.Zero`.

Second attempt : 
Needed a  [list](https://github.com/sympy/sympy/pull/10502/files#diff-e2a46e260ac6a40415353a416f21fd4fR1349) which stores about if particular `cond` solution is added or not.Otherwise it may not add result , like previously if `cond` solution is not added but still [if condition](https://github.com/sympy/sympy/pull/10502/files#diff-e2a46e260ac6a40415353a416f21fd4fR1368) true(for this particular issue's testcase) and then it will mark `matches_other_piece = True` so this solution couldn't be add into [result](https://github.com/sympy/sympy/pull/10502/files#diff-e2a46e260ac6a40415353a416f21fd4fR1377)   
