### PR TITLE
Matrix Cleanup Step 3

### DIFF
--- a/doc/src/modules/matrices/dense.rst
+++ b/doc/src/modules/matrices/dense.rst
@@ -10,6 +10,6 @@ Matrix Class Reference
 ImmutableMatrix Class Reference
 -------------------------------
 
-.. autoclass:: sympy.matrices.immutable.ImmutableMatrix
+.. autoclass:: sympy.matrices.immutable.ImmutableDenseMatrix
    :members:
    :noindex:

--- a/doc/src/modules/matrices/immutablematrices.rst
+++ b/doc/src/modules/matrices/immutablematrices.rst
@@ -8,7 +8,8 @@ performance reasons but means that standard matrices can not interact well with
 the rest of SymPy. This is because the :class:`Basic` object, from which most
 SymPy classes inherit, is immutable.
 
-The mission of the :class:`ImmutableMatrix` class is to bridge the tension
+The mission of the :class:`ImmutableDenseMatrix` class, which is aliased as
+:class:`ImmutableMatrix` for short, is to bridge the tension
 between performance/mutability and safety/immutability. Immutable matrices can
 do almost everything that normal matrices can do but they inherit from
 :class:`Basic` and can thus interact more naturally with the rest of SymPy.
@@ -38,5 +39,5 @@ ImmutableMatrix Class Reference
 
 .. module:: sympy.matrices.immutable
 
-.. autoclass:: ImmutableMatrix
+.. autoclass:: ImmutableDenseMatrix
    :members:

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2124,17 +2124,17 @@ def test_sympy__matrices__expressions__matexpr__MatrixBase():
     pass
 
 
-def test_sympy__matrices__immutable__ImmutableMatrix():
-    from sympy.matrices.immutable import ImmutableMatrix
-    m = ImmutableMatrix([[1, 2], [3, 4]])
+def test_sympy__matrices__immutable__ImmutableDenseMatrix():
+    from sympy.matrices.immutable import ImmutableDenseMatrix
+    m = ImmutableDenseMatrix([[1, 2], [3, 4]])
     assert _test_args(m)
     assert _test_args(Basic(*list(m)))
-    m = ImmutableMatrix(1, 1, [1])
+    m = ImmutableDenseMatrix(1, 1, [1])
     assert _test_args(m)
     assert _test_args(Basic(*list(m)))
-    m = ImmutableMatrix(2, 2, lambda i, j: 1)
+    m = ImmutableDenseMatrix(2, 2, lambda i, j: 1)
     assert m[0, 0] is S.One
-    m = ImmutableMatrix(2, 2, lambda i, j: 1/(1 + i) + 1/(1 + j))
+    m = ImmutableDenseMatrix(2, 2, lambda i, j: 1/(1 + i) + 1/(1 + j))
     assert m[1, 1] is S.One  # true div. will give 1.0 if i,j not sympified
     assert _test_args(m)
     assert _test_args(Basic(*list(m)))
@@ -2528,10 +2528,10 @@ def test_sympy__physics__quantum__gate__TwoQubitGate():
 
 def test_sympy__physics__quantum__gate__UGate():
     from sympy.physics.quantum.gate import UGate
-    from sympy.matrices.immutable import ImmutableMatrix
+    from sympy.matrices.immutable import ImmutableDenseMatrix
     from sympy import Integer, Tuple
     assert _test_args(
-        UGate(Tuple(Integer(1)), ImmutableMatrix([[1, 0], [0, 2]])))
+        UGate(Tuple(Integer(1)), ImmutableDenseMatrix([[1, 0], [0, 2]])))
 
 
 def test_sympy__physics__quantum__gate__XGate():

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -18,10 +18,10 @@ from .sparse import MutableSparseMatrix
 
 SparseMatrix = MutableSparseMatrix
 
-from .immutable import ImmutableMatrix, ImmutableSparseMatrix
+from .immutable import ImmutableDenseMatrix, ImmutableSparseMatrix
 
 MutableSparseMatrix = SparseMatrix
