### PR TITLE
Set print

### DIFF
--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -9,7 +9,7 @@ The Matrix expression module allows users to write down statements like
     >>> X = MatrixSymbol('X', 3, 3)
     >>> Y = MatrixSymbol('Y', 3, 3)
     >>> (X.T*X).I*Y
-    X^-1*X'^-1*Y
+    X**-1*X'**-1*Y
 
     >>> Matrix(X)
     Matrix([

--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -180,9 +180,9 @@ For example:
 
  >>> from sympy import FiniteSet
  >>> FiniteSet(1, 2, 3)   # Unordered
- {1, 2, 3}
+ FiniteSet(1, 2, 3)
  >>> FiniteSet((1, 2, 3))  # Ordered
- {(1, 2, 3)}
+ FiniteSet((1, 2, 3))
 
 
 Why not use dicts as output?
@@ -252,7 +252,7 @@ What is this domain argument about?
     >>> from sympy import solveset, S
     >>> from sympy.abc import x
     >>> solveset(x**2 + 1, x) # domain=S.Complexes is default
-    {-I, I}
+    FiniteSet(-I, I)
     >>> solveset(x**2 + 1, x, domain=S.Reals)
     EmptySet()
 
@@ -520,9 +520,9 @@ How are symbolic parameters handled in solveset?
     >>> from sympy import Symbol, FiniteSet, Interval, not_empty_in, sqrt, oo
     >>> from sympy.abc import x
     >>> not_empty_in(FiniteSet(x/2).intersect(Interval(0, 1)), x)
-    [0, 2]
+    Interval(0, 2)
     >>> not_empty_in(FiniteSet(x, x**2).intersect(Interval(1, 2)), x)
-    [-sqrt(2), -1] U [1, 2]
+    Union(Interval(-sqrt(2), -1), Interval(1, 2))
 
 
 References
@@ -550,12 +550,12 @@ Solving an equation like `x^2 == 1` can be done as follows::
     >>> from sympy import Symbol, Eq
     >>> x = Symbol('x')
     >>> solveset(Eq(x**2, 1), x)
-    {-1, 1}
+    FiniteSet(-1, 1)
 
 Or one may manually rewrite the equation as an expression equal to 0::
 
     >>> solveset(x**2 - 1, x)
-    {-1, 1}
+    FiniteSet(-1, 1)
 
 The first argument for :func:`solveset` is an expression (equal to zero) or an equation and the second argument
 is the symbol that we want to solve the equation for.

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -20,11 +20,11 @@ def singularities(expr, sym):
     >>> singularities(x**2 + x + 1, x)
     EmptySet()
     >>> singularities(1/(x + 1), x)
-    {-1}
+    FiniteSet(-1)
     >>> singularities(1/(y**2 + 1), y)
-    {-I, I}
+    FiniteSet(-I, I)
     >>> singularities(1/(y**3 + 1), y)
-    {-1, 1/2 - sqrt(3)*I/2, 1/2 + sqrt(3)*I/2}
+    FiniteSet(-1, 1/2 - sqrt(3)*I/2, 1/2 + sqrt(3)*I/2)
 
     References
     ==========

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -40,11 +40,11 @@ def not_empty_in(finset_intersection, *syms):
     >>> from sympy import FiniteSet, Interval, not_empty_in, oo
     >>> from sympy.abc import x
     >>> not_empty_in(FiniteSet(x/2).intersect(Interval(0, 1)), x)
-    [0, 2]
+    Interval(0, 2)
     >>> not_empty_in(FiniteSet(x, x**2).intersect(Interval(1, 2)), x)
-    [-sqrt(2), -1] U [1, 2]
+    Union(Interval(-sqrt(2), -1), Interval(1, 2))
     >>> not_empty_in(FiniteSet(x**2/(x + 2)).intersect(Interval(1, oo)), x)
-    (-2, -1] U [2, oo)
+    Union(Interval(-2, -1, True, False), Interval(2, oo, False, True))
     """
 
     # TODO: handle piecewise defined functions
@@ -189,16 +189,16 @@ class AccumulationBounds(AtomicExpr):
     >>> from sympy.abc import x
 
     >>> AccumBounds(0, 1) + AccumBounds(1, 2)
-    <1, 3>
+    AccumBounds(1, 3)
 
     >>> AccumBounds(0, 1) - AccumBounds(0, 2)
-    <-2, 1>
+    AccumBounds(-2, 1)
 
     >>> AccumBounds(-2, 3)*AccumBounds(-1, 1)
-    <-3, 3>
+    AccumBounds(-3, 3)
 
     >>> AccumBounds(1, 2)*AccumBounds(3, 5)
-    <3, 10>
+    AccumBounds(3, 10)
 
     The exponentiation of AccumulationBounds is defined
     as follows:
@@ -215,18 +215,18 @@ class AccumulationBounds(AtomicExpr):
     AccumulationBounds object is neglected.
 
     >>> AccumBounds(-1, 4)**(S(1)/2)
-    <0, 2>
+    AccumBounds(0, 2)
 
     >>> AccumBounds(1, 2)**2
-    <1, 4>
+    AccumBounds(1, 4)
 
     >>> AccumBounds(-1, oo)**(-1)
-    <-oo, oo>
+    AccumBounds(-oo, oo)
 
     Note: `<a, b>^2` is not same as `<a, b>*<a, b>`
 
     >>> AccumBounds(-1, 1)**2
-    <0, 1>
+    AccumBounds(0, 1)
 
     >>> AccumBounds(1, 3) < 4
     True
@@ -239,13 +239,13 @@ class AccumulationBounds(AtomicExpr):
     is defined as `f(\langle a, b\rangle) = \{ f(x) \mid a \le x \le b \}`
 
     >>> sin(AccumBounds(pi/6, pi/3))
-    <1/2, sqrt(3)/2>
+    AccumBounds(1/2, sqrt(3)/2)
 
     >>> exp(AccumBounds(0, 1))
-    <1, E>
+    AccumBounds(1, E)
 
     >>> log(AccumBounds(1, E))
-    <0, 1>
+    AccumBounds(0, 1)
 
     Some symbol in an expression can be substituted for a AccumulationBounds
     object. But it doesn't necessarily evaluate the AccumulationBounds for
@@ -255,10 +255,10 @@ class AccumulationBounds(AtomicExpr):
     the form it is used for substituion. For example:
 
     >>> (x**2 + 2*x + 1).subs(x, AccumBounds(-1, 1))
-    <-1, 4>
+    AccumBounds(-1, 4)
 
     >>> ((x + 1)**2).subs(x, AccumBounds(-1, 1))
-    <0, 4>
+    AccumBounds(0, 4)
 
     References
     ==========
@@ -779,13 +779,13 @@ class AccumulationBounds(AtomicExpr):
 
         >>> from sympy import AccumBounds, FiniteSet
         >>> AccumBounds(1, 3).intersection(AccumBounds(2, 4))
-        <2, 3>
+        AccumBounds(2, 3)
 
         >>> AccumBounds(1, 3).intersection(AccumBounds(4, 6))
         EmptySet()
 
         >>> AccumBounds(1, 4).intersection(FiniteSet(1, 2, 5))
-        {1, 2}
+        FiniteSet(1, 2)
 
         """
         if not isinstance(other, (AccumBounds, FiniteSet)):

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -486,7 +486,7 @@ class Category(Basic):
         >>> B = Object("B")
         >>> K = Category("K", FiniteSet(A, B))
         >>> K.objects
-        Class({Object("A"), Object("B")})
+        Class(FiniteSet(Object("A"), Object("B")))
 
         """
         return self.args[1]
@@ -681,7 +681,7 @@ class Diagram(Basic):
         True
         >>> d = Diagram([f, g], {g * f: "unique"})
         >>> d.conclusions[g * f]
-        {unique}
+        FiniteSet(unique)
 
         """
         premises = {}
@@ -813,7 +813,7 @@ class Diagram(Basic):
         >>> g = NamedMorphism(B, C, "g")
         >>> d = Diagram([f, g])
         >>> d.objects
-        {Object("A"), Object("B"), Object("C")}
+        FiniteSet(Object("A"), Object("B"), Object("C"))
 
         """
         return self.args[2]

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -39,7 +39,7 @@ class Partition(FiniteSet):
         >>> from sympy.combinatorics.partitions import Partition
         >>> a = Partition([1, 2], [3])
         >>> a
-        {{3}, {1, 2}}
+        FiniteSet(FiniteSet(3), FiniteSet(1, 2))
         >>> a.partition
         [[1, 2], [3]]
         >>> len(a)
@@ -81,7 +81,7 @@ class Partition(FiniteSet):
         >>> d = Partition(list(range(4)))
         >>> l = [d, b, a + 1, a, c]
         >>> l.sort(key=default_sort_key); l
-        [{{1, 2}}, {{1}, {2}}, {{1, x}}, {{3, 4}}, {{0, 1, 2, 3}}]
+        [FiniteSet(FiniteSet(1, 2)), FiniteSet(FiniteSet(1), FiniteSet(2)), FiniteSet(FiniteSet(1, x)), FiniteSet(FiniteSet(3, 4)), FiniteSet(FiniteSet(0, 1, 2, 3))]
         """
         if order is None:
             members = self.members
@@ -224,7 +224,7 @@ class Partition(FiniteSet):
         >>> a.RGS
         (0, 0, 1, 2, 2)
         >>> a + 1
-        {{3}, {4}, {5}, {1, 2}}
+        FiniteSet(FiniteSet(3), FiniteSet(4), FiniteSet(5), FiniteSet(1, 2))
         >>> _.RGS
         (0, 0, 1, 2, 3)
         """
@@ -252,12 +252,12 @@ class Partition(FiniteSet):
 
         >>> from sympy.combinatorics.partitions import Partition
         >>> Partition.from_rgs([0, 1, 2, 0, 1], list('abcde'))
-        {{c}, {a, d}, {b, e}}
+        FiniteSet(FiniteSet(c), FiniteSet(a, d), FiniteSet(b, e))
         >>> Partition.from_rgs([0, 1, 2, 0, 1], list('cbead'))
-        {{e}, {a, c}, {b, d}}
+        FiniteSet(FiniteSet(e), FiniteSet(a, c), FiniteSet(b, d))
         >>> a = Partition([1, 4], [2], [3, 5])
         >>> Partition.from_rgs(a.RGS, a.members)
-        {{2}, {1, 4}, {3, 5}}
+        FiniteSet(FiniteSet(2), FiniteSet(1, 4), FiniteSet(3, 5))
         """
         if len(rgs) != len(elements):
             raise ValueError('mismatch in rgs and element lengths')

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -47,9 +47,9 @@ class Polyhedron(Basic):
 
             >>> from sympy.combinatorics.polyhedron import Polyhedron
             >>> Polyhedron(list('abc'), [(1, 2, 0)]).faces
-            {(0, 1, 2)}
+            FiniteSet((0, 1, 2))
             >>> Polyhedron(list('abc'), [(1, 0, 2)]).faces
-            {(0, 1, 2)}
+            FiniteSet((0, 1, 2))
 
         The allowed transformations are entered as allowable permutations
         of the vertices for the polyhedron. Instance of Permutations
@@ -92,7 +92,7 @@ class Polyhedron(Basic):
         >>> tetra.size
         4
         >>> tetra.edges
-        {(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)}
+        FiniteSet((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3))
         >>> tetra.corners
         (w, x, y, z)
 
@@ -365,7 +365,7 @@ class Polyhedron(Basic):
 
         >>> from sympy.combinatorics.polyhedron import cube
         >>> cube.edges
-        {(0, 1), (0, 3), (0, 4), '...', (4, 7), (5, 6), (6, 7)}
+        FiniteSet((0, 1), (0, 3), (0, 4), '...', (4, 7), (5, 6), (6, 7))
 
         If you want to use letters or other names for the corners you
         can still use the pre-calculated faces:
@@ -492,7 +492,7 @@ class Polyhedron(Basic):
         >>> corners = (a, b, c)
         >>> faces = [(0, 1, 2)]
         >>> Polyhedron(corners, faces).edges
-        {(0, 1), (0, 2), (1, 2)}
+        FiniteSet((0, 1), (0, 2), (1, 2))
 
         """
         if self._edges is None:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -152,15 +152,15 @@ class FunctionClass(ManagedProperties):
         numbers is returned:
 
         >>> Function('f').nargs
-        Naturals0()
+        S.Naturals0
 
         If the function was initialized to accept one or more arguments, a
         corresponding set will be returned:
 
         >>> Function('f', nargs=1).nargs
-        {1}
+        FiniteSet(1)
         >>> Function('f', nargs=(2, 1)).nargs
-        {1, 2}
+        FiniteSet(1, 2)
 
         The undefined function, after application, also has the nargs
         attribute; the actual number of arguments is always available by
@@ -168,7 +168,7 @@ class FunctionClass(ManagedProperties):
 
         >>> f = Function('f')
         >>> f(1).nargs
-        Naturals0()
+        S.Naturals0
         >>> len(f(1).args)
         1
         """
@@ -757,7 +757,7 @@ class WildFunction(Function, AtomicExpr):
     >>> F = WildFunction('F')
     >>> f = Function('f')
     >>> F.nargs
-    Naturals0()
+    S.Naturals0
     >>> x.match(F)
     >>> F.match(F)
     {F_: F_}
@@ -773,7 +773,7 @@ class WildFunction(Function, AtomicExpr):
 
     >>> F = WildFunction('F', nargs=2)
     >>> F.nargs
-    {2}
+    FiniteSet(2)
     >>> f(x).match(F)
     >>> f(x, y).match(F)
     {F_: f(x, y)}
@@ -784,7 +784,7 @@ class WildFunction(Function, AtomicExpr):
 
     >>> F = WildFunction('F', nargs=(1, 2))
     >>> F.nargs
-    {1, 2}
+    FiniteSet(1, 2)
     >>> f(x).match(F)
     {F_: f(x)}
     >>> f(x, y).match(F)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -206,9 +206,9 @@ class Relational(Boolean, Expr, EvalfMixin):
         >>> from sympy import Symbol, Eq
         >>> x = Symbol('x', real=True)
         >>> (x>0).as_set()
-        (0, oo)
+        Interval(0, oo, True, True)
         >>> Eq(x, 0).as_set()
-        {0}
+        FiniteSet(0)
 
         """
         from sympy.solvers.inequalities import solve_univariate_inequality

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -367,7 +367,7 @@ class And(LatticeOp, BooleanFunction):
         >>> from sympy import And, Symbol
         >>> x = Symbol('x', real=True)
         >>> And(x<2, x>-2).as_set()
-        (-2, 2)
+        Interval(-2, 2, True, True)
         """
         from sympy.sets.sets import Intersection
         if len(self.free_symbols) == 1:
@@ -438,7 +438,7 @@ class Or(LatticeOp, BooleanFunction):
         >>> from sympy import Or, Symbol
         >>> x = Symbol('x', real=True)
         >>> Or(x>2, x<-2).as_set()
-        (-oo, -2) U (2, oo)
+        Union(Interval(-oo, -2, True, True), Interval(2, oo, True, True))
         """
         from sympy.sets.sets import Union
         if len(self.free_symbols) == 1:
@@ -531,7 +531,7 @@ class Not(BooleanFunction):
         >>> from sympy import Not, Symbol
         >>> x = Symbol('x', real=True)
         >>> Not(x>0).as_set()
-        (-oo, 0]
+        Interval(-oo, 0, True, False)
         """
         if len(self.free_symbols) == 1:
             return self.args[0].as_set().complement(S.Reals)

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -22,13 +22,13 @@ class Inverse(MatPow):
     >>> A = MatrixSymbol('A', 3, 3)
     >>> B = MatrixSymbol('B', 3, 3)
     >>> Inverse(A)
-    A^-1
+    A**-1
     >>> A.inverse() == Inverse(A)
     True
     >>> (A*B).inverse()
-    B^-1*A^-1
+    B**-1*A**-1
     >>> Inverse(A*B)
-    (A*B)^-1
+    (A*B)**-1
 
     """
     is_Inverse = True
@@ -73,7 +73,7 @@ def refine_Inverse(expr, assumptions):
     >>> from sympy import MatrixSymbol, Q, assuming, refine
     >>> X = MatrixSymbol('X', 2, 2)
     >>> X.I
-    X^-1
+    X**-1
     >>> with assuming(Q.orthogonal(X)):
     ...     print(refine(X.I))
     X'

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -195,11 +195,11 @@ class L2(HilbertSpace):
     >>> from sympy.physics.quantum.hilbert import L2
     >>> hs = L2(Interval(0,oo))
     >>> hs
-    L2([0, oo))
+    L2(Interval(0, oo, False, True))
     >>> hs.dimension
     oo
     >>> hs.interval
-    [0, oo)
+    Interval(0, oo, False, True)
 
     """
 

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -344,7 +344,7 @@ C \
     assert upretty(h3) == u('F')
     assert latex(h3) == r'\mathcal{F}'
     sT(h3, "FockSpace()")
-    assert str(h4) == 'L2([0, oo))'
+    assert str(h4) == 'L2(Interval(0, oo, False, True))'
     ascii_str = \
 """\
  2\n\
@@ -863,7 +863,7 @@ u("""\
     assert latex(e3) == \
         r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dag} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,j_{1}=1,j_{2}=1\right\rangle } + {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }}\right)\otimes {{\left|1,-1,j_{1}=1,j_{2}=1\right\rangle }}'
     sT(e3, "Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))), JzKetCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))), JzKetCoupled(Integer(1),Integer(-1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))))")
