### PR TITLE
a Number should know its own floor/ceiling

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -435,6 +435,14 @@ class Number(AtomicExpr):
     def __float__(self):
         return mlib.to_float(self._as_mpf_val(53))
 
+    def floor(self):
+        raise NotImplementedError('%s needs .floor() method' %
+            (self.__class__.__name__))
+
+    def ceiling(self):
+        raise NotImplementedError('%s needs .ceiling() method' %
+            (self.__class__.__name__))
+
     def _eval_conjugate(self):
         return self
 
@@ -1519,6 +1527,12 @@ class Rational(Number):
 
     __long__ = __int__
 
+    def floor(self):
+        return Integer(self.p // self.q)
+
+    def ceiling(self):
+        return -Integer(-self.p // self.q)
+
     def __eq__(self, other):
         try:
             other = _sympify(other)
@@ -1791,6 +1805,12 @@ class Integer(Rational):
         return self.p
 
     __long__ = __int__
+
+    def floor(self):
+        return Integer(self.p)
+
+    def ceiling(self):
+        return Integer(self.p)
 
     def __neg__(self):
         return Integer(-self.p)
@@ -2681,6 +2701,12 @@ class Infinity(with_metaclass(Singleton, Number)):
 
     __rmod__ = __mod__
 
+    def floor(self):
+        return self
+
+    def ceiling(self):
+        return self
+
 oo = S.Infinity
 
 
@@ -2892,6 +2918,12 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
 
     __rmod__ = __mod__
 
+    def floor(self):
+        return self
+
+    def ceiling(self):
+        return self
+
 
 class NaN(with_metaclass(Singleton, Number)):
     """
@@ -2978,6 +3010,12 @@ class NaN(with_metaclass(Singleton, Number)):
 
     __truediv__ = __div__
 
+    def floor(self):
+        return self
+
+    def ceiling(self):
+        return self
+
     def _as_mpf_val(self, prec):
         return _mpf_nan
 
@@ -3053,6 +3091,12 @@ class ComplexInfinity(with_metaclass(Singleton, AtomicExpr)):
     @staticmethod
     def __abs__():
         return S.Infinity
+
+    def floor(self):
+        return self
+
+    def ceiling(self):
+        return self
 
     @staticmethod
     def __neg__():

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -118,12 +118,7 @@ class floor(RoundFunction):
     @classmethod
     def _eval_number(cls, arg):
         if arg.is_Number:
-            if arg.is_Rational:
-                return Integer(arg.p // arg.q)
-            elif arg.is_Float:
-                return arg.floor()
-            else:
-                return arg
+            return arg.floor()
         elif isinstance(arg, ceiling):
             return arg
         elif isinstance(arg, floor):
@@ -193,12 +188,7 @@ class ceiling(RoundFunction):
     @classmethod
     def _eval_number(cls, arg):
         if arg.is_Number:
-            if arg.is_Rational:
-                return -Integer(-arg.p // arg.q)
-            elif arg.is_Float:
-                return arg.ceiling()
-            else:
-                return arg
+            return arg.ceiling()
         elif isinstance(arg, ceiling):
             return arg
         elif isinstance(arg, floor):

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -121,7 +121,7 @@ class floor(RoundFunction):
             if arg.is_Rational:
                 return Integer(arg.p // arg.q)
             elif arg.is_Float:
-                return Integer(int(arg.floor()))
+                return arg.floor()
             else:
                 return arg
         elif isinstance(arg, ceiling):
@@ -196,7 +196,7 @@ class ceiling(RoundFunction):
             if arg.is_Rational:
                 return -Integer(-arg.p // arg.q)
             elif arg.is_Float:
-                return Integer(int(arg.ceiling()))
+                return arg.ceiling()
             else:
                 return arg
         elif isinstance(arg, ceiling):


### PR DESCRIPTION
Knowledge about floors and ceilings of Numbers was storied in the
Functions floor and ceiling.  Instead, we make each subclass of Number
have a .floor() and .ceiling() method.
    
In the older code, the standalone floor/ceiling Functions were written
to assume all non-Rational non-Float Numbers were Integers (which
might not be true if other Number subclasses were introduced in the
future).  Also, its better OO practice for Rationals to know their own
floor and ceiling.
