### PR TITLE
Allows solution of integral(sqrt(a*x + b) / x, x) (#10847)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -546,6 +546,13 @@ def root_mul_rule(integral):
         return
 
     a, b, c = match[a], match[b], match[c]
+    d = sympy.Wild('d', exclude=[symbol])
+    e = sympy.Wild('e', exclude=[symbol])
+    f = sympy.Wild('f')
+    recursion_test = c.match(sympy.sqrt(d * symbol + e) * f)
+    if recursion_test:
+        return
+
     u = sympy.Dummy('u')
     u_func = sympy.sqrt(a * symbol + b)
     integrand = integrand.subs(u_func, u)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -304,7 +304,8 @@ def inverse_trig_rule(integral):
     possibilities = []
 
     if sympy.simplify(exp + 1) == 0 and not (negative(a) or negative(b)):
-        possibilities.append((ArctanRule, exp, a, 1, b, 1, sympy.And(a > 0, b > 0)))
+        pass
+        # possibilities.append((ArctanRule, exp, a, 1, b, 1, sympy.And(a > 0, b > 0)))
     elif sympy.simplify(2*exp + 1) == 0:
         possibilities.append((ArcsinRule, exp, a, 1, -b, -1, sympy.And(a > 0, b < 0)))
         possibilities.append((ArcsinhRule, exp, a, 1, b, 1, sympy.And(a > 0, b > 0)))

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -340,19 +340,11 @@ def mul_rule(integral):
 def _parts_rule(integrand, symbol):
     # LIATE rule:
     # log, inverse trig, algebraic (polynomial), trigonometric, exponential
-    def pull_out_polys(integrand):
+    def pull_out_algebraic(integrand):
         integrand = integrand.together()
-        polys = [arg for arg in integrand.args if (arg.is_polynomial(symbol) or \
-                                                   arg.is_algebraic_expr(symbol))]
-        # polys = [arg for arg in integrand.args if (arg.is_polynomial(symbol) or \
-        #                                            (isinstance(arg, sympy.Pow) and \
-        #                                             (symbol in arg.as_base_exp()[0].free_symbols)))]
-        # polys = [arg for arg in integrand.args if (arg.is_polynomial(symbol) or \
-        #                                            (isinstance(arg, sympy.Pow) and \
-        #                                             (symbol in arg.as_base_exp()[0].free_symbols) and \
-        #                                             arg.as_base_exp()[1] is not sympy.sympify(-1)))]
-        if polys:
-            u = sympy.Mul(*polys)
+        algebraic = [arg for arg in integrand.args if arg.is_algebraic_expr(symbol)]
+        if algebraic:
+            u = sympy.Mul(*algebraic)
             dv = integrand / u
             return u, dv
 
@@ -369,7 +361,7 @@ def _parts_rule(integrand, symbol):
         return pull_out_u_rl
 
     liate_rules = [pull_out_u(sympy.log), pull_out_u(sympy.atan, sympy.asin, sympy.acos),
-                   pull_out_polys, pull_out_u(sympy.sin, sympy.cos),
+                   pull_out_algebraic, pull_out_u(sympy.sin, sympy.cos),
                    pull_out_u(sympy.exp)]
 
 
@@ -416,6 +408,8 @@ def parts_rule(integral):
             return
 
         while True:
+            if (integrand / (v * du)).cancel() == 1:
+                break
             if symbol not in (integrand / (v * du)).cancel().free_symbols:
                 coefficient = ((v * du) / integrand).cancel()
                 rule = CyclicPartsRule(

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -341,11 +341,11 @@ def _parts_rule(integrand, symbol):
     # LIATE rule:
     # log, inverse trig, algebraic (polynomial), trigonometric, exponential
     def pull_out_algebraic(integrand):
-        integrand = integrand.together()
+        integrand = integrand.cancel().together()
         algebraic = [arg for arg in integrand.args if arg.is_algebraic_expr(symbol)]
         if algebraic:
             u = sympy.Mul(*algebraic)
-            dv = integrand / u
+            dv = (integrand / u).cancel()
             return u, dv
 
     def pull_out_u(*functions):
@@ -942,7 +942,7 @@ def integral_steps(integrand, symbol, **options):
     integral = IntegralInfo(integrand, symbol)
 
     def key(integral):
-        integrand = integral.integrand
+        integrand = integral.integrand.simplify()
 
         if isinstance(integrand, TrigonometricFunction):
             return TrigonometricFunction

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -386,9 +386,9 @@ def _parts_rule(integrand, symbol):
             for rule in liate_rules[index + 1:]:
                 r = rule(integrand)
                 # make sure dv is amenable to integration
-                if r and r[0].subs(dummy, 1) == dv:
+                if r and sympy.simplify(r[0].subs(dummy, 1)) == sympy.simplify(dv):
                     du = u.diff(symbol)
-                    v_step = integral_steps(dv, symbol)
+                    v_step = integral_steps(sympy.simplify(dv), symbol)
                     v = _manualintegrate(v_step)
 
                     return u, dv, v, du, v_step

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -343,9 +343,14 @@ def _parts_rule(integrand, symbol):
     def pull_out_polys(integrand):
         integrand = integrand.together()
         polys = [arg for arg in integrand.args if (arg.is_polynomial(symbol) or \
-                                                   (isinstance(arg, sympy.Pow) and \
-                                                    (symbol in arg.as_base_exp()[0].free_symbols) and \
-                                                    arg.as_base_exp()[1] is not sympy.sympify(-1)))]
+                                                   arg.is_algebraic_expr(symbol))]
+        # polys = [arg for arg in integrand.args if (arg.is_polynomial(symbol) or \
+        #                                            (isinstance(arg, sympy.Pow) and \
+        #                                             (symbol in arg.as_base_exp()[0].free_symbols)))]
+        # polys = [arg for arg in integrand.args if (arg.is_polynomial(symbol) or \
+        #                                            (isinstance(arg, sympy.Pow) and \
+        #                                             (symbol in arg.as_base_exp()[0].free_symbols) and \
+        #                                             arg.as_base_exp()[1] is not sympy.sympify(-1)))]
         if polys:
             u = sympy.Mul(*polys)
             dv = integrand / u

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -330,16 +330,17 @@ def mul_rule(integral):
 
     # Constant times function case
     coeff, f = integrand.as_independent(symbol)
