### PR TITLE
print Interval with methods indicating openess

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -26,13 +26,13 @@ def continuous_domain(f, symbol, domain):
     >>> from sympy.calculus.util import continuous_domain
     >>> x = Symbol('x')
     >>> continuous_domain(1/x, x, S.Reals)
-    Union(Interval(-oo, 0, True, True), Interval(0, oo, True, True))
+    Union(Interval.open(-oo, 0), Interval.open(0, oo))
     >>> continuous_domain(tan(x), x, Interval(0, pi))
-    Union(Interval(0, pi/2, False, True), Interval(pi/2, pi, True))
+    Union(Interval.Ropen(0, pi/2), Interval.Lopen(pi/2, pi))
     >>> continuous_domain(sqrt(x - 2), x, Interval(-5, 5))
     Interval(2, 5)
     >>> continuous_domain(log(2*x - 1), x, S.Reals)
-    Interval(1/2, oo, True, True)
+    Interval.open(1/2, oo)
 
     """
     from sympy.solvers.inequalities import solve_univariate_inequality
@@ -94,13 +94,13 @@ def function_range(f, symbol, domain):
     >>> function_range(sin(x), x, Interval(0, 2*pi))
     Interval(-1, 1)
     >>> function_range(tan(x), x, Interval(-pi/2, pi/2))
-    Interval(-oo, oo, True, True)
+    Interval(-oo, oo)
     >>> function_range(1/x, x, S.Reals)
-    Interval(-oo, oo, True, True)
+    Interval(-oo, oo)
     >>> function_range(exp(x), x, S.Reals)
-    Interval(0, oo, True, True)
+    Interval.open(0, oo)
     >>> function_range(log(x), x, S.Reals)
-    Interval(-oo, oo, True, True)
+    Interval(-oo, oo)
     >>> function_range(sqrt(x), x , Interval(-5, 9))
     Interval(0, 3)
 
@@ -191,7 +191,7 @@ def not_empty_in(finset_intersection, *syms):
     >>> not_empty_in(FiniteSet(x, x**2).intersect(Interval(1, 2)), x)
     Union(Interval(-sqrt(2), -1), Interval(1, 2))
     >>> not_empty_in(FiniteSet(x**2/(x + 2)).intersect(Interval(1, oo)), x)
-    Union(Interval(-2, -1, True), Interval(2, oo, False, True))
+    Union(Interval.Lopen(-2, -1), Interval(2, oo))
     """
 
     # TODO: handle piecewise defined functions

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1143,7 +1143,7 @@ class Basic(with_metaclass(ManagedProperties)):
 
         >>> from sympy.sets import Interval
         >>> i = Interval.Lopen(0, 5); i
-        Interval(0, 5, True)
+        Interval.Lopen(0, 5)
         >>> i.args
         (0, 5, True, False)
         >>> i.has(4)  # there is no "4" in the arguments

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -206,7 +206,7 @@ class Relational(Boolean, Expr, EvalfMixin):
         >>> from sympy import Symbol, Eq
         >>> x = Symbol('x', real=True)
         >>> (x > 0).as_set()
-        Interval(0, oo, True, True)
+        Interval.open(0, oo)
         >>> Eq(x, 0).as_set()
         {0}
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -367,7 +367,7 @@ class And(LatticeOp, BooleanFunction):
         >>> from sympy import And, Symbol
         >>> x = Symbol('x', real=True)
         >>> And(x<2, x>-2).as_set()
-        Interval(-2, 2, True, True)
+        Interval.open(-2, 2)
         """
         from sympy.sets.sets import Intersection
         if len(self.free_symbols) == 1:
@@ -438,7 +438,7 @@ class Or(LatticeOp, BooleanFunction):
         >>> from sympy import Or, Symbol
         >>> x = Symbol('x', real=True)
         >>> Or(x>2, x<-2).as_set()
-        Union(Interval(-oo, -2, True, True), Interval(2, oo, True, True))
+        Union(Interval.open(-oo, -2), Interval.open(2, oo))
         """
         from sympy.sets.sets import Union
         if len(self.free_symbols) == 1:
@@ -531,7 +531,7 @@ class Not(BooleanFunction):
         >>> from sympy import Not, Symbol
         >>> x = Symbol('x', real=True)
         >>> Not(x>0).as_set()
-        Interval(-oo, 0, True)
+        Interval(-oo, 0)
         """
         if len(self.free_symbols) == 1:
             return self.args[0].as_set().complement(S.Reals)

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -195,11 +195,11 @@ class L2(HilbertSpace):
     >>> from sympy.physics.quantum.hilbert import L2
     >>> hs = L2(Interval(0,oo))
     >>> hs
-    L2(Interval(0, oo, False, True))
+    L2(Interval(0, oo))
     >>> hs.dimension
     oo
     >>> hs.interval
-    Interval(0, oo, False, True)
+    Interval(0, oo)
 
     """
 

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -344,7 +344,7 @@ C \
     assert upretty(h3) == u'F'
     assert latex(h3) == r'\mathcal{F}'
     sT(h3, "FockSpace()")
-    assert str(h4) == 'L2(Interval(0, oo, False, True))'
+    assert str(h4) == 'L2(Interval(0, oo))'
     ascii_str = \
 """\
  2\n\
@@ -863,7 +863,7 @@ u("""\
     assert latex(e3) == \
         r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dag} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,j_{1}=1,j_{2}=1\right\rangle } + {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }}\right)\otimes {{\left|1,-1,j_{1}=1,j_{2}=1\right\rangle }}'
     sT(e3, "Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))), JzKetCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))), JzKetCoupled(Integer(1),Integer(-1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))))")
-    assert str(e4) == '(C(1)*C(2)+F**2)*(L2(Interval(0, oo, False, True))+H)'
+    assert str(e4) == '(C(1)*C(2)+F**2)*(L2(Interval(0, oo))+H)'
     ascii_str = \
 """\
 // 1    2\\    x2\\   / 2    \\\n\

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -174,14 +174,23 @@ class StrPrinter(Printer):
         return 'Integral(%s, %s)' % (self._print(expr.function), L)
 
     def _print_Interval(self, i):
-        fin =  'Interval(%s)'
-        if (i.args[2]==False and i.args[3]==False):
-            fin = fin %(', '.join([self._print(a) for a in i.args[:2]]))
-        elif i.args[3]==False:
-            fin = fin %(', '.join([self._print(a) for a in i.args[:3]]))
+        fin =  'Interval{m}({a}, {b})'
+        a, b, l, r = i.args
+        if a.is_infinite and b.is_infinite:
+            m = ''
+        elif a.is_infinite and not r:
+            m = ''
+        elif b.is_infinite and not l:
+            m = ''
+        elif not l and not r:
+            m = ''
+        elif l and r:
+            m = '.open'
+        elif l:
+            m = '.Lopen'
         else:
-            fin = fin %(', '.join([self._print(a) for a in i.args]))
-        return fin
+            m = '.Ropen'
+        return fin.format(**{'a': a, 'b': b, 'm': m})
 
     def _print_AccumulationBounds(self, i):
         left = '<'

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -155,12 +155,13 @@ def test_Integral():
 
 
 def test_Interval():
-    a = Symbol('a', real=True)
-    assert str(Interval(0, a)) == "Interval(0, a)"
-    assert str(Interval(0, a, False, False)) == "Interval(0, a)"
-    assert str(Interval(0, a, True, False)) == "Interval(0, a, True)"
-    assert str(Interval(0, a, False, True)) == "Interval(0, a, False, True)"
-    assert str(Interval(0, a, True, True)) == "Interval(0, a, True, True)"
+    n = (S.NegativeInfinity, 1, 2, S.Infinity)
+    for i in range(len(n)):
+        for j in range(i + 1, len(n)):
+            for l in (True, False):
+                for r in (True, False):
+                    ival = Interval(n[i], n[j], l, r)
+                    assert S(str(ival)) == ival
 
 
 def test_AccumBounds():

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -1006,11 +1006,11 @@ def normalize_theta_set(theta):
     >>> normalize_theta_set(Interval(9*pi/2, 5*pi))
     Interval(pi/2, pi)
     >>> normalize_theta_set(Interval(-3*pi/2, pi/2))
-    Interval(0, 2*pi, False, True)
+    Interval.Ropen(0, 2*pi)
     >>> normalize_theta_set(Interval(-pi/2, pi/2))
-    Union(Interval(0, pi/2), Interval(3*pi/2, 2*pi, False, True))
+    Union(Interval(0, pi/2), Interval.Ropen(3*pi/2, 2*pi))
     >>> normalize_theta_set(Interval(-4*pi, 3*pi))
-    Interval(0, 2*pi, False, True)
+    Interval.Ropen(0, 2*pi)
     >>> normalize_theta_set(Interval(-3*pi/2, -pi/2))
     Interval(pi/2, 3*pi/2)
     >>> normalize_theta_set(FiniteSet(0, pi, 3*pi))
@@ -1118,7 +1118,7 @@ class ComplexRegion(Set):
     >>> theta = Interval(0, 2*S.Pi)
     >>> c2 = ComplexRegion(r*theta, polar=True)  # Polar Form
     >>> c2  # unit Disk
-    ComplexRegion(Interval(0, 1) x Interval(0, 2*pi, False, True), True)
+    ComplexRegion(Interval(0, 1) x Interval.Ropen(0, 2*pi), True)
 
     * c2 represents the region in complex plane inside the
       Unit Disk centered at the origin.

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -77,14 +77,14 @@ class Set(Basic):
         >>> Interval(0, 1) + Interval(2, 3)
         Union(Interval(0, 1), Interval(2, 3))
         >>> Interval(1, 2, True, True) + FiniteSet(2, 3)
-        Union(Interval(1, 2, True), {3})
+        Union(Interval.Lopen(1, 2), {3})
 
         Similarly it is possible to use the '-' operator for set differences:
 
         >>> Interval(0, 2) - Interval(0, 1)
-        Interval(1, 2, True)
+        Interval.Lopen(1, 2)
         >>> Interval(1, 3) - FiniteSet(2)
-        Union(Interval(1, 2, False, True), Interval(2, 3, True))
+        Union(Interval.Ropen(1, 2), Interval.Lopen(2, 3))
 
         """
         return Union(self, other)
