### PR TITLE
FpGroups: replace FreeGroupElement with FpGroupElement

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -59,7 +59,7 @@ class FpGroup(DefaultPrinting):
         obj = object.__new__(cls)
         obj.free_group = fr_grp
         obj.symbols = fr_grp.symbols
-        obj.dtype = type("FgGroupElement", (FgGroupElement,), {"group": obj})
+        obj.dtype = type("FpGroupElement", (FpGroupElement,), {"group": obj})
         obj.generators = obj._generators()
         obj.relators = [obj._fp_rewrite(r) for r in relators]
 
@@ -75,17 +75,14 @@ class FpGroup(DefaultPrinting):
 
     def _generators(self):
         gens = [self.dtype(((s, 1),)) for s in self.symbols]
-        return gens
+        return tuple(gens)
 
     def _fp_rewrite(self, w):
         '''
         Rewrite the word `w` from `self.free_group` in terms of
-        the generators of `self`. If `w` is not in `self.free_group`
-        or `self`, don't do anything.
+        the generators of `self`.
 
         '''
-        # this could probably be replaced by a homomorphism
-        # from the free group
         if w.group == self:
             return w
         elif w.group != self.free_group:
@@ -1851,3 +1848,13 @@ def reidemeister_presentation(fp_grp, H, C=None):
     C.reidemeister_relators = tuple(C._reidemeister_relators)
 
     return C.schreier_generators, C.reidemeister_relators
+
+class FpGroupElement(FgGroupElement):
+
+    def reduce(self):
+        #to be implemented once the rewriting systems are added
+        raise NotImplementedError
+
+    def __eq__(self, oth):
+        #this will be different with rewriting systems
+        return super(FpGroupElement, self).__eq__(oth)

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -33,7 +33,7 @@ def free_group(symbols):
     >>> x**2*y**-1
     x**2*y**-1
     >>> type(_)
-    <class 'sympy.combinatorics.free_groups.FgGroupElement'>
+    <class 'sympy.combinatorics.free_groups.FreeGroupElement'>
 
     """
     _free_group = FreeGroup(symbols)
@@ -57,7 +57,7 @@ def xfree_group(symbols):
     >>> y**2*x**-2*z**-1
     y**2*x**-2*z**-1
     >>> type(_)
-    <class 'sympy.combinatorics.free_groups.FgGroupElement'>
+    <class 'sympy.combinatorics.free_groups.FreeGroupElement'>
 
     """
     _free_group = FreeGroup(symbols)
@@ -81,7 +81,7 @@ def vfree_group(symbols):
     >>> x**2*y**-2*z
     x**2*y**-2*z
     >>> type(_)
-    <class 'sympy.combinatorics.free_groups.FgGroupElement'>
+    <class 'sympy.combinatorics.free_groups.FreeGroupElement'>
 
     """
     _free_group = FreeGroup(symbols)
@@ -94,7 +94,7 @@ def _parse_symbols(symbols):
         return tuple()
     if isinstance(symbols, string_types):
         return _symbols(symbols, seq=True)
-    elif isinstance(symbols, Expr or FgGroupElement):
+    elif isinstance(symbols, Expr or FreeGroupElement):
         return (symbols,)
     elif is_sequence(symbols):
         if all(isinstance(s, string_types) for s in symbols):
@@ -147,7 +147,7 @@ class FreeGroup(DefaultPrinting):
             obj._hash = _hash
             obj._rank = rank
             # dtype method is used to create new instances of FgGroupElement
-            obj.dtype = type("FgGroupElement", (FgGroupElement,), {"group": obj})
+            obj.dtype = type("FreeGroupElement", (FreeGroupElement,), {"group": obj})
             obj.symbols = symbols
             obj.generators = obj._generators()
             obj._gens_set = set(obj.generators)
@@ -185,7 +185,7 @@ class FreeGroup(DefaultPrinting):
     def __contains__(self, i):
         """Return True if ``i`` is contained in FreeGroup."""
         if not isinstance(i, FgGroupElement):
-            raise TypeError("FreeGroup contains only FgGroupElement as elements "
+            raise TypeError("FreeGroup contains only FreeGroupElement as elements "
                         ", not elements of type %s" % type(i))
         group = i.group
         return self == group
@@ -318,7 +318,7 @@ class FreeGroup(DefaultPrinting):
         True
 
         """
