### PR TITLE
Codegen : Fixing inside printing

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -259,6 +259,7 @@ class CodePrinter(StrPrinter):
 
     def _print_Assignment(self, expr):
         from sympy.functions.elementary.piecewise import Piecewise
+        from sympy.functions.elementary.complexes import sign
         from sympy.matrices.expressions.matexpr import MatrixSymbol
         from sympy.tensor.indexed import IndexedBase
         lhs = expr.lhs
@@ -283,6 +284,16 @@ class CodePrinter(StrPrinter):
                 code0 = self._print(temp)
                 lines.append(code0)
             return "\n".join(lines)
+        elif isinstance(rhs,sign):
+            if rhs.args[0].is_integer:
+                temp=sign((Assignment(lhs,0),Assignment(lhs,S('isign')),rhs.args[0]))#sympifies isign as symbol and assigns to assign_to and returns as string
+                return self._print(temp)
+            elif rhs.args[0].is_complex:
+                temp=sign((Assignment(lhs,S('cmplx')),Assignment(lhs,S('%s/abs(%s)'%(self._print(rhs.args[0]),self._print(rhs.args[0])))),rhs.args[0]))#sympifies cmplx as symbol and assigns to assign_to and returns as string
+                return self._print(temp)
+            else:
+                temp=sign((Assignment(lhs,S('te')),Assignment(lhs,S('dsign')),rhs.args[0]))#sympifies dsign as symbol and assigns to assign_to and returns as string and te is a random symbol by me for assigning to assign_to
+                return self._print(temp)
         elif self._settings["contract"] and (lhs.has(IndexedBase) or
                 rhs.has(IndexedBase)):
             # Here we check if there is looping to be done, and if so

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -151,7 +151,6 @@ class FCodePrinter(CodePrinter):
     #for printing abs() function used in FORTRAN
     def _print_abs(self,func):
         return "abs(%s)"%(self._print(func.args[0]))
-    
 
     def _declare_number_const(self, name, value):
         return "parameter ({0} = {1})".format(name, value)

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -142,7 +142,6 @@ class FCodePrinter(CodePrinter):
                 return "merge(0d0, dsign(1d0, {0}), {0} == 0d0)".format(self._print(func.args[0]))
         else:
             return "Wrong Syntax Used.\nfcode(sign(x),assign_to='var'):- FORTRAN VERSION LESS THAN 95.\nfcode(sign(x),standard=95):- FORTRAN VERSION MORE THAN 95"
-                
     #for printing isign() function used in FORTRAN
     def _print_isign(self,func):
         return "isign(1,%s)"%self._print(func.args[1])

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -106,14 +106,53 @@ class FCodePrinter(CodePrinter):
 
     def _get_comment(self, text):
         return "! {0}".format(text)
-#issue 12267
+
     def _print_sign(self,func):
-        if func.args[0].is_integer:
-            return "merge(0, isign(1, {0}), {0} == 0)".format(self._print(func.args[0]))
-        elif func.args[0].is_complex:
-            return "merge(cmplx(0d0, 0d0), {0}/abs({0}), abs({0}) == 0d0)".format(self._print(func.args[0]))
+        lines=[]
+        if func.has(Assignment):
+            for i,j in enumerate(func.args):
+                if j[2].is_integer:
+                    lines.append("if (%s == 0) then"%self._print(j[2]))
+                    lines.append(self._print(j[0]))
+                    lines.append("else")
+                    tmp=self._print(j[1])
+                    lines.append(tmp+"(1,%s)"%self._print(j[2]))
+                    lines.append("end if")
+                elif j[2].is_complex:
+                    lines.append("if (abs(%s) == 0d0) then"%self._print(j[2]))
+                    lines.append(self._print(j[0])+'(0d0,0d0)')
+                    lines.append("else")
+                    lines.append(self._print(j[1]))
+                    lines.append("end if")
+                else:
+                    lines.append("if (%s == 0d0) then"%self._print(j[2]))
+                    tmp=self._print(j[0])
+                    lines.append(tmp[:-3]+"0d0")
+                    lines.append("else")
+                    tmp=self._print(j[1])
+                    lines.append(tmp+"(1d0,%s)"%self._print(j[2]))
+                    lines.append("end if")
+            return "\n".join(lines)
+        elif self._settings["standard"]>=95:
+            if func.args[0].is_integer:
+                return "merge(0, isign(1, {0}), {0} == 0)".format(self._print(func.args[0]))
+            elif func.args[0].is_complex:
+                return "merge(cmplx(0d0, 0d0), {0}/abs({0}), abs({0}) == 0d0)".format(self._print(func.args[0]))
+            else:
+                return "merge(0d0, dsign(1d0, {0}), {0} == 0d0)".format(self._print(func.args[0]))
         else:
-            return "merge(0d0, dsign(1d0, {0}), {0} == 0d0)".format(self._print(func.args[0]))
+            return "Wrong Syntax Used.\nfcode(sign(x),assign_to='var'):- FORTRAN VERSION LESS THAN 95.\nfcode(sign(x),standard=95):- FORTRAN VERSION MORE THAN 95"
+                
+    #for printing isign() function used in FORTRAN
+    def _print_isign(self,func):
+        return "isign(1,%s)"%self._print(func.args[1])
+    #for printing cmplx() function used in FORTRAN
+    def _print_cmplx(self,func):
+        return "cmplx(0d0,0d0)"
+    #for printing abs() function used in FORTRAN
+    def _print_abs(self,func):
+        return "abs(%s)"%(self._print(func.args[0]))
+    
 
     def _declare_number_const(self, name, value):
         return "parameter ({0} = {1})".format(name, value)

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -25,9 +25,12 @@ def test_fcode_sign():
     x=symbols('x')
     y=symbols('y', integer=True)
     z=symbols('z', complex=True)
-    assert fcode(sign(x), source_format='free') == "merge(0d0, dsign(1d0, x), x == 0d0)"
-    assert fcode(sign(y), source_format='free') == "merge(0, isign(1, y), y == 0)"
-    assert fcode(sign(z), source_format='free') == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
+    assert fcode(sign(x), standard=95, source_format="free") == "merge(0d0, dsign(1d0, x), x == 0d0)"
+    assert fcode(sign(y), standard=95, source_format="free") == "merge(0, isign(1, y), y == 0)"
+    assert fcode(sign(z), standard=95, source_format="free") == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
+    assert fcode(sign(x), assign_to="var", source_format="free") == 'if (x == 0d0) then\n   var =0d0\nelse\n   var = dsign(1d0,x)\nend if'
+    assert fcode(sign(y), assign_to="var", source_format="free") == 'if (y == 0) then\n   var = 0\nelse\n   var = isign(1,y)\nend if'
+    assert fcode(sign(z), assign_to="var", source_format="free") == 'if (abs(z) == 0d0) then\n   var = cmplx(0d0,0d0)\nelse\n   var = z/abs(z)\nend if'
 
 
 def test_fcode_Pow():


### PR DESCRIPTION
@bjodah @asmeurer  Fixes issue #12267 
-Change made in `codeprinter` to return correct Assignment expression
-upgraded `_print_sign()` to become compatible with FORTRAN77
-added `_print_isign()`,`_print_cmplx()`,`_print_abs()` to return FORTRAN `isign()`,`abs()`& `cmplx()`equivalent code
-added test cases in `test_fcode_sign()` 