### PR TITLE
Polygon intersection

### DIFF
--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -652,7 +652,7 @@ class Polygon(GeometrySet):
         return [t, 0, 1]
 
     def intersection(self, o):
-        """The intersection of two polygons.
+        """The intersection of polygon and geometry entity.
 
         The intersection may be empty and can contain individual Points and
         complete Line Segments.
@@ -660,7 +660,7 @@ class Polygon(GeometrySet):
         Parameters
         ==========
 
-        other: Polygon
+        other: GeometryEntity
 
         Returns
         =======
@@ -683,7 +683,10 @@ class Polygon(GeometrySet):
         >>> poly2 = Polygon(p5, p6, p7)
         >>> poly1.intersection(poly2)
         [Point2D(2/3, 0), Point2D(9/5, 1/5), Point2D(7/3, 1), Point2D(1/3, 1)]
-
+        >>> poly1.intersection(Line(p1, p2))
+        [Point2D(0, 0), Point2D(1, 0), Segment2D(Point2D(0, 0), Point2D(1, 0))]
+        >>> poly1.intersection(p1)
+        [Point2D(0, 0)]
         """
         intersection_result = []
 

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function
 
 from sympy.core import Expr, S, Symbol, oo, pi, sympify
-from sympy.core.compatibility import as_int, range
+from sympy.core.compatibility import as_int, range, ordered
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import cos, sin, tan
@@ -685,12 +685,22 @@ class Polygon(GeometrySet):
         [Point2D(2/3, 0), Point2D(9/5, 1/5), Point2D(7/3, 1), Point2D(1/3, 1)]
 
         """
-        res = []
+        intersection_result = []
+
         for side in self.sides:
             inter = side.intersection(o)
             if inter is not None:
-                res.extend(inter)
-        return list(uniq(res))
+                intersection_result.extend(inter)
+        intersection_result = list(uniq(intersection_result))
+
+        points = [object for object in intersection_result if isinstance(object, Point)]
+        segments = [object for object in intersection_result if isinstance(object, Segment)]
+
+        if points != [] and segments != []:
+            point_not_in_segment = [point for point in points for segment in segments if point not in segment]
+            return list(ordered(segments + point_not_in_segment))
+        else:
+            return list(ordered(intersection_result))
 
     def distance(self, o):
         """

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -692,12 +692,10 @@ class Polygon(GeometrySet):
         if isinstance(o, Polygon):
             for side in self.sides:
                 for side1 in o.sides:
-                    inter = side.intersection(side1)
-                    intersection_result.extend(inter)
+                    intersection_result.extend(side.intersection(side1))
         else:
             for side in self.sides:
-                inter = side.intersection(o)
-                intersection_result.extend(inter)
+                intersection_result.extend(side.intersection(o))
         intersection_result = list(uniq(intersection_result))
 
         points = [object for object in intersection_result if isinstance(object, Point)]
@@ -710,7 +708,6 @@ class Polygon(GeometrySet):
             return list(ordered(segments + points))
         else:
             return list(ordered(intersection_result))
-
 
 
     def distance(self, o):

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -689,19 +689,16 @@ class Polygon(GeometrySet):
         [Point2D(0, 0)]
         """
         intersection_result = []
-        if isinstance(o, Polygon):
-            for side in self.sides:
-                for side1 in o.sides:
-                    intersection_result.extend(side.intersection(side1))
-        else:
-            for side in self.sides:
-                intersection_result.extend(side.intersection(o))
+        k = o.sides if isinstance(o, Polygon) else [o]
+        for side in self.sides:
+            for side1 in k:
+                intersection_result.extend(side.intersection(side1))
+
         intersection_result = list(uniq(intersection_result))
+        points = [entity for entity in intersection_result if isinstance(entity, Point)]
+        segments = [entity for entity in intersection_result if isinstance(entity, Segment)]
 
-        points = [object for object in intersection_result if isinstance(object, Point)]
-        segments = [object for object in intersection_result if isinstance(object, Segment)]
-
-        if points != [] and segments != []:
+        if points and segments:
             points_in_segments = list(uniq([point for point in points for segment in segments if point in segment]))
             if points_in_segments:
                 for i in points_in_segments:
