### PR TITLE
get_dimensional_expr(func(expr)) should give 1 if expr is dimensionless

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -114,12 +114,12 @@ class Quantity(AtomicExpr):
             return dim
         elif isinstance(expr, Function):
             args = [Quantity.get_dimensional_expr(arg) for arg in expr.args]
-            if args == [1]:
-                return 1
+            if all(i == 1 for i in args):
+                return S.One
             return expr.func(*args)
         elif isinstance(expr, Quantity):
             return expr.dimension.name
-        return 1
+        return S.One
 
     @staticmethod
     def _collect_factor_and_dimension(expr):

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -114,6 +114,8 @@ class Quantity(AtomicExpr):
             return dim
         elif isinstance(expr, Function):
             args = [Quantity.get_dimensional_expr(arg) for arg in expr.args]
+            if args == [1]:
+                return 1
             return expr.func(*args)
         elif isinstance(expr, Quantity):
             return expr.dimension.name

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -341,6 +341,12 @@ def test_get_dimensional_expr_with_function():
         sin(Quantity.get_dimensional_expr(v_w1))
 
 
+def test_get_dimensional_expr_with_function_1():
+    v_w1 = Quantity('v_w1', length / time, meter / second)
+    v_w2 = Quantity('v_w2', length / time, meter / second)
+    assert Quantity.get_dimensional_expr(sin(v_w1/v_w2)) == 1
+
+
 def test_binary_information():
     assert convert_to(kibibyte, byte) == 1024*byte
     assert convert_to(mebibyte, byte) == 1024**2*byte


### PR DESCRIPTION
Current behaviour on master:
```
from sympy.physics.units import Quantity, Dimension, length, time, meter, second
from sympy import sin
v_w1 = Quantity('v_w1', length/time, meter/second)
v_w2 = Quantity('v_w2', length/time, meter/second)
result = Quantity.get_dimensional_expr(sin(v_w1/v_w2))
print result

sin(1)
```
This does not make sense, as `sin(1)` is a dimensionless number, so the result should be `1`. This PR makes `get_dimensional_expr()` return `1` whenever the expression inside a function is dimensionless.