-    assert str(e4) == '(C(1)*C(2)+F**2)*(L2([0, oo))+H)'
+    assert str(e4) == '(C(1)*C(2)+F**2)*(L2(Interval(0, oo, False, True))+H)'
     ascii_str = \
 """\
 // 1    2\\    x2\\   / 2    \\\n\

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3194,7 +3194,7 @@ def test_pretty_sets():
 
 def test_pretty_ConditionSet():
     from sympy import ConditionSet
-    ascii_str = '{x | x in (-oo, oo) and sin(x) = 0}'
+    ascii_str = '{x | x in Interval(-oo, oo, True, True) and sin(x) = 0}'
     ucode_str = u('{x | x ∊ ℝ ∧ sin(x) = 0}')
     assert pretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ascii_str
     assert upretty(ConditionSet(x, Eq(sin(x), 0), S.Reals)) == ucode_str
@@ -5171,9 +5171,9 @@ def test_issue_7180():
 
 
 def test_pretty_Complement():
-    assert pretty(S.Reals - S.Naturals) == '(-oo, oo) \ Naturals()'
+    assert pretty(S.Reals - S.Naturals) == 'Interval(-oo, oo, True, True) \ S.Naturals'
     assert upretty(S.Reals - S.Naturals) == u('ℝ \ ℕ')
-    assert pretty(S.Reals - S.Naturals0) == '(-oo, oo) \ Naturals0()'
+    assert pretty(S.Reals - S.Naturals0) == 'Interval(-oo, oo, True, True) \ S.Naturals0'
     assert upretty(S.Reals - S.Naturals0) == u('ℝ \ ℕ₀')
 
 
@@ -5187,7 +5187,7 @@ def test_pretty_SymmetricDifference():
 
 
 def test_pretty_Contains():
-    assert pretty(Contains(x, S.Integers)) == 'Contains(x, Integers())'
+    assert pretty(Contains(x, S.Integers)) == 'Contains(x, S.Integers)'
     assert upretty(Contains(x, S.Integers)) == u('x ∈ ℤ')
 
 

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -82,6 +82,18 @@ class ReprPrinter(Printer):
     def _print_list(self, expr):
         return "[%s]" % self.reprify(expr, ", ")
 
+    def _print_Integers(self, expr):
+        return "S.Integers"
+
+    def _print_Naturals(self, expr):
+        return "S.Naturals"
+
+    def _print_Naturals0(self, expr):
+        return "S.Naturals0"
+
+    def _print_Complexes(self, expr):
+        return "S.Complexes"
+
     def _print_MatrixBase(self, expr):
         # special case for some empty matrices
         if (expr.rows == 0) ^ (expr.cols == 0):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -676,6 +676,18 @@ class StrPrinter(Printer):
     def _print_Zero(self, expr):
         return "0"
 
+    def _print_Integers(self, expr):
+        return "S.Integers"
+
+    def _print_Naturals(self, expr):
+        return "S.Naturals"
+
+    def _print_Naturals0(self, expr):
+        return "S.Naturals0"
+
+    def _print_Complexes(self, expr):
+        return "S.Complexes"
+
     def _print_DMP(self, p):
         from sympy.core.sympify import SympifyError
         try:

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -145,7 +145,7 @@ class StrPrinter(Printer):
             printset = s[:3] + ['...'] + s[-3:]
         else:
             printset = s
-        return '{' + ', '.join(self._print(el) for el in printset) + '}'
+        return 'FiniteSet(' + ', '.join(self._print(el) for el in printset) + ')'
 
     def _print_Function(self, expr):
         return expr.func.__name__ + "(%s)" % self.stringify(expr.args, ", ")
@@ -173,28 +173,20 @@ class StrPrinter(Printer):
         return 'Integral(%s, %s)' % (self._print(expr.function), L)
 
     def _print_Interval(self, i):
-        if i.left_open:
-            left = '('
-        else:
-            left = '['
 
-        if i.right_open:
-            right = ')'
-        else:
-            right = ']'
-
-        return "%s%s, %s%s" % \
-               (left, self._print(i.start), self._print(i.end), right)
+        if not i.left_open and not i.right_open:
+            return "Interval(%s, %s)" % \
+                   (self._print(i.start), self._print(i.end))
+        return "Interval(%s, %s, %s, %s)" % \
+               (self._print(i.start), self._print(i.end), i.left_open, i.right_open)
 
     def _print_AccumulationBounds(self, i):
-        left = '<'
-        right = '>'
 
-        return "%s%s, %s%s" % \
-                (left, self._print(i.min), self._print(i.max), right)
+        return "AccumBounds(%s, %s)" % \
+               (self._print(i.min), self._print(i.max))
 
     def _print_Inverse(self, I):
-        return "%s^-1" % self.parenthesize(I.arg, PRECEDENCE["Pow"])
+        return "%s**-1" % self.parenthesize(I.arg, PRECEDENCE["Pow"])
 
     def _print_Lambda(self, obj):
         args, expr = obj.args
@@ -468,7 +460,7 @@ class StrPrinter(Printer):
         return format % (' '.join(terms), ', '.join(gens))
 
     def _print_ProductSet(self, p):
-        return ' x '.join(self._print(set) for set in p.sets)
+        return ' * '.join(self._print(set) for set in p.sets)
 
     def _print_AlgebraicNumber(self, expr):
         if expr.is_aliased:
@@ -663,7 +655,7 @@ class StrPrinter(Printer):
         return "Uniform(%s, %s)" % (expr.a, expr.b)
 
     def _print_Union(self, expr):
-        return ' U '.join(self._print(set) for set in expr.args)
+        return 'Union(' + ', '.join(self._print(set) for set in expr.args) + ')'
 
     def _print_Complement(self, expr):
         return ' \ '.join(self._print(set) for set in expr.args)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -156,17 +156,17 @@ def test_Integral():
 
 def test_Interval():
     a = Symbol('a', real=True)
-    assert str(Interval(0, a)) == "[0, a]"
-    assert str(Interval(0, a, False, False)) == "[0, a]"
-    assert str(Interval(0, a, True, False)) == "(0, a]"
-    assert str(Interval(0, a, False, True)) == "[0, a)"
-    assert str(Interval(0, a, True, True)) == "(0, a)"
+    assert str(Interval(0, a)) == "Interval(0, a)"
+    assert str(Interval(0, a, False, False)) == "Interval(0, a)"
+    assert str(Interval(0, a, True, False)) == "Interval(0, a, True, False)"
+    assert str(Interval(0, a, False, True)) == "Interval(0, a, False, True)"
+    assert str(Interval(0, a, True, True)) == "Interval(0, a, True, True)"
 
 
 def test_AccumBounds():
     a = Symbol('a', real=True)
-    assert str(AccumBounds(0, a)) == "<0, a>"
-    assert str(AccumBounds(0, 1)) == "<0, 1>"
+    assert str(AccumBounds(0, a)) == "AccumBounds(0, a)"
+    assert str(AccumBounds(0, 1)) == "AccumBounds(0, 1)"
 
 
 def test_Lambda():
@@ -671,8 +671,8 @@ def test_RandomDomain():
 
 
 def test_FiniteSet():
-    assert str(FiniteSet(*range(1, 51))) == '{1, 2, 3, ..., 48, 49, 50}'
-    assert str(FiniteSet(*range(1, 6))) == '{1, 2, 3, 4, 5}'
+    assert str(FiniteSet(*range(1, 51))) == 'FiniteSet(1, 2, 3, ..., 48, 49, 50)'
+    assert str(FiniteSet(*range(1, 6))) == 'FiniteSet(1, 2, 3, 4, 5)'
 
 
 def test_PrettyPoly():
@@ -733,8 +733,8 @@ def test_Xor():
     assert str(Xor(y, x, evaluate=False)) == "Xor(x, y)"
 
 def test_Complement():
-    assert str(Complement(S.Reals, S.Naturals)) == '(-oo, oo) \ Naturals()'
+    assert str(Complement(S.Reals, S.Naturals)) == 'Interval(-oo, oo, True, True) \ Naturals()'
 
 def test_SymmetricDifference():
     assert str(SymmetricDifference(Interval(2,3), Interval(3,4),evaluate=False)) == \
-           'SymmetricDifference([2, 3], [3, 4])'
+           'SymmetricDifference(Interval(2, 3), Interval(3, 4))'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -733,7 +733,7 @@ def test_Xor():
     assert str(Xor(y, x, evaluate=False)) == "Xor(x, y)"
 
 def test_Complement():
-    assert str(Complement(S.Reals, S.Naturals)) == 'Interval(-oo, oo, True, True) \ Naturals()'
+    assert str(Complement(S.Reals, S.Naturals)) == 'Interval(-oo, oo, True, True) \ S.Naturals'
 
 def test_SymmetricDifference():
     assert str(SymmetricDifference(Interval(2,3), Interval(3,4),evaluate=False)) == \

--- a/sympy/series/sequences.py
+++ b/sympy/series/sequences.py
@@ -343,7 +343,7 @@ class SeqExpr(SeqBase):
     >>> s.gen
     (1, 2, 3)
     >>> s.interval
-    [0, 10]
+    Interval(0, 10)
     >>> s.length
     11
 
@@ -684,7 +684,7 @@ class SeqExprOp(SeqBase):
     >>> s.gen
     (n**2, (1, 2, 3))
     >>> s.interval
-    [5, 10]
+    Interval(5, 10)
     >>> s.length
     6
 

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -19,7 +19,7 @@ class Contains(BooleanFunction):
     False
     >>> i = Symbol('i', integer=True)
     >>> Contains(i, S.Naturals)
-    Contains(i, Naturals())
+    Contains(i, S.Naturals)
 
     References
     ==========

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -203,7 +203,7 @@ class ImageSet(Set):
     False
 
     >>> FiniteSet(0, 1, 2, 3, 4, 5, 6, 7, 9, 10).intersect(squares)
-    {1, 4, 9}
+    FiniteSet(1, 4, 9)
 
     >>> square_iterable = iter(squares)
     >>> for i in range(4):
@@ -486,17 +486,17 @@ def normalize_theta_set(theta):
     >>> from sympy.sets.fancysets import normalize_theta_set
     >>> from sympy import Interval, FiniteSet, pi
     >>> normalize_theta_set(Interval(9*pi/2, 5*pi))
-    [pi/2, pi]
+    Interval(pi/2, pi)
     >>> normalize_theta_set(Interval(-3*pi/2, pi/2))
-    [0, 2*pi)
+    Interval(0, 2*pi, False, True)
     >>> normalize_theta_set(Interval(-pi/2, pi/2))
-    [0, pi/2] U [3*pi/2, 2*pi)
+    Union(Interval(0, pi/2), Interval(3*pi/2, 2*pi, False, True))
     >>> normalize_theta_set(Interval(-4*pi, 3*pi))
-    [0, 2*pi)
+    Interval(0, 2*pi, False, True)
     >>> normalize_theta_set(Interval(-3*pi/2, -pi/2))
-    [pi/2, 3*pi/2]
+    Interval(pi/2, 3*pi/2)
     >>> normalize_theta_set(FiniteSet(0, pi, 3*pi))
-    {0, pi}
+    FiniteSet(0, pi)
 
     """
     from sympy.functions.elementary.trigonometric import _pi_coeff as coeff
