### PR TITLE
Make Pow.subs to not use fractional powers for noncommutative objects

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -564,29 +564,61 @@ class Pow(Expr):
     def _eval_subs(self, old, new):
         from sympy import exp, log, Symbol
         def _check(ct1, ct2, old):
-            """Return bool, pow where, if bool is True, then the exponent of
-            Pow `old` will combine with `pow` so the substitution is valid,
-            otherwise bool will be False,
+            """Return (bool, pow, remainder_pow) where, if bool is True, then the
+            exponent of Pow `old` will combine with `pow` so the substitution
+            is valid, otherwise bool will be False.
+
+            For noncommutative objects, `pow` will be an integer, and a factor
+            `Pow(old.base, remainder_pow)` needs to be included. If there is
+            no such factor, None is returned. For commutative objects,
+            remainder_pow is always None.
 
             cti are the coefficient and terms of an exponent of self or old
             In this _eval_subs routine a change like (b**(2*x)).subs(b**x, y)
             will give y**2 since (b**x)**2 == b**(2*x); if that equality does
             not hold then the substitution should not occur so `bool` will be
             False.
+
             """
             coeff1, terms1 = ct1
             coeff2, terms2 = ct2
             if terms1 == terms2:
-                pow = coeff1/coeff2
-                try:
-                    pow = as_int(pow)
-                    combines = True
-                except ValueError:
-                    combines = Pow._eval_power(
-                        Pow(*old.as_base_exp(), evaluate=False),
-                        pow) is not None
-                return combines, pow
-            return False, None
+                if old.is_commutative:
+                    # Allow fractional powers for commutative objects
+                    pow = coeff1/coeff2
+                    try:
+                        pow = as_int(pow)
+                        combines = True
+                    except ValueError:
+                        combines = Pow._eval_power(
+                            Pow(*old.as_base_exp(), evaluate=False),
+                            pow) is not None
+                    return combines, pow, None
+                else:
+                    # With noncommutative symbols, substitute only integer powers
+                    if not isinstance(terms1, tuple):
+                        terms1 = (terms1,)
+                    if not all(term.is_integer for term in terms1):
+                        return False, None, None
+
+                    try:
+                        # Round pow toward zero
+                        pow, remainder = divmod(as_int(coeff1), as_int(coeff2))
+                        if pow < 0 and remainder != 0:
+                            pow += 1
+                            remainder -= as_int(coeff2)
+
+                        if remainder == 0:
+                            remainder_pow = None
+                        else:
+                            remainder_pow = Mul(remainder, *terms1)
+
+                        return True, pow, remainder_pow
+                    except ValueError:
+                        # Can't substitute
+                        pass
+
+            return False, None, None
 
         if old == self.base:
             return new**self.exp._subs(old, new)
@@ -601,10 +633,13 @@ class Pow(Expr):
             if self.exp.is_Add is False:
                 ct1 = self.exp.as_independent(Symbol, as_Add=False)
                 ct2 = old.exp.as_independent(Symbol, as_Add=False)
-                ok, pow = _check(ct1, ct2, old)
+                ok, pow, remainder_pow = _check(ct1, ct2, old)
                 if ok:
                     # issue 5180: (x**(6*y)).subs(x**(3*y),z)->z**2
-                    return self.func(new, pow)
+                    result = self.func(new, pow)
+                    if remainder_pow is not None:
+                        result = Mul(result, Pow(old.base, remainder_pow))
+                    return result
             else:  # b**(6*x+a).subs(b**(3*x), y) -> y**2 * b**a
                 # exp(exp(x) + exp(x**2)).subs(exp(exp(x)), w) -> w * exp(exp(x**2))
                 oarg = old.exp
@@ -614,10 +649,16 @@ class Pow(Expr):
                 for a in self.exp.args:
                     newa = a._subs(old, new)
                     ct1 = newa.as_coeff_mul()
-                    ok, pow = _check(ct1, ct2, old)
+                    ok, pow, remainder_pow = _check(ct1, ct2, old)
                     if ok:
                         new_l.append(new**pow)
+                        if remainder_pow is not None:
+                            o_al.append(remainder_pow)
                         continue
+                    elif not old.is_commutative and not newa.is_integer:
+                        # If any term in the exponent is non-integer,
+                        # we do not do any substitutions in the noncommutative case
+                        return
                     o_al.append(newa)
                 if new_l:
                     new_l.append(Pow(self.base, Add(*o_al), evaluate=False))
@@ -627,9 +668,12 @@ class Pow(Expr):
             ct1 = old.args[0].as_independent(Symbol, as_Add=False)
             ct2 = (self.exp*log(self.base)).as_independent(
                 Symbol, as_Add=False)
-            ok, pow = _check(ct1, ct2, old)
+            ok, pow, remainder_pow = _check(ct1, ct2, old)
             if ok:
-                return self.func(new, pow)  # (2**x).subs(exp(x*log(2)), z) -> z
+                result = self.func(new, pow)  # (2**x).subs(exp(x*log(2)), z) -> z
+                if remainder_pow is not None:
+                    result = Mul(result, Pow(old.base, remainder_pow))
+                return result
 
     def as_base_exp(self):
         """Return base and exp of self.

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -292,6 +292,8 @@ def test_subs_commutative():
 
 def test_subs_noncommutative():
     w, x, y, z, L = symbols('w x y z L', commutative=False)
