### PR TITLE
Minor Improvement To LieAlgebras Module

### DIFF
--- a/sympy/core/backend.py
+++ b/sympy/core/backend.py
@@ -10,6 +10,7 @@ if USE_SYMENGINE:
         lambdify, symarray, diff, zeros, eye, diag, ones, zeros,
         expand, Function, symbols, var, Add, Mul, Derivative,
         ImmutableMatrix, MatrixBase, Rational, Basic)
+    from symengine.lib.symengine_wrapper import gcd as igcd
     from symengine import AppliedUndef
 else:
     from sympy import (Symbol, Integer, sympify, S,
@@ -18,5 +19,5 @@ else:
         sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth,
         lambdify, symarray, diff, zeros, eye, diag, ones, zeros,
         expand, Function, symbols, var, Add, Mul, Derivative,
-        ImmutableMatrix, MatrixBase, Rational, Basic)
+        ImmutableMatrix, MatrixBase, Rational, Basic, igcd)
     from sympy.core.function import AppliedUndef

--- a/sympy/liealgebras/weyl_group.py
+++ b/sympy/liealgebras/weyl_group.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from sympy.core.compatibility import range
-from sympy.core.numbers import igcd
 from .cartan_type import CartanType
 from mpmath import fac
-from sympy.core.backend import Matrix, eye, Rational, Basic
+from sympy.core.backend import Matrix, eye, Rational, Basic, igcd
 
 class WeylGroup(Basic):
 
@@ -174,7 +173,7 @@ class WeylGroup(Basic):
                 if len(reflections) == 1:
                     return 2
                 else:
-                    m = len(reflections) / 2
+                    m = len(reflections) // 2
                     lcm = (6 * m)/ igcd(m, 6)
                 order = lcm / m
                 return order


### PR DESCRIPTION
These changes were made because the argument `m` wasn't simplified to an `int` in the case of  `SymEngine`, and hence `igcd` was throwing:
```
 `_____________________________________________________________ sympy/liealgebras/tests/test_weyl_group.py:test_weyl_group ______________________________________________________________
  File "/home/shikhar/sympy/sympy/liealgebras/tests/test_weyl_group.py", line 25, in test_weyl_group
    assert f.element_order('r1*r2*r1*r2') == 3
  File "/home/shikhar/sympy/sympy/liealgebras/weyl_group.py", line 179, in element_order
    lcm = (6 * m)/ igcd(m, 6)
  File "symengine/lib/symengine_wrapper.pyx", line 2691, in symengine.lib.symengine_wrapper.gcd (/feedstock_root/build_artefacts/python-symengine_1498959768456/work/symengine.py-b409536eb9029b274d2956ec14a7954a0089aa3a/build/lib.linux-x86_64-3.6/symengine/lib/symengine_wrapper.cpp:77069)
  File "symengine/lib/symengine_wrapper.pyx", line 2658, in symengine.lib.symengine_wrapper.require (/feedstock_root/build_artefacts/python-symengine_1498959768456/work/symengine.py-b409536eb9029b274d2956ec14a7954a0089aa3a/build/lib.linux-x86_64-3.6/symengine/lib/symengine_wrapper.cpp:75878)
TypeError: <class 'symengine.lib.symengine_wrapper.Integer'> required. 2.0 is of type <class 'symengine.lib.symengine_wrapper.RealDouble'>
```