### PR TITLE
evaluate args of Relational if possible

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -255,6 +255,9 @@ class Expr(Basic, EvalfMixin):
                 raise TypeError("Invalid comparison of complex %s" % me)
             if me is S.NaN:
                 raise TypeError("Invalid NaN comparison")
+        n2 = _n2(self, other)
+        if n2 is not None:
+            return _sympify(n2 >= 0)
         if self.is_real or other.is_real:
             dif = self - other
             if dif.is_nonnegative is not None and \
@@ -274,6 +277,9 @@ class Expr(Basic, EvalfMixin):
                 raise TypeError("Invalid comparison of complex %s" % me)
             if me is S.NaN:
                 raise TypeError("Invalid NaN comparison")
+        n2 = _n2(self, other)
+        if n2 is not None:
+            return _sympify(n2 <= 0)
         if self.is_real or other.is_real:
             dif = self - other
             if dif.is_nonpositive is not None and \
@@ -293,6 +299,9 @@ class Expr(Basic, EvalfMixin):
                 raise TypeError("Invalid comparison of complex %s" % me)
             if me is S.NaN:
                 raise TypeError("Invalid NaN comparison")
+        n2 = _n2(self, other)
+        if n2 is not None:
+            return _sympify(n2 > 0)
         if self.is_real or other.is_real:
             dif = self - other
             if dif.is_positive is not None and \
@@ -312,6 +321,9 @@ class Expr(Basic, EvalfMixin):
                 raise TypeError("Invalid comparison of complex %s" % me)
             if me is S.NaN:
                 raise TypeError("Invalid NaN comparison")
+        n2 = _n2(self, other)
+        if n2 is not None:
+            return _sympify(n2 < 0)
         if self.is_real or other.is_real:
             dif = self - other
             if dif.is_negative is not None and \
@@ -3333,6 +3345,20 @@ class UnevaluatedExpr(Expr):
             return self.args[0].doit(*args, **kwargs)
         else:
             return self.args[0]
+
+
+def _n2(a, b):
+    """Return (a - b).evalf(2) if it, a and b are comparable, else None.
+    This should only be used when a and b are already sympified.
+    """
+    if not all(i.is_number for i in (a, b)):
+        return
+    # /!\ if is very important (see issue 8245) not to
+    # use a re-evaluated number in the calculation of dif
+    if a.is_comparable and b.is_comparable:
+        dif = (a - b).evalf(2)
+        if dif.is_comparable:
+            return dif
 
 
 from .mul import Mul

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -286,6 +286,7 @@ class Equality(Relational):
     def __new__(cls, lhs, rhs=0, **options):
         from sympy.core.add import Add
         from sympy.core.logic import fuzzy_bool
+        from sympy.core.expr import _n2
         from sympy.simplify.simplify import clear_coefficients
 
         lhs = _sympify(lhs)
@@ -326,6 +327,10 @@ class Equality(Relational):
                         return S.false
                     if z:
                         return S.true
+                # evaluate numerically if possible
+                n2 = _n2(lhs, rhs)
+                if n2 is not None:
+                    return _sympify(n2 == 0)
                 # see if the ratio evaluates
                 n, d = dif.as_numer_denom()
                 rv = None

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,6 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises
-from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
-                   Implies, Xor, zoo, sqrt, Rational, simplify, Function)
+from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
+    Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function, Eq,
+    log, cos, sin)
 from sympy.core.compatibility import range
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
@@ -570,6 +571,8 @@ def test_issue_8245():
     assert (r < a) == True
     assert (r >= a) == False
     assert (r <= a) == True
+
+    assert Eq(log(cos(2)**2 + sin(2)**2), 0) == True
 
 
 def test_issue_8449():


### PR DESCRIPTION
This restores the ability to make decisions regarding Relationals
when the arguments (and their difference) can be computed as
comparable numbers. e.g. without simplification this allows

```
>>> Eq(log(cos(2)**2 + sin(2)**2), 0)
True
```
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
closes #10498