### PR TITLE
Add transform_to method to CoordSys3D

### DIFF
--- a/doc/src/modules/vector/coordsys.rst
+++ b/doc/src/modules/vector/coordsys.rst
@@ -194,12 +194,12 @@ rotate system by setting appropriate transformation equations.
   >>> B = CoordSys3D('A', transformation=lambda x,y,z: (x*sin(y), x*cos(y), z))
 
 
-In ``CoordSys3D`` is also dedicated method, ``transform_to`` which works
+In ``CoordSys3D`` is also dedicated method, ``create_new`` which works
 similarly to methods like ``locate_new``, ``orient_new_axis`` etc.
 
   >>> from sympy.vector import CoordSys3D
   >>> A = CoordSys3D('A')
-  >>> B = A.transform_to('B', transformation='spherical')
+  >>> B = A.create_new('B', transformation='spherical')
 
 Expression of quantities in different coordinate systems
 ========================================================

--- a/doc/src/modules/vector/coordsys.rst
+++ b/doc/src/modules/vector/coordsys.rst
@@ -3,7 +3,7 @@ More about Coordinate Systems
 =============================
 
 We will now look at how we can initialize new coordinate systems in
-:mod:`sympy.vector`, positioned and oriented in user-defined
+:mod:`sympy.vector`, transformed in user-defined
 ways with respect to already-existing systems.
 
 Locating new systems
@@ -67,7 +67,7 @@ The orientation is shown in the diagram below:
 There are two ways to achieve this.
 
 Using a method of CoordSys3D directly
---------------------------------------------
+-------------------------------------
 
 This is the easiest, cleanest, and hence the recommended way of doing
 it.
@@ -177,6 +177,29 @@ location of the new systems.
   (-2*sin(a))*C.i + (-2*cos(a))*C.j
 
 More on the ``express`` function in a bit.
+
+Transforming new system
+=======================
+
+The most general way of creating user-defined system is to use
+``transformation`` parameter in ``CoordSys3D``. Here we can define
+any transformation equations. If we are interested in some typical
+curvilinear coordinate system different that Cartesian, we can also
+use some predefined ones. It could be also possible to translate or
+rotate system by setting appropriate transformation equations.
+
+  >>> from sympy.vector import CoordSys3D
+  >>> from sympy import sin, cos
+  >>> A = CoordSys3D('A', transformation='spherical')
+  >>> B = CoordSys3D('A', transformation=lambda x,y,z: (x*sin(y), x*cos(y), z))
+
+
+In ``CoordSys3D`` is also dedicated method, ``transform_to`` which works
+similarly to methods like ``locate_new``, ``orient_new_axis`` etc.
+
+  >>> from sympy.vector import CoordSys3D
+  >>> A = CoordSys3D('A')
+  >>> B = A.transform_to('B', transformation='spherical')
 
 Expression of quantities in different coordinate systems
 ========================================================

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -950,7 +950,7 @@ class CoordSys3D(Basic):
                                vector_names=vector_names,
                                variable_names=variable_names)
 
