### PR TITLE
geometry : Support for implicit intersecting polygons

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2121,8 +2121,8 @@ class Segment2D(LinearEntity2D, Segment):
         p2 = Point(p2, dim=2)
         if p1 == p2:
             return p1
-        dir = kwargs.get('dir', False)
-        if not dir:
+        evaluate = kwargs.get('evaluate', False)
+        if not evaluate:
             if (p1.x > p2.x) == True:
                 p1, p2 = p2, p1
             elif (p1.x == p2.x) == True and (p1.y > p2.y) == True:

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -2121,10 +2121,12 @@ class Segment2D(LinearEntity2D, Segment):
         p2 = Point(p2, dim=2)
         if p1 == p2:
             return p1
-        if (p1.x > p2.x) == True:
-            p1, p2 = p2, p1
-        elif (p1.x == p2.x) == True and (p1.y > p2.y) == True:
-            p1, p2 = p2, p1
+        dir = kwargs.get('dir', False)
+        if not dir:
+            if (p1.x > p2.x) == True:
+                p1, p2 = p2, p1
+            elif (p1.x == p2.x) == True and (p1.y > p2.y) == True:
+                p1, p2 = p2, p1
         return LinearEntity2D.__new__(cls, p1, p2, **kwargs)
 
     def _svg(self, scale_factor=1., fill_color="#66cc99"):

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -176,7 +176,7 @@ class Polygon(GeometrySet):
             convex = True
         if not convex and not ignore_int:
             sides = {}
-            for i, side in enumerate(rv.directed_sides(True)):
+            for i, side in enumerate(rv.directed_sides):
                 sides[i] = [side]
             for i in sides:
                 # exclude the sides connected to si
@@ -393,22 +393,15 @@ class Polygon(GeometrySet):
             cy += v*(y1 + y2)
         return Point(simplify(A*cx), simplify(A*cy))
 
-
-    def directed_sides(self, dir=False):
-        """The line segments that form the sides of the polygon.
+    @property
+    def directed_sides(self):
+        """The directed line segments that form the sides of the polygon.
 
         Returns
         =======
 
-        sides : list of sides
+        sides : list of sides with direction as supplied by user.
             Each side is a Segment.
-
-        Notes
-        =====
-
-        Depending on the value of `dir` (that refers to direction)
-        the Segments that represent the sides can be directed
-        or undirected line segments.
 
         See Also
         ========
@@ -421,22 +414,17 @@ class Polygon(GeometrySet):
         >>> from sympy import Point, Polygon
         >>> p1, p2, p3, p4 = map(Point, [(0, 0), (1, 0), (5, 1), (0, 1)])
         >>> poly = Polygon(p1, p2, p3, p4)
-        >>> poly.directed_sides(True)
+        >>> poly.directed_sides
         [Segment2D(Point2D(0, 0), Point2D(1, 0)),
         Segment2D(Point2D(1, 0), Point2D(5, 1)),
         Segment2D(Point2D(5, 1), Point2D(0, 1)),
         Segment2D(Point2D(0, 1), Point2D(0, 0))]
