### PR TITLE
Performance improvement of _remove_repeated utility function

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -18,7 +18,8 @@ try:
     import mpmath
 except ImportError:
     raise ImportError("SymPy now depends on mpmath as an external library. "
-    "See http://docs.sympy.org/latest/install.html#mpmath for more information.")
+                      "See http://docs.sympy.org/latest/install.html#mpmath "
+                      "for more information.")
 
 from sympy.release import __version__
 

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -15,7 +15,6 @@ from __future__ import print_function, division
 from sympy.core.function import Function
 from sympy.functions import exp, Piecewise
 from sympy.tensor.indexed import Idx, Indexed
-from sympy.sets.sets import FiniteSet
 
 from sympy.core.compatibility import reduce
 
@@ -27,13 +26,13 @@ class IndexConformanceException(Exception):
 def _remove_repeated(inds):
     """Removes repeated objects from sequences
 
-    Returns a set of the unique objects and a tuple of all that have been
+    Returns a set of the unique objects and a set of all that have been
     removed.
 
     >>> from sympy.tensor.index_methods import _remove_repeated
     >>> l1 = [1, 2, 3, 2]
     >>> _remove_repeated(l1)
-    (set([1, 3]), (2,))
+    (set([1, 3]), set([2]))
 
     """
     ind_set = set()
@@ -78,7 +77,7 @@ def _get_indices_Mul(expr, return_dummies=False):
                 symmetry[pair] = s[pair]
 
     if return_dummies:
-        return inds, symmetry, dummies
+        return inds, symmetry, tuple(dummies)
     else:
         return inds, symmetry
 
@@ -374,12 +373,12 @@ def get_contraction_structure(expr):
 
     if isinstance(expr, Indexed):
         junk, key = _remove_repeated(expr.indices)
-        return {FiniteSet(*key) or None: {expr}}
+        return {tuple(key) or None: {expr}}
     elif expr.is_Atom:
         return {None: {expr}}
     elif expr.is_Mul:
         junk, junk, key = _get_indices_Mul(expr, return_dummies=True)
