### PR TITLE
test imageset args; modify ImageSet._contains

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -188,8 +188,8 @@ class ImageSet(Set):
     """
     Image of a set under a mathematical function. The transformation
     must be given as a Lambda function which has as many arguments
-    as the elements of the set upon which it operates (e.g. 1 argument
-    for acting on the set of integers or 2 arguments when acting on
+    as the elements of the set upon which it operates, e.g. 1 argument
+    when acting on the set of integers or 2 arguments when acting on
     a complex region.
 
     This function is not normally called directly, but is called
@@ -265,11 +265,11 @@ class ImageSet(Set):
                 raise NotImplementedError(filldedent('''
     Dimensions of input and output of Lambda are different.'''))
             eqs = [expr - val for val, expr in zip(other, L.expr)]
-            vars = L.variables
-            free = set(vars)
-            if all(i.is_number for i in list(Matrix(eqs).jacobian(vars))):
+            variables = L.variables
+            free = set(variables)
+            if all(i.is_number for i in list(Matrix(eqs).jacobian(variables))):
                 solns = list(linsolve([e - val for e, val in
-                zip(L.expr, other)], L.variables))
+                zip(L.expr, other)], variables))
             else:
                 syms = [e.free_symbols & free for e in eqs]
                 solns = {}
@@ -290,7 +290,7 @@ class ImageSet(Set):
                             raise NotImplementedError
                     else:
                         raise NotImplementedError
-                solns = cartes(*[solns[s] for s in vars])
+                solns = cartes(*[solns[s] for s in variables])
         else:
             # assume scalar -> scalar mapping
             solnsSet = solveset(L.expr - other, L.variables[0])

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2,19 +2,22 @@ from __future__ import print_function, division
 
 from itertools import product
 
-from sympy.core.sympify import _sympify, sympify, converter
+from sympy.core.sympify import (_sympify, sympify, converter,
+    SympifyError)
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
 from sympy.core.singleton import Singleton, S
 from sympy.core.evalf import EvalfMixin
 from sympy.core.numbers import Float
-from sympy.core.compatibility import iterable, with_metaclass, ordered, range
+from sympy.core.compatibility import (iterable, with_metaclass,
+    ordered, range)
 from sympy.core.evaluate import global_evaluate
+from sympy.core.function import FunctionClass
 from sympy.core.mul import Mul
 from sympy.core.relational import Eq
 from sympy.core.symbol import Symbol, Dummy
 from sympy.sets.contains import Contains
-from sympy.utilities.misc import func_name
+from sympy.utilities.misc import func_name, filldedent
 
 from mpmath import mpi, mpf
 from sympy.logic.boolalg import And, Or, Not, true, false
@@ -2016,7 +2019,7 @@ class SymmetricDifference(Set):
 
 def imageset(*args):
     r"""
-    Image of set under transformation ``f``.
+    Return an image of the set under transformation ``f``.
 
     If this function can't compute the image, it returns an
     unevaluated ImageSet object.
@@ -2028,7 +2031,7 @@ def imageset(*args):
     ========
 
     >>> from sympy import Interval, Symbol, imageset, sin, Lambda
-    >>> x = Symbol('x')
+    >>> from sympy.abc import x, y
 
     >>> imageset(x, 2*x, Interval(0, 2))
     [0, 4]
@@ -2039,25 +2042,47 @@ def imageset(*args):
     >>> imageset(Lambda(x, sin(x)), Interval(-2, 1))
     ImageSet(Lambda(x, sin(x)), [-2, 1])
 
