### PR TITLE
Fixing simpify (evaluate = False) for Unary Operators - Issue #10560

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -931,6 +931,11 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         if node.op.__class__ in self.operators:
             sympy_class = self.operators[node.op.__class__]
             right = self.visit(node.right)
+            left = self.visit(node.left)
+            if isinstance(node.left, ast.UnaryOp) and (isinstance(node.right, ast.UnaryOp) == 0) and sympy_class in ('Mul','Pow'):
+                temp = right
+                right = left
+                left = temp
 
             if isinstance(node.op, ast.Sub):
                 right = ast.UnaryOp(op=ast.USub(), operand=right)
@@ -945,7 +950,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
 
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
-                args=[self.visit(node.left), right],
+                args=[left, right],
                 keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
                 starargs=None,
                 kwargs=None

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -592,7 +592,6 @@ class Lambdifier(object):
                 template = 'float(%s)' % template
             elif self.complex_wrap_evalf:
                 template = 'complex(%s)' % template
-            
             # Wrapping should only happen on the outermost expression, which
             # is the only thing we know will be a number.
             float_wrap_evalf = self.float_wrap_evalf

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -116,10 +116,10 @@ class vectorized_lambdify(object):
         np_old_err = np.seterr(invalid='raise')
         try:
             temp_args = (np.array(a, dtype=np.complex) for a in args)
+            self.lambda_func = experimental_lambdify(self.args, self.expr, use_evalf=True,complex_wrap_evalf=True)
+            self.vector_func = np.vectorize(self.lambda_func, otypes=[np.complex])
             results = self.vector_func(*temp_args)
-            results = np.ma.masked_where(
-                                np.abs(results.imag) > 1e-7 * np.abs(results),
-                                results.real, copy=False)
+            results = np.ma.masked_where(np.abs(results.imag) > 1e-7 * np.abs(results),results.real, copy=False)
         except Exception as e:
             #DEBUG: print 'Error', type(e), e
             if ((isinstance(e, TypeError)
@@ -592,7 +592,7 @@ class Lambdifier(object):
                 template = 'float(%s)' % template
             elif self.complex_wrap_evalf:
                 template = 'complex(%s)' % template
-
+            
             # Wrapping should only happen on the outermost expression, which
             # is the only thing we know will be a number.
             float_wrap_evalf = self.float_wrap_evalf
@@ -603,7 +603,6 @@ class Lambdifier(object):
             self.float_wrap_evalf = float_wrap_evalf
             self.complex_wrap_evalf = complex_wrap_evalf
             return ret
-
     ##############################################################################
     # The namespace constructors
     ##############################################################################


### PR DESCRIPTION
`>>> sympify('4*-3', evaluate=False)`
`(-3)*4`
