### PR TITLE
Implementation of prime_nu(n) and prime_omega(n) to the ntheory module

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -75,6 +75,10 @@ Ntheory Functions Reference
 
 .. autofunction:: digits
 
+.. autofunction:: prime_nu
+
+.. autofunction:: prime_omega
+
 .. module:: sympy.ntheory.modular
 
 .. autofunction:: symmetric_residue

--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -75,9 +75,9 @@ Ntheory Functions Reference
 
 .. autofunction:: digits
 
-.. autofunction:: prime_nu
+.. autofunction:: primenu
 
-.. autofunction:: prime_omega
+.. autofunction:: primeomega
 
 .. module:: sympy.ntheory.modular
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3682,17 +3682,17 @@ def test_sympy__ntheory__factor___udivisor_sigma():
     assert _test_args(t)
 
 
-def test_sympy__ntheory__factor___prime_nu():
-    from sympy.ntheory.factor_ import prime_nu
+def test_sympy__ntheory__factor___primenu():
+    from sympy.ntheory.factor_ import primenu
     n = symbols('n', integer=True)
-    t = prime_nu(n)
+    t = primenu(n)
     assert _test_args(t)
 
 
-def test_sympy__ntheory__factor___prime_omega():
-    from sympy.ntheory.factor_ import prime_omega
+def test_sympy__ntheory__factor___primeomega():
+    from sympy.ntheory.factor_ import primeomega
     n = symbols('n', integer=True)
-    t = prime_omega(n)
+    t = primeomega(n)
     assert _test_args(t)
 
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3682,6 +3682,20 @@ def test_sympy__ntheory__factor___udivisor_sigma():
     assert _test_args(t)
 
 
+def test_sympy__ntheory__factor___prime_nu():
+    from sympy.ntheory.factor_ import prime_nu
+    n = symbols('n', integer=True)
+    t = prime_nu(n)
+    assert _test_args(t)
+
+
+def test_sympy__ntheory__factor___prime_omega():
+    from sympy.ntheory.factor_ import prime_omega
+    n = symbols('n', integer=True)
+    t = prime_omega(n)
+    assert _test_args(t)
+
+
 def test_sympy__ntheory__residue_ntheory__mobius():
     from sympy.ntheory import mobius
     assert _test_args(mobius(2))

--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -7,7 +7,7 @@ from .generate import nextprime, prevprime, prime, primepi, primerange, \
 from .primetest import isprime
 from .factor_ import divisors, factorint, multiplicity, perfect_power, \
     pollard_pm1, pollard_rho, primefactors, totient, trailing, divisor_count, \
-    divisor_sigma, factorrat, reduced_totient
+    divisor_sigma, factorrat, reduced_totient, prime_nu, prime_omega
 from .partitions_ import npartitions
 from .residue_ntheory import is_primitive_root, is_quad_residue, \
     legendre_symbol, jacobi_symbol, n_order, sqrt_mod, quadratic_residues, \

--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -7,7 +7,7 @@ from .generate import nextprime, prevprime, prime, primepi, primerange, \
 from .primetest import isprime
 from .factor_ import divisors, factorint, multiplicity, perfect_power, \
     pollard_pm1, pollard_rho, primefactors, totient, trailing, divisor_count, \
-    divisor_sigma, factorrat, reduced_totient, prime_nu, prime_omega
+    divisor_sigma, factorrat, reduced_totient, primenu, primeomega
 from .partitions_ import npartitions
 from .residue_ntheory import is_primitive_root, is_quad_residue, \
     legendre_symbol, jacobi_symbol, n_order, sqrt_mod, quadratic_residues, \

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1903,7 +1903,6 @@ class prime_omega(Function):
     .. math ::
         \Omega(n) = \sum_{i=1}^k m_i.
 
-
     References
     ==========
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1842,3 +1842,93 @@ class udivisor_sigma(Function):
                 raise ValueError("n must be a positive integer")
             else:
                 return Mul(*[1+p**(k*e) for p, e in factorint(n).items()])
