### PR TITLE
Updated _eval_is_odd to handle more complex inputs

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1279,9 +1279,9 @@ class Mul(Expr, AssocOp):
     numerator ("num") and denominator ("denom").  If the num is even, then the expression
     is even because .fraction() puts the quotient in lowest terms, so False.  If the
     denom is even, then we must find its 2-adic valuation to compare the factors of 2
-    in the denom against the factors of 2 in the num.  Once we evaluate the denom, then
-    we need to evaluate the symbols that make up the rest of the expression.  If
-    more factors of 2 in the num, then even.  Else, not enough info, so None.
+    in the denom against the factors of 2 in the symbols which are in the num.  Once we 
+    evaluate the denom, then we need to evaluate the symbols that make up the rest of the 
+    expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
     """
         is_integer = self.is_integer
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1287,6 +1287,7 @@ class Mul(Expr, AssocOp):
         is_integer = self.is_integer
 
         if is_integer:
+            factor2_num = 0
             coeff,args = self.as_coeff_mul()
             if coeff == 1 or coeff == -1:
                 r = True

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1286,11 +1286,11 @@ class Mul(Expr, AssocOp):
         is_integer = self.is_integer
 
             if is_integer:
-                self.as_coeff_mul()
+                (coeff,symbols) = self.as_coeff_mul()
                
-                if arg[0] == 1
+                if coeff == 1
                 r = True
-                    for t in self.arg[1]:
+                    for t in symbols.arg[1]:
                         if t.is_even:
                             return False
                         elif t.is_even == None:
@@ -1298,24 +1298,24 @@ class Mul(Expr, AssocOp):
                     return r
                 
                 else:
-                    arg[0].fraction()
-                    if numer(arg[0]) % 2 == 0:
+                    (numer,denom) = coeff.fraction()
+                    if numer % 2 == 0:
                         return False
 
-                    elif denom(arg[0]) % 2 == 0:
-                        denom(arg[0]).factorint()
+                    elif denom % 2 == 0:
+                        factordict = denom.factorint()
                         k = factordict[2]
-                        for t in self.arg[1]:
+                        for t in symbols:
                             if t.is_even:
                                 factor2_num += 1
-                            if t.is_even == None:
+                            elif t.is_even == None:
                                 pass
                         if k < factor2_num:
                             return False
                         else:
                             return None
-                    elif numer(arg[0]) % 2 !== 0 and denom(arg[0]) % 2 !== 0:
-                        for t in self.arg[1]:
+                    elif numer % 2 !== 0 and denom % 2 !== 0:
+                        for t in symbols:
                             if t.is_even:
                                 return False
                             elif t.is_even == None:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1282,6 +1282,7 @@ class Mul(Expr, AssocOp):
         #expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
         
         from sympy.simplify.radsimp import radsimp, fraction
+        from sympy.core.exprtools import Factors
         
         is_integer = self.is_integer
 
@@ -1302,7 +1303,7 @@ class Mul(Expr, AssocOp):
                     return False
 
                 elif denom % 2 == 0:
-                    factordict = denom.factorint()
+                    factordict = Factors(denom)
                     k = factordict[2]
                     for arg in args:
                         if arg.is_even:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1315,6 +1315,7 @@ class Mul(Expr, AssocOp):
                     else:
                         return None
                 elif numer % 2 != 0 and denom % 2 != 0:
+                    r = True
                     for arg in args:
                         if arg.is_even:
                             return False

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1288,7 +1288,7 @@ class Mul(Expr, AssocOp):
         if is_integer:
             (coeff,symbols) = self.as_coeff_mul()
                
-            if coeff == 1             
+            if coeff == 1
                 r = True
                 for t in symbols.arg[1]:
                     if t.is_even:
@@ -1323,7 +1323,7 @@ class Mul(Expr, AssocOp):
                     return r
                                      
         else:
-            return False           
+            return False
 
             
     def _eval_is_even(self):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -92,6 +92,8 @@ class Mul(Expr, AssocOp):
     __slots__ = []
 
     is_Mul = True
+    is_odd = self._eval_is_odd()
+    is_even = self._eval_is_even()
 
     @classmethod
     def flatten(cls, seq):
@@ -1264,39 +1266,33 @@ class Mul(Expr, AssocOp):
         is_integer = self.is_integer
 
         if is_integer:
-            r = True
             count_denom = 0
             count_num = 0
             for t in self.args:
-                    if isinstance(t,symbol):
-                        if not t.is_integer:
-                            if t == S.Half:
-                                count_denom += 1
-                        elif t.is_integer:
-                            if t.is_even:
-                                count_num += 1
-                            elif t.is_odd is None:
-                                r = None
-                                           
-                    if isinstance(t,int):
-                        if self % 2 == 0:
+                if t == S.Half:
+                    count_denom += 1
+                elif isinstance(t,Symbol):
+                    if t.is_integer:
+                        if t.is_even:
                             count_num += 1
-                                
-                
+                        elif t.is_odd is None or t.is_even is None:
+                            return None
+                                               
+                elif isinstance(t,int):
+                    if self % 2 == 0:
+                        count_num += 1                        
+                    
             if count_num == count_denom:
-                r = None
+                return None
             elif count_num > count_denom:
-                r = False
+                return False
             elif count_num < count_denom:
-                r = None
+                return None
 
-            # !integer -> !odd
+                # !integer -> !odd
         else:
-            r = False
-
+            return False
             
-    return r
-
     def _eval_is_even(self):
         is_integer = self.is_integer
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1287,11 +1287,11 @@ class Mul(Expr, AssocOp):
         is_integer = self.is_integer
 
         if is_integer:
-            (coeff,symbols) = self.as_coeff_mul()
+            coeff,symbols = self.as_coeff_mul()
             symbols = list(chain.from_iterable(symbols)) #.as_coeff_mul() returns a tuple for arg[1] so we change it to a list
             if coeff == 1 or coeff == -1:
                 r = True
-                for t in symbols.arg[1]:
+                for t in symbols:
                     if t.is_even:
                         return False
                     elif t.is_even == None:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1261,26 +1261,26 @@ class Mul(Expr, AssocOp):
         return self._eval_pos_neg(-1)     
     
     def _eval_is_odd(self):
-        """
-        First we check to see if the expression as a whole is an integer because
-        !integer implies !odd.  If is_integer, then proceed. Since we are using 
-        .as_coeff_mul(), there are two cases: either all
-        the arguments are symbols or there is a numeric coefficient !==1. 
+        
+        #First we check to see if the expression as a whole is an integer because
+        #!integer implies !odd.  If is_integer, then proceed. Since we are using 
+        #.as_coeff_mul(), there are two cases: either all
+        #the arguments are symbols or there is a numeric coefficient !==1. 
 
