### PR TITLE
Improved subs() for exponential expressions

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -571,6 +571,7 @@ class Pow(Expr):
             not hold then the substitution should not occur so `bool` will be
             False.
             """
+            from sympy.simplify.radsimp import denom
             coeff1, terms1 = ct1
             coeff2, terms2 = ct2
             if terms1 == terms2:
@@ -579,7 +580,7 @@ class Pow(Expr):
                     pow = as_int(pow)
                     combines = True
                 except ValueError:
-                    if coeff2 == 1:
+                    if denom(pow) == 1:
                         combines = True
                     else:
                         combines = Pow._eval_power(

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -571,17 +571,20 @@ class Pow(Expr):
             not hold then the substitution should not occur so `bool` will be
             False.
             """
-            from .evalf import N
             coeff1, terms1 = ct1
             coeff2, terms2 = ct2
             if terms1 == terms2:
                 pow = coeff1/coeff2
-                if N(pow).is_Number:
+                try:
+                    pow = as_int(pow)
                     combines = True
-                else:
-                    combines = Pow._eval_power(
-                        Pow(*old.as_base_exp(), evaluate=False),
-                        pow) is not None
+                except ValueError:
+                    if coeff2 == 1:
+                        combines = True
+                    else:
+                        combines = Pow._eval_power(
+                            Pow(*old.as_base_exp(), evaluate=False),
+                            pow) is not None
                 return combines, pow
             return False, None
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -559,7 +559,7 @@ class Pow(Expr):
         return self.base.is_polar
 
     def _eval_subs(self, old, new):
-        from sympy import exp, log, Symbol
+        from sympy import exp, log, Symbol, pi
         def _check(ct1, ct2, old):
             """Return bool, pow where, if bool is True, then the exponent of
             Pow `old` will combine with `pow` so the substitution is valid,
@@ -582,6 +582,9 @@ class Pow(Expr):
                     combines = Pow._eval_power(
                         Pow(*old.as_base_exp(), evaluate=False),
                         pow) is not None
+                if not combines:
+                    if pow.has(pi):
+                        combines = True
                 return combines, pow
             return False, None
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -571,20 +571,17 @@ class Pow(Expr):
             not hold then the substitution should not occur so `bool` will be
             False.
             """
+            from .evalf import N
             coeff1, terms1 = ct1
             coeff2, terms2 = ct2
             if terms1 == terms2:
                 pow = coeff1/coeff2
-                try:
-                    pow = as_int(pow)
+                if N(pow).is_Number:
                     combines = True
-                except ValueError:
+                else:
                     combines = Pow._eval_power(
                         Pow(*old.as_base_exp(), evaluate=False),
                         pow) is not None
-                if not combines:
-                    if pow.has(pi):
-                        combines = True
                 return combines, pow
             return False, None
 

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -598,7 +598,7 @@ def test_issue_5261():
     assert exp(e).subs(exp(x), y) == y**I
     assert (2**e).subs(2**x, y) == y**I
     eq = (-2)**e
-    assert eq.subs((-2)**x, y) == eq
+    assert eq.subs((-2)**x, y) == y**I
 
 
 def test_issue_6923():

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -454,7 +454,7 @@ def test_derivative_subs3():
 def test_issue_5284():
     A, B = symbols('A B', commutative=False)
     assert (x*A).subs(x**2*A, B) == x*A
-    assert (A**2).subs(A**3, B) == B**(2/3)
+    assert (A**2).subs(A**3, B) == A**2
     assert (A**6).subs(A**3, B) == B**2
 
 

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -71,6 +71,8 @@ def test_powers():
     assert exp(-1).subs(S.Exp1, 0) is S.ComplexInfinity
     assert (x**(4.0*y)).subs(x**(2.0*y), n) == n**2.0
     assert (2**(x + 2)).subs(2, 3) == 3**(x + 3)
+    f = exp(pi*x)
+    assert f.subs(exp(pi*x), x) == x
 
 
 def test_logexppow():   # no eval()

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -454,7 +454,7 @@ def test_derivative_subs3():
 def test_issue_5284():
     A, B = symbols('A B', commutative=False)
     assert (x*A).subs(x**2*A, B) == x*A
-    assert (A**2).subs(A**3, B) == A**2
+    assert (A**2).subs(A**3, B) == B**(2/3)
     assert (A**6).subs(A**3, B) == B**2
 
 


### PR DESCRIPTION
This is fix for issue #11223 . Previously, subs() could not handle substitutions having `pi` in the exponential power. 
#### Output before this PR:

``` python
>>> from sympy import *
>>> from sympy.abc import x,y,z
>>> from sympy import I
>>> g = -I*exp(2*pi*I*x) + I
>>> g.subs(exp(I*x), y)
-I*exp(2*I*pi*x) + I
```
#### Output after this PR:

``` python
>>> from sympy import *
>>> from sympy.abc import x,y,z
>>> from sympy import I
>>> g = -I*exp(2*pi*I*x) + I
>>> g.subs(exp(I*x), y)
-I*y**(2*pi) + I
```
