### PR TITLE
Repair is_tangent method in Ellipse class

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -702,8 +702,6 @@ class Ellipse(GeometrySet):
             elif intersect:
                 if all([(self.tangent_lines(i)[0]).equals((o.tangent_lines(i)[0])) for i in intersect]):
                     return True
-                else:
-                    return False
             else:
                 return False
         elif isinstance(o, Line2D):
@@ -716,8 +714,6 @@ class Ellipse(GeometrySet):
             if len(intersect) == 1:
                 if intersect[0] != o.source and not self.encloses_point(o.source):
                     return True
-                else:
-                    return False
             else:
                 return False
         elif isinstance(o, (Segment2D, Polygon)):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -700,20 +700,15 @@ class Ellipse(GeometrySet):
             if isinstance(intersect, Ellipse):
                 return True
             elif intersect:
-                if all([(self.tangent_lines(i)[0]).equals((o.tangent_lines(i)[0])) for i in intersect]):
-                    return True
+                return all((self.tangent_lines(i)[0]).equals((o.tangent_lines(i)[0])) for i in intersect)
             else:
                 return False
         elif isinstance(o, Line2D):
-            if len(self.intersection(o)) == 1:
-                return True
-            else:
-                return False
+            return len(self.intersection(o)) == 1
         elif isinstance(o, Ray2D):
             intersect = self.intersection(o)
             if len(intersect) == 1:
-                if intersect[0] != o.source and not self.encloses_point(o.source):
-                    return True
+                return intersect[0] != o.source and not self.encloses_point(o.source)
             else:
                 return False
         elif isinstance(o, (Segment2D, Polygon)):
@@ -722,7 +717,7 @@ class Ellipse(GeometrySet):
             for segment in segments:
                 intersect = self.intersection(segment)
                 if len(intersect) == 1:
-                    if not any([intersect[0] in i for i in segment.points])\
+                    if not any(intersect[0] in i for i in segment.points)\
                                    and all(not self.encloses_point(i) for i in segment.points):
                         any_intersect = True
                         continue

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -732,7 +732,9 @@ class Ellipse(GeometrySet):
             for segment in segments:
                 intersect = self.intersection(segment)
                 if len(intersect) == 1:
-                    if any([intersect[0] in i for i in segment.points]):
+                    if not any([intersect[0] in i for i in segment.points])\
+                            and ((all(self.encloses_point(i) for i in segment.points)) or
+                                     (all(not self.encloses_point(i) for i in segment.points))):
                         any_interect = True
                         continue
                     else:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -21,7 +21,7 @@ from sympy.geometry.line import Ray2D, Segment2D, Line2D, LinearEntity3D
 from sympy.polys import DomainError, Poly, PolynomialError
 from sympy.polys.polyutils import _not_a_coeff, _nsort
 from sympy.solvers import solve
-from sympy.utilities.misc import filldedent
+from sympy.utilities.misc import filldedent, func_name
 from sympy.utilities.decorator import doctest_depends_on
 
 from .entity import GeometryEntity, GeometrySet
@@ -712,24 +712,24 @@ class Ellipse(GeometrySet):
             else:
                 return False
         elif isinstance(o, (Segment2D, Polygon)):
-            any_intersect = False
+            all_tangents = False
             segments = o.sides if isinstance(o, Polygon) else [o]
             for segment in segments:
                 intersect = self.intersection(segment)
                 if len(intersect) == 1:
                     if not any(intersect[0] in i for i in segment.points)\
                                    and all(not self.encloses_point(i) for i in segment.points):
-                        any_intersect = True
+                        all_tangents = True
                         continue
                     else:
                         return False
                 else:
-                    return any_intersect
-            return any_intersect
+                    return all_tangents
+            return all_tangents
         elif isinstance(o, (LinearEntity3D, Point3D)):
             raise TypeError('Entity must be two dimensional, not three dimensional')
         else:
-            raise NotImplementedError("Unknown argument type")
+            raise TypeError('Is_tangent not handled for %s' % func_name(o))
 
     @property
     def major(self):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -720,7 +720,7 @@ class Ellipse(GeometrySet):
         elif isinstance(o, Ray2D):
             intersect = self.intersection(o)
             if len(intersect) == 1:
-                if intersect[0] != o.source:
+                if intersect[0] != o.source and not self.encloses_point(o.source):
                     return True
                 else:
                     return False

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -157,8 +157,6 @@ def test_ellipse_geom():
     e = Ellipse((0, 0), x, 1)
     assert e.normal_lines((x + 1, 0)) == [Line(Point(0, 0), Point(1, 0))]
     raises(NotImplementedError, lambda: e.normal_lines((x + 1, 1)))
