### PR TITLE
Typo in weights for Hermite polynomials

### DIFF
--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -935,7 +935,7 @@ class hermite(OrthogonalPolynomial):
     hermite(n, x) gives the nth Hermite polynomial in x, :math:`H_n(x)`
 
     The Hermite polynomials are orthogonal on :math:`(-\infty, \infty)`
-    with respect to the weight :math:`\exp\left(-\frac{x^2}{2}\right)`.
+    with respect to the weight :math:`\exp\left(-x^2\right)`.
 
     Examples
     ========


### PR DESCRIPTION
- The definition used should have as weight :math:`\exp\left(-x^2\right)`.
- This is the same definition used in SciPy.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
