### PR TITLE
Piecewise: _eval_interval and _eval_integral overhaul

### DIFF
--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -274,9 +274,9 @@ def deltasummation(f, limit, no_piecewise=False):
     >>> deltasummation(KroneckerDelta(i, k), (k, -oo, oo))
     1
     >>> deltasummation(KroneckerDelta(i, k), (k, 0, oo))
-    Piecewise((1, 0 <= i), (0, True))
+    Piecewise((1, i >= 0), (0, True))
     >>> deltasummation(KroneckerDelta(i, k), (k, 1, 3))
-    Piecewise((1, (1 <= i) & (i <= 3)), (0, True))
+    Piecewise((1, (i >= 1) & (i <= 3)), (0, True))
     >>> deltasummation(k*KroneckerDelta(i, j)*KroneckerDelta(j, k), (k, -oo, oo))
     j*KroneckerDelta(i, j)
     >>> deltasummation(j*KroneckerDelta(i, j), (j, -oo, oo))

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -6,7 +6,7 @@ from sympy.core.compatibility import range
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
-                                   Gt, Ge, Ne)
+                                   Gt, Ge, Ne, _canonical)
 from sympy.sets.sets import Interval, FiniteSet
 
 x, y, z, t = symbols('x,y,z,t')

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1064,7 +1064,6 @@ def _pair(A, B, union=False, dict=None, abi=False):
     (0, [(6, 2)])
     (1, [(4, 5), (4, 5)])
     """
-    from sympy.logic.boolalg import Xor
     if not any(i for i in (abi, dict, union)):
         dict = True
     if [bool(i) for i in (abi, dict, union)].count(True) != 1:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1073,9 +1073,11 @@ def _pair(A, B, union=False, dict=None, abi=False):
     c, d = B
     oo = S.Infinity
     # the real line is broken into pieces which are compactly
-    # represented as -oo, i1, hi1_lo2, i2, hi2_lo3, i3, ..., oo
-    # where i1, i2, ...., refer to the interval A (0), B(1) or
-    # neither (-1) as covering that intrval
+    # represented as -oo, i1, H1|L2, i2, H2|L3, i3, ..., oo
+    # where i1, i2, ...., refer to the interval A (0), B (1) or
+    # neither (-1) as covering that interval and Hi|Lj means
+    # either the hi boundary of the ith interval or the lo
+    # boundary of the jth interval
     if a is -oo and b is oo:
         br = a, 0, b
     elif c is -oo and d is oo:
@@ -1090,7 +1092,7 @@ def _pair(A, B, union=False, dict=None, abi=False):
     elif a is -oo and c is -oo:  # (-oo, b) (-oo, d)
         br = -oo, 0, b, 1, Max(b, d), -1, oo
     elif a is -oo and d is oo:  # (-oo, b) (c, oo)
-        br = -oo, 0, b, -1, Max(b,c), 1, oo
+        br = -oo, 0, b, -1, Max(b, c), 1, oo
     elif b is oo and c is -oo:  # (a, oo) (-oo, d)
         br = -oo, 1, Min(a, d), -1, a, 0, oo
     elif d is oo:  # (a, b) (c, oo)

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1017,43 +1017,41 @@ def _clip(A, B, k):
     oo = S.Infinity
     a, b = B
     c, d = A
-    a = Min(a, b)
     c, d = Min(Max(c, a), b), Min(Max(d, a), b)
-    A = c, d = Min(c, d), d
     # the real line is broken into pieces which are compactly
     # represented as -oo, i1, H|L, i2, H|L, i3, ..., oo
     # where i1, i2, ...., refer to the interval A (k), or
     # B (-1) or neither (-1) as covering that interval and H|L means
     # either the hi boundary of the ith interval or the lo
     # boundary of the (i+1)th interval
-    a, b, c, d = c, d, a, b  # code below assumes opposite ordering
-    if (d <= a) == True:
+    # /!\ If some integration of Piecewise is giving a wrong answer
+    # try uncommenting the commented out intervals.
+    if (b <= c) == True:
         br = (
         -oo, -1,
-        c, -1,
+        a, -1,
+        #b, -1,
+        c, k,
         d, -1,
-        a, k,
-        b, -1,
         oo)
-    elif (b <= c) == True:
+    elif (d <= a) == True:
         br = (
         -oo, -1,
-        a, k,
-        b, -1,
-        c, -1,
+        c, k,
         d, -1,
+        #a, -1,
+        b, -1,
         oo)
     else:
         br = (
         -oo, -1,
-        Min(a, c), -1,
-        Min(a, d), -1,
-        a, k,
-        b, -1,
-        Max(b, c), -1,
-        Max(b, d), -1,
+        Min(c, a), -1,
+        #Min(c, b), -1,
+        c, k,
+        d, -1,
+        #Max(d, a), -1,
+        Max(d, b), -1,
         oo)
-    a, b, c, d = c, d, a, b  # restore ordering
     # remove infinities that weren't there at the start
     oo = S.Infinity
     if -oo not in (a, c) and br[0] == -oo:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1078,34 +1078,38 @@ def _pair(A, B, union=False, dict=None, abi=False):
     # neither (-1) as covering that interval and Hi|Lj means
     # either the hi boundary of the ith interval or the lo
     # boundary of the jth interval
-    if a is -oo and b is oo:
+    if a is -oo and b is oo:                       # (-oo, oo), (c, d)
         br = a, 0, b
     elif c is -oo and d is oo:
-        if a is -oo:
+        if a is -oo:                               # (-oo, b) (-oo, oo)
             br = a, 0, b, 1, oo
-        elif b is oo:
+        elif b is oo:                              # (a, oo) (-oo, oo)
             br = -oo, 1, a, 0, b
-        else:
+        else:                                      # (a, b) (-oo, oo)
             br = -oo, 1, a, 0, b, 1, oo
-    elif b is oo and d is oo:  # (a, oo) (c, oo)
+    elif b is oo and d is oo:                      # (a, oo) (c, oo)
         br = -oo, -1, Min(a, c), 1, a, 0, oo
-    elif a is -oo and c is -oo:  # (-oo, b) (-oo, d)
+    elif a is -oo and c is -oo:                    # (-oo, b) (-oo, d)
         br = -oo, 0, b, 1, Max(b, d), -1, oo
-    elif a is -oo and d is oo:  # (-oo, b) (c, oo)
+    elif a is -oo and d is oo:                     # (-oo, b) (c, oo)
         br = -oo, 0, b, -1, Max(b, c), 1, oo
-    elif b is oo and c is -oo:  # (a, oo) (-oo, d)
+    elif b is oo and c is -oo:                     # (a, oo) (-oo, d)
         br = -oo, 1, Min(a, d), -1, a, 0, oo
-    elif d is oo:  # (a, b) (c, oo)
-        br = -oo, -1, Min(a, c), 1, a, 0, b, -1, Max(b, c), 1, oo
-    elif c is -oo:  # (a, b) (-oo, d)
-        br = -oo, 1, Min(a, d), -1, a, 0, b, 1, Max(b, d), -1, oo
-    elif b is oo:  # (a, oo) (c, d)
-        br = -oo, -1, Min(a, c), 1, Min(a, d), -1, a, 0, oo
-    elif a is -oo:  # (-oo, b) (c, d)
-        br = -oo, 0, b, -1, Max(b, c), 1, Max(b, d), -1, oo
-    else:  # (a, b) (c, d)
-        br = (-oo, -1, Min(a, c), 1, Min(a, d), -1, a, 0, b,
-            -1, Max(b, c), 1, Max(b, d), -1, oo)
+    elif d is oo:                                  # (a, b) (c, oo)
+        br = (-oo, -1, Min(a, c), 1, a, 0,
+            b, -1, Max(b, c), 1, oo)
+    elif c is -oo:                                 # (a, b) (-oo, d)
+        br = (-oo, 1, Min(a, d), -1, a, 0,
+            b, 1, Max(b, d), -1, oo)
+    elif b is oo:                                  # (a, oo) (c, d)
+        br = (-oo, -1, Min(a, c), 1,
+            Min(a, d), -1, a, 0, oo)
+    elif a is -oo:                                 # (-oo, b) (c, d)
+        br = (-oo, 0, b, -1, Max(b, c), 1,
+            Max(b, d), -1, oo)
+    else:                                          # (a, b) (c, d)
+        br = (-oo, -1, Min(a, c), 1, Min(a, d), -1,
+            a, 0, b, -1, Max(b, c), 1, Max(b, d), -1, oo)
     abi = []
     for _ in range(1, len(br) - 1, 2):
         a, b, i = br[_ - 1], br[_ + 1], br[_]

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core import Basic, S, Function, diff, Tuple, Dummy, Number
 from sympy.core.basic import as_Basic
-from sympy.core.sympify import _sympify, SympifyError
+from sympy.core.sympify import SympifyError
 from sympy.core.relational import Equality, Relational, _canonical
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or,
@@ -50,19 +50,8 @@ class ExprCondPair(Tuple):
         return self.args[1]
 
     @property
-    def free_symbols(self):
-        """
-        Return the free symbols of this pair.
-        """
-        # Overload Basic.free_symbols because self.args[1] may contain non-Basic
-        result = self.expr.free_symbols
-        if hasattr(self.cond, 'free_symbols'):
-            result |= self.cond.free_symbols
-        return result
-
-    @property
     def is_commutative(self):
-        return getattr(self.expr, 'is_commutative', False)
+        return self.expr.is_commutative
 
     def __iter__(self):
         yield self.expr
@@ -560,7 +549,7 @@ class Piecewise(Function):
             # In this case, it is just simple substitution
             return super(Piecewise, self)._eval_interval(sym, a, b)
         else:
-            x, lo, hi = map(_sympify, (sym, a, b))
+            x, lo, hi = map(as_Basic, (sym, a, b))
 
         if _first:  # get only x-dependent relationals
             def handler(ipw):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1007,74 +1007,37 @@ def _clip(A, B, k):
     ========
 
     >>> from sympy.functions.elementary.piecewise import _clip
-    >>> _clip((1, 3), (2, 4), 0)
+    >>> from sympy import Tuple
+    >>> A = Tuple(1, 3)
+    >>> B = Tuple(2, 4)
+    >>> _clip(A, B, 0)
     [(2, 3, 0), (3, 4, -1)]
 
     Interpretation: interval portion (2, 3) of interval (2, 4) is
     covered by interval (1, 3) and is keyed to 0 as requested;
     interval (3, 4) was not covered by (1, 3) and is keyed to -1.
     """
-    oo = S.Infinity
     a, b = B
     c, d = A
     c, d = Min(Max(c, a), b), Min(Max(d, a), b)
-    # the real line is broken into pieces which are compactly
-    # represented as -oo, i1, H|L, i2, H|L, i3, ..., oo
-    # where i1, i2, ...., refer to the interval A (k), or
-    # B (-1) or neither (-1) as covering that interval and H|L means
-    # either the hi boundary of the ith interval or the lo
-    # boundary of the (i+1)th interval
-    # /!\ If some integration of Piecewise is giving a wrong answer
-    # try uncommenting the commented out intervals.
-    if (b <= c) == True:
-        br = (
-        -oo, -1,
-        a, -1,
-        #b, -1,
-        c, k,
-        d, -1,
-        oo)
-    elif (d <= a) == True:
-        br = (
-        -oo, -1,
-        c, k,
-        d, -1,
-        #a, -1,
-        b, -1,
-        oo)
-    else:
-        br = (
-        -oo, -1,
-        Min(c, a), -1,
-        #Min(c, b), -1,
-        c, k,
-        d, -1,
-        #Max(d, a), -1,
-        Max(d, b), -1,
-        oo)
-    # remove infinities that weren't there at the start
-    oo = S.Infinity
-    if -oo not in (a, c) and br[0] == -oo:
-        br = br[2:]
-    if oo not in (b, d) and br[-1] == oo:
-        br = br[:-2]
-    # reform into tuples
     p = []
-    for _ in range(1, len(br) - 1, 2):
-        _a, _b, i = br[_ - 1], br[_ + 1], br[_]
-        # ignore zero-width intervals
-        if _a == _b:
-            continue
-        p.append((_a, _b, i))
-    # combine intervals that are now at the same level
-    remove = []
-    for i in range(1,len(p)):
-        if p[i][-1] == p[i - 1][-1]:
-            remove.append(i)
-            p[i - 1]=(p[i - 1][0],) + p[i][1:]
-    for i in reversed(remove):
-        p.pop(i)
-    return [tuple(map(_mmsimp, (a, b))) + (i,) for a, b, i in p]
+    if a != c:
+        p.append((Min(a, b), c, -1))
+    else:
+        pass
+    if c != d:
+        p.append((c, d, k))
+    else:
+        pass
+    if d != b:
+        if d == c and p and p[-1][-1] == -1:
+            p[-1] = p[-1][0], b, -1
+        else:
+            p.append((d, b, -1))
+    else:
+        pass
+    rv = [tuple(map(_mmsimp, (a, b))) + (i,) for a, b, i in p]
+    return [(a, b, i) for a, b, i in rv if a != b]
 
 
 def _mmsimp(e):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1,15 +1,19 @@
 from __future__ import print_function, division
 
-from sympy.core import Basic, S, Function, diff, Tuple, Symbol
+from sympy.core import Basic, S, Function, diff, Tuple, Dummy, Number
 from sympy.core.basic import as_Basic
-from sympy.core.relational import Equality, Relational, _canonical
 from sympy.core.sympify import _sympify, SympifyError
+from sympy.core.relational import Equality, Relational, _canonical
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import (And, Boolean, distribute_and_over_or,
     true, false, Not, Or, ITE, simplify_logic)
+from sympy.utilities.iterables import cartes
 from sympy.core.compatibility import default_sort_key, range
-from sympy.utilities.misc import func_name, filldedent
+from sympy.utilities.iterables import uniq, is_sequence, ordered, product
+from sympy.utilities.misc import filldedent, Undecidable, func_name
 
+
+Undefined = S.NaN  # Piecewise()
 
 class ExprCondPair(Tuple):
     """Represents an expression, condition pair."""
@@ -58,7 +62,7 @@ class ExprCondPair(Tuple):
 
     @property
     def is_commutative(self):
-        return self.expr.is_commutative
+        return getattr(self.expr, 'is_commutative', False)
 
     def __iter__(self):
         yield self.expr
@@ -149,52 +153,162 @@ class Piecewise(Function):
             return r
 
     @classmethod
-    def eval(cls, *args):
-        # Check for situations where we can evaluate the Piecewise object.
-        # 1) Hit an unevaluable cond (e.g. x<1) -> keep object
-        # 2) Hit a true condition -> return that expr
-        # 3) Remove false conditions, if no conditions left -> raise ValueError
-        all_conds_evaled = True    # Do all conds eval to a bool?
-        piecewise_again = False    # Should we pass args to Piecewise again?
-        non_false_ecpairs = []
-        or1 = Or(*[cond for (_, cond) in args if cond != true])
+    def eval(cls, *_args):
+        """Either return a modified version of the args or, if no
+        modifications were made, return None.
+
+        Modifications that are made here:
+        1) relationals are made canonical
+        2) any False conditions are dropped
+        3) any repeat of a previous condition is ignored
+        3) any args past one with a true condition are dropped
+
+        If there are no args left, an empty Piecewise will be returned.
+        If there is a single arg with a True condition, its
+        corresponding expression will be returned.
+        """
+
+        if not _args:
+            return
+
+        if len(_args) == 1 and _args[0][-1] == True:
+            return _args[0][0]
+
+        newargs = []  # the unevaluated conditions
+        current_cond = set()  # the conditions up to a given e, c pair
+        # make conditions canonical
+        args = []
+        for e, c in _args:
+            if not c.is_Atom and not isinstance(c, Relational):
+                free = c.free_symbols
+                if len(free) == 1:
+                    funcs = [i for i in c.atoms(Function)
+                        if not isinstance(i, Boolean)]
+                    if len(funcs) == 1 and len(
+                            c.xreplace({list(funcs)[0]: Dummy()}
+                            ).free_symbols) == 1:
+                        # we can treat function like a symbol
+                        free = funcs
+                    _c = c
+                    x = free.pop()
+                    try:
+                        c = c.as_set().as_relational(x)
+                    except NotImplementedError:
+                        pass
+                    else:
+                        reps = {}
+                        for i in c.atoms(Relational):
+                            ic = i.canonical
+                            if ic.rhs in (S.Infinity, S.NegativeInfinity):
+                                if not _c.has(ic.rhs):
+                                    # don't accept introduction of
+                                    # new Relationals with +/-oo
+                                    reps[i] = S.true
+                                elif ('=' not in ic.rel_op and
+                                        c.xreplace({x: i.rhs}) !=
+                                        _c.xreplace({x: i.rhs})):
+                                    reps[i] = Relational(
+                                        i.lhs, i.rhs, i.rel_op + '=')
+                        c = c.xreplace(reps)
+            args.append((e, _canonical(c)))
+
         for expr, cond in args:
             # Check here if expr is a Piecewise and collapse if one of
             # the conds in expr matches cond. This allows the collapsing
