### PR TITLE
matrices:Matrix**exponent stays unevaluated for non-integer exponent

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -134,15 +134,9 @@ class MatrixExpr(Basic):
         elif other is S.One:
             return self
 
-<<<<<<< Updated upstream
-        if(isinstance(self,MatPow)):
-            new_exp = sympify(self.exp * other)
-            if(isinstance(new_exp, Integer)):
-=======
         if isinstance(self,MatPow):
             new_exp = sympify(self.exp * other)
             if isinstance(new_exp, Integer):
->>>>>>> Stashed changes
                 return self.args[0] ** new_exp
             else:
                 return MatPow(self.args[0],new_exp)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -134,9 +134,15 @@ class MatrixExpr(Basic):
         elif other is S.One:
             return self
 
+<<<<<<< Updated upstream
         if(isinstance(self,MatPow)):
             new_exp = sympify(self.exp * other)
             if(isinstance(new_exp, Integer)):
+=======
+        if isinstance(self,MatPow):
+            new_exp = sympify(self.exp * other)
+            if isinstance(new_exp, Integer):
+>>>>>>> Stashed changes
                 return self.args[0] ** new_exp
             else:
                 return MatPow(self.args[0],new_exp)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -127,14 +127,14 @@ class MatrixExpr(Basic):
             raise ShapeError("Power of non-square matrix %s" % self)
         elif self.is_Identity:
             return self
-        elif other is S.NegativeOne and not isinstance(self,MatPow):
+        elif other is S.NegativeOne and not isinstance(self, MatPow):
             return Inverse(self)
         elif other is S.Zero:
             return Identity(self.rows)
         elif other is S.One:
             return self
 
-        if isinstance(self,MatPow):
+        if isinstance(self, MatPow):
             new_exp = sympify(self.exp * other)
             if isinstance(new_exp, Integer):
                 return self.args[0] ** new_exp

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -133,6 +133,14 @@ class MatrixExpr(Basic):
             return Identity(self.rows)
         elif other is S.One:
             return self
+
+        if(isinstance(self,MatPow)):
+            new_exp = sympify(self.exp * other)
+            if(isinstance(new_exp, Integer)):
+                return self.args[0] ** new_exp
+            else:
+                return MatPow(self.args[0],new_exp)
+
         return MatPow(self, other)
 
     @_sympifyit('other', NotImplemented)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -127,7 +127,7 @@ class MatrixExpr(Basic):
             raise ShapeError("Power of non-square matrix %s" % self)
         elif self.is_Identity:
             return self
-        elif other is S.NegativeOne:
+        elif other is S.NegativeOne and not isinstance(self,MatPow):
             return Inverse(self)
         elif other is S.Zero:
             return Identity(self.rows)

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -67,17 +67,10 @@ class MatPow(MatrixExpr):
         elif isinstance(base, MatrixBase) and exp.is_number:
             if exp is S.One:
                 return base
-<<<<<<< Updated upstream
-            return base.evaluate_power(exp)
-        from sympy.core import Symbol
-        if(isinstance(base,MatrixBase) and isinstance(exp,Symbol)):
-            return base.evaluate_power(exp)
-=======
             return MatrixBase._eval_power(base,exp)
         from sympy.core import Symbol
         if isinstance(base,MatrixBase) and isinstance(exp,Symbol):
             return MatrixBase._eval_power(base,exp)
->>>>>>> Stashed changes
         # Note: just evaluate cases we know, return unevaluated on others.
         # E.g., MatrixSymbol('x', n, m) to power 0 is not an error.
         elif exp is S.One:

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -67,7 +67,10 @@ class MatPow(MatrixExpr):
         elif isinstance(base, MatrixBase) and exp.is_number:
             if exp is S.One:
                 return base
-            return base**exp
+            return base.evaluate_power(exp)
+        from sympy.core import Symbol
+        if(isinstance(base,MatrixBase) and isinstance(exp,Symbol)):
+            return base.evaluate_power(exp)
         # Note: just evaluate cases we know, return unevaluated on others.
         # E.g., MatrixSymbol('x', n, m) to power 0 is not an error.
         elif exp is S.One:

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -67,10 +67,17 @@ class MatPow(MatrixExpr):
         elif isinstance(base, MatrixBase) and exp.is_number:
             if exp is S.One:
                 return base
