### PR TITLE
fix dmp_ff_div by simplifying gmpy rationals divisions

### DIFF
--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -66,11 +66,11 @@ class GMPYRationalField(RationalField):
 
     def exquo(self, a, b):
         """Exact quotient of `a` and `b`, implies `__div__`.  """
-        return GMPYRational(gmpy_qdiv(a, b))
+        return GMPYRational(a) / GMPYRational(b)
 
     def quo(self, a, b):
         """Quotient of `a` and `b`, implies `__div__`. """
-        return GMPYRational(gmpy_qdiv(GMPYRational(a), GMPYRational(b)))
+        return GMPYRational(a) / GMPYRational(b)
 
     def rem(self, a, b):
         """Remainder of `a` and `b`, implies nothing.  """
@@ -78,7 +78,7 @@ class GMPYRationalField(RationalField):
 
     def div(self, a, b):
         """Division of `a` and `b`, implies `__div__`. """
-        return GMPYRational(gmpy_qdiv(a, b)), self.zero
+        return GMPYRational(a) / GMPYRational(b), self.zero
 
     def numer(self, a):
         """Returns numerator of `a`. """

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -862,6 +862,22 @@ def test_dup_ff_div():
 
     assert dup_ff_div(f, g, QQ) == (q, r)
 
+def test_dup_ff_div_gmpy2():
+    try:
+        from gmpy2 import mpq
+    except ImportError:
+        return
+
+    from sympy.polys.domains import GMPYRationalField
+    K = GMPYRationalField()
+
+    f = [mpq(1,3), mpq(3,2)]
+    g = [mpq(2,1)]
+    assert dmp_ff_div(f, g, 0, K) == ([mpq(1,6), mpq(3,4)], [])
+
+    f = [mpq(1,2), mpq(1,3), mpq(1,4), mpq(1,5)]
+    g = [mpq(-1,1), mpq(1,1), mpq(-1,1)]
+    assert dmp_ff_div(f, g, 0, K) == ([mpq(-1,2), mpq(-5,6)], [mpq(7,12), mpq(-19,30)])
 
 def test_dmp_ff_div():
     raises(ZeroDivisionError, lambda: dmp_ff_div([[1, 2], [3]], [[]], 1, QQ))


### PR DESCRIPTION
There is a bug in gmpy2 `qdiv` (see [gmpy2 issue #150](https://github.com/aleaxit/gmpy/issues/150)). As a consequence when gmpy2 is installed polynomial divisions do not work anymore see #12753.

The proposed patch simplifies divisions of gmpy2 rationals (ie the methods `exquo`, `quo`, `div` in the domain `GMPYRationalField`) avoiding calls to `qdiv`. It also introduces a new test function with examples that use to fail.

Fixes #12753 