### PR TITLE
Support for __abs__ in SymPy matrices

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -19,7 +19,7 @@ from sympy.simplify import simplify as _simplify, signsimp, nsimplify
 from sympy.utilities.iterables import flatten, numbered_symbols
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
-from sympy.functions import exp, factorial
+from sympy.functions import Abs, exp, factorial
 from sympy.printing import sstr
 from sympy.core.compatibility import reduce, as_int, string_types
 from sympy.assumptions.refine import refine
@@ -1723,6 +1723,9 @@ class MatrixArithmetic(MatrixRequired):
 
     def __neg__(self):
         return self._eval_scalar_mul(-1)
+
+    def __abs__(self):
+        return self._new(self.rows, self.cols, lambda i, j: Abs(self[i, j]))
 
     @call_highest_priority('__rpow__')
     def __pow__(self, num):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1595,6 +1595,9 @@ class MatrixArithmetic(MatrixRequired):
 
     _op_priority = 10.01
 
+    def _eval_Abs(self):
+        return self._new(self.rows, self.cols, lambda i, j: Abs(self[i, j]))
+
     def _eval_add(self, other):
         return self._new(self.rows, self.cols,
                          lambda i, j: self[i, j] + other[i, j])
@@ -1639,6 +1642,10 @@ class MatrixArithmetic(MatrixRequired):
         return self._new(self.rows, self.cols, lambda i, j: other*self[i,j])
 
     # python arithmetic functions
+    def __abs__(self):
+        """Returns a new matrix with entry-wise absolute values."""
+        return self._eval_Abs()
+
     @call_highest_priority('__radd__')
     def __add__(self, other):
         """Return self + other, raising ShapeError if shapes don't match."""
@@ -1723,9 +1730,6 @@ class MatrixArithmetic(MatrixRequired):
 
     def __neg__(self):
         return self._eval_scalar_mul(-1)
-
-    def __abs__(self):
-        return self._new(self.rows, self.cols, lambda i, j: Abs(self[i, j]))
 
     @call_highest_priority('__rpow__')
     def __pow__(self, num):

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -8,6 +8,7 @@ from sympy.core.expr import Expr
 from sympy.core.compatibility import is_sequence, as_int, range
 from sympy.core.logic import fuzzy_and
 from sympy.core.singleton import S
+from sympy.functions import Abs
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.utilities.iterables import uniq
 
@@ -249,6 +250,9 @@ class SparseMatrix(MatrixBase):
             scale = (r1*rv[:, 0])[0, 0]
             rv /= scale
         return self._new(rv)
+
+    def _eval_Abs(self):
+        return self.applyfunc(lambda x: Abs(x))
 
     def _eval_add(self, other):
         """If `other` is a SparseMatrix, add efficiently. Otherwise,

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -540,6 +540,10 @@ def test_permute():
 
 
 # ArithmeticOnlyMatrix tests
+def test_abs():
+    m = ArithmeticOnlyMatrix([[1, -2], [x, y]])
+    assert abs(m) == ArithmeticOnlyMatrix([[1, 2], [Abs(x), Abs(y)]])
+
 def test_add():
     m = ArithmeticOnlyMatrix([[1, 2, 3], [x, y, x], [2*y, -50, z*x]])
     assert m + m == ArithmeticOnlyMatrix([[2, 4, 6], [2*x, 2*y, 2*x], [4*y, -100, 2*z*x]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -51,6 +51,10 @@ def test_sum():
     n = Matrix(1, 2, [1, 2])
     raises(ShapeError, lambda: m + n)
 
+def test_abs():
+    m = Matrix(1, 2, [-3, x])
+    n = Matrix(1, 2, [3, Abs(x)])
+    assert abs(m) == n
 
 def test_addition():
     a = Matrix((

--- a/sympy/matrices/tests/test_sparse.py
+++ b/sympy/matrices/tests/test_sparse.py
@@ -1,4 +1,4 @@
-from sympy import S, Symbol, I, Rational, PurePoly
+from sympy import Abs, S, Symbol, I, Rational, PurePoly
 from sympy.matrices import Matrix, SparseMatrix, eye, zeros, ShapeError
 from sympy.utilities.pytest import raises
 
@@ -255,6 +255,9 @@ def test_sparse_matrix():
     m0 = sparse_eye(3)
     assert m0.applyfunc(lambda x: 2*x) == sparse_eye(3)*2
     assert m0.applyfunc(lambda x: 0 ) == sparse_zeros(3)
+
+    # test__eval_Abs
+    assert abs(SparseMatrix(((x, 1), (y, 2*y)))) == SparseMatrix(((Abs(x), 1), (Abs(y), 2*Abs(y))))
 
     # test_LUdecomp
     testmat = SparseMatrix([[ 0, 2, 5, 3],


### PR DESCRIPTION
I was surprised to see `__abs__` being unsupported by matrices.
I think this should be quite uncontroversial, unless there is chance users would expect some kind
of matrix norm instead.

pinging @siefkenj for feedback.