### PR TITLE
printing,latex:fixed inconsistency in superscripts raised to power

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -462,7 +462,7 @@ class LatexPrinter(Printer):
             base, p, q = self.parenthesize(expr.base, PRECEDENCE['Pow']), expr.exp.p, expr.exp.q
             #fixes issue #12886, adds parentheses before superscripts raised to powers
             if '^' in base and expr.base.is_Symbol:
-                base="(%s)"%base
+                base = r"\left(%s\right)" % base
             if expr.base.is_Function:
                 return self._print(expr.base, "%s/%s" % (p, q))
             return r"%s^{%s/%s}" % (base, p, q)
@@ -487,7 +487,7 @@ class LatexPrinter(Printer):
                 #fixes issue #12886, adds parentheses before superscripts raised to powers
                 base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
                 if '^' in base and expr.base.is_Symbol:
-                    base="(%s)"%base
+                    base = r"\left(%s\right)" % base
                 exp = self._print(expr.exp)
 
                 return tex % (base, exp)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -460,6 +460,9 @@ class LatexPrinter(Printer):
             and expr.exp.is_Rational \
                 and expr.exp.q != 1:
             base, p, q = self.parenthesize(expr.base, PRECEDENCE['Pow']), expr.exp.p, expr.exp.q
+            #fixes issue #12886, adds parentheses before superscripts raised to powers
+            if '^' in base and expr.base.is_Symbol:
+                base="(%s)"%base
             if expr.base.is_Function:
                 return self._print(expr.base, "%s/%s" % (p, q))
             return r"%s^{%s/%s}" % (base, p, q)
@@ -481,9 +484,13 @@ class LatexPrinter(Printer):
                     if tex[:1] == "-":
                         return tex[1:].strip()
                 tex = r"%s^{%s}"
+                #fixes issue #12886, adds parentheses before superscripts raised to powers
+                base = self.parenthesize(expr.base, PRECEDENCE['Pow'])
+                if '^' in base and expr.base.is_Symbol:
+                    base="(%s)"%base
+                exp = self._print(expr.exp)
 
-                return tex % (self.parenthesize(expr.base, PRECEDENCE['Pow']),
-                              self._print(expr.exp))
+                return tex % (base, exp)
 
     def _print_UnevaluatedExpr(self, expr):
         return self._print(expr.args[0])

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1587,6 +1587,12 @@ def test_issue_10489():
     assert latex(s) == latexSymbolWithBrace
     assert latex(cos(s)) == r'\cos{\left (C_{x_{0}} \right )}'
 
+
+def test_issue_12886():
+    m__1, l__1 = symbols('m__1, l__1')
+    assert latex(m__1**2 + l__1**2) == r'\left(l^{1}\right)^{2} + \left(m^{1}\right)^{2}'
+
+
 def test_latex_UnevaluatedExpr():
     x = symbols("x")
     he = UnevaluatedExpr(1/x)


### PR DESCRIPTION
In the case of superscripts like 'x^1' in Latex, when the superscript is raised to a power, the superscript was indistinguished from the power.

As an example, with latex printing enabled:
Initially,
```
M__1, L__1=symbols('M__1, L__1')
a=M__1**3
b=L__1**3
print(a+b)
```
>>'M^{1}^{3}+L^{1}^{3}'

Now, the output is
>>'(M^{1})^{3}+(L^{1})^{3}'

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #12886 
