### PR TITLE
Add pretty and latex printing for Mod

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1385,9 +1385,9 @@ class LatexPrinter(Printer):
 
     def _print_Mod(self, expr, exp=None):
         if exp is not None:
-            return r'\left(%s\ mod\ %s\right)^{%s}' % (self.parenthesize(expr.args[0],
+            return r'\left(%s\bmod{%s}\right)^{%s}' % (self.parenthesize(expr.args[0],
                     PRECEDENCE['Mul'], strict=True), self._print(expr.args[1]), self._print(exp))
-        return r'%s\ mod\ %s' % (self.parenthesize(expr.args[0],
+        return r'%s\bmod{%s}' % (self.parenthesize(expr.args[0],
                 PRECEDENCE['Mul'], strict=True), self._print(expr.args[1]))
 
     def _print_HadamardProduct(self, expr):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -4,7 +4,7 @@ A Printer which converts an expression into its LaTeX equivalent.
 
 from __future__ import print_function, division
 
-from sympy.core import S, Add, Symbol
+from sympy.core import S, Add, Symbol, Mod
 from sympy.core.function import _coeff_isneg
 from sympy.core.sympify import SympifyError
 from sympy.core.alphabets import greeks
@@ -216,7 +216,8 @@ class LatexPrinter(Printer):
         elif expr.is_Mul:
             if not first and _coeff_isneg(expr):
                 return True
-
+        if any([expr.has(x) for x in (Mod,)]):
+            return True
         if (not last and
             any([expr.has(x) for x in (Integral, Piecewise, Product, Sum)])):
             return True
@@ -231,6 +232,8 @@ class LatexPrinter(Printer):
         things.
         """
         if expr.is_Relational:
+            return True
+        if any([expr.has(x) for x in (Mod,)]):
             return True
         return False
 
@@ -1379,6 +1382,13 @@ class LatexPrinter(Printer):
                 return r"\left(%s\right)" % self._print(x)
             return self._print(x)
         return ' '.join(map(parens, expr.args))
+
+    def _print_Mod(self, expr, exp=None):
+        if exp is not None:
+            return r'\left(%s\ mod\ %s\right)^{%s}' % (self.parenthesize(expr.args[0],
+                    PRECEDENCE['Mul'], strict=True), self._print(expr.args[1]), self._print(exp))
+        return r'%s\ mod\ %s' % (self.parenthesize(expr.args[0],
+                PRECEDENCE['Mul'], strict=True), self._print(expr.args[1]))
 
     def _print_HadamardProduct(self, expr):
         from sympy import Add, MatAdd, MatMul

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from sympy.core import S
 from sympy.core.containers import Tuple
 from sympy.core.function import _coeff_isneg
+from sympy.core.mod import Mod
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
 from sympy.core.power import Pow
@@ -1258,6 +1259,15 @@ class PrettyPrinter(Printer):
         if self._use_unicode:
             return prettyForm(pretty_symbol('gamma'))
         return self._print(Symbol("EulerGamma"))
+
+    def _print_Mod(self, expr):
+        pform = self._print(expr.args[0])
+        if pform.binding > prettyForm.MUL:
+            pform = prettyForm(*pform.parens())
+        pform = prettyForm(*pform.right(' mod '))
+        pform = prettyForm(*pform.right(self._print(expr.args[1])))
+        pform.binding = prettyForm.OPEN
+        return pform
 
     def _print_Add(self, expr, order=None):
         if self.order == 'none':

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5467,3 +5467,34 @@ def test_pretty_primeomega():
     n = symbols('n', integer=True)
     assert pretty(primeomega(n)) == ascii_str1
     assert upretty(primeomega(n)) == ucode_str1
+
+
+def test_pretty_Mod():
+    from sympy.core import Mod
+
+    ascii_str1 = "x mod 7"
+    ucode_str1 = u("x mod 7")
+
+    ascii_str2 = "(x + 1) mod 7"
+    ucode_str2 = u("(x + 1) mod 7")
+
+    ascii_str3 = "2*x mod 7"
+    ucode_str3 = u("2⋅x mod 7")
+
+    ascii_str4 = "(x mod 7) + 1"
+    ucode_str4 = u("(x mod 7) + 1")
+
+    ascii_str5 = "2*(x mod 7)"
+    ucode_str5 = u("2⋅(x mod 7)")
+
+    x = symbols('x', integer=True)
+    assert pretty(Mod(x, 7)) == ascii_str1
+    assert upretty(Mod(x, 7)) == ucode_str1
+    assert pretty(Mod(x + 1, 7)) == ascii_str2
+    assert upretty(Mod(x + 1, 7)) == ucode_str2
+    assert pretty(Mod(2 * x, 7)) == ascii_str3
+    assert upretty(Mod(2 * x, 7)) == ucode_str3
+    assert pretty(Mod(x, 7) + 1) == ascii_str4
+    assert upretty(Mod(x, 7) + 1) == ucode_str4
+    assert pretty(2 * Mod(x, 7)) == ascii_str5
+    assert upretty(2 * Mod(x, 7)) == ucode_str5

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -16,7 +16,7 @@ from sympy import (
     elliptic_e, elliptic_pi, cos, tan, Wild, true, false, Equivalent, Not,
     Contains, divisor_sigma, SymmetricDifference, SeqPer, SeqFormula,
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
-    AccumBounds, reduced_totient, primenu, primeomega)
+    AccumBounds, reduced_totient, primenu, primeomega, Mod)
 
 
 from sympy.ntheory.factor_ import udivisor_sigma
@@ -372,6 +372,12 @@ def test_latex_functions():
 
     assert latex(primeomega(n)) == r'\Omega\left(n\right)'
     assert latex(primeomega(n) ** 2) == r'\left(\Omega\left(n\right)\right)^{2}'
+
+    assert latex(Mod(x, 7)) == r'x\ mod\ 7'
+    assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\ mod\ 7'
+    assert latex(Mod(2 * x, 7)) == r'2 x\ mod\ 7'
+    assert latex(Mod(x, 7) + 1) == r'\left(x\ mod\ 7\right) + 1'
+    assert latex(2 * Mod(x, 7)) == r'2 \left(x\ mod\ 7\right)'
 
     # some unknown function name should get rendered with \operatorname
     fjlkd = Function('fjlkd')

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -373,11 +373,11 @@ def test_latex_functions():
     assert latex(primeomega(n)) == r'\Omega\left(n\right)'
     assert latex(primeomega(n) ** 2) == r'\left(\Omega\left(n\right)\right)^{2}'
 
-    assert latex(Mod(x, 7)) == r'x\ mod\ 7'
-    assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\ mod\ 7'
-    assert latex(Mod(2 * x, 7)) == r'2 x\ mod\ 7'
-    assert latex(Mod(x, 7) + 1) == r'\left(x\ mod\ 7\right) + 1'
-    assert latex(2 * Mod(x, 7)) == r'2 \left(x\ mod\ 7\right)'
+    assert latex(Mod(x, 7)) == r'x\bmod{7}'
+    assert latex(Mod(x + 1, 7)) == r'\left(x + 1\right)\bmod{7}'
+    assert latex(Mod(2 * x, 7)) == r'2 x\bmod{7}'
+    assert latex(Mod(x, 7) + 1) == r'\left(x\bmod{7}\right) + 1'
+    assert latex(2 * Mod(x, 7)) == r'2 \left(x\bmod{7}\right)'
 
     # some unknown function name should get rendered with \operatorname
     fjlkd = Function('fjlkd')


### PR DESCRIPTION
This PR fixes #11375.

Examples of pretty printing for Mod function after this PR:

``` python
>>> Mod(x, 7)
x mod 7

>>> Mod(x + 1, 7)
(x + 1) mod 7

>>> Mod(2 * x, 7)
2⋅x mod 7

>>> Mod(x, 7) + 1
(x mod 7) + 1

>>> 2 * Mod(x, 7)
2⋅(x mod 7)
```

The same is applied for latex printing.
