### PR TITLE
Supporting sign in fcode using f77

### DIFF
--- a/doc/src/modules/codegen.rst
+++ b/doc/src/modules/codegen.rst
@@ -551,8 +551,16 @@ available with ``autowrap``.
 There are other facilities available with Sympy to do efficient numeric
 computation. See :ref:`this<numeric_computation>` page for a comparison among them.
 
+
 Special (finite precision arithmetic) math functions
 ----------------------------------------------------
 
 .. automodule:: sympy.codegen.cfunctions
+    :members:
+
+
+Fortran specific functions
+--------------------------
+
+.. automodule:: sympy.codegen.ffunctions
     :members:

--- a/sympy/codegen/ffunctions.py
+++ b/sympy/codegen/ffunctions.py
@@ -1,0 +1,25 @@
+"""
+Functions with corresponding implementations in Fortran.
+
+The functions defined in this module allows the user to express functions such as ``dsign``
+as a SymPy function for symbolic manipulation.
+
+"""
+from sympy.core.function import Function
+
+
+class isign(Function):
+    """ Fortran sign intrinsic with for integer arguments. """
+    nargs = 2
+
+class dsign(Function):
+    """ Fortran sign intrinsic with for double precision arguments. """
+    nargs = 2
+
+class cmplx(Function):
+    """ Fortran complex conversion function. """
+    nargs = 2  # may be extended to (2, 3) at a later point
+
+class kind(Function):
+    """ Fortran kind function. """
+    nargs = 1

--- a/sympy/codegen/tests/test_ffunctions.py
+++ b/sympy/codegen/tests/test_ffunctions.py
@@ -1,0 +1,22 @@
+from sympy import Symbol
+from sympy.codegen.ffunctions import isign, dsign, cmplx, kind
+
+
+def test_isign():
+    x = Symbol('x', integer=True)
+    assert isign(1, x) == isign(1, x)
+
+
+def test_dsign():
+    x = Symbol('x')
+    assert dsign(1, x) == dsign(1, x)
+
+
+def test_cmplx():
+    x = Symbol('x')
+    assert cmplx(1, x) == cmplx(1, x)
+
+
+def test_kind():
+    x = Symbol('x')
+    assert kind(x) == kind(x)

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3798,6 +3798,26 @@ def test_sympy__codegen__cfunctions__hypot():
     assert _test_args(hypot(x, y))
 
 
+def test_sympy__codegen__ffunctions__isign():
+    from sympy.codegen.ffunctions import isign
+    assert _test_args(isign(1, x))
+
+
+def test_sympy__codegen__ffunctions__dsign():
+    from sympy.codegen.ffunctions import dsign
+    assert _test_args(dsign(1, x))
+
+
+def test_sympy__codegen__ffunctions__cmplx():
+    from sympy.codegen.ffunctions import cmplx
+    assert _test_args(cmplx(x, y))
+
+
+def test_sympy__codegen__ffunctions__kind():
+    from sympy.codegen.ffunctions import kind
+    assert _test_args(kind(x))
+
+
 def test_sympy__vector__coordsysrect__CoordSysCartesian():
     from sympy.vector.coordsysrect import CoordSysCartesian
     assert _test_args(CoordSysCartesian('C'))

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -20,14 +20,37 @@ def test_printmethod():
         def _fcode(self, printer):
             return "nint(%s)" % printer._print(self.args[0])
     assert fcode(nint(x)) == "      nint(x)"
-#issue 12267
-def test_fcode_sign():
+
+
+def test_fcode_sign():  #issue 12267
     x=symbols('x')
     y=symbols('y', integer=True)
     z=symbols('z', complex=True)
