### PR TITLE
ccode: Minor improvement in printing squares

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -160,6 +160,9 @@ class C89CodePrinter(CodePrinter):
             return '%ssqrt(%s)' % (self._ns, self._print(expr.base))
         elif expr.exp == S.One/3 and self.standard != 'C89':
             return '%scbrt(%s)' % (self._ns, self._print(expr.base))
+        elif expr.exp == 2:
+            return '%s%s*%s' % (self._ns, self._print(expr.base),
+                                self._print(expr.base))
         else:
             return '%spow(%s, %s)' % (self._ns, self._print(expr.base),
                                    self._print(expr.exp))


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
https://github.com/sympy/sympy/wiki/Code-Generation-Notes --> Here it is mentioned : 
```
The code printers don't print optimal code in many cases.
An example of this is powers in C. x**2 prints as pow(x, 2) instead of x*x.
```
This PR implements this minor change.
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
