### PR TITLE
Improving _invert method in solveset

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -144,8 +144,8 @@ def _invert_real(f, g_ys, symbol):
         if g is not S.Zero:
             return _invert_real(h, imageset(Lambda(n, n - g), g_ys), symbol)
         else:
-            if len(f.args) == 2 and \
-                not f.is_polynomial(symbol):
+            if len(f.args) == 2 and g_ys == FiniteSet(0) and \
+            not f.is_polynomial(symbol):
                 lhs = f
                 rhs = FiniteSet(0)
                 a, b = ordered(f.args)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -17,7 +17,7 @@ from sympy.polys.rootoftools import CRootOf
 
 from sympy.sets import (FiniteSet, ConditionSet, Complement, ImageSet)
 
-from sympy.utilities.pytest import XFAIL, raises, skip, slow
+from sympy.utilities.pytest import XFAIL, raises, skip, slow, SKIP
 from sympy.utilities.randtest import verify_numerically as tn
 from sympy.physics.units import cm
 
@@ -593,9 +593,13 @@ def test_units():
 def test_solve_only_exp_1():
     y = Symbol('y', positive=True, finite=True)
     assert solveset_real(exp(x) - y, x) == FiniteSet(log(y))
+    assert solveset_real(exp(x) + exp(-x) - y, x) != S.EmptySet
+
+
+@SKIP("Comparision Error")
+def test_solve_only_exp_compError():
     assert solveset_real(exp(x) + exp(-x) - 4, x) == \
         FiniteSet(log(-sqrt(3) + 2), log(sqrt(3) + 2))
-    assert solveset_real(exp(x) + exp(-x) - y, x) != S.EmptySet
 
 
 @XFAIL
@@ -1086,3 +1090,8 @@ def test_issue_8715():
         (Interval.open(-2, oo) - FiniteSet(0))
     assert solveset(eq.subs(x,log(x)), x, S.Reals) == \
         Interval.open(exp(-2), oo) - FiniteSet(1)
+
+
+def test_issue_10864():
+    x =symbols('x' , positive = True)
+    assert solveset(x**(y*z) - x,x,S.Reals) == FiniteSet(1)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -594,10 +594,6 @@ def test_solve_only_exp_1():
     y = Symbol('y', positive=True, finite=True)
     assert solveset_real(exp(x) - y, x) == FiniteSet(log(y))
     assert solveset_real(exp(x) + exp(-x) - y, x) != S.EmptySet
-
-
-@SKIP("Comparision Error")
-def test_solve_only_exp_compError():
     assert solveset_real(exp(x) + exp(-x) - 4, x) == \
         FiniteSet(log(-sqrt(3) + 2), log(sqrt(3) + 2))
 
@@ -913,7 +909,7 @@ def test_improve_coverage():
     x = Symbol('x')
     y = exp(x+1/x**2)
     solution = solveset(y**2+y, x, S.Reals)
-    unsolved_object = ConditionSet(x, Eq((exp((x**3 + 1)/x**2) + 1)*exp((x**3 + 1)/x**2), 0), S.Reals)
+    unsolved_object = ConditionSet(x, Eq(exp(x + x**(-2)) + exp(2*x + 2/x**2), 0), S.Reals)
     assert solution == unsolved_object
 
     assert _has_rational_power(sin(x)*exp(x) + 1, x) == (False, S.One)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -655,7 +655,7 @@ def test_solveset_complex_rational():
     assert solveset_complex((x - y**3)/((y**2)*sqrt(1 - y**2)), x) == \
         FiniteSet(y**3)
     assert solveset_complex(-x**2 - I, x) == \
-        FiniteSet(-sqrt(2)/2 + sqrt(2)*I/2, sqrt(2)/2 - sqrt(2)*I/2)
+        FiniteSet(-sqrt(-I), sqrt(-I))
 
 
 def test_solve_quintics():
@@ -687,7 +687,7 @@ def test_solveset_complex_exp():
 def test_solve_complex_log():
     assert solveset_complex(log(x), x) == FiniteSet(1)
     assert solveset_complex(1 - log(a + 4*x**2), x) == \
-        FiniteSet(-sqrt(-a/4 + E/4), sqrt(-a/4 + E/4))
+        FiniteSet(-sqrt(-a + E)/2, sqrt(-a + E)/2)
 
 
 def test_solve_complex_sqrt():
@@ -1087,6 +1087,13 @@ def test_issue_8715():
     assert solveset(eq.subs(x,log(x)), x, S.Reals) == \
         Interval.open(exp(-2), oo) - FiniteSet(1)
 
+
+def test_issue_11096():
+    assert solveset((-2)**x-4, x) == FiniteSet(log(4)/(log(2) + I*pi))
+
+@XFAIL
+def test_issue_11096_fail():
+    assert solveset((-2)**x-4, x, S.Reals) == FiniteSet(2)
 
 def test_issue_10864():
     x =symbols('x' , positive = True)


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/10864 and complex solution of https://github.com/sympy/sympy/issues/11096
Old solver have `_tsolve` to solve transcendental equation, but in `solveset` `_invert` method can handle some works of the `_tsolve` method.
One of them could be 

```
x =symbols('x' , positive = True)
solveset(x**(y*z) - x,x,S.Reals)

```
