### PR TITLE
Improve combsimp()

### DIFF
--- a/sympy/concrete/tests/test_gosper.py
+++ b/sympy/concrete/tests/test_gosper.py
@@ -43,9 +43,9 @@ def test_gosper_sum():
     # issue 6033:
     assert gosper_sum(
         n*(n + a + b)*a**n*b**n/(factorial(n + a)*factorial(n + b)), \
-        (n, 0, m)) == -a*b*(exp(m*log(a))*exp(m*log(b))*factorial(a)* \
-        factorial(b) - factorial(a + m)*factorial(b + m))/(factorial(a)* \
-        factorial(b)*factorial(a + m)*factorial(b + m))
+        (n, 0, m)).simplify() == -exp(m*log(a))*exp(m*log(b))*gamma(a + 1) \
+        *gamma(b + 1)/(gamma(a)*gamma(b)*gamma(a + m + 1)*gamma(b + m + 1)) \
+        + 1/(gamma(a)*gamma(b))
 
 
 def test_gosper_sum_indefinite():

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -470,8 +470,7 @@ def test_wallis_product():
     # can factor simple rational expressions
     A = Product(4*n**2 / (4*n**2 - 1), (n, 1, b))
     B = Product((2*n)*(2*n)/(2*n - 1)/(2*n + 1), (n, 1, b))
-    half = Rational(1, 2)
-    R = pi/2 * factorial(b)**2 / factorial(b - half) / factorial(b + half)
+    R = pi*gamma(b + 1)**2/(2*gamma(b + Rational(1, 2))*gamma(b + Rational(3, 2)))
     assert simplify(A.doit()) == R
     assert simplify(B.doit()) == R
     # This one should eventually also be doable (Euler's product formula for sin)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -651,7 +651,7 @@ def test_sine_transform():
     assert inverse_sine_transform(1/sqrt(w), w, t) == 1/sqrt(t)
 
     assert sine_transform(
-        (1/sqrt(t))**3, t, w) == sqrt(w)*gamma(S(1)/4)/(2*gamma(S(5)/4))
+        (1/sqrt(t))**3, t, w) == 2*sqrt(w)
 
     assert sine_transform(t**(-a), t, w) == 2**(
         -a + S(1)/2)*w**(a - 1)*gamma(-a/2 + 1)/gamma((a + 1)/2)

--- a/sympy/simplify/combsimp.py
+++ b/sympy/simplify/combsimp.py
@@ -2,6 +2,8 @@ from __future__ import print_function, division
 
 from sympy.core import Function, S, Mul, Pow, Add
 from sympy.core.compatibility import ordered, default_sort_key
+from sympy.core.basic import preorder_traversal
+from sympy.core.function import count_ops, expand_func
 from sympy.functions.combinatorial.factorials import binomial, CombinatorialFunction, factorial
 from sympy.functions import gamma, sqrt, sin
 from sympy.polys import factor, cancel
@@ -13,7 +15,7 @@ from sympy.utilities.iterables import uniq
 
 
 @timethis('combsimp')
-def combsimp(expr):
+def combsimp(expr, as_gamma = None, as_binomial = True):
     r"""
     Simplify combinatorial expressions.
 
@@ -29,21 +31,23 @@ def combsimp(expr):
     the resulting rising factorial to cancel. Rising factorials with
     the second argument being an integer are expanded into polynomial
     forms and finally all other rising factorial are rewritten in terms
-    of more familiar functions. If the initial expression consisted of
-    gamma functions alone, the result is expressed in terms of gamma
-    functions. If the initial expression consists of gamma function
-    with some other combinatorial, the result is expressed in terms of
-    gamma functions.
+    of more familiar functions.
 
-    If the result is expressed using gamma functions, the following three
-    additional steps are performed:
+    If as_gamma is None, is_gamma is set to True if initial expression
+    consisted of combinatorial functions or gamma functions with non-
+    integer arguments.
+
+    If as_gamma is True, the following additional two steps are performed.
 
     1. Reduce the number of gammas by applying the reflection theorem
        gamma(x)*gamma(1-x) == pi/sin(pi*x).
     2. Reduce the number of gammas by applying the multiplication theorem
        gamma(x)*gamma(x+1/n)*...*gamma(x+(n-1)/n) == C*gamma(n*x).
-    3. Reduce the number of prefactors by absorbing them into gammas, where
-       possible.
+
+    Then it reduces the number of prefactors by absorbing them into gammas,
+    where possible and expands gammas with rational argument. If as_gamma
+    is False, it rewrites gammas to factorials and if as_binomial is True,
+    it finds (a+b)!/a!b! and replaces with binomial.
 
     All transformation rules can be found (or was derived from) here:
 
@@ -64,17 +68,11 @@ def combsimp(expr):
 
     """
 
