### PR TITLE
pickling: Fix to make the pickling test pass

### DIFF
--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -84,7 +84,7 @@ def test_core_basic():
               Basic, Basic(),
               # XXX: dynamically created types are not picklable
               # BasicMeta, BasicMeta("test", (), {}),
-              SingletonRegistry, SingletonRegistry()):
+              SingletonRegistry, S):
         check(c)
 
 


### PR DESCRIPTION


SingletonRegistry() is already instantiated in `sympy.core.singleton` as `S`
Replaces `SingletonRegistry()` with `S` in `sympy.utilities.tests.test_pickling.py`

Fixes #12067