### PR TITLE
Series expansion of Subs and Indexed

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2512,7 +2512,7 @@ class Expr(Basic, EvalfMixin):
         if x.is_positive is x.is_negative is None or x.is_Symbol is not True:
             # replace x with an x that has a positive assumption
             xpos = Dummy('x', positive=True, finite=True)
-            rv = self.xreplace({x: xpos}).series(xpos, x0, n, dir, logx=logx)
+            rv = self.subs(x, xpos).series(xpos, x0, n, dir, logx=logx)
             if n is None:
                 return (s.subs(xpos, x) for s in rv)
             else:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1351,6 +1351,8 @@ class Derivative(Expr):
             yield self.func(term, *dx)
 
     def _eval_nseries(self, x, n, logx):
+        if x in self.variables:
+            n += 1
         arg = self.args[0].nseries(x, n=n, logx=logx)
         o = arg.getO()
         dx = self.args[1:]
@@ -1360,7 +1362,14 @@ class Derivative(Expr):
         return Add(*rv)
 
     def _eval_as_leading_term(self, x):
-        return self.args[0].as_leading_term(x)
+        return self.func(self.args[0].as_leading_term(x), *self.args[1:])
+        ddone = self.doit()
+        if isinstance(ddone, Derivative):
+            counts = self.variables.count(x)
+            for lt in self.args[0].lseries(x):
+                pass
+            return self.args[0].as_leading_term(x)
+        return ddone.as_leading_term(x)
 
     def _sage_(self):
         import sage.all as sage
@@ -1625,16 +1634,28 @@ class Subs(Expr):
                     self.variables, self.point).doit() for arg,
                     point in zip(self.variables, self.point) ])
 
+    # def series(self, x=None, x0=0, n=6, dir="+", logx=None):
+    #     # Need to overload this function, as .subs( ) does not work for Subs in
+    #     # case of expansion in the variable being substituted.
+    #     if x in self.args[1]:
+    #         return self.func(self.args[0].series(x, x0, n, dir, logx), *self.args[1:])
+    #     return self.series(x, x0, n, dir, logx)
+
     def _eval_nseries(self, x, n, logx):
-        if x in self.args[1]:
-            raise NotImplementedError("series variable is substitution variable")
+        # if x in self.args[1]:
+        #     raise NotImplementedError("series variable is substitution variable")
+        if x in self.args[2]:
+            # x is the variable being substituted into
+            apos = self.args[2].index(x)
+            other = self.args[1][apos]
+            arg = self.args[0].nseries(other, n=n, logx=logx)
+            o = arg.getO()
+            subs_args = [self.func(a, *self.args[1:]) for a in arg.removeO().args]
+            return Add(*subs_args) + o.subs(other, x)
         arg = self.args[0].nseries(x, n=n, logx=logx)
         o = arg.getO()
         other = self.args[1:]
-        #rv = [self.func(a, *other) for a in Add.make_args(arg.removeO())]
         rv = list(Add.make_args(arg.removeO()))
-        # if o:
-        #     rv.append(o.subs(x, self.args[2]))
         return Subs(Add(*rv), *other).doit()
 
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1679,6 +1679,18 @@ class Subs(Expr):
         subs_args = [self.func(a, *self.args[1:]) for a in arg.removeO().args]
         return Add(*subs_args) + o
 
+    def _eval_as_leading_term(self, x):
+        if x in self.point:
+            ipos = self.point.index(x)
+            xvar = self.variables[ipos]
+            return self.expr.as_leading_term(xvar)
+        if x in self.variables:
+            # if `x` is a dummy variable, it means it won't exist after the
+            # substitution has been performed:
+            return self
+        # The variable is independent of the substitution:
+        return self.expr.as_leading_term(x)
+
 
 def diff(f, *symbols, **kwargs):
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1631,6 +1631,11 @@ class Subs(Expr):
         return (self.expr.free_symbols - set(self.variables) |
             set(self.point.free_symbols))
 
+    def _has(self, pattern):
+        if pattern in self.variables and pattern not in self.point:
+            return False
+        return super(Subs, self)._has(pattern)
+
     def __eq__(self, other):
         if not isinstance(other, Subs):
             return False
