### PR TITLE
Skip some slow tests on Travis

### DIFF
--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -231,6 +231,10 @@ def test_pmint_trig():
 
 @slow # 8 seconds on 3.4 GHz
 def test_pmint_logexp():
+    if ON_TRAVIS:
+        # See https://github.com/sympy/sympy/pull/12795
+        skip("Too slow for travis.")
+
     f = (1 + x + x*exp(x))*(x + log(x) + exp(x) - 1)/(x + log(x) + exp(x))**2/x
     g = log(x + exp(x) + log(x)) + 1/(x + exp(x) + log(x))
 

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -11,7 +11,7 @@ from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
                        build_hypergeometric_formula)
 from sympy import hyper, I, S, meijerg, Piecewise, Tuple
 from sympy.abc import z, a, b, c
-from sympy.utilities.pytest import XFAIL, raises, slow, ON_TRAVIS
+from sympy.utilities.pytest import XFAIL, raises, slow, ON_TRAVIS, skip
 from sympy.utilities.randtest import verify_numerically as tn
 from sympy.core.compatibility import range
 

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -11,7 +11,7 @@ from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
                        build_hypergeometric_formula)
 from sympy import hyper, I, S, meijerg, Piecewise, Tuple
 from sympy.abc import z, a, b, c
-from sympy.utilities.pytest import XFAIL, raises, slow
+from sympy.utilities.pytest import XFAIL, raises, slow, ON_TRAVIS
 from sympy.utilities.randtest import verify_numerically as tn
 from sympy.core.compatibility import range
 
@@ -728,6 +728,10 @@ def test_prudnikov_2():
 
 @slow
 def test_prudnikov_3():
+    if ON_TRAVIS:
+        # See https://github.com/sympy/sympy/pull/12795
+        skip("Too slow for travis.")
+
     h = S.Half
     assert can_do([S(1)/4, S(3)/4], [h])
     assert can_do([S(1)/4, S(3)/4], [3*h])


### PR DESCRIPTION
See discussion at https://github.com/sympy/sympy/pull/12795. We should figure
out what is going on here, but for now, we need to stop the Travis build
errors.
