### PR TITLE
Add rel="canonical" tag to html doc theme

### DIFF
--- a/doc/src/_templates/layout.html
+++ b/doc/src/_templates/layout.html
@@ -1,0 +1,6 @@
+{% extends '!layout.html' %}
+
+{%- block linktags %}
+    <link href="http://docs.sympy.org/latest/{{ pagename }}.html" rel="canonical" />
+    {{ super() }}
+{%- endblock %}

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -32,7 +32,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.mathjax',
 mathjax_path = 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full'
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['.templates']
+templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->

This should hopefully help to fix the issue with google indexing old versions of the sympy docs that @asmeurer brought up on the mailing list while still hosting old versions of the documentation. This tag tells google that the "canonical" link for any page in the docs is really at docs.sympy.org/latest and not whatever other URL google is indexing. For example, when the next release happens, http://docs.sympy.org/1.1/tutorial/gotchas.html will get a tag in its header that looks like:

```
<link href="http://docs.sympy.org/latest/tutorial/gotchas.html" rel="canonical" />
```

When the googlebot next indexes the site, it will find canonical tags, and update search results so doc searches always go to the `latest` link.

If there's another doc version besides `latest` that it would be best to link to, let me know and I'll update this pull request.

More information about this tag from google's webmaster docs: https://support.google.com/webmasters/answer/139066?hl=en