### PR TITLE
Convergent series: improved a test for using the integral method

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -483,8 +483,9 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             return S.false
 
         ### ------------- integral test -------------- ###
-        sequence_positive = solveset(sequence_term >= 0, sym, S.Reals).sup == S.Infinity
-        sequence_decreasing = solveset(sequence_term.diff() <= 0, sym, S.Reals).sup == S.Infinity
+        sequence_positive = solveset(sequence_term >= 0, sym, interval).sup == S.Infinity
+        solve_decreasing = solveset(sequence_term.diff() <= 0, sym, interval)
+        sequence_decreasing = solve_decreasing.is_Interval and solve_decreasing.sup == S.Infinity
         if sequence_positive and sequence_decreasing:
             integral_val = Integral(sequence_term, (sym, lower_limit, upper_limit))
             try:

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -13,7 +13,7 @@ from sympy.functions.special.zeta_functions import zeta
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.logic.boolalg import And
 from sympy.polys import apart, PolynomialError
-from sympy.solvers import solve
+from sympy.solvers import solve, solveset
 from sympy.series.limits import limit
 from sympy.series.order import O
 from sympy.core.compatibility import range
@@ -483,7 +483,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             return S.false
 
         ### ------------- integral test -------------- ###
-        if is_decreasing(sequence_term, interval):
+        inequality = Derivative(sequence_term).doit() <= 0
+        solution_inequality = solveset(inequality, sym, S.Reals)
+        condition2 = solution_inequality.is_Interval and solution_inequality.right == upper_limit
+        if is_decreasing(sequence_term, interval) or condition2:
             integral_val = Integral(sequence_term, (sym, lower_limit, upper_limit))
             try:
                 integral_val_evaluated = integral_val.doit()

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -483,10 +483,9 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             return S.false
 
         ### ------------- integral test -------------- ###
-        inequality = Derivative(sequence_term).doit() <= 0
-        solution_inequality = solveset(inequality, sym, S.Reals)
-        condition2 = solution_inequality.is_Interval and solution_inequality.right == upper_limit
-        if is_decreasing(sequence_term, interval) or condition2:
+        sequence_positive = solveset(sequence_term >= 0, sym, S.Reals).sup == S.Infinity
+        sequence_decreasing = solveset(sequence_term.diff() <= 0, sym, S.Reals).sup == S.Infinity
+        if sequence_positive and sequence_decreasing:
             integral_val = Integral(sequence_term, (sym, lower_limit, upper_limit))
             try:
                 integral_val_evaluated = integral_val.doit()

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -930,6 +930,8 @@ def test_is_convergent():
     assert Sum(2**n/factorial(n), (n, 1, oo)).is_convergent() is S.true
 
     # integral test --
+    assert Sum(log(n)/n**3, (n, 1, oo)).is_convergent() is S.true
+    assert Sum(log(n)/n**2, (n, 1, oo)).is_convergent() is S.true
 
     # p-series test --
     assert Sum(1/(n**2 + 1), (n, 1, oo)).is_convergent() is S.true
@@ -972,7 +974,6 @@ def test_is_absolutely_convergent():
 @XFAIL
 def test_convergent_failing():
     assert Sum(sin(n)/n**3, (n, 1, oo)).is_convergent() is S.true
-    assert Sum(ln(n)/n**3, (n, 1, oo)).is_convergent() is S.true
     # is_decreasing is not handling "is_decreasing(1)", so raises error
 
     # dirichlet tests


### PR DESCRIPTION
In `is_convergent()` method, sometimes the condition
`is_decreasing(sequence_term, interval)`
for using the integral test returns (correctly) `false` and the integral test for
convergence is ignored.

The condition for using the integral test is that `sequence_term` is definitely decreasing
(i.e. for a certain point).
So I tried to implement this condition.

Now `Sum(log(n)/n**3, (n, 1, oo)).is_convergent()` returns `true`. This is due
to the fact that `log(n)/n**3` is not decreasing in `(1, oo)`, but it definitely
decreasing.

