### PR TITLE
Sets: Use of Reals set in place of S.Reals(11378)

### DIFF
--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -3,7 +3,7 @@ from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
 from .fancysets import ImageSet, Range, ComplexRegion
 from .contains import Contains
 from .conditionset import ConditionSet
-from ..core.singleton import S
 
+from ..core.singleton import S
 Reals = S.Reals
 del S

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -3,3 +3,7 @@ from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
 from .fancysets import ImageSet, Range, ComplexRegion
 from .contains import Contains
 from .conditionset import ConditionSet
+from ..core.singleton import S
+
+Reals = S.Reals
+del S


### PR DESCRIPTION
Reals set is created in sets/**init**.py file which is equivalent to S.Reals by importing S from core module and deleting S so that file doesn't export S.
