### PR TITLE
watch for Relational that is not Relational after solving

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -144,12 +144,11 @@ class Piecewise(Function):
                     if c == cond and (or1 == or2 or cond != true):
                         expr = e
                         piecewise_again = True
-            cond_eval = cls.__eval_cond(cond)
-            if cond_eval is None:
-                all_conds_evaled = False
-            elif cond_eval:
+            if cond == True:
                 if all_conds_evaled:
                     return expr
+            else:
+                all_conds_evaled = False
             if len(non_false_ecpairs) != 0:
                 if non_false_ecpairs[-1].cond == cond:
                     continue
@@ -369,30 +368,30 @@ class Piecewise(Function):
                 # Part 2: remove any interval overlap.  For any conflicts, the
                 # iterval already there wins, and the incoming interval updates
                 # its bounds accordingly.
-                if self.__eval_cond(lower < int_expr[n][1]) and \
-                        self.__eval_cond(lower >= int_expr[n][0]):
+                if True == (lower < int_expr[n][1]) and \
+                        True == (lower >= int_expr[n][0]):
                     lower = int_expr[n][1]
                 elif len(int_expr[n][1].free_symbols) and \
-                        self.__eval_cond(lower >= int_expr[n][0]):
-                    if self.__eval_cond(lower == int_expr[n][0]):
+                        True == (lower >= int_expr[n][0]):
+                    if lower == int_expr[n][0]:
                         lower = int_expr[n][1]
                     else:
                         int_expr[n][1] = Min(lower, int_expr[n][1])
                 elif len(int_expr[n][0].free_symbols) and \
-                        self.__eval_cond(upper == int_expr[n][1]):
+                        upper == int_expr[n][1]:
                     upper = Min(upper, int_expr[n][0])
                 elif len(int_expr[n][1].free_symbols) and \
                         (lower >= int_expr[n][0]) != True and \
                         (int_expr[n][1] == Min(lower, upper)) != True:
                     upper = Min(upper, int_expr[n][0])
-                elif self.__eval_cond(upper > int_expr[n][0]) and \
-                        self.__eval_cond(upper <= int_expr[n][1]):
+                elif True == (upper > int_expr[n][0]) and \
+                        True == (upper <= int_expr[n][1]):
                     upper = int_expr[n][0]
                 elif len(int_expr[n][0].free_symbols) and \
-                        self.__eval_cond(upper < int_expr[n][1]):
+                        True == (upper < int_expr[n][1]):
                     int_expr[n][0] = Max(upper, int_expr[n][0])
 
-            if self.__eval_cond(lower >= upper) != True:  # Is it still an interval?
+            if (lower >= upper) != True:  # Is it still an interval?
                 int_expr.append([lower, upper, expr])
             if orig_cond == targetcond:
                 # there may be more so don't return yet
@@ -525,17 +524,6 @@ class Piecewise(Function):
     _eval_is_zero = lambda self: self._eval_template_is_attr(
         'is_zero', when_multiple=False)
 
-    @classmethod
-    def __eval_cond(cls, cond):
-        """Return the truth value of the condition."""
-        from sympy.solvers.solvers import checksol
-        if cond == True:
-            return True
-        if isinstance(cond, Equality):
-            diff = cond.lhs - cond.rhs
-            if diff.is_commutative:
-                return diff.is_zero
-        return None
 
     def as_expr_set_pairs(self):
         exp_sets = []

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -325,9 +325,12 @@ class Piecewise(Function):
         def _solve_relational(r):
             rv = _solve_inequality(r, sym)
             if isinstance(rv, Relational) and \
-                    sym in rv.free_symbols and rv.args[0] != sym:
-                raise NotImplementedError(
-                    "Unable to solve relational %s for %s." % (r, sym))
+                    sym in rv.free_symbols:
+                if rv.args[0] != sym:
+                    raise NotImplementedError(filldedent('''
+Unable to solve relational %s for %s.''' % (r, sym)))
+                if rv.rel_op == '!=':
+                    rv = Or(sym < rv.rhs, sym > rv.rhs)
             if rv == (S.NegativeInfinity < sym) & (sym < S.Infinity):
                 rv = S.true
             return rv

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -196,14 +196,16 @@ def test_piecewise_integrate():
 
     g = Piecewise((0, Or(x <= -1, x >= 1)), (1 - x, x > 0), (1 + x, True))
     assert integrate(g, (x, -5, 1)) == 1
