### PR TITLE
Implemented docstrings to basic.py

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -391,6 +391,9 @@ class Basic(with_metaclass(ManagedProperties)):
     # Note, we always use the default ordering (lex) in __str__ and __repr__,
     # regardless of the global setting.  See issue 5487.
     def __repr__(self):
+        """Method to return the string representation.
+        Return the expression as a string.
+        """
         from sympy.printing import sstr
         return sstr(self, order=None)
 
@@ -542,6 +545,8 @@ class Basic(with_metaclass(ManagedProperties)):
 
     @staticmethod
     def _recursive_call(expr_to_call, on_args):
+        """Helper for rcall method.
+        """
         from sympy import Symbol
         def the_call_method_is_overridden(expr):
             for cls in getmro(type(expr)):


### PR DESCRIPTION
Hi. Looks like basic.py was missing couple of docstrings. These have been now implemented.