### PR TITLE
Enabled linsolve to solve for `Functions`

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -12,10 +12,9 @@ from __future__ import print_function, division
 from sympy.core.sympify import sympify
 from sympy.core import S, Pow, Dummy, pi, Expr, Wild, Mul, Equality
 from sympy.core.numbers import I, Number, Rational, oo
-from sympy.core.function import (Lambda, expand, expand_complex)
+from sympy.core.function import (Lambda, expand_complex)
 from sympy.core.relational import Eq
 from sympy.simplify.simplify import simplify, fraction, trigsimp
-from sympy.core.symbol import Symbol
 from sympy.functions import (log, Abs, tan, cot, sin, cos, sec, csc, exp,
                              acos, asin, acsc, asec, arg,
                              piecewise_fold)
@@ -1274,7 +1273,7 @@ def linsolve(system, *symbols):
         symbols = symbols[0]
 
     try:
-        sym = symbols[0].is_Symbol
+        sym = symbols[0].is_Symbol or symbols[0].is_Function
     except AttributeError:
         sym = False
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1048,6 +1048,9 @@ def test_linsolve():
     Augmatrix = Matrix([[0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0]])
     assert linsolve(Augmatrix, a, b, c, d, e) == FiniteSet((a, 0, c, 0, e))
 
+    # Issue #12604
+    f = Function('f')
+    assert linsolve([f(x) - 5], f(x)) == FiniteSet((5,))
 
 def test_solve_decomposition():
     x = Symbol('x')


### PR DESCRIPTION
#12604 

### Output before this PR:
``` python
>>> from sympy import *
>>> a = Function('a')
>>> b = Function('b')
>>> t = Symbol('t')
>>> linsolve([a(t) + b(t) - 5], a(t))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/parsoyaarihant/sympy/sympy/solvers/solveset.py", line 1283, in linsolve
    'second argument, not type %s: %s' % (type(symbols[0]), symbols[0]))
ValueError: Symbols or iterable of symbols must be given as second argument, not type a: a(t)
```

### Output after this PR:
```python
>>> linsolve([a(t) + b(t) - 5], a(t))
{(-b(t) + 5,)}
```

* Tests are added
* Removed unused functions from solveset.py (line 15, 18).
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->