### PR TITLE
Comment fixes for sympy.physics.mechanics module

### DIFF
--- a/sympy/physics/mechanics/body.py
+++ b/sympy/physics/mechanics/body.py
@@ -88,7 +88,7 @@ class Body(RigidBody, Particle):
         >>> mass = Symbol('mass')
         >>> body = Body('name_of_body', mass=mass)
 
-    The Particle version of the Body object can also recieve a masscenter point
+    The Particle version of the Body object can also receive a masscenter point
     and a reference frame, just not an inertia.
     """
 
@@ -149,7 +149,7 @@ class Body(RigidBody, Particle):
         Example
         =======
 
-        The first example applys a gravitational force in the x direction of
+        The first example applies a gravitational force in the x direction of
         Body's frame to the body's center of mass. ::
 
             >>> from sympy import Symbol
@@ -159,7 +159,7 @@ class Body(RigidBody, Particle):
             >>> body.apply_force(body.mass * g * body.frame.x)
 
         To apply force to any other point than center of mass, pass that point
-        as well. This example applys a gravitational force to a point a distance
+        as well. This example applies a gravitational force to a point a distance
         l from the body's center of mass in the y direction. The force is again
         applied in the x direction. ::
 

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -47,7 +47,7 @@ def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
     """Simple way to create inertia Dyadic object.
 
     If you don't know what a Dyadic is, just treat this like the inertia
-    tensor.  Then, do the easy thing and define it in a body-fixed frame.
+    tensor. Then, do the easy thing and define it in a body-fixed frame.
 
     Parameters
     ==========
@@ -455,7 +455,9 @@ def msubs(expr, *sub_dicts, **kwargs):
     the denominator. If this results in 0, simplification of the entire
     fraction is attempted. Using this selective simplification, only
     subexpressions that result in 1/0 are targeted, resulting in faster
-    performance."""
+    performance.
+
+    """
 
     sub_dict = dict_merge(*sub_dicts)
     smart = kwargs.pop('smart', False)
@@ -509,6 +511,7 @@ def _smart_subs(expr, sub_dict):
         If so, attempt to simplify it out. Then if node is in sub_dict,
         sub in the corresponding value."""
     expr = _crawl(expr, _tan_repl_func)
+
     def _recurser(expr, sub_dict):
         # Decompose the expression into num, den
         num, den = _fraction_decomp(expr)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -92,7 +92,7 @@ class KanesMethod(object):
     here (see the online documentation).
     Next we form FR* and FR to complete: Fr + Fr* = 0.
     We have the equations of motion at this point.
-    It makes sense to rearrnge them though, so we calculate the mass matrix and
+    It makes sense to rearrange them though, so we calculate the mass matrix and
     the forcing terms, for E.o.M. in the form: [MM] udot = forcing, where MM is
     the mass matrix, udot is a vector of the time derivatives of the
     generalized speeds, and forcing is a vector representing "forcing" terms.
@@ -487,7 +487,7 @@ class KanesMethod(object):
 
         The operating points may be also entered using the ``op_point`` kwarg.
         This takes a dictionary of {symbol: value}, or a an iterable of such
-        dictionaries. The values may be numberic or symbolic. The more values
+        dictionaries. The values may be numeric or symbolic. The more values
         you can specify beforehand, the faster this computation will run.
 
         As part of the deprecation cycle, the new method will not be used unless

--- a/sympy/physics/mechanics/models.py
+++ b/sympy/physics/mechanics/models.py
@@ -12,7 +12,7 @@ import sympy.physics.mechanics as me
 def multi_mass_spring_damper(n=1, apply_gravity=False,
                              apply_external_forces=False):
     """Returns a system containing the symbolic equations of motion and
-    associated variables for a simple mutli-degree of freedom point mass,
+    associated variables for a simple multi-degree of freedom point mass,
     spring, damper system with optional gravitational and external
     specified forces. For example, a two mass system under the influence of
     gravity and external forces looks like:


### PR DESCRIPTION
Corrected few comments in [sympy.physics.mechanics](https://github.com/sympy/sympy/tree/master/sympy/physics/mechanics) module by
 * fixing typographical errors
 * fixing grammatical errors
 * applying PEP8 style guide
