### PR TITLE
Enabled ASCII printing of Singularity Functions

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1151,10 +1151,10 @@ class PrettyPrinter(Printer):
             pform = base**n
             return pform
         else:
-            base = "<"
-            base += str(e.args[0]-e.args[1])
-            base += ">"
-            return self._print(base)**self._print(e.args[2])
+            n = self._print(e.args[2])
+            shift = self._print(e.args[0]-e.args[1])
+            base = self._print_seq(shift, "<", ">", ' ')
+            return base**n
 
     def _print_gamma(self, e):
         if self._use_unicode:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1151,7 +1151,10 @@ class PrettyPrinter(Printer):
             pform = base**n
             return pform
         else:
-            return self._print_Function(e)
+            base = "<"
+            base += str(e.args[0]-e.args[1])
+            base += ">"
+            return self._print(base)**self._print(e.args[2])
 
     def _print_gamma(self, e):
         if self._use_unicode:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4477,6 +4477,31 @@ def test_SingularityFunction():
        n\n\
 <x - y> \
 """)
+    assert xpretty(SingularityFunction(x, 0, n), use_unicode=False) == (
+"""\
+   n\n\
+<x> \
+""")
+    assert xpretty(SingularityFunction(x, 1, n), use_unicode=False) == (
+"""\
+       n\n\
+<x - 1> \
+""")
+    assert xpretty(SingularityFunction(x, -1, n), use_unicode=False) == (
+"""\
+       n\n\
+<x + 1> \
+""")
+    assert xpretty(SingularityFunction(x, a, n), use_unicode=False) == (
+"""\
+        n\n\
+<-a + x> \
+""")
+    assert xpretty(SingularityFunction(x, y, n), use_unicode=False) == (
+"""\
+       n\n\
+<x - y> \
+""")
 
 
 def test_deltas():


### PR DESCRIPTION
Fixes #11524. Added code for ASCII printing of Singularity Functions.

#### Sample Program
```python
>>> from sympy import SingularityFunction, pprint
>>> from sympy.abc import x, a, n
>>> pprint(SingularityFunction(x, a, n),use_unicode=False)
        n
<-a + x> 
```

* Tests are added.