### PR TITLE
NEW: longest_repetition, seq_replace, split, find

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2526,51 +2526,6 @@ def longest_repetition(*seq, **kwargs):
         return hits
 
 
-def all_repetitions(*seq, **kwargs):
-    """Return a list of all subsequences in seq that are repeated. The
-    subsequences are recursively processed so that any smaller
-    subsequences in them that appear in any of the original sequences
-    will be identified. By default, subsequences longer than 2 will be
-    identified. The keyword ``small`` can be used to specify
-    a larger or smaller size.
-
-    Examples
-    ========
-
-    >>> from sympy.utilities.iterables import all_repetitions
-    >>> seq = 'abc', 'abcd', 'abcd', 'bca', 'bcd'
-    >>> all_repetitions(*seq)
-    ['abcd', 'abc', 'bc']
-    >>> all_repetitions(*seq, small=3)
-    ['abcd', 'abc']
-    >>> all_repetitions(*seq, small=1)
-    ['abcd', 'abc', 'bc', 'a', 'd']
-    """
-    small = as_int(kwargs.get('small', 2))
-    if small < 0:
-        raise ValueError('`small` must be positive')
-    seq = list(seq)  # b/c tuple args cannot be modified in place
-    reps = []
-    while not all(len(i) < small for i in seq):
-        L = longest_repetition(*seq)
-        if len(L) < small:
-            # the longest repetition is too small
-            break
-        reps.append(L)
-        # break s_i into pieces, removing the found subsequences
-        i = 0
-        while i < len(seq):
-            at = find(seq[i], L)
-            if at != -1:
-                seq[i:i+1] = [seq[i][:at], seq[i][at + len(L):]]
-            i += 1
-        # if len(L) > small then there may be subsequences shared
-        # between it an the remaining sequences of seq
-        if len(L) != small:
-            seq.append(L[:])
-    return reps
-
-
 def extract_repetitions(seq, replacements):
     """Return a replacement list and sequences that have been modified
     by recursively removing repeated subsequences so as to minimize the

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2527,7 +2527,7 @@ def longest_repetition(*seq, **kwargs):
         return hits
 
 
-def extract_repetitions(seq, replacements):
+def extract_repetitions(replacements, *seq):
     """Return a replacement list and sequences that have been modified
     by recursively removing repeated subsequences so as to minimize the
     metric ``R + S`` where ``R`` is the combined length of the
@@ -2541,8 +2541,9 @@ def extract_repetitions(seq, replacements):
 
     >>> from sympy.utilities.iterables import extract_repetitions
     >>> import string
-    >>> s = ('cbedbbcebc', 'baebbcaabb', 'bdeaaddcdc')
-    >>> r, c = extract_repetitions(s, string.ascii_uppercase)
+    >>> s = ['cbedbbcebc', 'baebbcaabb', 'bdeaaddcdc']
+    >>> U = string.ascii_uppercase
+    >>> r, c = extract_repetitions(U, *s)
     >>> r
     [('D', 'dc'), ('C', 'bb'), ('B', 'aa'), ('A', 'Cc')]
     >>> c
@@ -2571,8 +2572,8 @@ def extract_repetitions(seq, replacements):
     of orderable elements, e.g. integers.
 
     >>> s = [[1, 2, 3], [1, 1, 2], [1, 1, 2, 3]]
-    >>> negs = (-i for i in range(1, sum(len(i) for i in s)))
-    >>> extract_repetitions(s, negs)
+    >>> from sympy import Range, oo
+    >>> extract_repetitions(Range(-1,-oo,-1), *s)
     ([(-2, [1, 2]), (-1, [1, -2])], [[-2, 3], [-1], [-1, 3]])
     >>> r, c = _
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2558,11 +2558,11 @@ def longest_repetition(seq_list, limit=None, sort=False):
 
 
 def extract_repetitions(replacements, seq_list):
