### PR TITLE
Implemented top level docstring to delta.py

### DIFF
--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -1,5 +1,13 @@
-from __future__ import print_function, division
+"""
+This module implements Kronecker Delta function.
 
+References
+==========
+
+- http://mathworld.wolfram.com/KroneckerDelta.html
+
+"""
+from __future__ import print_function, division
 from sympy.core import Add, Mul, S, Dummy
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import default_sort_key, range

--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -1,5 +1,5 @@
 """
-This module implements Kronecker Delta function.
+This module implements sums and products containing the Kronecker Delta function.
 
 References
 ==========


### PR DESCRIPTION
Hello.

Module `sympy/concrete/delta.py` was missing top level docstring. This has now been amended and docstring is added. 

Thank you. 