+    assert g._sort_expr_cond(x, -5, 1) == [
+        [-5, -1, 0], [-1, 0, x + 1], [0, 1, -x + 1]]
     assert integrate(g, (x, -5, y)).subs(y, 1) == 1
     assert integrate(g, (x, y, 1)).subs(y, -5) == 1
     assert integrate(g, (x, 1, -5)) == -1
     assert integrate(g, (x, 1, y)).subs(y, -5) == -1
     assert integrate(g, (x, y, -5)).subs(y, 1) == -1
-    assert integrate(g, (x, -5, y)) == Piecewise((0, y <= -1), (1, y >= 1),
+    assert integrate(g, (x, -5, y)) == Piecewise((1, y >= 1), (0, y <= -1),
         (-y**2/2 + y + 0.5, y > 0), (y**2/2 + y + 0.5, True))
-    assert integrate(g, (x, y, 1)) == Piecewise((1, y <= -1), (0, y >= 1),
+    assert integrate(g, (x, y, 1)) == Piecewise((0, y >= 1), (1, y <= -1),
         (y**2/2 - y + 0.5, y > 0), (-y**2/2 - y + 0.5, True))
 
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -538,17 +538,17 @@ def test_issue_11045():
     # ignore hidden false (handled in canonicalization)
     assert Piecewise((1, x > 1), (2, x > x + 1), (3, True)
         )._sort_expr_cond(x, 0, 3) == [[0, 1, 3], [1, 3, 1]]
-    # watch for false Piecewise
-    assert Piecewise((2, Eq(1 - x, x*(1/x -1)))
+    # watch for hidden True Piecewise
+    assert Piecewise((2, Eq(1 - x, x*(1/x - 1))), (0, True)
         )._sort_expr_cond(x, 0, 3, True) == [(0, 3, None)]
 
     # targetcond must be an existing condition
     A = And(x < 1, x > 0)
-    B = And(S(1) > x, x > 0)
+    B = And((x < 1).reversed, x > 0)
     assert A.as_set() == B.as_set()
     assert A != B
-    assert Piecewise((1, A), (0, True)
-        )._sort_expr_cond(x, -oo, oo, B) == []
+    raises(ValueError, lambda: Piecewise((1, A), (0, True)
+        )._sort_expr_cond(x, -oo, oo, B))
     # overlapping conditions of targetcond are recognized and ignored;
     # the condition x > 3 will be pre-empted by the first condition
     assert Piecewise((1, Or(x < 1, x > 2)), (2, x > 3), (3, True)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -2,7 +2,7 @@ from sympy import (
     adjoint, And, Basic, conjugate, diff, expand, Eq, Function, I,
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, solve, symbols, transpose,
-    cos, exp, Abs, Not, Symbol, S
+    cos, exp, Abs, Not, Symbol, S, Ne
 )
 from sympy.printing import srepr
 from sympy.utilities.pytest import XFAIL, raises
@@ -553,3 +553,15 @@ def test_issue_11045():
     # the condition x > 3 will be pre-empted by the first condition
     assert Piecewise((1, Or(x < 1, x > 2)), (2, x > 3), (3, True)
         )._sort_expr_cond(x, 0, 4, x > 3) == []
+
+    # convert Ne to Or
+    assert Piecewise((1, Ne(x, 0)), (2, True)
+        ).integrate((x, -1, 1)) == 2
+
+
+def test_issue_7305():
+    k = Symbol('k', integer=True)
+    m = Symbol('m', integer=True)
+    x = Symbol('x', real=True)
+    assert (exp(I*m*x)*exp(I*k*x)).integrate((x, 0, 2*pi)
+        ).simplify() == Piecewise((2*pi, Eq(k, -m)), (0, True))

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -518,7 +518,15 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                     discontinuities))).intersection(
                     Interval(domain.inf, domain.sup,
                     domain.inf not in domain, domain.sup not in domain))
-                reals = _nsort(critical_points, separated=True)[0]
+                if all(r.is_number for r in critical_points):
+                    reals = _nsort(critical_points, separated=True)[0]
+                else:
+                    from sympy.utilities.iterables import sift
+                    sifted = sift(critical_points, lambda x: x.is_real)
+                    try:
+                        reals = list(sorted(sifted[True]))
+                    except TypeError:
+                        raise NotImplementedError
             except NotImplementedError:
                 raise NotImplementedError('sorting of these roots is not supported')
 

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -574,6 +574,12 @@ def _pt(start, end):
 def _solve_inequality(ie, s):
     """ A hacky replacement for solve, since the latter only works for
         univariate inequalities. """
+    if s not in ie.free_symbols:
+        return ie
+    if ie.rhs == s:
+        ie = ie.reversed
+    if ie.lhs == s and s not in ie.rhs.free_symbols:
+        return ie
     expr = ie.lhs - ie.rhs
     try:
         p = Poly(expr, s)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -483,7 +483,8 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
         if rv is None:
             solns = solvify(e, gen, domain)
             if solns is None:
-                raise NotImplementedError(filldedent('''The inequality cannot be
+                raise NotImplementedError(filldedent('''
+                    The inequality cannot be
                     solved using solve_univariate_inequality.'''))
             singularities = []
             for d in denoms(expr, gen):

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -382,3 +382,5 @@ def test__solve_inequality():
         assert _solve_inequality(op(S.One, x), x).lhs == x
     ie = Eq(S.One, y)
     assert _solve_inequality(ie, x) == ie
+    a = Symbol('a', positive=True)
+    assert _solve_inequality(a/x > 1, x) == (S.Zero < x) & (x < a)

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -4,10 +4,9 @@ from sympy import (And, Eq, FiniteSet, Ge, Gt, Interval, Le, Lt, Ne, oo,
                    Or, S, sin, cos, tan, sqrt, Symbol, Union, Integral, Sum,
                    Function, Poly, PurePoly, pi, root, log, exp, Dummy, Abs)
 from sympy.solvers.inequalities import (reduce_inequalities,
-                                        solve_poly_inequality as psolve,
-                                        reduce_rational_inequalities,
-                                        solve_univariate_inequality as isolve,
-                                        reduce_abs_inequality)
+    solve_poly_inequality as psolve, reduce_rational_inequalities,
+    solve_univariate_inequality as isolve, reduce_abs_inequality,
+    _solve_inequality)
 from sympy.polys.rootoftools import rootof
 from sympy.solvers.solvers import solve
 from sympy.solvers.solveset import solveset
@@ -375,3 +374,11 @@ def test_issue_10671_12466():
     assert solveset((1/x).diff(x) < 0, x, i) == i
     assert solveset((log(x - 6)/x) <= 0, x, S.Reals) == \
         Interval.Lopen(6, 7)
+
+
+def test__solve_inequality():
+    for op in (Gt, Lt, Le, Ge, Eq, Ne):
+        assert _solve_inequality(op(x, 1), x).lhs == x
+        assert _solve_inequality(op(S.One, x), x).lhs == x
+    ie = Eq(S.One, y)
+    assert _solve_inequality(ie, x) == ie


### PR DESCRIPTION
There were several issues with Piecewise's `_sort_expr_cond` routine which this PR has addressed. Various inputs (Or, And, Relational) are more completely handled, now. The output should be a little more intuitive, too, with intervals non-overlapping -- a source of incorrect integrate results -- and only the intervals matching the optional targetcond are returned. There should probably be an error raised if a condition NOT in the Piecewise is given as a targetcond lest "errors pass silently" in an integration routine.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->

closes #11045
closes #12221
closes #7305

- [x] try solve #12560 so 7305 can be solved
- [x] convert Ne(x,y) to Or(x<y,x>y) before applying distribute_or_over_and
- [ ] is distribute_or_over_and hard? The fp_group and 7305 example take a long time to compute that.