### PR TITLE
Implement Dummy HASH

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -707,8 +707,7 @@ class Function(Application, Expr):
             else:
                 return Derivative(self, self.args[argindex - 1], evaluate=False)
         # See issue 4624 and issue 4719 and issue 5600
-        arg_dummy = Dummy('xi_%i' % argindex)
-        arg_dummy.dummy_index = hash(self.args[argindex - 1])
+        arg_dummy = Dummy('xi_%i' % argindex, shash=abs(hash(self.args[argindex - 1])))
         new_args = [arg for arg in self.args]
         new_args[argindex-1] = arg_dummy
         return Subs(Derivative(self.func(*new_args), arg_dummy),
@@ -1178,8 +1177,7 @@ class Derivative(Expr):
                 obj = None
             else:
                 if not is_symbol:
-                    new_v = Dummy('xi_%i' % i)
-                    new_v.dummy_index = hash(v)
+                    new_v = Dummy('xi_%i' % i, shash=abs(hash(v)))
                     expr = expr.xreplace({v: new_v})
                     old_v = v
                     v = new_v

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -211,11 +211,6 @@ class Dummy(Symbol):
             while shash in Dummy._count:
                 # Always positive
                 shash = int('%i%i' % (len(Dummy._count), random.randint(1, 10**24)))
-        else:
-            shash = int(shash)
-
-        if shash not in Dummy._count:
-            Dummy._count.append(shash)
 
         obj.dummy_index = shash
         return obj
@@ -225,13 +220,17 @@ class Dummy(Symbol):
 
     @cacheit
     def sort_key(self, order=None):
-        if self.dummy_index not in Dummy._count: Dummy._count.append(self.dummy_index)
-
         return self.class_key(), (
             2, (str(self), Dummy._count.index(self.dummy_index))), S.One.sort_key(), S.One
 
     def _hashable_content(self):
         return Symbol._hashable_content(self) + (self.dummy_index,)
+
+    def __setattr__(self, key, value):
+        if key=='dummy_index':
+            assert not isinstance(value, str) and str(value).isdigit() and value > 0, 'HASH must be an integer and > 0'
+            if value not in Dummy._count: Dummy._count.append(value)
+        super(Dummy, self).__setattr__(key, value)
 
 
 class Wild(Symbol):

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -14,6 +14,7 @@ from sympy.utilities.iterables import cartes
 
 import string
 import re as _re
+import random
 
 
 class Symbol(AtomicExpr, Boolean):
@@ -193,21 +194,31 @@ class Dummy(Symbol):
 
     """
 
-    _count = 0
+    _count = [None]
 
     __slots__ = ['dummy_index']
 
     is_Dummy = True
 
-    def __new__(cls, name=None, **assumptions):
+    def __new__(cls, name=None, shash=None, **assumptions):
         if name is None:
-            name = "Dummy_" + str(Dummy._count)
+            name = "Dummy_" + str(Dummy._count[-1])[-24:]
 
         cls._sanitize(assumptions, cls)
         obj = Symbol.__xnew__(cls, name, **assumptions)
 
-        Dummy._count += 1
-        obj.dummy_index = Dummy._count
+        if shash is None:
+            while shash in Dummy._count:
+                shash = str(name)
+                for i in range(24):
+                    shash += random.SystemRandom().choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
+        else:
+            shash = str(shash)
+
+        if shash not in Dummy._count:
+            Dummy._count.append(shash)
+
+        obj.dummy_index = shash
         return obj
 
     def __getstate__(self):

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -194,26 +194,25 @@ class Dummy(Symbol):
 
     """
 
-    _count = [None]
+    _count = [0]
 
     __slots__ = ['dummy_index']
 
     is_Dummy = True
 
-    def __new__(cls, name=None, shash=None, **assumptions):
+    def __new__(cls, name=None, shash=0, **assumptions):
         if name is None:
-            name = "Dummy_" + str(Dummy._count[-1])[-24:]
+            name = "Dummy_" + str(len(Dummy._count))
 
         cls._sanitize(assumptions, cls)
         obj = Symbol.__xnew__(cls, name, **assumptions)
 
-        if shash is None:
+        if shash == 0:
             while shash in Dummy._count:
-                shash = str(name)
-                for i in range(24):
-                    shash += random.SystemRandom().choice(string.ascii_uppercase + string.ascii_lowercase + string.digits)
+                # Always positive
+                shash = int('%i%i' % (len(Dummy._count), random.randint(1, 10**24)))
         else:
-            shash = str(shash)
+            shash = int(shash)
 
         if shash not in Dummy._count:
             Dummy._count.append(shash)
@@ -226,8 +225,10 @@ class Dummy(Symbol):
 
     @cacheit
     def sort_key(self, order=None):
+        if self.dummy_index not in Dummy._count: Dummy._count.append(self.dummy_index)
+
         return self.class_key(), (
-            2, (str(self), self.dummy_index)), S.One.sort_key(), S.One
+            2, (str(self), Dummy._count.index(self.dummy_index))), S.One.sort_key(), S.One
 
     def _hashable_content(self):
         return Symbol._hashable_content(self) + (self.dummy_index,)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1378,6 +1378,9 @@ def test_expr_sorting():
     exprs = [{1}, {1, 2}]
     assert sorted(exprs, key=default_sort_key) == exprs
 
