### PR TITLE
Simplified the solution returned by an imageset

### DIFF
--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -21,7 +21,7 @@ def test_singularities():
     assert singularities(1/(x**2 + 1), x) == FiniteSet(I, -I)
     assert singularities(x/(x**3 + 1), x) == FiniteSet(-1, (1 - sqrt(3)*I)/2,
                                                        (1 + sqrt(3)*I)/2)
-    assert singularities(1/(y**2 + 2*I*y + 1), y) == FiniteSet(-I + sqrt(2)*I, -I - sqrt(2)*I)
+    assert singularities(1/(y**2 + 2*I*y + 1), y) == FiniteSet(I*(-1 + sqrt(2)), -I*(1 + sqrt(2)))
 
 @XFAIL
 def test_singularities_non_rational():

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -865,8 +865,8 @@ def test_M5():
 
 
 def test_M6():
-    assert set(solveset(x**7 - 1, x)) == \
-        {cos(n*2*pi/7) + I*sin(n*2*pi/7) for n in range(0, 7)}
+    assert solveset(x**7 - 1, x) == \
+        FiniteSet(*(simplify(cos(n*2*pi/7) + I*sin(n*2*pi/7)) for n in range(0, 7)))
     # The paper asks for exp terms, but sin's and cos's may be acceptable;
     # if the results are simplified, exp terms appear for all but
     # -sin(pi/14) - I*cos(pi/14) and -sin(pi/14) + I*cos(pi/14) which

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2076,6 +2076,7 @@ def imageset(*args):
     from sympy.core import Lambda
     from sympy.sets.fancysets import ImageSet
     from sympy.geometry.util import _uniquely_named_symbol
+    from sympy.simplify import simplify
 
     if len(args) not in (2, 3):
         raise ValueError('imageset expects 2 or 3 args, got: %s' % len(args))
@@ -2116,6 +2117,9 @@ def imageset(*args):
             return imageset(Lambda(set.lamda.variables[0],
                                    f.expr.subs(f.variables[0], set.lamda.expr)),
                             set.base_set)
+
+    if isinstance(r, FiniteSet):
+        r = FiniteSet(*map(simplify, r))
 
     if r is not None:
         return r

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -387,7 +387,7 @@ def test_solveset_sqrt_2():
     assert solveset_real(eq, x) == FiniteSet(16)
 
     assert solveset_real(sqrt(x) + sqrt(sqrt(x)) - 4, x) == \
-        FiniteSet((-S.Half + sqrt(17)/2)**4)
+        FiniteSet((S.One - sqrt(17))**4/16)
 
     eq = sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))
     assert solveset_real(eq, x) == FiniteSet()
@@ -430,13 +430,8 @@ def test_solve_sqrt_3():
     eq = sqrt(2)*R*sqrt(1/(R + 1)) + (R + 1)*(sqrt(2)*sqrt(1/(R + 1)) - 1)
     sol = solveset_complex(eq, R)
 
-    assert sol == FiniteSet(*[S(5)/3 + 4*sqrt(10)*cos(atan(3*sqrt(111)/251)/3)/3,
-        -sqrt(10)*cos(atan(3*sqrt(111)/251)/3)/3 + 40*re(1/((-S(1)/2 -
-        sqrt(3)*I/2)*(S(251)/27 + sqrt(111)*I/9)**(S(1)/3)))/9 +
-        sqrt(30)*sin(atan(3*sqrt(111)/251)/3)/3 + S(5)/3 +
-        I*(-sqrt(30)*cos(atan(3*sqrt(111)/251)/3)/3 -
-        sqrt(10)*sin(atan(3*sqrt(111)/251)/3)/3 + 40*im(1/((-S(1)/2 -
-        sqrt(3)*I/2)*(S(251)/27 + sqrt(111)*I/9)**(S(1)/3)))/9)])
+    assert sol == FiniteSet(S(5)/3 + 4*sqrt(10)*cos(atan(3*sqrt(111)/251)/3)/3,
+ -4*sqrt(10)*sin((-2*atan(3*sqrt(111)/251) + pi)/6)/3 + S(5)/3)
 
     # the number of real roots will depend on the value of m: for m=1 there are 4
     # and for m=-1 there are none.