+    next_step = integral_steps(f, symbol)
 
-    if coeff != 1 and integral_steps(f, symbol) is not None:
+    if coeff != 1 and next_step is not None:
         return ConstantTimesRule(
             coeff, f,
-            integral_steps(f, symbol),
+            next_step,
             integrand, symbol)
 
 def _parts_rule(integrand, symbol):
     # LIATE rule:
-    # log, inverse trig, algebraic (polynomial), trigonometric, exponential
+    # log, inverse trig, algebraic, trigonometric, exponential
     def pull_out_algebraic(integrand):
         integrand = integrand.cancel().together()
         algebraic = [arg for arg in integrand.args if arg.is_algebraic_expr(symbol)]
@@ -440,8 +441,9 @@ def parts_rule(integral):
                              make_second_step(steps[1:], v * du),
                              integrand, symbol)
         else:
-            if integral_steps(integrand, symbol):
-                return integral_steps(integrand, symbol)
+            steps = integral_steps(integrand, symbol)
+            if steps:
+                return steps
             else:
                 return DontKnowRule(integrand, symbol)
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -173,7 +173,7 @@ def rewriter(condition, rewrite):
             rewritten = rewrite(*integral)
             if rewritten != integrand:
                 substep = integral_steps(rewritten, symbol)
-                if not isinstance(substep, DontKnowRule):
+                if not isinstance(substep, DontKnowRule) and substep:
                     return RewriteRule(
                         rewritten,
                         substep,

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -443,11 +443,10 @@ def parts_rule(integral):
                              make_second_step(steps[1:], v * du),
                              integrand, symbol)
         else:
