### PR TITLE
solve : Solutions with spurious real/imaginary terms are discarded(Fix for : #11760 )

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2615,8 +2615,9 @@ def nfloat(expr, n=15, exponent=False):
     if rv.is_Number:
         return Float(rv, n)
     elif rv.is_number:
+        from sympy.core.evalf import N
         # evalf doesn't always set the precision
-        rv = rv.n(n)
+        rv = N(rv, n, chop=True)
         if rv.is_Number:
             rv = Float(rv.n(n), n)
         else:


### PR DESCRIPTION
If the imaginary part of a rational expression is of form `0.e-exp`  then it should be discarded.

See `chop` options in : http://docs.sympy.org/dev/modules/evalf.html#accuracy-and-error-handling

Example(Issue : #11760 ) : 
```
from sympy import *
x, F, b, E, I, l, w, a = symbols('x, F, b, E, I, l, w, a', real=True)
y_AB = F * b * x**2 / 12 / E / I / l**3 * (3 * l * (b**2 - l**2) + x * (3 * l**2 - b**2))
y_BC = y_AB - F * (x - a)**3 / 6 / E / I
y = w * x**2 / 48 / E / I * (l - x) * (2 * x - 3 * l)
y_AB_sup = y_AB + y
y_BC_sup = y_BC + y
theta_AB = y_AB_sup.diff(x).expand().collect(x)
theta_BC = y_BC_sup.diff(x).expand().collect(x)
vals = {E: 30E6, I: 5, w: 100 / 12, F: 1000, a: 7 * 12, b: 3 * 12, l: 10 * 12}
theta_AB.subs(vals)
theta_BC.subs(vals)

print(solveset(theta_BC.subs(vals), x))
print(solve(theta_BC.subs(vals), x))
```
Previously : 
```
{-212.458467511565, 74.8365518854033, 159.761915626161}
[]
```
With the fix : 
```
{-212.458467511565, 74.8365518854033, 159.761915626161}
[-212.458467511565, 74.8365518854033, 159.761915626161]
```
Fixes : #11760 