### PR TITLE
Added docstrings to ast.py

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -376,7 +376,8 @@ class For(Basic):
     @property
     def target(self):
         """
-        Return the symbol from the for-loop representation.
+        Return the symbol (target) from the for-loop representation.
+        Target must be a symbol.
         """
         return self._args[0]
 
@@ -384,12 +385,14 @@ class For(Basic):
     def iterable(self):
         """
         Return the iterable from the for-loop representation.
+        Must be an iterable object.
         """
         return self._args[1]
 
     @property
     def body(self):
         """
-        Return the sympy expression from the for-loop representation.
+        Return the sympy expression (body) from the for-loop representation.
+        Must be an iterable object or CodeBlock.
         """
         return self._args[2]

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -375,12 +375,21 @@ class For(Basic):
 
     @property
     def target(self):
+        """
+        Return the symbol
+        """
         return self._args[0]
 
     @property
     def iterable(self):
+        """
+        Return the iterable
+        """
         return self._args[1]
 
     @property
     def body(self):
+        """
+        Return the sympy expression
+        """
         return self._args[2]

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -377,6 +377,7 @@ class For(Basic):
     def target(self):
         """
         Return the symbol (target) from the for-loop representation.
+        This object changes each iteration.
         Target must be a symbol.
         """
         return self._args[0]
@@ -385,6 +386,7 @@ class For(Basic):
     def iterable(self):
         """
         Return the iterable from the for-loop representation.
+        This is the object that target takes values from.
         Must be an iterable object.
         """
         return self._args[1]
@@ -393,6 +395,7 @@ class For(Basic):
     def body(self):
         """
         Return the sympy expression (body) from the for-loop representation.
+        This is run for each value of target.
         Must be an iterable object or CodeBlock.
         """
         return self._args[2]

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -376,20 +376,20 @@ class For(Basic):
     @property
     def target(self):
         """
-        Return the symbol
+        Return the symbol from the for-loop representation.
         """
         return self._args[0]
 
     @property
     def iterable(self):
         """
-        Return the iterable
+        Return the iterable from the for-loop representation.
         """
         return self._args[1]
 
     @property
     def body(self):
         """
-        Return the sympy expression
+        Return the sympy expression from the for-loop representation.
         """
         return self._args[2]


### PR DESCRIPTION
Hello.

Some property methods in `sympy/codegen/ast.py` were missing docstrings. 

These have been now added. 

Thank you.
