### PR TITLE
lambdify: Wrap input arguments with asarray when using numpy.

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -386,6 +386,14 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     namespace.update({'builtins':builtins, 'range':range})
 
     func = eval(lstr, namespace)
+    # For numpy lambdify, wrap all input arguments in arrays.
+    # This is a fix for gh-11306.
+    if module_provided and _module_present('numpy',namespaces):
+        def array_wrap(funcarg):
+            def wrapper(*argsx, **kwargsx):
+                return funcarg(*[namespace['asarray'](i) for i in argsx], **kwargsx)
+            return wrapper
+        func = array_wrap(func)
     # Apply the docstring
     sig = "func({0})".format(", ".join(str(i) for i in names))
     sig = textwrap.fill(sig, subsequent_indent=' '*8)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -347,6 +347,11 @@ def test_numpy_old_matrix():
     numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
     assert isinstance(f(1, 2, 3), numpy.matrix)
 
+def test_python_div_zero_issue_11306():
+    if not numpy:
+        skip("numpy not installed.")
+    p = Piecewise((1 / x, y < -1), (x, y <= 1), (1 / x, True))
+    lambdify([x, y], p, modules='numpy')(0, 1)
 
 def test_issue9474():
     mods = [None, 'math']


### PR DESCRIPTION
Fixes gh-11306.

I'm having issues with local test failures on sympy master (i.e., before this PR), so don't merge until tests pass (if they do).

CC @asmeurer 