-            # of Piecewise((Piecewise(x,x<0),x<0)) to Piecewise((x,x<0)).
+            # of Piecewise((Piecewise((x,x<0)),x<0)) to Piecewise((x,x<0)).
             # This is important when using piecewise_fold to simplify
             # multiple Piecewise instances having the same conds.
             # Eventually, this code should be able to collapse Piecewise's
             # having different intervals, but this will probably require
             # using the new assumptions.
             if isinstance(expr, Piecewise):
-                or2 = Or(*[c for (_, c) in expr.args if c != true])
-                for e, c in expr.args:
-                    # Don't collapse if cond is "True" as this leads to
-                    # incorrect simplifications with nested Piecewises.
-                    if c == cond and (or1 == or2 or cond != true):
-                        expr = e
-                        piecewise_again = True
-            cond_eval = cls.__eval_cond(cond)
-            if cond_eval is None:
-                all_conds_evaled = False
-            elif cond_eval:
-                if all_conds_evaled:
-                    return expr
-            if len(non_false_ecpairs) != 0:
-                if non_false_ecpairs[-1].cond == cond:
-                    continue
-                elif non_false_ecpairs[-1].expr == expr:
-                    newcond = Or(cond, non_false_ecpairs[-1].cond)
-                    if isinstance(newcond, (And, Or)):
-                        newcond = distribute_and_over_or(newcond)
-                    non_false_ecpairs[-1] = ExprCondPair(expr, newcond)
-                    continue
-            non_false_ecpairs.append(ExprCondPair(expr, cond))
-        if len(non_false_ecpairs) != len(args) or piecewise_again:
-            return cls(*non_false_ecpairs)
+                unmatching = []
+                for i, (e, c) in enumerate(expr.args):
+                    if c in current_cond:
+                        # this would already have triggered
+                        continue
+                    if c == cond:
+                        if c != True:
+                            # nothing past this condition will ever
+                            # trigger and only those args before this
+                            # that didn't match a previous condition
+                            # could possibly trigger
+                            if unmatching:
+                                expr = Piecewise(*(
+                                    unmatching + [(e, c)]))
+                            else:
+                                expr = e
+                        break
+                    else:
+                        unmatching.append((e, c))
 
-        return None
+            # check for condition repeats
+            got = False
+            # -- if an And contains a condition that was
+            #    already encountered, then the And will be
+            #    False: if the previous condition was False
+            #    then the And will be False and if the previous
+            #    condition is True then then we wouldn't get to
+            #    this point. In either case, we can skip this condition.
+            for i in ([cond] +
+                    (list(cond.args) if isinstance(cond, And) else
+                    [])):
+                if i in current_cond:
+                    got = True
+                    break
+            if got:
+                continue
+
+            # -- if not(c) is already in current_cond then c is
+            #    a redundant condition in an And. This does not
+            #    apply to Or, however: (e1, c), (e2, Or(~c, d))
+            #    is not (e1, c), (e2, d) because if c and d are
+            #    both False this would give no results when the
+            #    true answer should be (e2, True)
+            if isinstance(cond, And):
+                nonredundant = []
+                for c in cond.args:
+                    if (isinstance(c, Relational) and
+                            (~c).canonical in current_cond):
+                        continue
+                    nonredundant.append(c)
+                cond = cond.func(*nonredundant)
+            elif isinstance(cond, Relational):
+                if (~cond).canonical in current_cond:
+                    cond = S.true
+
+            current_cond.add(cond)
+
+            # collect successive e,c pairs when exprs or cond match
+            if newargs:
+                if newargs[-1].expr == expr:
+                    orcond = Or(cond, newargs[-1].cond)
+                    if isinstance(orcond, (And, Or)):
+                        orcond = distribute_and_over_or(orcond)
+                    newargs[-1] = ExprCondPair(expr, orcond)
+                    continue
+                elif newargs[-1].cond == cond:
+                    orexpr = Or(expr, newargs[-1].expr)
+                    if isinstance(orexpr, (And, Or)):
+                        orexpr = distribute_and_over_or(orexpr)
+                    newargs[-1] == ExprCondPair(orexpr, cond)
+                    continue
+
+            newargs.append(ExprCondPair(expr, cond))
+
+        # some conditions may have been redundant
+        missing = len(newargs) != len(_args)
+        # some conditions may have changed
+        same = all(a == b for a, b in zip(newargs, _args))
+        # if either change happened we return the expr with the
+        # updated args
+        if not newargs:
+            raise ValueError(filldedent('''
+                There are no conditions (or none that
+                are not trivially false) to define an
+                expression.'''))
+        if missing or not same:
+            return cls(*newargs)
 
     def doit(self, **hints):
         """
@@ -227,242 +341,442 @@ class Piecewise(Function):
     def _eval_evalf(self, prec):
         return self.func(*[(e.evalf(prec), c) for e, c in self.args])
 
-    def _eval_integral(self, x):
-        from sympy.integrals import integrate
-        return self.func(*[(integrate(e, x), c) for e, c in self.args])
+    def piecewise_integrate(self, x, **kwargs):
+        """Return the Piecewise with each expression being
+        replaced with its antiderivative. To obtain a continuous
+        antiderivative, use the `integrate` function or method.
 
