### PR TITLE
changes to _pt and solve_univariate_inequality

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -9,6 +9,7 @@ from sympy.core.relational import Relational, Eq, Ge, Lt
 from sympy.sets.sets import FiniteSet, Union
 from sympy.sets.fancysets import ImageSet
 from sympy.core.singleton import S
+from sympy.core.function import expand_mul
 
 from sympy.functions import Abs
 from sympy.logic import And
@@ -241,8 +242,8 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
                     (numer, denom), gen)
             except PolynomialError:
                 raise PolynomialError(filldedent('''
-                    only polynomials and
-                    rational functions are supported in this context'''))
+only polynomials and rational functions are supported in this context.
+                    '''))
 
             if not opt.domain.is_Exact:
                 numer, denom, exact = numer.to_exact(), denom.to_exact(), False
@@ -294,8 +295,9 @@ def reduce_abs_inequality(expr, rel, gen):
     """
     if gen.is_real is False:
          raise TypeError(filldedent('''
-            can't solve inequalities with absolute
-            values containing non-real variables'''))
+can't solve inequalities with absolute values containing non-real
+variables.
+            '''))
 
     def _bottom_up_scan(expr):
         exprs = []
@@ -445,10 +447,20 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     # This keeps the function independent of the assumptions about `gen`.
     # `solveset` makes sure this function is called only when the domain is
     # real.
-    d = Dummy(real=True)
-    expr = expr.subs(gen, d)
     _gen = gen
-    gen = d
+    if gen.is_real is False:
+        rv = S.EmptySet
+        return rv if not relational else rv.as_relational(_gen)
+    elif gen.is_real is None:
+        gen = Dummy('gen', real=True)
+        try:
+            expr = expr.xreplace({_gen: gen})
+        except TypeError:
+            raise TypeError(filldedent('''
+When gen is real, the relational has a complex part
+which leads to an invalid comparison like I < 0.
+            '''))
+
     rv = None
 
     if expr is S.true:
@@ -481,20 +493,33 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 domain = Interval(0, period, False, True)
 
         if rv is None:
-            solns = solvify(e, gen, domain)
-            if solns is None:
-                raise NotImplementedError(filldedent('''The inequality cannot be
-                    solved using solve_univariate_inequality.'''))
-            singularities = []
-            for d in denoms(expr, gen):
-                singularities.extend(solvify(d, gen, domain))
-            if not continuous:
-                domain = continuous_domain(e, gen, domain)
+            n, d = e.as_numer_denom()
+            try:
+                if gen not in n.free_symbols and len(e.free_symbols) > 1:
+                    raise ValueError
+                # this might raise ValueError on its own
+                # or it might give None...
+                solns = solvify(e, gen, domain)
+                if solns is None:
+                    # in which case we raise ValueError
+                    raise ValueError
+            except (ValueError, NotImplementedError):
+                raise NotImplementedError(filldedent('''
+The inequality cannot be solved using solve_univariate_inequality.
+                        '''))
 
-            include_x = expr.func(0, 0)
-
+            expanded_e = expand_mul(e)
             def valid(x):
-                v = e.subs(gen, x)
+                # this is used to see if gen=x satisfies the
+                # relational by substituting it into the
+                # expanded form and testing against 0, e.g.
+                # if expr = x*(x + 1) < 2 then e = x*(x + 1) - 2
+                # and expanded_e = x**2 + x - 2; the test is
+                # whether a given value of x satisfies
+                # x**2 + x - 2 < 0
+                #
+                # expanded_e, expr and gen used from enclosing scope
+                v = expanded_e.subs(gen, x)
                 try:
                     r = expr.func(v, 0)
                 except TypeError:
@@ -507,7 +532,17 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                     v = v.n(2)
                     if v.is_comparable:
                         return expr.func(v, 0)
