### PR TITLE
Matexpr: DiagonalMatrix and DiagonalOf enhancements

### DIFF
--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -16,7 +16,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (
     acos, acot, asin, atan, cos, cot, sin, tan)
 from sympy.logic.boolalg import Equivalent, Implies, Xor, And, to_cnf
-from sympy.utilities.pytest import raises, XFAIL, slow, raises
+from sympy.utilities.pytest import XFAIL, slow, raises
 from sympy.assumptions.assume import assuming
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 

--- a/sympy/matrices/expressions/diagonal.py
+++ b/sympy/matrices/expressions/diagonal.py
@@ -6,9 +6,12 @@ from sympy.functions.special.tensor_functions import KroneckerDelta
 
 
 class DiagonalMatrix(MatrixExpr):
-    """DiagonalMatrix(M) will create a create a matrix expression that
-    behaves as though all off-diagonal elements `M[i, j]` where `i != j`
-    are zero.
+    """DiagonalMatrix(M) will create a matrix expression that
+    behaves as though all off-diagonal elements,
+    `M[i, j]` where `i != j`, are zero.
+
+    Examples
+    ========
 
     >>> from sympy import MatrixSymbol, DiagonalMatrix, Symbol
     >>> n = Symbol('n', integer=True)
@@ -19,19 +22,19 @@ class DiagonalMatrix(MatrixExpr):
     >>> D[1, 1]
     x[1, 1]
 
-    The size of the diagonal -- the lesser of the two dimensions of `M` --
-    is accessed through the `size` property:
+    The length of the diagonal -- the lesser of the two dimensions of `M` --
+    is accessed through the `diagonal_length` property:
 
-    >>> D.size
+    >>> D.diagonal_length
     2
-    >>> DiagonalMatrix(MatrixSymbol('x', n + 1, n)).size
+    >>> DiagonalMatrix(MatrixSymbol('x', n + 1, n)).diagonal_length
     n
 
     When one of the dimensions is symbolic the other will be treated as
     though it is smaller:
 
     >>> tall = DiagonalMatrix(MatrixSymbol('x', n, 3))
-    >>> tall.size
+    >>> tall.diagonal_length
     3
     >>> tall[10, 1]
     0
@@ -39,7 +42,7 @@ class DiagonalMatrix(MatrixExpr):
     When the size of the diagonal is not known, a value of None will
     be returned:
 
-    >>> DiagonalMatrix(MatrixSymbol('x', n, m)).size is None
+    >>> DiagonalMatrix(MatrixSymbol('x', n, m)).diagonal_length is None
     True
 
     """
@@ -48,7 +51,7 @@ class DiagonalMatrix(MatrixExpr):
     shape = property(lambda self: self.arg.shape)
 
     @property
-    def size(self):
+    def diagonal_length(self):
         r, c = self.shape
         if r.is_Integer and c.is_Integer:
             m = min(r, c)
@@ -66,10 +69,10 @@ class DiagonalMatrix(MatrixExpr):
         return m
 
     def _entry(self, i, j):
-        if self.size is not None:
-            if Ge(i, self.size) is S.true:
+        if self.diagonal_length is not None:
+            if Ge(i, self.diagonal_length) is S.true:
                 return S.Zero
-            elif Ge(j, self.size) is S.true:
+            elif Ge(j, self.diagonal_length) is S.true:
                 return S.Zero
         eq = Eq(i, j)
         if eq is S.true:
@@ -80,9 +83,12 @@ class DiagonalMatrix(MatrixExpr):
 
 
 class DiagonalOf(MatrixExpr):
-    """DiagonalOf(M) will create a create a matrix expression that
-    is equal to the diagonal of M, represented as a single column
-    matrix.
+    """DiagonalOf(M) will create a matrix expression that
+    is equivalent to the diagonal of `M`, represented as
+    a single column matrix.
+
+    Examples
+    ========
 
     >>> from sympy import MatrixSymbol, DiagonalOf, Symbol
     >>> n = Symbol('n', integer=True)
@@ -99,24 +105,24 @@ class DiagonalOf(MatrixExpr):
     True
 
     The length of the diagonal -- the lesser of the two dimensions of `M` --
-    is accessed through the `size` property:
+    is accessed through the `diagonal_length` property:
 
-    >>> diag.size
+    >>> diag.diagonal_length
     2
-    >>> DiagonalOf(MatrixSymbol('x', n + 1, n)).size
+    >>> DiagonalOf(MatrixSymbol('x', n + 1, n)).diagonal_length
     n
 
     When only one of the dimensions is symbolic the other will be
     treated as though it is smaller:
 
     >>> dtall = DiagonalOf(MatrixSymbol('x', n, 3))
-    >>> dtall.size
+    >>> dtall.diagonal_length
     3
 
     When the size of the diagonal is not known, a value of None will
     be returned:
 
-    >>> DiagonalOf(MatrixSymbol('x', n, m)).size is None
+    >>> DiagonalOf(MatrixSymbol('x', n, m)).diagonal_length is None
     True
 
     """