-            # if integral_steps(integrand, symbol):
-            #     return integral_steps(integrand, symbol)
-            # else:
-            #     return DontKnowRule(integrand, symbol)
-            return integral_steps(integrand, symbol)
+            if integral_steps(integrand, symbol):
+                return integral_steps(integrand, symbol)
+            else:
+                return DontKnowRule(integrand, symbol)
 
     if steps:
         u, dv, v, du, v_step = steps[0]

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -254,8 +254,8 @@ def test_issue_6746():
     a = Symbol('a', negative=True)
     assert manualintegrate(1 / (a + b*x**2), x) == \
         Piecewise((atan(x/sqrt(a/b))/(b*sqrt(a/b)), a/b > 0), \
-	(-acoth(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 > -a/b)), \
-	(-atanh(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 < -a/b)))
+        (-acoth(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 > -a/b)), \
+        (-atanh(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 < -a/b)))
 
 
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -261,6 +261,12 @@ def test_issue_2850():
     assert manualintegrate(atan(x)*log(x), x) == -x*atan(x) + (x*atan(x) - \
             log(x**2 + 1)/2)*log(x) + log(x**2 + 1)/2 + Integral(log(x**2 + 1)/x, x)/2
 
+def test_issue_9462():
+    assert manualintegrate(sin(2*x)*exp(x), x) == -3*exp(x)*sin(2*x) \
+                           - 2*exp(x)*cos(2*x) + 4*Integral(2*exp(x)*cos(2*x), x)
+    assert manualintegrate((x - 3) / (x**2 - 2*x + 2)**2, x) == \
+                           Integral(x/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x) \
+                           - 3*Integral(1/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x)
 
 def test_constant_independent_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,7 +1,7 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Integral, integrate, pi, Dummy, Derivative,
                    diff, I, sqrt, erf, Piecewise, Eq, symbols,
-                   And, Heaviside, S, asinh, acosh, atanh, acoth)
+                   And, Heaviside, S, asinh, acosh, atanh, acoth, expand)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
     _parts_rule
 
@@ -278,10 +278,21 @@ def test_issue_10847():
     assert manualintegrate(x**2 / (x**2 - c), x) == c*Piecewise((atan(x/sqrt(-c))/sqrt(-c), -c > 0), \
                                                                 (-acoth(x/sqrt(c))/sqrt(c), And(-c < 0, x**2 > c)), \
                                                                 (-atanh(x/sqrt(c))/sqrt(c), And(-c < 0, x**2 < c))) + x
-    # assert manualintegrate(sqrt(x - y) * log(z / x), x) ==
+    assert manualintegrate(sqrt(x - y) * log(z / x), x) == 4*y**2*Piecewise((atan(sqrt(x - y)/sqrt(y))/sqrt(y), y > 0), \
+                                                                            (-acoth(sqrt(x - y)/sqrt(-y))/sqrt(-y), \
+                                                                             And(x - y > -y, y < 0)), \
+                                                                            (-atanh(sqrt(x - y)/sqrt(-y))/sqrt(-y), \
+                                                                             And(x - y < -y, y < 0)))/3 \
+                                                                             - 4*y*sqrt(x - y)/3 + 2*(x - y)**(3/2)*log(z/x)/3 \
+                                                                             + 4*(x - y)**(3/2)/9
+
     assert manualintegrate(sqrt(x) * log(x), x) == 2*x**(3/2)*log(x)/3 - 4*x**(3/2)/9
