### PR TITLE
Return unevaluated expression in dot and cross

### DIFF
--- a/sympy/vector/vector.py
+++ b/sympy/vector/vector.py
@@ -117,14 +117,16 @@ class Vector(BasisDependent):
         if isinstance(self, VectorZero) or isinstance(other, VectorZero):
             return S(0)
 
-        v1 = express(self, other._sys)
-        v2 = express(other, other._sys)
-        dotproduct = S(0)
-        for x in other._sys.base_vectors():
-            dotproduct += (v1.components.get(x, 0) *
-                           v2.components.get(x, 0))
-
-        return dotproduct
+        try:
+            v1 = express(self, other._sys)
+            v2 = express(other, other._sys)
+            dotproduct = S(0)
+            for x in other._sys.base_vectors():
+                dotproduct += (v1.components.get(x, 0) *
+                               v2.components.get(x, 0))
+            return dotproduct
+        except:
+            return Dot(self, other)
 
     def __and__(self, other):
         return self.dot(other)


### PR DESCRIPTION
instead of raise error when vector's  coordinate system aren't connected unevaluated expression is returned

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
