### PR TITLE
Implemented recursive calling of evalf() function

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -507,7 +507,7 @@ class Function(Application, Expr):
             func = getattr(mpmath, fname)
         except (AttributeError, KeyError):
             try:
-                return Float(self._imp_(*self.args), prec)
+                return Float(self._imp_(*[i.evalf(prec) for i in self.args]), prec)
             except (AttributeError, TypeError, ValueError):
                 return
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -751,6 +751,9 @@ def test_issue_2790():
     assert lambdify((x, (y, (w, z))), w + x + y + z)(1, (2, (3, 4))) == 10
     assert lambdify(x, x + 1, dummify=False)(1) == 2
 
+def test_issue_12092():
+    f = implemented_function('f', lambda x: x**2)
+    assert f(f(2)).evalf() == Float(16)
 
 def test_ITE():
     assert lambdify((x, y, z), ITE(x, y, z))(True, 5, 3) == 5


### PR DESCRIPTION
Fixes #12092. 

Enabled recursive calling of the `evalf()` function. 

#### Output before this PR:
```python 
>>> from sympy.utilities.lambdify import implemented_function
>>> f = implemented_function('f', lambda x: x ** 2)
>>> g = implemented_function('g', lambda x: 2 * x)
>>> print(f(g(2)).evalf())
f(g(2))
```

### Output after this PR:

```python
>>> from sympy.utilities.lambdify import implemented_function
>>> f = implemented_function('f', lambda x: x ** 2)
>>> g = implemented_function('g', lambda x: 2 * x)
>>> print(f(g(2)).evalf())
16.0000000000000
```
* Tests are added.