@@ -1674,7 +1679,7 @@ class Subs(Expr):
             arg = self.args[0].nseries(other, n=n, logx=logx)
             o = arg.getO()
             subs_args = [self.func(a, *self.args[1:]) for a in arg.removeO().args]
-            return Add(*subs_args) + o.subs(other, x)
+            return Add(*subs_args) + Subs(o.subs(other, x), x, self.point)
         arg = self.args[0].nseries(x, n=n, logx=logx)
         o = arg.getO()
         other = self.args[1:]

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1625,6 +1625,18 @@ class Subs(Expr):
                     self.variables, self.point).doit() for arg,
                     point in zip(self.variables, self.point) ])
 
+    def _eval_nseries(self, x, n, logx):
+        if x in self.args[1]:
+            raise NotImplementedError("series variable is substitution variable")
+        arg = self.args[0].nseries(x, n=n, logx=logx)
+        o = arg.getO()
+        other = self.args[1:]
+        #rv = [self.func(a, *other) for a in Add.make_args(arg.removeO())]
+        rv = list(Add.make_args(arg.removeO()))
+        # if o:
+        #     rv.append(o.subs(x, self.args[2]))
+        return Subs(Add(*rv), *other).doit()
+
 
 def diff(f, *symbols, **kwargs):
     """

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -980,6 +980,7 @@ class Integral(AddWithLimits):
                 break
         terms, order = expr.function.nseries(
             x=symb, n=n, logx=logx).as_coeff_add(Order)
+        order = [o.subs(symb, x) for o in order]
         return integrate(terms, *expr.limits) + Add(*order)*x
 
     def _eval_as_leading_term(self, x):

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -122,7 +122,7 @@ from sympy.core import Basic, S, oo, Symbol, I, Dummy, Wild, Mul
 from sympy.functions import log, exp
 from sympy.series.order import Order
 from sympy.simplify.powsimp import powsimp
-from sympy import cacheit
+from sympy import cacheit, Subs
 
 from sympy.core.compatibility import reduce
 
@@ -301,6 +301,8 @@ def mrv(e, x):
         raise NotImplementedError("MRV set computation for derviatives"
                                   " not implemented yet.")
         return mrv(e.args[0], x)
+    elif isinstance(e, Subs):
+        return mrv(e.doit(), x)
     raise NotImplementedError(
         "Don't know how to calculate the mrv of '%s'" % e)
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -632,7 +632,7 @@ def gruntz(e, z, z0, dir="+"):
     file. It relies heavily on the series expansion. Most frequently, gruntz()
     is only used if the faster limit() function (which uses heuristics) fails.
     """
-    if not isinstance(z, Symbol):
+    if not z.is_Symbol:
         raise NotImplementedError("Second argument must be a Symbol")
 
     #convert all limits to the limit z->oo; sign of z is handled in limitinf

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -122,7 +122,7 @@ from sympy.core import Basic, S, oo, Symbol, I, Dummy, Wild, Mul
 from sympy.functions import log, exp
 from sympy.series.order import Order
 from sympy.simplify.powsimp import powsimp
-from sympy import cacheit, Subs
+from sympy import cacheit
 
 from sympy.core.compatibility import reduce
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -301,8 +301,6 @@ def mrv(e, x):
         raise NotImplementedError("MRV set computation for derviatives"
                                   " not implemented yet.")
         return mrv(e.args[0], x)
-    elif isinstance(e, Subs):
-        return mrv(e.doit(), x)
     raise NotImplementedError(
         "Don't know how to calculate the mrv of '%s'" % e)
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -148,7 +148,7 @@ class Order(Expr):
                 variables = list(map(sympify, args))
                 point = [S.Zero]*len(variables)
 
-        if not all(isinstance(v, Symbol) for v in variables):
+        if not all(v.is_Symbol for v in variables):
             raise TypeError('Variables are not symbols, got %s' % variables)
 
         if len(list(uniq(variables))) != len(variables):

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -100,10 +100,17 @@ def test_issue_11313():
     assert Integral(log(x), x).series(x) == Integral(log(x), x).doit().series(x)
 
 
