### PR TITLE
Update solvers.py

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2781,6 +2781,16 @@ def nsolve(*args, **kwargs):
 
         f = lambdify(fargs, f, modules)
         return Float(findroot(f, x0, **kwargs))
+    
+    if type(fargs)==Symbol:
+        fargs = fargs.free_symbols
+    if fargs == None:
+        fargs = set()
+    if len(fargs)<f.cols:
+        fargs = set(fargs)
+        for temp in range(len(f)):
+            fargs = fargs.union(f[temp].free_symbols)
+    fargs = tuple(fargs)
 
     if len(fargs) > f.cols:
         raise NotImplementedError(filldedent('''

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2781,16 +2781,6 @@ def nsolve(*args, **kwargs):
 
         f = lambdify(fargs, f, modules)
         return Float(findroot(f, x0, **kwargs))
-    
-    if type(fargs)==Symbol:
-        fargs = fargs.free_symbols
-    if fargs == None:
-        fargs = set()
-    if len(fargs)<f.cols:
-        fargs = set(fargs)
-        for temp in range(len(f)):
-            fargs = fargs.union(f[temp].free_symbols)
-    fargs = tuple(fargs)
 
     if len(fargs) > f.cols:
         raise NotImplementedError(filldedent('''

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2781,7 +2781,18 @@ def nsolve(*args, **kwargs):
 
         f = lambdify(fargs, f, modules)
         return Float(findroot(f, x0, **kwargs))
-
+    fargstemp = fargs
+    if type(fargstemp) == Symbol:
+        fargstemp = fargstemp.free_symbols
+    if fargstemp == None:
+        fargstemp = set()
+    if len(fargstemp) < f.cols:
+        fargstemp2 = set(fargstemp)
+        for temp in range(len(f)):
+            fargstemp3 = fargstemp2.union(f[temp].free_symbols)
+            fargstemp2 = fargstemp3
+        fargstemp = fargstemp2
+    fargs = tuple(fargstemp)
     if len(fargs) > f.cols:
         raise NotImplementedError(filldedent('''
             need at least as many equations as variables'''))


### PR DESCRIPTION
This PR allows nsolve to solve equations without specifically telling it what are the variables . It also automatically accounts for if there are lesser number of variables stated than present in the equations to be solved .
eg : f1 = x - y + 2
f2 = x + y
f3 = y - z
print(nsolve( (f1, f2, f3), (0,0,0))) works as welll as 
print(nsolve( (f1, f2, f3),(x/y/z/x,y/y,z/z,x) (0,0,0)))
also works 