### PR TITLE
Move calculation from Del class to gradient, curl, divergence.

### DIFF
--- a/doc/src/modules/vector/examples.rst
+++ b/doc/src/modules/vector/examples.rst
@@ -88,7 +88,8 @@ Solution
 
 Start with a coordinate system
 
-  >>> from sympy.vector import CoordSysCartesian
+  >>> from sympy.vector import CoordSysCartesian, Del
+  >>> delop = Del()
   >>> C = CoordSysCartesian('C')
 
 The scalar field :math:`f` and the measure numbers of the vector field
@@ -109,11 +110,11 @@ Define the vector field as ``vfield`` and the scalar field as ``sfield``.
 
 Construct the expression for the LHS of the equation using ``C.delop``.
 
-  >>> lhs = (C.delop.dot(ffield * vfield)).doit()
+  >>> lhs = (delop.dot(ffield * vfield)).doit()
 
 Similarly, the RHS would be defined.
 
-  >>> rhs = ((vfield.dot(C.delop(ffield))) + (ffield * (C.delop.dot(vfield)))).doit()
+  >>> rhs = ((vfield.dot(delop(ffield))) + (ffield * (delop.dot(vfield)))).doit()
 
 Now, to prove the product rule, we would just need to equate the expanded and
 simplified versions of the lhs and the rhs, so that the SymPy expressions match.

--- a/doc/src/modules/vector/fields.rst
+++ b/doc/src/modules/vector/fields.rst
@@ -92,9 +92,10 @@ would be accessible as ``C.delop``.
 
 Given below is an example of usage of the ``delop`` object.
 
-  >>> from sympy.vector import CoordSysCartesian
+  >>> from sympy.vector import CoordSysCartesian, Del
   >>> C = CoordSysCartesian('C')
-  >>> gradient_field = C.delop(C.x*C.y*C.z)
+  >>> delop = Del()
+  >>> gradient_field = delop(C.x*C.y*C.z)
   >>> gradient_field
   (Derivative(C.x*C.y*C.z, C.x))*C.i + (Derivative(C.x*C.y*C.z, C.y))*C.j + (Derivative(C.x*C.y*C.z, C.z))*C.k
 
@@ -137,11 +138,12 @@ accomplished in two ways.
 
 One, by using the ``delop`` property
 
-  >>> from sympy.vector import CoordSysCartesian
+  >>> from sympy.vector import CoordSysCartesian, Del
   >>> C = CoordSysCartesian('C')
-  >>> C.delop.cross(C.x*C.y*C.z*C.i).doit()
+  >>> delop = Del()
+  >>> delop.cross(C.x*C.y*C.z*C.i).doit()
   C.x*C.y*C.j + (-C.x*C.z)*C.k
-  >>> (C.delop ^ C.x*C.y*C.z*C.i).doit()
+  >>> (delop ^ C.x*C.y*C.z*C.i).doit()
   C.x*C.y*C.j + (-C.x*C.z)*C.k
 
 Or by using the dedicated function
@@ -174,11 +176,12 @@ accomplished in two ways.
 
 One, by using the ``delop`` property
 
-  >>> from sympy.vector import CoordSysCartesian
+  >>> from sympy.vector import CoordSysCartesian, Del
   >>> C = CoordSysCartesian('C')
-  >>> C.delop.dot(C.x*C.y*C.z*(C.i + C.j + C.k)).doit()
+  >>> delop = Del()
+  >>> delop.dot(C.x*C.y*C.z*(C.i + C.j + C.k)).doit()
   C.x*C.y + C.x*C.z + C.y*C.z
-  >>> (C.delop & C.x*C.y*C.z*(C.i + C.j + C.k)).doit()
+  >>> (delop & C.x*C.y*C.z*(C.i + C.j + C.k)).doit()
   C.x*C.y + C.x*C.z + C.y*C.z
 
 Or by using the dedicated function
@@ -207,11 +210,12 @@ accomplished in two ways.
 
 One, by using the ``delop`` property
 
-  >>> from sympy.vector import CoordSysCartesian
+  >>> from sympy.vector import CoordSysCartesian, Del
   >>> C = CoordSysCartesian('C')
