### PR TITLE
[Not for merge] General form for list of args

### DIFF
--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -28,5 +28,6 @@ from .inequalities import reduce_inequalities, reduce_abs_inequality, \
     reduce_abs_inequalities, solve_poly_inequality, solve_rational_inequalities, solve_univariate_inequality
 
 from .decompogen import decompogen
+from .genform import genform
 
 from .solveset import solveset, linsolve, linear_eq_to_matrix

--- a/sympy/solvers/genform.py
+++ b/sympy/solvers/genform.py
@@ -1,0 +1,48 @@
+from sympy.solvers.solveset import linsolve
+from sympy import S, Dummy, Symbol, pi
+from sympy.simplify import (simplify, collect, powsimp, posify, powdenest,
+                            nsimplify, denom, logcombine)
+from sympy.polys import factor
+from sympy.solvers.solvers import solve
+from sympy.sets import ConditionSet, imageset
+from sympy.core.function import Lambda
+
+
+def genform(*args):
+    """
+    To compute General Form of any system.
+    Right now able to generate linear general form
+    Examples
+    ========
+
+    >>> from sympy.solvers.genform import genform
+    >>> from sympy.abc import x
+    >>> from sympy import sqrt, sin, cos
+    >>> from sympy.solvers.solvers import solve
+    >>> genform(pi/6,pi/2,pi)
+    ImageSet(Lambda(_n, pi*(2*_n - 1)/6), Naturals())
+    >>> genform(pi/2 , 3*pi/2)
+    ImageSet(Lambda(_n, pi*(2*_n - 1)/2), Naturals())
+    >>> genform(solve((sin(x)-1)*(sin(x)+1),x)[1],solve((sin(x)-1)*(sin(x)+1),x)[2])
+    ImageSet(Lambda(_n, pi*(2*_n - 1)/2), Naturals())
+
+
+    TODO implement for quadratic general form.
+    """
+    if len(args) == 1:
+        return args[0]
+    # TODO check linear general form or quadratic general form.
+    # https://github.com/sympy/sympy/wiki/
+    #          Solveset-and-Solver-Discussion#simplified-general-form-for-trigonometric-solution
+    else:
+        a = Dummy('a', real=True)
+        b = Dummy('b', real=True)
+        n = Dummy('n', real =True)
+        equations = []
+        for i in xrange(0,len(args)):
+            eq = a*(i+1) + b - args[i]
+            equations.append(eq)
+
+        a, b= list(linsolve(equations,(a,b)))[0]
+        res = simplify(a*n + b)
+        return imageset(Lambda(n, factor(res)), S.Naturals)


### PR DESCRIPTION
As I discussed here :
[wiki/Solveset-and-Solver-Discussion](https://github.com/sympy/sympy/wiki/Solveset-and-Solver-Discussion#simplified-general-form-for-trigonometric-solution) `solveset` need a method that can generalize `args`.
We can simplify the trigonometric solutions ,if we generalize them ,rather than sending each solution into  [solvers/solveset.py#L98](https://github.com/sympy/sympy/blob/master/sympy/solvers/solveset.py#L98).
Another thing is, if solution is `-pi/2` then convert this to positive `3*pi/2`; then generalize.This will give more known general form.
`genform` can be helpful for some other work also.

```
>>> genform(solve((sin(x)-1)*(sin(x)+1),x)[1],solve((sin(x)-1)*(sin(x)+1),x)[2])
⎧π⋅(2⋅n - 1)        ⎫
⎨─────────── | n ∊ ℕ⎬
⎩     2             ⎭

>>> solve((sin(x)-1)*(sin(x)+1),x)
⎡-π   π  3⋅π⎤
⎢───, ─, ───⎥
⎣ 2   2   2 ⎦

>>> solveset((sin(x)-1)*(sin(x)+1),x,S.Reals)
⎧        π        ⎫   ⎧        π        ⎫
⎨2⋅n⋅π - ─ | n ∊ ℤ⎬ ∪ ⎨2⋅n⋅π + ─ | n ∊ ℤ⎬
⎩        2        ⎭   ⎩        2        ⎭


```

This PR is just for discussion purpose.Any type of comment/suggestions will be appreciated.
