### PR TITLE
incorporating solve_decomposition to solve exp, trig and other equations.

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -620,7 +620,7 @@ def solve_decomposition(f, symbol, domain):
         result = S.EmptySet
         if isinstance(y_s, FiniteSet):
             for y in y_s:
-                solutions = solveset(Eq(g, y), symbol, domain)
+                solutions = _solveset(g - y, symbol, domain, _check=True)
                 if not isinstance(solutions, ConditionSet):
                     result += solutions
 
@@ -632,7 +632,7 @@ def solve_decomposition(f, symbol, domain):
                 iter_iset = y_s.args
 
             for iset in iter_iset:
-                new_solutions = solveset(Eq(iset.lamda.expr, g), symbol, domain)
+                new_solutions = _solveset(iset.lamda.expr - g, symbol, domain, _check=True)
                 dummy_var = tuple(iset.lamda.expr.free_symbols)[0]
                 base_set = iset.base_set
                 if isinstance(new_solutions, FiniteSet):
@@ -923,15 +923,13 @@ def solveset(f, symbol=None, domain=S.Complexes):
             result = ConditionSet(symbol, f, domain)
         return result
 
-    res = _solveset(f, symbol, domain, _check=True)
-
-    if isinstance(res, ConditionSet):
+    if decompogen(f, symbol)[0] == f:
+        return _solveset(f, symbol, domain, _check=True)
+    else:
         try:
             return solve_decomposition(f, symbol, domain)
         except:
-            return ConditionSet(symbol, Eq(f, 0), domain)
-    else:
-        return res
+            return _solveset(f, symbol, domain, _check=True)
 
 
 def solveset_real(f, symbol):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -391,7 +391,10 @@ def _solve_as_rational(f, symbol, domain):
     else:
         valid_solns = _solveset(g, symbol, domain)
         invalid_solns = _solveset(h, symbol, domain)
-        return valid_solns - invalid_solns
+        if isinstance(valid_solns, ConditionSet) or isinstance(invalid_solns, ConditionSet):
+            return ConditionSet(f, symbol, domain)
+        else:
+            return valid_solns - invalid_solns
 
 
 def _solve_trig(f, symbol, domain):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -419,7 +419,12 @@ def _solve_trig(f, symbol, domain):
     elif solns is S.EmptySet:
         return S.EmptySet
     else:
-        return ConditionSet(symbol, Eq(f_original, 0), S.Reals)
+        #try solving through solve_decomposition
+        try:
+            result = solve_decomposition(f_original, symbol, domain)
+            return result
+        except:
+            return ConditionSet(symbol, Eq(f_original, 0), S.Reals)
 
 
 def _solve_as_poly(f, symbol, domain=S.Complexes):
@@ -436,7 +441,10 @@ def _solve_as_poly(f, symbol, domain=S.Complexes):
             result = FiniteSet(*solns.keys())
         else:
             poly = Poly(f, symbol)
-            solns = poly.all_roots()
+            try:
+                solns = poly.all_roots()
+            except:
+                pass
             if poly.degree() <= len(solns):
                 result = FiniteSet(*solns)
             else:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -41,7 +41,6 @@ n = Symbol('n', real=True)
 
 
 def test_invert_real():
-
     x = Symbol('x', real=True)
     y = Symbol('y')
     n = Symbol('n')
@@ -757,12 +756,13 @@ def test_solve_trig():
     assert solveset(sin(y + a) - sin(y), a, domain=S.Reals) == \
         imageset(Lambda(n, 2*n*pi), S.Integers)
 
+
 def test_issue_13084():
     n = Dummy('n')
-    f2 = sin(2*x)**2 + 2* sin(2*x) + 1
-    f3 = sin(2*x) + 1
-    assert solveset(f2, x, S.Reals) == imageset(Lambda(n, pi*(4*n + 3)/4), S.Integers)
-    assert solveset(f3, x, S.Reals) == imageset(Lambda(n, pi*(4*n + 3)/4), S.Integers)
+    f1 = sin(2*x)**2 + 2* sin(2*x) + 1
+    f2 = sin(2*x) + 1
+    assert solveset(f1, x, S.Reals) == ImageSet(Lambda(n, n*pi + 3*pi/4), S.Integers)
+    assert solveset(f1, x, S.Reals) == ImageSet(Lambda(n, n*pi + 3*pi/4), S.Integers)
 
 @XFAIL
 def test_solve_trig_abs():
@@ -903,29 +903,33 @@ def test_solveset():
     assert solveset(Eq(exp(x), 1), x) == imageset(Lambda(n, 2*I*pi*n),
                                                   S.Integers)
 
