### PR TITLE
[WIP] Improve satask() performance

### DIFF
--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -21,11 +21,16 @@ class CNF(object):
     def copy(self):
         return CNF(set(self.clauses))
 
+    @classmethod
+    def from_prop(cls, prop):
+        res = CNF()
+        res.add(prop)
+        return res
+
 
 def satask(proposition, assumptions=True, context=global_assumptions,
         use_known_facts=True, iterations=oo):
-    ctx = CNF()
-    ctx.add(assumptions)
+    ctx = CNF.from_prop(assumptions)
     for c in context:
         ctx.add(c)
 
@@ -92,7 +97,9 @@ def get_all_relevant_facts(
         i += 1
 
     if use_known_facts:
+        known_facts_CNF = CNF.from_prop(get_known_facts_cnf())
         for expr in all_exprs:
-            relevant_facts.add(get_known_facts_cnf().rcall(expr))
+            for p in known_facts_CNF.clauses:
+                relevant_facts.add(p.rcall(expr))
 
     return relevant_facts

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -25,12 +25,14 @@ def satask(proposition, assumptions=True, context=global_assumptions,
     ctx.add(assumptions)
     for c in context:
         ctx.add(c)
+
     relevant_facts = get_all_relevant_facts(proposition, ctx,
         use_known_facts=use_known_facts, iterations=iterations)
+    for c in relevant_facts:
+        ctx.add(c)
 
-    assumptions = And(*ctx.clauses)
-    can_be_true = satisfiable(And(proposition, assumptions, relevant_facts))
-    can_be_false = satisfiable(And(~proposition, assumptions, relevant_facts))
+    can_be_true = satisfiable(And(proposition, *ctx.clauses))
+    can_be_false = satisfiable(And(~proposition, *ctx.clauses))
 
     if can_be_true and can_be_false:
         return None
@@ -87,4 +89,4 @@ def get_all_relevant_facts(
         for expr in all_exprs:
             relevant_facts.add(get_known_facts_cnf().rcall(expr))
 
-    return And(*relevant_facts)
+    return relevant_facts

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -56,7 +56,7 @@ class CNF(object):
         return CNF(clauses)
 
     def satisfiable(self):
-        return _satisfiable(EncodedCNF(self.clauses))
+        return _satisfiable(EncodedCNF.from_cnf(self))
 
 
 def satask(proposition, assumptions=True, context=global_assumptions,

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -3,8 +3,8 @@ from __future__ import print_function, division
 from sympy.core import oo
 
 from sympy.assumptions.assume import global_assumptions, AppliedPredicate
-from sympy.logic.algorithms.dpll2 import dpll_satisfiable as satisfiable
-from sympy.logic.boolalg import And, conjuncts, to_cnf
+from sympy.logic.algorithms.dpll2 import KB, _satisfiable
+from sympy.logic.boolalg import conjuncts, to_cnf
 from sympy.assumptions.ask_generated import get_known_facts_cnf
 from sympy.assumptions.sathandlers import fact_registry
 
@@ -17,6 +17,9 @@ class CNF(object):
 
     def add(self, proposition):
         self.clauses |= conjuncts(to_cnf(proposition))
+
+    def copy(self):
+        return CNF(set(self.clauses))
 
 
 def satask(proposition, assumptions=True, context=global_assumptions,
@@ -31,8 +34,11 @@ def satask(proposition, assumptions=True, context=global_assumptions,
     for c in relevant_facts:
         ctx.add(c)
 
-    can_be_true = satisfiable(And(proposition, *ctx.clauses))
-    can_be_false = satisfiable(And(~proposition, *ctx.clauses))
+    ctx2 = ctx.copy()
+    ctx.add(proposition)
+    can_be_true = _satisfiable(KB(ctx.clauses))
+    ctx2.add(~proposition)
+    can_be_false = _satisfiable(KB(ctx2.clauses))
 
     if can_be_true and can_be_false:
         return None

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -72,11 +72,14 @@ def satask(proposition, assumptions=True, context=global_assumptions,
         for expr in exprs:
             ctx &= known_facts_CNF.rcall(expr)
 
-    ctx2 = ctx.copy()
-    ctx.add(proposition)
-    can_be_true = ctx.satisfiable()
-    ctx2.add(~proposition)
-    can_be_false = ctx2.satisfiable()
+    sat_true = EncodedCNF.from_cnf(ctx)
+    sat_false = sat_true.copy()
+
+    sat_true.add_prop(proposition)
+    can_be_true = _satisfiable(sat_true)
+
+    sat_false.add_prop(~proposition)
+    can_be_false = _satisfiable(sat_false)
 
     if can_be_true and can_be_false:
         return None

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -47,10 +47,6 @@ def _extract_exprs(proposition, assumptions, context):
 
 def get_relevant_facts(relevant_facts, exprs, use_known_facts=True):
     newexprs = set()
-    if use_known_facts:
-        for expr in exprs:
-            relevant_facts.add(get_known_facts_cnf().rcall(expr))
-
     for expr in exprs:
         for fact in fact_registry[expr.func]:
             newfact = fact.rcall(expr)
@@ -69,11 +65,16 @@ def get_all_relevant_facts(proposition, assumptions=True,
     # infinite loop in the future.
     i = 0
     relevant_facts = set()
-    assumptions = And.make_args(assumptions)
-    exprs = _extract_exprs(proposition, assumptions, context)
+    exprs = _extract_exprs(proposition, And.make_args(assumptions), context)
+    all_exprs = set()
     while exprs and i < iterations:
+        all_exprs |= exprs
         (relevant_facts, exprs) = get_relevant_facts(
             relevant_facts, exprs, use_known_facts=use_known_facts)
         i += 1
+
+    if use_known_facts:
+        for expr in all_exprs:
+            relevant_facts.add(get_known_facts_cnf().rcall(expr))
 
     return And(*relevant_facts)

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from sympy.core import oo
 
 from sympy.assumptions.assume import global_assumptions, AppliedPredicate
-from sympy.logic.algorithms.dpll2 import KB, _satisfiable
+from sympy.logic.algorithms.dpll2 import EncodedCNF, _satisfiable
 from sympy.logic.boolalg import conjuncts, to_cnf
 from sympy.assumptions.ask_generated import get_known_facts_cnf
 from sympy.assumptions.sathandlers import fact_registry
@@ -56,7 +56,7 @@ class CNF(object):
         return CNF(clauses)
 
     def satisfiable(self):
-        return _satisfiable(KB(self.clauses))
+        return _satisfiable(EncodedCNF(self.clauses))
 
 
 def satask(proposition, assumptions=True, context=global_assumptions,

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -3,14 +3,14 @@ from __future__ import print_function, division
 from sympy.core import oo, Tuple
 
 from sympy.assumptions.assume import global_assumptions, AppliedPredicate
-from sympy.logic.inference import satisfiable
+from sympy.logic.algorithms.dpll2 import dpll_satisfiable as satisfiable
 from sympy.logic.boolalg import And
 from sympy.assumptions.ask_generated import get_known_facts_cnf
 from sympy.assumptions.sathandlers import fact_registry
 
 
 def satask(proposition, assumptions=True, context=global_assumptions,
-    use_known_facts=True, iterations=oo):
+        use_known_facts=True, iterations=oo):
     relevant_facts = get_all_relevant_facts(proposition, assumptions, context,
         use_known_facts=use_known_facts, iterations=iterations)
 

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -41,6 +41,15 @@ class EncodedCNF(object):
     def variables(self):
         return range(1, len(self.symbols) + 1)
 
+    def copy(self):
+        new_data = [set(clause) for clause in self.data]
+        return type(self)(new_data, self.encoding)
+
+    def add_prop(self, prop):
+        clauses = [self.encoding.encode(clause) for clause in conjuncts(to_cnf(prop))]
+        self.data += clauses
+
+
 class SATEncoding(object):
     def __init__(self, symbols):
         self.symbols = symbols


### PR DESCRIPTION
This branch makes satask() about 20 times faster. There are no real algorithmic changes, this simply uses explicit data structures to avoid expensive operations such as `And` instantiations, `to_cnf()` or `known_facts.rcall()`. The bottleneck now appears to be converting the "relevant facts" to CNF.

To do:
- [ ] Stabilise and clean up the new APIs
- [ ] Add unit tests for them
- [ ] Fix test failures
- [ ] Worry about backwards compatibility