### PR TITLE
Fix formatting of assume docs

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -123,12 +123,12 @@ class Predicate(Boolean):
         Q.prime(7)
 
     To obtain the truth value of an expression containing predicates, use
-    the function `ask`:
+    the function ``ask``:
 
         >>> ask(Q.prime(7))
         True
 
-    The tautological predicate `Q.is_true` can be used to wrap other objects:
+    The tautological predicate ``Q.is_true`` can be used to wrap other objects:
 
         >>> Q.is_true(x > 1)
         Q.is_true(x > 1)


### PR DESCRIPTION
This PR fixes a minor issue I noticed in the formatting of the documentation of the `assume` module:
<img width="722" alt="screen shot 2017-08-18 at 2 20 24 pm" src="https://user-images.githubusercontent.com/123110/29478163-68b8d7b0-8420-11e7-83cd-1b1f8e4d91f0.png">

## Testing
I compiled the docs locally with `make html`, and the documentation looks like this now:
<img width="742" alt="screen shot 2017-08-18 at 2 21 28 pm" src="https://user-images.githubusercontent.com/123110/29478189-87f196ee-8420-11e7-80fa-c555262c290f.png">
