### PR TITLE
Add a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting one of the project maintainers at asmeurer@gmail.com or
+ondrej.certik@gmail.com. All complaints will be reviewed and investigated and
+will result in a response that is deemed necessary and appropriate to the
+circumstances. Maintainers are obligated to maintain confidentiality with
+regard to the reporter of an incident.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/README.rst
+++ b/README.rst
@@ -108,15 +108,15 @@ Contributing
 ------------
 
 We welcome contributions from anyone, even if you are new to open
-source. Please read our [introduction to
-contributing](https://github.com/sympy/sympy/wiki/Introduction-to-contributing). If
-you are new and looking for some way to contribute a good place to start is to
-look at the issues tagged ["Easy to
-Fix"](https://github.com/sympy/sympy/issues?q=is%3Aopen+is%3Aissue+label%3A%22Easy+to+Fix%22).
+source. Please read our `introduction to contributing
+<https://github.com/sympy/sympy/wiki/Introduction-to-contributing>`_. If you
+are new and looking for some way to contribute a good place to start is to
+look at the issues tagged `Easy to Fix
+<https://github.com/sympy/sympy/issues?q=is%3Aopen+is%3Aissue+label%3A%22Easy+to+Fix%22>`_.
 
 Please note that all participants of this project are expected to follow our
 Code of Conduct. By participating in this project you agree to abide by its
-terms. See [CODE_OF_CONDUCT.MD](CODE_OF_CONDUCT.MD).
+terms. See `CODE_OF_CONDUCT.MD <CODE_OF_CONDUCT.MD>`_.
 
 Tests
 -----

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,20 @@ If you install it system-wide, you may need to prefix the previous command with 
 
 See http://docs.sympy.org/dev/install.html for more information.
 
+Contributing
+------------
+
+We welcome contributions from anyone, even if you are new to open
+source. Please read our [introduction to
+contributing](https://github.com/sympy/sympy/wiki/Introduction-to-contributing). If
+you are new and looking for some way to contribute a good place to start is to
+look at the issues tagged ["Easy to
+Fix"](https://github.com/sympy/sympy/issues?q=is%3Aopen+is%3Aissue+label%3A%22Easy+to+Fix%22).
+
+Please note that all participants of this project are expected to follow our
+Code of Conduct. By participating in this project you agree to abide by its
+terms. See [CODE_OF_CONDUCT.MD](CODE_OF_CONDUCT.MD).
+
 Tests
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ look at the issues tagged `Easy to Fix
 
 Please note that all participants of this project are expected to follow our
 Code of Conduct. By participating in this project you agree to abide by its
-terms. See `CODE_OF_CONDUCT.MD <CODE_OF_CONDUCT.MD>`_.
+terms. See `CODE_OF_CONDUCT.md <CODE_OF_CONDUCT.md>`_.
 
 Tests
 -----


### PR DESCRIPTION
The code of conduct is the [Contributor Covenant](http://contributor-covenant.org/), which is the same thing [NumFOCUS uses](http://www.numfocus.org/code-of-conduct.html) (although NumFOCUS is using version 1.2.0, which is only slightly different from 1.3.0). 

I also added a small contributing section to the README (because we didn't have that yet apparently).
