### PR TITLE
zeta function: zeta(x) for Re(x-1) not zero is finite

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -178,3 +178,8 @@ def test_stieltjes_evalf():
     assert abs(stieltjes(0).evalf() - 0.577215664) < 1E-9
     assert abs(stieltjes(0, 0.5).evalf() - 1.963510026) < 1E-9
     assert abs(stieltjes(1, 2).evalf() + 0.072815845 ) < 1E-9
+
+
+def test_issue_10475():
+    assert zeta(2 + I).is_finite
+    assert zeta(1).is_finite is False

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -463,6 +463,10 @@ class zeta(Function):
     def _eval_rewrite_as_lerchphi(self, s, a=1):
         return lerchphi(1, s, a)
 
+    def _eval_is_finite(self):
+        arg = self.args[0]
+        return not arg == 1
+
     def fdiff(self, argindex=1):
         if len(self.args) == 2:
             s, a = self.args


### PR DESCRIPTION
This commit should fix #10475 
- The (analytically continued) Riemann zeta function is finite in the whole plane except at 1 where it has a pole.
- Added tests for the changes

**Previously `zeta(2+I).is_finite` returned `None`:**

```
In [1]: from sympy import I

In [2]: from sympy.functions import zeta

In [3]: zeta(2+I).is_finite

In [4]: 
```

**Now:**

```
In [1]: from sympy import I

In [2]: from sympy.functions import zeta

In [3]: zeta(2+I).is_finite
Out[3]: True

In [4]: zeta(1).is_finite
Out[4]: False
```
