### PR TITLE
Derivatives of indexed objects

### DIFF
--- a/doc/src/modules/utilities/autowrap.rst
+++ b/doc/src/modules/utilities/autowrap.rst
@@ -13,7 +13,7 @@ routine that calculates a matrix-vector product.
 >>> i = Idx('i', m)
 >>> j = Idx('j', n)
 >>> instruction = Eq(y[i], A[i, j]*x[j]); instruction
-Eq(y[i], x[j]*A[i, j])
+Eq(y[i], A[i, j]*x[j])
 
 Because the code printers treat Indexed objects with repeated indices as a
 summation, the above equality instance will be translated to low-level code for

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -240,10 +240,9 @@ def apply_finite_diff(order, x_list, y_list, x0=S(0)):
     >>> i = Idx('i')
     >>> x_list, y_list = zip(*[(x[i+j], y[i+j]) for j in range(-1,2)])
     >>> apply_finite_diff(1, x_list, y_list, x[i])
-    (-1 + (x[i + 1] - x[i])/(-x[i - 1] + x[i]))*y[i]/(x[i + 1] - x[i]) + \
-(-x[i - 1] + x[i])*y[i + 1]/((-x[i - 1] + x[i + 1])*(x[i + 1] - x[i])) - \
-(x[i + 1] - x[i])*y[i - 1]/((-x[i - 1] + x[i + 1])*(-x[i - 1] + x[i]))
-
+    ((x[i + 1] - x[i])/(-x[i - 1] + x[i]) - 1)*y[i]/(x[i + 1] - x[i]) - \
+(x[i + 1] - x[i])*y[i - 1]/((x[i + 1] - x[i - 1])*(-x[i - 1] + x[i])) + \
+(-x[i - 1] + x[i])*y[i + 1]/((x[i + 1] - x[i - 1])*(x[i + 1] - x[i]))
 
     Notes
     =====

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -27,13 +27,13 @@ def _process_limits(*symbols):
     orientation = 1
     for V in symbols:
         if isinstance(V, Symbol) or getattr(V, '_diff_wrt', False):
-            limits.append(Tuple(V))
-            continue
-        elif isinstance(V, Idx):
-            if V.lower is None or V.upper is None:
-                limits.append(Tuple(V))
+            if isinstance(V, Idx):
+                if V.lower is None or V.upper is None:
+                    limits.append(Tuple(V))
+                else:
+                    limits.append(Tuple(V, V.lower, V.upper))
             else:
-                limits.append(Tuple(V, V.lower, V.upper))
+                limits.append(Tuple(V))
             continue
         elif is_sequence(V, Tuple):
             V = sympify(flatten(V))

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -214,8 +214,6 @@ class Product(ExprWithIntLimits):
             if dif.is_Integer and dif < 0:
                 a, b = b + 1, a - 1
                 f = 1 / f
-            if isinstance(i, Idx):
-                i = i.label
 
             g = self._eval_product(f, (i, a, b))
             if g in (None, S.NaN):

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -236,7 +236,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         # limits
         # XXX remove this test for free_symbols when the default _eval_derivative is in
         if x.is_Indexed:
-            if x.base not in self.free_symbols:
+            from sympy import IndexedBase
+            if x.base not in self.atoms(IndexedBase):
                 return S.Zero
         elif x not in self.free_symbols:
             return S.Zero

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -183,8 +183,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             if dif.is_integer and (dif < 0) == True:
                 a, b = b + 1, a - 1
                 f = -f
-            if isinstance(i, Idx):
-                i = i.label
+            # if isinstance(i, Idx):
+            #     i = i.label
 
             newf = eval_sum(f, (i, a, b))
             if newf is None:
@@ -235,7 +235,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         # don't want to differentiate wrt any free symbol in the upper or lower
         # limits
         # XXX remove this test for free_symbols when the default _eval_derivative is in
