### PR TITLE
Enabled refine_MatMul to accept non Matrix arguments

### DIFF
--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -263,8 +263,16 @@ def refine_MatMul(expr, assumptions):
     I
     """
     newargs = []
-    last = expr.args[0]
-    for arg in expr.args[1:]:
+    exprargs = []
+
+    for args in expr.args:
+        if args.is_Matrix:
+            exprargs.append(args)
+        else:
+            newargs.append(args)
+
+    last = exprargs[0]
+    for arg in exprargs[1:]:
         if arg == last.T and ask(Q.orthogonal(arg), assumptions):
             last = Identity(arg.shape[0])
         elif arg == last.conjugate() and ask(Q.unitary(arg), assumptions):

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -118,6 +118,10 @@ def test_collapse_MatrixBase():
 def test_refine():
     assert refine(C*C.T*D, Q.orthogonal(C)).doit() == D
 
+    kC = k*C
+    assert refine(kC*C.T, Q.orthogonal(C)).doit() == k*Identity(n)
+    assert refine(kC* kC.T, Q.orthogonal(C)).doit() == (k**2)*Identity(n)
+
 def test_matmul_no_matrices():
     assert MatMul(1) == 1
     assert MatMul(n, m) == n*m


### PR DESCRIPTION
This is fix for #11359. Enabled refine_MatMul to accept non Matrix arguments.
#### Output before this PR:

``` python
from sympy import *
from sympy.abc import a, l

E = MatrixSymbol('E', l, l)
aE = a * E

with assuming(Q.orthogonal(E)):
    print(refine(E.T * E))
    print(refine(aE.T * aE))
```

Returned:

``` python
/Users/wakita/anaconda3/envs/pyqtgl/bin/python "/Users/wakita/Dropbox (smartnova)/work/pysandbox/testsympy/aE.py"
Traceback (most recent call last):
  File "/Users/wakita/Dropbox (smartnova)/work/pysandbox/testsympy/aE.py", line 9, in <module>
    print(refine(aE.T * aE))
  File "/Users/wakita/anaconda3/envs/pyqtgl/lib/python3.5/site-packages/sympy/assumptions/refine.py", line 29, in refine
    args = [refine(arg, assumptions) for arg in expr.args]
  File "/Users/wakita/anaconda3/envs/pyqtgl/lib/python3.5/site-packages/sympy/assumptions/refine.py", line 29, in <listcomp>
    args = [refine(arg, assumptions) for arg in expr.args]
  File "/Users/wakita/anaconda3/envs/pyqtgl/lib/python3.5/site-packages/sympy/assumptions/refine.py", line 29, in refine
    args = [refine(arg, assumptions) for arg in expr.args]
  File "/Users/wakita/anaconda3/envs/pyqtgl/lib/python3.5/site-packages/sympy/assumptions/refine.py", line 29, in <listcomp>
    args = [refine(arg, assumptions) for arg in expr.args]
  File "/Users/wakita/anaconda3/envs/pyqtgl/lib/python3.5/site-packages/sympy/assumptions/refine.py", line 40, in refine
    new_expr = handler(expr, assumptions)
  File "/Users/wakita/anaconda3/envs/pyqtgl/lib/python3.5/site-packages/sympy/matrices/expressions/matmul.py", line 265, in refine_MatMul
    if arg == last.T and ask(Q.orthogonal(arg), assumptions):
AttributeError: 'Symbol' object has no attribute 'T'
```
#### Output after this PR:

``` python
>>> with assuming(Q.orthogonal(E)):
...     print(refine(E.T * E))
...     print(refine(E.T * aE))
...     print(refine(aE.T * aE))
... 
I
a*I
a*(a*E)'*E
```
