### PR TITLE
Added addition/subtraction for Rays and Segments instead of Complement/Unions sets

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1232,7 +1232,7 @@ class Ray(LinearEntity):
         # normalizing the directions as magnitude of ray is infinite
         new_dir = self.direction.unit + other.direction.unit
         try:
-            r = Ray(self.p1, self.p1+(new_dir /new_dir.distance(Point(0,0))))
+            r = Ray(self.p1, self.p1 + new_dir)
         except ValueError:
             raise GeometryError("Invalid ray operation. Possibly adding 2 rays in opposite direction")
         return r
@@ -1241,7 +1241,7 @@ class Ray(LinearEntity):
         """Subtract two rays vectorially (with unit magnitude)"""
         new_dir = self.direction.unit - other.direction.unit
         try:
-            r = Ray(self.p1, self.p1+(new_dir/new_dir.distance(Point(0,0))))
+            r = Ray(self.p1, self.p1 + new_dir)
         except ValueError:
             raise GeometryError("Invalid ray operation. Possibly adding 2 rays in opposite direction")
         return r
@@ -1464,6 +1464,12 @@ class Segment(LinearEntity):
         elif dim == 3:
             return Segment3D(p1, p2, **kwargs)
         return LinearEntity.__new__(cls, p1, p2, **kwargs)
+
+    def __add__(self, other):
+        raise TypeError("unsupported operand type(s) for +: '%s' and '%s'" % (type(self), type(other)))
+
+    def __sub__(self, other):
+        raise TypeError("unsupported operand type(s) for -: '%s' and '%s'" % (type(self), type(other)))
 
     def contains(self, other):
         """

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1204,6 +1204,53 @@ class Ray(LinearEntity):
             'marker-start="url(#markerCircle)" marker-end="url(#markerArrow)"/>'
             ).format(2. * scale_factor, path, fill_color)
 
+    def __add__(self, other):
+        """Add other ray to self in a vector sense (with unit magnitude).
+
+        Parameters
+        ==========
+
+        other : The other ray object that is to be added vectorially with self
+
+        Returns
+        =======
+
+        r : a new ray from the source of self that is in the direction of 
+            (self + other)
+
+        Examples
+        ========
+
+        >>> from sympy.geometry.line import Ray2D
+        >>> from sympy.geometry.point import Point2D
+        >>> r1 = Ray2D(Point2D(1,1), Point2D(1,3))
+        >>> r2 = Ray2D(Point2D(2,2), Point2D(3,2))
+        >>> r1+r2
+        Ray2D(Point2D(1, 1), Point2D(sqrt(2)/2 + 1, sqrt(2)/2 + 1))
+        
+        """
+        s_dir, o_dir = self.direction, other.direction
+        # normalizing the directions as we are only 
+        # adding unit vectors of directions
+        s_dir, o_dir = s_dir/s_dir.distance(Point(0,0)), o_dir/o_dir.distance(Point(0,0))
+        new_dir = s_dir+o_dir
+        try:
+            r = Ray(self.p1, self.p1+(new_dir/new_dir.distance(Point(0,0))))
+        except ValueError:
+            raise GeometryError("Invalid ray operation. Possibly adding 2 rays in opposite direction")
+        return r
+
+    def __sub__(self, other):
+        """Subtract two rays vectorially (with unit magnitude)"""
+        s_dir, o_dir = self.direction, other.direction
+        s_dir, o_dir = s_dir/s_dir.distance(Point(0,0)), o_dir/o_dir.distance(Point(0,0))
+        new_dir = s_dir-o_dir
+        try:
+            r = Ray(self.p1, self.p1+(new_dir/new_dir.distance(Point(0,0))))
+        except ValueError:
+            raise GeometryError("Invalid ray operation. Possibly adding 2 rays in opposite direction")
+        return r
+
     def contains(self, other):
         """
         Is other GeometryEntity contained in this Ray?
@@ -1422,6 +1469,46 @@ class Segment(LinearEntity):
         elif dim == 3:
             return Segment3D(p1, p2, **kwargs)
         return LinearEntity.__new__(cls, p1, p2, **kwargs)
