### PR TITLE
12709: trailing(-positive) == trailing(positive)

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -32,10 +32,9 @@ rnd = round_nearest
 
 
 def bitcount(n):
-    """Return smallest integer, b, such that n/2**b < 1. This means
-    that b is 0 if n < 1.
+    """Return smallest integer, b, such that |n|/2**b < 1.
     """
-    return mpmath_bitcount(int(n))
+    return mpmath_bitcount(abs(int(n)))
 
 # Used in a few places as placeholder values to denote exponents and
 # precision levels, e.g. of exact numbers. Must be careful to avoid

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -32,6 +32,9 @@ rnd = round_nearest
 
 
 def bitcount(n):
+    """Return smallest integer, b, such that n/2**b < 1. This means
+    that b is 0 if n < 1.
+    """
     return mpmath_bitcount(int(n))
 
 # Used in a few places as placeholder values to denote exponents and

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -166,7 +166,7 @@ def trailing(n):
     >>> trailing(63)
     0
     """
-    n = int(n)
+    n = abs(int(n))
     if not n:
         return 0
     low_byte = n & 0xff

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -1,6 +1,7 @@
 from sympy import (Sieve, binomial_coefficients, binomial_coefficients_list,
     Mul, S, Pow, sieve, Symbol, summation, Dummy,
     factorial as fac)
+from sympy.core.evalf import bitcount
 from sympy.core.numbers import Integer, Rational
 from sympy.core.compatibility import long, range
 
@@ -66,7 +67,7 @@ def multiproduct(seq=(), start=1):
     return units * multiproduct(multi)**2
 
 
-def test_trailing():
+def test_trailing_bitcount():
     assert trailing(0) == 0
     assert trailing(1) == 0
     assert trailing(-1) == 0
@@ -81,6 +82,7 @@ def test_trailing():
     # issue 12709
     big = small_trailing[-1]*2
     assert trailing(-big) == trailing(big)
+    assert bitcount(-big) == bitcount(big)
 
 
 def test_multiplicity():

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -12,7 +12,7 @@ from sympy.ntheory import (isprime, n_order, is_primitive_root,
     factorrat, reduced_totient)
 from sympy.ntheory.factor_ import (smoothness, smoothness_p,
     antidivisors, antidivisor_count, core, digits, udivisors, udivisor_sigma,
-    udivisor_count, primenu, primeomega)
+    udivisor_count, primenu, primeomega, small_trailing)
 from sympy.ntheory.generate import cycle_length
 from sympy.ntheory.multinomial import (
     multinomial_coefficients, multinomial_coefficients_iterator)
@@ -78,6 +78,9 @@ def test_trailing():
         assert trailing((1 << i) * 31337) == i
     assert trailing((1 << 1000001)) == 1000001
     assert trailing((1 << 273956)*7**37) == 273956
+    # issue 12709
+    big = small_trailing[-1]*2
+    assert trailing(-big) == trailing(big)
 
 
 def test_multiplicity():


### PR DESCRIPTION
Fixes #12709 . 

The problem arises when trailing (or bitcount) is given a negative number. Both use abs on their arguments now.