### PR TITLE
Matrix cleanup 6.5

### DIFF
--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -1579,7 +1579,7 @@ def test_P26():
                 [  0,   0,   0,   0,   0,  1,  0,  0,  0],
                 [  0,   0,   0,   0,   0,  0,  1, -1, -1],
                 [  0,   0,   0,   0,   0,  0,  0,  1,  0]])
-    assert M.eigenvals() == {
+    assert M.eigenvals(error_when_incomplete=False) == {
         S('-1/2 - sqrt(3)*I/2'): 2,
         S('-1/2 + sqrt(3)*I/2'): 2}
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3071,7 +3071,7 @@ class MatrixSubspaces(MatrixReductions):
         return [reduced.row(i) for i in range(len(pivots))]
 
     @classmethod
-    def orthogonalize(cls, *vecs, normalize=False):
+    def orthogonalize(cls, *vecs, **kwargs):
         """Apply the Gram-Schmidt orthogonalization procedure
         to vectors supplied in `vecs`.
 
@@ -3082,6 +3082,8 @@ class MatrixSubspaces(MatrixReductions):
         normalize : bool. Whether the returned vectors
                     should be renormalized to be unit vectors.
         """
+
+        normalize = kwargs.get('normalize', False)
 
         def project(a, b):
             return b * (a.dot(b) / b.dot(b))
@@ -3190,9 +3192,16 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
 
         return self.hstack(*p_cols), self.diag(*diag)
 
-    def eigenvals(self, **flags):
+    def eigenvals(self, error_when_incomplete=True, **flags):
         """Return eigenvalues using the Berkowitz agorithm to compute
         the characteristic polynomial.
+
+        Parameters
+        ==========
+
+        error_when_incomplete : bool
+            Raise an error when not all eigenvalues are computed. This is
+            caused by ``roots`` not returning a full list of eigenvalues.
 
         Since the roots routine doesn't always work well with Floats,
         they will be replaced with Rationals before calling that
@@ -3210,12 +3219,12 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix
-        if sum(m for m in eigs.values()) != self.cols:
+        if error_when_incomplete and sum(m for m in eigs.values()) != self.cols:
             raise MatrixError("Could not compute eigenvalues for {}".format(self))
 
         return eigs
 
-    def eigenvects(self, **flags):
+    def eigenvects(self, error_when_incomplete=True, **flags):
         """Return list of triples (eigenval, multiplicity, basis).
 
         The flag ``simplify`` has two effects:
@@ -3224,6 +3233,13 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
             2) if nullspace needs simplification to compute the
             basis, the simplify flag will be passed on to the
             nullspace routine which will interpret it there.
+
+        Parameters
+        ==========
+
+        error_when_incomplete : bool
+            Raise an error when not all eigenvalues are computed. This is
+            caused by ``roots`` not returning a full list of eigenvalues.
 
         If the matrix contains any Floats, they will be changed to Rationals
         for computation purposes, but the answers will be returned after being
@@ -3260,7 +3276,9 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
                         "Can't evaluate eigenvector for eigenvalue %s" % eigenval)
             return ret
 
-        eigenvals = mat.eigenvals(rational=False, **flags)
+        eigenvals = mat.eigenvals(rational=False,
+                                  error_when_incomplete=error_when_incomplete,
+                                  **flags)
         ret = [(val, mult, eigenspace(val)) for val, mult in
                     sorted(eigenvals.items(), key=default_sort_key)]
         if primitive:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3383,13 +3383,23 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
         cleanup()
         return ret
 
