### PR TITLE
[WIP] Improving solveset univariate Trig inequality

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -363,6 +363,30 @@ class ImageSet(Set):
     def is_iterable(self):
         return self.base_set.is_iterable
 
+    def at(self, n):
+        """To get value of ImageSet expr for certain `n` if `n` is in the base_set.
+
+        Examples
+        ========
+
+        >>> from sympy import pi, S, Dummy, Lambda
+        >>> from sympy.sets.sets import FiniteSet, Interval
+        >>> from sympy.sets.fancysets import ImageSet
+        >>> n = Dummy('n')
+        >>> ImageSet(Lambda(n, n*pi), S.Integers).at(0)
+        0
+        >>> ImageSet(Lambda(n, n*pi), S.Integers).at(1)
+        pi
+
+        """
+        base = self.base_set
+        if n in base:
+            lamb = self.args[0]
+            return lamb(n)
+        else:
+            raise ValueError("%s  is not in %s" % (n, base))
+
+
     def _intersect(self, other):
         from sympy.solvers.diophantine import diophantine
         if self.base_set is S.Integers:

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -5,7 +5,7 @@ from sympy.sets.sets import (FiniteSet, Interval, imageset, EmptySet, Union,
                              Intersection)
 from sympy.simplify.simplify import simplify
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
-                   Rational, sqrt, tan, log, exp, Abs, I, Tuple)
+                   Rational, sqrt, tan, log, exp, Abs, I, Tuple, Dummy, Lambda)
 from sympy.utilities.iterables import cartes
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, y, z, t
@@ -667,6 +667,15 @@ def test_ComplexRegion_FiniteSet():
 def test_union_RealSubSet():
     assert (S.Complexes).union(Interval(1, 2)) == S.Complexes
     assert (S.Complexes).union(S.Integers) == S.Complexes
+
+
+def test_imageset_at():
+    n = Dummy('n')
+    assert ImageSet(Lambda(n, n*pi + pi/2), S.Integers).at(S.Zero) == pi/2
+    assert ImageSet(Lambda(n, n*pi + pi/2), S.Integers).at(S(1)) == 3*pi/2
+
+    raises(ValueError, lambda: ImageSet(Lambda(n, n*pi + pi/2), \
+        S.Integers).at(S(1)/2))
 
 
 def test_issue_9980():

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -27,7 +27,9 @@ from .pde import pde_separate, pde_separate_add, pde_separate_mul, \
 from .deutils import ode_order
 
 from .inequalities import reduce_inequalities, reduce_abs_inequality, \
-    reduce_abs_inequalities, solve_poly_inequality, solve_rational_inequalities, solve_univariate_inequality
+    reduce_abs_inequalities, solve_poly_inequality,\
+    solve_rational_inequalities, solve_univariate_inequality,\
+    solveset_univariate_trig_inequality
 
 from .decompogen import decompogen
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -26,7 +26,8 @@ from sympy.matrices import Matrix
 from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf)
 from sympy.solvers.solvers import checksol, denoms, unrad
-from sympy.solvers.inequalities import solve_univariate_inequality
+from sympy.solvers.inequalities import (solve_univariate_inequality,
+                                        solveset_univariate_trig_inequality)
 from sympy.utilities import filldedent
 
 
