### PR TITLE
Do not export mpmath from sympy/__init__.py

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -20,6 +20,8 @@ except ImportError:
     raise ImportError("SymPy now depends on mpmath as an external library. "
     "See http://docs.sympy.org/latest/install.html#mpmath for more information.")
 
+del mpmath
+
 from sympy.release import __version__
 
 if 'dev' in __version__:


### PR DESCRIPTION
`mpmath` is imported in sympy/__init__.py to test if the module is available. I think it should not be exposed.

Refs #11453.
