### PR TITLE
ntheory : Add functionality to return list of all factors

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -946,9 +946,8 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         fac = factorint(n, limit=limit, use_trial=use_trial,
                            use_rho=use_rho, use_pm1=use_pm1,
                            verbose=verbose, visual=False, multiple=False)
-        factorlist = sum(([p] * fac[p]
-                         if fac[p] > 0 else [S(1)/p]*(-1 * fac[p])
-                         for p in sorted(fac)), [])
+        factorlist = sum(([p] * fac[p] if fac[p] > 0 else [S(1)/p]*(-1*fac[p])
+                               for p in sorted(fac)), [])
         return factorlist
 
     factordict = {}
@@ -1209,9 +1208,11 @@ def factorrat(rat, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         fac = factorrat(rat, limit=limit, use_trial=use_trial,
                   use_rho=use_rho, use_pm1=use_pm1,
                   verbose=verbose, visual=False,multiple=False)
-        factorlist = sum(([p] * fac[p]
-                         if fac[p] > 0 else [S(1)/p]*(-1 * fac[p])
-                         for p in sorted(fac)), [])
+        factorlist = sum(([p] * fac[p] if fac[p] > 0 else [S(1)/p]*(-1*fac[p])
+                               for p, _ in sorted(fac.items(),
+                                                        key=lambda(p, m): p
+                                                        if m > 0
+                                                        else 1/p)), [])
         return factorlist
 
     f = factorint(rat.p, limit=limit, use_trial=use_trial,

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1210,9 +1210,9 @@ def factorrat(rat, limit=None, use_trial=True, use_rho=True, use_pm1=True,
                   verbose=verbose, visual=False,multiple=False)
         factorlist = sum(([p] * fac[p] if fac[p] > 0 else [S(1)/p]*(-1*fac[p])
                                for p, _ in sorted(fac.items(),
-                                                        key=lambda(p, m): p
-                                                        if m > 0
-                                                        else 1/p)), [])
+                                                                key=lambda elem: elem[0]
+                                                                if elem[1] > 0
+                                                                else 1/elem[0])), [])
         return factorlist
 
     f = factorint(rat.p, limit=limit, use_trial=use_trial,

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -803,7 +803,7 @@ def _factorint_small(factors, n, limit, fail_max):
 
 
 def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
-              verbose=False, visual=None):
+              verbose=False, visual=None, multiple=False):
     r"""
     Given a positive integer ``n``, ``factorint(n)`` returns a dict containing
     the prime factors of ``n`` as keys and their respective multiplicities
@@ -942,6 +942,15 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     smoothness, smoothness_p, divisors
 
     """
+    if multiple:
+        fac = factorint(n, limit=limit, use_trial=use_trial,
+                           use_rho=use_rho, use_pm1=use_pm1,
+                           verbose=verbose, visual=False, multiple=False)
+        factorlist = sum(([p] * fac[p]
+                         if fac[p] > 0 else [S(1)/p]*(-1 * fac[p])
+                         for p in sorted(fac)), [])
+        return factorlist
+
     factordict = {}
     if visual and not isinstance(n, Mul) and not isinstance(n, dict):
         factordict = factorint(n, limit=limit, use_trial=use_trial,
@@ -1172,7 +1181,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
 
 def factorrat(rat, limit=None, use_trial=True, use_rho=True, use_pm1=True,
-              verbose=False, visual=None):
+              verbose=False, visual=None, multiple=False):
     r"""
     Given a Rational ``r``, ``factorrat(r)`` returns a dict containing
     the prime factors of ``r`` as keys and their respective multiplicities
@@ -1196,6 +1205,15 @@ def factorrat(rat, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         - ``visual``: Toggle product form of output
     """
     from collections import defaultdict
