### PR TITLE
11435 str printing logic

### DIFF
--- a/doc/src/modules/logic.rst
+++ b/doc/src/modules/logic.rst
@@ -18,11 +18,11 @@ You can build Boolean expressions with the standard python operators ``&``
     >>> from sympy import *
     >>> x, y = symbols('x,y')
     >>> y | (x & y)
-    Or(And(x, y), y)
+    (x & y) | y
     >>> x | y
-    Or(x, y)
+    x | y
     >>> ~x
-    Not(x)
+    ~x
 
 You can also form implications with ``>>`` and ``<<``::
 

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -96,9 +96,9 @@ class AllArgs(UnevaluatedOnFree):
     >>> x, y = symbols('x y')
     >>> a = AllArgs(Q.positive | Q.negative)
     >>> a
-    AllArgs(Or(Q.negative, Q.positive))
+    AllArgs((Q.negative) | (Q.positive))
     >>> a.rcall(x*y)
-    And(Or(Q.negative(x), Q.positive(x)), Or(Q.negative(y), Q.positive(y)))
+    ((Q.negative(x)) | (Q.positive(x))) & ((Q.negative(y)) | (Q.positive(y)))
     """
 
     def apply(self):
@@ -123,9 +123,9 @@ class AnyArgs(UnevaluatedOnFree):
     >>> x, y = symbols('x y')
     >>> a = AnyArgs(Q.positive & Q.negative)
     >>> a
-    AnyArgs(And(Q.negative, Q.positive))
+    AnyArgs((Q.negative) & (Q.positive))
     >>> a.rcall(x*y)
-    Or(And(Q.negative(x), Q.positive(x)), And(Q.negative(y), Q.positive(y)))
+    ((Q.negative(x)) & (Q.positive(x))) | ((Q.negative(y)) & (Q.positive(y)))
     """
 
     def apply(self):
@@ -153,7 +153,7 @@ class ExactlyOneArg(UnevaluatedOnFree):
     >>> a
     ExactlyOneArg(Q.positive)
     >>> a.rcall(x*y)