-        if x not in self.free_symbols:
+        if x.is_Indexed:
+            if x.base not in self.free_symbols:
+                return S.Zero
+        elif x not in self.free_symbols:
             return S.Zero
 
         # get limits and the function

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -183,8 +183,6 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             if dif.is_integer and (dif < 0) == True:
                 a, b = b + 1, a - 1
                 f = -f
-            # if isinstance(i, Idx):
-            #     i = i.label
 
             newf = eval_sum(f, (i, a, b))
             if newf is None:

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -531,16 +531,18 @@ def test_Sum_doit():
     s = Sum( Sum( Sum(2,(z,1,n+1)), (y,x+1,n)), (x,1,n))
     assert 0 == (s.doit() - n*(n+1)*(n-1)).factor()
 
+    assert Sum(KroneckerDelta(m, n), (m, -oo, oo)).doit() == Piecewise((1, And(-oo < n, n < oo)), (0, True))
+    assert Sum(x*KroneckerDelta(m, n), (m, -oo, oo)).doit() == Piecewise((x, And(-oo < n, n < oo)), (0, True))
     assert Sum(Sum(KroneckerDelta(m, n), (m, 1, 3)), (n, 1, 3)).doit() == 3
     assert Sum(Sum(KroneckerDelta(k, m), (m, 1, 3)), (n, 1, 3)).doit() == \
-        3*Piecewise((1, And(S(1) <= k, k <= 3)), (0, True))
-    assert Sum(f(n)*Sum(KroneckerDelta(m, n), (m, 0, oo)), (n, 1, 3)).doit() == \
-        f(1) + f(2) + f(3)
-    assert Sum(f(n)*Sum(KroneckerDelta(m, n), (m, 0, oo)), (n, 1, oo)).doit() == \
-        Sum(Piecewise((f(n), And(Le(0, n), n < oo)), (0, True)), (n, 1, oo))
+           3 * Piecewise((1, And(S(1) <= k, k <= 3)), (0, True))
+    assert Sum(f(n) * Sum(KroneckerDelta(m, n), (m, 0, oo)), (n, 1, 3)).doit() == \
+           f(1) + f(2) + f(3)
+    assert Sum(f(n) * Sum(KroneckerDelta(m, n), (m, 0, oo)), (n, 1, oo)).doit() == \
+           Sum(Piecewise((f(n), And(Le(0, n), n < oo)), (0, True)), (n, 1, oo))
     l = Symbol('l', integer=True, positive=True)
-    assert Sum(f(l)*Sum(KroneckerDelta(m, l), (m, 0, oo)), (l, 1, oo)).doit() == \
-        Sum(f(l), (l, 1, oo))
+    assert Sum(f(l) * Sum(KroneckerDelta(m, l), (m, 0, oo)), (l, 1, oo)).doit() == \
+           Sum(f(l), (l, 1, oo))
 
     # issue 2597
     nmax = symbols('N', integer=True, positive=True)

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -859,8 +859,8 @@ def test_indexed_idx_sum():
     assert Product(r, (i, 0, 3)).doit() == prod([r.xreplace({i: j}) for j in range(4)])
 
     j = symbols('j', integer=True)
-    assert Sum(r, (i, j, j+2)).doit() == sum([r.xreplace({i: Idx(j+k)}) for k in range(3)])
-    assert Product(r, (i, j, j+2)).doit() == prod([r.xreplace({i: Idx(j+k)}) for k in range(3)])
+    assert Sum(r, (i, j, j+2)).doit() == sum([r.xreplace({i: j+k}) for k in range(3)])
+    assert Product(r, (i, j, j+2)).doit() == prod([r.xreplace({i: j+k}) for k in range(3)])
 
     k = Idx('k', range=(1, 3))
     A = IndexedBase('A')

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -51,6 +51,7 @@ class Basic(with_metaclass(ManagedProperties)):
     is_number = False
     is_Atom = False
     is_Symbol = False
+    is_Indexed = False
     is_Dummy = False
     is_Wild = False
     is_Function = False

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1105,8 +1105,9 @@ class Derivative(Expr):
         # functions and Derivatives as those can be created by intermediate
         # derivatives.
         if evaluate:
