### PR TITLE
modify Piecewise's otherwise entry/printing

### DIFF
--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -274,9 +274,9 @@ def deltasummation(f, limit, no_piecewise=False):
     >>> deltasummation(KroneckerDelta(i, k), (k, -oo, oo))
     1
     >>> deltasummation(KroneckerDelta(i, k), (k, 0, oo))
-    Piecewise((1, 0 <= i), (0, True))
+    Piecewise((1, 0 <= i), 0)
     >>> deltasummation(KroneckerDelta(i, k), (k, 1, 3))
-    Piecewise((1, (1 <= i) & (i <= 3)), (0, True))
+    Piecewise((1, (1 <= i) & (i <= 3)), 0)
     >>> deltasummation(k*KroneckerDelta(i, j)*KroneckerDelta(j, k), (k, -oo, oo))
     j*KroneckerDelta(i, j)
     >>> deltasummation(j*KroneckerDelta(i, j), (j, -oo, oo))

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -89,7 +89,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
     >>> Sum(x**k, (k, 0, oo))
     Sum(x**k, (k, 0, oo))
     >>> Sum(x**k, (k, 0, oo)).doit()
-    Piecewise((1/(-x + 1), Abs(x) < 1), (Sum(x**k, (k, 0, oo)), True))
+    Piecewise((1/(-x + 1), Abs(x) < 1), Sum(x**k, (k, 0, oo)))
     >>> Sum(x**k/factorial(k), (k, 0, oo)).doit()
     exp(x)
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -91,6 +91,16 @@ class Piecewise(Function):
 
     def __new__(cls, *args, **options):
         # (Try to) sympify args first
+        default = options.pop('default', None)
+        if args and not isinstance(args[-1], (ExprCondPair, tuple, Tuple)):
+            # rewrite existing
+            args = args[:-1] + ((args[-1], true),)
+        if default is not None:
+            if args and args[-1][1] == True:
+                # given one replaces existing one
+                args = args[:-1] + ((default, true),)
+            else:
+                args = args + ((default, true),)
         newargs = []
         for ec in args:
             # ec could be a ExprCondPair or a tuple
@@ -115,6 +125,26 @@ class Piecewise(Function):
             return Basic.__new__(cls, *newargs, **options)
         else:
             return r
+
+    @property
+    def ec(self):
+        """
+        Returns the ExprCondPairs excluding the last one if it has
+        a condition that is true. (The default expression can
+        be obtained with the `default` property.)
+        """
+        rv = self.args
+        if rv and rv[-1].cond is S.true:
+            return rv[:-1]
+        return rv
+
+    @property
+    def default(self):
+        """
+        Returns the default expression.
+        """
+        if self.args and self.args[-1].cond is S.true:
+            return self.args[-1].expr
 
     @classmethod
     def eval(cls, *args):

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -4,6 +4,7 @@ from sympy import (
     Piecewise, piecewise_fold, Rational, solve, symbols, transpose,
     cos, exp, Abs, Not, Symbol, S
 )
+from sympy.functions.elementary.piecewise import ExprCondPair
 from sympy.printing import srepr
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -501,36 +502,7 @@ def test_as_expr_set_pairs():
         [((x - 2)**2, Interval(0, oo)), (0, Interval(-oo, 0, True, True))]
 
 
-@XFAIL
 def test_S_srepr_is_identity():
-    # this fails as follows:
-    '''
-    >>> from sympy.utilities.misc import filldedent
-    >>> p = Piecewise((10, Eq(x, 0)), (12, True))
-    >>> s = srepr(p)
-    >>> print(filldedent(s))
-
-    Piecewise(ExprCondPair(Integer(10), Equality(Symbol('x'),
-    Integer(0))), ExprCondPair(Integer(12), S.true))
-    >>> S(s)
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-      File "sympy\core\basic.py", line 398, in __repr__
-        return sstr(self, order=None)
-      File "sympy\printing\str.py", line 790, in sstr
-        p = StrPrinter(settings)
-      File "sympy\printing\printer.py", line 233, in doprint
-        return self._str(self._print(expr))
-      File "sympy\printing\printer.py", line 257, in _print
-        return getattr(self, printmethod)(expr, *args, **kwargs)
-      File "sympy\printing\str.py", line 145, in _print_Piecewise
-        for a in expr.ec + (() if expr.default is None else
-      File "sympy\printing\printer.py", line 257, in _print
-        return getattr(self, printmethod)(expr, *args, **kwargs)
-      File "sympy\printing\str.py", line 141, in _print_ExprCondPair
-        return '(%s, %s)' % (expr.expr, expr.cond)
-    AttributeError: 'ExprCondPair' object has no attribute 'expr'
-    '''
     p = Piecewise((10, Eq(x, 0)), (12, True))
