### PR TITLE
10401: evaluate Eq/Ne when the lhs - rhs evaluates

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -836,7 +836,7 @@ def test_issue_2787():
     s = Sum(binomial_dist*k, (k, 0, n))
     res = s.doit().simplify()
     assert res == Piecewise(
-        (n*p, And(Or(-n + 1 < 0, Ne(p/(p - 1), 1)), p/Abs(p - 1) <= 1)),
+        (n*p, p/Abs(p - 1) <= 1),
         (Sum(k*p**k*(-p + 1)**(-k)*(-p + 1)**n*binomial(n, k), (k, 0, n)),
         True))
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -489,6 +489,10 @@ class Add(Expr, AssocOp):
             return False
 
     def _eval_is_zero(self):
+        if self.is_commutative is False:
+            # issue 10528: there is no way to know if a nc symbol
+            # is zero or not
+            return
         nz = []
         z = 0
         im_or_z = False

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -86,13 +86,13 @@ Here follows a list of possible assumption names:
 
     finite
     infinite
-        object absolute value is bounded (is value is
-        arbitrarily large).  See [7]_, [8]_, [9]_.
+        object absolute value is bounded (arbitrarily large).
+        See [7]_, [8]_, [9]_.
 
     negative
     nonnegative
-        object can have only negative (only
-        nonnegative) values [1]_.
+        object can have only negative (nonnegative)
+        values [1]_.
 
     positive
     nonpositive

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -316,9 +316,12 @@ class Equality(Relational):
             # see if the difference evaluates
             if all(isinstance(i, Expr) for i in (lhs, rhs)):
                 dif = lhs - rhs
-                r = dif.is_zero
-                if r is not None:
-                    return _sympify(r)
+                z = dif.is_zero
+                if z is not None:
+                    if z is False and dif.is_commutative:  # issue 10728
+                        return S.false
+                    if z:
+                        return S.true
                 n, d = dif.as_numer_denom()
                 fin = [i.is_finite for i in (n, d)]
                 if fin[0] != fin[1] and None not in fin:

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -662,6 +662,39 @@ def test_issue_10304():
     e = 1 + d*I
     assert simplify(Eq(e, 0)) is S.false
 
+
+def test_issue_10401():
+    fin = symbols('inf', finite=True)
+    inf = symbols('inf', infinite=True)
+    inf2 = symbols('inf2', infinite=True)
+    zero = symbols('z', zero=True)
+    nonzero = symbols('nz', zero=False, finite=True)
+    E = Eq
+    T, F = S.true, S.false
+    assert E(fin, inf) is F
+    assert E(inf, inf2) is T and inf != inf2
+    assert E(inf/inf2, 0) is F
+    assert E(inf/fin, 0) is F
+    assert E(fin/inf, 0) is T
+    assert E(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
+    E = Ne
+    T, F = F, T
+    assert E(fin, inf) is F
+    assert E(inf, inf2) is T and inf != inf2
+    assert E(inf/inf2, 0) is F
+    assert E(inf/fin, 0) is F
+    assert E(fin/inf, 0) is T
+    assert E(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
+
+    assert Eq(fin/(fin + 1), 1) is S.false
+
+    o = symbols('o', odd=True)
+    assert Eq(o, 2*o) is S.false
+
+    p = symbols('p', positive=True)
+    assert Eq(p/(p - 1), 1) is S.false
+
+
 def test_issue_10633():
     assert Eq(True, False) == False
     assert Eq(False, True) == False

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -672,6 +672,7 @@ def test_issue_10401():
     nonzero = symbols('nz', zero=False, finite=True)
 
     assert Eq(1/(1/x + 1), 1).func is Eq
+    assert Eq(1/(1/x + 1), 1).subs(x, S.ComplexInfinity) is S.true
     assert Eq(1/(1/fin + 1), 1) is S.false
 
     T, F = S.true, S.false

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -664,27 +664,24 @@ def test_issue_10304():
 
 
 def test_issue_10401():
+    x = symbols('x')
     fin = symbols('inf', finite=True)
     inf = symbols('inf', infinite=True)
     inf2 = symbols('inf2', infinite=True)
     zero = symbols('z', zero=True)
     nonzero = symbols('nz', zero=False, finite=True)
-    E = Eq
+
+    assert Eq(1/(1/x + 1), 1).func is Eq
+    assert Eq(1/(1/fin + 1), 1) is S.false
+
     T, F = S.true, S.false
-    assert E(fin, inf) is F
-    assert E(inf, inf2) is T and inf != inf2
-    assert E(inf/inf2, 0) is F
-    assert E(inf/fin, 0) is F
-    assert E(fin/inf, 0) is T
-    assert E(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
-    E = Ne
-    T, F = F, T
-    assert E(fin, inf) is F
-    assert E(inf, inf2) is T and inf != inf2
-    assert E(inf/inf2, 0) is F
-    assert E(inf/fin, 0) is F
-    assert E(fin/inf, 0) is T
-    assert E(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
+    assert Eq(fin, inf) is F
+    assert Eq(inf, inf2) is T and inf != inf2
+    assert Eq(inf/inf2, 0) is F
+    assert Eq(inf/fin, 0) is F
+    assert Eq(fin/inf, 0) is T
+    assert Eq(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
+
 
     assert Eq(fin/(fin + 1), 1) is S.false
 
@@ -692,7 +689,7 @@ def test_issue_10401():
     assert Eq(o, 2*o) is S.false
 
     p = symbols('p', positive=True)
-    assert Eq(p/(p - 1), 1) is S.false
+    assert Eq(p/(p - 1), 1) is F
 
 
 def test_issue_10633():


### PR DESCRIPTION
The condition that the lhs and rhs be complex was added
without a test originally and it is not clear what it is
there for. The equality can still evaluate if one side
is real and the other complex.

The test that was corrected wouldn't fail as it was but
the inequality now evaluates, so the simpler expression
was used.

closes #10401 
closes #10687 
