### PR TITLE
Add a prec option to nsolve and change it to return Float and Matrix

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -45,6 +45,7 @@ from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent
 from sympy.utilities.iterables import uniq, generate_bell, flatten
+from sympy.utilities.decorator import conserve_mpmath_dps
 
 from mpmath import findroot
 
@@ -2633,7 +2634,7 @@ def _tsolve(eq, sym, **flags):
 
 # TODO: option for calculating J numerically
 
-
+@conserve_mpmath_dps
 def nsolve(*args, **kwargs):
     r"""
     Solve a nonlinear equation system numerically::
@@ -2661,8 +2662,7 @@ def nsolve(*args, **kwargs):
     >>> f1 = 3 * x1**2 - 2 * x2**2 - 1
     >>> f2 = x1**2 - 2 * x1 + x2**2 + 2 * x2 - 8
     >>> print(nsolve((f1, f2), (x1, x2), (-1, 1)))
-    [-1.19287309935246]
-    [ 1.27844411169911]
+    Matrix([[-1.19287309935246], [1.27844411169911]])
 
     For one-dimensional functions the syntax is simplified:
 
@@ -2672,6 +2672,16 @@ def nsolve(*args, **kwargs):
     3.14159265358979
     >>> nsolve(sin(x), 2)
     3.14159265358979
+
+    To solve with higher precision than the default, use the prec argument.
+
+    >>> from sympy import cos
+    >>> nsolve(cos(x) - x, 1)
+    0.739085133215161
+    >>> nsolve(cos(x) - x, 1, prec=50)
+    0.73908513321516064165531208767387340401341175890076
+    >>> cos(_)
+    0.73908513321516064165531208767387340401341175890076
 
     mpmath.findroot is used, you can find there more extensive documentation,
     especially concerning keyword parameters and available solvers. Note,
@@ -2711,6 +2721,13 @@ def nsolve(*args, **kwargs):
             used, but when using nsolve (and findroot) the keyword to use is
             "solver".'''))
 
+    if 'prec' in kwargs:
+        prec = kwargs.pop('prec')
+        import mpmath
+        mpmath.mp.dps = prec
+    else:
+        prec = None
+
     # interpret arguments
     if len(args) == 3:
         f = args[0]
@@ -2748,7 +2765,7 @@ def nsolve(*args, **kwargs):
         f = f.as_numer_denom()[0]
 
         f = lambdify(fargs, f, modules)
-        return findroot(f, x0, **kwargs)
+        return Float(findroot(f, x0, **kwargs))
 
     if len(fargs) > f.cols:
         raise NotImplementedError(filldedent('''
@@ -2767,7 +2784,7 @@ def nsolve(*args, **kwargs):
     J = lambdify(fargs, J, modules)
     # solve the system numerically
     x = findroot(f, x0, J=J, **kwargs)
-    return x
+    return Matrix(x)
 
 
 def _invert(eq, *symbols, **kwargs):

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -44,8 +44,9 @@ def test_nsolve():
     assert nsolve([Eq(
         f1), Eq(f2), Eq(f3)], [x, y, z], (1, 1, 1))  # just see that it works
     a = Symbol('a')
-    assert nsolve(1/(0.001 + a)**3 - 6/(0.9 - a)**3, a, 0.3).ae(
-        mpf('0.31883011387318591'))
+    assert abs(nsolve(1/(0.001 + a)**3 - 6/(0.9 - a)**3, a, 0.3) -
+        mpf('0.31883011387318591')) < 1e-15
+
 
 
 def test_issue_6408():
@@ -69,3 +70,8 @@ def test_increased_dps():
     q = nsolve(e1, x, 3.0)
 
     assert abs(sqrt(pi).evalf(128) - q) < 1e-128
+
+def test_nsolve_precision():
+    x = Symbol('x')
+    sol = nsolve(x**2 - pi, x, 3, prec=128)
+    assert abs(sqrt(pi).evalf(128) - sol) < 1e-128

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -1,4 +1,5 @@
-from sympy import Eq, Matrix, pi, sin, sqrt, Symbol, Integral, Piecewise, symbols
+from sympy import (Eq, Matrix, pi, sin, sqrt, Symbol, Integral, Piecewise,
+    symbols, Float)
 from mpmath import mnorm, mpf
 from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
@@ -72,6 +73,14 @@ def test_increased_dps():
     assert abs(sqrt(pi).evalf(128) - q) < 1e-128
 
 def test_nsolve_precision():
-    x = Symbol('x')
+    x, y = symbols('x y')
     sol = nsolve(x**2 - pi, x, 3, prec=128)
     assert abs(sqrt(pi).evalf(128) - sol) < 1e-128
+    assert isinstance(sol, Float)
+
+    sols = nsolve((y**2 - x, x**2 - pi), (x, y), (3, 3), prec=128)
+    assert isinstance(sols, Matrix)
+    assert sols.shape == (2, 1)
+    assert abs(sqrt(pi).evalf(128) - sols[0]) < 1e-128
+    assert abs(sqrt(sqrt(pi)).evalf(128) - sols[1]) < 1e-128
+    assert all(isinstance(i, Float) for i in sols)


### PR DESCRIPTION
Just adding a prec option to nsolve without changing it to return Floats
doesn't seem like a very good idea, since mpmath has a global precision,
meaning we either don't reset it (bad), or we do reset it and the returned mpf
prints with less precision than what was asked (although the full precision
would be saved in the mpf itself).

It makes sense that nsolve, which is a SymPy wrapper around mpmath.findroot,
should return SymPy types. However, this is technically a backwards
incompatible change, so I'm unsure if it should be made, and if so, if we
should attempt some kind of deprecation (I don't know how to deprecate a
return type). The best I can think of would be to only return a Float if the
prec option is used, but that would be inconsistent and confusing.

This depends on #11862 but I'm submitting it separately as it might be
controversial, and I don't want it to block the fixes there. 