### PR TITLE
Change printing of DifferentialExtesion object, add __eq__

### DIFF
--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -603,14 +603,14 @@ class DifferentialExtension(object):
     # attributes of a DifferentialExtension object
     def __repr__(self):
         # no need to have GeneratorType object printed in it
-        r = {attr: getattr(self, attr) for attr in self.__slots__ \
-                if not isinstance(getattr(self, attr), GeneratorType)}
-        return self.__class__.__name__ + '(%r)' % r
+        r = [(attr, getattr(self, attr)) for attr in self.__slots__
+                if not isinstance(getattr(self, attr), GeneratorType)]
+        return self.__class__.__name__ + '(dict(%r))' % (r)
 
     # fancy printing of DifferentialExtension object
     def __str__(self):
-        return self.__class__.__name__ + '({fa=%s, fd=%s, D=%s})' % \
-                (self.fa, self.fd, self.D)
+        return (self.__class__.__name__ + '({fa=%s, fd=%s, D=%s})' %
+                (self.fa, self.fd, self.D))
 
     # should only be used for debugging purposes, internally
     # f1 = f2 = log(x) at different places in code execution

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -667,12 +667,21 @@ def test_xtothex():
     assert isinstance(a, NonElementaryIntegral)
 
 
+def test_DifferentialExtension_equality():
+    DE1 = DE2 = DifferentialExtension(log(x), x)
+    assert DE1 == DE2
+
+
 def test_DifferentialExtension_printing():
     DE = DifferentialExtension(exp(2*x**2) + log(exp(x**2) + 1), x)
-    assert repr(DE) == "DifferentialExtension(extension=dict(fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), " \
-        "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), " \
-        "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]))"
-    assert str(DE) == "{'fa': Poly(t1 + t0**2, t1, domain='ZZ[t0]'), 'fd': Poly(1, t1, domain='ZZ'), " \
-        "'D': [Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')], " \
-        "'T': [x, t0, t1], 'Tfuncs': [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))], 'backsubs': [], " \
-        "'E_K': [1], 'E_args': [x**2], 'L_K': [2], 'L_args': [t0 + 1]}"
+    assert repr(DE) == "DifferentialExtension({'f': exp(2*x**2) + log(exp(x**2) + 1), " \
+            "'x': x, 'T': [x, t0, t1], 'D': [Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "  \
+            "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')], 'fa': Poly(t1 + t0**2, t1, domain='ZZ[t0]'), " \
+            "'fd': Poly(1, t1, domain='ZZ'), 'Tfuncs': [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))], " \
+            "'backsubs': [], 'E_K': [1], 'E_args': [x**2], 'L_K': [2], 'L_args': [t0 + 1], " \
+            "'cases': ['base', 'exp', 'primitive'], 'case': 'primitive', 't': t1, 'd': Poly(2*t0*x/(t0 + 1), " \
+            "t1, domain='ZZ(x,t0)'), 'newf': t0**2 + t1, 'level': -1, 'dummy': False})"
+
+    assert str(DE) == "DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), " \
+            "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), " \
+            "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]})"

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -674,14 +674,15 @@ def test_DifferentialExtension_equality():
 
 def test_DifferentialExtension_printing():
     DE = DifferentialExtension(exp(2*x**2) + log(exp(x**2) + 1), x)
-    assert repr(DE) == "DifferentialExtension({'f': exp(2*x**2) + log(exp(x**2) + 1), " \
-            "'x': x, 'T': [x, t0, t1], 'D': [Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "  \
-            "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')], 'fa': Poly(t1 + t0**2, t1, domain='ZZ[t0]'), " \
-            "'fd': Poly(1, t1, domain='ZZ'), 'Tfuncs': [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))], " \
-            "'backsubs': [], 'E_K': [1], 'E_args': [x**2], 'L_K': [2], 'L_args': [t0 + 1], " \
-            "'cases': ['base', 'exp', 'primitive'], 'case': 'primitive', 't': t1, 'd': Poly(2*t0*x/(t0 + 1), " \
-            "t1, domain='ZZ(x,t0)'), 'newf': t0**2 + t1, 'level': -1, 'dummy': False})"
+    assert repr(DE) == ("DifferentialExtension(dict([('f', exp(2*x**2) + log(exp(x**2) + 1)), "
+        "('x', x), ('T', [x, t0, t1]), ('D', [Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
+        "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]), ('fa', Poly(t1 + t0**2, t1, domain='ZZ[t0]')), "
+        "('fd', Poly(1, t1, domain='ZZ')), ('Tfuncs', [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))]), "
+        "('backsubs', []), ('E_K', [1]), ('E_args', [x**2]), ('L_K', [2]), ('L_args', [t0 + 1]), "
+        "('cases', ['base', 'exp', 'primitive']), ('case', 'primitive'), ('t', t1), "
+        "('d', Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')), ('newf', t0**2 + t1), ('level', -1), "
+        "('dummy', False)]))")
 
-    assert str(DE) == "DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), " \
-            "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), " \
-            "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]})"
+    assert str(DE) == ("DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), "
+        "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
+        "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]})")


### PR DESCRIPTION
Though we changed the printing of `DifferentialExtension` object in #12372 , but I now realize that debugging by this method will be more useful. The `_imporant_attributes` aren't enough for that.