### PR TITLE
A few comments have been added to all.py

### DIFF
--- a/examples/all.py
+++ b/examples/all.py
@@ -84,6 +84,10 @@ WINDOWED_EXAMPLES = [
     "advanced.pyglet_plotting",
 ]
 
+# intermediate.sample and beginner.plot_examples have not been included above
+# The reason being that these files depend on numpy that has not 
+# necessarily been installed in all systems. 
+
 EXAMPLE_DIR = os.path.dirname(__file__)
 
 


### PR DESCRIPTION
In reference to the issue #12341, the reason for `intermediate.sample` and `beginner.plot_examples` not being included in the TERMINAL and WINDOWED has been stated to avoid any confusions in the future.

