### PR TITLE
removed BOM character, fixes #10974 [skip ci]

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 This module contain solvers for all kinds of equations:
 
     - algebraic or transcendental, use solve()


### PR DESCRIPTION
I used grep to find what all files contain the BOM character and only found one file - `solvers.py`

```
grep -rl $'\xEF\xBB\xBF'
```

Then I removed the BOM character using this vim command - `:set nobomb`

@aktech Please have a look.