-        >>> poly.directed_sides()
-        [Segment2D(Point2D(0, 0), Point2D(1, 0)),
-        Segment2D(Point2D(1, 0), Point2D(5, 1)),
-        Segment2D(Point2D(0, 1), Point2D(5, 1)),
-        Segment2D(Point2D(0, 0), Point2D(0, 1))]
 
         """
         res = []
         args = self.vertices
         for i in range(-len(args), 0):
-            res.append(Segment(args[i], args[i + 1], dir=dir))
+            res.append(Segment(args[i], args[i + 1], dir=True))
         return res
 
     @property

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -687,6 +687,6 @@ def test_issue_2941():
 
 
 def test_directed_segments():
-    assert Segment((1, 0), (0, 0), dir=True).points ==\
+    assert Segment((1, 0), (0, 0), evaluate=True).points ==\
                                         (Point2D(1, 0), Point2D(0, 0))
     assert Segment((1, 0), (0, 0)).points == (Point2D(0, 0), Point2D(1, 0))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -684,3 +684,9 @@ def test_issue_2941():
     # midline intersection
     c, d = (-2, -3), (-2, 0)
     _check()
+
+
+def test_directed_segments():
+    assert Segment((1, 0), (0, 0), dir=True).points ==\
+                                        (Point2D(1, 0), Point2D(0, 0))
+    assert Segment((1, 0), (0, 0)).points == (Point2D(0, 0), Point2D(1, 0))

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -29,7 +29,7 @@ def test_polygon():
     # 2 "remove folded" tests
     assert Polygon(a, Point(3, 0), b, c) == t
     assert Polygon(a, b, Point(3, -1), b, c) == t
-    raises(GeometryError, lambda: Polygon((0, 0), (1, 0), (0, 1), (1, 1)))
+
     # remove multiple collinear points
     assert Polygon(Point(-4, 15), Point(-11, 15), Point(-15, 15),
         Point(-15, 33/5), Point(-15, -87/10), Point(-15, -15),
@@ -402,3 +402,23 @@ def test_intersection():
     assert poly2.intersection(Triangle(Point(0, 1), Point(1, 0), Point(-1, 1))) == [Point(-5/7, 6/7),
                                                                                     Segment(Point2D(0, 1), Point(1, 0))]
     assert poly1.intersection(RegularPolygon((-12, -15), 3, 3)) == []
+
+
+def test_intersecting_polygons():
+    poly1 = Polygon(Point(0, 0), Point(1, 0), Point(0, 1), Point(1, 1))
+    assert poly1.vertices == [Point2D(0, 0), Point2D(1, 0),
+                              Point2D(S(1)/2, S(1)/2), Point2D(0, 1),
+                              Point2D(1, 1), Point2D(S(1)/2, S(1)/2)]
+
+    poly2 = Polygon(Point(0, -3), Point(-1, -2), Point(2, 0), Point(-1, 2),
+                    Point(0, 3))
+    poly3 = Polygon(Point(0, -3), Point(-1, -2), Point(2, 0), Point(-1, 2),
+                    Point(0, 3), ignore_int=True)
+
+    assert poly2.vertices == [Point2D(0, -3), Point2D(-1, -2),
+                              Point2D(0, -4/3), Point2D(2, 0),
+                              Point2D(0, 4/3), Point2D(-1, 2),
+                              Point2D(0, 3), Point2D(0, 4/3),
+                              Point2D(0, -4/3)]
+    assert poly3.vertices == [Point2D(0, -3), Point2D(-1, -2),Point2D(2, 0),
+                              Point2D(-1, 2), Point2D(0, 3)]

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -404,7 +404,7 @@ def test_intersection():
     assert poly1.intersection(RegularPolygon((-12, -15), 3, 3)) == []
 
 
-def test_intersecting_polygons():
+def test_implicit_intersections():
     poly1 = Polygon(Point(0, 0), Point(1, 0), Point(0, 1), Point(1, 1))
     assert poly1.vertices == [Point2D(0, 0), Point2D(1, 0),
                               Point2D(S(1)/2, S(1)/2), Point2D(0, 1),
@@ -422,3 +422,6 @@ def test_intersecting_polygons():
                               Point2D(0, -4/3)]
     assert poly3.vertices == [Point2D(0, -3), Point2D(-1, -2),Point2D(2, 0),
                               Point2D(-1, 2), Point2D(0, 3)]
+
+    assert len(Polygon((0, 2), (1, 0), (2, 2), (3, 0), (4, 2), (4, 1),
+                       (0, 1)).sides) == 15

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -405,15 +405,16 @@ def test_intersection():
 
 
 def test_implicit_intersections():
-    poly1 = Polygon(Point(0, 0), Point(1, 0), Point(0, 1), Point(1, 1))
+    poly1 = Polygon(Point(0, 0), Point(1, 0),
+                    Point(0, 1), Point(1, 1), ignore_intersection=False)
     assert poly1.vertices == [Point2D(0, 0), Point2D(1, 0),
                               Point2D(S(1)/2, S(1)/2), Point2D(0, 1),
                               Point2D(1, 1), Point2D(S(1)/2, S(1)/2)]
 
     poly2 = Polygon(Point(0, -3), Point(-1, -2), Point(2, 0), Point(-1, 2),
-                    Point(0, 3))
+                    Point(0, 3), ignore_intersection=False)
     poly3 = Polygon(Point(0, -3), Point(-1, -2), Point(2, 0), Point(-1, 2),
-                    Point(0, 3), ignore_int=True)
+                    Point(0, 3))
 
     assert poly2.vertices == [Point2D(0, -3), Point2D(-1, -2),
                               Point2D(0, -4/3), Point2D(2, 0),
@@ -424,4 +425,25 @@ def test_implicit_intersections():
                               Point2D(-1, 2), Point2D(0, 3)]
 
     assert len(Polygon((0, 2), (1, 0), (2, 2), (3, 0), (4, 2), (4, 1),
-                       (0, 1)).sides) == 15
+                       (0, 1), ignore_intersection=False).sides) == 15
+
+    assert len(Polygon((1, 2), (4, 4), (4, 2),
+                       (2, 4), (2, 1), (5, 3),
+                       ignore_intersection=False).sides) == 20
+
+
+def test_area_implicit_intersecting_polygons():
+    assert Polygon(Point2D(0, 0), Point2D(1, 0), Point2D(0, 1), Point2D(1, 1),
+                   ignore_intersection=False).area == S(1) / 2
+
+    assert Polygon((0, -3), (-1, -2), (2, 0),
+                   (-1, 2), (0, 3), ignore_intersection=False).area == S(13)/3
+
+    assert Polygon((22, 87), (6, 3), (98, 77), (20, 56),
+                   (96, 52), (79, 34), (46, 78), (52, 73),
+                   (81, 85), (90, 43), ignore_intersection=False).area == \
+        S(140721035628604449602641) / 50466690459292972480
+
+    assert Polygon((0, 0), (5, 0), (5, 4), (1, 4), (1, 2),
+                   (3, 2), (3, 3), (2, 3), (2, 1), (4, 1),
+                   (4, 5), (0, 5), ignore_intersection=False).area == 17

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -61,7 +61,7 @@ def polytope_integrate(poly, expr, **kwargs):
     if isinstance(poly, Polygon):
         # For Vertex Representation
         hp_params = hyperplane_parameters(poly)
-        facets = poly.sides
+        facets = poly.directed_sides(True)
     else:
         # For Hyperplane Representation
         plen = len(poly)
@@ -116,7 +116,7 @@ def main_integrate(expr, facets, hp_params, max_degree=None):
     >>> from sympy.geometry.polygon import Polygon
     >>> from sympy.geometry.point import Point
     >>> triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
-    >>> facets = triangle.sides
+    >>> facets = triangle.directed_sides(dir=True)
     >>> hp_params = hyperplane_parameters(triangle)
     >>> main_integrate(x**2 + y**2, facets, hp_params)
     325/6
@@ -125,12 +125,10 @@ def main_integrate(expr, facets, hp_params, max_degree=None):
     dim_length = len(dims)
     result = {}
     integral_value = S.Zero
-
     if max_degree:
         y_degree = max_degree
         grad_terms = [[0, 0, 0, 0]] + \
             gradient_terms(max_degree)
-
         for facet_count, hp in enumerate(hp_params):
             a, b = hp[0], hp[1]
             x0 = facets[facet_count].points[0]
@@ -195,7 +193,7 @@ def integration_reduction(facets, index, a, b, expr, dims, degree):
     >>> from sympy.geometry.point import Point
     >>> from sympy.geometry.polygon import Polygon
     >>> triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
-    >>> facets = triangle.sides
+    >>> facets = triangle.directed_sides(dir=True)
     >>> a, b = hyperplane_parameters(triangle)[0]
     >>> integration_reduction(facets, 0, a, b, 1, (x, y), 0)
     5
@@ -241,7 +239,7 @@ def left_integral(m, index, facets, x0, expr, gens):
     >>> from sympy.geometry.point import Point
     >>> from sympy.geometry.polygon import Polygon
     >>> triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
-    >>> facets = triangle.sides
+    >>> facets = triangle.directed_sides(dir=True)
     >>> left_integral(3, 0, facets, facets[0].points[0], 1, (x, y))
     5
     """
