### PR TITLE
Came across a bare "except": converted it to "except Exception:"

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -65,7 +65,7 @@ def continuous_domain(f, symbol, domain):
         else:
             sings = Intersection(solveset(1/f, symbol), domain)
 
-    except:
+    except Exception:
         raise NotImplementedError("Methods for determining the continuous domains"
                                   " of this function has not been developed.")
 


### PR DESCRIPTION
https://github.com/sympy/sympy/issues/11668 As stated in issue, I came across a "bare except:", changed it to "except Exception:"

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
