### PR TITLE
Partial velocities no longer require frame re-expression.

### DIFF
--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -517,12 +517,10 @@ def get_motion_params(frame, **kwargs):
         return (acc, vel, kwargs['position'])
 
 
-def partial_velocity(vel_list, u_list, frame):
-    """Returns a list of partial velocities.
-
-    For a list of velocity or angular velocity vectors the partial derivatives
-    with respect to the supplied generalized speeds are computed, in the
-    specified ReferenceFrame.
+def partial_velocity(vel_vecs, gen_speeds, frame):
+    """Returns a list of partial velocities with respect to the provided
+    generalized speeds in the given reference frame for each of the supplied
+    velocity vectors.
 
     The output is a list of lists. The outer list has a number of elements
     equal to the number of supplied velocity vectors. The inner lists are, for
@@ -532,12 +530,13 @@ def partial_velocity(vel_list, u_list, frame):
     Parameters
     ==========
 
-    vel_list : list
-        List of velocities of Point's and angular velocities of ReferenceFrame's
-    u_list : list
-        List of independent generalized speeds.
+    vel_vecs : iterable
+        An iterable of velocity vectors (angular or linear).
+    gen_speeds : iterable
+        An iterable of generalized speeds.
     frame : ReferenceFrame
-        The ReferenceFrame the partial derivatives are going to be taken in.
+        The reference frame that the partial derivatives are going to be taken
+        in.
 
     Examples
     ========
@@ -549,24 +548,27 @@ def partial_velocity(vel_list, u_list, frame):
     >>> N = ReferenceFrame('N')
     >>> P = Point('P')
     >>> P.set_vel(N, u * N.x)
-    >>> vel_list = [P.vel(N)]
-    >>> u_list = [u]
-    >>> partial_velocity(vel_list, u_list, N)
+    >>> vel_vecs = [P.vel(N)]
+    >>> gen_speeds = [u]
+    >>> partial_velocity(vel_vecs, gen_speeds, N)
     [[N.x]]
 
     """
-    if not iterable(vel_list):
-        raise TypeError('Provide velocities in an iterable')
-    if not iterable(u_list):
-        raise TypeError('Provide speeds in an iterable')
-    list_of_pvlists = []
-    for i in vel_list:
-        pvlist = []
-        for j in u_list:
-            vel = i.diff(j, frame)
-            pvlist += [vel]
-        list_of_pvlists += [pvlist]
-    return list_of_pvlists
+
+    if not iterable(vel_vecs):
+        raise TypeError('Velocity vectors must be contained in an iterable.')
+
+    if not iterable(gen_speeds):
+        raise TypeError('Generalized speeds must be contained in an iterable')
+
+    vec_partials = []
+    for vec in vel_vecs:
+        partials = []
+        for speed in gen_speeds:
+            partials.append(vec.diff(speed, frame, var_in_dcm=False))
+        vec_partials.append(partials)
+
+    return vec_partials
 
 
 def dynamicsymbols(names, level=0):

--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -1,11 +1,10 @@
 from sympy import S, Integral, sin, cos, pi, sqrt, symbols
-from sympy.physics.vector import (Dyadic, Point, ReferenceFrame, \
-                                  Vector)
-from sympy.physics.vector import (cross, dot, express, \
-                                  time_derivative, kinematic_equations, \
-                                  outer, partial_velocity, \
-                                  get_motion_params)
-from sympy.physics.vector.functions import dynamicsymbols
+from sympy.physics.vector import Dyadic, Point, ReferenceFrame, Vector
+from sympy.physics.vector.functions import (cross, dot, express,
+                                            time_derivative,
+                                            kinematic_equations, outer,
+                                            partial_velocity,
+                                            get_motion_params, dynamicsymbols)
 from sympy.utilities.pytest import raises
 
 Vector.simp = True
@@ -465,3 +464,10 @@ def test_partial_velocity():
             [[- r*L.y, r*L.x, 0, L.x, cos(q2)*L.y - sin(q2)*L.z],
             [0, 0, 0, L.x, cos(q2)*L.y - sin(q2)*L.z],
             [L.x, L.y, L.z, 0, 0]])
+
+    # Make sure that partial velocities can be computed regardless if the
+    # orientation between frames is defined or not.
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    v = u4 * A.x + u5 * B.y
+    assert partial_velocity((v, ), (u4, u5), A) == [[A.x, B.y]]

--- a/sympy/physics/vector/tests/test_vector.py
+++ b/sympy/physics/vector/tests/test_vector.py
@@ -1,7 +1,7 @@
 from sympy import symbols, pi, sin, cos, ImmutableMatrix as Matrix
-from sympy.physics.vector import ReferenceFrame, Vector, \
-     dynamicsymbols, dot
+from sympy.physics.vector import ReferenceFrame, Vector, dynamicsymbols, dot
 from sympy.abc import x, y, z
+from sympy.utilities.pytest import raises
 
 
 Vector.simp = True
@@ -53,6 +53,7 @@ def test_Vector():
     assert Vector(0).separate() == {}
     assert v1.separate() == {A: v1}
     assert v5.separate() == {A: x*A.x + y*A.y, B: z*B.z}
+
 
 def test_Vector_diffs():
     q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')
@@ -119,6 +120,25 @@ def test_Vector_diffs():
     assert v4.diff(q1d, B) == 0
     assert v4.diff(q2d, B) == A.x - q3 * cos(q3) * N.z
     assert v4.diff(q3d, B) == B.x + q3 * N.x + N.y
+
+
+def test_vector_var_in_dcm():
+
+    N = ReferenceFrame('N')
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    u1, u2, u3, u4 = dynamicsymbols('u1 u2 u3 u4')
+
+    v = u1 * u2 * A.x + u3 * N.y + u4**2 * N.z
+
+    assert v.diff(u1, N, var_in_dcm=False) == u2 * A.x
+    assert v.diff(u1, A, var_in_dcm=False) == u2 * A.x
+    assert v.diff(u3, N, var_in_dcm=False) == N.y
+    assert v.diff(u3, A, var_in_dcm=False) == N.y
+    assert v.diff(u3, B, var_in_dcm=False) == N.y
+    assert v.diff(u4, N, var_in_dcm=False) == 2 * u4 * N.z
+
+    raises(ValueError, lambda: v.diff(u1, N))
 
 
 def test_vector_simplify():

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -485,24 +485,30 @@ class Vector(object):
         return self | other
     outer.__doc__ = __or__.__doc__
 
-    def diff(self, wrt, otherframe):
-        """Takes the partial derivative, with respect to a value, in a frame.
-
-        Returns a Vector.
+    def diff(self, var, frame, var_in_dcm=True):
+        """Returns the partial derivative of the vector with respect to a
+        variable in the provided reference frame.
 
         Parameters
         ==========
-
-        wrt : Symbol
+        var : Symbol
             What the partial derivative is taken with respect to.
-        otherframe : ReferenceFrame
-            The ReferenceFrame that the partial derivative is taken in.
+        frame : ReferenceFrame
+            The reference frame that the partial derivative is taken in.
+        var_in_dcm : boolean
+            If true, the differentiation algorithm assumes that the variable
+            may be present in any of the direction cosine matrices that relate
+            the frame to the frames of any component of the vector. But if it
+            is known that the variable is not present in the direction cosine
+            matrices, false can be set to skip full reexpression in the desired
+            frame.
 
         Examples
         ========
 
-        >>> from sympy.physics.vector import ReferenceFrame, Vector, dynamicsymbols
         >>> from sympy import Symbol
+        >>> from sympy.physics.vector import dynamicsymbols, ReferenceFrame
+        >>> from sympy.physics.vector import Vector
         >>> Vector.simp = True
         >>> t = Symbol('t')
         >>> q1 = dynamicsymbols('q1')
@@ -510,24 +516,39 @@ class Vector(object):
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])
         >>> A.x.diff(t, N)
         - q1'*A.z
+        >>> B = ReferenceFrame('B')
+        >>> u1, u2 = dynamicsymbols('u1, u2')
+        >>> v = u1 * A.x + u2 * B.y
+        >>> v.diff(u2, N, var_in_dcm=False)
+        B.y
 
         """
 
         from sympy.physics.vector.frame import _check_frame
