### PR TITLE
adding latex string option for bosonic operators

### DIFF
--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -434,6 +434,9 @@ class AnnihilateBoson(BosonicOperator, Annihilator):
 
     def __repr__(self):
         return "AnnihilateBoson(%s)" % self.state
+        
+    def _latex(self, printer):
+        return "b_{%s}" % self.state
 
 
 class CreateBoson(BosonicOperator, Creator):
@@ -470,6 +473,9 @@ class CreateBoson(BosonicOperator, Creator):
 
     def __repr__(self):
         return "CreateBoson(%s)" % self.state
+        
+    def _latex(self, printer):
+        return "b^\\dagger_{%s}" % self.state
 
 B = AnnihilateBoson
 Bd = CreateBoson

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -436,7 +436,7 @@ class AnnihilateBoson(BosonicOperator, Annihilator):
         return "AnnihilateBoson(%s)" % self.state
         
     def _latex(self, printer):
-        return "b_{%s}" % self.state
+        return "b_{%s}" % self.state.name
 
 
 class CreateBoson(BosonicOperator, Creator):
@@ -475,7 +475,7 @@ class CreateBoson(BosonicOperator, Creator):
         return "CreateBoson(%s)" % self.state
         
     def _latex(self, printer):
-        return "b^\\dagger_{%s}" % self.state
+        return "b^\\dagger_{%s}" % self.state.name
 
 B = AnnihilateBoson
 Bd = CreateBoson


### PR DESCRIPTION
the bosonic operators did not have the option of latex output like the fermionic ones. i have added them now.