-    # assert manualintegrate(sqrt(a*x + b), x) ==
-    # assert manualintegrate(sqrt(a*x + b) / (x + c), x) ==
+    assert manualintegrate(sqrt(a*x + b) / x, x) == -2*b*Piecewise((-atan(sqrt(a*x + b)/sqrt(-b))/sqrt(-b), -b > 0), \
+                                                               (acoth(sqrt(a*x + b)/sqrt(b))/sqrt(b), And(-b < 0, a*x + b > b)), \
+                                                               (atanh(sqrt(a*x + b)/sqrt(b))/sqrt(b), And(-b < 0, a*x + b < b))) \
+                                                               + 2*sqrt(a*x + b)
+
+    assert expand(manualintegrate(sqrt(a*x + b) / (x + c), x)) == -2*a*c*Piecewise((atan(sqrt(a*x + b)/sqrt(a*c - b))/sqrt(a*c - b), a*c - b > 0), (-acoth(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b > -a*c + b)), (-atanh(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b < -a*c + b))) + 2*b*Piecewise((atan(sqrt(a*x + b)/sqrt(a*c - b))/sqrt(a*c - b), a*c - b > 0), (-acoth(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b > -a*c + b)), (-atanh(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b < -a*c + b))) + 2*sqrt(a*x + b)
     assert manualintegrate((4*x**4 + 4*x**3 + 16*x**2 + 12*x + 8) \
                            / (x**6 + 2*x**5 + 3*x**4 + 4*x**3 + 3*x**2 + 2*x + 1), x) == \
                            2*x/(x**2 + 1) + 3*atan(x) - 1/(x**2 + 1) - 3/(x + 1)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,6 +1,6 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Integral, integrate, pi, Dummy, Derivative,
-                   diff, I, sqrt, erf, Piecewise, Eq, symbols,
+                   diff, I, sqrt, erf, Piecewise, Eq, symbols, Rational,
                    And, Heaviside, S, asinh, acosh, atanh, acoth, expand)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
     _parts_rule
@@ -304,7 +304,7 @@ def test_issue_10847():
                            2*x/(x**2 + 1) + 3*atan(x) - 1/(x**2 + 1) - 3/(x + 1)
     assert manualintegrate(sqrt(2*x + 3) / (x + 1), x) == 2*sqrt(2*x + 3) - log(sqrt(2*x + 3) + 1) + log(sqrt(2*x + 3) - 1)
     assert manualintegrate(sqrt(2*x + 3) / 2 * x, x) == (2*x + 3)**(5/2)/20 - (2*x + 3)**(3/2)/4
-    assert manualintegrate(x**(3/2) * log(x), x) == 0.4*x**2.5*log(x) - 0.16*x**2.5
+    assert manualintegrate(x**Rational(3,2) * log(x), x) == 2*x**Rational(5,2)*log(x)/5 - 4*x**Rational(5/2)/25
     assert manualintegrate(x**(-3) * log(x), x) == -log(x)/(2*x**2) - 1/(4*x**2)
 
 def test_constant_independent_of_symbol():

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -45,7 +45,7 @@ def test_manualintegrate_parts():
     assert manualintegrate(x * log(x), x) == x**2*log(x)/2 - x**2/4
     assert manualintegrate(log(x), x) == x * log(x) - x
     assert manualintegrate((3*x**2 + 5) * exp(x), x) == \
-        -6*x*exp(x) + (3*x**2 + 5)*exp(x) + 6*exp(x)
+        3*x**2*exp(x) - 6*x*exp(x) + 11*exp(x)
     assert manualintegrate(atan(x), x) == x*atan(x) - log(x**2 + 1)/2
 
     # Make sure _parts_rule doesn't pick u = constant but can pick dv =

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -292,10 +292,18 @@ def test_issue_10847():
                                                                (atanh(sqrt(a*x + b)/sqrt(b))/sqrt(b), And(-b < 0, a*x + b < b))) \
                                                                + 2*sqrt(a*x + b)
 
-    assert expand(manualintegrate(sqrt(a*x + b) / (x + c), x)) == -2*a*c*Piecewise((atan(sqrt(a*x + b)/sqrt(a*c - b))/sqrt(a*c - b), a*c - b > 0), (-acoth(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b > -a*c + b)), (-atanh(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b < -a*c + b))) + 2*b*Piecewise((atan(sqrt(a*x + b)/sqrt(a*c - b))/sqrt(a*c - b), a*c - b > 0), (-acoth(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b > -a*c + b)), (-atanh(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b < -a*c + b))) + 2*sqrt(a*x + b)
+    assert expand(manualintegrate(sqrt(a*x + b) / (x + c), x)) == -2*a*c*Piecewise((atan(sqrt(a*x + b)/sqrt(a*c - b))/sqrt(a*c - b), \
+        a*c - b > 0), (-acoth(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b > -a*c + b)), \
+        (-atanh(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b < -a*c + b))) \
+        + 2*b*Piecewise((atan(sqrt(a*x + b)/sqrt(a*c - b))/sqrt(a*c - b), a*c - b > 0), \
+        (-acoth(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b > -a*c + b)), \
+        (-atanh(sqrt(a*x + b)/sqrt(-a*c + b))/sqrt(-a*c + b), And(a*c - b < 0, a*x + b < -a*c + b))) + 2*sqrt(a*x + b)
+
     assert manualintegrate((4*x**4 + 4*x**3 + 16*x**2 + 12*x + 8) \
                            / (x**6 + 2*x**5 + 3*x**4 + 4*x**3 + 3*x**2 + 2*x + 1), x) == \
                            2*x/(x**2 + 1) + 3*atan(x) - 1/(x**2 + 1) - 3/(x + 1)
