### PR TITLE
Fix for formatting of :noindex: in gotchas.rst and rewriting.rst

### DIFF
--- a/doc/src/gotchas.rst
+++ b/doc/src/gotchas.rst
@@ -755,7 +755,8 @@ These will give you the function parameters and docstring for
 :func:`powsimp`.  The output will look something like this:
 
 .. module:: sympy.simplify.simplify
-.. autofunction:noindex: powsimp
+.. autofunction:: powsimp
+   :noindex:
 
 source()
 --------

--- a/doc/src/modules/rewriting.rst
+++ b/doc/src/modules/rewriting.rst
@@ -99,4 +99,5 @@ will be greatly improved.
 
 More information:
 
-.. autofunction:noindex: cse
+.. autofunction:: cse
+   :noindex:


### PR DESCRIPTION
Attempt to fix issue regarding missing text in documentation
I'm just getting started with open source contributing, hopefully this is correct.
fixes #12425  