-        wrt = sympify(wrt)
-        _check_frame(otherframe)
-        outvec = Vector(0)
-        for i, v in enumerate(self.args):
-            if v[1] == otherframe:
-                outvec += Vector([(v[0].diff(wrt), otherframe)])
+
+        var = sympify(var)
+        _check_frame(frame)
+
+        partial = Vector(0)
+
+        for i, vector_component in enumerate(self.args):
+            measure_number = vector_component[0]
+            component_frame = vector_component[1]
+            if component_frame == frame:
+                partial += Vector([(measure_number.diff(var), frame)])
             else:
-                if otherframe.dcm(v[1]).diff(wrt) == zeros(3, 3):
-                    d = v[0].diff(wrt)
-                    outvec += Vector([(d, v[1])])
-                else:
-                    d = (Vector([v]).express(otherframe)).args[0][0].diff(wrt)
-                    outvec += Vector([(d, otherframe)]).express(v[1])
-        return outvec
+                # If the direction cosine matrix relating the component frame
+                # with the derivative frame does not contain the variable.
+                if not var_in_dcm or (frame.dcm(component_frame).diff(var) ==
+                                      zeros(3, 3)):
+                    partial += Vector([(measure_number.diff(var),
+                                        component_frame)])
+                else:  # else express in the frame
+                    a = Vector([vector_component]).express(frame)
+                    d = a.args[0][0].diff(var)
+                    partial += Vector([(d, frame)]).express(component_frame)
+
+        return partial
 
     def express(self, otherframe, variables=False):
         """

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -531,7 +531,7 @@ class Vector(object):
 
         partial = Vector(0)
 
-        for i, vector_component in enumerate(self.args):
+        for vector_component in self.args:
             measure_number = vector_component[0]
             component_frame = vector_component[1]
             if component_frame == frame:
@@ -544,9 +544,9 @@ class Vector(object):
                     partial += Vector([(measure_number.diff(var),
                                         component_frame)])
                 else:  # else express in the frame
-                    a = Vector([vector_component]).express(frame)
-                    d = a.args[0][0].diff(var)
-                    partial += Vector([(d, frame)]).express(component_frame)
+                    reexp_vec_comp = Vector([vector_component]).express(frame)
+                    deriv = reexp_vec_comp.args[0][0].diff(var)
+                    partial += Vector([(deriv, frame)]).express(component_frame)
 
         return partial
 


### PR DESCRIPTION
Fixes #10865

When computing a partial velocity (i.e. partial derivative of a velocity vector
with respect to a generalized speed), it is known a priori that the generalized
speed does not appear in the direction cosine matrices that relate any of the
unit vectors in the vector expression, so the partials can be computed without
the need to re-express the velocity vector in the desired reference frame.

To allow this to function a flag has been added to the Vector.diff() method
that specifies whether or not the user knows if the variable in question is or
isn't present in the direction cosine matrices. Secondly, the partial_velocity
function utilizes this flag to ensure that the partials properly compute even
if the orientation of the reference frames associated with the velocity vector
is not specified.

This change will allow users to more cleanly solve problems where the location
and orientation of the body with respect to the Newtonian frame is ignorable,
for example a simple satellite.
