### PR TITLE
Implemented floordiv in sympy

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -178,6 +178,18 @@ class Expr(Basic, EvalfMixin):
     def __rmod__(self, other):
         return Mod(other, self)
 
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rfloordiv__')
+    def __floordiv__(self, other):
+        from sympy.functions.elementary.integers import floor
+        return floor(self / other)
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__floordiv__')
+    def __rfloordiv__(self, other):
+        from sympy.functions.elementary.integers import floor
+        return floor(self / other)
+
     def __int__(self):
         # Although we only need to round to the units position, we'll
         # get one more digit so the extra testing below can be avoided

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1277,6 +1277,10 @@ def test_issue_5300():
     x = Symbol('x', commutative=False)
     assert x*sqrt(2)/sqrt(6) == x*sqrt(3)/3
 
+def test_floordiv():
+    from sympy.functions.elementary.integers import floor
+    assert x // y == floor(x / y)
+
 
 def test_as_coeff_Mul():
     assert S(0).as_coeff_Mul() == (S.One, S.Zero)


### PR DESCRIPTION
- This is fix for issue #11208 . This is extension of #11211
- Tests are added.
#### Output after this PR:

``` python
 >>> from sympy import *
>>> from sympy.abc import x,y
>>> x//y
floor(x/y)
>>> 3//2
1
```
