### PR TITLE
matrices: det_LU_decomposition() handles singular matrices

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3888,60 +3888,22 @@ class MatrixBase(MatrixOperations, MatrixProperties, MatrixShaping):
         LUdecompositionFF
         LUsolve
         """
-
         combined, p = self.LUdecomposition_Simple(iszerofunc=_iszero)
-
-        L = self.zeros(combined.rows)
-        U = self.zeros(combined.rows, combined.cols)
-
-        # L is lower triangular self.rows x self.rows
-        # U is upper triangular self.rows x self.cols
-        # L has unit diagonal. For each column in combined, the subcolumn below the diagonal of combined is shared by L.
-        # If L has more columns than combined, then the remaining subcolumns below the diagonal of L are zero.
-        # The upper triangular portion of L and combined are equal.
-
-        max_index = min(self.rows, self.cols)
-
-        # Set diagonal entry to 1, and subdiagonal entries of L to subdiagonal entries of combined
-        for col_i in range(max_index):
-
-            L[col_i, col_i] = 1
-
-            for row_i in range(col_i + 1, L.rows):
-
-                L[row_i, col_i] = combined[row_i, col_i]
-
-                row_i += 1
-
-        # Fill in the remaining diagonal entries of L
-        for col_i in range(max_index, L.cols):
-
-            L[col_i, col_i] = 1
-
-        # Set upper triangular portion of U to upper triangular portion of combined
-        for row_i in range(max_index):
-
-            for col_i in range(row_i, U.cols):
-
-                U[row_i, col_i] = combined[row_i, col_i]
-
+        L = self.zeros(self.rows)
+        U = self.zeros(self.rows)
+        for i in range(self.rows):
+            for j in range(self.rows):
+                if i > j:
+                    L[i, j] = combined[i, j]
+                else:
+                    if i == j:
+                        L[i, i] = 1
+                    U[i, j] = combined[i, j]
         return L, U, p
 
     def LUdecomposition_Simple(self, iszerofunc=_iszero):
-
-        """Compute an lu decomposition of m x n matrix A, where
-        P*A = L*U
-        L is m x m lower triangular with unit diagonal
-        U is m x n upper triangular
-        P is an m x m permutation matrix
-        Returns an m x n matrix lu, and m element list perm where each element of perm is a two element list of row
-        exchange indices.
-        The factors L and U are encoded in lu.
-        The subdiagonal elements of L are stored in the subdiagonal elements of lu, that is lu[i, j] = L[i, j]
-        whenever i > j.
-        The diagonal of L, which is the identity matrix, is not explicitly stored.
-        U is stored in the upper triangular portion of lu, that is lu[i ,j] = U[i, j] whenever i >= j.
-        perm contains the integers in range(0, m), where each integer occurs exactly once.
+        """Returns A comprised of L, U (L's diag entries are 1) and
+        p which is the list of the row swaps (in order).
 
         See Also
         ========
@@ -3950,87 +3912,35 @@ class MatrixBase(MatrixOperations, MatrixProperties, MatrixShaping):
         LUdecompositionFF
         LUsolve
         """