+    >>> imageset(sin, Interval(-2, 1))
+    ImageSet(Lambda(x, sin(x)), [-2, 1])
+    >>> imageset(lambda y: x + y, Interval(-2, 1))
+    ImageSet(Lambda(_x, _x + x), [-2, 1])
+
     See Also
     ========
 
     sympy.sets.fancysets.ImageSet
 
     """
-    from sympy.core import Dummy, Lambda
+    from sympy.core import Lambda
     from sympy.sets.fancysets import ImageSet
+    from sympy.geometry.util import _uniquely_named_symbol
+
+    if len(args) not in (2, 3):
+        raise ValueError('imageset expects 2 or 3 args, got: %s' % len(args))
+
+    set = args[-1]
+    if not isinstance(set, Set):
+        name = func_name(set)
+        raise ValueError(
+            'last argument should be a set, not %s' % name)
+
     if len(args) == 3:
         f = Lambda(*args[:2])
-    else:
-        # var and expr are being defined this way to
-        # support Python lambda and not just sympy Lambda
+    elif len(args) == 2:
         f = args[0]
-        if not isinstance(f, Lambda):
-            var = Dummy()
-            expr = args[0](var)
+        if isinstance(f, Lambda):
+            pass
+        elif (
+                isinstance(f, FunctionClass) # like cos
+                or func_name(f) == '<lambda>'
+                ):
+            var = _uniquely_named_symbol(Symbol('x'), f(Dummy()))
+            expr = f(var)
             f = Lambda(var, expr)
-    set = args[-1]
+        else:
+            raise TypeError(filldedent('''
+        expecting lambda, Lambda, or FunctionClass, not \'%s\'''' %
+        func_name(f)))
 
     r = set._eval_imageset(f)
     if isinstance(r, ImageSet):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -7,11 +7,10 @@ from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
                    Rational, sqrt, tan, log, Abs, I, Tuple)
 from sympy.utilities.pytest import XFAIL, raises
+from sympy.abc import x, y, z
 
 import itertools
 
-x = Symbol('x')
-y = Symbol('y')
 
 
 def test_naturals():
@@ -85,7 +84,9 @@ def test_ImageSet():
     assert Tuple(2, S.Half) in ImageSet(Lambda((x, y), (x, 1/y)), c)
     assert Tuple(2, -2) not in ImageSet(Lambda((x, y), (x, y**2)), c)
     assert Tuple(2, -2) in ImageSet(Lambda((x, y), (x, -2)), c)
-    raises(NotImplementedError, lambda: 2/pi in ImageSet(Lambda((x, y), 2/x), c))
+    assert 2/pi not in ImageSet(Lambda((x, y), 2/x), c)
+    assert 2/S(100) not in ImageSet(Lambda((x, y), 2/x), c)
+    assert 2/S(3) in ImageSet(Lambda((x, y), 2/x), c)
 
 
 def test_image_is_ImageSet():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -5,11 +5,13 @@ from sympy.sets.sets import (FiniteSet, Interval, imageset, EmptySet, Union,
                              Intersection)
 from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
-                   Rational, sqrt, tan, log, Abs, I)
+                   Rational, sqrt, tan, log, Abs, I, Tuple)
 from sympy.utilities.pytest import XFAIL, raises
+
 import itertools
 
 x = Symbol('x')
+y = Symbol('y')
 
 
 def test_naturals():
@@ -56,6 +58,9 @@ def test_integers():
 
 
 def test_ImageSet():
+    assert ImageSet(Lambda(x, 1), S.Integers) == FiniteSet(1)
+    assert ImageSet(Lambda(x, y), S.Integers) == FiniteSet(y)
+
     squares = ImageSet(Lambda(x, x**2), S.Naturals)
     assert 4 in squares
     assert 5 not in squares
@@ -74,6 +79,14 @@ def test_ImageSet():
     assert Rational(.3) not in harmonics
 
     assert harmonics.is_iterable
+
+    c = ComplexRegion(Interval(1, 3)*Interval(1, 3))
+    assert Tuple(2, 6) in ImageSet(Lambda((x, y), (x, 2*y)), c)
+    assert Tuple(2, S.Half) in ImageSet(Lambda((x, y), (x, 1/y)), c)
+    assert Tuple(2, -2) not in ImageSet(Lambda((x, y), (x, y**2)), c)
+    assert Tuple(2, -2) in ImageSet(Lambda((x, y), (x, -2)), c)
+    raises(NotImplementedError, lambda: 2/pi in ImageSet(Lambda((x, y), 2/x), c))
+
 
 def test_image_is_ImageSet():
     assert isinstance(imageset(x, sqrt(sin(x)), Range(5)), ImageSet)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -7,10 +7,26 @@ from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
 from mpmath import mpi
 
 from sympy.core.compatibility import range
-from sympy.utilities.pytest import raises
 from sympy.utilities.pytest import raises, XFAIL
 
 from sympy.abc import x, y, z, m, n
+
+
+def test_imageset():
+    ints = S.Integers
+    raises(TypeError, lambda: imageset(x, ints))
+    raises(ValueError, lambda: imageset(x, y, z, ints))
+    raises(ValueError, lambda: imageset(Lambda(x, cos(x)), y))
+    assert imageset(cos, ints) == ImageSet(Lambda(x, cos(x)), ints)
+    def f(x):
+        return cos(x)
+    raises(TypeError, lambda: imageset(f, ints))
+    f = lambda x: cos(x)
+    assert imageset(f, ints) == ImageSet(Lambda(x, cos(x)), ints)
+    assert imageset(x, 1, ints) == FiniteSet(1)
+    assert imageset(x, y, ints) == FiniteSet(y)
+    assert (str(imageset(lambda y: x + y, Interval(-2, 1)).lamda.expr)
+        in ('_x + x', 'x + _x'))
 
 
 def test_interval_arguments():


### PR DESCRIPTION
closes #10476 and also handles non-linear expressions as added in tests
- [x] correct the following

```
>>> Tuple(S(1)/3,1,0) in imageset(Lambda((a,y,z),(1/y,a,z)),x)
False  <-- should be True
>>> Tuple(1,1/S(3),0) in imageset(Lambda((a,y,z),(y,1/a,z)),x)
True  <-- ok
```

Changes here also make possible a Rationals class:

```
>>> Rationals = imageset((x, y), x/y, S.Integers*S.Integers)
>>> S.Half in Rationals
True
>>> 1/pi in Rationals
False
```
