### PR TITLE
Fixing #11801

### DIFF
--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -24,6 +24,9 @@ def split_super_sub(text):
        ('var', ['sup'], ['sub1', 'sub2'])
 
     """
+    if len(text) == 0:
+        return text, [], []
+    
     pos = 0
     name = None
     supers = []

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -26,7 +26,7 @@ def split_super_sub(text):
     """
     if len(text) == 0:
         return text, [], []
-    
+
     pos = 0
     name = None
     supers = []

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5538,3 +5538,7 @@ def test_pretty_Mod():
     assert upretty(Mod(x, 7) + 1) == ucode_str4
     assert pretty(2 * Mod(x, 7)) == ascii_str5
     assert upretty(2 * Mod(x, 7)) == ucode_str5
+
+def test_issue_11801():
+    assert pretty(Symbol("")) == ""
+    assert upretty(Symbol("")) == ""

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -29,6 +29,7 @@ def test_super_sub():
     assert split_super_sub("x__a__b__c__d") == ("x", ["a", "b", "c", "d"], [])
     assert split_super_sub("alpha_11") == ("alpha", [], ["11"])
     assert split_super_sub("alpha_11_11") == ("alpha", [], ["11", "11"])
+    assert split_super_sub("") == ("", [], [])
 
 def test_requires_partial():
     x, y, z, t, nu = symbols('x y z t nu')


### PR DESCRIPTION
The code in the split_super_sub in conventions.py file assumes that that the length of the symbol is greater than 0. So I added an if statement to check for variable names that have length 0 and return the expected result. 