### PR TITLE
Modified KanesMethod to accept empty load

### DIFF
--- a/doc/src/modules/physics/mechanics/examples/bicycle_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/bicycle_example.rst
@@ -192,7 +192,7 @@ linearization to correctly work. ::
   ...           kd_eqs=kd)
   >>> print('Before Forming Generalized Active and Inertia Forces, Fr and Fr*')
   Before Forming Generalized Active and Inertia Forces, Fr and Fr*
-  >>> (fr, frstar) = KM.kanes_equations(FL, BL)
+  >>> (fr, frstar) = KM.kanes_equations(BL, FL)
   >>> print('Base Equations of Motion Computed')
   Base Equations of Motion Computed
 

--- a/doc/src/modules/physics/mechanics/examples/lin_pend_nonmin_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/lin_pend_nonmin_example.rst
@@ -100,7 +100,7 @@ coordinates need to be provided to the class. In this case we'll use `q_2` and
   >>> KM = KanesMethod(N, q_ind=[q2], u_ind=[u2], q_dependent=[q1],
   ...                  u_dependent=[u1], configuration_constraints=f_c,
   ...                  velocity_constraints=f_v, kd_eqs=kde)
-  >>> (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
+  >>> (fr, frstar) = KM.kanes_equations([pP],[(P, R)])
 
 For linearization, operating points can be specified on the call, or be
 substituted in afterwards. In this case we'll provide them in the call,

--- a/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane.rst
+++ b/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane.rst
@@ -69,7 +69,7 @@ Fr* from the body list, compute the mass matrix and forcing terms, then solve
 for the u dots (time derivatives of the generalized speeds). ::
 
   >>> KM = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3], kd_eqs=kd)
-  >>> (fr, frstar) = KM.kanes_equations(ForceList, BodyList)
+  >>> (fr, frstar) = KM.kanes_equations(BodyList, ForceList)
   >>> MM = KM.mass_matrix
   >>> forcing = KM.forcing
   >>> rhs = MM.inv() * forcing

--- a/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane_constraints.rst
+++ b/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane_constraints.rst
@@ -52,7 +52,7 @@ represent the constraint forces in those directions. ::
 
   >>> KM = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3], kd_eqs=kd,
   ...           u_auxiliary=[u4, u5, u6])
-  >>> (fr, frstar) = KM.kanes_equations(ForceList, BodyList)
+  >>> (fr, frstar) = KM.kanes_equations(BodyList, ForceList)
   >>> MM = KM.mass_matrix
   >>> forcing = KM.forcing
   >>> rhs = MM.inv() * forcing

--- a/doc/src/modules/physics/mechanics/kane.rst
+++ b/doc/src/modules/physics/mechanics/kane.rst
@@ -131,7 +131,7 @@ or ``(ReferenceFrame, Vector)`` to represent applied forces and torques. ::
   >>> BL = [Pa]
   >>> FL = [(P, 7 * N.x)]
   >>> KM = KanesMethod(N, [q], [u], [qd - u])
-  >>> (fr, frstar) = KM.kanes_equations(FL, BL)
+  >>> (fr, frstar) = KM.kanes_equations(BL, FL)
   >>> KM.mass_matrix
   Matrix([[5]])
   >>> KM.forcing

--- a/doc/src/modules/physics/mechanics/linearize.rst
+++ b/doc/src/modules/physics/mechanics/linearize.rst
@@ -143,7 +143,7 @@ pendulum system: ::
 
   >>> # Solve for eom with kanes method
   >>> KM = KanesMethod(N, q_ind=[q1], u_ind=[u1], kd_eqs=kde)
-  >>> fr, frstar = KM.kanes_equations([(P, R)], [pP])
+  >>> fr, frstar = KM.kanes_equations([pP], [(P, R)])
 
 1. Using the ``Linearizer`` class directly:
 -------------------------------------------

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -552,14 +552,20 @@ def _f_list_parser(fl, ref_frame):
     """Parses the provided forcelist composed of items
     of the form (obj, force).
     Returns a tuple containing:
-        vlist: The velocity (ang_vel for Frames, vel for Points) in
+        vel_list: The velocity (ang_vel for Frames, vel for Points) in
                 the provided reference frame.
-        flist: The forces.
+        f_list: The forces.
 
     Used internally in the KanesMethod and LagrangesMethod classes.
     """
     def flist_iter():
