### PR TITLE
Added sympify translators for basic numpy datatypes(Fixes #11086)

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -267,7 +267,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         pass
 
     if not isinstance(a, string_types):
-        for coerce in (float, int):
+        for coerce in (int, float):
             try:
                 return sympify(coerce(a))
             except (TypeError, ValueError, AttributeError, SympifyError):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -266,8 +266,20 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     except AttributeError:
         pass
 
+
+    #Support for basic numpy datatypes
+    if type(a).__module__ == 'numpy':
+        import numpy as np
+        try:
+            return sympify(np.asscalar(a))
+        except RuntimeError:
+            return sympify(np.float64(a))
+            #Exception case is for float128 which
+            #has no native python equivalent
+
+
     if not isinstance(a, string_types):
-        for coerce in (int, float):
+        for coerce in (float, int):
             try:
                 return sympify(coerce(a))
             except (TypeError, ValueError, AttributeError, SympifyError):
@@ -290,6 +302,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         except TypeError:
             # Not all iterables are rebuildable with their type.
             pass
+
 
     # At this point we were given an arbitrary expression
     # which does not inherit from Basic and doesn't implement
@@ -324,6 +337,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         raise SympifyError('could not parse %r' % a, exc)
 
     return expr
+
+
+#def numpy_to_sympy(a):
 
 
 def _sympify(a):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -339,9 +339,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     return expr
 
 
-#def numpy_to_sympy(a):
-
-
 def _sympify(a):
     """
     Short version of sympify for internal usage for __add__ and __eq__ methods

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -267,7 +267,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         pass
 
 
-    #Support for basic numpy datatypes
+    #Support for basic numpy datatypes.
     if type(a).__module__ == 'numpy':
         import numpy as np
         try:
@@ -275,7 +275,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         except RuntimeError:
             return sympify(np.float64(a))
             #Exception case is for float128 which
-            #has no native python equivalent
+            #has no native python equivalent.
 
 
     if not isinstance(a, string_types):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -267,15 +267,16 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         pass
 
 
-    #Support for basic numpy datatypes
+    #Support for basic numpy datatypes.
     if type(a).__module__ == 'numpy':
-        import numpy as np
-        try:
-            return sympify(np.asscalar(a))
-        except RuntimeError:
-            return sympify(np.float64(a))
-            #Exception case is for float128 which
-            #has no native python equivalent
+        import numpy
+        if(numpy.isscalar(a)):  
+            try:
+                return sympify(numpy.asscalar(a))
+            except RuntimeError:
+                return sympify(numpy.float64(a))
+                #Exception case is for float128 which
+                #has no native python equivalent.
 
 
     if not isinstance(a, string_types):

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -512,6 +512,30 @@ def test_sympify_set():
     assert sympify(set()) == EmptySet()
 
 
+def test_numpy():
+    try:
+        import numpy as np
+
+        assert sympify(np.bool_(1)) == True
+        assert sympify(np.int_(123)) == np.int_(123)
+        assert sympify(np.intc(123)) == np.intc(123)
+        assert sympify(np.intp(123)) == np.intp(123)
+        assert sympify(np.int8(-123)) == np.int8(-123)
+        assert sympify(np.int16(-123)) == np.int16(-123)
+        assert sympify(np.int32(123)) == np.int32(123)
+        assert sympify(np.int64(123)) == np.int64(123)
+        assert sympify(np.uint8(123)) == np.uint8(123)
+        assert sympify(np.uint16(1234)) == np.uint16(1234)
+        assert sympify(np.uint32(1234)) == np.uint32(1234)
+        assert sympify(np.uint64(1234)) == np.uint64(1234)
+        assert sympify(np.float16(1234.12)) == np.float16(1234.12)
+        assert sympify(np.float32(1234.1234)) == np.float32(1234.1234)
+        assert sympify(np.float64(1234.12345)) == np.float64(1234.12345)
+        assert sympify(np.complex64(1 + 2j)) == 1.0 + 2.0*I
+        assert sympify(np.complex128(1 + 2j)) == 1.0 + 2.0*I
+    except ImportError:
+        print('numpy not installed.Abort numpy tests.')
+
 @XFAIL
 def test_sympify_rational_numbers_set():
     ans = [Rational(3, 10), Rational(1, 5)]


### PR DESCRIPTION
This is reference to [#11086](https://github.com/sympy/sympy/issues/11086)

Previously for 64-bit systems running Python 3.x numpy's int64 was converted into float.This fix converts it to 'int'.

UPDATE : sympify translators for basic numpy datatypes have been added.Unit tests have also been written.

Previously :

```
import numpy as np
import sympy as sp

x = sp.symbols('x')
print(x * 1)
print(x * np.int64(1))

```

Output : 

```
x
1.0*x

```

```
With the fix : 
import numpy as np
import sympy as sp

x = sp.symbols('x')
print(x * 1)
print(x * np.int64(1))
```

Output : 

```
x
x
```
