### PR TITLE
TWave: various documentation fixes

### DIFF
--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -14,7 +14,7 @@ def test_twave():
     n = Symbol('n')  # Refractive index
     t = Symbol('t')  # Time
     x = Symbol('x')  # Spatial variable
-    k = Symbol('k')  # Wave number
+    k = Symbol('k')  # Wavenumber
     E = Function('E')
     w1 = TWave(A1, f, phi1)
     w2 = TWave(A2, f, phi2)

--- a/sympy/physics/optics/tests/test_waves.py
+++ b/sympy/physics/optics/tests/test_waves.py
@@ -13,7 +13,7 @@ def test_twave():
     A1, phi1, A2, phi2, f = symbols('A1, phi1, A2, phi2, f')
     n = Symbol('n')  # Refractive index
     t = Symbol('t')  # Time
-    x = Symbol('x')  # Spatial varaible
+    x = Symbol('x')  # Spatial variable
     k = Symbol('k')  # Wave number
     E = Function('E')
     w1 = TWave(A1, f, phi1)

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -22,14 +22,15 @@ c = speed_of_light.convert_to(meter/second)
 class TWave(Expr):
 
     r"""
-    This is a simple transverse sine wave travelling in a one dimensional space.
-    Basic properties are required at the time of creation of the object but
-    they can be changed later with respective methods provided.
+    This is a simple transverse sine wave travelling in a one-dimensional space.
+    Basic properties are required at the time of creation of the object,
+    but they can be changed later with respective methods provided.
 
-    It has been represented as :math:`A \times cos(k*x - \omega \times t + \phi )`
-    where :math:`A` is amplitude, :math:`\omega` is angular velocity, :math:`k`is
-    wavenumber, :math:`x` is a spatial variable to represent the position on the
-    dimension on which the wave propagates and :math:`\phi` is phase angle of the wave.
+    It is represented as :math:`A \times cos(k*x - \omega \times t + \phi )`,
+    where :math:`A` is the amplitude, :math:`\omega` is the angular velocity,
+    :math:`k` is the wavenumber (spatial frequency), :math:`x` is a spatial variable
+    to represent the position on the dimension on which the wave propagates,
+    and :math:`\phi` is the phase angle of the wave.
 
 
     Arguments
@@ -107,7 +108,8 @@ class TWave(Expr):
     @property
     def frequency(self):
         """
-        Returns the frequency of the wave.
+        Returns the frequency of the wave,
+        in cycles per second.
 
         Examples
         ========
@@ -124,7 +126,8 @@ class TWave(Expr):
     @property
     def time_period(self):
         """
-        Returns the time period of the wave.
+        Returns the temporal period of the wave,
+        in seconds per cycle.
 
         Examples
         ========
@@ -141,7 +144,8 @@ class TWave(Expr):
     @property
     def wavelength(self):
         """
-        Returns wavelength of the wave.
+        Returns the wavelength (spatial period) of the wave,
+        in meters per cycle.
         It depends on the medium of the wave.
 
         Examples
@@ -176,7 +180,8 @@ class TWave(Expr):
     @property
     def phase(self):
         """
-        Returns the phase angle of the wave.
+        Returns the phase angle of the wave,
+        in radians.
 
         Examples
         ========
@@ -193,8 +198,9 @@ class TWave(Expr):
     @property
     def speed(self):
         """
-        Returns the speed of travelling wave.
-        It is medium dependent.
+        Returns the propagation speed of the wave,
+        in meters mer second.
+        It is dependent on the propagation medium.
 
         Examples
         ========
@@ -211,7 +217,8 @@ class TWave(Expr):
     @property
     def angular_velocity(self):
         """
-        Returns angular velocity of the wave.
+        Returns the angular velocity of the wave,
+        in radians per second.
 
         Examples
         ========
@@ -228,7 +235,8 @@ class TWave(Expr):
     @property
     def wavenumber(self):
         """
-        Returns wavenumber of the wave.
+        Returns the wavenumber of the wave,
+        in radians per meter.
 
         Examples
         ========

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -199,7 +199,7 @@ class TWave(Expr):
     def speed(self):
         """
         Returns the propagation speed of the wave,
-        in meters mer second.
+        in meters per second.
         It is dependent on the propagation medium.
 
         Examples


### PR DESCRIPTION
- fix math rendering (was missing a space after backtick)
- include units in the documentation of properties, for additional clarity
- use articles ("a", "the"...) consistently
- minor punctuation tweaks for correctness and readability

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
