### PR TITLE
Added system.py to physics/mechanics

### DIFF
--- a/doc/src/modules/physics/mechanics/api/system.rst
+++ b/doc/src/modules/physics/mechanics/api/system.rst
@@ -1,0 +1,9 @@
+===========================
+SymbolicSystem (Docstrings)
+===========================
+
+SymbolicSystem
+==============
+
+.. automodule:: sympy.physics.mechanics.system
+   :members:

--- a/doc/src/modules/physics/mechanics/api/system.rst
+++ b/doc/src/modules/physics/mechanics/api/system.rst
@@ -5,7 +5,7 @@ SymbolicSystem (Docstrings)
 SymbolicSystem
 ==============
 
-.. automodule:: sympy.physics.mechanics.system
+.. autoclass:: sympy.physics.mechanics.system.SymbolicSystem
    :members:
 
    .. automethod:: __init__

--- a/doc/src/modules/physics/mechanics/api/system.rst
+++ b/doc/src/modules/physics/mechanics/api/system.rst
@@ -5,7 +5,5 @@ SymbolicSystem (Docstrings)
 SymbolicSystem
 ==============
 
-.. autoclass:: sympy.physics.mechanics.system.SymbolicSystem
+.. automodule:: sympy.physics.mechanics.system
    :members:
-
-   .. automethod:: __init__

--- a/doc/src/modules/physics/mechanics/api/system.rst
+++ b/doc/src/modules/physics/mechanics/api/system.rst
@@ -7,3 +7,5 @@ SymbolicSystem
 
 .. automodule:: sympy.physics.mechanics.system
    :members:
+
+   .. automethod:: __init__

--- a/doc/src/modules/physics/mechanics/index.rst
+++ b/doc/src/modules/physics/mechanics/index.rst
@@ -76,6 +76,7 @@ Guide to Mechanics
     masses.rst
     kane.rst
     lagrange.rst
+    symsystem.rst
     linearize.rst
     examples.rst
     advanced.rst
@@ -89,6 +90,7 @@ Mechanics API
 
     api/part_bod.rst
     api/kane_lagrange.rst
+    api/system.rst
     api/linearize.rst
     api/expr_manip.rst
     api/printing.rst

--- a/doc/src/modules/physics/mechanics/symsystem.rst
+++ b/doc/src/modules/physics/mechanics/symsystem.rst
@@ -33,28 +33,28 @@ The first step will be to initialize all of the dynamic and constant symbols. ::
 Next step is to define the equations of motion in multiple forms:
 
     [1] Explicit form where the kinematics and dynamics are combined
-        x' = F(x, t, r, p)
+        x' = F_1(x, t, r, p)
 
     [2] Implicit form where the kinematics and dynamics are combined
-        M(x, p) x' = F(x, t, r, p)
+        M(x, p) x' = F_2(x, t, r, p)
 
     [3] Implicit form where the kinematics and dynamics are separate
-        M(q, p) u' = F(q, u, t, r, p)
+        M(q, p) u' = F_3(q, u, t, r, p)
         q' = G(q, u, t, r, p)
 
 where
 
