### PR TITLE
evalf : Increase depth of symbolic evaluation for Abs()

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -208,21 +208,19 @@ def complex_accuracy(result):
 
 
 def get_abs(expr, prec, options):
-    from sympy.functions.elementary.complexes import Abs
-
     re, im, re_acc, im_acc = evalf(expr, prec + 2, options)
 
     if not re:
         re, re_acc, im, im_acc = im, im_acc, re, re_acc
     if im:
         if expr.is_number:
-            abs_expr, _, acc, _ = evalf(Abs(N(expr, prec + 2)),
+            abs_expr, _, acc, _ = evalf(abs(N(expr, prec + 2)),
                                         prec + 2, options)
             return abs_expr, None, acc, None
         else:
             if 'subs' in options:
                 return libmp.mpc_abs((re, im), prec), None, re_acc, None
-            return Abs(expr), None, prec, None
+            return abs(expr), None, prec, None
     elif re:
         return mpf_abs(re), None, re_acc, None
     else:

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -210,14 +210,21 @@ def complex_accuracy(result):
 def get_abs(expr, prec, options):
     from sympy.functions.elementary.complexes import Abs
 
-    real, imag, re_acc, im_acc = evalf(expr, prec + 2, options)
-    if real or imag:
+    re, im, re_acc, im_acc = evalf(expr, prec + 2, options)
+
+    if not re:
+        re, re_acc, im, im_acc = im, im_acc, re, re_acc
+    if im:
         if expr.is_number:
             abs_expr, _, acc, _ = evalf(Abs(N(expr, prec + 2)),
                                         prec + 2, options)
             return abs_expr, None, acc, None
         else:
+            if 'subs' in options:
+                return libmp.mpc_abs((re, im), prec), None, re_acc, None
             return Abs(expr), None, prec, None
+    elif re:
+        return mpf_abs(re), None, re_acc, None
     else:
         return None, None, None, None
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -208,13 +208,16 @@ def complex_accuracy(result):
 
 
 def get_abs(expr, prec, options):
-    re, im, re_acc, im_acc = evalf(expr, prec + 2, options)
-    if not re:
-        re, re_acc, im, im_acc = im, im_acc, re, re_acc
-    if im:
-        return libmp.mpc_abs((re, im), prec), None, re_acc, None
-    elif re:
-        return mpf_abs(re), None, re_acc, None
+    from sympy.functions.elementary.complexes import Abs
+
+    real, imag, re_acc, im_acc = evalf(expr, prec + 2, options)
+    if real or imag:
+        if expr.is_number:
+            abs_expr, _, acc, _ = evalf(Abs(N(expr, prec + 2)),
+                                        prec + 2, options)
+            return abs_expr, None, acc, None
+        else:
+            return Abs(expr), None, prec, None
     else:
         return None, None, None, None
 
@@ -815,7 +818,7 @@ def evalf_log(expr, prec, options):
 
     re = mpf_log(mpf_abs(xre), prec, rnd)
     size = fastlog(re)
-    if prec - size > workprec:
+    if prec - size > workprec and re != fzero:
         # We actually need to compute 1+x accurately, not x
         arg = Add(S.NegativeOne, arg, evaluate=False)
         xre, xim, _, _ = evalf_add(arg, prec, options)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -129,6 +129,7 @@ def test_evalf_logs():
     assert NS("log(pi*I)", 15) == '1.14472988584940 + 1.57079632679490*I'
     assert NS('log(-1 + 0.00001)', 2) == '-1.0e-5 + 3.1*I'
     assert NS('log(100, 10, evaluate=False)', 15) == '2.00000000000000'
+    assert NS('-2*I*log(-(-1)**(S(1)/9))', 15) == '-5.58505360638185'
 
 
 def test_evalf_trig():


### PR DESCRIPTION
Absolute value was imprecise for some quantities. This was because the computed mpmath values for real and imaginary parts are obviously not infinitely accurate.Therefore the `Abs()` for such expressions was inaccurate.  
Hence ,symbolic evaluation is carried out first and then converted to float.

Example :
====================
Previously : 
```
>>> from sympy import *
>>> a = -2*I*log(-(-1)**(S(1)/9))
>>> a.evalf()
-5.58505360638185 + 2.09933628361472e-140*I
```
There is a spurious imaginary part which arises because at one step the `get_abs()` function is called for `(-1)**(S(1)/9)`. Now, the real and imaginary parts are computed and then `mpc_abs()` is called on those quantities.But obviously the computed real and imaginary are not infinitely precise and hence the value returned by `mpc_abs()`  is different from `1`.

With the fix : 
```
>>> from sympy import *
>>> a = -2*I*log(-(-1)**(S(1)/9))
>>> a.evalf()
-5.58505360638185
```