### PR TITLE
Implemented get_dimensional_expr for Derivative

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -132,6 +132,13 @@ class Quantity(AtomicExpr):
                 assert dim == addend_dim
                 factor += addend_factor
             return factor, dim
+        elif isinstance(expr, Derivative):
+            factor, dim = Quantity._collect_factor_and_dimension(expr.args[0])
+            for independent in expr.args[1:]:
+                ifactor, idim = Quantity._collect_factor_and_dimension(independent)
+                factor /= ifactor
+                dim /= idim
+            return factor, dim
         elif isinstance(expr, Function):
             fds = [Quantity._collect_factor_and_dimension(arg) for arg in expr.args]
             return expr.func(*(f[0] for f in fds)), expr.func(*(d[1] for d in fds))

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -7,7 +7,7 @@ Physical quantities.
 from __future__ import division
 
 from sympy import (
-    Add, AtomicExpr, Basic, Function, Mul, Pow, S, Symbol, sympify)
+    Add, AtomicExpr, Basic, Derivative, Function, Mul, Pow, S, Symbol, sympify)
 from sympy.core.compatibility import string_types
 from sympy.physics.units import Dimension, dimensions
 from sympy.physics.units.prefixes import Prefix
@@ -96,6 +96,9 @@ class Quantity(AtomicExpr):
             return Quantity.get_dimensional_expr(expr.base) ** expr.exp
         elif isinstance(expr, Add):
             return Quantity.get_dimensional_expr(expr.args[0])
+        elif isinstance(expr, Derivative):
+            return Quantity.get_dimensional_expr(expr.args[0]) /\
+                Quantity.get_dimensional_expr(expr.args[1])
         elif isinstance(expr, Quantity):
             return expr.dimension.name
         return 1

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -97,8 +97,10 @@ class Quantity(AtomicExpr):
         elif isinstance(expr, Add):
             return Quantity.get_dimensional_expr(expr.args[0])
         elif isinstance(expr, Derivative):
-            return Quantity.get_dimensional_expr(expr.args[0]) /\
-                Quantity.get_dimensional_expr(expr.args[1])
+            dim = Quantity.get_dimensional_expr(expr.args[0])
+            for independent in expr.args[1:]:
+                dim /= Quantity.get_dimensional_expr(independent)
+            return dim
         elif isinstance(expr, Quantity):
             return expr.dimension.name
         return 1

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -290,6 +290,8 @@ def test_dimensional_expr_of_derivative():
     dfdx = f(x, y).diff(x, y)
     dl_dt = dfdx.subs({f(x, y): l, x: t, y: t1})
     assert Quantity.get_dimensional_expr(dl_dt) ==\
-        Quantity.get_dimensional_expr(l / t / t1)
+        Quantity.get_dimensional_expr(l / t / t1) ==\
+        Symbol("length")/Symbol("time")**2
     assert Quantity._collect_factor_and_dimension(dl_dt) ==\
-        Quantity._collect_factor_and_dimension(l / t / t1)
+        Quantity._collect_factor_and_dimension(l / t / t1) ==\
+        (10, length/time**2)

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -279,11 +279,17 @@ def test_factor_and_dimension_with_Abs():
     expr = v_w1 - Abs(v_w1)
     assert (0, lenth/time) == Quantity._collect_factor_and_dimension(expr)
 
+
 def test_dimensional_expr_of_derivative():
-    l = Quantity('l', length)
-    t = Quantity('t', time)
+    l = Quantity('l', length, 36 * km)
+    t = Quantity('t', time, hour)
+    t1 = Quantity('t1', time, second)
     x = Symbol('x')
+    y = Symbol('y')
     f = Function('f')
-    dfdx = f(x).diff(x)
-    dl_dt = dfdx.subs({f(x): l, x: t})
-    assert length/time == Dimension(Quantity.get_dimensional_expr(dl_dt))
+    dfdx = f(x, y).diff(x, y)
+    dl_dt = dfdx.subs({f(x, y): l, x: t, y: t1})
+    assert Quantity.get_dimensional_expr(dl_dt) ==\
+        Quantity.get_dimensional_expr(l / t / t1)
+    assert Quantity._collect_factor_and_dimension(dl_dt) ==\
+        Quantity._collect_factor_and_dimension(l / t / t1)

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -3,8 +3,8 @@
 from __future__ import division
 
 from sympy import (
-    Abs, Add, Basic, Number, Rational, S, Symbol, diff, exp, integrate, log,
-    sqrt, symbols)
+    Abs, Add, Basic, Function, Number, Rational, S, Symbol, diff, exp,
+    integrate, log, sqrt, symbols)
 from sympy.physics.units import (
     amount_of_substance, convert_to, find_unit, volume)
 from sympy.physics.units.definitions import (
@@ -278,3 +278,12 @@ def test_factor_and_dimension_with_Abs():
     v_w1 = Quantity('v_w1', length/time, S(3)/2*meter/second)
     expr = v_w1 - Abs(v_w1)
     assert (0, lenth/time) == Quantity._collect_factor_and_dimension(expr)
+
+def test_dimensional_expr_of_derivative():
+    l = Quantity('l', length)
+    t = Quantity('t', time)
+    x = Symbol('x')
+    f = Function('f')
+    dfdx = f(x).diff(x)
+    dl_dt = dfdx.subs({f(x): l, x: t})
+    assert length/time == Dimension(Quantity.get_dimensional_expr(dl_dt))


### PR DESCRIPTION
So far, `Quantity.get_dimensional_expr()` was not defined for derivatives, but it seemed straightforward to do so. Now, we get:
```
from sympy import Derivative, Function, Symbol
from sympy.physics.units import Dimension, Quantity, length, time, meter, second
l = Quantity('l', length)
t = Quantity('t', time)
x = Symbol('x')
f = Function('f')
dfdx = f(x).diff(x)
dl_dt = dfdx.subs({f(x): l, x: t})
Dimension(Quantity.get_dimensional_expr(dl_dt))

length/time
```