-    x : states, i.e. [q, u]
-    t : time
-    r : specified (exogenous) inputs
-    p : constants
-    q : generalized coordinates
-    u : generalized speeds
-    M : mass matrix or generalized inertia matrix (implicit dynamical
-        equations or combined dynamics and kinematics)
-    F : right hand side (implicit dynamical equations or combined dynamics
-        and kinematics)
-    G : right hand side of the kinematical differential equations ::
+x : states, i.e. [q, u]
+t : time
+r : specified (exogenous) inputs
+p : constants
+q : generalized coordinates
+u : generalized speeds
+M : mass matrix or generalized inertia matrix (implicit dynamical equations or
+combined dynamics and kinematics)
+F : right hand side (implicit dynamical equations or combined dynamics and
+kinematics)
+G : right hand side of the kinematical differential equations ::
 
     >>> dyn_implicit_mat = Matrix([[1, 0, -x/m],
     ...                            [0, 1, -y/m],

--- a/doc/src/modules/physics/mechanics/symsystem.rst
+++ b/doc/src/modules/physics/mechanics/symsystem.rst
@@ -1,0 +1,184 @@
+=====================================
+Symbolic Systems in Physics/Mechanics
+=====================================
+
+The `SymbolicSystem` class in physics/mechanics is a location for the pertinent
+of a dynamic system. In its most basic form it contains the equations of motion
+for the dynamic system, however, it can also contain information regarding the
+loads that the system is feeling, the bodies that the system is comprised of
+and any additional equations the user feels is important for the system. The
+goal of this class is to provide a unified output format for the equations of
+motion that simulation code can be designed around.
+
+SymbolicSystem Example Usage
+============================
+
+This code will go over the manual input of the equations of motion for the
+simple pendulum into `SymbolicSystem` using x and y coordinates instead of
+theta.
+
+The equations of motion are formed at
+http://nbviewer.jupyter.org/github/bmcage/odes/blob/master/docs/ipython/Planar%20Pendulum%20as%20DAE.ipynb ::
+
+    >>> from sympy import atan, symbols, Matrix
+    >>> from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame,
+    ...                                      Particle, Point)
+    >>> import sympy.physics.mechanics.system as system
+
+The first step will be to initialize all of the dynamic and constant symbols. ::
+
+    >>> x, y, u, v, lam = dynamicsymbols('x y u v lambda')
+    >>> m, l, g = symbols('m l g')
+
+Next step is to define the equations of motion in multiple forms:
+
+    [1] Explicit form where the kinematics and dynamics are combined
+        x' = F(x, t, r, p)
+
+    [2] Implicit form where the kinematics and dynamics are combined
+        M(x, p) x' = F(x, t, r, p)
+
+    [3] Implicit form where the kinematics and dynamics are separate
+        M(q, p) u' = F(q, u, t, r, p)
+        q' = G(q, u, t, r, p)
+
+where
+
+    x : states, i.e. [q, u]
+    t : time
+    r : specified (exogenous) inputs
+    p : constants
+    q : generalized coordinates
+    u : generalized speeds
+    M : mass matrix or generalized inertia matrix (implicit dynamical
+        equations or combined dynamics and kinematics)
+    F : right hand side (implicit dynamical equations or combined dynamics
+        and kinematics)
+    G : right hand side of the kinematical differential equations ::
+
+    >>> dyn_implicit_mat = Matrix([[1, 0, -x/m],
+    ...                            [0, 1, -y/m],
+    ...                            [0, 0, l**2/m]])
+    >>> dyn_implicit_rhs = Matrix([0, 0, u**2 + v**2 - g*y])
+    >>> comb_implicit_mat = Matrix([[1, 0, 0, 0, 0],
+    ...                             [0, 1, 0, 0, 0],
+    ...                             [0, 0, 1, 0, -x/m],
+    ...                             [0, 0, 0, 1, -y/m],
+    ...                             [0, 0, 0, 0, l**2/m]])
+    >>> comb_implicit_rhs = Matrix([u, v, 0, 0, u**2 + v**2 - g*y])
+    >>> kin_explicit_rhs = Matrix([u, v])
+    >>> comb_explicit_rhs = comb_implicit_mat.LUsolve(comb_implicit_rhs)
+
+Now the reference frames, points and particles will be set up so this
+information can be passed into `system.SymbolicSystem` in the form of a bodies
+and loads iterable. ::
+
+    >>> theta = atan(x/y)
+    >>> N = ReferenceFrame('N')
+    >>> A = N.orientnew('A', 'Axis', [theta, N.z])
+    >>> O = Point('O')
+    >>> P = O.locatenew('P', l * A.x)
+    >>> Pa = Particle('Pa', P, m)
+
+Now the bodies and loads iterables need to be initialized. ::
+
+    >>> bodies = [Pa]
+    >>> loads = [(P, g * m * N.x)]
+
+The equations of motion are in the form of a differential algebraic equation
+(DAE) and DAE solvers need to know which of the equations are the algebraic
+expressions. This information is passed into `SymbolicSystem` as a list
+specifying which rows are the algebraic equations. In this example it is a
+different row based on the chosen equations of motion format. The row index
+should always correspond to the mass matrix that is being input to the
+`SymbolicSystem` class but will always correspond to the row index of the
+combined dynamics and kinematics when being accessed from the `SymbolicSystem`
+class. ::
+
+    >>> alg_con = [2]
+    >>> alg_con_full = [4]
+
+An iterable containing the states now needs to be created for the solvers. ::
+
+    >>> states = (x, y, u, v, lam)
+
+Now the equations of motion instances can be created using the above mentioned
+equations of motion formats. ::
+
+    >>> symsystem1 = system.SymbolicSystem(states, comb_explicit_rhs, 
+    ...                                    alg_con=alg_con_full, bodies=bodies, 
+    ...                                    loads=loads)
+    >>> symsystem2 = system.SymbolicSystem(states, comb_implicit_rhs, 
+    ...                                    mass_matrix=comb_implicit_mat,
+    ...                                    alg_con=alg_con_full,
+    ...                                    coord_idxs=(0, 1))
+    >>> symsystem3 = system.SymbolicSystem(states, dyn_implicit_rhs, 
+    ...                                    mass_matrix=dyn_implicit_mat,
+    ...                                    coordinate_derivatives=kin_explicit_rhs,
+    ...                                    alg_con=alg_con, coord_idxs=(0, 1), 
+    ...                                    speed_idxs=(2, 3))
+
+The `SymbolicSystem` class can determine which of the states are considered
+coordinates or speeds by passing in the indexes of the coordinates and speeds.
+If these indexes are not passed in the object will not be able to differentiate
+between coordinates and speeds. Like coordinates and speeds, the bodies and
+loads attributes can only be accessed if they are specified during
+initialization of the `SymbolicSystem` class. Lastly here are some attributes
+accessible from the `SymbolicSystem` class. ::
+
+    >>> symsystem1.states
+    Matrix([
+    [     x(t)],
+    [     y(t)],
+    [     u(t)],
+    [     v(t)],
+    [lambda(t)]])
+    >>> symsystem2.coordinates
+    Matrix([
+    [x(t)],
+    [y(t)]])
+    >>> symsystem3.speeds
+    Matrix([
+    [u(t)],
+    [v(t)]])
+    >>> symsystem1.comb_explicit_rhs
+    Matrix([
+    [                                   u(t)],
+    [                                   v(t)],
+    [(-g*y(t) + u(t)**2 + v(t)**2)*x(t)/l**2],
+    [(-g*y(t) + u(t)**2 + v(t)**2)*y(t)/l**2],
+    [   m*(-g*y(t) + u(t)**2 + v(t)**2)/l**2]])
+    >>> symsystem2.comb_implicit_rhs
+    Matrix([
+    [                       u(t)],
+    [                       v(t)],
+    [                          0],
+    [                          0],
+    [-g*y(t) + u(t)**2 + v(t)**2]])
+    >>> symsystem2.comb_implicit_mat
+    Matrix([
+    [1, 0, 0, 0,       0],
+    [0, 1, 0, 0,       0],
+    [0, 0, 1, 0, -x(t)/m],
+    [0, 0, 0, 1, -y(t)/m],
+    [0, 0, 0, 0,  l**2/m]])
+    >>> symsystem3.dyn_implicit_rhs
+    Matrix([
+    [                          0],
+    [                          0],
+    [-g*y(t) + u(t)**2 + v(t)**2]])
+    >>> symsystem3.dyn_implicit_mat
+    Matrix([
+    [1, 0, -x(t)/m],
+    [0, 1, -y(t)/m],
+    [0, 0,  l**2/m]])
+    >>> symsystem3.kin_explicit_rhs
+    Matrix([
+    [u(t)],
+    [v(t)]])
+    >>> symsystem1.alg_con
+    [4]
+    >>> symsystem1.dynamic_symbols
+    set([lambda(t), u(t), v(t), x(t), y(t)])
+    >>> symsystem1.constant_symbols
+    set([g, l, m])

--- a/doc/src/modules/physics/mechanics/symsystem.rst
+++ b/doc/src/modules/physics/mechanics/symsystem.rst
@@ -3,22 +3,28 @@ Symbolic Systems in Physics/Mechanics
 =====================================
 
 The `SymbolicSystem` class in physics/mechanics is a location for the pertinent
-of a dynamic system. In its most basic form it contains the equations of motion
-for the dynamic system, however, it can also contain information regarding the
-loads that the system is feeling, the bodies that the system is comprised of
-and any additional equations the user feels is important for the system. The
-goal of this class is to provide a unified output format for the equations of
-motion that simulation code can be designed around.
+information of a multibody dynamic system. In its most basic form it contains
+the equations of motion for the dynamic system, however, it can also contain
+information regarding the loads that the system is subject to, the bodies that
+the system is comprised of and any additional equations the user feels is
+important for the system. The goal of this class is to provide a unified output
+format for the equations of motion that numerical analysis code can be designed
+around.
 
 SymbolicSystem Example Usage
 ============================
 
 This code will go over the manual input of the equations of motion for the
-simple pendulum into `SymbolicSystem` using x and y coordinates instead of
-theta.
+simple pendulum that uses the Cartesian location of the mass as the generalized
+coordinates into `SymbolicSystem`.
 
-The equations of motion are formed at
-http://nbviewer.jupyter.org/github/bmcage/odes/blob/master/docs/ipython/Planar%20Pendulum%20as%20DAE.ipynb ::
+The equations of motion are formed in the physics/mechanics/examples_. In that
+spot the variables q1 and q2 are used in place of x and y and the reference
+frame is rotated 90 degrees.
+
+.. _examples: ../examples/lin_pend_nonmin_example.html
+
+::
 
     >>> from sympy import atan, symbols, Matrix
     >>> from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame,
@@ -36,15 +42,15 @@ Next step is to define the equations of motion in multiple forms:
         x' = F_1(x, t, r, p)
 
     [2] Implicit form where the kinematics and dynamics are combined
-        M(x, p) x' = F_2(x, t, r, p)
+        M_2(x, p) x' = F_2(x, t, r, p)
 
     [3] Implicit form where the kinematics and dynamics are separate
-        M(q, p) u' = F_3(q, u, t, r, p)
+        M_3(q, p) u' = F_3(q, u, t, r, p)
         q' = G(q, u, t, r, p)
 
 where
 
-x : states, i.e. [q, u]
+x : states, e.g. [q, u]
 t : time
 r : specified (exogenous) inputs
 p : constants
@@ -54,7 +60,9 @@ M : mass matrix or generalized inertia matrix (implicit dynamical equations or
 combined dynamics and kinematics)
 F : right hand side (implicit dynamical equations or combined dynamics and
 kinematics)
-G : right hand side of the kinematical differential equations ::
+G : right hand side of the kinematical differential equations 
+
+::
 
     >>> dyn_implicit_mat = Matrix([[1, 0, -x/m],
     ...                            [0, 1, -y/m],
@@ -98,9 +106,15 @@ class. ::
     >>> alg_con = [2]
     >>> alg_con_full = [4]
 
-An iterable containing the states now needs to be created for the solvers. ::
+An iterable containing the states now needs to be created for the system. The
+`SymbolicSystem` class can determine which of the states are considered
+coordinates or speeds by passing in the indexes of the coordinates and speeds.
+If these indexes are not passed in the object will not be able to differentiate
+between coordinates and speeds. ::
 
     >>> states = (x, y, u, v, lam)
+    >>> coord_idxs = (0, 1)
+    >>> speed_idxs = (2, 3)
 
 Now the equations of motion instances can be created using the above mentioned
 equations of motion formats. ::
@@ -111,20 +125,18 @@ equations of motion formats. ::
     >>> symsystem2 = system.SymbolicSystem(states, comb_implicit_rhs, 
     ...                                    mass_matrix=comb_implicit_mat,
     ...                                    alg_con=alg_con_full,
-    ...                                    coord_idxs=(0, 1))
+    ...                                    coord_idxs=coord_idxs)
     >>> symsystem3 = system.SymbolicSystem(states, dyn_implicit_rhs, 
     ...                                    mass_matrix=dyn_implicit_mat,
     ...                                    coordinate_derivatives=kin_explicit_rhs,
-    ...                                    alg_con=alg_con, coord_idxs=(0, 1), 
-    ...                                    speed_idxs=(2, 3))
+    ...                                    alg_con=alg_con, 
+    ...                                    coord_idxs=coord_idxs, 
+    ...                                    speed_idxs=speed_idxs)
 
-The `SymbolicSystem` class can determine which of the states are considered
-coordinates or speeds by passing in the indexes of the coordinates and speeds.
-If these indexes are not passed in the object will not be able to differentiate
-between coordinates and speeds. Like coordinates and speeds, the bodies and
-loads attributes can only be accessed if they are specified during
-initialization of the `SymbolicSystem` class. Lastly here are some attributes
-accessible from the `SymbolicSystem` class. ::
+ Like coordinates and speeds, the bodies and loads attributes can only be
+ accessed if they are specified during initialization of the `SymbolicSystem`
+ class. Lastly here are some attributes accessible from the `SymbolicSystem`
+ class. ::
 
     >>> symsystem1.states
     Matrix([

--- a/doc/src/modules/physics/mechanics/symsystem.rst
+++ b/doc/src/modules/physics/mechanics/symsystem.rst
@@ -50,17 +50,18 @@ Next step is to define the equations of motion in multiple forms:
 
 where
 
-x : states, e.g. [q, u]
-t : time
-r : specified (exogenous) inputs
-p : constants
-q : generalized coordinates
-u : generalized speeds
-M : mass matrix or generalized inertia matrix (implicit dynamical equations or
-combined dynamics and kinematics)
-F : right hand side (implicit dynamical equations or combined dynamics and
-kinematics)
-G : right hand side of the kinematical differential equations 
+    x : states, e.g. [q, u]
+    t : time
+    r : specified (exogenous) inputs
+    p : constants
+    q : generalized coordinates
+    u : generalized speeds
+    F_1 : right hand side of the combined equations in explicit form
+    F_2 : right hand side of the combined equations in implicit form
+    F_3 : right hand side of the dynamical equations in implicit form
+    M_2 : mass matrix of the combined equations in implicit form
+    M_3 : mass matrix of the dynamical equations in implicit form
+    G : right hand side of the kinematical differential equations
 
 ::
 
@@ -82,10 +83,15 @@ information can be passed into `system.SymbolicSystem` in the form of a bodies
 and loads iterable. ::
 
     >>> theta = atan(x/y)
+    >>> omega = dynamicsymbols('omega')
     >>> N = ReferenceFrame('N')
     >>> A = N.orientnew('A', 'Axis', [theta, N.z])
+    >>> A.set_ang_vel(N, omega * N.z)
     >>> O = Point('O')
+    >>> O.set_vel(N, 0)
     >>> P = O.locatenew('P', l * A.x)
+    >>> P.v2pt_theory(O, N, A)
+    l*omega*A.y
     >>> Pa = Particle('Pa', P, m)
 
 Now the bodies and loads iterables need to be initialized. ::
@@ -190,7 +196,7 @@ equations of motion formats. ::
     [v(t)]])
     >>> symsystem1.alg_con
     [4]
-    >>> symsystem1.dynamic_symbols
-    set([lambda(t), u(t), v(t), x(t), y(t)])
-    >>> symsystem1.constant_symbols
-    set([g, l, m])
+    >>> symsystem1.bodies
+    (Pa,)
+    >>> symsystem1.loads
+    ((P, g*m*N.x),)

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -42,3 +42,7 @@ __all__.extend(linearize.__all__)
 from . import body
 from .body import *
 __all__.extend(body.__all__)
+
+from . import system
+from .system import *
+__all__.extend(system.__all__)

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -26,17 +26,17 @@ class SymbolicSystem(object):
 
     where
 
-        x : states, i.e. [q, u]
-        t : time
-        r : specified (exogenous) inputs
-        p : constants
-        q : generalized coordinates
-        u : generalized speeds
-        M : mass matrix or generalized inertia matrix (implicit dynamical
-            equations or combined dynamics and kinematics)
-        F : right hand side (implicit dynamical equations or combined dynamics
-            and kinematics)
-        G : right hand side of the kinematical differential equations
+    x : states, i.e. [q, u]
+    t : time
+    r : specified (exogenous) inputs
+    p : constants
+    q : generalized coordinates
+    u : generalized speeds
+    M : mass matrix or generalized inertia matrix (implicit dynamical equations
+    or combined dynamics and kinematics)
+    F : right hand side (implicit dynamical equations or combined dynamics and
+    kinematics)
+    G : right hand side of the kinematical differential equations
 
 
 

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -1,0 +1,248 @@
+class SymbolicSystem(object):
+    """SymbolicSystem is a class that contains all the information about a
+    system in a symbolic format such as the equations of motions and the bodies
+    and loads in the system.
+
+    There are three ways that the equations of motion can be described for
+    Symbolic System:
+
+
+        [1] Explicit form where the kinematics and dynamics are combined
+            x' = F(x, t, r, p)
+
+        [2] Implicit form where the kinematics and dynamics are combined
+            M(x, p) x' = F(x, t, r, p)
+
+        [3] Implicit form where the kinematics and dynamics are separate
+            M(q, p) u' = F(q, u, t, r, p)
+            q' = G(q, u, t, r, p)
+
+    where
+
+        x : states, i.e. [q, u]
+        t : time
+        r : specified (exogenous) inputs
+        p : constants
+        q : generalized coordinates
+        u : generalized speeds
+        M : mass matrix or generalized inertia matrix (implicit dynamical
+            equations or combined dynamics and kinematics)
+        F : right hand side (implicit dynamical equations or combined dynamics
+            and kinematics)
+        G : right hand side of the kinematical differential equations
+
+
+
+    Attributes
+    ==========
+
+    TODO - come up with the size of the matrices and add a notes section
+    detailing any variables I used
+
+    coordinates : Matrix
+        This is a matrix containing the generalized coordinates of the system
+
+    speeds : Matrix
+        This is a matrix containing the generalized speeds of the system
+
+    states : Matrix
+        This is a matrix containing the state variables of the system
+
+    alg_con : List
+        This list contains the indices of the algebraic constraints in the
+        combined equations of motion. The presence of these constraints requires
+        that a DAE solver be used instead of an ODE solver
+
+    dyn_implicit_mat : Matrix
+        This is the M matrix in form [3] of the equations of motion (the mass
+        matrix or generalized inertia matrix of the dynamical equations of
+        motion in implicit form).
+
+    dyn_implicit_rhs : Matrix
+        This is the F vector in form [3] of the equations of motion (the right
+        hand side of the dynamical equations of motion in implicit form).
+
+    comb_implicit_mat : Matrix
+        This is the M matrix in form [2] of the equations of motion. This matrix
+        contains a block diagonal structure where the top left block (the first
+        rows) represent the matrix in the implicit form of the kinematical
+        equations and the bottom right block (the last rows) represent the
+        matrix in the implicit form of the dynamical equations.
+
+    comb_implicit_rhs : Matrix
+        This is the F vector in form [2] of the equations of motion. The top
+        part of the vector represents the right hand side of the implicit form
+        of the kinemaical equations and the bottom of the vector represents the
+        right hand side of the implicit form of the dynamical equations of
+        motion.
+
+    comb_explicit_rhs : Matrix
+        This vector represents the right hand side of the combined equations of
+        motion in explicit form (form [1] from above).
+
+    kin_explicit_rhs : Matrix
+        This is the right hand side of the explicit form of the kinematical
+        equations of motion as can be seen in form [3] (the G matrix).
+
+    dynamic_symbols : Matrix
+        This matrix contains all of the symbols that have a time dependence in
+        the equations of motion of the system
+
+    constant_symbols : Matrix
+        This matrix contains all of the symbols that do not have a time
+        dependence in the equations of motion of the system
+
+    output_eqns : Dictionary
+        If output equations were given they are stored in a dictionary where the
+        key corresponds to the name given for the specific equation and the
+        value is the equation itself in symbolic form
+
+    bodies : List
+        If the bodies in the system were given they are stored in a list for
+        future access
+
+    loads : List
+        If the loads in the system were given they are stored in a list for
+        future access. This includes forces and torques where forces are given
+        by (point of application, force vector) and torques are given by
+        (reference frame acted upon, torque vector).
+
+    Parameters
+    ==========
+
+    coord_states : ordered iterable of functions of time
+        This input will either be a collection of the coordinates or states of
+        the system depending on whether or not the speeds are also given. If
+        speeds are specified this input will be assumed to be the coordinates
+        otherwise this input will be assumed to be the states.
+
+    right_hand_side : Matrix
+        This variable is the right hand side of the equations of motion in any
+        of the forms. The specific form will be assumed depending on whether a
+        mass matrix or coordinate derivatives are given.
+
+    speeds : ordered iterable of functions of time, optional
+        This is a collection of the generalized speeds of the system. If given
+        it will be assumed that the first argument (coord_states) will represent
+        the generalized coordinates of the system.
+
+    mass_matrix : Matrix, optional
+        The matrix of the implicit forms of the equations of motion (forms [2]
+        and [3]). The distinction between the forms is determined by whether or
+        not the coordinate derivatives are passed in. If they are given form [3]
+        will be assumed otherwise form [2] is assumed.
+
+    coordinate_derivatives : Matrix, optional
+        The right hand side of the kinematical equations in explicit form. If
+        given it will be assumed that the equations of motion are being entered
+        in form [3].
+
+    alg_con : Iterable, optional
+        The indexes of the rows in the equations of motion that contain
+        algebraic constraints instead of differential equations. If the
+        equations are input in form [3], it will be assumed the indexes are
+        referencing the mass_matrix/right_hand_side combination and not the
+        coordinate_derivatives.
+
+    output_eqns : Dictionary, optional
+        Any output equations that are desired to be tracked are stored in a
+        dictionary where the key corresponds to the name given for the specific
+        equation and the value is the equation itself in symbolic form
+
+    coord_idxs : Iterable, optional
+        If coord_states corresponds to the states rather than the coordinates
+        this variable will tell SymbolicSystem which indexes of the states
+        correspond to generalized coordinates.
+
+    speed_idxs : Iterable, optional
+        If coord_states corresponds to the states rather than the coordinates
+        this variable will tell SymbolicSystem which indexes of the states
+        correspond to generalized speeds.
+
+    bodies : List, optional
+        List containing the bodies of the system
+
+    loads : List, optional
+        List containing the loads of the system where forces are given by (point
+        of application, force vector) and torques are given by (reference frame
+        acting upon, torque vector). Ex [(point, force), (ref_frame, torque)]
+
+    """
+
+    def __init__(self):
+        """init method"""
+
+    @property
+    def coordinates(self):
+        """Returns the column matrix of the generalized coordinates"""
+
+    @property
+    def speeds(self):
+        """Returns the column matrix of generalized speeds"""
+
+    @property
+    def states(self):
+        """Returns the column matrix of the state variables"""
+
+    @property
+    def alg_con(self):
+        """Returns a list with the indices of the rows containing algebraic
+        constraints in the combined form of the equations of motion"""
+
+    @property
+    def dyn_implicit_mat(self):
+        """Returns the matrix, M, corresponding to the dynamic equations in
+        implicit form, M x' = F, where the kinematical equations are not
+        included"""
+
+    @property
+    def dyn_implicit_rhs(self):
+        """Returns the column matrix, F, corresponding to the dynamic equations
+        in implicit form, M x' = F, where the kinematical equations are not
+        included"""
+
+    @property
+    def comb_implicit_mat(self):
+        """Returns the matrix, M, corresponding to the equations of motion in
+        implicit form (form [2]), M x' = F, where the kinematical equations are
+        included"""
+
+    @property
+    def comb_implicit_rhs(self):
+        """Returns the column matrix, F, corresponding to the equations of
+        motion in implicit form (form [2]), M x' = F, where the kinematical
+        equations are included"""
+
+    @property
+    def comb_explicit_rhs(self):
+        """Returns the right hand side of the equations of motion in explicit
+        form, x' = F, where the kinematical equations are included"""
+
+    @property
+    def kin_explicit_rhs(self):
+        """Returns the right hand side of the kinematical equations in explicit
+        form, q' = G"""
+
+    @property
+    def dynamic_symbols(self):
+        """Returns a column matrix containing all of the symbols in the system
+        that depend on time"""
+
+    @property
+    def constant_symbols(self):
+        """Returns a column matrix containing all of the symbols in the system
+        that do not depend on time"""
+
+    @property
+    def output_eqns(self):
+        """Returns a dictionary of the given output equations where the key's
+        are user defined names for each equation and the values are the symbolic
+        equations themselves"""
+
+    @property
+    def bodies(self):
+        """Returns the bodies in the system"""
+
+    @property
+    def loads(self):
+        """Returns the loads in the system"""

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -200,7 +200,7 @@ class SymbolicSystem(object):
         >>> kin_explicit_rhs = Matrix([omega])
         >>> dyn_implicit_mat = Matrix([l**2 * m])
         >>> dyn_implicit_rhs = Matrix([-g * l * m * sin(theta)])
-        >>> symsystem = SymbolicSystem(theta, dyn_implicit_rhs, omega,
+        >>> symsystem = SymbolicSystem([theta], dyn_implicit_rhs, [omega],
         ...                            dyn_implicit_mat)
 
     """

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -39,7 +39,67 @@ class SymbolicSystem(object):
     M_3 : mass matrix of the dynamical equations in implicit form
     G : right hand side of the kinematical differential equations
 
+        Parameters
+        ==========
 
+        coord_states : ordered iterable of functions of time
+            This input will either be a collection of the coordinates or states
+            of the system depending on whether or not the speeds are also given.
+            If speeds are specified this input will be assumed to be the
+            coordinates otherwise this input will be assumed to be the states.
+
+        right_hand_side : Matrix
+            This variable is the right hand side of the equations of motion in
+            any of the forms. The specific form will be assumed depending on
+            whether a mass matrix or coordinate derivatives are given.
+
+        speeds : ordered iterable of functions of time, optional
+            This is a collection of the generalized speeds of the system. If
+            given it will be assumed that the first argument (coord_states) will
+            represent the generalized coordinates of the system.
+
+        mass_matrix : Matrix, optional
+            The matrix of the implicit forms of the equations of motion (forms
+            [2] and [3]). The distinction between the forms is determined by
+            whether or not the coordinate derivatives are passed in. If they are
+            given form [3] will be assumed otherwise form [2] is assumed.
+
+        coordinate_derivatives : Matrix, optional
+            The right hand side of the kinematical equations in explicit form.
+            If given it will be assumed that the equations of motion are being
+            entered in form [3].
+
+        alg_con : Iterable, optional
+            The indexes of the rows in the equations of motion that contain
+            algebraic constraints instead of differential equations. If the
+            equations are input in form [3], it will be assumed the indexes are
+            referencing the mass_matrix/right_hand_side combination and not the
+            coordinate_derivatives.
+
+        output_eqns : Dictionary, optional
+            Any output equations that are desired to be tracked are stored in a
+            dictionary where the key corresponds to the name given for the
+            specific equation and the value is the equation itself in symbolic
+            form
+
+        coord_idxs : Iterable, optional
+            If coord_states corresponds to the states rather than the
+            coordinates this variable will tell SymbolicSystem which indexes of
+            the states correspond to generalized coordinates.
+
+        speed_idxs : Iterable, optional
+            If coord_states corresponds to the states rather than the
+            coordinates this variable will tell SymbolicSystem which indexes of
+            the states correspond to generalized speeds.
+
+        bodies : iterable of Body/Rigidbody objects, optional
+            Iterable containing the bodies of the system
+
+        loads : iterable of load instances (described below), optional
+            Iterable containing the loads of the system where forces are given
+            by (point of application, force vector) and torques are given by
+            (reference frame acting upon, torque vector). Ex [(point, force),
+            (ref_frame, torque)]
 
     Attributes
     ==========
@@ -146,72 +206,7 @@ class SymbolicSystem(object):
                  mass_matrix=None, coordinate_derivatives=None, alg_con=None,
                  output_eqns={}, coord_idxs=None, speed_idxs=None, bodies=None,
                  loads=None):
-        """Initializes a SymbolicSystem object
-
-
-        Parameters
-        ==========
-
-        coord_states : ordered iterable of functions of time
-            This input will either be a collection of the coordinates or states
-            of the system depending on whether or not the speeds are also given.
-            If speeds are specified this input will be assumed to be the
-            coordinates otherwise this input will be assumed to be the states.
-
-        right_hand_side : Matrix
-            This variable is the right hand side of the equations of motion in
-            any of the forms. The specific form will be assumed depending on
-            whether a mass matrix or coordinate derivatives are given.
-
-        speeds : ordered iterable of functions of time, optional
-            This is a collection of the generalized speeds of the system. If
-            given it will be assumed that the first argument (coord_states) will
-            represent the generalized coordinates of the system.
-
-        mass_matrix : Matrix, optional
-            The matrix of the implicit forms of the equations of motion (forms
-            [2] and [3]). The distinction between the forms is determined by
-            whether or not the coordinate derivatives are passed in. If they are
-            given form [3] will be assumed otherwise form [2] is assumed.
-
-        coordinate_derivatives : Matrix, optional
-            The right hand side of the kinematical equations in explicit form.
-            If given it will be assumed that the equations of motion are being
-            entered in form [3].
-
-        alg_con : Iterable, optional
-            The indexes of the rows in the equations of motion that contain
-            algebraic constraints instead of differential equations. If the
-            equations are input in form [3], it will be assumed the indexes are
-            referencing the mass_matrix/right_hand_side combination and not the
-            coordinate_derivatives.
-
-        output_eqns : Dictionary, optional
-            Any output equations that are desired to be tracked are stored in a
-            dictionary where the key corresponds to the name given for the
-            specific equation and the value is the equation itself in symbolic
-            form
-
-        coord_idxs : Iterable, optional
-            If coord_states corresponds to the states rather than the
-            coordinates this variable will tell SymbolicSystem which indexes of
-            the states correspond to generalized coordinates.
-
-        speed_idxs : Iterable, optional
-            If coord_states corresponds to the states rather than the
-            coordinates this variable will tell SymbolicSystem which indexes of
-            the states correspond to generalized speeds.
-
-        bodies : iterable of Body/Rigidbody objects, optional
-            Iterable containing the bodies of the system
-
-        loads : iterable of load instances (described below), optional
-            Iterable containing the loads of the system where forces are given
-            by (point of application, force vector) and torques are given by
-            (reference frame acting upon, torque vector). Ex [(point, force),
-            (ref_frame, torque)]
-
-        """
+        """Initializes a SymbolicSystem object"""
 
         # Extract information on speeds, coordinates and states
         if speeds is None:

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -1,3 +1,10 @@
+from sympy import eye, Matrix, zeros
+from sympy.physics.mechanics import dynamicsymbols
+from sympy.physics.mechanics.functions import find_dynamicsymbols
+
+__all__ = ['SymbolicSystem']
+
+
 class SymbolicSystem(object):
     """SymbolicSystem is a class that contains all the information about a
     system in a symbolic format such as the equations of motions and the bodies
@@ -51,7 +58,10 @@ class SymbolicSystem(object):
     alg_con : List
         This list contains the indices of the algebraic constraints in the
         combined equations of motion. The presence of these constraints requires
-        that a DAE solver be used instead of an ODE solver
+        that a DAE solver be used instead of an ODE solver. If the system is
+        given in form [3] the alg_con variable will be adjusted such that it is
+        a representation of the combined kinematics and dynamics thus make sure
+        it always matches the mass matrix entered.
 
     dyn_implicit_mat : Matrix
         This is the M matrix in form [3] of the equations of motion (the mass
@@ -169,80 +179,233 @@ class SymbolicSystem(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, coord_states, right_hand_side, speeds=None,
+                 mass_matrix=None, coordinate_derivatives=None, alg_con=None,
+                 output_eqns={}, coord_idxs=None, speed_idxs=None, bodies=None,
+                 loads=None):
         """init method"""
+
+        # Extract information on speeds, coordinates and states
+        if speeds is None:
+            self._states = Matrix(coord_states)
+
+            if coord_idxs is None:
+                self._coordinates = None
+            else:
+                coords = [coord_states[i] for i in coord_idxs]
+                self._coordinates = Matrix(coords)
+
+            if speed_idxs is None:
+                self._speeds = None
+            else:
+                speeds_inter = [coord_states[i] for i in speed_idxs]
+                self._speeds = Matrix(speeds_inter)
+        else:
+            self._coordinates = Matrix(coord_states)
+            self._speeds = Matrix(speeds)
+            self._states = self._coordinates.col_join(self._speeds)
+
+        # Extract equations of motion form
+        if coordinate_derivatives is not None:
+            self._kin_explicit_rhs = coordinate_derivatives
+            self._dyn_implicit_rhs = right_hand_side
+            self._dyn_implicit_mat = mass_matrix
+            self._comb_implicit_rhs = None
+            self._comb_implicit_mat = None
+            self._comb_explicit_rhs = None
+        elif mass_matrix is not None:
+            self._kin_explicit_rhs = None
+            self._dyn_implicit_rhs = None
+            self._dyn_implicit_mat = None
+            self._comb_implicit_rhs = right_hand_side
+            self._comb_implicit_mat = mass_matrix
+            self._comb_explicit_rhs = None
+        else:
+            self._kin_explicit_rhs = None
+            self._dyn_implicit_rhs = None
+            self._dyn_implicit_mat = None
+            self._comb_implicit_rhs = None
+            self._comb_implicit_mat = None
+            self._comb_explicit_rhs = right_hand_side
+
+        # Set the remainder of the inputs as instance attributes
+        if alg_con is not None and coordinate_derivatives is not None:
+            alg_con = [i + len(coordinate_derivatives) for i in alg_con]
+        self._alg_con = alg_con
+        self._output_eqns = output_eqns
+        self._bodies = bodies
+        self._loads = loads
 
     @property
     def coordinates(self):
         """Returns the column matrix of the generalized coordinates"""
+        if self._coordinates is None:
+            raise AttributeError("The coordinates were not specified")
+        else:
+            return self._coordinates
 
     @property
     def speeds(self):
         """Returns the column matrix of generalized speeds"""
+        if self._speeds is None:
+            raise AttributeError("The speeds were not specified")
+        else:
+            return self._speeds
 
     @property
     def states(self):
         """Returns the column matrix of the state variables"""
+        return self._states
 
     @property
     def alg_con(self):
         """Returns a list with the indices of the rows containing algebraic
         constraints in the combined form of the equations of motion"""
+        return self._alg_con
 
     @property
     def dyn_implicit_mat(self):
         """Returns the matrix, M, corresponding to the dynamic equations in
         implicit form, M x' = F, where the kinematical equations are not
         included"""
+        if self._dyn_implicit_mat is None:
+            raise AttributeError("dyn_implicit_mat is not specified for "
+                                 "equations of motion form [1] or [2]")
+        else:
+            return self._dyn_implicit_mat
 
     @property
     def dyn_implicit_rhs(self):
         """Returns the column matrix, F, corresponding to the dynamic equations
         in implicit form, M x' = F, where the kinematical equations are not
         included"""
+        if self._dyn_implicit_rhs is None:
+            raise AttributeError("dyn_implicit_rhs is not specified for "
+                                 "equations of motion form [1] or [2]")
+        else:
+            return self._dyn_implicit_rhs
 
     @property
     def comb_implicit_mat(self):
         """Returns the matrix, M, corresponding to the equations of motion in
         implicit form (form [2]), M x' = F, where the kinematical equations are
         included"""
+        if self._comb_implicit_mat is None:
+            if self._dyn_implicit_mat is not None:
+                num_kin_eqns = len(self._kin_explicit_rhs)
+                num_dyn_eqns = len(self._dyn_implicit_rhs)
+                zeros1 = zeros(num_kin_eqns, num_dyn_eqns)
+                zeros2 = zeros(num_dyn_eqns, num_kin_eqns)
+                inter1 = eye(num_kin_eqns).row_join(zeros1)
+                inter2 = zeros2.row_join(self._dyn_implicit_mat)
+                self._comb_implicit_mat = inter1.col_join(inter2)
+                return self._comb_implicit_mat
+            else:
+                raise AttributeError("comb_implicit_mat is not specified for "
+                                     "equations of motion form [1]")
+        else:
+            return self._comb_implicit_mat
 
     @property
     def comb_implicit_rhs(self):
         """Returns the column matrix, F, corresponding to the equations of
         motion in implicit form (form [2]), M x' = F, where the kinematical
         equations are included"""
+        if self._comb_implicit_rhs is None:
+            if self._dyn_implicit_rhs is not None:
+                kin_inter = self._kin_explicit_rhs
+                dyn_inter = self._dyn_implicit_rhs
+                self._comb_implicit_rhs = kin_inter.col_join(dyn_inter)
+                return self._comb_implicit_rhs
+            else:
+                raise AttributeError("comb_implicit_mat is not specified for "
+                                     "equations of motion in form [1]")
+        else:
+            return self._comb_implicit_rhs
+
+    def compute_explicit_form(self):
+        """If the explicit right hand side of the combined equations of motion
+        is to provided upon initialization, this method will calculate it. This
+        calculation can potentially take awhile to compute."""
+        inter = self._comb_implicit_mat.LUsolve(self._comb_implicit_rhs)
+        self._comb_explicit_rhs = inter
 
     @property
     def comb_explicit_rhs(self):
         """Returns the right hand side of the equations of motion in explicit
         form, x' = F, where the kinematical equations are included"""
+        if self._comb_explicit_rhs is None:
+            raise AttributeError("Please run .combute_explicit_form before "
+                                 "attempting to access comb_explicit_rhs")
+        else:
+            return self._comb_explicit_rhs
 
     @property
     def kin_explicit_rhs(self):
         """Returns the right hand side of the kinematical equations in explicit
         form, q' = G"""
+        if self._kin_explicit_rhs is None:
+            raise AttributeError("kin_explicit_rhs is not specified for "
+                                 "equations of motion form [1] or [2]")
+        else:
+            return self._kin_explicit_rhs
 
     @property
     def dynamic_symbols(self):
         """Returns a column matrix containing all of the symbols in the system
         that depend on time"""
+        # Create a list of all of the expressions in the equations of motion
+        if self._comb_explicit_rhs is None:
+            eom_expressions = (self.comb_implicit_mat[:] +
+                               self.comb_implicit_rhs[:])
+        else:
+            eom_expressions = (self._comb_explicit_rhs[:])
+
+        functions_of_time = set()
+        for expr in eom_expressions:
+            functions_of_time = functions_of_time.union(
+                find_dynamicsymbols(expr))
+        functions_of_time = functions_of_time.union(self._states)
+
+        return functions_of_time
 
     @property
     def constant_symbols(self):
         """Returns a column matrix containing all of the symbols in the system
         that do not depend on time"""
+        # Create a list of all of the expressions in the equations of motion
+        if self._comb_explicit_rhs is None:
+            eom_expressions = (self.comb_implicit_mat[:] +
+                               self.comb_implicit_rhs[:])
+        else:
+            eom_expressions = (self._comb_explicit_rhs[:])
+
+        constants = set()
+        for expr in eom_expressions:
+            constants = constants.union(expr.free_symbols)
+        constants.remove(dynamicsymbols._t)
+
+        return constants
 
     @property
     def output_eqns(self):
         """Returns a dictionary of the given output equations where the key's
         are user defined names for each equation and the values are the symbolic
         equations themselves"""
+        return self._output_eqns
 
     @property
     def bodies(self):
         """Returns the bodies in the system"""
+        if self._bodies is None:
+            raise AttributeError("bodies were not specified for the system")
+        else:
+            return self._bodies
 
     @property
     def loads(self):
         """Returns the loads in the system"""
+        if self._loads is None:
+            raise AttributeError("bodies were not specified for the system")
+        else:
+            return self._loads

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -15,13 +15,13 @@ class SymbolicSystem(object):
 
 
         [1] Explicit form where the kinematics and dynamics are combined
-            x' = F(x, t, r, p)
+            x' = F_1(x, t, r, p)
 
         [2] Implicit form where the kinematics and dynamics are combined
-            M(x, p) x' = F(x, t, r, p)
+            M(x, p) x' = F_2(x, t, r, p)
 
         [3] Implicit form where the kinematics and dynamics are separate
-            M(q, p) u' = F(q, u, t, r, p)
+            M(q, p) u' = F_3(q, u, t, r, p)
             q' = G(q, u, t, r, p)
 
     where

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -18,15 +18,15 @@ class SymbolicSystem(object):
             x' = F_1(x, t, r, p)
 
         [2] Implicit form where the kinematics and dynamics are combined
-            M(x, p) x' = F_2(x, t, r, p)
+            M_2(x, p) x' = F_2(x, t, r, p)
 
         [3] Implicit form where the kinematics and dynamics are separate
-            M(q, p) u' = F_3(q, u, t, r, p)
+            M_3(q, p) u' = F_3(q, u, t, r, p)
             q' = G(q, u, t, r, p)
 
     where
 
-    x : states, i.e. [q, u]
+    x : states, e.g. [q, u]
     t : time
     r : specified (exogenous) inputs
     p : constants
@@ -43,16 +43,13 @@ class SymbolicSystem(object):
     Attributes
     ==========
 
-    TODO - come up with the size of the matrices and add a notes section
-    detailing any variables I used
-
-    coordinates : Matrix
+    coordinates : Matrix, shape(n, 1)
         This is a matrix containing the generalized coordinates of the system
 
-    speeds : Matrix
+    speeds : Matrix, shape(m, 1)
         This is a matrix containing the generalized speeds of the system
 
-    states : Matrix
+    states : Matrix, shape(o, 1)
         This is a matrix containing the state variables of the system
 
     alg_con : List
@@ -63,34 +60,34 @@ class SymbolicSystem(object):
         a representation of the combined kinematics and dynamics thus make sure
         it always matches the mass matrix entered.
 
-    dyn_implicit_mat : Matrix
+    dyn_implicit_mat : Matrix, shape(m, m)
         This is the M matrix in form [3] of the equations of motion (the mass
         matrix or generalized inertia matrix of the dynamical equations of
         motion in implicit form).
 
-    dyn_implicit_rhs : Matrix
+    dyn_implicit_rhs : Matrix, shape(m, 1)
         This is the F vector in form [3] of the equations of motion (the right
         hand side of the dynamical equations of motion in implicit form).
 
-    comb_implicit_mat : Matrix
+    comb_implicit_mat : Matrix, shape(o, o)
         This is the M matrix in form [2] of the equations of motion. This matrix
         contains a block diagonal structure where the top left block (the first
         rows) represent the matrix in the implicit form of the kinematical
         equations and the bottom right block (the last rows) represent the
         matrix in the implicit form of the dynamical equations.
 
-    comb_implicit_rhs : Matrix
+    comb_implicit_rhs : Matrix, shape(o, 1)
         This is the F vector in form [2] of the equations of motion. The top
         part of the vector represents the right hand side of the implicit form
         of the kinemaical equations and the bottom of the vector represents the
         right hand side of the implicit form of the dynamical equations of
         motion.
 
-    comb_explicit_rhs : Matrix
+    comb_explicit_rhs : Matrix, shape(o, 1)
         This vector represents the right hand side of the combined equations of
         motion in explicit form (form [1] from above).
 
-    kin_explicit_rhs : Matrix
+    kin_explicit_rhs : Matrix, shape(m, 1)
         This is the right hand side of the explicit form of the kinematical
         equations of motion as can be seen in form [3] (the G matrix).
 
@@ -203,6 +200,13 @@ class SymbolicSystem(object):
         >>> symsystem = SymbolicSystem([theta], dyn_implicit_rhs, [omega],
         ...                            dyn_implicit_mat)
 
+    Notes
+    =====
+
+    m : number of generalized speeds
+    n : number of generalized coordinates
+    o : number of states
+
     """
 
     def __init__(self, coord_states, right_hand_side, speeds=None,
@@ -266,7 +270,7 @@ class SymbolicSystem(object):
     def coordinates(self):
         """Returns the column matrix of the generalized coordinates"""
         if self._coordinates is None:
-            raise AttributeError("The coordinates were not specified")
+            raise AttributeError("The coordinates were not specified.")
         else:
             return self._coordinates
 
@@ -274,7 +278,7 @@ class SymbolicSystem(object):
     def speeds(self):
         """Returns the column matrix of generalized speeds"""
         if self._speeds is None:
-            raise AttributeError("The speeds were not specified")
+            raise AttributeError("The speeds were not specified.")
         else:
             return self._speeds
 
@@ -296,7 +300,7 @@ class SymbolicSystem(object):
         included"""
         if self._dyn_implicit_mat is None:
             raise AttributeError("dyn_implicit_mat is not specified for "
-                                 "equations of motion form [1] or [2]")
+                                 "equations of motion form [1] or [2].")
         else:
             return self._dyn_implicit_mat
 
@@ -307,7 +311,7 @@ class SymbolicSystem(object):
         included"""
         if self._dyn_implicit_rhs is None:
             raise AttributeError("dyn_implicit_rhs is not specified for "
-                                 "equations of motion form [1] or [2]")
+                                 "equations of motion form [1] or [2].")
         else:
             return self._dyn_implicit_rhs
 
@@ -328,7 +332,7 @@ class SymbolicSystem(object):
                 return self._comb_implicit_mat
             else:
                 raise AttributeError("comb_implicit_mat is not specified for "
-                                     "equations of motion form [1]")
+                                     "equations of motion form [1].")
         else:
             return self._comb_implicit_mat
 
@@ -345,7 +349,7 @@ class SymbolicSystem(object):
                 return self._comb_implicit_rhs
             else:
                 raise AttributeError("comb_implicit_mat is not specified for "
-                                     "equations of motion in form [1]")
+                                     "equations of motion in form [1].")
         else:
             return self._comb_implicit_rhs
 
@@ -362,7 +366,7 @@ class SymbolicSystem(object):
         form, x' = F, where the kinematical equations are included"""
         if self._comb_explicit_rhs is None:
             raise AttributeError("Please run .combute_explicit_form before "
-                                 "attempting to access comb_explicit_rhs")
+                                 "attempting to access comb_explicit_rhs.")
         else:
             return self._comb_explicit_rhs
 
@@ -372,7 +376,7 @@ class SymbolicSystem(object):
         form, q' = G"""
         if self._kin_explicit_rhs is None:
             raise AttributeError("kin_explicit_rhs is not specified for "
-                                 "equations of motion form [1] or [2]")
+                                 "equations of motion form [1] or [2].")
         else:
             return self._kin_explicit_rhs
 
