### PR TITLE
Improved pattern matching for is_Pow patterns

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1146,7 +1146,7 @@ class Pow(Expr):
         m = expand_power_base(self,force=True)
         if m.is_Mul & expr.is_Mul:
             return m.matches(expr)
-            
+
         d = repl_dict.copy()
         d = self.base.matches(b, d)
         if d is None:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1120,6 +1120,7 @@ class Pow(Expr):
         return self.func(n, exp), self.func(d, exp)
 
     def matches(self, expr, repl_dict={}, old=False):
+        from sympy.core import expand_power_base
         expr = _sympify(expr)
 
         # special case, pattern = 1 and expr.exp can match to 0
@@ -1142,6 +1143,10 @@ class Pow(Expr):
                 return sb.matches(b**(e/se), repl_dict)
             return sb.matches(expr**(1/se), repl_dict)
 
+        m = expand_power_base(self,force=True)
+        if m.is_Mul & expr.is_Mul:
+            return m.matches(expr)
+            
         d = repl_dict.copy()
         d = self.base.matches(b, d)
         if d is None:

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -97,6 +97,7 @@ def test_match_exclude():
     assert e.match(p*x + q*y + r) == {p: 4, q: 5, r: 6}
 
     a = Wild('a', exclude=[x])
+    m = Wild('m', exclude=[x])
 
     e = 3*x
     assert e.match(p*x) == {p: 3}
@@ -110,6 +111,8 @@ def test_match_exclude():
     assert e.match(p*x**2 + p*x + 2*p) == {p: 3/x}
     assert e.match(a*x**2 + a*x + 2*a) is None
 
+    e = (2*x)**3
+    assert e.match((a*x)**m) == {m: 3, a: 2}
 
 def test_mul():
     x, y, a, b, c = map(Symbol, 'xyabc')


### PR DESCRIPTION
Pattern matching of `is_Pow` patterns couldn't handle pattern of `is_Mul` expressions. I used `expand_power_base()` function to expand the pattern into a `is_Mul` expression and complete pattern matching successfully.
### Output before this PR:
``` python
>>> from sympy import *
>>> from sympy.abc import x
>>> b = Wild('b',exclude=[x])
>>> m = Wild('m',exclude=[x])
>>> expr = (4*x)**2
>>> print(expr.match((b*x)**m))
None
```

### Output after this PR:
``` python
>>> expr.match((b*x)**m)
{m_: 2, b_: 4}
```

* Tests are added

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->