### PR TITLE
Do not remove identities into Add and Mul when evaluate=False

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1006,6 +1006,8 @@ class Basic(with_metaclass(ManagedProperties)):
                     nonnumber = self.func(*nonnumber)
                     if coeff is S.One:
                         return nonnumber
+                    elif nonnumber is S.One:
+                        return coeff
                     else:
                         return self.func(coeff, nonnumber, evaluate=False)
                 return rv

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -182,10 +182,13 @@ class Mul(Expr, AssocOp):
             if not a.is_zero and a.is_Rational:
                 r, b = b.as_coeff_Mul()
                 if b.is_Add:
-                    if r is not S.One:  # 2-arg hack
+                    if r is not S.One and r is not S.NegativeOne:  # 2-arg hack
                         # leave the Mul as a Mul
                         rv = [cls(a*r, b, evaluate=False)], [], None
                     elif b.is_commutative:
+                        if r is S.NegativeOne:
+                            a = a * r
+
                         if a is S.One:
                             rv = [b], [], None
                         else:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -182,13 +182,14 @@ class Mul(Expr, AssocOp):
             if not a.is_zero and a.is_Rational:
                 r, b = b.as_coeff_Mul()
                 if b.is_Add:
-                    if r is not S.One and r is not S.NegativeOne:  # 2-arg hack
-                        # leave the Mul as a Mul
-                        rv = [cls(a*r, b, evaluate=False)], [], None
+                    if r is not S.One:  # 2-arg hack
+                        a = a * r
+                        if a is S.One:
+                            rv = [b], [], None
+                        else:
+                            # leave the Mul as a Mul
+                            rv = [cls(a*r, b, evaluate=False)], [], None
                     elif b.is_commutative:
-                        if r is S.NegativeOne:
-                            a = a * r
-
                         if a is S.One:
                             rv = [b], [], None
                         else:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -188,7 +188,7 @@ class Mul(Expr, AssocOp):
                             rv = [b], [], None
                         else:
                             # leave the Mul as a Mul
-                            rv = [cls(a*r, b, evaluate=False)], [], None
+                            rv = [cls(a, b, evaluate=False)], [], None
                     elif b.is_commutative:
                         if a is S.One:
                             rv = [b], [], None

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2541,6 +2541,10 @@ class One(with_metaclass(Singleton, IntegerConstant)):
     def __neg__():
         return S.NegativeOne
 
+    @staticmethod
+    def __div__(other):
+        return Pow(other, -1)
+
     def _eval_power(self, expt):
         return self
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -28,10 +28,11 @@ class AssocOp(Basic):
     def __new__(cls, *args, **options):
         from sympy import Order
         args = list(map(_sympify, args))
-        args = [a for a in args if a is not cls.identity]
 
         if not options.pop('evaluate', global_evaluate[0]):
             return cls._from_args(args)
+
+        args = [a for a in args if a is not cls.identity]
 
         if len(args) == 0:
             return cls.identity

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1369,10 +1369,10 @@ def test_suppressed_evaluation():
     c = Pow(3, 2, evaluate=False)
     assert a != 6
     assert a.func is Add
-    assert a.args == (3, 2)
+    assert a.args == (0, 3, 2)
     assert b != 6
     assert b.func is Mul
-    assert b.args == (3, 2)
+    assert b.args == (1, 3, 2)
     assert c != 9
     assert c.func is Pow
     assert c.args == (3, 2)

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -3,6 +3,7 @@ from sympy.core.evaluate import evaluate
 from sympy.core import Mul, Add, Pow, S
 from sympy import sqrt
 
+
 def test_add():
     with evaluate(False):
         expr = x + x
@@ -26,13 +27,13 @@ def test_add():
         assert S(2) * 4 == Mul(2, 4)
         assert 4 * S(2) == Mul(2, 4)
 
-        assert S(6) / 3 == Mul(6, S(1) / 3)
+        assert S(6) / 3 == Mul(6, Pow(3, -1))
         assert S(1) / 3 * 6 == Mul(S(1) / 3, 6)
 
         assert 9 ** S(2) == Pow(9, 2)
         assert S(2) ** 9 == Pow(2, 9)
 
-        assert S(2) / 2 == Mul(2, S(1) / 2)
+        assert S(2) / 2 == Mul(2, Pow(2, -1))
         assert S(1) / 2 * 2 == Mul(S(1) / 2, 2)
 
         assert S(2) / 3 + 1 == Add(S(2) / 3, 1)
