### PR TITLE
group theory: more efficient Sylow subgroups for Sym and Alt groups

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1680,6 +1680,9 @@ class PermutationGroup(Basic):
         answer True (i.e., G is symmetric/alternating) guaranteed to be
         correct, and the answer False being incorrect with probability eps.
 
+        For degree < 8, the order of the group is checked so the test
+        is deterministic.
+
         Notes
         =====
 
@@ -1712,7 +1715,9 @@ class PermutationGroup(Basic):
         if _random_prec is None:
             n = self.degree
             if n < 8:
-                return False
+                sym_order = reduce(lambda x, y: x*y, range(1, n+1))
+                order = self.order()
+                return order == sym_order or 2*order == sym_order
             if not self.is_transitive():
                 return False
             if n < 17:
@@ -3556,6 +3561,104 @@ class PermutationGroup(Basic):
                 gens_p = gens_p[:j] + [x] + gens_p[j:]
         return PermutationGroup(gens_r)
 
+    def _sylow_alt_sym(self, p):
+        '''
+        Return a p-Sylow subgroup of a symmetric or an
+        alternating group.
+
+        The algorithm for this is hinted at in [1], Chapter 4,
+        Exercise 4.
+
+        For Sym(n) with n = p^i, the idea is as follows. Partition
+        the interval [0..n-1] into p equal parts, each of length p^(i-1):
+        [0..p^(i-1)-1], [p^(i-1)..2*p^(i-1)-1]...[(p-1)*p^(i-1)..p^i-1].
+        Find a p-Sylow subgroup of Sym(p^(i-1)) (treated as a subgroup
+        of `self`) acting on each of the parts. Call the subgroups
+        P_1, P_2...P_p. The generators for the subgroups P_2...P_p
+        can be obtained from those of P_1 by applying a "shifting"
+        permutation to them, that is, a permutation mapping [0..p^(i-1)-1]
+        to the second part (the other parts are obtained by using the shift
+        multiple times). The union of this permutation and the generators
+        of P_1 is a p-Sylow subgroup of `self`.
+
+        For n not equal to a power of p, partition
+        [0..n-1] in accordance with how n would be written in base p.
+        E.g. for p=2 and n=11, 11 = 2^3 + 2^2 + 1 so the partition
+        is [[0..7], [8..9], {10}]. To generate a p-Sylow subgroup,
+        take the union of the generators for each of the parts.
+        For the above example, {(0 1), (0 2)(1 3), (0 4), (1 5)(2 7)}
+        from the first part, {(8 9)} from the second part and
+        nothing from the third. This gives 4 generators in total, and
+        the subgroup they generate is p-Sylow.
+
+        Alternating groups are treated the same except when p=2. In this
+        case, the p-Sylow subgroup corresponding to the first part should
+        have (0 1)(2 3) instead of (0 1) as a generator, and (0 1)(s s+1)
+        should be added for an appropriate s (the start of a part) for each
+        part in the partition.
+
+        See Also
+        ========
+        sylow_subgroup, is_alt_sym
+
+        '''
+        from sympy.combinatorics.named_groups import SymmetricGroup
+        n = self.degree
+        gens = []
+        identity = Permutation(n-1)
+        # the case of 2-sylow subgroups of alternating groups
+        # needs special treatment
+        alt = p == 2 and identity(0, 1) not in self
+
+        # find the presentation of n in base p
+        coeffs = []
+        m = n
+        while m > 0:
+            coeffs.append(m % p)
+            m = m // p
+
+        power = len(coeffs)-1
+        # gens[:i] is the generating set for a p-Sylow
+        # subgroup on [0..p**i-1]
+        for i in range(1, power+1):
+            gen = Permutation([(j + p**(i-1)) % p**i for j in range(p**i)]) 
+            if alt and gen == Permutation(0, 1):
+                # (0 1) shouldn't be added for alternating groups
+                continue
+            gens.append(identity*gen)
+
+        # the first point in the current part (see the algorithm
+        # description in the docstring)
+        start = 0
+
+        while power > 0:
+            a = coeffs[power]
+
+            # make the permutation shifting the start of the first
+            # part ([0..p^i] for some i) to the current one
+            for s in range(a):
+                shift = Permutation()
+                if start > 0:
+                    for i in range(p**power):
+                        shift = shift(i, start + i)
+
+                for gen in gens[:power]:
+                    # shift the generator to the start of the
+                    # partition part
+                    gen = shift*gen*shift
+                    gens.append(gen)
+                    if alt:
+                        gen = Permutation(0, 1)*gen*Permutation(0, 1)*gen
+                        if gen.is_identity:
+                            continue
+                        if not gen in gens:
+                            gens.append(gen)
+
+                start += p**power
+            power = power-1
+
+        return gens
+
     def sylow_subgroup(self, p):
         '''
         Return a p-Sylow subgroup of the group.
@@ -3611,6 +3714,9 @@ class PermutationGroup(Basic):
         p_group, n = is_p_group(self)
         if p_group:
             return self
+
+        if self.is_alt_sym():
+            return PermutationGroup(self._sylow_alt_sym(p))
 
         # if there is a non-trivial orbit with size not divisible
         # by p, the sylow subgroup is contained in its stabilizer

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3619,21 +3619,14 @@ class PermutationGroup(Basic):
         power = len(coeffs)-1
         # for a symmetric group, gens[:i] is the generating
         # set for a p-Sylow subgroup on [0..p**(i-1)-1]. For
-        # alternating groups, it's the same generators without
-        # (0 1)
+        # alternating groups, the same is given by gens[:2*(i-1)]
         for i in range(1, power+1):
             if i == 1 and alt:
                 # (0 1) shouldn't be added for alternating groups
                 continue
             gen = Permutation([(j + p**(i-1)) % p**i for j in range(p**i)])
             gens.append(identity*gen)
-
-        added = gens[:]
-
-        # add the other generators so that gens generates the 2-Sylow
-        # subgroup of an alternating group on [0..p**power-1]
-        if alt:
-            for gen in added:
+            if alt:
                 gen = Permutation(0, 1)*gen*Permutation(0, 1)*gen
                 gens.append(gen)
 
@@ -3655,11 +3648,13 @@ class PermutationGroup(Basic):
                     if alt:
                         gen = Permutation(0, 1)*shift*Permutation(0, 1)*shift
                         gens.append(gen)
-                        j = power - 1 # one less because (0 1) is missing
+                        j = 2*(power - 1)
                     else:
                         j = power
 
-                    for gen in gens[:j]:
+                    for i, gen in enumerate(gens[:j]):
+                        if alt and i % 2 == 1:
+                            continue
                         # shift the generator to the start of the
                         # partition part
                         gen = shift*gen*shift

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1715,7 +1715,9 @@ class PermutationGroup(Basic):
         if _random_prec is None:
             n = self.degree
             if n < 8:
-                sym_order = reduce(lambda x, y: x*y, range(1, n+1))
+                sym_order = 1
+                for i in range(2, n+1):
+                    sym_order *= i
                 order = self.order()
                 return order == sym_order or 2*order == sym_order
             if not self.is_transitive():
@@ -3618,10 +3620,10 @@ class PermutationGroup(Basic):
         # gens[:i] is the generating set for a p-Sylow
         # subgroup on [0..p**(i-1)-1]
         for i in range(1, power+1):
-            gen = Permutation([(j + p**(i-1)) % p**i for j in range(p**i)])
-            if alt and gen == Permutation(0, 1):
+            if i == 1 and alt:
                 # (0 1) shouldn't be added for alternating groups
                 continue
+            gen = Permutation([(j + p**(i-1)) % p**i for j in range(p**i)])
             gens.append(identity*gen)
 
         # the first point in the current part (see the algorithm

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3592,17 +3592,14 @@ class PermutationGroup(Basic):
         the subgroup they generate is p-Sylow.
 
         Alternating groups are treated the same except when p=2. In this
-        case, the p-Sylow subgroup corresponding to the first part should
-        have (0 1)(2 3) instead of (0 1) as a generator, and (0 1)(s s+1)
-        should be added for an appropriate s (the start of a part) for each
-        part in the partition.
+        case, (0 1)(s s+1) should be added for an appropriate s (the start
+        of a part) for each part in the partitions.
 
         See Also
         ========
         sylow_subgroup, is_alt_sym
 
         '''