@@ -709,6 +706,7 @@ class Polygon(GeometrySet):
             return list(ordered(segments + points))
         else:
             return list(ordered(intersection_result))
+
 
     def distance(self, o):
         """

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -702,13 +702,13 @@ class Polygon(GeometrySet):
         segments = [object for object in intersection_result if isinstance(object, Segment)]
 
         if points != [] and segments != []:
-            points_in_segments = [point for point in points for segment in segments if point in segment]
-            for i in points_in_segments:
-                points.remove(i)
+            points_in_segments = list(uniq([point for point in points for segment in segments if point in segment]))
+            if points_in_segments:
+                for i in points_in_segments:
+                    points.remove(i)
             return list(ordered(segments + points))
         else:
             return list(ordered(intersection_result))
-
 
     def distance(self, o):
         """

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -689,10 +689,14 @@ class Polygon(GeometrySet):
         [Point2D(0, 0)]
         """
         intersection_result = []
-
-        for side in self.sides:
-            inter = side.intersection(o)
-            if inter is not None:
+        if isinstance(o, Polygon):
+            for side in self.sides:
+                for side1 in o.sides:
+                    inter = side.intersection(side1)
+                    intersection_result.extend(inter)
+        else:
+            for side in self.sides:
+                inter = side.intersection(o)
                 intersection_result.extend(inter)
         intersection_result = list(uniq(intersection_result))
 
@@ -700,10 +704,14 @@ class Polygon(GeometrySet):
         segments = [object for object in intersection_result if isinstance(object, Segment)]
 
         if points != [] and segments != []:
-            point_not_in_segment = [point for point in points for segment in segments if point not in segment]
-            return list(ordered(segments + point_not_in_segment))
+            points_in_segments = [point for point in points for segment in segments if point in segment]
+            for i in points_in_segments:
+                points.remove(i)
+            return list(ordered(segments + points))
         else:
             return list(ordered(intersection_result))
+
+
 
     def distance(self, o):
         """

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -676,15 +676,15 @@ class Polygon(GeometrySet):
         Examples
         ========
 
-        >>> from sympy import Point, Polygon
+        >>> from sympy import Point, Polygon, Line
         >>> p1, p2, p3, p4 = map(Point, [(0, 0), (1, 0), (5, 1), (0, 1)])
         >>> poly1 = Polygon(p1, p2, p3, p4)
         >>> p5, p6, p7 = map(Point, [(3, 2), (1, -1), (0, 2)])
         >>> poly2 = Polygon(p5, p6, p7)
         >>> poly1.intersection(poly2)
-        [Point2D(2/3, 0), Point2D(9/5, 1/5), Point2D(7/3, 1), Point2D(1/3, 1)]
+        [Point2D(1/3, 1), Point2D(2/3, 0), Point2D(9/5, 1/5), Point2D(7/3, 1)]
         >>> poly1.intersection(Line(p1, p2))
