### PR TITLE
DOC: standardize variables in pde_separate and helpers

### DIFF
--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -814,9 +814,9 @@ def pde_separate(eq, fun, sep, strategy='mul'):
 
     :param eq: Partial differential equation
 
-    :param fun: Original function F(x, y, z)
+    :param fun: Original function u(x, t)
 
-    :param sep: List of separated functions [X(x), u(y, z)]
+    :param sep: List of separated functions [X(x), T(t)]
 
     :param strategy: Separation strategy. You can choose between additive
         separation ('add') and multiplicative separation ('mul') which is
@@ -897,11 +897,11 @@ def pde_separate_add(eq, fun, sep):
     """
     Helper function for searching additive separable solutions.
 
-    Consider an equation of two independent variables x, y and a dependent
-    variable w, we look for the product of two functions depending on different
+    Consider an equation of two independent variables x and t and a dependent
+    variable u, we look for the sum of two functions depending on different
     arguments:
 
-    `w(x, y, z) = X(x) + y(y, z)`
+    `u(x, t) = X(x) + T(t)`
 
     Examples
     ========
@@ -922,11 +922,11 @@ def pde_separate_mul(eq, fun, sep):
     """
     Helper function for searching multiplicative separable solutions.
 
-    Consider an equation of two independent variables x, y and a dependent
-    variable w, we look for the product of two functions depending on different
+    Consider an equation of two independent variables x and t and a dependent
+    variable u, we look for the product of two functions depending on different
     arguments:
 
-    `w(x, y, z) = X(x)*u(y, z)`
+    `u(x, t) = X(x)*T(t)`
 
     Examples
     ========
@@ -935,9 +935,16 @@ def pde_separate_mul(eq, fun, sep):
     >>> from sympy.abc import x, y
     >>> u, X, Y = map(Function, 'uXY')
 
-    >>> eq = Eq(D(u(x, y), x, 2), D(u(x, y), y, 2))
-    >>> pde_separate_mul(eq, u(x, y), [X(x), Y(y)])
-    [Derivative(X(x), x, x)/X(x), Derivative(Y(y), y, y)/Y(y)]
+    >>> eq = Eq(D(u(x, y), x, 2), D(u(x, t), t, 2))
+    >>> pde_separate_mul(eq, u(x, t), [X(x), T(t)])
+    [Derivative(X(x), x, x)/X(x), Derivative(T(t), t, t)/T(t)]
+
+    References
+    ==========
+
+    - Viktor Grigoryan, "Partial Differential Equations"
+      Math 124A - Fall 2010, p. 84
+
 
     """
     return pde_separate(eq, fun, sep, strategy='mul')

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -897,9 +897,9 @@ def pde_separate_add(eq, fun, sep):
     """
     Helper function for searching additive separable solutions.
 
-    Consider an equation of two independent variables x and t and a dependent
-    variable u, we look for the sum of two functions depending on different
-    arguments:
+    Consider a function, u, of two independent variables x and t. We
+    seek a sum of functions, each being dependent on one of the
+    variables:
 
     `u(x, t) = X(x) + T(t)`
 
@@ -922,9 +922,9 @@ def pde_separate_mul(eq, fun, sep):
     """
     Helper function for searching multiplicative separable solutions.
 
-    Consider an equation of two independent variables x and t and a dependent
-    variable u, we look for the product of two functions depending on different
-    arguments:
+    Consider a function, u, of two independent variables x and t.  We
+    seek a product of functions, each being dependent on one of the
+    variables:
 
     `u(x, t) = X(x)*T(t)`
 


### PR DESCRIPTION
This request closes #11296.

The help-string for `pde_separate` should be consistent with those of its helpers, `pde_separate_add` and `pde_separate_mul`; further, the text should be consistent with the examples.

The previous request, #11296, was to fix a simple mistake of 'product' instead of 'sum' in the help-string for `pde_separate_add`, presumably having arisen from a copy'n'paste from its sibling, `pde_separate_mul`.  This was queried by @smichr who made a more extensive suggestion which at the time exceeded my knowledge of the functions.

On closer inspection, the examples for `pde_separate` use a dependent variable u depending on independent variables `x` and `t`, but the text refers to a `Function` `F(x, y, z)` instead of `u(x, t)`, and worse calls one of the separated functions `u`.

Another minor confusion is that the dependent variable `t` is changed to `y` in the (otherwise identical) example for `pde_separate_mul`.

This request makes all three help-string consistent with each other, and between text and examples, changing the text to match the examples.

I have also added a reference to Grigoryan (2010) for the multiplicative example, those course notes being the main reference for this module.
