### PR TITLE
Use .. warning directive in lambdify/sympify

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -66,8 +66,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
        - booleans, including ``None`` (will leave ``None`` unchanged)
        - lists, sets or tuples containing any of the above
 
-    Note that this function uses ``eval``, and thus shouldn't be used on
-    unsanitized input.
+    .. warning::
+        Note that this function uses ``eval``, and thus shouldn't be used on
+        unsanitized input.
 
     If the argument is already a type that SymPy understands, it will do
     nothing but return that value. This can be used at the beginning of a

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -193,8 +193,9 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
      - lists that contain a mix of the arguments above, with higher priority
        given to entries appearing first.
 
-    Note that this function uses ``eval``, and thus shouldn't be used on
-    unsanitized input.
+    .. warning::
+        Note that this function uses ``eval``, and thus shouldn't be used on
+        unsanitized input.
 
     The default behavior is to substitute all arguments in the provided
     expression with dummy symbols. This allows for applied functions (e.g.


### PR DESCRIPTION
Fixes #12001 , which was an issue created in response to comments in #11995 .

Use .. warning directive in lambdify/sympify for warning messages around unsanitized input.