-        [Point2D(0, 0), Point2D(1, 0), Segment2D(Point2D(0, 0), Point2D(1, 0))]
+        [Segment2D(Point2D(0, 0), Point2D(1, 0))]
         >>> poly1.intersection(p1)
         [Point2D(0, 0)]
         """

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -376,3 +376,21 @@ def test_eulerline():
         == Point2D(5, 5*sqrt(3)/3)
     assert Triangle(Point(4, -6), Point(4, -1), Point(-3, 3)).eulerline \
         == Line(Point2D(64/7, 3), Point2D(-29/14, -7/2))
+
+def test_intersection():
+    poly1 = Triangle(Point(0, 0), Point(1, 0), Point(0, 1))
+    poly2 = Polygon(Point(0, 1), Point(-5, 0),
+                    Point(0, -4), Point(0, 1/5), Point(1/2, -0.1), Point(1,0), Point(0, 1))
+
+    assert poly1.intersection(poly2) == [Point(1/3, 0), Segment(Point(0, 0), Point(0, 1/5)),
+                                         Segment(Point(0, 1), Point(1, 0))]
+    assert poly2.intersection(poly1) == [Point2D(1/3, 0), Segment(Point2D(0, 0), Point(0, 1/5)),
+                                         Segment(Point(0, 1), Point(1, 0))]
+    assert poly1.intersection(Point(0, 0)) == [Point(0, 0)]
+    assert poly1.intersection(Point(-12,  -43)) == []
+    assert poly2.intersection(Line((-12, 0), (12, 0))) == [Point(-5, 0), Point(0, 0),
+                                                           Point(1/3, 0), Point(1, 0)]
+    assert poly2.intersection(Ray((-3,4), (1,0))) == [Segment(Point(0, 1), Point(1, 0))]
+    assert poly2.intersection(Circle((0, -1), 1)) == [Point2D(0, -2), Point2D(0, 0)]
+
+test_intersection()

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -377,6 +377,7 @@ def test_eulerline():
     assert Triangle(Point(4, -6), Point(4, -1), Point(-3, 3)).eulerline \
         == Line(Point2D(64/7, 3), Point2D(-29/14, -7/2))
 
+
 def test_intersection():
     poly1 = Triangle(Point(0, 0), Point(1, 0), Point(0, 1))
     poly2 = Polygon(Point(0, 1), Point(-5, 0),
@@ -390,6 +391,14 @@ def test_intersection():
     assert poly1.intersection(Point(-12,  -43)) == []
     assert poly2.intersection(Line((-12, 0), (12, 0))) == [Point(-5, 0), Point(0, 0),
                                                            Point(1/3, 0), Point(1, 0)]
+    assert poly2.intersection(Line((-12, 12), (12, 12))) == []
     assert poly2.intersection(Ray((-3,4), (1,0))) == [Segment(Point(0, 1), Point(1, 0))]
-    assert poly2.intersection(Circle((0, -1), 1)) == [Point2D(0, -2), Point2D(0, 0)]
-
+    assert poly2.intersection(Circle((0, -1), 1)) == [Point(0, -2), Point(0, 0)]
+    assert poly1.intersection(poly1) == [Segment(Point(0, 0), Point(0, 1)), Segment(Point(0, 0), Point(1, 0)),
+                                         Segment(Point(0, 1), Point(1, 0))]
+    assert poly2.intersection(poly2) == [Segment(Point(-5, 0), Point(0, -4)), Segment(Point(-5, 0), Point(0, 1)),
+                                         Segment(Point(0, -4), Point(0, 1/5)), Segment(Point(0, 1/5), Point(1/2, -1/10)),
+                                         Segment(Point(0, 1), Point(1, 0)), Segment(Point(1/2, -1/10), Point(1, 0))]
+    assert poly2.intersection(Triangle(Point(0, 1), Point(1, 0), Point(-1, 1))) == [Point(-5/7, 6/7),
+                                                                                    Segment(Point2D(0, 1), Point(1, 0))]
+    assert poly1.intersection(RegularPolygon((-12, -15), 3, 3)) == []

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -102,7 +102,7 @@ def test_polygon():
         Point(0, 0)
     raises(ValueError, lambda: Polygon(
         Point(x, 0), Point(0, y), Point(x, y)).arbitrary_point('x'))
-    assert p6.intersection(r) == [Point(-9, 33/5), Point(-9, -84/13)]
+    assert p6.intersection(r) == [Point(-9, -84/13), Point(-9, 33/5)]
     #
     # Regular polygon
     #
@@ -393,4 +393,3 @@ def test_intersection():
     assert poly2.intersection(Ray((-3,4), (1,0))) == [Segment(Point(0, 1), Point(1, 0))]
     assert poly2.intersection(Circle((0, -1), 1)) == [Point2D(0, -2), Point2D(0, 0)]
 
-test_intersection()


### PR DESCRIPTION
I modified `intersection` method in `Polygon` class. Previously we got wrong result and unordered.
This method were covered by tests very poorly, I handled in my tests every corner cases (I hope so).
What I change:
* previously, when two polygon have one side, as a result of intersection we get this side and additionally two neighboring vertex. From result I removed points which are contained in resulted segment.
* result are ordered using `ordered`

