### PR TITLE
9480 matrix rank incorrect

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2767,7 +2767,6 @@ class MatrixBase(object):
                 for k in range(pivot, r.rows):
                     if simplify and k > pivot:
                         r[k, i] = simpfunc(r[k, i])
-                    #if not iszerofunc(r[k, i]):
                     if not Eq(r[pivot, i], 0): 
                         r.row_swap(pivot, k)
                         break

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -12,6 +12,7 @@ from sympy.core.numbers import Integer, ilcm, Float
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.core.compatibility import is_sequence, default_sort_key, range, NotIterable
+from sympy.core.relational import Eq
 
 from sympy.polys import PurePoly, roots, cancel, gcd
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
@@ -2762,11 +2763,12 @@ class MatrixBase(object):
                 break
             if simplify:
                 r[pivot, i] = simpfunc(r[pivot, i])
-            if iszerofunc(r[pivot, i]):
+            if Eq(r[pivot, i], 0): 
                 for k in range(pivot, r.rows):
                     if simplify and k > pivot:
                         r[k, i] = simpfunc(r[k, i])
-                    if not iszerofunc(r[k, i]):
+                    #if not iszerofunc(r[k, i]):
+                    if not Eq(r[pivot, i], 0): 
                         r.row_swap(pivot, k)
                         break
                 else:


### PR DESCRIPTION
This is a fix for https://github.com/sympy/sympy/issues/9480.

The original complaint was that for the matrix:

m = Matrix([[-5 + 5_sqrt(2), -5], [-5_sqrt(2)/2 + 5, -5*sqrt(2)/2]])

the rank was calculated by sympy to be 2 (with simplification disabled) when in reality the rank of this matrix is 1. The underlying issue was the rref for m being computed incorrectly. To my knowledge, my fix neither introduces any performance issues (I don't use simplify) nor causes any of the tests to fail.

My solution makes use of sympy.core.relational.Eq.
