### PR TITLE
Modified some tests for solveset

### DIFF
--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -190,6 +190,8 @@ def test_is_function_class_equation():
     assert _is_function_class_equation(TrigonometricFunction,
                                        tan(x)**2 + sin(x) - 1, x) is True
     assert _is_function_class_equation(TrigonometricFunction,
+                                       tan(x) + x, x) is False
+    assert _is_function_class_equation(TrigonometricFunction,
                                        tan(x**2), x) is False
     assert _is_function_class_equation(TrigonometricFunction,
                                        tan(x**2) + sin(x), x) is False
@@ -215,6 +217,8 @@ def test_is_function_class_equation():
                                        a*tanh(x) - 1, x) is True
     assert _is_function_class_equation(HyperbolicFunction,
                                        tanh(x)**2 + sinh(x) - 1, x) is True
+    assert _is_function_class_equation(HyperbolicFunction,
+                                       tanh(x) + x, x) is False
     assert _is_function_class_equation(HyperbolicFunction,
                                        tanh(x**2), x) is False
     assert _is_function_class_equation(HyperbolicFunction,

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -452,21 +452,13 @@ def test_solve_polynomial_symbolic_param():
         FiniteSet(sqrt(1 + sqrt(a)), -sqrt(1 + sqrt(a)),
                   sqrt(1 - sqrt(a)), -sqrt(1 - sqrt(a)))
 
-    # By attempt to make Set.contains behave symbolically SetDifference on
-    # FiniteSet isn't working very well.
-    # Simple operations like `FiniteSet(a) - FiniteSet(-b)` raises `TypeError`
-    # The likely course of action will making such operations return
-    # SetDifference object. That will also change the expected output of
-    # the given tests. Till the SetDifference becomes well behaving again the
-    # following tests are kept as comments.
+    # issue 4507
+    assert solveset_complex(y - b/(1 + a*x), x) == \
+        FiniteSet((b/y - 1)/a) - FiniteSet(-1/a)
 
-    # # issue 4508
-    # assert solveset_complex(y - b*x/(a + x), x) == \
-    #     FiniteSet(-a*y/(y - b))
-    #
-    # # issue 4507
-    # assert solveset_complex(y - b/(1 + a*x), x) == \
-    #     FiniteSet((b - y)/(a*y))
+    # issue 4508
+    assert solveset_complex(y - b*x/(a + x), x) == \
+        FiniteSet(-a*y/(y - b)) - FiniteSet(-a)
 
 
 def test_solve_rational():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -317,16 +317,15 @@ def test_return_root_of():
     assert solveset_complex(s, x) == \
         FiniteSet(*Poly(s*4, domain='ZZ').all_roots())
 
-    # XXX: this comparison should work without converting the FiniteSet to list
-    # See #7876
+    # Refer issue #7876
     eq = x*(x - 1)**2*(x + 1)*(x**6 - x + 1)
-    assert list(solveset_complex(eq, x)) == \
-        list(FiniteSet(-1, 0, 1, CRootOf(x**6 - x + 1, 0),
+    assert solveset_complex(eq, x) == \
+        FiniteSet(-1, 0, 1, CRootOf(x**6 - x + 1, 0),
                        CRootOf(x**6 - x + 1, 1),
                        CRootOf(x**6 - x + 1, 2),
                        CRootOf(x**6 - x + 1, 3),
                        CRootOf(x**6 - x + 1, 4),
-                       CRootOf(x**6 - x + 1, 5)))
+                       CRootOf(x**6 - x + 1, 5))
 
 
 def test__has_rational_power():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -560,10 +560,8 @@ def test_solve_abs():
 
     assert solveset_real(Abs(x - 7) - 8, x) == FiniteSet(-S(1), S(15))
 
-    # issue 9565. Note: solveset_real does not solve this as it is
-    # solveset's job to handle Relationals
-    assert solveset(Abs((x - 1)/(x - 5)) <= S(1)/3, domain=S.Reals
-        ) == Interval(-1, 2)
+    # issue 9565
+    assert solveset_real(Abs((x - 1)/(x - 5)) <= S(1)/3, x) == Interval(-1, 2)
 
     # issue #10069
     eq = abs(1/(x - 1)) - 1 > 0


### PR DESCRIPTION
While going through the test suite, I found some tests which can be updated with the changes made in the codebase. Here are a few of them: 
- [x] [376582e](https://github.com/sympy/sympy/commit/376582ecff8a900411c9ab7c41b95c9480ab868f): With the change in internals, `solveset_real` can now be used for solving Relationals now. #9565
- [x] [dbbed02](https://github.com/sympy/sympy/commit/dbbed022c0fa90e5ce556dc242074ff9554f0fed): As we are now able to handle set differences, the tests for #4507 and #4508 can be added.
- [x] [5d37856](https://github.com/sympy/sympy/commit/5d3785680d49b766d0a24e0c3f3a5ca33a5e267b): Added a few tests to emphasize that the given equation should only be comprised of functions of the desired function class. 
- [x] [92939d5](https://github.com/sympy/sympy/commit/92939d5a2d20eafbfab19dca868c76da28d5bb0a): The ability to evaluate 2 `FiniteSet` objects for equality should allow us to rewrite this test in a simplified way. #7876

Ping @aktech @asmeurer @hargup @smichr  
