### PR TITLE
Empty intersection returns UniversalSet

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1469,7 +1469,7 @@ class Intersection(Set):
         args = flatten(args)
 
         if len(args) == 0:
-            return S.EmptySet
+            return S.UniversalSet
 
         # args can't be ordered for Partition see issue #9608
         if 'Partition' not in [type(a).__name__ for a in args]:

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -311,6 +311,8 @@ def test_intersection():
 
     assert Intersection(S.Complexes, FiniteSet(S.ComplexInfinity)) == S.EmptySet
 
+    # issue 12178
+    assert Intersection() == S.UniversalSet
 
 def test_issue_9623():
     n = Symbol('n')


### PR DESCRIPTION
Fixes #12178 .

Previously, `Interesction() == S.EmptySet` , but based on [Wikipedia](https://en.wikipedia.org/wiki/Intersection_(set_theory)#Nullary_intersection). `Interesction()` is changed to `Interesction() == S.UniversalSet`

#### Output before this PR:

```python 
In [46]: Intersection()
Out[46]: ∅
```

### Output after this PR:

```python 
>>> from sympy.sets import * 
>>> Intersection()
UniversalSet()
```

* Tests are added.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>