### PR TITLE
Interval(oo, oo) returns S.EmptySet

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -737,6 +737,8 @@ class Interval(Set, EvalfMixin):
         if end == start and (left_open or right_open):
             return S.EmptySet
         if end == start and not (left_open or right_open):
+            if start == S.Infinity:
+                return S.EmptySet
             return FiniteSet(end)
 
         # Make sure infinite interval end points are open.

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -737,7 +737,7 @@ class Interval(Set, EvalfMixin):
         if end == start and (left_open or right_open):
             return S.EmptySet
         if end == start and not (left_open or right_open):
-            if start == S.Infinity:
+            if start == S.Infinity or start == S.NegativeInfinity:
                 return S.EmptySet
             return FiniteSet(end)
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -36,6 +36,7 @@ def test_interval_arguments():
     assert Interval(-oo, 0).left_open is true
     assert Interval(oo, -oo) == S.EmptySet
     assert Interval(oo, oo) == S.EmptySet
+    assert Interval(-oo, -oo) == S.EmptySet
 
     assert isinstance(Interval(1, 1), FiniteSet)
     e = Sum(x, (x, 1, 3))

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -35,6 +35,7 @@ def test_interval_arguments():
     assert Interval(-oo, 0) == Interval(-oo, 0, True, False)
     assert Interval(-oo, 0).left_open is true
     assert Interval(oo, -oo) == S.EmptySet
+    assert Interval(oo, oo) == S.EmptySet
 
     assert isinstance(Interval(1, 1), FiniteSet)
     e = Sum(x, (x, 1, 3))


### PR DESCRIPTION
Fixes #11731. Added test for case when `Interval(oo, oo)` to return `S.EmptySet`.

### Sample Program
```python 
>>> from sympy import Interval, oo
>>> Interval(oo, oo)
EmptySet()
```


* Tests are added.