### PR TITLE
elliptic_integrals: rewrite to use standard notation for z, m

### DIFF
--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -15,25 +15,25 @@ class elliptic_k(Function):
     r"""
     The complete elliptic integral of the first kind, defined by
 
-    .. math:: K(z) = F\left(\tfrac{\pi}{2}\middle| z\right)
+    .. math:: K(m) = F\left(\tfrac{\pi}{2}\middle| m\right)
 
     where `F\left(z\middle| m\right)` is the Legendre incomplete
     elliptic integral of the first kind.
 
-    The function `K(z)` is a single-valued function on the complex
+    The function `K(m)` is a single-valued function on the complex
     plane with branch cut along the interval `(1, \infty)`.
 
     Examples
     ========
 
     >>> from sympy import elliptic_k, I, pi
-    >>> from sympy.abc import z
+    >>> from sympy.abc import m
     >>> elliptic_k(0)
     pi/2
     >>> elliptic_k(1.0 + I)
     1.50923695405127 + 0.625146415202697*I
-    >>> elliptic_k(z).series(z, n=3)
-    pi/2 + pi*z/8 + 9*pi*z**2/128 + O(z**3)
+    >>> elliptic_k(m).series(n=3)
+    pi/2 + pi*m/8 + 9*pi*m**2/128 + O(m**3)
 
     References
     ==========
@@ -48,37 +48,37 @@ class elliptic_k(Function):
     """
 
     @classmethod
-    def eval(cls, z):
-        if z is S.Zero:
+    def eval(cls, m):
+        if m is S.Zero:
             return pi/2
-        elif z is S.Half:
+        elif m is S.Half:
             return 8*pi**(S(3)/2)/gamma(-S(1)/4)**2
-        elif z is S.One:
+        elif m is S.One:
             return S.ComplexInfinity
-        elif z is S.NegativeOne:
+        elif m is S.NegativeOne:
             return gamma(S(1)/4)**2/(4*sqrt(2*pi))