-    Or(And(Not(Q.positive(x)), Q.positive(y)), And(Not(Q.positive(y)), Q.positive(x)))
+    ((Q.positive(x)) & (~(Q.positive(y)))) | ((Q.positive(y)) & (~(Q.positive(x))))
     """
     def apply(self):
         expr = self.expr

--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -276,7 +276,7 @@ def deltasummation(f, limit, no_piecewise=False):
     >>> deltasummation(KroneckerDelta(i, k), (k, 0, oo))
     Piecewise((1, 0 <= i), (0, True))
     >>> deltasummation(KroneckerDelta(i, k), (k, 1, 3))
-    Piecewise((1, And(1 <= i, i <= 3)), (0, True))
+    Piecewise((1, (1 <= i) & (i <= 3)), (0, True))
     >>> deltasummation(k*KroneckerDelta(i, j)*KroneckerDelta(j, k), (k, -oo, oo))
     j*KroneckerDelta(i, j)
     >>> deltasummation(j*KroneckerDelta(i, j), (j, -oo, oo))

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -669,7 +669,7 @@ class GreaterThan(_Greater):
     >>> type( e )
     And
     >>> e
-    And(x < y, y < z)
+    (x < y) & (y < z)
 
     Note that this is different than chaining an equality directly via use of
     parenthesis (this is currently an open bug in SymPy [2]_):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -141,8 +141,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     >>> _clash1
     {'C': C, 'E': E, 'I': I, 'N': N, 'O': O, 'Q': Q, 'S': S}
     >>> sympify('I & Q', _clash1)
-    And(I, Q)
-
+    I & Q
+    
     Strict
     ------
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -142,6 +142,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     {'C': C, 'E': E, 'I': I, 'N': N, 'O': O, 'Q': Q, 'S': S}
     >>> sympify('I & Q', _clash1)
     I & Q
+
     Strict
     ------
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -142,7 +142,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     {'C': C, 'E': E, 'I': I, 'N': N, 'O': O, 'Q': Q, 'S': S}
     >>> sympify('I & Q', _clash1)
     I & Q
-    
     Strict
     ------
 

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -481,12 +481,12 @@ def test_issue_6540_6552():
 
 
 def test_issue_6046():
-    assert str(S("Q & C", locals=_clash1)) == 'And(C, Q)'
+    assert str(S("Q & C", locals=_clash1)) == 'C & Q'
     assert str(S('pi(x)', locals=_clash2)) == 'pi(x)'
     assert str(S('pi(C, Q)', locals=_clash)) == 'pi(C, Q)'
     locals = {}
     exec_("from sympy.abc import Q, C", locals)
-    assert str(S('C&Q', locals)) == 'And(C, Q)'
+    assert str(S('C&Q', locals)) == 'C & Q'
 
 
 def test_issue_8821_highprec_from_str():

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -51,10 +51,10 @@ def bspline_basis(d, knots, n, x, close=True):
     Here is an example of a cubic B-spline:
 
         >>> bspline_basis(3, range(5), 0, x)
-        Piecewise((x**3/6, (x < 1) & (x >= 0)), 
-                  (-x**3/2 + 2*x**2 - 2*x + 2/3, (x < 2) & (x >= 1)), 
-                  (x**3/2 - 4*x**2 + 10*x - 22/3, (x < 3) & (x >= 2)), 
-                  (-x**3/6 + 2*x**2 - 8*x + 32/3, (x <= 4) & (x >= 3)), 
+        Piecewise((x**3/6, (x < 1) & (x >= 0)),
+                  (-x**3/2 + 2*x**2 - 2*x + 2/3, (x < 2) & (x >= 1)),
+                  (x**3/2 - 4*x**2 + 10*x - 22/3, (x < 3) & (x >= 2)),
+                  (-x**3/6 + 2*x**2 - 8*x + 32/3, (x <= 4) & (x >= 3)),
                   (0, True))
 
     By repeating knot points, you can introduce discontinuities in the
@@ -138,13 +138,13 @@ def bspline_basis_set(d, knots, x):
     >>> knots = range(5)
     >>> splines = bspline_basis_set(d, knots, x)
     >>> splines
-    [Piecewise((x**2/2, (x < 1) & (x >= 0)), 
-              (-x**2 + 3*x - 3/2, (x < 2) & (x >= 1)), 
-              (x**2/2 - 3*x + 9/2, (x <= 3) & (x >= 2)), 
-              (0, True)), 
-    Piecewise((x**2/2 - x + 1/2, (x < 2) & (x >= 1)), 
-             (-x**2 + 5*x - 11/2, (x < 3) & (x >= 2)), 
-             (x**2/2 - 4*x + 8, (x <= 4) & (x >= 3)), 
+    [Piecewise((x**2/2, (x < 1) & (x >= 0)),
+              (-x**2 + 3*x - 3/2, (x < 2) & (x >= 1)),
+              (x**2/2 - 3*x + 9/2, (x <= 3) & (x >= 2)),
+              (0, True)),
+    Piecewise((x**2/2 - x + 1/2, (x < 2) & (x >= 1)),
+             (-x**2 + 5*x - 11/2, (x < 3) & (x >= 2)),
+             (x**2/2 - 4*x + 8, (x <= 4) & (x >= 3)),
              (0, True))]
 
     See Also

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -43,7 +43,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 0
         >>> knots = range(5)
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((1, And(x <= 1, x >= 0)), (0, True))
+        Piecewise((1, (x <= 1) & (x >= 0)), (0, True))
 
     For a given ``(d, knots)`` there are ``len(knots)-d-1`` B-splines defined, that
     are indexed by ``n`` (starting at 0).
@@ -51,10 +51,10 @@ def bspline_basis(d, knots, n, x, close=True):
     Here is an example of a cubic B-spline:
 
         >>> bspline_basis(3, range(5), 0, x)
-        Piecewise((x**3/6, And(x < 1, x >= 0)),
-                  (-x**3/2 + 2*x**2 - 2*x + 2/3, And(x < 2, x >= 1)),
-                  (x**3/2 - 4*x**2 + 10*x - 22/3, And(x < 3, x >= 2)),
-                  (-x**3/6 + 2*x**2 - 8*x + 32/3, And(x <= 4, x >= 3)),
+        Piecewise((x**3/6, (x < 1) & (x >= 0)), 
+                  (-x**3/2 + 2*x**2 - 2*x + 2/3, (x < 2) & (x >= 1)), 
+                  (x**3/2 - 4*x**2 + 10*x - 22/3, (x < 3) & (x >= 2)), 
+                  (-x**3/6 + 2*x**2 - 8*x + 32/3, (x <= 4) & (x >= 3)), 
                   (0, True))
 
     By repeating knot points, you can introduce discontinuities in the
@@ -63,7 +63,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 1
         >>> knots = [0,0,2,3,4]
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((-x/2 + 1, And(x <= 2, x >= 0)), (0, True))
+        Piecewise((-x/2 + 1, (x <= 2) & (x >= 0)), (0, True))
 
     It is quite time consuming to construct and evaluate B-splines. If you
     need to evaluate a B-splines many times, it is best to lambdify them
@@ -138,14 +138,14 @@ def bspline_basis_set(d, knots, x):
     >>> knots = range(5)
     >>> splines = bspline_basis_set(d, knots, x)
     >>> splines
-    [Piecewise((x**2/2, And(x < 1, x >= 0)),
-               (-x**2 + 3*x - 3/2, And(x < 2, x >= 1)),
-               (x**2/2 - 3*x + 9/2, And(x <= 3, x >= 2)),
-               (0, True)),
-     Piecewise((x**2/2 - x + 1/2, And(x < 2, x >= 1)),
-               (-x**2 + 5*x - 11/2, And(x < 3, x >= 2)),
-               (x**2/2 - 4*x + 8, And(x <= 4, x >= 3)),
-               (0, True))]
+    [Piecewise((x**2/2, (x < 1) & (x >= 0)), 
+              (-x**2 + 3*x - 3/2, (x < 2) & (x >= 1)), 
+              (x**2/2 - 3*x + 9/2, (x <= 3) & (x >= 2)), 
+              (0, True)), 
+    Piecewise((x**2/2 - x + 1/2, (x < 2) & (x >= 1)), 
+             (-x**2 + 5*x - 11/2, (x < 3) & (x >= 2)), 
+             (x**2/2 - 4*x + 8, (x <= 4) & (x >= 3)), 
+             (0, True))]
 
     See Also
     ========

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -587,7 +587,7 @@ def _condsimp(cond):
     >>> from sympy import Or, Eq, unbranched_argument as arg, And
     >>> from sympy.abc import x, y, z
     >>> simp(Or(x < y, z, Eq(x, y)))
-    Or(x <= y, z)
+    (x <= y) | z
     >>> simp(Or(x <= y, And(x < y, z)))
     x <= y
     """

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -319,7 +319,7 @@ class And(LatticeOp, BooleanFunction):
     >>> from sympy.abc import x, y
     >>> from sympy.logic.boolalg import And
     >>> x & y
