### PR TITLE
Create operators.py file

### DIFF
--- a/doc/src/modules/vector/fields.rst
+++ b/doc/src/modules/vector/fields.rst
@@ -147,7 +147,7 @@ One, by using the ``delop`` property
 Or by using the dedicated function
 
   >>> from sympy.vector import curl
-  >>> curl(C.x*C.y*C.z*C.i, C)
+  >>> curl(C.x*C.y*C.z*C.i)
   C.x*C.y*C.j + (-C.x*C.z)*C.k
 
 Divergence
@@ -184,7 +184,7 @@ One, by using the ``delop`` property
 Or by using the dedicated function
 
   >>> from sympy.vector import divergence
-  >>> divergence(C.x*C.y*C.z*(C.i + C.j + C.k), C)
+  >>> divergence(C.x*C.y*C.z*(C.i + C.j + C.k))
   C.x*C.y + C.x*C.z + C.y*C.z
 
 Gradient
@@ -217,7 +217,7 @@ One, by using the ``delop`` property
 Or by using the dedicated function
 
   >>> from sympy.vector import gradient
-  >>> gradient(C.x*C.y*C.z, C)
+  >>> gradient(C.x*C.y*C.z)
   C.y*C.z*C.i + C.x*C.z*C.j + C.x*C.y*C.k
 
 Directional Derivative
@@ -268,7 +268,7 @@ To check if a vector field is conservative in :mod:`sympy.vector`, the
   >>> field = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
   >>> is_conservative(field)
   True
-  >>> curl(field, R)
+  >>> curl(field)
   0
 
 A solenoidal field, on the other hand, is a vector field whose divergence
@@ -282,7 +282,7 @@ To check if a vector field is solenoidal in :mod:`sympy.vector`, the
   >>> field = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
   >>> is_solenoidal(field)
   True
-  >>> divergence(field, R)
+  >>> divergence(field)
   0
 
 Scalar potential functions

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3943,6 +3943,27 @@ def test_sympy__vector__deloperator__Del():
     assert _test_args(Del(C))
 
 
+def test_sympy__vector__operators__Curl():
+    from sympy.vector.operators import Curl
+    from sympy.vector.coordsysrect import CoordSysCartesian
+    C = CoordSysCartesian('C')
+    assert _test_args(Curl(C.i))
+
+
+def test_sympy__vector__operators__Divergence():
+    from sympy.vector.operators import Divergence
+    from sympy.vector.coordsysrect import CoordSysCartesian
+    C = CoordSysCartesian('C')
+    assert _test_args(Divergence(C.i))
+
+
+def test_sympy__vector__operators__Gradient():
+    from sympy.vector.operators import Gradient
+    from sympy.vector.coordsysrect import CoordSysCartesian
+    C = CoordSysCartesian('C')
+    assert _test_args(Gradient(C.x))
+
+
 def test_sympy__vector__orienters__Orienter():
     from sympy.vector.orienters import Orienter
     #Not to be initialized
@@ -3986,24 +4007,3 @@ def test_sympy__vector__scalar__BaseScalar():
 def test_sympy__physics__wigner__Wigner3j():
     from sympy.physics.wigner import Wigner3j
     assert _test_args(Wigner3j(0, 0, 0, 0, 0, 0))
-
-
-def test_sympy__vector__operators_Gradient():
-    from sympy.vector.operators import Gradient
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
-    assert _test_args(Gradient(C.x))
-
-
-def test_sympy__vector__operators_Divergence():
-    from sympy.vector.operators import Divergence
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
-    assert _test_args(Divergence(C.i))
-
-
-def test_sympy__vector__operators_Curl():
-    from sympy.vector.operators import Curl
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
-    assert _test_args(Curl(C.i))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3982,6 +3982,28 @@ def test_sympy__vector__scalar__BaseScalar():
     C = CoordSysCartesian('C')
     assert _test_args(BaseScalar('Cx', 0, C, ' ', ' '))
 
+
 def test_sympy__physics__wigner__Wigner3j():
     from sympy.physics.wigner import Wigner3j
     assert _test_args(Wigner3j(0, 0, 0, 0, 0, 0))
