### PR TITLE
Fixed an error in frame.py

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -559,9 +559,15 @@ class ReferenceFrame(object):
         #of the frames it is linked to. Also remove it from the _dcm_dict of
         #its parent
         frames = self._dcm_cache.keys()
+        dcm_dict_del = []
+        dcm_cache_del = []
         for frame in frames:
             if frame in self._dcm_dict:
-                del frame._dcm_dict[self]
+                dcm_dict_del += [frame]
+            dcm_cache_del += [frame]
+        for frame in dcm_dict_del:
+            del frame._dcm_dict[self]
+        for frame in dcm_cache_del:
             del frame._dcm_cache[self]
         #Add the dcm relationship to _dcm_dict
         self._dcm_dict = self._dlist[0] = {}

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -171,6 +171,14 @@ def test_issue_10348():
     I = ReferenceFrame('I')
     A = I.orientnew('A', 'space', u, 'XYZ')
 
+
+def test_issue_11503():
+    A = ReferenceFrame("A")
+    B = A.orientnew("B", "Axis", [35, A.y])
+    C = ReferenceFrame("C")
+    A.orient(C, "Axis", [70, C.z])
+
+
 def test_partial_velocity():
 
     N = ReferenceFrame('N')


### PR DESCRIPTION
There was a spot in frame.py where keys were being deleted from a
dictionary in a for loop over the keys of that dictionary. This threw up
errors and has now been fixed.

closes issue #11503 
