### PR TITLE
Array transpose

### DIFF
--- a/doc/src/modules/tensor/array.rst
+++ b/doc/src/modules/tensor/array.rst
@@ -6,6 +6,9 @@ N-dim array
 .. automodule:: sympy.tensor.array
 
 
+Classes
+-------
+
 .. autoclass:: ImmutableDenseNDimArray
    :members:
 
@@ -17,3 +20,15 @@ N-dim array
 
 .. autoclass:: MutableSparseNDimArray
    :members:
+
+
+Functions
+---------
+
+.. autofunction:: derive_by_array
+
+.. autofunction:: permutedims
+
+.. autofunction:: tensorcontraction
+
+.. autofunction:: tensorproduct

--- a/sympy/tensor/array/__init__.py
+++ b/sympy/tensor/array/__init__.py
@@ -202,7 +202,7 @@ z*cos(y*z) + exp(x)
 
 from .dense_ndim_array import MutableDenseNDimArray, ImmutableDenseNDimArray
 from .sparse_ndim_array import MutableSparseNDimArray, ImmutableSparseNDimArray
-from .arrayop import tensorproduct, tensorcontraction, derive_by_array
+from .arrayop import tensorproduct, tensorcontraction, derive_by_array, permutedims
 
 Array = ImmutableDenseNDimArray
 NDimArray = ImmutableDenseNDimArray

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -210,25 +210,22 @@ def derive_by_array(expr, dx):
             return diff(expr, dx)
 
 
-def _array_transpose(expr, order=None):
+def permutedims(expr, perm):
     """
-    Evaluates the transpose of an array.
+    Permutes the indices of an array.
 
-    Optional parameter to specify an index permutation.
+    Parameter specifies the permutation of the indices.
     """
     if not isinstance(expr, NDimArray):
-        return transpose(expr)
+        raise TypeError("expression has to be an N-dim array")
 
+    perm = tuple(perm)
     rank = expr.rank()
 
-    if order is None:
-        # order is reversed indices order:
-        order = tuple(reversed(range(expr.rank())))
-    elif len(order) < rank:
-        # order is incomplete, fill it:
-        order = tuple(order) + tuple(range(len(order), rank))
+    if tuple(sorted(perm)) != tuple(range(rank)):
+        raise ValueError("not a permutation")
 
-    reverse = [order.index(i) for i in range(rank)]
+    reverse = [perm.index(i) for i in range(rank)]
 
     def permute_array(arr):
         new_arr = [None]*len(arr)

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -256,13 +256,11 @@ def permutedims(expr, perm):
     if not isinstance(perm, Permutation):
         perm = Permutation(list(perm))
 
-    # Get the inverse permutation:
-    iperm = perm**-1
-    # Rank abbreviation:
-    rank = expr.rank()
+    if perm.size != expr.rank():
+        raise ValueError("wrong permutation size")
 
-    if tuple(sorted(perm.array_form)) != tuple(range(rank)):
-        raise ValueError("not a permutation")
+    # Get the inverse permutation:
+    iperm = ~perm
 
     indices_span = perm([range(i) for i in expr.shape])
 

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -368,8 +368,10 @@ class NDimArray(object):
             return Derivative(self, *args, **kwargs)
 
     def _eval_transpose(self):
-        from .arrayop import _array_transpose
-        return _array_transpose(self)
+        if self.rank() != 2:
+            raise ValueError("array rank not 2")
+        from .arrayop import permutedims
+        return permutedims(self, (1, 0))
 
     def transpose(self):
         return self._eval_transpose()

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 import collections
-from sympy import Matrix, Integer, sympify, Basic, Derivative
+from sympy import Matrix, Integer, sympify, Basic, Derivative, conjugate
 
 
 class NDimArray(object):
@@ -366,6 +366,25 @@ class NDimArray(object):
             return self.diff(*args)
         else:
             return Derivative(self, *args, **kwargs)
