### PR TITLE
Amended missing whitespaces from test_subs.py

### DIFF
--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -622,14 +622,14 @@ def test_mul2():
 
 def test_noncommutative_subs():
     x,y = symbols('x,y', commutative=False)
-    assert (x*y*x).subs([(x,x*y),(y,x)],simultaneous=True) == (x*y*x**2*y)
+    assert (x*y*x).subs([(x, x*y), (y, x)], simultaneous=True) == (x*y*x**2*y)
 
 
 def test_issue_2877():
     f = Float(2.0)
     assert (x + f).subs({f: 2}) == x + 2
 
-    def r(a,b,c):
+    def r(a, b, c):
         return factor(a*x**2 + b*x + c)
     e = r(5/6, 10, 5)
     assert nsimplify(e) == 5*x**2/6 + 10*x + 5


### PR DESCRIPTION
There were missing whitespaces introduced to test_subs.py. This has now been amended. Thank you.
