### PR TITLE
solve() missing a solution for x**(1/x)-1

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1557,7 +1557,11 @@ def _solve(f, *symbols, **flags):
                         try:
                             t = Dummy('t')
                             iv = _solve(u - t, symbol, **flags)
-                            soln = list(ordered({i.subs(t, s) for i in iv for s in soln}))
+                            new_soln = list(ordered({i.subs(t, s) for i in iv for s in soln}))
+                            if new_soln[0] == S.NaN:
+                                pass
+                            else:
+                                soln = new_soln
                         except NotImplementedError:
                             # perhaps _tsolve can handle f_num
                             soln = None

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1430,7 +1430,7 @@ def _solve(f, *symbols, **flags):
             return x, 1
 
         if len(gens) > 1:
-            # If there is more than one generator, it could be that the
+            # If there are more than one generator, it could be that the
             # generators have the same base but different powers, e.g.
             #   >>> Poly(exp(x) + 1/exp(x))
             #   Poly(exp(-x) + exp(x), exp(-x), exp(x), domain='ZZ')
@@ -1555,15 +1555,17 @@ def _solve(f, *symbols, **flags):
                     u = poly.gen
                     if u != symbol:
                         try:
-                            if deg == 1:
-                                if checksol(f, symbol, soln[0]):
-                                    temp_soln = soln
                             t = Dummy('t')
                             iv = _solve(u - t, symbol, **flags)
+                            temp_soln = soln
+                            index_list = []
                             soln = list(ordered({i.subs(t, s) for i in iv for s in soln}))
-                            soln[:] = (val for val in soln if val != S.NaN)
-                            if not soln:
-                                soln = temp_soln
+                            for index, s in enumerate(soln):
+                                if s == S.NaN:
+                                    index_list.append(index)
+                            for i in index_list:
+                                if checksol(f, symbol, temp_soln[i]):
+                                    soln.append(temp_soln[i])
                         except NotImplementedError:
                             # perhaps _tsolve can handle f_num
                             soln = None

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1555,12 +1555,15 @@ def _solve(f, *symbols, **flags):
                     u = poly.gen
                     if u != symbol:
                         try:
+                            if deg == 1:
+                                if checksol(f, symbol, soln[0]):
+                                    temp_soln = soln
                             t = Dummy('t')
                             iv = _solve(u - t, symbol, **flags)
-                            new_soln = list(ordered({i.subs(t, s) for i in iv for s in soln}))
-                            new_soln[:] = (val for val in new_soln if val != S.NaN)
-                            if new_soln:
-                                soln = new_soln
+                            soln = list(ordered({i.subs(t, s) for i in iv for s in soln}))
+                            soln[:] = (val for val in soln if val != S.NaN)
+                            if not soln:
+                                soln = temp_soln
                         except NotImplementedError:
                             # perhaps _tsolve can handle f_num
                             soln = None

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1558,14 +1558,21 @@ def _solve(f, *symbols, **flags):
                             t = Dummy('t')
                             iv = _solve(u - t, symbol, **flags)
                             temp_soln = soln
-                            index_list = []
                             soln = list(ordered({i.subs(t, s) for i in iv for s in soln}))
-                            for index, s in enumerate(soln):
-                                if s == S.NaN:
-                                    index_list.append(index)
-                            for i in index_list:
-                                if checksol(f, symbol, temp_soln[i]):
-                                    soln.append(temp_soln[i])
+                            count_nan = 0
+                            if S.NaN in soln:
+                                count_nan = soln.count(S.NaN)
+                                # try getting a solution for the equation
+                            if count_nan != 0:
+                                # heuristic -01(check whether the root satisfies the equation)
+                                index_list = []
+                                for index, s in enumerate(soln):
+                                    if s == S.NaN:
+                                        index_list.append(index)
+                                for i in index_list:
+                                    if checksol(f, symbol, temp_soln[i]):
+                                        soln.append(temp_soln[i])
+                                        count_nan -= 1
                         except NotImplementedError:
                             # perhaps _tsolve can handle f_num
                             soln = None

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1558,9 +1558,8 @@ def _solve(f, *symbols, **flags):
                             t = Dummy('t')
                             iv = _solve(u - t, symbol, **flags)
                             new_soln = list(ordered({i.subs(t, s) for i in iv for s in soln}))
-                            if new_soln[0] == S.NaN:
-                                pass
-                            else:
+                            new_soln[:] = (val for val in new_soln if val != S.NaN)
+                            if new_soln:
                                 soln = new_soln
                         except NotImplementedError:
                             # perhaps _tsolve can handle f_num

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1484,6 +1484,10 @@ def test_issue_6989():
         [Piecewise((-1, x > 0), (0, True))]
 
 
+def test_issue_12538():
+    assert solve(x**(1/x) - 1, x) == [1]
+
+
 def test_lambert_multivariate():
     from sympy.abc import a, x, y
     from sympy.solvers.bivariate import _filtered_gens, _lambert, _solve_lambert

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1486,6 +1486,9 @@ def test_issue_6989():
 
 def test_issue_12538():
     assert solve(x**(1/x) - 1, x) == [1]
+    assert solve(x**(2/x) - 3*x**(1/x) + 2, x) == [1, -LambertW(-log(2))/log(2)]
+    assert solve(x**(3/x) - 6*x**(2/x) + 11*x**(1/x) - 6, x) == \
+        [1, -LambertW(-log(2))/log(2), -LambertW(-log(3))/log(3)]
 
 
 def test_lambert_multivariate():


### PR DESCRIPTION
This PR is an attempt to fix the issue of `solve` not able to solve equation `x**(1/x) - 1`.
fixes [issue#12538](https://github.com/sympy/sympy/issues/12538).

After finding out the `roots` `solve` again tries to find a solution by solving `x**(1/x) - t` , which sometimes makes it even more complicated to solve(like in this case).
I tried apply a heuristic approach by checking if `_solve` is able to find out the `roots` and in case solving again leads to a solution not appropriate(possibly a `NaN`) it would take `roots` as its result.

ping @asmeurer @smichr 