+
+
+class prime_nu(Function):
+    """
+    Calculate the number of distinct prime factors for a positive integer n.
+
+    If n's prime factorization is:
+
+    .. math ::
+        n = \prod_{i=1}^k p_i^{m_i},
+
+    then ``prime_nu(n)`` or `\\nu(n)` is:
+
+    .. math ::
+        \\nu(n) = k.
+
+    References
+    ==========
+
+    .. [1] http://mathworld.wolfram.com/PrimeFactor.html
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.factor_ import prime_nu
+    >>> prime_nu(1)
+    0
+    >>> prime_nu(30)
+    3
+
+    See Also
+    ========
+
+    factorint
+    """
+
+    @classmethod
+    def eval(cls, n):
+        n = sympify(n)
+        if n.is_Integer:
+            if n <= 0:
+                raise ValueError("n must be a positive integer")
+            else:
+                return len(factorint(n).keys())
+
+
+class prime_omega(Function):
+    """
+    Calculate the number of prime factors counting multiplicities for a
+    positive integer n.
+
+    If n's prime factorization is:
+
+    .. math ::
+        n = \prod_{i=1}^k p_i^{m_i},
+
+    then ``prime_omega(n)``  or `\Omega(n)` is:
+
+    .. math ::
+        \Omega(n) = \sum_{i=1}^k m_i.
+
+
+    References
+    ==========
+
+    .. [1] http://mathworld.wolfram.com/PrimeFactor.html
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.factor_ import prime_omega
+    >>> prime_omega(1)
+    0
+    >>> prime_omega(20)
+    3
+
+    See Also
+    ========
+
+    factorint
+    """
+
+    @classmethod
+    def eval(cls, n):
+        n = sympify(n)
+        if n.is_Integer:
+            if n <= 0:
+                raise ValueError("n must be a positive integer")
+            else:
+                return sum(factorint(n).values())

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1844,8 +1844,8 @@ class udivisor_sigma(Function):
                 return Mul(*[1+p**(k*e) for p, e in factorint(n).items()])
 
 
-class prime_nu(Function):
-    """
+class primenu(Function):
+    r"""
     Calculate the number of distinct prime factors for a positive integer n.
 
     If n's prime factorization is:
@@ -1853,10 +1853,10 @@ class prime_nu(Function):
     .. math ::
         n = \prod_{i=1}^k p_i^{m_i},
 
-    then ``prime_nu(n)`` or `\\nu(n)` is:
+    then ``primenu(n)`` or `\nu(n)` is:
 
     .. math ::
-        \\nu(n) = k.
+        \nu(n) = k.
 
     References
     ==========
@@ -1866,10 +1866,10 @@ class prime_nu(Function):
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import prime_nu
-    >>> prime_nu(1)
+    >>> from sympy.ntheory.factor_ import primenu
+    >>> primenu(1)
     0
-    >>> prime_nu(30)
+    >>> primenu(30)
     3
 
     See Also
@@ -1888,8 +1888,8 @@ class prime_nu(Function):
                 return len(factorint(n).keys())
 
 
-class prime_omega(Function):
-    """
+class primeomega(Function):
+    r"""
     Calculate the number of prime factors counting multiplicities for a
     positive integer n.
 
@@ -1898,7 +1898,7 @@ class prime_omega(Function):
     .. math ::
         n = \prod_{i=1}^k p_i^{m_i},
 
-    then ``prime_omega(n)``  or `\Omega(n)` is:
+    then ``primeomega(n)``  or `\Omega(n)` is:
 
     .. math ::
         \Omega(n) = \sum_{i=1}^k m_i.
@@ -1911,10 +1911,10 @@ class prime_omega(Function):
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import prime_omega
-    >>> prime_omega(1)
+    >>> from sympy.ntheory.factor_ import primeomega
+    >>> primeomega(1)
     0
-    >>> prime_omega(20)
+    >>> primeomega(20)
     3
 
     See Also

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -12,7 +12,7 @@ from sympy.ntheory import (isprime, n_order, is_primitive_root,
     factorrat, reduced_totient)
 from sympy.ntheory.factor_ import (smoothness, smoothness_p,
     antidivisors, antidivisor_count, core, digits, udivisors, udivisor_sigma,
-    udivisor_count, prime_nu, prime_omega)
+    udivisor_count, primenu, primeomega)
 from sympy.ntheory.generate import cycle_length
 from sympy.ntheory.multinomial import (
     multinomial_coefficients, multinomial_coefficients_iterator)
@@ -484,29 +484,29 @@ def test_digits():
     assert digits(-92838, 11) == [-11, 6, 3, 8, 2, 9]
 
 
-def test_prime_nu():
-    assert prime_nu(2) == 1
-    assert prime_nu(2 * 3) == 2
-    assert prime_nu(2 * 3 * 5) == 3
-    assert prime_nu(3 * 25) == prime_nu(3) + prime_nu(25)
-    assert [prime_nu(p) for p in primerange(1, 10)] == [1, 1, 1, 1]
-    assert prime_nu(fac(50)) == 15
-    assert prime_nu(2 ** 9941 - 1) == 1
+def test_primenu():
+    assert primenu(2) == 1
+    assert primenu(2 * 3) == 2
+    assert primenu(2 * 3 * 5) == 3
+    assert primenu(3 * 25) == primenu(3) + primenu(25)
+    assert [primenu(p) for p in primerange(1, 10)] == [1, 1, 1, 1]
+    assert primenu(fac(50)) == 15
+    assert primenu(2 ** 9941 - 1) == 1
     n = Symbol('n', integer=True)
