### PR TITLE
Fix Mpmathprinter issue #13147 and #13148

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -202,16 +202,9 @@ class MpmathPrinter(PythonCodePrinter):
     printmethod = "_mpmathcode"
 
     _kf = dict(chain(
-        PythonCodePrinter._kf.items(),
+        _known_functions.items(),
         [(k, 'mpmath.' + v) for k, v in _known_functions_mpmath.items()]
     ))
-
-    def doprint(self, expr, **kwargs):
-        from sympy.functions import log
-        from sympy.codegen.cfunctions import log2, log1p
-        expr = expr.replace(log2, lambda arg: arg.rewrite(log))
-        expr = expr.replace(log1p, lambda arg: arg.rewrite(log))
-        return super(MpmathPrinter, self).doprint(expr, **kwargs)
 
     def _print_Integer(self, e):
         return '%s(%d)' % (self._module_format('mpmath.mpf'), e)
@@ -234,6 +227,14 @@ class MpmathPrinter(PythonCodePrinter):
     def _print_lowergamma(self,e): #printer for the lowergamma functioin
         return "{0}({1}, 0, {2})".format(
             self._module_format('mpmath.gammainc'), self._print(e.args[0]), self._print(e.args[1]))
+
+    def _print_log2(self, e):
+        return '{0}({1})/{0}(2)'.format(
+            self._module_format('mpmath.log'), self._print(e.args[0]))
+
+    def _print_log1p(self, e):
+        return '{0}({1}+1)'.format(
+            self._module_format('mpmath.log'), self._print(e.args[0]))
 
 for k in MpmathPrinter._kf:
     setattr(MpmathPrinter, '_print_%s' % k, _print_known_func)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -302,7 +302,7 @@ def test_math():
 
 def test_sin():
     f = lambdify(x, sin(x)**2)
-    assert isinstance(f(2), float)
+    assert isinstance(f(2), (float, mpmath.ctx_mp_python.mpf))
     f = lambdify(x, sin(x)**2, modules="math")
     assert isinstance(f(2), float)
 


### PR DESCRIPTION
- Fixed MpmathPrinter.doprint(expr) when expr is string or list. Replaced replace log1p/log2 logics in doprint with _print_~ as suggested by @asmeurer on #13147. Fixes #13147.
- Fixed lambdify test case failing on Windows where NumPy is not installed and mpmath is used to lambdify. Related to #13148.