### PR TITLE
Intersection with S.Reals shouldn't clear coeff

### DIFF
--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -398,7 +398,7 @@ How does ``solveset`` ensure that it is not returning any wrong solution?
     >>> from sympy import symbols, S, pprint, solveset
     >>> x, n = symbols('x, n')
     >>> pprint(solveset(abs(x) - n, x, domain=S.Reals), use_unicode=True)
-    [0, ∞) ∩ {n}
+    ([0, ∞) ∩ {n}) ∪ ((-∞, 0] ∩ {-n})
 
  Though, there still a lot of work needs to be done in this regard.
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1532,14 +1532,15 @@ class Intersection(Set):
                     e = list(s)[0]
                     if e.free_symbols:
                         rhs = Dummy()
-                        e, r = clear_coefficients(e, rhs)
-                        if r != rhs:
-                            iargs = list(ivl.args)
-                            iargs[0] = r.subs(rhs, ivl.start)
-                            iargs[1] = r.subs(rhs, ivl.end)
-                            if iargs[0] > iargs[1]:
-                                iargs = iargs[:2][::-1] + iargs[-2:][::-1]
-                            rv = Intersection(FiniteSet(e), Interval(*iargs), evaluate=False)
+                        if ivl != S.Reals:
+                            e, r = clear_coefficients(e, rhs)
+                            if r != rhs:
+                                iargs = list(ivl.args)
+                                iargs[0] = r.subs(rhs, ivl.start)
+                                iargs[1] = r.subs(rhs, ivl.end)
+                                if iargs[0] > iargs[1]:
+                                    iargs = iargs[:2][::-1] + iargs[-2:][::-1]
+                                rv = Intersection(FiniteSet(e), Interval(*iargs), evaluate=False)
             return rv
 
         # If any of the sets are unions, return a Union of Intersections

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1524,23 +1524,6 @@ class Intersection(Set):
         # Handle Finite sets
         rv = Intersection._handle_finite_sets(args)
         if rv is not None:
-            # simplify symbolic intersection between a FiniteSet
-            # and an interval
-            if isinstance(rv, Intersection) and len(rv.args) == 2:
-                ivl, s = rv.args
-                if isinstance(s, FiniteSet) and len(s) == 1 and isinstance(ivl, Interval):
-                    e = list(s)[0]
-                    if e.free_symbols:
-                        rhs = Dummy()
-                        if ivl != S.Reals:
-                            e, r = clear_coefficients(e, rhs)
-                            if r != rhs:
-                                iargs = list(ivl.args)
-                                iargs[0] = r.subs(rhs, ivl.start)
-                                iargs[1] = r.subs(rhs, ivl.end)
-                                if iargs[0] > iargs[1]:
-                                    iargs = iargs[:2][::-1] + iargs[-2:][::-1]
-                                rv = Intersection(FiniteSet(e), Interval(*iargs), evaluate=False)
             return rv
 
         # If any of the sets are unions, return a Union of Intersections

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1053,3 +1053,11 @@ def test_issue_10285():
 def test_issue_10931():
     assert S.Integers - S.Integers == EmptySet()
     assert S.Integers - S.Reals == EmptySet()
+
+
+def test_issue_11174():
+    soln = Intersection(S.Reals, FiniteSet(-x))
+    assert Intersection(FiniteSet(-x), S.Reals) == soln
+
+    soln = Intersection(S.Reals, FiniteSet(x))
+    assert Intersection(FiniteSet(x), S.Reals) == soln

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1035,29 +1035,14 @@ def test_issue_8257():
     assert FiniteSet(-oo) + Interval(-oo, oo) == reals_plus_negativeinfinity
 
 
-def test_issue_10285():
-    assert FiniteSet(-x - 1).intersect(Interval.Ropen(1, 2)) == \
-        FiniteSet(x).intersect(Interval.Lopen(-3, -2))
-    eq = -x - 2*(-x - y)
-    s = signsimp(eq)
-    ivl = Interval.open(0, 1)
-    assert FiniteSet(eq).intersect(ivl) == FiniteSet(s).intersect(ivl)
-    assert FiniteSet(-eq).intersect(ivl) == \
-        FiniteSet(s).intersect(Interval.open(-1, 0))
-    eq -= 1
-    ivl = Interval.Lopen(1, oo)
-    assert FiniteSet(eq).intersect(ivl) == \
-        FiniteSet(s).intersect(Interval.Lopen(2, oo))
-
-
 def test_issue_10931():
     assert S.Integers - S.Integers == EmptySet()
     assert S.Integers - S.Reals == EmptySet()
 
 
 def test_issue_11174():
-    soln = Intersection(S.Reals, FiniteSet(-x))
+    soln = Intersection(Interval(-oo, oo), FiniteSet(-x), evaluate=False)
     assert Intersection(FiniteSet(-x), S.Reals) == soln
 
