### PR TITLE
fixed missing codes in documentation and usage section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,16 @@ Everything is at:
 
 http://docs.sympy.org/
 
-You can generate everything at the above site in your local copy of SymPy by::
+You can generate everything at the above site in your local copy of SymPy by:
+
+first, install the prerequisites to make the html, e.g. on Debian/Ubuntu (similarly for other distributions)::
+
+    apt-get install python-sphinx texlive-latex-recommended dvipng librsvg2-bin imagemagick docbook2x
+
+also, mpmath must be installed. refer to the doc:
+http://docs.sympy.org/latest/install.html#mpmath
+
+then enter::
 
     $ cd doc
     $ make html


### PR DESCRIPTION
I ran the $ make html 
and got errors for prerequisites.

after installing the prerequisites..
further,  got mpmath dependency error.
.............................
.............................
mkdir -p src/modules
PYTHONPATH=..: sphinx-build -b html -d _build/doctrees  src _build/html
Running Sphinx v1.3.5

Exception occurred:
  File "/home/aman/sympy/sympy/**init**.py", line 20, in <module>
    raise ImportError("SymPy now depends on mpmath as an external library. "
ImportError: SymPy now depends on mpmath as an external library. See http://docs.sympy.org/latest/install.html#mpmath for more information.
The full traceback has been saved in /tmp/sphinx-err-upXm9Z.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at https://github.com/sphinx-doc/sphinx/issues. Thanks!
...................
..................

So, I referred online and found solutions ( https://github.com/sympy/sympy/blob/master/doc/README.rst ) and then made changes to the README.rst
