### PR TITLE
Fix evalf of AssocOp not changing precision of floats in non-number arguments

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -332,9 +332,7 @@ class AssocOp(Basic):
                         args.append(a)
                     else:
                         args.append(newa)
-                if not _aresame(tuple(args), tail_args):
-                    tail = self.func(*args)
-                return self.func(x, tail)
+                return self.func(x, *args)
 
         # this is the same as above, but there were no pure-number args to
         # deal with
@@ -345,9 +343,7 @@ class AssocOp(Basic):
                 args.append(a)
             else:
                 args.append(newa)
-        if not _aresame(tuple(args), self.args):
-            return self.func(*args)
-        return self
+        return self.func(*args)
 
     @classmethod
     def make_args(cls, expr):

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -226,6 +226,9 @@ def test_evalf_bugs():
     #issue 5412
     assert ((oo*I).n() == S.Infinity*I)
     assert ((oo+oo*I).n() == S.Infinity + S.Infinity*I)
+    
+    #issue 11518
+    assert NS(2*x**2.5, 5) == '2.0000*x**2.5000'
 
 
 def test_evalf_integer_parts():

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -226,7 +226,7 @@ def test_evalf_bugs():
     #issue 5412
     assert ((oo*I).n() == S.Infinity*I)
     assert ((oo+oo*I).n() == S.Infinity + S.Infinity*I)
-    
+
     #issue 11518
     assert NS(2*x**2.5, 5) == '2.0000*x**2.5000'
 


### PR DESCRIPTION
Fixed AssocOp._eval_evalf() not changing precision of floats in non-number arguments.
Floats with different precision but same representation is equal, so _aresame returned True and precision was not changed.
Fixes #11518 