### PR TITLE
Replace the coefficient of  abs  in the lookup table of meijerint.

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -108,7 +108,7 @@ def _create_lookup_table(table):
     add((b + t)**(-a), [1 - a], [], [0], [], t/b, b**(-a)/gamma(a),
         hint=Not(IsNonPositiveInteger(a)))
     add(abs(b - t)**(-a), [1 - a], [(1 - a)/2], [0], [(1 - a)/2], t/b,
-        pi/(gamma(a)*cos(pi*a/2))*abs(b)**(-a), re(a) < 1)
+        2*sin(pi*a/2)*gamma(1 - a)*abs(b)**(-a), re(a) < 1)
     add((t**a - b**a)/(t - b), [0, a], [], [0, a], [], t/b,
         b**(a - 1)*sin(a*pi)/pi)
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -110,7 +110,8 @@ def test_mellin_transform():
 
     # TODO also the conditions should be simplified
     assert MT(abs(1 - x)**(-rho), x, s) == (
-        cos(pi*(rho/2 - s))*gamma(s)*gamma(rho - s)/(cos(pi*rho/2)*gamma(rho)),
+        2*sin(pi*rho/2)*gamma(1 - rho)*
+        cos(pi*(rho/2 - s))*gamma(s)*gamma(rho-s)/pi,
         (0, re(rho)), And(re(rho) - 1 < 0, re(rho) < 1))
     mt = MT((1 - x)**(beta - 1)*Heaviside(1 - x)
             + a*(x - 1)**(beta - 1)*Heaviside(x - 1), x, s)
@@ -126,6 +127,7 @@ def test_mellin_transform():
     assert MT(expr.subs(b, bpos), x, s) == \
         (-a*(2*bpos)**(a + 2*s)*gamma(s)*gamma(-a - 2*s)/gamma(-a - s + 1),
          (0, -re(a)/2), True)
+
     expr = (sqrt(x + b**2) + b)**a/sqrt(x + b**2)
     assert MT(expr.subs(b, bpos), x, s) == \
         (2**(a + 2*s)*bpos**(a + 2*s - 1)*gamma(s)


### PR DESCRIPTION
The denominator of the coefficient  `pi/(cos(pi*a/2)*gamma(a))`
becomes indeterminate for negative odd integers  `a`  where  `cos(pi*a/2)`
has a zero and  `gamma(a)`  has a pole. There is no code for computing
the limit at such argument values. This PR replaces the coefficient
with  `2*sin(pi*a/2)*gamma(1 - a)`, which is well defined for  `re(a) < 1`,
since the only poles of gamma occur at nonpositive integers.

The equivalence of the two forms can be derived from the standard
formulas

```
gamma(a)*gamma(1 - a) = pi/sin(pi*a)
```

and

```
sin(pi*a) = 2*sin(pi*a/2)*cos(pi*a/2).
```
