### PR TITLE
Slater expansions with floating point parameters

### DIFF
--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -646,3 +646,12 @@ def test_issue_6860():
 def test_issue_8368():
     assert meijerint_indefinite(cosh(x)*exp(-x*t), x) == (
         (-t - 1)*exp(x) + (-t + 1)*exp(-x))*exp(-t*x)/2/(t**2 - 1)
+
+
+def test_issue_10681():
+    from sympy import RR
+    from sympy.abc import R, r
+    f = integrate(r**2*(R**2-r**2)**0.5, r, meijerg=True)
+    g = (1.0/3)*R**1.0*r**3*hyper((-0.5, S(3)/2), (S(5)/2,),
+                                  r**2*exp_polar(2*I*pi)/R**2)
+    assert RR.almosteq((f/g).n(), 1.0, 1e-12)

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2293,6 +2293,8 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default'):
                 s = Dummy('s')
                 integrand = z**s
                 for b in bm:
+                    if not Mod(b, 1):
+                        b = int(b)
                     integrand *= gamma(b - s)
                 for a in an:
                     integrand *= gamma(1 - a + s)
@@ -2304,7 +2306,7 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default'):
                 # Now sum the finitely many residues:
                 # XXX This speeds up some cases - is it a good idea?
                 integrand = expand_func(integrand)
-                for r in range(lu):
+                for r in range(int(lu)):
                     resid = residue(integrand, s, b_ + r)
                     resid = apply_operators(resid, ops, lambda f: z*f.diff(z))
                     res -= resid

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2294,7 +2294,7 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default'):
                 integrand = z**s
                 for b in bm:
                     if not Mod(b, 1):
-                        b = int(b)
+                        b = int(round(b))
                     integrand *= gamma(b - s)
                 for a in an:
                     integrand *= gamma(1 - a + s)
@@ -2306,7 +2306,7 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default'):
                 # Now sum the finitely many residues:
                 # XXX This speeds up some cases - is it a good idea?
                 integrand = expand_func(integrand)
-                for r in range(int(lu)):
+                for r in range(int(round(lu))):
                     resid = residue(integrand, s, b_ + r)
                     resid = apply_operators(resid, ops, lambda f: z*f.diff(z))
                     res -= resid

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -543,6 +543,15 @@ def test_meijerg_confluence():
     assert u([1, 1], [2, 2, 5], [1, 1, 6], [0])
 
 
+def test_meijerg_with_Floats():
+    # see issue #10681
+    from sympy import RR
+    f = meijerg(((3.0, 1), ()), ((S(3)/2,), (0,)), z)
+    a = -2.3632718012073
+    g = a*z**(S(3)/2)*hyper((-0.5, S(3)/2), (S(5)/2,), z*exp_polar(I*pi))
+    assert RR.almosteq((hyperexpand(f)/g).n(), 1.0, 1e-12)
+
+
 def test_lerchphi():
     from sympy import combsimp, exp_polar, polylog, log, lerchphi
     assert hyperexpand(hyper([1, a], [a + 1], z)/a) == lerchphi(z, 1, a)


### PR DESCRIPTION
This is a minimal fix for #10681. It makes meijerint accept
G-functions with floating point parameters. It does not enhance
hyperexpand to simplify the resulting hypergeometric functions.

Two points are modified in `do_slater`:
- The loop count `lu` is cast as an `int`. It is always integer-valued
  but may be of Float type as it is derived from the parameters.
- `expand_func` cannot currently expand gamma-functions having
  floating point integers in their arguments. Therefore such constants
  are cast as `int`s when the integrand is formed.
