### PR TITLE
Matrix norm for order 1 added.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4366,10 +4366,10 @@ class MatrixBase(MatrixDeprecated, MatrixDeterminant, MatrixProperties):
 
         # Matrix Norms
         else:
-            if ord == 1: #maximum column sum 
+            if ord == 1: #maximum column sum
                 k = 0
                 max_= 0
-                for i in range(self.shape[1]): 
+                for i in range(self.shape[1]):
                     sum_ = 0
                     a = k
                     for j in range(self.shape[0]):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4308,7 +4308,7 @@ class MatrixBase(MatrixDeprecated, MatrixDeterminant, MatrixProperties):
         'fro'  Frobenius norm                - does not exist
         inf    --                            max(abs(x))
         -inf   --                            min(abs(x))
-        1      --                            as below
+        1      maximum column sum            as below
         -1     --                            as below
         2      2-norm (largest sing. value)  as below
         -2     smallest singular value       as below
@@ -4366,7 +4366,22 @@ class MatrixBase(MatrixDeprecated, MatrixDeterminant, MatrixProperties):
 
         # Matrix Norms
         else:
-            if ord == 2:  # Spectral Norm
+            if ord == 1: #maximum column sum 
+                k = 0
+                max_= 0
+                for i in range(self.shape[1]): 
+                    sum_ = 0
+                    a = k
+                    for j in range(self.shape[0]):
+                        sum_ += abs(self[a])
+                        a += self.shape[1]
+                    if(max_ <= sum_):
+                        max_ = sum_
+                    k+=1
+
+                return max_
+
+            elif ord == 2:  # Spectral Norm
                 # Maximum singular value
                 return Max(*self.singular_values())
 


### PR DESCRIPTION
Fixes #12565 

Note : Matrix Norm for order 1 is the maximum sum of column of absolute values in a given matrix

Consider the following code :

```
In [1]: from sympy import Matrix, pprint

In [2]: M= Matrix(3, 3, [1, 3, 0, -2, -1, 0, 3, 9, 6])

In [3]: pprint(M)
⎡1   3   0⎤
⎢         ⎥
⎢-2  -1  0⎥
⎢         ⎥
⎣3   9   6⎦

In [4]: M.norm(1)
Out[4]: 13

```


