### PR TITLE
direction property added to Point; discussion about canonical Plane

### DIFF
--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -39,15 +39,33 @@ class Plane(GeometryEntity):
     Examples
     ========
 
-    >>> from sympy import Plane, Point3D
+    >>> from sympy import Plane, Point
     >>> from sympy.abc import x
-    >>> Plane(Point3D(1, 1, 1), Point3D(2, 3, 4), Point3D(2, 2, 2))
+    >>> Plane(Point(1, 1, 1), Point(2, 3, 4), Point(2, 2, 2))
     Plane(Point3D(1, 1, 1), (-1, 2, -1))
     >>> Plane((1, 1, 1), (2, 3, 4), (2, 2, 2))
     Plane(Point3D(1, 1, 1), (-1, 2, -1))
-    >>> Plane(Point3D(1, 1, 1), normal_vector=(1,4,7))
+    >>> Plane(Point(1, 1, 1), normal_vector=(1,4,7))
     Plane(Point3D(1, 1, 1), (1, 4, 7))
 
+    When three points are given, the normal vector direction will
+    depend on the order of the points given:
+
+    >>> a, b, c = (0, 0, 0), (1, 0, 0), (0, 1, 0)
+    >>> Plane(a, b, c).normal_vector
+    (0, 0, 1)
+    >>> Plane(b, a, c).normal_vector
+    (0, 0, -1)
+
+    Simplification of normal_vector can be handled with
+    the direction property of Point. For simplicity, the
+    normal vector is given explicitly below rather than
+    using 3 points, but the idea is the same:
+
+    >>> Plane((1, 1, 1), (2, 4, 6)).normal_vector
+    (2, 4, 6)
+    >>> Point(_).direction.args
+    (1, 2, 3)
     """
     def __new__(cls, p1, a=None, b=None, **kwargs):
         p1 = Point3D(p1, dim=3)

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -841,6 +841,34 @@ class Point(GeometryEntity):
         and a distance of 1 from the origin"""
         return self / abs(self)
 
+    @property
+    def direction(self):
+        """Return that Point that is in the same direction as `self`
+        but with any gcd of the coordinates removed.
+
+        Examples
+        ========
+
+        >>> from sympy.geometry.point import Point
+        >>> a = Point(2, 4)
+        >>> a.direction
+        Point2D(1, 2)
+        >>> a.unit
+        Point2D(sqrt(5)/5, 2*sqrt(5)/5)
+        >>> _.direction
+        Point2D(1, 2)
+        """
+        from sympy.polys.polytools import gcd
+        from sympy.core.compatibility import reduce
+        args = self.args
+        # done twice for issue 12794
+        for _ in range(2):
+            g = reduce(gcd, args)
+            args = [i/g for i in args]
+            if all(i.is_Integer for i in args):
+                break
+        return Point(*args)
+
     n = evalf
 
     __truediv__ = __div__

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -414,3 +414,11 @@ def test_direction_cosine():
     assert p2.direction_cosine(Point3D(0, 0, 0)) == [-sqrt(3) / 3, -sqrt(3) / 3, -sqrt(3) / 3]
     assert p2.direction_cosine(Point3D(1, 1, 12)) == [0, 0, 1]
     assert p2.direction_cosine(Point3D(12, 1, 12)) == [sqrt(2) / 2, 0, sqrt(2) / 2]
+
+
+def test_direction():
+    x = Symbol('x')
+    assert Point(2, 4).direction == Point(1, 2)
+    assert (Point(2, 4)*x).direction == Point(1, 2)
+    assert Point(1, 2).unit.direction == Point(1, 2)
+    assert Point(2, 4, 6).direction == Point(1, 2, 3)


### PR DESCRIPTION
Although a unit property exists for Point, there
is no property that will give a Point with the
gcd of the coordinates removed.
```
>>> a = Point(2, 4, 6)
>>> a.direction
Point3D(1, 2, 3)
>>> a.unit
Point3D(sqrt(14)/14, sqrt(14)/7, 3*sqrt(14)/14)
>>> _.direction
Point3D(1, 2, 3)
```

This is useful if one wants to represent a Plane's `normal_vector` in a different way. It probably is best not to do this automatically -- like Ray does not automatically set p2 to be a distance of 1 from p1 and this can be useful for plotting Rays: the arbitrary point depends on the distance between p1 and p2:
```
>>> Ray((0,0),(1,1)).arbitrary_point()
Point2D(t, t)
>>> Ray((0,0),(2,2)).arbitrary_point()
Point2D(2*t, 2*t)
```
It also probably makes sense to leave the defining point used with the `normal_vector` alone. This can also be useful for plotting in that the Plane has a point of "focus". If one were making things canonical, it might make sense to shift p1 to some canonical point, maybe something like this:

```
def canonical(plane):
    """Return a canonical p1 and normal vector for a plane.

    Examples
    ========

    >> from sympy import Plane
    >> from sympy.abc import x, y, z
    >> from sympy.geometry.plane import canonical
    >> a, b, c = (2,4,8), (0,1,0), (x,y,z)
    >> Plane(a, b, c)
    Plane(Point3D(2, 4, 8), (8*y - 3*z - 8, -8*x + 2*z, 3*x - 2*y + 2))
    >> canonical(_)
    (Point3D(4*x - z, 0, 0), (-8*y + 3*z + 8, 8*x - 2*z, -3*x + 2*y - 2))
    >> canonical(Plane(b, a, c)) == _
    True

    >> Plane(a, b, (3, 1, 2))
    Plane(Point3D(2, 4, 8), (-6, -20, 9))
    >> canonical(_)
    (Point3D(10, 0, 0), (6, 20, -9))
    """
    from sympy.core.function import _coeff_isneg
    from sympy.core.compatibility import ordered
    from sympy import Dummy
    from symyp.core.exprtools import factor_terms
    from sympy.geometry.point import Point
    from sympy.solvers.solvers import solve
    neg = lambda x: _coeff_isneg(x) or x.could_extract_minus_sign()
    x, y, z = [Dummy() for i in range(3)]
    eq = plane.equation(x, y, z)
    free = list(ordered(eq.free_symbols & set([x, y, z])))
    pt = [0]*3
    while free:
        v = free.pop()
        if free:
            eq = eq.subs(v, 0)
    i = (x, y, z).index(v)
    pt[i] = factor_terms(solve(eq, v)[0].as_numer_denom()[0])
    if pt[i].is_Mul and pt[i].args[0].is_Number:
        pt[i] = pt[i]/pt[i].args[0]
    v = Point(plane.normal_vector)
    if neg(v.x):
        v = v*-1
    elif v.x == 0 and neg(v.y):
        v = v*-1
    elif v.x == v.y == 0 and neg(v.z):
        v = v*-1
    return Point(pt), v.direction.args
```