### PR TITLE
Fixes #10710: Use instances of Mapping rather than dict in subs

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,5 +1,6 @@
 """Base class for all the objects in SymPy"""
 from __future__ import print_function, division
+from collections import Mapping
 
 from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit
@@ -833,7 +834,7 @@ class Basic(with_metaclass(ManagedProperties)):
             sequence = args[0]
             if isinstance(sequence, set):
                 unordered = True
-            elif isinstance(sequence, (Dict, dict)):
+            elif isinstance(sequence, (Dict, Mapping)):
                 unordered = True
                 sequence = sequence.items()
             elif not iterable(sequence):

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -1,6 +1,8 @@
 """This tests sympy/core/basic.py with (ideally) no reference to subclasses
 of Basic or Atom."""
 
+from collections import ChainMap, OrderedDict
+
 from sympy.core.basic import Basic, Atom, preorder_traversal
 from sympy.core.singleton import S, Singleton
 from sympy.core.symbol import symbols
@@ -64,6 +66,8 @@ def test_subs():
     assert b21.subs([(b2, b1), (b1, b2)]) == Basic(b2, b2)
 
     assert b21.subs({b1: b2, b2: b1}) == Basic(b2, b2)
+    assert b21.subs(ChainMap({b1: b2}, {b2: b1})) == Basic(b2, b2)
+    assert b21.subs(OrderedDict([(b2, b1), (b1, b2)])) == Basic(b2, b2)
 
     raises(ValueError, lambda: b21.subs('bad arg'))
     raises(ValueError, lambda: b21.subs(b1, b2, b3))

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -1,7 +1,8 @@
 """This tests sympy/core/basic.py with (ideally) no reference to subclasses
 of Basic or Atom."""
 
-from collections import ChainMap, OrderedDict
+import collections
+import sys
 
 from sympy.core.basic import Basic, Atom, preorder_traversal
 from sympy.core.singleton import S, Singleton
@@ -66,8 +67,10 @@ def test_subs():
     assert b21.subs([(b2, b1), (b1, b2)]) == Basic(b2, b2)
 
     assert b21.subs({b1: b2, b2: b1}) == Basic(b2, b2)
-    assert b21.subs(ChainMap({b1: b2}, {b2: b1})) == Basic(b2, b2)
-    assert b21.subs(OrderedDict([(b2, b1), (b1, b2)])) == Basic(b2, b2)
+    if sys.version_info >= (3, 3):
+        assert b21.subs(collections.ChainMap({b1: b2}, {b2: b1})) == Basic(b2, b2)
+    if sys.version_info >= (2, 7):
+        assert b21.subs(collections.OrderedDict([(b2, b1), (b1, b2)])) == Basic(b2, b2)
 
     raises(ValueError, lambda: b21.subs('bad arg'))
     raises(ValueError, lambda: b21.subs(b1, b2, b3))


### PR DESCRIPTION
Fixes #10710. All standard library `dict`-like objects are instances of `Mapping` thus, `OrderedDict`, `ChainMap`, etc., can now be a drop-in replacement for a `dict` in substitutions. Rather than having to wrap the object in a `dict` call.

In Python 3.3 `collections.abc` separated, however to keep compatibility with `sys.version_info < (3,3)`
`from collections import Mapping` works for newer and older versions of Python.
