### PR TITLE
Small optimization to MatMul._entry

### DIFF
--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -64,6 +64,9 @@ class MatMul(MatrixExpr):
         if X.has(ImmutableMatrix) or Y.has(ImmutableMatrix):
             return coeff*Add(*[X[i, k]*Y[k, j] for k in range(X.cols)])
         result = Sum(coeff*X[i, k]*Y[k, j], (k, 0, X.cols - 1))
+        if not X.cols.is_number:
+            # Don't waste time in result.doit() if the sum bounds are symbolic
+            expand = False
         return result.doit() if expand else result
 
     def as_coeff_matrices(self):


### PR DESCRIPTION
Don't call Sum.doit(), even if expand is set to True, if we know the bounds
are symbolic. There's no way the summation can evaluate to anything in that
case, so it just wastes time in the summation algorithms. This can result in a
performance hit if many MatMul indexed terms in an expression.