-ImmutableDenseMatrix = ImmutableMatrix
+ImmutableMatrix = ImmutableDenseMatrix
 
 from .expressions import (MatrixSlice, BlockDiagMatrix, BlockMatrix,
         FunctionMatrix, Identity, Inverse, MatAdd, MatMul, MatPow, MatrixExpr,

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -18,10 +18,9 @@ from .sparse import MutableSparseMatrix
 
 SparseMatrix = MutableSparseMatrix
 
-from .immutable import ImmutableDenseMatrix, ImmutableSparseMatrix
+from .immutable import ImmutableMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix
 
 MutableSparseMatrix = SparseMatrix
-ImmutableMatrix = ImmutableDenseMatrix
 
 from .expressions import (MatrixSlice, BlockDiagMatrix, BlockMatrix,
         FunctionMatrix, Identity, Inverse, MatAdd, MatMul, MatPow, MatrixExpr,

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -45,9 +45,6 @@ class DenseMatrix(MatrixBase):
         except AttributeError:
             return False
 
-    def __ne__(self, other):
-        return not self == other
-
     def __getitem__(self, key):
         """Return portion of self defined by key. If the key involves a slice
         then a list will be returned (if key is a single slice) or a matrix
@@ -140,23 +137,6 @@ class DenseMatrix(MatrixBase):
         """
         return self._new(rhs.rows, rhs.cols, lambda i, j: rhs[i, j] / self[i, i])
 
-    def _eval_adjoint(self):
-        return self.T.C
-
-    def _eval_conjugate(self):
-        """By-element conjugation.
-
-        See Also
-        ========
-
-        transpose: Matrix transposition
-        H: Hermite conjugation
-        D: Dirac conjugation
-        """
-        out = self._new(self.rows, self.cols,
-                        lambda i, j: self[i, j].conjugate())
-        return out
-
     def _eval_determinant(self):
         return self.det()
 
@@ -229,79 +209,6 @@ class DenseMatrix(MatrixBase):
             raise ValueError("Inversion method unrecognized")
         return self._new(rv)
 
-    def _eval_trace(self):
-        """Calculate the trace of a square matrix.
-
-        Examples
-        ========
-
-        >>> from sympy.matrices import eye
-        >>> eye(3).trace()
-        3
-
-        """
-        trace = 0
-        for i in range(self.cols):
-            trace += self._mat[i*self.cols + i]
-        return trace
-
-    def _eval_transpose(self):
-        """Matrix transposition.
-
-        Examples
-        ========
-
-        >>> from sympy import Matrix, I
-        >>> m=Matrix(((1, 2+I), (3, 4)))
-        >>> m
-        Matrix([
-        [1, 2 + I],
-        [3,     4]])
-        >>> m.transpose()
-        Matrix([
-        [    1, 3],
-        [2 + I, 4]])
-        >>> m.T == m.transpose()
-        True
-
-        See Also
-        ========
-
-        conjugate: By-element conjugation
-        """
-        a = []
-        for i in range(self.cols):
-            a.extend(self._mat[i::self.cols])
-        return self._new(self.cols, self.rows, a)
-
-    def as_real_imag(self):
-        """Returns a tuple of the real part of the input Matrix
-           and it's imaginary part.
-
-           >>> from sympy import Matrix, I
-           >>> A = Matrix([[1+2*I, 3], [4+7*I, 5]])
-           >>> A.as_real_imag()
-           (Matrix([
-           [1, 3],
-           [4, 5]]), Matrix([
-           [2, 0],
-           [7, 0]]))
-           >>> from sympy.abc import x, y, z, w
-           >>> B = Matrix([[x, y + x * I], [z + w * I, z]])
-           >>> B.as_real_imag()
-           (Matrix([
-           [        re(x), re(y) - im(x)],
-           [re(z) - im(w),         re(z)]]), Matrix([
-           [        im(x), re(x) + im(y)],
-           [re(w) + im(z),         im(z)]]))
-
-        """
-        from sympy.functions.elementary.complexes import re, im
-        real_mat = self._new(self.rows, self.cols, lambda i, j: re(self[i, j]))
-        im_mat = self._new(self.rows, self.cols, lambda i, j: im(self[i, j]))
-
-        return (real_mat, im_mat)
-
     def _LDLdecomposition(self):
         """Helper function of LDLdecomposition.
         Without the error checks.
@@ -343,34 +250,10 @@ class DenseMatrix(MatrixBase):
                                            for k in range(i + 1, self.rows))) / self[i, i]
         return self._new(X)
 
-    def applyfunc(self, f):
-        """Apply a function to each element of the matrix.
-
-        Examples
-        ========
-
-        >>> from sympy import Matrix
-        >>> m = Matrix(2, 2, lambda i, j: i*2+j)
-        >>> m
-        Matrix([
-        [0, 1],
-        [2, 3]])
-        >>> m.applyfunc(lambda i: 2*i)
-        Matrix([
-        [0, 2],
-        [4, 6]])
-
-        """
-        if not callable(f):
-            raise TypeError("`f` must be callable.")
-
-        out = self._new(self.rows, self.cols, list(map(f, self._mat)))
-        return out
-
     def as_immutable(self):
         """Returns an Immutable version of this Matrix
         """
-        from .immutable import ImmutableMatrix as cls
+        from .immutable import ImmutableDenseMatrix as cls
         if self.rows and self.cols:
             return cls._new(self.tolist())
         return cls._new(self.rows, self.cols, [])
@@ -391,30 +274,6 @@ class DenseMatrix(MatrixBase):
         [3, 5]])
         """
         return Matrix(self)
-
-    def col(self, j):
-        """Elementary column selector.
-
-        Examples
-        ========
-
-        >>> from sympy import eye
-        >>> eye(2).col(0)
-        Matrix([
-        [1],
-        [0]])
-
-        See Also
-        ========
-
-        row
-        col_op
-        col_swap
-        col_del
-        col_join
-        col_insert
-        """
-        return self[:, j]
 
     def equals(self, other, failing_expression=False):
         """Applies ``equals`` to corresponding elements of the matrices,
@@ -467,97 +326,6 @@ class DenseMatrix(MatrixBase):
         mat = [cls._sympify(0)]*n*n
         mat[::n + 1] = [cls._sympify(1)]*n
         return cls._new(n, n, mat)
-
-    @property
-    def is_Identity(self):
-        if not self.is_square:
-            return False
-        if not all(self[i, i] == 1 for i in range(self.rows)):
-            return False
-        for i in range(self.rows):
-            for j in range(i + 1, self.cols):
-                if self[i, j] or self[j, i]:
-                    return False
-        return True
-
-    def reshape(self, rows, cols):
-        """Reshape the matrix. Total number of elements must remain the same.
-
-        Examples
-        ========
-
-        >>> from sympy import Matrix
-        >>> m = Matrix(2, 3, lambda i, j: 1)
-        >>> m
-        Matrix([
-        [1, 1, 1],
-        [1, 1, 1]])
-        >>> m.reshape(1, 6)
-        Matrix([[1, 1, 1, 1, 1, 1]])
-        >>> m.reshape(3, 2)
-        Matrix([
-        [1, 1],
-        [1, 1],
-        [1, 1]])
-
-        """
-        if len(self) != rows*cols:
-            raise ValueError("Invalid reshape parameters %d %d" % (rows, cols))
-        return self._new(rows, cols, lambda i, j: self._mat[i*cols + j])
-
-    def row(self, i):
-        """Elementary row selector.
-
-        Examples
-        ========
-
-        >>> from sympy import eye
-        >>> eye(2).row(0)
-        Matrix([[1, 0]])
-
-        See Also
-        ========
-
-        col
-        row_op
-        row_swap
-        row_del
-        row_join
-        row_insert
-        """
-        return self[i, :]
-
-    def tolist(self):
-        """Return the Matrix as a nested Python list.
-
-        Examples
-        ========
-
-        >>> from sympy import Matrix, ones
-        >>> m = Matrix(3, 3, range(9))
-        >>> m
-        Matrix([
-        [0, 1, 2],
-        [3, 4, 5],
-        [6, 7, 8]])
-        >>> m.tolist()
-        [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
-        >>> ones(3, 0).tolist()
-        [[], [], []]
-
-        When there are no rows then it will not be possible to tell how
-        many columns were in the original matrix:
-
-        >>> ones(0, 3).tolist()
-        []
-
-        """
-        if not self.rows:
-            return []
-        if not self.cols:
-            return [[] for i in range(self.rows)]
-        return [self._mat[i: i + self.cols]
-                for i in range(0, len(self), self.cols)]
 
     @classmethod
     def zeros(cls, r, c=None):
@@ -1330,7 +1098,7 @@ def diag(*values, **kwargs):
     <class 'sympy.matrices.dense.MutableDenseMatrix'>
     >>> from sympy.matrices import ImmutableMatrix
     >>> type(diag(1, cls=ImmutableMatrix))
-    <class 'sympy.matrices.immutable.ImmutableMatrix'>
+    <class 'sympy.matrices.immutable.ImmutableDenseMatrix'>
 
     See Also
     ========

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -45,9 +45,9 @@ class BlockMatrix(MatrixExpr):
 
     """
     def __new__(cls, *args):
-        from sympy.matrices.immutable import ImmutableMatrix
+        from sympy.matrices.immutable import ImmutableDenseMatrix
         args = map(sympify, args)
-        mat = ImmutableMatrix(*args)
+        mat = ImmutableDenseMatrix(*args)
 
         obj = Basic.__new__(cls, mat)
         return obj
@@ -217,12 +217,12 @@ class BlockDiagMatrix(BlockMatrix):
 
     @property
     def blocks(self):
-        from sympy.matrices.immutable import ImmutableMatrix
+        from sympy.matrices.immutable import ImmutableDenseMatrix
         mats = self.args
         data = [[mats[i] if i == j else ZeroMatrix(mats[i].rows, mats[j].cols)
                         for j in range(len(mats))]
                         for i in range(len(mats))]
-        return ImmutableMatrix(data)
+        return ImmutableDenseMatrix(data)
 
     @property
     def shape(self):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -263,7 +263,7 @@ class MatrixExpr(Basic):
         """
         Returns a dense Matrix with elements represented explicitly
 
-        Returns an object of type ImmutableMatrix.
+        Returns an object of type ImmutableDenseMatrix.
 
         Examples
         ========
@@ -283,8 +283,8 @@ class MatrixExpr(Basic):
         as_mutable: returns mutable Matrix type
 
         """
-        from sympy.matrices.immutable import ImmutableMatrix
-        return ImmutableMatrix([[    self[i, j]
+        from sympy.matrices.immutable import ImmutableDenseMatrix
+        return ImmutableDenseMatrix([[    self[i, j]
                             for j in range(self.cols)]
                             for i in range(self.rows)])
 
@@ -309,7 +309,7 @@ class MatrixExpr(Basic):
 
         See Also
         ========
-        as_explicit: returns ImmutableMatrix
+        as_explicit: returns ImmutableDenseMatrix
         """
         return self.as_explicit().as_mutable()
 

--- a/sympy/matrices/expressions/slice.py
+++ b/sympy/matrices/expressions/slice.py
@@ -37,7 +37,7 @@ class MatrixSlice(MatrixExpr):
 
     >>> from sympy import MatrixSlice, ImmutableMatrix
     >>> M = ImmutableMatrix(4, 4, range(16))
-    >>> print(M)
+    >>> M
     Matrix([
     [ 0,  1,  2,  3],
     [ 4,  5,  6,  7],
@@ -45,7 +45,7 @@ class MatrixSlice(MatrixExpr):
     [12, 13, 14, 15]])
 
     >>> B = MatrixSlice(M, (0, 2), (2, 4))
-    >>> print(ImmutableMatrix(B))
+    >>> ImmutableMatrix(B)
     Matrix([
     [2, 3],
     [6, 7]])

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -99,6 +99,9 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
 # See https://github.com/sympy/sympy/issues/7213
 ImmutableDenseMatrix.is_zero = DenseMatrix.is_zero
 
+# make sure ImmutableDenseMatrix is aliased as ImmutableMatrix
+ImmutableMatrix = ImmutableDenseMatrix
+
 
 class ImmutableSparseMatrix(SparseMatrix, Basic):
     """Create an immutable version of a sparse matrix.

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -13,7 +13,7 @@ def sympify_matrix(arg):
     return arg.as_immutable()
 sympify_converter[MatrixBase] = sympify_matrix
 
-class ImmutableMatrix(MatrixExpr, DenseMatrix):
+class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
     """Create an immutable version of a matrix.
 
     Examples
@@ -35,13 +35,11 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     # MatrixExpr is set as NotIterable, but we want explicit matrices to be
     # iterable
     _iterable = True
-    is_Matrix = True
     _class_priority = 8
     _op_priority = 10.001
 
-    @classmethod
-    def _new(cls, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], ImmutableMatrix):
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], ImmutableDenseMatrix):
             return args[0]
         rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
         rows = Integer(rows)
@@ -49,12 +47,11 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
         mat = Tuple(*flat_list)
         return Basic.__new__(cls, rows, cols, mat)
 
-    def __new__(cls, *args, **kwargs):
-        return cls._new(*args, **kwargs)
+    __hash__ = MatrixExpr.__hash__
 
-    @property
-    def shape(self):
-        return tuple([int(i) for i in self.args[:2]])
+    @classmethod
+    def _new(cls, *args, **kwargs):
+        return cls(*args, **kwargs)
 
     @property
     def _mat(self):
@@ -63,15 +60,13 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     def _entry(self, i, j):
         return DenseMatrix.__getitem__(self, (i, j))
 
-    __getitem__ = DenseMatrix.__getitem__
-
     def __setitem__(self, *args):
-        raise TypeError("Cannot set values of ImmutableMatrix")
+        raise TypeError("Cannot set values of {}".format(self.__class__))
 
     def _eval_Eq(self, other):
         """Helper method for Equality with matrices.
 
-        Relational automatically converts matrices to ImmutableMatrix
+        Relational automatically converts matrices to ImmutableDenseMatrix
         instances, so this method only applies here.  Returns True if the
         matrices are definitively the same, False if they are definitively
         different, and None if undetermined (e.g. if they contain Symbols).
@@ -81,48 +76,31 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
         if not hasattr(other, 'shape') or self.shape != other.shape:
             return S.false
         if isinstance(other, MatrixExpr) and not isinstance(
-                other, ImmutableMatrix):
+                other, ImmutableDenseMatrix):
             return None
         diff = self - other
         return sympify(diff.is_zero)
 
-    adjoint = MatrixBase.adjoint
-    conjugate = MatrixBase.conjugate
-    # C and T are defined in MatrixExpr...I don't know why C alone
-    # needs to be defined here
-    C = MatrixBase.C
+    @property
+    def cols(self):
+        return int(self.args[1])
 
-    as_mutable = DenseMatrix.as_mutable
-    as_real_imag = DenseMatrix.as_real_imag
-    _eval_trace = DenseMatrix._eval_trace
-    _eval_transpose = DenseMatrix._eval_transpose
-    _eval_conjugate = DenseMatrix._eval_conjugate
-    _eval_adjoint = DenseMatrix._eval_adjoint
-    _eval_inverse = DenseMatrix._eval_inverse
-    _eval_simplify = DenseMatrix._eval_simplify
-    _eval_diff = DenseMatrix._eval_diff
+    @property
+    def rows(self):
+        return int(self.args[0])
 
-    equals = DenseMatrix.equals
-    is_Identity = DenseMatrix.is_Identity
+    @property
+    def shape(self):
+        return tuple(int(i) for i in self.args[:2])
 
-    __add__ = MatrixBase.__add__
-    __radd__ = MatrixBase.__radd__
-    __mul__ = MatrixBase.__mul__
-    __matmul__ = MatrixBase.__matmul__
-    __rmul__ = MatrixBase.__rmul__
-    __rmatmul__ = MatrixBase.__rmatmul__
-    __pow__ = MatrixBase.__pow__
-    __sub__ = MatrixBase.__sub__
-    __rsub__ = MatrixBase.__rsub__
-    __neg__ = MatrixBase.__neg__
-    __div__ = MatrixBase.__div__
-    __truediv__ = MatrixBase.__truediv__
 # This is included after the class definition as a workaround for issue 7213.
 # See https://github.com/sympy/sympy/issues/7213
-ImmutableMatrix.is_zero = DenseMatrix.is_zero
+# the object is non-zero
+# See https://github.com/sympy/sympy/issues/7213
+ImmutableDenseMatrix.is_zero = DenseMatrix.is_zero
 
 
-class ImmutableSparseMatrix(Basic, SparseMatrix):
+class ImmutableSparseMatrix(SparseMatrix, Basic):
     """Create an immutable version of a sparse matrix.
 
     Examples
@@ -165,11 +143,7 @@ class ImmutableSparseMatrix(Basic, SparseMatrix):
     def __setitem__(self, *args):
         raise TypeError("Cannot set values of ImmutableSparseMatrix")
 
-    subs = MatrixBase.subs
-
-    xreplace = MatrixBase.xreplace
-
     def __hash__(self):
         return hash((type(self).__name__,) + (self.shape, tuple(self._smat)))
 
-    _eval_Eq = ImmutableMatrix._eval_Eq
+    _eval_Eq = ImmutableDenseMatrix._eval_Eq

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -332,6 +332,8 @@ def test_is_zero():
 
 def test_values():
     assert set(PropertiesOnlyMatrix(2,2,[0,1,2,3]).values()) == set([1,2,3])
+    x = Symbol('x', real=True)
+    assert set(PropertiesOnlyMatrix(2,2,[x,0,0,1]).values()) == set([x,1])
 
 
 # OperationsOnlyMatrix tests
@@ -347,6 +349,13 @@ def test_adjoint():
     ans = OperationsOnlyMatrix([[0, 1], [-I, 0]])
     assert ans.adjoint() == Matrix(dat)
 
+def test_as_real_imag():
+    m1 = OperationsOnlyMatrix(2,2,[1,2,3,4])
+    m3 = OperationsOnlyMatrix(2,2,[1+S.ImaginaryUnit,2+2*S.ImaginaryUnit,3+3*S.ImaginaryUnit,4+4*S.ImaginaryUnit])
+
+    a,b = m3.as_real_imag()
+    assert a == m1
+    assert b == m1
 
 def test_conjugate():
     M = OperationsOnlyMatrix([[0, I, 5],

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2873,3 +2873,13 @@ def test_issue_11238():
     assert m1.rank(simplify=True) == 1
     assert m2.rank(simplify=True) == 1
     assert m3.rank(simplify=True) == 1
+
+def test_as_real_imag():
+    m1 = Matrix(2,2,[1,2,3,4])
+    m2 = m1*S.ImaginaryUnit
+    m3 = m1 + m2
+
+    for kls in classes:
+        a,b = kls(m3).as_real_imag()
+        assert list(a) == list(m1)
+        assert list(b) == list(m1)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -441,6 +441,7 @@ class CodePrinter(StrPrinter):
     _print_list = _print_not_supported
     _print_Matrix = _print_not_supported
     _print_ImmutableMatrix = _print_not_supported
+    _print_ImmutableDenseMatrix = _print_not_supported
     _print_MutableDenseMatrix = _print_not_supported
     _print_MatrixBase = _print_not_supported
     _print_DeferredVector = _print_not_supported

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1356,8 +1356,9 @@ class LatexPrinter(Printer):
             out_str = r'\left' + left_delim + out_str + \
                       r'\right' + right_delim
         return out_str % r"\\".join(lines)
-    _print_ImmutableMatrix = _print_MatrixBase
-    _print_Matrix = _print_MatrixBase
+    _print_ImmutableMatrix = _print_ImmutableDenseMatrix \
+                           = _print_Matrix \
+                           = _print_MatrixBase
 
     def _print_MatrixElement(self, expr):
         return self._print(expr.parent) + '_{%s, %s}'%(expr.i, expr.j)

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,6 @@
 from sympy.utilities.pytest import raises
 from sympy import (symbols, Function, Integer, Matrix, Abs,
-    Rational, Float, S, WildFunction, ImmutableMatrix, sin, true, false, ones,
+    Rational, Float, S, WildFunction, ImmutableDenseMatrix, sin, true, false, ones,
     sqrt, root, AlgebraicNumber, Symbol, Dummy, Wild)
 from sympy.core.compatibility import exec_
 from sympy.geometry import Point, Ellipse
@@ -80,7 +80,7 @@ def test_list():
 
 
 def test_Matrix():
-    for cls, name in [(Matrix, "MutableDenseMatrix"), (ImmutableMatrix, "ImmutableMatrix")]:
+    for cls, name in [(Matrix, "MutableDenseMatrix"), (ImmutableDenseMatrix, "ImmutableDenseMatrix")]:
         sT(cls([[x**+1, 1], [y, x + y]]),
            "%s([[Symbol('x'), Integer(1)], [Symbol('y'), Add(Symbol('x'), Symbol('y'))]])" % name)
 

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -122,7 +122,7 @@ class TheanoPrinter(Printer):
         else:
             return tt.stacklists([[self._print(arg, **kwargs) for arg in L]
                                          for L in X.tolist()])
-    _print_ImmutableMatrix = _print_DenseMatrix
+    _print_ImmutableMatrix = _print_ImmutableDenseMatrix = _print_DenseMatrix
 
     def _print_MatMul(self, expr, **kwargs):
         children = [self._print(arg, **kwargs) for arg in expr.args]

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -829,7 +829,7 @@ def solve(f, *symbols, **flags):
     ###########################################################################
     for i, fi in enumerate(f):
         if isinstance(fi, Equality):
-            if 'ImmutableMatrix' in [type(a).__name__ for a in fi.args]:
+            if 'ImmutableDenseMatrix' in [type(a).__name__ for a in fi.args]:
                 f[i] = fi.lhs - fi.rhs
             else:
                 f[i] = Add(fi.lhs, -fi.rhs, evaluate=False)

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -55,7 +55,7 @@ MPMATH_TRANSLATIONS = {
     #"uppergamma":"upper_gamma",
     "LambertW": "lambertw",
     "MutableDenseMatrix": "matrix",
-    "ImmutableMatrix": "matrix",
+    "ImmutableDenseMatrix": "matrix",
     "conjugate": "conj",
     "dirichlet_eta": "altzeta",
     "Ei": "ei",
@@ -85,7 +85,7 @@ NUMPY_TRANSLATIONS = {
     "ImmutableSparseMatrix": "array",
     "Matrix": "array",
     "MutableDenseMatrix": "array",
-    "ImmutableMatrix": "array",
+    "ImmutableDenseMatrix": "array",
     "ImmutableDenseMatrix": "array",
 }
 
@@ -214,13 +214,13 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
     In previous releases ``lambdify`` replaced ``Matrix`` with ``numpy.matrix``
     by default. As of release 1.0 ``numpy.array`` is the default.
-    To get the old default behavior you must pass in ``[{'ImmutableMatrix':
+    To get the old default behavior you must pass in ``[{'ImmutableDenseMatrix':
     numpy.matrix}, 'numpy']`` to the ``modules`` kwarg.
 
     >>> from sympy import lambdify, Matrix
     >>> from sympy.abc import x, y
     >>> import numpy
-    >>> array2mat = [{'ImmutableMatrix': numpy.matrix}, 'numpy']
+    >>> array2mat = [{'ImmutableDenseMatrix': numpy.matrix}, 'numpy']
     >>> f = lambdify((x, y), Matrix([x, y]), modules=array2mat)
     >>> f(1, 2)
     matrix([[1],

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -357,7 +357,7 @@ def test_numpy_old_matrix():
         skip("numpy not installed.")
     A = Matrix([[x, x*y], [sin(z) + 4, x**z]])
     sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
-    f = lambdify((x, y, z), A, [{'ImmutableMatrix': numpy.matrix}, 'numpy'])
+    f = lambdify((x, y, z), A, [{'ImmutableDenseMatrix': numpy.matrix}, 'numpy'])
     numpy.testing.assert_allclose(f(1, 2, 3), sol_arr)
     assert isinstance(f(1, 2, 3), numpy.matrix)
 


### PR DESCRIPTION
The matrix cleanup work is starting to pay off. Many methods that were duplicated across `MatrixBase` and
`DenseMatrix` and `SparseMatrix` were deleted.  Appropriate `_eval_...` functions (mostly in `SparseMatrix`) were overridden to provide optimized behavior.

This PR also declutters the `ImmutableMatrix` classes by switching inheritance to happen in the correct order.
