### PR TITLE
Updated cxxcode

### DIFF
--- a/sympy/printing/cxxcode.py
+++ b/sympy/printing/cxxcode.py
@@ -27,7 +27,9 @@ reserved['C++11'] = reserved['C++98'][:] + [
     'alignas', 'alignof', 'char16_t', 'char32_t', 'constexpr', 'decltype',
     'noexcept', 'nullptr', 'static_assert', 'thread_local'
 ]
-reserved['C++17'] = []
+reserved['C++17'] = reserved['C++11'][:] - [
+    'register'
+] 
 # TM TS: atomic_cancel, atomic_commit, atomic_noexcept, synchronized
 # concepts TS: concept, requires
 # module TS: import, module

--- a/sympy/printing/cxxcode.py
+++ b/sympy/printing/cxxcode.py
@@ -27,9 +27,8 @@ reserved['C++11'] = reserved['C++98'][:] + [
     'alignas', 'alignof', 'char16_t', 'char32_t', 'constexpr', 'decltype',
     'noexcept', 'nullptr', 'static_assert', 'thread_local'
 ]
-reserved['C++17'] = reserved['C++11'][:] - [
-    'register'
-] 
+reserved['C++17'] = reserved['C++11'][:]
+reserved['C++17'].remove('register')
 # TM TS: atomic_cancel, atomic_commit, atomic_noexcept, synchronized
 # concepts TS: concept, requires
 # module TS: import, module


### PR DESCRIPTION
**Removed keyword register from C++17 reserved keywords**
The register keyword was deprecated in the 2011 C++ standard. C++17 tries to clear the standard, so the keyword is now removed.
Refer this link : [http://www.bfilipek.com/2017/01/cpp17features.html#remove-deprecated-use-of-the-register-keyword](url)
Review the changes @bjodah @smichr @moorepants 