-        for obj, force in fl:
+        for pair in fl:
+            if not pair:
+                # TODO: Handle the case where there is an empty tuple in an
+                # otherwise non-empty forcing list (which is a very rare case)
+                yield None
+                continue
+            obj, force = pair
             if isinstance(obj, ReferenceFrame):
                 yield obj.ang_vel_in(ref_frame), force
             elif isinstance(obj, Point):
@@ -567,6 +573,10 @@ def _f_list_parser(fl, ref_frame):
             else:
                 raise TypeError('First entry in each forcelist pair must '
                                 'be a point or frame.')
-    unzip = lambda l: list(zip(*l)) if l[0] else [(), ()]
-    vel_list, f_list = unzip(list(flist_iter()))
+
+    if not fl:
+        vel_list, f_list = (), ()
+    else:
+        unzip = lambda l: list(zip(*l)) if l[0] else [(), ()]
+        vel_list, f_list = unzip(list(flist_iter()))
     return vel_list, f_list

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -560,11 +560,6 @@ def _f_list_parser(fl, ref_frame):
     """
     def flist_iter():
         for pair in fl:
-            if not pair:
-                # TODO: Handle the case where there is an empty tuple in an
-                # otherwise non-empty forcing list (which is a very rare case)
-                yield None
-                continue
             obj, force = pair
             if isinstance(obj, ReferenceFrame):
                 yield obj.ang_vel_in(ref_frame), force

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -97,7 +97,7 @@ class KanesMethod(object):
     generalized speeds, and forcing is a vector representing "forcing" terms.
 
         >>> KM = KanesMethod(N, q_ind=[q], u_ind=[u], kd_eqs=kd)
-        >>> (fr, frstar) = KM.kanes_equations(FL, BL)
+        >>> (fr, frstar) = KM.kanes_equations(BL, FL)
         >>> MM = KM.mass_matrix
         >>> forcing = KM.forcing
         >>> rhs = MM.inv() * forcing
@@ -696,20 +696,26 @@ class KanesMethod(object):
         Parameters
         ==========
 
+        bodies : iterable
+            An iterable of all RigidBody's and Particle's in the system.
+            A system must have at least one body.
         loads : iterable
             Takes in an iterable of (Particle, Vector) or (ReferenceFrame, Vector)
             tuples which represent the force at a point or torque on a frame.
             Must be either a non-empty iterable of tuples or None which corresponds
             to a system with no constraints.
-        bodies : iterable
-            An iterable of all RigidBody's and Particle's in the system.
-            A system must have at least one body.
         """
         if (bodies is None and loads != None) or isinstance(bodies[0], tuple):
             # This switches the order if they use the old way.
             bodies, loads = loads, bodies
-            SymPyDeprecationWarning('The API has changed and will be deprecated, '
-                    'loads is now the second argument and optional.').warn()
+            SymPyDeprecationWarning(value='The API for kanes_equations() has changed such '
+                    'that the loads (forces and torques) are now the second argument '
+                    'and is optional with None being the default.',
+                    feature='The kanes_equation() argument order',
+                    last_supported_version="1.0",
+                    useinstead='switched argument order to update your code, For example: '
+                    'kanes_equations(loads, bodies) > kanes_equations(bodies, loads).',
+                    issue=10945, deprecated_since_version="1.0").warn()
 
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -267,10 +267,8 @@ class KanesMethod(object):
 
     def _form_fr(self, fl):
         """Form the generalized active force."""
-        if not fl or len(fl) == 0 or len(fl[0]) == 0:
-            fl = [(self._inertial, 0 * self._inertial.x)]
-        elif not iterable(fl):
-            raise TypeError('Force pairs must be supplied in an iterable.')
+        if fl and not iterable(fl):
+            raise TypeError('Force pairs must be supplied in an iterable or empty.')
 
         N = self._inertial
         # pull out relevant velocities for constructing partial velocities

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -268,7 +268,8 @@ class KanesMethod(object):
     def _form_fr(self, fl):
         """Form the generalized active force."""
         if fl != None and (len(fl) == 0 or not iterable(fl)):
