### PR TITLE
Sympy-10313: Updated printing.rst

### DIFF
--- a/doc/src/tutorial/printing.rst
+++ b/doc/src/tutorial/printing.rst
@@ -229,6 +229,32 @@ format, which can be rendered with Graphviz.  See the
 :ref:`tutorial-manipulation` section for some examples of the output of this
 printer.
 
+    >>> from sympy.printing.dot import dotprint
+    >>> from sympy.abc import x
+    >>> print(dotprint(x+2)) 
+    digraph{
+
+    # Graph style
+    "ordering"="out"
+    "rankdir"="TD"
+
+    #########
+    # Nodes #
+    #########
+
+    "Add(Integer(2), Symbol(x))_()" ["color"="black", "label"="Add", "shape"="ellipse"];
+    "Integer(2)_(0,)" ["color"="black", "label"="2", "shape"="ellipse"];
+    "Symbol(x)_(1,)" ["color"="black", "label"="x", "shape"="ellipse"];
+
+    #########
+    # Edges #
+    #########
+
+    "Add(Integer(2), Symbol(x))_()" -> "Integer(2)_(0,)";
+    "Add(Integer(2), Symbol(x))_()" -> "Symbol(x)_(1,)";
+    }
+
+
 .. rubric:: Footnotes
 
 .. [#srepr-fn] SymPy does not use the Python builtin ``repr()`` function for

--- a/doc/src/tutorial/printing.rst
+++ b/doc/src/tutorial/printing.rst
@@ -233,23 +233,18 @@ printer.
     >>> from sympy.abc import x
     >>> print(dotprint(x+2)) 
     digraph{
-
     # Graph style
     "ordering"="out"
     "rankdir"="TD"
-
     #########
     # Nodes #
     #########
-
     "Add(Integer(2), Symbol(x))_()" ["color"="black", "label"="Add", "shape"="ellipse"];
     "Integer(2)_(0,)" ["color"="black", "label"="2", "shape"="ellipse"];
     "Symbol(x)_(1,)" ["color"="black", "label"="x", "shape"="ellipse"];
-
     #########
     # Edges #
     #########
-
     "Add(Integer(2), Symbol(x))_()" -> "Integer(2)_(0,)";
     "Add(Integer(2), Symbol(x))_()" -> "Symbol(x)_(1,)";
     }


### PR DESCRIPTION
Updated printing.rst, added an example for dot printing.
Fix for [#10313](https://github.com/sympy/sympy/issues/10313)
