### PR TITLE
fixed #10719: eigenvals of empty matrix raises IndexError

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3032,7 +3032,10 @@ class MatrixBase(object):
         # roots doesn't like Floats, so replace them with Rationals
         # unless the nsimplify flag indicates that this has already
         # been done, e.g. in eigenvects
+
         mat = self
+        if( not mat ):
+        	return {}
         if flags.pop('rational', True):
             if any(v.has(Float) for v in mat):
                 mat = mat._new(mat.rows, mat.cols,

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3034,7 +3034,7 @@ class MatrixBase(object):
         # been done, e.g. in eigenvects
         mat = self
 
-        if( not mat ):
+        if not mat:
             return {}
         if flags.pop('rational', True):
             if any(v.has(Float) for v in mat):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3032,10 +3032,10 @@ class MatrixBase(object):
         # roots doesn't like Floats, so replace them with Rationals
         # unless the nsimplify flag indicates that this has already
         # been done, e.g. in eigenvects
-
         mat = self
+
         if( not mat ):
-        	return {}
+            return {}
         if flags.pop('rational', True):
             if any(v.has(Float) for v in mat):
                 mat = mat._new(mat.rows, mat.cols,

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -927,8 +927,9 @@ def test_eigen():
     sevals = list(sorted(evals.keys()))
     assert all(abs(nevals[i] - sevals[i]) < 1e-9 for i in range(len(nevals)))
 
-    # issue _
+    # issue 10719
     assert Matrix([]).eigenvals() == {}
+    assert Matrix([]).eigenvects() == []
 
 
 def test_subs():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -927,6 +927,9 @@ def test_eigen():
     sevals = list(sorted(evals.keys()))
     assert all(abs(nevals[i] - sevals[i]) < 1e-9 for i in range(len(nevals)))
 
+    # issue _
+    assert Matrix([]).eigenvals() == {}
+
 
 def test_subs():
     assert Matrix([[1, x], [x, 4]]).subs(x, 5) == Matrix([[1, 5], [5, 4]])


### PR DESCRIPTION
Now,

```
>>> Matrix([]).eigenvals()
{}
```

fixed #10719
