### PR TITLE
[WIP] Making Range work with symbolic entries

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1501,7 +1501,7 @@ class PrettyPrinter(Printer):
 
         if s.start.is_infinite:
             printset = s.start, dots, s[-1] - s.step, s[-1]
-        elif s.stop.is_infinite or len(s) > 4:
+        elif s.stop.is_infinite or s.is_symbolic or len(s) > 4:
             it = iter(s)
             printset = next(it), next(it), dots, s[-1]
         else:

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -471,6 +471,9 @@ class Range(Set):
 
     def __new__(cls, *args):
         from sympy.functions.elementary.integers import ceiling
+
+        args = _sympify(args)
+
         if len(args) == 1:
             if isinstance(args[0], range if PY3 else xrange):
                 args = args[0].__reduce__()[1]  # use pickle method
@@ -481,7 +484,7 @@ class Range(Set):
         if slc.step == 0:
             raise ValueError("step cannot be 0")
 
-        start, stop, step = slc.start or 0, slc.stop, slc.step or 1
+        start, stop, step = slc.start or S(0), slc.stop, slc.step or S(1)
         try:
             start, stop, step = [
                 w if w in [S.NegativeInfinity, S.Infinity]
@@ -512,8 +515,8 @@ class Range(Set):
             n = ceiling((stop - ref)/step)
             if n <= 0:
                 # null Range
-                start = end = 0
-                step = 1
+                start = end = S(0)
+                step = S(1)
             else:
                 end = ref + n*step
         return Basic.__new__(cls, start, end, step)


### PR DESCRIPTION
I haven't addressed all the methods in Range yet. I also haven't added any tests yet. I will likely just raise NotImplementedError for complicated things like intersect, since I don't actually need those for my use-cases. 

One known issue: `Range(n).size` gives `abs(n)`, but it should be `Piecewise((n, n > 0), (0, True))` (or some equivalent). 

If anyone wants to pick up this work, feel free (but let me know). I don't know how long it will be before I finish this. 
