### PR TITLE
(tensor module) Fix bug in _TensorDataLazyEvaluator._contract_ndarray()

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -966,7 +966,8 @@ class _TensorDataLazyEvaluator(CantSympify):
         numpy = import_module('numpy')
 
         def ikey(x):
-            return x[1:]
+            # sort by component number , then by position in component
+            return x[2], x[1]
 
         free1 = free1[:]
         free2 = free2[:]


### PR DESCRIPTION
Fixes #10972, tests included.

Cause of the bug: free indices in `_contract_ndarray()` were sorted in wrong order.

By the way, free indices are stored as triplets
`(TensorIndex, position inside the component, component number)`.
Such ordering seems a bit counter-intuitive to me: why position inside the component goes before the component number? Wouldn't it be better to swap them? @Upabjojr what do you think about it?
