### PR TITLE
cancel consistently handles exprs

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -12,6 +12,7 @@ from .cache import cacheit
 from .logic import fuzzy_not, _fuzzy_group
 from .compatibility import reduce, range
 from .expr import Expr
+from sympy.utilities.iterables import sift
 
 # internal marker to indicate:
 #   "there are still non-commutative objects -- don't forget to process them"
@@ -64,7 +65,9 @@ def _unevaluated_Mul(*args):
     False
 
     """
-    args = list(args)
+    sifted = sift(args, lambda x: bool(x.is_commutative))
+    args = sifted[True]
+    nc = sifted[False]
     newargs = []
     ncargs = []
     co = S.One
@@ -84,7 +87,7 @@ def _unevaluated_Mul(*args):
         newargs.insert(0, co)
     if ncargs:
         newargs.append(Mul._from_args(ncargs))
-    return Mul._from_args(newargs)
+    return Mul._from_args(newargs + nc)
 
 
 class Mul(Expr, AssocOp):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1766,7 +1766,7 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
         margs = list(factors.args)
         if margs[0].is_Number:
             margs[0] *= coeff
-            if margs[0] == 1:
+            if margs[0] is S.One:
                 margs.pop(0)
         else:
             margs.insert(0, coeff)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -9,6 +9,7 @@ from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
                    exp_polar, expand, diff, O, Heaviside, Si, Max, UnevaluatedExpr,
                    integrate)
 from sympy.core.function import AppliedUndef
+from sympy.core.mul import _unevaluated_Mul
 from sympy.core.compatibility import range
 from sympy.physics.secondquant import FockState
 from sympy.physics.units import meter
@@ -1789,3 +1790,8 @@ def test_normal():
     x = symbols('x')
     e = Mul(S.Half, 1 + x, evaluate=False)
     assert e.normal() == e
+
+
+def test__unevaluated_Mul():
+    A, B = symbols('A B', commutative=False)
+    assert _unevaluated_Mul(x, A, B, S(2), A).args == (2, x, A, B, A)

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2959,7 +2959,8 @@ def test_Y9():
 
 def test_Y10():
     assert (fourier_transform(abs(x)*exp(-3*abs(x)), x, z) ==
-            (-8*pi**2*z**2 + 18)/(16*pi**4*z**4 + 72*pi**2*z**2 + 81))
+            2*((-4*pi**2*z**2 + 9)/
+            (16*pi**4*z**4 + 72*pi**2*z**2 + 81)))
 
 
 @SKIP("https://github.com/sympy/sympy/issues/7181")

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -45,7 +45,7 @@ class ExprCondPair(Tuple):
 
     @property
     def is_commutative(self):
-        return self.expr.is_commutative
+        return getattr(self.expr, 'is_commutative', False)
 
     def __iter__(self):
         yield self.expr

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -122,7 +122,9 @@ def test_piecewise():
 
     # Test commutativity
     assert p.is_commutative is True
-
+    # if there is a non-Basic arg it might *contain*
+    # commutative things but it, itself, is not commutative
+    assert Piecewise(([1], x < 0)).is_commutative is False
 
 def test_piecewise_free_symbols():
     a = symbols('a')

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -107,12 +107,12 @@ def test_legendre():
     assert legendre(10, 0) != 0
     assert legendre(11, 0) == 0
 
+    f = S(3)/7
     assert roots(legendre(4, x), x) == {
-        sqrt(Rational(3, 7) - Rational(2, 35)*sqrt(30)): 1,
-        -sqrt(Rational(3, 7) - Rational(2, 35)*sqrt(30)): 1,
-        sqrt(Rational(3, 7) + Rational(2, 35)*sqrt(30)): 1,
-        -sqrt(Rational(3, 7) + Rational(2, 35)*sqrt(30)): 1,
-    }
+        -sqrt(2*sqrt(30)/35 + f): 1,
+        sqrt(-2*sqrt(30)/35 + f): 1,
+        -sqrt(-2*sqrt(30)/35 + f): 1,
+        sqrt(2*sqrt(30)/35 + f): 1}
 
     n = Symbol("n")
 

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -661,7 +661,7 @@ def test_diff():
     C_0, C_1, C_2, C_3 = symbols('C_0, C_1, C_2, C_3')
     q = Si(x)
     assert p.diff(x).to_expr() == q.diff()
-    assert p.diff(x, 2).to_expr().subs(C_0, -S(1)/3) == q.diff(x, 2).simplify()
+    assert p.diff(x, 2).to_expr().subs(C_0, -S(1)/3).equals(q.diff(x, 2))
     assert p.diff(x, 3).series().subs({C_3:-S(1)/3, C_0:0}) == q.diff(x, 3).series()
 
 def test_extended_domain_in_expr_to_holonomic():

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -19,7 +19,7 @@ def ratint(f, x, **flags):
        >>> from sympy.abc import x
 
        >>> ratint(36/(x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2), x)
-       6*(2*x + 1)/(x**2 - 1) + 4*log(x - 2) - 4*log(x + 1)
+       (12*x + 6)/(x**2 - 1) + 4*log(x - 2) - 4*log(x + 1)
 
        References
        ==========
@@ -131,7 +131,7 @@ def ratint_ratpart(f, g, x):
         (0, 1/(x**2 + y**2))
         >>> ratint_ratpart(Poly(36, x, domain='ZZ'),
         ... Poly(x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2, x, domain='ZZ'), x)
-        (6*(2*x + 1)/(x**2 - 1), 12/(x**2 - x - 2))
+        ((12*x + 6)/(x**2 - 1), 12/(x**2 - x - 2))
 
     See Also
     ========

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -19,7 +19,7 @@ def ratint(f, x, **flags):
        >>> from sympy.abc import x
 
        >>> ratint(36/(x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2), x)
-       (12*x + 6)/(x**2 - 1) + 4*log(x - 2) - 4*log(x + 1)
+       6*(2*x + 1)/(x**2 - 1) + 4*log(x - 2) - 4*log(x + 1)
 
        References
        ==========
@@ -131,7 +131,7 @@ def ratint_ratpart(f, g, x):
         (0, 1/(x**2 + y**2))
         >>> ratint_ratpart(Poly(36, x, domain='ZZ'),
         ... Poly(x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2, x, domain='ZZ'), x)
-        ((12*x + 6)/(x**2 - 1), 12/(x**2 - x - 2))
+        (6*(2*x + 1)/(x**2 - 1), 12/(x**2 - x - 2))
 
     See Also
     ========

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -4,7 +4,7 @@ from sympy import (
     Expr, factor, Function, I, Integral, integrate, Interval, Lambda,
     LambertW, log, Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify,
     sin, tan, sqrt, sstr, Sum, Symbol, symbols, sympify, trigsimp, Tuple, nan,
-    And, Eq, Ne, re, im, polar_lift, meijerg, SingularityFunction
+    And, Eq, Ne, re, im, polar_lift, meijerg, SingularityFunction, cancel
 )
 from sympy.functions.elementary.complexes import periodic_argument
 from sympy.integrals.risch import NonElementaryIntegral
@@ -971,9 +971,8 @@ def test_atom_bug():
 
 def test_limit_bug():
     z = Symbol('z', zero=False)
-    assert integrate(sin(x*y*z), (x, 0, pi), (y, 0, pi)) == \
-        (log(z**2) + 2*EulerGamma + 2*log(pi))/(2*z) - \
-        (-log(pi*z) + log(pi**2*z**2)/2 + Ci(pi**2*z))/z + log(pi)/z
+    assert cancel(integrate(sin(x*y*z), (x, 0, pi), (y, 0, pi))
+        ) == (log(z) - Ci(pi**2*z) + EulerGamma + 2*log(pi))/z
 
 
 def test_issue_4703():
@@ -1062,7 +1061,7 @@ def test_risch_option():
     # risch=True only allowed on indefinite integrals
     raises(ValueError, lambda: integrate(1/log(x), (x, 0, oo), risch=True))
     assert integrate(exp(-x**2), x, risch=True) == NonElementaryIntegral(exp(-x**2), x)
-    assert integrate(log(1/x)*y, x, y, risch=True) == y**2*(x*log(1/x)/2 + x/2)
+    assert integrate(log(1/x)*y, x, y, risch=True) == y**2*(x*log(1/x) + x)/2
     assert integrate(erf(x), x, risch=True) == Integral(erf(x), x)
     # TODO: How to test risch=False?
 

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -67,7 +67,7 @@ def test_ratint():
     g = x**4 - 2*x**3 + 5*x**2 - 4*x + 4
 
     assert ratint(f/g, x) == \
-        x + S(1)/2*x**2 + S(1)/2*log(2 - x + x**2) - (4*x - 9)/(14 - 7*x + 7*x**2) + \
+        x + S(1)/2*x**2 + S(1)/2*log(2 - x + x**2) + (-4*x + 9)/(14 - 7*x + 7*x**2) + \
         13*sqrt(7)*atan(-S(1)/7*sqrt(7) + 2*x*sqrt(7)/7)/49
 
     assert ratint(1/(x**2 + x + 1), x) == \

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -394,7 +394,7 @@ def test_integrate_nonlinear_no_specials():
     DE = DifferentialExtension(extension={'D': [Poly(1, x),
         Poly(-t**2 - t/x - (1 - nu**2/x**2), t)], 'Tfuncs': [f]})
     assert integrate_nonlinear_no_specials(a, d, DE) == \
-        (-log(1 + f(x)**2 + x**2/2)/2 - (4 + x**2)/(4 + 2*x**2 + 4*f(x)**2), True)
+        (-log(1 + f(x)**2 + x**2/2)/2 + (-4 - x**2)/(4 + 2*x**2 + 4*f(x)**2), True)
     assert integrate_nonlinear_no_specials(Poly(t, t), Poly(1, t), DE) == \
         (0, False)
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -848,11 +848,11 @@ def inverse_mellin_transform(F, s, x, strip, **hints):
 
     >>> f = 1/(s**2 - 1)
     >>> inverse_mellin_transform(f, s, x, (-oo, -1))
-    (x/2 - 1/(2*x))*Heaviside(x - 1)
+    x*(1 - 1/x**2)*Heaviside(x - 1)/2
     >>> inverse_mellin_transform(f, s, x, (-1, 1))
     -x*Heaviside(-x + 1)/2 - Heaviside(x - 1)/(2*x)
     >>> inverse_mellin_transform(f, s, x, (1, oo))
-    (-x/2 + 1/(2*x))*Heaviside(-x + 1)
+    (-x**2/2 + 1/2)*Heaviside(-x + 1)/x
 
     See Also
     ========

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -20,7 +20,7 @@ def apart(f, x=None, full=False, **options):
 
     Given a rational function ``f``, computes the partial fraction
     decomposition of ``f``. Two algorithms are available: One is based on the
-    undertermined coefficients method, the other is Bronstein's full partial
+    undetermined coefficients method, the other is Bronstein's full partial
     fraction decomposition algorithm.
 
     The undetermined coefficients method (selected by ``full=False``) uses

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6410,8 +6410,8 @@ def _cancel_pq(p, q, *gens, **args):
             cq, Q = _clear_numer(Q.as_expr())
             return c*cp/cq, P, Q
         else:
-            # XXX it is possible that there is a gcd in P or Q
-            # it is being left there unless there is a compelling
+            # XXX it is possible that there is a gcd in P or Q.
+            # It is being left there unless there is a compelling
             # reason to fix this when returning Polys; it is
             # already handled when Expr are returned.
             return c, P, Q
@@ -6529,10 +6529,6 @@ def cancel(f, *gens, **args):
     if not isinstance(F, tuple):
         F = sympify(f)
 
-    # gens may have been sent as gens=x or gens=(x,) so
-    # flatten out the star args
-    # gens = tuple(flatten(gens))
-
     # argument checking
     if isinstance(F, tuple):
         if len(F) != 2:
@@ -6544,23 +6540,10 @@ def cancel(f, *gens, **args):
             expecting tuple (containing the numerator and denominator)
             or Expr, not %s''' % F))
 
-    # recognize non-Symbol gens
-    symbol_gens = sift(gens, lambda x: isinstance(x, Symbol))
-    if symbol_gens[False]:
-        reps = [(g, Dummy()) for g in symbol_gens[True]]
-        # the reps are processed in the order give
-        if isinstance(F, tuple):
-            F = tuple([i.subs(reps) for i in F])
-        else:
-            F = F.subs(reps)
-        G = tuple([d for _, d in reps] + symbol_gens[True])
-    else:
-        G = gens
-
     # dispatch to helper
     if isinstance(F, tuple):
         p, q = F
-        c, n, d = _cancel_pq(p, q, *G, **args)
+        c, n, d = _cancel_pq(p, q, *gens, **args)
         # when polification fails the expression may
         # have become a number; put the numbers in the
         # c position
@@ -6571,7 +6554,7 @@ def cancel(f, *gens, **args):
             c *= n
             n = S.One
     else:
-        rv = _cancel(F, *G, **args)
+        rv = _cancel(F, *gens, **args)
         c, nd = rv.as_coeff_Mul()
         n, d = fraction(nd)
 
@@ -6579,15 +6562,6 @@ def cancel(f, *gens, **args):
        rv = _keep_coeff(c, n/d)
     else:
        rv = c, n, d
-
-    # post-process for non-symbol generators
-    if symbol_gens[False]:
-        _reps = dict([(v, k) for k, v in reps])
-        if isinstance(rv, tuple):
-            c, p, q = rv
-            rv = c, p.xreplace(_reps), q.xreplace(_reps)
-        else:
-            rv = rv.xreplace(_reps)
 
     return rv
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6395,29 +6395,34 @@ def nth_power_roots_poly(f, n, *gens, **args):
         return result
 
 
-def _cancel(f, *gens, **args):
-    # helper for cancel
+def _cancel_pq(p, q, *gens, **args):
+    # helper for cancel where f is a Tuple
     from sympy.core.exprtools import factor_terms
     from sympy.functions.elementary.piecewise import Piecewise
-
-    if isinstance(f, Tuple):
-        p, q = f
-    elif f.is_Number or isinstance(f, Relational) or not isinstance(f, Expr):
-        return f
-    elif isinstance(f, (Mul, Add)):
-        p, q = factor_terms(f, radical=True).as_numer_denom()
-    else:
-        return f.replace(
-            lambda x: isinstance(x, (Mul, Add)),
-            lambda x: _cancel(x, *gens, **args))
 
     try:
         (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)
     except PolificationFailed:
-        if not isinstance(f, Tuple):
-            return f
+        return Tuple(S.One, p, q)
+    else:
+        c, P, Q = F.cancel(G)
+
+        if not opt.polys:
+            return Tuple(c, P.as_expr(), Q.as_expr())
         else:
-            return Tuple(S.One, p, q)
+            return Tuple(c, P, Q)
+
+
+def _cancel(f, *gens, **args):
+    # helper for cancel when f is an Expr
+    from sympy.core.exprtools import factor_terms
+    from sympy.functions.elementary.piecewise import Piecewise
+
+    p, q = factor_terms(f, radical=True).as_numer_denom()
+    try:
+        (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)
+    except PolificationFailed:
+        return f
     except PolynomialError as msg:
         if f.is_commutative and not f.has(Piecewise):
             raise PolynomialError(msg)
@@ -6443,14 +6448,7 @@ def _cancel(f, *gens, **args):
             return f.xreplace(dict(reps))
     else:
         c, P, Q = F.cancel(G)
-
-        if not isinstance(f, Tuple):
-            return c*(P.as_expr()/Q.as_expr())
-        else:
-            if not opt.polys:
-                return Tuple(c, P.as_expr(), Q.as_expr())
-            else:
-                return Tuple(c, P, Q)
+        return c*(P.as_expr()/Q.as_expr())
 
 
 @public
@@ -6473,20 +6471,40 @@ def cancel(f, *gens, **args):
     options.allowed_flags(args, ['polys'])
 
     f = sympify(f)  # if tuple, now a Tuple
+
+    # argument checking
     if isinstance(f, Tuple) and len(f) != 2:
         raise ValueError(filldedent('''
             Use a tuple of length 2 to send the numerator and
             denominator of an expression.'''))
+    if not isinstance(f, (Tuple, Expr)):
+        raise ValueError('expecting tuple or Expr, not %s' % f)
 
+    # recognize non-Symbol args
     sifted = sift(gens, lambda x: not isinstance(x, Symbol))
     if sifted[True]:
         reps = [(g, Dummy()) for g in sifted[True]]
         # the reps are processed in the order give
-        rv = _cancel(f.subs(reps), *Tuple(*gens).xreplace(dict(reps)), **args)
+        F, G = f.subs(reps), Tuple(*gens).xreplace(dict(reps))
+    else:
+        F, G = f, gens
+
+    # dispatch to helper
+    if isinstance(F, Tuple):
+        p, q = F
+        rv = _cancel_pq(p, q, *G, **args)
+    elif isinstance(F, (Mul, Add)):
+        rv = _cancel(F, *G, **args)
+    else:
+        rv = f.replace(
+            lambda x: isinstance(x, (Mul, Add)),
+            lambda x: _cancel(x, *G, **args))
+
+    # post-process if necessary
+    if sifted[True]:
         _reps = dict([(v, k) for k, v in reps])
         return rv.xreplace(_reps)
-
-    return _cancel(f, *gens, **args)
+    return rv
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6453,7 +6453,7 @@ def cancel(f, *gens, **args):
     """
     Cancel common factors in a rational function ``f`` returning
     ``p/q`` where ``p`` and ``q`` are fully expanded expressions
