### PR TITLE
dsolve() converts floats to integers/rationals #10379

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2113,7 +2113,8 @@ def odesimp(eq, func, order, constants, hint):
     else:
         # The solution is not solved, so try to solve it
         try:
-            eqsol = solve(eq, func, force=True)
+            floats = any(i.is_Float for i in eq.atoms(Number))
+            eqsol = solve(eq, func, force=True, rational=False if floats else None)
             if not eqsol:
                 raise NotImplementedError
         except (NotImplementedError, PolynomialError):

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2670,5 +2670,5 @@ def test_C1_function_9239():
 def test_issue_10379():
     t,y = symbols('t,y')
     sol =  dsolve(f(t).diff(t)-(1-51.05*y*f(t)), rational=False)
-    ans =  Eq(f(t), (0.019588638589618*exp(y*(C1 - 51.05*t)) + 0.019588638589618)/y) 
+    ans =  Eq(f(t), (0.019588638589618*exp(y*(C1 - 51.05*t)) + 0.019588638589618)/y)
     assert str(sol) == str(ans)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2666,3 +2666,9 @@ def test_C1_function_9239():
     sol = [Eq(C1(t), 9*C1*exp(-6*sqrt(3)*t) + 9*C2*exp(6*sqrt(3)*t)), \
     Eq(C2(t), -6*sqrt(3)*C1*exp(-6*sqrt(3)*t) + 6*sqrt(3)*C2*exp(6*sqrt(3)*t))]
     assert dsolve(eq) == sol
+
+def test_issue_10379():
+    t,y = symbols('t,y')
+    sol =  dsolve(f(t).diff(t)-(1-51.05*y*f(t)), rational=False)
+    ans =  Eq(f(t), (0.019588638589618*exp(y*(C1 - 51.05*t)) + 0.019588638589618)/y) 
+    assert str(sol) == str(ans)


### PR DESCRIPTION
If the equation has floats then forcing `solve` not to convert floats to rationals. Fixes #10379 
