### PR TITLE
Immutable Array hash corrections for Python 3

### DIFF
--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -403,6 +403,9 @@ class NDimArray(object):
 class ImmutableNDimArray(NDimArray, Basic):
     _op_priority = 11.0
 
+    def __hash__(self):
+        return Basic.__hash__(self)
+
 
 from sympy.core.numbers import Integer
 from sympy.core.sympify import sympify

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -355,3 +355,10 @@ def test_symbolic_indexing():
     raises(ValueError, lambda: Ms[i, -1])
     raises(ValueError, lambda: Ms[2, i])
     raises(ValueError, lambda: Ms[-1, i])
+
+
+def test_issue_12665():
+    # Testing Python 3 hash of immutable arrays:
+    arr = ImmutableDenseNDimArray([1, 2, 3])
+    # This should NOT raise an exception:
+    hash(arr)


### PR DESCRIPTION
Fixes #12665