### PR TITLE
Fix incorrect factor() of expression with float coefficients

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1222,12 +1222,14 @@ def dup_factor_list(f, K0):
             if K0_inexact is None:
                 coeff = coeff/denom
             else:
+                num_factors = 0
                 for i, (f, k) in enumerate(factors):
                     f = dup_quo_ground(f, denom, K0)
                     f = dup_convert(f, K0, K0_inexact)
                     factors[i] = (f, k)
+                    num_factors += k
 
-                coeff = K0_inexact.convert(coeff, K0)
+                coeff = K0_inexact.convert(coeff*denom**(num_factors - 1), K0)
                 K0 = K0_inexact
 
     if j:
@@ -1301,12 +1303,14 @@ def dmp_factor_list(f, u, K0):
             if K0_inexact is None:
                 coeff = coeff/denom
             else:
+                num_factors = 0
                 for i, (f, k) in enumerate(factors):
                     f = dmp_quo_ground(f, denom, u, K0)
                     f = dmp_convert(f, u, K0, K0_inexact)
                     factors[i] = (f, k)
+                    num_factors += k
 
-                coeff = K0_inexact.convert(coeff, K0)
+                coeff = K0_inexact.convert(coeff*denom**(num_factors - 1), K0)
                 K0 = K0_inexact
 
     for i, j in enumerate(reversed(J)):

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2444,6 +2444,10 @@ def test_factor():
 
     assert factor(sqrt(x**2)) == sqrt(x**2)
 
+    # issue 13149
+    assert factor(expand((0.5*x+1)*(0.5*y+1))) == Mul(4.0, 0.25*x + 0.5, 0.25*y + 0.5, evaluate = False)
+    assert factor(expand((0.5*x+0.5)**2)) == 4.0*(0.25*x + 0.25)**2
+
 
 def test_factor_large():
     f = (x**2 + 4*x + 4)**10000000*(x**2 + 1)*(x**2 + 2*x + 1)**1234567


### PR DESCRIPTION
Fixes #13149.

It has been suggested that cause of this is incorrect handling of `denom` in `dup_factor_list()` `dmp_factor_list()` in `/polys/factortools.py` - dividing every factor by denom. (see #13149)

This commit fixes the issue by multiplying coeff by denom**(the number of factors including exponent - 1).

Another fix(below) is dividing coeff rather than factors by denom, and it produces different results. I'm not sure which is more appropriate for `factor()`.
```
diff --git a/sympy/polys/factortools.py b/sympy/polys/factortools.py
index 5c250e911..6e37d14b0 100644
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1223,10 +1223,10 @@ def dup_factor_list(f, K0):
                 coeff = coeff/denom
             else:
                 for i, (f, k) in enumerate(factors):
-                    f = dup_quo_ground(f, denom, K0)
                     f = dup_convert(f, K0, K0_inexact)
                     factors[i] = (f, k)

+                coeff = K0.quo(coeff, denom)
                 coeff = K0_inexact.convert(coeff, K0)
                 K0 = K0_inexact

@@ -1302,10 +1302,10 @@ def dmp_factor_list(f, u, K0):
                 coeff = coeff/denom
             else:
                 for i, (f, k) in enumerate(factors):
-                    f = dmp_quo_ground(f, denom, u, K0)
                     f = dmp_convert(f, u, K0, K0_inexact)
                     factors[i] = (f, k)

+                coeff = K0.quo(coeff, denom)
                 coeff = K0_inexact.convert(coeff, K0)
                 K0 = K0_inexact
```

Fixes #8754, fixes #9296, fixes #9630, fixes last comment of #12140, fixes #12506, fixes #12792, and fixes #13115.