### PR TITLE
dsolve() converts floats to integers/rationals #10379

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -656,7 +656,7 @@ def dsolve(eq, func=None, hint="default", simplify=True,
         else:
             # The key 'hint' stores the hint needed to be solved for.
             hint = hints['hint']
-            return _helper_simplify(eq, hint, hints, simplify)
+            return _helper_simplify(eq, hint, hints, simplify, **kwargs)
 
 def _helper_simplify(eq, hint, match, simplify=True, **kwargs):
     r"""
@@ -682,7 +682,7 @@ def _helper_simplify(eq, hint, match, simplify=True, **kwargs):
         free = eq.free_symbols
         cons = lambda s: s.free_symbols.difference(free)
         if isinstance(sols, Expr):
-            return odesimp(sols, func, order, cons(sols), hint)
+            return odesimp(sols, func, order, cons(sols), hint, **kwargs)
         return [odesimp(s, func, order, cons(s), hint) for s in sols]
     else:
         # We still want to integrate (you can disable it separately with the hint)
@@ -1985,7 +1985,7 @@ def checksysodesol(eqs, sols, func=None):
 
 
 @vectorize(0)
-def odesimp(eq, func, order, constants, hint):
+def odesimp(eq, func, order, constants, hint, **kwargs):
     r"""
     Simplifies ODEs, including trying to solve for ``func`` and running
     :py:meth:`~sympy.solvers.ode.constantsimp`.
@@ -2112,8 +2112,9 @@ def odesimp(eq, func, order, constants, hint):
 
     else:
         # The solution is not solved, so try to solve it
+        rational_flag = kwargs.get('rational', True)
         try:
-            eqsol = solve(eq, func, force=True)
+            eqsol = solve(eq, func, force=True, rational=rational_flag)
             if not eqsol:
                 raise NotImplementedError
         except (NotImplementedError, PolynomialError):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -529,6 +529,9 @@ def dsolve(eq, func=None, hint="default", simplify=True,
         - Do ``help(ode.ode_<hintname>)`` to get help more information on a
           specific hint, where ``<hintname>`` is the name of a hint without
           ``_Integral``.
+        - By default floats are converted into rationals. You can use
+          dsolve(eq, f, rational=False) when solving ODEs with floats to force
+          dsolve not to convert floats to rationals.
 
     For system of ordinary differential equations
     =============================================
@@ -2112,6 +2115,7 @@ def odesimp(eq, func, order, constants, hint, **kwargs):
 
     else:
         # The solution is not solved, so try to solve it
+        # Pass the kwargs to solve
         solve_flags = kwargs
         try:
             eqsol = solve(eq, func, force=True, **solve_flags)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2112,9 +2112,9 @@ def odesimp(eq, func, order, constants, hint, **kwargs):
 
     else:
         # The solution is not solved, so try to solve it
-        rational_flag = kwargs.get('rational', True)
+        solve_flags = kwargs
         try:
-            eqsol = solve(eq, func, force=True, rational=rational_flag)
+            eqsol = solve(eq, func, force=True, **solve_flags)
             if not eqsol:
                 raise NotImplementedError
         except (NotImplementedError, PolynomialError):

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2666,3 +2666,9 @@ def test_C1_function_9239():
     sol = [Eq(C1(t), 9*C1*exp(-6*sqrt(3)*t) + 9*C2*exp(6*sqrt(3)*t)), \
     Eq(C2(t), -6*sqrt(3)*C1*exp(-6*sqrt(3)*t) + 6*sqrt(3)*C2*exp(6*sqrt(3)*t))]
     assert dsolve(eq) == sol
+
+def test_issue_10379():
+    t,y = symbols('t,y')
+    ans = Eq(f(t), (0.019588638589618*exp(y*(C1 - 51.05*t)) + 0.019588638589618)/y)
+    sol = dsolve(f(t).diff(t)-(1-51.05*y*f(t)), rational=False)
+    assert str(sol) == str(ans)


### PR DESCRIPTION
I am having problem in adding tests. After the changes are made 
`dsolve(f(t).diff(t)-(1-51.05*y*f(t)), rational=False)` 
gives solution 
`Eq(f(t), (0.019588638589618*exp(y*(C1 - 51.05*t)) + 0.019588638589618)/y)`
But adding 
`eq = f(t).diff(t)-(1-51.05*y*f(t))`
`sol = Eq(f(t), (0.019588638589618*exp(y*(C1 - 51.05*t)) + 0.019588638589618)/y)`
`assert dsolve(eq, rational=False) == sol`  
raises assertion error.
@asmeurer 
