### PR TITLE
group theory: PermutationGroup methods for FpGroup

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -353,20 +353,25 @@ class FpGroup(DefaultPrinting):
             self._perm_isomorphism = T
         return P, T
 
-    def _perm_group_list(self, method):
+    def _perm_group_list(self, method_name, *args):
         '''
-        Given a `PermutationGroup` method that returns a list of subgroups,
-        return a list of lists containing the generators of these subgroups
-        in terms of the generators of `self`.
+        Given the name of a `PermutationGroup` method (returning a subgroup
+        or a list of subgroups) and (optionally) additional arguments it takes,
+        return a list or a list of lists containing the generators of this (or
+        these) subgroups in terms of the generators of `self`.
 
         '''
+        from sympy.combinatorics import PermutationGroup
         P, T = self._to_perm_group()
-        perm_result = method(P)
+        perm_result = getattr(P, method_name)(*args)
+        single = False
+        if isinstance(perm_result, PermutationGroup):
+            perm_result, single = [perm_result], True
         result = []
         for group in perm_result:
             gens = group.generators
             result.append(T.invert(gens))
-        return result
+        return result[0] if single else result
 
     def derived_series(self):
         '''
@@ -374,8 +379,7 @@ class FpGroup(DefaultPrinting):
         of the subgroups in the derived series of `self`.
 
         '''
-        method = lambda x: x.derived_series()
-        return self._perm_group_list(method)
+        return self._perm_group_list('derived_series')
 
     def lower_central_series(self):
         '''
@@ -383,16 +387,14 @@ class FpGroup(DefaultPrinting):
         of the subgroups in the lower central series of `self`.
 
         '''
-        method = lambda x: x.lower_central_series()
-        return self._perm_group_list(method)
+        return self._perm_group_list('lower_central_series')
 
     def center(self):
         '''
         Return the list of generators of the center of `self`.
 
         '''
-        method = lambda x: [x.center()]
-        return self._perm_group_list(method)[0]
+        return self._perm_group_list('center')
 
 
     def derived_subgroup(self):
@@ -400,8 +402,7 @@ class FpGroup(DefaultPrinting):
         Return the list of generators of the derived subgroup of `self`.
 
         '''
-        method = lambda x: [x.derived_subgroup()]
-        return self._perm_group_list(method)[0]
+        return self._perm_group_list('derived_subgroup')
 
 
     def centralizer(self, other):
@@ -412,8 +413,7 @@ class FpGroup(DefaultPrinting):
         '''
         T = self._to_perm_group()[1]
         other = T(other)
-        method = lambda x: [x.centralizer(other)]
-        return self._perm_group_list(method)[0]
+        return self._perm_group_list('centralizer', other)
 
     def normal_closure(self, other):
         '''
@@ -423,8 +423,7 @@ class FpGroup(DefaultPrinting):
         '''
         T = self._to_perm_group()[1]
         other = T(other)
-        method = lambda x: [x.normal_closure(other)]
-        return self._perm_group_list(method)[0]
+        return self._perm_group_list('normal_closure', other)
 
     def _perm_property(self, attr):
         '''

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -13,6 +13,7 @@ from sympy.combinatorics.rewritingsystem import RewritingSystem
 from sympy.combinatorics.coset_table import (CosetTable,
                                              coset_enumeration_r,
                                              coset_enumeration_c)
+from sympy.combinatorics import PermutationGroup
 
 from itertools import product
 
@@ -361,7 +362,6 @@ class FpGroup(DefaultPrinting):
         these) subgroups in terms of the generators of `self`.
 
         '''
-        from sympy.combinatorics import PermutationGroup
         P, T = self._to_perm_group()
         perm_result = getattr(P, method_name)(*args)
         single = False

--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -186,8 +186,7 @@ class FreeGroup(DefaultPrinting):
     def __contains__(self, i):
         """Return True if ``i`` is contained in FreeGroup."""
         if not isinstance(i, FreeGroupElement):
-            raise TypeError("FreeGroup contains only FreeGroupElement as elements "
-                        ", not elements of type %s" % type(i))
+            return False
         group = i.group
         return self == group
 

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -180,7 +180,9 @@ def test_permutation_methods():
 
     # DiheadralGroup(4)
     G = FpGroup(F, [x**2, y**4, x*y*x**-1*y])
-    assert G.normal_closure([x]) == [x, x*y**2]
+    S = FpSubgroup(G, G.normal_closure([x]))
+    assert x in S
+    assert y**-1*x*y in S
 
     # Z_5xZ_4
     G = FpGroup(F, [x*y*x**-1*y**-1, y**5, x**4])

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -168,3 +168,31 @@ def test_fp_subgroup():
     S = FpSubgroup(F, [x**-1*y*x])
     assert x**-1*y**4*x in S
     assert x**-1*y**4*x**2 not in S
+
+def test_permutation_methods():
+    from sympy.combinatorics.fp_groups import FpSubgroup
+    F, x, y = free_group("x, y")
+    # DihedralGroup(8)
+    G = FpGroup(F, [x**2, y**8, x*y*x**-1*y])
+    T = G._to_perm_group()[1]
+    assert T.is_isomorphism()
+    assert G.center() == [G.identity, y**4]
+
+    # DiheadralGroup(4)
+    G = FpGroup(F, [x**2, y**4, x*y*x**-1*y])
+    assert G.normal_closure([x]) == [x, x*y**2]
+
+    # Z_5xZ_4
+    G = FpGroup(F, [x*y*x**-1*y**-1, y**5, x**4])
+    assert G.is_abelian
+    assert G.is_solvable
+
+    # AlternatingGroup(5)
+    G = FpGroup(F, [x**3, y**2, (x*y)**5])
+    assert not G.is_solvable
+
+    # AlternatingGroup(4)
+    G = FpGroup(F, [x**3, y**2, (x*y)**3])
+    assert len(G.derived_series()) == 3
+    S = FpSubgroup(G, G.derived_subgroup())
+    assert S.order() == 4


### PR DESCRIPTION
This PR implements some of the methods from the `PermutationGroup` class for the `FpGroup` class. This is done by using coset tables to find an isomorphism from an `FpGroup` to a `PermutationGroup`, applying the method in the latter and then using the isomorphism to go back. Additionally, homomorphisms can now invert or be applied to a list of elements.