### PR TITLE
Check Meijer G-function parameters

### DIFF
--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy.core import S, I, pi, oo, ilcm, Mod
+from sympy.core import S, I, pi, oo, zoo, ilcm, Mod
 from sympy.core.function import Function, Derivative, ArgumentIndexError
 from sympy.core.containers import Tuple
 from sympy.core.compatibility import reduce, range
@@ -445,7 +445,7 @@ class meijerg(TupleParametersBase):
         if len(args) == 5:
             args = [(args[0], args[1]), (args[2], args[3]), args[4]]
         if len(args) != 3:
-            raise TypeError("args must eiter be as, as', bs, bs', z or "
+            raise TypeError("args must be either as, as', bs, bs', z or "
                             "as, bs, z")
 
         def tr(p):
@@ -453,8 +453,16 @@ class meijerg(TupleParametersBase):
                 raise TypeError("wrong argument")
             return TupleArg(_prep_tuple(p[0]), _prep_tuple(p[1]))
 
+        arg0, arg1 = tr(args[0]), tr(args[1])
+        if Tuple(arg0, arg1).has(oo, zoo, -oo):
+            raise ValueError("G-function parameters must be finite")
+        if any((a - b).is_Integer and a - b > 0
+               for a in arg0[0] for b in arg1[0]):
+            raise ValueError("no parameter a1, ..., an may differ from "
+                         "any b1, ..., bm by a positive integer")
+
         # TODO should we check convergence conditions?
-        return Function.__new__(cls, tr(args[0]), tr(args[1]), args[2])
+        return Function.__new__(cls, arg0, arg1, args[2])
 
     def fdiff(self, argindex=3):
         if argindex != 3:

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -133,6 +133,10 @@ def test_meijer():
     assert tn(meijerg(Tuple(1, 1), Tuple(), Tuple(1), Tuple(0), z),
               log(1 + z), z)
 
+    # test exceptions
+    raises(ValueError, lambda: meijerg(((3, 1), (2,)), ((oo,), (2, 0)), x))
+    raises(ValueError, lambda: meijerg(((3, 1), (2,)), ((1,), (2, 0)), x))
+
     # differentiation
     g = meijerg((randcplx(),), (randcplx() + 2*I,), Tuple(),
                 (randcplx(), randcplx()), z)

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1467,6 +1467,12 @@ def _rewrite_single(f, x, recursive=True):
                     #      but better be safe.
                     if Tuple(*(r1 + (g,))).has(oo, zoo, -oo):
                         continue
+                    # A Meijer G-function is defined only if no
+                    # a in g.an differs from any b in g.bm
+                    # by a positive integer.
+                    if any((a - b).is_integer and (a - b) > 0
+                           for a in g.an for b in g.bm):
+                        continue
                     g = meijerg(g.an, g.aother, g.bm, g.bother,
                                 unpolarify(g.argument, exponents_only=True))
                     res.append(r1 + (g,))

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1461,17 +1461,14 @@ def _rewrite_single(f, x, recursive=True):
                 for fac, g in terms:
                     r1 = _get_coeff_exp(unpolarify(fac.subs(subs).subs(z, x),
                                                    exponents_only=True), x)
-                    g = g.subs(subs).subs(z, x)
+                    try:
+                        g = g.subs(subs).subs(z, x)
+                    except ValueError:
+                        continue
                     # NOTE these substitutions can in principle introduce oo,
                     #      zoo and other absurdities. It shouldn't matter,
                     #      but better be safe.
                     if Tuple(*(r1 + (g,))).has(oo, zoo, -oo):
-                        continue
-                    # A Meijer G-function is defined only if no
-                    # a in g.an differs from any b in g.bm
-                    # by a positive integer.
-                    if any((a - b).is_integer and (a - b) > 0
-                           for a in g.an for b in g.bm):
                         continue
                     g = meijerg(g.an, g.aother, g.bm, g.bother,
                                 unpolarify(g.argument, exponents_only=True))


### PR DESCRIPTION
A Meijer G-function with indices m, n, p, q is defined only if no parameter a1, ..., an differs from a parameter b1, ..., bm by a positive integer. This PR checks the parameters.
Currently some integrations, e.g. the one in #8733, return meaningless expressions.
