### PR TITLE
dsolve fix for 1st_exact_Integral

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2811,7 +2811,6 @@ def _handle_Integral(expr, func, order, hint):
         del y
     elif hint == "1st_exact_Integral":
         sol = expr
-        del y
     elif hint == "nth_linear_constant_coeff_homogeneous":
         sol = expr
     elif not hint.endswith("_Integral"):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2810,7 +2810,6 @@ def _handle_Integral(expr, func, order, hint):
         sol = (expr.doit()).subs(y, f(x))
         del y
     elif hint == "1st_exact_Integral":
-        sol = expr.subs(y, f(x))
         del y
     elif hint == "nth_linear_constant_coeff_homogeneous":
         sol = expr

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2810,6 +2810,7 @@ def _handle_Integral(expr, func, order, hint):
         sol = (expr.doit()).subs(y, f(x))
         del y
     elif hint == "1st_exact_Integral":
+        sol = expr
         del y
     elif hint == "nth_linear_constant_coeff_homogeneous":
         sol = expr

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1018,6 +1018,11 @@ def test_1st_exact1():
     assert checkodesol(eq4, sol4, order=1, solve_for_func=False)[0]
     assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
 
+def test_1st_exact_Integral():
+    eq = cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x)
+    sol = 'Eq(Integral(_y**2 - x*sin(_y) - Integral(-sin(_y), x), _y) + Integral(cos(_y), x), C1)'
+    assert str(dsolve(eq, f(x), simplify=False, hint='1st_exact_Integral')) == sol
+
 
 @slow
 @XFAIL


### PR DESCRIPTION
This is fix for #11290. Prevented substitution of `y` in the expression.
#### Output before this PR:

``` python
In [15]: dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x), f(x), simplify=False, hint='1st_exact_Integral')
Out[15]:
f(x)
 ⌠
 ⎮   ⎛ 2              ⌠           ⎞      ⌠
 ⎮   ⎜y  - x⋅sin(y) - ⎮ -sin(y) dx⎟ dy + ⎮ cos(f(x)) dx = C₁
 ⎮   ⎝                ⌡           ⎠      ⌡
 ⌡


In [16]: dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x), f(x), simplify=False, hint='1st_exact_Integral').doit()
Out[16]:
 3
f (x)   ⌠
───── + ⎮ cos(f(x)) dx = C₁
  3     ⌡
```
#### Output after this PR:

``` python
>>> from sympy import Function, dsolve, cos, sin
>>> from sympy.abc import x
>>> f = Function('f')
>>> pprint(dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x), f(x), simplify=False, hint='1st_exact_Integral'))
⌠                                                     
⎮ ⎛ 2              ⌠           ⎞      ⌠               
⎮ ⎜y  - x⋅sin(y) - ⎮ -sin(y) dx⎟ dy + ⎮ cos(y) dx = C₁
⎮ ⎝                ⌡           ⎠      ⌡               
⌡                                                     
>>> pprint(dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x), f(x), simplify=False, hint='1st_exact_Integral').doit())
 3                
y                 
── + x⋅cos(y) = C₁
3                 
```
