### PR TITLE
Fix/Normalize factor() of expression with float coefficients

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1218,14 +1218,15 @@ def dup_factor_list(f, K0):
                 factors[i] = (dup_convert(f, K, K0), k)
 
             coeff = K0.convert(coeff, K)
+            coeff = K0.quo(coeff, denom)
 
-            if K0_inexact is None:
-                coeff = coeff/denom
-            else:
+            if K0_inexact:
                 for i, (f, k) in enumerate(factors):
-                    f = dup_quo_ground(f, denom, K0)
+                    max_norm = dup_max_norm(f, K0)
+                    f = dup_quo_ground(f, max_norm, K0)
                     f = dup_convert(f, K0, K0_inexact)
                     factors[i] = (f, k)
+                    coeff = K0.mul(coeff, K0.pow(max_norm, k))
 
                 coeff = K0_inexact.convert(coeff, K0)
                 K0 = K0_inexact
@@ -1297,14 +1298,15 @@ def dmp_factor_list(f, u, K0):
                 factors[i] = (dmp_convert(f, u, K, K0), k)
 
             coeff = K0.convert(coeff, K)
+            coeff = K0.quo(coeff, denom)
 
-            if K0_inexact is None:
-                coeff = coeff/denom
-            else:
+            if K0_inexact:
                 for i, (f, k) in enumerate(factors):
-                    f = dmp_quo_ground(f, denom, u, K0)
+                    max_norm = dmp_max_norm(f, u, K0)
+                    f = dmp_quo_ground(f, max_norm, u, K0)
                     f = dmp_convert(f, u, K0, K0_inexact)
                     factors[i] = (f, k)
+                    coeff = K0.mul(coeff, K0.pow(max_norm, k))
 
                 coeff = K0_inexact.convert(coeff, K0)
                 K0 = K0_inexact

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -528,7 +528,7 @@ def test_dup_factor_list():
 
     f = 6.7225336055071*x**2 - 10.6463972754741*x - 0.33469524022264
     coeff, factors = R.dup_factor_list(f)
-    assert coeff == RR(1.0) and len(factors) == 1 and factors[0][0].almosteq(f, 1e-10) and factors[0][1] == 1
+    assert coeff == RR(10.6463972754741) and len(factors) == 1 and factors[0][0].max_norm() == RR(1.0) and factors[0][1] == 1
 
     Rt, t = ring("t", ZZ)
     R, x = ring("x", Rt)
@@ -628,12 +628,12 @@ def test_dmp_factor_list():
     f = 2.0*x**2 - 8.0*y**2
 
     assert R.dmp_factor_list(f) == \
-        (RR(2.0), [(1.0*x - 2.0*y, 1),
-                   (1.0*x + 2.0*y, 1)])
+        (RR(8.0), [(0.5*x - y, 1),
+                   (0.5*x + y, 1)])
 
     f = 6.7225336055071*x**2*y**2 - 10.6463972754741*x*y - 0.33469524022264
     coeff, factors = R.dmp_factor_list(f)
-    assert coeff == RR(1.0) and len(factors) == 1 and factors[0][0].almosteq(f, 1e-10) and factors[0][1] == 1
+    assert coeff == RR(10.6463972754741) and len(factors) == 1 and factors[0][0].max_norm() == RR(1.0) and factors[0][1] == 1
 
     Rt, t = ring("t", ZZ)
     R, x, y = ring("x,y", Rt)

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -528,7 +528,10 @@ def test_dup_factor_list():
 
     f = 6.7225336055071*x**2 - 10.6463972754741*x - 0.33469524022264
     coeff, factors = R.dup_factor_list(f)
-    assert coeff == RR(10.6463972754741) and len(factors) == 1 and factors[0][0].max_norm() == RR(1.0) and factors[0][1] == 1
+    assert coeff == RR(10.6463972754741)
+    assert len(factors) == 1
+    assert factors[0][0].max_norm() == RR(1.0)
+    assert factors[0][1] == 1
 
     Rt, t = ring("t", ZZ)
     R, x = ring("x", Rt)
@@ -633,7 +636,10 @@ def test_dmp_factor_list():
 
     f = 6.7225336055071*x**2*y**2 - 10.6463972754741*x*y - 0.33469524022264
     coeff, factors = R.dmp_factor_list(f)
-    assert coeff == RR(10.6463972754741) and len(factors) == 1 and factors[0][0].max_norm() == RR(1.0) and factors[0][1] == 1
+    assert coeff == RR(10.6463972754741)
+    assert len(factors) == 1
+    assert factors[0][0].max_norm() == RR(1.0)
+    assert factors[0][1] == 1
 
     Rt, t = ring("t", ZZ)
     R, x, y = ring("x,y", Rt)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2445,7 +2445,8 @@ def test_factor():
     assert factor(sqrt(x**2)) == sqrt(x**2)
 
     # issue 13149
-    assert factor(expand((0.5*x+1)*(0.5*y+1))) == Mul(1.0, 0.5*x + 1.0, 0.5*y + 1.0, evaluate = False)
+    assert factor(expand((0.5*x+1)*(0.5*y+1))) == Mul(1.0, 0.5*x + 1.0,
+        0.5*y + 1.0, evaluate = False)
     assert factor(expand((0.5*x+0.5)**2)) == 0.25*(1.0*x + 1.0)**2
 
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2444,6 +2444,10 @@ def test_factor():
 
     assert factor(sqrt(x**2)) == sqrt(x**2)
 
+    # issue 13149
+    assert factor(expand((0.5*x+1)*(0.5*y+1))) == Mul(1.0, 0.5*x + 1.0, 0.5*y + 1.0, evaluate = False)
+    assert factor(expand((0.5*x+0.5)**2)) == 0.25*(1.0*x + 1.0)**2
+
 
 def test_factor_large():
     f = (x**2 + 4*x + 4)**10000000*(x**2 + 1)*(x**2 + 2*x + 1)**1234567

--- a/sympy/simplify/tests/test_combsimp.py
+++ b/sympy/simplify/tests/test_combsimp.py
@@ -1,7 +1,7 @@
 from sympy import (
     Rational, combsimp, factorial, gamma, binomial, Symbol, pi, S,
     sin, exp, powsimp, sqrt, sympify, FallingFactorial, RisingFactorial,
-    simplify, symbols, cos, rf)
+    simplify, symbols, cos, rf, Mul)
 
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 
@@ -28,7 +28,8 @@ def test_combsimp():
     assert combsimp(binomial(n + 2, k + S(1)/2)) == 4*((n + 1)*(n + 2) *
         binomial(n, k + S(1)/2))/((2*k - 2*n - 1)*(2*k - 2*n - 3))
     assert combsimp(binomial(n + 2, k + 2.0)) == \
-        -((1.0*n + 2.0)*binomial(n + 1.0, k + 2.0))/(k - n)
+        Mul(-2.0, 0.5*n + 1.0, binomial(n + 1.0, k + 2.0),
+        evaluate = False)/(k - n)
 
     # coverage tests
     assert combsimp(factorial(n*(1 + n) - n**2 - n)) == 1


### PR DESCRIPTION
Fixes #13149.

It has been suggested that cause of this is incorrect handling of `denom` in `dup_factor_list()` `dmp_factor_list()` in `/polys/factortools.py` - dividing every factor by denom. (see #13149)

This commit fixes the issue by dividing coeff by denom once. Also, it normalizes maximum coefficient(norm) to one, as suggested by @jksuom in #13167.

Fixes #8754, fixes #9296, fixes #9630, fixes last comment of #12140, fixes #12506, fixes #12792, and fixes #13115.