### PR TITLE
Mixed coordinates for gradient

### DIFF
--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -8,7 +8,7 @@ from sympy.vector.coordsysrect import CoordSys3D, CoordSysCartesian
 from sympy.vector.functions import (express, matrix_to_vector,
                                     is_conservative, is_solenoidal,
                                     scalar_potential, directional_derivative,
-                                    scalar_potential_difference, split_coordinate)
+                                    scalar_potential_difference)
 from sympy.vector.point import Point
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)

--- a/sympy/vector/__init__.py
+++ b/sympy/vector/__init__.py
@@ -8,7 +8,7 @@ from sympy.vector.coordsysrect import CoordSys3D, CoordSysCartesian
 from sympy.vector.functions import (express, matrix_to_vector,
                                     is_conservative, is_solenoidal,
                                     scalar_potential, directional_derivative,
-                                    scalar_potential_difference)
+                                    scalar_potential_difference, split_coordinate)
 from sympy.vector.point import Point
 from sympy.vector.orienters import (AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -1,7 +1,7 @@
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.scalar import BaseScalar
 from sympy.vector.vector import Vector, BaseVector
-from sympy.vector.operators import curl, divergence
+from sympy.vector.operators import gradient, curl, divergence
 from sympy import diff, integrate, S, simplify
 from sympy.core import sympify
 from sympy.vector.dyadic import Dyadic
@@ -124,17 +124,6 @@ def express(expr, system, system2=None, variables=False):
         return expr
 
 
-def split_coordinate(expr):
-    import collections
-    d = collections.defaultdict(lambda: S.One)
-    if isinstance(expr, (BaseScalar, BaseVector)):
-        return [expr]
-    else:
-        for i in expr.args:
-            d[frozenset(i.atoms(CoordSys3D))] *= i
-        return d.values()
-
-
 def directional_derivative(field, direction_vector):
     """
     Returns the directional derivative of a scalar or vector field computed
@@ -166,7 +155,9 @@ def directional_derivative(field, direction_vector):
     """
     from sympy.vector.operators import _get_coord_sys_from_expr
     coord_sys = _get_coord_sys_from_expr(field)
-    if coord_sys is not None:
+    if len(coord_sys) > 0:
+        # TODO: This gets a random coordinate system in case of multiple ones:
+        coord_sys = coord_sys.pop()
         field = express(field, coord_sys, variables=True)
         i, j, k = coord_sys.base_vectors()
         x, y, z = coord_sys.base_scalars()

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -1,7 +1,7 @@
 from sympy.vector.coordsysrect import CoordSys3D
 from sympy.vector.scalar import BaseScalar
 from sympy.vector.vector import Vector, BaseVector
-from sympy.vector.operators import gradient, curl, divergence
+from sympy.vector.operators import curl, divergence
 from sympy import diff, integrate, S, simplify
 from sympy.core import sympify
 from sympy.vector.dyadic import Dyadic
@@ -122,6 +122,17 @@ def express(expr, system, system2=None, variables=False):
                 subs_dict.update(f.scalar_map(system))
             return expr.subs(subs_dict)
         return expr
+
+
+def split_coordinate(expr):
+    import collections
+    d = collections.defaultdict(lambda: S.One)
+    if isinstance(expr, (BaseScalar, BaseVector)):
+        return [expr]
+    else:
+        for i in expr.args:
+            d[frozenset(i.atoms(CoordSys3D))] *= i
+        return d.values()
 
 
 def directional_derivative(field, direction_vector):

--- a/sympy/vector/operators.py
+++ b/sympy/vector/operators.py
@@ -153,10 +153,9 @@ def curl(vect, coord_sys=None, doit=True):
         i, j, k = coord_sys.base_vectors()
         x, y, z = coord_sys.base_scalars()
         h1, h2, h3 = coord_sys.lame_coefficients()
-        from sympy.vector.functions import express
-        vectx = express(vect.dot(i), coord_sys, variables=True)
-        vecty = express(vect.dot(j), coord_sys, variables=True)
-        vectz = express(vect.dot(k), coord_sys, variables=True)
+        vectx = vect.dot(i)
+        vecty = vect.dot(j)
+        vectz = vect.dot(k)
         outvec = Vector.zero
         outvec += (Derivative(vectz * h3, y) -
                    Derivative(vecty * h2, z)) * i / (h2 * h3)
@@ -169,16 +168,30 @@ def curl(vect, coord_sys=None, doit=True):
             return outvec.doit()
         return outvec
     else:
-
         # TODO: use some of the vector calculus properties for this:
         coord_sys = coord_sys.pop()  # get one random coord_sys
         i, j, k = coord_sys.base_vectors()
+        x, y, z = coord_sys.base_scalars()
+        h1, h2, h3 = coord_sys.lame_coefficients()
 
         from .functions import express
         vectx = express(vect.dot(i), coord_sys, variables=True)
         vecty = express(vect.dot(j), coord_sys, variables=True)
         vectz = express(vect.dot(k), coord_sys, variables=True)
-        return curl(vectx*i + vecty*j + vectz*k)
+
+        # This is a repetition of previous code, it will be removed as soon as
+        # we have some better algorithm to deal with this case:
+        outvec = Vector.zero
+        outvec += (Derivative(vectz * h3, y) -
+                   Derivative(vecty * h2, z)) * i / (h2 * h3)
+        outvec += (Derivative(vectx * h1, z) -
+                   Derivative(vectz * h3, x)) * j / (h1 * h3)
+        outvec += (Derivative(vecty * h2, x) -
+                   Derivative(vectx * h1, y)) * k / (h2 * h1)
+
+        if doit:
+            return outvec.doit()
+        return outvec
 
 
 def divergence(vect, coord_sys=None, doit=True):
@@ -275,11 +288,9 @@ def gradient(scalar_field, coord_sys=None, doit=True):
         return Vector.zero
     elif len(coord_sys) == 1:
         coord_sys = coord_sys.pop()
-        from sympy.vector.functions import express
         h1, h2, h3 = coord_sys.lame_coefficients()
         i, j, k = coord_sys.base_vectors()
         x, y, z = coord_sys.base_scalars()
-        #scalar_field = express(scalar_field, coord_sys, variables=True)
         vx = Derivative(scalar_field, x) / h1
         vy = Derivative(scalar_field, y) / h2
         vz = Derivative(scalar_field, z) / h3

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -266,11 +266,12 @@ def test_mixed_coordinates():
     assert gradient(a.x*b.y) == b.y*a.i + a.x*b.j
     assert gradient(3*cos(q)*a.x*b.x+a.y*(a.x+((cos(q)+b.x)))) ==\
            (a.y + 3*b.x*cos(q))*a.i + (a.x + b.x + cos(q))*a.j + (3*a.x*cos(q) + a.y)*b.i
+    # Some tests need further work:
     # assert gradient(a.x*(cos(a.x+b.x))) == (cos(a.x + b.x))*a.i + a.x*Gradient(cos(a.x + b.x))
     # assert gradient(cos(a.x + b.x)*cos(a.x + b.z)) == Gradient(cos(a.x + b.x)*cos(a.x + b.z))
-    # assert gradient(a.x**b.y) == Gradient(a.x**b.y)
-    # assert gradient(cos(a.x+b.y)*a.z) ==
-    # assert gradient(cos(a.x*b.y)) == Gradient(cos(a.x*b.y))
+    assert gradient(a.x**b.y) == Gradient(a.x**b.y)
+    # assert gradient(cos(a.x+b.y)*a.z) == None
+    assert gradient(cos(a.x*b.y)) == Gradient(cos(a.x*b.y))
     assert gradient(3*cos(q)*a.x*b.x*a.z*a.y+ b.y*b.z + cos(a.x+a.y)*b.z) == \
            (3*a.y*a.z*b.x*cos(q) - b.z*sin(a.x + a.y))*a.i + \
            (3*a.x*a.z*b.x*cos(q) - b.z*sin(a.x + a.y))*a.j + (3*a.x*a.y*b.x*cos(q))*a.k + \

--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -5,7 +5,7 @@ from sympy.simplify import simplify
 from sympy.core.symbol import symbols
 from sympy.core import S
 from sympy import sin, cos
-from sympy.vector.operators import curl, divergence, gradient
+from sympy.vector.operators import curl, divergence, gradient, Gradient
 from sympy.vector.deloperator import Del
 from sympy.vector.functions import (is_conservative, is_solenoidal,
                                     scalar_potential, directional_derivative,
@@ -256,3 +256,22 @@ def test_differential_operators_curvilinear_system():
     assert curl(A.r*A.i + A.theta*A.j + A.phi*A.k) == \
            (cos(A.theta)*A.phi/(sin(A.theta)*A.r))*A.i + (-A.phi/A.r)*A.j + A.theta/A.r*A.k
     assert curl(A.r*A.j + A.phi*A.k) == (cos(A.theta)*A.phi/(sin(A.theta)*A.r))*A.i + (-A.phi/A.r)*A.j + 2*A.k
+
+
+def test_mixed_coordinates():
+    # gradient
+    a = CoordSys3D('a')
+    b = CoordSys3D('b')
+    c = CoordSys3D('c')
+    assert gradient(a.x*b.y) == b.y*a.i + a.x*b.j
+    assert gradient(3*cos(q)*a.x*b.x+a.y*(a.x+((cos(q)+b.x)))) ==\
+           (a.y + 3*b.x*cos(q))*a.i + (a.x + b.x + cos(q))*a.j + (3*a.x*cos(q) + a.y)*b.i
+    # assert gradient(a.x*(cos(a.x+b.x))) == (cos(a.x + b.x))*a.i + a.x*Gradient(cos(a.x + b.x))
+    # assert gradient(cos(a.x + b.x)*cos(a.x + b.z)) == Gradient(cos(a.x + b.x)*cos(a.x + b.z))
+    # assert gradient(a.x**b.y) == Gradient(a.x**b.y)
+    # assert gradient(cos(a.x+b.y)*a.z) ==
+    # assert gradient(cos(a.x*b.y)) == Gradient(cos(a.x*b.y))
+    assert gradient(3*cos(q)*a.x*b.x*a.z*a.y+ b.y*b.z + cos(a.x+a.y)*b.z) == \
+           (3*a.y*a.z*b.x*cos(q) - b.z*sin(a.x + a.y))*a.i + \
+           (3*a.x*a.z*b.x*cos(q) - b.z*sin(a.x + a.y))*a.j + (3*a.x*a.y*b.x*cos(q))*a.k + \
+           (3*a.x*a.y*a.z*cos(q))*b.i + b.z*b.j + (b.y + cos(a.x + a.y))*b.k


### PR DESCRIPTION
This PR allows `gradient` to handle mixed coordinate system. 
Not every new tests could be unlocked, because at that moment `Gradient`, unevaluated expression, isn't interpret as `vector` so we cannot add such expression to another `vector`. 

TODO:
- [ ] `Gradient` need to be interpreted as `vector` (#13097). 
