### PR TITLE
Physics documentation

### DIFF
--- a/doc/src/modules/physics/mechanics/advanced.rst
+++ b/doc/src/modules/physics/mechanics/advanced.rst
@@ -49,12 +49,6 @@ measure numbers, and have unsorted output from the ``mprint``, ``mpprint``, and
 those functions, as the sorting can increase printing time from seconds to
 minutes.
 
-Differentiating
----------------
-Differentiation of very large expressions can take some time in SymPy; it is
-possible for large expressions to take minutes for the derivative to be
-evaluated. This will most commonly come up in linearization.
-
 Substitution
 ------------
 There are two common issues with substitution in mechanics:

--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -21,7 +21,7 @@ Particle
 
 Particles are created with the class ``Particle`` in :mod:`mechanics`.
 A ``Particle`` object has an associated point and an associated mass which are
-the only two attributes of the object.::
+the only two attributes of the object.
 
   >>> from sympy.physics.mechanics import Particle, Point
   >>> from sympy import Symbol
@@ -45,7 +45,7 @@ Rigid Body
 
 Rigid bodies are created in a similar fashion as particles. The ``RigidBody``
 class generates objects with four attributes: mass, center of mass, a reference
-frame, and an inertia tuple::
+frame, and an inertia tuple
 
   >>> from sympy import Symbol
   >>> from sympy.physics.mechanics import ReferenceFrame, Point, RigidBody
@@ -219,7 +219,7 @@ The following example shows how to use the momenta functions in
 :mod:`mechanics`.
 
 One begins by creating the requisite symbols to describe the system. Then
-the reference frame is created and the kinematics are done. ::
+the reference frame is created and the kinematics are done.
 
   >> from sympy import symbols
   >> from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame
@@ -238,14 +238,14 @@ the reference frame is created and the kinematics are done. ::
   >> P.v2pt_theory(O, N, a)
 
 Finally, the bodies that make up the system are created. In this case the
-system consists of a particle Pa and a RigidBody A. ::
+system consists of a particle Pa and a RigidBody A.
 
   >> Pa = Particle('Pa', P, m)
   >> I = outer(N.z, N.z)
   >> A = RigidBody('A', Ac, a, M, (I, Ac))
 
 Then one can either choose to evaluate the the momenta of individual components
-of the system or of the entire system itself. ::
+of the system or of the entire system itself.
 
   >> linear_momentum(N,A)
   M*l1*q1d*N.y
@@ -321,7 +321,7 @@ The following example shows how to use the energy functions in
 :mod:`mechanics`.
 
 As was discussed above in the momenta functions, one first creates the system
-by going through an identical procedure. ::
+by going through an identical procedure.
 
   >> from sympy import symbols
   >> from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, outer
@@ -344,7 +344,7 @@ by going through an identical procedure. ::
   >> A = RigidBody('A', Ac, a, M, (I, Ac))
 
 The user can then determine the kinetic energy of any number of entities of the
-system: ::
+system:
 
   >> kinetic_energy(N, Pa)
   2*l1**2*m*q1d**2
@@ -359,14 +359,14 @@ limited to determining just inertial kinetic energy.
 For potential energies, the user must first specify the potential energy of
 every entity of the system using the :mod:`potential_energy` property. The
 potential energy of any number of entities comprising the system can then be
-determined: ::
+determined:
 
   >> Pa.potential_energy = m * g * h
   >> A.potential_energy = M * g * H
   >> potential_energy(A, Pa)
   H*M*g + g*h*m
 
-One can also determine the Lagrangian for this system: ::
+One can also determine the Lagrangian for this system:
 
   >> Lagrangian(Pa, A)
   -H*M*g + M*l1**2*q1d**2/2 - g*h*m + 2*l1**2*m*q1d**2 + q1d**2/2

--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -21,7 +21,7 @@ Particle
 
 Particles are created with the class ``Particle`` in :mod:`mechanics`.
 A ``Particle`` object has an associated point and an associated mass which are
