### PR TITLE
Solves & Fixes Issue No 9480 | Matrix.rank() now gives correct result

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -28,7 +28,6 @@ def _iszero(x):
     """Returns True if x is zero."""
     if len(x.free_symbols) == 0:
         x = _simplify(x)
-        
     return x.is_zero
 
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -26,6 +26,9 @@ from types import FunctionType
 
 def _iszero(x):
     """Returns True if x is zero."""
+    if len(x.free_symbols) == 0:
+        x = _simplify(x)
+        
     return x.is_zero
 
 
@@ -2734,7 +2737,7 @@ class MatrixBase(object):
             pivot += 1
         return self._new(r), pivotlist
 
-    def rank(self, iszerofunc=_iszero, simplify=False):
+    def rank(self, iszerofunc=_iszero, simplify=True):
         """
         Returns the rank of a matrix
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2736,7 +2736,7 @@ class MatrixBase(object):
             pivot += 1
         return self._new(r), pivotlist
 
-    def rank(self, iszerofunc=_iszero, simplify=True):
+    def rank(self, iszerofunc=_iszero, simplify=False):
         """
         Returns the rank of a matrix
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2661,3 +2661,7 @@ def test_issue_9422():
     assert x*M1 != M1*x
     assert a*M1 == M1*a
     assert y*x*M == Matrix([[y*x, 0], [0, y*x]])
+
+def test_issue_9480():
+    m = Matrix([[-5 + 5*sqrt(2), -5], [-5*sqrt(2)/2 + 5, -5*sqrt(2)/2]])
+    assert m.rank() == 1


### PR DESCRIPTION
Hi !

I have been looking into this issue #9480 . This PR fixes #9480 .

simplify() support added. Now, it gives correct result for Matrix.rank().

This is the code that was executed-:

```
m = Matrix([[-5 + 5*sqrt(2), -5], [-5*sqrt(2)/2 + 5, -5*sqrt(2)/2]])
print("shape:", m.shape)
print("det:", m.det())
print("rank:", m.rank())
```

Previously the output was:

```
shape: (2, 2)
det: 0
rank: 2
```

Now, the new output is-:

```
shape: (2, 2)
det: 0
rank: 1
```

Hence as we see, the output for rank is now correct.

Fixes & Resolves #9480 . 

@asmeurer @jksuom Please have a look into this PR, and suggest if any changes?

Thanks! :smile: 
