### PR TITLE
Unicode issue with sympy.stats.FiniteRV #11934

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -17,6 +17,7 @@ from __future__ import print_function, division
 from sympy import (Basic, S, Expr, Symbol, Tuple, And, Add, Eq, lambdify,
         Equality, Lambda, DiracDelta, sympify)
 from sympy.core.relational import Relational
+from sympy.core.compatibility import string_types
 from sympy.logic.boolalg import Boolean
 from sympy.solvers.solveset import solveset
 from sympy.sets.sets import FiniteSet, ProductSet, Intersection
@@ -174,7 +175,7 @@ class SinglePSpace(PSpace):
     attributed to a single variable/symbol.
     """
     def __new__(cls, s, distribution):
-        if isinstance(s, str):
+        if isinstance(s, string_types):
             s = Symbol(s)
         if not isinstance(s, Symbol):
             raise TypeError("s should have been string or Symbol")


### PR DESCRIPTION
Per @asmeurer 's suggestion, have imported `string_types` from `sympy.core.compatibility` in `sympy.stats.rv.py`. I tested locally and also the test run for Stats module was successful `$ ./bin/test stats`. Please let me know if questions or suggestions.