-    # as a rule of thumb, if the expression contained gammas initially, it
-    # probably makes sense to retain them
-    as_gamma = expr.has(gamma)
-    as_factorial = expr.has(factorial)
-    as_binomial = expr.has(binomial)
+    if as_gamma is None:
+        as_gamma = any(isinstance(node, (gamma, CombinatorialFunction)) and
+            not all(arg.is_integer for arg in node.args)
+            for node in preorder_traversal(expr))
 
-
-    expr = expr.replace(binomial,
-        lambda n, k: _rf((n - k + 1).expand(), k.expand())/_rf(1, k.expand()))
-    expr = expr.replace(factorial,
-        lambda n: _rf(1, n.expand()))
     expr = expr.rewrite(gamma)
     expr = expr.replace(gamma,
         lambda n: _rf(1, (n - 1).expand()))
@@ -105,6 +103,9 @@ def combsimp(expr):
                 coeff *= _rf(n - ck - _k + 1, ck)/_rf(_k + 1, ck)
                 rewrite = True
                 k = _k
+
+        if count_ops(k) > count_ops(n - k):
+            k = n - k
 
         if rewrite:
             return coeff*binomial(n, k)
@@ -220,166 +221,167 @@ def combsimp(expr):
 
         # =========== level 2 work: pure gamma manipulation =========
 
-        # Try to reduce the number of gamma factors by applying the
-        # reflection formula gamma(x)*gamma(1-x) = pi/sin(pi*x)
-        for gammas, numer, denom in [(
-            numer_gammas, numer_others, denom_others),
-                (denom_gammas, denom_others, numer_others)]:
-            new = []
-            while gammas:
-                g1 = gammas.pop()
-                if g1.is_integer:
-                    new.append(g1)
-                    continue
-                for i, g2 in enumerate(gammas):
-                    n = g1 + g2 - 1
-                    if not n.is_Integer:
+        if as_gamma:
+            # Try to reduce the number of gamma factors by applying the
+            # reflection formula gamma(x)*gamma(1-x) = pi/sin(pi*x)
+            for gammas, numer, denom in [(
+                numer_gammas, numer_others, denom_others),
+                    (denom_gammas, denom_others, numer_others)]:
+                new = []
+                while gammas:
+                    g1 = gammas.pop()
+                    if g1.is_integer:
+                        new.append(g1)
                         continue
-                    numer.append(S.Pi)
-                    denom.append(sin(S.Pi*g1))
-                    gammas.pop(i)
-                    if n > 0:
-                        for k in range(n):
-                            numer.append(1 - g1 + k)
-                    elif n < 0:
-                        for k in range(-n):
-                            denom.append(-g1 - k)
-                    break
-                else:
-                    new.append(g1)
-            # /!\ updating IN PLACE
-            gammas[:] = new
-
-        # Try to reduce the number of gammas by using the duplication
-        # theorem to cancel an upper and lower: gamma(2*s)/gamma(s) =
-        # 2**(2*s + 1)/(4*sqrt(pi))*gamma(s + 1/2). Although this could
-        # be done with higher argument ratios like gamma(3*x)/gamma(x),
-        # this would not reduce the number of gammas as in this case.
-        for ng, dg, no, do in [(numer_gammas, denom_gammas, numer_others,
-                                denom_others),
-                               (denom_gammas, numer_gammas, denom_others,
-                                numer_others)]:
-
-            while True:
-                for x in ng:
-                    for y in dg:
-                        n = x - 2*y
-                        if n.is_Integer:
-                            break
+                    for i, g2 in enumerate(gammas):
+                        n = g1 + g2 - 1
+                        if not n.is_Integer:
+                            continue
+                        numer.append(S.Pi)
+                        denom.append(sin(S.Pi*g1))
+                        gammas.pop(i)
+                        if n > 0:
+                            for k in range(n):
+                                numer.append(1 - g1 + k)
+                        elif n < 0:
+                            for k in range(-n):
+                                denom.append(-g1 - k)
+                        break
                     else:
