### PR TITLE
permutation groups: implemented coset transversal and coset table

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -842,8 +842,6 @@ class CosetTable(DefaultPrinting):
         """
         A = self.A
         A_dict = self.A_dict
-        A_dict_inv = self.A_dict_inv
-        X = self.fp_group.generators
         table = self.table
         for x in A:
             z = table[gamma][A_dict[x]]

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -767,7 +767,6 @@ class PermutationGroup(Basic):
 
     def coset_table(self, H):
         """Return the standardised (right) coset table of self in H as a list of lists.
-
         """
         #Maybe this should be made to return an instance of CosetTable from fp_groups.py
         #but the class would need to be changed first to be compatible with PermutationGroups

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1213,7 +1213,7 @@ class PermutationGroup(Basic):
 
         >>> from sympy.combinatorics import Permutation, PermutationGroup
         >>> p = PermutationGroup(Permutation(1, 3), Permutation(1, 2))
-        >>> p.elements
+        >>> p._elements
         [(3), (2 3), (3)(1 2), (1 2 3), (1 3 2), (1 3)]
 
         """

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -685,8 +685,6 @@ class PermutationGroup(Basic):
         Returns a transversal of the right cosets of self by its subgroup H
         using the second method described in [1], Subsection 4.6.7
         '''
-        if not H.is_subgroup(self):
-            raise ValueError("The argument must be a subgroup")
 
         if H.order() == 1:
             return self._elements
@@ -771,6 +769,8 @@ class PermutationGroup(Basic):
         but the class would need to be changed first to be compatible with PermutationGroups
         '''
         from itertools import chain, product
+        if not H.is_subgroup(self):
+            raise ValueError("The argument must be a subgroup")
         T = self.coset_transversal(H)
         n = len(T)
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -685,6 +685,8 @@ class PermutationGroup(Basic):
         Returns a transversal of the right cosets of self by its subgroup H
         using the second method described in [1], Subsection 4.6.7
         '''
+        if not H.is_subgroup(self):
+            raise ValueError("The argument must be a subgroup")
 
         if H.order() == 1:
             return self._elements

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -681,10 +681,11 @@ class PermutationGroup(Basic):
         return self._transversals
 
     def coset_transversal(self, H):
-        '''
-        Returns a transversal of the right cosets of self by its subgroup H
+        """Return a transversal of the right cosets of self by its subgroup H
         using the second method described in [1], Subsection 4.6.7
-        '''
+
+        """
+
         if not H.is_subgroup(self):
             raise ValueError("The argument must be a subgroup")
 
@@ -735,11 +736,11 @@ class PermutationGroup(Basic):
         return T
 
     def _coset_representative(self, g, H):
-        '''
-        Finds the representative of gH from transversal that
+        """Return the representative of gH from the transversal that
         would be computed by `self.coset_transversal(H)`.
         The base of self must be an extension of H.base.
-        '''
+
+        """
         if H.order() == 1:
             return g
         if not(self.base[:len(H.base)] == H.base):
@@ -765,11 +766,12 @@ class PermutationGroup(Basic):
         return step(0, g)
 
     def coset_table(self, H):
-        '''
-        Returns standardised (right) coset table of self in H as a list of lists
-        Maybe this should be made to return an instance of CosetTable from fp_groups.py
-        but the class would need to be changed first to be compatible with PermutationGroups
-        '''
+        """Return the standardised (right) coset table of self in H as a list of lists.
+
+        """
+        #Maybe this should be made to return an instance of CosetTable from fp_groups.py
+        #but the class would need to be changed first to be compatible with PermutationGroups
+
         from itertools import chain, product
         if not H.is_subgroup(self):
             raise ValueError("The argument must be a subgroup")

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -692,17 +692,19 @@ class PermutationGroup(Basic):
         if H.order() == 1:
             return self._elements
 
-        self._schreier_sims(base=H.base) #so that G.base is an extension of H.base
+        self._schreier_sims(base=H.base) # make G.base an extension of H.base
 
         base = self.base
         base_ordering = _base_ordering(base, self.degree)
         identity = Permutation(self.degree - 1)
 
         transversals = self.basic_transversals[:]
-        # transversals is a list of dictionaries. Get rid of the keys so that it is a list
-        # of lists and sort each list in the increasing order of base[l]^x
+        # transversals is a list of dictionaries. Get rid of the keys
+        # so that it is a list of lists and sort each list in
+        # the increasing order of base[l]^x
         for l, t in enumerate(transversals):
-            transversals[l] = sorted(t.values(), key = lambda x: base_ordering[base[l]^x])
+            transversals[l] = sorted(t.values(),
+                                key = lambda x: base_ordering[base[l]^x])
 
         orbits = H.basic_orbits
         h_stabs = H.basic_stabilizers
@@ -710,9 +712,10 @@ class PermutationGroup(Basic):
 
         indices = [x.order()//y.order() for x, y in zip(g_stabs, h_stabs)]
 
-        # T^(l) should be a right transversal of H^(l) in G^(l) for 1<=l<=len(base)
-        # While H^(l) is the trivial group, T^(l) contains all the elements of G^(l)
-        # so we might just as well start with l = len(h_stabs)-1
+        # T^(l) should be a right transversal of H^(l) in G^(l) for
+        # 1<=l<=len(base). While H^(l) is the trivial group, T^(l)
+        # contains all the elements of G^(l) so we might just as well
+        # start with l = len(h_stabs)-1
         T = g_stabs[len(h_stabs)]._elements
         t_len = len(T)
         l = len(h_stabs)-1
@@ -736,13 +739,13 @@ class PermutationGroup(Basic):
         return T
 
     def _coset_representative(self, g, H):
-        """Return the representative of gH from the transversal that
+        """Return the representative of Hg from the transversal that
         would be computed by `self.coset_transversal(H)`.
 
         """
         if H.order() == 1:
             return g
