### PR TITLE
integrals/intpoly: Change list casting to set casting for decompose()

### DIFF
--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -556,7 +556,7 @@ def decompose(expr, separate=False):
     >>> decompose(x**2 + x*y + x + y + x**3*y**2 + y**5)
     {1: x + y, 2: x**2 + x*y, 5: x**3*y**2 + y**5}
     >>> decompose(x**2 + x*y + x + y + x**3*y**2 + y**5, True)
-    [x, y, x**2, y**5, x*y, x**3*y**2]
+    {x, x**2, y, y**5, x*y, x**3*y**2}
     """
     expr = S(expr)
     poly_dict = {}

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -569,7 +569,7 @@ def decompose(expr, separate=False):
             degrees = [(sum(degree_list(monom, *symbols)), monom)
                        for monom in expr.args]
             if separate:
-                return [monom[1] for monom in degrees]
+                return {monom[1] for monom in degrees}
             else:
                 for monom in degrees:
                     degree, term = monom
@@ -593,7 +593,7 @@ def decompose(expr, separate=False):
         poly_dict[0] = expr
 
     if separate:
-        return list(poly_dict.values())
+        return set(poly_dict.values())
     return poly_dict
 
 

--- a/sympy/integrals/tests/test_intpoly.py
+++ b/sympy/integrals/tests/test_intpoly.py
@@ -26,15 +26,15 @@ def test_decompose():
     assert decompose(9*x**2 + y + 4*x + x**3 + y**2*x + 3) ==\
         {0: 3, 1: 4*x + y, 2: 9*x**2, 3: x**3 + x*y**2}
 
-    assert decompose(x, True) == [x]
-    assert decompose(x ** 2, True) == [x ** 2]
-    assert decompose(x * y, True) == [x * y]
-    assert decompose(x + y, True) == [x, y]
-    assert decompose(x ** 2 + y, True) == [y, x ** 2]
-    assert decompose(8 * x ** 2 + 4 * y + 7, True) == [7, 4*y, 8*x**2]
-    assert decompose(x ** 2 + 3 * y * x, True) == [x ** 2, 3 * x * y]
+    assert decompose(x, True) == {x}
+    assert decompose(x ** 2, True) == {x**2}
+    assert decompose(x * y, True) == {x * y}
+    assert decompose(x + y, True) == {x, y}
+    assert decompose(x ** 2 + y, True) == {y, x ** 2}
+    assert decompose(8 * x ** 2 + 4 * y + 7, True) == {7, 4*y, 8*x**2}
+    assert decompose(x ** 2 + 3 * y * x, True) == {x ** 2, 3 * x * y}
     assert decompose(9 * x ** 2 + y + 4 * x + x ** 3 + y ** 2 * x + 3, True) == \
-           [3, y, x**3, 4*x, 9*x**2, x*y**2]
+           {3, y, 4*x, 9*x**2, x*y**2, x**3}
 
 
 def test_best_origin():


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
@asmeurer If `separate=True` the dictionary will have duplicate keys when `expr` is of `Add` type. Then a `list` or more correctly a `set` should be returned. I did not directly return `set` for other cases because of more if-else checks.
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #13042 