-                        continue
-                    break
-                else:
-                    break
-                ng.remove(x)
-                dg.remove(y)
-                if n > 0:
-                    for k in range(n):
-                        no.append(2*y + k)
-                elif n < 0:
-                    for k in range(-n):
-                        do.append(2*y - 1 - k)
-                ng.append(y + S(1)/2)
-                no.append(2**(2*y - 1))
-                do.append(sqrt(S.Pi))
+                        new.append(g1)
+                # /!\ updating IN PLACE
+                gammas[:] = new
 
-        # Try to reduce the number of gamma factors by applying the
-        # multiplication theorem (used when n gammas with args differing
-        # by 1/n mod 1 are encountered).
-        #
-        # run of 2 with args differing by 1/2
-        #
-        # >>> combsimp(gamma(x)*gamma(x+S.Half))
-        # 2*sqrt(2)*2**(-2*x - 1/2)*sqrt(pi)*gamma(2*x)
-        #
-        # run of 3 args differing by 1/3 (mod 1)
-        #
-        # >>> combsimp(gamma(x)*gamma(x+S(1)/3)*gamma(x+S(2)/3))
-        # 6*3**(-3*x - 1/2)*pi*gamma(3*x)
-        # >>> combsimp(gamma(x)*gamma(x+S(1)/3)*gamma(x+S(5)/3))
-        # 2*3**(-3*x - 1/2)*pi*(3*x + 2)*gamma(3*x)
-        #
-        def _run(coeffs):
-            # find runs in coeffs such that the difference in terms (mod 1)
-            # of t1, t2, ..., tn is 1/n
-            u = list(uniq(coeffs))
-            for i in range(len(u)):
-                dj = ([((u[j] - u[i]) % 1, j) for j in range(i + 1, len(u))])
-                for one, j in dj:
-                    if one.p == 1 and one.q != 1:
-                        n = one.q
-                        got = [i]
-                        get = list(range(1, n))
-                        for d, j in dj:
-                            m = n*d
-                            if m.is_Integer and m in get:
-                                get.remove(m)
-                                got.append(j)
-                                if not get:
-                                    break
+            # Try to reduce the number of gammas by using the duplication
+            # theorem to cancel an upper and lower: gamma(2*s)/gamma(s) =
+            # 2**(2*s + 1)/(4*sqrt(pi))*gamma(s + 1/2). Although this could
+            # be done with higher argument ratios like gamma(3*x)/gamma(x),
+            # this would not reduce the number of gammas as in this case.
+            for ng, dg, no, do in [(numer_gammas, denom_gammas, numer_others,
+                                    denom_others),
+                                   (denom_gammas, numer_gammas, denom_others,
+                                    numer_others)]:
+
+                while True:
+                    for x in ng:
+                        for y in dg:
+                            n = x - 2*y
+                            if n.is_Integer:
+                                break
                         else:
                             continue
-                        for i, j in enumerate(got):
-                            c = u[j]
-                            coeffs.remove(c)
-                            got[i] = c
-                        return one.q, got[0], got[1:]
-
-        def _mult_thm(gammas, numer, denom):
-            # pull off and analyze the leading coefficient from each gamma arg
-            # looking for runs in those Rationals
-
-            # expr -> coeff + resid -> rats[resid] = coeff
-            rats = {}
-            for g in gammas:
-                c, resid = g.as_coeff_Add()
-                rats.setdefault(resid, []).append(c)
-
-            # look for runs in Rationals for each resid
-            keys = sorted(rats, key=default_sort_key)
-            for resid in keys:
-                coeffs = list(sorted(rats[resid]))
-                new = []
-                while True:
-                    run = _run(coeffs)
-                    if run is None:
                         break