-        if not isinstance(g, FgGroupElement):
+        if not isinstance(g, FreeGroupElement):
             return False
         elif self != g.group:
             return False
@@ -338,11 +338,10 @@ class FreeGroup(DefaultPrinting):
 #                          FgGroupElement                                  #
 ############################################################################
 
-
 class FgGroupElement(CantSympify, DefaultPrinting, tuple):
-    """Used to create elements of FreeGroup. It can not be used directly to
-    create a free group element. It is called by the `dtype` method of the
-    `FreeGroup` class.
+    """Used to create elements of FreeGroup (`FreeGroupElement`) or FpGroup
+    (`FpGroupElement`). It can not be used directly to create a free group
+    element. It is called by the `dtype` method of the associated group.
 
     """
     is_assoc_word = True
@@ -1251,3 +1250,5 @@ def zero_mul_simp(l, index):
         if l[index][1] == 0:
             del l[index]
             index -= 1
+
+FreeGroupElement = FgGroupElement

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -33,7 +33,7 @@ def free_group(symbols):
     >>> x**2*y**-1
     x**2*y**-1
     >>> type(_)
-    <class 'sympy.combinatorics.free_groups.FreeGroupElement'>
+    <class 'sympy.combinatorics.free_groups.FgGroupElement'>
 
     """
     _free_group = FreeGroup(symbols)
@@ -57,7 +57,7 @@ def xfree_group(symbols):
     >>> y**2*x**-2*z**-1
     y**2*x**-2*z**-1
     >>> type(_)
-    <class 'sympy.combinatorics.free_groups.FreeGroupElement'>
+    <class 'sympy.combinatorics.free_groups.FgGroupElement'>
 
     """
     _free_group = FreeGroup(symbols)
@@ -81,7 +81,7 @@ def vfree_group(symbols):
     >>> x**2*y**-2*z
     x**2*y**-2*z
     >>> type(_)
-    <class 'sympy.combinatorics.free_groups.FreeGroupElement'>
+    <class 'sympy.combinatorics.free_groups.FgGroupElement'>
 
     """
     _free_group = FreeGroup(symbols)
@@ -94,7 +94,7 @@ def _parse_symbols(symbols):
         return tuple()
     if isinstance(symbols, string_types):
         return _symbols(symbols, seq=True)
-    elif isinstance(symbols, Expr or FreeGroupElement):
+    elif isinstance(symbols, Expr or FgGroupElement):
         return (symbols,)
     elif is_sequence(symbols):
         if all(isinstance(s, string_types) for s in symbols):
@@ -146,8 +146,8 @@ class FreeGroup(DefaultPrinting):
             obj = object.__new__(cls)
             obj._hash = _hash
             obj._rank = rank
-            # dtype method is used to create new instances of FreeGroupElement
-            obj.dtype = type("FreeGroupElement", (FreeGroupElement,), {"group": obj})
+            # dtype method is used to create new instances of FgGroupElement
+            obj.dtype = type("FgGroupElement", (FgGroupElement,), {"group": obj})
             obj.symbols = symbols
             obj.generators = obj._generators()
             obj._gens_set = set(obj.generators)
@@ -184,8 +184,8 @@ class FreeGroup(DefaultPrinting):
 
     def __contains__(self, i):
         """Return True if ``i`` is contained in FreeGroup."""
