### PR TITLE
Piecewise expr must be Basic

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -63,9 +63,7 @@ class AppliedPredicate(Boolean):
     __slots__ = []
 
     def __new__(cls, predicate, arg):
-        if not isinstance(arg, bool):
-            # XXX: There is not yet a Basic type for True and False
-            arg = _sympify(arg)
+        arg = _sympify(arg)
         return Boolean.__new__(cls, predicate, arg)
 
     is_Atom = True  # do not attempt to decompose this
@@ -126,10 +124,15 @@ class Predicate(Boolean):
 
     Predicates merely wrap their argument and remain unevaluated:
 
-        >>> from sympy import Q, ask, Symbol, S
-        >>> x = Symbol('x')
+        >>> from sympy import Q, ask
+        >>> type(Q.prime)
+        <class 'sympy.assumptions.assume.Predicate'>
+        >>> Q.prime.name
+        'prime'
         >>> Q.prime(7)
         Q.prime(7)
+        >>> _.func.name
+        'prime'
 
     To obtain the truth value of an expression containing predicates, use
     the function ``ask``:
@@ -139,10 +142,9 @@ class Predicate(Boolean):
 
     The tautological predicate ``Q.is_true`` can be used to wrap other objects:
 
+        >>> from sympy.abc import x
         >>> Q.is_true(x > 1)
         Q.is_true(x > 1)
-        >>> Q.is_true(S(1) < x)
-        Q.is_true(1 < x)
 
     """
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -111,6 +111,15 @@ class AppliedPredicate(Boolean):
     def _eval_ask(self, assumptions):
         return self.func.eval(self.arg, assumptions)
 
+    @property
+    def binary_symbols(self):
+        from sympy.core.relational import Eq, Ne
+        if self.func.name in ['is_true', 'is_false']:
+            i = self.arg
+            if i.is_Boolean or i.is_Symbol or isinstance(i, (Eq, Ne)):
+                return i.binary_symbols
+        return set()
+
 
 class Predicate(Boolean):
     """A predicate is a function that returns a boolean value.

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -104,8 +104,8 @@ def test_periodicity():
     assert periodicity(exp(x)**sin(x), x) is None
     assert periodicity(sin(x)**y, y) is None
 
