### PR TITLE
Improve docs for custom printing

### DIFF
--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -94,6 +94,10 @@ in a shorter form.
                not all(isinstance(i, Symbol) for i in vars):
                 return super()._print_Derivative(expr)
 
+	    # If you want the printer to work correctly for nested
+	    # expressions then use self._print() instead of str() or latex().
+	    # See the example of nested modulo below in the custom printing
+	    # method section.
             return "{}_{{{}}}".format(
                 self._print(Symbol(function.func.__name__)),
                             ''.join(self._print(i) for i in vars))

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -96,7 +96,7 @@ for your custom SymPy object. See the code below::
 
         def _latex(self, printer=None):
             # This is the printmethod of LatexPrinter.
-            return \"\\\\textbf{{{}}}\".format(self.text)
+            return self.text
 
     class MyPrinter(Printer):
         \"\"\" Our custom Printer. \"\"\"
@@ -150,7 +150,7 @@ The output of the code above is::
     x'
     My expression on steroids.
     MY EXPRESSION ON STEROIDS.
-    \\textbf{My expression on steroids.}
+    My expression on steroids.
 
 """
 

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -19,7 +19,7 @@ While looking for the method, it follows these steps:
 
 1. **Let the object print itself if it knows how.**
 
-    The printers looks for a specific method in every object. The name of that method
+    The printers look for a specific method in every object. The name of that method
     depends on the specific printer and is defined under ``Printer.printmethod``.
     For example, StrPrinter calls ``_sympystr`` and LatexPrinter calls ``_latex``.
     Look at the documentation of the printer that you want to use.
@@ -75,8 +75,10 @@ Example of Custom Printer
 
 .. _printer_example:
 
-In the example below, we have a printer which prints derivative of a function
-in a shorter form. See the code below::
+In the example below, we have a printer which prints the derivative of a function
+in a shorter form.
+
+.. code-block:: python
 
     from sympy import Symbol
     from sympy.printing.latex import LatexPrinter, print_latex
@@ -99,7 +101,7 @@ in a shorter form. See the code below::
 
     def print_my_latex(expr):
         \"\"\" Most of the printers define their own wrappers for print().
-        These wrappers usually takes printer settings. Our printer does not have
+        These wrappers usually take printer settings. Our printer does not have
         any settings.
         \"\"\"
         print(MyLatexPrinter().doprint(expr))
@@ -123,9 +125,10 @@ The output of the code above is::
 Example of Custom Printing Method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In this example below, we want to print modulo operator in a different way in
-latex. Therefore, we override the method ``_latex`` of ``Mod``. See the example
-below::
+In the example below, the latex printing of the modulo operator is modified.
+This is done by overriding the method ``_latex`` of ``Mod``.
+
+.. code-block:: python
 
     from sympy import Symbol, Mod
     from sympy.printing.latex import print_latex

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -122,6 +122,32 @@ The output of the code above is::
 
 Example of Custom Printing Method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In this example below, we want to print modulo operator in a different way in
+latex. Therefore, we override the method ``_latex`` of ``Mod``. See the example
+below::
+
+    from sympy import Symbol, Mod
+    from sympy.printing.latex import print_latex
+
+
+    class ModOp(Mod):
+        def _latex(self, printer=None):
+            a, b = [printer.doprint(i) for i in self.args]
+            return "\operatorname{Mod}{\left( %s,%s \\\\right)}" % (a,b)
+
+
+    x = Symbol('x')
+    m = Symbol('m')
+
+    print_latex(ModOp(x, m))
+    print_latex(Mod(x, m))
+
+The output of the code above is::
+
+    \\operatorname{Mod}{\\left( x,m \\right)}
+    x\\bmod{m}
+
 """
 
 from __future__ import print_function, division

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -168,7 +168,6 @@ The output of the code above is::
     x\\bmod{m}
     \operatorname{Mod}{\left( \operatorname{Mod}{\left( x,m \\right)},7 \\right)}
     \operatorname{Mod}{\left( ModOpWrong(x, m),7 \\right)}