-    def jordan_form(self, calc_transform=True):
+    def jordan_form(self, calc_transform=True, **kwargs):
         """Return `(P, J)` where `J` is a Jordan block
         matrix and `P` is a matrix such that
 
             `self == P*J*P**-1`
 
-        If `calc_transform=False`, then only `J` is returned.
+
+        Parameters
+        ==========
+
+        calc_transform : bool
+            If ``False``, then only `J` is returned.
+        chop : bool
+            All matrices are convered to exact types when computing
+            eigenvalues and eigenvectors.  As a result, there may be
+            approximation errors.  If ``chop==True``, these errors
+            will be truncated.
 
         Examples
         ========
@@ -3412,6 +3422,19 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
         if not self.is_square:
             raise NonSquareMatrixError("Only square matrices have Jordan forms")
 
+        chop = kwargs.pop('chop', False)
+        mat = self
+        has_floats = any(v.has(Float) for v in self)
+
+        def restore_floats(*args):
+            """If `has_floats` is `True`, cast all `args` as
+            matrices of floats."""
+            if has_floats:
+                args = [m.evalf(chop=chop) for m in args]
+            if len(args) == 1:
+                return args[0]
+            return args
+
         # cache calculations for some speedup
         mat_cache = {}
         def eig_mat(val, pow):
@@ -3422,7 +3445,7 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
             if (val, pow - 1) in mat_cache:
                 mat_cache[(val, pow)] = mat_cache[(val, pow - 1)] * mat_cache[(val, 1)]
             else:
-                mat_cache[(val, pow)] = (self - val*self.eye(self.rows))**pow
+                mat_cache[(val, pow)] = (mat - val*self.eye(self.rows))**pow
             return mat_cache[(val, pow)]
 
         # helper functions
@@ -3464,25 +3487,29 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
                 if pivots[-1] == len(small_basis):
                     return v
 
+        # roots doesn't like Floats, so replace them with Rationals
+        if has_floats:
+            mat = mat.applyfunc(lambda x: nsimplify(x, rational=True))
+
         # first calculate the jordan block structure
-        eigs = self.eigenvals()
+        eigs = mat.eigenvals()
 
         # make sure that we found all the roots by counting
         # the algebraic multiplicity
-        if sum(m for m in eigs.values()) != self.cols:
-            raise MatrixError("Could not compute eigenvalues for {}".format(self))
+        if sum(m for m in eigs.values()) != mat.cols:
+            raise MatrixError("Could not compute eigenvalues for {}".format(mat))
 
         # most matrices have distinct eigenvalues
         # and so are diagonalizable.  In this case, don't
         # do extra work!
-        if len(eigs.keys()) == self.cols:
+        if len(eigs.keys()) == mat.cols:
             blocks = list(sorted(eigs.keys(), key=default_sort_key))
-            jordan_mat = self.diag(*blocks)
+            jordan_mat = mat.diag(*blocks)
             if not calc_transform:
-                return jordan_mat
+                return restore_floats(jordan_mat)
             jordan_basis = [eig_mat(eig, 1).nullspace()[0] for eig in blocks]
-            basis_mat = self.hstack(*jordan_basis)
-            return basis_mat, jordan_mat
+            basis_mat = mat.hstack(*jordan_basis)
+            return restore_floats(basis_mat, jordan_mat)
 
         block_structre = []
         for eig in sorted(eigs.keys(), key=default_sort_key):
@@ -3498,11 +3525,11 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
 
             block_structre.extend(
                 (eig, size) for size, num in size_nums for _ in range(num))
-        blocks = (self.jordan_block(size=size, eigenvalue=eig) for eig, size in block_structre)
-        jordan_mat = self.diag(*blocks)
+        blocks = (mat.jordan_block(size=size, eigenvalue=eig) for eig, size in block_structre)
+        jordan_mat = mat.diag(*blocks)
 
         if not calc_transform:
-            return jordan_mat
+            return restore_floats(jordan_mat)
 
         # For each generalized eigenspace, calculate a basis.
         # We start by looking for a vector in null( (A - eig*I)**n )
@@ -3533,9 +3560,9 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
                 eig_basis.extend(new_vecs)
                 jordan_basis.extend(reversed(new_vecs))
 
-        basis_mat = self.hstack(*jordan_basis)
+        basis_mat = mat.hstack(*jordan_basis)
 
-        return basis_mat, jordan_mat
+        return restore_floats(basis_mat, jordan_mat)
 
     def left_eigenvects(self, **flags):
         """Returns left eigenvectors and eigenvalues.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3511,7 +3511,7 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
             basis_mat = mat.hstack(*jordan_basis)
             return restore_floats(basis_mat, jordan_mat)
 
