### PR TITLE
Min/Max._eval_simplify added

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -354,6 +354,32 @@ class MinMaxBase(Expr, LatticeOp):
             obj._argset = _args
             return obj
 
+    def _eval_simplify(self, ratio, measure):
+        # simplify Min(foo, y, Max(foo, x)) to Min(foo, y)
+        # Like And/Or, anything in common between the two
+        # is cause to eliminate the opposite arg.
+        cls = self.func
+        if cls == Min:
+            op = Max
+        elif cls == Max:
+            op = Min
+        else:
+            op = None
+        if op:
+            unnested = set()
+            nested = []
+            remove = []
+            for a in self.args:
+                if isinstance(a, op):
+                    nested.append(a)
+                else:
+                    unnested.add(a)
+            N = len(nested) - 1
+            for i, n in enumerate(reversed(nested)):
+                if set(n.args) & unnested:
+                    nested.pop(N - i)
+            return cls(*(list(unnested) + nested))
+
     @classmethod
     def _new_args_filter(cls, arg_sequence):
         """

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -369,3 +369,10 @@ def test_issue_11099():
             Min(x, y).subs(random_test_data).evalf()
         assert Max(x, y).evalf(subs=random_test_data) == \
             Max(x, y).subs(random_test_data).evalf()
+
+
+def test_issue_12638():
+    from sympy.abc import a, b, c, d
+    assert Min(a, b, c, Max(a, b)).simplify() == Min(a, b, c)
+    assert Min(a, b, Max(a, b, c)).simplify() == Min(a, b)
+    assert Min(a, b, Max(a, c)).simplify() == Min(a, b)


### PR DESCRIPTION
closes #12638, allowing Min and Max to respond to `simplify`

See added tests for examples.