### PR TITLE
Fix #12361: change all misspelling Bareis to Bareiss

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1386,7 +1386,7 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
     return m
 
 
-def wronskian(functions, var, method='bareis'):
+def wronskian(functions, var, method='bareiss'):
     """
     Compute Wronskian for [] of functions
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2630,8 +2630,8 @@ class MatrixBase(MatrixArithmetic, MatrixOperations, MatrixProperties, MatrixSha
             raise AttributeError
         return self.H * mgamma(0)
 
-    def det_bareis(self):
-        """Compute matrix determinant using Bareis' fraction-free
+    def det_bareiss(self):
+        """Compute matrix determinant using Bareiss' fraction-free
         algorithm which is an extension of the well known Gaussian
         elimination method. This approach is best suited for dense
         symbolic matrices and will result in a determinant with
@@ -2680,7 +2680,7 @@ class MatrixBase(MatrixArithmetic, MatrixOperations, MatrixProperties, MatrixSha
                     else:
                         return S.Zero
 
-                # proceed with Bareis' fraction-free (FF)
+                # proceed with Bareiss' fraction-free (FF)
                 # form of Gaussian elimination algorithm
                 for i in range(k + 1, n):
                     for j in range(k + 1, n):
@@ -2714,7 +2714,7 @@ class MatrixBase(MatrixArithmetic, MatrixOperations, MatrixProperties, MatrixSha
 
 
         det
-        det_bareis
+        det_bareiss
         berkowitz_det
         """
         if not self.is_square:
@@ -2733,18 +2733,18 @@ class MatrixBase(MatrixArithmetic, MatrixOperations, MatrixProperties, MatrixSha
 
         return prod.expand()
 
-    def det(self, method="bareis"):
+    def det(self, method="bareiss"):
         """Computes the matrix determinant using the method "method".
 
         Possible values for "method":
-          bareis ... det_bareis
+          bareiss ... det_bareiss
           berkowitz ... berkowitz_det
           det_LU ... det_LU_decomposition
 
         See Also
         ========
 
-        det_bareis
+        det_bareiss
         berkowitz_det
         det_LU
         """
@@ -2756,8 +2756,8 @@ class MatrixBase(MatrixArithmetic, MatrixOperations, MatrixProperties, MatrixSha
             raise NonSquareMatrixError()
         if not self:
             return S.One
-        if method == "bareis":
-            return self.det_bareis()
+        if method == "bareiss":
+            return self.det_bareiss()
         elif method == "berkowitz":
             return self.berkowitz_det()
         elif method == "det_LU":

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -309,7 +309,7 @@ def test_determinant():
     for M in [Matrix(), Matrix([[1]])]:
         assert (
             M.det() ==
-            M.det_bareis() ==
+            M.det_bareiss() ==
             M.berkowitz_det() ==
             M.det_LU_decomposition() ==
             1)
@@ -317,20 +317,20 @@ def test_determinant():
     M = Matrix(( (-3,  2),
                  ( 8, -5) ))
 
-    assert M.det(method="bareis") == -1
+    assert M.det(method="bareiss") == -1
     assert M.det(method="berkowitz") == -1
 
     M = Matrix(( (x,   1),
                  (y, 2*y) ))
 
-    assert M.det(method="bareis") == 2*x*y - y
+    assert M.det(method="bareiss") == 2*x*y - y
     assert M.det(method="berkowitz") == 2*x*y - y
 
     M = Matrix(( (1, 1, 1),
                  (1, 2, 3),
                  (1, 3, 6) ))
 
-    assert M.det(method="bareis") == 1
+    assert M.det(method="bareiss") == 1
     assert M.det(method="berkowitz") == 1
 
     M = Matrix(( ( 3, -2,  0, 5),
@@ -338,7 +338,7 @@ def test_determinant():
                  ( 0, -2,  5, 0),
                  ( 5,  0,  3, 4) ))
 
-    assert M.det(method="bareis") == -289
+    assert M.det(method="bareiss") == -289
     assert M.det(method="berkowitz") == -289
 
     M = Matrix(( ( 1,  2,  3,  4),
@@ -346,7 +346,7 @@ def test_determinant():
                  ( 9, 10, 11, 12),
                  (13, 14, 15, 16) ))
 
-    assert M.det(method="bareis") == 0
+    assert M.det(method="bareiss") == 0
     assert M.det(method="berkowitz") == 0
 
     M = Matrix(( (3, 2, 0, 0, 0),
@@ -355,7 +355,7 @@ def test_determinant():
                  (0, 0, 0, 3, 2),
                  (2, 0, 0, 0, 3) ))
 
-    assert M.det(method="bareis") == 275
+    assert M.det(method="bareiss") == 275
     assert M.det(method="berkowitz") == 275
 
     M = Matrix(( (1, 0,  1,  2, 12),
@@ -364,7 +364,7 @@ def test_determinant():
                  (3, 2, -1,  1,  8),
                  (1, 1,  1,  0,  6) ))
 
-    assert M.det(method="bareis") == -55
+    assert M.det(method="bareiss") == -55
     assert M.det(method="berkowitz") == -55
 
     M = Matrix(( (-5,  2,  3,  4,  5),
@@ -373,7 +373,7 @@ def test_determinant():
                  ( 1,  2,  3, -2,  5),
                  ( 1,  2,  3,  4, -1) ))
 
-    assert M.det(method="bareis") == 11664
+    assert M.det(method="bareiss") == 11664
     assert M.det(method="berkowitz") == 11664
 
     M = Matrix(( ( 2,  7, -1, 3, 2),
@@ -382,14 +382,14 @@ def test_determinant():
                  (-3, -2,  4, 5, 3),
                  ( 1,  0,  0, 0, 1) ))
 
-    assert M.det(method="bareis") == 123
+    assert M.det(method="bareiss") == 123
     assert M.det(method="berkowitz") == 123
 
     M = Matrix(( (x, y, z),
                  (1, 0, 0),
                  (y, z, x) ))
 
-    assert M.det(method="bareis") == z**2 - x*y
+    assert M.det(method="bareiss") == z**2 - x*y
     assert M.det(method="berkowitz") == z**2 - x*y
 
 
@@ -1807,7 +1807,7 @@ def test_errors():
     raises(NonSquareMatrixError, lambda: Matrix([1, 2]).det())
     raises(ValueError,
         lambda: Matrix([[1, 2], [3, 4]]).det(method='Not a real method'))
-    raises(NonSquareMatrixError, lambda: Matrix([1, 2]).det_bareis())
+    raises(NonSquareMatrixError, lambda: Matrix([1, 2]).det_bareiss())
     raises(NonSquareMatrixError, lambda: Matrix([1, 2]).berkowitz())
     raises(NonSquareMatrixError, lambda: Matrix([1, 2]).berkowitz_det())
     raises(ValueError,


### PR DESCRIPTION
I have fixed the misspelling "Bareis" into "Bareiss" in sympy/sympy/matrices/matrices.py and sympy/sympy/matrices/test/test_matrices.py