-  >>> C.delop.gradient(C.x*C.y*C.z).doit()
+  >>> delop = Del()
+  >>> delop.gradient(C.x*C.y*C.z).doit()
   C.y*C.z*C.i + C.x*C.z*C.j + C.x*C.y*C.k
-  >>> C.delop(C.x*C.y*C.z).doit()
+  >>> delop(C.x*C.y*C.z).doit()
   C.y*C.z*C.i + C.x*C.z*C.j + C.x*C.y*C.k
 
 Or by using the dedicated function
@@ -237,14 +241,15 @@ Directional derivatives of vector and scalar fields can be computed in
 :mod:`sympy.vector` using the ``delop`` property of
 ``CoordSysCartesian``.
 
-  >>> from sympy.vector import CoordSysCartesian
+  >>> from sympy.vector import CoordSysCartesian, Del
   >>> C = CoordSysCartesian('C')
+  >>> delop = Del()
   >>> vel = C.i + C.j + C.k
   >>> scalar_field = C.x*C.y*C.z
   >>> vector_field = C.x*C.y*C.z*C.i
-  >>> (vel.dot(C.delop))(scalar_field)
+  >>> (vel.dot(delop))(scalar_field)
   C.x*C.y + C.x*C.z + C.y*C.z
-  >>> (vel & C.delop)(vector_field)
+  >>> (vel & delop)(vector_field)
   (C.x*C.y + C.x*C.z + C.y*C.z)*C.i
 
 Conservative and Solenoidal fields

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3938,9 +3938,7 @@ def test_sympy__vector__dyadic__DyadicZero():
 
 def test_sympy__vector__deloperator__Del():
     from sympy.vector.deloperator import Del
-    from sympy.vector.coordsysrect import CoordSysCartesian
-    C = CoordSysCartesian('C')
-    assert _test_args(Del(C))
+    assert _test_args(Del())
 
 
 def test_sympy__vector__operators__Curl():

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -1269,12 +1269,13 @@ def test_O3():
     assert (va ^ vb) | (vc ^ vd) == -(va | vc)*(vb | vd) + (va | vd)*(vb | vc)
 
 def test_O4():
-    from sympy.vector import CoordSysCartesian
+    from sympy.vector import CoordSysCartesian, Del
     N = CoordSysCartesian("N")
+    delop = Del()
     i, j, k = N.base_vectors()
     x, y, z = N.base_scalars()
     F = i*(x*y*z) + j*((x*y*z)**2) + k*((y**2)*(z**3))
-    assert N.delop.cross(F).doit() == (-2*x**2*y**2*z + 2*y*z**3)*i + x*y*j + (2*x*y**2*z**2 - x*z)*k
+    assert delop.cross(F).doit() == (-2*x**2*y**2*z + 2*y*z**3)*i + x*y*j + (2*x*y**2*z**2 - x*z)*k
 
 # The vector module has no way of representing vectors symbolically (without
 # respect to a basis)

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -6,7 +6,6 @@ from sympy.vector.scalar import BaseScalar
 from sympy.vector.deloperator import Del
 from sympy.vector.coordsysrect import CoordSysCartesian
 from sympy.vector.functions import (express, matrix_to_vector,
-                                    curl, divergence, gradient,
                                     is_conservative, is_solenoidal,
                                     scalar_potential, directional_derivative,
                                     scalar_potential_difference)

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -1,14 +1,14 @@
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.basic import Basic
-from sympy.vector.scalar import BaseScalar
-from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol
 from sympy.core.compatibility import string_types, range
 from sympy.core.cache import cacheit
