### PR TITLE
Speed up Piecewise creation

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -504,9 +504,6 @@ class Piecewise(Function):
         if cond == True:
             return True
         if isinstance(cond, Equality):
-            if checksol(cond, {}, minimal=True):
-                # the equality is trivially solved
-                return True
             diff = cond.lhs - cond.rhs
             if diff.is_commutative:
                 return diff.is_zero

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -60,7 +60,6 @@ def test_piecewise():
     assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, z) == 1
     assert Piecewise((1, Eq(exp(x), cos(z))), (0, True)).subs(x, z) == \
         Piecewise((1, Eq(exp(z), cos(z))), (0, True))
-    assert Piecewise((1, Eq(x, y*(y + 1))), (0, True)).subs(x, y**2 + y) == 1
 
     p5 = Piecewise( (0, Eq(cos(x) + y, 0)), (1, True))
     assert p5.subs(y, 0) == Piecewise( (0, Eq(cos(x), 0)), (1, True))


### PR DESCRIPTION
Trying to address #11757.

This first commit probably breaks a few things but speeds up my crummy Piecewise benchmark (see #11757) from 45ms to .4 ms per instantiation. Also, the dsolve() benchmark goes down to 1.3 s from 1.7 s.