-    assert periodicity(Abs(sin(Abs(sin(x)))),x) == pi
-    assert all(periodicity(Abs(f(x)),x) == pi for f in (
+    assert periodicity(Abs(sin(Abs(sin(x)))), x) == pi
+    assert all(periodicity(Abs(f(x)), x) == pi for f in (
         cos, sin, sec, csc, tan, cot))
     assert periodicity(Abs(sin(tan(x))), x) == pi
     assert periodicity(Abs(sin(sin(x) + tan(x))), x) == 2*pi

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -12,16 +12,30 @@ a = Symbol('a', real=True)
 
 def test_function_range():
     x, y, a, b = symbols('x y a b')
-    assert function_range(sin(x), x, Interval(-pi/2, pi/2)) == Interval(-1, 1)
-    assert function_range(sin(x), x, Interval(0, pi)) == Interval(0, 1)
-    assert function_range(tan(x), x, Interval(0, pi)) == Interval(-oo, oo)
-    assert function_range(tan(x), x, Interval(pi/2, pi)) == Interval(-oo, 0)
-    assert function_range((x + 3)/(x - 2), x, Interval(-5, 5)) == Interval(-oo, oo)
-    assert function_range(1/(x**2), x, Interval(-1, 1)) == Interval(1, oo)
-    assert function_range(exp(x), x, Interval(-1, 1)) == Interval(exp(-1), exp(1))
-    assert function_range(log(x) - x, x, S.Reals) == Interval(-oo, -1)
-    assert function_range(sqrt(3*x - 1), x, Interval(0, 2)) == Interval(0, sqrt(5))
-    raises(NotImplementedError, lambda : function_range(exp(x)*(sin(x)-cos(x))/2 - x, x, S.Reals))
+    assert function_range(sin(x), x, Interval(-pi/2, pi/2)
+        ) == Interval(-1, 1)
+    assert function_range(sin(x), x, Interval(0, pi)
+        ) == Interval(0, 1)
+    assert function_range(tan(x), x, Interval(0, pi)
+        ) == Interval(-oo, oo)
+    assert function_range(tan(x), x, Interval(pi/2, pi)
+        ) == Interval(-oo, 0)
+    assert function_range((x + 3)/(x - 2), x, Interval(-5, 5)
+        ) == Interval(-oo, oo)
+    assert function_range(1/(x**2), x, Interval(-1, 1)
+        ) == Interval(1, oo)
+    assert function_range(exp(x), x, Interval(-1, 1)
+        ) == Interval(exp(-1), exp(1))
+    assert function_range(log(x) - x, x, S.Reals
+        ) == Interval(-oo, -1)
+    assert function_range(sqrt(3*x - 1), x, Interval(0, 2)
+        ) == Interval(0, sqrt(5))
+    assert function_range(x*(x - 1) - (x**2 - x), x, S.Reals
+        ) == FiniteSet(0)
+    assert function_range(x*(x - 1) - (x**2 - x) + y, x, S.Reals
+        ) == FiniteSet(y)
+    raises(NotImplementedError, lambda : function_range(
+        exp(x)*(sin(x) - cos(x))/2 - x, x, S.Reals))
 
 
 def test_continuous_domain():

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -114,7 +114,11 @@ def function_range(f, symbol, domain):
 
     vals = S.EmptySet
     period = periodicity(f, symbol)
-    if not any(period is i for i in (None, S.Zero)):
+    if period is S.Zero:
+        # the expression is constant wrt symbol
+        return FiniteSet(f.expand())
+
+    if period is not None:
         inf = domain.inf
         inf_period = S.Zero if inf.is_infinite else inf
         sup_period = inf_period + period

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -337,15 +337,15 @@ def periodicity(f, symbol, check=False):
     >>> periodicity(exp(x), x)
 
     """
-    from sympy import simplify, lcm_list
+    from sympy.core.function import diff
+    from sympy.core.mod import Mod
+    from sympy.core.relational import Relational
     from sympy.functions.elementary.complexes import Abs
     from sympy.functions.elementary.trigonometric import (
         TrigonometricFunction, sin, cos, csc, sec)
+    from sympy.simplify.simplify import simplify
     from sympy.solvers.decompogen import decompogen
-    from sympy.core import Mod
-    from sympy.polys.polytools import degree
-    from sympy.core.function import diff
-    from sympy.core.relational import Relational
+    from sympy.polys.polytools import degree, lcm_list
 
     def _check(orig_f, period):
         '''Return the checked period or raise an error.'''
@@ -364,14 +364,15 @@ def periodicity(f, symbol, check=False):
                 (symbol, symbol, period, orig_f, new_f)))
 
     orig_f = f
-    f = simplify(orig_f)
     period = None
-
-    if symbol not in f.free_symbols:
-        return S.Zero
 
     if isinstance(f, Relational):
         f = f.lhs - f.rhs
+
+    f = simplify(f)
+
+    if symbol not in f.free_symbols:
+        return S.Zero
 
     if isinstance(f, TrigonometricFunction):
         try:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -13,6 +13,19 @@ from .singleton import S
 from inspect import getmro
 
 
+def as_Basic(expr):
+    """Return expr as a Basic instance using strict sympify
+    or raise a TypeError; this is just a wrapper to _sympify,
+    raising a TypeError instead of a SympifyError."""
+    from sympy.utilities.misc import func_name
+    try:
+        return _sympify(expr)
+    except SympifyError:
+        raise TypeError(
+            'Argument must be a Basic object, not `%s`' % func_name(
+            expr))
+
+
 class Basic(with_metaclass(ManagedProperties)):
     """
     Base class for all objects in SymPy.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2490,11 +2490,13 @@ def count_ops(expr, visual=False):
 
     """
     from sympy import Integral, Symbol
+    from sympy.core.relational import Relational
     from sympy.simplify.radsimp import fraction
     from sympy.logic.boolalg import BooleanFunction
+    from sympy.utilities.misc import func_name
 
     expr = sympify(expr)
-    if isinstance(expr, Expr):
+    if isinstance(expr, Expr) and not expr.is_Relational:
 
         ops = []
         args = [expr]
@@ -2579,11 +2581,11 @@ def count_ops(expr, visual=False):
                count_ops(v, visual=visual) for k, v in expr.items()]
     elif iterable(expr):
         ops = [count_ops(i, visual=visual) for i in expr]
-    elif isinstance(expr, BooleanFunction):
+    elif isinstance(expr, (Relational, BooleanFunction)):
         ops = []
         for arg in expr.args:
             ops.append(count_ops(arg, visual=True))
-        o = Symbol(expr.func.__name__.upper())
+        o = Symbol(func_name(expr, short=True).upper())
         ops.append(o)
     elif not isinstance(expr, Basic):
         ops = []

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -405,6 +405,10 @@ class LatticeOp(AssocOp):
     def __new__(cls, *args, **options):
         args = (_sympify(arg) for arg in args)
         try:
+            # /!\ args is a generator and _new_args_filter
+            # must be careful to handle as such; this
+            # is done so short-circuiting can be done
+            # without having to sympify all values
             _args = frozenset(cls._new_args_filter(args))
         except ShortCircuit:
             return sympify(cls.zero)

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -404,6 +404,7 @@ class LatticeOp(AssocOp):
 
     def __new__(cls, *args, **options):
         args = (_sympify(arg) for arg in args)
+
         try:
             # /!\ args is a generator and _new_args_filter
             # must be careful to handle as such; this

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -48,7 +48,7 @@ class Relational(Boolean, Expr, EvalfMixin):
 
     >>> from sympy import Rel
     >>> from sympy.abc import x, y
-    >>> Rel(y, x+x**2, '==')
+    >>> Rel(y, x + x**2, '==')
     Eq(y, x**2 + x)
 
     """

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -67,9 +67,31 @@ class Relational(Boolean, Expr, EvalfMixin):
         # corresponding to that operator and delegate to it
         try:
             cls = cls.ValidRelationOperator[rop]
-            return cls(lhs, rhs, **assumptions)
+            rv = cls(lhs, rhs, **assumptions)
+            # /// drop when Py2 is no longer supported
+            # validate that Booleans are not being used in a relational
+            # other than Eq/Ne;
+            if isinstance(rv, (Eq, Ne)):
+                pass
+            elif isinstance(rv, Relational):  # could it be otherwise?
+                from sympy.core.symbol import Symbol
+                from sympy.logic.boolalg import Boolean
+                from sympy.utilities.misc import filldedent
+                for a in rv.args:
+                    if isinstance(a, Symbol):
+                        continue
+                    if isinstance(a, Boolean):
+                        from sympy.utilities.misc import filldedent
+                        raise TypeError(filldedent('''
+                            A Boolean argument can only be used in
+                            Eq and Ne; all other relationals expect
+                            real expressions.
+                        '''))
+            # \\\
+            return rv
         except KeyError:
-            raise ValueError("Invalid relational operator symbol: %r" % rop)
+            raise ValueError(
+                "Invalid relational operator symbol: %r" % rop)
 
     @property
     def lhs(self):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -230,32 +230,14 @@ class Relational(Boolean, Expr, EvalfMixin):
 
     __bool__ = __nonzero__
 
-    def as_set(self):
-        """
-        Rewrites univariate inequality in terms of real sets
-
-        Examples
-        ========
-
-        >>> from sympy import Symbol, Eq
-        >>> x = Symbol('x', real=True)
-        >>> (x > 0).as_set()
-        Interval.open(0, oo)
-        >>> Eq(x, 0).as_set()
-        {0}
-
-        """
+    def _eval_as_set(self):
+        # self is univariate and periodicity(self, x) in (0, None)
+        from sympy.solvers.solveset import solveset
         from sympy.solvers.inequalities import solve_univariate_inequality
         syms = self.free_symbols
-
-        if len(syms) == 1:
-            sym = syms.pop()
-        else:
-            raise NotImplementedError("Sorry, Relational.as_set procedure"
-                                      " is not yet implemented for"
-                                      " multivariate expressions")
-
-        return solve_univariate_inequality(self, sym, relational=False)
+        assert len(syms) == 1
+        x = syms.pop()
+        return solve_univariate_inequality(self, x, relational=False)
 
     @property
     def binary_symbols(self):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -232,7 +232,6 @@ class Relational(Boolean, Expr, EvalfMixin):
 
     def _eval_as_set(self):
         # self is univariate and periodicity(self, x) in (0, None)
-        from sympy.solvers.solveset import solveset
         from sympy.solvers.inequalities import solve_univariate_inequality
         syms = self.free_symbols
         assert len(syms) == 1

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -621,12 +621,8 @@ class GreaterThan(_Greater):
     One generally does not instantiate these classes directly, but uses various
     convenience methods:
 
-    >>> e1 = Ge( x, 2 )      # Ge is a convenience wrapper
-    >>> print(e1)
-    x >= 2
-
-    >>> rels = Ge( x, 2 ), Gt( x, 2 ), Le( x, 2 ), Lt( x, 2 )
-    >>> print('%s\\n%s\\n%s\\n%s' % rels)
+    >>> for f in [Ge, Gt, Le, Lt]:  # convenience wrappers
+    ...     print(f(x, 2))
     x >= 2
     x > 2
     x <= 2
@@ -638,135 +634,133 @@ class GreaterThan(_Greater):
     littering the math with oddball function calls.  However there are certain
     (minor) caveats of which to be aware (search for 'gotcha', below).
 
-    >>> e2 = x >= 2
-    >>> print(e2)
+    >>> x >= 2
     x >= 2
-    >>> print("e1: %s,    e2: %s" % (e1, e2))
-    e1: x >= 2,    e2: x >= 2
-    >>> e1 == e2
+    >>> _ == Ge(x, 2)
     True
 
     However, it is also perfectly valid to instantiate a ``*Than`` class less
     succinctly and less conveniently:
 
-    >>> rels = Rel(x, 1, '>='), Relational(x, 1, '>='), GreaterThan(x, 1)
-    >>> print('%s\\n%s\\n%s' % rels)
-    x >= 1
-    x >= 1
-    x >= 1
-
-    >>> rels = Rel(x, 1, '>'), Relational(x, 1, '>'), StrictGreaterThan(x, 1)
-    >>> print('%s\\n%s\\n%s' % rels)
+    >>> Rel(x, 1, ">")
     x > 1
-    x > 1
+    >>> Relational(x, 1, ">")
     x > 1
 
-    >>> rels = Rel(x, 1, '<='), Relational(x, 1, '<='), LessThan(x, 1)
-    >>> print("%s\\n%s\\n%s" % rels)
+    >>> StrictGreaterThan(x, 1)
+    x > 1
+    >>> GreaterThan(x, 1)
+    x >= 1
+    >>> LessThan(x, 1)
     x <= 1
-    x <= 1
-    x <= 1
-
-    >>> rels = Rel(x, 1, '<'), Relational(x, 1, '<'), StrictLessThan(x, 1)
-    >>> print('%s\\n%s\\n%s' % rels)
-    x < 1
-    x < 1
+    >>> StrictLessThan(x, 1)
     x < 1
 
     Notes
     =====
 
-    There are a couple of "gotchas" when using Python's operators.
+    There are a couple of "gotchas" to be aware of when using Python's
+    operators.
 
-    The first enters the mix when comparing against a literal number as the lhs
-    argument.  Due to the order that Python decides to parse a statement, it may
-    not immediately find two objects comparable.  For example, to evaluate the
-    statement (1 < x), Python will first recognize the number 1 as a native
-    number, and then that x is *not* a native number.  At this point, because a
-    native Python number does not know how to compare itself with a SymPy object
-    Python will try the reflective operation, (x > 1).  Unfortunately, there is
-    no way available to SymPy to recognize this has happened, so the statement
-    (1 < x) will turn silently into (x > 1).
+    The first is that what your write is not always what you get:
 
-    >>> e1 = x >  1
-    >>> e2 = x >= 1
-    >>> e3 = x <  1
-    >>> e4 = x <= 1
-    >>> e5 = 1 >  x
-    >>> e6 = 1 >= x
-    >>> e7 = 1 <  x
-    >>> e8 = 1 <= x
-    >>> print("%s     %s\\n"*4 % (e1, e2, e3, e4, e5, e6, e7, e8))
-    x > 1     x >= 1
-    x < 1     x <= 1
-    x < 1     x <= 1
-    x > 1     x >= 1
+        >>> 1 < x
+        x > 1
 
-    If the order of the statement is important (for visual output to the
-    console, perhaps), one can work around this annoyance in a couple ways: (1)
-    "sympify" the literal before comparison, (2) use one of the wrappers, or (3)
-    use the less succinct methods described above:
+        Due to the order that Python parses a statement, it may
+        not immediately find two objects comparable.  When "1 < x"
+        is evaluated, Python recognizes that the number 1 is a native
+        number and that x is *not*.  Because a native Python number does
+        not know how to compare itself with a SymPy object
+        Python will try the reflective operation, "x > 1" and that is the
+        form that gets evaluated, hence returned.
 
-    >>> e1 = S(1) >  x
-    >>> e2 = S(1) >= x
-    >>> e3 = S(1) <  x
-    >>> e4 = S(1) <= x
-    >>> e5 = Gt(1, x)
-    >>> e6 = Ge(1, x)
-    >>> e7 = Lt(1, x)
-    >>> e8 = Le(1, x)
-    >>> print("%s     %s\\n"*4 % (e1, e2, e3, e4, e5, e6, e7, e8))
-    1 > x     1 >= x
-    1 < x     1 <= x
-    1 > x     1 >= x
-    1 < x     1 <= x
+        If the order of the statement is important (for visual output to
+        the console, perhaps), one can work around this annoyance in a
+        couple ways:
 
-    The other gotcha is with chained inequalities.  Occasionally, one may be
-    tempted to write statements like:
+        (1) "sympify" the literal before comparison
 
-    >>> e = x < y < z
-    Traceback (most recent call last):
-    ...
-    TypeError: symbolic boolean expression has no truth value.
+        >>> S(1) < x
+        1 < x
 
-    Due to an implementation detail or decision of Python [1]_, there is no way
-    for SymPy to reliably create that as a chained inequality.  To create a
-    chained inequality, the only method currently available is to make use of
-    And:
+        (2) use one of the wrappers or less succint methods described
+        above
 
-    >>> e = And(x < y, y < z)
-    >>> type( e )
-    And
-    >>> e
-    (x < y) & (y < z)
+        >>> Lt(1, x)
+        1 < x
+        >>> Relational(1, x, "<")
+        1 < x
 
-    Note that this is different than chaining an equality directly via use of
-    parenthesis (this is currently an open bug in SymPy [2]_):
+    The second gotcha involves writing equality tests between relationals
+    when one or both sides of the test involve a literal relational:
 
-    >>> e = (x < y) < z
-    >>> type( e )
-    <class 'sympy.core.relational.StrictLessThan'>
-    >>> e
-    (x < y) < z
+        >>> e = x < 1; e
+        x < 1
+        >>> e == e  # neither side is a literal
+        True
+        >>> e == x < 1  # expecting True, too
+        False
+        >>> e != x < 1  # expecting False
+        x < 1
+        >>> x < 1 != x < 1  # expecting False or the same thing as before
+        Traceback (most recent call last):
+        ...
+        TypeError: cannot determine truth value of Relational
 
-    Any code that explicitly relies on this latter functionality will not be
-    robust as this behaviour is completely wrong and will be corrected at some
-    point.  For the time being (circa Jan 2012), use And to create chained
-    inequalities.
+        The solution for this case is to wrap literal relationals in
+        parentheses:
+
+        >>> e == (x < 1)
+        True
+        >>> e != (x < 1)
+        False
+        >>> (x < 1) != (x < 1)
+        False
+
+    The third gotcha involves chained inequalities not involving
+    '==' or '!='. Occasionally, one may be tempted to write:
+
+        >>> e = x < y < z
+        Traceback (most recent call last):
+        ...
+        TypeError: symbolic boolean expression has no truth value.
+
+        Due to an implementation detail or decision of Python [1]_,
+        there is no way for SymPy to create a chained inequality with
+        that syntax so one must use And:
+
+        >>> e = And(x < y, y < z)
+        >>> type( e )
+        And
+        >>> e
+        (x < y) & (y < z)
+
+        Although this can also be done with the '&' operator, it cannot
+        be done with the 'and' operarator:
+
+        >>> (x < y) & (y < z)
+        (x < y) & (y < z)
+        >>> (x < y) and (y < z)
+        Traceback (most recent call last):
+        ...
+        TypeError: cannot determine truth value of Relational
 
     .. [1] This implementation detail is that Python provides no reliable
-       method to determine that a chained inequality is being built.  Chained
-       comparison operators are evaluated pairwise, using "and" logic (see
-       http://docs.python.org/2/reference/expressions.html#notin).  This is done
-       in an efficient way, so that each object being compared is only
-       evaluated once and the comparison can short-circuit.  For example, ``1
-       > 2 > 3`` is evaluated by Python as ``(1 > 2) and (2 > 3)``.  The
-       ``and`` operator coerces each side into a bool, returning the object
-       itself when it short-circuits.  The bool of the --Than operators
-       will raise TypeError on purpose, because SymPy cannot determine the
-       mathematical ordering of symbolic expressions.  Thus, if we were to
-       compute ``x > y > z``, with ``x``, ``y``, and ``z`` being Symbols,
-       Python converts the statement (roughly) into these steps:
+       method to determine that a chained inequality is being built.
+       Chained comparison operators are evaluated pairwise, using "and"
+       logic (see
+       http://docs.python.org/2/reference/expressions.html#notin). This
+       is done in an efficient way, so that each object being compared
+       is only evaluated once and the comparison can short-circuit. For
+       example, ``1 > 2 > 3`` is evaluated by Python as ``(1 > 2) and (2
+       > 3)``. The ``and`` operator coerces each side into a bool,
+       returning the object itself when it short-circuits. The bool of
+       the --Than operators will raise TypeError on purpose, because
+       SymPy cannot determine the mathematical ordering of symbolic
+       expressions. Thus, if we were to compute ``x > y > z``, with
+       ``x``, ``y``, and ``z`` being Symbols, Python converts the
+       statement (roughly) into these steps:
 
         (1) x > y > z
         (2) (x > y) and (y > z)
@@ -782,14 +776,6 @@ class GreaterThan(_Greater):
            control how it short circuits, so it is impossible to make something
            like ``x > y > z`` work.  There was a PEP to change this,
            :pep:`335`, but it was officially closed in March, 2012.
-
-    .. [2] For more information, see these two bug reports:
-
-       "Separate boolean and symbolic relationals"
-       `Issue 4986 <https://github.com/sympy/sympy/issues/4986>`_
-
-       "It right 0 < x < 1 ?"
-       `Issue 6059 <https://github.com/sympy/sympy/issues/6059>`_
 
     """
     __slots__ = ()

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -235,6 +235,10 @@ class Relational(Boolean, Expr, EvalfMixin):
 
         return solve_univariate_inequality(self, sym, relational=False)
 
+    @property
+    def binary_symbols(self):
+        # override where necessary
+        return set()
 
 Rel = Relational
 
@@ -381,6 +385,15 @@ class Equality(Relational):
     def _eval_relation(cls, lhs, rhs):
         return _sympify(lhs == rhs)
 
+    @property
+    def binary_symbols(self):
+        if S.true in self.args or S.false in self.args:
+            if self.lhs.is_Symbol:
+                return set([self.lhs])
+            elif self.rhs.is_Symbol:
+                return set([self.rhs])
+        return set()
+
 Eq = Equality
 
 
@@ -434,6 +447,15 @@ class Unequality(Relational):
     @classmethod
     def _eval_relation(cls, lhs, rhs):
         return _sympify(lhs != rhs)
+
+    @property
+    def binary_symbols(self):
+        if S.true in self.args or S.false in self.args:
+            if self.lhs.is_Symbol:
+                return set([self.lhs])
+            elif self.rhs.is_Symbol:
+                return set([self.rhs])
+        return set()
 
 Ne = Unequality
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -288,6 +288,9 @@ class Symbol(AtomicExpr, Boolean):
 
     binary_symbols = free_symbols  # in this case, not always
 
+    def as_set(self):
+        return S.UniversalSet
+
 
 class Dummy(Symbol):
     """Dummy symbols are each unique, even if they have the same name:

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -286,6 +286,8 @@ class Symbol(AtomicExpr, Boolean):
     def free_symbols(self):
         return {self}
 
+    binary_symbols = free_symbols  # in this case, not always
+
 
 class Dummy(Symbol):
     """Dummy symbols are each unique, even if they have the same name:

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2125,7 +2125,7 @@ def test_sympy__liealgebras__type_g__TypeG():
 
 def test_sympy__logic__boolalg__And():
     from sympy.logic.boolalg import And
-    assert _test_args(And(x, y, 2))
+    assert _test_args(And(x, y, 1))
 
 
 @SKIP("abstract class")
@@ -2156,7 +2156,7 @@ def test_sympy__logic__boolalg__Equivalent():
 
 def test_sympy__logic__boolalg__ITE():
     from sympy.logic.boolalg import ITE
-    assert _test_args(ITE(x, y, 2))
+    assert _test_args(ITE(x, y, 1))
 
 
 def test_sympy__logic__boolalg__Implies():
@@ -2166,7 +2166,7 @@ def test_sympy__logic__boolalg__Implies():
 
 def test_sympy__logic__boolalg__Nand():
     from sympy.logic.boolalg import Nand
-    assert _test_args(Nand(x, y, 2))
+    assert _test_args(Nand(x, y, 1))
 
 
 def test_sympy__logic__boolalg__Nor():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -87,7 +87,9 @@ def _test_args(obj):
 
 def test_sympy__assumptions__assume__AppliedPredicate():
     from sympy.assumptions.assume import AppliedPredicate, Predicate
+    from sympy import Q
     assert _test_args(AppliedPredicate(Predicate("test"), 2))
+    assert _test_args(Q.is_true(True))
 
 def test_sympy__assumptions__assume__Predicate():
     from sympy.assumptions.assume import Predicate

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -4,12 +4,12 @@ of Basic or Atom."""
 import collections
 import sys
 
-from sympy.core.basic import Basic, Atom, preorder_traversal
+from sympy.core.basic import Basic, Atom, preorder_traversal, as_Basic
 from sympy.core.singleton import S, Singleton
 from sympy.core.symbol import symbols
 from sympy.core.compatibility import default_sort_key, with_metaclass
 
-from sympy import sin, Lambda, Q, cos, gamma
+from sympy import sin, Lambda, Q, cos, gamma, Tuple
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.functions.elementary.piecewise import Piecewise
@@ -267,3 +267,9 @@ def test_literal_evalf_is_number_is_zero_is_comparable():
     assert n.is_comparable is False
     assert n.n(2).is_comparable is False
     assert n.n(2).n(2).is_comparable
+
+
+def test_as_Basic():
+    assert as_Basic(1) is S.One
+    assert as_Basic(()) == Tuple()
+    raises(TypeError, lambda: as_Basic([]))

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -1,6 +1,6 @@
 from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
     count_ops, S, And, I, pi, Eq, Or, Not, Xor, Nand, Nor, Implies, \
-    Equivalent, MatrixSymbol, Symbol, ITE
+    Equivalent, MatrixSymbol, Symbol, ITE, Rel
 from sympy.core.containers import Tuple
 
 x, y, z = symbols('x,y,z')
@@ -16,6 +16,7 @@ def test_count_ops_non_visual():
     assert count(x + y*x + 2*y) == 4
     assert count({x + y: x}) == 1
     assert count({x + y: S(2) + x}) is not S.One
+    assert count(x < y) == 1
     assert count(Or(x,y)) == 1
     assert count(And(x,y)) == 1
     assert count(Not(x)) == 1
@@ -32,6 +33,7 @@ def test_count_ops_visual():
     ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(
         'Add Mul Pow sin cos exp And Derivative Integral'.upper())
     DIV, SUB, NEG = symbols('DIV SUB NEG')
+    LT, LE, GT, GE, EQ, NE = symbols('LT LE GT GE EQ NE')
     NOT, OR, AND, XOR, IMPLIES, EQUIVALENT, ITE, BASIC, TUPLE = symbols(
         'Not Or And Xor Implies Equivalent ITE Basic Tuple'.upper())
 
@@ -95,6 +97,8 @@ def test_count_ops_visual():
     assert count(Basic()) == 0
     assert count(Basic(Basic(),Basic(x,x+y))) == ADD + 2*BASIC
     assert count(Basic(x, x + y)) == ADD + BASIC
+    assert [count(Rel(x, y, op)) for op in '< <= > >= == <> !='.split()
+        ] == [LT, LE, GT, GE, EQ, NE, NE]
     assert count(Or(x, y)) == OR
     assert count(And(x, y)) == AND
     assert count(Or(x, Or(y, And(z, a)))) == AND + OR
@@ -110,7 +114,7 @@ def test_count_ops_visual():
     assert count(Basic(Tuple(x))) == BASIC + TUPLE
     #It checks that TUPLE is counted as an operation.
 
-    assert count(Eq(x + y, S(2))) == ADD
+    assert count(Eq(x + y, S(2))) == ADD + EQ
 
 
 def test_issue_9324():

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -95,17 +95,17 @@ def test_count_ops_visual():
     assert count(Basic()) == 0
     assert count(Basic(Basic(),Basic(x,x+y))) == ADD + 2*BASIC
     assert count(Basic(x, x + y)) == ADD + BASIC
-    assert count(Or(x,y)) == OR
-    assert count(And(x,y)) == AND
-    assert count(And(x**y,z)) == AND + POW
-    assert count(Or(x,Or(y,And(z,a)))) == AND + OR
-    assert count(Nor(x,y)) == NOT + OR
-    assert count(Nand(x,y)) == NOT + AND
-    assert count(Xor(x,y)) == XOR
-    assert count(Implies(x,y)) == IMPLIES
-    assert count(Equivalent(x,y)) == EQUIVALENT
-    assert count(ITE(x,y,z)) == ITE
-    assert count([Or(x,y), And(x,y), Basic(x+y)]) == ADD + AND + BASIC + OR
+    assert count(Or(x, y)) == OR
+    assert count(And(x, y)) == AND
+    assert count(Or(x, Or(y, And(z, a)))) == AND + OR
+    assert count(Nor(x, y)) == NOT + OR
+    assert count(Nand(x, y)) == NOT + AND
+    assert count(Xor(x, y)) == XOR
+    assert count(Implies(x, y)) == IMPLIES
+    assert count(Equivalent(x, y)) == EQUIVALENT
+    assert count(ITE(x, y, z)) == ITE
+    assert count([Or(x, y), And(x, y), Basic(x + y)]
+        ) == ADD + AND + BASIC + OR
 
     assert count(Basic(Tuple(x))) == BASIC + TUPLE
     #It checks that TUPLE is counted as an operation.

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -587,11 +587,17 @@ def test_issue_8449():
 
 def test_simplify():
     assert simplify(x*(y + 1) - x*y - x + 1 < x) == (x > 1)
-    r = S(1) < -x
-    # until relationals have an _eval_simplify method
-    # if there is no simplification to do on either side
-    # the only the canonical form is returned
-    assert simplify(r) == r.canonical
+    r = S(1) < x
+    # canonical operations are not the same as simplification,
+    # so if there is no simplification, canonicalization will
+    # not be done
+    assert simplify(r) != r.canonical
+    # this is not a random test; in _eval_simplify
+    # this will simplify to S.false and that is the
+    # reason for the 'if r.is_Relational' in Relational's
+    # _eval_simplify routine
+    assert simplify(-(2**(3*pi/2) + 6**pi)**(1/pi) +
+        2*(2**(pi/2) + 3**pi)**(1/pi) < 0) is S.false
 
 
 def test_equals():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -715,3 +715,13 @@ def test_issue_10927():
     x = symbols('x')
     assert str(Eq(x, oo)) == 'Eq(x, oo)'
     assert str(Eq(x, -oo)) == 'Eq(x, -oo)'
+
+
+def test_binary_symbols():
+    ans = set([x])
+    for f in Eq, Ne:
+        for t in S.true, S.false:
+            eq = f(x, S.true)
+            assert eq.binary_symbols == ans
+            assert eq.reversed.binary_symbols == ans
+        assert f(x, 1).binary_symbols == set()

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -590,8 +590,9 @@ def test_simplify():
     r = S(1) < x
     # canonical operations are not the same as simplification,
     # so if there is no simplification, canonicalization will
-    # not be done
-    assert simplify(r) != r.canonical
+    # be done unless the measure forbids it
+    assert simplify(r) == r.canonical
+    assert simplify(r, ratio=0) != r.canonical
     # this is not a random test; in _eval_simplify
     # this will simplify to S.false and that is the
     # reason for the 'if r.is_Relational' in Relational's

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -726,3 +726,14 @@ def test_binary_symbols():
             assert eq.binary_symbols == ans
             assert eq.reversed.binary_symbols == ans
         assert f(x, 1).binary_symbols == set()
+
+
+def test_rel_args():
+    # can't have Boolean args; this is automatic with Python 3
+    # so this test and the __lt__, etc..., definitions in
+    # relational.py and boolalg.py which are marked with ///
+    # can be removed.
+    for op in ['<', '<=', '>', '>=']:
+        for b in (S.true, x < 1, And(x, y)):
+            for v in (0.1, 1, 2**32, t, S(1)):
+                raises(TypeError, lambda: Relational(b, v, op))

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -542,6 +542,24 @@ class Piecewise(Function):
                 pass
 
     def as_expr_set_pairs(self):
+        """Return tuples for each argument of self that give
+        the expression and the interval in which it is valid.
+        If a condition cannot be converted to a set, an error
+        will be raised. The variable of the conditions is
+        assumed to be real; sets of real values are returned.
+
+        Examples
+        ========
+        >>> from sympy import Piecewise
+        >>> from sympy.abc import x
+        >>> Piecewise(
+        ...     (1, x < 2),
+        ...     (2,(x > 0) & (x < 4)),
+        ...     (3, True)).as_expr_set_pairs()
+        [(1, Interval.open(-oo, 2)),
+         (2, Interval.Ropen(2, 4)),
+         (3, Interval(4, oo))]
+        """
         exp_sets = []
         U = S.Reals
         for expr, cond in self.args:

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -534,7 +534,6 @@ def test_piecewise_evaluate():
     assert p != x
     assert p.is_Piecewise
     assert all(isinstance(i, Basic) for i in p.args)
-    assert Piecewise((1, Eq(1, True))).args == ((1, Eq(1, True)),)
 
 
 def test_as_expr_set_pairs():

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -363,7 +363,8 @@ class DiracDelta(Function):
             # I dont know how to handle the case for DiracDelta expressions
             # having arguments with more than one variable.
             raise TypeError(filldedent('''
-                rewrite(SingularityFunction) doesn't support arguments with more that 1 variable.'''))
+                rewrite(SingularityFunction) doesn't support
+                arguments with more that 1 variable.'''))
 
 
     @staticmethod
@@ -608,7 +609,8 @@ class Heaviside(Function):
             # I dont know how to handle the case for Heaviside expressions
             # having arguments with more than one variable.
             raise TypeError(filldedent('''
-                rewrite(SingularityFunction) doesn't support arguments with more that 1 variable.'''))
+                rewrite(SingularityFunction) doesn't
+                support arguments with more that 1 variable.'''))
 
     def _sage_(self):
         import sage.all as sage

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -884,6 +884,7 @@ def test_issue_4527():
         (m*sin(k*x)*cos(m*x)/(k**2 - m**2) -
          k*sin(m*x)*cos(k*x)/(k**2 - m**2), True))
 
+
 def test_issue_4199():
     ypos = Symbol('y', positive=True)
     # TODO: Remove conds='none' below, let the assumption take care of it.

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -167,6 +167,20 @@ class BooleanAtom(Boolean):
     __rmod__ = _noop
     _eval_power = _noop
 
+    # /// drop when Py2 is no longer supported
+    def __lt__(self, other):
+        from sympy.utilities.misc import filldedent
+        raise TypeError(filldedent('''
+            A Boolean argument can only be used in
+            Eq and Ne; all other relationals expect
+            real expressions.
+        '''))
+
+    __le__ = __lt__
+    __gt__ = __lt__
+    __ge__ = __lt__
+    # \\\
+
 
 class BooleanTrue(with_metaclass(Singleton, BooleanAtom)):
     """
@@ -338,6 +352,19 @@ class BooleanFunction(Application, Boolean):
 
     def _eval_simplify(self, ratio, measure):
         return simplify_logic(self)
+
+    # /// drop when Py2 is no longer supported
+    def __lt__(self, other):
+        from sympy.utilities.misc import filldedent
+        raise TypeError(filldedent('''
+            A Boolean argument can only be used in
+            Eq and Ne; all other relationals expect
+            real expressions.
+        '''))
+    __le__ = __lt__
+    __ge__ = __lt__
+    __gt__ = __lt__
+    # \\\
 
     @classmethod
     def binary_check_and_simplify(self, *args):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -242,15 +242,32 @@ class BooleanTrue(with_metaclass(Singleton, BooleanAtom)):
     Examples
     ========
 
-    >>> from sympy import sympify, true, Or
+    >>> from sympy import sympify, true, false, Or
     >>> sympify(True)
     True
-    >>> ~true
-    False
-    >>> ~True
-    -2
-    >>> Or(True, False)
+    >>> _ is True, _ is true
+    (False, True)
+
+    >>> Or(true, false)
     True
+    >>> _ is true
+    True
+
+    Python operators give a boolean result for true but a
+    bitwise result for True
+
+    >>> ~true, ~True
+    (False, -2)
+    >>> true >> true, True >> True
+    (True, 0)
+
+    Python operators give a boolean result for true but a
+    bitwise result for True
+
+    >>> ~true, ~True
+    (False, -2)
+    >>> true >> true, True >> True
+    (True, 0)
 
     See Also
     ========
@@ -296,15 +313,24 @@ class BooleanFalse(with_metaclass(Singleton, BooleanAtom)):
     Examples
     ========
 
-    >>> from sympy import sympify, false, Or, true
+    >>> from sympy import sympify, true, false, Or
     >>> sympify(False)
     False
-    >>> false >> false
+    >>> _ is False, _ is false
+    (False, True)
+
+    >>> Or(true, false)
     True
-    >>> False >> False
-    0
-    >>> Or(True, False)
+    >>> _ is true
     True
+
+    Python operators give a boolean result for false but a
+    bitwise result for False
+
+    >>> ~false, ~False
+    (True, -1)
+    >>> false >> false, False >> False
+    (True, 0)
 
     See Also
     ========

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -455,6 +455,10 @@ class Or(LatticeOp, BooleanFunction):
                                       " implemented for multivariate"
                                       " expressions")
 
+    @property
+    def binary_symbols(self):
+        return set().union(*[i.binary_symbols for i in self.args])
+
 
 class Not(BooleanFunction):
     """

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,8 +1,9 @@
 from __future__ import division
 
 from sympy.assumptions.ask import Q
+from sympy.core.containers import Tuple
 from sympy.core.numbers import oo
-from sympy.core.relational import Equality
+from sympy.core.relational import Equality, Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions import Piecewise
@@ -15,14 +16,14 @@ from sympy.logic.boolalg import (
     eliminate_implications, is_nnf, is_cnf, is_dnf, simplify_logic,
     to_nnf, to_cnf, to_dnf, to_int_repr, bool_map, true, false,
     BooleanAtom, is_literal, term_to_integer, integer_to_term,
-    truth_table)
+    truth_table, as_Boolean)
 
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.utilities import cartes
 
 
-A, B, C, D= symbols('A,B,C,D')
-
+A, B, C, D = symbols('A:D')
+a, b, c, d, e, w, x, y, z = symbols('a:e w:z')
 
 def test_overloading():
     """Test that |, & are overloaded as expected"""
@@ -37,7 +38,6 @@ def test_overloading():
 
 
 def test_And():
-
     assert And() is true
     assert And(A) == A
     assert And(True) is true
@@ -50,8 +50,9 @@ def test_And():
     assert And(True, True, True) is true
     assert And(True, True, A) == A
     assert And(True, False, A) is false
-    assert And(2, A) == A
-    assert And(2, 3) is true
+    assert And(1, A) == A
+    raises(TypeError, lambda: And(2, A))
+    raises(TypeError, lambda: And(A < 2, A))
     assert And(A < 1, A >= 1) is false
     e = A > 1
     assert And(e, e.canonical) == e.canonical
@@ -60,7 +61,6 @@ def test_And():
 
 
 def test_Or():
-
     assert Or() is false
     assert Or(A) == A
     assert Or(True) is true
@@ -73,7 +73,9 @@ def test_Or():
     assert Or(True, False, False) is true
     assert Or(True, False, A) is true
     assert Or(False, False, A) == A
-    assert Or(2, A) is true
+    assert Or(1, A) is true
+    raises(TypeError, lambda: Or(2, A))
+    raises(TypeError, lambda: Or(A < 2, A))
     assert Or(A < 1, A >= 1) is true
     e = A > 1
     assert Or(e, e.canonical) == e
@@ -82,7 +84,6 @@ def test_Or():
 
 
 def test_Xor():
-
     assert Xor() is false
     assert Xor(A) == A
     assert Xor(A, A) is false
@@ -108,7 +109,6 @@ def test_Xor():
 
 
 def test_Not():
-
     raises(TypeError, lambda: Not(True, False))
     assert Not(True) is false
     assert Not(False) is true
@@ -118,7 +118,6 @@ def test_Not():
 
 
 def test_Nand():
-
     assert Nand() is false
     assert Nand(A) == ~A
     assert Nand(True) is false
@@ -134,7 +133,6 @@ def test_Nand():
 
 
 def test_Nor():
-
     assert Nor() is true
     assert Nor(A) == ~A
     assert Nor(True) is false
@@ -149,7 +147,6 @@ def test_Nor():
     assert Nor(True, False, A) is false
 
 def test_Xnor():
-
     assert Xnor() is true
     assert Xnor(A) == ~A
     assert Xnor(A, A) is true
@@ -168,7 +165,6 @@ def test_Xnor():
 
 
 def test_Implies():
-
     raises(ValueError, lambda: Implies(A, B, C))
     assert Implies(True, True) is true
     assert Implies(True, False) is false
@@ -184,7 +180,6 @@ def test_Implies():
 
 
 def test_Equivalent():
-
     assert Equivalent(A, B) == Equivalent(B, A) == Equivalent(A, B, A)
     assert Equivalent() is true
     assert Equivalent(A, A) == Equivalent(A) is true
@@ -210,7 +205,6 @@ def test_equals():
     assert ((A | ~B) & (~A | B)).equals((~A & ~B) | (A & B)) is True
     assert (A >> B).equals(~A >> ~B) is False
     assert (A >> (B >> A)).equals(A >> (C >> A)) is False
-    raises(NotImplementedError, lambda: And(A, A < B).equals(And(A, B > A)))
 
 
 def test_simplification():
@@ -219,7 +213,6 @@ def test_simplification():
     """
     set1 = [[0, 0, 1], [0, 1, 1], [1, 0, 0], [1, 1, 0]]
     set2 = [[0, 0, 0], [0, 1, 0], [1, 0, 1], [1, 1, 1]]
-    from sympy.abc import w, x, y, z
     assert SOPform([x, y, z], set1) == Or(And(Not(x), z), And(Not(z), x))
     assert Not(SOPform([x, y, z], set2)) == Not(Or(And(Not(x), Not(z)), And(x, z)))
     assert POSform([x, y, z], set1 + set2) is true
@@ -242,13 +235,14 @@ def test_simplification():
     assert simplify_logic(Equivalent(A, B)) == \
            Or(And(A, B), And(Not(A), Not(B)))
     assert simplify_logic(And(Equality(A, 2), C)) == And(Equality(A, 2), C)
+    assert simplify_logic(And(Equality(A, 2), A)) is S.false
     assert simplify_logic(And(Equality(A, 2), A)) == And(Equality(A, 2), A)
     assert simplify_logic(And(Equality(A, B), C)) == And(Equality(A, B), C)
     assert simplify_logic(Or(And(Equality(A, 3), B), And(Equality(A, 3), C))) \
            == And(Equality(A, 3), Or(B, C))
-    e = And(A, x**2 - x)
-    assert simplify_logic(e) == And(A, x*(x - 1))
-    assert simplify_logic(e, deep=False) == e
+    b = (~x & ~y & ~z) | ( ~x & ~y & z)
+    e = And(A, b)
+    assert simplify_logic(e) == A & ~x & ~y
 
     # check input
     ans = SOPform([x, y], [[1, 0]])
@@ -278,7 +272,6 @@ def test_bool_map():
 
     minterms = [[0, 0, 0, 1], [0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1],
         [1, 1, 1, 1]]
-    from sympy.abc import a, b, c, w, x, y, z
     assert bool_map(Not(Not(a)), a) == (a, {a: a})
     assert bool_map(SOPform([w, x, y, z], minterms),
         POSform([w, x, y, z], minterms)) == \
@@ -304,7 +297,6 @@ def test_bool_symbol():
 
 
 def test_is_boolean():
-
     assert true.is_Boolean
     assert (A & B).is_Boolean
     assert (A | B).is_Boolean
@@ -313,7 +305,6 @@ def test_is_boolean():
 
 
 def test_subs():
-
     assert (A & B).subs(A, True) == B
     assert (A & B).subs(A, False) is false
     assert (A & B).subs(B, True) == A
@@ -346,7 +337,6 @@ def test_and_associativity():
 
 
 def test_or_assicativity():
-
     assert ((A | B) | C) == (A | (B | C))
 
 
@@ -358,7 +348,6 @@ def test_double_negation():
 # test methods
 
 def test_eliminate_implications():
-    from sympy.abc import A, B, C, D
     assert eliminate_implications(Implies(A, B, evaluate=False)) == (~A) | B
     assert eliminate_implications(
         A >> (C >> Not(B))) == Or(Or(Not(B), Not(C)), Not(A))
@@ -383,7 +372,6 @@ def test_disjuncts():
 
 
 def test_distribute():
-
     assert distribute_and_over_or(Or(And(A, B), C)) == And(Or(A, C), Or(B, C))
     assert distribute_or_over_and(And(A, Or(B, C))) == Or(And(A, B), And(A, C))
 
@@ -409,10 +397,14 @@ def test_to_nnf():
     assert to_nnf((A >> B) ^ (B >> A)) == (A & ~B) | (~A & B)
     assert to_nnf((A >> B) ^ (B >> A), False) == \
             (~A | ~B | A | B) & ((A & ~B) | (~A & B))
+    assert ITE(A, 1, 0).to_nnf() == A
+    assert ITE(A, 0, 1).to_nnf() == ~A
+    # although ITE can hold non-Boolean, it will complain if
+    # an attempt is made to convert the ITE to Boolean nnf
+    raises(TypeError, lambda: ITE(A < 1, [1], B).to_nnf())
 
 
 def test_to_cnf():
-
     assert to_cnf(~(B | C)) == And(Not(B), Not(C))
     assert to_cnf((A & B) | C) == And(Or(A, C), Or(B, C))
     assert to_cnf(A >> B) == (~A) | B
@@ -427,7 +419,6 @@ def test_to_cnf():
 
 
 def test_to_dnf():
-
     assert to_dnf(~(B | C)) == And(Not(B), Not(C))
     assert to_dnf(A & (B | C)) == Or(And(A, B), And(A, C))
     assert to_dnf(A >> B) == (~A) | B
@@ -455,7 +446,6 @@ def test_to_int_repr():
 
 
 def test_is_nnf():
-    from sympy.abc import A, B
     assert is_nnf(true) is True
     assert is_nnf(A) is True
     assert is_nnf(~A) is True
@@ -468,7 +458,6 @@ def test_is_nnf():
 
 
 def test_is_cnf():
-    x, y, z = symbols('x,y,z')
     assert is_cnf(x) is True
     assert is_cnf(x | y | z) is True
     assert is_cnf(x & y & z) is True
@@ -477,7 +466,6 @@ def test_is_cnf():
 
 
 def test_is_dnf():
-    x, y, z = symbols('x,y,z')
     assert is_dnf(x) is True
     assert is_dnf(x | y | z) is True
     assert is_dnf(x & y & z) is True
@@ -486,8 +474,7 @@ def test_is_dnf():
 
 
 def test_ITE():
-    A, B, C = map(Boolean, symbols('A,B,C'))
-
+    A, B, C = symbols('A:C')
     assert ITE(True, False, True) is false
     assert ITE(True, True, False) is true
     assert ITE(False, True, False) is false
@@ -501,19 +488,31 @@ def test_ITE():
     B = True
     assert ITE(And(A, B), B, C) == C
     assert ITE(Or(A, False), And(B, True), False) is false
-    x = symbols('x')
     assert ITE(x, A, B) == Not(x)
     assert ITE(x, B, A) == x
+    assert ITE(1, x, y) == x
+    assert ITE(0, x, y) == y
+    raises(TypeError, lambda: ITE(2, x, y))
+    raises(TypeError, lambda: ITE(1, [], y))
+    raises(TypeError, lambda: ITE(1, (), y))
+    raises(TypeError, lambda: ITE(1, y, []))
+    assert ITE(1, 1, 1) is S.true
+    assert isinstance(ITE(1, 1, 1, evaluate=False), ITE)
 
-def test_ITE_rewrite_Piecewise():
-
-    assert ITE(A, B, C).rewrite(Piecewise) == Piecewise((B, A), (C, True))
-
-
-def test_ITE_diff():
-    # analogous to Piecewise.diff
-    x = symbols('x')
-    assert ITE(x > 0, x**2, x).diff(x) == ITE(x > 0, 2*x, 1)
+    raises(TypeError, lambda: ITE(x > 1, y, x))
+    assert ITE(Eq(x, True), y, x) == ITE(x, y, x)
+    assert ITE(Eq(x, False), y, x) == ITE(~x, y, x)
+    assert ITE(Ne(x, True), y, x) == ITE(~x, y, x)
+    assert ITE(Ne(x, False), y, x) == ITE(x, y, x)
+    # 0 and 1 in the context are not treated as True/False
+    # so the equality must always be False since dissimilar
+    # objects cannot be equal
+    assert ITE(Eq(x, 0), y, x) == x
+    assert ITE(Eq(x, 1), y, x) == x
+    assert ITE(Ne(x, 0), y, x) == y
+    assert ITE(Ne(x, 1), y, x) == y
+    assert ITE(Eq(x, 0), y, z).subs(x, 0) == y
+    assert ITE(Eq(x, 0), y, z).subs(x, 1) == z
 
 
 def test_is_literal():
@@ -548,8 +547,6 @@ def test_operators():
 
 
 def test_true_false():
-    x = symbols('x')
-
     assert true is S.true
     assert false is S.false
     assert true is not True
@@ -684,8 +681,6 @@ def test_true_false():
 
 
 def test_bool_as_set():
-    x = symbols('x')
-
     assert And(x <= 2, x >= -2).as_set() == Interval(-2, 2)
     assert Or(x >= 2, x <= -2).as_set() == Interval(-oo, -2) + Interval(2, oo)
     assert Not(x > 2).as_set() == Interval(-oo, 2)
@@ -694,6 +689,7 @@ def test_bool_as_set():
         Union(Interval(-oo,2),Interval(3,oo))
     assert true.as_set() == S.UniversalSet
     assert false.as_set() == EmptySet()
+    assert x.as_set() == S.UniversalSet
 
 
 @XFAIL
@@ -726,7 +722,6 @@ def test_canonical_atoms():
 
 
 def test_issue_8777():
-    x = symbols('x')
     assert And(x > 2, x < oo).as_set() == Interval(2, oo, left_open=True)
     assert And(x >= 1, x < oo).as_set() == Interval(1, oo)
     assert (x < oo).as_set() == Interval(-oo, oo)
@@ -734,7 +729,6 @@ def test_issue_8777():
 
 
 def test_issue_8975():
-    x = symbols('x')
     assert Or(And(-oo < x, x <= -2), And(2 <= x, x < oo)).as_set() == \
         Interval(-oo, -2) + Interval(2, oo)
 
@@ -751,14 +745,12 @@ def test_integer_to_term():
 
 
 def test_truth_table():
-    x, y = symbols('x,y')
     assert list(truth_table(And(x, y), [x, y], input=False)) == [False, False, False, True]
     assert list(truth_table(x | y, [x, y], input=False)) == [False, True, True, True]
     assert list(truth_table(x >> y, [x, y], input=False)) == [True, True, False, True]
 
 
 def test_issue_8571():
-    x = symbols('x')
     for t in (S.true, S.false):
         raises(TypeError, lambda: +t)
         raises(TypeError, lambda: -t)
@@ -785,6 +777,38 @@ def test_expand_relational():
     assert r.expand() is S.false
     assert (q > 0).expand() is S.true
 
+
 def test_issue_12717():
     assert S.true.is_Atom == True
     assert S.false.is_Atom == True
+
+
+def test_as_Boolean():
+    nz = symbols('nz', nonzero=True)
+    assert all(as_Boolean(i) is S.true for i in (True, S.true, 1, nz))
+    z = symbols('z', zero=True)
+    assert all(as_Boolean(i) is S.false for i in (False, S.false, 0, z))
+    assert all(as_Boolean(i) == i for i in (x, x < 0))
+    for i in (2, S(2), x + 1, []):
+        raises(TypeError, lambda: as_Boolean(i))
+
+
+def test_binary_symbols():
+    assert ITE(x < 1, y, z).binary_symbols == set((y, z))
+    for f in (Eq, Ne):
+        assert f(x, 1).binary_symbols == set()
+        assert f(x, True).binary_symbols == set([x])
+        assert f(x, False).binary_symbols == set([x])
+    assert S.true.binary_symbols == set()
+    assert S.false.binary_symbols == set()
+    assert x.binary_symbols == set([x])
+    assert And(x, Eq(y, False), Eq(z, 1)).binary_symbols == set([x, y])
+    assert Q.prime(x).binary_symbols == set()
+    assert Q.is_true(x < 1).binary_symbols == set()
+    assert Q.is_true(x).binary_symbols == set([x])
+    assert Q.is_true(Eq(x, True)).binary_symbols == set([x])
+    assert Q.prime(x).binary_symbols == set()
+
+
+def test_BooleanFunction_diff():
+    assert And(x, y).diff(x) == Piecewise((0, Eq(False, y)), (1, True))

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -7,6 +7,7 @@ from sympy.core.relational import Equality, Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions import Piecewise
+from sympy.functions.elementary.trigonometric import sin
 from sympy.sets.sets import (EmptySet, Interval, Union)
 from sympy.simplify.simplify import simplify
 from sympy.logic.boolalg import (
@@ -681,6 +682,7 @@ def test_true_false():
 
 
 def test_bool_as_set():
+    assert ITE(y <= 0, False, y >= 1).as_set() == Interval(1, oo)
     assert And(x <= 2, x >= -2).as_set() == Interval(-2, 2)
     assert Or(x >= 2, x <= -2).as_set() == Interval(-oo, -2) + Interval(2, oo)
     assert Not(x > 2).as_set() == Interval(-oo, 2)
@@ -690,6 +692,10 @@ def test_bool_as_set():
     assert true.as_set() == S.UniversalSet
     assert false.as_set() == EmptySet()
     assert x.as_set() == S.UniversalSet
+    assert And(Or(x < 1, x > 3), x < 2
+        ).as_set() == Interval.open(-oo, 1)
+    assert And(x < 1, sin(x) < 3).as_set() == (x < 1).as_set()
+    raises(NotImplementedError, lambda: (sin(x) < 1).as_set())
 
 
 @XFAIL

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1018,6 +1018,10 @@ class PrettyPrinter(Printer):
         D.binding = prettyForm.OPEN
         return D
 
+    def _print_ITE(self, ite):
+        from sympy.functions.elementary.piecewise import Piecewise
+        return self._print(ite.rewrite(Piecewise))
+
     def _hprint_vec(self, v):
         D = None
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6,7 +6,7 @@ from sympy import (
     Pow, Product, QQ, RR, Rational, Ray, rootof, RootSum, S,
     Segment, Subs, Sum, Symbol, Tuple, Trace, Xor, ZZ, conjugate,
     groebner, oo, pi, symbols, ilex, grlex, Range, Contains,
-    SeqPer, SeqFormula, SeqAdd, SeqMul, fourier_series, fps,
+    SeqPer, SeqFormula, SeqAdd, SeqMul, fourier_series, fps, ITE,
     Complement, Interval, Intersection, Union, EulerGamma, GoldenRatio)
 from sympy.core.expr import UnevaluatedExpr
 
@@ -164,6 +164,9 @@ PIECEWISE:
 
 Piecewise((x,x<1),(x**2,True))
 
+ITE:
+
+ITE(x, y, z)
 
 SEQUENCES (TUPLES, LISTS, DICTIONARIES):
 
@@ -3196,6 +3199,21 @@ u("""\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
+
+
+def test_pretty_ITE():
+    expr = ITE(x, y, z)
+    assert pretty(expr) == (
+        '/y    for x  \n'
+        '<            \n'
+        '\\z  otherwise'
+        )
+    assert upretty(expr) == u("""\
+⎧y    for x  \n\
+⎨            \n\
+⎩z  otherwise\
+""")
+
 
 def test_pretty_seq():
     expr = ()

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -86,8 +86,9 @@ class RCodePrinter(CodePrinter):
         'reserved_word_suffix': '_',
     }
     _operators = {
-       'and':'&',
+       'and': '&',
         'or': '|',
+       'not': '!',
     }
 
     _relationals = {

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -251,13 +251,13 @@ def test_ccode_Piecewise_deep():
 
 
 def test_ccode_ITE():
-    expr = ITE(x < 1, x, x**2)
+    expr = ITE(x < 1, y, z)
     assert ccode(expr) == (
             "((x < 1) ? (\n"
-            "   x\n"
+            "   y\n"
             ")\n"
             ": (\n"
-            "   pow(x, 2)\n"
+            "   z\n"
             "))")
 
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -1,5 +1,5 @@
 import warnings
-from sympy.core import (pi, oo, symbols, Rational, Integer, Float,
+from sympy.core import (S, pi, oo, symbols, Rational, Integer, Float,
                         GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq, nan)
 from sympy.functions import (Abs, acos, acosh, asin, asinh, atan, atanh, atan2,
                              ceiling, cos, cosh, erf, erfc, exp, floor, gamma, log,
@@ -144,6 +144,10 @@ def test_ccode_user_functions():
 
 
 def test_ccode_boolean():
+    assert ccode(True) == "true"
+    assert ccode(S.true) == "true"
+    assert ccode(False) == "false"
+    assert ccode(S.false) == "false"
     assert ccode(x & y) == "x && y"
     assert ccode(x | y) == "x || y"
     assert ccode(~x) == "!x"

--- a/sympy/printing/tests/test_rcode.py
+++ b/sympy/printing/tests/test_rcode.py
@@ -1,4 +1,4 @@
-from sympy.core import (pi, oo, Symbol, symbols, Rational, Integer,
+from sympy.core import (S, pi, oo, Symbol, symbols, Rational, Integer,
                         GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq)
 from sympy.functions import (Piecewise, sin, cos, Abs, exp, ceiling, sqrt,
                              gamma, sign, Max)
@@ -122,8 +122,13 @@ def test_rcode_user_functions():
 
 
 def test_rcode_boolean():
+    assert rcode(True) == "True"
+    assert rcode(S.true) == "True"
+    assert rcode(False) == "False"
+    assert rcode(S.false) == "False"
     assert rcode(x & y) == "x & y"
     assert rcode(x | y) == "x | y"
+    assert rcode(~x) == "!x"
     assert rcode(x & y & z) == "x & y & z"
     assert rcode(x | y | z) == "x | y | z"
     assert rcode((x & y) | z) == "z | x & y"

--- a/sympy/printing/tests/test_rcode.py
+++ b/sympy/printing/tests/test_rcode.py
@@ -188,9 +188,9 @@ def test_rcode_Piecewise_deep():
 
 
 def test_rcode_ITE():
-    expr = ITE(x < 1, x, x**2)
+    expr = ITE(x < 1, y, z)
     p = rcode(expr)
-    ref="ifelse(x < 1,x,x^2)"
+    ref="ifelse(x < 1,y,z)"
     assert p == ref
 
 

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -182,12 +182,12 @@ def test_reserved_words():
 
 
 def test_ITE():
-    expr = ITE(x < 1, x, x + 2)
+    expr = ITE(x < 1, y, z)
     assert rust_code(expr) == (
             "if (x < 1) {\n"
-            "    x\n"
+            "    y\n"
             "} else {\n"
-            "    x + 2\n"
+            "    z\n"
             "}")
 
 

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -46,3 +46,6 @@ class Contains(BooleanFunction):
             for i in self.args[1].args
             if i.is_Boolean or i.is_Symbol or
             isinstance(i, (Eq, Ne))])
+
+    def as_set(self):
+        return self

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic
+from sympy.core.relational import Eq, Ne
 from sympy.logic.boolalg import BooleanFunction
 
 
@@ -38,3 +39,10 @@ class Contains(BooleanFunction):
         ret = S.contains(x)
         if not isinstance(ret, Contains):
             return ret
+
+    @property
+    def binary_symbols(self):
+        return set().union(*[i.binary_symbols
+            for i in self.args[1].args
+            if i.is_Boolean or i.is_Symbol or
+            isinstance(i, (Eq, Ne))])

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -14,7 +14,7 @@ from sympy.core.compatibility import (iterable, with_metaclass,
 from sympy.core.evaluate import global_evaluate
 from sympy.core.function import FunctionClass
 from sympy.core.mul import Mul
-from sympy.core.relational import Eq
+from sympy.core.relational import Eq, Ne
 from sympy.core.symbol import Symbol, Dummy, _uniquely_named_symbol
 from sympy.sets.contains import Contains
 from sympy.utilities.misc import func_name, filldedent
@@ -1406,6 +1406,11 @@ class Union(Set, EvalfMixin):
 
     def as_relational(self, symbol):
         """Rewrite a Union in terms of equalities and logic operators. """
+        if len(self.args) == 2:
+            a, b = self.args
+            if (a.sup == b.inf and a.inf is S.NegativeInfinity
+                    and b.sup is S.Infinity):
+                return And(Ne(symbol, a.sup), symbol < b.sup, symbol > a.inf)
         return Or(*[set.as_relational(symbol) for set in self.args])
 
     @property

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -2000,12 +2000,12 @@ class FiniteSet(Set, EvalfMixin):
         """
         r = false
         for e in self._elements:
+            # override global evaluation so we can use Eq to do
+            # do the evaluation
             t = Eq(e, other, evaluate=True)
-            if isinstance(t, Eq):
-                t = t.simplify()
-            if t == true:
+            if t is true:
                 return t
-            elif t != false:
+            elif t is not false:
                 r = None
         return r
 

--- a/sympy/sets/tests/test_contains.py
+++ b/sympy/sets/tests/test_contains.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, Contains, S, Interval, FiniteSet, oo
+from sympy import Symbol, Contains, S, Interval, FiniteSet, oo, Eq
 
 
 def test_contains_basic():

--- a/sympy/sets/tests/test_contains.py
+++ b/sympy/sets/tests/test_contains.py
@@ -20,3 +20,18 @@ def test_issue_6194():
 def test_issue_10326():
     assert Contains(oo, Interval(-oo, oo)) == False
     assert Contains(-oo, Interval(-oo, oo)) == False
+
+
+def test_binary_symbols():
+    x = Symbol('x')
+    y = Symbol('y')
+    z = Symbol('z')
+    assert Contains(x, FiniteSet(y, Eq(z, True))
+        ).binary_symbols == set([y, z])
+
+
+def test_as_set():
+    x = Symbol('x')
+    y = Symbol('y')
+    assert Contains(x, FiniteSet(y)
+        ).as_set() == Contains(x, FiniteSet(y))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -634,9 +634,9 @@ def test_issue_7001():
 def test_inequality_no_auto_simplify():
     # no simplify on creation but can be simplified
     lhs = cos(x)**2 + sin(x)**2
-    rhs = 2;
-    e = Lt(lhs, rhs)
-    assert e == Lt(lhs, rhs, evaluate=False)
+    rhs = 2
+    e = Lt(lhs, rhs, evaluate=False)
+    assert e is not S.true
     assert simplify(e)
 
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2319,12 +2319,12 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
     This function returns a tuple.  The first item in the tuple is ``True`` if
     the substitution results in ``0``, and ``False`` otherwise. The second
     item in the tuple is what the substitution results in.  It should always
-    be ``0`` if the first item is ``True``. Note that sometimes this function
-    will ``False``, but with an expression that is identically equal to ``0``,
-    instead of returning ``True``.  This is because
-    :py:meth:`~sympy.simplify.simplify.simplify` cannot reduce the expression
-    to ``0``.  If an expression returned by this function vanishes
-    identically, then ``sol`` really is a solution to ``ode``.
+    be ``0`` if the first item is ``True``. Sometimes this function will
+    return ``False`` even when an expression is identically equal to ``0``.
+    This happens when :py:meth:`~sympy.simplify.simplify.simplify` does not
+    reduce the expression to ``0``.  If an expression returned by this
+    function vanishes identically, then ``sol`` really is a solution to
+    the ``ode``.
 
     If this function seems to hang, it is probably because of a hard
     simplification.

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -245,15 +245,13 @@ def checksol(f, symbol, sol=None, **flags):
     if isinstance(f, Poly):
         f = f.as_expr()
     elif isinstance(f, (Equality, Unequality)):
-        args = f.args
         if f.rhs in (S.true, S.false):
-            args = args[1], args[0]
-        B, E = args
+            f = f.reversed
+        B, E = f.args
         if B in (S.true, S.false):
-            if not (E.is_Symbol or E.is_Relational) and isinstance(E, Expr):
-                # Equality is always false since an expression can never
-                # be a Boolean
-                f = S.false
+            f = f.subs(sol)
+            if f not in (S.true, S.false):
+                return
         else:
             f = Add(f.lhs, -f.rhs, evaluate=False)
 
@@ -936,13 +934,6 @@ def solve(f, *symbols, **flags):
                         return L
                     elif R.is_Boolean and (~R).is_Symbol:
                         return ~L
-                    elif isinstance(R, Expr):
-                        # an expression cannot be a Boolean
-                        raise TypeError(filldedent('''
-                            This equality cannot be solved since
-                            symbols in an Expr cannot take on Boolean
-                            values.
-                        '''))
                     else:
                         raise NotImplementedError(filldedent('''
                             Unanticipated argument of Eq when other arg

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1003,6 +1003,7 @@ def solvify(f, symbol, domain):
         period = periodicity(f, symbol)
         if period is not None:
             solutions = S.EmptySet
+            iter_solutions = ()
             if isinstance(solution_set, ImageSet):
                 iter_solutions = (solution_set,)
             elif isinstance(solution_set, Union):

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -110,10 +110,10 @@ def test_reduce_poly_inequalities_complex_relational():
         [[Ge(x**2, 0)]], x, relational=True) == And(Lt(-oo, x), Lt(x, oo))
     assert reduce_rational_inequalities(
         [[Gt(x**2, 0)]], x, relational=True) == \
-        And(Or(And(Lt(-oo, x), Lt(x, 0)), And(Lt(0, x), Lt(x, oo))))
+        And(Gt(x, -oo), Lt(x, oo), Ne(x, 0))
     assert reduce_rational_inequalities(
         [[Ne(x**2, 0)]], x, relational=True) == \
-        And(Or(And(Lt(-oo, x), Lt(x, 0)), And(Lt(0, x), Lt(x, oo))))
+        And(Gt(x, -oo), Lt(x, oo), Ne(x, 0))
 
     for one in (S(1), S(1.0)):
         inf = one*oo

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -310,6 +310,10 @@ def test_solve_univariate_inequality():
     raises(NotImplementedError, lambda: isolve(1/(x - y) < 0, x))
     raises(TypeError, lambda: isolve(x - I < 0, x))
 
+    # make sure iter_solutions gets a default value
+    raises(NotImplementedError, lambda: isolve(
+        Eq(cos(x)**2 + sin(x)**2, 1), x))
+
 
 def test_trig_inequalities():
     # all the inequalities are solved in a periodic interval.

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1,6 +1,6 @@
 from sympy import (
     Abs, And, Derivative, Dummy, Eq, Float, Function, Gt, I, Integral,
-    LambertW, Lt, Matrix, Or, Poly, Q, Rational, S, Symbol,
+    LambertW, Lt, Matrix, Or, Poly, Q, Rational, S, Symbol, Ne,
     Wild, acos, asin, atan, atanh, cos, cosh, diff, erf, erfinv, erfc,
     erfcinv, exp, im, log, pi, re, sec, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
@@ -559,6 +559,19 @@ def test_solve_inequalities():
 
     assert solve(sin(x) > S.Half) == And(pi/6 < x, x < 5*pi/6)
 
+    assert solve(Eq(False, x < 1)) == (S(1) <= x) & (x < oo)
+    assert solve(Eq(True, x < 1)) == (-oo < x) & (x < 1)
+    assert solve(Eq(x < 1, False)) == (S(1) <= x) & (x < oo)
+    assert solve(Eq(x < 1, True)) == (-oo < x) & (x < 1)
+
+    assert solve(Eq(False, x)) == False
+    assert solve(Eq(True, x)) == True
+    assert solve(Eq(False, ~x)) == True
+    assert solve(Eq(True, ~x)) == False
+    assert solve(Ne(True, x)) == False
+
+    raises(TypeError, lambda: solve(Eq(x + 1, True)))
+
 
 def test_issue_4793():
     assert solve(1/x) == []
@@ -1078,6 +1091,15 @@ def test_checksol():
     dict_var_soln = {y: - sqrt(r) / sqrt(tan(t)**2 + 1),
                             x: -sqrt(r)*tan(t)/sqrt(tan(t)**2 + 1)}
     assert checksol(eq, dict_var_soln) == True
+    assert checksol(Eq(x, False), {x: False}) is True
+    assert checksol(Ne(x, False), {x: False}) is False
+    assert checksol(Eq(x < 1, True), {x: 0}) is True
+    assert checksol(Eq(x < 1, True), {x: 1}) is False
+    assert checksol(Eq(x < 1, False), {x: 1}) is True
+    assert checksol(Eq(x < 1, False), {x: 0}) is False
+    # expressions are not Booleans
+    assert checksol(Eq(x + 1, False), {x: -1}) is False
+    assert checksol(Eq(x + 1, True), {x: 0}) is False
 
 
 def test__invert():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -570,8 +570,6 @@ def test_solve_inequalities():
     assert solve(Eq(True, ~x)) == False
     assert solve(Ne(True, x)) == False
 
-    raises(TypeError, lambda: solve(Eq(x + 1, True)))
-
 
 def test_issue_4793():
     assert solve(1/x) == []
@@ -1089,7 +1087,7 @@ def test_checksol():
     x, y, r, t = symbols('x, y, r, t')
     eq = r - x**2 - y**2
     dict_var_soln = {y: - sqrt(r) / sqrt(tan(t)**2 + 1),
-                            x: -sqrt(r)*tan(t)/sqrt(tan(t)**2 + 1)}
+        x: -sqrt(r)*tan(t)/sqrt(tan(t)**2 + 1)}
     assert checksol(eq, dict_var_soln) == True
     assert checksol(Eq(x, False), {x: False}) is True
     assert checksol(Ne(x, False), {x: False}) is False
@@ -1097,9 +1095,7 @@ def test_checksol():
     assert checksol(Eq(x < 1, True), {x: 1}) is False
     assert checksol(Eq(x < 1, False), {x: 1}) is True
     assert checksol(Eq(x < 1, False), {x: 0}) is False
-    # expressions are not Booleans
-    assert checksol(Eq(x + 1, False), {x: -1}) is False
-    assert checksol(Eq(x + 1, True), {x: 0}) is False
+    assert checksol(Eq(x + 1, x**2 + 1), {x: 1}) is True
 
 
 def test__invert():

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -224,18 +224,42 @@ def find_executable(executable, path=None):
         return None
 
 
-def func_name(x):
+def func_name(x, short=False):
     '''Return function name of `x` (if defined) else the `type(x)`.
+    If short is True and there is a shorter alias for the result,
+    return the alias.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.misc import func_name
+    >>> from sympy.abc import x
+    >>> func_name(x < 1)
+    'StrictLessThan'
+    >>> func_name(x < 1, short=True)
+    'Lt'
+
     See Also
     ========
     sympy.core.compatibility get_function_name
     '''
+    alias = {
+    'GreaterThan': 'Ge',
+    'StrictGreaterThan': 'Gt',
+    'LessThan': 'Le',
+    'StrictLessThan': 'Lt',
+    'Equality': 'Eq',
+    'Unequality': 'Ne',
+    }
     typ = type(x)
     if str(typ).startswith("<type '"):
         typ = str(typ).split("'")[1].split("'")[0]
     elif str(typ).startswith("<class '"):
         typ = str(typ).split("'")[1].split("'")[0]
-    return getattr(getattr(x, 'func', x), '__name__', typ)
+    rv = getattr(getattr(x, 'func', x), '__name__', typ)
+    if short:
+        rv = alias.get(rv, rv)
+    return rv
 
 
 def _replace(reps):

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -233,6 +233,8 @@ def func_name(x):
     typ = type(x)
     if str(typ).startswith("<type '"):
         typ = str(typ).split("'")[1].split("'")[0]
+    elif str(typ).startswith("<class '"):
+        typ = str(typ).split("'")[1].split("'")[0]
     return getattr(getattr(x, 'func', x), '__name__', typ)
 
 


### PR DESCRIPTION
## Summary of changes

* changes to ExprCondPair
  * expr must be Basic
  * cond must be Boolean or must be able to be reduced to Boolean
  * a cond containing Piecewise will be folded
  * a cond that is a Piecewise (perhaps after folding) will be rewritten as ITE with canonical Relationals
  * a TypeError is raised if the cond is not a Boolean
 * is is used instead of == since ExprCondPair args are Boolean now
* `piecewise_fold` will convert ITE conditions to nnf and simplified if possible
* ITE/And/Or take only Boolean args e.g. `And(x, y)` is okay, `And(2, x + 1, x**2)` is not.
* ITE now pretty prints like Piecewise
* BooleanFunction has a binary_symbols property which returns a set of symbols which can have a boolean/binary value
* as_Basic utility function to return the Basic version of an expression or raise an error if there is none.
* Piecewise._eval_subs is updated to reflect that Piecewise does not contain bool
* `piecewise_fold` now folds the conditions and if the condition (before or after folding) contains Boolean expressions, then it is converted to an unsimplified BooleanFunction.
```
>>> Piecewise((1,Piecewise((x>1,x<3),(x>2,True))))
Piecewise((1, ITE(x < 3, x > 1, x > 2)))
>>> piecewise_fold(_)
Piecewise((1, ((x >= 3) | (x > 1)) & ((x > 2) | (x < 3))))
>>> simplify(_)
Piecewise((1, x > 1))
```
* `as_Boolean` is added to boolalg which behaves like as_Basic
* Boolean gets default `as_set` and `to_nnf` methods
* args of ITE, And and Or must be Boolean (for ITE this required adding a `__new__` definition
* simplify_logic now does simplification of variables before checking if the expression is a BooleanFunction since this may change the input function's type
* Piecewise.rewrite(ITE)  has been added
* conditionals appearing in a solution of a Piecewise function are simplified
* differentiation of Boolean is simply unevaluated for expressions involving relationals in the symbol for which the derivative is requested unless the symbol is a binary symbol
```
>>> (x<1).diff(x)
Derivative(x < 1, x)
>>> And(x<1, x).diff(x)  # result does not depend on whether x is 0 or 1
0
>>> And(x<=1, x).diff(x)  #in this case it does: x =0 gives False while x=1 gives True
1
```
* `func_name` recognizes "<class 'foo'>" when trying to identify `foo`
* PEP8 edits of periodicity tests
* solve and checksol more carefully handle Eq/Ne expressions which have one arg that is True or False; in this case, the other arg must also be a Boolean
* interval solutions from solve are now disabled in Piecewise solving -- when solving for x one should not have x in the solution

(Much of this is split out of #12587)
closes #13223
closes #13255 on which it was built
fixes #13347
fixes #13349 
fixes #13370 
addressed #13350 but doesn't handle case of non-binary symbols; close if master doesn't handle Relationals like `(x**2 < 1).diff(x)`

- [x] check coverage

**REMOVED**
* careful simplification of BooleanFunction is added for univariate expressions
* simplification of complex univariate Relationals has been implemented through the use of sets provided that the involved expressions do not have periodic behavior.
* Relational._eval_simplify has been modified to use the newly added `simplify_relationships` which will try to simplify boolean functions via sets (with care not to add +/-oo when not necessary)
