### PR TITLE
polytools.degree: Speed up by avoiding Poly term collection

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4408,7 +4408,7 @@ def degree(f, gen=0):
     degree_list
     """
 
-    f = sympify(f)
+    f = sympify(f, strict=True)
     if f.is_number and f.as_expr().is_Number:
         return S.Zero if f else S.NegativeInfinity
 
@@ -4416,14 +4416,14 @@ def degree(f, gen=0):
         f, _ = poly_from_expr(f)
         if isinstance(gen, int) and f.is_multivariate:
             raise ValueError("For multivariate expressions, an explicit generator must be given for gen, not an integer.")
-    if not sympify(gen).is_Number:
+    if not sympify(gen, strict=True).is_Number:
         if gen not in f.gens and f.is_Poly:
             # try recast without explicit gens
             f, _ = poly_from_expr(f.as_expr())
         if gen not in f.gens:
             return S.Zero
 
-    return sympify(f.degree(gen))
+    return sympify(f.degree(gen), strict=True)
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4415,7 +4415,7 @@ def degree(f, *gens, **args):
         gens.append(f.gens[0])
         f = f.as_expr()
 
-    if f.is_Number:
+    if f.is_Number:
         if len(gens) == 0:
             raise ComputationFailed('degree', 1, PolificationFailed({'gens': ()}, orig, f))
         if f == 0:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4414,8 +4414,7 @@ def degree(f, gen=0):
 
     if not f.is_Poly:
         f, _ = poly_from_expr(f)
-        if isinstance(gen, int) and f.is_multivariate:
-            raise ValueError("For multivariate expressions, an explicit generator must be given for gen, not an integer.")
+
     if not sympify(gen, strict=True).is_Number:
         if gen not in f.gens and f.is_Poly:
             # try recast without explicit gens

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4383,7 +4383,7 @@ def _update_args(args, key, value):
 
 
 @public
-def degree(f, *gens, **args):
+def degree(f, gen=0):
     """
     Return the degree of ``f`` in the given variable.
 
@@ -4402,35 +4402,26 @@ def degree(f, *gens, **args):
     >>> degree(0, x)
     -oo
 
+    See also
+    ========
+    total_degree
+    degree_list
     """
-    options.allowed_flags(args, ['gen', 'polys'])
+
     f = sympify(f)
-    gen = args.pop('gen', 0)
+    if not f.is_Poly:
+        if f.is_number:
+            return S.Zero if f else S.NegativeInfinity
+        f, _ = poly_from_expr(f)
 
-    if f.is_Poly:
-        if len(gens) == 0:
-            return sympify(f.degree(gen=gen))
-        f = f.as_expr()
+    if not isinstance(gen, int):
+        if gen not in f.gens and f.is_Poly:
+            # try recast without explicit gens
+            f, _ = poly_from_expr(f.as_expr())
+        if gen not in f.gens:
+            return S.Zero
 
-    try:
-        if f.is_Number:
-           F, opt = poly_from_expr(f, *gens, **args)
-        else:
-            F, opt = poly_from_expr(f, **args)
-    except PolificationFailed as exc:
-        raise ComputationFailed('degree', 1, exc)
-
-    if len(gens) == 0:
-        gens = F.gens
-    if isinstance(gen, int):
-        try:
-            gen = gens[gen]
-        except IndexError:
-            raise PolynomialError("-%s <= gen < %s expected, got %s" %
-                                  (len(gens), len(gens), gen))
-    if gen in F.gens:
-        return sympify(F.degree(gen))
-    return S.Zero
+    return sympify(f.degree(gen))
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4404,32 +4404,32 @@ def degree(f, *gens, **args):
 
     """
     options.allowed_flags(args, ['gen', 'polys'])
-    f, orig = sympify(f), f
-    gens = list(gens)
-    gen = args.get('gen')
-    if gen is not None:
-        gens = [sympify(gen)] + gens
-        del args['gen']
+    f = sympify(f)
+    gen = args.pop('gen', 0)
 
     if f.is_Poly:
-        gens.append(f.gens[0])
+        if len(gens) == 0:
+            return sympify(f.degree(gen=gen))
         f = f.as_expr()
 
