### PR TITLE
Fixed #10701: is_nilpotent() modified

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2080,6 +2080,8 @@ class MatrixBase(object):
         >>> a.is_nilpotent()
         False
         """
+        if not self:
+            return True
         if not self.is_square:
             raise NonSquareMatrixError(
                 "Nilpotency is valid only for square matrices")

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1189,6 +1189,8 @@ def test_is_nilpotent():
     assert a.is_nilpotent()
     a = Matrix([[1, 0], [0, 1]])
     assert not a.is_nilpotent()
+    a = Matrix([])
+    assert a.is_nilpotent()
 
 
 def test_zeros_ones_fill():


### PR DESCRIPTION
previously `is_nilpotent()` for empty matrix is returning IndexError. Now it returns true.
The reason is :- 
An empty matrix is a zero matrix. This is a vacuous truth accepted by all. Now as it is zero matrix it should be nilpotent.
