### PR TITLE
Fixed Issue #10931 Complement of S.Integers with itself and S.Reals.

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1619,7 +1619,8 @@ class Complement(Set, EvalfMixin):
         Simplify a :class:`Complement`.
 
         """
-        if B == S.UniversalSet:
+        # Fixed Issue 10931
+        if B == S.UniversalSet or B == A or (A == S.Integers and B == S.Reals):
             return EmptySet()
 
         if isinstance(B, Union):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1620,7 +1620,7 @@ class Complement(Set, EvalfMixin):
 
         """
         # Fixed Issue 10931
-        if B == S.UniversalSet or B == A or (A == S.Integers and B == S.Reals):
+        if B == S.UniversalSet or A.is_subset(B):
             return EmptySet()
 
         if isinstance(B, Union):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1028,3 +1028,7 @@ def test_issue_10285():
     ivl = Interval.Lopen(1, oo)
     assert FiniteSet(eq).intersect(ivl) == \
         FiniteSet(s).intersect(Interval.Lopen(2, oo))
+
+def test_issue_10931():
+    assert S.Integers - S.Integers == EmptySet()
+    assert S.Integers - S.Reals == EmptySet()


### PR DESCRIPTION
Now this is evaluating right.

```
In [2]: S.Integers - S.Integers
Out[2]: EmptySet()

In [3]: S.Integers - S.Reals
Out[3]: EmptySet()
```

If something is wrong then please guide me.
