### PR TITLE
Geometric sum evaluates correctly for float base (Fixes : #11642) 

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -987,6 +987,7 @@ def _eval_sum_hyper(f, i, a):
     from sympy.functions import hyper
     from sympy.simplify import hyperexpand, hypersimp, fraction, simplify
     from sympy.polys.polytools import Poly, factor
+    from sympy.core.numbers import Float
 
     if a != 0:
         return _eval_sum_hyper(f.subs(i, i + a), i, 0)
@@ -999,6 +1000,10 @@ def _eval_sum_hyper(f, i, a):
     hs = hypersimp(f, i)
     if hs is None:
         return None
+
+    if isinstance(hs,Float):
+        from sympy.simplify.simplify import nsimplify
+        hs = nsimplify(hs)
 
     numer, denom = fraction(factor(hs))
     top, topl = numer.as_coeff_mul(i)

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -259,23 +259,23 @@ def test_geometric_sums():
     result = Sum(0.5**n,(n, 1, oo)).doit()
     assert result == 1
     assert result.is_Float
-    
+
     result = Sum(0.25**n,(n, 1, oo)).doit()
     assert result == S(1)/3
     assert result.is_Float
-    
+
     result = Sum(0.99999**n,(n, 1, oo)).doit()
     assert result == 99999
     assert result.is_Float
-    
+
     result = Sum(Rational(1,2)**n,(n, 1, oo)).doit()
     assert result == 1
     assert not result.is_Float
-    
+
     result = Sum(Rational(3,5)**n,(n, 1, oo)).doit()
     assert result == S(3)/2
     assert not result.is_Float
-    
+
     assert Sum(1.0**n,(n,1,oo)).doit() == oo
     assert Sum(2.43**n,(n,1,oo)).doit() == oo
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -255,6 +255,29 @@ def test_geometric_sums():
     #issue 9908:
     assert Sum(1/(n**3 - 1), (n, -oo, -2)).doit() == summation(1/(n**3 - 1), (n, -oo, -2))
 
+    #issue 11642:
+    result = Sum(0.5**n,(n, 1, oo)).doit()
+    assert result == 1
+    assert result.is_Float
+    
+    result = Sum(0.25**n,(n, 1, oo)).doit()
+    assert result == S(1)/3
+    assert result.is_Float
+    
+    result = Sum(0.99999**n,(n, 1, oo)).doit()
+    assert result == 99999
+    assert result.is_Float
+    
+    result = Sum(Rational(1,2)**n,(n, 1, oo)).doit()
+    assert result == 1
+    assert not result.is_Float
+    
+    result = Sum(Rational(3,5)**n,(n, 1, oo)).doit()
+    assert result == S(3)/2
+    assert not result.is_Float
+    
+    assert Sum(1.0**n,(n,1,oo)).doit() == oo
+    assert Sum(2.43**n,(n,1,oo)).doit() == oo
 
 def test_harmonic_sums():
     assert summation(1/k, (k, 0, n)) == Sum(1/k, (k, 0, n))


### PR DESCRIPTION
Reference : #11642 

Now geometric sum evaluates correctly for both Rational as well as float bases
Example : 

```
>>Sum((0.35)**(n), (n, 1, oo)).doit()
0.538461538461538
>>Sum((1.35)**(n), (n, 1, oo)).doit()
oo
>>Sum((0.5)**(n), (n, 1, oo)).doit()
1.00000000000000
```

Some unit tests have also been added.
