### PR TITLE
Reconstruction of directional derivative

### DIFF
--- a/doc/src/modules/vector/fields.rst
+++ b/doc/src/modules/vector/fields.rst
@@ -252,7 +252,7 @@ Directional derivatives of vector and scalar fields can be computed in
 
 Or by using the dedicated function
   >>> from sympy.vector import directional_derivative
-  >>> directional_derivative(C.x*C.y*C.z, 3*C.i + 4*C.j + C.k)
+  >>> directional_derivative(3*C.i + 4*C.j + C.k, C.x*C.y*C.z)
   C.x*C.y + 4*C.x*C.z + 3*C.y*C.z
 
 Conservative and Solenoidal fields

--- a/doc/src/modules/vector/fields.rst
+++ b/doc/src/modules/vector/fields.rst
@@ -252,7 +252,7 @@ Directional derivatives of vector and scalar fields can be computed in
 
 Or by using the dedicated function
   >>> from sympy.vector import directional_derivative
-  >>> directional_derivative(3*C.i + 4*C.j + C.k, C.x*C.y*C.z)
+  >>> directional_derivative(C.x*C.y*C.z, 3*C.i + 4*C.j + C.k)
   C.x*C.y + 4*C.x*C.z + 3*C.y*C.z
 
 Conservative and Solenoidal fields

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -124,7 +124,7 @@ def express(expr, system, system2=None, variables=False):
         return expr
 
 
-def directional_derivative(direction_vector, field):
+def directional_derivative(field, direction_vector):
     """
     Returns the directional derivative of a scalar or vector field computed
     along a given vector in coordinate system which parameters are expressed.
@@ -132,11 +132,12 @@ def directional_derivative(direction_vector, field):
     Parameters
     ==========
 
+    field : Vector or Scalar
+        The scalar or vector field to compute the directional derivative of
+
     direction_vector : Vector
         The vector to calculated directional derivative along them.
 
-    field : Vector or Scalar
-        The scalar or vector field to compute the directional derivative of
 
     Examples
     ========
@@ -145,10 +146,10 @@ def directional_derivative(direction_vector, field):
     >>> R = CoordSys3D('R')
     >>> f1 = R.x*R.y*R.z
     >>> v1 = 3*R.i + 4*R.j + R.k
-    >>> directional_derivative(v1, f1)
+    >>> directional_derivative(f1, v1)
     R.x*R.y + 4*R.x*R.z + 3*R.y*R.z
     >>> f2 = 5*R.x**2*R.z
-    >>> directional_derivative(v1, f2)
+    >>> directional_derivative(f2, v1)
     5*R.x**2 + 30*R.x*R.z
 
     """

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -184,10 +184,12 @@ def test_solenoidal():
     assert is_solenoidal(cos(q)*i + sin(q)*j + cos(q)*P.k) is True
     assert is_solenoidal(z*P.i + P.x*k) is True
 
+
 def test_directional_derivative():
-    assert directional_derivative(C.x*C.y*C.z, 3*C.i + 4*C.j + C.k) == C.x*C.y + 4*C.x*C.z + 3*C.y*C.z
-    assert directional_derivative(5*C.x**2*C.z, 3*C.i + 4*C.j + C.k) == 5*C.x**2 + 30*C.x*C.z
-    assert directional_derivative(5*C.x**2*C.z, 4*C.j) == S.Zero
+    assert directional_derivative(3*C.i + 4*C.j + C.k, C.x*C.y*C.z) == C.x*C.y + 4*C.x*C.z + 3*C.y*C.z
+    assert directional_derivative(3*C.i + 4*C.j + C.k, 5*C.x**2*C.z) == 5*C.x**2 + 30*C.x*C.z
+    assert directional_derivative(4*C.j, 5*C.x**2*C.z) == S.Zero
+
 
 def test_scalar_potential():
     assert scalar_potential(Vector.zero, C) == 0

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -186,9 +186,9 @@ def test_solenoidal():
 
 
 def test_directional_derivative():
-    assert directional_derivative(3*C.i + 4*C.j + C.k, C.x*C.y*C.z) == C.x*C.y + 4*C.x*C.z + 3*C.y*C.z
-    assert directional_derivative(3*C.i + 4*C.j + C.k, 5*C.x**2*C.z) == 5*C.x**2 + 30*C.x*C.z
-    assert directional_derivative(4*C.j, 5*C.x**2*C.z) == S.Zero
+    assert directional_derivative(C.x*C.y*C.z, 3*C.i + 4*C.j + C.k) == C.x*C.y + 4*C.x*C.z + 3*C.y*C.z
+    assert directional_derivative(5*C.x**2*C.z, 3*C.i + 4*C.j + C.k) == 5*C.x**2 + 30*C.x*C.z
+    assert directional_derivative(5*C.x**2*C.z, 4*C.j) == S.Zero
 
 
 def test_scalar_potential():

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -110,7 +110,7 @@ class Vector(BasisDependent):
         if isinstance(other, Del):
             def directional_derivative(field):
                 from sympy.vector.functions import directional_derivative
-                return directional_derivative(self, field)
+                return directional_derivative(field, self)
             return directional_derivative
 
         if isinstance(self, VectorZero) or isinstance(other, VectorZero):

--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -109,20 +109,8 @@ class Vector(BasisDependent):
         # Check if the other is a del operator
         if isinstance(other, Del):
             def directional_derivative(field):
-                from sympy.vector.operators import _get_coord_sys_from_expr
-                coord_sys = _get_coord_sys_from_expr(field)
-                if coord_sys is not None:
-                    field = express(field, coord_sys, variables=True)
-                    out = self.dot(coord_sys._i) * df(field, coord_sys._x)
-                    out += self.dot(coord_sys._j) * df(field, coord_sys._y)
-                    out += self.dot(coord_sys._k) * df(field, coord_sys._z)
-                    if out == 0 and isinstance(field, Vector):
-                        out = Vector.zero
-                    return out
-                elif isinstance(field, Vector) :
-                    return Vector.zero
-                else:
-                    return S(0)
+                from sympy.vector.functions import directional_derivative
+                return directional_derivative(self, field)
             return directional_derivative
 
         if isinstance(self, VectorZero) or isinstance(other, VectorZero):


### PR DESCRIPTION
Calculation are moved from `Vector` class to separate functions. 
Update comments and tests.

The problem are arguments. In `directional_derivative` function which was added recently (#12417) not only usage of this function is different from  `Vector` class  (see #12969) but also the order.

The problematic code are already in 1.1 version. Should we add deprecation? 

