### PR TITLE
Pretty print GoldenRatio and EulerGamma as φ and γ

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1230,6 +1230,16 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*pform.left(name))
         return pform
 
+    def _print_GoldenRatio(self, expr):
+        if self._use_unicode:
+            return prettyForm(pretty_symbol('phi'))
+        return self._print(Symbol("GoldenRatio"))
+
+    def _print_EulerGamma(self, expr):
+        if self._use_unicode:
+            return prettyForm(pretty_symbol('gamma'))
+        return self._print(Symbol("EulerGamma"))
+
     def _print_Add(self, expr, order=None):
         if self.order == 'none':
             terms = list(expr.args)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -974,11 +974,11 @@ x - ── + ─── + O⎝x ⎠\n\
 
 def test_EulerGamma():
     assert pretty(EulerGamma) == str(EulerGamma) == "EulerGamma"
-    assert upretty(EulerGamma) == "γ"
+    assert upretty(EulerGamma) == u"γ"
 
 def test_GoldenRatio():
     assert pretty(GoldenRatio) == str(GoldenRatio) == "GoldenRatio"
-    assert upretty(GoldenRatio) == "φ"
+    assert upretty(GoldenRatio) == u"φ"
 
 def test_pretty_relational():
     expr = Eq(x, y)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6,8 +6,8 @@ from sympy import (
     Pow, Product, QQ, RR, Rational, Ray, rootof, RootSum, S,
     Segment, Subs, Sum, Symbol, Tuple, Trace, Xor, ZZ, conjugate,
     groebner, oo, pi, symbols, ilex, grlex, Range, Contains,
-    SeqPer, SeqFormula, SeqAdd, SeqMul, Interval, Union, fourier_series, fps,
-    Complement, FiniteSet, Interval, Intersection, Union)
+    SeqPer, SeqFormula, SeqAdd, SeqMul, fourier_series, fps,
+    Complement, Interval, Intersection, Union, EulerGamma, GoldenRatio)
 
 from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
     Piecewise, Shi, Si, atan2, binomial, catalan, ceiling, cos,
@@ -972,6 +972,13 @@ x - ── + ─── + O⎝x ⎠\n\
     assert pretty(expr, order='rev-lex') == ascii_str
     assert upretty(expr, order='rev-lex') == ucode_str
 
+def test_EulerGamma():
+    assert pretty(EulerGamma) == str(EulerGamma) == "EulerGamma"
+    assert upretty(EulerGamma) == "γ"
+
+def test_GoldenRatio():
+    assert pretty(GoldenRatio) == str(GoldenRatio) == "GoldenRatio"
+    assert upretty(GoldenRatio) == "φ"
 
 def test_pretty_relational():
     expr = Eq(x, y)


### PR DESCRIPTION
This matches the latex() output for these constants, which is \phi and \gamma.
The ASCII pretty printer still prints them as GoldenRatio and EulerGamma,
since if we have to write it out, we might as well write out the constant name
itself instead of "phi" and "gamma".
