### PR TITLE
Use discrete_log in nthroot_mod

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -724,15 +724,7 @@ def _nthroot_mod1(s, q, p, all_roots):
         s1 = pow(s, f, p)
         y = pow(g, f, p)
         h = pow(g, f*q, p)
-        # find t discrete log of s1 base h, h**x = s1 mod p
-        # used a naive implementation
-        # TODO implement using Ref [1]
-        pr = 1
-        for t in range(p):
-            if pr == s1:
-                break
-            pr = pr*h % p
-
+        t = discrete_log(p, s1, h)
         g2 = pow(g, z*t, p)
         g3 = igcdex(g2, p)[0]
         r = r1*g3 % p


### PR DESCRIPTION
Instead of using the naive implementation, now we should use the
recently added discrete_log (sympy/sympy#11546).
