### PR TITLE
Travis: move the symengine tests to the "dependency" builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
         - TEST_THEANO="true"
         - TEST_ASCII="true"
         - TEST_AUTOWRAP="true"
+        - TEST_SYMENGINE="true"
       addons:
         apt:
           packages:
@@ -41,6 +42,7 @@ matrix:
         - TEST_THEANO="true"
         - TEST_ASCII="true"
         - TEST_AUTOWRAP="true"
+        - TEST_SYMENGINE="true"
       addons:
         apt:
           packages:
@@ -93,9 +95,6 @@ matrix:
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"
-    - python: 3.5
-      env:
-        - TEST_SYMENGINE="true"
 
     # Everything here and below is in the allow_failures. The need to be
     # duplicated here and in that section below.

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -27,11 +27,6 @@ if [[ "${TEST_SAGE}" == "true" ]]; then
     ./bin/test -k tensorflow
 fi
 
-if [[ "${TEST_SYMENGINE}" == "true" ]]; then
-    echo "Testing SYMENGINE"
-    export USE_SYMENGINE=1
-fi
-
 # We change directories to make sure that we test the installed version of
 # sympy.
 mkdir empty
@@ -131,10 +126,13 @@ fi
 
 
 if [[ "${TEST_SYMENGINE}" == "true" ]]; then
+    echo "Testing SYMENGINE"
+    export USE_SYMENGINE=1
     cat << EOF | python
 print('Testing SymEngine')
 import sympy
 if not sympy.test('sympy/physics/mechanics'):
     raise Exception('Tests failed')
 EOF
+    unset USE_SYMENGINE
 fi


### PR DESCRIPTION
This reduces the number of builds, which allows us to get more out of
concurrent builds. This also lets us test symengine in Python 2.
