### PR TITLE
Improved Mathematica parser for multiplication operator

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -23,6 +23,10 @@ def parse(s):
         lambda m: parse(m.group(1)) + translateFunction(
             m.group(2)) + parse(m.group(3))),
 
+        # Space multiplication between two functions
+        (r"\A(\w+\[[^\]]+[^\[]*\])( )(\w+\[[^\]]+[^\[]*\])\Z",
+        lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(3)) + ")"),
+
         (r"\A(\w+)\[([^\]]+[^\[]*)\]\Z",  # Function call
         lambda m: translateFunction(
             m.group(1)) + "(" + parse(m.group(2)) + ")"),
@@ -41,6 +45,10 @@ def parse(s):
 
         (r"\A(-? *[\d\.]+)([a-zA-Z].*)\Z",  # Implied multiplication - 2a
         lambda m: parse(m.group(1)) + "*" + parse(m.group(2))),
+
+        # Multiplication between any object and a function
+        (r"\A(.+)([*])(\w+\[[^\]]+[^\[]*\])\Z",
+        lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(3)) + ")"),
 
         (r"\A([^=]+)([\^\-\*/\+=]=?)(.+)\Z",  # Infix operator
         lambda m: parse(m.group(1)) + translateOperator(m.group(2)) + parse(m.group(3))))

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -14,7 +14,7 @@ def parse(s):
     # Begin rules
     rules = (
         # Arithmetic operation between a constant and a function
-        (r"\A(\d+)([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",
+        (r"\A(\d+)\s*([*/+-^])\s*(\w+\[[^\]]+[^\[]*\])\Z",
         lambda m: m.group(
             1) + translateFunction(m.group(2)) + parse(m.group(3))),
 
@@ -24,7 +24,7 @@ def parse(s):
             m.group(2)) + parse(m.group(3))),
 
         # Space multiplication between two functions
-        (r"\A(\w+\[[^\]]+[^\[]*\])( )(\w+\[[^\]]+[^\[]*\])\Z",
+        (r"\A(\w+\[[^\]]+[^\[]*\])( +)(\w+\[[^\]]+[^\[]*\])\Z",
         lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(3)) + ")"),
 
         (r"\A(\w+)\[([^\]]+[^\[]*)\]\Z",  # Function call
@@ -48,6 +48,10 @@ def parse(s):
 
         # Multiplication between any object and a function
         (r"\A(.+)([*])(\w+\[[^\]]+[^\[]*\])\Z",
+        lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(3)) + ")"),
+
+        # Space multiplication between any object and a function
+        (r"\A(.+)( +)(\w+\[[^\]]+[^\[]*\])\Z",
         lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(3)) + ")"),
 
         (r"\A([^=]+)([\^\-\*/\+=]=?)(.+)\Z",  # Infix operator

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -8,6 +8,7 @@ def test_mathematica():
         'Sin[x]^2': 'sin(x)**2',
         '2(x-1)': '2*(x-1)',
         '3y+8': '3*y+8',
+        '3y + 8': '3*y+8',
         'Arcsin[2x+9(4-x)^2]/x': 'asin(2*x+9*(4-x)**2)/x',
         'x+y': 'x+y',
         '355/113': '355/113',
@@ -22,8 +23,10 @@ def test_mathematica():
         'Sin[Cos[x]]': 'sin(cos(x))',
         '2*Sqrt[x+y]': '2*sqrt(x+y)', # Test case from the issue 4259
         'x*Sin[1/x]': 'x*sin(1/x)',
+        'x  Sin[1/x]': 'x*sin(1/x)',
         'Sin[1/x]*x': 'x*sin(1/x)',
-        'Sin[x] Cos[Sin[x]]': 'sin(x)*cos(sin(x))'
+        'Sin[x] Cos[Sin[x]]': 'sin(x)*cos(sin(x))',
+        'Sin[x]  Cos[x]': 'sin(x)*cos(x)'
         }
     for e in d:
         assert mathematica(e) == sympify(d[e])

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -20,6 +20,10 @@ def test_mathematica():
         '2*Sin[x+y]': '2*sin(x+y)',
         'Sin[x]+Cos[y]': 'sin(x)+cos(y)',
         'Sin[Cos[x]]': 'sin(cos(x))',
-        '2*Sqrt[x+y]': '2*sqrt(x+y)'}   # Test case from the issue 4259
+        '2*Sqrt[x+y]': '2*sqrt(x+y)', # Test case from the issue 4259
+        'x*Sin[1/x]': 'x*sin(1/x)',
+        'Sin[1/x]*x': 'x*sin(1/x)',
+        'Sin[x] Cos[Sin[x]]': 'sin(x)*cos(sin(x))'
+        }
     for e in d:
         assert mathematica(e) == sympify(d[e])


### PR DESCRIPTION
Fixes #8501.

Added support for:
* Space Multiplication of two functions
* `*` operator between a function and a object.

### Sample Program:
```python 
>>> from sympy.parsing.mathematica import mathematica as M
>>> M("x*Sin[1/x]")
x*sin(1/x)
>>> M("Sin[1/x]*x")
x*sin(1/x)
>>> M("Sin[x] Cos[x]")
sin(x)*cos(x)
```

#### Note:

We still need to implement parsing for space multiplication. Some [work](https://github.com/sympy/sympy/pull/8766/files#diff-5bead3fe0fbe39640e6bbc0055461aefR45) is done by @nishithshah2211 on space multiplication but that solution will not always be true.

I think we need better framework for parsing than `Mathematica` parser already has (such as parsing using ASTs) to implement space multiplication.
