### PR TITLE
MRG: Allow for complex Numpy scalars in sympify

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -50,6 +50,7 @@ class CantSympify(object):
     """
     pass
 
+
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         evaluate=None):
     """Converts an arbitrary expression to a type that can be used inside SymPy.
@@ -256,12 +257,13 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         else:
             return a
 
-    #Support for basic numpy datatypes
+    # Support for basic numpy datatypes
     if type(a).__module__ == 'numpy':
         import numpy as np
         if np.isscalar(a):
             if not isinstance(a, np.floating):
-                return sympify(np.asscalar(a))
+                func = converter[complex] if np.iscomplex(a) else sympify
+                return func(np.asscalar(a))
             else:
                 try:
                     from sympy.core.numbers import Float

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -578,8 +578,11 @@ def test_numpy():
     assert equal(sympify(np.float32(1.123456)), Float(1.123456, precision=24))
     assert equal(sympify(np.float64(1.1234567891234)),
                 Float(1.1234567891234, precision=53))
+    assert equal(sympify(np.longdouble(1.123456789)),
+                 Float(1.123456789, precision=80))
     assert equal(sympify(np.complex64(1 + 2j)), S(1.0 + 2.0*I))
     assert equal(sympify(np.complex128(1 + 2j)), S(1.0 + 2.0*I))
+    assert equal(sympify(np.longcomplex(1 + 2j)), S(1.0 + 2.0*I))
 
     try:
         assert equal(sympify(np.float96(1.123456789)),


### PR DESCRIPTION
Cherry-pick of b4b89e7 / https://github.com/sympy/sympy/pull/12901

As of Sympy 1.1, the following raises a recursion error:

>>> c = np.longcomplex(1 + 1j)
>>> print(sympify(c))

This is because the sympify code had the following:

   if not isinstance(a, np.floating):
       return sympify(np.asscalar(a))

In the case of `c` above, it is not `np.floating` type (it's complex)
and `np.asscalar(c)` returns another numpy scalar (rather than a Python
scalar, as would be the case for the `np.complex` type), so causing the
loop to go into infinite recursion.

Add handling of the complex case directly in the sympify clause above,
and add test for `np.longcomplex` type.

While I'm at it, add test for `np.longdouble` type, which will be
`np.float96` on 32-bit platforms, `np.float128` on 64-bit.