### PR TITLE
Fixed string formatting error in as_int

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -333,7 +333,7 @@ def as_int(n):
         if result != n:
             raise TypeError
     except TypeError:
-        raise ValueError('%s is not an integer' % n)
+        raise ValueError('{:s} is not an integer'.format(n))
     return result
 
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -333,7 +333,7 @@ def as_int(n):
         if result != n:
             raise TypeError
     except TypeError:
-        raise ValueError('{:s} is not an integer'.format(n))
+        raise '%s is not an integer' % (n,)
     return result
 
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -333,7 +333,7 @@ def as_int(n):
         if result != n:
             raise TypeError
     except TypeError:
-        raise '%s is not an integer' % (n,)
+        raise TypeError('%s is not an integer' % (n,))
     return result
 
 


### PR DESCRIPTION
The `%` string formatting operator interprets a `tuple` argument as a list of values to be formatted. This causes `as_int` to break when constructing an error message and raise this unhelpful exception:

```
TypeError: not all arguments converted during string formatting
```

This commit replace the `% n` with a `.format(n)`, which does not have this ambiguity.
