### PR TITLE
[DOC] Added docstring for ExprWithIntLimits class

### DIFF
--- a/sympy/concrete/expr_with_intlimits.py
+++ b/sympy/concrete/expr_with_intlimits.py
@@ -12,6 +12,14 @@ class ReorderError(NotImplementedError):
             "%s could not be reordered: %s." % (expr, msg))
 
 class ExprWithIntLimits(ExprWithLimits):
+    """
+    The class for expressions with integer limits.
+
+    See Also
+    ========
+
+    ExprWithLimits, Product, Sum
+    """
     def change_index(self, var, trafo, newvar=None):
         """
         Change index of a Sum or Product.


### PR DESCRIPTION
Hi. 

ExprWithIntLimits class was missing a docstring. This has been now added.

```./bin/test quality``` executed locally - all green.

Thank you.