-    And(x, y)
+    x & y
 
     Notes
     =====
@@ -392,7 +392,7 @@ class Or(LatticeOp, BooleanFunction):
     >>> from sympy.abc import x, y
     >>> from sympy.logic.boolalg import Or
     >>> x | y
-    Or(x, y)
+    x | y
 
     Notes
     =====
@@ -471,11 +471,11 @@ class Not(BooleanFunction):
     >>> Not(Or(True, False))
     False
     >>> Not(And(And(True, x), Or(x, False)))
-    Not(x)
+    ~x
     >>> ~x
-    Not(x)
+    ~x
     >>> Not(And(Or(A, B), Or(~A, ~B)))
-    Not(And(Or(A, B), Or(Not(A), Not(B))))
+    ~(((~A) | (~B)) & (A | B))
 
     Notes
     =====
@@ -698,7 +698,7 @@ class Nand(BooleanFunction):
     >>> Nand(True, True)
     False
     >>> Nand(x, y)
-    Not(And(x, y))
+    ~(x & y)
 
     """
     @classmethod
@@ -732,7 +732,7 @@ class Nor(BooleanFunction):
     >>> Nor(False, False)
     True
     >>> Nor(x, y)
-    Not(Or(x, y))
+    ~(x | y)
 
     """
     @classmethod
@@ -963,7 +963,7 @@ def conjuncts(expr):
     >>> conjuncts(A & B)
     frozenset([A, B])
     >>> conjuncts(A | B)
-    frozenset([Or(A, B)])
+    frozenset([A | B])
 
     """
     return And.make_args(expr)
@@ -980,7 +980,7 @@ def disjuncts(expr):
     >>> disjuncts(A | B)
     frozenset([A, B])
     >>> disjuncts(A & B)
-    frozenset([And(A, B)])
+    frozenset([A & B])
 
     """
     return Or.make_args(expr)
