### PR TITLE
berkowitz() function modified for empty matrices

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2924,8 +2924,9 @@ class MatrixBase(object):
         berkowitz_eigenvals
         """
         from sympy.matrices import zeros
+        berk = [(1,)]
         if not self:
-            return (1,)
+            return tuple(berk)
 
         if not self.is_square:
             raise NonSquareMatrixError()
@@ -2959,7 +2960,11 @@ class MatrixBase(object):
         for i, T in enumerate(transforms):
             polys.append(T*polys[i])
 
-        return tuple(map(tuple, polys))
+        tup = tuple(map(tuple, polys))
+        for i in tup:
+            berk.append(i)
+        return tuple(berk)
+
 
     def berkowitz_det(self):
         """Computes determinant using Berkowitz method.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2894,15 +2894,18 @@ class MatrixBase(object):
 
            >>> M = Matrix([[x, y, z], [1, 0, 0], [y, z, x]])
 
-           >>> p, q, r = M.berkowitz()
+           >>> p, q, r, s = M.berkowitz()
 
-           >>> p # 1 x 1 M's sub-matrix
+           >>> p # 0 x 0 M's sub-matrix
+           (1,)
+
+           >>> q # 1 x 1 M's sub-matrix
            (1, -x)
 
-           >>> q # 2 x 2 M's sub-matrix
+           >>> r # 2 x 2 M's sub-matrix
            (1, -x, -y)
 
-           >>> r # 3 x 3 M's sub-matrix
+           >>> s # 3 x 3 M's sub-matrix
            (1, -2*x, x**2 - y*z - y, x*y - z**2)
 
            For more information on the implemented algorithm refer to:
@@ -2991,7 +2994,7 @@ class MatrixBase(object):
 
         berkowitz
         """
-        sign, minors = S.NegativeOne, []
+        sign, minors = S.One, []
 
         for poly in self.berkowitz():
             minors.append(sign*poly[-1])

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2951,9 +2951,9 @@ class MatrixBase(object):
         berkowitz_eigenvals
         """
         from sympy.matrices import zeros
-        berk = [(1,)]
+        berk = ((1,),)
         if not self:
-            return tuple(berk)
+            return berk
 
         if not self.is_square:
             raise NonSquareMatrixError()
@@ -2987,10 +2987,7 @@ class MatrixBase(object):
         for i, T in enumerate(transforms):
             polys.append(T*polys[i])
 
-        tup = tuple(map(tuple, polys))
-        for i in tup:
-            berk.append(i)
-        return tuple(berk)
+        return berk + tuple(map(tuple, polys))
 
 
     def berkowitz_det(self):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2924,6 +2924,8 @@ class MatrixBase(object):
         berkowitz_eigenvals
         """
         from sympy.matrices import zeros
+        if not self:
+            return (1,)
 
         if not self.is_square:
             raise NonSquareMatrixError()

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -430,9 +430,9 @@ def test_det_LU_decomposition():
 def test_berkowitz_minors():
     B = Matrix(2, 2, [1, 2, 2, 1])
 
-    assert B.berkowitz_minors() == (1, -3)
+    assert B.berkowitz_minors() == (1, 1, -3)
     E = Matrix([])
-    assert E.berkowitz() == (1,)
+    assert E.berkowitz() == ((1,),)
 
 def test_slicing():
     m0 = eye(4)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -431,7 +431,8 @@ def test_berkowitz_minors():
     B = Matrix(2, 2, [1, 2, 2, 1])
 
     assert B.berkowitz_minors() == (1, -3)
-
+    E = Matrix([])
+    assert E.berkowitz() == (1,)
 
 def test_slicing():
     m0 = eye(4)


### PR DESCRIPTION
The berkowitz() function, till now, is returning IndexError for empty matrices. Now this will return a tuple of `(1,)`. As the syntax of python doesn't support returning `(1)` I am returning `(1,)`.
