### PR TITLE
making decompogen capable for handling exponential functions

### DIFF
--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -1,5 +1,5 @@
 from sympy.core import Function, Pow, sympify
-from sympy.polys import Poly, decompose, GeneratorsNeeded
+from sympy.polys import Poly, decompose
 
 
 def decompogen(f, symbol):

--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -37,25 +37,27 @@ def decompogen(f, symbol):
     if isinstance(f, (Function, Pow)):
         if f.args[0] == symbol:
             return [f]
-        try:
-            result += [f.subs(f.args[0], symbol)] + decompogen(f.args[0], symbol)
-        except TypeError:
-            result = [f]
+
+        if f.is_Pow:
+            base, expo = f.args
+            if expo.has(symbol):
+                return [f]
+
+        result += [f.subs(f.args[0], symbol)] + decompogen(f.args[0], symbol)
         return result
 
     # ===== Convert to Polynomial ===== #
-    try:
-        fp = Poly(f)
-    except GeneratorsNeeded:
-        return None
+    fp = Poly(f)
     gens = list(filter(lambda x: symbol in x.free_symbols , fp.gens))
     if len(gens) == 1 and gens[0] != symbol:
+        if gens[0].is_Pow:
+            base, expo = gens[0].args
+            if expo.has(symbol):
+                return [f]
+
         f1 = f.subs(gens[0], symbol)
         f2 = gens[0]
-        try:
-            result += [f1] + decompogen(f2, symbol)
-        except TypeError:
-            result = [f]
+        result += [f1] + decompogen(f2, symbol)
         return result
 
     # ===== Polynomial decompose() ====== #

--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -41,7 +41,10 @@ def decompogen(f, symbol):
         if f.is_Pow:
             base, expo = f.args
             if expo.has(symbol):
-                return [f]
+                if f.args[1] == symbol:
+                    return [f]
+                result += [f.subs(f.args[1], symbol)] + decompogen(f.args[1], symbol)
+                return result
 
         result += [f.subs(f.args[0], symbol)] + decompogen(f.args[0], symbol)
         return result
@@ -49,12 +52,14 @@ def decompogen(f, symbol):
     # ===== Convert to Polynomial ===== #
     fp = Poly(f)
     gens = list(filter(lambda x: symbol in x.free_symbols , fp.gens))
-    if len(gens) == 1 and gens[0] != symbol:
-        if gens[0].is_Pow:
-            base, expo = gens[0].args
-            if expo.has(symbol):
-                return [f]
 
+    if gens[0].is_Pow:
+        if gens[0].has(symbol):
+            if f.args[1].args[1] == symbol:
+                return [f]
+            return [f.subs(f.args[1].args[1], symbol)] + decompogen(f.args[1].args[1], symbol)
+
+    if len(gens) == 1 and gens[0] != symbol:
         f1 = f.subs(gens[0], symbol)
         f2 = gens[0]
         result += [f1] + decompogen(f2, symbol)

--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -1,5 +1,5 @@
 from sympy.core import Function, Pow, sympify
-from sympy.polys import Poly, decompose
+from sympy.polys import Poly, decompose, GeneratorsNeeded
 
 
 def decompogen(f, symbol):
@@ -46,7 +46,7 @@ def decompogen(f, symbol):
     # ===== Convert to Polynomial ===== #
     try:
         fp = Poly(f)
-    except:
+    except GeneratorsNeeded:
         return None
     gens = list(filter(lambda x: symbol in x.free_symbols , fp.gens))
     if len(gens) == 1 and gens[0] != symbol:

--- a/sympy/solvers/decompogen.py
+++ b/sympy/solvers/decompogen.py
@@ -37,17 +37,25 @@ def decompogen(f, symbol):
     if isinstance(f, (Function, Pow)):
         if f.args[0] == symbol:
             return [f]
-        result += [f.subs(f.args[0], symbol)] + decompogen(f.args[0], symbol)
+        try:
+            result += [f.subs(f.args[0], symbol)] + decompogen(f.args[0], symbol)
+        except TypeError:
+            result = [f]
         return result
 
     # ===== Convert to Polynomial ===== #
-    fp = Poly(f)
+    try:
+        fp = Poly(f)
+    except:
+        return None
     gens = list(filter(lambda x: symbol in x.free_symbols , fp.gens))
-
     if len(gens) == 1 and gens[0] != symbol:
         f1 = f.subs(gens[0], symbol)
         f2 = gens[0]
