### PR TITLE
API for listing old assump created, public variable created for private variable.

### DIFF
--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -228,6 +228,15 @@ def evaluate_old_assump(pred):
     """
     return pred.xreplace(Transform(_old_assump_replacer))
 
+class ListAssump():
+    def old():
+        from sympy.core.assumptions import _assume_defined as r
+        print(r)
+    """
+        A call for this function gives back all the old assumptions in the sympy.
+        Straight away prints all the old assumptions.
+
+    """
 
 class CheckOldAssump(UnevaluatedOnFree):
     def apply(self):

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -230,7 +230,7 @@ def evaluate_old_assump(pred):
 
 class ListAssump():
     def old():
-        from sympy.core.assumptions import _assume_defined as r
+        from sympy.core.assumptions import get_old_assump as r
         print(r)
     """
         A call for this function gives back all the old assumptions in the sympy.

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -203,6 +203,8 @@ _assume_defined = _assume_rules.defined_facts.copy()
 _assume_defined.add('polar')
 _assume_defined = frozenset(_assume_defined)
 
+get_old_assump = _assume_defined
+
 
 class StdFactKB(FactKB):
     """A FactKB specialised for the built-in rules


### PR DESCRIPTION
Issue #11539 resolved

Public variable for _assume_defined created. New variable is called get_old_assump

API now imports the public variable instead of private variable.