-            raise TypeError('Force pairs must be supplied in an non-empty iterable or None.')
+            raise ValueError('Force pairs must be supplied in an '
+                'non-empty iterable or None.')
 
         N = self._inertial
         # pull out relevant velocities for constructing partial velocities

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -696,14 +696,14 @@ class KanesMethod(object):
         Parameters
         ==========
 
-        loads : list
-            Takes in a list of (Point, Vector) or (ReferenceFrame, Vector)
+        loads : iterable
+            Takes in an iterable of (Point, Vector) or (ReferenceFrame, Vector)
             tuples which represent the force at a point or torque on a frame.
             Must be either a non-empty list of tuples or None which corresponds
             to a system with no constraints.
-        bodies : list
-            A list of all RigidBody's and Particle's in the system.
-
+        bodies : iterable
+            An iterable of all RigidBody's and Particle's in the system.
+            A system must have at least one body.
         """
 
         if not self._k_kqdot:

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -267,8 +267,9 @@ class KanesMethod(object):
 
     def _form_fr(self, fl):
         """Form the generalized active force."""
-
-        if not iterable(fl):
+        if not fl or len(fl) == 0 or len(fl[0]) == 0:
+            fl = [(self._inertial, 0 * self._inertial.x)]
+        elif not iterable(fl):
             raise TypeError('Force pairs must be supplied in an iterable.')
 
         N = self._inertial
@@ -708,12 +709,7 @@ class KanesMethod(object):
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')
-        #Create a dummy load (inertial, zero vector) if no load is given
-        if FL == () or len(FL[0]) == 0:
-            fr = self._form_fr([(self._inertial, 0 * self._inertial.x)])
-        #Compute load as usual
-        else:
-            fr = self._form_fr(FL)
+        fr = self._form_fr(FL)
         frstar = self._form_frstar(BL)
         if self._uaux:
             if not self._udep:

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -697,18 +697,22 @@ class KanesMethod(object):
         ==========
 
         loads : iterable
-            Takes in an iterable of (Point, Vector) or (ReferenceFrame, Vector)
+            Takes in an iterable of (Particle, Vector) or (ReferenceFrame, Vector)
             tuples which represent the force at a point or torque on a frame.
             Must be either a non-empty iterable of tuples or None which corresponds
             to a system with no constraints.
         bodies : iterable
             An iterable of all RigidBody's and Particle's in the system.
 
+        and
+            ( (isinstance(bodies[0][0], Particle) and isinstance(bodies[0][1], Vector)) or
+            (isinstance(bodies[0][0], ReferenceFrame) and isinstance(bodies[0][1], Vector)) )
         """
-        if isinstance(bodies[0], (ReferenceFrame, Vector)) or isinstance(bodies[0], (Particle, Vector)) or bodies is None:
-        # This switches the order if they use the old way.
+        if (bodies is None and loads != None) or ( isinstance(bodies[0], tuple) ):
+            # This switches the order if they use the old way.
             bodies, loads = loads, bodies
-            raise DeprecationWarning("The API has changed and will be deprecated, loads is now the second argument and optional.")
+            SymPyDeprecationWarning('The API has changed and will be deprecated, '
+                    'loads is now the second argument and optional.').warn()
 
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -708,8 +708,12 @@ class KanesMethod(object):
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')
-
-        fr = self._form_fr(FL)
+        #Create a dummy load (inertial, zero vector) if no load is given
+        if FL == () or len(FL[0]) == 0:
+            fr = self._form_fr([(self._inertial, 0 * self._inertial.x)])
+        #Compute load as usual
+        else:
+            fr = self._form_fr(FL)
         frstar = self._form_frstar(BL)
         if self._uaux:
             if not self._udep:

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -713,10 +713,9 @@ class KanesMethod(object):
                     'that the loads (forces and torques) are now the second argument '
                     'and is optional with None being the default.',
                     feature='The kanes_equation() argument order',