+
+    def _eval_transpose(self):
+        from .arrayop import _array_transpose
+        return _array_transpose(self)
+
+    def transpose(self):
+        return self._eval_transpose()
+
+    def _eval_conjugate(self):
+        return self.func([i.conjugate() for i in self], self.shape)
+
+    def conjugate(self):
+        return self._eval_conjugate()
+
+    def _eval_adjoint(self):
+        return self.transpose().conjugate()
+
+    def adjoint(self):
+        return self._eval_adjoint()
 
 
 class ImmutableNDimArray(NDimArray, Basic):

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -1,7 +1,9 @@
+from sympy.utilities.pytest import raises
+
 from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate
 from sympy.tensor.array import Array
 
-from sympy.tensor.array.arrayop import tensorproduct, tensorcontraction, derive_by_array, _array_transpose
+from sympy.tensor.array.arrayop import tensorproduct, tensorcontraction, derive_by_array, permutedims
 
 
 def test_tensorproduct():
@@ -86,12 +88,12 @@ def test_issue_emerged_while_discussing_10972():
                                                            [sa[110] + sa[126] + sa[142] + sa[18] + sa[2] + sa[34], sa[111] + sa[127] + sa[143] + sa[19] + sa[3] + sa[35]]])
 
 
-def test_array_transpose():
+def test_array_permutedims():
     sa = symbols('a0:144')
 
     m1 = Array(sa[:6], (2, 3))
-    assert _array_transpose(m1) == transpose(m1)
-    assert m1.tomatrix().T == _array_transpose(m1).tomatrix()
+    assert permutedims(m1, (1, 0)) == transpose(m1)
+    assert m1.tomatrix().T == permutedims(m1, (1, 0)).tomatrix()
 
     assert m1.tomatrix().T == transpose(m1).tomatrix()
     assert m1.tomatrix().C == conjugate(m1).tomatrix()
@@ -103,7 +105,11 @@ def test_array_transpose():
 
     po = Array(sa, [2, 2, 3, 3, 2, 2])
 
