### PR TITLE
Reversed range

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1487,7 +1487,6 @@ class LatexPrinter(Printer):
         dots = r'\ldots'
 
         if s.start.is_infinite:
-            it = iter(s)
             printset = s.start, dots, s._last_element - s.step, s._last_element
         elif s.stop.is_infinite or len(s) > 4:
             it = iter(s)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1484,9 +1484,14 @@ class LatexPrinter(Printer):
     _print_frozenset = _print_set
 
     def _print_Range(self, s):
-        if len(s) > 4:
+        dots = r'\ldots'
+
+        if s.start.is_infinite:
             it = iter(s)
-            printset = next(it), next(it), '\ldots', s._last_element
+            printset = s.start, dots, s._last_element - s.step, s._last_element
+        elif s.stop.is_infinite or len(s) > 4:
+            it = iter(s)
+            printset = next(it), next(it), dots, s._last_element
         else:
             printset = tuple(s)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1469,7 +1469,7 @@ class PrettyPrinter(Printer):
         else:
             dots = '...'
 
-        if s.start is S.NegativeInfinity:
+        if s.start in [S.NegativeInfinity, S.Infinity]:
             it = iter(s)
             printset = s.start, dots, s._last_element - s.step, s._last_element
         elif s.stop is S.Infinity or len(s) > 4:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1469,10 +1469,10 @@ class PrettyPrinter(Printer):
         else:
             dots = '...'
 
-        if s.start in [S.NegativeInfinity, S.Infinity]:
+        if s.start.is_infinite:
             it = iter(s)
             printset = s.start, dots, s._last_element - s.step, s._last_element
-        elif s.stop is S.Infinity or len(s) > 4:
+        elif s.stop.is_infinite or len(s) > 4:
             it = iter(s)
             printset = next(it), next(it), dots, s._last_element
         else:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1470,7 +1470,6 @@ class PrettyPrinter(Printer):
             dots = '...'
 
         if s.start.is_infinite:
-            it = iter(s)
             printset = s.start, dots, s._last_element - s.step, s._last_element
         elif s.stop.is_infinite or len(s) > 4:
             it = iter(s)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3186,6 +3186,11 @@ def test_pretty_sets():
     assert pretty(Range(0, oo, 2)) == ascii_str
     assert upretty(Range(0, oo, 2)) == ucode_str
 
+    ascii_str = '{oo, ..., 2, 0}'
+    ucode_str = u('{∞, …, 2, 0}')
+    assert pretty(Range(oo, 1, -2)) == ascii_str
+    assert upretty(Range(oo, 1, -2)) == ucode_str
+
     ascii_str = '{-oo, ..., -3, -2}'
     ucode_str = u('{-∞, …, -3, -2}')
     assert pretty(Range(-2, -oo, -1)) == ascii_str

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3181,6 +3181,11 @@ def test_pretty_sets():
     assert pretty(Range(0, 30, 1)) == ascii_str
     assert upretty(Range(0, 30, 1)) == ucode_str
 
+    ascii_str = '{30, 29, ..., 2}'
+    ucode_str = u('{30, 29, …, 2}')
+    assert pretty(Range(30, 1, -1)) == ascii_str
+    assert upretty(Range(30, 1, -1)) == ucode_str
+
     ascii_str = '{0, 2, ..., oo}'
     ucode_str = u('{0, 2, …, ∞}')
     assert pretty(Range(0, oo, 2)) == ascii_str
@@ -3188,13 +3193,14 @@ def test_pretty_sets():
 
     ascii_str = '{oo, ..., 2, 0}'
     ucode_str = u('{∞, …, 2, 0}')
-    assert pretty(Range(oo, 1, -2)) == ascii_str
-    assert upretty(Range(oo, 1, -2)) == ucode_str
+    assert pretty(Range(oo, -2, -2)) == ascii_str
+    assert upretty(Range(oo, -2, -2)) == ucode_str
 
-    ascii_str = '{-oo, ..., -3, -2}'
-    ucode_str = u('{-∞, …, -3, -2}')
+    ascii_str = '{-2, -3, ..., -oo}'
+    ucode_str = u('{-2, -3, …, -∞}')
     assert pretty(Range(-2, -oo, -1)) == ascii_str
     assert upretty(Range(-2, -oo, -1)) == ucode_str
+
 
 
 def test_pretty_ConditionSet():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -511,6 +511,18 @@ def test_latex_Range():
         r'\left\{1, 2, \ldots, 50\right\}'
     assert latex(Range(1, 4)) == r'\left\{1, 2, 3\right\}'
 
