### PR TITLE
kinematic_equations returns zero when speeds is zero

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -621,13 +621,16 @@ class ReferenceFrame(object):
                 from sympy.physics.vector.functions import kinematic_equations
                 q1, q2, q3 = amounts
                 u1, u2, u3 = symbols('u1, u2, u3', cls=Dummy)
-                templist = kinematic_equations([u1, u2, u3], [q1, q2, q3],
-                                               rot_type, rot_order)
-                templist = [expand(i) for i in templist]
-                td = solve(templist, [u1, u2, u3])
-                u1 = expand(td[u1])
-                u2 = expand(td[u2])
-                u3 = expand(td[u3])
+                if all(i.is_number for i in [q1, q2, q3]):
+                    u1, u2, u3 = [0, 0, 0]
+                else:
+                    templist = kinematic_equations([u1, u2, u3], [q1, q2, q3],
+                                                   rot_type, rot_order)
+                    templist = [expand(i) for i in templist]
+                    td = solve(templist, [u1, u2, u3])
+                    u1 = expand(td[u1])
+                    u2 = expand(td[u2])
+                    u3 = expand(td[u3])
                 wvec = u1 * self.x + u2 * self.y + u3 * self.z
             except (CoercionFailed, AssertionError):
                 wvec = self._w_diff_dcm(parent)

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -621,9 +621,11 @@ class ReferenceFrame(object):
                 from sympy.physics.vector.functions import kinematic_equations
                 q1, q2, q3 = amounts
                 u1, u2, u3 = symbols('u1, u2, u3', cls=Dummy)
-                if all(i.is_number for i in [q1, q2, q3]):
+                t = dynamicsymbols._t
+                if all(i.is_constant(t) for i in [q1, q2, q3]):
                     u1, u2, u3 = [0, 0, 0]
                 else:
+                    u1, u2, u3 = symbols('u1 u2 u3', cls=Dummy)
                     templist = kinematic_equations([u1, u2, u3], [q1, q2, q3],
                                                    rot_type, rot_order)
                     templist = [expand(i) for i in templist]

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -274,6 +274,8 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
             raise ValueError('Not an acceptable rotation order')
         if len(coords) != 3:
             raise ValueError('Need 3 coordinates for body or space')
+        if speeds == (0,0,0):
+            return [0,0,0]
         # Actual hard-coded kinematic differential equations
         q1, q2, q3 = coords
         q1d, q2d, q3d = [diff(i, dynamicsymbols._t) for i in coords]

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -123,6 +123,9 @@ def test_ang_vel():
     assert G.ang_vel_in(N) == q1d * (N.x + N.y).normalize()
     assert N.ang_vel_in(G) == -q1d * (N.x + N.y).normalize()
 
+    # #12600
+    H = N.orientnew('H', 'body', (pi, pi / 2, 0), '132')
+    assert H.ang_vel_in(N) == 0
 
 def test_dcm():
     q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')

--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -440,6 +440,8 @@ def test_kin_eqs():
             -0.5 * q0 * u2 + 0.5 * q1 * u3 - 0.5 * q3 * u1 + q2d,
             -0.5 * q0 * u3 - 0.5 * q1 * u2 + 0.5 * q2 * u1 + q3d,
             0.5 * q1 * u1 + 0.5 * q2 * u2 + 0.5 * q3 * u3 + q0d]
+    assert kinematic_equations((0, 0, 0), (pi, pi / 2, 0), 'body', '132') == \
+            [0,0,0]
 
 
 def test_partial_velocity():


### PR DESCRIPTION
Fixes #12600. 

### Outpur before this PR:
``` python
>>> import sympy as sm
>>> import sympy.physics.mechanics as me
>>> N = me.ReferenceFrame('N')
>>> me.kinematic_equations((0, 0, 0), (sm.pi, sm.pi / 2, 0), 'body', '132')
[nan, 0, nan]
>>> A = N.orientnew('A', 'body', (sm.pi, sm.pi / 2, 0), '132')
>>> A.ang_vel_in(N)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/parsoyaarihant/sympy/sympy/physics/vector/vector.py", line 361, in __str__
    if ar[i][0][j] == 1:
TypeError: 'NaN' object does not support indexing
```

### Output after this PR:
``` python
>>> import sympy as sm
>>> import sympy.physics.mechanics as me
>>> N = me.ReferenceFrame('N')
>>> me.kinematic_equations((0, 0, 0), (sm.pi, sm.pi / 2, 0), 'body', '132')
[0, 0, 0]
>>> A = N.orientnew('A', 'body', (sm.pi, sm.pi / 2, 0), '132')
>>> A.ang_vel_in(N)
0
```

* Tests are added.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->