### PR TITLE
Fixing sympify (evaluate = False) for Unary Operators - Issue #10560

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -931,6 +931,11 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         if node.op.__class__ in self.operators:
             sympy_class = self.operators[node.op.__class__]
             right = self.visit(node.right)
+            left = self.visit(node.left)
+            if isinstance(node.left, ast.UnaryOp) and (isinstance(node.right, ast.UnaryOp) == 0) and sympy_class in ('Mul','Pow'):
+                temp = right
+                right = left
+                left = temp
 
             if isinstance(node.op, ast.Sub):
                 right = ast.UnaryOp(op=ast.USub(), operand=right)
@@ -945,7 +950,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
 
             new_node = ast.Call(
                 func=ast.Name(id=sympy_class, ctx=ast.Load()),
-                args=[self.visit(node.left), right],
+                args=[left, right],
                 keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
                 starargs=None,
                 kwargs=None


### PR DESCRIPTION
`>>> sympify('4*-3', evaluate=False)`
`(-3)*4`
