### PR TITLE
12600: make kinematic_equations more robust

### DIFF
--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -1,4 +1,5 @@
 from sympy import S, Integral, sin, cos, pi, sqrt, symbols
+from sympy.solvers.solvers import solve
 from sympy.physics.vector import Dyadic, Point, ReferenceFrame, Vector
 from sympy.physics.vector.functions import (cross, dot, express,
                                             time_derivative,
@@ -440,6 +441,13 @@ def test_kin_eqs():
             -0.5 * q0 * u2 + 0.5 * q1 * u3 - 0.5 * q3 * u1 + q2d,
             -0.5 * q0 * u3 - 0.5 * q1 * u2 + 0.5 * q2 * u1 + q3d,
             0.5 * q1 * u1 + 0.5 * q2 * u2 + 0.5 * q3 * u3 + q0d]
+    # test a couple special cases where the solution is 0
+    assert solve(kinematic_equations(
+        [u1, u2, u3], [q0, pi/2, q2], 'body', '123'), [u1, u2, u3]
+        ) == {u1: 0, u2: 0}
+    assert solve(kinematic_equations(
+        [u1, u2, u3], [q0, 0, q2], 'body', '121'), [u1, u2, u3]
+        ) == {u2: 0, u3: 0}
 
 
 def test_partial_velocity():


### PR DESCRIPTION
The equations returned from kinematic_equations provide the
relationships from which rotational speeds (u1, u2, u3) are
determined. There are certain special coordinates for which
the previous form of the equations involved a division by 0
condition. That has been removed modifying the equations so
they do not involve division.  The solution, now, may not
include all u1, u2 and u3. Any missing ui is given a value
of 0.

From the issue:

```
>>> import sympy as sm
>>> import sympy.physics.mechanics as me
>>> N = me.ReferenceFrame('N')
>>> me.kinematic_equations((0, 0, 0), (sm.pi, sm.pi / 2, 0), 'body', '132')
[0, 0, 0]
>>> A = N.orientnew('A', 'body', (sm.pi, sm.pi / 2, 0), '132')
>>> A.ang_vel_in(N)  # _u2 is a Dummy that indicates an arbitrary speed
_u2*A.y
```
closes #12600 
closes #12625 
closes #12612
