### PR TITLE
Implemented Ellipsis in slicing Sympy Matrices.

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -68,8 +68,15 @@ class DenseMatrix(MatrixBase):
         >>> m[::2]
         [1, 3]
         """
-        if isinstance(key, tuple):
-            i, j = key
+        if isinstance(key, tuple) or key is Ellipsis:
+            if key is Ellipsis:
+                i = j = slice(None, None, None)
+            else:
+                i, j = key
+            if i is Ellipsis:
+                i = slice(None, None, None)
+            if j is Ellipsis:
+                j = slice(None, None, None)
             try:
                 i, j = self.key2ij(key)
                 return self._mat[i*self.cols + j]

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -225,9 +225,20 @@ class MatrixExpr(Basic):
         if not isinstance(key, tuple) and isinstance(key, slice):
             from sympy.matrices.expressions.slice import MatrixSlice
             return MatrixSlice(self, key, (0, None, 1))
+        if key is Ellipsis:
+            i = j = slice(None, None, None)
+            from sympy.matrices.expressions.slice import MatrixSlice
+            return MatrixSlice(self, i, j)
         if isinstance(key, tuple) and len(key) == 2:
             i, j = key
             if isinstance(i, slice) or isinstance(j, slice):
+                from sympy.matrices.expressions.slice import MatrixSlice
+                return MatrixSlice(self, i, j)
+            if (i is Ellipsis) or (j is Ellipsis):
+                if i is Ellipsis:
+                    i = slice(None, None, None)
+                if j is Ellipsis:
+                    j = slice(None, None, None)
                 from sympy.matrices.expressions.slice import MatrixSlice
                 return MatrixSlice(self, i, j)
             i, j = sympify(i), sympify(j)

--- a/sympy/matrices/expressions/tests/test_slice.py
+++ b/sympy/matrices/expressions/tests/test_slice.py
@@ -40,6 +40,11 @@ def test_slicing():
     assert X[2, :] == MatrixSlice(X, 2, (0, m))
     assert X[k, :] == MatrixSlice(X, k, (0, m))
 
+def test_ellipsis():
+    assert X[...] == MatrixSlice(X, (0, n), (0, m))
+    assert X[2, ...] == MatrixSlice(X, 2, (0, m))
+    assert X[k, ...] == MatrixSlice(X, k, (0, m))
+
 def test_exceptions():
     X = MatrixSymbol('x', 10, 20)
     raises(IndexError, lambda: X[0:12, 2])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -451,6 +451,9 @@ def test_slicing():
     m2 = Matrix([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]])
     assert m2[:, -1] == Matrix(4, 1, [3, 7, 11, 15])
     assert m2[-2:, :] == Matrix([[8, 9, 10, 11], [12, 13, 14, 15]])
+    assert m2[...] == m2
+    assert m2[-2:, ...] == Matrix([[8, 9, 10, 11], [12, 13, 14, 15]])
+    assert m2[..., -1] == Matrix(4, 1, [3, 7, 11, 15])
 
 
 def test_submatrix_assignment():


### PR DESCRIPTION
This is fix for  #11345. Added conditions when the argument is `ellipsis`.
#### Sample Program

``` python
>>> from sympy import *
>>> from sympy.abc import m, n
>>> X = MatrixSymbol('X', n, m)
>>> X[...]
X[:n, :m]
>>> X[2, ...]
X[2, :m]
>>> X[..., 2]
X[:n, 2]
```
