### PR TITLE
10755: raise TypeError when using int or round on symbolic expr

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -192,6 +192,8 @@ class Expr(Basic, EvalfMixin):
         # (regardless of how much extra work we do to calculate extra decimal
         # places) we need to test whether we are off by one.
         from sympy import Dummy
+        if not self.is_number:
+            raise TypeError("can't convert symbols to int")
         r = self.round(2)
         if not r.is_Number:
             raise TypeError("can't convert complex to int")
@@ -3139,7 +3141,9 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy import Float
         x = self
-        if x.is_number and not x.is_Atom:
+        if not x.is_number:
+            raise TypeError("can't round symbolic expression")
+        if not x.is_Atom:
             xn = x.n(2)
             if not pure_complex(xn, or_real=True):
                 raise TypeError('Expected a number but got %s:' %

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -442,6 +442,7 @@ def test_is_algebraic_expr():
     assert (cos(y)/sqrt(x)).is_algebraic_expr(y) is False
     assert (cos(y)/sqrt(x)).is_algebraic_expr(x, y) is False
 
+
 def test_SAGE1():
     #see https://github.com/sympy/sympy/issues/3346
     class MyInt:
@@ -1426,9 +1427,11 @@ def test_issue_4199():
     assert a._eval_interval(x, -oo, oo) == -y
     assert a._eval_interval(x, oo, -oo) == y
 
+
 def test_eval_interval_zoo():
     # Test that limit is used when zoo is returned
     assert Si(1/x)._eval_interval(x, 0, 1) == -pi/2 + Si(1)
+
 
 def test_primitive():
     assert (3*(x + 1)**2).primitive() == (3, (x + 1)**2)
@@ -1657,6 +1660,7 @@ def test_round():
     assert S.NegativeInfinity.round() == S.NegativeInfinity
     assert S.ComplexInfinity.round() == S.ComplexInfinity
 
+
 def test_round_exception_nostr():
     # Don't use the string form of the expression in the round exception, as
     # it's too slow
@@ -1668,6 +1672,7 @@ def test_round_exception_nostr():
     else:
         # Did not raise
         raise AssertionError("Did not raise")
+
 
 def test_extract_branch_factor():
     assert exp_polar(2.0*I*pi).extract_branch_factor() == (1, 1)
@@ -1706,3 +1711,9 @@ def test_issue_7426():
 def test_issue_10161():
     x = symbols('x', real=True)
     assert x*abs(x)*abs(x) == x**3
+
+
+def test_issue_10755():
+    x = symbols('x')
+    raises(TypeError, lambda: int(log(x)))
+    raises(TypeError, lambda: log(x).round(2))


### PR DESCRIPTION
Fixes #10755 

``` python
>>> from sympy import *
>>> var('x y')
(x, y)
>>> solve(log(y) - log(0.1222*x**0.8628), x)
[11.4314187062073*y**(2500/2157)]
```

Other more precise tests that gave the same error were used in this PR.
