### PR TITLE
Returning an empty tuple for NoneType objects while merging solutions in Diophantine solver

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -114,7 +114,7 @@ def merge_solution(var, var_t, solution):
     """
     l = []
 
-    if None in solution:
+    if solution is None or None in solution:
         return ()
 
     solution = iter(solution)


### PR DESCRIPTION
- [x] closes #10956  

The current implementation results in a `TypeError` when the `solution` itself is `None`.

For example:

``` python

In []: from sympy import *
In []: from sympy.solvers.diophantine import *
In []: x, y = symbols('x, y')
In []: foo = x*pi - y*pi - pi/2
In []: diophantine(foo)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-caab88e391cb> in <module>()
----> 1 diophantine(foo)

/home/kshitij10496/Repo/sympy/sympy/solvers/diophantine.py in diophantine(eq, param)
     90 
     91         if eq_type in ["linear", "homogeneous_ternary_quadratic", "general_pythagorean"]:
---> 92             if merge_solution(var, var_t, solution) != ():
     93                 sols.add(merge_solution(var, var_t, solution))
     94 

/home/kshitij10496/Repo/sympy/sympy/solvers/diophantine.py in merge_solution(var, var_t, solution)
    115     l = []
    116 
--> 117     if None in solution:
    118         return ()
    119 

TypeError: argument of type 'NoneType' is not iterable
```

The same problem with the new implementation returns the:

```
python
In []: diophantine(foo)
Out[]: set()

```

Ping @aktech @smichr 
