### PR TITLE
Check hyper() b-parameters in test_hyperexpand

### DIFF
--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -9,7 +9,7 @@ from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
                        hyperexpand, Hyper_Function, G_Function,
                        reduce_order_meijer,
                        build_hypergeometric_formula)
-from sympy import hyper, I, S, meijerg, Piecewise
+from sympy import hyper, I, S, meijerg, Piecewise, Tuple
 from sympy.abc import z, a, b, c
 from sympy.utilities.pytest import XFAIL, raises, slow
 from sympy.utilities.randtest import verify_numerically as tn
@@ -48,8 +48,13 @@ def can_do(ap, bq, numerical=True, div=1, lowerplane=False):
     if not numerical:
         return True
     repl = {}
-    for n, a in enumerate(r.free_symbols - {z}):
-        repl[a] = randcplx(n)/div
+    randsyms = r.free_symbols - {z}
+    while randsyms:
+        # Only randomly generated parameters are checked.
+        for n, a in enumerate(randsyms):
+            repl[a] = randcplx(n)/div
+        if not any([b.is_Integer and b <= 0 for b in Tuple(*bq).subs(repl)]):
+            break
     [a, b, c, d] = [2, -1, 3, 1]
     if lowerplane:
         [a, b, c, d] = [2, -2, 3, -1]


### PR DESCRIPTION
If any of the b-parameters of a hypergeometric series is a negative
integer or zero, the series is not well defined unless there is an
a-parameter of the same type with smaller absolute value, in which
case the series is a polynomial.

In this patch, the the b-parameters are checked only if there are
randomly generated parameters to allow test_polynomial pass.
(a-parameters could also be checked in case there is a bad b-parameter,
but it is easier to just generate a set of new ones since there are
separate tests for polynomial cases.)

Fixes #11881