### PR TITLE
Heaviside(0,h) can be used to specify value at 0

### DIFF
--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -440,7 +440,7 @@ class Heaviside(Function):
         Heaviside(0)
 
         >>> Heaviside(0, 1)
-        Heaviside(1)
+        1
 
         >>> Heaviside(-5)
         0
@@ -467,7 +467,7 @@ class Heaviside(Function):
             return S.One
         elif arg.is_zero:
             if H0 == S.NaN:
-                return cls(arg)
+                return
             elif H0 != None:
                 return H0
         elif arg is S.NaN:
@@ -494,14 +494,13 @@ class Heaviside(Function):
            Piecewise((0, x**2 - 1 < 0), (Heaviside(0), Eq(x**2 - 1, 0)), (1, x**2 - 1 > 0))
 
         """
-        if arg.is_real:
-            if H0 == None:
-                return Piecewise((0, arg < 0), (Heaviside(0), Eq(arg, 0)), (1, arg > 0))
-            if H0 == 0:
-                return Piecewise((0, arg <= 0), (1, arg > 0))
-            if H0 == 1:
-                return Piecewise((0, arg < 0), (1, arg >= 0))
-            return Piecewise((1, arg > 0), (H0, Eq(arg, 0)), (0, arg > 0))
+        if H0 == None:
+            return Piecewise((0, arg < 0), (Heaviside(0), Eq(arg, 0)), (1, arg > 0))
+        if H0 == 0:
+            return Piecewise((0, arg <= 0), (1, arg > 0))
+        if H0 == 1:
+            return Piecewise((0, arg < 0), (1, arg >= 0))
+        return Piecewise((0, arg < 0), (H0, Eq(arg, 0)), (1, arg > 0))
 
     def _eval_rewrite_as_sign(self, *args):
         """Represents the Heaviside function in the form of sign function.

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -353,6 +353,20 @@ class Heaviside(Function):
     .. [*] Regarding to the value at 0, Mathematica defines ``H(0) = 1``,
            but Maple uses ``H(0) = undefined``
 
+    To specify the value of Heaviside at x=0, a second argument
+    can be given, and Heaviside will that value.
+
+    >>> from sympy import Heaviside
+    >>> from sympy.abc import y
+    >>> Heaviside(9)
+    1
+    >>> Heaviside(-9)
+    0
+    >>> Heaviside(0)
+    Heaviside(0)
+    >>> Heaviside(0, y)
+    y
+
     See Also
     ========
 
@@ -394,7 +408,7 @@ class Heaviside(Function):
             raise ArgumentIndexError(self, argindex)
 
     @classmethod
-    def eval(cls, arg):
+    def eval(cls, arg, H0=None):
         """
         Returns a simplified form or a value of Heaviside depending on the
         argument passed by the Heaviside object.
@@ -420,6 +434,9 @@ class Heaviside(Function):
         >>> Heaviside(0)
         Heaviside(0)
 
+        >>> Heaviside(0, 1)
+        Heaviside(1)
+
         >>> Heaviside(-5)
         0
 
@@ -436,6 +453,8 @@ class Heaviside(Function):
         1
 
         """
+        if H0 == None:
+            H0 = S.NaN
         arg = sympify(arg)
         if arg is S.NaN:
             return S.NaN
@@ -445,6 +464,8 @@ class Heaviside(Function):
             return S.Zero
         elif arg.is_positive:
             return S.One
+        elif arg.is_zero and H0 != S.NaN:
+            return H0
 
     def _eval_rewrite_as_Piecewise(self, arg):
         """Represents Heaviside in a Piecewise form
@@ -499,6 +520,24 @@ class Heaviside(Function):
         sign
 
         """
