### PR TITLE
Implemented `._partition_args()` function for Rubi pattern matcher

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1530,6 +1530,9 @@ class Basic(with_metaclass(ManagedProperties)):
         Return a `dict` of subexpressions which contains `var`.
         Subexpressions which doesn't contain `var` are considered to be constant.
 
+        See:
+        https://people.eecs.berkeley.edu/~fateman/papers/partition-new2.pdf
+
         Examples
         ========
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1560,18 +1560,15 @@ class Basic(with_metaclass(ManagedProperties)):
         leaves['Constant'] = []
 
         if not isinstance(self, (Mul, Add)):
-            if self.has(var):
+            if var in self.free_symbols:
                 leaves[self.__class__.__name__] = [self]
             else:
                 leaves['Constant'] = [self]
             return leaves
 
         for subexpr in self.args:
-            if subexpr.has(var):
-                try:
-                    leaves[subexpr.__class__.__name__].append(subexpr)
-                except:
-                    leaves[subexpr.__class__.__name__] = [subexpr]
+            if var in subexpr.free_symbols:
+                leaves.setdefault(subexpr.__class__.__name__, []).append(subexpr)
             else:
                 leaves['Constant'].append(subexpr)
         return leaves

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1525,10 +1525,11 @@ class Basic(with_metaclass(ManagedProperties)):
         pattern = sympify(pattern)
         return pattern.matches(self, old=old)
 
-    def _partition_args(self, var):
+    def _partition_args(self, var, all_comm=True):
         """
         Return a `dict` of subexpressions which contains `var`.
         Subexpressions which doesn't contain `var` are considered to be constant.
+        Note: Partition of non-commutative terms is not supported.
 
         See:
         https://people.eecs.berkeley.edu/~fateman/papers/partition-new2.pdf
@@ -1565,6 +1566,9 @@ class Basic(with_metaclass(ManagedProperties)):
             else:
                 leaves['Constant'] = [self]
             return leaves
+
+        if self.args_cnc()[1] and not all_comm:
+            raise NotImplementedError("Partition of non-commutative terms is not supported")
 
         for subexpr in self.args:
             if var in subexpr.free_symbols:

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -219,3 +219,12 @@ def test_literal_evalf_is_number_is_zero_is_comparable():
     assert n.is_comparable is False
     assert n.n(2).is_comparable is False
     assert n.n(2).n(2).is_comparable
+
+def test_partition():
+    x, a, b = symbols('x, a, b')
+    expr = a + b + x
+    assert expr._partition_args(x) == {'Constant': [a, b], 'Symbol': [x]}
+    expr = cos(a)*b*sin(x)
+    assert expr._partition_args(x) == {'Constant': [b, cos(a)], 'sin': [sin(x)]}
+    assert exp(x)._partition_args(x) == {'Constant': [], 'exp': [exp(x)]}
+    assert exp(a)._partition_args(x) == {'Constant': [exp(a)]}


### PR DESCRIPTION
I have implemented `._partition_args()` function which can be used to make new Rubi pattern matcher efficient. Pattern matching of `is_commutative` expressions(`Add` and `Mul`) leads to exponential time. By partitioning the expression into subexpressions which contain integration variable and which does not, we can reduce the search space of matcher.

`expr.partition(var)` function returns a `dict` of subexpressions which contains `var`. Subexpressions which doesn't contain `var` are considered to be `Constant`.

#### Sample Program:
``` python
>>> from sympy import exp, sqrt, cos, sin
>>> from sympy.abc import x, a, b
>>> expr = a + b + x
>>> expr._partition_args(x)
{'Constant': [a, b], 'Symbol': [x]}
>>> expr = cos(a)*b*sin(x)
>>> expr._partition_args(x)
{'Constant': [b, cos(a)], 'sin': [sin(x)]}
```

Reference:

[https://people.eecs.berkeley.edu/~fateman/papers/partition-new2.pdf](https://people.eecs.berkeley.edu/~fateman/papers/partition-new2.pdf)


* Tests are added.