### PR TITLE
erf and exp/trig integral functions: rewrite as integrals

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -3,7 +3,7 @@
 
 from __future__ import print_function, division
 
-from sympy.core import Add, S, sympify, cacheit, pi, I
+from sympy.core import Add, S, sympify, cacheit, pi, I, oo
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import factorial
@@ -188,6 +188,18 @@ class erf(Function):
 
     def _eval_rewrite_as_erfi(self, z):
         return -I*erfi(I*z)
+
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, x):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, 0, x))
 
     def _eval_as_leading_term(self, x):
         from sympy import Order
@@ -378,6 +390,18 @@ class erfc(Function):
     def _eval_rewrite_as_expint(self, z):
         return S.One - sqrt(z**2)/z + z*expint(S.Half, z**2)/sqrt(S.Pi)
 
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, x):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, x, oo))
+
     def _eval_as_leading_term(self, x):
         from sympy import Order
         arg = self.args[0].as_leading_term(x)
@@ -556,6 +580,18 @@ class erfi(Function):
     def _eval_rewrite_as_expint(self, z):
         return sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
 
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, x):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return S(2)/sqrt(pi)*Integral(exp(t**2), (t, 0, x))
+
     def as_real_imag(self, deep=True, **hints):
         if self.args[0].is_real:
             if deep:
@@ -704,6 +740,19 @@ class erf2(Function):
 
     def _eval_rewrite_as_expint(self, x, y):
         return erf(y).rewrite(expint) - erf(x).rewrite(expint)
+
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, x, y):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, x, y))
+
 
 class erfinv(Function):
     r"""
@@ -1097,6 +1146,18 @@ class Ei(Function):
     def _eval_rewrite_as_tractable(self, z):
         return exp(z) * _eis(z)
 
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, x):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return Integral(exp(t)/t, (t, -oo, x))
+
     def _eval_nseries(self, x, n, logx):
         x0 = self.args[0].limit(x, 0)
         if x0 is S.Zero:
@@ -1266,6 +1327,18 @@ class expint(Function):
     _eval_rewrite_as_Ci = _eval_rewrite_as_Si
     _eval_rewrite_as_Chi = _eval_rewrite_as_Si
     _eval_rewrite_as_Shi = _eval_rewrite_as_Si
+
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, nu, x):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return Integral(exp(-x*t)/(x**nu), (t, 1, oo))
 
     def _eval_nseries(self, x, n, logx):
         if not self.args[0].has(x):
@@ -1449,6 +1522,18 @@ class li(Function):
     def _eval_rewrite_as_tractable(self, z):
         return z * _eis(log(z))
 
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, x):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return Integral(1/log(t), (t, 0, x))
+
 
 class Li(Function):
     r"""
@@ -1534,6 +1619,19 @@ class Li(Function):
     def _eval_rewrite_as_tractable(self, z):
         return self.rewrite(li).rewrite("tractable", deep=True)
 
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, x):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return Integral(1/log(t), (t, 2, x))
+
+
 ###############################################################################
 #################### TRIGONOMETRIC INTEGRALS ##################################
 ###############################################################################
@@ -1583,6 +1681,18 @@ class TrigonometricIntegral(Function):
     def _eval_rewrite_as_uppergamma(self, z):
         from sympy import uppergamma
         return self._eval_rewrite_as_expint(z).rewrite(uppergamma)
+
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, z):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return Integral(self._trigfunc(t)/t, (t, 0, z))
 
     def _eval_nseries(self, x, n, logx):
         # NOTE this is fairly inefficient
@@ -2084,6 +2194,18 @@ class FresnelIntegral(Function):
         im = x/(2*y) * sqrt(sq) * (self.func(x - x*sqrt(sq)) -
                 self.func(x + x*sqrt(sq)))
         return (re, im)
+
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, z):
+        from sympy import Integral
+        t = Symbol('t', Dummy=True)
+        return Integral(self._trigfunc(S.Half*pi*t**2), (t, 0, z))
 
 
 class fresnels(FresnelIntegral):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1180,7 +1180,7 @@ class expint(Function):
     Hence for :math:`z` with positive real part we have
 
     .. math:: \operatorname{E}_\nu(z)
-              =   \int_1^\infty \frac{e^{-zt}}{z^\nu} \mathrm{d}t,
+              =   \int_1^\infty \frac{e^{-zt}}{t^\nu} \mathrm{d}t,
 
     which explains the name.
 
@@ -1338,7 +1338,7 @@ class expint(Function):
     def _as_integral(self, nu, x):
         from sympy import Integral
         t = Symbol('t', Dummy=True)
-        return Integral(exp(-x*t)/(x**nu), (t, 1, oo))
+        return Integral(exp(-x*t)/(t**nu), (t, 1, oo))
 
     def _eval_nseries(self, x, n, logx):
         if not self.args[0].has(x):

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -189,17 +189,22 @@ class erf(Function):
     def _eval_rewrite_as_erfi(self, z):
         return -I*erfi(I*z)
 