@@ -176,7 +176,7 @@ class Set(Basic):
 
         >>> from sympy import Interval, S
         >>> Interval(0, 1).complement(S.Reals)
-        Union(Interval(-oo, 0, True, True), Interval(1, oo, True, True))
+        Union(Interval.open(-oo, 0), Interval.open(1, oo))
 
         >>> Interval(0, 1).complement(S.UniversalSet)
         UniversalSet() \ Interval(0, 1)
@@ -227,9 +227,9 @@ class Set(Basic):
 
         >>> from sympy import Interval, S
         >>> Interval(1, 3).symmetric_difference(S.Reals)
-        Union(Interval(-oo, 1, True, True), Interval(3, oo, True, True))
+        Union(Interval.open(-oo, 1), Interval.open(3, oo))
         >>> Interval(1, 10).symmetric_difference(S.Reals)
-        Union(Interval(-oo, 1, True, True), Interval(10, oo, True, True))
+        Union(Interval.open(-oo, 1), Interval.open(10, oo))
 
         >>> from sympy import S, EmptySet
         >>> S.Reals.symmetric_difference(EmptySet())
@@ -534,7 +534,7 @@ class Set(Basic):
         ========
         >>> from sympy import Interval
         >>> Interval(0, 1).interior
-        Interval(0, 1, True, True)
+        Interval.open(0, 1)
         >>> Interval(0, 1).boundary.interior
         EmptySet()
         """
@@ -779,14 +779,14 @@ class Interval(Set, EvalfMixin):
     >>> from sympy import Symbol, Interval
     >>> Interval(0, 1)
     Interval(0, 1)
-    >>> Interval(0, 1, False, True)
-    Interval(0, 1, False, True)
     >>> Interval.Ropen(0, 1)
-    Interval(0, 1, False, True)
+    Interval.Ropen(0, 1)
+    >>> Interval.Ropen(0, 1)
+    Interval.Ropen(0, 1)
     >>> Interval.Lopen(0, 1)
-    Interval(0, 1, True)
+    Interval.Lopen(0, 1)
     >>> Interval.open(0, 1)
-    Interval(0, 1, True, True)
+    Interval.open(0, 1)
 
     >>> a = Symbol('a', real=True)
     >>> Interval(0, a)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -30,7 +30,7 @@ def solve_poly_inequality(poly, rel):
     [{0}]
 
     >>> solve_poly_inequality(Poly(x**2 - 1, x, domain='ZZ'), '!=')
-    [Interval(-oo, -1, True, True), Interval(-1, 1, True, True), Interval(1, oo, True, True)]
+    [Interval.open(-oo, -1), Interval.open(-1, 1), Interval.open(1, oo)]
 
     >>> solve_poly_inequality(Poly(x**2 - 1, x, domain='ZZ'), '==')
     [{-1}, {1}]
@@ -120,7 +120,7 @@ def solve_poly_inequalities(polys):
     >>> solve_poly_inequalities(((
     ... Poly(x**2 - 3), ">"), (
     ... Poly(-x**2 + 1), ">")))
-    Union(Interval(-oo, -sqrt(3), True, True), Interval(-1, 1, True, True), Interval(sqrt(3), oo, True, True))
+    Union(Interval.open(-oo, -sqrt(3)), Interval.open(-1, 1), Interval.open(sqrt(3), oo))
     """
     from sympy import Union
     return Union(*[solve_poly_inequality(*p) for p in polys])
