### PR TITLE
Implemented a separate solver for equations containing Hyperbolic functions

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -386,6 +386,10 @@ def _solve_real_trig(f, symbol):
     else:
         return ConditionSet(symbol, Eq(f_original, 0), S.Reals)
 
+def _solve_hyperbolic(f, symbol):
+    """ Helper to solve hyperbolic equations """
+    g = f.rewrite(exp)
+    return solveset_complex(g, symbol)
 
 def _solve_as_poly(f, symbol, domain=S.Complexes):
     """
@@ -572,9 +576,10 @@ def _solveset(f, symbol, domain, _check=False):
         # wrong solutions we are using this technique only if both f and g are
         # finite for a finite input.
         result = Union(*[solver(m, symbol) for m in f.args])
-    elif _is_function_class_equation(TrigonometricFunction, f, symbol) or \
-            _is_function_class_equation(HyperbolicFunction, f, symbol):
+    elif _is_function_class_equation(TrigonometricFunction, f, symbol):
         result = _solve_real_trig(f, symbol)
+    elif _is_function_class_equation(HyperbolicFunction, f, symbol):
+        result = _solve_hyperbolic(f, symbol)
     elif f.is_Piecewise:
         dom = domain
         result = EmptySet()

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,7 +1,7 @@
 from sympy import (
     Abs, Dummy, Eq, Gt, Function,
     LambertW, Piecewise, Poly, Rational, S, Symbol, Matrix,
-    asin, acos, acsc, asec, atan, atanh, cos, csc, erf, erfinv, erfc, erfcinv,
+    asin, acos, acsc, asec, atan, atanh, cos, cosh, csc, erf, erfinv, erfc, erfcinv,
     exp, log, pi, sin, sinh, sec, sqrt, symbols,
     tan, tanh, atan2, arg,
     Lambda, imageset, cot, acot, I, EmptySet, Union, E, Interval, Intersection,
@@ -858,6 +858,15 @@ def test_solve_lambert():
     assert solveset_real(5**(x/2) - 2**(x/3), x) == FiniteSet(0)
     b = sqrt(6)*sqrt(log(2))/sqrt(log(5))
     assert solveset_real(5**(x/2) - 2**(3/x), x) == FiniteSet(-b, b)
+
+
+def test_solve_hyperbolic():
+    x = Symbol('x')
+    n = Dummy('n')
+    assert solveset(sinh(x), x) == ImageSet(Lambda(n, n*I*pi),S.Integers)
+    assert solveset(sinh(x)+cosh(x) + 1,x) == ImageSet(Lambda(n, I*(2*n*pi + pi)), S.Integers)
+    assert solveset(sinh(x)+cosh(x),x) == S.EmptySet
+    assert solveset(sinh(x)+cos(x),x) == ConditionSet(x, Eq(cos(x) + sinh(x), 0), S.Complexes)
 
 
 def test_solveset():


### PR DESCRIPTION
Before, we used to get a ConditionSet for a solvable equation

``` python
In [ ]: solveset(sinh(x), x)
Out[ ]: 
⎧            ⎛ 2⋅x    ⎞  -x    ⎫
⎪            ⎝ℯ    - 1⎠⋅ℯ      ⎪
⎨x | x ∊ ℝ ∧ ────────────── = 0⎬
⎪                  2           ⎪
⎩                              ⎭
```

Now:

``` python
In [ ]: solveset(sinh(x), x)
Out[ ]: {n⋅ⅈ⋅π | n ∊ ℤ}
```
- [x] Implemented solver
- [x] Added tests
- [x] fixes #9531
- [x] fixes #9606

I think we should have separate solver for handling Hyperbolic functions.
Since, both `solveset_real` and `solveset_complex` are merely wrapper on `solveset`, separating the solver for Trigonometric Equations and Hyperbolic Equations would be a better idea.

Reference: [Comment](https://github.com/sympy/sympy/pull/9750#issuecomment-126755568)

Ping @aktech @hargup @smichr @asmeurer 