+    a, b = exprs = [Dummy('x'), Dummy('x')]
+    assert sorted([b, a], key=default_sort_key) == exprs
+
 
 def test_as_ordered_factors():
     f, g = symbols('f,g', cls=Function)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1378,9 +1378,6 @@ def test_expr_sorting():
     exprs = [{1}, {1, 2}]
     assert sorted(exprs, key=default_sort_key) == exprs
 
-    a, b = exprs = [Dummy('x'), Dummy('x')]
-    assert sorted([b, a], key=default_sort_key) == exprs
-
 
 def test_as_ordered_factors():
     f, g = symbols('f,g', cls=Function)

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -30,10 +30,6 @@ def test_Symbol():
 
 def test_Dummy():
     assert Dummy() != Dummy()
-    Dummy._count = 0
-    d1 = Dummy()
-    Dummy._count = 0
-    assert d1 == Dummy()
 
 
 def test_as_dummy():

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -12,7 +12,7 @@ from .printer import Printer
 import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps, repr_dps
 from sympy.core.compatibility import range
-
+from sympy.core.symbol import Dummy
 
 class ReprPrinter(Printer):
     printmethod = "_sympyrepr"
@@ -145,12 +145,17 @@ class ReprPrinter(Printer):
 
     def _print_Symbol(self, expr):
         d = expr._assumptions.generator
+        if isinstance(expr, Dummy):
+            t = ", shash='%s'" % expr.dummy_index
+        else:
+            t = ""
+
         if d == {}:
-            return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
+            return "%s(%s%s)" % (expr.__class__.__name__, self._print(expr.name), t)
         else:
             attr = ['%s=%s' % (k, v) for k, v in d.items()]
-            return "%s(%s, %s)" % (expr.__class__.__name__,
-                                   self._print(expr.name), ', '.join(attr))
+            return "%s(%s%s, %s)" % (expr.__class__.__name__,
+                                   self._print(expr.name), t, ', '.join(attr))
 
     def _print_Predicate(self, expr):
         return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -146,7 +146,7 @@ class ReprPrinter(Printer):
     def _print_Symbol(self, expr):
         d = expr._assumptions.generator
         if isinstance(expr, Dummy):
-            t = ", shash='%s'" % expr.dummy_index
+            t = ", shash=%i" % expr.dummy_index
         else:
             t = ""
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -284,7 +284,7 @@ def test_ccode_loops_matrix_vector():
 
 
 def test_dummy_loops():
-    i, m = symbols('i m', integer=True, cls=Dummy)
+    i, m = Dummy('i', integer=True, shash=500), Dummy('m', integer=True, shash=501)
     x = IndexedBase('x')
     y = IndexedBase('y')
     i = Idx(i, m)

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -536,7 +536,7 @@ def test_loops():
 
 
 def test_dummy_loops():
