### PR TITLE
Typos in the files in  /examples/intermediate have been fixed.

### DIFF
--- a/examples/intermediate/trees.py
+++ b/examples/intermediate/trees.py
@@ -9,7 +9,7 @@ and paste in the sequence returned by this script:
 
 1, 1, 1, 1, 2, 3, 6, 11, 23, 47, 106
 
-and it will shows you the A000055
+and it will show you the A000055
 """
 
 from sympy import Symbol, Poly

--- a/examples/intermediate/vandermonde.py
+++ b/examples/intermediate/vandermonde.py
@@ -80,7 +80,7 @@ def gen_poly(points, order, syms):
         raise ValueError("Must provide points")
     dim = len(points[0]) - 1
     if dim > len(syms):
-        raise ValueError("Must provide at lease %d symbols for the polynomial" % dim)
+        raise ValueError("Must provide at least %d symbols for the polynomial" % dim)
     V, tmp_syms, terms = vandermonde(order, dim)
     if num_pts < V.shape[0]:
         raise ValueError(


### PR DESCRIPTION
I could identify two typo errors in the files `trees.py` and `vandermonde.py`. They have been corrected.


