### PR TITLE
Expr: _eval_interval checks both limits(left and right)

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -781,7 +781,7 @@ class Expr(Basic, EvalfMixin):
         else:
             A = self.subs(x, a)
             if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                if a < b:
+                if (a < b) == True:
                     A = limit(self, x, a,"+")
                 else:
                     A = limit(self, x, a,"-")
@@ -796,7 +796,7 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                if b < a:
+                if (b < a) == True:
                     B = limit(self, x, b,"+")
                 else:
                     B = limit(self, x, b,"-")

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -773,7 +773,7 @@ class Expr(Basic, EvalfMixin):
 
         """
         from sympy.series import limit, Limit
-        
+
         if (a is None and b is None):
             raise ValueError('Both interval ends cannot be None.')
 
@@ -800,10 +800,10 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                if (b < a) != False:
-                    B = limit(self, x, b,"+")
-                else:
+                if (a < b) != False:
                     B = limit(self, x, b,"-")
+                else:
+                    B = limit(self, x, b,"+")
 
                 if isinstance(B, Limit):
                     raise NotImplementedError("Could not compute limit")

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -781,7 +781,9 @@ class Expr(Basic, EvalfMixin):
         else:
             A = self.subs(x, a)
             if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                A = limit(self, x, a)
+                A = limit(self, x, a, '+')
+                if A != limit(self, x, a, '-'):
+                    raise MathError("Right limit and left limit do not match")
                 if A is S.NaN:
                     return A
                 if isinstance(A, Limit):
@@ -792,7 +794,9 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                B = limit(self, x, b)
+                B = limit(self, x, b, '+')
+                if B != limit(self, x, b, '-'):
+                    raise MathError("Right limit and left limit do not match")
                 if isinstance(B, Limit):
                     raise NotImplementedError("Could not compute limit")
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -781,7 +781,7 @@ class Expr(Basic, EvalfMixin):
         else:
             A = self.subs(x, a)
             if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                if a.__lt__(b):
+                if a < b:
                     A = limit(self, x, a,"+")
                 else:
                     A = limit(self, x, a,"-")
@@ -796,7 +796,7 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                if b.__lt__(a):
+                if b < a:
                     B = limit(self, x, b,"+")
                 else:
                     B = limit(self, x, b,"-")

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -781,9 +781,7 @@ class Expr(Basic, EvalfMixin):
         else:
             A = self.subs(x, a)
             if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                A = limit(self, x, a, '+')
-                if A != limit(self, x, a, '-'):
-                    raise MathError("Right limit and left limit do not match")
+                A = limit(self, x, a)
                 if A is S.NaN:
                     return A
                 if isinstance(A, Limit):
@@ -794,9 +792,7 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                B = limit(self, x, b, '+')
-                if B != limit(self, x, b, '-'):
-                    raise MathError("Right limit and left limit do not match")
+                B = limit(self, x, b)
                 if isinstance(B, Limit):
                     raise NotImplementedError("Could not compute limit")
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -774,11 +774,11 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy.series import limit, Limit
         
-        if a == b:
-            return 0;
-
         if (a is None and b is None):
             raise ValueError('Both interval ends cannot be None.')
+
+        if a == b:
+            return 0;
 
         if a is None:
             A = 0

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -781,7 +781,11 @@ class Expr(Basic, EvalfMixin):
         else:
             A = self.subs(x, a)
             if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                A = limit(self, x, a)
+                if a.__lt__(b):
+                    A = limit(self, x, a,"+")
+                else:
+                    A = limit(self, x, a,"-")
+
                 if A is S.NaN:
                     return A
                 if isinstance(A, Limit):
@@ -792,7 +796,11 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                B = limit(self, x, b)
+                if b.__lt__(a):
+                    B = limit(self, x, b,"+")
+                else:
+                    B = limit(self, x, b,"-")
+
                 if isinstance(B, Limit):
                     raise NotImplementedError("Could not compute limit")
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -773,6 +773,10 @@ class Expr(Basic, EvalfMixin):
 
         """
         from sympy.series import limit, Limit
+        
+        if a == b:
+            return 0;
+
         if (a is None and b is None):
             raise ValueError('Both interval ends cannot be None.')
 
@@ -781,7 +785,7 @@ class Expr(Basic, EvalfMixin):
         else:
             A = self.subs(x, a)
             if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                if (a < b) == True:
+                if (a < b) != False:
                     A = limit(self, x, a,"+")
                 else:
                     A = limit(self, x, a,"-")
@@ -796,7 +800,7 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                if (b < a) == True:
+                if (b < a) != False:
                     B = limit(self, x, b,"+")
                 else:
                     B = limit(self, x, b,"-")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1768,5 +1768,4 @@ def test_issue_10755():
 
 def test_issue_11877():
     x = symbols('x')
-    y = integrate(x**2/(-x*x), (x, 0, 1))
-    assert y == S(-1)
+    assert integrate(log(S(1)/2 - x), (x, 0, S(1)/2)) == -S(1)/2 -log(2)/2

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1768,4 +1768,5 @@ def test_issue_10755():
 
 def test_issue_11877():
     x = symbols('x')
-    assert (long(integrate(log(0.5-x), (x, 0, 0.5))) == long(-0.846573590279973))
+    y = integrate(x**2/(-x*x), (x, 0, 1))
+    assert y == S(-1)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -6,7 +6,8 @@ from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
                    Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp,
                    simplify, together, collect, factorial, apart, combsimp, factor, refine,
                    cancel, Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E,
-                   exp_polar, expand, diff, O, Heaviside, Si, Max, UnevaluatedExpr)
+                   exp_polar, expand, diff, O, Heaviside, Si, Max, UnevaluatedExpr,
+                   integrate)
 from sympy.core.function import AppliedUndef
 from sympy.core.compatibility import range
 from sympy.physics.secondquant import FockState
@@ -1764,3 +1765,7 @@ def test_issue_10755():
     x = symbols('x')
     raises(TypeError, lambda: int(log(x)))
     raises(TypeError, lambda: log(x).round(2))
+
+def test_issue_11877():
+    x = symbols('x')
+    assert (long(integrate(log(0.5-x), (x, 0, 0.5))) == long(-0.846573590279973))


### PR DESCRIPTION
Ref. #11877

Expr._eval_interval now evaluates right limit and left limit both

Before
`>>> integrate(log(0.5-x), (x, 0, 0.5))
−0.846573590279973+1.0iπ`

After:
`>>> integrate(log(0.5-x), (x, 0, 0.5))
 799, in _eval_interval
    raise MathError("Right limit and left limit do not match")`