### PR TITLE
Enabled Non Integer `nu` values in bessel.rewrite()

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -675,7 +675,6 @@ class jn(SphericalBesselBase):
     def _eval_rewrite_as_besselj(self, nu, z):
         return sqrt(pi/(2*z)) * besselj(nu + S.Half, z)
 
-    @assume_integer_order
     def _eval_rewrite_as_bessely(self, nu, z):
         return (-1)**nu * sqrt(pi/(2*z)) * bessely(-nu - S.Half, z)
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -672,7 +672,6 @@ class jn(SphericalBesselBase):
     def _rewrite(self):
         return self._eval_rewrite_as_besselj(self.order, self.argument)
 
-    @assume_integer_order
     def _eval_rewrite_as_besselj(self, nu, z):
         return sqrt(pi/(2*z)) * besselj(nu + S.Half, z)
 

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -81,10 +81,11 @@ def test_rewrite():
     # complex-valued, whereas SBFs are defined only for integer orders)
     order = nu
     for f in (besselj, bessely):
-        assert yn(order, z) == yn(order, z).rewrite(f)
-        assert jn(order, z) == jn(order, z).rewrite(f)
         assert hn1(order, z) == hn1(order, z).rewrite(f)
         assert hn2(order, z) == hn2(order, z).rewrite(f)
+
+    assert jn(order, z).rewrite(besselj) == sqrt(2)*sqrt(pi)*sqrt(1/z)*besselj(order + S(1)/2, z)/2
+    assert jn(order, z).rewrite(bessely) == (-1)**nu*sqrt(2)*sqrt(pi)*sqrt(1/z)*bessely(-order - S(1)/2, z)/2
 
     # for integral orders rewriting SBFs w.r.t bessel[jy] is allowed
     N = Symbol('n', integer=True)


### PR DESCRIPTION
Fix for #11777 . Enabled function `def _eval_rewrite_as_besselj(self, nu, z)` to accept non integer values.
### Sample Program

``` python
>>> from sympy import Symbol, jn, sin, cos, expand_func, besselj, bessely
>>> z = Symbol("z")
>>> nu = Symbol("nu")
>>> jn(nu, z).rewrite(besselj)
sqrt(2)*sqrt(pi)*sqrt(1/z)*besselj(nu + 1/2, z)/2
```
#### Note
- Some tests are failing since previously the function was not defined for non integer values and the output was:

``` python
>>> from sympy import Symbol, jn, sin, cos, expand_func, besselj, bessely
>>> u = Symbol("nu")
>>> z = Symbol("z")
>>> jn(nu, z)
```
