### PR TITLE
Implemented missing docstring

### DIFF
--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -37,6 +37,10 @@ mlatex = vlatex
 
 
 def mechanics_printing(**kwargs):
+    """
+    Initializes time derivative printing for all SymPy objects in
+    mechanics module.
+    """
 
     init_vprinting(**kwargs)
 


### PR DESCRIPTION
Hi. Looks like sympy/physics/mechanics/functions.py was missing a docstring. This has been implemented. 

```./bin/test quality``` executed locally - all green.

Thank you.