### PR TITLE
Better docstring for the output of Matrix.rref()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4083,6 +4083,13 @@ class MatrixBase(object):
         (Matrix([
         [1, 0],
         [0, 1]]), [0, 1])
+        >>> rref_matrix, rref_pivots = m.rref()
+        >>> rref_matrix
+        Matrix([
+        [1, 0],
+        [0, 1]])
+        >>> rref_pivots
+        [0, 1]
         """
         simpfunc = simplify if isinstance(
             simplify, FunctionType) else _simplify


### PR DESCRIPTION
Fixes #11597 

A small addition to the docstring of rref() in order to explain clearly how to grab the echelon form of a matrix and the pivots separately.
