### PR TITLE
Handle extra symbol in diophantine

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -152,11 +152,24 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None):
             if not is_sequence(syms):
                 raise TypeError(
                     'syms should be given as a sequence, e.g. a list')
-            syms = [i for i in syms if i in var]
+
             if syms != var:
-                map = dict(zip(syms, range(len(syms))))
-                return set([tuple([t[map[i]] for i in var])
-                    for t in diophantine(eq, param)])
+                extra_syms = list(filter(lambda x: x not in var, syms))
+                syms_var = list(filter(lambda x: x in syms, var))
+                map = dict(zip(syms_var, range(len(syms_var))))
+                soln = diophantine(eq, param)
+
+                if len(syms) > len(var):
+                    num_sym = numbered_symbols("m", integer=True, start=1)
+                    for e in extra_syms:
+                        map[e] = next(num_sym)
+                        # reduce by one for all other keys after `e`
+
+                return set([tuple([t[map[i]]
+                           if i not in extra_syms
+                            else map[i]
+                                  for i in syms])
+                            for t in soln])
         n, d = eq.as_numer_denom()
         if not n.free_symbols:
             return set()

--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -152,7 +152,7 @@ def diophantine(eq, param=symbols("t", integer=True), syms=None):
             if not is_sequence(syms):
                 raise TypeError(
                     'syms should be given as a sequence, e.g. a list')
-
+            syms = list(syms)
             if syms != var:
                 extra_syms = list(filter(lambda x: x not in var, syms))
                 syms_var = list(filter(lambda x: x in syms, var))

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -871,3 +871,19 @@ def test_issue_9538():
     eq = x - 3*y + 2
     assert diophantine(eq, syms=[y,x]) == set([(t_0, 3*t_0 - 2)])
     raises(TypeError, lambda: diophantine(eq, syms=set([y,x])))
+
+def test_issue_11236():
+    eq = x**2 + 3*x*y + 4*x
+    soln_xyz = set([(0, n1, m1), (3*t_0 - 4, -t_0, m1)])
+    soln_xzy = set([(0, m1, n1), (3*t_0 - 4, m1, - t_0)])
+    soln_yxz = set([(-t_0, 3*t_0 - 4, m1), (n1, 0, m1)])
+    soln_yzx =set([(-t_0, m1, 3*t_0 - 4), (n1, m1, 0)])
+    soln_zxy = set([(m1, 0, n1), (m1, 3*t_0 - 4, -t_0)])
+    soln_zyx = set([(m1, n1, 0), (m1, -t_0, 3*t_0 - 4)])
+
+    assert diophantine(eq, syms=[x, y, z]) == soln_xyz
+    assert diophantine(eq, syms=[x, z, y]) == soln_xzy
+    assert diophantine(eq, syms=[y, x, z]) == soln_yxz
+    assert diophantine(eq, syms=[y, z, x]) == soln_yzx
+    assert diophantine(eq, syms=[z, x, y]) == soln_zxy
+    assert diophantine(eq, syms=[z, y, x]) == soln_zyx


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/11236

ex: 

```
In [ ]: eq = x**2 + 3*x*y + 4*x

In [ ]: diophantine(eq, syms=[x, z, y])
Out[ ]: set([(0, m₁, n₁), (3⋅t₀ - 4, m₁, -t₀)])

```
