### PR TITLE
paulialgebra: Improved evaluate_pauli_product

### DIFF
--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -11,7 +11,7 @@ References
 
 from __future__ import print_function, division
 
-from sympy import Symbol, I
+from sympy import Symbol, I, Mul
 
 __all__ = ['evaluate_pauli_product']
 
@@ -154,12 +154,28 @@ def evaluate_pauli_product(arg):
     >>> evaluate_pauli_product(x**2*Pauli(2)*Pauli(1))
     -I*x**2*sigma3
     '''
-    tmp = arg.as_coeff_mul()
-    sigma_product = 1
-    com_product = 1
-    for el in tmp[1]:
-        if isinstance(el, Pauli):
-            sigma_product *= el
-        else:
-            com_product *= el
-    return (tmp[0]*sigma_product*com_product)
+    start = arg
+    end = arg
+
+    if not(isinstance(arg, Mul)):
+        return arg
+
+    while ((not(start == end)) | ((start == arg) & (end == arg))):
+        start = end
+
+        tmp = start.as_coeff_mul()
+        sigma_product = 1
+        com_product = 1
+        keeper = 1
+
+        for el in tmp[1]:
+            if isinstance(el, Pauli):
+                sigma_product *= el
+            elif not(el.is_commutative):
+                keeper = keeper*sigma_product*el
+                sigma_product = 1
+            else:
+                com_product *= el
+        end = (tmp[0]*keeper*sigma_product*com_product)
+        if end == arg: break
+    return end

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -1,4 +1,4 @@
-from sympy import I
+from sympy import I, symbols
 from sympy.physics.paulialgebra import Pauli
 from sympy.utilities.pytest import XFAIL
 
@@ -6,9 +6,10 @@ sigma1 = Pauli(1)
 sigma2 = Pauli(2)
 sigma3 = Pauli(3)
 
+tau1 = symbols("tau1", commutative = False)
+
 
 def test_Pauli():
-    from sympy.physics.paulialgebra import evaluate_pauli_product
 
     assert sigma1 == sigma1
     assert sigma1 != sigma2
@@ -21,8 +22,6 @@ def test_Pauli():
     assert sigma2*sigma2 == 1
     assert sigma3*sigma3 == 1
 
-    assert evaluate_pauli_product(I*sigma2*sigma3) == -sigma1
-
     assert sigma1**0 == 1
     assert sigma1**1 == sigma1
     assert sigma1**2 == 1
@@ -33,8 +32,21 @@ def test_Pauli():
 
     assert sigma1*2*sigma1 == 2
 
+
+def test_evaluate_pauli_product():
+    from sympy.physics.paulialgebra import evaluate_pauli_product
+
+    assert evaluate_pauli_product(I*sigma2*sigma3) == -sigma1
+
     # Check issue 6471
     assert evaluate_pauli_product(-I*4*sigma1*sigma2) == 4*sigma3
+
+    # Acting on non-Mul objects should return the input
+    assert evaluate_pauli_product(1) == 1
+    # After consecutive multiplication, one or no Pauli should remain
+    assert evaluate_pauli_product(I*sigma1*sigma2*sigma1*sigma2) == -I
+    # Must respect non-commuting properties of other symbols
+    assert evaluate_pauli_product(I*sigma1*sigma2*tau1*sigma1*sigma3) == I*sigma3*tau1*sigma2
 
 
 @XFAIL


### PR DESCRIPTION
evaluate_pauli_product had several limitations before:
1. Acting on arguments that did not have the as_coeff_mul() gave errors.
2. The functions purpose seems to be as a work around for the XFAIL/FIXME that
   still remains in the code. But did not produce a satisfying end result.
3. It should respect commutative rules.

This meant that, for example:

1.
In [1]: from sympy.physics.paulialgebra import Pauli, evaluate_pauli_product
In [2]: evaluate_pauli_product(1)
[---]
AttributeError: 'int' object has no attribute 'as_coeff_mul'

2.
In [3]: from sympy import I
In [4]: evaluate_pauli_product(I \* Pauli(1) \* Pauli(2) \* Pauli(1) \* Pauli(2))
Out[4]: -sigma3 \* sigma1 \* sigma2

3.
In [5]: from sympy import symbols
In [6]: tau1 = symbols("tau1", commutative = False)
In [7]: evaluate_pauli_product(I \* Pauli(1) \* Pauli(2) \* tau1 \* Pauli(1) \* Pauli(2))
Out[7]: -sigma3 \* sigma1 \* sigma2 \* tau1

With the fixes in this commit, the output of the above is instead:

1.
In [1]: from sympy.physics.paulialgebra import Pauli, evaluate_pauli_product
In [2]: evaluate_pauli_product(1)
Out[2]: 1

2.
In [3]: from sympy import I
In [4]: evaluate_pauli_product(I \* Pauli(1) \* Pauli(2) \* Pauli(1) \* Pauli(2))
Out[4]: -I

3.
In [5]: from sympy import symbols
In [6]: tau1 = symbols("tau1", commutative = False)
In [7]: evaluate_pauli_product(I \* Pauli(1) \* Pauli(2) \* tau1 \* Pauli(1) \* Pauli(2))
Out[7]: -I \* sigma3 \* tau1 \* sigma3
