### PR TITLE
Fix Tensorflow lambdify Max/Min with multiple arguments

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -115,6 +115,24 @@ class TensorflowPrinter(LambdaPrinter):
         #     own because StrPrinter doesn't define it.
         return '{0}({1})'.format('logical_not', ','.join(self._print(i) for i in expr.args))
 
+    def _print_Min(self, expr, **kwargs):
+        from sympy import Min
+        if len(expr.args) == 1:
+            return self._print(expr.args[0], **kwargs)
+
+        return 'minimum({0}, {1})'.format(
+            self._print(expr.args[0], **kwargs),
+            self._print(Min(*expr.args[1:]), **kwargs))
+
+    def _print_Max(self, expr, **kwargs):
+        from sympy import Max
+        if len(expr.args) == 1:
+            return self._print(expr.args[0], **kwargs)
+
+        return 'maximum({0}, {1})'.format(
+            self._print(expr.args[0], **kwargs),
+            self._print(Max(*expr.args[1:]), **kwargs))
+
     def _print_Piecewise(self, expr, **kwargs):
         from sympy import Piecewise
         e, cond = expr.args[0].args

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -98,14 +98,14 @@ class TensorflowPrinter(LambdaPrinter):
         "Logical And printer"
         # We have to override LambdaPrinter because it uses Python 'and' keyword.
         # If LambdaPrinter didn't define it, we could use StrPrinter's
-        # version of the function and add 'logical_and' to NUMPY_TRANSLATIONS.
+        # version of the function and add 'logical_and' to TENSORFLOW_TRANSLATIONS.
         return '{0}({1})'.format('logical_and', ','.join(self._print(i) for i in expr.args))
 
     def _print_Or(self, expr):
         "Logical Or printer"
         # We have to override LambdaPrinter because it uses Python 'or' keyword.
         # If LambdaPrinter didn't define it, we could use StrPrinter's
-        # version of the function and add 'logical_or' to NUMPY_TRANSLATIONS.
+        # version of the function and add 'logical_or' to TENSORFLOW_TRANSLATIONS.
         return '{0}({1})'.format('logical_or', ','.join(self._print(i) for i in expr.args))
 
     def _print_Not(self, expr):
@@ -145,7 +145,7 @@ class TensorflowPrinter(LambdaPrinter):
             return '{op}({lhs}, {rhs})'.format(op=op[expr.rel_op],
                                                lhs=lhs,
                                                rhs=rhs)
-        return super(NumPyPrinter, self)._print_Relational(expr)
+        return super(TensorflowPrinter, self)._print_Relational(expr)
 
 
 class NumPyPrinter(LambdaPrinter):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -92,8 +92,6 @@ NUMPY_TRANSLATIONS = {
 TENSORFLOW_TRANSLATIONS = {
     "Abs": "abs",
     "ceiling": "ceil",
-    "Max": "maximum",
-    "Min": "minimum",
     "im": "imag",
     "ln": "log",
     "Mod": "mod",

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -518,6 +518,24 @@ def test_tensorflow_piecewise():
     assert func(a).eval(session=s, feed_dict={a: 0}) == 0
     assert func(a).eval(session=s, feed_dict={a: 1}) == 1
 
+def test_tensorflow_multi_max():
+    if not tensorflow:
+        skip("tensorflow not installed.")
+    expr = Max(x, -x, x**2)
+    func = lambdify(x, expr, modules="tensorflow")
+    a = tensorflow.placeholder(dtype=tensorflow.float32)
+    s = tensorflow.Session()
+    assert func(a).eval(session=s, feed_dict={a: -2}) == 4
+
+def test_tensorflow_multi_min():
+    if not tensorflow:
+        skip("tensorflow not installed.")
+    expr = Min(x, -x, x**2)
+    func = lambdify(x, expr, modules="tensorflow")
+    a = tensorflow.placeholder(dtype=tensorflow.float32)
+    s = tensorflow.Session()
+    assert func(a).eval(session=s, feed_dict={a: -2}) == -2
+
 def test_tensorflow_relational():
     if not tensorflow:
         skip("tensorflow not installed.")


### PR DESCRIPTION
Tensorflow `maximum` and `minimum` both only accept two arguments, so in the case of a Sympy Max expression with more than two arguments, lambdify with Tensorflow fails to produce runnable TF code. This PR fixes that issue, and corrects some typos related to sloppy copy-pasting of code.
