### PR TITLE
add atrribute "usebackend" to Plot to change backend

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -77,7 +77,7 @@ class Plot(object):
 
     This class permits the plotting of sympy expressions using numerous
     backends (matplotlib, textplot, the old pyglet module for sympy, Google
-    charts api, etc).To choose between a backend use ``backend`` option while
+    charts api, etc).To choose a backend use ``backend`` option while
     initilizing the plot class. Example: ``p1 = plot(x*x,backend='text')``,
     options given are:
     - 'text'

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -184,7 +184,7 @@ class Plot(object):
         # The backend type. On every show() a new backend instance is created
         # in self._backend which is tightly coupled to the Plot instance
         # (thanks to the parent attribute of the backend).
-        if 'usebackend' in kwargs:
+        if 'backend' in kwargs:
             self.backend = plot_backends[kwargs.pop('backend')]
         else:
             self.backend = DefaultBackend

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -67,6 +67,9 @@ def _arity(f):
        return len([p for p in param if p.kind == p.POSITIONAL_OR_KEYWORD])
 
 
+plot_backends = {}
+
+
 class Plot(object):
     """The central class of the plotting module.
 
@@ -180,8 +183,8 @@ class Plot(object):
 
         # The backend type. On every show() a new backend instance is created
         # in self._backend which is tightly coupled to the Plot instance
-        # (thanks to the parent attribute of the backend).
-        self.backend = DefaultBackend
+        # (thanks to the parent attribute of the backend). kwargs.pop('usebackend')
+        self.backend = plot_backends[kwargs.pop('usebackend')]
 
         # The keyword arguments should only contain options for the plot.
         for key, val in kwargs.items():
@@ -922,9 +925,9 @@ class MatplotlibBackend(BaseBackend):
                 self.ax.set_zlim((min(z), max(z)))
             elif s.is_3Dsurface:
                 x, y, z = s.get_meshes()
-                collection = self.ax.plot_surface(x, y, z,
-                    cmap=getattr(self.cm, 'viridis', self.cm.jet),
-                    rstride=1, cstride=1, linewidth=0.1)
+                collection = self.ax.plot_surface(x, y, z, cmap=self.cm.jet,
+                                                  rstride=1, cstride=1,
+                                                  linewidth=0.1)
             elif s.is_implicit:
                 #Smart bounds have to be set to False for implicit plots.
                 self.ax.spines['left'].set_smart_bounds(False)
@@ -1069,11 +1072,9 @@ class DefaultBackend(BaseBackend):
             return TextBackend(parent)
 
 
-plot_backends = {
-    'matplotlib': MatplotlibBackend,
-    'text': TextBackend,
-    'default': DefaultBackend
-}
+plot_backends['matplotlib'] = MatplotlibBackend
+plot_backends['text'] = TextBackend
+plot_backends['default'] = DefaultBackend
 
 
 ##############################################################################

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -184,7 +184,7 @@ class Plot(object):
         # The backend type. On every show() a new backend instance is created
         # in self._backend which is tightly coupled to the Plot instance
         # (thanks to the parent attribute of the backend). kwargs.pop('usebackend')
-        self.backend = plot_backends[kwargs.pop('usebackend')]
+        self.backend = plot_backends[kwargs.pop('backend')]
 
         # The keyword arguments should only contain options for the plot.
         for key, val in kwargs.items():

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -183,8 +183,11 @@ class Plot(object):
 
         # The backend type. On every show() a new backend instance is created
         # in self._backend which is tightly coupled to the Plot instance
-        # (thanks to the parent attribute of the backend). kwargs.pop('usebackend')
-        self.backend = plot_backends[kwargs.pop('usebackend')]
+        # (thanks to the parent attribute of the backend).
+        if 'usebackend' in kwargs:
+            self.backend = plot_backends[kwargs.pop('usebackend')]
+        else:
+            self.backend = DefaultBackend
 
         # The keyword arguments should only contain options for the plot.
         for key, val in kwargs.items():
@@ -926,8 +929,8 @@ class MatplotlibBackend(BaseBackend):
             elif s.is_3Dsurface:
                 x, y, z = s.get_meshes()
                 collection = self.ax.plot_surface(x, y, z,
-                     cmap=getattr(self.cm, 'viridis', self.cm.jet),
-                     rstride=1, cstride=1, linewidth=0.1)
+                    cmap=getattr(self.cm, 'viridis', self.cm.jet),
+                    rstride=1, cstride=1, linewidth=0.1)
             elif s.is_implicit:
                 #Smart bounds have to be set to False for implicit plots.
                 self.ax.spines['left'].set_smart_bounds(False)

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -77,7 +77,11 @@ class Plot(object):
 
     This class permits the plotting of sympy expressions using numerous
     backends (matplotlib, textplot, the old pyglet module for sympy, Google
-    charts api, etc).
+    charts api, etc).To choose between a backend use ``backend`` option while
+    initilizing the plot class. Example: ``p1 = plot(x*x,backend='text')``,
+    options given are:
+    - 'text'
+    - 'matplotlib'
 
     The figure can contain an arbitrary number of plots of sympy expressions,
     lists of coordinates of points, etc. Plot has a private attribute _series that

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -925,9 +925,9 @@ class MatplotlibBackend(BaseBackend):
                 self.ax.set_zlim((min(z), max(z)))
             elif s.is_3Dsurface:
                 x, y, z = s.get_meshes()
-                collection = self.ax.plot_surface(x, y, z, cmap=self.cm.jet,
-                                                  rstride=1, cstride=1,
-                                                  linewidth=0.1)
+                collection = self.ax.plot_surface(x, y, z,
+                     cmap=getattr(self.cm, 'viridis', self.cm.jet),
+                     rstride=1, cstride=1, linewidth=0.1)
             elif s.is_implicit:
                 #Smart bounds have to be set to False for implicit plots.
                 self.ax.spines['left'].set_smart_bounds(False)


### PR DESCRIPTION
Ref. #11898

This is just a proof of concept, i just wanted to demonstrated what i had in mind. essentially you can use "usebackend" attribute to change backend. example:
```
from sympy import symbols
from sympy import plot

t = symbols('t')
x1 = plot(t**2,usebackend="text")
``` 

the above example draws text graph even if matplotlib is installed.