-    if f.is_Number:
-        if len(gens) == 0:
-            raise ComputationFailed('degree', 1, PolificationFailed({'gens': ()}, orig, f))
-        if f == 0:
-            return S.NegativeInfinity
-        return S.Zero
-
     try:
-        F, opt = poly_from_expr(f, **args)
+        if f.is_Number:
+           F, opt = poly_from_expr(f, *gens, **args)
+        else:
+            F, opt = poly_from_expr(f, **args)
     except PolificationFailed as exc:
         raise ComputationFailed('degree', 1, exc)
 
-    gens.append(F.gens[0])
-    if gens[0] in F.gens:
-        return sympify(F.degree(gens[0]))
+    if len(gens) == 0:
+        gens = F.gens
+    if isinstance(gen, int):
+        try:
+            gen = gens[gen]
+        except IndexError:
+            raise PolynomialError("-%s <= gen < %s expected, got %s" %
+                                  (len(gens), len(gens), gen))
+    if gen in F.gens:
+        return sympify(F.degree(gen))
     return S.Zero
 
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4404,13 +4404,16 @@ def degree(f, *gens, **args):
 
     """
     options.allowed_flags(args, ['gen', 'polys'])
-
+    f = sympify(f).as_expr()
     try:
-        F, opt = poly_from_expr(f, *gens, **args)
+        if f.is_Number:
+            F, opt = poly_from_expr(f, *gens, **args)
+        else:
+            F, opt = poly_from_expr(f)
     except PolificationFailed as exc:
         raise ComputationFailed('degree', 1, exc)
 
-    return sympify(F.degree(opt.gen))
+    return sympify(F.degree(*gens, **args))
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4408,7 +4408,7 @@ def degree(f, gen=0):
     degree_list
     """
 
-    f = sympyify(f, strict=True)
+    f = sympify(f, strict=True)
     if f.is_Poly:
         p = f
         isNum = p.as_expr().is_Number

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4404,7 +4404,7 @@ def degree(f, *gens, **args):
 
     """
     options.allowed_flags(args, ['gen', 'polys'])
-    f = sympify(f)
+    f, orig = sympify(f), f
     try:
         gens = [sympify(args['gen'])] + list(gens)
         del args['gen']
@@ -4413,7 +4413,7 @@ def degree(f, *gens, **args):
 
     if f.is_Number:
         if len(gens) == 0:
-            raise ComputationFailed('degree', 1, "degree(%s) failed without generators" % f)
+            raise ComputationFailed('degree', 1, PolificationFailed({'gens': ()}, orig, f))
         if f == 0:
             return S.NegativeInfinity
         return S.Zero

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4404,18 +4404,37 @@ def degree(f, *gens, **args):
 
     """
     options.allowed_flags(args, ['gen', 'polys'])
-    f = sympify(f).as_expr()
+    f = sympify(f)
     try:
-        if f.is_Number:
-            F, opt = poly_from_expr(f, *gens, **args)
-        else:
-            F, opt = poly_from_expr(f)
+        gens = [sympify(args['gen'])] + list(gens)
+        del args['gen']
+    except KeyError:
+        pass
+
+    if f.is_Number:
+        if len(gens) == 0:
+            raise ComputationFailed('degree', 1, "degree(%s) failed without generators" % f)
+        if f == 0:
+            return S.NegativeInfinity
+        return S.Zero
+
+    if f.is_Poly:
+        if len(gens) == 0:
+            return sympify(f.degree(**args))
+        if gens[0] in f.gens:
+            return sympify(f.degree(gens[0], **args))
+    try:
+        F, opt = poly_from_expr(f.as_expr())
     except PolificationFailed as exc:
         raise ComputationFailed('degree', 1, exc)
+
+    if F.is_zero:
+        return S.NegativeInfinity
+
     if len(gens) != 0:
         if gens[0] in F.gens:
             return sympify(F.degree(gens[0], **args))
