### PR TITLE
[WIP] Spatial vector functions

### DIFF
--- a/doc/src/modules/physics/vector/api/spatial.rst
+++ b/doc/src/modules/physics/vector/api/spatial.rst
@@ -1,0 +1,23 @@
+=====================================
+Spatial Vector Functions (Docstrings)
+=====================================
+
+These functions implement basic spatial vector operations. It should be noted
+that there is not currently a spatial vector object and these functions all
+operate on matrices. These functions are useful anywhere spatial vectors may be
+used such as Featherstone's articulated body algorith of equations of motion
+formation.
+
+Spatial Rotation Matrices
+=========================
+
+.. autofunction:: sympy.physics.vector.spatial.rot
+
+.. autofunction:: sympy.physics.vector.spatial.xlt
+
+Spatial Cross Products
+======================
+
+.. autofunction:: sympy.physics.vector.spatial.cross_m
+
+.. autofunction:: sympy.physics.vector.spatial.cross_f

--- a/doc/src/modules/physics/vector/index.rst
+++ b/doc/src/modules/physics/vector/index.rst
@@ -41,4 +41,5 @@ Vector API
     api/kinematics.rst
     api/printing.rst
     api/functions.rst
+    api/spatial.rst
     api/fieldfunctions.rst

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -219,6 +219,33 @@ class Body(RigidBody, Particle):
         Calculates the 6x6 spatial inertia from the 3x3 inertia, the mass of the
         body and the location of the inertia from the center of mass as
         specified by vec.
+
+        Defined as equation 2.63 on page 33 of Rigid Body Dynamics Algorithms
+
+        Parameters
+        ==========
+
+        vec: Vector
+            Defines the point at which the spatial inertia will be calculated.
+            The vector can be defined in any reference frame so long as that
+            reference frame has been oriented relative to the Bodys frame.
+
+        Example
+        =======
+
+        This example will find the spatial inertia at a point [1, 1, 1] from the
+        body's center of mass. ::
+
+            >>> from sympy.physics.mechanics import Body
+            >>> body = Body('body')
+            >>> r = 1 * body.frame.x + 1 * body.frame.y + 1 * body.frame.z
+            >>> body.spatial_inertia(r)
+
+        References
+        ==========
+
+            .. [Featherstone2007] Roy Featherstone, Rigid Body Dynamics
+               Algorithms.  2007 Springer
         """
 
         vec = vec.to_matrix(self.frame)

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -240,12 +240,25 @@ class Body(RigidBody, Particle):
             >>> body = Body('body')
             >>> r = 1 * body.frame.x + 1 * body.frame.y + 1 * body.frame.z
             >>> body.spatial_inertia(r)
+            Matrix([
+            [body_ixx + 2*body_mass,   body_ixy - body_mass,   body_izx -
+             body_mass,          0, -body_mass,  body_mass],
+            [  body_ixy - body_mass, body_iyy + 2*body_mass,   body_iyz -
+               body_mass,  body_mass,          0, -body_mass],
+            [  body_izx - body_mass,   body_iyz - body_mass, body_izz +
+               2*body_mass, -body_mass,  body_mass,          0],
+            [                     0,              body_mass,
+               -body_mass,  body_mass,          0,          0],
+            [            -body_mass,                      0,
+               body_mass,          0,  body_mass,          0],
+            [             body_mass,             -body_mass,
+               0,          0,          0,  body_mass]])
 
         References
         ==========
 
-            .. [Featherstone2007] Roy Featherstone, Rigid Body Dynamics
-               Algorithms.  2007 Springer
+        .. [Featherstone2007] Roy Featherstone, Rigid Body Dynamics
+            Algorithms.  2007 Springer
         """
 
         vec = vec.to_matrix(self.frame)

--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -1,7 +1,8 @@
-from sympy import Symbol
+from sympy import eye, Symbol
 from sympy.physics.mechanics import (RigidBody, Particle, ReferenceFrame,
                                      inertia)
 from sympy.physics.vector import Point, Vector