-    q = S(srepr(p))
+    q = S(srepr(p), locals={'ExprCondPair': ExprCondPair})
     assert p == q

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -43,7 +43,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 0
         >>> knots = range(5)
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((1, (x >= 0) & (x <= 1)), (0, True))
+        Piecewise((1, (x >= 0) & (x <= 1)), 0)
 
     For a given ``(d, knots)`` there are ``len(knots)-d-1`` B-splines defined, that
     are indexed by ``n`` (starting at 0).
@@ -58,7 +58,7 @@ def bspline_basis(d, knots, n, x, close=True):
                   (x >= 2) & (x < 3)),
                   (-x**3/6 + 2*x**2 - 8*x + 32/3,
                   (x >= 3) & (x <= 4)),
-                  (0, True))
+                  0)
 
     By repeating knot points, you can introduce discontinuities in the
     B-splines and their derivatives:
@@ -66,7 +66,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 1
         >>> knots = [0,0,2,3,4]
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((-x/2 + 1, (x >= 0) & (x <= 2)), (0, True))
+        Piecewise((-x/2 + 1, (x >= 0) & (x <= 2)), 0)
 
     It is quite time consuming to construct and evaluate B-splines. If you
     need to evaluate a B-splines many times, it is best to lambdify them
@@ -144,11 +144,11 @@ def bspline_basis_set(d, knots, x):
     [Piecewise((x**2/2, (x >= 0) & (x < 1)),
                (-x**2 + 3*x - 3/2, (x >= 1) & (x < 2)),
                (x**2/2 - 3*x + 9/2, (x >= 2) & (x <= 3)),
-               (0, True)),
+               0),
     Piecewise((x**2/2 - x + 1/2, (x >= 1) & (x < 2)),
               (-x**2 + 5*x - 11/2, (x >= 2) & (x < 3)),
               (x**2/2 - 4*x + 8, (x >= 3) & (x <= 4)),
-              (0, True))]
+              0)]
 
     See Also
     ========

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -313,13 +313,13 @@ class DiracDelta(Function):
            >>> x = Symbol('x')
 
            >>> DiracDelta(x).rewrite(Piecewise)
-           Piecewise((DiracDelta(0), Eq(x, 0)), (0, True))
+           Piecewise((DiracDelta(0), Eq(x, 0)), 0)
 
            >>> DiracDelta(x - 5).rewrite(Piecewise)
-           Piecewise((DiracDelta(0), Eq(x - 5, 0)), (0, True))
+           Piecewise((DiracDelta(0), Eq(x - 5, 0)), 0)
 
            >>> DiracDelta(x**2 - 5).rewrite(Piecewise)
-           Piecewise((DiracDelta(0), Eq(x**2 - 5, 0)), (0, True))
+           Piecewise((DiracDelta(0), Eq(x**2 - 5, 0)), 0)
 
            >>> DiracDelta(x - 5, 4).rewrite(Piecewise)
            DiracDelta(x - 5, 4)

--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -51,7 +51,7 @@ class SingularityFunction(Function):
     >>> diff(SingularityFunction(x, 4, 0), x, 2)
     SingularityFunction(x, 4, -2)
     >>> SingularityFunction(x, 4, 5).rewrite(Piecewise)
-    Piecewise(((x - 4)**5, x - 4 > 0), (0, True))
+    Piecewise(((x - 4)**5, x - 4 > 0), 0)
     >>> expr = SingularityFunction(x, a, n)
     >>> y = Symbol('y', positive=True)
     >>> n = Symbol('n', nonnegative=True)

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -114,7 +114,7 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     >>> heurisch(cos(n*x), x)
     sin(n*x)/n
     >>> heurisch_wrapper(cos(n*x), x)
-    Piecewise((x, Eq(n, 0)), (sin(n*x)/n, True))
+    Piecewise((x, Eq(n, 0)), sin(n*x)/n)
 
     See Also
     ========

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -361,7 +361,7 @@ class Integral(AddWithLimits):
         >>> from sympy import Integral
         >>> from sympy.abc import x, i
         >>> Integral(x**i, (i, 1, 3)).doit()
-        Piecewise((2, Eq(log(x), 0)), (x**3/log(x) - x/log(x), True))
+        Piecewise((2, Eq(log(x), 0)), x**3/log(x) - x/log(x))
 
         See Also
         ========
