### PR TITLE
Add test for a case in prde_no_cancel_b_large

### DIFF
--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -294,9 +294,9 @@ def prde_no_cancel_b_large(b, Q, n, DE):
 
     Given a derivation D on k[t], n in ZZ, and b, q1, ..., qm in k[t] with
     b != 0 and either D == d/dt or deg(b) > max(0, deg(D) - 1), returns
-    h1, ..., hr in k[r] and a matrix A with coefficients in Const(k) such that
+    h1, ..., hr in k[t] and a matrix A with coefficients in Const(k) such that
     if c1, ..., cm in Const(k) and q in k[t] satisfy deg(q) <= n and
-    Dq + b*Q == Sum(ci*qi, (i, 1, m)), then q = Sum(dj*hj, (j, 1, r)), where
+    Dq + b*q == Sum(ci*qi, (i, 1, m)), then q = Sum(dj*hj, (j, 1, r)), where
     d1, ..., dr in Const(k) and A*Matrix([[c1, ..., cm, d1, ..., dr]]).T == 0.
     """
     db = b.degree(DE.t)
@@ -314,7 +314,7 @@ def prde_no_cancel_b_large(b, Q, n, DE):
         dc = -1
         M = zeros(0, 2)
     else:
-        dc = max([qi.degree(t) for qi in Q])
+        dc = max([qi.degree(DE.t) for qi in Q])
         M = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i))
     A, u = constant_system(M, zeros(dc + 1, 1), DE)
     c = eye(m)

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -105,6 +105,10 @@ def test_prde_no_cancel():
     assert prde_no_cancel_b_large(Poly(1, x), [Poly(x**3, x), Poly(1, x)], 3, DE) == \
         ([Poly(x**3 - 3*x**2 + 6*x - 6, x), Poly(1, x)], Matrix([[1, 0, -1, 0],
                                                                  [0, 1, 0, -1]]))
+    assert prde_no_cancel_b_large(Poly(x, x), [Poly(x**2, x), Poly(1, x)], 1, DE) == \
+        ([Poly(x, x, domain='ZZ'), Poly(0, x, domain='ZZ')], Matrix([[1, -1,  0,  0],
+                                                                    [1,  0, -1,  0],
+                                                                    [0,  1,  0, -1]]))
     # b small
     # XXX: Is there a better example of a monomial with D.degree() > 2?
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**3 + 1, t)]})


### PR DESCRIPTION
The added test case tests the [line number 317-318 in prde.py](https://github.com/sympy/sympy/blob/master/sympy/integrals/prde.py#L317-L318).
I have manually verified that the test case with given inputs, does give that output (following the algorithm given in the text book).

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
