### PR TITLE
ntheory/factor_.py: totient() edited to raise error when input is not a positive integer/symbol  

### DIFF
--- a/examples/advanced/pidigits.py
+++ b/examples/advanced/pidigits.py
@@ -72,7 +72,7 @@ def interactive():
     print("Compute digits of pi with SymPy\n")
     base = input("Which base? (2-36, 10 for decimal) \n> ")
     digits = input("How many digits? (enter a big number, say, 10000)\n> ")
-    tofile = input("Output to file? (enter a filename, or just press enter\nto print directly to the screen) \n> ")
+    tofile = raw_input("Output to file? (enter a filename, or just press enter\nto print directly to the screen) \n> ")
     if tofile:
         tofile = open(tofile, "w")
     calculateit(pi, base, digits, tofile)

--- a/examples/advanced/pidigits.py
+++ b/examples/advanced/pidigits.py
@@ -72,7 +72,7 @@ def interactive():
     print("Compute digits of pi with SymPy\n")
     base = input("Which base? (2-36, 10 for decimal) \n> ")
     digits = input("How many digits? (enter a big number, say, 10000)\n> ")
-    tofile = raw_input("Output to file? (enter a filename, or just press enter\nto print directly to the screen) \n> ")
+    tofile = input("Output to file? (enter a filename, or just press enter\nto print directly to the screen) \n> ")
     if tofile:
         tofile = open(tofile, "w")
     calculateit(pi, base, digits, tofile)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1582,7 +1582,6 @@ class totient(Function):
     """
     @classmethod
     def eval(cls, n):
-        print("TEST")
         n = sympify(n)
         if n.is_Integer:
             if n < 1:
@@ -1592,7 +1591,7 @@ class totient(Function):
             for p, k in factors.items():
                 t *= (p - 1) * p**(k - 1)
             return t
-        elif x.is_Symbol:
+        elif n.is_Symbol:
             pass
         else:
             raise TypeError("n must be a positive integer")

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1591,6 +1591,10 @@ class totient(Function):
             for p, k in factors.items():
                 t *= (p - 1) * p**(k - 1)
             return t
+        elif x.is_Symbol:
+            pass
+        else:
+            raise TypeError("n must be a positive integer")
 
     def _eval_is_integer(self):
         return fuzzy_and([self.args[0].is_integer, self.args[0].is_positive])

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1592,10 +1592,10 @@ class totient(Function):
                 t *= (p - 1) * p**(k - 1)
             return t
         elif n.is_Symbol:
-            if n.is_integer:
-               pass
-            else:
+            if n.is_integer==False:
                raise TypeError("n must be a positive integer")
+            else:
+               pass
         else:
             raise TypeError("n must be a positive integer")
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1582,6 +1582,7 @@ class totient(Function):
     """
     @classmethod
     def eval(cls, n):
+        print("TEST")
         n = sympify(n)
         if n.is_Integer:
             if n < 1:

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1592,7 +1592,10 @@ class totient(Function):
                 t *= (p - 1) * p**(k - 1)
             return t
         elif n.is_Symbol:
-            pass
+            if n.is_integer:
+               pass
+            else:
+               raise TypeError("n must be a positive integer")
         else:
             raise TypeError("n must be a positive integer")
 


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
```
>>> from sympy import *
>>> totient(4.5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/akash/sympy/sympy/core/function.py", line 427, in __new__
    result = super(Function, cls).__new__(cls, *args, **options)
  File "/home/akash/sympy/sympy/core/function.py", line 250, in __new__
    evaluated = cls.eval(*args)
  File "/home/akash/sympy/sympy/ntheory/factor_.py", line 1597, in eval
    raise TypeError("n must be a positive integer")
TypeError: n must be a positive integer
 
```

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #8875
