### PR TITLE
Fix calculation of rank of matrix.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -27,7 +27,10 @@ from types import FunctionType
 
 def _iszero(x):
     """Returns True if x is zero."""
-    return x.is_zero
+    if hasattr(x, "free_symbols") and not x.free_symbols:
+        return x.equals(0)
+    else:
+        return x.is_zero
 
 
 class MatrixError(Exception):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2735,6 +2735,26 @@ def test_issue_10770():
             assert new == m and id(new) != id(m)
 
 
+def test_issue_11238():
+    from sympy import Point, tan, sqrt, pi, Matrix, simplify
+    x = 8*tan(13*pi/45)/(tan(13*pi/45) + sqrt(3))
+    y = (-8*sqrt(3)*tan(13*pi/45)**2 + 24*tan(13*pi/45))/(-3 + tan(13*pi/45)**2)
+    p1 = Point(0, 0)
+    p2 = Point(1, -sqrt(3))
+    p0 = Point(x,y)
+    m1 = Matrix([p1 - simplify(p0), p2 - simplify(p0)])
+    m2 = Matrix([p1 - p0, p2 - p0])
+    m3 = Matrix([simplify(p1 - p0), simplify(p2 - p0)])
+    assert m1.rank(simplify=True) == m2.rank(simplify=True) == \
+           m3.rank(simplify=True) == 1
+
+
+def test_issue_9480():
+    m = Matrix([[-5 + 5*sqrt(2), -5],
+                [-5*sqrt(2)/2 + 5, -5*sqrt(2)/2]])
+    assert m.rank() == 1
+
+
 def test_issue_10658():
     A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert A.extract([0, 1, 2], [True, True, False]) == \


### PR DESCRIPTION
Fix calculation of rank of a matrix with complicated elements.  

This PR able to close #9480 and #11238.

I did some performance test for 3 implementations of _iszero()
So, 1st function (from current master):

```
def _iszero(x):
    """Returns True if x is zero."""
    return x.is_zero
```

We can see next:

```
In [23]: def check_rank():
    time_all = 0
    for k in xrange(1000):
        A = Matrix([[7, 6, 5, 4, 3, 2],
                        [9, 7, 8, 9, 4, 3],
                        [7, 4, 9, 7, 0, 0],
                        [5, 3, 6, 1, 0, 0],
                        [0, 0, 5, 6, 0, 0],
                        [0, 0, 6, 8, 0, sqrt(k)]])
        begin_t = time.time()
        b = A.rank()
        time_all += time.time() - begin_t
    return time_all
   ....: 

In [24]: check_rank()
Out[24]: 5.189665794372559

In [25]: check_rank()
Out[25]: 5.310587406158447

In [26]: check_rank()
Out[26]: 5.2525904178619385

In [27]: check_rank()
Out[27]: 5.224452018737793

In [28]: check_rank()
Out[28]: 5.226367950439453

In [29]: %paste
from sympy import Point, tan, sqrt, pi, Matrix, simplify
x = 8*tan(13*pi/45)/(tan(13*pi/45) + sqrt(3))
y = (-8*sqrt(3)*tan(13*pi/45)**2 + 24*tan(13*pi/45))/(-3 + tan(13*pi/45)**2)
p1 = Point(0, 0)
p2 = Point(1, -sqrt(3))
p0 = Point(x,y)
m1 = Matrix([p1 - simplify(p0), p2 - simplify(p0)])
m2 = Matrix([p1 - p0, p2 - p0])
m3 = Matrix([simplify(p1 - p0), simplify(p2 - p0)])

print(m1.rank(simplify=True))
print(m2.rank(simplify=True))
print(m3.rank(simplify=True))

## -- End pasted text --
2
2
2
```

If we can use function from #10650, 

```
def _iszero(x):
      """Returns True if x is zero."""
    if hasattr(x, "free_symbols") and not x.free_symbols:
        # if we do not have free symbols, we will call _simplify()
        # without risks to lose some confines for domain of an expression,
        # because it will be some number
        x = _simplify(x)
    return x.is_zero
```

we will get

```
In [1]: import time

In [2]: from sympy import *

In [3]: def check_rank():
    time_all = 0
    for k in xrange(1000):
        A = Matrix([[7, 6, 5, 4, 3, 2],
                        [9, 7, 8, 9, 4, 3],
                        [7, 4, 9, 7, 0, 0],
                        [5, 3, 6, 1, 0, 0],
                        [0, 0, 5, 6, 0, 0],
                        [0, 0, 6, 8, 0, sqrt(k)]])
        begin_t = time.time()
        b = A.rank()
        time_all += time.time() - begin_t
    return time_all
   ...: 

In [4]: check_rank()
Out[4]: 23.70626139640808

In [5]: check_rank()
Out[5]: 23.882262468338013

In [6]: check_rank()
Out[6]: 23.626940965652466

In [7]: %paste
from sympy import Point, tan, sqrt, pi, Matrix, simplify
x = 8*tan(13*pi/45)/(tan(13*pi/45) + sqrt(3))
y = (-8*sqrt(3)*tan(13*pi/45)**2 + 24*tan(13*pi/45))/(-3 + tan(13*pi/45)**2)
p1 = Point(0, 0)
p2 = Point(1, -sqrt(3))
p0 = Point(x,y)
m1 = Matrix([p1 - simplify(p0), p2 - simplify(p0)])
m2 = Matrix([p1 - p0, p2 - p0])
m3 = Matrix([simplify(p1 - p0), simplify(p2 - p0)])

print(m1.rank(simplify=True))
print(m2.rank(simplify=True))
print(m3.rank(simplify=True))

## -- End pasted text --
1
2
2
```

So, the second implementation is slower as first and as wrong, as first.

Third function (this PR):

```
def _iszero(x):
    """Returns True if x is zero."""
    if hasattr(x, "free_symbols") and not x.free_symbols:
        return x.equals(0)
    else:
        return x.is_zero
```

And we have output:

```
In [1]: from sympy import *

In [2]: import time

In [3]: def check_rank():
    time_all = 0
    for k in xrange(1000):
        A = Matrix([[7, 6, 5, 4, 3, 2],
                        [9, 7, 8, 9, 4, 3],
                        [7, 4, 9, 7, 0, 0],
                        [5, 3, 6, 1, 0, 0],
                        [0, 0, 5, 6, 0, 0],
                        [0, 0, 6, 8, 0, sqrt(k)]])
        begin_t = time.time()
        b = A.rank()
        time_all += time.time() - begin_t
    return time_all
   ...: 

In [4]: check_rank()
Out[4]: 25.26923680305481

In [5]: check_rank()
Out[5]: 25.200393676757812

In [6]: check_rank()
Out[6]: 25.13577675819397

In [7]: %paste
from sympy import Point, tan, sqrt, pi, Matrix, simplify
x = 8*tan(13*pi/45)/(tan(13*pi/45) + sqrt(3))
y = (-8*sqrt(3)*tan(13*pi/45)**2 + 24*tan(13*pi/45))/(-3 + tan(13*pi/45)**2)
p1 = Point(0, 0)
p2 = Point(1, -sqrt(3))
p0 = Point(x,y)
m1 = Matrix([p1 - simplify(p0), p2 - simplify(p0)])
m2 = Matrix([p1 - p0, p2 - p0])
m3 = Matrix([simplify(p1 - p0), simplify(p2 - p0)])

print(m1.rank(simplify=True))
print(m2.rank(simplify=True))
print(m3.rank(simplify=True))

## -- End pasted text --
1
1
1

```

Third implementation is slower as first too, and even as second. But, it is absolutly right.
