### PR TITLE
Use set -e in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -348,9 +348,11 @@ install:
     elif [[ "${TEST_SAGE}" != "true" ]]; then
       python setup.py install;
     fi
-script: |
-    bin/test_travis.sh
-    if [[ "${TEST_SPHINX}" == "true" ]]; then
+script:
+  # Don't run doctr of the build fails
+  - set -e
+  - bin/test_travis.sh
+  - if [[ "${TEST_SPHINX}" == "true" ]]; then
         doctr deploy --deploy-repo sympy/sympy_doc --gh-pages-docs dev --command './generate_indexes.py';
     fi
 notifications:


### PR DESCRIPTION
Using one line doesn't work. We need to use set -e to make it so that doctr
doesn't run when the build fails properly.

I meant to get this in https://github.com/sympy/sympy/pull/11935 before it was merged. 