### PR TITLE
Fix latex(S.Naturals0)

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1566,7 +1566,7 @@ class LatexPrinter(Printer):
         return r"\mathbb{N}"
 
     def _print_Naturals0(self, n):
-        return r"\mathbb{N_0}"
+        return r"\mathbb{N}_0"
 
     def _print_Integers(self, i):
         return r"\mathbb{Z}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -659,7 +659,7 @@ def test_latex_Naturals():
 
 
 def test_latex_Naturals0():
-    assert latex(S.Naturals0) == r"\mathbb{N_0}"
+    assert latex(S.Naturals0) == r"\mathbb{N}_0"
 
 
 def test_latex_Integers():


### PR DESCRIPTION
Previously it returned \mathbb{N_0}. Now it returns \mathbb{N}_0. The 0 should
not be blackboard font. Also, for whatever reason, at least for me, LaTeX
renders \mathbb{N_0} with a subscript \nvdash instead of 0. This seems odd,
and I'm not sure if there is not some issue on my computer, but regardless,
the 0 should not be blackboard.
