### PR TITLE
Print Rational is a SymPy reconstructible way

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -20,6 +20,7 @@ class StrPrinter(Printer):
     _default_settings = {
         "order": None,
         "full_prec": "auto",
+        "sympy_integers": False,
     }
 
     _relationals = dict()
@@ -549,6 +550,8 @@ class StrPrinter(Printer):
         if expr.q == 1:
             return str(expr.p)
         else:
+            if self._settings.get("sympy_integers", False):
+                return "S(%s)/%s" % (expr.p, expr.q)
             return "%s/%s" % (expr.p, expr.q)
 
     def _print_PythonRational(self, expr):

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -489,6 +489,9 @@ def test_Rational():
     assert str(sqrt(-4)) == str(2*I)
     assert str(2**Rational(1, 10**10)) == "2**(1/10000000000)"
 
+    assert sstr(Rational(2, 3), sympy_integers=True) == "S(2)/3"
+    assert sstr(Symbol("x")**Rational(2, 3), sympy_integers=True) == "x**(S(2)/3)"
+
 
 def test_Float():
     # NOTE dps is the whole number of decimal digits


### PR DESCRIPTION
Added support to print `Rational` with a `S( )` wrapper. See tests for examples.