-    def _eval_interval(self, sym, a, b):
-        """Evaluates the function along the sym in a given interval ab"""
+        Examples
+        ========
+
+        >>> from sympy import Piecewise
+        >>> from sympy.abc import x
+        >>> p = Piecewise((0, x < 0), (1, x < 1), (2, True))
+        >>> p.piecewise_integrate(x)
+        Piecewise((0, x < 0), (x, x < 1), (2*x, True))
+
+        Note that this does not give a continuous function, e.g.
+        at x = 1 the 3rd condition applies and the antiderivative
+        there is 2*x so the value of the antiderivative is 2:
+
+        >>> anti = _
+        >>> anti.subs(x, 1)
+        2
+
+        The continuous derivative accounts for the integral *up to*
+        the point of interest, however:
+
+        >>> p.integrate(x)
+        Piecewise((0, x < 0), (x, x < 1), (2*x - 1, True))
+        >>> _.subs(x, 1)
+        1
+
+        See Also
+        ========
+        Piecewise._eval_integral
+        """
+        from sympy.integrals import integrate
+        return self.func(*[(integrate(e, x, **kwargs), c) for e, c in self.args])
+
+    def _handle_irel(self, x, handler):
+        """Return either None (if the conditions of self depend only on x) else
+        a Piecewise expression whose expressions (handled by the handler that
+        was passed) are paired with the governing x-independent relationals,
+        e.g. Piecewise((A, a(x) & b(y)), (B, c(x) | c(y)) ->
+        Piecewise(
+            (handler(Piecewise((A, a(x) & True), (B, c(x) | True)), b(y) & c(y)),
+            (handler(Piecewise((A, a(x) & True), (B, c(x) | False)), b(y)),
+            (handler(Piecewise((A, a(x) & False), (B, c(x) | True)), c(y)),
+            (handler(Piecewise((A, a(x) & False), (B, c(x) | False)), True))
+        """
+        # identify governing relationals
+        rel = self.atoms(Relational)
+        irel = list(ordered([r for r in rel if x not in r.free_symbols
+            and r not in (S.true, S.false)]))
+        if irel:
+            args = {}
+            exprinorder = []
+            for truth in product((1, 0), repeat=len(irel)):
+                reps = dict(zip(irel, truth))
+                # only store the true conditions since the false are implied
+                # when they appear lower in the Piecewise args
+                if 1 not in truth:
+                    cond = None  # flag this one so it doesn't get combined
+                else:
+                    andargs = Tuple(*[i for i in reps if reps[i]])
+                    free = list(andargs.free_symbols)
+                    if len(free) == 1:
+                        from sympy.solvers.inequalities import (
+                            reduce_inequalities, _solve_inequality)
+                        try:
+                            t = reduce_inequalities(andargs, free[0])
+                            # ValueError when there are potentially
+                            # nonvanishing imaginary parts
+                        except (ValueError, NotImplementedError):
+                            # at least isolate free symbol on left
+                            t = And(*[_solve_inequality(
+                                a, free[0], linear=True)
+                                for a in andargs])
+                    else:
+                        t = And(*andargs)
+                    if t is S.false:
+                        continue  # an impossible combination
+                    cond = t
+                expr = handler(self.xreplace(reps))
+                if isinstance(expr, self.func) and len(expr.args) == 1:
+                    expr, econd = expr.args[0]
+                    cond = And(econd, True if cond is None else cond)
+                # the ec pairs are being collected since all possibilities
+                # are being enumerated, but don't put the last one in since
+                # its expr might match a previous expression and it
+                # must appear last in the args
+                if cond is not None:
+                    args.setdefault(expr, []).append(cond)
+                    # but since we only store the true conditions we must maintain
+                    # the order so that the expression with the most true values
+                    # comes first
+                    exprinorder.append(expr)
+            # convert collected conditions as args of Or
+            for k in args:
+                args[k] = Or(*args[k])
+            # take them in the order obtained
+            args = [(e, args[e]) for e in uniq(exprinorder)]
+            # add in the last arg
+            args.append((expr, True))
+            # if any condition reduced to True, it needs to go last
+            # and there should only be one of them or else the exprs
+            # should agree
+            trues = [i for i in range(len(args)) if args[i][1] is S.true]
+            if not trues:
+                # make the last one True since all cases were enumerated
+                e, c = args[-1]
+                args[-1] = (e, S.true)
+            else:
+                assert len(set([e for e, c in [args[i] for i in trues]])) == 1
+                args.append(args.pop(trues.pop()))
+                while trues:
+                    args.pop(trues.pop())
+            return Piecewise(*args)
+
+    def _eval_integral(self, x, _first=True, **kwargs):
+        """Return the indefinite integral of the
+        Piecewise such that subsequent substitution of x with a
+        value will give the value of the integral (not including
+        the constant of integration) up to that point. To only
+        integrate the individual parts of Piecewise, use the
+        `piecewise_integrate` method.
+
+        Examples
+        ========
+
+        >>> from sympy import Piecewise
+        >>> from sympy.abc import x
+        >>> p = Piecewise((0, x < 0), (1, x < 1), (2, True))
+        >>> p.integrate(x)
+        Piecewise((0, x < 0), (x, x < 1), (2*x - 1, True))
+        >>> p.piecewise_integrate(x)
+        Piecewise((0, x < 0), (x, x < 1), (2*x, True))
+
+        See Also
+        ========
+        Piecewise.piecewise_integrate
+        """
+        from sympy.integrals.integrals import integrate
+
+        if _first:
+            def handler(ipw):
+                if isinstance(ipw, self.func):
+                    return ipw._eval_integral(x, _first=False, **kwargs)
+                else:
+                    return ipw.integrate(x, **kwargs)
+            irv = self._handle_irel(x, handler)
+            if irv is not None:
+                return irv
+
+        # handle a Piecewise from -oo to oo with and no x-independent relationals
+        # -----------------------------------------------------------------------
+        try:
+            abei = self._intervals(x)
+        except NotImplementedError:
+            from sympy import Integral
+            return Integral(self, x)  # unevaluated
+
+        pieces = [(a, b) for a, b, _, _ in abei]
+        oo = S.Infinity
+        done = [(-oo, oo, -1)]
+        for k, p in enumerate(pieces):
+            if p[:2] == (-oo, oo):
+                # all undone intervals will get this key
+                for j, (a, b, i) in enumerate(done):
+                    if i == -1:
+                        done[j] = a, b, k
+                break  # nothing else to consider
+            N = len(done) - 1
+            for j, (a, b, i) in enumerate(reversed(done)):
+                if i == -1:
+                    j = N - j
+                    done[j: j + 1] = _clip(p, (a, b), k)
+
+        # check for holes
+        for a, b, i in done:
+            if i == -1 and a != b:
+                # when we reference arg -1 we will get Undefined
+                abei.append((-oo, oo, Undefined, -1))
+                break
+
+        # return the sum of the intervals
+        args = []
+        sum = None
+        for a, b, i in done:
+            anti = integrate(abei[i][-2], x, **kwargs)
+            if sum is None:
+                sum = anti
+            else:
+                sum = sum.subs(x, a)
+                if sum == Undefined:
+                    sum = 0
+                sum += anti._eval_interval(x, a, x)
+            # see if we know whether b is contained in original
+            # condition
+            if b is S.Infinity:
+                cond = True
+            elif self.args[abei[i][-1]].cond.subs(x, b) == False:
+                cond = (x < b)
+            else:
+                cond = (x <= b)
+            args.append((_mmsimp(sum), cond))
+        return Piecewise(*args)
+
+    def _eval_interval(self, sym, a, b, _first=True):
+        """Evaluates the function along the sym in a given interval [a, b]"""
         # FIXME: Currently complex intervals are not supported.  A possible
         # replacement algorithm, discussed in issue 5227, can be found in the
         # following papers;
         #     http://portal.acm.org/citation.cfm?id=281649
         #     http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.70.4127&rep=rep1&type=pdf
+        from sympy.core.symbol import Dummy
 
         if a is None or b is None:
             # In this case, it is just simple substitution
-            return piecewise_fold(
-                super(Piecewise, self)._eval_interval(sym, a, b))
+            return super(Piecewise, self)._eval_interval(sym, a, b)
+        else:
+            x, lo, hi = map(_sympify, (sym, a, b))
 
-        mul = 1
-        if (a == b) == True:
-            return S.Zero
-        elif (a > b) == True:
-            a, b, mul = b, a, -1
-        elif (a <= b) != True:
-            newargs = []
-            for e, c in self.args:
-                intervals = self._sort_expr_cond(
-                    sym, S.NegativeInfinity, S.Infinity, c)
-                values = []
-                for lower, upper, expr in intervals:
-                    if (a < lower) == True:
-                        mid = lower
-                        rep = b
-                        val = e._eval_interval(sym, mid, b)
-                        val += self._eval_interval(sym, a, mid)
-                    elif (a > upper) == True:
-                        mid = upper
-                        rep = b
-                        val = e._eval_interval(sym, mid, b)
-                        val += self._eval_interval(sym, a, mid)
-                    elif (a >= lower) == True and (a <= upper) == True:
-                        rep = b
-                        val = e._eval_interval(sym, a, b)
-                    elif (b < lower) == True:
-                        mid = lower
-                        rep = a
-                        val = e._eval_interval(sym, a, mid)
-                        val += self._eval_interval(sym, mid, b)
-                    elif (b > upper) == True:
-                        mid = upper
-                        rep = a
-                        val = e._eval_interval(sym, a, mid)
-                        val += self._eval_interval(sym, mid, b)
-                    elif ((b >= lower) == True) and ((b <= upper) == True):
-                        rep = a
-                        val = e._eval_interval(sym, a, b)
-                    else:
-                        raise NotImplementedError(
-                            """The evaluation of a Piecewise interval when both the lower
-                            and the upper limit are symbolic is not yet implemented.""")
-                    values.append(val)
-                if len(set(values)) == 1:
-                    try:
-                        c = c.subs(sym, rep)
-                    except AttributeError:
-                        pass
-                    e = values[0]
-                    newargs.append((e, c))
+        if _first:  # get only x-dependent relationals
+            def handler(ipw):
+                if isinstance(ipw, self.func):
+                    return ipw._eval_interval(x, lo, hi, _first=None)
                 else:
-                    for i in range(len(values)):
-                        newargs.append((values[i], (c == True and i == len(values) - 1) or
-                            And(rep >= intervals[i][0], rep <= intervals[i][1])))
-            return self.func(*newargs)
+                    return ipw._eval_interval(x, lo, hi)
+            irv = self._handle_irel(x, handler)
+            if irv is not None:
+                return irv
 
-        # Determine what intervals the expr,cond pairs affect.
-        int_expr = self._sort_expr_cond(sym, a, b)
-
-        # Finally run through the intervals and sum the evaluation.
-        ret_fun = 0
-        for int_a, int_b, expr in int_expr:
-            if isinstance(expr, Piecewise):
-                # If we still have a Piecewise by now, _sort_expr_cond would
-                # already have determined that its conditions are independent
-                # of the integration variable, thus we just use substitution.
-                ret_fun += piecewise_fold(
-                    super(Piecewise, expr)._eval_interval(sym, Max(a, int_a), Min(b, int_b)))
+            if (lo < hi) is S.true or hi is S.Infinity or lo is S.NegativeInfinity:
+                pass
             else:
-                ret_fun += expr._eval_interval(sym, Max(a, int_a), Min(b, int_b))
-        return mul * ret_fun
+                neg = -self._eval_interval(x, hi, lo, _first=False)
+                if (lo < hi) is S.false or lo is S.Infinity or hi is S.NegativeInfinity:
+                    rv = neg
+                else:
+                    rv = Piecewise(
+                        (self._eval_interval(x, lo, hi, _first=False),
+                            lo < hi),
+                        (neg,
+                            True))
+                if rv == Undefined:
+                    raise ValueError("Can't integrate across undefined region.")
+                return rv
 
-    def _sort_expr_cond(self, sym, a, b, targetcond=None):
-        """Determine what intervals the expr, cond pairs affect.
+        # handle a Piecewise with lo <= hi and no x-independent relationals
+        # -----------------------------------------------------------------
+        try:
+            abei = self._intervals(x)
+        except NotImplementedError:
+            from sympy import Integral
+            # not being able to do the interval of f(x) can
+            # be stated as not being able to do the integral
+            # of f'(x) over the same range
+            return Integral(self.diff(x), (x, lo, hi))  # unevaluated
 
-        1) If cond is True, then log it as default
-        1.1) Currently if cond can't be evaluated, throw NotImplementedError.
-        2) For each inequality, if previous cond defines part of the interval
-           update the new conds interval.
-           -  eg x < 1, x < 3 -> [oo,1],[1,3] instead of [oo,1],[oo,3]
-        3) Sort the intervals to make it easier to find correct exprs
+        pieces = [(a, b) for a, b, _, _ in abei]
+        done = [(lo, hi, -1)]
+        oo = S.Infinity
+        for k, p in enumerate(pieces):
+            if p[:2] == (-oo, oo):
+                # all undone intervals will get this key
+                for j, (a, b, i) in enumerate(done):
+                    if i == -1:
+                        done[j] = a, b, k
+                break  # nothing else to consider
+            N = len(done) - 1
+            for j, (a, b, i) in enumerate(reversed(done)):
+                if i == -1:
+                    j = N - j
+                    done[j: j + 1] = _clip(p, (a, b), k)
+        # check for holes
+        for a, b, i in done:
+            if i == -1:
+                if a != b:
+                    # this requires a default (i == -1)
+                    # over a potentially non-zero interval
+                    # since a != b so we can't do this
+                    return S.NaN
+                else:
+                    # XXX are there expressions that would give
+                    # a value over a zero-width interval?
+                    # Integrating DiracDelta or Heaviside
+                    # does but we are not integrating right
+                    # now. If there are things to check for
+                    # check expression given by abei[i][-2]
+                    pass
+        # return the sum of the intervals
+        sum = S.Zero
+        for a, b, i in done:
+            sum += abei[i][-2]._eval_interval(x, a, b)
+        return _mmsimp(sum)
 
-        Under normal use, we return the expr,cond pairs in increasing order
-        along the real axis corresponding to the symbol sym.  If targetcond
-        is given, we return a list of (lowerbound, upperbound) pairs for
-        this condition."""
+    def _intervals(self, sym):
+        """Return a list of tuples, (a, b, e, i), where a and b
+        are the lower and upper bounds in which the expression e
+        of argument i in self is defined.
+
+        If there are any relationals not involving sym, or
+        any relational cannot be solved for sym,
+        NotImplementedError is raised. The evaluated conditions will
+        be returned as ranges. Discontinuous ranges will be
+        returned separately with identical expressions and
+        the first condition that evaluates to True will be
+        returned as the last tuple with a, b = -oo, oo.
+        """
         from sympy.solvers.inequalities import _solve_inequality
-        default = None
-        int_expr = []
+        from sympy.logic.boolalg import to_cnf, distribute_or_over_and
+
+        assert isinstance(self, Piecewise)
+
+        def _solve_relational(r):
+            rv = _solve_inequality(r, sym)
+            if isinstance(rv, Relational) and \
+                    sym in rv.free_symbols:
+                if rv.args[0] != sym:
+                    raise NotImplementedError(filldedent('''
+                        Unable to solve relational
+                        %s for %s.''' % (r, sym)))
+                if rv.rel_op == '!=':
+                    try:
+                        rv = Or(sym < rv.rhs, sym > rv.rhs)
+                    except TypeError:
+                        # e.g. x != I ==> all real x satisfy
+                        rv = S.true
+            if rv == (S.NegativeInfinity < sym) & (sym < S.Infinity):
+                rv = S.true
+            return rv
+
+        def nonsymfail(cond):
+            raise NotImplementedError(filldedent('''
+                A condition not involving
+                %s appeared: %s''' % (sym, cond)))
+
+        # make self canonical wrt Relationals
+        reps = dict(
+            [(r,_solve_relational(r)) for r in self.atoms(Relational)])
+        # process args individually so if any evaluate, their position
+        # in the original Piecewise will be known
+        args = [i.xreplace(reps) for i in self.args]
+
+        # precondition args
         expr_cond = []
-        or_cond = False
-        or_intervals = []
-        independent_expr_cond = []
-        for expr, cond in self.args:
+        default = idefault = None
+        for i, (expr, cond) in enumerate(args):
+            if cond == False:
+                continue
+            elif cond == True:
+                default = expr
+                idefault = i
+                break
+            elif sym not in cond.free_symbols:
+                nonsymfail(cond)
+
+            cond = to_cnf(cond)
+            if isinstance(cond, And):
+                cond = distribute_or_over_and(cond)
+
             if isinstance(cond, Or):
-                for cond2 in sorted(cond.args, key=default_sort_key):
-                    expr_cond.append((expr, cond2))
-            else:
-                expr_cond.append((expr, cond))
-            if cond == True:
-                break
-        for expr, cond in expr_cond:
-            if cond == True:
-                independent_expr_cond.append((expr, cond))
-                default = self.func(*independent_expr_cond)
-                break
-            orig_cond = cond
-            if sym not in cond.free_symbols:
-                independent_expr_cond.append((expr, cond))
-                continue
-            elif isinstance(cond, Equality):
-                continue
-            elif isinstance(cond, And):
+                expr_cond.extend(
+                    [(i, expr, o) for o in cond.args])
+            elif cond != False:
+                expr_cond.append((i, expr, cond))
+
+        # determine intervals represented by conditions
+        int_expr = []
+        for iarg, expr, cond in expr_cond:
+            if isinstance(cond, Equality):
+                if cond.lhs == sym:
+                    v = cond.rhs
+                    int_expr.append((v, v, expr.subs(sym, v), iarg))
+                    continue
+                else:
+                    nonsymfail(cond)
+
+            if isinstance(cond, And):
                 lower = S.NegativeInfinity
                 upper = S.Infinity
+                nonsym = False
+                rhs = None
                 for cond2 in cond.args:
-                    if sym not in [cond2.lts, cond2.gts]:
-                        cond2 = _solve_inequality(cond2, sym)
-                    if cond2.lts == sym:
+                    if isinstance(cond2, Equality):
+                        # all relationals were solved and
+                        # only sym-dependent ones made it to here
+                        assert cond2.lhs == sym
+                        assert sym not in cond2.rhs.free_symbols
+                        if rhs is None:
+                            rhs = cond2.rhs
+                        else:
+                            same = Eq(cond2.rhs, rhs)
+                            if same == False:
+                                cond = S.false
+                                break
+                            elif same != True:
+                                raise Undecidable('%s did not evaluate' % same)
+                    elif cond2.lts == sym:
                         upper = Min(cond2.gts, upper)
                     elif cond2.gts == sym:
                         lower = Max(cond2.lts, lower)
                     else:
-                        raise NotImplementedError(
-                            "Unable to handle interval evaluation of expression.")
-            else:
-                if sym not in [cond.lts, cond.gts]:
-                    cond = _solve_inequality(cond, sym)
+                        # mark but don't fail until later
+                        nonsym = cond2
+                if rhs is not None and cond not in (S.true, S.false):
+                    lower = upper = rhs
+                    cond = cond.subs(sym, lower)
+                # cond might have evaluated b/c of an Eq
+                if cond is S.true:
+                    default = expr
+                    continue
+                elif cond is S.false:
+                    continue
+                elif nonsym is not False:
+                    nonsymfail(nonsym)
+                else:
+                    pass  # for coverage
+            elif isinstance(cond, Relational):
                 lower, upper = cond.lts, cond.gts  # part 1: initialize with givens
                 if cond.lts == sym:                # part 1a: expand the side ...
                     lower = S.NegativeInfinity   # e.g. x <= 0 ---> -oo <= 0
                 elif cond.gts == sym:            # part 1a: ... that can be expanded
                     upper = S.Infinity           # e.g. x >= 0 --->  oo >= 0
                 else:
-                    raise NotImplementedError(
-                        "Unable to handle interval evaluation of expression.")
+                    nonsymfail(cond)
+            else:
+                raise NotImplementedError(
+                    'unrecognized condition: %s' % cond)
 
-            # part 1b: Reduce (-)infinity to what was passed in.
-            lower, upper = Max(a, lower), Min(b, upper)
+            lower, upper = lower, Max(lower, upper)
+            if (lower > upper) is not S.true:
+                int_expr.append((lower, upper, expr, iarg))
 
-            for n in range(len(int_expr)):
-                # Part 2: remove any interval overlap.  For any conflicts, the
-                # iterval already there wins, and the incoming interval updates
-                # its bounds accordingly.
-                if self.__eval_cond(lower < int_expr[n][1]) and \
-                        self.__eval_cond(lower >= int_expr[n][0]):
-                    lower = int_expr[n][1]
-                elif len(int_expr[n][1].free_symbols) and \
-                        self.__eval_cond(lower >= int_expr[n][0]):
-                    if self.__eval_cond(lower == int_expr[n][0]):
-                        lower = int_expr[n][1]
-                    else:
-                        int_expr[n][1] = Min(lower, int_expr[n][1])
-                elif len(int_expr[n][0].free_symbols) and \
-                        self.__eval_cond(upper == int_expr[n][1]):
-                    upper = Min(upper, int_expr[n][0])
-                elif len(int_expr[n][1].free_symbols) and \
-                        (lower >= int_expr[n][0]) != True and \
-                        (int_expr[n][1] == Min(lower, upper)) != True:
-                    upper = Min(upper, int_expr[n][0])
-                elif self.__eval_cond(upper > int_expr[n][0]) and \
-                        self.__eval_cond(upper <= int_expr[n][1]):
-                    upper = int_expr[n][0]
-                elif len(int_expr[n][0].free_symbols) and \
-                        self.__eval_cond(upper < int_expr[n][1]):
-                    int_expr[n][0] = Max(upper, int_expr[n][0])
-
-            if self.__eval_cond(lower >= upper) != True:  # Is it still an interval?
-                int_expr.append([lower, upper, expr])
-            if orig_cond == targetcond:
-                return [(lower, upper, None)]
-            elif isinstance(targetcond, Or) and cond in targetcond.args:
-                or_cond = Or(or_cond, cond)
-                or_intervals.append((lower, upper, None))
-                if or_cond == targetcond:
-                    or_intervals.sort(key=lambda x: x[0])
-                    return or_intervals
-
-        int_expr.sort(key=lambda x: x[1].sort_key(
-        ) if x[1].is_number else S.NegativeInfinity.sort_key())
-        int_expr.sort(key=lambda x: x[0].sort_key(
-        ) if x[0].is_number else S.Infinity.sort_key())
-
-        for n in range(len(int_expr)):
-            if len(int_expr[n][0].free_symbols) or len(int_expr[n][1].free_symbols):
-                if isinstance(int_expr[n][1], Min) or int_expr[n][1] == b:
-                    newval = Min(*int_expr[n][:-1])
-                    if n > 0 and int_expr[n][0] == int_expr[n - 1][1]:
-                        int_expr[n - 1][1] = newval
-                    int_expr[n][0] = newval
-                else:
-                    newval = Max(*int_expr[n][:-1])
-                    if n < len(int_expr) - 1 and int_expr[n][1] == int_expr[n + 1][0]:
-                        int_expr[n + 1][0] = newval
-                    int_expr[n][1] = newval
-
-        # Add holes to list of intervals if there is a default value,
-        # otherwise raise a ValueError.
-        holes = []
-        curr_low = a
-        for int_a, int_b, expr in int_expr:
-            if (curr_low < int_a) == True:
-                holes.append([curr_low, Min(b, int_a), default])
-            elif (curr_low >= int_a) != True:
-                holes.append([curr_low, Min(b, int_a), default])
-            curr_low = Min(b, int_b)
-        if (curr_low < b) == True:
-            holes.append([Min(b, curr_low), b, default])
-        elif (curr_low >= b) != True:
-            holes.append([Min(b, curr_low), b, default])
-
-        if holes and default is not None:
-            int_expr.extend(holes)
-            if targetcond == True:
-                return [(h[0], h[1], None) for h in holes]
-        elif holes and default is None:
-            raise ValueError("Called interval evaluation over piecewise "
-                             "function on undefined intervals %s" %
-                             ", ".join([str((h[0], h[1])) for h in holes]))
+        if default is not None:
+            int_expr.append(
+                (S.NegativeInfinity, S.Infinity, default, idefault))
 
         return int_expr
 
@@ -627,7 +941,7 @@ def piecewise_fold(expr):
     >>> from sympy.abc import x
     >>> p = Piecewise((x, x < 1), (1, S(1) <= x))
     >>> piecewise_fold(x*p)
-    Piecewise((x**2, x < 1), (x, 1 <= x))
+    Piecewise((x**2, x < 1), (x, True))
 
     See Also
     ========
@@ -664,3 +978,222 @@ def piecewise_fold(expr):
             new_args.append((expr.func(*e), And(*c)))
 
     return Piecewise(*new_args)
+
+
+def _pair(A, B, union=False, dict=None, abi=False):
+    """Return the intervals on the real number line that are covered
+    by the two intervals, A = [a, b] and B = [c, d]. If union is
+    true then a simple list of intervals is returned; if dict is
+    true (default) then the intervals are keyed to 0 if they are
+    covered by A, 1 if they are covered by B and -1 if they are covered
+    by neither, with higher precedence given to A. If abi is true,
+    return an ordered set of tuples (a, b, i) where
+    a is the lower bound, b is the upper bound and i indicates which
+    interval covers that range: 0 for A, 1 for B and -1 for neither.
+
+    Examples
+    ========
+
+    >>> from sympy import Tuple
+    >>> from sympy.functions.elementary.piecewise import _pair
+    >>> from sympy.abc import x
+
+    For the following segments,
+
+           1---2
+                      4---5
+
+    5 regions are identified:
+
+        -oo -> 1 -> 2 -> 4 -> 5 -> oo
+
+    >>> A = (1, 2); B = (4, 5)
+    >>> _pair(A, B, abi=True)
+    [(-oo, 1, -1), (1, 2, 0), (2, 4, -1), (4, 5, 1), (5, oo, -1)]
+    >>> _pair(A, B, union=True)
+    [(1, 2), (4, 5)]
+    >>> _pair(A, B, dict=True)  # default
+    {-1: [(-oo, 1), (2, 4), (5, oo)], 0: [(1, 2)], 1: [(4, 5)]}
+
+    When one or more of the boundaries are symbolic, the results
+    become more complex and the boundaries are given in terms of
+    Min and Max functions:
+
+    >>> _pair((x, 2), (4, 5))
+    {-1: [(-oo, Min(4, x)), (Min(5, x), x), (2, 4), (5, oo)],
+    0: [(x, 2)],
+    1: [(Min(4, x), Min(5, x)), (4, 5)]}
+
+    When an actual value is given for x, there may be redundant
+    intervals and intervals with no width:
+
+    >>> last = _
+    >>> def replace(x, y):
+    ...     rv = {}
+    ...     for k, v in last.items():
+    ...         rv[k] = [Tuple(*i).subs(x, y) for i in v]
+    ...     return rv
+    ...
+    >>> for k, v in sorted(replace(x, 1).items()):
+    ...     k, v
+    (-1, [(-oo, 1), (1, 1), (2, 4), (5, oo)])
+    (0, [(1, 2)])
+    (1, [(1, 1), (4, 5)])
+
+    There may also be intervals wherein the right boundary is greater
+    than the left and redundant intervals:
+
+    >>> for k, v in sorted(replace(x, 6).items()):
+    ...     (k, v)
+    (-1, [(-oo, 4), (5, 6), (2, 4), (5, oo)])
+    (0, [(6, 2)])
+    (1, [(4, 5), (4, 5)])
+    """
+    from sympy.logic.boolalg import Xor
+    if not any(i for i in (abi, dict, union)):
+        dict = True
+    if [bool(i) for i in (abi, dict, union)].count(True) != 1:
+        raise ValueError('only 1 of abi, dict and union may be True')
+
+    a, b = A
+    c, d = B
+    oo = S.Infinity
+    # the real line is broken into pieces which are compactly
+    # represented as -oo, i1, hi1_lo2, i2, hi2_lo3, i3, ..., oo
+    # where i1, i2, ...., refer to the interval A (0), B(1) or
+    # neither (-1) as covering that intrval
+    if a is -oo and b is oo:
+        br = a, 0, b
+    elif c is -oo and d is oo:
+        if a is -oo:
+            br = a, 0, b, 1, oo
+        elif b is oo:
+            br = -oo, 1, a, 0, b
+        else:
+            br = -oo, 1, a, 0, b, 1, oo
+    elif b is oo and d is oo:  # (a, oo) (c, oo)
+        br = -oo, -1, Min(a, c), 1, a, 0, oo
+    elif a is -oo and c is -oo:  # (-oo, b) (-oo, d)
+        br = -oo, 0, b, 1, Max(b, d), -1, oo
+    elif a is -oo and d is oo:  # (-oo, b) (c, oo)
+        br = -oo, 0, b, -1, Max(b,c), 1, oo
+    elif b is oo and c is -oo:  # (a, oo) (-oo, d)
+        br = -oo, 1, Min(a, d), -1, a, 0, oo
+    elif d is oo:  # (a, b) (c, oo)
+        br = -oo, -1, Min(a, c), 1, a, 0, b, -1, Max(b, c), 1, oo
+    elif c is -oo:  # (a, b) (-oo, d)
+        br = -oo, 1, Min(a, d), -1, a, 0, b, 1, Max(b, d), -1, oo
+    elif b is oo:  # (a, oo) (c, d)
+        br = -oo, -1, Min(a, c), 1, Min(a, d), -1, a, 0, oo
+    elif a is -oo:  # (-oo, b) (c, d)
+        br = -oo, 0, b, -1, Max(b, c), 1, Max(b, d), -1, oo
+    else:  # (a, b) (c, d)
+        br = (-oo, -1, Min(a, c), 1, Min(a, d), -1, a, 0, b,
+            -1, Max(b, c), 1, Max(b, d), -1, oo)
+    abi = []
+    for _ in range(1, len(br) - 1, 2):
+        a, b, i = br[_ - 1], br[_ + 1], br[_]
+        if a == b:
+            continue
+        abi.append((a, b, i))
+    if not union and not dict:
+        return abi
+    if union:
+        rv = []
+        for a, b, i in abi:
+            if i == -1:
+                continue
+            K = (a, b)
+            if not rv or a != rv[-1][1]:
+                # it's a new interval
+                rv.append(K)
+            else:
+                # it joins with the last one
+                rv[-1] = rv[-1][0], K[1]
+        return rv
+    # dict
+    rv = {}
+    for a, b, i in abi:
+        rv.setdefault(i, []).append((a, b))
+    return rv
+
+
+def _clip(A, B, k):
+    """Return interval B as intervals that are covered by A (keyed
+    to k) and all others keyed to -1.
+
+    Examples
+    ========
+
+    >>> from sympy.functions.elementary.piecewise import _clip
+    >>> _clip((1, 3), (2, 4), 0)
+    [(2, 3, 0), (3, 4, -1)]
+    """
+    # pair(A, B) will give keys of -1, 0 and 1
+    # we rekey A intervals to k and change all others
+    # to -1
+    a, b = B
+    c, d = A
+    A = c, d = Min(Max(c, a), b), Min(Max(d, a), b)
+    p = _pair(A, B, abi=True)
+    # remove infinities that weren't there at the start
+    oo = S.Infinity
+    if -oo not in (a, c) and p[0][0] == -oo:
+        p.pop(0)
+    if oo not in (b, d) and p[-1][1] == oo:
+        p.pop()
+    # rekey key 0 to k
+    assert k != -1
+    for i in range(len(p)):
+        if p[i][-1] == 0:
+            p[i] = p[i][:2] + (k,)
+        else:
+            # rekey all other keys to -1
+            p[i] = p[i][:2] + (-1,)
+    # combine intervals that are now at the same level
+    remove = []
+    for i in range(1,len(p)):
+        if p[i][-1] == p[i - 1][-1]:
+            remove.append(i)
+            p[i - 1]=(p[i - 1][0],) + p[i][1:]
+    for i in reversed(remove):
+        p.pop(i)
+    return [tuple(map(_mmsimp, (a, b))) + (i,) for a, b, i in p]
+
+
+def _mmsimp(e):
+    # simplify min/max relationships
+    from sympy import simplify, Expr
+    from sympy.logic.boolalg import Boolean
+
+    def rw(m):
+        if isinstance(m, Min):
+            return simplify(And(*[rw(i) for i in m.args]))
+        elif isinstance(m, Max):
+            return simplify(Or(*[rw(i) for i in m.args]))
+        elif not m.is_Atom:
+            return m.func(*[rw(a) for a in m.args])
+        else:
+            return m
+
+    def wr(m):
+        if isinstance(m, And):
+            return Min(*[wr(i) for i in m.args])
+        elif isinstance(m, Or):
+            return Max(*[wr(i) for i in m.args])
+        elif not m.is_Atom:
+            return m.func(*[wr(a) for a in m.args])
+        else:
+            return m
+
+    # And and Or are going to be used to identify arg that
+    # warrant simplification but we can't allow any non-Booleans
+    # into BooleanFunctions, so replace any non-Booleans with
+    # Dummy symbols
+    reps = []
+    for m in e.atoms(Min, Max):
+        nonBool = dict([(n, Dummy()) for n in m.atoms(Expr)
+            if not isinstance(n, (Boolean, Min, Max))])
+        reps.append((m, wr(rw(m.xreplace(nonBool))).xreplace(
+            dict([(v, k) for k, v in nonBool.items()]))))
+    return e.xreplace(dict(reps))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -278,7 +278,7 @@ def test_3_piecewise_integrate():
         assert p.subs(r).integrate(lim.subs(r)) == q.subs(r)
 
 
-def test_miejer_bypass():
+def test_meijer_bypass():
     # totally bypass meijerg machinery when dealing
     # with Piecewise in integrate
     assert Piecewise((1, x < 4), (0, True)).integrate((x, oo, 1)) == -3
@@ -969,16 +969,15 @@ def test_containment():
 
 
 def test_piecewise_with_DiracDelta():
-    # XXX not sure what these should be
     d1 = DiracDelta(x - 1)
     assert integrate(d1, (x, -oo, oo)) == 1
     assert integrate(d1, (x, 0, 2)) == 1
-    assert Piecewise((d1, Eq(x, 2)), (0, True)).integrate(x) == 0  # right
-    # XXX should the following be
-    # Piecewise((Heaviside(0), Eq(x, 1)), (1, x > 1), (0, True))?
-    assert Piecewise((d1, Eq(x, 1)), (0, True)).integrate(x) == 0
+    assert Piecewise((d1, Eq(x, 2)), (0, True)).integrate(x) == 0
     assert Piecewise((d1, x < 2), (0, True)).integrate(x) == Piecewise(
         (Heaviside(x - 1), x < 2), (1, True))
+    # TODO raise error if function is discontinuous at limit of
+    # integration, e.g. integrate(d1, (x, -2, 1)) or Piecewise(
+    # (d1, Eq(x ,1)
 
 
 def test_issue_10258():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -161,19 +161,15 @@ def test_piecewise_integrate1():
     assert integrate(g, (x, -2, 2)) == Rational(14, 3)
     assert integrate(g, (x, -2, 5)) == Rational(43, 6)
 
-    g = Piecewise(((x - 5)**5, 4 <= x), (f, x < 4))
-    assert integrate(g, (x, -2, 2)) == Rational(14, 3)
-    assert integrate(g, (x, -2, 5)) == Rational(43, 6)
+    assert g == Piecewise(((x - 5)**5, x >= 4), (f, x < 4))
 
     g = Piecewise(((x - 5)**5, 2 <= x), (f, x < 2))
     assert integrate(g, (x, -2, 2)) == Rational(14, 3)
     assert integrate(g, (x, -2, 5)) == -Rational(701, 6)
 
-    g = Piecewise(((x - 5)**5, 2 <= x), (f, True))
-    assert integrate(g, (x, -2, 2)) == Rational(14, 3)
-    assert integrate(g, (x, -2, 5)) == -Rational(701, 6)
+    assert g == Piecewise(((x - 5)**5, 2 <= x), (f, True))
 
-    g = Piecewise(((x - 5)**5, 2 <= x), (2 * f, True))
+    g = Piecewise(((x - 5)**5, 2 <= x), (2*f, True))
     assert integrate(g, (x, -2, 2)) == 2 * Rational(14, 3)
     assert integrate(g, (x, -2, 5)) == -Rational(673, 6)
 
@@ -202,70 +198,58 @@ def test_piecewise_integrate1():
         (-Min(1, Max(0, y))**2/2 + 1/2, y < 1),
         (-y + 1, True))
 
-    g = Piecewise((1 - x, Interval(0, 1).contains(x)),
-        (1 + x, Interval(-1, 0).contains(x)), (0, True))
-    assert integrate(g, (x, -5, 1)) == 1
-    assert integrate(g, (x, 1, -5)) == -1
-    assert integrate(g, (x, 1, y)).subs(y, -5) == -1
-    assert integrate(g, (x, y, -5)).subs(y, 1) == -1
-    i = integrate(g, (x, -5, y))
-    assert i.subs(y, 1) == 1
-    assert piecewise_fold(i.rewrite(Piecewise)
-        ) == Piecewise(
-        (1, y >= 1),
-        (-y**2/2 + y + 1/2, y >= 0),
-        (y**2/2 + y + 1/2, y >= -1),
-        (0, True))
-    assert i == Piecewise(
-        (-Min(-1, y)**2/2 - Min(-1, y) +
-            Min(0, y)**2 - Min(1, y)**2/2 + Min(1, y), y > -5),
-        (0, True))
-    i = integrate(g, (x, y, 1))
-    assert i.subs(y, -5) == 1
-    assert piecewise_fold(i.rewrite(Piecewise)
-        )== Piecewise(
-        (1, y <= -1),
-        (-y**2/2 - y + 1/2, y <= 0),
-        (y**2/2 - y + 1/2, y < 1),
-        (0, True))
-    assert i == Piecewise(
-        (Min(1, Max(0, y))**2 - Min(1, Max(-1, y), Max(0, y))**2/2 -
-            Min(1, Max(-1, y), Max(0, y)) + 1/2, y < 1),
-        (0, True))
-
-    g = Piecewise((0, Or(x <= -1, x >= 1)), (1 - x, x > 0),
-        (1 + x, True))
-    assert integrate(g, (x, -5, 1)) == 1
-    assert integrate(g, (x, 1, -5)) == -1
-    assert integrate(g, (x, 1, y)).subs(y, -5) == -1
-    assert integrate(g, (x, y, -5)).subs(y, 1) == -1
-    i = integrate(g, (x, -5, y))
-    assert i.subs(y, 1) == 1
-    assert piecewise_fold(i.rewrite(Piecewise)
-        ) == Piecewise(
-        (1, y >= 1),
-        (-y**2/2 + y + 1/2, y >= 0),
-        (y**2/2 + y + 1/2, y >= -1),
-        (0, True))
-    assert i == Piecewise(
-        (-Min(-1, y)**2/2 - Min(-1, y) + Min(0, y)**2 -
-            Min(1, y)**2/2 + Min(1, y), y > -5),
-        (0, True))
-    i = integrate(g, (x, y, 1))
-    assert i.subs(y, -5) == 1
-    assert piecewise_fold(i.rewrite(Piecewise)
-        ) == Piecewise(
-        (1, y <= -1),
-        (-y**2/2 - y + 1/2, y <= 0),
-        (y**2/2 - y + 1/2, y < 1),
-        (0, True))
-    assert i == Piecewise(
-        (-Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
-            Min(1, Max(0, y))**2 + 1/2, y < 1),
-        (0, True))
+    for j, g in enumerate([
+        Piecewise((1 - x, Interval(0, 1).contains(x)),
+            (1 + x, Interval(-1, 0).contains(x)), (0, True)),
+        Piecewise((0, Or(x <= -1, x >= 1)), (1 - x, x > 0),
+            (1 + x, True))]):
+        assert integrate(g, (x, -5, 1)) == 1
+        assert integrate(g, (x, 1, -5)) == -1
+        assert integrate(g, (x, 1, y)).subs(y, -5) == -1
+        assert integrate(g, (x, y, -5)).subs(y, 1) == -1
+        i = integrate(g, (x, -5, y))
+        assert i.subs(y, 1) == 1
+        assert piecewise_fold(i.rewrite(Piecewise)
+            ) == Piecewise(
+            (1, y >= 1),
+            (-y**2/2 + y + 1/2, y >= 0),
+            (y**2/2 + y + 1/2, y >= -1),
+            (0, True))
+        assert i == Piecewise(
+            (-Min(-1, y)**2/2 - Min(-1, y) +
+                Min(0, y)**2 - Min(1, y)**2/2 + Min(1, y), y > -5),
+            (0, True))
+        i = integrate(g, (x, y, 1))
+        assert i.subs(y, -5) == 1
+        assert piecewise_fold(i.rewrite(Piecewise)
+            )== Piecewise(
+            (1, y <= -1),
+            (-y**2/2 - y + 1/2, y <= 0),
+            (y**2/2 - y + 1/2, y < 1),
+            (0, True))
+        # the solutions are different because
+        # Min(1, Max(-1, y), Max(0, y)) is not
+        # simplifying to Min(1, Max(-1, y))
+        assert i == [
+            Piecewise(
+                (
+                -Min(1, Max(-1, y), Max(0, y))**2/2
+                -Min(1, Max(-1, y), Max(0, y))
+                +Min(1, Max(0, y))**2
+                +1/2,
+                    y < 1),
+                (0, True)),
+            Piecewise(
+                (
+                -Min(1, Max(-1, y))**2/2
+                -Min(1, Max(-1, y))
+                +Min(1, Max(0, y))**2
+                +1/2,
+                    y < 1),
+                (0, True))][j]
 
 
-def test_3_piecewise_integrate():
+def test_piecewise_integrate2():
     from itertools import permutations
     lim = Tuple(x, c, d)
     p = Piecewise((1, x < a), (2, x > b), (3, True))
@@ -284,7 +268,7 @@ def test_meijer_bypass():
     assert Piecewise((1, x < 4), (0, True)).integrate((x, oo, 1)) == -3
 
 
-def test_piecewise_integrate2_inequality_conditions():
+def test_piecewise_integrate3_inequality_conditions():
     from sympy.utilities.iterables import cartes
     lim = (x, 0, 5)
     # set below includes two pts below range, 2 pts in range,
@@ -310,7 +294,7 @@ def test_piecewise_integrate2_inequality_conditions():
     # values
 
 
-def test_piecewise_integrate3_symbolic_conditions():
+def test_piecewise_integrate4_symbolic_conditions():
     a = Symbol('a', real=True, finite=True)
     b = Symbol('b', real=True, finite=True)
     x = Symbol('x', real=True, finite=True)
@@ -374,7 +358,7 @@ def test_piecewise_integrate3_symbolic_conditions():
             assert ans.subs(reps) == p.subs(reps).integrate(lim.subs(reps))
 
 
-def test_piecewise_integrate4_independent_conditions():
+def test_piecewise_integrate5_independent_conditions():
     p = Piecewise((0, Eq(y, 0)), (x*y, True))
     assert integrate(p, (x, 1, 3)) == Piecewise((0, Eq(y, 0)), (4*y, True))
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -2,13 +2,15 @@ from sympy import (
     adjoint, And, Basic, conjugate, diff, expand, Eq, Function, I, ITE,
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, solve, symbols, transpose,
-    cos, exp, Abs, Not, Symbol, S, sqrt, Tuple, zoo
-)
+    cos, exp, Abs, Ne, Not, Symbol, S, sqrt, Tuple, zoo,
+    factor_terms, DiracDelta, Heaviside)
 from sympy.printing import srepr
 from sympy.utilities.pytest import XFAIL, raises
 
+from sympy.functions.elementary.piecewise import Undefined
 
-x, y = symbols('x y')
+
+a, b, c, d, x, y = symbols('a:d, x, y')
 z = symbols('z', nonzero=True)
 
 
@@ -40,6 +42,9 @@ def test_piecewise():
     cond = (Piecewise((1, x < 0), (2, True)) < y)
     assert Piecewise((1, cond)
         ) == Piecewise((1, ITE(x < 0, y > 1, y > 2)))
+
+    assert Piecewise((1, x > 0), (2, And(x <= 0, x > -1))
+        ) == Piecewise((1, x > 0), (2, x > -1))
 
     # Test subs
     p = Piecewise((-1, x < -1), (x**2, x < 0), (log(x), x >= 0))
@@ -87,7 +92,7 @@ def test_piecewise():
 
     # Test doit
     f_int = Piecewise((Integral(x, (x, 0, 1)), x < 1))
-    assert f_int.doit() == Piecewise( (1.0/2.0, x < 1) )
+    assert f_int.doit() == Piecewise( (1/2, x < 1) )
 
     # Test differentiation
     f = x
@@ -125,34 +130,34 @@ def test_piecewise():
     assert peval2._eval_interval(x, -1, None) == -peval2.subs(x, -1)
 
     # Test integration
-    p_int = Piecewise((-x, x < -1), (x**3/3.0, x < 0), (-x + x*log(x), x >= 0))
-    assert integrate(p, x) == p_int
+    assert p.integrate() == Piecewise(
+        (-x, x < -1),
+        (x**3/3 + 4/3, x < 0),
+        (x*log(x) - x + 4/3, True))
     p = Piecewise((x, x < 1), (x**2, -1 <= x), (x, 3 < x))
-    assert integrate(p, (x, -2, 2)) == 5.0/6.0
-    assert integrate(p, (x, 2, -2)) == -5.0/6.0
+    assert integrate(p, (x, -2, 2)) == 5/6.0
+    assert integrate(p, (x, 2, -2)) == -5/6.0
     p = Piecewise((0, x < 0), (1, x < 1), (0, x < 2), (1, x < 3), (0, True))
     assert integrate(p, (x, -oo, oo)) == 2
     p = Piecewise((x, x < -10), (x**2, x <= -1), (x, 1 < x))
-    raises(ValueError, lambda: integrate(p, (x, -2, 2)))
+    assert integrate(p, (x, -2, 2)) == Undefined
 
     # Test commutativity
     assert isinstance(p, Piecewise) and p.is_commutative is True
 
 
 def test_piecewise_free_symbols():
-    a = symbols('a')
     f = Piecewise((x, a < 0), (y, True))
     assert f.free_symbols == {x, y, a}
 
 
-def test_piecewise_integrate():
+def test_piecewise_integrate1():
     x, y = symbols('x y', real=True, finite=True)
 
-    # XXX Use '<=' here! '>=' is not yet implemented ..
-    f = Piecewise(((x - 2)**2, 0 <= x), (1, True))
+    f = Piecewise(((x - 2)**2, x >= 0), (1, True))
     assert integrate(f, (x, -2, 2)) == Rational(14, 3)
 
-    g = Piecewise(((x - 5)**5, 4 <= x), (f, True))
+    g = Piecewise(((x - 5)**5, x >= 4), (f, True))
     assert integrate(g, (x, -2, 2)) == Rational(14, 3)
     assert integrate(g, (x, -2, 5)) == Rational(43, 6)
 
@@ -177,8 +182,11 @@ def test_piecewise_integrate():
 
     g = Piecewise((1, x - y < 0), (0, True))
     assert integrate(g, (y, -oo, 0)) == -Min(0, x)
-    assert integrate(g, (y, 0, oo)) == oo - Max(0, x)
-    assert integrate(g, (y, -oo, oo)) == oo - x
+    assert g.subs(x, -3).integrate((y, -oo, 0)) == 3
+    assert integrate(g, (y, 0, -oo)) == Min(0, x)
+    assert integrate(g, (y, 0, oo)) == -Max(0, x) + oo
+    assert integrate(g, (y, -oo, 42)) == -Min(42, x) + 42
+    assert integrate(g, (y, -oo, oo)) == -x + oo
 
     g = Piecewise((0, x < 0), (x, x <= 1), (1, True))
     assert integrate(g, (x, -5, 1)) == Rational(1, 2)
@@ -187,57 +195,124 @@ def test_piecewise_integrate():
     assert integrate(g, (x, 1, -5)) == -Rational(1, 2)
     assert integrate(g, (x, 1, y)).subs(y, -5) == -Rational(1, 2)
     assert integrate(g, (x, y, -5)).subs(y, 1) == -Rational(1, 2)
-    assert integrate(g, (x, -5, y)) == Piecewise((0, y < 0),
-        (y**2/2, y <= 1), (y - 0.5, True))
-    assert integrate(g, (x, y, 1)) == Piecewise((0.5, y < 0),
-        (0.5 - y**2/2, y <= 1), (1 - y, True))
+    assert integrate(g, (x, -5, y)) == Piecewise(
+        (y - Min(0, y)**2/2 + Min(1, y)**2/2 - Min(1, y), y > -5),
+        (0, True))
+    assert integrate(g, (x, y, 1)) == Piecewise(
+        (-Min(1, Max(0, y))**2/2 + 1/2, y < 1),
+        (-y + Min(1, y), True))
 
     g = Piecewise((1 - x, Interval(0, 1).contains(x)),
         (1 + x, Interval(-1, 0).contains(x)), (0, True))
     assert integrate(g, (x, -5, 1)) == 1
-    assert integrate(g, (x, -5, y)).subs(y, 1) == 1
-    assert integrate(g, (x, y, 1)).subs(y, -5) == 1
     assert integrate(g, (x, 1, -5)) == -1
     assert integrate(g, (x, 1, y)).subs(y, -5) == -1
     assert integrate(g, (x, y, -5)).subs(y, 1) == -1
-    assert integrate(g, (x, -5, y)) == Piecewise(
-        (-y**2/2 + y + 0.5, Interval(0, 1).contains(y)),
-        (y**2/2 + y + 0.5, Interval(-1, 0).contains(y)),
-        (0, y <= -1), (1, True))
-    assert integrate(g, (x, y, 1)) == Piecewise(
-        (y**2/2 - y + 0.5, Interval(0, 1).contains(y)),
-        (-y**2/2 - y + 0.5, Interval(-1, 0).contains(y)),
-        (1, y <= -1), (0, True))
+    i = integrate(g, (x, -5, y))
+    assert i.subs(y, 1) == 1
+    assert piecewise_fold(i.rewrite(Piecewise)
+        ) == Piecewise(
+        (1, y >= 1),
+        (-y**2/2 + y + 1/2, y >= 0),
+        (y**2/2 + y + 1/2, y >= -1),
+        (0, True))
+    assert i == Piecewise(
+        (-Min(-1, y)**2/2 - Min(-1, y) +
+            Min(0, y)**2 - Min(1, y)**2/2 + Min(1, y), y > -5),
+        (Max(-5, Min(-1, y))**2/2 + Max(-5, Min(-1, y)) -
+            Min(0, Max(-5, y))**2/2 - Min(0, Max(-5, y)), True))
+    i = integrate(g, (x, y, 1))
+    assert i.subs(y, -5) == 1
+    assert piecewise_fold(i.rewrite(Piecewise)
+        )== Piecewise(
+        (1, y <= -1),
+        (-y**2/2 - y + 1/2, y <= 0),
+        (y**2/2 - y + 1/2, y < 1),
+        (0, True))
+    assert i == Piecewise(
+        (Min(1, Max(0, y))**2 - Min(1, Max(-1, y), Max(0, y))**2/2 -
+            Min(1, Max(-1, y), Max(0, y)) + S.Half, y < 1),
+        (0, True))
 
-    g = Piecewise((0, Or(x <= -1, x >= 1)), (1 - x, x > 0), (1 + x, True))
+    g = Piecewise((0, Or(x <= -1, x >= 1)), (1 - x, x > 0),
+        (1 + x, True))
     assert integrate(g, (x, -5, 1)) == 1
-    assert integrate(g, (x, -5, y)).subs(y, 1) == 1
-    assert integrate(g, (x, y, 1)).subs(y, -5) == 1
     assert integrate(g, (x, 1, -5)) == -1
     assert integrate(g, (x, 1, y)).subs(y, -5) == -1
     assert integrate(g, (x, y, -5)).subs(y, 1) == -1
-    assert integrate(g, (x, -5, y)) == Piecewise((0, y <= -1), (1, y >= 1),
-        (-y**2/2 + y + 0.5, y > 0), (y**2/2 + y + 0.5, True))
-    assert integrate(g, (x, y, 1)) == Piecewise((1, y <= -1), (0, y >= 1),
-        (y**2/2 - y + 0.5, y > 0), (-y**2/2 - y + 0.5, True))
+    i = integrate(g, (x, -5, y))
+    assert i.subs(y, 1) == 1
+    assert piecewise_fold(i.rewrite(Piecewise)
+        ) == Piecewise(
+        (1, y >= 1),
+        (-y**2/2 + y + 1/2, y >= 0),
+        (y**2/2 + y + 1/2, y >= -1),
+        (0, True))
+    assert i == Piecewise(
+        (-Min(-1, y)**2/2 - Min(-1, y) + Min(0, y)**2 -
+            Min(1, y)**2/2 + Min(1, y), y > -5),
+        (Max(-5, y)**2/2 - Max(-5, y) + Max(-5, Min(-1, y))**2/2 +
+            Max(-5, Min(-1, y)) - Min(0, Max(-5, y))**2, True))
+    i = integrate(g, (x, y, 1))
+    assert i.subs(y, -5) == 1
+    assert piecewise_fold(i.rewrite(Piecewise)
+        ) == Piecewise(
+        (1, y <= -1),
+        (-y**2/2 - y + 1/2, y <= 0),
+        (y**2/2 - y + 1/2, y < 1),
+        (0, True))
+    assert i == Piecewise(
+        (-Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
+            Min(1, Max(0, y))**2 + S.Half, y < 1),
+        (0, True))
 
 
-def test_piecewise_integrate_inequality_conditions():
-    c1, c2 = symbols("c1 c2", positive=True)
-    g = Piecewise((0, c1*x > 1), (1, c1*x > 0), (0, True))
-    assert integrate(g, (x, -oo, 0)) == 0
-    assert integrate(g, (x, -5, 0)) == 0
-    assert integrate(g, (x, 0, 5)) == Min(5, 1/c1)
-    assert integrate(g, (x, 0, oo)) == 1/c1
-
-    g = Piecewise((0, c1*x + c2*y > 1), (1, c1*x + c2*y > 0), (0, True))
-    assert integrate(g, (x, -oo, 0)).subs(y, 0) == 0
-    assert integrate(g, (x, -5, 0)).subs(y, 0) == 0
-    assert integrate(g, (x, 0, 5)).subs(y, 0) == Min(5, 1/c1)
-    assert integrate(g, (x, 0, oo)).subs(y, 0) == 1/c1
+def test_3_piecewise_integrate():
+    from itertools import permutations
+    lim = Tuple(x, c, d)
+    p = Piecewise((1, x < a), (2, x > b), (3, True))
+    q = p.integrate(lim)
+    assert q == Piecewise(
+        (2*d - Min(c, d) - 2*Min(d, Max(a, c)) + Min(d, Max(a, b, c)), c < d),
+        (-2*c + Min(c, d) + 2*Min(c, Max(a, d)) - Min(c, Max(a, b, d)), True))
+    for v in permutations((1, 2, 3, 4)):
+        r = dict(zip((a, b, c, d), v))
+        assert p.subs(r).integrate(lim.subs(r)) == q.subs(r)
 
 
-def test_piecewise_integrate_symbolic_conditions():
+def test_miejer_bypass():
+    # totally bypass meijerg machinery when dealing
+    # with Piecewise in integrate
+    assert Piecewise((1, x < 4), (0, True)).integrate((x, oo, 1)) == -3
+
+
+def test_piecewise_integrate2_inequality_conditions():
+    from sympy.utilities.iterables import cartes
+    lim = (x, 0, 5)
+    # set below includes two pts below range, 2 pts in range,
+    # 2 pts above range, and the boundaries
+    N = (-2, -1, 0, 1, 2, 5, 6, 7)
+
+    p = Piecewise((1, x > a), (2, x > b), (0, True))
+    ans = p.integrate(lim)
+    for i, j in cartes(N, repeat=2):
+        reps = dict(zip((a, b), (i, j)))
+        assert ans.subs(reps) == p.subs(reps).integrate(lim)
+    assert ans.subs(a, 4).subs(b, 1) == 0 + 2*3 + 1
+
+    p = Piecewise((1, x > a), (2, x < b), (0, True))
+    ans = p.integrate(lim)
+    for i, j in cartes(N, repeat=2):
+        reps = dict(zip((a, b), (i, j)))
+        assert ans.subs(reps) == p.subs(reps).integrate(lim)
+
+    # delete old tests that involved c1 and c2 since those
+    # reduce to the above except that a value of 0 was used
+    # for two expressions whereas the above uses 3 different
+    # values
+
+
+def test_piecewise_integrate3_symbolic_conditions():
     a = Symbol('a', real=True, finite=True)
     b = Symbol('b', real=True, finite=True)
     x = Symbol('x', real=True, finite=True)
@@ -248,39 +323,62 @@ def test_piecewise_integrate_symbolic_conditions():
     p3 = Piecewise((0, x < a), (1, x < b), (0, True))
     p4 = Piecewise((0, x > b), (1, x > a), (0, True))
     p5 = Piecewise((1, And(a < x, x < b)), (0, True))
-    assert integrate(p0, (x, -oo, y)) == Min(b, y) - Min(a, b, y)
-    assert integrate(p1, (x, -oo, y)) == Min(b, y) - Min(a, b, y)
-    assert integrate(p2, (x, -oo, y)) == Min(b, y) - Min(a, b, y)
-    assert integrate(p3, (x, -oo, y)) == Min(b, y) - Min(a, b, y)
-    assert integrate(p4, (x, -oo, y)) == Min(b, y) - Min(a, b, y)
-    assert integrate(p5, (x, -oo, y)) == Min(b, y) - Min(a, b, y)
-    assert integrate(p0, (x, y, oo)) == Max(a, b, y) - Max(a, y)
-    assert integrate(p1, (x, y, oo)) == Max(a, b, y) - Max(a, y)
-    assert integrate(p2, (x, y, oo)) == Max(a, b, y) - Max(a, y)
-    assert integrate(p3, (x, y, oo)) == Max(a, b, y) - Max(a, y)
-    assert integrate(p4, (x, y, oo)) == Max(a, b, y) - Max(a, y)
-    assert integrate(p5, (x, y, oo)) == Max(a, b, y) - Max(a, y)
 
-    assert integrate(p0, x) == Piecewise((0, Or(x < a, x > b)), (x, True))
-    assert integrate(p1, x) == Piecewise((0, Or(x < a, x > b)), (x, True))
-    assert integrate(p2, x) == Piecewise((0, Or(x < a, x > b)), (x, True))
+    # check values of a=1, b=3 (and reversed) with values
+    # of y of 0, 1, 2, 3, 4
+    lim = Tuple(x, -oo, y)
+    for p in (p0, p1, p2, p3, p4, p5):
+        ans = p.integrate(lim)
+        for i in range(5):
+            reps = {a:1, b:3, y:i}
+            assert ans.subs(reps) == p.subs(reps).integrate(lim.subs(reps))
+            reps = {a: 3, b:1, y:i}
+            assert ans.subs(reps) == p.subs(reps).integrate(lim.subs(reps))
+    lim = Tuple(x, y, oo)
+    for p in (p0, p1, p2, p3, p4, p5):
+        ans = p.integrate(lim)
+        for i in range(5):
+            reps = {a:1, b:3, y:i}
+            assert ans.subs(reps) == p.subs(reps).integrate(lim.subs(reps))
+            reps = {a:3, b:1, y:i}
+            assert ans.subs(reps) == p.subs(reps).integrate(lim.subs(reps))
+
+    ans = Piecewise(
+        (0, x <= Min(a, b)),
+        (x - Min(a, b), x <= b),
+        (b - Min(a, b), True))
+    for i in (p0, p1, p2, p4):
+        assert i.integrate(x) == ans
+    assert p3.integrate(x) == Piecewise(
+        (0, x < a),
+        (-a + x, x <= Max(a, b)),
+        (-a + Max(a, b), True))
+    assert p5.integrate(x) == Piecewise(
+        (0, x <= a),
+        (-a + x, x <= Max(a, b)),
+        (-a + Max(a, b), True))
 
     p1 = Piecewise((0, x < a), (0.5, x > b), (1, True))
     p2 = Piecewise((0.5, x > b), (0, x < a), (1, True))
     p3 = Piecewise((0, x < a), (1, x < b), (0.5, True))
     p4 = Piecewise((0.5, x > b), (1, x > a), (0, True))
     p5 = Piecewise((1, And(a < x, x < b)), (0.5, x > b), (0, True))
-    assert integrate(p1, (x, -oo, y)) == 0.5*y + 0.5*Min(b, y) - Min(a, b, y)
-    assert integrate(p2, (x, -oo, y)) == 0.5*y + 0.5*Min(b, y) - Min(a, b, y)
-    assert integrate(p3, (x, -oo, y)) == 0.5*y + 0.5*Min(b, y) - Min(a, b, y)
-    assert integrate(p4, (x, -oo, y)) == 0.5*y + 0.5*Min(b, y) - Min(a, b, y)
-    assert integrate(p5, (x, -oo, y)) == 0.5*y + 0.5*Min(b, y) - Min(a, b, y)
+
+    # check values of a=1, b=3 (and reversed) with values
+    # of y of 0, 1, 2, 3, 4
+    lim = Tuple(x, -oo, y)
+    for p in (p1, p2, p3, p4, p5):
+        ans = p.integrate(lim)
+        for i in range(5):
+            reps = {a:1, b:3, y:i}
+            assert ans.subs(reps) == p.subs(reps).integrate(lim.subs(reps))
+            reps = {a: 3, b:1, y:i}
+            assert ans.subs(reps) == p.subs(reps).integrate(lim.subs(reps))
 
 
-def test_piecewise_integrate_independent_conditions():
+def test_piecewise_integrate4_independent_conditions():
     p = Piecewise((0, Eq(y, 0)), (x*y, True))
-    assert integrate(p, (x, 1, 3)) == \
-        Piecewise((0, Eq(y, 0)), (4*y, True))
+    assert integrate(p, (x, 1, 3)) == Piecewise((0, Eq(y, 0)), (4*y, True))
 
 
 def test_piecewise_simplify():
@@ -441,17 +539,55 @@ def test_piecewise_interval():
     assert p1.subs(x, -0.5) == 0
     assert p1.subs(x, 0.5) == 0.5
     assert p1.diff(x) == Piecewise((1, Interval(0, 1).contains(x)), (0, True))
-    assert integrate(
-        p1, x) == Piecewise((x**2/2, Interval(0, 1).contains(x)), (0, True))
+    assert integrate(p1, x) == Piecewise(
+        (0, x <= 0),
+        (x**2/2, x <= 1),
+        (1/2, True))
 
 
 def test_piecewise_collapse():
-    p1 = Piecewise((x, x < 0), (x**2, x > 1))
-    p2 = Piecewise((p1, x < 0), (p1, x > 1))
-    assert p2 == Piecewise((x, x < 0), (x**2, 1 < x))
-
-    p1 = Piecewise((Piecewise((x, x < 0), (1, True)), True))
-    assert p1 == Piecewise((Piecewise((x, x < 0), (1, True)), True))
+    assert Piecewise((x, True)) == x
+    a = x < 1
+    assert Piecewise((x, a), (x + 1, a)) == Piecewise((x, a))
+    assert Piecewise((x, a), (x + 1, a.reversed)) == Piecewise((x, a))
+    b = x < 5
+    def canonical(i):
+        if isinstance(i, Piecewise):
+            return Piecewise(*i.args)
+        return i
+    for args in [
+        ((1, a), (Piecewise((2, a), (3, b)), b)),
+        ((1, a), (Piecewise((2, a), (3, b.reversed)), b)),
+        ((1, a), (Piecewise((2, a), (3, b)), b), (4, True)),
+        ((1, a), (Piecewise((2, a), (3, b), (4, True)), b)),
+        ((1, a), (Piecewise((2, a), (3, b), (4, True)), b), (5, True))]:
+        for i in (0, 2, 10):
+            assert canonical(
+                Piecewise(*args, evaluate=False).subs(x, i)
+                ) == canonical(Piecewise(*args).subs(x, i))
+    r1, r2, r3, r4 = symbols('r1:5')
+    a = x < r1
+    b = x < r2
+    c = x < r3
+    d = x < r4
+    assert Piecewise((1, a), (Piecewise(
+        (2, a), (3, b), (4, c)), b), (5, c)
+        ) == Piecewise((1, a), (3, b), (5, c))
+    assert Piecewise((1, a), (Piecewise(
+        (2, a), (3, b), (4, c), (6, True)), c), (5, d)
+        ) == Piecewise((1, a), (Piecewise(
+        (3, b), (4, c)), c), (5, d))
+    assert Piecewise((1, Or(a, d)), (Piecewise(
+        (2, d), (3, b), (4, c)), b), (5, c)
+        ) == Piecewise((1, Or(a, d)), (Piecewise(
+        (2, d), (3, b)), b), (5, c))
+    assert Piecewise((1, c), (2, ~c), (3, S.true)
+        ) == Piecewise((1, c), (2, S.true))
+    assert Piecewise((1, c), (2, And(~c, b)), (3,True)
+        ) == Piecewise((1, c), (2, b), (3, True))
+    assert Piecewise((1, c), (2, Or(~c, b)), (3,True)
+        ).subs(dict(zip((r1, r2, r3, r4, x), (1, 2, 3, 4, 3.5))))  == 2
+    assert Piecewise((1, c), (2, ~c)) == Piecewise((1, c), (2, True))
 
 
 def test_piecewise_lambdify():
@@ -534,6 +670,9 @@ def test_piecewise_evaluate():
     assert p != x
     assert p.is_Piecewise
     assert all(isinstance(i, Basic) for i in p.args)
+    assert Piecewise((1, Eq(1, x))).args == ((1, Eq(x, 1)),)
+    assert Piecewise((1, Eq(1, x)), evaluate=False).args == (
+        (1, Eq(1, x)),)
 
 
 def test_as_expr_set_pairs():
@@ -548,6 +687,301 @@ def test_S_srepr_is_identity():
     p = Piecewise((10, Eq(x, 0)), (12, True))
     q = S(srepr(p))
     assert p == q
+
+
+def test_issue_12587():
+    # sort holes into intervals
+    p = Piecewise((1, x > 4), (2, Not((x <= 3) & (x > -1))), (3, True))
+    assert p.integrate((x, -5, 5)) == 23
+    p = Piecewise((1, x > 1), (2, x < y), (3, True))
+    lim = x, -3, 3
+    ans = p.integrate(lim)
+    for i in range(-1, 3):
+        assert ans.subs(y, i) == p.subs(y, i).integrate(lim)
+
+
+def test_issue_11045():
+    assert integrate(1/(x*sqrt(x**2 - 1)), (x, 1, 2)) == pi/3
+
+    # handle And with Or arguments
+    assert Piecewise((1, And(Or(x < 1, x > 3), x < 2)), (0, True)
+        ).integrate((x, 0, 3)) == 1
+
+    # hidden false
+    assert Piecewise((1, x > 1), (2, x > x + 1), (3, True)
+        ).integrate((x, 0, 3)) == 5
+    # targetcond is Eq
+    assert Piecewise((1, x > 1), (2, Eq(1, x)), (3, True)
+        ).integrate((x, 0, 4)) == 6
+    # And has Relational needing to be solved
+    assert Piecewise((1, And(2*x > x + 1, x < 2)), (0, True)
+        ).integrate((x, 0, 3)) == 1
+    # Or has Relational needing to be solved
+    assert Piecewise((1, Or(2*x > x + 2, x < 1)), (0, True)
+        ).integrate((x, 0, 3)) == 2
+    # ignore hidden false (handled in canonicalization)
+    assert Piecewise((1, x > 1), (2, x > x + 1), (3, True)
+        ).integrate((x, 0, 3)) == 5
+    # watch for hidden True Piecewise
+    assert Piecewise((2, Eq(1 - x, x*(1/x - 1))), (0, True)
+        ).integrate((x, 0, 3)) == 6
+
+    # overlapping conditions of targetcond are recognized and ignored;
+    # the condition x > 3 will be pre-empted by the first condition
+    assert Piecewise((1, Or(x < 1, x > 2)), (2, x > 3), (3, True)
+        ).integrate((x, 0, 4)) == 6
+
+    # convert Ne to Or
+    assert Piecewise((1, Ne(x, 0)), (2, True)
+        ).integrate((x, -1, 1)) == 2
+
+    # no default but well defined
+    assert Piecewise((x, (x > 1) & (x < 3)), (1, (x < 4))
+        ).integrate((x, 1, 4)) == 5
+
+    p = Piecewise((x, (x > 1) & (x < 3)), (1, (x < 4)))
+    # with y unknown, this fails because there might be a hole
+    # in intervals [Min(1, Max(4, y)), 1] and [Min(4, y), y]. The
+    # first one should simplify (i.e. since 1 is less than the
+    # minumum value of Max(4, y) that interval should be [1, 1]
+    raises(ValueError, lambda: p.integrate((x, 1, y)))
+    assert p.integrate((x, 1, 4)) == 5
+
+    # handle Not
+    p = Piecewise((1, x > 1), (2, Not(And(x > 1, x< 3))), (3, True))
+    assert p.integrate((x, 0, 3)) == 4
+
+    # handle updating of int_expr when there is overlap
+    p = Piecewise(
+        (1, And(5 > x, x > 1)),
+        (2, Or(x < 3, x > 7)),
+        (4, x < 8))
+    assert p.integrate((x, 0, 10)) == 20
+
+    # And with Eq arg handling
+    assert Piecewise((1, x < 1), (2, And(Eq(x, 3), x > 1))
+        ).integrate((x, 0, 3)) == S.NaN
+    assert Piecewise((1, x < 1), (2, And(Eq(x, 3), x > 1)), (3, True)
+        ).integrate((x, 0, 3)) == 7
+    assert Piecewise((1, x < 0), (2, And(Eq(x, 3), x < 1)), (3, True)
+        ).integrate((x, -1, 1)) == 4
+    # middle condition doesn't matter: it's a zero width interval
+    assert Piecewise((1, x < 1), (2, Eq(x, 3) & (y < x)), (3, True)
+        ).integrate((x, 0, 3)) == 7
+
+
+def test_holes():
+    nan = Undefined
+    assert Piecewise((1, x < 2)).integrate(x) == Piecewise(
+        (x, x < 2), (nan, True))
+    assert Piecewise((1, And(x > 1, x < 2))).integrate(x) == Piecewise(
+        (nan, x < 1), (x - 1, x < 2), (nan, True))
+    assert Piecewise((1, And(x > 1, x < 2))).integrate((x, 0, 3)) == nan
+    assert Piecewise((1, And(x > 0, x < 4))).integrate((x, 1, 3)) == 2
+
+    # this also tests that the integrate method is used on non-Piecwise
+    # arguments in _eval_integral
+    A, B = symbols("A B")
+    a, b = symbols('a b', finite=True)
+    assert Piecewise((A, And(x < 0, a < 1)), (B, Or(x < 1, a > 2))
+        ).integrate(x) == Piecewise(
+        (B*x, a > 2),
+        (Piecewise((A*x, x < 0), (B*x, x < 1), (nan, True)), a < 1),
+        (Piecewise((B*x, x < 1), (nan, True)), True))
+
+
+def test_issue_11922():
+    def f(x):
+        return Piecewise((0, x < -1), (1 - x**2, x < 1), (0, True))
+    autocorr = lambda k: (
+        f(x) * f(x + k)).integrate((x, -1, 1))
+    assert autocorr(1.9) > 0
+    k = symbols('k')
+    good_autocorr = lambda k: (
+        (1 - x**2) * f(x + k)).integrate((x, -1, 1))
+    a = good_autocorr(k)
+    assert a.subs(k, 3) == 0
+    k = symbols('k', positive=True)
+    a = good_autocorr(k)
+    assert a.subs(k, 3) == 0
+    assert Piecewise((0, x < 1), (10, (x >= 1))
+        ).integrate() == Piecewise((0, x < 1), (10*x - 10, True))
+
+
+def test_issue_5227():
+    f = 0.0032513612725229*Piecewise((0, x < -80.8461538461539),
+        (-0.0160799238820171*x + 1.33215984776403, x < 2),
+        (Piecewise((0.3, x > 123), (0.7, True)) +
+        Piecewise((0.4, x > 2), (0.6, True)), x <=
+        123), (-0.00817409766454352*x + 2.10541401273885, x <
+        380.571428571429), (0, True))
+    i = integrate(f, (x, -oo, oo))
+    assert i == Integral(f, (x, -oo, oo)).doit()
+    assert str(i) == '1.00195081676351'
+    assert Piecewise((1, x - y < 0), (0, True)
+        ).integrate(y) == Piecewise((0, y <= x), (-x + y, True))
+
+
+def test_issue_10137():
+    a = Symbol('a', real=True, finite=True)
+    b = Symbol('b', real=True, finite=True)
+    x = Symbol('x', real=True, finite=True)
+    y = Symbol('y', real=True, finite=True)
+    p0 = Piecewise((0, Or(x < a, x > b)), (1, True))
+    p1 = Piecewise((0, Or(a > x, b < x)), (1, True))
+    assert integrate(p0, (x, y, oo)) == integrate(p1, (x, y, oo))
+    p3 = Piecewise((1, And(0 < x, x < a)), (0, True))
+    p4 = Piecewise((1, And(a > x, x > 0)), (0, True))
+    ip3 = integrate(p3, x)
+    assert ip3 == Piecewise(
+        (0, x <= 0),
+        (x, x <= Max(0, a)),
+        (Max(0, a), True))
+    ip4 = integrate(p4, x)
+    assert ip4 == ip3
+    assert p3.integrate((x, 2, 4)) == Min(4, Max(2, a)) - 2
+    assert p4.integrate((x, 2, 4)) == Min(4, Max(2, a)) - 2
+
+
+def test_stackoverflow_43852159():
+    f = lambda x: Piecewise((1 , (x >= -1) & (x <= 1)) , (0, True))
+    Conv = lambda x: integrate(f(x - y)*f(y), (y, -oo, +oo))
+    cx = Conv(x)
+    assert cx.subs(x, -1.5) == cx.subs(x, 1.5)
+    assert cx.subs(x, 3) == 0
+    assert piecewise_fold(f(x - y)*f(y)) == Piecewise(
+        (1, (y >= -1) & (y <= 1) & (x - y >= -1) & (x - y <= 1)),
+        (0, True))
+
+
+def test_issue_12557():
+    '''
+    # 3200 seconds to compute the fourier part of issue
+    import sympy as sym
+    x,y,z,t = sym.symbols('x y z t')
+    k = sym.symbols("k", integer=True)
+    fourier = sym.fourier_series(sym.cos(k*x)*sym.sqrt(x**2),
+                                 (x, -sym.pi, sym.pi))
+    assert fourier == FourierSeries(
+    sqrt(x**2)*cos(k*x), (x, -pi, pi), (Piecewise((pi**2,
+    Eq(k, 0)), (2*(-1)**k/k**2 - 2/k**2, True))/(2*pi),
+    SeqFormula(Piecewise((pi**2, (Eq(_n, 0) & Eq(k, 0)) | (Eq(_n, 0) &
+    Eq(_n, k) & Eq(k, 0)) | (Eq(_n, 0) & Eq(k, 0) & Eq(_n, -k)) | (Eq(_n,
+    0) & Eq(_n, k) & Eq(k, 0) & Eq(_n, -k))), (pi**2/2, Eq(_n, k) | Eq(_n,
+    -k) | (Eq(_n, 0) & Eq(_n, k)) | (Eq(_n, k) & Eq(k, 0)) | (Eq(_n, 0) &
+    Eq(_n, -k)) | (Eq(_n, k) & Eq(_n, -k)) | (Eq(k, 0) & Eq(_n, -k)) |
+    (Eq(_n, 0) & Eq(_n, k) & Eq(_n, -k)) | (Eq(_n, k) & Eq(k, 0) & Eq(_n,
+    -k))), ((-1)**k*pi**2*_n**3*sin(pi*_n)/(pi*_n**4 - 2*pi*_n**2*k**2 +
+    pi*k**4) - (-1)**k*pi**2*_n**3*sin(pi*_n)/(-pi*_n**4 + 2*pi*_n**2*k**2
+    - pi*k**4) + (-1)**k*pi*_n**2*cos(pi*_n)/(pi*_n**4 - 2*pi*_n**2*k**2 +
+    pi*k**4) - (-1)**k*pi*_n**2*cos(pi*_n)/(-pi*_n**4 + 2*pi*_n**2*k**2 -
+    pi*k**4) - (-1)**k*pi**2*_n*k**2*sin(pi*_n)/(pi*_n**4 -
+    2*pi*_n**2*k**2 + pi*k**4) +
+    (-1)**k*pi**2*_n*k**2*sin(pi*_n)/(-pi*_n**4 + 2*pi*_n**2*k**2 -
+    pi*k**4) + (-1)**k*pi*k**2*cos(pi*_n)/(pi*_n**4 - 2*pi*_n**2*k**2 +
+    pi*k**4) - (-1)**k*pi*k**2*cos(pi*_n)/(-pi*_n**4 + 2*pi*_n**2*k**2 -
+    pi*k**4) - (2*_n**2 + 2*k**2)/(_n**4 - 2*_n**2*k**2 + k**4),
+    True))*cos(_n*x)/pi, (_n, 1, oo)), SeqFormula(0, (_k, 1, oo))))
+    '''
+    x = symbols("x", real=True)
+    k = symbols('k',  integer=True)
+    abs2 = lambda x: Piecewise((-x, x <= 0), (x, x > 0))
+    assert integrate(abs2(x), (x, -pi, pi)) == pi**2
+    # attempting a Piecewise rewrite is not automatic so this needs
+    # help
+    func = cos(k*x)*sqrt(x**2)
+    assert integrate(func, (x, -pi, pi)
+        ) == Integral(cos(k*x)*Abs(x), (x, -pi, pi))
+    assert factor_terms(integrate(func.rewrite(Piecewise), (x, -pi, pi)
+        )) == Piecewise(
+        (pi**2, Eq(k, 0)), (((-1)**k - 1)/k**2*2, True))
+
+
+def test_issue_6900():
+    t0, t1, T, t = symbols('t0, t1 T t')
+    f = Piecewise((0, t < t0), (x, And(t0 <= t, t < t1)), (0, t >= t1))
+    assert f.integrate(t) == Piecewise(
+        (0, t <= t0),
+        (t*x - t0*x, t <= Max(t0, t1)),
+        (-t0*x + x*Max(t0, t1), True))
+    assert f.integrate((t, t0, T)) == Piecewise(
+        (-x*Min(T, t0) + x*Min(T, Max(t0, t1)), t0 < T),
+        (0, True))
+
+
+def test_issue_10122():
+    assert solve(abs(x) + abs(x - 1) - 1 > 0, x
+        ) == Or(And(-oo < x, x < 0), And(S.One < x, x < oo))
+
+
+def test_issue_4313():
+    u = Piecewise((0, x <= 0), (1, x >= a), (x/a, True))
+    e = (u - u.subs(x, y))**2/(x - y)**2
+    M = Max(0, a)
+    assert integrate(e,  x).expand() == Piecewise(
+        (Piecewise(
+            (0, x <= 0),
+            (-y**2/(a**2*x - a**2*y) + x/a**2 - 2*y*log(-y)/a**2 +
+                2*y*log(x - y)/a**2 - y/a**2, x <= M),
+            (-y**2/(-a**2*y + a**2*M) + 1/(-y + M) -
+                1/(x - y) - 2*y*log(-y)/a**2 + 2*y*log(-y +
+                M)/a**2 - y/a**2 + M/a**2, True)),
+        ((a <= y) & (y <= 0)) | ((y <= 0) & (y > -oo))),
+        (Piecewise(
+            (-1/(x - y), x <= 0),
+            (-a**2/(a**2*x - a**2*y) + 2*a*y/(a**2*x - a**2*y) -
+                y**2/(a**2*x - a**2*y) + 2*log(-y)/a - 2*log(x - y)/a +
+                2/a + x/a**2 - 2*y*log(-y)/a**2 + 2*y*log(x - y)/a**2 -
+                y/a**2, x <= M),
+            (-a**2/(-a**2*y + a**2*M) + 2*a*y/(-a**2*y +
+                a**2*M) - y**2/(-a**2*y + a**2*M) +
+                2*log(-y)/a - 2*log(-y + M)/a + 2/a -
+                2*y*log(-y)/a**2 + 2*y*log(-y + M)/a**2 -
+                y/a**2 + M/a**2, True)),
+        a <= y),
+        (Piecewise(
+            (-y**2/(a**2*x - a**2*y), x <= 0),
+            (x/a**2 + y/a**2, x <= M),
+            (a**2/(-a**2*y + a**2*M) -
+                a**2/(a**2*x - a**2*y) - 2*a*y/(-a**2*y + a**2*M) +
+                2*a*y/(a**2*x - a**2*y) + y**2/(-a**2*y + a**2*M) -
+                y**2/(a**2*x - a**2*y) + y/a**2 + M/a**2, True)),
+        True))
+
+
+def test__intervals():
+    assert Piecewise((x + 2, Eq(x, 3)))._intervals(x) == [(3, 3, 5, 0)]
+    assert Piecewise(
+        (1, x > x + 1),
+        (Piecewise((1, x < x + 1)), 2*x < 2*x + 1),
+        (1, True))._intervals(x) == [(-oo, oo, 1, 1)]
+    assert Piecewise((1, Ne(x, I)), (0, True))._intervals(x) == [
+        (-oo, oo, 1, 0)]
+
+
+def test_containment():
+    a, b, c, d, e = [1, 2, 3, 4, 5]
+    p = (Piecewise((d, x > 1), (e, True))*
+        Piecewise((a, Abs(x - 1) < 1), (b, Abs(x - 2) < 2), (c, True)))
+    assert p.integrate(x).diff(x) == Piecewise(
+        (c*e, x <= 0),
+        (a*e, x <= 1),
+        (a*d, x < 2),  # this is what we want to get right
+        (b*d, x < 4),
+        (c*d, True))
+
+
+def test_piecewise_with_DiracDelta():
+    # XXX not sure what these should be
+    d1 = DiracDelta(x - 1)
+    assert integrate(d1, (x, -oo, oo)) == 1
+    assert integrate(d1, (x, 0, 2)) == 1
+    assert Piecewise((d1, Eq(x, 2)), (0, True)).integrate(x) == 0  # right
+    # XXX should the following be
+    # Piecewise((Heaviside(0), Eq(x, 1)), (1, x > 1), (0, True))?
+    assert Piecewise((d1, Eq(x, 1)), (0, True)).integrate(x) == 0
+    assert Piecewise((d1, x < 2), (0, True)).integrate(x) == Piecewise(
+        (Heaviside(x - 1), x < 2), (1, True))
 
 
 def test_issue_10258():
@@ -584,10 +1018,45 @@ def test_issue_10087():
 
 
 def test_issue_8919():
-    x, c_1, c_2, c_3, c_4 = symbols('x c_1:5')
-    f1 = Piecewise( (c_1, x < 1), (c_2, True))
-    f2 = Piecewise( (c_3, x < S(1)/3), (c_4, True))
-    assert integrate(f1*f2, (x, 0, 2)) == c_1*c_3/3 + 2*c_1*c_4/3 + c_2*c_4
+    c = symbols('c:5')
+    x = symbols("x")
+    f1 = Piecewise((c[1], x < 1), (c[2], True))
+    f2 = Piecewise((c[3], x < S(1)/3), (c[4], True))
+    assert integrate(f1*f2, (x, 0, 2)
+        ) == c[1]*c[3]/3 + 2*c[1]*c[4]/3 + c[2]*c[4]
+    f1 = Piecewise((0, x < 1), (2, True))
+    f2 = Piecewise((3, x < 2), (0, True))
+    assert integrate(f1*f2, (x, 0, 3)) == 6
+
+    y = symbols("y", positive=True)
+    a, b, c, x, z = symbols("a,b,c,x,z", real=True)
+    I = Integral(Piecewise(
+        (0, (x >= y) | (x < 0) | (b > c)),
+        (a, True)), (x, 0, z))
+    ans = I.doit()
+    assert ans == Piecewise((0, b > c), (a*z - a*Min(0, z), True))
+    for cond in (True, False):
+         for yy in range(1, 3):
+             for zz in range(-1, 0, 1):
+                 reps = [(b > c, cond), (y, yy), (z, zz)]
+                 assert ans.subs(reps) == I.subs(reps).doit()
+
+
+def test_unevaluated_integrals():
+    f = Function('f')
+    p = Piecewise((1, Eq(f(x) - 1, 0)), (2, x - 10 < 0), (0, True))
+    assert p.integrate(x) == Integral(p, x)
+    assert p.integrate((x, 0, 5)) == Integral(p, (x, 0, 5))
+    # test it by replacing f(x) with x%2 which will not
+    # affect the answer: the integrand is essentially 2 over
+    # the domain of integration
+    assert Integral(p, (x, 0, 5)).subs(f(x), x%2).n() == 10
+
+    # this is a test of using _solve_inequality when
+    # solve_univariate_inequality fails
+    assert p.integrate(y) == Piecewise(
+        (y, Eq(f(x), 1) | ((x < 10) & Eq(f(x), 1))),
+        (2*y, (x >= -oo) & (x < 10)), (0, True))
 
 
 def test_conditions_as_alternate_booleans():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -200,7 +200,7 @@ def test_piecewise_integrate1():
         (0, True))
     assert integrate(g, (x, y, 1)) == Piecewise(
         (-Min(1, Max(0, y))**2/2 + 1/2, y < 1),
-        (-y + Min(1, y), True))
+        (-y + 1, True))
 
     g = Piecewise((1 - x, Interval(0, 1).contains(x)),
         (1 + x, Interval(-1, 0).contains(x)), (0, True))
@@ -219,8 +219,7 @@ def test_piecewise_integrate1():
     assert i == Piecewise(
         (-Min(-1, y)**2/2 - Min(-1, y) +
             Min(0, y)**2 - Min(1, y)**2/2 + Min(1, y), y > -5),
-        (Max(-5, Min(-1, y))**2/2 + Max(-5, Min(-1, y)) -
-            Min(0, Max(-5, y))**2/2 - Min(0, Max(-5, y)), True))
+        (0, True))
     i = integrate(g, (x, y, 1))
     assert i.subs(y, -5) == 1
     assert piecewise_fold(i.rewrite(Piecewise)
@@ -231,7 +230,7 @@ def test_piecewise_integrate1():
         (0, True))
     assert i == Piecewise(
         (Min(1, Max(0, y))**2 - Min(1, Max(-1, y), Max(0, y))**2/2 -
-            Min(1, Max(-1, y), Max(0, y)) + S.Half, y < 1),
+            Min(1, Max(-1, y), Max(0, y)) + 1/2, y < 1),
         (0, True))
 
     g = Piecewise((0, Or(x <= -1, x >= 1)), (1 - x, x > 0),
@@ -251,8 +250,7 @@ def test_piecewise_integrate1():
     assert i == Piecewise(
         (-Min(-1, y)**2/2 - Min(-1, y) + Min(0, y)**2 -
             Min(1, y)**2/2 + Min(1, y), y > -5),
-        (Max(-5, y)**2/2 - Max(-5, y) + Max(-5, Min(-1, y))**2/2 +
-            Max(-5, Min(-1, y)) - Min(0, Max(-5, y))**2, True))
+        (0, True))
     i = integrate(g, (x, y, 1))
     assert i.subs(y, -5) == 1
     assert piecewise_fold(i.rewrite(Piecewise)
@@ -263,7 +261,7 @@ def test_piecewise_integrate1():
         (0, True))
     assert i == Piecewise(
         (-Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
-            Min(1, Max(0, y))**2 + S.Half, y < 1),
+            Min(1, Max(0, y))**2 + 1/2, y < 1),
         (0, True))
 
 
@@ -273,8 +271,8 @@ def test_3_piecewise_integrate():
     p = Piecewise((1, x < a), (2, x > b), (3, True))
     q = p.integrate(lim)
     assert q == Piecewise(
-        (2*d - Min(c, d) - 2*Min(d, Max(a, c)) + Min(d, Max(a, b, c)), c < d),
-        (-2*c + Min(c, d) + 2*Min(c, Max(a, d)) - Min(c, Max(a, b, d)), True))
+        (-c + 2*d - 2*Min(d, Max(a, c)) + Min(d, Max(a, b, c)), c < d),
+        (-2*c + d + 2*Min(c, Max(a, d)) - Min(c, Max(a, b, d)), True))
     for v in permutations((1, 2, 3, 4)):
         r = dict(zip((a, b, c, d), v))
         assert p.subs(r).integrate(lim.subs(r)) == q.subs(r)
@@ -905,9 +903,8 @@ def test_issue_6900():
         (t*x - t0*x, t <= Max(t0, t1)),
         (-t0*x + x*Max(t0, t1), True))
     assert f.integrate((t, t0, T)) == Piecewise(
-        (-x*Min(T, t0) + x*Min(T, Max(t0, t1)), t0 < T),
+        (-t0*x + x*Min(T, Max(t0, t1)), T > t0),
         (0, True))
-
 
 def test_issue_10122():
     assert solve(abs(x) + abs(x - 1) - 1 > 0, x

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -872,8 +872,9 @@ def test_issue_4517():
 
 def test_issue_4527():
     k, m = symbols('k m', integer=True)
-    assert integrate(sin(k*x)*sin(m*x), (x, 0, pi)) == Piecewise(
-        (0, And(Eq(k, 0), Eq(m, 0))),
+    ans = integrate(sin(k*x)*sin(m*x), (x, 0, pi)
+            ).simplify() == Piecewise(
+        (0, Eq(k, 0) | Eq(m, 0)),
         (-pi/2, Eq(k, -m)),
         (pi/2, Eq(k, m)),
         (0, True))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -611,7 +611,7 @@ def test_messy():
         log(S(1)/2 + sqrt(2)/2)
 
     assert integrate(1/x/sqrt(1 - x**2), x, meijerg=True) == \
-        Piecewise((-acosh(1/x), 1 < abs(x**(-2))), (I*asin(1/x), True))
+        Piecewise((-acosh(1/x), abs(x**(-2)) > 1), (I*asin(1/x), True))
 
 
 def test_issue_6122():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -86,7 +86,6 @@ def test_mellin_transform_fail():
             (-1, -S(1)/2), True)
 
 
-@slow
 def test_mellin_transform():
     from sympy import Max, Min
     MT = mellin_transform
@@ -100,22 +99,24 @@ def test_mellin_transform():
         (1/(nu + s), (-re(nu), oo), True)
 
     assert MT((1 - x)**(beta - 1)*Heaviside(1 - x), x, s) == \
-        (gamma(beta)*gamma(s)/gamma(beta + s), (0, oo), re(-beta) < 0)
+        (gamma(beta)*gamma(s)/gamma(beta + s), (0, oo), -re(beta) < 0)
     assert MT((x - 1)**(beta - 1)*Heaviside(x - 1), x, s) == \
         (gamma(beta)*gamma(1 - beta - s)/gamma(1 - s),
-            (-oo, -re(beta) + 1), re(-beta) < 0)
+            (-oo, -re(beta) + 1), -re(beta) < 0)
 
     assert MT((1 + x)**(-rho), x, s) == \
         (gamma(s)*gamma(rho - s)/gamma(rho), (0, re(rho)), True)
 
-    # TODO also the conditions should be simplified
+    # TODO also the conditions should be simplified, e.g.
+    # And(re(rho) - 1 < 0, re(rho) < 1) should just be
+    # re(rho) < 1
     assert MT(abs(1 - x)**(-rho), x, s) == (
         2*sin(pi*rho/2)*gamma(1 - rho)*
         cos(pi*(rho/2 - s))*gamma(s)*gamma(rho-s)/pi,
         (0, re(rho)), And(re(rho) - 1 < 0, re(rho) < 1))
     mt = MT((1 - x)**(beta - 1)*Heaviside(1 - x)
             + a*(x - 1)**(beta - 1)*Heaviside(x - 1), x, s)
-    assert mt[1], mt[2] == ((0, -re(beta) + 1), True)
+    assert mt[1], mt[2] == ((0, -re(beta) + 1), -re(beta) < 0)
 
     assert MT((x**a - b**a)/(x - b), x, s)[0] == \
         pi*b**(a + s - 1)*sin(pi*a)/(sin(pi*s)*sin(pi*(a + s)))
@@ -146,6 +147,14 @@ def test_mellin_transform():
     assert MT(log(abs(1 - x)), x, s) == (pi/(s*tan(pi*s)), (-1, 0), True)
     assert MT(log(abs(1 - 1/x)), x, s) == (pi/(s*tan(pi*s)), (0, 1), True)
 
+    # 8.4.14
+    assert MT(erf(sqrt(x)), x, s) == \
+        (-gamma(s + S(1)/2)/(sqrt(pi)*s), (-S(1)/2, 0), True)
+
+
+@slow
+def test_mellin_transform2():
+    MT = mellin_transform
     # TODO we cannot currently do these (needs summation of 3F2(-1))
     #      this also implies that they cannot be written as a single g-function
     #      (although this is possible)
@@ -158,10 +167,6 @@ def test_mellin_transform():
     mt = MT(log(x)/(x + 1)**2, x, s)
     assert mt[1:] == ((0, 2), True)
     assert not hyperexpand(mt[0], allow_hyper=True).has(meijerg)
-
-    # 8.4.14
-    assert MT(erf(sqrt(x)), x, s) == \
-        (-gamma(s + S(1)/2)/(sqrt(pi)*s), (-S(1)/2, 0), True)
 
 
 @slow
@@ -294,7 +299,7 @@ def test_expint():
     # TODO LT of Si, Shi, Chi is a mess ...
     assert laplace_transform(Ci(x), x, s) == (-log(1 + s**2)/2/s, 0, True)
     assert laplace_transform(expint(a, x), x, s) == \
-        (lerchphi(s*polar_lift(-1), 1, a), 0, S(0) < re(a))
+        (lerchphi(s*exp_polar(I*pi), 1, a), 0, S(0) < re(a))
     assert laplace_transform(expint(1, x), x, s) == (log(s + 1)/s, 0, True)
     assert laplace_transform(expint(2, x), x, s) == \
         ((s - log(s + 1))/s**2, 0, True)
@@ -460,10 +465,9 @@ def test_laplace_transform():
 
     # test a bug
     spos = symbols('s', positive=True)
-    assert LT(exp(t), t, spos)[:2] == (1/(spos - 1), True)
+    assert LT(exp(t), t, spos)[:2] == (1/(spos - 1), 1)
 
     # basic tests from wikipedia
-
     assert LT((t - a)**b*exp(-c*(t - a))*Heaviside(t - a), t, s) == \
         ((s + c)**(-b - 1)*exp(-a*s)*gamma(b + 1), -c, True)
     assert LT(t**a, t, s) == (s**(-a - 1)*gamma(a + 1), 0, True)
@@ -480,13 +484,12 @@ def test_laplace_transform():
 
     assert LT(log(t/a), t, s) == ((log(a*s) + EulerGamma)/s/-1, 0, True)
 
-    assert LT(erf(t), t, s) == ((erfc(s/2))*exp(s**2/4)/s, 0, True)
+    assert LT(erf(t), t, s) == (erfc(s/2)*exp(s**2/4)/s, 0, True)
 
     assert LT(sin(a*t), t, s) == (a/(a**2 + s**2), 0, True)
     assert LT(cos(a*t), t, s) == (s/(a**2 + s**2), 0, True)
     # TODO would be nice to have these come out better
-    assert LT(
-        exp(-a*t)*sin(b*t), t, s) == (b/(b**2 + (a + s)**2), -a, True)
+    assert LT(exp(-a*t)*sin(b*t), t, s) == (b/(b**2 + (a + s)**2), -a, True)
     assert LT(exp(-a*t)*cos(b*t), t, s) == \
         ((a + s)/(b**2 + (a + s)**2), -a, True)
 
@@ -510,6 +513,8 @@ def test_laplace_transform():
         ((2*sin(s**2/(2*pi))*fresnelc(s/pi) - 2*cos(s**2/(2*pi))*fresnels(s/pi)
         + sqrt(2)*cos(s**2/(2*pi) + pi/4))/(2*s), 0, True))
 
+    cond = Ne(1/s, 1) & (
+        S(0) < cos(Abs(periodic_argument(s, oo)))*Abs(s) - 1)
     assert LT(Matrix([[exp(t), t*exp(-t)], [t*exp(-t), exp(t)]]), t, s) ==\
         Matrix([
             [(1/(s - 1), 1, True), ((s + 1)**(-2), 0, True)],
@@ -524,8 +529,8 @@ def test_issue_8368_7173():
     assert LT(cosh(x), x, s) == (s/(s**2 - 1), 1, True)
     assert LT(sinh(x + 3), x, s) == (
         (-s + (s + 1)*exp(6) + 1)*exp(-3)/(s - 1)/(s + 1)/2, 1, True)
-    assert LT(sinh(x)*cosh(x), x, s) == (1/(s**2 - 4), 2, Ne(s/2, 1))
-
+    assert LT(sinh(x)*cosh(x), x, s) == (
+        1/(s**2 - 4), 2, Ne(s/2, 1))
     # trig (make sure they are not being rewritten in terms of exp)
     assert LT(cos(x + 3), x, s) == ((s*cos(3) - sin(3))/(s**2 + 1), 0, True)
 
@@ -765,12 +770,18 @@ def test_issue_8882():
 
 
 def test_issue_7173():
-    assert laplace_transform(sinh(a*x)*cosh(a*x), x, s) == \
-        (a/(s**2 - 4*a**2), 0,
-        And(Or(Abs(periodic_argument(exp_polar(I*pi)*polar_lift(a), oo)) <
-        pi/2, Abs(periodic_argument(exp_polar(I*pi)*polar_lift(a), oo)) <=
-        pi/2), Or(Abs(periodic_argument(a, oo)) < pi/2,
-        Abs(periodic_argument(a, oo)) <= pi/2)))
+    from sympy import cse
+    x0, x1, x2 = symbols('x:3')
+    ans = laplace_transform(sinh(a*x)*cosh(a*x), x, s)
+    r, e = cse(ans)
+    assert r == [
+        (x0, pi/2),
+        (x1, Abs(periodic_argument(a, oo))),
+        (x2, Abs(periodic_argument(exp_polar(I*pi)*polar_lift(a), oo)))]
+    assert e == [
+        a/(-4*a**2 + s**2),
+        0,
+        ((x0 >= x1) | (x1 < x0)) & ((x0 >= x2) | (x2 < x0))]
 
 
 def test_issue_8514():

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -290,7 +290,7 @@ def test_matrixelement_diff():
     assert w[k, p].diff(w[k, p]) == 1
     assert w[k, p].diff(w[0, 0]) == KroneckerDelta(0, k)*KroneckerDelta(0, p)
     assert str(dexpr) == "Sum(KroneckerDelta(_k, p)*D[k, _k], (_k, 0, n - 1))"
-    assert str(dexpr.doit()) == 'Piecewise((D[k, p], (0 <= p) & (p <= n - 1)), (0, True))'
+    assert str(dexpr.doit()) == 'Piecewise((D[k, p], (p >= 0) & (p <= n - 1)), (0, True))'
 
 
 def test_MatrixElement_with_values():

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -72,24 +72,24 @@ def test_piecewise():
 
     p = Piecewise(
         (x**2, x < 0),
-        (x, Interval(0, 1, False, True).contains(x)),
+        (x, x < 1),
         (2 - x, x >= 1),
-        (0, True)
+        (0, True), evaluate=False
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x**2) if (x < 0) else (((x) if (((x >= 0) and (x < 1))) " \
+    assert l == "((x**2) if (x < 0) else (((x) if (x < 1) " \
         "else (((-x + 2) if (x >= 1) else (((0) if (True) else None)))))))"
 
     p = Piecewise(
         (x**2, x < 0),
-        (x, Interval(0, 1, False, True).contains(x)),
-        (2 - x, x >= 1),
+        (x, x < 1),
+        (2 - x, x >= 1), evaluate=False
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x**2) if (x < 0) else (((x) if (((x >= 0) and " \
-        "(x < 1))) else (((-x + 2) if (x >= 1) else None)))))"
+    assert l == ("((x**2) if (x < 0) else (((x) if (x < 1) else "
+        "(((-x + 2) if (x >= 1) else None)))))")
 
     p = Piecewise(
         (1, x >= 1),

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -891,8 +891,8 @@ def test_latex_Piecewise():
     assert latex(p, itex=True) == "\\begin{cases} x & \\text{for}\\: x \\lt 1 \\\\x^{2} &" \
                                   " \\text{otherwise} \\end{cases}"
     p = Piecewise((x, x < 0), (0, x >= 0))
-    assert latex(p) == "\\begin{cases} x & \\text{for}\\: x < 0 \\\\0 &" \
-                       " \\text{for}\\: x \\geq 0 \\end{cases}"
+    assert latex(p) == '\\begin{cases} x & \\text{for}\\: x < 0 \\\\0 &' \
+                       ' \\text{otherwise} \\end{cases}'
     A, B = symbols("A B", commutative=False)
     p = Piecewise((A**2, Eq(A, B)), (A*B, True))
     s = r"\begin{cases} A^{2} & \text{for}\: A = B \\A B & \text{otherwise} \end{cases}"

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -539,7 +539,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 # expanded_e, expr and gen used from enclosing scope
                 v = expanded_e.subs(gen, x)
                 try:
-                    r = expr.func(v, 0)
+                    r = expand_mul(expr.func(v, 0))
                 except TypeError:
                     r = S.false
                 if r in (S.true, S.false):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -537,9 +537,9 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 # x**2 + x - 2 < 0
                 #
                 # expanded_e, expr and gen used from enclosing scope
-                v = expanded_e.subs(gen, x)
+                v = expanded_e.subs(gen, expand_mul(x))
                 try:
-                    r = expand_mul(expr.func(v, 0))
+                    r = expr.func(v, 0)
                 except TypeError:
                     r = S.false
                 if r in (S.true, S.false):

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1996,7 +1996,7 @@ def QuadraticU(name, a, b):
     |   /  a   b    \
     |12*|- - - - + z|
     |   \  2   2    /
-    <-----------------  for And(a <= z, z <= b)
+    <-----------------  for And(b >= z, a <= z)
     |            3
     |    (-a + b)
     |
@@ -2070,7 +2070,7 @@ def RaisedCosine(name, mu, s):
     /   /pi*(-mu + z)\
     |cos|------------| + 1
     |   \     s      /
-    <---------------------  for And(z <= mu + s, mu - s <= z)
+    <---------------------  for And(z >= mu - s, z <= mu + s)
     |         2*s
     |
     \          0                        otherwise
@@ -2335,15 +2335,15 @@ def Trapezoidal(name, a, b, c, d):
 
     >>> pprint(density(X)(z), use_unicode=False)
     /        -2*a + 2*z
-    |-------------------------  for And(a <= z, z < b)
+    |-------------------------  for And(a <= z, b > z)
     |(-a + b)*(-a - b + c + d)
     |
     |           2
-    |     --------------        for And(b <= z, z < c)
+    |     --------------        for And(b <= z, c > z)
     <     -a - b + c + d
     |
     |        2*d - 2*z
-    |-------------------------  for And(c <= z, z <= d)
+    |-------------------------  for And(d >= z, c <= z)
     |(-c + d)*(-a - b + c + d)
     |
     \            0                     otherwise
@@ -2413,15 +2413,15 @@ def Triangular(name, a, b, c):
 
     >>> pprint(density(X)(z), use_unicode=False)
     /    -2*a + 2*z
-    |-----------------  for And(a <= z, z < c)
+    |-----------------  for And(a <= z, c > z)
     |(-a + b)*(-a + c)
     |
     |       2
-    |     ------              for z = c
+    |     ------              for c = z
     <     -a + b
     |
     |   2*b - 2*z
-    |----------------   for And(z <= b, c < z)
+    |----------------   for And(b >= z, c < z)
     |(-a + b)*(b - c)
     |
     \        0                otherwise
@@ -2509,7 +2509,7 @@ def Uniform(name, left, right):
     >>> X = Uniform("x", a, b)
 
     >>> density(X)(z)
-    Piecewise((1/(-a + b), (a <= z) & (z <= b)), (0, True))
+    Piecewise((1/(-a + b), (b >= z) & (a <= z)), (0, True))
 
     >>> cdf(X)(z)  # doctest: +SKIP
     -a/(-a + b) + z/(-a + b)

--- a/sympy/utilities/tests/test_codegen_julia.py
+++ b/sympy/utilities/tests/test_codegen_julia.py
@@ -218,7 +218,7 @@ def test_jl_output_arg_mixed_unordered():
 
 
 def test_jl_piecewise_():
-    pw = Piecewise((0, x < -1), (x**2, x <= 1), (-x+2, x > 1), (1, True))
+    pw = Piecewise((0, x < -1), (x**2, x <= 1), (-x+2, x > 1), (1, True), evaluate=False)
     name_expr = ("pwtest", pw)
     result, = codegen(name_expr, "Julia", header=False, empty=False)
     source = result[1]

--- a/sympy/utilities/tests/test_codegen_octave.py
+++ b/sympy/utilities/tests/test_codegen_octave.py
@@ -207,7 +207,7 @@ def test_m_output_arg_mixed_unordered():
 
 
 def test_m_piecewise_():
-    pw = Piecewise((0, x < -1), (x**2, x <= 1), (-x+2, x > 1), (1, True))
+    pw = Piecewise((0, x < -1), (x**2, x <= 1), (-x+2, x > 1), (1, True), evaluate=False)
     name_expr = ("pwtest", pw)
     result, = codegen(name_expr, "Octave", header=False, empty=False)
     source = result[1]

--- a/sympy/utilities/tests/test_codegen_rust.py
+++ b/sympy/utilities/tests/test_codegen_rust.py
@@ -226,7 +226,7 @@ def test_output_arg_mixed_unordered():
 
 
 def test_piecewise_():
-    pw = Piecewise((0, x < -1), (x**2, x <= 1), (-x+2, x > 1), (1, True))
+    pw = Piecewise((0, x < -1), (x**2, x <= 1), (-x+2, x > 1), (1, True), evaluate=False)
     name_expr = ("pwtest", pw)
     result, = codegen(name_expr, "Rust", header=False, empty=False)
     source = result[1]

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -14,7 +14,7 @@ from sympy import (Rational, symbols, Dummy, factorial, sqrt, log, exp, oo, zoo,
     im, DiracDelta, chebyshevt, legendre_poly, polylog, series, O,
     atan, sinh, cosh, tanh, floor, ceiling, solve, asinh, acot, csc, sec,
     LambertW, N, apart, sqrtdenest, factorial2, powdenest, Mul, S, ZZ,
-    Poly, expand_func, E, Q, And, Or, Ne, Eq, Le, Lt,
+    Poly, expand_func, E, Q, And, Or, Ne, Eq, Le, Lt, Min,
     ask, refine, AlgebraicNumber, continued_fraction_iterator as cf_i,
     continued_fraction_periodic as cf_p, continued_fraction_convergents as cf_c,
     continued_fraction_reduce as cf_r, FiniteSet, elliptic_e, elliptic_f,
@@ -2307,8 +2307,8 @@ def test_V1():
 
 
 def test_V2():
-    assert (integrate(Piecewise((-x, x < 0), (x, x >= 0)), x) ==
-            Piecewise((-x**2/2, x < 0), (x**2/2, x >= 0)))
+    assert integrate(Piecewise((-x, x < 0), (x, x >= 0)), x
+        ) == Piecewise((-x**2/2, x < 0), (x**2/2, True))
 
 
 def test_V3():
@@ -2570,10 +2570,9 @@ def test_W21():
 def test_W22():
     t, u = symbols('t u', real=True)
     s = Lambda(x, Piecewise((1, And(x >= 1, x <= 2)), (0, True)))
-    assert (integrate(s(t)*cos(t), (t, 0, u)) ==
-            Piecewise((sin(u) - sin(1), And(u <= 2, u >= 1)),
-                      (0, And(u <= 1, u >= -oo)),
-                      (-sin(1) + sin(2), True)))
+    assert integrate(s(t)*cos(t), (t, 0, u)) == Piecewise(
+        (-sin(Min(1, u)) + sin(Min(2, u)), u > 0),
+        (0, True))
 
 
 @XFAIL


### PR DESCRIPTION
Piecewise changes
-  integration hints are passed along during piecewise integration
-  indefinite integration now returns a continuous result; the old result (integration of pieces) is now called by method `piecewise_integrate`
- _sort_expr_cond has been removed and replaced with _abe which gives unsorted intervals and expressions generated by the Piecewise function; there is not a 1:1 correspondence between the items returned and the Piecewise arguments; the errors associated with encountering unexpected logical functions has been reduced

- [x] check to see that the collapse-code is covered by the added tests
- [x] check to see which of these are still valid with the minimal changes now
- [x] cf https://groups.google.com/forum/#!topic/sympy/_F2FzA0CYZw

closes #11045
closes #12221
closes #7305
closes #12674 
closes #11922 
closes #10137
closes #5227
closes #12557 
closes #6900
closes #10122
closes #4313
closes #9885
closes #12976

- [x] fix piecewise_fold to maintain arg order for arbitrary args by using cartes on the piecwise args or (a, True) for non-piecewise args
- [x] leave instantiation simple wrt filtering out duplicates and let that be handled by `smooth` otherwise if a `not(c)` is seen in or_seen, that is a redundant condition, too, e.g. `(1,x>0),(2,And(x<=0,x>-1)) -> (1,x>0),(2,x>-1)`
- [x] add tests from #8919
- [x] check that pw defined over range of integration but with no default value works
- [x] when this is committed, make a note [here](http://stackoverflow.com/questions/43852159/wrong-result-when-integrating-piecewise-function-in-sympy/43854090#43854090) because that integral gives the correct answer now.
- [x] make sure that new `piecewise_integrate` and `_eval_integral` are ok without deprecation
- [x] ~~name `_handle_irel` as `piecewise_unfold(x)`? Or can this function be removed by making `abe` emit (a, b, e, aux_conditions)?~~
- [x] replace `_sort_expr_cond` with a more robust integrator of piecewise functions; this is currently being tested.
- [x] break out `_msp`
- [x] break out `piecewise_fold` since this is a small (vital) part that is easy to stand separately
- [x] unify holes handling:
```
>>> Piecewise((a,Eq(1,x)),(b,And(x>0,x<3))).integrate((x,a,b))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\core\expr.py", line 3082, in integrate
    return integrate(self, *args, **kwargs)
  File "sympy\integrals\integrals.py", line 1311, in integrate
    risch=risch, manual=manual)
  File "sympy\integrals\integrals.py", line 569, in doit
    evalued = Add(*others)._eval_interval(x, a, b)
  File "sympy\functions\elementary\piecewise.py", line 537, in _eval_interval
    raise ValueError("Can't integrate across undefined region.")
ValueError: Can't integrate across undefined region.
>>> Piecewise((a,Eq(1,x)),(b,And(x>0,x<3))).integrate(x)
nan

Results and the range in which they are valid could be given 
instead of nan, but perhaps an error as in the definite case 
would be better for the indefinite case instead of `nan`.

But in this case we get a partial answer because the integral is defined for x > -oo
up to 2:

>>> Piecewise((1, x < 2)).integrate(x)
Piecewise((x, x < 2), (nan, True))

```
- [x] is it necessary to allow for lists to be expressions in Piecewise to be consistent with solve  output? 
A: they can already be args in master. Only the _subs method had to be modified to deal with them.
```
in master

>>> Piecewise(([1,2,3],x>1))
Piecewise(([1, 2, 3], x > 1))
>>> _.subs(x,2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\core\basic.py", line 915, in subs
    rv = rv._subs(old, new, **kwargs)
  File "sympy\core\cache.py", line 93, in wrapper
    retval = cfunc(*args, **kwargs)
  File "sympy\core\compatibility.py", line 794, in wrapper
    return user_function(*args, **kwds)
  File "sympy\core\basic.py", line 1027, in _subs
    rv = self._eval_subs(old, new)
  File "sympy\functions\elementary\piecewise.py", line 455, in _eval_subs
    e = e._subs(old, new)
AttributeError: 'list' object has no attribute '_subs'
```
- [x] check to see that this was tested
- [x] make Relational.canonical simpler
- [x] find out why test_transforms.py line 300 and 473 are failing
- [x] make sorting of roots a different PR
- [x] separate out Piecewise handling for solve and make new PR; don't allow list as an arg in Piecewise [recall this conversation](https://github.com/sympy/sympy/pull/12920#discussion_r126713297)
- [x] debug tests at and below the following
test_piecewise.py", line 671, in test_issue_11045
test_transforms.py", line 530, in test_issue_8368_7173
test_transforms.py", line 468, in test_laplace_transform

- [x] check on solving of integral in #13140
- [x] check if ` lower, upper = lower, Max(lower, upper) ` should be `...= Min(lower, upper), Max...`.
    A: no, it fails then
- [x] change abei to intervals?
- [x] if `rv.rel_op == '!=':  rv = Or(sym < rv.rhs, sym > rv.rhs)` will fail if rhs is `I`; perhaps `sym<oo` should be used instead
- [x] extract the inequalities modifications and the formal power series modification
- [x] try to extract the changes to integrals.py
- [x] get rid of C3 in test_ode in the line `x, y, z, C3 = symbols('x, y, z, C3', function=True)`

~~- [ ] break out the Piecewise.eval changes~~