### PR TITLE
interactive/printing: Add support for MutableNDimArray for printing

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -105,6 +105,9 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         from sympy import Basic
         from sympy.matrices import MatrixBase
         from sympy.physics.vector import Vector, Dyadic
+        from sympy.core.compatibility import integer_types
+        from sympy.tensor.array import NDimArray # all other types inherit from NDimArray
+
         if isinstance(o, (list, tuple, set, frozenset)):
             return all(_can_print_latex(i) for i in o)
         elif isinstance(o, dict):
@@ -116,6 +119,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic)):
             return True
         elif isinstance(o, (float, integer_types)) and print_builtin:
+            return True
+        elif isinstance(o, NDimArray):
             return True
         return False
 
@@ -176,8 +181,10 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         from sympy.core.basic import Basic
         from sympy.matrices.matrices import MatrixBase
         from sympy.physics.vector import Vector, Dyadic
+        from sympy.tensor.array import NDimArray # all other types inherit from NDimArray
+
         printable_types = [Basic, MatrixBase, float, tuple, list, set,
-                frozenset, dict, Vector, Dyadic] + list(integer_types)
+                frozenset, dict, Vector, Dyadic, NDimArray] + list(integer_types)
 
         plaintext_formatter = ip.display_formatter.formatters['text/plain']
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -117,11 +117,9 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             return False
         # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
         # to use here, than these explicit imports.
-        elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic)):
+        elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic, NDimArray)):
             return True
         elif isinstance(o, (float, integer_types)) and print_builtin:
-            return True
-        elif isinstance(o, NDimArray):
             return True
         return False
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -96,25 +96,34 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             debug('matplotlib exception caught:', repr(e))
             return None
 
-    def _get_latex_printable_types():
-        from sympy.core.basic import Basic
-        from sympy.matrices.matrices import MatrixBase
-        from sympy.physics.vector import Vector, Dyadic
-        from sympy.tensor.array import NDimArray # all other NDimArray types inherit from NDimArray
-
-        printable_types = [Basic, MatrixBase, float, tuple, list, set,
-                frozenset, dict, Vector, Dyadic, NDimArray] + list(integer_types)
-
-        return printable_types
-
     def _can_print_latex(o):
         """Return True if type o can be printed with LaTeX.
 
         If o is a container type, this is True if and only if every element of
         o can be printed with LaTeX.
         """
-        printable_types = _get_latex_printable_types()
-        return isinstance(o, tuple(printable_types))
+        from sympy import Basic
+        from sympy.matrices import MatrixBase
+        from sympy.physics.vector import Vector, Dyadic
+        from sympy.tensor.array import NDimArray
+        # If you're adding another type, make sure you add it to printable_types
+        # later in this file as well
+
+        if isinstance(o, (list, tuple, set, frozenset)):
+            return all(_can_print_latex(i) for i in o)
+        elif isinstance(o, dict):
+            return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
+        elif isinstance(o, bool):
+            return False
+        # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
+        # to use here, than these explicit imports.
+        elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic)):
+            return True
+        elif isinstance(o, (float, integer_types)) and print_builtin:
+            return True
+        elif isinstance(o, NDimArray):
+            return True
+        return False
 
     def _print_latex_png(o):
         """
@@ -170,7 +179,14 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
 
     import IPython
     if V(IPython.__version__) >= '0.11':
-        printable_types = _get_latex_printable_types()
+        from sympy.core.basic import Basic
+        from sympy.matrices.matrices import MatrixBase
+        from sympy.physics.vector import Vector, Dyadic
+        from sympy.tensor.array import NDimArray
+
+        printable_types = [Basic, MatrixBase, float, tuple, list, set,
+                frozenset, dict, Vector, Dyadic, NDimArray] + list(integer_types)
+
         plaintext_formatter = ip.display_formatter.formatters['text/plain']
 
         for cls in printable_types:

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -256,20 +256,6 @@ class NDimArray(object):
 
         return f(self._loop_size, self.shape, 0, self._loop_size)
 
-        out_str = ''
-
-        # forming output string
-        for i, el in enumerate(self):
-
-            out_str += str(el) + '  '
-            chidx = i+1
-            for sh in reversed(self.shape):
-                if chidx % sh == 0:
-                    out_str += '\n'
-                    chidx //= sh
-
-        return out_str
-
     def __repr__(self):
         return self.__str__()
 


### PR DESCRIPTION
NDimArrays of the mutable type had to be explicitly added to `_can_print_latex` function and `printable_types` array so that they would display properly in Latex (in an IPython / Jupyter environment)

Commit 2 does exactly this. Commit 3 improves on this by merging the shared logic of `_can_print_latex` and `printable_types` to remove duplication, and Commit 1 is removal of dead code (general housekeeping).

Fixes #12386