### PR TITLE
Simplification in Ellipse intersection method

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -18,7 +18,7 @@ from sympy.simplify import simplify, trigsimp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.geometry.exceptions import GeometryError
-from sympy.geometry import Ray, Segment
+from sympy.geometry.line import Ray2D, Segment2D, Line2D, LinearEntity3D
 from sympy.polys import DomainError, Poly, PolynomialError
 from sympy.polys.polyutils import _not_a_coeff, _nsort
 from sympy.solvers import solve
@@ -642,17 +642,21 @@ class Ellipse(GeometrySet):
             else:
                 return []
 
-        elif isinstance(o, (Segment, Ray)):
+        elif isinstance(o, (Segment2D, Ray2D)):
             ellipse_equation = self.equation(x, y)
             result = solve([ellipse_equation, Line(o.points[0], o.points[1]).equation(x, y)], [x, y])
             return list(ordered([Point(i) for i in result if i in o]))
 
-        elif isinstance(o, (Ellipse, Line)):
+        elif isinstance(o, (Ellipse, Line2D)):
             if o == self:
                 return self
             else:
                 ellipse_equation = self.equation(x, y)
                 return list(ordered([Point(i) for i in solve([ellipse_equation, o.equation(x, y)], [x, y])]))
+        elif isinstance(o, LinearEntity3D):
+                raise TypeError('Entity must be two dimensional, not three dimensional')
+        else:
+            raise TypeError('Wrong type of argument were put')
 
     def is_tangent(self, o):
         """Is `o` tangent to the ellipse?

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -167,36 +167,6 @@ class Ellipse(GeometrySet):
 
         return GeometryEntity.__new__(cls, center, hradius, vradius, **kwargs)
 
-    def _do_ellipse_intersection(self, o):
-        """The intersection of an ellipse with another ellipse or a circle.
-
-        Private helper method for `intersection`.
-
-        """
-        x = Dummy('x', real=True)
-        y = Dummy('y', real=True)
-        seq = self.equation(x, y)
-        oeq = o.equation(x, y)
-        # TODO: Replace solve with nonlinsolve, when nonlinsolve will be able to solve in real domain
-        result = solve([seq, oeq], x, y)
-        return [Point(*r) for r in list(uniq(result))]
-
-    def _do_line_intersection(self, o):
-        """
-        Find the intersection of a LinearEntity and the ellipse.
-
-        All LinearEntities are treated as a line and filtered at
-        the end to see that they lie in o.
-
-        """
-        x, y = symbols('x y', real=True)
-        ellipse_equation = self.equation(x, y)
-        if isinstance(o, (Segment, Ray)):
-            result = solve([ellipse_equation,Line(o.points[0], o.points[1]).equation()], [x, y])
-            return list(ordered([Point(i) for i in result if i in o]))
-        elif isinstance(o, Line):
-            return list(ordered([Point(i) for i in solve([ellipse_equation, o.equation()], [x, y])]))
-
     def _svg(self, scale_factor=1., fill_color="#66cc99"):
         """Returns SVG ellipse element for the Ellipse.
 
@@ -663,24 +633,27 @@ class Ellipse(GeometrySet):
         >>> e.intersection(Ellipse(Point(-1, 0), 3, 4))
         [Point2D(-17/5, -12/5), Point2D(-17/5, 12/5), Point2D(7/5, -12/5), Point2D(7/5, 12/5)]
         """
+        # TODO: Replace solve with nonlinsolve, when nonlinsolve will be able to solve in real domain
+        x = Dummy('x', real=True)
+        y = Dummy('y', real=True)
+
         if isinstance(o, Point):
             if o in self:
                 return [o]
             else:
                 return []
 
-        elif isinstance(o, LinearEntity):
-            # LinearEntity may be a ray/segment, so check the points
-            # of intersection for coincidence first
-            return self._do_line_intersection(o)
+        elif isinstance(o, (Segment, Ray)):
+            ellipse_equation = self.equation(x, y)
+            result = solve([ellipse_equation, Line(o.points[0], o.points[1]).equation(x, y)], [x, y])
+            return list(ordered([Point(i) for i in result if i in o]))
 
-        elif isinstance(o, Ellipse):
+        elif isinstance(o, (Ellipse, Line)):
             if o == self:
                 return self
             else:
-                return self._do_ellipse_intersection(o)
-
-        return o.intersection(self)
+                ellipse_equation = self.equation(x, y)
+                return list(ordered([Point(i) for i in solve([ellipse_equation, o.equation(x, y)], [x, y])]))
 
     def is_tangent(self, o):
         """Is `o` tangent to the ellipse?
@@ -727,7 +700,7 @@ class Ellipse(GeometrySet):
             return (inter is not None and len(inter) == 1
                     and isinstance(inter[0], Point))
         elif isinstance(o, LinearEntity):
-            inter = self._do_line_intersection(o)
+            inter = self.intersection(o)
             if inter is not None and len(inter) == 1:
                 return inter[0] in o
             else:
@@ -735,7 +708,7 @@ class Ellipse(GeometrySet):
         elif isinstance(o, Polygon):
             c = 0
             for seg in o.sides:
-                inter = self._do_line_intersection(seg)
+                inter = self.intersection(seg)
                 c += len([True for point in inter if point in seg])
             return c == 1
         else:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -628,8 +628,7 @@ class Ellipse(GeometrySet):
         >>> e.intersection(Ellipse(Point(100500, 0), 4, 3))
         []
         >>> e.intersection(Ellipse(Point(0, 0), 3, 4))
-        [Point2D(-363/175, -48*sqrt(111)/175), Point2D(-363/175, 48*sqrt(111)/175), Point2D(3, 0)]
-
+        [Point2D(3, 0), Point2D(-363/175, -48*sqrt(111)/175), Point2D(-363/175, 48*sqrt(111)/175)]
         >>> e.intersection(Ellipse(Point(-1, 0), 3, 4))
         [Point2D(-17/5, -12/5), Point2D(-17/5, 12/5), Point2D(7/5, -12/5), Point2D(7/5, 12/5)]
         """

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -203,6 +203,8 @@ def test_ellipse_geom():
     assert intersection(Circle(Point(0, 0), 2), Circle(Point(7, 0), 1)) == []
     assert intersection(Ellipse(Point(0, 0), 5, 17), Ellipse(Point(4, 0), 1, 0.2)) == [Point(5, 0)]
     assert intersection(Ellipse(Point(0, 0), 5, 17), Ellipse(Point(4, 0), 0.999, 0.2)) == []
+    raises(TypeError, lambda: intersection(e2, Line((0, 0, 0), (0,0,1))))
+    raises(TypeError, lambda: intersection(e2, Rational(12)))
     # some special case intersections
     csmall = Circle(p1, 3)
     cbig = Circle(p1, 5)

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -668,8 +668,7 @@ def test_symbolic_intersect():
     # Issue 7814.
     circle = Circle(Point(x, 0), y)
     line = Line(Point(k, z), slope=0)
-    assert line.intersection(circle) == [
-        Point(x - sqrt(y ** 2 - z ** 2), z), Point(x + sqrt(y ** 2 - z ** 2), z)]
+    assert line.intersection(circle) == [Point(x + sqrt((y - z) * (y + z)), z), Point(x - sqrt((y - z) * (y + z)), z)]
 
 
 def test_issue_2941():


### PR DESCRIPTION
I removed two private method in `Ellipse` class: `_do_line_intersection` and `_do_ellipse_intersection` and simplified code.
I also add code which handle exception and test, which cover this feature.
Result are now canonical ordered. I need to change one test in `test_line`, where this order were not preserved. I changed only order, not value.
