### PR TITLE
fix py2 Float unicode prec bug

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -810,7 +810,7 @@ class Float(Number):
         prec = mlib.libmpf.dps_to_prec(dps)
         if isinstance(num, float):
             _mpf_ = mlib.from_float(num, prec, rnd)
-        elif isinstance(num, str):
+        elif isinstance(num, string_types):
             _mpf_ = mlib.from_str(num, prec, rnd)
         elif isinstance(num, decimal.Decimal):
             if num.is_finite():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -483,6 +483,10 @@ def test_Float():
     assert Float(oo) == Float('+inf')
     assert Float(-oo) == Float('-inf')
 
+    # unicode
+    assert Float(u'0.73908513321516064100000000') == Float('0.73908513321516064100000000')
+    assert Float(u'0.73908513321516064100000000', 28) == Float('0.73908513321516064100000000', 28)
+
 
 def test_Float_default_to_highprec_from_str():
     s = str(pi.evalf(128))


### PR DESCRIPTION
Fixes (python 2 only):

``` python
>>> Float(u'0.73908513321516064100000000', 28)
0.7390851332151606722931092008
```
