### PR TITLE
8571: raise TypeError for expressions with BooleanAtom

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -95,7 +95,6 @@ class BooleanAtom(Boolean):
 
     __add__ = _noop
     __radd__ = _noop
-    __neg__ = _noop
     __sub__ = _noop
     __rsub__ = _noop
     __mul__ = _noop
@@ -107,6 +106,7 @@ class BooleanAtom(Boolean):
     __div__ = _noop
     __rtruediv__ = _noop
     __mod__ = _noop
+    __rmod__ = _noop
     _eval_power = _noop
 
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -84,9 +84,30 @@ class BooleanAtom(Boolean):
     Base class of BooleanTrue and BooleanFalse.
     """
     is_Boolean = True
+    _op_priority = 11  # higher than Expr
+
     @property
     def canonical(self):
         return self
+
+    def _noop(self, other=None):
+        raise TypeError('BooleanAtom not allowed in this context.')
+
+    __add__ = _noop
+    __radd__ = _noop
+    __neg__ = _noop
+    __sub__ = _noop
+    __rsub__ = _noop
+    __mul__ = _noop
+    __rmul__ = _noop
+    __pow__ = _noop
+    __rpow__ = _noop
+    __rdiv__ = _noop
+    __truediv__ = _noop
+    __div__ = _noop
+    __rtruediv__ = _noop
+    __mod__ = _noop
+    _eval_power = _noop
 
 
 class BooleanTrue(with_metaclass(Singleton, BooleanAtom)):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from sympy.assumptions.ask import Q
 from sympy.core.numbers import oo
 from sympy.core.relational import Equality
@@ -725,3 +727,23 @@ def test_truth_table():
     assert list(truth_table(And(x, y), [x, y], input=False)) == [False, False, False, True]
     assert list(truth_table(x | y, [x, y], input=False)) == [False, True, True, True]
     assert list(truth_table(x >> y, [x, y], input=False)) == [True, True, False, True]
+
+
+def test_issue_8571():
+    x = symbols('x')
+    for t in (S.true, S.false):
+        raises(TypeError, lambda: +t)
+        raises(TypeError, lambda: -t)
+        raises(TypeError, lambda: abs(t))
+        # use int(bool(t)) to get 0 or 1
+        raises(TypeError, lambda: int(t))
+
+        for o in [S.Zero, S.One, x]:
+            for _ in range(2):
+                raises(TypeError, lambda: o + t)
+                raises(TypeError, lambda: o - t)
+                raises(TypeError, lambda: o % t)
+                raises(TypeError, lambda: o*t)
+                raises(TypeError, lambda: o/t)
+                raises(TypeError, lambda: o**t)
+                o, t = t, o  # do again in reversed order

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -356,7 +356,10 @@ def _dict_from_expr(expr, opt):
                 and expr.base.is_Add)
 
     if opt.expand is not False:
-        expr = expr.expand()
+        try:
+            expr = expr.expand()
+        except AttributeError:
+            raise PolynomialError('expression must support expand method')
         # TODO: Integrate this into expand() itself
         while any(_is_expandable_pow(i) or i.is_Mul and
             any(_is_expandable_pow(j) for j in i.args) for i in

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -285,3 +285,4 @@ def test_dict_from_expr():
     assert dict_from_expr(Eq(x, 1)) == \
         ({(0,): -Integer(1), (1,): Integer(1)}, (x,))
     raises(PolynomialError, lambda: dict_from_expr(A*B - B*A))
+    raises(PolynomialError, lambda: dict_from_expr(S.true))


### PR DESCRIPTION
closes #8571
closes #8441
closes #10569

The `_op_priority` of BooleanAtom is set to 1 greater than Expr so
its `__r*__` methods get called first and allow a consistent
TypeError to be raised for expressions involving S.true or S.false.
