### PR TITLE
integrate((sign(x - 1) - sign(x - 2))*cos(x), x) raises TypeError #7163

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -257,7 +257,7 @@ class sign(Function):
     is_finite = True
     is_complex = True
 
-    def doit(self):
+    def doit(self, **hints):
         if self.args[0].is_zero is False:
             return self.args[0] / Abs(self.args[0])
         return self


### PR DESCRIPTION
Added `**hints`, now `integrate((sign(x - 1) - sign(x - 2))*cos(x), x)` doesn't raise TypeError
