### PR TITLE
Empty matrix and 1x1 matrix are always diagonal and symmetric

### DIFF
--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -38,6 +38,10 @@ class AskSymmetricHandler(CommonHandler):
         factor, mmul = expr.as_coeff_mmul()
         if all(ask(Q.symmetric(arg), assumptions) for arg in mmul.args):
             return True
+        # TODO: implement sathandlers system for the matrices.
+        # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
+        if ask(Q.diagonal(expr), assumptions):
+            return True
         if len(mmul.args) >= 2 and mmul.args[0] == mmul.args[-1].T:
             if len(mmul.args) == 2:
                 return True
@@ -51,6 +55,10 @@ class AskSymmetricHandler(CommonHandler):
     def MatrixSymbol(expr, assumptions):
         if not expr.is_square:
             return False
+        # TODO: implement sathandlers system for the matrices.
+        # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
+        if ask(Q.diagonal(expr), assumptions):
+            return True
         if Q.symmetric(expr) in conjuncts(assumptions):
             return True
 
@@ -66,6 +74,10 @@ class AskSymmetricHandler(CommonHandler):
 
     @staticmethod
     def MatrixSlice(expr, assumptions):
+        # TODO: implement sathandlers system for the matrices.
+        # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
+        if ask(Q.diagonal(expr), assumptions):
+            return True
         if not expr.on_diag:
             return None
         else:
@@ -366,7 +378,13 @@ class AskDiagonalHandler(CommonHandler):
     """
 
     @staticmethod
+    def _is_empty_or_1x1(expr):
+        return expr.shape == (0, 0) or expr.shape == (1, 1)
+
+    @staticmethod
     def MatMul(expr, assumptions):
+        if AskDiagonalHandler._is_empty_or_1x1(expr):
+            return True
         factor, matrices = expr.as_coeff_matrices()
         if all(ask(Q.diagonal(m), assumptions) for m in matrices):
             return True
@@ -378,6 +396,8 @@ class AskDiagonalHandler(CommonHandler):
 
     @staticmethod
     def MatrixSymbol(expr, assumptions):
+        if AskDiagonalHandler._is_empty_or_1x1(expr):
+            return True
         if Q.diagonal(expr) in conjuncts(assumptions):
             return True
 
@@ -393,6 +413,8 @@ class AskDiagonalHandler(CommonHandler):
 
     @staticmethod
     def MatrixSlice(expr, assumptions):
+        if AskDiagonalHandler._is_empty_or_1x1(expr):
+            return True
         if not expr.on_diag:
             return None
         else:

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -7,6 +7,11 @@ from sympy.utilities.pytest import XFAIL
 X = MatrixSymbol('X', 2, 2)
 Y = MatrixSymbol('Y', 2, 3)
 Z = MatrixSymbol('Z', 2, 2)
+A1x1 = MatrixSymbol('A1x1', 1, 1)
+B1x1 = MatrixSymbol('B1x1', 1, 1)
+C0x0 = MatrixSymbol('C0x0', 0, 0)
+V1 = MatrixSymbol('V1', 2, 1)
+V2 = MatrixSymbol('V2', 2, 1)
 
 def test_square():
     assert ask(Q.square(X))
@@ -46,7 +51,13 @@ def test_symmetric():
     assert ask(Q.symmetric(Y.T*X*Y)) is None
     assert ask(Q.symmetric(Y.T*X*Y), Q.symmetric(X)) is True
     assert ask(Q.symmetric(X*X*X*X*X*X*X*X*X*X), Q.symmetric(X)) is True
-
+    assert ask(Q.symmetric(A1x1)) is True
+    assert ask(Q.symmetric(A1x1 + B1x1)) is True
+    assert ask(Q.symmetric(A1x1 * B1x1)) is True
+    assert ask(Q.symmetric(V1.T*V1)) is True
+    assert ask(Q.symmetric(V1.T*(V1 + V2))) is True
+    assert ask(Q.symmetric(V1.T*(V1 + V2) + A1x1)) is True
+    assert ask(Q.symmetric(MatrixSlice(Y, (0, 1), (1, 2)))) is True
 
 def _test_orthogonal_unitary(predicate):
     assert ask(predicate(X), predicate(X))
@@ -115,6 +126,14 @@ def test_diagonal():
     assert ask(Q.diagonal(X), Q.lower_triangular(X) & Q.upper_triangular(X))
     assert ask(Q.symmetric(X), Q.diagonal(X))
     assert ask(Q.triangular(X), Q.diagonal(X))
+    assert ask(Q.diagonal(C0x0))
+    assert ask(Q.diagonal(A1x1))
+    assert ask(Q.diagonal(A1x1 + B1x1))
+    assert ask(Q.diagonal(A1x1*B1x1))
+    assert ask(Q.diagonal(V1.T*V2))
+    assert ask(Q.diagonal(V1.T*(X + Z)*V1))
+    assert ask(Q.diagonal(MatrixSlice(Y, (0, 1), (1, 2)))) is True
+    assert ask(Q.diagonal(V1.T*(V1 + V2))) is True
 
 
 def test_non_atoms():

--- a/sympy/matrices/expressions/tests/test_transpose.py
+++ b/sympy/matrices/expressions/tests/test_transpose.py
@@ -38,3 +38,9 @@ def test_transpose():
 
 def test_refine():
     assert refine(C.T, Q.symmetric(C)) == C
+
+
+def test_transpose1x1():
+    m = MatrixSymbol('m', 1, 1)
+    assert m == refine(m.T)
+    assert m == refine(m.T.T)


### PR DESCRIPTION
Fixes #11899. When 1x1 matrix is transposed it returns itself, such that:

`m.T == m
`

where m is 1x1 matrix.