### PR TITLE
Use left-handed limit for integration with discontinuity at right end of interval

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -792,7 +792,7 @@ class Expr(Basic, EvalfMixin):
         else:
             B = self.subs(x, b)
             if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
-                B = limit(self, x, b)
+                B = limit(self, x, b, dir="-")
                 if isinstance(B, Limit):
                     raise NotImplementedError("Could not compute limit")
 


### PR DESCRIPTION
Fixes #11877

When integrand is discontinuous at the right end b of the integration interval [a,b] then the improper integral must be evaluated using a left hand limit here since the interval of integration is entirely on the left side of the upper limit.

Test using
```
x = Symbol('x')
integrate(log(0.5-x), (x, 0, 0.5))
```

Notice output:
```
Out[2]: -0.846573590279973
```