### PR TITLE
factor_list : check base and exp for coeff

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5652,6 +5652,9 @@ def _symbolic_factor_list(expr, opt, method):
             continue
         if arg.is_Pow:
             base, exp = arg.args
+            if base.is_Number and exp.is_Number:
+                coeff *= arg
+                continue
             if base.is_Number:
                 factors.append((base, exp))
                 continue

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2265,7 +2265,7 @@ def test_factor():
 
     assert factor_list(1) == (1, [])
     assert factor_list(6) == (6, [])
-    assert factor_list(sqrt(3), x) == (1, [(3, S.Half)])
+    assert factor_list(sqrt(3), x) == (sqrt(3), [])
     assert factor_list((-1)**x, x) == (1, [(-1, x)])
     assert factor_list((2*x)**y, x) == (1, [(2, y), (x, y)])
     assert factor_list(sqrt(x*y), x) == (1, [(x*y, S.Half)])
@@ -3163,3 +3163,8 @@ def test_factor_terms():
     # issue 7067
     assert factor_list(x*(x + y)) == (1, [(x, 1), (x + y, 1)])
     assert sqf_list(x*(x + y)) == (1, [(x, 1), (x + y, 1)])
+
+
+def test_issue_11198():
+    assert factor_list(sqrt(2)*x) == (sqrt(2), [(x, 1)])
+    assert factor_list(sqrt(2)*sin(x), sin(x)) == (sqrt(2), [(sin(x), 1)])


### PR DESCRIPTION
Fixes : https://github.com/sympy/sympy/issues/11198
### Current master branch

```
In [ ]: factor_list(sqrt(2)*sin(x), sin(x))
Out[ ]: (1, [(2, 1/2), (sin(x), 1)])

In [ ]: factor_list(3 ,x)
Out[ ]: (3, [])

In [ ]: factor_list(sqrt(3) ,x)
Out[ ]: (1, [(3, 1/2)])

```
### This branch

```
In [1]:  factor_list(sqrt(2)*sin(x), sin(x))
Out[1]: (√2, [(sin(x), 1)])

In [2]: factor_list(3 ,x)
Out[2]: (3, [])

In [5]:  factor_list(sqrt(3) ,x)
Out[5]: (√3, [])


```
