### PR TITLE
[WIP] expand_mul() : fixed the crash for nilpotent terms 

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -350,7 +350,7 @@ class Mul(Expr, AssocOp):
                         o12 = b1 ** new_exp
 
                         # now o12 could be a commutative object
-                        if o12.is_commutative:
+                        if isinstance(o12, int) or o12.is_commutative:
                             seq.append(o12)
                             continue
                         else:


### PR DESCRIPTION
Fixes #11985 
As suggested by in the issue, i tried replacing `if o12.is_commutative:` by `if isinstance(o12, int) or o12.is_commutative:` in [line 353 here](https://github.com/sympy/sympy/blob/9670ff89dd8bff7878c6d636ec4f493b87d092df/sympy/core/mul.py#L353)
The tests passed.
However , i got the error `'int' object has no attribute 'is_Order'` in [line 238 here](https://github.com/sympy/sympy/blob/9670ff89dd8bff7878c6d636ec4f493b87d092df/sympy/core/mul.py#L238)
I tried replacing `if o.is_Order:` by `if isinstance(o, int) or o.is_Order:` but then I got `'int' object has no attribute 'as_expr_variables'` in the [next line here](https://github.com/sympy/sympy/blob/9670ff89dd8bff7878c6d636ec4f493b87d092df/sympy/core/mul.py#L239)
What should be done?