-        if not isinstance(i, FreeGroupElement):
-            raise TypeError("FreeGroup contains only FreeGroupElement as elements "
+        if not isinstance(i, FgGroupElement):
+            raise TypeError("FreeGroup contains only FgGroupElement as elements "
                         ", not elements of type %s" % type(i))
         group = i.group
         return self == group
@@ -318,7 +318,7 @@ class FreeGroup(DefaultPrinting):
         True
 
         """
-        if not isinstance(g, FreeGroupElement):
+        if not isinstance(g, FgGroupElement):
             return False
         elif self != g.group:
             return False
@@ -335,11 +335,11 @@ class FreeGroup(DefaultPrinting):
 
 
 ############################################################################
-#                          FreeGroupElement                                #
+#                          FgGroupElement                                  #
 ############################################################################
 
 
-class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
+class FgGroupElement(CantSympify, DefaultPrinting, tuple):
     """Used to create elements of FreeGroup. It can not be used directly to
     create a free group element. It is called by the `dtype` method of the
     `FreeGroup` class.
@@ -380,7 +380,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         Since elements (i.e. words) don't commute, the indexing of tuple
         makes that property to stay.
 
-        The structure in ``array_form`` of ``FreeGroupElement`` is of form:
+        The structure in ``array_form`` of ``FgGroupElement`` is of form:
 
         ``( ( symbol_of_gen , exponent ), ( , ), ... ( , ) )``
 
@@ -405,7 +405,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
     @property
     def letter_form(self):
         """
-        The letter representation of a ``FreeGroupElement`` is a tuple
+        The letter representation of a ``FgGroupElement`` is a tuple
         of generator symbols, with each entry corresponding to a group
         generator. Inverses of the generators are represented by
         negative generator symbols.
@@ -455,7 +455,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
 
     @property
     def ext_rep(self):
-        """This is called the External Representation of ``FreeGroupElement``
+        """This is called the External Representation of ``FgGroupElement``
         """
         return tuple(flatten(self.array_form))
 
@@ -465,8 +465,6 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
     def __str__(self):
         if self.is_identity:
             return "<identity>"
-
-        symbols = self.group.symbols
         str_form = ""
         array_form = self.array_form
         for i in range(len(array_form)):
@@ -554,7 +552,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
 
     def inverse(self):
         """
-        Returns the inverse of a ``FreeGroupElement`` element
+        Returns the inverse of a ``FgGroupElement`` element
 
         Examples
         ========
@@ -572,7 +570,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         return group.dtype(r)
 
     def order(self):
-        """Find the order of a ``FreeGroupElement``.
+        """Find the order of a ``FgGroupElement``.
 
         Examples
         ========
@@ -595,7 +593,7 @@ class FreeGroupElement(CantSympify, DefaultPrinting, tuple):
         """
         group = self.group
         if not isinstance(other, group.dtype):
-            raise ValueError("commutator of only FreeGroupElement of the same "
+            raise ValueError("commutator of only FgGroupElement of the same "
                     "FreeGroup exists")
         else:
             return self.inverse()*other.inverse()*self*other

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -810,7 +810,7 @@ def test_subgroup_presentations():
     assert str(p1) == "((y_1, y_2), (y_1**2, y_2**3, y_2*y_1*y_2*y_1*y_2*y_1))"
 
     H = f.subgroup(H)
-    gens = [H._fp_rewrite(p) for p in p1[0]]
+    gens = tuple([H._fp_rewrite(p) for p in p1[0]])
     rels = [H._fp_rewrite(p) for p in p1[1]]
     assert (H.generators, H.relators) == (gens, rels)
 

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -810,7 +810,9 @@ def test_subgroup_presentations():
     assert str(p1) == "((y_1, y_2), (y_1**2, y_2**3, y_2*y_1*y_2*y_1*y_2*y_1))"
 
     H = f.subgroup(H)
-    assert (H.generators, H.relators) == p1
+    gens = [H._fp_rewrite(p) for p in p1[0]]
+    rels = [H._fp_rewrite(p) for p in p1[1]]
+    assert (H.generators, H.relators) == (gens, rels)
 
     f = FpGroup(F, [x**3, y**3, (x*y)**3])
     H = [x*y, x*y**-1]


### PR DESCRIPTION
This PR makes elements of `FpGroup`s distinct from the elements of the underlying `FreeGroup` by introducing `FpGroupElement`. The original `FreeGroupElement` is replaced with `FgGroupElement` of which `FpGroupElement` is a subclass, and `FreeGroupElement = FgGroupElement`.

The method `_fp_rewrite()` is implemented for `FpGroup`s to allow the user to pass elements of the underlying free group to a given `FpGroup`.