-        return Integer(0)
+        return S.Zero
 
     return sympify(F.degree(*gens, **args))
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4405,11 +4405,16 @@ def degree(f, *gens, **args):
     """
     options.allowed_flags(args, ['gen', 'polys'])
     f, orig = sympify(f), f
+    gens = list(gens)
     try:
-        gens = [sympify(args['gen'])] + list(gens)
+        gens = [sympify(args['gen'])] + gens
         del args['gen']
     except KeyError:
         pass
+
+    if f.is_Poly:
+        gens.append(f.gens[0])
+        f = f.as_expr()
 
     if f.is_Number:
         if len(gens) == 0:
@@ -4418,25 +4423,15 @@ def degree(f, *gens, **args):
             return S.NegativeInfinity
         return S.Zero
 
-    if f.is_Poly:
-        if len(gens) == 0:
-            return sympify(f.degree(**args))
-        if gens[0] in f.gens:
-            return sympify(f.degree(gens[0], **args))
     try:
-        F, opt = poly_from_expr(f.as_expr())
+        F, opt = poly_from_expr(f, **args)
     except PolificationFailed as exc:
         raise ComputationFailed('degree', 1, exc)
 
-    if F.is_zero:
-        return S.NegativeInfinity
-
-    if len(gens) != 0:
-        if gens[0] in F.gens:
-            return sympify(F.degree(gens[0], **args))
-        return S.Zero
-
-    return sympify(F.degree(*gens, **args))
+    gens.append(F.gens[0])
+    if gens[0] in F.gens:
+        return sympify(F.degree(gens[0]))
+    return S.Zero
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4406,11 +4406,10 @@ def degree(f, *gens, **args):
     options.allowed_flags(args, ['gen', 'polys'])
     f, orig = sympify(f), f
     gens = list(gens)
-    try:
-        gens = [sympify(args['gen'])] + gens
+    gen = args.get('gen')
+    if gen is not None:
+        gens = [sympify(gen)] + gens
         del args['gen']
-    except KeyError:
-        pass
 
     if f.is_Poly:
         gens.append(f.gens[0])

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4409,9 +4409,10 @@ def degree(f, gen=0):
     """
 
     f = sympify(f)
+    if f.is_Number:
+        return S.Zero if f else S.NegativeInfinity
+
     if not f.is_Poly:
-        if f.is_number:
-            return S.Zero if f else S.NegativeInfinity
         f, _ = poly_from_expr(f)
 
     if not isinstance(gen, int):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4412,6 +4412,10 @@ def degree(f, *gens, **args):
             F, opt = poly_from_expr(f)
     except PolificationFailed as exc:
         raise ComputationFailed('degree', 1, exc)
+    if len(gens) != 0:
+        if gens[0] in F.gens:
+            return sympify(F.degree(gens[0], **args))
+        return Integer(0)
 
     return sympify(F.degree(*gens, **args))
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4408,21 +4408,26 @@ def degree(f, gen=0):
     degree_list
     """
 
-    f = sympify(f, strict=True)
-    if f.is_number and f.as_expr().is_Number:
-        return S.Zero if f else S.NegativeInfinity
+    if f.is_Poly:
+        p = f
+        isNum = p.as_expr().is_Number
+    else:
+        p = sympify(f, strict=True)
+        isNum = p.is_Number
+        if not isNum:
+            p, _ = poly_from_expr(f)
 
-    if not f.is_Poly:
-        f, _ = poly_from_expr(f)
+    if isNum:
+        return S.Zero if p else S.NegativeInfinity
 
     if not sympify(gen, strict=True).is_Number:
-        if gen not in f.gens and f.is_Poly:
+        if gen not in p.gens and f.is_Poly:
             # try recast without explicit gens
-            f, _ = poly_from_expr(f.as_expr())
-        if gen not in f.gens:
+            p, _ = poly_from_expr(f.as_expr())
+        if gen not in p.gens:
             return S.Zero
 
-    return sympify(f.degree(gen), strict=True)
+    return sympify(p.degree(gen), strict=True)
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4409,13 +4409,14 @@ def degree(f, gen=0):
     """
 
     f = sympify(f)
-    if f.is_Number:
+    if f.is_number and f.as_expr().is_Number:
         return S.Zero if f else S.NegativeInfinity
 
     if not f.is_Poly:
         f, _ = poly_from_expr(f)
