### PR TITLE
Unicode issue with sympy.stats.FiniteRV

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -17,6 +17,7 @@ from __future__ import print_function, division
 from sympy import (Basic, S, Expr, Symbol, Tuple, And, Add, Eq, lambdify,
         Equality, Lambda, DiracDelta, sympify)
 from sympy.core.relational import Relational
+from sympy.core.compatibility import string_types
 from sympy.logic.boolalg import Boolean
 from sympy.solvers.solveset import solveset
 from sympy.sets.sets import FiniteSet, ProductSet, Intersection
@@ -174,7 +175,7 @@ class SinglePSpace(PSpace):
     attributed to a single variable/symbol.
     """
     def __new__(cls, s, distribution):
-        if isinstance(s, str):
+        if isinstance(s, string_types):
             s = Symbol(s)
         if not isinstance(s, Symbol):
             raise TypeError("s should have been string or Symbol")

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -1,7 +1,8 @@
+from __future__ import unicode_literals
 from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic,
         DiracDelta)
-from sympy.stats import (Die, Normal, Exponential, P, E, variance, covariance,
+from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, variance, covariance,
         skewness, density, given, independent, dependent, where, pspace,
         random_symbols, sample)
 from sympy.stats.rv import (ProductPSpace, rs_swap, Density, NamedArgsMixin,
@@ -214,3 +215,9 @@ def test_issue_10052():
     assert P(X < 3, X == 2) == 0
     raises(ValueError, lambda: P(1))
     raises(ValueError, lambda: P(X < 1, 2))
+
+def test_issue_11934():
+    density = {0: .5, 1: .5}
+    X = FiniteRV('X', density)
+    assert E(X) == 0.5
+    assert P( X>= 2) == 0


### PR DESCRIPTION
Fixes #11934 
When working in Python2.7 with `unicode_lierals`, the symbol used in the function was being evaluated as a unicode characterwhich produced an error . This problem has been fixed now. As suggested by @asmeurer on Gitter Chat, I have imported `string_types` from `sympy.core.compatibility` in `sympy/stats/rv.py `where there is a check for `isinstance(s, str)`, hence eliminating the problem . I hope this has resolved the issue pretty well. A test case `test_issue_11934` has also been added to `sympy/stats/tests/test_rv.py`