### PR TITLE
[matrices] Add smart pivoting to `rref`

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2861,22 +2861,30 @@ class MatrixBase(object):
                 break
             if simplify:
                 r[pivot, i] = simpfunc(r[pivot, i])
-            if iszerofunc(r[pivot, i]):
-                for k in range(pivot, r.rows):
-                    if simplify and k > pivot:
-                        r[k, i] = simpfunc(r[k, i])
-                    if not iszerofunc(r[k, i]):
-                        r.row_swap(pivot, k)
-                        break
-                else:
-                    continue
-            scale = r[pivot, i]
-            r.row_op(pivot, lambda x, _: x / scale)
+
+            pivot_offset, pivot_val, assumed_nonzero, newly_determined = _find_reasonable_pivot(r[pivot:, i], iszerofunc, simpfunc)
+            # `_find_reasonable_pivot` may have simplified
+            # some elements along the way.  If they were simplified
+            # and then determined to be either zero or non-zero for
+            # sure, they are stored in the `newly_determined` list
+            for (offset, val) in newly_determined:
+                r[pivot + offset, i] = val
+
+            # if `pivot_offset` is None, this column has no
+            # pivot
+            if pivot_offset is None:
+                continue
+
+            # swap the pivot column into place
+            pivot_pos = pivot + pivot_offset
+            r.row_swap(pivot, pivot_pos)
+
+            r.row_op(pivot, lambda x, _: x / pivot_val)
             for j in range(r.rows):
                 if j == pivot:
                     continue
-                scale = r[j, i]
-                r.zip_row_op(j, pivot, lambda x, y: x - scale*y)
+                pivot_val = r[j, i]
+                r.zip_row_op(j, pivot, lambda x, y: x - pivot_val*y)
             pivotlist.append(i)
             pivot += 1
         return self._new(r), pivotlist
@@ -4587,3 +4595,76 @@ def a2idx(j, n=None):
         if not (j >= 0 and j < n):
             raise IndexError("Index out of range: a[%s]" % (j, ))
     return int(j)
+
+def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):
+    """ Find the lowest index of an item in `col` that is
+    suitable for a pivot.  If `col` consists only of
+    Floats, the pivot with the largest norm is returned.
+    Otherwise, the first element where `iszerofunc` returns
+    False is used.  If `iszerofunc` doesn't return false,
+    items are simplified and retested until a suitable
+    pivot is found.
+
+    Returns a 4-tuple
+        (pivot_offset, pivot_val, assumed_nonzero, newly_determined)
+    where pivot_offset is the index of the pivot, pivot_val is
+    the (possibly simplified) value of the pivot, assumed_nonzero
+    is True if an assumption that the pivot was non-zero
+    was made without being probed, and newly_determined are
+    elements that were simplified during the process of pivot
+    finding."""
+
+    newly_determined = []
+    col = list(col)
+    if all(isinstance(x, Float) for x in col):
+        # if everything is a Float, do partial pivoting
+        # by returning the maximum element
+        col_abs = [abs(x) for x in col]
+        max_value = max(col_abs)
+        if max_value == 0:
+            return (None, None, False, newly_determined)
+        index = col_abs.index(max_value)
+        return (index, col[index], False, newly_determined)
+
+    possible_zeros = []
+    for i,x in enumerate(col):
+        is_zero = iszerofunc(x)
+        if is_zero is False:
+            # we found something that is definitely not zero
+            return (i, x, False, newly_determined)
+        possible_zeros.append(is_zero)
+
+    # by this point, we've found no certain non-zeros
+    if all(possible_zeros):
+        # if everything is definitely zero, we have
+        # no pivot
+        return (None, None, False, newly_determined)
+
+    # we haven't found any for-sure non-zeros, so
+    # go through the elements iszerofunc couldn't
+    # make a determination about and opportunistically
+    # simplify to see if we find something
+    for i,x in enumerate(col):
+        if possible_zeros[i] is not None:
+            continue
+        simped = simpfunc(x)
+        is_zero = iszerofunc(simped)
+        if is_zero in (True, False):
+            newly_determined.append( (i, simped) )
+        if is_zero is False:
+            return (i, simped, False, newly_determined)
+        possible_zeros[i] = is_zero
+
+    # after simplifying some things that we're recognized
+    # as zeros might be zeros
+    if all(possible_zeros):
+        # if everything is definitely zero, we have
+        # no pivot
+        return (None, None, False, newly_determined)
+
+    # at this point there is nothing that could definitely
+    # be a pivot.  To maintain compatibility with existing
+    # behavior, we'll assume that an illdetermined thing is
+    # non-zero.  We should probably raise a warning in this case
+    i = possible_zeros.index(None)
+    return (i, col[i], True, newly_determined)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4666,7 +4666,7 @@ def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):
             return (i, simped, False, newly_determined)
         possible_zeros[i] = is_zero
 
