### PR TITLE
Revert change to cse

### DIFF
--- a/doc/src/modules/rewriting.rst
+++ b/doc/src/modules/rewriting.rst
@@ -74,11 +74,16 @@ in the ``cse`` function. Examples::
     ⎛    ⎡  ________⎤⎞
     ⎝[], ⎣╲╱ sin(x) ⎦⎠
 
-    >>> pprint(cse(sqrt(sin(x) + 4)*sqrt(sin(x) + 5)), use_unicode=True)
-    ⎛               ⎡   ________   ________⎤⎞
+    >>> pprint(cse(sqrt(sin(x)+5)*sqrt(sin(x)+4)), use_unicode=True)
+    ⎛                ⎡  ________   ________⎤⎞
     ⎝[(x₀, sin(x))], ⎣╲╱ x₀ + 4 ⋅╲╱ x₀ + 5 ⎦⎠
 
-    >>> pprint(cse((x - y)*(z - y) + sqrt((x - y)*(z - y))), use_unicode=True)
+    >>> pprint(cse(sqrt(sin(x+1) + 5 + cos(y))*sqrt(sin(x+1) + 4 + cos(y))),
+    ...     use_unicode=True)
+    ⎛                             ⎡  ________   ________⎤⎞
+    ⎝[(x₀, sin(x + 1) + cos(y))], ⎣╲╱ x₀ + 4 ⋅╲╱ x₀ + 5 ⎦⎠
+
+    >>> pprint(cse((x-y)*(z-y) + sqrt((x-y)*(z-y))), use_unicode=True)
     ⎛                                     ⎡  ____     ⎤⎞
     ⎝[(x₀, -y), (x₁, (x + x₀)⋅(x₀ + z))], ⎣╲╱ x₁  + x₁⎦⎠
 
@@ -87,7 +92,7 @@ elimination can be passed in the``optimizations`` optional argument. A set of
 predefined basic optimizations can be applied by passing
 ``optimizations='basic'``::
 
-    >>> pprint(cse((x - y)*(z - y) + sqrt((x - y)*(z - y)), optimizations='basic'),
+    >>> pprint(cse((x-y)*(z-y) + sqrt((x-y)*(z-y)), optimizations='basic'),
     ...     use_unicode=True)
     ⎛                          ⎡  ____     ⎤⎞
     ⎝[(x₀, -(x - y)⋅(y - z))], ⎣╲╱ x₀  + x₀⎦⎠

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1086,7 +1086,7 @@ class Expr(Basic, EvalfMixin):
         Note: -1 is always separated from a Number unless split_1 is False.
 
         >>> from sympy import symbols, oo
-        >>> A, B = symbols('A B', commutative=False)
+        >>> A, B = symbols('A B', commutative=0)
         >>> x, y = symbols('x y')
         >>> (-2*x*y).args_cnc()
         [[-1, 2, x, y], []]

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -595,9 +595,9 @@ def test_issue_6559():
     # though this involves cse it generated a failure in Mul._eval_subs
     x0, x1 = symbols('x0 x1')
     e = -log(-12*sqrt(2) + 17)/24 - log(-2*sqrt(2) + 3)/12 + sqrt(2)/3
+    # XXX modify cse so x1 is eliminated and x0 = -sqrt(2)?
     assert cse(e) == (
-        [(x0, sqrt(2))],
-        [x0/3 - log(-12*x0 + 17)/24 - log(-2*x0 + 3)/12])
+        [(x0, sqrt(2))], [x0/3 - log(-12*x0 + 17)/24 - log(-2*x0 + 3)/12])
 
 
 def test_issue_5261():

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -120,11 +120,9 @@ class MatMul(MatrixExpr):
     # Needed for partial compatibility with Mul
     def args_cnc(self, **kwargs):
         coeff, matrices = self.as_coeff_matrices()
+        # I don't know how coeff could have noncommutative factors, but this
+        # handles it.
         coeff_c, coeff_nc = coeff.args_cnc(**kwargs)