-        #The base of self must be an extension of H.base.
+        # The base of self must be an extension of H.base.
         if not(self.base[:len(H.base)] == H.base):
             self._schreier_sims(base=H.base)
         orbits = H.basic_orbits[:]
@@ -763,10 +766,12 @@ class PermutationGroup(Basic):
         return step(0, g)
 
     def coset_table(self, H):
-        """Return the standardised (right) coset table of self in H as a list of lists.
+        """Return the standardised (right) coset table of self in H as
+        a list of lists.
         """
-        #Maybe this should be made to return an instance of CosetTable from fp_groups.py
-        #but the class would need to be changed first to be compatible with PermutationGroups
+        # Maybe this should be made to return an instance of CosetTable
+        # from fp_groups.py but the class would need to be changed first
+        # to be compatible with PermutationGroups
 
         from itertools import chain, product
         if not H.is_subgroup(self):
@@ -774,8 +779,8 @@ class PermutationGroup(Basic):
         T = self.coset_transversal(H)
         n = len(T)
 
-        A = list(chain.from_iterable((gen, gen**-1) \
-                for gen in self.generators))
+        A = list(chain.from_iterable((gen, gen**-1)
+                    for gen in self.generators))
 
         table = []
         for i in range(n):
@@ -785,8 +790,8 @@ class PermutationGroup(Basic):
 
 
         # standardize (this is the same as the algorithm used in fp_groups)
-        # If CosetTable is made compatible with PermutationGroups, this should
-        # be replaced by table.standardize()
+        # If CosetTable is made compatible with PermutationGroups, this
+        # should be replaced by table.standardize()
         A = range(len(A))
         gamma = 1
         for alpha, a in product(range(n), A):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -699,7 +699,7 @@ class PermutationGroup(Basic):
         identity = Permutation(self.degree - 1)
 
         transversals = self.basic_transversals[:]
-        # transversals is a dictionary. Get rid of the keys so that it is a list
+        # transversals is a list of dictionaries. Get rid of the keys so that it is a list
         # of lists and sort each list in the increasing order of base[l]^x
         for l, t in enumerate(transversals):
             transversals[l] = sorted(t.values(), key = lambda x: base_ordering[base[l]^x])
@@ -708,7 +708,7 @@ class PermutationGroup(Basic):
         h_stabs = H.basic_stabilizers
         g_stabs = self.basic_stabilizers
 
-        indices = [x.order()/y.order() for x, y in zip(g_stabs, h_stabs)]
+        indices = [x.order()//y.order() for x, y in zip(g_stabs, h_stabs)]
 
         # T^(l) should be a right transversal of H^(l) in G^(l) for 1<=l<=len(base)
         # While H^(l) is the trivial group, T^(l) contains all the elements of G^(l)
@@ -716,7 +716,7 @@ class PermutationGroup(Basic):
         T = g_stabs[len(h_stabs)]._elements
         t_len = len(T)
         l = len(h_stabs)-1
-        while l>-1:
+        while l > -1:
             T_next = []
             for u in transversals[l]:
                 if u == identity:
@@ -738,27 +738,24 @@ class PermutationGroup(Basic):
     def _coset_representative(self, g, H):
         """Return the representative of gH from the transversal that
         would be computed by `self.coset_transversal(H)`.
