### PR TITLE
Remove `AppliedUndef.def _sage_`

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -764,13 +764,6 @@ class AppliedUndef(Function):
     def _eval_as_leading_term(self, x):
         return self
 
-    def _sage_(self):
-        import sage.all as sage
-        fname = str(self.func)
-        args = [arg._sage_() for arg in self.args]
-        func = sage.function(fname)(*args)
-        return func
-
 class UndefinedFunction(FunctionClass):
     """
     The (meta)class of undefined functions.


### PR DESCRIPTION
This is required for newer versions of SageMath:

https://git.sagemath.org/sage.git/tree/build/pkgs/sympy/patches/01_undeffun_sage.patch?h=develop