### PR TITLE
ccode: Add capability to _print_Indexed() to use user-defined strided schemes and offsets

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -172,31 +172,26 @@ class C89CodePrinter(CodePrinter):
         # calculate index for 1d array
         offset = expr.offset
         strides = expr.strides
+        indices = expr.indices
 
         if strides is None or isinstance(strides, str):
             dims = expr.shape
-            elem = S.Zero
             shift = S.One
+            temp = tuple()
             if strides == 'C' or strides is None:
                 traversal = reversed(range(expr.rank))
+                indices = indices[::-1]
             elif strides == 'F':
                 traversal = range(expr.rank)
 
             for i in traversal:
-                elem += expr.indices[i]*shift
+                temp += (shift,)
                 shift *= dims[i]
-
-            if offset is None:
-                offset = ""
-            return "%s[%s]" % (self._print(expr.base.label),
-                               self._print(elem) + str(offset))
-        elif isinstance(strides, tuple):
-            if offset is None:
-                offset = ""
-            return "%s[%s]" % (self._print(expr.base.label),
-                               str(sum([x[0]*x[1]
-                                   for x in zip(expr.indices, strides)])) +
-                               " + " + str(offset))
+            strides = temp
+        return "%s[%s]" % (self._print(expr.base.label),
+                               self._print(sum([x[0]*x[1]
+                                   for x in zip(indices, strides)])
+                                   + offset))
 
     def _print_Idx(self, expr):
         return self._print(expr.label)

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -170,8 +170,8 @@ class C89CodePrinter(CodePrinter):
 
     def _print_Indexed(self, expr):
         # calculate index for 1d array
-        offset = expr.offset
-        strides = expr.strides
+        offset = getattr(expr.base, 'offset', S.Zero)
+        strides = getattr(expr.base, 'strides', None)
         indices = expr.indices
 
         if strides is None or isinstance(strides, str):
@@ -188,10 +188,8 @@ class C89CodePrinter(CodePrinter):
                 temp += (shift,)
                 shift *= dims[i]
             strides = temp
-        return "%s[%s]" % (self._print(expr.base.label),
-                               self._print(sum([x[0]*x[1]
-                                   for x in zip(indices, strides)])
-                                   + offset))
+        flat_index = sum([x[0]*x[1] for x in zip(indices, strides)]) + offset
+        return "%s[%s]" % (self._print(expr.base.label), self._print(flat_index))
 
     def _print_Idx(self, expr):
         return self._print(expr.label)

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -268,14 +268,15 @@ def test_ccode_Indexed():
 
         A = IndexedBase('A', shape=(5,3))[i, j]
         assert p._print_Indexed(A) == 'A[%s]' % (3*i + j)
+
         A = IndexedBase('A', shape=(5,3), strides='F')[i, j]
         assert p._print_Indexed(A) == 'A[%s]' % (i + 5*j)
 
         A = IndexedBase('A', shape=(29,29), strides=(1, s), offset=o)[i, j]
-        assert p._print_Indexed(A) == 'A[s*j + i + o]'
+        assert p._print_Indexed(A) == 'A[o + s*j + i]'
 
         A = IndexedBase('A', strides=(s, m, n), offset=o)[i, j, k]
-        assert p._print_Indexed(A) == 'A[m*j + n*k + s*i + o]'
+        assert p._print_Indexed(A) == 'A[m*j + n*k + o + s*i]'
 
 def test_ccode_Indexed_without_looking_for_contraction():
     len_y = 5

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -269,19 +269,16 @@ def test_ccode_Indexed():
         A = IndexedBase('A', shape=(5,3))[i, j]
         assert p._print_Indexed(A) == 'A[%s]' % (3*i + j)
 
-        A = IndexedBase('A', shape=(5,3))[i, j]
-        A.set_strides('F')
-        assert p._print_Indexed(A) == 'A[%s]' % (i + 5*j)
+        A = IndexedBase('A', shape=(5,3), strides='F')[i, j]
+        assert ccode(A) == 'A[%s]' % (i + 5*j)
 
-        A = IndexedBase('A', shape=(29,29))[i, j]
-        A.set_strides((1, s))
-        A.set_offset(o)
-        assert p._print_Indexed(A) == 'A[o + s*j + i]'
+        A = IndexedBase('A', shape=(29,29), strides=(1, s), offset=o)[i, j]
+        assert ccode(A) == 'A[o + s*j + i]'
 
