### PR TITLE
Resolves Issue No 10134 | "raise StopIteration" Removed

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1306,14 +1306,14 @@ class PermutationGroup(Basic):
                     yield x._array_form
                 else:
                     yield x
-            raise StopIteration
+            return
         if len(u) == 1:
             for i in basic_orbits[0]:
                 if af:
                     yield u[0][i]._array_form
                 else:
                     yield u[0][i]
-            raise StopIteration
+            return
 
         u = list(reversed(u))
         basic_orbits = basic_orbits[::-1]
@@ -1327,7 +1327,7 @@ class PermutationGroup(Basic):
             # backtrack when finished iterating over coset
             if pos[h] >= posmax[h]:
                 if h == 0:
-                    raise StopIteration
+                    return
                 pos[h] = 0
                 h -= 1
                 stg.pop()

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2602,7 +2602,7 @@ class Expr(Basic, EvalfMixin):
                 yield series.removeO()
             else:
                 yield series
-            raise StopIteration
+            return
 
         while series.is_Order:
             n += 1


### PR DESCRIPTION
Hi. 

This resolves and fixes issue #10134 . 

There are many places in the SymPy code-base, where `raise StopIteration` or simply `StopIteration` can be found, but there are many places, where it's used internally, and hence it doesn't cause any issue, giving no need to replace them. - @jksuom 

I looked into all the files having `StopIteration` and wherever `StopIteration` was used independently, I have replaced it with `return` so that, the problem of deprecation of `StopIteration` doesn't exist. 

Fixes #10134 . 

Thank you! :smile: @jksuom @asmeurer 