-
-        if self.rows == 0 or self.cols == 0:
-
-            raise ValueError('Matrix must have at least one entry to apply LUdecomposition_Simple().')
-
-        lu = self.as_mutable()
-
-        pivot_col = 0
-
-        row_swaps = []
-
-        for pivot_row in range(0, lu.rows-1):
-
-            if iszerofunc(lu[pivot_row, pivot_col]):
-                # Search for non-zero pivot.
-                pivot_row_cand = pivot_row
-
-                while True:
-
-                    # Guarantee at top of loop: pivot_row_cand < lu.rows and pivot_col < lu.cols
-                    pivot_row_cand += 1
-
-                    if pivot_row_cand == lu.rows:
-
-                        # All candidate pivots in the pivot column are zero.
-                        # New pivot column is next column to the right.
-                        pivot_row_cand = pivot_row
-                        pivot_col += 1
-
-                        if pivot_col == lu.cols:
-
-                            # All candidate pivots are zero implies that Gaussian elimination is complete.
-                            return lu, row_swaps
-
-                    if not iszerofunc(lu[pivot_row_cand, pivot_col]):
-
-                        break
-
-                if pivot_row != pivot_row_cand:
-                    # Row swap book keeping:
-                    # Record which rows were swapped.
-                    # Update stored portion of L factor by multiplying L on the left and right with the current
-                    # permutation.
-                    # Swap rows of U.
-                    row_swaps.append([pivot_row, pivot_row_cand])
-
-                    # Update L.
-                    for col in range(0, pivot_row):
-                        tmp = lu[pivot_row, col]
-                        lu[pivot_row, col] = lu[pivot_row_cand, col]
-                        lu[pivot_row_cand, col] = tmp
-
-                    # Swap rows of U in the pivot column.
-                    lu[pivot_row, pivot_col] = lu[pivot_row_cand, pivot_col]
-                    lu[pivot_row_cand, pivot_col] = 0
-
-                    for col in range(pivot_col+1, lu.shape[1]):
-
-                        tmp = lu[pivot_row, col]
-                        lu[pivot_row, col] = lu[pivot_row_cand, col]
-                        lu[pivot_row_cand, col] = tmp
-
-            for row in range(pivot_row + 1, lu.rows):
-
-                # Store factors of L in the subcolumn below (pivot_row, pivot_row).
-                lu[row, pivot_row] = lu[row, pivot_col]/lu[pivot_row, pivot_col]
-
-                # Add multiple of pivot row to row below it.
-                # Two loops to handle case where pivot_col > pivot_row
-
-                for col in range(1 + pivot_row if pivot_row == pivot_col else pivot_col, lu.cols):
-
-                    lu[row, col] -= lu[row, pivot_row] * lu[pivot_row, col]
-
-            pivot_col += 1
-
-            if pivot_col == lu.cols:
-                # All candidate pivots are zero implies that Gaussian elimination is complete.
-                return lu, row_swaps
-
-        return lu, row_swaps
+        if not self.is_square:
+            raise NonSquareMatrixError(
+                "A Matrix must be square to apply LUdecomposition_Simple().")
+        n = self.rows
+        A = self.as_mutable()
+        p = []
+        # factorization
+        for j in range(n):
+            for i in range(j):
+                for k in range(i):
+                    A[i, j] = A[i, j] - A[i, k] * A[k, j]
+            pivot = -1
+            for i in range(j, n):
+                for k in range(j):
+                    A[i, j] = A[i, j] - A[i, k] * A[k, j]
+                # find the first non-zero pivot, includes any expression
+                if pivot == -1 and not iszerofunc(A[i, j]):
+                    pivot = i
+            if pivot < 0:
+                # this result is based on iszerofunc's analysis of the possible pivots, so even though
+                # the element may not be strictly zero, the supplied iszerofunc's evaluation gave True
+                raise ValueError("No nonzero pivot found; inversion failed.")
+            if pivot != j:  # row must be swapped
+                A.row_swap(pivot, j)
+                p.append([pivot, j])
+            scale = 1 / A[j, j]
+            for i in range(j + 1, n):
+                A[i, j] = A[i, j] * scale
+        return A, p
 
     def LUdecompositionFF(self):
         """Compute a fraction-free LU decomposition.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3888,22 +3888,60 @@ class MatrixBase(MatrixOperations, MatrixProperties, MatrixShaping):
         LUdecompositionFF
         LUsolve
         """
+
         combined, p = self.LUdecomposition_Simple(iszerofunc=_iszero)