-        A = IndexedBase('A')[i, j, k]
-        A.set_strides((s, m, n))
-        A.set_offset(o)
-        assert p._print_Indexed(A) == 'A[m*j + n*k + o + s*i]'
+        Abase = IndexedBase('A', strides=(s, m, n), offset=o)
+        assert ccode(Abase[i, j, k]) == 'A[m*j + n*k + o + s*i]'
+        assert ccode(Abase[2, 3, k]) == 'A[3*m + n*k + o + 2*s]'
+
 
 def test_ccode_Indexed_without_looking_for_contraction():
     len_y = 5

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -249,7 +249,7 @@ def test_ccode_settings():
 def test_ccode_Indexed():
     from sympy.tensor import IndexedBase, Idx
     from sympy import symbols
-    n, m, o = symbols('n m o', integer=True)
+    s, n, m, o = symbols('s n m o', integer=True)
     i, j, k = Idx('i', n), Idx('j', m), Idx('k', o)
 
     x = IndexedBase('x')[j]
@@ -266,7 +266,16 @@ def test_ccode_Indexed():
         assert p._print_Indexed(B) == 'B[%s]' % (i*o*m+j*o+k)
         assert p._not_c == set()
 
+        A = IndexedBase('A', shape=(5,3))[i, j]
+        assert p._print_Indexed(A) == 'A[%s]' % (3*i + j)
+        A = IndexedBase('A', shape=(5,3), strides='F')[i, j]
+        assert p._print_Indexed(A) == 'A[%s]' % (i + 5*j)
 
+        A = IndexedBase('A', shape=(29,29), strides=(1, s), offset=o)[i, j]
+        assert p._print_Indexed(A) == 'A[s*j + i + o]'
+
+        A = IndexedBase('A', strides=(s, m, n), offset=o)[i, j, k]
+        assert p._print_Indexed(A) == 'A[m*j + n*k + s*i + o]'
 
 def test_ccode_Indexed_without_looking_for_contraction():
     len_y = 5

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -269,13 +269,18 @@ def test_ccode_Indexed():
         A = IndexedBase('A', shape=(5,3))[i, j]
         assert p._print_Indexed(A) == 'A[%s]' % (3*i + j)
 
-        A = IndexedBase('A', shape=(5,3), strides='F')[i, j]
+        A = IndexedBase('A', shape=(5,3))[i, j]
+        A.set_strides('F')
         assert p._print_Indexed(A) == 'A[%s]' % (i + 5*j)
 
-        A = IndexedBase('A', shape=(29,29), strides=(1, s), offset=o)[i, j]
+        A = IndexedBase('A', shape=(29,29))[i, j]
+        A.set_strides((1, s))
+        A.set_offset(o)
         assert p._print_Indexed(A) == 'A[o + s*j + i]'
 
-        A = IndexedBase('A', strides=(s, m, n), offset=o)[i, j, k]
+        A = IndexedBase('A')[i, j, k]
+        A.set_strides((s, m, n))
+        A.set_offset(o)
         assert p._print_Indexed(A) == 'A[m*j + n*k + o + s*i]'
 
 def test_ccode_Indexed_without_looking_for_contraction():

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -493,7 +493,7 @@ class IndexedBase(Expr, NotIterable):
 
         """
 
-        return Indexed._base_offset.get(self, 0)
+        return Indexed._base_offsets.get(self, S.Zero)
 
     @property
     def label(self):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -462,12 +462,14 @@ class IndexedBase(Expr, NotIterable):
 
         Examples
         ==========
-
+        >>> from sympy.printing import ccode
+        >>> from sympy.tensor import IndexedBase, Idx
+        >>> from sympy import symbols
         >>> l, m, n, o = symbols('l m n o', integer=True)
         >>> A = IndexedBase('A', strides=(l, m, n), offset=o)
         >>> i, j, k = Idx('i'), Idx('j'), Idx('k')
         >>> ccode(A[i, j, k])
-        'A[i*l + j*m + k*n + o]'
+        'A[l*i + m*j + n*k + o]'
 
         """
         return self._offset

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -371,7 +371,7 @@ class IndexedBase(Expr, NotIterable):
     is_symbol = True
     is_Atom = True
 
-    def __new__(cls, label, shape=None, strides=None, offset=None, **kw_args):
+    def __new__(cls, label, shape=None, strides=None, offset=0, **kw_args):
         if isinstance(label, string_types):
             label = Symbol(label)
         elif isinstance(label, Symbol):


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
As mentioned in #12464 , `ccode` unrolled 2D `Indexed` objects in row-major format. This PR adds support for unrolling in column-major format as well.

Example : 
```
>>> from sympy import *
>>> A = IndexedBase('A', shape=(5,3))
>>> i, j = Idx('i'), Idx('j')
>>> ccode(A[i,j])
'A[3*i + j]'
>>> A = IndexedBase('A', shape=(5,3), ordering=1)
>>> ccode(A[i,j])
'A[i + 5*j]'
```

UPDATE : Now support for strided schemes and offset have been added
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #12464 