+    if multiple:
+        fac = factorrat(rat, limit=limit, use_trial=use_trial,
+                  use_rho=use_rho, use_pm1=use_pm1,
+                  verbose=verbose, visual=False,multiple=False)
+        factorlist = sum(([p] * fac[p]
+                         if fac[p] > 0 else [S(1)/p]*(-1 * fac[p])
+                         for p in sorted(fac)), [])
+        return factorlist
+
     f = factorint(rat.p, limit=limit, use_trial=use_trial,
                   use_rho=use_rho, use_pm1=use_pm1,
                   verbose=verbose).copy()

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1210,9 +1210,9 @@ def factorrat(rat, limit=None, use_trial=True, use_rho=True, use_pm1=True,
                   verbose=verbose, visual=False,multiple=False)
         factorlist = sum(([p] * fac[p] if fac[p] > 0 else [S(1)/p]*(-1*fac[p])
                                for p, _ in sorted(fac.items(),
-                                                                key=lambda elem: elem[0]
-                                                                if elem[1] > 0
-                                                                else 1/elem[0])), [])
+                                                        key=lambda elem: elem[0]
+                                                        if elem[1] > 0
+                                                        else 1/elem[0])), [])
         return factorlist
 
     f = factorint(rat.p, limit=limit, use_trial=use_trial,

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -850,6 +850,14 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     >>> factorint(3*101**7, limit=5)
     {3: 1, 101: 7}
 
+    List of Factors:
+
+    If ``multiple`` is set to ``True`` then a list containing the
+    prime factors including multiplicities is returned.
+
+    >>> factorint(24, multiple=True)
+    [2, 2, 2, 3]
+
     Visual Factorization:
 
     If ``visual`` is set to ``True``, then it will return a visual
@@ -1201,6 +1209,7 @@ def factorrat(rat, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         - ``use_rho``: Toggle use of Pollard's rho method
         - ``use_pm1``: Toggle use of Pollard's p-1 method
         - ``verbose``: Toggle detailed printing of progress
+        - ``multiple``: Toggle returning a list of factors or dict
         - ``visual``: Toggle product form of output
     """
     from collections import defaultdict

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -154,6 +154,20 @@ def test_factorint():
     assert factorint(5951757) == {3: 1, 7: 1, 29: 2, 337: 1}
     assert factorint(64015937) == {7993: 1, 8009: 1}
     assert factorint(2**(2**6) + 1) == {274177: 1, 67280421310721: 1}
+
+    assert factorint(0, multiple=True) == [0]
+    assert factorint(1, multiple=True) == []
+    assert factorint(-1, multiple=True) == [-1]
+    assert factorint(-2, multiple=True) == [-1, 2]
+    assert factorint(-16, multiple=True) == [-1, 2, 2, 2, 2]
+    assert factorint(2, multiple=True) == [2]
+    assert factorint(24, multiple=True) == [2, 2, 2, 3]
+    assert factorint(126, multiple=True) == [2, 3, 3, 7]
+    assert factorint(123456, multiple=True) == [2, 2, 2, 2, 2, 2, 3, 643]
+    assert factorint(5951757, multiple=True) == [3, 7, 29, 29, 337]
+    assert factorint(64015937, multiple=True) == [7993, 8009]
+    assert factorint(2**(2**6) + 1, multiple=True) == [274177, 67280421310721]
+
     assert multiproduct(factorint(fac(200))) == fac(200)
     for b, e in factorint(fac(150)).items():
         assert e == fac_multiplicity(150, b)
@@ -423,6 +437,13 @@ def test_factorrat():
     assert str(factorrat(S(1)/1, visual=True)) == '1'
     assert str(factorrat(S(25)/14, visual=True)) == '5**2/(2*7)'
     assert str(factorrat(S(-25)/14/9, visual=True)) == '-5**2/(2*3**2*7)'
+
+    assert factorrat(S(12)/1, multiple=True) == [2, 2, 3]
+    assert factorrat(S(1)/1, multiple=True) == []
+    assert factorrat(S(25)/14, multiple=True) == [1/2, 5, 5, 1/7]
+    assert factorrat(S(12)/1, multiple=True) == [2, 2, 3]
+    assert factorrat(S(-25)/14/9, multiple=True) == \
+        [-1, 1/2, 1/3, 1/3, 5, 5, 1/7]
 
 
 def test_visual_io():

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -440,10 +440,10 @@ def test_factorrat():
 
     assert factorrat(S(12)/1, multiple=True) == [2, 2, 3]
     assert factorrat(S(1)/1, multiple=True) == []
-    assert factorrat(S(25)/14, multiple=True) == [1/2, 5, 5, 1/7]
+    assert factorrat(S(25)/14, multiple=True) == [1/7, 1/2, 5, 5]
     assert factorrat(S(12)/1, multiple=True) == [2, 2, 3]
     assert factorrat(S(-25)/14/9, multiple=True) == \
-        [-1, 1/2, 1/3, 1/3, 5, 5, 1/7]
+        [-1, 1/7, 1/3, 1/3, 1/2, 5, 5]
 
 
 def test_visual_io():


### PR DESCRIPTION
Passing in the argument `multiple=True` to `factorint()` or `factorrat()` returns a list of all the prime factors constituting the number along with multiplicity.

PR #12124 got messed up, so I opened a new PR.
Example:
```
>>> factorint(222,multiple=True)
[2, 3, 37]
>>>factorrat(S(25)/14, multiple=True)
[1/2, 5, 5, 1/7]
```
Fixes #12101 

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
Fixes #12101 