@@ -140,7 +146,7 @@ class DiagonalOf(MatrixExpr):
         return m, S.One
 
     @property
-    def size(self):
+    def diagonal_length(self):
         return self.shape[0]
 
     def _entry(self, i, j):

--- a/sympy/matrices/expressions/diagonal.py
+++ b/sympy/matrices/expressions/diagonal.py
@@ -1,23 +1,147 @@
 from __future__ import print_function, division
 
 from sympy.matrices.expressions import MatrixExpr
-from sympy.core import S, Eq
+from sympy.core import S, Eq, Ge
 from sympy.functions.special.tensor_functions import KroneckerDelta
+
+
 class DiagonalMatrix(MatrixExpr):
+    """DiagonalMatrix(M) will create a create a matrix expression that
+    behaves as though all off-diagonal elements `M[i, j]` where `i != j`
+    are zero.
+
+    >>> from sympy import MatrixSymbol, DiagonalMatrix, Symbol
+    >>> n = Symbol('n', integer=True)
+    >>> m = Symbol('m', integer=True)
+    >>> D = DiagonalMatrix(MatrixSymbol('x', 2, 3))
+    >>> D[1, 2]
+    0
+    >>> D[1, 1]
+    x[1, 1]
+
+    The size of the diagonal -- the lesser of the two dimensions of `M` --
+    is accessed through the `size` property:
+
+    >>> D.size
+    2
+    >>> DiagonalMatrix(MatrixSymbol('x', n + 1, n)).size
+    n
+
+    When one of the dimensions is symbolic the other will be treated as
+    though it is smaller:
+
+    >>> tall = DiagonalMatrix(MatrixSymbol('x', n, 3))
+    >>> tall.size
+    3
+    >>> tall[10, 1]
+    0
+
+    When the size of the diagonal is not known, a value of None will
+    be returned:
+
+    >>> DiagonalMatrix(MatrixSymbol('x', n, m)).size is None
+    True
+
+    """
     arg = property(lambda self: self.args[0])
-    shape = property(lambda self: (self.arg.shape[0], self.arg.shape[0]))
+
+    shape = property(lambda self: self.arg.shape)
+
+    @property
+    def size(self):
+        r, c = self.shape
+        if r.is_Integer and c.is_Integer:
+            m = min(r, c)
+        elif r.is_Integer and not c.is_Integer:
+            m = r
+        elif c.is_Integer and not r.is_Integer:
+            m = c
+        elif r == c:
+            m = r
+        else:
+            try:
+                m = min(r, c)
+            except TypeError:
+                m = None
+        return m
 
     def _entry(self, i, j):
+        if self.size is not None:
+            if Ge(i, self.size) is S.true:
+                return S.Zero
+            elif Ge(j, self.size) is S.true:
+                return S.Zero
         eq = Eq(i, j)
