### PR TITLE
Guard __slots__ declarations in Jython case.

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -8,6 +8,7 @@ from .decorators import _sympifyit, call_highest_priority
 from .cache import cacheit
 from .compatibility import reduce, as_int, default_sort_key, range
 from mpmath.libmp import mpf_log, prec_to_dps
+import os
 
 from collections import defaultdict
 
@@ -26,8 +27,8 @@ class Expr(Basic, EvalfMixin):
 
     sympy.core.basic.Basic
     """
-
-    __slots__ = []
+    if os.name != 'java':
+        __slots__ = []
 
     @property
     def _diff_wrt(self):
@@ -3222,7 +3223,8 @@ class AtomicExpr(Atom, Expr):
     is_number = False
     is_Atom = True
 
-    __slots__ = []
+    if os.name != 'java':
+        __slots__ = []
 
     def _eval_derivative(self, s):
         if self == s:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -14,12 +14,14 @@ from sympy.core.function import Application, Derivative
 from sympy.core.compatibility import ordered, range, with_metaclass, as_int
 from sympy.core.sympify import converter, _sympify, sympify
 from sympy.core.singleton import Singleton, S
+import os
 
 
 class Boolean(Basic):
     """A boolean object is an object for which logic operations make sense."""
 
-    __slots__ = []
+    if os.name != 'java':
+        __slots__ = []
 
     def __and__(self, other):
         """Overloading for & operator"""


### PR DESCRIPTION
Advances work on Jython support. See http://bugs.jython.org/issue1777.

This not directly yields Jython-support as of this writing. Import will fail with
```
  File "/data/workspace/linux/sympy/sympy/sympy/printing/pretty/__init__.py", line 3, in <module>
    from .pretty import (pretty, pretty_print, pprint, pprint_use_unicode,
UnicodeDecodeError: 'unicodeescape' codec can't decode bytes in position 2-33: illegal Unicode character
```

because Jython currently does not support `u'\N{whatever}'` notation. However that needs to be fixed in Jython, then sympy will probably work. See http://bugs.jython.org/issue2548.
(I was able to make sympy 1.0 work on Jython with the changes in this PR; sympy 1.0 did not yet use \N escape sequences.)