-        if coeff_c == [1]:
-            coeff_c = []
-        elif coeff_c == set([1]):
-            coeff_c = set()
 
         return coeff_c, coeff_nc + matrices
 

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -130,4 +130,4 @@ def test_matmul_no_matrices():
 def test_matmul_args_cnc():
     a, b = symbols('a b', commutative=False)
     assert MatMul(n, a, b, A, A.T).args_cnc() == ([n], [a, b, A, A.T])
-    assert MatMul(A, A.T).args_cnc() == ([], [A, A.T])
+    assert MatMul(A, A.T).args_cnc() == ([1], [A, A.T])

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -428,9 +428,9 @@ def llvm_callable(args, expr, callback_type=None):
     >>> from sympy.abc import x,y
     >>> e1 = x*x + y*y
     >>> e2 = 4*(x*x + y*y) + 8.0
-    >>> after_cse = cse([e1, e2])
+    >>> after_cse = cse([e1,e2])
     >>> after_cse
-    ([(x0, x**2 + y**2)], [x0, 4*x0 + 8.0])
+    ([(x0, x**2), (x1, y**2)], [x0 + x1, 4*x0 + 4*x1 + 8.0])
     >>> j1 = jit.llvm_callable([x,y], after_cse)
     >>> j1(1.0, 2.0)
     (5.0, 28.0)

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -494,3 +494,18 @@ def test_cse_ignore():
     subst2, red2 = cse(exprs, ignore=(y,))  # y is not allowed in substitutions
     assert not any(y in sub.free_symbols for _, sub in subst2), "Sub-expressions containing y must be ignored"
     assert any(sub - sqrt(x + 1) == 0 for _, sub in subst2), "cse failed to identify sqrt(x + 1) as sub-expression"
+
+
+def test_cse__performance():
+    import time
+    nexprs, nterms = 3, 20
+    x = symbols('x:%d' % nterms)
+    exprs = [
+        reduce(add, [x[j]*(-1)**(i+j) for j in range(nterms)])
+        for i in range(nexprs)
+    ]
+    assert exprs[0] == exprs[1]
+    subst, red = cse(exprs)
+    assert len(subst) > 0, "exprs[0] == exprs[2], i.e. a CSE"
+    for i, e in enumerate(red):
+        assert (e.subs(reversed(subst)) - exprs[i]).simplify() == 0

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -180,6 +180,20 @@ def test_non_commutative_order():
     assert cse(l) == ([(x0, B+C)], [x0, A*x0])
 
 
+@XFAIL # Worked in gh-11232, but was reverted due to performance considerations
+def test_issue_10228():
+    assert cse([x*y**2 + x*y]) == ([(x0, x*y)], [x0*y + x0])
+    assert cse([x + y, 2*x + y]) == ([(x0, x + y)], [x0, x + x0])
+    assert cse((w + 2*x + y + z, w + x + 1)) == (
+        [(x0, w + x)], [x0 + x + y + z, x0 + 1])
+    assert cse(((w + x + y + z)*(w - x))/(w + x)) == (
+        [(x0, w + x)], [(x0 + y + z)*(w - x)/x0])
+    a, b, c, d, f, g, j, m = symbols('a, b, c, d, f, g, j, m')
+    exprs = (d*g**2*j*m, 4*a*f*g*m, a*b*c*f**2)
+    assert cse(exprs) == (
+        [(x0, g*m), (x1, a*f)], [d*g*j*x0, 4*x0*x1, b*c*f*x1]
+)
+
 @XFAIL
 def test_powers():
     assert cse(x*y**2 + x*y) == ([(x0, x*y)], [x0*y + x0])

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -1,8 +1,12 @@
+from functools import reduce
 import itertools
+from operator import add
 
-from sympy import (Add, Pow, Symbol, exp, sqrt, symbols, sympify, cse,
-                   Matrix, S, cos, sin, Eq, Function, Tuple, CRootOf,
-                   IndexedBase, Idx, Piecewise, O, Mul)
+from sympy import (
+    Add, Mul, Pow, Symbol, exp, sqrt, symbols, sympify, cse,
+    Matrix, S, cos, sin, Eq, Function, Tuple, CRootOf,
+    IndexedBase, Idx, Piecewise, O
+)
 from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.functions.special.hyper import meijerg
 from sympy.simplify import cse_main, cse_opts