+=======
+    def _eval_rewrite_as_Piecewise(self, *args):
+        if len(args) == 2:
+            arg, H0 = args[0], args[1]
+        else:
+            arg, H0 = args[0], None
+        if arg.is_real:
+            if H0 == None:
+                return Piecewise((1, arg > 0), (0, arg < 0))
+            return Piecewise((1, arg > 0), (H0, Eq(arg, 0)), (0, True))
+
+    def _eval_rewrite_as_sign(self, *args):
+        if len(args) == 2:
+            arg, H0 = args[0], args[1]
+        else:
+            arg, H0 = args[0], None
+        # the value of H0 is ignored currently
+>>>>>>> Heaviside(0,h) can be used to specify value at 0
         if arg.is_real:
             return (sign(arg)+1)/2
 

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -357,9 +357,8 @@ class Heaviside(Function):
            is common practice to assume ``H(0) == 0`` to match the Laplace
            transform of a DiracDelta distribution.
 
-    To specify the value of Heaviside at x=0, a second argument
-    can be given.  Omit this 2nd argument or pass NaN to recover the default
-    behavior.
+    To specify the value of Heaviside at x=0, a second argument can be given.
+    Omit this 2nd argument or pass ``NaN`` to recover the default behavior.
 
     >>> from sympy import Heaviside, S
     >>> from sympy.abc import x

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -475,7 +475,7 @@ class Heaviside(Function):
         elif fuzzy_not(im(arg).is_zero):
             raise ValueError("Function defined only for Real Values. Complex part: %s  found in %s ." % (repr(im(arg)), repr(arg)) )
 
-    def _eval_rewrite_as_Piecewise(self, arg):
+    def _eval_rewrite_as_Piecewise(self, arg, H0 = None):
         """Represents Heaviside in a Piecewise form
 
            Examples
@@ -494,10 +494,19 @@ class Heaviside(Function):
            Piecewise((0, x**2 - 1 < 0), (Heaviside(0), Eq(x**2 - 1, 0)), (1, x**2 - 1 > 0))
 
         """
-        return Piecewise((0, arg < 0), (Heaviside(0), Eq(arg, 0)), (1, arg > 0))
+        if arg.is_real:
+            if H0 == None:
+                return Piecewise((0, arg < 0), (Heaviside(0), Eq(arg, 0)), (1, arg > 0))
+            if H0 == 0:
+                return Piecewise((0, arg <= 0), (1, arg > 0))
+            if H0 == 1:
+                return Piecewise((0, arg < 0), (1, arg >= 0))
+            return Piecewise((1, arg > 0), (H0, Eq(arg, 0)), (0, arg > 0))
 
-    def _eval_rewrite_as_sign(self, arg):
+    def _eval_rewrite_as_sign(self, *args):
         """Represents the Heaviside function in the form of sign function.
+        The value of the second argument of Heaviside must be unspecified or 1/2
+        for rewritting as sign to be strictly equivalent
 
         Examples
         ========
@@ -507,6 +516,9 @@ class Heaviside(Function):
 
         >>> Heaviside(x).rewrite(sign)
         sign(x)/2 + 1/2
+
+        >>> Heaviside(x, 0).rewrite(sign)
+        Heaviside(x, 0)
 
         >>> Heaviside(x - 2).rewrite(sign)
         sign(x - 2)/2 + 1/2
@@ -528,30 +540,13 @@ class Heaviside(Function):
         sign
 
         """
-=======
-    def _eval_rewrite_as_Piecewise(self, *args):
         if len(args) == 2:
             arg, H0 = args[0], args[1]
         else:
             arg, H0 = args[0], None
         if arg.is_real:
-            if H0 == None:
-                return Piecewise((1, arg > 0), (0, arg < 0))
-            if H0 == 0:
-                return Piecewise((1, arg > 0), (0, True))
-            if H0 == 1:
-                return Piecewise((1, arg >= 0), (0, True))
-            return Piecewise((1, arg > 0), (H0, Eq(arg, 0)), (0, True))
-
-    def _eval_rewrite_as_sign(self, *args):
-        if len(args) == 2:
-            arg, H0 = args[0], args[1]
-        else:
-            arg, H0 = args[0], None
-        # the value of H0 is ignored currently
->>>>>>> Heaviside(0,h) can be used to specify value at 0
-        if arg.is_real:
-            return (sign(arg)+1)/2
+            if H0 == None or H0 == S.Half:
+                return (sign(arg)+1)/2
 
     def _sage_(self):
         import sage.all as sage

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -71,7 +71,8 @@ def test_heaviside():
     assert Heaviside(nan) == nan
 
     assert Heaviside(0, x) == x
