### PR TITLE
residue_ntheory: args should be ints

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -72,11 +72,12 @@ def _primitive_root_prime_iter(p):
     >>> list(_primitive_root_prime_iter(19))
     [2, 3, 10, 13, 14, 15]
     """
-    p = as_int(p)
+    # it is assumed that p is an int
     v = [(p - 1) // i for i in factorint(p - 1).keys()]
     a = 2
     while a < p:
         for pw in v:
+            # a TypeError below may indicate that p was not an int
             if pow(a, pw, p) == 1:
                 break
         else:
@@ -626,7 +627,7 @@ def is_nthpow_residue(a, n, m):
     .. [1] P. Hackman "Elementary Number Theory" (2009), page 76
 
     """
-    a, n, m = [as_int(i) for i in (a, n, m)]
+    a, n, m = as_int(a), as_int(n), as_int(m)
     if m <= 0:
         raise ValueError('m must be > 0')
     if n < 0:
@@ -766,8 +767,9 @@ def nthroot_mod(a, n, p, all_roots=False):
     23
     """
     from sympy.core.numbers import igcdex
+    a, n, p = as_int(a), as_int(n), as_int(p)
     if n == 2:
-        return sqrt_mod(a, p , all_roots)
+        return sqrt_mod(a, p, all_roots)
     f = totient(p)
     # see Hackman "Elementary Number Theory" (2009), page 76
     if not is_nthpow_residue(a, n, p):
@@ -817,6 +819,7 @@ def quadratic_residues(p):
     >>> quadratic_residues(7)
     [0, 1, 2, 4]
     """
+    p = as_int(p)
     r = set()
     for i in range(p // 2 + 1):
         r.add(pow(i, 2, p))
@@ -1282,6 +1285,7 @@ def discrete_log(n, a, b, order=None, prime_order=None):
     3
 
     """
+    n, a, b = as_int(n), as_int(a), as_int(b)
     if order is None:
         order = n_order(b, n)
 

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from sympy import Symbol
+from sympy import S, Symbol, Tuple
 from sympy.core.compatibility import range
 
 from sympy.ntheory import n_order, is_primitive_root, is_quad_residue, \
@@ -65,6 +65,9 @@ def test_residue():
     raises(ValueError, lambda: is_quad_residue(2, 0))
 
 
+    assert quadratic_residues(S.One) == [0]
+    assert quadratic_residues(1) == [0]
+    assert quadratic_residues(12) == [0, 1, 4, 9]
     assert quadratic_residues(12) == [0, 1, 4, 9]
     assert quadratic_residues(13) == [0, 1, 3, 4, 9, 10, 12]
     assert [len(quadratic_residues(i)) for i in range(1, 20)] == \
@@ -161,6 +164,8 @@ def test_residue():
     assert is_nthpow_residue(31, 4, 41)
     assert not is_nthpow_residue(2, 2, 5)
     assert is_nthpow_residue(8547, 12, 10007)
+    assert nthroot_mod(29, 31, 74) == 31
+    assert nthroot_mod(*Tuple(29, 31, 74)) == 31
     assert nthroot_mod(1801, 11, 2663) == 44
     for a, q, p in [(51922, 2, 203017), (43, 3, 109), (1801, 11, 2663),
           (26118163, 1303, 33333347), (1499, 7, 2663), (595, 6, 2663),
@@ -236,3 +241,6 @@ def test_residue():
     assert discrete_log(2456747, 3**51, 3) == 51
     assert discrete_log(32942478, 11**127, 11) == 127
     assert discrete_log(432751500361, 7**324, 7) == 324
+    args = 5779, 3528, 6215
+    assert discrete_log(*args) == 687
+    assert discrete_log(*Tuple(*args)) == 687


### PR DESCRIPTION
fixes #13201

Most routines in residue_ntheory are careful to make their args ints. A few weren't and if the routines encounter Integers, errors result. For example, if `pow` gets called with mixed args the following can happen:

```python
>>> pow(3,S(2),4)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for pow(): 'int', 'Integer', 'int'
>>> pow(3,2,4)
1
```