### PR TITLE
fix in assumtions - addition of infinite terms

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -446,15 +446,23 @@ class Add(Expr, AssocOp):
     def _eval_is_algebraic_expr(self, syms):
         return all(term._eval_is_algebraic_expr(syms) for term in self.args)
 
+    def _eval_is_real(self):
+        for a in self.args:
+            if a.is_infinite:
+                return None
+        return _fuzzy_group((a.is_real for a in self.args), quick_exit=True)
+
+    def _eval_is_complex(self):
+        for a in self.args:
+            if a.is_infinite:
+                return None
+        return  _fuzzy_group((a.is_complex for a in self.args), quick_exit=True)
+
     # assumption methods
-    _eval_is_real = lambda self: _fuzzy_group(
-        (a.is_real for a in self.args), quick_exit=True)
-    _eval_is_complex = lambda self: _fuzzy_group(
-        (a.is_complex for a in self.args), quick_exit=True)
     _eval_is_antihermitian = lambda self: _fuzzy_group(
         (a.is_antihermitian for a in self.args), quick_exit=True)
     _eval_is_finite = lambda self: _fuzzy_group(
-        (a.is_finite for a in self.args), quick_exit=True)
+        (a.is_finite for a in self.args), quick_exit=False)
     _eval_is_hermitian = lambda self: _fuzzy_group(
         (a.is_hermitian for a in self.args), quick_exit=True)
     _eval_is_integer = lambda self: _fuzzy_group(

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -713,6 +713,36 @@ def test_Add_is_algebraic():
     assert (na + x).is_algebraic is None
 
 
+def test_Add_is_complex():
+    r  = Symbol('r', infinite=True, real=True)
+    p = Symbol('p', infinite=True, positive=True)
+    n = Symbol('n', infinite=True, negative=True)
+    i = Symbol('i', infinite=True, imaginary=True)
+    z = Symbol('z', infinite=True, imaginary=False, real=False, complex=True)
+    assert (p + r).is_complex is None
+    assert (n + r).is_complex is None
+    assert (z + r).is_complex is None
+    assert (z + p).is_complex is None
+    assert (z + n).is_complex is None
+    assert (z + i).is_complex is None
+    assert (p + r).is_real is None
+    assert (n + r).is_real is None
+    assert (r + 1).is_complex is None
+    assert (p + r).is_real is None
+    # infinite/finite not mentioned
+    x = Symbol('x', real=True)
+    y = Symbol('y', positive=True)
+    assert (x+y).is_real
+    assert (x+y).is_complex
+
+
+def test_Add_is_finite():
+    p = Symbol('p', infinite=True, positive=True)
+    nn = Symbol('nn', nonnegative=True, infinite=True)
+    assert (p + nn).is_finite is False
+    assert (p + 1).is_finite is False
+
+
 def test_Mul_is_algebraic():
     a = Symbol('a', algebraic=True)
     b = Symbol('a', algebraic=True)


### PR DESCRIPTION
Addresses issues from #8046 
Fixes issues 9-16 from the list

If any one term in Addition is infinite, then is_real/is_complex returns None
If `is_infinite/is_finite` is `None`, then `is_real/is_complex` property of Add depends on `is_real/is_complex` property of each term
