### PR TITLE
[DOC] Added docstring to copy method in gruntz.py

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -230,6 +230,7 @@ class SubsSet(dict):
         return res, exps
 
     def copy(self):
+        """Create a shallow copy of SubsSet"""
         r = SubsSet()
         r.rewrites = self.rewrites.copy()
         for expr, var in self.items():


### PR DESCRIPTION
Hi. 

Looks like copy method in sympy/series/gruntz.py was missing a docstring.

This has now been added.

Thank you.