-        L = self.zeros(self.rows)
-        U = self.zeros(self.rows)
-        for i in range(self.rows):
-            for j in range(self.rows):
-                if i > j:
-                    L[i, j] = combined[i, j]
-                else:
-                    if i == j:
-                        L[i, i] = 1
-                    U[i, j] = combined[i, j]
+
+        L = self.zeros(combined.rows)
+        U = self.zeros(combined.rows, combined.cols)
+
+        # L is lower triangular self.rows x self.rows
+        # U is upper triangular self.rows x self.cols
+        # L has unit diagonal. For each column in combined, the subcolumn below the diagonal of combined is shared by L.
+        # If L has more columns than combined, then the remaining subcolumns below the diagonal of L are zero.
+        # The upper triangular portion of L and combined are equal.
+
+        max_index = min(self.rows, self.cols)
+
+        # Set diagonal entry to 1, and subdiagonal entries of L to subdiagonal entries of combined
+        for col_i in range(max_index):
+
+            L[col_i, col_i] = 1
+
+            for row_i in range(col_i + 1, L.rows):
+
+                L[row_i, col_i] = combined[row_i, col_i]
+
+                row_i += 1
+
+        # Fill in the remaining diagonal entries of L
+        for col_i in range(max_index, L.cols):
+
+            L[col_i, col_i] = 1
+
+        # Set upper triangular portion of U to upper triangular portion of combined
+        for row_i in range(max_index):
+
+            for col_i in range(row_i, U.cols):
+
+                U[row_i, col_i] = combined[row_i, col_i]
+
         return L, U, p
 
     def LUdecomposition_Simple(self, iszerofunc=_iszero):
-        """Returns A comprised of L, U (L's diag entries are 1) and
-        p which is the list of the row swaps (in order).
+
+        """Compute an lu decomposition of m x n matrix A, where
+        P*A = L*U
+        L is m x m lower triangular with unit diagonal
+        U is m x n upper triangular
+        P is an m x m permutation matrix
+        Returns an m x n matrix lu, and m element list perm where each element of perm is a two element list of row
+        exchange indices.
+        The factors L and U are encoded in lu.
+        The subdiagonal elements of L are stored in the subdiagonal elements of lu, that is lu[i, j] = L[i, j]
+        whenever i > j.
+        The diagonal of L, which is the identity matrix, is not explicitly stored.
+        U is stored in the upper triangular portion of lu, that is lu[i ,j] = U[i, j] whenever i >= j.
+        perm contains the integers in range(0, m), where each integer occurs exactly once.
 
         See Also
         ========
