### PR TITLE
curvilinear coordinate system in documentation

### DIFF
--- a/doc/src/modules/vector/fields.rst
+++ b/doc/src/modules/vector/fields.rst
@@ -255,6 +255,22 @@ Or by using the dedicated function
   >>> directional_derivative(C.x*C.y*C.z, 3*C.i + 4*C.j + C.k)
   C.x*C.y + 4*C.x*C.z + 3*C.y*C.z
 
+Field operator in orthogonal curvilinear coordinate system
+==========================================================
+
+``vector`` package supports calculation in different kind of orthogonal
+curvilinear coordinate system. To do that, scaling factor (also known as
+Lame coefficients) are used to express ``curl``, ``divergence`` or ``gradient``
+in desired type of coordinate system.
+
+For example if we want to calculate ``gradient`` in cylindrical coordinate
+system all we need to do is to create proper coordinate system
+
+  >>> from sympy.vector import CoordSys3D
+  >>> c = CoordSys3D('c', transformation='cylindrical', variable_names=("r", "theta", "z"))
+  >>> gradient(c.r*c.theta*c.z)
+      c.theta*c.z*c.i + c.r*c.z/c.theta*c.j + c.r*c.theta*c.k
+
 Conservative and Solenoidal fields
 ==================================
 


### PR DESCRIPTION
This PR informs that field operators in `vector` package can be computed in different kind of curvilinear coordinate system.