@@ -144,7 +144,7 @@ def solve_rational_inequalities(eqs):
     >>> solve_rational_inequalities([[
     ... ((Poly(x), Poly(1, x)), '!='),
     ... ((Poly(-x + 1), Poly(1, x)), '>=')]])
-    Union(Interval(-oo, 0, True, True), Interval(0, 1, True))
+    Union(Interval.open(-oo, 0), Interval.Lopen(0, 1))
 
     See Also
     ========
@@ -427,14 +427,14 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     ((2 <= x) & (x < oo)) | ((x <= -2) & (-oo < x))
 
     >>> solve_univariate_inequality(x**2 >= 4, x, relational=False)
-    Union(Interval(-oo, -2, True), Interval(2, oo, False, True))
+    Union(Interval(-oo, -2), Interval(2, oo))
 
     >>> domain = Interval(0, S.Infinity)
     >>> solve_univariate_inequality(x**2 >= 4, x, False, domain)
-    Interval(2, oo, False, True)
+    Interval(2, oo)
 
     >>> solve_univariate_inequality(sin(x) > 0, x, relational=False)
-    Interval(0, pi, True, True)
+    Interval.open(0, pi)
 
     """
     from sympy.calculus.util import (continuous_domain, periodicity,

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -866,7 +866,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
       domain leads to a NotImplementedError.
 
     >>> solveset(exp(x) > 1, x, R)
-    Interval(0, oo, True, True)
+    Interval.open(0, oo)
 
     """
     f = sympify(f)

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -785,7 +785,7 @@ def where(condition, given_condition=None, **kwargs):
     Domain: (-1 < x) & (x < 1)
 
     >>> where(X**2<1).set
-    Interval(-1, 1, True, True)
+    Interval.open(-1, 1)
 
     >>> where(And(D1<=D2 , D2<3))
     Domain: ((Eq(a, 1)) & (Eq(b, 1))) | ((Eq(a, 1)) & (Eq(b, 2))) | ((Eq(a, 2)) & (Eq(b, 2)))    """


### PR DESCRIPTION
It is perhaps more salient to see Intervals printed
with an explicit word telling the closure rather than
having to remember that True or False refer to the
interval being open or closed, respectively:

Interval.Ropen(3, 4) == Interval(3, 4, False, True)

The form on the left is now the default str form that is shown.

When Infinity is involved, it is not explicitly indicated
as open since neither oo nor -oo are included in intervals, e.g.

Interval.Ropen(3, oo) ==> Interval(3, oo)

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