-        block_structre = []
+        block_structure = []
         for eig in sorted(eigs.keys(), key=default_sort_key):
             chain = nullity_chain(eig)
             block_sizes = blocks_from_nullity_chain(chain)
@@ -3523,9 +3523,9 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
             # we expect larger Jordan blocks to come earlier
             size_nums.reverse()
 
-            block_structre.extend(
+            block_structure.extend(
                 (eig, size) for size, num in size_nums for _ in range(num))
-        blocks = (mat.jordan_block(size=size, eigenvalue=eig) for eig, size in block_structre)
+        blocks = (mat.jordan_block(size=size, eigenvalue=eig) for eig, size in block_structure)
         jordan_mat = mat.diag(*blocks)
 
         if not calc_transform:
@@ -3546,7 +3546,7 @@ class MatrixEigen(MatrixSubspaces, MatrixProperties, MatrixSpecial):
 
         for eig in sorted(eigs.keys(), key=default_sort_key):
             eig_basis = []
-            for block_eig, size in block_structre:
+            for block_eig, size in block_structure:
                 if block_eig != eig:
                     continue
                 null_big = (eig_mat(eig, size)).nullspace()

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1255,3 +1255,12 @@ def test_jordan_form():
     # make sure if we cannot factor the characteristic polynomial, we raise an error
     m = Matrix([[3, 0, 0, 0, -3], [0, -3, -3, 0, 3], [0, 3, 0, 3, 0], [0, 0, 3, 0, 3], [3, 0, 0, 3, 0]])
     raises(MatrixError, lambda: m.jordan_form())
+
+    # make sure that if the input has floats, the output does too
+    m = Matrix([
+        [                0.6875, 0.125 + 0.1875*sqrt(3)],
+        [0.125 + 0.1875*sqrt(3),                 0.3125]])
+
+    P, J = m.jordan_form()
+    assert all(isinstance(x, Float) or x == 0 for x in P)
+    assert all(isinstance(x, Float) or x == 0 for x in J)

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -215,6 +215,7 @@ def test_hstack():
                 [6,  7,  8, 6,  7,  8, 6,  7,  8],
                 [9, 10, 11, 9, 10, 11, 9, 10, 11]])
     raises(ShapeError, lambda: m.hstack(m, m2))
+    assert Matrix.hstack() == Matrix()
 
 def test_vstack():
     m = ShapingOnlyMatrix(4, 3, lambda i, j: i*3 + j)
@@ -234,6 +235,7 @@ def test_vstack():
                                 [6,  7,  8],
                                 [9, 10, 11]])
     raises(ShapeError, lambda: m.vstack(m, m2))
+    assert Matrix.vstack() == Matrix()
 
 
 # PropertiesOnlyMatrix tests
@@ -1155,3 +1157,101 @@ def test_nullspace():
     # make sure the null space is really gets zeroed
     assert all(e.is_zero for e in m*basis[0])
     assert all(e.is_zero for e in m*basis[1])