@@ -576,7 +576,7 @@ class ComplexRegion(Set):
     >>> c = Interval(1, 8)
     >>> c1 = ComplexRegion(a*b)  # Rectangular Form
     >>> c1
-    ComplexRegion([2, 3] x [4, 6], False)
+    ComplexRegion(Interval(2, 3) * Interval(4, 6), False)
 
     * c1 represents the rectangular region in complex plane
       surrounded by the coordinates (2, 4), (3, 4), (3, 6) and
@@ -584,7 +584,7 @@ class ComplexRegion(Set):
 
     >>> c2 = ComplexRegion(Union(a*b, b*c))
     >>> c2
-    ComplexRegion([2, 3] x [4, 6] U [4, 6] x [1, 8], False)
+    ComplexRegion(Union(Interval(2, 3) * Interval(4, 6), Interval(4, 6) * Interval(1, 8)), False)
 
     * c2 represents the Union of two rectangular regions in complex
       plane. One of them surrounded by the coordinates of c1 and
@@ -600,7 +600,7 @@ class ComplexRegion(Set):
     >>> theta = Interval(0, 2*S.Pi)
     >>> c2 = ComplexRegion(r*theta, polar=True)  # Polar Form
     >>> c2  # unit Disk
-    ComplexRegion([0, 1] x [0, 2*pi), True)
+    ComplexRegion(Interval(0, 1) * Interval(0, 2*pi, False, True), True)
 
     * c2 represents the region in complex plane inside the
       Unit Disk centered at the origin.
