### PR TITLE
Corrected condition for NotImplementedError  in nthroot_pow

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -775,10 +775,10 @@ def nthroot_mod(a, n, p, all_roots=False):
         return sqrt_mod(a, p , all_roots)
     f = totient(p)
     # see Hackman "Elementary Number Theory" (2009), page 76
+    if primitive_root(p) == None:
+        raise NotImplementedError("Not Implemented for m without primitive root")
     if pow(a, f // igcd(f, n), p) != 1:
         return None
-    if not isprime(p):
-        raise NotImplementedError
 
     if (p - 1) % n == 0:
         return _nthroot_mod1(a, n, p, all_roots)

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -775,10 +775,10 @@ def nthroot_mod(a, n, p, all_roots=False):
         return sqrt_mod(a, p , all_roots)
     f = totient(p)
     # see Hackman "Elementary Number Theory" (2009), page 76
+    if not is_nthpow_residue(a, n, p):
+        return None
     if primitive_root(p) == None:
         raise NotImplementedError("Not Implemented for m without primitive root")
-    if pow(a, f // igcd(f, n), p) != 1:
-        return None
 
     if (p - 1) % n == 0:
         return _nthroot_mod1(a, n, p, all_roots)

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -166,6 +166,8 @@ def test_residue():
         r = nthroot_mod(a, q, p)
         assert pow(r, q, p) == a
     assert nthroot_mod(11, 3, 109) is None
+    raises(NotImplementedError, lambda: nthroot_mod(16, 5, 36))
+    raises(NotImplementedError, lambda: nthroot_mod(9, 16, 36))
 
     for p in primerange(5, 100):
         qv = range(3, p, 4)


### PR DESCRIPTION
Fixed #10886 
Now

```
In [1]: nthroot_mod(16, 5, 36)      
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
<ipython-input-1-51bcd0bb57e5> in <module>()
----> 1 nthroot_mod(16, 5, 36)

/home/silicon-lover/code/sympy/sympy/ntheory/residue_ntheory.pyc in nthroot_mod(a, n, p, all_roots)
    777     # see Hackman "Elementary Number Theory" (2009), page 76
    778     if primitive_root(p) == None:
--> 779         raise NotImplementedError("Not Implemented for m without primitive root")
    780     if pow(a, f // igcd(f, n), p) != 1:
    781         return None

NotImplementedError: Not Implemented for m without primitive root
```