+<<<<<<< Updated upstream
             return base.evaluate_power(exp)
         from sympy.core import Symbol
         if(isinstance(base,MatrixBase) and isinstance(exp,Symbol)):
             return base.evaluate_power(exp)
+=======
+            return MatrixBase._eval_power(base,exp)
+        from sympy.core import Symbol
+        if isinstance(base,MatrixBase) and isinstance(exp,Symbol):
+            return MatrixBase._eval_power(base,exp)
+>>>>>>> Stashed changes
         # Note: just evaluate cases we know, return unevaluated on others.
         # E.g., MatrixSymbol('x', n, m) to power 0 is not an error.
         elif exp is S.One:

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -43,7 +43,7 @@ def test_as_explicit():
     assert MatPow(A, -2).as_explicit() == (A.inv())**2
     # less expensive than testing on a 2x2
     A = ImmutableMatrix([4]);
-    assert MatPow(A, S.Half).as_explicit() == (A**S.Half ).doit()
+    assert MatPow(A, S.Half).as_explicit() == (A**S.Half).doit()
 
 
 def test_as_explicit_nonsquare():

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -43,7 +43,7 @@ def test_as_explicit():
     assert MatPow(A, -2).as_explicit() == (A.inv())**2
     # less expensive than testing on a 2x2
     A = ImmutableMatrix([4]);
-    assert MatPow(A, S.Half).as_explicit() == A**S.Half
+    assert MatPow(A, S.Half).as_explicit() == (A**S.Half).doit()
 
 
 def test_as_explicit_nonsquare():

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -43,7 +43,7 @@ def test_as_explicit():
     assert MatPow(A, -2).as_explicit() == (A.inv())**2
     # less expensive than testing on a 2x2
     A = ImmutableMatrix([4]);
-    assert MatPow(A, S.Half).as_explicit() == (A**S.Half).doit()
+    assert MatPow(A, S.Half).as_explicit() == (A**S.Half ).doit()
 
 
 def test_as_explicit_nonsquare():

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -186,7 +186,11 @@ class MatrixBase(object):
     def __neg__(self):
         return -1*self
 
+<<<<<<< Updated upstream
     def evaluate_power(self,num):
+=======
+    def _eval_power(self,num):
+>>>>>>> Stashed changes
         from sympy.matrices import eye, diag, MutableMatrix
         from sympy import binomial
         if not self.is_square:
@@ -227,6 +231,7 @@ class MatrixBase(object):
             raise TypeError("Only SymPy expressions or int objects are supported as exponent for matrices")
 
     def __pow__(self, num):
+<<<<<<< Updated upstream
         sympy_type = type(sympify(num))
         if(sympy_type == type(sympify(0))):
             from sympy.matrices import eye
@@ -238,6 +243,19 @@ class MatrixBase(object):
             return MatPow(self,num)
         else:
             return self.evaluate_power(num)
+=======
+        sympy_num = sympify(num)
+        if sympy_num is S.Zero:
+            from sympy.matrices import eye
+            return eye(self.cols)
+        elif sympy_num is S.One:
+            return self
+        elif not isinstance(sympy_num,Integer) and sympy_num is not S.NegativeOne:
+            from sympy.matrices.expressions.matpow import MatPow
+            return MatPow(self,num)
+        else:
+            return MatrixBase._eval_power(self,num)
+>>>>>>> Stashed changes
 
     def __radd__(self, other):
         return self + other
@@ -4093,13 +4111,6 @@ class MatrixBase(object):
         (Matrix([
         [1, 0],
         [0, 1]]), [0, 1])
