### PR TITLE
Fix (pi**3).is_algebraic in the _eval_algebraic in Pow

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1066,7 +1066,7 @@ class Pow(Expr):
             return True
         elif self.exp.is_rational:
             if self.base.is_algebraic is False:
-                return self.exp.is_nonzero
+                return self.exp.is_zero
             return self.base.is_algebraic
         elif self.base.is_algebraic and self.exp.is_algebraic:
             if ((fuzzy_not(self.base.is_zero)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -759,6 +759,10 @@ def test_Pow_is_algebraic():
     assert (t**n).is_algebraic is None
     assert (t**n).is_integer is None
 
+    assert (pi**3).is_algebraic is False
+    r = Symbol('r', zero=True)
+    assert (pi**r).is_algebraic is True
+
 
 def test_Mul_is_prime():
     from sympy import Mul


### PR DESCRIPTION
In general this is a fix for `z**r` where `z` is algebraic and `r` is rational.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
