### PR TITLE
Allow choosing the latex printer using init_printing in normal python

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -357,6 +357,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     else:
         if str_printer is not None:
             stringify_func = str_printer
+        elif use_latex is not None:
+            stringify_func = default_latex
         else:
             from sympy.printing import sstrrepr as stringify_func
 


### PR DESCRIPTION
Previously the latex printer was not an option for a standard python
interpreter using init_printing.

Before Change:

```
>>> from sympy import *
>>> init_printing(use_latex=True)
>>> Rational(7, 6)
7/6
>>> init_printing(pretty_print=False, use_latex=True)
>>> Rational(7, 6)
7/6
```

After Change:

```
>>> from sympy import *
>>> init_printing(use_latex=True)
>>> Rational(7, 6)
7/6
>>> init_printing(pretty_print=False, use_latex=True)
>>> Rational(7, 6)
\frac{7}{6}
```

Note that it still requires explicit delcaration of pretty_print being
False. Would this be the desired functionality?

Closes #10834 