-    assert prime_nu(n)
-    assert prime_nu(n).subs(n, 2 ** 31 - 1) == 1
-    assert summation(prime_nu(n), (n, 2, 30)) == 43
+    assert primenu(n)
+    assert primenu(n).subs(n, 2 ** 31 - 1) == 1
+    assert summation(primenu(n), (n, 2, 30)) == 43
 
 
-def test_prime_omega():
-    assert prime_omega(2) == 1
-    assert prime_omega(2 * 2) == 2
-    assert prime_omega(2 * 2 * 3) == 3
-    assert prime_omega(3 * 25) == prime_omega(3) + prime_omega(25)
-    assert [prime_omega(p) for p in primerange(1, 10)] == [1, 1, 1, 1]
-    assert prime_omega(fac(50)) == 108
-    assert prime_omega(2 ** 9941 - 1) == 1
+def test_primeomega():
+    assert primeomega(2) == 1
+    assert primeomega(2 * 2) == 2
+    assert primeomega(2 * 2 * 3) == 3
+    assert primeomega(3 * 25) == primeomega(3) + primeomega(25)
+    assert [primeomega(p) for p in primerange(1, 10)] == [1, 1, 1, 1]
+    assert primeomega(fac(50)) == 108
+    assert primeomega(2 ** 9941 - 1) == 1
     n = Symbol('n', integer=True)
-    assert prime_omega(n)
-    assert prime_omega(n).subs(n, 2 ** 31 - 1) == 1
-    assert summation(prime_omega(n), (n, 2, 30)) == 59
+    assert primeomega(n)
+    assert primeomega(n).subs(n, 2 ** 31 - 1) == 1
+    assert summation(primeomega(n), (n, 2, 30)) == 59

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -12,7 +12,7 @@ from sympy.ntheory import (isprime, n_order, is_primitive_root,
     factorrat, reduced_totient)
 from sympy.ntheory.factor_ import (smoothness, smoothness_p,
     antidivisors, antidivisor_count, core, digits, udivisors, udivisor_sigma,
-    udivisor_count)
+    udivisor_count, prime_nu, prime_omega)
 from sympy.ntheory.generate import cycle_length
 from sympy.ntheory.multinomial import (
     multinomial_coefficients, multinomial_coefficients_iterator)
@@ -482,3 +482,31 @@ def test_digits():
     assert digits(384753, 71) == [71, 1, 5, 23, 4]
     assert digits(93409) == [10, 9, 3, 4, 0, 9]
     assert digits(-92838, 11) == [-11, 6, 3, 8, 2, 9]
+
+
+def test_prime_nu():
+    assert prime_nu(2) == 1
+    assert prime_nu(2 * 3) == 2
+    assert prime_nu(2 * 3 * 5) == 3
+    assert prime_nu(3 * 25) == prime_nu(3) + prime_nu(25)
+    assert [prime_nu(p) for p in primerange(1, 10)] == [1, 1, 1, 1]
+    assert prime_nu(fac(50)) == 15
+    assert prime_nu(2 ** 9941 - 1) == 1
+    n = Symbol('n', integer=True)
+    assert prime_nu(n)
+    assert prime_nu(n).subs(n, 2 ** 31 - 1) == 1
+    assert summation(prime_nu(n), (n, 2, 30)) == 43
+
+
+def test_prime_omega():
+    assert prime_omega(2) == 1
+    assert prime_omega(2 * 2) == 2
+    assert prime_omega(2 * 2 * 3) == 3
+    assert prime_omega(3 * 25) == prime_omega(3) + prime_omega(25)
+    assert [prime_omega(p) for p in primerange(1, 10)] == [1, 1, 1, 1]
+    assert prime_omega(fac(50)) == 108
+    assert prime_nu(2 ** 9941 - 1) == 1
+    n = Symbol('n', integer=True)
+    assert prime_omega(n)
+    assert prime_omega(n).subs(n, 2 ** 31 - 1) == 1
+    assert summation(prime_omega(n), (n, 2, 30)) == 59

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -505,7 +505,7 @@ def test_prime_omega():
     assert prime_omega(3 * 25) == prime_omega(3) + prime_omega(25)
     assert [prime_omega(p) for p in primerange(1, 10)] == [1, 1, 1, 1]
     assert prime_omega(fac(50)) == 108
