### PR TITLE
Add support for more than two operands in numpy logical and/or representations.

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -321,14 +321,14 @@ class NumPyPrinter(PythonCodePrinter):
         # We have to override LambdaPrinter because it uses Python 'and' keyword.
         # If LambdaPrinter didn't define it, we could use StrPrinter's
         # version of the function and add 'logical_and' to NUMPY_TRANSLATIONS.
-        return '{0}({1})'.format(self._module_format('numpy.logical_and'), ','.join(self._print(i) for i in expr.args))
+        return '{0}.reduce(({1}))'.format(self._module_format('numpy.logical_and'), ','.join(self._print(i) for i in expr.args))
 
     def _print_Or(self, expr):
         "Logical Or printer"
         # We have to override LambdaPrinter because it uses Python 'or' keyword.
         # If LambdaPrinter didn't define it, we could use StrPrinter's
         # version of the function and add 'logical_or' to NUMPY_TRANSLATIONS.
-        return '{0}({1})'.format(self._module_format('numpy.logical_or'), ','.join(self._print(i) for i in expr.args))
+        return '{0}.reduce(({1}))'.format(self._module_format('numpy.logical_or'), ','.join(self._print(i) for i in expr.args))
 
     def _print_Not(self, expr):
         "Logical Not printer"

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -433,12 +433,17 @@ def test_numpy_logical_ops():
     if not numpy:
         skip("numpy not installed.")
     and_func = lambdify((x, y), And(x, y), modules="numpy")
+    and_func_3 = lambdify((x, y, z), And(x, y, z), modules="numpy")
     or_func = lambdify((x, y), Or(x, y), modules="numpy")
+    or_func_3 = lambdify((x, y, z), Or(x, y, z), modules="numpy")
     not_func = lambdify((x), Not(x), modules="numpy")
     arr1 = numpy.array([True, True])
     arr2 = numpy.array([False, True])
+    arr3 = numpy.array([True, False])
     numpy.testing.assert_array_equal(and_func(arr1, arr2), numpy.array([False, True]))
+    numpy.testing.assert_array_equal(and_func_3(arr1, arr2, arr3), numpy.array([False, False]))
     numpy.testing.assert_array_equal(or_func(arr1, arr2), numpy.array([True, True]))
+    numpy.testing.assert_array_equal(or_func_3(arr1, arr2, arr3), numpy.array([True, True]))
     numpy.testing.assert_array_equal(not_func(arr2), numpy.array([True, False]))
 
 def test_numpy_matmul():


### PR DESCRIPTION
Currently when using `numpy` modules in `lambdify`, `Or` expressions with more than two operands fail (since `numpy.logical_or` and `numpy.logical_and` only take two logical operands). This patch adds support for arbitrary number of operand larger than (or equal to) two.