### PR TITLE
Raises Error instead of RuntimeWarning

### DIFF
--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -360,9 +360,8 @@ def test_python_div_zero_issue_11306():
     if not numpy:
         skip("numpy not installed.")
     p = Piecewise((1 / x, y < -1), (x, y <= 1), (1 / x, True))
-    numpy.seterr(all='raise')
+    numpy.seterr(divide='raise')
     lambdify([x, y], p, modules='numpy')(0, 1)
-
 
 def test_issue9474():
     mods = [None, 'math']

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2,6 +2,7 @@ from itertools import product
 import math
 
 import mpmath
+import warnings
 
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
@@ -357,10 +358,15 @@ def test_numpy_old_matrix():
     assert isinstance(f(1, 2, 3), numpy.matrix)
 
 def test_python_div_zero_issue_11306():
+    warnings.filterwarnings("error")
     if not numpy:
         skip("numpy not installed.")
     p = Piecewise((1 / x, y < -1), (x, y <= 1), (1 / x, True))
-    lambdify([x, y], p, modules='numpy')(0, 1)
+    try:
+        lambdify([x, y], p, modules='numpy')(0, 1)
+    except RuntimeWarning:
+        raises(RuntimeError, lambda: lambdify([x, y], p, modules='numpy')(0, 1))
+
 
 def test_issue9474():
     mods = [None, 'math']

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2,7 +2,6 @@ from itertools import product
 import math
 
 import mpmath
-import warnings
 
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
@@ -358,14 +357,11 @@ def test_numpy_old_matrix():
     assert isinstance(f(1, 2, 3), numpy.matrix)
 
 def test_python_div_zero_issue_11306():
-    warnings.filterwarnings("error")
     if not numpy:
         skip("numpy not installed.")
     p = Piecewise((1 / x, y < -1), (x, y <= 1), (1 / x, True))
-    try:
-        lambdify([x, y], p, modules='numpy')(0, 1)
-    except RuntimeWarning:
-        raises(RuntimeError, lambda: lambdify([x, y], p, modules='numpy')(0, 1))
+    numpy.seterr(all='raise')
+    lambdify([x, y], p, modules='numpy')(0, 1)
 
 
 def test_issue9474():


### PR DESCRIPTION
Fixes #11727 . Imported `warnings` to catch warnings as exceptions. Reference:
http://stackoverflow.com/questions/5644836/in-python-how-does-one-catch-warnings-as-if-they-were-exceptions

``` python

MacBook-Pro-4:sympy parsoyaarihant$ ./bin/test lambdify
============================= test process starts ==============================
executable:         /Users/parsoyaarihant/anaconda/bin/python  (3.5.2-final-0) [CPython]
architecture:       64-bit
cache:              yes
ground types:       python 
random seed:        21678500
hash randomization: on (PYTHONHASHSEED=3383391197)

sympy/utilities/tests/test_lambdify.py[65] ...........s...................E.....
..ssssssss..................                                              [FAIL]

________________________________________________________________________________
___ sympy/utilities/tests/test_lambdify.py:test_python_div_zero_issue_11306 ____
  File "/users/parsoyaarihant/sympy/sympy/utilities/tests/test_lambdify.py", line 368, in test_python_div_zero_issue_11306
    raises(RuntimeError, lambda: lambdify([x, y], p, modules='numpy')(0, 1))
  File "/Users/parsoyaarihant/sympy/sympy/utilities/pytest.py", line 78, in raises
    code()
  File "/users/parsoyaarihant/sympy/sympy/utilities/tests/test_lambdify.py", line 368, in <lambda>
    raises(RuntimeError, lambda: lambdify([x, y], p, modules='numpy')(0, 1))
  File "/Users/parsoyaarihant/sympy/sympy/utilities/lambdify.py", line 412, in wrapper
    return funcarg(*[namespace['asarray'](i) for i in argsx], **kwargsx)
  File "<string>", line 1, in <lambda>
RuntimeWarning: divide by zero encountered in true_divide

===== tests finished: 55 passed, 9 skipped, 1 exceptions, in 8.03 seconds ======
DO *NOT* COMMIT!
```
