### PR TITLE
core.evaluate : evaluate(False) works for numeric operators (Fix for : #11614)

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -231,7 +231,10 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     """
     if evaluate is None:
-        evaluate = global_evaluate[0]
+        if global_evaluate[0] is False:
+            evaluate = global_evaluate[0]
+        else:
+            evaluate = True
     try:
         if a in sympy_classes:
             return a

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -8,7 +8,6 @@ from .core import all_classes as sympy_classes
 from .compatibility import iterable, string_types, range
 from .evaluate import global_evaluate
 
-#from sympy.core.numbers import Float
 
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -266,6 +266,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     except AttributeError:
         pass
 
+    #Support for basic numpy datatypes
+    if type(a).__module__ == 'numpy':
         import numpy as np
         if np.isscalar(a):
             try:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -266,6 +266,17 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     except AttributeError:
         pass
 
+    #Support for basic numpy datatypes.
+    if type(a).__module__ == 'numpy':
+        import numpy
+        if(numpy.isscalar(a)):
+            try:
+                return sympify(numpy.asscalar(a))
+            except RuntimeError:
+                return sympify(numpy.float64(a))
+                #Exception case is for float128 which
+                #has no native python equivalent.
+
     if not isinstance(a, string_types):
         for coerce in (float, int):
             try:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -8,6 +8,7 @@ from .core import all_classes as sympy_classes
 from .compatibility import iterable, string_types, range
 from .evaluate import global_evaluate
 
+#from sympy.core.numbers import Float
 
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):
@@ -266,16 +267,18 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     except AttributeError:
         pass
 
-    #Support for basic numpy datatypes.
-    if type(a).__module__ == 'numpy':
-        import numpy
-        if(numpy.isscalar(a)):
+        import numpy as np
+        if np.isscalar(a):
             try:
-                return sympify(numpy.asscalar(a))
+                return sympify(np.asscalar(a))
             except RuntimeError:
-                return sympify(numpy.float64(a))
-                #Exception case is for float128 which
-                #has no native python equivalent.
+                from sympy.core import Float
+                a = str(list(np.reshape(np.asarray(a),
+                                (1, np.size(a)))[0]))[1:-1]
+                return Float(a)
+                #Exception case is for float96,float128 which has no native
+                #python equivalent.It's better to not use this for
+                #all numpy floats as it's a bit slow.
 
     if not isinstance(a, string_types):
         for coerce in (float, int):

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -1,6 +1,7 @@
 from sympy.abc import x, y
 from sympy.core.evaluate import evaluate
-from sympy.core import Mul, Add
+from sympy.core import Mul, Add, Pow, S
+from sympy import sqrt
 
 def test_add():
     with evaluate(False):
@@ -15,7 +16,27 @@ def test_add():
 
     assert isinstance(x + x, Mul)
 
+    with evaluate(False):
+        assert S(1) + 1 == Add(1, 1)
+        assert S(4) - 3 == Add(4, -3)
+        assert S(2) * 4 == Mul(2, 4)
+        assert S(6) / 3 == Mul(6, S(1)/ 3)
+        assert S(2) ** 9 == Pow(2, 9)
+        assert S(2) / 2 == 2*S(1) / 2
 
+        assert S(2) / 3 + 1 == Add(S(2) / 3, 1)
+        assert S(4) / 7 - 3 == Add(S(4) / 7, -3)
+        assert S(2) / 4 * 4 == Mul(S(2) / 4, 4)
+        assert S(6) / 3 == Mul(6, S(1) / 3)
+        assert S(2) ** 9 == Pow(S(2), 9)
+        assert S(2) / 2 == 2*S(1) / 2
+
+        assert S(1) / 3 + sqrt(3) == Add(S(1) / 3, sqrt(3))
+        assert S(1) / 2 * 10.333 == Mul(S(1) / 2, 10.333)
+        assert sqrt(2) * sqrt(2) == Mul(sqrt(2), sqrt(2))
+
+        assert S(1) / 2 + x == Add(S(1) / 2, x)
+        assert S(1) / x * x == Mul(S(1) / x, x)
 
 def test_nested():
     with evaluate(False):

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -511,6 +511,29 @@ def test_sympify_set():
     assert sympify({n}) == FiniteSet(n)
     assert sympify(set()) == EmptySet()
 
+def test_numpy():
+    try:
+        import numpy as np
+
+        assert sympify(np.bool_(1)) == True
+        assert sympify(np.int_(123)) == np.int_(123)
+        assert sympify(np.intc(123)) == np.intc(123)
+        assert sympify(np.intp(123)) == np.intp(123)
+        assert sympify(np.int8(-123)) == np.int8(-123)
+        assert sympify(np.int16(-123)) == np.int16(-123)
+        assert sympify(np.int32(123)) == np.int32(123)
+        assert sympify(np.int64(123)) == np.int64(123)
+        assert sympify(np.uint8(123)) == np.uint8(123)
+        assert sympify(np.uint16(1234)) == np.uint16(1234)
+        assert sympify(np.uint32(1234)) == np.uint32(1234)
+        assert sympify(np.uint64(1234)) == np.uint64(1234)
+        assert sympify(np.float16(1234.12)) == np.float16(1234.12)
+        assert sympify(np.float32(1234.1234)) == np.float32(1234.1234)
+        assert sympify(np.float64(1234.12345)) == np.float64(1234.12345)
+        assert sympify(np.complex64(1 + 2j)) == 1.0 + 2.0*I
+        assert sympify(np.complex128(1 + 2j)) == 1.0 + 2.0*I
+    except ImportError:
+        print('numpy not installed.Abort numpy tests.')
 
 @XFAIL
 def test_sympify_rational_numbers_set():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -11,6 +11,7 @@ from sympy.functions.combinatorial.factorials import factorial, factorial2
 from sympy.abc import _clash, _clash1, _clash2
 from sympy.core.compatibility import exec_, HAS_GMPY, PY3
 from sympy.sets import FiniteSet, EmptySet
+from sympy.external import import_module
 
 import mpmath
 
@@ -512,36 +513,36 @@ def test_sympify_set():
     assert sympify(set()) == EmptySet()
 
 def test_numpy():
-    try:
-        import numpy as np
-
-        assert sympify(np.bool_(1)) == True
-        assert sympify(np.int_(123)) == np.int_(123)
-        assert sympify(np.intc(123)) == np.intc(123)
-        assert sympify(np.intp(123)) == np.intp(123)
-        assert sympify(np.int8(-123)) == np.int8(-123)
-        assert sympify(np.int16(-123)) == np.int16(-123)
-        assert sympify(np.int32(123)) == np.int32(123)
-        assert sympify(np.int64(123)) == np.int64(123)
-        assert sympify(np.uint8(123)) == np.uint8(123)
-        assert sympify(np.uint16(1234)) == np.uint16(1234)
-        assert sympify(np.uint32(1234)) == np.uint32(1234)
-        assert sympify(np.uint64(1234)) == np.uint64(1234)
-        assert sympify(np.float16(1234.12)) == np.float16(1234.12)
-        assert sympify(np.float32(1234.1234)) == np.float32(1234.1234)
-        assert sympify(np.float64(1234.12345)) == np.float64(1234.12345)
-        assert sympify(np.complex64(1 + 2j)) == 1.0 + 2.0*I
-        assert sympify(np.complex128(1 + 2j)) == 1.0 + 2.0*I
-        try:
-            assert sympify(np.float96(1.123456789)) == np.float96(1.123456789)
-        except AttributeError:#float96 does not exist on all platforms
-            pass
-        try:
-            assert sympify(np.float128(1.123456789123)) == np.float128(1.123456789123)
-        except AttributeError:#float128 does not exist on all platforms
-            pass
-    except ImportError:
-        print('numpy not installed.Abort numpy tests.')
+        from sympy.utilities.pytest import skip
+        np = import_module('numpy')
+        if np:
+            assert sympify(np.bool_(1)) == True
+            assert sympify(np.int_(123)) == np.int_(123)
+            assert sympify(np.intc(123)) == np.intc(123)
+            assert sympify(np.intp(123)) == np.intp(123)
+            assert sympify(np.int8(-123)) == np.int8(-123)
+            assert sympify(np.int16(-123)) == np.int16(-123)
+            assert sympify(np.int32(123)) == np.int32(123)
+            assert sympify(np.int64(123)) == np.int64(123)
+            assert sympify(np.uint8(123)) == np.uint8(123)
+            assert sympify(np.uint16(1234)) == np.uint16(1234)
+            assert sympify(np.uint32(1234)) == np.uint32(1234)
+            assert sympify(np.uint64(1234)) == np.uint64(1234)
+            assert sympify(np.float16(1234.12)) == np.float16(1234.12)
+            assert sympify(np.float32(1234.1234)) == np.float32(1234.1234)
+            assert sympify(np.float64(1234.12345)) == np.float64(1234.12345)
+            assert sympify(np.complex64(1 + 2j)) == 1.0 + 2.0*I
+            assert sympify(np.complex128(1 + 2j)) == 1.0 + 2.0*I
+            try:
+                assert sympify(np.float96(1.123456789)) == np.float96(1.123456789)
+            except AttributeError:#float96 does not exist on all platforms
+                pass
+            try:
+                assert sympify(np.float128(1.123456789123)) == np.float128(1.123456789123)
+            except AttributeError:#float128 does not exist on all platforms
+                pass
+        else:
+            skip('numpy not installed.Abort numpy tests.')
 
 @XFAIL
 def test_sympify_rational_numbers_set():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -532,6 +532,14 @@ def test_numpy():
         assert sympify(np.float64(1234.12345)) == np.float64(1234.12345)
         assert sympify(np.complex64(1 + 2j)) == 1.0 + 2.0*I
         assert sympify(np.complex128(1 + 2j)) == 1.0 + 2.0*I
+        try:
+            assert sympify(np.float96(1.123456789)) == np.float96(1.123456789)
+        except AttributeError:#float96 does not exist on all platforms
+            pass
+        try:
+            assert sympify(np.float128(1.123456789123)) == np.float128(1.123456789123)
+        except AttributeError:#float128 does not exist on all platforms
+            pass
     except ImportError:
         print('numpy not installed.Abort numpy tests.')
 


### PR DESCRIPTION
Ref : #11614 

Certain fixes have been done to `sympify.py` and `numbers.py` to ensure that if numerical operations are executed in a `with evaluate(False):` block the unevaluated numerical expression is returned.

Example : 

Previously : 

```
>>> with evaluate(False):
...     print(S(1) + 4)
... 
5
```

With the fix :

```
>>> with evaluate(False):
...     print(S(1) + 4)
... 
1 + 4
```

Unit tests have also been added.
