### PR TITLE
Fix factorisation of floating point polynomials

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1223,7 +1223,8 @@ def dup_factor_list(f, K0):
                 coeff = coeff/denom
             else:
                 for i, (f, k) in enumerate(factors):
-                    f = dup_quo_ground(f, denom, K0)
+                    if i == 0:
+                        f = dup_quo_ground(f, denom, K0)
                     f = dup_convert(f, K0, K0_inexact)
                     factors[i] = (f, k)
 
@@ -1302,7 +1303,8 @@ def dmp_factor_list(f, u, K0):
                 coeff = coeff/denom
             else:
                 for i, (f, k) in enumerate(factors):
-                    f = dmp_quo_ground(f, denom, u, K0)
+                    if i == 0:
+                        f = dmp_quo_ground(f, denom, u, K0)
                     f = dmp_convert(f, u, K0, K0_inexact)
                     factors[i] = (f, k)
 

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -561,6 +561,10 @@ def test_dup_factor_list():
     R, x = ring("x", EX)
     raises(DomainError, lambda: R.dup_factor_list(EX(sin(1))))
 
+    R, x = ring("x", RR)
+    expr = x**2 - 0.01
+    (a, ((b, c), (d, e))) = R.dup_factor_list(expr)
+    assert a*b*c*d*e == expr
 
 def test_dmp_factor_list():
     R, x, y = ring("x,y", ZZ)
@@ -657,6 +661,10 @@ def test_dmp_factor_list():
     R, x, y = ring("x,y", EX)
     raises(DomainError, lambda: R.dmp_factor_list(EX(sin(1))))
 
+    R, x, y = ring("x,y", RR)
+    expr = x**2 - 0.01*y**2
+    (a, ((b, c), (d, e))) = R.dmp_factor_list(expr)
+    assert a*b*c*d*e == expr
 
 def test_dup_irreducible_p():
     R, x = ring("x", ZZ)


### PR DESCRIPTION
Fixes the following bugs:

```
In [1]: factor(x**2 - 0.01*y**2)
Out[1]: 1.0⋅(0.1⋅x - 0.01⋅y)⋅(0.1⋅x + 0.01⋅y)

In [2]: expand(factor(x**2 - 0.01*y**2))
Out[2]: 
      2           2
0.01⋅x  - 0.0001⋅y 

In [3]: factor(x**2 - 0.01)
Out[3]: 1.0⋅(0.1⋅x - 0.01)⋅(0.1⋅x + 0.01)

In [4]: expand(factor(x**2 - 0.01))
Out[4]: 
      2         
0.01⋅x  - 0.0001
```
