### PR TITLE
Optimize `ImmutableMatrix`

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -22,6 +22,17 @@ class Tuple(Basic):
     SymPy framework.  The wrapped tuple is available as self.args, but
     you can also access elements or slices with [:] syntax.
 
+    Parameters
+    ==========
+
+    sympify : bool
+        If ``False``, ``sympify`` is not called on ``args``. This
+        can be used for speedups for very large tuples where the
+        elements are known to already be sympy objects.
+
+    Example
+    =======
+
     >>> from sympy import symbols
     >>> from sympy.core.containers import Tuple
     >>> a, b, c, d = symbols('a b c d')
@@ -32,8 +43,9 @@ class Tuple(Basic):
 
     """
 
-    def __new__(cls, *args):
-        args = [ sympify(arg) for arg in args ]
+    def __new__(cls, *args, **kwargs):
+        if kwargs.get('sympify', True):
+            args = ( sympify(arg) for arg in args )
         obj = Basic.__new__(cls, *args)
         return obj
 

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -52,7 +52,7 @@ class Tuple(Basic):
     def __getitem__(self, i):
         if isinstance(i, slice):
             indices = i.indices(len(self))
-            return Tuple(*[self.args[j] for j in range(*indices)])
+            return Tuple(*(self.args[j] for j in range(*indices)))
         return self.args[i]
 
     def __len__(self):
@@ -103,7 +103,7 @@ class Tuple(Basic):
         return hash(self.args)
 
     def _to_mpmath(self, prec):
-        return tuple([a._to_mpmath(prec) for a in self.args])
+        return tuple(a._to_mpmath(prec) for a in self.args)
 
     def __lt__(self, other):
         return sympify(self.args < other.args)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -155,6 +155,13 @@ class DenseMatrix(MatrixBase):
         mat = [a + b for a,b in zip(self._mat, other._mat)]
         return classof(self, other)._new(self.rows, self.cols, mat, copy=False)
 
+    def _eval_extract(self, rowsList, colsList):
+        mat = self._mat
+        cols = self.cols
+        indices = (i * cols + j for i in rowsList for j in colsList)
+        return self._new(len(rowsList), len(colsList),
+                         list(mat[i] for i in indices), copy=False)
+
     def _eval_matrix_mul(self, other):
         from sympy import Add
         # cache attributes for faster access

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -27,6 +27,17 @@ def _iszero(x):
     return x.is_zero
 
 
+def _compare_sequence(a, b):
+    """Compares the elements of a list/tupe `a`
+    and a list/tuple `b`.  `_compare_sequence((1,2), [1, 2])`
+    is True, whereas `(1,2) == [1, 2]` is False"""
+    if type(a) is type(b):
+        # if they are the same type, compare directly
+        return a == b
+    # there is no overhead for calling `tuple` on a
+    # tuple
+    return tuple(a) == tuple(b)
+
 class DenseMatrix(MatrixBase):
 
     is_MatrixExpr = False
@@ -40,9 +51,9 @@ class DenseMatrix(MatrixBase):
             if self.shape != other.shape:
                 return False
             if isinstance(other, Matrix):
-                return self._mat == other._mat
+                return _compare_sequence(self._mat,  other._mat)
             elif isinstance(other, MatrixBase):
-                return self._mat == Matrix(other)._mat
+                return _compare_sequence(self._mat, Matrix(other)._mat)
         except AttributeError:
             return False
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -28,7 +28,7 @@ def _iszero(x):
 
 
 def _compare_sequence(a, b):
-    """Compares the elements of a list/tupe `a`
+    """Compares the elements of a list/tuple `a`
     and a list/tuple `b`.  `_compare_sequence((1,2), [1, 2])`
     is True, whereas `(1,2) == [1, 2]` is False"""
     if type(a) is type(b):

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -41,11 +41,19 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
     def __new__(cls, *args, **kwargs):
         if len(args) == 1 and isinstance(args[0], ImmutableDenseMatrix):
             return args[0]
