### PR TITLE
Fix pull request message to always be hidden

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-<If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
+<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>


### PR DESCRIPTION
GitHub stopped automatically hiding it because the # character gave it away as
not a real HTML tag. Now mark it as an HTML comment, which should always be
hidden.

As proof, here is the message (you shouldn't be able to see it):

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
