### PR TITLE
Change the default color map for 3d printing to viridis

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -911,9 +911,9 @@ class MatplotlibBackend(BaseBackend):
                 self.ax.set_zlim((min(z), max(z)))
             elif s.is_3Dsurface:
                 x, y, z = s.get_meshes()
-                collection = self.ax.plot_surface(x, y, z, cmap=self.cm.jet,
-                                                  rstride=1, cstride=1,
-                                                  linewidth=0.1)
+                collection = self.ax.plot_surface(x, y, z,
+                    cmap=getattr(self.cm, 'viridis', self.cm.jet),
+                    rstride=1, cstride=1, linewidth=0.1)
             elif s.is_implicit:
                 #Smart bounds have to be set to False for implicit plots.
                 self.ax.spines['left'].set_smart_bounds(False)


### PR DESCRIPTION
It still uses jet if viridis is not available, to support older versions of
matplotlib.

It looks like at lot more refactoring would be needed to make this user configurable (and other things as well), so I didn't attempt it. At least viridis is better than jet. 
## Before

![figure_1-jet](https://cloud.githubusercontent.com/assets/71486/16888823/076338aa-4aa8-11e6-8875-76571b80dfd7.png)
## After

![figure_1-viridis](https://cloud.githubusercontent.com/assets/71486/16888825/0db0441e-4aa8-11e6-84cd-4562bc2a2905.png)
## Code

``` py
In [1]: %matplotlib
Using matplotlib backend: MacOSX

In [2]: from sympy.plotting import plot3d

In [3]: from sympy import *

In [4]: x, y = symbols('x y')

In [5]: plot3d(x**3 - 3*x*y**2)
Out[5]: <sympy.plotting.plot.Plot at 0x112677518>
```

Related: https://stackoverflow.com/questions/38379403/change-colormap-in-sympys-plot3d CC @nicoguaro