@@ -997,7 +997,7 @@ def distribute_and_over_or(expr):
     >>> from sympy.logic.boolalg import distribute_and_over_or, And, Or, Not
     >>> from sympy.abc import A, B, C
     >>> distribute_and_over_or(Or(A, And(Not(B), Not(C))))
-    And(Or(A, Not(B)), Or(A, Not(C)))
+    ((~B) | A) & ((~C) | A)
     """
     return _distribute((expr, And, Or))
 
@@ -1015,7 +1015,7 @@ def distribute_or_over_and(expr):
     >>> from sympy.logic.boolalg import distribute_or_over_and, And, Or, Not
     >>> from sympy.abc import A, B, C
     >>> distribute_or_over_and(And(Or(Not(A), B), C))
-    Or(And(B, C), And(C, Not(A)))
+    ((~A) & C) | (B & C)
     """
     return _distribute((expr, Or, And))
 
@@ -1054,9 +1054,9 @@ def to_nnf(expr, simplify=True):
     >>> from sympy.abc import A, B, C, D
     >>> from sympy.logic.boolalg import Not, Equivalent, to_nnf
     >>> to_nnf(Not((~A & ~B) | (C & D)))
-    And(Or(A, B), Or(Not(C), Not(D)))
+    ((~C) | (~D)) & (A | B)
     >>> to_nnf(Equivalent(A >> B, B >> A))
-    And(Or(A, And(A, Not(B)), Not(B)), Or(And(B, Not(A)), B, Not(A)))
+    (((~A) & B) | (~A) | B) & (((~B) & A) | (~B) | A)
     """
     if is_nnf(expr, simplify):
         return expr
@@ -1075,9 +1075,9 @@ def to_cnf(expr, simplify=False):
     >>> from sympy.logic.boolalg import to_cnf
     >>> from sympy.abc import A, B, D
     >>> to_cnf(~(A | B) | D)
-    And(Or(D, Not(A)), Or(D, Not(B)))
+    ((~A) | D) & ((~B) | D)
     >>> to_cnf((A | B) & (A | ~A), True)
-    Or(A, B)
+    A | B
 
     """
     expr = sympify(expr)
@@ -1107,9 +1107,9 @@ def to_dnf(expr, simplify=False):
     >>> from sympy.logic.boolalg import to_dnf
     >>> from sympy.abc import A, B, C
     >>> to_dnf(B & (A | C))
-    Or(And(A, B), And(B, C))
+    (A & B) | (B & C)
     >>> to_dnf((A & B) | (A & ~B) | (B & C) | (~B & C), True)
-    Or(A, C)
+    A | C
 
     """
     expr = sympify(expr)
@@ -1277,11 +1277,11 @@ def eliminate_implications(expr):
          eliminate_implications
     >>> from sympy.abc import A, B, C
     >>> eliminate_implications(Implies(A, B))
-    Or(B, Not(A))
+    (~A) | B
     >>> eliminate_implications(Equivalent(A, B))
-    And(Or(A, Not(B)), Or(B, Not(A)))
+    ((~A) | B) & ((~B) | A)
     >>> eliminate_implications(Equivalent(A, B, C))
-    And(Or(A, Not(C)), Or(B, Not(A)), Or(C, Not(B)))
+    ((~A) | B) & ((~B) | C) & ((~C) | A)
     """
     return to_nnf(expr)
 
@@ -1590,7 +1590,7 @@ def SOPform(variables, minterms, dontcares=None):
     ...             [0, 1, 1, 1], [1, 0, 1, 1], [1, 1, 1, 1]]
     >>> dontcares = [[0, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 1]]
     >>> SOPform([w, x, y, z], minterms, dontcares)
-    Or(And(Not(w), z), And(y, z))
+    ((~w) & z) | (y & z)
 
     References
     ==========
@@ -1642,7 +1642,7 @@ def POSform(variables, minterms, dontcares=None):
     ...             [1, 0, 1, 1], [1, 1, 1, 1]]
     >>> dontcares = [[0, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 1]]
     >>> POSform([w, x, y, z], minterms, dontcares)
-    And(Or(Not(w), y), z)
+    ((~w) | y) & z
 
     References
     ==========
