### PR TITLE
piecewise fold modifications

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -540,7 +540,51 @@ def piecewise_fold(expr):
     """
     if not isinstance(expr, Basic) or not expr.has(Piecewise):
         return expr
-    new_args = list(map(piecewise_fold, expr.args))
+
+    new_args = []
+    if isinstance(expr, (ExprCondPair, Piecewise)):
+        for e, c in expr.args:
+            if not isinstance(e, Piecewise):
+                e = piecewise_fold(e)
+            if isinstance(e, Piecewise):
+                new_args.extend([(piecewise_fold(ei), And(ci, c)) for ei, ci in e.args])
+            else:
+                new_args.append((e, c))
+    else:
+        from sympy.utilities.iterables import cartes
+        folded = list(map(piecewise_fold, expr.args))
+        for ec in cartes(*[
+                (i.args if isinstance(i, Piecewise) else
+                 [(i, S.true)]) for i in folded]):
+            e, c = zip(*ec)
+            new_args.append((expr.func(*e), And(*c)))
+
+    return Piecewise(*new_args)
+
+
+def piecewise_fold_old(expr):
+    """
+    Takes an expression containing a piecewise function and returns the
+    expression in piecewise form.
+
+    Examples
+    ========
+
+    >>> from sympy import Piecewise, sympify as S
+    >>> from sympy.functions.elementary.piecewise import piecewise_fold_old
+    >>> from sympy.abc import x
+    >>> p = Piecewise((x, x < 1), (1, S(1) <= x))
+    >>> piecewise_fold_old(x*p)
+    Piecewise((x**2, x < 1), (x, 1 <= x))
+
+    See Also
+    ========
+
+    Piecewise
+    """
+    if not isinstance(expr, Basic) or not expr.has(Piecewise):
+        return expr
+    new_args = list(map(piecewise_fold_old, expr.args))
     if expr.func is ExprCondPair:
         return ExprCondPair(*new_args)
     piecewise_args = []
@@ -554,7 +598,7 @@ def piecewise_fold(expr):
         if isinstance(expr, Boolean):
             # If expr is Boolean, we must return some kind of PiecewiseBoolean.
             # This is constructed by means of Or, And and Not.
-            # piecewise_fold(0 < Piecewise( (sin(x), x<0), (cos(x), True)))
+            # piecewise_fold_old(0 < Piecewise( (sin(x), x<0), (cos(x), True)))
             # can't return Piecewise((0 < sin(x), x < 0), (0 < cos(x), True))
             # but instead Or(And(x < 0, 0 < sin(x)), And(0 < cos(x), Not(x<0)))
             other = True
@@ -563,10 +607,10 @@ def piecewise_fold(expr):
                 rtn = Or(rtn, And(other, c, e))
                 other = And(other, Not(c))
             if len(piecewise_args) > 1:
-                return piecewise_fold(rtn)
+                return piecewise_fold_old(rtn)
             return rtn
         if len(piecewise_args) > 1:
-            return piecewise_fold(Piecewise(*new_args))
+            return piecewise_fold_old(Piecewise(*new_args))
         return Piecewise(*new_args)
     else:
         return expr.func(*new_args)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -329,6 +329,10 @@ def test_piecewise_fold():
     assert integrate(
         piecewise_fold(p), (x, -oo, oo)) == integrate(2*x + 2, (x, 0, 1))
 
+    assert piecewise_fold(
+        Piecewise((1, y <= 0), (-Piecewise((2, y >= 0)), True)
+        )) == Piecewise((1, y <= 0), (-2, y >= 0))
+
 
 def test_piecewise_fold_piecewise_in_cond():
     p1 = Piecewise((cos(x), x < 0), (0, True))
@@ -338,16 +342,21 @@ def test_piecewise_fold_piecewise_in_cond():
     assert(p2.subs(x, 1) == 0.0)
     assert(p2.subs(x, -pi/4) == 1.0)
     p4 = Piecewise((0, Eq(p1, 0)), (1,True))
-    assert(piecewise_fold(p4) == Piecewise(
-        (0, Or(And(Eq(cos(x), 0), x < 0), Not(x < 0))), (1, True)))
+    ans = piecewise_fold(p4)
+    for i in range(-1, 1):
+        assert ans.subs(x, i) == p4.subs(x, i)
 
     r1 = 1 < Piecewise((1, x < 1), (3, True))
-    assert(piecewise_fold(r1) == Not(x < 1))
+    ans = piecewise_fold(r1)
+    for i in range(2):
+        assert ans.subs(x, i) == r1.subs(x, i)
 
     p5 = Piecewise((1, x < 0), (3, True))
     p6 = Piecewise((1, x < 1), (3, True))
-    p7 = piecewise_fold(Piecewise((1, p5 < p6), (0, True)))
-    assert(Piecewise((1, And(Not(x < 1), x < 0)), (0, True)))
+    p7 = Piecewise((1, p5 < p6), (0, True))
+    ans = piecewise_fold(p7)
+    for i in range(-1, 2):
+        assert ans.subs(x, i) == p7.subs(x, i)
 
 
 @XFAIL
@@ -363,12 +372,8 @@ def test_piecewise_fold_expand():
     p1 = Piecewise((1, Interval(0, 1, False, True).contains(x)), (0, True))
 
     p2 = piecewise_fold(expand((1 - x)*p1))
-    assert p2 == Piecewise((1 - x, Interval(0, 1, False, True).contains(x)),
-        (Piecewise((-x, Interval(0, 1, False, True).contains(x)), (0, True)), True))
-
-    p2 = expand(piecewise_fold((1 - x)*p1))
-    assert p2 == Piecewise(
-        (1 - x, Interval(0, 1, False, True).contains(x)), (0, True))
+    assert p2 == Piecewise((1 - x, (x >= 0) & (x < 1)), (0, True))
+    assert p2 == expand(piecewise_fold((1 - x)*p1))
 
 
 def test_piecewise_duplicate():
@@ -511,3 +516,27 @@ def test_issue_10258():
     assert Piecewise((0, x < 1), (1, True)).is_finite
     b = Basic()
     assert Piecewise((b, x < 1)).is_finite is None
+
+    # 10258
+    c = Piecewise((1, x < 0), (2, True)) < 3
+    assert c != True
+    assert piecewise_fold(c) == True
+
+
+def test_issue_10087():
+    a, b = Piecewise((x, x > 1), (2, True)), Piecewise((x, x > 3), (3, True))
+    m = a*b
+    f = piecewise_fold(m)
+    for i in (0, 2, 4):
+        assert m.subs(x, i) == f.subs(x, i)
+    m = a + b
+    f = piecewise_fold(m)
+    for i in (0, 2, 4):
+        assert m.subs(x, i) == f.subs(x, i)
+
+
+def test_issue_8919():
+    x, c_1, c_2, c_3, c_4 = symbols('x c_1:5')
+    f1 = Piecewise( (c_1, x < 1), (c_2, True))
+    f2 = Piecewise( (c_3, x < S(1)/3), (c_4, True))
+    assert integrate(f1*f2, (x, 0, 2)) == c_1*c_3/3 + 2*c_1*c_4/3 + c_2*c_4


### PR DESCRIPTION
fixes #10087
fixes #8919
- [x] blocked on #12920

No simplification of the resulting piecewise is attempted, a new "denested" piecewise is simply returned. It may not look as simple as it could, but it should behave properly. See the added tests which fail in master but pass here.

A different sort of change is that a Piecewise is returned instead of a Boolean in some cases. Here is an example from the inline comments of the old `piecewise_fold`:
```
>>> p = 0 < Piecewise( (sin(x), x<0), (cos(x), True))
>>> piecewise_fold_old(p)
((x >= 0) & (cos(x) > 0)) | ((x < 0) & (sin(x) > 0))

>>> piecewise_fold(p)
Piecewise((sin(x) > 0, x < 0), (cos(x) > 0, True))
```

- [x] remove piecewise_fold_old
