### PR TITLE
Fixes Issue #6599 : correctly evaluates limit((n+cos(n))/n,n,oo)

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -10,6 +10,8 @@ from sympy.functions.special.gamma_functions import gamma
 from sympy.series.order import Order
 from .gruntz import gruntz
 from sympy.core.exprtools import factor_terms
+from sympy.simplify.ratsimp import ratsimp
+from sympy.polys import PolynomialError
 
 def limit(e, z, z0, dir="+"):
     """
@@ -49,7 +51,6 @@ def limit(e, z, z0, dir="+"):
 
 def heuristics(e, z, z0, dir):
     rv = None
-
     if abs(z0) is S.Infinity:
         rv = limit(e.subs(z, 1/z), z, S.Zero, "+" if z0 is S.Infinity else "-")
         if isinstance(rv, Limit):
@@ -69,8 +70,13 @@ def heuristics(e, z, z0, dir):
         if r:
             rv = e.func(*r)
             if rv is S.NaN:
-                return
-
+                try:
+                    rat_e = ratsimp(e)
+                except PolynomialError:
+                    return
+                if rat_e is S.NaN or rat_e == e:
+                    return
+                return limit(rat_e, z, z0, dir)
     return rv
 
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -483,13 +483,20 @@ def test_limit_seq():
     assert (limit(Sum(y**2 * Sum(2**z/z, (z, 1, y)), (y, 1, x)) /
                   (2**x*x), x, oo) == 4)
 
+
 def test_issue_11879():
     assert simplify(limit(((x+y)**n-x**n)/y, y, 0)) == n*x**(n-1)
+
 
 def test_limit_with_Float():
     k = symbols("k")
     assert limit(1.0 ** k, k, oo) == 1
     assert limit(0.3*1.0**k, k, oo) == Float(0.3)
 
+
 def test_issue_10610():
     assert limit(3**x*3**(-x - 1)*(x + 1)**2/x**2, x, oo) == S(1)/3
+
+
+def test_issue_6599():
+    assert limit((n + cos(n))/n, n, oo) == 1


### PR DESCRIPTION
This is in reference to issue #6599.

Correctly evaluates `limit((n+cos(n))/n,n,oo) = 1` .