### PR TITLE
fixed #11779 the latex printer for the Singularity function

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1452,7 +1452,7 @@ class LatexPrinter(Printer):
     def _print_SingularityFunction(self, expr):
         shift = self._print(expr.args[0] - expr.args[1])
         power = self._print(expr.args[2])
-        tex = r"{\langle %s \rangle}^ %s" % (shift, power)
+        tex = r"{\langle %s \rangle}^ {%s}" % (shift, power)
         return tex
 
     def _print_Heaviside(self, expr, exp=None):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1452,7 +1452,7 @@ class LatexPrinter(Printer):
     def _print_SingularityFunction(self, expr):
         shift = self._print(expr.args[0] - expr.args[1])
         power = self._print(expr.args[2])
-        tex = r"{\langle %s \rangle}^ {%s}" % (shift, power)
+        tex = r"{\langle %s \rangle}^{%s}" % (shift, power)
         return tex
 
     def _print_Heaviside(self, expr, exp=None):


### PR DESCRIPTION
"The Singularity function powers [did] not print correctly in the qtconsole #11779". To fix this problem, "the latex printer simply [needed] to have curly braces around the exponent." (moorepants, October 26, 2016)
