### PR TITLE
Further enhancement of Pauli Algebra

### DIFF
--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -1,6 +1,7 @@
 from sympy import I, symbols
 from sympy.physics.paulialgebra import Pauli
 from sympy.utilities.pytest import XFAIL
+from sympy.physics.quantum import TensorProduct
 
 sigma1 = Pauli(1)
 sigma2 = Pauli(2)
@@ -41,12 +42,13 @@ def test_evaluate_pauli_product():
     # Check issue 6471
     assert evaluate_pauli_product(-I*4*sigma1*sigma2) == 4*sigma3
 
-    # Acting on non-Mul objects should return the input
-    assert evaluate_pauli_product(1) == 1
-    # After consecutive multiplication, one or no Pauli should remain
-    assert evaluate_pauli_product(I*sigma1*sigma2*sigma1*sigma2) == -I
-    # Must respect non-commuting properties of other symbols
-    assert evaluate_pauli_product(I*sigma1*sigma2*tau1*sigma1*sigma3) == I*sigma3*tau1*sigma2
+    assert evaluate_pauli_product(
+        1 + I*sigma1*sigma2*sigma1*sigma2 + \
+        I*sigma1*sigma2*tau1*sigma1*sigma3 + \
+        ((tau1**2).subs(tau1, I*sigma1)) + \
+        sigma3*((tau1**2).subs(tau1, I*sigma1)) + \
+        TensorProduct(I*sigma1*sigma2*sigma1*sigma2, 1)
+    ) == 1 -I + I*sigma3*tau1*sigma2 - 1 - sigma3 - I*TensorProduct(1,1)
 
 
 @XFAIL


### PR DESCRIPTION
The `evaluate_pauli_product` still lacked several important features:

It did not iterate over `Add`, e.g.:

```
In [16]: evaluate_pauli_product(I*sigma1*sigma2+1)
Out[16]: 1 + I*sigma1*sigma2
```

did not iterate over `TensorProduct`, e.g.:

```
In [17]: from sympy.physics.quantum import TensorProduct

In [19]: evaluate_pauli_product(TensorProduct(I*sigma1*sigma2, 1))
Out[19]: I*(sigma1*sigma2)x 1
```

and some powers that could easily emerge from substitutions were not
evaluated, e.g.:

```
In [21]: tau1 = symbols('tau1', commutative=False)

In [22]: ((tau1**2).subs(tau1, I*sigma1))
Out[22]: -sigma1**2

In [23]: evaluate_pauli_product(((tau1**2).subs(tau1, I*sigma1)))
Out[23]: -sigma1**2
```

With this commit, these, and many other situations, are evaluated correctly.

The `test_paulialgebra.py` has been rewritten to have one test that tests all
of the above and the previous non-trivial tests.