@@ -614,7 +614,7 @@ class ComplexRegion(Set):
     >>> upper_half_unit_disk = ComplexRegion(Interval(0, 1)*Interval(0, S.Pi), polar=True)
     >>> intersection = unit_disk.intersect(upper_half_unit_disk)
     >>> intersection
-    ComplexRegion([0, 1] x [0, pi], True)
+    ComplexRegion(Interval(0, 1) * Interval(0, pi), True)
     >>> intersection == upper_half_unit_disk
     True
 
@@ -693,10 +693,10 @@ class ComplexRegion(Set):
         >>> c = Interval(1, 7)
         >>> C1 = ComplexRegion(a*b)
         >>> C1.sets
-        [2, 3] x [4, 5]
+        Interval(2, 3) * Interval(4, 5)
         >>> C2 = ComplexRegion(Union(a*b, b*c))
         >>> C2.sets
-        [2, 3] x [4, 5] U [4, 5] x [1, 7]
+        Union(Interval(2, 3) * Interval(4, 5), Interval(4, 5) * Interval(1, 7))
 
         """
         return self._sets
@@ -727,10 +727,10 @@ class ComplexRegion(Set):
         >>> c = Interval(1, 7)
         >>> C1 = ComplexRegion(a*b)
         >>> C1.psets
-        ([2, 3] x [4, 5],)
+        (Interval(2, 3) * Interval(4, 5),)
         >>> C2 = ComplexRegion(Union(a*b, b*c))
         >>> C2.psets
-        ([2, 3] x [4, 5], [4, 5] x [1, 7])
+        (Interval(2, 3) * Interval(4, 5), Interval(4, 5) * Interval(1, 7))
 
         """
         if self.sets.is_ProductSet:
@@ -756,10 +756,10 @@ class ComplexRegion(Set):
         >>> c = Interval(1, 7)
         >>> C1 = ComplexRegion(a*b)
         >>> C1.a_interval
-        [2, 3]
+        Interval(2, 3)
         >>> C2 = ComplexRegion(Union(a*b, b*c))
         >>> C2.a_interval
-        [2, 3] U [4, 5]
+        Union(Interval(2, 3), Interval(4, 5))
 
         """
         a_interval = []
@@ -785,10 +785,10 @@ class ComplexRegion(Set):
         >>> c = Interval(1, 7)
         >>> C1 = ComplexRegion(a*b)
         >>> C1.b_interval
-        [4, 5]
+        Interval(4, 5)
         >>> C2 = ComplexRegion(Union(a*b, b*c))
         >>> C2.b_interval
-        [1, 7]
+        Interval(1, 7)
 
         """
         b_interval = []

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -70,18 +70,18 @@ class Set(Basic):
 
         >>> from sympy import Interval, FiniteSet
         >>> Interval(0, 1).union(Interval(2, 3))
-        [0, 1] U [2, 3]
+        Union(Interval(0, 1), Interval(2, 3))
         >>> Interval(0, 1) + Interval(2, 3)
-        [0, 1] U [2, 3]
+        Union(Interval(0, 1), Interval(2, 3))
         >>> Interval(1, 2, True, True) + FiniteSet(2, 3)
