### PR TITLE
lambdify: Better error message for NameError

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -131,7 +131,7 @@ def _import(module, reload="False"):
             module]
     except KeyError:
         raise NameError(
-            "'%s' module can't be used for lambdification" % module)
+            "The Sympy object does not have a equivalent numerical implementation in the supplied modules: '%s'. You can either supply your own function or add a module that has an implementation." % module)
 
     # Clear namespace or exit
     if namespace != namespace_default:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -130,8 +130,10 @@ def _import(module, reload="False"):
         namespace, namespace_default, translations, import_commands = MODULES[
             module]
     except KeyError:
-        raise NameError(
-            "The Sympy object does not have a equivalent numerical implementation in the supplied modules: '%s'. You can either supply your own function or add a module that has an implementation." % module)
+        raise NameError("The SymPy object does not have an equivalent "
+                "numerical implementation in the supplied modules: '%s'. "
+                "You can either supply your own function or add a module "
+                "that has an implementation." % module)
 
     # Clear namespace or exit
     if namespace != namespace_default:


### PR DESCRIPTION
Sympy objects that do not have numerical implementations in the modules
supplied would say that the object wasn't defined.
The error message fix makes changes that make it clear
that a numerical function that maps to the symbolic one must exist.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
Fixes #9339