### PR TITLE
Fix Matrix Regressions

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -239,10 +239,9 @@ class MatrixShaping(MatrixRequired):
         col
         row_join
         """
-        from sympy.matrices import MutableMatrix
-        # Allows you to build a matrix even if it is null matrix
-        if not self:
-            return type(self)(other)
+        # A null matrix can allways be stacked (see  #10770)
+        if self.rows == 0 and self.cols != other.cols:
+            return self._new(0, other.cols, []).col_join(other)
 
         if self.cols != other.cols:
             raise ShapeError(
@@ -476,9 +475,9 @@ class MatrixShaping(MatrixRequired):
         row
         col_join
         """
-        # Allows you to build a matrix even if it is null matrix
-        if not self:
-            return self._new(other)
+        # A null matrix can allways be stacked (see  #10770)
+        if self.cols == 0 and self.rows != other.rows:
+            return self._new(other.rows, 0, []).row_join(other)
 
         if self.rows != other.rows:
             raise ShapeError(

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -239,7 +239,7 @@ class MatrixShaping(MatrixRequired):
         col
         row_join
         """
-        # A null matrix can allways be stacked (see  #10770)
+        # A null matrix can always be stacked (see  #10770)
         if self.rows == 0 and self.cols != other.cols:
             return self._new(0, other.cols, []).col_join(other)
 
@@ -475,7 +475,7 @@ class MatrixShaping(MatrixRequired):
         row
         col_join
         """
-        # A null matrix can allways be stacked (see  #10770)
+        # A null matrix can always be stacked (see  #10770)
         if self.cols == 0 and self.rows != other.rows:
             return self._new(other.rows, 0, []).row_join(other)
 

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -64,9 +64,12 @@ class MatMul(MatrixExpr):
         if X.has(ImmutableMatrix) or Y.has(ImmutableMatrix):
             return coeff*Add(*[X[i, k]*Y[k, j] for k in range(X.cols)])
         result = Sum(coeff*X[i, k]*Y[k, j], (k, 0, X.cols - 1))
-        if not X.cols.is_number:
-            # Don't waste time in result.doit() if the sum bounds are symbolic
-            expand = False
+        try:
+            if not X.cols.is_number:
+                # Don't waste time in result.doit() if the sum bounds are symbolic
+                expand = False
+        except AttributeError:
+            pass
         return result.doit() if expand else result
 
     def as_coeff_matrices(self):

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -6,7 +6,7 @@ from sympy.matrices.expressions import Adjoint, Transpose, det, MatPow
 from sympy.matrices.expressions.matmul import (factor_in_front, remove_ids,
         MatMul, xxinv, any_zeros, unpack, only_squares)
 from sympy.strategies import null_safe
-from sympy import refine, Q
+from sympy import refine, Q, Symbol
 
 n, m, l, k = symbols('n m l k', integer=True)
 A = MatrixSymbol('A', n, m)
@@ -131,3 +131,7 @@ def test_matmul_args_cnc():
     a, b = symbols('a b', commutative=False)
     assert MatMul(n, a, b, A, A.T).args_cnc() == ([n], [a, b, A, A.T])
     assert MatMul(A, A.T).args_cnc() == ([1], [A, A.T])
+
+def test_issue_12950():
+    M = Matrix([[Symbol("x")]]) * MatrixSymbol("A", 1, 1)
+    assert MatrixSymbol("A", 1, 1).as_explicit()[0]*Symbol('x') == M.as_explicit()[0]

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -221,6 +221,14 @@ def test_hstack():
     raises(ShapeError, lambda: m.hstack(m, m2))
     assert Matrix.hstack() == Matrix()
 
+    # test regression #12938
+    M1 = Matrix.zeros(0, 0)
+    M2 = Matrix.zeros(0, 1)
+    M3 = Matrix.zeros(0, 2)
+    M4 = Matrix.zeros(0, 3)
+    m = ShapingOnlyMatrix.hstack(M1, M2, M3, M4)
+    assert m.rows == 0 and m.cols == 6
+
 def test_vstack():
     m = ShapingOnlyMatrix(4, 3, lambda i, j: i*3 + j)
     m2 = ShapingOnlyMatrix(3, 4, lambda i, j: i*3 + j)


### PR DESCRIPTION
Two matrix regressions were found in sympy 1.1:  

Behavior of Matrix.hstack changed in sympy 1.1 #12938

and

as_explicit raises an error for MatMul objects (regression in sympy 1.1) #12950 

This PR resolves those issues.