### PR TITLE
is_zero_dimensional: remove sqrt from the eqs

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6506,20 +6506,16 @@ def is_zero_dimensional(F, *gens, **args):
 
     # Remove sqrt or radicals from `F` eqs, if present.
     for eq in F:
+        eq_new = eq
         without_radicals = unrad(simplify(eq))
         if without_radicals:
             eq_unrad, cov = without_radicals
             if not cov:
-                F.remove(eq)
-                # remove the denominator
-                eq_unrad = eq_unrad.as_numer_denom()[0]
-                F.append(eq_unrad)
-        else:
-            # remove the denominator
-            eq_orig = eq
-            eq = eq.as_numer_denom()[0]
-            F.remove(eq_orig)
-            F.append(eq)
+                eq_new = eq_unrad
+        # use the numerator
+        eq_new = eq_new.as_numer_denom()[0]
+        F.remove(eq)
+        F.append(eq_new)
     return GroebnerBasis(F, *gens, **args).is_zero_dimensional
 
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6501,6 +6501,17 @@ def is_zero_dimensional(F, *gens, **args):
     Algorithms, 3rd edition, p. 230
 
     """
+    from sympy.solvers.solvers import unrad
+    from sympy.simplify import simplify
+
+    # Remove sqrt or radicals from `F` eqs, if present.
+    for eq in F:
+        without_radicals = unrad(simplify(eq))
+        if without_radicals:
+            eq_unrad, cov = without_radicals
+            if not cov:
+                F.remove(eq)
+                F.append(eq_unrad)
     return GroebnerBasis(F, *gens, **args).is_zero_dimensional
 
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6511,7 +6511,15 @@ def is_zero_dimensional(F, *gens, **args):
             eq_unrad, cov = without_radicals
             if not cov:
                 F.remove(eq)
+                # remove the denominator
+                eq_unrad = eq_unrad.as_numer_denom()[0]
                 F.append(eq_unrad)
+        else:
+            # remove the denominator
+            eq_orig = eq
+            eq = eq.as_numer_denom()[0]
+            F.remove(eq_orig)
+            F.append(eq)
     return GroebnerBasis(F, *gens, **args).is_zero_dimensional
 
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3031,6 +3031,29 @@ def test_is_zero_dimensional():
     assert is_zero_dimensional(F, x, y, z) is True
 
 
+def test_issue_11175_test1():
+    system = [sqrt(x**2 + y**2) - sqrt(10), x + y - 4]
+    assert is_zero_dimensional(system) is True
+    assert is_zero_dimensional(system, [x, y]) is True
+
+    x1 = 0
+    y1 = -620
+    r1 = 920
+    x2 = 126
+    y2 = 276
+    x3 = 51
+    y3 = 205
+    r3 = 104
+    v = [x, y, z]
+
+    g1 = sqrt((x - x1)**2 + (y - y1)**2) + z - r1
+    g2 = (x2 - x)**2 + (y2 - y)**2 - z**2
+    g3 = sqrt((x - x3)**2 + (y - y3)**2) + z - r3
+    G = [g1, g2, g3]
+    assert is_zero_dimensional(G, v) is True
+    assert is_zero_dimensional(G) is True
+
+
 def test_GroebnerBasis():
     F = [x*y - 2*y, 2*y**2 - x**2]
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3031,7 +3031,7 @@ def test_is_zero_dimensional():
     assert is_zero_dimensional(F, x, y, z) is True
 
 
-def test_issue_11175_test1():
+def test_issue_11175():
     system = [sqrt(x**2 + y**2) - sqrt(10), x + y - 4]
     assert is_zero_dimensional(system) is True
     assert is_zero_dimensional(system, [x, y]) is True
@@ -3052,6 +3052,9 @@ def test_issue_11175_test1():
     G = [g1, g2, g3]
     assert is_zero_dimensional(G, v) is True
     assert is_zero_dimensional(G) is True
+
+    system = [x**2 + 2/y - 2, x + y - 3]
+    assert is_zero_dimensional(system, [x, y]) is True
 
 
 def test_GroebnerBasis():


### PR DESCRIPTION
Fixes some cases of https://github.com/sympy/sympy/issues/11175
#### Master branch

```
In [1]: system = [sqrt(x**2 + y**2) - sqrt(10), x + y - 4]

In [2]:  is_zero_dimensional(system)
Out[2]: False

In [3]:  is_zero_dimensional(system, [x, y])
---------------------------------------------------------------------------
PolynomialError: sqrt(x**2 + y**2) contains an element of the generators set

In [4]: solve(system, [x, y])
Out[4]: [(1, 3), (3, 1)]

In [5]: x1 = 0

In [6]:     y1 = -620

In [7]:     r1 = 920

In [8]:     x2 = 126

In [9]:     y2 = 276

In [10]:     x3 = 51

In [11]:     y3 = 205

In [12]:     r3 = 104

In [13]:     v = [x, y, z]

In [14]:     g1 = sqrt((x - x1)**2 + (y - y1)**2) + z - r1

In [15]:     g2 = (x2 - x)**2 + (y2 - y)**2 - z**2

In [16]:     g3 = sqrt((x - x3)**2 + (y - y3)**2) + z - r3

In [17]:     G = [g1, g2, g3]

In [18]:     is_zero_dimensional(G, v)
PolynomialError
```
#### This branch

```
In [ ]: system = [sqrt(x**2 + y**2) - sqrt(10), x + y - 4]

In [ ]:  is_zero_dimensional(system)
Out[ ]: True

In [ ]:  is_zero_dimensional(system, [x, y])
Out[ ]: True


In [ ]: x1 = 0

In [ ]:     y1 = -620

In [ ]:     r1 = 920

In [ ]:     x2 = 126

In [ ]:     y2 = 276

In [ ]:     x3 = 51

In [ ]:     y3 = 205

In [ ]:     r3 = 104

In [ ]:     v = [x, y, z]

In [ ]:     g1 = sqrt((x - x1)**2 + (y - y1)**2) + z - r1

In [ ]:     g2 = (x2 - x)**2 + (y2 - y)**2 - z**2

In [ ]:     g3 = sqrt((x - x3)**2 + (y - y3)**2) + z - r3

In [ ]:     G = [g1, g2, g3]

In [ ]:     is_zero_dimensional(G, v)
True

```