+from sympy.core import S
+from sympy.vector.scalar import BaseScalar
+from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol, sin
+import sympy.vector
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-from sympy.core import S
-from sympy import sin
-import sympy.vector
-from sympy.utilities.exceptions import SymPyDeprecationWarning
+
 
 class CoordSysCartesian(Basic):
     """
@@ -150,9 +150,6 @@ class CoordSysCartesian(Basic):
         obj._h2 = S.One
         obj._h3 = S.One
 
-        # Assign a Del operator instance
-        from sympy.vector.deloperator import Del
-        obj._delop = Del()
 
         # Assign params
         obj._parent = parent
@@ -198,7 +195,6 @@ class CoordSysCartesian(Basic):
         if curv_coord_name not in coefficient_mapping:
             raise ValueError('Wrong set of parameters. Type of coordinate system is defined')
         self._h1, self._h2, self._h3 = coefficient_mapping[curv_coord_name]
-        self._delop._h1, self._delop._h2, self._delop._h3 = coefficient_mapping[curv_coord_name]
 
     @property
     def origin(self):
@@ -211,7 +207,8 @@ class CoordSysCartesian(Basic):
             useinstead="it as instance Del class",
             deprecated_since_version="1.1"
             ).warn()
-        return self._delop
+        from sympy.vector.deloperator import Del
+        return Del()
 
     @property
     def i(self):

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -152,7 +152,7 @@ class CoordSysCartesian(Basic):
 
         # Assign a Del operator instance
         from sympy.vector.deloperator import Del
-        obj._delop = Del(obj)
+        obj._delop = Del()
 
         # Assign params
         obj._parent = parent

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -8,7 +8,7 @@ from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
 from sympy.core import S
 from sympy import cos
 import sympy.vector
-
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 class CoordSysCartesian(Basic):
     """
@@ -205,6 +205,11 @@ class CoordSysCartesian(Basic):
 
     @property
     def delop(self):
+        SymPyDeprecationWarning(
+            feature="delop operator inside coordinate system",
+            useinstead="it as instance Del class",
+            deprecated_since_version="1.1"
+            ).warn()
         return self._delop
 
     @property

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -1,3 +1,4 @@
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core import Basic
 from sympy.vector.vector import Vector
 from sympy.vector.operators import gradient, divergence, curl
@@ -9,7 +10,13 @@ class Del(Basic):
     mathematical expressions as the 'nabla' symbol.
     """
 
-    def __new__(cls, ):
+    def __new__(cls, system=None):
+        if system is not None:
+            SymPyDeprecationWarning(
+                feature="delop operator inside coordinate system",
+                useinstead="it as instance Del class",
+                deprecated_since_version="1.1"
+            ).warn()
         obj = super(Del, cls).__new__(cls)
         obj._name = "delop"
         return obj
@@ -36,9 +43,8 @@ class Del(Basic):
         >>> from sympy.vector import CoordSysCartesian, Del
         >>> C = CoordSysCartesian('C')
         >>> delop = Del()
-        >>> delop.gradient(C.x)
-        (Derivative(C.x, C.x))*C.i + (Derivative(C.x, C.y))*C.j +
-            (Derivative(C.x, C.z))*C.k
+        >>> delop.gradient(9)
+        0
         >>> delop(C.x*C.y*C.z).doit()
         C.y*C.z*C.i + C.x*C.z*C.j + C.x*C.y*C.k
 

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -1,10 +1,6 @@
 from sympy.core import Basic
-from sympy.core.function import Derivative
 from sympy.vector.vector import Vector
-from sympy.vector.functions import express
-from sympy.vector.coordsysrect import CoordSysCartesian
-from sympy.vector.scalar import BaseScalar
-from sympy.core import S
+from sympy.vector.operators import gradient, divergence, curl
 
 
 class Del(Basic):
@@ -13,19 +9,10 @@ class Del(Basic):
     mathematical expressions as the 'nabla' symbol.
     """
 
-    def __new__(cls, system):
-        if not isinstance(system, CoordSysCartesian):
-            raise TypeError("system should be a CoordSysCartesian")
-        obj = super(Del, cls).__new__(cls, system)
-        obj._x, obj._y, obj._z = system.x, system.y, system.z
-        obj._i, obj._j, obj._k = system.i, system.j, system.k
-        obj._system = system
-        obj._name = system.__str__() + ".delop"
+    def __new__(cls, ):
+        obj = super(Del, cls).__new__(cls)
+        obj._name = "delop"
         return obj
-
-    @property
-    def system(self):
-        return self._system
 
     def gradient(self, scalar_field, doit=False):
         """
@@ -48,28 +35,19 @@ class Del(Basic):
 
         >>> from sympy.vector import CoordSysCartesian
         >>> C = CoordSysCartesian('C')
-        >>> C.delop.gradient(9)
-        (Derivative(9, C.x))*C.i + (Derivative(9, C.y))*C.j +
-            (Derivative(9, C.z))*C.k
+        >>> C.delop.gradient(C.x)
+        (Derivative(C.x, C.x))*C.i + (Derivative(C.x, C.y))*C.j +
+            (Derivative(C.x, C.z))*C.k
         >>> C.delop(C.x*C.y*C.z).doit()
         C.y*C.z*C.i + C.x*C.z*C.j + C.x*C.y*C.k
 
         """
