### PR TITLE
Experimental sathandlers

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -729,6 +729,44 @@ class AssumptionKeys(object):
         """
         return Predicate('is_true')
 
+    # XXX: empty_matrix or just empty?
+    @predicate_memo
+    def empty_matrix(self):
+        """
+        A matrix having at least one dimension equal to zero.
+
+        Examples
+        ========
+
+        >>> from sympy import Q, ask, MatrixSymbol
+        >>> X = MatrixSymbol('X', 0, 0)
+        >>> Y = MatrixSymbol('Y', 2, 0)
+        >>> Z = MatrixSymbol('Z', 2, 2)
+        >>> ask(Q.empty_matrix(X))
+        True
+        >>> ask(Q.empty_matrix(Z*Y))
+        True
+        >>> ask(Q.empty_matrix(Z))
+        False
+        """
+        return Predicate('empty_matrix')
+
+    # XXX: is scalar_matrix predicat needed?
+    @predicate_memo
+    def scalar_matrix(self):
+        """
+        A 1-by-1 matrix.
+        """
+        return Predicate('scalar_matrix')
+
+    # XXX: is zero_matrix predicat needed?
+    @predicate_memo
+    def zero_matrix(self):
+        """
+        Zero matrix.
+        """
+        return Predicate('zero_matrix')
+
     @predicate_memo
     def symmetric(self):
         """
@@ -1523,6 +1561,10 @@ def get_known_facts():
         Equivalent(Q.invertible, ~Q.singular),
         Implies(Q.integer_elements, Q.real_elements),
         Implies(Q.real_elements, Q.complex_elements),