+    def as_integral(self, t=None):
+        """
+        Return this function written as an integral, in terms of a variable
+        of integration `t`.  If `t` is omitted, a dummy variable is used.
+        """
+        if t is None:
+            t = Dummy('t')
+        return self._as_integral(*self.args, t)
+
     def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
-
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, x):
-        from sympy import Integral
         t = Dummy('t')
-        return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, 0, x))
+        return self._as_integral(*args, t)
+
+    def _as_integral(self, z, t):
+        from sympy import Integral
+        return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, 0, z))
 
     def _eval_as_leading_term(self, x):
         from sympy import Order
@@ -390,17 +395,13 @@ class erfc(Function):
     def _eval_rewrite_as_expint(self, z):
         return S.One - sqrt(z**2)/z + z*expint(S.Half, z**2)/sqrt(S.Pi)
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    # TODO: poor style, should inherit/mixin or similar?
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, x):
+    def _as_integral(self, z, t):
         from sympy import Integral
-        t = Dummy('t')
-        return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, x, oo))
+        return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, z, oo))
 
     def _eval_as_leading_term(self, x):
         from sympy import Order
@@ -580,17 +581,12 @@ class erfi(Function):
     def _eval_rewrite_as_expint(self, z):
         return sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, x):
+    def _as_integral(self, z, t):
         from sympy import Integral
-        t = Dummy('t')
-        return S(2)/sqrt(pi)*Integral(exp(t**2), (t, 0, x))
+        return S(2)/sqrt(pi)*Integral(exp(t**2), (t, 0, z))
 
     def as_real_imag(self, deep=True, **hints):
         if self.args[0].is_real:
@@ -741,16 +737,11 @@ class erf2(Function):
     def _eval_rewrite_as_expint(self, x, y):
         return erf(y).rewrite(expint) - erf(x).rewrite(expint)
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, x, y):
+    def _as_integral(self, x, y, t):
         from sympy import Integral
-        t = Dummy('t')
         return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, x, y))
 
 
@@ -1146,17 +1137,12 @@ class Ei(Function):
     def _eval_rewrite_as_tractable(self, z):
         return exp(z) * _eis(z)
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, x):
+    def _as_integral(self, z, t):
         from sympy import Integral
-        t = Dummy('t')
-        return Integral(exp(t)/t, (t, -oo, x))
+        return Integral(exp(t)/t, (t, -oo, z))
 
     def _eval_nseries(self, x, n, logx):
         x0 = self.args[0].limit(x, 0)
@@ -1328,16 +1314,11 @@ class expint(Function):
     _eval_rewrite_as_Chi = _eval_rewrite_as_Si
     _eval_rewrite_as_Shi = _eval_rewrite_as_Si
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, nu, x):
+    def _as_integral(self, nu, x, t):
         from sympy import Integral
-        t = Dummy('t')
         return Integral(exp(-x*t)/(t**nu), (t, 1, oo))
 
     def _eval_nseries(self, x, n, logx):
@@ -1522,17 +1503,12 @@ class li(Function):
     def _eval_rewrite_as_tractable(self, z):
         return z * _eis(log(z))
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, x):
+    def _as_integral(self, z, t):
         from sympy import Integral
-        t = Dummy('t')
-        return Integral(1/log(t), (t, 0, x))
+        return Integral(1/log(t), (t, 0, z))
 
 
 class Li(Function):
@@ -1619,17 +1595,12 @@ class Li(Function):
     def _eval_rewrite_as_tractable(self, z):
         return self.rewrite(li).rewrite("tractable", deep=True)
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, x):
+    def _as_integral(self, z, t):
         from sympy import Integral
-        t = Dummy('t')
-        return Integral(1/log(t), (t, 2, x))
+        return Integral(1/log(t), (t, 2, z))
 
 
 ###############################################################################
@@ -1682,16 +1653,11 @@ class TrigonometricIntegral(Function):
         from sympy import uppergamma
         return self._eval_rewrite_as_expint(z).rewrite(uppergamma)
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, z):
+    def _as_integral(self, z, t):
         from sympy import Integral
-        t = Dummy('t')
         return Integral(self._trigfunc(t)/t, (t, 0, z))
 
     def _eval_nseries(self, x, n, logx):
@@ -2195,16 +2161,11 @@ class FresnelIntegral(Function):
                 self.func(x + x*sqrt(sq)))
         return (re, im)
 
-    def _eval_rewrite_as_Integral(self, *args):
-        return self.as_integral
+    as_integral = erf.as_integral
+    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
 
-    @property
-    def as_integral(self):
-        return self._as_integral(*self.args)
-
-    def _as_integral(self, z):
+    def _as_integral(self, z, t):
         from sympy import Integral
-        t = Dummy('t')
         return Integral(self._trigfunc(S.Half*pi*t**2), (t, 0, z))
 
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -24,6 +24,21 @@ from sympy.core.compatibility import range
 ###############################################################################
 
 