-        elif z in (S.Infinity, S.NegativeInfinity, I*S.Infinity,
+        elif m in (S.Infinity, S.NegativeInfinity, I*S.Infinity,
                    I*S.NegativeInfinity, S.ComplexInfinity):
             return S.Zero
 
     def fdiff(self, argindex=1):
-        z = self.args[0]
-        return (elliptic_e(z) - (1 - z)*elliptic_k(z))/(2*z*(1 - z))
+        m = self.args[0]
+        return (elliptic_e(m) - (1 - m)*elliptic_k(m))/(2*m*(1 - m))
 
     def _eval_conjugate(self):
-        z = self.args[0]
-        if (z.is_real and (z - 1).is_positive) is False:
-            return self.func(z.conjugate())
+        m = self.args[0]
+        if (m.is_real and (m - 1).is_positive) is False:
+            return self.func(m.conjugate())
 
     def _eval_nseries(self, x, n, logx):
         from sympy.simplify import hyperexpand
         return hyperexpand(self.rewrite(hyper)._eval_nseries(x, n=n, logx=logx))
 
-    def _eval_rewrite_as_hyper(self, z):
-        return (pi/2)*hyper((S.Half, S.Half), (S.One,), z)
+    def _eval_rewrite_as_hyper(self, m):
+        return (pi/2)*hyper((S.Half, S.Half), (S.One,), m)
 
-    def _eval_rewrite_as_meijerg(self, z):
-        return meijerg(((S.Half, S.Half), []), ((S.Zero,), (S.Zero,)), -z)/2
+    def _eval_rewrite_as_meijerg(self, m):
+        return meijerg(((S.Half, S.Half), []), ((S.Zero,), (S.Zero,)), -m)/2
 
     def _sage_(self):
         import sage.all as sage
@@ -155,12 +155,12 @@ class elliptic_e(Function):
 
     .. math:: E\left(z\middle| m\right) = \int_0^z \sqrt{1 - m \sin^2 t} dt
 
-    Called with a single argument `z`, evaluates the Legendre complete
+    Called with a single argument `m`, evaluates the Legendre complete
     elliptic integral of the second kind
 
-    .. math:: E(z) = E\left(\tfrac{\pi}{2}\middle| z\right)
+    .. math:: E(m) = E\left(\tfrac{\pi}{2}\middle| m\right)
 
-    The function `E(z)` is a single-valued function on the complex
+    The function `E(m)` is a single-valued function on the complex
     plane with branch cut along the interval `(1, \infty)`.
 
     Examples
@@ -170,8 +170,8 @@ class elliptic_e(Function):
     >>> from sympy.abc import z, m
     >>> elliptic_e(z, m).series(z)
     z + z**5*(-m**2/40 + m/30) - m*z**3/6 + O(z**6)
-    >>> elliptic_e(z).series(z, n=4)
-    pi/2 - pi*z/8 - 3*pi*z**2/128 - 5*pi*z**3/512 + O(z**4)
+    >>> elliptic_e(m).series(n=4)
+    pi/2 - pi*m/8 - 3*pi*m**2/128 - 5*pi*m**3/512 + O(m**4)
     >>> elliptic_e(1 + I, 2 - I/2).n()
     1.55203744279187 + 0.290764986058437*I
     >>> elliptic_e(0)
@@ -188,8 +188,9 @@ class elliptic_e(Function):
     """
 
     @classmethod
-    def eval(cls, z, m=None):
-        if m is not None:
+    def eval(cls, m, z=None):
+        if z is not None:
+            z, m = m, z
             k = 2*z/pi
             if m.is_zero:
                 return z
@@ -202,15 +203,15 @@ class elliptic_e(Function):
             elif z.could_extract_minus_sign():
                 return -elliptic_e(-z, m)
         else:
-            if z.is_zero:
+            if m.is_zero:
                 return pi/2
-            elif z is S.One:
+            elif m is S.One:
                 return S.One
-            elif z is S.Infinity:
+            elif m is S.Infinity:
                 return I*S.Infinity
-            elif z is S.NegativeInfinity:
+            elif m is S.NegativeInfinity:
                 return S.Infinity
-            elif z is S.ComplexInfinity:
+            elif m is S.ComplexInfinity:
                 return S.ComplexInfinity
 
     def fdiff(self, argindex=1):
@@ -221,9 +222,9 @@ class elliptic_e(Function):
             elif argindex == 2:
                 return (elliptic_e(z, m) - elliptic_f(z, m))/(2*m)
         else:
-            z = self.args[0]
+            m = self.args[0]
             if argindex == 1:
-                return (elliptic_e(z) - elliptic_k(z))/(2*z)
+                return (elliptic_e(m) - elliptic_k(m))/(2*m)
         raise ArgumentIndexError(self, argindex)
 
     def _eval_conjugate(self):
@@ -232,9 +233,9 @@ class elliptic_e(Function):
             if (m.is_real and (m - 1).is_positive) is False:
                 return self.func(z.conjugate(), m.conjugate())
         else:
-            z = self.args[0]
-            if (z.is_real and (z - 1).is_positive) is False:
-                return self.func(z.conjugate())
+            m = self.args[0]
+            if (m.is_real and (m - 1).is_positive) is False:
+                return self.func(m.conjugate())
 
     def _eval_nseries(self, x, n, logx):
         from sympy.simplify import hyperexpand
@@ -244,14 +245,14 @@ class elliptic_e(Function):
 
     def _eval_rewrite_as_hyper(self, *args):
         if len(args) == 1:
-            z = args[0]
-            return (pi/2)*hyper((-S.Half, S.Half), (S.One,), z)
+            m = args[0]
+            return (pi/2)*hyper((-S.Half, S.Half), (S.One,), m)
 
     def _eval_rewrite_as_meijerg(self, *args):
         if len(args) == 1:
-            z = args[0]
+            m = args[0]
             return -meijerg(((S.Half, S(3)/2), []), \
-                            ((S.Zero,), (S.Zero,)), -z)/4
+                            ((S.Zero,), (S.Zero,)), -m)/4
 
 
 class elliptic_pi(Function):


### PR DESCRIPTION
The incomplete elliptic integrals depend on "the amplitude" z and "the
parameter" m.  The complete elliptic integrals depend only on the
parameter, taking the value pi/2 for the amplitude.  In some cases,
"z" was used for the parameter both in the code and in the docs.
The latter can be confusing b/c it breaks from standard notation (and
especially b/c Elliptic integrals have various different common conventions
in use).

This commit changes the docs as well as the code.  It makes no functional
changes.
