### PR TITLE
init_session: improved detection of current IPython session

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -416,16 +416,11 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 raise RuntimeError("IPython is not available on this system")
             ip = None
         else:
-            version = V(IPython.__version__)
-            if '1.0' > version >= '0.11':
-                ip = IPython.core.ipapi.get()
-            elif version >= '1.0':
+            try:
                 from IPython import get_ipython
                 ip = get_ipython()
-            else:
-                ip = IPython.ipapi.get()
-                if ip:
-                    ip = ip.IP
+            except ImportError:
+                ip = None
         in_ipython = bool(ip)
         if ipython is None:
             ipython = in_ipython

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -416,11 +416,12 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 raise RuntimeError("IPython is not available on this system")
             ip = None
         else:
-            if V(IPython.__version__) >= '0.11':
-                tis = IPython.terminal.interactiveshell.TerminalInteractiveShell
-                ip = None
-                if tis.initialized():
-                    ip = tis.instance()
+            version = V(IPython.__version__)
+            if '1.0' > version >= '0.11':
+                ip = IPython.core.ipapi.get()
+            elif version >= '1.0':
+                from IPython import get_ipython
+                ip = get_ipython()
             else:
                 ip = IPython.ipapi.get()
                 if ip:

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -417,10 +417,10 @@ def init_session(ipython=None, pretty_print=True, order=None,
             ip = None
         else:
             if V(IPython.__version__) >= '0.11':
-                try:
-                    ip = get_ipython()
-                except NameError:
-                    ip = None
+                tis = IPython.terminal.interactiveshell.TerminalInteractiveShell
+                ip = None
+                if tis.initialized():
+                    ip = tis.instance()
             else:
                 ip = IPython.ipapi.get()
                 if ip:


### PR DESCRIPTION
Previously, to detect if there was a running IPython session, init_session relied on a function called get_ipython, injected into the global namespace by IPython. However, this function is not in scope during initialization, particularly, it is not in scope during the execution of startup scripts. This had the unfortunate consequence of creating  new mainloop on top of the previous one when init_session was called in a startup script. This commit changes the detection to use IPython.terminal.interactiveshell.TerminalInteractiveShell.initialized, a public-API method that works in this edge case as expected. Hence, it
becomes possible to use init_session in startup scripts.
