### PR TITLE
Don't show cmd.exe windows when generating Latex images on Windows

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+import os
 from os.path import join
 import tempfile
 import shutil
@@ -195,8 +196,17 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             raise RuntimeError("latex program is not installed")
 
         try:
+            # Avoid showing a cmd.exe window when running this
+            # on Windows
+            if os.name == 'nt':
+                creation_flag = 0x08000000 # CREATE_NO_WINDOW
+            else:
+                creation_flag = 0 # Default value
             check_output(['latex', '-halt-on-error', '-interaction=nonstopmode',
-                          'texput.tex'], cwd=workdir, stderr=STDOUT)
+                          'texput.tex'],
+                         cwd=workdir,
+                         stderr=STDOUT,
+                         creationflags=creation_flag)
         except CalledProcessError as e:
             raise RuntimeError(
                 "'latex' exited abnormally with the following output:\n%s" %


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->

Fixes #11882 and motivated by http://stackoverflow.com/q/42891448/438386