### PR TITLE
Improve the printing of sympy.physics.vector with divisions

### DIFF
--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -16,6 +16,7 @@ N = ReferenceFrame('N')
 
 v = a ** 2 * N.x + b * N.y + c * sin(alpha) * N.z
 w = alpha * N.x + sin(omega) * N.y + alpha * beta * N.z
+o = a/b * N.x + (c+b)/a * N.y + c**2/b * N.z
 
 y = a ** 2 * (N.x | N.y) + b * (N.y | N.y) + c * sin(alpha) * (N.z | N.y)
 x = alpha * (N.x | N.x) + sin(omega) * (N.y | N.z) + alpha * beta * (N.z | N.x)
@@ -47,7 +48,6 @@ a  n_x + b n_y + c*sin(alpha) n_z\
 a  n_x + b n_y + c⋅sin(α) n_z\
 """)
 
-
     assert ascii_vpretty(v) == expected
     assert unicode_vpretty(v) == uexpected
 
@@ -56,6 +56,23 @@ a  n_x + b n_y + c⋅sin(α) n_z\
 
     assert ascii_vpretty(w) == expected
     assert unicode_vpretty(w) == uexpected
+
+    expected = """\
+                     2
+a       b + c       c
+- n_x + ----- n_y + -- n_z
+b         a         b\
+"""
+    uexpected = u("""\
+                     2
+a       b + c       c
+─ n_x + ───── n_y + ── n_z
+b         a         b\
+""")
+
+    assert ascii_vpretty(o) == expected
+    assert unicode_vpretty(o) == uexpected
+
 
 def test_vector_latex():
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -287,12 +287,12 @@ class Vector(object):
                             else:
                                 pform = vp._print(
                                     ar[i][0][j])
-                            pform = prettyForm(*pform.right(" ", 
+                            pform = prettyForm(*pform.right(" ",
                                                 ar[i][1].pretty_vecs[j]))
                         else:
                             continue
                         pforms.append(pform)
-                
+
                 pform = prettyForm.__add__(*pforms)
                 kwargs["wrap_line"] = kwargs.get("wrap_line")
                 kwargs["num_columns"] = kwargs.get("num_columns")

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -255,10 +255,10 @@ class Vector(object):
     def _pretty(self, printer=None):
         """Pretty Printing method. """
         from sympy.physics.vector.printing import VectorPrettyPrinter
+        from sympy.printing.pretty.stringpict import prettyForm
         e = self
 
         class Fake(object):
-            baseline = 0
 
             def render(self, *args, **kwargs):
                 ar = e.args  # just to shorten things
@@ -266,38 +266,40 @@ class Vector(object):
                     return unicode(0)
                 settings = printer._settings if printer else {}
                 vp = printer if printer else VectorPrettyPrinter(settings)
-                ol = []  # output list, to be concatenated to a string
+                pforms = []  # output list, to be concatenated to a string
                 for i, v in enumerate(ar):
                     for j in 0, 1, 2:
                         # if the coef of the basis vector is 1, we skip the 1
                         if ar[i][0][j] == 1:
-                            ol.append(u" + " + ar[i][1].pretty_vecs[j])
+                            pform = vp._print(ar[i][1].pretty_vecs[j])
                         # if the coef of the basis vector is -1, we skip the 1
                         elif ar[i][0][j] == -1:
-                            ol.append(u" - " + ar[i][1].pretty_vecs[j])
+                            pform = vp._print(ar[i][1].pretty_vecs[j])
+                            pform= prettyForm(*pform.left(" - "))
+                            bin = prettyForm.NEG
+                            pform = prettyForm(binding=bin, *pform)
                         elif ar[i][0][j] != 0:
                             # If the basis vector coeff is not 1 or -1,
                             # we might wrap it in parentheses, for readability.
                             if isinstance(ar[i][0][j], Add):
-                                arg_str = vp._print(
-                                    ar[i][0][j]).parens()[0]
+                                pform = vp._print(
+                                    ar[i][0][j]).parens()
                             else:
-                                arg_str = (vp.doprint(
-                                    ar[i][0][j]))
+                                pform = vp._print(
+                                    ar[i][0][j])
+                            pform = prettyForm(*pform.right(" ", 
+                                                ar[i][1].pretty_vecs[j]))
+                        else:
+                            continue
+                        pforms.append(pform)
+                
+                pform = prettyForm.__add__(*pforms)
+                kwargs["wrap_line"] = kwargs.get("wrap_line")
+                kwargs["num_columns"] = kwargs.get("num_columns")
+                out_str = pform.render(*args, **kwargs)
+                mlines = [line.rstrip() for line in out_str.split("\n")]
+                return "\n".join(mlines)
 
-                            if arg_str[0] == u"-":
-                                arg_str = arg_str[1:]
-                                str_start = u" - "
-                            else:
-                                str_start = u" + "
-                            ol.append(str_start + arg_str + ' ' +
-                                      ar[i][1].pretty_vecs[j])
-                outstr = u"".join(ol)
-                if outstr.startswith(u" + "):
-                    outstr = outstr[3:]
-                elif outstr.startswith(" "):
-                    outstr = outstr[1:]
-                return outstr
         return Fake()
 
     def __ror__(self, other):


### PR DESCRIPTION
Fix the issue #2863 multiple line string handling with prettyForm

Example:

```
In [1]: from sympy import init_printing

In [2]: init_printing()

In [3]: from sympy.abc import a, b, c, d

In [4]: from sympy.physics.vector import ReferenceFrame

In [5]: N=ReferenceFrame("N")

In [6]: v = a/b*N.x + (c+b)/a*N.y + c**2/b*N.z

In [7]: v
Out[7]:
                     2
a       b + c       c
─ n_x + ───── n_y + ── n_z
b         a         b
```