+
+
+def test_sympy__vector__operators_Gradient():
+    from sympy.vector.operators import Gradient
+    from sympy.vector.coordsysrect import CoordSysCartesian
+    C = CoordSysCartesian('C')
+    assert _test_args(Gradient(C.x))
+
+
+def test_sympy__vector__operators_Divergence():
+    from sympy.vector.operators import Divergence
+    from sympy.vector.coordsysrect import CoordSysCartesian
+    C = CoordSysCartesian('C')
+    assert _test_args(Divergence(C.i))
+
+
+def test_sympy__vector__operators_Curl():
+    from sympy.vector.operators import Curl
+    from sympy.vector.coordsysrect import CoordSysCartesian
+    C = CoordSysCartesian('C')
+    assert _test_args(Curl(C.i))

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -13,3 +13,4 @@ from sympy.vector.functions import (express, matrix_to_vector,
 from sympy.vector.point import Point
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
+from sympy.vector.operators import Gradient, Divergence, Curl

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -13,4 +13,4 @@ from sympy.vector.functions import (express, matrix_to_vector,
 from sympy.vector.point import Point
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-from sympy.vector.operators import Gradient, Divergence, Curl
+from sympy.vector.operators import Gradient, Divergence, Curl, gradient, curl, divergence

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -2,6 +2,7 @@ from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.dyadic import Dyadic
 from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.scalar import BaseScalar
+from sympy.vector.operators import gradient, curl, divergence
 from sympy import sympify, diff, integrate, S, simplify
 
 
@@ -122,98 +123,6 @@ def express(expr, system, system2=None, variables=False):
         return expr
 
 
-def curl(vect, coord_sys):
-    """
-    Returns the curl of a vector field computed wrt the base scalars
-    of the given coordinate system.
-
-    Parameters
-    ==========
-
-    vect : Vector
-        The vector operand
-
-    coord_sys : CoordSysCartesian
-        The coordinate system to calculate the curl in
-
-    Examples
-    ========
-
-    >>> from sympy.vector import CoordSysCartesian, curl
-    >>> R = CoordSysCartesian('R')
-    >>> v1 = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
-    >>> curl(v1, R)
-    0
-    >>> v2 = R.x*R.y*R.z*R.i
-    >>> curl(v2, R)
-    R.x*R.y*R.j + (-R.x*R.z)*R.k
-
-    """
-
-    return coord_sys.delop.cross(vect).doit()
-
-
-def divergence(vect, coord_sys):
-    """
-    Returns the divergence of a vector field computed wrt the base
-    scalars of the given coordinate system.
-
-    Parameters
-    ==========
-
-    vect : Vector
-        The vector operand
-
-    coord_sys : CoordSysCartesian
-        The cooordinate system to calculate the divergence in
-
-    Examples
-    ========
-
-    >>> from sympy.vector import CoordSysCartesian, divergence
-    >>> R = CoordSysCartesian('R')
-    >>> v1 = R.x*R.y*R.z * (R.i+R.j+R.k)
-    >>> divergence(v1, R)
-    R.x*R.y + R.x*R.z + R.y*R.z
-    >>> v2 = 2*R.y*R.z*R.j
-    >>> divergence(v2, R)
-    2*R.z
-
-    """
-
-    return coord_sys.delop.dot(vect).doit()
-
-
-def gradient(scalar, coord_sys):
-    """
-    Returns the vector gradient of a scalar field computed wrt the
-    base scalars of the given coordinate system.
-
-    Parameters
-    ==========
-
-    scalar : SymPy Expr
-        The scalar field to compute the gradient of
-
-    coord_sys : CoordSysCartesian
-        The coordinate system to calculate the gradient in
-
-    Examples
-    ========
-
-    >>> from sympy.vector import CoordSysCartesian, gradient
-    >>> R = CoordSysCartesian('R')
-    >>> s1 = R.x*R.y*R.z
-    >>> gradient(s1, R)
-    R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
-    >>> s2 = 5*R.x**2*R.z
-    >>> gradient(s2, R)
-    10*R.x*R.z*R.i + 5*R.x**2*R.k
-
-    """
-
-    return coord_sys.delop(scalar).doit()
-
 def directional_derivative(scalar, vect):
     """
     Returns the directional derivative of a scalar field computed along a given vector
@@ -245,8 +154,8 @@ def directional_derivative(scalar, vect):
     5*R.x**2 + 30*R.x*R.z
 
     """
-    coord_sys = vect._sys
-    return gradient(scalar, coord_sys).dot(vect).doit()
+    return gradient(scalar).dot(vect).doit()
+
 
 def is_conservative(field):
     """
@@ -278,8 +187,7 @@ def is_conservative(field):
         raise TypeError("field should be a Vector")
     if field == Vector.zero:
         return True
-    coord_sys = list(field.separate())[0]
-    return curl(field, coord_sys).simplify() == Vector.zero
+    return curl(field).simplify() == Vector.zero
 
 
 def is_solenoidal(field):
@@ -312,8 +220,7 @@ def is_solenoidal(field):
         raise TypeError("field should be a Vector")
     if field == Vector.zero:
         return True
-    coord_sys = list(field.separate())[0]
-    return divergence(field, coord_sys).simplify() == S(0)
+    return divergence(field).simplify() == S(0)
 
 
 def scalar_potential(field, coord_sys):
@@ -340,7 +247,7 @@ def scalar_potential(field, coord_sys):
     >>> scalar_potential(R.k, R) == R.z
     True
     >>> scalar_field = 2*R.x**2*R.y*R.z
-    >>> grad_field = gradient(scalar_field, R)
+    >>> grad_field = gradient(scalar_field)
     >>> scalar_potential(grad_field, R)
     2*R.x**2*R.y*R.z
 

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -1,4 +1,4 @@
-from sympy.core.basic import Basic
+from sympy.core.expr import Expr
 from sympy.core import  sympify
 from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.vector import Vector
@@ -25,7 +25,7 @@ def _get_coord_sys_from_expr(expr, coord_sys=None):
         return list(expr.atoms(CoordSysCartesian))[0]
 
 
-class Gradient(Basic):
+class Gradient(Expr):
     """
     Represents unevaluated Gradient.
 
@@ -42,7 +42,7 @@ class Gradient(Basic):
 
     def __new__(cls, expr):
         expr = sympify(expr)
-        obj = Basic.__new__(cls, expr)
+        obj = Expr.__new__(cls, expr)
         obj._expr = expr
         return obj
 
@@ -50,7 +50,7 @@ class Gradient(Basic):
         return gradient(self._expr)
 
 
-class Divergence(Basic):
+class Divergence(Expr):
     """
     Represents unevaluated Divergence.
 
@@ -67,7 +67,7 @@ class Divergence(Basic):
 
     def __new__(cls, expr):
         expr = sympify(expr)
-        obj = Basic.__new__(cls, expr)
+        obj = Expr.__new__(cls, expr)
         obj._expr = expr
         return obj
 
@@ -75,7 +75,7 @@ class Divergence(Basic):
         return divergence(self._expr)
 
 
-class Curl(Basic):
+class Curl(Expr):
     """
     Represents unevaluated Curl.
 
@@ -92,7 +92,7 @@ class Curl(Basic):
 
     def __new__(cls, expr):
         expr = sympify(expr)
-        obj = Basic.__new__(cls, expr)
+        obj = Expr.__new__(cls, expr)
         obj._expr = expr
         return obj
 

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -18,9 +18,9 @@ def _get_coord_sys_from_expr(expr, coord_sys=None):
             deprecated_since_version="1.1"
         ).warn()
     if expr is Vector.zero:
-        return False
+        return None
     elif expr == 0:
-        return False
+        return None
     else:
         return list(expr.atoms(CoordSysCartesian))[0]
 
@@ -128,10 +128,12 @@ def gradient(scalar, coord_sys=None):
     10*R.x*R.z*R.i + 5*R.x**2*R.k
 
     """
-    if _get_coord_sys_from_expr(scalar, coord_sys) is False:
+
+    coord_sys = _get_coord_sys_from_expr(scalar, coord_sys)
+    if coord_sys is None:
         return Vector.zero
     else:
-        return _get_coord_sys_from_expr(scalar, coord_sys).delop(scalar).doit()
+        return coord_sys.delop(scalar).doit()
 
 
 def divergence(vector, coord_sys=None):
@@ -162,10 +164,12 @@ def divergence(vector, coord_sys=None):
     2*R.z
 
     """
-    if _get_coord_sys_from_expr(vector, coord_sys) is False:
+
+    coord_sys = _get_coord_sys_from_expr(vector, coord_sys)
+    if coord_sys is None:
         return S.Zero
     else:
-        return _get_coord_sys_from_expr(vector, coord_sys).delop.dot(vector).doit()
+        return coord_sys.delop.dot(vector).doit()
 
 
 def curl(vector, coord_sys=None):
@@ -196,7 +200,9 @@ def curl(vector, coord_sys=None):
     R.x*R.y*R.j + (-R.x*R.z)*R.k
 
     """
-    if _get_coord_sys_from_expr(vector, coord_sys) is False:
+
+    coord_sys = _get_coord_sys_from_expr(vector, coord_sys)
+    if coord_sys is None:
         return Vector.zero
     else:
-        return _get_coord_sys_from_expr(vector, coord_sys).delop.cross(vector).doit()
+        return coord_sys.delop.cross(vector).doit()

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -1,4 +1,5 @@
-from sympy.core import Expr, sympify
+from sympy.core.basic import Basic
+from sympy.core import  sympify
 from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.vector import Vector
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -18,7 +19,7 @@ def _get_coord_sys_from_expr(expr, coord_sys=None):
     return list(expr.atoms(CoordSysCartesian))[0]
 
 
-class Gradient(Expr):
+class Gradient(Basic):
     """
     Represents unevaluated Gradient.
 
@@ -35,7 +36,7 @@ class Gradient(Expr):
 
     def __new__(cls, expr):
         expr = sympify(expr)
-        obj = Expr.__new__(cls, expr)
+        obj = Basic.__new__(cls, expr)
         obj._expr = expr
         return obj
 
@@ -43,7 +44,7 @@ class Gradient(Expr):
         return gradient(self._expr)
 
 
-class Divergence(Expr):
+class Divergence(Basic):
     """
     Represents unevaluated Divergence.
 
@@ -60,7 +61,7 @@ class Divergence(Expr):
 
     def __new__(cls, expr):
         expr = sympify(expr)
-        obj = Expr.__new__(cls, expr)
+        obj = Basic.__new__(cls, expr)
         obj._expr = expr
         return obj
 
@@ -68,7 +69,7 @@ class Divergence(Expr):
         return divergence(self._expr)
 
 
-class Curl(Expr):
+class Curl(Basic):
     """
     Represents unevaluated Curl.
 
@@ -85,7 +86,7 @@ class Curl(Expr):
 
     def __new__(cls, expr):
         expr = sympify(expr)
-        obj = Expr.__new__(cls, expr)
+        obj = Basic.__new__(cls, expr)
         obj._expr = expr
         return obj
 
@@ -125,7 +126,7 @@ def gradient(scalar, coord_sys=None):
     return _get_coord_sys_from_expr(scalar, coord_sys).delop(scalar).doit()
 
 
-def divergence(vect, coord_sys=None):
+def divergence(vector, coord_sys=None):
     """
     Returns the divergence of a vector field computed wrt the base
     scalars of the given coordinate system.
@@ -154,10 +155,10 @@ def divergence(vect, coord_sys=None):
 
     """
 
-    return _get_coord_sys_from_expr(vect, coord_sys).delop.dot(vect).doit()
+    return _get_coord_sys_from_expr(vector, coord_sys).delop.dot(vector).doit()
 
 
-def curl(vect, coord_sys=None):
+def curl(vector, coord_sys=None):
     """
     Returns the curl of a vector field computed wrt the base scalars
     of the given coordinate system.
@@ -186,4 +187,4 @@ def curl(vect, coord_sys=None):
 
     """
 
-    return _get_coord_sys_from_expr(vect, coord_sys).delop.cross(vect).doit()
+    return _get_coord_sys_from_expr(vector, coord_sys).delop.cross(vector).doit()

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -3,6 +3,7 @@ from sympy.core import  sympify
 from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.vector import Vector
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy import S
 
 
 def _get_coord_sys_from_expr(expr, coord_sys=None):
@@ -16,7 +17,12 @@ def _get_coord_sys_from_expr(expr, coord_sys=None):
             useinstead="do not use it",
             deprecated_since_version="1.1"
         ).warn()