-
-        scalar_field = express(scalar_field, self.system,
-                               variables=True)
-        vx = Derivative(scalar_field, self._x)
-        vy = Derivative(scalar_field, self._y)
-        vz = Derivative(scalar_field, self._z)
-
-        if doit:
-            return (vx * self._i + vy * self._j + vz * self._k).doit()
-        return vx * self._i + vy * self._j + vz * self._k
+        return gradient(scalar_field, doit=doit)
 
     __call__ = gradient
     __call__.__doc__ = gradient.__doc__
 
-    def dot(self, vect, doit=False):
+    def dot(self, vector, doit=False):
         """
         Represents the dot product between this operator and a given
         vector - equal to the divergence of the vector field.
@@ -77,7 +55,7 @@ class Del(Basic):
         Parameters
         ==========
 
-        vect : Vector
+        vector : Vector
             The vector whose divergence is to be calculated.
 
         doit : bool
@@ -97,19 +75,12 @@ class Del(Basic):
         C.x*C.y + C.x*C.z + C.y*C.z
 
         """
-
-        vx = _diff_conditional(vect.dot(self._i), self._x)
-        vy = _diff_conditional(vect.dot(self._j), self._y)
-        vz = _diff_conditional(vect.dot(self._k), self._z)
-
-        if doit:
-            return (vx + vy + vz).doit()
-        return vx + vy + vz
+        return divergence(vector, doit=doit)
 
     __and__ = dot
     __and__.__doc__ = dot.__doc__
 
-    def cross(self, vect, doit=False):
+    def cross(self, vector, doit=False):
         """
         Represents the cross product between this operator and a given
         vector - equal to the curl of the vector field.
@@ -117,7 +88,7 @@ class Del(Basic):
         Parameters
         ==========
 
-        vect : Vector
+        vector : Vector
             The vector whose curl is to be calculated.
 
         doit : bool
@@ -139,20 +110,7 @@ class Del(Basic):
 
         """
 
-        vectx = express(vect.dot(self._i), self.system, variables=True)
-        vecty = express(vect.dot(self._j), self.system, variables=True)
-        vectz = express(vect.dot(self._k), self.system, variables=True)
-        outvec = Vector.zero
-        outvec += (Derivative(vectz, self._y) -
-                   Derivative(vecty, self._z)) * self._i
-        outvec += (Derivative(vectx, self._z) -
-                   Derivative(vectz, self._x)) * self._j
-        outvec += (Derivative(vecty, self._x) -
-                   Derivative(vectx, self._y)) * self._k
-
-        if doit:
-            return outvec.doit()
-        return outvec
+        return curl(vector, doit=doit)
 
     __xor__ = cross
     __xor__.__doc__ = cross.__doc__
@@ -162,17 +120,3 @@ class Del(Basic):
 
     __repr__ = __str__
     _sympystr = __str__
-
-
-def _diff_conditional(expr, base_scalar):
-    """
-    First re-expresses expr in the system that base_scalar belongs to.
-    If base_scalar appears in the re-expressed form, differentiates
-    it wrt base_scalar.
-    Else, returns S(0)
-    """
-
-    new_expr = express(expr, base_scalar.system, variables=True)
-    if base_scalar in new_expr.atoms(BaseScalar):
-        return Derivative(new_expr, base_scalar)
-    return S(0)

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -47,7 +47,7 @@ class Del(Basic):
     __call__ = gradient
     __call__.__doc__ = gradient.__doc__
 
-    def dot(self, vector, doit=False):
+    def dot(self, vect, doit=False):
         """
         Represents the dot product between this operator and a given
         vector - equal to the divergence of the vector field.
@@ -55,7 +55,7 @@ class Del(Basic):
         Parameters
         ==========
 
-        vector : Vector
+        vect : Vector
             The vector whose divergence is to be calculated.
 
         doit : bool
@@ -75,12 +75,12 @@ class Del(Basic):
         C.x*C.y + C.x*C.z + C.y*C.z
 
         """
