### PR TITLE
geometry: Fix for rotation of Circle

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1137,7 +1137,7 @@ class Ellipse(GeometrySet):
         Ellipse(Point2D(-1, 0), 2, 1)
         """
         if self.hradius == self.vradius:
-            return self.func(*self.args)
+            return self.func(self.center.rotate(angle, pt), self.hradius)
         if (angle/S.Pi).is_integer:
             return super(Ellipse, self).rotate(angle, pt)
         if (2*angle/S.Pi).is_integer:

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -269,6 +269,13 @@ def test_ellipse_geom():
     assert e.rotate(pi, (1, 2)) == Ellipse(Point(2, 4), 2, 1)
     raises(NotImplementedError, lambda: e.rotate(pi/3))
 
+    # Circle rotation tests (Issue #11743)
+    # Link - https://github.com/sympy/sympy/issues/11743
+    cir = Circle(Point(1, 0), 1)
+    assert cir.rotate(pi/2) == Circle(Point2D(0, 1), 1)
+    assert cir.rotate(pi/3) == Circle(Point2D(1/2, sqrt(3)/2), 1)
+    assert cir.rotate(pi/3,Point(1, 0)) == Circle(Point2D(1, 0), 1)
+    assert cir.rotate(pi/3,Point(0, 1)) == Circle(Point2D(1/2 + sqrt(3)/2, 1/2 + sqrt(3)/2), 1)
 
 def test_ellipse_random_point():
     y1 = Symbol('y1', real=True)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -272,10 +272,10 @@ def test_ellipse_geom():
     # Circle rotation tests (Issue #11743)
     # Link - https://github.com/sympy/sympy/issues/11743
     cir = Circle(Point(1, 0), 1)
-    assert cir.rotate(pi/2) == Circle(Point2D(0, 1), 1)
-    assert cir.rotate(pi/3) == Circle(Point2D(1/2, sqrt(3)/2), 1)
-    assert cir.rotate(pi/3,Point(1, 0)) == Circle(Point2D(1, 0), 1)
-    assert cir.rotate(pi/3,Point(0, 1)) == Circle(Point2D(1/2 + sqrt(3)/2, 1/2 + sqrt(3)/2), 1)
+    assert cir.rotate(pi/2) == Circle(Point(0, 1), 1)
+    assert cir.rotate(pi/3) == Circle(Point(1/2, sqrt(3)/2), 1)
+    assert cir.rotate(pi/3, Point(1, 0)) == Circle(Point(1, 0), 1)
+    assert cir.rotate(pi/3, Point(0, 1)) == Circle(Point(1/2 + sqrt(3)/2, 1/2 + sqrt(3)/2), 1)
 
 def test_ellipse_random_point():
     y1 = Symbol('y1', real=True)


### PR DESCRIPTION
`rotate` function fixed for Circles
Example:

```
In [1]: cir = Circle(Point(1,0),1)

In [2]: cir.rotate(pi/2)
Out[2]: Circle(Point2D(0, 1), 1)

In [3]: cir.rotate(pi/3)
Out[3]: Circle(Point2D(1/2, sqrt(3)/2), 1)

In [4]: cir.rotate(pi/3,Point(1,0))
Out[4]: Circle(Point2D(1, 0), 1)

In [5]: cir.rotate(pi/3,Point(0,1))
Out[5]: Circle(Point2D(1/2 + sqrt(3)/2, 1/2 + sqrt(3)/2), 1)
```
