### PR TITLE
Improve pytest compatibility: add raises

### DIFF
--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -10,7 +10,7 @@ from sympy.core.compatibility import get_function_name
 
 try:
     import py
-    from py.test import skip
+    from py.test import skip, raises
     USE_PYTEST = getattr(sys, '_running_pytest', False)
 except ImportError:
     USE_PYTEST = False


### PR DESCRIPTION
This allows pytest to run test files that use `raises()`
