### PR TITLE
Don't lose precision when converting a Float to Rational

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -118,7 +118,6 @@ def seterr(divide=False):
 
 
 def _as_integer_ratio(p):
-    """compatibility implementation for python < 2.6"""
     neg_pow, man, expt, bc = getattr(p, '_mpf_', mpmath.mpf(p)._mpf_)
     p = [1, -1][neg_pow % 2]*man
     if expt < 0:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -117,6 +117,18 @@ def seterr(divide=False):
         _errdict["divide"] = divide
 
 
+def _as_integer_ratio(p):
+    """compatibility implementation for python < 2.6"""
+    neg_pow, man, expt, bc = getattr(p, '_mpf_', mpmath.mpf(p)._mpf_)
+    p = [1, -1][neg_pow % 2]*man
+    if expt < 0:
+        q = 2**-expt
+    else:
+        q = 1
+        p *= 2**expt
+    return int(p), int(q)
+
+
 def _decimal_to_Rational_prec(dec):
     """Convert an ordinary decimal instance to a Rational."""
     if not dec.is_finite():
@@ -1269,8 +1281,6 @@ class Rational(Number):
                     p = fractions.Fraction(p)
                 except ValueError:
                     pass  # error will raise below
-            elif isinstance(p, float):
-                p = fractions.Fraction(p)
 
             if not isinstance(p, string_types):
                 try:
@@ -1279,8 +1289,8 @@ class Rational(Number):
                 except NameError:
                     pass  # error will raise below
 
-                if isinstance(p, Float):
-                    return Rational(*float(p).as_integer_ratio())
+                if isinstance(p, (float, Float)):
+                    return Rational(*_as_integer_ratio(p))
 
             if not isinstance(p, SYMPY_INTS + (Rational,)):
                 raise TypeError('invalid input: %s' % p)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -301,6 +301,8 @@ def test_Rational_new():
     assert Rational('1e2/1e-2') == Rational(10000)
     assert Rational(-1, 0) == S.ComplexInfinity
     assert Rational(1, 0) == S.ComplexInfinity
+    # Make sure Rational doesn't lose precision on Floats
+    assert Rational(pi.evalf(100)).evalf(100) == pi.evalf(100)
     raises(TypeError, lambda: Rational('3**3'))
     raises(TypeError, lambda: Rational('1/2 + 2/3'))
 


### PR DESCRIPTION
This reverts an earlier commit that made Rational use Python's `float.as_integer_ratio` for `Float`, which loses precision. 

CC @scopatz 