### PR TITLE
[tensor] fix problem in TensAdd.data (Issue #9862) (replaces PR #9863)

### DIFF
--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -822,14 +822,21 @@ class _TensorDataLazyEvaluator(CantSympify):
 
         if isinstance(key, TensAdd):
             sumvar = S.Zero
-            data_list = [i.data for i in key.args]
+            data_list = []
+            free_args_list = []
+            for arg in key.args:
+                if isinstance(arg, TensExpr):
+                    data_list.append(arg.data)
+                    free_args_list.append([x[0] for x in arg.free])
+                else:
+                    data_list.append(arg)
+                    free_args_list.append([])
             if all([i is None for i in data_list]):
                 return None
             if any([i is None for i in data_list]):
                 raise ValueError("Mixing tensors with associated components "\
                                  "data with tensors without components data")
 
-            free_args_list = [[x[0] for x in arg.free] for arg in key.args]
             numpy = import_module("numpy")
             for data, free_args in zip(data_list, free_args_list):
                 if len(free_args) < 2:

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1478,6 +1478,23 @@ def test_valued_tensor_expressions():
     assert expr5.data.expand() == 28*E*x1 + 12*px*x1 + 20*py*x1 + 28*pz*x1 + 136*x2 + 3*x3
 
 
+def test_valued_tensor_add_scalar():
+    numpy = import_module("numpy")
+    if numpy is None:
+        skip("numpy not installed.")
+
+    (A, B, AB, BA, C, Lorentz, E, px, py, pz, LorentzD, mu0, mu1, mu2, ndm, n0, n1,
+     n2, NA, NB, NC, minkowski, ba_matrix, ndm_matrix, i0, i1, i2, i3, i4) = _get_valued_base_test_variables()
+
+    # one scalar summand after the contracted tensor
+    expr1 = A(i0)*A(-i0) - (E**2 - px**2 - py**2 - pz**2)
+    assert expr1.data == 0
+
+    # multiple scalar summands in front of the contracted tensor
+    expr2 = E**2 - px**2 - py**2 - pz**2 - A(i0)*A(-i0)
+    assert expr2.data == 0
+
+
 def test_noncommuting_components():
     numpy = import_module("numpy")
     if numpy is None:


### PR DESCRIPTION
This is a simple (perhaps naive) fix of the problem described in Issue #9862.

In this solution, I have assumed that the arguments of a TensAdd instance are either instances of TensExpr or usual sympy expressions which are already in the 'data' form. Please correct me if this is not the case!

@Upabjojr, this pull request replaces the old pull request #9863. It adds a test and extends the bug-fix to the list creation of 'free_args_list'.
