### PR TITLE
Global option to stop automatic distribution

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -26,7 +26,7 @@ from .function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
 from .evalf import PrecisionExhausted, N
 from .containers import Tuple, Dict
 from .exprtools import gcd_terms, factor_terms, factor_nc
-from .evaluate import evaluate
+from .evaluate import evaluate, distribute
 
 # expose singletons
 Catalan = S.Catalan

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -26,7 +26,7 @@ from .function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
 from .evalf import PrecisionExhausted, N
 from .containers import Tuple, Dict
 from .exprtools import gcd_terms, factor_terms, factor_nc
-from .evaluate import evaluate, distribute
+from .evaluate import evaluate
 
 # expose singletons
 Catalan = S.Catalan

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -822,7 +822,7 @@ class Add(Expr, AssocOp):
         return self.func(*[t.transpose() for t in self.args])
 
     def __neg__(self):
-        return self.func(*[-t for t in self.args])
+        return self*(-1)
 
     def _sage_(self):
         s = 0

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -9,7 +9,17 @@ class _global_evaluate(list):
         clear_cache()
         super(_global_evaluate, self).__setitem__(key, value)
 
+
+class _global_distribute(list):
+    """ The cache must be cleared whenever global_distribute is changed. """
+
+    def __setitem__(self, key, value):
+        clear_cache()
+        super(_global_distribute, self).__setitem__(key, value)
+
+
 global_evaluate = _global_evaluate([True])
+global_distribute = _global_distribute([True])
 
 
 @contextmanager
@@ -40,3 +50,29 @@ def evaluate(x):
     global_evaluate[0] = x
     yield
     global_evaluate[0] = old
+
+
+@contextmanager
+def distribute(x):
+    """ Control automatic distribution of Number over Add
+
+    This context managers controls whether or not Mul distribute Number over
+    Add
+
+    Examples
+    ========
+
+    >>> from sympy.abc import x
+    >>> from sympy.core.evaluate import distribute
+    >>> print(2*(x + 1))
+    2*x + 2
+    >>> with distribute(False):
+    ...     print(2*(x + 1))
+    2*(x + 1)
+    """
+
+    old = global_distribute[0]
+
+    global_distribute[0] = x
+    yield
+    global_distribute[0] = old

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -8,7 +8,7 @@ class _global_function(list):
     def __setitem__(self, key, value):
         if (self[key] != value):
             clear_cache()
-        super(_global_evaluate, self).__setitem__(key, value)
+        super(_global_function, self).__setitem__(key, value)
 
 
 global_evaluate = _global_function([True])

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -2,24 +2,16 @@ from .cache import clear_cache
 from contextlib import contextmanager
 
 
-class _global_evaluate(list):
-    """ The cache must be cleared whenever global_evaluate is changed. """
+class _global_function(list):
+    """ The cache must be cleared whenever _global_function is changed. """
 
     def __setitem__(self, key, value):
         clear_cache()
         super(_global_evaluate, self).__setitem__(key, value)
 
 
