### PR TITLE
Fix use of % operator on string with multiple arguments

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1962,7 +1962,7 @@ class MatrixArithmetic(MatrixRequired):
         if getattr(other, 'is_MatrixLike', False):
             return MatrixArithmetic._eval_add(self, other)
 
-        raise TypeError('cannot add %s and %s' % type(self), type(other))
+        raise TypeError('cannot add %s and %s' % (type(self), type(other)))
 
     @call_highest_priority('__rdiv__')
     def __div__(self, other):
@@ -2020,7 +2020,7 @@ class MatrixArithmetic(MatrixRequired):
         except TypeError:
             pass
 
-        raise TypeError('Cannot multiply %s and %s' % type(self), type(other))
+        raise TypeError('Cannot multiply %s and %s' % (type(self), type(other)))
 
     def __neg__(self):
         return self._eval_scalar_mul(-1)
@@ -2086,7 +2086,7 @@ class MatrixArithmetic(MatrixRequired):
         except TypeError:
             pass
 
-        raise TypeError('Cannot multiply %s and %s' % type(self), type(other))
+        raise TypeError('Cannot multiply %s and %s' % (type(self), type(other)))
 
     @call_highest_priority('__sub__')
     def __rsub__(self, a):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4010,7 +4010,7 @@ def a2idx(j, n=None):
         try:
             j = j.__index__()
         except AttributeError:
-            raise IndexError("Invalid index a[%r]" % j)
+            raise IndexError("Invalid index a[%r]" % (j,))
     if n is not None:
         if j < 0:
             j += n

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -64,7 +64,7 @@ class DeferredVector(Symbol, NotIterable):
         return sstr(self)
 
     def __repr__(self):
-        return "DeferredVector('%s')" % (self.name)
+        return "DeferredVector('%s')" % self.name
 
 
 class MatrixDeterminant(MatrixCommon):
@@ -4010,12 +4010,12 @@ def a2idx(j, n=None):
         try:
             j = j.__index__()
         except AttributeError:
-            raise IndexError("Invalid index a[%r]" % (j,))
+            raise IndexError("Invalid index a[%r]" % j)
     if n is not None:
         if j < 0:
             j += n
         if not (j >= 0 and j < n):
-            raise IndexError("Index out of range: a[%s]" % (j,))
+            raise IndexError("Index out of range: a[%s]" % j)
     return int(j)
 
 


### PR DESCRIPTION
This is a minor fix, but the incorrect format strings raised a `TypeError`:
```
TypeError: not enough arguments for format string
```
Don't know if we want this in for 1.1?

cc @asmeurer @siefkenj 