### PR TITLE
Added link to pdf version of docs in the main documentation page

### DIFF
--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -5,6 +5,8 @@
 Welcome to SymPy's documentation!
 =================================
 
+A PDF version of these docs can be found `here <https://github.com/sympy/sympy/releases>`_.
+
 `SymPy <http://sympy.org>`_ is a Python library for symbolic mathematics.
 If you are new to SymPy, start with the :ref:`Tutorial <tutorial>`.
 


### PR DESCRIPTION
Fixes #11927.

- Added a link to the pdf version of the docs at the top of the documentation page at http://docs.sympy.org/latest/index.html