### PR TITLE
Improve plane class

### DIFF
--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -418,7 +418,6 @@ class Plane(GeometryEntity):
                 if len(h) == 2:
                     return [Line3D(Point3D(0, h[y], h[z]), direction_ratio=c)]
 
-
     def is_coplanar(self, o):
         """ Returns True if `o` is coplanar with self, else False.
 

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -7,6 +7,7 @@ Plane
 """
 from __future__ import division, print_function
 
+from sympy import simplify
 from sympy.core import Dummy, Rational, S, Symbol
 from sympy.core.compatibility import is_sequence
 from sympy.functions.elementary.trigonometric import acos, asin, sqrt
@@ -279,6 +280,31 @@ class Plane(GeometryEntity):
             f = sqrt(sum([i**2 for i in self.normal_vector]))
             return abs(e / f)
 
+    def equals(self, o):
+        """
+        Returns True if self and o are the same mathematical entities.
+
+        Examples
+        ========
+
+        >>> from sympy import Plane, Point3D
+        >>> a = Plane(Point3D(1, 2, 3), normal_vector=(1, 1, 1))
+        >>> b = Plane(Point3D(1, 2, 3), normal_vector=(2, 2, 2))
+        >>> c = Plane(Point3D(1, 2, 3), normal_vector=(-1, 4, 6))
+        >>> a.equals(a)
+        True
+        >>> a.equals(b)
+        True
+        >>> a.equals(c)
+        False
+        """
+        if isinstance(o, Plane):
+            a = self.equation()
+            b = o.equation()
+            return simplify(a / b).is_constant()
+        else:
+            return False
+
     def equation(self, x=None, y=None, z=None):
         """The equation of the Plane.
 
@@ -391,6 +417,7 @@ class Plane(GeometryEntity):
                 h = solve((d.subs(x, 0), e.subs(x, 0)),[y, z])
                 if len(h) == 2:
                     return [Line3D(Point3D(0, h[y], h[z]), direction_ratio=c)]
+
 
     def is_coplanar(self, o):
         """ Returns True if `o` is coplanar with self, else False.

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -392,7 +392,7 @@ class Plane(GeometryEntity):
                         return []  # e.g. a segment might not intersect a plane
                     return [p]
         if isinstance(o, Plane):
-            if o == self:
+            if self.equals(o):
                 return [self]
             if self.is_parallel(o):
                 return []

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -71,7 +71,6 @@ def test_plane():
                Ray3D(Point3D(14/3, 11/3, 11/3), Point3D(13/3, 13/3, 10/3))
     assert pl3.perpendicular_line(r.args) == pl3.perpendicular_line(r)
 
-
     assert pl3.is_parallel(pl6) is False
     assert pl4.is_parallel(pl6)
     assert pl6.is_parallel(l1) is False

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -160,7 +160,7 @@ def test_plane():
 
     assert pl3.random_point() in pl3
 
-    #test geometrical entity using equals
+    # test geometrical entity using equals
     assert pl4.intersection(pl4.p1)[0].equals(pl4.p1)
     assert pl3.intersection(pl6)[0].equals(Line3D(Point3D(8, 4, 0), Point3D(2, 4, 6)))
     pl8 = Plane((1, 2, 0), normal_vector=(0, 0, 1))

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -167,6 +167,7 @@ def test_plane():
     assert pl8.intersection(Line3D(p1, (1, 12, 0)))[0].equals(Line((0, 0, 0), (0.1, 1.2, 0)))
     assert pl8.intersection(Ray3D(p1, (1, 12, 0)))[0].equals(Ray((0, 0, 0), (1, 12, 0)))
     assert pl8.intersection(Segment3D(p1, (21, 1, 0)))[0].equals(Segment3D(p1, (21, 1, 0)))
+    assert pl8.intersection(Plane(p1, normal_vector=(0, 0, 112)))[0].equals(pl8)
     assert pl8.intersection(Plane(p1, normal_vector=(0, 12, 0)))[0].equals(
         Line3D(p1, direction_ratio=(112 * pi, 0, 0)))
     assert pl8.intersection(Plane(p1, normal_vector=(11, 0, 1)))[0].equals(

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -160,6 +160,30 @@ def test_plane():
 
     assert pl3.random_point() in pl3
 
+    #test geometrical entity using equals
+    assert pl4.intersection(pl4.p1)[0].equals(pl4.p1)
+    assert pl3.intersection(pl6)[0].equals(Line3D(Point3D(8, 4, 0), Point3D(2, 4, 6)))
+    pl8 = Plane((1, 2, 0), normal_vector=(0, 0, 1))
+    assert pl8.intersection(Line3D(p1, (1, 12, 0)))[0].equals(Line((0, 0, 0), (0.1, 1.2, 0)))
+    assert pl8.intersection(Ray3D(p1, (1, 12, 0)))[0].equals(Ray((0, 0, 0), (1, 12, 0)))
+    assert pl8.intersection(Segment3D(p1, (21, 1, 0)))[0].equals(Segment3D(p1, (21, 1, 0)))
+    assert pl8.intersection(Plane(p1, normal_vector=(0, 12, 0)))[0].equals(
+        Line3D(p1, direction_ratio=(112 * pi, 0, 0)))
+    assert pl8.intersection(Plane(p1, normal_vector=(11, 0, 1)))[0].equals(
+        Line3D(p1, direction_ratio=(0, -11, 0)))
+    assert pl8.intersection(Plane(p1, normal_vector=(1, 0, 11)))[0].equals(
+        Line3D(p1, direction_ratio=(0, 11, 0)))
+    assert pl8.intersection(Plane(p1, normal_vector=(-1, -1, -11)))[0].equals(
+        Line3D(p1, direction_ratio=(1, -1, 0)))
+    assert pl3.random_point() in pl3
+    assert len(pl8.intersection(Ray3D(Point3D(0, 2, 3), Point3D(1, 0, 3)))) is 0
+    # check if two plane are equals
+    assert pl6.intersection(pl6)[0].equals(pl6)
+    assert pl8.equals(Plane(p1, normal_vector=(0, 12, 0))) is False
+    assert pl8.equals(pl8)
+    assert pl8.equals(Plane(p1, normal_vector=(0, 0, -12)))
+    assert pl8.equals(Plane(p1, normal_vector=(0, 0, -12*sqrt(3))))
+
     # issue 8570
     l2 = Line3D(Point3D(S(50000004459633)/5000000000000,
                         -S(891926590718643)/1000000000000000,


### PR DESCRIPTION
I've added a method `equals()` in the `Plane` class (overriding a method from the base class, `GeometryEntity`) and I've changed a condition in the `intersection()` method there to use `equals`.

My motivation was that, I created new tests and one of them (`sympy/geometry/tests/tests_plane:170`) didn't pass (before changes). The reason was that the mentioned condition in `intersection():366` checked if given planes are equal as objects not as geometrical entities. If we pass a different object, which represents the same plane, as a result of intersection we should get the whole plane, but the result was an empty list. What's more, if we wanted to use method `equals()` before, we also got wrong result, because the method from this base class was used.