+# TODO: poor style, should inherit/mixin or similar?
+def as_integral(self, t=None):
+    """
+    Return this function written as an integral, in terms of a variable
+    of integration `t`.  If `t` is omitted, a dummy variable is used.
+    """
+    if t is None:
+        t = Dummy('t')
+    return self._as_integral(*(self.args + (t,)))
+
+def _eval_rewrite_as_Integral(self, *args):
+    t = Dummy('t')
+    return self._as_integral(*(args + (t,)))
+
+
 class erf(Function):
     r"""
     The Gauss error function. This function is defined as:
@@ -189,18 +204,8 @@ class erf(Function):
     def _eval_rewrite_as_erfi(self, z):
         return -I*erfi(I*z)
 
-    def as_integral(self, t=None):
-        """
-        Return this function written as an integral, in terms of a variable
-        of integration `t`.  If `t` is omitted, a dummy variable is used.
-        """
-        if t is None:
-            t = Dummy('t')
-        return self._as_integral(*self.args, t)
-
-    def _eval_rewrite_as_Integral(self, *args):
-        t = Dummy('t')
-        return self._as_integral(*args, t)
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, z, t):
         from sympy import Integral
@@ -395,9 +400,8 @@ class erfc(Function):
     def _eval_rewrite_as_expint(self, z):
         return S.One - sqrt(z**2)/z + z*expint(S.Half, z**2)/sqrt(S.Pi)
 
-    # TODO: poor style, should inherit/mixin or similar?
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, z, t):
         from sympy import Integral
@@ -429,6 +433,7 @@ class erfc(Function):
         im = x/(2*y) * sqrt(sq) * (self.func(x - x*sqrt(sq)) -
                     self.func(x + x*sqrt(sq)))
         return (re, im)
+
 
 class erfi(Function):
     r"""
@@ -581,8 +586,8 @@ class erfi(Function):
     def _eval_rewrite_as_expint(self, z):
         return sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
 
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, z, t):
         from sympy import Integral
@@ -737,8 +742,8 @@ class erf2(Function):
     def _eval_rewrite_as_expint(self, x, y):
         return erf(y).rewrite(expint) - erf(x).rewrite(expint)
 
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, x, y, t):
         from sympy import Integral
@@ -1137,8 +1142,8 @@ class Ei(Function):
     def _eval_rewrite_as_tractable(self, z):
         return exp(z) * _eis(z)
 
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, z, t):
         from sympy import Integral
@@ -1314,8 +1319,8 @@ class expint(Function):
     _eval_rewrite_as_Chi = _eval_rewrite_as_Si
     _eval_rewrite_as_Shi = _eval_rewrite_as_Si
 
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, nu, x, t):
         from sympy import Integral
@@ -1503,8 +1508,8 @@ class li(Function):
     def _eval_rewrite_as_tractable(self, z):
         return z * _eis(log(z))
 
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, z, t):
         from sympy import Integral
@@ -1595,8 +1600,8 @@ class Li(Function):
     def _eval_rewrite_as_tractable(self, z):
         return self.rewrite(li).rewrite("tractable", deep=True)
 
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, z, t):
         from sympy import Integral
@@ -1653,8 +1658,8 @@ class TrigonometricIntegral(Function):
         from sympy import uppergamma
         return self._eval_rewrite_as_expint(z).rewrite(uppergamma)
 
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, z, t):
         from sympy import Integral
@@ -2161,8 +2166,8 @@ class FresnelIntegral(Function):
                 self.func(x + x*sqrt(sq)))
         return (re, im)
 
-    as_integral = erf.as_integral
-    _eval_rewrite_as_Integral = erf._eval_rewrite_as_Integral
+    as_integral = as_integral
+    _eval_rewrite_as_Integral = _eval_rewrite_as_Integral
 
     def _as_integral(self, z, t):
         from sympy import Integral

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 
 from sympy.core import Add, S, sympify, cacheit, pi, I, oo
 from sympy.core.function import Function, ArgumentIndexError
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import Symbol, Dummy
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt, root
@@ -198,7 +198,7 @@ class erf(Function):
 
     def _as_integral(self, x):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, 0, x))
 
     def _eval_as_leading_term(self, x):
@@ -399,7 +399,7 @@ class erfc(Function):
 
     def _as_integral(self, x):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, x, oo))
 
     def _eval_as_leading_term(self, x):
@@ -589,7 +589,7 @@ class erfi(Function):
 
     def _as_integral(self, x):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return S(2)/sqrt(pi)*Integral(exp(t**2), (t, 0, x))
 
     def as_real_imag(self, deep=True, **hints):
@@ -750,7 +750,7 @@ class erf2(Function):
 
     def _as_integral(self, x, y):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return S(2)/sqrt(pi)*Integral(exp(-t**2), (t, x, y))
 
 
@@ -1155,7 +1155,7 @@ class Ei(Function):
 
     def _as_integral(self, x):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return Integral(exp(t)/t, (t, -oo, x))
 
     def _eval_nseries(self, x, n, logx):