-        from sympy.combinatorics.named_groups import SymmetricGroup
         n = self.degree
         gens = []
         identity = Permutation(n-1)
@@ -3619,9 +3616,9 @@ class PermutationGroup(Basic):
 
         power = len(coeffs)-1
         # gens[:i] is the generating set for a p-Sylow
-        # subgroup on [0..p**i-1]
+        # subgroup on [0..p**(i-1)-1]
         for i in range(1, power+1):
-            gen = Permutation([(j + p**(i-1)) % p**i for j in range(p**i)]) 
+            gen = Permutation([(j + p**(i-1)) % p**i for j in range(p**i)])
             if alt and gen == Permutation(0, 1):
                 # (0 1) shouldn't be added for alternating groups
                 continue
@@ -3635,7 +3632,7 @@ class PermutationGroup(Basic):
             a = coeffs[power]
 
             # make the permutation shifting the start of the first
-            # part ([0..p^i] for some i) to the current one
+            # part ([0..p^i-1] for some i) to the current one
             for s in range(a):
                 shift = Permutation()
                 if start > 0:

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3607,10 +3607,7 @@ class PermutationGroup(Basic):
         identity = Permutation(n-1)
         # the case of 2-sylow subgroups of alternating groups
         # needs special treatment
-        order = 1
-        for i in range(3, n+1):
-            order *= i
-        alt = p == 2 and self.order() == order
+        alt = p == 2 and all(g.is_even for g in self.generators)
 
         # find the presentation of n in base p
         coeffs = []

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -828,6 +828,11 @@ def test_sylow_subgroup():
         else:
             assert len(ls) == length
 
+    G = SymmetricGroup(100)
+    S = G.sylow_subgroup(3)
+    assert G.order() % S.order() == 0
+    assert G.order()/S.order() % 3 > 0
+
 def test_presentation():
     def _test(P):
         G = P.presentation()

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -833,6 +833,11 @@ def test_sylow_subgroup():
     assert G.order() % S.order() == 0
     assert G.order()/S.order() % 3 > 0
 
+    G = AlternatingGroup(100)
+    S = G.sylow_subgroup(2)
+    assert G.order() % S.order() == 0
+    assert G.order()/S.order() % 2 > 0
+
 def test_presentation():
     def _test(P):
         G = P.presentation()


### PR DESCRIPTION
This PR adds a separate method `_sylow_alt_sym` for computation of Sylow subgroups of symmetric and alternating groups, to be used as part of the main `sylow_subgroup` method. This is much more efficient than the general approach, so that for example, a 3-Sylow subgroup of `SymmetricGroup(100)` can be found within a hundredth of a second compared to more than a minute that it currently takes (probably much more, I stopped waiting).

Additionally, `is_alt_sym` is slightly modified to handle the case of permutation groups of degree less than 8.