+                    else:
+                        break
+                    ng.remove(x)
+                    dg.remove(y)
+                    if n > 0:
+                        for k in range(n):
+                            no.append(2*y + k)
+                    elif n < 0:
+                        for k in range(-n):
+                            do.append(2*y - 1 - k)
+                    ng.append(y + S(1)/2)
+                    no.append(2**(2*y - 1))
+                    do.append(sqrt(S.Pi))
 
-                    # process the sequence that was found:
-                    # 1) convert all the gamma functions to have the right
-                    #    argument (could be off by an integer)
-                    # 2) append the factors corresponding to the theorem
-                    # 3) append the new gamma function
+            # Try to reduce the number of gamma factors by applying the
+            # multiplication theorem (used when n gammas with args differing
+            # by 1/n mod 1 are encountered).
+            #
+            # run of 2 with args differing by 1/2
+            #
+            # >>> combsimp(gamma(x)*gamma(x+S.Half))
+            # 2*sqrt(2)*2**(-2*x - 1/2)*sqrt(pi)*gamma(2*x)
+            #
+            # run of 3 args differing by 1/3 (mod 1)
+            #
+            # >>> combsimp(gamma(x)*gamma(x+S(1)/3)*gamma(x+S(2)/3))
+            # 6*3**(-3*x - 1/2)*pi*gamma(3*x)
+            # >>> combsimp(gamma(x)*gamma(x+S(1)/3)*gamma(x+S(5)/3))
+            # 2*3**(-3*x - 1/2)*pi*(3*x + 2)*gamma(3*x)
+            #
+            def _run(coeffs):
+                # find runs in coeffs such that the difference in terms (mod 1)
+                # of t1, t2, ..., tn is 1/n
+                u = list(uniq(coeffs))
+                for i in range(len(u)):
+                    dj = ([((u[j] - u[i]) % 1, j) for j in range(i + 1, len(u))])
+                    for one, j in dj:
+                        if one.p == 1 and one.q != 1:
+                            n = one.q
+                            got = [i]
+                            get = list(range(1, n))
+                            for d, j in dj:
+                                m = n*d
+                                if m.is_Integer and m in get:
+                                    get.remove(m)
+                                    got.append(j)
+                                    if not get:
+                                        break
+                            else:
+                                continue
+                            for i, j in enumerate(got):
+                                c = u[j]
+                                coeffs.remove(c)
+                                got[i] = c
+                            return one.q, got[0], got[1:]
 
-                    n, ui, other = run
+            def _mult_thm(gammas, numer, denom):
+                # pull off and analyze the leading coefficient from each gamma arg
+                # looking for runs in those Rationals
 
-                    # (1)
-                    for u in other:
-                        con = resid + u - 1
-                        for k in range(int(u - ui)):
-                            numer.append(con - k)
+                # expr -> coeff + resid -> rats[resid] = coeff
+                rats = {}
+                for g in gammas:
+                    c, resid = g.as_coeff_Add()
+                    rats.setdefault(resid, []).append(c)
 
-                    con = n*(resid + ui)  # for (2) and (3)
+                # look for runs in Rationals for each resid
+                keys = sorted(rats, key=default_sort_key)
+                for resid in keys:
+                    coeffs = list(sorted(rats[resid]))
+                    new = []
+                    while True:
+                        run = _run(coeffs)
+                        if run is None:
+                            break
 
-                    # (2)
-                    numer.append((2*S.Pi)**(S(n - 1)/2)*
-                                 n**(S(1)/2 - con))
-                    # (3)
-                    new.append(con)
+                        # process the sequence that was found:
+                        # 1) convert all the gamma functions to have the right
+                        #    argument (could be off by an integer)
+                        # 2) append the factors corresponding to the theorem
+                        # 3) append the new gamma function
 
-                # restore resid to coeffs
-                rats[resid] = [resid + c for c in coeffs] + new
+                        n, ui, other = run
 