-
-    if not isinstance(gen, int):
+        if isinstance(gen, int) and f.is_multivariate:
+            raise ValueError("For multivariate expressions, an explicit generator must be given for gen, not an integer.")
+    if not sympify(gen).is_Number:
         if gen not in f.gens and f.is_Poly:
             # try recast without explicit gens
             f, _ = poly_from_expr(f.as_expr())

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4408,26 +4408,26 @@ def degree(f, gen=0):
     degree_list
     """
 
-    if isinstance(f, Poly):
+    f = sympyify(f, strict=True)
+    if f.is_Poly:
         p = f
         isNum = p.as_expr().is_Number
     else:
-        p = sympify(f, strict=True)
-        isNum = p.is_Number
+        isNum = f.is_Number
         if not isNum:
             p, _ = poly_from_expr(f)
 
     if isNum:
-        return S.Zero if p else S.NegativeInfinity
+        return S.Zero if f else S.NegativeInfinity
 
     if not sympify(gen, strict=True).is_Number:
-        if gen not in p.gens and isinstance(f, Poly):
+        if f.is_Poly and gen not in p.gens:
             # try recast without explicit gens
             p, _ = poly_from_expr(f.as_expr())
         if gen not in p.gens:
             return S.Zero
 
-    return sympify(p.degree(gen), strict=True)
+    return Integer(p.degree(gen))
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4408,7 +4408,7 @@ def degree(f, gen=0):
     degree_list
     """
 
-    if f.is_Poly:
+    if isinstance(f, Poly):
         p = f
         isNum = p.as_expr().is_Number
     else:
@@ -4421,7 +4421,7 @@ def degree(f, gen=0):
         return S.Zero if p else S.NegativeInfinity
 
     if not sympify(gen, strict=True).is_Number:
-        if gen not in p.gens and f.is_Poly:
+        if gen not in p.gens and isinstance(f, Poly):
             # try recast without explicit gens
             p, _ = poly_from_expr(f.as_expr())
         if gen not in p.gens:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1179,6 +1179,12 @@ def test_Poly_degree():
     assert degree(Poly(y**2 + x**3, x), x, y, gen=y) == 2
     raises(ComputationFailed, lambda: degree(1))
 
+    assert degree(Poly(exp(x) + y**2, y), exp(x)) == 1
+    assert degree(Poly(exp(x) + y**2, y), y, exp(x), gen=1) == 1
+
+    p = exp(x) + y**2
+    assert degree(p) == Poly(p).degree(0)
+
 
 def test_Poly_degree_list():
     assert Poly(0, x).degree_list() == (-oo,)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -52,7 +52,7 @@ from sympy.polys.orderings import lex, grlex, grevlex
 
 from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, sqrt, Piecewise, Derivative,
-    exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff, E)
+    exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff)
 
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
@@ -1166,9 +1166,10 @@ def test_Poly_degree():
     assert degree(x*y**2, y) == 2
     assert degree(x*y**2, z) == 0
 
+    assert degree(y**2+x**3) == 3
+    assert degree(y**2+x**3, 1) == 2
     assert degree(pi) == 1
-    raises(ValueError, lambda: degree(x + y**2))
-    raises(ValueError, lambda: degree(pi + E**2))
+
     raises(PolynomialError, lambda: degree(x, 1.1))
 
     assert degree(Poly(0,x),z) == -oo

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -52,7 +52,7 @@ from sympy.polys.orderings import lex, grlex, grevlex
 
 from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, sqrt, Piecewise, Derivative,
-    exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff)
+    exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff, E)
 
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
@@ -1166,15 +1166,17 @@ def test_Poly_degree():
     assert degree(x*y**2, y) == 2
     assert degree(x*y**2, z) == 0
 
-    assert degree(y**2+x**3) == 3
     assert degree(pi) == 1
+    raises(ValueError, lambda: degree(x + y**2))
+    raises(ValueError, lambda: degree(pi + E**2))
+    raises(PolynomialError, lambda: degree(x, 1.1))
 
     assert degree(Poly(0,x),z) == -oo
     assert degree(Poly(1,x),z) == 0
     assert degree(Poly(x**2+y**3,y)) == 3
     assert degree(Poly(y**2 + x**3, y, x), 1) == 3
     assert degree(Poly(y**2 + x**3, x), z) == 0
-
+    assert degree(Poly(y**2 + x**3 + z**4, x), z) == 4
 
 def test_Poly_degree_list():
     assert Poly(0, x).degree_list() == (-oo,)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1167,6 +1167,7 @@ def test_Poly_degree():
     assert degree(x*y**2, z) == 0
 
     assert degree(y**2+x**3) == 3
