### PR TITLE
Added Semi-Latus Rectum to Ellipse module

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -942,38 +942,38 @@ class Ellipse(GeometrySet):
     @property
     def semilatus_rectum(self):
         """
-        Calculates the semi-latus rectum of the Ellipse. 
-        
-        Semi-latus rectum is defined as one half of the the chord through a 
+        Calculates the semi-latus rectum of the Ellipse.
+
+        Semi-latus rectum is defined as one half of the the chord through a
         focus parallel to the conic section directrix of a conic section.
-        
+
         Returns
         =======
-        
+
         semilatus_rectum : number
-        
+
         See Also
         ========
-        
+
         apoapsis : Returns greatest distance between focus and contour
-        
+
         periapsis : The shortest distance between the focus and the contour
-        
+
         Examples
         ========
-        
+
         >>> from sympy import Point, Ellipse
         >>> p1 = Point(0, 0)
         >>> e1 = Ellipse(p1, 3, 1)
         >>> e1.semilatus_rectum()
         1/3
-        
+
         References
         ==========
-        
+
         [1] http://mathworld.wolfram.com/SemilatusRectum.html
         [2] https://en.wikipedia.org/wiki/Ellipse#Semi-latus_rectum
-        
+
         """
         return self.major * (1 - self.eccentricity ** 2)
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -965,7 +965,7 @@ class Ellipse(GeometrySet):
         >>> from sympy import Point, Ellipse
         >>> p1 = Point(0, 0)
         >>> e1 = Ellipse(p1, 3, 1)
-        >>> e1.semilatus_rectum()
+        >>> e1.semilatus_rectum
         1/3
 
         References

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -938,6 +938,46 @@ class Ellipse(GeometrySet):
         """
         return self.major * (1 - self.eccentricity)
 
+
+    @property
+    def semilatus_rectum(self):
+        """
+        Calculates the semi-latus rectum of the Ellipse. 
+        
+        Semi-latus rectum is defined as one half of the the chord through a 
+        focus parallel to the conic section directrix of a conic section.
+        
+        Returns
+        =======
+        
+        semilatus_rectum : number
+        
+        See Also
+        ========
+        
+        apoapsis : Returns greatest distance between focus and contour
+        
+        periapsis : The shortest distance between the focus and the contour
+        
+        Examples
+        ========
+        
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.semilatus_rectum()
+        1/3
+        
+        References
+        ==========
+        
+        [1] http://mathworld.wolfram.com/SemilatusRectum.html
+        [2] https://en.wikipedia.org/wiki/Ellipse#Semi-latus_rectum
+        
+        """
+        return self.major * (1 - self.eccentricity ** 2)
+
+
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the Ellipse.
 

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -166,6 +166,7 @@ def test_ellipse_geom():
     assert e4.eccentricity == ecc
     assert e4.periapsis == major*(1 - ecc)
     assert e4.apoapsis == major*(1 + ecc)
+    assert e4.semilatus_rectum == major*(1 - ecc ** 2)
     # independent of orientation
     e4 = Ellipse(p2, major, minor)
     assert e4.focus_distance == sqrt(major**2 - minor**2)


### PR DESCRIPTION
Hi. 

Looks like Ellipse module was missing a semi-latus rectum property, which is half of the length of chord through a focus parallel to the conic section directrix of a conic section. 

Reference: http://mathworld.wolfram.com/SemilatusRectum.html

Unit tests ran locally - all green. 


