### PR TITLE
 matrices : Matrix ** exponent stays unevaluated for non-integer exponents

### DIFF
--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -67,7 +67,10 @@ class MatPow(MatrixExpr):
         elif isinstance(base, MatrixBase) and exp.is_number:
             if exp is S.One:
                 return base
-            return base**exp
+            return base.evaluate_power(exp)
+        from sympy.core import Symbol
+        if isinstance(base, MatrixBase) and type(exp) == type(Symbol('test_symbol')):
+            return base.evaluate_power(exp)
         # Note: just evaluate cases we know, return unevaluated on others.
         # E.g., MatrixSymbol('x', n, m) to power 0 is not an error.
         elif exp is S.One:

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -43,7 +43,7 @@ def test_as_explicit():
     assert MatPow(A, -2).as_explicit() == (A.inv())**2
     # less expensive than testing on a 2x2
     A = ImmutableMatrix([4]);
-    assert MatPow(A, S.Half).as_explicit() == A**S.Half
+    assert MatPow(A, S.Half).as_explicit() == (A**S.Half).doit()
 
 
 def test_as_explicit_nonsquare():

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -185,11 +185,9 @@ class MatrixBase(object):
 
     def __neg__(self):
         return -1*self
-
-    def __pow__(self, num):
+    def evaluate_power(self,num):
         from sympy.matrices import eye, diag, MutableMatrix
         from sympy import binomial
-
         if not self.is_square:
             raise NonSquareMatrixError()
         if isinstance(num, int) or isinstance(num, Integer):
@@ -208,16 +206,15 @@ class MatrixBase(object):
                 n //= 2
             return self._new(a)
         elif isinstance(num, (Expr, float)):
-
             def jordan_cell_power(jc, n):
                 N = jc.shape[0]
                 l = jc[0, 0]
                 for i in range(N):
-                        for j in range(N-i):
-                                bn = binomial(n, i)
-                                if isinstance(bn, binomial):
-                                        bn = bn._eval_expand_func()
-                                jc[j, i+j] = l**(n-i)*bn
+                    for j in range(N-i):
+                        bn = binomial(n, i)
+                        if isinstance(bn, binomial):
+                            bn = bn._eval_expand_func()
+                        jc[j, i+j] = l**(n-i)*bn
 
             P, jordan_cells = self.jordan_cells()
             # Make sure jordan_cells matrices are mutable:
@@ -226,9 +223,19 @@ class MatrixBase(object):
                 jordan_cell_power(j, num)
             return self._new(P*diag(*jordan_cells)*P.inv())
         else:
-            raise TypeError(
-                "Only SymPy expressions or int objects are supported as exponent for matrices")
-
+            raise TypeError("Only SymPy expressions or int objects are supported as exponent for matrices")
+    def __pow__(self, num):
+        sympy_type = type(sympify(num))
+        if(sympy_type == type(sympify(0))):
+            from sympy.matrices import eye
+            return eye(self.cols)
+        elif(sympy_type == type(sympify(1))):
+            return self
+        elif(sympy_type != type(sympify(2)) and sympy_type != type(sympify(-1))):
+            from sympy.matrices.expressions.matpow import MatPow
+            return MatPow(self,num)
+        else:
+            return self.evaluate_power(num)
     def __radd__(self, other):
         return self + other
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -196,20 +196,20 @@ def test_power():
     assert Matrix([[1, 2], [3, 4]])**Integer(2) == Matrix([[7, 10], [15, 22]])
 
     A = Matrix([[33, 24], [48, 57]])
-    assert (A**(S(1)/2))[:] == [5, 2, 4, 7]
+    assert ( (A**(S(1)/2)).doit() )[:] == [5, 2, 4, 7]
     A = Matrix([[0, 4], [-1, 5]])
-    assert (A**(S(1)/2))**2 == A
+    assert ((A**(S(1)/2))**2).doit() == A
 
-    assert Matrix([[1, 0], [1, 1]])**(S(1)/2) == Matrix([[1, 0], [S.Half, 1]])
-    assert Matrix([[1, 0], [1, 1]])**0.5 == Matrix([[1.0, 0], [0.5, 1.0]])
+    assert (Matrix([[1, 0], [1, 1]])**(S(1)/2)).doit() == Matrix([[1, 0], [S.Half, 1]])
+    assert (Matrix([[1, 0], [1, 1]])**0.5).doit() == Matrix([[1.0, 0], [0.5, 1.0]])
     from sympy.abc import a, b, n
-    assert Matrix([[1, a], [0, 1]])**n == Matrix([[1, a*n], [0, 1]])
-    assert Matrix([[b, a], [0, b]])**n == Matrix([[b**n, a*b**(n-1)*n], [0, b**n]])
-    assert Matrix([[a, 1, 0], [0, a, 1], [0, 0, a]])**n == Matrix([
+    assert (Matrix([[1, a], [0, 1]])**n).doit() == Matrix([[1, a*n], [0, 1]])
+    assert (Matrix([[b, a], [0, b]])**n).doit() == Matrix([[b**n, a*b**(n-1)*n], [0, b**n]])
+    assert (Matrix([[a, 1, 0], [0, a, 1], [0, 0, a]])**n).doit() == Matrix([
         [a**n, a**(n-1)*n, a**(n-2)*(n-1)*n/2],
         [0, a**n, a**(n-1)*n],
         [0, 0, a**n]])
-    assert Matrix([[a, 1, 0], [0, a, 0], [0, 0, b]])**n == Matrix([
+    assert (Matrix([[a, 1, 0], [0, a, 0], [0, 0, b]])**n).doit() == Matrix([
         [a**n, a**(n-1)*n, 0],
         [0, a**n, 0],
         [0, 0, b**n]])

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -318,5 +318,5 @@ def fidelity(state1, state2):
         raise ValueError("The dimensions of both args should be equal and the "
                          "matrix obtained should be a square matrix")
 
-    sqrt_state1 = state1**Rational(1, 2)
-    return Tr((sqrt_state1 * state2 * sqrt_state1)**Rational(1, 2)).doit()
+    sqrt_state1 = (state1**Rational(1, 2)).doit()
+    return Tr( ((sqrt_state1 * state2 * sqrt_state1)**Rational(1, 2)).doit() ).doit()


### PR DESCRIPTION
 matrices:Matrix**exponent stays unevaluated for non-integer exponent

If exponent can be sympified to a sympy integer then matrix**exponent
is evaluated by default.Otherwise , it is stored in a MatPow object
and can be evaluated by calling the doit() method.

Some changes have also been done to other test functions which
earlier evaluated Rational and symbolic exponents by default.

Another new feature has been added : doit() on a MatPow object
evaluates for symbolic exponents as well.
Fix for : #11557 
