### PR TITLE
Amended missing docstring in frv.py

### DIFF
--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -124,6 +124,9 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
     """
 
     def __new__(cls, domain, condition):
+        """
+        Create a new instance of ConditionalFiniteDomain class
+        """
         if condition is True:
             return domain
         cond = rv_subs(condition)


### PR DESCRIPTION
Hello. 

There was a missing docstring in sympy/stats/frv.py. This has now been amended.

Thank you.