+
 def test_conditionset():
-    n = Dummy('n')
     assert solveset(Eq(sin(x)**2 + cos(x)**2, 1), x, domain=S.Reals) == \
         ConditionSet(x, True, S.Reals)
-    assert solveset(x**2 + x*sin(x) - 1, x, domain=S.Reals) == \
-        ConditionSet(x, Eq(x**2 + x*sin(x) - 1, 0), S.Reals)
 
-    assert solveset(sin(Abs(x)) - x, x, domain=S.Reals) == \
+    assert solveset(Eq(x**2 + x*sin(x), 1), x, domain=S.Reals) == \
+        ConditionSet(x, Eq(x*(x + sin(x)) - 1, 0), S.Reals)
+
+    assert solveset(Eq(sin(Abs(x)), x), x, domain=S.Reals) == \
         ConditionSet(x, Eq(-x + sin(Abs(x)), 0), Interval(-oo, oo))
 
-    assert solveset(-I*(exp(I*x) - exp(-I*x))/2 - 1, x) == \
+    assert solveset(Eq(-I*(exp(I*x) - exp(-I*x))/2, 1), x) == \
         imageset(Lambda(n, 2*n*pi + pi/2), S.Integers)
 
     assert solveset(x + sin(x) > 1, x, domain=S.Reals) == \
         ConditionSet(x, x + sin(x) > 1, S.Reals)
+
 
 @XFAIL
 def test_conditionset_equality():
     ''' Checking equality of different representations of ConditionSet'''
     assert solveset(Eq(tan(x), y), x) == ConditionSet(x, Eq(tan(x), y), S.Complexes)
 
+
 def test_solveset_domain():
     x = Symbol('x')
+
     assert solveset(x**2 - x - 6, x, Interval(0, oo)) == FiniteSet(3)
     assert solveset(x**2 - 1, x, Interval(0, oo)) == FiniteSet(1)
     assert solveset(x**4 - 16, x, Interval(0, 10)) == FiniteSet(2)
@@ -936,7 +940,7 @@ def test_improve_coverage():
     x = Symbol('x')
     y = exp(x+1/x**2)
     solution = solveset(y**2+y, x, S.Reals)
-    unsolved_object = ConditionSet(x, Eq(exp(x + x**(-2)) + exp(2*x + 2/x**2), 0), S.Reals)
+    unsolved_object = ConditionSet(x, Eq((exp((x**3 + 1)/x**2) + 1)*exp((x**3 + 1)/x**2), 0), S.Reals)
     assert solution == unsolved_object
 
     assert _has_rational_power(sin(x)*exp(x) + 1, x) == (False, S.One)
@@ -1004,9 +1008,6 @@ def test_linsolve():
     assert linsolve(M, (x1, x2, x3, x4)) == sol
     assert linsolve(Eqns, (x1, x2, x3, x4)) == sol
     assert linsolve(system1, (x1, x2, x3, x4)) == sol
-
-    # raise ValueError if no symbols are given
-    raises(ValueError, lambda: linsolve(system1))
 
     # raise ValueError if, A & b is not given as tuple
     raises(ValueError, lambda: linsolve(A, b, x1, x2, x3, x4))
@@ -1506,7 +1507,7 @@ def test_simplification():
 def test_issue_10555():
     f = Function('f')
     assert solveset(f(x) - pi/2, x, S.Reals) == \
-        ConditionSet(x, Eq(f(x) - pi/2, 0), S.Reals)
+        ConditionSet(x, Eq(2*f(x) - pi, 0), S.Reals)
 
 
 def test_issue_8715():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -757,9 +757,11 @@ def test_solve_trig():
         imageset(Lambda(n, 2*n*pi), S.Integers)
 
 def test_issue_13084():
-    f = sin(2*x + 3) - Rational(1,2)
-    assert solveset(f, x, S.Reals) == ConditionSet(x, Eq(sin(2*x + 3) - 1/2, 0), S.Reals)
-
+    n = Dummy('n')
+    f2 = sin(2*x)**2 + 2* sin(2*x) + 1
+    f3 = sin(2*x) + 1
+    assert solveset(f2, x, S.Reals) == imageset(Lambda(n, pi*(4*n + 3)/4), S.Integers)
+    assert solveset(f3, x, S.Reals) == imageset(Lambda(n, pi*(4*n + 3)/4), S.Integers)
 
 @XFAIL
 def test_solve_trig_abs():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -756,6 +756,10 @@ def test_solve_trig():
     assert solveset(sin(y + a) - sin(y), a, domain=S.Reals) == \
         imageset(Lambda(n, 2*n*pi), S.Integers)
 
