### PR TITLE
Use Meijerg G-function methods for integrating sinc

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -739,19 +739,6 @@ class Integral(AddWithLimits):
         from sympy.integrals.risch import risch_integrate
         from sympy import sinc
 
-        # if instance of sinc function, first try using the G-function methods
-        # skip only if meijerg = False (user may prefer some other method)
-        # if integral still fails, just move on with regular algorithm flow
-        if isinstance(f, sinc) and meijerg is not False:
-            try:
-                meij_f = meijerint_indefinite(f, x)
-            except NotImplementedError:
-                from sympy.integrals.meijerint import _debug
-                _debug('NotImplementedError from meijerint_definite')
-            if meij_f is not None:
-                return meij_f
-
-
         if risch:
             try:
                 return risch_integrate(f, x, conds=conds)
@@ -902,17 +889,6 @@ class Integral(AddWithLimits):
                         parts.append(coeff*h)
                         continue
 
-                # fall back to heurisch
-                try:
-                    if conds == 'piecewise':
-                        h = heurisch_wrapper(g, x, hints=[])
-                    else:
-                        h = heurisch(g, x, hints=[])
-                except PolynomialError:
-                    # XXX: this exception means there is a bug in the
-                    # implementation of heuristic Risch integration
-                    # algorithm.
-                    h = None
             else:
                 h = None
 
@@ -948,6 +924,20 @@ class Integral(AddWithLimits):
                 except (ValueError, PolynomialError):
                     # can't handle some SymPy expressions
                     pass
+
+            if h is None:
+                # fall back to heurisch
+                try:
+                    if conds == 'piecewise':
+                        h = heurisch_wrapper(g, x, hints=[])
+                    else:
+                        h = heurisch(g, x, hints=[])
+                except PolynomialError:
+                    # XXX: this exception means there is a bug in the
+                    # implementation of heuristic Risch integration
+                    # algorithm.
+                    h = None
+
 
             # if we failed maybe it was because we had
             # a product that could have been expanded,

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -737,6 +737,20 @@ class Integral(AddWithLimits):
         from sympy.integrals.heurisch import heurisch, heurisch_wrapper
         from sympy.integrals.rationaltools import ratint
         from sympy.integrals.risch import risch_integrate
+        from sympy import sinc
+
+        # if instance of sinc function, first try using the G-function methods
+        # skip only if meijerg = False (user may prefer some other method)
+        # if integral still fails, just move on with regular algorithm flow
+        if isinstance(f, sinc) and meijerg is not False:
+            try:
+                meij_f = meijerint_indefinite(f, x)
+            except NotImplementedError:
+                from sympy.integrals.meijerint import _debug
+                _debug('NotImplementedError from meijerint_definite')
+            if meij_f is not None:
+                return meij_f
+
 
         if risch:
             try:


### PR DESCRIPTION
Fixes #11856

Uses Meijerg G-function methods first for functions
like sinc(x) since this method finds the integral quicker.

This will not check using the G-functions if it is explicitly mentioned `meijerg=False`
Examples-
```
In [3]: sinc(t*x).integrate()
Out[3]: 
Si(π⋅t)
───────
   π   
```
The above example is quick since it uses the 'hack'. 
```
In [3]: nsinc(t).integrate(meijerg=False)
Out[3]: 
Si(π⋅t)
───────
   π   
```
The above example will NOT utilise the hack and will take a longer time to evaluate.