-the only two attributes of the object.
+the only two attributes of the object.::
 
   >>> from sympy.physics.mechanics import Particle, Point
   >>> from sympy import Symbol
@@ -45,7 +45,7 @@ Rigid Body
 
 Rigid bodies are created in a similar fashion as particles. The ``RigidBody``
 class generates objects with four attributes: mass, center of mass, a reference
-frame, and an inertia tuple
+frame, and an inertia tuple::
 
   >>> from sympy import Symbol
   >>> from sympy.physics.mechanics import ReferenceFrame, Point, RigidBody
@@ -219,7 +219,7 @@ The following example shows how to use the momenta functions in
 :mod:`mechanics`.
 
 One begins by creating the requisite symbols to describe the system. Then
-the reference frame is created and the kinematics are done.
+the reference frame is created and the kinematics are done. ::
 
   >> from sympy import symbols
   >> from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame
@@ -238,14 +238,14 @@ the reference frame is created and the kinematics are done.
   >> P.v2pt_theory(O, N, a)
 
 Finally, the bodies that make up the system are created. In this case the
-system consists of a particle Pa and a RigidBody A.
+system consists of a particle Pa and a RigidBody A. ::
 
   >> Pa = Particle('Pa', P, m)
   >> I = outer(N.z, N.z)
   >> A = RigidBody('A', Ac, a, M, (I, Ac))
 
 Then one can either choose to evaluate the the momenta of individual components
-of the system or of the entire system itself.
+of the system or of the entire system itself. ::
 
   >> linear_momentum(N,A)
   M*l1*q1d*N.y
@@ -321,7 +321,7 @@ The following example shows how to use the energy functions in
 :mod:`mechanics`.
 
 As was discussed above in the momenta functions, one first creates the system
-by going through an identical procedure.
+by going through an identical procedure. ::
 
   >> from sympy import symbols
   >> from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, outer
@@ -344,7 +344,7 @@ by going through an identical procedure.
   >> A = RigidBody('A', Ac, a, M, (I, Ac))
 
 The user can then determine the kinetic energy of any number of entities of the
-system:
+system: ::
 
   >> kinetic_energy(N, Pa)
   2*l1**2*m*q1d**2
@@ -359,14 +359,14 @@ limited to determining just inertial kinetic energy.
 For potential energies, the user must first specify the potential energy of
 every entity of the system using the :mod:`potential_energy` property. The
 potential energy of any number of entities comprising the system can then be
-determined:
+determined: ::
 
   >> Pa.potential_energy = m * g * h
   >> A.potential_energy = M * g * H
   >> potential_energy(A, Pa)
   H*M*g + g*h*m
 
-One can also determine the Lagrangian for this system:
+One can also determine the Lagrangian for this system: ::
 
   >> Lagrangian(Pa, A)
   -H*M*g + M*l1**2*q1d**2/2 - g*h*m + 2*l1**2*m*q1d**2 + q1d**2/2

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -624,7 +624,6 @@ class ReferenceFrame(object):
         rot_order : str
             If applicable, the order of a series of rotations.
 
-
         Examples
         ========
 
@@ -634,17 +633,12 @@ class ReferenceFrame(object):
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.x])
 
-
-        .orient() documentation:\n
-        ========================
-
         """
 
         newframe = self.__class__(newname, variables, indices, latexs)
         newframe.orient(self, rot_type, amounts, rot_order)
         return newframe
 
-    orientnew.__doc__ += orient.__doc__
 
     def set_ang_acc(self, otherframe, value):
         """Define the angular acceleration Vector in a ReferenceFrame.

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -437,7 +437,7 @@ class ReferenceFrame(object):
 
         >>> from sympy.physics.vector import ReferenceFrame, Vector
         >>> from sympy import symbols
-        >>> q0, q1, q2, q3, q4 = symbols('q0 q1 q2 q3 q4')
+        >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
         >>> N = ReferenceFrame('N')
         >>> B = ReferenceFrame('B')
 
