### PR TITLE
Transpose String changed #11044 

### DIFF
--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -9,7 +9,7 @@ The Matrix expression module allows users to write down statements like
     >>> X = MatrixSymbol('X', 3, 3)
     >>> Y = MatrixSymbol('Y', 3, 3)
     >>> (X.T*X).I*Y
-    X^-1*X'^-1*Y
+    X^-1*X.T^-1*Y
 
     >>> Matrix(X)
     Matrix([

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -139,8 +139,8 @@ class BlockMatrix(MatrixExpr):
         >>> B = BlockMatrix([[X, Z], [ZeroMatrix(m,n), Y]])
         >>> B.transpose()
         Matrix([
-        [X',  0],
-        [Z', Y']])
+        [X.T,  0],
+        [Z.T, Y.T]])
         >>> _.transpose()
         Matrix([
         [X, Z],

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -76,7 +76,7 @@ def refine_Inverse(expr, assumptions):
     X^-1
     >>> with assuming(Q.orthogonal(X)):
     ...     print(refine(X.I))
-    X'
+    X.T
     """
     if ask(Q.orthogonal(expr), assumptions):
         return expr.arg.T

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -257,7 +257,7 @@ def refine_MatMul(expr, assumptions):
     >>> X = MatrixSymbol('X', 2, 2)
     >>> expr = X * X.T
     >>> print(expr)
-    X*X'
+    X*X.T
     >>> with assuming(Q.orthogonal(X)):
     ...     print(refine(expr))
     I

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -21,13 +21,13 @@ class Transpose(MatrixExpr):
     >>> A = MatrixSymbol('A', 3, 5)
     >>> B = MatrixSymbol('B', 5, 3)
     >>> Transpose(A)
-    A'
+    A.T
     >>> A.T == transpose(A) == Transpose(A)
     True
     >>> Transpose(A*B)
-    (A*B)'
+    (A*B).T
     >>> transpose(A*B)
-    B'*A'
+    B.T*A.T
 
     """
     is_Transpose = True
@@ -84,7 +84,7 @@ def refine_Transpose(expr, assumptions):
     >>> from sympy import MatrixSymbol, Q, assuming, refine
     >>> X = MatrixSymbol('X', 2, 2)
     >>> X.T
-    X'
+    X.T
     >>> with assuming(Q.symmetric(X)):
     ...     print(refine(X.T))
     X

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -657,7 +657,7 @@ class StrPrinter(Printer):
         return self._print_tuple(expr)
 
     def _print_Transpose(self, T):
-        return "%s'" % self.parenthesize(T.arg, PRECEDENCE["Pow"])
+        return "%s.T" % self.parenthesize(T.arg, PRECEDENCE["Pow"])
 
     def _print_Uniform(self, expr):
         return "Uniform(%s, %s)" % (expr.a, expr.b)


### PR DESCRIPTION
Now the output is:

``` python
>>> from sympy import *
>>> from sympy.abc import *
>>> x = MatrixSymbol('x',3,1)
>>> x.T
x.T
>>> f = lambdify(x,x.T*x)
>>> f
<function <lambda> at 0x000000000511CD68>
```

Now, it does not give syntax error but lambdify is still not working.
