### PR TITLE
12657: treat -oo like oo in Add

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -678,6 +678,9 @@ class Add(Expr, AssocOp):
 
     def _eval_subs(self, old, new):
         if not old.is_Add:
+            if old is S.Infinity and -old in self.args:
+                # foo - oo is foo + (-oo) internally
+                return self.xreplace({-old: -new})
             return None
 
         coeff_self, terms_self = self.as_coeff_Add()

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2701,6 +2701,10 @@ class Infinity(with_metaclass(Singleton, Number)):
     def _latex(self, printer):
         return r"\infty"
 
+    def _eval_subs(self, old, new):
+        if self == old:
+            return new
+
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):
         if isinstance(other, Number):
@@ -2919,6 +2923,10 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
 
     def _latex(self, printer):
         return r"-\infty"
+
+    def _eval_subs(self, old, new):
+        if self == old:
+            return new
 
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -706,3 +706,13 @@ def test_issue_8886():
     assert x.subs(x, v) == x
     assert v.subs(v, x) == v
     assert v.__eq__(x) is False
+
+
+def test_issue_12657():
+    # treat -oo like the atom that it is
+    reps = [(-oo, 1), (oo, 2)]
+    assert (x < -oo).subs(reps) == (x < 1)
+    assert (x < -oo).subs(list(reversed(reps))) == (x < 1)
+    reps = [(-oo, 2), (oo, 1)]
+    assert (x < oo).subs(reps) == (x < 1)
+    assert (x < oo).subs(list(reversed(reps))) == (x < 1)


### PR DESCRIPTION
closes #12657

A test with `(x - oo).subs(oo, y)` already exists and continues to pass.