### PR TITLE
Define __signature__ on Function

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -143,9 +143,12 @@ class FunctionClass(ManagedProperties):
         Allow Python 3's inspect.signature to give a useful signature for
         Function subclasses.
         """
-        # Python 3 only, but this method is also only ever called in Python
-        # 3.
-        from inspect import signature
+        # Python 3 only, but backports (like the one in IPython) still might
+        # call this.
+        try:
+            from inspect import signature
+        except ImportError:
+            return None
 
         # TODO: Look at nargs
         return signature(self.eval)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -138,6 +138,19 @@ class FunctionClass(ManagedProperties):
         cls._nargs = nargs
 
     @property
+    def __signature__(self):
+        """
+        Allow Python 3's inspect.signature to give a useful signature for
+        Function subclasses.
+        """
+        # Python 3 only, but this method is also only ever called in Python
+        # 3.
+        from inspect import signature
+
+        # TODO: Look at nargs
+        return signature(self.eval)
+
+    @property
     def nargs(self):
         """Return a set of the allowed number of arguments for the function.
 


### PR DESCRIPTION
This lets Python 3's inspect.signature give a useful signature for Function subclasses.

For example,

**BEFORE**

``` py
In [1]: import inspect

In [2]: inspect.signature(LambertW)
Out[2]: <Signature (*args, **options)>
```

**AFTER**

``` py
In [1]: import inspect

In [2]: inspect.signature(LambertW)
Out[2]: <Signature (x, k=None)>
```

I was hoping this would also improve the IPython `?` help, but that is contingent
on https://github.com/ipython/ipython/issues/3678.
