### PR TITLE
10395: watch for non-Add/Mul AssocOp during evalf

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1281,19 +1281,20 @@ def evalf(x, prec, options):
             # Fall back to ordinary evalf if possible
             if 'subs' in options:
                 x = x.subs(evalf_subs(prec, options['subs']))
-            re, im = x._eval_evalf(prec).as_real_imag()
+            xe = x._eval_evalf(prec)
+            re, im = xe.as_real_imag()
             if re.has(re_) or im.has(im_):
                 raise NotImplementedError
             if re == 0:
                 re = None
                 reprec = None
-            else:
+            elif re.is_number:
                 re = re._to_mpmath(prec, allow_ints=False)._mpf_
                 reprec = prec
             if im == 0:
                 im = None
                 imprec = None
-            else:
+            elif im.is_number:
                 im = im._to_mpmath(prec, allow_ints=False)._mpf_
                 imprec = prec
             r = re, im, reprec, imprec

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -292,6 +292,10 @@ class AssocOp(Basic):
             return False
         return is_in
 
+    def evalf(self, prec=None, **options):
+        return self.func(*[a.evalf(prec, options) for a in self.args])
+    n = evalf
+
     def _eval_evalf(self, prec):
         """
         Evaluate the parts of self that are numbers; if the whole thing

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -292,10 +292,6 @@ class AssocOp(Basic):
             return False
         return is_in
 
-    def evalf(self, prec=None, **options):
-        return self.func(*[a.evalf(prec, options) for a in self.args])
-    n = evalf
-
     def _eval_evalf(self, prec):
         """
         Evaluate the parts of self that are numbers; if the whole thing

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,7 +1,7 @@
-from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp, factorial,
-                   fibonacci, floor, Function, GoldenRatio, I, Integral,
-                   integrate, log, Mul, N, oo, pi, Pow, product, Product,
-                   Rational, S, Sum, sin, sqrt, sstr, sympify, Symbol)
+from sympy import (Abs, Add, atan, ceiling, cos, E, Eq, exp,
+    factorial, fibonacci, floor, Function, GoldenRatio, I, Integral,
+    integrate, log, Mul, N, oo, pi, Pow, product, Product,
+    Rational, S, Sum, sin, sqrt, sstr, sympify, Symbol, Max, nfloat)
 from sympy.core.evalf import (complex_accuracy, PrecisionExhausted,
     scaled_zero, get_integer_part, as_mpmath)
 from mpmath import inf, ninf
@@ -495,3 +495,11 @@ def test_AssocOp_Function():
     # should raise a value error because the first arg computes
     # a non-comparable (prec=1) imaginary part
     raises(ValueError, lambda: e._eval_evalf(2))
+
+
+def test_issue_10395():
+    eq = x*Max(0, y)
+    assert nfloat(eq) == eq
+    eq = x*Max(y, -1.1)
+    assert nfloat(eq) == eq
+    assert Max(y, 4).n() == Max(4.0, y)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -5,6 +5,7 @@ from sympy.core.numbers import oo
 from sympy.core.relational import Equality
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.sets.sets import (EmptySet, Interval, Union)
 from sympy.simplify.simplify import simplify
 from sympy.logic.boolalg import (
@@ -747,3 +748,9 @@ def test_issue_8571():
                 raises(TypeError, lambda: o/t)
                 raises(TypeError, lambda: o**t)
                 o, t = t, o  # do again in reversed order
+
+
+def test_issue_10641():
+    x = symbols('x')
+    assert str(Or(x < sqrt(3), x).n(2)) == 'Or(x, x < 1.7)'
+    assert str(And(x < sqrt(3), x).n(2)) == 'And(x, x < 1.7)'

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -5,7 +5,6 @@ from sympy.core.numbers import oo
 from sympy.core.relational import Equality
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
-from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.sets.sets import (EmptySet, Interval, Union)
 from sympy.simplify.simplify import simplify
 from sympy.logic.boolalg import (
@@ -748,9 +747,3 @@ def test_issue_8571():
                 raises(TypeError, lambda: o/t)
                 raises(TypeError, lambda: o**t)
                 o, t = t, o  # do again in reversed order
-
-
-def test_issue_10641():
-    x = symbols('x')
-    assert str(Or(x < sqrt(3), x).n(2)) == 'Or(x, x < 1.7)'
-    assert str(And(x < sqrt(3), x).n(2)) == 'And(x, x < 1.7)'


### PR DESCRIPTION
Also, don't try to evalf re and im parts unless they are
numbers.  The added tests test this.

Fixes #10395
Fixes #10641