-                    return S.false
+                    # not comparable or couldn't be evaluated
+                    raise NotImplementedError(
+                        'relationship did not evaluate: %s' % r)
+
+            singularities = []
+            for d in denoms(expr, gen):
+                singularities.extend(solvify(d, gen, domain))
+            if not continuous:
+                domain = continuous_domain(e, gen, domain)
+
+            include_x = '=' in expr.rel_op and expr.rel_op != '!='
 
             try:
                 discontinuities = set(domain.boundary -
@@ -517,11 +552,25 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                     discontinuities))).intersection(
                     Interval(domain.inf, domain.sup,
                     domain.inf not in domain, domain.sup not in domain))
-                reals = _nsort(critical_points, separated=True)[0]
+                if all(r.is_number for r in critical_points):
+                    reals = _nsort(critical_points, separated=True)[0]
+                else:
+                    from sympy.utilities.iterables import sift
+                    sifted = sift(critical_points, lambda x: x.is_real)
+                    if sifted[None]:
+                        # there were some roots that weren't known
+                        # to be real
+                        raise NotImplementedError
+                    try:
+                        reals = sifted[True]
+                        if len(reals) > 1:
+                            reals = list(sorted(reals))
+                    except TypeError:
+                        raise NotImplementedError
             except NotImplementedError:
                 raise NotImplementedError('sorting of these roots is not supported')
 
-            sol_sets = [S.EmptySet]
+            empty = sol_sets = [S.EmptySet]
 
             start = domain.inf
             if valid(start) and start.is_finite:
@@ -560,14 +609,34 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
 
 def _pt(start, end):
     """Return a point between start and end"""
-    if start.is_infinite and end.is_infinite:
-        pt = S.Zero
-    elif end.is_infinite:
-        pt = start + 1
-    elif start.is_infinite:
-        pt = end - 1
-    else:
+    if not start.is_infinite and not end.is_infinite:
         pt = (start + end)/2
+    elif start.is_infinite and end.is_infinite:
+        pt = S.Zero
+    else:
+        if (start.is_infinite and start.is_positive is None or
+                end.is_infinite and end.is_positive is None):
+            raise ValueError('cannot proceed with unsigned infinite values')
+        if (end.is_infinite and end.is_negative or
+                start.is_infinite and start.is_positive):
+            start, end = end, start
+        # if possible, use a multiple of self which has
+        # better behavior when checking assumptions than
+        # an expression obtained by adding or subtracting 1
+        if end.is_infinite:
+            if start.is_positive:
+                pt = start*2
+            elif start.is_negative:
+                pt = start*S.Half
+            else:
+                pt = start + 1
+        elif start.is_infinite:
+            if end.is_positive:
+                pt = end*S.Half
+            elif end.is_negative:
+                pt = end*2
+            else:
+                pt = end - 1
     return pt
 
 
@@ -618,8 +687,8 @@ def _reduce_inequalities(inequalities, symbols):
                 continue
             else:
                 raise NotImplementedError(filldedent('''
-                    inequality has more than one
-                    symbol of interest'''))
+inequality has more than one symbol of interest.
+                    '''))
 
         if expr.is_polynomial(gen):
             poly_part.setdefault(gen, []).append((expr, rel))
@@ -671,7 +740,8 @@ def reduce_inequalities(inequalities, symbols=[]):
     symbols = (set(symbols) or gens) & gens
     if any(i.is_real is False for i in symbols):
         raise TypeError(filldedent('''
