### PR TITLE
Fixed three minor typos in the tutorial documentation

### DIFF
--- a/doc/src/tutorial/printing.rst
+++ b/doc/src/tutorial/printing.rst
@@ -169,7 +169,7 @@ Unicode Pretty Printer
 ----------------------
 
 The Unicode pretty printer is also accessed from ``pprint()`` and
-``pretty()``.  It the terminal supports Unicode, it is used automatically.  If
+``pretty()``.  If the terminal supports Unicode, it is used automatically.  If
 ``pprint()`` is not able to detect that the terminal supports unicode, you can
 pass ``use_unicode=True`` to force it to use Unicode.
 

--- a/doc/src/tutorial/simplification.rst
+++ b/doc/src/tutorial/simplification.rst
@@ -394,7 +394,7 @@ the simplification to take place, regardless of assumptions.
     (t⋅z)
 
 Note that in some instances, in particular, when the exponents are integers or
-rational numbers, and identity 2 holds, it will be applied automatically
+rational numbers, and identity 2 holds, it will be applied automatically.
 
    >>> (z*t)**2
      2  2
@@ -849,7 +849,7 @@ example
     >>> orig_frac = frac = cancel(list_to_frac(l))
     >>> del l
 
-Click on "Run code block in SymPy Live" on the definition of ``list_to_frac)``
+Click on "Run code block in SymPy Live" on the definition of ``list_to_frac()``
 above, and then on the above example, and try to reproduce ``l`` from
 ``frac``.  I have deleted ``l`` at the end to remove the temptation for
 peeking (you can check your answer at the end by calling


### PR DESCRIPTION
- In the printing page of the tutorial under the Unicode Pretty Printer
  subheading, there is an "It" where there should be an "If".
- In the simplification page of the tutorial under the powsimp
  subheading, one of the lines preceeding a code example is missing a
  period.
- Again in the simplification page in the second to last paragraph,
  there is an improperly closed parentheses
