### PR TITLE
Remove "Projects using SymPy" from the docs

### DIFF
--- a/doc/src/outreach.rst
+++ b/doc/src/outreach.rst
@@ -24,21 +24,6 @@ in your local copy of SymPy by::
 The license of all the logos is the same as SymPy: BSD. See the LICENSE file in
 the trunk for more information.
 
-Projects using SymPy
---------------------
-
-This is an (incomplete) list of projects that use SymPy. If you use SymPy in
-your project, please let us know on our mailinglist_, so that we can add your
-project here as well.
-
-* `SfePy <http://sfepy.org/>`_ (simple finite elements in Python)
-* `Quameon <http://quameon.sourceforge.net/>`_ (Quantum Monte Carlo in Python)
-* `Lcapy <http://lcapy.elec.canterbury.ac.nz/>`_ (Experimental Python package for teaching linear circuit analysis)
-* `Quantum Programming in Python <http://digitalcommons.calpoly.edu/cgi/viewcontent.cgi?article=1072&context=physsp/>`_ (Quantum 1D Simple Harmonic Oscillator and Quantum Mapping Gate)
-* `LaTeX Expression project documentation <http://mech.fsv.cvut.cz/~stransky/software/latexexpr/doc/>`_ (easy LaTeX typesetting of algebraic expressions in symbolic form with automatic substitution and result computation)
-* `Symbolic statistical modeling <https://www.researchgate.net/publication/260585491_Symbolic_Statistics_with_SymPy/>`_ (Adding statistical operations to complex physical models)
-
-
 .. _mailinglist:        https://groups.google.com/forum/#!forum/sympy
 
 Blogs, News, Magazines


### PR DESCRIPTION
It now lives on the website.

Fixes #10273.
