### PR TITLE
Add LLVM JIT callbacks for PyCuba integration.

### DIFF
--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -136,7 +136,7 @@ class LLVMJitCallbackPrinter(LLVMJitPrinter):
         return value
 
 
-class LoopCreator(object):
+class _LoopCreator(object):
     def __init__(self, builder, func):
         self.builder = builder
         self.func = func
@@ -437,7 +437,7 @@ class LLVMJitCodeCallbackVector(LLVMJitCode):
         bb_entry = self.fn.append_basic_block('entry')
         builder = ll.IRBuilder(bb_entry)
 
-        loop = LoopCreator(builder, self.fn)
+        loop = _LoopCreator(builder, self.fn)
 
         start = ll.Constant(ll.IntType(32), 0)
         step = ll.Constant(ll.IntType(32), 1)


### PR DESCRIPTION
Also add vectorized callbacks for cubature and pycuba.
(The '_v' variants of each callback type: 'cubature_v' and 'cuba_v')

The LoopCreator class helps creating the blocks and branches for loops.

The vector size for cubature is size_t, but all the internal loop variables
use 32 bit ints.  This could cause problems if there are very large vector
lengths.

Also, ctypes.c_size_t converts to a 64 bit int.  This may not work correctly
on a 32-bit system (untested).

There is a potential issue with a proliferation of supported callbacks.
It might be good to create an interface that lets users specify the
layout and functionality for other callbacks.  The CodeSignature object
could be a starting point to define that interface.

**Timing results:**
nquad w/python callback, time = 0.1216 s
   integral results =  (0.24608765540191072, 1.4434249909731589e-08)
nquad w/jit callback, time = 0.0491 s, speedup = 2.48
   integral results =  (0.24608765540191072, 1.4434249909731589e-08)

cubature w/python callback, time = 0.7949 s
cubature w/jit callback, time = 0.0052 s, speedup = 154.35
cubature (vectorized) w/jit callback, time = 0.0052 s, speedup = 152.67

Cuba (Cuhre) w/python callback, time = 0.0064 s
Cuba (Cuhre) w/jit callback, time = 0.0002 s, speedup = 37.96
   integral result =  0.24609025980570043
Cuba (Cuhre) (vectorized) w/jit callback, time = 0.0002 s, speedup = 40.22
  integral result =  0.24609025980570043

The vectorized callbacks are not much faster, most likely because the SIMD vectorization is not enabled during the LLVM compile.

**Example code:**

``` python
from __future__ import print_function

import sympy.printing.llvmjitcode as jit
from sympy import exp
from sympy.abc import x,y,z
from scipy.integrate import nquad
import math
from cubature import cubature
from timeit import timeit
import pycuba


# Sympy expression
e = exp(-2.0*(x*x + y*y + z*z))

# Python version (for nquad)
def f(x,y,z):
    return math.exp(-2.0*(x*x + y*y + z*z))

# Python version (for cubature)
def cf(array):
    x = array[0]
    y = array[1]
    z = array[2]
    return math.exp(-2.0*(x*x + y*y + z*z))

# Python version (for Cuba)
def Integrand(ndim, xx, ncomp, ff, userdata):
    b = 10.0
    x = b*xx[0]
    y = b*xx[1]
    z = b*xx[2]

    ff[0] = math.exp(-2.0*(x*x + y*y + z*z))
    return 0

ndim = 3
lim = [0.0, 10.0]
lims = [lim]*ndim
lim_min = [lim[0]]*ndim
lim_max = [lim[1]]*ndim
jacobian = lim[1]**3

# ---------------------
# Scipy.integrate.nquad
# ---------------------

# Python callback
def run_nquad():
    global python_nquad_res
    python_nquad_res = nquad(f, lims)
nquad_time = timeit(stmt=run_nquad, number=1)
print('nquad w/python callback, time = %.4f s'%nquad_time)
print('   integral results = ',python_nquad_res)

# JIT compiled callback
e_scipy = jit.llvm_callable([x,y,z], e, callback_type='scipy.integrate')
def run_nquad_jit():
    global nquad_res
    nquad_res = nquad(e_scipy, lims)
nquad_time_jit = timeit(stmt=run_nquad_jit, number=1)
print('nquad w/jit callback, time = %.4f s, speedup = %.2f'%(nquad_time_jit,nquad_time/nquad_time_jit))
print('   integral results = ',nquad_res)


# --------
# Cubature
# --------

# Python callback
def run_cubature():
    cubature(cf, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max)
cubature_time = timeit(stmt=run_cubature, number=1)
print('cubature w/python callback, time = %.4f s'%cubature_time)

# Number timeit evals for JIT code
neval = 100

# JIT compiled callback
e_cub = jit.llvm_callable([x,y,z], e, callback_type='cubature')
def run_cubature_jit():
    cubature(e_cub, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max)
cubature_time_jit = timeit(stmt=run_cubature_jit, number=neval)
print('cubature w/jit callback, time = %.4f s, speedup = %.2f'%(cubature_time_jit/neval, neval*cubature_time/cubature_time_jit))


# JIT compiled callback (vectorized)
e_cub = jit.llvm_callable([x,y,z], e, callback_type='cubature_v')
def run_cubature_v_jit():
    cubature(e_cub, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max, vectorized=True)
cubature_v_time_jit = timeit(stmt=run_cubature_v_jit, number=neval)
print('cubature (vectorized) w/jit callback, time = %.4f s, speedup = %.2f'%(cubature_v_time_jit/neval, neval*cubature_time/cubature_v_time_jit))


# ----
# Cuba
# ----

# Python callback
def run_cuhre():
    res = pycuba.Cuhre(Integrand, ndim=3)

cuhre_time = timeit(stmt=run_cuhre, number=1)
print('Cuba (Cuhre) w/python callback, time = %.4f s'%cuhre_time)

e2 = e.subs({x:10.0*x, y:10.0*y, z:10.0*z})
# JIT compiled callback
e_cuba = jit.llvm_callable([x,y,z], e2, callback_type='cuba')
def run_cuhre_jit():
    global jit_res
    jit_res = pycuba.Cuhre(e_cuba, ndim=3)
cuhre_jit_time = timeit(stmt=run_cuhre_jit, number=neval)
print('Cuba (Cuhre) w/jit callback, time = %.4f s, speedup = %.2f'%(cuhre_jit_time/neval, neval*cuhre_time/cuhre_jit_time))
print('   integral result = ',jit_res['results'][0]['integral']*jacobian)

# JIT compiled callback (vectorized)
e_cuba = jit.llvm_callable([x,y,z], e2, callback_type='cuba_v')
def run_cuhre_v_jit():
    global jit_v_res
    jit_v_res = pycuba.Cuhre(e_cuba, ndim=3, nvec=100)
cuhre_v_jit_time = timeit(stmt=run_cuhre_v_jit, number=neval)
print('Cuba (Cuhre) (vectorized) w/jit callback, time = %.4f s, speedup = %.2f'%(cuhre_v_jit_time/neval, neval*cuhre_time/cuhre_v_jit_time))
print('  integral result = ',jit_res['results'][0]['integral']*jacobian)
```
