### PR TITLE
Implemented function on symbol can give ValueError

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -466,7 +466,7 @@ class Function(Application, Expr):
         except (AttributeError, KeyError):
             try:
                 return Float(self._imp_(*self.args), prec)
-            except (AttributeError, TypeError):
+            except (AttributeError, TypeError, ValueError):
                 return
 
         # Convert all args to mpf or mpc

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -502,6 +502,23 @@ def test_imps():
     raises(ValueError, lambda: lambdify(x, f(f2(x))))
 
 
+def test_imps_errors():
+    # Test errors that implemented functions can return, and still be able to
+    # form expressions.
+    # See: https://github.com/sympy/sympy/issues/10810
+    for val, error_class in product((0, 0., 2, 2.0),
+                                    (AttributeError, TypeError, ValueError)):
+
+        def myfunc(a):
+            if a == 0:
+                raise error_class
+            return 1
+
+        f = implemented_function('f', myfunc)
+        expr = f(val)
+        assert expr == f(val)
+
+
 def test_imps_wrong_args():
     raises(ValueError, lambda: implemented_function(sin, lambda x: x))
 


### PR DESCRIPTION
See: https://github.com/sympy/sympy/issues/10810

Sympy may try and simplify functions such as f(0.), by evaluating them
numerically.  When doing this, the floating point value (such as 0.) has
been converted to a sympy Float object.  Trying to evaluate the symbolic
float argument with numerical implemented functions can cause a variety
of errors.  Around line 468 of core/function.py:eval_evalf, there is a check for
these kinds of errors, falling back to the not-evaluated form.  At the
moment eval_evalf only allows implemented functions to return TypeError
and AttributeError, otherwise the routine raises the error and crashes
out.

I recently came across a case where a numerical function
(scipy.interpolate.interp1d) returns a ValueError if we pass it symbols
to operate on, which seems a reasonable thing to do, and something that
may be true of other implemented functions receiving unexpected sympy
arguments to evaluate.

Allow ValueError as well as the other valid errors.