-
 """
 
 from __future__ import print_function, division

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -137,7 +137,7 @@ This is done by overriding the method ``_latex`` of ``Mod``.
     class ModOp(Mod):
         def _latex(self, printer=None):
             a, b = [printer.doprint(i) for i in self.args]
-            return "\operatorname{Mod}{\left( %s,%s \\\\right)}" % (a,b)
+            return r"\\operatorname{Mod}{\left( %s,%s \\\\right)}" % (a,b)
 
 
     x = Symbol('x')

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -130,14 +130,22 @@ This is done by overriding the method ``_latex`` of ``Mod``.
 
 .. code-block:: python
 
-    from sympy import Symbol, Mod
+    from sympy import Symbol, Mod, Integer
     from sympy.printing.latex import print_latex
 
 
     class ModOp(Mod):
-        def _latex(self, printer=None):
-            a, b = [printer.doprint(i) for i in self.args]
-            return r"\\operatorname{Mod}{\left( %s,%s \\\\right)}" % (a,b)
+	def _latex(self, printer=None):
+	    # Always use printer.doprint() otherwise nested expressions won't
+	    # work. See the example of ModOpWrong.
+	    a, b = [printer.doprint(i) for i in self.args]
+	    return r"\operatorname{Mod}{\left( %s,%s \\right)}" % (a,b)
+
+
+    class ModOpWrong(Mod):
+	def _latex(self, printer=None):
+	    a, b = [str(i) for i in self.args]
+	    return r"\operatorname{Mod}{\left( %s,%s \\right)}" % (a,b)
 
 
     x = Symbol('x')
@@ -146,10 +154,16 @@ This is done by overriding the method ``_latex`` of ``Mod``.
     print_latex(ModOp(x, m))
     print_latex(Mod(x, m))
 
+    # Nested modulo.
+    print_latex(ModOp(ModOp(x, m), Integer(7)))
+    print_latex(ModOpWrong(ModOpWrong(x, m), Integer(7)))
+
 The output of the code above is::
 
-    \\operatorname{Mod}{\\left( x,m \\right)}
+    \operatorname{Mod}{\left( x,m \\right)}
     x\\bmod{m}
+    \operatorname{Mod}{\left( \operatorname{Mod}{\left( x,m \\right)},7 \\right)}
+    \operatorname{Mod}{\left( ModOpWrong(x, m),7 \\right)}
 
 """
 

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -19,7 +19,7 @@ While looking for the method, it follows these steps:
 
 1. **Let the object print itself if it knows how.**
 
-    The printers look for a specific method in every object. The name of that method
+    The printer looks for a specific method in every object. The name of that method
     depends on the specific printer and is defined under ``Printer.printmethod``.
     For example, StrPrinter calls ``_sympystr`` and LatexPrinter calls ``_latex``.
     Look at the documentation of the printer that you want to use.

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -94,10 +94,10 @@ in a shorter form.
                not all(isinstance(i, Symbol) for i in vars):
                 return super()._print_Derivative(expr)
 
-	    # If you want the printer to work correctly for nested
-	    # expressions then use self._print() instead of str() or latex().
-	    # See the example of nested modulo below in the custom printing
-	    # method section.
+            # If you want the printer to work correctly for nested
+            # expressions then use self._print() instead of str() or latex().
+            # See the example of nested modulo below in the custom printing
+            # method section.
             return "{}_{{{}}}".format(
                 self._print(Symbol(function.func.__name__)),
                             ''.join(self._print(i) for i in vars))
@@ -139,17 +139,17 @@ This is done by overriding the method ``_latex`` of ``Mod``.
 
 
     class ModOp(Mod):
-	def _latex(self, printer=None):
-	    # Always use printer.doprint() otherwise nested expressions won't
-	    # work. See the example of ModOpWrong.
-	    a, b = [printer.doprint(i) for i in self.args]
-	    return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
+        def _latex(self, printer=None):
+            # Always use printer.doprint() otherwise nested expressions won't
+            # work. See the example of ModOpWrong.
+            a, b = [printer.doprint(i) for i in self.args]
+            return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
 
 
     class ModOpWrong(Mod):
-	def _latex(self, printer=None):
-	    a, b = [str(i) for i in self.args]
-	    return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
+        def _latex(self, printer=None):
+            a, b = [str(i) for i in self.args]
+            return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
 
 
     x = Symbol('x')

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -143,13 +143,13 @@ This is done by overriding the method ``_latex`` of ``Mod``.
 	    # Always use printer.doprint() otherwise nested expressions won't
 	    # work. See the example of ModOpWrong.
 	    a, b = [printer.doprint(i) for i in self.args]
-	    return r"\operatorname{Mod}{\left( %s,%s \\right)}" % (a,b)
+	    return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
 
 
     class ModOpWrong(Mod):
 	def _latex(self, printer=None):
 	    a, b = [str(i) for i in self.args]
-	    return r"\operatorname{Mod}{\left( %s,%s \\right)}" % (a,b)
+	    return r"\\operatorname{Mod}{\\left( %s,%s \\right)}" % (a,b)
 
 
     x = Symbol('x')
@@ -164,10 +164,10 @@ This is done by overriding the method ``_latex`` of ``Mod``.
 
 The output of the code above is::
 
-    \operatorname{Mod}{\left( x,m \\right)}
+    \\operatorname{Mod}{\\left( x,m \\right)}
     x\\bmod{m}
-    \operatorname{Mod}{\left( \operatorname{Mod}{\left( x,m \\right)},7 \\right)}
-    \operatorname{Mod}{\left( ModOpWrong(x, m),7 \\right)}
+    \\operatorname{Mod}{\\left( \\operatorname{Mod}{\\left( x,m \\right)},7 \\right)}
+    \\operatorname{Mod}{\\left( ModOpWrong(x, m),7 \\right)}
 """
 
 from __future__ import print_function, division


### PR DESCRIPTION
Add example of writing custom printing method for printing custom expressions.

Simplify some parts of the example to highlight the important parts.

Rewrite the code from python2 to python3.

Encourage the users to write their own wrappers for `print()` instead of
overriding `Basic.__str__` .

Improve the formatting of the whole tutorial.

Move the parts that were duplicated into one place.

Fixes #11025
