### PR TITLE
Properly handle decorated functions in test files

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1089,7 +1089,7 @@ class SymPyTests(object):
                         func = gl[f]
                         # Handle multiple decorators
                         while hasattr(func, '__wrapped__'):
-                            func = gl[f].__wrapped__
+                            func = func.__wrapped__
 
                         if inspect.getsourcefile(func) == filename:
                             funcs.append(gl[f])

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1077,22 +1077,22 @@ class SymPyTests(object):
             clear_cache()
             self._count += 1
             random.seed(self._seed)
-            pytestfile = ""
-            if "XFAIL" in gl:
-                pytestfile = inspect.getsourcefile(gl["XFAIL"])
-            pytestfile2 = ""
-            if "slow" in gl:
-                pytestfile2 = inspect.getsourcefile(gl["slow"])
             disabled = gl.get("disabled", False)
             if not disabled:
                 # we need to filter only those functions that begin with 'test_'
-                # that are defined in the testing file or in the file where
-                # is defined the XFAIL decorator
-                funcs = [gl[f] for f in gl.keys() if f.startswith("test_") and
-                    (inspect.isfunction(gl[f]) or inspect.ismethod(gl[f])) and
-                    (inspect.getsourcefile(gl[f]) == filename or
-                     inspect.getsourcefile(gl[f]) == pytestfile or
-                     inspect.getsourcefile(gl[f]) == pytestfile2)]
+                # We have to be careful about decorated functions. As long as
+                # the decorator uses functools.wraps, we can detect it.
+                funcs = []
+                for f in gl:
+                    if (f.startswith("test_") and (inspect.isfunction(gl[f])
+                        or inspect.ismethod(gl[f]))):
+                        func = gl[f]
+                        # Handle multiple decorators
+                        while hasattr(func, '__wrapped__'):
+                            func = gl[f].__wrapped__
+
+                        if inspect.getsourcefile(func) == filename:
+                            funcs.append(gl[f])
                 if slow:
                     funcs = [f for f in funcs if getattr(f, '_slow', False)]
                 # Sorting of XFAILed functions isn't fixed yet :-(


### PR DESCRIPTION
The problem is that inspect.getsourcefile on a decorated function gives the
file for the decorator (even if it uses functools.wraps). Previously, checks
for the decorators @XFAIL and @slow were hardcoded (or rather, their module,
sympy.utilities.pytest), but there are other decorators (for instance,
@conserve_mpmath_dps from sympy.utilities.decorators).

The code now checks every function to see if it is decorated, and checks the
source file of the original. This only works if the decorator uses
functools.wraps (but note that it wouldn't work anyway if it didn't, because
the name would be the name of the decorator, not "test_...").

Several tests that use @conserve_mpmath_dps which previously did not run are
now running (example, there is one in test_sympify). I did not yet run the
full tests suite to see if any previously non-running tests are failing.