### PR TITLE
integrals: Improved heurisch.py to get Unevaluated Integral Object of som…

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -642,9 +642,10 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
 
         coeff_ring = PolyRing(poly_coeffs, ground)
         ring = PolyRing(V, coeff_ring)
-
-        numer = ring.from_expr(raw_numer)
-
+        try:
+            numer = ring.from_expr(raw_numer)
+        except ValueError:
+            raise PolynomialError
         solution = solve_lin_sys(numer.coeffs(), coeff_ring, _raw=False)
 
         if solution is None:

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -71,7 +71,9 @@ def test_heurisch_exp():
     assert heurisch(Integral(x**z*y, (y, 1, 2), (z, 2, 3)).function, x) == (x*x**z*y)/(z+1)
     assert heurisch(Sum(x**z, (z, 1, 2)).function, z) == x**z/log(x)
 
-
+def test_issue_10680():
+    assert integrate(x**log(x**log(x**log(x))),x)
+ 
 def test_heurisch_trigonometric():
     assert heurisch(sin(x), x) == -cos(x)
     assert heurisch(pi*sin(x) + 1, x) == x - pi*cos(x)

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -4,7 +4,7 @@ from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     besselj, besselk, bessely, jn
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
 from sympy.utilities.pytest import XFAIL, skip, slow, ON_TRAVIS
-from sympy.integrals.integrals import integrate 
+from sympy.integrals.integrals import integrate
 x, y, z, nu = symbols('x,y,z,nu')
 f = Function('f')
 

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -26,6 +26,8 @@ def test_components():
     assert components(f(x)*diff(f(x), x), x) == \
         set([x, f(x), Derivative(f(x), x), Derivative(f(x), x)])
 
+def test_issue_10680():
+    assert isinstance(integrate(x**log(x**log(x**log(x))),x), Integral)
 
 def test_heurisch_polynomials():
     assert heurisch(1, x) == x

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -72,9 +72,6 @@ def test_heurisch_exp():
 
     assert heurisch(Integral(x**z*y, (y, 1, 2), (z, 2, 3)).function, x) == (x*x**z*y)/(z+1)
     assert heurisch(Sum(x**z, (z, 1, 2)).function, z) == x**z/log(x)
-
-def test_issue_10680():
-    assert integrate(x**log(x**log(x**log(x))),x)
  
 def test_heurisch_trigonometric():
     assert heurisch(sin(x), x) == -cos(x)

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -4,7 +4,7 @@ from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     besselj, besselk, bessely, jn
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
 from sympy.utilities.pytest import XFAIL, skip, slow, ON_TRAVIS
-
+from sympy.integrals.integrals import integrate 
 x, y, z, nu = symbols('x,y,z,nu')
 f = Function('f')
 

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -72,7 +72,7 @@ def test_heurisch_exp():
 
     assert heurisch(Integral(x**z*y, (y, 1, 2), (z, 2, 3)).function, x) == (x*x**z*y)/(z+1)
     assert heurisch(Sum(x**z, (z, 1, 2)).function, z) == x**z/log(x)
- 
+
 def test_heurisch_trigonometric():
     assert heurisch(sin(x), x) == -cos(x)
     assert heurisch(pi*sin(x) + 1, x) == x - pi*cos(x)


### PR DESCRIPTION
Integral: Updated heurisch.py to get Unevaluated Integral Object of Complex Expression

As we Know From Documentation That If ingrate() funtion is unable to solve any Integrand then it return its Unevaluated Integral Object .
But for Some Expression like x, log(x), xlog(x), log(xlog(x)), xlog(xlog(x)) ,xlog(xlog(x**log(x))),etc. so While Caculating Integration of this Expression heurisch.py raise a ValueError Execption from " numer = ring.from_expr(raw_numer) " .
As we can see these expression are not polynomial so code have to raise a PolynomialError which is caught by _eval_integral .
So I have changed some in code by which a PolynomialError raise and _eval_integral return a Unevaluated integral Object.

```

>>> from sympy import*
>>> from sympy import init_printing
>>> init_printing(use_unicode=True)
>>> x=symbols('x')
>>> expr=x**log(x**log(x**log(x)))
>>> expr#shows proper output
>>> integrate(expr,x)#shows proper output not an exception

```

 so as we can see Now we able to get unevaluated Integral Object.
 Previously it showing Error, issuse #10680.
