### PR TITLE
Changes made to __round__ in sympy/core/numbers.py from float to Float

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -418,7 +418,7 @@ class Number(AtomicExpr):
         return divmod(other, self)
 
     def __round__(self, *args):
-        return round(float(self), *args)
+        return round(Float(self), *args)
 
     def _as_mpf_val(self, prec):
         """Evaluation of mpf tuple accurate to at least prec bits."""


### PR DESCRIPTION
round for Float loses precision #12056
I've made necessary changes to round in sympy/core/numbers.py function because it was causing a precision error.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