@@ -1711,12 +1711,12 @@ def simplify_logic(expr, form=None, deep=True):
     >>> from sympy import S
     >>> b = (~x & ~y & ~z) | ( ~x & ~y & z)
     >>> simplify_logic(b)
-    And(Not(x), Not(y))
+    (~x) & (~y)
 
     >>> S(b)
-    Or(And(Not(x), Not(y), Not(z)), And(Not(x), Not(y), z))
+    ((~x) & (~y) & (~z)) | ((~x) & (~y) & z)
     >>> simplify_logic(_)
-    And(Not(x), Not(y))
+    (~x) & (~y)
 
     """
 
@@ -1805,7 +1805,7 @@ def bool_map(bool1, bool2):
     >>> function1 = SOPform([x, z, y],[[1, 0, 1], [0, 0, 1]])
     >>> function2 = SOPform([a, b, c],[[1, 0, 1], [1, 0, 0]])
     >>> bool_map(function1, function2)
-    (And(Not(z), y), {y: a, z: b})
+    ((~z) & y, {y: a, z: b})
 
     The results are not necessarily unique, but they are canonical. Here,
     ``(w, z)`` could be ``(a, d)`` or ``(d, a)``:
@@ -1813,10 +1813,10 @@ def bool_map(bool1, bool2):
     >>> eq =  Or(And(Not(y), w), And(Not(y), z), And(x, y))
     >>> eq2 = Or(And(Not(c), a), And(Not(c), d), And(b, c))
     >>> bool_map(eq, eq2)
-    (Or(And(Not(y), w), And(Not(y), z), And(x, y)), {w: a, x: b, y: c, z: d})
+    (((~y) & w) | ((~y) & z) | (x & y), {w: a, x: b, y: c, z: d})
     >>> eq = And(Xor(a, b), c, And(c,d))
     >>> bool_map(eq, eq.subs(c, x))
-    (And(Or(Not(a), Not(b)), Or(a, b), c, d), {a: a, b: b, c: d, d: x})
+    (((~a) | (~b)) & (a | b) & c & d, {a: a, b: b, c: d, d: x})
 
     """
 

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -249,11 +249,11 @@ class PropKB(KB):
 
         >>> l.tell(x | y)
         >>> l.clauses
-        [Or(x, y)]
+        [x | y]
 
         >>> l.tell(y)
         >>> l.clauses
-        [y, Or(x, y)]
+        [y, x | y]
         """
         for c in conjuncts(to_cnf(sentence)):
             self.clauses_.add(c)
@@ -289,7 +289,7 @@ class PropKB(KB):
 
         >>> l.tell(x | y)
         >>> l.clauses
-        [Or(x, y)]
+        [x | y]
 
         >>> l.retract(x | y)
         >>> l.clauses

--- a/sympy/logic/utilities/dimacs.py
+++ b/sympy/logic/utilities/dimacs.py
@@ -21,11 +21,11 @@ def load(s):
     >>> load('1')
     cnf_1
     >>> load('1 2')
-    Or(cnf_1, cnf_2)
+    cnf_1 | cnf_2
     >>> load('1 \\n 2')
-    And(cnf_1, cnf_2)
+    cnf_1 & cnf_2
     >>> load('1 2 \\n 3')
-    And(Or(cnf_1, cnf_2), cnf_3)
+    (cnf_1 | cnf_2) & cnf_3
     """
     clauses = []
 

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -273,7 +273,7 @@ def test_matrixelement_diff():
     assert w[k, p].diff(w[k, p]) == 1
     assert w[k, p].diff(w[0, 0]) == KroneckerDelta(0, k)*KroneckerDelta(0, p)
     assert str(dexpr) == "Sum(KroneckerDelta(_k, p)*D[k, _k], (_k, 0, n - 1))"
-    assert str(dexpr.doit()) == 'Piecewise((D[k, p], And(0 <= p, p <= n - 1)), (0, True))'
+    assert str(dexpr.doit()) == 'Piecewise((D[k, p], (0 <= p) & (p <= n - 1)), (0, True))'
 
 
 def test_MatrixElement_with_values():

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -4,7 +4,7 @@ A Printer for generating readable representation of most sympy classes.
 
 from __future__ import print_function, division
 
-from sympy.core import S, Rational, Pow, Basic, Mul
+from sympy.core import S, Rational, Pow, Basic, Mul, Atom
 from sympy.core.mul import _keep_coeff
 from .printer import Printer
 from sympy.printing.precedence import precedence, PRECEDENCE
