### PR TITLE
Intersection of null Range and an Interval returns EmptySet

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -552,8 +552,12 @@ class Range(Set):
             if not all(i.is_number for i in other.args[:2]):
                 return
 
+            # In case of null Range, return an EmptySet.
+            if self.size == 0:
+                return S.EmptySet
+
             # trim down to self's size, and represent
-            # as a Range with step 1
+            # as a Range with step 1.
             start = ceiling(max(other.inf, self.inf))
             if start not in other:
                 start += 1

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -314,6 +314,10 @@ def test_range_interval_intersection():
     assert Range(4).intersect(Interval.open(0, 3)) == Range(1, 3)
     assert Range(4).intersect(Interval.open(0.1, 0.5)) is S.EmptySet
 
+    # Null Range intersections
+    assert Range(0).intersect(Interval(0.2, 0.8)) is S.EmptySet
+    assert Range(0).intersect(Interval(-oo, oo)) is S.EmptySet
+
 
 def test_Integers_eval_imageset():
     ans = ImageSet(Lambda(x, 2*x + S(3)/7), S.Integers)


### PR DESCRIPTION
A null `Range` is a set with no elements. It is an empty `Range` object.
However, the current implementation doesn't demonstrate this fact in the `intersection` operation.

This PR is an attempt to reflect this behavior of a null `Range` object. 
Closes #11147 

**Current Implementation**

``` python
In []: Intersection(Range(0), Interval(0, 10))
# results in a NotImplementedError
In []: Intersection(S.Integers, Interval(0.2, 0.8))
# results in a NotImplementedError
```

 **New Implementation**

``` python
In []: Intersection(Range(0), FiniteSet(0, 10))
Out[]: EmptySet()

In []: Intersection(S.Integers, Interval(0.2, 0.8))
Out[]: EmptySet()
```

Ping @asmeurer @smichr @hargup @aktech 
