### PR TITLE
Need to pass if  integral have symbolic upper and lower bound.

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -455,7 +455,7 @@ class MinMaxBase(Expr, LatticeOp):
         return fuzzy_and(arg.is_real for arg in self.args)
 
 
-class Max(MinMaxBase, Application):
+class Max(MinMaxBase, Application) :
     """
     Return, if possible, the maximum value of the list.
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -206,7 +206,7 @@ class Piecewise(Function):
         # following papers;
         #     http://portal.acm.org/citation.cfm?id=281649
         #     http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.70.4127&rep=rep1&type=pdf
-
+        from sympy import Symbol, symbols, Min
         if a is None or b is None:
             # In this case, it is just simple substitution
             return piecewise_fold(
@@ -215,6 +215,8 @@ class Piecewise(Function):
         mul = 1
         if (a == b) == True:
             return S.Zero
+        elif a.atoms(Symbol) or b.atoms(Symbol):
+            pass
         elif (a > b) == True:
             a, b, mul = b, a, -1
         elif (a <= b) != True:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -215,7 +215,7 @@ class Piecewise(Function):
         mul = 1
         if (a == b) == True:
             return S.Zero
-        elif a.atoms(Symbol) or b.atoms(Symbol):
+        elif isinstance((a,b) , Symbol) and (a.atoms(Symbol) or b.atoms(Symbol)):
             pass
         elif (a > b) == True:
             a, b, mul = b, a, -1

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1117,5 +1117,15 @@ def test_issue_4950():
         -2.4*exp(8*x) - 12.0*exp(5*x)
 
 
+def test_issue_10434():
+    w = symbols('w' , positive = True)
+    res = (1/(2 * pi) * integrate(exp(1j * x * n), (x, -w, w)))
+    assert res ==\
+     Piecewise((2*w, Eq(n, 0)), (-1.0*I*exp(1.0*I*n*w)/n + 1.0*I*exp(-1.0*I*n*w)/n, True))/(2*pi)
+    res_sin = res.rewrite(sin)
+    final = simplify(res_sin)
+    assert final == Piecewise((w/pi, Eq(n, 0)), (1.0*sin(1.0*n*w)/(pi*n), True))
+
+
 def test_issue_4968():
     assert integrate(sin(log(x**2))) == x*sin(2*log(x))/5 - 2*x*cos(2*log(x))/5


### PR DESCRIPTION
Tried to fix : https://github.com/sympy/sympy/issues/10434
`1/(2 * pi) * integrate(exp(1j * w * n), (w, -wc, wc))`
gives answer in `exp` form ,as generally sympy gives.
When we rewrite the answer is `sin` and simplify we get the desired answer :  
`(sin(wc) * n)/(pi * n)`
