### PR TITLE
Don't print anything with init_session(quiet=True)

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -39,6 +39,9 @@ def _make_message(ipython=True, quiet=False, source=None):
     import sys
     import os
 
+    if quiet:
+        return ""
+
     python_version = "%d.%d.%d" % sys.version_info[:3]
 
     if ipython:
@@ -59,26 +62,25 @@ def _make_message(ipython=True, quiet=False, source=None):
     args = shell_name, sympy_version, python_version, ARCH, ', '.join(info)
     message = "%s console for SymPy %s (Python %s-%s) (%s)\n" % args
 
-    if not quiet:
-        if source is None:
-            source = preexec_source
+    if source is None:
+        source = preexec_source
 
-        _source = ""
+    _source = ""
 
-        for line in source.split('\n')[:-1]:
-            if not line:
-                _source += '\n'
-            else:
-                _source += '>>> ' + line + '\n'
-
-        doc_version = sympy_version
-        if 'dev' in doc_version:
-            doc_version = "dev"
+    for line in source.split('\n')[:-1]:
+        if not line:
+            _source += '\n'
         else:
-            doc_version = "%s/" % doc_version
+            _source += '>>> ' + line + '\n'
 
-        message += '\n' + verbose_message % {'source': _source,
-                                             'version': doc_version}
+    doc_version = sympy_version
+    if 'dev' in doc_version:
+        doc_version = "dev"
+    else:
+        doc_version = "%s/" % doc_version
+
+    message += '\n' + verbose_message % {'source': _source,
+                                         'version': doc_version}
 
     return message
 


### PR DESCRIPTION
Previously it printed the line

```
IPython console for SymPy 1.0.1.dev (Python 3.5.1-64-bit) (ground types: python)
```