@@ -457,7 +452,7 @@ def test_solve_polynomial_symbolic_param():
 
     # issue 4507
     assert solveset_complex(y - b/(1 + a*x), x) == \
-        FiniteSet((b/y - 1)/a) - FiniteSet(-1/a)
+        FiniteSet((b - y)/(a*y)) - FiniteSet(-1/a)
 
     # issue 4508
     assert solveset_complex(y - b*x/(a + x), x) == \
@@ -655,7 +650,7 @@ def test_solveset_complex_rational():
     assert solveset_complex((x - y**3)/((y**2)*sqrt(1 - y**2)), x) == \
         FiniteSet(y**3)
     assert solveset_complex(-x**2 - I, x) == \
-        FiniteSet(-sqrt(2)/2 + sqrt(2)*I/2, sqrt(2)/2 - sqrt(2)*I/2)
+        FiniteSet(sqrt(2)*(-1 + I)/2, sqrt(2)*(1 - I)/2)
 
 
 def test_solve_quintics():
@@ -1041,8 +1036,9 @@ def test_issue_9557():
 def test_issue_9778():
     assert solveset(x**3 + 1, x, S.Reals) == FiniteSet(-1)
     assert solveset(x**(S(3)/5) + 1, x, S.Reals) == S.EmptySet
-    assert solveset(x**3 + y, x, S.Reals) == Intersection(Interval(-oo, oo), \
-        FiniteSet((-y)**(S(1)/3)*Piecewise((1, Ne(-im(y), 0)), ((-1)**(S(2)/3), -y < 0), (1, True))))
+    assert solveset(x**3 + y, x, S.Reals) == Intersection(S.Reals,
+        FiniteSet(Piecewise(((-1)**(S(2)/3)*(-y)**(S(1)/3), -y < 0),
+                            ((-y)**(S(1)/3), True))))
 
 
 @XFAIL
@@ -1060,8 +1056,8 @@ def test_issue_9953():
 
 def test_issue_9913():
     assert solveset(2*x + 1/(x - 10)**2, x, S.Reals) == \
-        FiniteSet(-(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)/3 - 100/
-                (3*(3*sqrt(24081)/4 + S(4027)/4)**(S(1)/3)) + S(20)/3)
+        FiniteSet(-(6*sqrt(24081) + 8054)**(S(1)/3)/6 - 100*2**(S(2)/3)/
+                 (3*(3*sqrt(24081) + 4027)**(S(1)/3)) + S(20)/3)
 
 
 def test_issue_10397():

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -40,13 +40,12 @@ def test_single_normal():
     assert simplify(variance(Y)) == sigma**2
     pdf = density(Y)
     x = Symbol('x')
-    assert (pdf(x) ==
-            2**S.Half*exp(-(mu - x)**2/(2*sigma**2))/(2*pi**S.Half*sigma))
+    assert (pdf(x) == sqrt(2)*exp(-(-mu + x)**2/(2*sigma**2))/
+                     (2*sqrt(pi)*sigma))
 
     assert P(X**2 < 1) == erf(2**S.Half/2)
 
     assert E(X, Eq(X, mu)) == mu
-
 
 @XFAIL
 def test_conditional_1d():


### PR DESCRIPTION
Some nominal simplification of the values returned for the evaluation of `imageset` to a `FiniteSet` object.
I have modified the tests accordingly.

From master:

``` python
In[] : solveset(2**x - 4, x, S.Reals)
Out[]: {log(4)/log(2)}
```

From this branch:

``` python
In[] : solveset(2**x - 4, x, S.Reals)
Out[]: {2}
```
