### PR TITLE
Add deprecation warnings to densearith, densetools and densesolve

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -20,6 +20,7 @@ from sympy.utilities.decorator import doctest_depends_on
 from sympy.matrices.matrices import (MatrixBase,
                                      ShapeError, a2idx, classof)
 
+from sympy.core.decorators import deprecated
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 def _iszero(x):
@@ -1280,10 +1281,13 @@ def hessian(f, varlist, constraints=[]):
             out[j, i] = out[i, j]
     return out
 
-
+@deprecated(useinstead="jordan_block", deprecated_since_version="1.1")
 def jordan_cell(eigenval, n):
+    return jordan_block(eigenval, n)
+
+def jordan_block(eigenval, n):
     """
-    Create matrix of Jordan cell kind:
+    Create a Jordan block:
 
     Examples
     ========

--- a/sympy/matrices/densearith.py
+++ b/sympy/matrices/densearith.py
@@ -3,8 +3,14 @@ Fundamental arithmetic of dense matrices. The dense matrix is stored
 as a list of lists.
 
 """
-
 from sympy.core.compatibility import range
+
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
+SymPyDeprecationWarning(
+    feature="densearith",
+    issue=12695,
+    deprecated_since_version="1.1").warn()
 
 def add(matlist1, matlist2, K):
     """

--- a/sympy/matrices/densesolve.py
+++ b/sympy/matrices/densesolve.py
@@ -10,9 +10,14 @@ from sympy.matrices.densetools import rowadd, rowmul, conjugate_transpose
 from sympy.core.symbol import symbols
 from sympy.core.compatibility import range
 from sympy.core.power import isqrt
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 import copy
 
+SymPyDeprecationWarning(
+    feature="densesolve",
+    issue=12695,
+    deprecated_since_version="1.1").warn()
 
 
 def row_echelon(matlist, K):

--- a/sympy/matrices/densetools.py
+++ b/sympy/matrices/densetools.py
@@ -5,7 +5,12 @@ The dense matrix is stored as a list of lists
 """
 
 from sympy.core.compatibility import range
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
+SymPyDeprecationWarning(
+    feature="densetools",
+    issue=12695,
+    deprecated_since_version="1.1").warn()
 
 def trace(matlist, K):
     """

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2104,7 +2104,7 @@ class MatrixDecompositions(MatrixSubspaces):
 
         if rankcheck:
             SymPyDeprecationWarning(
-                feature="Keyword argument 'rankcheck' is deprecated.",
+                feature="Keyword argument 'rankcheck'",
                 issue=9796,
                 deprecated_since_version="1.1").warn()
             if self.rank() != min(self.rows, self.cols):

--- a/sympy/matrices/tests/test_densearith.py
+++ b/sympy/matrices/tests/test_densearith.py
@@ -1,5 +1,8 @@
-from sympy.matrices.densetools import eye
-from sympy.matrices.densearith import add, sub, mulmatmat, mulmatscaler
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from sympy.matrices.densetools import eye
+    from sympy.matrices.densearith import add, sub, mulmatmat, mulmatscaler
 from sympy import ZZ
 
 

--- a/sympy/matrices/tests/test_densesolve.py
+++ b/sympy/matrices/tests/test_densesolve.py
@@ -1,4 +1,7 @@
-from sympy.matrices.densesolve import LU_solve, rref_solve, cholesky_solve
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from sympy.matrices.densesolve import LU_solve, rref_solve, cholesky_solve
 from sympy import Dummy
 from sympy import QQ
 

--- a/sympy/matrices/tests/test_densetools.py
+++ b/sympy/matrices/tests/test_densetools.py
@@ -1,5 +1,8 @@
-from sympy.matrices.densetools import trace, transpose
-from sympy.matrices.densetools import eye
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from sympy.matrices.densetools import trace, transpose
+    from sympy.matrices.densetools import eye
 from sympy import ZZ
 
 def test_trace():

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -149,7 +149,7 @@ class SymPyDeprecationWarning(DeprecationWarning):
     def warn(self, stacklevel=2):
         see_above = self.fullMessage
         # the next line is what the user would see after the error is printed
-        # if stacklevel was set to 1. If you are writting a wrapper around this,
+        # if stacklevel was set to 1. If you are writing a wrapper around this,
         # increase the stacklevel accordingly.
         warnings.warn(see_above, SymPyDeprecationWarning, stacklevel=stacklevel)
 


### PR DESCRIPTION
This PR adds deprecation warnings at the beginning of densearith.py, densetools.py and densesolve.py in the matrices module. Additionally `jordan_cell` is deprecated to be replaced with `jordan_block` (as was attempted in the previous PRs for this issue) and a typo in a docstring to `SymPyDeprecationWarning` is corrected.

Should I add a note about this to the release notes?

Fixes #12695 
