### PR TITLE
powdenest before simplify in gruntz - issue #11879

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -121,7 +121,7 @@ from __future__ import print_function, division
 from sympy.core import Basic, S, oo, Symbol, I, Dummy, Wild, Mul
 from sympy.functions import log, exp
 from sympy.series.order import Order
-from sympy.simplify.powsimp import powsimp
+from sympy.simplify.powsimp import powsimp, powdenest
 from sympy import cacheit
 
 from sympy.core.compatibility import reduce
@@ -463,6 +463,9 @@ def calculate_series(e, x, logx=None):
 
     for t in e.lseries(x, logx=logx):
         t = cancel(t)
+
+        if t.has(exp) and t.has(log):
+            t = powdenest(t)
 
         if t.simplify():
             break

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -479,7 +479,7 @@ def test_limit_seq():
 
 def test_issue_11879():
     assert simplify(limit(((x+y)**n-x**n)/y, y, 0)) == n*x**(n-1)
-    
+
 def test_limit_with_Float():
     k = symbols("k")
     assert limit(1.0 ** k, k, oo) == 1

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -477,7 +477,9 @@ def test_limit_seq():
     assert (limit(Sum(y**2 * Sum(2**z/z, (z, 1, y)), (y, 1, x)) /
                   (2**x*x), x, oo) == 4)
 
-
+def test_issue_11879():
+    assert simplify(limit(((x+y)**n-x**n)/y, y, 0)) == n*x**(n-1)
+    
 def test_limit_with_Float():
     k = symbols("k")
     assert limit(1.0 ** k, k, oo) == 1


### PR DESCRIPTION
As suggested by @jksuom, add a powdenest before simplify. Also check expression has exp and log before denesting. This might not be necessary.
 
Fixes #11879

