### PR TITLE
Add a note to the PULL_REQUEST_TEMPLATE about PR titles

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 <!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
 
-<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
+<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,3 @@
+<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
+
 <!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>


### PR DESCRIPTION
Hopefully this will stem the tide of "Fixes #NNNN" PR titles.

Note, I've intentionally not hard line-wrapped the text, as GitHub already soft wraps it. 