@@ -1270,7 +1270,7 @@ def integrate(*args, **kwargs):
 
     >>> integrate(x**a*exp(-x), (x, 0, oo)) # same as conds='piecewise'
     Piecewise((gamma(a + 1), -re(a) < 1),
-        (Integral(x**a*exp(-x), (x, 0, oo)), True))
+        Integral(x**a*exp(-x), (x, 0, oo)))
 
     >>> integrate(x**a*exp(-x), (x, 0, oo), conds='none')
     gamma(a + 1)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -288,7 +288,7 @@ def test_matrixelement_diff():
     assert w[k, p].diff(w[k, p]) == 1
     assert w[k, p].diff(w[0, 0]) == KroneckerDelta(0, k)*KroneckerDelta(0, p)
     assert str(dexpr) == "Sum(KroneckerDelta(_k, p)*D[k, _k], (_k, 0, n - 1))"
-    assert str(dexpr.doit()) == 'Piecewise((D[k, p], (0 <= p) & (p <= n - 1)), (0, True))'
+    assert str(dexpr.doit()) == 'Piecewise((D[k, p], (0 <= p) & (p <= n - 1)), 0)'
 
 
 def test_MatrixElement_with_values():

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -62,9 +62,7 @@ class Beam(object):
     >>> b.deflection()
     (7*x - SingularityFunction(x, 0, 3)/2 + SingularityFunction(x, 2, 4)/4 - 3*SingularityFunction(x, 4, 3)/2)/(E*I)
     >>> b.deflection().rewrite(Piecewise)
-    (7*x - Piecewise((x**3, x > 0), (0, True))/2
-         - 3*Piecewise(((x - 4)**3, x - 4 > 0), (0, True))/2
-         + Piecewise(((x - 2)**4, x - 2 > 0), (0, True))/4)/(E*I)
+    (7*x - Piecewise((x**3, x > 0), 0)/2 - 3*Piecewise(((x - 4)**3, x - 4 > 0), 0)/2 + Piecewise(((x - 2)**4, x - 2 > 0), 0)/4)/(E*I)
     """
 
     def __init__(self, length, elastic_modulus, second_moment, variable=Symbol('x')):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -644,7 +644,7 @@ class Wavefunction(Function):
         >>> x = Symbol('x', real=True)
         >>> n = 1
         >>> L = 1
-        >>> g = Piecewise((0, x < 0), (0, x > L), (sqrt(2//L)*sin(n*pi*x/L), True))
+        >>> g = Piecewise((0, x < 0), (0, x > L), sqrt(2//L)*sin(n*pi*x/L))
         >>> f = Wavefunction(g, x)
         >>> f.norm
         1

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -75,7 +75,7 @@ class StrPrinter(Printer):
         return "False"
 
     def _print_Not(self, expr):
-        return '~%s' %(self.parenthesize(expr.args[0],PRECEDENCE["Not"]))
+        return '~%s' % (self.parenthesize(expr.args[0],PRECEDENCE["Not"]))
 
     def _print_And(self, expr):
         return self.stringify(expr.args, " & ", PRECEDENCE["BitwiseAnd"])
@@ -139,6 +139,11 @@ class StrPrinter(Printer):
 
     def _print_ExprCondPair(self, expr):
         return '(%s, %s)' % (expr.expr, expr.cond)
+
+    def _print_Piecewise(self, expr):
+        return 'Piecewise(%s)' % ', '.join([self._print(a)
+            for a in expr.ec + (() if expr.default is None else
+            (expr.default,))])
 
     def _print_FiniteSet(self, s):
         s = sorted(s, key=default_sort_key)
@@ -237,7 +242,7 @@ class StrPrinter(Printer):
         _print_MatrixBase
 
     def _print_MatrixElement(self, expr):
-        return self._print(expr.parent) + '[%s, %s]'%(expr.i, expr.j)
+        return self._print(expr.parent) + '[%s, %s]' % (expr.i, expr.j)
 
     def _print_MatrixSlice(self, expr):
         def strslice(x):
@@ -698,7 +703,7 @@ class StrPrinter(Printer):
         return "Uniform(%s, %s)" % (expr.a, expr.b)
 
     def _print_Union(self, expr):
-        return 'Union(%s)' %(', '.join([self._print(a) for a in expr.args]))
+        return 'Union(%s)' % (', '.join([self._print(a) for a in expr.args]))
 
     def _print_Complement(self, expr):
         return ' \ '.join(self._print(set) for set in expr.args)
@@ -766,7 +771,6 @@ class StrPrinter(Printer):
     def _print_Tr(self, expr):
         #TODO : Handle indices
         return "%s(%s)" % ("Tr", self._print(expr.args[0]))
-
 
 def sstr(expr, **settings):
     """Returns the expression as a string.

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -489,11 +489,11 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
     >>> from sympy.abc import x, k
 
     >>> rh(exp(x), x, -S.One, (k + 1), k, 1)