@@ -16,7 +20,7 @@ from sympy.core.compatibility import range
 
 
 w, x, y, z = symbols('w,x,y,z')
-x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18 = symbols('x:19')
+x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12 = symbols('x:13')
 
 
 def test_numbered_symbols():
@@ -175,17 +179,9 @@ def test_non_commutative_order():
     assert cse(l) == ([(x0, B+C)], [x0, A*x0])
 
 
-def test_issue_10228():
-    assert cse([x*y**2 + x*y]) == ([(x0, x*y)], [x0*y + x0])
-    assert cse([x + y, 2*x + y]) == ([(x0, x + y)], [x0, x + x0])
-    assert cse((w + 2*x + y + z, w + x + 1)) == (
-        [(x0, w + x)], [x0 + x + y + z, x0 + 1])
-    assert cse(((w + x + y + z)*(w - x))/(w + x)) == (
-        [(x0, w + x)], [(x0 + y + z)*(w - x)/x0])
-    a, b, c, d, f, g, j, m = symbols('a, b, c, d, f, g, j, m')
-    exprs = (d*g**2*j*m, 4*a*f*g*m, a*b*c*f**2)
-    assert cse(exprs) == (
-        [(x0, g*m), (x1, a*f)], [d*g*j*x0, 4*x0*x1, b*c*f*x1])
+@XFAIL
+def test_powers():
+    assert cse(x*y**2 + x*y) == ([(x0, x*y)], [x0*y + x0])
 
 
 def test_issue_4498():
@@ -273,21 +269,12 @@ def test_issue_4499():
         sqrt(z))*G(b)*G(2*a - b + 1), 1, 0, S(1)/2, z/2, -b + 1, -2*a + b,
         -2*a))
     c = cse(t)
-    # check rebuild
-    r = c[0]
-    tt = list(c[1][0])
-    for i in range(len(tt)):
-        for re in reversed(r):
-            tt[i] = tt[i].subs(*re)
-        assert tt[i] == t[i]
-    # check answer
     ans = (
-        [(x0, 2*a), (x1, -b), (x2, x0 + x1 + 1), (x3, sqrt(z)), (x4,
-        B(x0 + x1, x3)), (x5, G(b)), (x6, G(x2)), (x7, -x0), (x8,
-        (x3/2)**(x7 + 1)), (x9, x5*x6*x8*B(b - 1, x3)), (x10,
-        x5*x6*x8*B(b, x3)), (x11, B(x2, x3))], [(a, a + 1/2, x0, b,
-        x2, x4*x9, x10*x3*x4, x11*x3*x9, x10*x11, 1, 0, 1/2, z/2, x1 +
-        1, b + x7, x7)])
+        [(x0, 2*a), (x1, -b), (x2, x1 + 1), (x3, x0 + x2), (x4, sqrt(z)), (x5,
+        B(x0 + x1, x4)), (x6, G(b)), (x7, G(x3)), (x8, -x0), (x9,
+        (x4/2)**(x8 + 1)), (x10, x6*x7*x9*B(b - 1, x4)), (x11, x6*x7*x9*B(b,
+        x4)), (x12, B(x3, x4))], [(a, a + S(1)/2, x0, b, x3, x10*x5,
+        x11*x4*x5, x10*x12*x4, x11*x12, 1, 0, S(1)/2, z/2, x2, b + x8, x8)])
     assert ans == c
 
 
@@ -321,13 +308,12 @@ def test_cse_MatrixSymbol():
     B = MatrixSymbol("B", n, n)
     assert cse(B) == ([], [B])
 
-
 def test_cse_MatrixExpr():
     from sympy import MatrixSymbol
     A = MatrixSymbol('A', 3, 3)
     y = MatrixSymbol('y', 3, 1)
 
