### PR TITLE
numbers: Fix interpretation of mpmath Floats(Fixes : #11092)

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -772,7 +772,7 @@ class Float(Number):
             num = num._mpf_
 
         if prec is None:
-            dps = 15
+            dps = mpmath.mp.dps
             if isinstance(num, Float):
                 return num
             if isinstance(num, string_types) and _literal_float(num):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2,7 +2,7 @@ import decimal
 from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
-                   AlgebraicNumber, simplify, sin)
+                   AlgebraicNumber, simplify, sympify, sin)
 from sympy.core.compatibility import long
 from sympy.core.power import integer_nthroot, isqrt
 from sympy.core.logic import fuzzy_not
@@ -1272,6 +1272,11 @@ def test_conversion_to_mpmath():
     assert mpmath.mpmathify(Integer(1)) == mpmath.mpf(1)
     assert mpmath.mpmathify(Rational(1, 2)) == mpmath.mpf(0.5)
     assert mpmath.mpmathify(Float('1.23', 15)) == mpmath.mpf('1.23')
+
+def test_conversion_from_mpmath():
+    with mpmath.workdps(50):
+        a = mpmath.mpf('1.0')/mpmath.mpf('3.0')
+        assert sympify(a) == Float(a)
 
 
 def test_relational():


### PR DESCRIPTION
Ensures that Float() and sympify() return results with same precision.
Ref : #11092 

```
>>> mpmath.mp.dps=50
>>> a=mpmath.mpf('1.0')/mpmath.mpf('3.0')
>>> a
mpf('0.33333333333333333333333333333333333333333333333333311')
>>> sympify(a)
0.33333333333333333333333333333333333333333333333333
>>> Float(a)
0.33333333333333333333333333333333333333333333333333
```
