### PR TITLE
Fix lambdify for Indexed

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -8,7 +8,8 @@ from __future__ import print_function, division
 import inspect
 import textwrap
 
-from sympy.core.compatibility import exec_, is_sequence, iterable, string_types, range, builtins
+from sympy.core.compatibility import (exec_, is_sequence, iterable,
+    NotIterable, string_types, range, builtins)
 from sympy.utilities.decorator import doctest_depends_on
 
 # These are the namespaces the lambda functions will use.
@@ -491,7 +492,7 @@ def lambdastr(args, expr, printer=None, dummify=False):
 
     # Transform args
     def isiter(l):
-        return iterable(l, exclude=(str, DeferredVector))
+        return iterable(l, exclude=(str, DeferredVector, NotIterable))
 
     if isiter(args) and any(isiter(i) for i in args):
         from sympy.utilities.iterables import flatten

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -7,7 +7,7 @@ from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
     Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
-    true, false, And, Or, Not, ITE, Min, Max, floor, diff)
+    true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum)
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import skip
@@ -651,3 +651,13 @@ def test_Min_Max():
     # see gh-10375
     assert lambdify((x, y, z), Min(x, y, z))(1, 2, 3) == 1
     assert lambdify((x, y, z), Max(x, y, z))(1, 2, 3) == 3
+
+def test_Indexed():
+    # Issue #10934
+    if not numpy:
+        skip("numpy not installed")
+
+    a = IndexedBase('a')
+    i, j = symbols('i j')
+    b = numpy.array([[1, 2], [3, 4]])
+    assert lambdify(a, Sum(a[x, y], (x, 0, 1), (y, 0, 1)))(b) == 10


### PR DESCRIPTION
The use of iterable from sympy.core.compatibility needed to exclude the
NotIterable mixin for it to not see Indexed as iterable.

Fixes #10934.
