### PR TITLE
Solves & Fixes Issue No 10488 | Simplest form of Integral Value returned | ashutosh.saboo96@gmail.com

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -15,7 +15,7 @@ from sympy.core.sympify import sympify
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
-from sympy.matrices import Matrix, ImmutableMatrix
+from sympy.matrices import MatrixBase
 from sympy.utilities.misc import filldedent
 from sympy.polys import Poly, PolynomialError
 from sympy.functions import Piecewise, sqrt, sign
@@ -397,7 +397,7 @@ class Integral(AddWithLimits):
         if function.is_zero:
             return S.Zero
 
-        if isinstance(function, (Matrix, ImmutableMatrix)):
+        if isinstance(function, MatrixBase):
             return function.applyfunc(lambda f: self.func(f, self.limits).doit(**hints))
 
         # There is no trivial answer, so continue

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -15,7 +15,7 @@ from sympy.core.sympify import sympify
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
-from sympy.utilities import xthreaded
+from sympy.matrices import Matrix, ImmutableMatrix
 from sympy.utilities.misc import filldedent
 from sympy.polys import Poly, PolynomialError
 from sympy.functions import Piecewise, sqrt, sign
@@ -397,6 +397,9 @@ class Integral(AddWithLimits):
         if function.is_zero:
             return S.Zero
 
+        if isinstance(function, (Matrix, ImmutableMatrix)):
+            return function.applyfunc(lambda f: self.func(f, self.limits).doit(**hints))
+
         # There is no trivial answer, so continue
 
         undone_limits = []
@@ -744,7 +747,6 @@ class Integral(AddWithLimits):
 
         # try to convert to poly(x) and then integrate if successful (fast)
         poly = f.as_poly(x)
-
         if poly is not None and not meijerg:
             return poly.integrate().as_expr()
 
@@ -1094,7 +1096,6 @@ class Integral(AddWithLimits):
         return f
 
 
-@xthreaded
 def integrate(*args, **kwargs):
     """integrate(f, var, ...)
 
@@ -1257,7 +1258,6 @@ def integrate(*args, **kwargs):
         return integral
 
 
-@xthreaded
 def line_integrate(field, curve, vars):
     """line_integrate(field, Curve, variables)
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -15,6 +15,10 @@ from sympy.core.sympify import sympify
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
+from sympy.simplify.simplify import simplify
+from sympy import expand_log
+#from sympy.utilities import xthreaded
+#from sympy.matrices import Matrix, ImmutableMatrix
 from sympy.matrices import MatrixBase
 from sympy.utilities.misc import filldedent
 from sympy.polys import Poly, PolynomialError
@@ -734,6 +738,7 @@ class Integral(AddWithLimits):
         # will return a sympy expression instead of a Polynomial.
         #
         # see Polynomial for details.
+
         if isinstance(f, Poly) and not meijerg:
             return f.integrate(x)
 
@@ -758,9 +763,19 @@ class Integral(AddWithLimits):
             else:
                 if i:
                     # There was a nonelementary integral. Try integrating it.
-                    return result + i.doit(risch=False)
+                    a="ans"
+                    a=str(result + i.doit(risch=False))
+                    if "log" in a:
+                        return expand_log(simplify(result + i.doit(risch=False)))
+                    else:
+                        return simplify(result + i.doit(risch=False))
                 else:
-                    return result
+                    a="ans"
+                    a=str(result)
+                    if "log" in a:
+                        return expand_log(simplify(result))
+                    else:
+                        return simplify(result)
 
         # since Integral(f=g1+g2+...) == Integral(g1) + Integral(g2) + ...
         # we are going to handle Add terms separately,
@@ -1096,6 +1111,7 @@ class Integral(AddWithLimits):
         return f
 
 
+#@xthreaded
 def integrate(*args, **kwargs):
     """integrate(f, var, ...)
 
@@ -1258,6 +1274,7 @@ def integrate(*args, **kwargs):
         return integral
 
 
+#@xthreaded
 def line_integrate(field, curve, vars):
     """line_integrate(field, Curve, variables)
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1111,6 +1111,11 @@ def test_issue_7130():
     integrand = (cos(pi*i*x/L)**2 / (a + b*x)).rewrite(exp)
     assert x not in integrate(integrand, (x, 0, L)).free_symbols
 
+def test_issue_10567():
+    a, b, c, t = symbols('a b c t')
+    vt = Matrix([a*t, b, c])
+    assert integrate(vt, t) == Integral(vt, t).doit()
+    assert integrate(vt, t) == Matrix([[a*t**2/2], [b*t], [c*t]])
 
 def test_issue_4950():
     assert integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x) ==\


### PR DESCRIPTION
Hello!

I have been working on this issue - #10488 since a pretty long time. This pull request fixes #10488 .

```
import sympy
x, a, b  = sympy.symbols('x,a,b')
print(sympy.integrate(x/(a*x+b), x))
```

Earlier this code gave output-:

`x/a - b*log(a**2*x + a*b)/a**2
`
Now, the new output given is-:

`(a*x - b*(log(a) + log(a*x + b)))/a**2`

Hence, as we see now it gives the simplest possible output, so that the user can easily identify the constant, and hence it fixes this issue.

@asmeurer @jksuom Are there any other changes in the code, that you would recommend? Or is it ready to be merged now?

Thank you! :smile: 
