### PR TITLE
Fixed typo in documentation of asech

### DIFF
--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -539,8 +539,7 @@ def test_asech():
     assert asech(2/sqrt(2 + sqrt(2))) == acosh(sqrt(2 + sqrt(2))/2)
     assert asech(S(2)) == acosh(1/S(2))
 
-    # asech(x) == I*acos(x)
-    # (Note: the exact formula is asech(x) == +/- I*acos(x))
+    # asech(x) == I*acos(1/x)
     assert asech(-sqrt(2)) == I*acos(-1/sqrt(2))
     assert asech(-2/sqrt(3)) == I*acos(-sqrt(3)/2)
     assert asech(-S(2)) == I*acos(-S.Half)

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -540,6 +540,7 @@ def test_asech():
     assert asech(S(2)) == acosh(1/S(2))
 
     # asech(x) == I*acos(1/x)
+    # (Note: the exact formula is asech(x) == +/- I*acos(1/x))
     assert asech(-sqrt(2)) == I*acos(-1/sqrt(2))
     assert asech(-2/sqrt(3)) == I*acos(-sqrt(3)/2)
     assert asech(-S(2)) == I*acos(-S.Half)


### PR DESCRIPTION
The range of `acos(x)` is `[0,pi]` . Hence `asech(x) = + I*acos(1/x)`