-    with no factors in common.
+    (in the generators given) with no factors in common.
 
     If the numerator and denominator of ``f`` are already
     known, they can be sent directly and a tuple giving
@@ -6509,6 +6509,18 @@ def cancel(f, *gens, **args):
     (1, Poly(2, x, domain='ZZ'), Poly(3*x, x, domain='ZZ'))
     >>> cancel((p, q))
     (1, 2, 3*x)
+
+    The state of expansion of the result depends on the generators
+    given:
+
+    >>> n = x**2*(y**2*z - z) - y**2*z + z
+    >>> d = x*(y*z - z) - y*z + z
+    >>> cancel(n/d)
+    x*y + x + y + 1
+    >>> cancel(n/d, y)
+    x + y*(x + 1) + 1
+    >>> cancel(n/d, x)
+    x*(y + 1) + y + 1
 
     Notes
     =====

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -45,7 +45,7 @@ from sympy.polys.polyerrors import (
     GeneratorsError,
 )
 
-from sympy.utilities import group, sift, public
+from sympy.utilities import group, sift, public, flatten
 from sympy.utilities.misc import filldedent
 
 import sympy.polys
@@ -6422,7 +6422,7 @@ def _cancel(f, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)
     except PolificationFailed:
-        return f
+        return p/q
     except PolynomialError as msg:
         if f.is_commutative and not f.has(Piecewise):
             raise PolynomialError(msg)
