### PR TITLE
Modified is_positive for cosh function

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -482,9 +482,9 @@ class Abs(Function):
                 return S.Infinity
         if arg.is_zero:
             return S.Zero
-        if arg.is_nonnegative:
+        if arg.is_nonnegative or arg.is_positive:
             return arg
-        if arg.is_nonpositive:
+        if arg.is_nonpositive or arg.is_negative:
             return -arg
         if arg.is_imaginary:
             arg2 = -S.ImaginaryUnit * arg
@@ -502,16 +502,6 @@ class Abs(Function):
             unk = [a for a in abs_free_arg.free_symbols if a.is_real is None]
             if not unk or not all(conj.has(conjugate(u)) for u in unk):
                 return sqrt(expand_mul(arg*conj))
-
-        # if the expression is a function, then try to see if its positive or negative
-        # functions which have `is_positive` and `is_negative` values of form - bool or None
-        if isinstance(arg, Function) and not isinstance(arg.is_positive,property) \
-        and not isinstance(arg.is_negative,property):
-            if arg.is_positive:
-                return arg
-            elif arg.is_negative:
-                return S(-1)*arg
-
 
     def _eval_is_integer(self):
         if self.args[0].is_real:

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -503,6 +503,16 @@ class Abs(Function):
             if not unk or not all(conj.has(conjugate(u)) for u in unk):
                 return sqrt(expand_mul(arg*conj))
 
+        # if the expression is a function, then try to see if its positive or negative
+        # functions which have `is_positive` and `is_negative` values of form - bool or None
+        if isinstance(arg, Function) and not isinstance(arg.is_positive,property) \
+        and not isinstance(arg.is_negative,property):
+            if arg.is_positive:
+                return arg
+            elif arg.is_negative:
+                return S(-1)*arg
+
+
     def _eval_is_integer(self):
         if self.args[0].is_real:
             return self.args[0].is_integer

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -482,9 +482,9 @@ class Abs(Function):
                 return S.Infinity
         if arg.is_zero:
             return S.Zero
-        if arg.is_nonnegative or arg.is_positive:
+        if arg.is_nonnegative:
             return arg
-        if arg.is_nonpositive or arg.is_negative:
+        if arg.is_nonpositive:
             return -arg
         if arg.is_imaginary:
             arg2 = -S.ImaginaryUnit * arg

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -214,6 +214,11 @@ class cosh(HyperbolicFunction):
         if self.args[0].is_real:
             return True
 