-    assert fcode(sign(x), source_format='free') == "merge(0d0, dsign(1d0, x), x == 0d0)"
-    assert fcode(sign(y), source_format='free') == "merge(0, isign(1, y), y == 0)"
-    assert fcode(sign(z), source_format='free') == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
+    assert fcode(sign(x), standard=95, source_format='free') == "merge(0d0, dsign(1d0, x), x == 0d0)"
+    assert fcode(sign(y), standard=95, source_format='free') == "merge(0, isign(1, y), y == 0)"
+    assert fcode(sign(z), standard=95, source_format='free') == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
+    assert fcode(sign(x), assign_to="var") == (
+        "      if (x == 0) then\n"
+        "         var = 0\n"
+        "      else\n"
+        "         var = dsign(1, x)\n"
+        "      end if"
+    )
+    assert fcode(sign(y), assign_to="var") == (
+        "      if (y == 0) then\n"
+        "         var = 0\n"
+        "      else\n"
+        "         var = isign(1, y)\n"
+        "      end if"
+    )
+    assert fcode(sign(z), assign_to="var") == (
+        "      if (Abs(z) == 0) then\n"
+        "         var = cmplx(0, 0)\n"
+        "      else\n"
+        "         var = z/Abs(z)\n"
+        "      end if"
+    )
+    raises(NotImplementedError, lambda: fcode(sign(x)))
 
 
 def test_fcode_Pow():
@@ -351,8 +374,8 @@ def test_fcode_Xlogical():
 
 def test_fcode_Relational():
     x, y = symbols("x y")
-    assert fcode(Relational(x, y, "=="), source_format="free") == "Eq(x, y)"
-    assert fcode(Relational(x, y, "!="), source_format="free") == "Ne(x, y)"
+    assert fcode(Relational(x, y, "=="), source_format="free") == "x == y"
+    assert fcode(Relational(x, y, "!="), source_format="free") == "x /= y"
     assert fcode(Relational(x, y, ">="), source_format="free") == "x >= y"
     assert fcode(Relational(x, y, "<="), source_format="free") == "x <= y"
     assert fcode(Relational(x, y, ">"), source_format="free") == "x > y"

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -26,9 +26,9 @@ def test_fcode_sign():  #issue 12267
     x=symbols('x')
     y=symbols('y', integer=True)
     z=symbols('z', complex=True)
-    assert fcode(sign(x), standard=95, source_format='free') == "merge(0d0, dsign(1d0, x), x == 0d0)"
+    assert fcode(sign(x), standard=95, source_format='free') == "merge(0, dsign(1, x), x == 0)"
     assert fcode(sign(y), standard=95, source_format='free') == "merge(0, isign(1, y), y == 0)"
-    assert fcode(sign(z), standard=95, source_format='free') == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
+    assert fcode(sign(z), standard=95, source_format='free') == "merge(cmplx(0, 0), z/abs(z), abs(z) == 0)"
     assert fcode(sign(x), assign_to="var") == (
         "      if (x == 0) then\n"
         "         var = 0\n"
@@ -44,10 +44,10 @@ def test_fcode_sign():  #issue 12267
         "      end if"
     )
     assert fcode(sign(z), assign_to="var") == (
-        "      if (Abs(z) == 0) then\n"
+        "      if (abs(z) == 0) then\n"
         "         var = cmplx(0, 0)\n"
         "      else\n"
-        "         var = z/Abs(z)\n"
+        "         var = z/abs(z)\n"
         "      end if"
     )
     raises(NotImplementedError, lambda: fcode(sign(x)))

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -751,7 +751,7 @@ def test_intrinsic_math_codegen():
         'REAL*8 function test_abs(x)\n'
         'implicit none\n'
         'REAL*8, intent(in) :: x\n'
-        'test_abs = Abs(x)\n'
+        'test_abs = abs(x)\n'
         'end function\n'
         'REAL*8 function test_acos(x)\n'
         'implicit none\n'


### PR DESCRIPTION
Fixes #12267, supersedes #12351 

- Introduce a new module: `.codegen.ffunctions`
- Intercept `Assignment` in fcode.py and check for sign

Pinging @Franjov for review and feedback.
Pinging @SatyaPrakashDwibedi since this PR is essentially feedback on how to extend the code-printers (in regards to #12351)