### PR TITLE
Amended several line-too-long errors in frame.py

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -426,12 +426,12 @@ class ReferenceFrame(object):
             defined in relation to.
         rot_type : str
             The type of orientation matrix that is being created. Supported
-            types are 'Body', 'Space', 'Quaternion', 'Axis', and 'DCM'. See examples
-            for correct usage.
+            types are 'Body', 'Space', 'Quaternion', 'Axis', and 'DCM'.
+            See examples for correct usage.
         amounts : list OR value
             The quantities that the orientation matrix will be defined by.
-            In case of rot_type='DCM', value must be a sympy.matrices.MatrixBase object
-            (or subclasses of it).
+            In case of rot_type='DCM', value must be a
+            sympy.matrices.MatrixBase object (or subclasses of it).
         rot_order : str
             If applicable, the order of a series of rotations.
 
@@ -477,7 +477,8 @@ class ReferenceFrame(object):
 
         >>> B.orient(N, 'Axis', [q1, N.x + 2 * N.y])
 
-        Last is DCM (Direction Cosine Matrix). This is a rotation matrix given manually.
+        Last is DCM (Direction Cosine Matrix). This is a rotation matrix
+        given manually.
 
         >>> B.orient(N, 'DCM', eye(3))
         >>> B.orient(N, 'DCM', ImmutableMatrix([[0, 1, 0], [0, 0, -1], [-1, 0, 0]]))


### PR DESCRIPTION
Hello. 

Looks like sympy/physics/vector/frame.py had several too long lines in docstring of orient method.

These have now been amended.

Thank you.
