### PR TITLE
Add PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+<If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>


### PR DESCRIPTION
This includes a simple message telling people to cross reference issues with
"Fixes #NNNN". The message is placed in angle brackets so that if someone
leaves it in, it will be invisible. I tested GitHub, and for single-commit
pull requests it still auto-populates the pull request comment with the commit
message (below the template). See https://github.com/asmeurer/GitHub-Issues-Test/pull/21.

Fixes #10620.

I've checked "allow edits from maintainers" so feel free to push up any edits to the wording. 
