### PR TITLE
Fix using preprocessor_statements kwarg in CCodeGen.

### DIFF
--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -798,6 +798,7 @@ class CCodeGen(CodeGen):
         super(CCodeGen, self).__init__(project=project)
         self.printer = printer or c_code_printers[self.standard.lower()]()
 
+        self.preprocessor_statements = preprocessor_statements
         if preprocessor_statements is None:
             self.preprocessor_statements = ['#include <math.h>']
 


### PR DESCRIPTION
Just fixes a silly oversight from #12833, where passing the `preprocessor_statements` kwarg to `C*CodeGen` didn't actually set the attribute.