### PR TITLE
Union(S.UniversalSet - Interval(1, 2), Interval(3, 4)) isn't simplified #9577

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -990,6 +990,16 @@ class Interval(Set, EvalfMixin):
 
         See Set._union for docstring
         """
+        if isinstance(other, Complement):
+            A, B = other.args
+            if A == S.UniversalSet:
+                if Intersection(B, self).is_EmptySet:
+                    return other
+                else:
+                    if B.is_subset(self):
+                        return S.UniversalSet
+                    else:
+                        return Complement(S.UniversalSet,Complement(B,self))
         if other.is_UniversalSet:
             return S.UniversalSet
         if other.is_Interval and self._is_comparable(other):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -999,7 +999,7 @@ class Interval(Set, EvalfMixin):
                     if B.is_subset(self):
                         return S.UniversalSet
                     else:
-                        return Complement(S.UniversalSet,Complement(B,self))
+                        return Complement(S.UniversalSet, Complement(B, self))
         if other.is_UniversalSet:
             return S.UniversalSet
         if other.is_Interval and self._is_comparable(other):
@@ -1718,6 +1718,12 @@ class Complement(Set, EvalfMixin):
         B = self.args[1]
         return And(A.contains(other), Not(B.contains(other)))
 
+    def _complement(self, other):
+        A = self.args[0]
+        B = self.args[1]
+        if other == S.UniversalSet:
+            if A == S.UniversalSet or B == S.UniversalSet:
+                return B
 
 class EmptySet(with_metaclass(Singleton, Set)):
     """

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1056,3 +1056,13 @@ def test_issue_11174():
 
     soln = Intersection(S.Reals, FiniteSet(x), evaluate=False)
     assert Intersection(FiniteSet(x), S.Reals) == soln
+
+def test_issue_9577():
+    un = S.UniversalSet
+    assert Union(Complement(un, Interval(1, 2)), Interval(3, 4)) == \
+            Complement(un, Interval(1, 2))
+    assert Union(Complement(un, Interval(1, 2)), Interval(1, 3)) == un
+    assert Union(un - Union(Interval(1, 2), Interval(3, 4)), Interval(1, 4)) == \
+            un
+    assert Union(S.UniversalSet - Interval(1, 4), Interval(2, 6)) == \
+            Intersection(S.UniversalSet, Complement(S.UniversalSet, Interval(1, 2, False, True)))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1065,4 +1065,7 @@ def test_issue_9577():
     assert Union(un - Union(Interval(1, 2), Interval(3, 4)), Interval(1, 4)) == \
             un
     assert Union(S.UniversalSet - Interval(1, 4), Interval(2, 6)) == \
-            Intersection(S.UniversalSet, Complement(S.UniversalSet, Interval(1, 2, False, True)))
+            Complement(S.UniversalSet, Interval(1, 2, False, True))
+    assert Intersection(S.UniversalSet - Union(Interval(1, 2), Interval(3, 4)),
+            Interval(1, 4)) == Complement(S.UniversalSet, Intersection(S.UniversalSet,
+            S.UniversalSet - Interval(2, 3,True,True)))


### PR DESCRIPTION
Before this PR,
`>> Union(S.UniversalSet - Interval(1, 2), Interval(3, 4)) == Complement(S.UniversalSet, Interval(1, 2))
False`
After this PR.
`>> Union(S.UniversalSet - Interval(1, 2), Interval(3, 4)) == Complement(S.UniversalSet, Interval(1, 2))
True`