-    """Return a replacement list and sequences that have been modified
-    by recursively removing repeated subsequences so as to minimize the
-    metric ``R + S`` where ``R`` is the combined length of the
-    computed subsequences and ``S`` is the length of the modified
-    original sequences.
+    """Return a replacement list and sequences that have been
+    modified by recursively removing repeated subsequences from the
+    sequences in `seq_list` and assigning them (in the order found)
+    to the replacements given by `replacements`.
+
 
     Examples
     ========

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2500,12 +2500,13 @@ def longest_repetition(*seq, **kwargs):
             # they all matched
             m += 1
         if i == j and m > abs(b - a):  # matches overlap in seq[i]
-            # mark the position of the middle of the the longer subsequence
+            # mark the position of the middle of the longer subsequence
             if la > lb:
                 m = la//2
             else:
                 a = b
                 m = lb//2
+            m = min(m, big)
             # trim the subsequence until it appears as a match in the
             # latter half of the longer subsequence
             while m and m > length:

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2334,7 +2334,7 @@ def seq_replace(seq, a, b=[]):
         start = i + len(b)
 
 
-def find(sequence, subsequence, start=0):
+def find(seq, subseq, start=0, all=False):
     """Return starting index at which subsequence appears in sequence
     at or beyond the index corresponding to position `start`, else -1.
 
@@ -2344,10 +2344,18 @@ def find(sequence, subsequence, start=0):
     >>> from sympy.utilities.iterables import find
     >>> find('alabaster', 'ba')
     3
-    >>> find('alabaster', 'a', 1)
+    >>> find('alabaster', 'a', start=1)
     2
-    >>> find('alabaster', 'e', -3)
+    >>> find('alabaster', 'e', start=-3)
     7
+
+    To find all occurances at or past the start,
+    set keyword `all` to True:
+
+    >>> find('alabaster', 'a', all=True)
+    [0, 2, 4]
+    >>> find('alabaster', 'a', 1, all=True)
+    [2, 4]
 
     See Also
     ========
@@ -2356,26 +2364,30 @@ def find(sequence, subsequence, start=0):
     # adapted from http://code.activestate.com/recipes/
     # 117223-boyer-moore-horspool-string-searching/
     from collections import defaultdict
-    m = len(subsequence)
-    n = len(sequence)
+    m = len(subseq)
+    n = len(seq)
     if m > n:
-        return -1
+        return -1 if not all else []
     if start < 0:
         start = max(-n, start) + n
     skip = defaultdict(lambda: m)
     for k in range(m - 1):
-        skip[subsequence[k]] = m - k - 1
+        skip[subseq[k]] = m - k - 1
     k = m - 1 + start
+    loc = []
     while k < n:
         j = m - 1
         i = k
-        while j >= 0 and sequence[i] == subsequence[j]:
+        while j >= 0 and seq[i] == subseq[j]:
             j -= 1
             i -= 1
         if j == -1:
-            return i + 1
-        k += skip[sequence[k]]
-    return -1
+            if all:
+                loc.append(i + 1)
+            else:
+                return i + 1
+        k += skip[seq[k]]
+    return -1 if not all else loc
 
 
 def split(s, ignore=()):

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -4,7 +4,7 @@ import string
 
 from sympy import (
     symbols, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
-    factorial, true)
+    factorial, true, oo)
 from sympy.combinatorics import RGS_enum, RGS_unrank, Permutation
 from sympy.core.compatibility import range
 from sympy.utilities.iterables import (
@@ -26,6 +26,7 @@ from sympy.utilities.enumerative import (
 
 from sympy.core.singleton import S
 from sympy.functions.elementary.piecewise import Piecewise, ExprCondPair
+from sympy.sets.fancysets import Range
 from sympy.utilities.pytest import raises
 
 w, x, y, z = symbols('w,x,y,z')
@@ -848,7 +849,7 @@ def test_extract_repetitions():
         'dcaabededb', 'aaacdddaba', 'dcaceacdcb', 'ecabcedbad',
         'eebeabdebb', 'ebbdabdbbc', 'ddeadbeadb', 'decedceced',
         'edddbcceea', 'eeddacdcac']
-    a, b = extract_repetitions(s, string.uppercase)
+    a, b = extract_repetitions(s, string.ascii_uppercase)
     assert a == \
         [('P', 'dd'), ('O', 'ce'), ('N', 'bb'), ('M', 'ad'), ('L', 'ac'),
         ('K', 'ed'), ('J', 'ab'), ('I', 'Kd'), ('H', 'eN'), ('G', 'dca'),
@@ -863,8 +864,11 @@ def test_extract_repetitions():
     assert s == b
 
     s = [list(i) for i in ('abc','abcd','abcde')]
-    re = extract_repetitions(s, string.uppercase)
+    re = extract_repetitions(s, string.ascii_uppercase)
     assert re == ([('B', ['a', 'b', 'c']), ('A', ['B', 'd'])],
         [['B'], ['A'], ['A', 'e']])
-    assert extract_repetitions(s, [1, 2]) == \
-        ([(2, ['a', 'b', 'c']), (1, [2, 'd'])], [[2], [1], [1, 'e']])
+    s = [[ord(i) for i in i] for i in ('abc','abcd','abcde')]
+    ans = ([(-2, [97, 98, 99]), (-1, [-2, 100])], [[-2], [-1], [-1, 101]])
+    assert extract_repetitions(s, [-1, -2]) == ans
+    assert extract_repetitions(s, Range(-1, -oo, -1)) == \
+        ([(-2, [97, 98, 99]), (-1, [-2, 100])], [[-2], [-1], [-1, 101]])

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -828,11 +828,12 @@ def test_find():
 
 
 def test_extract_repetitions():
+    U = string.ascii_uppercase
     s = [
         'dcaabededb', 'aaacdddaba', 'dcaceacdcb', 'ecabcedbad',
         'eebeabdebb', 'ebbdabdbbc', 'ddeadbeadb', 'decedceced',
         'edddbcceea', 'eeddacdcac']
-    a, b = extract_repetitions(s, string.ascii_uppercase)
+    a, b = extract_repetitions(U, *s)
     assert a == \
         [('P', 'dd'), ('O', 'ce'), ('N', 'bb'), ('M', 'ad'), ('L', 'ac'),
         ('K', 'ed'), ('J', 'ab'), ('I', 'Kd'), ('H', 'eN'), ('G', 'dca'),
@@ -847,11 +848,11 @@ def test_extract_repetitions():
     assert s == b
 
     s = [list(i) for i in ('abc','abcd','abcde')]
-    re = extract_repetitions(s, string.ascii_uppercase)
+    re = extract_repetitions(U, *s)
     assert re == ([('B', ['a', 'b', 'c']), ('A', ['B', 'd'])],
         [['B'], ['A'], ['A', 'e']])
     s = [[ord(i) for i in i] for i in ('abc','abcd','abcde')]
     ans = ([(-2, [97, 98, 99]), (-1, [-2, 100])], [[-2], [-1], [-1, 101]])
-    assert extract_repetitions(s, [-1, -2]) == ans
-    assert extract_repetitions(s, Range(-1, -oo, -1)) == \
+    assert extract_repetitions([-1, -2], *s) == ans
+    assert extract_repetitions(Range(-1, -oo, -1), *s) == \
         ([(-2, [97, 98, 99]), (-1, [-2, 100])], [[-2], [-1], [-1, 101]])

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -19,8 +19,7 @@ from sympy.utilities.iterables import (
     permutations, postfixes, postorder_traversal, prefixes, reshape,
     rotate_left, rotate_right, runs, sift, subsets, take,
     topological_sort, unflatten, uniq, variations,
-    seq_replace, find, split, longest_repetition, all_repetitions,
-    extract_repetitions)
+    seq_replace, find, split, longest_repetition, extract_repetitions)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -792,25 +791,6 @@ def test_longest_repetition():
     assert lr(*split(list('a$$$$$$aaaabb'), list('a$'))) == ['b']
     assert lr(*'ab$aa$abba$'.split('$')) == 'ab'
     assert lr(*'baaabaaaa'.split('b')) == 'aaa'
-
-
-def test_all_repetitions():
-    raises(ValueError, lambda: all_repetitions('abc', small=1.2))
-    raises(ValueError, lambda: all_repetitions('abc', small=-1))
-    assert all_repetitions('abc', 'abcd', small=5) == []
-
-    s = 'abc', 'abcd', 'abcd', 'bca', 'bcd'
-    a1 = ['abcd', 'abc', 'bc']
-    a2 = ['abcd', 'abc']
-    a3 = ['abcd', 'abc', 'bc', 'a', 'd']
-    assert all_repetitions(*s) == a1
-    assert all_repetitions(*s, small=3) == a2
-    assert all_repetitions(*s, small=1) == a3
-    # test them in list form
-    s, a1, a2, a3 = [[list(i) for i in j] for j in (s, a1, a2, a3)]
-    assert all_repetitions(*s) == a1
-    assert all_repetitions(*s, small=3) == a2
-    assert all_repetitions(*s, small=1) == a3
 
 
 def test_split():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -806,6 +806,7 @@ def test_split():
     assert split('cab', 'c') == ['', 'ab']
     assert split('ccab', 'c') == ['', 'ab']
     assert split([1, 0, 2, 3, 4, 3], [3, 2]) == [[1, 0], [4], []]
+    assert split([1, 0, 2, 3, 4, 3], 3) == [[1, 0, 2], [4], []]
 
 
 def test_find():
@@ -856,3 +857,6 @@ def test_extract_repetitions():
     assert extract_repetitions([-1, -2], *s) == ans
     assert extract_repetitions(Range(-1, -oo, -1), *s) == \
         ([(-2, [97, 98, 99]), (-1, [-2, 100])], [[-2], [-1], [-1, 101]])
+    x0, x1 = take(numbered_symbols(), 2)
+    assert extract_repetitions(numbered_symbols(), *s) == \
+        ([(x1, [97, 98, 99]), (x0, [x1, 100])], [[x1], [x0], [x0, 101]])

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -775,25 +775,31 @@ def test_seq_replace():
 
 def test_longest_repetition():
     lr = longest_repetition
-    assert lr('a') == ''
-    assert lr('aaa') == 'a'
-    assert lr('aaaa') == 'aa'
-    assert lr('aaaac') == 'aa'
-    assert lr('babab') == 'ab'
-    assert lr('bcbcb') == 'bc'
-    assert lr('abcabd') == 'ab'
-    assert lr('aabaabc') == 'aab'
-    assert lr('abcxxabcxxabc') == 'abcxx'
-    assert lr('aba$bxa$bab') == 'a$b'
-    assert lr(*'aba$bxa$bab'.split('$')) == 'ab'
-    assert lr('a$$$$$$aaaa') == '$$$'
-    assert lr(*'a$$$$$$aaaa'.split('$')) == 'aa'
-    assert lr(*split(list('a$$$$$$aaaabb'), list('a$'))) == ['b']
-    assert lr(*'ab$aa$abba$'.split('$')) == 'ab'
-    assert lr(*'baaabaaaa'.split('b')) == 'aaa'
+    assert lr(['a']) == []
+    assert lr(['aaa']) == ['a']
+    assert lr(['aaaa']) == ['aa']
+    assert lr(['aaaac']) == ['aa']
+    assert lr(['babab']) == ['ab', 'ba']
+    assert lr(['bcbcb']) == ['bc', 'cb']
+    assert lr(['abcabd']) == ['ab']
+    assert lr(['aabaabc']) == ['aab']
+    assert lr(['abcxxabcxxabc']) == ['abcxx', 'bcxxa', 'cxxab', 'xxabc']
+    assert lr(['aba$bxa$bab']) == ['a$b']
+    assert lr('aba$bxa$bab'.split('$')) == ['ab', 'ba']
+    assert lr(['a$$$$$$aaaa']) == ['$$$']
+    assert lr('a$$$$$$aaaa'.split('$')) == ['aa']
+    assert lr(split(list('a$$$$$$aaaabb'), list('a$'))) == [['b']]
+    assert lr('ab$aa$abba$'.split('$')) == ['ab']
+    assert lr('baaabaaaa'.split('b')) == ['aaa']
     s = [1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1]
-    assert longest_repetition(s, all=True, max=2) == \
+    assert longest_repetition([s], limit=2) == \
         [[0, 1], [1, 0], [1, 1]]
+    # for mixed input (rare case, likely) strings are returned as lists
+    assert extract_repetitions(
+        'ABC',
+        ['abab', [1, 2, 1, 2, 'a', 'c', 'a', 'c']]) == (
+        [('C', ['a', 'c']), ('B', [1, 2]), ('A', ['a', 'b'])],
+        [['A', 'A'], ['B', 'B', 'C', 'C']])
 
 
 def test_split():
@@ -834,7 +840,7 @@ def test_extract_repetitions():
         'dcaabededb', 'aaacdddaba', 'dcaceacdcb', 'ecabcedbad',
         'eebeabdebb', 'ebbdabdbbc', 'ddeadbeadb', 'decedceced',
         'edddbcceea', 'eeddacdcac']
-    a, b = extract_repetitions(U, *s)
+    a, b = extract_repetitions(U, s)
     assert a == \
         [('P', 'dd'), ('O', 'ce'), ('N', 'bb'), ('M', 'ad'), ('L', 'ac'),
         ('K', 'ed'), ('J', 'ab'), ('I', 'Kd'), ('H', 'eN'), ('G', 'dca'),
@@ -849,14 +855,14 @@ def test_extract_repetitions():
     assert s == b
 
     s = [list(i) for i in ('abc','abcd','abcde')]
-    re = extract_repetitions(U, *s)
+    re = extract_repetitions(U, s)
     assert re == ([('B', ['a', 'b', 'c']), ('A', ['B', 'd'])],
         [['B'], ['A'], ['A', 'e']])
     s = [[ord(i) for i in i] for i in ('abc','abcd','abcde')]
     ans = ([(-2, [97, 98, 99]), (-1, [-2, 100])], [[-2], [-1], [-1, 101]])
-    assert extract_repetitions([-1, -2], *s) == ans
-    assert extract_repetitions(Range(-1, -oo, -1), *s) == \
+    assert extract_repetitions([-1, -2], s) == ans
+    assert extract_repetitions(Range(-1, -oo, -1), s) == \
         ([(-2, [97, 98, 99]), (-1, [-2, 100])], [[-2], [-1], [-1, 101]])
     x0, x1 = take(numbered_symbols(), 2)
-    assert extract_repetitions(numbered_symbols(), *s) == \
+    assert extract_repetitions(numbered_symbols(), s) == \
         ([(x1, [97, 98, 99]), (x0, [x1, 100])], [[x1], [x0], [x0, 101]])

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from textwrap import dedent
+import string
 
 from sympy import (
     symbols, Integral, Tuple, Dummy, Basic, default_sort_key, Matrix,
@@ -18,7 +19,8 @@ from sympy.utilities.iterables import (
     permutations, postfixes, postorder_traversal, prefixes, reshape,
     rotate_left, rotate_right, runs, sift, subsets, take,
     topological_sort, unflatten, uniq, variations,
-    seq_replace, find, split, longest_repetition, all_repetitions)
+    seq_replace, find, split, longest_repetition, all_repetitions,
+    extract_repetitions)
 from sympy.utilities.enumerative import (
     factoring_visitor, multiset_partitions_taocp )
 
@@ -177,10 +179,12 @@ def test_cartes():
     assert list(cartes('a', repeat=2)) == [('a', 'a')]
     assert list(cartes(list(range(2)))) == [(0,), (1,)]
 
+
 def test_filter_symbols():
     s = numbered_symbols()
     filtered = filter_symbols(s, symbols("x0 x2 x3"))
     assert take(filtered, 3) == list(symbols("x1 x4 x5"))
+
 
 def test_numbered_symbols():
     s = numbered_symbols(cls=Dummy)
@@ -837,3 +841,30 @@ def test_find():
     assert find('aba', 'a', start=-3) == 0
     assert find('aba', 'a', start=-4) == 0
     assert find('aba', 'a', start=-5) == 0
+
+
+def test_extract_repetitions():
+    s = [
+        'dcaabededb', 'aaacdddaba', 'dcaceacdcb', 'ecabcedbad',
+        'eebeabdebb', 'ebbdabdbbc', 'ddeadbeadb', 'decedceced',
+        'edddbcceea', 'eeddacdcac']
+    a, b = extract_repetitions(s, string.uppercase)
+    assert a == \
+        [('P', 'dd'), ('O', 'ce'), ('N', 'bb'), ('M', 'ad'), ('L', 'ac'),
+        ('K', 'ed'), ('J', 'ab'), ('I', 'Kd'), ('H', 'eN'), ('G', 'dca'),
+        ('F', 'cK'), ('E', 'Ld'), ('D', 'Jd'), ('C', 'eF'), ('B', 'eMb'),
+        ('A', 'Ec')]
+    assert b == \
+        ['GJKKb', 'aaEPJa', 'GOAb', 'ecJFbM', 'eebeDH', 'HdDNc', 'PBB',
+        'dCcC', 'IdbcOea', 'eIAL']
+    for ai in a[::-1]:
+        for i in range(len(b)):
+            b[i] = b[i].replace(*ai)
+    assert s == b
+
+    s = [list(i) for i in ('abc','abcd','abcde')]
+    re = extract_repetitions(s, string.uppercase)
+    assert re == ([('B', ['a', 'b', 'c']), ('A', ['B', 'd'])],
+        [['B'], ['A'], ['A', 'e']])
+    assert extract_repetitions(s, [1, 2]) == \
+        ([(2, ['a', 'b', 'c']), (1, [2, 'd'])], [[2], [1], [1, 'e']])

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -825,11 +825,15 @@ def test_find():
     assert find('a', 'a') == 0
     assert find('aa', 'a') == 0
     assert find('ba', 'a') == 1
-    assert find('aa', 'a', 1) == 1
-    assert find('aba', 'a', 1) == 2
-    assert find('aba', 'a', 3) == -1
-    assert find('aba', 'a', -1) == 2
-    assert find('aba', 'a', -2) == 2
-    assert find('aba', 'a', -3) == 0
-    assert find('aba', 'a', -4) == 0
-    assert find('aba', 'a', -5) == 0
+    assert find('aa', 'a', start=1) == 1
+    assert find('aa', 'a', all=True) == [0, 1]
+    assert find('aa', 'a', start=1, all=True) == [1]
+    assert find('aa', 'a', 2, all=True) == []
+    assert find('aa', 'aaa', all=True) == []
+    assert find('aba', 'a', start=1) == 2
+    assert find('aba', 'a', start=3) == -1
+    assert find('aba', 'a', start=-1) == 2
+    assert find('aba', 'a', start=-2) == 2
+    assert find('aba', 'a', start=-3) == 0
+    assert find('aba', 'a', start=-4) == 0
+    assert find('aba', 'a', start=-5) == 0

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -791,6 +791,9 @@ def test_longest_repetition():
     assert lr(*split(list('a$$$$$$aaaabb'), list('a$'))) == ['b']
     assert lr(*'ab$aa$abba$'.split('$')) == 'ab'
     assert lr(*'baaabaaaa'.split('b')) == 'aaa'
+    s = [1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1]
+    assert longest_repetition(s, all=True, max=2) == \
+        [[0, 1], [1, 0], [1, 1]]
 
 
 def test_split():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -779,7 +779,7 @@ def test_longest_repetition():
     assert lr(['aaa']) == ['a']
     assert lr(['aaaa']) == ['aa']
     assert lr(['aaaac']) == ['aa']
-    assert lr(['babab']) == ['ab', 'ba']
+    assert lr(['babab']) == ['ba', 'ab']
     assert lr(['bcbcb']) == ['bc', 'cb']
     assert lr(['abcabd']) == ['ab']
     assert lr(['aabaabc']) == ['aab']
@@ -793,7 +793,7 @@ def test_longest_repetition():
     assert lr('baaabaaaa'.split('b')) == ['aaa']
     s = [1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1]
     assert longest_repetition([s], limit=2) == \
-        [[0, 1], [1, 0], [1, 1]]
+        [[1, 1], [1, 0], [0, 1]]
     # for mixed input (rare case, likely) strings are returned as lists
     assert extract_repetitions(
         'ABC',
@@ -842,13 +842,13 @@ def test_extract_repetitions():
         'edddbcceea', 'eeddacdcac']
     a, b = extract_repetitions(U, s)
     assert a == \
-        [('P', 'dd'), ('O', 'ce'), ('N', 'bb'), ('M', 'ad'), ('L', 'ac'),
-        ('K', 'ed'), ('J', 'ab'), ('I', 'Kd'), ('H', 'eN'), ('G', 'dca'),
-        ('F', 'cK'), ('E', 'Ld'), ('D', 'Jd'), ('C', 'eF'), ('B', 'eMb'),
-        ('A', 'Ec')]
+        [('Q', 'bb'), ('P', 'dc'), ('O', 'ec'), ('N', 'ee'), ('M',
+        'ad'), ('L', 'dd'), ('K', 'ac'), ('J', 'ed'), ('I', 'ab'),
+        ('H', 'Jb'), ('G', 'eQ'), ('F', 'Id'), ('E', 'Pa'), ('D',
+        'Ld'), ('C', 'eMb'), ('B', 'OJ'), ('A', 'Ec')]
     assert b == \
-        ['GJKKb', 'aaEPJa', 'GOAb', 'ecJFbM', 'eebeDH', 'HdDNc', 'PBB',
-        'dCcC', 'IdbcOea', 'eIAL']
+        ['EIJH', 'aaKDIa', 'AeKPb', 'OIcHM', 'NbeFG', 'GdFQc', 'LCC',
+        'dBcB', 'eDbccNa', 'eJdKA']
     for ai in a[::-1]:
         for i in range(len(b)):
             b[i] = b[i].replace(*ai)


### PR DESCRIPTION
I propose utility functions for `iterables` that will be useful for #10271 but do not otherwise depend on that PR.

The main function is something that can be used to identify repeated subsequences of contiguous elements (more precisely a repeated "substring" although we are not working with strings) in one or more sequences. (The proper scope of the subsequence problem is to identify an ordered sequence of elements -- not necessarily contiguous -- that appears is two sequences, e.g. 'abe' for 'abcde' and 'alabaster'. A description and code [are here](http://www.geeksforgeeks.org/printing-longest-common-subsequence/).)

``` python
>>> s = [[1, 2, 3], [1, 1, 2], [1, 1, 2, 3]]
>>> extract_repetitions(numbered_symbols(), *s)
([(x1, [1, 2]), (x0, [1, x1])], [[x1, 3], [x0], [x0, 3]])
```

The supporting functions allow for the following:
- Find a subsequence

``` python
>>> s=ibin(23)
>>> s
[1, 0, 1, 1, 1]
>>> find(s, [0,1])
1
>>> find(s, [1], all=True)
[0, 2, 3, 4]
```
- Split a sequence on given elements

``` python
>>> s
[1, 0, 1, 1, 1]
>>> split(s, 0)
[[1], [1, 1, 1]]
```
- replace a subsequence in-place

``` python
>>> s
[1, 0, 1, 1, 1]
>>> seq_replace(s,[0,1], 2);s
[1, 2, 1, 1]
```
- find repetitions in a sequence

``` python
>>> s=ibin(23545)
>>> s
[1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1]
>>> longest_repetition(s)  # first lexical
[0, 1, 1]
>>> longest_repetition(s, all=True)
[[0, 1, 1], [1, 0, 1], [1, 1, 0], [1, 1, 1]]
>>> longest_repetition(s, all=True, max=2)
[[0, 1], [1, 0], [1, 1]]
```

To demonstrate how it can be used with several open issues related to cse, consider the following:

``` python
def _cse(*e):
    muls = all(i.is_Mul or i.is_Pow for i in e)
    if not muls:
        assert all(i.is_Add for i in e)
        F = Add
    else:
        F = Mul
    def remap(*e):
        args = list(ordered(set(flatten(F.make_args(i) for i in e))))
        mapping = dict(zip(args, range(len(args))))
        for k in list(mapping.keys()):
            if muls and k.is_Pow and k.exp.is_Integer and k.exp > 0:
                b,p = k.as_base_exp()
            elif k.is_Mul and k.args[0].is_Integer and k.args[0] > 0:
                p,b = k.as_two_terms()
            else:
                continue
            if b in mapping:
                v = mapping[b]
            else:
                v = mapping[k]
                mapping[b] = v
            mapping[k]=[v]*p
        return mapping, [
            flatten([mapping[a] for a in F.make_args(i)]) for i in e]
    m, ints = remap(*e)
    commutative=all(i.is_commutative for i in m)
    if commutative:
        for i in ints:
            i.sort()
    r, c = extract_repetitions(
        numbered_symbols(commutative=commutative), *ints)
    rev_map = {v:k for k,v in m.items() if type(v) is int}
    for i in range(len(r)):
        a,b = r[i]
        b = F(*[rev_map.get(j,j) for j in b])
        r[i] = a, b
    for i in range(len(c)):
        c[i] = F(*[rev_map.get(j,j) for j in c[i]])
    return r, c
```

In the following, `CAPS` are noncommutative and `lowercase` are commutative.
#10238

``` python
>>> _cse(A*B*A*B*C*D, A*A*B*E*C*D)
([(x1, C*D), (x0, A*B)], [x0**2*x1, A*x0*E*x1])
```
#6717

``` python
_cse(B*A*A, A*A)
([(x0, A**2)], [B*x0, x0])
```
#10228

``` python
>>> _cse(x*y, x**2*y)
([(x0, x*y)], [x0, x*x0])
>>> _cse(x + y, 2*x + y)
([(x0, x + y)], [x0, x + x0])
```

NOTE: for simple expressions this works, but in general, for ~~non~~commutative expressions, 
one must detect repeated subsequences (which are not necessarily contiguous) 
not "substrings". e.g.

``` python
>>> _cse(d*g**2*j*m, 4*a*f*g*m, a*b*c*f**2)
([], [d*g**2*j*m, 4*a*f*g*m, a*b*c*f**2])
```

Using `pairwise_most_common` from #11232, the following is an idea for extracting expressions from commutative Muls:

``` python
def do(*e):
    """Return the subexpression(s) from the list of Mul expressions, `e`, with
    the highest op count.
    """
    pd = [i.as_powers_dict() for i in e]
    s = [set(i) for i in pd]
    mc = pairwise_most_common(s)
    best = []
    most = 0
    for st, ix in mc:
        check = []
        all_ix = set()
        for j in ix:
            for jj in j:
                all_ix.add(jj)
        for j in all_ix:
            E = []
            for i in st:
                E.extend([i]*pd[j][i])
            if len(E) > 1:
                check.append(E)
        rv = []
        for args in longest_repetition(check):
            if len(args) == 1:
                continue
            m = Mul(*args)
            ops = m.count_ops()
            if ops > most:
                best = []
            if ops >= most:
                best.append(m)
                most = ops
    return best

>>> do(*(d*g*j*m, 4*a*g*m*f, a*b*c*f**2))
[g*m, a*f]  <-- both have op count of 1
>>> do(*(d*g*j*m, 4*a*g*m*f**3, a*b*c*f**2))
[a*f**2] <-- there is only one sub-expression with an op count of 2
```