-        If we have all symbols, then we only need to find one symbol that is even
-        because an even*odd = even and even*even=even.  Therefore, even if a symbol is
-        None, if a different symbol in the expression is even, then we can still determine
-        that the expression is even, so False.  If no even or None symbols are encountered, 
-        then all symbols must have been odd which would make the expression odd, so True.
+        #If we have all symbols, then we only need to find one symbol that is even
+        #because an even*odd = even and even*even=even.  Therefore, even if a symbol is
+        #None, if a different symbol in the expression is even, then we can still determine
+        #that the expression is even, so False.  If no even or None symbols are encountered, 
+        #then all symbols must have been odd which would make the expression odd, so True.
 
-        If we have a numeric coefficient !==1, then we will use .fraction() to get its
-        numerator ("num") and denominator ("denom").  If the num is even, then the expression
-        is even because .fraction() puts the quotient in lowest terms, so False.  If the
-        denom is even, then we must find its 2-adic valuation to compare the factors of 2
-        in the denom against the factors of 2 in the symbols which are in the num.  Once we 
-        evaluate the denom, then we need to evaluate the symbols that make up the rest of the 
-        expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
-        """
+        #If we have a numeric coefficient !==1, then we will use .fraction() to get its
+        #numerator ("num") and denominator ("denom").  If the num is even, then the expression
+        #is even because .fraction() puts the quotient in lowest terms, so False.  If the
+        #denom is even, then we must find its 2-adic valuation to compare the factors of 2
+        #in the denom against the factors of 2 in the symbols which are in the num.  Once we 
+        #evaluate the denom, then we need to evaluate the symbols that make up the rest of the 
+        #expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
+        
         from sympy.simplify.radsimp import radsimp, fraction
         
         is_integer = self.is_integer

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1263,26 +1263,26 @@ class Mul(Expr, AssocOp):
     
     def _eval_is_odd(self):
 
-    """
-    First we check to see if the expression as a whole is an integer because
-    !integer implies !odd.  If is_integer, then proceed. Since we are using 
-    .as_coeff_mul(), there are two cases: either all
-    the arguments are symbols or there is a numeric coefficient !==1. 
+        """
+        First we check to see if the expression as a whole is an integer because
+        !integer implies !odd.  If is_integer, then proceed. Since we are using 
+        .as_coeff_mul(), there are two cases: either all
+        the arguments are symbols or there is a numeric coefficient !==1. 
 
-    If we have all symbols, then we only need to find one symbol that is even
-    because an even*odd = even and even*even=even.  Therefore, even if a symbol is
-    None, if a different symbol in the expression is even, then we can still determine
-    that the expression is even, so False.  If no even or None symbols are encountered, 
-    then all symbols must have been odd which would make the expression odd, so True.
+        If we have all symbols, then we only need to find one symbol that is even
+        because an even*odd = even and even*even=even.  Therefore, even if a symbol is
+        None, if a different symbol in the expression is even, then we can still determine
+        that the expression is even, so False.  If no even or None symbols are encountered, 
+        then all symbols must have been odd which would make the expression odd, so True.
 
-    If we have a numeric coefficient !==1, then we will use .fraction() to get its
-    numerator ("num") and denominator ("denom").  If the num is even, then the expression
-    is even because .fraction() puts the quotient in lowest terms, so False.  If the
-    denom is even, then we must find its 2-adic valuation to compare the factors of 2
-    in the denom against the factors of 2 in the symbols which are in the num.  Once we 
-    evaluate the denom, then we need to evaluate the symbols that make up the rest of the 
-    expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
-    """
+        If we have a numeric coefficient !==1, then we will use .fraction() to get its
+        numerator ("num") and denominator ("denom").  If the num is even, then the expression
+        is even because .fraction() puts the quotient in lowest terms, so False.  If the
+        denom is even, then we must find its 2-adic valuation to compare the factors of 2
+        in the denom against the factors of 2 in the symbols which are in the num.  Once we 
+        evaluate the denom, then we need to evaluate the symbols that make up the rest of the 
+        expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
+        """
         is_integer = self.is_integer
 
             if is_integer:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1282,13 +1282,11 @@ class Mul(Expr, AssocOp):
         #expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
         
         from sympy.simplify.radsimp import radsimp, fraction
-        from itertools import chain
         
         is_integer = self.is_integer
 
         if is_integer:
             coeff,symbols = self.as_coeff_mul()
-            symbols = list(chain.from_iterable(symbols)) #.as_coeff_mul() returns a tuple for arg[1] so we change it to a list
             if coeff == 1 or coeff == -1:
                 r = True
                 for t in symbols:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1282,12 +1282,13 @@ class Mul(Expr, AssocOp):
         #expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
         
         from sympy.simplify.radsimp import radsimp, fraction
+        from itertools import chain
         
         is_integer = self.is_integer
 
         if is_integer:
             (coeff,symbols) = self.as_coeff_mul()
-               
+            symbols = list(chain.from_iterable(symbols)) #.as_coeff_mul() returns a tuple for arg[1] so we change it to a list
             if coeff == 1 or coeff == -1:
                 r = True
                 for t in symbols.arg[1]:
@@ -1321,7 +1322,7 @@ class Mul(Expr, AssocOp):
                         elif t.is_even == None:
                             r = None
                     return r
-                                     
+        # !integer = !odd                            
         else:
             return False
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1283,7 +1283,7 @@ class Mul(Expr, AssocOp):
                             count_num += 1
                                 
                 
-            if count_num = count_denom:
+            if count_num == count_denom:
                 r = None
             elif count_num > count_denom:
                 r = False

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1282,7 +1282,7 @@ class Mul(Expr, AssocOp):
         #expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
         
         from sympy.simplify.radsimp import radsimp, fraction
-        from sympy.core.exprtools import Factors
+        from sympy.ntheory import factorint
         
         is_integer = self.is_integer
 
@@ -1303,7 +1303,7 @@ class Mul(Expr, AssocOp):
                     return False
 
                 elif denom % 2 == 0:
-                    factordict = Factors(denom,limit=2)
+                    factordict = factorint(denom,limit(>2))
                     k = factordict[2]
                     for arg in args:
                         if arg.is_even:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1287,7 +1287,6 @@ class Mul(Expr, AssocOp):
         is_integer = self.is_integer
 
         if is_integer:
-            factor2_num = 0
             coeff,args = self.as_coeff_mul()
             if coeff == 1 or coeff == -1:
                 r = True
@@ -1304,6 +1303,7 @@ class Mul(Expr, AssocOp):
                     return False
 
                 elif denom % 2 == 0:
+                    factor2_num = 0
                     factordict = factorint(denom,limit=2)
                     k = factordict[2]
                     for arg in args:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1259,9 +1259,9 @@ class Mul(Expr, AssocOp):
         if self.args[0] == -1:
             return (-self).is_positive  # remove -1
         return self._eval_pos_neg(-1)
-    
+
     def _eval_is_odd(self):
-        
+
         #First we check to see if the expression as a whole is an integer because
         #!integer implies !odd.  If is_integer, then proceed. Since we are using 
         #.as_coeff_mul(), there are two cases: either all
@@ -1280,10 +1280,10 @@ class Mul(Expr, AssocOp):
         #in the denom against the factors of 2 in the symbols which are in the num.  Once we 
         #evaluate the denom, then we need to evaluate the symbols that make up the rest of the 
         #expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
-        
+
         from sympy.simplify.radsimp import radsimp, fraction
         from sympy.ntheory import factorint
-        
+
         is_integer = self.is_integer
 
         if is_integer:
@@ -1296,7 +1296,7 @@ class Mul(Expr, AssocOp):
                     elif arg.is_even == None:
                         r = None
                 return r
-                
+    
             else:
                 numer,denom = fraction(coeff)
                 if numer % 2 == 0:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1288,7 +1288,7 @@ class Mul(Expr, AssocOp):
         if is_integer:
             (coeff,symbols) = self.as_coeff_mul()
                
-            if coeff == 1
+            if coeff == 1:
                 r = True
                 for t in symbols.arg[1]:
                     if t.is_even:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1303,7 +1303,7 @@ class Mul(Expr, AssocOp):
                     return False
 
                 elif denom % 2 == 0:
-                    factordict = Factors(denom,limit>2)
+                    factordict = Factors(denom,limit(>2))
                     k = factordict[2]
                     for arg in args:
                         if arg.is_even:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1289,10 +1289,10 @@ class Mul(Expr, AssocOp):
             coeff,symbols = self.as_coeff_mul()
             if coeff == 1 or coeff == -1:
                 r = True
-                for t in symbols:
-                    if t.is_even:
+                for symbol in symbols:
+                    if symbol.is_even:
                         return False
-                    elif t.is_even == None:
+                    elif symbol.is_even == None:
                         r = None
                 return r
                 
@@ -1304,20 +1304,20 @@ class Mul(Expr, AssocOp):
                 elif denom % 2 == 0:
                     factordict = denom.factorint()
                     k = factordict[2]
-                    for t in symbols:
-                        if t.is_even:
+                    for symbol in symbols:
+                        if symbol.is_even:
                             factor2_num += 1
-                        elif t.is_even == None:
+                        elif symbol.is_even == None:
                             pass
                     if k < factor2_num:
                         return False
                     else:
                         return None
                 elif numer % 2 != 0 and denom % 2 != 0:
-                    for t in symbols:
-                        if t.is_even:
+                    for symbol in symbols:
+                        if symbol.is_even:
                             return False
-                        elif t.is_even == None:
+                        elif symbol.is_even == None:
                             r = None
                     return r
         # !integer = !odd                            

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1286,38 +1286,38 @@ class Mul(Expr, AssocOp):
         is_integer = self.is_integer
 
         if is_integer:
-            coeff,symbols = self.as_coeff_mul()
+            coeff,args = self.as_coeff_mul()
             if coeff == 1 or coeff == -1:
                 r = True
-                for symbol in symbols:
-                    if symbol.is_even:
+                for arg in args:
+                    if arg.is_even:
                         return False
-                    elif symbol.is_even == None:
+                    elif arg.is_even == None:
                         r = None
                 return r
                 
             else:
-                (numer,denom) = fraction(coeff)
+                numer,denom = fraction(coeff)
                 if numer % 2 == 0:
                     return False
 
                 elif denom % 2 == 0:
                     factordict = denom.factorint()
                     k = factordict[2]
-                    for symbol in symbols:
-                        if symbol.is_even:
+                    for arg in args:
+                        if arg.is_even:
                             factor2_num += 1
-                        elif symbol.is_even == None:
+                        elif arg.is_even == None:
                             pass
                     if k < factor2_num:
                         return False
                     else:
                         return None
                 elif numer % 2 != 0 and denom % 2 != 0:
-                    for symbol in symbols:
-                        if symbol.is_even:
+                    for arg in args:
+                        if arg.is_even:
                             return False
-                        elif symbol.is_even == None:
+                        elif arg.is_even == None:
                             r = None
                     return r
         # !integer = !odd                            

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1266,6 +1266,11 @@ class Mul(Expr, AssocOp):
         is_integer = self.is_integer
 
         if is_integer:
+            #The entire expression is an integer, but it
+            #can be decomposed into fractions (i.e.
+            #numerator and denominator.
+            #The counters keep track of multiples of 2 in
+            #numerator and denominator to determine oddness.
             count_denom = 0
             count_num = 0
             for t in self.args:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1264,25 +1264,38 @@ class Mul(Expr, AssocOp):
         is_integer = self.is_integer
 
         if is_integer:
-            r, acc = True, 1
+            r = True
+            count_denom = 0
+            count_num = 0
             for t in self.args:
-                if not t.is_integer:
-                    return None
-                elif t.is_even:
-                    r = False
-                elif t.is_integer:
-                    if r is False:
-                        pass
-                    elif acc != 1 and (acc + t).is_odd:
-                        r = False
-                    elif t.is_odd is None:
-                        r = None
-                acc = t
-            return r
+                    if isinstance(t,symbol):
+                        if not t.is_integer:
+                            if t == S.Half:
+                                count_denom += 1
+                        elif t.is_integer:
+                            if t.is_even:
+                                count_num += 1
+                            elif t.is_odd is None:
+                                r = None
+                                           
+                    if isinstance(t,int):
+                        if self % 2 == 0:
+                            count_num += 1
+                                
+                
+            if count_num = count_denom:
+                r = None
+            elif count_num > count_denom:
+                r = False
+            elif count_num < count_denom:
+                r = None
 
-        # !integer -> !odd
-        elif is_integer is False:
-            return False
+            # !integer -> !odd
+        else:
+            r = False
+
+            
+    return r
 
     def _eval_is_even(self):
         is_integer = self.is_integer

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1262,26 +1262,27 @@ class Mul(Expr, AssocOp):
         return self._eval_pos_neg(-1)     
     
     def _eval_is_odd(self):
- 
-  """ First we check to see if the expression as a whole is an integer because
-  !integer implies !odd.  If is_integer, then proceed. Since we are using 
-  .as_coeff_mul(), there are two cases: either all
-  the arguments are symbols or there is a numeric coefficient !==1. 
-  
-  If we have all symbols, then we only need to find one symbol that is even
-  because an even*odd = even and even*even=even.  Therefore, even if a symbol is
-  None, if a different symbol in the expression is even, then we can still determine
-  that the expression is even, so False.  If no even or None symbols are encountered, 
-  then all symbols must have been odd which would make the expression odd, so True.
-  
-  If we have a numeric coefficient !==1, then we will use .fraction() to get its
-  numerator ("num") and denominator ("denom").  If the num is even, then the expression
-  is even because .fraction() puts the quotient in lowest terms, so False.  If the
-  denom is even, then we must find its 2-adic valuation to compare the factors of 2
-  in the denom against the factors of 2 in the num.  Once we evaluate the denom, then
-  we need to evaluate the symbols that make up the rest of the expression.  If
-  more factors of 2 in the num, then even.  Else, not enough info, so None.
-  """
+
+    """
+    First we check to see if the expression as a whole is an integer because
+    !integer implies !odd.  If is_integer, then proceed. Since we are using 
+    .as_coeff_mul(), there are two cases: either all
+    the arguments are symbols or there is a numeric coefficient !==1. 
+
+    If we have all symbols, then we only need to find one symbol that is even
+    because an even*odd = even and even*even=even.  Therefore, even if a symbol is
+    None, if a different symbol in the expression is even, then we can still determine
+    that the expression is even, so False.  If no even or None symbols are encountered, 
+    then all symbols must have been odd which would make the expression odd, so True.
+
+    If we have a numeric coefficient !==1, then we will use .fraction() to get its
+    numerator ("num") and denominator ("denom").  If the num is even, then the expression
+    is even because .fraction() puts the quotient in lowest terms, so False.  If the
+    denom is even, then we must find its 2-adic valuation to compare the factors of 2
+    in the denom against the factors of 2 in the num.  Once we evaluate the denom, then
+    we need to evaluate the symbols that make up the rest of the expression.  If
+    more factors of 2 in the num, then even.  Else, not enough info, so None.
+    """
         is_integer = self.is_integer
 
             if is_integer:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1288,7 +1288,7 @@ class Mul(Expr, AssocOp):
         if is_integer:
             (coeff,symbols) = self.as_coeff_mul()
                
-            if coeff == 1:
+            if coeff == 1 or coeff == -1:
                 r = True
                 for t in symbols.arg[1]:
                     if t.is_even:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1314,7 +1314,7 @@ class Mul(Expr, AssocOp):
                         return False
                     else:
                         return None
-                elif numer % 2 !== 0 and denom % 2 !== 0:
+                elif numer % 2 != 0 and denom % 2 != 0:
                     for t in symbols:
                         if t.is_even:
                             return False

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -12,6 +12,7 @@ from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group
 from .compatibility import reduce, range
 from .expr import Expr
+from sympy.simplify.radsimp import radsimp, fraction
 
 # internal marker to indicate:
 #   "there are still non-commutative objects -- don't forget to process them"
@@ -1265,38 +1266,44 @@ class Mul(Expr, AssocOp):
     def _eval_is_odd(self):
         is_integer = self.is_integer
 
-        if is_integer:
-            #The entire expression is an integer, but it
-            #can be decomposed into fractions (i.e.
-            #numerator and denominator.
-            #The counters keep track of multiples of 2 in
-            #numerator and denominator to determine oddness.
-            count_denom = 0
-            count_num = 0
-            for t in self.args:
-                if t == S.Half:
-                    count_denom += 1
-                elif isinstance(t,Symbol):
-                    if t.is_integer:
+            if is_integer:
+                self.as_coeff_mul()
+               
+                if arg[0] == 1
+                r = True
+                    for t in self.arg[1]:
                         if t.is_even:
-                            count_num += 1
-                        elif t.is_odd is None or t.is_even is None:
-                            return None
-                                               
-                elif isinstance(t,int):
-                    if self % 2 == 0:
-                        count_num += 1                        
-                    
-            if count_num == count_denom:
-                return None
-            elif count_num > count_denom:
-                return False
-            elif count_num < count_denom:
-                return None
+                            return False
+                        elif t.is_even == None:
+                            r = None
+                    return r
+                
+                else:
+                    arg[0].fraction()
+                    if numer(arg[0]) % 2 == 0:
+                        return False
 
-                # !integer -> !odd
-        else:
-            return False
+                    elif denom(arg[0]) % 2 == 0:
+                        denom(arg[0]).factorint()
+                        k = factordict[2]
+                        for t in self.arg[1]:
+                            if t.is_even:
+                                factor2_num += 1
+                            if t.is_even == None:
+                                pass
+                        if k < factor2_num:
+                            return False
+                        else:
+                            return None
+                    elif numer(arg[0]) % 2 !== 0 and denom(arg[0]) % 2 !== 0:
+                        for t in self.arg[1]:
+                            if t.is_even:
+                                return False
+                            elif t.is_even == None:
+                                r = None
+                        return r
+                        
+
             
     def _eval_is_even(self):
         is_integer = self.is_integer

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1298,7 +1298,7 @@ class Mul(Expr, AssocOp):
                 return r
                 
             else:
-                (numer,denom) = coeff.fraction()
+                (numer,denom) = fraction(coeff)
                 if numer % 2 == 0:
                     return False
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1303,7 +1303,7 @@ class Mul(Expr, AssocOp):
                     return False
 
                 elif denom % 2 == 0:
-                    factordict = factorint(denom,limit(>2))
+                    factordict = factorint(denom,limit=2)
                     k = factordict[2]
                     for arg in args:
                         if arg.is_even:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1261,9 +1261,29 @@ class Mul(Expr, AssocOp):
     def _eval_is_negative(self):
         if self.args[0] == -1:
             return (-self).is_positive  # remove -1
-        return self._eval_pos_neg(-1)
-
+        return self._eval_pos_neg(-1)     
+    
     def _eval_is_odd(self):
+ 
+  """ First we check to see if the expression as a whole is an integer because
+  !integer implies !odd.  If is_integer, then proceed. Since we are using 
+  .as_coeff_mul(), there are two cases: either all
+  the arguments are symbols or there is a numeric coefficient !==1. 
+  
+  If we have all symbols, then we only need to find one symbol that is even
+  because an even*odd = even and even*even=even.  Therefore, even if a symbol is
+  None, if a different symbol in the expression is even, then we can still determine
+  that the expression is even, so False.  If no even or None symbols are encountered, 
+  then all symbols must have been odd which would make the expression odd, so True.
+  
+  If we have a numeric coefficient !==1, then we will use .fraction() to get its
+  numerator ("num") and denominator ("denom").  If the num is even, then the expression
+  is even because .fraction() puts the quotient in lowest terms, so False.  If the
+  denom is even, then we must find its 2-adic valuation to compare the factors of 2
+  in the denom against the factors of 2 in the num.  Once we evaluate the denom, then
+  we need to evaluate the symbols that make up the rest of the expression.  If
+  more factors of 2 in the num, then even.  Else, not enough info, so None.
+  """
         is_integer = self.is_integer
 
             if is_integer:
@@ -1302,7 +1322,9 @@ class Mul(Expr, AssocOp):
                             elif t.is_even == None:
                                 r = None
                         return r
-                        
+                                     
+            else:
+                return False           
 
             
     def _eval_is_even(self):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1303,7 +1303,7 @@ class Mul(Expr, AssocOp):
                     return False
 
                 elif denom % 2 == 0:
-                    factordict = Factors(denom)
+                    factordict = Factors(denom,limit>2)
                     k = factordict[2]
                     for arg in args:
                         if arg.is_even:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1285,45 +1285,45 @@ class Mul(Expr, AssocOp):
         """
         is_integer = self.is_integer
 
