### PR TITLE
Added atomic mass constant to units.py

### DIFF
--- a/sympy/physics/units.py
+++ b/sympy/physics/units.py
@@ -260,7 +260,7 @@ hbar = planck / (2*pi)
 avogadro_number = Rational('6.022140857') * 10**23
 avogadro = avogadro_constant = avogadro_number / mol
 boltzmann = Rational('1.38064852') * ten**-23 * J / K
-atomic_mass_constant = Rational('1.660538921') * ten**-27 * kg
+atomic_mass_constant = Rational('1.660539040') * ten**-27 * kg
 
 gee = gees = Rational('9.80665') * m/s**2
 atmosphere = atmospheres = atm = 101325 * pascal

--- a/sympy/physics/units.py
+++ b/sympy/physics/units.py
@@ -260,6 +260,7 @@ hbar = planck / (2*pi)
 avogadro_number = Rational('6.022140857') * 10**23
 avogadro = avogadro_constant = avogadro_number / mol
 boltzmann = Rational('1.38064852') * ten**-23 * J / K
+atomic_mass_constant = Rational('1.660538921') * ten**-27 * kg
 
 gee = gees = Rational('9.80665') * m/s**2
 atmosphere = atmospheres = atm = 101325 * pascal


### PR DESCRIPTION
Added atomic mass constant to units.py. In physics and chemistry, the atomic mass constant, is one twelfth of the mass of an unbound atom of carbon-12 at rest and in its ground state. This constant is  used to define the atomic mass unit. 