@@ -295,7 +293,7 @@ def integration_reduction_dynamic(facets, index, a, b, expr,
     >>> from sympy.geometry.point import Point
     >>> from sympy.geometry.polygon import Polygon
     >>> triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
-    >>> facets = triangle.sides
+    >>> facets = triangle.directed_sides(dir=True)
     >>> a, b = hyperplane_parameters(triangle)[0]
     >>> x0 = facets[0].points[0]
     >>> monomial_values = [[0, 0, 0, 0], [1, 0, 0, 5],\

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -61,7 +61,7 @@ def polytope_integrate(poly, expr, **kwargs):
     if isinstance(poly, Polygon):
         # For Vertex Representation
         hp_params = hyperplane_parameters(poly)
-        facets = poly.directed_sides(True)
+        facets = poly.directed_sides
     else:
         # For Hyperplane Representation
         plen = len(poly)
@@ -116,7 +116,7 @@ def main_integrate(expr, facets, hp_params, max_degree=None):
     >>> from sympy.geometry.polygon import Polygon
     >>> from sympy.geometry.point import Point
     >>> triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
-    >>> facets = triangle.directed_sides(dir=True)
+    >>> facets = triangle.directed_sides
     >>> hp_params = hyperplane_parameters(triangle)
     >>> main_integrate(x**2 + y**2, facets, hp_params)
     325/6
@@ -193,7 +193,7 @@ def integration_reduction(facets, index, a, b, expr, dims, degree):
     >>> from sympy.geometry.point import Point
     >>> from sympy.geometry.polygon import Polygon
     >>> triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
-    >>> facets = triangle.directed_sides(dir=True)
+    >>> facets = triangle.directed_sides
     >>> a, b = hyperplane_parameters(triangle)[0]
     >>> integration_reduction(facets, 0, a, b, 1, (x, y), 0)
     5
@@ -239,7 +239,7 @@ def left_integral(m, index, facets, x0, expr, gens):
     >>> from sympy.geometry.point import Point
     >>> from sympy.geometry.polygon import Polygon
     >>> triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
-    >>> facets = triangle.directed_sides(dir=True)
+    >>> facets = triangle.directed_sides
     >>> left_integral(3, 0, facets, facets[0].points[0], 1, (x, y))
     5
     """
@@ -293,7 +293,7 @@ def integration_reduction_dynamic(facets, index, a, b, expr,
     >>> from sympy.geometry.point import Point
     >>> from sympy.geometry.polygon import Polygon
     >>> triangle = Polygon(Point(0, 3), Point(5, 3), Point(1, 1))
-    >>> facets = triangle.directed_sides(dir=True)
+    >>> facets = triangle.directed_sides
     >>> a, b = hyperplane_parameters(triangle)[0]
     >>> x0 = facets[0].points[0]
     >>> monomial_values = [[0, 0, 0, 0], [1, 0, 0, 5],\

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -131,8 +131,7 @@ def main_integrate(expr, facets, hp_params, max_degree=None):
             gradient_terms(max_degree)
         for facet_count, hp in enumerate(hp_params):
             a, b = hp[0], hp[1]
-            x0 = facets[facet_count].points[0]
-
+            x0 = facets[facet_count][0][0]
             for i, monom in enumerate(grad_terms):
                 #  Every monomial is a tuple :
                 #  (term, x_degree, y_degree, value over boundary)
@@ -204,7 +203,10 @@ def integration_reduction(facets, index, a, b, expr, dims, degree):
     a, b = (S(a[0]), S(a[1])), S(b)
 
     value = S.Zero
-    x0 = facets[index].points[0]
+    if isinstance(facets[index], Segment2D):
+        x0 = facets[index].points[0]
+    else:
+        x0 = facets[index][0][0]
     m = len(facets)
     gens = (x, y)
 
@@ -247,7 +249,14 @@ def left_integral(m, index, facets, x0, expr, gens):
     for j in range(0, m):
         intersect = ()
         if j == (index - 1) % m or j == (index + 1) % m:
-            intersect = intersection(facets[index], facets[j])
+            if not isinstance(facets[index], Segment2D):
+                segment_i = Segment2D(facets[index][0][0],
+                                      facets[index][1][0], evaluate=True)
+                segment_j = Segment2D(facets[j][0][0],
+                                      facets[j][1][0], evaluate=True)
+                intersect = intersection(segment_i, segment_j)
+            else:
+                intersect = intersection(facets[index], facets[j])
         if intersect:
             distance_origin = norm(tuple(map(lambda x, y: x - y,
                                              intersect, x0)))

--- a/sympy/integrals/tests/test_intpoly.py
+++ b/sympy/integrals/tests/test_intpoly.py
@@ -149,7 +149,6 @@ def test_polytope_integrate():
     assert result_dict[expr3] == 1946257153/924
 
 
-@XFAIL
 def test_polytopes_intersecting_sides():
     #  Intersecting polygons not implemented yet in SymPy. Will be implemented
     #  soon. As of now, the intersection point will have to be manually
@@ -157,12 +156,12 @@ def test_polytopes_intersecting_sides():
     fig5 = Polygon(Point(-4.165, -0.832), Point(-3.668, 1.568),
                    Point(-3.266, 1.279), Point(-1.090, -2.080),
                    Point(3.313, -0.683), Point(3.033, -4.845),
-                   Point(-4.395, 4.840), Point(-1.007, -3.328))
+                   Point(-4.395, 4.840), Point(-1.007, -3.328), ignore_int=True)
     assert polytope_integrate(fig5, x**2 + x*y + y**2) ==\
         S(1633405224899363)/(24*10**12)
 
     fig6 = Polygon(Point(-3.018, -4.473), Point(-0.103, 2.378),
                    Point(-1.605, -2.308), Point(4.516, -0.771),
-                   Point(4.203, 0.478))
+                   Point(4.203, 0.478), ignore_int=True)
     assert polytope_integrate(fig6, x**2 + x*y + y**2) ==\
         S(88161333955921)/(3*10**12)

--- a/sympy/integrals/tests/test_intpoly.py
+++ b/sympy/integrals/tests/test_intpoly.py
@@ -156,12 +156,12 @@ def test_polytopes_intersecting_sides():
     fig5 = Polygon(Point(-4.165, -0.832), Point(-3.668, 1.568),
                    Point(-3.266, 1.279), Point(-1.090, -2.080),
                    Point(3.313, -0.683), Point(3.033, -4.845),
-                   Point(-4.395, 4.840), Point(-1.007, -3.328), ignore_int=True)
+                   Point(-4.395, 4.840), Point(-1.007, -3.328))
     assert polytope_integrate(fig5, x**2 + x*y + y**2) ==\
         S(1633405224899363)/(24*10**12)
 
     fig6 = Polygon(Point(-3.018, -4.473), Point(-0.103, 2.378),
                    Point(-1.605, -2.308), Point(4.516, -0.771),
-                   Point(4.203, 0.478), ignore_int=True)
+                   Point(4.203, 0.478))
     assert polytope_integrate(fig6, x**2 + x*y + y**2) ==\
         S(88161333955921)/(3*10**12)


### PR DESCRIPTION
Intersecting polygons with both implicit and explicit intersections are allowed. Remaining XFAILs for `intpoly` module pass as a result.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
