### PR TITLE
[DOC] Implemented docstring for closure property method

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -478,7 +478,7 @@ class Set(Basic):
     @property
     def closure(self):
         """
-        Property method which returns a closure of a set.
+        Property method which returns the closure of a set.
         The closure is defined as the union of the set itself and its
         boundary.
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -477,6 +477,19 @@ class Set(Basic):
 
     @property
     def closure(self):
+        """
+        Property method which returns a closure of a set.
+        The closure is defined as the union of the set itself and its
+        boundary.
+
+        Examples
+        ========
+        >>> from sympy import S, Interval
+        >>> S.Reals.closure
+        (-oo, oo)
+        >>> Interval(0, 1).closure
+        [0, 1]
+        """
         return self + self.boundary
 
     @property


### PR DESCRIPTION
Hi. 

Looks like closure property method in sympy/sets/sets.py was missing a docstring. This docstring has been now added. 

Thank you.

