### PR TITLE
Polynomials with no generators

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -4,7 +4,6 @@ from __future__ import print_function, division
 
 from sympy.polys.polyutils import parallel_dict_from_basic
 from sympy.polys.polyoptions import build_options
-from sympy.polys.polyerrors import GeneratorsNeeded
 from sympy.polys.domains import ZZ, QQ, RR, EX
 from sympy.polys.domains.realfield import RealField
 from sympy.utilities import public
@@ -116,9 +115,8 @@ def _construct_composite(coeffs, opt):
         numers.append(numer)
         denoms.append(denom)
 
-    try:
-        polys, gens = parallel_dict_from_basic(numers + denoms)  # XXX: sorting
-    except GeneratorsNeeded:
+    polys, gens = parallel_dict_from_basic(numers + denoms)  # XXX: sorting
+    if not gens:
         return None
 
     if opt.composite is None:

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -11,7 +11,6 @@ from sympy.polys.fields import field
 
 from sympy.polys.polyerrors import (
     UnificationFailed,
-    GeneratorsNeeded,
     GeneratorsError,
     CoercionFailed,
     NotInvertible,
@@ -483,11 +482,13 @@ def test_Domain_convert():
 
 
 def test_PolynomialRing__init():
-    raises(GeneratorsNeeded, lambda: ZZ.poly_ring())
+    R, = ring("", ZZ)
+    assert ZZ.poly_ring() == R.to_domain()
 
 
 def test_FractionField__init():
-    raises(GeneratorsNeeded, lambda: ZZ.frac_field())
+    F, = field("", ZZ)
+    assert ZZ.frac_field() == F.to_domain()
 
 
 def test_inject():

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4139,9 +4139,8 @@ def _poly_from_expr(expr, opt):
     elif opt.expand:
         expr = expr.expand()
 
-    try:
-        rep, opt = _dict_from_expr(expr, opt)
-    except GeneratorsNeeded:
+    rep, opt = _dict_from_expr(expr, opt)
+    if not opt.gens:
         raise PolificationFailed(opt, orig, expr)
 
     monoms, coeffs = list(zip(*list(rep.items())))
@@ -4218,9 +4217,8 @@ def _parallel_poly_from_expr(exprs, opt):
         for i in _polys:
             exprs[i] = exprs[i].as_expr()
 
-    try:
-        reps, opt = _parallel_dict_from_expr(exprs, opt)
-    except GeneratorsNeeded:
+    reps, opt = _parallel_dict_from_expr(exprs, opt)
+    if not opt.gens:
         raise PolificationFailed(opt, origs, exprs, True)
 
     for k in opt.gens:

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function, division
 
-from sympy.polys.polyerrors import PolynomialError, GeneratorsNeeded, GeneratorsError
+from sympy.polys.polyerrors import PolynomialError, GeneratorsError
 from sympy.polys.polyoptions import build_options
 
 from sympy.core.exprtools import decompose_power, decompose_power_rat
@@ -268,14 +268,6 @@ def _parallel_dict_from_expr_no_gens(exprs, opt):
             terms.append((coeff, elements))
 
         reprs.append(terms)
-
-    if not gens:
-        if len(exprs) == 1:
-            arg = exprs[0]
-        else:
-            arg = (exprs,)
-
-        raise GeneratorsNeeded("specify generators to give %s a meaning" % arg)
 
     gens = _sort_gens(gens, opt=opt)
     k, indices = len(gens), {}

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -388,7 +388,10 @@ class PolyRing(DefaultPrinting, IPolys):
     def index(self, gen):
         """Compute index of ``gen`` in ``self.gens``. """
         if gen is None:
-            i = 0
+            if self.ngens:
+                i = 0
+            else:
+                i = -1  # indicate impossible choice
         elif isinstance(gen, int):
             i = gen
 
@@ -874,10 +877,14 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     @property
     def is_squarefree(f):
+        if not f.ring.ngens:
+            return True
         return f.ring.dmp_sqf_p(f)
 
     @property
     def is_irreducible(f):
+        if not f.ring.ngens:
+            return True
         return f.ring.dmp_irreducible_p(f)
 
     @property
@@ -1601,6 +1608,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         if not f:
             return -oo
+        elif i < 0:
+            return 0
         else:
             return max([ monom[i] for monom in f.itermonoms() ])
 
@@ -1627,6 +1636,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
         if not f:
             return -oo
+        elif i < 0:
+            return 0
         else:
             return min([ monom[i] for monom in f.itermonoms() ])
 
@@ -1762,7 +1773,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         """
         p = self.ring.zero
         expv = self.leading_expv()
-        if expv:
+        if expv is not None:
             p[expv] = self[expv]
         return p
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -172,7 +172,7 @@ def sring(exprs, *symbols, **options):
 
 def _parse_symbols(symbols):
     if isinstance(symbols, string_types):
-        return _symbols(symbols, seq=True)
+        return _symbols(symbols, seq=True) if symbols else ()
     elif isinstance(symbols, Expr):
         return (symbols,)
     elif is_sequence(symbols):

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -215,14 +215,26 @@ class PolyRing(DefaultPrinting, IPolys):
 
             obj._one = [(obj.zero_monom, domain.one)]
 
-            codegen = MonomialOps(ngens)
-            obj.monomial_mul = codegen.mul()
-            obj.monomial_pow = codegen.pow()
-            obj.monomial_mulpow = codegen.mulpow()
-            obj.monomial_ldiv = codegen.ldiv()
-            obj.monomial_div = codegen.div()
-            obj.monomial_lcm = codegen.lcm()
-            obj.monomial_gcd = codegen.gcd()
+            if ngens:
+                # These expect monomials in at least one variable
+                codegen = MonomialOps(ngens)
+                obj.monomial_mul = codegen.mul()
+                obj.monomial_pow = codegen.pow()
+                obj.monomial_mulpow = codegen.mulpow()
+                obj.monomial_ldiv = codegen.ldiv()
+                obj.monomial_div = codegen.div()
+                obj.monomial_lcm = codegen.lcm()
+                obj.monomial_gcd = codegen.gcd()
+            else:
+                monunit = lambda a, b: ()
+                obj.monomial_mul = monunit
+                obj.monomial_pow = monunit
+                obj.monomial_mulpow = lambda a, b, c: ()
+                obj.monomial_ldiv = monunit
+                obj.monomial_div = monunit
+                obj.monomial_lcm = monunit
+                obj.monomial_gcd = monunit
+
 
             if order is lex:
                 obj.leading_expv = lambda f: max(f)

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -15,11 +15,15 @@ from sympy.polys.monomials import MonomialOps
 from sympy.polys.orderings import lex
 from sympy.polys.heuristicgcd import heugcd
 from sympy.polys.compatibility import IPolys
-from sympy.polys.polyutils import expr_from_dict, _dict_reorder, _parallel_dict_from_expr
-from sympy.polys.polyerrors import CoercionFailed, GeneratorsError, GeneratorsNeeded, ExactQuotientFailed, MultivariatePolynomialError
+from sympy.polys.polyutils import (expr_from_dict, _dict_reorder,
+                                   _parallel_dict_from_expr)
+from sympy.polys.polyerrors import (
+    CoercionFailed, GeneratorsError,
+    ExactQuotientFailed, MultivariatePolynomialError)
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.domains.polynomialring import PolynomialRing
-from sympy.polys.polyoptions import Domain as DomainOpt, Order as OrderOpt, build_options
+from sympy.polys.polyoptions import (Domain as DomainOpt,
+                                     Order as OrderOpt, build_options)
 from sympy.polys.densebasic import dmp_to_dict, dmp_from_dict
 from sympy.polys.constructor import construct_domain
 from sympy.printing.defaults import DefaultPrinting
@@ -167,9 +171,6 @@ def sring(exprs, *symbols, **options):
         return (_ring, polys)
 
 def _parse_symbols(symbols):
-    if not symbols:
-        raise GeneratorsNeeded("generators weren't specified")
-
     if isinstance(symbols, string_types):
         return _symbols(symbols, seq=True)
     elif isinstance(symbols, Expr):

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -230,7 +230,7 @@ def test__dict_from_expr_if_gens():
 
 
 def test__dict_from_expr_no_gens():
-    raises(GeneratorsNeeded, lambda: dict_from_expr(Integer(17)))
+    assert dict_from_expr(Integer(17)) == ({(): Integer(17)}, ())
 
     assert dict_from_expr(x) == ({(1,): Integer(1)}, (x,))
     assert dict_from_expr(y) == ({(1,): Integer(1)}, (y,))
@@ -240,7 +240,7 @@ def test__dict_from_expr_no_gens():
         x + y) == ({(1, 0): Integer(1), (0, 1): Integer(1)}, (x, y))
 
     assert dict_from_expr(sqrt(2)) == ({(1,): Integer(1)}, (sqrt(2),))
-    raises(GeneratorsNeeded, lambda: dict_from_expr(sqrt(2), greedy=False))
+    assert dict_from_expr(sqrt(2), greedy=False) == ({(): sqrt(2)}, ())
 
     assert dict_from_expr(x*y, domain=ZZ[x]) == ({(1,): x}, (y,))
     assert dict_from_expr(x*y, domain=ZZ[y]) == ({(1,): y}, (x,))

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -276,6 +276,10 @@ def test_PolyElement_from_expr():
     raises(ValueError, lambda: R.from_expr(2**x))
     raises(ValueError, lambda: R.from_expr(7*x + sqrt(2)))
 
+    R, = ring("", ZZ)
+    f = R.from_expr(1)
+    assert f == 1 and isinstance(f, R.dtype)
+
 def test_PolyElement_degree():
     R, x,y,z = ring("x,y,z", ZZ)
 
@@ -307,6 +311,10 @@ def test_PolyElement_degree():
     assert (x*y**3 + z).degree(z) == 1
     assert (7*x**5*y**3 + z).degree(z) == 1
 
+    R, = ring("", ZZ)
+    assert R(0).degree() == -oo
+    assert R(1).degree() == 0
+
 def test_PolyElement_tail_degree():
     R, x,y,z = ring("x,y,z", ZZ)
 
@@ -337,6 +345,10 @@ def test_PolyElement_tail_degree():
     assert (2*y**3 + x**3*z).tail_degree(z) == 0
     assert (x*y**3 + x**3*z).tail_degree(z) == 0
     assert (7*x**5*y**3 + x**3*z).tail_degree(z) == 0
+
+    R, = ring("", ZZ)
+    assert R(0).tail_degree() == -oo
+    assert R(1).tail_degree() == 0
 
 def test_PolyElement_degrees():
     R, x,y,z = ring("x,y,z", ZZ)
@@ -371,6 +383,9 @@ def test_PolyElement_coeff():
     raises(ValueError, lambda: f.coeff(-x*y*z))
     raises(ValueError, lambda: f.coeff(7*z**3))
 
+    R, = ring("", ZZ)
+    R(3).coeff(1) == 3
+
 def test_PolyElement_LC():
     R, x, y = ring("x,y", QQ, lex)
     assert R(0).LC == QQ(0)
@@ -388,6 +403,10 @@ def test_PolyElement_LT():
     assert R(0).LT == ((0, 0), QQ(0))
     assert (QQ(1,2)*x).LT == ((1, 0), QQ(1, 2))
     assert (QQ(1,4)*x*y + QQ(1,2)*x).LT == ((1, 1), QQ(1, 4))
+
+    R, = ring("", ZZ)
+    assert R(0).LT == ((), 0)
+    assert R(1).LT == ((), 1)
 
 def test_PolyElement_leading_monom():
     R, x, y = ring("x,y", QQ, lex)
@@ -809,6 +828,12 @@ def test_PolyElement_div():
     r = 2*x + 1
 
     assert f.div(G) == (Q, r)
+
+    R, = ring("", ZZ)
+    assert R(3).div(R(2)) == (0, 3)
+
+    R, = ring("", QQ)
+    assert R(3).div(R(2)) == (QQ(3, 2), 0)
 
 def test_PolyElement_rem():
     R, x = ring("x", ZZ, grlex)
@@ -1240,6 +1265,10 @@ def test_PolyElement_is_():
     assert (f + 1).is_cyclotomic is True
 
     raises(MultivariatePolynomialError, lambda: x.is_cyclotomic)
+
+    R, = ring("", ZZ)
+    assert R(4).is_squarefree is True
+    assert R(6).is_irreducible is True
 
 def test_PolyElement_drop():
     R, x,y,z = ring("x,y,z", ZZ)

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -21,8 +21,9 @@ def test_PolyRing___init__():
     assert len(PolyRing(x, ZZ, lex).gens) == 1
     assert len(PolyRing(("x", "y", "z"), ZZ, lex).gens) == 3
     assert len(PolyRing((x, y, z), ZZ, lex).gens) == 3
+    assert len(PolyRing("", ZZ, lex).gens) == 0
+    assert len(PolyRing([], ZZ, lex).gens) == 0
 
-    raises(GeneratorsNeeded, lambda: PolyRing([], ZZ, lex))
     raises(GeneratorsError, lambda: PolyRing(0, ZZ, lex))
 
     assert PolyRing("x", ZZ[t], lex).domain == ZZ[t]
@@ -79,6 +80,9 @@ def test_PolyRing_ring_new():
     assert R.ring_new({(2, 0, 0): 1, (1, 1, 0): 2, (1, 0, 0): 3, (0, 0, 2): 4, (0, 0, 1): 5, (0, 0, 0): 6}) == f
     assert R.ring_new([((2, 0, 0), 1), ((1, 1, 0), 2), ((1, 0, 0), 3), ((0, 0, 2), 4), ((0, 0, 1), 5), ((0, 0, 0), 6)]) == f
 
+    R, = ring("", QQ)
+    assert R.ring_new([((), 7)]) == R(7)
+
 def test_PolyRing_drop():
     R, x,y,z = ring("x,y,z", ZZ)
 
@@ -118,17 +122,30 @@ def test_PolyRing_is_():
     assert R.is_univariate is False
     assert R.is_multivariate is True
 
+    R = PolyRing("", QQ, lex)
+
+    assert R.is_univariate is False
+    assert R.is_multivariate is False
+
 def test_PolyRing_add():
     R, x = ring("x", ZZ)
     F = [ x**2 + 2*i + 3 for i in range(4) ]
 
     assert R.add(F) == reduce(add, F) == 4*x**2 + 24
 
+    R, = ring("", ZZ)
+
+    assert R.add([2, 5, 7]) == 14
+
 def test_PolyRing_mul():
     R, x = ring("x", ZZ)
     F = [ x**2 + 2*i + 3 for i in range(4) ]
 
     assert R.mul(F) == reduce(mul, F) == x**8 + 24*x**6 + 206*x**4 + 744*x**2 + 945
+
+    R, = ring("", ZZ)
+
+    assert R.mul([2, 3, 5]) == 30
 
 def test_sring():
     x, y, z, t = symbols("x,y,z,t")
@@ -151,6 +168,12 @@ def test_sring():
     Rt = FracField("t", ZZ, lex)
     R = PolyRing("x,y,z", Rt, lex)
     assert sring(x + 2*y/t + t**2*z/3, x, y, z) == (R, R.x + 2*R.y/Rt.t + Rt.t**2*R.z/3)
+
+    r = sqrt(2) - sqrt(3)
+    R, a = sring(r, extension=True)
+    assert R.domain == QQ.algebraic_field(r)
+    assert R.gens == ()
+    assert a == R.domain.from_sympy(r)
 
 def test_PolyElement___hash__():
     R, x, y, z = ring("x,y,z", QQ)
@@ -226,6 +249,9 @@ def test_PolyElement_as_expr():
     assert f.as_expr(X, Y, Z) == g
 
     raises(ValueError, lambda: f.as_expr(X))
+
+    R, = ring("", ZZ)
+    R(3).as_expr() == 3
 
 def test_PolyElement_from_expr():
     x, y, z = symbols("x,y,z")
@@ -391,6 +417,9 @@ def test_PolyElement_terms():
 
     assert f.terms() == f.terms(grlex) == f.terms('grlex') == [((1, 7), 1), ((2, 3), 2)]
     assert f.terms(lex) == f.terms('lex') == [((2, 3), 2), ((1, 7), 1)]
+
+    R, = ring("", ZZ)
+    assert R(3).terms() == [((), 3)]
 
 def test_PolyElement_monoms():
     R, x,y,z = ring("x,y,z", QQ)


### PR DESCRIPTION
The standard methods for the construction of polynomials, `.as_poly`
and `Poly`, are able to find the minimal coefficient domain for a
polynomial given as an expression. However, they can only be used
in case there is at least one independent generator because the
representation they create, the 'dense' polynomial, is a nested list
of lists whose depth is the number of generators. Otherwise, a dummy
temporary generator has to be added for the construction of the
coefficient domain.

The representation of 'sparse' polynomials is different. It is a
dictionary whose keys are monomials of the polynomial ring.
The monomials are tuples of integers, one for each generator. The
empty tuple can be used to represent the unit monomial of
a polynomial ring with no generators.

This PR implements sparse polynomial rings with no generators. They are
not intended for practical use, only for convenient construction of
coefficient domains. In fact, such polynomial rings are isomorphic
to their coefficient domains, and therefore not needed for other
purposes.

The construction of both dense and sparse polynomials makes use of the
same routines at the lowest level. They currently raise a
`GeneratorsNeeded` exception if no generators are found. To allow
the construction of sparse polynomials with no generators, these
routines have been modified to return the tuple of generators even
if there are none. An exception is raised only when a dense polynomial
construction is attempted.
