### PR TITLE
fixed print statement compatibility with python2

### DIFF
--- a/examples/beginner/series.py
+++ b/examples/beginner/series.py
@@ -12,17 +12,17 @@ def main():
     x = Symbol('x')
 
     e = 1/cos(x)
-    print()
+    print('')
     print("Series for sec(x):")
-    print()
+    print('')
     pprint(e.series(x, 0, 10))
     print("\n")
 
     e = 1/sin(x)
     print("Series for csc(x):")
-    print()
+    print('')
     pprint(e.series(x, 0, 4))
-    print()
+    print('')
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
for getting an empty line, print() works in python3 but in python2 ,it outputs just empty parenthesis ()
