### PR TITLE
Updated expr.coeff() doctstring

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1106,11 +1106,12 @@ class Expr(Basic, EvalfMixin):
 
     def coeff(self, x, n=1, right=False):
         """
-        Returns the coefficient from the term(s) containing ``x**n`` or None. If ``n``
+        Returns the coefficient from the term(s) containing ``x**n``. If ``n``
         is zero then all terms independent of ``x`` will be returned.
 
-        When x is noncommutative, the coeff to the left (default) or right of x
-        can be returned. The keyword 'right' is ignored when x is commutative.
+        When ``x`` is noncommutative, the coefficient to the left (default) or
+        right of ``x`` can be returned. The keyword 'right' is ignored when
+        ``x`` is commutative.
 
         See Also
         ========


### PR DESCRIPTION
Fixes #12200 .

Updated Docstring of Expr.coeff() to:

```
        Returns the coefficient from the term(s) containing ``x**n``.
        If ``n`` is zero then all terms independent of ``x`` will be
        returned.

        When ``x`` is noncommutative, the coefficient to the
        left (default) or right of ``x`` can be returned. The keyword
        'right' is ignored when ``x`` is commutative.
```
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>