-            # rebuild the gamma arguments
-            g = []
-            for resid in keys:
-                g += rats[resid]
-            # /!\ updating IN PLACE
-            gammas[:] = g
+                        # (1)
+                        for u in other:
+                            con = resid + u - 1
+                            for k in range(int(u - ui)):
+                                numer.append(con - k)
 
-        for l, numer, denom in [(numer_gammas, numer_others, denom_others),
-                                (denom_gammas, denom_others, numer_others)]:
-            _mult_thm(l, numer, denom)
+                        con = n*(resid + ui)  # for (2) and (3)
+
+                        # (2)
+                        numer.append((2*S.Pi)**(S(n - 1)/2)*
+                                     n**(S(1)/2 - con))
+                        # (3)
+                        new.append(con)
+
+                    # restore resid to coeffs
+                    rats[resid] = [resid + c for c in coeffs] + new
+
+                # rebuild the gamma arguments
+                g = []
+                for resid in keys:
+                    g += rats[resid]
+                # /!\ updating IN PLACE
+                gammas[:] = g
+
+            for l, numer, denom in [(numer_gammas, numer_others, denom_others),
+                                    (denom_gammas, denom_others, numer_others)]:
+                _mult_thm(l, numer, denom)
 
         # =========== level >= 2 work: factor absorbtion =========
 
@@ -466,11 +468,65 @@ def combsimp(expr):
     if expr != was:
         expr = factor(expr)
 
+    expr = expr.replace(gamma,
+        lambda n: expand_func(gamma(n)) if n.is_number and n.is_rational else gamma(n))
+
     if not as_gamma:
-        if as_factorial:
-            expr = expr.rewrite(factorial)
-        elif as_binomial:
-            expr = expr.rewrite(binomial)
+        expr = expr.rewrite(factorial)
+
+        if as_binomial:
+            from .simplify import bottom_up
+
+            def f(rv):
+                n, d = rv.as_numer_denom()
+
+                if n.is_Mul:
+                    n_args = list(n.args)
+                    n_fact_args = [arg.args[0] for arg in n.args if isinstance(arg, factorial)]
+                    if not n_fact_args:
+                        return rv
+                elif isinstance(n, factorial):
+                    n_args = [n]
+                    n_fact_args = [n.args[0]]
+                else:
+                    return rv
+
+                if d.is_Mul:
+                    d_args = list(d.args)
+                elif isinstance(d, factorial):
+                    d_args = [n]
+                else:
+                    return rv
+
+                hit = False
+                for i in range(len(d_args)):
+                    ai = d_args[i]
+                    if not isinstance(ai, factorial):
+                        continue
+
+                    for j in range(i + 1, len(d_args)):
+                        aj = d_args[j]
+                        if not isinstance(aj, factorial):
+                            continue
+
+                        sum = ai.args[0] + aj.args[0]
+                        if sum in n_fact_args:
+                            n_args.remove(factorial(sum))
+                            n_fact_args.remove(sum)
+                            n_args.append(binomial(sum, ai.args[0] if count_ops(ai.args[0]) < count_ops(aj.args[0]) else aj.args[0]))
+
+                            d_args[i] = None
+                            d_args[j] = None
+                            hit = True
+                            break
+
+                if hit:
+                    n = Mul(*[_arg for _arg in n_args if _arg])
+                    d = Mul(*[_arg for _arg in d_args if _arg])
+                    return n/d
+                return rv
+
+            expr = bottom_up(expr, f)
 
     return expr
 

--- a/sympy/simplify/tests/test_combsimp.py
+++ b/sympy/simplify/tests/test_combsimp.py
@@ -23,20 +23,32 @@ def test_combsimp():
     assert combsimp(factorial(n)*binomial(n + 1, k + 1)/binomial(n, k)) == \
         factorial(n + 1)/(1 + k)
 
-    assert combsimp(binomial(n - 1, k)) == binomial(n - 1, k)
-
     assert combsimp(binomial(n + 2, k + S(1)/2)) == gamma(n + 3)/ \
         (gamma(k + 3/2)*gamma(-k + n + 5/2))
     assert combsimp(binomial(n + 2, k + 2.0)) == \
         gamma(n + 3)/(gamma(k + 3.0)*gamma(-k + n + 1))