+            from sympy import IndexedBase
             symbol_set = set(sc[0].base if sc[0].is_Indexed else sc[0] for sc in variable_count if sc[0].is_Symbol)
-            if symbol_set.difference(expr.free_symbols):
+            if symbol_set.difference(expr.free_symbols).difference(expr.atoms(IndexedBase)):
                 return S.Zero
 
         # We make a generator so as to only generate a variable when necessary.
@@ -1156,15 +1157,7 @@ class Derivative(Expr):
                     expr = expr.xreplace({v: new_v})
                     old_v = v
                     v = new_v
-                if v.is_Indexed and not v.indices[0].is_Dummy:
-                    from sympy import Indexed
-                    idx_v = v.indices
-                    idx_dummy = tuple(Dummy("xi_%i" % i) for i in range(len(v.indices)))
-                    v = Indexed(v.base, *idx_dummy)
-                    obj = expr._eval_derivative(v)
-                    obj = obj.doit().xreplace(dict(zip(idx_dummy, idx_v)))
-                else:
-                    obj = expr._eval_derivative(v)
+                obj = expr._eval_derivative(v)
                 nderivs += 1
                 if not is_symbol:
                     if obj is not None:

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -441,6 +441,10 @@ class KroneckerDelta(Function):
     def _latex_no_arg(printer):
         return r'\delta'
 
+    @property
+    def indices(self):
+        return self.args[0:2]
+
     def _sage_(self):
         import sage.all as sage
         return sage.kronecker_delta(self.args[0]._sage_(), self.args[1]._sage_())

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -247,7 +247,7 @@ def test_ccode_loops_matrix_vector():
         '}\n'
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
-        '      y[i] = x[j]*A[%s] + y[i];\n' % (i*n + j) +\
+        '      y[i] = A[%s]*x[j] + y[i];\n' % (i*n + j) +\
         '   }\n'
         '}'
     )
@@ -287,7 +287,7 @@ def test_ccode_loops_add():
         '}\n'
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
-        '      y[i] = x[j]*A[%s] + y[i];\n' % (i*n + j) +\
+        '      y[i] = A[%s]*x[j] + y[i];\n' % (i*n + j) +\
         '   }\n'
         '}'
     )
@@ -315,7 +315,7 @@ def test_ccode_loops_multiple_contractions():
         '   for (int j=0; j<n; j++){\n'
         '      for (int k=0; k<o; k++){\n'
         '         for (int l=0; l<p; l++){\n'
-        '            y[i] = y[i] + b[%s]*a[%s];\n' % (j*o*p + k*p + l, i*n*o*p + j*o*p + k*p + l) +\
+        '            y[i] = a[%s]*b[%s] + y[i];\n' % (i*n*o*p + j*o*p + k*p + l, j*o*p + k*p + l) +\
         '         }\n'
         '      }\n'
         '   }\n'
@@ -385,14 +385,14 @@ def test_ccode_loops_multiple_terms():
     s2 = (
         'for (int i=0; i<m; i++){\n'
         '   for (int k=0; k<o; k++){\n'
-        '      y[i] = b[k]*a[%s] + y[i];\n' % (i*o + k) +\
+        '      y[i] = a[%s]*b[k] + y[i];\n' % (i*o + k) +\
         '   }\n'
         '}\n'
     )
     s3 = (
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
-        '      y[i] = b[j]*a[%s] + y[i];\n' % (i*n + j) +\
+        '      y[i] = a[%s]*b[j] + y[i];\n' % (i*n + j) +\
         '   }\n'
         '}\n'
     )

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -167,7 +167,7 @@ def test_jscode_loops_matrix_vector():
         '}\n'
         'for (var i=0; i<m; i++){\n'
         '   for (var j=0; j<n; j++){\n'
-        '      y[i] = x[j]*A[n*i + j] + y[i];\n'
+        '      y[i] = A[n*i + j]*x[j] + y[i];\n'
         '   }\n'
         '}'
     )
