### PR TITLE
Matrix can now be symbolically indexed

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -95,14 +95,18 @@ class DenseMatrix(MatrixBase):
                 i, j = self.key2ij(key)
                 return self._mat[i*self.cols + j]
             except (TypeError, IndexError):
+                if (isinstance(i, Expr) and not i.is_number) or (isinstance(j, Expr) and not j.is_number):
+                    if ((j < 0) is True) or ((j >= self.shape[1]) is True) or\
+                       ((i < 0) is True) or ((i >= self.shape[0]) is True):
+                        raise ValueError("index out of boundary")
+                    from sympy.matrices.expressions.matexpr import MatrixElement
+                    return MatrixElement(self, i, j)
+
                 if isinstance(i, slice):
                     # XXX remove list() when PY2 support is dropped
                     i = list(range(self.rows))[i]
                 elif is_sequence(i):
                     pass
-                elif isinstance(i, Expr) and not i.is_number:
-                    from sympy.matrices.expressions.matexpr import MatrixElement
-                    return MatrixElement(self, i, j)
                 else:
                     i = [i]
                 if isinstance(j, slice):
@@ -110,9 +114,6 @@ class DenseMatrix(MatrixBase):
                     j = list(range(self.cols))[j]
                 elif is_sequence(j):
                     pass
-                elif isinstance(j, Expr) and not j.is_number:
-                    from sympy.matrices.expressions.matexpr import MatrixElement
-                    return MatrixElement(self, i, j)
                 else:
                     j = [j]
                 return self.extract(i, j)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -4,6 +4,7 @@ import random
 from sympy import Derivative
 
 from sympy.core.basic import Basic
+from sympy.core.expr import Expr
 from sympy.core.compatibility import is_sequence, as_int, range
 from sympy.core.function import count_ops
 from sympy.core.decorators import call_highest_priority
@@ -99,6 +100,9 @@ class DenseMatrix(MatrixBase):
                     i = list(range(self.rows))[i]
                 elif is_sequence(i):
                     pass
+                elif isinstance(i, Expr) and not i.is_number:
+                    from sympy.matrices.expressions.matexpr import MatrixElement
+                    return MatrixElement(self, i, j)
                 else:
                     i = [i]
                 if isinstance(j, slice):
@@ -106,6 +110,9 @@ class DenseMatrix(MatrixBase):
                     j = list(range(self.cols))[j]
                 elif is_sequence(j):
                     pass
+                elif isinstance(j, Expr) and not j.is_number:
+                    from sympy.matrices.expressions.matexpr import MatrixElement
+                    return MatrixElement(self, i, j)
                 else:
                     j = [j]
                 return self.extract(i, j)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -361,6 +361,9 @@ class MatrixElement(Expr):
 
     def _eval_derivative(self, v):
         if not isinstance(v, MatrixElement):
+            from sympy import MatrixBase
+            if isinstance(self.parent, MatrixBase):
+                return self.parent.diff(v)[self.i, self.j]
             return S.Zero
 
         if self.args[0] != v.args[0]:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -341,6 +341,16 @@ class MatrixElement(Expr):
     is_symbol = True
     is_commutative = True
 
+    def __new__(cls, name, n, m):
+        n, m = map(sympify, (n, m))
+        from sympy import MatrixBase
+        if isinstance(name, (MatrixBase,)):
+            if n.is_Integer and m.is_Integer:
+                return name[n, m]
+        name = sympify(name)
+        obj = Expr.__new__(cls, name, n, m)
+        return obj
+
     def doit(self, **kwargs):
         deep = kwargs.get('deep', True)
         if deep:

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -6,7 +6,8 @@ from sympy.functions import transpose, sin, cos, sqrt
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
-        Transpose, Adjoint)
+        SparseMatrix, Transpose, Adjoint)
+from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.utilities.pytest import raises
 
 n, m, l, k, p = symbols('n m l k p', integer=True)
@@ -273,3 +274,20 @@ def test_matrixelement_diff():
     assert w[k, p].diff(w[0, 0]) == KroneckerDelta(0, k)*KroneckerDelta(0, p)
     assert str(dexpr) == "Sum(KroneckerDelta(_k, p)*D[k, _k], (_k, 0, n - 1))"
     assert str(dexpr.doit()) == 'Piecewise((D[k, p], And(0 <= p, p <= n - 1)), (0, True))'
