### PR TITLE
Improved power substitutions

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -565,6 +565,12 @@ class Pow(Expr):
         if old == self.base:
             return new**self.exp._subs(old, new)
 
+        # issue 10829: (4**x - 3*y + 2).subs(2**x, y) -> y**2 - 3*y + 2
+        if old.func is self.func and self.exp == old.exp:
+            l = log(self.base, old.base)
+            if l.is_Number:
+                return Pow(new, l)
+
         if old.func is self.func and self.base == old.base:
             if self.exp.is_Add is False:
                 ct1 = self.exp.as_independent(Symbol, as_Add=False)

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -656,6 +656,12 @@ def test_issue_5217():
     assert q.subs(sub) == 2*y**2*s
 
 
+def test_issue_10829():
+    from sympy.abc import x, y
+
+    assert (4**x).subs(2**x, y) == y**2
+    assert (9**x).subs(3**x, y) == y**2
+
 def test_pow_eval_subs_no_cache():
     # Tests pull request 9376 is working
     from sympy.core.cache import clear_cache


### PR DESCRIPTION
Fixes sympy/sympy#10829

This PR makes `(a**x).subs(b**x, y)` -> `y**log(a, b)` if `log(a, b)` is resolved to be a number. Also added relevant tests.
