### PR TITLE
By default turn on all `DeprecationWarning` at SymPy level.

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -25,8 +25,7 @@ from sympy.release import __version__
 if 'dev' in __version__:
     def enable_warnings():
         import warnings
-        warnings.filterwarnings('error',   '.*',                      DeprecationWarning, module='sympy.*')
-        # let's not fail the test on that yet.
+        warnings.filterwarnings('error',   '.*',   DeprecationWarning, module='sympy.*')
         warnings.filterwarnings('default', '.*inspect.getargspec.*', DeprecationWarning, module='sympy.*')
         del warnings
     enable_warnings()

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -24,15 +24,11 @@ from sympy.release import __version__
 
 if 'dev' in __version__:
     def enable_warnings():
-        import os
         import warnings
-        action ='default'
-        travis = (os.environ.get('TRAVIS','') == 'true')
-        if travis:
-            action = 'error'
-        warnings.filterwarnings(action,   '.*',                      DeprecationWarning, module='sympy.*')
-        # let's not fail the test on that yet. 
+        warnings.filterwarnings('error',   '.*',                      DeprecationWarning, module='sympy.*')
+        # let's not fail the test on that yet.
         warnings.filterwarnings('default', '.*inspect.getargspec.*', DeprecationWarning, module='sympy.*')
+        del warnings
     enable_warnings()
     del enable_warnings
 
@@ -94,4 +90,3 @@ evalf._create_evalf_table()
 #import abc
 
 from .deprecated import *
-

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -25,7 +25,7 @@ from sympy.release import __version__
 if 'dev' in __version__:
     def enable_warnings():
         import warnings
-        warnings.filterwarnings('error',   '.*',   DeprecationWarning, module='sympy.*')
+        warnings.filterwarnings('default',   '.*',   DeprecationWarning, module='sympy.*')
         del warnings
     enable_warnings()
     del enable_warnings

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -22,6 +22,21 @@ except ImportError:
 
 from sympy.release import __version__
 
+if 'dev' in __version__:
+    def enable_warnings():
+        import os
+        import warnings
+        action ='default'
+        travis = (os.environ.get('TRAVIS','') == 'true')
+        if travis:
+            action = 'error'
+        warnings.filterwarnings(action,   '.*',                      DeprecationWarning, module='sympy.*')
+        # let's not fail the test on that yet. 
+        warnings.filterwarnings('default', '.*inspect.getargspec.*', DeprecationWarning, module='sympy.*')
+    enable_warnings()
+    del enable_warnings
+
+
 import sys
 if sys.version_info[0] == 2 and sys.version_info[1] < 6:
     raise ImportError("Python Version 2.6 or above is required for SymPy.")
@@ -79,3 +94,4 @@ evalf._create_evalf_table()
 #import abc
 
 from .deprecated import *
+

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -26,7 +26,6 @@ if 'dev' in __version__:
     def enable_warnings():
         import warnings
         warnings.filterwarnings('error',   '.*',   DeprecationWarning, module='sympy.*')
-        warnings.filterwarnings('default', '.*inspect.getargspec.*', DeprecationWarning, module='sympy.*')
         del warnings
     enable_warnings()
     del enable_warnings

--- a/sympy/ntheory/egyptian_fraction.py
+++ b/sympy/ntheory/egyptian_fraction.py
@@ -3,7 +3,11 @@ from __future__ import print_function, division
 import sympy.polys
 from sympy import Integer
 from sympy.core.compatibility import range
-from fractions import gcd
+import sys
+if sys.version_info < (3,5):
+    from fractions import gcd
+else:
+    from math import gcd
 
 
 def egyptian_fraction(r, algorithm="Greedy"):

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 import inspect
+import sys
 
 from sympy.external import import_module
 
@@ -220,7 +221,11 @@ def theano_function(inputs, outputs, dtypes={}, cache=None, **kwargs):
     broadcastables = dim_handling(inputs, **kwargs)
 
     # Remove keyword arguments corresponding to dim_handling
-    dim_names = inspect.getargspec(dim_handling)[0]
+    if sys.version_info < (3,):
+        dim_names = inspect.getargspec(dim_handling)[0]
+    else:
+        param = inspect.signature(dim_handling).parameters.items()
+        dim_names = [n for n,p in param if p.kind == p.POSITIONAL_OR_KEYWORD]
     theano_kwargs = dict((k, v) for k, v in kwargs.items()
                                 if k not in dim_names)
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -494,6 +494,13 @@ def _test(*paths, **kwargs):
     import warnings
     warnings.simplefilter("error", SymPyDeprecationWarning)
 
+    # This specific deprecated feature is not fixed yet, don't fail test on it.
+    # we've got an issue to remind us to take care of it:
+    # https://github.com/sympy/sympy/issues/11255
+    # then we can turn it back into error to not reintroduce it.
+    warnings.filterwarnings('default', '.*inspect.getargspec.*',
+            DeprecationWarning, module='sympy.*')
+
     test_files = t.get_test_files('sympy')
 
     not_blacklisted = [f for f in test_files

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -493,6 +493,7 @@ def _test(*paths, **kwargs):
     # Show deprecation warnings
     import warnings
     warnings.simplefilter("error", SymPyDeprecationWarning)
+    warnings.filterwarnings('error', '.*', DeprecationWarning, module='sympy.*')
 
     test_files = t.get_test_files('sympy')
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -494,13 +494,6 @@ def _test(*paths, **kwargs):
     import warnings
     warnings.simplefilter("error", SymPyDeprecationWarning)
 
-    # This specific deprecated feature is not fixed yet, don't fail test on it.
-    # we've got an issue to remind us to take care of it:
-    # https://github.com/sympy/sympy/issues/11255
-    # then we can turn it back into error to not reintroduce it.
-    warnings.filterwarnings('default', '.*inspect.getargspec.*',
-            DeprecationWarning, module='sympy.*')
-
     test_files = t.get_test_files('sympy')
 
     not_blacklisted = [f for f in test_files

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -679,6 +679,7 @@ def _doctest(*paths, **kwargs):
     # Show deprecation warnings
     import warnings
     warnings.simplefilter("error", SymPyDeprecationWarning)
+    warnings.filterwarnings('error', '.*', DeprecationWarning, module='sympy.*')
 
     r = PyTestReporter(verbose, split=split, colors=colors,\
                        force_colors=force_colors)


### PR DESCRIPTION
Apply that only to dev version (let's not be too aggressive),
and turn them into error on Travis (if continuous integration).
Otherwise you'll miss API's updates.

---

ping @asmeurer 

```
$ isympy
REPO/sympy/core/function.py:107: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  evalargspec = inspect.getargspec(cls.eval)
REPO/sympy/core/function.py:107: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  evalargspec = inspect.getargspec(cls.eval)
REPO/sympy/interactive/session.py:475: DeprecationWarning: mainloop `display_banner` argument is deprecated since IPython 5.0. Call `show_banner()` if needed.
  mainloop(message)

In [1]:
```

From a recent [disagreement ](https://github.com/ipython/ipython/pull/9631) we had on how to handle deprecations. 
Who knows the test might turn up more deprecated features. 
