### PR TITLE
physics.hydrogen: Added normalized hydrogen wave functions psi_{nlm}

### DIFF
--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -85,7 +85,7 @@ def R_nl(n, l, r, Z=1):
 
 def psi_nlm(n, l, m, r, phi, theta, Z=1):
     """
-    Returns the Hydrogen wave function psi_{nlm}. It's the product of 
+    Returns the Hydrogen wave function psi_{nlm}. It's the product of
     the radial wavefunction R_{nl} and the spherical harmonic Y_{l}^{m}.
     
     n, l, m
@@ -98,8 +98,8 @@ def psi_nlm(n, l, m, r, phi, theta, Z=1):
         polar angle
     Z
         atomic number (1 for Hydrogen, 2 for Helium, ...)
-        
-    Everything is in Hartree atomic units. 
+    
+    Everything is in Hartree atomic units.
     
     Examples
     ========
@@ -111,9 +111,9 @@ def psi_nlm(n, l, m, r, phi, theta, Z=1):
     >>> theta=Symbol("theta", real=True)
     >>> Z=Symbol("Z", positive=True, integer=True, nonzero=True)
     >>> psi_nlm(1,0,0,r,phi,theta,Z)
-    sqrt(Z**3)*exp(-Z*r)/sqrt(pi)
+    Z**(3/2)*exp(-Z*r)/sqrt(pi)
     >>> psi_nlm(2,1,1,r,phi,theta,Z)
-    -Z*r*sqrt(Z**3)*exp(I*phi)*exp(-Z*r/2)*sin(theta)/(8*sqrt(pi))
+    -Z**(5/2)*r*exp(I*phi)*exp(-Z*r/2)*sin(theta)/(8*sqrt(pi))
     
     Integrating the absolute square of a hydrogen wavefunction psi_{nlm}
     over the whole space leads 1.

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy import factorial, sqrt, exp, S, assoc_laguerre, Float
+from sympy import factorial, sqrt, exp, S, assoc_laguerre, Float, Ynm
 
 
 def R_nl(n, l, r, Z=1):
@@ -81,6 +81,64 @@ def R_nl(n, l, r, Z=1):
     # some books. Both coefficients seem to be the same fast:
     # C =  S(2)/n**2 * sqrt(1/a**3 * factorial(n_r) / (factorial(n+l)))
     return C * r0**l * assoc_laguerre(n_r, 2*l + 1, r0).expand() * exp(-r0/2)
+
+
+def psi_nlm(n, l, m, r, phi, theta, Z=1):
+    """
+    Returns the Hydrogen wave function psi_{nlm}. It's the product of 
+    the radial wavefunction R_{nl} and the spherical harmonic Y_{l}^{m}.
+    
+    n, l, m
+        quantum numbers 'n', 'l' and 'm'
+    r
+        radial coordinate
+    phi
+        azimuthal angle
+    theta
+        polar angle
+    Z
+        atomic number (1 for Hydrogen, 2 for Helium, ...)
+        
+    Everything is in Hartree atomic units. 
+    
+    Examples
+    ========
+
+    >>> from sympy.physics.hydrogen import psi_nlm
+    >>> from sympy import Symbol
+    >>> r=Symbol("r", real=True, positive=True)
+    >>> phi=Symbol("phi", real=True)
+    >>> theta=Symbol("theta", real=True)
+    >>> Z=Symbol("Z", positive=True, integer=True, nonzero=True)
+    >>> psi_nlm(1,0,0,r,phi,theta,Z)
+    sqrt(Z**3)*exp(-Z*r)/sqrt(pi)
+    >>> psi_nlm(2,1,1,r,phi,theta,Z)
+    -Z*r*sqrt(Z**3)*exp(I*phi)*exp(-Z*r/2)*sin(theta)/(8*sqrt(pi))
+    
+    Integrating the absolute square of a hydrogen wavefunction psi_{nlm}
+    over the whole space leads 1.
+    
+    The normalization of the hydrogen wavefunctions psi_nlm is:
+    
+    >>> from sympy import integrate, conjugate, pi, oo, sin
+    >>> wf=psi_nlm(2,1,1,r,phi,theta,Z)
+    >>> abs_sqrd=wf*conjugate(wf)
+    >>> jacobi=r**2*sin(theta)
+    >>> integrate(abs_sqrd*jacobi, (r,0,oo), (phi,0,2*pi), (theta,0,pi))
+    1
+    """
+    
+    # sympify arguments
+    n, l, m, r, phi, theta, Z = S(n), S(l), S(m), S(r), S(phi), S(theta), S(Z)
+    # check if values for n,l,m make physically sense
+    if n.is_integer and n<1:
+        raise ValueError("'n' must be positive integer")
+    if l.is_integer and not (n > l):
+        raise ValueError("'n' must be greater than 'l'")
+    if m.is_integer and not (abs(m)<=l):
+        raise ValueError("|'m'| must be less or equal 'l'")
+    # return the hydrogen wave function
+    return R_nl(n, l, r, Z)*Ynm(l,m,theta,phi).expand(func=True)
 
 
 def E_nl(n, Z=1):

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -87,7 +87,7 @@ def psi_nlm(n, l, m, r, phi, theta, Z=1):
     """
     Returns the Hydrogen wave function psi_{nlm}. It's the product of
     the radial wavefunction R_{nl} and the spherical harmonic Y_{l}^{m}.
-    
+
     n, l, m
         quantum numbers 'n', 'l' and 'm'
     r
@@ -98,9 +98,9 @@ def psi_nlm(n, l, m, r, phi, theta, Z=1):
         polar angle
     Z
         atomic number (1 for Hydrogen, 2 for Helium, ...)
-    
+
     Everything is in Hartree atomic units.
-    
+
     Examples
     ========
 
@@ -114,12 +114,12 @@ def psi_nlm(n, l, m, r, phi, theta, Z=1):
     Z**(3/2)*exp(-Z*r)/sqrt(pi)
     >>> psi_nlm(2,1,1,r,phi,theta,Z)
     -Z**(5/2)*r*exp(I*phi)*exp(-Z*r/2)*sin(theta)/(8*sqrt(pi))
-    
+
     Integrating the absolute square of a hydrogen wavefunction psi_{nlm}
     over the whole space leads 1.
-    
+
     The normalization of the hydrogen wavefunctions psi_nlm is:
-    
+
     >>> from sympy import integrate, conjugate, pi, oo, sin
     >>> wf=psi_nlm(2,1,1,r,phi,theta,Z)
     >>> abs_sqrd=wf*conjugate(wf)
@@ -127,7 +127,7 @@ def psi_nlm(n, l, m, r, phi, theta, Z=1):
     >>> integrate(abs_sqrd*jacobi, (r,0,oo), (phi,0,2*pi), (theta,0,pi))
     1
     """
-    
+
     # sympify arguments
     n, l, m, r, phi, theta, Z = S(n), S(l), S(m), S(r), S(phi), S(theta), S(Z)
     # check if values for n,l,m make physically sense


### PR DESCRIPTION
New feature:
In addition to the already existing radial wave functions of the
hydrogen atom, now there's also the possibility to get the full
wavefunction psi_nlm, depending on the quantum numbers n, l and m
and the spherical coordinates r, phi and theta. Check Wikipedia
"Hydrogen atom" or any quantum text book for validation of the
formula.

See docstring for examples.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