+def test_issue_13084():
+    f = sin(2*x + 3) - Rational(1,2)
+    assert solveset(f, x, S.Reals) == ConditionSet(x, Eq(sin(2*x + 3) - 1/2, 0), S.Reals)
+
 
 @XFAIL
 def test_solve_trig_abs():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -41,6 +41,7 @@ n = Symbol('n', real=True)
 
 
 def test_invert_real():
+
     x = Symbol('x', real=True)
     y = Symbol('y')
     n = Symbol('n')
@@ -902,33 +903,29 @@ def test_solveset():
     assert solveset(Eq(exp(x), 1), x) == imageset(Lambda(n, 2*I*pi*n),
                                                   S.Integers)
 
-
 def test_conditionset():
+    n = Dummy('n')
     assert solveset(Eq(sin(x)**2 + cos(x)**2, 1), x, domain=S.Reals) == \
         ConditionSet(x, True, S.Reals)
+    assert solveset(x**2 + x*sin(x) - 1, x, domain=S.Reals) == \
+        ConditionSet(x, Eq(x**2 + x*sin(x) - 1, 0), S.Reals)
 
-    assert solveset(Eq(x**2 + x*sin(x), 1), x, domain=S.Reals) == \
-        ConditionSet(x, Eq(x*(x + sin(x)) - 1, 0), S.Reals)
-
-    assert solveset(Eq(sin(Abs(x)), x), x, domain=S.Reals) == \
+    assert solveset(sin(Abs(x)) - x, x, domain=S.Reals) == \
         ConditionSet(x, Eq(-x + sin(Abs(x)), 0), Interval(-oo, oo))
 
-    assert solveset(Eq(-I*(exp(I*x) - exp(-I*x))/2, 1), x) == \
+    assert solveset(-I*(exp(I*x) - exp(-I*x))/2 - 1, x) == \
         imageset(Lambda(n, 2*n*pi + pi/2), S.Integers)
 
     assert solveset(x + sin(x) > 1, x, domain=S.Reals) == \
         ConditionSet(x, x + sin(x) > 1, S.Reals)
-
 
 @XFAIL
 def test_conditionset_equality():
     ''' Checking equality of different representations of ConditionSet'''
     assert solveset(Eq(tan(x), y), x) == ConditionSet(x, Eq(tan(x), y), S.Complexes)
 
-
 def test_solveset_domain():
     x = Symbol('x')
-
     assert solveset(x**2 - x - 6, x, Interval(0, oo)) == FiniteSet(3)
     assert solveset(x**2 - 1, x, Interval(0, oo)) == FiniteSet(1)
     assert solveset(x**4 - 16, x, Interval(0, 10)) == FiniteSet(2)
@@ -939,7 +936,7 @@ def test_improve_coverage():
     x = Symbol('x')
     y = exp(x+1/x**2)
     solution = solveset(y**2+y, x, S.Reals)
-    unsolved_object = ConditionSet(x, Eq((exp((x**3 + 1)/x**2) + 1)*exp((x**3 + 1)/x**2), 0), S.Reals)
+    unsolved_object = ConditionSet(x, Eq(exp(x + x**(-2)) + exp(2*x + 2/x**2), 0), S.Reals)
     assert solution == unsolved_object
 
     assert _has_rational_power(sin(x)*exp(x) + 1, x) == (False, S.One)
@@ -1509,7 +1506,7 @@ def test_simplification():
 def test_issue_10555():
     f = Function('f')
     assert solveset(f(x) - pi/2, x, S.Reals) == \
-        ConditionSet(x, Eq(2*f(x) - pi, 0), S.Reals)
+        ConditionSet(x, Eq(f(x) - pi/2, 0), S.Reals)
 
 
 def test_issue_8715():


### PR DESCRIPTION
Fixes[#13084](https://github.com/sympy/sympy/issues/13084)

As the issue suggests, equations like:

```
>>> sin(2*x + 3) - Rational(1,2)
# returns a TypeError
```
Figuring what may have caused it, I found out that when such equations are converted to `exp` , `_solve_rational()` solves the equation by evaluating `valid_solns and invalid_solns` and returns the difference, but in present case `valid_solns` gets a `ConditionSet` and `invalid_solns` a `FiniteSet`
, and getting their difference raises the error.

This PR gets the result as `ConditionSet`

```
>>> sin(2*x + 3) - Rational(1,2)
ConditionSet(x, Eq(sin(2*x + 3) - 1/2, 0), S.Reals)
```
Getting the actual result for such equations can be done by calling `inverter`, but I thought it wouldd be better to discuss the approach first before implementing it.

ping @asmeurer @Shekharrajak @aktech @smichr 