### PR TITLE
Simplify: expressions with inverse trigonometric/hyperbolic function using logarithmic rewrite

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1317,6 +1317,11 @@ def test_sympy__functions__elementary__hyperbolic__ReciprocalHyperbolicFunction(
     pass
 
 
+@SKIP("abstract class")
+def test_sympy__functions__elementary__hyperbolic__InverseHyperbolicFunction():
+    pass
+
+
 def test_sympy__functions__elementary__hyperbolic__acosh():
     from sympy.functions.elementary.hyperbolic import acosh
     assert _test_args(acosh(2))

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -771,7 +771,13 @@ class sech(ReciprocalHyperbolicFunction):
 ############################# HYPERBOLIC INVERSES #############################
 ###############################################################################
 
-class asinh(Function):
+class InverseHyperbolicFunction(Function):
+    """Base class for inverse hyperbolic functions."""
+
+    pass
+
+
+class asinh(InverseHyperbolicFunction):
     """
     The inverse hyperbolic sine function.
 
@@ -856,7 +862,7 @@ class asinh(Function):
         return sinh
 
 
-class acosh(Function):
+class acosh(InverseHyperbolicFunction):
     """
     The inverse hyperbolic cosine function.
 
@@ -961,7 +967,7 @@ class acosh(Function):
         return cosh
 
 
-class atanh(Function):
+class atanh(InverseHyperbolicFunction):
     """
     The inverse hyperbolic tangent function.
 
@@ -1039,7 +1045,7 @@ class atanh(Function):
         return tanh
 
 
-class acoth(Function):
+class acoth(InverseHyperbolicFunction):
     """
     The inverse hyperbolic cotangent function.
 
@@ -1114,7 +1120,7 @@ class acoth(Function):
         return coth
 
 
-class asech(Function):
+class asech(InverseHyperbolicFunction):
     """
     The inverse hyperbolic secant function.
 
@@ -1241,7 +1247,7 @@ class asech(Function):
         return log(1/arg + sqrt(1/arg - 1) * sqrt(1/arg + 1))
 
 
-class acsch(Function):
+class acsch(InverseHyperbolicFunction):
     """
     The inverse hyperbolic cosecant function.
 

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -37,6 +37,8 @@ def test_sin():
     assert sin(atan(x)) == x / sqrt(1 + x**2)
     assert sin(acos(x)) == sqrt(1 - x**2)
     assert sin(acot(x)) == 1 / (sqrt(1 + 1 / x**2) * x)
+    assert sin(acsc(x)) == 1 / x
+    assert sin(asec(x)) == sqrt(1 - 1 / x**2)
     assert sin(atan2(y, x)) == y / sqrt(x**2 + y**2)
 
     assert sin(pi*I) == sinh(pi)*I
@@ -247,6 +249,8 @@ def test_cos():
     assert cos(atan(x)) == 1 / sqrt(1 + x**2)
     assert cos(asin(x)) == sqrt(1 - x**2)
     assert cos(acot(x)) == 1 / sqrt(1 + 1 / x**2)
+    assert cos(acsc(x)) == sqrt(1 - 1 / x**2)
+    assert cos(asec(x)) == 1 / x
     assert cos(atan2(y, x)) == x / sqrt(x**2 + y**2)
 
     assert cos(pi*I) == cosh(pi)
@@ -404,6 +408,8 @@ def test_tan():
     assert tan(asin(x)) == x / sqrt(1 - x**2)
     assert tan(acos(x)) == sqrt(1 - x**2) / x
     assert tan(acot(x)) == 1 / x
+    assert tan(acsc(x)) == 1 / (sqrt(1 - 1 / x**2) * x)
+    assert tan(asec(x)) == sqrt(1 - 1 / x**2) * x
     assert tan(atan2(y, x)) == y/x
 
     assert tan(pi*I) == tanh(pi)*I
@@ -548,6 +554,8 @@ def test_cot():
     assert cot(atan(x)) == 1 / x
     assert cot(asin(x)) == sqrt(1 - x**2) / x
     assert cot(acos(x)) == x / sqrt(1 - x**2)
+    assert cot(acsc(x)) == sqrt(1 - 1 / x**2) * x
+    assert cot(asec(x)) == 1 / (sqrt(1 - 1 / x**2) * x)
     assert cot(atan2(y, x)) == x/y
 
     assert cot(pi*I) == -coth(pi)*I
@@ -842,7 +850,7 @@ def test_atan():
 
 
 def test_atan_rewrite():
-    assert atan(x).rewrite(log) == I*log((1 - I*x)/(1 + I*x))/2
+    assert atan(x).rewrite(log) == I*(log(1 - I*x)-log(1 + I*x))/2
     assert atan(x).rewrite(asin) == (-asin(1/sqrt(x**2 + 1)) + pi/2)*sqrt(x**2)/x
     assert atan(x).rewrite(acos) == sqrt(x**2)*acos(1/sqrt(x**2 + 1))/x
     assert atan(x).rewrite(acot) == acot(1/x)
@@ -933,7 +941,7 @@ def test_acot():
 
 
 def test_acot_rewrite():
-    assert acot(x).rewrite(log) == I*log((x - I)/(x + I))/2
+    assert acot(x).rewrite(log) == I*(log(x - I)-log(x + I))/2
     assert acot(x).rewrite(asin) == x*(-asin(sqrt(-x**2)/sqrt(-x**2 - 1)) + pi/2)*sqrt(x**(-2))
     assert acot(x).rewrite(acos) == x*sqrt(x**(-2))*acos(sqrt(-x**2)/sqrt(-x**2 - 1))
     assert acot(x).rewrite(atan) == atan(1/x)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2272,8 +2272,8 @@ class atan(InverseTrigonometricFunction):
         return self.args[0].is_real
 
     def _eval_rewrite_as_log(self, x):
-        return S.ImaginaryUnit/2 * (log(
-            (S(1) - S.ImaginaryUnit * x)/(S(1) + S.ImaginaryUnit * x)))
+        return S.ImaginaryUnit/2 * (log(S(1) - S.ImaginaryUnit * x)
+            - log(S(1) + S.ImaginaryUnit * x))
 
     def _eval_aseries(self, n, args0, x, logx):
         if args0[0] == S.Infinity:
@@ -2420,8 +2420,8 @@ class acot(InverseTrigonometricFunction):
             return super(atan, self)._eval_aseries(n, args0, x, logx)
 
     def _eval_rewrite_as_log(self, x):
-        return S.ImaginaryUnit/2 * \
-            (log((x - S.ImaginaryUnit)/(x + S.ImaginaryUnit)))
+        return S.ImaginaryUnit/2 * (log(x - S.ImaginaryUnit)
+            - log(x + S.ImaginaryUnit))
 
     def inverse(self, argindex=1):
         """

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -348,6 +348,14 @@ class sin(TrigonometricFunction):
             x = arg.args[0]
             return 1 / (sqrt(1 + 1 / x**2) * x)
 
+        if arg.func is acsc:
+            x = arg.args[0]
+            return 1 / x
+
+        if arg.func is asec:
+            x = arg.args[0]
+            return sqrt(1 - 1 / x**2)
+
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -632,6 +640,14 @@ class cos(TrigonometricFunction):
         if arg.func is acot:
             x = arg.args[0]
             return 1 / sqrt(1 + 1 / x**2)
+
+        if arg.func is acsc:
+            x = arg.args[0]
+            return sqrt(1 - 1 / x**2)
+
+        if arg.func is asec:
+            x = arg.args[0]
+            return 1 / x
 
     @staticmethod
     @cacheit
@@ -1026,6 +1042,14 @@ class tan(TrigonometricFunction):
             x = arg.args[0]
             return 1 / x
 
+        if arg.func is acsc:
+            x = arg.args[0]
+            return 1 / (sqrt(1 - 1 / x**2) * x)
+
+        if arg.func is asec:
+            x = arg.args[0]
+            return sqrt(1 - 1 / x**2) * x
+
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -1303,6 +1327,14 @@ class cot(TrigonometricFunction):
         if arg.func is acos:
             x = arg.args[0]
             return x / sqrt(1 - x**2)
+
+        if arg.func is acsc:
+            x = arg.args[0]
+            return sqrt(1 - 1 / x**2) * x
+
+        if arg.func is asec:
+            x = arg.args[0]
+            return 1 / (sqrt(1 - 1 / x**2) * x)
 
     @staticmethod
     @cacheit

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -16,10 +16,12 @@ from sympy.functions import (
     gamma, exp, sqrt, log, exp_polar, piecewise_fold)
 from sympy.core.sympify import _sympify
 from sympy.functions.elementary.exponential import ExpBase
-from sympy.functions.elementary.hyperbolic import HyperbolicFunction
+from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
+    InverseHyperbolicFunction)
 from sympy.functions.elementary.integers import ceiling
 from sympy.functions.elementary.complexes import unpolarify
-from sympy.functions.elementary.trigonometric import TrigonometricFunction
+from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
+    InverseTrigonometricFunction)
 from sympy.functions.combinatorial.factorials import CombinatorialFunction
 from sympy.functions.special.bessel import besselj, besseli, besselk, jn, bessely
 
@@ -567,6 +569,10 @@ def simplify(expr, ratio=1.7, measure=count_ops, fu=False):
     if expr.has(TrigonometricFunction) and not fu or expr.has(
             HyperbolicFunction):
         expr = trigsimp(expr, deep=True)
+
+    if expr.has(InverseTrigonometricFunction) or expr.has(InverseHyperbolicFunction):
+        _e = expr.rewrite(log)
+        expr = shorter(expr, _e, together(logcombine(_e), deep = True))
 
     if expr.has(log):
         expr = shorter(expand_log(expr, deep=True), logcombine(expr))


### PR DESCRIPTION
Attempts to simplify expressions with inverse trigonometric function or inverse hyperbolic function using logarithmic rewrite.

I'm not sure about best location and way to do it.

**Examples:**

- `(inverse trigonometric/hyperbolic function) - (logarithmic representation of the function)` -> `0`
- `E**(I*asin(x)) - I*x` -> `sqrt(-x**2 + 1)`
- `x*E**acsch(x) - sqrt(1 + x**2)` -> `1` (where `x.isPositive == True`)
- `atanh(x) + log(-x + 1)/2` -> `log(x + 1)/2`
- `atan(x)/I + log(x*I + 1)/2` -> `log(-I*x + 1)/2`

Depends on #13109 