### PR TITLE
group theory: add a check for homomorphisms from permutation groups

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -750,10 +750,7 @@ def simplify_presentation(*args, **kwargs):
     `change_gens = True`.
 
     '''
-    change_gens = False
-    for k, v in kwargs.items():
-        if k == "change_gens":
-            change_gens = v
+    change_gens = kwargs.get("change_gens", False)
 
     if len(args) == 1:
         if not isinstance(args[0], FpGroup):

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -738,19 +738,29 @@ def first_in_class(C, Y=[]):
 #                    Simplifying Presentation
 #========================================================================
 
-def simplify_presentation(*args):
+def simplify_presentation(*args, **kwargs):
     '''
     For an instance of `FpGroup`, return a simplified isomorphic copy of
     the group (e.g. remove redundant generators or relators). Alternatively,
     a list of generators and relators can be passed in which case the
     simplified lists will be returned.
 
+    By default, the generators of the group are unchanged. If you would
+    like to remove redundant generators, set the keyword argument
+    `change_gens = True`.
+
     '''
+    change_gens = False
+    for k, v in kwargs.items():
+        if k == "change_gens":
+            change_gens = v
+
     if len(args) == 1:
         if not isinstance(args[0], FpGroup):
             raise TypeError("The argument must be an instance of FpGroup")
         G = args[0]
-        gens, rels = simplify_presentation(G.generators, G.relators)
+        gens, rels = simplify_presentation(G.generators, G.relators,
+                                              change_gens=change_gens)
         if gens:
             return FpGroup(gens[0].group, rels)
         return FpGroup([])
@@ -768,22 +778,23 @@ def simplify_presentation(*args):
     prev_rels = []
     while not set(prev_rels) == set(rels):
         prev_rels = rels
-        while not set(prev_gens) == set(gens):
+        while change_gens and not set(prev_gens) == set(gens):
             prev_gens = gens
             gens, rels = elimination_technique_1(gens, rels, identity)
         rels = _simplify_relators(rels, identity)
 
-    syms = [g.array_form[0][0] for g in gens]
-    F = free_group(syms)[0]
-    identity = F.identity
-    gens = F.generators
-    subs = dict(zip(syms, gens))
-    for j, r in enumerate(rels):
-        a = r.array_form
-        rel = identity
-        for sym, p in a:
-            rel = rel*subs[sym]**p
-        rels[j] = rel
+    if change_gens:
+        syms = [g.array_form[0][0] for g in gens]
+        F = free_group(syms)[0]
+        identity = F.identity
+        gens = F.generators
+        subs = dict(zip(syms, gens))
+        for j, r in enumerate(rels):
+            a = r.array_form
+            rel = identity
+            for sym, p in a:
+                rel = rel*subs[sym]**p
+            rels[j] = rel
     return gens, rels
 
 def _simplify_relators(rels, identity):
@@ -1094,7 +1105,7 @@ def reidemeister_presentation(fp_grp, H, C=None):
     define_schreier_generators(C)
     reidemeister_relators(C)
     gens, rels = C._schreier_generators, C._reidemeister_relators
-    gens, rels = simplify_presentation(gens, rels)
+    gens, rels = simplify_presentation(gens, rels, change_gens=True)
 
     C.schreier_generators = tuple(gens)
     C.reidemeister_relators = tuple(rels)

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -256,11 +256,6 @@ def homomorphism(domain, codomain, gens, images=[], check=True):
     define a homomorphism.
 
     '''
-    if check and isinstance(domain, PermutationGroup):
-        raise NotImplementedError("Checking if the homomorphism is well-defined "
-            "is not implemented for permutation groups. Use check=False if you "
-            "would like to create the homomorphism")
-
     if not isinstance(domain, (PermutationGroup, FpGroup, FreeGroup)):
         raise TypeError("The domain must be a group")
     if not isinstance(codomain, (PermutationGroup, FpGroup, FreeGroup)):
@@ -287,8 +282,13 @@ def homomorphism(domain, codomain, gens, images=[], check=True):
     return GroupHomomorphism(domain, codomain, images)
 
 def _check_homomorphism(domain, codomain, images):
-    rels = domain.relators
+    if hasattr(domain, 'relators'):
+        rels = domain.relators
+    else:
+        gens = domain.presentation().generators
+        rels = domain.presentation().relators
     identity = codomain.identity
+
     def _image(r):
         if r.is_identity:
             return identity
@@ -307,10 +307,14 @@ def _check_homomorphism(domain, codomain, images):
             # both indices
             while i < len(r):
                 power = r_arr[j][1]
-                if r[i] in images:
-                    w = w*images[r[i]]**power
+                if isinstance(domain, PermutationGroup):
+                    s = domain.generators[gens.index(r[i])]
                 else:
-                    w = w*images[r[i]**-1]**power
+                    s = r[i]
+                if s in images:
+                    w = w*images[s]**power
+                else:
+                    w = w*images[s**-1]**power
                 i += abs(power)
                 j += 1
             return w

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -167,6 +167,9 @@ class PermutationGroup(Basic):
 
         # these attributes are assigned after running _random_pr_init
         obj._random_gens = []
+
+        # finite presentation of the group as an instance of `FpGroup`
+        obj._fp_presentation = None
         return obj
 
     def __getitem__(self, i):
@@ -3703,6 +3706,9 @@ class PermutationGroup(Basic):
         from sympy.combinatorics.homomorphisms import homomorphism
         from itertools import product
 
+        if G._fp_presentation:
+            return G._fp_presentation
+
         def _factor_group_by_rels(G, rels):
             if isinstance(G, FpGroup):
                 return FpGroup(G.free_group, list(uniq(
@@ -3801,7 +3807,8 @@ class PermutationGroup(Basic):
             C_p = G_p.coset_enumeration([], strategy="coset_table",
                                 draft=C_p, max_cosets=n, incomplete=True)
 
-        return simplify_presentation(G_p)
+        G._fp_presentation = simplify_presentation(G_p)
+        return G._fp_presentation
 
 
 def _orbit(degree, generators, alpha, action='tuples'):

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -45,7 +45,7 @@ def test_homomorphism():
     D = DihedralGroup(8)
     p = Permutation(0, 1, 2, 3, 4, 5, 6, 7)
     P = PermutationGroup(p)
-    T = homomorphism(P, D, [p], [p], check=False)
+    T = homomorphism(P, D, [p], [p])
     assert T.is_injective()
     assert not T.is_isomorphism()
     assert T.invert(p**3) == p**3


### PR DESCRIPTION
This PR completes the method checking if given images extend to a homomorphism by adding the final case of the `PermutationGroup` domain.

Additionally:
* Added `_fp_presentation` attribute for permutation groups because computing the presentation is time-consuming
* Changed `simpify_presentation` so that the generators of the group are preserved by default. If it's desirable to remove redundant generators, the keyword `change_generators` can be used.