### PR TITLE
Making the module holonomic usable

### DIFF
--- a/sympy/holonomic/__init__.py
+++ b/sympy/holonomic/__init__.py
@@ -1,3 +1,3 @@
 from .holonomic import (DifferentialOperator, HolonomicFunction, DifferentialOperators,
-    from_hyper, from_meijerg, from_sympy)
+    from_hyper, from_meijerg, expr_to_holonomic)
 from .recurrence import RecurrenceOperators, RecurrenceOperator, HolonomicSequence

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -355,7 +355,7 @@ class HolonomicFunction(object):
     import numpy as np
     var("x")
     r = np.linspace(1, 5, 100)
-    y = sympy.holonomic.from_sympy(sin(x)**2/x, x0=1).evalf(r)
+    y = sympy.holonomic.expr_to_holonomic(sin(x)**2/x, x0=1).evalf(r)
     plt.plot(r, y, label="holonomic function")
     plt.show()
     ``
@@ -598,7 +598,7 @@ class HolonomicFunction(object):
         elif S(b).is_Number:
             try:
                 return HolonomicFunction(self.annihilator * D, self.x, a,\
-                    y0).to_sympy().subs(self.x, b)
+                    y0).to_expr().subs(self.x, b)
             except TypeError:
                 return HolonomicFunction(self.annihilator * D, self.x, a, y0).evalf(b)
 
@@ -618,11 +618,11 @@ class HolonomicFunction(object):
         >>> R, Dx = DifferentialOperators(ZZ.old_poly_ring(x),'Dx')
 
         # derivative of sin(x)
-        >>> HolonomicFunction(Dx**2 + 1, x, 0, [0, 1]).diff().to_sympy()
+        >>> HolonomicFunction(Dx**2 + 1, x, 0, [0, 1]).diff().to_expr()
         cos(x)
 
         # derivative of e^2*x
-        >>> HolonomicFunction(Dx - 2, x, 0, 1).diff().to_sympy()
+        >>> HolonomicFunction(Dx - 2, x, 0, 1).diff().to_expr()
         2*exp(2*x)
 
         See Also
@@ -1452,7 +1452,7 @@ class HolonomicFunction(object):
 
         return sol
 
-    def to_sympy(self):
+    def to_expr(self):
         """
         Converts a Holonomic Function back to elementary functions.
 
@@ -1465,10 +1465,10 @@ class HolonomicFunction(object):
         >>> x = symbols('x')
         >>> R, Dx = DifferentialOperators(ZZ.old_poly_ring(x),'Dx')
 
-        >>> HolonomicFunction(x**2*Dx**2 + x*Dx + (x**2 - 1), x, 0, [0, S(1)/2]).to_sympy()
+        >>> HolonomicFunction(x**2*Dx**2 + x*Dx + (x**2 - 1), x, 0, [0, S(1)/2]).to_expr()
         besselj(1, x)
 
-        >>> HolonomicFunction((1 + x)*Dx**3 + Dx**2, x, 0, [1, 1, 1]).to_sympy()
+        >>> HolonomicFunction((1 + x)*Dx**3 + Dx**2, x, 0, [1, 1, 1]).to_expr()
         x*log(x + 1) + log(x + 1) + 1
 
         """
@@ -1482,21 +1482,21 @@ class HolonomicFunction(object):
         Examples
         ========
 
-        >>> from sympy.holonomic import from_sympy
+        >>> from sympy.holonomic import expr_to_holonomic
         >>> from sympy import symbols, sin, cos, exp
         >>> x = symbols('x')
 
-        >>> from_sympy(sin(x)).change_ics(1)
+        >>> expr_to_holonomic(sin(x)).change_ics(1)
         HolonomicFunction((1) + (1)Dx**2, x), f(1) = sin(1), f'(1) = cos(1)
 
-        >>> from_sympy(exp(x)).change_ics(2)
+        >>> expr_to_holonomic(exp(x)).change_ics(2)
         HolonomicFunction((-1) + (1)Dx, x), f(2) = exp(2)
         """
 
         symbolic = True
 
         try:
-            sol = from_sympy(self.to_sympy(), x0=b)
+            sol = expr_to_holonomic(self.to_expr(), x0=b)
         except:
             symbolic = False
 
@@ -1668,7 +1668,7 @@ _lookup_table = None
 from sympy.integrals.meijerint import _mytype
 
 
-def from_sympy(func, x=None, initcond=True, x0=0):
+def expr_to_holonomic(func, x=None, initcond=True, x0=0):
     """
     Uses `meijerint._rewrite1` to convert to `meijerg` function and then
     eventually to Holonomic Functions. Only works when `meijerint._rewrite1`
@@ -1677,13 +1677,13 @@ def from_sympy(func, x=None, initcond=True, x0=0):
     Examples
     ========
 
