### PR TITLE
Better support for complex numbers in nsolve

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -991,5 +991,18 @@ class Add(Expr, AssocOp):
         from sympy.series.limitseq import difference_delta as dd
         return self.func(*[dd(a, n, step) for a in self.args])
 
+    @property
+    def _mpc_(self):
+        """
+        Convert self to an mpmath mpc if possible
+        """
+        from sympy.core.numbers import I, Float
+        re_part, rest = self.as_coeff_Add()
+        im_part, imag_unit = rest.as_coeff_Mul()
+        if not imag_unit == I:
+            raise ValueError("Cannot convert to mpc. Must be of the form Number + Number*I")
+
+        return (Float(re_part)._mpf_, Float(im_part)._mpf_)
+
 from .mul import Mul, _keep_coeff, prod
 from sympy.core.numbers import Rational

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1000,7 +1000,10 @@ class Add(Expr, AssocOp):
         re_part, rest = self.as_coeff_Add()
         im_part, imag_unit = rest.as_coeff_Mul()
         if not imag_unit == I:
-            raise ValueError("Cannot convert to mpc. Must be of the form Number + Number*I")
+            # ValueError may seem more reasonable but since it's a @property,
+            # we need to use AttributeError to keep from confusing things like
+            # hasattr.
+            raise AttributeError("Cannot convert Add to mpc. Must be of the form Number + Number*I")
 
         return (Float(re_part)._mpf_, Float(im_part)._mpf_)
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -653,6 +653,18 @@ class Mul(Expr, AssocOp):
             return rv.expand()
         return rv
 
