### PR TITLE
 And/Or are more aware of arg interactions … 

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1138,7 +1138,6 @@ def test_issue_8368():
                 And(
                     Ne(1/s, 1),
                     Abs(periodic_argument(s, oo)) < pi/2,
-                    Abs(periodic_argument(s, oo)) <= pi/2,
                     cos(Abs(periodic_argument(s, oo)))*Abs(s) - 1 > 0)),
             (   Integral(exp(-s*x)*sinh(x), (x, 0, oo)),
                 True))

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -14,6 +14,7 @@ from sympy.core.function import Application, Derivative
 from sympy.core.compatibility import ordered, range, with_metaclass, as_int
 from sympy.core.sympify import converter, _sympify, sympify
 from sympy.core.singleton import Singleton, S
+from sympy.utilities.iterables import uniq
 
 
 class Boolean(Basic):
@@ -343,9 +344,11 @@ class And(LatticeOp, BooleanFunction):
 
     @classmethod
     def _new_args_filter(cls, args):
+        from sympy.core.relational import Equality
         newargs = []
         rel = []
-        for x in reversed(list(args)):
+        drev = {}
+        for x in reversed(list(uniq(args))):  # maintain order
             if isinstance(x, Number) or x in (0, 1):
                 newargs.append(True if x else False)
                 continue
@@ -356,8 +359,43 @@ class And(LatticeOp, BooleanFunction):
                 nc = (~c).canonical
                 if any(r == nc for r in rel):
                     return [S.false]
+                if c.rel_op in ("<", ">"):
+                    rev = c.reversed.func(*c.args)  # x < 0 --> x > 0
+                    if any(r == rev for r in rel):
+                        return [S.false]
+                    drev[c] = rev
+                # weak (x <= 0) /strong (x < 0) interaction
+                if c.rel_op not in ('==', '!='):
+                    ws = (~c).reversed.func(*c.args)  # x < 0 --> x <= 0
+                    if any(r == ws for r in rel):
+                        if c.rel_op in ("<", ">"):
+                            # strong replaces weak
+                            rel.remove(ws)
+                            rel.append(c)
+                            try:
+                                newargs.remove(ws)
+                            except ValueError:
+                                newargs.remove(ws.reversed)
+                            newargs.append(x)
+                        # weak is ignored
+                        continue
                 rel.append(c)
             newargs.append(x)
+        # check for equality condition
+        for c in rel:
+            if c.rel_op in ("<=", ">="):
+                rev = drev.get(c, c.reversed.func(*c.args))
+                if any(r == rev for r in rel):
+                    rel.remove(rev)
+                    try:
+                        newargs.remove(rev)
+                    except ValueError:
+                        newargs.remove(rev.reversed)
+                    try:
+                        newargs.remove(c)
+                    except ValueError:
+                        newargs.remove(c.reversed)
+                    newargs.append(Equality(*c.args))
         return LatticeOp._new_args_filter(newargs, And)
 
     def as_set(self):
@@ -414,8 +452,10 @@ class Or(LatticeOp, BooleanFunction):
 
     @classmethod
     def _new_args_filter(cls, args):
+        from sympy.core.relational import Unequality
         newargs = []
         rel = []
+        drev = {}
         for x in args:
             if isinstance(x, Number) or x in (0, 1):
                 newargs.append(True if x else False)
@@ -427,8 +467,44 @@ class Or(LatticeOp, BooleanFunction):
                 nc = (~c).canonical
                 if any(r == nc for r in rel):
                     return [S.true]
+                if c.rel_op in ("<=", ">="):
+                    rev = c.reversed.func(*c.args)  # x < 0 --> x > 0
+                    if any(r == rev for r in rel):
+                        return [S.true]
+                    drev[c] = rev
+                # strong (x < 0) and weak (x <= 0)
+                if c.rel_op not in ('==', '!='):
+                    ws = (~c).reversed.func(*c.args)  # x <= 0 --> x < 0
+                    if any(r == ws for r in rel):
+                        # strong is ignored
+                        if c.rel_op in ("<", ">"):
+                            continue
+                        # weak (x<=0) replaces strong (x<0)
+                        rel.remove(ws)
+                        rel.append(c)
+                        try:
+                            newargs.remove(ws)
+                        except ValueError:
+                            newargs.remove(ws.reversed)
+                        newargs.append(x)
+                        continue
                 rel.append(c)
             newargs.append(x)
