### PR TITLE
autowrap tempdir appended to system path with os.getcwd

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -138,13 +138,13 @@ class CodeWrapper(object):
         oldwork = os.getcwd()
         os.chdir(workdir)
         try:
-            sys.path.append(workdir)
+            sys.path.append(os.getcwd())
             self._generate_code(routine, helpers)
             self._prepare_files(routine)
             self._process_files(routine)
             mod = __import__(self.module_name)
         finally:
-            sys.path.remove(workdir)
+            sys.path.append(os.getcwd())
             CodeWrapper._module_counter += 1
             os.chdir(oldwork)
             if not self.filepath:
@@ -682,13 +682,13 @@ class UfuncifyCodeWrapper(CodeWrapper):
         oldwork = os.getcwd()
         os.chdir(workdir)
         try:
-            sys.path.append(workdir)
+            sys.path.append(os.getcwd())
             self._generate_code(routines, helpers)
             self._prepare_files(routines, funcname)
             self._process_files(routines)
             mod = __import__(self.module_name)
         finally:
-            sys.path.remove(workdir)
+            sys.path.remove(os.getcwd())
             CodeWrapper._module_counter += 1
             os.chdir(oldwork)
             if not self.filepath:


### PR DESCRIPTION
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>

I'm using Python 3.5, Ubuntu 14.04. When specifying the `tempdir` parameter on the `autowrap` method I received the error 
```
sympy/sympy/utilities/autowrap.py", line 147, in wrap_code
    mod = __import__(self.module_name)
ImportError: No module named 'wrapper_module_1'
```
This PR fixes the error, by appending `os.getcwd()` to the system path rather than the `workdir` parameter. This addresses the error I was receiving.