### PR TITLE
MRG: remove duplicate Examples in atom docstring

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -420,9 +420,6 @@ class Basic(with_metaclass(ManagedProperties)):
            If one or more types are given, the results will contain only
            those types of atoms.
 
-           Examples
-           ========
-
            >>> from sympy import Number, NumberSymbol, Symbol
            >>> (1 + x + 2*sin(y + I*pi)).atoms(Symbol)
            {x, y}


### PR DESCRIPTION
The docstring for the `atoms` method has two Examples sections.  This
breaks - for example - the numpy docstring parser.

On a side note, I think the indentation is wrong for that docstring.