### PR TITLE
Fixed misclassification of diophantine equation

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -402,7 +402,7 @@ def classify_diop(eq, _dict=True):
         diop_type = "cubic_thue"
 
     elif (total_degree > 3 and total_degree % 2 == 0 and
-            all(k.is_Pow for k in coeff if k != 1)):
+            all(k.is_Pow and k.exp == total_degree for k in coeff if k != 1)):
         if all(coeff[k] == 1 for k in coeff if k != 1):
             diop_type = 'general_sum_of_even_powers'
 

--- a/sympy/solvers/tests/test_diophantine.py
+++ b/sympy/solvers/tests/test_diophantine.py
@@ -46,6 +46,7 @@ def test_classify_diop():
     raises(TypeError, lambda: classify_diop(x**2/3 - 1))
     raises(ValueError, lambda: classify_diop(1))
     raises(NotImplementedError, lambda: classify_diop(w*x*y*z - 1))
+    raises(NotImplementedError, lambda: classify_diop(x**3 + y**3 + z**4 - 90))
     assert classify_diop(14*x**2 + 15*x - 42) == (
         [x], {1: -42, x: 15, x**2: 14}, 'univariate')
     assert classify_diop(x*y + z) == (
@@ -60,6 +61,8 @@ def test_classify_diop():
         [w, x, y, z], {x*y: 1, w*z: 1}, 'homogeneous_general_quadratic')
     assert classify_diop(x*y**2 + 1) == (
         [x, y], {x*y**2: 1, 1: 1}, 'cubic_thue')
+    assert classify_diop(x**4 + y**4 + z**4 - (1 + 16 + 81)) == (
+        [x, y, z], {1: -98, x**4: 1, z**4: 1, y**4: 1}, 'general_sum_of_even_powers')
 
 
 def test_linear():


### PR DESCRIPTION
This PR should fix #11418.

In order fix the misclassification of `general_sum_of_even_powers` equations, a check was made that all powers should be the same.
