### PR TITLE
added definition for __nonzero__ to ProductSet class

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -665,8 +665,9 @@ class ProductSet(Set):
     def __len__(self):
         return Mul(*[len(s) for s in self.args])
 
-    def __nonzero__(self):
+    def __bool__(self):
         return all([bool(s) for s in self.args])
+    __nonzero__ = __bool__
 
 
 class Interval(Set, EvalfMixin):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -667,6 +667,7 @@ class ProductSet(Set):
 
     def __bool__(self):
         return all([bool(s) for s in self.args])
+        
     __nonzero__ = __bool__
 
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -665,6 +665,9 @@ class ProductSet(Set):
     def __len__(self):
         return Mul(*[len(s) for s in self.args])
 
+    def __nonzero__(self):
+        return all([bool(s) for s in self.args])
+
 
 class Interval(Set, EvalfMixin):
     """

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1024,7 +1024,6 @@ def test_issue_10285():
         FiniteSet(s).intersect(Interval.Lopen(2, oo))
 
 
-
 def test_bool_ProductSet():
     assert bool(Interval(0,2) * Interval(1,3))
     assert not bool(Interval(1,0) * Interval(0,2))
@@ -1032,3 +1031,4 @@ def test_bool_ProductSet():
     assert bool(FiniteSet(1,2,3,4) * Interval(0,2))
     assert not bool(FiniteSet(1,2,3,4) * Interval(1,0))
     assert bool(FiniteSet(1,2,3,4) * FiniteSet(3,4))
+    

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -781,6 +781,7 @@ def test_image_FiniteSet():
     x = Symbol('x', real=True)
     assert imageset(x, 2*x, FiniteSet(1, 2, 3)) == FiniteSet(2, 4, 6)
 
+
 def test_image_Union():
     x = Symbol('x', real=True)
     assert imageset(x, x**2, Interval(-2, 0) + FiniteSet(1, 2, 3)) == \
@@ -1021,3 +1022,13 @@ def test_issue_10285():
     ivl = Interval.Lopen(1, oo)
     assert FiniteSet(eq).intersect(ivl) == \
         FiniteSet(s).intersect(Interval.Lopen(2, oo))
+
+
+
+def test_bool_ProductSet():
+    assert bool(Interval(0,2) * Interval(1,3))
+    assert not bool(Interval(1,0) * Interval(0,2))
+    assert not bool(Interval(1,0) * Interval(2,0))
+    assert bool(FiniteSet(1,2,3,4) * Interval(0,2))
+    assert not bool(FiniteSet(1,2,3,4) * Interval(1,0))
+    assert bool(FiniteSet(1,2,3,4) * FiniteSet(3,4))


### PR DESCRIPTION
Defined `__nonzero__` for ProductSet class in response to issue #10859.  Function returns true if every argument in a ProductSet class is nonempty.
