### PR TITLE
#6984: Fix bug preventing the use of nullary functions

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -428,7 +428,7 @@ class Function(Application, Expr):
         if not evaluate or not isinstance(result, cls):
             return result
 
-        if len(result.args) > 0:
+        if result.args:
             pr = max(cls._should_evalf(a) for a in result.args)
             pr2 = min(cls._should_evalf(a) for a in result.args)
             if pr2 > 0:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -428,10 +428,11 @@ class Function(Application, Expr):
         if not evaluate or not isinstance(result, cls):
             return result
 
-        pr = max(cls._should_evalf(a) for a in result.args)
-        pr2 = min(cls._should_evalf(a) for a in result.args)
-        if pr2 > 0:
-            return result.evalf(mlib.libmpf.prec_to_dps(pr))
+        if len(result.args) > 0:
+            pr = max(cls._should_evalf(a) for a in result.args)
+            pr2 = min(cls._should_evalf(a) for a in result.args)
+            if pr2 > 0:
+                return result.evalf(mlib.libmpf.prec_to_dps(pr))
         return result
 
     @classmethod

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -425,14 +425,12 @@ class Function(Application, Expr):
 
         evaluate = options.get('evaluate', global_evaluate[0])
         result = super(Function, cls).__new__(cls, *args, **options)
-        if not evaluate or not isinstance(result, cls):
-            return result
-
-        if result.args:
-            pr = max(cls._should_evalf(a) for a in result.args)
+        if evaluate and isinstance(result, cls) and result.args:
             pr2 = min(cls._should_evalf(a) for a in result.args)
             if pr2 > 0:
-                return result.evalf(mlib.libmpf.prec_to_dps(pr))
+                pr = max(cls._should_evalf(a) for a in result.args)
+                result = result.evalf(mlib.libmpf.prec_to_dps(pr))
+
         return result
 
     @classmethod

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -47,6 +47,17 @@ def test_general_function():
     assert edxdx == diff(diff(nu(x), x), x)
     assert edxdy == 0
 
+def test_general_function_nullary():
+    nu = Function('nu')
+
+    e = nu()
+    edx = e.diff(x)
+    edxdx = e.diff(x).diff(x)
+    assert e == nu()
+    assert edx != nu()
+    assert edx == 0
+    assert edxdx == 0
+
 
 def test_derivative_subs_bug():
     e = diff(g(x), x)
@@ -98,6 +109,15 @@ def test_diff_symbols():
 def test_Function():
     class myfunc(Function):
         @classmethod
+        def eval(cls):  # zero args
+            return
+
+    assert myfunc.nargs == FiniteSet(0)
+    assert myfunc().nargs == FiniteSet(0)
+    raises(TypeError, lambda: myfunc(x).nargs)
+
+    class myfunc(Function):
+        @classmethod
         def eval(cls, x):  # one arg
             return
 
@@ -136,6 +156,12 @@ def test_Lambda():
     assert e(x) == x**2
     assert e(y) == y**2
 
+    assert Lambda((), 42)() == 42
+    assert Lambda((), 42) == Lambda((), 42)
+    assert Lambda((), 42) != Lambda((), 43)
+    assert Lambda((), f(x))() == f(x)
+    assert Lambda((), 42).nargs == FiniteSet(0)
+
     assert Lambda(x, x**2) == Lambda(x, x**2)
     assert Lambda(x, x**2) == Lambda(y, y**2)
     assert Lambda(x, x**2) != Lambda(y, y**2 + 1)
@@ -161,6 +187,7 @@ def test_Lambda():
     assert Lambda(x, 1)(1) is S.One
 
 
+
 def test_IdentityFunction():
     assert Lambda(x, x) is Lambda(y, y) is S.IdentityFunction
     assert Lambda(x, 2*x) is not S.IdentityFunction
@@ -170,11 +197,14 @@ def test_IdentityFunction():
 def test_Lambda_symbols():
     assert Lambda(x, 2*x).free_symbols == set()
     assert Lambda(x, x*y).free_symbols == {y}
+    assert Lambda((), 42).free_symbols == set()
+    assert Lambda((), x*y).free_symbols == {x,y}
 
 
 def test_Lambda_arguments():
     raises(TypeError, lambda: Lambda(x, 2*x)(x, y))
     raises(TypeError, lambda: Lambda((x, y), x + y)(x))
+    raises(TypeError, lambda: Lambda((), 42)(x))
 
 
 def test_Lambda_equality():


### PR DESCRIPTION
As mentioned in the linked issue the usefulness of nullary functions is limited, but I have run into this issue twice now and decided to look into how difficult a solution might be.

While the validity of nullary functions was certainly implied before (e.g. by `Function('f').nargs` returning `S.Naturals0`) any attempt to apply that function with no arguments (e.g. `e = f()`) would fail.
The cause was the logic for determining precision and automatic evalf behaviour, which utilizes `max()` over all arguments. As `max()` requires a non empty sequence this obviously failed.

I also added and extended the most obviously relevant test cases in test_function.py. Most other test cases, especially those concerning multiple differentiation, do not appear to be relevant for a constant function. 
I am slightly concerned that I missed some other implication this change might have, especially considering that `Function` is fairly widespread in use , on the other hand no existing functionality was changed, just a new use case supported.

Fixes #6984