### PR TITLE
Simplify by rewriting expression

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -603,10 +603,11 @@ class Expr(Basic, EvalfMixin):
                 return False
         return True
 
-    def equals(self, other, failing_expression=False):
+    def equals(self, other, failing_expression=False, rewrite=False):
         """Return True if self == other, False if it doesn't, or None. If
         failing_expression is True then the expression which did not simplify
-        to a 0 will be returned instead of None.
+        to a 0 will be returned instead of None. If rewrite is True then it
+        attempts to rewrite the expression when simplifying it.
 
         If ``self`` is a Number (or complex number) that is not zero, then
         the result is False.
@@ -631,7 +632,7 @@ class Expr(Basic, EvalfMixin):
         # don't worry about doing simplification steps one at a time
         # because if the expression ever goes to 0 then the subsequent
         # simplification steps that are done will be very fast.
-        diff = factor_terms(simplify(self - other), radical=True)
+        diff = factor_terms(simplify(self - other, rewrite=rewrite), radical=True)
 
         if not diff:
             return True

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -504,7 +504,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, fu=False, rewrite=False):
     simplification strategies and then compares them using the measure
     function, we get a completely different result that is still different
     from the input expression by doing this.
-    
+
     If rewrite is True then it attempts to rewrite given expression in
     all possible terms, simplify rewritten expressions, and return the
     simplest one.


### PR DESCRIPTION
- Added option to attempt to rewrite given expression in all possible terms, simplify rewritten expressions, and return the simplest one in `simplify()`.
- Added option to rewrite when simplifying `self - other` in `equals()`.

**Things to consider:**

- whether to rewrite original expression(`original_expr`) or simplified expression(`expr`)
- better way of getting 'rewritables': it currently preorder-transverses all nodes and gets the name from attribute of its class starting with _eval_rewrite_as_, maybe just major functions like exp and log?
- whether to check rewritten equations are identical to original expression or have duplicates: simplify() would give same results, does python or sympy caches the result?

**Related issue(s):**
- #11988