+    alpha = symbols('alpha', commutative=True)
+    someint = symbols('someint', commutative=True, integer=True)
 
     assert (x*y).subs(x*y, L) == L
     assert (w*y*x).subs(x*y, L) == w*y*x
@@ -305,6 +307,61 @@ def test_subs_noncommutative():
     assert (x*y**z).subs(z, L) == x*y**L
     assert (w*x*y*z*x*y).subs(x*y*z, L) == w*L*x*y
     assert (w*x*y*y*w*x*x*y*x*y*y*x*y).subs(x*y, L) == w*L*y*w*x*L**2*y*L
+
+    # Check fractional power substitutions. It should not do
+    # substitutions that choose a value for noncommutative log,
+    # or inverses that don't already appear in the expressions.
+    assert (x*x*x).subs(x*x, L) == L*x
+    assert (x*x*x*y*x*x*x*x).subs(x*x, L) == L*x*y*L**2
+    for p in range(1, 5):
+        for k in range(10):
+            assert (y * x**k).subs(x**p, L) == y * L**(k//p) * x**(k % p)
+    assert (x**(3/2)).subs(x**(1/2), L) == x**(3/2)
+    assert (x**(1/2)).subs(x**(1/2), L) == L
+    assert (x**(-1/2)).subs(x**(1/2), L) == x**(-1/2)
+    assert (x**(-1/2)).subs(x**(-1/2), L) == L
+
+    assert (x**(2*someint)).subs(x**someint, L) == L**2
+    assert (x**(2*someint + 3)).subs(x**someint, L) == L**2*x**3
+    assert (x**(3*someint + 3)).subs(x**someint, L) == L**3*x**3
+    assert (x**(3*someint)).subs(x**(2*someint), L) == L * x**someint
+    assert (x**(4*someint)).subs(x**(2*someint), L) == L**2
+    assert (x**(4*someint + 1)).subs(x**(2*someint), L) == L**2 * x
+    assert (x**(4*someint)).subs(x**(3*someint), L) == L * x**someint
+    assert (x**(4*someint + 1)).subs(x**(3*someint), L) == L * x**(someint + 1)
+
+    assert (x**(2*alpha)).subs(x**alpha, L) == x**(2*alpha)
+    assert (x**(2*alpha + 2)).subs(x**2, L) == x**(2*alpha + 2)
+    assert ((2*z)**alpha).subs(z**alpha, y) == (2*z)**alpha
+    assert (x**(2*someint*alpha)).subs(x**someint, L) == x**(2*someint*alpha)
+    assert (x**(2*someint + alpha)).subs(x**someint, L) == x**(2*someint + alpha)
+
+    # This could in principle be substituted, but is not currently
+    # because it requires recognizing that someint**2 is divisible by
+    # someint.
+    assert (x**(someint**2 + 3)).subs(x**someint, L) == x**(someint**2 + 3)
+
+    # alpha**z := exp(log(alpha) z) is usually well-defined
+    assert (4**z).subs(2**z, y) == y**2
+
+    # Negative powers
+    assert (x**(-1)).subs(x**3, L) == x**(-1)
+    assert (x**(-2)).subs(x**3, L) == x**(-2)
+    assert (x**(-3)).subs(x**3, L) == L**(-1)
+    assert (x**(-4)).subs(x**3, L) == L**(-1) * x**(-1)
+    assert (x**(-5)).subs(x**3, L) == L**(-1) * x**(-2)
+
+    assert (x**(-1)).subs(x**(-3), L) == x**(-1)
+    assert (x**(-2)).subs(x**(-3), L) == x**(-2)
+    assert (x**(-3)).subs(x**(-3), L) == L
+    assert (x**(-4)).subs(x**(-3), L) == L * x**(-1)
+    assert (x**(-5)).subs(x**(-3), L) == L * x**(-2)
+
+    assert (x**1).subs(x**(-3), L) == x
+    assert (x**2).subs(x**(-3), L) == x**2
+    assert (x**3).subs(x**(-3), L) == L**(-1)
+    assert (x**4).subs(x**(-3), L) == L**(-1) * x
+    assert (x**5).subs(x**(-3), L) == L**(-1) * x**2
 
 
 def test_subs_basic_funcs():


### PR DESCRIPTION
Manipulations involving fractional powers of noncommutative objects are
incorrect for many use cases, and sympy should not do them by itself.
Change Pow.subs code to limit substitutions to integer powers when
substituting noncommutative symbols.

Fixes #13004