### PR TITLE
Issue#10801 : Made limits work with a binomial expression

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -853,6 +853,9 @@ class binomial(CombinatorialFunction):
         from sympy import gamma
         return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
 
+    def _eval_rewrite_as_tractable(self, n, k):
+        return self._eval_rewrite_as_gamma(n, k).rewrite('tractable')
+
     def _eval_rewrite_as_FallingFactorial(self, n, k):
         if k.is_integer:
             return ff(n, k) / factorial(k)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.compatibility import string_types
 from sympy.core.symbol import Dummy
-from sympy.functions.combinatorial.factorials import factorial, binomial
+from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.special.gamma_functions import gamma
 from sympy.series.order import Order
 from .gruntz import gruntz
@@ -135,11 +135,6 @@ class Limit(Expr):
 
         if not e.has(z):
             return e
-
-        # limit can work with binomial by converting to factorial first
-        if (e.has(binomial) and not (hints.get('sequence', True)
-            and z0 is S.Infinity)):
-            e = e.rewrite(factorial)
 
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul
 from sympy.core.compatibility import string_types
 from sympy.core.symbol import Dummy
-from sympy.functions.combinatorial.factorials import factorial
+from sympy.functions.combinatorial.factorials import factorial, binomial
 from sympy.functions.special.gamma_functions import gamma
 from sympy.series.order import Order
 from .gruntz import gruntz
@@ -135,6 +135,11 @@ class Limit(Expr):
 
         if not e.has(z):
             return e
+
+        # limit can work with binomial by converting to factorial first
+        if (e.has(binomial) and not (hints.get('sequence', True)
+            and z0 is S.Infinity)):
+            e = e.rewrite(factorial)
 
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -458,7 +458,7 @@ def test_issue_8730():
 
 def test_issue_10801():
     # make sure limits work with binomial
-    assert limit(16**k/(k*binomial(2*k,k)**2), k, oo) == pi
+    assert limit(16**k / (k * binomial(2*k, k)**2), k, oo) == pi
 
 
 def test_issue_9205():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -456,6 +456,11 @@ def test_issue_8730():
     assert limit(subfactorial(x), x, oo) == oo
 
 
+def test_issue_10801():
+    # make sure limits work with binomial
+    assert limit(16**k/(k*binomial(2*k,k)**2), k, oo) == pi
+
+
 def test_issue_9205():
     x, y, a = symbols('x, y, a')
     assert Limit(x, x, a).free_symbols == {a}


### PR DESCRIPTION
This patch fixes #10801 .

The issue was that this doesn't work:
`limit(16**k/(k*binomial(2*k,k)**2), k, oo)`
In general limit doesn't work with such expressions. 
So to fix it we can check if it contains binomial and then convert it to factorial form.
Now it works as shown:

```
In [1]: limit(16**k/(k*binomial(2*k,k)**2), k, oo)
Out[1]: π
```

Please review. 