@@ -605,8 +605,8 @@ class ReferenceFrame(object):
         parent._ang_vel_dict.update({self: -wvec})
         self._var_dict = {}
 
-    def orientnew(self, newname, rot_type, amounts, rot_order='', variables=None,
-                  indices=None, latexs=None):
+    def orientnew(self, newname, rot_type, amounts, rot_order='',
+                  variables=None, indices=None, latexs=None):
         """Creates a new ReferenceFrame oriented with respect to this Frame.
 
         See ReferenceFrame.orient() for acceptable rotation types, amounts,
@@ -629,8 +629,40 @@ class ReferenceFrame(object):
 
         >>> from sympy.physics.vector import ReferenceFrame, Vector
         >>> from sympy import symbols
-        >>> q1 = symbols('q1')
+        >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
         >>> N = ReferenceFrame('N')
+
+        Now we have a choice of how to implement the orientation. First is
+        Body. Body orientation takes this reference frame through three
+        successive simple rotations. Acceptable rotation orders are of length
+        3, expressed in XYZ or 123, and cannot have a rotation about about an
+        axis twice in a row.
+
+        >>> A = N.orientnew('A', 'Body', [q1, q2, q3], '123')
+        >>> A = N.orientnew('A', 'Body', [q1, q2, 0], 'ZXZ')
+        >>> A = N.orientnew('A', 'Body', [0, 0, 0], 'XYX')
+
+        Next is Space. Space is like Body, but the rotations are applied in the
+        opposite order.
+
+        >>> A = N.orientnew('A', 'Space', [q1, q2, q3], '312')
+
+        Next is Quaternion. This orients the new ReferenceFrame with
+        Quaternions, defined as a finite rotation about lambda, a unit vector,
+        by some amount theta.
+        This orientation is described by four parameters:
+        q0 = cos(theta/2)
+        q1 = lambda_x sin(theta/2)
+        q2 = lambda_y sin(theta/2)
+        q3 = lambda_z sin(theta/2)
+        Quaternion does not take in a rotation order.
+
+        >>> A = N.orientnew('A', 'Quaternion', [q0, q1, q2, q3])
+
+        Last is Axis. This is a rotation about an arbitrary, non-time-varying
+        axis by some angle. The axis is supplied as a Vector. This is how
+        simple rotations are defined.
+
         >>> A = N.orientnew('A', 'Axis', [q1, N.x])
 
         """
@@ -638,7 +670,6 @@ class ReferenceFrame(object):
         newframe = self.__class__(newname, variables, indices, latexs)
         newframe.orient(self, rot_type, amounts, rot_order)
         return newframe
-
 
     def set_ang_acc(self, otherframe, value):
         """Define the angular acceleration Vector in a ReferenceFrame.

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -249,10 +249,10 @@ class Point(object):
         Parameters
         ==========
 
-        value : Vector
-            The vector value of this point's acceleration in the frame
         frame : ReferenceFrame
             The frame in which this point's acceleration is defined
+        value : Vector
+            The vector value of this point's acceleration in the frame
 
         Examples
         ========
@@ -278,10 +278,10 @@ class Point(object):
         Parameters
         ==========
 
+        otherpoint : Point
+            The other point which this point's location is defined relative to
         value : Vector
             The vector which defines the location of this point
-        point : Point
-            The other point which this point's location is defined relative to
 
         Examples
         ========
@@ -309,10 +309,10 @@ class Point(object):
         Parameters
         ==========
 
-        value : Vector
-            The vector value of this point's velocity in the frame
         frame : ReferenceFrame
             The frame in which this point's velocity is defined
+        value : Vector
+            The vector value of this point's velocity in the frame
 
         Examples
         ========


### PR DESCRIPTION
Fixed some consistency issues in the documentation of Physics.vector.point. Also included is a bug fix for the documentation of physics.vector.frame.ReferenceFrame. Each of the fixes are explained in more detail in their respective commit messages.
