### PR TITLE
group theory: Use incomplete coset tables in _finite_index_subgroup

### DIFF
--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -117,7 +117,7 @@ class CosetTable(DefaultPrinting):
         `\alpha \in \Omega` and `x \in A`.
 
         """
-        return not any([None in self.table[coset] for coset in self.omega])
+        return not any(None in self.table[coset] for coset in self.omega)
 
     # Pg. 153 [1]
     def define(self, alpha, x):


### PR DESCRIPTION
This PR makes use of continuing coset enumeration with incomplete coset tables in `_finite_index_subgroup` (used in FpGroup's `order` method). This slightly reduces the computation time as there is no need to recompute the tables.
Additionally, coset enumeration keywords were added to the `coset_table` method.