### PR TITLE
[Not For Merge]Helper function for solving log eqs

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -561,6 +561,33 @@ def _solve_abs(f, symbol, domain):
     else:
         return ConditionSet(symbol, Eq(f, 0), domain)
 
+def _logsolver(f, symbol, domain):
+    f = sympify(f)
+    f = logcombine(f, force = True)
+    if domain.is_subset(S.Reals):
+        result = solveset_real(f, symbol)
+    else:
+        result = solveset_complex(f, symbol)
+    if isinstance(result, ConditionSet):
+        lhs_s, rhs_s = _invert(f, 0, symbol, domain)
+        if lhs_s == symbol:
+            rhs_s = FiniteSet(*[Mul(*
+                    signsimp(i).as_content_primitive())
+                    for i in rhs_s])
+            result = rhs_s
+        elif isinstance(rhs_s, FiniteSet):
+            for eq in [lhs_s - rhs for rhs in rhs_s]:
+                equation = eq
+            equation = simplify(equation)
+            num,deno = fraction(equation)
+            num = ratsimp(num)
+            result = _solveset(num, symbol, domain)
+    if (result, FiniteSet):
+        for x in result:
+            if sign(x) == -1:
+                result -= FiniteSet(x)  # to remove negative values
+    return result
+
 
 def solve_decomposition(f, symbol, domain):
     """

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -559,6 +559,14 @@ def test_uselogcombine_1():
         -3 + sqrt(-12 + exp(3))*exp(S(3)/2)/2 + exp(3)/2,
         -sqrt(-12 + exp(3))*exp(S(3)/2)/2 - 3 + exp(3)/2)
 
+@XFAIL
+def test_otherlog():
+    f1 = log(8*x) - log(1 + x**Rational(1, 2)) - 2
+    f2 = log(x, 4) + log(x - 12, 4) - 3
+    assert solveset(f1, x, S.Reals) == FiniteSet(
+         sqrt(exp(2) + 32)*exp(3)/128 + (exp(2) + 16)*exp(2)/128)
+    assert solveset(f2, x) == FiniteSet(16)
+
 
 @XFAIL
 def test_uselogcombine_2():


### PR DESCRIPTION
I tried to implement helper function(`_logsolver`) for ` logarithmic equations`. This will be a part of ` transolve` later.
All the ` @XFail` tests of   `test_uselogcombine_1` passes .

I also added few more `@XFails`. At present `_logsolver` solves only for ` natural logs` . I will be implementing it for different bases too. But I thought rather to have an opinion regarding the implementation until now and would  move ahead after discussion.

Ref: [#11540](https://github.com/sympy/sympy/pull/11540)

ping @asmeurer @Shekharrajak @kshitij10496 @aktech @smichr 