-def test_series_Indexed():
-    A = IndexedBase("A")
-    i = symbols("i")
-    assert (sin(A[i])).series(A[i]) == A[i] - A[i]**3/6 + O(A[i]**5)
+def test_series_of_Subs():
+    from sympy.abs import x, y, z
+
+    subs1 = Subs(sin(x), (x,), (y,))
+    subs2 = Subs(sin(x) * cos(z), (x,), (y,))
+    subs3 = Subs(sin(x * z), (x, z), (y, x))
+
+    assert subs1.series(x) == subs1
+    assert subs1.series(y) == Subs(x - x**3/6 + x**5/120 + O(x**6), (x,), (y,))
+    assert subs2.series(z) == Subs(z**4*sin(x)/24 - z**2*sin(x)/2 + sin(x), (x,), (y,))
+    print subs1.series(y)
 
 
 def test_issue_3978():

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -101,16 +101,18 @@ def test_issue_11313():
 
 
 def test_series_of_Subs():
-    from sympy.abs import x, y, z
+    from sympy.abc import x, y, z
 
     subs1 = Subs(sin(x), (x,), (y,))
     subs2 = Subs(sin(x) * cos(z), (x,), (y,))
     subs3 = Subs(sin(x * z), (x, z), (y, x))
 
     assert subs1.series(x) == subs1
-    assert subs1.series(y) == Subs(x - x**3/6 + x**5/120 + O(x**6), (x,), (y,))
-    assert subs2.series(z) == Subs(z**4*sin(x)/24 - z**2*sin(x)/2 + sin(x), (x,), (y,))
-    print subs1.series(y)
+    assert subs1.series(y) == Subs(x, (x,), (y,)) + Subs(-x**3/6, (x,), (y,)) + Subs(x**5/120, (x,), (y,)) + O(y**6)
+    assert subs1.series(z) == subs1
+    assert subs2.series(z) == Subs(z**4*sin(x)/24, (x,), (y,)) + Subs(-z**2*sin(x)/2, (x,), (y,)) + Subs(sin(x), (x,), (y,)) + O(z**6)
+    assert subs3.series(x).doit() == subs3.doit().series(x)
+    assert subs3.series(z).doit() == sin(x*y)
 
 
 def test_issue_3978():

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -4,7 +4,7 @@ from sympy.tensor.indexed import IndexException
 from sympy.utilities.pytest import raises
 
 # import test:
-from sympy import IndexedBase, Idx, Indexed, S, sin, cos, Sum, Piecewise, And
+from sympy import IndexedBase, Idx, Indexed, S, sin, cos, Sum, Piecewise, And, Order
 
 
 def test_Idx_construction():
@@ -255,3 +255,9 @@ def test_differentiation():
     assert Sum(a*h[m], (m, -oo, oo)).diff(h[n]).doit() == a
     assert Sum(a*h[m], (n, -oo, oo)).diff(h[n]) == Sum(a*KroneckerDelta(m, n), (n, -oo, oo))
     assert Sum(a*h[m], (m, -oo, oo)).diff(h[m]) == oo*a
+
+
+def test_indexed_series():
+    A = IndexedBase("A")
+    i = symbols("i", integer=True)
+    assert sin(A[i]).series(A[i]) == A[i] - A[i]**3/6 + A[i]**5/120 + Order(A[i]**6, A[i])


### PR DESCRIPTION
This PR request allows the expansion of series for:
- Substitution objects _Subs_
- Indexed objects _Indexed_

One problem: Kronecker deltas are not created for indexed having same base but different indices as the `.has(x)` method does not consider `A[i]` to have `A[j]`.

That is:

``` python
In [6]: sin(A[i]).series(A[i])
Out[6]: 
           3       5           
       A[i]    A[i]     ⎛    6⎞
A[i] - ───── + ───── + O⎝A[i] ⎠
         6      120            

In [7]: sin(A[i]).series(A[j])
Out[7]: sin(A[i])
```
