### PR TITLE
Added top-level docstring for singularities.py

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -12,7 +12,7 @@ the following function types in the given ``Interval``:
 - Decreasing
 - Strictly Decreasing
 - Monotonic
- 
+
 """
 
 from sympy.core.sympify import sympify

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -1,3 +1,20 @@
+"""
+Singularities
+=============
+
+This module implements algorithms for finding singularities for a function
+and identifying types of functions.
+
+The differential calculus methods in this module include methods to identify
+the following function types in the given ``Interval``:
+- Increasing
+- Strictly Increasing
+- Decreasing
+- Strictly Decreasing
+- Monotonic
+ 
+"""
+
 from sympy.core.sympify import sympify
 from sympy.solvers.solveset import solveset
 from sympy.simplify import simplify


### PR DESCRIPTION
Hello. 

Module `sympy/calculus/singularities.py` was missing top-level docstring.

This has been added.

Thank you. 
