### PR TITLE
Don't show cmd.exe windows on all check_output calls of printing/preview.py

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -243,7 +243,14 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                 raise SystemError("Invalid output format: %s" % output)
 
             try:
-                check_output(cmd, cwd=workdir, stderr=STDOUT)
+                # Avoid showing a cmd.exe window when running this
+                # on Windows
+                if os.name == 'nt':
+                    creation_flag = 0x08000000 # CREATE_NO_WINDOW
+                else:
+                    creation_flag = 0 # Default value
+                check_output(cmd, cwd=workdir, stderr=STDOUT,
+                             creationflags=creation_flag)
             except CalledProcessError as e:
                 raise RuntimeError(
                     "'%s' exited abnormally with the following output:\n%s" %
@@ -320,7 +327,14 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             win.close()
         else:
             try:
-                check_output([viewer, src], cwd=workdir, stderr=STDOUT)
+                # Avoid showing a cmd.exe window when running this
+                # on Windows
+                if os.name == 'nt':
+                    creation_flag = 0x08000000 # CREATE_NO_WINDOW
+                else:
+                    creation_flag = 0 # Default value
+                check_output([viewer, src], cwd=workdir, stderr=STDOUT,
+                             creationflags=creation_flag)
             except CalledProcessError as e:
                 raise RuntimeError(
                     "'%s %s' exited abnormally with the following output:\n%s" %


### PR DESCRIPTION
This completes the work started in PR #12391.