### PR TITLE
Proper evalf of Min/Max

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -454,7 +454,7 @@ class MinMaxBase(Expr, LatticeOp):
         return Add(*l)
 
     def evalf(self, prec=None, **options):
-        return self.func(*[a.evalf(prec, options) for a in self.args])
+        return self.func(*[a.evalf(prec, **options) for a in self.args])
     n = evalf
 
     _eval_is_algebraic = lambda s: _torf(i.is_algebraic for i in s.args)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -351,3 +351,21 @@ def test_rewrite_MaxMin_as_Heaviside():
         x*Heaviside(-2*x)*Heaviside(-x - 2) - \
         x*Heaviside(2*x)*Heaviside(x - 2) \
         - 2*Heaviside(-x + 2)*Heaviside(x + 2)
+
+
+def test_issue_11099():
+    from sympy.abc import x, y
+    # some fixed value tests
+    fixed_test_data = {x: -2, y: 3}
+    assert Min(x, y).evalf(subs=fixed_test_data) == \
+        Min(x, y).subs(fixed_test_data).evalf()
+    assert Max(x, y).evalf(subs=fixed_test_data) == \
+        Max(x, y).subs(fixed_test_data).evalf()
+    # randomly generate some test data
+    from random import randint
+    for i in range(20):
+        random_test_data = {x: randint(-100, 100), y: randint(-100, 100)}
+        assert Min(x, y).evalf(subs=random_test_data) == \
+            Min(x, y).subs(random_test_data).evalf()
+        assert Max(x, y).evalf(subs=random_test_data) == \
+            Max(x, y).subs(random_test_data).evalf()


### PR DESCRIPTION
This fixes issue #11099, by passing options as keyword arguments when evaluating the args of Min/Max.
