### PR TITLE
Improved Latex Printing of Piecewise Functions

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -235,10 +235,12 @@ class LatexPrinter(Printer):
         elif expr.is_Mul:
             if not first and _coeff_isneg(expr):
                 return True
+        if expr.is_Piecewise:
+            return True
         if any([expr.has(x) for x in (Mod,)]):
             return True
         if (not last and
-            any([expr.has(x) for x in (Integral, Piecewise, Product, Sum)])):
+            any([expr.has(x) for x in (Integral, Product, Sum)])):
             return True
 
         return False

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -867,7 +867,7 @@ def test_latex_Piecewise():
     p = Piecewise((A**2, Eq(A, B)), (A*B, True))
     s = r"\begin{cases} A^{2} & \text{for}\: A = B \\A B & \text{otherwise} \end{cases}"
     assert latex(p) == s
-    assert latex(A*p) == r"A %s" % s
+    assert latex(A*p) == r"A \left(%s\right)" % s
     assert latex(p*A) == r"\left(%s\right) A" % s
 
 


### PR DESCRIPTION
Fixes #11275 .

To match the output of Latex printer with that of Pretty Printer, a conditional statement is added in the function `_needs_mul_brackets()` to always include brackets for piecewise function whenever is multiplied to another function.

#### Output Before this PR
```python
In [39]: latex(FiniteSet(6**(S(1)/3)*x**(S(1)/3)*Piecewise(((-1)**(S(2)/3), 3*x/4 < 0), (1, True))))
Out[39]: '\\left\\{\\sqrt[3]{6} \\sqrt[3]{x} \\begin{cases} \\left(-1\\right)^{\\frac{2}{3}} & \\text{for}\\: \\frac{3 x}{4} < 0 \\\\1 & \\text{otherwise} \\end{cases}\\right\\}'
```
#### Output After Changes in this PR
```python
>>> from sympy import *
>>> from sympy.abc import x, A , B
>>> pprint(A*Piecewise((A**2, Eq(A, B)), (A*B, True)))
  ⎛⎧ 2            ⎞
  ⎜⎪A    for A = B⎟
A⋅⎜⎨              ⎟
  ⎜⎪A⋅B  otherwise⎟
  ⎝⎩              ⎠
>>> latex(A*Piecewise((A**2, Eq(A, B)), (A*B, True)))
'A \\left(\\begin{cases} A^{2} & \\text{for}\\: A = B \\\\A B & \\text{otherwise} \\end{cases}\\right)'
>>> pprint(FiniteSet(6**(S(1)/3)*x**(S(1)/3)*Piecewise(((-1)**(S(2)/3), 3*x/4 < 0), (1, True))))
⎧            ⎛⎧    2/3      3⋅x    ⎞⎫
⎪3 ___ 3 ___ ⎜⎪(-1)     for ─── < 0⎟⎪
⎨╲╱ 6 ⋅╲╱ x ⋅⎜⎨              4     ⎟⎬
⎪            ⎜⎪                    ⎟⎪
⎩            ⎝⎩   1      otherwise ⎠⎭
>>> latex(FiniteSet(6**(S(1)/3)*x**(S(1)/3)*Piecewise(((-1)**(S(2)/3), 3*x/4 < 0), (1, True))))
'\\left\\{\\sqrt[3]{6} \\sqrt[3]{x} \\left(\\begin{cases} \\left(-1\\right)^{\\frac{2}{3}} & \\text{for}\\: \\frac{3 x}{4} < 0 \\\\1 & \\text{otherwise} \\end{cases}\\right)\\right\\}'
```
Tests are changed to accommodate for the changes.