### PR TITLE
Fix #11827 Naturals0 can be intersection

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -665,6 +665,11 @@ class ProductSet(Set):
     def __len__(self):
         return Mul(*[len(s) for s in self.args])
 
+    def __bool__(self):
+        return all([bool(s) for s in self.args])
+
+    __nonzero__ = __bool__
+
 
 class Interval(Set, EvalfMixin):
     """

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -963,6 +963,8 @@ def test_issue_Symbol_inter():
     assert Intersection(FiniteSet(x**2, 1, sin(x)), FiniteSet(x**2, 2, sin(x)), r) == \
         Intersection(r, FiniteSet(x**2, sin(x)))
 
+def test_issue_11827():
+    assert S.Naturals0**4
 
 def test_issue_10113():
     f = x**2/(x**2 - 4)


### PR DESCRIPTION
Fix #11827 Naturals0 can be intersection

## After this PR:

```python
In [1]: from sympy import *

In [2]: d = symbols("d")

In [3]: solution = sets.FiniteSet((d + 1, -d + 4, -d + 5, d))

In [4]: solution.intersect(S.Naturals0**4)
Out[4]: Intersection(Naturals0() x Naturals0() x Naturals0() x Naturals0(), {(d + 1, -d + 4, -d + 5, d)})
```