-
-
     # Properties
     major = 3
     minor = 1
@@ -285,6 +283,7 @@ def test_ellipse_geom():
     assert cir.rotate(pi/3, Point(1, 0)) == Circle(Point(1, 0), 1)
     assert cir.rotate(pi/3, Point(0, 1)) == Circle(Point(1/2 + sqrt(3)/2, 1/2 + sqrt(3)/2), 1)
 
+
 def test_ellipse_random_point():
     y1 = Symbol('y1', real=True)
     e3 = Ellipse(Point(0, 0), y1, y1)
@@ -320,6 +319,7 @@ def test_transform():
     assert Circle((0, 0), 2).scale(3, 3) == \
         Circle((0, 0), 6)
 
+
 def test_bounds():
     e1 = Ellipse(Point(0,0), 3, 5)
     e2 = Ellipse(Point(2, -2), 7, 7)
@@ -329,6 +329,7 @@ def test_bounds():
     assert e2.bounds == (-5, -9, 9, 5)
     assert c1.bounds == (-5, -9, 9, 5)
     assert c2.bounds == (-2, -2, 2, 2)
+
 
 def test_reflect():
     b = Symbol('b')
@@ -340,6 +341,7 @@ def test_reflect():
     assert e.area == -e.reflect(Line((1, 0), slope=0)).area
     assert e.area == -e.reflect(Line((1, 0), slope=oo)).area
     raises(NotImplementedError, lambda: e.reflect(Line((1, 0), slope=m)))
+
 
 def test_is_tangent():
     e1 = Ellipse(Point(0,0), 3, 5)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -104,7 +104,7 @@ def test_ellipse_geom():
     assert e2.is_tangent(Line(p1_3, p2 + Point(half, 1)))
     assert c1.is_tangent(Line(p1_1, Point(0, sqrt(2))))
     assert e1.is_tangent(Line(Point(0, 0), Point(1, 1))) is False
-    assert c1.is_tangent(e1) is False
+    assert c1.is_tangent(e1) is True
     assert c1.is_tangent(Ellipse(Point(2, 0), 1, 1)) is True
     assert c1.is_tangent(
         Polygon(Point(1, 1), Point(1, -1), Point(2, 0))) is True
@@ -346,8 +346,7 @@ def test_is_tangent():
     c1 = Circle(Point(2, -2), 7)
     assert e1.is_tangent(Point(0, 0)) is False
     assert e1.is_tangent(Point(3, 0)) is False
-    assert e1.is_tangent(e1) is False
-    assert e1.is_tangent(c1) is False
+    assert e1.is_tangent(e1) is True
     assert e1.is_tangent(Ellipse((0, 0), 3, 2)) is True
     assert c1.is_tangent(Ellipse((2, -2), 7, 1)) is True
     assert c1.is_tangent(Circle((11, -2), 2)) is True
@@ -362,3 +361,19 @@ def test_is_tangent():
     assert e1.is_tangent(Segment((12, 12), (3, 0))) is False
     assert e1.is_tangent(Segment((-3, 0), (3, 0))) is False
     assert e1.is_tangent(Segment((-3, 5), (3, 5))) is True
+    assert e1.is_tangent(Line((0, 0), (1, 1))) is False
+    assert e1.is_tangent(Line((-3, 0), (-2.99, -0.001))) is False
+    assert e1.is_tangent(Line((-3, 0), (-3, 1))) is True
+    assert e1.is_tangent(Polygon((0, 0), (5, 5), (5, -5))) is False
+    assert e1.is_tangent(Polygon((-100, -50), (-40, -334), (-70, -52))) is False
+    assert e1.is_tangent(Polygon((-3, 0), (3, 0), (0, 1))) is False
+    assert e1.is_tangent(Polygon((-3, 0), (3, 0), (0, 5))) is False
+    assert e1.is_tangent(Polygon((-3, 0), (0, -5), (3, 0), (0, 5))) is False
+    assert e1.is_tangent(Polygon((-3, -5), (-3, 5), (3, 5), (3, -5))) is True
+    assert c1.is_tangent(Polygon((-3, -5), (-3, 5), (3, 5), (3, -5))) is False
+    assert e1.is_tangent(Polygon((0, 0), (3, 0), (7, 7), (0, 5))) is False
+    assert e1.is_tangent(Polygon((3, 12), (3, -12), (6, 5))) is True
+    assert e1.is_tangent(Polygon((3, 12), (3, -12), (0, -5), (0, 5))) is False
+    assert e1.is_tangent(Polygon((3, 0), (5, 7), (6, -5))) is False
+    raises(TypeError, lambda: e1.is_tangent(Point(0, 0, 0)))
+    raises(NotImplementedError, lambda: e1.is_tangent(Rational(5)))

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -355,3 +355,10 @@ def test_is_tangent():
     assert c1.is_tangent(Ray((-5, -2), (-15, -20))) is False
     assert c1.is_tangent(Ray((-3, -2), (-15, -20))) is False
     assert c1.is_tangent(Ray((9, 20), (9, -20))) is True