-            if is_integer:
-                (coeff,symbols) = self.as_coeff_mul()
+        if is_integer:
+            (coeff,symbols) = self.as_coeff_mul()
                
-                if coeff == 1
+            if coeff == 1             
                 r = True
-                    for t in symbols.arg[1]:
+                for t in symbols.arg[1]:
+                    if t.is_even:
+                        return False
+                    elif t.is_even == None:
+                        r = None
+                return r
+                
+            else:
+                (numer,denom) = coeff.fraction()
+                if numer % 2 == 0:
+                    return False
+
+                elif denom % 2 == 0:
+                    factordict = denom.factorint()
+                    k = factordict[2]
+                    for t in symbols:
+                        if t.is_even:
+                            factor2_num += 1
+                        elif t.is_even == None:
+                            pass
+                    if k < factor2_num:
+                        return False
+                    else:
+                        return None
+                elif numer % 2 !== 0 and denom % 2 !== 0:
+                    for t in symbols:
                         if t.is_even:
                             return False
                         elif t.is_even == None:
                             r = None
                     return r
-                
-                else:
-                    (numer,denom) = coeff.fraction()
-                    if numer % 2 == 0:
-                        return False
-
-                    elif denom % 2 == 0:
-                        factordict = denom.factorint()
-                        k = factordict[2]
-                        for t in symbols:
-                            if t.is_even:
-                                factor2_num += 1
-                            elif t.is_even == None:
-                                pass
-                        if k < factor2_num:
-                            return False
-                        else:
-                            return None
-                    elif numer % 2 !== 0 and denom % 2 !== 0:
-                        for t in symbols:
-                            if t.is_even:
-                                return False
-                            elif t.is_even == None:
-                                r = None
-                        return r
                                      
