### PR TITLE
Remove old unicode compatibility

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -17,7 +17,6 @@ String and Unicode compatible changes:
       compatible function
     * `unichr()` removed in Python 3, import `unichr` for Python 2/3 compatible
       function
-    * Use `u_decode()` to decode utf-8 formatted unicode strings
     * `string_types` gives str in Python 3, unicode and str in Python 2,
       equivalent to basestring
 
@@ -72,8 +71,6 @@ if PY3:
     # String / unicode compatibility
     unicode = str
     unichr = chr
-    def u_decode(x):
-        return x
 
     Iterator = object
 
@@ -102,8 +99,6 @@ else:
     # String / unicode compatibility
     unicode = unicode
     unichr = unichr
-    def u_decode(x):
-        return x.decode('utf-8')
 
     class Iterator(object):
         def next(self):

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -38,12 +38,12 @@ Renamed function attributes:
 
 Moved modules:
     * `reduce()`
-    * `StringIO()`
-    * `cStringIO()` (same as `StingIO()` in Python 3)
+    * `cStringIO()` (uses `StringIO.cStringIO` in Python 2, same as `StingIO()`
+      in Python 3, use `io.StringIO` for normal `StringIO`)
     * Python 2 `__builtins__`, access with Python 3 name, `builtins`
 
 Iterator/list changes:
-    * `xrange` removed in Python 3, import `xrange` for Python 2/3 compatible
+    * `xrange` removed in Python 3, import `range` for Python 2/3 compatible
       iterator version of range
 
 exec:

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -17,7 +17,6 @@ String and Unicode compatible changes:
       compatible function
     * `unichr()` removed in Python 3, import `unichr` for Python 2/3 compatible
       function
-    * Use `u()` for escaped unicode sequences (e.g. u'\u2020' -> u('\u2020'))
     * Use `u_decode()` to decode utf-8 formatted unicode strings
     * `string_types` gives str in Python 3, unicode and str in Python 2,
       equivalent to basestring
@@ -73,8 +72,6 @@ if PY3:
     # String / unicode compatibility
     unicode = str
     unichr = chr
-    def u(x):
-        return x
     def u_decode(x):
         return x
 
@@ -105,8 +102,6 @@ else:
     # String / unicode compatibility
     unicode = unicode
     unichr = unichr
-    def u(x):
-        return codecs.unicode_escape_decode(x)[0]
     def u_decode(x):
         return x.decode('utf-8')
 

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet, Integer
 from sympy.core.containers import tuple_wrapper
 from sympy.utilities.pytest import raises
-from sympy.core.compatibility import is_sequence, iterable, u, range
+from sympy.core.compatibility import is_sequence, iterable, range
 
 
 def test_Tuple():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -3,7 +3,7 @@ from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
                    AlgebraicNumber, simplify, sin)
-from sympy.core.compatibility import long, u
+from sympy.core.compatibility import long
 from sympy.core.power import integer_nthroot, isqrt
 from sympy.core.logic import fuzzy_not
 from sympy.core.numbers import (igcd, ilcm, igcdex, seterr, _intcache,

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -2,7 +2,6 @@ from sympy import (Symbol, Wild, GreaterThan, LessThan, StrictGreaterThan,
     StrictLessThan, pi, I, Rational, sympify, symbols, Dummy
 )
 
-from sympy.core.compatibility import u
 from sympy.utilities.pytest import raises
 
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division
 
 from sympy.core import S, Add, Mul, sympify, Symbol, Dummy
-from sympy.core.compatibility import u
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import (Function, Derivative, ArgumentIndexError,
     AppliedUndef)

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -3,6 +3,7 @@
 from __future__ import print_function, division
 
 from distutils.version import LooseVersion as V
+from io import StringIO
 
 from sympy.external import import_module
 from sympy.interactive.printing import init_printing
@@ -111,7 +112,6 @@ def int_to_Integer(s):
     1/2
     """
     from tokenize import generate_tokens, untokenize, NUMBER, NAME, OP
-    from sympy.core.compatibility import StringIO
 
     def _is_int(num):
         """

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -1,6 +1,5 @@
 """Tests that the IPython printing module is properly loaded. """
 
-from sympy.core.compatibility import u
 from sympy.interactive.session import init_ipython_session
 from sympy.external import import_module
 from sympy.utilities.pytest import raises

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -12,7 +12,7 @@ from sympy.matrices import (
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix)
-from sympy.core.compatibility import long, iterable, u, range
+from sympy.core.compatibility import long, iterable, range
 from sympy.utilities.iterables import flatten, capture
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
 from sympy.solvers import solve

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -9,11 +9,12 @@ from .sympy_tokenize import \
 from keyword import iskeyword
 
 import ast
+import io
 import re
 import unicodedata
 
 import sympy
-from sympy.core.compatibility import exec_, StringIO
+from sympy.core.compatibility import exec_
 from sympy.core.basic import Basic
 
 _re_repeated = re.compile(r"^(\d*)\.(\d*)\[(\d+)\]$")
@@ -787,7 +788,7 @@ def stringify_expr(s, local_dict, global_dict, transformations):
     """
 
     tokens = []
-    input_code = StringIO(s.strip())
+    input_code = io.StringIO(s.strip())
     for toknum, tokval, _, _, _ in generate_tokens(input_code.readline):
         tokens.append((toknum, tokval))
 

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -3,7 +3,6 @@
 from __future__ import print_function, division
 
 from sympy import S, Expr, Mul, Integer
-from sympy.core.compatibility import u
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.operator import Operator

--- a/sympy/physics/quantum/boson.py
+++ b/sympy/physics/quantum/boson.py
@@ -1,6 +1,5 @@
 """Bosonic quantum operators."""
 
-from sympy.core.compatibility import u
 from sympy import Mul, Integer, exp, sqrt, conjugate
 from sympy.physics.quantum import Operator
 from sympy.physics.quantum import HilbertSpace, FockSpace, Ket, Bra, IdentityOperator

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -17,7 +17,7 @@ Todo:
 from __future__ import print_function, division
 
 from sympy import Mul
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from sympy.external import import_module
 from sympy.physics.quantum.gate import Gate, OneQubitGate, CGate, CGateS
 from sympy.core.core import BasicMeta

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -3,7 +3,6 @@
 from __future__ import print_function, division
 
 from sympy import S, Expr, Mul, Add
-from sympy.core.compatibility import u
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.dagger import Dagger

--- a/sympy/physics/quantum/constants.py
+++ b/sympy/physics/quantum/constants.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from sympy.core.numbers import NumberSymbol
 from sympy.core.singleton import Singleton
-from sympy.core.compatibility import u, with_metaclass
+from sympy.core.compatibility import with_metaclass
 from sympy.printing.pretty.stringpict import prettyForm
 import mpmath.libmp as mlib
 

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -201,7 +201,7 @@ class Density(HermitianOperator):
         return printer._print(r'\rho', *args)
 
     def _print_operator_name_pretty(self, printer, *args):
-        return prettyForm(unichr('\N{GREEK SMALL LETTER RHO}'))
+        return prettyForm(u'\N{GREEK SMALL LETTER RHO}')
 
     def _eval_trace(self, **kwargs):
         indices = kwargs.get('indices', [])

--- a/sympy/physics/quantum/fermion.py
+++ b/sympy/physics/quantum/fermion.py
@@ -1,6 +1,5 @@
 """Fermionic quantum operators."""
 
-from sympy.core.compatibility import u
 from sympy import Integer
 from sympy.physics.quantum import Operator
 from sympy.physics.quantum import HilbertSpace, Ket, Bra

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -20,7 +20,7 @@ import random
 
 from sympy import Add, I, Integer, Mul, Pow, sqrt, Tuple
 from sympy.core.numbers import Number
-from sympy.core.compatibility import is_sequence, u, unicode, range
+from sympy.core.compatibility import is_sequence, unicode, range
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -11,7 +11,7 @@ Todo:
 from __future__ import print_function, division
 
 from sympy import floor, pi, sqrt, sympify, eye
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from sympy.core.numbers import NegativeOne
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qexpr import QuantumError

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -8,7 +8,7 @@ Authors:
 from __future__ import print_function, division
 
 from sympy import Basic, Interval, oo, sympify
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.qexpr import QuantumError
@@ -417,7 +417,7 @@ class TensorProductHilbertSpace(HilbertSpace):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u(' ') + u('\N{N-ARY CIRCLED TIMES OPERATOR}') + u(' ')))
+                    pform = prettyForm(*pform.right(u' \N{N-ARY CIRCLED TIMES OPERATOR} '))
                 else:
                     pform = prettyForm(*pform.right(' x '))
         return pform
@@ -528,7 +528,7 @@ class DirectSumHilbertSpace(HilbertSpace):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u(' ') + u('\N{CIRCLED PLUS}') + u(' ')))
+                    pform = prettyForm(*pform.right(u' \N{CIRCLED PLUS} '))
                 else:
                     pform = prettyForm(*pform.right(' + '))
         return pform

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from sympy import Expr, sympify, Symbol, Matrix
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.core.containers import Tuple
-from sympy.core.compatibility import is_sequence, string_types, u
+from sympy.core.compatibility import is_sequence, string_types
 
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.matrixutils import (

--- a/sympy/physics/quantum/qft.py
+++ b/sympy/physics/quantum/qft.py
@@ -14,7 +14,7 @@ Todo:
 from __future__ import print_function, division
 
 from sympy import Expr, Matrix, exp, I, pi, Integer, Symbol
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from sympy.functions import sqrt
 
 from sympy.physics.quantum.qapply import qapply

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy import sqrt, I, Symbol, Integer, S
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.operator import Operator
 from sympy.physics.quantum.state import Bra, Ket, State

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from sympy import (Add, binomial, cos, exp, Expr, factorial, I, Integer, Mul,
                    pi, Rational, S, sin, simplify, sqrt, Sum, symbols, sympify,
                    Tuple, Dummy)
-from sympy.core.compatibility import u, unicode, range
+from sympy.core.compatibility import unicode, range
 from sympy.matrices import zeros
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.pretty.pretty_symbology import pretty_symbol
@@ -404,7 +404,7 @@ class J2Op(SpinOpBase, HermitianOperator):
 
     def _print_contents_pretty(self, printer, *args):
         a = prettyForm(unicode(self.name))
-        b = prettyForm(u('2'))
+        b = prettyForm(u'2')
         return a**b
 
     def _print_contents_latex(self, printer, *args):
@@ -500,7 +500,7 @@ class Rotation(UnitaryOperator):
 
     def _print_operator_name_pretty(self, printer, *args):
         if printer._use_unicode:
-            return prettyForm(u('\N{SCRIPT CAPITAL R}') + u(' '))
+            return prettyForm(u'\N{SCRIPT CAPITAL R} ')
         else:
             return prettyForm("R ")
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from sympy import (cacheit, conjugate, Expr, Function, integrate, oo, sqrt,
                    Tuple)
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from sympy.printing.pretty.stringpict import stringPict
 from sympy.physics.quantum.qexpr import QExpr, dispatch_method
 

--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy import Expr, Add, Mul, Matrix, Pow, sympify
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from sympy.core.trace import Tr
 from sympy.printing.pretty.stringpict import prettyForm
 
@@ -201,7 +201,7 @@ class TensorProduct(Expr):
             pform = prettyForm(*pform.right(next_pform))
             if i != length - 1:
                 if printer._use_unicode:
-                    pform = prettyForm(*pform.right(u('\N{N-ARY CIRCLED TIMES OPERATOR}') + u(' ')))
+                    pform = prettyForm(*pform.right(u'\N{N-ARY CIRCLED TIMES OPERATOR}' + u' '))
                 else:
                     pform = prettyForm(*pform.right('x' + ' '))
         return pform

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -33,8 +33,6 @@ from sympy.printing import srepr
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.latex import latex
 
-from sympy.core.compatibility import u_decode as u
-
 MutableDenseMatrix = Matrix
 
 ENV = {}
@@ -78,11 +76,11 @@ def test_anticommutator():
 \\    /\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎧ 2  ⎫\n\
 ⎨A ,B⎬\n\
 ⎩    ⎭\
-""")
+"""
     assert pretty(ac_tall) == ascii_str
     assert upretty(ac_tall) == ucode_str
     assert latex(ac_tall) == r'\left\{A^{2},B\right\}'
@@ -102,11 +100,11 @@ C       \n\
  1,2,3,4\
 """
     ucode_str = \
-u("""\
+u"""\
  5,6    \n\
 C       \n\
  1,2,3,4\
-""")
+"""
     assert pretty(cg) == ascii_str
     assert upretty(cg) == ucode_str
     assert latex(cg) == r'C^{5,6}_{1,2,3,4}'
@@ -119,11 +117,11 @@ C       \n\
 \\2  4  6/\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎛1  3  5⎞\n\
 ⎜       ⎟\n\
 ⎝2  4  6⎠\
-""")
+"""
     assert pretty(wigner3j) == ascii_str
     assert upretty(wigner3j) == ucode_str
     assert latex(wigner3j) == \
@@ -137,11 +135,11 @@ u("""\
 \\4  5  6/\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎧1  2  3⎫\n\
 ⎨       ⎬\n\
 ⎩4  5  6⎭\
-""")
+"""
     assert pretty(wigner6j) == ascii_str
     assert upretty(wigner6j) == ucode_str
     assert latex(wigner6j) == \
@@ -157,13 +155,13 @@ u("""\
 \\7  8  9/\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎧1  2  3⎫\n\
 ⎪       ⎪\n\
 ⎨4  5  6⎬\n\
 ⎪       ⎪\n\
 ⎩7  8  9⎭\
-""")
+"""
     assert pretty(wigner9j) == ascii_str
     assert upretty(wigner9j) == ucode_str
     assert latex(wigner9j) == \
@@ -188,10 +186,10 @@ def test_commutator():
 [A ,B]\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎡ 2  ⎤\n\
 ⎣A ,B⎦\
-""")
+"""
     assert pretty(c_tall) == ascii_str
     assert upretty(c_tall) == ucode_str
     assert latex(c_tall) == r'\left[A^{2},B\right]'
@@ -269,10 +267,10 @@ C   /X \\\n\
  3,0\\ 1/\
 """
     ucode_str = \
-u("""\
+u"""\
 C   ⎛X ⎞\n\
  3,0⎝ 1⎠\
-""")
+"""
     assert pretty(g2) == ascii_str
     assert upretty(g2) == ucode_str
     assert latex(g2) == r'C_{3,0}{\left(X_{1}\right)}'
@@ -284,10 +282,10 @@ CNOT   \n\
     1,0\
 """
     ucode_str = \