+
+
+# EigenOnlyMatrix tests
+def test_eigenvals():
+    M = EigenOnlyMatrix([[0, 1, 1],
+                [1, 0, 0],
+                [1, 1, 1]])
+    assert M.eigenvals() == {2*S.One: 1, -S.One: 1, S.Zero: 1}
+
+    # if we cannot factor the char poly, we raise an error
+    m = Matrix([[3, 0, 0, 0, -3], [0, -3, -3, 0, 3], [0, 3, 0, 3, 0], [0, 0, 3, 0, 3], [3, 0, 0, 3, 0]])
+    raises(MatrixError, lambda: m.eigenvals())
+
+def test_eigenvects():
+    M = EigenOnlyMatrix([[0, 1, 1],
+                [1, 0, 0],
+                [1, 1, 1]])
+    vecs = M.eigenvects()
+    for val, mult, vec_list in vecs:
+        assert len(vec_list) == 1
+        assert M*vec_list[0] == val*vec_list[0]
+
+def test_left_eigenvects():
+    M = EigenOnlyMatrix([[0, 1, 1],
+                [1, 0, 0],
+                [1, 1, 1]])
+    vecs = M.left_eigenvects()
+    for val, mult, vec_list in vecs:
+        assert len(vec_list) == 1
+        assert vec_list[0]*M == val*vec_list[0]
+
+def test_diagonalize():
+    m = EigenOnlyMatrix(2, 2, [0, -1, 1, 0])
+    raises(MatrixError, lambda: m.diagonalize(reals_only=True))
+    P, D = m.diagonalize()
+    assert D.is_diagonal()
+    assert D == Matrix([
+                 [-I, 0],
+                 [ 0, I]])
+
+    # make sure we use floats out if floats are passed in
+    m = EigenOnlyMatrix(2, 2, [0, .5, .5, 0])
+    P, D = m.diagonalize()
+    assert all(isinstance(e, Float) for e in D.values())
+    assert all(isinstance(e, Float) for e in P.values())
+
+    _, D2 = m.diagonalize(reals_only=True)
+    assert D == D2
+
+def test_is_diagonalizable():
+    a, b, c = symbols('a b c')
+    m = EigenOnlyMatrix(2, 2, [a, c, c, b])
+    assert m.is_symmetric()
+    assert m.is_diagonalizable()
+    assert not EigenOnlyMatrix(2, 2, [1, 1, 0, 1]).is_diagonalizable()
+
+    m = EigenOnlyMatrix(2, 2, [0, -1, 1, 0])
+    assert m.is_diagonalizable()
+    assert not m.is_diagonalizable(reals_only=True)
+
+def test_jordan_form():
+    m = Matrix(3, 2, [-3, 1, -3, 20, 3, 10])
+    raises(NonSquareMatrixError, lambda: m.jordan_form())
+
+    # the next two tests test the cases where the old
+    # algorithm failed due to the fact that the block structure can
+    # *NOT* be determined  from algebraic and geometric multiplicity alone
+    # This can be seen most easily when one lets compute the J.c.f. of a matrix that
+    # is in J.c.f already.
+    m = EigenOnlyMatrix(4, 4, [2, 1, 0, 0,
+                    0, 2, 1, 0,
+                    0, 0, 2, 0,
+                    0, 0, 0, 2
+    ])
+    P, J = m.jordan_form()
+    assert m == J
+
+    m = EigenOnlyMatrix(4, 4, [2, 1, 0, 0,
+                    0, 2, 0, 0,
+                    0, 0, 2, 1,
+                    0, 0, 0, 2
+    ])
+    P, J = m.jordan_form()
+    assert m == J
+
+    A = Matrix([[ 2,  4,  1,  0],
+                [-4,  2,  0,  1],
+                [ 0,  0,  2,  4],
+                [ 0,  0, -4,  2]])
+    P, J = A.jordan_form()
+    assert simplify(P*J*P.inv()) == A
+
+    assert EigenOnlyMatrix(1,1,[1]).jordan_form() == (Matrix([1]), Matrix([1]))
+    assert EigenOnlyMatrix(1,1,[1]).jordan_form(calc_transform=False) == Matrix([1])
+
+    # make sure if we cannot factor the characteristic polynomial, we raise an error
+    m = Matrix([[3, 0, 0, 0, -3], [0, -3, -3, 0, 3], [0, 3, 0, 3, 0], [0, 0, 3, 0, 3], [3, 0, 0, 3, 0]])
+    raises(MatrixError, lambda: m.jordan_form())

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1260,7 +1260,6 @@ def test_jordan_form():
     m = Matrix([
         [                0.6875, 0.125 + 0.1875*sqrt(3)],
         [0.125 + 0.1875*sqrt(3),                 0.3125]])
-
     P, J = m.jordan_form()
     assert all(isinstance(x, Float) or x == 0 for x in P)
     assert all(isinstance(x, Float) or x == 0 for x in J)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -216,14 +216,14 @@ def test_power():
         [0, 0, b**n]])
 
     A = Matrix([[1, 0], [1, 7]])
-    assert A._matrix_pow_by_jordan_blocks(3) == A._matrix_pow_by_recursion(3)
+    assert A._matrix_pow_by_jordan_blocks(3) == A._eval_pow_by_recursion(3)
     A = Matrix([[2]])
     assert A**10 == Matrix([[2**10]]) == A._matrix_pow_by_jordan_blocks(10) == \
