### PR TITLE
Adapted the Rate.m package (for Mathematica) to sympy.concrete.guess.guess

### DIFF
--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -381,15 +381,17 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
 
 
 @public
-def guess(l, stop=False, evaluate=True, niter=None):
+def guess(l, all=False, evaluate=True, niter=None):
     """
     This function is adapted from the Rate.m package for Mathematica
     written by Christian Krattenthaler.
     It tries to guess a formula from a given sequence of rational numbers.
 
-    In order to speed up the process, the 'stop' variable allows to stop
-    the computation as soon as at least one answer is detected during an
-    iteration.
+    In order to speed up the process, the 'all' variable is set to False by
+    default, stopping the computation as some results are returned during an
+    iteration; the variable can be set to True if more iterations are needed
+    (other formulas may be found; however they may be equivalent to the first
+    ones).
 
     Another option is the 'evaluate' variable (default is True); setting it
     to False will leave the involved products unevaluated.
@@ -431,6 +433,6 @@ def guess(l, stop=False, evaluate=True, niter=None):
             for i in range(k):
                 r = list(map(lambda v: g[k-i-1][0]
                       * myprod(v, (symb[k-i], 1, symb[k-i-1]-1)), r))
-            if stop: return r
+            if not all: return r
             res += r
     return res

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -425,8 +425,8 @@ def guess(l, all=False, evaluate=True, niter=2, variables=None):
     >>> [r[0].subs(i0,n).doit() for n in range(1,10)]
     [1, 2, 7, 42, 429, 7436, 218348, 10850216, 911835460]
     """
-    n = len(l)
-    niter = min(n-1, niter)
+    N = len(l)
+    niter = min(N-1, niter)
     myprod = product if evaluate else Product
     g = []
     res = []
@@ -436,12 +436,11 @@ def guess(l, all=False, evaluate=True, niter=2, variables=None):
         symb = variables
     for k, s in enumerate(symb):
         g.append(l)
-        l = [Rational(l[i+1], l[i]) for i in range(n-k-1)]
         n, r = len(g[k]), []
         for i in range(n-1):
             ri = rinterp(enumerate(g[k][:-1], start=1), n-2-i, X=s)
             if ((denom(ri).subs({s:n}) != 0)
-                    and (ri.subs({s:n})-g[k][-1] == 0)
+                    and (ri.subs({s:n}) - g[k][-1] == 0)
                     and ri not in r):
               r.append(ri)
         if r:
@@ -450,4 +449,5 @@ def guess(l, all=False, evaluate=True, niter=2, variables=None):
                       * myprod(v, (symb[k-i], 1, symb[k-i-1]-1)), r))
             if not all: return r
             res += r
+        l = [Rational(l[i+1], l[i]) for i in range(N-k-1)]
     return res

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -63,13 +63,13 @@ def find_simple_recurrence_vector(l):
         m = [a]
         for k in range(b+1, len(l)):
             m.append(-sum(l[j+1]*m[b-j-1] for j in range(b, k))*a)
-        l, q = m, [0] * max(len(q2), b+len(q1))
+        l, m = m, [0] * max(len(q2), b+len(q1))
         for k in range(len(q2)):
-            q[k] = a*q2[k]
+            m[k] = a*q2[k]
         for k in range(b, b+len(q1)):
-            q[k] += q1[k-b]
-        while q[-1]==0: q.pop() # because trailing zeros can occur
-        q1, q2, b = q2, q, 1
+            m[k] += q1[k-b]
+        while m[-1]==0: m.pop() # because trailing zeros can occur
+        q1, q2, b = q2, m, 1
     return [0]
 
 @public
@@ -420,18 +420,17 @@ def guess(l, stop=False, evaluate=True, niter=None):
     for k, s in enumerate(symb):
         g.append(l)
         l = [Rational(l[i+1], l[i]) for i in range(n-k-1)]