+    assert e1.is_tangent(Segment((2, 2), (-7, 7))) is False
+    assert e1.is_tangent(Segment((0, 0), (1, 2))) is False
+    assert c1.is_tangent(Segment((0, 0), (-5, -2))) is False
+    assert e1.is_tangent(Segment((3, 0), (12, 12))) is False
+    assert e1.is_tangent(Segment((12, 12), (3, 0))) is False
+    assert e1.is_tangent(Segment((-3, 0), (3, 0))) is False
+    assert e1.is_tangent(Segment((-3, 5), (3, 5))) is True

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -340,3 +340,18 @@ def test_reflect():
     assert e.area == -e.reflect(Line((1, 0), slope=0)).area
     assert e.area == -e.reflect(Line((1, 0), slope=oo)).area
     raises(NotImplementedError, lambda: e.reflect(Line((1, 0), slope=m)))
+
+def test_is_tangent():
+    e1 = Ellipse(Point(0,0), 3, 5)
+    c1 = Circle(Point(2, -2), 7)
+    assert e1.is_tangent(Point(0, 0)) is False
+    assert e1.is_tangent(Point(3, 0)) is False
+    assert e1.is_tangent(e1) is False
+    assert e1.is_tangent(c1) is False
+    assert e1.is_tangent(Ellipse((0, 0), 3, 2)) is True
+    assert c1.is_tangent(Ellipse((2, -2), 7, 1)) is True
+    assert c1.is_tangent(Circle((11, -2), 2)) is True
+    assert c1.is_tangent(Circle((7, -2), 2)) is True
+    assert c1.is_tangent(Ray((-5, -2), (-15, -20))) is False
+    assert c1.is_tangent(Ray((-3, -2), (-15, -20))) is False
+    assert c1.is_tangent(Ray((9, 20), (9, -20))) is True

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -380,4 +380,4 @@ def test_is_tangent():
     assert e1.is_tangent(Polygon((3, 12), (3, -12), (0, -5), (0, 5))) is False
     assert e1.is_tangent(Polygon((3, 0), (5, 7), (6, -5))) is False
     raises(TypeError, lambda: e1.is_tangent(Point(0, 0, 0)))
-    raises(NotImplementedError, lambda: e1.is_tangent(Rational(5)))
+    raises(TypeError, lambda: e1.is_tangent(Rational(5)))

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -349,12 +349,14 @@ def test_is_tangent():
     assert e1.is_tangent(Point(0, 0)) is False
     assert e1.is_tangent(Point(3, 0)) is False
     assert e1.is_tangent(e1) is True
+    assert e1.is_tangent(Ellipse((0, 0), 1, 2)) is False
     assert e1.is_tangent(Ellipse((0, 0), 3, 2)) is True
     assert c1.is_tangent(Ellipse((2, -2), 7, 1)) is True
     assert c1.is_tangent(Circle((11, -2), 2)) is True
     assert c1.is_tangent(Circle((7, -2), 2)) is True
     assert c1.is_tangent(Ray((-5, -2), (-15, -20))) is False
     assert c1.is_tangent(Ray((-3, -2), (-15, -20))) is False
+    assert c1.is_tangent(Ray((-3, -22), (15, 20))) is False
     assert c1.is_tangent(Ray((9, 20), (9, -20))) is True
     assert e1.is_tangent(Segment((2, 2), (-7, 7))) is False
     assert e1.is_tangent(Segment((0, 0), (1, 2))) is False


### PR DESCRIPTION
My PR corrects `is_tangent` method in ellipse. This method were wrong in almost every cases. Checking if two figures are tangent is not trivial exercise. We have here lot's of corner situation. I hope that tests, which I also create cover all of them.