### PR TITLE
Allow custom codegen class to be passed in to autowrap and codegen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,7 +3,7 @@ order of the date of their first contribution), except those who explicitly
 didn't want to be mentioned. People with a * next to their names are not found
 in the metadata of the git history. This file is generated automatically by
 running `./bin/authors_update.py`.
-There are a total of 617 authors.
+There are a total of 618 authors.
 
 Ondřej Čertík <ondrej@certik.cz>
 Fabian Pedregosa <fabian@fseoane.net>
@@ -621,4 +621,5 @@ Vincent Delecroix <vincent.delecroix@labri.fr>
 Michael Sparapany <msparapa@purdue.edu>
 harsh_jain <harshjniitr@gmail.com>
 Nathan Goldbaum <ngoldbau@illinois.edu>
+Kenneth Lyons <ixjlyons@gmail.com>
 latot <felipematas@yahoo.com>

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -241,21 +241,21 @@ def test_autowrap_custom_printer():
         '}\n'
     )
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # write a trivial header file to use in the generated code
-        open(os.path.join(tmpdir, 'shortpi.h'), 'w').write('#define S_PI 3.14')
+    tmpdir = tempfile.mkdtemp()
+    # write a trivial header file to use in the generated code
+    open(os.path.join(tmpdir, 'shortpi.h'), 'w').write('#define S_PI 3.14')
 
-        func = autowrap(expr, backend='cython', tempdir=tmpdir, code_gen=gen)
+    func = autowrap(expr, backend='cython', tempdir=tmpdir, code_gen=gen)
 
-        assert func(4.2) == 3.14 * 4.2
+    assert func(4.2) == 3.14 * 4.2
 
-        # check that the generated code is correct
-        for filename in os.listdir(tmpdir):
-            if filename.startswith('wrapped_code') and filename.endswith('.c'):
-                with open(os.path.join(tmpdir, filename)) as f:
-                    lines = f.readlines()
-                    expected = expected % filename.replace('.c', '.h')
-                    assert ''.join(lines[7:]) == expected
+    # check that the generated code is correct
+    for filename in os.listdir(tmpdir):
+        if filename.startswith('wrapped_code') and filename.endswith('.c'):
+            with open(os.path.join(tmpdir, filename)) as f:
+                lines = f.readlines()
+                expected = expected % filename.replace('.c', '.h')
+                assert ''.join(lines[7:]) == expected
 
 
 # Numpy

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -208,6 +208,56 @@ def test_issue_10274_C_cython():
     has_module('Cython')
     runtest_issue_10274('C89', 'cython')
 
