### PR TITLE
Improved ITE() function

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -929,6 +929,11 @@ class ITE(BooleanFunction):
             return c
         if b == c:
             return b
+        else:
+            if b == True and c == False:
+                return a
+            if b == False and c == True:
+                return Not(a)
 
     def to_nnf(self, simplify=True):
         a, b, c = self.args

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -482,6 +482,9 @@ def test_ITE():
     B = True
     assert ITE(And(A, B), B, C) == C
     assert ITE(Or(A, False), And(B, True), False) is false
+    x = symbols('x')
+    assert ITE(x, A, B) == Not(x)
+    assert ITE(x, B, A) == x
 
 
 def test_ITE_diff():


### PR DESCRIPTION
Fix for #11530. Case when `b!=c` is added.
#### Sample Program:

``` python
>>> from sympy import *
>>> from sympy.abc import x
>>> ITE(x, False, True)
Not(x)
>>> ITE(x, True, False)
x
```
