### PR TITLE
Make UndefinedFunction.__new__ accept the full type() function signature

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -776,9 +776,11 @@ class UndefinedFunction(FunctionClass):
     """
     The (meta)class of undefined functions.
     """
-    def __new__(mcl, name, **kwargs):
-        ret = BasicMeta.__new__(mcl, name, (AppliedUndef,), kwargs)
-        ret.__module__ = None
+    def __new__(mcl, name, bases=(AppliedUndef,), mod_dict=None, **kwargs):
+        mod_dict = mod_dict or {}
+        mod_dict.update(kwargs)
+        mod_dict['__module__'] = None # For pickling
+        ret = super(UndefinedFunction, mcl).__new__(mcl, name, bases, mod_dict)
         return ret
 
     def __instancecheck__(cls, instance):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -775,11 +775,11 @@ class UndefinedFunction(FunctionClass):
     """
     The (meta)class of undefined functions.
     """
-    def __new__(mcl, name, bases=(AppliedUndef,), mod_dict=None, **kwargs):
-        mod_dict = mod_dict or {}
-        mod_dict.update(kwargs)
-        mod_dict['__module__'] = None # For pickling
-        ret = super(UndefinedFunction, mcl).__new__(mcl, name, bases, mod_dict)
+    def __new__(mcl, name, bases=(AppliedUndef,), __dict__=None, **kwargs):
+        __dict__ = __dict__ or {}
+        __dict__.update(kwargs)
+        __dict__['__module__'] = None # For pickling
+        ret = super(UndefinedFunction, mcl).__new__(mcl, name, bases, __dict__)
         return ret
 
     def __instancecheck__(cls, instance):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -36,7 +36,6 @@ from .assumptions import ManagedProperties
 from .basic import Basic
 from .cache import cacheit
 from .compatibility import iterable, is_sequence, as_int, ordered
-from .core import BasicMeta
 from .decorators import _sympifyit
 from .expr import Expr, AtomicExpr
 from .numbers import Rational, Float

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -35,9 +35,6 @@ excluded_attrs = set(['_assumptions', '_mhash'])
 def check(a, exclude=[], check_attr=True):
     """ Check that pickling and copying round-trips.
     """
-    # Python 2.6+ warns about BasicException.message, for example.
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-
     protocols = [0, 1, 2, copy.copy, copy.deepcopy]
     # Python 2.x doesn't support the third pickling protocol
     if sys.version_info >= (3,):
@@ -78,10 +75,6 @@ def check(a, exclude=[], check_attr=True):
                     assert getattr(b, i) == attr, "%s != %s" % (getattr(b, i), attr)
         c(a, b, d1)
         c(b, a, d2)
-
-    # reset filters
-    warnings.simplefilter("default", category=DeprecationWarning)
-    warnings.simplefilter("error", category=SymPyDeprecationWarning)
 
 #================== core =========================
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -42,7 +42,7 @@ def check(a, exclude=[], check_attr=True):
     # Python 2.x doesn't support the third pickling protocol
     if sys.version_info >= (3,):
         protocols.extend([3])
-    if sys.version_info >= (3,4):
+    if sys.version_info >= (3, 4):
         protocols.extend([4])
     if cloudpickle:
         protocols.extend([cloudpickle])
@@ -165,7 +165,7 @@ def test_Singletons():
     protocols = [0, 1, 2]
     if sys.version_info >= (3,):
         protocols.extend([3])
-    if sys.version_info >= (3,4):
+    if sys.version_info >= (3, 4):
         protocols.extend([4])
     copiers = [copy.copy, copy.deepcopy]
     copiers += [lambda x: pickle.loads(pickle.dumps(x, proto))

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -137,8 +137,17 @@ def test_core_function():
         check(f)
 
 
+def test_core_undefinedfunctions():
+    f = Function("f")
+    # Full XFAILed test below
+    exclude = list(range(5))
+    if sys.version_info < (3,):
+        # https://github.com/cloudpipe/cloudpickle/issues/65
+        exclude.append(cloudpickle)
+    check(f, exclude=exclude)
+
 @XFAIL
-def test_core_dynamicfunctions():
+def test_core_undefinedfunctions_fail():
     # This fails because f is assumed to be a class at sympy.basic.function.f
     f = Function("f")
     check(f)

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -1,3 +1,4 @@
+import sys
 import copy
 import pickle
 import warnings
@@ -19,7 +20,7 @@ from sympy.core.function import Derivative, Function, FunctionClass, Lambda, \
 from sympy.sets.sets import Interval
 from sympy.core.multidimensional import vectorize
 
-from sympy.core.compatibility import HAS_GMPY, PY3
+from sympy.core.compatibility import HAS_GMPY
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from sympy import symbols, S
@@ -35,8 +36,11 @@ def check(a, exclude=[], check_attr=True):
 
     protocols = [0, 1, 2, copy.copy, copy.deepcopy]
     # Python 2.x doesn't support the third pickling protocol
-    if PY3:
+    if sys.version_info >= (3,):
         protocols.extend([3])
+    if sys.version_info >= (3,4):
+        protocols.extend([4])
+
     for protocol in protocols:
         if protocol in exclude:
             continue
@@ -151,8 +155,10 @@ def test_core_multidimensional():
 
 def test_Singletons():
     protocols = [0, 1, 2]
-    if PY3:
+    if sys.version_info >= (3,):
         protocols.extend([3])
+    if sys.version_info >= (3,4):
+        protocols.extend([4])
     copiers = [copy.copy, copy.deepcopy]
     copiers += [lambda x: pickle.loads(pickle.dumps(x, proto))
             for proto in protocols]

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -54,7 +54,7 @@ def check(a, exclude=[], check_attr=True):
         if callable(protocol):
             if isinstance(a, BasicMeta):
                 # Classes can't be copied, but that's okay.
-                return
+                continue
             b = protocol(a)
         elif inspect.ismodule(protocol):
             b = protocol.loads(protocol.dumps(a))


### PR DESCRIPTION
This is required to make pickling work with cloudpickle (in Python 3). It also
makes it possible to create an undefined function directly with

``` py
class f(AppliedUndef, metaclass=UndefinedFunction):
    __module__ = None
```

(although this is not recommended)

I've also cleaned up `UndefinedFunction.__new__` a bit (using `super()` instead of
calling `BasicMeta` directly, setting `__module__` in the module dictionary).

This fixes #11692 

I'll add some tests in a bit, but I want to make sure none of the tests fail with this change first. 