@@ -3912,35 +3950,87 @@ class MatrixBase(MatrixOperations, MatrixProperties, MatrixShaping):
         LUdecompositionFF
         LUsolve
         """
-        if not self.is_square:
-            raise NonSquareMatrixError(
-                "A Matrix must be square to apply LUdecomposition_Simple().")
-        n = self.rows
-        A = self.as_mutable()
-        p = []
-        # factorization
-        for j in range(n):
-            for i in range(j):
-                for k in range(i):
-                    A[i, j] = A[i, j] - A[i, k] * A[k, j]
-            pivot = -1
-            for i in range(j, n):
-                for k in range(j):
-                    A[i, j] = A[i, j] - A[i, k] * A[k, j]
-                # find the first non-zero pivot, includes any expression
-                if pivot == -1 and not iszerofunc(A[i, j]):
-                    pivot = i
-            if pivot < 0:
-                # this result is based on iszerofunc's analysis of the possible pivots, so even though
-                # the element may not be strictly zero, the supplied iszerofunc's evaluation gave True
-                raise ValueError("No nonzero pivot found; inversion failed.")
-            if pivot != j:  # row must be swapped
-                A.row_swap(pivot, j)
-                p.append([pivot, j])
-            scale = 1 / A[j, j]
-            for i in range(j + 1, n):
-                A[i, j] = A[i, j] * scale
-        return A, p
+
+        if self.rows == 0 or self.cols == 0:
+
+            raise ValueError('Matrix must have at least one entry to apply LUdecomposition_Simple().')
+
+        lu = self.as_mutable()
+
+        pivot_col = 0
+
+        row_swaps = []
+
+        for pivot_row in range(0, lu.rows-1):
+
+            if iszerofunc(lu[pivot_row, pivot_col]):
+                # Search for non-zero pivot.
+                pivot_row_cand = pivot_row
+
+                while True:
+
+                    # Guarantee at top of loop: pivot_row_cand < lu.rows and pivot_col < lu.cols
+                    pivot_row_cand += 1
+
+                    if pivot_row_cand == lu.rows:
+
+                        # All candidate pivots in the pivot column are zero.
+                        # New pivot column is next column to the right.
+                        pivot_row_cand = pivot_row
+                        pivot_col += 1
+
+                        if pivot_col == lu.cols:
+
+                            # All candidate pivots are zero implies that Gaussian elimination is complete.
+                            return lu, row_swaps
+
+                    if not iszerofunc(lu[pivot_row_cand, pivot_col]):
+
+                        break
+
+                if pivot_row != pivot_row_cand:
+                    # Row swap book keeping:
+                    # Record which rows were swapped.
+                    # Update stored portion of L factor by multiplying L on the left and right with the current
+                    # permutation.
+                    # Swap rows of U.
+                    row_swaps.append([pivot_row, pivot_row_cand])
+
+                    # Update L.
+                    for col in range(0, pivot_row):
+                        tmp = lu[pivot_row, col]
+                        lu[pivot_row, col] = lu[pivot_row_cand, col]
+                        lu[pivot_row_cand, col] = tmp
+
+                    # Swap rows of U in the pivot column.
+                    lu[pivot_row, pivot_col] = lu[pivot_row_cand, pivot_col]
+                    lu[pivot_row_cand, pivot_col] = 0
+
+                    for col in range(pivot_col+1, lu.shape[1]):
+
+                        tmp = lu[pivot_row, col]
+                        lu[pivot_row, col] = lu[pivot_row_cand, col]
+                        lu[pivot_row_cand, col] = tmp
+
+            for row in range(pivot_row + 1, lu.rows):
+
+                # Store factors of L in the subcolumn below (pivot_row, pivot_row).
+                lu[row, pivot_row] = lu[row, pivot_col]/lu[pivot_row, pivot_col]
+
+                # Add multiple of pivot row to row below it.
+                # Two loops to handle case where pivot_col > pivot_row
+
+                for col in range(1 + pivot_row if pivot_row == pivot_col else pivot_col, lu.cols):
+
+                    lu[row, col] -= lu[row, pivot_row] * lu[pivot_row, col]
+
+            pivot_col += 1
+
+            if pivot_col == lu.cols:
+                # All candidate pivots are zero implies that Gaussian elimination is complete.
+                return lu, row_swaps
+
+        return lu, row_swaps
 
     def LUdecompositionFF(self):
         """Compute a fraction-free LU decomposition.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -603,25 +603,6 @@ def test_LUdecomp():
     assert U.is_upper
     assert (L*U).permuteBkwd(p) - testmat == zeros(4)
 
-    # non-square
-    testmat = Matrix([[1, 2, 3],
-                      [4, 5, 6],
-                      [7, 8, 9],
-                      [10, 11, 12]])
-    L, U, p = testmat.LUdecomposition()
-    assert L.is_lower
-    assert U.is_upper
-    assert (L*U).permuteBkwd(p) - testmat == zeros(4, 3)
-
-    # square and singular
-    testmat = Matrix([[1, 2, 3],
-                      [2, 4, 6],
-                      [4, 5, 6]])
-    L, U, p = testmat.LUdecomposition()
-    assert L.is_lower
-    assert U.is_upper
-    assert (L*U).permuteBkwd(p) - testmat == zeros(3)
-
     M = Matrix(((1, x, 1), (2, y, 0), (y, 0, z)))
     L, U, p = M.LUdecomposition()
     assert L.is_lower