+from sympy.physics.vector.spatial import cross_m
 
 __all__ = ['Body']
 
@@ -97,6 +98,8 @@ class Body(RigidBody, Particle):
 
         self.name = name
         self.loads = []
+        self.parent_joint = None
+        self.child_joints = []
 
         if frame is None:
             frame = ReferenceFrame(name + '_frame')
@@ -210,3 +213,23 @@ class Body(RigidBody, Particle):
         if not isinstance(vec, Vector):
             raise TypeError("A Vector must be supplied to add torque.")
         self.loads.append((self.frame, vec))
+
+    def spatial_inertia(self, vec):
+        """
+        Calculates the 6x6 spatial inertia from the 3x3 inertia, the mass of the
+        body and the location of the inertia from the center of mass as
+        specified by vec.
+        """
+
+        vec = vec.to_matrix(self.frame)
+        inertia = self.inertia[0].to_matrix(self.frame)
+        top_left = inertia+self.mass*cross_m(vec)*cross_m(vec).transpose()
+        top_right = self.mass*cross_m(vec)
+        bottom_left = self.mass*cross_m(vec).transpose()
+        bottom_right = self.mass*eye(3)
+
+        top_row = top_left.row_join(top_right)
+        bottom_row = bottom_left.row_join(bottom_right)
+        out = top_row.col_join(bottom_row)
+
+        return out

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -1,3 +1,4 @@
+from sympy import Symbol, symbols
 from sympy.physics.vector import Point, ReferenceFrame
 from sympy.physics.mechanics import inertia, Body
 from sympy.utilities.pytest import raises

--- a/sympy/physics/mechanics/tests/test_body.py
+++ b/sympy/physics/mechanics/tests/test_body.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, symbols
+from sympy import Matrix, simplify, Symbol, symbols, zeros
 from sympy.physics.vector import Point, ReferenceFrame
 from sympy.physics.mechanics import inertia, Body
 from sympy.utilities.pytest import raises

--- a/sympy/physics/vector/spatial.py
+++ b/sympy/physics/vector/spatial.py
@@ -1,7 +1,3 @@
-# This file will contain spatial vector functions that will be used in the
-# implementation of Featherstone's methods. The functions will be follow the
-# nomenclature used in Featherstone's "Rigid Body Dynamics Algorithms" book.
-
 # This code will assume the spatial vectors are given such that the first three
 # elements correspond to rotations and the last three elements correspond to
 # translations. This is not a requirement of spatial vectors in general but
@@ -12,14 +8,6 @@
 #     Springer
 
 from sympy import cos, Matrix, sin, zeros
-
-################################################################################
-#
-# Rotations
-#
-################################################################################
-
-# Rotations and nomenclature taken from table 2.2 on page 23
 
 
 def rx(theta):
@@ -125,7 +113,9 @@ def rz(theta):
 
 
 def rot(E):
-    """This function returns the 6x6 rotation matrix for spatial vectors.
+    """This function returns the 6x6 rotation matrix for spatial vectors as
+    defined in table 2.2 on page 23 of Featherstone's Rigid Body Dynamics
+    Algorithms book.
 
     Parameters
     ==========
@@ -160,16 +150,10 @@ def rot(E):
     return X
 
 
-################################################################################
-#
-# Translations
-#
-################################################################################
-
-# Formulas and nomeclature taken from table 2.2 on page 23
-
 def xlt(r):
-    """This function returns the 6x6 translation matrix for spatial vectors.
+    """This function returns the 6x6 translation matrix for spatial vectors as
+    defined in table 2.2 on page 23 of Featherstones' Rigid Body Dynamics
+    Algorithms book.
 
     Parameters
     ==========
@@ -206,18 +190,9 @@ def xlt(r):
     return X
 
 
-################################################################################
-#
-# Spatial cross products
-#
-################################################################################
-
-# The spatial cross product tables can be found in figure 2.5 on page 24
-# The table may be incorrect? Matrix is built based on Roy Featherstone's Matlab
-# code.
-
 def cross_f(v):