-    return list(expr.atoms(CoordSysCartesian))[0]
+    if expr is Vector.zero:
+        return False
+    elif expr == 0:
+        return False
+    else:
+        return list(expr.atoms(CoordSysCartesian))[0]
 
 
 class Gradient(Basic):
@@ -122,8 +128,10 @@ def gradient(scalar, coord_sys=None):
     10*R.x*R.z*R.i + 5*R.x**2*R.k
 
     """
-
-    return _get_coord_sys_from_expr(scalar, coord_sys).delop(scalar).doit()
+    if _get_coord_sys_from_expr(scalar, coord_sys) is False:
+        return Vector.zero
+    else:
+        return _get_coord_sys_from_expr(scalar, coord_sys).delop(scalar).doit()
 
 
 def divergence(vector, coord_sys=None):
@@ -154,8 +162,10 @@ def divergence(vector, coord_sys=None):
     2*R.z
 
     """
-
-    return _get_coord_sys_from_expr(vector, coord_sys).delop.dot(vector).doit()
+    if _get_coord_sys_from_expr(vector, coord_sys) is False:
+        return S.Zero
+    else:
+        return _get_coord_sys_from_expr(vector, coord_sys).delop.dot(vector).doit()
 
 
 def curl(vector, coord_sys=None):
@@ -186,5 +196,7 @@ def curl(vector, coord_sys=None):
     R.x*R.y*R.j + (-R.x*R.z)*R.k
 
     """
-
-    return _get_coord_sys_from_expr(vector, coord_sys).delop.cross(vector).doit()
+    if _get_coord_sys_from_expr(vector, coord_sys) is False:
+        return Vector.zero
+    else:
+        return _get_coord_sys_from_expr(vector, coord_sys).delop.cross(vector).doit()

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -1,10 +1,25 @@
 from sympy.core import Expr
 from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.vector import Vector
-from sympy.vector.deloperator import Del
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
-def _get_coord_sys_from_expr(expr):
+def _get_coord_sys_from_expr(expr, coord_sys=None):
+    """
+
+    expr : vector or scalar
+        From this parameter is obtained information about
+        coordinate system.
+    coord_sys : CoordSysCartesian
+        Deprecated since version 1.1. This parameter is unnecessary.
+
+    """
+    if coord_sys is not None:
+        SymPyDeprecationWarning(
+            feature="coord_sys parameter",
+            useinstead="do not use it",
+            deprecated_since_version="1.1"
+        ).warn()
     return list(expr.atoms(CoordSysCartesian))[0]
 
 
@@ -18,8 +33,8 @@ class Gradient(Expr):
     >>> from sympy.vector import CoordSysCartesian, Gradient
     >>> R = CoordSysCartesian('R')
     >>> s = R.x*R.y*R.z
-    >>> Gradient(s, R)
-    Gradient(R.x*R.y*R.z, R)
+    >>> Gradient(s)
+    Gradient(R.x*R.y*R.z)
 
     """
 
