### PR TITLE
Fixed issue #13102 with could_extract_minus_sign

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2174,7 +2174,7 @@ class Expr(Basic, EvalfMixin):
         return Add(*coeffs)
 
     def could_extract_minus_sign(self):
-         """Return True if self is not in a canonical form with respect
+        """Return True if self is not in a canonical form with respect
         to its sign.
 
         For most expressions, e, there will be a difference in e and -e.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2174,20 +2174,25 @@ class Expr(Basic, EvalfMixin):
         return Add(*coeffs)
 
     def could_extract_minus_sign(self):
-        """Canonical way to choose an element in the set {e, -e} where
-           e is any expression. If the canonical element is e, we have
-           e.could_extract_minus_sign() == True, else
-           e.could_extract_minus_sign() == False.
+         """Return True if self is not in a canonical form with respect
+        to its sign.
 
-           For any expression, the set ``{e.could_extract_minus_sign(),
-           (-e).could_extract_minus_sign()}`` must be ``{True, False}``.
+        For most expressions, e, there will be a difference in e and -e.
+        When there is, True will be returned for one and False for the
+        other; False will be returned if there is no difference.
 
-           >>> from sympy.abc import x, y
-           >>> (x-y).could_extract_minus_sign() != (y-x).could_extract_minus_sign()
-           True
+        Examples
+        ========
+
+        >>> from sympy.abc import x, y
+        >>> e = x - y
+        >>> {i.could_extract_minus_sign() for i in (e, -e)}
+        {False, True}
 
         """
         negative_self = -self
+        if self == negative_self:
+            return False  # e.g. zoo*x == -zoo*x
         self_has_minus = (self.extract_multiplicatively(-1) is not None)
         negative_self_has_minus = (
             (negative_self).extract_multiplicatively(-1) is not None)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1065,6 +1065,14 @@ def test_extractions():
     assert ((x + x*y)/y).could_extract_minus_sign() is False
     assert (x*(-x - x**3)).could_extract_minus_sign() is True
     assert ((-x - y)/(x + y)).could_extract_minus_sign() is True
+
+    class sign_invariant(Function, Expr):
+        nargs =1
+        def __neg__(self):
+            return self
+    foo =sign_invariant(x)
+    assert foo == -foo
+    assert foo.could_extract_minus_sign() is False
     # The results of each of these will vary on different machines, e.g.
     # the first one might be False and the other (then) is true or vice versa,
     # so both are included.

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
+from sympy import (Add, Basic, Expr, S, Symbol, Wild, Float, Integer, Rational, I,
                    sin, cos, tan, exp, log, nan, oo, sqrt, symbols, Integral, sympify,
                    WildFunction, Poly, Function, Derivative, Number, pi, NumberSymbol, zoo,
                    Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp,
@@ -1067,10 +1067,10 @@ def test_extractions():
     assert ((-x - y)/(x + y)).could_extract_minus_sign() is True
 
     class sign_invariant(Function, Expr):
-        nargs =1
+        nargs = 1
         def __neg__(self):
             return self
-    foo =sign_invariant(x)
+    foo = sign_invariant(x)
     assert foo == -foo
     assert foo.could_extract_minus_sign() is False
     # The results of each of these will vary on different machines, e.g.


### PR DESCRIPTION
Put an if statement in could_extract_minus_sign to deal with 
when `expr=-expr`

This is done to fix the bug raised in #13102 