-            else:
-                return False           
+        else:
+            return False           
 
             
     def _eval_is_even(self):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1303,7 +1303,7 @@ class Mul(Expr, AssocOp):
                     return False
 
                 elif denom % 2 == 0:
-                    factordict = Factors(denom,limit(>2))
+                    factordict = Factors(denom,limit=2)
                     k = factordict[2]
                     for arg in args:
                         if arg.is_even:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1258,7 +1258,7 @@ class Mul(Expr, AssocOp):
     def _eval_is_negative(self):
         if self.args[0] == -1:
             return (-self).is_positive  # remove -1
-        return self._eval_pos_neg(-1)     
+        return self._eval_pos_neg(-1)
     
     def _eval_is_odd(self):
         

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -12,7 +12,6 @@ from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group
 from .compatibility import reduce, range
 from .expr import Expr
-from sympy.simplify.radsimp import radsimp, fraction
 
 # internal marker to indicate:
 #   "there are still non-commutative objects -- don't forget to process them"
@@ -1262,7 +1261,6 @@ class Mul(Expr, AssocOp):
         return self._eval_pos_neg(-1)     
     
     def _eval_is_odd(self):
-
         """
         First we check to see if the expression as a whole is an integer because
         !integer implies !odd.  If is_integer, then proceed. Since we are using 
@@ -1283,6 +1281,8 @@ class Mul(Expr, AssocOp):
         evaluate the denom, then we need to evaluate the symbols that make up the rest of the 
         expression.  If more factors of 2 in the num, then even.  Else, not enough info, so None.
         """
+        from sympy.simplify.radsimp import radsimp, fraction
+        
         is_integer = self.is_integer
 
         if is_integer:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -93,8 +93,6 @@ class Mul(Expr, AssocOp):
     __slots__ = []
 
     is_Mul = True
-    is_odd = self._eval_is_odd()
-    is_even = self._eval_is_even()
 
     @classmethod
     def flatten(cls, seq):


### PR DESCRIPTION
Changed the function _eval_is_odd to handle integer inputs that have a denominator, such as 
```
n = Symbol('n',integer=True,even=True)
m = Symbol('m',integer=true,even=True)
x = Mul(n,m,S.Half)
```
The example expression x is recognized by SymPy as an integer, but can be decomposed into n,m,and 1/2.  My new function evaluates the oddness of each part and uses this to calculate the oddness of the entire integer.

Addresses issue #8648 