### PR TITLE
Codegen support common subexpression replacement

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -612,14 +612,14 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
 
     helps = []
     for name_h, expr_h, args_h in helpers:
-        helps.append(make_routine(name_h, expr_h, args_h))
+        helps.append(code_gen.routine(name_h, expr_h, args_h))
 
     for name_h, expr_h, args_h in helpers:
         if expr.has(expr_h):
             name_h = binary_function(name_h, expr_h, backend='dummy')
             expr = expr.subs(expr_h, name_h(*args_h))
     try:
-        routine = make_routine('autofunc', expr, args)
+        routine = code_gen.routine('autofunc', expr, args)
     except CodeGenArgumentListError as e:
         # if all missing arguments are for pure output, we simply attach them
         # at the end and try again, because the wrappers will silently convert
@@ -629,7 +629,7 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
             if not isinstance(missing, OutputArgument):
                 raise
             new_args.append(missing.name)
-        routine = make_routine('autofunc', expr, args + new_args)
+        routine = code_gen.routine('autofunc', expr, args + new_args)
 
     return code_wrapper.wrap_code(routine, helpers=helps)
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -101,7 +101,7 @@ from sympy.matrices import (MatrixSymbol, ImmutableMatrix, MatrixBase,
 __all__ = [
     # description of routines
     "Routine", "DataType", "default_datatypes", "get_default_datatype",
-    "Argument", "InputArgument", "Result",
+    "Argument", "InputArgument", "OutputArgument", "Result",
     # routines -> code
     "CodeGen", "CCodeGen", "FCodeGen", "JuliaCodeGen", "OctaveCodeGen",
     "RustCodeGen",

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -180,10 +180,11 @@ class Routine(object):
 
         local_symbols = set()
         for r in local_vars:
-            if not isinstance(r, Result):
-                raise ValueError("Unknown Routine result: %s" % r)
-            symbols.update(r.expr.free_symbols)
-            local_symbols.add(r.name)
+            if isinstance(r, Result):
+                symbols.update(r.expr.free_symbols)
+                local_symbols.add(r.name)
+            else:
+                local_symbols.add(r)
 
         symbols = set([s.label if isinstance(s, Idx) else s for s in symbols])
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -921,8 +921,9 @@ class CCodeGen(CodeGen):
                     dims = result.expr.shape
                     assert dims[1] == 1, "2D matrices not supported yet"
                     code_lines.append("{0} {1}[{2}];\n".format(t, str(assign_to), dims[0]))
+                    prefix = ""
                 else:
-                    code_lines.append("{0} {1};\n".format(t, str(assign_to)))
+                    prefix = "const {0} ".format(t)
                 return_val = assign_to
             else:
                 assign_to = result.result_var
@@ -944,7 +945,7 @@ class CCodeGen(CodeGen):
             for name, value in sorted(constants, key=str):
                 code_lines.append("double const %s = %s;\n" % (name, value))
             
-            code_lines.append("%s\n" % c_expr)
+            code_lines.append("{}{}\n".format(prefix, c_expr))
             
         return code_lines
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -416,8 +416,7 @@ class OutputArgument(Argument, ResultBase):
         ResultBase.__init__(self, expr, result_var)
 
     def __str__(self):
-        return "%s(%r, %r, %r)" % (self.__class__.__name__, self.name, self.expr,
-            self.result_var)
+        return "%s(%r, %r, %r)" % (self.__class__.__name__, self.name, self.result_var, self.expr)
 
     __repr__ = __str__
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -599,7 +599,7 @@ class CodeGen(object):
             local_expressions = Tuple(*[b for _,b in common])
         else:
             local_expressions = Tuple()
-            
+
         if is_sequence(expr) and not isinstance(expr, (MatrixBase, MatrixExpr)):
             if not expr:
                 raise ValueError("No expression given")
@@ -613,8 +613,8 @@ class CodeGen(object):
         else:
             # local variables for indexed expressions
             local_vars = {i.label for i in expressions.atoms(Idx)}
-            local_symbols = local_vars            
-            
+            local_symbols = local_vars
+
         # global variables
         global_vars = set() if global_vars is None else set(global_vars)
 
@@ -922,7 +922,7 @@ class CCodeGen(CodeGen):
         for arg in routine.arguments:
             if isinstance(arg, ResultBase) and not arg.dimensions:
                 dereference.append(arg.name)
-        
+
         code_lines = []
         for result in routine.local_vars:
 
@@ -943,18 +943,17 @@ class CCodeGen(CodeGen):
                 prefix = ""
             else:
                 prefix = "const {0} ".format(t)
-            
+
             constants, not_c, c_expr = self._printer_method_with_settings(
                 'doprint', dict(human=False, dereference=dereference),
                 result.expr, assign_to=assign_to)
 
             for name, value in sorted(constants, key=str):
                 code_lines.append("double const %s = %s;\n" % (name, value))
-            
-            code_lines.append("{}{}\n".format(prefix, c_expr))
-            
-        return code_lines
 
+            code_lines.append("{}{}\n".format(prefix, c_expr))
+
+        return code_lines
 
     def _call_printer(self, routine):
         code_lines = []

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -556,9 +556,6 @@ class CodeGen(object):
 
         """
 
-        if self.cse:
-            return self.routine_cse(name, expr, argument_sequence, global_vars)
-
         if is_sequence(expr) and not isinstance(expr, (MatrixBase, MatrixExpr)):
             if not expr:
                 raise ValueError("No expression given")
@@ -566,14 +563,26 @@ class CodeGen(object):
         else:
             expressions = Tuple(expr)
 
-        # local variables
-        local_vars = {i.label for i in expressions.atoms(Idx)}
+        if self.cse:
+            if isinstance(expr, Equality):
+                common, simplified = cse(expr.rhs)
+                expr = sm.Eq(expr.lhs, simplified[0])
+            else:
+                common, simplified = cse(expr)
+                expr = simplified
+
+            local_vars = [Result(b,a) for a,b in common]
+            local_symbols = set([a for a,_ in common])
+        else:
+            # local variables
+            local_vars = {i.label for i in expressions.atoms(Idx)}
+            local_symbols = local_vars
 
         # global variables
         global_vars = set() if global_vars is None else set(global_vars)
 
         # symbols that should be arguments
-        symbols = expressions.free_symbols - local_vars - global_vars
+        symbols = expressions.free_symbols - local_symbols - global_vars
         new_symbols = set([])
         new_symbols.update(symbols)
 
@@ -672,151 +681,6 @@ class CodeGen(object):
             arg_list = new_args
 
         return Routine(name, arg_list, return_val, local_vars, global_vars)
-
-    def routine_cse(self, name, expr, argument_sequence=None, global_vars=None):
-        """Creates an Routine object that is appropriate for this language.
-        This implementation is appropriate for at least C/Fortran.  Subclasses
-        can override this if necessary.
-        Here, we assume at most one return value (the l-value) which must be
-        scalar.  Additional outputs are OutputArguments (e.g., pointers on
-        right-hand-side or pass-by-reference).  Matrices are always returned
-        via OutputArguments.  If ``argument_sequence`` is None, arguments will
-        be ordered alphabetically, but with all InputArguments first, and then
-        OutputArgument and InOutArguments.
-        """
-
-        from sympy import __version__ as sympy_version
-        from sympy.core import Symbol, S, Expr, Tuple, Equality, Function, Basic
-        from sympy.core.compatibility import is_sequence, StringIO, string_types
-        from sympy.core.relational import Equality
-        from sympy.printing.codeprinter import AssignmentError
-        from sympy.printing.ccode import c_code_printers
-        from sympy.simplify.cse_main import cse
-        from sympy.tensor import Idx, Indexed, IndexedBase
-        from sympy.matrices import (MatrixSymbol, ImmutableMatrix, MatrixBase,
-                                    MatrixExpr, MatrixSlice)
-    
-        if is_sequence(expr) and not isinstance(expr, (MatrixBase, MatrixExpr)):
-            if not expr:
-                raise ValueError("No expression given")
-            expressions = Tuple(*expr)
-        else:
-            expressions = Tuple(expr)
-
-        common, simplified = cse(expr)
-        local_vars = [Result(b,a) for a,b in common]
-        local_symbols = set([a for a,_ in common])
-        expr = simplified
-
-        # global variables
-        global_vars = set() if global_vars is None else set(global_vars)
-
-        # symbols that should be arguments
-        symbols = expressions.free_symbols - local_symbols - global_vars
-        new_symbols = set([])
-        new_symbols.update(symbols)
-
-        for symbol in symbols:
-            if isinstance(symbol, Idx):
-                new_symbols.remove(symbol)
-                new_symbols.update(symbol.args[1].free_symbols)
-        symbols = new_symbols
-
-        # Decide whether to use output argument or return value
-        return_val = []
-        output_args = []
-        for expr in expressions:
-            if isinstance(expr, Equality):
-                out_arg = expr.lhs
-                if out_arg in local_vars: continue
-                expr = expr.rhs
-                print("{} = {}".format(out_arg, expr))
-                if isinstance(out_arg, Indexed):
-                    dims = tuple([ (S.Zero, dim - 1) for dim in out_arg.shape])
-                    symbol = out_arg.base.label
-                elif isinstance(out_arg, Symbol):
-                    dims = []
-                    symbol = out_arg
-                elif isinstance(out_arg, MatrixSymbol):
-                    dims = tuple([ (S.Zero, dim - 1) for dim in out_arg.shape])
-                    symbol = out_arg
-                else:
-                    raise CodeGenError("Only Indexed, Symbol, or MatrixSymbol "
-                                       "can define output arguments.")
-
-                if expr.has(symbol):
-                    output_args.append(
-                        InOutArgument(symbol, out_arg, expr, dimensions=dims))
-                else:
-                    output_args.append(
-                        OutputArgument(symbol, out_arg, expr, dimensions=dims))
-
-                # remove duplicate arguments when they are not local variables
-                if symbol not in local_vars:                    
-                    print("Removing output argument symbol {} from {}".format(symbol, symbols))
-                    # avoid duplicate arguments
-                    symbols.remove(symbol)
-            elif isinstance(expr, (ImmutableMatrix, MatrixSlice)):
-                # Create a "dummy" MatrixSymbol to use as the Output arg
-                out_arg = MatrixSymbol('out_%s' % abs(hash(expr)), *expr.shape)
-                dims = tuple([(S.Zero, dim - 1) for dim in out_arg.shape])
-                output_args.append(
-                    OutputArgument(out_arg, out_arg, expr, dimensions=dims))
-            else:
-                return_val.append(Result(expr))
-
-        arg_list = []
-
-        # setup input argument list
-        array_symbols = {}
-        for array in expressions.atoms(Indexed):
-            array_symbols[array.base.label] = array
-        for array in expressions.atoms(MatrixSymbol):
-            array_symbols[array] = array
-
-        for symbol in sorted(symbols, key=str):
-            if symbol in array_symbols:
-                dims = []
-                array = array_symbols[symbol]
-                for dim in array.shape:
-                    dims.append((S.Zero, dim - 1))
-                metadata = {'dimensions': dims}
-            else:
-                metadata = {}
-
-            arg_list.append(InputArgument(symbol, **metadata))
-
-        output_args.sort(key=lambda x: str(x.name))
-        arg_list.extend(output_args)
-        
-        if argument_sequence is not None:
-            # if the user has supplied IndexedBase instances, we'll accept that
-            new_sequence = []
-            for arg in argument_sequence:
-                if isinstance(arg, IndexedBase):
-                    new_sequence.append(arg.label)
-                else:
-                    new_sequence.append(arg)
-            argument_sequence = new_sequence
-
-            missing = [x for x in arg_list if x.name not in argument_sequence]
-            if missing:
-                msg = "Argument list didn't specify: {0} "
-                msg = msg.format(", ".join([str(m.name) for m in missing]))
-                raise CodeGenArgumentListError(msg, missing)
-
-            # create redundant arguments to produce the requested sequence
-            name_arg_dict = {x.name: x for x in arg_list}
-            new_args = []
-            for symbol in argument_sequence:
-                try:
-                    new_args.append(name_arg_dict[symbol])
-                except KeyError:
-                    new_args.append(InputArgument(symbol))
-            arg_list = new_args
-
-        return Routine(name, arg_list, return_val, local_vars, global_vars)
-
 
     def write(self, routines, prefix, to_files=False, header=True, empty=True):
         """Writes all the source code files for the given routines.
@@ -1011,7 +875,7 @@ class CCodeGen(CodeGen):
         return []
 
     def _declare_locals(self, routine):
-        
+
         # Compose a list of symbols to be dereferenced in the function
         # body. These are the arguments that were passed by a reference
         # pointer, excluding arrays.

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -117,6 +117,7 @@ __all__ = [
 
 class Routine(object):
     """Generic description of evaluation routine for set of expressions.
+
     A CodeGen class can translate instances of this class into code in a
     particular language.  The routine specification covers all the features
     present in these languages.  The CodeGen part must raise an exception
@@ -124,30 +125,38 @@ class Routine(object):
     example, multiple return values are possible in Python, but not in C or
     Fortran.  Another example: Fortran and Python support complex numbers,
     while C does not.
+
     """
 
     def __init__(self, name, arguments, results, local_vars, global_vars):
         """Initialize a Routine instance.
+
         Parameters
         ==========
+
         name : string
             Name of the routine.
+
         arguments : list of Arguments
             These are things that appear in arguments of a routine, often
             appearing on the right-hand side of a function call.  These are
             commonly InputArguments but in some languages, they can also be
             OutputArguments or InOutArguments (e.g., pass-by-reference in C
             code).
+
         results : list of Results
             These are the return values of the routine, often appearing on
             the left-hand side of a function call.  The difference between
             Results and OutputArguments and when you should use each is
             language-specific.
+
         local_vars : list of Results
             These are variables that will be defined at the beginning of the
             function.
+
         global_vars : list of Symbols
             Variables which will not be passed into the function.
+
         """
 
         # extract all input symbols and all symbols appearing in an expression
@@ -169,7 +178,7 @@ class Routine(object):
                 raise ValueError("Unknown Routine result: %s" % r)
             symbols.update(r.expr.free_symbols)
 
-        local_symbols = set([])
+        local_symbols = set()
         for r in local_vars:
             if not isinstance(r, Result):
                 raise ValueError("Unknown Routine result: %s" % r)
@@ -201,8 +210,10 @@ class Routine(object):
     @property
     def variables(self):
         """Returns a set of all variables possibly used in the routine.
+
         For routines with unnamed return values, the dummies that may or
         may not be used will be included in the set.
+
         """
         v = set(self.local_vars)
         for arg in self.arguments:
@@ -214,13 +225,13 @@ class Routine(object):
     @property
     def result_variables(self):
         """Returns a list of OutputArgument, InOutArgument and Result.
+
         If return values are present, they are at the end ot the list.
         """
         args = [arg for arg in self.arguments if isinstance(
             arg, (OutputArgument, InOutArgument))]
         args.extend(self.results)
         return args
-
 
 
 class DataType(object):
@@ -673,7 +684,7 @@ class CodeGen(object):
                 metadata = {'dimensions': dims}
             else:
                 metadata = {}
-    
+
             arg_list.append(InputArgument(symbol, **metadata))
 
         output_args.sort(key=lambda x: str(x.name))
@@ -706,8 +717,6 @@ class CodeGen(object):
             arg_list = new_args
 
         return Routine(name, arg_list, return_val, local_vars, global_vars)
-
-
 
     def write(self, routines, prefix, to_files=False, header=True, empty=True):
         """Writes all the source code files for the given routines.

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -117,7 +117,6 @@ __all__ = [
 
 class Routine(object):
     """Generic description of evaluation routine for set of expressions.
-
     A CodeGen class can translate instances of this class into code in a
     particular language.  The routine specification covers all the features
     present in these languages.  The CodeGen part must raise an exception
@@ -125,37 +124,30 @@ class Routine(object):
     example, multiple return values are possible in Python, but not in C or
     Fortran.  Another example: Fortran and Python support complex numbers,
     while C does not.
-
     """
 
     def __init__(self, name, arguments, results, local_vars, global_vars):
         """Initialize a Routine instance.
-
         Parameters
         ==========
-
         name : string
             Name of the routine.
-
         arguments : list of Arguments
             These are things that appear in arguments of a routine, often
             appearing on the right-hand side of a function call.  These are
             commonly InputArguments but in some languages, they can also be
             OutputArguments or InOutArguments (e.g., pass-by-reference in C
             code).
-
         results : list of Results
             These are the return values of the routine, often appearing on
             the left-hand side of a function call.  The difference between
             Results and OutputArguments and when you should use each is
             language-specific.
-
-        local_vars : list of Symbols
-            These are used internally by the routine.
-
+        local_vars : list of Results
+            These are variables that will be defined at the beginning of the
+            function.
         global_vars : list of Symbols
             Variables which will not be passed into the function.
-
         """
 
         # extract all input symbols and all symbols appearing in an expression
@@ -177,13 +169,20 @@ class Routine(object):
                 raise ValueError("Unknown Routine result: %s" % r)
             symbols.update(r.expr.free_symbols)
 
+        local_symbols = set([])
+        for r in local_vars:
+            if not isinstance(r, Result):
+                raise ValueError("Unknown Routine result: %s" % r)
+            symbols.update(r.expr.free_symbols)
+            local_symbols.add(r.name)
+
         symbols = set([s.label if isinstance(s, Idx) else s for s in symbols])
 
         # Check that all symbols in the expressions are covered by
         # InputArguments/InOutArguments---subset because user could
         # specify additional (unused) InputArguments or local_vars.
         notcovered = symbols.difference(
-            input_symbols.union(local_vars).union(global_vars))
+            input_symbols.union(local_symbols).union(global_vars))
         if notcovered != set([]):
             raise ValueError("Symbols needed for output are not in input " +
                              ", ".join([str(x) for x in notcovered]))
@@ -202,10 +201,8 @@ class Routine(object):
     @property
     def variables(self):
         """Returns a set of all variables possibly used in the routine.
-
         For routines with unnamed return values, the dummies that may or
         may not be used will be included in the set.
-
         """
         v = set(self.local_vars)
         for arg in self.arguments:
@@ -217,13 +214,13 @@ class Routine(object):
     @property
     def result_variables(self):
         """Returns a list of OutputArgument, InOutArgument and Result.
-
         If return values are present, they are at the end ot the list.
         """
         args = [arg for arg in self.arguments if isinstance(
             arg, (OutputArgument, InOutArgument))]
         args.extend(self.results)
         return args
+
 
 
 class DataType(object):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -607,8 +607,9 @@ class CodeGen(object):
         else:
             expressions = Tuple(expr)
 
-        if self.cse and {i.label for i in expressions.atoms(Idx)} != set():
-            raise CodeGenError("CSE and Indexed expressions do not play well together yet")
+        if self.cse:
+            if {i.label for i in expressions.atoms(Idx)} != set():
+                raise CodeGenError("CSE and Indexed expressions do not play well together yet")
         else:
             # local variables for indexed expressions
             local_vars = {i.label for i in expressions.atoms(Idx)}

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -643,9 +643,9 @@ class CodeGen(object):
 
         # setup input argument list
         array_symbols = {}
-        for array in expressions.atoms(Indexed):
+        for array in expressions.atoms(Indexed) | local_expressions.atoms(Indexed):
             array_symbols[array.base.label] = array
-        for array in expressions.atoms(MatrixSymbol):
+        for array in expressions.atoms(MatrixSymbol) | local_expressions.atoms(MatrixSymbol):
             array_symbols[array] = array
 
         for symbol in sorted(symbols, key=str):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -937,7 +937,7 @@ class CCodeGen(CodeGen):
             if isinstance(result.expr, (MatrixBase, MatrixExpr)):
                 dims = result.expr.shape
                 if dims[1] != 1:
-                    raise CodeGenError("Only column vectors are supported. {} as dimensions {}".format(result.expr, dims))
+                    raise CodeGenError("Only column vectors are supported in local variabels. Local result {} has dimensions {}".format(result, dims))
                 code_lines.append("{0} {1}[{2}];\n".format(t, str(assign_to), dims[0]))
                 prefix = ""
             else:

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -495,6 +495,12 @@ class Result(Variable, ResultBase):
                           dimensions=dimensions, precision=precision)
         ResultBase.__init__(self, expr, result_var)
 
+    def __str__(self):
+        return "%s(%r, %r, %r)" % (self.__class__.__name__, self.name, self.expr,
+            self.result_var)
+
+    __repr__ = __str__
+
 
 #
 # Transformation of routine objects into code

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -504,7 +504,7 @@ class Result(Variable, ResultBase):
         ResultBase.__init__(self, expr, result_var)
 
     def __str__(self):
-        return "%s(%r, %r, %r)" % (self.__class__.__name__, self.name, self.expr,
+        return "%s(%r, %r, %r)" % (self.__class__.__name__, self.expr, self.name,
             self.result_var)
 
     __repr__ = __str__

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -570,6 +570,25 @@ def test_ccode_matrixsymbol_slice():
     )
     assert source == expected
 
+def test_ccode_cse():
+    a, b, c, d = symbols('a b c d')
+    e = MatrixSymbol('e', 3, 1)
+    name_expr = ("test", [Equality(e, Matrix([[a*b], [a*b + c*d], [a*b*c*d]]))])
+    generator = CCodeGen(cse=True)
+    result = codegen(name_expr, code_gen=generator, header=False, empty=False)
+    source = result[0][1]
+    expected = (
+        '#include "test.h"\n'
+        '#include <math.h>\n'
+        'void test(double a, double b, double c, double d, double *e) {\n'
+        '   const double x0 = a*b;\n'
+        '   const double x1 = c*d;\n'
+        '   e[0] = x0;\n'
+        '   e[1] = x0 + x1;\n'
+        '   e[2] = x0*x1;\n'
+        '}\n'
+    )
+    assert source == expected
 
 def test_empty_f_code():
     code_gen = FCodeGen()


### PR DESCRIPTION
This makes an extension to the Routine class in codegen to allow adding Result
objects to the local_vars field. These are then output as C assignments in the
CCodeGen class in the _declare_locals method. This allows defining routines with
local variable calculations and writing them correctly.

Next, it extends the CCodeGen object so that if the cse field is True, it will perform
CSE on the expressions passed in. It keeps the correct set of input and output
arguments while doing this. It correctly handles the case of MatrixSymbol input and
output arguments.

Provides some work towards #11038