@@ -28,11 +43,8 @@ class Gradient(Expr):
         obj._scalar = scalar
         return obj
 
-    def gradient(self):
-        return Del(_get_coord_sys_from_expr(self._scalar)).gradient(self._scalar)
-
     def doit(self):
-        return self.gradient().doit()
+        return gradient(self._scalar)
 
 
 class Divergence(Expr):
@@ -42,11 +54,11 @@ class Divergence(Expr):
     Examples
     ========
 
-    >>> from sympy.vector import CoordSysCartesian, Gradient
+    >>> from sympy.vector import CoordSysCartesian, Divergence
     >>> R = CoordSysCartesian('R')
     >>> v = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
-    >>> Divergence(v, R)
-    Divergence(R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k, R)
+    >>> Divergence(v)
+    Divergence(R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k)
 
     """
 
@@ -55,11 +67,8 @@ class Divergence(Expr):
         obj._vect = vect
         return obj
 
-    def divergence(self):
-        return Del(_get_coord_sys_from_expr(self._vect)).dot(self._vect)
-
     def doit(self):
-        return self.divergence().doit()
+        return divergence(self._vect)
 
 
 class Curl(Expr):
@@ -72,8 +81,8 @@ class Curl(Expr):
     >>> from sympy.vector import CoordSysCartesian, Curl
     >>> R = CoordSysCartesian('R')
     >>> v = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
-    >>> Curl(v, R)
-    Curl(R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k, R)
+    >>> Curl(v)
+    Curl(R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k)
 
     """
 
@@ -82,11 +91,8 @@ class Curl(Expr):
         obj._vect = vect
         return obj
 
-    def curl(self):
-        return Del(_get_coord_sys_from_expr(self._vect)).cross(self._vect)
-
     def doit(self):
-        return self.curl().doit()
+        return curl(self._vect)
 
 
 def gradient(scalar, coord_sys=None):
@@ -102,6 +108,7 @@ def gradient(scalar, coord_sys=None):
 
     coord_sys : CoordSysCartesian
         The coordinate system to calculate the gradient in
+        Deprecated since version 1.1
 
     Examples
     ========
@@ -117,7 +124,7 @@ def gradient(scalar, coord_sys=None):
 
     """
 
-    return _get_coord_sys_from_expr(scalar).delop(scalar).doit()
+    return _get_coord_sys_from_expr(scalar, coord_sys).delop(scalar).doit()
 
 
 def divergence(vect, coord_sys=None):
@@ -133,6 +140,7 @@ def divergence(vect, coord_sys=None):
 
     coord_sys : CoordSysCartesian
         The coordinate system to calculate the gradient in
+        Deprecated since version 1.1
 
     Examples
     ========
@@ -148,7 +156,7 @@ def divergence(vect, coord_sys=None):
 
     """
 
-    return _get_coord_sys_from_expr(vect).delop.dot(vect).doit()
+    return _get_coord_sys_from_expr(vect, coord_sys).delop.dot(vect).doit()
 
 
 def curl(vect, coord_sys=None):
@@ -163,7 +171,8 @@ def curl(vect, coord_sys=None):
         The vector operand
 
     coord_sys : CoordSysCartesian
-        The coordinate system to calculate the gradient in
+        The coordinate system to calculate the gradient in.
+        Deprecated since version 1.1
 
     Examples
     ========
@@ -179,4 +188,4 @@ def curl(vect, coord_sys=None):
 
     """
 
-    return _get_coord_sys_from_expr(vect).delop.cross(vect).doit()
+    return _get_coord_sys_from_expr(vect, coord_sys).delop.cross(vect).doit()

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -1,4 +1,4 @@
-from sympy.core import Expr
+from sympy.core import Expr, sympify
 from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.vector import Vector
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -6,13 +6,8 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 def _get_coord_sys_from_expr(expr, coord_sys=None):
     """