-        A._matrix_pow_by_recursion(10)
+        A._eval_pow_by_recursion(10)
 
     # testing a matrix that cannot be jordan blocked issue 11766
     m = Matrix([[3, 0, 0, 0, -3], [0, -3, -3, 0, 3], [0, 3, 0, 3, 0], [0, 0, 3, 0, 3], [3, 0, 0, 3, 0]])
-    raises(AttributeError, lambda: m._matrix_pow_by_jordan_blocks(10))
+    raises(MatrixError, lambda: m._matrix_pow_by_jordan_blocks(10))
 
     # test issue 11964
     raises(ValueError, lambda: Matrix([[1, 1], [3, 3]])._matrix_pow_by_jordan_blocks(-10))
@@ -1628,10 +1628,6 @@ def test_jordan_form():
     Jmust = Matrix(3, 3, [2, 1, 0, 0, 2, 0, 0, 0, 2])
     P, J = m.jordan_form()
     assert Jmust == J
-    P, Jcells = m.jordan_cells()
-    # same here see 1456ff
-    assert Jcells[1] == Matrix(1, 1, [2])
-    assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
 
     # complexity: all of eigenvalues are equal
     m = Matrix(3, 3, [2, 6, -15, 1, 1, -5, 1, 2, -6])
@@ -1672,27 +1668,6 @@ def test_jordan_form():
     P, J = m.jordan_form()
     assert Jmust == J
 
-    # the following tests are new and include (some) test the cases where the old
-    # algorithm failed due to the fact that the block structure can
-    # *NOT* be determined  from algebraic and geometric multiplicity alone
-    # This can be seen most easily when one lets compute the J.c.f. of a matrix that
-    # is in J.c.f already.
-    m = Matrix(4, 4, [2, 1, 0, 0,
-                    0, 2, 1, 0,
-                    0, 0, 2, 0,
-                    0, 0, 0, 2
-    ])
-    P, J = m.jordan_form()
-    assert m == J
-
-    m = Matrix(4, 4, [2, 1, 0, 0,
-                    0, 2, 0, 0,
-                    0, 0, 2, 1,
-                    0, 0, 0, 2
-    ])
-    P, J = m.jordan_form()
-    assert m == J
-
 
 def test_jordan_form_complex_issue_9274():
     A = Matrix([[ 2,  4,  1,  0],
@@ -1719,12 +1694,16 @@ def test_issue_10220():
                 [0, 1, 1, 0],
                 [0, 0, 1, 1],
                 [0, 0, 0, 1]])
-    P, C = M.jordan_cells()
+    P, J = M.jordan_form()
     assert P == Matrix([[0, 1, 0, 1],
                         [1, 0, 0, 0],
                         [0, 1, 0, 0],
                         [0, 0, 1, 0]])
-    assert len(C) == 2
+    assert J == Matrix([
+                        [1, 1, 0, 0],
+                        [0, 1, 1, 0],
+                        [0, 0, 1, 0],
+                        [0, 0, 0, 1]])
 
 
 def test_Matrix_berkowitz_charpoly():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,5 +1,6 @@
 import collections
 import random
+import warnings
 
 from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
@@ -16,6 +17,7 @@ from sympy.matrices import (
 from sympy.core.compatibility import long, iterable, range
 from sympy.utilities.iterables import flatten, capture
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.solvers import solve
 from sympy.assumptions import Q
 
@@ -2940,3 +2942,14 @@ def test_as_real_imag():
         a,b = kls(m3).as_real_imag()
         assert list(a) == list(m1)
         assert list(b) == list(m1)
+
+def test_deprecated():
+    # Maintain tests for deprecated functions.  We must capture
+    # the deprecation warnings.  When the deprecated functionality is
+    # removed, the corresponding tests should be removed.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        P, Jcells = m.jordan_cells()
+        assert Jcells[1] == Matrix(1, 1, [2])
+        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])


### PR DESCRIPTION
This PR moves `jordan_form` into `EigenMatrix` as well as adds tests for `EigenMatrix`. It also deprecates `jordan_cell` and `jordan_cells`, replacing `jordan_cell` with `jordan_block`.