### PR TITLE
Add method for inverse rotation matrix. 

### DIFF
--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -388,12 +388,14 @@ class CoordSys3D(Basic):
                   diff(equations[2], self.z)**2)
         return map(simplify, [h1, h2, h3])
 
-    def _rotation_trans_equations(self):
+    def _inverse_rotation_matrix(self):
+        return simplify(self._parent_rotation_matrix ** -1)
+
+    def _rotation_trans_equations(self, matrix):
         """
         Returns the transformation equations obtained from rotation matrix.
 
         """
-        matrix = self._parent_rotation_matrix
 
         trans_eq1 = matrix[0]*self.x + matrix[1]*self.y + matrix[2]*self.z
         trans_eq2 = matrix[3]*self.x + matrix[4]*self.y + matrix[5]*self.z

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -389,6 +389,10 @@ class CoordSys3D(Basic):
         return map(simplify, [h1, h2, h3])
 
     def _inverse_rotation_matrix(self):
+        """
+        Returns inverse rotation matrix.
+
+        """
         return simplify(self._parent_rotation_matrix ** -1)
 
     def _rotation_trans_equations(self, matrix):

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -387,6 +387,15 @@ def test_coordsys3d():
 
 def test_rotation_trans_equations():
     a = CoordSys3D('a')
+    from sympy import symbols
+    q0 = symbols('q0')
     assert a._rotation_trans_equations(a._parent_rotation_matrix) == (a.x, a.y, a.z)
+    assert a._rotation_trans_equations(a._inverse_rotation_matrix()) == (a.x, a.y, a.z)
     b = a.orient_new_axis('b', 0, -a.k)
-    assert b._rotation_trans_equations(a._parent_rotation_matrix) == (b.x, b.y, b.z)
+    assert b._rotation_trans_equations(b._parent_rotation_matrix) == (b.x, b.y, b.z)
+    assert b._rotation_trans_equations(b._inverse_rotation_matrix()) == (b.x, b.y, b.z)
+    c = a.orient_new_axis('c', q0, -a.k)
+    assert c._rotation_trans_equations(c._parent_rotation_matrix) == \
+           (-sin(q0) * c.y + cos(q0) * c.x, sin(q0) * c.x + cos(q0) * c.y, c.z)
+    assert c._rotation_trans_equations(c._inverse_rotation_matrix()) == \
+           (sin(q0) * c.y + cos(q0) * c.x, -sin(q0) * c.x + cos(q0) * c.y, c.z)

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -387,6 +387,6 @@ def test_coordsys3d():
 
 def test_rotation_trans_equations():
     a = CoordSys3D('a')
-    assert a._rotation_trans_equations() == (a.x, a.y, a.z)
+    assert a._rotation_trans_equations(a._parent_rotation_matrix) == (a.x, a.y, a.z)
     b = a.orient_new_axis('b', 0, -a.k)
-    assert b._rotation_trans_equations() == (b.x, b.y, b.z)
+    assert b._rotation_trans_equations(a._parent_rotation_matrix) == (b.x, b.y, b.z)


### PR DESCRIPTION
This PR introduces method for calculation inverse transformation matrix. 
It wil be used for calculation of inverse transformation equations. 

It could be also done by substitution `angle` -> `-angle`. The result is the same if we remember that sine is odd `-sin(angle)=sin(-angle)` and cosine is even `cos(-angle)=cos(angle)`