-    >>> from sympy.holonomic.holonomic import from_sympy
+    >>> from sympy.holonomic.holonomic import expr_to_holonomic
     >>> from sympy import sin, exp, symbols
     >>> x = symbols('x')
-    >>> from_sympy(sin(x))
+    >>> expr_to_holonomic(sin(x))
     HolonomicFunction((1) + (1)Dx**2, x), f(0) = 0, f'(0) = 1
 
-    >>> from_sympy(exp(x))
+    >>> expr_to_holonomic(exp(x))
     HolonomicFunction((-1) + (1)Dx, x), f(0) = 1
 
     See Also
@@ -1736,15 +1736,15 @@ def from_sympy(func, x=None, initcond=True, x0=0):
     args = func.args
     f = func.func
     from sympy.core import Add, Mul, Pow
-    sol = from_sympy(args[0], x=x, initcond=False)
+    sol = expr_to_holonomic(args[0], x=x, initcond=False)
 
     if f is Add:
         for i in range(1, len(args)):
-            sol += from_sympy(args[i], x=x, initcond=False)
+            sol += expr_to_holonomic(args[i], x=x, initcond=False)
 
     elif f is Mul:
         for i in range(1, len(args)):
-            sol *= from_sympy(args[i], x=x, initcond=False)
+            sol *= expr_to_holonomic(args[i], x=x, initcond=False)
 
     elif f is Pow:
         sol = sol**args[1]

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1040,7 +1040,7 @@ class HolonomicFunction(object):
         # check whether a power series exists if the point is singular
         if self.annihilator.is_singular(x0=self.x0):
             indicialroots = self._indicial()
-            if all(i < 0 or not int(i) == i for i in indicialroots):
+            if any(not int(i) == i for i in indicialroots):
                 from .holonomicerrors import NotPowerSeriesError
                 raise NotPowerSeriesError(self, self.x0)
 
@@ -1279,7 +1279,7 @@ class HolonomicFunction(object):
             if - i - b <= 0 and degree - i - b >= 0:
                 s = s + listofdmp[degree - i - b] * y
             y *= x - i
