### PR TITLE
modified expr.py, so that _eval_interval() now takes limit from the left

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -792,7 +792,7 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                B = limit(self, x, b)
+                B = limit(self, x, b,'-')
                 if isinstance(B, Limit):
                     raise NotImplementedError("Could not compute limit")
 


### PR DESCRIPTION
Fixes #11877 
Earlier limit from the right was taken as the method limit in expr.py by default was taking '+' sign.