### PR TITLE
Fix #11727 raises RuntimeError instead of Warning in lambdify

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -409,11 +409,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     if module_provided and _module_present('numpy',namespaces):
         def array_wrap(funcarg):
             def wrapper(*argsx, **kwargsx):
-                namespace['seterr'](divide='raise')
-                try:
-                    return funcarg(*[namespace['asarray'](i) for i in argsx], **kwargsx)
-                except FloatingPointError as e:
-                    raise RuntimeError(e)
+                return funcarg(*[namespace['asarray'](i) for i in argsx], **kwargsx)
             return wrapper
         func = array_wrap(func)
     # Apply the docstring

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -409,7 +409,11 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     if module_provided and _module_present('numpy',namespaces):
         def array_wrap(funcarg):
             def wrapper(*argsx, **kwargsx):
-                return funcarg(*[namespace['asarray'](i) for i in argsx], **kwargsx)
+                namespace['seterr'](divide='raise')
+                try:
+                    return funcarg(*[namespace['asarray'](i) for i in argsx], **kwargsx)
+                except FloatingPointError as e:
+                    raise RuntimeError(e)
             return wrapper
         func = array_wrap(func)
     # Apply the docstring

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -359,8 +359,9 @@ def test_numpy_old_matrix():
 def test_python_div_zero_issue_11306():
     if not numpy:
         skip("numpy not installed.")
+    numpy.seterr(divide='raise')
     p = Piecewise((1 / x, y < -1), (x, y <= 1), (1 / x, True))
-    raises(RuntimeError,lambda:lambdify([x, y], p, modules='numpy')(0, 1))
+    raises(FloatingPointError,lambda:lambdify([x, y], p, modules='numpy')(0, 1))
 
 def test_issue9474():
     mods = [None, 'math']

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -360,7 +360,7 @@ def test_python_div_zero_issue_11306():
     if not numpy:
         skip("numpy not installed.")
     p = Piecewise((1 / x, y < -1), (x, y <= 1), (1 / x, True))
-    lambdify([x, y], p, modules='numpy')(0, 1)
+    raises(RuntimeError,lambda:lambdify([x, y], p, modules='numpy')(0, 1))
 
 def test_issue9474():
     mods = [None, 'math']
@@ -767,3 +767,4 @@ def test_Indexed():
     i, j = symbols('i j')
     b = numpy.array([[1, 2], [3, 4]])
     assert lambdify(a, Sum(a[x, y], (x, 0, 1), (y, 0, 1)))(b) == 10
+

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -768,4 +768,3 @@ def test_Indexed():
     i, j = symbols('i j')
     b = numpy.array([[1, 2], [3, 4]])
     assert lambdify(a, Sum(a[x, y], (x, 0, 1), (y, 0, 1)))(b) == 10
-


### PR DESCRIPTION
Catch the specific warning and raise RuntimeError
