### PR TITLE
Allow TensorProduct for ImmutableMatrices

### DIFF
--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy import Expr, Add, Mul, Matrix, Pow, sympify
+from sympy import Expr, Add, Mul, MatrixBase, Pow, sympify
 from sympy.core.compatibility import u, range
 from sympy.core.trace import Tr
 from sympy.printing.pretty.stringpict import prettyForm
@@ -117,7 +117,7 @@ class TensorProduct(Expr):
     is_commutative = False
 
     def __new__(cls, *args):
-        if isinstance(args[0], (Matrix, numpy_ndarray, scipy_sparse_matrix)):
+        if isinstance(args[0], (MatrixBase, numpy_ndarray, scipy_sparse_matrix)):
             return matrix_tensor_product(*args)
         c_part, new_args = cls.flatten(sympify(args))
         c_part = Mul(*c_part)

--- a/sympy/physics/quantum/tests/test_matrixutils.py
+++ b/sympy/physics/quantum/tests/test_matrixutils.py
@@ -1,6 +1,6 @@
 from random import randint
 
-from sympy import Matrix, zeros, ones, Integer
+from sympy import Matrix, zeros, ones, Integer, ImmutableMatrix
 
 from sympy.physics.quantum.matrixutils import (
     to_sympy, to_numpy, to_scipy_sparse, matrix_tensor_product,
@@ -37,65 +37,77 @@ def test_matrix_tensor_product():
     if not np:
         skip("numpy not installed.")
 
-    l1 = zeros(4)
-    for i in range(16):
-        l1[i] = 2**i
-    l2 = zeros(4)
-    for i in range(16):
-        l2[i] = i
-    l3 = zeros(2)
-    for i in range(4):
-        l3[i] = i
-    vec = Matrix([1, 2, 3])
+    for M in [Matrix, ImmutableMatrix]:
+        l1 = zeros(4)
+        for i in range(16):
+            l1[i] = 2**i
+        l1 = M(l1)
+        l2 = zeros(4)
+        for i in range(16):
+            l2[i] = i
+        l2 = M(l2)
+        l3 = zeros(2)
+        for i in range(4):
+            l3[i] = i
+        l3 = M(l3)
+        vec = M([1, 2, 3])
 
-    #test for Matrix known 4x4 matricies
-    numpyl1 = np.matrix(l1.tolist())
-    numpyl2 = np.matrix(l2.tolist())
-    numpy_product = np.kron(numpyl1, numpyl2)
-    args = [l1, l2]
-    sympy_product = matrix_tensor_product(*args)
-    assert numpy_product.tolist() == sympy_product.tolist()
-    numpy_product = np.kron(numpyl2, numpyl1)
-    args = [l2, l1]
-    sympy_product = matrix_tensor_product(*args)
-    assert numpy_product.tolist() == sympy_product.tolist()
+        #test for Matrix known 4x4 matricies
+        numpyl1 = np.matrix(l1.tolist())
+        numpyl2 = np.matrix(l2.tolist())
+        numpy_product = np.kron(numpyl1, numpyl2)
+        args = [l1, l2]
+        sympy_product = matrix_tensor_product(*args)
+        assert numpy_product.tolist() == sympy_product.tolist()
+        numpy_product = np.kron(numpyl2, numpyl1)
+        args = [l2, l1]
+        sympy_product = matrix_tensor_product(*args)
+        assert numpy_product.tolist() == sympy_product.tolist()
 
-    #test for other known matrix of different dimensions
-    numpyl2 = np.matrix(l3.tolist())
-    numpy_product = np.kron(numpyl1, numpyl2)
-    args = [l1, l3]
-    sympy_product = matrix_tensor_product(*args)
-    assert numpy_product.tolist() == sympy_product.tolist()
-    numpy_product = np.kron(numpyl2, numpyl1)
-    args = [l3, l1]
-    sympy_product = matrix_tensor_product(*args)
-    assert numpy_product.tolist() == sympy_product.tolist()
+        #test for other known matrix of different dimensions
+        numpyl2 = np.matrix(l3.tolist())
+        numpy_product = np.kron(numpyl1, numpyl2)
+        args = [l1, l3]
+        sympy_product = matrix_tensor_product(*args)
+        assert numpy_product.tolist() == sympy_product.tolist()
+        numpy_product = np.kron(numpyl2, numpyl1)
+        args = [l3, l1]
+        sympy_product = matrix_tensor_product(*args)
+        assert numpy_product.tolist() == sympy_product.tolist()
 
-    #test for non square matrix
-    numpyl2 = np.matrix(vec.tolist())
-    numpy_product = np.kron(numpyl1, numpyl2)
-    args = [l1, vec]
-    sympy_product = matrix_tensor_product(*args)
-    assert numpy_product.tolist() == sympy_product.tolist()
-    numpy_product = np.kron(numpyl2, numpyl1)
-    args = [vec, l1]
-    sympy_product = matrix_tensor_product(*args)
-    assert numpy_product.tolist() == sympy_product.tolist()
+        #test for non square matrix
+        numpyl2 = np.matrix(vec.tolist())
+        numpy_product = np.kron(numpyl1, numpyl2)
+        args = [l1, vec]
+        sympy_product = matrix_tensor_product(*args)
+        assert numpy_product.tolist() == sympy_product.tolist()
+        numpy_product = np.kron(numpyl2, numpyl1)
+        args = [vec, l1]
+        sympy_product = matrix_tensor_product(*args)
+        assert numpy_product.tolist() == sympy_product.tolist()
 
-    #test for random matrix with random values that are floats
-    random_matrix1 = np.random.rand(randint(1, 5), randint(1, 5))
-    random_matrix2 = np.random.rand(randint(1, 5), randint(1, 5))
-    numpy_product = np.kron(random_matrix1, random_matrix2)
-    args = [Matrix(random_matrix1.tolist()), Matrix(random_matrix2.tolist())]
-    sympy_product = matrix_tensor_product(*args)
-    assert not (sympy_product - Matrix(numpy_product.tolist())).tolist() > \
-        (ones(sympy_product.rows, sympy_product.cols)*epsilon).tolist()
+        #test for random matrix with random values that are floats
+        random_matrix1 = np.random.rand(randint(1, 5), randint(1, 5))
+        random_matrix2 = np.random.rand(randint(1, 5), randint(1, 5))
+        numpy_product = np.kron(random_matrix1, random_matrix2)
+        args = [Matrix(random_matrix1.tolist()), Matrix(random_matrix2.tolist())]
+        sympy_product = matrix_tensor_product(*args)
+        assert not (sympy_product - Matrix(numpy_product.tolist())).tolist() > \
+            (ones(sympy_product.rows, sympy_product.cols)*epsilon).tolist()
 
-    #test for three matrix kronecker
-    sympy_product = matrix_tensor_product(l1, vec, l2)
+        #test for three matrix kronecker
+        sympy_product = matrix_tensor_product(l1, vec, l2)
 
-    numpy_product = np.kron(l1, np.kron(vec, l2))
-    assert numpy_product.tolist() == sympy_product.tolist()
+        numpy_product = np.kron(l1, np.kron(vec, l2))
+        assert numpy_product.tolist() == sympy_product.tolist()
+
+    m1 = ones(2)
+    m2 = ones(2).as_immutable()
+    assert isinstance(matrix_tensor_product(m1, m2), ImmutableMatrix)
+    assert isinstance(matrix_tensor_product(m2, m1), ImmutableMatrix)
+    assert isinstance(matrix_tensor_product(m1, m1, m2), ImmutableMatrix)
+    assert isinstance(matrix_tensor_product(m2, m1, m1), ImmutableMatrix)
+    assert isinstance(matrix_tensor_product(m1, m2, m1), ImmutableMatrix)
 
 
 scipy = import_module('scipy', __import__kwargs={'fromlist': ['sparse']})

--- a/sympy/physics/quantum/tests/test_tensorproduct.py
+++ b/sympy/physics/quantum/tests/test_tensorproduct.py
@@ -1,4 +1,4 @@
-from sympy import I, symbols, Matrix
+from sympy import I, symbols, Matrix, ImmutableMatrix
 
 from sympy.physics.quantum.commutator import Commutator as Comm
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -32,6 +32,15 @@ def test_tensor_product_abstract():
     assert isinstance(TP(A, B), TP)
     assert TP(A, B).subs(A, C) == TP(C, B)
 
+def test_tensor_product_matrix():
+    assert isinstance(TensorProduct(mat1, mat2), Matrix)
+    assert isinstance(TensorProduct(mat1, mat2.as_immutable()),
+                      ImmutableMatrix)
+    assert isinstance(TensorProduct(mat1.as_immutable(), mat2),
+                      ImmutableMatrix)
+    assert isinstance(TensorProduct(mat1.as_immutable(),
+                                    mat2.as_immutable()),
+                      ImmutableMatrix)
 
 def test_tensor_product_expand():
     assert TP(A + B, B + C).expand(tensorproduct=True) == \


### PR DESCRIPTION
Fixes #10734

Currently, attempting to call `TensorProduct` with an ImmutableMatrix leads to an error.
These commits make a couple of small changes to fix these errors so things work as expect.

``` python
>>> from sympy import *
>>> from sympy.physics.quantum.tensorproduct import TensorProduct
>>> M = eye(2).as_immutable()
>>> N = eye(2).as_immutable()
>>> MN = TensorProduct(M, N)
>>> MN
Matrix([
[1, 0, 0, 0],
[0, 1, 0, 0],
[0, 0, 1, 0],
[0, 0, 0, 1]])
>>> type(MN)
<class 'sympy.matrices.immutable.ImmutableMatrix'>
```

I wasn't sure how much it was okay to modify the tests, so I left those changes as a separate commit.
