### PR TITLE
Refixed #11779 the latex printer for the Singularity function

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1452,7 +1452,7 @@ class LatexPrinter(Printer):
     def _print_SingularityFunction(self, expr):
         shift = self._print(expr.args[0] - expr.args[1])
         power = self._print(expr.args[2])
-        tex = r"{\langle %s \rangle}^ %s" % (shift, power)
+        tex = r"{\langle %s \rangle}^ {%s}" % (shift, power)
         return tex
 
     def _print_Heaviside(self, expr, exp=None):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1452,7 +1452,7 @@ class LatexPrinter(Printer):
     def _print_SingularityFunction(self, expr):
         shift = self._print(expr.args[0] - expr.args[1])
         power = self._print(expr.args[2])
-        tex = r"{\langle %s \rangle}^ {%s}" % (shift, power)
+        tex = r"{\langle %s \rangle}^{%s}" % (shift, power)
         return tex
 
     def _print_Heaviside(self, expr, exp=None):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -138,10 +138,10 @@ def test_latex_builtins():
 
 
 def test_latex_SingularityFunction():
-    assert latex(SingularityFunction(x, 4, 5)) == r"{\langle x - 4 \rangle}^ 5"
-    assert latex(SingularityFunction(x, -3, 4)) == r"{\langle x + 3 \rangle}^ 4"
-    assert latex(SingularityFunction(x, 0, 4)) == r"{\langle x \rangle}^ 4"
-    assert latex(SingularityFunction(x, a, n)) == r"{\langle - a + x \rangle}^ n"
+    assert latex(SingularityFunction(x, 4, 5)) == r"{\langle x - 4 \rangle}^{5}"
+    assert latex(SingularityFunction(x, -3, 4)) == r"{\langle x + 3 \rangle}^{4}"
+    assert latex(SingularityFunction(x, 0, 4)) == r"{\langle x \rangle}^{4}"
+    assert latex(SingularityFunction(x, a, n)) == r"{\langle - a + x \rangle}^{n}"
 
 
 def test_latex_cycle():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -142,8 +142,9 @@ def test_latex_SingularityFunction():
     assert latex(SingularityFunction(x, -3, 4)) == r"{\langle x + 3 \rangle}^{4}"
     assert latex(SingularityFunction(x, 0, 4)) == r"{\langle x \rangle}^{4}"
     assert latex(SingularityFunction(x, a, n)) == r"{\langle - a + x \rangle}^{n}"
-
-
+    assert latex(SingularityFunction(x, 4, -2)) == r"{\langle x - 4 \rangle}^{-2}"
+    assert latex(SingularityFunction(x, 4, -1)) == r"{\langle x - 4 \rangle}^{-1}"
+    
 def test_latex_cycle():
     assert latex(Cycle(1, 2, 4)) == r"\left( 1\; 2\; 4\right)"
     assert latex(Cycle(1, 2)(4, 5, 6)) == r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -144,7 +144,7 @@ def test_latex_SingularityFunction():
     assert latex(SingularityFunction(x, a, n)) == r"{\langle - a + x \rangle}^{n}"
     assert latex(SingularityFunction(x, 4, -2)) == r"{\langle x - 4 \rangle}^{-2}"
     assert latex(SingularityFunction(x, 4, -1)) == r"{\langle x - 4 \rangle}^{-1}"
-    
+
 def test_latex_cycle():
     assert latex(Cycle(1, 2, 4)) == r"\left( 1\; 2\; 4\right)"
     assert latex(Cycle(1, 2)(4, 5, 6)) == r"\left( 1\; 2\right)\left( 4\; 5\; 6\right)"


### PR DESCRIPTION
"The Singularity function powers [did] not print correctly in the qtconsole #11779". To fix this problem, "the latex printer simply [needed] to have curly braces around the exponent." (moorepants, October 26, 2016)