-    assert Heaviside(0, S.NaN).func == Heaviside
+    assert Heaviside(0).func == Heaviside
+    assert Heaviside(0, S.NaN) == Heaviside(0)
 
     assert adjoint(Heaviside(x)) == Heaviside(x)
     assert adjoint(Heaviside(x - y)) == Heaviside(x - y)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -71,6 +71,7 @@ def test_heaviside():
     assert Heaviside(nan) == nan
 
     assert Heaviside(0, x) == x
+    assert Heaviside(0, S.NaN).func == Heaviside
 
     assert adjoint(Heaviside(x)) == Heaviside(x)
     assert adjoint(Heaviside(x - y)) == Heaviside(x - y)
@@ -96,6 +97,10 @@ def test_rewrite():
         Piecewise((0, y < 0), (Heaviside(0), Eq(y, 0)), (1, y > 0)))
     assert Heaviside(x, y).rewrite(Piecewise) == (
         Piecewise((0, x < 0), (y, Eq(x, 0)), (1, x > 0)))
+    assert Heaviside(x, 0).rewrite(Piecewise) == (
+        Piecewise((0, x <= 0), (1, x > 0)))
+    assert Heaviside(x, 1).rewrite(Piecewise) == \
+        Piecewise((0, x < 0), (1, x >= 0)))
 
     assert Heaviside(x).rewrite(sign) == (sign(x)+1)/2
     assert Heaviside(y).rewrite(sign) == Heaviside(y)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -70,6 +70,8 @@ def test_heaviside():
     assert Heaviside(1) == 1
     assert Heaviside(nan) == nan
 
+    assert Heaviside(0, x) == x
+
     assert adjoint(Heaviside(x)) == Heaviside(x)
     assert adjoint(Heaviside(x - y)) == Heaviside(x - y)
     assert conjugate(Heaviside(x)) == Heaviside(x)
@@ -92,6 +94,8 @@ def test_rewrite():
         Piecewise((0, x < 0), (Heaviside(0), Eq(x, 0)), (1, x > 0)))
     assert Heaviside(y).rewrite(Piecewise) == (
         Piecewise((0, y < 0), (Heaviside(0), Eq(y, 0)), (1, y > 0)))
+    assert Heaviside(x, y).rewrite(Piecewise) == (
+        Piecewise((0, x < 0), (y, Eq(x, 0)), (1, x > 0)))
 
     assert Heaviside(x).rewrite(sign) == (sign(x)+1)/2
     assert Heaviside(y).rewrite(sign) == Heaviside(y)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -71,7 +71,6 @@ def test_heaviside():
     assert Heaviside(nan) == nan
 
     assert Heaviside(0, x) == x
-    assert Heaviside(0).func == Heaviside
     assert Heaviside(0, S.NaN) == Heaviside(0)
 
     assert adjoint(Heaviside(x)) == Heaviside(x)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -99,11 +99,13 @@ def test_rewrite():
         Piecewise((0, x < 0), (y, Eq(x, 0)), (1, x > 0)))
     assert Heaviside(x, 0).rewrite(Piecewise) == (
         Piecewise((0, x <= 0), (1, x > 0)))
-    assert Heaviside(x, 1).rewrite(Piecewise) == \
+    assert Heaviside(x, 1).rewrite(Piecewise) == (
         Piecewise((0, x < 0), (1, x >= 0)))
 
     assert Heaviside(x).rewrite(sign) == (sign(x)+1)/2
     assert Heaviside(y).rewrite(sign) == Heaviside(y)
+    assert Heaviside(x, S.Half).rewrite(sign) == (sign(x)+1)/2
+    assert Heaviside(x, y).rewrite(sign) == Heaviside(x, y)
 
     assert DiracDelta(y).rewrite(Piecewise) == Piecewise((DiracDelta(0), Eq(y, 0)), (0, True))
     assert DiracDelta(y, 1).rewrite(Piecewise) == DiracDelta(y, 1)


### PR DESCRIPTION
A proposed method for allowing user-specified values in the Heaviside function at x=0.
See issue #11060.
