### PR TITLE
Added docstring for symmetric_difference method

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -238,7 +238,7 @@ class Set(Basic):
         References
         ==========
         .. [1] https://en.wikipedia.org/wiki/Symmetric_difference
-        
+
         """
         return SymmetricDifference(self, other)
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -219,6 +219,27 @@ class Set(Basic):
             return FiniteSet(*[el for el in other if self.contains(el) != True])
 
     def symmetric_difference(self, other):
+        """
+        Returns symmetric difference of `self` and `other`.
+
+        Examples
+        ========
+
+        >>> from sympy import Interval, S
+        >>> Interval(1, 3).symmetric_difference(S.Reals)
+        (-oo, 1) U (3, oo)
+        >>> Interval(1, 10).symmetric_difference(S.Reals)
+        (-oo, 1) U (10, oo)
+
+        >>> from sympy import S, EmptySet
+        >>> S.Reals.symmetric_difference(EmptySet())
+        (-oo, oo)
+
+        References
+        ==========
+        .. [1] https://en.wikipedia.org/wiki/Symmetric_difference
+        
+        """
         return SymmetricDifference(self, other)
 
     def _symmetric_difference(self, other):


### PR DESCRIPTION
Hi. 

The method symmetric_difference was missing a docstring. This has been added with examples and references.

Thank you.