### PR TITLE
fix bug in extract_multiplicatively()

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -11,7 +11,6 @@ from mpmath.libmp import mpf_log, prec_to_dps
 
 from collections import defaultdict
 
-
 class Expr(Basic, EvalfMixin):
     """
     Base class for algebraic expressions.
@@ -1940,6 +1939,8 @@ class Expr(Basic, EvalfMixin):
            x/6
 
         """
+        from .function import _coeff_isneg
+
         c = sympify(c)
         if self is S.NaN:
             return None
@@ -1957,9 +1958,8 @@ class Expr(Basic, EvalfMixin):
             if x is not None:
                 return x.extract_multiplicatively(b)
 
-        from sympy.core.function import _coeff_isneg as f
-        if c.is_Number and c.is_negative and all(f(t) for t in Add.make_args(self)):
-            return (-1*self).extract_multiplicatively(-1*c)
+        if c.is_Number and c.is_negative and all(_coeff_isneg(t) for t in Add.make_args(self)):
+            return (-self).extract_multiplicatively(-c)
 
         quotient = self / c
         if self.is_Number:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1956,6 +1956,11 @@ class Expr(Basic, EvalfMixin):
             x = self.extract_multiplicatively(a)
             if x is not None:
                 return x.extract_multiplicatively(b)
+
+        from sympy.core.function import _coeff_isneg as f
+        if c.is_Number and c.is_negative and all(f(t) for t in Add.make_args(self)):
+            return (-1*self).extract_multiplicatively(-1*c)
+
         quotient = self / c
         if self.is_Number:
             if self is S.Infinity:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1012,11 +1012,12 @@ def test_extractions():
     assert (sqrt(x)).extract_multiplicatively(x) is None
     assert (sqrt(x)).extract_multiplicatively(1/x) is None
     assert x.extract_multiplicatively(-x) is None
-    assert (-2-4*I).extract_multiplicatively(-2) == 1 + 2*I
+    assert (-2 - 4*I).extract_multiplicatively(-2) == 1 + 2*I
+    assert (-2 - 4*I).extract_multiplicatively(3) is None
     assert (-2*x - 4*y - 8).extract_multiplicatively(-2) == x + 2*y + 4
     assert (-2*x*y - 4*x**2*y).extract_multiplicatively(-2*y) == 2*x**2 + x
     assert (2*x*y + 4*x**2*y).extract_multiplicatively(2*y) == 2*x**2 + x
-    assert (-4*y**2*x).extract_multiplicatively(-3*y) == None
+    assert (-4*y**2*x).extract_multiplicatively(-3*y) is None
 
     assert ((x*y)**3).extract_additively(1) is None
     assert (x + 1).extract_additively(x) == 1

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1012,6 +1012,11 @@ def test_extractions():
     assert (sqrt(x)).extract_multiplicatively(x) is None
     assert (sqrt(x)).extract_multiplicatively(1/x) is None
     assert x.extract_multiplicatively(-x) is None
+    assert (-2-4*I).extract_multiplicatively(-2) == 1 + 2*I
+    assert (-2*x - 4*y - 8).extract_multiplicatively(-2) == x + 2*y + 4
+    assert (-2*x*y - 4*x**2*y).extract_multiplicatively(-2*y) == 2*x**2 + x
+    assert (2*x*y + 4*x**2*y).extract_multiplicatively(2*y) == 2*x**2 + x
+    assert (-4*y**2*x).extract_multiplicatively(-3*y) == None
 
     assert ((x*y)**3).extract_additively(1) is None
     assert (x + 1).extract_additively(x) == 1


### PR DESCRIPTION
Fixes #12254 .
Can you review this and suggest improvements @smichr, @cbm755 ?

And consider this test case : 
```
>>> (4*y**2*(-x*y-2*y)).extract_multiplicatively(-2*y)
```
I am not sure whether we should return ```None``` or ```2*x*y**2 + 4*y**2``` ,  currently it returns ```None```