### PR TITLE
Solves and Fixes Issue No 10567 | ashutosh.saboo96@gmail.com

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -15,7 +15,7 @@ from sympy.core.sympify import sympify
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
-from sympy.matrices import Matrix, ImmutableMatrix
+from sympy.matrices import MatrixBase
 from sympy.utilities.misc import filldedent
 from sympy.polys import Poly, PolynomialError
 from sympy.functions import Piecewise, sqrt, sign
@@ -397,7 +397,7 @@ class Integral(AddWithLimits):
         if function.is_zero:
             return S.Zero
 
-        if isinstance(function, (Matrix, ImmutableMatrix)):
+        if isinstance(function, MatrixBase):
             return function.applyfunc(lambda f: self.func(f, self.limits).doit(**hints))
 
         # There is no trivial answer, so continue

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -15,7 +15,7 @@ from sympy.core.sympify import sympify
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
-from sympy.utilities import xthreaded
+from sympy.matrices import Matrix, ImmutableMatrix
 from sympy.utilities.misc import filldedent
 from sympy.polys import Poly, PolynomialError
 from sympy.functions import Piecewise, sqrt, sign
@@ -397,6 +397,9 @@ class Integral(AddWithLimits):
         if function.is_zero:
             return S.Zero
 
+        if isinstance(function, (Matrix, ImmutableMatrix)):
+            return function.applyfunc(lambda f: self.func(f, self.limits).doit(**hints))
+
         # There is no trivial answer, so continue
 
         undone_limits = []
@@ -744,7 +747,6 @@ class Integral(AddWithLimits):
 
         # try to convert to poly(x) and then integrate if successful (fast)
         poly = f.as_poly(x)
-
         if poly is not None and not meijerg:
             return poly.integrate().as_expr()
 
@@ -1094,7 +1096,6 @@ class Integral(AddWithLimits):
         return f
 
 
-@xthreaded
 def integrate(*args, **kwargs):
     """integrate(f, var, ...)
 
@@ -1257,7 +1258,6 @@ def integrate(*args, **kwargs):
         return integral
 
 
-@xthreaded
 def line_integrate(field, curve, vars):
     """line_integrate(field, Curve, variables)
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1111,6 +1111,11 @@ def test_issue_7130():
     integrand = (cos(pi*i*x/L)**2 / (a + b*x)).rewrite(exp)
     assert x not in integrate(integrand, (x, 0, L)).free_symbols
 
+def test_issue_10567():
+    a, b, c, t = symbols('a b c t')
+    vt = Matrix([a*t, b, c])
+    assert integrate(vt, t) == Integral(vt, t).doit()
+    assert integrate(vt, t) == Matrix([[a*t**2/2], [b*t], [c*t]])
 
 def test_issue_4950():
     assert integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x) ==\


### PR DESCRIPTION
@jksuom @asmeurer . Here is the code that solves this issue - #10567 .

Support for Matrix inputs has been added into the new code, and the xthreaded decorator which was causing the problem has been fixed. 

Earlier the output was -:

```
>>> a,b,c = symbols('a b c')
>>> t = symbols('t')
>>> vt = Matrix([a*t,b,c])
>>> integrate(vt,t)
Matrix([
[a*t**2/2],
[     b*t],
[     c*t]])
>>> Integral(vt,t).doit()
a*t**4/3 + b*t**2/2 + c*t
```

Now the new output is-:

```
>>> a,b,c = symbols('a b c')
>>> t = symbols('t')
>>> vt = Matrix([a*t,b,c])
>>> integrate(vt,t)
Matrix([
[a*t**2/2],
[     b*t],
[     c*t]])
>>> Integral(vt,t).doit()
Matrix([
[a*t**2/2],
[     b*t],
[     c*t]])
```

Hence, as we see, Integral(vt,t).doit() and integrate(vt,t) give the same output here with the new code. Fixes #10567 .
