### PR TITLE
Add `dict` option to `nsolve`

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2760,7 +2760,7 @@ def nsolve(*args, **kwargs):
         prec = None
 
     # keyword argument to return result as a dictionary
-    as_dict = kwargs.get('dict', False)
+    as_dict = kwargs.pop('dict', False)
 
     # interpret arguments
     if len(args) == 3:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2662,6 +2662,14 @@ def nsolve(*args, **kwargs):
     that supports matrices. For more information on the syntax, please see the
     docstring of lambdify.
 
+    If the keyword arguments contain 'dict'=True (default is False) nsolve
+    will return a list (perhaps empty) of solution mappings. This might be
+    especially useful if you want to use nsolve as a fallback to solve since
+    using the dict argument for both methods produces return values of
+    consistent type structure. Please note: to keep this consistency with
+    solve, the solution will be returned in a list even though nsolve
+    (currently at least) only finds one solution at a time.
+
     Overdetermined systems are supported.
 
     >>> from sympy import Symbol, nsolve

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -108,3 +108,15 @@ def test_nsolve_complex():
 
     assert nsolve([x**2 + 2, y**2 + 2], [x, y], [I, I]) == Matrix([sqrt(2.)*I, sqrt(2.)*I])
     assert nsolve([x**2 + 2, y**2 + 2], [x, y], [I, I]) == Matrix([sqrt(2.)*I, sqrt(2.)*I])
+
+def test_nsolve_dict_kwarg():
+    x, y = symbols('x y')
+    # one variable
+    assert nsolve(x**2 - 2, 1, dict = True) == \
+        [{x: sqrt(2.)}]
+    # one variable with complex solution
+    assert nsolve(x**2 + 2, I, dict = True) == \
+        [{x: sqrt(2.)*I}]
+    # two variables
+    assert nsolve([x**2 + y**2 - 5, x**2 - y**2 + 1], [x, y], [1, 1], dict = True) == \
+        [{x: sqrt(2.), y: sqrt(3.)}]


### PR DESCRIPTION
**Motivation:** If you're using `solve` with the `dict` option and want to call `nsolve` as a fallback, it would be useful, to get the same output return type and format. However, `nsolve` doesn't have a `dict` option, so far.

**Example:** Here's what my implementation looks like.
```python
>>> from sympy import *
>>> x, y = symbols("x y")
>>> equations = [Eq(2*x+y, 3), Eq(y-x, 1)]
>>> variables = [x, y]
>>> guesses = [1, 1]
>>> solve(equations, variables)
{x: 2/3, y: 5/3}
>>> solve(equations, variables, dict = True)
[{x: 2/3, y: 5/3}]
>>> nsolve(equations, variables, guesses)
Matrix([[0.666666666666667], [1.66666666666667]])
>>> nsolve(equations, variables, guesses, dict = True)
[{x: 0.666666666666667, y: 1.66666666666667}]
```

**Changes:** The `return` statement has been moved to the end of the function. It's now the same `return` for both one-dimensional and multi-dimensional calls. I didn't really change that much: those 20 deletions originate only from the necessary additional `else`. What was left to do was to distinguish between the different types, which the solution might have: either iterable (when solving multiple variables) or not (when solving only one variable). The most pythonic way to test if the result is iterable seems to be to assume the result to be iterable (line 2838) and to gracefully fail if not (line 2840).