### PR TITLE
Added docstring to _test method in frv.py

### DIFF
--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -143,6 +143,11 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
 
 
     def _test(self, elem):
+        """
+        Test the value. If value is boolean, return it. If value is equality
+        relational (two objects are equal), return it with left-hand side
+        being equal to right-hand side. Otherwise, raise ValueError exception.
+        """
         val = self.condition.xreplace(dict(elem))
         if val in [True, False]:
             return val


### PR DESCRIPTION
Hi. 

There was another method missing a docstring in sympy/stats/frv.py.

This has been now amended.

Thank you.