### PR TITLE
Lambdify now handles symbols with invalid Python identifiers.

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division
+import re
 
 from .str import StrPrinter
 from sympy.utilities import default_sort_key
@@ -9,6 +10,8 @@ class LambdaPrinter(StrPrinter):
     This printer converts expressions into strings that can be used by
     lambdify.
     """
+
+    _valid_identifier_regex = re.compile('^[^\d\W]\w*\Z', re.UNICODE)
 
     def _print_MatrixBase(self, expr):
         return "%s(%s)" % (expr.__class__.__name__,
@@ -87,6 +90,18 @@ class LambdaPrinter(StrPrinter):
             ') else (', self._print(expr.args[2]), '))'
         ]
         return ''.join(result)
+
+    def _print_Symbol(self, expr):
+
+        s = super(LambdaPrinter, self)._print_Symbol(expr)
+
+        # Replace any invalid Python identifier characters in the symbol name
+        # with underscores.
+        if re.match(self._valid_identifier_regex, s):
+            return s
+        else:
+            return re.sub('\W|^(?=\d)', '_', s)
+
 
 class NumPyPrinter(LambdaPrinter):
     """

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -179,3 +179,12 @@ def test_multiple_sums():
 
 def test_settings():
     raises(TypeError, lambda: lambdarepr(sin(x), method="garbage"))
+
+
+def test_invalid_python_identifier():
+
+    s = symbols(r'32v2?g#Gmw845h$Wb53wi\phi')
+    assert lambdarepr(s) == '_32v2_g_Gmw845h_Wb53wi_phi'
+
+    s = symbols('k_\dot{\phi}')
+    assert lambdarepr(s) == 'k__dot__phi_'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -77,6 +77,12 @@ def test_atoms():
     f = lambdify(x, I + x, {"I": 1j})
     assert f(1) == 1 + 1j
 
+
+def test_invalid_symbol_names():
+    x, y = symbols('\omega, \dot{\gamma}')
+    f = lambdify([x, y], x + y)
+    assert f(1, 2) == 3
+
 #================== Test different modules =========================
 
 # high precision output of sin(0.2*pi) is used to detect if precision is lost unwanted


### PR DESCRIPTION
This fixes issue #7249.

Note that if you happen to create a symbol name that matches what an invalid
name will convert to there will be unexpected consequences if dummify is False,
but I think that it is worth having this work seemlessly for the large majority
of use cases, e.g.:

a, b = symbols('\k _k')
f = lambdify((a, b), a + b, dummify=False)
