### PR TITLE
octave: don't print newlines between rows in matrices

### DIFF
--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -310,13 +310,8 @@ class OctaveCodePrinter(CodePrinter):
         elif (A.rows, A.cols) == (1, 1):
             # Octave does not distinguish between scalars and 1x1 matrices
             return self._print(A[0, 0])
-        elif A.rows == 1:
-            return "[%s]" % A.table(self, rowstart='', rowend='', colsep=' ')
-        elif A.cols == 1:
-            # note .table would unnecessarily equispace the rows
-            return "[%s]" % "; ".join([self._print(a) for a in A])
-        return "[%s]" % A.table(self, rowstart='', rowend='',
-                                rowsep=';\n', colsep=' ')
+        return "[%s]" % "; ".join(" ".join([self._print(a) for a in A[r, :]])
+                                  for r in range(A.rows))
 
 
     def _print_SparseMatrix(self, A):

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -145,9 +145,7 @@ def test_Matrices():
     A = Matrix([[1, sin(x/2), abs(x)],
                 [0, 1, pi],
                 [0, exp(1), ceiling(x)]]);
-    expected = ("[1 sin(x/2)  abs(x);\n"
-                "0        1      pi;\n"
-                "0   exp(1) ceil(x)]")
+    expected = "[1 sin(x/2) abs(x); 0 1 pi; 0 exp(1) ceil(x)]"
     assert mcode(A) == expected
     # row and columns
     assert mcode(A[:,0]) == "[1; 0; 0]"
@@ -204,7 +202,7 @@ def test_containers():
     assert mcode(Tuple(*[1, 2, 3])) == "{1, 2, 3}"
     assert mcode((1, x*y, (3, x**2))) == "{1, x.*y, {3, x.^2}}"
     # scalar, matrix, empty matrix and empty list
-    assert mcode((1, eye(3), Matrix(0, 0, []), [])) == "{1, [1 0 0;\n0 1 0;\n0 0 1], [], {}}"
+    assert mcode((1, eye(3), Matrix(0, 0, []), [])) == "{1, [1 0 0; 0 1 0; 0 0 1], [], {}}"
 
 
 def test_octave_noninline():
@@ -260,7 +258,7 @@ def test_octave_matrix_assign_to():
     A = Matrix([[1, 2, 3]])
     assert mcode(A, assign_to='a') == "a = [1 2 3];"
     A = Matrix([[1, 2], [3, 4]])
-    assert mcode(A, assign_to='A') == "A = [1 2;\n3 4];"
+    assert mcode(A, assign_to='A') == "A = [1 2; 3 4];"
 
 
 def test_octave_matrix_assign_to_more():

--- a/sympy/utilities/tests/test_codegen_octave.py
+++ b/sympy/utilities/tests/test_codegen_octave.py
@@ -347,8 +347,7 @@ def test_m_matrix_output_autoname_2():
         "  out1 = x + y;\n"
         "  out2 = [2*x 2*y 2*z];\n"
         "  out3 = [x; y; z];\n"
-        "  out4 = [x  y;\n"
-        "  z 16];\n"
+        "  out4 = [x y; z 16];\n"
         "end\n"
     )
     assert source == expected


### PR DESCRIPTION
Maybe this could be re-introduced only for "big" matrices and only
when generating m-files.  But octave_code itself is often used to
generate single-line expressions where the newline is at best a
distraction.  Even in generated m-files the previous behaviour did
not look good because the subsequent lines were not indented properly.