### PR TITLE
Fix `ImmutableMatrix * MatrixSymbol` calculations

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -505,7 +505,11 @@ class MatrixBase(object):
                 raise ShapeError("Matrices size mismatch.")
             if A.cols == 0:
                 return classof(A, B)._new(A.rows, B.cols, lambda i, j: 0)
-            blst = B.T.tolist()
+            try:
+                blst = B.T.tolist()
+            except AttributeError:
+                # If B is a MatrixSymbol, B.T.tolist does not exist
+                return NotImplemented
             alst = A.tolist()
             return classof(A, B)._new(A.rows, B.cols, lambda i, j:
                 reduce(lambda k, l: k + l,

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -49,6 +49,7 @@ def test_matrix_symbol_MM():
     Y = eye(3) + X
     assert Y[1, 1] == 1 + X[1, 1]
 
+
 def test_matrix_symbol_vector_matrix_multiplication():
     A = MM * SV
     B = IM * SV
@@ -57,6 +58,7 @@ def test_matrix_symbol_vector_matrix_multiplication():
     assert B == C
     D = (SV.T * IM.T).T
     assert C == D
+
 
 def test_indexing_interactions():
     assert (a * IM)[1, 1] == 5*a

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -14,6 +14,7 @@ from sympy.matrices.matrices import classof
 from sympy.utilities.pytest import raises
 
 SM = MatrixSymbol('X', 3, 3)
+SV = MatrixSymbol('v', 3, 1)
 MM = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 IM = ImmutableMatrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 meye = eye(3)
@@ -48,6 +49,14 @@ def test_matrix_symbol_MM():
     Y = eye(3) + X
     assert Y[1, 1] == 1 + X[1, 1]
 
+def test_matrix_symbol_vector_matrix_multiplication():
+    A = MM * SV
+    B = IM * SV
+    assert A == B
+    C = (SV.T * MM.T).T
+    assert B == C
+    D = (SV.T * IM.T).T
+    assert C == D
 
 def test_indexing_interactions():
     assert (a * IM)[1, 1] == 5*a


### PR DESCRIPTION
This is a proposal for a fix for bug #11090. The following currently throws an AttributeError:

```
import sympy
v = sympy.MatrixSymbol('v', 2, 1)
Z = sympy.zeros(2, 2)
I = sympy.exp(Z)
I * v
```

This PR does not break tests (`./setup.py test`) that went through before. 

Alternative solutions would be
- to catch the exception and throw another error containing a proper explanation that this isn't supposed to work
- to alter the `_op_priority` of `ImmutableMatrix`es or `MatrixSymbol`s such that `MatrixSymbol.__rmul__` is preferred.