-        (1, 2] U {3}
+        Union(Interval(1, 2, True, False), FiniteSet(3))
 
         Similarly it is possible to use the '-' operator for set differences:
 
         >>> Interval(0, 2) - Interval(0, 1)
-        (1, 2]
+        Interval(1, 2, True, False)
         >>> Interval(1, 3) - FiniteSet(2)
-        [1, 2) U (2, 3]
+        Union(Interval(1, 2, False, True), Interval(2, 3, True, False))
 
         """
         return Union(self, other)
@@ -93,7 +93,7 @@ class Set(Basic):
         >>> from sympy import Interval
 
         >>> Interval(1, 3).intersect(Interval(1, 2))
-        [1, 2]
+        Interval(1, 2)
 
         >>> from sympy import imageset, Lambda, symbols, S
         >>> n, m = symbols('n m')
@@ -173,10 +173,10 @@ class Set(Basic):
 
         >>> from sympy import Interval, S
         >>> Interval(0, 1).complement(S.Reals)
-        (-oo, 0) U (1, oo)
+        Union(Interval(-oo, 0, True, True), Interval(1, oo, True, True))
 
         >>> Interval(0, 1).complement(S.UniversalSet)
-        UniversalSet() \ [0, 1]
+        UniversalSet() \ Interval(0, 1)
 
         """
         return Complement(universe, self)
@@ -389,7 +389,7 @@ class Set(Basic):
         >>> from sympy import FiniteSet, EmptySet
         >>> A = EmptySet()
         >>> A.powerset()
-        {EmptySet()}
+        FiniteSet(EmptySet())
         >>> A = FiniteSet(1, 2)
         >>> a, b, c = FiniteSet(1), FiniteSet(2), FiniteSet(1, 2)
         >>> A.powerset() == FiniteSet(a, b, c, EmptySet())
@@ -444,9 +444,9 @@ class Set(Basic):
 
         >>> from sympy import Interval
         >>> Interval(0, 1).boundary
-        {0, 1}
+        FiniteSet(0, 1)
         >>> Interval(0, 1, True, False).boundary
