### PR TITLE
added two _sage_ methods for gamma function

### DIFF
--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -165,6 +165,7 @@ def test_functions():
     check_expression("atanh(x)", "x")
     check_expression("acoth(x)", "x")
     check_expression("exp(x)", "x")
+    check_expression("gamma(x)", "x")
     check_expression("log(x)", "x")
     check_expression("re(x)", "x")
     check_expression("im(x)", "x")
@@ -188,6 +189,7 @@ def test_functions():
     check_expression("loggamma(x)", "x")
     check_expression("Ynm(n,m,x,y)", "n, m, x, y")
     check_expression("hyper((n,m),(m,n),x)", "n, m, x")
+    check_expression("uppergamma(y, x)", "x, y")
 
 def test_issue_4023():
     sage.var("a x")

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -197,6 +197,10 @@ class gamma(Function):
     def _latex_no_arg(printer):
         return r'\Gamma'
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.gamma(self.args[0]._sage_())
+
 
 ###############################################################################
 ################## LOWER and UPPER INCOMPLETE GAMMA FUNCTIONS #################
@@ -470,6 +474,10 @@ class uppergamma(Function):
     def _eval_rewrite_as_expint(self, s, x):
         from sympy import expint
         return expint(1 - s, x)*x**s
+
+    def _sage_(self):
+        import sage.all as sage
+        return sage.gamma(self.args[0]._sage_(), self.args[1]._sage_())
 
 
 ###############################################################################


### PR DESCRIPTION

#### Brief description of what is fixed or changed

Add  `_sage_` methods for conversion of gamma and upper_gamma back to sage

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * enhance conversion of gamma and upper_gamma back to sage

<!-- END RELEASE NOTES -->