### PR TITLE
Enabled Non Integer `nu` for `yn` bessel functions

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -733,11 +733,9 @@ class yn(SphericalBesselBase):
     def _rewrite(self):
         return self._eval_rewrite_as_bessely(self.order, self.argument)
 
-    @assume_integer_order
     def _eval_rewrite_as_besselj(self, nu, z):
         return (-1)**(nu+1) * sqrt(pi/(2*z)) * besselj(-nu - S.Half, z)
 
-    @assume_integer_order
     def _eval_rewrite_as_bessely(self, nu, z):
         return sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -733,9 +733,11 @@ class yn(SphericalBesselBase):
     def _rewrite(self):
         return self._eval_rewrite_as_bessely(self.order, self.argument)
 
+    @assume_integer_order
     def _eval_rewrite_as_besselj(self, nu, z):
         return (-1)**(nu+1) * sqrt(pi/(2*z)) * besselj(-nu - S.Half, z)
 
+    @assume_integer_order
     def _eval_rewrite_as_bessely(self, nu, z):
         return sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
 

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -81,11 +81,10 @@ def test_rewrite():
     # complex-valued, whereas SBFs are defined only for integer orders)
     order = nu
     for f in (besselj, bessely):
+        assert yn(order, z) == yn(order, z).rewrite(f)
         assert hn1(order, z) == hn1(order, z).rewrite(f)
         assert hn2(order, z) == hn2(order, z).rewrite(f)
 
-    assert yn(order, z).rewrite(besselj) == (-1)**(nu+1) * sqrt(pi/(2*z)) * besselj(-nu - S(1)/2, z)
-    assert yn(order, z).rewrite(bessely) == sqrt(pi/(2*z)) * bessely(nu + S(1)/2, z)
     assert jn(order, z).rewrite(besselj) == sqrt(2)*sqrt(pi)*sqrt(1/z)*besselj(order + S(1)/2, z)/2
     assert jn(order, z).rewrite(bessely) == (-1)**nu*sqrt(2)*sqrt(pi)*sqrt(1/z)*bessely(-order - S(1)/2, z)/2
 

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -84,6 +84,8 @@ def test_rewrite():
         assert hn1(order, z) == hn1(order, z).rewrite(f)
         assert hn2(order, z) == hn2(order, z).rewrite(f)
 
+    assert yn(order, z).rewrite(besselj) == (-1)**(nu+1) * sqrt(pi/(2*z)) * besselj(-nu - S(1)/2, z)
+    assert yn(order, z).rewrite(bessely) == sqrt(pi/(2*z)) * bessely(nu + S(1)/2, z)
     assert jn(order, z).rewrite(besselj) == sqrt(2)*sqrt(pi)*sqrt(1/z)*besselj(order + S(1)/2, z)/2
     assert jn(order, z).rewrite(bessely) == (-1)**nu*sqrt(2)*sqrt(pi)*sqrt(1/z)*bessely(-order - S(1)/2, z)/2
 


### PR DESCRIPTION
Fixes #11777.

In reference to:
#11785

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
