### PR TITLE
Incorrect test case in limits

### DIFF
--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -233,6 +233,7 @@ def test_AccumBounds():
 
     assert limit(frac(x)**x, x, oo) == AccumBounds(0, oo)
     assert limit(((sin(x) + 1)/2)**x, x, oo) == AccumBounds(0, oo)
+    # Possible improvement: AccumBounds(0, 1)
 
 
 @XFAIL


### PR DESCRIPTION
`limit(((sin(x) + 1)/2)**x, x, oo)` should return `AccumBounds(0, 1)`
But , it returns `AccumBounds(0, oo)`