### PR TITLE
Define limit for negative rational powers (#11672)

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -47,7 +47,6 @@ def limit(e, z, z0, dir="+"):
 
 def heuristics(e, z, z0, dir):
     rv = None
-
     if abs(z0) is S.Infinity:
         rv = limit(e.subs(z, 1/z), z, S.Zero, "+" if z0 is S.Infinity else "-")
         if isinstance(rv, Limit):
@@ -118,13 +117,11 @@ class Limit(Expr):
         isyms.update(self.args[2].free_symbols)
         return isyms
 
-
     def doit(self, **hints):
         """Evaluates limit"""
         from sympy.series.limitseq import limit_seq
 
         e, z, z0, dir = self.args
-
         if hints.get('deep', True):
             e = e.doit(**hints)
             z = z.doit(**hints)
@@ -167,6 +164,16 @@ class Limit(Expr):
 
         if e.is_Order:
             return Order(limit(e.expr, z, z0), *e.args[1:])
+
+        #Check to see if e is a simple power series, like (-1/2)**x
+        if e.is_Pow and len(e.free_symbols) == 1:
+            k = e.free_symbols.pop()
+            if k == z:
+                try:
+                    if (abs(e.base) < 1 and z0 is S.Infinity) or (abs(e.base) > 1 and z0 is S.NegativeInfinity):
+                        return 0
+                except TypeError:
+                    pass
 
         try:
             r = gruntz(e, z, z0, dir)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -173,11 +173,12 @@ class Limit(Expr):
             k = e.exp/z
             if k.is_Number and k > 0:
                 a = abs(e.base)
-                try:
-                    if (a < 1 and z0 is S.Infinity) or (a > 1 and z0 is S.NegativeInfinity):
-                        return 0
-                except TypeError:
-                    pass
+                if not a.has(z):
+                    try:
+                        if (a < 1 and z0 is S.Infinity) or (a > 1 and z0 is S.NegativeInfinity):
+                            return 0
+                    except TypeError:
+                        pass
 
         try:
             r = gruntz(e, z, z0, dir)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -46,6 +46,7 @@ def limit(e, z, z0, dir="+"):
 
 
 def heuristics(e, z, z0, dir):
+
     rv = None
     if abs(z0) is S.Infinity:
         rv = limit(e.subs(z, 1/z), z, S.Zero, "+" if z0 is S.Infinity else "-")
@@ -117,11 +118,13 @@ class Limit(Expr):
         isyms.update(self.args[2].free_symbols)
         return isyms
 
+
     def doit(self, **hints):
         """Evaluates limit"""
         from sympy.series.limitseq import limit_seq
 
         e, z, z0, dir = self.args
+
         if hints.get('deep', True):
             e = e.doit(**hints)
             z = z.doit(**hints)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -169,11 +169,12 @@ class Limit(Expr):
             return Order(limit(e.expr, z, z0), *e.args[1:])
 
         #Check to see if e is a simple power series, like (-1/2)**x
-        if e.is_Pow and len(e.free_symbols) == 1:
-            k = e.free_symbols.pop()
-            if k == z:
+        if e.is_Pow:
+            k = e.exp/z
+            if k.is_Number and k > 0:
+                a = abs(e.base)
                 try:
-                    if (abs(e.base) < 1 and z0 is S.Infinity) or (abs(e.base) > 1 and z0 is S.NegativeInfinity):
+                    if (a < 1 and z0 is S.Infinity) or (a > 1 and z0 is S.NegativeInfinity):
                         return 0
                 except TypeError:
                     pass

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -52,7 +52,6 @@ def test_basic1():
     assert limit(1/tan(x**3), x, (2*pi)**(S(1)/3), dir="-") == -oo
     assert limit(1/cot(x)**3, x, (3*pi/2), dir="+") == -oo
     assert limit(1/cot(x)**3, x, (3*pi/2), dir="-") == oo
-
     # approaching 0
     # from dir="+"
     assert limit(1 + 1/x, x, 0) == oo
@@ -67,7 +66,6 @@ def test_basic1():
     assert limit(sqrt(x), x, 0, dir='-') == 0
     assert limit(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
     assert limit((1 + cos(x))**oo, x, 0) == oo
-
 
 def test_basic2():
     assert limit(x**x, x, 0, dir="+") == 1
@@ -482,3 +480,10 @@ def test_limit_with_Float():
     k = symbols("k")
     assert limit(1.0 ** k, k, oo) == 1
     assert limit(0.3*1.0**k, k, oo) == Float(0.3)
+
+def test_limit_with_negatives():
+    j = Rational(1,-2)
+    k = Rational(-2,1)
+    assert limit(j**x,x,oo) == 0
+    assert limit(k**x,x,-oo) == 0
+    raises(NotImplementedError,lambda: limit(j**(x*y),x,oo))

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -52,6 +52,7 @@ def test_basic1():
     assert limit(1/tan(x**3), x, (2*pi)**(S(1)/3), dir="-") == -oo
     assert limit(1/cot(x)**3, x, (3*pi/2), dir="+") == -oo
     assert limit(1/cot(x)**3, x, (3*pi/2), dir="-") == oo
+
     # approaching 0
     # from dir="+"
     assert limit(1 + 1/x, x, 0) == oo
@@ -66,6 +67,7 @@ def test_basic1():
     assert limit(sqrt(x), x, 0, dir='-') == 0
     assert limit(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
     assert limit((1 + cos(x))**oo, x, 0) == oo
+
 
 def test_basic2():
     assert limit(x**x, x, 0, dir="+") == 1


### PR DESCRIPTION
When calculating the limit of a function, doit() now checks to see if the expression is a simple power sequence that converges to 0 (i.e., the limit referenced in #11672), and if it is, returns 0; otherwise, the algorithm continues as normal.
