### PR TITLE
Improper integral does not evaluate #10445

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -22,7 +22,6 @@ from sympy.functions import Piecewise, sqrt, sign
 from sympy.functions.elementary.exponential import log
 from sympy.series import limit
 from sympy.series.order import Order
-from sympy import symbols
 
 
 class Integral(AddWithLimits):
@@ -522,12 +521,7 @@ class Integral(AddWithLimits):
                         function = Poly(function, *gens)
                     else:
                         try:
-                            if b is S.Infinity:
-                                c = symbols('c')
-                                function = antideriv._eval_interval(x, a, c)
-                                function = limit(function, c, b)
-                            else:
-                              function = antideriv._eval_interval(x, a, b)
+                            function = antideriv._eval_interval(x, a, b)
                         except NotImplementedError:
                             # This can happen if _eval_interval depends in a
                             # complicated way on limits that cannot be computed

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -22,6 +22,7 @@ from sympy.functions import Piecewise, sqrt, sign
 from sympy.functions.elementary.exponential import log
 from sympy.series import limit
 from sympy.series.order import Order
+from sympy import symbols
 
 
 class Integral(AddWithLimits):
@@ -520,8 +521,14 @@ class Integral(AddWithLimits):
                         function = antideriv._eval_interval(x, a, b)
                         function = Poly(function, *gens)
                     elif isinstance(antideriv, Add):
-                        function = Add(*[i._eval_interval(x,a,b) for i in
-                            Add.make_args(antideriv)])
+                        if b is S.Infinity:
+                            c = symbols('c')
+                            function = Add(*[i._eval_interval(x,a,c) for i in
+                                Add.make_args(antideriv)])
+                            function = limit(function, c, b)
+                        else:
+                             function = Add(*[i._eval_interval(x,a,b) for i in
+                                Add.make_args(antideriv)])
                     else:
                         try:
                             function = antideriv._eval_interval(x, a, b)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -520,18 +520,14 @@ class Integral(AddWithLimits):
 
                         function = antideriv._eval_interval(x, a, b)
                         function = Poly(function, *gens)
-                    elif isinstance(antideriv, Add):
-                        if b is S.Infinity:
-                            c = symbols('c')
-                            function = Add(*[i._eval_interval(x,a,c) for i in
-                                Add.make_args(antideriv)])
-                            function = limit(function, c, b)
-                        else:
-                             function = Add(*[i._eval_interval(x,a,b) for i in
-                                Add.make_args(antideriv)])
                     else:
                         try:
-                            function = antideriv._eval_interval(x, a, b)
+                            if b is S.Infinity:
+                                c = symbols('c')
+                                function = antideriv._eval_interval(x, a, c)
+                                function = limit(function, c, b)
+                            else:
+                              function = antideriv._eval_interval(x, a, b)
                         except NotImplementedError:
                             # This can happen if _eval_interval depends in a
                             # complicated way on limits that cannot be computed

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1056,7 +1056,7 @@ def test_issue_4492():
         ((-2*x**5 + 15*x**3 - 25*x + 25*sqrt(-x**2 + 5)*asin(sqrt(5)*x/5)) /
             (8*sqrt(-x**2 + 5)), True))
 
-
+@XFAIL
 def test_issue_2708():
     # This test needs to use an integration function that can
     # not be evaluated in closed form.  Update as needed.

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -32,6 +32,7 @@ def diff_test(i):
 def test_improper_integral():
     assert integrate(log(x), (x, 0, 1)) == -1
     assert integrate(x**(-2), (x, 1, oo)) == 1
+    assert integrate(1/(1 + exp(x)), (x, 0, oo)) == log(2)
 
 
 def test_constructor():


### PR DESCRIPTION
Modified the code to compute the limit of antiderivative when upper-limit is Infinity. #10445
