### PR TITLE
limit working now with binomial #10801 

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -136,11 +136,10 @@ class Limit(Expr):
 
         if not e.has(z):
             return e
-
-        #limit is not working with binomial,gruntz raise an exception
-        #limit can work with binomial by converting to factorial first.
-        #we have to also check that given limit should not be limits
-        #of sequences.
+        # limit is not working with binomial, gruntz raise an exception
+        # limit can work with binomial by converting to factorial first.
+        # we have to also check that given limit should not be limits
+        # of sequences.
         if e.has(binomial) and not (hints.get('sequence', True) and z0 is S.Infinity):
            e = e.rewrite(factorial)
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -136,21 +136,14 @@ class Limit(Expr):
 
         if not e.has(z):
             return e
-<<<<<<< HEAD
 
-        #limit is not working with binomial,gruntz raise not exception
-=======
         #limit is not working with binomial,gruntz raise an exception
->>>>>>> b939ad9c1ddea3233028aafa177f86fb2afa0e94
         #limit can work with binomial by converting to factorial first.
         #we have to also check that given limit should not be limits
         #of sequences.
         if e.has(binomial) and not (hints.get('sequence', True) and z0 is S.Infinity):
-<<<<<<< HEAD
-            e = e.rewrite(factorial)
-=======
-            e=e.rewrite(factorial)
->>>>>>> b939ad9c1ddea3233028aafa177f86fb2afa0e94
+           e = e.rewrite(factorial)
+ 
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.
         # factorial is defined to be zero for negative inputs (which
@@ -200,4 +193,5 @@ class Limit(Expr):
                     raise NotImplementedError()
             else:
                 raise NotImplementedError()
+
         return r

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -136,12 +136,13 @@ class Limit(Expr):
 
         if not e.has(z):
             return e
-        #limit is not working with binomial,gruntz raise an exception
+
+        #limit is not working with binomial,gruntz raise not exception
         #limit can work with binomial by converting to factorial first.
         #we have to also check that given limit should not be limits
         #of sequences.
         if e.has(binomial) and not (hints.get('sequence', True) and z0 is S.Infinity):
-            e=e.rewrite(factorial)
+            e = e.rewrite(factorial)
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.
         # factorial is defined to be zero for negative inputs (which

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -143,7 +143,7 @@ class Limit(Expr):
         #of sequences.
         if e.has(binomial) and not (hints.get('sequence', True) and z0 is S.Infinity):
            e = e.rewrite(factorial)
- 
+
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.
         # factorial is defined to be zero for negative inputs (which

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -4,6 +4,7 @@ from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.compatibility import string_types
 from sympy.core.symbol import Dummy
 from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.combinatorial.factorials import binomial
 from sympy.functions.special.gamma_functions import gamma
 from sympy.series.order import Order
 from .gruntz import gruntz
@@ -135,7 +136,12 @@ class Limit(Expr):
 
         if not e.has(z):
             return e
-
+        #limit is not working with binomial,gruntz raise an exception
+        #limit can work with binomial by converting to factorial first.
+        #we have to also check that given limit should not be limits
+        #of sequences.
+        if e.has(binomial) and not (hints.get('sequence', True) and z0 is S.Infinity):
+            e=e.rewrite(factorial)
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.
         # factorial is defined to be zero for negative inputs (which
@@ -185,5 +191,4 @@ class Limit(Expr):
                     raise NotImplementedError()
             else:
                 raise NotImplementedError()
-
         return r

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -455,13 +455,15 @@ def test_issue_4503():
 def test_issue_8730():
     assert limit(subfactorial(x), x, oo) == oo
 
+def test_issue_10801():
+    assert limit(16**x/(x*binomial(2*x,x)**2), x, oo) == pi
 
 def test_issue_9205():
     x, y, a = symbols('x, y, a')
-    assert Limit(x, x, a).free_symbols == set([a])
-    assert Limit(x, x, a, '-').free_symbols == set([a])
-    assert Limit(x + y, x + y, a).free_symbols == set([a])
-    assert Limit(-x**2 + y, x**2, a).free_symbols == set([y, a])
+    assert Limit(x, x, a).free_symbols == {a}
+    assert Limit(x, x, a, '-').free_symbols == {a}
+    assert Limit(x + y, x + y, a).free_symbols == {a}
+    assert Limit(-x**2 + y, x**2, a).free_symbols == {y, a}
 
 
 def test_limit_seq():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -456,11 +456,7 @@ def test_issue_8730():
     assert limit(subfactorial(x), x, oo) == oo
 
 def test_issue_10801():
-<<<<<<< HEAD
     assert limit(16**x/(x*binomial(2*x, x)**2), x, oo) == pi
-=======
-    assert limit(16**x/(x*binomial(2*x,x)**2), x, oo) == pi
->>>>>>> b939ad9c1ddea3233028aafa177f86fb2afa0e94
 
 def test_issue_9205():
     x, y, a = symbols('x, y, a')

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -456,7 +456,7 @@ def test_issue_8730():
     assert limit(subfactorial(x), x, oo) == oo
 
 def test_issue_10801():
-    assert limit(16**x/(x*binomial(2*x,x)**2), x, oo) == pi
+    assert limit(16**x/(x*binomial(2*x, x)**2), x, oo) == pi
 
 def test_issue_9205():
     x, y, a = symbols('x, y, a')


### PR DESCRIPTION
As we know that binomial funtion can be reduced into to their factorial form
 for calculating the limit of funtion we are using gruntz algorithm. gruntz algorithm is not works with  binomial limits so we have to convert its factorial form.
 for example:
 while calculating `limit(16**k/(k*binomial(2*k,k)**2), k, oo)`
 we are getting NotImplemented Exception but after some changes we are now able to get the result as PI.
"