-        The base of self must be an extension of H.base.
 
         """
         if H.order() == 1:
             return g
+        #The base of self must be an extension of H.base.
         if not(self.base[:len(H.base)] == H.base):
             self._schreier_sims(base=H.base)
-        orbits = H.basic_orbits
-        stabilizers = H.basic_stabilizers
-        transversals = self.basic_transversals
+        orbits = H.basic_orbits[:]
+        h_transversals = [_.values() for _ in H.basic_transversals]
+        transversals = [_.values() for _ in self.basic_transversals]
         base = self.base
         base_ordering = _base_ordering(base, self.degree)
         def step(l, x):
-            gammas = sorted(orbits[l], key = lambda y: base_ordering[y^x])
-            gamma = gammas[0]
-            for h in stabilizers[l]._elements:
-                if base[l]^h == gamma:
-                    break
-            x = h*x
-            if l<len(orbits)-1:
-                for u in transversals[l].values():
+            gamma = sorted(orbits[l], key = lambda y: base_ordering[y^x])[0]
+            i = [base[l]^h for h in h_transversals[l]].index(gamma)
+            x = h_transversals[l][i]*x
+            if l < len(orbits)-1:
+                for u in transversals[l]:
                     if base[l]^u == base[l]^x:
                         break
                 x = step(l+1, x*u**-1)*u

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -746,8 +746,8 @@ class PermutationGroup(Basic):
         if not(self.base[:len(H.base)] == H.base):
             self._schreier_sims(base=H.base)
         orbits = H.basic_orbits[:]
-        h_transversals = [_.values() for _ in H.basic_transversals]
-        transversals = [_.values() for _ in self.basic_transversals]
+        h_transversals = [list(_.values()) for _ in H.basic_transversals]
+        transversals = [list(_.values()) for _ in self.basic_transversals]
         base = self.base
         base_ordering = _base_ordering(base, self.degree)
         def step(l, x):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1214,7 +1214,7 @@ class PermutationGroup(Basic):
         >>> from sympy.combinatorics import Permutation, PermutationGroup
         >>> p = PermutationGroup(Permutation(1, 3), Permutation(1, 2))
         >>> p._elements
-        [(3), (2 3), (3)(1 2), (1 2 3), (1 3 2), (1 3)]
+        [(3), (3)(1 2), (1 3), (2 3), (1 2 3), (1 3 2)]
 
         """
         return list(islice(self.generate(), None))

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -731,19 +731,19 @@ def test_coset_transvesal():
     G = AlternatingGroup(5)
     H = PermutationGroup(Permutation(0,1,2),Permutation(1,2)(3,4))
     assert G.coset_transversal(H) == \
