### PR TITLE
Make simplify return self for matrices

### DIFF
--- a/doc/src/modules/physics/mechanics/examples/lin_pend_nonmin_example.rst
+++ b/doc/src/modules/physics/mechanics/examples/lin_pend_nonmin_example.rst
@@ -84,7 +84,7 @@ radial velocity). ::
 
   >>> f_c = Matrix([P.pos_from(pN).magnitude() - L])
   >>> f_v = Matrix([P.vel(N).express(A).dot(A.x)])
-  >>> f_v.simplify()
+  >>> _ = f_v.simplify()
 
 The force on the system is just gravity, at point ``P``. ::
 

--- a/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane.rst
+++ b/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane.rst
@@ -75,7 +75,7 @@ for the u dots (time derivatives of the generalized speeds). ::
   >>> rhs = MM.inv() * forcing
   >>> kdd = KM.kindiffdict()
   >>> rhs = rhs.subs(kdd)
-  >>> rhs.simplify()
+  >>> _ = rhs.simplify()
   >>> mprint(rhs)
   Matrix([
   [(4*g*sin(q2) + 6*r*u2*u3 - r*u3**2*tan(q2))/(5*r)],

--- a/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane_constraints.rst
+++ b/doc/src/modules/physics/mechanics/examples/rollingdisc_example_kane_constraints.rst
@@ -58,7 +58,7 @@ represent the constraint forces in those directions. ::
   >>> rhs = MM.inv() * forcing
   >>> kdd = KM.kindiffdict()
   >>> rhs = rhs.subs(kdd)
-  >>> rhs.simplify()
+  >>> _ = rhs.simplify()
   >>> mprint(rhs)
   Matrix([
   [(4*g*sin(q2) + 6*r*u2*u3 - r*u3**2*tan(q2))/(5*r)],

--- a/doc/src/modules/physics/mechanics/examples/rollingdisc_example_lagrange.rst
+++ b/doc/src/modules/physics/mechanics/examples/rollingdisc_example_lagrange.rst
@@ -56,12 +56,12 @@ accelerations(q double dots) with the ``rhs`` method. ::
   >>> q = [q1, q2, q3]
   >>> l = LagrangesMethod(Lag, q)
   >>> le = l.form_lagranges_equations()
-  >>> le.simplify(); le
+  >>> le.simplify()
   Matrix([
   [m*r**2*(6*sin(q2)*q3'' + 5*sin(2*q2)*q1'*q2' + 6*cos(q2)*q2'*q3' - 5*cos(2*q2)*q1''/2 + 7*q1''/2)/4],
   [                      m*r*(4*g*sin(q2) - 5*r*sin(2*q2)*q1'**2/2 - 6*r*cos(q2)*q1'*q3' + 5*r*q2'')/4],
   [                                                 3*m*r**2*(sin(q2)*q1'' + cos(q2)*q1'*q2' + q3'')/2]])
-  >>> lrhs = l.rhs(); lrhs.simplify(); lrhs
+  >>> lrhs = l.rhs(); lrhs.simplify()
   Matrix([
   [                                                          q1'],
   [                                                          q2'],

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -934,6 +934,7 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         for i in range(len(self._mat)):
             self._mat[i] = _simplify(self._mat[i], ratio=ratio,
                                      measure=measure)
+        return self
 
     def zip_row_op(self, i, k, f):
         """In-place operation on row ``i`` using two-arg functor whose args are

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1010,7 +1010,8 @@ def test_simplify():
                         [           1 + y, 2*((1 - 1*cos(pi*n))/(pi*n)) ]])
     eq = (1 + x)**2
     M = Matrix([[eq]])
-    M.simplify()
+    _M = M.simplify()
+    assert _M is M
     assert M == Matrix([[eq]])
     M.simplify(ratio=oo) == M
     assert M == Matrix([[eq.simplify(ratio=oo)]])


### PR DESCRIPTION
This makes `Matrix.simplify` consistent with `Expr.simplify`.
It is convenient when working in jupyter notebooks.

compare notebook cell:

```
diff1 = (sp.Matrix(f1).jacobian(y1) - sp.Matrix(j1))
diff1.simplify()
diff1
```

with 

```
(sp.Matrix(f1).jacobian(y1) - sp.Matrix(j1)).simplify()
```
