### PR TITLE
groups: fix FpSubgroup's "contains" method

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -297,12 +297,13 @@ class FpSubgroup(DefaultPrinting):
     group belongs to the subgroup
 
     '''
-    def __init__(self, G, gens):
+    def __init__(self, G, gens, normal=False):
         super(FpSubgroup,self).__init__()
         self.parent = G
         self.generators = list(set([g for g in gens if g != G.identity]))
         self._min_words = None #for use in __contains__
         self.C = None
+        self.normal = normal
 
     def __contains__(self, g):
 
@@ -330,6 +331,8 @@ class FpSubgroup(DefaultPrinting):
                 # make the initial list
                 gens = []
                 for w in self.generators:
+                    if self.normal:
+                        w = w.cyclic_reduction()
                     gens.extend(_process(w))
 
                 for w1 in gens:
@@ -381,7 +384,7 @@ class FpSubgroup(DefaultPrinting):
                 # check if w is a word in _min_words or one of
                 # the infinite families in it
                 w, r = w.cyclic_reduction(removed=True)
-                if r.is_identity:
+                if r.is_identity or self.normal:
                     return w in min_words
                 else:
                     t = [s[1] for s in min_words if isinstance(s, tuple)
@@ -410,6 +413,8 @@ class FpSubgroup(DefaultPrinting):
                         return True
                 return False
 
+            if self.normal:
+                g = g.cyclic_reduction()
             return _word_break(g)
         else:
             if self.C is None:

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -444,6 +444,15 @@ class FpSubgroup(DefaultPrinting):
             return free_group(', '.join(gen_syms))[0]
         return self.parent.subgroup(C=self.C)
 
+    def __str__(self):
+        if len(self.generators) > 30:
+            str_form = "<fp subgroup with %s generators>" % len(self.generators)
+        else:
+            str_form = "<fp subgroup on the generators %s>" % str(self.generators)
+        return str_form
+
+    __repr__ = __str__
+
 
 ###############################################################################
 #                           LOW INDEX SUBGROUPS                               #

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -84,14 +84,14 @@ class GroupHomomorphism(object):
             raise NotImplementedError(
                 "Kernel computation is not implemented for infinite groups")
         gens = []
-        K = FpSubgroup(G, gens)
+        K = FpSubgroup(G, gens, normal=True)
         i = self.image().order()
         while K.order()*i != G_order:
             r = G.random_element()
             k = r*self.invert(self(r))
             if not k in K:
                 gens.append(k)
-                K = FpSubgroup(G, gens)
+                K = FpSubgroup(G, gens, normal=True)
         return K
 
     def image(self):

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -160,7 +160,6 @@ def test_order():
     assert f.order() == 2000
 
 def test_fp_subgroup():
-    from sympy import S
     F, x, y = free_group("x, y")
     f = FpGroup(F, [x**4, y**2, x*y*x**-1*y])
     S = FpSubgroup(f, [x*y])

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from sympy import S
 from sympy.combinatorics.fp_groups import (FpGroup, low_index_subgroups,
-                                           reidemeister_presentation)
+                                   reidemeister_presentation, FpSubgroup)
 from sympy.combinatorics.free_groups import free_group
 
 """
@@ -158,3 +158,14 @@ def test_order():
     F, a, b, c = free_group("a, b, c")
     f = FpGroup(F, [a**250, b**2, c*b*c**-1*b, c**4, c**-1*a**-1*c*a, a**-1*b**-1*a*b])
     assert f.order() == 2000
+
+def test_fp_subgroup():
+    from sympy import S
+    F, x, y = free_group("x, y")
+    f = FpGroup(F, [x**4, y**2, x*y*x**-1*y])
+    S = FpSubgroup(f, [x*y])
+    assert (x*y)**-3 in S
+
+    S = FpSubgroup(F, [x**-1*y*x])
+    assert x**-1*y**4*x in S
+    assert x**-1*y**4*x**2 not in S


### PR DESCRIPTION
This PR extends the `__contains__` method of the `FpSubgroup` class to handle subgroups of free groups generated by a set containing elements that are not cyclically reduced, i.e. of the form `r*w*r**-1`
for some words `r` and `w`. Previously they would lead to an infinite loop as the method would try to add
all words of the form `r*w**n*r**-1` to a list. Now, this infinite family is handled by checking for cyclic reduction and appending the tuple `(r, w)` to the list instead.

Two new methods were added for `FreeGroupElement`s.
 * `cyclic_reduction` is similar to `identity_cyclic_reduction` but doesn't cyclically permute the reduced part of the word. For example, `(x**-3*y*x**5).identity_cyclic_reduction() == x**2*y` while `(x**-3*y*x**5).cyclic_reduction() == y*x**2`. Also, it has a keyword argument for returning the removed part (in this case `x**-3`).
* `power_of` checks if the word is a power of some other word.