### PR TITLE
Improved code style in physics units

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,5 @@
+[style]
+# requires https://github.com/google/yapf/pull/427
+no_spaces_around_selected_binary_operators = *,/
+split_before_named_assigns = False
+split_penalty_import_names = 1000

--- a/sympy/physics/units/__init__.py
+++ b/sympy/physics/units/__init__.py
@@ -29,6 +29,7 @@ Useful functions:
 
 """
 
+# yapf: disable
 from sympy.core.compatibility import string_types
 from .dimensions import Dimension, DimensionSystem
 from .unitsystem import UnitSystem
@@ -182,6 +183,8 @@ from .definitions import (
     planck_length,
 )
 
+# yapf: enable
+
 
 def find_unit(quantity):
     """
@@ -210,7 +213,10 @@ def find_unit(quantity):
     import sympy.physics.units as u
     rv = []
     if isinstance(quantity, string_types):
-        rv = [i for i in dir(u) if quantity in i and isinstance(getattr(u, i), Quantity)]
+        rv = [
+            i for i in dir(u)
+            if quantity in i and isinstance(getattr(u, i), Quantity)
+        ]
         dim = getattr(u, quantity)
         if isinstance(dim, Dimension):
             rv.extend(find_unit(dim))
@@ -225,10 +231,12 @@ def find_unit(quantity):
             elif isinstance(quantity, Dimension):
                 if other.dimension == quantity:
                     rv.append(str(i))
-            elif other.dimension == Dimension(Quantity.get_dimensional_expr(quantity)):
+            elif other.dimension == Dimension(
+                    Quantity.get_dimensional_expr(quantity)):
                 rv.append(str(i))
 
     return sorted(rv, key=len)
+
 
 # NOTE: the old units module had additional variables:
 # 'density', 'illuminance', 'resistance'.

--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -42,7 +42,8 @@ ug = microgram = micrograms = Quantity("microgram", mass, micro*gram, "ug")
 newton = newtons = N = Quantity("newton", force, kilogram*meter/second**2, "N")
 joule = joules = J = Quantity("joule", energy, newton*meter, "J")
 watt = watts = W = Quantity("watt", power, joule/second, "W")
-pascal = pascals = Pa = pa = Quantity("pascal", pressure, newton/meter**2, "Pa")
+pascal = pascals = Pa = pa = Quantity("pascal", pressure, newton/meter**2,
+                                      "Pa")
 hertz = hz = Hz = Quantity("hertz", frequency, 1, "Hz")
 
 # MKSA extension to MKS: derived units
@@ -50,24 +51,32 @@ hertz = hz = Hz = Quantity("hertz", frequency, 1, "Hz")
 coulomb = coulombs = C = Quantity("coulomb", charge, 1, abbrev='C')
 volt = volts = v = V = Quantity("volt", voltage, joule/coulomb, abbrev='V')
 ohm = ohms = Quantity("ohm", impedance, volt/ampere, abbrev='ohm')
-siemens = S = mho = mhos = Quantity("siemens", conductance, ampere/volt, abbrev='S')
+siemens = S = mho = mhos = Quantity("siemens", conductance, ampere/volt,
+                                    abbrev='S')
 farad = farads = F = Quantity("farad", capacitance, coulomb/volt, abbrev='F')
-henry = henrys = H = Quantity("henry", inductance, volt*second/ampere, abbrev='H')
-tesla = teslas = T = Quantity("tesla", magnetic_density, volt*second/meter**2, abbrev='T')
-weber = webers = Wb = wb = Quantity("weber", magnetic_flux, joule/ampere, abbrev='Wb')
+henry = henrys = H = Quantity("henry", inductance, volt*second/ampere,
+                              abbrev='H')
+tesla = teslas = T = Quantity("tesla", magnetic_density, volt*second/meter**2,
+                              abbrev='T')
+weber = webers = Wb = wb = Quantity("weber", magnetic_flux, joule/ampere,
+                                    abbrev='Wb')
 
 # Other derived units:
 
 optical_power = dioptre = D = Quantity("dioptre", 1/length, 1/meter)
-lux = lx = Quantity("lux", luminous_intensity/length**2, steradian*candela/meter**2)
+lux = lx = Quantity("lux", luminous_intensity/length**2,
+                    steradian*candela/meter**2)
 
 # Common length units
 
 km = kilometer = kilometers = Quantity("kilometer", length, kilo*meter, "km")
 dm = decimeter = decimeters = Quantity("decimeter", length, deci*meter, "dm")
-cm = centimeter = centimeters = Quantity("centimeter", length, centi*meter, "cm")
-mm = millimeter = millimeters = Quantity("millimeter", length, milli*meter, "mm")
-um = micrometer = micrometers = micron = microns = Quantity("micrometer", length, micro*meter, "um")
+cm = centimeter = centimeters = Quantity("centimeter", length, centi*meter,
+                                         "cm")
+mm = millimeter = millimeters = Quantity("millimeter", length, milli*meter,
+                                         "mm")
+um = micrometer = micrometers = micron = microns = Quantity(
+    "micrometer", length, micro*meter, "um")
 nm = nanometer = nanometers = Quantity("nanometer", length, nano*meter, "nn")
 pm = picometer = picometers = Quantity("picometer", length, pico*meter, "pm")
 
@@ -75,19 +84,22 @@ ft = foot = feet = Quantity("foot", length, Rational(3048, 10000)*meter, "ft")
 inch = inches = Quantity("inch", length, foot/12)
 yd = yard = yards = Quantity("yard", length, 3*feet, "yd")
 mi = mile = miles = Quantity("mile", length, 5280*feet)
-nmi = nautical_mile = nautical_miles = Quantity("nautical_mile", length, 6076*feet)
+nmi = nautical_mile = nautical_miles = Quantity("nautical_mile", length,
+                                                6076*feet)
 
 # Common volume and area units
 
-l = liter = liters = Quantity("liter", length**3, meter**3 / 1000)
-dl = deciliter = deciliters = Quantity("deciliter", length**3, liter / 10)
-cl = centiliter = centiliters = Quantity("centiliter", length**3, liter / 100)
-ml = milliliter = milliliters = Quantity("milliliter", length**3, liter / 1000)
+l = liter = liters = Quantity("liter", length**3, meter**3/1000)
+dl = deciliter = deciliters = Quantity("deciliter", length**3, liter/10)
+cl = centiliter = centiliters = Quantity("centiliter", length**3, liter/100)
+ml = milliliter = milliliters = Quantity("milliliter", length**3, liter/1000)
 
 # Common time units
 
-ms = millisecond = milliseconds = Quantity("millisecond", time, milli*second, "ms")
-us = microsecond = microseconds = Quantity("microsecond", time, micro*second, "us")
+ms = millisecond = milliseconds = Quantity("millisecond", time, milli*second,
+                                           "ms")
+us = microsecond = microseconds = Quantity("microsecond", time, micro*second,
+                                           "us")
 ns = nanosecond = nanoseconds = Quantity("nanosecond", time, nano*second, "ns")
 ps = picosecond = picoseconds = Quantity("picosecond", time, pico*second, "ps")
 
