### PR TITLE
Fixed Polygon.arbitrary_point() bug due to undirected segments

### DIFF
--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -427,6 +427,38 @@ class Polygon(GeometrySet):
         for i in range(-len(args), 0):
             res.append(Segment(args[i], args[i + 1]))
         return res
+    
+    @property
+    def sides_rays(self):
+        """The line rays that form the sides of the polygon (sides as directed Rays).
+
+        Returns
+        =======
+
+        sides_rays : list of sides as rays
+            Each side is a Ray (directed).
+
+        See Also
+        ========
+
+        sympy.geometry.point.Point, sympy.geometry.line.Ray
+
+        Examples
+        ========
+
+        >>> from sympy import Point, Polygon
+        >>> p1, p2, p3, p4 = map(Point, [(0, 0), (1, 0), (5, 1), (0, 1)])
+        >>> poly = Polygon(p1, p2, p3, p4)
+        >>> poly.sides_rays
+        [Ray2D(Point2D(0, 0), Point2D(1, 0)), Ray2D(Point2D(1, 0), Point2D(5, 1)), Ray2D(Point2D(5, 1), Point2D(0, 1)), Ray2D(Point2D(0, 1), Point2D(0, 0))]
+
+
+        """
+        res = []
+        args = self.vertices
+        for i in range(-len(args), 0):
+            res.append(Ray(args[i], args[i + 1]))
+        return res
 
     @property
     def bounds(self):
@@ -571,7 +603,8 @@ class Polygon(GeometrySet):
         The parameter, varying from 0 to 1, assigns points to the position on
         the perimeter that is that fraction of the total perimeter. So the
         point evaluated at t=1/2 would return the point from the first vertex
-        that is 1/2 way around the polygon.
+        that is 1/2 way around the polygon (the direction of the point is related
+        to the direction of the points used to create the Polygon).
 
         Parameters
         ==========
@@ -614,10 +647,11 @@ class Polygon(GeometrySet):
         sides = []
         perimeter = self.perimeter
         perim_fraction_start = 0
-        for s in self.sides:
-            side_perim_fraction = s.length/perimeter
+        for r in self.sides_rays:
+            length = r.points[0].distance(r.points[1])
+            side_perim_fraction = length/perimeter
             perim_fraction_end = perim_fraction_start + side_perim_fraction
-            pt = s.arbitrary_point(parameter).subs(
+            pt = r.arbitrary_point(parameter).subs(
                 t, (t - perim_fraction_start)/side_perim_fraction)
             sides.append(
                 (pt, (And(perim_fraction_start <= t, t < perim_fraction_end))))


### PR DESCRIPTION
Originally, the Polygon.arbitrary_point() function used undirected Segments to calculate the points. This assumption sometimes did not work, as the order of points used to create the Polygon might be inverted, thus returning the wrong value.

This fix uses Rays instead of Segment objects. Rays are directed lines, thus, the order of Points used to create the Polygon is maintained. Another change necessary so the rest of the code base remains intact: create a new @sides_rays property, which is analogous to the @sides property but returns Rays instead of Segments.

Fixes issue [#12966](https://github.com/sympy/sympy/issues/12966).