-        return divergence(vector, doit=doit)
+        return divergence(vect, doit=doit)
 
     __and__ = dot
     __and__.__doc__ = dot.__doc__
 
-    def cross(self, vector, doit=False):
+    def cross(self, vect, doit=False):
         """
         Represents the cross product between this operator and a given
         vector - equal to the curl of the vector field.
@@ -88,7 +88,7 @@ class Del(Basic):
         Parameters
         ==========
 
-        vector : Vector
+        vect : Vector
             The vector whose curl is to be calculated.
 
         doit : bool
@@ -110,7 +110,7 @@ class Del(Basic):
 
         """
 
-        return curl(vector, doit=doit)
+        return curl(vect, doit=doit)
 
     __xor__ = cross
     __xor__.__doc__ = cross.__doc__

--- a/sympy/vector/deloperator.py
+++ b/sympy/vector/deloperator.py
@@ -33,12 +33,13 @@ class Del(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSysCartesian, Del
         >>> C = CoordSysCartesian('C')
-        >>> C.delop.gradient(C.x)
+        >>> delop = Del()
+        >>> delop.gradient(C.x)
         (Derivative(C.x, C.x))*C.i + (Derivative(C.x, C.y))*C.j +
             (Derivative(C.x, C.z))*C.k
-        >>> C.delop(C.x*C.y*C.z).doit()
+        >>> delop(C.x*C.y*C.z).doit()
         C.y*C.z*C.i + C.x*C.z*C.j + C.x*C.y*C.k
 
         """
@@ -67,12 +68,13 @@ class Del(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSysCartesian, Del
+        >>> delop = Del()
         >>> C = CoordSysCartesian('C')
-        >>> C.delop.dot(C.x*C.i)
+        >>> delop.dot(C.x*C.i)
         Derivative(C.x, C.x)
         >>> v = C.x*C.y*C.z * (C.i + C.j + C.k)
-        >>> (C.delop & v).doit()
+        >>> (delop & v).doit()
         C.x*C.y + C.x*C.z + C.y*C.z
 
         """
@@ -100,13 +102,14 @@ class Del(Basic):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSysCartesian, Del
         >>> C = CoordSysCartesian('C')
+        >>> delop = Del()
         >>> v = C.x*C.y*C.z * (C.i + C.j + C.k)
-        >>> C.delop.cross(v, doit = True)
+        >>> delop.cross(v, doit = True)
         (-C.x*C.y + C.x*C.z)*C.i + (C.x*C.y - C.y*C.z)*C.j +
             (-C.x*C.z + C.y*C.z)*C.k
-        >>> (C.delop ^ C.i).doit()
+        >>> (delop ^ C.i).doit()
         0
 
         """

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -1,9 +1,10 @@
 from sympy.vector.coordsysrect import CoordSysCartesian
-from sympy.vector.dyadic import Dyadic
-from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.scalar import BaseScalar
+from sympy.vector.vector import Vector, BaseVector
 from sympy.vector.operators import gradient, curl, divergence
-from sympy import sympify, diff, integrate, S, simplify
+from sympy import diff, integrate, S, simplify
+from sympy.core import sympify
+from sympy.vector.dyadic import Dyadic
 
 
 def express(expr, system, system2=None, variables=False):

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -18,12 +18,15 @@ def _get_coord_sys_from_expr(expr, coord_sys=None):
             useinstead="do not use it",
             deprecated_since_version="1.1"
         ).warn()
-    if expr is Vector.zero:
+
+    try:
+        coord_sys = list(expr.atoms(CoordSysCartesian))
+        if len(coord_sys) == 1:
+            return coord_sys[0]
+        else:
+            return None
+    except:
         return None
-    elif expr == 0:
-        return None
-    else:
-        return list(expr.atoms(CoordSysCartesian))[0]
 
 
 class Gradient(Expr):

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -119,6 +119,11 @@ def curl(vect, coord_sys=None, doit=True):
         The coordinate system to calculate the gradient in.
         Deprecated since version 1.1
 
+    doit : bool
+        If True, the result is returned after calling .doit() on
+        each component. Else, the returned expression contains
+        Derivative instances
+
     Examples
     ========
 
@@ -169,6 +174,11 @@ def divergence(vect, coord_sys=None, doit=True):
         The coordinate system to calculate the gradient in
         Deprecated since version 1.1
 
+    doit : bool
+        If True, the result is returned after calling .doit() on
+        each component. Else, the returned expression contains
+        Derivative instances
+
     Examples
     ========
 
@@ -213,6 +223,11 @@ def gradient(scalar_field, coord_sys=None, doit=True):
     coord_sys : CoordSysCartesian
         The coordinate system to calculate the gradient in
         Deprecated since version 1.1
+
+    doit : bool
+        If True, the result is returned after calling .doit() on
+        each component. Else, the returned expression contains
+        Derivative instances
 
     Examples
     ========

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -101,7 +101,7 @@ class Curl(Expr):
         return curl(self._expr, doit=True)
 
 
-def curl(vector, coord_sys=None, doit=True):
+def curl(vect, coord_sys=None, doit=True):
     """
     Returns the curl of a vector field computed wrt the base scalars
     of the given coordinate system.
@@ -109,7 +109,7 @@ def curl(vector, coord_sys=None, doit=True):
     Parameters
     ==========
 
-    vector : Vector
+    vect : Vector
         The vector operand
 
     coord_sys : CoordSysCartesian
@@ -130,14 +130,14 @@ def curl(vector, coord_sys=None, doit=True):
 
     """
 
-    coord_sys = _get_coord_sys_from_expr(vector, coord_sys)
+    coord_sys = _get_coord_sys_from_expr(vect, coord_sys)
     if coord_sys is None:
         return Vector.zero
     else:
         from sympy.vector.functions import express
-        vectx = express(vector.dot(coord_sys._i), coord_sys, variables=True)
-        vecty = express(vector.dot(coord_sys._j), coord_sys, variables=True)
-        vectz = express(vector.dot(coord_sys._k), coord_sys, variables=True)
+        vectx = express(vect.dot(coord_sys._i), coord_sys, variables=True)
+        vecty = express(vect.dot(coord_sys._j), coord_sys, variables=True)
+        vectz = express(vect.dot(coord_sys._k), coord_sys, variables=True)
         outvec = Vector.zero
         outvec += (Derivative(vectz * coord_sys._h3, coord_sys._y) -
                    Derivative(vecty * coord_sys._h2, coord_sys._z)) * coord_sys._i / (coord_sys._h2 * coord_sys._h3)
@@ -151,7 +151,7 @@ def curl(vector, coord_sys=None, doit=True):
         return outvec
 
 
-def divergence(vector, coord_sys=None, doit=True):
+def divergence(vect, coord_sys=None, doit=True):
     """
     Returns the divergence of a vector field computed wrt the base
     scalars of the given coordinate system.
@@ -181,15 +181,15 @@ def divergence(vector, coord_sys=None, doit=True):
 
     """
 
-    coord_sys = _get_coord_sys_from_expr(vector, coord_sys)
+    coord_sys = _get_coord_sys_from_expr(vect, coord_sys)
     if coord_sys is None:
         return S.Zero
     else:
-        vx = _diff_conditional(vector.dot(coord_sys._i), coord_sys._x, coord_sys._h2, coord_sys._h3) \
+        vx = _diff_conditional(vect.dot(coord_sys._i), coord_sys._x, coord_sys._h2, coord_sys._h3) \
              / (coord_sys._h1 * coord_sys._h2 * coord_sys._h3)
-        vy = _diff_conditional(vector.dot(coord_sys._j), coord_sys._y, coord_sys._h3, coord_sys._h1) \
+        vy = _diff_conditional(vect.dot(coord_sys._j), coord_sys._y, coord_sys._h3, coord_sys._h1) \
              / (coord_sys._h1 * coord_sys._h2 * coord_sys._h3)
-        vz = _diff_conditional(vector.dot(coord_sys._k), coord_sys._z, coord_sys._h1, coord_sys._h2) \
+        vz = _diff_conditional(vect.dot(coord_sys._k), coord_sys._z, coord_sys._h1, coord_sys._h2) \
              / (coord_sys._h1 * coord_sys._h2 * coord_sys._h3)
         if doit:
             return (vx + vy + vz).doit()

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -22,10 +22,7 @@ a, b, c, q = symbols('a b c q')
 def test_del_operator():
     # Tests for curl
 
-    # assert (delop ^ Vector.zero ==
-    #         (Derivative(0, C.y) - Derivative(0, C.z))*C.i +
-    #         (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
-    #         (Derivative(0, C.x) - Derivative(0, C.y))*C.k)
+    assert delop ^ Vector.zero == Vector.zero
     assert ((delop ^ Vector.zero).doit() == Vector.zero ==
             curl(Vector.zero))
     assert delop.cross(Vector.zero) == delop ^ Vector.zero
@@ -83,10 +80,10 @@ def test_del_operator():
             -a*sin(y)/x**2 * i + a*cos(y)/x * j)
 
     #Tests for directional derivative
-    # assert (Vector.zero & delop)(a) == S(0)
-    # assert ((Vector.zero & delop)(a)).doit() == S(0)
+    assert (Vector.zero & delop)(a) == S(0)
+    assert ((Vector.zero & delop)(a)).doit() == S(0)
     assert ((v & delop)(Vector.zero)).doit() == Vector.zero
-    # assert ((v & delop)(S(0))).doit() == S(0)
+    assert ((v & delop)(S(0))).doit() == S(0)
     assert ((i & delop)(x)).doit() == 1
     assert ((j & delop)(y)).doit() == 1
     assert ((k & delop)(z)).doit() == 1

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -85,7 +85,7 @@ def test_del_operator():
     #Tests for directional derivative
     # assert (Vector.zero & delop)(a) == S(0)
     # assert ((Vector.zero & delop)(a)).doit() == S(0)
-    # assert ((v & delop)(Vector.zero)).doit() == Vector.zero
+    assert ((v & delop)(Vector.zero)).doit() == Vector.zero
     # assert ((v & delop)(S(0))).doit() == S(0)
     assert ((i & delop)(x)).doit() == 1
     assert ((j & delop)(y)).doit() == 1
@@ -99,7 +99,7 @@ def test_del_operator():
     assert ((i & delop)(v)).doit() == i
     assert ((j & delop)(v)).doit() == j
     assert ((k & delop)(v)).doit() == k
-    # assert ((v & delop)(Vector.zero)).doit() == Vector.zero
+    assert ((v & delop)(Vector.zero)).doit() == Vector.zero
 
 
 def test_product_rules():

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -6,6 +6,7 @@ from sympy.core.symbol import symbols
 from sympy.core import S
 from sympy import sin, cos
 from sympy.vector.operators import curl, divergence, gradient
+from sympy.vector.deloperator import Del
 from sympy.vector.functions import (is_conservative, is_solenoidal,
                                     scalar_potential, directional_derivative,
                                     scalar_potential_difference)
@@ -14,7 +15,7 @@ from sympy.utilities.pytest import raises
 C = CoordSysCartesian('C')
 i, j, k = C.base_vectors()
 x, y, z = C.base_scalars()
-delop = C.delop
+delop = Del()
 a, b, c, q = symbols('a b c q')
 
 

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -20,10 +20,11 @@ a, b, c, q = symbols('a b c q')
 
 def test_del_operator():
     # Tests for curl
-    assert (delop ^ Vector.zero ==
-            (Derivative(0, C.y) - Derivative(0, C.z))*C.i +
-            (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
-            (Derivative(0, C.x) - Derivative(0, C.y))*C.k)
+
+    # assert (delop ^ Vector.zero ==
+    #         (Derivative(0, C.y) - Derivative(0, C.z))*C.i +
+    #         (-Derivative(0, C.x) + Derivative(0, C.z))*C.j +
+    #         (Derivative(0, C.x) - Derivative(0, C.y))*C.k)
     assert ((delop ^ Vector.zero).doit() == Vector.zero ==
             curl(Vector.zero))
     assert delop.cross(Vector.zero) == delop ^ Vector.zero
@@ -81,10 +82,10 @@ def test_del_operator():
             -a*sin(y)/x**2 * i + a*cos(y)/x * j)
 
     #Tests for directional derivative
-    assert (Vector.zero & delop)(a) == S(0)
-    assert ((Vector.zero & delop)(a)).doit() == S(0)
-    assert ((v & delop)(Vector.zero)).doit() == Vector.zero
-    assert ((v & delop)(S(0))).doit() == S(0)
+    # assert (Vector.zero & delop)(a) == S(0)
+    # assert ((Vector.zero & delop)(a)).doit() == S(0)
+    # assert ((v & delop)(Vector.zero)).doit() == Vector.zero
+    # assert ((v & delop)(S(0))).doit() == S(0)
     assert ((i & delop)(x)).doit() == 1
     assert ((j & delop)(y)).doit() == 1
     assert ((k & delop)(z)).doit() == 1
@@ -97,7 +98,7 @@ def test_del_operator():
     assert ((i & delop)(v)).doit() == i
     assert ((j & delop)(v)).doit() == j
     assert ((k & delop)(v)).doit() == k
-    assert ((v & delop)(Vector.zero)).doit() == Vector.zero
+    # assert ((v & delop)(Vector.zero)).doit() == Vector.zero
 
 
 def test_product_rules():

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -118,8 +118,10 @@ class Vector(BasisDependent):
                     if out == 0 and isinstance(field, Vector):
                         out = Vector.zero
                     return out
-                else:
+                elif isinstance(field, Vector) :
                     return Vector.zero
+                else:
+                    return S(0)
             return directional_derivative
 
         if isinstance(self, VectorZero) or isinstance(other, VectorZero):

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -110,14 +110,16 @@ class Vector(BasisDependent):
             def directional_derivative(field):
                 from sympy.vector.operators import _get_coord_sys_from_expr
                 coord_sys = _get_coord_sys_from_expr(field)
-                field = express(field, coord_sys, variables=True)
-                out = self.dot(coord_sys._i) * df(field, coord_sys._x)
-                out += self.dot(coord_sys._j) * df(field, coord_sys._y)
-                out += self.dot(coord_sys._k) * df(field, coord_sys._z)
-                if out == 0 and isinstance(field, Vector):
-                    out = Vector.zero
-                return out
-
+                if coord_sys is not None:
+                    field = express(field, coord_sys, variables=True)
+                    out = self.dot(coord_sys._i) * df(field, coord_sys._x)
+                    out += self.dot(coord_sys._j) * df(field, coord_sys._y)
+                    out += self.dot(coord_sys._k) * df(field, coord_sys._z)
+                    if out == 0 and isinstance(field, Vector):
+                        out = Vector.zero
+                    return out
+                else:
+                    return Vector.zero
             return directional_derivative
 
         if isinstance(self, VectorZero) or isinstance(other, VectorZero):

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -108,10 +108,12 @@ class Vector(BasisDependent):
         # Check if the other is a del operator
         if isinstance(other, Del):
             def directional_derivative(field):
-                field = express(field, other.system, variables=True)
-                out = self.dot(other._i) * df(field, other._x)
-                out += self.dot(other._j) * df(field, other._y)
-                out += self.dot(other._k) * df(field, other._z)
+                from sympy.vector.operators import _get_coord_sys_from_expr
+                coord_sys = _get_coord_sys_from_expr(field)
+                field = express(field, coord_sys, variables=True)
+                out = self.dot(coord_sys._i) * df(field, coord_sys._x)
+                out += self.dot(coord_sys._j) * df(field, coord_sys._y)
+                out += self.dot(coord_sys._k) * df(field, coord_sys._z)
                 if out == 0 and isinstance(field, Vector):
                     out = Vector.zero
                 return out

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -73,8 +73,9 @@ class Vector(BasisDependent):
         Examples
         ========
 
-        >>> from sympy.vector import CoordSysCartesian
+        >>> from sympy.vector import CoordSysCartesian, Del
         >>> C = CoordSysCartesian('C')
+        >>> delop = Del()
         >>> C.i.dot(C.j)
         0
         >>> C.i & C.i
@@ -82,7 +83,7 @@ class Vector(BasisDependent):
         >>> v = 3*C.i + 4*C.j + 5*C.k
         >>> v.dot(C.k)
         5
-        >>> (C.i & C.delop)(C.x*C.y*C.z)
+        >>> (C.i & delop)(C.x*C.y*C.z)
         C.y*C.z
         >>> d = C.i.outer(C.i)
         >>> C.i.dot(d)


### PR DESCRIPTION
Now Delop is only symbol, independent from coordinate system.

TODO:
- [x] add warning in `Del` class, because this PR introduce changes in constructor.
- [x] resolve problem with some tests which are now disabled 
- [x] Update comment. In `Del` operators are described calculations which are not there
