### PR TITLE
call `init_ipython_session` even if in IPython

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -429,9 +429,8 @@ def init_session(ipython=None, pretty_print=True, order=None,
         ip = init_python_session()
         mainloop = ip.interact
     else:
-        if ip is None:
-            ip = init_ipython_session(argv=argv, auto_symbols=auto_symbols,
-                auto_int_to_Integer=auto_int_to_Integer)
+        ip = init_ipython_session(argv=argv, auto_symbols=auto_symbols,
+            auto_int_to_Integer=auto_int_to_Integer)
 
         if V(IPython.__version__) >= '0.11':
             # runsource is gone, use run_cell instead, which doesn't


### PR DESCRIPTION
This is to fix #2839 since `init_ipython_session` is responsible for enabling the options.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
