### PR TITLE
integrals : Add singularity test for Zero denominator

### DIFF
--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1441,12 +1441,12 @@ def test_sort_key_atomic_expr():
 def test_issue_4199():
     # first subs and limit gives NaN
     a = x/y
-    assert a._eval_interval(x, 0, oo)._eval_interval(y, oo, 0) is S.NaN
+    assert a._eval_interval(x, S(0), oo)._eval_interval(y, oo, S(0)) is S.NaN
     # second subs and limit gives NaN
-    assert a._eval_interval(x, 0, oo)._eval_interval(y, 0, oo) is S.NaN
+    assert a._eval_interval(x, S(0), oo)._eval_interval(y, S(0), oo) is S.NaN
     # difference gives S.NaN
     a = x - y
-    assert a._eval_interval(x, 1, oo)._eval_interval(y, oo, 1) is S.NaN
+    assert a._eval_interval(x, S(1), oo)._eval_interval(y, oo, S(1)) is S.NaN
     raises(ValueError, lambda: x._eval_interval(x, None, None))
     a = -y*Heaviside(x - y)
     assert a._eval_interval(x, -oo, oo) == -y
@@ -1455,7 +1455,7 @@ def test_issue_4199():
 
 def test_eval_interval_zoo():
     # Test that limit is used when zoo is returned
-    assert Si(1/x)._eval_interval(x, 0, 1) == -pi/2 + Si(1)
+    assert Si(1/x)._eval_interval(x, S(0), S(1)) == -pi/2 + Si(1)
 
 
 def test_primitive():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1170,3 +1170,11 @@ def test_issue_4950():
 
 def test_issue_4968():
     assert integrate(sin(log(x**2))) == x*sin(2*log(x))/5 - 2*x*cos(2*log(x))/5
+
+def test_singularities():
+    assert integrate(1/x**2, (x, -oo, oo)) == oo
+    assert integrate(1/x**2, (x, -1, 1)) == oo
+    assert integrate(1/(x - 1)**2, (x, -2, 2)) == oo
+
+    assert integrate(1/x**2, (x, 1, -1)) == -oo
+    assert integrate(1/(x - 1)**2, (x, 2, -2)) == -oo

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -646,7 +646,7 @@ def test_issue_6860():
 def test_issue_7337():
     f = meijerint_indefinite(x*sqrt(2*x + 3), x).together()
     assert f == sqrt(2*x + 3)*(2*x**2 + x - 3)/5
-    assert f._eval_interval(x, -1, 1) == S(2)/5
+    assert f._eval_interval(x, S(-1), S(1)) == S(2)/5
 
 
 def test_issue_8368():


### PR DESCRIPTION
`_eval_interval` ignored singularities within the interval during evaluation.This PR adds capability to check singularities which arise from zero denominator.

Ref : #12133 
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
Fixes #12133 