### PR TITLE
[DOC] Added lambdify docstring for Tensorflow usage

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -91,7 +91,7 @@ class LambdaPrinter(StrPrinter):
 class TensorflowPrinter(LambdaPrinter):
     """
     Tensorflow printer which handles vectorized piecewise functions,
-    logical operators, etc.
+    logical operators, max/min, and relational operators.
     """
 
     def _print_And(self, expr):

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -317,6 +317,26 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     ``lambdify`` always prefers ``_imp_`` implementations to implementations
     in other namespaces, unless the ``use_imps`` input parameter is False.
 
+    Usage with Tensorflow module:
+
+    >>> import tensorflow as tf
+    >>> f = Max(x, sin(x))
+    >>> func = lambdify(x, f, 'tensorflow')
+    >>> result = func(tf.constant(1.0))
+    >>> result # a tf.Tensor representing the result of the calculation
+    <tf.Tensor 'Maximum:0' shape=() dtype=float32>
+    >>> sess = tf.Session()
+    >>> sess.run(result) # compute result
+    1.0
+    >>> var = tf.Variable(1.0)
+    >>> sess.run(tf.global_variables_initializer())
+    >>> sess.run(func(var)) # also works for tf.Variable and tf.Placeholder
+    1.0
+    >>> tensor = tf.constant([[1.0, 2.0], [3.0, 4.0]]) # works with any shape tensor
+    >>> sess.run(func(tensor))
+    array([[ 1.,  2.],
+           [ 3.,  4.]], dtype=float32)
+
     """
     from sympy.core.symbol import Symbol
     from sympy.utilities.iterables import flatten


### PR DESCRIPTION
Following up on [this issue](https://github.com/sympy/sympy/issues/11420#issuecomment-264669120), this PR adds an example to the `lambdify` docstring that shows how to use it with Tensorflow.