### PR TITLE
The Zen of SymPy: from sympy import this

### DIFF
--- a/sympy/this.py
+++ b/sympy/this.py
@@ -1,0 +1,29 @@
+"""The Zen of SymPy.
+
+This is still a work in progress. Feel free to add, modify, reorder, or
+delete items from it. Some of these perhaps apply more to developing SymPy
+than using it.
+"""
+
+s = """Gur Mra bs FlzCl
+
+Harinyhngrq vf orggre guna rinyhngrq.
+Gur hfre vagresnpr znggref.
+Cevagvat znggref.
+Cher Clguba pna or snfg rabhtu.
+Vs vg'f gbb fybj, vgf (cebonoyl) lbhe snhyg.
+Qbphzragngvba znggref.
+Pbeerpgarff vf zber vzcbegnag guna fcrrq.
+Chfu vg va abj naq vzcebir hcba vg yngre.
+Pbirentr ol grfgvat znggref.
+Fzneg grfgf ner orggre guna enaqbz grfgf.
+Ohg enaqbz grfgf fbzrgvzrf svaq jung lbhe fznegrfg grfg zvffrq.
+Gur Clguba jnl vf cebonoyl gur evtug jnl.
+Pbzzhavgl vf zber vzcbegnag guna pbqr."""
+
+d = {}
+for c in (65, 97):
+    for i in range(26):
+        d[chr(i + c)] = chr((i + 13) % 26 + c)
+
+print("".join([d.get(c, c) for c in s]))


### PR DESCRIPTION
Source: https://github.com/sympy/sympy/wiki/The-Zen-of-SymPy

Idea inspired from: https://github.com/python/cpython/blob/master/Lib/this.py

Usage:

``` python
>>> from sympy import this
The Zen of SymPy

Unevaluated is better than evaluated.
The user interface matters.
Printing matters.
Pure Python can be fast enough.
If it's too slow, its (probably) your fault.
Documentation matters.
Correctness is more important than speed.
Push it in now and improve upon it later.
Coverage by testing matters.
Smart tests are better than random tests.
But random tests sometimes find what your smartest test missed.
The Python way is probably the right way.
Community is more important than code.
```

ping @certik @asmeurer @moorepants 

Feel free to agree or disagree to add this.