+        # check for unequality condition
+        for c in rel:
+            if c.rel_op in ("<", ">"):
+                rev = c.reversed.func(*c.args)  # x < 0 --> x > 0
+                if any(r == rev for r in rel):
+                    rel.remove(rev)
+                    try:
+                        newargs.remove(rev)
+                    except ValueError:
+                        newargs.remove(rev.reversed)
+                    try:
+                        newargs.remove(c)
+                    except ValueError:
+                        newargs.remove(c.reversed)
+                    newargs.append(Unequality(*c.args))
         return LatticeOp._new_args_filter(newargs, Or)
 
     def as_set(self):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -348,7 +348,17 @@ class And(LatticeOp, BooleanFunction):
         newargs = []
         rel = []
         drev = {}
-        for x in reversed(list(uniq(args))):  # maintain order
+        # flatten and maintain order
+        sargs = list(args)
+        while True:
+            changed = False
+            for i in range(len(sargs)):
+                if isinstance(sargs[i], cls):
+                    sargs[i: i + 1] = sargs[i].args
+                    changed = True
+            if not changed:
+                break
+        for x in reversed(list(uniq(sargs))):
             if isinstance(x, Number) or x in (0, 1):
                 newargs.append(True if x else False)
                 continue
@@ -457,7 +467,17 @@ class Or(LatticeOp, BooleanFunction):
         newargs = []
         rel = []
         drev = {}
-        for x in args:
+        # flatten and maintain order
+        sargs = list(args)
+        while True:
+            changed = False
+            for i in range(len(sargs)):
+                if isinstance(sargs[i], cls):
+                    sargs[i: i + 1] = sargs[i].args
+                    changed = True
+            if not changed:
+                break
+        for x in sargs:
             if isinstance(x, Number) or x in (0, 1):
                 newargs.append(True if x else False)
                 continue

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -387,14 +387,15 @@ class And(LatticeOp, BooleanFunction):
                 rev = drev.get(c, c.reversed.func(*c.args))
                 if any(r == rev for r in rel):
                     rel.remove(rev)
-                    try:
-                        newargs.remove(rev)
-                    except ValueError:
-                        newargs.remove(rev.reversed)
-                    try:
-                        newargs.remove(c)
-                    except ValueError:
-                        newargs.remove(c.reversed)
+                    did = 0
+                    for r in (rev, c, rev.reversed, c.reversed):
+                        try:
+                            newargs.remove(r)
+                            did += 1
+                        except ValueError:
+                            pass
+                    if did != 2:
+                        print('equality condition with', args,'did not remove 2')
                     newargs.append(Equality(*c.args))
         return LatticeOp._new_args_filter(newargs, And)
 
@@ -496,14 +497,15 @@ class Or(LatticeOp, BooleanFunction):
                 rev = c.reversed.func(*c.args)  # x < 0 --> x > 0
                 if any(r == rev for r in rel):
                     rel.remove(rev)
-                    try:
-                        newargs.remove(rev)
-                    except ValueError:
-                        newargs.remove(rev.reversed)
-                    try:
-                        newargs.remove(c)
-                    except ValueError:
-                        newargs.remove(c.reversed)
+                    did = 0
+                    for r in (c, rev, c.reversed, rev.reversed):
+                        try:
+                            newargs.remove(r)
+                            did += 1
+                        except ValueError:
+                            pass
+                    if did != 2:
+                        print('Ne condition with',args,'did not remove 2 args')
                     newargs.append(Unequality(*c.args))
         return LatticeOp._new_args_filter(newargs, Or)
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -84,6 +84,8 @@ def test_And():
     assert And(w.reversed, s) == s
 
     assert And(A < 0, A > 0) is S.false
+    # denesting
+    assert And(And(A > 0, A > B), A >= 0) == And(A > 0, A > B, A >= 0)
 
 
 def test_Or():
@@ -134,6 +136,8 @@ def test_Or():
     assert Or(w.reversed, s.reversed) == w.reversed
 
     assert Or(A <= 0, A >= 0) is S.true
