### PR TITLE
solveset_real need to check symbol in condition.

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -487,8 +487,19 @@ def solveset_real(f, symbol):
     elif f.is_Piecewise:
         result = EmptySet()
         expr_set_pairs = f.as_expr_set_pairs()
-        for (expr, in_set) in expr_set_pairs:
-            solns = solveset_real(expr, symbol).intersect(in_set)
+        expr_cond = {}
+        sym_interval ={}
+        for other_n, (expr_tmp, cond) in enumerate(f.args):
+            expr_cond[expr_tmp] = cond
+        for (expr, in_set_symbol) in expr_set_pairs:
+            solns_tmp = solveset_real(expr, symbol)
+            # by default symbol interval. many times cond symbols are expr symbols
+            for sym in expr.atoms(Symbol):
+                if sym == expr_cond[expr].atoms(Symbol):
+                    sym_interval[sym] = in_set_symbol
+                else:
+                    sym_interval[sym] = (S.Reals)
+            solns = solns_tmp.intersect(sym_interval[symbol])
             result = result + solns
     else:
         lhs, rhs_s = invert_real(f, 0, symbol)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -469,10 +469,10 @@ def solveset_real(f, symbol):
 
     result = EmptySet()
 
-    if f.expand().is_zero:
-        return S.Reals
-    elif not f.has(symbol):
+    if not f.has(symbol):
         return EmptySet()
+    elif f.expand().is_zero:
+        return S.Reals
     elif f.is_Mul and all([_is_finite_with_finite_vars(m) for m in f.args]):
         # if f(x) and g(x) are both finite we can say that the solution of
         # f(x)*g(x) == 0 is same as Union(f(x) == 0, g(x) == 0) is not true in

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -469,10 +469,10 @@ def solveset_real(f, symbol):
 
     result = EmptySet()
 
-    if not f.has(symbol):
-        return EmptySet()
-    elif f.expand().is_zero:
+    if f.expand().is_zero:
         return S.Reals
+    elif not f.has(symbol):
+        return EmptySet()
     elif f.is_Mul and all([_is_finite_with_finite_vars(m) for m in f.args]):
         # if f(x) and g(x) are both finite we can say that the solution of
         # f(x)*g(x) == 0 is same as Union(f(x) == 0, g(x) == 0) is not true in
@@ -495,12 +495,18 @@ def solveset_real(f, symbol):
             solns_tmp = solveset_real(expr, symbol)
             # by default symbol interval. many times cond symbols are expr symbols
             for sym in expr.atoms(Symbol):
-                if sym == expr_cond[expr].atoms(Symbol):
+                if expr_cond[expr] != True:
+                    cond_symbol = expr_cond[expr].atoms(Symbol)
+                if sym == cond_symbol:
                     sym_interval[sym] = in_set_symbol
-                else:
+                elif sym != cond_symbol:
                     sym_interval[sym] = (S.Reals)
-            solns = solns_tmp.intersect(sym_interval[symbol])
-            result = result + solns
+            if not expr.has(Symbol):
+                solns = solns_tmp.intersect(in_set_symbol)
+                result = result + solns
+            else:
+                solns = solns_tmp.intersect(sym_interval[symbol])
+                result = result + solns
     else:
         lhs, rhs_s = invert_real(f, 0, symbol)
         if lhs == symbol:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -628,7 +628,7 @@ def test_piecewise():
     )
     y = Symbol('y', positive=True)
     assert solveset_real(absxm3 - y, x) == FiniteSet(-y + 3, y + 3)
-    assert solveset(f, x, domain=S.Reals) == Union(FiniteSet(2), Interval(-oo, 0, True, True))
+    assert solveset(f, x, domain=S.Reals) == FiniteSet(2)
 
 
 def test_solveset_complex_polynomial():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -628,7 +628,7 @@ def test_piecewise():
     )
     y = Symbol('y', positive=True)
     assert solveset_real(absxm3 - y, x) == FiniteSet(-y + 3, y + 3)
-    assert solveset(f, x, domain=S.Reals) == FiniteSet(2)
+    assert solveset(f, x, domain=S.Reals) == Union(FiniteSet(2), Interval(-oo, 0, True, True))
 
 
 def test_solveset_complex_polynomial():
@@ -1058,6 +1058,8 @@ def test_issue_9953():
     assert linsolve([ ], x) == S.EmptySet
 
 
+def test_issue_10534():
+    assert solveset_real(Piecewise((x, y<0), (x + 1, True)), x) == FiniteSet(-1,0)
 def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
         FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/


### PR DESCRIPTION
Tried to fix : https://github.com/sympy/sympy/issues/10534
Problem was `solveset` was assuming that condition symbol is same as `symbol` for which it is finding solution. so there was problem when condition doesn't contains the solution symbol.
Now is storing the symbols of condition and defining the interval accordingly for all the symbols.
