### PR TITLE
Rewrite GoldenRatio in terms of sqrt

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3311,9 +3311,7 @@ class GoldenRatio(with_metaclass(Singleton, NumberSymbol)):
         import sage.all as sage
         return sage.golden_ratio
 
-    def _eval_rewrite_as_sqrt(self):
-        from sympy import sqrt
-        return S.Half + S.Half*sqrt(5)
+    _eval_rewrite_as_sqrt = _eval_expand_func
 
 
 class EulerGamma(with_metaclass(Singleton, NumberSymbol)):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3311,6 +3311,10 @@ class GoldenRatio(with_metaclass(Singleton, NumberSymbol)):
         import sage.all as sage
         return sage.golden_ratio
 
+    def _eval_rewrite_as_sqrt(self):
+        from sympy import sqrt
+        return S.Half + S.Half*sqrt(5)
+
 
 class EulerGamma(with_metaclass(Singleton, NumberSymbol)):
     r"""The Euler-Mascheroni constant.

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1544,3 +1544,7 @@ def test_mod_inverse():
     raises(TypeError, lambda: mod_inverse(2, x))
     raises(ValueError, lambda: mod_inverse(2, S.Half))
     raises(ValueError, lambda: mod_inverse(2, cos(1)**2 + sin(1)**2))
+
+
+def test_golden_ratio_rewrite_as_sqrt():
+    assert GoldenRatio.rewrite(sqrt) == S.Half + sqrt(5)*S.Half


### PR DESCRIPTION
Now the ouput is 

```
In [2]: GoldenRatio.rewrite(sqrt)
Out[2]:
      ___
1   \/ 5
- + -----
2     2
```

Also added tests.

---

TODO
- [x] should this be written as `_eval_expand_func`?
