### PR TITLE
Changed Py3.5 to Py3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
             - libatlas-base-dev
             - liblapack-dev
             - gfortran
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"


### PR DESCRIPTION
#12814 

Changed the version for tests common to both Py2.7 and Py3.5 to Py2.7 and Py3.6 respectively. 