### PR TITLE
`Eq(oo, -oo)` returns False

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -315,6 +315,8 @@ class Equality(Relational):
                 if L != R:
                     return S.false
                 if L is False:
+                    if lhs == -rhs:  # Eq(oo, -oo)
+                        return S.false
                     return S.true
             elif None in fin and False in fin:
                 return Relational.__new__(cls, lhs, rhs, **options)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -689,6 +689,7 @@ def test_issue_10401():
     assert Eq(inf/fin, 0) is F
     assert Eq(fin/inf, 0) is T
     assert Eq(zero/nonzero, 0) is T and ((zero/nonzero) != 0)
+    assert Eq(inf, -inf) is F
 
 
     assert Eq(fin/(fin + 1), 1) is S.false


### PR DESCRIPTION
### Output before this PR:
``` python
>>> from sympy import Eq, oo
>>> Eq(oo, -oo)
True
>>> Eq(oo, oo)
True
```

### Output after this PR:
``` python
>>> Eq(oo, -oo)
False
>>> Eq(oo, oo)
True
```

* Tests are added.
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->