### PR TITLE
Issue 2708: Don't split integrals that can't be computed

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1068,7 +1068,6 @@ def test_issue_4492():
         ((-2*x**5 + 15*x**3 - 25*x + 25*sqrt(-x**2 + 5)*asin(sqrt(5)*x/5)) /
             (8*sqrt(-x**2 + 5)), True))
 
-@XFAIL
 def test_issue_2708():
     # This test needs to use an integration function that can
     # not be evaluated in closed form.  Update as needed.
@@ -1076,7 +1075,11 @@ def test_issue_2708():
     integral_f = NonElementaryIntegral(f, (z, 2, 3))
     assert Integral(f, (z, 2, 3)).doit() == integral_f
     assert integrate(f + exp(z), (z, 2, 3)) == integral_f - exp(2) + exp(3)
-
+    assert integrate(2*f + exp(z), (z, 2, 3)) == \
+        2*integral_f - exp(2) + exp(3)
+    assert integrate(exp(1.2*n*s*z*(-t + z)/t), (z, 0, x)) == \
+        1.0*NonElementaryIntegral(exp(-1.2*n*s*z)*exp(1.2*n*s*z**2/t),
+                                  (z, 0, x))
 
 def test_issue_8368():
     assert integrate(exp(-s*x)*cosh(x), (x, 0, oo)) == \


### PR DESCRIPTION
Issue #2708 was (partially) fixed in commit 6fe73a1f by evaluating
separately the terms of the antiderivative. That gave rise to another
issue #10445, which was fixed in #10515 by removing the separation.

This PR aims to combine the merits of the two PRs by treating
separately those terms of the antiderivative that contain unevaluated
integral factors and evaluating the rest together in one sum.

Note: The factor 1.0 originates in `polys` via `risch_integrate`.
It could be removed in `integrals` but should probably be
handled in `polys`, as in commit c6981704, for example.
