### PR TITLE
link added for as_content_primitive() in basic.py and typo-fix

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -701,7 +701,10 @@ class Basic(with_metaclass(ManagedProperties)):
         """A stub to allow Basic args (like Tuple) to be skipped when computing
         the content and primitive components of an expression.
 
-        See docstring of Expr.as_content_primitive
+        See Also
+        ========
+
+        sympy.core.expr.Expr.as_content_primitive
         """
         return S.One, self
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1861,7 +1861,7 @@ class Expr(Basic, EvalfMixin):
         """This method should recursively remove a Rational from all arguments
         and return that (content) and the new self (primitive). The content
         should always be positive and ``Mul(*foo.as_content_primitive()) == foo``.
-        The primitive need no be in canonical form and should try to preserve
+        The primitive need not be in canonical form and should try to preserve
         the underlying structure if possible (i.e. expand_mul should not be
         applied to self).
 


### PR DESCRIPTION
This PR is an attempt to improve the docstring in `basic.py`. `as_content_primitive()` is defined in both `basic.py` and `expr.py`. At present the one in `basic.py` simply tells  to `See docstring of Expr.as_content_primitive`, but I thought it would be better if a link is provided instead, so that the reader can be redirected easily. And also there is a small typo-fix(`no-not`)