### PR TITLE
Add kwarg 'ignore' to cse() for disqualification.

### DIFF
--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -477,3 +477,24 @@ def test_issue_11577():
 def test_hollow_rejection():
     eq = [x + 3, x + 4]
     assert cse(eq) == ([], eq)
+
+
+def test_cse_ignore():
+    exprs = [exp(y)*(3*y + 3*sqrt(x+1)), exp(y)*(5*y + 5*sqrt(x+1))]
+    subst1, red1 = cse(exprs)
+    for symb, sub in subst1:
+        if y in sub.free_symbols:
+            break  # expected behaviour
+    else:
+        raise ValueError("cse failed to identify any term with y")
+
+    subst2, red2 = cse(exprs, ignore=(y,))  # y is not allowed in substitutions
+    for symb, sub in subst2:
+        if y in sub.free_symbols:
+            raise ValueError("Sub-expressions containing y must be ignored")
+
+    for symb, sub in subst2:
+        if sub - sqrt(x+1) == 0:
+            break
+    else:
+        raise ValueError("cse failed to identify sqrt(x + 1) as sub-expression")

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -482,19 +482,8 @@ def test_hollow_rejection():
 def test_cse_ignore():
     exprs = [exp(y)*(3*y + 3*sqrt(x+1)), exp(y)*(5*y + 5*sqrt(x+1))]
     subst1, red1 = cse(exprs)
-    for symb, sub in subst1:
-        if y in sub.free_symbols:
-            break  # expected behaviour
-    else:
-        raise ValueError("cse failed to identify any term with y")
+    assert any(y in sub.free_symbols for _, sub in subst1), "cse failed to identify any term with y"
 
     subst2, red2 = cse(exprs, ignore=(y,))  # y is not allowed in substitutions
-    for symb, sub in subst2:
-        if y in sub.free_symbols:
-            raise ValueError("Sub-expressions containing y must be ignored")
-
-    for symb, sub in subst2:
-        if sub - sqrt(x+1) == 0:
-            break
-    else:
-        raise ValueError("cse failed to identify sqrt(x + 1) as sub-expression")
+    assert not any(y in sub.free_symbols for _, sub in subst2), "Sub-expressions containing y must be ignored"
+    assert any(sub - sqrt(x + 1) == 0 for _, sub in subst2), "cse failed to identify sqrt(x + 1) as sub-expression"


### PR DESCRIPTION
I needed a way to tell `cse` not to create substitutions containing a subset of symbols.
I've implemented this functionality by adding a keyword argument `ignore` to `cse`.

I found this to be useful e.g. when doing code-generation where a set of variables may change much more often than others. If you don't include the frequently changing variables in the common subexpressions, then the substitutions stay valid over e.g. iterations in numerical code.

Let me know what you think.