### PR TITLE
(tensor module) Fix bug in TensAdd.data evaluation

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -828,8 +828,16 @@ class _TensorDataLazyEvaluator(CantSympify):
             if any([i is None for i in data_list]):
                 raise ValueError("Mixing tensors with associated components "\
                                  "data with tensors without components data")
-            for i in data_list:
-                sumvar += i
+
+            free_args_list = [[x[0] for x in arg.free] for arg in key.args]
+            numpy = import_module("numpy")
+            for data, free_args in zip(data_list, free_args_list):
+                if len(free_args) < 2:
+                    sumvar += data
+                else:
+                    free_args_pos = {y: x for x, y in enumerate(free_args)}
+                    axes = [free_args_pos[arg] for arg in key.free_args]
+                    sumvar += numpy.transpose(data, axes)
             return sumvar
 
         return None

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1777,3 +1777,56 @@ def test_TensMul_data():
     assert ((F(alpha, mu) * F(beta, nu) * u(-alpha) * u(-beta)).data ==
             (E(mu) * E(nu)).data
             ).all()
+
+    S2 = TensorType([Lorentz] * 2, tensorsymmetry([1] * 2))
+    g = S2('g')
+    g.data = Lorentz.data
+
+    # tensor 'perp' is orthogonal to vector 'u'
+    perp = u(mu) * u(nu) + g(mu, nu)
+
+    mul_1 = u(-mu) * perp(mu, nu)
+    assert (mul_1.data == numpy.array([0, 0, 0, 0])).all()
+
+    mul_2 = u(-mu) * perp(mu, alpha) * perp(nu, beta)
+    assert (mul_2.data == numpy.zeros(shape=(4, 4, 4))).all()
+
+    Fperp = perp(mu, alpha) * perp(nu, beta) * F(-alpha, -beta)
+    assert (Fperp.data[0, :] == numpy.array([0, 0, 0, 0])).all()
+    assert (Fperp.data[:, 0] == numpy.array([0, 0, 0, 0])).all()
+
+    mul_3 = u(-mu) * Fperp(mu, nu)
+    assert (mul_3.data == numpy.array([0, 0, 0, 0])).all()
+
+
+def test_issue_11020_TensAdd_data():
+    Lorentz = TensorIndexType('Lorentz', metric=False, dummy_fmt='i', dim=2)
+    Lorentz.data = [-1, 1]
+
+    a, b, c, d = tensor_indices('a, b, c, d', Lorentz)
+    i0, i1 = tensor_indices('i_0:2', Lorentz)
+
+    Vec = TensorType([Lorentz], tensorsymmetry([1]))
+    S2 = TensorType([Lorentz] * 2, tensorsymmetry([1] * 2))
+
+    # metric tensor
+    g = S2('g')
+    g.data = Lorentz.data
+
+    u = Vec('u')
+    u.data = [1, 0]
+
+    add_1 = g(b, c) * g(d, i0) * u(-i0) - g(b, c) * u(d)
+    assert (add_1.data == numpy.zeros(shape=(2, 2, 2))).all()
+    # Now let us replace index `d` with `a`:
+    add_2 = g(b, c) * g(a, i0) * u(-i0) - g(b, c) * u(a)
+    assert (add_2.data == numpy.zeros(shape=(2, 2, 2))).all()
+
+    # some more tests
+    # perp is tensor orthogonal to u^\mu
+    perp = u(a) * u(b) + g(a, b)
+    mul_1 = u(-a) * perp(a, b)
+    assert (mul_1.data == numpy.array([0, 0])).all()
+
+    mul_2 = u(-c) * perp(c, a) * perp(d, b)
+    assert (mul_2.data == numpy.zeros(shape=(2, 2, 2))).all()

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1800,6 +1800,10 @@ def test_TensMul_data():
 
 
 def test_issue_11020_TensAdd_data():
+    numpy = import_module('numpy')
+    if numpy is None:
+        return
+
     Lorentz = TensorIndexType('Lorentz', metric=False, dummy_fmt='i', dim=2)
     Lorentz.data = [-1, 1]
 


### PR DESCRIPTION
Fixes #11020, tests included.

We transpose all `data` arrays of `TensAdd` arguments, so that they all have the same free index order (the order is defined by `TensAdd.free_args` - I didn't change it).
