### PR TITLE
Guard against recursion error in _can_print_latex

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -102,26 +102,33 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         If o is a container type, this is True if and only if every element of
         o can be printed with LaTeX.
         """
-        from sympy import Basic
-        from sympy.matrices import MatrixBase
-        from sympy.physics.vector import Vector, Dyadic
-        from sympy.tensor.array import NDimArray
-        # If you're adding another type, make sure you add it to printable_types
-        # later in this file as well
 
-        if isinstance(o, (list, tuple, set, frozenset)):
-            return all(_can_print_latex(i) for i in o)
-        elif isinstance(o, dict):
-            return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
-        elif isinstance(o, bool):
+        try:
+            from sympy import Basic
+            from sympy.matrices import MatrixBase
+            from sympy.physics.vector import Vector, Dyadic
+            from sympy.tensor.array import NDimArray
+            # If you're adding another type, make sure you add it to printable_types
+            # later in this file as well
+
+            if isinstance(o, (list, tuple, set, frozenset)):
+               return all(_can_print_latex(i) for i in o)
+            elif isinstance(o, dict):
+               return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
+            elif isinstance(o, bool):
+               return False
+            # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
+            # to use here, than these explicit imports.
+            elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic, NDimArray)):
+               return True
+            elif isinstance(o, (float, integer_types)) and print_builtin:
+               return True
             return False
-        # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
-        # to use here, than these explicit imports.
-        elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic, NDimArray)):
-            return True
-        elif isinstance(o, (float, integer_types)) and print_builtin:
-            return True
-        return False
+        except:
+            print("RuntimeError: maximum recursion depth exceeded in comparison")
+            # This is in case maximum recursion depth is reached.
+            # Since RecursionError is for versions of Python 3.5+
+            # so this is to guard against RecursionError for older versions.
 
     def _print_latex_png(o):
         """

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -124,8 +124,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             elif isinstance(o, (float, integer_types)) and print_builtin:
                return True
             return False
-        except:
-            print("RuntimeError: maximum recursion depth exceeded in comparison")
+        except RuntimeError:
+            return False
             # This is in case maximum recursion depth is reached.
             # Since RecursionError is for versions of Python 3.5+
             # so this is to guard against RecursionError for older versions.


### PR DESCRIPTION
Since versions of Python before `Python 3.5` do not support RecursionError. So, we need to check for RuntimeError to support the lower Python versions.
Fixes #12444 