@@ -786,9 +787,14 @@ def solveset(f, symbol=None, domain=S.Complexes):
                 not supported. Try the real domain by
                 setting domain=S.Reals'''))
         try:
-            result = solve_univariate_inequality(
-            f, symbol, relational=False) - _invalid_solutions(
-            f, symbol, domain)
+            if _is_function_class_equation(
+                    TrigonometricFunction, f.lhs - f.rhs, symbol):
+                result = solveset_univariate_trig_inequality(
+                    f, symbol)
+            else:
+                result = solve_univariate_inequality(
+                    f, symbol, relational=False) - _invalid_solutions(
+                    f, symbol, domain)
         except NotImplementedError:
             result = ConditionSet(symbol, f, domain)
         return result

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -472,6 +472,29 @@ def test_solve_rational():
     assert solveset_real((x**2/(7 - x)).diff(x), x) == \
         FiniteSet(S(0), S(14))
 
+def test_solveset_inequalities():
+    soln = Interval(2, 3, True, True)
+    assert solveset((x - 3)/(x - 2) < 0, x, S.Reals) == soln
+
+    n = Dummy('n')
+    start = ImageSet(Lambda(n, 2*n*pi + pi/6), S.Integers)
+    end = ImageSet(Lambda(n, 2*n*pi + 5*pi/6), S.Integers)
+    soln = Interval(start, end, True, True)
+    assert solveset(sin(x) > S.Half, x, S.Reals) == soln
+
+    soln = Interval(-oo, -1, True, True)
+    assert solveset(x/(x + 1) > 1, x,S.Reals) == soln
+
+    start = ImageSet(Lambda(n, 2*n*pi + pi/4), S.Integers)
+    end = ImageSet(Lambda(n, 2*n*pi + 3*pi/4), S.Integers)
+    soln = Interval(start, end, True, True)
+    assert solveset(sin(x) > 1/sqrt(2), x, S.Reals) == soln
+
+    start = ImageSet(Lambda(n, n*pi - pi/3), S.Integers)
+    end = ImageSet(Lambda(n, n*pi + pi/3), S.Integers)
+    soln = Interval(start, end, True, True)
+    assert solveset((2*cos(x)+1)/(2*cos(x)-1) > 0, x, S.Reals) == soln
+
 
 def test_solveset_real_gen_is_pow():
     assert solveset_real(sqrt(1) + 1, x) == EmptySet()
@@ -708,19 +731,16 @@ def test_solveset_complex_tan():
 def test_solve_trig():
     from sympy.abc import n
     assert solveset_real(sin(x), x) == \
-        Union(imageset(Lambda(n, 2*pi*n), S.Integers),
-              imageset(Lambda(n, 2*pi*n + pi), S.Integers))
+        imageset(Lambda(n, pi*n), S.Integers)
 
     assert solveset_real(sin(x) - 1, x) == \
         imageset(Lambda(n, 2*pi*n + pi/2), S.Integers)
 
     assert solveset_real(cos(x), x) == \
-        Union(imageset(Lambda(n, 2*pi*n - pi/2), S.Integers),
-              imageset(Lambda(n, 2*pi*n + pi/2), S.Integers))
+        imageset(Lambda(n, n*pi + pi/2), S.Integers)
 
     assert solveset_real(sin(x) + cos(x), x) == \
-        Union(imageset(Lambda(n, 2*n*pi - pi/4), S.Integers),
-              imageset(Lambda(n, 2*n*pi + 3*pi/4), S.Integers))
+        imageset(Lambda(n, n*pi - pi/4), S.Integers)
 
     assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptySet
 


### PR DESCRIPTION
`solveset_univariate_trig_inequality` function is added to handle Trigonometric inequality.

Main intention is to get extended solution.

eg.

```
In [2]: solveset((2*cos(x)+1)/(2*cos(x)-1) > 0, x, S.Reals)
Out[2]:
⎡⎧      π        ⎫  ⎧      π        ⎫⎤
⎢⎨n⋅π - ─ | n ∊ ℤ⎬, ⎨n⋅π + ─ | n ∊ ℤ⎬⎥
⎣⎩      3        ⎭  ⎩      3        ⎭⎦

n [4]: solveset(sin(x) > 1/sqrt(2), x, S.Reals)
Out[4]:
⎛⎧        π        ⎫  ⎧        3⋅π        ⎫⎞
⎜⎨2⋅n⋅π + ─ | n ∊ ℤ⎬, ⎨2⋅n⋅π + ─── | n ∊ ℤ⎬⎟
⎝⎩        4        ⎭  ⎩         4         ⎭⎠

In [15]: solveset(2*cos(x) + sqrt(3) < 0, x, S.Reals)
Out[15]:
⎛⎧        5⋅π        ⎫  ⎧        7⋅π        ⎫⎞
⎜⎨2⋅n⋅π + ─── | n ∊ ℤ⎬, ⎨2⋅n⋅π + ─── | n ∊ ℤ⎬⎟
⎝⎩         6         ⎭  ⎩         6         ⎭⎠

In [16]: solveset_univariate_trig_inequality(tan(x) > 0, x)
Out[16]: 
⎛               ⎧      π        ⎫⎞
⎜{n⋅π | n ∊ ℤ}, ⎨n⋅π + ─ | n ∊ ℤ⎬⎟
⎝               ⎩      2        ⎭⎠

```
