### PR TITLE
Amended E202 on test_zeta_functions.py line 182

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -179,7 +179,7 @@ def test_stieltjes():
 def test_stieltjes_evalf():
     assert abs(stieltjes(0).evalf() - 0.577215664) < 1E-9
     assert abs(stieltjes(0, 0.5).evalf() - 1.963510026) < 1E-9
-    assert abs(stieltjes(1, 2).evalf() + 0.072815845 ) < 1E-9
+    assert abs(stieltjes(1, 2).evalf() + 0.072815845) < 1E-9
 
 
 def test_issue_10475():


### PR DESCRIPTION
There was E202 (extra white space before closing bracket) in `sympy/functions/special/tests/test_zeta_functions.py`, line 182. This has been amended.
