### PR TITLE
fix of #11726: pde_separate() allows expressions as input

### DIFF
--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -853,6 +853,9 @@ def pde_separate(eq, fun, sep, strategy='mul'):
     if isinstance(eq, Equality):
         if eq.rhs != 0:
             return pde_separate(Eq(eq.lhs - eq.rhs), fun, sep, strategy)
+    else:
+        return pde_separate(Eq(eq, 0), fun, sep, strategy)
+
     if eq.rhs != 0:
         raise ValueError("Value should be 0")
 

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -1,7 +1,7 @@
 from sympy import (Derivative as D, Eq, exp, sin,
     Function, Symbol, symbols, cos, log)
 from sympy.core import S
-from sympy.solvers.pde import (pde_separate_add, pde_separate_mul,
+from sympy.solvers.pde import (pde_separate, pde_separate_add, pde_separate_mul,
     pdsolve, classify_pde, checkpdesol)
 from sympy.utilities.pytest import raises
 
@@ -65,6 +65,16 @@ def test_pde_separate_mul():
     res = pde_separate_mul(eq, u(theta, r), [R(r), T(theta)])
     assert res == [r*D(R(r), r)/R(r) + r**2*D(R(r), r, r)/R(r) + c*r**2,
             -D(T(theta), theta, theta)/T(theta)]
+
+def test_issue_11726():
+    x, t = symbols("x t")
+    f  = symbols("f", cls=Function)
+    X, T = symbols("X T", cls=Function)
+
+    u = f(x, t)
+    eq = u.diff(x, 2) - u.diff(t, 2)
+    res = pde_separate(eq, u, [T(x), X(t)])
+    assert res == [D(T(x), x, x)/T(x),D(X(t), t, t)/X(t)]
 
 def test_pde_classify():
     # When more number of hints are added, add tests for classifying here.
@@ -212,3 +222,4 @@ def test_pdsolve_variable_coeff():
     eq = exp(2*x)*(u.diff(y)) + y*u - u
     sol = pdsolve(eq, hint='1st_linear_variable_coeff')
     assert sol == Eq(u, exp((-y**2 + 2*y + 2*F(x))*exp(-2*x)/2))
+

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -66,6 +66,7 @@ def test_pde_separate_mul():
     assert res == [r*D(R(r), r)/R(r) + r**2*D(R(r), r, r)/R(r) + c*r**2,
             -D(T(theta), theta, theta)/T(theta)]
 
+
 def test_issue_11726():
     x, t = symbols("x t")
     f  = symbols("f", cls=Function)
@@ -75,6 +76,7 @@ def test_issue_11726():
     eq = u.diff(x, 2) - u.diff(t, 2)
     res = pde_separate(eq, u, [T(x), X(t)])
     assert res == [D(T(x), x, x)/T(x),D(X(t), t, t)/X(t)]
+
 
 def test_pde_classify():
     # When more number of hints are added, add tests for classifying here.
@@ -222,4 +224,3 @@ def test_pdsolve_variable_coeff():
     eq = exp(2*x)*(u.diff(y)) + y*u - u
     sol = pdsolve(eq, hint='1st_linear_variable_coeff')
     assert sol == Eq(u, exp((-y**2 + 2*y + 2*F(x))*exp(-2*x)/2))
-


### PR DESCRIPTION
The problem is described in #11726. I did a little modification so that pde_separate() will accept either an Equality or an expression as input, with the expression assumed to be equal to 0. 