+
+    def __add__(self, other):
+        """Add other segment to self vectorially.
+
+        Parameters
+        ==========
+
+        other : The other segment object that is to be added vectorially
+                with self
+
+        Returns
+        =======
+
+        s : a new resultant segment from the addition of self and 'other'
+            segment
+
+        Notes
+        =====
+
+        The resulting segment is calculated by shifting the 'other' segment
+        parallelly such that the other.p1 is same as self.p1  
+
+        Examples
+        ========
+
+        >>> from sympy.geometry.line import Segment2D
+        >>> from sympy.geometry.point import Point2D
+        >>> s1 = Segment2D(Point2D(0,1), Point2D(0,3))
+        >>> s2 = Segment2D(Point2D(2,2), Point2D(3,2))
+        >>> s1+s2
+        Segment2D(Point2D(0, 1), Point2D(1, 3))
+        
+        """
+        new_dir = self.direction+other.direction
+        return Segment(self.p1, self.p1+new_dir)
+
+    def __sub__(self, other):
+        """Subtract two segments vectorially"""
+        new_dir = self.direction-other.direction
+        return Segment(self.p1, self.p1+new_dir)
 
     def contains(self, other):
         """

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1215,7 +1215,7 @@ class Ray(LinearEntity):
         Returns
         =======
 
-        r : a new ray from the source of self that is in the direction of 
+        r : a new ray from the source of self that is in the direction of
             (self + other)
 
         Examples
@@ -1223,28 +1223,23 @@ class Ray(LinearEntity):
 
         >>> from sympy.geometry.line import Ray2D
         >>> from sympy.geometry.point import Point2D
-        >>> r1 = Ray2D(Point2D(1,1), Point2D(1,3))
-        >>> r2 = Ray2D(Point2D(2,2), Point2D(3,2))
+        >>> r1 = Ray2D(Point2D(0,0), Point2D(0,10))
+        >>> r2 = Ray2D(Point2D(1,0), Point2D(2,0))
         >>> r1+r2
-        Ray2D(Point2D(1, 1), Point2D(sqrt(2)/2 + 1, sqrt(2)/2 + 1))
-        
+        Ray2D(Point2D(0, 0), Point2D(sqrt(2)/2, sqrt(2)/2)))
+
         """
-        s_dir, o_dir = self.direction, other.direction
-        # normalizing the directions as we are only 
-        # adding unit vectors of directions
-        s_dir, o_dir = s_dir/s_dir.distance(Point(0,0)), o_dir/o_dir.distance(Point(0,0))
-        new_dir = s_dir+o_dir
+        # normalizing the directions as magnitude of ray is infinite
+        new_dir = self.direction.unit + other.direction.unit
         try:
-            r = Ray(self.p1, self.p1+(new_dir/new_dir.distance(Point(0,0))))
+            r = Ray(self.p1, self.p1+(new_dir /new_dir.distance(Point(0,0))))
         except ValueError:
             raise GeometryError("Invalid ray operation. Possibly adding 2 rays in opposite direction")
         return r
 
     def __sub__(self, other):
         """Subtract two rays vectorially (with unit magnitude)"""
-        s_dir, o_dir = self.direction, other.direction
-        s_dir, o_dir = s_dir/s_dir.distance(Point(0,0)), o_dir/o_dir.distance(Point(0,0))
-        new_dir = s_dir-o_dir
+        new_dir = self.direction.unit - other.direction.unit
         try:
             r = Ray(self.p1, self.p1+(new_dir/new_dir.distance(Point(0,0))))
         except ValueError:
@@ -1469,46 +1464,6 @@ class Segment(LinearEntity):
         elif dim == 3:
             return Segment3D(p1, p2, **kwargs)
         return LinearEntity.__new__(cls, p1, p2, **kwargs)