-    # after simplifying some things that we're recognized
+    # after simplifying, some things that were recognized
     # as zeros might be zeros
     if all(possible_zeros):
         # if everything is definitely zero, we have

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2767,6 +2767,30 @@ def test_partial_pivoting():
     mm=Matrix([[0.003 ,59.14, 59.17],[ 5.291, -6.13,46.78]])
     assert mm.rref()[0] == Matrix([[1.0,   0, 10.0], [  0, 1.0,  1.0]])
 
+    # issue #11549
+    m_mixed = Matrix([[6e-17, 1.0, 4],[ -1.0,   0, 8],[    0,   0, 1]])
+    m_float = Matrix([[6e-17, 1.0, 4.],[ -1.0,   0., 8.],[    0.,   0., 1.]])
+    m_inv = Matrix([[  0,    -1.0,  8.0],[1.0, 6.0e-17, -4.0],[  0,       0,    1]])
+    # this example is numerically unstable and involves a matrix with a norm >= 8,
+    # this comparing the difference of the results with 1e-15 is numerically sound.
+    assert (m_mixed.inv() - m_inv).norm() < 1e-15
+    assert (m_float.inv() - m_inv).norm() < 1e-15
+
+def test_iszero_substitution():
+    """ When doing numerical computations, all elements that pass
+    the iszerofunc test should be set to numerically zero if they
+    aren't already. """
+
+    # Matrix from issue #9060
+    m = Matrix([[0.9, -0.1, -0.2, 0],[-0.8, 0.9, -0.4, 0],[-0.1, -0.8, 0.6, 0]])
+    m_rref = m.rref(iszerofunc=lambda x: abs(x)<6e-15)[0]
+    m_correct = Matrix([[1.0,   0, -0.301369863013699, 0],[  0, 1.0, -0.712328767123288, 0],[  0,   0,                  0, 0]])
+    m_diff = m_rref - m_correct
+    assert m_diff.norm() < 1e-15
+    # if a zero-substitution wasn't made, this entry will be -1.11022302462516e-16
+    assert m_rref[2,2] == 0
+
+
 @slow
 def test_issue_11238():
     from sympy import Point

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2766,3 +2766,19 @@ def test_partial_pivoting():
     # example from https://en.wikipedia.org/wiki/Pivot_element
     mm=Matrix([[0.003 ,59.14, 59.17],[ 5.291, -6.13,46.78]])
     assert mm.rref()[0] == Matrix([[1.0,   0, 10.0], [  0, 1.0,  1.0]])
+
+@slow
+def test_issue_11238():
+    from sympy import Point
+    xx = 8*tan(13*pi/45)/(tan(13*pi/45) + sqrt(3))
+    yy = (-8*sqrt(3)*tan(13*pi/45)**2 + 24*tan(13*pi/45))/(-3 + tan(13*pi/45)**2)
+    p1 = Point(0, 0)
+    p2 = Point(1, -sqrt(3))
+    p0 = Point(xx,yy)
+    m1 = Matrix([p1 - simplify(p0), p2 - simplify(p0)])
+    m2 = Matrix([p1 - p0, p2 - p0])
+    m3 = Matrix([simplify(p1 - p0), simplify(p2 - p0)])
+
+    assert m1.rank(simplify=True) == 1
+    assert m2.rank(simplify=True) == 1
+    assert m3.rank(simplify=True) == 1


### PR DESCRIPTION
This patch addresses issues #10718, #9480, #11434, #11238

Now, during row reduction, when searching for a pivot, all elements are checked using `is_zero`.  If an element is proved to be non-zero, then it is used as a pivot.  If no elements can be proved to be non-zero, elements are simplified to see if one can be proved to be non-zero.  If that fails, elements are compared with zero using `.equals(0)` (similarly to PR #11479).  Finally, if no suitable pivots are found (and it cannot be prove that they are all zero), an assumption is made that one of the undetermined elements is non-zero.

This patch also implements partial pivoting if all entries in a matrix column are floats.