@@ -1337,7 +1337,7 @@ class expint(Function):
 
     def _as_integral(self, nu, x):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return Integral(exp(-x*t)/(t**nu), (t, 1, oo))
 
     def _eval_nseries(self, x, n, logx):
@@ -1531,7 +1531,7 @@ class li(Function):
 
     def _as_integral(self, x):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return Integral(1/log(t), (t, 0, x))
 
 
@@ -1628,7 +1628,7 @@ class Li(Function):
 
     def _as_integral(self, x):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return Integral(1/log(t), (t, 2, x))
 
 
@@ -1691,7 +1691,7 @@ class TrigonometricIntegral(Function):
 
     def _as_integral(self, z):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return Integral(self._trigfunc(t)/t, (t, 0, z))
 
     def _eval_nseries(self, x, n, logx):
@@ -2204,7 +2204,7 @@ class FresnelIntegral(Function):
 
     def _as_integral(self, z):
         from sympy import Integral
-        t = Symbol('t', Dummy=True)
+        t = Dummy('t')
         return Integral(self._trigfunc(S.Half*pi*t**2), (t, 0, z))
 
 

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -18,6 +18,7 @@ from sympy.utilities.pytest import raises
 x, y, z = symbols('x,y,z')
 w = Symbol("w", real=True)
 n = Symbol("n", integer=True)
+t = Symbol("t", Dummy=True)
 
 
 def test_erf():
@@ -73,6 +74,11 @@ def test_erf():
          re(x)*Abs(im(x))/(2*im(x)*Abs(re(x)))))
 
     raises(ArgumentIndexError, lambda: erf(x).fdiff(2))
+
+
+def test_erf_write_as_integral():
+    assert erf(z).rewrite('Integral') == \
+        2/sqrt(pi)*Integral(exp(-t**2), (t, 0, z))
 
 
 def test_erf_series():
@@ -147,6 +153,11 @@ def test_erfc_evalf():
     assert abs( erfc(Float(2.0)) - 0.00467773 ) < 1E-8 # XXX
 
 
+def test_erfc_write_as_integral():
+    assert erfc(z).rewrite('Integral') == \
+        2/sqrt(pi)*Integral(exp(-t**2), (t, z, oo))
+
+
 def test_erfi():
     assert erfi(nan) == nan
 
@@ -191,6 +202,11 @@ def test_erfi():
     raises(ArgumentIndexError, lambda: erfi(x).fdiff(2))
 
 
+def test_erfi_write_as_integral():
+    assert erfi(z).rewrite('Integral') == \
+        2/sqrt(pi)*Integral(exp(t**2), (t, 0, z))
+
+
 def test_erfi_series():
     assert erfi(x).series(x, 0, 7) == 2*x/sqrt(pi) + \
         2*x**3/3/sqrt(pi) + x**5/5/sqrt(pi) + O(x**7)
@@ -232,6 +248,11 @@ def test_erf2():
     assert erf2(x, y).rewrite('erfi') == I*(erfi(I*x) - erfi(I*y))
 
     raises(ArgumentIndexError, lambda: erfi(x).fdiff(3))
+
+
+def test_erf2_write_as_integral():
+    assert erf2(x, y).rewrite('Integral') == \
+        2/sqrt(pi)*Integral(exp(-t**2), (t, x, y))
 
 
 def test_erfinv():
@@ -339,6 +360,10 @@ def test_ei():
         x**3/18 + x**4/96 + x**5/600 + O(x**6)
 
 
+def test_ei_write_as_integral():
+    assert Ei(z).rewrite('Integral') == Integral(exp(t)/t, (t, -oo, z))
+
+
 def test_expint():
     assert mytn(expint(x, y), expint(x, y).rewrite(uppergamma),
                 y**(x - 1)*uppergamma(1 - x, y), x)
@@ -386,6 +411,16 @@ def test_expint():
     assert expint(4, z).series(z) == S(1)/3 - z/2 + z**2/2 + \
         z**3*(log(z)/6 - S(11)/36 + EulerGamma/6) - z**4/24 + \
         z**5/240 + O(z**6)
+
+
+def test_expint_write_as_integral():
+    assert E1(z).rewrite('Integral') == Integral(exp(-t*z)/z, (t, 1, oo))
+    assert expint(1, z).rewrite('Integral') == \
+        Integral(exp(-t*z)/z, (t, 1, oo))
+    assert expint(2, z).rewrite('Integral') == \
+        Integral(exp(-t*z)/(z**2), (t, 1, oo))
+    assert expint(n, z).rewrite('Integral') == \
+        Integral(exp(-t*z)/(z**n), (t, 1, oo))
 
 
 def test__eis():
@@ -473,6 +508,11 @@ def test_Li():
     assert Li(z).rewrite(li) == li(z) - li(2)
 
 
