### PR TITLE
Fix issue_12555. limit((3**x + 2 * x**10) / (x**10 + E**x), x, -oo) gives 0 instead of 2

### DIFF
--- a/issue.py
+++ b/issue.py
@@ -1,8 +1,0 @@
-from __future__ import division, print_function
-
-from sympy import *
-
-x = Symbol('x', real = True)
-
-expr = (3**x + 2* x**10) / (x**10 + E**x)
-l = limit(expr, x, -oo)

--- a/issue.py
+++ b/issue.py
@@ -1,0 +1,8 @@
+from __future__ import division, print_function
+
+from sympy import *
+
+x = Symbol('x', real = True)
+
+expr = (3**x + 2* x**10) / (x**10 + E**x)
+l = limit(expr, x, -oo)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -162,8 +162,12 @@ class Limit(Expr):
                                         for m in Mul.make_args(a))
                                     for a in Add.make_args(w)))
                 if all(ok(w) for w in e.as_numer_denom()):
-                    u = Dummy(positive=(z0 is S.Infinity))
-                    inve = e.subs(z, 1/u)
+                    if z0 is S.NegativeInfinity:
+                        u = Dummy(positive=True)
+                        inve = e.subs(z, -1/u)
+                    else:
+                        u = Dummy(positive=(z0 is S.Infinity))
+                        inve = e.subs(z, 1/u)
                     r = limit(inve.as_leading_term(u), u,
                               S.Zero, "+" if z0 is S.Infinity else "-")
                     if isinstance(r, Limit):

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -167,8 +167,7 @@ class Limit(Expr):
                         inve = e.subs(z, -1/u)
                     else:
                         inve = e.subs(z, 1/u)
-                    r = limit(inve.as_leading_term(u), u,
-                              S.Zero, "+" if z0 is S.Infinity else "-")
+                    r = limit(inve.as_leading_term(u), u, S.Zero, "+")
                     if isinstance(r, Limit):
                         return self
                     else:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -162,11 +162,10 @@ class Limit(Expr):
                                         for m in Mul.make_args(a))
                                     for a in Add.make_args(w)))
                 if all(ok(w) for w in e.as_numer_denom()):
+                    u = Dummy(positive=True)
                     if z0 is S.NegativeInfinity:
-                        u = Dummy(positive=True)
                         inve = e.subs(z, -1/u)
                     else:
-                        u = Dummy(positive=(z0 is S.Infinity))
                         inve = e.subs(z, 1/u)
                     r = limit(inve.as_leading_term(u), u,
                               S.Zero, "+" if z0 is S.Infinity else "-")

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -501,3 +501,7 @@ def test_issue_10610():
 
 def test_issue_6599():
     assert limit((n + cos(n))/n, n, oo) == 1
+
+def test_issue_12555():
+    assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, -oo) == 2
+    assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, oo) == oo


### PR DESCRIPTION
The wrong behavior is due to the fact that leading terms of numerator and denominator was calculated with a mistake. At some point the substitution `x = 1/u` was performed and then the leading terms of numerator and denominator were calculated comparing the order of the addends. In the case of the numerator we have `O(3**(1/u))` and `O(u**(-10))`.
When comparing the previous order, sympy assumes that `u` tends to `0`, but positive. Instead in this situation `u` should be negative.

Fixes #12555.