### PR TITLE
Fix ValueError of Identity Cycle's `.list(size!=None)`

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -369,7 +369,7 @@ class Cycle(dict):
         if not self and size is None:
             raise ValueError('must give size for empty Cycle')
         if size is not None:
-            big = max([i for i in self.keys() if self[i] != i])
+            big = max([i for i in self.keys() if self[i] != i] + [0])
             size = max(size, big + 1)
         else:
             size = self.size

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -364,6 +364,8 @@ def test_Cycle():
     raises(ValueError, lambda: Cycle().list())
     assert Cycle(1, 2).list() == [0, 2, 1]
     assert Cycle(1, 2).list(4) == [0, 2, 1, 3]
+    assert Cycle(3).list(2) == [0, 1]
+    assert Cycle(3).list(6) == [0, 1, 2, 3, 4, 5]
     assert Permutation(Cycle(1, 2), size=4) == \
         Permutation([0, 2, 1, 3])
     assert str(Cycle(1, 2)(4, 5)) == '(1 2)(4 5)'


### PR DESCRIPTION
A small fix in `.list()` method of `Cycle`
