### PR TITLE
use builtin Fractions to help with Rational and igcd

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -155,34 +155,31 @@ def igcd(*args):
     5
 
     """
-    a = 0
-    args = list(args)
-    while args:
-        a = args.pop()
-        if a == 0:
-            continue
-        break
-    if a not in (0, 1):
-        a = abs(as_int(a))
-        while args:
-            b = args.pop()
-            if b == 0:
-                continue
-            if b == 1:
-                a = 1
-                break
-            b = abs(as_int(b))
-            t = a, b
+    a = abs(as_int(args[0])) if args else 0
+    k = 1
+    if a != 1:
+        while k < len(args):
+            b = args[k]
+            k += 1
             try:
-                a = _gcdcache[t]
+                a = _gcdcache[(a, b)]
             except KeyError:
+                b = as_int(b)
+                if not b:
+                    continue
+                if b == 1:
+                    a = 1
+                    break
+                if b < 0:
+                    b = -b
+                t = a, b
                 while b:
                     a, b = b, a % b
-                _gcdcache[t] = a
-                if a == 1:
-                    break
-    test_others = [as_int(arg) for arg in args]
-    return int(a)  # convert long to int if possible for py 2.7
+                _gcdcache[t] = _gcdcache[t[1], t[0]] = a
+    while k < len(args):
+        ok = as_int(args[k])
+        k += 1
+    return a
 
 
 def ilcm(*args):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -155,8 +155,15 @@ def igcd(*args):
     5
 
     """
-    a = abs(as_int(args[0])) if args else 0
-    k = 1
+    if len(args) < 2:
+        raise TypeError(
+            'igcd() takes at least 2 arguments (%s given)' % len(args))
+    if 1 in args:
+        a = 1
+        k = 0
+    else:
+        a = abs(as_int(args[0]))
+        k = 1
     if a != 1:
         while k < len(args):
             b = args[k]
@@ -197,6 +204,9 @@ def ilcm(*args):
     30
 
     """
+    if len(args) < 2:
+        raise TypeError(
+            'ilcm() takes at least 2 arguments (%s given)' % len(args))
     if 0 in args:
         return 0
     a = args[0]

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -184,6 +184,7 @@ def test_divmod():
 
 
 def test_igcd():
+    assert igcd() == 0
     assert igcd(0, 0) == 0
     assert igcd(0, 1) == 1
     assert igcd(1, 0) == 1
@@ -205,6 +206,9 @@ def test_igcd():
     assert igcd(*[10, 20, 30]) == 10
     raises(ValueError, lambda: igcd(45.1, 30))
     raises(ValueError, lambda: igcd(45, 30.1))
+    raises(ValueError, lambda: igcd(0, None))
+    raises(ValueError, lambda: igcd(1, 2, None))
+    raises(ValueError, lambda: igcd(None, 1, 2))
 
 
 def test_ilcm():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -8,9 +8,13 @@ from sympy.core.power import integer_nthroot
 from sympy.core.logic import fuzzy_not
 from sympy.core.numbers import (igcd, ilcm, igcdex, seterr, _intcache,
     mpf_norm, comp, mod_inverse)
-from mpmath import mpf
+from sympy.utilities.iterables import permutations
 from sympy.utilities.pytest import XFAIL, raises
+
+from mpmath import mpf
 import mpmath
+
+
 
 t = Symbol('t', real=False)
 
@@ -185,6 +189,7 @@ def test_divmod():
 
 def test_igcd():
     assert igcd() == 0
+    assert igcd(-2) == 2
     assert igcd(0, 0) == 0
     assert igcd(0, 1) == 1
     assert igcd(1, 0) == 1
@@ -204,11 +209,11 @@ def test_igcd():
     assert igcd(-7, 3) == 1
     assert igcd(-7, -3) == 1
     assert igcd(*[10, 20, 30]) == 10
-    raises(ValueError, lambda: igcd(45.1, 30))
-    raises(ValueError, lambda: igcd(45, 30.1))
     raises(ValueError, lambda: igcd(0, None))
-    raises(ValueError, lambda: igcd(1, 2, None))
-    raises(ValueError, lambda: igcd(None, 1, 2))
+    for args in permutations((45.1, 1, 30)):
+        raises(ValueError, lambda: igcd(*args))
+    for args in permutations((1, 2, None)):
+        raises(ValueError, lambda: igcd(*args))
 
 
 def test_ilcm():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -188,8 +188,6 @@ def test_divmod():
 
 
 def test_igcd():
-    assert igcd() == 0
-    assert igcd(-2) == 2
     assert igcd(0, 0) == 0
     assert igcd(0, 1) == 1
     assert igcd(1, 0) == 1
@@ -209,7 +207,10 @@ def test_igcd():
     assert igcd(-7, 3) == 1
     assert igcd(-7, -3) == 1
     assert igcd(*[10, 20, 30]) == 10
+    raises(TypeError, lambda: igcd())
+    raises(TypeError, lambda: igcd(2))
     raises(ValueError, lambda: igcd(0, None))
+    raises(ValueError, lambda: igcd(1, 2.2))
     for args in permutations((45.1, 1, 30)):
         raises(ValueError, lambda: igcd(*args))
     for args in permutations((1, 2, None)):

--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -1800,13 +1800,13 @@ def _diop_ternary_quadratic(_var, coeff):
             _coeff[x*y] = 0
             _coeff[x*z] = 0
 
-            X_0, y_0, z_0 = _diop_ternary_quadratic(var, _coeff)
+            x_0, y_0, z_0 = _diop_ternary_quadratic(var, _coeff)
 
-            if X_0 is None:
+            if x_0 is None:
                 return (None, None, None)
 
             p, q = _rational_pq(B*y_0 + C*z_0, 2*A)
-            x_0, y_0, z_0 = X_0*q - p, y_0*q, z_0*q
+            x_0, y_0, z_0 = x_0*q - p, y_0*q, z_0*q
 
         elif coeff[z*y] != 0:
             if coeff[y**2] == 0:


### PR DESCRIPTION
closes #11081 
closes #11089
- `igcd` now uses fractions.gcd to do the computation; caching is still in place. Also, a check that _all_ args be ints will catch cases where a gcd=1 might occur before bad input is encountered.
- the `Fraction` object is used to do handle some parsing of `Rational` input and to compute the limited denominator. I wonder if it might be better to use `Fraction` as the underlying representation and then update methods like `Rational.p` and `Rational.args` to return the correct args of the `Fraction`. Any thoughts would be welcome.
- [x] clean up history