+def test_li_Li_write_as_integral():
+    assert li(z).rewrite('Integral') == Integral(1/log(t), (t, 0, z))
+    assert Li(z).rewrite('Integral') == Integral(1/log(t), (t, 2, z))
+
+
 def test_si():
     assert Si(I*x) == I*Shi(x)
     assert Shi(I*x) == I*Si(x)
@@ -515,7 +555,6 @@ def test_si():
     assert Si(x).nseries(x, 1, n=3) == \
         Si(1) + (x - 1)*sin(1) + (x - 1)**2*(-sin(1)/2 + cos(1)/2) + O((x - 1)**3, (x, 1))
 
-    t = Symbol('t', Dummy=True)
     assert Si(x).rewrite(sinc) == Integral(sinc(t), (t, 0, x))
 
 
@@ -560,6 +599,13 @@ def test_ci():
     assert Chi(x).nseries(x, n=4) == \
         EulerGamma + log(x) + x**2/4 + x**4/96 + O(x**5)
     assert limit(log(x) - Ci(2*x), x, 0) == -log(2) - EulerGamma
+
+
+def test_trig_integral_write_as_integral():
+    assert Si(z).rewrite('Integral') == Integral(sin(t)/t, (t, 0, z))
+    assert Ci(z).rewrite('Integral') == Integral(cos(t)/t, (t, 0, z))
+    assert Shi(z).rewrite('Integral') == Integral(sinh(t)/t, (t, 0, z))
+    assert Chi(z).rewrite('Integral') == Integral(cosh(t)/t, (t, 0, z))
 
 
 def test_fresnel():
@@ -674,3 +720,10 @@ def test_fresnel():
     verify_numerically(im(fresnelc(z)), fresnelc(z).as_real_imag()[1], z)
     verify_numerically(fresnelc(z), fresnelc(z).rewrite(hyper), z)
     verify_numerically(fresnelc(z), fresnelc(z).rewrite(meijerg), z)
+
+
+def test_fresnel_write_as_integral():
+    assert fresnels(z).rewrite('Integral') == \
+        Integral(sin(S.Half*pi*t**2), (t, 0, z))
+    assert fresnelc(z).rewrite('Integral') == \
+        Integral(cos(S.Half*pi*t**2), (t, 0, z))

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -414,13 +414,13 @@ def test_expint():
 
 
 def test_expint_write_as_integral():
-    assert E1(z).rewrite('Integral') == Integral(exp(-t*z)/z, (t, 1, oo))
+    assert E1(z).rewrite('Integral') == Integral(exp(-t*z)/t, (t, 1, oo))
     assert expint(1, z).rewrite('Integral') == \
-        Integral(exp(-t*z)/z, (t, 1, oo))
+        Integral(exp(-t*z)/t, (t, 1, oo))
     assert expint(2, z).rewrite('Integral') == \
-        Integral(exp(-t*z)/(z**2), (t, 1, oo))
+        Integral(exp(-t*z)/(t**2), (t, 1, oo))
     assert expint(n, z).rewrite('Integral') == \
-        Integral(exp(-t*z)/(z**n), (t, 1, oo))
+        Integral(exp(-t*z)/(t**n), (t, 1, oo))
 
 
 def test__eis():

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -77,8 +77,16 @@ def test_erf():
 
 
 def test_erf_as_integral():
-    assert str(erf(z).as_integral) == \
-        str(2/sqrt(pi)*Integral(exp(-t**2), (t, 0, z)))
+    assert erf(z).as_integral(t) == 2/sqrt(pi)*Integral(exp(-t**2), (t, 0, z))
+    assert erf(z).as_integral(x) == 2/sqrt(pi)*Integral(exp(-x**2), (x, 0, z))
+
+
+def test_erf_as_integral_dummy():
+    assert str(erf(z).as_integral()) == str(erf(z).as_integral(t))
+
+
+def test_erf_rewrite_as_integral():
+    assert str(erf(z).rewrite('Integral')) == str(erf(z).as_integral(t))
 
 
 def test_erf_series():
@@ -154,8 +162,7 @@ def test_erfc_evalf():
 
 
 def test_erfc_as_integral():
-    assert str(erfc(z).as_integral) == \
-        str(2/sqrt(pi)*Integral(exp(-t**2), (t, z, oo)))
+    assert erfc(z).as_integral(t) == 2/sqrt(pi)*Integral(exp(-t**2), (t, z, oo))
 
 
 def test_erfi():
@@ -203,8 +210,7 @@ def test_erfi():
 
 
 def test_erfi_as_integral():
-    assert str(erfi(z).as_integral) == \
-        str(2/sqrt(pi)*Integral(exp(t**2), (t, 0, z)))
+    assert erfi(z).as_integral(t) == 2/sqrt(pi)*Integral(exp(t**2), (t, 0, z))
 
 
 def test_erfi_series():
@@ -251,8 +257,7 @@ def test_erf2():
 
 
 def test_erf2_as_integral():
