### PR TITLE
fancysets: fix for special sets (Integers, Naturals)

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -13,6 +13,7 @@ from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
                              FiniteSet, imageset)
 from sympy.sets.conditionset import ConditionSet
 from sympy.utilities.misc import filldedent, func_name
+from sympy.core.symbol import Symbol
 
 
 class Naturals(with_metaclass(Singleton, Set)):
@@ -54,11 +55,11 @@ class Naturals(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if not other.is_number:
-            return S.false
+        if isinstance(other,Symbol):
+            return None
         elif other.is_positive and other.is_integer:
             return S.true
-        elif other.is_integer is False or other.is_positive is False:
+        else:
             return S.false
 
 
@@ -85,11 +86,11 @@ class Naturals0(Naturals):
     _inf = S.Zero
 
     def _contains(self, other):
-        if not other.is_number:
-            return S.false
+        if isinstance(other,Symbol):
+            return None
         elif other.is_integer and other.is_nonnegative:
             return S.true
-        elif other.is_integer is False or other.is_nonnegative is False:
+        else:
             return S.false
 
 
@@ -135,8 +136,8 @@ class Integers(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if not other.is_number:
-            return S.false
+        if isinstance(other,Symbol):
+            return None
         elif other.is_integer:
             return S.true
         else:
@@ -1465,7 +1466,9 @@ class Complexes(with_metaclass(Singleton, ComplexRegion)):
         return "S.Complexes"
 
     def _contains(self,other):
-        if not other.is_complex:
+        if isinstance(other,Symbol):
+            return None
+        elif not other.is_complex:
             return S.false
         else:
             return S.true

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -54,7 +54,7 @@ class Naturals(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if isinstance(other,Set):
+        if not isinstance(other, Expr):
             return S.false
         elif other.is_positive and other.is_integer:
             return S.true
@@ -84,7 +84,7 @@ class Naturals0(Naturals):
     _inf = S.Zero
 
     def _contains(self, other):
-        if isinstance(other,Set):
+        if not isinstance(other, Expr):
             return S.false
         elif other.is_integer and other.is_nonnegative:
             return S.true
@@ -134,7 +134,7 @@ class Integers(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if isinstance(other,Set):
+        if not isinstance(other, Expr):
             return S.false
         elif other.is_integer:
             return S.true
@@ -1361,9 +1361,9 @@ class ComplexRegion(Set):
         if isTuple and len(other) != 2:
             raise ValueError('expecting Tuple of length 2')
 
-        # If the other is a Set (FiniteSet, Interval, ...)
-        if isinstance(other,Set):
-            return False
+        # If the other is not an Expression, and neither a Tuple
+        if not isinstance(other, Expr) and not isinstance(other, Tuple):
+            return S.false
         # self in rectangular form
         if not self.polar:
             re, im = other if isTuple else other.as_real_imag()

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -58,6 +58,9 @@ class Naturals(with_metaclass(Singleton, Set)):
             return S.true
         elif other.is_integer is False or other.is_positive is False:
             return S.false
+        elif isinstance(other,Interval) or isinstance(other,FiniteSet) or isinstance(other,EmptySet):
+            return S.false
+
 
     def __iter__(self):
         i = self._inf
@@ -85,6 +88,8 @@ class Naturals0(Naturals):
         if other.is_integer and other.is_nonnegative:
             return S.true
         elif other.is_integer is False or other.is_nonnegative is False:
+            return S.false
+        elif isinstance(other,Interval) or isinstance(other,FiniteSet) or isinstance(other,EmptySet):
             return S.false
 
 
@@ -134,6 +139,9 @@ class Integers(with_metaclass(Singleton, Set)):
             return S.true
         elif other.is_integer is False:
             return S.false
+        elif isinstance(other,Interval) or isinstance(other,FiniteSet) or isinstance(other,EmptySet):
+            return S.false
+
 
     def _union(self, other):
         intersect = Intersection(self, other)
@@ -1455,3 +1463,11 @@ class Complexes(with_metaclass(Singleton, ComplexRegion)):
 
     def __repr__(self):
         return "S.Complexes"
+
+    def _contains(self,other):
+        if isinstance(other,Interval) or isinstance(other,FiniteSet) or isinstance(other,EmptySet):
+            return S.false
+        elif sympify(other).is_complex:
+            return S.true
+        else:
+            return S.false

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -13,7 +13,6 @@ from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
                              FiniteSet, imageset)
 from sympy.sets.conditionset import ConditionSet
 from sympy.utilities.misc import filldedent, func_name
-from sympy.core.symbol import Symbol
 
 
 class Naturals(with_metaclass(Singleton, Set)):
@@ -55,13 +54,12 @@ class Naturals(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if isinstance(other,Symbol):
-            return None
-        elif other.is_positive and other.is_integer:
+        if other.is_positive and other.is_integer:
             return S.true
-        else:
+        elif other.is_integer is False or other.is_positive is False:
             return S.false
-
+        elif isinstance(other,Set):
+            return S.false
 
     def __iter__(self):
         i = self._inf
@@ -86,11 +84,11 @@ class Naturals0(Naturals):
     _inf = S.Zero
 
     def _contains(self, other):
-        if isinstance(other,Symbol):
-            return None
-        elif other.is_integer and other.is_nonnegative:
+        if other.is_integer and other.is_nonnegative:
             return S.true
-        else:
+        elif other.is_integer is False or other.is_nonnegative is False:
+            return S.false
+        elif isinstance(other,Set):
             return S.false
 
 
@@ -136,13 +134,12 @@ class Integers(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if isinstance(other,Symbol):
-            return None
-        elif other.is_integer:
+        if other.is_integer:
             return S.true
-        else:
+        elif other.is_integer is False:
             return S.false
-
+        elif isinstance(other,Set):
+            return S.false
 
     def _union(self, other):
         intersect = Intersection(self, other)
@@ -1464,11 +1461,3 @@ class Complexes(with_metaclass(Singleton, ComplexRegion)):
 
     def __repr__(self):
         return "S.Complexes"
-
-    def _contains(self,other):
-        if isinstance(other,Symbol):
-            return None
-        elif not other.is_complex:
-            return S.false
-        else:
-            return S.true

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -54,11 +54,11 @@ class Naturals(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if other.is_positive and other.is_integer:
+        if isinstance(other,Set):
+            return S.false
+        elif other.is_positive and other.is_integer:
             return S.true
         elif other.is_integer is False or other.is_positive is False:
-            return S.false
-        elif isinstance(other,Set):
             return S.false
 
     def __iter__(self):
@@ -84,11 +84,11 @@ class Naturals0(Naturals):
     _inf = S.Zero
 
     def _contains(self, other):
-        if other.is_integer and other.is_nonnegative:
+        if isinstance(other,Set):
+            return S.false
+        elif other.is_integer and other.is_nonnegative:
             return S.true
         elif other.is_integer is False or other.is_nonnegative is False:
-            return S.false
-        elif isinstance(other,Set):
             return S.false
 
 
@@ -134,11 +134,11 @@ class Integers(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if other.is_integer:
+        if isinstance(other,Set):
+            return S.false
+        elif other.is_integer:
             return S.true
         elif other.is_integer is False:
-            return S.false
-        elif isinstance(other,Set):
             return S.false
 
     def _union(self, other):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -54,11 +54,11 @@ class Naturals(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if other.is_positive and other.is_integer:
+        if not other.is_number:
+            return S.false
+        elif other.is_positive and other.is_integer:
             return S.true
         elif other.is_integer is False or other.is_positive is False:
-            return S.false
-        elif isinstance(other,Interval) or isinstance(other,FiniteSet) or isinstance(other,EmptySet):
             return S.false
 
 
@@ -85,11 +85,11 @@ class Naturals0(Naturals):
     _inf = S.Zero
 
     def _contains(self, other):
-        if other.is_integer and other.is_nonnegative:
+        if not other.is_number:
+            return S.false
+        elif other.is_integer and other.is_nonnegative:
             return S.true
         elif other.is_integer is False or other.is_nonnegative is False:
-            return S.false
-        elif isinstance(other,Interval) or isinstance(other,FiniteSet) or isinstance(other,EmptySet):
             return S.false
 
 
@@ -135,11 +135,11 @@ class Integers(with_metaclass(Singleton, Set)):
         return None
 
     def _contains(self, other):
-        if other.is_integer:
-            return S.true
-        elif other.is_integer is False:
+        if not other.is_number:
             return S.false
-        elif isinstance(other,Interval) or isinstance(other,FiniteSet) or isinstance(other,EmptySet):
+        elif other.is_integer:
+            return S.true
+        else:
             return S.false
 
 
@@ -1465,9 +1465,7 @@ class Complexes(with_metaclass(Singleton, ComplexRegion)):
         return "S.Complexes"
 
     def _contains(self,other):
-        if isinstance(other,Interval) or isinstance(other,FiniteSet) or isinstance(other,EmptySet):
+        if not other.is_complex:
             return S.false
-        elif sympify(other).is_complex:
-            return S.true
         else:
-            return S.false
+            return S.true

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1360,6 +1360,10 @@ class ComplexRegion(Set):
         isTuple = isinstance(other, Tuple)
         if isTuple and len(other) != 2:
             raise ValueError('expecting Tuple of length 2')
+
+        # If the other is a Set (FiniteSet, Interval, ...)
+        if isinstance(other,Set):
+            return False
         # self in rectangular form
         if not self.polar:
             re, im = other if isTuple else other.as_real_imag()

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -680,9 +680,9 @@ def test_issue_9980():
     assert R.func(*R.args) == R
 
 def test_issue_11732():
-    interval12 = Interval(1,2)
-    finiteset1234 = FiniteSet(1,2,3,4)
-    pointComplex = Tuple(1,5)
+    interval12 = Interval(1, 2)
+    finiteset1234 = FiniteSet(1, 2, 3, 4)
+    pointComplex = Tuple(1, 5)
 
     assert (interval12 in S.Naturals) == False
     assert (interval12 in S.Naturals0) == False

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -678,3 +678,23 @@ def test_issue_9980():
                                     Interval(1, 5)*Interval(1, 3)), False)
     assert c1.func(*c1.args) == c1
     assert R.func(*R.args) == R
+
+def test_issue_11732():
+    interval12 = Interval(1,2)
+    finiteset1234 = FiniteSet(1,2,3,4)
+    pointComplex = Tuple(1,5)
+
+    assert (interval12 in S.Naturals) == False
+    assert (interval12 in S.Naturals0) == False
+    assert (interval12 in S.Integers) == False
+    assert (interval12 in S.Complexes) == False
+
+    assert (finiteset1234 in S.Naturals) == False
+    assert (finiteset1234 in S.Naturals0) == False
+    assert (finiteset1234 in S.Integers) == False
+    assert (finiteset1234 in S.Complexes) == False
+
+    assert (pointComplex in S.Naturals) == False
+    assert (pointComplex in S.Naturals0) == False
+    assert (pointComplex in S.Integers) == False
+    assert (pointComplex in S.Complexes) == True


### PR DESCRIPTION
Returns S.false for comparing intervals and sets against these sets
`S.Integers`, `S.Naturals`, `S.Naturals0`, `S.Complexes`
Instead of throwing back errors

Example:

```
In [1]: Interval(1,2) in S.EmptySet
Out[1]: False

In [2]: Interval(1,2) in S.Integers
Out[2]: False

In [3]: Interval(1,2) in S.Naturals
Out[3]: False

In [4]: Interval(1,2) in S.Naturals0
Out[4]: False

In [5]: EmptySet() in S.Naturals0
Out[5]: False

In [6]: EmptySet() in S.Naturals
Out[6]: False

In [7]: Interval(1,2) in S.Reals
Out[7]: False

In [8]: Interval(1,2) in S.Complexes
Out[8]: False
```