-            inequalities cannot contain symbols that are not real.'''))
+inequalities cannot contain symbols that are not real.
+            '''))
 
     # make vanilla symbol real
     recast = dict([(i, Dummy(i.name, real=True))

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -1,6 +1,6 @@
 """Tests for tools for solving inequalities and systems of inequalities. """
 
-from sympy import (And, Eq, FiniteSet, Ge, Gt, Interval, Le, Lt, Ne, oo,
+from sympy import (And, Eq, FiniteSet, Ge, Gt, Interval, Le, Lt, Ne, oo, I,
                    Or, S, sin, cos, tan, sqrt, Symbol, Union, Integral, Sum,
                    Function, Poly, PurePoly, pi, root, log, exp, Dummy, Abs)
 from sympy.solvers.inequalities import (reduce_inequalities,
@@ -289,6 +289,20 @@ def test_solve_univariate_inequality():
 
     n = Dummy('n')
     raises(NotImplementedError, lambda: isolve(Abs(x) <= n, x, relational=False))
+    c1 = Dummy("c1", positive=True)
+    raises(NotImplementedError, lambda: isolve(n/c1 < 0, c1))
+    n = Dummy('n', negative=True)
+    assert isolve(n/c1 > -2, c1) == (-n/2 < c1)
+    assert isolve(n/c1 < 0, c1) == True
+    assert isolve(n/c1 > 0, c1) == False
+
+    zero = cos(1)**2 + sin(1)**2 - 1
+    raises(NotImplementedError, lambda: isolve(x**2 < zero, x))
+    raises(NotImplementedError, lambda: isolve(
+        x**2 < zero*I, x))
+    raises(NotImplementedError, lambda: isolve(1/(x - y) < 2, x))
+    raises(NotImplementedError, lambda: isolve(1/(x - y) < 0, x))
+    raises(TypeError, lambda: isolve(x - I < 0, x))
 
 
 def test_trig_inequalities():
@@ -375,3 +389,16 @@ def test_issue_10671_12466():
     assert solveset((1/x).diff(x) < 0, x, i) == i
     assert solveset((log(x - 6)/x) <= 0, x, S.Reals) == \
         Interval.Lopen(6, 7)
+
+
+def test__pt():
+    from sympy.solvers.inequalities import _pt
+    assert _pt(-oo, oo) == 0
+    assert _pt(S(1), S(3)) == 2
+    assert _pt(S(1), oo) == _pt(oo, S(1)) == 2
+    assert _pt(S(1), -oo) == _pt(-oo, S(1)) == S.Half
+    assert _pt(S(-1), oo) == _pt(oo, S(-1)) == -S.Half
+    assert _pt(S(-1), -oo) == _pt(-oo, S(-1)) == -2
+    assert _pt(x, oo) == _pt(oo, x) == x + 1
+    assert _pt(x, -oo) == _pt(-oo, x) == x - 1
+    raises(ValueError, lambda: _pt(Dummy('i', infinite=True), S(1)))


### PR DESCRIPTION
This is part of #12587 being submitted independently.

If solves this issue

```
>>> var('a b',positive=True)
(a,b)
>>> solve(a/b<3,b)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/base/data/home/apps/s~sympy-live-hrd/49.400254913747479351/sympy/sympy/solvers/solvers.py", line 832, in solve
    return reduce_inequalities(f, symbols=symbols)
  File "/base/data/home/apps/s~sympy-live-hrd/49.400254913747479351/sympy/sympy/solvers/inequalities.py", line 616, in reduce_inequalities
    rv = _reduce_inequalities(inequalities, symbols)
  File "/base/data/home/apps/s~sympy-live-hrd/49.400254913747479351/sympy/sympy/solvers/inequalities.py", line 532, in _reduce_inequalities
    other.append(_solve_inequality(Relational(expr, 0, rel), gen))
  File "/base/data/home/apps/s~sympy-live-hrd/49.400254913747479351/sympy/sympy/solvers/inequalities.py", line 499, in _solve_inequality
    return reduce_rational_inequalities([[ie]], s)
  File "/base/data/home/apps/s~sympy-live-hrd/49.400254913747479351/sympy/sympy/solvers/inequalities.py", line 254, in reduce_rational_inequalities
    solution &= solve_univariate_inequality(expr, gen, relational=False)
  File "/base/data/home/apps/s~sympy-live-hrd/49.400254913747479351/sympy/sympy/solvers/inequalities.py", line 448, in solve_univariate_inequality
    raise NotImplementedError('sorting of these roots is not supported')
NotImplementedError: sorting of these roots is not supported

```

without solving #12560, however.