### PR TITLE
Implemented Quantity.get_dimensional_expr() for functions.

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -101,6 +101,9 @@ class Quantity(AtomicExpr):
             for independent in expr.args[1:]:
                 dim /= Quantity.get_dimensional_expr(independent)
             return dim
+        elif isinstance(expr, Function):
+            args = [Quantity.get_dimensional_expr(arg) for arg in expr.args]
+            return expr.func(*args)
         elif isinstance(expr, Quantity):
             return expr.dimension.name
         return 1

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from sympy import (
     Abs, Add, Basic, Function, Number, Rational, S, Symbol, diff, exp,
-    integrate, log, sqrt, symbols)
+    integrate, log, sin, sqrt, symbols)
 from sympy.physics.units import (
     amount_of_substance, convert_to, find_unit, volume)
 from sympy.physics.units.definitions import (
@@ -295,3 +295,9 @@ def test_dimensional_expr_of_derivative():
     assert Quantity._collect_factor_and_dimension(dl_dt) ==\
         Quantity._collect_factor_and_dimension(l / t / t1) ==\
         (10, length/time**2)
+
+
+def test_get_dimensional_expr_with_function():
+    v_w1 = Quantity('v_w1', length / time, meter / second)
+    assert Quantity.get_dimensional_expr(sin(v_w1)) == \
+        sin(Quantity.get_dimensional_expr(v_w1))


### PR DESCRIPTION
Test case:
```
from sympy.physics.units import Quantity, Dimension, length, time, meter, second
from sympy import sin
v_w1 = Quantity('v_w1', length/time, meter/second)
result = Quantity.get_dimensional_expr(sin(v_w1))
print result
assert Quantity.get_dimensional_expr(sin(v_w1)) == sin(Quantity.get_dimensional_expr(v_w1))
```
On the current master, the above code returns:
```
1
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
...
```

With this PR, the code returns:
```
sin(length/time)
```
