### PR TITLE
Accelerated callbacks for integration routines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -297,7 +297,7 @@ before_install:
         conda config --set always_yes yes --set changeps1 no;
         conda update -q conda;
         conda info -a;
-        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION matplotlib numpy scipy pip;
+        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION matplotlib numpy scipy pip llvmlite;
         source activate test-environment;
     fi
 
@@ -323,7 +323,6 @@ install:
       pip uninstall -y sympy;
       pip install setuptools;
       python setup.py install;
-      conda install llvmlite;
     elif [[ "${TEST_SAGE}" != "true" ]]; then
       python setup.py install;
     fi

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -369,8 +369,7 @@ def llvm_callable(args, expr, callback_type=None):
         signature.input_arg = 1
         signature.ret_arg = 4
     else:
-        print("Unknown callback type: %s" % callback_type)
-        return None
+        raise ValueError("Unknown callback type: %s" % callback_type)
 
     signature.arg_ctypes = arg_ctypes
 

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -50,15 +50,21 @@ class LLVMJitPrinter(Printer):
         if expr.exp == S.NegativeOne:
             return self.builder.fdiv(ll.Constant(self.fp_type, 1.0), base0)
         if expr.exp == S.Half:
-            fn_type = ll.FunctionType(self.fp_type, [self.fp_type])
-            fn = ll.Function(self.module, fn_type, "sqrt")
+            fn = self.ext_fn.get("sqrt")
+            if not fn:
+                fn_type = ll.FunctionType(self.fp_type, [self.fp_type])
+                fn = ll.Function(self.module, fn_type, "sqrt")
+                self.ext_fn["sqrt"] = fn
             return self.builder.call(fn, [base0], "sqrt")
         if expr.exp == 2:
             return self.builder.fmul(base0, base0)
 
         exp0 = self._print(expr.exp)
-        fn_type = ll.FunctionType(self.fp_type, [self.fp_type, self.fp_type])
-        fn = ll.Function(self.module, fn_type, "pow")
+        fn = self.ext_fn.get("pow")
+        if not fn:
+            fn_type = ll.FunctionType(self.fp_type, [self.fp_type, self.fp_type])
+            fn = ll.Function(self.module, fn_type, "pow")
+            self.ext_fn["pow"] = fn
         return self.builder.call(fn, [base0, exp0], "pow")
 
     def _print_Mul(self, expr):

--- a/sympy/printing/tests/test_llvmjit.py
+++ b/sympy/printing/tests/test_llvmjit.py
@@ -1,5 +1,6 @@
 
 from sympy.external import import_module
+import ctypes
 
 
 if import_module('llvmlite'):
@@ -8,7 +9,7 @@ else:
     disabled = True
 
 import sympy
-from sympy.abc import a, b
+from sympy.abc import a, b, n
 
 
 # copied from numpy.isclose documentation
@@ -44,10 +45,71 @@ def test_func():
 
     assert isclose(jit_res, res)
 
+
 def test_two_func():
     e = 4.0*sympy.exp(-a) + sympy.exp(b)
-    f = g.llvm_callable([a,b], e)
-    res = float(e.subs({a: 1.5, b:2.0}).evalf())
+    f = g.llvm_callable([a, b], e)
+    res = float(e.subs({a: 1.5, b: 2.0}).evalf())
     jit_res = f(1.5, 2.0)
+
+    assert isclose(jit_res, res)
+
+
+def test_callback():
+    e = a + 1.2
+    f = g.llvm_callable([a], e, callback_type='scipy.integrate.test')
+    m = ctypes.c_int(1)
+    array_type = ctypes.c_double * 1
+    inp = {a: 2.2}
+    array = array_type(inp[a])
+    jit_res = f(m, array)
+
+    res = float(e.subs(inp).evalf())
+
+    assert isclose(jit_res, res)
+
+
+def test_callback_cubature():
+    e = a + 1.2
+    f = g.llvm_callable([a], e, callback_type='cubature')
+    m = ctypes.c_int(1)
+    array_type = ctypes.c_double * 1
+    inp = {a: 2.2}
+    array = array_type(inp[a])
+    out_array = array_type(0.0)
+    jit_ret = f(m, array, None, m, out_array)
+
+    assert jit_ret == 0
+
+    res = float(e.subs(inp).evalf())
+
+    assert isclose(out_array[0], res)
+
+
+def test_callback_two():
+    e = 3*a*b
+    f = g.llvm_callable([a, b], e, callback_type='scipy.integrate.test')
+    m = ctypes.c_int(2)
+    array_type = ctypes.c_double * 2
+    inp = {a: 0.2, b: 1.7}
+    array = array_type(inp[a], inp[b])
+    jit_res = f(m, array)
+
+    res = float(e.subs(inp).evalf())
+
+    assert isclose(jit_res, res)
+
+
+def test_callback_alt_two():
+    d = sympy.IndexedBase('d')
+    e = 3*d[0]*d[1]
+    f = g.llvm_callable([n, d], e, callback_type='scipy.integrate.test')
+    m = ctypes.c_int(2)
+    array_type = ctypes.c_double * 2
+    inp = {d[0]: 0.2, d[1]: 1.7}
+    array = array_type(inp[d[0]], inp[d[1]])
+    jit_res = f(m, array)
+
+    res = float(e.subs(inp).evalf())
 
     assert isclose(jit_res, res)