-        result = {FiniteSet(*key) or None: {expr}}
+        result = {tuple(key) or None: {expr}}
         # recurse on every factor
         nested = []
         for fac in expr.args:

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -36,14 +36,15 @@ def _remove_repeated(inds):
     (set([1, 3]), (2,))
 
     """
-    sum_index = {}
+    ind_set = set()
+    remove_set = set()
     for i in inds:
-        if i in sum_index:
-            sum_index[i] += 1
+        if i in ind_set:
+            remove_set.add(i)
         else:
-            sum_index[i] = 0
-    inds = [x for x in inds if not sum_index[x]]
-    return set(inds), tuple([ i for i in sum_index if sum_index[i] ])
+            ind_set.add(i)
+
+    return ind_set-remove_set, tuple(remove_set)
 
 
 def _get_indices_Mul(expr, return_dummies=False):

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -15,7 +15,7 @@ from __future__ import print_function, division
 from sympy.core.function import Function
 from sympy.functions import exp, Piecewise
 from sympy.tensor.indexed import Idx, Indexed
-
+from sympy.sets.sets import FiniteSet
 
 from sympy.core.compatibility import reduce
 
@@ -44,7 +44,7 @@ def _remove_repeated(inds):
         else:
             ind_set.add(i)
 
-    return ind_set-remove_set, tuple(remove_set)
+    return ind_set-remove_set, remove_set
 
 
 def _get_indices_Mul(expr, return_dummies=False):
@@ -374,12 +374,12 @@ def get_contraction_structure(expr):
 
     if isinstance(expr, Indexed):
         junk, key = _remove_repeated(expr.indices)
-        return {key or None: {expr}}
+        return {FiniteSet(*key) or None: {expr}}
     elif expr.is_Atom:
         return {None: {expr}}
     elif expr.is_Mul:
         junk, junk, key = _get_indices_Mul(expr, return_dummies=True)
-        result = {key or None: {expr}}
+        result = {FiniteSet(*key) or None: {expr}}
         # recurse on every factor
         nested = []
         for fac in expr.args:

--- a/sympy/tensor/tests/test_index_methods.py
+++ b/sympy/tensor/tests/test_index_methods.py
@@ -1,5 +1,6 @@
 from sympy.core import symbols, S, Pow, Function
 from sympy.functions import exp
+from sympy.sets.sets import FiniteSet
 from sympy.utilities.pytest import raises
 from sympy.tensor.indexed import Idx, IndexedBase
 from sympy.tensor.index_methods import IndexConformanceException
@@ -86,9 +87,10 @@ def test_get_contraction_structure_basic():
     i, j = Idx('i'), Idx('j')
     assert get_contraction_structure(x[i]*y[j]) == {None: set([x[i]*y[j]])}
     assert get_contraction_structure(x[i] + y[j]) == {None: set([x[i], y[j]])}
-    assert get_contraction_structure(x[i]*y[i]) == {(i,): set([x[i]*y[i]])}
     assert get_contraction_structure(
-        1 + x[i]*y[i]) == {None: set([S.One]), (i,): set([x[i]*y[i]])}
+        x[i]*y[i]) == {FiniteSet(i): set([x[i]*y[i]])}
+    assert get_contraction_structure(
+        1 + x[i]*y[i]) == {None: set([S.One]), FiniteSet(i): set([x[i]*y[i]])}
     assert get_contraction_structure(x[i]**y[i]) == {None: set([x[i]**y[i]])}
 
 
@@ -98,10 +100,11 @@ def test_get_contraction_structure_complex():
     A = IndexedBase('A')
     i, j, k = Idx('i'), Idx('j'), Idx('k')
     expr1 = y[i] + A[i, j]*x[j]
-    d1 = {None: set([y[i]]), (j,): set([A[i, j]*x[j]])}
+    d1 = {None: set([y[i]]), FiniteSet(j): set([A[i, j]*x[j]])}
     assert get_contraction_structure(expr1) == d1
     expr2 = expr1*A[k, i] + x[k]
-    d2 = {None: set([x[k]]), (i,): set([expr1*A[k, i]]), expr1*A[k, i]: [d1]}
+    d2 = {None: set([x[k]]), FiniteSet(i): set([expr1*A[k, i]]),
+          expr1*A[k, i]: [d1]}
     assert get_contraction_structure(expr2) == d2
 
 
@@ -113,8 +116,8 @@ def test_contraction_structure_simple_Pow():
     assert get_contraction_structure(ii_jj) == {
         None: set([ii_jj]),
         ii_jj: [
-            {(i,): set([x[i, i]])},
-            {(j,): set([y[j, j]])}
+            {FiniteSet(i): set([x[i, i]])},
+            {FiniteSet(j): set([y[j, j]])}
         ]
     }
 
@@ -129,18 +132,18 @@ def test_contraction_structure_Mul_and_Pow():
     ij_i = (x[i]*y[j])**(y[i])
     assert get_contraction_structure(ij_i) == {None: set([ij_i])}
     j_ij_i = x[j]*(x[i]*y[j])**(y[i])
-    assert get_contraction_structure(j_ij_i) == {(j,): set([j_ij_i])}
+    assert get_contraction_structure(j_ij_i) == {FiniteSet(j): set([j_ij_i])}
     j_i_ji = x[j]*x[i]**(y[j]*x[i])
-    assert get_contraction_structure(j_i_ji) == {(j,): set([j_i_ji])}
+    assert get_contraction_structure(j_i_ji) == {FiniteSet(j): set([j_i_ji])}
     ij_exp_kki = x[i]*y[j]*exp(y[i]*y[k, k])
     result = get_contraction_structure(ij_exp_kki)
     expected = {
-        (i,): set([ij_exp_kki]),
+        FiniteSet(i): set([ij_exp_kki]),
         ij_exp_kki: [{
                      None: set([exp(y[i]*y[k, k])]),
                 exp(y[i]*y[k, k]): [{
                     None: set([y[i]*y[k, k]]),
-                    y[i]*y[k, k]: [{(k,): set([y[k, k]])}]
+                    y[i]*y[k, k]: [{FiniteSet(k): set([y[k, k]])}]
                 }]}
         ]
     }
@@ -155,8 +158,8 @@ def test_contraction_structure_Add_in_Pow():
     expected = {
         None: set([s_ii_jj_s]),
         s_ii_jj_s: [
-            {None: set([S.One]), (i,): set([x[i, i]])},
-            {None: set([S.One]), (j,): set([y[j, j]])}
+            {None: set([S.One]), FiniteSet(i): set([x[i, i]])},
+            {None: set([S.One]), FiniteSet(j): set([y[j, j]])}
         ]
     }
     result = get_contraction_structure(s_ii_jj_s)
@@ -172,12 +175,12 @@ def test_contraction_structure_Pow_in_Pow():
     expected = {
         None: set([ii_jj_kk]),
         ii_jj_kk: [
-            {(i,): set([x[i, i]])},
+            {FiniteSet(i): set([x[i, i]])},
             {
                 None: set([y[j, j]**z[k, k]]),
                 y[j, j]**z[k, k]: [
-                    {(j,): set([y[j, j]])},
-                    {(k,): set([z[k, k]])}
+                    {FiniteSet(j): set([y[j, j]])},
+                    {FiniteSet(k): set([z[k, k]])}
                 ]
             }
         ]
@@ -202,8 +205,8 @@ def test_ufunc_support():
 
     assert get_contraction_structure(f(x[i])) == {None: set([f(x[i])])}
     assert get_contraction_structure(
-        f(y[i])*g(x[i])) == {(i,): set([f(y[i])*g(x[i])])}
+        f(y[i])*g(x[i])) == {FiniteSet(i): set([f(y[i])*g(x[i])])}
     assert get_contraction_structure(
-        f(y[i])*g(f(x[i]))) == {(i,): set([f(y[i])*g(f(x[i]))])}
+        f(y[i])*g(f(x[i]))) == {FiniteSet(i): set([f(y[i])*g(f(x[i]))])}
     assert get_contraction_structure(
-        f(x[j], y[i])*g(x[i])) == {(i,): set([f(x[j], y[i])*g(x[i])])}
+        f(x[j], y[i])*g(x[i])) == {FiniteSet(i): set([f(x[j], y[i])*g(x[i])])}


### PR DESCRIPTION
Performance measured with following code (store in a file or run in terminal)

```
def r_old(inds):
    sum_index = {}
    for i in inds:
        if i in sum_index:
            sum_index[i] += 1
        else:
            sum_index[i] = 0
    inds = [x for x in inds if not sum_index[x]]
    return set(inds), tuple([ i for i in sum_index if sum_index[i] ])

def r_new(inds):
    ind_set = set()
    remove_set = set()
    for i in inds:
        if i in ind_set:
            remove_set.add(i)
        else:
            ind_set.add(i)
    return ind_set-remove_set, tuple(remove_set)

if __name__ == "__main__":
    import timeit
    print(timeit.repeat("r_old([1, 2, 3, 2, 4, 2, 3, 5, 1, 2, 3])",
                        "from __main__ import r_old", number=100000))
    print(timeit.repeat("r_new([1, 2, 3, 2, 4, 2, 3, 5, 1, 2, 3])",
                        "from __main__ import r_new", number=100000))
```

Results:
python 3.4
[0.34863924486407843, 0.3507206412770802, 0.34888814001763657]
[0.22447691390537017, 0.22464669290186956, 0.22363443374641934]
python 2.7
[0.2722262944472432, 0.2710292883736882, 0.27160191828883296]
[0.20663686197095876, 0.20522389017137832, 0.20427492394157531]