-        {0, 1}
+        FiniteSet(0, 1)
         """
         return self._boundary
 
@@ -526,13 +526,13 @@ class ProductSet(Set):
     >>> from sympy import Interval, FiniteSet, ProductSet
     >>> I = Interval(0, 5); S = FiniteSet(1, 2, 3)
     >>> ProductSet(I, S)
-    [0, 5] x {1, 2, 3}
+    Interval(0, 5) * FiniteSet(1, 2, 3)
 
     >>> (2, 2) in ProductSet(I, S)
     True
 
     >>> Interval(0, 1) * Interval(0, 1) # The unit square
-    [0, 1] x [0, 1]
+    Interval(0, 1) * Interval(0, 1)
 
     >>> coin = FiniteSet('H', 'T')
     >>> set(coin**2)
@@ -679,19 +679,19 @@ class Interval(Set, EvalfMixin):
 
     >>> from sympy import Symbol, Interval
     >>> Interval(0, 1)
-    [0, 1]
+    Interval(0, 1)
     >>> Interval(0, 1, False, True)
-    [0, 1)
+    Interval(0, 1, False, True)
     >>> Interval.Ropen(0, 1)
-    [0, 1)
+    Interval(0, 1, False, True)
     >>> Interval.Lopen(0, 1)
-    (0, 1]
+    Interval(0, 1, True, False)
     >>> Interval.open(0, 1)
-    (0, 1)
+    Interval(0, 1, True, True)
 
     >>> a = Symbol('a', real=True)
     >>> Interval(0, a)
-    [0, a]
+    Interval(0, a)
 
     Notes
     =====
@@ -1119,13 +1119,13 @@ class Union(Set, EvalfMixin):
 
     >>> from sympy import Union, Interval
     >>> Union(Interval(1, 2), Interval(3, 4))
-    [1, 2] U [3, 4]
+    Union(Interval(1, 2), Interval(3, 4))
 
     The Union constructor will always try to merge overlapping intervals,
     if possible. For example:
 
     >>> Union(Interval(1, 2), Interval(2, 3))
-    [1, 3]
+    Interval(1, 3)
 
     See Also
     ========
@@ -1338,12 +1338,12 @@ class Intersection(Set):
 
     >>> from sympy import Intersection, Interval
     >>> Intersection(Interval(1, 3), Interval(2, 4))
-    [2, 3]
+    Interval(2, 3)
 
     We often use the .intersect method
 
     >>> Interval(1,3).intersect(Interval(2,4))
-    [2, 3]
+    Interval(2, 3)
 
     See Also
     ========
@@ -1586,7 +1586,7 @@ class Complement(Set, EvalfMixin):
 
     >>> from sympy import Complement, FiniteSet
     >>> Complement(FiniteSet(0, 1, 2), FiniteSet(1))
-    {0, 2}
+    FiniteSet(0, 2)
 
     See Also
     =========
@@ -1711,7 +1711,7 @@ class UniversalSet(with_metaclass(Singleton, Set)):
     UniversalSet()
 
     >>> Interval(1, 2).intersect(S.UniversalSet)
-    [1, 2]
+    Interval(1, 2)
 
     See Also
     ========
@@ -1762,13 +1762,13 @@ class FiniteSet(Set, EvalfMixin):
 
     >>> from sympy import FiniteSet
     >>> FiniteSet(1, 2, 3, 4)
-    {1, 2, 3, 4}
+    FiniteSet(1, 2, 3, 4)
     >>> 3 in FiniteSet(1, 2, 3, 4)
     True
 
     >>> members = [1, 2, 3, 4]
     >>> FiniteSet(*members)
-    {1, 2, 3, 4}
+    FiniteSet(1, 2, 3, 4)
 
     References
     ==========
@@ -1984,7 +1984,7 @@ class SymmetricDifference(Set):
 
     >>> from sympy import SymmetricDifference, FiniteSet
     >>> SymmetricDifference(FiniteSet(1, 2, 3), FiniteSet(3, 4, 5))
-    {1, 2, 4, 5}
+    FiniteSet(1, 2, 4, 5)
 
     See Also
     ========
@@ -2031,13 +2031,13 @@ def imageset(*args):
     >>> x = Symbol('x')
 
     >>> imageset(x, 2*x, Interval(0, 2))
-    [0, 4]
+    Interval(0, 4)
 
     >>> imageset(lambda x: 2*x, Interval(0, 2))
-    [0, 4]
+    Interval(0, 4)
 
     >>> imageset(Lambda(x, sin(x)), Interval(-2, 1))
-    ImageSet(Lambda(x, sin(x)), [-2, 1])
+    ImageSet(Lambda(x, sin(x)), Interval(-2, 1))
 
     See Also
     ========

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -26,13 +26,13 @@ def solve_poly_inequality(poly, rel):
     >>> from sympy.solvers.inequalities import solve_poly_inequality
 
     >>> solve_poly_inequality(Poly(x, x, domain='ZZ'), '==')
-    [{0}]
+    [FiniteSet(0)]
 
     >>> solve_poly_inequality(Poly(x**2 - 1, x, domain='ZZ'), '!=')
-    [(-oo, -1), (-1, 1), (1, oo)]
+    [Interval(-oo, -1, True, True), Interval(-1, 1, True, True), Interval(1, oo, True, True)]
 
     >>> solve_poly_inequality(Poly(x**2 - 1, x, domain='ZZ'), '==')
-    [{-1}, {1}]
+    [FiniteSet(-1), FiniteSet(1)]
 
     See Also
     ========
@@ -119,7 +119,7 @@ def solve_poly_inequalities(polys):
     >>> solve_poly_inequalities(((
     ... Poly(x**2 - 3), ">"), (
     ... Poly(-x**2 + 1), ">")))
-    (-oo, -sqrt(3)) U (-1, 1) U (sqrt(3), oo)
+    Union(Interval(-oo, -sqrt(3), True, True), Interval(-1, 1, True, True), Interval(sqrt(3), oo, True, True))
     """
     from sympy import Union
     return Union(*[solve_poly_inequality(*p) for p in polys])
@@ -138,12 +138,12 @@ def solve_rational_inequalities(eqs):
     >>> solve_rational_inequalities([[
     ... ((Poly(-x + 1), Poly(1, x)), '>='),
     ... ((Poly(-x + 1), Poly(1, x)), '<=')]])
-    {1}
+    FiniteSet(1)
 
     >>> solve_rational_inequalities([[
     ... ((Poly(x), Poly(1, x)), '!='),
     ... ((Poly(-x + 1), Poly(1, x)), '>=')]])
-    (-oo, 0) U (0, 1]
+    Union(Interval(-oo, 0, True, True), Interval(0, 1, True, False))
 
     See Also
     ========
@@ -392,7 +392,7 @@ def solve_univariate_inequality(expr, gen, relational=True):
     Or(And(-oo < x, x <= -2), And(2 <= x, x < oo))
 
     >>> solve_univariate_inequality(x**2 >= 4, x, relational=False)