+
+    assert combsimp(factorial(n - S.Half)) == gamma(n + S.Half)
+    assert combsimp(factorial(n - S.Half), as_gamma = False) == \
+        factorial(n - S.Half)
+    assert combsimp(gamma(n + 3)) == factorial(n + 2)
+    assert combsimp(gamma(n + 3), as_gamma = True) == gamma(n + 3)
+    # issue 6658
+    assert combsimp(binomial(n, n - k)) == binomial(n, k)
+    # issue 6341, 7135
+    assert combsimp(factorial(n)/(factorial(k)*factorial(n - k))) == \
+        binomial(n, k)
+    assert combsimp(factorial(2*n)/factorial(n)**2) == binomial(2*n, n)
+    assert combsimp(factorial(n)/(factorial(k)*factorial(n - k)),
+        as_binomial = False) == factorial(n)/(factorial(k)*factorial(n - k))
+    # issue 11548
+    assert combsimp(binomial(0, x)) == sin(pi*x)/(pi*x)
 
     # coverage tests
     assert combsimp(factorial(n*(1 + n) - n**2 - n)) == 1
     assert combsimp(binomial(n + k - 2, n)) == \
         binomial(k + n - 2, n)
     i = Symbol('i', integer=True)
-    e = gamma(i + 3)
-    assert combsimp(e) == factorial(i + 2)
     e = gamma(exp(i))
     assert combsimp(e) == e
     e = gamma(n + S(1)/3)*gamma(n + S(2)/3)
@@ -125,6 +137,9 @@ def test_combsimp_gamma():
         gamma(k)*gamma(k + R(1, 3))*gamma(k + R(2, 3))/gamma(3*k/2)) == (
         3*2**(3*k + 1)*3**(-3*k - S.Half)*sqrt(pi)*gamma(3*k/2 + S.Half)/2)
 
+    # issue 6153
+    assert combsimp(gamma(S(1)/4)/gamma(S(5)/4)) == 4
+
 
 def test_issue_9699():
     n, k = symbols('n k', real=True)
@@ -132,4 +147,5 @@ def test_issue_9699():
     assert combsimp((n + 1)*factorial(n)) == gamma(n + 2)
     assert combsimp((x + 1)*factorial(x)/gamma(y)) == gamma(x + 2)/gamma(y)
     assert combsimp(factorial(n)/n) == gamma(n)
-    assert combsimp(rf(x + n, k)*binomial(n, k)) == gamma(n + 1)*gamma(k + n + x)/(gamma(k + 1)*gamma(n + x)*gamma(-k + n + 1))
+    assert combsimp(rf(x + n, k)*binomial(n, k)) == gamma(n + 1)*gamma(k + n
+        + x)/(gamma(k + 1)*gamma(n + x)*gamma(-k + n + 1))

--- a/sympy/simplify/tests/test_combsimp.py
+++ b/sympy/simplify/tests/test_combsimp.py
@@ -7,7 +7,7 @@ from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 
 
 def test_combsimp():
-    from sympy.abc import n, k
+    n, k = symbols('n k', integer = True)
 
     assert combsimp(factorial(n)) == factorial(n)
     assert combsimp(binomial(n, k)) == binomial(n, k)
@@ -23,20 +23,20 @@ def test_combsimp():
     assert combsimp(factorial(n)*binomial(n + 1, k + 1)/binomial(n, k)) == \
         factorial(n + 1)/(1 + k)
 
-    assert combsimp(binomial(n - 1, k)) == -((-n + k)*binomial(n, k))/n
+    assert combsimp(binomial(n - 1, k)) == binomial(n - 1, k)
 
-    assert combsimp(binomial(n + 2, k + S(1)/2)) == 4*((n + 1)*(n + 2) *
-        binomial(n, k + S(1)/2))/((2*k - 2*n - 1)*(2*k - 2*n - 3))
+    assert combsimp(binomial(n + 2, k + S(1)/2)) == gamma(n + 3)/ \
+        (gamma(k + 3/2)*gamma(-k + n + 5/2))
     assert combsimp(binomial(n + 2, k + 2.0)) == \
