### PR TITLE
Python 3.3 bin/test --no-subprocess says hash randomization is off #7184

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -12,7 +12,7 @@ from __future__ import print_function
 import sys
 import os
 from optparse import OptionParser
-import re,random
+import re
 
 from get_sympy import path_hack
 path_hack()

--- a/bin/test
+++ b/bin/test
@@ -12,7 +12,7 @@ from __future__ import print_function
 import sys
 import os
 from optparse import OptionParser
-import re
+import re,random
 
 from get_sympy import path_hack
 path_hack()
@@ -44,8 +44,7 @@ def vararg_callback(option, opt_str, value, parser):
 
 
 parser = OptionParser()
-parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
-        default=False)
+parser.add_option("-v", "--verbose", action="store_true", dest="verbose",        default=False)
 parser.add_option("--pdb", action="store_true", dest="pdb",
         default=False, help="Run post mortem pdb on each failure")
 parser.add_option("--no-colors", action="store_false", dest="colors",
@@ -72,7 +71,7 @@ parser.add_option("--timeout", action="store", dest="timeout",
         default=False, help="Set a timeout for the all functions, in seconds. By default there is no timeout.", type='int')
 parser.add_option("--slow", action="store_true", dest="slow",
         default=False, help="Run only the slow functions.")
-parser.add_option("--no-subprocess", action="store_false", dest="subprocess",
+parser.add_option("--no-subprocess", action="store_true", dest="subprocess",
                   default=True, help="Don't run the tests in a separate "
                   "subprocess.  This may prevent hash randomization from being enabled.")
 parser.add_option("-E", "--enhance-asserts", action="store_true", dest="enhance_asserts",
@@ -92,6 +91,7 @@ options, args = parser.parse_args()
 
 # Check this again here to give a better error message
 if options.split:
+    print(options.split)
     sp = re.compile(r'([0-9]+)/([1-9][0-9]*)')
     if not sp.match(options.split):
         parser.error("option --split: must be of the form a/b where a and b "
@@ -101,6 +101,9 @@ if not options.cache:
     os.environ['SYMPY_USE_CACHE'] = 'no'
 if options.types:
     os.environ['SYMPY_GROUND_TYPES'] = options.types
+#hash_seed = os.getenv("PYTHONHASHSEED")
+# if not hash_seed:
+#         os.environ["PYTHONHASHSEED"] = str(random.randrange(2**32))
 
 import sympy
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -191,8 +191,9 @@ def run_in_subprocess_with_hash_randomization(function, function_args=(),
     p.communicate()
     if p.returncode != 0:
         return False
-
+    
     hash_seed = os.getenv("PYTHONHASHSEED")
+    
     if not hash_seed:
         os.environ["PYTHONHASHSEED"] = str(random.randrange(2**32))
     else:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -195,7 +195,7 @@ def run_in_subprocess_with_hash_randomization(function, function_args=(),
     hash_seed = os.getenv("PYTHONHASHSEED")
     
     if not hash_seed:
-        os.environ["PYTHONHASHSEED"] = str(random.randrange(2**32))
+        os.environ["PYTHONHASHSEED"] = str(random.randint(1,2**32))
     else:
         if not force:
             return False


### PR DESCRIPTION
Currently `./bin/test  --no-subprocess` in the python3 hash seed is off instead of on, this fixes the issue.