-class _global_distribute(list):
-    """ The cache must be cleared whenever global_distribute is changed. """
-
-    def __setitem__(self, key, value):
-        clear_cache()
-        super(_global_distribute, self).__setitem__(key, value)
-
-
-global_evaluate = _global_evaluate([True])
-global_distribute = _global_distribute([True])
+global_evaluate = _global_function([True])
+global_distribute = _global_function([True])
 
 
 @contextmanager

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -50,7 +50,8 @@ def distribute(x):
     """ Control automatic distribution of Number over Add
 
     This context managers controls whether or not Mul distribute Number over
-    Add
+    Add. Plan is to avoid distributing Number over Add in all of sympy. Once
+    that is done, this contextmanager will be removed.
 
     Examples
     ========

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -6,7 +6,8 @@ class _global_function(list):
     """ The cache must be cleared whenever _global_function is changed. """
 
     def __setitem__(self, key, value):
-        clear_cache()
+        if (self[key] != value):
+            clear_cache()
         super(_global_evaluate, self).__setitem__(key, value)
 
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -186,17 +186,14 @@ class Mul(Expr, AssocOp):
                         # leave the Mul as a Mul
                         rv = [cls(a*r, b, evaluate=False)], [], None
                     elif b.is_commutative:
-                        if a is S.One:
-                            rv = [b], [], None
-                        else:
-                            r, b = b.as_coeff_Add()
-                            bargs = [_keep_coeff(a, bi) for bi in Add.make_args(b)]
-                            _addsort(bargs)
-                            ar = a*r
-                            if ar:
-                                bargs.insert(0, ar)
-                            bargs = [Add._from_args(bargs)]
-                            rv = bargs, [], None
+                        r, b = b.as_coeff_Add()
+                        bargs = [_keep_coeff(a, bi) for bi in Add.make_args(b)]
+                        _addsort(bargs)
+                        ar = a*r
+                        if ar:
+                            bargs.insert(0, ar)
+                        bargs = [Add._from_args(bargs)]
+                        rv = bargs, [], None
             if rv:
                 return rv
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -12,6 +12,7 @@ from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group
 from .compatibility import reduce, range
 from .expr import Expr
+from .evaluate import global_distribute
 
 # internal marker to indicate:
 #   "there are still non-commutative objects -- don't forget to process them"
@@ -185,7 +186,7 @@ class Mul(Expr, AssocOp):
                     if r is not S.One:  # 2-arg hack
                         # leave the Mul as a Mul
                         rv = [cls(a*r, b, evaluate=False)], [], None
-                    elif b.is_commutative:
+                    elif global_distribute[0] and b.is_commutative:
                         r, b = b.as_coeff_Add()
                         bargs = [_keep_coeff(a, bi) for bi in Add.make_args(b)]
                         _addsort(bargs)
@@ -606,7 +607,7 @@ class Mul(Expr, AssocOp):
             c_part.insert(0, coeff)
 
         # we are done
-        if (not nc_part and len(c_part) == 2 and c_part[0].is_Number and
+        if (global_distribute[0] and not nc_part and len(c_part) == 2 and c_part[0].is_Number and
                 c_part[1].is_Add):
             # 2*(1+a) -> 2 + 2 * a
             coeff = c_part[0]

--- a/sympy/core/tests/test_priority.py
+++ b/sympy/core/tests/test_priority.py
@@ -47,6 +47,9 @@ class Higher(Expr):
     def __rdiv__(self, other):
         return self.result
 
+    def _eval_is_commutative(self):
+        return True
+
     __truediv__ = __div__
     __rtruediv__ = __rdiv__
 

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -235,7 +235,7 @@ def test_commutation():
     c = Commutator(F(m), Fd(m))
     assert c == +1 - 2*NO(Fd(m)*F(m))
     c = Commutator(Fd(m), F(m))
-    assert c == -1 + 2*NO(Fd(m)*F(m))
+    assert c.expand() == -1 + 2*NO(Fd(m)*F(m))
 
     C = Commutator
     X, Y, Z = symbols('X,Y,Z', commutative=False)


### PR DESCRIPTION
Partial fix for #4596

Here's a small benchmark from the issue

```Python
from sympy import *
from sympy.core.cache import *
knl = sympify("hankel_1(0, k*sqrt((a0 + b0*tau)**2 + (a1 + b1*tau)**2))")

def func(dist, simplify):
    with(distribute(dist)):
        ops=diff(knl, "tau", 5, simplify=simplify)
        print(ops.count_ops())

clear_cache()
%time func(True, True)
clear_cache()
%time func(True, False)
clear_cache()
%time func(False, True)
clear_cache()
%time func(False, False)
```

with the output,
```
417
CPU times: user 744 ms, sys: 0 ns, total: 744 ms
Wall time: 742 ms
3133
CPU times: user 276 ms, sys: 0 ns, total: 276 ms
Wall time: 277 ms
417
CPU times: user 340 ms, sys: 0 ns, total: 340 ms
Wall time: 339 ms
488
CPU times: user 156 ms, sys: 0 ns, total: 156 ms
Wall time: 154 ms
```

For this code, when add*number is not distributed with the global option, op count is 488, whereas if it was distributed, op count is 3133. Simplify with both options give the same op count of 417.

Here's some code from the docs where it says, "Because there can be a significant amount of simplification that can be done when multiple differentiations are performed, results will be automatically simplified ..."

```python
>>> from sympy import sqrt, diff
>>> from sympy.abc import x
>>> e = sqrt((x + 1)**2 + x)
>>> diff(e, x, 5, simplify=False).count_ops()
136
>>> diff(e, x, 5).count_ops()
30
```
Here's with no automatic distribution,
```python
>>> from sympy import *
>>> from sympy.abc import x
>>> e = sqrt((x + 1)**2 + x)
>>> with distribute(False):
...     print(diff(e, x, 5, simplify=False).count_ops())
... 
37
>>> with distribute(False):
...     print(diff(e, x, 5).count_ops())
... 
33
```
Note that here the increase in the opcount for `simplify=True` is probably because a bug with simplify.

Thanks to @skirpichev, for figuring out where changes were necessary.