-
-    expr : vector or scalar
-        From this parameter is obtained information about
-        coordinate system.
-    coord_sys : CoordSysCartesian
-        Deprecated since version 1.1. This parameter is unnecessary.
-
+    expr : expression
+        The coordinate system is extracted from this parameter.
     """
     if coord_sys is not None:
         SymPyDeprecationWarning(
@@ -38,13 +33,14 @@ class Gradient(Expr):
 
     """
 
-    def __new__(cls, scalar):
-        obj = Expr.__new__(cls, scalar)
-        obj._scalar = scalar
+    def __new__(cls, expr):
+        expr = sympify(expr)
+        obj = Expr.__new__(cls, expr)
+        obj._expr = expr
         return obj
 
-    def doit(self):
-        return gradient(self._scalar)
+    def doit(self, **kwargs):
+        return gradient(self._expr)
 
 
 class Divergence(Expr):
@@ -62,13 +58,14 @@ class Divergence(Expr):
 
     """
 
-    def __new__(cls, vect):
-        obj = Expr.__new__(cls, vect)
-        obj._vect = vect
+    def __new__(cls, expr):
+        expr = sympify(expr)
+        obj = Expr.__new__(cls, expr)
+        obj._expr = expr
         return obj
 
-    def doit(self):
-        return divergence(self._vect)
+    def doit(self, **kwargs):
+        return divergence(self._expr)
 
 
 class Curl(Expr):
@@ -86,13 +83,14 @@ class Curl(Expr):
 
     """
 
-    def __new__(cls, vect):
-        obj = Expr.__new__(cls, vect)
-        obj._vect = vect
+    def __new__(cls, expr):
+        expr = sympify(expr)
+        obj = Expr.__new__(cls, expr)
+        obj._expr = expr
         return obj
 
-    def doit(self):
-        return curl(self._vect)
+    def doit(self, **kwargs):
+        return curl(self._expr)
 
 
 def gradient(scalar, coord_sys=None):

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -1,0 +1,154 @@
+from sympy.vector.coordsysrect import CoordSysCartesian
+from sympy.core import Basic
+from sympy.vector.vector import Vector
+from sympy.vector.deloperator import Del
+
+
+class Gradient(Basic):
+    """
+    Represents unevaluated Gradient.
+    
+    Examples
+    ========
+    
+    >>> from sympy.vector import CoordSysCartesian, Gradient
+    >>> R = CoordSysCartesian('R')
+    >>> s1 = R.x*R.y*R.z
+    >>> Gradient(s1, R)
+    (Derivative(R.x*R.y*R.z, R.x))*R.i git + (Derivative(R.x*R.y*R.z, R.y))*R.j + (Derivative(R.x*R.y*R.z, R.z))*R.k
+    """
+
+    def __new__(cls, scalar, coord_sys):
+        return Del(coord_sys).gradient(scalar)
+
+
+class Divergence(Basic):
+    """
+    Represents unevaluated Divergence.
+
+    Examples
+    ========
+    
+    >>> from sympy.vector import CoordSysCartesian, Gradient
+    >>> R = CoordSysCartesian('R')
+    >>> v = R.x*R.y*R.z*R.i + R.j + R.k
+    >>> Divergence(v, R)
+    Derivative(R.x*R.y*R.z, R.x)
+    
+    """
+
+    def __new__(cls, vect, coord_sys):
+        return Del(coord_sys).dot(vect)
+
+
+class Curl(Basic):
+    """
+    Represents unevaluated Curl.
+
+    Examples
+    ========
+
+    >>> from sympy.vector import CoordSysCartesian, Curl
+    >>> R = CoordSysCartesian('R')
+    >>> s1 = R.x*R.y*R.z*R.i + R.j
+    Curl(s1, R)
+    (Derivative(0, R.y) - Derivative(1, R.z))*R.i + (-Derivative(0, R.x) + 
+    Derivative(R.x*R.y*R.z, R.z))*R.j + (Derivative(1, R.x) - Derivative(R.x*R.y*R.z, R.y))*R.k    
+    
+    """
+
+    def __new__(cls, vect, coord_sys):
+        return Del(coord_sys).cross(vect)
+
+
+def gradient(scalar, coord_sys):
+    """
+    Returns the vector gradient of a scalar field computed wrt the
+    base scalars of the given coordinate system.
+
+    Parameters
+    ==========
+
+    scalar : SymPy Expr
+        The scalar field to compute the gradient of
+
+    coord_sys : CoordSysCartesian
+        The coordinate system to calculate the gradient in
+
+    Examples
+    ========
+
+    >>> from sympy.vector import CoordSysCartesian, gradient
+    >>> R = CoordSysCartesian('R')
+    >>> s1 = R.x*R.y*R.z
+    >>> gradient(s1, R)
+    R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
+    >>> s2 = 5*R.x**2*R.z
+    >>> gradient(s2, R)
+    10*R.x*R.z*R.i + 5*R.x**2*R.k
+
+    """
+
+    return Gradient(scalar, coord_sys).doit()
+
+
+def divergence(vect, coord_sys):
+    """
+    Returns the divergence of a vector field computed wrt the base
+    scalars of the given coordinate system.
+
+    Parameters
+    ==========
+
+    vect : Vector
+        The vector operand
+        
+    coord_sys : CoordSysCartesian
+        The coordinate system to calculate the gradient in
+
+    Examples
+    ========
+
+    >>> from sympy.vector import CoordSysCartesian, divergence
+    >>> R = CoordSysCartesian('R')
+    >>> v1 = R.x*R.y*R.z * (R.i+R.j+R.k)
+    >>> divergence(v1)
+    R.x*R.y + R.x*R.z + R.y*R.z
+    >>> v2 = 2*R.y*R.z*R.j
+    >>> divergence(v2, R)
+    2*R.z
+
+    """
+
+    return Divergence(vect, coord_sys).doit()
+
+
+def curl(vect, coord_sys):
+    """
+    Returns the curl of a vector field computed wrt the base scalars
+    of the given coordinate system.
+
+    Parameters
+    ==========
+
+    vect : Vector
+        The vector operand
+
+    coord_sys : CoordSysCartesian
+        The coordinate system to calculate the gradient in
+
+    Examples
+    ========
+
+    >>> from sympy.vector import CoordSysCartesian, curl
+    >>> R = CoordSysCartesian('R')
+    >>> v1 = R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
+    >>> curl(v1)
+    0
+    >>> v2 = R.x*R.y*R.z*R.i
+    >>> curl(v2, R)
+    R.x*R.y*R.j + (-R.x*R.z)*R.k
+
+    """
+
+    return Curl(vect, coord_sys).doit()

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -4,6 +4,10 @@ from sympy.vector.vector import Vector
 from sympy.vector.deloperator import Del
 
 
