### PR TITLE
Travis to use the old version of theano

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -264,7 +264,7 @@ before_install:
   - |
     if [[ "${TEST_THEANO}" == "true" ]]; then
         # this assumes TEST_THEANO runs in the same build as TEST_MATPLOTLIB
-        conda install theano;
+        conda install theano = 0.8.2;
     fi
   - |
     if [[ "${TEST_AUTOWRAP}" == "true" ]]; then


### PR DESCRIPTION
Recently `theano` was updated from **0.8.2** to **0.9.0** which was leading to fall of all `theano` jobs for Travis. For example, see #12368  
This has been fixed and after this, `theano` jobs would be working quite properly