--- a/sympy/printing/tests/test_llvmjit.py
+++ b/sympy/printing/tests/test_llvmjit.py
@@ -55,6 +55,24 @@ def test_two_func():
     assert isclose(jit_res, res)
 
 
+def test_two_sqrt():
+    e = 4.0*sympy.sqrt(a) + sympy.sqrt(b)
+    f = g.llvm_callable([a, b], e)
+    res = float(e.subs({a: 1.5, b: 2.0}).evalf())
+    jit_res = f(1.5, 2.0)
+
+    assert isclose(jit_res, res)
+
+
+def test_two_pow():
+    e = a**1.5 + b**7
+    f = g.llvm_callable([a, b], e)
+    res = float(e.subs({a: 1.5, b: 2.0}).evalf())
+    jit_res = f(1.5, 2.0)
+
+    assert isclose(jit_res, res)
+
+
 def test_callback():
     e = a + 1.2
     f = g.llvm_callable([a], e, callback_type='scipy.integrate.test')

--- a/sympy/printing/tests/test_llvmjit.py
+++ b/sympy/printing/tests/test_llvmjit.py
@@ -131,3 +131,13 @@ def test_callback_alt_two():
     res = float(e.subs(inp).evalf())
 
     assert isclose(jit_res, res)
+
+
+def test_bad_callback():
+    e = a
+    try:
+        g.llvm_callable([a], e, callback_type='bad_callback')
+    except ValueError:
+        pass
+    else:
+        assert False, "Should raise exception with unknown callback"


### PR DESCRIPTION
This builds on #10451 

scipy.integrate routines accept compiled callbacks. This compiles Sympy expressions to a function with the appropriate signature.

The signature check on scipy.integrate unfortunately does not quite match the actual function (requires c_double rather than pointer to c_double).  So two versions of the ctypes wrapper can be generated - one that passes the signature check ('scipy.integrate'), and one that matches the actual function, which is necessary for direct calls to the function for testing ('scipy.integrate.test')

One limiting performance factor with `nquad` for multiple dimensional integration is that it calls back through python for each dimension (since it makes iterated calls to the 1-D quad routine).  Other integration packages may be better.  The `cubature` library has a python wrapper: https://github.com/saullocastro/cubature

Should this functionality be better integrated into autowrap (so other backends can provide it too)?

Some timing results with a 3-D integrand:

nquad w/python callback, time = 0.122 s
nquad w/jit callback, time = 0.048 s, speedup = 2.55
cubature w/python callback, time = 0.864 s
cubature w/jit callback, time = 0.005 s, speedup = 166.11

**Example Code**

``` python
from __future__ import print_function

import sympy.printing.llvmjitcode as jit
from sympy import exp
from sympy.abc import x,y,z
from scipy.integrate import nquad
import math
from cubature import cubature
from timeit import timeit


# Sympy expression
e = exp(-2.0*(x*x + y*y + z*z))

# Python version (for nquad)
def f(x,y,z):
    return math.exp(-2.0*(x*x + y*y + z*z))

# Python version (for cubature)
def cf(array):
    x = array[0]
    y = array[1]
    z = array[2]
    return math.exp(-2.0*(x*x + y*y + z*z))

ndim = 3
lim = [0.0, 10.0]
lims = [lim]*ndim
lim_min = [lim[0]]*ndim
lim_max = [lim[1]]*ndim

# Scipy.integrate.nquad

# Python callback
def run_nquad():
    nquad(f, lims)
nquad_time = timeit(stmt=run_nquad, number=1)
print('nquad w/python callback, time = %.3f s'%nquad_time)

# JIT compiled callback
e_scipy = jit.llvm_callable([x,y,z], e, callback_type='scipy.integrate')
def run_nquad_jit():
    nquad(e_scipy, lims)
nquad_time_jit = timeit(stmt=run_nquad_jit, number=1)
print('nquad w/jit callback, time = %.3f s, speedup = %.2f'%(nquad_time_jit,nquad_time/nquad_time_jit))


# Cubature

# Python callback
def run_cubature():
    cubature(cf, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max)
cubature_time = timeit(stmt=run_cubature, number=1)
print('cubature w/python callback, time = %.3f s'%cubature_time)


# JIT compiled callback
e_cub = jit.llvm_callable([x,y,z], e, callback_type='cubature')
def run_cubature_jit():
    cubature(e_cub, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max)
cubature_time_jit = timeit(stmt=run_cubature_jit, number=1)
print('cubature w/jit callback, time = %.3f s, speedup = %.2f'%(cubature_time_jit,cubature_time/cubature_time_jit))
```