+def _get_coord_sys_from_expr(expr):
+    return list(expr.atoms(CoordSysCartesian))[0]
+
+
 class Gradient(Expr):
     """
     Represents unevaluated Gradient.
@@ -24,11 +28,11 @@ class Gradient(Expr):
         obj._scalar = scalar
         return obj
 
-    def _get_coord_sys_from_expr(self, scalar):
-        return list(scalar.atoms(CoordSysCartesian))[0]
+    def gradient(self):
+        return Del(_get_coord_sys_from_expr(self._scalar)).gradient(self._scalar)
 
     def doit(self):
-        return Del(self._get_coord_sys_from_expr(self._scalar)).gradient(self._scalar).doit()
+        return self.gradient().doit()
 
 
 class Divergence(Expr):
@@ -51,11 +55,11 @@ class Divergence(Expr):
         obj._vect = vect
         return obj
 
-    def _get_coord_sys_from_expr(self, vect):
-        return vect._sys
+    def divergence(self):
+        return Del(_get_coord_sys_from_expr(self._vect)).dot(self._vect)
 
     def doit(self):
-        return Del(self._get_coord_sys_from_expr(self._vect)).dot(self._vect).doit()
+        return self.divergence().doit()
 
 
 class Curl(Expr):
@@ -78,11 +82,11 @@ class Curl(Expr):
         obj._vect = vect
         return obj
 
-    def _get_coord_sys_from_expr(self, vect):
-        return vect._sys
+    def curl(self):
+        return Del(_get_coord_sys_from_expr(self._vect)).cross(self._vect)
 
     def doit(self):
-        return Del(self._get_coord_sys_from_expr(self._vect)).cross(self._vect).doit()
+        return self.curl().doit()
 
 
 def gradient(scalar, coord_sys=None):
@@ -113,10 +117,7 @@ def gradient(scalar, coord_sys=None):
 
     """
 
-    if coord_sys is None:
-        return Gradient(scalar).doit()
-    else:
-        return coord_sys.delop(scalar).doit()
+    return _get_coord_sys_from_expr(scalar).delop(scalar).doit()
 
 
 def divergence(vect, coord_sys=None):
@@ -147,10 +148,7 @@ def divergence(vect, coord_sys=None):
 
     """
 
-    if coord_sys is None:
-        return Divergence(vect).doit()
-    else:
-        coord_sys.delop.dot(vect).doit()
+    return _get_coord_sys_from_expr(vect).delop.dot(vect).doit()
 
 
 def curl(vect, coord_sys=None):
@@ -181,7 +179,4 @@ def curl(vect, coord_sys=None):
 
     """
 
-    if coord_sys is None:
-        return Divergence(vect).doit()
-    else:
-        coord_sys.delop.cross(vect).doit()
+    return _get_coord_sys_from_expr(vect).delop.cross(vect).doit()

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -25,7 +25,7 @@ def test_del_operator():
             (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
             (Derivative(0, C.x) - Derivative(0, C.y))*C.k)
     assert ((delop ^ Vector.zero).doit() == Vector.zero ==
-            curl(Vector.zero, C))
+            curl(Vector.zero))
     assert delop.cross(Vector.zero) == delop ^ Vector.zero
     assert (delop ^ i).doit() == Vector.zero
     assert delop.cross(2*y**2*j, doit=True) == Vector.zero
@@ -33,14 +33,14 @@ def test_del_operator():
     v = x*y*z * (i + j + k)
     assert ((delop ^ v).doit() ==
             (-x*y + x*z)*i + (x*y - y*z)*j + (-x*z + y*z)*k ==
-            curl(v, C))
+            curl(v))
     assert delop ^ v == delop.cross(v)
     assert (delop.cross(2*x**2*j) ==
             (Derivative(0, C.y) - Derivative(2*C.x**2, C.z))*C.i +
             (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
             (-Derivative(0, C.y) + Derivative(2*C.x**2, C.x))*C.k)
     assert (delop.cross(2*x**2*j, doit=True) == 4*x*k ==
-            curl(2*x**2*j, C))
+            curl(2*x**2*j))
 
     #Tests for divergence
     assert delop & Vector.zero == S(0) == divergence(Vector.zero)
@@ -62,19 +62,19 @@ def test_del_operator():
 
     #Tests for gradient
     assert (delop.gradient(0, doit=True) == Vector.zero ==
-            gradient(0, C))
+            gradient(0))
     assert delop.gradient(0) == delop(0)
     assert (delop(S(0))).doit() == Vector.zero
     assert (delop(x) == (Derivative(C.x, C.x))*C.i +
             (Derivative(C.x, C.y))*C.j + (Derivative(C.x, C.z))*C.k)
