### PR TITLE
Simplification with assumptions: refine and abs

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy.core import S, Add, Expr, Basic
+from sympy.core import S, Add, Expr, Basic, Mul
 from sympy.assumptions import Q, ask
 
 
@@ -70,6 +70,9 @@ def refine_abs(expr, assumptions):
         return arg
     if ask(Q.negative(arg), assumptions):
         return -arg
+    # arg is Mul
+    if isinstance(arg, Mul):
+        return refine(abs(arg.args[0]), assumptions) * refine(abs(arg / arg.args[0]), assumptions)
 
 
 def refine_Pow(expr, assumptions):

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division
 from sympy.core import S, Add, Expr, Basic, Mul
 from sympy.assumptions import Q, ask
 
-
 def refine(expr, assumptions=True):
     """
     Simplify an expression using assumptions.
@@ -63,6 +62,7 @@ def refine_abs(expr, assumptions):
 
     """
     from sympy.core.logic import fuzzy_not
+    from sympy import Abs
     arg = expr.args[0]
     if ask(Q.real(arg), assumptions) and \
             fuzzy_not(ask(Q.negative(arg), assumptions)):
@@ -72,7 +72,15 @@ def refine_abs(expr, assumptions):
         return -arg
     # arg is Mul
     if isinstance(arg, Mul):
-        return refine(abs(arg.args[0]), assumptions) * refine(abs(arg / arg.args[0]), assumptions)
+        r = [refine(abs(a), assumptions) for a in arg.args]
+        non_abs = []
+        in_abs = []
+        for i in r:
+            if isinstance(i, Abs):
+                in_abs.append(i.args[0])
+            else:
+                non_abs.append(i)
+        return Mul(*non_abs) * Abs(Mul(*in_abs))
 
 
 def refine_Pow(expr, assumptions):

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -174,3 +174,12 @@ def test_eval_refine():
 
     mock_obj = MockExpr()
     assert refine(mock_obj)
+
+def test_refine_issue_12724():
+    expr1 = refine(Abs(x * y), Q.positive(x))
+    expr2 = refine(Abs(x * y * z), Q.positive(x))
+    assert expr1 == x * Abs(y)
+    assert expr2 == x * Abs(y) * Abs(z)
+    y1 = Symbol('y1', real = True)
+    expr3 = refine(Abs(x * y1**2 * z), Q.positive(x))
+    assert expr3 == x * y1**2 * Abs(z)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -179,7 +179,7 @@ def test_refine_issue_12724():
     expr1 = refine(Abs(x * y), Q.positive(x))
     expr2 = refine(Abs(x * y * z), Q.positive(x))
     assert expr1 == x * Abs(y)
-    assert expr2 == x * Abs(y) * Abs(z)
+    assert expr2 == x * Abs(y * z)
     y1 = Symbol('y1', real = True)
     expr3 = refine(Abs(x * y1**2 * z), Q.positive(x))
     assert expr3 == x * y1**2 * Abs(z)


### PR DESCRIPTION
This deals with  #12724. In case of `refine(abs(x*y), Q.positive(x))`
the result was `Abs(x*y)`, which is mathematically correct. A better result
is `x * Abs(y)`.

This PR proposes a change in `refine_abs()` method in `sympy/assumptions/refine.py`.
In the case the arg is a multiplication, the `Abs` is splitted according to the factors of arg.
A test is added in `sympy/assumptions/tests/test_refine.py`.

