### PR TITLE
alphabetically referenced modules of parsing.rst (issue #10456)

### DIFF
--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -4,11 +4,23 @@ Parsing input
 Parsing Functions Reference
 ---------------------------
 
+.. autofunction:: sympy.parsing.mathematica.mathematica
+
+.. autofunction:: sympy.parsing.maxima.parse_maxima
+
+.. autofunction:: sympy.parsing.sympy_parser.eval_expr
+
 .. autofunction:: sympy.parsing.sympy_parser.parse_expr
 
 .. autofunction:: sympy.parsing.sympy_parser.stringify_expr
 
-.. autofunction:: sympy.parsing.sympy_parser.eval_expr
+.. autofunction:: sympy.parsing.sympy_tokenize.any
+
+.. autofunction:: sympy.parsing.sympy_tokenize.generate_tokens
+
+.. autofunction:: sympy.parsing.sympy_tokenize.group
+
+.. autofunction:: sympy.parsing.sympy_tokenize.maybe
 
 .. autofunction:: sympy.parsing.sympy_tokenize.printtoken
 
@@ -16,17 +28,6 @@ Parsing Functions Reference
 
 .. autofunction:: sympy.parsing.sympy_tokenize.untokenize
 
-.. autofunction:: sympy.parsing.sympy_tokenize.generate_tokens
-
-.. autofunction:: sympy.parsing.sympy_tokenize.group
-
-.. autofunction:: sympy.parsing.sympy_tokenize.any
-
-.. autofunction:: sympy.parsing.sympy_tokenize.maybe
-
-.. autofunction:: sympy.parsing.maxima.parse_maxima
-
-.. autofunction:: sympy.parsing.mathematica.mathematica
 
 Parsing Exceptions Reference
 ----------------------------
@@ -43,30 +44,31 @@ local_dict, global_dict`` and returns a list of transformed tokens. They can
 be used by passing a list of functions to :py:func:`parse_expr` and are
 applied in the order given.
 
-.. autodata:: sympy.parsing.sympy_parser.standard_transformations
+.. autofunction:: sympy.parsing.sympy_parser.convert_xor
+
+.. autofunction:: sympy.parsing.sympy_parser.function_exponentiation
+
+.. autofunction:: sympy.parsing.sympy_parser.implicit_application
+
+.. autofunction:: sympy.parsing.sympy_parser.implicit_multiplication
+
+.. autofunction:: sympy.parsing.sympy_parser.implicit_multiplication_application
 
 .. autofunction:: sympy.parsing.sympy_parser.split_symbols
 
 .. autofunction:: sympy.parsing.sympy_parser.split_symbols_custom
 
-.. autofunction:: sympy.parsing.sympy_parser.implicit_multiplication
-
-.. autofunction:: sympy.parsing.sympy_parser.implicit_application
-
-.. autofunction:: sympy.parsing.sympy_parser.function_exponentiation
-
-.. autofunction:: sympy.parsing.sympy_parser.implicit_multiplication_application
+.. autodata:: sympy.parsing.sympy_parser.standard_transformations
 
 .. autofunction:: sympy.parsing.sympy_parser.rationalize
 
-.. autofunction:: sympy.parsing.sympy_parser.convert_xor
 
 These are included in
 :data:``sympy.parsing.sympy_parser.standard_transformations`` and generally
 don't need to be manually added by the user.
 
-.. autofunction:: sympy.parsing.sympy_parser.factorial_notation
+.. autofunction:: sympy.parsing.sympy_parser.auto_number
 
 .. autofunction:: sympy.parsing.sympy_parser.auto_symbol
 
-.. autofunction:: sympy.parsing.sympy_parser.auto_number
+.. autofunction:: sympy.parsing.sympy_parser.factorial_notation


### PR DESCRIPTION
I Have alphabetically referenced modules of parsing.rst . If this is correct i would like to work on other modules. @moorepants  can I know whether this  is what you meant by alphabetical ordering? 
