### PR TITLE
Use isinstance in Application._eval_subs

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -308,7 +308,7 @@ class Application(with_metaclass(FunctionClass, Basic)):
         return self.__class__
 
     def _eval_subs(self, old, new):
-        if (old.is_Function and new.is_Function and old == self.func and
+        if (isinstance(old, Function) and isinstance(new, Function) and old == self.func and
             len(self.args) in new.nargs):
             return new(*self.args)
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -308,8 +308,9 @@ class Application(with_metaclass(FunctionClass, Basic)):
         return self.__class__
 
     def _eval_subs(self, old, new):
-        if (isinstance(old, Function) and isinstance(new, Function) and old == self.func and
-            len(self.args) in new.nargs):
+        if (old.is_Function and new.is_Function and
+            callable(old) and callable(new) and
+            old == self.func and len(self.args) in new.nargs):
             return new(*self.args)
 
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -804,3 +804,10 @@ def test_Derivative_as_finite_difference():
     xm, xp, ym, yp = x-half, x+half, y-half, y+half
     ref2 = f(xm, ym) + f(xp, yp) - f(xp, ym) - f(xm, yp)
     assert (d2fdxdy.as_finite_difference() - ref2).simplify() == 0
+
+def test_issue_11159():
+    # Tests Application._eval_subs
+    expr1 = E
+    expr0 = expr1 * expr1
+    expr1 = expr0.subs(expr1,expr0)
+    assert expr0 == expr1


### PR DESCRIPTION
is_Function applies to both the class and the instance, but the code was
assuming it was the class.

Fixes #11159.