-        return roots(R.to_sympy(s), x, filter='R').keys()
+        return roots(R.to_sympy(s), x, filter='R')
 
     def evalf(self, points, method='RK4', h=0.05, derivatives=False):
         """
@@ -1792,6 +1792,8 @@ def expr_to_holonomic(func, x=None, initcond=True, x0=0, lenics=None, domain=QQ)
             sol = _convert_meijerint(func, x, initcond=False, domain=domain)
             if not sol:
                 raise NotImplementedError
+            if not initcond:
+                return sol
             if not lenics:
                 lenics = sol.annihilator.order
             y0 = _find_conditions(func, x, x0, lenics)

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -596,6 +596,7 @@ class HolonomicFunction(object):
 
         # if the upper limits is a Number, a numerical value will be returned
         elif S(b).is_Number:
+            from .holonomicerrors import NotHyperSeriesError, NotPowerSeriesError
             try:
                 s = HolonomicFunction(self.annihilator * D, self.x, a,\
                     y0).to_expr()
@@ -604,7 +605,7 @@ class HolonomicFunction(object):
                     return indefinite
                 else:
                     return s.limit(self.x, b)
-            except TypeError:
+            except (NotHyperSeriesError, NotPowerSeriesError):
                 return HolonomicFunction(self.annihilator * D, self.x, a, y0).evalf(b)
 
         return HolonomicFunction(self.annihilator * D, self.x)
@@ -1302,7 +1303,8 @@ class HolonomicFunction(object):
 
         for i in roots(self.annihilator.listofpoly[-1].rep):
             if i == self.x0 or i in points:
-                raise TypeError("Provided path contains a singularity")
+                from .holonomicerrors import SingularityError
+                raise SingularityError(self, i)
 
         if lp:
             return _evalf(self, points, method=method, derivatives=derivatives)[-1]
@@ -1407,7 +1409,8 @@ class HolonomicFunction(object):
                 break
 
         if not is_hyper:
-            raise TypeError("The series is not Hypergeometric")
+            from .holonomicerrors import NotHyperSeriesError
+            raise NotHyperSeriesError(self, self.x0)
 
         a = r.listofpoly[0]
         b = r.listofpoly[-1]
@@ -1511,9 +1514,10 @@ class HolonomicFunction(object):
         if lenics == None and len(self.y0) > self.annihilator.order:
             lenics = len(self.y0)
 
+        from .holonomicerrors import NotPowerSeriesError, NotHyperSeriesError
         try:
             sol = expr_to_holonomic(self.to_expr(), x0=b, lenics=lenics)
-        except:
+        except (NotPowerSeriesError, NotHyperSeriesError):
             symbolic = False
 
         if symbolic and sol.x0 == b:

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1082,6 +1082,7 @@ class HolonomicFunction(object):
         smallest_n = lower + degree
         dummys = {}
         eqs = []
+        unknowns = []
 
         # an appropriate shift of the recurrence
         for j in range(lower, upper + 1):
@@ -1133,6 +1134,7 @@ class HolonomicFunction(object):
 
                     elif not i + j[0] in dummys:
                         dummys[i + j[0]] = Symbol('C_%s' %(i + j[0]))
+                        unknowns.append(dummys[i + j[0]])
 
                     if j[1] <= i:
                         eq += dict1[j].subs(n, i) * dummys[i + j[0]]
@@ -1140,7 +1142,7 @@ class HolonomicFunction(object):
                 eqs.append(eq)
 
             # solve the system of equations formed
-            soleqs = solve(eqs)
+            soleqs = solve(eqs, *unknowns)
 
             if isinstance(soleqs, dict):
 

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1561,7 +1561,7 @@ class HolonomicFunction(object):
 
         from .holonomicerrors import NotPowerSeriesError, NotHyperSeriesError
         try:
-            sol = expr_to_holonomic(self.to_expr(), x0=b, lenics=lenics, domain=self.annihilator.parent.base.domain)
+            sol = expr_to_holonomic(self.to_expr(), x=self.x, x0=b, lenics=lenics, domain=self.annihilator.parent.base.domain)
         except (NotPowerSeriesError, NotHyperSeriesError):
             symbolic = False
 

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -587,7 +587,7 @@ class HolonomicFunction(object):
         # use evalf to get the values at `a`
         else:
             y0 = [S(0)]
-            tempy0 = self.evalf(a, derivatives=True)
+            tempy0 = self.change_ics(a).y0
             y0 += tempy0
 
         # if the upper limit is `x`, the answer will be a function
@@ -596,7 +596,11 @@ class HolonomicFunction(object):
 
         # if the upper limits is a Number, a numerical value will be returned
         elif S(b).is_Number:
-            return HolonomicFunction(self.annihilator * D, self.x, a, y0).evalf(b)
+            try:
+                return HolonomicFunction(self.annihilator * D, self.x, a,\
+                    y0).to_sympy().subs(self.x, b)
+            except TypeError:
+                return HolonomicFunction(self.annihilator * D, self.x, a, y0).evalf(b)
 
         return HolonomicFunction(self.annihilator * D, self.x)
 
@@ -1496,7 +1500,7 @@ class HolonomicFunction(object):
         except:
             symbolic = False
 
-        if symbolic:
+        if symbolic and sol.x0 == b:
             return sol
 
         y0 = self.evalf(b, derivatives=True)

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -19,6 +19,8 @@ from sympy.matrices import Matrix
 from sympy.polys.polyclasses import DMF
 from sympy.polys.polyroots import roots
 from sympy.functions.elementary.exponential import exp_polar, exp
+from .holonomicerrors import NotPowerSeriesError, NotHyperSeriesError, SingularityError, NotHolonomicError
+from sympy.polys.rings import PolyElement
 
 
 def DifferentialOperators(base, generator):
@@ -631,7 +633,6 @@ class HolonomicFunction(object):
 
         # if the upper limits is a Number, a numerical value will be returned
         elif S(b).is_Number:
-            from .holonomicerrors import NotHyperSeriesError, NotPowerSeriesError
             try:
                 s = HolonomicFunction(self.annihilator * D, self.x, a,\
                     y0).to_expr()
@@ -903,7 +904,6 @@ class HolonomicFunction(object):
 
     def __pow__(self, n):
         if n < 0:
-            from .holonomicerrors import NotHolonomicError
             raise NotHolonomicError("Negative Power on a Holonomic Function")
         if n == 0:
             return S(1)
@@ -1041,7 +1041,6 @@ class HolonomicFunction(object):
         if self.annihilator.is_singular(x0=self.x0):
             indicialroots = self._indicial()
             if any(not int(i) == i for i in indicialroots):
-                from .holonomicerrors import NotPowerSeriesError
                 raise NotPowerSeriesError(self, self.x0)
 
         dict1 = {}
@@ -1343,7 +1342,6 @@ class HolonomicFunction(object):
 
         for i in roots(self.annihilator.parent.base.to_sympy(self.annihilator.listofpoly[-1]), self.x):
             if i == self.x0 or i in points:
-                from .holonomicerrors import SingularityError
                 raise SingularityError(self, i)
 
         if lp:
@@ -1450,14 +1448,12 @@ class HolonomicFunction(object):
                 break
 
         if not is_hyper:
-            from .holonomicerrors import NotHyperSeriesError
             raise NotHyperSeriesError(self, self.x0)
 
         a = r.listofpoly[0]
         b = r.listofpoly[-1]
 
         # the constant multiple of argument of hypergeometric function
-        from sympy.polys.rings import PolyElement
         if isinstance(a.rep[0], PolyElement):
             c = - (S(a.rep[0].as_expr()) * m**(a.degree())) / (S(b.rep[0].as_expr()) * m**(b.degree()))
         else:
@@ -1559,7 +1555,6 @@ class HolonomicFunction(object):
         if lenics == None and len(self.y0) > self.annihilator.order:
             lenics = len(self.y0)
 
-        from .holonomicerrors import NotPowerSeriesError, NotHyperSeriesError
         try:
             sol = expr_to_holonomic(self.to_expr(), x=self.x, x0=b, lenics=lenics, domain=self.annihilator.parent.base.domain)
         except (NotPowerSeriesError, NotHyperSeriesError):
@@ -1972,7 +1967,6 @@ def _extend_y0(Holonomic, n):
                         return y0
                 except AttributeError:
                     pass
-                from sympy.polys.rings import PolyElement
                 if isinstance(r, PolyElement):
                     r = r.as_expr()
                 sol += a * r
@@ -2018,7 +2012,6 @@ def DMFsubs(frac, x0, mpm=False):
             j = sympify(j)._to_mpmath(mp.prec)
         sol_q += j * x0**i
 
-    from sympy.polys.rings import PolyElement
     if isinstance(sol_p, PolyElement):
         sol_p = sol_p.as_expr()
     if isinstance(sol_q, PolyElement):

--- a/sympy/holonomic/holonomicerrors.py
+++ b/sympy/holonomic/holonomicerrors.py
@@ -1,0 +1,28 @@
+""" Common Exceptions for `holonomic` module. """
+
+from __future__ import print_function, division
+
+class BaseHolonomicError(Exception):
+
+    def new(self, *args):
+        raise NotImplementedError("abstract base class")
+
+class NotPowerSeriesError(BaseHolonomicError):
+
+    def __init__(self, holonomic, x0):
+        self.holonomic = holonomic
+        self.x0 = x0
+
+    def __str__(self):
+        s = 'A Power Series doesnot exists for '
+        s += str(self.holonomic)
+        s += ' about %s.' %self.x0
+        return s
+
+class NotHolonomicError(BaseHolonomicError):
+
+    def __init__(self, m):
+        self.m = m
+
+    def __str__(self):
+        return self.m

--- a/sympy/holonomic/holonomicerrors.py
+++ b/sympy/holonomic/holonomicerrors.py
@@ -26,3 +26,26 @@ class NotHolonomicError(BaseHolonomicError):
 
     def __str__(self):
         return self.m
+
+class SingularityError(BaseHolonomicError):
+
+    def __init__(self, holonomic, x0):
+        self.holonomic = holonomic
+        self.x0 = x0
+
+    def __str__(self):
+        s = str(self.holonomic)
+        s += ' has a singularity at %s.' %self.x0
+        return s
+
+class NotHyperSeriesError(BaseHolonomicError):
+
+    def __init__(self, holonomic, x0):
+        self.holonomic = holonomic
+        self.x0 = x0
+
+    def __str__(self):
+        s = 'Power series expansion of '
+        s += str(self.holonomic)
+        s += ' about %s is not hypergeometric' %self.x0
+        return s

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -549,14 +549,21 @@ def test_integrate():
     q = 1 - cos(x)
     assert p == q
     p = from_sympy(sin(x)).integrate((x, 0, 3))
-    q = '1.98999246812687'
-    assert sstr(p) == q
+    q = 1 - cos(3)
+    assert p == q
     p = from_sympy(sin(x)/x, x0=1).integrate((x, 1, 2))
     q = '0.659329913368450'
     assert sstr(p) == q
     p = from_sympy(sin(x)**2/x, x0=1).integrate((x, 1, 0))
     q = '-0.423690480850035'
     assert sstr(p) == q
+    p = from_sympy(sin(x)/x)
+    assert p.integrate(x).to_sympy() == Si(x)
+    assert p.integrate((x, 0, 2)) == Si(2)
+    p = from_sympy(sin(x)**2/x)
+    q = p.to_sympy()
+    assert p.integrate(x).to_sympy() == q.integrate((x, 0, x))
+    assert p.integrate((x, 0, 1)) == q.integrate((x, 0, 1))
 
 def test_diff():
     x, y = symbols('x, y')

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -481,7 +481,12 @@ def test_expr_to_holonomic():
     p = p.to_expr()
     q = log(x)/2 - Ci(2*x)/2 + Ci(2)/2
     assert p == q
-
+    p = expr_to_holonomic(x**(1/2), x0=1)
+    q = HolonomicFunction(x*Dx - 1/2, x, 1, 1)
+    assert p == q
+    p = expr_to_holonomic(sqrt(1 + x**2))
+    q = HolonomicFunction((-x) + (x**2 + 1)*Dx, x, 0, 1)
+    assert p == q
 
 def test_to_hyper():
     x = symbols('x')
@@ -538,6 +543,12 @@ def test_to_expr():
     p = expr_to_holonomic(erf(x) + x).to_expr()
     q = 3*C_3*x - 3*sqrt(pi)*C_3*erf(x)/2 + x + 2*x/sqrt(pi)
     assert p == q
+    p = expr_to_holonomic(sqrt(x), x0=1).to_expr()
+    assert p == sqrt(x)
+    p = expr_to_holonomic(sqrt(1 + x**2)).to_expr()
+    assert p == sqrt(1+x**2)
+    p = expr_to_holonomic((2*x**2 + 1)**(2/3)).to_expr()
+    assert p == (2*x**2 + 1)**(S(2)/3)
 
 def test_integrate():
     x = symbols('x')

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -576,6 +576,9 @@ def test_integrate():
     assert p.integrate(x).to_expr() == q.integrate((x, 0, x))
     assert p.integrate((x, 0, 1)) == q.integrate((x, 0, 1))
     assert expr_to_holonomic(1/x).integrate(x).to_expr() == log(x)
+    p = expr_to_holonomic((x + 1)**3*exp(-x), x0=-1, lenics=4).integrate(x).to_expr()
+    q = (-x**3 - 6*x**2 - 15*x + 6*exp(x + 1) - 16)*exp(-x)
+    assert p == q
 
 def test_diff():
     x, y = symbols('x, y')

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -1,5 +1,5 @@
 from sympy.holonomic import (DifferentialOperator, HolonomicFunction,
-    DifferentialOperators, from_hyper, from_meijerg, from_sympy)
+    DifferentialOperators, from_hyper, from_meijerg, expr_to_holonomic)
 from sympy.holonomic.recurrence import RecurrenceOperators, HolonomicSequence
 from sympy import (symbols, hyper, S, sqrt, pi, exp, erf, erfc, sstr,
     O, I, meijerg, sin, cos, log, cosh, besselj, hyperexpand, Ci, EulerGamma, Si)
@@ -105,8 +105,8 @@ def test_addition_initial_condition():
     r = HolonomicFunction((-x**2 - x + 1) + (x**2 + x)*Dx + (-x - 2)*Dx**3 + \
         (x + 1)*Dx**4, x, 2, [4, 1, 2, -5 ])
     assert p + q == r
-    p = from_sympy(sin(x))
-    q = from_sympy(1/x)
+    p = expr_to_holonomic(sin(x))
+    q = expr_to_holonomic(1/x)
     r = HolonomicFunction((x**2 + 6) + (x**3 + 2*x)*Dx + (x**2 + 6)*Dx**2 + (x**3 + 2*x)*Dx**3, \
         x, 1, [sin(1) + 1, -1 + cos(1), -sin(1) + 2])
     assert p + q == r
@@ -139,8 +139,8 @@ def test_multiplication_initial_condition():
     q = HolonomicFunction(Dx**3 + 1, x, 0, [1, 2, 1])
     r = HolonomicFunction(6*Dx + 3*Dx**2 + 2*Dx**3 - 3*Dx**4 + Dx**6, x, 0, [1, 5, 14, 17, 17, 2])
     assert p * q == r
-    p = from_sympy(sin(x))
-    q = from_sympy(1/x)
+    p = expr_to_holonomic(sin(x))
+    q = expr_to_holonomic(1/x)
     r = HolonomicFunction(x + 2*Dx + x*Dx**2, x, 1, [sin(1), -sin(1) + cos(1)])
     assert p * q == r
 
@@ -236,13 +236,13 @@ def test_to_Sequence_Initial_Coniditons():
     q = (HolonomicSequence(1 + (n + 1)*Sn + (n**5 - 5*n**3 + 4*n)*Sn**2), 3)
     assert p == q
     C_1, C_2, C_3 = symbols('C_1, C_2, C_3')
-    p = from_sympy(log(1+x**2))
+    p = expr_to_holonomic(log(1+x**2))
     q = (HolonomicSequence(n**2 + (n**2 + 2*n)*Sn**2, [0, 0, C_2, 0]), 2)
     assert p.to_sequence() == q
     p = p.diff()
     q = (HolonomicSequence((n + 1) + (n + 1)*Sn**2, [0, C_1, 0]), 1)
     assert p.to_sequence() == q
-    p = from_sympy(erf(x) + x).to_sequence()
+    p = expr_to_holonomic(erf(x) + x).to_sequence()
     q = (HolonomicSequence((2*n**2 - 2*n) + (n**3 + 2*n**2 - n - 2)*Sn**2, [0, 1 + 2/sqrt(pi), 0, C_3]), 2)
     assert p == q
 
@@ -270,7 +270,7 @@ def test_series():
         (4-6*x**3+2*x**4)*Dx**2, x, 0, [1, 0]).series(n=7)
     q = 1 - 3*x**2/4 - x**3/4 - 5*x**4/32 - 3*x**5/40 - 17*x**6/384 + O(x**7)
     assert p == q
-    p = from_sympy(erf(x) + x).series(n=10)
+    p = expr_to_holonomic(erf(x) + x).series(n=10)
     C_3 = symbols('C_3')
     q = (erf(x) + x).series(n=10)
     assert p.subs(C_3, -2/(3*sqrt(pi))) == q
@@ -429,56 +429,56 @@ def test_evalf_rk4():
     s = '0.493152791638442 - 1.41553435639707e-15*I'
     assert sstr(p[-1]) == s
 
-def test_from_sympy():
+def test_expr_to_holonomic():
     x = symbols('x')
     R, Dx = DifferentialOperators(QQ.old_poly_ring(x), 'Dx')
-    p = from_sympy((sin(x)/x)**2)
+    p = expr_to_holonomic((sin(x)/x)**2)
     q = HolonomicFunction(8*x + (4*x**2 + 6)*Dx + 6*x*Dx**2 + x**2*Dx**3, x, 0, \
         [1, 0, -2/3])
     assert p == q
-    p = from_sympy(1/(1+x**2)**2)
+    p = expr_to_holonomic(1/(1+x**2)**2)
     q = HolonomicFunction(4*x + (x**2 + 1)*Dx, x, 0, 1)
     assert p == q
-    p = from_sympy(exp(x)*sin(x)+x*log(1+x))
+    p = expr_to_holonomic(exp(x)*sin(x)+x*log(1+x))
     q = HolonomicFunction((2*x**3 + 10*x**2 + 20*x + 18) + (-2*x**4 - 10*x**3 - 20*x**2 \
         - 18*x)*Dx + (2*x**5 + 6*x**4 + 7*x**3 + 8*x**2 + 10*x - 4)*Dx**2 + \
         (-2*x**5 - 5*x**4 - 2*x**3 + 2*x**2 - x + 4)*Dx**3 + (x**5 + 2*x**4 - x**3 - \
         7*x**2/2 + x + 5/2)*Dx**4, x, 0, [0, 1, 4, -1])
     assert p == q
-    p = from_sympy(x*exp(x)+cos(x)+1)
+    p = expr_to_holonomic(x*exp(x)+cos(x)+1)
     q = HolonomicFunction((-x - 3)*Dx + (x + 2)*Dx**2 + (-x - 3)*Dx**3 + (x + 2)*Dx**4, x, \
         0, [2, 1, 1, 3])
     assert p == q
     assert (x*exp(x)+cos(x)+1).series(n=10) == p.series(n=10)
-    p = from_sympy(log(1 + x)**2 + 1)
+    p = expr_to_holonomic(log(1 + x)**2 + 1)
     q = HolonomicFunction(Dx + (3*x + 3)*Dx**2 + (x**2 + 2*x + 1)*Dx**3, x, 0, [1, 0, 2])
     assert p == q
-    p = from_sympy(erf(x)**2 + x)
+    p = expr_to_holonomic(erf(x)**2 + x)
     q = HolonomicFunction((8*x**4 - 2*x**2 + 2)*Dx**2 + (6*x**3 - x/2)*Dx**3 + \
         (x**2+ 1/4)*Dx**4, x, 0, [0, 1, 8/pi, 0])
     assert p == q
-    p = from_sympy(cosh(x)*x)
+    p = expr_to_holonomic(cosh(x)*x)
     q = HolonomicFunction((-x**2 + 2) -2*x*Dx + x**2*Dx**2, x, 0, [0, 1])
     assert p == q
-    p = from_sympy(besselj(2, x))
+    p = expr_to_holonomic(besselj(2, x))
     q = HolonomicFunction((x**2 - 4) + x*Dx + x**2*Dx**2, x, 0, [0, 0])
     assert p == q
-    p = from_sympy(besselj(0, x) + exp(x))
+    p = expr_to_holonomic(besselj(0, x) + exp(x))
     q = HolonomicFunction((-x**2 - x/2 + 1/2) + (x**2 - x/2 - 3/2)*Dx + (-x**2 + x/2 + 1)*Dx**2 +\
         (x**2 + x/2)*Dx**3, x, 0, [2, 1, 1/2])
     assert p == q
-    p = from_sympy(sin(x)**2/x)
+    p = expr_to_holonomic(sin(x)**2/x)
     q = HolonomicFunction(4 + 4*x*Dx + 3*Dx**2 + x*Dx**3, x, 0, [0, 1, 0])
     assert p == q
-    p = from_sympy(sin(x)**2/x, x0=2)
+    p = expr_to_holonomic(sin(x)**2/x, x0=2)
     q = HolonomicFunction((4) + (4*x)*Dx + (3)*Dx**2 + (x)*Dx**3, x, 2, [sin(2)**2/2,
         sin(2)*cos(2) - sin(2)**2/4, -3*sin(2)**2/4 + cos(2)**2 - sin(2)*cos(2)])
     assert p == q
-    p = from_sympy(log(x)/2 - Ci(2*x)/2 + Ci(2)/2)
+    p = expr_to_holonomic(log(x)/2 - Ci(2*x)/2 + Ci(2)/2)
     q = HolonomicFunction(4*Dx + 4*x*Dx**2 + 3*Dx**3 + x*Dx**4, x, 0, \
         [-log(2)/2 - EulerGamma/2 + Ci(2)/2, 0, 1, 0])
     assert p == q
-    p = p.to_sympy()
+    p = p.to_expr()
     q = log(x)/2 - Ci(2*x)/2 + Ci(2)/2
     assert p == q
 
@@ -509,74 +509,75 @@ def test_to_hyper():
     q = besselj(0, x)
     assert p == q
 
-def test_to_sympy():
+def test_to_expr():
     x = symbols('x')
     R, Dx = DifferentialOperators(ZZ.old_poly_ring(x), 'Dx')
-    p = HolonomicFunction(Dx - 1, x, 0, 1).to_sympy()
+    p = HolonomicFunction(Dx - 1, x, 0, 1).to_expr()
     q = exp(x)
     assert p == q
-    p = HolonomicFunction(Dx**2 + 1, x, 0, [1, 0]).to_sympy()
+    p = HolonomicFunction(Dx**2 + 1, x, 0, [1, 0]).to_expr()
     q = cos(x)
     assert p == q
-    p = HolonomicFunction(Dx**2 - 1, x, 0, [1, 0]).to_sympy()
+    p = HolonomicFunction(Dx**2 - 1, x, 0, [1, 0]).to_expr()
     q = cosh(x)
     assert p == q
     p = HolonomicFunction(2 + (4*x - 1)*Dx + \
-        (x**2 - x)*Dx**2, x, 0, [1, 2]).to_sympy()
+        (x**2 - x)*Dx**2, x, 0, [1, 2]).to_expr()
     q = 1/(x**2 - 2*x + 1)
     assert p == q
-    p = from_sympy(sin(x)**2/x).integrate((x, 0, x)).to_sympy()
+    p = expr_to_holonomic(sin(x)**2/x).integrate((x, 0, x)).to_expr()
     q = (sin(x)**2/x).integrate((x, 0, x))
     assert p == q
     C_1, C_2, C_3 = symbols('C_1, C_2, C_3')
-    p = from_sympy(log(1+x**2)).to_sympy()
+    p = expr_to_holonomic(log(1+x**2)).to_expr()
     q = C_2*log(x**2 + 1)
     assert p == q
-    p = from_sympy(log(1+x**2)).diff().to_sympy()
+    p = expr_to_holonomic(log(1+x**2)).diff().to_expr()
     q = C_1*x/(x**2 + 1)
     assert p == q
-    p = from_sympy(erf(x) + x).to_sympy()
+    p = expr_to_holonomic(erf(x) + x).to_expr()
     q = 3*C_3*x - 3*sqrt(pi)*C_3*erf(x)/2 + x + 2*x/sqrt(pi)
     assert p == q
 
 def test_integrate():
     x = symbols('x')
     R, Dx = DifferentialOperators(ZZ.old_poly_ring(x), 'Dx')
-    p = from_sympy(sin(x)**2/x, x0=1).integrate((x, 2, 3))
+    p = expr_to_holonomic(sin(x)**2/x, x0=1).integrate((x, 2, 3))
     q = '0.166270406994788'
     assert sstr(p) == q
-    p = from_sympy(sin(x)).integrate((x, 0, x)).to_sympy()
+    p = expr_to_holonomic(sin(x)).integrate((x, 0, x)).to_expr()
     q = 1 - cos(x)
     assert p == q
-    p = from_sympy(sin(x)).integrate((x, 0, 3))
+    p = expr_to_holonomic(sin(x)).integrate((x, 0, 3))
     q = 1 - cos(3)
     assert p == q
-    p = from_sympy(sin(x)/x, x0=1).integrate((x, 1, 2))
+    p = expr_to_holonomic(sin(x)/x, x0=1).integrate((x, 1, 2))
     q = '0.659329913368450'
     assert sstr(p) == q
-    p = from_sympy(sin(x)**2/x, x0=1).integrate((x, 1, 0))
+    p = expr_to_holonomic(sin(x)**2/x, x0=1).integrate((x, 1, 0))
     q = '-0.423690480850035'
     assert sstr(p) == q
-    p = from_sympy(sin(x)/x)
-    assert p.integrate(x).to_sympy() == Si(x)
+    p = expr_to_holonomic(sin(x)/x)
+    assert p.integrate(x).to_expr() == Si(x)
     assert p.integrate((x, 0, 2)) == Si(2)
-    p = from_sympy(sin(x)**2/x)
-    q = p.to_sympy()
-    assert p.integrate(x).to_sympy() == q.integrate((x, 0, x))
+    p = expr_to_holonomic(sin(x)**2/x)
+    q = p.to_expr()
+    assert p.integrate(x).to_expr() == q.integrate((x, 0, x))
     assert p.integrate((x, 0, 1)) == q.integrate((x, 0, 1))
+    assert expr_to_holonomic(1/x).integrate(x).to_expr() == log(x)
 
 def test_diff():
     x, y = symbols('x, y')
     R, Dx = DifferentialOperators(ZZ.old_poly_ring(x), 'Dx')
     p = HolonomicFunction(x*Dx**2 + 1, x, 0, [0, 1])
-    assert p.diff().to_sympy() == p.to_sympy().diff().simplify()
+    assert p.diff().to_expr() == p.to_expr().diff().simplify()
     p = HolonomicFunction(Dx**2 - 1, x, 0, [1, 0])
-    assert p.diff(x, 2).to_sympy() == p.to_sympy()
-    p = from_sympy(Si(x))
-    assert p.diff().to_sympy() == sin(x)/x
+    assert p.diff(x, 2).to_expr() == p.to_expr()
+    p = expr_to_holonomic(Si(x))
+    assert p.diff().to_expr() == sin(x)/x
     assert p.diff(y) == 0
     C_1, C_2, C_3 = symbols('C_1, C_2, C_3')
     q = Si(x)
-    assert p.diff(x).to_sympy() == q.diff()
-    assert p.diff(x, 2).to_sympy().subs(C_1, -S(1)/3) == q.diff(x, 2).simplify()
+    assert p.diff(x).to_expr() == q.diff()
+    assert p.diff(x, 2).to_expr().subs(C_1, -S(1)/3) == q.diff(x, 2).simplify()
     assert p.diff(x, 3).series().subs(C_2, S(1)/10) == q.diff(x, 3).series()

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -481,7 +481,7 @@ def test_expr_to_holonomic():
     p = p.to_expr()
     q = log(x)/2 - Ci(2*x)/2 + Ci(2)/2
     assert p == q
-    p = expr_to_holonomic(x**(1/2), x0=1)
+    p = expr_to_holonomic(x**(S(1)/2), x0=1)
     q = HolonomicFunction(x*Dx - 1/2, x, 1, 1)
     assert p == q
     p = expr_to_holonomic(sqrt(1 + x**2))
@@ -547,7 +547,7 @@ def test_to_expr():
     assert p == sqrt(x)
     p = expr_to_holonomic(sqrt(1 + x**2)).to_expr()
     assert p == sqrt(1+x**2)
-    p = expr_to_holonomic((2*x**2 + 1)**(2/3)).to_expr()
+    p = expr_to_holonomic((2*x**2 + 1)**(S(2)/3)).to_expr()
     assert p == (2*x**2 + 1)**(S(2)/3)
 
 def test_integrate():

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -278,6 +278,10 @@ class Domain(object):
             else:
                 cls = K1.__class__
 
+            from sympy.polys.domains.old_polynomialring import GlobalPolynomialRing
+            if cls == GlobalPolynomialRing:
+                return cls(domain, symbols)
+
             return cls(domain, symbols, order)
 
         def mkinexact(cls, K0, K1):


### PR DESCRIPTION
- [x] Fixed smaller bugs. Fixed #11288 , Fixed #11314 , Fixed #11315 , Fixed #11316 , Fixed #11318 , Fixed #11321 , Fixed #11326 , Fixed #11327 
- [x] Added support for `RR` domain. Fixes #11325 .

```
>>> expr_to_holonomic(1.1329138213*x, x0=1, domain=RR).to_expr()
1.1329138213⋅x
```
- [x] Added support for multivariable fields. Fixes #11323 .

```
>>> expr_to_holonomic(a*x, x=x,domain=QQ[a], lenics=2).integrate(x).to_expr()
a*x**2/2
```
