### PR TITLE
Changed Printing of Logic Expressions

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -75,15 +75,15 @@ class StrPrinter(Printer):
         return "False"
 
     def _print_And(self, expr):
-        return '(%s)' % (' & '.join(sorted(self._print(a) for a in
-            expr.args)))
+        return '%s' % (' & '.join([self.parenthesize(arg, precedence(expr))
+            for arg in expr.args]))
 
     def _print_Or(self, expr):
-        return '(%s)' % (' | '.join(sorted(self._print(a) for a in
-            expr.args)))
+        return '%s' % (' | '.join([self.parenthesize(arg, precedence(expr))
+            for arg in expr.args]))
 
     def _print_Not(self, expr):
-        return '%s(%s)' % ('~', self._print(expr.args[0]))
+        return '%s%s' % ('~', self._print(expr.args[0]))
 
     def _print_AppliedPredicate(self, expr):
         return '%s(%s)' % (expr.func, expr.arg)
@@ -122,11 +122,11 @@ class StrPrinter(Printer):
 
     def _print_RandomDomain(self, d):
         try:
-            return 'Domain: ' + self._print(d.as_boolean())
+            return 'Domain: (' + self._print(d.as_boolean()) + ')'
         except Exception:
             try:
-                return ('Domain: ' + self._print(d.symbols) + ' in ' +
-                        self._print(d.set))
+                return ('Domain: (' + self._print(d.symbols) + ' in ' +
+                        self._print(d.set) + ')')
             except:
                 return 'Domain on ' + self._print(d.symbols)
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -75,12 +75,15 @@ class StrPrinter(Printer):
         return "False"
 
     def _print_And(self, expr):
-        return '%s(%s)' % (expr.func, ', '.join(sorted(self._print(a) for a in
+        return '(%s)' % (' & '.join(sorted(self._print(a) for a in
             expr.args)))
 
     def _print_Or(self, expr):
-        return '%s(%s)' % (expr.func, ', '.join(sorted(self._print(a) for a in
+        return '(%s)' % (' | '.join(sorted(self._print(a) for a in
             expr.args)))
+
+    def _print_Not(self, expr):
+        return '%s(%s)' % ('~', self._print(expr.args[0]))
 
     def _print_AppliedPredicate(self, expr):
         return '%s(%s)' % (expr.func, expr.arg)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -660,14 +660,14 @@ def test_settings():
 def test_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, where
     X = Normal('x1', 0, 1)
-    assert str(where(X > 0)) == "Domain: And(0 < x1, x1 < oo)"
+    assert str(where(X > 0)) == "Domain: (0 < x1 & x1 < oo)"
 
     D = Die('d1', 6)
-    assert str(where(D > 4)) == "Domain: Or(Eq(d1, 5), Eq(d1, 6))"
+    assert str(where(D > 4)) == "Domain: (Eq(d1, 5) | Eq(d1, 6))"
 
     A = Exponential('a', 1)
     B = Exponential('b', 1)
-    assert str(pspace(Tuple(A, B)).domain) == "Domain: And(0 <= a, 0 <= b, a < oo, b < oo)"
+    assert str(pspace(Tuple(A, B)).domain) == "Domain: (0 <= a & 0 <= b & a < oo & b < oo)"
 
 
 def test_FiniteSet():


### PR DESCRIPTION
Fix for #11435.
- Changed the functions _print_And() _print_Or() to print `&` and `|`
  symbols in the expressions instead of `And` and `Or`.
#### Sample Program

``` python
>>> from sympy import *
>>> from sympy.abc import x,y,z
>>> And(Not(x), Or(y, z))
((y | z) & ~(x))
```
- Previous tests are modified to account for new changes.
