### PR TITLE
Simple fix for B-Splines of higher than 1 degree with repeated knots.

### DIFF
--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -35,7 +35,7 @@ def _add_splines(c, b1, d, b2):
     return rv.expand()
 
 
-def bspline_basis(d, knots, n, x, close=True):
+def bspline_basis(d, knots, n, x):
     """The `n`-th B-spline at `x` of degree `d` with knots.
 
     B-Splines are piecewise polynomials of degree `d` [1]_.  They are defined on
@@ -56,11 +56,11 @@ def bspline_basis(d, knots, n, x, close=True):
     Here is an example of a cubic B-spline:
 
         >>> bspline_basis(3, range(5), 0, x)
-        Piecewise((x**3/6, (x >= 0) & (x < 1)),
+        Piecewise((x**3/6, (x >= 0) & (x <= 1)),
                   (-x**3/2 + 2*x**2 - 2*x + 2/3,
-                  (x >= 1) & (x < 2)),
+                  (x >= 1) & (x <= 2)),
                   (x**3/2 - 4*x**2 + 10*x - 22/3,
-                  (x >= 2) & (x < 3)),
+                  (x >= 2) & (x <= 3)),
                   (-x**3/6 + 2*x**2 - 8*x + 32/3,
                   (x >= 3) & (x <= 4)),
                   (0, True))
@@ -104,23 +104,21 @@ def bspline_basis(d, knots, n, x, close=True):
         raise ValueError('n + d + 1 must not exceed len(knots) - 1')
     if d == 0:
         result = Piecewise(
-            (S.One, Interval(knots[n], knots[n + 1], False,
-             not close).contains(x)),
+            (S.One, Interval(knots[n], knots[n + 1]).contains(x)),
             (0, True)
         )
     elif d > 0:
         denom = knots[n + d + 1] - knots[n + 1]
         if denom != S.Zero:
             B = (knots[n + d + 1] - x)/denom
-            b2 = bspline_basis(d - 1, knots, n + 1, x, close)
+            b2 = bspline_basis(d - 1, knots, n + 1, x)
         else:
             b2 = B = S.Zero
 
         denom = knots[n + d] - knots[n]
         if denom != S.Zero:
             A = (x - knots[n])/denom
-            b1 = bspline_basis(
-                d - 1, knots, n, x, close and (B == S.Zero or b2 == S.Zero))
+            b1 = bspline_basis(d - 1, knots, n, x)
         else:
             b1 = A = S.Zero
 

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -175,12 +175,12 @@ def bspline_basis_set(d, knots, x):
     >>> knots = range(5)
     >>> splines = bspline_basis_set(d, knots, x)
     >>> splines
-    [Piecewise((x**2/2, (x >= 0) & (x < 1)),
-               (-x**2 + 3*x - 3/2, (x >= 1) & (x < 2)),
+    [Piecewise((x**2/2, (x >= 0) & (x <= 1)),
+               (-x**2 + 3*x - 3/2, (x >= 1) & (x <= 2)),
                (x**2/2 - 3*x + 9/2, (x >= 2) & (x <= 3)),
                (0, True)),
-    Piecewise((x**2/2 - x + 1/2, (x >= 1) & (x < 2)),
-              (-x**2 + 5*x - 11/2, (x >= 2) & (x < 3)),
+    Piecewise((x**2/2 - x + 1/2, (x >= 1) & (x <= 2)),
+              (-x**2 + 5*x - 11/2, (x >= 2) & (x <= 3)),
               (x**2/2 - 4*x + 8, (x >= 3) & (x <= 4)),
               (0, True))]
 

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -25,22 +25,33 @@ def _add_splines(c, b1, d, b2):
 
             # This merging algorithm assume the conditions in p1 and p2 are sorted
             for arg in p1.args[:-1]:
-                cond = arg.cond
+                # Conditional of Piecewise are And objects
+                # the args of the And object is a tuple of two Relational objects
+                # the numerical value is in the .rhs of the Relational object
                 expr = arg.expr
+                cond = arg.cond
+
+                lower = cond.args[0].rhs
 
                 # Check p2 for matching conditions that can be merged
                 for i, arg2 in enumerate(p2args):
-                    if arg2.cond < cond:
-                        # arg2 condition smaller than arg1, add to new_args by itself (no match expected in p1)
-                        new_args.append(arg2)
-                        del p2args[i]
-                        break
-                    elif arg2.cond == cond:
+                    expr2 = arg2.expr
+                    cond2 = arg2.cond
+
+                    lower_2 = cond2.args[0].rhs
+                    upper_2 = cond2.args[1].rhs
+
+                    if cond2 == cond:
                         # Conditions match, join expressions
-                        expr += arg2.expr
+                        expr += expr2
                         # Remove matching element
                         del p2args[i]
                         # No need to check the rest
+                        break
+                    elif lower_2 < lower and upper_2 <= lower:
+                        # Check if arg2 condition smaller than arg1, add to new_args by itself (no match expected in p1)
+                        new_args.append(arg2)
+                        del p2args[i]
                         break
 
                 # Checked all, add expr and cond

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -16,16 +16,21 @@ def _add_splines(c, b1, d, b2):
         new_args = []
         n_intervals = len(b1.args)
         if n_intervals != len(b2.args):
-            raise ValueError("Args of b1 and b2 are not equal")
-        new_args.append((c*b1.args[0].expr, b1.args[0].cond))
-        for i in range(1, n_intervals - 1):
-            new_args.append((
-                c*b1.args[i].expr + d*b2.args[i - 1].expr,
-                b1.args[i].cond
-            ))
-        new_args.append((d*b2.args[-2].expr, b2.args[-2].cond))
-        new_args.append(b2.args[-1])
-        rv = Piecewise(*new_args)
+            # Args of b1 and b2 are not equal. Just combining the Piecewise without any fancy optimisation
+            p1 = piecewise_fold(c*b1)
+            p2 = piecewise_fold(d*b2)
+
+            rv = p1 + p2
+        else:
+            new_args.append((c*b1.args[0].expr, b1.args[0].cond))
+            for i in range(1, n_intervals - 1):
+                new_args.append((
+                    c*b1.args[i].expr + d*b2.args[i - 1].expr,
+                    b1.args[i].cond
+                ))
+            new_args.append((d*b2.args[-2].expr, b2.args[-2].cond))
+            new_args.append(b2.args[-1])
+            rv = Piecewise(*new_args)
 
     return rv.expand()
 

--- a/sympy/functions/special/tests/test_bsplines.py
+++ b/sympy/functions/special/tests/test_bsplines.py
@@ -11,38 +11,37 @@ def test_basic_degree_0():
     knots = range(5)
     splines = bspline_basis_set(d, knots, x)
     for i in range(len(splines)):
-        assert splines[i] == Piecewise((1, Interval(i, i + 1)
-                                       .contains(x)), (0, True))
+        assert splines[i] == Piecewise((1, Interval(i, i + 1).contains(x)),
+                                       (0, True))
 
 
 def test_basic_degree_1():
     d = 1
     knots = range(5)
     splines = bspline_basis_set(d, knots, x)
-    assert splines[0] == Piecewise(
-        (x, Interval(0, 1, False, True).contains(x)),
-        (2 - x, Interval(1, 2).contains(x)), (0, True))
-    assert splines[1] == Piecewise(
-        (-1 + x, Interval(1, 2, False, True).contains(x)),
-        (3 - x, Interval(2, 3).contains(x)), (0, True))
-    assert splines[2] == Piecewise(
-        (-2 + x, Interval(2, 3, False, True).contains(x)),
-        (4 - x, Interval(3, 4).contains(x)), (0, True))
+    assert splines[0] == Piecewise((x, Interval(0, 1).contains(x)),
+                                   (2 - x, Interval(1, 2).contains(x)),
+                                   (0, True))
+    assert splines[1] == Piecewise((-1 + x, Interval(1, 2).contains(x)),
+                                   (3 - x, Interval(2, 3).contains(x)),
+                                   (0, True))
+    assert splines[2] == Piecewise((-2 + x, Interval(2, 3).contains(x)),
+                                   (4 - x, Interval(3, 4).contains(x)),
+                                   (0, True))
 
 
 def test_basic_degree_2():
     d = 2
     knots = range(5)
     splines = bspline_basis_set(d, knots, x)
-    b0 = Piecewise((x**2/2, Interval(0, 1, False, True).contains(x)),
-        (Rational(
-            -3, 2) + 3*x - x**2, Interval(1, 2, False, True).contains(x)),
-        (Rational(9, 2) - 3*x + x**2/2, Interval(2, 3).contains(x)), (0, True))
-    b1 = Piecewise(
-        (Rational(1, 2) - x + x**2/2, Interval(1, 2, False, True).contains(x)),
-        (Rational(
-            -11, 2) + 5*x - x**2, Interval(2, 3, False, True).contains(x)),
-        (8 - 4*x + x**2/2, Interval(3, 4).contains(x)), (0, True))
+    b0 = Piecewise((x**2/2, Interval(0, 1).contains(x)),
+                   (Rational(-3, 2) + 3*x - x**2, Interval(1, 2).contains(x)),
+                   (Rational(9, 2) - 3*x + x**2/2, Interval(2, 3).contains(x)),
+                   (0, True))
+    b1 = Piecewise((Rational(1, 2) - x + x**2/2, Interval(1, 2).contains(x)),
+                   (Rational(-11, 2) + 5*x - x**2, Interval(2, 3).contains(x)),
+                   (8 - 4*x + x**2/2, Interval(3, 4).contains(x)),
+                   (0, True))
     assert splines[0] == b0
     assert splines[1] == b1
 
@@ -52,11 +51,9 @@ def test_basic_degree_3():
     knots = range(5)
     splines = bspline_basis_set(d, knots, x)
     b0 = Piecewise(
-        (x**3/6, Interval(0, 1, False, True).contains(x)),
-        (Rational(2, 3) - 2*x + 2*x**2 - x**3/2, Interval(1, 2,
-         False, True).contains(x)),
-        (Rational(-22, 3) + 10*x - 4*x**2 + x**3/2, Interval(2, 3,
-         False, True).contains(x)),
+        (x**3/6, Interval(0, 1).contains(x)),
+        (Rational(2, 3) - 2*x + 2*x**2 - x**3/2, Interval(1, 2).contains(x)),
+        (Rational(-22, 3) + 10*x - 4*x**2 + x**3/2, Interval(2, 3).contains(x)),
         (Rational(32, 3) - 8*x + 2*x**2 - x**3/6, Interval(3, 4).contains(x)),
         (0, True)
     )
@@ -69,18 +66,18 @@ def test_repeated_degree_1():
     splines = bspline_basis_set(d, knots, x)
     assert splines[0] == Piecewise((1 - x, Interval(0, 1).contains(x)),
                                    (0, True))
-    assert splines[1] == Piecewise(
-        (x, Interval(0, 1, False, True).contains(x)),
-        (2 - x, Interval(1, 2).contains(x)), (0, True))
-    assert splines[2] == Piecewise((-1 + x, Interval(1, 2).contains(x)
-                                   ), (0, True))
+    assert splines[1] == Piecewise((x, Interval(0, 1).contains(x)),
+                                   (2 - x, Interval(1, 2).contains(x)),
+                                   (0, True))
+    assert splines[2] == Piecewise((-1 + x, Interval(1, 2).contains(x)),
+                                   (0, True))
     assert splines[3] == Piecewise((3 - x, Interval(2, 3).contains(x)),
                                    (0, True))
-    assert splines[4] == Piecewise(
-        (-2 + x, Interval(2, 3, False, True).contains(x)),
-        (4 - x, Interval(3, 4).contains(x)), (0, True))
-    assert splines[5] == Piecewise((-3 + x, Interval(3, 4).contains(x)
-                                   ), (0, True))
+    assert splines[4] == Piecewise((-2 + x, Interval(2, 3).contains(x)),
+                                   (4 - x, Interval(3, 4).contains(x)),
+                                   (0, True))
+    assert splines[5] == Piecewise((-3 + x, Interval(3, 4).contains(x)),
+                                   (0, True))
 
 
 def test_repeated_degree_2():

--- a/sympy/functions/special/tests/test_bsplines.py
+++ b/sympy/functions/special/tests/test_bsplines.py
@@ -85,8 +85,6 @@ def test_repeated_degree_2():
     knots = [0, 0, 1, 2, 2, 3, 4, 4]
     splines = bspline_basis_set(d, knots, x)
 
-    print(str(splines[2]))
-
     assert splines[0] == Piecewise(((-3*x**2/2 + 2*x), And(x <= 1, x >= 0)),
                                    (x**2/2 - 2*x + 2, And(x <= 2, x >= 1)),
                                    (0, True))

--- a/sympy/functions/special/tests/test_bsplines.py
+++ b/sympy/functions/special/tests/test_bsplines.py
@@ -1,6 +1,6 @@
 from sympy.functions import bspline_basis_set
 from sympy.core.compatibility import range
-from sympy import Piecewise, Interval
+from sympy import Piecewise, Interval, And
 from sympy import symbols, Rational
 
 x, y = symbols('x,y')
@@ -81,3 +81,33 @@ def test_repeated_degree_1():
         (4 - x, Interval(3, 4).contains(x)), (0, True))
     assert splines[5] == Piecewise((-3 + x, Interval(3, 4).contains(x)
                                    ), (0, True))
+
+
+def test_repeated_degree_2():
+    d = 2
+    knots = [0, 0, 1, 2, 2, 3, 4, 4]
+    splines = bspline_basis_set(d, knots, x)
+
+    assert splines[0] == (Piecewise((-x**2 + x, And(x < 1, x >= 0)),
+                                    (0, True))
+                          + Piecewise((-x**2/2 + x, And(x < 1, x >= 0)),
+                                      (x**2/2 - 2*x + 2, And(x <= 2, x >= 1)),
+                                      (0, True)))
+    assert splines[1] == (Piecewise((-x**2 + 3*x - 2, And(x <= 2, x >= 1)),
+                                    (0, True))
+                          + Piecewise((x**2/2, And(x < 1, x >= 0)),
+                                      (-x**2/2 + x, And(x < 2, x >= 1)),
+                                      (0, True)))
+    assert splines[2] == Piecewise((x**2 - 2*x + 1, And(x < 2, x >= 1)),
+                                   (x**2 - 6*x + 9, And(x <= 3, x >= 2)),
+                                   (0, True))
+    assert splines[3] == (Piecewise((-x**2 + 5*x - 6, And(x < 3, x >= 2)),
+                                    (0, True))
+                          + Piecewise((-x**2/2 + 3*x - 4, And(x < 3, x >= 2)),
+                                      (x**2/2 - 4*x + 8, And(x <= 4, x >= 3)),
+                                      (0, True)))
+    assert splines[4] == (Piecewise((-x**2 + 7*x - 12, And(x <= 4, x >= 3)),
+                                    (0, True))
+                          + Piecewise((x**2/2 - 2*x + 2, And(x < 3, x >= 2)),
+                                      (-x**2/2 + 3*x - 4, And(x < 4, x >= 3)),
+                                      (0, True)))

--- a/sympy/functions/special/tests/test_bsplines.py
+++ b/sympy/functions/special/tests/test_bsplines.py
@@ -85,26 +85,20 @@ def test_repeated_degree_2():
     knots = [0, 0, 1, 2, 2, 3, 4, 4]
     splines = bspline_basis_set(d, knots, x)
 
-    assert splines[0] == (Piecewise((-x**2 + x, And(x < 1, x >= 0)),
-                                    (0, True))
-                          + Piecewise((-x**2/2 + x, And(x < 1, x >= 0)),
-                                      (x**2/2 - 2*x + 2, And(x <= 2, x >= 1)),
-                                      (0, True)))
-    assert splines[1] == (Piecewise((-x**2 + 3*x - 2, And(x <= 2, x >= 1)),
-                                    (0, True))
-                          + Piecewise((x**2/2, And(x < 1, x >= 0)),
-                                      (-x**2/2 + x, And(x < 2, x >= 1)),
-                                      (0, True)))
-    assert splines[2] == Piecewise((x**2 - 2*x + 1, And(x < 2, x >= 1)),
+    print(str(splines[2]))
+
+    assert splines[0] == Piecewise(((-3*x**2/2 + 2*x), And(x <= 1, x >= 0)),
+                                   (x**2/2 - 2*x + 2, And(x <= 2, x >= 1)),
+                                   (0, True))
+    assert splines[1] == Piecewise((x**2/2, And(x <= 1, x >= 0)),
+                                   (-3*x**2/2 + 4*x - 2, And(x <= 2, x >= 1)),
+                                   (0, True))
+    assert splines[2] == Piecewise((x**2 - 2*x + 1, And(x <= 2, x >= 1)),
                                    (x**2 - 6*x + 9, And(x <= 3, x >= 2)),
                                    (0, True))
-    assert splines[3] == (Piecewise((-x**2 + 5*x - 6, And(x < 3, x >= 2)),
-                                    (0, True))
-                          + Piecewise((-x**2/2 + 3*x - 4, And(x < 3, x >= 2)),
-                                      (x**2/2 - 4*x + 8, And(x <= 4, x >= 3)),
-                                      (0, True)))
-    assert splines[4] == (Piecewise((-x**2 + 7*x - 12, And(x <= 4, x >= 3)),
-                                    (0, True))
-                          + Piecewise((x**2/2 - 2*x + 2, And(x < 3, x >= 2)),
-                                      (-x**2/2 + 3*x - 4, And(x < 4, x >= 3)),
-                                      (0, True)))
+    assert splines[3] == Piecewise((-3*x**2/2 + 8*x - 10, And(x <= 3, x >= 2)),
+                                   (x**2/2 - 4*x + 8, And(x <= 4, x >= 3)),
+                                   (0, True))
+    assert splines[4] == Piecewise((x**2/2 - 2*x + 2, And(x <= 3, x >= 2)),
+                                   (-3*x**2/2 + 10*x - 16, And(x <= 4, x >= 3)),
+                                   (0, True))


### PR DESCRIPTION
A quick (and fairly ugly) fix for full B-Spline functionality.
Supports B-Splines with repeated knots at higher than degree 1. 
Handled with nested Piecewise expressions.

Fixes #8474.