### PR TITLE
Added docstring for is_closed method in sets.py

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -462,6 +462,16 @@ class Set(Basic):
 
     @property
     def is_closed(self):
+        """
+        A property method to check whether a set is closed. A set is closed
+        if it's complement is an open set.
+
+        Examples
+        ========
+        >>> from sympy import Interval
+        >>> Interval(0, 1).is_closed
+        True
+        """
         return self.boundary.is_subset(self)
 
     @property


### PR DESCRIPTION
Hi.

```is_closed``` property method was missing a docstring.

This has been now added.

Thank you.