### PR TITLE
Add __wrapped__ to slow wrapper

### DIFF
--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -147,6 +147,7 @@ if not USE_PYTEST:
             func()
 
         func_wrapper = functools.update_wrapper(func_wrapper, func)
+        func_wrapper.__wrapped__ = func
         return func_wrapper
 
 else:


### PR DESCRIPTION
SymPy's test finds the slow tests by following the `__wrapped__`
links provided by update_wrapper in Python 3.2. This PR adds
the attribute to enable slow tests in all versions.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