-                    last_supported_version="1.0",
                     useinstead='switched argument order to update your code, For example: '
                     'kanes_equations(loads, bodies) > kanes_equations(bodies, loads).',
-                    issue=10945, deprecated_since_version="1.0").warn()
+                    issue=10945, deprecated_since_version="1.1").warn()
 
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -267,8 +267,8 @@ class KanesMethod(object):
 
     def _form_fr(self, fl):
         """Form the generalized active force."""
-        if fl and not iterable(fl):
-            raise TypeError('Force pairs must be supplied in an iterable or empty.')
+        if fl != None and (len(fl) == 0 or not iterable(fl)):
+            raise TypeError('Force pairs must be supplied in an non-empty iterable or None.')
 
         N = self._inertial
         # pull out relevant velocities for constructing partial velocities
@@ -683,7 +683,7 @@ class KanesMethod(object):
             f_lin_B = Matrix()
         return (f_lin_A, f_lin_B, Matrix(other_dyns))
 
-    def kanes_equations(self, FL, BL):
+    def kanes_equations(self, loads=None, bodies=None):
         """ Method to form Kane's equations, Fr + Fr* = 0.
 
         Returns (Fr, Fr*). In the case where auxiliary generalized speeds are
@@ -696,10 +696,12 @@ class KanesMethod(object):
         Parameters
         ==========
 
-        FL : list
+        loads : list
             Takes in a list of (Point, Vector) or (ReferenceFrame, Vector)
             tuples which represent the force at a point or torque on a frame.
-        BL : list
+            Must be either a non-empty list of tuples or None which corresponds
+            to a system with no constraints.
+        bodies : list
             A list of all RigidBody's and Particle's in the system.
 
         """
@@ -707,8 +709,8 @@ class KanesMethod(object):
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '
                     'kinematic differential equations to use this method.')
-        fr = self._form_fr(FL)
-        frstar = self._form_frstar(BL)
+        fr = self._form_fr(loads)
+        frstar = self._form_frstar(bodies)
         if self._uaux:
             if not self._udep:
                 km = KanesMethod(self._inertial, self.q, self._uaux,
@@ -720,8 +722,8 @@ class KanesMethod(object):
                         self._f_nh))
             km._qdot_u_map = self._qdot_u_map
             self._km = km
-            fraux = km._form_fr(FL)
-            frstaraux = km._form_frstar(BL)
+            fraux = km._form_fr(loads)
+            frstaraux = km._form_frstar(bodies)
             self._aux_eq = fraux + frstaraux
             self._fr = fr.col_join(fraux)
             self._frstar = frstar.col_join(frstaraux)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -705,7 +705,7 @@ class KanesMethod(object):
             An iterable of all RigidBody's and Particle's in the system.
             A system must have at least one body.
         """
-        if (bodies is None and loads != None) or ( isinstance(bodies[0], tuple) ):
+        if (bodies is None and loads != None) or isinstance(bodies[0], tuple):
             # This switches the order if they use the old way.
             bodies, loads = loads, bodies
             SymPyDeprecationWarning('The API has changed and will be deprecated, '

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -5,7 +5,7 @@ __all__ = ['KanesMethod']
 from sympy import zeros, Matrix, diff, solve_linear_system_LU, eye
 from sympy.core.compatibility import range
 from sympy.utilities import default_sort_key
-from sympy.physics.vector import (ReferenceFrame, dynamicsymbols,
+from sympy.physics.vector import (Vector, ReferenceFrame, dynamicsymbols,
                                   partial_velocity)
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
@@ -683,7 +683,7 @@ class KanesMethod(object):
             f_lin_B = Matrix()
         return (f_lin_A, f_lin_B, Matrix(other_dyns))
 
-    def kanes_equations(self, loads=None, bodies=None):
+    def kanes_equations(self, bodies, loads=None):
         """ Method to form Kane's equations, Fr + Fr* = 0.
 
         Returns (Fr, Fr*). In the case where auxiliary generalized speeds are
@@ -696,15 +696,19 @@ class KanesMethod(object):
         Parameters
         ==========
 
-        loads : list
-            Takes in a list of (Point, Vector) or (ReferenceFrame, Vector)
+        loads : iterable
+            Takes in an iterable of (Point, Vector) or (ReferenceFrame, Vector)
             tuples which represent the force at a point or torque on a frame.