-    """This function returns the force cross product (vx*).
+    """This function returns the force space cross product (vx*). This operation
+    is defined in Featherstone's Rigid Body Dynamics Algorithms book.
 
     Parameters
     ==========
@@ -255,18 +230,21 @@ def cross_f(v):
 
 
 def cross_m(v):
-    """This function returns the motion cross product (vx).
+    """This function returns the motion cross product (vx). The operation will
+    depend on the size of the matrix entered. If a 3x1 vector is given the 3x3
+    cross product matrix will be returned. Otherwise the code will assume that a
+    6x1 matrix was given and will return the 6x6 cross product matrix.
 
     Parameters
     ==========
 
-    v: Matrix, size(6, 1)
+    v: Matrix, size(6, 1) or size(3, 1)
         This is the input vector for the cross product vx.
 
     Returns
     =======
 
-    crossed: Matrix, size(6, 6)
+    crossed: Matrix, size(6, 6) or size(3, 3)
         This is the result of the motion cross product.
 
     Examples
@@ -297,45 +275,3 @@ def cross_m(v):
                           [-v5, v4,   0, -v2, v1,   0]])
 
     return crossed
-
-
-################################################################################
-#
-# Transformation Matrices
-#
-################################################################################
-
-def X_to_Xstar(X):
-    """This function will take a motion transformation matrix and change it to a
-    force transformation matrix.
-
-    Parameters
-    ==========
-
-    X: Matrix, size(6, 6)
-        This is the transformation matrix for the motion space of spatial
-        vectors
-
-    Returns
-    =======
-
-    Xstar: Matrix, size(6, 6)
-        This is the transformation matrix for the force space of spatial vectors
-
-    Examples
-    ========
-
-    A transformation matrix for a rotation about the z direction in the force
-    space can be determined as follows::
-
-        >>> from sympy import symbols
-        >>> from sympy.physics.vector.spatial import rz, rot, X_to_Xstar
-        >>> theta = symbols('theta')
-        >>> E = rz(theta)
-        >>> X = rot(E)
-        >>> Xstar = X_to_Xstar(X)
-    """
-
-    Xstar = X.inv().transpose()
-
-    return Xstar

