### PR TITLE
13143: collect handling of derivatives

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -351,7 +351,9 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
 
     collected, disliked = defaultdict(list), S.Zero
     for product in summa:
-        terms = [parse_term(i) for i in ordered(Mul.make_args(product))]
+        c, nc = product.args_cnc(split_1=False)
+        args = list(ordered(c)) + nc
+        terms = [parse_term(i) for i in args]
         small_first = True
 
         for symbol in syms:

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -257,7 +257,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
         terms is a list of tuples as returned by parse_terms;
         pattern is an expression treated as a product of factors
         """
-        pattern = list(ordered(Mul.make_args(pattern)))
+        pattern = Mul.make_args(pattern)
 
         if len(terms) < len(pattern):
             # pattern is longer than matched product

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -157,6 +157,9 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
     ========
     collect_const, collect_sqrt, rcollect
     """
+    expr = sympify(expr)
+    syms = list(syms) if iterable(syms) else [syms]
+
     if evaluate is None:
         evaluate = global_evaluate[0]
 
@@ -254,7 +257,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
         terms is a list of tuples as returned by parse_terms;
         pattern is an expression treated as a product of factors
         """
-        pattern = Mul.make_args(pattern)
+        pattern = list(ordered(Mul.make_args(pattern)))
 
         if len(terms) < len(pattern):
             # pattern is longer than matched product
@@ -331,12 +334,8 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
                 expr.base, syms, func, True, exact, distribute_order_term)
             return Pow(b, expr.exp)
 
-    if iterable(syms):
-        syms = [expand_power_base(i, deep=False) for i in syms]
-    else:
-        syms = [expand_power_base(syms, deep=False)]
+    syms = [expand_power_base(i, deep=False) for i in syms]
 
-    expr = sympify(expr)
     order_term = None
 
     if distribute_order_term:
@@ -352,7 +351,8 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
 
     collected, disliked = defaultdict(list), S.Zero
     for product in summa:
-        terms = [parse_term(i) for i in Mul.make_args(product)]
+        terms = [parse_term(i) for i in ordered(Mul.make_args(product))]
+        small_first = True
 
         for symbol in syms:
             if SYMPY_DEBUG:
@@ -360,6 +360,9 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
                     str(terms), str(symbol))
                 )
 
+            if isinstance(symbol, Derivative) and small_first:
+                terms = list(reversed(terms))
+                small_first = not small_first
             result = parse_expression(terms, symbol)
 
             if SYMPY_DEBUG:
@@ -371,12 +374,14 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
                 # when there was derivative in current pattern we
                 # will need to rebuild its expression from scratch
                 if not has_deriv:
-                    index = 1
+                    margs = []
                     for elem in elems:
-                        e = elem[1]
-                        if elem[2] is not None:
-                            e *= elem[2]
-                        index *= Pow(elem[0], e)
+                        if elem[2] is None:
+                            e = elem[1]
+                        else:
+                            e = elem[1]*elem[2]
+                        margs.append(Pow(elem[0], e))
+                    index = Mul(*margs)
                 else:
                     index = make_expression(elems)
                 terms = expand_power_base(make_expression(terms), deep=False)


### PR DESCRIPTION
* sympification of expr should be done before Expr attributes
  are used (test added)
* xfailed test was re-written with umul and put in a place
  where f was defined -- it would never have passed as
  written because f was not defined
* use ordered to make arg handling canonical; I'm not sure
  that it is needed with pattern; with product, it is necessary
  to get functions/derivatives containing those functions to
  be collected properly
* rebuilding exprs with *= is expension; collect factors in margs

closes #13143