### PR TITLE
`Eq(x, oo)` remains unevaluated

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -345,7 +345,7 @@ class Equality(Relational):
                                 rv = fuzzy_bool(Eq(*args))
                                 if rv is True:
                                     rv = None
-                elif any(a.is_infinite for a in Add.make_args(n)):  # (inf or nan)/x != 0
+                elif all(a.is_infinite for a in Add.make_args(n)):  # (inf or nan)/x != 0
                     rv = S.false
                 if rv is not None:
                     return _sympify(rv)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -316,6 +316,8 @@ class Equality(Relational):
                     return S.false
                 if L is False:
                     return S.true
+            elif None in fin and False in fin:
+                return Relational.__new__(cls, lhs, rhs, **options)
 
             if all(isinstance(i, Expr) for i in (lhs, rhs)):
                 # see if the difference evaluates
@@ -345,7 +347,7 @@ class Equality(Relational):
                                 rv = fuzzy_bool(Eq(*args))
                                 if rv is True:
                                     rv = None
-                elif all(a.is_infinite for a in Add.make_args(n)):  # (inf or nan)/x != 0
+                elif any(a.is_infinite for a in Add.make_args(n)):  # (inf or nan)/x != 0
                     rv = S.false
                 if rv is not None:
                     return _sympify(rv)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -705,3 +705,8 @@ def test_issue_10633():
     assert Eq(False, True) == False
     assert Eq(True, True) == True
     assert Eq(False, False) == True
+
+def test_issue_10927():
+    x = symbols('x')
+    assert str(Eq(x, oo)) == 'Eq(x, oo)'
+    assert str(Eq(x, -oo)) == 'Eq(x, -oo)'

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4078,6 +4078,31 @@ k = 0   \
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+    expr = Sum(k**k, (k, oo, n))
+    ascii_str = \
+"""\
+  n      \n\
+ ___     \n\
+ \\  `    \n\
+  \\     k\n\
+  /    k \n\
+ /__,    \n\
+k = oo   \
+"""
+    ucode_str = \
+u("""\
+  n     \n\
+ ___    \n\
+ ╲      \n\
+  ╲    k\n\
+  ╱   k \n\
+ ╱      \n\
+ ‾‾‾    \n\
+k = ∞   \
+""")
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
     expr = Sum(k**(Integral(x**n, (x, -oo, oo))), (k, 0, n**n))
     ascii_str = \
 """\


### PR DESCRIPTION
Fixes #10927 and  #12501.

#### Output before this PR:
```python
>>> from sympy import Eq, oo
>>> from sympy.abc import x
>>> Eq(x, oo)
False
```

#### Output after this PR:
```python 
>>> from sympy import Eq, oo
>>> from sympy.abc import x
>>> Eq(x, oo)
Eq(x, oo)
```

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->