### PR TITLE
Intersection of certain ImageSets with Intervals

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -212,7 +212,9 @@ class ImageSet(Set):
     Examples
     ========
 
-    >>> from sympy import Symbol, S, ImageSet, FiniteSet, Lambda
+    >>> from sympy import Symbol, S, pi, Dummy, Lambda
+    >>> from sympy.sets.sets import FiniteSet, Interval
+    >>> from sympy.sets.fancysets import ImageSet
 
     >>> x = Symbol('x')
     >>> N = S.Naturals
@@ -232,6 +234,12 @@ class ImageSet(Set):
     4
     9
     16
+
+    >>> n = Dummy('n')
+    >>> solutions = ImageSet(Lambda(n, n*pi), S.Integers) # solutions of sin(x) = 0
+    >>> dom = Interval(-1, 1)
+    >>> dom.intersect(solutions)
+    {0}
 
     See Also
     ========
@@ -406,13 +414,12 @@ class ImageSet(Set):
                                 solveset_real(im, n_)))
 
         elif isinstance(other, Interval):
-            from sympy.solvers.solveset import invert_real, invert_complex,
-            solveset
+            from sympy.solvers.solveset import (invert_real, invert_complex,
+                                                solveset)
 
             f = self.lamda.expr
             n = self.lamda.variables[0]
             base_set = self.base_set
-            inf, sup = other.inf, other.sup
             new_inf, new_sup = None, None
 
             if f.is_real:
@@ -420,8 +427,8 @@ class ImageSet(Set):
             else:
                 inverter = invert_complex
 
-            g1, h1 = inverter(f, inf, n)
-            g2, h2 = inverter(f, sup, n)
+            g1, h1 = inverter(f, other.inf, n)
+            g2, h2 = inverter(f, other.sup, n)
 
             if all(isinstance(i, FiniteSet) for i in (h1, h2)):
                 if g1 == n:

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -446,11 +446,17 @@ def test_imageset_intersect_interval():
     f1 = ImageSet(Lambda(n, n*pi), S.Integers)
     f2 = ImageSet(Lambda(n, 2*n), Interval(0, pi))
     f3 = ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers)
+    # complex expressions
+    f4 = ImageSet(Lambda(n, n*I*pi), S.Integers)
+    f5 = ImageSet(Lambda(n, 2*I*n*pi + pi/2), S.Integers)
 
     assert f1.intersect(Interval(-1, 1)) == FiniteSet(0)
-    assert f2.intersect(Interval( 1, 2)) == Interval(1, 2)
+    assert f2.intersect(Interval(1, 2)) == Interval(1, 2)
     assert f3.intersect(Interval(-1, 1)) == S.EmptySet
     assert f3.intersect(Interval(-5, 5)) == FiniteSet(-3*pi/2, pi/2)
+    assert f4.intersect(Interval(-1, 1)) == FiniteSet(0)
+    assert f4.intersect(Interval(1, 2)) == S.EmptySet
+    assert f5.intersect(Interval(0, 1)) == S.EmptySet
 
 
 def test_infinitely_indexed_set_3():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -5,7 +5,7 @@ from sympy.sets.sets import (FiniteSet, Interval, imageset, EmptySet, Union,
                              Intersection)
 from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
-                   Rational, sqrt, tan, log, Abs, I, Tuple)
+                   Rational, sqrt, tan, log, exp, Abs, I, Tuple)
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, y, z, t
@@ -449,6 +449,11 @@ def test_imageset_intersect_interval():
     # complex expressions
     f4 = ImageSet(Lambda(n, n*I*pi), S.Integers)
     f5 = ImageSet(Lambda(n, 2*I*n*pi + pi/2), S.Integers)
+    # non-linear expressions
+    f6 = ImageSet(Lambda(n, log(n)), S.Integers)
+    f7 = ImageSet(Lambda(n, n**2), S.Integers)
+    f8 = ImageSet(Lambda(n, Abs(n)), S.Integers)
+    f9 = ImageSet(Lambda(n, exp(n)), S.Naturals0)
 
     assert f1.intersect(Interval(-1, 1)) == FiniteSet(0)
     assert f2.intersect(Interval(1, 2)) == Interval(1, 2)
@@ -457,6 +462,10 @@ def test_imageset_intersect_interval():
     assert f4.intersect(Interval(-1, 1)) == FiniteSet(0)
     assert f4.intersect(Interval(1, 2)) == S.EmptySet
     assert f5.intersect(Interval(0, 1)) == S.EmptySet
+    assert f6.intersect(Interval(0, 1)) == FiniteSet(S.Zero, log(2))
+    assert f7.intersect(Interval(0, 10)) == Intersection(f7, Interval(0, 10))
+    assert f8.intersect(Interval(0, 2)) == Intersection(f8, Interval(0, 2))
+    assert f9.intersect(Interval(1, 2)) == Intersection(f9, Interval(1, 2))
 
 
 def test_infinitely_indexed_set_3():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -441,6 +441,18 @@ def test_imageset_intersect_real():
     assert s.intersect(S.Reals) == imageset(Lambda(n, 2*n*pi - pi/4), S.Integers)
 
 
+def test_imageset_intersect_interval():
+    from sympy.abc import n
+    f1 = ImageSet(Lambda(n, n*pi), S.Integers)
+    f2 = ImageSet(Lambda(n, 2*n), Interval(0, pi))
+    f3 = ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers)
+
+    assert f1.intersect(Interval(-1, 1)) == FiniteSet(0)
+    assert f2.intersect(Interval( 1, 2)) == Interval(1, 2)
+    assert f3.intersect(Interval(-1, 1)) == S.EmptySet
+    assert f3.intersect(Interval(-5, 5)) == FiniteSet(-3*pi/2, pi/2)
+
+
 def test_infinitely_indexed_set_3():
     from sympy.abc import n, m, t
     assert imageset(Lambda(m, 2*pi*m), S.Integers).intersect(


### PR DESCRIPTION
This PR is an attempt to return an evaluated `Intersection` result for the intersection of certain `ImageSet` and `Interval` objects.

The type of `ImageSet` objects which qualify for this evaluation needs to have a linear `Lambda` function in the concerned variable. 
The methodology used is explained [here](https://github.com/sympy/sympy/wiki/GSoC-2016-Solvers-Progress#minutes-of-meeting-2) 

For example,

``` python
In []: f = ImageSet(Lambda(n, 2*n*pi + pi/2), S.Integers)
```
### Current Implementation

``` python
In []: Intersection(f3, Interval(-1, 1))
Out[]: Intersection([-1, 1], ImageSet(Lambda(n, 2*pi*n + pi/2), Integers()))

In []: Intersection(f3, Interval(-10, 10))
Out[]: Intersection([-10, 10], ImageSet(Lambda(n, 2*pi*n + pi/2), Integers()))
```
### New Implementation

``` python
In []: Intersection(f3, Interval(-1, 1))
Out[]: EmptySet()

In []: Intersection(f3, Interval(-10, 10))
Out[]: {-3*pi/2, pi/2, 5*pi/2}
```

Ping @hargup @aktech @asmeurer @Shekharrajak 
