### PR TITLE
Matrix Printing: Fix printing errors in Matrix Symbol and subs()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ sample.tex
 
 # pytest related data file for slow tests
 .ci/durations.log
+

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -384,6 +384,43 @@ class MatrixElement(Expr):
         return KroneckerDelta(self.args[1], v.args[1])*KroneckerDelta(self.args[2], v.args[2])
 
 
+    def _MatrixElement_expansion(self, printer, elementAccess):
+        '''
+        _MatrixElement_expansion distributes the element access over the terms in the MatrixElement object.
+        printer is the requesting printer to generate the expanded form of the MatrixElement object.
+        elementAccess is the precomputed indices to access the matrix element from the matrix.
+        '''
+        from sympy.matrices import MatrixSymbol, MutableDenseMatrix
+
+        # if the MatrixElement object is an instance of MatrixSymbol,
+        # simply, return the concatenation of the matrix element and elementAccess
+        if isinstance(self.parent, MatrixSymbol):
+            return printer._print(self.parent) + elementAccess
+
+        # get the terms from the MatrixElement object
+        terms = list(self.parent.args)
+        # creat an empty list in which the intermediate result is stored
+        l = []
+        # loop over the terms and concatenate the term and elementAccess
+        for term in terms:
+            t = printer._print(term)
+            # get the the sign of the term
+            if t.startswith('-'):
+                sign = "-"
+                t = t[1:]
+            else:
+                sign = "+"
+            # concatenate the term and elementAccess and add them to l
+            l.extend([sign, t + elementAccess])
+
+        # if the first term is positive, remove its sign from l
+        sign = l.pop(0)
+        if sign == '+':
+            sign = ""
+
+        return sign + ' '.join(l)
+
+
 class MatrixSymbol(MatrixExpr):
     """Symbolic representation of a Matrix object
 

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -231,8 +231,9 @@ class C89CodePrinter(CodePrinter):
         return self._print(_piecewise)
 
     def _print_MatrixElement(self, expr):
-        return "{0}[{1}]".format(expr.parent, expr.j +
-                expr.i*expr.parent.shape[1])
+        elementAccess = "[{0}]".format(expr.j + expr.i * expr.parent.shape[1])
+        printer = self
+        return expr._MatrixElement_expansion(printer, elementAccess)
 
     def _print_Symbol(self, expr):
         name = super(C89CodePrinter, self)._print_Symbol(expr)

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -29,7 +29,7 @@ from sympy.sets import Range
 from sympy.codegen.ast import Assignment
 from sympy.codegen.ffunctions import isign, dsign, cmplx, merge, literal_dp
 from sympy.printing.codeprinter import CodePrinter
-from sympy.printing.precedence import precedence
+from sympy.printing.precedence import precedence, PRECEDENCE
 
 known_functions = {
     "sin": "sin",
@@ -185,7 +185,7 @@ class FCodePrinter(CodePrinter):
                                       "standards earlier than Fortran95.")
 
     def _print_MatrixElement(self, expr):
-        return "{0}({1}, {2})".format(expr.parent, expr.i + 1, expr.j + 1)
+        return "{0}({1}, {2})".format(self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True), expr.i + 1, expr.j + 1)
 
     def _print_Add(self, expr):
         # purpose: print complex numbers nicely in Fortran.

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -12,7 +12,7 @@ from __future__ import print_function, division
 from sympy.core import S
 from sympy.codegen.ast import Assignment
 from sympy.printing.codeprinter import CodePrinter
-from sympy.printing.precedence import precedence
+from sympy.printing.precedence import precedence, PRECEDENCE
 from sympy.core.compatibility import string_types, range
 
 
@@ -160,8 +160,8 @@ class JavascriptCodePrinter(CodePrinter):
             return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
 
     def _print_MatrixElement(self, expr):
-        return "{0}[{1}]".format(expr.parent, expr.j +
-                expr.i*expr.parent.shape[1])
+        return "{0}[{1}]".format(self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True),
+                                 expr.j + expr.i * expr.parent.shape[1])
 
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -14,7 +14,7 @@ from sympy.core import Mul, Pow, S, Rational
 from sympy.core.compatibility import string_types, range
 from sympy.core.mul import _keep_coeff
 from sympy.printing.codeprinter import CodePrinter, Assignment
-from sympy.printing.precedence import precedence
+from sympy.printing.precedence import precedence, PRECEDENCE
 from re import search
 
 # List of known functions.  First, those that have the same name in
@@ -363,7 +363,7 @@ class JuliaCodePrinter(CodePrinter):
 
 
     def _print_MatrixElement(self, expr):
-        return self._print(expr.parent) + '[%s,%s]'%(expr.i+1, expr.j+1)
+        return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) + '[%s,%s]' % (expr.i + 1, expr.j + 1)
 
 
     def _print_MatrixSlice(self, expr):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1361,7 +1361,7 @@ class LatexPrinter(Printer):
                            = _print_MatrixBase
 
     def _print_MatrixElement(self, expr):
-        return self._print(expr.parent) + '_{%s, %s}'%(expr.i, expr.j)
+        return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) + '_{%s, %s}' % (expr.i, expr.j)
 
     def _print_MatrixSlice(self, expr):
         def latexslice(x):

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -16,7 +16,7 @@ from sympy.core.compatibility import string_types, range
 from sympy.core.mul import _keep_coeff
 from sympy.codegen.ast import Assignment
 from sympy.printing.codeprinter import CodePrinter
-from sympy.printing.precedence import precedence
+from sympy.printing.precedence import precedence, PRECEDENCE
 from re import search
 
 # List of known functions.  First, those that have the same name in
@@ -345,7 +345,7 @@ class OctaveCodePrinter(CodePrinter):
 
 
     def _print_MatrixElement(self, expr):
-        return self._print(expr.parent) + '(%s, %s)'%(expr.i+1, expr.j+1)
+        return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) + '(%s, %s)' % (expr.i + 1, expr.j + 1)
 
 
     def _print_MatrixSlice(self, expr):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -692,6 +692,7 @@ class PrettyPrinter(Printer):
                     Symbol(expr.parent.name + '_%d%d'%(expr.i, expr.j)))
         else:
             prettyFunc = self._print(expr.parent)
+            prettyFunc = prettyForm(*prettyFunc.parens())
             prettyIndices = self._print_seq((expr.i, expr.j), delimiter=', '
                     ).parens(left='[', right=']')[0]
             pform = prettyForm(binding=prettyForm.FUNC,

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5770,6 +5770,47 @@ def test_pretty_Mod():
     assert pretty(2 * Mod(x, 7)) == ascii_str5
     assert upretty(2 * Mod(x, 7)) == ucode_str5
 
+def test_MatrixElement_printing():
+    # test case from issue #11821
+    A = MatrixSymbol("A", 1, 3)
+    B = MatrixSymbol("B", 1, 3)
+    C = MatrixSymbol("C", 1, 3)
+    M = MatrixSymbol("M", 1, 3)
+
+    ascii_str1 = "A_00"
+    ucode_str1 = u("A₀₀")
+    assert pretty(A[0, 0]) == ascii_str1
+    assert upretty(A[0, 0]) == ucode_str1
+
+    ascii_str1 = "3*A_00"
+    ucode_str1 = u("3⋅A₀₀")
+    assert pretty(3 * A[0, 0]) == ascii_str1
+    assert upretty(3 * A[0, 0]) == ucode_str1
+
+    ascii_str1 = "(-B + A)[0, 0]"
+    ucode_str1 = u("(-B + A)[0, 0]")
+    E = A - B
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert pretty(F) == ascii_str1
+    assert upretty(F) == ucode_str1
+
+    ascii_str1 = "(-B + A + M)[0, 0]"
+    ucode_str1 = u("(-B + A + M)[0, 0]")
+    E = A - B + M
+    F = C[0, 0]
+    F = F.subs(C, E)
+
+    assert pretty(F) == ascii_str1
+    assert upretty(F) == ucode_str1
+
+    ascii_str1 = "(A + M)[0, 1]"
+    ucode_str1 = u("(A + M)[0, 1]")
+    E = A + M
+    F = C[0, 1]
+    F = F.subs(C, E)
+    assert pretty(F) == ascii_str1
+    assert upretty(F) == ucode_str1
 
 def test_issue_11801():
     assert pretty(Symbol("")) == ""

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -237,7 +237,7 @@ class StrPrinter(Printer):
         _print_MatrixBase
 
     def _print_MatrixElement(self, expr):
-        return self._print(expr.parent) + '[%s, %s]'%(expr.i, expr.j)
+        return self.parenthesize(expr.parent, PRECEDENCE["Atom"], strict=True) + '[%s, %s]' % (expr.i, expr.j)
 
     def _print_MatrixSlice(self, expr):
         def strslice(x):

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -491,6 +491,32 @@ def test_Matrix_printing():
         "M[7] = sqrt(q[0]) + 4;\n"
         "M[8] = 0;")
 
+def test_MatrixElement_printing():
+    # test cases for issue #11821
+    A = MatrixSymbol("A", 1, 3)
+    B = MatrixSymbol("B", 1, 3)
+    C = MatrixSymbol("C", 1, 3)
+    M = MatrixSymbol("M", 1, 3)
+
+    assert (ccode(A[0, 0]) == "A[0]")
+    assert (ccode(3 * A[0, 0]) == "3*A[0]")
+
+    E = A-B
+
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert (ccode(F) == "(-1)*B[0] + A[0]")
+
+    E = A - B + M
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert (ccode(F) == "(-1)*B[0] + A[0] + M[0]")
+
+    E = A + M
+    F = C[0, 1]
+    F = F.subs(C, E)
+    assert (ccode(F) == "A[1] + M[1]")
+
 
 def test_ccode_reserved_words():
     x, y = symbols('x, if')
@@ -513,6 +539,8 @@ def test_ccode_sign():
 def test_ccode_Assignment():
     assert ccode(Assignment(x, y + z)) == 'x = y + z;'
     assert ccode(aug_assign(x, '+', y + z)) == 'x += y + z;'
+
+
 
 
 def test_ccode_For():

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -685,3 +685,29 @@ def test_fcode_For():
     assert sol == ("      do x = 0, 10, 2\n"
                    "         y = x*y\n"
                    "      end do")
+
+
+def test_MatrixElement_printing():
+    # test cases for issue #11821
+    A = MatrixSymbol("A", 1, 3)
+    B = MatrixSymbol("B", 1, 3)
+    C = MatrixSymbol("C", 1, 3)
+    M = MatrixSymbol("M", 1, 3)
+
+    assert (fcode(A[0, 0]) == "      A(1, 1)")
+    assert (fcode(3 * A[0, 0]) == "      3*A(1, 1)")
+
+    E = A-B
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert(fcode(F) == "      ((-1)*B + A)(1, 1)")
+
+    E = A - B + M
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert (fcode(F) == "      ((-1)*B + A + M)(1, 1)")
+
+    E = A + M
+    F = C[0, 1]
+    F = F.subs(C, E)
+    assert (fcode(F) == "      (A + M)(1, 2)")

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -364,3 +364,14 @@ def test_Matrix_printing():
         "M[6] = 2*q[4]/q[1];\n"
         "M[7] = Math.sqrt(q[0]) + 4;\n"
         "M[8] = 0;")
+
+
+def test_MatrixElement_printing():
+    # test case from issue #11821
+    A = MatrixSymbol("A",1,3)
+    B = MatrixSymbol("B",1,3)
+    C = MatrixSymbol("C",1,3)
+    E = A-B
+    F = C[0,0]
+    F = F.subs(C,E)
+    assert(jscode(F) == "((-1)*B + A)[0]")

--- a/sympy/printing/tests/test_julia.py
+++ b/sympy/printing/tests/test_julia.py
@@ -362,3 +362,29 @@ def test_specfun():
     assert julia_code(hankel2(n, x)) == 'hankelh2(n, x)'
     assert julia_code(jn(n, x)) == 'sqrt(2)*sqrt(pi)*sqrt(1./x).*besselj(n + 1/2, x)/2'
     assert julia_code(yn(n, x)) == 'sqrt(2)*sqrt(pi)*sqrt(1./x).*bessely(n + 1/2, x)/2'
+
+
+def test_MatrixElement_printing():
+    # test cases for issue #11821
+    A = MatrixSymbol("A", 1, 3)
+    B = MatrixSymbol("B", 1, 3)
+    C = MatrixSymbol("C", 1, 3)
+    M = MatrixSymbol("M", 1, 3)
+
+    assert (julia_code(A[0, 0]) == "A[1,1]")
+    assert (julia_code(3 * A[0, 0]) == "3*A[1,1]")
+
+    E = A-B
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert(julia_code(F) == "((-1)*B + A)[1,1]")
+
+    E = A - B + M
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert (julia_code(F) == "((-1)*B + A + M)[1,1]")
+
+    E = A + M
+    F = C[0, 1]
+    F = F.subs(C, E)
+    assert (julia_code(F) == "(A + M)[1,2]")

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -35,6 +35,7 @@ from sympy.physics.quantum import Commutator, Operator
 from sympy.core.trace import Tr
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
+from sympy import MatrixSymbol
 
 x, y, z, t, a, b = symbols('x y z t a b')
 k, m, n = symbols('k m n', integer=True)
@@ -1585,6 +1586,31 @@ def test_issue_10489():
     s = Symbol(latexSymbolWithBrace)
     assert latex(s) == latexSymbolWithBrace
     assert latex(cos(s)) == r'\cos{\left (C_{x_{0}} \right )}'
+
+
+def test_MatrixElement_printing():
+    # test cases for issue #11821
+    A = MatrixSymbol("A", 1, 3)
+    B = MatrixSymbol("B", 1, 3)
+    C = MatrixSymbol("C", 1, 3)
+    M = MatrixSymbol("M", 1, 3)
+
+    assert latex(A[0, 0]) == r"A_{0, 0}"
+    assert latex(3 * A[0, 0]) == r"3 A_{0, 0}"
+    E = A-B
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert latex(F) == r"\left(-1 B + A\right)_{0, 0}"
+
+    E = A - B + M
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert latex(F) == r"\left(-1 B + A + M\right)_{0, 0}"
+
+    E = A + M
+    F = C[0, 1]
+    F = F.subs(C, E)
+    assert latex(F) == r"\left(A + M\right)_{0, 1}"
 
 
 def test_latex_UnevaluatedExpr():

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -377,3 +377,28 @@ def test_specfun():
     assert octave_code(yn(n, x)) == 'sqrt(2)*sqrt(pi)*sqrt(1./x).*bessely(n + 1/2, x)/2'
     assert octave_code(LambertW(x)) == 'lambertw(x)'
     assert octave_code(LambertW(x, n)) == 'lambertw(n, x)'
+
+
+def test_MatrixElement_printing():
+    # test case from issue #11821
+    A = MatrixSymbol("A", 1, 3)
+    B = MatrixSymbol("B", 1, 3)
+    C = MatrixSymbol("C", 1, 3)
+
+    assert mcode(A[0, 0]) == "A(1, 1)"
+    assert mcode(3 * A[0, 0]) == "3*A(1, 1)"
+
+    E = A-B
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert mcode(F) == "((-1)*B + A)(1, 1)"
+
+    E = A - B + M
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert mcode(F) == "((-1)*B + A + M)(1, 1)"
+
+    E = A + M
+    F = C[0, 1]
+    F = F.subs(C, E)
+    assert mcode(F) == "(A + M)(1, 2)"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -17,6 +17,7 @@ from sympy.core.compatibility import range
 
 from sympy.printing import sstr, sstrrepr, StrPrinter
 from sympy.core.trace import Tr
+from sympy import MatrixSymbol
 
 x, y, z, w = symbols('x,y,z,w')
 d = Dummy('d')
@@ -752,6 +753,31 @@ def test_SymmetricDifference():
     assert str(SymmetricDifference(Interval(2, 3), Interval(3, 4),evaluate=False)) == \
            'SymmetricDifference(Interval(2, 3), Interval(3, 4))'
 
+
+def test_MatrixElement_printing():
+    # test case from issue #11821
+    A = MatrixSymbol("A", 1, 3)
+    B = MatrixSymbol("B", 1, 3)
+    C = MatrixSymbol("C", 1, 3)
+    M = MatrixSymbol("M", 1, 3)
+
+    assert (str(A[0, 0]) == "A[0, 0]")
+    assert (str(3 * A[0, 0]) == "3*A[0, 0]")
+
+    E = A-B
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert str(F) == "((-1)*B + A)[0, 0]"
+
+    E = A - B + M
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert str(F) == "((-1)*B + A + M)[0, 0]"
+
+    E = A + M
+    F = C[0, 0]
+    F = F.subs(C, E)
+    assert str(F) == "(A + M)[0, 0]"
 
 def test_UnevaluatedExpr():
     a, b = symbols("a b")


### PR DESCRIPTION
Fixed the bug in _print_MatrixElement method so as to correctly
output the results of operations between two matrices.

Fixes https://github.com/sympy/sympy/issues/11821