-
-    def __add__(self, other):
-        """Add other segment to self vectorially.
-
-        Parameters
-        ==========
-
-        other : The other segment object that is to be added vectorially
-                with self
-
-        Returns
-        =======
-
-        s : a new resultant segment from the addition of self and 'other'
-            segment
-
-        Notes
-        =====
-
-        The resulting segment is calculated by shifting the 'other' segment
-        parallelly such that the other.p1 is same as self.p1  
-
-        Examples
-        ========
-
-        >>> from sympy.geometry.line import Segment2D
-        >>> from sympy.geometry.point import Point2D
-        >>> s1 = Segment2D(Point2D(0,1), Point2D(0,3))
-        >>> s2 = Segment2D(Point2D(2,2), Point2D(3,2))
-        >>> s1+s2
-        Segment2D(Point2D(0, 1), Point2D(1, 3))
-        
-        """
-        new_dir = self.direction+other.direction
-        return Segment(self.p1, self.p1+new_dir)
-
-    def __sub__(self, other):
-        """Subtract two segments vectorially"""
-        new_dir = self.direction-other.direction
-        return Segment(self.p1, self.p1+new_dir)
 
     def contains(self, other):
         """

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1226,7 +1226,7 @@ class Ray(LinearEntity):
         >>> r1 = Ray2D(Point2D(0,0), Point2D(0,10))
         >>> r2 = Ray2D(Point2D(1,0), Point2D(2,0))
         >>> r1+r2
-        Ray2D(Point2D(0, 0), Point2D(sqrt(2)/2, sqrt(2)/2)))
+        Ray2D(Point2D(0, 0), Point2D(1, 1))
 
         """
         # normalizing the directions as magnitude of ray is infinite

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1205,46 +1205,10 @@ class Ray(LinearEntity):
             ).format(2. * scale_factor, path, fill_color)
 
     def __add__(self, other):
-        """Add other ray to self in a vector sense (with unit magnitude).
-
-        Parameters
-        ==========
-
-        other : The other ray object that is to be added vectorially with self
-
-        Returns
-        =======
-
-        r : a new ray from the source of self that is in the direction of
-            (self + other)
-
-        Examples
-        ========
-
-        >>> from sympy.geometry.line import Ray2D
-        >>> from sympy.geometry.point import Point2D
-        >>> r1 = Ray2D(Point2D(0,0), Point2D(0,10))
-        >>> r2 = Ray2D(Point2D(1,0), Point2D(2,0))
-        >>> r1+r2
-        Ray2D(Point2D(0, 0), Point2D(1, 1))
-
-        """
-        # normalizing the directions as magnitude of ray is infinite
-        new_dir = self.direction.unit + other.direction.unit
-        try:
-            r = Ray(self.p1, self.p1 + new_dir)
-        except ValueError:
-            raise GeometryError("Invalid ray operation. Possibly adding 2 rays in opposite direction")
-        return r
+        raise TypeError("unsupported operand type(s) for +: '%s' and '%s'" % (type(self), type(other)))
 
     def __sub__(self, other):
