### PR TITLE
integrals: fixed bug which produced a wrong result when integrating derivatives

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -888,8 +888,12 @@ def derivative_rule(integral):
         if integral.symbol in diff_variables:
             return DerivativeRule(*integral)
         else:
-            return ParameterDerivativeRule(integral_steps(undifferentiated_function, integral.symbol),
-                                           diff_variables, integrand, integral.symbol)
+            substep = integral_steps(undifferentiated_function,
+                                     integral.symbol)
+            return ParameterDerivativeRule(substep,
+                                           diff_variables,
+                                           integrand,
+                                           integral.symbol)
     else:
         return ConstantRule(integral.integrand, *integral)
 
@@ -1163,12 +1167,9 @@ def eval_derivativerule(integrand, symbol):
     if len(integrand.args) == 2:
         return integrand.args[0]
     else:
-        # we are removing the last occurence of symbol
-        # from the list of differentiating variables
-        diff_vars = tuple(reversed(integrand.args[1:]))
-        symbol_index = diff_vars.index(symbol)
-        diff_vars_symbol_removed = diff_vars[:symbol_index] + diff_vars[symbol_index + 1:]
-        return sympy.Derivative(integrand.args[0], *(reversed(diff_vars_symbol_removed)))
+        new_diff_vars = list(integrand.args[1:])
+        new_diff_vars.remove(symbol)
+        return sympy.Derivative(integrand.args[0], *(new_diff_vars))
 
 @evaluates(ParameterDerivativeRule)
 def eval_paramderivrule(substep, diff_vars, integrand, symbol):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -53,8 +53,6 @@ InverseHyperbolicRule = Rule("InverseHyperbolicRule", "func")
 AlternativeRule = Rule("AlternativeRule", "alternatives")
 DontKnowRule = Rule("DontKnowRule")
 DerivativeRule = Rule("DerivativeRule")
-ParameterDerivativeRule = Rule("ParameterDerivativeRule",
-                               "undiffed vars")
 RewriteRule = Rule("RewriteRule", "rewritten substep")
 PiecewiseRule = Rule("PiecewiseRule", "subfunctions")
 HeavisideRule = Rule("HeavisideRule", "harg ibnd substep")
@@ -888,12 +886,7 @@ def derivative_rule(integral):
         if integral.symbol in diff_variables:
             return DerivativeRule(*integral)
         else:
-            substep = integral_steps(undifferentiated_function,
-                                     integral.symbol)
-            return ParameterDerivativeRule(substep,
-                                           diff_variables,
-                                           integrand,
-                                           integral.symbol)
+            return DontKnowRule(integrand, integral.symbol)
     else:
         return ConstantRule(integral.integrand, *integral)
 
@@ -1170,11 +1163,6 @@ def eval_derivativerule(integrand, symbol):
         new_diff_vars = list(integrand.args[1:])
         new_diff_vars.remove(symbol)
         return sympy.Derivative(integrand.args[0], *(new_diff_vars))
-
-@evaluates(ParameterDerivativeRule)
-def eval_paramderivrule(substep, diff_vars, integrand, symbol):
-    return sympy.Derivative(_manualintegrate(substep), *diff_vars)
-
 
 @evaluates(HeavisideRule)
 def eval_heaviside(harg, ibnd, substep, integrand, symbol):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,12 +1,13 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Integral, integrate, pi, Dummy, Derivative,
                    diff, I, sqrt, erf, Piecewise, Eq, symbols, Rational,
-                   And, Heaviside, S, asinh, acosh, atanh, acoth, expand)
+                   And, Heaviside, S, asinh, acosh, atanh, acoth, expand,
+                   Function)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
     _parts_rule
 
 x, y, z, u, n, a, b, c = symbols('x y z u n a b c')
-
+f = Function('f')
 
 def test_find_substitutions():
     assert find_substitutions((cot(x)**2 + 1)**2*csc(x)**2*cot(x)**2, x, u) == \
@@ -182,7 +183,7 @@ def test_manualintegrate_derivative():
     assert manualintegrate(pi * Derivative(x**2 + 2*x + 3), x) == \
         pi * ((x**2 + 2*x + 3))
     assert manualintegrate(Derivative(x**2 + 2*x + 3, y), x) == \
-        x * Derivative(x**2 + 2*x + 3, y)
+        Derivative(x**3/3 + x**2 + 3*x, y)
     assert manualintegrate(Derivative(sin(x), x, x, y, x), x) == \
         Derivative(sin(x), x, x, y)
 
@@ -316,5 +317,11 @@ def test_issue_10847():
     assert manualintegrate(x**(-3) * log(x), x) == -log(x)/(2*x**2) - 1/(4*x**2)
     assert manualintegrate(log(y)/(y**2*(1 - 1/y)), y) == (-log(y) + log(y - 1))*log(y) + log(y)**2/2 - Integral(log(y - 1)/y, y)
 
-def test_constant_independent_of_symbol():
+def test_issue_12899():
+    assert manualintegrate(f(x,y).diff(x),y) == Derivative(Integral(f(x,y),y),x)
+    assert manualintegrate(f(x,y).diff(y).diff(x),y) == Derivative(f(x,y),x)
+
+
+
+def test_constant_independeint_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -183,7 +183,7 @@ def test_manualintegrate_derivative():
     assert manualintegrate(pi * Derivative(x**2 + 2*x + 3), x) == \
         pi * ((x**2 + 2*x + 3))
     assert manualintegrate(Derivative(x**2 + 2*x + 3, y), x) == \
-        Derivative(x**3/3 + x**2 + 3*x, y)
+        Integral(Derivative(x**2 + 2*x + 3, y))
     assert manualintegrate(Derivative(sin(x), x, x, x, y), x) == \
         Derivative(sin(x), x, x, y)
 
@@ -318,10 +318,9 @@ def test_issue_10847():
     assert manualintegrate(log(y)/(y**2*(1 - 1/y)), y) == (-log(y) + log(y - 1))*log(y) + log(y)**2/2 - Integral(log(y - 1)/y, y)
 
 def test_issue_12899():
-    assert manualintegrate(f(x,y).diff(x),y) == Derivative(Integral(f(x,y),y),x)
+    assert manualintegrate(f(x,y).diff(x),y) == Integral(Derivative(f(x,y),x),y)
     assert manualintegrate(f(x,y).diff(y).diff(x),y) == Derivative(f(x,y),x)
 
 
-
-def test_constant_independeint_of_symbol():
+def test_constant_independent_of_symbol():
     assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -184,7 +184,7 @@ def test_manualintegrate_derivative():
         pi * ((x**2 + 2*x + 3))
     assert manualintegrate(Derivative(x**2 + 2*x + 3, y), x) == \
         Derivative(x**3/3 + x**2 + 3*x, y)
-    assert manualintegrate(Derivative(sin(x), x, x, y, x), x) == \
+    assert manualintegrate(Derivative(sin(x), x, x, x, y), x) == \
         Derivative(sin(x), x, x, y)
 
 


### PR DESCRIPTION
Fixes issue #12899. The original logic was faulty in several ways:
a) treating a derivative with respect to a variable different
from integration symbol as if it was constant.
b) looking only at the last variable of the differentiation.
Fixed a test in test_manual. Added new tests in test_manual
This makes a mild assumption that integration and differentiation commute.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