-        if k:
-            n, r = len(g[k]), []
-            for i in range(n-1):
-                ri = rinterp(enumerate(g[k][:-1], start=1), n-2-i, X=s)
-                if ((denom(ri).subs({s:n}) != 0)
-                        and (ri.subs({s:n})-g[k][-1] == 0)
-                        and ri not in r):
-                  r.append(ri)
-            if r:
-                for i in range(k):
-                    r = list(map(lambda v: g[k-i-1][0]
-                          * myprod(v, (symb[k-i], 1, symb[k-i-1]-1)), r))
-                if stop: return r
-                res += r
+        n, r = len(g[k]), []
+        for i in range(n-1):
+            ri = rinterp(enumerate(g[k][:-1], start=1), n-2-i, X=s)
+            if ((denom(ri).subs({s:n}) != 0)
+                    and (ri.subs({s:n})-g[k][-1] == 0)
+                    and ri not in r):
+              r.append(ri)
+        if r:
+            for i in range(k):
+                r = list(map(lambda v: g[k-i-1][0]
+                      * myprod(v, (symb[k-i], 1, symb[k-i-1]-1)), r))
+            if stop: return r
+            res += r
     return res

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -436,9 +436,9 @@ def guess(l, all=False, evaluate=True, niter=2, variables=None):
         symb = variables
     for k, s in enumerate(symb):
         g.append(l)
-        n, r = len(g[k]), []
-        for i in range(n-1):
-            ri = rinterp(enumerate(g[k][:-1], start=1), n-2-i, X=s)
+        n, r = len(l), []
+        for i in range(n-2-1, -1, -1):
+            ri = rinterp(enumerate(g[k][:-1], start=1), i, X=s)
             if ((denom(ri).subs({s:n}) != 0)
                     and (ri.subs({s:n}) - g[k][-1] == 0)
                     and ri not in r):

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -425,6 +425,8 @@ def guess(l, all=False, evaluate=True, niter=2, variables=None):
     >>> [r[0].subs(i0,n).doit() for n in range(1,10)]
     [1, 2, 7, 42, 429, 7436, 218348, 10850216, 911835460]
     """
+    if any(a==0 for a in l[:-1]):
+        return []
     N = len(l)
     niter = min(N-1, niter)
     myprod = product if evaluate else Product
@@ -444,9 +446,9 @@ def guess(l, all=False, evaluate=True, niter=2, variables=None):
                     and ri not in r):
               r.append(ri)
         if r:
-            for i in range(k):
-                r = list(map(lambda v: g[k-i-1][0]
-                      * myprod(v, (symb[k-i], 1, symb[k-i-1]-1)), r))
+            for i in range(k-1, -1, -1):
+                r = list(map(lambda v: g[i][0]
+                      * myprod(v, (symb[i+1], 1, symb[i]-1)), r))
             if not all: return r
             res += r
         l = [Rational(l[i+1], l[i]) for i in range(N-k-1)]

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -430,8 +430,8 @@ def guess(l, stop=False, evaluate=True, niter=None):
                   r.append(ri)
             if r:
                 for i in range(k):
-                    r = map(lambda v: g[k-i-1][0]
-                          * myprod(v, (symb[k-i], 1, symb[k-i-1]-1)), r)
+                    r = list(map(lambda v: g[k-i-1][0]
+                          * myprod(v, (symb[k-i], 1, symb[k-i-1]-1)), r))
                 if stop: return r
-                res += list(r)
+                res += r
     return res

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -381,7 +381,7 @@ def guess_generating_function(v, X=Symbol('x'), types=['all'], maxsqrtn=2):
 
 
 @public
-def guess(l, all=False, evaluate=True, niter=None):
+def guess(l, all=False, evaluate=True, niter=2, variables=None):
     """
     This function is adapted from the Rate.m package for Mathematica
     written by Christian Krattenthaler.
@@ -396,11 +396,24 @@ def guess(l, all=False, evaluate=True, niter=None):
     Another option is the 'evaluate' variable (default is True); setting it
     to False will leave the involved products unevaluated.
 
