### PR TITLE
nsolve:added printer to mpmathprinter for incomple gamma functions

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -348,6 +348,11 @@ class MpmathPrinter(LambdaPrinter):
         args = str(tuple(map(int, e._mpf_)))
         return 'mpf(%s)' % args
 
+    def _print_Uppergamma(self,e):
+        return "gammainc({0}, {1}, inf)".format(e.args[0], e.args[1])
+
+    def _print_Lowergamma(self,e):
+        return "gammainc({0}, 0,{1})".format(e.args[0], e.args[1])
 
 def lambdarepr(expr, **settings):
     """

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -50,9 +50,9 @@ MPMATH_TRANSLATIONS = {
     "E": "e",
     "I": "j",
     "ln": "log",
-    #"lowergamma":"lower_gamma",
+    "lowergamma":"gammainc",
     "oo": "inf",
-    #"uppergamma":"upper_gamma",
+    "uppergamma":"gammainc",
     "LambertW": "lambertw",
     "MutableDenseMatrix": "matrix",
     "ImmutableMatrix": "matrix",
@@ -499,7 +499,7 @@ def lambdastr(args, expr, printer=None, dummify=False):
     from sympy.matrices import DeferredVector
     from sympy import Dummy, sympify, Symbol, Function, flatten
 
-    if printer is not None:
+    if printer is None:
         if inspect.isfunction(printer):
             lambdarepr = printer
         else:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -14,6 +14,7 @@ from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import skip
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.external import import_module
+from sympy.functions.special.gamma_functions import uppergamma, lowergamma
 import sympy
 
 
@@ -751,16 +752,18 @@ def test_issue_2790():
     assert lambdify((x, (y, (w, z))), w + x + y + z)(1, (2, (3, 4))) == 10
     assert lambdify(x, x + 1, dummify=False)(1) == 2
 
-
 def test_ITE():
     assert lambdify((x, y, z), ITE(x, y, z))(True, 5, 3) == 5
     assert lambdify((x, y, z), ITE(x, y, z))(False, 5, 3) == 3
-
 
 def test_Min_Max():
     # see gh-10375
     assert lambdify((x, y, z), Min(x, y, z))(1, 2, 3) == 1
     assert lambdify((x, y, z), Max(x, y, z))(1, 2, 3) == 3
+
+def test_issue_12173():
+    assert lambdify((x,y), uppergamma(x,y))(1,2)==exp(-2)
+    assert lambdify((x,y), lowergamma(x,y))(1,2)==(-exp(-2)+1)
 
 def test_Indexed():
     # Issue #10934


### PR DESCRIPTION
previously the mpmathprinter didn't had any printer for upper gamma and lower gamma function. The two added printer gives the output in string format as required by mpmath gammainc.
The changes passed all the tests
Fixes #12173 
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>