### PR TITLE
Drastically improving the performance of `diop_DN` by implementing `special_diop_DN`

### DIFF
--- a/sympy/solvers/diophantine.py
+++ b/sympy/solvers/diophantine.py
@@ -1193,30 +1193,40 @@ def special_diop_DN(D, N):
     It is better to call `diop_DN` rather than this function, as
     the former checks the condition `N**2 < D`, and calls the latter only
     if appropriate.
+
     Usage
     =====
-    ``special_diop_DN(D, N, t)``: D and N are integers as in `x^2 - Dy^2 = N`.
+
+    ``special_diop_DN(D, N)``: D and N are integers as in `x^2 - Dy^2 = N`.
+
     Details
     =======
+
     ``D`` and ``N`` correspond to D and N in the equation.
+
     Examples
     ========
+
     >>> from sympy.solvers.diophantine import special_diop_DN
-    >>> special_diop_DN(13, -4) # Solves equation x**2 - 13*y**2 = -4
-    [(3, 1), (36, 10), (393, 109)]
-    The output can be interpreted as follows: There are three fundamental
-    solutions to the equation `x^2 - 13y^2 = -4` given by (3, 1), (393, 109)
-    and (36, 10). Each tuple is in the form (x, y), i.e solution (3, 1) means
-    that `x = 3` and `y = 1`.
+    >>> special_diop_DN(13, -3) # Solves equation x**2 - 13*y**2 = -3
+    [(7, 2), (137, 38)]
+
+    The output can be interpreted as follows: There are two fundamental
+    solutions to the equation `x^2 - 13y^2 = -3` given by (7, 2) and
+    (137, 38). Each tuple is in the form (x, y), i.e solution (7, 2) means
+    that `x = 7` and `y = 2`.
+
     >>> special_diop_DN(986, 1) # Solves equation x**2 - 986*y**2 = 1
     [(49299, 1570)]
-    >>> special_diop_DN(2, 11) # Solves equation x**2 - 2*y**2 = 11
-    Returns `AssertionError`, as the special case `N**2 < D` does not hold.
+
     See Also
     ========
+
     diop_DN()
+
     References
     ==========
+    
     .. [1] Quadratic Diophantine Equations, T. Andreescu and D. Andrica,
         Springer, 2015.
     """


### PR DESCRIPTION
`diop_DN` is supposed to solve equations of the form `x^2 - Dy^2 = N`. In the special case where `N**2 < D`, the algorithm can be drastically improved. I implemented `special_diop_DN`, which handles this special case. `diop_DN` is properly modified to call `special_diop_DN` when the condition holds.

The algorithm is described in section 4.4.4 of [a recent book by Andreescu and Andrica](https://www.amazon.com/dp/B010NDFVVQ) (see the `References` section in the docstring of `special_diop_DN`).

Here's a simple Python 3 script, which I called before and after the modification. It shows that the results are exactly the same, while the computation time is drastically improved.

``` python3
from sympy.solvers.diophantine import diop_DN
import time

def compute_time(D, N):
    start = time.time()
    print(sorted(diop_DN(D, N)))
    end = time.time()
    print(end - start)
```
### Calling the code with D = 2445 and N = -20:

Before modification:

```
[(445, 9), (17625560, 356454), (698095554475, 14118073569)]
1.2723524570465088
```

After modification:

```
[(445, 9), (17625560, 356454), (698095554475, 14118073569)]
0.08705878257751465
```

which shows a 15x speedup.
### Calling the code with D = 15591784605 and N = -20:

Before modification:

```
[(60145511205912604135, 481676332249987), (43515067067365511127244066200080244072811233926170959044480, 348491142270985090658657655047654883395085464613844602), (31482998879077977735535771876291439849532659433050614521649001937263629211747101550276446658294425, 252132122984000423052237248789961107447059546106181159304489022736086083481921633088240245507)]
91.75106477737427
```

After modification:

```
[(60145511205912604135, 481676332249987), (43515067067365511127244066200080244072811233926170959044480, 348491142270985090658657655047654883395085464613844602), (31482998879077977735535771876291439849532659433050614521649001937263629211747101550276446658294425, 252132122984000423052237248789961107447059546106181159304489022736086083481921633088240245507)]
0.47781968116760254
```

which shows a 192x speedup.