+    assert latex(Range(0, 3, 1)) == r'\left\{0, 1, 2\right\}'
+
+    assert latex(Range(0, 30, 1)) == r'\left\{0, 1, \ldots, 29\right\}'
+
+    assert latex(Range(30, 1, -1)) == r'\left\{30, 29, \ldots, 2\right\}'
+
+    assert latex(Range(0, oo, 2)) == r'\left\{0, 2, \ldots, \infty\right\}'
+
+    assert latex(Range(oo, -2, -2)) == r'\left\{\infty, \ldots, 2, 0\right\}'
+
+    assert latex(Range(-2, -oo, -1)) == r'\left\{-2, -3, \ldots, -\infty\right\}'
+
 
 def test_latex_sequences():
     s1 = SeqFormula(a**2, (0, oo))

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -405,18 +405,14 @@ class Range(Set):
             raise ValueError("The start and end value of "
                              "Range cannot both be unbounded")
 
-        dif = stop - start
-        if dif.is_infinite:
+        if start.is_infinite:
             end = stop
         else:
-            if dif is S.Zero:
+            ref = start if start.is_finite else stop
+            n = ceiling((stop - ref)/step)
+            if n <= 0:
                 return S.EmptySet
-            n, r = divmod(dif, step)
-            if n < 0:
-                return S.EmptySet
-            if r:
-                n += 1
-            end = start + n*step
+            end = ref + n*step
         return Basic.__new__(cls, start, end, step)
 
     start = property(lambda self: self.args[0])

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -335,6 +335,8 @@ class Range(Set):
 
         # expand range
         slc = slice(*args)
