### PR TITLE
_eval_derivative_wrt #7437b

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1134,23 +1134,14 @@ class Derivative(Expr):
             if unhandled_non_symbol:
                 obj = None
             else:
-                if not is_symbol:
-                    new_v = Dummy('xi_%i' % i)
-                    new_v.dummy_index = hash(v)
-                    expr = expr.xreplace({v: new_v})
-                    old_v = v
-                    v = new_v
-                obj = expr._eval_derivative(v)
-                nderivs += 1
-                if not is_symbol:
+                if is_symbol:
+                    obj = expr._eval_derivative(v)
+                else:
+                    tmp_expr, tmp_v = v._eval_derivative_wrt(expr, 'xi_%i' % i) or (None, None)
+                    obj = tmp_expr._eval_derivative(tmp_v) if tmp_expr is not None else None
                     if obj is not None:
-                        if not old_v.is_Symbol and obj.is_Derivative:
-                            # Derivative evaluated at a point that is not a
-                            # symbol
-                            obj = Subs(obj, v, old_v)
-                        else:
-                            obj = obj.xreplace({v: old_v})
-                    v = old_v
+                        obj = obj.subs(tmp_v, v)
+                nderivs += 1
 
             if obj is None:
                 unhandled_variables.append(v)
@@ -1264,6 +1255,11 @@ class Derivative(Expr):
         # already been attempted and was not computed, either because it
         # couldn't be or evaluate=False originally.
         return self.func(self.expr, *(self.variables + (v, )), evaluate=False)
+
+    def _eval_derivative_wrt(self, expr, new_name):
+        new_self = Dummy(new_name)
+        new_expr = expr.subs(self, new_self)
+        return (new_expr, new_self)
 
     def doit(self, **hints):
         expr = self.expr
@@ -1621,6 +1617,10 @@ class Subs(Expr):
                     self.variables, self.point).doit() for arg,
                     point in zip(self.variables, self.point) ])
 
+    def _eval_derivative_wrt(self, expr, new_name):
+        new_self = Dummy(new_name)
+        new_expr = expr.subs(self, new_self)
+        return (new_expr, new_self)
 
 def diff(f, *symbols, **kwargs):
     """

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -6,7 +6,7 @@ from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
     Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp,
     simplify, together, collect, factorial, apart, combsimp, factor, refine,
     cancel, Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E,
-    exp_polar, expand, diff, O, Heaviside, Si, Max)
+    exp_polar, expand, diff, O, Heaviside, Si, Max, Expr)
 from sympy.core.function import AppliedUndef
 from sympy.core.compatibility import range
 from sympy.physics.secondquant import FockState
@@ -1706,3 +1706,18 @@ def test_issue_7426():
 def test_issue_10161():
     x = symbols('x', real=True)
     assert x*abs(x)*abs(x) == x**3
+
+
+def test_eval_derivative_wrt():
+    class MyClass(Expr):
+        _diff_wrt = True
+
+        def _eval_derivative_wrt(self, expr, new_name):
+            if expr.has(y):
+                return None
+            new_self = Dummy(new_name)
+            new_expr = expr.subs(self, new_self)
+            return (new_expr, new_self)
+
+    assert (x*MyClass()).diff(MyClass()) == x
+    assert (y*MyClass()).diff(MyClass()) == Derivative(y*MyClass(), MyClass())

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -525,7 +525,7 @@ def test_diff_wrt():
     assert f(
         sin(x)).diff(x) == Subs(Derivative(f(x), x), (x,), (sin(x),))*cos(x)
 
-    assert diff(f(g(x)), g(x)) == Subs(Derivative(f(x), x), (x,), (g(x),))
+    assert diff(f(g(x)), g(x)) == Derivative(f(g(x)), g(x))
 
 
 def test_diff_wrt_func_subs():

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -1,4 +1,4 @@
-from sympy.core import S, symbols, Add, Mul
+from sympy.core import S, symbols, Add, Mul, diff, Derivative
 from sympy.functions import transpose, sin, cos, sqrt
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
@@ -13,6 +13,7 @@ B = MatrixSymbol('B', m, l)
 C = MatrixSymbol('C', n, n)
 D = MatrixSymbol('D', n, n)
 E = MatrixSymbol('E', m, n)
+w = MatrixSymbol('w', n, 1)
 
 
 def test_shape():
@@ -242,3 +243,8 @@ def test_Zero_power():
     assert z2**3 == MatPow(z2, 3).doit()
     assert z2**0 == Identity(3)
     raises(ValueError, lambda:MatPow(z2, -1).doit())
+
+
+def test_issue_7421():
+    assert isinstance(diff((D*w)[k,0], w[p,0]), Derivative)
+    assert isinstance(diff(w.T*D*w, w[0,0]), Derivative)


### PR DESCRIPTION
restored PR #7437 (made a few minor changes). This is related to issue #5858. The modification here is that I have added default implementation of `_eval_derivative_wrt`at line 97 of expr.py as suggested by cliffordwolf in one of the comments of the initial PR.
ping @asmeurer .