-    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), (0, True)), 1, 1)
+    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), 0), 1, 1)
+**********************************************************************
 
     >>> rh(ln(1 + x), x, k**2, k*(k + 1), k, 1)
-    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
-     Eq(Mod(k, 1), 0)), (0, True)), x, 2)
+    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)), 0), x, 2)
 
     References
     ==========
@@ -672,11 +672,11 @@ def solve_de(f, x, DE, order, g, k):
     >>> from sympy.abc import x, k, f
 
     >>> solve_de(exp(x), x, D(f(x), x) - f(x), 1, f, k)
-    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), (0, True)), 1, 1)
+    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), 0), 1, 1)
+**********************************************************************
 
     >>> solve_de(ln(1 + x), x, (x + 1)*D(f(x), x, 2) + D(f(x)), 2, f, k)
-    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
-     Eq(Mod(k, 1), 0)), (0, True)), x, 2)
+    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)), 0), x, 2)
     """
     sol = None
     syms = DE.free_symbols.difference({g, x})
@@ -717,11 +717,11 @@ def hyper_algorithm(f, x, k, order=4):
     >>> from sympy.abc import x, k
 
     >>> hyper_algorithm(exp(x), x, k)
-    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), (0, True)), 1, 1)
+    (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), 0), 1, 1)
+**********************************************************************
 
     >>> hyper_algorithm(ln(1 + x), x, k)
-    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
-     Eq(Mod(k, 1), 0)), (0, True)), x, 2)
+    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)), 0), x, 2)
 
     See Also
     ========

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -490,7 +490,6 @@ def rsolve_hypergeometric(f, x, P, Q, k, m):
 
     >>> rh(exp(x), x, -S.One, (k + 1), k, 1)
     (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), 0), 1, 1)
-**********************************************************************
 
     >>> rh(ln(1 + x), x, k**2, k*(k + 1), k, 1)
     (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)), 0), x, 2)
@@ -673,10 +672,10 @@ def solve_de(f, x, DE, order, g, k):
 
     >>> solve_de(exp(x), x, D(f(x), x) - f(x), 1, f, k)
     (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), 0), 1, 1)
-**********************************************************************
 
     >>> solve_de(ln(1 + x), x, (x + 1)*D(f(x), x, 2) + D(f(x)), 2, f, k)
-    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)), 0), x, 2)
+    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
+    Eq(Mod(k, 1), 0)), 0), x, 2)
     """
     sol = None
     syms = DE.free_symbols.difference({g, x})
@@ -718,10 +717,10 @@ def hyper_algorithm(f, x, k, order=4):
 
     >>> hyper_algorithm(exp(x), x, k)
     (Piecewise((1/factorial(k), Eq(Mod(k, 1), 0)), 0), 1, 1)
-**********************************************************************
 
     >>> hyper_algorithm(ln(1 + x), x, k)
-    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1), Eq(Mod(k, 1), 0)), 0), x, 2)
+    (Piecewise(((-1)**(k - 1)*factorial(k - 1)/RisingFactorial(2, k - 1),
+    Eq(Mod(k, 1), 0)), 0), x, 2)
 
     See Also
     ========

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -836,7 +836,7 @@ def Exponential(name, rate):
     lambda*exp(-lambda*z)
 
     >>> cdf(X)(z)
-    Piecewise((1 - exp(-lambda*z), z >= 0), (0, True))
+    Piecewise((1 - exp(-lambda*z), z >= 0), 0)
 
     >>> E(X)
     1/lambda
@@ -2392,7 +2392,7 @@ def Uniform(name, left, right):
     >>> X = Uniform("x", a, b)
 
     >>> density(X)(z)
-    Piecewise((1/(-a + b), (a <= z) & (z <= b)), (0, True))
+    Piecewise((1/(-a + b), (a <= z) & (z <= b)), 0)
 
     >>> cdf(X)(z)  # doctest: +SKIP
     -a/(-a + b) + z/(-a + b)


### PR DESCRIPTION
This is an alternative to #1009 
closes #1009 

It offers an alternative entry of the `otherwise` expression for a Piecewise. `args` is unchanged, however, and two new properties (name yet to be finalized) are added to access the args with conditions -- the ExprCondPairs -- and the one without.

```
>>> Piecewise((a, x < 0), b) == Piecewise((a, x < 0), (b, True)) == Piecewise((a, x < 0), default=b)
True
>>> Piecewise((a, x < 0), (b, True))
Piecewise((a, x < 0), b)
```