### PR TITLE
Deprecation warnings to 'densearith.py' 'densetools.py' 'densesolve.py' 

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1283,7 +1283,7 @@ def hessian(f, varlist, constraints=[]):
 
 def jordan_block(eigenval, n):
     """
-    Create matrix of Jordan block kind:
+    Create a Jordan block:
 
     Examples
     ========
@@ -1476,3 +1476,14 @@ def zeros(*args, **kwargs):
     from .dense import Matrix
 
     return Matrix.zeros(*args, **kwargs)
+
+def test_deprecated():
+# Maintain tests for deprecated functions.  We must capture
+# the deprecation warnings.  When the deprecated functionality is
+# removed, the corresponding tests should be removed.
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+    m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+    P, Jcells = m.jordan_blocks()
+    assert Jcells[1] == Matrix(1, 1, [2])
+    assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1281,16 +1281,16 @@ def hessian(f, varlist, constraints=[]):
     return out
 
 
-def jordan_cell(eigenval, n):
+def jordan_block(eigenval, n):
     """
-    Create matrix of Jordan cell kind:
+    Create matrix of Jordan block kind:
 
     Examples
     ========
 
-    >>> from sympy.matrices import jordan_cell
+    >>> from sympy.matrices import jordan_block
     >>> from sympy.abc import x
