### PR TITLE
11498 pass rotational matrices

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -438,7 +438,7 @@ class ReferenceFrame(object):
         ========
 
         >>> from sympy.physics.vector import ReferenceFrame, Vector
-        >>> from sympy import symbols
+        >>> from sympy import symbols, eye, ImmutableMatrix
         >>> q0, q1, q2, q3 = symbols('q0 q1 q2 q3')
         >>> N = ReferenceFrame('N')
         >>> B = ReferenceFrame('B')
@@ -479,7 +479,7 @@ class ReferenceFrame(object):
         Last is DCM (Direction Cosine Matrix). This is a rotation matrix given manually.
 
         >>> B.orient(N, 'DCM', eye(3))
-        >>> B.orient(N, 'DCM', ImmutableMatrix([[0, 1, 0], [0, 0, -1], [-1, 0, 0]]]))
+        >>> B.orient(N, 'DCM', ImmutableMatrix([[0, 1, 0], [0, 0, -1], [-1, 0, 0]]))
 
         """
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -1,5 +1,5 @@
 from sympy import (diff, trigsimp, expand, sin, cos, solve, Symbol, sympify,
-                   eye, symbols, Dummy, ImmutableMatrix as Matrix, MutableDenseMatrix as MDMatrix)
+                   eye, symbols, Dummy, ImmutableMatrix as Matrix, MatrixBase)
 from sympy.core.compatibility import string_types, range
 from sympy.physics.vector.vector import Vector, _check_vector
 
@@ -483,7 +483,7 @@ class ReferenceFrame(object):
         if rot_type == 'DCM':
             # When rot_type == 'DCM', then amounts must be a Matrix type object
             # (e.g. sympy.matrices.dense.MutableDenseMatrix).
-            if type(amounts) not in (MDMatrix, Matrix):
+            if not isinstance(amounts, MatrixBase):
                 raise TypeError("Amounts must be a sympy Matrix type object.")
         else:
             amounts = list(amounts)

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -470,11 +470,16 @@ class ReferenceFrame(object):
 
         >>> B.orient(N, 'Quaternion', [q0, q1, q2, q3])
 
-        Last is Axis. This is a rotation about an arbitrary, non-time-varying
+        Next is Axis. This is a rotation about an arbitrary, non-time-varying
         axis by some angle. The axis is supplied as a Vector. This is how
         simple rotations are defined.
 
         >>> B.orient(N, 'Axis', [q1, N.x + 2 * N.y])
+
+        Last is DCM (Direction Cosine Matrix). This is a rotation matrix given manually.
+
+        >>> B.orient(N, 'DCM', eye(3))
+        >>> B.orient(N, 'DCM', ImmutableMatrix([[0, 1, 0], [0, 0, -1], [-1, 0, 0]]]))
 
         """
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -425,10 +425,12 @@ class ReferenceFrame(object):
             defined in relation to.
         rot_type : str
             The type of orientation matrix that is being created. Supported
-            types are 'Body', 'Space', 'Quaternion', and 'Axis'. See examples
+            types are 'Body', 'Space', 'Quaternion', 'Axis', and 'DCM'. See examples
             for correct usage.
         amounts : list OR value
             The quantities that the orientation matrix will be defined by.
+            In case of rot_type='DCM', value must be a sympy.matrices.MatrixBase object
+            (or subclasses of it).
         rot_order : str
             If applicable, the order of a series of rotations.
 

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -1,4 +1,4 @@
-from sympy import sin, cos, pi, zeros, ImmutableMatrix as Matrix
+from sympy import sin, cos, pi, zeros, eye, ImmutableMatrix as Matrix
 from sympy.physics.vector import (ReferenceFrame, Vector, CoordinateSym,
                                   dynamicsymbols, time_derivative, express)
 
@@ -196,3 +196,9 @@ def test_partial_velocity():
 
     assert N.partial_velocity(N, u1) == 0
     assert A.partial_velocity(A, u1) == 0
+
+
+def test_issue_11498():
+    A = ReferenceFrame('A')
+    B = ReferenceFrame('B')
+    A.orient(B, 'DCM', eye(3))

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -201,4 +201,16 @@ def test_partial_velocity():
 def test_issue_11498():
     A = ReferenceFrame('A')
     B = ReferenceFrame('B')
+
+    # Identity transformation
     A.orient(B, 'DCM', eye(3))
+    assert A.dcm(B) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    assert B.dcm(A) == Matrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    # x -> y
+    # y -> -z
+    # z -> -x
+    A.orient(B, 'DCM', Matrix([[0, 1, 0], [0, 0, -1], [-1, 0, 0]]))
+    assert B.dcm(A) == Matrix([[0, 1, 0], [0, 0, -1], [-1, 0, 0]])
+    assert A.dcm(B) == Matrix([[0, 0, -1], [1, 0, 0], [0, -1, 0]])
+    assert B.dcm(A).T == A.dcm(B)


### PR DESCRIPTION
Fixes [#11498](https://github.com/sympy/sympy/issues/11498)

The `RerefenceFrame.orient` method can now accept a sympy.matrices.MatrixBase object (or subclasses of it). To achieve that, one has to give `rot_type='DCM'` and `amounts=<sympy.matrices.MatrixBase>`, e.g.:
`A.orient(B, 'DCM', eye(3))`
or
`A.orient(B, 'DCM', ImmutableMatrix([[0, 1, 0], [0, 0, -1], [-1, 0, 0]])`