--- a/sympy/physics/vector/spatial.py
+++ b/sympy/physics/vector/spatial.py
@@ -1,0 +1,341 @@
+# This file will contain spatial vector functions that will be used in the
+# implementation of Featherstone's methods. The functions will be follow the
+# nomenclature used in Featherstone's "Rigid Body Dynamics Algorithms" book.
+
+# This code will assume the spatial vectors are given such that the first three
+# elements correspond to rotations and the last three elements correspond to
+# translations. This is not a requirement of spatial vectors in general but
+# rather a selected convention.
+
+# References:
+#     [Featherstone2007] Roy Featherstone, Rigid Body Dynamics Algorithms. 2007
+#     Springer
+
+from sympy import cos, Matrix, sin, zeros
+
+################################################################################
+#
+# Rotations
+#
+################################################################################
+
+# Rotations and nomenclature taken from table 2.2 on page 23
+
+
+def rx(theta):
+    """This function returns the 3x3 rotation matrix for a rotation of theta
+    degrees about the x axis.
+
+    Parameters
+    ==========
+
+    theta: numeric (int, float, etc)
+        This is the angle of the rotation around the x-axis. The angle is given
+        in degrees
+
+    Returns
+    =======
+
+    E: Matrix, size(3, 3)
+        This is the calculated transformation matrix
+
+    Examples
+    ========
+
+    Simply provide an angle and the function will return the rotation matrix. ::
+
+        >>> from sympy.physics.vector.spatial import rx
+        >>> theta = 35
+        >>> E = rx(theta)
+    """
+
+    E = Matrix([[1,           0,          0],
+                [0,  cos(theta), sin(theta)],
+                [0, -sin(theta), cos(theta)]])
+
+    return E
+
+
+def ry(theta):
+    """This function returns the 3x3 rotation matrix for a rotation of theta
+    degrees about the y axis.
+
+    Parameters
+    ==========
+
+    theta: numeric (int, float, etc)
+        This is the angle of the rotation around the y-axis. The angle is given
+        in degrees
+
+    Returns
+    =======
+
+    E: Matrix, size(3, 3)
+        This is the calculated transformation matrix
+
+    Examples
+    ========
+
+    Simply provide an angle and the function will return the rotation matrix. ::
+
+        >>> from sympy.physics.vector.spatial import ry
+        >>> theta = 35
+        >>> E = ry(theta)
+    """
+
+    E = Matrix([[cos(theta), 0, -sin(theta)],
+                [0,          1,           0],
+                [sin(theta), 0,  cos(theta)]])
+
+    return E
+
+
+def rz(theta):
+    """This function returns the 3x3 rotation matrix for a rotation of theta
+    degrees about the z axis.
+
+    Parameters
+    ==========
+
+    theta: numeric (int, float, etc)
+        This is the angle of the rotation around the z-axis. The angle is given
+        in degrees
+
+    Returns
+    =======
+
+    E: Matrix, size(3, 3)
+        This is the calculated transformation matrix
+
+    Examples
+    ========
+
+    Simply provide an angle and the function will return the rotation matrix. ::
+
+        >>> from sympy.physics.vector.spatial import rz
+        >>> theta = 35
+        >>> E = rz(theta)
+    """
+
+    E = Matrix([[cos(theta),  sin(theta), 0],
+                [-sin(theta), cos(theta), 0],
+                [0,           0,          1]])
+
+    return E
+
+
+def rot(E):
+    """This function returns the 6x6 rotation matrix for spatial vectors.
+
+    Parameters
+    ==========
+
+    E: Matrix, size(3, 3)
+        This is the 3x3 rotation matrix representing the rotation in 3D
+        coordinates
+
+    Returns
+    =======
+
+    X: Matrix, size(6, 6)
+        This is the 6x6 rotation matrix for spatial vectors
+
+    Examples
+    ========
+
+    A simple example would be a single rotation of theta degrees about the x
+    axis. ::
+
+        >>> from sympy.physics.vector.spatial import rx, rot
+        >>> theta = 35
+        >>> E = rx(theta)
+        >>> X = rot(E)
+
+    This takes the 3x3 rotation matrix and puts it in a form to be used with
+    spatial vectors.
+    """
+
+    X = E.row_join(zeros(3)).col_join(zeros(3).row_join(E))
+
+    return X
+
+
+################################################################################
+#
+# Translations
+#
+################################################################################
+
+# Formulas and nomeclature taken from table 2.2 on page 23
+
+def xlt(r):
+    """This function returns the 6x6 translation matrix for spatial vectors.
+
+    Parameters
+    ==========
+
+    r: Matrix, size(3, 1)
+        This is the 3D vector representing the translation from the original
+        origin point to the new origin point
+
+    Returns
+    =======
+
+    X: Matrix, size(6,6)
+        This is the 6x6 translation matrix for spatial vectors
+
+    Examples
+    ========
+
+    For a unit translation in the x direction the transformation matrix for
+    spatial vectors can be formed as follows::
+
+        >>> from sympy import Matrix
+        >>> from sympy.physics.vector.spatial import xlt
+        >>> r = Matrix([1, 0, 0])
+        >>> X = xlt(r)
+    """
+
+    X = Matrix([[1,        0,     0, 0, 0, 0],
+                [0,        1,     0, 0, 0, 0],
+                [0,        0,     1, 0, 0, 0],
+                [0,     r[2], -r[1], 1, 0, 0],
+                [-r[2],    0,  r[0], 0, 1, 0],
+                [r[1], -r[0],     0, 0, 0, 1]])
+
+    return X
+
+
+################################################################################
+#
+# Spatial cross products
+#
+################################################################################
+
+# The spatial cross product tables can be found in figure 2.5 on page 24
+# The table may be incorrect? Matrix is built based on Roy Featherstone's Matlab
+# code.
+
+def cross_f(v):
+    """This function returns the force cross product (vx*).
+
+    Parameters
+    ==========
+
+    v: Matrix, size(6, 1)
+        This is the input vector for the cross product vx*.
+
+    Returns
+    =======
+
+    crossed: Matrix, size(6, 6)
+        This is the result of the force cross product.
+
+    Examples
+    ========
+
+    A simple example of the cross product of a vector v. ::
+
+        >>> from sympy import Matrix, symbols
+        >>> from sympy.physics.vector.spatial import cross_f
+        >>> v1, v2, v3, v4, v5, v6 = symbols('v1 v2 v3 v4 v5 v6')
+        >>> v = Matrix([v1, v2, v3, v4, v5, v6])
+        >>> crossed_f = cross_f(v)
+
+    Notes
+    =====
+
+    It is worth noting that the force cross product is the negative transpose of
+    the motion cross product (vx* = -(vx)^T)
+    """
+
+    crossed = -cross_m(v).transpose()
+
+    return crossed
+
+
+def cross_m(v):
+    """This function returns the motion cross product (vx).
+
+    Parameters
+    ==========
+
+    v: Matrix, size(6, 1)
+        This is the input vector for the cross product vx.
+
+    Returns
+    =======
+
+    crossed: Matrix, size(6, 6)
+        This is the result of the motion cross product.
+
+    Examples
+    ========
+
+    A simple example of the cross product of a vector v. ::
+
+        >>> from sympy import Matrix, symbols
+        >>> from sympy.physics.vector.spatial import cross_m
+        >>> v1, v2, v3, v4, v5, v6 = symbols('v1 v2 v3 v4 v5 v6')
+        >>> v = Matrix([v1, v2, v3, v4, v5, v6])
+        >>> crossed_m = cross_m(v)
+    """
+
+    if v.shape == (3, 1):
+        v1, v2, v3 = v
+        crossed = Matrix([[0, -v3, v2],
+                          [v3, 0, -v1],
+                          [-v2, v1, 0]])
+    else:
+        v1, v2, v3, v4, v5, v6 = v
+
+        crossed = Matrix([[0,  -v3,  v2,  0,   0,   0],
+                          [v3,   0, -v1,  0,   0,   0],
+                          [-v2, v1,   0,  0,   0,   0],
+                          [0,  -v6,  v5,  0, -v3,  v2],
+                          [v6,   0, -v4, v3,   0, -v1],
+                          [-v5, v4,   0, -v2, v1,   0]])
+
+    return crossed
+
+
+################################################################################
+#
+# Transformation Matrices
+#
+################################################################################
+
+def X_to_Xstar(X):
+    """This function will take a motion transformation matrix and change it to a
+    force transformation matrix.
+
+    Parameters
+    ==========
+
+    X: Matrix, size(6, 6)
+        This is the transformation matrix for the motion space of spatial
+        vectors
+
+    Returns
+    =======
+
+    Xstar: Matrix, size(6, 6)
+        This is the transformation matrix for the force space of spatial vectors
+
+    Examples
+    ========
+
+    A transformation matrix for a rotation about the z direction in the force
+    space can be determined as follows::
+
+        >>> from sympy import symbols
+        >>> from sympy.physics.vector.spatial import rz, rot, X_to_Xstar
+        >>> theta = symbols('theta')
+        >>> E = rz(theta)
+        >>> X = rot(E)
+        >>> Xstar = X_to_Xstar(X)
+    """
+
+    Xstar = X.inv().transpose()
+
+    return Xstar

