### PR TITLE
Added docstring for sets property method

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -706,6 +706,19 @@ class ProductSet(Set):
 
     @property
     def sets(self):
+        """
+        Returns the arguments of 'self', or in the other words, the factors
+        of Cartesian Product.
+
+        Examples
+        ========
+
+        >>> from sympy import Interval, ProductSet
+        >>> I = Interval(0, 1) * Interval(0, 2)
+        >>> I.sets
+        ([0, 1], [0, 2])
+
+        """
         return self.args
 
     @property

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -713,7 +713,7 @@ class ProductSet(Set):
         Examples
         ========
 
-        >>> from sympy import Interval, ProductSet
+        >>> from sympy import Interval
         >>> I = Interval(0, 1) * Interval(0, 2)
         >>> I.sets
         ([0, 1], [0, 2])


### PR DESCRIPTION
Hello.

```sets``` property method in ProductSet class of sympy/sets/sets.py was missing a docstring. This has been now added, with an appropriate example.

```./bin/test quality``` executed locally - all green.

Thank you. 