### PR TITLE
example modified

### DIFF
--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -47,6 +47,9 @@ def _mostfunc(lhs, func, X=None):
     ``func`` can be a function (exp, log, etc...) or any other SymPy object,
     like Pow.
 
+    If ``X`` is not ``None``, then the function returns the term composed with the
+    most ``func`` having the specified variable.
+
     Examples
     ========
 
@@ -56,8 +59,8 @@ def _mostfunc(lhs, func, X=None):
     >>> from sympy.abc import x, y
     >>> _mostfunc(exp(x) + exp(exp(x) + 2), exp)
     exp(exp(x) + 2)
-    >>> _mostfunc(exp(x) + exp(exp(y) + 2), exp, x)
-    exp(x)
+    >>> _mostfunc(exp(x) + exp(exp(y) + 2), exp)
+    exp(exp(y) + 2)
     >>> _mostfunc(exp(x) + exp(exp(y) + 2), exp, x)
     exp(x)
     >>> _mostfunc(x, exp, x) is None


### PR DESCRIPTION
In `bivariate.py` function named `_mostfunc` has an example that is repeated, therefore I tried to modify the example so that one finds it easier to understand what the function does. Following is what I modified:
```
>>> _mostfunc(exp(x) + exp(exp(y) + 2), exp)
exp(exp(y) + 2)
```
This example would help one understand that the result also depends on the variable specified, as, if variable(3rd param) is defined it would work accordingly as given in the docs example:
```
>>> _mostfunc(exp(x) + exp(exp(y) + 2), exp, x)
exp(x)
```

