### PR TITLE
S(0).as_coeff_Mul() == (1, 0) not (0, 1)

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -547,7 +547,7 @@ class Number(AtomicExpr):
         """Efficiently extract the coefficient of a product. """
         if rational and not self.is_Rational:
             return S.One, self
-        return self, S.One
+        return (self, S.One) if self else (S.One, self)
 
     def as_coeff_Add(self):
         """Efficiently extract the coefficient of a summation. """

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1278,6 +1278,7 @@ def test_issue_5300():
 
 
 def test_as_coeff_Mul():
+    assert S(0).as_coeff_Mul() == (S.One, S.Zero)
     assert Integer(3).as_coeff_Mul() == (Integer(3), Integer(1))
     assert Rational(3, 4).as_coeff_Mul() == (Rational(3, 4), Integer(1))
     assert Float(5.0).as_coeff_Mul() == (Float(5.0), Integer(1))


### PR DESCRIPTION
With this change, one may confidently write `expr/expr.as_coeff_Mul()` and know that there will be no multiplicative number left on `expr` -- even if `expr` is `S.Zero`.
