### PR TITLE
biquadratic solving; Poly.free_symbols; ltrim

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -255,7 +255,7 @@ class Poly(Expr):
         ========
 
         >>> from sympy import Poly
-        >>> from sympy.abc import x, y
+        >>> from sympy.abc import x, y, z
 
         >>> Poly(x**2 + 1).free_symbols
         {x}
@@ -263,12 +263,17 @@ class Poly(Expr):
         {x, y}
         >>> Poly(x**2 + y, x).free_symbols
         {x, y}
+        >>> Poly(x**2 + y, x, z).free_symbols
+        {x, y}
 
         """
-        symbols = set([])
-
-        for gen in self.gens:
-            symbols |= gen.free_symbols
+        symbols = set()
+        gens = self.gens
+        for i in range(len(gens)):
+            for monom in self.monoms():
+                if monom[i]:
+                    symbols |= gens[i].free_symbols
+                    break
 
         return symbols | self.free_symbols_in_domain
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -614,7 +614,10 @@ class Poly(Expr):
 
     def ltrim(f, gen):
         """
-        Remove dummy generators from the "left" of ``f``.
+        Remove dummy generators from ``f`` that are to the left of
+        specified ``gen`` in the generators as ordered. When ``gen``
+        is an integer, it refers to the generator located at that
+        position within the tuple of generators of ``f``.
 
         Examples
         ========
@@ -624,19 +627,22 @@ class Poly(Expr):
 
         >>> Poly(y**2 + y*z**2, x, y, z).ltrim(y)
         Poly(y**2 + y*z**2, y, z, domain='ZZ')
+        >>> Poly(z, x, y, z).ltrim(-1)
+        Poly(z, z, domain='ZZ')
 
         """
         rep = f.as_dict(native=True)
         j = f._gen_to_level(gen)
+
         terms = {}
 
         for monom, coeff in rep.items():
-            monom = monom[j:]
 
-            if monom not in terms:
-                terms[monom] = coeff
-            else:
+            if any(i for i in monom[:j]):
+                # some generator is used in the portion to be trimmed
                 raise PolynomialError("can't left trim %s" % f)
+
+            terms[monom[j:]] = coeff
 
         gens = f.gens[j:]
 
@@ -658,7 +664,7 @@ class Poly(Expr):
         False
 
         """
-        indices = set([])
+        indices = set()
 
         for gen in gens:
             try:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -853,9 +853,10 @@ def test_Poly_reorder():
 def test_Poly_ltrim():
     f = Poly(y**2 + y*z**2, x, y, z).ltrim(y)
     assert f.as_expr() == y**2 + y*z**2 and f.gens == (y, z)
+    assert Poly(x*y - x, z, x, y).ltrim(1) == Poly(x*y - x, x, y)
 
     raises(PolynomialError, lambda: Poly(x*y**2 + y**2, x, y).ltrim(y))
-
+    raises(PolynomialError, lambda: Poly(x*y - x, x, y).ltrim(-1))
 
 def test_Poly_has_only_gens():
     assert Poly(x*y + 1, x, y, z).has_only_gens(x, y) is True

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -468,6 +468,8 @@ def test_Poly_free_symbols():
     assert Poly(x**2 + sin(y*z)).free_symbols == {x, y, z}
     assert Poly(x**2 + sin(y*z), x).free_symbols == {x, y, z}
     assert Poly(x**2 + sin(y*z), x, domain=EX).free_symbols == {x, y, z}
+    assert Poly(1 + x + x**2, x, y, z).free_symbols == {x}
+    assert Poly(x + sin(y), z).free_symbols == {x, y}
 
 
 def test_PurePoly_free_symbols():

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -76,22 +76,16 @@ def solve_biquadratic(f, g, opt):
     if len(G) != 2:
         raise SolveFailed
 
-    p, q = G
     x, y = opt.gens
+    p, q = G
+    if not p.gcd(q).as_expr().is_constant(x, y):
+        # not 0-dimensional
+        raise SolveFailed
 
     p = Poly(p, x, expand=False)
-    p_roots = roots(p)
-    k, m = list(zip(*p_roots.items()))
-    if sum(m) == 1 and (y not in k[0].free_symbols
-            and y in p.free_symbols):
-        # this is not a zero-dimensional system
-        raise SolveFailed
-    p_roots = [ rcollect(expr, y) for expr in p_roots.keys() ]
+    p_roots = [ rcollect(expr, y) for expr in roots(p).keys() ]
 