+    @property
+    def is_nonnegative(self):
+        if self.args[0].is_real:
+            return True
+
     def fdiff(self, argindex=1):
         if argindex == 1:
             return sinh(self.args[0])

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -209,6 +209,11 @@ class cosh(HyperbolicFunction):
     sinh, tanh, acosh
     """
 
+    @property
+    def is_positive(self):
+        if self._eval_is_real():
+            return True
+
     def fdiff(self, argindex=1):
         if argindex == 1:
             return sinh(self.args[0])

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -211,7 +211,7 @@ class cosh(HyperbolicFunction):
 
     @property
     def is_positive(self):
-        if self._eval_is_real():
+        if self.args[0].is_real:
             return True
 
     def fdiff(self, argindex=1):

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -8,6 +8,10 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
 
+from sympy import pi, Eq
+from sympy.logic import Or, And
+
+
 
 def _rewrite_hyperbolics_as_exp(expr):
     expr = sympify(expr)
@@ -211,8 +215,6 @@ class cosh(HyperbolicFunction):
 
     @property
     def is_positive(self):
-        from sympy import pi, Eq
-        from sympy.logic import Or, And
         arg = self.args[0]
 
         if arg.is_real:
@@ -238,8 +240,6 @@ class cosh(HyperbolicFunction):
 
     @property
     def is_nonnegative(self):
-        from sympy import pi, Eq
-        from sympy.logic import Or, And
         arg = self.args[0]
 
         if arg.is_real:

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -211,13 +211,31 @@ class cosh(HyperbolicFunction):
 
     @property
     def is_positive(self):
-        if self.args[0].is_real:
+        from sympy import pi, Eq
+        from sympy.logic import Or, And
+        arg = self.args[0]
+
+        if arg.is_real:
             return True
+
+        re, im = arg.as_real_imag()
+        im_mod = im % (2*pi)
+        return Or(And(Eq(re, 0), Or(im_mod < pi/2, im_mod > 3*pi/2)), Eq(im_mod, 0))
+
 
     @property
     def is_nonnegative(self):
-        if self.args[0].is_real:
+        from sympy import pi, Eq
+        from sympy.logic import Or, And
+        arg = self.args[0]
+
+        if arg.is_real:
             return True
+
+        re, im = arg.as_real_imag()
+        im_mod = im % (2*pi)
+        return Or(And(Eq(re, 0), Or(im_mod <= pi/2, im_mod >= 3*pi/2)), Eq(im_mod, 0))
+
 
     def fdiff(self, argindex=1):
         if argindex == 1:

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -220,6 +220,19 @@ class cosh(HyperbolicFunction):
 
         re, im = arg.as_real_imag()
         im_mod = im % (2*pi)
+
+        if im_mod == 0:
+            return True
+
+        if re == 0:
+            try:
+                if im_mod < pi/2 or im_mod > 3*pi/2:
+                    return True
+                elif im_mod >= pi/2 or im_mod <= 3*pi/2:
+                    return False
+            except:
+                pass
+
         return Or(And(Eq(re, 0), Or(im_mod < pi/2, im_mod > 3*pi/2)), Eq(im_mod, 0))
 
 
@@ -234,6 +247,19 @@ class cosh(HyperbolicFunction):
 
         re, im = arg.as_real_imag()
         im_mod = im % (2*pi)
+
+        if im_mod == 0:
+            return True
+
+        if re == 0:
+            try:
+                if im_mod <= pi/2 or im_mod >= 3*pi/2:
+                    return True
+                elif im_mod > pi/2 or im_mod < 3*pi/2:
+                    return False
+            except:
+                pass
+
         return Or(And(Eq(re, 0), Or(im_mod <= pi/2, im_mod >= 3*pi/2)), Eq(im_mod, 0))
 
 

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -920,3 +920,13 @@ def test_cosh_expansion():
     assert cosh(2*x).expand(trig=True) == cosh(x)**2 + sinh(x)**2
     assert cosh(3*x).expand(trig=True).expand() == \
         3*sinh(x)**2*cosh(x) + cosh(x)**3
+
+# See issue 11721
+# cosh(x) is positive for real values of x
+def test_cosh_positive():
+    x = symbols('x')
+    k = symbols('k',real=True)
+
+    assert cosh(x).is_positive is None
+    assert cosh(k).is_positive == True
+    assert abs(cosh(k)) == cosh(k)

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -921,9 +921,9 @@ def test_cosh_expansion():
     assert cosh(3*x).expand(trig=True).expand() == \
         3*sinh(x)**2*cosh(x) + cosh(x)**3
 
-# See issue 11721
-# cosh(x) is positive for real values of x
 def test_cosh_positive():
+    # See issue 11721
+    # cosh(x) is positive for real values of x
     x = symbols('x')
     k = symbols('k',real=True)
 

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -925,8 +925,11 @@ def test_cosh_positive():
     # See issue 11721
     # cosh(x) is positive for real values of x
     x = symbols('x')
-    k = symbols('k',real=True)
+    k = symbols('k', real=True)
+    n = symbols('n', integer=True)
 
-    assert cosh(x).is_positive is None
     assert cosh(k).is_positive == True
     assert abs(cosh(k)) == cosh(k)
+    assert cosh(k + 2*n*pi*I).is_positive == True
+    assert cosh(I*pi/4).is_positive == True
+    assert cosh(3*I*pi/4).is_positive == False


### PR DESCRIPTION
Fixes #11721.

`cosh(x).is_positive` returns `True` if x is real.
Also modified the `Abs` function to return the function itself or its negative if the function is positive or negative.

Example:
```
In [1]: r=symbols('r',real=True)

In [2]: abs(cosh(x))
Out[2]: │cosh(x)│

In [3]: abs(cosh(r))
Out[3]: cosh(r)

In [4]: abs(cosh(r)) == cosh(r)
Out[4]: True

In [5]: abs(cosh(x)) == cosh(x)
Out[5]: False

In [6]: cosh(r).is_positive
Out[6]: True

In [7]: cosh(x).is_positive

In [8]:      
```