@@ -207,7 +207,7 @@ def test_jscode_loops_add():
         '}\n'
         'for (var i=0; i<m; i++){\n'
         '   for (var j=0; j<n; j++){\n'
-        '      y[i] = x[j]*A[n*i + j] + y[i];\n'
+        '      y[i] = A[n*i + j]*x[j] + y[i];\n'
         '   }\n'
         '}'
     )
@@ -235,7 +235,7 @@ def test_jscode_loops_multiple_contractions():
         '   for (var j=0; j<n; j++){\n'
         '      for (var k=0; k<o; k++){\n'
         '         for (var l=0; l<p; l++){\n'
-        '            y[i] = y[i] + b[%s]*a[%s];\n' % (j*o*p + k*p + l, i*n*o*p + j*o*p + k*p + l) +\
+        '            y[i] = a[%s]*b[%s] + y[i];\n' % (i*n*o*p + j*o*p + k*p + l, j*o*p + k*p + l) +\
         '         }\n'
         '      }\n'
         '   }\n'
@@ -305,14 +305,14 @@ def test_jscode_loops_multiple_terms():
     s2 = (
         'for (var i=0; i<m; i++){\n'
         '   for (var k=0; k<o; k++){\n'
-        '      y[i] = b[k]*a[%s] + y[i];\n' % (i*o + k) +\
+        '      y[i] = a[%s]*b[k] + y[i];\n' % (i*o + k) +\
         '   }\n'
         '}\n'
     )
     s3 = (
         'for (var i=0; i<m; i++){\n'
         '   for (var j=0; j<n; j++){\n'
-        '      y[i] = b[j]*a[%s] + y[i];\n' % (i*n + j) +\
+        '      y[i] = a[%s]*b[j] + y[i];\n' % (i*n + j) +\
         '   }\n'
         '}\n'
     )

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -235,10 +235,11 @@ def get_indices(expr):
         return inds, {}
     elif expr is None:
         return set(), {}
-    elif expr.is_Atom:
-        return set(), {}
     elif isinstance(expr, Idx):
         return {expr}, {}
+    elif expr.is_Atom:
+        return set(), {}
+
 
     # recurse via specialized functions
     else:

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -336,11 +336,11 @@ def get_contraction_structure(expr):
 
     >>> d = get_contraction_structure(x[i]*(y[i] + A[i, j]*x[j]))
     >>> sorted(d.keys(), key=default_sort_key)
-    [(x[j]*A[i, j] + y[i])*x[i], (i,)]
+    [(A[i, j]*x[j] + y[i])*x[i], (i,)]
     >>> d[(i,)]
-    set([(x[j]*A[i, j] + y[i])*x[i]])
+    set([(A[i, j]*x[j] + y[i])*x[i]])
     >>> d[x[i]*(A[i, j]*x[j] + y[i])]
-    [{None: set([y[i]]), (j,): set([x[j]*A[i, j]])}]
+    [{None: set([y[i]]), (j,): set([A[i, j]*x[j]])}]
 
     Powers with contractions in either base or exponent will also be found as
     keys in the dictionary, mapping to a list of results from recursive calls:

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -107,6 +107,7 @@ matrix element ``M[i, j]`` as in the following diagram::
 
 from __future__ import print_function, division
 
+from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.core import Expr, Tuple, Symbol, sympify, S
 from sympy.core.compatibility import is_sequence, string_types, NotIterable, range
 