@@ -44,14 +45,14 @@ def test_add():
         assert S(2) / 4 * 4 == Mul(S(2) / 4, 4)
         assert 4 * (S(2) / 4) == Mul(4, S(2) / 4)
 
-        assert S(6) / 3 == Mul(6, S(1) / 3)
+        assert S(6) / 3 == Mul(6, Pow(3, -1))
         assert S(1) / 3 * 6 == Mul(S(1) / 3, 6)
 
         assert S(1) / 3 + sqrt(3) == Add(S(1) / 3, sqrt(3))
         assert sqrt(3) + S(1) / 3 == Add(sqrt(3), S(1) / 3)
 
         assert S(1) / 2 * 10.333 == Mul(S(1) / 2, 10.333)
-        assert 10.333 * S(1) / 2 == Mul(10.333, S(1) / 2)
+        assert 10.333 * (S(1) / 2) == Mul(10.333, (S(1) / 2))
 
         assert sqrt(2) * sqrt(2) == Mul(sqrt(2), sqrt(2))
 
@@ -59,7 +60,8 @@ def test_add():
         assert x + S(1) / 2 == Add(x, S(1) / 2)
 
         assert S(1) / x * x == Mul(S(1) / x, x)
-        assert x * S(1) / x == Mul(x, S(1) / x)
+        assert x * S(1) / x == Mul(Mul(x, 1), Pow(x, -1))
+
 
 def test_nested():
     with evaluate(False):

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -27,6 +27,7 @@ def test_add():
         assert S(2) * 4 == Mul(2, 4)
         assert 4 * S(2) == Mul(2, 4)
 
+        assert S(1) / 3 == Pow(3, -1)
         assert S(6) / 3 == Mul(6, Pow(3, -1))
         assert S(1) / 3 * 6 == Mul(S(1) / 3, 6)
 

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -470,7 +470,7 @@ def test_kernS():
     ss = kernS(s)
     assert ss != -1 and ss.simplify() == -1
     # issue 6687
-    assert kernS('Interval(-1,-2 - 4*(-3))') == Interval(-1, Add(-2, Mul(12, 1, evaluate=False), evaluate=False))
+    assert kernS('Interval(-1,-2 - 4*(-3))') == Interval(-1, 10)
     assert kernS('_kern') == Symbol('_kern')
     assert kernS('E**-(x)') == exp(-x)
     e = 2*(x + y)*y

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -470,7 +470,7 @@ def test_kernS():
     ss = kernS(s)
     assert ss != -1 and ss.simplify() == -1
     # issue 6687
-    assert kernS('Interval(-1,-2 - 4*(-3))') == Interval(-1, 10)
+    assert kernS('Interval(-1,-2 - 4*(-3))') == Interval(-1, Add(-2, Mul(12, 1, evaluate=False), evaluate=False))
     assert kernS('_kern') == Symbol('_kern')
     assert kernS('E**-(x)') == exp(-x)
     e = 2*(x + y)*y

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -992,6 +992,8 @@ def fraction(expr, exact=False):
         else:
             numer.append(term)
     if exact:
+        numer = [a for a in numer if a is not Mul.identity]
+        denom = [a for a in denom if a is not Mul.identity]
         return Mul(*numer, evaluate=False), Mul(*denom, evaluate=False)
     else:
         return Mul(*numer), Mul(*denom)

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -987,13 +987,13 @@ def fraction(expr, exact=False):
                 numer.append(term)
         elif term.is_Rational:
             n, d = term.as_numer_denom()
-            numer.append(n)
-            denom.append(d)
+            if n is not S.One:
+                numer.append(n)
+            if d is not S.One:
+                denom.append(d)
         else:
             numer.append(term)
     if exact:
-        numer = [a for a in numer if a is not Mul.identity]
-        denom = [a for a in denom if a is not Mul.identity]
         return Mul(*numer, evaluate=False), Mul(*denom, evaluate=False)
     else:
         return Mul(*numer), Mul(*denom)


### PR DESCRIPTION
As discussed on ML ( https://groups.google.com/forum/#!topic/sympy/kx-sZvDy2ac ), this change prevent `Mul` and `Add` from removing their identity element if evaluate=False.

From an external point of view, the behavior is now : 

```python
a = Add(0, 3, 2, evaluate=False)
assert a.func is Add
assert a.args == (0, 3, 2)
# Previously, it was:
#  assert a.args == (3, 2)
     
b = Mul(1, 3, 2, evaluate=False)
assert b.func is Mul
assert b.args == (1, 3, 2)
# Previously, it was:
# assert b.args == (3, 2)
```

All other changes are there to ensure backward compatibility in functions relying on the old behavior.