### PR TITLE
Passing an explicit tuple to format string.

### DIFF
--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -376,7 +376,7 @@ def test_Cycle():
     assert Cycle(1, 2).list() == [0, 2, 1]
     assert Cycle(1, 2).list(4) == [0, 2, 1, 3]
     assert Cycle().size == 0
-    raises(TypeError, lambda: Cycle((1, 2)))
+    raises(ValueError, lambda: Cycle((1, 2)))
     raises(ValueError, lambda: Cycle(1, 2, 1))
     raises(TypeError, lambda: Cycle(1, 2)*{})
     raises(ValueError, lambda: Cycle(4)[a])

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -331,7 +331,7 @@ def as_int(n):
         if result != n:
             raise TypeError
     except TypeError:
-        raise ValueError('%s is not an integer' % n)
+        raise ValueError('%s is not an integer' % (n,))
     return result
 
 


### PR DESCRIPTION
This way, if the **actual** value is a tuple, formatting will still work without a `TypeError`.

----

For example:

```python
>>> val = 14.25
>>> 'not an int: %s' % val
'not an int: 14.25'
>>> val = (14, 25)
>>> 'not an int: %s' % val
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
>>> 'not an int: %s' % (val,)
'not an int: (14, 25)'
```