-    try:
-        q = q.ltrim(-1)
-    except PolynomialError:
-        raise SolveFailed
+    q = q.ltrim(-1)
     q_roots = list(roots(q).keys())
 
     solutions = []

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -89,7 +89,6 @@ def solve_biquadratic(f, g, opt):
     try:
         q = q.ltrim(-1)
     except PolynomialError:
-        # q was not univariate
         raise SolveFailed
     q_roots = list(roots(q).keys())
 
@@ -166,7 +165,7 @@ def solve_generic(polys, opt):
     def _is_univariate(f):
         """Returns True if 'f' is univariate in its last variable. """
         for monom in f.monoms():
-            if any(m > 0 for m in monom[:-1]):
+            if any(m for m in monom[:-1]):
                 return False
 
         return True

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -78,7 +78,7 @@ def solve_biquadratic(f, g, opt):
 
     x, y = opt.gens
     p, q = G
-    if not p.gcd(q).as_expr().is_constant(x, y):
+    if not p.gcd(q).is_ground:
         # not 0-dimensional
         raise SolveFailed
 

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -80,11 +80,13 @@ def solve_biquadratic(f, g, opt):
     x, y = opt.gens
 
     p = Poly(p, x, expand=False)
-    p_roots = [ rcollect(expr, y) for expr in roots(p).keys() ]
-    if not all(y in i.free_symbols for i in p_roots):
-        # then the solution won't depend on y
-        # and this is not a zero-dimensional system
+    p_roots = roots(p)
+    k, m = list(zip(*p_roots.items()))
+    if sum(m) == 1 and (y not in k[0].free_symbols
+            and y in p.free_symbols):
+        # this is not a zero-dimensional system
         raise SolveFailed
+    p_roots = [ rcollect(expr, y) for expr in p_roots.keys() ]
 
     try:
         q = q.ltrim(-1)

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -53,10 +53,10 @@ def test_solve_biquadratic():
 
     f_1 = (x - 1)**2 + (y - 1)**2 - r**2
     f_2 = (x - 2)**2 + (y - 2)**2 - r**2
-
-    assert solve_poly_system([f_1, f_2], x, y) == \
-        [(S(3)/2 - sqrt(-1 + 2*r**2)/2, S(3)/2 + sqrt(-1 + 2*r**2)/2),
-         (S(3)/2 + sqrt(-1 + 2*r**2)/2, S(3)/2 - sqrt(-1 + 2*r**2)/2)]
+    s = sqrt(2*r**2 - 1)
+    a = (3 - s)/2
+    b = (3 + s)/2
+    assert solve_poly_system([f_1, f_2], x, y) == [(a, b), (b, a)]
 
     f_1 = (x - 1)**2 + (y - 2)**2 - r**2
     f_2 = (x - 1)**2 + (y - 1)**2 - r**2

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -1,6 +1,7 @@
 """Tests for solvers of systems of polynomial equations. """
 
-from sympy import flatten, I, Integer, Poly, QQ, Rational, S, sqrt, symbols
+from sympy import (flatten, I, Integer, Poly, QQ, Rational, S, sqrt,
+    solve, symbols)
 from sympy.abc import x, y, z
 from sympy.polys import PolynomialError
 from sympy.solvers.polysys import solve_poly_system, solve_triangulated
@@ -79,6 +80,13 @@ def test_solve_biquadratic():
 
     assert len(result) == 2 and all(len(r) == 2 for r in result)
     assert all(len(r.find(query)) == 1 for r in flatten(result))
+
+    s1 = (x*y - y, x**2 - x)
+    assert solve(s1) == [{x: 1}, {x: 0, y: 0}]
+    s2 = (x*y - x, y**2 - y)
+    assert solve(s2) == [{y: 1}, {x: 0, y: 0}]
+    raises(NotImplementedError, lambda: solve_poly_system(s1))
+    raises(NotImplementedError, lambda: solve_poly_system(s2))
 
 
 def test_solve_triangualted():


### PR DESCRIPTION
- closes #12851
- closes #12815

Both of the following now recognize infinite solutions and neither raises an ltrim error
```
s1 = (x*y - y, x**2 - x)  
assert solve(s1) == [{x: 1}, {x: 0, y: 0}]  
s2 = (x*y - x, y**2 - y)  
assert solve(s2) == [{y: 1}, {x: 0, y: 0}]  
```
- closes #12846

dummy symbols are not included in Poly.free_symbols anymore
```
Poly(x + y, x, z).free_symbols now gives {x, y} instead of {x, y, z}
```
