### PR TITLE
Add link to pdf documentation in doc index

### DIFF
--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -10,6 +10,8 @@ If you are new to SymPy, start with the :ref:`Tutorial <tutorial>`.
 
 This is the central page for all of SymPy's documentation.
 
+The documentation in pdf form can be found at
+`https://github.com/sympy/sympy/releases/ <https://github.com/sympy/sympy/releases/>`_.
 
 Contents:
 


### PR DESCRIPTION
<If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>

Following suggestion at
https://gitter.im/sympy/sympy?at=584e131e7e2af9d1229b35a0