### PR TITLE
Support augmented matrices in rref()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4662,12 +4662,21 @@ class MatrixBase(MatrixOperations, MatrixProperties, MatrixShaping):
 
         return M.applyfunc(lambda x: x.replace(F, G, map))
 
-    def rref(self, iszerofunc=_iszero, simplify=False):
+    def rref(self, iszerofunc=_iszero, simplify=False, aug=None):
         """Return reduced row-echelon form of matrix and indices of pivot vars.
 
         To simplify elements before finding nonzero pivots set simplify=True
         (to use the default SymPy simplify function) or pass a custom
         simplify function.
+
+        Parameters
+        ==========
+        iszerofunc : callable
+        simplify : bool or callable
+        aug : MutableMatrix (optional)
+            Optional extra columns to form an augmented matrix.
+            The row operations performed will also be performed
+            on ``aug`` if given.
 
         Examples
         ========
@@ -4716,13 +4725,20 @@ class MatrixBase(MatrixOperations, MatrixProperties, MatrixShaping):
             # swap the pivot column into place
             pivot_pos = pivot + pivot_offset
             r.row_swap(pivot, pivot_pos)
+            if aug is not None:
+                aug.row_swap(pivot, pivot_pos)
 
             r.row_op(pivot, lambda x, _: x / pivot_val)
+            if aug is not None:
+                aug.row_op(pivot, lambda x, _: x / pivot_val)
+
             for j in range(r.rows):
                 if j == pivot:
                     continue
                 pivot_val = r[j, i]
                 r.zip_row_op(j, pivot, lambda x, y: x - pivot_val * y)
+                if aug is not None:
+                    aug.zip_row_op(j, pivot, lambda x, y: x - pivot_val * y)
             pivotlist.append(i)
             pivot += 1
         return self._new(r), pivotlist

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4694,10 +4694,19 @@ class MatrixBase(MatrixOperations, MatrixProperties, MatrixShaping):
         [0, 1]])
         >>> rref_pivots
         [0, 1]
-        >>> Matrix([[1, 1, x**2], [0, 1, x**3]]).rref(cols=2)
-        (Matrix([
-        [1, 0, -x**3 + x**2],
-        [0, 1,         x**3]]), [0, 1])
+        >>> from sympy.abc import y, z
+        >>> R, pivots = Matrix([[1, 1, 1, x], [0, 1, 0, y], [1, 2, 1, z]]).rref(cols=3)
+        >>> R[:, :3]
+        Matrix([
+        [1, 0, 1],
+        [0, 1, 0],
+        [0, 0, 0]])
+        >>> pivots == [0, 1]
+        True
+        >>> R[:2, 3]
+        Matrix([
+        [x - y],
+        [    y]])
 
         """
         simpfunc = simplify if isinstance(

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2854,37 +2854,34 @@ def test_issue_11238():
 
 
 def test_rref_aug():
-    A1 = Matrix([[1, 2, 3], [3, 4, 7], [6, 5, 9]])
-    B1a = MutableDenseMatrix([[0], [2], [11]])
-    R1a, pivots1a = A1.rref(aug=B1a)
-    assert R1a == eye(3) and pivots1a == [0, 1, 2] and B1a == Matrix([[4], [1], [-2]])
+    A1a = Matrix([[1, 2, 3, 0], [3, 4, 7, 2], [6, 5, 9, 11]])
+    R1a, pivots1a = A1a.rref(cols=3)
+    assert R1a[:, :-1] == eye(3) and pivots1a == [0, 1, 2] and R1a[:, -1] == Matrix([[4], [1], [-2]])
 
-    B1b = MutableDenseMatrix([[x], [y], [z]])
-    R1b, pivots1b = A1.rref(aug=B1b)
-    delta1b = B1b - Matrix([
+    A1b = Matrix([[1, 2, 3, x], [3, 4, 7, y], [6, 5, 9, z]])
+    R1b, pivots1b = A1b.rref(cols=3)
+    delta1b = R1b[:, -1] - Matrix([
         [(x - 3*y + 2*z)/4],
         [(15*x - 9*y + 2*z)/4],
         [(7*y - 2*z - 9*x)/4]
     ])
     delta1b.simplify()
-    assert R1b == eye(3) and pivots1b == [0, 1, 2] and delta1b == Matrix([[0], [0], [0]])
+    assert R1b[:, :-1] == eye(3) and pivots1b == [0, 1, 2] and delta1b == Matrix([[0], [0], [0]])
 
-    A2 = Matrix([[0, 1, -1], [2, 1, 1], [1, 0, 1]])
-    B2 = MutableDenseMatrix([[x], [y], [z]])
-    R2, pivots2 = A2.rref(aug=B2)
-    assert R2 == Matrix([[1, 0, 1], [0, 1, -1], [0, 0, 0]]) and pivots2 == [0, 1]
-    delta2 = (B2[:2, :] - Matrix([
+    A2 = Matrix([[0, 1, -1, x], [2, 1, 1, y], [1, 0, 1, z]])
+    R2, pivots2 = A2.rref(cols=3)
+    assert R2[:, :-1] == Matrix([[1, 0, 1], [0, 1, -1], [0, 0, 0]]) and pivots2 == [0, 1]
+    delta2 = (R2[:2, -1] - Matrix([
         [(y - x)/2],
         [x]
     ]))
     delta2.simplify()
     assert delta2 == Matrix([[0], [0]])
 
-    A3 = Matrix([[-1, 0, 1], [1, 2, 1], [1, 1, 0]])
-    B3 = MutableDenseMatrix([[x], [y], [z]])
-    R3, pivots3 = A3.rref(aug=B3)
-    assert R3 == Matrix([[1, 0, -1], [0, 1, 1], [0, 0, 0]]) and pivots3 == [0, 1]
-    delta3 = (B3[:2, :] - Matrix([
+    A3 = Matrix([[-1, 0, 1, x], [1, 2, 1, y], [1, 1, 0, z]])
+    R3, pivots3 = A3.rref(cols=3)
+    assert R3[:, :-1] == Matrix([[1, 0, -1], [0, 1, 1], [0, 0, 0]]) and pivots3 == [0, 1]
+    delta3 = (R3[:2, -1] - Matrix([
         [-x],
         [(x + y)/2]
     ]))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2851,3 +2851,42 @@ def test_issue_11238():
     assert m1.rank(simplify=True) == 1
     assert m2.rank(simplify=True) == 1
     assert m3.rank(simplify=True) == 1
+
+
+def test_rref_aug():
+    A1 = Matrix([[1, 2, 3], [3, 4, 7], [6, 5, 9]])
+    B1a = MutableDenseMatrix([[0], [2], [11]])
+    R1a, pivots1a = A1.rref(aug=B1a)
+    assert R1a == eye(3) and pivots1a == [0, 1, 2] and B1a == Matrix([[4], [1], [-2]])
+
+    B1b = MutableDenseMatrix([[x], [y], [z]])
+    R1b, pivots1b = A1.rref(aug=B1b)
+    delta1b = B1b - Matrix([
+        [(x - 3*y + 2*z)/4],
+        [(15*x - 9*y + 2*z)/4],
+        [(7*y - 2*z - 9*x)/4]
+    ])
+    delta1b.simplify()
+    assert R1b == eye(3) and pivots1b == [0, 1, 2] and delta1b == Matrix([[0], [0], [0]])
+
+    A2 = Matrix([[0, 1, -1], [2, 1, 1], [1, 0, 1]])
+    B2 = MutableDenseMatrix([[x], [y], [z]])
+    R2, pivots2 = A2.rref(aug=B2)
+    assert R2 == Matrix([[1, 0, 1], [0, 1, -1], [0, 0, 0]]) and pivots2 == [0, 1]
+    delta2 = (B2[:2, :] - Matrix([
+        [(y - x)/2],
+        [x]
+    ]))
+    delta2.simplify()
+    assert delta2 == Matrix([[0], [0]])
+
+    A3 = Matrix([[-1, 0, 1], [1, 2, 1], [1, 1, 0]])
+    B3 = MutableDenseMatrix([[x], [y], [z]])
+    R3, pivots3 = A3.rref(aug=B3)
+    assert R3 == Matrix([[1, 0, -1], [0, 1, 1], [0, 0, 0]]) and pivots3 == [0, 1]
+    delta3 = (B3[:2, :] - Matrix([
+        [-x],
+        [(x + y)/2]
+    ]))
+    delta3.simplify()
+    assert delta3 == Matrix([[0], [0]])


### PR DESCRIPTION
This is a way to allow rref to handle augmented matrices without introducing any backward incompatible changes. cf. https://en.wikipedia.org/wiki/Row_echelon_form#Systems_of_linear_equations and https://en.wikipedia.org/wiki/Augmented_matrix#Solution_of_a_linear_system

Let me know what you think.