+
+
+def test_MatrixElement_with_values():
+    M = Matrix([[2, 3], [4, 5]])
+    i, j = symbols("i, j")
+    Mij = M[i, j]
+    assert isinstance(Mij, MatrixElement)
+    Ms = SparseMatrix([[2, 3], [4, 5]])
+    msij = M[i, j]
+    assert isinstance(msij, MatrixElement)
+    for oi, oj in [(0, 0), (0, 1), (1, 0), (1, 1)]:
+        assert Mij.subs({i: oi, j: oj}) == M[oi, oj]
+        assert msij.subs({i: oi, j: oj}) == Ms[oi, oj]
+    A = MatrixSymbol("A", 2, 2)
+    assert A[0, 0].subs(A, M) == 2
+    assert A[i, j].subs(A, M) == M[i, j]
+    assert M[i, j].subs(M, A) == A[i, j]

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -277,18 +277,19 @@ def test_matrixelement_diff():
 
 
 def test_MatrixElement_with_values():
-    M = Matrix([[2, 3], [4, 5]])
+    x, y, z, w = symbols("x y z w")
+    M = Matrix([[x, y], [z, w]])
     i, j = symbols("i, j")
     Mij = M[i, j]
     assert isinstance(Mij, MatrixElement)
     Ms = SparseMatrix([[2, 3], [4, 5]])
-    msij = M[i, j]
+    msij = Ms[i, j]
     assert isinstance(msij, MatrixElement)
     for oi, oj in [(0, 0), (0, 1), (1, 0), (1, 1)]:
         assert Mij.subs({i: oi, j: oj}) == M[oi, oj]
         assert msij.subs({i: oi, j: oj}) == Ms[oi, oj]
     A = MatrixSymbol("A", 2, 2)
-    assert A[0, 0].subs(A, M) == 2
+    assert A[0, 0].subs(A, M) == x
     assert A[i, j].subs(A, M) == M[i, j]
     assert M[i, j].subs(M, A) == A[i, j]
 
@@ -296,3 +297,11 @@ def test_MatrixElement_with_values():
     assert M[3*i - 2, j].subs({i: 1, j: 0}) == M[1, 0]
     assert isinstance(M[i, 0], MatrixElement)
     assert M[i, 0].subs(i, 0) == M[0, 0]
+    assert M[0, i].subs(i, 1) == M[0, 1]
+
+    assert M[i, j].diff(x) == Matrix([[1, 0], [0, 0]])[i, j]
+
+    raises(ValueError, lambda: M[i, 2])
+    raises(ValueError, lambda: M[i, -1])
+    raises(ValueError, lambda: M[2, i])
+    raises(ValueError, lambda: M[-1, i])

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -291,3 +291,8 @@ def test_MatrixElement_with_values():
     assert A[0, 0].subs(A, M) == 2
     assert A[i, j].subs(A, M) == M[i, j]
     assert M[i, j].subs(M, A) == A[i, j]
+
+    assert isinstance(M[3*i - 2, j], MatrixElement)
+    assert M[3*i - 2, j].subs({i: 1, j: 0}) == M[1, 0]
+    assert isinstance(M[i, 0], MatrixElement)
+    assert M[i, 0].subs(i, 0) == M[0, 0]

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -4,6 +4,7 @@ import copy
 from collections import defaultdict
 
 from sympy.core.containers import Dict
+from sympy.core.expr import Expr
 from sympy.core.compatibility import is_sequence, as_int, range
 from sympy.core.logic import fuzzy_and
 from sympy.core.singleton import S
@@ -143,6 +144,9 @@ class SparseMatrix(MatrixBase):
                     i = list(range(self.rows))[i]
                 elif is_sequence(i):
                     pass
+                elif isinstance(i, Expr) and not i.is_number:
+                    from sympy.matrices.expressions.matexpr import MatrixElement
+                    return MatrixElement(self, i, j)
                 else:
                     if i >= self.rows:
                         raise IndexError('Row index out of bounds')
@@ -152,6 +156,9 @@ class SparseMatrix(MatrixBase):
                     j = list(range(self.cols))[j]
                 elif is_sequence(j):
                     pass
+                elif isinstance(j, Expr) and not j.is_number:
+                    from sympy.matrices.expressions.matexpr import MatrixElement
+                    return MatrixElement(self, i, j)
                 else:
                     if j >= self.cols:
                         raise IndexError('Col index out of bounds')


### PR DESCRIPTION
``` python
In [3]: M = Matrix([[2, 3], [4, 5]])

In [4]: M
Out[4]: 
⎡2  3⎤
⎢    ⎥
⎣4  5⎦

In [5]: ;var i,j
Out[5]: (i, j)

In [6]: M[i, j]
Out[6]: 
⎡2  3⎤[i, j]
⎢    ⎥      
⎣4  5⎦   
```
