### PR TITLE
Remove documented redundant comments

### DIFF
--- a/sympy/integrals/__init__.py
+++ b/sympy/integrals/__init__.py
@@ -1,15 +1,3 @@
-"""Integration functions that integrates a sympy expression.
-
-    Examples
-    ========
-
-    >>> from sympy import integrate, sin
-    >>> from sympy.abc import x
-    >>> integrate(1/x,x)
-    log(x)
-    >>> integrate(sin(x),x)
-    -cos(x)
-"""
 from .integrals import integrate, Integral, line_integrate
 from .transforms import (mellin_transform, inverse_mellin_transform,
                         MellinTransform, InverseMellinTransform,


### PR DESCRIPTION
The basics of integration are already in the documentation of sympy .So removed the commented out section.
