### PR TITLE
Moves autowrap tests in with MATPLOTLIB/THEANO/ASCII tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,8 +177,6 @@ matrix:
         - TEST_TENSORFLOW="true"
       sudo: true
       dist: trusty
-
-
     # PyPy randomly fails because of some PyPy bugs (Fatal RPython error: AssertionError)
     - python: "pypy"
       env:
@@ -274,7 +272,8 @@ before_install:
         # this assumes TEST_THEANO runs in the same build as TEST_MATPLOTLIB
         conda install theano;
     fi
-  - if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
+  - |
+    if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
         # this assumes TEST_AUTOWRAP runs in the same build as TEST_MATPLOTLIB
         conda install libgfortran libgcc gcc cython;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
         - TEST_MATPLOTLIB="true"
         - TEST_THEANO="true"
         - TEST_ASCII="true"
+        - TEST_AUTOWRAP="true"
       addons:
         apt:
           packages:
@@ -41,6 +42,7 @@ matrix:
         - TEST_MATPLOTLIB="true"
         - TEST_THEANO="true"
         - TEST_ASCII="true"
+        - TEST_AUTOWRAP="true"
       addons:
         apt:
           packages:
@@ -96,39 +98,12 @@ matrix:
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"
-
-    - python: 2.7
-      env:
-        - TEST_AUTOWRAP="true"
-      addons:
-        apt:
-          packages:
-            - gfortran
-            - gcc
-            - python-numpy
-            - cython
-      virtualenv:
-        system_site_packages: true
-
     - python: 3.5
       env:
         - TEST_SYMENGINE="true"
 
     # Everything here and below is in the allow_failures. The need to be
     # duplicated here and in that section below.
-    - python: 3.5
-      env:
-        - TEST_AUTOWRAP="true"
-      addons:
-        apt:
-          packages:
-            - gfortran
-            - gcc
-            - python-numpy
-            - cython
-      virtualenv:
-        system_site_packages: true
-
     - python: 3.5 # Dummy value
       env:
         - TEST_SAGE="true"
@@ -194,20 +169,6 @@ matrix:
             - pypy
 
   allow_failures:
-    # Fails because of some issues with Travis
-    - python: 3.5
-      env:
-        - TEST_AUTOWRAP="true"
-      addons:
-        apt:
-          packages:
-            - gfortran
-            - gcc
-            - python-numpy
-            - cython
-      virtualenv:
-        system_site_packages: true
-
     # The apt installation of sage fails sometimes
     - python: 3.5 # Dummy value
       env:
@@ -279,9 +240,6 @@ before_install:
   - if [[ "${FASTCACHE}" != "false" ]]; then
       pip install fastcache;
     fi
-  - if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
-      pip uninstall -y numpy;
-    fi
   - if [[ "${TEST_GMPY}" == "true" ]]; then
       pip install "gmpy==1.16";
     fi
@@ -306,16 +264,19 @@ before_install:
         conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION matplotlib numpy scipy pip llvmlite;
         source activate test-environment;
     fi
-
+  - if [[ "${TEST_SYMENGINE}" == "true" ]]; then
+        conda config --add channels conda-forge;
+        conda config --add channels symengine;
+        conda install python-symengine=0.2.0;
+    fi
   - |
     if [[ "${TEST_THEANO}" == "true" ]]; then
         # this assumes TEST_THEANO runs in the same build as TEST_MATPLOTLIB
         conda install theano;
     fi
-  - if [[ "${TEST_SYMENGINE}" == "true" ]]; then
-        conda config --add channels conda-forge;
-        conda config --add channels symengine;
-        conda install python-symengine=0.2.0;
+  - if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
+        # this assumes TEST_AUTOWRAP runs in the same build as TEST_MATPLOTLIB
+        conda install libgfortran libgcc gcc cython;
     fi
   - |
     if [[ "${TEST_TENSORFLOW}" == "true" ]]; then
@@ -339,13 +300,11 @@ install:
       then virtualenv -p /usr/bin/pypy ~/.venv;
            . ~/.venv/bin/activate;
     fi
-  - if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
+  - if [[ "${TEST_SAGE}" != "true" ]]; then
       pip uninstall -y setuptools;
       python setup.py install;
       pip uninstall -y sympy;
       pip install setuptools;
-      python setup.py install;
-    elif [[ "${TEST_SAGE}" != "true" ]]; then
       python setup.py install;
     fi
 script:

--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -1,8 +1,8 @@
 """Tools to assist importing optional external modules."""
 
 from __future__ import print_function, division
-
 import sys
+from distutils.version import StrictVersion
 
 # Override these in the module to change the default warning behavior.
 # For example, you might set both to False before running the tests so that
@@ -154,10 +154,14 @@ def import_module(module, min_module_version=None, min_python_version=None,
         modversion = getattr(mod, module_version_attr)
         if module_version_attr_call_args is not None:
             modversion = modversion(*module_version_attr_call_args)
-        if modversion < min_module_version:
+        # NOTE: StrictVersion() is use here to make sure a comparison like
+        # '1.11.2' < '1.6.1' doesn't fail. There is not a straight forward way
+        # to create a unit test for this.
+        if StrictVersion(modversion) < StrictVersion(min_module_version):
             if warn_old_version:
                 # Attempt to create a pretty string version of the version
-                if isinstance(min_module_version, basestring):
+                from ..core.compatibility import string_types
+                if isinstance(min_module_version, string_types):
                     verstr = min_module_version
                 elif isinstance(min_module_version, (tuple, list)):
                     verstr = '.'.join(map(str, min_module_version))

--- a/sympy/external/tests/test_importtools.py
+++ b/sympy/external/tests/test_importtools.py
@@ -33,3 +33,6 @@ def test_no_stdlib_collections3():
         min_module_version='1.1.0')
     if matplotlib:
         assert collections != matplotlib.collections
+
+def test_min_module_version_python3_basestring_error():
+    import_module('mpmath', min_module_version='1000.0.1')


### PR DESCRIPTION
- Uninstall cycle is now under the SAGE tests.
- autowrap related tests run with matplotlib, theano, an ascii tests.
- TEST_AUTOWRAP now uses conda installed packages.

<If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
