### PR TITLE
clarify that nonzero = True implies a real number

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -66,8 +66,10 @@ Here follows a list of possible assumption names:
         divisor other than ``1`` or the number itself.  See [4]_.
 
     zero
+        object has the value of ``0``.
+
     nonzero
-        object is zero (not zero).
+        object is a real number that is not zero.
 
     rational
         object can have only values from the set


### PR DESCRIPTION
Reading the current version of the docs one would think `nonzero = True` has the same effect as `zero = False`. But there is a difference: nonzero = True implies the object is real (per line 199).  

Pointed out by asmeurer at https://stackoverflow.com/questions/37365141/declare-a-sympy-symbol-non-zero/37365769#comment62268728_37365769