-    assert str(erf2(x, y).as_integral) == \
-        str(2/sqrt(pi)*Integral(exp(-t**2), (t, x, y)))
+    assert erf2(x, y).as_integral(t) == 2/sqrt(pi)*Integral(exp(-t**2), (t, x, y))
 
 
 def test_erfinv():
@@ -361,7 +366,7 @@ def test_ei():
 
 
 def test_ei_as_integral():
-    assert str(Ei(z).as_integral) == str(Integral(exp(t)/t, (t, -oo, z)))
+    assert Ei(z).as_integral(t) == Integral(exp(t)/t, (t, -oo, z))
 
 
 def test_expint():
@@ -414,13 +419,10 @@ def test_expint():
 
 
 def test_expint_as_integral():
-    assert str(E1(z).as_integral) == str(Integral(exp(-t*z)/t, (t, 1, oo)))
-    assert str(expint(1, z).as_integral) == \
-        str(Integral(exp(-t*z)/t, (t, 1, oo)))
-    assert str(expint(2, z).as_integral) == \
-        str(Integral(exp(-t*z)/(t**2), (t, 1, oo)))
-    assert str(expint(n, z).as_integral) == \
-        str(Integral(exp(-t*z)/(t**n), (t, 1, oo)))
+    assert E1(z).as_integral(t) == Integral(exp(-t*z)/t, (t, 1, oo))
+    assert expint(1, z).as_integral(t) == Integral(exp(-t*z)/t, (t, 1, oo))
+    assert expint(2, z).as_integral(t) == Integral(exp(-t*z)/(t**2), (t, 1, oo))
+    assert expint(n, z).as_integral(t) == Integral(exp(-t*z)/(t**n), (t, 1, oo))
 
 
 def test__eis():
@@ -508,9 +510,9 @@ def test_Li():
     assert Li(z).rewrite(li) == li(z) - li(2)
 
 
-def test_li_Li_write_as_integral():
-    assert str(li(z).as_integral) == str(Integral(1/log(t), (t, 0, z)))
-    assert str(Li(z).as_integral) == str(Integral(1/log(t), (t, 2, z)))
+def test_li_Li_as_integral():
+    assert li(z).as_integral(t) == Integral(1/log(t), (t, 0, z))
+    assert Li(z).as_integral(t) == Integral(1/log(t), (t, 2, z))
 
 
 def test_si():
@@ -603,10 +605,10 @@ def test_ci():
 
 
 def test_trig_integral_as_integral():
-    assert str(Si(z).as_integral) == str(Integral(sin(t)/t, (t, 0, z)))
-    assert str(Ci(z).as_integral) == str(Integral(cos(t)/t, (t, 0, z)))
-    assert str(Shi(z).as_integral) == str(Integral(sinh(t)/t, (t, 0, z)))
-    assert str(Chi(z).as_integral) == str(Integral(cosh(t)/t, (t, 0, z)))
+    assert Si(z).as_integral(t) == Integral(sin(t)/t, (t, 0, z))
+    assert Ci(z).as_integral(t) == Integral(cos(t)/t, (t, 0, z))
+    assert Shi(z).as_integral(t) == Integral(sinh(t)/t, (t, 0, z))
+    assert Chi(z).as_integral(t) == Integral(cosh(t)/t, (t, 0, z))
 
 
 def test_fresnel():
@@ -723,8 +725,6 @@ def test_fresnel():
     verify_numerically(fresnelc(z), fresnelc(z).rewrite(meijerg), z)
 
 
-def test_fresnel_write_as_integral():
-    assert str(fresnels(z).as_integral) == \
-        str(Integral(sin(S.Half*pi*t**2), (t, 0, z)))
-    assert str(fresnelc(z).as_integral) == \
-        str(Integral(cos(S.Half*pi*t**2), (t, 0, z)))
+def test_fresnel_as_integral():
+    assert fresnels(z).as_integral(t) == Integral(sin(S.Half*pi*t**2), (t, 0, z))
+    assert fresnelc(z).as_integral(t) == Integral(cos(S.Half*pi*t**2), (t, 0, z))

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -89,6 +89,17 @@ def test_erf_rewrite_as_integral():
     assert str(erf(z).rewrite('Integral')) == str(erf(z).as_integral(t))
 
 
