### PR TITLE
checksol may need to simplify `val` to get zero value for equation `f`

### DIFF
--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -225,7 +225,7 @@ def test_ellipse_geom():
     assert e1.intersection(e2) == ans
     e2 = Ellipse(Point(x, y), 4, 8)
     c = sqrt(3991)
-    ans = [Point(c/68 + a, -2*c/17 + a/2), Point(-c/68 + a, 2*c/17 + a/2)]
+    ans = [Point(-c/68 + a, 2*c/17 + a/2), Point(c/68 + a, -2*c/17 + a/2)]
     assert [p.subs({x: 2, y:1}) for p in e1.intersection(e2)] == ans
 
     # Combinations of above

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -225,7 +225,7 @@ def test_ellipse_geom():
     assert e1.intersection(e2) == ans
     e2 = Ellipse(Point(x, y), 4, 8)
     c = sqrt(3991)
-    ans = [Point(-c/68 + a, 2*c/17 + a/2), Point(c/68 + a, -2*c/17 + a/2)]
+    ans = [Point(c/68 + a, -2*c/17 + a/2), Point(-c/68 + a, 2*c/17 + a/2)]
     assert [p.subs({x: 2, y:1}) for p in e1.intersection(e2)] == ans
 
     # Combinations of above

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -228,7 +228,7 @@ def checksol(f, symbol, sol=None, **flags):
                     return False
                 # there are free symbols -- simple expansion might work
                 _, val = val.as_content_primitive()
-                val = simplify(expand_mul(expand_multinomial(val)))
+                val = expand_mul(expand_multinomial(val))
         elif attempt == 2:
             if minimal:
                 return
@@ -237,7 +237,7 @@ def checksol(f, symbol, sol=None, **flags):
                     sol[k] = simplify(sol[k])
             # start over without the failed expanded form, possibly
             # with a simplified solution
-            val = f.subs(sol)
+            val = simplify(f.subs(sol))
             if flags.get('force', True):
                 val, reps = posify(val)
                 # expansion may work now, so try again and check

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -228,7 +228,7 @@ def checksol(f, symbol, sol=None, **flags):
                     return False
                 # there are free symbols -- simple expansion might work
                 _, val = val.as_content_primitive()
-                val = expand_mul(expand_multinomial(val))
+                val = simplify(expand_mul(expand_multinomial(val)))
         elif attempt == 2:
             if minimal:
                 return
@@ -245,16 +245,6 @@ def checksol(f, symbol, sol=None, **flags):
                 if exval.is_number or not exval.free_symbols:
                     # we can decide now
                     val = exval
-        elif attempt == 3:
-            val = powsimp(val)
-        elif attempt == 4:
-            val = cancel(val)
-        elif attempt == 5:
-            val = val.expand()
-        elif attempt == 6:
-            val = together(val)
-        elif attempt == 7:
-            val = powsimp(val)
         else:
             # if there are no radicals and no functions then this can't be
             # zero anymore -- can it?

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1075,10 +1075,8 @@ def test_unrad_fail():
 def test_checksol():
     x, y, r, t = symbols('x, y, r, t')
     eq = r - x**2 - y**2
-    dict_var_soln = {
-                                y: -sqrt(r)/sqrt(tan(t)**2 + 1),
-                                x: -sqrt(r)*tan(t)/sqrt(tan(t)**2 + 1)
-                            }
+    dict_var_soln = {y: - sqrt(r) / sqrt(tan(t)**2 + 1),
+                            x: -sqrt(r)*tan(t)/sqrt(tan(t)**2 + 1)}
     assert checksol(eq, dict_var_soln) == True
 
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1072,6 +1072,16 @@ def test_unrad_fail():
         -1, -1 + CRootOf(x**5 + x**4 + 5*x**3 + 8*x**2 + 10*x + 5, 0)**3]
 
 
+def test_checksol():
+    x, y, r, t = symbols('x, y, r, t')
+    eq = r - x**2 - y**2
+    dict_var_soln = {
+                                y: -sqrt(r)/sqrt(tan(t)**2 + 1),
+                                x: -sqrt(r)*tan(t)/sqrt(tan(t)**2 + 1)
+                            }
+    assert checksol(eq, dict_var_soln) == True
+
+
 def test__invert():
     assert _invert(x - 2) == (2, x)
     assert _invert(2) == (2, 0)
@@ -1780,7 +1790,6 @@ def test_issue_2840_8155():
     assert solve(2*sin(x) - 2*sin(2*x)) == [
         0, -pi, pi, -2*I*log(-sqrt(3)/2 - I/2), -2*I*log(-sqrt(3)/2 + I/2),
         -2*I*log(sqrt(3)/2 - I/2), -2*I*log(sqrt(3)/2 + I/2)]
-
 
 def test_issue_9567():
     assert solve(1 + 1/(x - 1)) == [0]


### PR DESCRIPTION
#### master branch

```
In [1]: x, y, r, t = symbols('x, y, r, t')

In [2]: eq = r - x**2 - y**2

In [3]: dict_var_soln = {
   ...:                             y: -sqrt(r)/sqrt(tan(t)**2 + 1),
   ...:                             x: -sqrt(r)*tan(t)/sqrt(tan(t)**2 + 1)
   ...:                         }

In [4]: checksol(eq,dict_var_soln)  # output None

```
#### this branch

```
In [1]: x, y, r, t = symbols('x, y, r, t')

In [2]: eq = r - x**2 - y**2

In [3]: dict_var_soln = {
   ...:                             y: -sqrt(r)/sqrt(tan(t)**2 + 1),
   ...:                             x: -sqrt(r)*tan(t)/sqrt(tan(t)**2 + 1)
   ...:                         }

In [4]: checksol(eq,dict_var_soln)
Out[4]: True

```

Main point is : need `simplify` to reduce the terms. In this case `r - r*tan(t)**2/(tan(t)**2 + 1) - r/(tan(t)**2 + 1)` was not simplified.

```
In [7]: f = r - r*tan(t)**2/(tan(t)**2 + 1) - r/(tan(t)**2 + 1)

In [8]: 

In [8]: f
Out[8]: 
          2                  
     r⋅tan (t)         r     
r - ─────────── - ───────────
       2             2       
    tan (t) + 1   tan (t) + 1

In [9]: simplify(f)
Out[9]: 0
```