-    soln = Intersection(S.Reals, FiniteSet(x))
+    soln = Intersection(S.Reals, FiniteSet(x), evaluate=False)
     assert Intersection(FiniteSet(x), S.Reals) == soln

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1086,3 +1086,14 @@ def test_issue_8715():
         (Interval.open(-2, oo) - FiniteSet(0))
     assert solveset(eq.subs(x,log(x)), x, S.Reals) == \
         Interval.open(exp(-2), oo) - FiniteSet(1)
+
+def test_issue_11174():
+    r, t = symbols('r t')
+    eq = z**2 + exp(2*x) - sin(y)
+    soln = Intersection(S.Reals, FiniteSet(log(-z**2 + sin(y))/2))
+    assert solveset(eq, x, S.Reals) == soln
+
+    eq = sqrt(r)*Abs(tan(t))/sqrt(tan(t)**2 + 1) + x*tan(t)
+    s = -sqrt(r)*Abs(tan(t))/(sqrt(tan(t)**2 + 1)*tan(t))
+    soln = Intersection(S.Reals, FiniteSet(s))
+    assert solveset(eq, x, S.Reals) == soln

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -139,13 +139,20 @@ def test_invert_real():
     n = Dummy('n')
     x = Symbol('x')
 
-    h1 = Intersection(Interval(-oo, -3), FiniteSet(-a + b - 3),
+    h1 = Intersection(Interval(-3, oo), FiniteSet(a + b - 3),
+                      imageset(Lambda(n, -n + a - 3), Interval(-oo, 0)))
+
+    h2 = Intersection(Interval(-oo, -3), FiniteSet(-a + b - 3),
                       imageset(Lambda(n, n - a - 3), Interval(0, oo)))
 
-    h2 = Intersection(Interval(-3, oo), FiniteSet(a - b - 3),
+    h3 = Intersection(Interval(-3, oo), FiniteSet(a - b - 3),
                       imageset(Lambda(n, -n + a - 3), Interval(0, oo)))
 
-    assert invert_real(Abs(Abs(x + 3) - a) - b, 0, x) == (x, Union(h1, h2))
+    h4 = Intersection(Interval(-oo, -3), FiniteSet(-a - b - 3),
+                      imageset(Lambda(n, n - a - 3), Interval(-oo, 0)))
+
+    soln = (x, Union(h1, h2, h3, h4))
+    assert invert_real(Abs(Abs(x + 3) - a) - b, 0, x) == soln
 
 
 def test_invert_complex():


### PR DESCRIPTION
Fixes some cases of https://github.com/sympy/sympy/issues/11174
##### From master branch :

```
In [1]: Intersection(FiniteSet(-x), S.Reals)
Out[1]: (-∞, ∞) ∩ {x}

In [2]: solveset(z**2 + exp(2*x) - sin(y),x,S.Reals)
Out[2]: 
          ⎧   ⎛ ⎛ 2         ⎞⎞⎫
(-∞, ∞) ∩ ⎨log⎝-⎝z  - sin(y)⎠⎠⎬
          ⎩                   ⎭

In [4]: r, t = symbols('r t')

In [5]: solveset(sqrt(r)*Abs(tan(t))/sqrt(tan(t)**2 + 1) + x*tan(t),x,S.Reals)
Out[5]: 
          ⎧      √r⋅│tan(t)│      ⎫
(-∞, ∞) ∩ ⎪───────────────────────⎪
          ⎨   _____________       ⎬
          ⎪  ╱    2               ⎪
          ⎩╲╱  tan (t) + 1 ⋅tan(t)⎭

```
##### From this branch :

```
In [ ]: Intersection(FiniteSet(-x), S.Reals)
Out[ ]: ℝ ∩ {-x}

In [ ]: solveset(z**2 + exp(2*x) - sin(y),x,S.Reals)
Out[ ]: 
    ⎧   ⎛   2         ⎞⎫
    ⎪log⎝- z  + sin(y)⎠⎪
ℝ ∩ ⎨──────────────────⎬
    ⎪        2         ⎪
    ⎩                  ⎭

In [ ]: r, t = symbols('r t')
In [ ]: solveset(sqrt(r)*Abs(tan(t))/sqrt(tan(t)**2 + 1) + x*tan(t),x,S.Reals)
Out[ ]: 
    ⎧     -√r⋅│tan(t)│      ⎫
ℝ ∩ ⎪───────────────────────⎪
    ⎨   _____________       ⎬
    ⎪  ╱    2               ⎪
    ⎩╲╱  tan (t) + 1 ⋅tan(t)⎭

```

If someone use `x, y, z` as Real number then `log(-(z**2 - sin(y)))` is not the correct ans. Ans should be `log(-(z**2 - sin(y)))/2`. similarly 3rd case.