-        if eq is S.false:
-            return S.Zero
-        elif eq is S.true:
+        if eq is S.true:
             return self.arg[i, i]
+        elif eq is S.false:
+            return S.Zero
         return self.arg[i, j]*KroneckerDelta(i, j)
 
+
 class DiagonalOf(MatrixExpr):
+    """DiagonalOf(M) will create a create a matrix expression that
+    is equal to the diagonal of M, represented as a single column
+    matrix.
+
+    >>> from sympy import MatrixSymbol, DiagonalOf, Symbol
+    >>> n = Symbol('n', integer=True)
+    >>> m = Symbol('m', integer=True)
+    >>> x = MatrixSymbol('x', 2, 3)
+    >>> diag = DiagonalOf(x)
+    >>> diag.shape
+    (2, 1)
+
+    The diagonal can be addressed like a matrix or vector and will
+    return the corresponding element of the original matrix:
+
+    >>> diag[1, 0] == diag[1] == x[1, 1]
+    True
+
+    The length of the diagonal -- the lesser of the two dimensions of `M` --
+    is accessed through the `size` property:
+
+    >>> diag.size
+    2
+    >>> DiagonalOf(MatrixSymbol('x', n + 1, n)).size
+    n
+
+    When only one of the dimensions is symbolic the other will be
+    treated as though it is smaller:
+
+    >>> dtall = DiagonalOf(MatrixSymbol('x', n, 3))
+    >>> dtall.size
+    3
+
+    When the size of the diagonal is not known, a value of None will
+    be returned:
+
+    >>> DiagonalOf(MatrixSymbol('x', n, m)).size is None
+    True
+
+    """
     arg = property(lambda self: self.args[0])
-    shape = property(lambda self: (self.arg.shape[0], S.One))
+    @property
+    def shape(self):
+        r, c = self.arg.shape
+        if r.is_Integer and c.is_Integer:
+            m = min(r, c)
+        elif r.is_Integer and not c.is_Integer:
+            m = r
+        elif c.is_Integer and not r.is_Integer:
+            m = c
+        elif r == c:
+            m = r
+        else:
+            try:
+                m = min(r, c)
+            except TypeError:
+                m = None
+        return m, S.One
+
+    @property
+    def size(self):
+        return self.shape[0]
 
     def _entry(self, i, j):
         return self.arg[i, i]

--- a/sympy/matrices/expressions/tests/test_diagonal.py
+++ b/sympy/matrices/expressions/tests/test_diagonal.py
@@ -1,16 +1,25 @@
 from sympy.matrices.expressions import MatrixSymbol
 from sympy.matrices.expressions.diagonal import DiagonalMatrix, DiagonalOf
-from sympy import Symbol, ask, Q
+from sympy import Symbol, ask, Q, KroneckerDelta
+from sympy.utilities.pytest import raises
+
 
 n = Symbol('n')
-X = MatrixSymbol('X', n, n)
-D = DiagonalMatrix(X)
-d = DiagonalOf(X)
+m = Symbol('m')
+
 
 def test_DiagonalMatrix():
+    x = MatrixSymbol('x', n, m)
+    D = DiagonalMatrix(x)
+    assert D.size is None
+    assert D.shape == (n, m)
+
+    x = MatrixSymbol('x', n, n)
+    D = DiagonalMatrix(x)
+    assert D.size == n
     assert D.shape == (n, n)
     assert D[1, 2] == 0
-    assert D[1, 1] == X[1, 1]
+    assert D[1, 1] == x[1, 1]
     i = Symbol('i')
     j = Symbol('j')
     x = MatrixSymbol('x', 3, 3)
@@ -19,10 +28,59 @@ def test_DiagonalMatrix():
     assert ij.subs({i:0, j:0}) == x[0, 0]
     assert ij.subs({i:0, j:1}) == 0
     assert ij.subs({i:1, j:1}) == x[1, 1]