-    expr1 = 2*(A.T*A).I * A * y
+    expr1 = (A.T*A).I * A * y
     expr2 = (A.T*A) * A * y
     replacements, reduced_exprs = cse([expr1, expr2])
     assert len(replacements) > 0
@@ -337,7 +323,6 @@ def test_cse_MatrixExpr():
 
     replacements, reduced_exprs = cse([A**2, A + A**2])
     assert replacements
-
 
 def test_Piecewise():
     f = Piecewise((-z + x*y, Eq(y, 0)), (-z - x*y, True))
@@ -504,8 +489,8 @@ def test_cse__performance():
         reduce(add, [x[j]*(-1)**(i+j) for j in range(nterms)])
         for i in range(nexprs)
     ]
-    assert exprs[0] == exprs[1]
+    assert (exprs[0] + exprs[1]).simplify() == 0
     subst, red = cse(exprs)
-    assert len(subst) > 0, "exprs[0] == exprs[2], i.e. a CSE"
+    assert len(subst) > 0, "exprs[0] == -exprs[2], i.e. a CSE"
     for i, e in enumerate(red):
         assert (e.subs(reversed(subst)) - exprs[i]).simplify() == 0

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -7,6 +7,7 @@ from sympy import (
     Matrix, S, cos, sin, Eq, Function, Tuple, CRootOf,
     IndexedBase, Idx, Piecewise, O
 )
+from sympy.core.function import count_ops
 from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.functions.special.hyper import meijerg
 from sympy.simplify import cse_main, cse_opts
@@ -446,7 +447,6 @@ def test_issue_11230():
 @XFAIL
 def test_issue_11577():
     def check(eq):
-        from sympy.core.function import count_ops
         r, c = cse(eq)
         assert eq.count_ops() >= \
             len(r) + sum([i[1].count_ops() for i in r]) + \
@@ -494,3 +494,10 @@ def test_cse__performance():
     assert len(subst) > 0, "exprs[0] == -exprs[2], i.e. a CSE"
     for i, e in enumerate(red):
         assert (e.subs(reversed(subst)) - exprs[i]).simplify() == 0
+
+
+def test_issue_12070():
+    exprs = [x+y,2+x+y,x+y+z,3+x+y+z]
+    subst, red = cse(exprs)
+    assert 6 >= (len(subst) + sum([v.count_ops() for k, v in subst]) +
+                 count_ops(red))

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4338,6 +4338,8 @@ def ode_linear_coefficients(eq, func, order, match):
     >>> f = Function('f')
     >>> df = f(x).diff(x)
     >>> eq = (x + f(x) + 1)*df + (f(x) - 6*x + 1)
+    >>> dsolve(eq, hint='linear_coefficients')
+    [Eq(f(x), -x - sqrt(C1 + 7*x**2) - 1), Eq(f(x), -x + sqrt(C1 + 7*x**2) - 1)]
     >>> pprint(dsolve(eq, hint='linear_coefficients'))
                       ___________                     ___________
                    /         2                     /         2
@@ -4401,6 +4403,8 @@ def ode_separable_reduced(eq, func, order, match):
     >>> f = Function('f')
     >>> d = f(x).diff(x)
     >>> eq = (x - x**2*f(x))*d - f(x)
+    >>> dsolve(eq, hint='separable_reduced')
+    [Eq(f(x), (-sqrt(C1*x**2 + 1) + 1)/x), Eq(f(x), (sqrt(C1*x**2 + 1) + 1)/x)]
     >>> pprint(dsolve(eq, hint='separable_reduced'))
                  ___________                ___________
                 /     2                    /     2


### PR DESCRIPTION
This reverts changes to `cse_main` from gh-11232 which unfortunately degraded the CSE performance too much (see https://github.com/sympy/sympy_benchmarks/pull/38 & gh-12411).

Timings for `test_cse__performance` on my laptop:
- master: 935 s
- this PR: 0.1 s

EDIT: We should reopen gh-10228, when merging this.