-        """Subtract two rays vectorially (with unit magnitude)"""
-        new_dir = self.direction.unit - other.direction.unit
-        try:
-            r = Ray(self.p1, self.p1 + new_dir)
-        except ValueError:
-            raise GeometryError("Invalid ray operation. Possibly adding 2 rays in opposite direction")
-        return r
+        raise TypeError("unsupported operand type(s) for -: '%s' and '%s'" % (type(self), type(other)))
 
     def contains(self, other):
         """

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -142,8 +142,13 @@ def test_basic_properties_2d():
 
     r1 = Ray(p1, Point(0, 1))
     r2 = Ray(Point(0, 1), p1)
+    r3 = Ray(Point(1, 0), p2)
+    r4 = Ray(p2, Point(1, 0))
 
     s1 = Segment(p1, p10)
+    s2 = Segment(p1, Point(0,1))
+    s3 = Segment(p1, Point(1,0))
+    s4 = Segment(p1,p2)
     p_s1 = s1.random_point()
 
     assert Line((1, 1), slope=1) == Line((1, 1), (2, 2))
@@ -161,8 +166,11 @@ def test_basic_properties_2d():
     assert s1 in Line(p1, p10)
     assert Ray(Point(0, 0), Point(0, 1)) in Ray(Point(0, 0), Point(0, 2))
     assert Ray(Point(0, 0), Point(0, 2)) in Ray(Point(0, 0), Point(0, 1))
+    assert (r1+r3) == r1
+    assert (r1-r4) == r1
     assert (r1 in s1) is False
     assert Segment(p1, p2) in s1
+    assert (s2+s3) == s4
     assert Ray(Point(x1, x1), Point(x1, 1 + x1)) != Ray(p1, Point(-1, 5))
     assert Segment(p1, p2).midpoint == Point(Rational(1, 2), Rational(1, 2))
     assert Segment(p1, Point(-x1, x1)).length == sqrt(2 * (x1 ** 2))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -53,6 +53,14 @@ def test_angle_between():
                                 Line3D(Point3D(0, 0, 0), Point3D(5, 0, 0))), acos(sqrt(3) / 3)
 
 
+def test_closing_angle():
+    a = Ray((0, 0), angle=0)
+    b = Ray((1, 2), angle=pi/2)
+    assert a.closing_angle(b) == -pi/2
+    assert b.closing_angle(a) == pi/2
+    assert a.closing_angle(a) == 0
+
+
 def test_arbitrary_point():
     l1 = Line3D(Point3D(0, 0, 0), Point3D(1, 1, 1))
     l2 = Line(Point(x1, x1), Point(y1, y1))
@@ -142,8 +150,6 @@ def test_basic_properties_2d():
 
     r1 = Ray(p1, Point(0, 1))
     r2 = Ray(Point(0, 1), p1)
-    r3 = Ray(Point(1, 0), p2)
-    r4 = Ray(p2, Point(1, 0))
 
     s1 = Segment(p1, p10)
     p_s1 = s1.random_point()
@@ -163,8 +169,6 @@ def test_basic_properties_2d():
     assert s1 in Line(p1, p10)
     assert Ray(Point(0, 0), Point(0, 1)) in Ray(Point(0, 0), Point(0, 2))
     assert Ray(Point(0, 0), Point(0, 2)) in Ray(Point(0, 0), Point(0, 1))
-    assert (r1+r3) == Ray(Point(0, 0), Point(0, 2))
-    assert (r1-r4) == Ray(Point(0, 0), Point(0, 2))
     assert (r1 in s1) is False
     assert Segment(p1, p2) in s1
     assert Ray(Point(x1, x1), Point(x1, 1 + x1)) != Ray(p1, Point(-1, 5))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -146,9 +146,6 @@ def test_basic_properties_2d():
     r4 = Ray(p2, Point(1, 0))
 
     s1 = Segment(p1, p10)
-    s2 = Segment(p1, Point(0,1))
-    s3 = Segment(p1, Point(1,0))
-    s4 = Segment(p1,p2)
     p_s1 = s1.random_point()
 
     assert Line((1, 1), slope=1) == Line((1, 1), (2, 2))
@@ -170,7 +167,6 @@ def test_basic_properties_2d():
     assert (r1-r4) == r1
     assert (r1 in s1) is False
     assert Segment(p1, p2) in s1
-    assert (s2+s3) == s4
     assert Ray(Point(x1, x1), Point(x1, 1 + x1)) != Ray(p1, Point(-1, 5))
     assert Segment(p1, p2).midpoint == Point(Rational(1, 2), Rational(1, 2))
     assert Segment(p1, Point(-x1, x1)).length == sqrt(2 * (x1 ** 2))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -163,8 +163,8 @@ def test_basic_properties_2d():
     assert s1 in Line(p1, p10)
     assert Ray(Point(0, 0), Point(0, 1)) in Ray(Point(0, 0), Point(0, 2))
     assert Ray(Point(0, 0), Point(0, 2)) in Ray(Point(0, 0), Point(0, 1))
-    assert (r1+r3) == r1
-    assert (r1-r4) == r1
+    assert (r1+r3) == Ray(Point(0, 0), Point(0, 2))
+    assert (r1-r4) == Ray(Point(0, 0), Point(0, 2))
     assert (r1 in s1) is False
     assert Segment(p1, p2) in s1
     assert Ray(Point(x1, x1), Point(x1, 1 + x1)) != Ray(p1, Point(-1, 5))


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #12988.
For Ray class, I have handled the exception of addition(subtraction) of opposite(same) rays.
Added some tests for 2D case. This could be extended to 3D as well.