-    (-oo, -2] U [2, oo)
+    Union(Interval(-oo, -2, True, False), Interval(2, oo, False, True))
 
     """
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -67,16 +67,16 @@ def _invert(f_x, y, x, domain=S.Complexes):
     When does exp(x) == y?
 
     >>> invert_complex(exp(x), y, x)
-    (x, ImageSet(Lambda(_n, I*(2*_n*pi + arg(y)) + log(Abs(y))), Integers()))
+    (x, ImageSet(Lambda(_n, I*(2*_n*pi + arg(y)) + log(Abs(y))), S.Integers))
     >>> invert_real(exp(x), y, x)
-    (x, Intersection((-oo, oo), {log(y)}))
+    (x, Intersection(Interval(-oo, oo, True, True), FiniteSet(log(y))))
 
     When does exp(x) == 1?
 
     >>> invert_complex(exp(x), 1, x)
-    (x, ImageSet(Lambda(_n, 2*_n*I*pi), Integers()))
+    (x, ImageSet(Lambda(_n, 2*_n*I*pi), S.Integers))
     >>> invert_real(exp(x), 1, x)
-    (x, {0})
+    (x, FiniteSet(0))
 
     See Also
     ========
@@ -703,11 +703,11 @@ def solveset(f, symbol=None, domain=S.Complexes):
 
     >>> x = Symbol('x')
     >>> pprint(solveset(exp(x) - 1, x), use_unicode=False)
-    {2*n*I*pi | n in Integers()}
+    {2*n*I*pi | n in S.Integers}
 
     >>> x = Symbol('x', real=True)
     >>> pprint(solveset(exp(x) - 1, x), use_unicode=False)
-    {2*n*I*pi | n in Integers()}
+    {2*n*I*pi | n in S.Integers}
 
     * If you want to use `solveset` to solve the equation in the
       real domain, provide a real domain. (Using `solveset\_real`
@@ -716,25 +716,25 @@ def solveset(f, symbol=None, domain=S.Complexes):
     >>> R = S.Reals
     >>> x = Symbol('x')
     >>> solveset(exp(x) - 1, x, R)
-    {0}
+    FiniteSet(0)
     >>> solveset_real(exp(x) - 1, x)
-    {0}
+    FiniteSet(0)
 
     The solution is mostly unaffected by assumptions on the symbol,
     but there may be some slight difference:
 
     >>> pprint(solveset(sin(x)/x,x), use_unicode=False)
-    ({2*n*pi | n in Integers()} \ {0}) U ({2*n*pi + pi | n in Integers()} \ {0})
+    ({2*n*pi | n in S.Integers} \ {0}) U ({2*n*pi + pi | n in S.Integers} \ {0})
 
     >>> p = Symbol('p', positive=True)
     >>> pprint(solveset(sin(p)/p, p), use_unicode=False)
-    {2*n*pi | n in Integers()} U {2*n*pi + pi | n in Integers()}
+    {2*n*pi | n in S.Integers} U {2*n*pi + pi | n in S.Integers}
 
     * Inequalities can be solved over the real domain only. Use of a complex
       domain leads to a NotImplementedError.
 
     >>> solveset(exp(x) > 1, x, R)
-    (0, oo)
+    Interval(0, oo, True, True)
 
     """
     f = sympify(f)
@@ -1008,7 +1008,7 @@ def linsolve(system, *symbols):
     [6],
     [9]])
     >>> linsolve((A, b), [x, y, z])
-    {(-1, 2, 0)}
+    FiniteSet((-1, 2, 0))
 
     * Parametric Solution: In case the system is under determined, the function
       will return parametric solution in terms of the given symbols.
@@ -1019,13 +1019,13 @@ def linsolve(system, *symbols):
     >>> A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> b = Matrix([3, 6, 9])
     >>> linsolve((A, b), [x, y, z])
-    {(z - 1, -2*z + 2, z)}
+    FiniteSet((z - 1, -2*z + 2, z))
 
     * List of Equations as input
 
     >>> Eqns = [3*x + 2*y - z - 1, 2*x - 2*y + 4*z + 2, - x + S(1)/2*y - z]
     >>> linsolve(Eqns, x, y, z)
-    {(1, -2, -2)}
+    FiniteSet((1, -2, -2))
 
     * Augmented Matrix as input
 
@@ -1036,21 +1036,21 @@ def linsolve(system, *symbols):
     [2, 6,  8, 3],
     [6, 8, 18, 5]])
     >>> linsolve(aug, x, y, z)
-    {(3/10, 2/5, 0)}
+    FiniteSet((3/10, 2/5, 0))
 
     * Solve for symbolic coefficients
 
     >>> a, b, c, d, e, f = symbols('a, b, c, d, e, f')
     >>> eqns = [a*x + b*y - c, d*x + e*y - f]
     >>> linsolve(eqns, x, y)
-    {((-b*f + c*e)/(a*e - b*d), (a*f - c*d)/(a*e - b*d))}
+    FiniteSet(((-b*f + c*e)/(a*e - b*d), (a*f - c*d)/(a*e - b*d)))
 
     * A degenerate system returns solution as set of given
       symbols.
 
     >>> system = Matrix(([0,0,0], [0,0,0], [0,0,0]))
     >>> linsolve(system, x, y)
-    {(x, y)}
+    FiniteSet((x, y))
 
     * For an empty system linsolve returns empty set
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -780,7 +780,7 @@ def where(condition, given_condition=None, **kwargs):
     Domain: And(-1 < x, x < 1)
 
     >>> where(X**2<1).set
-    (-1, 1)
+    Interval(-1, 1, True, True)
 
     >>> where(And(D1<=D2 , D2<3))
     Domain: Or(And(Eq(a, 1), Eq(b, 1)), And(Eq(a, 1), Eq(b, 2)), And(Eq(a, 2), Eq(b, 2)))    """


### PR DESCRIPTION
Addresses #10672 

I changed the printing of `FiniteSet` from the bracket-enclosed form `{ , , ... , , }` to `FiniteSet( , , ... , ,)`. This was needed as `{ }` enclosed elements are thought of as python dictionaries by the interpreter, and our requirement is that whatever is output by `str` should be able to reproduce the expression.

Edit: I meant python set, not dictionary. 