@@ -1805,6 +1786,8 @@ def test_errors():
     raises(MatrixError, lambda: Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]
            ]).QRdecomposition())
     raises(MatrixError, lambda: Matrix(1, 2, [1, 2]).QRdecomposition())
+    raises(
+        NonSquareMatrixError, lambda: Matrix([1, 2]).LUdecomposition_Simple())
     raises(ValueError, lambda: Matrix([[1, 2], [3, 4]]).minorEntry(4, 5))
     raises(ValueError, lambda: Matrix([[1, 2], [3, 4]]).minorMatrix(4, 5))
     raises(TypeError, lambda: Matrix([1, 2, 3]).cross(1))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -603,6 +603,25 @@ def test_LUdecomp():
     assert U.is_upper
     assert (L*U).permuteBkwd(p) - testmat == zeros(4)
 
+    # non-square
+    testmat = Matrix([[1, 2, 3],
+                      [4, 5, 6],
+                      [7, 8, 9],
+                      [10, 11, 12]])
+    L, U, p = testmat.LUdecomposition()
+    assert L.is_lower
+    assert U.is_upper
+    assert (L*U).permuteBkwd(p) - testmat == zeros(4, 3)
+
+    # square and singular
+    testmat = Matrix([[1, 2, 3],
+                      [2, 4, 6],
+                      [4, 5, 6]])
+    L, U, p = testmat.LUdecomposition()
+    assert L.is_lower
+    assert U.is_upper
+    assert (L*U).permuteBkwd(p) - testmat == zeros(3)
+
     M = Matrix(((1, x, 1), (2, y, 0), (y, 0, z)))
     L, U, p = M.LUdecomposition()
     assert L.is_lower
@@ -1786,8 +1805,6 @@ def test_errors():
     raises(MatrixError, lambda: Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]
            ]).QRdecomposition())
     raises(MatrixError, lambda: Matrix(1, 2, [1, 2]).QRdecomposition())
-    raises(
-        NonSquareMatrixError, lambda: Matrix([1, 2]).LUdecomposition_Simple())
     raises(ValueError, lambda: Matrix([[1, 2], [3, 4]]).minorEntry(4, 5))
     raises(ValueError, lambda: Matrix([[1, 2], [3, 4]]).minorMatrix(4, 5))
     raises(TypeError, lambda: Matrix([1, 2, 3]).cross(1))


### PR DESCRIPTION
Addresses issue #12321.
This pull request extends the functionality of
matrices.det_LU_decomposition() so that it returns zero when
passed a singular matrix instead of raising a ValueError.

Current behvior:
>>> A=sympy.Matrix([[1, 2], [1, 2]])
>>> A.det_LU_decomposition()
Traceback (most recent call last):
File "<stdin>", line 1, in <module>```
File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/sympy/matrices/matrices.py", line 2602, in det_LU_decomposition
    l, u, p = M.LUdecomposition()
File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/sympy/matrices/matrices.py", line 1333, in LUdecomposition
    combined, p = self.LUdecomposition_Simple(iszerofunc=_iszero)
File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/sympy/matrices/matrices.py", line 1377, in LUdecomposition_Simple
    raise ValueError("No nonzero pivot found; inversion failed.")
ValueError: No nonzero pivot found; inversion failed.

New behavior:
>>> A=sympy.Matrix([[1, 2], [1, 2]])
>>> A.det_LU_decomposition()
0

This new behavior is implemented by catching the ValueError that
LUdecomposition_Simple() raises when it cannot find a nonzero
pivot, and returning zero from the except statement.
This is not a terribly robust approach, since future versions of
LUdecomposition_Simple() may raise a ValueError for some other reason.
See pull request #12218 for an extension to LUdecomposition_Simple()
that will make det_LU_decomposition() handle all square matrices.