--- a/sympy/physics/vector/tests/test_spatial.py
+++ b/sympy/physics/vector/tests/test_spatial.py
@@ -127,24 +127,3 @@ def test_cross_m():
 
     # Test the obtained 6x6 results against the expected results
     assert simplify(crossed_m - crossed_m_exp) == zeros(6)
-
-
-def test_X_to_Xstar():
-    # Obtain the return results for X_to_Xstar
-    theta = symbols('theta')
-    E = spatial.rz(theta)
-    X = spatial.rot(E)
-    Xstar = spatial.X_to_Xstar(X)
-
-    # Set up the expected return value
-    Xstar_exp = Matrix([[-sin(theta)**2/cos(theta) + 1/cos(theta), sin(theta),
-                         0, 0, 0, 0],
-                        [-sin(theta), cos(theta), 0, 0, 0, 0],
-                        [0, 0, 1, 0, 0, 0],
-                        [0, 0, 0, -sin(theta)**2/cos(theta) + 1/cos(theta),
-                         sin(theta), 0],
-                        [0, 0, 0, -sin(theta), cos(theta), 0],
-                        [0, 0, 0, 0, 0, 1]])
-
-    # Test the obtained results against the expected results
-    assert simplify(Xstar - Xstar_exp) == zeros(6)