@@ -131,7 +132,9 @@ class Indexed(Expr):
 
     """
     is_commutative = True
+    is_Indexed = True
     is_Symbol = True
+    is_Atom = True
 
     def __new__(cls, base, *args, **kw_args):
         from sympy.utilities.misc import filldedent
@@ -159,7 +162,7 @@ class Indexed(Expr):
                 raise IndexException(msg)
             result = S.One
             for index1, index2 in zip(self.indices, wrt.indices):
-                result *= DeltaIndexedBase()[index1, index2]
+                result *= KroneckerDelta(index1, index2)
             return result
         else:
             return S.Zero
@@ -284,6 +287,10 @@ class Indexed(Expr):
         indices = list(map(p.doprint, self.indices))
         return "%s[%s]" % (p.doprint(self.base), ", ".join(indices))
 
+    @property
+    def free_symbols(self):
+        return {self.base}
+
 
 class IndexedBase(Expr, NotIterable):
     """Represent the base or stem of an indexed object
@@ -338,6 +345,7 @@ class IndexedBase(Expr, NotIterable):
     """
     is_commutative = True
     is_Symbol = True
+    is_Atom = True
 
     def __new__(cls, label, shape=None, **kw_args):
         if isinstance(label, string_types):
@@ -482,6 +490,10 @@ class Idx(Expr):
     """
 
     is_integer = True
+    is_finite = True
+    is_Symbol = True
+    is_Atom = True
+    _diff_wrt = True
 
     def __new__(cls, label, range=None, **kw_args):
         from sympy.utilities.misc import filldedent
@@ -584,3 +596,7 @@ class Idx(Expr):
 
     def _sympystr(self, p):
         return p.doprint(self.label)
+
+    @property
+    def free_symbols(self):
+        return {self}

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -287,9 +287,9 @@ class Indexed(Expr):
         indices = list(map(p.doprint, self.indices))
         return "%s[%s]" % (p.doprint(self.base), ", ".join(indices))
 
-    @property
-    def free_symbols(self):
-        return {self.base}
+    # @property
+    # def free_symbols(self):
+    #     return {self.base}
 
 
 class IndexedBase(Expr, NotIterable):
@@ -491,6 +491,7 @@ class Idx(Expr):
 
     is_integer = True
     is_finite = True
+    is_real = True
     is_Symbol = True
     is_Atom = True
     _diff_wrt = True
@@ -530,6 +531,8 @@ class Idx(Expr):
             args = label,
 
         obj = Expr.__new__(cls, *args, **kw_args)
+        obj._assumptions["finite"] = True
+        obj._assumptions["real"] = True
         return obj
 
     @property

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -42,7 +42,7 @@ matrix element ``M[i, j]`` as in the following diagram::
 
     >>> x = IndexedBase('x')
     >>> M[i, j]*x[j]
-    x[j]*M[i, j]
+    M[i, j]*x[j]
 
     If the indexed objects will be converted to component based arrays, e.g.
     with the code printers or the autowrap framework, you also need to provide
@@ -479,13 +479,6 @@ class Idx(Expr):
     (0, 3)
     >>> idx = Idx(i, oo); idx.lower, idx.upper
     (0, oo)
