### PR TITLE
Making is_Mul LaTeX expressions consistent with Pretty Printer

### DIFF
--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -60,6 +60,7 @@ def test_latex_basic():
     assert latex(1/x) == r"\frac{1}{x}"
     assert latex(1/x, fold_short_frac=True) == "1 / x"
     assert latex(1/x**2) == r"\frac{1}{x^{2}}"
+    assert latex(1/(x + y)/2) == r"\frac{1}{2 \left(x + y\right)}"
     assert latex(x/2) == r"\frac{x}{2}"
     assert latex(x/2, fold_short_frac=True) == "x / 2"
     assert latex((x + y)/(2*x)) == r"\frac{x + y}{2 x}"
@@ -121,6 +122,9 @@ def test_latex_basic():
         r"z_i \vee \left(x_i \wedge y_i\right)"
     assert latex(Implies(x, y), symbol_names={x: "x_i", y: "y_i"}) == \
         r"x_i \Rightarrow y_i"
+
+    p = Symbol('p', positive=True)
+    assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left (p \right )}"
 
 
 def test_latex_builtins():

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -957,6 +957,11 @@ def fraction(expr, exact=False):
             if ex.is_negative:
                 if ex is S.NegativeOne:
                     denom.append(b)
+                elif exact:
+                    if ex.is_constant():
+                        denom.append(Pow(b, -ex))
+                    else:
+                        numer.append(term)
                 else:
                     denom.append(Pow(b, -ex))
             elif ex.is_positive:
@@ -973,8 +978,10 @@ def fraction(expr, exact=False):
             denom.append(d)
         else:
             numer.append(term)
-
-    return Mul(*numer), Mul(*denom)
+    if exact:
+        return Mul(*numer, evaluate=False), Mul(*denom, evaluate=False)
+    else:
+        return Mul(*numer), Mul(*denom)
 
 
 def numer(expr):

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -385,6 +385,7 @@ def test_fraction():
     assert fraction(x*(y + 1)/y**7) == (x*(y + 1), y**7)
 
     assert fraction(exp(-x), exact=True) == (exp(-x), 1)
+    assert fraction((1/(x + y))/2, exact=True) == (1, Mul(2,(x + y), evaluate=False))
 
     assert fraction(x*A/y) == (x*A, y)
     assert fraction(x*A**-1/y) == (x*A**-1, y)
@@ -393,6 +394,8 @@ def test_fraction():
     assert fraction(exp(n)) == (1, exp(-n))
     assert fraction(exp(-n)) == (exp(-n), 1)
 
+    p = symbols('p', positive=True)
+    assert fraction(exp(-p)*log(p), exact=True) == (exp(-p)*log(p), 1)
 
 def test_issue_5615():
     aA, Re, a, b, D = symbols('aA Re a b D')


### PR DESCRIPTION
This is fix for issue #11275.
#### Output before this PR:

``` python
In [9]: var('x', positive=True)
Out[9]: x

In [10]: latex(exp(-x)*log(x))
Out[10]: '\\frac{1}{e^{x}} \\log{\\left (x \\right )}'

In [14]: var('x y')
Out[14]: (x, y)

In [15]: latex(1/(x + y)/2)
Out[15]: '\\frac{1}{2 x + 2 y}'

```
#### Output after this PR:

``` python
>>> var('x', positive=True)
x
>>> latex(exp(-x)*log(x))
'e^{- x} \\log{\\left (x \\right )}'
>>> var('x y')
(x, y)
>>> latex(1/(x + y)/2)
'\\frac{1}{2 \\left(x + y\\right)}'
```
- Tests are added.