@@ -95,23 +107,29 @@ minute = minutes = Quantity("minute", time, 60*second)
 h = hour = hours = Quantity("hour", time, 60*minute)
 day = days = Quantity("day", time, 24*hour)
 
-anomalistic_year = anomalistic_years = Quantity("anomalistic_year", time, 365.259636*day)
+anomalistic_year = anomalistic_years = Quantity("anomalistic_year", time,
+                                                365.259636*day)
 sidereal_year = sidereal_years = Quantity("sidereal_year", time, 31558149.540)
 tropical_year = tropical_years = Quantity("tropical_year", time, 365.24219*day)
 common_year = common_years = Quantity("common_year", time, 365*day)
 julian_year = julian_years = Quantity("julian_year", time, 365.25*day)
 draconic_year = draconic_years = Quantity("draconic_year", time, 346.62*day)
-gaussian_year = gaussian_years = Quantity("gaussian_year", time, 365.2568983*day)
-full_moon_cycle = full_moon_cycles = Quantity("full_moon_cycle", time, 411.78443029*day)
+gaussian_year = gaussian_years = Quantity("gaussian_year", time,
+                                          365.2568983*day)
+full_moon_cycle = full_moon_cycles = Quantity("full_moon_cycle", time,
+                                              411.78443029*day)
 
 year = years = tropical_year
 
 #### CONSTANTS ####
 
 # Newton constant
-G = gravitational_constant = Quantity("gravitational_constant", length**3*mass**-1*time**-2, 6.67408e-11*m**3/(kg*s**2), abbrev="G")
+G = gravitational_constant = Quantity("gravitational_constant",
+                                      length**3*mass**-1*time**-2,
+                                      6.67408e-11*m**3/(kg*s**2), abbrev="G")
 # speed of light
-c = speed_of_light = Quantity("speed_of_light", velocity, 299792458*meter/second, abbrev="c")
+c = speed_of_light = Quantity("speed_of_light", velocity,
+                              299792458*meter/second, abbrev="c")
 # Wave impedance of free space
 Z0 = Quantity("WaveImpedence", impedance, 119.9169832*pi, abbrev='Z_0')
 # Reduced Planck constant
@@ -119,54 +137,76 @@ hbar = Quantity("hbar", action, 1.05457266e-34*joule*second, abbrev="hbar")
 # Planck constant
 planck = Quantity("planck", action, 2*pi*hbar, abbrev="h")
 # Electronvolt
-eV = electronvolt = electronvolts = Quantity("electronvolt", energy, 1.60219e-19*joule, abbrev="eV")
+eV = electronvolt = electronvolts = Quantity("electronvolt", energy,
+                                             1.60219e-19*joule, abbrev="eV")
 # Avogadro number
 avogadro_number = Quantity("avogadro_number", 1, 6.022140857e23)
 # Avogadro constant
-avogadro = avogadro_constant = Quantity("avogadro_constant", amount_of_substance**-1, avogadro_number / mol)
+avogadro = avogadro_constant = Quantity(
+    "avogadro_constant", amount_of_substance**-1, avogadro_number/mol)
 # Boltzmann constant
-boltzmann = boltzmann_constant = Quantity("boltzmann_constant", energy/temperature, 1.38064852e-23*joule/kelvin)
+boltzmann = boltzmann_constant = Quantity(
+    "boltzmann_constant", energy/temperature, 1.38064852e-23*joule/kelvin)
 # Atomic mass
-amu = amus = atomic_mass_unit = atomic_mass_constant = Quantity("atomic_mass_constant", mass, 1.660539040e-24*gram)
+amu = amus = atomic_mass_unit = atomic_mass_constant = Quantity(
+    "atomic_mass_constant", mass, 1.660539040e-24*gram)
 # Molar gas constant