+    assert degree(pi) == 1
 
     assert degree(Poly(0,x),z) == -oo
     assert degree(Poly(1,x),z) == 0

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1158,6 +1158,7 @@ def test_Poly_degree():
     assert Poly(2*y, x, y).degree(gen=y) == 1
     assert Poly(x*y, x, y).degree(gen=y) == 1
 
+    assert degree(0, x) == -oo
     assert degree(1, x) == 0
     assert degree(x, x) == 1
 
@@ -1166,6 +1167,7 @@ def test_Poly_degree():
 
     assert degree(x*y**2, x, y) == 1
     assert degree(x*y**2, y, x) == 2
+    assert degree(x*y**2, z) == 0
 
     raises(ComputationFailed, lambda: degree(1))
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1169,6 +1169,11 @@ def test_Poly_degree():
     assert degree(x*y**2, y, x) == 2
     assert degree(x*y**2, z) == 0
 
+    assert degree(y**2+x**3) == 3
+    assert degree(x**2+y**3) == 2
+
+    assert degree(Poly(y**2 + x**3, x, y), x, y, gen=y) == 2
+    assert degree(Poly(y**2 + x**3, x), x, y, gen=y) == 2
     raises(ComputationFailed, lambda: degree(1))
 
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1172,6 +1172,9 @@ def test_Poly_degree():
     assert degree(y**2+x**3) == 3
     assert degree(x**2+y**3) == 2
 
+    assert degree(Poly(0,x),z) == -oo
+    assert degree(Poly(1,x),z) == 0
+    assert degree(Poly(x**2+y**3,y)) == 3
     assert degree(Poly(y**2 + x**3, x, y), x, y, gen=y) == 2
     assert degree(Poly(y**2 + x**3, x), x, y, gen=y) == 2
     raises(ComputationFailed, lambda: degree(1))

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1162,28 +1162,17 @@ def test_Poly_degree():
     assert degree(1, x) == 0
     assert degree(x, x) == 1
 
-    assert degree(x*y**2, gen=x) == 1
-    assert degree(x*y**2, gen=y) == 2
-
-    assert degree(x*y**2, x, y) == 1
-    assert degree(x*y**2, y, x) == 2
+    assert degree(x*y**2, x) == 1
+    assert degree(x*y**2, y) == 2
     assert degree(x*y**2, z) == 0
 
     assert degree(y**2+x**3) == 3
-    assert degree(x**2+y**3) == 2
 
     assert degree(Poly(0,x),z) == -oo
     assert degree(Poly(1,x),z) == 0
     assert degree(Poly(x**2+y**3,y)) == 3
-    assert degree(Poly(y**2 + x**3, x, y), x, y, gen=y) == 2
-    assert degree(Poly(y**2 + x**3, x), x, y, gen=y) == 2
-    raises(ComputationFailed, lambda: degree(1))
-
-    assert degree(Poly(exp(x) + y**2, y), exp(x)) == 1
-    assert degree(Poly(exp(x) + y**2, y), y, exp(x), gen=1) == 1
-
-    p = exp(x) + y**2
-    assert degree(p) == Poly(p).degree(0)
+    assert degree(Poly(y**2 + x**3, y, x), 1) == 3
+    assert degree(Poly(y**2 + x**3, x), z) == 0
 
 
 def test_Poly_degree_list():


### PR DESCRIPTION
`Poly(f, var)` can sometimes take much longer than `Poly(f)` because it collects with respect to the variable. This behavior is unnecessary for `degree`, so this commit uses `Poly(f)` instead.

Before:
```
>>> import timeit
>>> timeit.timeit("degree(f, c5)", globals=globals(),number=20)
77.93264110297285
>>> timeit.timeit("Poly(f).degree(c5)", globals=globals(),number=20)
2.8491278389856802
```
After:
```
>>> timeit.timeit("degree(f, c5)", globals=globals(),number=20)
2.906191912352824
>>> timeit.timeit("Poly(f).degree(c5)", globals=globals(),number=20)
2.888086826285871
```

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
See sympy/sympy#12998. This fixes it for `degree`, but not `degree_list`