-    assert prime_nu(2 ** 9941 - 1) == 1
+    assert prime_omega(2 ** 9941 - 1) == 1
     n = Symbol('n', integer=True)
     assert prime_omega(n)
     assert prime_omega(n).subs(n, 2 ** 31 - 1) == 1

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1884,6 +1884,19 @@ class LatexPrinter(Printer):
             return r"\sigma^*^{%s}%s" % (self._print(exp), tex)
         return r"\sigma^*%s" % tex
 
+    def _print_primenu(self, expr, exp=None):
+        if exp is not None:
+            return r'\left(\nu\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
+                    self._print(exp))
+        return r'\nu\left(%s\right)' % self._print(expr.args[0])
+
+    def _print_primeomega(self, expr, exp=None):
+        if exp is not None:
+            return r'\left(\Omega\left(%s\right)\right)^{%s}' % (self._print(expr.args[0]),
+                    self._print(exp))
+        return r'\Omega\left(%s\right)' % self._print(expr.args[0])
+
+
 def translate(s):
     r'''
     Check for a modifier ending the string.  If present, convert the

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2054,6 +2054,24 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*pform.right(')'))
         return pform
 
+    def _print_primenu(self, e):
+        pform = self._print(e.args[0])
+        pform = prettyForm(*pform.parens())
+        if self._use_unicode:
+            pform = prettyForm(*pform.left(greek_unicode['nu']))
+        else:
+            pform = prettyForm(*pform.left('nu'))
+        return pform
+
+    def _print_primeomega(self, e):
+        pform = self._print(e.args[0])
+        pform = prettyForm(*pform.parens())
+        if self._use_unicode:
+            pform = prettyForm(*pform.left(greek_unicode['Omega']))
+        else:
+            pform = prettyForm(*pform.left('Omega'))
+        return pform
+
 
 def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5445,3 +5445,25 @@ def test_issue_9877():
     ucode_str2 = u'{x} ∩ {y} ∩ ({z} \ [1, 2])'
     d, e, f, g = FiniteSet(x), FiniteSet(y), FiniteSet(z), Interval(1, 2)
     assert upretty(Intersection(d, e, Complement(f, g))) == ucode_str2
+
+
+def test_pretty_primenu():
+    from sympy.ntheory.factor_ import primenu
+
+    ascii_str1 = "nu(n)"
+    ucode_str1 = u("ν(n)")
+
+    n = symbols('n', integer=True)
+    assert pretty(primenu(n)) == ascii_str1
+    assert upretty(primenu(n)) == ucode_str1
+
+
+def test_pretty_primeomega():
+    from sympy.ntheory.factor_ import primeomega
+
+    ascii_str1 = "Omega(n)"
+    ucode_str1 = u("Ω(n)")
+
+    n = symbols('n', integer=True)
+    assert pretty(primeomega(n)) == ascii_str1
+    assert upretty(primeomega(n)) == ucode_str1

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -16,7 +16,7 @@ from sympy import (
     elliptic_e, elliptic_pi, cos, tan, Wild, true, false, Equivalent, Not,
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
-    AccumBounds, reduced_totient)
+    AccumBounds, reduced_totient, primenu, primeomega)
 
 
 from sympy.ntheory.factor_ import udivisor_sigma
@@ -366,6 +366,12 @@ def test_latex_functions():
     assert latex(udivisor_sigma(x)**2) == r"\sigma^*^{2}\left(x\right)"
     assert latex(udivisor_sigma(x, y)) == r"\sigma^*_y\left(x\right)"
     assert latex(udivisor_sigma(x, y)**2) == r"\sigma^*^{2}_y\left(x\right)"
+
+    assert latex(primenu(n)) == r'\nu\left(n\right)'
+    assert latex(primenu(n) ** 2) == r'\left(\nu\left(n\right)\right)^{2}'
+
+    assert latex(primeomega(n)) == r'\Omega\left(n\right)'
+    assert latex(primeomega(n) ** 2) == r'\left(\Omega\left(n\right)\right)^{2}'
 
     # some unknown function name should get rendered with \operatorname
     fjlkd = Function('fjlkd')


### PR DESCRIPTION
This PR suggests the addition of two Functions to the ntheory module.
- **prime_nu(n)**: calculate the number of distinct prime factors for a positive integer n.
- **prime_omega(n)**: calculate the number of prime factors counting multiplicities for a positive integer n.

Both are counterparts to Wolfram's PrimeNu[n] and PrimeOmega[n]:
https://reference.wolfram.com/language/ref/PrimeNu.html
https://reference.wolfram.com/language/ref/PrimeOmega.html
