### PR TITLE
printing: Delete duplicate function definition

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1615,9 +1615,6 @@ class LatexPrinter(Printer):
     def _print_FormalPowerSeries(self, s):
         return self._print_Add(s.truncate())
 
-    def _print_FormalPowerSeries(self, s):
-        return self._print_Add(s.truncate())
-
     def _print_FiniteField(self, expr):
         return r"\mathbb{F}_{%s}" % expr.mod
 


### PR DESCRIPTION
Delete duplicate definition of function _print_FormalPowerSeries from
sympy/printing/latex. _print_FormalPowerSeries was defined twice, each with
the same definition.