@@ -424,7 +428,7 @@ class SymbolicSystem(object):
     def bodies(self):
         """Returns the bodies in the system"""
         if self._bodies is None:
-            raise AttributeError("bodies were not specified for the system")
+            raise AttributeError("bodies were not specified for the system.")
         else:
             return self._bodies
 
@@ -432,6 +436,6 @@ class SymbolicSystem(object):
     def loads(self):
         """Returns the loads in the system"""
         if self._loads is None:
-            raise AttributeError("bodies were not specified for the system")
+            raise AttributeError("loads were not specified for the system.")
         else:
             return self._loads

--- a/sympy/physics/mechanics/system.py
+++ b/sympy/physics/mechanics/system.py
@@ -177,6 +177,32 @@ class SymbolicSystem(object):
         of application, force vector) and torques are given by (reference frame
         acting upon, torque vector). Ex [(point, force), (ref_frame, torque)]
 
+    Example
+    =======
+
+    As a simple example, the dynamics of a simple pendulum will be input into a
+    SymbolicSystem object manually. First some imports will be needed and then
+    symbols will be set up for the length of the pendulum (l), mass at the end
+    of the pendulum (m), and a constant for gravity (g). ::
+
+        >>> from sympy import Matrix, sin, symbols
+        >>> from sympy.physics.mechanics import dynamicsymbols, SymbolicSystem
+        >>> l, m, g = symbols('l m g')
+
+    The system will be defined by an angle of theta from the vertical and a
+    generalized speed of omega will be used where omega = theta_dot. ::
+
+        >>> theta, omega = dynamicsymbols('theta omega')
+
+    Now the equations of motion are ready to be formed and passed to the
+    SymbolicSystem object. ::
+
+        >>> kin_explicit_rhs = Matrix([omega])
+        >>> dyn_implicit_mat = Matrix([l**2 * m])
+        >>> dyn_implicit_rhs = Matrix([-g * l * m * sin(theta)])
+        >>> symsystem = SymbolicSystem(theta, dyn_implicit_rhs, omega,
+        ...                            dyn_implicit_mat)
+
     """
 
     def __init__(self, coord_states, right_hand_side, speeds=None,

--- a/sympy/physics/mechanics/tests/test_system.py
+++ b/sympy/physics/mechanics/tests/test_system.py
@@ -1,0 +1,238 @@
+from sympy import symbols, Matrix, atan, simplify, zeros
+from sympy.physics.mechanics import (dynamicsymbols, Particle, Point,
+                                     ReferenceFrame, SymbolicSystem)
+from sympy.utilities.pytest import raises
+
+# This class is going to be tested using a simple pendulum set up in x and y
+# coordinates
+x, y, u, v, lam = dynamicsymbols('x y u v lambda')
+m, l, g = symbols('m l g')
+
+# Set up the different forms the equations can take
+#       [1] Explicit form where the kinematics and dynamics are combined
+#           x' = F(x, t, r, p)
+#
+#       [2] Implicit form where the kinematics and dynamics are combined
+#           M(x, p) x' = F(x, t, r, p)
+#
+#       [3] Implicit form where the kinematics and dynamics are separate
+#           M(q, p) u' = F(q, u, t, r, p)
+#           q' = G(q, u, t, r, p)
+dyn_implicit_mat = Matrix([[1, 0, -x/m],
+                           [0, 1, -y/m],
+                           [0, 0, l**2/m]])
+
+dyn_implicit_rhs = Matrix([0, 0, u**2 + v**2 - g*y])
+
+comb_implicit_mat = Matrix([[1, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0],
+                            [0, 0, 1, 0, -x/m],
+                            [0, 0, 0, 1, -y/m],
+                            [0, 0, 0, 0, l**2/m]])
+
+comb_implicit_rhs = Matrix([u, v, 0, 0, u**2 + v**2 - g*y])
+
+kin_explicit_rhs = Matrix([u, v])
+
+comb_explicit_rhs = comb_implicit_mat.LUsolve(comb_implicit_rhs)
+
+# Set up a body and load to pass into the system
+theta = atan(x / y)
+N = ReferenceFrame('N')
+A = N.orientnew('A', 'Axis', [theta, N.z])
+O = Point('O')
+P = O.locatenew('P', l * A.x)
+
+Pa = Particle('Pa', P, m)
+
+bodies = [Pa]
+loads = [(P, g * m * N.x)]
+
+# Set up some output equations to be given to SymbolicSystem
+# Change to make these fit the pendulum
+PE = symbols("PE")
+out_eqns = {PE: m*g*(l+y)}
+
+# Set up remaining arguments that can be passed to SymbolicSystem
+alg_con = [2]
+alg_con_full = [4]
+coordinates = (x, y, lam)
+speeds = (u, v)
+states = (x, y, u, v, lam)
+coord_idxs = (0, 1)
+speed_idxs = (2, 3)
+
+
+def test_form_1():
+    symsystem1 = SymbolicSystem(states, comb_explicit_rhs,
+                                alg_con=alg_con_full, output_eqns=out_eqns,
+                                coord_idxs=coord_idxs, speed_idxs=speed_idxs,
+                                bodies=bodies, loads=loads)
+
+    assert symsystem1.coordinates == Matrix([x, y])
+    assert symsystem1.speeds == Matrix([u, v])
+    assert symsystem1.states == Matrix([x, y, u, v, lam])
+
+    assert symsystem1.alg_con == [4]
+
+    inter = comb_explicit_rhs
+    assert simplify(symsystem1.comb_explicit_rhs - inter) == zeros(5, 1)
+
+    assert symsystem1.dynamic_symbols == set([x, y, u, v, lam])
+    assert symsystem1.constant_symbols == set([m, l, g])
+
+    assert symsystem1.output_eqns == out_eqns
+
+    assert symsystem1.bodies == [Pa]
+    assert symsystem1.loads == [(P, g * m * N.x)]
+
+
+def test_form_2():
+    symsystem2 = SymbolicSystem(coordinates, comb_implicit_rhs, speeds=speeds,
+                                mass_matrix=comb_implicit_mat,
+                                alg_con=alg_con_full, output_eqns=out_eqns,
+                                bodies=bodies, loads=loads)
+
+    assert symsystem2.coordinates == Matrix([x, y, lam])
+    assert symsystem2.speeds == Matrix([u, v])
+    assert symsystem2.states == Matrix([x, y, lam, u, v])
+
+    assert symsystem2.alg_con == [4]
+
+    inter = comb_implicit_rhs
+    assert simplify(symsystem2.comb_implicit_rhs - inter) == zeros(5, 1)
+    assert simplify(symsystem2.comb_implicit_mat-comb_implicit_mat) == zeros(5)
+
+    inter = comb_explicit_rhs
+    symsystem2.compute_explicit_form()
+    assert simplify(symsystem2.comb_explicit_rhs - inter) == zeros(5, 1)
+
+    assert symsystem2.dynamic_symbols == set([x, y, u, v, lam])
+    assert symsystem2.constant_symbols == set([m, l, g])
+
+    assert symsystem2.output_eqns == out_eqns
+
+    assert symsystem2.bodies == [Pa]
+    assert symsystem2.loads == [(P, g * m * N.x)]
+
+
+def test_form_3():
+    symsystem3 = SymbolicSystem(states, dyn_implicit_rhs,
+                                mass_matrix=dyn_implicit_mat,
+                                coordinate_derivatives=kin_explicit_rhs,
+                                alg_con=alg_con, coord_idxs=coord_idxs,
+                                speed_idxs=speed_idxs, bodies=bodies,
+                                loads=loads)
+
+    assert symsystem3.coordinates == Matrix([x, y])
+    assert symsystem3.speeds == Matrix([u, v])
+    assert symsystem3.states == Matrix([x, y, u, v, lam])
+
+    assert symsystem3.alg_con == [4]
+
+    inter1 = kin_explicit_rhs
+    inter2 = dyn_implicit_rhs
+    assert simplify(symsystem3.kin_explicit_rhs - inter1) == zeros(2, 1)
+    assert simplify(symsystem3.dyn_implicit_mat - dyn_implicit_mat) == zeros(3)
+    assert simplify(symsystem3.dyn_implicit_rhs - inter2) == zeros(3, 1)
+
+    inter = comb_implicit_rhs
+    assert simplify(symsystem3.comb_implicit_rhs - inter) == zeros(5, 1)
+    assert simplify(symsystem3.comb_implicit_mat-comb_implicit_mat) == zeros(5)
+
+    inter = comb_explicit_rhs
+    symsystem3.compute_explicit_form()
+    assert simplify(symsystem3.comb_explicit_rhs - inter) == zeros(5, 1)
+
+    assert symsystem3.dynamic_symbols == set([x, y, u, v, lam])
+    assert symsystem3.constant_symbols == set([m, l, g])
+
+    assert symsystem3.output_eqns == {}
+
+    assert symsystem3.bodies == [Pa]
+    assert symsystem3.loads == [(P, g * m * N.x)]
+
+
+def test_property_attributes():
+    symsystem = SymbolicSystem(states, comb_explicit_rhs,
+                               alg_con=alg_con_full, output_eqns=out_eqns,
+                               coord_idxs=coord_idxs, speed_idxs=speed_idxs,
+                               bodies=bodies, loads=loads)
+
+    with raises(AttributeError):
+        symsystem.bodies = 42
+    with raises(AttributeError):
+        symsystem.coordinates = 42
+    with raises(AttributeError):
+        symsystem.dyn_implicit_rhs = 42
+    with raises(AttributeError):
+        symsystem.comb_implicit_rhs = 42
+    with raises(AttributeError):
+        symsystem.loads = 42
+    with raises(AttributeError):
+        symsystem.dyn_implicit_mat = 42
+    with raises(AttributeError):
+        symsystem.comb_implicit_mat = 42
+    with raises(AttributeError):
+        symsystem.kin_explicit_rhs = 42
+    with raises(AttributeError):
+        symsystem.comb_explicit_rhs = 42
+    with raises(AttributeError):
+        symsystem.speeds = 42
+    with raises(AttributeError):
+        symsystem.states = 42
+    with raises(AttributeError):
+        symsystem.dynamic_symbols = 42
+    with raises(AttributeError):
+        symsystem.constant_symbols = 42
+    with raises(AttributeError):
+        symsystem.alg_con = 42
+
+
+def test_not_specified_errors():
+    """This test will cover errors that arise from trying to access attributes
+    that were not specificed upon object creation"""
+    # Trying to access form 2 when form 1 given
+    # Trying to access form 3 when form 2 given
+
+    symsystem1 = SymbolicSystem(states, comb_explicit_rhs)
+
+    with raises(AttributeError):
+        symsystem1.comb_implicit_mat
+    with raises(AttributeError):
+        symsystem1.comb_implicit_rhs
+    with raises(AttributeError):
+        symsystem1.dyn_implicit_mat
+    with raises(AttributeError):
+        symsystem1.dyn_implicit_rhs
+    with raises(AttributeError):
+        symsystem1.kin_explicit_rhs
+
+    symsystem2 = SymbolicSystem(coordinates, comb_implicit_rhs, speeds=speeds,
+                                mass_matrix=comb_implicit_mat)
+
+    with raises(AttributeError):
+        symsystem2.dyn_implicit_mat
+    with raises(AttributeError):
+        symsystem2.dyn_implicit_rhs
+    with raises(AttributeError):
+        symsystem2.kin_explicit_rhs
+
+    # Attribute error when trying to access coordinates and speeds when only the
+    # states were given.
+    with raises(AttributeError):
+        symsystem1.coordinates
+    with raises(AttributeError):
+        symsystem1.speeds
+
+    # Attribute error when trying to access bodies and loads when they are not
+    # given
+    with raises(AttributeError):
+        symsystem1.bodies
+    with raises(AttributeError):
+        symsystem1.loads
+
+    # Attribute error when trying to access comb_explicit_rhs before it was
+    # calculated
+    with raises(AttributeError):
+        symsystem2.comb_explicit_rhs

--- a/sympy/physics/mechanics/tests/test_system.py
+++ b/sympy/physics/mechanics/tests/test_system.py
@@ -78,13 +78,15 @@ def test_form_1():
     inter = comb_explicit_rhs
     assert simplify(symsystem1.comb_explicit_rhs - inter) == zeros(5, 1)
 
-    assert symsystem1.dynamic_symbols == set([x, y, u, v, lam])
-    assert symsystem1.constant_symbols == set([m, l, g])
+    assert set(symsystem1.dynamic_symbols()) == set([y, v, lam, u, x])
+    assert type(symsystem1.dynamic_symbols()) == tuple
+    assert set(symsystem1.constant_symbols()) == set([l, g, m])
+    assert type(symsystem1.constant_symbols()) == tuple
 
     assert symsystem1.output_eqns == out_eqns
 
-    assert symsystem1.bodies == [Pa]
-    assert symsystem1.loads == [(P, g * m * N.x)]
+    assert symsystem1.bodies == (Pa,)
+    assert symsystem1.loads == ((P, g * m * N.x),)
 
 
 def test_form_2():
@@ -103,17 +105,20 @@ def test_form_2():
     assert simplify(symsystem2.comb_implicit_rhs - inter) == zeros(5, 1)
     assert simplify(symsystem2.comb_implicit_mat-comb_implicit_mat) == zeros(5)
 
+    assert set(symsystem2.dynamic_symbols()) == set([y, v, lam, u, x])
+    assert type(symsystem2.dynamic_symbols()) == tuple
+    assert set(symsystem2.constant_symbols()) == set([l, g, m])
+    assert type(symsystem2.constant_symbols()) == tuple
+
     inter = comb_explicit_rhs
     symsystem2.compute_explicit_form()
     assert simplify(symsystem2.comb_explicit_rhs - inter) == zeros(5, 1)
 
-    assert symsystem2.dynamic_symbols == set([x, y, u, v, lam])
-    assert symsystem2.constant_symbols == set([m, l, g])
 
     assert symsystem2.output_eqns == out_eqns
 
-    assert symsystem2.bodies == [Pa]
-    assert symsystem2.loads == [(P, g * m * N.x)]
+    assert symsystem2.bodies == (Pa,)
+    assert symsystem2.loads == ((P, g * m * N.x),)
 
 
 def test_form_3():
@@ -144,13 +149,15 @@ def test_form_3():
     symsystem3.compute_explicit_form()
     assert simplify(symsystem3.comb_explicit_rhs - inter) == zeros(5, 1)
 
-    assert symsystem3.dynamic_symbols == set([x, y, u, v, lam])
-    assert symsystem3.constant_symbols == set([m, l, g])
+    assert set(symsystem3.dynamic_symbols()) == set([y, v, lam, u, x])
+    assert type(symsystem3.dynamic_symbols()) == tuple
+    assert set(symsystem3.constant_symbols()) == set([l, g, m])
+    assert type(symsystem3.constant_symbols()) == tuple
 
     assert symsystem3.output_eqns == {}
 
-    assert symsystem3.bodies == [Pa]
-    assert symsystem3.loads == [(P, g * m * N.x)]
+    assert symsystem3.bodies == (Pa,)
+    assert symsystem3.loads == ((P, g * m * N.x),)
 
 
 def test_property_attributes():
@@ -182,16 +189,13 @@ def test_property_attributes():
     with raises(AttributeError):
         symsystem.states = 42
     with raises(AttributeError):
-        symsystem.dynamic_symbols = 42
-    with raises(AttributeError):
-        symsystem.constant_symbols = 42
-    with raises(AttributeError):
         symsystem.alg_con = 42
 
 
 def test_not_specified_errors():
     """This test will cover errors that arise from trying to access attributes
-    that were not specificed upon object creation"""
+    that were not specificed upon object creation or were specified on creation
+    and the user trys to recalculate them."""
     # Trying to access form 2 when form 1 given
     # Trying to access form 3 when form 2 given
 
@@ -207,6 +211,8 @@ def test_not_specified_errors():
         symsystem1.dyn_implicit_rhs
     with raises(AttributeError):
         symsystem1.kin_explicit_rhs
+    with raises(AttributeError):
+        symsystem1.compute_explicit_form()
 
     symsystem2 = SymbolicSystem(coordinates, comb_implicit_rhs, speeds=speeds,
                                 mass_matrix=comb_implicit_mat)


### PR DESCRIPTION
Added a class called SymbolicSystem to physics/mechanics to act as a container class for the equations of motion and other details related to dynamic systems. I have created all of the class attributes and docstrings. This work emerged from work done in PR #11182  and in PR [#353](https://github.com/pydy/pydy/pull/353) in the pydy repository.

Would it be better to name the file `symbolicsystem`, `symsystem` or just leave it as `system`?