-    assert (delop(x)).doit() == i == gradient(x, C)
+    assert (delop(x)).doit() == i == gradient(x)
     assert (delop(x*y*z) ==
             (Derivative(C.x*C.y*C.z, C.x))*C.i +
             (Derivative(C.x*C.y*C.z, C.y))*C.j +
             (Derivative(C.x*C.y*C.z, C.z))*C.k)
     assert (delop.gradient(x*y*z, doit=True) ==
             y*z*i + z*x*j + x*y*k ==
-            gradient(x*y*z, C))
+            gradient(x*y*z))
     assert delop(x*y*z) == delop.gradient(x*y*z)
     assert (delop(2*x**2)).doit() == 4*x*i
     assert ((delop(a*sin(y) / x)).doit() ==

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -5,8 +5,8 @@ from sympy.simplify import simplify
 from sympy.core.symbol import symbols
 from sympy.core import S
 from sympy import sin, cos
-from sympy.vector.functions import (curl, divergence, gradient,
-                                    is_conservative, is_solenoidal,
+from sympy.vector.operators import curl, divergence, gradient
+from sympy.vector.functions import (is_conservative, is_solenoidal,
                                     scalar_potential, directional_derivative,
                                     scalar_potential_difference)
 from sympy.utilities.pytest import raises
@@ -17,9 +17,9 @@ x, y, z = C.base_scalars()
 delop = C.delop
 a, b, c, q = symbols('a b c q')
 
-def test_del_operator():
 
-    #Tests for curl
+def test_del_operator():
+    # Tests for curl
     assert (delop ^ Vector.zero ==
             (Derivative(0, C.y) - Derivative(0, C.z))*C.i +
             (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
@@ -28,7 +28,7 @@ def test_del_operator():
             curl(Vector.zero, C))
     assert delop.cross(Vector.zero) == delop ^ Vector.zero
     assert (delop ^ i).doit() == Vector.zero
-    assert delop.cross(2*y**2*j, doit = True) == Vector.zero
+    assert delop.cross(2*y**2*j, doit=True) == Vector.zero
     assert delop.cross(2*y**2*j) == delop ^ 2*y**2*j
     v = x*y*z * (i + j + k)
     assert ((delop ^ v).doit() ==
@@ -39,29 +39,29 @@ def test_del_operator():
             (Derivative(0, C.y) - Derivative(2*C.x**2, C.z))*C.i +
             (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
             (-Derivative(0, C.y) + Derivative(2*C.x**2, C.x))*C.k)
-    assert (delop.cross(2*x**2*j, doit = True) == 4*x*k ==
+    assert (delop.cross(2*x**2*j, doit=True) == 4*x*k ==
             curl(2*x**2*j, C))
 
     #Tests for divergence
-    assert delop & Vector.zero == S(0) == divergence(Vector.zero, C)
+    assert delop & Vector.zero == S(0) == divergence(Vector.zero)
     assert (delop & Vector.zero).doit() == S(0)
     assert delop.dot(Vector.zero) == delop & Vector.zero
     assert (delop & i).doit() == S(0)
-    assert (delop & x**2*i).doit() == 2*x == divergence(x**2*i, C)
-    assert (delop.dot(v, doit = True) == x*y + y*z + z*x ==
-            divergence(v, C))
+    assert (delop & x**2*i).doit() == 2*x == divergence(x**2*i)
+    assert (delop.dot(v, doit=True) == x*y + y*z + z*x ==
+            divergence(v))
     assert delop & v == delop.dot(v)
-    assert delop.dot(1/(x*y*z) * (i + j + k), doit = True) == \
+    assert delop.dot(1/(x*y*z) * (i + j + k), doit=True) == \
            - 1 / (x*y*z**2) - 1 / (x*y**2*z) - 1 / (x**2*y*z)
     v = x*i + y*j + z*k
     assert (delop & v == Derivative(C.x, C.x) +
             Derivative(C.y, C.y) + Derivative(C.z, C.z))
-    assert delop.dot(v, doit = True) == 3 == divergence(v, C)
+    assert delop.dot(v, doit=True) == 3 == divergence(v)
     assert delop & v == delop.dot(v)
     assert simplify((delop & v).doit()) == 3
 
     #Tests for gradient
-    assert (delop.gradient(0, doit = True) == Vector.zero ==
+    assert (delop.gradient(0, doit=True) == Vector.zero ==
             gradient(0, C))
     assert delop.gradient(0) == delop(0)
     assert (delop(S(0))).doit() == Vector.zero
@@ -72,7 +72,7 @@ def test_del_operator():
             (Derivative(C.x*C.y*C.z, C.x))*C.i +
             (Derivative(C.x*C.y*C.z, C.y))*C.j +
             (Derivative(C.x*C.y*C.z, C.z))*C.k)
-    assert (delop.gradient(x*y*z, doit = True) ==
+    assert (delop.gradient(x*y*z, doit=True) ==
             y*z*i + z*x*j + x*y*k ==
             gradient(x*y*z, C))
     assert delop(x*y*z) == delop.gradient(x*y*z)
@@ -118,33 +118,33 @@ def test_product_rules():
     u = x**2*i + 4*j - y**2*z*k
     v = 4*i + x*y*z*k
 
-    #First product rule
-    lhs = delop(f * g, doit = True)
+    # First product rule
+    lhs = delop(f * g, doit=True)
     rhs = (f * delop(g) + g * delop(f)).doit()
     assert simplify(lhs) == simplify(rhs)
 
-    #Second product rule
+    # Second product rule
     lhs = delop(u & v).doit()
     rhs = ((u ^ (delop ^ v)) + (v ^ (delop ^ u)) + \
           ((u & delop)(v)) + ((v & delop)(u))).doit()
     assert simplify(lhs) == simplify(rhs)
 
-    #Third product rule
+    # Third product rule
     lhs = (delop & (f*v)).doit()
     rhs = ((f * (delop & v)) + (v & (delop(f)))).doit()
     assert simplify(lhs) == simplify(rhs)
 
-    #Fourth product rule
+    # Fourth product rule
     lhs = (delop & (u ^ v)).doit()
     rhs = ((v & (delop ^ u)) - (u & (delop ^ v))).doit()
     assert simplify(lhs) == simplify(rhs)
 
-    #Fifth product rule
+    # Fifth product rule
     lhs = (delop ^ (f * v)).doit()
     rhs = (((delop(f)) ^ v) + (f * (delop ^ v))).doit()
     assert simplify(lhs) == simplify(rhs)
 
-    #Sixth product rule
+    # Sixth product rule
     lhs = (delop ^ (u ^ v)).doit()
     rhs = ((u * (delop & v) - v * (delop & u) +
            (v & delop)(u) - (u & delop)(v))).doit()
@@ -153,9 +153,9 @@ def test_product_rules():
 
 P = C.orient_new_axis('P', q, C.k)
 scalar_field = 2*x**2*y*z
-grad_field = gradient(scalar_field, C)
+grad_field = gradient(scalar_field)
 vector_field = y**2*i + 3*x*j + 5*y*z*k
-curl_field = curl(vector_field, C)
+curl_field = curl(vector_field)
 
 
 def test_conservative():

--- a/sympy/vector/tests/test_operators.py
+++ b/sympy/vector/tests/test_operators.py
@@ -1,0 +1,29 @@
+from sympy.vector import CoordSysCartesian, Gradient, Divergence, Curl, VectorZero
+
+
+R = CoordSysCartesian('R')
+s1 = R.x*R.y*R.z
+s2 = R.x + 3*R.y**2
+v1 = R.x*R.i + R.z*R.z*R.j
+v2 = R.x*R.i + R.y*R.j + R.z*R.k
+
+
+def test_Gradient():
+    assert Gradient(s1, R) == Gradient(R.x*R.y*R.z, R)
+    assert Gradient(s2, R) == Gradient(R.x + 3*R.y**2, R)
+    assert Gradient(s1, R).doit() == R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
+    assert Gradient(s2, R).doit() == R.i + 6*R.y*R.j
+
+
+def test_Divergence():
+    assert Divergence(v1, R) == Divergence(R.x*R.i + R.z*R.z*R.j, R)
+    assert Divergence(v2, R) == Divergence(R.x*R.i + R.y*R.j + R.z*R.k, R)
+    assert Divergence(v1, R).doit() == 1
+    assert Divergence(v2, R).doit() == 3
+
+
+def test_Curl():
+    assert Curl(v1, R) == Curl(R.x*R.i + R.z*R.z*R.j, R)
+    assert Curl(v2, R) == Curl(R.x*R.i + R.y*R.j + R.z*R.k, R)
+    assert Curl(v1, R).doit() == (-2*R.z)*R.i
+    assert Curl(v2, R).doit() == VectorZero()

--- a/sympy/vector/tests/test_operators.py
+++ b/sympy/vector/tests/test_operators.py
@@ -1,4 +1,4 @@
-from sympy.vector import CoordSysCartesian, Gradient, Divergence, Curl, VectorZero
+from sympy.vector import CoordSysCartesian, Gradient, Divergence, Curl, VectorZero, curl
 
 
 R = CoordSysCartesian('R')

--- a/sympy/vector/tests/test_operators.py
+++ b/sympy/vector/tests/test_operators.py
@@ -1,4 +1,4 @@
-from sympy.vector import CoordSysCartesian, Gradient, Divergence, Curl, VectorZero, curl
+from sympy.vector import CoordSysCartesian, Gradient, Divergence, Curl, VectorZero
 
 
 R = CoordSysCartesian('R')

--- a/sympy/vector/tests/test_operators.py
+++ b/sympy/vector/tests/test_operators.py
@@ -9,21 +9,21 @@ v2 = R.x*R.i + R.y*R.j + R.z*R.k
 
 
 def test_Gradient():
-    assert Gradient(s1, R) == Gradient(R.x*R.y*R.z, R)
-    assert Gradient(s2, R) == Gradient(R.x + 3*R.y**2, R)
-    assert Gradient(s1, R).doit() == R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
-    assert Gradient(s2, R).doit() == R.i + 6*R.y*R.j
+    assert Gradient(s1) == Gradient(R.x*R.y*R.z)
+    assert Gradient(s2) == Gradient(R.x + 3*R.y**2)
+    assert Gradient(s1).doit() == R.y*R.z*R.i + R.x*R.z*R.j + R.x*R.y*R.k
+    assert Gradient(s2).doit() == R.i + 6*R.y*R.j
 
 
 def test_Divergence():
-    assert Divergence(v1, R) == Divergence(R.x*R.i + R.z*R.z*R.j, R)
-    assert Divergence(v2, R) == Divergence(R.x*R.i + R.y*R.j + R.z*R.k, R)
-    assert Divergence(v1, R).doit() == 1
-    assert Divergence(v2, R).doit() == 3
+    assert Divergence(v1) == Divergence(R.x*R.i + R.z*R.z*R.j)
+    assert Divergence(v2) == Divergence(R.x*R.i + R.y*R.j + R.z*R.k)
+    assert Divergence(v1).doit() == 1
+    assert Divergence(v2).doit() == 3
 
 
 def test_Curl():
-    assert Curl(v1, R) == Curl(R.x*R.i + R.z*R.z*R.j, R)
-    assert Curl(v2, R) == Curl(R.x*R.i + R.y*R.j + R.z*R.k, R)
-    assert Curl(v1, R).doit() == (-2*R.z)*R.i
-    assert Curl(v2, R).doit() == VectorZero()
+    assert Curl(v1) == Curl(R.x*R.i + R.z*R.z*R.j)
+    assert Curl(v2) == Curl(R.x*R.i + R.y*R.j + R.z*R.k)
+    assert Curl(v1).doit() == (-2*R.z)*R.i
+    assert Curl(v2).doit() == VectorZero()


### PR DESCRIPTION
Create classes `Gradient`, `Curl`, `Divergence` where expression
is not evaluated. 

Functions `curl`, `divergence`, `gradient` now
are localized in `operators.py` file.

Argument `coord_sys` in gradient, curl, divergence, have default value `None`.
This parameter is obtained from vector or scalar itself in function `_get_coord_sys_from_expr`



