### PR TITLE
note added about Cycle and Permutation application of non-disjoint cycles

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -540,8 +540,8 @@ class Permutation(Basic):
     >>> Permutation(1,2,3) == Permutation(2,3,1) == Permutation(3,1,2)
     True
 
-    The disjoint cycle notation is convenient when representing permutations
-    that have several cycles in them:
+    The disjoint cycle notation is convenient when representing
+    permutations that have several cycles in them:
 
     >>> Permutation(1, 2)(3, 5) == Permutation([[1, 2], [3, 5]])
     True
@@ -553,6 +553,29 @@ class Permutation(Basic):
     Permutation([0, 3, 2, 1])
     >>> _ == Permutation([[1, 2]])*Permutation([[1, 3]])*Permutation([[2, 3]])
     True
+
+        Caution: when the cycles have common elements
+        between them then the order in which the
+        permutations are applied matters. The
+        convention is that the permutations are
+        applied from *right to left*. In the following, the
+        transposition of elements 2 and 3 is followed
+        by the transposition of elements 1 and 2:
+
+        >>> Permutation(1, 2)(2, 3) == Permutation([(1, 2), (2, 3)])
+        True
+        >>> Permutation(1, 2)(2, 3).list()
+        [0, 3, 1, 2]
+
+        If the first and second elements had been
+        swapped first, followed by the swapping of the second
+        and third, the result would have been [0, 2, 3, 1].
+        If, for some reason, you want to apply the cycles
+        in the order they are entered, you can simply reverse
+        the order of cycles:
+
+        >>> Permutation([(1, 2), (2, 3)][::-1]).list()
+        [0, 2, 3, 1]
 
     Entering a singleton in a permutation is a way to indicate the size of the
     permutation. The ``size`` keyword can also be used.


### PR DESCRIPTION
Old notes hidden in the comments of this OP.
<!-- Former changes:

Cycle and Permutation can now process cycles from left to right:

- This is new notation for Cycle and for Permutation and evaluates the product from the left to the right:

`Cycle((a,b),(c,d)) == Permutation((a,b),(c,d))`

- `Permutation((a, b), cycle=True)` this is new: the `cycle` keyword is needed to disambiguate a single cycle from the array-form instantiation of a permutation; the latter requires all elements to be present and is not a change from the current status.

`Cycle(a,b) == Permutation((a, b), cycle=True) != Permutation((a,b))`

- the following are existing behaviors which evaluate the product from right to left (which only matters if the cycles are not disjoint -- but there is no way to check it with this notation):

`Cycle(a,b)(c,d) == Permutation(a,b)(c,d) == Permutation(((a,b), (c,d)))`

So there are two ways to compute Permutations with cycles: the nested list of lists or unnested lists. The only advantage to the nested lists, `Permutation(((a,b), (c,d)))`, or nested ints, `Permutation((a,b))` form is that all elements must be present.

A possible addition could be 
1. a keyword `disjoint` that would force checking of the unnested cycles to see that there are no repeated elements
1. a keyword `from_left` could be added to force the nested lists to be processed from left to right. Or an error could be made to disallow non-disjoint cycles to be used in that notation while at the same time making processing from left to right and at a later date, the error could be dropped. -->

No change has been made other than to put a note of caution in the docstring of permutation.

closes #12487 