-        -((1.0*n + 2.0)*binomial(n + 1.0, k + 2.0))/(k - n)
+        gamma(n + 3)/(gamma(k + 3.0)*gamma(-k + n + 1))
 
     # coverage tests
     assert combsimp(factorial(n*(1 + n) - n**2 - n)) == 1
     assert combsimp(binomial(n + k - 2, n)) == \
-        k*(k - 1)*binomial(n + k, n)/((n + k)*(n + k - 1))
+        binomial(k + n - 2, n)
     i = Symbol('i', integer=True)
     e = gamma(i + 3)
-    assert combsimp(e) == e
+    assert combsimp(e) == factorial(i + 2)
     e = gamma(exp(i))
     assert combsimp(e) == e
     e = gamma(n + S(1)/3)*gamma(n + S(2)/3)
@@ -129,7 +129,7 @@ def test_combsimp_gamma():
 def test_issue_9699():
     n, k = symbols('n k', real=True)
     x, y = symbols('x, y')
-    assert combsimp((n + 1)*factorial(n)) == factorial(n + 1)
+    assert combsimp((n + 1)*factorial(n)) == gamma(n + 2)
     assert combsimp((x + 1)*factorial(x)/gamma(y)) == gamma(x + 2)/gamma(y)
-    assert combsimp(factorial(n)/n) == factorial(n - 1)
-    assert combsimp(rf(x + n, k)*binomial(n, k)) == binomial(n, k)*gamma(k + n + x)/gamma(n + x)
+    assert combsimp(factorial(n)/n) == gamma(n)
+    assert combsimp(rf(x + n, k)*binomial(n, k)) == gamma(n + 1)*gamma(k + n + x)/(gamma(k + 1)*gamma(n + x)*gamma(-k + n + 1))

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -542,7 +542,7 @@ def test_weibull_numeric():
     bvals = [S.Half, 1, S(3)/2, 5]
     for b in bvals:
         X = Weibull('x', a, b)
-        assert simplify(E(X)) == simplify(a * gamma(1 + 1/S(b)))
+        assert simplify(E(X)) == expand_func(a * gamma(1 + 1/S(b)))
         assert simplify(variance(X)) == simplify(
             a**2 * gamma(1 + 2/S(b)) - E(X)**2)
         # Not testing Skew... it's slow with int/frac values > 3/2

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2028,7 +2028,7 @@ def test_S4():
 def test_S5():
     n, k = symbols('n k', integer=True, positive=True)
     assert (Product((2*k - 1)/(2*k), (k, 1, n)).doit().combsimp() ==
-            factorial(n - Rational(1, 2))/(sqrt(pi)*factorial(n)))
+            gamma(n + Rational(1, 2))/(sqrt(pi)*gamma(n + 1)))
 
 
 @SKIP("https://github.com/sympy/sympy/issues/7133")


### PR DESCRIPTION
* Removed original as_gamma, as_factorial, as_binomial detection by checking whether original expression contained them.
* Added as_gamma as option(default None), and when None, it automatically detects by checking non-integer arguments of CombinatorialFunctions and gamma functions exist. Since factorial and binomial coefficient are defined for integers and expanded to real numbers with gamma function, I think if non-integer arguments are present, it makes more sense and is more simplified to write them in gamma functions. Fixes #8156
* Removed rewriting binomial coefficient to `_rf((n - k + 1).expand(), k.expand())/_rf(1, k.expand()))`. Fixes #11548 
* Added binomial coefficient simplification using `binomial(n, n-r) = binomial(n, r)`. Fixes #6658 
* Only apply gamma function simplifications when as_gamma is True to preserve integer arguments. Fixes #6341
* Expand gamma functions with rational number argument. Fixes #6153 and fixes #10101
* Added as_binomial as option(default True), and when True, it finds (a+b)!/a!b! and replaces with binomial coefficient. Fixes #7135 and #6341 (Should include inexact matches like (a+b-1)!/a!b!? It may become more complicated.)

~~**TODO:**~~

- [x] ~~Rewrite to binomial coefficient doesn't work when a == b since it is automatically combined to Pow~~
- [x] ~~Add/fix test cases~~

Related issue(discussion) : #9785