### PR TITLE
codegen: generate Octave code for more functions

### DIFF
--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -35,7 +35,7 @@ known_fcns_src1 = ["sin", "cos", "tan", "cot", "sec", "csc",
 known_fcns_src2 = {
     "Abs": "abs",
     "ceiling": "ceil",
-    "Chi": "cosint",
+    "Chi": "coshint",
     "Ci": "cosint",
     "conjugate": "conj",
     "DiracDelta": "dirac",
@@ -44,7 +44,7 @@ known_fcns_src2 = {
     "li": "logint",
     "loggamma": "gammaln",
     "polygamma": "psi",
-    "Shi": "sinint",
+    "Shi": "sinhint",
     "Si": "sinint",
 }
 

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -21,20 +21,31 @@ from re import search
 
 # List of known functions.  First, those that have the same name in
 # SymPy and Octave.   This is almost certainly incomplete!
-known_fcns_src1 = ["sin", "cos", "tan", "asin", "acos", "atan", "atan2",
-                   "sinh", "cosh", "tanh", "asinh", "acosh", "atanh",
-                   "log", "exp", "erf", "gamma", "sign", "floor", "csc",
-                   "sec", "cot", "coth", "acot", "acoth", "erfc",
-                   "besselj", "bessely", "besseli", "besselk",
-                   "erfinv", "erfcinv", "factorial" ]
+known_fcns_src1 = ["sin", "cos", "tan", "cot", "sec", "csc",
+                   "asin", "acos", "acot", "atan", "atan2", "asec", "acsc",
+                   "sinh", "cosh", "tanh", "coth", "csch", "sech",
+                   "asinh", "acosh", "atanh", "acoth", "asech", "acsch",
+                   "erfc", "erfi", "erf", "erfinv", "erfcinv",
+                   "besseli", "besselj", "besselk", "bessely",
+                   "exp", "factorial", "floor", "fresnelc", "fresnels",
+                   "gamma", "log", "polylog", "sign", "zeta"]
+
 # These functions have different names ("Sympy": "Octave"), more
 # generally a mapping to (argument_conditions, octave_function).
 known_fcns_src2 = {
     "Abs": "abs",
     "ceiling": "ceil",
+    "Chi": "cosint",
+    "Ci": "cosint",
     "conjugate": "conj",
     "DiracDelta": "dirac",
     "Heaviside": "heaviside",
+    "laguerre": "laguerreL",
+    "li": "logint",
+    "loggamma": "gammaln",
+    "polygamma": "psi",
+    "Shi": "sinint",
+    "Si": "sinint",
 }
 
 
@@ -369,6 +380,16 @@ class OctaveCodePrinter(CodePrinter):
 
     def _print_Identity(self, expr):
         return "eye(%s)" % self._print(expr.shape[0])
+
+
+    def _print_uppergamma(self, expr):
+        return "gammainc(%s, %s, 'upper')" % (self._print(expr.args[1]),
+                                              self._print(expr.args[0]))
+
+
+    def _print_lowergamma(self, expr):
+        return "gammainc(%s, %s, 'lower')" % (self._print(expr.args[1]),
+                                              self._print(expr.args[0]))
 
 
     def _print_hankel1(self, expr):

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -9,6 +9,7 @@ from sympy.matrices import (eye, Matrix, MatrixSymbol, Identity,
 from sympy.functions.special.bessel import (jn, yn, besselj, bessely, besseli,
                                             besselk, hankel1, hankel2, airyai,
                                             airybi, airyaiprime, airybiprime)
+from sympy.functions.special.gamma_functions import (lowergamma, uppergamma)
 from sympy.utilities.pytest import XFAIL
 from sympy.core.compatibility import range
 
@@ -363,5 +364,7 @@ def test_specfun():
     assert octave_code(airyaiprime(x)) == 'airy(1, x)'
     assert octave_code(airybi(x)) == 'airy(2, x)'
     assert octave_code(airybiprime(x)) == 'airy(3, x)'
+    assert octave_code(uppergamma(n, x)) == 'gammainc(x, n, \'upper\')'
+    assert octave_code(lowergamma(n, x)) == 'gammainc(x, n, \'lower\')'
     assert octave_code(jn(n, x)) == 'sqrt(2)*sqrt(pi)*sqrt(1./x).*besselj(n + 1/2, x)/2'
     assert octave_code(yn(n, x)) == 'sqrt(2)*sqrt(pi)*sqrt(1./x).*bessely(n + 1/2, x)/2'


### PR DESCRIPTION
Most of these have numerical implementations in either core Octave
or the Symbolic package, either in current releases or in the master
branches.  In a few cases, Octave will end up calling SymPy again, which
might seem a bit odd but from Octave's point of view, its an implementation
detail.

In Matlab, these functions are provided by core Matlab or by the Symbolic
Math Toolbox (however, I have not tested extensively on Matlab).
