### PR TITLE
row_join() and col_join() of sparse.py modified for empty matrices

### DIFF
--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1371,8 +1371,7 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         True
         """
         if not self:
-            typ = type(self)
-            return typ(other)
+            return type(self)(other)
         A, B = self, other
         if not A.rows == B.rows:
             raise ShapeError()
@@ -1432,8 +1431,7 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         True
         """
         if not self:
-            typ = type(self)
-            return typ(other)
+            return type(self)(other)
         A, B = self, other
         if not A.cols == B.cols:
             raise ShapeError()

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -1370,6 +1370,9 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         >>> C == A.col_insert(A.cols, B)
         True
         """
+        if not self:
+            typ = type(self)
+            return typ(other)
         A, B = self, other
         if not A.rows == B.rows:
             raise ShapeError()
@@ -1428,6 +1431,9 @@ class MutableSparseMatrix(SparseMatrix, MatrixBase):
         >>> C == A.row_insert(A.rows, Matrix(B))
         True
         """
+        if not self:
+            typ = type(self)
+            return typ(other)
         A, B = self, other
         if not A.cols == B.cols:
             raise ShapeError()

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -18,6 +18,14 @@ def test_sparse_matrix():
     ))
     assert SparseMatrix(a) == a
 
+    from sympy.matrices import MutableSparseMatrix, MutableDenseMatrix
+    a = MutableSparseMatrix([])
+    b = MutableDenseMatrix([1, 2])
+    assert a.row_join(b) == b
+    assert a.col_join(b) == b
+    assert type(a.row_join(b)) == type(a)
+    assert type(a.col_join(b)) == type(a)
+
     # test element assignment
     a = SparseMatrix((
         (1, 0),


### PR DESCRIPTION
This fixes the issue of rebuilding a sparse matrix from an empty sparse matrix. Actually this is a fix to [this issue](https://github.com/sympy/sympy/issues/10770). Due to some problems creating a separate pull request. 