-    >>> jordan_cell(x, 4)
+    >>> jordan_block(x, 4)
     Matrix([
     [x, 1, 0, 0],
     [0, x, 1, 0],

--- a/sympy/matrices/densearith.py
+++ b/sympy/matrices/densearith.py
@@ -252,7 +252,7 @@ def test_deprecated():
     # removed, the corresponding tests should be removed.
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
-        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
         P, Jcells = m.jordan_cells()
-        assert Jcells[1] == Matrix(1, 1, [2])
-        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
+        assert Jcells[1] == matlist(1, 1, [2])
+        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densearith.py
+++ b/sympy/matrices/densearith.py
@@ -230,6 +230,16 @@ def mulrowcol(row, col, K):
     is expected to be removed later as we have a good data structure to
     facilitate column operations.
 
+def test_deprecated():
+    # Maintain tests for deprecated functions.  We must capture
+    # the deprecation warnings.  When the deprecated functionality is
+    # removed, the corresponding tests should be removed.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        P, Jcells = m.jordan_cells()
+        assert Jcells[1] == Matrix(1, 1, [2])
+        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
     Examples
     ========
 

--- a/sympy/matrices/densearith.py
+++ b/sympy/matrices/densearith.py
@@ -246,13 +246,3 @@ def mulrowcol(row, col, K):
         result += row[i]*col[i]
     return result
 
-def test_deprecated():
-    # Maintain tests for deprecated functions.  We must capture
-    # the deprecation warnings.  When the deprecated functionality is
-    # removed, the corresponding tests should be removed.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
-        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-        P, Jcells = m.jordan_blocks()
-        assert Jcells[1] == matlist(1, 1, [2])
-        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densearith.py
+++ b/sympy/matrices/densearith.py
@@ -253,6 +253,6 @@ def test_deprecated():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
         m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-        P, Jcells = m.jordan_cells()
+        P, Jcells = m.jordan_blocks()
         assert Jcells[1] == matlist(1, 1, [2])
         assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densearith.py
+++ b/sympy/matrices/densearith.py
@@ -230,16 +230,6 @@ def mulrowcol(row, col, K):
     is expected to be removed later as we have a good data structure to
     facilitate column operations.
 
-def test_deprecated():
-    # Maintain tests for deprecated functions.  We must capture
-    # the deprecation warnings.  When the deprecated functionality is
-    # removed, the corresponding tests should be removed.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
-        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-        P, Jcells = m.jordan_cells()
-        assert Jcells[1] == Matrix(1, 1, [2])
-        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
     Examples
     ========
 
@@ -255,3 +245,14 @@ def test_deprecated():
     for i in range(len(row)):
         result += row[i]*col[i]
     return result
+
+def test_deprecated():
+    # Maintain tests for deprecated functions.  We must capture
+    # the deprecation warnings.  When the deprecated functionality is
+    # removed, the corresponding tests should be removed.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        P, Jcells = m.jordan_cells()
+        assert Jcells[1] == Matrix(1, 1, [2])
+        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densesolve.py
+++ b/sympy/matrices/densesolve.py
@@ -452,6 +452,6 @@ def test_deprecated():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
         m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-        P, Jcells = m.jordan_cells()
+        P, Jcells = m.jordan_blocks()
         assert Jcells[1] == matlist(1, 1, [2])
         assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densesolve.py
+++ b/sympy/matrices/densesolve.py
@@ -451,7 +451,7 @@ def test_deprecated():
     # removed, the corresponding tests should be removed.
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
-        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
         P, Jcells = m.jordan_cells()
-        assert Jcells[1] == Matrix(1, 1, [2])
-        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
+        assert Jcells[1] == matlist(1, 1, [2])
+        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densesolve.py
+++ b/sympy/matrices/densesolve.py
@@ -444,3 +444,14 @@ def backward_substitution(upper_triangle, variable, constant, K):
             a += copy_upper_triangle[i][j]*variable[j][0]
         variable[i][0] = (constant[i][0] - a)/copy_upper_triangle[i][i]
     return variable
+
+def test_deprecated():
+    # Maintain tests for deprecated functions.  We must capture
+    # the deprecation warnings.  When the deprecated functionality is
+    # removed, the corresponding tests should be removed.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        P, Jcells = m.jordan_cells()
+        assert Jcells[1] == Matrix(1, 1, [2])
+        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densesolve.py
+++ b/sympy/matrices/densesolve.py
@@ -445,13 +445,3 @@ def backward_substitution(upper_triangle, variable, constant, K):
         variable[i][0] = (constant[i][0] - a)/copy_upper_triangle[i][i]
     return variable
 
-def test_deprecated():
-    # Maintain tests for deprecated functions.  We must capture
-    # the deprecation warnings.  When the deprecated functionality is
-    # removed, the corresponding tests should be removed.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
-        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-        P, Jcells = m.jordan_blocks()
-        assert Jcells[1] == matlist(1, 1, [2])
-        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densetools.py
+++ b/sympy/matrices/densetools.py
@@ -256,6 +256,6 @@ def test_deprecated():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
         m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-        P, Jcells = m.jordan_cells()
+        P, Jcells = m.jordan_blocks()
         assert Jcells[1] == matlist(1, 1, [2])
         assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densetools.py
+++ b/sympy/matrices/densetools.py
@@ -255,7 +255,7 @@ def test_deprecated():
     # removed, the corresponding tests should be removed.
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
-        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
         P, Jcells = m.jordan_cells()
-        assert Jcells[1] == Matrix(1, 1, [2])
-        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
+        assert Jcells[1] == matlist(1, 1, [2])
+        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densetools.py
+++ b/sympy/matrices/densetools.py
@@ -248,3 +248,14 @@ def isHermitian(matlist, K):
     False
     """
     return conjugate_transpose(matlist, K) == matlist
+
+def test_deprecated():
+    # Maintain tests for deprecated functions.  We must capture
+    # the deprecation warnings.  When the deprecated functionality is
+    # removed, the corresponding tests should be removed.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        P, Jcells = m.jordan_cells()
+        assert Jcells[1] == Matrix(1, 1, [2])
+        assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/densetools.py
+++ b/sympy/matrices/densetools.py
@@ -249,13 +249,3 @@ def isHermitian(matlist, K):
     """
     return conjugate_transpose(matlist, K) == matlist
 
-def test_deprecated():
-    # Maintain tests for deprecated functions.  We must capture
-    # the deprecation warnings.  When the deprecated functionality is
-    # removed, the corresponding tests should be removed.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
-        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-        P, Jcells = m.jordan_blocks()
-        assert Jcells[1] == matlist(1, 1, [2])
-        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/tests/test_densearith.py
+++ b/sympy/matrices/tests/test_densearith.py
@@ -46,3 +46,15 @@ def test_mulmatscaler():
 
     assert mulmatscaler(a, ZZ(4), ZZ) == [[ZZ(4), ZZ(0), ZZ(0)], [ZZ(0), ZZ(4), ZZ(0)], [ZZ(0), ZZ(0), ZZ(4)]]
     assert mulmatscaler(b, ZZ(1), ZZ) == [[ZZ(3), ZZ(7), ZZ(4)], [ZZ(2), ZZ(4), ZZ(5)], [ZZ(6), ZZ(2), ZZ(3)]]
+
+
+def test_deprecated():
+    # Maintain tests for deprecated functions.  We must capture
+    # the deprecation warnings.  When the deprecated functionality is
+    # removed, the corresponding tests should be removed.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        P, Jcells = m.jordan_blocks()
+        assert Jcells[1] == matlist(1, 1, [2])
+        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/tests/test_densesolve.py
+++ b/sympy/matrices/tests/test_densesolve.py
@@ -17,3 +17,15 @@ def test_rref_solve():
     x, y, z = Dummy('x'), Dummy('y'), Dummy('z')
 
     assert rref_solve([[QQ(25), QQ(15), QQ(-5)], [QQ(15), QQ(18), QQ(0)], [QQ(-5), QQ(0), QQ(11)]], [[x], [y], [z]], [[QQ(2)], [QQ(3)], [QQ(1)]], QQ) == [[QQ(-1, 225)], [QQ(23, 135)], [QQ(4, 45)]]
+
+
+def test_deprecated():
+    # Maintain tests for deprecated functions.  We must capture
+    # the deprecation warnings.  When the deprecated functionality is
+    # removed, the corresponding tests should be removed.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        P, Jcells = m.jordan_blocks()
+        assert Jcells[1] == matlist(1, 1, [2])
+        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])

--- a/sympy/matrices/tests/test_densetools.py
+++ b/sympy/matrices/tests/test_densetools.py
@@ -16,3 +16,15 @@ def test_transpose():
 
     assert transpose(a, ZZ) == ([[ZZ(3), ZZ(2), ZZ(6)], [ZZ(7), ZZ(4), ZZ(2)], [ZZ(4), ZZ(5), ZZ(3)]])
     assert transpose(b, ZZ) == b
+
+
+def test_deprecated():
+    # Maintain tests for deprecated functions.  We must capture
+    # the deprecation warnings.  When the deprecated functionality is
+    # removed, the corresponding tests should be removed.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        m = matlist(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
+        P, Jcells = m.jordan_blocks()
+        assert Jcells[1] == matlist(1, 1, [2])
+        assert Jcells[0] == matlist(2, 2, [2, 1, 0, 2])


### PR DESCRIPTION
Added test_deprecated() function to fix the tests to handle the deprecation warnings.#12695

Also renamed jordan_cell and jordan_cells with the more commonly used words jordan_block and jordan_blocks.#12685