### PR TITLE
ntheory: totient() raises TypeError if the input is not a positive integer/Symbol

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -17,6 +17,7 @@ from sympy.core.mul import Mul
 from sympy.core.compatibility import as_int, SYMPY_INTS, range
 from sympy.core.singleton import S
 from sympy.core.function import Function
+from sympy.core.expr import Expr
 
 small_trailing = [i and max(int(not i % 2**j) and j for j in range(1, 8))
     for i in range(256)]
@@ -1591,6 +1592,8 @@ class totient(Function):
             for p, k in factors.items():
                 t *= (p - 1) * p**(k - 1)
             return t
+        elif not isinstance(n, Expr) or (n.is_integer is False) or (n.is_positive is False):
+            raise ValueError("n must be a positive integer")
 
     def _eval_is_integer(self):
         return fuzzy_and([self.args[0].is_integer, self.args[0].is_positive])

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -301,6 +301,9 @@ def test_totient():
     assert totient(5009) == 5008
     assert totient(2**100) == 2**99
 
+    raises(ValueError, lambda: totient(30.1))
+    raises(ValueError, lambda: totient(20.001))
+
     m = Symbol("m", integer=True)
     assert totient(m)
     assert totient(m).subs(m, 3**10) == 3**10 - 3**9
@@ -308,6 +311,16 @@ def test_totient():
 
     n = Symbol("n", integer=True, positive=True)
     assert totient(n).is_integer
+
+    x=Symbol("x", integer=False)
+    raises(ValueError, lambda: totient(x))
+
+    y=Symbol("y", positive=False)
+    raises(ValueError, lambda: totient(y))
+
+    z=Symbol("z", positive=True, integer=True)
+    raises(ValueError, lambda: totient(2**(-z)))
+
 
 def test_reduced_totient():
     assert [reduced_totient(k) for k in range(1, 16)] == \


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
totient() raises a type error if the input given is not an integer/Symbol. An error is also raised if the input
is a symbol specified as non-integer/ non-positive. 

Example: 

```
 from sympy import *
>>> x=Symbol('x', positive=False)
>>> totient(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/akash/sympy/sympy/core/function.py", line 427, in __new__
    result = super(Function, cls).__new__(cls, *args, **options)
  File "/home/akash/sympy/sympy/core/function.py", line 250, in __new__
    evaluated = cls.eval(*args)
  File "/home/akash/sympy/sympy/ntheory/factor_.py", line 1596, in eval
    raise ValueError("n must be a positive integer")
ValueError: n must be a positive integer
``` 
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #8875 
