### PR TITLE
Faster `tolist` for `DenseMatrix`

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -279,7 +279,7 @@ class DenseMatrix(MatrixBase):
         return self._new(self.rows, self.cols, mat, copy=False)
 
     def _eval_tolist(self):
-        mat = self._mat
+        mat = list(self._mat)
         cols = self.cols
         return [mat[i*cols:(i + 1)*cols] for i in range(self.rows)]
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -278,6 +278,11 @@ class DenseMatrix(MatrixBase):
         mat = [a*other for a in self._mat]
         return self._new(self.rows, self.cols, mat, copy=False)
 
+    def _eval_tolist(self):
+        mat = self._mat
+        cols = self.cols
+        return [mat[i*cols:(i + 1)*cols] for i in range(self.rows)]
+
     def _LDLdecomposition(self):
         """Helper function of LDLdecomposition.
         Without the error checks.


### PR DESCRIPTION
Speedup `tolist` for `DenseMatrix` subclasses.  This gives a 20% speed boost to `lambdify` on a dense matrix.  See #12731