### PR TITLE
added closing_angle; minor geometry modifications

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -106,7 +106,8 @@ class LinearEntity(GeometrySet):
         return len(self.p1)
 
     def angle_between(l1, l2):
-        """The angle formed between the two linear entities.
+        """The smallest of the two angles formed at the
+        intersection of two linear entities.
 
         Parameters
         ==========
@@ -133,7 +134,7 @@ class LinearEntity(GeometrySet):
         See Also
         ========
 
-        is_perpendicular
+        is_perpendicular, closing_angle
 
         Examples
         ========
@@ -155,6 +156,50 @@ class LinearEntity(GeometrySet):
 
         v1, v2 = l1.direction, l2.direction
         return acos(v1.dot(v2)/(abs(v1)*abs(v2)))
+
+    def closing_angle(l1, l2):
+        """The ccw angle needed to align l2 with l1.
+
+        Parameters
+        ==========
+
+        l1 : LinearEntity
+        l2 : LinearEntity
+
+        Returns
+        =======
+
+        angle : angle in radians
+
+        See Also
+        ========
+
+        angle_between
+
+        Examples
+        ========
+
+        >>> from sympy import Point, Line, pi
+        >>> l1 = Line((0, 0), (1, 0))
+        >>> l2 = l1.rotate(-pi/2)
+        >>> l1.closing_angle(l2)
+        pi/2
+        >>> l2.closing_angle(l1)
+        3*pi/2
+        """
+        if not isinstance(l1, LinearEntity) and not isinstance(l2, LinearEntity):
+            raise TypeError('Must pass only LinearEntity objects')
+
+        v1, v2 = l1.direction, l2.direction
+        ang = l1.angle_between(l2)
+        if not ang:
+            return ang
+        ok = not ang or v2.unit.rotate(ang).equals(v1.unit)
+        if ok is None:
+            raise Undecidable("can't determine orientation of %s and %s" % (l1, l2))
+        if ok is False:
+            return 2*S.Pi - ang
+        return ang
 
     def arbitrary_point(self, parameter='t'):
         """A parameterized point on the Line.

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -114,11 +114,6 @@ class Point(GeometryEntity):
 
         # unpack into coords
         coords = args[0] if len(args) == 1 else args
-        # A point where only `dim` is specified is initialized
-        # to zeros.
-        if len(coords) == 0 and kwargs.get('dim', None):
-            coords = (S.Zero,)*kwargs.get('dim')
-
 
         # check args and handle quickly handle Point instances
         if isinstance(coords, Point):
@@ -132,6 +127,10 @@ class Point(GeometryEntity):
             raise TypeError(filldedent('''
                 Expecting sequence of coordinates, not `{}`'''
                                        .format(func_name(coords))))
+        # A point where only `dim` is specified is initialized
+        # to zeros.
+        if len(coords) == 0 and kwargs.get('dim', None):
+            coords = (S.Zero,)*kwargs.get('dim')
 
         coords = Tuple(*coords)
         dim = kwargs.get('dim', len(coords))

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -236,6 +236,18 @@ class Polygon(GeometrySet):
 
     @staticmethod
     def _isright(a, b, c):
+        """Return True/False for cw/ccw orientation.
+
+        Examples
+        ========
+
+        >>> from sympy import Point, Polygon
+        >>> a, b, c = [Point(i) for i in [(0, 0), (1, 1), (1, 0)]]
+        >>> Polygon._isright(a, b, c)
+        True
+        >>> Polygon._isright(a, c, b)
+        False
+        """
         ba = b - a
         ca = c - a
         t_area = simplify(ba.x*ca.y - ca.x*ba.y)

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -54,9 +54,10 @@ def test_angle_between():
 
 
 def test_closing_angle():
-    a = Line((0, 0), slope=0)
-    assert a.closing_angle(a.rotate(pi/2)) == 3*pi/2
-    assert a.closing_angle(a.rotate(-pi/2)) == pi/2
+    a = Ray((0, 0), angle=0)
+    b = Ray((1, 2), angle=pi/2)
+    assert a.closing_angle(b) == -pi/2
+    assert b.closing_angle(a) == pi/2
     assert a.closing_angle(a) == 0
 
 

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -53,6 +53,13 @@ def test_angle_between():
                                 Line3D(Point3D(0, 0, 0), Point3D(5, 0, 0))), acos(sqrt(3) / 3)
 
 
+def test_closing_angle():
+    a = Line((0, 0), slope=0)
+    assert a.closing_angle(a.rotate(pi/2)) == 3*pi/2
+    assert a.closing_angle(a.rotate(-pi/2)) == pi/2
+    assert a.closing_angle(a) == 0
+
+
 def test_arbitrary_point():
     l1 = Line3D(Point3D(0, 0, 0), Point3D(1, 1, 1))
     l2 = Line(Point(x1, x1), Point(y1, y1))


### PR DESCRIPTION
Is there a better name for `closing_angle` which represents the angle of one linear entity relative to another? Maybe `angle_from`? This is like the clockhand angle. `angle_between` always gives the smallest angle between to lines, but sometimes one wants to know the 4 quadrant angle.

Also: edits to docstrings and reordering of `Point.__new__` to put Point handling sooner.