-    i, m = symbols('i m', integer=True, cls=Dummy)
+    i, m = Dummy('i', integer=True, shash=500), Dummy('m', integer=True, shash=501)
     x = IndexedBase('x')
     y = IndexedBase('y')
     i = Idx(i, m)

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -176,7 +176,7 @@ def test_jscode_loops_matrix_vector():
 
 
 def test_dummy_loops():
-    i, m = symbols('i m', integer=True, cls=Dummy)
+    i, m = Dummy('i', integer=True, shash=500), Dummy('m', integer=True, shash=501)
     x = IndexedBase('x')
     y = IndexedBase('y')
     i = Idx(i, m)

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -139,14 +139,14 @@ def test_Wild():
 def test_Dummy():
     # cannot use sT here
     d = Dummy('d', nonzero=True)
-    assert srepr(d) == "Dummy('d', shash='" + str(d.dummy_index) + "', nonzero=True)"
+    assert srepr(d) == "Dummy('d', shash=" + str(d.dummy_index) + ", nonzero=True)"
     assert d == eval(srepr(d))
 
 def test_Dummy_from_Symbol():
     # should not get the full dictionary of assumptions
     n = Symbol('n', integer=True)
     d = n.as_dummy()
-    assert srepr(d) == "Dummy('n', shash='" + str(d.dummy_index) + "', integer=True)"
+    assert srepr(d) == "Dummy('n', shash=" + str(d.dummy_index) + ", integer=True)"
 
 
 def test_tuple():

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -139,14 +139,14 @@ def test_Wild():
 def test_Dummy():
     # cannot use sT here
     d = Dummy('d', nonzero=True)
-    assert srepr(d) == "Dummy('d', nonzero=True)"
-
+    assert srepr(d) == "Dummy('d', shash='" + str(d.dummy_index) + "', nonzero=True)"
+    assert d == eval(srepr(d))
 
 def test_Dummy_from_Symbol():
     # should not get the full dictionary of assumptions
     n = Symbol('n', integer=True)
     d = n.as_dummy()
-    assert srepr(d) == "Dummy('n', integer=True)"
+    assert srepr(d) == "Dummy('n', shash='" + str(d.dummy_index) + "', integer=True)"
 
 
 def test_tuple():

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -401,7 +401,7 @@ def test_loops_c():
 
 def test_dummy_loops_c():
     from sympy.tensor import IndexedBase, Idx
-    i, m = symbols('i m', integer=True, cls=Dummy)
+    i, m = Dummy('i', integer=True, shash=500), Dummy('m', integer=True, shash=501)
     x = IndexedBase('x')
     y = IndexedBase('y')
     i = Idx(i, m)
@@ -1049,7 +1049,7 @@ def test_loops():
 
 def test_dummy_loops_f95():
     from sympy.tensor import IndexedBase, Idx
-    i, m = symbols('i m', integer=True, cls=Dummy)
+    i, m = Dummy('i', integer=True, shash=500), Dummy('m', integer=True, shash=501)
     x = IndexedBase('x')
     y = IndexedBase('y')
     i = Idx(i, m)


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/11847

Hi, well, this try fix the issue, sadly i can't found an easy way to this, basically for 2 words...
"HASH Collision", lets think the example only store the dummy_index and pass it to the Dummy function:

```
>>> a=Dummy()  %Index 0
>>> a = srepr(a)  %Index 0
%% Move to other env to can import the data
>>> b = Dummy() %Index 0
>>> a = eval(a)  %Eval the previous expression, Index 0
>>> b == a  %Hash collision, this two should be differents.
True
```

I think my code normally is... ugly,  so if someone wanna change formats, names, etc, welcome, and any recommendation and discuss obvs this is open.

I choose that method for random number only for cryptographic security, and avoid the most possible the hash collision.

Thx. Cya.