+    @property
+    def _mpc_(self):
+        """
+        Convert self to an mpmath mpc if possible
+        """
+        from sympy.core.numbers import I, Float
+        im_part, imag_unit = self.as_coeff_Mul()
+        if not imag_unit == I:
+            raise ValueError("Cannot convert to mpc. Must be of the form Number*I")
+
+        return (Float(0)._mpf_, Float(im_part)._mpf_)
+
     @cacheit
     def as_two_terms(self):
         """Return head and tail of self.

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -661,7 +661,10 @@ class Mul(Expr, AssocOp):
         from sympy.core.numbers import I, Float
         im_part, imag_unit = self.as_coeff_Mul()
         if not imag_unit == I:
-            raise ValueError("Cannot convert to mpc. Must be of the form Number*I")
+            # ValueError may seem more reasonable but since it's a @property,
+            # we need to use AttributeError to keep from confusing things like
+            # hasattr.
+            raise AttributeError("Cannot convert Mul to mpc. Must be of the form Number*I")
 
         return (Float(0)._mpf_, Float(im_part)._mpf_)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3579,6 +3579,10 @@ class ImaginaryUnit(with_metaclass(Singleton, AtomicExpr)):
         import sage.all as sage
         return sage.I
 
+    @property
+    def _mpc_(self):
+        return (Float(0)._mpf_, Float(1)._mpf_)
+
 I = S.ImaginaryUnit
 
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1287,12 +1287,25 @@ def test_issue_4611():
     assert (EulerGamma + x).evalf() == EulerGamma.evalf() + x
     assert (GoldenRatio + x).evalf() == GoldenRatio.evalf() + x
 
-
+@conserve_mpmath_dps
 def test_conversion_to_mpmath():
     assert mpmath.mpmathify(Integer(1)) == mpmath.mpf(1)
     assert mpmath.mpmathify(Rational(1, 2)) == mpmath.mpf(0.5)
     assert mpmath.mpmathify(Float('1.23', 15)) == mpmath.mpf('1.23')
 
+    assert mpmath.mpmathify(1 + 2*I) == mpmath.mpc(1 + 2j)
+    assert mpmath.mpmathify(1.0 + 2*I) == mpmath.mpc(1 + 2j)
+    assert mpmath.mpmathify(1 + 2.0*I) == mpmath.mpc(1 + 2j)
+    assert mpmath.mpmathify(1.0 + 2.0*I) == mpmath.mpc(1 + 2j)
+    assert mpmath.mpmathify(Rational(1, 2) + Rational(1, 2)*I) == mpmath.mpc(0.5 + 0.5j)
+
+    assert mpmath.mpmathify(2*I) == mpmath.mpc(2j)
+    assert mpmath.mpmathify(2.0*I) == mpmath.mpc(2j)
+    assert mpmath.mpmathify(Rational(1, 2)*I) == mpmath.mpc(0.5j)
+
+    mpmath.mp.dps = 100
+    assert mpmath.mpmathify(pi.evalf(100) + pi.evalf(100)*I) == mpmath.pi + mpmath.pi*mpmath.j
+    assert mpmath.mpmathify(pi.evalf(100)*I) == mpmath.pi*mpmath.j
 
 def test_relational():
     # real

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1293,6 +1293,8 @@ def test_conversion_to_mpmath():
     assert mpmath.mpmathify(Rational(1, 2)) == mpmath.mpf(0.5)
     assert mpmath.mpmathify(Float('1.23', 15)) == mpmath.mpf('1.23')
 
+    assert mpmath.mpmathify(I) == mpmath.mpc(1j)
+
     assert mpmath.mpmathify(1 + 2*I) == mpmath.mpc(1 + 2j)
     assert mpmath.mpmathify(1.0 + 2*I) == mpmath.mpc(1 + 2j)
     assert mpmath.mpmathify(1 + 2.0*I) == mpmath.mpc(1 + 2j)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2765,7 +2765,7 @@ def nsolve(*args, **kwargs):
         f = f.as_numer_denom()[0]
 
         f = lambdify(fargs, f, modules)
-        return Float(findroot(f, x0, **kwargs))
+        return sympify(findroot(f, x0, **kwargs))
 
     if len(fargs) > f.cols:
         raise NotImplementedError(filldedent('''

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -1,5 +1,5 @@
 from sympy import (Eq, Matrix, pi, sin, sqrt, Symbol, Integral, Piecewise,
-    symbols, Float)
+    symbols, Float, I)
 from mpmath import mnorm, mpf
 from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
@@ -84,3 +84,10 @@ def test_nsolve_precision():
     assert abs(sqrt(pi).evalf(128) - sols[0]) < 1e-128
     assert abs(sqrt(sqrt(pi)).evalf(128) - sols[1]) < 1e-128
     assert all(isinstance(i, Float) for i in sols)
+
+def test_nsolve_complex():
+    x, y = symbols('x y')
+
+    assert nsolve(x**2 + 2, 1j) == sqrt(2.)*I
+
+    assert nsolve([x**2 + 2, y**2 + 2], [x, y], [1j, 1j]) == Matrix([sqrt(2.)*I, sqrt(2.)*I])

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -89,5 +89,7 @@ def test_nsolve_complex():
     x, y = symbols('x y')
 
     assert nsolve(x**2 + 2, 1j) == sqrt(2.)*I
+    assert nsolve(x**2 + 2, I) == sqrt(2.)*I
 
-    assert nsolve([x**2 + 2, y**2 + 2], [x, y], [1j, 1j]) == Matrix([sqrt(2.)*I, sqrt(2.)*I])
+    assert nsolve([x**2 + 2, y**2 + 2], [x, y], [I, I]) == Matrix([sqrt(2.)*I, sqrt(2.)*I])
+    assert nsolve([x**2 + 2, y**2 + 2], [x, y], [I, I]) == Matrix([sqrt(2.)*I, sqrt(2.)*I])


### PR DESCRIPTION
- Fixes a regression that prevented nsolve from returning a complex number.

- Allow converting SymPy expressions of the form `Number + Number*I` to `mpmath.mpc`.

- Allow SymPy complex numbers as initial point arguments to nsolve (like `nsolve(x**2 + 2, I)`).

Fixes https://github.com/sympy/sympy/issues/12062. 
