### PR TITLE
TensorProduct: Associativity of the tensor product

### DIFF
--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -121,12 +121,23 @@ class TensorProduct(Expr):
             return matrix_tensor_product(*args)
         c_part, new_args = cls.flatten(sympify(args))
         c_part = Mul(*c_part)
+
         if len(new_args) == 0:
             return c_part
         elif len(new_args) == 1:
             return c_part * new_args[0]
         else:
-            tp = Expr.__new__(cls, *new_args)
+            # Making the TensorProduct associative.
+            flat_args = []
+            for n_arg in new_args:
+                if isinstance(n_arg, TensorProduct):
+                    new_c_part, new_new_args = n_arg.flatten(sympify(n_arg.args))
+                    new_c_part = Mul(*new_c_part)
+                    c_part = c_part*new_c_part
+                    flat_args = flat_args + new_new_args
+                else:
+                    flat_args.append(n_arg)
+            tp = Expr.__new__(cls, *flat_args)
             return c_part * tp
 
     @classmethod

--- a/sympy/physics/quantum/tests/test_tensorproduct.py
+++ b/sympy/physics/quantum/tests/test_tensorproduct.py
@@ -48,6 +48,10 @@ def test_tensor_product_commutator():
 def test_tensor_product_simp():
     assert tensor_product_simp(TP(A, B)*TP(B, C)) == TP(A*B, B*C)
 
+def test_tensor_product_associativity():
+    assert TP(TP(A,B),C) == TP(A,B,C)
+    assert TP(A,TP(B,C)) == TP(A,B,C)
+
 
 def test_issue_5923():
     # most of the issue regarding sympification of args has been handled


### PR DESCRIPTION
 In several applications of the tensor product, one mathematical object can be
decomposed as a tensor product of sub-parts (for example spinors on product
spaces).

However, previous to this commit, the following happened

```
In [1]: from sympy import symbols, srepr

In [2]: from sympy.physics.quantum import TensorProduct as TP

In [3]: A,B,C = symbols('A,B,C', commutative = False)

In [4]: TP(A,B,C)
Out[4]: AxBxC

In [5]: srepr(TP(A,B,C))
Out[5]: "TensorProduct(Symbol('A', commutative=False), Symbol('B',
    commutative=False), Symbol('C', commutative=False))"

In [9]: TP(TP(A,B),C)
Out[9]: AxBxC

In [10]: srepr(TP(TP(A,B),C))
Out[10]: "TensorProduct(TensorProduct(Symbol('A', commutative=False),
     Symbol('B', commutative=False)), Symbol('C', commutative=False))"
```

The TP(TP(A,B),C) illustrates some object that has been decompused as TP(A,B),
but it does not produce the same output -- that is, the implementation of
TensorProduct is not associative. But the mathematical tensor product is.

The above also causes a problem during multiplication: TP(TP(A,B),C) *
TP(A,B,C) cannot be carried out because of the apparent different tensor
product decompositions.

 This commit instead gives

```
In [1]: from sympy import symbols

In [2]: from sympy.physics.quantum import TensorProduct as TP

In [3]: A,B,C = symbols('A,B,C', commutative = False)

In [4]: TP(A,B,C) == TP(TP(A,B),C)
Out[4]: True

In [5]: TP(A,B,C) == TP(A,TP(B,C))
Out[5]: True
```

That is, the TensorProduct is now associative.