-            Must be either a non-empty list of tuples or None which corresponds
+            Must be either a non-empty iterable of tuples or None which corresponds
             to a system with no constraints.
-        bodies : list
-            A list of all RigidBody's and Particle's in the system.
+        bodies : iterable
+            An iterable of all RigidBody's and Particle's in the system.
 
         """
+        if isinstance(bodies[0], (ReferenceFrame, Vector)) or isinstance(bodies[0], (Particle, Vector)) or bodies is None:
+        # This switches the order if they use the old way.
+            bodies, loads = loads, bodies
+            raise DeprecationWarning("The API has changed and will be deprecated, loads is now the second argument and optional.")
 
         if not self._k_kqdot:
             raise AttributeError('Create an instance of KanesMethod with '

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -31,6 +31,9 @@ def test_one_dof():
     assert expand(rhs[0]) == expand(-(q * k + u * c) / m)
     assert (KM.linearize(A_and_B=True, new_method=True)[0] ==
             Matrix([[0, 1], [-k/m, -c/m]]))
+    assert KM.kanes_equations((), BL)[0] == Matrix([0])
+    assert KM.kanes_equations(None, BL)[0] == Matrix([0])
+    assert KM.kanes_equations([()], BL)[0] == Matrix([0])
 
     # Ensure that the old linearizer still works and that the new linearizer
     # gives the same results. The old linearizer is deprecated and should be

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -323,6 +323,9 @@ def test_input_format():
     assert KM.kanes_equations(BL, loads=None)[0] == Matrix([0])
     # test for input format kane.kanes_equations(bodies=(body1, body 2))
     assert KM.kanes_equations(BL)[0] == Matrix([0])
+    # test for error raised when a wrong force list (in this case a string) is provided
+    from sympy.utilities.pytest import raises
+    raises(ValueError, lambda: KM._form_fr('bad input'))
 
     # 2 dof problem from test_two_dof
     q1, q2, u1, u2 = dynamicsymbols('q1 q2 u1 u2')

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -320,7 +320,7 @@ def test_input_format():
     BL = [pa1, pa2]
 
     KM = KanesMethod(N, q_ind=[q1, q2], u_ind=[u1, u2], kd_eqs=kd)
-    # test for input format 
+    # test for input format
     # kane.kanes_equations(bodies_and_particles=(body1, body2), loads=(load1, load2))
     KM.kanes_equations(bodies=BL, loads=FL)
     MM = KM.mass_matrix

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -292,13 +292,13 @@ def test_input_format():
     P.set_vel(N, u * N.x)
 
     kd = [qd - u]
-    FL = [(P, (-k * q - c * u) * N.x)]
+    FL = ((P, (-k * q - c * u) * N.x))
     pa = Particle('pa', P, m)
     BL = [pa]
 
     KM = KanesMethod(N, [q], [u], kd)
-    # test for input format kane.kanes_equations(None, (body1, body2, particle1))
-    assert KM.kanes_equations(None, BL)[0] == Matrix([0])
+    # test for input format kane.kanes_equations((body1, body2, particle1))
+    assert KM.kanes_equations(BL)[0] == Matrix([0])
     # test for input format kane.kanes_equations(bodies=(body1, body 2), loads=None)
     assert KM.kanes_equations(bodies=BL, loads=None)[0] == Matrix([0])
 
@@ -313,11 +313,11 @@ def test_input_format():
     P2.set_vel(N, (u1 + u2) * N.x)
     kd = [q1d - u1, q2d - u2]
 
-    FL = [(P1, (-k1 * q1 - c1 * u1 + k2 * q2 + c2 * u2) * N.x), (P2, (-k2 *
-        q2 - c2 * u2) * N.x)]
+    FL = ((P1, (-k1 * q1 - c1 * u1 + k2 * q2 + c2 * u2) * N.x), (P2, (-k2 *
+        q2 - c2 * u2) * N.x))
     pa1 = Particle('pa1', P1, m)
     pa2 = Particle('pa2', P2, m)
-    BL = [pa1, pa2]
+    BL = (pa1, pa2)
 
     KM = KanesMethod(N, q_ind=[q1, q2], u_ind=[u1, u2], kd_eqs=kd)
     # test for input format

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -24,7 +24,11 @@ def test_one_dof():
     BL = [pa]
 
     KM = KanesMethod(N, [q], [u], kd)
-    KM.kanes_equations(FL, BL)
+    # The old input format raises a deprecation warning, so catch it here so
+    # it doesn't cause py.test to fail.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        KM.kanes_equations(FL, BL)
     MM = KM.mass_matrix
     forcing = KM.forcing
     rhs = MM.inv() * forcing
@@ -72,7 +76,11 @@ def test_two_dof():
     # pass relevant information, and form Fr & Fr*. Then we calculate the mass
     # matrix and forcing terms, and finally solve for the udots.
     KM = KanesMethod(N, q_ind=[q1, q2], u_ind=[u1, u2], kd_eqs=kd)
-    KM.kanes_equations(FL, BL)
+    # The old input format raises a deprecation warning, so catch it here so
+    # it doesn't cause py.test to fail.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        KM.kanes_equations(FL, BL)
     MM = KM.mass_matrix
     forcing = KM.forcing
     rhs = MM.inv() * forcing
@@ -95,7 +103,9 @@ def test_pend():
     BL = [pa]
 
     KM = KanesMethod(N, [q], [u], kd)
-    KM.kanes_equations(FL, BL)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        KM.kanes_equations(FL, BL)
     MM = KM.mass_matrix
     forcing = KM.forcing
     rhs = MM.inv() * forcing
@@ -156,7 +166,9 @@ def test_rolling_disc():
     # terms, then solve for the u dots (time derivatives of the generalized
     # speeds).
     KM = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3], kd_eqs=kd)
-    KM.kanes_equations(ForceList, BodyList)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        KM.kanes_equations(ForceList, BodyList)
     MM = KM.mass_matrix
     forcing = KM.forcing
     rhs = MM.inv() * forcing
@@ -209,13 +221,17 @@ def test_aux():
 
     KM = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3, u4, u5],
                      kd_eqs=kd)
-    (fr, frstar) = KM.kanes_equations(ForceList, BodyList)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        (fr, frstar) = KM.kanes_equations(ForceList, BodyList)
     fr = fr.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
     frstar = frstar.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
 
     KM2 = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3], kd_eqs=kd,
                       u_auxiliary=[u4, u5])
-    (fr2, frstar2) = KM2.kanes_equations(ForceList, BodyList)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        (fr2, frstar2) = KM2.kanes_equations(ForceList, BodyList)
     fr2 = fr2.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
     frstar2 = frstar2.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
 
@@ -278,7 +294,9 @@ def test_parallel_axis():
                  (C, N.x * F)]
 
     km = KanesMethod(N, [q1, q2], [u1, u2], kindiffs)
-    (fr, frstar) = km.kanes_equations(forceList, bodyList)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        (fr, frstar) = km.kanes_equations(forceList, bodyList)
     mm = km.mass_matrix_full
     assert mm[3, 3] == Iz
 
@@ -292,15 +310,20 @@ def test_input_format():
     P.set_vel(N, u * N.x)
 
     kd = [qd - u]
-    FL = ((P, (-k * q - c * u) * N.x))
+    FL = [(P, (-k * q - c * u) * N.x)]
     pa = Particle('pa', P, m)
     BL = [pa]
 
     KM = KanesMethod(N, [q], [u], kd)
     # test for input format kane.kanes_equations((body1, body2, particle1))
     assert KM.kanes_equations(BL)[0] == Matrix([0])
-    # test for input format kane.kanes_equations(bodies=(body1, body 2), loads=None)
+    # test for input format kane.kanes_equations(bodies=(body1, body 2), loads=(load1,load2))
     assert KM.kanes_equations(bodies=BL, loads=None)[0] == Matrix([0])
+    # test for input format kane.kanes_equations(bodies=(body1, body 2), loads=None)
+    assert KM.kanes_equations(BL, loads=None)[0] == Matrix([0])
+    # test for input format kane.kanes_equations(bodies=(body1, body 2))
+    assert KM.kanes_equations(BL)[0] == Matrix([0])
+
 
     # 2 dof problem from test_two_dof
     q1, q2, u1, u2 = dynamicsymbols('q1 q2 u1 u2')
@@ -321,8 +344,8 @@ def test_input_format():
 
     KM = KanesMethod(N, q_ind=[q1, q2], u_ind=[u1, u2], kd_eqs=kd)
     # test for input format
-    # kane.kanes_equations(bodies_and_particles=(body1, body2), loads=(load1, load2))
-    KM.kanes_equations(bodies=BL, loads=FL)
+    # kane.kanes_equations((body1, body2), (load1, load2))
+    KM.kanes_equations(BL, FL)
     MM = KM.mass_matrix
     forcing = KM.forcing
     rhs = MM.inv() * forcing

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -301,6 +301,8 @@ def test_input_format():
     assert KM.kanes_equations(None, BL)[0] == Matrix([0])
     # test for input format kane.kanes_equations(bodies=(body1, body 2), loads=None)
     assert KM.kanes_equations(bodies=BL, loads=None)[0] == Matrix([0])
+    # test for input format kane.kanes_equations(bodies=(body1, body 2))
+    assert KM.kanes_equations(bodies=BL)[0] == Matrix([0])
 
     # 2 dof problem from test_two_dof
     q1, q2, u1, u2 = dynamicsymbols('q1 q2 u1 u2')
@@ -313,11 +315,11 @@ def test_input_format():
     P2.set_vel(N, (u1 + u2) * N.x)
     kd = [q1d - u1, q2d - u2]
 
-    FL = [(P1, (-k1 * q1 - c1 * u1 + k2 * q2 + c2 * u2) * N.x), (P2, (-k2 *
-        q2 - c2 * u2) * N.x)]
+    FL = ((P1, (-k1 * q1 - c1 * u1 + k2 * q2 + c2 * u2) * N.x), (P2, (-k2 *
+        q2 - c2 * u2) * N.x))
     pa1 = Particle('pa1', P1, m)
     pa2 = Particle('pa2', P2, m)
-    BL = [pa1, pa2]
+    BL = (pa1, pa2)
 
     KM = KanesMethod(N, q_ind=[q1, q2], u_ind=[u1, u2], kd_eqs=kd)
     # test for input format

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -1,9 +1,12 @@
+import warnings
+
 from sympy.core.compatibility import range
 from sympy import cos, Matrix, simplify, sin, solve, tan, pi
 from sympy import symbols, trigsimp, zeros
 from sympy.physics.mechanics import (cross, dot, dynamicsymbols, KanesMethod,
                                      inertia, inertia_of_point_mass,
                                      Point, ReferenceFrame, RigidBody)
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
 def test_aux_dep():
@@ -177,7 +180,9 @@ def test_aux_dep():
         )
 
     # fr, frstar, frstar_steady and kdd(kinematic differential equations).
-    (fr, frstar)= kane.kanes_equations(forceList, bodyList)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        (fr, frstar)= kane.kanes_equations(forceList, bodyList)
     frstar_steady = frstar.subs(ud_zero).subs(u_dep_dict).subs(steady_conditions)\
                     .subs({q[3]: -r*cos(q[1])}).expand()
     kdd = kane.kindiffdict()
@@ -261,7 +266,9 @@ def test_non_central_inertia():
 
     forces = [(pS_star, -M*g*F.x), (pQ, Q1*A.x + Q2*A.y + Q3*A.z)]
     bodies = [rbA, rbB, rbC]
-    fr, fr_star = km.kanes_equations(forces, bodies)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        fr, fr_star = km.kanes_equations(forces, bodies)
     vc_map = solve(vc, [u4, u5])
 
     # KanesMethod returns the negative of Fr, Fr* as defined in Kane1985.
@@ -282,7 +289,9 @@ def test_non_central_inertia():
                                            rb.frame)
         bodies2.append(RigidBody('', rb.masscenter, rb.frame, rb.mass,
                                  (I, pD)))
-    fr2, fr_star2 = km.kanes_equations(forces, bodies2)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        fr2, fr_star2 = km.kanes_equations(forces, bodies2)
     assert (trigsimp(fr_star2.subs(vc_map).subs(u3, 0)).doit().expand() ==
             fr_star_expected.expand())
 
@@ -370,7 +379,9 @@ def test_sub_qdot():
             -(mA + 2*mB +2*J/R**2) * u2.diff(t) + mA*a*u1**2,
             0])
 
-    fr, fr_star = km.kanes_equations(forces, bodies)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        fr, fr_star = km.kanes_equations(forces, bodies)
     assert (fr.expand() == fr_expected.expand())
     assert (trigsimp(fr_star).expand() == fr_star_expected.expand())
 
@@ -430,7 +441,9 @@ def test_sub_qdot2():
     u_expr += qd[3:]
     kde = [ui - e for ui, e in zip(u, u_expr)]
     km1 = KanesMethod(A, q, u, kde)
-    fr1, _ = km1.kanes_equations(forces, [])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        fr1, _ = km1.kanes_equations(forces, [])
 
     ## Calculate generalized active forces if we impose the condition that the
     # disk C is rolling without slipping
@@ -439,7 +452,9 @@ def test_sub_qdot2():
     vc = [pC_hat.vel(A) & uv for uv in [A.x, A.y]]
     km2 = KanesMethod(A, q, u_indep, kde,
                       u_dependent=u_dep, velocity_constraints=vc)
-    fr2, _ = km2.kanes_equations(forces, [])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        fr2, _ = km2.kanes_equations(forces, [])
 
     fr1_expected = Matrix([
         -R*g*m*sin(q[1]),

--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -175,7 +175,9 @@ def test_bicycle():
             u_ind=[u2, u3, u5],
             u_dependent=[u1, u4, u6], velocity_constraints=conlist_speed,
             kd_eqs=kd)
-    (fr, frstar) = KM.kanes_equations(FL, BL)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        (fr, frstar) = KM.kanes_equations(FL, BL)
 
     # This is the start of entering in the numerical values from the benchmark
     # paper to validate the eigen values of the linearized equations from this

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,9 +1,11 @@
 from __future__ import division
+import warnings
 from sympy import symbols, Matrix, solve, simplify, cos, sin, atan, sqrt
 from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
     dot, cross, inertia, KanesMethod, Particle, RigidBody, Lagrangian,\
     LagrangesMethod
 from sympy.utilities.pytest import slow
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
 @slow
@@ -74,7 +76,9 @@ def test_linearize_rolling_disc_kane():
     KM = KanesMethod(N, [q1, q2, q3, q4, q5], [u1, u2, u3], kd_eqs=kindiffs,
             q_dependent=[q6], configuration_constraints=f_c,
             u_dependent=[u4, u5, u6], velocity_constraints=f_v)
-    (fr, fr_star) = KM.kanes_equations(FL, BL)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        (fr, fr_star) = KM.kanes_equations(FL, BL)
 
     # Test generalized form equations
     linearizer = KM.to_linearizer()
@@ -157,7 +161,9 @@ def test_linearize_pendulum_kane_minimal():
 
     # Solve for eom with kanes method
     KM = KanesMethod(N, q_ind=[q1], u_ind=[u1], kd_eqs=kde)
-    (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
 
     # Linearize
     A, B, inp_vec = KM.linearize(A_and_B=True, new_method=True, simplify=True)
@@ -216,7 +222,9 @@ def test_linearize_pendulum_kane_nonminimal():
     KM = KanesMethod(N, q_ind=[q2], u_ind=[u2], q_dependent=[q1],
             u_dependent=[u1], configuration_constraints=f_c,
             velocity_constraints=f_v, acceleration_constraints=f_a, kd_eqs=kde)
-    (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
 
     # Set the operating point to be straight down, and non-moving
     q_op = {q1: L, q2: 0}


### PR DESCRIPTION
Fixes to #10841. 
I have made changes to the kanes_method in KanesMethod to accept 
a load that is either None, an empty tuple or a list containing one empty
tuple. The new fr will be calculated with a dummy tuple of the inertial
frame of the system and the zero vector in that frame. The new fr will be
a Matrix of zero column as desired.