+    assert ask(Q.diagonal(D))  # affirm that D is diagonal
 
-def test_DiagonalMatrix_Assumptions():
-    assert ask(Q.diagonal(D))
+    x = MatrixSymbol('x', n, 3)
+    D = DiagonalMatrix(x)
+    assert D.size == 3
+    assert D.shape == (n, 3)
+    assert D[2, m] == KroneckerDelta(2, m)*x[2, m]
+    assert D[3, m] == 0
+    raises(IndexError, lambda: D[m, 3])
+
+    x = MatrixSymbol('x', 3, n)
+    D = DiagonalMatrix(x)
+    assert D.size == 3
+    assert D.shape == (3, n)
+    assert D[m, 2] == KroneckerDelta(m, 2)*x[m, 2]
+    assert D[m, 3] == 0
+    raises(IndexError, lambda: D[3, m])
+
+    x = MatrixSymbol('x', n, m)
+    D = DiagonalMatrix(x)
+    assert D.size is None
+    assert D.shape == (n, m)
+    assert D[m, 4] != 0
+
+    x = MatrixSymbol('x', 3, 4)
+    assert [DiagonalMatrix(x)[i] for i in range(12)] == [
+        x[0, 0], 0, 0, 0, 0, x[1, 1], 0, 0, 0, 0, x[2, 2], 0]
+
+    # shape is retained, issue 12427
+    assert (
+        DiagonalMatrix(MatrixSymbol('x', 3, 4))*
+        DiagonalMatrix(MatrixSymbol('x', 4, 2))).shape == (3, 2)
+
 
 def test_DiagonalOf():
+    x = MatrixSymbol('x', n, n)
+    d = DiagonalOf(x)
     assert d.shape == (n, 1)
-    assert d[2, 0] == X[2, 2]
+    assert d.size == n
+    assert d[2, 0] == d[2] == x[2, 2]
+
+    x = MatrixSymbol('x', n, m)
+    d = DiagonalOf(x)
+    assert d.shape == (None, 1)
+    assert d.size is None
+    assert d[2, 0] == d[2] == x[2, 2]
+
+    d = DiagonalOf(MatrixSymbol('x', 4, 3))
+    assert d.shape == (3, 1)
+    d = DiagonalOf(MatrixSymbol('x', n, 3))
+    assert d.shape == (3, 1)
+    d = DiagonalOf(MatrixSymbol('x', 3, n))
+    assert d.shape == (3, 1)
+    x = MatrixSymbol('x', n, m)
+    assert [DiagonalOf(x)[i] for i in range(4)] ==[
+        x[0, 0], x[1, 1], x[2, 2], x[3, 3]]

--- a/sympy/matrices/expressions/tests/test_diagonal.py
+++ b/sympy/matrices/expressions/tests/test_diagonal.py
@@ -11,12 +11,12 @@ m = Symbol('m')
 def test_DiagonalMatrix():
     x = MatrixSymbol('x', n, m)
     D = DiagonalMatrix(x)
-    assert D.size is None
+    assert D.diagonal_length is None
     assert D.shape == (n, m)
 
     x = MatrixSymbol('x', n, n)
     D = DiagonalMatrix(x)
-    assert D.size == n
+    assert D.diagonal_length == n
     assert D.shape == (n, n)
     assert D[1, 2] == 0
     assert D[1, 1] == x[1, 1]
@@ -32,7 +32,7 @@ def test_DiagonalMatrix():
 
     x = MatrixSymbol('x', n, 3)
     D = DiagonalMatrix(x)
-    assert D.size == 3
+    assert D.diagonal_length == 3
     assert D.shape == (n, 3)
     assert D[2, m] == KroneckerDelta(2, m)*x[2, m]
     assert D[3, m] == 0
@@ -40,7 +40,7 @@ def test_DiagonalMatrix():
 
     x = MatrixSymbol('x', 3, n)
     D = DiagonalMatrix(x)