+    assert manualintegrate(sqrt(2*x + 3) / (x + 1), x) == 2*sqrt(2*x + 3) - log(sqrt(2*x + 3) + 1) + log(sqrt(2*x + 3) - 1)
+    assert manualintegrate(sqrt(2*x + 3) / 2 * x, x) == (2*x + 3)**(5/2)/20 - (2*x + 3)**(3/2)/4
 
 def test_constant_independent_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,7 +1,7 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Integral, integrate, pi, Dummy, Derivative,
                    diff, I, sqrt, erf, Piecewise, Eq, symbols,
-                   And, Heaviside, S, asinh, acosh)
+                   And, Heaviside, S, asinh, acosh, atanh, acoth)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
     _parts_rule
 
@@ -99,11 +99,11 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(1 / (4 + x**2), x) == atan(x / 2) / 2
     assert manualintegrate(1 / (1 + 4 * x**2), x) == atan(2*x) / 2
     assert manualintegrate(1/(a + b*x**2), x) == \
-        Piecewise(((sqrt(a/b)*atan(x*sqrt(b/a))/a), And(a > 0, b > 0)))
+        Piecewise((atan(x/sqrt(a/b))/(b*sqrt(a/b)), a/b > 0), (-acoth(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 > -a/b)), (-atanh(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 < -a/b)))
     assert manualintegrate(1/(4 + b*x**2), x) == \
-        Piecewise((sqrt(1/b)*atan(sqrt(b)*x/2)/2, b > 0))
+        Piecewise((atan(x/(2*sqrt(1/b)))/(2*b*sqrt(1/b)), 4/b > 0), (-acoth(x/(2*sqrt(-1/b)))/(2*b*sqrt(-1/b)), And(4/b < 0, x**2 > -4/b)), (-atanh(x/(2*sqrt(-1/b)))/(2*b*sqrt(-1/b)), And(4/b < 0, x**2 < -4/b)))
     assert manualintegrate(1/(a + 4*x**2), x) == \
-        Piecewise((atan(2*x*sqrt(1/a))/(2*sqrt(a)), a > 0))
+        Piecewise((atan(2*x/sqrt(a))/(2*sqrt(a)), a/4 > 0), (-acoth(2*x/sqrt(-a))/(2*sqrt(-a)), And(a/4 < 0, x**2 > -a/4)), (-atanh(2*x/sqrt(-a))/(2*sqrt(-a)), And(a/4 < 0, x**2 < -a/4)))
     assert manualintegrate(1/(4 + 4*x**2), x) == atan(x) / 4
 
     # asin
@@ -165,8 +165,8 @@ def test_manualintegrate_trig_substitution():
 
 
 def test_manualintegrate_rational():
-    assert manualintegrate(1/(4 - x**2), x) == -log(x - 2)/4 + log(x + 2)/4
-    assert manualintegrate(1/(-1 + x**2), x) == log(x - 1)/2 - log(x + 1)/2
+    assert manualintegrate(1/(4 - x**2), x) == Piecewise((acoth(x/2)/2, x**2 > 4), (atanh(x/2)/2, x**2 < 4))
+    assert manualintegrate(1/(-1 + x**2), x) == Piecewise((-acoth(x), x**2 > 1), (-atanh(x), x**2 < 1))
 
 
 def test_manualintegrate_derivative():