+def test_error_fcn_composition_rewrite_as_integral():
+    fcns = [erf, erfc, erfi, Ei, E1, li, Li, Si, Ci, Shi, Chi, fresnels, fresnelc]
+    for g in fcns:
+        for h in fcns:
+            f = g(h(z))
+            gin = g(z).as_integral()
+            hin = h(z).as_integral()
+            assert str(f.rewrite('Integral', deep=False)) == str(gin.subs(z, h(z)))
+            assert str(f.rewrite('Integral', deep=True)) == str(gin.subs(z, hin))
+
+
 def test_erf_series():
     assert erf(x).series(x, 0, 7) == 2*x/sqrt(pi) - \
         2*x**3/3/sqrt(pi) + x**5/5/sqrt(pi) + O(x**7)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -1,7 +1,7 @@
 from sympy import (
     symbols, expand, expand_func, nan, oo, Float, conjugate, diff,
     re, im, Abs, O, exp_polar, polar_lift, gruntz, limit,
-    Symbol, I, integrate, Integral, S,
+    Symbol, Dummy, I, integrate, Integral, S,
     sqrt, sin, cos, sinc, sinh, cosh, exp, log, pi, EulerGamma,
     erf, erfc, erfi, erf2, erfinv, erfcinv, erf2inv,
     gamma, uppergamma,
@@ -18,7 +18,7 @@ from sympy.utilities.pytest import raises
 x, y, z = symbols('x,y,z')
 w = Symbol("w", real=True)
 n = Symbol("n", integer=True)
-t = Symbol("t", Dummy=True)
+t = Dummy("t")
 
 
 def test_erf():
@@ -76,9 +76,9 @@ def test_erf():
     raises(ArgumentIndexError, lambda: erf(x).fdiff(2))
 
 
-def test_erf_write_as_integral():
-    assert erf(z).rewrite('Integral') == \
-        2/sqrt(pi)*Integral(exp(-t**2), (t, 0, z))
+def test_erf_as_integral():
+    assert str(erf(z).as_integral) == \
+        str(2/sqrt(pi)*Integral(exp(-t**2), (t, 0, z)))
 
 
 def test_erf_series():
@@ -153,9 +153,9 @@ def test_erfc_evalf():
     assert abs( erfc(Float(2.0)) - 0.00467773 ) < 1E-8 # XXX
 
 
-def test_erfc_write_as_integral():
-    assert erfc(z).rewrite('Integral') == \
-        2/sqrt(pi)*Integral(exp(-t**2), (t, z, oo))
+def test_erfc_as_integral():
+    assert str(erfc(z).as_integral) == \
+        str(2/sqrt(pi)*Integral(exp(-t**2), (t, z, oo)))
 
 
 def test_erfi():
@@ -202,9 +202,9 @@ def test_erfi():
     raises(ArgumentIndexError, lambda: erfi(x).fdiff(2))
 
 
-def test_erfi_write_as_integral():
-    assert erfi(z).rewrite('Integral') == \
-        2/sqrt(pi)*Integral(exp(t**2), (t, 0, z))
+def test_erfi_as_integral():
+    assert str(erfi(z).as_integral) == \
+        str(2/sqrt(pi)*Integral(exp(t**2), (t, 0, z)))
 
 
 def test_erfi_series():
@@ -250,9 +250,9 @@ def test_erf2():
     raises(ArgumentIndexError, lambda: erfi(x).fdiff(3))
 
 
-def test_erf2_write_as_integral():
-    assert erf2(x, y).rewrite('Integral') == \
-        2/sqrt(pi)*Integral(exp(-t**2), (t, x, y))
+def test_erf2_as_integral():
+    assert str(erf2(x, y).as_integral) == \
+        str(2/sqrt(pi)*Integral(exp(-t**2), (t, x, y)))
 
 
 def test_erfinv():
@@ -360,8 +360,8 @@ def test_ei():
         x**3/18 + x**4/96 + x**5/600 + O(x**6)
 
 
-def test_ei_write_as_integral():
-    assert Ei(z).rewrite('Integral') == Integral(exp(t)/t, (t, -oo, z))
+def test_ei_as_integral():
+    assert str(Ei(z).as_integral) == str(Integral(exp(t)/t, (t, -oo, z)))
 
 
 def test_expint():
@@ -413,14 +413,14 @@ def test_expint():
         z**5/240 + O(z**6)
 
 
-def test_expint_write_as_integral():
-    assert E1(z).rewrite('Integral') == Integral(exp(-t*z)/t, (t, 1, oo))
-    assert expint(1, z).rewrite('Integral') == \
-        Integral(exp(-t*z)/t, (t, 1, oo))
-    assert expint(2, z).rewrite('Integral') == \
-        Integral(exp(-t*z)/(t**2), (t, 1, oo))
-    assert expint(n, z).rewrite('Integral') == \
-        Integral(exp(-t*z)/(t**n), (t, 1, oo))
+def test_expint_as_integral():
+    assert str(E1(z).as_integral) == str(Integral(exp(-t*z)/t, (t, 1, oo)))
+    assert str(expint(1, z).as_integral) == \
+        str(Integral(exp(-t*z)/t, (t, 1, oo)))
+    assert str(expint(2, z).as_integral) == \
+        str(Integral(exp(-t*z)/(t**2), (t, 1, oo)))
+    assert str(expint(n, z).as_integral) == \
+        str(Integral(exp(-t*z)/(t**n), (t, 1, oo)))
 
 
 def test__eis():
@@ -509,8 +509,8 @@ def test_Li():
 
 
 def test_li_Li_write_as_integral():
-    assert li(z).rewrite('Integral') == Integral(1/log(t), (t, 0, z))
-    assert Li(z).rewrite('Integral') == Integral(1/log(t), (t, 2, z))
+    assert str(li(z).as_integral) == str(Integral(1/log(t), (t, 0, z)))
+    assert str(Li(z).as_integral) == str(Integral(1/log(t), (t, 2, z)))
 
 
 def test_si():
@@ -555,6 +555,7 @@ def test_si():
     assert Si(x).nseries(x, 1, n=3) == \
         Si(1) + (x - 1)*sin(1) + (x - 1)**2*(-sin(1)/2 + cos(1)/2) + O((x - 1)**3, (x, 1))
 
+    t = Symbol('t', Dummy=True)
     assert Si(x).rewrite(sinc) == Integral(sinc(t), (t, 0, x))
 
 
@@ -601,11 +602,11 @@ def test_ci():
     assert limit(log(x) - Ci(2*x), x, 0) == -log(2) - EulerGamma
 
 
-def test_trig_integral_write_as_integral():
-    assert Si(z).rewrite('Integral') == Integral(sin(t)/t, (t, 0, z))
-    assert Ci(z).rewrite('Integral') == Integral(cos(t)/t, (t, 0, z))
-    assert Shi(z).rewrite('Integral') == Integral(sinh(t)/t, (t, 0, z))
-    assert Chi(z).rewrite('Integral') == Integral(cosh(t)/t, (t, 0, z))
+def test_trig_integral_as_integral():
+    assert str(Si(z).as_integral) == str(Integral(sin(t)/t, (t, 0, z)))
+    assert str(Ci(z).as_integral) == str(Integral(cos(t)/t, (t, 0, z)))
+    assert str(Shi(z).as_integral) == str(Integral(sinh(t)/t, (t, 0, z)))
+    assert str(Chi(z).as_integral) == str(Integral(cosh(t)/t, (t, 0, z)))
 
 
 def test_fresnel():
@@ -723,7 +724,7 @@ def test_fresnel():
 
 
 def test_fresnel_write_as_integral():
-    assert fresnels(z).rewrite('Integral') == \
-        Integral(sin(S.Half*pi*t**2), (t, 0, z))
-    assert fresnelc(z).rewrite('Integral') == \
-        Integral(cos(S.Half*pi*t**2), (t, 0, z))
+    assert str(fresnels(z).as_integral) == \
+        str(Integral(sin(S.Half*pi*t**2), (t, 0, z)))
+    assert str(fresnelc(z).as_integral) == \
+        str(Integral(cos(S.Half*pi*t**2), (t, 0, z)))

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -15,10 +15,9 @@ from sympy.core.function import ArgumentIndexError
 
 from sympy.utilities.pytest import raises
 
-x, y, z = symbols('x,y,z')
+x, y, z, t = symbols('x,y,z,t')
 w = Symbol("w", real=True)
 n = Symbol("n", integer=True)
-t = Dummy("t")
 
 
 def test_erf():
@@ -82,10 +81,12 @@ def test_erf_as_integral():
 
 
 def test_erf_as_integral_dummy():
+    t = Dummy("t")
     assert str(erf(z).as_integral()) == str(erf(z).as_integral(t))
 
 
 def test_erf_rewrite_as_integral():
+    t = Dummy("t")
     assert str(erf(z).rewrite('Integral')) == str(erf(z).as_integral(t))
 
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -181,7 +181,7 @@ def test_functions():
     one_var = (acosh, ln, Heaviside, factorial, bernoulli, coth, tanh,
             sign, arg, asin, DiracDelta, re, Abs, sinh, cos, cot, acos, acot,
             gamma, bell, harmonic, LambertW, zeta, log, factorial, asinh,
-            acoth, cosh, dirichlet_eta, loggamma, ceiling, im, fibonacci,
+            acoth, cosh, dirichlet_eta, loggamma, erf, ceiling, im, fibonacci,
             conjugate, tan, floor, atanh, sin, atan, lucas, exp)
     two_var = (rf, ff, lowergamma, chebyshevu, chebyshevt, binomial,
             atan2, polygamma, hermite, legendre, uppergamma)

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -181,7 +181,7 @@ def test_functions():
     one_var = (acosh, ln, Heaviside, factorial, bernoulli, coth, tanh,
             sign, arg, asin, DiracDelta, re, Abs, sinh, cos, cot, acos, acot,
             gamma, bell, harmonic, LambertW, zeta, log, factorial, asinh,
-            acoth, cosh, dirichlet_eta, loggamma, erf, ceiling, im, fibonacci,
+            acoth, cosh, dirichlet_eta, loggamma, ceiling, im, fibonacci,
             conjugate, tan, floor, atanh, sin, atan, lucas, exp)
     two_var = (rf, ff, lowergamma, chebyshevu, chebyshevt, binomial,
             atan2, polygamma, hermite, legendre, uppergamma)


### PR DESCRIPTION
Many of these funtions are actually defined in terms of integrals
or at least can be written that way.  Now this will work:
`erf(z).rewrite('Integral')`.  Similarly for the other error fcns
as well as exponential integral fcns and trig integral fcns.
