### PR TITLE
Restrict as_terms to comparing complex coefficients.

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -924,7 +924,7 @@ class Expr(Basic, EvalfMixin):
 
             if _term is not S.One:
                 for factor in Mul.make_args(_term):
-                    if factor.is_number:
+                    if factor.is_complex:
                         try:
                             coeff *= complex(factor)
                         except TypeError:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1407,6 +1407,9 @@ def test_as_ordered_terms():
     assert f.as_ordered_terms(order="rev-lex") == [2, y, x*y**4, x**2*y**2]
     assert f.as_ordered_terms(order="rev-grlex") == [2, y, x**2*y**2, x*y**4]
 
+    # issue sympy/sympy/10800
+    (Integral(sin(exp(x)), (x, 0, 1)) + 1).__str__()# test to see if this takes forever
+
 
 def test_sort_key_atomic_expr():
     from sympy.physics.units import m, s


### PR DESCRIPTION
Fixes sympy/sympy#10800
