### PR TITLE
Improving Floor and Ceiling functions

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -124,6 +124,10 @@ class floor(RoundFunction):
                 return Integer(int(arg.floor()))
             else:
                 return arg
+        elif isinstance(arg, ceiling):
+            return arg.args[0]
+        elif isinstance(arg, floor):
+            return arg.args[0]
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[0]
 
@@ -195,6 +199,10 @@ class ceiling(RoundFunction):
                 return Integer(int(arg.ceiling()))
             else:
                 return arg
+        elif isinstance(arg, ceiling):
+            return arg.args[0]
+        elif isinstance(arg, floor):
+            return arg.args[0]
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[1]
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -125,9 +125,9 @@ class floor(RoundFunction):
             else:
                 return arg
         elif isinstance(arg, ceiling):
-            return arg.args[0]
+            return arg
         elif isinstance(arg, floor):
-            return arg.args[0]
+            return arg
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[0]
 
@@ -200,9 +200,9 @@ class ceiling(RoundFunction):
             else:
                 return arg
         elif isinstance(arg, ceiling):
-            return arg.args[0]
+            return arg
         elif isinstance(arg, floor):
-            return arg.args[0]
+            return arg
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[1]
 

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -255,7 +255,7 @@ def test_issue_4149():
     assert floor(3 + E + pi*I + y*I) == 5 + floor(pi + y)*I
 
 def test_issue_11207():
-    assert floor(floor(x)) == x
-    assert floor(ceiling(x)) == x
-    assert ceiling(floor(x)) == x
-    assert floor(ceiling(x)) == x
+    assert floor(floor(x)) == floor(x)
+    assert floor(ceiling(x)) == ceiling(x)
+    assert ceiling(floor(x)) == floor(x)
+    assert floor(ceiling(x)) == ceiling(x)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -253,3 +253,9 @@ def test_issue_4149():
     assert floor(3 + pi*I + y*I) == 3 + floor(pi + y)*I
     assert floor(3*I + pi*I + y*I) == floor(3 + pi + y)*I
     assert floor(3 + E + pi*I + y*I) == 5 + floor(pi + y)*I
+
+def test_issue_11207():
+    assert floor(floor(x)) == x
+    assert floor(ceiling(x)) == x
+    assert ceiling(floor(x)) == x
+    assert floor(ceiling(x)) == x

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -258,4 +258,4 @@ def test_issue_11207():
     assert floor(floor(x)) == floor(x)
     assert floor(ceiling(x)) == ceiling(x)
     assert ceiling(floor(x)) == floor(x)
-    assert floor(ceiling(x)) == ceiling(x)
+    assert ceiling(ceiling(x)) == ceiling(x)


### PR DESCRIPTION
This is fix for #11207 . Added test cases for floor and ceiling instances in their own indivdual class.
#### Previous output:

``` python
>>> from sympy import * 
>>> from sympy.abc import x
>>> floor(ceiling(x))
floor(ceiling(x))
>>> floor(floor(x))
floor(floor(x))
>>> ceiling(ceiling(x))
ceiling(ceiling(x))
>>> ceiling(floor(x))
ceiling(floor(x))
```
#### Output after this PR:

``` python
>>> from sympy import * 
>>> from sympy.abc import x
>>> floor(ceiling(x))
ceiling(x)
>>> floor(floor(x))
floor(x)
>>> ceiling(ceiling(x))
ceiling(x)
>>> ceiling(floor(x))
floor(x)
```
- Tests are added.