+
+        Implies(Q.scalar_matrix, Q.diagonal),
+        Implies(Q.zero_matrix & Q.square, Q.diagonal),
+        Implies(Q.empty_matrix & Q.square, Q.diagonal),
     )
 
 from sympy.assumptions.ask_generated import (

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -751,14 +751,6 @@ class AssumptionKeys(object):
         """
         return Predicate('empty_matrix')
 
-    # XXX: is scalar_matrix predicat needed?
-    @predicate_memo
-    def scalar_matrix(self):
-        """
-        A 1-by-1 matrix.
-        """
-        return Predicate('scalar_matrix')
-
     # XXX: is zero_matrix predicat needed?
     @predicate_memo
     def zero_matrix(self):
@@ -1552,7 +1544,6 @@ def get_known_facts():
         Implies(Q.upper_triangular, Q.triangular),
         Implies(Q.triangular, Q.upper_triangular | Q.lower_triangular),
         Implies(Q.upper_triangular & Q.lower_triangular, Q.diagonal),
-        Implies(Q.diagonal, Q.symmetric),
         Implies(Q.unit_triangular, Q.triangular),
         Implies(Q.invertible, Q.fullrank),
         Implies(Q.invertible, Q.square),
@@ -1562,9 +1553,9 @@ def get_known_facts():
         Implies(Q.integer_elements, Q.real_elements),
         Implies(Q.real_elements, Q.complex_elements),
 
-        Implies(Q.scalar_matrix, Q.diagonal),
         Implies(Q.zero_matrix & Q.square, Q.diagonal),
         Implies(Q.empty_matrix & Q.square, Q.diagonal),
+        Implies(Q.diagonal, Q.symmetric),
     )
 
 from sympy.assumptions.ask_generated import (

--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -38,33 +38,17 @@ class AskSymmetricHandler(CommonHandler):
         factor, mmul = expr.as_coeff_mmul()
         if all(ask(Q.symmetric(arg), assumptions) for arg in mmul.args):
             return True
-        # TODO: implement sathandlers system for the matrices.
-        # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
-        if ask(Q.diagonal(expr), assumptions):
-            return True
         if len(mmul.args) >= 2 and mmul.args[0] == mmul.args[-1].T:
             if len(mmul.args) == 2:
                 return True
             return ask(Q.symmetric(MatMul(*mmul.args[1:-1])), assumptions)
 
     @staticmethod
-    def MatAdd(expr, assumptions):
-        return all(ask(Q.symmetric(arg), assumptions) for arg in expr.args)
-
-    @staticmethod
     def MatrixSymbol(expr, assumptions):
         if not expr.is_square:
             return False
-        # TODO: implement sathandlers system for the matrices.
-        # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
-        if ask(Q.diagonal(expr), assumptions):
-            return True
         if Q.symmetric(expr) in conjuncts(assumptions):
             return True
-
-    @staticmethod
-    def ZeroMatrix(expr, assumptions):
-        return ask(Q.square(expr), assumptions)
 
     @staticmethod
     def Transpose(expr, assumptions):
@@ -74,10 +58,6 @@ class AskSymmetricHandler(CommonHandler):
 
     @staticmethod
     def MatrixSlice(expr, assumptions):
-        # TODO: implement sathandlers system for the matrices.
-        # Now it duplicates the general fact: Implies(Q.diagonal, Q.symmetric).
-        if ask(Q.diagonal(expr), assumptions):
-            return True
         if not expr.on_diag:
             return None
         else:
@@ -377,18 +357,9 @@ class AskDiagonalHandler(CommonHandler):
     Handler for key 'diagonal'
     """
 
-    @staticmethod
-    def _is_empty_or_1x1(expr):
-        return expr.shape == (0, 0) or expr.shape == (1, 1)
-
-    @staticmethod
-    def MatMul(expr, assumptions):
-        if AskDiagonalHandler._is_empty_or_1x1(expr):
-            return True
-        factor, matrices = expr.as_coeff_matrices()
-        if all(ask(Q.diagonal(m), assumptions) for m in matrices):
-            return True
-
+    # TODO: this method should be replaced by the rule:
+    #   (MatAdd, Implies(AllArgs(Q.diagonal), Q.diagonal))
+    # the tests are failing if `def MatAdd` is deleted. Why?
     @staticmethod
     def MatAdd(expr, assumptions):
         if all(ask(Q.diagonal(arg), assumptions) for arg in expr.args):
@@ -396,8 +367,6 @@ class AskDiagonalHandler(CommonHandler):
 
     @staticmethod
     def MatrixSymbol(expr, assumptions):
-        if AskDiagonalHandler._is_empty_or_1x1(expr):
-            return True
         if Q.diagonal(expr) in conjuncts(assumptions):
             return True
 
@@ -413,8 +382,6 @@ class AskDiagonalHandler(CommonHandler):
 
     @staticmethod
     def MatrixSlice(expr, assumptions):
-        if AskDiagonalHandler._is_empty_or_1x1(expr):
-            return True
         if not expr.on_diag:
             return None
         else:

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -29,15 +29,6 @@ def satask(proposition, assumptions=True, context=global_assumptions,
         return False
 
     if not can_be_true and not can_be_false:
-        from pprint import pprint
-        pprint(can_be_true)
-        pprint(can_be_false)
-        pprint('proposition')
-        pprint(proposition)
-        pprint('assumptions')
-        pprint(assumptions)
-        pprint('relevant_facts')
-        pprint(relevant_facts)
         # TODO: Run additional checks to see which combination of the
         # assumptions, global_assumptions, and relevant_facts are
         # inconsistent.

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -29,6 +29,15 @@ def satask(proposition, assumptions=True, context=global_assumptions,
         return False
 
     if not can_be_true and not can_be_false:
+        from pprint import pprint
+        pprint(can_be_true)
+        pprint(can_be_false)
+        pprint('proposition')
+        pprint(proposition)
+        pprint('assumptions')
+        pprint(assumptions)
+        pprint('relevant_facts')
+        pprint(relevant_facts)
         # TODO: Run additional checks to see which combination of the
         # assumptions, global_assumptions, and relevant_facts are
         # inconsistent.

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -303,7 +303,7 @@ class CheckEmptyMatrix(UnevaluatedOnFree):
 class CheckOneByOneMatrix(UnevaluatedOnFree):
 
     def apply(self):
-        return Equivalent(self.args[0], self.expr.shape == (1, 1))
+        return Implies(self.expr.shape == (1, 1), self.args[0])
 
 fact_registry = ClassFactRegistry()
 
@@ -318,15 +318,13 @@ for klass, fact in [
     (MatAdd, Implies(AllArgs(Q.symmetric), Q.symmetric)),
     (MatAdd, Implies(AllArgs(Q.diagonal), Q.diagonal)),
     (MatMul, Implies(AllArgs(Q.diagonal), Q.diagonal)),
-    # TODO: or may be CustomLambda?
     (MatrixExpr, CheckSquareMatrix(Q.square)),
-    (MatrixExpr, CheckOneByOneMatrix(Q.scalar_matrix)),
+    (MatrixExpr, CheckOneByOneMatrix(Q.diagonal)),
     (MatrixExpr, CheckEmptyMatrix(Q.empty_matrix)),
     (ZeroMatrix, Q.zero_matrix),
     (Identity, Q.diagonal),
     # TODO: why are tests failing if these rules are moved to ask.py?
-    (MatrixExpr, Implies(Q.scalar_matrix, Q.diagonal)),
-    (MatrixExpr, Implies(Q.empty_matrix & Q.square, Q.diagonal)),
+    # (MatrixExpr, Implies(Q.empty_matrix & Q.square, Q.diagonal)),
 
     (Add, Implies(AllArgs(Q.positive), Q.positive)),
     (Add, Implies(AllArgs(Q.negative), Q.negative)),

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -7,7 +7,7 @@ from sympy.core.numbers import ImaginaryUnit
 from sympy.core.sympify import _sympify
 from sympy.core.rules import Transform
 from sympy.core.logic import fuzzy_or, fuzzy_and
-from sympy.matrices.expressions import MatMul
+from sympy.matrices.expressions import (Identity, MatAdd, MatMul, MatrixExpr, ZeroMatrix)
 
 from sympy.functions.elementary.complexes import Abs
 
@@ -288,6 +288,22 @@ class ClassFactRegistry(MutableMapping):
     def __repr__(self):
         return repr(self.d)
 
+class CheckSquareMatrix(UnevaluatedOnFree):
+
+    def apply(self):
+        r, c = self.expr.shape
+        return Equivalent(self.args[0], r == c)
+
+class CheckEmptyMatrix(UnevaluatedOnFree):
+
+    def apply(self):
+        r, c = self.expr.shape
+        return Equivalent(self.args[0], r == 0 or c == 0)
+
+class CheckOneByOneMatrix(UnevaluatedOnFree):
+
+    def apply(self):
+        return Equivalent(self.args[0], self.expr.shape == (1, 1))
 
 fact_registry = ClassFactRegistry()
 
@@ -299,6 +315,19 @@ def register_fact(klass, fact, registry=fact_registry):
 for klass, fact in [
     (Mul, Equivalent(Q.zero, AnyArgs(Q.zero))),
     (MatMul, Implies(AllArgs(Q.square), Equivalent(Q.invertible, AllArgs(Q.invertible)))),
+    (MatAdd, Implies(AllArgs(Q.symmetric), Q.symmetric)),
+    (MatAdd, Implies(AllArgs(Q.diagonal), Q.diagonal)),
+    (MatMul, Implies(AllArgs(Q.diagonal), Q.diagonal)),
+    # TODO: or may be CustomLambda?
+    (MatrixExpr, CheckSquareMatrix(Q.square)),
+    (MatrixExpr, CheckOneByOneMatrix(Q.scalar_matrix)),
+    (MatrixExpr, CheckEmptyMatrix(Q.empty_matrix)),
+    (ZeroMatrix, Q.zero_matrix),
+    (Identity, Q.diagonal),
+    # TODO: why are tests failing if these rules are moved to ask.py?
+    (MatrixExpr, Implies(Q.scalar_matrix, Q.diagonal)),
+    (MatrixExpr, Implies(Q.empty_matrix & Q.square, Q.diagonal)),
+
     (Add, Implies(AllArgs(Q.positive), Q.positive)),
     (Add, Implies(AllArgs(Q.negative), Q.negative)),
     (Mul, Implies(AllArgs(Q.positive), Q.positive)),

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -128,6 +128,9 @@ def test_diagonal():
     assert ask(Q.diagonal(X), Q.lower_triangular(X) & Q.upper_triangular(X))
     assert ask(Q.symmetric(X), Q.diagonal(X))
     assert ask(Q.triangular(X), Q.diagonal(X))
+    
+    assert ask(Q.empty_matrix(C0x0) & Q.square(C0x0))
+    assert ask(Q.diagonal(A1x1))
     assert ask(Q.diagonal(C0x0))
     assert ask(Q.diagonal(A1x1))
     assert ask(Q.diagonal(A1x1 + B1x1))

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -51,7 +51,9 @@ def test_symmetric():
     assert ask(Q.symmetric(Y.T*X*Y)) is None
     assert ask(Q.symmetric(Y.T*X*Y), Q.symmetric(X)) is True
     assert ask(Q.symmetric(X*X*X*X*X*X*X*X*X*X), Q.symmetric(X)) is True
-    assert ask(Q.symmetric(A1x1)) is True
+    assert ask(Q.symmetric(C0x0))
+    # assert ask(Q.scalar_matrix(A1x1)) is True
+    # assert ask(Q.symmetric(A1x1), Q.scalar_matrix(A1x1)) is True
     assert ask(Q.symmetric(A1x1 + B1x1)) is True
     assert ask(Q.symmetric(A1x1 * B1x1)) is True
     assert ask(Q.symmetric(V1.T*V1)) is True


### PR DESCRIPTION
@asmeurer, @jksuom 
This is an example of a sat handlers for the matrices.

1. Is the goal to migrate from `sympy/assumptions/handlers/matrices.py` to `sympy/assumptions/sathandlers.py`?

For instance instead of writing custom code like this:
```
        if all(ask(Q.diagonal(arg), assumptions) for arg in mmul.args):
            return True
```
We could use the rules: `(MatMul, Implies(AllArgs(Q. diagonal), Q. diagonal)),`

2. Which function is supposed to be used: `ask` or `satask`?