--- a/sympy/physics/vector/tests/test_spatial.py
+++ b/sympy/physics/vector/tests/test_spatial.py
@@ -1,0 +1,150 @@
+from sympy import cos, Matrix, simplify, sin, symbols, zeros
+import sympy.physics.vector.spatial as spatial
+
+
+def test_rx():
+    # Obtain the return results for rx
+    theta = symbols('theta')
+    E = spatial.rx(theta)
+
+    # Set up the expected return results
+    E_exp = Matrix([[1,           0,           0],
+                    [0,  cos(theta),  sin(theta)],
+                    [0, -sin(theta), cos(theta)]])
+
+    # Test the obtained results against the expected return results
+    assert simplify(E - E_exp) == zeros(3)
+
+
+def test_ry():
+    # Obtain the return results for ry
+    theta = symbols('theta')
+    E = spatial.ry(theta)
+
+    # Set up the expected return results
+    E_exp = Matrix([[cos(theta), 0, -sin(theta)],
+                    [0,          1,           0],
+                    [sin(theta), 0,  cos(theta)]])
+
+    # Test the obtained results against the expected return results
+    assert simplify(E - E_exp) == zeros(3)
+
+
+def test_rz():
+    # Obtain the return results for rz
+    theta = symbols('theta')
+    E = spatial.rz(theta)
+
+    # Set up the expected return results
+    E_exp = Matrix([[cos(theta),  sin(theta), 0],
+                    [-sin(theta), cos(theta), 0],
+                    [0,           0,          1]])
+
+    # Test the obtained rsults against the expected return results
+    assert simplify(E - E_exp) == zeros(3)
+
+
+def test_rot():
+    # Obtain the return results for rot for a rotation theta about the z axis
+    theta = symbols('theta')
+    E = spatial.rz(theta)
+    X = spatial.rot(E)
+
+    # Set up the expected return results
+    X_exp = Matrix([[cos(theta),  sin(theta), 0, 0,           0,          0],
+                    [-sin(theta), cos(theta), 0, 0,           0,          0],
+                    [0,           0,          1, 0,           0,          0],
+                    [0,           0,          0, cos(theta),  sin(theta), 0],
+                    [0,           0,          0, -sin(theta), cos(theta), 0],
+                    [0,           0,          0, 0,           0,          1]])
+
+    # Test the obtained results against the expected return results
+    assert simplify(X - X_exp) == zeros(6)
+
+
+def test_xlt():
+    # Obtain the return results for xlt
+    L = symbols('L')
+    r = Matrix([0, 0, L])
+    X = spatial.xlt(r)
+
+    # Set up the expected return results
+    X_exp = Matrix([[1,  0, 0, 0, 0, 0],
+                    [0,  1, 0, 0, 0, 0],
+                    [0,  0, 1, 0, 0, 0],
+                    [0,  L, 0, 1, 0, 0],
+                    [-L, 0, 0, 0, 1, 0],
+                    [0,  0, 0, 0, 0, 1]])
+
+    # Test the obtained results against the expected results
+    assert simplify(X - X_exp) == zeros(6)
+
+
+def test_cross_f():
+    # Obtain the return results for cross_f
+    v1, v2, v3, v4, v5, v6 = symbols('v1 v2 v3 v4 v5 v6')
+    v = Matrix([v1, v2, v3, v4, v5, v6])
+    crossed_f = spatial.cross_f(v)
+
+    # Set up the expected result
+    crossed_f_exp = Matrix([[0,  -v3,  v2,   0, -v6,  v5],
+                            [v3,   0, -v1,  v6,   0, -v4],
+                            [-v2, v1,   0, -v5,  v4,   0],
+                            [0,    0,   0,   0, -v3,  v2],
+                            [0,    0,   0,  v3,   0, -v1],
+                            [0,    0,   0, -v2,  v1,   0]])
+
+    # Test the obtained results against the expected results
+    assert simplify(crossed_f - crossed_f_exp) == zeros(6)
+
+
+def test_cross_m():
+    v1, v2, v3, v4, v5, v6 = symbols('v1 v2 v3 v4 v5 v6')
+    # Test the 3x3 return results
+    v = Matrix([v1, v2, v3])
+    crossed_m = spatial.cross_m(v)
+
+    # Set up the 3x3 expected result
+    crossed_m_exp = Matrix([[0,  -v3,  v2],
+                            [v3,   0, -v1],
+                            [-v2, v1,   0]])
+
+    # Test the obtained 3x3 results against the expected results
+    assert simplify(crossed_m - crossed_m_exp) == zeros(3)
+
+    # Set up the expected 3x3 results
+    # Obtain the 6x6 return results for cross_m
+    v = Matrix([v1, v2, v3, v4, v5, v6])
+    crossed_m = spatial.cross_m(v)
+
+    # Set up the 6x6 expected result
+    crossed_m_exp = Matrix([[0,  -v3,  v2,  0,   0,   0],
+                            [v3,   0, -v1,  0,   0,   0],
+                            [-v2, v1,   0,  0,   0,   0],
+                            [0,  -v6,  v5,  0, -v3,  v2],
+                            [v6,   0, -v4, v3,   0, -v1],
+                            [-v5, v4,   0, -v2, v1,   0]])
+
+    # Test the obtained 6x6 results against the expected results
+    assert simplify(crossed_m - crossed_m_exp) == zeros(6)
+
+
+def test_X_to_Xstar():
+    # Obtain the return results for X_to_Xstar
+    theta = symbols('theta')
+    E = spatial.rz(theta)
+    X = spatial.rot(E)
+    Xstar = spatial.X_to_Xstar(X)
+
+    # Set up the expected return value
+    Xstar_exp = Matrix([[-sin(theta)**2/cos(theta) + 1/cos(theta), sin(theta),
+                         0, 0, 0, 0],
+                        [-sin(theta), cos(theta), 0, 0, 0, 0],
+                        [0, 0, 1, 0, 0, 0],
+                        [0, 0, 0, -sin(theta)**2/cos(theta) + 1/cos(theta),
+                         sin(theta), 0],
+                        [0, 0, 0, -sin(theta), cos(theta), 0],
+                        [0, 0, 0, 0, 0, 1]])
+
+    # Test the obtained results against the expected results
+    assert simplify(Xstar - Xstar_exp) == zeros(6)


### PR DESCRIPTION
This PR has different spatial vector functions as defined in Featherstone's book. Note that they all operate on 6x1 matrices. I also added a method to the `Body` object so that it can calculate its spatial inertia at a given point. Also added to body are some empty attributes that will be made use of by the joints that I will be sending a PR for soon.

I do not know that all of the spatial vector functions will be needed and I will weed out the ones that are not necessary.

I have some confusion about how he defines his 3x3 rotation matrices. In all of his 3x3 rotation matrices (functions rx, ry, and rz) the negative is not on the same term I have seen in other literature. A quick link to the wikipedia page for [rotation matrices](https://en.wikipedia.org/wiki/Rotation_matrix) shows this discrepancy. @moorepants do you know why this might be? (Featherstone defines these matrices on in table 2.2 in his book on page 23)
