### PR TITLE
Added support for a bodies attribute to LagrangesMethod

### DIFF
--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -33,6 +33,8 @@ class LagrangesMethod(object):
     forcelist : iterable
         Iterable of (Point, vector) or (ReferenceFrame, vector) tuples
         describing the forces on the system.
+    bodies : iterable
+        Iterable containing the rigid bodies and particles of the system.
     mass_matrix : Matrix
         The system's mass matrix
     forcing : Matrix
@@ -99,19 +101,19 @@ class LagrangesMethod(object):
     Please refer to the docstrings on each method for more details.
     """
 
-    def __init__(self, Lagrangian, qs, coneqs=None, forcelist=None,
-            frame=None, hol_coneqs=None, nonhol_coneqs=None):
+    def __init__(self, Lagrangian, qs, coneqs=None, forcelist=None, bodies=None,
+                 frame=None, hol_coneqs=None, nonhol_coneqs=None):
         """Supply the following for the initialization of LagrangesMethod
 
         Lagrangian : Sympifyable
 
-        qs: array_like
+        qs : array_like
             The generalized coordinates
 
-        hol_coneqs: array_like, optional
+        hol_coneqs : array_like, optional
             The holonomic constraint equations
 
-        nonhol_coneqs: array_like, optional
+        nonhol_coneqs : array_like, optional
             The nonholonomic constraint equations
 
         forcelist : iterable, optional
@@ -119,6 +121,10 @@ class LagrangesMethod(object):
             tuples which represent the force at a point or torque on a frame.
             This feature is primarily to account for the nonconservative forces
             and/or moments.
+
+        bodies : iterable, optional
+            Takes an iterable containing the rigid bodies and particles of the
+            system.
 
         frame : ReferenceFrame, optional
             Supply the inertial frame. This is used to determine the
@@ -139,6 +145,7 @@ class LagrangesMethod(object):
         self._forcelist = forcelist
         if frame and not isinstance(frame, ReferenceFrame):
             raise TypeError('frame must be a valid ReferenceFrame')
+        self._bodies = bodies
         self.inertial = frame
 
         self.lam_vec = Matrix()
@@ -458,6 +465,10 @@ class LagrangesMethod(object):
     @property
     def u(self):
         return self._qdots
+
+    @property
+    def bodies(self):
+        return self._bodies
 
     @property
     def forcelist(self):

--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -161,7 +161,7 @@ def test_dub_pen():
     ParP.potential_energy = - m * g * l * cos(q1)
     ParR.potential_energy = - m * g * l * cos(q1) - m * g * l * cos(q2)
     L = Lagrangian(N, ParP, ParR)
-    lm = LagrangesMethod(L, [q1, q2])
+    lm = LagrangesMethod(L, [q1, q2], bodies=[ParP, ParR])
     lm.form_lagranges_equations()
 
     assert simplify(l*m*(2*g*sin(q1) + l*sin(q1)*sin(q2)*q2dd
@@ -170,6 +170,7 @@ def test_dub_pen():
     assert simplify(l*m*(g*sin(q2) + l*sin(q1)*sin(q2)*q1dd
         - l*sin(q1)*cos(q2)*q1d**2 + l*sin(q2)*cos(q1)*q1d**2
         + l*cos(q1)*cos(q2)*q1dd + l*q2dd) - lm.eom[1]) == 0
+    assert lm.bodies == [ParP, ParR]
 
 
 def test_rolling_disc():


### PR DESCRIPTION
LagrangesMethod now has a self.bodies attribute just like KanesMethod. Tests have also been added.

In a conversation with @moorepants I brought up that `LagrangesMethod` does not have information on the bodies of the system for which it finds the equations of motion. It was determined that the body information must therefore lie in the `Lagrangian`. Upon further research I determined this was only part true. The `Lagrangian` does use the bodies information of the system but it turns out it is only a function not a class and only returns a sympy expression of the Lagrangian. This means that there is not attribute to access the bodies information inside of `LagrangesMethod`. I decided a minimally invasive solution to add bodies to the system was to make it an optional keyword argument upon initialization of the `LagrangesMethod` instance. The attribute access was made to be identical to the `KanesMethod` API.