-R = molar_gas_constant = Quantity("molar_gas_constant", energy/(temperature * amount_of_substance),
+R = molar_gas_constant = Quantity("molar_gas_constant",
+                                  energy/(temperature*amount_of_substance),
                                   8.3144598*joule/kelvin/mol, abbrev="R")
 # Faraday constant
-faraday_constant = Quantity("faraday_constant", charge/amount_of_substance, 96485.33289*C/mol)
+faraday_constant = Quantity("faraday_constant", charge/amount_of_substance,
+                            96485.33289*C/mol)
 # Josephson constant
-josephson_constant = Quantity("josephson_constant", frequency/voltage, 483597.8525e9*hertz/V, abbrev="K_j")
+josephson_constant = Quantity("josephson_constant", frequency/voltage,
+                              483597.8525e9*hertz/V, abbrev="K_j")
 # Von Klitzing constant
-von_klitzing_constant = Quantity("von_klitzing_constant", voltage/current, 25812.8074555*ohm, abbrev="R_k")
+von_klitzing_constant = Quantity("von_klitzing_constant", voltage/current,
+                                 25812.8074555*ohm, abbrev="R_k")
 # Acceleration due to gravity (on the Earth surface)
-gee = gees = acceleration_due_to_gravity = Quantity("acceleration_due_to_gravity", acceleration, 9.80665*meter/second**2, "g")
+gee = gees = acceleration_due_to_gravity = Quantity(
+    "acceleration_due_to_gravity", acceleration, 9.80665*meter/second**2, "g")
 # magnetic constant:
-u0 = magnetic_constant = Quantity("magnetic_constant", force/current**2, 4*pi/10**7 * newton/ampere**2)
+u0 = magnetic_constant = Quantity("magnetic_constant", force/current**2,
+                                  4*pi/10**7*newton/ampere**2)
 # electric constat:
-e0 = electric_constant = vacuum_permittivity = Quantity("vacuum_permittivity", capacitance/length, 1/(u0 * c**2))
+e0 = electric_constant = vacuum_permittivity = Quantity(
+    "vacuum_permittivity", capacitance/length, 1/(u0*c**2))
 # vacuum impedance:
-Z0 = vacuum_impedance = Quantity("vacuum_impedance", impedance, u0 * c)
+Z0 = vacuum_impedance = Quantity("vacuum_impedance", impedance, u0*c)
 # Coulomb's constant:
-coulomb_constant = electric_force_constant = Quantity("coulomb_constant", force*length**2/charge**2, 1/(4*pi*vacuum_permittivity), "k_e")
+coulomb_constant = electric_force_constant = Quantity(
+    "coulomb_constant", force*length**2/charge**2,
+    1/(4*pi*vacuum_permittivity), "k_e")
 
-atmosphere = atmospheres = atm = Quantity("atmosphere", pressure, 101325 * pascal, "atm")
+atmosphere = atmospheres = atm = Quantity("atmosphere", pressure,
+                                          101325*pascal, "atm")
 
 kPa = kilopascal = Quantity("kilopascal", pressure, kilo*Pa, "kPa")
 bar = bars = Quantity("bar", pressure, 100*kPa, "bar")
-pound = pounds = Quantity("pound", mass, 0.45359237 * kg)  # exact
-psi = Quantity("psi", pressure, pound * gee / inch ** 2)
+pound = pounds = Quantity("pound", mass, 0.45359237*kg)  # exact
+psi = Quantity("psi", pressure, pound*gee/inch**2)
 dHg0 = 13.5951  # approx value at 0 C
-mmHg = torr = Quantity("mmHg", pressure, dHg0 * acceleration_due_to_gravity * kilogram / meter**2)
-mmu = mmus = milli_mass_unit = Quantity("milli_mass_unit", mass, atomic_mass_unit/1000)
-quart = quarts = Quantity("quart", length**3, Rational(231, 4) * inch**3)
+mmHg = torr = Quantity("mmHg", pressure,
+                       dHg0*acceleration_due_to_gravity*kilogram/meter**2)
+mmu = mmus = milli_mass_unit = Quantity("milli_mass_unit", mass,
+                                        atomic_mass_unit/1000)
+quart = quarts = Quantity("quart", length**3, Rational(231, 4)*inch**3)
 
 # Other convenient units and magnitudes
 
-ly = lightyear = lightyears = Quantity("lightyear", length, speed_of_light*julian_year, "ly")
-au = astronomical_unit = astronomical_units = Quantity("astronomical_unit", length, 149597870691*meter, "AU")
+ly = lightyear = lightyears = Quantity("lightyear", length,
+                                       speed_of_light*julian_year, "ly")
+au = astronomical_unit = astronomical_units = Quantity(
+    "astronomical_unit", length, 149597870691*meter, "AU")
 
 # Planck units:
 planck_mass = Quantity("planck_mass", mass, sqrt(hbar*speed_of_light/G), "m_P")
-planck_time = Quantity("planck_time", time, sqrt(hbar*G/speed_of_light**5), "t_P")
-planck_temperature = Quantity("planck_temperature", temperature, sqrt(hbar*speed_of_light**5/G/boltzmann**2), "T_P")
-planck_length = Quantity("planck_length", length, sqrt(hbar*G/speed_of_light**3), "l_P")
+planck_time = Quantity("planck_time", time,
+                       sqrt(hbar*G/speed_of_light**5), "t_P")
+planck_temperature = Quantity("planck_temperature", temperature,
+                              sqrt(hbar*speed_of_light**5/G/boltzmann**2),
+                              "T_P")
+planck_length = Quantity("planck_length", length,
+                         sqrt(hbar*G/speed_of_light**3), "l_P")
 # TODO: add more from https://en.wikipedia.org/wiki/Planck_units

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -1,5 +1,4 @@
 # -*- coding:utf-8 -*-
-
 """
 Definition of physical dimensions.
 
@@ -77,7 +76,8 @@ class Dimension(Expr):
             name = sympify(name)
 
         if not isinstance(name, Expr):
-            raise TypeError("Dimension name needs to be a valid math expression")
+            raise TypeError(
+                "Dimension name needs to be a valid math expression")
 
         if isinstance(symbol, string_types):
             symbol = Symbol(symbol)
@@ -106,7 +106,8 @@ class Dimension(Expr):
 
     def __eq__(self, other):
         if isinstance(other, Dimension):
-            return self.get_dimensional_dependencies() == other.get_dimensional_dependencies()
+            return self.get_dimensional_dependencies(
+            ) == other.get_dimensional_dependencies()
         return False
 
     def __str__(self):
@@ -141,8 +142,8 @@ class Dimension(Expr):
         """
 
         if not isinstance(other, Dimension):
-            raise TypeError("Only dimension can be added; '%s' is not valid"
-                            % type(other))
+            raise TypeError(
+                "Only dimension can be added; '%s' is not valid" % type(other))
         elif isinstance(other, Dimension) and self != other:
             raise ValueError("Only dimension which are equal can be added; "
                              "'%s' and '%s' are different" % (self, other))
@@ -174,7 +175,7 @@ class Dimension(Expr):
         return Dimension(self.name/other.name)
 
     def __rdiv__(self, other):
-        return other * pow(self, -1)
+        return other*pow(self, -1)
 
     __truediv__ = __div__
     __rtruediv__ = __rdiv__
@@ -200,7 +201,10 @@ class Dimension(Expr):
 
         if name.is_Mul:
             ret = collections.defaultdict(int)
-            dicts = [Dimension._get_dimensional_dependencies_for_name(i) for i in name.args]
+            dicts = [
+                Dimension._get_dimensional_dependencies_for_name(i)
+                for i in name.args
+            ]
             for d in dicts:
                 for k, v in d.items():
                     ret[k] += v
@@ -292,24 +296,33 @@ luminous_intensity._register_as_base_dim()
 # Dimensional dependencies for derived dimensions
 Dimension._dimensional_dependencies["velocity"] = dict(length=1, time=-1)
 Dimension._dimensional_dependencies["acceleration"] = dict(length=1, time=-2)
-Dimension._dimensional_dependencies["momentum"] = dict(mass=1, length=1, time=-1)
+Dimension._dimensional_dependencies["momentum"] = dict(mass=1, length=1,
+                                                       time=-1)
 Dimension._dimensional_dependencies["force"] = dict(mass=1, length=1, time=-2)
 Dimension._dimensional_dependencies["energy"] = dict(mass=1, length=2, time=-2)
 Dimension._dimensional_dependencies["power"] = dict(length=2, mass=1, time=-3)
-Dimension._dimensional_dependencies["pressure"] = dict(mass=1, length=-1, time=-2)
+Dimension._dimensional_dependencies["pressure"] = dict(mass=1, length=-1,
+                                                       time=-2)
 Dimension._dimensional_dependencies["frequency"] = dict(time=-1)
 Dimension._dimensional_dependencies["action"] = dict(length=2, mass=1, time=-1)
 Dimension._dimensional_dependencies["volume"] = dict(length=3)
 
 # Dimensional dependencies for derived dimensions
-Dimension._dimensional_dependencies["voltage"] = dict(mass=1, length=2, current=-1, time=-3)
-Dimension._dimensional_dependencies["impedance"] = dict(mass=1, length=2, current=-2, time=-3)
-Dimension._dimensional_dependencies["conductance"] = dict(mass=-1, length=-2, current=2, time=3)
-Dimension._dimensional_dependencies["capacitance"] = dict(mass=-1, length=-2, current=2, time=4)
-Dimension._dimensional_dependencies["inductance"] = dict(mass=1, length=2, current=-2, time=-2)
+Dimension._dimensional_dependencies["voltage"] = dict(mass=1, length=2,
+                                                      current=-1, time=-3)
+Dimension._dimensional_dependencies["impedance"] = dict(
+    mass=1, length=2, current=-2, time=-3)
+Dimension._dimensional_dependencies["conductance"] = dict(
+    mass=-1, length=-2, current=2, time=3)
+Dimension._dimensional_dependencies["capacitance"] = dict(
+    mass=-1, length=-2, current=2, time=4)
+Dimension._dimensional_dependencies["inductance"] = dict(
+    mass=1, length=2, current=-2, time=-2)
 Dimension._dimensional_dependencies["charge"] = dict(current=1, time=1)
-Dimension._dimensional_dependencies["magnetic_density"] = dict(mass=1, current=-1, time=-2)
-Dimension._dimensional_dependencies["magnetic_flux"] = dict(length=2, mass=1, current=-1, time=-2)
+Dimension._dimensional_dependencies["magnetic_density"] = dict(
+    mass=1, current=-1, time=-2)
+Dimension._dimensional_dependencies["magnetic_flux"] = dict(
+    length=2, mass=1, current=-1, time=-2)
 
 
 class DimensionSystem(object):
@@ -348,8 +361,8 @@ class DimensionSystem(object):
         self._dims = tuple(set(base) | set(dims))
 
         if self.is_consistent is False:
-            raise ValueError("The system with basis '%s' is not consistent"
-                             % str(self._base_dims))
+            raise ValueError("The system with basis '%s' is not consistent" %
+                             str(self._base_dims))
 
     def __str__(self):
         """
@@ -362,7 +375,8 @@ class DimensionSystem(object):
         if self.name != "":
             return self.name
         else:
-            return "DimensionSystem(%s)" % ", ".join(str(d) for d in self._base_dims)
+            return "DimensionSystem(%s)" % ", ".join(
+                str(d) for d in self._base_dims)
 
     def __repr__(self):
         return "<DimensionSystem: %s>" % repr(self._base_dims)
@@ -410,7 +424,8 @@ class DimensionSystem(object):
                     break
         elif isinstance(dim, Dimension):
             for i, idim in enumerate(self._dims):
-                if dim.get_dimensional_dependencies() == idim.get_dimensional_dependencies():
+                if dim.get_dimensional_dependencies(
+                ) == idim.get_dimensional_dependencies():
                     return idim
 
         return found_dim
@@ -483,8 +498,7 @@ class DimensionSystem(object):
         #TODO: the inversion will fail if the system is inconsistent, for
         #      example if the matrix is not a square
         return reduce(lambda x, y: x.row_join(y),
-                      [self.dim_can_vector(d) for d in self._base_dims]
-                      ).inv()
+                      [self.dim_can_vector(d) for d in self._base_dims]).inv()
 
     def dim_can_vector(self, dim):
         """
@@ -501,14 +515,17 @@ class DimensionSystem(object):
         """
         Vector representation in terms of the base dimensions.
         """
-        return self.can_transf_matrix * Matrix(self.dim_can_vector(dim))
+        return self.can_transf_matrix*Matrix(self.dim_can_vector(dim))
 
     def print_dim_base(self, dim):
         """
         Give the string expression of a dimension in term of the basis symbols.
         """
         dims = self.dim_vector(dim)
-        symbols = [i.symbol if i.symbol is not None else i.name for i in self._base_dims]
+        symbols = [
+            i.symbol if i.symbol is not None else i.name
+            for i in self._base_dims
+        ]
         res = S.One
         for (s, p) in zip(symbols, dims):
             res *= s**p

--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 Module defining unit prefixe class and some constants.
 
@@ -64,16 +63,17 @@ class Prefix(Expr):
     def __str__(self):
         # TODO: add proper printers and tests:
         if self.base == 10:
-            return "Prefix(%r, %r, %r)" % (
-                str(self.name), str(self.abbrev), self._exponent)
+            return "Prefix(%r, %r, %r)" % (str(self.name), str(self.abbrev),
+                                           self._exponent)
         else:
-            return "Prefix(%r, %r, %r, %r)" % (
-                str(self.name), str(self.abbrev), self._exponent, self.base)
+            return "Prefix(%r, %r, %r, %r)" % (str(self.name),
+                                               str(self.abbrev),
+                                               self._exponent, self.base)
 
     __repr__ = __str__
 
     def __mul__(self, other):
-        fact = self.scale_factor * other.scale_factor
+        fact = self.scale_factor*other.scale_factor
 
         if fact == 1:
             return 1
@@ -84,10 +84,10 @@ class Prefix(Expr):
                     return PREFIXES[p]
             return fact
 
-        return self.scale_factor * other
+        return self.scale_factor*other
 
     def __div__(self, other):
-        fact = self.scale_factor / other.scale_factor
+        fact = self.scale_factor/other.scale_factor
 
         if fact == 1:
             return 1
@@ -97,16 +97,16 @@ class Prefix(Expr):
                     return PREFIXES[p]
             return fact
 
-        return self.scale_factor / other
+        return self.scale_factor/other
 
     __truediv__ = __div__
 
     def __rdiv__(self, other):
         if other == 1:
             for p in PREFIXES:
-                if PREFIXES[p].scale_factor == 1 / self.scale_factor:
+                if PREFIXES[p].scale_factor == 1/self.scale_factor:
                     return PREFIXES[p]
-        return other / self.scale_factor
+        return other/self.scale_factor
 
     __rtruediv__ = __rdiv__
 
@@ -132,8 +132,10 @@ def prefix_unit(unit, prefixes):
     prefixed_units = []
 
     for prefix_abbr, prefix in prefixes.items():
-        prefixed_units.append(Quantity("%s%s" % (prefix.name, unit.name), unit.dimension, unit.scale_factor * prefix,
-                                       "%s%s" % (prefix.abbrev, unit.abbrev)))
+        prefixed_units.append(
+            Quantity("%s%s" % (prefix.name, unit.name), unit.dimension,
+                     unit.scale_factor*prefix, "%s%s" % (prefix.abbrev,
+                                                         unit.abbrev)))
 
     return prefixed_units
 
@@ -159,7 +161,6 @@ atto = Prefix('atto', 'a', -18)
 zepto = Prefix('zepto', 'z', -21)
 yocto = Prefix('yocto', 'y', -24)
 
-
 # http://physics.nist.gov/cuu/Units/prefixes.html
 PREFIXES = {
     'Y': yotta,
@@ -184,14 +185,12 @@ PREFIXES = {
     'y': yocto,
 }
 
-
 kibi = Prefix('kibi', 'Y', 10, 2)
 mebi = Prefix('mebi', 'Y', 20, 2)
 gibi = Prefix('gibi', 'Y', 30, 2)
 tebi = Prefix('tebi', 'Y', 40, 2)
 pebi = Prefix('pebi', 'Y', 50, 2)
 exbi = Prefix('exbi', 'Y', 60, 2)
-
 
 # http://physics.nist.gov/cuu/Units/binary.html
 BIN_PREFIXES = {

--- a/sympy/physics/units/systems/SI.py
+++ b/sympy/physics/units/systems/SI.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 SI unit system.
 Based on MKSA, which stands for "meter, kilogram, second, ampere".
@@ -31,7 +30,6 @@ base_dims = (amount_of_substance, luminous_intensity, temperature)
 
 # dimension system
 _si_dim = _mksa_dim.extend(base=base_dims, dims=derived_dims, name='SI')
-
 
 units = [mol, cd, K, lux]
 all_units = []

--- a/sympy/physics/units/systems/mks.py
+++ b/sympy/physics/units/systems/mks.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 MKS unit system.
 

--- a/sympy/physics/units/systems/mksa.py
+++ b/sympy/physics/units/systems/mksa.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 MKS unit system.
 
@@ -19,8 +18,7 @@ dims = (voltage, impedance, conductance, capacitance, inductance, charge,
         magnetic_density, magnetic_flux)
 
 # dimension system
-_mksa_dim = _mks_dim.extend(base=(current,), dims=dims, name='MKSA')
-
+_mksa_dim = _mks_dim.extend(base=(current, ), dims=dims, name='MKSA')
 
 units = [A, V, ohm, S, F, H, C, T, Wb]
 all_units = []
@@ -29,4 +27,4 @@ for u in units:
 
 all_units.extend([Z0])
 
-MKSA = MKS.extend(base=(A,), units=all_units, name='MKSA')
+MKSA = MKS.extend(base=(A, ), units=all_units, name='MKSA')

--- a/sympy/physics/units/systems/natural.py
+++ b/sympy/physics/units/systems/natural.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # -*- coding: utf-8 -*-
-
 """
 Naturalunit system.
 
@@ -22,7 +21,7 @@ dims = (length, mass, time, momentum, force, energy, power, frequency)
 
 # dimension system
 _natural_dim = DimensionSystem(base=(action, energy, velocity), dims=dims,
-                              name="Natural system")
+                               name="Natural system")
 
 units = prefix_unit(eV, PREFIXES)
 

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -64,26 +64,35 @@ def test_add_sub():
 
 
 def test_mul_div_exp():
-    velo = length / time
+    velo = length/time
 
-    assert (length * length) == length ** 2
+    assert (length*length) == length**2
 
-    assert (length * length).get_dimensional_dependencies() == {"length": 2}
-    assert (length ** 2).get_dimensional_dependencies() == {"length": 2}
-    assert (length * time).get_dimensional_dependencies() == { "length": 1, "time": 1}
-    assert velo.get_dimensional_dependencies() == { "length": 1, "time": -1}
-    assert (velo ** 2).get_dimensional_dependencies() == {"length": 2, "time": -2}
+    assert (length*length).get_dimensional_dependencies() == {"length": 2}
+    assert (length**2).get_dimensional_dependencies() == {"length": 2}
+    assert (length*time).get_dimensional_dependencies() == {
+        "length": 1,
+        "time": 1
+    }
+    assert velo.get_dimensional_dependencies() == {"length": 1, "time": -1}
+    assert (velo**2).get_dimensional_dependencies() == {
+        "length": 2,
+        "time": -2
+    }
 
-    assert (length / length).get_dimensional_dependencies() == {}
-    assert (velo / length * time).get_dimensional_dependencies() == {}
-    assert (length ** -1).get_dimensional_dependencies() == {"length": -1}
-    assert (velo ** -1.5).get_dimensional_dependencies() == {"length": -1.5, "time": 1.5}
+    assert (length/length).get_dimensional_dependencies() == {}
+    assert (velo/length*time).get_dimensional_dependencies() == {}
+    assert (length**-1).get_dimensional_dependencies() == {"length": -1}
+    assert (velo**-1.5).get_dimensional_dependencies() == {
+        "length": -1.5,
+        "time": 1.5
+    }
 
     length_a = length**"a"
     assert length_a.get_dimensional_dependencies() == {"length": Symbol("a")}
 
     assert length != 1
-    assert length / length != 1
+    assert length/length != 1
 
-    length_0 = length ** 0
+    length_0 = length**0
     assert length_0.get_dimensional_dependencies() == {}

--- a/sympy/physics/units/tests/test_dimensionsystem.py
+++ b/sympy/physics/units/tests/test_dimensionsystem.py
@@ -10,10 +10,10 @@ from sympy.utilities.pytest import raises
 def test_definition():
 
     base = (length, time)
-    ms = DimensionSystem(base, (velocity,), "MS", "MS system")
+    ms = DimensionSystem(base, (velocity, ), "MS", "MS system")
 
     assert ms._base_dims == DimensionSystem.sort_dims(base)
-    assert set(ms._dims) == set(base + (velocity,))
+    assert set(ms._dims) == set(base + (velocity, ))
     assert ms.name == "MS"
     assert ms.descr == "MS system"
 
@@ -26,19 +26,20 @@ def test_error_definition():
 def test_str_repr():
     assert str(DimensionSystem((length, time), name="MS")) == "MS"
     dimsys = DimensionSystem((length, time))
-    assert str(dimsys) == 'DimensionSystem(Dimension(length, L), Dimension(time, T))'
+    assert str(
+        dimsys) == 'DimensionSystem(Dimension(length, L), Dimension(time, T))'
 
-    assert (repr(DimensionSystem((length, time), name="MS"))
-            == '<DimensionSystem: (Dimension(length, L), Dimension(time, T))>')
+    assert (repr(DimensionSystem((length, time), name="MS")) ==
+            '<DimensionSystem: (Dimension(length, L), Dimension(time, T))>')
 
 
 def test_call():
-    mksa = DimensionSystem((length, time, mass, current), (action,))
+    mksa = DimensionSystem((length, time, mass, current), (action, ))
     assert mksa(action) == mksa.print_dim_base(action)
 
 
 def test_get_dim():
-    ms = DimensionSystem((length, time), (velocity,))
+    ms = DimensionSystem((length, time), (velocity, ))
 
     assert ms.get_dim("L") == length
     assert ms.get_dim("length") == length
@@ -49,9 +50,9 @@ def test_get_dim():
 
 
 def test_extend():
-    ms = DimensionSystem((length, time), (velocity,))
+    ms = DimensionSystem((length, time), (velocity, ))
 
-    mks = ms.extend((mass,), (action,))
+    mks = ms.extend((mass, ), (action, ))
 
     res = DimensionSystem((length, time, mass), (velocity, action))
     assert mks._base_dims == res._base_dims
@@ -60,8 +61,8 @@ def test_extend():
 
 def test_sort_dims():
 
-    assert (DimensionSystem.sort_dims((length, velocity, time))
-                                      == (length, time, velocity))
+    assert (DimensionSystem.sort_dims((length, velocity,
+                                       time)) == (length, time, velocity))
 
 
 def test_list_dims():
@@ -101,7 +102,8 @@ def test_inv_can_transf_matrix():
     assert dimsys.inv_can_transf_matrix == eye(3)
 
     dimsys = DimensionSystem((length, velocity, action))
-    assert dimsys.inv_can_transf_matrix == Matrix([[2, 1, 1], [1, 0, 0], [-1, 0, -1]])
+    assert dimsys.inv_can_transf_matrix == Matrix([[2, 1, 1], [1, 0, 0],
+                                                   [-1, 0, -1]])
 
 
 def test_can_transf_matrix():
@@ -110,7 +112,8 @@ def test_can_transf_matrix():
     assert dimsys.can_transf_matrix == eye(3)
 
     dimsys = DimensionSystem((length, velocity, action))
-    assert dimsys.can_transf_matrix == Matrix([[0, 1, 0], [1, -1, 1], [0, -1, -1]])
+    assert dimsys.can_transf_matrix == Matrix([[0, 1, 0], [1, -1, 1],
+                                               [0, -1, -1]])
 
 
 def test_is_consistent():
@@ -119,7 +122,7 @@ def test_is_consistent():
 
 
 def test_print_dim_base():
-    mksa = DimensionSystem((length, time, mass, current), (action,))
+    mksa = DimensionSystem((length, time, mass, current), (action, ))
     L, M, T = symbols("L M T")
     assert mksa.print_dim_base(action) == L**2*M/T
 

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from sympy import symbols, log
-from sympy.physics.units import Quantity, Dimension
-from sympy.physics.units.prefixes import PREFIXES, Prefix, prefix_unit, kilo, \
-    kibi
+from sympy import log, symbols
+from sympy.physics.units import Dimension, Quantity
+from sympy.physics.units.prefixes import (
+    PREFIXES, Prefix, kibi, kilo, prefix_unit)
 
 
 def test_prefix_operations():
@@ -12,18 +12,18 @@ def test_prefix_operations():
 
     dodeca = Prefix('dodeca', 'dd', 1, base=12)
 
-    assert m * k == 1
-    assert k * k == M
-    assert 1 / m == k
-    assert k / m == M
+    assert m*k == 1
+    assert k*k == M
+    assert 1/m == k
+    assert k/m == M
 
-    assert dodeca * dodeca == 144
-    assert 1 / dodeca == 1 / 12
-    assert k / dodeca == 1000 / 12
-    assert dodeca / dodeca == 1
+    assert dodeca*dodeca == 144
+    assert 1/dodeca == 1/12
+    assert k/dodeca == 1000/12
+    assert dodeca/dodeca == 1
 
     m = Quantity("meter", 1, 6)
-    assert dodeca / m == 12 / m
+    assert dodeca/m == 12/m
 
 
 def test_prefix_unit():
@@ -32,9 +32,11 @@ def test_prefix_unit():
 
     pref = {"m": PREFIXES["m"], "c": PREFIXES["c"], "d": PREFIXES["d"]}
 
-    res = [Quantity("millimeter", length, PREFIXES["m"], "mm"),
-           Quantity("centimeter", length, PREFIXES["c"], "cm"),
-           Quantity("decimeter", length, PREFIXES["d"], "dm")]
+    res = [
+        Quantity("millimeter", length, PREFIXES["m"], "mm"),
+        Quantity("centimeter", length, PREFIXES["c"], "cm"),
+        Quantity("decimeter", length, PREFIXES["d"], "dm")
+    ]
 
     prefs = prefix_unit(m, pref)
     assert set(prefs) == set(res)

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -22,6 +22,7 @@ k = PREFIXES["k"]
 def test_str_repr():
     assert str(kg) == "kilogram"
 
+
 def test_eq():
     # simple test
     assert 10*m == 10*m
@@ -32,7 +33,7 @@ def test_convert_to():
     q = Quantity("q1", length, 5000)
     assert q.convert_to(m) == 5000*m
 
-    assert speed_of_light.convert_to(m / s) == 299792458 * m / s
+    assert speed_of_light.convert_to(m/s) == 299792458*m/s
     # TODO: eventually support this kind of conversion:
     # assert (2*speed_of_light).convert_to(m / s) == 2 * 299792458 * m / s
     assert day.convert_to(s) == 86400*s
@@ -62,7 +63,7 @@ def test_Quantity_definition():
 
     v = Quantity("u", length, 5*kilo)
     assert v.dimension == length
-    assert v.scale_factor == 5 * 1000
+    assert v.scale_factor == 5*1000
 
     raises(ValueError, lambda: Quantity('invalid', 'dimension', 1))
     raises(ValueError, lambda: Quantity('mismatch', length, kg))
@@ -135,11 +136,11 @@ def test_check_unit_consistency():
 def test_mul_div():
     u = Quantity("u", length, 10)
 
-    assert 1 / u == u**(-1)
-    assert u / 1 == u
+    assert 1/u == u**(-1)
+    assert u/1 == u
 
-    v1 = u / Quantity("t", time, 2)
-    v2 = Quantity("v", length / time, 5)
+    v1 = u/Quantity("t", time, 2)
+    v2 = Quantity("v", length/time, 5)
 
     # Pow only supports structural equality:
     assert v1 != v2
@@ -149,9 +150,9 @@ def test_mul_div():
     # (requires somehow manipulating the core).
     # assert u / Quantity('l2', length, 2) == 5
 
-    assert u * 1 == u
+    assert u*1 == u
 
-    ut1 = u * Quantity("t", time, 2)
+    ut1 = u*Quantity("t", time, 2)
     ut2 = Quantity("ut", length*time, 20)
 
     # Mul only supports structural equality:
@@ -159,29 +160,29 @@ def test_mul_div():
     assert ut1 == ut2.convert_to(ut1)
 
     # Mul only supports structural equality:
-    assert u * Quantity("lp1", length**-1, 2) != 20
+    assert u*Quantity("lp1", length**-1, 2) != 20
 
     assert u**0 == 1
     assert u**1 == u
     # TODO: Pow only support structural equality:
-    assert u ** 2 != Quantity("u2", length ** 2, 100)
-    assert u ** -1 != Quantity("u3", length ** -1, 0.1)
+    assert u**2 != Quantity("u2", length**2, 100)
+    assert u**-1 != Quantity("u3", length**-1, 0.1)
 
-    assert u ** 2 == Quantity("u2", length ** 2, 100).convert_to(u)
-    assert u ** -1 == Quantity("u3", length ** -1, S.One/10).convert_to(u)
+    assert u**2 == Quantity("u2", length**2, 100).convert_to(u)
+    assert u**-1 == Quantity("u3", length**-1, S.One/10).convert_to(u)
 
 
 def test_units():
-    assert convert_to((5*m/s * day) / km, 1) == 432
-    assert convert_to(foot / meter, meter) == Rational('0.3048')
+    assert convert_to((5*m/s*day)/km, 1) == 432
+    assert convert_to(foot/meter, meter) == Rational('0.3048')
     # amu is a pure mass so mass/mass gives a number, not an amount (mol)
     # TODO: need better simplification routine:
     assert str(convert_to(grams/amu, grams).n(2)) == '6.0e+23'
 
     # Light from the sun needs about 8.3 minutes to reach earth
-    t = (1*au / speed_of_light) / minute
+    t = (1*au/speed_of_light)/minute
     # TODO: need a better way to simplify expressions containing units:
-    t = convert_to(convert_to(t, meter / minute), meter)
+    t = convert_to(convert_to(t, meter/minute), meter)
     assert t == 49865956897/5995849160
 
     # TODO: fix this, it should give `m` without `Abs`
@@ -190,12 +191,12 @@ def test_units():
 
     t = Symbol('t')
     assert integrate(t*m/s, (t, 1*s, 5*s)) == 12*m*s
-    assert (t * m/s).integrate((t, 1*s, 5*s)) == 12*m*s
+    assert (t*m/s).integrate((t, 1*s, 5*s)) == 12*m*s
 
 
 def test_issue_quart():
-    assert convert_to(4 * quart / inch ** 3, meter) == 231
-    assert convert_to(4 * quart / inch ** 3, millimeter) == 231
+    assert convert_to(4*quart/inch**3, meter) == 231
+    assert convert_to(4*quart/inch**3, millimeter) == 231
 
 
 def test_issue_5565():
@@ -214,14 +215,16 @@ def test_find_unit():
         'kilometer', 'lightyear', 'nanometer', 'picometer', 'centimeter',
         'decimeters', 'kilometers', 'lightyears', 'micrometer', 'millimeter',
         'nanometers', 'picometers', 'centimeters', 'micrometers',
-        'millimeters', 'nautical_mile', 'planck_length', 'nautical_miles', 'astronomical_unit',
-        'astronomical_units']
+        'millimeters', 'nautical_mile', 'planck_length', 'nautical_miles',
+        'astronomical_unit', 'astronomical_units'
+    ]
     assert find_unit(inch**-1) == ['D', 'dioptre', 'optical_power']
     assert find_unit(length**-1) == ['D', 'dioptre', 'optical_power']
-    assert find_unit(inch ** 3) == [
+    assert find_unit(inch**3) == [
         'l', 'cl', 'dl', 'ml', 'liter', 'quart', 'liters', 'quarts',
-        'deciliter', 'centiliter', 'deciliters', 'milliliter',
-        'centiliters', 'milliliters']
+        'deciliter', 'centiliter', 'deciliters', 'milliliter', 'centiliters',
+        'milliliters'
+    ]
     assert find_unit('voltage') == ['V', 'v', 'volt', 'volts']
 
 
@@ -235,12 +238,12 @@ def test_Quantity_derivative():
 
 def test_sum_of_incompatible_quantities():
     raises(ValueError, lambda: meter + second)
-    raises(ValueError, lambda: 2 * meter + second)
-    raises(ValueError, lambda: 2 * meter + 3 * second)
-    raises(ValueError, lambda: 1 / second + 1 / meter)
-    raises(ValueError, lambda: 2 * meter*(mile + centimeter) + km)
+    raises(ValueError, lambda: 2*meter + second)
+    raises(ValueError, lambda: 2*meter + 3*second)
+    raises(ValueError, lambda: 1/second + 1/meter)
+    raises(ValueError, lambda: 2*meter*(mile + centimeter) + km)
 
-    expr = 2 * (mile + centimeter)/second + km/hour
+    expr = 2*(mile + centimeter)/second + km/hour
     assert expr in Basic._constructor_postprocessor_mapping
     for i in expr.args:
         assert i in Basic._constructor_postprocessor_mapping
@@ -253,14 +256,15 @@ def test_factor_and_dimension():
         meter/second + 36*km/(10*hour))
 
     x, y = symbols('x y')
-    assert (x + y/100, length) == Quantity._collect_factor_and_dimension(
-        x*m + y*centimeter)
+    assert (
+        x + y/100,
+        length) == Quantity._collect_factor_and_dimension(x*m + y*centimeter)
 
     cH = Quantity('cH', amount_of_substance/volume)
     pH = -log(cH)
 
-    assert (1, volume/amount_of_substance) == Quantity._collect_factor_and_dimension(
-        exp(pH))
+    assert (1, volume/amount_of_substance
+            ) == Quantity._collect_factor_and_dimension(exp(pH))
 
     v_w1 = Quantity('v_w1', length/time, S(3)/2*meter/second)
     v_w2 = Quantity('v_w2', length/time, 2*meter/second)
@@ -285,7 +289,7 @@ def test_factor_and_dimension_with_Abs():
 
 
 def test_dimensional_expr_of_derivative():
-    l = Quantity('l', length, 36 * km)
+    l = Quantity('l', length, 36*km)
     t = Quantity('t', time, hour)
     t1 = Quantity('t1', time, second)
     x = Symbol('x')

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -23,7 +23,7 @@ def test_definition():
     assert ms.descr == "MS system"
 
     assert ms._system._base_dims == DimensionSystem.sort_dims(base_dim)
-    assert set(ms._system._dims) == set(base_dim + (velocity,))
+    assert set(ms._system._dims) == set(base_dim + (velocity, ))
 
 
 def test_error_definition():
@@ -40,15 +40,15 @@ def test_str_repr():
 def test_print_unit_base():
     A = Quantity("A", current, 1)
     Js = Quantity("Js", action, 1)
-    mksa = UnitSystem((m, kg, s, A), (Js,))
+    mksa = UnitSystem((m, kg, s, A), (Js, ))
 
     assert mksa.print_unit_base(Js) == m**2*kg*s**-1/1000
 
 
 def test_extend():
-    ms = UnitSystem((m, s), (c,))
+    ms = UnitSystem((m, s), (c, ))
     Js = Quantity("Js", action, 1)
-    mks = ms.extend((kg,), (Js,))
+    mks = ms.extend((kg, ), (Js, ))
 
     res = UnitSystem((m, s, kg), (c, Js))
     assert set(mks._base_units) == set(res._base_units)
@@ -56,7 +56,7 @@ def test_extend():
 
 
 def test_dim():
-    dimsys = UnitSystem((m, kg, s), (c,))
+    dimsys = UnitSystem((m, kg, s), (c, ))
     assert dimsys.dim == 3
 
 

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -36,14 +36,18 @@ def test_dim_simplify_pow():
 
 def test_dim_simplify_rec():
     assert dim_simplify(Mul(Add(L, L), T)) == L*T
-    assert dim_simplify((L + L) * T) == L*T
+    assert dim_simplify((L + L)*T) == L*T
 
 
 def test_dim_simplify_dimless():
     # TODO: this should be somehow simplified on its own,
     # without the need of calling `dim_simplify`:
-    assert dim_simplify(sin(L*L**-1)**2*L).get_dimensional_dependencies() == L.get_dimensional_dependencies()
-    assert dim_simplify(sin(L * L**(-1))**2 * L).get_dimensional_dependencies() == L.get_dimensional_dependencies()
+    assert dim_simplify(
+        sin(L*L**-1)**2*
+        L).get_dimensional_dependencies() == L.get_dimensional_dependencies()
+    assert dim_simplify(
+        sin(L*L**(-1))**2*
+        L).get_dimensional_dependencies() == L.get_dimensional_dependencies()
 
 
 def test_convert_to_quantities():
@@ -52,22 +56,27 @@ def test_convert_to_quantities():
     assert convert_to(mile, kilometer) == 1.609344*kilometer
     assert convert_to(meter/second, speed_of_light) == speed_of_light/299792458
     assert convert_to(299792458*meter/second, speed_of_light) == speed_of_light
-    assert convert_to(2*299792458*meter/second, speed_of_light) == 2*speed_of_light
+    assert convert_to(2*299792458*meter/second,
+                      speed_of_light) == 2*speed_of_light
     assert convert_to(speed_of_light, meter/second) == 299792458*meter/second
     assert convert_to(2*speed_of_light, meter/second) == 599584916*meter/second
     assert convert_to(day, second) == 86400*second
     assert convert_to(2*hour, minute) == 120*minute
     assert convert_to(mile, meter) == 1609.344*meter
-    assert convert_to(mile/hour, kilometer/hour) == 25146*kilometer/(15625*hour)
+    assert convert_to(mile/hour,
+                      kilometer/hour) == 25146*kilometer/(15625*hour)
     assert convert_to(3*newton, meter/second) == 3*newton
-    assert convert_to(3*newton, kilogram*meter/second**2) == 3*meter*kilogram/second**2
+    assert convert_to(3*newton,
+                      kilogram*meter/second**2) == 3*meter*kilogram/second**2
     assert convert_to(kilometer + mile, meter) == 2609.344*meter
     assert convert_to(2*kilometer + 3*mile, meter) == 6828.032*meter
     assert convert_to(inch**2, meter**2) == 16129*meter**2/25000000
     assert convert_to(3*inch**2, meter) == 48387*meter**2/25000000
-    assert convert_to(2*kilometer/hour + 3*mile/hour, meter/second) == 53344*meter/(28125*second)
-    assert convert_to(2*kilometer/hour + 3*mile/hour, centimeter/second) == 213376*centimeter/(1125*second)
-    assert convert_to(kilometer * (mile + kilometer), meter) == 2609344 * meter ** 2
+    assert convert_to(2*kilometer/hour + 3*mile/hour,
+                      meter/second) == 53344*meter/(28125*second)
+    assert convert_to(2*kilometer/hour + 3*mile/hour,
+                      centimeter/second) == 213376*centimeter/(1125*second)
+    assert convert_to(kilometer*(mile + kilometer), meter) == 2609344*meter**2
 
     assert convert_to(steradian, coulomb) == steradian
     assert convert_to(radians, degree) == 180*degree/pi
@@ -77,20 +86,33 @@ def test_convert_to_quantities():
 
 
 def test_convert_to_tuples_of_quantities():
-    assert convert_to(speed_of_light, [meter, second]) == 299792458 * meter / second
-    assert convert_to(speed_of_light, (meter, second)) == 299792458 * meter / second
-    assert convert_to(speed_of_light, Tuple(meter, second)) == 299792458 * meter / second
-    assert convert_to(joule, [meter, kilogram, second]) == kilogram*meter**2/second**2
-    assert convert_to(joule, [centimeter, gram, second]) == 10000000*centimeter**2*gram/second**2
-    assert convert_to(299792458*meter/second, [speed_of_light]) == speed_of_light
-    assert convert_to(speed_of_light / 2, [meter, second, kilogram]) == meter/second*299792458 / 2
+    assert convert_to(speed_of_light, [meter,
+                                       second]) == 299792458*meter/second
+    assert convert_to(speed_of_light, (meter,
+                                       second)) == 299792458*meter/second
+    assert convert_to(speed_of_light, Tuple(meter,
+                                            second)) == 299792458*meter/second
+    assert convert_to(joule, [meter, kilogram,
+                              second]) == kilogram*meter**2/second**2
+    assert convert_to(joule, [centimeter, gram,
+                              second]) == 10000000*centimeter**2*gram/second**2
+    assert convert_to(299792458*meter/second,
+                      [speed_of_light]) == speed_of_light
+    assert convert_to(speed_of_light/2, [meter, second,
+                                         kilogram]) == meter/second*299792458/2
     # This doesn't make physically sense, but let's keep it as a conversion test:
-    assert convert_to(2 * speed_of_light, [meter, second, kilogram]) == 2 * 299792458 * meter / second
+    assert convert_to(2*speed_of_light, [meter, second,
+                                         kilogram]) == 2*299792458*meter/second
     assert convert_to(G, [G, speed_of_light, planck]) == 1.0*G
 
-    assert NS(convert_to(meter, [G, speed_of_light, hbar]), n=7) == '6.187242e+34*gravitational_constant**0.5000000*hbar**0.5000000*speed_of_light**(-1.500000)'
+    assert NS(
+        convert_to(meter, [G, speed_of_light, hbar]), n=7
+    ) == '6.187242e+34*gravitational_constant**0.5000000*hbar**0.5000000*speed_of_light**(-1.500000)'
     assert NS(convert_to(planck_mass, kilogram), n=7) == '2.176471e-8*kilogram'
     assert NS(convert_to(planck_length, meter), n=7) == '1.616229e-35*meter'
     assert NS(convert_to(planck_time, second), n=6) == '5.39116e-44*second'
-    assert NS(convert_to(planck_temperature, kelvin), n=7) == '1.416809e+32*kelvin'
-    assert NS(convert_to(convert_to(meter, [G, speed_of_light, planck]), meter), n=10) == '1.000000000*meter'
+    assert NS(convert_to(planck_temperature, kelvin),
+              n=7) == '1.416809e+32*kelvin'
+    assert NS(
+        convert_to(convert_to(meter, [G, speed_of_light, planck]), meter),
+        n=10) == '1.000000000*meter'

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 Unit system for physical quantities; include definition of constants.
 """
@@ -85,10 +84,10 @@ class UnitSystem(object):
         factor = unit.scale_factor
         vec = self._system.dim_vector(unit.dimension)
 
-        for (u, p) in sorted(zip(self._base_units, vec), key=lambda x: x[1],
-                             reverse=True):
+        for (u, p) in sorted(
+                zip(self._base_units, vec), key=lambda x: x[1], reverse=True):
 
-            factor /= u.scale_factor ** p
+            factor /= u.scale_factor**p
             if p == 0:
                 continue
             elif p == 1:
@@ -96,7 +95,7 @@ class UnitSystem(object):
             else:
                 res *= u**p
 
-        return factor * res
+        return factor*res
 
     @property
     def dim(self):


### PR DESCRIPTION
```console
$ pip install pytest pytest-cov pytest-pycodestyle
$ pytest --pep8 --doctest-module --cov=sympy.physics.units --cov-report=term-missing ./sympy/physics/units/
```

Reformatting can be done by running following commands:
```console
$ pip install -e git+https://github.com/jirikuncar/yapf.git@sympy-style
$ yapf -ir sympy/physics/units/  # code style
$ isort -r sympy/physics/units/  # keep sorted imports
```

@asmeurer @moorepants @Upabjojr please let me know if you want to tweak any other formatting option.