### PR TITLE
fixed cos.rewrite(sqrt) sometimes not fully rewriting

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -779,11 +779,11 @@ class cos(TrigonometricFunction):
             # if n can be factored in terms of Fermat primes with
             # multiplicity of each being 1, return those primes, else
             # False
-            from sympy import chebyshevt
             primes = []
             for p_i in cst_table_some:
-                n, r = divmod(n, p_i)
-                if not r:
+                quotient, remainder = divmod(n, p_i)
+                if remainder == 0:
+                    n = quotient
                     primes.append(p_i)
                     if n == 1:
                         return tuple(primes)


### PR DESCRIPTION
See #13066
`functions.elementary.trigonometric.cos._eval_rewrite_as_sqrt` would fail to fully rewrite `cos(pi/51)` on python 3.6 only. This turned out to be an issue with the `_fermatCoords` function which is supposed to factor 51 into fermat primes. Trigonometric expressions with these fermat primes as denominators of pi can be rewritten using squareroots.

The function uses `divmod` repeatedly to get the factors. `n` was set to the whole number result of the `divmod`. This is where the bug was, since that would mean that if `n` was not divisible by that particular factor, then `n` would still be changed to the whole number result, which usually ended up being 0, in which case the function would miss the other factors and return `False`. Or in rare cases it would have led to a false factorization.

The reason this bug only revealed itself in 3.6 is because the ordering of dicts was changed. Previously for n=51 it so happened that python ordered the dict with 17 first, then 3, which are both divisible.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #13066