### PR TITLE
Added top-level docstring to euler.py

### DIFF
--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -1,3 +1,7 @@
+"""
+This module implements a method to find 
+Euler-Lagrange Equations for given Lagrangian.
+"""
 from itertools import combinations_with_replacement
 from sympy import Function, sympify, diff, Eq, S, Symbol, Derivative
 from sympy.core.compatibility import (iterable, range)

--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -1,5 +1,5 @@
 """
-This module implements a method to find 
+This module implements a method to find
 Euler-Lagrange Equations for given Lagrangian.
 """
 from itertools import combinations_with_replacement


### PR DESCRIPTION
Hello.

The top-level docstring for sympy/calculus/euler.py was missing.

This has been now added.

Thank you. 
