### PR TITLE
Fixed apart() producing wrong answer

### DIFF
--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -104,10 +104,10 @@ class PolynomialRing(Ring, CompositeDomain):
 
     def from_FractionField(K1, a, K0):
         """Convert a rational function to ``dtype``. """
-        denom = K0.denom(a)
+        q, r = K0.numer(a).div(K0.denom(a))
 
-        if denom.is_ground:
-            return K1.from_PolynomialRing(K0.numer(a)/denom, K0.field.ring.to_domain())
+        if r.is_zero:
+            return K1.from_PolynomialRing(q, K0.field.ring.to_domain())
         else:
             return None
 

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -78,7 +78,7 @@ def apart(f, x=None, full=False, **options):
         P, Q = f.as_numer_denom()
 
     _options = options.copy()
-    options = set_defaults(options, extension=True, field=True)
+    options = set_defaults(options, extension=True)
     try:
         (P, Q), opt = parallel_poly_from_expr((P, Q), x, **options)
     except PolynomialError as msg:

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -78,7 +78,7 @@ def apart(f, x=None, full=False, **options):
         P, Q = f.as_numer_denom()
 
     _options = options.copy()
-    options = set_defaults(options, extension=True)
+    options = set_defaults(options, extension=True, field=True)
     try:
         (P, Q), opt = parallel_poly_from_expr((P, Q), x, **options)
     except PolynomialError as msg:

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -8,7 +8,7 @@ from sympy.polys.partfrac import (
 )
 
 from sympy import (S, Poly, E, pi, I, Matrix, Eq, RootSum, Lambda,
-                   Symbol, Dummy, factor, together, sqrt, Expr)
+                   Symbol, Dummy, factor, together, sqrt, Expr, Rational)
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.abc import x, y, a, b, c
 
@@ -36,6 +36,18 @@ def test_apart():
         2 - E + E*pi + E*x + (E*pi + 2)*(pi - 1)/(x - pi)
 
     assert apart(Eq((x**2 + 1)/(x + 1), x), x) == Eq(x - 1 + 2/(x + 1), x)
+
+    assert apart(x/2, y) == x/2
+
+    f, g = (x+y)/(2*x - y), Rational(3/2)*y/((2*x - y)) + Rational(1/2)
+
+    assert apart(f, x, full=False) == g
+    assert apart(f, x, full=True) == g
+
+    f, g = (x+y)/(2*x - y), 3*x/(2*x - y) - 1
+
+    assert apart(f, y, full=False) == g
+    assert apart(f, y, full=True) == g
 
     raises(NotImplementedError, lambda: apart(1/(x + 1)/(y + 2)))
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1700,6 +1700,14 @@ def test_div():
     q = f.exquo(g)
     assert q.get_domain().is_ZZ
 
+    f, g = Poly(x+y, x), Poly(2*x+y, x)
+    q, r = f.div(g)
+    assert q.get_domain().is_Frac and r.get_domain().is_Frac
+    r = f.rem(g)
+    assert r.get_domain().is_Frac
+    q = f.quo(g)
+    assert q.get_domain().is_Frac
+
 
 def test_gcdex():
     f, g = 2*x, x**2 - 16

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1703,10 +1703,6 @@ def test_div():
     f, g = Poly(x+y, x), Poly(2*x+y, x)
     q, r = f.div(g)
     assert q.get_domain().is_Frac and r.get_domain().is_Frac
-    r = f.rem(g)
-    assert r.get_domain().is_Frac
-    q = f.quo(g)
-    assert q.get_domain().is_Frac
 
 
 def test_gcdex():


### PR DESCRIPTION
apart() produced a wrong result when given multivariate polynomial with fractional coefficients in a result. Division was done correctly, but the domain wasn't properly converted to a field. Now the default parameter `field=True` is set explicitly before conversion to polynomial.

Previously:
`In [1]: apart(x/2, y)`
`Out[1]: 0`

Now:
`In [1]: apart(x/2, y)`
`Out[1]:`
x
─
2

This fixes #12177, #9123.