@@ -75,12 +75,28 @@ class StrPrinter(Printer):
         return "False"
 
     def _print_And(self, expr):
-        return '%s(%s)' % (expr.func, ', '.join(sorted(self._print(a) for a in
-            expr.args)))
+        sub_exprs = []
+        for a in expr.args:
+            if isinstance(a, Atom):
+                sub_exprs.append(self._print(a))
+            else:
+                sub_exprs.append('(%s)' % self._print(a))
+        return ' & '.join(sorted(sub_exprs))
 
     def _print_Or(self, expr):
-        return '%s(%s)' % (expr.func, ', '.join(sorted(self._print(a) for a in
-            expr.args)))
+        sub_exprs = []
+        for a in expr.args:
+            if isinstance(a, Atom):
+                sub_exprs.append(self._print(a))
+            else:
+                sub_exprs.append('(%s)' % self._print(a))
+        return ' | '.join(sorted(sub_exprs))
+
+    def _print_Not(self, expr):
+        if isinstance(expr.args[0], Atom):
+            return '~%s' % expr.args[0]
+        else:
+            return '~(%s)' % expr.args[0]
 
     def _print_AppliedPredicate(self, expr):
         return '%s(%s)' % (expr.func, expr.arg)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1,10 +1,10 @@
 from __future__ import division
 
-from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
+from sympy import (Abs, And, Catalan, cos, Derivative, E, EulerGamma, exp,
     factorial, factorial2, Function, GoldenRatio, I, Integer, Integral,
-    Interval, Lambda, Limit, Matrix, nan, O, oo, pi, Pow, Rational, Float, Rel,
-    S, sin, SparseMatrix, sqrt, summation, Sum, Symbol, symbols, Wild,
-    WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
+    Interval, Lambda, Limit, Matrix, nan, Not, O, Or, oo, pi, Pow, Rational,
+    Float, Rel, S, sin, SparseMatrix, sqrt, summation, Sum, Symbol, symbols,
+    Wild, WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
     AccumBounds)
 from sympy.core import Expr
@@ -188,6 +188,9 @@ def test_list():
     assert str([x**2, x*y + 1]) == sstr([x**2, x*y + 1]) == "[x**2, x*y + 1]"
     assert str([x**2, [y + x]]) == sstr([x**2, [y + x]]) == "[x**2, [x + y]]"
 
+def test_Logic():
+    assert str(And(Not(x), Or(y, z))) == "(y | z) & (~x)"
+    assert str(Not(Or(x, y))) == "~(x | y)"
 
 def test_Matrix_str():
     M = Matrix([[x**+1, 1], [y, x + y]])
@@ -660,14 +663,15 @@ def test_settings():
 def test_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, where
     X = Normal('x1', 0, 1)
-    assert str(where(X > 0)) == "Domain: And(0 < x1, x1 < oo)"
+    # print(str(where(X > 0)))
+    assert str(where(X > 0)) == "Domain: (0 < x1) & (x1 < oo)"
 
     D = Die('d1', 6)
-    assert str(where(D > 4)) == "Domain: Or(Eq(d1, 5), Eq(d1, 6))"
+    assert str(where(D > 4)) == "Domain: (Eq(d1, 5)) | (Eq(d1, 6))"
 
     A = Exponential('a', 1)
     B = Exponential('b', 1)
-    assert str(pspace(Tuple(A, B)).domain) == "Domain: And(0 <= a, 0 <= b, a < oo, b < oo)"
+    assert str(pspace(Tuple(A, B)).domain) == "Domain: (0 <= a) & (0 <= b) & (a < oo) & (b < oo)"
 
 
 def test_FiniteSet():

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -208,9 +208,9 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
     Eq(x, 0)
 
     >>> reduce_rational_inequalities([[x + 2 > 0]], x)
-    And(-2 < x, x < oo)
+    (-2 < x) & (x < oo)
     >>> reduce_rational_inequalities([[(x + 2, ">")]], x)