-    assert _array_transpose(po) == Array(
+    raises(ValueError, lambda: permutedims(po, (1, 1)))
+    raises(ValueError, lambda: po.transpose())
+    raises(ValueError, lambda: po.adjoint())
+
+    assert permutedims(po, reversed(range(po.rank()))) == Array(
         [[[[[[sa[0], sa[72]], [sa[36], sa[108]]], [[sa[12], sa[84]], [sa[48], sa[120]]], [[sa[24],
                                                                                            sa[96]], [sa[60], sa[132]]]],
            [[[sa[4], sa[76]], [sa[40], sa[112]]], [[sa[16],
@@ -138,7 +144,7 @@ def test_array_transpose():
                                                      sa[95]], [sa[59], sa[131]]],
             [[sa[35], sa[107]], [sa[71], sa[143]]]]]]])
 
-    assert _array_transpose(po, (1, 0)) == Array(
+    assert permutedims(po, (1, 0, 2, 3, 4, 5)) == Array(
         [[[[[[sa[0], sa[1]], [sa[2], sa[3]]], [[sa[4], sa[5]], [sa[6], sa[7]]], [[sa[8], sa[9]], [sa[10],
                                                                                                   sa[11]]]],
            [[[sa[12], sa[13]], [sa[14], sa[15]]], [[sa[16], sa[17]], [sa[18],
@@ -181,7 +187,7 @@ def test_array_transpose():
                                                                                      sa[139]]],
                                                                [[sa[140], sa[141]], [sa[142], sa[143]]]]]]])
 
-    assert _array_transpose(po, (0, 2, 1, 4, 3)) == Array(
+    assert permutedims(po, (0, 2, 1, 4, 3, 5)) == Array(
         [[[[[[sa[0], sa[1]], [sa[4], sa[5]], [sa[8], sa[9]]], [[sa[2], sa[3]], [sa[6], sa[7]], [sa[10],
                                                                                                 sa[11]]]],
            [[[sa[36], sa[37]], [sa[40], sa[41]], [sa[44], sa[45]]], [[sa[38],

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -1,7 +1,7 @@
-from sympy import symbols, sin, exp, log, cos
+from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate
 from sympy.tensor.array import Array
 
-from sympy.tensor.array.arrayop import tensorproduct, tensorcontraction, derive_by_array
+from sympy.tensor.array.arrayop import tensorproduct, tensorcontraction, derive_by_array, _array_transpose
 
 
 def test_tensorproduct():
@@ -84,3 +84,133 @@ def test_issue_emerged_while_discussing_10972():
                                                              sa[140] + sa[143] + sa[32] + sa[35]]])
     assert tensorcontraction(po, (0, 1), (2, 3)) == Array([[sa[0] + sa[108] + sa[124] + sa[140] + sa[16] + sa[32], sa[1] + sa[109] + sa[125] + sa[141] + sa[17] + sa[33]],
                                                            [sa[110] + sa[126] + sa[142] + sa[18] + sa[2] + sa[34], sa[111] + sa[127] + sa[143] + sa[19] + sa[3] + sa[35]]])
+
+
+def test_array_transpose():
+    sa = symbols('a0:144')
+
+    m1 = Array(sa[:6], (2, 3))
+    assert _array_transpose(m1) == transpose(m1)
+    assert m1.tomatrix().T == _array_transpose(m1).tomatrix()
+
+    assert m1.tomatrix().T == transpose(m1).tomatrix()
+    assert m1.tomatrix().C == conjugate(m1).tomatrix()
+    assert m1.tomatrix().H == adjoint(m1).tomatrix()
+
+    assert m1.tomatrix().T == m1.transpose().tomatrix()
+    assert m1.tomatrix().C == m1.conjugate().tomatrix()
+    assert m1.tomatrix().H == m1.adjoint().tomatrix()
+
+    po = Array(sa, [2, 2, 3, 3, 2, 2])
+
+    assert _array_transpose(po) == Array(
+        [[[[[[sa[0], sa[72]], [sa[36], sa[108]]], [[sa[12], sa[84]], [sa[48], sa[120]]], [[sa[24],
+                                                                                           sa[96]], [sa[60], sa[132]]]],
+           [[[sa[4], sa[76]], [sa[40], sa[112]]], [[sa[16],
+                                                    sa[88]], [sa[52], sa[124]]],
+            [[sa[28], sa[100]], [sa[64], sa[136]]]],
+           [[[sa[8],
+              sa[80]], [sa[44], sa[116]]], [[sa[20], sa[92]], [sa[56], sa[128]]], [[sa[32],
+                                                                                    sa[104]], [sa[68], sa[140]]]]],
+          [[[[sa[2], sa[74]], [sa[38], sa[110]]], [[sa[14],
+                                                    sa[86]], [sa[50], sa[122]]], [[sa[26], sa[98]], [sa[62], sa[134]]]],
+           [[[sa[6],
+              sa[78]], [sa[42], sa[114]]], [[sa[18], sa[90]], [sa[54], sa[126]]], [[sa[30],
+                                                                                    sa[102]], [sa[66], sa[138]]]],
+           [[[sa[10], sa[82]], [sa[46], sa[118]]], [[sa[22],
+                                                     sa[94]], [sa[58], sa[130]]],
+            [[sa[34], sa[106]], [sa[70], sa[142]]]]]],
+         [[[[[sa[1],
+              sa[73]], [sa[37], sa[109]]], [[sa[13], sa[85]], [sa[49], sa[121]]], [[sa[25],
+                                                                                    sa[97]], [sa[61], sa[133]]]],
+           [[[sa[5], sa[77]], [sa[41], sa[113]]], [[sa[17],
+                                                    sa[89]], [sa[53], sa[125]]],
+            [[sa[29], sa[101]], [sa[65], sa[137]]]],
+           [[[sa[9],
+              sa[81]], [sa[45], sa[117]]], [[sa[21], sa[93]], [sa[57], sa[129]]], [[sa[33],
+                                                                                    sa[105]], [sa[69], sa[141]]]]],
+          [[[[sa[3], sa[75]], [sa[39], sa[111]]], [[sa[15],
+                                                    sa[87]], [sa[51], sa[123]]], [[sa[27], sa[99]], [sa[63], sa[135]]]],
+           [[[sa[7],
+              sa[79]], [sa[43], sa[115]]], [[sa[19], sa[91]], [sa[55], sa[127]]], [[sa[31],
+                                                                                    sa[103]], [sa[67], sa[139]]]],
+           [[[sa[11], sa[83]], [sa[47], sa[119]]], [[sa[23],
+                                                     sa[95]], [sa[59], sa[131]]],
+            [[sa[35], sa[107]], [sa[71], sa[143]]]]]]])
+
+    assert _array_transpose(po, (1, 0)) == Array(
+        [[[[[[sa[0], sa[1]], [sa[2], sa[3]]], [[sa[4], sa[5]], [sa[6], sa[7]]], [[sa[8], sa[9]], [sa[10],
+                                                                                                  sa[11]]]],
+           [[[sa[12], sa[13]], [sa[14], sa[15]]], [[sa[16], sa[17]], [sa[18],
+                                                                      sa[19]]], [[sa[20], sa[21]], [sa[22], sa[23]]]],
+           [[[sa[24], sa[25]], [sa[26],
+                                sa[27]]], [[sa[28], sa[29]], [sa[30], sa[31]]], [[sa[32], sa[33]], [sa[34],
+                                                                                                    sa[35]]]]],
+          [[[[sa[72], sa[73]], [sa[74], sa[75]]], [[sa[76], sa[77]], [sa[78],
+                                                                      sa[79]]], [[sa[80], sa[81]], [sa[82], sa[83]]]],
+           [[[sa[84], sa[85]], [sa[86],
+                                sa[87]]], [[sa[88], sa[89]], [sa[90], sa[91]]], [[sa[92], sa[93]], [sa[94],
+                                                                                                    sa[95]]]],
+           [[[sa[96], sa[97]], [sa[98], sa[99]]], [[sa[100], sa[101]], [sa[102],
+                                                                        sa[103]]],
+            [[sa[104], sa[105]], [sa[106], sa[107]]]]]], [[[[[sa[36], sa[37]], [sa[38],
+                                                                                sa[39]]],
+                                                            [[sa[40], sa[41]], [sa[42], sa[43]]],
+                                                            [[sa[44], sa[45]], [sa[46],
+                                                                                sa[47]]]],
+                                                           [[[sa[48], sa[49]], [sa[50], sa[51]]],
+                                                            [[sa[52], sa[53]], [sa[54],
+                                                                                sa[55]]],
+                                                            [[sa[56], sa[57]], [sa[58], sa[59]]]],
+                                                           [[[sa[60], sa[61]], [sa[62],
+                                                                                sa[63]]],
+                                                            [[sa[64], sa[65]], [sa[66], sa[67]]],
+                                                            [[sa[68], sa[69]], [sa[70],
+                                                                                sa[71]]]]], [
+                                                              [[[sa[108], sa[109]], [sa[110], sa[111]]],
+                                                               [[sa[112], sa[113]], [sa[114],
+                                                                                     sa[115]]],
+                                                               [[sa[116], sa[117]], [sa[118], sa[119]]]],
+                                                              [[[sa[120], sa[121]], [sa[122],
+                                                                                     sa[123]]],
+                                                               [[sa[124], sa[125]], [sa[126], sa[127]]],
+                                                               [[sa[128], sa[129]], [sa[130],
+                                                                                     sa[131]]]],
+                                                              [[[sa[132], sa[133]], [sa[134], sa[135]]],
+                                                               [[sa[136], sa[137]], [sa[138],
+                                                                                     sa[139]]],
+                                                               [[sa[140], sa[141]], [sa[142], sa[143]]]]]]])
+
+    assert _array_transpose(po, (0, 2, 1, 4, 3)) == Array(
+        [[[[[[sa[0], sa[1]], [sa[4], sa[5]], [sa[8], sa[9]]], [[sa[2], sa[3]], [sa[6], sa[7]], [sa[10],
+                                                                                                sa[11]]]],
+           [[[sa[36], sa[37]], [sa[40], sa[41]], [sa[44], sa[45]]], [[sa[38],
+                                                                      sa[39]], [sa[42], sa[43]], [sa[46], sa[47]]]]],
+          [[[[sa[12], sa[13]], [sa[16],
+                                sa[17]], [sa[20], sa[21]]], [[sa[14], sa[15]], [sa[18], sa[19]], [sa[22],
+                                                                                                  sa[23]]]],
+           [[[sa[48], sa[49]], [sa[52], sa[53]], [sa[56], sa[57]]], [[sa[50],
+                                                                      sa[51]], [sa[54], sa[55]], [sa[58], sa[59]]]]],
+          [[[[sa[24], sa[25]], [sa[28],
+                                sa[29]], [sa[32], sa[33]]], [[sa[26], sa[27]], [sa[30], sa[31]], [sa[34],
+                                                                                                  sa[35]]]],
+           [[[sa[60], sa[61]], [sa[64], sa[65]], [sa[68], sa[69]]], [[sa[62],
+                                                                      sa[63]], [sa[66], sa[67]], [sa[70], sa[71]]]]]],
+         [[[[[sa[72], sa[73]], [sa[76],
+                                sa[77]], [sa[80], sa[81]]], [[sa[74], sa[75]], [sa[78], sa[79]], [sa[82],
+                                                                                                  sa[83]]]],
+           [[[sa[108], sa[109]], [sa[112], sa[113]], [sa[116], sa[117]]], [[sa[110],
+                                                                            sa[111]], [sa[114], sa[115]],
+                                                                           [sa[118], sa[119]]]]],
+          [[[[sa[84], sa[85]], [sa[88],
+                                sa[89]], [sa[92], sa[93]]], [[sa[86], sa[87]], [sa[90], sa[91]], [sa[94],
+                                                                                                  sa[95]]]],
+           [[[sa[120], sa[121]], [sa[124], sa[125]], [sa[128], sa[129]]], [[sa[122],
+                                                                            sa[123]], [sa[126], sa[127]],
+                                                                           [sa[130], sa[131]]]]],
+          [[[[sa[96], sa[97]], [sa[100],
+                                sa[101]], [sa[104], sa[105]]], [[sa[98], sa[99]], [sa[102], sa[103]], [sa[106],
+                                                                                                       sa[107]]]],
+           [[[sa[132], sa[133]], [sa[136], sa[137]], [sa[140], sa[141]]], [[sa[134],
+                                                                            sa[135]], [sa[138], sa[139]],
+                                                                           [sa[142], sa[143]]]]]]])

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -1,9 +1,10 @@
+from sympy.combinatorics import Permutation
 from sympy.utilities.pytest import raises
 
 from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate
-from sympy.tensor.array import Array
+from sympy.tensor.array import Array, NDimArray
 
-from sympy.tensor.array.arrayop import tensorproduct, tensorcontraction, derive_by_array, permutedims
+from sympy.tensor.array import tensorproduct, tensorcontraction, derive_by_array, permutedims
 
 
 def test_tensorproduct():
@@ -102,6 +103,12 @@ def test_array_permutedims():
     assert m1.tomatrix().T == m1.transpose().tomatrix()
     assert m1.tomatrix().C == m1.conjugate().tomatrix()
     assert m1.tomatrix().H == m1.adjoint().tomatrix()
+
+    z = NDimArray.zeros(4,5,6,7)
+
+    assert permutedims(z, (2, 3, 1, 0)).shape == (6, 7, 5, 4)
+    assert permutedims(z, [2, 3, 1, 0]).shape == (6, 7, 5, 4)
+    assert permutedims(z, Permutation([2, 3, 1, 0])).shape == (6, 7, 5, 4)
 
     po = Array(sa, [2, 2, 3, 3, 2, 2])
 
@@ -220,3 +227,8 @@ def test_array_permutedims():
            [[[sa[132], sa[133]], [sa[136], sa[137]], [sa[140], sa[141]]], [[sa[134],
                                                                             sa[135]], [sa[138], sa[139]],
                                                                            [sa[142], sa[143]]]]]]])
+
+    po2 = po.reshape(4, 9, 2, 2)
+    assert po2 == Array([[[[sa[0], sa[1]], [sa[2], sa[3]]], [[sa[4], sa[5]], [sa[6], sa[7]]], [[sa[8], sa[9]], [sa[10], sa[11]]], [[sa[12], sa[13]], [sa[14], sa[15]]], [[sa[16], sa[17]], [sa[18], sa[19]]], [[sa[20], sa[21]], [sa[22], sa[23]]], [[sa[24], sa[25]], [sa[26], sa[27]]], [[sa[28], sa[29]], [sa[30], sa[31]]], [[sa[32], sa[33]], [sa[34], sa[35]]]], [[[sa[36], sa[37]], [sa[38], sa[39]]], [[sa[40], sa[41]], [sa[42], sa[43]]], [[sa[44], sa[45]], [sa[46], sa[47]]], [[sa[48], sa[49]], [sa[50], sa[51]]], [[sa[52], sa[53]], [sa[54], sa[55]]], [[sa[56], sa[57]], [sa[58], sa[59]]], [[sa[60], sa[61]], [sa[62], sa[63]]], [[sa[64], sa[65]], [sa[66], sa[67]]], [[sa[68], sa[69]], [sa[70], sa[71]]]], [[[sa[72], sa[73]], [sa[74], sa[75]]], [[sa[76], sa[77]], [sa[78], sa[79]]], [[sa[80], sa[81]], [sa[82], sa[83]]], [[sa[84], sa[85]], [sa[86], sa[87]]], [[sa[88], sa[89]], [sa[90], sa[91]]], [[sa[92], sa[93]], [sa[94], sa[95]]], [[sa[96], sa[97]], [sa[98], sa[99]]], [[sa[100], sa[101]], [sa[102], sa[103]]], [[sa[104], sa[105]], [sa[106], sa[107]]]], [[[sa[108], sa[109]], [sa[110], sa[111]]], [[sa[112], sa[113]], [sa[114], sa[115]]], [[sa[116], sa[117]], [sa[118], sa[119]]], [[sa[120], sa[121]], [sa[122], sa[123]]], [[sa[124], sa[125]], [sa[126], sa[127]]], [[sa[128], sa[129]], [sa[130], sa[131]]], [[sa[132], sa[133]], [sa[134], sa[135]]], [[sa[136], sa[137]], [sa[138], sa[139]]], [[sa[140], sa[141]], [sa[142], sa[143]]]]])
+
+    assert permutedims(po2, (3, 2, 0, 1)) == Array([[[[sa[0], sa[4], sa[8], sa[12], sa[16], sa[20], sa[24], sa[28], sa[32]], [sa[36], sa[40], sa[44], sa[48], sa[52], sa[56], sa[60], sa[64], sa[68]], [sa[72], sa[76], sa[80], sa[84], sa[88], sa[92], sa[96], sa[100], sa[104]], [sa[108], sa[112], sa[116], sa[120], sa[124], sa[128], sa[132], sa[136], sa[140]]], [[sa[2], sa[6], sa[10], sa[14], sa[18], sa[22], sa[26], sa[30], sa[34]], [sa[38], sa[42], sa[46], sa[50], sa[54], sa[58], sa[62], sa[66], sa[70]], [sa[74], sa[78], sa[82], sa[86], sa[90], sa[94], sa[98], sa[102], sa[106]], [sa[110], sa[114], sa[118], sa[122], sa[126], sa[130], sa[134], sa[138], sa[142]]]], [[[sa[1], sa[5], sa[9], sa[13], sa[17], sa[21], sa[25], sa[29], sa[33]], [sa[37], sa[41], sa[45], sa[49], sa[53], sa[57], sa[61], sa[65], sa[69]], [sa[73], sa[77], sa[81], sa[85], sa[89], sa[93], sa[97], sa[101], sa[105]], [sa[109], sa[113], sa[117], sa[121], sa[125], sa[129], sa[133], sa[137], sa[141]]], [[sa[3], sa[7], sa[11], sa[15], sa[19], sa[23], sa[27], sa[31], sa[35]], [sa[39], sa[43], sa[47], sa[51], sa[55], sa[59], sa[63], sa[67], sa[71]], [sa[75], sa[79], sa[83], sa[87], sa[91], sa[95], sa[99], sa[103], sa[107]], [sa[111], sa[115], sa[119], sa[123], sa[127], sa[131], sa[135], sa[139], sa[143]]]]])

--- a/sympy/tensor/array/tests/test_arrayop.py
+++ b/sympy/tensor/array/tests/test_arrayop.py
@@ -1,4 +1,9 @@
+import random
+
+import itertools
+
 from sympy.combinatorics import Permutation
+from sympy.combinatorics.permutations import _af_invert
 from sympy.utilities.pytest import raises
 
 from sympy import symbols, sin, exp, log, cos, transpose, adjoint, conjugate
@@ -103,6 +108,23 @@ def test_array_permutedims():
     assert m1.tomatrix().T == m1.transpose().tomatrix()
     assert m1.tomatrix().C == m1.conjugate().tomatrix()
     assert m1.tomatrix().H == m1.adjoint().tomatrix()
+
+    raises(ValueError, lambda: permutedims(m1, (0,)))
+    raises(ValueError, lambda: permutedims(m1, (0, 0)))
+    raises(ValueError, lambda: permutedims(m1, (1, 2, 0)))
+
+    # Some tests with random arrays:
+    dims = 6
+    shape = [random.randint(1,5) for i in range(dims)]
+    elems = [random.random() for i in range(tensorproduct(*shape))]
+    ra = Array(elems, shape)
+    perm = list(range(dims))
+    # Randomize the permutation:
+    random.shuffle(perm)
+    # Test inverse permutation:
+    assert permutedims(permutedims(ra, perm), _af_invert(perm)) == ra
+    # Test that permuted shape corresponds to action by `Permutation`:
+    assert permutedims(ra, perm).shape == tuple(Permutation(perm)(shape))
 
     z = NDimArray.zeros(4,5,6,7)
 


### PR DESCRIPTION
Declared as a private function.

First commit is based on the logic of _numpy.transpose( )_

The transpose of 1-rank and 2-rank arrays are straightforward (for 1-rank it's the identity, for 2-rank it's the matrix transpose). The generalization to higher rank is somewhat ambiguous. 

Here are the solutions adopted by other programs/libraries:
- Mathematica: [Transpose](https://reference.wolfram.com/language/ref/Transpose.html) flips the first two indices: `A[a, b, c, ... ] ===> A[b, a, c, ... ]`. Optional permutation argument for generalization (images representation). 
- _numpy_: [transpose](http://docs.scipy.org/doc/numpy-1.10.1/reference/generated/numpy.transpose.html) flips all indices: `A[a, b, c, ..., z] ===> A[z, y, ... , b, a]`. Optional permutation argument (images representation). 
- _julia_: only 2-rank arrays can be [transposed](http://docs.julialang.org/en/latest/stdlib/linalg/#Base.transpose), generalization to higher ranks is provided by [permutedims](http://docs.julialang.org/en/latest/stdlib/arrays/#Base.permutedims). Applying the transposition on 1-rank arrays gives surprizingly a 2-rank array (N-dims to (1, N)-dims).

The questions now are:
1. Shall I rename the function to permute indices to _permutedims_?
2. When does it mathematically make sense to speak of _transposition_?
3. Shall the transpose operator raise an exception when applied to _N_-rank arrays with _N>2_? (leave the index permutations to something like _permutedims_?)
4. Shall the transpose operator act on 1-rank arrays? Or shall it be limited to 2-rank arrays only?
