### PR TITLE
Allow to sympify range/xrange objects into Range

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
     Function, I, S, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,
-    Pow, Or, true, false, Abs, pi)
+    Pow, Or, true, false, Abs, pi, Range)
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError, kernS
 from sympy.core.decorators import _sympifyit
@@ -9,7 +9,7 @@ from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2
 from sympy.abc import _clash, _clash1, _clash2
-from sympy.core.compatibility import exec_, HAS_GMPY
+from sympy.core.compatibility import exec_, HAS_GMPY, PY3
 
 import mpmath
 
@@ -492,3 +492,13 @@ def test_issue_8821_highprec_from_str():
     s = str(pi.evalf(128))
     p = sympify(s)
     assert Abs(sin(p)) < 1e-127
+
+def test_Range():
+    # Only works in Python 3 where range returns a range type
+    if PY3:
+        builtin_range = range
+    else:
+        builtin_range = xrange
+
+    assert sympify(builtin_range(10)) == Range(10)
+    assert _sympify(builtin_range(10)) == Range(10)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -3,11 +3,11 @@ from __future__ import print_function, division
 from sympy.logic.boolalg import And
 from sympy.core import oo
 from sympy.core.basic import Basic
-from sympy.core.compatibility import as_int, with_metaclass, range
+from sympy.core.compatibility import as_int, with_metaclass, range, PY3
 from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
                              FiniteSet)
 from sympy.core.singleton import Singleton, S, sympify
-from sympy.core.sympify import _sympify
+from sympy.core.sympify import _sympify, converter
 from sympy.core.function import Lambda
 
 
@@ -322,6 +322,15 @@ class Range(Set):
 
     def __new__(cls, *args):
         from sympy.functions.elementary.integers import ceiling
+        if len(args) == 1:
+            if PY3 and isinstance(args[0], range):
+                # Python 3 range object.
+                args = args[0].start, args[0].stop, args[0].step
+            elif not PY3 and isinstance(args[0], xrange):
+                # Seems the only way to access the args is through the pickle
+                # methods
+                args = args[0].__reduce__()[1]
+
         # expand range
         slc = slice(*args)
         start, stop, step = slc.start or 0, slc.stop, slc.step or 1
@@ -445,6 +454,11 @@ class Range(Set):
     def _boundary(self):
         return self
 
+
+if PY3:
+    converter[range] = Range
+else:
+    converter[xrange] = Range
 
 def normalize_theta_set(theta):
     """

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,4 +1,4 @@
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, PY3
 from sympy.sets.fancysets import (ImageSet, Range, normalize_theta_set,
                                   ComplexRegion)
 from sympy.sets.sets import (FiniteSet, Interval, imageset, EmptySet, Union,
@@ -154,6 +154,17 @@ def test_Range():
 
     assert Range(1, 10, 1).boundary == Range(1, 10, 1)
 
+    # Make sure to use range in Python 3 and xrange in Python 2 (regardless of
+    # compatibility imports above)
+    if PY3:
+        builtin_range = range
+    else:
+        builtin_range = xrange
+
+    assert Range(builtin_range(10)) == Range(10)
+    assert Range(builtin_range(1, 10)) == Range(1, 10)
+    assert Range(builtin_range(1, 10, 2)) == Range(1, 10, 2)
+    assert Range(builtin_range(1000000000000)) == Range(1000000000000)
 
 def test_range_interval_intersection():
     # Intersection with intervals


### PR DESCRIPTION
This also enables Range(range(10)) (in Python 3) and Range(xrange(10)) (in
Python 2).
