### PR TITLE
Test against hanging Mod on symbols (tests gh-10963)

### DIFF
--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1597,6 +1597,9 @@ def test_Mod():
     n = Symbol('n', odd=True)
     assert Mod(n, 2) == 1
 
+    # issue 10963
+    assert (x**6000%400).args[1] == 400
+
 
 def test_Mod_is_integer():
     p = Symbol('p', integer=True)


### PR DESCRIPTION
`x**6000%400` used to hang, it was fixed in 652150e
this adds a test specifically for gh-10963
