### PR TITLE
Matrix norm for order 1 added.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4306,9 +4306,9 @@ class MatrixBase(MatrixDeprecated, MatrixDeterminant, MatrixProperties):
         =====  ============================  ==========================
         None   Frobenius norm                2-norm
         'fro'  Frobenius norm                - does not exist
-        inf    --                            max(abs(x))
+        inf                                  max(abs(x))
         -inf   --                            min(abs(x))
-        1      --                            as below
+        1      maximum column sum            as below
         -1     --                            as below
         2      2-norm (largest sing. value)  as below
         -2     smallest singular value       as below
@@ -4366,7 +4366,20 @@ class MatrixBase(MatrixDeprecated, MatrixDeterminant, MatrixProperties):
 
         # Matrix Norms
         else:
-            if ord == 2:  # Spectral Norm
+            if ord == 1: #maximum column sum of absolute value
+                max_row = 0
+                k = 0
+                for i in range(self.shape[0]): #first iterate through rows
+                    sum_ = 0
+                    for j in range(self.shape[1]): #iterating through each entry of a given row
+                        sum_ += abs(self[k])
+                        k+=1
+                    if(max_row <= sum_):
+                        max_row = sum_
+                return max_row
+
+
+            elif ord == 2:  # Spectral Norm
                 # Maximum singular value
                 return Max(*self.singular_values())
 


### PR DESCRIPTION
Fixes #12565 

Note : Matrix norm for order 1 corresponds to the maximum column sum for absolute values of the given matrix

Consider the following code :

```
In [1]: from sympy import Matrix, Symbol, trigsimp, cos, sin, oo

In [2]: from sympy import pprint

In [3]: M= Matrix(3, 3, [1, 3, 0, -2, -6, 0, 3, 9, 6])

In [4]: pprint(M)
⎡1   3   0⎤
⎢         ⎥
⎢-2  -6  0⎥
⎢         ⎥
⎣3   9   6⎦

In [5]: M.norm(1)
Out[5]: 18

```
