### PR TITLE
Solves & Fixes Issue No 10488 | Redundant constant term removed from Integral Value

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -8,7 +8,7 @@ from sympy import S, Symbol, symbols, I, log, atan, \
 from sympy.polys import Poly, resultant, ZZ
 from sympy.polys.polytools import count_roots
 from sympy.core.compatibility import range
-
+from sympy import primitive
 
 def ratint(f, x, **flags):
     """Performs indefinite integration of rational functions.
@@ -92,17 +92,19 @@ def ratint(f, x, **flags):
 
         if not real:
             for h, q in L:
+                h=h.primitive()
                 eps += RootSum(
-                    q, Lambda(t, t*log(h.as_expr())), quadratic=True)
+                    q, Lambda(t, t*log(h[1].as_expr())), quadratic=True)
         else:
             for h, q in L:
-                R = log_to_real(h, q, x, t)
+                h=h.primitive()
+                R = log_to_real(h[1], q, x, t)
 
                 if R is not None:
                     eps += R
                 else:
                     eps += RootSum(
-                        q, Lambda(t, t*log(h.as_expr())), quadratic=True)
+                        q, Lambda(t, t*log(h[1].as_expr())), quadratic=True)
 
         result += eps
 

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -8,7 +8,6 @@ from sympy import S, Symbol, symbols, I, log, atan, \
 from sympy.polys import Poly, resultant, ZZ
 from sympy.polys.polytools import count_roots
 from sympy.core.compatibility import range
-from sympy import primitive
 
 def ratint(f, x, **flags):
     """Performs indefinite integration of rational functions.
@@ -92,19 +91,19 @@ def ratint(f, x, **flags):
 
         if not real:
             for h, q in L:
-                h=h.primitive()
+                _, h=h.primitive()
                 eps += RootSum(
-                    q, Lambda(t, t*log(h[1].as_expr())), quadratic=True)
+                    q, Lambda(t, t*log(h.as_expr())), quadratic=True)
         else:
             for h, q in L:
-                h=h.primitive()
-                R = log_to_real(h[1], q, x, t)
+                _, h=h.primitive()
+                R = log_to_real(h, q, x, t)
 
                 if R is not None:
                     eps += R
                 else:
                     eps += RootSum(
-                        q, Lambda(t, t*log(h[1].as_expr())), quadratic=True)
+                        q, Lambda(t, t*log(h.as_expr())), quadratic=True)
 
         result += eps
 

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -91,12 +91,12 @@ def ratint(f, x, **flags):
 
         if not real:
             for h, q in L:
-                _, h=h.primitive()
+                _, h = h.primitive()
                 eps += RootSum(
                     q, Lambda(t, t*log(h.as_expr())), quadratic=True)
         else:
             for h, q in L:
-                _, h=h.primitive()
+                _, h = h.primitive()
                 R = log_to_real(h, q, x, t)
 
                 if R is not None:

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -129,6 +129,9 @@ def test_issue_5981():
     u = symbols('u')
     assert integrate(1/(u**2 + 1)) == atan(u)
 
+def test_issue_10488():
+    a,b,c,x = symbols('a b c x', real=True, positive=True)
+    assert integrate(x/(a*x+b),x) == x/a - b*log(a*x + b)/a**2
 
 def test_log_to_atan():
     f, g = (Poly(x + S(1)/2, x, domain='QQ'), Poly(sqrt(3)/2, x, domain='EX'))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2391,7 +2391,7 @@ def test_heuristic1():
     i4 = infinitesimals(eq4, hint='abaco1_simple')
     assert i4 == [{eta(x, f(x)): 1, xi(x, f(x)): 0},
         {eta(x, f(x)): 0,
-        xi(x, f(x)): sqrt(2*a0 + 2*a1*x + 2*a2*x**2 + 2*a3*x**3 + 2*a4*x**4)}]
+        xi(x, f(x)): sqrt(a0 + a1*x + a2*x**2 + a3*x**3 + a4*x**4)}]
     i5 = infinitesimals(eq5, hint='abaco1_simple')
     assert i5 == [{xi(x, f(x)): 0, eta(x, f(x)): exp(-1/x)}]
 


### PR DESCRIPTION
Hello.

Fixes and Solves #10488 . Support for h.primitive() added, to remove the redundant terms from the integral value. 

This issue is based on the output of this code-:

```
import sympy
x, a, b  = sympy.symbols('x,a,b')
print(sympy.integrate(x/(a*x+b), x))
```

Previously, this gave an output as-:

`x/a - b*log(a**2*x + a*b)/a**2`

Now, after the new code, this is the new output-:

`x/a - b*log(a*x + b)/a**2`

Hence, as can be observed, the redundant term of b*log(a) is removed, and hence this fixes #10488 .

@asmeurer @jksuom @rtrwalker
