### PR TITLE
10571: autowrap's args parameter now allows all ordered iterables

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -77,7 +77,7 @@ from subprocess import STDOUT, CalledProcessError
 from string import Template
 
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import check_output, range
+from sympy.core.compatibility import check_output, range, iterable
 from sympy.core.function import Lambda
 from sympy.core.relational import Eq
 from sympy.core.symbol import Dummy, Symbol
@@ -472,7 +472,8 @@ def autowrap(
         the generated code and the wrapper input files are left intact in the
         specified path.
     args : iterable, optional
-        An iterable of symbols. Specifies the argument sequence for the function.
+        An ordered iterable of symbols. Specifies the argument sequence for the
+        function.
     flags : iterable, optional
         Additional option flags that will be passed to the backend.
     verbose : bool, optional
@@ -493,7 +494,6 @@ def autowrap(
     >>> binary_func(1, 4, 2)
     -1.0
     """
-
     if language:
         _validate_backend_language(backend, language)
     else:
@@ -501,6 +501,7 @@ def autowrap(
 
     helpers = [helpers] if helpers else ()
     flags = flags if flags else ()
+    args = list(args) if iterable(args, exclude=set) else args
 
     code_generator = get_code_generator(language, "autowrap")
     CodeWrapperClass = _get_code_wrapper_class(backend)

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -117,6 +117,11 @@ def test_autowrap_args():
     assert f.args == "y, x, z"
     assert f.returns == "z"
 
+    f = autowrap(Eq(z, x + y + z), backend='dummy', args=(y, x, z))
+    assert f() == str(x + y + z)
+    assert f.args == "y, x, z"
+    assert f.returns == "z"
+
 
 def test_autowrap_store_files():
     x, y = symbols('x y')


### PR DESCRIPTION
This pull request replaces #10577 , I didn't manage my fork's branches properly that time.

This is to fix #10571. I also added a unit test, and changed the docstring of autowrap to reflect that the iterable should be ordered, since order matters in this case. Any thoughts/suggestions?
