### PR TITLE
Added docstring to invert_real method

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -103,6 +103,10 @@ invert_complex = _invert
 
 
 def invert_real(f_x, y, x, domain=S.Reals):
+    """
+    Inverts a real-valued function. Same as _invert, but sets
+    the domain to ``S.Reals`` before inverting.
+    """
     return _invert(f_x, y, x, domain)
 
 


### PR DESCRIPTION
Added docstring to `invert_real` method. Solves #11203, as `invert_complex` is being used by default and that method has docstrings already.
