### PR TITLE
Float: drop extraneous "+" when printing Float(S.Infinity)

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -567,6 +567,9 @@ class StrPrinter(Printer):
             rv = '-0.' + rv[3:]
         elif rv.startswith('.0'):
             rv = '0.' + rv[2:]
+        if rv.startswith('+'):
+            # e.g., +inf -> inf
+            rv = rv[1:]
         return rv
 
     def _print_Relational(self, expr):

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -500,6 +500,8 @@ def test_Float():
                                      '5028841971693993751058209749445923')
     assert str(pi.round(-1)) == '0.'
     assert str((pi**400 - (pi**400).round(1)).n(2)) == '-0.e+88'
+    assert str(Float(S.Infinity)) == 'inf'
+    assert str(Float(S.NegativeInfinity)) == '-inf'
 
 
 def test_Relational():


### PR DESCRIPTION
Float has its own floating point infinity, generated from e.g.,
`Float(oo)` or `Float(float('inf'))`.   This printed as "+inf" by
mpmath, which lead to such fuzz as "x + +inf".  Strip this extra "+".
Add tests.