-        result += [f1] + decompogen(f2, symbol)
+        try:
+            result += [f1] + decompogen(f2, symbol)
+        except TypeError:
+            result = [f]
         return result
 
     # ===== Polynomial decompose() ====== #

--- a/sympy/solvers/tests/test_decompogen.py
+++ b/sympy/solvers/tests/test_decompogen.py
@@ -14,6 +14,9 @@ def test_decompogen():
     assert decompogen(Abs(cos(x)**2 + 3*cos(x) - 4), x) == [Abs(x), x**2 + 3*x - 4, cos(x)]
     assert decompogen(sin(x)**2 + sin(x) - sqrt(3)/2, x) == [x**2 + x - sqrt(3)/2, sin(x)]
     assert decompogen(Abs(cos(y)**2 + 3*cos(x) - 4), x) == [Abs(x), 3*x + cos(y)**2 - 4, cos(x)]
+    assert decompogen(2**x, x) == [2**x]
+    assert decompogen(2**x + 10, x) == [x + 10, 2**x]
+    assert decompogen(2**(x+3) + 4, x) == [8*x + 4, 2**x]
 
 
 def test_decompogen_poly():

--- a/sympy/solvers/tests/test_decompogen.py
+++ b/sympy/solvers/tests/test_decompogen.py
@@ -18,8 +18,10 @@ def test_decompogen():
 
 def test_expo():
     assert decompogen(2**x, x) == [2**x]
+    assert decompogen(2**(x+1), x) == [2**x, x+1]
     assert decompogen(2**x - 10, x) == [2**x - 10]
-    assert decompogen(2**(x+3) + 4, x) == [2**(x+3) + 4]
+    assert decompogen(2**(x+3) - 4, x) == [2**x - 4, x+3]
+    assert decompogen(2**4**(x+1) - 16, x) == [2**x - 16, 4**x, x + 1]
 
 
 def test_decompogen_poly():

--- a/sympy/solvers/tests/test_decompogen.py
+++ b/sympy/solvers/tests/test_decompogen.py
@@ -14,9 +14,12 @@ def test_decompogen():
     assert decompogen(Abs(cos(x)**2 + 3*cos(x) - 4), x) == [Abs(x), x**2 + 3*x - 4, cos(x)]
     assert decompogen(sin(x)**2 + sin(x) - sqrt(3)/2, x) == [x**2 + x - sqrt(3)/2, sin(x)]
     assert decompogen(Abs(cos(y)**2 + 3*cos(x) - 4), x) == [Abs(x), 3*x + cos(y)**2 - 4, cos(x)]
+
+
+def test_expo():
     assert decompogen(2**x, x) == [2**x]
-    assert decompogen(2**x + 10, x) == [x + 10, 2**x]
-    assert decompogen(2**(x+3) + 4, x) == [8*x + 4, 2**x]
+    assert decompogen(2**x - 10, x) == [2**x - 10]
+    assert decompogen(2**(x+3) + 4, x) == [2**(x+3) + 4]
 
 
 def test_decompogen_poly():


### PR DESCRIPTION
Currently it seems `decompogen` is not able to handle exponential functions.

```
>>> decompogen(2**x, x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/yathartha/.local/lib/python3.5/site-packages/sympy/solvers/decompogen.py", line 40, in decompogen
    result += [f.subs(f.args[0], symbol)] + decompogen(f.args[0], symbol)
  File "/home/yathartha/.local/lib/python3.5/site-packages/sympy/solvers/decompogen.py", line 44, in decompogen
    fp = Poly(f)
  File "/home/yathartha/.local/lib/python3.5/site-packages/sympy/polys/polytools.py", line 129, in __new__
    return cls._from_expr(rep, opt)
  File "/home/yathartha/.local/lib/python3.5/site-packages/sympy/polys/polytools.py", line 240, in _from_expr
    return cls._from_dict(rep, opt)
  File "/home/yathartha/.local/lib/python3.5/site-packages/sympy/polys/polytools.py", line 178, in _from_dict
    "can't initialize from 'dict' without generators")
sympy.polys.polyerrors.GeneratorsNeeded: can't initialize from 'dict' without generators

```
This is mainly because it is not able to convert a constant(`2` in this case) to a polynomial, which give the  above result.
I'm not sure that exponential expressions should be decomposed or not, but they should not return such error.

ping @asmeurer @smichr @jksuom