### PR TITLE
Minor fix in KanesMethod's docstring

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -78,10 +78,10 @@ class KanesMethod(object):
     assigned to it.
     Finally, a list of all bodies and particles needs to be created.
 
-    >>> kd = [qd - u]
-    >>> FL = [(P, (-k * q - c * u) * N.x)]
-    >>> pa = Particle('pa', P, m)
-    >>> BL = [pa]
+        >>> kd = [qd - u]
+        >>> FL = [(P, (-k * q - c * u) * N.x)]
+        >>> pa = Particle('pa', P, m)
+        >>> BL = [pa]
 
     Finally we can generate the equations of motion.
     First we create the KanesMethod object and supply an inertial frame,


### PR DESCRIPTION
There was a portion of example code in KanesMethod's docstring that was
not at the same indention level as the rest of the example code. This
has been fixed