-    And(-2 < x, x < oo)
+    (-2 < x) & (x < oo)
     >>> reduce_rational_inequalities([[x + 2]], x)
     Eq(x, -2)
     """
@@ -282,10 +282,10 @@ def reduce_abs_inequality(expr, rel, gen):
     >>> x = Symbol('x', real=True)
 
     >>> reduce_abs_inequality(Abs(x - 5) - 3, '<', x)
-    And(2 < x, x < 8)
+    (2 < x) & (x < 8)
 
     >>> reduce_abs_inequality(Abs(x + 2)*3 - 13, '<', x)
-    And(-19/3 < x, x < 7/3)
+    (-19/3 < x) & (x < 7/3)
 
     See Also
     ========
@@ -365,10 +365,10 @@ def reduce_abs_inequalities(exprs, gen):
 
     >>> reduce_abs_inequalities([(Abs(3*x - 5) - 7, '<'),
     ... (Abs(x + 25) - 13, '>')], x)
-    And(-2/3 < x, Or(And(-12 < x, x < oo), And(-oo < x, x < -38)), x < 4)
+    (((-12 < x) & (x < oo)) | ((-oo < x) & (x < -38))) & (-2/3 < x) & (x < 4)
 
     >>> reduce_abs_inequalities([(Abs(x - 4) + Abs(3*x - 5) - 7, '<')], x)
-    And(1/2 < x, x < 4)
+    (1/2 < x) & (x < 4)
 
     See Also
     ========
@@ -421,7 +421,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals):
     >>> x = Symbol('x')
 
     >>> solve_univariate_inequality(x**2 >= 4, x)
-    Or(And(-oo < x, x <= -2), And(2 <= x, x < oo))
+    ((-oo < x) & (x <= -2)) | ((2 <= x) & (x < oo))
 
     >>> solve_univariate_inequality(x**2 >= 4, x, relational=False)
     (-oo, -2] U [2, oo)
@@ -648,7 +648,7 @@ def reduce_inequalities(inequalities, symbols=[]):
     >>> from sympy.solvers.inequalities import reduce_inequalities
 
     >>> reduce_inequalities(0 <= x + 3, [])
-    And(-3 <= x, x < oo)
+    (-3 <= x) & (x < oo)
 
     >>> reduce_inequalities(0 <= x + y*2 - 1, [x])
     x >= -2*y + 1

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -449,7 +449,7 @@ def solve(f, *symbols, **flags):
     * boolean or univariate Relational
 
         >>> solve(x < 3)
-        And(-oo < x, x < 3)
+        (-oo < x) & (x < 3)
 
     * to always get a list of solution mappings, use flag dict=True
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2336,7 +2336,7 @@ def Uniform(name, left, right):
     >>> X = Uniform("x", a, b)
 
     >>> density(X)(z)
-    Piecewise((1/(-a + b), And(a <= z, z <= b)), (0, True))
+    Piecewise((1/(-a + b), (a <= z) & (z <= b)), (0, True))
 
     >>> cdf(X)(z)  # doctest: +SKIP
     -a/(-a + b) + z/(-a + b)

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -781,13 +781,14 @@ def where(condition, given_condition=None, **kwargs):
     >>> X = Normal('x', 0, 1)
 
     >>> where(X**2<1)
-    Domain: And(-1 < x, x < 1)
+    Domain: (-1 < x) & (x < 1)
 
     >>> where(X**2<1).set
     (-1, 1)
 
     >>> where(And(D1<=D2 , D2<3))
-    Domain: Or(And(Eq(a, 1), Eq(b, 1)), And(Eq(a, 1), Eq(b, 2)), And(Eq(a, 2), Eq(b, 2)))    """
+    Domain: ((Eq(a, 1)) & (Eq(b, 1))) | ((Eq(a, 1)) & (Eq(b, 2))) | ((Eq(a, 2)) & (Eq(b, 2)))
+    """
     if given_condition is not None:  # If there is a condition
         # Recompute on new conditional expr
         return where(given(condition, given_condition, **kwargs), **kwargs)


### PR DESCRIPTION
Fixes #11435. 

Changed str printing of logic expressions to use operators &, |, ~
instead of And, Or, Not. I opted to use parentheses around all
non-Atomic expressions to achieve correctness and clarity. However,
it is worth noting that this approach sometimes uses extraneous
parentheses, as it does not account for precedence among the logical
operators.

I also fixed all tests and doctests that used the old version of printing.

Before:

```
>>> print(And(Not(x), Or(y, z)))
And(Not(x), Or(y, z))
```

After:

```
>>> print(And(Not(x), Or(y, z)))
(y | z) & (~x)
```
