### PR TITLE
Use postprocessors for AccumBounds instead of hard-coding it in Mul/Add.flatten

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -309,3 +309,18 @@ def test_contains_AccumBounds():
     raises(TypeError, lambda: a in AccumBounds(1, 2))
     assert (-oo in AccumBounds(1, oo)) == S.true
     assert (oo in AccumBounds(-oo, 0)) == S.true
+
+def test_AccumBounds_postprocessor():
+    assert Mul(0, AccumBounds(-1, 1)) == Mul(AccumBounds(-1, 1), 0) == 0
+    assert Mul(2, AccumBounds(-1, 1)) == Mul(AccumBounds(-1, 1), 2) == AccumBounds(-2, 2)
+    assert Mul(AccumBounds(-1, 1), 2, AccumBounds(-2, 0)) == \
+           Mul(2, AccumBounds(-1, 1), AccumBounds(-2, 0)) == \
+           Mul(AccumBounds(-1, 1), AccumBounds(-2, 0), 2) == \
+           AccumBounds(-4, 4)
+
+    assert Add(0, AccumBounds(-1, 1)) == Add(AccumBounds(-1, 1), 0) == AccumBounds(-1, 1)
+    assert Add(2, AccumBounds(-1, 1)) == Add(AccumBounds(-1, 1), 2) == AccumBounds(1, 3)
+    assert Add(AccumBounds(-1, 1), 2, AccumBounds(-2, 0)) == \
+           Add(2, AccumBounds(-1, 1), AccumBounds(-2, 0)) == \
+           Add(AccumBounds(-1, 1), AccumBounds(-2, 0), 2) == \
+           AccumBounds(-1, 3)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -750,6 +750,7 @@ class AccumulationBounds(AtomicExpr):
     def __rsub__(self, other):
         return self.__neg__() + other
 
+
     @_sympifyit('other', NotImplemented)
     def __mul__(self, other):
         if isinstance(other, Expr):
@@ -1222,6 +1223,33 @@ class AccumulationBounds(AtomicExpr):
         if other.min <= self.min and other.max >= self.min:
             return AccumBounds(other.min, Max(self.max, other.max))
 
+
+def _AccumulationBounds_constroctor_postprocessor_Mul(expr):
+    res = S(1)
+    non_accum_args = []
+    for arg in expr.args:
+        if isinstance(arg, AccumulationBounds):
+            # Call AccumulationBounds.__mul__
+            res = res*arg
+        else:
+            non_accum_args.append(arg)
+    return res*Mul.fromiter(non_accum_args)
+
+def _AccumulationBounds_constroctor_postprocessor_Add(expr):
+    res = S(0)
+    non_accum_args = []
+    for arg in expr.args:
+        if isinstance(arg, AccumulationBounds):
+            # Call AccumulationBounds.__add__
+            res = res + arg
+        else:
+            non_accum_args.append(arg)
+    return res + Add.fromiter(non_accum_args)
+
+Basic._constructor_postprocessor_mapping[AccumulationBounds] = {
+    "Mul": [_AccumulationBounds_constroctor_postprocessor_Mul],
+    "Add": [_AccumulationBounds_constroctor_postprocessor_Add],
+}
 
 # setting an alias for AccumulationBounds
 AccumBounds = AccumulationBounds

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1224,7 +1224,7 @@ class AccumulationBounds(AtomicExpr):
             return AccumBounds(other.min, Max(self.max, other.max))
 
 
-def _AccumulationBounds_constroctor_postprocessor_Mul(expr):
+def _AccumulationBounds_constructor_postprocessor_Mul(expr):
     res = S(1)
     non_accum_args = []
     for arg in expr.args:
@@ -1235,7 +1235,7 @@ def _AccumulationBounds_constroctor_postprocessor_Mul(expr):
             non_accum_args.append(arg)
     return res*Mul.fromiter(non_accum_args)
 
-def _AccumulationBounds_constroctor_postprocessor_Add(expr):
+def _AccumulationBounds_constructor_postprocessor_Add(expr):
     res = S(0)
     non_accum_args = []
     for arg in expr.args:
@@ -1247,8 +1247,8 @@ def _AccumulationBounds_constroctor_postprocessor_Add(expr):
     return res + Add.fromiter(non_accum_args)
 
 Basic._constructor_postprocessor_mapping[AccumulationBounds] = {
-    "Mul": [_AccumulationBounds_constroctor_postprocessor_Mul],
-    "Add": [_AccumulationBounds_constroctor_postprocessor_Add],
+    "Mul": [_AccumulationBounds_constructor_postprocessor_Mul],
+    "Add": [_AccumulationBounds_constructor_postprocessor_Add],
 }
 
 # setting an alias for AccumulationBounds

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -90,7 +90,6 @@ class Add(Expr, AssocOp):
         sympy.core.mul.Mul.flatten
 
         """
-        from sympy.calculus.util import AccumBounds
         from sympy.matrices.expressions import MatrixExpr
         rv = None
         if len(seq) == 2:
@@ -137,10 +136,6 @@ class Add(Expr, AssocOp):
                     if coeff is S.NaN:
                         # we know for sure the result will be nan
                         return [S.NaN], [], None
-                continue
-
-            elif isinstance(o, AccumBounds):
-                coeff = o.__add__(coeff)
                 continue
 
             elif isinstance(o, MatrixExpr):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -172,7 +172,6 @@ class Mul(Expr, AssocOp):
               Removal of 1 from the sequence is already handled by AssocOp.__new__.
         """
 
-        from sympy.calculus.util import AccumBounds
         rv = None
         if len(seq) == 2:
             a, b = seq
@@ -269,9 +268,6 @@ class Mul(Expr, AssocOp):
                         return [S.NaN], [], None
                 continue
 
-            elif isinstance(o, AccumBounds):
-                coeff = o.__mul__(coeff)
-                continue
 
             elif o is S.ComplexInfinity:
                 if not coeff:


### PR DESCRIPTION
Fixes #13159.