### PR TITLE
core.evaluate : evaluate(False) works for numeric operators (Fix for : #11614)

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -231,7 +231,10 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     """
     if evaluate is None:
-        evaluate = global_evaluate[0]
+        if global_evaluate[0] is False:
+            evaluate = global_evaluate[0]
+        else:
+            evaluate = True
     try:
         if a in sympy_classes:
             return a

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -19,25 +19,25 @@ def test_add():
     with evaluate(False):
         assert S(1) + 1 == Add(1, 1)
         assert 1 + S(1) == Add(1, 1)
-        
+
         assert S(4) - 3 == Add(4, -3)
         assert -3 + S(4) == Add(4, -3)
-        
+
         assert S(2) * 4 == Mul(2, 4)
         assert 4 * S(2) == Mul(2, 4)
-        
+
         assert S(6) / 3 == Mul(6, S(1)/ 3)
         assert S(1)/3 * 6 == Mul(S(1)/ 3, 6)
 		
         assert 9 ** S(2) == Pow(9, 2)
-        assert S(2) ** 9 == Pow(2, 9)        
+        assert S(2) ** 9 == Pow(2, 9)
 
         assert S(2) / 2 == Mul(2, S(1) / 2)
         assert S(1)/2 * 2 == Mul(S(1) / 2, 2)
 
         assert S(2) / 3 + 1 == Add(S(2) / 3, 1)
         assert 1 + S(2) / 3 == Add(1, S(2) / 3)	
-        
+
         assert S(4) / 7 - 3 == Add(S(4) / 7, -3)
         assert -3 + S(4) / 7 == Add(-3, S(4) / 7)
 	
@@ -49,15 +49,15 @@ def test_add():
 
         assert S(1) / 3 + sqrt(3) == Add(S(1) / 3, sqrt(3))
         assert sqrt(3) + S(1) / 3 == Add(sqrt(3), S(1) / 3)
-        
+
         assert S(1) / 2 * 10.333 == Mul(S(1) / 2, 10.333)
         assert 10.333 * S(1) / 2 == Mul(10.333, S(1) / 2)
-        
+
         assert sqrt(2) * sqrt(2) == Mul(sqrt(2), sqrt(2))
 
         assert S(1) / 2 + x == Add(S(1) / 2, x)
         assert x + S(1) / 2 == Add(x, S(1) / 2)
-        
+
         assert S(1) / x * x == Mul(S(1) / x, x)
         assert x * S(1) / x == Mul(x, S(1) / x)
 

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -28,7 +28,7 @@ def test_add():
 
         assert S(6) / 3 == Mul(6, S(1) / 3)
         assert S(1) / 3 * 6 == Mul(S(1) / 3, 6)
-		
+
         assert 9 ** S(2) == Pow(9, 2)
         assert S(2) ** 9 == Pow(2, 9)
 
@@ -36,11 +36,11 @@ def test_add():
         assert S(1) / 2 * 2 == Mul(S(1) / 2, 2)
 
         assert S(2) / 3 + 1 == Add(S(2) / 3, 1)
-        assert 1 + S(2) / 3 == Add(1, S(2) / 3)	
+        assert 1 + S(2) / 3 == Add(1, S(2) / 3)
 
         assert S(4) / 7 - 3 == Add(S(4) / 7, -3)
         assert -3 + S(4) / 7 == Add(-3, S(4) / 7)
-	
+
         assert S(2) / 4 * 4 == Mul(S(2) / 4, 4)
         assert 4 * (S(2) / 4) == Mul(4, S(2) / 4)
 

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -1,6 +1,7 @@
 from sympy.abc import x, y
 from sympy.core.evaluate import evaluate
-from sympy.core import Mul, Add
+from sympy.core import Mul, Add, Pow, S
+from sympy import sqrt
 
 def test_add():
     with evaluate(False):
@@ -15,7 +16,27 @@ def test_add():
 
     assert isinstance(x + x, Mul)
 
+    with evaluate(False):
+        assert S(1) + 1 == Add(1, 1)
+        assert S(4) - 3 == Add(4, -3)
+        assert S(2) * 4 == Mul(2, 4)
+        assert S(6) / 3 == Mul(6, S(1)/ 3)
+        assert S(2) ** 9 == Pow(2, 9)
+        assert S(2) / 2 == 2*S(1) / 2
 
+        assert S(2) / 3 + 1 == Add(S(2) / 3, 1)
+        assert S(4) / 7 - 3 == Add(S(4) / 7, -3)
+        assert S(2) / 4 * 4 == Mul(S(2) / 4, 4)
+        assert S(6) / 3 == Mul(6, S(1) / 3)
+        assert S(2) ** 9 == Pow(S(2), 9)
+        assert S(2) / 2 == 2*S(1) / 2
+
+        assert S(1) / 3 + sqrt(3) == Add(S(1) / 3, sqrt(3))
+        assert S(1) / 2 * 10.333 == Mul(S(1) / 2, 10.333)
+        assert sqrt(2) * sqrt(2) == Mul(sqrt(2), sqrt(2))
+
+        assert S(1) / 2 + x == Add(S(1) / 2, x)
+        assert S(1) / x * x == Mul(S(1) / x, x)
 
 def test_nested():
     with evaluate(False):

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -26,14 +26,14 @@ def test_add():
         assert S(2) * 4 == Mul(2, 4)
         assert 4 * S(2) == Mul(2, 4)
 
-        assert S(6) / 3 == Mul(6, S(1)/ 3)
-        assert S(1)/3 * 6 == Mul(S(1)/ 3, 6)
+        assert S(6) / 3 == Mul(6, S(1) / 3)
+        assert S(1) / 3 * 6 == Mul(S(1) / 3, 6)
 		
         assert 9 ** S(2) == Pow(9, 2)
         assert S(2) ** 9 == Pow(2, 9)
 
         assert S(2) / 2 == Mul(2, S(1) / 2)
-        assert S(1)/2 * 2 == Mul(S(1) / 2, 2)
+        assert S(1) / 2 * 2 == Mul(S(1) / 2, 2)
 
         assert S(2) / 3 + 1 == Add(S(2) / 3, 1)
         assert 1 + S(2) / 3 == Add(1, S(2) / 3)	

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -18,25 +18,48 @@ def test_add():
 
     with evaluate(False):
         assert S(1) + 1 == Add(1, 1)
+        assert 1 + S(1) == Add(1, 1)
+        
         assert S(4) - 3 == Add(4, -3)
+        assert -3 + S(4) == Add(4, -3)
+        
         assert S(2) * 4 == Mul(2, 4)
+        assert 4 * S(2) == Mul(2, 4)
+        
         assert S(6) / 3 == Mul(6, S(1)/ 3)
-        assert S(2) ** 9 == Pow(2, 9)
-        assert S(2) / 2 == 2*S(1) / 2
+        assert S(1)/3 * 6 == Mul(S(1)/ 3, 6)
+		
+        assert 9 ** S(2) == Pow(9, 2)
+        assert S(2) ** 9 == Pow(2, 9)        
+
+        assert S(2) / 2 == Mul(2, S(1) / 2)
+        assert S(1)/2 * 2 == Mul(S(1) / 2, 2)
 
         assert S(2) / 3 + 1 == Add(S(2) / 3, 1)
+        assert 1 + S(2) / 3 == Add(1, S(2) / 3)	
+        
         assert S(4) / 7 - 3 == Add(S(4) / 7, -3)
+        assert -3 + S(4) / 7 == Add(-3, S(4) / 7)
+	
         assert S(2) / 4 * 4 == Mul(S(2) / 4, 4)
+        assert 4 * (S(2) / 4) == Mul(4, S(2) / 4)
+
         assert S(6) / 3 == Mul(6, S(1) / 3)
-        assert S(2) ** 9 == Pow(S(2), 9)
-        assert S(2) / 2 == 2*S(1) / 2
+        assert S(1) / 3 * 6 == Mul(S(1) / 3, 6)
 
         assert S(1) / 3 + sqrt(3) == Add(S(1) / 3, sqrt(3))
+        assert sqrt(3) + S(1) / 3 == Add(sqrt(3), S(1) / 3)
+        
         assert S(1) / 2 * 10.333 == Mul(S(1) / 2, 10.333)
+        assert 10.333 * S(1) / 2 == Mul(10.333, S(1) / 2)
+        
         assert sqrt(2) * sqrt(2) == Mul(sqrt(2), sqrt(2))
 
         assert S(1) / 2 + x == Add(S(1) / 2, x)
+        assert x + S(1) / 2 == Add(x, S(1) / 2)
+        
         assert S(1) / x * x == Mul(S(1) / x, x)
+        assert x * S(1) / x == Mul(x, S(1) / x)
 
 def test_nested():
     with evaluate(False):

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -10,7 +10,7 @@ from sympy.core.compatibility import get_function_name
 
 try:
     import py
-    from py.test import skip
+    from py.test import skip, raises
     USE_PYTEST = getattr(sys, '_running_pytest', False)
 except ImportError:
     USE_PYTEST = False


### PR DESCRIPTION
Ref : #11614 

Certain fixes have been done to `sympify.py` and `numbers.py` to ensure that if numerical operations are executed in a `with evaluate(False):` block the unevaluated numerical expression is returned.

Example : 

Previously : 

```
>>> with evaluate(False):
...     print(S(1) + 4)
... 
5
```

With the fix :

```
>>> with evaluate(False):
...     print(S(1) + 4)
... 
1 + 4
```

Unit tests have also been added.
