### PR TITLE
matrices : re and im works for matrices (Fix for : #11600)

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -58,6 +58,8 @@ class re(Function):
             return arg
         elif arg.is_imaginary or (S.ImaginaryUnit*arg).is_real:
             return S.Zero
+        elif arg.is_Matrix:
+            return arg.as_real_imag()[0]
         elif arg.is_Function and arg.func is conjugate:
             return re(arg.args[0])
         else:
@@ -152,6 +154,8 @@ class im(Function):
             return S.Zero
         elif arg.is_imaginary or (S.ImaginaryUnit*arg).is_real:
             return -S.ImaginaryUnit * arg
+        elif arg.is_Matrix:
+            return arg.as_real_imag()[1]
         elif arg.is_Function and arg.func is conjugate:
             return -im(arg.args[0])
         else:

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -2,7 +2,8 @@ from sympy import (
     Abs, adjoint, arg, atan2, conjugate, cos, DiracDelta, E, exp, expand,
     Expr, Function, Heaviside, I, im, log, nan, oo, pi, Rational, re, S,
     sign, sin, sqrt, Symbol, symbols, transpose, zoo, exp_polar, Piecewise,
-    Interval, comp, Integral)
+    Interval, comp, Integral, Matrix, ImmutableMatrix, SparseMatrix,
+    ImmutableSparseMatrix, MatrixSymbol, FunctionMatrix, Lambda)
 from sympy.utilities.pytest import XFAIL, raises
 
 
@@ -80,6 +81,23 @@ def test_re():
 
     assert re(S.ComplexInfinity) == S.NaN
 