-
-    The label can be a literal integer instead of a string/``Symbol``:
-
-    >>> idx = Idx(2, n); idx.lower, idx.upper
-    (0, n - 1)
-    >>> idx.label
-    2
 
     """
 

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -200,6 +200,8 @@ def test_differentiation():
     from sympy.functions.special.tensor_functions import KroneckerDelta
     i, j, k, l = symbols('i j k l', cls=Idx)
     a = symbols('a')
+    m, n = symbols("m, n", integer=True, finite=True)
+    assert m.is_real
     h, L = symbols('h L', cls=IndexedBase)
     hi, hj = h[i], h[j]
 
@@ -211,18 +213,48 @@ def test_differentiation():
     assert expr.diff(hj) == S(2) * KroneckerDelta(i, j)
     assert expr.diff(hi) == S(2) * KroneckerDelta(i, i)
     assert expr.diff(a) == S.Zero
-    assert Sum(expr, (i, -oo, oo)).diff(hj).doit() == Piecewise((2, And(-oo < j, j < oo)), (0, True))  # S(2) * KroneckerDelta(i, j)
+
     ss = Sum(expr, (i, -oo, oo))
-    assert ss.diff(hi) == Sum(S(2) * KroneckerDelta(i, i), i)
+    print ss.diff(hj)
+
+    assert Sum(expr, (i, -oo, oo)).diff(hj) == Sum(2*KroneckerDelta(i, j), (i, -oo, oo))
+    assert Sum(expr.diff(hj), (i, -oo, oo)) == Sum(2*KroneckerDelta(i, j), (i, -oo, oo))
+    assert Sum(expr, (i, -oo, oo)).diff(hj).doit() == 2
+
+    assert Sum(expr, (i, -oo, oo)).diff(hi) == oo
+    assert Sum(expr.diff(hi), (i, -oo, oo)) == Sum(2, (i, -oo, oo))
+    assert Sum(expr, (i, -oo, oo)).diff(hi).doit() == oo
 
     expr = a * hj * hj / S(2)
     assert expr.diff(hi) == a * h[j] * KroneckerDelta(i, j)
     assert expr.diff(a) == hj * hj / S(2)
     assert expr.diff(a, 2) == S.Zero
-    assert Sum(expr, (i, -oo, oo)).diff(hi).doit() == Piecewise((a*h[j], And(-oo < j, j < oo)), (0, True))  # Sum(a * h[i])
+
+    assert Sum(expr, (i, -oo, oo)).diff(hi) == Sum(a*KroneckerDelta(i, j)*h[j], (i, -oo, oo))
+    assert Sum(expr.diff(hi), (i, -oo, oo)) == Sum(a*KroneckerDelta(i, j)*h[j], (i, -oo, oo))
+    assert Sum(expr, (i, -oo, oo)).diff(hi).doit() == a*h[j]
+
+    assert Sum(expr, (j, -oo, oo)).diff(hi) == Sum(a*KroneckerDelta(i, j)*h[j], (j, -oo, oo))
+    assert Sum(expr.diff(hi), (j, -oo, oo)) == Sum(a*KroneckerDelta(i, j)*h[j], (j, -oo, oo))
+    assert Sum(expr, (j, -oo, oo)).diff(hi).doit() == a*h[i]
 
     expr = a * sin(hj * hj)
-    assert expr.diff(hi) == a * cos(hj * hj) * S(2) * hj * KroneckerDelta(i, j)
+    assert expr.diff(hi) == 2*a*cos(hj * hj) * hj * KroneckerDelta(i, j)
+    assert expr.diff(hj) == 2*a*cos(hj * hj) * hj
 
     expr = a * L[i, j] * h[j]
+    assert expr.diff(hi) == a*L[i, j]*KroneckerDelta(i, j)
+    assert expr.diff(hj) == a*L[i, j]
+    assert expr.diff(L[i, j]) == a*h[j]
+    assert expr.diff(L[k, l]) == a*KroneckerDelta(i, k)*KroneckerDelta(j, l)*h[j]
+    assert expr.diff(L[i, l]) == a*KroneckerDelta(j, l)*h[j]
+
+    assert Sum(expr, (j, -oo, oo)).diff(L[k, l]) == Sum(a * KroneckerDelta(i, k) * KroneckerDelta(j, l) * h[j], (j, -oo, oo))
     assert Sum(expr, (j, -oo, oo)).diff(L[k, l]).doit() == a * KroneckerDelta(i, k) * h[l]
+
+    assert h[m].diff(h[m]) == 1
+    assert h[m].diff(h[n]) == KroneckerDelta(m, n)
+    assert Sum(a*h[m], (m, -oo, oo)).diff(h[n]) == Sum(a*KroneckerDelta(m, n), (m, -oo, oo))
+    assert Sum(a*h[m], (m, -oo, oo)).diff(h[n]).doit() == a
+    assert Sum(a*h[m], (n, -oo, oo)).diff(h[n]) == Sum(a*KroneckerDelta(m, n), (n, -oo, oo))
+    assert Sum(a*h[m], (m, -oo, oo)).diff(h[m]) == oo*a

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -214,9 +214,6 @@ def test_differentiation():
     assert expr.diff(hi) == S(2) * KroneckerDelta(i, i)
     assert expr.diff(a) == S.Zero
 
-    ss = Sum(expr, (i, -oo, oo))
-    print ss.diff(hj)
-
     assert Sum(expr, (i, -oo, oo)).diff(hj) == Sum(2*KroneckerDelta(i, j), (i, -oo, oo))
     assert Sum(expr.diff(hj), (i, -oo, oo)) == Sum(2*KroneckerDelta(i, j), (i, -oo, oo))
     assert Sum(expr, (i, -oo, oo)).diff(hj).doit() == 2

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -274,7 +274,7 @@ class Variable(object):
             Controls the precision of floating point constants.
 
         """
