### PR TITLE
Added a shortened URL for a reference in Crypto

### DIFF
--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -551,7 +551,9 @@ def encipher_vigenere(msg, key, symbols=None):
     ==========
 
     .. [1] http://en.wikipedia.org/wiki/Vigenere_cipher
-    .. [2] https://goo.gl/ijr22d
+    .. [2] http://web.archive.org/web/20071116100808/
+       http://filebox.vt.edu/users/batman/kryptos.html
+       (short URL: https://goo.gl/ijr22d)
 
     """
     msg, key, A = _prep(msg, key, symbols)

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -551,8 +551,7 @@ def encipher_vigenere(msg, key, symbols=None):
     ==========
 
     .. [1] http://en.wikipedia.org/wiki/Vigenere_cipher
-    .. [2] http://web.archive.org/web/20071116100808/
-       http://filebox.vt.edu/users/batman/kryptos.html
+    .. [2] https://goo.gl/ijr22d
 
     """
     msg, key, A = _prep(msg, key, symbols)


### PR DESCRIPTION
The given URL if directly copied and pasted will generate `not a valid URL on web archive`.
The reason is the addition of the blank spaces in front of the second line which is read as a character. 
So, added a shortened URL for convenience,