### PR TITLE
Update util.py : fix #12949

### DIFF
--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -685,10 +685,29 @@ def intersection(*entities):
     from .entity import GeometryEntity
     from .point import Point
 
-    if len(entities) <= 1:
-        return []
+    if union == False:
 
-    # entities may be an immutable tuple
+        if len(entities) <= 1:
+            return []
+
+        # entities may be an immutable tuple
+        entities = list(entities)
+        for i, e in enumerate(entities):
+            if not isinstance(e, GeometryEntity):
+                try:
+                    entities[i] = Point(e)
+                except NotImplementedError:
+                    raise ValueError('%s is not a GeometryEntity and cannot be made into Point' % str(e))
+
+        res = entities[0].intersection(entities[1])
+        for entity in entities[2:]:
+            newres = []
+            for x in res:
+                newres.extend(x.intersection(entity))
+            res = newres
+        return res
+
+    ans = []
     entities = list(entities)
     for i, e in enumerate(entities):
         if not isinstance(e, GeometryEntity):
@@ -696,11 +715,13 @@ def intersection(*entities):
                 entities[i] = Point(e)
             except NotImplementedError:
                 raise ValueError('%s is not a GeometryEntity and cannot be made into Point' % str(e))
-
-    res = entities[0].intersection(entities[1])
-    for entity in entities[2:]:
-        newres = []
-        for x in res:
-            newres.extend(x.intersection(entity))
-        res = newres
-    return res
+    for j in range(0, len(entities)):
+        for k in range(j + 1, len(entities)):
+            if len(intersection(entities[j], entities[k])) is not 0:
+                ans.append(intersection(entities[j], entities[k]))
+                   
+    temp = []
+    for element in ans:
+        if element not in temp:
+            temp.append(element)
+    return temp


### PR DESCRIPTION
#12949  fix.
I have added a new argument called union. When union is false, intersection works like it used to before. But when union is set to true, we can find all the points of intersection of the lines.
```
>>>v1 = Line((1,0),(1,1))
>>>v2 = Line((2,0),(2,1))
>>>h = Line((0,0), slope=0)
>>>len(intersection(v1,h))
1
`>>>len(intersection(v1,v2,h,union=True))`
`2`  (as expected)