@@ -247,7 +247,10 @@ def test_issue_6746():
         (y + 1)**(n*x)/(n*log(y + 1))
     a = Symbol('a', negative=True)
     assert manualintegrate(1 / (a + b*x**2), x) == \
-        Integral(1/(a + b*x**2), x)
+        Piecewise((atan(x/sqrt(a/b))/(b*sqrt(a/b)), a/b > 0), \
+	(-acoth(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 > -a/b)), \
+	(-atanh(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 < -a/b)))
+
 
 
 def test_issue_2850():

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -304,6 +304,8 @@ def test_issue_10847():
                            2*x/(x**2 + 1) + 3*atan(x) - 1/(x**2 + 1) - 3/(x + 1)
     assert manualintegrate(sqrt(2*x + 3) / (x + 1), x) == 2*sqrt(2*x + 3) - log(sqrt(2*x + 3) + 1) + log(sqrt(2*x + 3) - 1)
     assert manualintegrate(sqrt(2*x + 3) / 2 * x, x) == (2*x + 3)**(5/2)/20 - (2*x + 3)**(3/2)/4
+    assert manualintegrate(x**(3/2) * log(x), x) == 0.4*x**2.5*log(x) - 0.16*x**2.5
+    assert manualintegrate(x**(-3) * log(x), x) == -log(x)/(2*x**2) - 1/(4*x**2)
 
 def test_constant_independent_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -306,6 +306,7 @@ def test_issue_10847():
     assert manualintegrate(sqrt(2*x + 3) / 2 * x, x) == (2*x + 3)**(5/2)/20 - (2*x + 3)**(3/2)/4
     assert manualintegrate(x**Rational(3,2) * log(x), x) == 2*x**Rational(5,2)*log(x)/5 - 4*x**Rational(5/2)/25
     assert manualintegrate(x**(-3) * log(x), x) == -log(x)/(2*x**2) - 1/(4*x**2)
+    assert manualintegrate(log(y)/(y**2*(1 - 1/y)), y) == (-log(y) + log(y - 1))*log(y) + log(y)**2/2 - Integral(log(y - 1)/y, y)
 
 def test_constant_independent_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -5,7 +5,7 @@ from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
     _parts_rule
 
-x, y, u, n, a, b = symbols('x y u n a b')
+x, y, z, u, n, a, b, c = symbols('x y z u n a b c')
 
 
 def test_find_substitutions():
@@ -99,11 +99,17 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(1 / (4 + x**2), x) == atan(x / 2) / 2
     assert manualintegrate(1 / (1 + 4 * x**2), x) == atan(2*x) / 2
     assert manualintegrate(1/(a + b*x**2), x) == \
-        Piecewise((atan(x/sqrt(a/b))/(b*sqrt(a/b)), a/b > 0), (-acoth(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 > -a/b)), (-atanh(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 < -a/b)))
+        Piecewise((atan(x/sqrt(a/b))/(b*sqrt(a/b)), a/b > 0), \
+                  (-acoth(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 > -a/b)), \
+                  (-atanh(x/sqrt(-a/b))/(b*sqrt(-a/b)), And(a/b < 0, x**2 < -a/b)))
     assert manualintegrate(1/(4 + b*x**2), x) == \
-        Piecewise((atan(x/(2*sqrt(1/b)))/(2*b*sqrt(1/b)), 4/b > 0), (-acoth(x/(2*sqrt(-1/b)))/(2*b*sqrt(-1/b)), And(4/b < 0, x**2 > -4/b)), (-atanh(x/(2*sqrt(-1/b)))/(2*b*sqrt(-1/b)), And(4/b < 0, x**2 < -4/b)))
+        Piecewise((atan(x/(2*sqrt(1/b)))/(2*b*sqrt(1/b)), 4/b > 0), \
+                  (-acoth(x/(2*sqrt(-1/b)))/(2*b*sqrt(-1/b)), And(4/b < 0, x**2 > -4/b)), \
+                  (-atanh(x/(2*sqrt(-1/b)))/(2*b*sqrt(-1/b)), And(4/b < 0, x**2 < -4/b)))
     assert manualintegrate(1/(a + 4*x**2), x) == \