-        [Permutation(4), Permutation(2, 3, 4), Permutation(2, 4, 3),\
-         Permutation(1, 2, 4), Permutation(4)(1, 2, 3), Permutation(1, 3)(2, 4),\
-         Permutation(0, 1, 2, 3, 4), Permutation(0, 1, 2, 4, 3),\
+        [Permutation(4), Permutation(2, 3, 4), Permutation(2, 4, 3),
+         Permutation(1, 2, 4), Permutation(4)(1, 2, 3), Permutation(1, 3)(2, 4),
+         Permutation(0, 1, 2, 3, 4), Permutation(0, 1, 2, 4, 3),
          Permutation(0, 1, 3, 2, 4), Permutation(0, 2, 4, 1, 3)]
 
 def test_coset_table():
-    G = PermutationGroup(Permutation(0,1,2,3), Permutation(0,1,2),\
+    G = PermutationGroup(Permutation(0,1,2,3), Permutation(0,1,2),
          Permutation(0,4,2,7), Permutation(5,6), Permutation(0,7));
     H = PermutationGroup(Permutation(0,1,2,3), Permutation(0,7))
     assert G.coset_table(H) == \
-        [[0, 0, 0, 0, 1, 2, 3, 3, 0, 0], [4, 5, 2, 5, 6, 0, 7, 7, 1, 1],\
-         [5, 4, 5, 1, 0, 6, 8, 8, 6, 6], [3, 3, 3, 3, 7, 8, 0, 0, 3, 3],\
-         [2, 1, 4, 4, 4, 4, 9, 9, 4, 4], [1, 2, 1, 2, 5, 5, 10, 10, 5, 5],\
-         [6, 6, 6, 6, 2, 1, 11, 11, 2, 2], [9, 10, 8, 10, 11, 3, 1, 1, 7, 7],\
-         [10, 9, 10, 7, 3, 11, 2, 2, 11, 11], [8, 7, 9, 9, 9, 9, 4, 4, 9, 9],\
+        [[0, 0, 0, 0, 1, 2, 3, 3, 0, 0], [4, 5, 2, 5, 6, 0, 7, 7, 1, 1],
+         [5, 4, 5, 1, 0, 6, 8, 8, 6, 6], [3, 3, 3, 3, 7, 8, 0, 0, 3, 3],
+         [2, 1, 4, 4, 4, 4, 9, 9, 4, 4], [1, 2, 1, 2, 5, 5, 10, 10, 5, 5],
+         [6, 6, 6, 6, 2, 1, 11, 11, 2, 2], [9, 10, 8, 10, 11, 3, 1, 1, 7, 7],
+         [10, 9, 10, 7, 3, 11, 2, 2, 11, 11], [8, 7, 9, 9, 9, 9, 4, 4, 9, 9],
          [7, 8, 7, 8, 10, 10, 5, 5, 10, 10], [11, 11, 11, 11, 8, 7, 6, 6, 8, 8]]

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -726,3 +726,24 @@ def test_is_group():
 
 def test_PermutationGroup():
     assert PermutationGroup() == PermutationGroup(Permutation())
+
+def test_coset_transvesal():
+    G = AlternatingGroup(5)
+    H = PermutationGroup(Permutation(0,1,2),Permutation(1,2)(3,4))
+    assert G.coset_transversal(H) == \
+        [Permutation(4), Permutation(2, 3, 4), Permutation(2, 4, 3),\
+         Permutation(1, 2, 4), Permutation(4)(1, 2, 3), Permutation(1, 3)(2, 4),\
+         Permutation(0, 1, 2, 3, 4), Permutation(0, 1, 2, 4, 3),\
+         Permutation(0, 1, 3, 2, 4), Permutation(0, 2, 4, 1, 3)]
+
+def test_coset_table():
+    G = PermutationGroup(Permutation(0,1,2,3), Permutation(0,1,2),\
+         Permutation(0,4,2,7), Permutation(5,6), Permutation(0,7));
+    H = PermutationGroup(Permutation(0,1,2,3), Permutation(0,7))
+    assert G.coset_table(H) == \
+        [[0, 0, 0, 0, 1, 2, 3, 3, 0, 0], [4, 5, 2, 5, 6, 0, 7, 7, 1, 1],\
+         [5, 4, 5, 1, 0, 6, 8, 8, 6, 6], [3, 3, 3, 3, 7, 8, 0, 0, 3, 3],\
+         [2, 1, 4, 4, 4, 4, 9, 9, 4, 4], [1, 2, 1, 2, 5, 5, 10, 10, 5, 5],\
+         [6, 6, 6, 6, 2, 1, 11, 11, 2, 2], [9, 10, 8, 10, 11, 3, 1, 1, 7, 7],\
+         [10, 9, 10, 7, 3, 11, 2, 2, 11, 11], [8, 7, 9, 9, 9, 9, 4, 4, 9, 9],\
+         [7, 8, 7, 8, 10, 10, 5, 5, 10, 10], [11, 11, 11, 11, 8, 7, 6, 6, 8, 8]]


### PR DESCRIPTION
This adds a method `G.coset_transversal(H)` that returns a transversal of the
right cosets of G by its subgroup H, and  `G.coset_table(H)` which returns
a list of lists representing the standardised coset table of `G` by H. It makes use
of another new (internal) method, `_coset_representative` which finds the coset
representative of a given element in the transversal returned by
`coset_transversal`.

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
