### PR TITLE
[DOC] Added docstring to do_subs method in gruntz.py

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -206,6 +206,7 @@ class SubsSet(dict):
         return dict.__getitem__(self, key)
 
     def do_subs(self, e):
+        """Substitute the variables with expressions"""
         for expr, var in self.items():
             e = e.subs(var, expr)
         return e


### PR DESCRIPTION
Hi. 

Looks like ```do_subs``` method in sympy/series/gruntz.py was missing a docstring.

This has been now added.

Thank you.