-        Piecewise((atan(2*x/sqrt(a))/(2*sqrt(a)), a/4 > 0), (-acoth(2*x/sqrt(-a))/(2*sqrt(-a)), And(a/4 < 0, x**2 > -a/4)), (-atanh(2*x/sqrt(-a))/(2*sqrt(-a)), And(a/4 < 0, x**2 < -a/4)))
+        Piecewise((atan(2*x/sqrt(a))/(2*sqrt(a)), a/4 > 0), \
+                  (-acoth(2*x/sqrt(-a))/(2*sqrt(-a)), And(a/4 < 0, x**2 > -a/4)), \
+                  (-atanh(2*x/sqrt(-a))/(2*sqrt(-a)), And(a/4 < 0, x**2 < -a/4)))
     assert manualintegrate(1/(4 + 4*x**2), x) == atan(x) / 4
 
     # asin
@@ -267,6 +273,18 @@ def test_issue_9462():
     assert manualintegrate((x - 3) / (x**2 - 2*x + 2)**2, x) == \
                            Integral(x/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x) \
                            - 3*Integral(1/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x)
+
+def test_issue_10847():
+    assert manualintegrate(x**2 / (x**2 - c), x) == c*Piecewise((atan(x/sqrt(-c))/sqrt(-c), -c > 0), \
+                                                                (-acoth(x/sqrt(c))/sqrt(c), And(-c < 0, x**2 > c)), \
+                                                                (-atanh(x/sqrt(c))/sqrt(c), And(-c < 0, x**2 < c))) + x
+    # assert manualintegrate(sqrt(x - y) * log(z / x), x) ==
+    assert manualintegrate(sqrt(x) * log(x), x) == 2*x**(3/2)*log(x)/3 - 4*x**(3/2)/9
+    # assert manualintegrate(sqrt(a*x + b), x) ==
+    # assert manualintegrate(sqrt(a*x + b) / (x + c), x) ==
+    assert manualintegrate((4*x**4 + 4*x**3 + 16*x**2 + 12*x + 8) \
+                           / (x**6 + 2*x**5 + 3*x**4 + 4*x**3 + 3*x**2 + 2*x + 1), x) == \
+                           2*x/(x**2 + 1) + 3*atan(x) - 1/(x**2 + 1) - 3/(x + 1)
 
 def test_constant_independent_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -221,8 +221,10 @@ def test_parametric_log_deriv():
 
 
 def test_issue_10798():
-    from sympy import integrate, pi, I, log, polylog, exp_polar
+    from sympy import integrate, pi, I, log, polylog, exp_polar, Piecewise, meijerg, Abs
     from sympy.abc import x, y
     assert integrate(1/(1-(x*y)**2), (x, 0, 1), y) == \
-        I*pi*log(y)/2 + polylog(2, exp_polar(I*pi)/y)/2 - \
-        polylog(2, exp_polar(2*I*pi)/y)/2
+        -Piecewise((I*pi*log(y) - polylog(2, y), Abs(y) < 1), (-I*pi*log(1/y) - polylog(2, y), Abs(1/y) < 1), \
+                   (-I*pi*meijerg(((), (1, 1)), ((0, 0), ()), y) + I*pi*meijerg(((1, 1), ()), ((), (0, 0)), y) - polylog(2, y), True))/2 \
+                   - log(y)*log(1 - 1/y)/2 + log(y)*log(1 + 1/y)/2 + log(y)*log(y - 1)/2 \
+                   - log(y)*log(y + 1)/2 + I*pi*log(y)/2 - polylog(2, y*exp_polar(I*pi))/2


### PR DESCRIPTION
Additions to manualintegrate.py:
- SOverXBLtZeroRule: handles condition when b < 0
- SOverXAXGtZeroRule: handles condition when b > 0 and a \* x > 0
- SOverXAXLtZeroRule: handles condition when b > 0 and a \* x < 0
- In pull_out_polys function with _parts_rule, added additional or condition
  that allows integration by parts to be performed in conjunction with
  non-integer powers

Fixes #10847 
