### PR TITLE
[WIP] Function: add a chain rule test for creating the same Dummy

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -709,7 +709,6 @@ class Function(Application, Expr):
                 return Derivative(self, self.args[argindex - 1], evaluate=False)
         # See issue 4624 and issue 4719 and issue 5600
         arg_dummy = Dummy('xi_%i' % argindex)
-        arg_dummy.dummy_index = hash(self.args[argindex - 1])
         new_args = [arg for arg in self.args]
         new_args[argindex-1] = arg_dummy
         return Subs(Derivative(self.func(*new_args), arg_dummy),
@@ -1180,7 +1179,6 @@ class Derivative(Expr):
             else:
                 if not is_symbol:
                     new_v = Dummy('xi_%i' % i)
-                    new_v.dummy_index = hash(v)
                     expr = expr.xreplace({v: new_v})
                     old_v = v
                     v = new_v

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -10,6 +10,7 @@ from sympy.solvers.solveset import solveset
 from sympy.utilities.iterables import subsets, variations
 from sympy.core.cache import clear_cache
 from sympy.core.compatibility import range
+from sympy.core.basic import preorder_traversal
 
 f, g, h = symbols('f g h', cls=Function)
 
@@ -77,6 +78,13 @@ def test_derivative_evaluate():
 
     assert Derivative(Derivative(f(x), x), x) == diff(f(x), x, x)
     assert Derivative(sin(x), x, 0) == sin(x)
+
+
+def test_derivative_reuse_dummy():
+    # this chain rule should introduce two and only two Dummy variables
+    A = f(g(x), h(g(x))).diff(x)
+    dummies = {d for d in preorder_traversal(A) if d.is_Dummy}
+    assert len(dummies) == 2
 
 
 def test_diff_symbols():


### PR DESCRIPTION
If the same function appears in different places, Derivative may make
the same Dummy substitution several times.  The code (ab)uses the `dummy_index`
to ensure these Dummies are the same.  But AFAICT, this is not tested for.
So add a test.