### PR TITLE
Improved manual integrate for manualintegrate(x**y, x)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1024,7 +1024,8 @@ def eval_constanttimes(constant, other, substep, integrand, symbol):
 
 @evaluates(PowerRule)
 def eval_power(base, exp, integrand, symbol):
-    return (base ** (exp + 1)) / (exp + 1)
+    return sympy.Piecewise((sympy.log(base), sympy.Eq(exp, -1)),
+        ((base**(exp + 1))/(exp + 1), True))
 
 @evaluates(ExpRule)
 def eval_exp(base, exp, integrand, symbol):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -217,6 +217,11 @@ def test_issue_6799():
     assert not integrate(integrand, limits).has(Dummy)
 
 
+def test_issue_12251():
+    assert manualintegrate(x**y, x) == Piecewise(
+        (log(x), Eq(y, -1)), (x**(y + 1)/(y + 1), True))
+
+
 def test_issue_3796():
     assert manualintegrate(diff(exp(x + x**2)), x) == exp(x + x**2)
     assert integrate(x * exp(x**4), x, risch=False) == -I*sqrt(pi)*erf(I*x**2)/4


### PR DESCRIPTION
Fixes #12251 .

Previously the rule did not check if the `exp == -1` and returned the answer as `(base ** (exp + 1)) / (exp + 1)`. If `exp == -1` , then the answer should be `log(base)`.

### Output before this PR:
```python
>>> from sympy.integrals.manualintegrate import manualintegrate
>>> from sympy.abc import x, y
>>> manualintegrate(x**y, x)
x**(y + 1)/(y + 1)
```
### Output after this PR: 
```python 
>>> from sympy.integrals.manualintegrate import manualintegrate
>>> from sympy.abc import x, y
>>> manualintegrate(x**y, x)
Piecewise((log(x), Eq(y, -1)), (x**(y + 1)/(y + 1), True))
```

* Tests are added.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>