### PR TITLE
powsimp() modified for noncommutative variables

### DIFF
--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -387,7 +387,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                 if nc_part:
                     b1, e1 = nc_part[-1].as_base_exp()
                     b2, e2 = term.as_base_exp()
-                    if (e1 == e2 and e2.is_commutative):
+                    if (e1 == e2 and e2.is_commutative and (not isinstance(b1, Mul) or not isinstance(b2, Mul))):
                         nc_part[-1] = Pow(b1*b2, e1)
                         continue
                 nc_part.append(term)

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -379,7 +379,9 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         nc_part = []
         for term in expr.args:
             if term.is_commutative:
-                c_powers.append(list(term.as_base_exp()))            
+                c_powers.append(list(term.as_base_exp()))
+            else:                
+                nc_part.append(term)
 
         # Pull out numerical coefficients from exponent if assumptions allow
         # e.g., 2**(2*x) => 4**x

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -379,18 +379,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         nc_part = []
         for term in expr.args:
             if term.is_commutative:
-                c_powers.append(list(term.as_base_exp()))
-            else:
-                # This is the logic that combines bases that are
-                # different and non-commutative, but with equal and
-                # commutative exponents: A**x*B**x == (A*B)**x.
-                if nc_part:
-                    b1, e1 = nc_part[-1].as_base_exp()
-                    b2, e2 = term.as_base_exp()
-                    if (e1 == e2 and e2.is_commutative and (not isinstance(b1, Mul) or not isinstance(b2, Mul))):
-                        nc_part[-1] = Pow(b1*b2, e1)
-                        continue
-                nc_part.append(term)
+                c_powers.append(list(term.as_base_exp()))            
 
         # Pull out numerical coefficients from exponent if assumptions allow
         # e.g., 2**(2*x) => 4**x

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -380,7 +380,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         for term in expr.args:
             if term.is_commutative:
                 c_powers.append(list(term.as_base_exp()))
-            else:                
+            else:
                 nc_part.append(term)
 
         # Pull out numerical coefficients from exponent if assumptions allow

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -118,24 +118,24 @@ def test_powsimp_nc():
     assert powsimp(A**x*A**y, combine='base') == A**x*A**y
     assert powsimp(A**x*A**y, combine='exp') == A**(x + y)
 
-    assert powsimp(A**x*B**x, combine='all') == (A*B)**x
-    assert powsimp(A**x*B**x, combine='base') == (A*B)**x
+    assert powsimp(A**x*B**x, combine='all') == A**x*B**x
+    assert powsimp(A**x*B**x, combine='base') == A**x*B**x
     assert powsimp(A**x*B**x, combine='exp') == A**x*B**x
 
-    assert powsimp(B**x*A**x, combine='all') == (B*A)**x
-    assert powsimp(B**x*A**x, combine='base') == (B*A)**x
+    assert powsimp(B**x*A**x, combine='all') == B**x*A**x
+    assert powsimp(B**x*A**x, combine='base') == B**x*A**x
     assert powsimp(B**x*A**x, combine='exp') == B**x*A**x
 
     assert powsimp(A**x*A**y*A**z, combine='all') == A**(x + y + z)
     assert powsimp(A**x*A**y*A**z, combine='base') == A**x*A**y*A**z
     assert powsimp(A**x*A**y*A**z, combine='exp') == A**(x + y + z)
 
-    assert powsimp(A**x*B**x*C**x, combine='all') == (A*B*C)**x
-    assert powsimp(A**x*B**x*C**x, combine='base') == (A*B*C)**x
+    assert powsimp(A**x*B**x*C**x, combine='all') == A**x*B**x*C**x
+    assert powsimp(A**x*B**x*C**x, combine='base') == A**x*B**x*C**x
     assert powsimp(A**x*B**x*C**x, combine='exp') == A**x*B**x*C**x
 
-    assert powsimp(B**x*A**x*C**x, combine='all') == (B*A*C)**x
-    assert powsimp(B**x*A**x*C**x, combine='base') == (B*A*C)**x
+    assert powsimp(B**x*A**x*C**x, combine='all') == B**x*A**x*C**x
+    assert powsimp(B**x*A**x*C**x, combine='base') == B**x*A**x*C**x
     assert powsimp(B**x*A**x*C**x, combine='exp') == B**x*A**x*C**x
 
 
@@ -295,3 +295,7 @@ def test_issue_10195():
     assert powsimp(e_x) == (-1)**(n/2 - Rational(1, 2)) + (-1)**(3*n/2 +
             Rational(1,2))
     assert powsimp((-1)**(3*a/2)) == (-I)**a
+
+def test_issue_11981():
+    x, y = symbols('x y', commutative=False)
+    assert powsimp((x*y)**2 * (y*x)**2) == (x*y)**2 * (y*x)**2

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -299,4 +299,3 @@ def test_issue_10195():
 def test_issue_11981():
     x, y = symbols('x y', commutative=False)
     assert powsimp((x*y)**2 * (y*x)**2) == (x*y)**2 * (y*x)**2
-	

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -299,4 +299,4 @@ def test_issue_10195():
 def test_issue_11981():
     x, y = symbols('x y', commutative=False)
     assert powsimp((x*y)**2 * (y*x)**2) == (x*y)**2 * (y*x)**2
-    
+

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -299,4 +299,3 @@ def test_issue_10195():
 def test_issue_11981():
     x, y = symbols('x y', commutative=False)
     assert powsimp((x*y)**2 * (y*x)**2) == (x*y)**2 * (y*x)**2
-

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -299,3 +299,4 @@ def test_issue_10195():
 def test_issue_11981():
     x, y = symbols('x y', commutative=False)
     assert powsimp((x*y)**2 * (y*x)**2) == (x*y)**2 * (y*x)**2
+    

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -299,3 +299,4 @@ def test_issue_10195():
 def test_issue_11981():
     x, y = symbols('x y', commutative=False)
     assert powsimp((x*y)**2 * (y*x)**2) == (x*y)**2 * (y*x)**2
+	


### PR DESCRIPTION
The PR fixes #11981 where the powsimp() function returns incorrect output for noncommutative variables.