+    n, m, l = symbols('n m l')
+    A = MatrixSymbol('A',n,m)
+    assert re(A) == (S(1)/2) * (A + conjugate(A))
+
+    A = Matrix([[1 + 4*I,2],[0, -3*I]])
+    assert re(A) == Matrix([[1, 2],[0, 0]])
+
+    A = ImmutableMatrix([[1 + 3*I, 3-2*I],[0, 2*I]])
+    assert re(A) == ImmutableMatrix([[1, 3],[0, 0]])
+
+    X = ImmutableSparseMatrix([[i*I + i for i in range(5)] for i in range(5)])
+    Y = SparseMatrix([[i for i in range(5)] for i in range(5)])
+    assert re(X).as_immutable() == Y
+
+    X = FunctionMatrix(3, 3, Lambda((n, m), n + m*I))
+    assert re(X) == Matrix([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
+
 
 def test_im():
     x, y = symbols('x,y')
@@ -151,6 +169,24 @@ def test_im():
 
     assert im(S.ComplexInfinity) == S.NaN
 
+    n, m, l = symbols('n m l')
+    A = MatrixSymbol('A',n,m)
+
+    assert im(A) == (S(1)/(2*I)) * (A - conjugate(A))
+
+    A = Matrix([[1 + 4*I, 2],[0, -3*I]])
+    assert im(A) == Matrix([[4, 0],[0, -3]])
+
+    A = ImmutableMatrix([[1 + 3*I, 3-2*I],[0, 2*I]])
+    assert im(A) == ImmutableMatrix([[3, -2],[0, 2]])
+
+    X = ImmutableSparseMatrix(
+            [[i*I + i for i in range(5)] for i in range(5)])
+    Y = SparseMatrix([[i for i in range(5)] for i in range(5)])
+    assert im(X).as_immutable() == Y
+
+    X = FunctionMatrix(3, 3, Lambda((n, m), n + m*I))
+    assert im(X) == Matrix([[0, 1, 2], [0, 1, 2], [0, 1, 2]])
 
 def test_sign():
     assert sign(1.2) == 1

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -91,9 +91,18 @@ def test_re():
     A = ImmutableMatrix([[1 + 3*I, 3-2*I],[0, 2*I]])
     assert re(A) == ImmutableMatrix([[1, 3],[0, 0]])
 
-    X = ImmutableSparseMatrix([[i*I + i for i in range(5)] for i in range(5)])
-    Y = SparseMatrix([[i for i in range(5)] for i in range(5)])
-    assert re(X).as_immutable() == Y
+    X = SparseMatrix([[2*j + i*I for i in range(5)] for j in range(5)])
+    assert re(X) - Matrix([[0, 0, 0, 0, 0],
+                           [2, 2, 2, 2, 2],
+                           [4, 4, 4, 4, 4],
+                           [6, 6, 6, 6, 6],
+                           [8, 8, 8, 8, 8]]) == Matrix.zeros(5)
+
+    assert im(X) - Matrix([[0, 1, 2, 3, 4],
+                           [0, 1, 2, 3, 4],
+                           [0, 1, 2, 3, 4],
+                           [0, 1, 2, 3, 4],
+                           [0, 1, 2, 3, 4]]) == Matrix.zeros(5)
 
     X = FunctionMatrix(3, 3, Lambda((n, m), n + m*I))
     assert re(X) == Matrix([[0, 0, 0], [1, 1, 1], [2, 2, 2]])

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -322,6 +322,34 @@ class DenseMatrix(MatrixBase):
             a.extend(self._mat[i::self.cols])
         return self._new(self.cols, self.rows, a)
 
+    def as_real_imag(self):
+        """Returns a tuple of the real part of the input Matrix
+           and it's imaginary part.
+
+           >>> from sympy import Matrix, I
+           >>> A = Matrix([[1+2*I,3],[4+7*I,5]])
+           >>> A.as_real_imag()
+           (Matrix([
+           [1, 3],
+           [4, 5]]), Matrix([
+           [2, 0],
+           [7, 0]]))
+           >>> from sympy.abc import x, y, z, w
+           >>> B = Matrix([[x, y + x * I],[z + w * I, z]])
+           >>> B.as_real_imag()
+           (Matrix([
+           [        re(x), re(y) - im(x)],
+           [re(z) - im(w),         re(z)]]), Matrix([
+           [        im(x), re(x) + im(y)],
+           [re(w) + im(z),         im(z)]]))
+
+        """
+        from sympy.functions.elementary.complexes import re, im
+        real_mat = self._new(self.rows, self.cols, lambda i, j: re(self[i, j]))
+        im_mat = self._new(self.rows, self.cols, lambda i, j: im(self[i, j]))
+
+        return (real_mat, im_mat)
+
     def _LDLdecomposition(self):
         """Helper function of LDLdecomposition.
         Without the error checks.

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -16,7 +16,7 @@ from sympy.matrices.expressions.determinant import det, Determinant
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.inverse import Inverse
 from sympy.matrices import Matrix, ShapeError
-
+from sympy.functions.elementary.complexes import re, im
 
 class BlockMatrix(MatrixExpr):
     """A BlockMatrix is a Matrix composed of other smaller, submatrices
@@ -124,6 +124,15 @@ class BlockMatrix(MatrixExpr):
             elif ask(Q.invertible(D)):
                 return det(D)*det(A - B*D.I*C)
         return Determinant(self)
+
+    def as_real_imag(self):
+        real_matrices = [re(matrix) for matrix in self.blocks]
+        real_matrices = Matrix(self.blockshape[0], self.blockshape[1], real_matrices)
+
+        im_matrices = [im(matrix) for matrix in self.blocks]
+        im_matrices = Matrix(self.blockshape[0], self.blockshape[1], im_matrices)
+
+        return (real_matrices, im_matrices)
 
     def transpose(self):
         """Return transpose of matrix.

--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -2,7 +2,8 @@ from __future__ import print_function, division
 
 from .matexpr import MatrixExpr
 from sympy import Basic, sympify
-
+from sympy.matrices import Matrix
+from sympy.functions.elementary.complexes import re, im
 
 class FunctionMatrix(MatrixExpr):
     """
@@ -45,3 +46,6 @@ class FunctionMatrix(MatrixExpr):
     def _eval_trace(self):
         from sympy.matrices.expressions.trace import Trace
         return Trace._eval_rewrite_as_Sum(Trace(self)).doit()
+
+    def as_real_imag(self):
+        return (re(Matrix(self)), im(Matrix(self)))

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -171,6 +171,12 @@ class MatrixExpr(Basic):
         from sympy.matrices.expressions.transpose import Transpose
         return Adjoint(Transpose(self))
 
+    def as_real_imag(self):
+        from sympy import I
+        real = (S(1)/2) * (self + self._eval_conjugate())
+        im = (self - self._eval_conjugate())/(2*I)
+        return (real, im)
+
     def _eval_inverse(self):
         from sympy.matrices.expressions.inverse import Inverse
         return Inverse(self)

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -35,7 +35,7 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     # MatrixExpr is set as NotIterable, but we want explicit matrices to be
     # iterable
     _iterable = True
-
+    is_Matrix = True
     _class_priority = 8
 
     @classmethod
@@ -92,6 +92,7 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     C = MatrixBase.C
 
     as_mutable = DenseMatrix.as_mutable
+    as_real_imag = DenseMatrix.as_real_imag
     _eval_trace = DenseMatrix._eval_trace
     _eval_transpose = DenseMatrix._eval_transpose
     _eval_conjugate = DenseMatrix._eval_conjugate
@@ -142,7 +143,7 @@ class ImmutableSparseMatrix(Basic, SparseMatrix):
     >>> _.shape
     (3, 3)
     """
-
+    is_Matrix = True
     _class_priority = 9
 
     @classmethod

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1140,6 +1140,10 @@ class MatrixBase(object):
         """ Returns the conjugate of the matrix."""
         return self._eval_conjugate()
 
+    def as_real_imag(self):
+        """Returns a tuple containing the (real, imaginary) part of matrix."""
+        return self.as_real_imag()
+
     def copy(self):
         """
         Returns the copy of a matrix.

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -334,6 +334,17 @@ class SparseMatrix(MatrixBase):
             conj._smat[key] = value.conjugate()
         return conj
 
+    def as_real_imag(self):
+        """Returns tuple containing (real , imaginary) part of sparse matrix"""
+        from sympy.functions.elementary.complexes import re, im
+        real_smat = im_smat = self.copy()
+
+        for key, value in self._smat.items():
+            real_smat._smat[key] = re(value)
+            im_smat._smat[key] = im(value)
+
+        return (real_smat, im_smat)
+
     def _eval_inverse(self, **kwargs):
         """Return the matrix inverse using Cholesky or LDL (default)
         decomposition as selected with the ``method`` keyword: 'CH' or 'LDL',

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -337,7 +337,8 @@ class SparseMatrix(MatrixBase):
     def as_real_imag(self):
         """Returns tuple containing (real , imaginary) part of sparse matrix"""
         from sympy.functions.elementary.complexes import re, im
-        real_smat = im_smat = self.copy()
+        real_smat = self.copy()
+        im_smat = self.copy()
 
         for key, value in self._smat.items():
             real_smat._smat[key] = re(value)


### PR DESCRIPTION
Reference : #11600 
re() and im() works for both explicit matrices and matrix expressions.

Examples :

```
>>> m,n = symbols('m n')
>>> A = MatrixSymbol('A',m,n)
>>> re(A)
(1/2)*(Adjoint(A.T) + A)
>>> im(A)
(-I/2)*((-1)*Adjoint(A.T) + A)
```

```
>>> A = Matrix([[1+3*I,2*I],[1+9*I,3*I]])
>>> A
Matrix([
[1 + 3*I, 2*I],
[1 + 9*I, 3*I]])
>>> re(A)
Matrix([
[1, 0],
[1, 0]])
>>> im(A)
Matrix([
[3, 2],
[9, 3]])

```

 Unit tests for other types of matrices such as SparseMatrices and FunctionMatrices have also been added.
