### PR TITLE
Fix issue #8193

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1367,28 +1367,27 @@ def classify_sysode(eq, funcs=None, **kwargs):
             derivs = eqs.atoms(Derivative)
             func = set().union(*[d.atoms(AppliedUndef) for d in derivs])
             for func_ in  func:
-                order[func_] = 0
                 funcs.append(func_)
     funcs = list(set(funcs))
     if len(funcs) < len(eq):
         raise ValueError("Number of functions given is less than number of equations %s" % funcs)
     func_dict = dict()
     for func in funcs:
-        if not order[func]:
+        if not order.get(func, False):
             max_order = 0
             for i, eqs_ in enumerate(eq):
                 order_ = ode_order(eqs_,func)
                 if max_order < order_:
                     max_order = order_
                     eq_no = i
-        if eq_no in func_dict:
-            list_func = []
-            list_func.append(func_dict[eq_no])
-            list_func.append(func)
-            func_dict[eq_no] = list_func
-        else:
-            func_dict[eq_no] = func
-        order[func] = max_order
+            if eq_no in func_dict:
+                list_func = []
+                list_func.append(func_dict[eq_no])
+                list_func.append(func)
+                func_dict[eq_no] = list_func
+            else:
+                func_dict[eq_no] = func
+            order[func] = max_order
     funcs = [func_dict[i] for i in range(len(func_dict))]
     matching_hints['func'] = funcs
     for func in funcs:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -879,6 +879,9 @@ def test_classify_sysode():
     -12*x(t) + 12*y(t) + 5*Derivative(z(t), t)], 'order': {z(t): 1, y(t): 1, x(t): 1}}
     assert classify_sysode(eq16) == sol16
 
+    # issue 8193: funcs parameter for classify_sysode has to actually work
+    assert classify_sysode(eq1, funcs=[x(t), y(t)]) == sol1
+
 
 def test_ode_order():
     f = Function('f')


### PR DESCRIPTION
fixes #8193 

The error originally reported in the issue was being triggered by an edge case in `classify_sysode` where the dictionary used to track ODE order (relative to unknown functions) was expected to be pre-initialized with zeroes for all functions prior to use, but was not being pre-initialized when a non-None `funcs` parameter was given (in this case by the `dsolve` function).

This PR changes `classify_sysode` to instead initialize the order dictionary on-the-fly in all cases.