-u("""\
+u"""\
 CNOT   \n\
     1,0\
-""")
+"""
     assert pretty(g3) == ascii_str
     assert upretty(g3) == ucode_str
     assert latex(g3) == r'CNOT_{1,0}'
@@ -298,10 +296,10 @@ U \n\
  0\
 """
     ucode_str = \
-u("""\
+u"""\
 U \n\
  0\
-""")
+"""
     assert str(g4) == \
 """\
 U((0,),Matrix([\n\
@@ -331,10 +329,10 @@ def test_hilbert():
 C \
 """
     ucode_str = \
-u("""\
+u"""\
  2\n\
 C \
-""")
+"""
     assert pretty(h2) == ascii_str
     assert upretty(h2) == ucode_str
     assert latex(h2) == r'\mathcal{C}^{2}'
@@ -351,10 +349,10 @@ C \
 L \
 """
     ucode_str = \
-u("""\
+u"""\
  2\n\
 L \
-""")
+"""
     assert pretty(h4) == ascii_str
     assert upretty(h4) == ucode_str
     assert latex(h4) == r'{\mathcal{L}^2}\left( \left[0, \infty\right) \right)'
@@ -366,10 +364,10 @@ L \
 H + C \
 """
     ucode_str = \
-u("""\
+u"""\
      2\n\
 H ⊕ C \
-""")
+"""
     assert pretty(h1 + h2) == ascii_str
     assert upretty(h1 + h2) == ucode_str
     assert latex(h1 + h2)
@@ -381,10 +379,10 @@ H ⊕ C \
 H x C \
 """
     ucode_str = \
-u("""\
+u"""\
      2\n\
 H ⨂ C \
-""")
+"""
     assert pretty(h1*h2) == ascii_str
     assert upretty(h1*h2) == ucode_str
     assert latex(h1*h2)
@@ -397,10 +395,10 @@ H ⨂ C \
 H  \
 """
     ucode_str = \
-u("""\
+u"""\
  ⨂2\n\
 H  \
-""")
+"""
     assert pretty(h1**2) == ascii_str
     assert upretty(h1**2) == ucode_str
     assert latex(h1**2) == r'{\mathcal{H}}^{\otimes 2}'
@@ -448,12 +446,12 @@ def test_innerproduct():
  \\2|2/ \
 """
     ucode_str = \
-u("""\
+u"""\
  ╱ │ ╲ \n\
 ╱ x│x ╲\n\
 ╲ ─│─ ╱\n\
  ╲2│2╱ \
-""")
+"""
     assert pretty(ip_tall1) == ascii_str
     assert upretty(ip_tall1) == ucode_str
     assert latex(ip_tall1) == \
@@ -468,12 +466,12 @@ u("""\
  \\ |2/ \
 """
     ucode_str = \
-u("""\
+u"""\
  ╱ │ ╲ \n\
 ╱  │x ╲\n\
 ╲ x│─ ╱\n\
  ╲ │2╱ \
-""")
+"""
     assert pretty(ip_tall2) == ascii_str
     assert upretty(ip_tall2) == ucode_str
     assert latex(ip_tall2) == \
@@ -489,12 +487,12 @@ u("""\
  \\2| / \
 """
     ucode_str = \
-u("""\
+u"""\
  ╱ │ ╲ \n\
 ╱ x│  ╲\n\
 ╲ ─│x ╱\n\
  ╲2│ ╱ \
-""")
+"""
     assert pretty(ip_tall3) == ascii_str
     assert upretty(ip_tall3) == ucode_str
     assert latex(ip_tall3) == \
@@ -523,10 +521,10 @@ def test_operator():
 A  \
 """
     ucode_str = \
-u("""\
+u"""\
  -1\n\
 A  \
-""")
+"""
     assert pretty(inv) == ascii_str
     assert upretty(inv) == ucode_str
     assert latex(inv) == r'A^{-1}'
@@ -539,11 +537,11 @@ DifferentialOperator|--(f(x)),f(x)|\n\
                     \dx           /\
 """
     ucode_str = \
-u("""\
+u"""\
                     ⎛d            ⎞\n\
 DifferentialOperator⎜──(f(x)),f(x)⎟\n\
                     ⎝dx           ⎠\
-""")
+"""
     assert pretty(d) == ascii_str
     assert upretty(d) == ucode_str
     assert latex(d) == \
@@ -603,10 +601,10 @@ L \n\
  z\
 """
     ucode_str = \
-u("""\
+u"""\
 L \n\
  z\
-""")
+"""
     assert pretty(lz) == ascii_str
     assert upretty(lz) == ucode_str
     assert latex(lz) == 'L_z'
@@ -618,10 +616,10 @@ L \n\
 J \
 """
     ucode_str = \
-u("""\
+u"""\
  2\n\
 J \
-""")
+"""
     assert pretty(J2) == ascii_str
     assert upretty(J2) == ucode_str
     assert latex(J2) == r'J^2'
@@ -633,10 +631,10 @@ J \n\
  z\
 """
     ucode_str = \
-u("""\
+u"""\
 J \n\
  z\
-""")
+"""
     assert pretty(Jz) == ascii_str
     assert upretty(Jz) == ucode_str
     assert latex(Jz) == 'J_z'
@@ -688,11 +686,11 @@ D   (4,5,6)\n\
  2,3       \
 """
     ucode_str = \
-u("""\
+u"""\
  1         \n\
 D   (4,5,6)\n\
  2,3       \
-""")
+"""
     assert pretty(bigd) == ascii_str
     assert upretty(bigd) == ucode_str
     assert latex(bigd) == r'D^{1}_{2,3}\left(4,5,6\right)'
@@ -705,11 +703,11 @@ d   (4)\n\
  2,3   \
 """
     ucode_str = \
-u("""\
+u"""\
  1     \n\
 d   (4)\n\
  2,3   \
-""")
+"""
     assert pretty(smalld) == ascii_str
     assert upretty(smalld) == ucode_str
     assert latex(smalld) == r'd^{1}_{2,3}\left(4\right)'
@@ -743,12 +741,12 @@ def test_state():
  \\2|\
 """
     ucode_str = \
-u("""\
+u"""\
  ╱ │\n\
 ╱ x│\n\
 ╲ ─│\n\
  ╲2│\
-""")
+"""
     assert pretty(bra_tall) == ascii_str
     assert upretty(bra_tall) == ucode_str
     assert latex(bra_tall) == r'{\left\langle \frac{x}{2}\right|}'
@@ -762,12 +760,12 @@ u("""\
 |2/ \
 """
     ucode_str = \
-u("""\
+u"""\
 │ ╲ \n\
 │x ╲\n\
 │─ ╱\n\
 │2╱ \
-""")
+"""
     assert pretty(ket_tall) == ascii_str
     assert upretty(ket_tall) == ucode_str
     assert latex(ket_tall) == r'{\left|\frac{x}{2}\right\rangle }'
@@ -812,13 +810,13 @@ def test_big_expr():
 \\ z/             \\\\                    \dx           / /         /                                 \
 """
     ucode_str = \
-u("""\
+u"""\
                  ⎧                                      3        ⎫                                 \n\
                  ⎪⎛                                   †⎞         ⎪                                 \n\
     2  ⎛ †    †⎞ ⎨⎜                    ⎛d            ⎞ ⎟   †    †⎬                                 \n\
 ⎛J ⎞ ⨂ ⎝A  + B ⎠⋅⎪⎜DifferentialOperator⎜──(f(x)),f(x)⎟ ⎟ ,A  + B ⎪⋅(⟨1,0❘ + ⟨1,1❘)⋅(❘0,0⟩ + ❘1,-1⟩)\n\
 ⎝ z⎠             ⎩⎝                    ⎝dx           ⎠ ⎠         ⎭                                 \
-""")
+"""
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == \
@@ -832,11 +830,11 @@ u("""\
 [\\ z/       ] \\         / [    z]\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎡    2      ⎤ ⎧ -2  †  †⎫ ⎡ 2   ⎤\n\
 ⎢⎛J ⎞ ,A + B⎥⋅⎨E  ,D ⋅C ⎬⋅⎢J ,J ⎥\n\
 ⎣⎝ z⎠       ⎦ ⎩         ⎭ ⎣    z⎦\
-""")
+"""
     assert pretty(e2) == ascii_str
     assert upretty(e2) == ucode_str
     assert latex(e2) == \
@@ -852,12 +850,12 @@ u("""\
 \\2  4  6/                                                                                             \
 """
     ucode_str = \
-u("""\
+u"""\
           ⎡ †          ⎤  ⎛   2     ⎞                                                                 \n\
 ⎛1  3  5⎞⋅⎣B  + A,C + D⎦⨂ ⎜- J  + J ⎟⋅❘1,0⟩⟨1,1❘⋅(❘1,0,j₁=1,j₂=1⟩ + ❘1,1,j₁=1,j₂=1⟩)⨂ ❘1,-1,j₁=1,j₂=1⟩\n\
 ⎜       ⎟                 ⎝        z⎠                                                                 \n\
 ⎝2  4  6⎠                                                                                             \
-""")
+"""
     assert pretty(e3) == ascii_str
     assert upretty(e3) == ucode_str
     assert latex(e3) == \
@@ -870,10 +868,10 @@ u("""\
 \\\\C  x C / + F  / x \L  + H/\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎛⎛ 1    2⎞    ⨂2⎞   ⎛ 2    ⎞\n\
 ⎝⎝C  ⨂ C ⎠ ⊕ F  ⎠ ⨂ ⎝L  ⊕ H⎠\
-""")
+"""
     assert pretty(e4) == ascii_str
     assert upretty(e4) == ucode_str
     assert latex(e4) == \

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -216,10 +216,10 @@ def test_dagger():
 x \
 """
     ucode_str = \
-u("""\
+u"""\
  †\n\
 x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     assert latex(expr) == r'x^{\dag}'
@@ -254,10 +254,10 @@ def test_gate():
  2        \
 """
     ucode_str = \
-u("""\
+u"""\
 1 ⋅❘10101⟩\n\
  2        \
-""")
+"""
     assert pretty(g1*q) == ascii_str
     assert upretty(g1*q) == ucode_str
     assert latex(g1*q) == r'1_{2} {\left|10101\right\rangle }'

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,5 +1,5 @@
 from sympy import sympify, Add, ImmutableMatrix as Matrix
-from sympy.core.compatibility import u, unicode
+from sympy.core.compatibility import unicode
 from .printing import (VectorLatexPrinter, VectorPrettyPrinter,
                        VectorStrPrinter)
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -1,6 +1,6 @@
 from sympy import (diff, trigsimp, expand, sin, cos, solve, Symbol, sympify,
                    eye, symbols, Dummy, ImmutableMatrix as Matrix)
-from sympy.core.compatibility import string_types, u, range
+from sympy.core.compatibility import string_types, range
 from sympy.physics.vector.vector import Vector, _check_vector
 
 __all__ = ['CoordinateSym', 'ReferenceFrame']

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from sympy import Derivative
-from sympy.core.compatibility import u
 from sympy.core.function import UndefinedFunction
 from sympy.core.symbol import Symbol
 from sympy.interactive.printing import init_printing

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from sympy import symbols, sin, cos, sqrt, Function
-from sympy.core.compatibility import u_decode as u
 from sympy.physics.vector import ReferenceFrame, dynamicsymbols
 from sympy.physics.vector.printing import (VectorLatexPrinter, vpprint)
 
@@ -43,16 +42,16 @@ def test_vector_pretty_print():
  2
 a  n_x + b n_y + c*sin(alpha) n_z\
 """
-    uexpected = u("""\
+    uexpected = u"""\
  2
 a  n_x + b n_y + c⋅sin(α) n_z\
-""")
+"""
 
     assert ascii_vpretty(v) == expected
     assert unicode_vpretty(v) == uexpected
 
-    expected = u('alpha n_x + sin(omega) n_y + alpha*beta n_z')
-    uexpected = u('α n_x + sin(ω) n_y + α⋅β n_z')
+    expected = u'alpha n_x + sin(omega) n_y + alpha*beta n_z'
+    uexpected = u'α n_x + sin(ω) n_y + α⋅β n_z'
 
     assert ascii_vpretty(w) == expected
     assert unicode_vpretty(w) == uexpected
@@ -63,12 +62,12 @@ a       b + c       c
 - n_x + ----- n_y + -- n_z
 b         a         b\
 """
-    uexpected = u("""\
+    uexpected = u"""\
                      2
 a       b + c       c
 ─ n_x + ───── n_y + ── n_z
 b         a         b\
-""")
+"""
 
     assert ascii_vpretty(o) == expected
     assert unicode_vpretty(o) == uexpected
@@ -157,15 +156,15 @@ def test_dyadic_pretty_print():
 a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\
 """
 
-    uexpected = u("""\
+    uexpected = u"""\
  2
 a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
-""")
+"""
     assert ascii_vpretty(y) == expected
     assert unicode_vpretty(y) == uexpected
 
-    expected = u('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x')
-    uexpected = u('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x')
+    expected = u'alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x'
+    uexpected = u'α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x'
     assert ascii_vpretty(x) == expected
     assert unicode_vpretty(x) == uexpected
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,6 +1,6 @@
 from sympy import (S, sympify, trigsimp, expand, sqrt, Add, zeros,
                    ImmutableMatrix as Matrix)
-from sympy.core.compatibility import u, unicode
+from sympy.core.compatibility import unicode
 from sympy.utilities.misc import filldedent
 
 __all__ = ['Vector']

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division
 from sympy import sympify, S, Mul
 from sympy.core.function import _coeff_isneg
 from sympy.core.alphabets import greeks
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from .printer import Printer
 from .pretty.pretty_symbology import greek_unicode
 from .conventions import split_super_sub, requires_partial

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -12,7 +12,7 @@ from sympy.printing.precedence import PRECEDENCE, precedence
 from sympy.utilities import group
 from sympy.utilities.iterables import has_variety
 from sympy.core.sympify import SympifyError
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 from sympy.core.add import Add
 
 from sympy.printing.printer import Printer
@@ -157,14 +157,14 @@ class PrettyPrinter(Printer):
             arg = e.args[0]
             pform = self._print(arg)
             if isinstance(arg, Equivalent):
-                return self._print_Equivalent(arg, altchar=u("\N{NOT IDENTICAL TO}"))
+                return self._print_Equivalent(arg, altchar=u"\N{NOT IDENTICAL TO}")
             if isinstance(arg, Implies):
-                return self._print_Implies(arg, altchar=u("\N{RIGHTWARDS ARROW WITH STROKE}"))
+                return self._print_Implies(arg, altchar=u"\N{RIGHTWARDS ARROW WITH STROKE}")
 
             if arg.is_Boolean and not arg.is_Not:
                 pform = prettyForm(*pform.parens())
 
-            return prettyForm(*pform.left(u("\N{NOT SIGN}")))
+            return prettyForm(*pform.left(u"\N{NOT SIGN}"))
         else:
             return self._print_Function(e)
 
@@ -184,50 +184,50 @@ class PrettyPrinter(Printer):
             if arg.is_Boolean and not arg.is_Not:
                 pform_arg = prettyForm(*pform_arg.parens())
 
-            pform = prettyForm(*pform.right(u(' %s ') % char))
+            pform = prettyForm(*pform.right(u' %s ' % char))
             pform = prettyForm(*pform.right(pform_arg))
 
         return pform
 
     def _print_And(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\N{LOGICAL AND}"))
+            return self.__print_Boolean(e, u"\N{LOGICAL AND}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Or(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\N{LOGICAL OR}"))
+            return self.__print_Boolean(e, u"\N{LOGICAL OR}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Xor(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\N{XOR}"))
+            return self.__print_Boolean(e, u"\N{XOR}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Nand(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\N{NAND}"))
+            return self.__print_Boolean(e, u"\N{NAND}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Nor(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u("\N{NOR}"))
+            return self.__print_Boolean(e, u"\N{NOR}")
         else:
             return self._print_Function(e, sort=True)
 
     def _print_Implies(self, e, altchar=None):
         if self._use_unicode:
-            return self.__print_Boolean(e, altchar or u("\N{RIGHTWARDS ARROW}"), sort=False)
+            return self.__print_Boolean(e, altchar or u"\N{RIGHTWARDS ARROW}", sort=False)
         else:
             return self._print_Function(e)
 
     def _print_Equivalent(self, e, altchar=None):
         if self._use_unicode:
-            return self.__print_Boolean(e, altchar or u("\N{IDENTICAL TO}"))
+            return self.__print_Boolean(e, altchar or u"\N{IDENTICAL TO}")
         else:
             return self._print_Function(e, sort=True)
 
@@ -416,7 +416,7 @@ class PrettyPrinter(Printer):
         if self._use_unicode:
             # use unicode corners
             horizontal_chr = xobj('-', 1)
-            corner_chr = u('\N{BOX DRAWINGS LIGHT DOWN AND HORIZONTAL}')
+            corner_chr = u'\N{BOX DRAWINGS LIGHT DOWN AND HORIZONTAL}'
 
         func_height = pretty_func.height()
 
@@ -571,7 +571,7 @@ class PrettyPrinter(Printer):
 
         LimArg = self._print(z)
         if self._use_unicode:
-            LimArg = prettyForm(*LimArg.right(u('\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{RIGHTWARDS ARROW}')))
+            LimArg = prettyForm(*LimArg.right(u'\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{RIGHTWARDS ARROW}'))
         else:
             LimArg = prettyForm(*LimArg.right('->'))
         LimArg = prettyForm(*LimArg.right(self._print(z0)))
@@ -580,7 +580,7 @@ class PrettyPrinter(Printer):
             dir = ""
         else:
             if self._use_unicode:
-                dir = u('\N{SUPERSCRIPT PLUS SIGN}') if str(dir) == "+" else u('\N{SUPERSCRIPT MINUS}')
+                dir = u'\N{SUPERSCRIPT PLUS SIGN}' if str(dir) == "+" else u'\N{SUPERSCRIPT MINUS}'
 
         LimArg = prettyForm(*LimArg.right(self._print(dir)))
 
@@ -730,7 +730,7 @@ class PrettyPrinter(Printer):
     def _print_Adjoint(self, expr):
         pform = self._print(expr.arg)
         if self._use_unicode:
-            dag = prettyForm(u('\N{DAGGER}'))
+            dag = prettyForm(u'\N{DAGGER}')
         else:
             dag = prettyForm('+')
         from sympy.matrices import MatrixSymbol
@@ -811,11 +811,11 @@ class PrettyPrinter(Printer):
                 #if the coef of the basis vector is 1
                 #we skip the 1
                 if v == 1:
-                    o1.append(u("") +
+                    o1.append(u"" +
                               k._pretty_form)
                 #Same for -1
                 elif v == -1:
-                    o1.append(u("(-1) ") +
+                    o1.append(u"(-1) " +
                               k._pretty_form)
                 #For a general expr
                 else:
@@ -827,8 +827,8 @@ class PrettyPrinter(Printer):
                     o1.append(arg_str + ' ' + k._pretty_form)
                 vectstrs.append(k._pretty_form)
 
-        #outstr = u("").join(o1)
-        if o1[0].startswith(u(" + ")):
+        #outstr = u"".join(o1)
+        if o1[0].startswith(u" + "):
             o1[0] = o1[0][3:]
         elif o1[0].startswith(" "):
             o1[0] = o1[0][1:]
@@ -840,8 +840,8 @@ class PrettyPrinter(Printer):
             if '\n' in partstr:
                 tempstr = partstr
                 tempstr = tempstr.replace(vectstrs[i], '')
-                tempstr = tempstr.replace(u('\N{RIGHT PARENTHESIS UPPER HOOK}'),
-                                          u('\N{RIGHT PARENTHESIS UPPER HOOK}')
+                tempstr = tempstr.replace(u'\N{RIGHT PARENTHESIS UPPER HOOK}',
+                                          u'\N{RIGHT PARENTHESIS UPPER HOOK}'
                                           + ' ' + vectstrs[i])
                 o1[i] = tempstr
         o1 = [x.split('\n') for x in o1]
@@ -865,7 +865,7 @@ class PrettyPrinter(Printer):
                                            3*(len(lengths)-1)))
                     strs[j] += ' '*(lengths[-1]+3)
 
-        return prettyForm(u('\n').join([s[:-3] for s in strs]))
+        return prettyForm(u'\n'.join([s[:-3] for s in strs]))
 
     def _print_Piecewise(self, pexpr):
 
@@ -1109,7 +1109,7 @@ class PrettyPrinter(Printer):
     def _print_Lambda(self, e):
         vars, expr = e.args
         if self._use_unicode:
-            arrow = u(" \N{RIGHTWARDS ARROW FROM BAR} ")
+            arrow = u" \N{RIGHTWARDS ARROW FROM BAR} "
         else:
             arrow = " -> "
         if len(vars) == 1:
@@ -1129,7 +1129,7 @@ class PrettyPrinter(Printer):
             elif len(expr.variables):
                 pform = prettyForm(*pform.right(self._print(expr.variables[0])))
             if self._use_unicode:
-                pform = prettyForm(*pform.right(u(" \N{RIGHTWARDS ARROW} ")))
+                pform = prettyForm(*pform.right(u" \N{RIGHTWARDS ARROW} "))
             else:
                 pform = prettyForm(*pform.right(" -> "))
             if len(expr.point) > 1:
@@ -1371,7 +1371,7 @@ class PrettyPrinter(Printer):
             and expt is S.Half and bpretty.height() == 1
             and (bpretty.width() == 1
                  or (base.is_Integer and base.is_nonnegative))):
-            return prettyForm(*bpretty.left(u('\N{SQUARE ROOT}')))
+            return prettyForm(*bpretty.left(u'\N{SQUARE ROOT}'))
 
         # Construct root sign, start with the \/ shape
         _zZ = xobj('/', 1)
@@ -1464,7 +1464,7 @@ class PrettyPrinter(Printer):
             from sympy import Pow
             return self._print(Pow(p.sets[0], len(p.sets), evaluate=False))
         else:
-            prod_char = u("\N{MULTIPLICATION SIGN}") if self._use_unicode else 'x'
+            prod_char = u"\N{MULTIPLICATION SIGN}" if self._use_unicode else 'x'
             return self._print_seq(p.sets, None, None, ' %s ' % prod_char,
                                    parenthesize=lambda set: set.is_Union or
                                    set.is_Intersection or set.is_ProductSet)
@@ -1476,7 +1476,7 @@ class PrettyPrinter(Printer):
     def _print_Range(self, s):
 
         if self._use_unicode:
-            dots = u("\N{HORIZONTAL ELLIPSIS}")
+            dots = u"\N{HORIZONTAL ELLIPSIS}"
         else:
             dots = '...'
 
@@ -1547,7 +1547,7 @@ class PrettyPrinter(Printer):
 
     def _print_ImageSet(self, ts):
         if self._use_unicode:
-            inn = u("\N{SMALL ELEMENT OF}")
+            inn = u"\N{SMALL ELEMENT OF}"
         else:
             inn = 'in'
         variables = self._print_seq(ts.lamda.variables)
@@ -1559,10 +1559,10 @@ class PrettyPrinter(Printer):
 
     def _print_ConditionSet(self, ts):
         if self._use_unicode:
-            inn = u("\N{SMALL ELEMENT OF}")
+            inn = u"\N{SMALL ELEMENT OF}"
             # using _and because and is a keyword and it is bad practice to
             # overwrite them
-            _and = u("\N{LOGICAL AND}")
+            _and = u"\N{LOGICAL AND}"
         else:
             inn = 'in'
             _and = 'and'
@@ -1583,7 +1583,7 @@ class PrettyPrinter(Printer):
 
     def _print_ComplexRegion(self, ts):
         if self._use_unicode:
-            inn = u("\N{SMALL ELEMENT OF}")
+            inn = u"\N{SMALL ELEMENT OF}"
         else:
             inn = 'in'
         variables = self._print_seq(ts.variables)
@@ -1596,7 +1596,7 @@ class PrettyPrinter(Printer):
     def _print_Contains(self, e):
         var, set = e.args
         if self._use_unicode:
-            el = u(" \N{ELEMENT OF} ")
+            el = u" \N{ELEMENT OF} "
             return prettyForm(*stringPict.next(self._print(var),
                                                el, self._print(set)), binding=8)
         else:
@@ -1604,7 +1604,7 @@ class PrettyPrinter(Printer):
 
     def _print_FourierSeries(self, s):
         if self._use_unicode:
-            dots = u("\N{HORIZONTAL ELLIPSIS}")
+            dots = u"\N{HORIZONTAL ELLIPSIS}"
         else:
             dots = '...'
         return self._print_Add(s.truncate()) + self._print(dots)
@@ -1614,7 +1614,7 @@ class PrettyPrinter(Printer):
 
     def _print_SeqFormula(self, s):
         if self._use_unicode:
-            dots = u("\N{HORIZONTAL ELLIPSIS}")
+            dots = u"\N{HORIZONTAL ELLIPSIS}"
         else:
             dots = '...'
 
@@ -1749,7 +1749,7 @@ class PrettyPrinter(Printer):
 
     def _print_FiniteField(self, expr):
         if self._use_unicode:
-            form = u('\N{DOUBLE-STRUCK CAPITAL Z}_%d')
+            form = u'\N{DOUBLE-STRUCK CAPITAL Z}_%d'
         else:
             form = 'GF(%d)'
 
@@ -1757,19 +1757,19 @@ class PrettyPrinter(Printer):
 
     def _print_IntegerRing(self, expr):
         if self._use_unicode:
-            return prettyForm(u('\N{DOUBLE-STRUCK CAPITAL Z}'))
+            return prettyForm(u'\N{DOUBLE-STRUCK CAPITAL Z}')
         else:
             return prettyForm('ZZ')
 
     def _print_RationalField(self, expr):
         if self._use_unicode:
-            return prettyForm(u('\N{DOUBLE-STRUCK CAPITAL Q}'))
+            return prettyForm(u'\N{DOUBLE-STRUCK CAPITAL Q}')
         else:
             return prettyForm('QQ')
 
     def _print_RealField(self, domain):
         if self._use_unicode:
-            prefix = u('\N{DOUBLE-STRUCK CAPITAL R}')
+            prefix = u'\N{DOUBLE-STRUCK CAPITAL R}'
         else:
             prefix = 'RR'
 
@@ -1780,7 +1780,7 @@ class PrettyPrinter(Printer):
 
     def _print_ComplexField(self, domain):
         if self._use_unicode:
-            prefix = u('\N{DOUBLE-STRUCK CAPITAL C}')
+            prefix = u'\N{DOUBLE-STRUCK CAPITAL C}'
         else:
             prefix = 'CC'
 
@@ -2022,11 +2022,11 @@ class PrettyPrinter(Printer):
         field = diff._form_field
         if hasattr(field, '_coord_sys'):
             string = field._coord_sys._names[field._index]
-            return self._print(u('\N{DOUBLE-STRUCK ITALIC SMALL D} ') + pretty_symbol(string))
+            return self._print(u'\N{DOUBLE-STRUCK ITALIC SMALL D} ' + pretty_symbol(string))
         else:
             pform = self._print(field)
             pform = prettyForm(*pform.parens())
-            return prettyForm(*pform.left(u("\N{DOUBLE-STRUCK ITALIC SMALL D}")))
+            return prettyForm(*pform.left(u"\N{DOUBLE-STRUCK ITALIC SMALL D}"))
 
     def _print_Tr(self, p):
         #TODO: Handle indices

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -6,7 +6,7 @@ import sys
 import warnings
 unicode_warnings = ''
 
-from sympy.core.compatibility import u, unicode, range
+from sympy.core.compatibility import unicode, range
 
 # first, setup unicodedate environment
 try:
@@ -559,13 +559,13 @@ def annotated(letter):
     information.
     """
     ucode_pics = {
-        'F': (2, 0, 2, 0, u('\N{BOX DRAWINGS LIGHT DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
-                            '\N{BOX DRAWINGS LIGHT VERTICAL AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
-                            '\N{BOX DRAWINGS LIGHT UP}')),
+        'F': (2, 0, 2, 0, u'\N{BOX DRAWINGS LIGHT DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
+                          u'\N{BOX DRAWINGS LIGHT VERTICAL AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\n'
+                          u'\N{BOX DRAWINGS LIGHT UP}'),
         'G': (3, 0, 3, 1,
-              u('\N{BOX DRAWINGS LIGHT ARC DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC DOWN AND LEFT}\n'
-                '\N{BOX DRAWINGS LIGHT VERTICAL}\N{BOX DRAWINGS LIGHT RIGHT}\N{BOX DRAWINGS LIGHT DOWN AND LEFT}\n'
-                '\N{BOX DRAWINGS LIGHT ARC UP AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC UP AND LEFT}'))
+              u'\N{BOX DRAWINGS LIGHT ARC DOWN AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC DOWN AND LEFT}\n'
+              u'\N{BOX DRAWINGS LIGHT VERTICAL}\N{BOX DRAWINGS LIGHT RIGHT}\N{BOX DRAWINGS LIGHT DOWN AND LEFT}\n'
+              u'\N{BOX DRAWINGS LIGHT ARC UP AND RIGHT}\N{BOX DRAWINGS LIGHT HORIZONTAL}\N{BOX DRAWINGS LIGHT ARC UP AND LEFT}')
     }
     ascii_pics = {
         'F': (3, 0, 3, 0, ' _\n|_\n|\n'),

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -15,7 +15,7 @@ TODO:
 from __future__ import print_function, division
 
 from .pretty_symbology import hobj, vobj, xsym, xobj, pretty_use_unicode
-from sympy.core.compatibility import u, string_types, range
+from sympy.core.compatibility import string_types, range
 
 
 class stringPict(object):
@@ -346,7 +346,7 @@ class stringPict(object):
         return str.join('\n', self.picture)
 
     def __unicode__(self):
-        return unicode.join(u('\n'), self.picture)
+        return unicode.join(u'\n', self.picture)
 
     def __repr__(self):
         return "stringPict(%r,%d)" % ('\n'.join(self.picture), self.baseline)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3762,9 +3762,9 @@ def test_pretty_prec():
 
 
 def test_pprint():
+    import io
     import sys
-    from sympy.core.compatibility import StringIO
-    fd = StringIO()
+    fd = io.StringIO()
     sso = sys.stdout
     sys.stdout = fd
     try:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -27,7 +27,6 @@ from sympy.physics.units import joule
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.core.trace import Tr
 
-from sympy.core.compatibility import u_decode as u
 from sympy.core.compatibility import range
 
 a, b, x, y, z, k = symbols('a,b,x,y,z,k')
@@ -357,9 +356,9 @@ def test_pretty_basic():
 oo\
 """
     ucode_str = \
-u("""\
+u"""\
 ∞\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -370,10 +369,10 @@ u("""\
 x \
 """
     ucode_str = \
-u("""\
+u"""\
  2\n\
 x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -385,11 +384,11 @@ x \
 x\
 """
     ucode_str = \
-u("""\
+u"""\
 1\n\
 ─\n\
 x\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -401,10 +400,10 @@ x\
 x    \
 """
     ucode_str = \
-("""\
+u"""\
  -1.0\n\
 x    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -416,10 +415,10 @@ x    \
 2    \
 """
     ucode_str = \
-("""\
+u"""\
  -1.0\n\
 2    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -432,12 +431,12 @@ y \n\
 x \
 """
     ucode_str = \
-u("""\
+u"""\
 y \n\
 ──\n\
  2\n\
 x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -450,12 +449,12 @@ x \
 x   \
 """
     ucode_str = \
-u("""\
+u"""\
  1  \n\
 ────\n\
  5/2\n\
 x   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -466,10 +465,10 @@ x   \
 (-2) \
 """
     ucode_str = \
-u("""\
+u"""\
     x\n\
 (-2) \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -481,10 +480,10 @@ u("""\
 3 \
 """
     ucode_str = \
-u("""\
+u"""\
  1\n\
 3 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -505,20 +504,20 @@ x  + x + 1\
 x  + 1 + x\
 """
     ucode_str_1 = \
-u("""\
+u"""\
          2\n\
 1 + x + x \
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
  2        \n\
 x  + x + 1\
-""")
+"""
     ucode_str_3 = \
-u("""\
+u"""\
  2        \n\
 x  + 1 + x\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2, ascii_str_3]
     assert upretty(expr) in [ucode_str_1, ucode_str_2, ucode_str_3]
 
@@ -532,13 +531,13 @@ x  + 1 + x\
 -x + 1\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 1 - x\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 -x + 1\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -552,13 +551,13 @@ u("""\
 -2*x + 1\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 1 - 2⋅x\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 -2⋅x + 1\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -570,11 +569,11 @@ x\n\
 y\
 """
     ucode_str = \
-u("""\
+u"""\
 x\n\
 ─\n\
 y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -586,11 +585,11 @@ y\
  y \
 """
     ucode_str = \
-u("""\
+u"""\
 -x \n\
 ───\n\
  y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -608,17 +607,17 @@ x + 2\n\
   y  \
 """
     ucode_str_1 = \
-u("""\
+u"""\
 2 + x\n\
 ─────\n\
   y  \
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 x + 2\n\
 ─────\n\
   y  \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -636,17 +635,17 @@ y*(1 + x)\
 y*(x + 1)\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 y⋅(1 + x)\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 (1 + x)⋅y\
-""")
+"""
     ucode_str_3 = \
-u("""\
+u"""\
 y⋅(x + 1)\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2, ascii_str_3]
     assert upretty(expr) in [ucode_str_1, ucode_str_2, ucode_str_3]
 
@@ -665,17 +664,17 @@ y⋅(x + 1)\
 x + 10\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 -5⋅x  \n\
 ──────\n\
 10 + x\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 -5⋅x  \n\
 ──────\n\
 x + 10\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -685,9 +684,9 @@ x + 10\
 -3*x - 1/2\
 """
     ucode_str = \
-u("""\
+u"""\
 -3⋅x - 1/2\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -697,9 +696,9 @@ u("""\
 -3*x + 1/2\
 """
     ucode_str = \
-u("""\
+u"""\
 -3⋅x + 1/2\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -711,11 +710,11 @@ u("""\
    2    2\
 """
     ucode_str = \
-u("""\
+u"""\
   3⋅x   1\n\
 - ─── - ─\n\
    2    2\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -727,11 +726,11 @@ u("""\
    2    2\
 """
     ucode_str = \
-u("""\
+u"""\
   3⋅x   1\n\
 - ─── + ─\n\
    2    2\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -745,11 +744,11 @@ def test_negative_fractions():
  y \
 """
     ucode_str =\
-u("""\
+u"""\
 -x \n\
 ───\n\
  y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -x*z/y
@@ -760,11 +759,11 @@ u("""\
   y  \
 """
     ucode_str =\
-u("""\
+u"""\
 -x⋅z \n\
 ─────\n\
   y  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = x**2/y
@@ -776,12 +775,12 @@ x \n\
 y \
 """
     ucode_str =\
-u("""\
+u"""\
  2\n\
 x \n\
 ──\n\
 y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -x**2/y
@@ -793,12 +792,12 @@ y \
  y  \
 """
     ucode_str =\
-u("""\
+u"""\
   2 \n\
 -x  \n\
 ────\n\
  y  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -x/(y*z)
@@ -809,11 +808,11 @@ u("""\
 y*z\
 """
     ucode_str =\
-u("""\
+u"""\
 -x \n\
 ───\n\
 y⋅z\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -a/y**2
@@ -825,12 +824,12 @@ y⋅z\
  y \
 """
     ucode_str =\
-u("""\
+u"""\
 -a \n\
 ───\n\
   2\n\
  y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = y**(-a/b)
@@ -842,12 +841,12 @@ u("""\
 y   \
 """
     ucode_str =\
-u("""\
+u"""\
  -a \n\
  ───\n\
   b \n\
 y   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -1/y**2
@@ -859,12 +858,12 @@ y   \
  y \
 """
     ucode_str =\
-u("""\
+u"""\
 -1 \n\
 ───\n\
   2\n\
  y \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = -10/b**2
@@ -876,12 +875,12 @@ u("""\
  b  \
 """
     ucode_str =\
-u("""\
+u"""\
 -10 \n\
 ────\n\
   2 \n\
  b  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
     expr = Rational(-200, 37)
@@ -892,11 +891,11 @@ u("""\
   37 \
 """
     ucode_str =\
-u("""\
+u"""\
 -200 \n\
 ─────\n\
   37 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -908,10 +907,10 @@ def test_issue_5524():
 """
 
     assert upretty(-(-x + 5)*(-x - 2*sqrt(2) + 5) - (-y + 5)*(-y + 5)) == \
-u("""\
+u"""\
                                   2\n\
 (x - 5)⋅(-x - 2⋅√2 + 5) - (-y + 5) \
-""")
+"""
 
 
 def test_pretty_ordering():
@@ -957,12 +956,12 @@ x - -- + --- + O\\x /\n\
     6    120        \
 """
     ucode_str = \
-u("""\
+u"""\
      3     5        \n\
     x     x     ⎛ 6⎞\n\
 x - ── + ─── + O⎝x ⎠\n\
     6    120        \
-""")
+"""
     assert pretty(expr, order=None) == ascii_str
     assert upretty(expr, order=None) == ucode_str
 
@@ -987,9 +986,9 @@ def test_pretty_relational():
 x = y\
 """
     ucode_str = \
-u("""\
+u"""\
 x = y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -999,9 +998,9 @@ x = y\
 x < y\
 """
     ucode_str = \
-u("""\
+u"""\
 x < y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1011,9 +1010,9 @@ x < y\
 x > y\
 """
     ucode_str = \
-u("""\
+u"""\
 x > y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1023,9 +1022,9 @@ x > y\
 x <= y\
 """
     ucode_str = \
-u("""\
+u"""\
 x ≤ y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1035,9 +1034,9 @@ x ≤ y\
 x >= y\
 """
     ucode_str = \
-u("""\
+u"""\
 x ≥ y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1055,17 +1054,17 @@ x ≥ y\
 y + 1      \
 """
     ucode_str_1 = \
-u("""\
+u"""\
   x      2\n\
 ───── ≠ y \n\
 1 + y     \
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
   x      2\n\
 ───── ≠ y \n\
 y + 1     \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1076,9 +1075,9 @@ def test_Assignment():
 x := y\
 """
     ucode_str = \
-u("""\
+u"""\
 x := y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1086,31 +1085,31 @@ def test_issue_7117():
     # See also issue #5031 (hence the evaluate=False in these).
     e = Eq(x + 1, x/2)
     q = Mul(2, e, evaluate=False)
-    assert upretty(q) == u("""\
+    assert upretty(q) == u"""\
   ⎛        x⎞\n\
 2⋅⎜x + 1 = ─⎟\n\
   ⎝        2⎠\
-""")
+"""
     q = Add(e, 6, evaluate=False)
-    assert upretty(q) == u("""\
+    assert upretty(q) == u"""\
     ⎛        x⎞\n\
 6 + ⎜x + 1 = ─⎟\n\
     ⎝        2⎠\
-""")
+"""
     q = Pow(e, 2, evaluate=False)
-    assert upretty(q) == u("""\
+    assert upretty(q) == u"""\
            2\n\
 ⎛        x⎞ \n\
 ⎜x + 1 = ─⎟ \n\
 ⎝        2⎠ \
-""")
+"""
     e2 = Eq(x, 2)
     q = Mul(e, e2, evaluate=False)
-    assert upretty(q) == u("""\
+    assert upretty(q) == u"""\
 ⎛        x⎞        \n\
 ⎜x + 1 = ─⎟⋅(x = 2)\n\
 ⎝        2⎠        \
-""")
+"""
 
 
 def test_pretty_rational():
@@ -1123,12 +1122,12 @@ y \n\
 x \
 """
     ucode_str = \
-u("""\
+u"""\
 y \n\
 ──\n\
  2\n\
 x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1142,13 +1141,13 @@ y   \n\
 x   \
 """
     ucode_str = \
-u("""\
+u"""\
  3/2\n\
 y   \n\
 ────\n\
  5/2\n\
 x   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1162,13 +1161,13 @@ sin (x)\n\
 tan (x)\
 """
     ucode_str = \
-u("""\
+u"""\
    3   \n\
 sin (x)\n\
 ───────\n\
    2   \n\
 tan (x)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1187,15 +1186,15 @@ def test_pretty_functions():
 e  + 2*x\
 """
     ucode_str_1 = \
-u("""\
+u"""\
        x\n\
 2⋅x + ℯ \
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
  x     \n\
 ℯ + 2⋅x\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1205,9 +1204,9 @@ u("""\
 |x|\
 """
     ucode_str = \
-u("""\
+u"""\
 │x│\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1227,19 +1226,19 @@ u("""\
 |x  + 1|\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 │  x   │\n\
 │──────│\n\
 │     2│\n\
 │1 + x │\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 │  x   │\n\
 │──────│\n\
 │ 2    │\n\
 │x  + 1│\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1251,11 +1250,11 @@ u("""\
 |y - |x||\
 """
     ucode_str = \
-u("""\
+u"""\
 │   1   │\n\
 │───────│\n\
 │y - │x││\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1266,9 +1265,9 @@ u("""\
 n!\
 """
     ucode_str = \
-u("""\
+u"""\
 n!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1278,9 +1277,9 @@ n!\
 (2*n)!\
 """
     ucode_str = \
-u("""\
+u"""\
 (2⋅n)!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1290,9 +1289,9 @@ u("""\
 ((n!)!)!\
 """
     ucode_str = \
-u("""\
+u"""\
 ((n!)!)!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1306,13 +1305,13 @@ u("""\
 (n + 1)!\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 (1 + n)!\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 (n + 1)!\
-""")
+"""
 
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
@@ -1323,9 +1322,9 @@ u("""\
 !n\
 """
     ucode_str = \
-u("""\
+u"""\
 !n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1335,9 +1334,9 @@ u("""\
 !(2*n)\
 """
     ucode_str = \
-u("""\
+u"""\
 !(2⋅n)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1348,9 +1347,9 @@ u("""\
 n!!\
 """
     ucode_str = \
-u("""\
+u"""\
 n!!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1360,9 +1359,9 @@ n!!\
 (2*n)!!\
 """
     ucode_str = \
-u("""\
+u"""\
 (2⋅n)!!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1372,9 +1371,9 @@ u("""\
 ((n!!)!!)!!\
 """
     ucode_str = \
-u("""\
+u"""\
 ((n!!)!!)!!\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1388,13 +1387,13 @@ u("""\
 (n + 1)!!\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 (1 + n)!!\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 (n + 1)!!\
-""")
+"""
 
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
@@ -1407,11 +1406,11 @@ u("""\
   \k/\
 """
     ucode_str = \
-u("""\
+u"""\
   ⎛n⎞\n\
 2⋅⎜ ⎟\n\
   ⎝k⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1424,11 +1423,11 @@ u("""\
   \ k /\
 """
     ucode_str = \
-u("""\
+u"""\
   ⎛2⋅n⎞\n\
 2⋅⎜   ⎟\n\
   ⎝ k ⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1442,12 +1441,12 @@ u("""\
   \k /\
 """
     ucode_str = \
-u("""\
+u"""\
   ⎛ 2⎞\n\
   ⎜n ⎟\n\
 2⋅⎜  ⎟\n\
   ⎝k ⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1459,10 +1458,10 @@ C \n\
  n\
 """
     ucode_str = \
-u("""\
+u"""\
 C \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1473,10 +1472,10 @@ _\n\
 x\
 """
     ucode_str = \
-u("""\
+u"""\
 _\n\
 x\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1493,15 +1492,15 @@ ________\n\
 f(x + 1)\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 ________\n\
 f(1 + x)\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 ________\n\
 f(x + 1)\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1511,9 +1510,9 @@ f(x + 1)\
 f(x)\
 """
     ucode_str = \
-u("""\
+u"""\
 f(x)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1523,9 +1522,9 @@ f(x)\
 f(x, y)\
 """
     ucode_str = \
-u("""\
+u"""\
 f(x, y)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1543,17 +1542,17 @@ f|-----, y|\n\
  \\y + 1   /\
 """
     ucode_str_1 = \
-u("""\
+u"""\
  ⎛  x     ⎞\n\
 f⎜─────, y⎟\n\
  ⎝1 + y   ⎠\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
  ⎛  x     ⎞\n\
 f⎜─────, y⎟\n\
  ⎝y + 1   ⎠\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1568,14 +1567,14 @@ f⎜─────, y⎟\n\
 f\\x             /\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛ ⎛ ⎛ ⎛ ⎛ x⎞⎞⎞⎞⎞
  ⎜ ⎜ ⎜ ⎜ ⎝x ⎠⎟⎟⎟⎟
  ⎜ ⎜ ⎜ ⎝x    ⎠⎟⎟⎟
  ⎜ ⎜ ⎝x       ⎠⎟⎟
  ⎜ ⎝x          ⎠⎟
 f⎝x             ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1586,10 +1585,10 @@ f⎝x             ⎠\
 sin (x)\
 """
     ucode_str = \
-u("""\
+u"""\
    2   \n\
 sin (x)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1600,10 +1599,10 @@ _     _\n\
 a - I*b\
 """
     ucode_str = \
-u("""\
+u"""\
 _     _\n\
 a - ⅈ⋅b\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1615,11 +1614,11 @@ a - ⅈ⋅b\
 e       \
 """
     ucode_str = \
-u("""\
+u"""\
  _     _\n\
  a - ⅈ⋅b\n\
 ℯ       \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1637,17 +1636,17 @@ ___________\n\
 f\\f(x) + 1/\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 ___________\n\
  ⎛    ____⎞\n\
 f⎝1 + f(x)⎠\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 ___________\n\
  ⎛____    ⎞\n\
 f⎝f(x) + 1⎠\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1665,17 +1664,17 @@ f|-----, y|\n\
  \\y + 1   /\
 """
     ucode_str_1 = \
-u("""\
+u"""\
  ⎛  x     ⎞\n\
 f⎜─────, y⎟\n\
  ⎝1 + y   ⎠\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
  ⎛  x     ⎞\n\
 f⎜─────, y⎟\n\
  ⎝y + 1   ⎠\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -1687,11 +1686,11 @@ floor|------------|\n\
      \y - floor(x)/\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎢   1   ⎥\n\
 ⎢───────⎥\n\
 ⎣y - ⌊x⌋⎦\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1703,11 +1702,11 @@ ceiling|--------------|\n\
        \y - ceiling(x)/\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎡   1   ⎤\n\
 ⎢───────⎥\n\
 ⎢y - ⌈x⌉⎥\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1718,10 +1717,10 @@ E \n\
  n\
 """
     ucode_str = \
-u("""\
+u"""\
 E \n\
  n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1739,7 +1738,7 @@ E         \n\
 """
 
     ucode_str = \
-u("""\
+u"""\
 E         \n\
      1    \n\
  ─────────\n\
@@ -1748,7 +1747,7 @@ E         \n\
          1\n\
      1 + ─\n\
          n\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1772,10 +1771,10 @@ u"√2"
 \/ 2 \
 """
     ucode_str = \
-u("""\
+u"""\
 3 ___\n\
 ╲╱ 2 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1786,10 +1785,10 @@ u("""\
   \/ 2 \
 """
     ucode_str = \
-u("""\
+u"""\
 1000___\n\
   ╲╱ 2 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1801,11 +1800,11 @@ u("""\
 \/  x  + 1 \
 """
     ucode_str = \
-u("""\
+u"""\
    ________\n\
   ╱  2     \n\
 ╲╱  x  + 1 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1817,10 +1816,10 @@ u("""\
 \/  1 + \/ 5  \
 """
     ucode_str = \
-u("""\
+u"""\
 3 ________\n\
 ╲╱ 1 + √5 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1831,10 +1830,10 @@ x ___\n\
 \/ 2 \
 """
     ucode_str = \
-u("""\
+u"""\
 x ___\n\
 ╲╱ 2 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1845,10 +1844,10 @@ x ___\n\
 \/ 2 + pi \
 """
     ucode_str = \
-u("""\
+u"""\
   _______\n\
 ╲╱ 2 + π \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1865,7 +1864,7 @@ u("""\
                     \/  x  + 3 \
 """
     ucode_str = \
-u("""\
+u"""\
      ____________              \n\
     ╱      2        1000___    \n\
    ╱      x  + 1      ╲╱ x  + 1\n\
@@ -1873,7 +1872,7 @@ u("""\
 ╲╱        x + 2        ________\n\
                       ╱  2     \n\
                     ╲╱  x  + 3 \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1882,10 +1881,10 @@ def test_pretty_sqrt_char_knob():
     # See PR #9234.
     expr = sqrt(2)
     ucode_str1 = \
-u("""\
+u"""\
   ___\n\
 ╲╱ 2 \
-""")
+"""
     ucode_str2 = \
 u"√2"
     assert xpretty(expr, use_unicode=True,
@@ -1898,10 +1897,10 @@ def test_pretty_sqrt_longsymbol_no_sqrt_char():
     # Do not use unicode sqrt char for long symbols (see PR #9234).
     expr = sqrt(Symbol('C1'))
     ucode_str = \
-u("""\
+u"""\
   ____\n\
 ╲╱ C₁ \
-""")
+"""
     assert upretty(expr) == ucode_str
 
 
@@ -1914,10 +1913,10 @@ d   \n\
  x,y\
 """
     ucode_str = \
-u("""\
+u"""\
 δ   \n\
  x,y\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -1928,7 +1927,7 @@ def test_pretty_product():
     expr = Product(f((n/3)**2), (n, k**2, l))
 
     unicode_str = \
-u("""\
+u"""\
     l           \n\
 ┬────────┬      \n\
 │        │  ⎛ 2⎞\n\
@@ -1937,7 +1936,7 @@ u("""\
 │        │  ⎝9 ⎠\n\
 │        │      \n\
        2        \n\
-  n = k         """)
+  n = k         """
     ascii_str = \
 """\
     l           \n\
@@ -1956,7 +1955,7 @@ __________      \n\
     expr = Product(f((n/3)**2), (n, k**2, l), (l, 1, m))
 
     unicode_str = \
-u("""\
+u"""\
     m          l           \n\
 ┬────────┬ ┬────────┬      \n\
 │        │ │        │  ⎛ 2⎞\n\
@@ -1965,7 +1964,7 @@ u("""\
 │        │ │        │  ⎝9 ⎠\n\
 │        │ │        │      \n\
   l = 1           2        \n\
-             n = k         """)
+             n = k         """
     ascii_str = \
 """\
     m          l           \n\
@@ -1999,10 +1998,10 @@ def test_pretty_lambda():
 x -> x \
 """
     ucode_str = \
-u("""\
+u"""\
      2\n\
 x ↦ x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2014,11 +2013,11 @@ x ↦ x \
 \\x -> x / \
 """
     ucode_str = \
-u("""\
+u"""\
         2
 ⎛     2⎞ \n\
 ⎝x ↦ x ⎠ \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2035,10 +2034,10 @@ u("""\
 (x, y) -> x \
 """
     ucode_str = \
-u("""\
+u"""\
           2\n\
 (x, y) ↦ x \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2050,9 +2049,9 @@ def test_pretty_order():
 O(1)\
 """
     ucode_str = \
-u("""\
+u"""\
 O(1)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2064,11 +2063,11 @@ O|-|\n\
  \\x/\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛1⎞\n\
 O⎜─⎟\n\
  ⎝x⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2079,10 +2078,10 @@ O⎜─⎟\n\
 O\\x  + y ; (x, y) -> (0, 0)/\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛ 2    2                 ⎞\n\
 O⎝x  + y ; (x, y) → (0, 0)⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2092,9 +2091,9 @@ O⎝x  + y ; (x, y) → (0, 0)⎠\
 O(1; x -> oo)\
 """
     ucode_str = \
-u("""\
+u"""\
 O(1; x → ∞)\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2106,11 +2105,11 @@ O|-; x -> oo|\n\
  \\x         /\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛1       ⎞\n\
 O⎜─; x → ∞⎟\n\
  ⎝x       ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2121,10 +2120,10 @@ O⎜─; x → ∞⎟\n\
 O\\x  + y ; (x, y) -> (oo, oo)/\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛ 2    2                 ⎞\n\
 O⎝x  + y ; (x, y) → (∞, ∞)⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2139,11 +2138,11 @@ d         \n\
 dx        \
 """
     ucode_str = \
-u("""\
+u"""\
 d         \n\
 ──(log(x))\n\
 dx        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2161,17 +2160,17 @@ d             \n\
 dx            \
 """
     ucode_str_1 = \
-u("""\
+u"""\
     d         \n\
 x + ──(log(x))\n\
     dx        \
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 d             \n\
 ──(log(x)) + x\n\
 dx            \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -2190,17 +2189,17 @@ d                 \n\
 dx                \
 """
     ucode_str_1 = \
-u("""\
+u"""\
 ∂                 \n\
 ──(log(x + y) + x)\n\
 ∂x                \
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 ∂                 \n\
 ──(x + log(x + y))\n\
 ∂x                \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2], upretty(expr)
 
@@ -2221,19 +2220,19 @@ dy dx             \
 dy dx             \
 """
     ucode_str_1 = \
-u("""\
+u"""\
    2              \n\
   d  ⎛          2⎞\n\
 ─────⎝log(x) + x ⎠\n\
 dy dx             \
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
    2              \n\
   d  ⎛ 2         ⎞\n\
 ─────⎝x  + log(x)⎠\n\
 dy dx             \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -2253,19 +2252,19 @@ x  + -----(2*x*y)\n\
      dx dy       \
 """
     ucode_str_1 = \
-u("""\
+u"""\
    2             \n\
   ∂             2\n\
 ─────(2⋅x⋅y) + x \n\
 ∂x ∂y            \
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
         2        \n\
  2     ∂         \n\
 x  + ─────(2⋅x⋅y)\n\
      ∂x ∂y       \
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -2279,13 +2278,13 @@ x  + ─────(2⋅x⋅y)\n\
 dx        \
 """
     ucode_str = \
-u("""\
+u"""\
   2       \n\
  ∂        \n\
 ───(2⋅x⋅y)\n\
   2       \n\
 ∂x        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2299,13 +2298,13 @@ d          \n\
 dx         \
 """
     ucode_str = \
-u("""\
+u"""\
  17        \n\
 ∂          \n\
 ────(2⋅x⋅y)\n\
   17       \n\
 ∂x         \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2319,13 +2318,13 @@ u("""\
 dy dx        \
 """
     ucode_str = \
-u("""\
+u"""\
    3         \n\
   ∂          \n\
 ──────(2⋅x⋅y)\n\
      2       \n\
 ∂y ∂x        \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2340,11 +2339,11 @@ u("""\
 dalpha             \
 """
     ucode_str = \
-u("""\
+u"""\
 d       \n\
 ──(β(α))\n\
 dα      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2360,11 +2359,11 @@ def test_pretty_integrals():
 /           \
 """
     ucode_str = \
-u("""\
+u"""\
 ⌠          \n\
 ⎮ log(x) dx\n\
 ⌡          \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2379,12 +2378,12 @@ u("""\
 /       \
 """
     ucode_str = \
-u("""\
+u"""\
 ⌠      \n\
 ⎮  2   \n\
 ⎮ x  dx\n\
 ⌡      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2402,7 +2401,7 @@ u("""\
 /            \
 """
     ucode_str = \
-u("""\
+u"""\
 ⌠           \n\
 ⎮    2      \n\
 ⎮ sin (x)   \n\
@@ -2410,7 +2409,7 @@ u("""\
 ⎮    2      \n\
 ⎮ tan (x)   \n\
 ⌡           \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2426,13 +2425,13 @@ u("""\
 /          \
 """
     ucode_str = \
-u("""\
+u"""\
 ⌠         \n\
 ⎮  ⎛ x⎞   \n\
 ⎮  ⎝2 ⎠   \n\
 ⎮ x     dx\n\
 ⌡         \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2449,14 +2448,14 @@ u("""\
 1        \
 """
     ucode_str = \
-u("""\
+u"""\
 2      \n\
 ⌠      \n\
 ⎮  2   \n\
 ⎮ x  dx\n\
 ⌡      \n\
 1      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2473,14 +2472,14 @@ u("""\
 1/2      \
 """
     ucode_str = \
-u("""\
+u"""\
  10      \n\
  ⌠       \n\
  ⎮   2   \n\
  ⎮  x  dx\n\
  ⌡       \n\
 1/2      \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2495,12 +2494,12 @@ u("""\
 /  /             \
 """
     ucode_str = \
-u("""\
+u"""\
 ⌠ ⌠            \n\
 ⎮ ⎮  2  2      \n\
 ⎮ ⎮ x ⋅y  dx dy\n\
 ⌡ ⌡            \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2518,7 +2517,7 @@ u("""\
  0   0                             \
 """
     ucode_str = \
-u("""\
+u"""\
 2⋅π π             \n\
  ⌠  ⌠             \n\
  ⎮  ⎮ sin(θ)      \n\
@@ -2526,7 +2525,7 @@ u("""\
  ⎮  ⎮ cos(φ)      \n\
  ⌡  ⌡             \n\
  0  0             \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2564,19 +2563,19 @@ def test_pretty_matrix():
 [  y     x + y]\
 """
     ucode_str_1 = \
-u("""\
+u"""\
 ⎡     2       ⎤
 ⎢1 + x     1  ⎥
 ⎢             ⎥
 ⎣  y     x + y⎦\
-""")
+"""
     ucode_str_2 = \
-u("""\
+u"""\
 ⎡ 2           ⎤
 ⎢x  + 1    1  ⎥
 ⎢             ⎥
 ⎣  y     x + y⎦\
-""")
+"""
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
@@ -2591,14 +2590,14 @@ u("""\
 [0  e           1  ]\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎡x           ⎤
 ⎢─    y     θ⎥
 ⎢y           ⎥
 ⎢            ⎥
 ⎢    ⅈ⋅k⋅φ   ⎥
 ⎣0  ℯ       1⎦\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2645,11 +2644,11 @@ tr|[    ]|
   \[3  4]/\
 """
     ucode_str_1 = \
-u("""\
+u"""\
   ⎛⎡1  2⎤⎞
 tr⎜⎢    ⎥⎟
   ⎝⎣3  4⎦⎠\
-""")
+"""
     ascii_str_2 = \
 """\
   /[1  2]\     /[2  4]\\
@@ -2657,11 +2656,11 @@ tr|[    ]| + tr|[    ]|
   \[3  4]/     \[6  8]/\
 """
     ucode_str_2 = \
-u("""\
+u"""\
   ⎛⎡1  2⎤⎞     ⎛⎡2  4⎤⎞
 tr⎜⎢    ⎥⎟ + tr⎜⎢    ⎥⎟
   ⎝⎣3  4⎦⎠     ⎝⎣6  8⎦⎠\
-""")
+"""
     assert pretty(Trace(X)) == ascii_str_1
     assert upretty(Trace(X)) == ucode_str_1
 
@@ -2715,13 +2714,13 @@ def test_pretty_piecewise():
 \             \
 """
     ucode_str = \
-u("""\
+u"""\
 ⎧x   for x < 1\n\
 ⎪             \n\
 ⎨ 2           \n\
 ⎪x   otherwise\n\
 ⎩             \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2735,13 +2734,13 @@ u("""\
  \\\\             /\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛⎧x   for x < 1⎞\n\
  ⎜⎪             ⎟\n\
 -⎜⎨ 2           ⎟\n\
  ⎜⎪x   otherwise⎟\n\
  ⎝⎩             ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2760,7 +2759,7 @@ x + |<            | + |< 2           | + 1\n\
                       \\\\             /    \
 """
     ucode_str = \
-u("""\
+u"""\
                       ⎛⎧x            ⎞    \n\
                       ⎜⎪─   for x < 2⎟    \n\
                       ⎜⎪y            ⎟    \n\
@@ -2770,7 +2769,7 @@ x + ⎜⎨            ⎟ + ⎜⎨ 2           ⎟ + 1\n\
                       ⎜⎪             ⎟    \n\
                       ⎜⎪1   otherwise⎟    \n\
                       ⎝⎩             ⎠    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2789,7 +2788,7 @@ x - |<            | + |< 2           | + 1\n\
                       \\\\             /    \
 """
     ucode_str = \
-u("""\
+u"""\
                       ⎛⎧x            ⎞    \n\
                       ⎜⎪─   for x < 2⎟    \n\
                       ⎜⎪y            ⎟    \n\
@@ -2799,7 +2798,7 @@ x - ⎜⎨            ⎟ + ⎜⎨ 2           ⎟ + 1\n\
                       ⎜⎪             ⎟    \n\
                       ⎜⎪1   otherwise⎟    \n\
                       ⎝⎩             ⎠    \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2811,11 +2810,11 @@ x*|<            |\n\
   \\\\y  otherwise/\
 """
     ucode_str = \
-u("""\
+u"""\
   ⎛⎧x  for x > 0⎞\n\
 x⋅⎜⎨            ⎟\n\
   ⎝⎩y  otherwise⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2834,7 +2833,7 @@ x⋅⎜⎨            ⎟\n\
                 \\\\             /\
 """
     ucode_str = \
-u("""\
+u"""\
                 ⎛⎧x            ⎞\n\
                 ⎜⎪─   for x < 2⎟\n\
                 ⎜⎪y            ⎟\n\
@@ -2844,7 +2843,7 @@ u("""\
                 ⎜⎪             ⎟\n\
                 ⎜⎪1   otherwise⎟\n\
                 ⎝⎩             ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2863,7 +2862,7 @@ u("""\
                  \\\\             /\
 """
     ucode_str = \
-u("""\
+u"""\
                  ⎛⎧x            ⎞\n\
                  ⎜⎪─   for x < 2⎟\n\
                  ⎜⎪y            ⎟\n\
@@ -2873,7 +2872,7 @@ u("""\
                  ⎜⎪             ⎟\n\
                  ⎜⎪1   otherwise⎟\n\
                  ⎝⎩             ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2892,7 +2891,7 @@ u("""\
 \  \\_|2, 2 \      1, 0 | y/             \
 """
     ucode_str = \
-u("""\
+u"""\
 ⎧                                │1│    \n\
 ⎪            0               for │─│ < 1\n\
 ⎪                                │y│    \n\
@@ -2902,7 +2901,7 @@ u("""\
 ⎪  ╭─╮0, 2 ⎛2, 1       │ 1⎞             \n\
 ⎪y⋅│╶┐     ⎜           │ ─⎟   otherwise \n\
 ⎩  ╰─╯2, 2 ⎝      1, 0 │ y⎠             \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2917,12 +2916,12 @@ u("""\
 \\\\y  otherwise/ \
 """
     ucode_str = \
-u("""\
+u"""\
                2\n\
 ⎛⎧x  for x > 0⎞ \n\
 ⎜⎨            ⎟ \n\
 ⎝⎩y  otherwise⎠ \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2933,9 +2932,9 @@ def test_pretty_seq():
 ()\
 """
     ucode_str = \
-u("""\
+u"""\
 ()\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2945,9 +2944,9 @@ u("""\
 []\
 """
     ucode_str = \
-u("""\
+u"""\
 []\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2958,9 +2957,9 @@ u("""\
 {}\
 """
     ucode_str = \
-u("""\
+u"""\
 {}\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert pretty(expr_2) == ascii_str
     assert upretty(expr) == ucode_str
@@ -2974,11 +2973,11 @@ u("""\
  x  \
 """
     ucode_str = \
-u("""\
+u"""\
 ⎛1 ⎞\n\
 ⎜─,⎟\n\
 ⎝x ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -2992,13 +2991,13 @@ u("""\
                cos (phi)  \
 """
     ucode_str = \
-u("""\
+u"""\
 ⎡                2   ⎤\n\
 ⎢ 2  1        sin (θ)⎥\n\
 ⎢x , ─, x, y, ───────⎥\n\
 ⎢    x           2   ⎥\n\
 ⎣             cos (φ)⎦\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3012,13 +3011,13 @@ u("""\
                cos (phi)  \
 """
     ucode_str = \
-u("""\
+u"""\
 ⎛                2   ⎞\n\
 ⎜ 2  1        sin (θ)⎟\n\
 ⎜x , ─, x, y, ───────⎟\n\
 ⎜    x           2   ⎟\n\
 ⎝             cos (φ)⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3032,13 +3031,13 @@ u("""\
                cos (phi)  \
 """
     ucode_str = \
-u("""\
+u"""\
 ⎛                2   ⎞\n\
 ⎜ 2  1        sin (θ)⎟\n\
 ⎜x , ─, x, y, ───────⎟\n\
 ⎜    x           2   ⎟\n\
 ⎝             cos (φ)⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3049,9 +3048,9 @@ u("""\
 {x: sin(x)}\
 """
     ucode_str = \
-u("""\
+u"""\
 {x: sin(x)}\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert pretty(expr_2) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3066,11 +3065,11 @@ u("""\
  x  y             \
 """
     ucode_str = \
-u("""\
+u"""\
 ⎧1  1        2   ⎫\n\
 ⎨─: ─, x: sin (x)⎬\n\
 ⎩x  y            ⎭\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert pretty(expr_2) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3084,10 +3083,10 @@ u("""\
 [x ]\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎡ 2⎤\n\
 ⎣x ⎦\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3098,10 +3097,10 @@ u("""\
 (x ,)\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎛ 2 ⎞\n\
 ⎝x ,⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3112,10 +3111,10 @@ u("""\
 (x ,)\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎛ 2 ⎞\n\
 ⎝x ,⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3127,11 +3126,11 @@ u("""\
 {x : 1}\
 """
     ucode_str = \
-u("""\
+u"""\
 ⎧ 2   ⎫\n\
 ⎨x : 1⎬\n\
 ⎩     ⎭\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert pretty(expr_2) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3189,7 +3188,7 @@ def test_pretty_sets():
     assert upretty(Range(0, 30, 1)) == ucode_str
 
     ascii_str = '{30, 29, ..., 2}'
-    ucode_str = u('{30, 29, …, 2}')
+    ucode_str = u'{30, 29, …, 2}'
     assert pretty(Range(30, 1, -1)) == ascii_str
     assert upretty(Range(30, 1, -1)) == ucode_str
 
@@ -3199,12 +3198,12 @@ def test_pretty_sets():
     assert upretty(Range(0, oo, 2)) == ucode_str
 
     ascii_str = '{oo, ..., 2, 0}'
-    ucode_str = u('{∞, …, 2, 0}')
+    ucode_str = u'{∞, …, 2, 0}'
     assert pretty(Range(oo, -2, -2)) == ascii_str
     assert upretty(Range(oo, -2, -2)) == ucode_str
 
     ascii_str = '{-2, -3, ..., -oo}'
-    ucode_str = u('{-2, -3, …, -∞}')
+    ucode_str = u'{-2, -3, …, -∞}'
     assert pretty(Range(-2, -oo, -1)) == ascii_str
     assert upretty(Range(-2, -oo, -1)) == ucode_str
 
@@ -3355,11 +3354,11 @@ def test_pretty_FourierSeries():
 """
 
     ucode_str = \
-u("""\
+u"""\
                       2⋅sin(3⋅x)    \n\
 2⋅sin(x) - sin(2⋅x) + ────────── + …\n\
                           3         \
-""")
+"""
 
     assert pretty(f) == ascii_str
     assert upretty(f) == ucode_str
@@ -3377,12 +3376,12 @@ x - -- + -- - -- + -- + O\\x /\n\
 """
 
     ucode_str = \
-u("""\
+u"""\
      2    3    4    5        \n\
     x    x    x    x     ⎛ 6⎞\n\
 x - ── + ── - ── + ── + O⎝x ⎠\n\
     2    3    4    5         \
-""")
+"""
 
     assert pretty(f) == ascii_str
     assert upretty(f) == ucode_str
@@ -3396,10 +3395,10 @@ def test_pretty_limits():
 x->oo \
 """
     ucode_str = \
-u("""\
+u"""\
 lim x\n\
 x─→∞ \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3411,11 +3410,11 @@ x─→∞ \
 x->0+  \
 """
     ucode_str = \
-u("""\
+u"""\
       2\n\
  lim x \n\
 x─→0⁺  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3427,11 +3426,11 @@ x─→0⁺  \
 x->0+x\
 """
     ucode_str = \
-u("""\
+u"""\
      1\n\
  lim ─\n\
 x─→0⁺x\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3443,11 +3442,11 @@ x─→0⁺x\
 x->0+\\  x   /\
 """
     ucode_str = \
-u("""\
+u"""\
      ⎛sin(x)⎞\n\
  lim ⎜──────⎟\n\
 x─→0⁺⎝  x   ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3459,11 +3458,11 @@ x─→0⁺⎝  x   ⎠\
 x->0-\\  x   /\
 """
     ucode_str = \
-u("""\
+u"""\
      ⎛sin(x)⎞\n\
  lim ⎜──────⎟\n\
 x─→0⁻⎝  x   ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3474,10 +3473,10 @@ x─→0⁻⎝  x   ⎠\
 x->0+            \
 """
     ucode_str = \
-u("""\
+u"""\
  lim (x + sin(x))\n\
 x─→0⁺            \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3489,11 +3488,11 @@ x─→0⁺            \
 \\x->0+ / \
 """
     ucode_str = \
-u("""\
+u"""\
         2\n\
 ⎛ lim x⎞ \n\
 ⎝x─→0⁺ ⎠ \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3505,11 +3504,11 @@ u("""\
 x->0+\\  y->0+\\2//\
 """
     ucode_str = \
-u("""\
+u"""\
      ⎛       ⎛y⎞⎞\n\
  lim ⎜x⋅ lim ⎜─⎟⎟\n\
 x─→0⁺⎝  y─→0⁺⎝2⎠⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3521,11 +3520,11 @@ x─→0⁺⎝  y─→0⁺⎝2⎠⎠\
   x->0+\\  y->0+\\2//\
 """
     ucode_str = \
-u("""\
+u"""\
        ⎛       ⎛y⎞⎞\n\
 2⋅ lim ⎜x⋅ lim ⎜─⎟⎟\n\
   x─→0⁺⎝  y─→0⁺⎝2⎠⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3538,10 +3537,10 @@ def test_pretty_ComplexRootOf():
 CRootOf\\x  + 11*x - 2, 0/\
 """
     ucode_str = \
-u("""\
+u"""\
        ⎛ 5              ⎞\n\
 CRootOf⎝x  + 11⋅x - 2, 0⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3555,10 +3554,10 @@ def test_pretty_RootSum():
 RootSum\\x  + 11*x - 2/\
 """
     ucode_str = \
-u("""\
+u"""\
        ⎛ 5           ⎞\n\
 RootSum⎝x  + 11⋅x - 2⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3570,10 +3569,10 @@ RootSum⎝x  + 11⋅x - 2⎠\
 RootSum\\x  + 11*x - 2, z -> e /\
 """
     ucode_str = \
-u("""\
+u"""\
        ⎛ 5                  z⎞\n\
 RootSum⎝x  + 11⋅x - 2, z ↦ ℯ ⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3587,9 +3586,9 @@ def test_GroebnerBasis():
 GroebnerBasis([], x, y, domain=ZZ, order=lex)\
 """
     ucode_str = \
-u("""\
+u"""\
 GroebnerBasis([], x, y, domain=ℤ, order=lex)\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3603,10 +3602,10 @@ GroebnerBasis([], x, y, domain=ℤ, order=lex)\
 GroebnerBasis\\[x  - x - 3*y + 1, y  - 2*x + y - 1], x, y, domain=ZZ, order=grlex/\
 """
     ucode_str = \
-u("""\
+u"""\
              ⎛⎡ 2                 2              ⎤                             ⎞\n\
 GroebnerBasis⎝⎣x  - x - 3⋅y + 1, y  - 2⋅x + y - 1⎦, x, y, domain=ℤ, order=grlex⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3619,10 +3618,10 @@ GroebnerBasis⎝⎣x  - x - 3⋅y + 1, y  - 2⋅x + y - 1⎦, x, y, domain=ℤ, 
 GroebnerBasis\\[2*x - y  - y + 1, y  + 2*y  - 3*y  - 16*y + 7], x, y, domain=ZZ, order=lex/\
 """
     ucode_str = \
-u("""\
+u"""\
              ⎛⎡       2           4      3      2           ⎤                           ⎞\n\
 GroebnerBasis⎝⎣2⋅x - y  - y + 1, y  + 2⋅y  - 3⋅y  - 16⋅y + 7⎦, x, y, domain=ℤ, order=lex⎠\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -3814,7 +3813,7 @@ def test_pretty_sum():
 k = 0   \
 """
     ucode_str = \
-u("""\
+u"""\
   n     \n\
  ___    \n\
  ╲      \n\
@@ -3823,7 +3822,7 @@ u("""\
  ╱      \n\
  ‾‾‾    \n\
 k = 0   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3847,7 +3846,7 @@ ______            \n\
  k = 0            \
 """
     ucode_str = \
-u("""\
+u"""\
    n            \n\
   n             \n\
 ______          \n\
@@ -3863,7 +3862,7 @@ ______          \n\
 ╱               \n\
 ‾‾‾‾‾‾          \n\
 k = 0           \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3894,7 +3893,7 @@ k = 0           \
   k = 0             \
 """
     ucode_str = \
-u("""\
+u"""\
 ∞                 \n\
 ⌠                 \n\
 ⎮   x             \n\
@@ -3914,7 +3913,7 @@ u("""\
  ╱                \n\
  ‾‾‾‾‾‾           \n\
  k = 0            \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3947,7 +3946,7 @@ k = n  + n + x  + x + - + -           \n\
                       x   n           \
 """
     ucode_str = \
-u("""\
+u"""\
           ∞                          \n\
           ⌠                          \n\
           ⎮   x                      \n\
@@ -3969,7 +3968,7 @@ u("""\
      2        2       1   x          \n\
 k = n  + n + x  + x + ─ + ─          \n\
                       x   n          \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -3995,7 +3994,7 @@ n  + n + x  + x + - + -           \n\
          k = 0                    \
 """
     ucode_str = \
-u("""\
+u"""\
  2        2       1   x          \n\
 n  + n + x  + x + ─ + ─          \n\
                   x   n          \n\
@@ -4012,7 +4011,7 @@ n  + n + x  + x + ─ + ─          \n\
          ╱                       \n\
          ‾‾‾‾‾‾                  \n\
          k = 0                   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4027,7 +4026,7 @@ n  + n + x  + x + ─ + ─          \n\
 x = 0  \
 """
     ucode_str = \
-u("""\
+u"""\
   ∞    \n\
  ___   \n\
  ╲     \n\
@@ -4036,14 +4035,14 @@ u("""\
  ╱     \n\
  ‾‾‾   \n\
 x = 0  \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = Sum(x**2, (x, 0, oo))
     ascii_str = \
-u("""\
+u"""\
   oo    \n\
  ___    \n\
  \\  `   \n\
@@ -4051,9 +4050,9 @@ u("""\
   /   x \n\
  /__,   \n\
 x = 0   \
-""")
+"""
     ucode_str = \
-u("""\
+u"""\
   ∞     \n\
  ___    \n\
  ╲      \n\
@@ -4062,7 +4061,7 @@ u("""\
  ╱      \n\
  ‾‾‾    \n\
 x = 0   \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4080,7 +4079,7 @@ x = 0   \
 x = 0  \
 """
     ucode_str = \
-u("""\
+u"""\
   ∞    \n\
  ____  \n\
  ╲     \n\
@@ -4091,7 +4090,7 @@ u("""\
  ╱     \n\
  ‾‾‾‾  \n\
 x = 0  \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4110,7 +4109,7 @@ ____    \n\
 x = 0   \
 """
     ucode_str = \
-u("""\
+u"""\
   ∞     \n\
  ____   \n\
  ╲      \n\
@@ -4121,7 +4120,7 @@ u("""\
  ╱      \n\
  ‾‾‾‾   \n\
 x = 0   \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4141,7 +4140,7 @@ ____          \n\
 x = 0         \
 """
     ucode_str = \
-u("""\
+u"""\
   ∞           \n\
 _____         \n\
 ╲             \n\
@@ -4154,7 +4153,7 @@ _____         \n\
 ╱             \n\
 ‾‾‾‾‾         \n\
 x = 0         \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4173,7 +4172,7 @@ ____    \n\
 x = 0   \
 """
     ucode_str = \
-u("""\
+u"""\
   ∞     \n\
  ____   \n\
  ╲      \n\
@@ -4184,7 +4183,7 @@ u("""\
  ╱      \n\
  ‾‾‾‾   \n\
 x = 0   \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4203,7 +4202,7 @@ ____      \n\
 x = 0     \
 """
     ucode_str = \
-u("""\
+u"""\
   ∞       \n\
  ____     \n\
  ╲        \n\
@@ -4214,7 +4213,7 @@ u("""\
  ╱        \n\
  ‾‾‾‾     \n\
 x = 0     \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4233,7 +4232,7 @@ ____  ____     \n\
 y = 1 x = 0    \
 """
     ucode_str = \
-u("""\
+u"""\
   2     ∞      \n\
 ____  ____     \n\
 ╲     ╲        \n\
@@ -4244,7 +4243,7 @@ ____  ____     \n\
 ╱     ╱        \n\
 ‾‾‾‾  ‾‾‾‾     \n\
 y = 1 x = 0    \
-""")
+"""
     expr = Sum(1/(1 + 1/(
         1 + 1/k)) + 1, (k, 111, 1 + 1/n), (k, 1/(1 + m), oo)) + 1/(1 + 1/k)
     ascii_str = \
@@ -4267,7 +4266,7 @@ k = -----                                \n\
     m + 1                                \
 """
     ucode_str = \
-u("""\
+u"""\
                1                         \n\
            1 + ─                         \n\
     ∞          n                         \n\
@@ -4286,7 +4285,7 @@ u("""\
       1   k = 111                        \n\
 k = ─────                                \n\
     m + 1                                \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4304,13 +4303,13 @@ kg*m \n\
 """
 
     unicode_str = \
-u("""\
+u"""\
     2\n\
 kg⋅m \n\
 ─────\n\
    2 \n\
   s  \
-""")
+"""
     assert upretty(expr) == unicode_str
     assert pretty(expr) == ascii_str
 
@@ -4324,10 +4323,10 @@ def test_pretty_Subs():
       |x=phi \
 """
     unicode_str = \
-u("""\
+u"""\
 (f(x))│   2\n\
       │x=φ \
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == unicode_str
@@ -4340,11 +4339,11 @@ u("""\
 \\dx      /|x=0\
 """
     unicode_str = \
-u("""\
+u"""\
 ⎛d       ⎞│   \n\
 ⎜──(f(x))⎟│   \n\
 ⎝dx      ⎠│x=0\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == unicode_str
@@ -4359,13 +4358,13 @@ u("""\
 \\   y    /|x=0, y=1/2\
 """
     unicode_str = \
-u("""\
+u"""\
 ⎛d       ⎞│          \n\
 ⎜──(f(x))⎟│          \n\
 ⎜dx      ⎟│          \n\
 ⎜────────⎟│          \n\
 ⎝   y    ⎠│x=0, y=1/2\
-""")
+"""
 
     assert pretty(expr) == ascii_str
     assert upretty(expr) == unicode_str
@@ -4380,11 +4379,11 @@ def test_gammas():
 def test_hyper():
     expr = hyper((), (), z)
     ucode_str = \
-u("""\
+u"""\
  ┌─  ⎛  │  ⎞\n\
  ├─  ⎜  │ z⎟\n\
 0╵ 0 ⎝  │  ⎠\
-""")
+"""
     ascii_str = \
 """\
   _         \n\
@@ -4397,11 +4396,11 @@ u("""\
 
     expr = hyper((), (1,), x)
     ucode_str = \
-u("""\
+u"""\
  ┌─  ⎛  │  ⎞\n\
  ├─  ⎜  │ x⎟\n\
 0╵ 1 ⎝1 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
   _         \n\
@@ -4414,11 +4413,11 @@ u("""\
 
     expr = hyper([2], [1], x)
     ucode_str = \
-u("""\
+u"""\
  ┌─  ⎛2 │  ⎞\n\
  ├─  ⎜  │ x⎟\n\
 1╵ 1 ⎝1 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
   _         \n\
@@ -4431,13 +4430,13 @@ u("""\
 
     expr = hyper((pi/3, -2*k), (3, 4, 5, -3), x)
     ucode_str = \
-u("""\
+u"""\
      ⎛  π         │  ⎞\n\
  ┌─  ⎜  ─, -2⋅k   │  ⎟\n\
  ├─  ⎜  3         │ x⎟\n\
 2╵ 4 ⎜            │  ⎟\n\
      ⎝3, 4, 5, -3 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
                       \n\
@@ -4452,11 +4451,11 @@ u("""\
 
     expr = hyper((pi, S('2/3'), -2*k), (3, 4, 5, -3), x**2)
     ucode_str = \
-u("""\
+u"""\
  ┌─  ⎛π, 2/3, -2⋅k │  2⎞\n\
  ├─  ⎜             │ x ⎟\n\
 3╵ 4 ⎝3, 4, 5, -3  │   ⎠\
-""")
+"""
     ascii_str = \
 """\
   _                      \n\
@@ -4469,7 +4468,7 @@ u("""\
 
     expr = hyper([1, 2], [3, 4], 1/(1/(1/(1/x + 1) + 1) + 1))
     ucode_str = \
-u("""\
+u"""\
      ⎛     │       1      ⎞\n\
      ⎜     │ ─────────────⎟\n\
      ⎜     │         1    ⎟\n\
@@ -4479,7 +4478,7 @@ u("""\
      ⎜     │             1⎟\n\
      ⎜     │         1 + ─⎟\n\
      ⎝     │             x⎠\
-""")
+"""
 
     ascii_str = \
 """\
@@ -4501,11 +4500,11 @@ u("""\
 def test_meijerg():
     expr = meijerg([pi, pi, x], [1], [0, 1], [1, 2, 3], z)
     ucode_str = \
-u("""\
+u"""\
 ╭─╮2, 3 ⎛π, π, x     1    │  ⎞\n\
 │╶┐     ⎜                 │ z⎟\n\
 ╰─╯4, 5 ⎝ 0, 1    1, 2, 3 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
  __2, 3 /pi, pi, x     1    |  \\\n\
@@ -4517,13 +4516,13 @@ u("""\
 
     expr = meijerg([1, pi/7], [2, pi, 5], [], [], z**2)
     ucode_str = \
-u("""\
+u"""\
         ⎛   π          │   ⎞\n\
 ╭─╮0, 2 ⎜1, ─  2, π, 5 │  2⎟\n\
 │╶┐     ⎜   7          │ z ⎟\n\
 ╰─╯5, 0 ⎜              │   ⎟\n\
         ⎝              │   ⎠\
-""")
+"""
     ascii_str = \
 """\
         /   pi           |   \\\n\
@@ -4536,11 +4535,11 @@ u("""\
     assert upretty(expr) == ucode_str
 
     ucode_str = \
-u("""\
+u"""\
 ╭─╮ 1, 10 ⎛1, 1, 1, 1, 1, 1, 1, 1, 1, 1  1 │  ⎞\n\
 │╶┐       ⎜                                │ z⎟\n\
 ╰─╯11,  2 ⎝             1                1 │  ⎠\
-""")
+"""
     ascii_str = \
 """\
  __ 1, 10 /1, 1, 1, 1, 1, 1, 1, 1, 1, 1  1 |  \\\n\
@@ -4555,7 +4554,7 @@ u("""\
     expr = meijerg([1, 2, ], [4, 3], [3], [4, 5], 1/(1/(1/(1/x + 1) + 1) + 1))
 
     ucode_str = \
-u("""\
+u"""\
         ⎛           │       1      ⎞\n\
         ⎜           │ ─────────────⎟\n\
         ⎜           │         1    ⎟\n\
@@ -4565,7 +4564,7 @@ u("""\
         ⎜           │             1⎟\n\
         ⎜           │         1 + ─⎟\n\
         ⎝           │             x⎠\
-""")
+"""
 
     ascii_str = \
 """\
@@ -4586,7 +4585,7 @@ u("""\
     expr = Integral(expr, x)
 
     ucode_str = \
-u("""\
+u"""\
 ⌠                                        \n\
 ⎮         ⎛           │       1      ⎞   \n\
 ⎮         ⎜           │ ─────────────⎟   \n\
@@ -4598,7 +4597,7 @@ u("""\
 ⎮         ⎜           │         1 + ─⎟   \n\
 ⎮         ⎝           │             x⎠   \n\
 ⌡                                        \
-""")
+"""
 
     ascii_str = \
 """\
@@ -4631,10 +4630,10 @@ def test_noncommutative():
 A*B*C  \
 """
     ucode_str = \
-u("""\
+u"""\
      -1\n\
 A⋅B⋅C  \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4645,10 +4644,10 @@ A⋅B⋅C  \
 C  *A*B\
 """
     ucode_str = \
-u("""\
+u"""\
  -1    \n\
 C  ⋅A⋅B\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4659,10 +4658,10 @@ C  ⋅A⋅B\
 A*C  *B\
 """
     ucode_str = \
-u("""\
+u"""\
    -1  \n\
 A⋅C  ⋅B\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4675,12 +4674,12 @@ A*C  *B\n\
    x   \
 """
     ucode_str = \
-u("""\
+u"""\
    -1  \n\
 A⋅C  ⋅B\n\
 ───────\n\
    x   \
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4698,11 +4697,11 @@ atan2|-------, \\/ x |\n\
      \\   20         /\
 """
     ucode_str = \
-u("""\
+u"""\
      ⎛√2⋅y    ⎞\n\
 atan2⎜────, √x⎟\n\
      ⎝ 20     ⎠\
-""")
+"""
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
@@ -4744,11 +4743,11 @@ K|-----|\n\
  \z + 1/\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛  1  ⎞\n\
 K⎜─────⎟\n\
  ⎝z + 1⎠\
-""")
+"""
     expr = elliptic_k(1/(z + 1))
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4760,11 +4759,11 @@ F|1|-----|\n\
  \ |z + 1/\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛ │  1  ⎞\n\
 F⎜1│─────⎟\n\
  ⎝ │z + 1⎠\
-""")
+"""
     expr = elliptic_f(1, 1/(1 + z))
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4776,11 +4775,11 @@ E|-----|\n\
  \z + 1/\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛  1  ⎞\n\
 E⎜─────⎟\n\
  ⎝z + 1⎠\
-""")
+"""
     expr = elliptic_e(1/(z + 1))
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4792,11 +4791,11 @@ E|1|-----|\n\
  \ |z + 1/\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛ │  1  ⎞\n\
 E⎜1│─────⎟\n\
  ⎝ │z + 1⎠\
-""")
+"""
     expr = elliptic_e(1, 1/(1 + z))
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4808,11 +4807,11 @@ Pi|3|-|\n\
   \ |x/\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛ │4⎞\n\
 Π⎜3│─⎟\n\
  ⎝ │x⎠\
-""")
+"""
     expr = elliptic_pi(3, 4/x)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4824,11 +4823,11 @@ Pi|3; -|6|\n\
   \   x| /\
 """
     ucode_str = \
-u("""\
+u"""\
  ⎛   4│ ⎞\n\
 Π⎜3; ─│6⎟\n\
  ⎝   x│ ⎠\
-""")
+"""
     expr = elliptic_pi(3, 4/x, 6)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -4878,13 +4877,13 @@ def test_issue_6359():
 \/       / \
 """
     assert upretty(Integral(x**2, x)**2) == \
-u("""\
+u"""\
          2
 ⎛⌠      ⎞ \n\
 ⎜⎮  2   ⎟ \n\
 ⎜⎮ x  dx⎟ \n\
 ⎝⌡      ⎠ \
-""")
+"""
 
     assert pretty(Sum(x**2, (x, 0, 1))**2) == \
 """\
@@ -4898,7 +4897,7 @@ u("""\
 \\x = 0   / \
 """
     assert upretty(Sum(x**2, (x, 0, 1))**2) == \
-u("""\
+u"""\
           2
 ⎛  1     ⎞ \n\
 ⎜ ___    ⎟ \n\
@@ -4908,7 +4907,7 @@ u("""\
 ⎜ ╱      ⎟ \n\
 ⎜ ‾‾‾    ⎟ \n\
 ⎝x = 0   ⎠ \
-""")
+"""
 
     assert pretty(Product(x**2, (x, 1, 2))**2) == \
 """\
@@ -4921,7 +4920,7 @@ u("""\
 \\x = 1    / \
 """
     assert upretty(Product(x**2, (x, 1, 2))**2) == \
-u("""\
+u"""\
            2
 ⎛  2      ⎞ \n\
 ⎜┬────┬   ⎟ \n\
@@ -4929,7 +4928,7 @@ u("""\
 ⎜│    │ x ⎟ \n\
 ⎜│    │   ⎟ \n\
 ⎝x = 1    ⎠ \
-""")
+"""
 
     f = Function('f')
     assert pretty(Derivative(f(x), x)**2) == \
@@ -4940,12 +4939,12 @@ u("""\
 \\dx      / \
 """
     assert upretty(Derivative(f(x), x)**2) == \
-u("""\
+u"""\
           2
 ⎛d       ⎞ \n\
 ⎜──(f(x))⎟ \n\
 ⎝dx      ⎠ \
-""")
+"""
 
 def test_issue_6739():
     ascii_str = \
@@ -4956,11 +4955,11 @@ def test_issue_6739():
 \/ x \
 """
     ucode_str = \
-u("""\
+u"""\
 1 \n\
 ──\n\
 √x\
-""")
+"""
     assert pretty(1/sqrt(x)) == ascii_str
     assert upretty(1/sqrt(x)) == ucode_str
 
@@ -5008,17 +5007,17 @@ def test_categories():
         "EmptySet(), id:A2-->A2: EmptySet(), id:A3-->A3: " \
         "EmptySet(), f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet()}"
 
-    assert upretty(d) == u("{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, " \
-        "id:A₂——▶A₂: ∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}")
+    assert upretty(d) == u"{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, " \
+        u"id:A₂——▶A₂: ∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}"
 
     d = Diagram({f1: "unique", f2: S.EmptySet}, {f2 * f1: "unique"})
     assert pretty(d) == "{f2*f1:A1-->A3: EmptySet(), id:A1-->A1: " \
         "EmptySet(), id:A2-->A2: EmptySet(), id:A3-->A3: " \
         "EmptySet(), f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet()}" \
         " ==> {f2*f1:A1-->A3: {unique}}"
-    assert upretty(d) == u("{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, id:A₂——▶A₂: " \
-        "∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}" \
-        " ══▶ {f₂∘f₁:A₁——▶A₃: {unique}}")
+    assert upretty(d) == u"{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, id:A₂——▶A₂: " \
+        u"∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}" \
+        u" ══▶ {f₂∘f₁:A₁——▶A₃: {unique}}"
 
     grid = DiagramGrid(d)
     assert pretty(grid) == "A1  A2\n      \nA3    "
@@ -5031,10 +5030,10 @@ def test_PrettyModules():
     M = F.submodule([x, y], [1, x**2])
 
     ucode_str = \
-u("""\
+u"""\
        2\n\
 ℚ[x, y] \
-""")
+"""
     ascii_str = \
 """\
         2\n\
@@ -5045,10 +5044,10 @@ QQ[x, y] \
     assert pretty(F) == ascii_str
 
     ucode_str = \
-u("""\
+u"""\
 ╱        ⎡    2⎤╲\n\
 ╲[x, y], ⎣1, x ⎦╱\
-""")
+"""
     ascii_str = \
 """\
               2  \n\
@@ -5061,10 +5060,10 @@ u("""\
     I = R.ideal(x**2, y)
 
     ucode_str = \
-u("""\
+u"""\
 ╱ 2   ╲\n\
 ╲x , y╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -5078,13 +5077,13 @@ u("""\
     Q = F / M
 
     ucode_str = \
-u("""\
+u"""\
             2    \n\
      ℚ[x, y]     \n\
 ─────────────────\n\
 ╱        ⎡    2⎤╲\n\
 ╲[x, y], ⎣1, x ⎦╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -5099,12 +5098,12 @@ u("""\
     assert pretty(Q) == ascii_str
 
     ucode_str = \
-u("""\
+u"""\
 ╱⎡    3⎤                                                ╲\n\
 │⎢   x ⎥   ╱        ⎡    2⎤╲           ╱        ⎡    2⎤╲│\n\
 │⎢1, ──⎥ + ╲[x, y], ⎣1, x ⎦╱, [2, y] + ╲[x, y], ⎣1, x ⎦╱│\n\
 ╲⎣   2 ⎦                                                ╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -5119,12 +5118,12 @@ def test_QuotientRing():
     R = QQ.old_poly_ring(x)/[x**2 + 1]
 
     ucode_str = \
-u("""\
+u"""\
   ℚ[x]  \n\
 ────────\n\
 ╱ 2    ╲\n\
 ╲x  + 1╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -5138,10 +5137,10 @@ u("""\
     assert pretty(R) == ascii_str
 
     ucode_str = \
-u("""\
+u"""\
     ╱ 2    ╲\n\
 1 + ╲x  + 1╱\
-""")
+"""
 
     ascii_str = \
 """\
@@ -5161,10 +5160,10 @@ def test_Homomorphism():
     expr = homomorphism(R.free_module(1), R.free_module(1), [0])
 
     ucode_str = \
-u("""\
+u"""\
           1         1\n\
 [0] : ℚ[x]  ──> ℚ[x] \
-""")
+"""
 
     ascii_str = \
 """\
@@ -5178,11 +5177,11 @@ u("""\
     expr = homomorphism(R.free_module(2), R.free_module(2), [0, 0])
 
     ucode_str = \
-u("""\
+u"""\
 ⎡0  0⎤       2         2\n\
 ⎢    ⎥ : ℚ[x]  ──> ℚ[x] \n\
 ⎣0  0⎦                  \
-""")
+"""
 
     ascii_str = \
 """\
@@ -5197,12 +5196,12 @@ u("""\
     expr = homomorphism(R.free_module(1), R.free_module(1) / [[x]], [0])
 
     ucode_str = \
-u("""\
+u"""\
                     1\n\
           1     ℚ[x] \n\
 [0] : ℚ[x]  ──> ─────\n\
                 <[x]>\
-""")
+"""
 
     ascii_str = \
 """\
@@ -5262,13 +5261,13 @@ def test_issue_8292():
     from sympy.core import sympify
     e = sympify('((x+x**4)/(x-1))-(2*(x-1)**4/(x-1)**4)', evaluate=False)
     ucode_str = \
-u("""\
+u"""\
            4    4    \n\
   2⋅(x - 1)    x  + x\n\
 - ────────── + ──────\n\
           4    x - 1 \n\
    (x - 1)           \
-""")
+"""
     ascii_str = \
 """\
            4    4    \n\
@@ -5284,11 +5283,11 @@ u("""\
 def test_issue_4335():
     expr = -y(x).diff(x)
     ucode_str = \
-u("""\
+u"""\
  d       \n\
 -──(y(x))\n\
  dx      \
-""")
+"""
     ascii_str = \
 """\
   d       \n\
@@ -5303,13 +5302,13 @@ def test_issue_8344():
     from sympy.core import sympify
     e = sympify('2*x*y**2/1**2 + 1', evaluate=False)
     ucode_str = \
-u("""\
+u"""\
      2    \n\
 2⋅x⋅y     \n\
 ────── + 1\n\
    2      \n\
   1       \
-""")
+"""
     assert upretty(e) == ucode_str
 
 
@@ -5318,36 +5317,36 @@ def test_issue_6324():
     y = Pow(10, -2, evaluate=False)
     e = Mul(x, y, evaluate=False)
     ucode_str = \
-u("""\
+u"""\
   3\n\
  2 \n\
 ───\n\
   2\n\
 10 \
-""")
+"""
     assert upretty(e) == ucode_str
 
 
 def test_issue_7927():
     e = sin(x/2)**cos(x/2)
     ucode_str = \
-u("""\
+u"""\
            ⎛x⎞\n\
         cos⎜─⎟\n\
            ⎝2⎠\n\
 ⎛   ⎛x⎞⎞      \n\
 ⎜sin⎜─⎟⎟      \n\
 ⎝   ⎝2⎠⎠      \
-""")
+"""
     assert upretty(e) == ucode_str
     e = sin(x)**(S(11)/13)
     ucode_str = \
-u("""\
+u"""\
         11\n\
         ──\n\
         13\n\
 (sin(x))  \
-""")
+"""
     assert upretty(e) == ucode_str
 
 
@@ -5356,13 +5355,13 @@ def test_issue_6134():
 
     e = lamda*x*Integral(phi(t)*pi*sin(pi*t), (t, 0, 1)) + lamda*x**2*Integral(phi(t)*2*pi*sin(2*pi*t), (t, 0, 1))
     ucode_str = \
-u("""\
+u"""\
      1                              1                   \n\
    2 ⌠                              ⌠                   \n\
 λ⋅x ⋅⎮ 2⋅π⋅φ(t)⋅sin(2⋅π⋅t) dt + λ⋅x⋅⎮ π⋅φ(t)⋅sin(π⋅t) dt\n\
      ⌡                              ⌡                   \n\
      0                              0                   \
-""")
+"""
     assert upretty(e) == ucode_str
 
 

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,7 +1,6 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
     pi, GoldenRatio, EulerGamma, Sum, Eq, Ne, Ge, Lt, Float
-from sympy.core.compatibility import u
 from sympy.printing.mathml import mathml, MathMLPrinter
 
 from sympy.utilities.pytest import raises

--- a/sympy/strategies/branch/tests/test_core.py
+++ b/sympy/strategies/branch/tests/test_core.py
@@ -36,8 +36,8 @@ def test_exhaust():
     assert set(brl(5)) == {0, 10}
 
 def test_debug():
-    from sympy.core.compatibility import StringIO
-    file = StringIO()
+    import io
+    file = io.StringIO()
     rl = debug(posdec, file)
     list(rl(5))
     log = file.getvalue()

--- a/sympy/strategies/tests/test_core.py
+++ b/sympy/strategies/tests/test_core.py
@@ -56,8 +56,8 @@ def test_do_one():
     assert rule(rule(1)) == 3
 
 def test_debug():
-    from sympy.core.compatibility import StringIO
-    file = StringIO()
+    import io
+    file = io.StringIO()
     rl = debug(posdec, file)
     rl(5)
     log = file.getvalue()

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -80,12 +80,13 @@ unsurmountable issues that can only be tackled with dedicated code generator:
 
 from __future__ import print_function, division
 
+import io
 import os
 import textwrap
 
 from sympy import __version__ as sympy_version
 from sympy.core import Symbol, S, Expr, Tuple, Equality, Function
-from sympy.core.compatibility import is_sequence, StringIO, string_types
+from sympy.core.compatibility import is_sequence, string_types
 from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.ccode import ccode, CCodePrinter
 from sympy.printing.fcode import fcode, FCodePrinter
@@ -659,7 +660,7 @@ class CodeGen(object):
             result = []
             for dump_fn in self.dump_fns:
                 filename = "%s.%s" % (prefix, dump_fn.extension)
-                contents = StringIO()
+                contents = io.StringIO()
                 dump_fn(self, routines, contents, prefix, header, empty)
                 result.append((filename, contents.getvalue()))
             return result

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -609,11 +609,11 @@ def capture(func):
     '2\\n-\\nx\\n'
 
     """
-    from sympy.core.compatibility import StringIO
+    import io
     import sys
 
     stdout = sys.stdout
-    sys.stdout = file = StringIO()
+    sys.stdout = file = io.StringIO()
     try:
         func()
     finally:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -314,7 +314,6 @@ def translate(s, a, b=None, c=None):
     ========
 
     >>> from sympy.utilities.misc import translate
-    >>> from sympy.core.compatibility import unichr
     >>> abc = 'abc'
     >>> translate(abc, None, 'a')
     'bc'

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -14,6 +14,7 @@ Goals:
 
 from __future__ import print_function, division
 
+import io
 import os
 import sys
 import platform
@@ -1230,8 +1231,6 @@ class SymPyDocTests(object):
     def test_file(self, filename):
         clear_cache()
 
-        from sympy.core.compatibility import StringIO
-
         rel_name = filename[len(self._root_dir) + 1:]
         dirname, file = os.path.split(filename)
         module = rel_name.replace(os.sep, '.')[:-3]
@@ -1284,7 +1283,7 @@ class SymPyDocTests(object):
                     pdoctest.IGNORE_EXCEPTION_DETAIL)
             runner._checker = SymPyOutputChecker()
             old = sys.stdout
-            new = StringIO()
+            new = io.StringIO()
             sys.stdout = new
             # If the testing is normal, the doctests get importing magic to
             # provide the global namespace. If not normal (the default) then

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -1,6 +1,7 @@
 # Tests that require installed backends go into
 # sympy/test_external/test_autowrap
 
+import io
 import os
 import tempfile
 import shutil
@@ -11,7 +12,6 @@ from sympy.utilities.codegen import (CCodeGen, CodeGenArgumentListError,
                                      make_routine)
 from sympy.utilities.pytest import raises
 from sympy.core import symbols, Eq
-from sympy.core.compatibility import StringIO
 
 
 def get_string(dump_fn, routines, prefix="file"):
@@ -22,7 +22,7 @@ def get_string(dump_fn, routines, prefix="file"):
        The header and the empty lines are not generator to facilitate the
        testing of the output.
     """
-    output = StringIO()
+    output = io.StringIO()
     dump_fn(routines, output, prefix)
     source = output.getvalue()
     output.close()

--- a/sympy/utilities/tests/test_codegen_julia.py
+++ b/sympy/utilities/tests/test_codegen_julia.py
@@ -1,6 +1,7 @@
+import io
+
 from sympy.core import (S, symbols, Eq, pi, Catalan, EulerGamma, Lambda,
                         Dummy, Function)
-from sympy.core.compatibility import StringIO
 from sympy import erf, Integral, Piecewise
 from sympy import Equality
 from sympy.matrices import Matrix, MatrixSymbol
@@ -17,7 +18,7 @@ x, y, z = symbols('x,y,z')
 
 def test_empty_jl_code():
     code_gen = JuliaCodeGen()
-    output = StringIO()
+    output = io.StringIO()
     code_gen.dump_jl([], output, "file", header=False, empty=False)
     source = output.getvalue()
     assert source == ""
@@ -106,7 +107,7 @@ def test_jl_code_argument_order():
     expr = x + y
     routine = make_routine("test", expr, argument_sequence=[z, x, y], language="julia")
     code_gen = JuliaCodeGen()
-    output = StringIO()
+    output = io.StringIO()
     code_gen.dump_jl([routine], output, "test", header=False, empty=False)
     source = output.getvalue()
     expected = (

--- a/sympy/utilities/tests/test_codegen_octave.py
+++ b/sympy/utilities/tests/test_codegen_octave.py
@@ -1,6 +1,7 @@
+import io
+
 from sympy.core import (S, symbols, Eq, pi, Catalan, EulerGamma, Lambda,
                         Dummy, Function)
-from sympy.core.compatibility import StringIO
 from sympy import erf, Integral, Piecewise
 from sympy import Equality
 from sympy.matrices import Matrix, MatrixSymbol
@@ -17,7 +18,7 @@ x, y, z = symbols('x,y,z')
 
 def test_empty_m_code():
     code_gen = OctaveCodeGen()
-    output = StringIO()
+    output = io.StringIO()
     code_gen.dump_m([], output, "file", header=False, empty=False)
     source = output.getvalue()
     assert source == ""
@@ -102,7 +103,7 @@ def test_m_code_argument_order():
     expr = x + y
     routine = make_routine("test", expr, argument_sequence=[z, x, y], language="octave")
     code_gen = OctaveCodeGen()
-    output = StringIO()
+    output = io.StringIO()
     code_gen.dump_m([routine], output, "test", header=False, empty=False)
     source = output.getvalue()
     expected = (

--- a/sympy/utilities/timeutils.py
+++ b/sympy/utilities/timeutils.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 import timeit
 import math
 
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import range
 
 _scales = [1e0, 1e3, 1e6, 1e9]
 _units = [u's', u'ms', u'\N{GREEK SMALL LETTER MU}s', u'ns']

--- a/sympy/vector/dyadic.py
+++ b/sympy/vector/dyadic.py
@@ -1,9 +1,9 @@
 from sympy.vector.basisdependent import (BasisDependent, BasisDependentAdd,
                                          BasisDependentMul, BasisDependentZero)
 from sympy.core import S, Pow
+from sympy.core.compatibility import unicode
 from sympy.core.expr import AtomicExpr
 from sympy import ImmutableMatrix as Matrix
-from sympy.core.compatibility import u
 import sympy.vector
 
 
@@ -197,10 +197,10 @@ class BaseDyadic(Dyadic, AtomicExpr):
         obj._measure_number = 1
         obj._components = {obj: S(1)}
         obj._sys = vector1._sys
-        obj._pretty_form = u('(' + vector1._pretty_form + '|' +
-                             vector2._pretty_form + ')')
-        obj._latex_form = ('(' + vector1._latex_form + "{|}" +
-                           vector2._latex_form + ')')
+        obj._pretty_form = (u'(' + vector1._pretty_form + u'|' +
+            vector2._pretty_form + u')')
+        obj._latex_form = (u'(' + vector1._latex_form + u"{|}" +
+            vector2._latex_form + u')')
 
         return obj
 

--- a/sympy/vector/scalar.py
+++ b/sympy/vector/scalar.py
@@ -1,6 +1,6 @@
 from sympy.core import Expr, Symbol, S
 from sympy.core.sympify import _sympify
-from sympy.core.compatibility import u, range
+from sympy.core.compatibility import unicode, range
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.printing.precedence import PRECEDENCE
 
@@ -34,7 +34,7 @@ class BaseScalar(Expr):
         # The _id is used for equating purposes, and for hashing
         obj._id = (index, system)
         obj._name = obj.name = name
-        obj._pretty_form = u(pretty_str)
+        obj._pretty_form = unicode(pretty_str)
         obj._latex_form = latex_str
         obj._system = system
 

--- a/sympy/vector/tests/test_printing.py
+++ b/sympy/vector/tests/test_printing.py
@@ -3,7 +3,6 @@ from sympy import Integral, latex, Function
 from sympy import pretty as xpretty
 from sympy.vector import CoordSysCartesian, Vector, express
 from sympy.abc import a, b, c
-from sympy.core.compatibility import u_decode as u
 from sympy.utilities.pytest import XFAIL
 
 def pretty(expr):
@@ -33,64 +32,56 @@ v.append((a**2 + N.x)*N.i + N.k)
 v.append((a**2 + b)*N.i + 3*(C.y - c)*N.k)
 f = Function('f')
 v.append(N.j - (Integral(f(b)) - C.x**2)*N.k)
-upretty_v_8 = u(
-"""\
+upretty_v_8 = u"""\
 N_j + ⎛   2   ⌠        ⎞ N_k\n\
       ⎜C_x  - ⎮ f(b) db⎟    \n\
       ⎝       ⌡        ⎠    \
-""")
-pretty_v_8 = u(
-"""\
+"""
+pretty_v_8 = """\
 N_j + /         /       \\\n\
       |   2    |        |\n\
       |C_x  -  | f(b) db|\n\
       |        |        |\n\
       \\       /         / \
-""")
+"""
 
 v.append(N.i + C.k)
 v.append(express(N.i, C))
 v.append((a**2 + b)*N.i + (Integral(f(b)))*N.k)
-upretty_v_11 = u(
-"""\
+upretty_v_11 = u"""\
 ⎛ 2    ⎞ N_i + ⎛⌠        ⎞ N_k\n\
 ⎝a  + b⎠       ⎜⎮ f(b) db⎟    \n\
                ⎝⌡        ⎠    \
-""")
-pretty_v_11 = u(
-"""\
+"""
+pretty_v_11 = """\
 / 2    \\ + /  /       \\\n\
 \\a  + b/ N_i| |        |\n\
            | | f(b) db|\n\
            | |        |\n\
            \\/         / \
-""")
+"""
 
 for x in v:
     d.append(x | N.k)
 s = 3*N.x**2*C.y
-upretty_s = u(
-"""\
+upretty_s = u"""\
          2\n\
 3⋅C_y⋅N_x \
-""")
-pretty_s = u(
-"""\
+"""
+pretty_s = """\
          2\n\
 3*C_y*N_x \
-""")
+"""
 
 #This is the pretty form for ((a**2 + b)*N.i + 3*(C.y - c)*N.k) | N.k
-upretty_d_7 = u(
-"""\
+upretty_d_7 = u"""\
 ⎛ 2    ⎞ (N_i|N_k) + (-3⋅c + 3⋅C_y) (N_k|N_k)\n\
 ⎝a  + b⎠                                     \
-""")
-pretty_d_7 = u(
-"""\
+"""
+pretty_d_7 = """\
 / 2    \\ (N_i|N_k) + (3*C_y - 3*c) (N_k|N_k)\n\
 \\a  + b/                                    \
-""")
+"""
 
 
 def test_str_printing():

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -7,7 +7,7 @@ from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.basisdependent import (BasisDependent, BasisDependentAdd,
                                          BasisDependentMul, BasisDependentZero)
 from sympy.vector.dyadic import BaseDyadic, Dyadic, DyadicAdd
-from sympy.core.compatibility import u
+from sympy.core.compatibility import unicode
 
 
 class Vector(BasisDependent):
@@ -365,7 +365,7 @@ class BaseVector(Vector, AtomicExpr):
         obj._components = {obj: S(1)}
         obj._measure_number = S(1)
         obj._name = name
-        obj._pretty_form = u(pretty_str)
+        obj._pretty_form = unicode(pretty_str)
         obj._latex_form = latex_str
         obj._system = system
 


### PR DESCRIPTION
The `u()` and (in all but one case) the `u_decode` functions are not needed anymore because support goes back to 3.3. Many places weren't using these functions, so a lot of this is cleaning up imports. There is one case where `u_decode` is really needed as far as I could figure, but I think it is a special enough case to warrant pulling it out of `compatibility.py` and documenting why it is such an odd case, if for no other reason than we shouldn't be using these functions going forward if we are doing unicode correctly.
