### PR TITLE
[Don't merge] Connecting diophantine and solveset

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -540,6 +540,7 @@ def _solveset(f, symbol, domain, _check=False):
     # _check controls whether the answer is checked or not
 
     from sympy.simplify.simplify import signsimp
+    from sympy.solvers.diophantine import diop_solve
     orig_f = f
     f = together(f)
     if f.is_Mul:
@@ -552,7 +553,14 @@ def _solveset(f, symbol, domain, _check=False):
 
     # assign the solvers to use
     solver = lambda f, x, domain=domain: _solveset(f, x, domain)
-    if domain.is_subset(S.Reals):
+    if domain is S.Integers:
+        # calling methods from diophantine.py
+        solution = diop_solve(orig_f)
+        # solution in finiteset
+        # return FiniteSet(tuple(solution))
+        # solution in imageset
+        return imageset(Lambda(solution[0].free_symbols, tuple(solution)), S.Integers)
+    elif domain.is_subset(S.Reals):
         inverter_func = invert_real
     else:
         inverter_func = invert_complex
@@ -764,6 +772,8 @@ def solveset(f, symbol=None, domain=S.Complexes):
     if symbol is None:
         if len(free_symbols) == 1:
             symbol = free_symbols.pop()
+        elif domain is S.Integers:
+            pass
         else:
             raise ValueError(filldedent('''
                 The independent variable must be specified for a


### PR DESCRIPTION
Now `solveset` returns `Integers` solution for an equation using `diophantine.py` .

```
>>> solveset(2*x + 3*y - 5, x, S.Integers)
{(3⋅t₀ - 5, -2⋅t₀ + 5) | t₀ ∊ ℤ}
>>> solveset(2*x + 3*y - 5, domain=S.Integers)
{(3⋅t₀ - 5, -2⋅t₀ + 5) | t₀ ∊ ℤ}
```

**Please suggest if something more is expected.**

If we want the solution in `Finiteset` then we will get : 

```
>>> solveset(2*x + 3*y - 5, domain=S.Integers)
{(3⋅t₀ - 5, -2⋅t₀ + 5) }
```

which is similar to the way used in `linsolve`. 
