### PR TITLE
Init printing docstring addition and bug fix

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -400,16 +400,13 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         Printer.set_global_settings(order=order, use_unicode=use_unicode,
                                     wrap_line=wrap_line, num_columns=num_columns)
     else:
-        _stringify_func = stringify_func
-
         if pretty_print:
-            stringify_func = lambda expr: \
-                             _stringify_func(expr, order=order,
-                                             use_unicode=use_unicode,
-                                             wrap_line=wrap_line,
-                                             num_columns=num_columns)
+            args = ('order', 'use_unicode', 'wrap_line', 'num_columns')
         else:
-            stringify_func = lambda expr: _stringify_func(expr, order=order)
+            args = ('order')
+
+        for i in args:
+            settings[i] = locals()[i]
 
     if in_ipython:
         mode_in_settings = settings.pop("mode", None)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -308,6 +308,9 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         A custom pretty printer. This should mimic sympy.printing.pretty().
     latex_printer: function, optional, default=None
         A custom LaTeX printer. This should mimic sympy.printing.latex().
+    **settings:
+        Dictionary of any additional keyword-value arguments to be passed
+        directly to the printer function.
 
     Examples
     ========


### PR DESCRIPTION
I added the ability to pass arguments from init_printing to the printer that init_printing uses through a **settings argument a little while back. This addition did not properly interact with the no_global input argument in init_printing and this code should fix that issue. In addition **settings has been added to init_printing's docstring.
