### PR TITLE
Issue #12146

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -350,6 +350,7 @@ def check_assumptions(expr, against=None, **assumptions):
         if test is expected:
             continue
         elif test is not None:
+            print("Assumption for (",expr,") is wrong as",key,"returned ",end="")
             return False
         result = None  # Can't conclude, unless an other test fails.
     return result


### PR DESCRIPTION
```
>>> from sympy import Symbol, pi, I, exp, check_assumptions
>>> check_assumptions(pi, real=True, negative=True)
Assumption for ( pi ) is wrong as negative returned False
>>> x = Symbol('x', real=True, positive=True)
>>> check_assumptions(-2*x - 5, real=True, positive=True)
Assumption for ( -2*x - 5 ) is wrong as positive returned False
>>> check_assumptions(-2*x - 5, real=False, positive=True)
Assumption for ( -2*x - 5 ) is wrong as real returned False
```
Here `False` is due to bool return value.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