+    # denesting
+    assert Or(Or(A > 0, A > B), A >= 0) == Or(A > 0, A > B, A >= 0)
 
 
 def test_Xor():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 from sympy.assumptions.ask import Q
 from sympy.core.numbers import oo
-from sympy.core.relational import Equality
+from sympy.core.relational import Equality, Unequality
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.sets.sets import (EmptySet, Interval, Union)
@@ -55,7 +55,35 @@ def test_And():
     e = A > 1
     assert And(e, e.canonical) == e.canonical
     g, l, ge, le = A > B, B < A, A >= B, B <= A
-    assert And(g, l, ge, le) == And(l, le)
+    assert And(g, l, ge, le) == l
+    # last one that is not redundant should be returned
+    for a, b in ((g, l), (l, g)):
+        assert And(a, b) == b
+        assert And(a.reversed, b) == b
+        assert And(a.reversed, b.reversed) == b.reversed
+        assert And(a, b.reversed) == b.reversed
+
+    # equality detection
+    ans = Equality(A, 0)
+    a, b = (A <= 0, A >= 0)
+    for a, b in ((a, b), (b, a)):
+        assert And(a, b) == ans
+        assert And(a.reversed, b) == ans
+        assert And(a.reversed, b.reversed) == ans
+        assert And(a, b.reversed) == ans
+
+    # strong/weak detection
+    s, w = (A < 0, A <= 0)
+    assert And(s, w) == s
+    assert And(s.reversed, w) == s.reversed
+    assert And(s.reversed, w.reversed) == s.reversed
+    assert And(s, w.reversed) == s
+    assert And(w, s) == s
+    assert And(w, s.reversed) == s.reversed
+    assert And(w.reversed, s.reversed) == s.reversed
+    assert And(w.reversed, s) == s
+
+    assert And(A < 0, A > 0) is S.false
 
 
 def test_Or():
@@ -78,6 +106,34 @@ def test_Or():
     assert Or(e, e.canonical) == e
     g, l, ge, le = A > B, B < A, A >= B, B <= A
     assert Or(g, l, ge, le) == Or(g, ge)
+    # first one that is not redundant should be returned
+    for a, b in ((g, l), (l, g)):
+        assert Or(a, b) == a
+        assert Or(a.reversed, b) == a.reversed
+        assert Or(a.reversed, b.reversed) == a.reversed
+        assert Or(a, b.reversed) == a
+
+    # unequality detection
+    ans = Unequality(A, 0)
+    a, b = (A < 0, A > 0)
+    for a, b in ((a, b), (b, a)):
+        assert Or(a, b) == ans
+        assert Or(a.reversed, b) == ans
+        assert Or(a.reversed, b.reversed) == ans
+        assert Or(a, b.reversed) == ans
+
+    # strong/weak detection
+    s, w = (A < 0, A <= 0)
+    assert Or(s, w) == w
+    assert Or(s.reversed, w) == w
+    assert Or(s, w.reversed) == w.reversed
+    assert Or(s.reversed, w.reversed) == w.reversed
+    assert Or(w, s) == w
+    assert Or(w, s.reversed) == w
+    assert Or(w.reversed, s) == w.reversed
+    assert Or(w.reversed, s.reversed) == w.reversed
+
+    assert Or(A <= 0, A >= 0) is S.true
 
 
 def test_Xor():


### PR DESCRIPTION
 strong/weak interaction

```
And(x<=0, x<0) -> x<0
Or(x<=0, x<0) -> x<=0
```

In/Unequality and noncomplementary True/False

```
>>> Or(x<0,x>0)
Ne(x, 0)
>>> Or(x<=0,x>=0)
True
>>> And(x<0,x>0)
False
>>> And(x<=0,x>=0)
Eq(x, 0)
 ```

closes #8373 

Future (a different PR) enhancements might look for interactions between `Eq` and other elements, but it is not my impression that those are encountered as often:

```
And(Eq(x, 1), x > 1) -> False
And(Eq(x, 1), x>0) -> Eq(x, 1)
And(Eq(x,0), Eq(x, 1)) ->False
```