-        if not isinstance(name, (Symbol, MatrixSymbol)):
+        if not isinstance(name, (Symbol, MatrixSymbol, Idx)):
             raise TypeError("The first argument must be a sympy symbol.")
         if datatype is None:
             datatype = get_default_datatype(name)
@@ -358,6 +358,7 @@ class ResultBase(object):
 
     __repr__ = __str__
 
+
 class OutputArgument(Argument, ResultBase):
     """OutputArgument are always initialized in the routine."""
 
@@ -404,6 +405,7 @@ class OutputArgument(Argument, ResultBase):
 
     __repr__ = __str__
 
+
 class InOutArgument(Argument, ResultBase):
     """InOutArgument are never initialized in the routine."""
 
@@ -420,6 +422,7 @@ class InOutArgument(Argument, ResultBase):
             self.result_var)
 
     __repr__ = __str__
+
 
 class Result(Variable, ResultBase):
     """An expression for a return value.
@@ -541,6 +544,9 @@ class CodeGen(object):
                 if isinstance(out_arg, Indexed):
                     dims = tuple([ (S.Zero, dim - 1) for dim in out_arg.shape])
                     symbol = out_arg.base.label
+                elif isinstance(out_arg, Idx):
+                    dims = []
+                    symbol = out_arg
                 elif isinstance(out_arg, Symbol):
                     dims = []
                     symbol = out_arg
@@ -574,7 +580,7 @@ class CodeGen(object):
         # setup input argument list
         array_symbols = {}
         for array in expressions.atoms(Indexed):
-            array_symbols[array.base.label] = array
+            array_symbols[array.base] = array
         for array in expressions.atoms(MatrixSymbol):
             array_symbols[array] = array
 

--- a/sympy/utilities/tests/test_codegen_julia.py
+++ b/sympy/utilities/tests/test_codegen_julia.py
@@ -528,7 +528,7 @@ def test_jl_tensor_loops_multiple_contractions():
         '        for j = 1:n\n'
         '            for k = 1:o\n'
         '                for l = 1:p\n'
-        '                    y[i] = y[i] + B[j,k,l].*A[i,j,k,l]\n'
+        '                    y[i] = A[i,j,k,l].*B[j,k,l] + y[i]\n'
         '                end\n'
         '            end\n'
         '        end\n'

--- a/sympy/utilities/tests/test_codegen_octave.py
+++ b/sympy/utilities/tests/test_codegen_octave.py
@@ -502,7 +502,7 @@ def test_m_tensor_loops_multiple_contractions():
         '    for j = 1:n\n'
         '      for k = 1:o\n'
         '        for l = 1:p\n'
-        '          y(i) = y(i) + B(j, k, l).*A(i, j, k, l);\n'
+        '          y(i) = A(i, j, k, l).*B(j, k, l) + y(i);\n'
         '        end\n'
         '      end\n'
         '    end\n'


### PR DESCRIPTION
This PR provides derivatives for indexed objects.

It is roughly based on https://github.com/sympy/sympy/pull/9314 , except that 
- here the standard _KroneckerDelta_ is used (no secondary class to represent the Kronecker delta). 
- no implicit summation of repeated indices is assumed for the derivative, the code printer instead behaves exactly the same. That is, **no API breaks**.
- Derivatives of _Sum_ objects of indexed symbols are supported.
