### PR TITLE
[WIP] elliptic_integrals: add "as_integral" property

### DIFF
--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -80,6 +80,18 @@ class elliptic_k(Function):
     def _eval_rewrite_as_meijerg(self, z):
         return meijerg(((S.Half, S.Half), []), ((S.Zero,), (S.Zero,)), -z)/2
 
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, m):
+        from sympy import Integral, Dummy
+        t = Dummy('t')
+        return Integral(1/sqrt(1 - m*sin(t)**2), (t, 0, pi/2))
+
     def _sage_(self):
         import sage.all as sage
         return sage.elliptic_kc(self.args[0]._sage_())
@@ -146,6 +158,18 @@ class elliptic_f(Function):
         z, m = self.args
         if (m.is_real and (m - 1).is_positive) is False:
             return self.func(z.conjugate(), m.conjugate())
+
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, z, m):
+        from sympy import Integral, Dummy
+        t = Dummy('t')
+        return Integral(1/(sqrt(1 - m*sin(t)**2)), (t, 0, z))
 
 
 class elliptic_e(Function):
@@ -252,6 +276,19 @@ class elliptic_e(Function):
             z = args[0]
             return -meijerg(((S.Half, S(3)/2), []), \
                             ((S.Zero,), (S.Zero,)), -z)/4
+
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, *args):
+        from sympy import Integral, Dummy
+        z, m = (pi/2, args[0]) if len(args) == 1 else args
+        t = Dummy('t')
+        return Integral(sqrt(1 - m*sin(t)**2), (t, 0, z))
 
 
 class elliptic_pi(Function):
@@ -362,3 +399,19 @@ class elliptic_pi(Function):
             elif argindex == 2:
                 return (elliptic_e(m)/(m - 1) + elliptic_pi(n, m))/(2*(n - m))
         raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_Integral(self, *args):
+        return self.as_integral
+
+    @property
+    def as_integral(self):
+        return self._as_integral(*self.args)
+
+    def _as_integral(self, n, m, z=None):
+        from sympy import Integral, Dummy
+        if z is None:
+            z = pi/2
+        else:
+            n, z, m = n, m, z
+        t = Dummy('t')
+        return Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z))

--- a/sympy/functions/special/tests/test_elliptic_integrals.py
+++ b/sympy/functions/special/tests/test_elliptic_integrals.py
@@ -1,5 +1,5 @@
 from sympy import (S, Symbol, pi, I, oo, zoo, sin, sqrt, tan, gamma,
-    atanh, hyper, meijerg, O)
+    atanh, hyper, meijerg, O, Dummy, Integral)
 from sympy.functions.special.elliptic_integrals import (elliptic_k as K,
     elliptic_f as F, elliptic_e as E, elliptic_pi as P)
 from sympy.utilities.randtest import (test_derivative_numerically as td,
@@ -9,6 +9,7 @@ from sympy.abc import z, m, n
 
 i = Symbol('i', integer=True)
 j = Symbol('k', integer=True, positive=True)
+t = Dummy('t')
 
 def test_K():
     assert K(0) == pi/2
@@ -40,6 +41,11 @@ def test_K():
         25*pi*z**3/512 + 1225*pi*z**4/32768 + 3969*pi*z**5/131072 + O(z**6)
 
 
+def test_K_as_integral():
+    assert str(K(m).as_integral) == \
+        str(Integral(1/sqrt(1 - m*sin(t)**2), (t, 0, pi/2)))
+
+
 def test_F():
     assert F(z, 0) == z
     assert F(0, m) == 0
@@ -63,6 +69,11 @@ def test_F():
 
     assert F(z, m).series(z) == \
         z + z**5*(3*m**2/40 - m/30) + m*z**3/6 + O(z**6)
+
+
+def test_F_as_integral():
+    assert str(F(z, m).as_integral) == \
+        str(Integral(1/sqrt(1 - m*sin(t)**2), (t, 0, z)))
 
 
 def test_E():
@@ -104,6 +115,13 @@ def test_E():
         z + z**5*(-m**2/40 + m/30) - m*z**3/6 + O(z**6)
     assert E(z).series(z) == pi/2 - pi*z/8 - 3*pi*z**2/128 - \
         5*pi*z**3/512 - 175*pi*z**4/32768 - 441*pi*z**5/131072 + O(z**6)
+
+
+def test_E_as_integral():
+    assert str(E(z, m).as_integral) == \
+        str(Integral(sqrt(1 - m*sin(t)**2), (t, 0, z)))
+    assert str(E(m).as_integral) == \
+        str(Integral(sqrt(1 - m*sin(t)**2), (t, 0, pi/2)))
 
 
 def test_P():
@@ -150,3 +168,10 @@ def test_P():
 
     assert P(n, z, m).series(z) == z + z**3*(m/6 + n/3) + \
         z**5*(3*m**2/40 + m*n/10 - m/30 + n**2/5 - n/15) + O(z**6)
+
+
+def test_P_as_integral():
+    assert str(P(n, z, m).as_integral) == \
+        str(Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, z)))
+    assert str(P(n, m).as_integral) == \
+        str(Integral(1/((1 - n*sin(t)**2)*sqrt(1 - m*sin(t)**2)), (t, 0, pi/2)))


### PR DESCRIPTION
Elliptic integrals are special functions defined in terms of integrals.
Allow each of them to be rewritten as integrals.  Add tests.