-    By default, the number of iterations is set to len(l)-1 but a lower
-    value can be specified with the optional 'niter' variable.
+    By default, the number of iterations is set to 2 but a greater value (up
+    to len(l)-1) can be specified with the optional 'niter' variable.
+    More and more convoluted results are found when the order of the
+    iteration gets higher:
+
+      * first iteration returns polynomial or rational functions;
+      * second iteration returns products of rising factorials and their
+        inverses;
+      * third iteration returns products of products of rising factorials
+        and their inverses;
+      * etc.
 
     The returned formulas contain symbols i0, i1, i2, ... where the main
-    variables is i0 (and auxiliary variables are i1, i2, ...).
+    variables is i0 (and auxiliary variables are i1, i2, ...). A list of
+    other symbols can be provided in the 'variables' option; the length of
+    the least should be the value of 'niter' (more is acceptable but only
+    the first symbols will be used); in this case, the main variable will be
+    the first symbol in the list.
 
     >>> from sympy.concrete.guess import guess
     >>> guess([1,2,6,24,120], evaluate=False)
@@ -413,12 +426,14 @@ def guess(l, all=False, evaluate=True, niter=None):
     [1, 2, 7, 42, 429, 7436, 218348, 10850216, 911835460]
     """
     n = len(l)
-    if niter==None: niter = n-1
-    else: niter = min(n-1, niter)
+    niter = min(n-1, niter)
     myprod = product if evaluate else Product
     g = []
     res = []
-    symb = symbols('i:'+str(niter))
+    if variables == None:
+        symb = symbols('i:'+str(niter))
+    else:
+        symb = variables
     for k, s in enumerate(symb):
         g.append(l)
         l = [Rational(l[i+1], l[i]) for i in range(n-k-1)]

--- a/sympy/concrete/guess.py
+++ b/sympy/concrete/guess.py
@@ -420,7 +420,7 @@ def guess(l, all=False, evaluate=True, niter=2, variables=None):
     [Product(i1 + 1, (i1, 1, i0 - 1))]
 
     >>> from sympy import symbols
-    >>> r = guess([1,2,7,42,429,7436,218348,10850216])
+    >>> r = guess([1,2,7,42,429,7436,218348,10850216], niter=4)
     >>> i0 = symbols("i0")
     >>> [r[0].subs(i0,n).doit() for n in range(1,10)]
     [1, 2, 7, 42, 429, 7436, 218348, 10850216, 911835460]

--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -297,20 +297,19 @@ def rational_interpolate(data, degnum, X=symbols('x')):
 
     xdata, ydata = list(zip(*data))
 
-    m = degnum + 1
-    k = len(xdata) - m - 1
-    if k<1:
+    k = len(xdata) - degnum - 1
+    if k<0:
         raise OptionError("Too few values for the required degree.")
-    c = ones(m+k+1, m+k+2)
-    for j in range(max(m, k)):
-        for i in range(m+k+1):
+    c = ones(degnum+k+1, degnum+k+2)
+    for j in range(max(degnum, k)):
+        for i in range(degnum+k+1):
             c[i, j+1] = c[i, j]*xdata[i]
     for j in range(k+1):
-        for i in range(m+k+1):
-            c[i, m+k+1-j] = -c[i, k-j]*ydata[i]
+        for i in range(degnum+k+1):
+            c[i, degnum+k+1-j] = -c[i, k-j]*ydata[i]
     r = c.nullspace()[0]
-    return (sum(r[i] * X**i for i in range(m+1))
-            / sum(r[i+m+1] * X**i for i in range(k+1)))
+    return (sum(r[i] * X**i for i in range(degnum+1))
+            / sum(r[i+degnum+1] * X**i for i in range(k+1)))
 
 
 @public


### PR DESCRIPTION
This commit contains two changes:

  * fixed a small error in `sympy.polys.polyfuncs.rational_interpolate` where the degree of the numerator was shifted by 1 (strangely, the tests were right, but for some other values, the expected numerator was getting a degree higher (by 1) than expected);
  * added a `sympy.concrete.guess.guess` function adapted from the famous [Rate.m](http://www.mat.univie.ac.at/~kratt/rate/rate.html) package for Mathematica.

I discovered the bug in the first function by using it when writing the new `guess()` function. Everything seems to be consistent now.

@mattpap and @certik , Could you review this commit? Best regards.