-    def transform_to(self, name, transformation, variable_names=None, vector_names=None):
+    def create_new(self, name, transformation, variable_names=None, vector_names=None):
         """
         Returns a CoordSys3D which is connected to self by transformation.
 
@@ -974,7 +974,7 @@ class CoordSys3D(Basic):
 
         >>> from sympy.vector import CoordSys3D
         >>> a = CoordSys3D('a')
-        >>> b = a.transform_to('b', transformation='spherical')
+        >>> b = a.create_new('b', transformation='spherical')
         >>> b.transformation_to_parent()
         (b.x*sin(b.y)*cos(b.z), b.x*sin(b.y)*sin(b.z), b.x*cos(b.y))
         >>> b.transformation_from_parent()

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -40,6 +40,10 @@ class CoordSys3D(Basic):
         name : str
             The name of the new CoordSys3D instance.
 
+        transformation : Lambda, Tuple, str
+            Transformation defined by transformation equations or chooesed
+            from predefined ones.
+
         location : Vector
             The position vector of the new system's origin wrt the parent
             instance.
@@ -443,9 +447,9 @@ class CoordSys3D(Basic):
         return self._transformation_lambda(*self.base_scalars())
 
     def transformation_from_parent(self):
-        if self.parent is None:
+        if self._parent is None:
             raise ValueError("no parent coordinate system, use `transformation_from_parent_function()`")
-        return self._transformation_from_parent_lambda(*self.parent.base_scalars())
+        return self._transformation_from_parent_lambda(*self._parent.base_scalars())
 
     def transformation_from_parent_function(self):
         return self._transformation_from_parent_lambda
@@ -945,6 +949,40 @@ class CoordSys3D(Basic):
                                location=location,
                                vector_names=vector_names,
                                variable_names=variable_names)
+
+    def transform_to(self, name, transformation, variable_names=None, vector_names=None):
+        """
+        Returns a CoordSys3D which is connected to self by transformation.
+
+        Parameters
+        ==========
+
+        name : str
+            The name of the new CoordSys3D instance.
+
+        transformation : Lambda, Tuple, str
+            Transformation defined by transformation equations or chooesed
+            from predefined ones.
+
+        vector_names, variable_names : iterable(optional)
+            Iterables of 3 strings each, with custom names for base
+            vectors and base scalars of the new system respectively.
+            Used for simple str printing.
+
+        Examples
+        ========
+
+        >>> from sympy.vector import CoordSys3D
+        >>> a = CoordSys3D('a')
+        >>> b = a.transform_to('b', transformation='spherical')
+        >>> b.transformation_to_parent()
+        (b.x*sin(b.y)*cos(b.z), b.x*sin(b.y)*sin(b.z), b.x*cos(b.y))
+        >>> b.transformation_from_parent()
+        (sqrt(a.x**2 + a.y**2 + a.z**2), acos(a.z/sqrt(a.x**2 + a.y**2 + a.z**2)), atan2(a.y, a.x))
+
+        """
+        return CoordSys3D(name, parent=self, transformation=transformation,
+                          variable_names=variable_names, vector_names=vector_names)
 
     def __init__(self, name, location=None, rotation_matrix=None,
                  parent=None, vector_names=None, variable_names=None,

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -249,6 +249,7 @@ def test_vector_with_orientation():
     assert C.j.cross(A.i) == (sin(q2))*A.j + (-cos(q2))*A.k
     assert express(C.k.cross(A.i), C).trigsimp() == cos(q3)*C.j
 
+
 def test_orient_new_methods():
     N = CoordSys3D('N')
     orienter1 = AxisOrienter(q4, N.j)
@@ -290,6 +291,16 @@ def test_locatenew_point():
     p2 = p.locate_new('p2', A.i)
     assert p1.position_wrt(p2) == 2*v - A.i
     assert p2.express_coordinates(C) == (-2*a + 1, -2*b, -2*c)
+
+
+def test_transform_to():
+    a = CoordSys3D('a')
+    c = a.transform_to('c', transformation='spherical')
+    assert c._parent == a
+    assert c.transformation_to_parent() == \
+           (c.x*sin(c.y)*cos(c.z), c.x*sin(c.y)*sin(c.z), c.x*cos(c.y))
+    assert c.transformation_from_parent() == \
+           (sqrt(a.x**2 + a.y**2 + a.z**2), acos(a.z/sqrt(a.x**2 + a.y**2 + a.z**2)), atan2(a.y, a.x))
 
 
 def test_evalf():

--- a/sympy/vector/tests/test_coordsysrect.py
+++ b/sympy/vector/tests/test_coordsysrect.py
@@ -293,9 +293,9 @@ def test_locatenew_point():
     assert p2.express_coordinates(C) == (-2*a + 1, -2*b, -2*c)
 
 
-def test_transform_to():
+def test_create_new():
     a = CoordSys3D('a')
-    c = a.transform_to('c', transformation='spherical')
+    c = a.create_new('c', transformation='spherical')
     assert c._parent == a
     assert c.transformation_to_parent() == \
            (c.x*sin(c.y)*cos(c.z), c.x*sin(c.y)*sin(c.z), c.x*cos(c.y))


### PR DESCRIPTION
This PR adds a method `transform_to` which is similar to method that works for translation and rotation. 
I also add to documentation short description about that.

This PR also fixes `transformation_from_parent` method. `Coordsys3D` doesn't have attribute `parent but has `_parent`. 