### PR TITLE
manualintegrate: suppress trivial substitutions

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -158,6 +158,8 @@ def find_substitutions(integrand, symbol, u_var):
         new_integrand = test_subterm(u, u_diff)
         if new_integrand is not False:
             constant, new_integrand = new_integrand
+            if new_integrand == integrand.subs(symbol, u_var):
+                continue
             substitution = (u, constant, new_integrand)
             if substitution not in results:
                 results.append(substitution)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -169,6 +169,9 @@ def test_manualintegrate_trig_substitution():
          (49*x**2 + 1)**(3*S.Half)/5764801 +
          3*sqrt(49*x**2 + 1)/5764801 + 1/(5764801*sqrt(49*x**2 + 1)))
 
+def test_manualintegrate_trivial_substitution():
+    assert manualintegrate((exp(x) - exp(-x))/x, x) == \
+        -Integral(exp(-x)/x, x) + Integral(exp(x)/x, x)
 
 def test_manualintegrate_rational():
     assert manualintegrate(1/(4 - x**2), x) == Piecewise((acoth(x/2)/2, x**2 > 4), (atanh(x/2)/2, x**2 < 4))


### PR DESCRIPTION
The substitution rule in manualintegrate does run into infinite
recursion when the new and old integrands only differ by a change
of variable. An example of this is

`manualintegrate((exp(x) - exp(-x))/x, x)`

This PR compares the new integrand with the old integrand after
variable substitution.
