### PR TITLE
v2pt_theory: Added zero velocity constraint requirement.

### DIFF
--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -380,7 +380,7 @@ class Point(object):
         v1 = self.vel(interframe)
         v2 = otherpoint.vel(outframe)
         omega = interframe.ang_vel_in(outframe)
-        otherpoint.set_vel(fixedframe, 0)
+        otherpoint.set_vel(interframe, 0)
         self.set_vel(outframe, v1 + v2 + (omega ^ dist))
         return self.vel(outframe)
 

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -380,6 +380,7 @@ class Point(object):
         v1 = self.vel(interframe)
         v2 = otherpoint.vel(outframe)
         omega = interframe.ang_vel_in(outframe)
+        otherpoint.set_vel(fixedframe, 0)
         self.set_vel(outframe, v1 + v2 + (omega ^ dist))
         return self.vel(outframe)
 
@@ -427,6 +428,7 @@ class Point(object):
         omega = fixedframe.ang_vel_in(outframe)
         self.set_vel(outframe, v + (omega ^ dist))
         self.set_vel(fixedframe, 0)
+        otherpoint.set_vel(fixedframe, 0)
         return self.vel(outframe)
 
     def vel(self, frame):

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -426,6 +426,7 @@ class Point(object):
         v = otherpoint.vel(outframe)
         omega = fixedframe.ang_vel_in(outframe)
         self.set_vel(outframe, v + (omega ^ dist))
+        self.set_vel(fixedframe, 0)
         return self.vel(outframe)
 
     def vel(self, frame):

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -18,6 +18,7 @@ def test_point_v1pt_theorys():
     assert P.v1pt_theory(O, N, B) == N.x + qd * B.y
     P.set_vel(B, B.z)
     assert P.v1pt_theory(O, N, B) == B.z + N.x + qd * B.y
+    assert O.vel(B) == 0
 
 
 def test_point_a1pt_theorys():
@@ -52,7 +53,7 @@ def test_point_v2pt_theorys():
     assert P.v2pt_theory(O, N, B) == (qd * B.z ^ B.x)
     O.set_vel(N, N.x)
     assert P.v2pt_theory(O, N, B) == N.x + qd * B.y
-
+    assert O.vel(B) == 0
 
 def test_point_a2pt_theorys():
     q = dynamicsymbols('q')


### PR DESCRIPTION
I'm unsure if what I am adding here, which is a trivial detail, was
intentionally left out; here is the description of what I have done:
P and O are two points of a rigid body B that is moving in frame N.
The velocity of P in N, N^v^P, can be computed using v2pt_theory,
which it does admirably. However, the function should also set
B^v^P = 0; that is what I have added. In fact, the function should
likely also constrain the B^v^O to be 0; that is what makes P and O
2 points of the same body.
Further, this constraint of B^v^O should also likely be added to v1pt
theory. If you agree, I can commit changes to that next time, as well.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below.>
