### PR TITLE
Fix issue #12677

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -785,6 +785,7 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy.series import limit, Limit
         from sympy.solvers.solveset import solveset
+        from sympy.sets.sets import Intersection, Interval
 
         if (a is None and b is None):
             raise ValueError('Both interval ends cannot be None.')
@@ -826,7 +827,12 @@ class Expr(Basic, EvalfMixin):
         value = B - A
 
         if a.is_comparable and b.is_comparable:
-            singularities = list(solveset(self.cancel().as_numer_denom()[1], x))
+            if a < b:
+                domain = Interval(a, b)
+            else:
+                domain = Interval(b, a)
+            singularities = solveset(self.cancel().as_numer_denom()[1], x)
+            singularities = list(Intersection(domain, singularities))
             for s in singularities:
                 if a < s < b:
                     value += -limit(self, x, s, "+") + limit(self, x, s, "-")

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -831,7 +831,7 @@ class Expr(Basic, EvalfMixin):
                 domain = Interval(a, b)
             else:
                 domain = Interval(b, a)
-            singularities = solveset(self.cancel().as_numer_denom()[1], x, domain = domain)
+            singularities = list(solveset(self.cancel().as_numer_denom()[1], x, domain = domain))
             for s in singularities:
                 if a < s < b:
                     value += -limit(self, x, s, "+") + limit(self, x, s, "-")

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -785,7 +785,7 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy.series import limit, Limit
         from sympy.solvers.solveset import solveset
-        from sympy.sets.sets import Intersection, Interval
+        from sympy.sets.sets import Interval
 
         if (a is None and b is None):
             raise ValueError('Both interval ends cannot be None.')
@@ -831,8 +831,7 @@ class Expr(Basic, EvalfMixin):
                 domain = Interval(a, b)
             else:
                 domain = Interval(b, a)
-            singularities = solveset(self.cancel().as_numer_denom()[1], x)
-            singularities = list(Intersection(domain, singularities))
+            singularities = solveset(self.cancel().as_numer_denom()[1], x, domain = domain)
             for s in singularities:
                 if a < s < b:
                     value += -limit(self, x, s, "+") + limit(self, x, s, "-")

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1177,3 +1177,6 @@ def test_singularities():
 
     assert integrate(1/x**2, (x, 1, -1)) == -oo
     assert integrate(1/(x - 1)**2, (x, 2, -2)) == -oo
+
+def test_issue_12677():
+    assert integrate(sin(x) / (cos(x)**3) , (x, 0, pi/6)) == Rational(1,6)


### PR DESCRIPTION
This fix concerns issue #12677 , where the definite integral
`integrate(sin(x)/(cos(x)**3), (x, 0, pi/6))` does not work.
In `_eval_interval(self, x, a, b)`of `expr.py`, sympy calculates the singularities
of the primitive, as the zeros of the denominator. This returns in an infinite set; hence
there is an infinite loop. Intersecting the singularities with the domain should avoid
this situation.

Added a test for the issue.