-        rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
+        if kwargs.get('copy', True) is False:
+            if len(args) != 3:
+                raise TypeError("'copy=False' requires a matrix be initialized as rows,cols,[list]")
+            rows, cols, flat_list = args
+        else:
+            rows, cols, flat_list = cls._handle_creation_inputs(*args, **kwargs)
+            flat_list = list(flat_list) # create a shallow copy
         rows = Integer(rows)
         cols = Integer(cols)
-        mat = Tuple(*flat_list)
-        return Basic.__new__(cls, rows, cols, mat)
+        if not isinstance(flat_list, Tuple):
+            flat_list = Tuple(*flat_list)
+
+        return Basic.__new__(cls, rows, cols, flat_list)
 
     __hash__ = MatrixExpr.__hash__
 
@@ -80,6 +88,15 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
             return None
         diff = self - other
         return sympify(diff.is_zero)
+
+    def _eval_extract(self, rowsList, colsList):
+        # self._mat is a Tuple.  It is slightly faster to index a
+        # tuple over a Tuple, so grab the internal tuple directly
+        mat = self._mat.args
+        cols = self.cols
+        indices = (i * cols + j for i in rowsList for j in colsList)
+        return self._new(len(rowsList), len(colsList),
+                         Tuple(*(mat[i] for i in indices), sympify=False), copy=False)
 
     @property
     def cols(self):

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -55,7 +55,7 @@ class ImmutableDenseMatrix(DenseMatrix, MatrixExpr):
 
     @property
     def _mat(self):
-        return list(self.args[2])
+        return self.args[2]
 
     def _entry(self, i, j):
         return DenseMatrix.__getitem__(self, (i, j))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -15,6 +15,7 @@ from sympy.matrices import (
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix)
 from sympy.core.compatibility import long, iterable, range
+from sympy.core import Tuple
 from sympy.utilities.iterables import flatten, capture
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -35,7 +36,7 @@ def test_args():
         assert m.rows == 3 and type(m.rows) is int
         assert m.cols == 2 and type(m.cols) is int
         if not c % 2:
-            assert type(m._mat) is list
+            assert type(m._mat) in (list, tuple, Tuple)
         else:
             assert type(m._smat) is dict
 


### PR DESCRIPTION
There was quadratic complexity growth in `ImmutableDenseMatrix`
because `list(self.args[2])` was called every time `self._mat`
was accessed.  This patch passes the request directly through.

Tests show a small speedup for small matrices and a large speedup for big matrices.

Running

```
X = DeferredVector("X")
for i in range(1,11):
    w = 100*i
    mat = Matrix(1, w, lambda i, j: X[i*j])
    print(w)
    %timeit lambdify(X, mat)
```

produces 

```
100
100 loops, best of 3: 4.73 ms per loop
200
100 loops, best of 3: 9.19 ms per loop
300
100 loops, best of 3: 13.9 ms per loop
400
100 loops, best of 3: 18.9 ms per loop
500
10 loops, best of 3: 24.2 ms per loop
600
10 loops, best of 3: 29.3 ms per loop
700
10 loops, best of 3: 34.7 ms per loop
800
10 loops, best of 3: 40.6 ms per loop
900
10 loops, best of 3: 46.4 ms per loop
1000
10 loops, best of 3: 53 ms per loop
```

on master and

```
100
100 loops, best of 3: 4.55 ms per loop
200
100 loops, best of 3: 8.34 ms per loop
300
100 loops, best of 3: 12.3 ms per loop
400
100 loops, best of 3: 16.2 ms per loop
500
10 loops, best of 3: 20 ms per loop
600
10 loops, best of 3: 23.9 ms per loop
700
10 loops, best of 3: 27.8 ms per loop
800
10 loops, best of 3: 31.7 ms per loop
900
10 loops, best of 3: 35.7 ms per loop
1000
10 loops, best of 3: 39.9 ms per loop
```

with this PR.

With a matrix of size 10000, the difference is `396 ms` vs `1.55 s`