### PR TITLE
Corrected the typo error in line 106 of the file mathml.py 

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -103,7 +103,7 @@ class MathMLPrinter(Printer):
         coeff, terms = expr.as_coeff_mul()
         if coeff is S.One and len(terms) == 1:
             # XXX since the negative coefficient has been handled, I don't
-            # thing a coeff of 1 can remain
+            # think a coeff of 1 can remain
             return self._print(terms[0])
 
         if self.order != 'old':


### PR DESCRIPTION
This PR closes the issue #11986 .
In the line `106` , `thing` has been replaced by `think`. And as suggested by @moorepants in #11977 ,
the commit message includes `[skip ci]`.