@@ -6481,11 +6481,12 @@ def cancel(f, *gens, **args):
         raise ValueError('expecting tuple or Expr, not %s' % f)
 
     # recognize non-Symbol args
+    gens = Tuple(*flatten(gens))
     sifted = sift(gens, lambda x: not isinstance(x, Symbol))
     if sifted[True]:
         reps = [(g, Dummy()) for g in sifted[True]]
         # the reps are processed in the order give
-        F, G = f.subs(reps), Tuple(*gens).xreplace(dict(reps))
+        F, G = f.subs(reps), gens.xreplace(dict(reps))
     else:
         F, G = f, gens
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6452,7 +6452,7 @@ def _cancel(f, *gens, **args):
         if isinstance(f, (Mul, Add)):
             sifted = sift(f.args, lambda x:
                 x.is_commutative and not isinstance(x, Piecewise))
-            c, nc = sifted[True], sifted[False]
+            c, nc = sifted[True], sifted[False] + sifted[None]
             nc = [_cancel(i, *gens, **args) for i in nc]
             return f.func(_cancel(f.func._from_args(c), *gens, **args), *nc)
         else:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6403,14 +6403,14 @@ def _cancel_pq(p, q, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)
     except PolificationFailed:
-        return Tuple(S.One, p, q)
+        return S.One, p, q
     else:
         c, P, Q = F.cancel(G)
 
         if not opt.polys:
-            return Tuple(c, P.as_expr(), Q.as_expr())
+            return c, P.as_expr(), Q.as_expr()
         else:
-            return Tuple(c, P, Q)
+            return c, P, Q
 
 
 def _cancel(f, *gens, **args):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6570,11 +6570,10 @@ def cancel(f, *gens, **args):
         if n and n.is_Number:
             c *= n
             n = S.One
-
     else:
         rv = _cancel(F, *G, **args)
         c, nd = rv.as_coeff_Mul()
-        n, d = fraction(nd) if nd.is_Mul else (nd, S.One)
+        n, d = fraction(nd)
 
     if not as_tuple:
        rv = _keep_coeff(c, n/d)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6418,6 +6418,8 @@ def _cancel(f, *gens, **args):
     from sympy.core.exprtools import factor_terms
     from sympy.functions.elementary.piecewise import Piecewise
 
+    if not isinstance(f, Expr):
+        return f
     p, q = factor_terms(f, radical=True).as_numer_denom()
     try:
         (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6492,7 +6492,8 @@ def cancel(f, *gens, **args):
     # post-process if necessary
     if sifted[True]:
         _reps = dict([(v, k) for k, v in reps])
-        return rv.xreplace(_reps)
+        rv = rv.xreplace(_reps)
+
     return rv
 
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -7077,6 +7077,7 @@ def poly(expr, *gens, **args):
     return _poly(expr, opt)
 
 def _clear_numer(P):
+    from sympy.core.compatibility import reduce
     # a very light touch to remove any Integer gcd from
     # terms of P
     if P.is_Add:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6397,9 +6397,6 @@ def nth_power_roots_poly(f, n, *gens, **args):
 
 def _cancel_pq(p, q, *gens, **args):
     # helper for cancel to handle explicit numerator and denominator
-    from sympy.core.exprtools import factor_terms
-    from sympy.functions.elementary.piecewise import Piecewise
-
     try:
         (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)
     except PolificationFailed:
@@ -6443,6 +6440,7 @@ def _cancel(f, *gens, **args):
             c, nc = sifted[True], sifted[False]
             nc = [_cancel(i) for i in nc]
             return f.func(_cancel(f.func._from_args(c)), *nc)
+        return f.func(*[_cancel(i) for i in f.args])
 
 
 @public

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -58,6 +58,7 @@ from sympy import (
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
+from sympy.stats import Variance
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.simplify import simplify
 
@@ -2936,6 +2937,11 @@ def test_cancel():
     assert cancel(M[0,0] + 7) == M[0,0] + 7
     expr = sin(M[1, 4] + M[2, 1] * 5 * M[4, 0]) - 5 * M[1, 2] / z
     assert cancel(expr) == (z*sin(M[1, 4] + M[2, 1] * 5 * M[4, 0]) - 5 * M[1, 2]) / z
+
+    nc = Variance(x)
+    assert nc.is_commutative is None  # if this fails get a new object
+    eq = 4*nc
+    assert cancel(eq) == eq
 
 
 def test_issue_11506():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2815,6 +2815,12 @@ def test_cancel():
 
     assert cancel(oo) == oo
 
+    raises(ValueError, lambda: cancel((1, 2, 3)))  # too long
+    # sending a tuple is a special case to be used with care;
+    # it represents (numer, denom) of an expression and should.
+    # To cancel items in a list, iterate over the items or use map.
+    raises(ValueError, lambda: cancel([x]))
+
     # if there is no generator, the (p, q) must be sympified
     pq = Tuple(1, 2).args
     assert cancel(pq) == (S.Half, 1, 1)
@@ -2936,15 +2942,9 @@ def test_cancel():
 
 def test_issue_11506():
     f = (exp(x) + 1)/exp(x)
-    assert cancel(log(f)) == log(f)
-    assert cancel(f, exp(-x)) == 1 + exp(-x)
-    assert cancel(f, exp(-x), exp(x)) == 1 + exp(-x)
-    # order matters
-    assert cancel(f, exp(x), exp(-x)) == f
-    raw = cancel((2, 3))
-    assert isinstance(raw, tuple) and raw == (1, 2, 3)
-    raises(ValueError, lambda: cancel((1, 2, 3)))
-    raises(ValueError, lambda: cancel([x]))  # by design; use map
+    e = f.expand()
+    assert cancel(e) == f
+    assert cancel(log(e)) == log(f)
 
 
 def test_reduced():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2823,7 +2823,7 @@ def test_cancel():
 
     # if there is no generator, the (p, q) must be sympified
     pq = Tuple(1, 2).args
-    assert cancel(pq) == (S.Half, 1, 1)
+    assert cancel(pq) == (1, 1, 2)
     # these are fine
     assert cancel((1, 0), x) == (1, 1, 0)
     assert cancel((0, 1), x) == (1, 0, 1)
@@ -2834,20 +2834,18 @@ def test_cancel():
     f, g, p, q = 4*x**2 - 4, 2*x - 2, 2*x + 2, 1
     F, G, P, Q = [ Poly(u, x) for u in (f, g, p, q) ]
 
-    eans = (2, x + 1, 1)
     assert F.cancel(G) == (1, P, Q)
-    assert cancel((f, g)) == eans
-    assert cancel((f, g), x) == eans
-    assert cancel((f, g), *(x,)) == eans
+    assert cancel((f, g)) == (1, p, q)
+    assert cancel((f, g), x) == (1, p, q)
+    assert cancel((f, g), *(x,)) == (1, p, q)
     assert cancel((F, G)) == (1, P, Q)
     assert cancel((f, g), polys=True) == (1, P, Q)
-    assert cancel((F, G), polys=False) == eans
+    assert cancel((F, G), polys=False) == (1, p, q)
     eq = (x**2/4 - 1)/(x/2 - 1)
-    ans = (S.Half, x + 2, 1)
-    assert cancel(fraction(eq)) == ans
-    assert cancel(eq.as_numer_denom()) == ans
+    assert cancel(fraction(eq)) == (1, x + 2, 2)
+    assert cancel(eq.as_numer_denom()) == (1, x + 2, 2)
     assert cancel(eq) == _keep_coeff(S.Half, x + 2)
-    assert cancel((1/eq).as_numer_denom()) == (2, 1, x + 2)
+    assert cancel((1/eq).as_numer_denom()) == (1, 2, x + 2)
 
     f = (x**2 - 2)/(x + sqrt(2))
 
@@ -2866,7 +2864,7 @@ def test_cancel():
     assert cancel((x**2 - y**2)/(x - y)) == x + y
 
     assert cancel((x**3 - 1)/(x**2 - 1)) == (x**2 + x + 1)/(x + 1)
-    assert cancel((x**3/2 - S(1)/2)/(x**2 - 1)) == (x**2 + x + 1)/(x + 1)/2
+    assert cancel((x**3/2 - S(1)/2)/(x**2 - 1)) == (x**2 + x + 1)/(2*x + 2)
 
     assert cancel((exp(2*x) + 2*exp(x) + 1)/(exp(x) + 1)) == exp(x) + 1
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -51,8 +51,9 @@ from sympy.polys.domains.realfield import RealField
 from sympy.polys.orderings import lex, grlex, grevlex
 
 from sympy import (
-    S, Integer, Rational, Float, Mul, Symbol, sqrt, Piecewise, Derivative,
-    exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff)
+    S, Integer, Rational, Float, Mul, Symbol, sqrt, Piecewise,
+    Derivative, exp, sin, tanh, expand, oo, I, pi, re, im, rootof,
+    Eq, Tuple, Expr, diff, log)
 
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
@@ -2918,14 +2919,16 @@ def test_cancel():
     assert cancel(expr) == (z*sin(M[1, 4] + M[2, 1] * 5 * M[4, 0]) - 5 * M[1, 2]) / z
 
 
-def test_issue_1506b():
+def test_issue_15605():
     f = (exp(x) + 1)/exp(x)
+    assert cancel(log(f)) == log(f)
     assert cancel(f, exp(-x)) == 1 + exp(-x)
     assert cancel(f, exp(-x), exp(x)) == 1 + exp(-x)
     # order matters
     assert cancel(f, exp(x), exp(-x)) == f
-    assert isinstance(cancel((2, 3)), Tuple)
-    assert isinstance(cancel((1, 2, 3)), Tuple)
+    raw = cancel((2, 3))
+    assert isinstance(raw, Tuple) and raw == (1, 2, 3)
+    raises(ValueError, lambda: cancel((1, 2, 3)))
 
 
 def test_reduced():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3189,7 +3189,9 @@ def test_keep_coeff():
     assert _keep_coeff(S(1), x) == x
     assert _keep_coeff(S(-1), x) == -x
     assert _keep_coeff(S(1.0), x) == 1.0*x
+    assert _keep_coeff(S(1.0), 1.*x) == 1.0*x
     assert _keep_coeff(S(-1.0), x) == -1.0*x
+    assert _keep_coeff(S(-1.0), -1.*x) == 1.0*x
     assert _keep_coeff(S(1), 2*x) == 2*x
     assert _keep_coeff(S(2), x/2) == x
     assert _keep_coeff(S(2), sin(x)) == 2*sin(x)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2900,20 +2900,22 @@ def test_cancel():
 
     # issue 7022
     A = Symbol('A', commutative=False)
-    p1 = Piecewise((A*(x**2 - 1)/(x + 1), x > 1), ((x + 2)/(x**2 + 2*x), True))
+    rat = (x**2 - 1)/(x + 1)
+    p1 = Piecewise((A*rat, x > 1), ((x + 2)/(x**2 + 2*x), True))
     p2 = Piecewise((A*(x - 1), x > 1), (1/x, True))
     assert cancel(p1) == p2
     assert cancel(2*p1) == 2*p2
     assert cancel(1 + p1) == 1 + p2
-    assert cancel((x**2 - 1)/(x + 1)*p1) == (x - 1)*p2
-    assert cancel((x**2 - 1)/(x + 1) + p1) == (x - 1) + p2
-    p3 = Piecewise(((x**2 - 1)/(x + 1), x > 1), ((x + 2)/(x**2 + 2*x), True))
+    assert cancel(rat*p1) == (x - 1)*p2
+    assert cancel(rat + p1) == (x - 1) + p2
+    p3 = Piecewise((rat, x > 1), ((x + 2)/(x**2 + 2*x), True))
     p4 = Piecewise(((x - 1), x > 1), (1/x, True))
     assert cancel(p3) == p4
     assert cancel(2*p3) == 2*p4
     assert cancel(1 + p3) == 1 + p4
-    assert cancel((x**2 - 1)/(x + 1)*p3) == (x - 1)*p4
-    assert cancel((x**2 - 1)/(x + 1) + p3) == (x - 1) + p4
+    assert cancel(rat*p3) == (x - 1)*p4
+    assert cancel(rat + p3) == (x - 1) + p4
+    assert cancel(Piecewise((rat, rat > 1))) == Piecewise((x - 1, x - 1 > 1))
 
     # issue 9363
     M = MatrixSymbol('M', 5, 5)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2915,7 +2915,10 @@ def test_cancel():
     assert cancel(1 + p3) == 1 + p4
     assert cancel(rat*p3) == (x - 1)*p4
     assert cancel(rat + p3) == (x - 1) + p4
-    assert cancel(Piecewise((rat, rat > 1))) == Piecewise((x - 1, x - 1 > 1))
+    assert cancel(Piecewise((rat, rat > 1))
+        ) == Piecewise((x - 1, x - 1 > 1))
+    assert cancel(Piecewise(([rat], x > 1))
+        ) == Piecewise(([x - 1], x > 1))
 
     # issue 9363
     M = MatrixSymbol('M', 5, 5)
@@ -2934,7 +2937,7 @@ def test_issue_11506():
     raw = cancel((2, 3))
     assert isinstance(raw, tuple) and raw == (1, 2, 3)
     raises(ValueError, lambda: cancel((1, 2, 3)))
-    raises(ValueError, lambda: cancel([x]))
+    raises(ValueError, lambda: cancel([x]))  # by design; use map
 
 
 def test_reduced():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2917,6 +2917,17 @@ def test_cancel():
     expr = sin(M[1, 4] + M[2, 1] * 5 * M[4, 0]) - 5 * M[1, 2] / z
     assert cancel(expr) == (z*sin(M[1, 4] + M[2, 1] * 5 * M[4, 0]) - 5 * M[1, 2]) / z
 
+
+def test_issue_1506b():
+    f = (exp(x) + 1)/exp(x)
+    assert cancel(f, exp(-x)) == 1 + exp(-x)
+    assert cancel(f, exp(-x), exp(x)) == 1 + exp(-x)
+    # order matters
+    assert cancel(f, exp(x), exp(-x)) == f
+    assert isinstance(cancel((2, 3)), Tuple)
+    assert isinstance(cancel((1, 2, 3)), Tuple)
+
+
 def test_reduced():
     f = 2*x**4 + y**2 - x**2 + y**3
     G = [x**3 - x, y**3 - y]

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2820,6 +2820,9 @@ def test_cancel():
     assert cancel((1, 0), x) == (1, 1, 0)
     assert cancel((0, 1), x) == (1, 0, 1)
 
+    # PolificationFailed raises for this case
+    assert cancel((2 + 2*x)/(1 + x)) == 2
+
     f, g, p, q = 4*x**2 - 4, 2*x - 2, 2*x + 2, 1
     F, G, P, Q = [ Poly(u, x) for u in (f, g, p, q) ]
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2929,6 +2929,7 @@ def test_issue_15605():
     raw = cancel((2, 3))
     assert isinstance(raw, Tuple) and raw == (1, 2, 3)
     raises(ValueError, lambda: cancel((1, 2, 3)))
+    raises(ValueError, lambda: cancel([x]))
 
 
 def test_reduced():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2845,7 +2845,9 @@ def test_cancel():
     eq = (x**2/4 - 1)/(x/2 - 1)
     assert cancel(fraction(eq)) == (1, x + 2, 2)
     assert cancel(eq.as_numer_denom()) == (1, x + 2, 2)
-    assert cancel(eq) == _keep_coeff(S.Half, x + 2)
+    assert cancel(eq) == 1 + x/2
+    assert cancel(eq, tuple=True) == (1, x + 2, 2)
+    assert cancel(eq, coeff=True) == _keep_coeff(S.Half, x + 2)
     assert cancel((1/eq).as_numer_denom()) == (1, 2, x + 2)
 
     f = (x**2 - 2)/(x + sqrt(2))
@@ -2942,6 +2944,8 @@ def test_cancel():
     assert nc.is_commutative is None  # if this fails get a new object
     eq = 4*nc
     assert cancel(eq) == eq
+
+    assert cancel((x**2 + x, x + 1), tuple=False) == x
 
 
 def test_issue_11506():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2919,7 +2919,7 @@ def test_cancel():
     assert cancel(expr) == (z*sin(M[1, 4] + M[2, 1] * 5 * M[4, 0]) - 5 * M[1, 2]) / z
 
 
-def test_issue_15605():
+def test_issue_11506():
     f = (exp(x) + 1)/exp(x)
     assert cancel(log(f)) == log(f)
     assert cancel(f, exp(-x)) == 1 + exp(-x)
@@ -2927,7 +2927,7 @@ def test_issue_15605():
     # order matters
     assert cancel(f, exp(x), exp(-x)) == f
     raw = cancel((2, 3))
-    assert isinstance(raw, Tuple) and raw == (1, 2, 3)
+    assert isinstance(raw, tuple) and raw == (1, 2, 3)
     raises(ValueError, lambda: cancel((1, 2, 3)))
     raises(ValueError, lambda: cancel([x]))
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -119,6 +119,7 @@ debug this function to figure out the exact problem.
 from __future__ import print_function, division
 
 from sympy.core import Basic, S, oo, Symbol, I, Dummy, Wild, Mul
+from sympy.core.function import expand_mul, expand_power_base
 from sympy.functions import log, exp
 from sympy.series.order import Order
 from sympy.simplify.powsimp import powsimp, powdenest
@@ -468,6 +469,8 @@ def calculate_series(e, x, logx=None):
 
         if t.has(exp) and t.has(log):
             t = powdenest(t)
+        if t.has(exp):
+            t = expand_power_base(expand_mul(t))
 
         if t.simplify():
             break

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -390,12 +390,11 @@ def test_MrvTestCase_page47_ex3_21():
 
 
 def test_I():
-    from sympy.functions import sign as sgn
     y = Symbol("y")
     assert gruntz(I*x, x, oo) == I*oo
     assert gruntz(y*I*x, x, oo) == y*I*oo
     assert gruntz(y*3*I*x, x, oo) == y*I*oo
-    assert gruntz(y*3*sin(I)*x, x, oo).simplify() == sgn(y)*I*oo
+    assert gruntz(y*3*sin(I)*x, x, oo).simplify() == y*I*oo
 
 
 def test_issue_4814():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -161,6 +161,7 @@ def test_issue_5652():
     assert simplify(E + exp(-E)) == exp(-E) + E
     n = symbols('n', commutative=False)
     assert simplify(n + n**(-n)) == n + n**(-n)
+    assert simplify(n + n**(-(x**2 + x)/(x + 1))) == n + n**(-x)
 
 
 def test_simplify_fail1():


### PR DESCRIPTION
- expressions (wherever they occur in an Expr) should be handled consistently now as identified in #11506
- tuple output can be turned on or off with keyword `tuple`
```
>>> cancel((Poly(x),Poly(y)))
(1, Poly(x, x, y, domain='ZZ'), Poly(y, x, y, domain='ZZ'))
>>> cancel((Poly(x),Poly(y)), tuple=False)
x/y
>>> cancel(x/2+1)
(x + 2)/2
>>> cancel(x/2+1, tuple=True)
(1/2, x + 2, 1)
```
- when the output is not a tuple, it will always be a fraction or an expression with numerator of 1,
unevaluate if necessary
- passing a tuple of length other than 2 is disabled
- the handling of expressions and numerator/denominator tuples is separated

closes #12787 
closes #11506