-    assert D.size == 3
+    assert D.diagonal_length == 3
     assert D.shape == (3, n)
     assert D[m, 2] == KroneckerDelta(m, 2)*x[m, 2]
     assert D[m, 3] == 0
@@ -48,7 +48,7 @@ def test_DiagonalMatrix():
 
     x = MatrixSymbol('x', n, m)
     D = DiagonalMatrix(x)
-    assert D.size is None
+    assert D.diagonal_length is None
     assert D.shape == (n, m)
     assert D[m, 4] != 0
 
@@ -66,13 +66,13 @@ def test_DiagonalOf():
     x = MatrixSymbol('x', n, n)
     d = DiagonalOf(x)
     assert d.shape == (n, 1)
-    assert d.size == n
+    assert d.diagonal_length == n
     assert d[2, 0] == d[2] == x[2, 2]
 
     x = MatrixSymbol('x', n, m)
     d = DiagonalOf(x)
     assert d.shape == (None, 1)
-    assert d.size is None
+    assert d.diagonal_length is None
     assert d[2, 0] == d[2] == x[2, 2]
 
     d = DiagonalOf(MatrixSymbol('x', 4, 3))

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -10,6 +10,7 @@ from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.utilities.pytest import raises
 
+
 n, m, l, k, p = symbols('n m l k p', integer=True)
 x = symbols('x')
 A = MatrixSymbol('A', n, m)
@@ -190,6 +191,7 @@ def test_matmul_simplify():
     assert simplify(MatMul(A, ImmutableMatrix([[sin(x)**2 + cos(x)**2]]))) == \
         MatMul(A, ImmutableMatrix([[1]]))
 
+
 def test_invariants():
     A = MatrixSymbol('A', n, m)
     B = MatrixSymbol('B', m, l)
@@ -216,9 +218,13 @@ def test_single_indexing():
     raises(IndexError, lambda: A[n])
     B = MatrixSymbol('B', n, m)
     raises(IndexError, lambda: B[1])
+    B = MatrixSymbol('B', n, 3)
+    assert B[3] == B[1, 0]
+
 
 def test_MatrixElement_commutative():
     assert A[0, 1]*A[1, 0] == A[1, 0]*A[0, 1]
+
 
 def test_MatrixSymbol_determinant():
     A = MatrixSymbol('A', 4, 4)
@@ -235,6 +241,7 @@ def test_MatrixSymbol_determinant():
         A[0, 3]*A[1, 0]*A[2, 2]*A[3, 1] + A[0, 3]*A[1, 1]*A[2, 0]*A[3, 2] - \
         A[0, 3]*A[1, 1]*A[2, 2]*A[3, 0] - A[0, 3]*A[1, 2]*A[2, 0]*A[3, 1] + \
         A[0, 3]*A[1, 2]*A[2, 1]*A[3, 0]
+
 
 def test_MatrixElement_diff():
     assert (A[3, 0]*A[0, 0]).diff(A[0, 0]) == A[3, 0]

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -58,7 +58,7 @@ def _invert(f_x, y, x, domain=S.Complexes):
     in the complex domain, having infinitely many branches.)
 
     If you are working with real values only (or you are not sure which
-    function to use) you should probably use set the domain to
+    function to use) you should probably set the domain to
     ``S.Reals`` (or use `invert\_real` which does that automatically).
 
 


### PR DESCRIPTION
Fixes #12427 and gives DiagonalOf and DiagonalMatrix docstrings that demonstrate how they behave.

A break from the previous behavior is that concrete indices are assumed to be smaller than symbolic ones and None is returned if the length of the diagonal cannot be determined. (Previously, the number of rows was always taken to be the length of the diagonal and the DiagonalMatrix was assumed to be square.)

Single-index indexing, e.g. `M[3]` is now allowed as long as the number of columns is known. This means that DiagonalOf can always be addressed wth a single index (since its number of columns is always 1).

A couple of inconsequential edits of other files were made as they were noticed along the way.