+
+def test_autowrap_custom_printer():
+    has_module('Cython')
+
+    from sympy import pi
+    from sympy.utilities.codegen import C99CodeGen
+    from sympy.printing.ccode import C99CodePrinter
+    from sympy.functions.elementary.exponential import exp
+
+    class PiPrinter(C99CodePrinter):
+        def _print_Pi(self, expr):
+            return "S_PI"
+
+    printer = PiPrinter()
+    gen = C99CodeGen(printer=printer)
+    gen.preprocessor_statements.append('#include "shortpi.h"')
+
+    expr = pi * a
+
+    expected = (
+        '#include "%s"\n'
+        '#include <math.h>\n'
+        '#include "shortpi.h"\n'
+        '\n'
+        'double autofunc(double a) {\n'
+        '\n'
+        '   double autofunc_result;\n'
+        '   autofunc_result = S_PI*a;\n'
+        '   return autofunc_result;\n'
+        '\n'
+        '}\n'
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # write a trivial header file to use in the generated code
+        open(os.path.join(tmpdir, 'shortpi.h'), 'w').write('#define S_PI 3.14')
+
+        func = autowrap(expr, backend='cython', tempdir=tmpdir, code_gen=gen)
+
+        assert func(4.2) == 3.14 * 4.2
+
+        # check that the generated code is correct
+        for filename in os.listdir(tmpdir):
+            if filename.startswith('wrapped_code') and filename.endswith('.c'):
+                with open(os.path.join(tmpdir, filename)) as f:
+                    lines = f.readlines()
+                    expected = expected % filename.replace('.c', '.h')
+                    assert ''.join(lines[7:]) == expected
+
+
 # Numpy
 
 def test_ufuncify_numpy():

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -129,7 +129,6 @@ class C89CodePrinter(CodePrinter):
     def __init__(self, settings={}):
         super(C89CodePrinter, self).__init__(settings)
         self.known_functions = dict(self._kf, **settings.get('user_functions', {}))
-        self._dereference = set(settings.get('dereference', []))
 
     def _rate_index_position(self, p):
         return p*5
@@ -249,7 +248,7 @@ class C89CodePrinter(CodePrinter):
 
     def _print_Symbol(self, expr):
         name = super(C89CodePrinter, self)._print_Symbol(expr)
-        if expr in self._dereference:
+        if expr in self._settings['dereference']:
             return '(*{0})'.format(name)
         else:
             return name

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -900,11 +900,11 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
     >>> f(np.arange(5), 3)
     array([  3.,   4.,   7.,  12.,  19.])
 
-    For the F2Py and Cython backends, inputs are required to be equal length
-    1-dimensional arrays. The F2Py backend will perform type conversion, but
+    For the 'f2py' and 'cython' backends, inputs are required to be equal length
+    1-dimensional arrays. The 'f2py' backend will perform type conversion, but
     the Cython backend will error if the inputs are not of the expected type.
 
-    >>> f_fortran = ufuncify((x, y), y + x**2, backend='F2Py')
+    >>> f_fortran = ufuncify((x, y), y + x**2, backend='f2py')
     >>> f_fortran(1, 2)
     array([ 3.])
     >>> f_fortran(np.array([1, 2, 3]), np.array([1.0, 2.0, 3.0]))

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -499,7 +499,8 @@ def autowrap(
     -1.0
     """
     if language:
-        _validate_backend_language(backend, language)
+        if not isinstance(language, type):
+            _validate_backend_language(backend, language)
     else:
         language = _infer_language(backend)
 

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -451,7 +451,7 @@ def _validate_backend_language(backend, language):
 @doctest_depends_on(exe=('f2py', 'gfortran'), modules=('numpy',))
 def autowrap(
     expr, language=None, backend='f2py', tempdir=None, args=None, flags=None,
-    verbose=False, helpers=None):
+    verbose=False, helpers=None, code_gen=None):
     """Generates python callable binaries based on the math expression.
 
     Parameters
@@ -484,6 +484,8 @@ def autowrap(
         compiled main expression can link to the helper routine. Items should
         be tuples with (<funtion_name>, <sympy_expression>, <arguments>). It
         is mandatory to supply an argument sequence to helper routines.
+    code_gen : CodeGen instance
+        An instance of a CodeGen subclass. Overrides ``language``.
 
     >>> from sympy.abc import x, y, z
     >>> from sympy.utilities.autowrap import autowrap
@@ -501,13 +503,15 @@ def autowrap(
     helpers = [helpers] if helpers else ()
     args = list(args) if iterable(args, exclude=set) else args
 
-    code_generator = get_code_generator(language, "autowrap")
+    if code_gen is None:
+        code_gen = get_code_generator(language, "autowrap")
+
     CodeWrapperClass = {
         'F2PY': F2PyCodeWrapper,
         'CYTHON': CythonCodeWrapper,
         'DUMMY': DummyWrapper
     }[backend.upper()]
-    code_wrapper = CodeWrapperClass(code_generator, tempdir, flags if flags else (), verbose)
+    code_wrapper = CodeWrapperClass(code_gen, tempdir, flags if flags else (), verbose)
 
     helps = []
     for name_h, expr_h, args_h in helpers:

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -421,12 +421,6 @@ class F2PyCodeWrapper(CodeWrapper):
         return getattr(mod, name)
 
 
-def _get_code_wrapper_class(backend):
-    wrappers = {'F2PY': F2PyCodeWrapper, 'CYTHON': CythonCodeWrapper,
-        'DUMMY': DummyWrapper}
-    return wrappers[backend.upper()]
-
-
 # Here we define a lookup of backends -> tuples of languages. For now, each
 # tuple is of length 1, but if a backend supports more than one language,
 # the most preferable language is listed first.
@@ -505,12 +499,15 @@ def autowrap(
         language = _infer_language(backend)
 
     helpers = [helpers] if helpers else ()
-    flags = flags if flags else ()
     args = list(args) if iterable(args, exclude=set) else args
 
     code_generator = get_code_generator(language, "autowrap")
-    CodeWrapperClass = _get_code_wrapper_class(backend)
-    code_wrapper = CodeWrapperClass(code_generator, tempdir, flags, verbose)
+    CodeWrapperClass = {
+        'F2PY': F2PyCodeWrapper,
+        'CYTHON': CythonCodeWrapper,
+        'DUMMY': DummyWrapper
+    }[backend.upper()]
+    code_wrapper = CodeWrapperClass(code_generator, tempdir, flags if flags else (), verbose)
 
     helps = []
     for name_h, expr_h, args_h in helpers:

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -792,7 +792,7 @@ class CCodeGen(CodeGen):
     code_extension = "c"
     interface_extension = "h"
     standard = 'c99'
-    preprocessor_statements = ['#include <math.h>\n']
+    preprocessor_statements = ['#include <math.h>']
 
     def __init__(self, project="project", printer=None):
         super(CCodeGen, self).__init__(project=project)
@@ -837,8 +837,9 @@ class CCodeGen(CodeGen):
 
     def _preprocessor_statements(self, prefix):
         code_lines = []
-        code_lines.append("#include \"%s.h\"\n" % os.path.basename(prefix))
+        code_lines.append('#include "{}.h"'.format(os.path.basename(prefix)))
         code_lines.extend(self.preprocessor_statements)
+        code_lines = ['{}\n'.format(l) for l in code_lines]
         return code_lines
 
     def _get_routine_opening(self, routine):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -792,7 +792,7 @@ class CCodeGen(CodeGen):
     code_extension = "c"
     interface_extension = "h"
     standard = 'c99'
-    preprocessor_extras = []
+    preprocessor_statements = ['#include <math.h>\n']
 
     def __init__(self, project="project", printer=None):
         super(CCodeGen, self).__init__(project=project)
@@ -838,8 +838,7 @@ class CCodeGen(CodeGen):
     def _preprocessor_statements(self, prefix):
         code_lines = []
         code_lines.append("#include \"%s.h\"\n" % os.path.basename(prefix))
-        code_lines.append("#include <math.h>\n")
-        code_lines.extend(self.preprocessor_extras)
+        code_lines.extend(self.preprocessor_statements)
         return code_lines
 
     def _get_routine_opening(self, routine):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -792,11 +792,14 @@ class CCodeGen(CodeGen):
     code_extension = "c"
     interface_extension = "h"
     standard = 'c99'
-    preprocessor_statements = ['#include <math.h>']
 
-    def __init__(self, project="project", printer=None):
+    def __init__(self, project="project", printer=None,
+                 preprocessor_statements=None):
         super(CCodeGen, self).__init__(project=project)
         self.printer = printer or c_code_printers[self.standard.lower()]()
+
+        if preprocessor_statements is None:
+            self.preprocessor_statements = ['#include <math.h>']
 
     def _get_header(self):
         """Writes a common header for the generated files."""

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -1853,13 +1853,10 @@ def get_code_generator(language, project=None, standard=None):
             language = 'C89'
         elif standard.lower() == 'c99':
             language = 'C99'
-    if isinstance(language, type):
-        CodeGenClass = language
-    else:
-        CodeGenClass = {"C": CCodeGen, "C89": C89CodeGen, "C99": C99CodeGen,
-                        "F95": FCodeGen, "JULIA": JuliaCodeGen,
-                        "OCTAVE": OctaveCodeGen,
-                        "RUST": RustCodeGen}.get(language.upper())
+    CodeGenClass = {"C": CCodeGen, "C89": C89CodeGen, "C99": C99CodeGen,
+                    "F95": FCodeGen, "JULIA": JuliaCodeGen,
+                    "OCTAVE": OctaveCodeGen,
+                    "RUST": RustCodeGen}.get(language.upper())
     if CodeGenClass is None:
         raise ValueError("Language '%s' is not supported." % language)
     return CodeGenClass(project)

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -1856,8 +1856,6 @@ def get_code_generator(language, project=None, standard=None):
             language = 'C99'
     if isinstance(language, type):
         CodeGenClass = language
-    elif isinstance(language, CodeGen):
-        return language
     else:
         CodeGenClass = {"C": CCodeGen, "C89": C89CodeGen, "C99": C99CodeGen,
                         "F95": FCodeGen, "JULIA": JuliaCodeGen,
@@ -1873,9 +1871,9 @@ def get_code_generator(language, project=None, standard=None):
 #
 
 
-def codegen(name_expr, language, prefix=None, project="project",
+def codegen(name_expr, language=None, prefix=None, project="project",
             to_files=False, header=True, empty=True, argument_sequence=None,
-            global_vars=None, standard=None):
+            global_vars=None, standard=None, code_gen=None):
     """Generate source code for expressions in a given language.
 
     Parameters
@@ -1888,7 +1886,7 @@ def codegen(name_expr, language, prefix=None, project="project",
         considered an output argument.  If expression is an iterable, then
         the routine will have multiple outputs.
 
-    language : string
+    language : string,
         A string that indicates the source code language.  This is case
         insensitive.  Currently, 'C', 'F95' and 'Octave' are supported.
         'Octave' generates code compatible with both Octave and Matlab.
@@ -1925,6 +1923,11 @@ def codegen(name_expr, language, prefix=None, project="project",
     global_vars : iterable, optional
         Sequence of global variables used by the routine.  Variables
         listed here will not show up as function arguments.
+
+    standard : string
+
+    code_gen : CodeGen instance
+        An instance of a CodeGen subclass. Overrides ``language``.
 
     Examples
     ========
@@ -1998,7 +2001,13 @@ def codegen(name_expr, language, prefix=None, project="project",
     """
 
     # Initialize the code generator.
-    code_gen = get_code_generator(language, project, standard)
+    if language is None:
+        if code_gen is None:
+            raise ValueError("Need either language or code_gen")
+    else:
+        if code_gen is not None:
+            raise ValueError("You cannot specify both language and code_gen.")
+        code_gen = get_code_generator(language, project, standard)
 
     if isinstance(name_expr[0], string_types):
         # single tuple is given, turn it into a singleton list with a tuple.

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -1833,10 +1833,13 @@ def get_code_generator(language, project, standard=None):
             language = 'C89'
         elif standard.lower() == 'c99':
             language = 'C99'
-    CodeGenClass = {"C": CCodeGen, "C89": C89CodeGen, "C99": C99CodeGen,
-                    "F95": FCodeGen, "JULIA": JuliaCodeGen,
-                    "OCTAVE": OctaveCodeGen,
-                    "RUST": RustCodeGen}.get(language.upper())
+    if isinstance(language, type):
+        CodeGenClass = language
+    else:
+        CodeGenClass = {"C": CCodeGen, "C89": C89CodeGen, "C99": C99CodeGen,
+                        "F95": FCodeGen, "JULIA": JuliaCodeGen,
+                        "OCTAVE": OctaveCodeGen,
+                        "RUST": RustCodeGen}.get(language.upper())
     if CodeGenClass is None:
         raise ValueError("Language '%s' is not supported." % language)
     return CodeGenClass(project)

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1448,7 +1448,7 @@ def test_custom_codegen():
 
     printer = C99CodePrinter(settings={'user_functions': {'exp': 'fastexp'}})
     gen = C99CodeGen(printer=printer)
-    gen.preprocessor_statements.append('#include "fastexp.h"\n')
+    gen.preprocessor_statements.append('#include "fastexp.h"')
 
     x, y = symbols('x y')
     expr = exp(x + y)

--- a/sympy/utilities/tests/test_codegen_rust.py
+++ b/sympy/utilities/tests/test_codegen_rust.py
@@ -42,9 +42,11 @@ def test_simple_code_with_header():
     result, = codegen(name_expr, "Rust", header=True, empty=False)
     assert result[0] == "test.rs"
     source = result[1]
+    version_str = "Code generated with sympy %s" % sympy.__version__
+    version_line = version_str.center(76).rstrip()
     expected = (
         "/*\n"
-        " *                    Code generated with sympy " + sympy.__version__ + "\n"
+        " *%(version_line)s\n"
         " *\n"
         " *              See http://www.sympy.org/ for more information.\n"
         " *\n"
@@ -54,7 +56,7 @@ def test_simple_code_with_header():
         "    let out1 = z*(x + y);\n"
         "    out1\n"
         "}\n"
-    )
+    ) % {'version_line': version_line}
     assert source == expected
 
 
@@ -288,9 +290,11 @@ def test_multifcns_per_file_w_header():
     result = codegen(name_expr, "Rust", header=True, empty=False)
     assert result[0][0] == "foo.rs"
     source = result[0][1];
+    version_str = "Code generated with sympy %s" % sympy.__version__
+    version_line = version_str.center(76).rstrip()
     expected = (
         "/*\n"
-        " *                    Code generated with sympy " + sympy.__version__ + "\n"
+        " *%(version_line)s\n"
         " *\n"
         " *              See http://www.sympy.org/ for more information.\n"
         " *\n"
@@ -306,7 +310,7 @@ def test_multifcns_per_file_w_header():
         "    let out2 = 4*y;\n"
         "    (out1, out2)\n"
         "}\n"
-    )
+    ) % {'version_line': version_line}
     assert source == expected
 
 


### PR DESCRIPTION
This feature would allow users to create their own code printer for use in `autowrap` and `codegen`. Here's a working example.

```python
import sympy as sp
from sympy.printing.ccode import C99CodePrinter
from sympy.utilities.codegen import CCodeGen, codegen
from sympy.utilities.autowrap import autowrap

x = sp.symbols('x')

class CustomCCodePrinter(C99CodePrinter):
    _kf = dict(C99CodePrinter._kf, exp='fastexp')

class CustomCCodeGen(CCodeGen):
    printer = CustomCCodePrinter

    def _ccode(self, expr, assign_to=None, **settings):
        return self.printer(settings).doprint(expr, assign_to)

    def _indent_code(self, codelines):
        return self.printer().indent_code(codelines)

    def _preprocessor_statements(self, prefix):
        lines = super(CustomCCodeGen, self)._preprocessor_statements(prefix)
        lines.append("#include \"fastexp.h\"\n")
        return lines

#autowrap(sp.exp(x), language=CustomCCodeGen, backend='cython', tempdir='./tmp')

[(cname, ccode), (hname, hcode)] = codegen(('expr', sp.exp(x)), CustomCCodeGen)
print(ccode)
```

The `autowrap` line is commented out because compilation fails without passing compiler flags to tell it where the `fastexp.h` header is, but the generated code looks correct. Here's the `codegen` output:


```c
/******************************************************************************
 *                    Code generated with sympy 1.0.1.dev                     *
 *                                                                            *
 *              See http://www.sympy.org/ for more information.               *
 *                                                                            *
 *                       This file is part of 'project'                       *
 ******************************************************************************/
#include "expr.h"
#include <math.h>
#include "fastexp.h"

double expr(double x) {

   double expr_result;
   expr_result = fastexp(x);
   return expr_result;

}
```

Updates to the docstring of `autowrap` and `codegen` would still be needed, as well as tests. Submitting now to get feedback on how the feature itself and potential side effects.