### PR TITLE
Fix powsimp issues #9183, #10095, and KeyError

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1174,6 +1174,11 @@ class Pow(Expr):
         if neg_exp:
             n, d = d, n
             exp = -exp
+        if exp.is_infinite:
+            if n is S.One and d is not S.One:
+                return n, self.func(d, exp)
+            if n is not S.One and d is S.One:
+                return self.func(n, exp), d
         return self.func(n, exp), self.func(d, exp)
 
     def matches(self, expr, repl_dict={}, old=False):

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -276,7 +276,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         bases = []
         for b, e in c_powers:
             b, e = bkey(b, e)
-            if b in common_b.keys():
+            if b in common_b:
                 common_b[b] = common_b[b] + e
             else:
                 common_b[b] = e

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -163,9 +163,9 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             # allow 2**x/4 -> 2**(x - 2); don't do this when b and e are
             # Numbers since autoevaluation will undo it, e.g.
             # 2**(1/3)/4 -> 2**(1/3 - 2) -> 2**(1/3)/4
-            if (b and b.is_Number and b.is_rational and not all(
-                ei.is_Number for ei in e) and  coeff is not S.One
-                and b not in (S.One, S.NegativeOne)):
+            if (b and b.is_Rational and not all(ei.is_Number for ei in e) and \
+                    coeff is not S.One and
+                    b not in (S.One, S.NegativeOne)):
                 m = multiplicity(abs(b), abs(coeff))
                 if m:
                     e.append(m)

--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -163,9 +163,9 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             # allow 2**x/4 -> 2**(x - 2); don't do this when b and e are
             # Numbers since autoevaluation will undo it, e.g.
             # 2**(1/3)/4 -> 2**(1/3 - 2) -> 2**(1/3)/4
-            if (b and b.is_Number and not all(ei.is_Number for ei in e) and \
-                    coeff is not S.One and
-                    b not in (S.One, S.NegativeOne)):
+            if (b and b.is_Number and b.is_rational and not all(
+                ei.is_Number for ei in e) and  coeff is not S.One
+                and b not in (S.One, S.NegativeOne)):
                 m = multiplicity(abs(b), abs(coeff))
                 if m:
                     e.append(m)

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -98,6 +98,12 @@ def test_powsimp():
     # issue 8836
     assert str( powsimp(exp(I*pi/3)*root(-1,3)) ) == '(-1)**(2/3)'
 
+    # issue 9183
+    assert powsimp(-0.1**x) == -0.1**x
+
+    # issue 10095
+    assert powsimp((1/(2*E))**oo) == 0
+
 
 def test_powsimp_negated_base():
     assert powsimp((-x + y)/sqrt(x - y)) == -sqrt(x - y)

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -1,7 +1,7 @@
 from sympy import (
     symbols, powsimp, symbols, MatrixSymbol, sqrt, pi, Mul, gamma, Function,
     S, I, exp, simplify, sin, E, log, hyper, Symbol, Dummy, powdenest, root,
-    Rational)
+    Rational, oo)
 
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 
@@ -102,7 +102,7 @@ def test_powsimp():
     assert powsimp(-0.1**x) == -0.1**x
 
     # issue 10095
-    assert powsimp((1/(2*E))**oo) == 0
+    assert powsimp((1/(2*E))**oo) == (exp(-1)/2)**oo
 
 
 def test_powsimp_negated_base():

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -104,6 +104,10 @@ def test_powsimp():
     # issue 10095
     assert powsimp((1/(2*E))**oo) == (exp(-1)/2)**oo
 
+    # PR 13131
+    eq = sin(2*x)**2*sin(2.0*x)**2
+    assert powsimp(eq) == eq
+
 
 def test_powsimp_negated_base():
     assert powsimp((-x + y)/sqrt(x - y)) == -sqrt(x - y)


### PR DESCRIPTION
- Fixed powsimp raising ValueError when base is float and Pow is argument of Mul. Since multiplicity expects integer or rational but powsimp doesn't checks it, it raises ValueError: fixes #9183
- Fixed Pow.as_numer_denom() returning nan when either numerator or denominator of base is 1 and exp is infinite. Since 1**oo is NaN, numerator or denominator becomes NaN: fixes #10095
- Fixed powsimp raising KeyError in common_b[b] = common_b[b] + e, when one base is Float and another is equal Rational(Integer). This seems to be caused by #11707.

~**Thing(s) to consider:** Should we automatically evaluate k**oo to zero where k is in (-1, 1), i.e., `(1/(2*E))**oo`?~