### PR TITLE
Add codegen relationals to the relational fuzz test

### DIFF
--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -266,7 +266,8 @@ def test_new_relational():
             if randint(0, 1):
                 relation_type += strtype(randint(0, length))
             if relation_type not in ('==', 'eq', '!=', '<>', 'ne', '>=', 'ge',
-                                     '<=', 'le', '>', 'gt', '<', 'lt'):
+                                     '<=', 'le', '>', 'gt', '<', 'lt', ':=',
+                                     '+=', '-=', '*=', '/=', '%='):
                 break
 
         raises(ValueError, lambda: Relational(x, 1, relation_type))


### PR DESCRIPTION
This was failing in Python 3.3 with --seed 56571198, which was giving /=. See
https://travis-ci.org/sympy/sympy/jobs/164767904.