-        >>> rref_matrix, rref_pivots = m.rref()
-        >>> rref_matrix
-        Matrix([
-        [1, 0],
-        [0, 1]])
-        >>> rref_pivots
-        [0, 1]
         """
         simpfunc = simplify if isinstance(
             simplify, FunctionType) else _simplify

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -231,19 +231,6 @@ class MatrixBase(object):
             raise TypeError("Only SymPy expressions or int objects are supported as exponent for matrices")
 
     def __pow__(self, num):
-<<<<<<< Updated upstream
-        sympy_type = type(sympify(num))
-        if(sympy_type == type(sympify(0))):
-            from sympy.matrices import eye
-            return eye(self.cols)
-        elif(sympy_type == type(sympify(1))):
-            return self
-        elif(sympy_type != type(sympify(2)) and sympy_type != type(sympify(-1))):
-            from sympy.matrices.expressions.matpow import MatPow
-            return MatPow(self,num)
-        else:
-            return self.evaluate_power(num)
-=======
         sympy_num = sympify(num)
         if sympy_num is S.Zero:
             from sympy.matrices import eye
@@ -255,7 +242,6 @@ class MatrixBase(object):
             return MatPow(self,num)
         else:
             return MatrixBase._eval_power(self,num)
->>>>>>> Stashed changes
 
     def __radd__(self, other):
         return self + other

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -211,7 +211,7 @@ class MatrixBase(object):
                 N = jc.shape[0]
                 l = jc[0, 0]
                 for i in range(N):
-                    for j in range(N-i):
+                    for j in range(N - i):
                         bn = binomial(n, i)
                         if isinstance(bn, binomial):
                             bn = bn._eval_expand_func()
@@ -224,7 +224,7 @@ class MatrixBase(object):
                 jordan_cell_power(j, num)
             return self._new(P*diag(*jordan_cells)*P.inv())
         else:
-            raise TypeError("Only SymPy expressions or int objects are supported as exponent for matrices")
+            raise TypeError("Only SymPy expressions or int objects are supported as matrix exponents")
 
     def __pow__(self, num):
         sympy_num = sympify(num)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -186,11 +186,7 @@ class MatrixBase(object):
     def __neg__(self):
         return -1*self
 
-<<<<<<< Updated upstream
-    def evaluate_power(self,num):
-=======
     def _eval_power(self,num):
->>>>>>> Stashed changes
         from sympy.matrices import eye, diag, MutableMatrix
         from sympy import binomial
         if not self.is_square:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -196,24 +196,29 @@ def test_power():
     assert Matrix([[1, 2], [3, 4]])**Integer(2) == Matrix([[7, 10], [15, 22]])
 
     A = Matrix([[33, 24], [48, 57]])
-    assert (A**(S(1)/2))[:] == [5, 2, 4, 7]
+    assert ((A**(S(1)/2)).doit())[:] == [5, 2, 4, 7]
     A = Matrix([[0, 4], [-1, 5]])
     assert (A**(S(1)/2))**2 == A
 
-    assert Matrix([[1, 0], [1, 1]])**(S(1)/2) == Matrix([[1, 0], [S.Half, 1]])
-    assert Matrix([[1, 0], [1, 1]])**0.5 == Matrix([[1.0, 0], [0.5, 1.0]])
+    assert (Matrix([[1, 0], [1, 1]])**(S(1)/2)).doit() == Matrix([[1, 0], [S.Half, 1]])
+    assert (Matrix([[1, 0], [1, 1]])**0.5).doit() == Matrix([[1.0, 0], [0.5, 1.0]])
     from sympy.abc import a, b, n
-    assert Matrix([[1, a], [0, 1]])**n == Matrix([[1, a*n], [0, 1]])
-    assert Matrix([[b, a], [0, b]])**n == Matrix([[b**n, a*b**(n-1)*n], [0, b**n]])
-    assert Matrix([[a, 1, 0], [0, a, 1], [0, 0, a]])**n == Matrix([
+    assert (Matrix([[1, a], [0, 1]])**n).doit() == Matrix([[1, a*n], [0, 1]])
+    assert (Matrix([[b, a], [0, b]])**n).doit() == Matrix([[b**n, a*b**(n-1)*n], [0, b**n]])
+    assert (Matrix([[a, 1, 0], [0, a, 1], [0, 0, a]])**n).doit() == Matrix([
         [a**n, a**(n-1)*n, a**(n-2)*(n-1)*n/2],
         [0, a**n, a**(n-1)*n],
         [0, 0, a**n]])
-    assert Matrix([[a, 1, 0], [0, a, 0], [0, 0, b]])**n == Matrix([
+    assert (Matrix([[a, 1, 0], [0, a, 0], [0, 0, b]])**n).doit() == Matrix([
         [a**n, a**(n-1)*n, 0],
         [0, a**n, 0],
         [0, 0, b**n]])
-
+    
+    assert (A**2)**3 == A**6
+    assert (A**(S(2)/3))**6 == A**4
+    assert (A**(S(3)/4))**(S(4)/3) == A
+    assert (A**(1/n))**n == A
+    assert (A**(a/n))**(b*n) == A**(a*b)
 
 def test_creation():
     raises(ValueError, lambda: Matrix(5, 5, range(20)))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -196,7 +196,7 @@ def test_power():
     assert Matrix([[1, 2], [3, 4]])**Integer(2) == Matrix([[7, 10], [15, 22]])
 
     A = Matrix([[33, 24], [48, 57]])
-    assert ( (A**(S(1)/2)).doit() )[:] == [5, 2, 4, 7]
+    assert ((A**(S(1)/2)).doit())[:] == [5, 2, 4, 7]
     A = Matrix([[0, 4], [-1, 5]])
     assert ((A**(S(1)/2))**2).doit() == A
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -213,7 +213,7 @@ def test_power():
         [a**n, a**(n-1)*n, 0],
         [0, a**n, 0],
         [0, 0, b**n]])
-    
+
     assert (A**2)**3 == A**6
     assert (A**(S(2)/3))**6 == A**4
     assert (A**(S(3)/4))**(S(4)/3) == A

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -196,9 +196,13 @@ def test_power():
     assert Matrix([[1, 2], [3, 4]])**Integer(2) == Matrix([[7, 10], [15, 22]])
 
     A = Matrix([[33, 24], [48, 57]])
+<<<<<<< Updated upstream
     assert ((A**(S(1)/2)).doit())[:] == [5, 2, 4, 7]
+=======
+    assert ( (A**(S(1)/2)).doit() )[:] == [5, 2, 4, 7]
+>>>>>>> Stashed changes
     A = Matrix([[0, 4], [-1, 5]])
-    assert (A**(S(1)/2))**2 == A
+    assert ((A**(S(1)/2))**2).doit() == A
 
     assert (Matrix([[1, 0], [1, 1]])**(S(1)/2)).doit() == Matrix([[1, 0], [S.Half, 1]])
     assert (Matrix([[1, 0], [1, 1]])**0.5).doit() == Matrix([[1.0, 0], [0.5, 1.0]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -196,11 +196,7 @@ def test_power():
     assert Matrix([[1, 2], [3, 4]])**Integer(2) == Matrix([[7, 10], [15, 22]])
 
     A = Matrix([[33, 24], [48, 57]])
-<<<<<<< Updated upstream
-    assert ((A**(S(1)/2)).doit())[:] == [5, 2, 4, 7]
-=======
     assert ( (A**(S(1)/2)).doit() )[:] == [5, 2, 4, 7]
->>>>>>> Stashed changes
     A = Matrix([[0, 4], [-1, 5]])
     assert ((A**(S(1)/2))**2).doit() == A
 

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -318,5 +318,5 @@ def fidelity(state1, state2):
         raise ValueError("The dimensions of both args should be equal and the "
                          "matrix obtained should be a square matrix")
 
-    sqrt_state1 = state1**Rational(1, 2)
-    return Tr((sqrt_state1 * state2 * sqrt_state1)**Rational(1, 2)).doit()
+    sqrt_state1 = (state1**Rational(1, 2)).doit()
+    return Tr( ((sqrt_state1 * state2 * sqrt_state1)**Rational(1, 2)).doit() ).doit()

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -319,4 +319,4 @@ def fidelity(state1, state2):
                          "matrix obtained should be a square matrix")
 
     sqrt_state1 = (state1**Rational(1, 2)).doit()
-    return Tr( ((sqrt_state1 * state2 * sqrt_state1)**Rational(1, 2)).doit() ).doit()
+    return Tr(((sqrt_state1 * state2 * sqrt_state1)**Rational(1, 2)).doit()).doit()


### PR DESCRIPTION
If exponent can be sympified to a sympy integer then matrix**exponent
is evaluated by default.Otherwise , it is stored in a MatPow object
and can be evaluated by calling the doit() method.
1. Some changes have also been done to other test functions which
   earlier evaluated Rational and symbolic exponents by default.

2.doit() on a MatPow object evaluates for symbolic exponents as well.

3.If the total exponent is an integer then MatPow object is not returned ::
-  `(A ** (S(1)/2))**3 --> MatPow(A,S(1)/2)` is first created.Since clubbing together exponents results in 3/2 , final result returned is `MatPow(A,S(3)/2)`. 
-  `(A ** (S(1)/3))**6 --> MatPow(A,S(1)/3)` is first created.Since clubbing together exponents results in 2 , final result returned is`A ^ 2` (evaluated form).

Reference : #11557 
