### PR TITLE
Explicitly set the Sphinx theme to classic

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -93,6 +93,8 @@ html_static_path = ['_static']
 # using the given strftime format.
 html_last_updated_fmt = '%b %d, %Y'
 
+html_theme = 'classic'
+
 html_logo = '_static/sympylogo.png'
 html_favicon = '../_build/logo/sympy-notailtext-favicon.ico'
 # See http://sphinx-doc.org/theming.html#builtin-themes.


### PR DESCRIPTION
Newer versions of Sphinx have changed the default theme to alabaster. Our docs
were still rendering mostly the same because we copied and modified the
classic theme css in the _static directory (to change the colors to green).
However, it was causing the top navigation bar to not appear, as alabaster
doesn't have it. 

This was only visible in the dev docs, as the release docs are pinned to build against Sphinx 1.1.3.

See http://stackoverflow.com/q/39262189/161801.
