### PR TITLE
Fixed #10782: Changed condition_number()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3220,7 +3220,8 @@ class MatrixBase(object):
 
         singular_values
         """
-
+        if not self:
+            return 0
         singularvalues = self.singular_values()
         return Max(*singularvalues) / Min(*singularvalues)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3221,7 +3221,7 @@ class MatrixBase(object):
         singular_values
         """
         if not self:
-            return 0
+            return S.Zero
         singularvalues = self.singular_values()
         return Max(*singularvalues) / Min(*singularvalues)
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2047,6 +2047,9 @@ def test_condition_number():
     assert all(Float(1.).epsilon_eq(Mc.subs(x, val).evalf()) for val in
         [Rational(1, 5), Rational(1, 2), Rational(1, 10), pi/2, pi, 7*pi/4 ])
 
+    #issue 10782
+    assert Matrix([]).condition_number() == 0
+
 
 def test_equality():
     A = Matrix(((1, 2, 3), (4, 5, 6), (7, 8, 9)))


### PR DESCRIPTION
This fixes issue [10782](https://github.com/sympy/sympy/issues/10782). The new `eigenvals()` function returns empty dict, `singular_values()` function returns an empty list. So for this reason `condition_number()` is returning `ValueError` as it can't get any max and min element. As I found from some other sources, condition number for empty matrix is zero.