+        if slc.step == 0:
+            raise ValueError("step cannot be 0")
         start, stop, step = slc.start or 0, slc.stop, slc.step or 1
         try:
             start, stop, step = [w if w in [S.NegativeInfinity, S.Infinity] else sympify(as_int(w))

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -498,10 +498,18 @@ class Range(Set):
 
 
     def __len__(self):
-        if self.start.is_infinite or self.stop.is_infinite:
-            return S.Infinity
-        return abs((self.stop - self.start)//self.step)
+        dif = self.stop - self.start
+        if dif.is_infinite:
+            raise ValueError(
+                "Use .size to get the length of an infinite Range")
+        return abs(dif//self.step)
 
+    @property
+    def size(self):
+        dif = self.stop - self.start
+        if dif.is_infinite:
+            return S.Infinity
+        return abs(dif//self.step)
 
     def __nonzero__(self):
         return True

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -477,7 +477,9 @@ class Range(Set):
         return None
 
     def _contains(self, other):
-        if not other.is_Integer:
+        if other.is_integer is None:
+            return
+        if other.is_integer is False:
             return S.false
         ref = self.start if self.start.is_finite else self.stop
         if (ref - other) % self.step:  # off sequence
@@ -511,8 +513,6 @@ class Range(Set):
     __bool__ = __nonzero__
 
     def _ith_element(self, i):
-        if self.start.is_infinite:
-            return self.start
         return self.start + i*self.step
 
     @property

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -331,7 +331,7 @@ class Range(Set):
         >>> list(Range(10, 0, -2))
         [10, 8, 6, 4, 2]
 
-    Although this object it a set, it maintains the order of the elements, so
+    Although this object is a set, it maintains the order of the elements, so
     that it can be used in contexts where range would be used. However, it
     does support the usual set operations.
 
@@ -341,10 +341,6 @@ class Range(Set):
         >>> list(_)
         [4, 6]
 
-    Infinite ranges are allowed. If the starting point is -oo, the final value
-    is stop - step. For example, Range(-oo, 0, 2) represents the negative even
-    integers, {-oo, ..., -4, -2}.
-
     The stop value is canonicalized to the largest possible value for the
     given step, so that equivalent ranges always have the same args. For
     example, Range(0, 10, 3) and Range(0, 12, 3) both create the same object,
@@ -352,6 +348,11 @@ class Range(Set):
 
         >>> Range(0, 10, 3) == Range(0, 12, 3)
         True
+
+
+    Infinite ranges are allowed. If the starting point is infinite, the final value
+    is stop - step. For example, Range(-oo, 0, 2) represents the negative even
+    integers, {-oo, ..., -4, -2}.
 
     Examples
     ========

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -188,56 +188,56 @@ def test_Range():
 
 def test_range_interval_intersection():
 
-    for line, (r, i, manual) in enumerate([
+    for line, (r, i) in enumerate([
         # Intersection with intervals
-        (Range(0, 10, 1), Interval(2, 6), Range(2, 7)),
-        (Range(0, 2, 1), Interval(2, 6), None),
-        (Range(0, 3, 1), Interval(2, 6), None),
-        (Range(0, 4, 1), Interval(2, 6), None),
-        (Range(0, 7, 1), Interval(2, 6), None),
-        (Range(0, 10, 1), Interval(2, 6), None),
-        (Range(2, 3, 1), Interval(2, 6), None),
-        (Range(2, 4, 1), Interval(2, 6), None),
-        (Range(2, 7, 1), Interval(2, 6), None),
-        (Range(2, 10, 1), Interval(2, 6), None),
-        (Range(3, 4, 1), Interval(2, 6), None),
-        (Range(3, 7, 1), Interval(2, 6), None),
-        (Range(3, 10, 1), Interval(2, 6), None),
-        (Range(6, 7, 1), Interval(2, 6), None),
-        (Range(6, 10, 1), Interval(2, 6), None),
-        (Range(7, 10, 1), Interval(2, 6), None),
-        (Range(0, 10, 2), Interval(3, 5), Range(4, 6, 2)),
-        (Range(1, 10, 2), Interval(2, 6), None),
-        (Range(2, 10, 2), Interval(2, 6), None),
-        (Range(3, 10, 2), Interval(2, 6), None),
-        (Range(6, 10, 2), Interval(2, 6), None),
-        (Range(10), Interval(5.1, 6.9), Range(6, 7)),
+        (Range(0, 10, 1), Interval(2, 6)),
+        (Range(0, 2, 1), Interval(2, 6)),
+        (Range(0, 3, 1), Interval(2, 6)),
+        (Range(0, 4, 1), Interval(2, 6)),
+        (Range(0, 7, 1), Interval(2, 6)),
+        (Range(0, 10, 1), Interval(2, 6)),
+        (Range(2, 3, 1), Interval(2, 6)),
+        (Range(2, 4, 1), Interval(2, 6)),
+        (Range(2, 7, 1), Interval(2, 6)),
+        (Range(2, 10, 1), Interval(2, 6)),
+        (Range(3, 4, 1), Interval(2, 6)),
+        (Range(3, 7, 1), Interval(2, 6)),
+        (Range(3, 10, 1), Interval(2, 6)),
+        (Range(6, 7, 1), Interval(2, 6)),
+        (Range(6, 10, 1), Interval(2, 6)),
+        (Range(7, 10, 1), Interval(2, 6)),
+        (Range(0, 10, 2), Interval(3, 5)),
+        (Range(1, 10, 2), Interval(2, 6)),
+        (Range(2, 10, 2), Interval(2, 6)),
+        (Range(3, 10, 2), Interval(2, 6)),
+        (Range(6, 10, 2), Interval(2, 6)),
+        (Range(10), Interval(5.1, 6.9)),
 
         # Open Intervals are removed
-        (Range(0, 10, 1), Interval(2, 6, True, True), Range(3, 6)),
+        (Range(0, 10, 1), Interval(2, 6, True, True)),
 
         # Try this with large steps
-        (Range(0, 100, 10), Interval(15, 55), Range(20, 60, 10)),
+        (Range(0, 100, 10), Interval(15, 55)),
 
 
         # Infinite range
-        (Range(0, oo, 2), Interval(-1, 5), Range(0, 6, 2)),
-        (Range(-oo, 4, 3), Interval(-10, 20), Range(-8, 4, 3)),
-        (Range(-oo, 4, 3), Interval(-10, -5), Range(-8, -2, 3)),
+        (Range(0, oo, 2), Interval(-1, 5)),
+        (Range(-oo, 4, 3), Interval(-10, 20)),
+        (Range(-oo, 4, 3), Interval(-10, -5)),
 
         # Infinite interval
-        (Range(-3, 0, 3), Interval(-oo, 0), Range(-3, 0, 3)),
-        (Range(0, 10, 3), Interval(3, oo), Range(3, 10, 3)),
-        (Range(0, 10, 3), Interval(-oo, 5), Range(0, 5, 3)),
+        (Range(-3, 0, 3), Interval(-oo, 0)),
+        (Range(0, 10, 3), Interval(3, oo)),
+        (Range(0, 10, 3), Interval(-oo, 5)),
 
         # Infinite interval, infinite range start
-        (Range(-oo, 1, 3), Interval(-oo, 5), Range(-oo, 1, 3)),
-        (Range(-oo, 1, 3), Interval(-oo, -3), Range(-oo, -2, 3)),
+        (Range(-oo, 1, 3), Interval(-oo, 5)),
+        (Range(-oo, 1, 3), Interval(-oo, -3)),
 
         # Infinite interval, infinite range end
-        (Range(0, oo, 3), Interval(5, oo), Range(6, oo, 3)),
-        (Range(0, oo, 3), Interval(-5, oo), Range(0, oo, 3)),
-        (Range(0, oo, 3), Interval(-oo, 5), Range(0, 5, 3)),
+        (Range(0, oo, 3), Interval(5, oo)),
+        (Range(0, oo, 3), Interval(-5, oo)),
+        (Range(0, oo, 3), Interval(-oo, 5)),
 
         ]):
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -103,12 +103,12 @@ def test_ImageSet_iterator_not_injetive():
     assert (next(i), next(i), next(i), next(i)) == (0, 2, 4, 6)
 
 
-@XFAIL
 def test_inf_Range_len():
-    assert len(Range(0, oo, 2)) == oo
-    assert len(Range(0, -oo, -2)) == oo
-    assert len(Range(oo, 0, -2)) == oo
-    assert len(Range(-oo, 0, 2)) == oo
+    raises(ValueError, lambda: len(Range(0, oo, 2)))
+    assert Range(0, oo, 2).size is S.Infinity
+    assert Range(0, -oo, -2).size is S.Infinity
+    assert Range(oo, 0, -2).size is S.Infinity
+    assert Range(-oo, 0, 2).size is S.Infinity
 
 
 def test_Range():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -132,6 +132,7 @@ def test_Range():
     raises(ValueError, lambda: Range(-oo, oo))
     raises(ValueError, lambda: Range(-oo, oo, 2))
     raises(ValueError, lambda: Range(0, pi, 1))
+    raises(ValueError, lambda: Range(1, 10, 0))
 
     assert 5 in Range(0, oo, 5)
     assert -5 in Range(-oo, 0, 5)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -204,10 +204,19 @@ def test_range_interval_intersection():
         (Range(0, 10, 3), Interval(-oo, 5), Range(0, 5, 3)),
         (Range(10, 0, -3), Interval(-oo, 5), Range(4, -1, -3)),
 
+        # Infinite interval, infinite range start
         (Range(-oo, 1, 3), Interval(-oo, 5), Range(-oo, 1, 3)),
         (Range(-oo, 1, 3), Interval(-oo, -3), Range(-oo, -2, 3)),
         (Range(oo, 1, -3), Interval(-3, oo), Range(oo, 1, -3)),
         (Range(oo, 1, -3), Interval(5, oo), Range(oo, 4, -3)),
+
+        # Infinite interval, infinite range end
+        (Range(0, oo, 3), Interval(5, oo), Range(6, oo, 3)),
+        (Range(0, oo, 3), Interval(-5, oo), Range(0, oo, 3)),
+        (Range(0, oo, 3), Interval(-oo, 5), Range(0, 5, 3)),
+        (Range(0, -oo, -3), Interval(-oo, -5), Range(-6, -oo, -3)),
+        (Range(0, -oo, -3), Interval(-oo, 5), Range(0, -oo, -3)),
+        (Range(0, -oo, -3), Interval(-5, oo), Range(0, -5, -3)),
 
         ]:
         assert r.intersect(i) == result, "%s.intersect(%s) == %s" % (r, i,

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -188,7 +188,7 @@ def test_Range():
 
 def test_range_interval_intersection():
 
-    for line, (r, i, hand_checked) in enumerate([
+    for line, (r, i, manual) in enumerate([
         # Intersection with intervals
         (Range(0, 10, 1), Interval(2, 6), Range(2, 7)),
         (Range(0, 2, 1), Interval(2, 6), None),
@@ -240,59 +240,28 @@ def test_range_interval_intersection():
         (Range(0, oo, 3), Interval(-oo, 5), Range(0, 5, 3)),
 
         ]):
-        assert r
+
         for rev in range(2):
             if rev:
                 r = r.reversed
-                if hand_checked:
-                    hand_checked = hand_checked.reversed
             result = r.intersection(i)
 
-            # compute the answer a different way
-            ans = []
-            if result:
-                _r = r
-                if _r.start.is_infinite:
-                    _r = _r.reversed
-                if _r.step < 0:
-                    if _r.start >= i.inf:
-                        for e in iter(_r):
-                            if e < i.inf:
-                                break
-                            if e in i:
-                                if len(ans) > 1:
-                                    ans[1] = e
-                                else:
-                                    ans.append(e)
-                            if ans and i.inf.is_infinite and _r.stop.is_infinite:
-                                ans.append(i.inf)
-                                break
-                else:
-                    if _r.start <= i.sup:
-                        for e in iter(_r):
-                            if e > i.sup:
-                                break
-                            if e in i:
-                                if len(ans) > 1:
-                                    ans[1] = e
-                                else:
-                                    ans.append(e)
-                            if ans and i.sup.is_infinite and _r.stop.is_infinite:
-                                ans.append(i.sup)
-                                break
-            if not ans:
-                assert not result
+            msg = "line %s: %s.intersect(%s) != %s" % (line, r, i, result)
+            if result is S.EmptySet:
+                assert (
+                    r.sup < i.inf or
+                        r.sup == i.inf and i.left_open) or (
+                    r.inf > i.sup or
+                        r.inf == i.sup and i.right_open), msg
             else:
-                if len(ans) == 1:
-                    ans.append(ans[0])
-                A, B = ans
-                ans = Range(A, B + _r.step, _r.step)
-                if r.step != ans.step:
-                    ans = ans.reversed
-                assert r.step == ans.step
-                if hand_checked:
-                    assert hand_checked == ans, "%s.intersect(%s) -> %s or %s" % (r, i, ans, hand_checked)
-                assert result == ans, "%s.intersect(%s) == %s" % (r, i, ans)
+                checks = a, b, c, d = [
+                result.inf in i or result.inf == i.inf,
+                result.inf - abs(result.step) not in i or \
+                    result.inf == r.inf,
+                result.sup in i or result.sup == i.sup,
+                result.sup + abs(result.step) not in i or \
+                    result.sup == r.sup]
+                assert all(_ for _ in checks), msg
 
 
 def test_fun():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -103,6 +103,14 @@ def test_ImageSet_iterator_not_injetive():
     assert (next(i), next(i), next(i), next(i)) == (0, 2, 4, 6)
 
 
+@XFAIL
+def test_inf_Range_len():
+    assert len(Range(0, oo, 2)) == oo
+    assert len(Range(0, -oo, -2)) == oo
+    assert len(Range(oo, 0, -2)) == oo
+    assert len(Range(-oo, 0, 2)) == oo
+
+
 def test_Range():
     assert Range(5) == Range(0, 5) == Range(0, 5, 1)
 
@@ -125,8 +133,8 @@ def test_Range():
     assert Range(60, 7, -10).inf == 10
 
     assert len(Range(10, 38, 10)) == 3
-    assert Range(0, 0, 5) == S.EmptySet
 
+    assert Range(0, 0, 5) == S.EmptySet
     assert Range(1, 1) == S.EmptySet
     raises(ValueError, lambda: Range(0, oo, oo))
     raises(ValueError, lambda: Range(-oo, oo))
@@ -180,7 +188,6 @@ def test_Range():
 
 def test_range_interval_intersection():
 
-    txt = txt = "FiniteSet(*%s).intersect(%s) == FiniteSet(*%s)"
     for line, (r, i, hand_checked) in enumerate([
         # Intersection with intervals
         (Range(0, 10, 1), Interval(2, 6), Range(2, 7)),
@@ -283,9 +290,9 @@ def test_range_interval_intersection():
                 if r.step != ans.step:
                     ans = ans.reversed
                 assert r.step == ans.step
-                assert result == ans, "%s.intersect(%s) == %s" % (r, i, ans)
                 if hand_checked:
-                    assert result == hand_checked, txt % (r, i, hand_checked)
+                    assert hand_checked == ans, "%s.intersect(%s) -> %s or %s" % (r, i, ans, hand_checked)
+                assert result == ans, "%s.intersect(%s) == %s" % (r, i, ans)
 
 
 def test_fun():


### PR DESCRIPTION
@smichr here you go. If you have any suggestions on how to improve (read: simplify) the logic in `Range._intersect`, that would be awesome. I believe the test cases I added cover all the combinations. The infinite range case (particularly infinite start) is nasty because it is handled differently from the others.  If you see anything that you caught that I missed also let me know. 

Fixes #10606.
