### PR TITLE
Separate gammasimp from combsimp & Improve combsimp()

### DIFF
--- a/doc/src/tutorial/simplification.rst
+++ b/doc/src/tutorial/simplification.rst
@@ -674,6 +674,7 @@ combsimp
 
 To simplify combinatorial expressions, use ``combsimp()``.
 
+    >>> n, k = symbols('n k', integer = True)
     >>> combsimp(factorial(n)/factorial(n - 3))
     n⋅(n - 2)⋅(n - 1)
     >>> combsimp(binomial(n+1, k+1)/binomial(n, k))
@@ -681,9 +682,13 @@ To simplify combinatorial expressions, use ``combsimp()``.
     ─────
     k + 1
 
-``combsimp()`` also simplifies expressions with ``gamma``.
+gammasimp
+---------
 
-    >>> combsimp(gamma(x)*gamma(1 - x))
+To simplify expressions with gamma functions or combinatorial functions with
+non-integer argument, use ``gammasimp()``.
+
+    >>> gammasimp(gamma(x)*gamma(1 - x))
        π
     ────────
     sin(π⋅x)

--- a/sympy/benchmarks/bench_meijerint.py
+++ b/sympy/benchmarks/bench_meijerint.py
@@ -189,7 +189,7 @@ bench = [
     'integrate(besselj(a,x)*besselj(b,x)/x, (x,0,oo), meijerg=True)',
 
     'hyperexpand(meijerg((-s - a/2 + 1, -s + a/2 + 1), (-a/2 - S(1)/2, -s + a/2 + S(3)/2), (a/2, -a/2), (-a/2 - S(1)/2, -s + a/2 + S(3)/2), 1))',
-    "combsimp(S('2**(2*s)*(-pi*gamma(-a + 1)*gamma(a + 1)*gamma(-a - s + 1)*gamma(-a + s - 1/2)*gamma(a - s + 3/2)*gamma(a + s + 1)/(a*(a + s)) - gamma(-a - 1/2)*gamma(-a + 1)*gamma(a + 1)*gamma(a + 3/2)*gamma(-s + 3/2)*gamma(s - 1/2)*gamma(-a + s + 1)*gamma(a - s + 1)/(a*(-a + s)))*gamma(-2*s + 1)*gamma(s + 1)/(pi*s*gamma(-a - 1/2)*gamma(a + 3/2)*gamma(-s + 1)*gamma(-s + 3/2)*gamma(s - 1/2)*gamma(-a - s + 1)*gamma(-a + s - 1/2)*gamma(a - s + 1)*gamma(a - s + 3/2))'))",
+    "gammasimp(S('2**(2*s)*(-pi*gamma(-a + 1)*gamma(a + 1)*gamma(-a - s + 1)*gamma(-a + s - 1/2)*gamma(a - s + 3/2)*gamma(a + s + 1)/(a*(a + s)) - gamma(-a - 1/2)*gamma(-a + 1)*gamma(a + 1)*gamma(a + 3/2)*gamma(-s + 3/2)*gamma(s - 1/2)*gamma(-a + s + 1)*gamma(a - s + 1)/(a*(-a + s)))*gamma(-2*s + 1)*gamma(s + 1)/(pi*s*gamma(-a - 1/2)*gamma(a + 3/2)*gamma(-s + 1)*gamma(-s + 3/2)*gamma(s - 1/2)*gamma(-a - s + 1)*gamma(-a + s - 1/2)*gamma(a - s + 1)*gamma(a - s + 3/2))'))",
 
     'mellin_transform(E1(x), x, s)',
     'inverse_mellin_transform(gamma(s)/s, s, x, (0, oo))',

--- a/sympy/concrete/tests/test_gosper.py
+++ b/sympy/concrete/tests/test_gosper.py
@@ -43,9 +43,9 @@ def test_gosper_sum():
     # issue 6033:
     assert gosper_sum(
         n*(n + a + b)*a**n*b**n/(factorial(n + a)*factorial(n + b)), \
-        (n, 0, m)) == -a*b*(exp(m*log(a))*exp(m*log(b))*factorial(a)* \
-        factorial(b) - factorial(a + m)*factorial(b + m))/(factorial(a)* \
-        factorial(b)*factorial(a + m)*factorial(b + m))
+        (n, 0, m)).simplify() == -exp(m*log(a) + m*log(b))*gamma(a + 1) \
+        *gamma(b + 1)/(gamma(a)*gamma(b)*gamma(a + m + 1)*gamma(b + m + 1)) \
+        + 1/(gamma(a)*gamma(b))
 
 
 def test_gosper_sum_indefinite():

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -470,8 +470,7 @@ def test_wallis_product():
     # can factor simple rational expressions
     A = Product(4*n**2 / (4*n**2 - 1), (n, 1, b))
     B = Product((2*n)*(2*n)/(2*n - 1)/(2*n + 1), (n, 1, b))
-    half = Rational(1, 2)
-    R = pi/2 * factorial(b)**2 / factorial(b - half) / factorial(b + half)
+    R = pi*gamma(b + 1)**2/(2*gamma(b + S(1)/2)*gamma(b + S(3)/2))
     assert simplify(A.doit()) == R
     assert simplify(B.doit()) == R
     # This one should eventually also be doable (Euler's product formula for sin)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3150,6 +3150,11 @@ class Expr(Basic, EvalfMixin):
         from sympy.simplify import combsimp
         return combsimp(self)
 
+    def gammasimp(self):
+        """See the gammasimp function in sympy.simplify"""
+        from sympy.simplify import gammasimp
+        return gammasimp(self)
+
     def factor(self, *gens, **args):
         """See the factor() function in sympy.polys.polytools"""
         from sympy.polys import factor

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -7,7 +7,7 @@ from sympy import (Add, Basic, Expr, S, Symbol, Wild, Float, Integer, Rational, 
                    simplify, together, collect, factorial, apart, combsimp, factor, refine,
                    cancel, Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E,
                    exp_polar, expand, diff, O, Heaviside, Si, Max, UnevaluatedExpr,
-                   integrate)
+                   integrate, gammasimp)
 from sympy.core.function import AppliedUndef
 from sympy.core.compatibility import range
 from sympy.physics.secondquant import FockState
@@ -1226,6 +1226,7 @@ def test_action_verbs():
         (a*x**2 + b*x**2 + a*x - b*x + c).collect(x)
     assert apart(y/(y + 2)/(y + 1), y) == (y/(y + 2)/(y + 1)).apart(y)
     assert combsimp(y/(x + 2)/(x + 1)) == (y/(x + 2)/(x + 1)).combsimp()
+    assert gammasimp(gamma(x)/gamma(x-5)) == (gamma(x)/gamma(x-5)).gammasimp()
     assert factor(x**2 + 5*x + 6) == (x**2 + 5*x + 6).factor()
     assert refine(sqrt(x**2)) == sqrt(x**2).refine()
     assert cancel((x**2 + 5*x + 6)/(x + 2)) == ((x**2 + 5*x + 6)/(x + 2)).cancel()

--- a/sympy/core/tests/test_noncommutative.py
+++ b/sympy/core/tests/test_noncommutative.py
@@ -9,6 +9,7 @@ from sympy import (
     cos,
     expand,
     factor,
+    gammasimp,
     posify,
     radsimp,
     ratsimp,
@@ -63,6 +64,10 @@ def test_collect():
 
 def test_combsimp():
     assert combsimp(A*B - B*A) == A*B - B*A
+
+
+def test_gammasimp():
+    assert gammasimp(A*B - B*A) == A*B - B*A
 
 
 def test_conjugate():

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -19,7 +19,9 @@ class CombinatorialFunction(Function):
     """Base class for combinatorial functions. """
 
     def _eval_simplify(self, ratio, measure):
-        from sympy.simplify.simplify import combsimp
+        from sympy.simplify.combsimp import combsimp
+        # combinatorial function with non-integer arguments is
+        # automatically passed to gammasimp
         expr = combsimp(self)
         if measure(expr) <= ratio*measure(self):
             return expr

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -845,7 +845,7 @@ def _int0oo_1(g, x):
     gamma(-a)*gamma(c + 1)/(y*gamma(-d)*gamma(b + 1))
     """
     # See [L, section 5.6.1]. Note that s=1.
-    from sympy import gamma, combsimp, unpolarify
+    from sympy import gamma, gammasimp, unpolarify
     eta, _ = _get_coeff_exp(g.argument, x)
     res = 1/eta
     # XXX TODO we should reduce order first
@@ -857,7 +857,7 @@ def _int0oo_1(g, x):
         res /= gamma(1 - b - 1)
     for a in g.aother:
         res /= gamma(a + 1)
-    return combsimp(unpolarify(res))
+    return gammasimp(unpolarify(res))
 
 
 def _rewrite_saxena(fac, po, g1, g2, x, full_pb=False):

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -321,7 +321,7 @@ def test_lookup_table():
 
 def test_branch_bug():
     from sympy import powdenest, lowergamma
-    # TODO combsimp cannot prove that the factor is unity
+    # TODO gammasimp cannot prove that the factor is unity
     assert powdenest(integrate(erf(x**3), x, meijerg=True).diff(x),
            polar=True) == 2*erf(x**3)*gamma(S(2)/3)/3/gamma(S(5)/3)
     assert integrate(erf(x**3), x, meijerg=True) == \
@@ -339,7 +339,7 @@ def test_linear_subs():
 def test_probability():
     # various integrals from probability theory
     from sympy.abc import x, y
-    from sympy import symbols, Symbol, Abs, expand_mul, combsimp, powsimp, sin
+    from sympy import symbols, Symbol, Abs, expand_mul, gammasimp, powsimp, sin
     mu1, mu2 = symbols('mu1 mu2', real=True, nonzero=True, finite=True)
     sigma1, sigma2 = symbols('sigma1 sigma2', real=True, nonzero=True,
                              finite=True, positive=True)
@@ -408,10 +408,10 @@ def test_probability():
         /gamma(alpha)/gamma(beta)
     assert integrate(betadist, (x, 0, oo), meijerg=True) == 1
     i = integrate(x*betadist, (x, 0, oo), meijerg=True, conds='separate')
-    assert (combsimp(i[0]), i[1]) == (alpha/(beta - 1), 1 < beta)
+    assert (gammasimp(i[0]), i[1]) == (alpha/(beta - 1), 1 < beta)
     j = integrate(x**2*betadist, (x, 0, oo), meijerg=True, conds='separate')
     assert j[1] == (1 < beta - 1)
-    assert combsimp(j[0] - i[0]**2) == (alpha + beta - 1)*alpha \
+    assert gammasimp(j[0] - i[0]**2) == (alpha + beta - 1)*alpha \
         /(beta - 2)/(beta - 1)**2
 
     # Beta distribution
@@ -441,7 +441,7 @@ def test_probability():
     assert simplify(integrate(x*chisquared, (x, 0, oo), meijerg=True)) == k
     assert simplify(integrate(x**2*chisquared, (x, 0, oo), meijerg=True)) == \
         k*(k + 2)
-    assert combsimp(integrate(((x - k)/sqrt(2*k))**3*chisquared, (x, 0, oo),
+    assert gammasimp(integrate(((x - k)/sqrt(2*k))**3*chisquared, (x, 0, oo),
                     meijerg=True)) == 2*sqrt(2)/sqrt(k)
 
     # Dagum distribution
@@ -525,7 +525,7 @@ def test_probability():
 
     # misc tests
     k = Symbol('k', positive=True)
-    assert combsimp(expand_mul(integrate(log(x)*x**(k - 1)*exp(-x)/gamma(k),
+    assert gammasimp(expand_mul(integrate(log(x)*x**(k - 1)*exp(-x)/gamma(k),
                               (x, 0, oo)))) == polygamma(0, k)
 
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -12,7 +12,7 @@ from sympy import (
     cos, S, Abs, And, Or, sin, sqrt, I, log, tan, hyperexpand, meijerg,
     EulerGamma, erf, erfc, besselj, bessely, besseli, besselk,
     exp_polar, polar_lift, unpolarify, Function, expint, expand_mul,
-    combsimp, trigsimp, atan, sinh, cosh, Ne, periodic_argument, atan2, Abs)
+    gammasimp, trigsimp, atan, sinh, cosh, Ne, periodic_argument, atan2, Abs)
 from sympy.utilities.pytest import XFAIL, slow, skip, raises
 from sympy.matrices import Matrix, eye
 from sympy.abc import x, s, a, b, c, d
@@ -253,7 +253,7 @@ def test_mellin_transform_bessel():
     # TODO products of besselk are a mess
 
     mt = MT(exp(-x/2)*besselk(a, x/2), x, s)
-    mt0 = combsimp((trigsimp(combsimp(mt[0].expand(func=True)))))
+    mt0 = gammasimp((trigsimp(gammasimp(mt[0].expand(func=True)))))
     assert mt0 == 2*pi**(S(3)/2)*cos(pi*s)*gamma(-s + S(1)/2)/(
         (cos(2*pi*a) - cos(2*pi*s))*gamma(-a - s + 1)*gamma(a - s + 1))
     assert mt[1:] == ((Max(-re(a), re(a)), oo), True)
@@ -650,8 +650,7 @@ def test_sine_transform():
     assert sine_transform(1/sqrt(t), t, w) == 1/sqrt(w)
     assert inverse_sine_transform(1/sqrt(w), w, t) == 1/sqrt(t)
 
-    assert sine_transform(
-        (1/sqrt(t))**3, t, w) == sqrt(w)*gamma(S(1)/4)/(2*gamma(S(5)/4))
+    assert sine_transform((1/sqrt(t))**3, t, w) == 2*sqrt(w)
 
     assert sine_transform(t**(-a), t, w) == 2**(
         -a + S(1)/2)*w**(a - 1)*gamma(-a/2 + 1)/gamma((a + 1)/2)

--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -85,7 +85,7 @@ def dominant(expr, n):
     term0 = terms[-1]
     comp = [term0]  # comparable terms
     for t in terms[:-1]:
-        e = (term0 / t).combsimp()
+        e = (term0 / t).gammasimp()
         l = limit_seq(e, n)
         if l is S.Zero:
             term0 = t
@@ -179,7 +179,7 @@ def limit_seq(expr, n=None, trials=5):
             return None
 
         num, den = (difference_delta(t.expand(), n) for t in [num, den])
-        expr = (num / den).combsimp()
+        expr = (num / den).gammasimp()
 
         if not expr.has(Sum):
             result = _limit_inf(expr, n)
@@ -196,4 +196,4 @@ def limit_seq(expr, n=None, trials=5):
         if den is None:
             return None
 
-        expr = (num / den).combsimp()
+        expr = (num / den).gammasimp()

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -28,4 +28,6 @@ from .powsimp import powsimp, powdenest
 
 from .combsimp import combsimp
 
+from .gammasimp import gammasimp
+
 from .ratsimp import ratsimp, ratsimpmodprime

--- a/sympy/simplify/combsimp.py
+++ b/sympy/simplify/combsimp.py
@@ -1,19 +1,18 @@
 from __future__ import print_function, division
 
-from sympy.core import Function, S, Mul, Pow, Add
-from sympy.core.compatibility import ordered, default_sort_key
+from sympy.core import Mul, Pow
 from sympy.core.basic import preorder_traversal
-from sympy.core.function import count_ops, expand_func
-from sympy.functions.combinatorial.factorials import binomial, CombinatorialFunction, factorial
-from sympy.functions import gamma, sqrt, sin
-from sympy.polys import factor, cancel
+from sympy.core.function import count_ops
+from sympy.functions.combinatorial.factorials import (binomial,
+    CombinatorialFunction, factorial)
+from sympy.functions import gamma
+from sympy.simplify.gammasimp import gammasimp, _gammasimp
 
 from sympy.utilities.timeutils import timethis
-from sympy.utilities.iterables import sift, uniq
 
 
 @timethis('combsimp')
-def combsimp(expr, as_comb = True):
+def combsimp(expr):
     r"""
     Simplify combinatorial expressions.
 
@@ -23,39 +22,23 @@ def combsimp(expr, as_comb = True):
     the size of their arguments.
 
     The algorithm works by rewriting all combinatorial functions as
-    expressions involving rising factorials (Pochhammer symbols) and
-    applies recurrence relations and other transformations applicable
-    to rising factorials, to reduce their arguments, possibly letting
-    the resulting rising factorial to cancel. Rising factorials with
-    the second argument being an integer are expanded into polynomial
-    forms and finally all other rising factorial are rewritten in terms
-    of more familiar functions. If the initial expression consisted of
-    gamma functions alone, the result is expressed in terms of gamma
-    functions. If the initial expression consists of gamma function
-    with some other combinatorial, the result is expressed in terms of
-    gamma functions.
+    gamma functions and applying gammasimp() except simplification
+    steps that may make an integer argument non-integer. See docstring
+    of gammasimp for more information.
 
-    If the result is expressed using gamma functions, the following three
-    additional steps are performed:
+    Then it rewrites expression in terms of factorials and binomials by
+    rewriting gammas as factorials and converting (a+b)!/a!b! into
+    binomials.
 
-    1. Reduce the number of gammas by applying the reflection theorem
-       gamma(x)*gamma(1-x) == pi/sin(pi*x).
-    2. Reduce the number of gammas by applying the multiplication theorem
-       gamma(x)*gamma(x+1/n)*...*gamma(x+(n-1)/n) == C*gamma(n*x).
-    3. Reduce the number of prefactors by absorbing them into gammas, where
-       possible.
-
-    All transformation rules can be found (or was derived from) here:
-
-    1. http://functions.wolfram.com/GammaBetaErf/Pochhammer/17/01/02/
-    2. http://functions.wolfram.com/GammaBetaErf/Pochhammer/27/01/0005/
+    If expression has gamma functions or combinatorial functions
+    with non-integer argument, it is automatically passed to gammasimp.
 
     Examples
     ========
 
     >>> from sympy.simplify import combsimp
-    >>> from sympy import factorial, binomial
-    >>> from sympy.abc import n, k
+    >>> from sympy import factorial, binomial, symbols
+    >>> n, k = symbols('n k', integer = True)
 
     >>> combsimp(factorial(n)/factorial(n - 3))
     n*(n - 2)*(n - 1)
@@ -65,502 +48,69 @@ def combsimp(expr, as_comb = True):
     """
 
     expr = expr.rewrite(gamma)
-    expr = expr.replace(gamma,
-        lambda n: _rf(1, (n - 1).expand()))
+    if any(isinstance(node, gamma) and not node.args[0].is_integer
+        for node in preorder_traversal(expr)):
+        return gammasimp(expr);
 
-    if as_comb:
-        expr = expr.replace(_rf,
-            lambda a, b: binomial(a + b - 1, b)*gamma(b + 1))
-    else:
-        expr = expr.replace(_rf,
-            lambda a, b: gamma(a + b)/gamma(a))
-
-    def rule(n, k):
-        coeff, rewrite = S.One, False
-
-        cn, _n = n.as_coeff_Add()
-
-        if _n and cn.is_Integer and cn:
-            coeff *= _rf(_n + 1, cn)/_rf(_n - k + 1, cn)
-            rewrite = True
-            n = _n
-
-        # this sort of binomial has already been removed by
-        # rising factorials but is left here in case the order
-        # of rule application is changed
-        if k.is_Add:
-            ck, _k = k.as_coeff_Add()
-            if _k and ck.is_Integer and ck:
-                coeff *= _rf(n - ck - _k + 1, ck)/_rf(_k + 1, ck)
-                rewrite = True
-                k = _k
-
-        if count_ops(k) > count_ops(n - k):
-            rewrite = True
-            k = n - k
-
-        if rewrite:
-            return coeff*binomial(n, k)
-
-    expr = expr.replace(binomial, rule)
-
-    def rule_gamma(expr, level=0):
-        """ Simplify products of gamma functions further. """
-
-        if expr.is_Atom:
-            return expr
-
-        def gamma_rat(x):
-            # helper to simplify ratios of gammas
-            was = x.count(gamma)
-            xx = x.replace(gamma, lambda n: _rf(1, (n - 1).expand()
-                ).replace(_rf, lambda a, b: gamma(a + b)/gamma(a)))
-            if xx.count(gamma) < was:
-                x = xx
-            return x
-
-        def gamma_factor(x):
-            # return True if there is a gamma factor in shallow args
-            if x.func is gamma:
-                return True
-            if x.is_Add or x.is_Mul:
-                return any(gamma_factor(xi) for xi in x.args)
-            if x.is_Pow and (x.exp.is_integer or x.base.is_positive):
-                return gamma_factor(x.base)
-            return False
-
-        # recursion step
-        if level == 0:
-            expr = expr.func(*[rule_gamma(x, level + 1) for x in expr.args])
-            level += 1
-
-        if not expr.is_Mul:
-            return expr
-
-        # non-commutative step
-        if level == 1:
-            args, nc = expr.args_cnc()
-            if not args:
-                return expr
-            if nc:
-                return rule_gamma(Mul._from_args(args), level + 1)*Mul._from_args(nc)
-            level += 1
-
-        # pure gamma handling, not factor absorbtion
-        if level == 2:
-            sifted = sift(expr.args, gamma_factor)
-            gamma_ind = Mul(*sifted.pop(False, []))
-            d = Mul(*sifted.pop(True, []))
-            assert not sifted
-
-            nd, dd = d.as_numer_denom()
-            for ipass in range(2):
-                args = list(ordered(Mul.make_args(nd)))
-                for i, ni in enumerate(args):
-                    if ni.is_Add:
-                        ni, dd = Add(*[
-                            rule_gamma(gamma_rat(a/dd), level + 1) for a in ni.args]
-                            ).as_numer_denom()
-                        args[i] = ni
-                        if not dd.has(gamma):
-                            break
-                nd = Mul(*args)
-                if ipass ==  0 and not gamma_factor(nd):
-                    break
-                nd, dd = dd, nd  # now process in reversed order
-            expr = gamma_ind*nd/dd
-            if not (expr.is_Mul and (gamma_factor(dd) or gamma_factor(nd))):
-                return expr
-            level += 1
-
-        # iteration until constant
-        if level == 3:
-            while True:
-                was = expr
-                expr = rule_gamma(expr, 4)
-                if expr == was:
-                    return expr
-
-        numer_gammas = []
-        denom_gammas = []
-        numer_others = []
-        denom_others = []
-        def explicate(p):
-            if p is S.One:
-                return None, []
-            b, e = p.as_base_exp()
-            if e.is_Integer:
-                if b.func is gamma:
-                    return True, [b.args[0]]*e
-                else:
-                    return False, [b]*e
-            else:
-                return False, [p]
-
-        newargs = list(ordered(expr.args))
-        while newargs:
-            n, d = newargs.pop().as_numer_denom()
-            isg, l = explicate(n)
-            if isg:
-                numer_gammas.extend(l)
-            elif isg is False:
-                numer_others.extend(l)
-            isg, l = explicate(d)
-            if isg:
-                denom_gammas.extend(l)
-            elif isg is False:
-                denom_others.extend(l)
-
-        # =========== level 2 work: pure gamma manipulation =========
-
-        if not as_comb:
-            # Try to reduce the number of gamma factors by applying the
-            # reflection formula gamma(x)*gamma(1-x) = pi/sin(pi*x)
-            for gammas, numer, denom in [(
-                numer_gammas, numer_others, denom_others),
-                    (denom_gammas, denom_others, numer_others)]:
-                new = []
-                while gammas:
-                    g1 = gammas.pop()
-                    if g1.is_integer:
-                        new.append(g1)
-                        continue
-                    for i, g2 in enumerate(gammas):
-                        n = g1 + g2 - 1
-                        if not n.is_Integer:
-                            continue
-                        numer.append(S.Pi)
-                        denom.append(sin(S.Pi*g1))
-                        gammas.pop(i)
-                        if n > 0:
-                            for k in range(n):
-                                numer.append(1 - g1 + k)
-                        elif n < 0:
-                            for k in range(-n):
-                                denom.append(-g1 - k)
-                        break
-                    else:
-                        new.append(g1)
-                # /!\ updating IN PLACE
-                gammas[:] = new
-
-            # Try to reduce the number of gammas by using the duplication
-            # theorem to cancel an upper and lower: gamma(2*s)/gamma(s) =
-            # 2**(2*s + 1)/(4*sqrt(pi))*gamma(s + 1/2). Although this could
-            # be done with higher argument ratios like gamma(3*x)/gamma(x),
-            # this would not reduce the number of gammas as in this case.
-            for ng, dg, no, do in [(numer_gammas, denom_gammas, numer_others,
-                                    denom_others),
-                                   (denom_gammas, numer_gammas, denom_others,
-                                    numer_others)]:
-
-                while True:
-                    for x in ng:
-                        for y in dg:
-                            n = x - 2*y
-                            if n.is_Integer:
-                                break
-                        else:
-                            continue
-                        break
-                    else:
-                        break
-                    ng.remove(x)
-                    dg.remove(y)
-                    if n > 0:
-                        for k in range(n):
-                            no.append(2*y + k)
-                    elif n < 0:
-                        for k in range(-n):
-                            do.append(2*y - 1 - k)
-                    ng.append(y + S(1)/2)
-                    no.append(2**(2*y - 1))
-                    do.append(sqrt(S.Pi))
-
-            # Try to reduce the number of gamma factors by applying the
-            # multiplication theorem (used when n gammas with args differing
-            # by 1/n mod 1 are encountered).
-            #
-            # run of 2 with args differing by 1/2
-            #
-            # >>> combsimp(gamma(x)*gamma(x+S.Half))
-            # 2*sqrt(2)*2**(-2*x - 1/2)*sqrt(pi)*gamma(2*x)
-            #
-            # run of 3 args differing by 1/3 (mod 1)
-            #
-            # >>> combsimp(gamma(x)*gamma(x+S(1)/3)*gamma(x+S(2)/3))
-            # 6*3**(-3*x - 1/2)*pi*gamma(3*x)
-            # >>> combsimp(gamma(x)*gamma(x+S(1)/3)*gamma(x+S(5)/3))
-            # 2*3**(-3*x - 1/2)*pi*(3*x + 2)*gamma(3*x)
-            #
-            def _run(coeffs):
-                # find runs in coeffs such that the difference in terms (mod 1)
-                # of t1, t2, ..., tn is 1/n
-                u = list(uniq(coeffs))
-                for i in range(len(u)):
-                    dj = ([((u[j] - u[i]) % 1, j) for j in range(i + 1, len(u))])
-                    for one, j in dj:
-                        if one.p == 1 and one.q != 1:
-                            n = one.q
-                            got = [i]
-                            get = list(range(1, n))
-                            for d, j in dj:
-                                m = n*d
-                                if m.is_Integer and m in get:
-                                    get.remove(m)
-                                    got.append(j)
-                                    if not get:
-                                        break
-                            else:
-                                continue
-                            for i, j in enumerate(got):
-                                c = u[j]
-                                coeffs.remove(c)
-                                got[i] = c
-                            return one.q, got[0], got[1:]
-
-            def _mult_thm(gammas, numer, denom):
-                # pull off and analyze the leading coefficient from each gamma arg
-                # looking for runs in those Rationals
-
-                # expr -> coeff + resid -> rats[resid] = coeff
-                rats = {}
-                for g in gammas:
-                    c, resid = g.as_coeff_Add()
-                    rats.setdefault(resid, []).append(c)
-
-                # look for runs in Rationals for each resid
-                keys = sorted(rats, key=default_sort_key)
-                for resid in keys:
-                    coeffs = list(sorted(rats[resid]))
-                    new = []
-                    while True:
-                        run = _run(coeffs)
-                        if run is None:
-                            break
-
-                        # process the sequence that was found:
-                        # 1) convert all the gamma functions to have the right
-                        #    argument (could be off by an integer)
-                        # 2) append the factors corresponding to the theorem
-                        # 3) append the new gamma function
-
-                        n, ui, other = run
-
-                        # (1)
-                        for u in other:
-                            con = resid + u - 1
-                            for k in range(int(u - ui)):
-                                numer.append(con - k)
-
-                        con = n*(resid + ui)  # for (2) and (3)
-
-                        # (2)
-                        numer.append((2*S.Pi)**(S(n - 1)/2)*
-                                     n**(S(1)/2 - con))
-                        # (3)
-                        new.append(con)
-
-                    # restore resid to coeffs
-                    rats[resid] = [resid + c for c in coeffs] + new
-
-                # rebuild the gamma arguments
-                g = []
-                for resid in keys:
-                    g += rats[resid]
-                # /!\ updating IN PLACE
-                gammas[:] = g
-
-            for l, numer, denom in [(numer_gammas, numer_others, denom_others),
-                                    (denom_gammas, denom_others, numer_others)]:
-                _mult_thm(l, numer, denom)
-
-        # =========== level >= 2 work: factor absorbtion =========
-
-        if level >= 2:
-            # Try to absorb factors into the gammas: x*gamma(x) -> gamma(x + 1)
-            # and gamma(x)/(x - 1) -> gamma(x - 1)
-            # This code (in particular repeated calls to find_fuzzy) can be very
-            # slow.
-            def find_fuzzy(l, x):
-                if not l:
-                    return
-                S1, T1 = compute_ST(x)
-                for y in l:
-                    S2, T2 = inv[y]
-                    if T1 != T2 or (not S1.intersection(S2) and
-                                    (S1 != set() or S2 != set())):
-                        continue
-                    # XXX we want some simplification (e.g. cancel or
-                    # simplify) but no matter what it's slow.
-                    a = len(cancel(x/y).free_symbols)
-                    b = len(x.free_symbols)
-                    c = len(y.free_symbols)
-                    # TODO is there a better heuristic?
-                    if a == 0 and (b > 0 or c > 0):
-                        return y
-
-            # We thus try to avoid expensive calls by building the following
-            # "invariants": For every factor or gamma function argument
-            #   - the set of free symbols S
-            #   - the set of functional components T
-            # We will only try to absorb if T1==T2 and (S1 intersect S2 != emptyset
-            # or S1 == S2 == emptyset)
-            inv = {}
-
-            def compute_ST(expr):
-                if expr in inv:
-                    return inv[expr]
-                return (expr.free_symbols, expr.atoms(Function).union(
-                        set(e.exp for e in expr.atoms(Pow))))
-
-            def update_ST(expr):
-                inv[expr] = compute_ST(expr)
-            for expr in numer_gammas + denom_gammas + numer_others + denom_others:
-                update_ST(expr)
-
-            for gammas, numer, denom in [(
-                numer_gammas, numer_others, denom_others),
-                    (denom_gammas, denom_others, numer_others)]:
-                new = []
-                while gammas:
-                    g = gammas.pop()
-                    cont = True
-                    while cont:
-                        cont = False
-                        y = find_fuzzy(numer, g)
-                        if y is not None:
-                            numer.remove(y)
-                            if y != g:
-                                numer.append(y/g)
-                                update_ST(y/g)
-                            g += 1
-                            cont = True
-                        y = find_fuzzy(denom, g - 1)
-                        if y is not None:
-                            denom.remove(y)
-                            if y != g - 1:
-                                numer.append((g - 1)/y)
-                                update_ST((g - 1)/y)
-                            g -= 1
-                            cont = True
-                    new.append(g)
-                # /!\ updating IN PLACE
-                gammas[:] = new
-
-        # =========== rebuild expr ==================================
-
-        return Mul(*[gamma(g) for g in numer_gammas]) \
-            / Mul(*[gamma(g) for g in denom_gammas]) \
-            * Mul(*numer_others) / Mul(*denom_others)
-
-    # (for some reason we cannot use Basic.replace in this case)
-    was = factor(expr)
-    expr = rule_gamma(was)
-    if expr != was:
-        expr = factor(expr)
-
-    expr = expr.replace(gamma,
-        lambda n: expand_func(gamma(n)) if n.is_Rational else gamma(n))
-
-    if as_comb:
-        expr = expr.rewrite(factorial)
-
-        from .simplify import bottom_up
-
-        def f(rv):
-            n, d = rv.as_numer_denom()
-
-            n_args = []
-            n_fact_args = []
-            if isinstance(n, (Mul, Pow, factorial)):
-                for factor, exp in n.as_powers_dict().items():
-                    try:
-                        n_args.extend([factor]*exp)
-                        if isinstance(factor, factorial):
-                            n_fact_args.extend([factor.args[0]]*exp)
-                    except TypeError:
-                        n_args.append(factor**exp)
-            if not n_args or not n_fact_args:
-                return rv
-
-            d_args = []
-            if isinstance(d, (Mul, Pow, factorial)):
-                for factor, exp in d.as_powers_dict().items():
-                    try:
-                        d_args.extend([factor]*exp)
-                    except TypeError:
-                        n_args.append(factor**exp)
-            else:
-                return rv
-
-            hit = False
-            for i in range(len(d_args)):
-                ai = d_args[i]
-                if not isinstance(ai, factorial):
-                    continue
-
-                for j in range(i + 1, len(d_args)):
-                    aj = d_args[j]
-                    if not isinstance(aj, factorial):
-                        continue
-
-                    sum = ai.args[0] + aj.args[0]
-                    if sum in n_fact_args:
-                        n_args.remove(factorial(sum))
-                        n_fact_args.remove(sum)
-                        n_args.append(binomial(sum, ai.args[0] if count_ops(
-                        ai.args[0]) < count_ops(aj.args[0]) else aj.args[0]))
-
-                        d_args[i] = None
-                        d_args[j] = None
-                        hit = True
-                        break
-
-            if hit:
-                n = Mul(*[_arg for _arg in n_args if _arg])
-                d = Mul(*[_arg for _arg in d_args if _arg])
-                return n/d
-            return rv
-
-        expr = bottom_up(expr, f)
-
+    expr = _gammasimp(expr, as_comb = True)
+    expr = _gamma_as_comb(expr)
     return expr
 
-class _rf(Function):
-    @classmethod
-    def eval(cls, a, b):
-        if b.is_Integer:
-            if not b:
-                return S.One
 
-            n, result = int(b), S.One
+def _gamma_as_comb(expr):
+    """
+    Helper function for combsimp.
 
-            if n > 0:
-                for i in range(n):
-                    result *= a + i
+    Rewrites expression in terms of factorials and binomials
+    """
 
-                return result
-            elif n < 0:
-                for i in range(1, -n + 1):
-                    result *= a - i
+    expr = expr.rewrite(factorial)
 
-                return 1/result
-        else:
-            if b.is_Add:
-                c, _b = b.as_coeff_Add()
+    from .simplify import bottom_up
 
-                if c.is_Integer:
-                    if c > 0:
-                        return _rf(a, _b)*_rf(a + _b, c)
-                    elif c < 0:
-                        return _rf(a, _b)/_rf(a + _b + c, -c)
+    def f(rv):
+        if not rv.is_Mul:
+            return rv
+        rvd = rv.as_powers_dict()
+        nd_fact_args = [[], []] # numerator, denominator
 
-            if a.is_Add:
-                c, _a = a.as_coeff_Add()
+        for k in rvd:
+            if isinstance(k, factorial) and rvd[k].is_Integer:
+                if rvd[k].is_positive:
+                    nd_fact_args[0].extend([k.args[0]]*rvd[k])
+                else:
+                    nd_fact_args[1].extend([k.args[0]]*-rvd[k])
+                rvd[k] = 0
+        if not nd_fact_args[0] or not nd_fact_args[1]:
+            return rv
 
-                if c.is_Integer:
-                    if c > 0:
-                        return _rf(_a, b)*_rf(_a + b, c)/_rf(_a, c)
-                    elif c < 0:
-                        return _rf(_a, b)*_rf(_a + c, -c)/_rf(_a + b + c, -c)
+        hit = False
+        for m in range(2):
+            i = 0
+            while i < len(nd_fact_args[m]):
+                ai = nd_fact_args[m][i]
+                for j in range(i + 1, len(nd_fact_args[m])):
+                    aj = nd_fact_args[m][j]
+
+                    sum = ai + aj
+                    if sum in nd_fact_args[1 - m]:
+                        hit = True
+
+                        nd_fact_args[1 - m].remove(sum)
+                        del nd_fact_args[m][j]
+                        del nd_fact_args[m][i]
+
+                        rvd[binomial(sum, ai if count_ops(ai) <
+                                count_ops(aj) else aj)] += (
+                                -1 if m == 0 else 1)
+                        break
+                else:
+                    i += 1
+
+        if hit:
+            return Mul(*([k**rvd[k] for k in rvd] + [factorial(k)
+                    for k in nd_fact_args[0]]))/Mul(*[factorial(k)
+                    for k in nd_fact_args[1]])
+        return rv
+
+    return bottom_up(expr, f)

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -1,0 +1,513 @@
+from __future__ import print_function, division
+
+from sympy.core import Function, S, Mul, Pow, Add
+from sympy.core.compatibility import ordered, default_sort_key
+from sympy.core.basic import preorder_traversal
+from sympy.core.function import count_ops, expand_func
+from sympy.functions.combinatorial.factorials import (binomial,
+    CombinatorialFunction, factorial)
+from sympy.functions import gamma, sqrt, sin
+from sympy.polys import factor, cancel
+
+from sympy.utilities.iterables import sift, uniq
+
+
+def gammasimp(expr):
+    r"""
+    Simplify expressions with gamma functions.
+
+    This function takes as input an expression containing gamma
+    functions or functions that can be rewritten in terms of gamma
+    functions and tries to minimize the number of those functions and
+    reduce the size of their arguments.
+
+    The algorithm works by rewriting all gamma functions as expressions
+    involving rising factorials (Pochhammer symbols) and applies
+    recurrence relations and other transformations applicable to rising
+    factorials, to reduce their arguments, possibly letting the resulting
+    rising factorial to cancel. Rising factorials with the second argument
+    being an integer are expanded into polynomial forms and finally all
+    other rising factorial are rewritten in terms of gamma functions.
+
+    Then the following two steps are performed.
+
+    1. Reduce the number of gammas by applying the reflection theorem
+       gamma(x)*gamma(1-x) == pi/sin(pi*x).
+    2. Reduce the number of gammas by applying the multiplication theorem
+       gamma(x)*gamma(x+1/n)*...*gamma(x+(n-1)/n) == C*gamma(n*x).
+
+    It then reduces the number of prefactors by absorbing them into gammas
+    where possible and expands gammas with rational argument.
+
+    All transformation rules can be found (or was derived from) here:
+
+    1. http://functions.wolfram.com/GammaBetaErf/Pochhammer/17/01/02/
+    2. http://functions.wolfram.com/GammaBetaErf/Pochhammer/27/01/0005/
+
+    Examples
+    ========
+
+    >>> from sympy.simplify import gammasimp
+    >>> from sympy import gamma, factorial, Symbol
+    >>> from sympy.abc import x
+    >>> n = Symbol('n', integer = True)
+
+    >>> gammasimp(gamma(x)/gamma(x - 3))
+    (x - 3)*(x - 2)*(x - 1)
+    >>> gammasimp(gamma(n + 3))
+    gamma(n + 3)
+
+    """
+
+    expr = expr.rewrite(gamma)
+    return _gammasimp(expr, as_comb = False)
+
+
+def _gammasimp(expr, as_comb):
+    """
+    Helper function for gammasimp and combsimp.
+
+    Simplifies expressions written in terms of gamma function. If
+    as_comb is True, it tries to preserve integer arguments. See
+    docstring of gammasimp for more information. This was part of
+    combsimp() in combsimp.py.
+    """
+
+    expr = expr.replace(gamma,
+        lambda n: _rf(1, (n - 1).expand()))
+
+    if as_comb:
+        expr = expr.replace(_rf,
+            lambda a, b: binomial(a + b - 1, b)*gamma(b + 1))
+    else:
+        expr = expr.replace(_rf,
+            lambda a, b: gamma(a + b)/gamma(a))
+
+    def rule(n, k):
+        coeff, rewrite = S.One, False
+
+        cn, _n = n.as_coeff_Add()
+
+        if _n and cn.is_Integer and cn:
+            coeff *= _rf(_n + 1, cn)/_rf(_n - k + 1, cn)
+            rewrite = True
+            n = _n
+
+        # this sort of binomial has already been removed by
+        # rising factorials but is left here in case the order
+        # of rule application is changed
+        if k.is_Add:
+            ck, _k = k.as_coeff_Add()
+            if _k and ck.is_Integer and ck:
+                coeff *= _rf(n - ck - _k + 1, ck)/_rf(_k + 1, ck)
+                rewrite = True
+                k = _k
+
+        if count_ops(k) > count_ops(n - k):
+            rewrite = True
+            k = n - k
+
+        if rewrite:
+            return coeff*binomial(n, k)
+
+    expr = expr.replace(binomial, rule)
+
+    def rule_gamma(expr, level=0):
+        """ Simplify products of gamma functions further. """
+
+        if expr.is_Atom:
+            return expr
+
+        def gamma_rat(x):
+            # helper to simplify ratios of gammas
+            was = x.count(gamma)
+            xx = x.replace(gamma, lambda n: _rf(1, (n - 1).expand()
+                ).replace(_rf, lambda a, b: gamma(a + b)/gamma(a)))
+            if xx.count(gamma) < was:
+                x = xx
+            return x
+
+        def gamma_factor(x):
+            # return True if there is a gamma factor in shallow args
+            if x.func is gamma:
+                return True
+            if x.is_Add or x.is_Mul:
+                return any(gamma_factor(xi) for xi in x.args)
+            if x.is_Pow and (x.exp.is_integer or x.base.is_positive):
+                return gamma_factor(x.base)
+            return False
+
+        # recursion step
+        if level == 0:
+            expr = expr.func(*[rule_gamma(x, level + 1) for x in expr.args])
+            level += 1
+
+        if not expr.is_Mul:
+            return expr
+
+        # non-commutative step
+        if level == 1:
+            args, nc = expr.args_cnc()
+            if not args:
+                return expr
+            if nc:
+                return rule_gamma(Mul._from_args(args), level + 1)*Mul._from_args(nc)
+            level += 1
+
+        # pure gamma handling, not factor absorbtion
+        if level == 2:
+            sifted = sift(expr.args, gamma_factor)
+            gamma_ind = Mul(*sifted.pop(False, []))
+            d = Mul(*sifted.pop(True, []))
+            assert not sifted
+
+            nd, dd = d.as_numer_denom()
+            for ipass in range(2):
+                args = list(ordered(Mul.make_args(nd)))
+                for i, ni in enumerate(args):
+                    if ni.is_Add:
+                        ni, dd = Add(*[
+                            rule_gamma(gamma_rat(a/dd), level + 1) for a in ni.args]
+                            ).as_numer_denom()
+                        args[i] = ni
+                        if not dd.has(gamma):
+                            break
+                nd = Mul(*args)
+                if ipass ==  0 and not gamma_factor(nd):
+                    break
+                nd, dd = dd, nd  # now process in reversed order
+            expr = gamma_ind*nd/dd
+            if not (expr.is_Mul and (gamma_factor(dd) or gamma_factor(nd))):
+                return expr
+            level += 1
+
+        # iteration until constant
+        if level == 3:
+            while True:
+                was = expr
+                expr = rule_gamma(expr, 4)
+                if expr == was:
+                    return expr
+
+        numer_gammas = []
+        denom_gammas = []
+        numer_others = []
+        denom_others = []
+        def explicate(p):
+            if p is S.One:
+                return None, []
+            b, e = p.as_base_exp()
+            if e.is_Integer:
+                if b.func is gamma:
+                    return True, [b.args[0]]*e
+                else:
+                    return False, [b]*e
+            else:
+                return False, [p]
+
+        newargs = list(ordered(expr.args))
+        while newargs:
+            n, d = newargs.pop().as_numer_denom()
+            isg, l = explicate(n)
+            if isg:
+                numer_gammas.extend(l)
+            elif isg is False:
+                numer_others.extend(l)
+            isg, l = explicate(d)
+            if isg:
+                denom_gammas.extend(l)
+            elif isg is False:
+                denom_others.extend(l)
+
+        # =========== level 2 work: pure gamma manipulation =========
+
+        if not as_comb:
+            # Try to reduce the number of gamma factors by applying the
+            # reflection formula gamma(x)*gamma(1-x) = pi/sin(pi*x)
+            for gammas, numer, denom in [(
+                numer_gammas, numer_others, denom_others),
+                    (denom_gammas, denom_others, numer_others)]:
+                new = []
+                while gammas:
+                    g1 = gammas.pop()
+                    if g1.is_integer:
+                        new.append(g1)
+                        continue
+                    for i, g2 in enumerate(gammas):
+                        n = g1 + g2 - 1
+                        if not n.is_Integer:
+                            continue
+                        numer.append(S.Pi)
+                        denom.append(sin(S.Pi*g1))
+                        gammas.pop(i)
+                        if n > 0:
+                            for k in range(n):
+                                numer.append(1 - g1 + k)
+                        elif n < 0:
+                            for k in range(-n):
+                                denom.append(-g1 - k)
+                        break
+                    else:
+                        new.append(g1)
+                # /!\ updating IN PLACE
+                gammas[:] = new
+
+            # Try to reduce the number of gammas by using the duplication
+            # theorem to cancel an upper and lower: gamma(2*s)/gamma(s) =
+            # 2**(2*s + 1)/(4*sqrt(pi))*gamma(s + 1/2). Although this could
+            # be done with higher argument ratios like gamma(3*x)/gamma(x),
+            # this would not reduce the number of gammas as in this case.
+            for ng, dg, no, do in [(numer_gammas, denom_gammas, numer_others,
+                                    denom_others),
+                                   (denom_gammas, numer_gammas, denom_others,
+                                    numer_others)]:
+
+                while True:
+                    for x in ng:
+                        for y in dg:
+                            n = x - 2*y
+                            if n.is_Integer:
+                                break
+                        else:
+                            continue
+                        break
+                    else:
+                        break
+                    ng.remove(x)
+                    dg.remove(y)
+                    if n > 0:
+                        for k in range(n):
+                            no.append(2*y + k)
+                    elif n < 0:
+                        for k in range(-n):
+                            do.append(2*y - 1 - k)
+                    ng.append(y + S(1)/2)
+                    no.append(2**(2*y - 1))
+                    do.append(sqrt(S.Pi))
+
+            # Try to reduce the number of gamma factors by applying the
+            # multiplication theorem (used when n gammas with args differing
+            # by 1/n mod 1 are encountered).
+            #
+            # run of 2 with args differing by 1/2
+            #
+            # >>> gammasimp(gamma(x)*gamma(x+S.Half))
+            # 2*sqrt(2)*2**(-2*x - 1/2)*sqrt(pi)*gamma(2*x)
+            #
+            # run of 3 args differing by 1/3 (mod 1)
+            #
+            # >>> gammasimp(gamma(x)*gamma(x+S(1)/3)*gamma(x+S(2)/3))
+            # 6*3**(-3*x - 1/2)*pi*gamma(3*x)
+            # >>> gammasimp(gamma(x)*gamma(x+S(1)/3)*gamma(x+S(5)/3))
+            # 2*3**(-3*x - 1/2)*pi*(3*x + 2)*gamma(3*x)
+            #
+            def _run(coeffs):
+                # find runs in coeffs such that the difference in terms (mod 1)
+                # of t1, t2, ..., tn is 1/n
+                u = list(uniq(coeffs))
+                for i in range(len(u)):
+                    dj = ([((u[j] - u[i]) % 1, j) for j in range(i + 1, len(u))])
+                    for one, j in dj:
+                        if one.p == 1 and one.q != 1:
+                            n = one.q
+                            got = [i]
+                            get = list(range(1, n))
+                            for d, j in dj:
+                                m = n*d
+                                if m.is_Integer and m in get:
+                                    get.remove(m)
+                                    got.append(j)
+                                    if not get:
+                                        break
+                            else:
+                                continue
+                            for i, j in enumerate(got):
+                                c = u[j]
+                                coeffs.remove(c)
+                                got[i] = c
+                            return one.q, got[0], got[1:]
+
+            def _mult_thm(gammas, numer, denom):
+                # pull off and analyze the leading coefficient from each gamma arg
+                # looking for runs in those Rationals
+
+                # expr -> coeff + resid -> rats[resid] = coeff
+                rats = {}
+                for g in gammas:
+                    c, resid = g.as_coeff_Add()
+                    rats.setdefault(resid, []).append(c)
+
+                # look for runs in Rationals for each resid
+                keys = sorted(rats, key=default_sort_key)
+                for resid in keys:
+                    coeffs = list(sorted(rats[resid]))
+                    new = []
+                    while True:
+                        run = _run(coeffs)
+                        if run is None:
+                            break
+
+                        # process the sequence that was found:
+                        # 1) convert all the gamma functions to have the right
+                        #    argument (could be off by an integer)
+                        # 2) append the factors corresponding to the theorem
+                        # 3) append the new gamma function
+
+                        n, ui, other = run
+
+                        # (1)
+                        for u in other:
+                            con = resid + u - 1
+                            for k in range(int(u - ui)):
+                                numer.append(con - k)
+
+                        con = n*(resid + ui)  # for (2) and (3)
+
+                        # (2)
+                        numer.append((2*S.Pi)**(S(n - 1)/2)*
+                                     n**(S(1)/2 - con))
+                        # (3)
+                        new.append(con)
+
+                    # restore resid to coeffs
+                    rats[resid] = [resid + c for c in coeffs] + new
+
+                # rebuild the gamma arguments
+                g = []
+                for resid in keys:
+                    g += rats[resid]
+                # /!\ updating IN PLACE
+                gammas[:] = g
+
+            for l, numer, denom in [(numer_gammas, numer_others, denom_others),
+                                    (denom_gammas, denom_others, numer_others)]:
+                _mult_thm(l, numer, denom)
+
+        # =========== level >= 2 work: factor absorbtion =========
+
+        if level >= 2:
+            # Try to absorb factors into the gammas: x*gamma(x) -> gamma(x + 1)
+            # and gamma(x)/(x - 1) -> gamma(x - 1)
+            # This code (in particular repeated calls to find_fuzzy) can be very
+            # slow.
+            def find_fuzzy(l, x):
+                if not l:
+                    return
+                S1, T1 = compute_ST(x)
+                for y in l:
+                    S2, T2 = inv[y]
+                    if T1 != T2 or (not S1.intersection(S2) and
+                                    (S1 != set() or S2 != set())):
+                        continue
+                    # XXX we want some simplification (e.g. cancel or
+                    # simplify) but no matter what it's slow.
+                    a = len(cancel(x/y).free_symbols)
+                    b = len(x.free_symbols)
+                    c = len(y.free_symbols)
+                    # TODO is there a better heuristic?
+                    if a == 0 and (b > 0 or c > 0):
+                        return y
+
+            # We thus try to avoid expensive calls by building the following
+            # "invariants": For every factor or gamma function argument
+            #   - the set of free symbols S
+            #   - the set of functional components T
+            # We will only try to absorb if T1==T2 and (S1 intersect S2 != emptyset
+            # or S1 == S2 == emptyset)
+            inv = {}
+
+            def compute_ST(expr):
+                if expr in inv:
+                    return inv[expr]
+                return (expr.free_symbols, expr.atoms(Function).union(
+                        set(e.exp for e in expr.atoms(Pow))))
+
+            def update_ST(expr):
+                inv[expr] = compute_ST(expr)
+            for expr in numer_gammas + denom_gammas + numer_others + denom_others:
+                update_ST(expr)
+
+            for gammas, numer, denom in [(
+                numer_gammas, numer_others, denom_others),
+                    (denom_gammas, denom_others, numer_others)]:
+                new = []
+                while gammas:
+                    g = gammas.pop()
+                    cont = True
+                    while cont:
+                        cont = False
+                        y = find_fuzzy(numer, g)
+                        if y is not None:
+                            numer.remove(y)
+                            if y != g:
+                                numer.append(y/g)
+                                update_ST(y/g)
+                            g += 1
+                            cont = True
+                        y = find_fuzzy(denom, g - 1)
+                        if y is not None:
+                            denom.remove(y)
+                            if y != g - 1:
+                                numer.append((g - 1)/y)
+                                update_ST((g - 1)/y)
+                            g -= 1
+                            cont = True
+                    new.append(g)
+                # /!\ updating IN PLACE
+                gammas[:] = new
+
+        # =========== rebuild expr ==================================
+
+        return Mul(*[gamma(g) for g in numer_gammas]) \
+            / Mul(*[gamma(g) for g in denom_gammas]) \
+            * Mul(*numer_others) / Mul(*denom_others)
+
+    # (for some reason we cannot use Basic.replace in this case)
+    was = factor(expr)
+    expr = rule_gamma(was)
+    if expr != was:
+        expr = factor(expr)
+
+    expr = expr.replace(gamma,
+        lambda n: expand_func(gamma(n)) if n.is_Rational else gamma(n))
+
+    return expr
+
+
+class _rf(Function):
+    @classmethod
+    def eval(cls, a, b):
+        if b.is_Integer:
+            if not b:
+                return S.One
+
+            n, result = int(b), S.One
+
+            if n > 0:
+                for i in range(n):
+                    result *= a + i
+
+                return result
+            elif n < 0:
+                for i in range(1, -n + 1):
+                    result *= a - i
+
+                return 1/result
+        else:
+            if b.is_Add:
+                c, _b = b.as_coeff_Add()
+
+                if c.is_Integer:
+                    if c > 0:
+                        return _rf(a, _b)*_rf(a + _b, c)
+                    elif c < 0:
+                        return _rf(a, _b)/_rf(a + _b + c, -c)
+
+            if a.is_Add:
+                c, _a = a.as_coeff_Add()
+
+                if c.is_Integer:
+                    if c > 0:
+                        return _rf(_a, b)*_rf(_a + b, c)/_rf(_a, c)
+                    elif c < 0:
+                        return _rf(_a, b)*_rf(_a + c, -c)/_rf(_a + b + c, -c)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -582,6 +582,8 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False):
         expr = shorter(expand_log(expr, deep=True), logcombine(expr))
 
     if expr.has(CombinatorialFunction, gamma):
+        # expression with gamma functions or non-integer arguments is
+        # automatically passed to gammasimp
         expr = combsimp(expr)
 
     if expr.has(Sum):

--- a/sympy/simplify/tests/test_combsimp.py
+++ b/sympy/simplify/tests/test_combsimp.py
@@ -1,13 +1,11 @@
 from sympy import (
-    Rational, combsimp, factorial, gamma, binomial, Symbol, pi, S,
-    sin, exp, powsimp, sqrt, sympify, FallingFactorial, RisingFactorial,
-    simplify, symbols, cos, rf, Mul)
-
-from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
+    combsimp, factorial, gamma, binomial, S, FallingFactorial, RisingFactorial,
+    symbols)
+from sympy.abc import x
 
 
 def test_combsimp():
-    from sympy.abc import n, k
+    k, m, n = symbols('k m n', integer = True)
 
     assert combsimp(factorial(n)) == factorial(n)
     assert combsimp(binomial(n, k)) == binomial(n, k)
@@ -23,27 +21,27 @@ def test_combsimp():
     assert combsimp(factorial(n)*binomial(n + 1, k + 1)/binomial(n, k)) == \
         factorial(n + 1)/(1 + k)
 
-    assert combsimp(binomial(n - 1, k)) == -((-n + k)*binomial(n, k))/n
+    assert combsimp(gamma(n + 3)) == factorial(n + 2)
 
-    assert combsimp(binomial(n + 2, k + S(1)/2)) == 4*((n + 1)*(n + 2) *
-        binomial(n, k + S(1)/2))/((2*k - 2*n - 1)*(2*k - 2*n - 3))
-    assert combsimp(binomial(n + 2, k + 2.0)) == \
-        Mul(-2.0, 0.5*n + 1.0, binomial(n + 1.0, k + 2.0),
-        evaluate = False)/(k - n)
+    assert combsimp(factorial(x)) == gamma(x + 1)
 
-    # coverage tests
+    # issue 9699
+    assert combsimp((n + 1)*factorial(n)) == factorial(n + 1)
+    assert combsimp(factorial(n)/n) == factorial(n-1)
+
+    # issue 6658
+    assert combsimp(binomial(n, n - k)) == binomial(n, k)
+
+    # issue 6341, 7135
+    assert combsimp(factorial(n)/(factorial(k)*factorial(n - k))) == \
+        binomial(n, k)
+    assert combsimp(factorial(k)*factorial(n - k)/factorial(n)) == \
+        1/binomial(n, k)
+    assert combsimp(factorial(2*n)/factorial(n)**2) == binomial(2*n, n)
+    assert combsimp(factorial(2*n)*factorial(k)*factorial(n - k)/
+        factorial(n)**3) == binomial(2*n, n)/binomial(n, k)
+
     assert combsimp(factorial(n*(1 + n) - n**2 - n)) == 1
-    assert combsimp(binomial(n + k - 2, n)) == \
-        k*(k - 1)*binomial(n + k, n)/((n + k)*(n + k - 1))
-    i = Symbol('i', integer=True)
-    e = gamma(i + 3)
-    assert combsimp(e) == e
-    e = gamma(exp(i))
-    assert combsimp(e) == e
-    e = gamma(n + S(1)/3)*gamma(n + S(2)/3)
-    assert combsimp(e) == e
-    assert combsimp(gamma(4*n + S(1)/2)/gamma(2*n - S(3)/4)) == \
-        2**(4*n - S(5)/2)*(8*n - 3)*gamma(2*n + S(3)/4)/sqrt(pi)
 
     assert combsimp(6*FallingFactorial(-4, n)/factorial(n)) == \
         (-1)**n*(n + 1)*(n + 2)*(n + 3)
@@ -62,75 +60,3 @@ def test_combsimp():
         n*(n - 1)*(n - 2)
     assert combsimp(6*RisingFactorial(4, -n - 1)/factorial(-n - 1)) == \
         -n*(n - 1)*(n - 2)
-
-
-def test_combsimp_gamma():
-    from sympy.abc import x, y
-    R = Rational
-
-    assert combsimp(gamma(x)) == gamma(x)
-    assert combsimp(gamma(x + 1)/x) == gamma(x)
-    assert combsimp(gamma(x)/(x - 1)) == gamma(x - 1)
-    assert combsimp(x*gamma(x)) == gamma(x + 1)
-    assert combsimp((x + 1)*gamma(x + 1)) == gamma(x + 2)
-    assert combsimp(gamma(x + y)*(x + y)) == gamma(x + y + 1)
-    assert combsimp(x/gamma(x + 1)) == 1/gamma(x)
-    assert combsimp((x + 1)**2/gamma(x + 2)) == (x + 1)/gamma(x + 1)
-    assert combsimp(x*gamma(x) + gamma(x + 3)/(x + 2)) == \
-        (x + 2)*gamma(x + 1)
-
-    assert combsimp(gamma(2*x)*x) == gamma(2*x + 1)/2
-    assert combsimp(gamma(2*x)/(x - S(1)/2)) == 2*gamma(2*x - 1)
-
-    assert combsimp(gamma(x)*gamma(1 - x)) == pi/sin(pi*x)
-    assert combsimp(gamma(x)*gamma(-x)) == -pi/(x*sin(pi*x))
-    assert combsimp(1/gamma(x + 3)/gamma(1 - x)) == \
-        sin(pi*x)/(pi*x*(x + 1)*(x + 2))
-
-    assert powsimp(combsimp(
-        gamma(x)*gamma(x + S(1)/2)*gamma(y)/gamma(x + y))) == \
-        2**(-2*x + 1)*sqrt(pi)*gamma(2*x)*gamma(y)/gamma(x + y)
-    assert combsimp(1/gamma(x)/gamma(x - S(1)/3)/gamma(x + S(1)/3)) == \
-        3**(3*x - S(3)/2)/(2*pi*gamma(3*x - 1))
-    assert simplify(
-        gamma(S(1)/2 + x/2)*gamma(1 + x/2)/gamma(1 + x)/sqrt(pi)*2**x) == 1
-    assert combsimp(gamma(S(-1)/4)*gamma(S(-3)/4)) == 16*sqrt(2)*pi/3
-
-    assert powsimp(combsimp(gamma(2*x)/gamma(x))) == \
-        2**(2*x - 1)*gamma(x + S(1)/2)/sqrt(pi)
-
-    # issue 6792
-    e = (-gamma(k)*gamma(k + 2) + gamma(k + 1)**2)/gamma(k)**2
-    assert combsimp(e) == -k
-    assert combsimp(1/e) == -1/k
-    e = (gamma(x) + gamma(x + 1))/gamma(x)
-    assert combsimp(e) == x + 1
-    assert combsimp(1/e) == 1/(x + 1)
-    e = (gamma(x) + gamma(x + 2))*(gamma(x - 1) + gamma(x))/gamma(x)
-    assert combsimp(e) == (x**2 + x + 1)*gamma(x + 1)/(x - 1)
-    e = (-gamma(k)*gamma(k + 2) + gamma(k + 1)**2)/gamma(k)**2
-    assert combsimp(e**2) == k**2
-    assert combsimp(e**2/gamma(k + 1)) == k/gamma(k)
-    a = R(1, 2) + R(1, 3)
-    b = a + R(1, 3)
-    assert combsimp(gamma(2*k)/gamma(k)*gamma(k + a)*gamma(k + b))
-    3*2**(2*k + 1)*3**(-3*k - 2)*sqrt(pi)*gamma(3*k + R(3, 2))/2
-
-    A, B = symbols('A B', commutative=False)
-    assert combsimp(e*B*A) == combsimp(e)*B*A
-
-    # check iteration
-    assert combsimp(gamma(2*k)/gamma(k)*gamma(-k - R(1, 2))) == (
-        -2**(2*k + 1)*sqrt(pi)/(2*((2*k + 1)*cos(pi*k))))
-    assert combsimp(
-        gamma(k)*gamma(k + R(1, 3))*gamma(k + R(2, 3))/gamma(3*k/2)) == (
-        3*2**(3*k + 1)*3**(-3*k - S.Half)*sqrt(pi)*gamma(3*k/2 + S.Half)/2)
-
-
-def test_issue_9699():
-    n, k = symbols('n k', real=True)
-    x, y = symbols('x, y')
-    assert combsimp((n + 1)*factorial(n)) == factorial(n + 1)
-    assert combsimp((x + 1)*factorial(x)/gamma(y)) == gamma(x + 2)/gamma(y)
-    assert combsimp(factorial(n)/n) == factorial(n - 1)
-    assert combsimp(rf(x + n, k)*binomial(n, k)) == binomial(n, k)*gamma(k + n + x)/gamma(n + x)

--- a/sympy/simplify/tests/test_gammasimp.py
+++ b/sympy/simplify/tests/test_gammasimp.py
@@ -1,0 +1,102 @@
+from sympy import (
+    Rational, gammasimp, factorial, gamma, binomial, Symbol, pi, S,
+    sin, exp, powsimp, sqrt, simplify, symbols, cos, rf)
+
+from sympy.abc import x, y, n, k
+
+
+def test_gammasimp():
+    R = Rational
+
+    # was part of test_combsimp_gamma() in test_combsimp.py
+    assert gammasimp(gamma(x)) == gamma(x)
+    assert gammasimp(gamma(x + 1)/x) == gamma(x)
+    assert gammasimp(gamma(x)/(x - 1)) == gamma(x - 1)
+    assert gammasimp(x*gamma(x)) == gamma(x + 1)
+    assert gammasimp((x + 1)*gamma(x + 1)) == gamma(x + 2)
+    assert gammasimp(gamma(x + y)*(x + y)) == gamma(x + y + 1)
+    assert gammasimp(x/gamma(x + 1)) == 1/gamma(x)
+    assert gammasimp((x + 1)**2/gamma(x + 2)) == (x + 1)/gamma(x + 1)
+    assert gammasimp(x*gamma(x) + gamma(x + 3)/(x + 2)) == \
+        (x + 2)*gamma(x + 1)
+
+    assert gammasimp(gamma(2*x)*x) == gamma(2*x + 1)/2
+    assert gammasimp(gamma(2*x)/(x - S(1)/2)) == 2*gamma(2*x - 1)
+
+    assert gammasimp(gamma(x)*gamma(1 - x)) == pi/sin(pi*x)
+    assert gammasimp(gamma(x)*gamma(-x)) == -pi/(x*sin(pi*x))
+    assert gammasimp(1/gamma(x + 3)/gamma(1 - x)) == \
+        sin(pi*x)/(pi*x*(x + 1)*(x + 2))
+
+    assert gammasimp(factorial(n + 2)) == gamma(n + 3)
+    assert gammasimp(binomial(n, k)) == \
+        gamma(n + 1)/(gamma(k + 1)*gamma(-k + n + 1))
+
+    assert powsimp(gammasimp(
+        gamma(x)*gamma(x + S(1)/2)*gamma(y)/gamma(x + y))) == \
+        2**(-2*x + 1)*sqrt(pi)*gamma(2*x)*gamma(y)/gamma(x + y)
+    assert gammasimp(1/gamma(x)/gamma(x - S(1)/3)/gamma(x + S(1)/3)) == \
+        3**(3*x - S(3)/2)/(2*pi*gamma(3*x - 1))
+    assert simplify(
+        gamma(S(1)/2 + x/2)*gamma(1 + x/2)/gamma(1 + x)/sqrt(pi)*2**x) == 1
+    assert gammasimp(gamma(S(-1)/4)*gamma(S(-3)/4)) == 16*sqrt(2)*pi/3
+
+    assert powsimp(gammasimp(gamma(2*x)/gamma(x))) == \
+        2**(2*x - 1)*gamma(x + S(1)/2)/sqrt(pi)
+
+    # issue 6792
+    e = (-gamma(k)*gamma(k + 2) + gamma(k + 1)**2)/gamma(k)**2
+    assert gammasimp(e) == -k
+    assert gammasimp(1/e) == -1/k
+    e = (gamma(x) + gamma(x + 1))/gamma(x)
+    assert gammasimp(e) == x + 1
+    assert gammasimp(1/e) == 1/(x + 1)
+    e = (gamma(x) + gamma(x + 2))*(gamma(x - 1) + gamma(x))/gamma(x)
+    assert gammasimp(e) == (x**2 + x + 1)*gamma(x + 1)/(x - 1)
+    e = (-gamma(k)*gamma(k + 2) + gamma(k + 1)**2)/gamma(k)**2
+    assert gammasimp(e**2) == k**2
+    assert gammasimp(e**2/gamma(k + 1)) == k/gamma(k)
+    a = R(1, 2) + R(1, 3)
+    b = a + R(1, 3)
+    assert gammasimp(gamma(2*k)/gamma(k)*gamma(k + a)*gamma(k + b))
+    3*2**(2*k + 1)*3**(-3*k - 2)*sqrt(pi)*gamma(3*k + R(3, 2))/2
+
+    # issue 9699
+    assert gammasimp((x + 1)*factorial(x)/gamma(y)) == gamma(x + 2)/gamma(y)
+    assert gammasimp(rf(x + n, k)*binomial(n, k)) == gamma(n + 1)*gamma(k + n
+        + x)/(gamma(k + 1)*gamma(n + x)*gamma(-k + n + 1))
+
+    A, B = symbols('A B', commutative=False)
+    assert gammasimp(e*B*A) == gammasimp(e)*B*A
+
+    # check iteration
+    assert gammasimp(gamma(2*k)/gamma(k)*gamma(-k - R(1, 2))) == (
+        -2**(2*k + 1)*sqrt(pi)/(2*((2*k + 1)*cos(pi*k))))
+    assert gammasimp(
+        gamma(k)*gamma(k + R(1, 3))*gamma(k + R(2, 3))/gamma(3*k/2)) == (
+        3*2**(3*k + 1)*3**(-3*k - S.Half)*sqrt(pi)*gamma(3*k/2 + S.Half)/2)
+
+    # issue 6153
+    assert gammasimp(gamma(S(1)/4)/gamma(S(5)/4)) == 4
+
+    # was part of test_combsimp() in test_combsimp.py
+    assert gammasimp(binomial(n + 2, k + S(1)/2)) == gamma(n + 3)/ \
+        (gamma(k + 3/2)*gamma(-k + n + 5/2))
+    assert gammasimp(binomial(n + 2, k + 2.0)) == \
+        gamma(n + 3)/(gamma(k + 3.0)*gamma(-k + n + 1))
+
+    # issue 11548
+    assert gammasimp(binomial(0, x)) == sin(pi*x)/(pi*x)
+
+    e = gamma(n + S(1)/3)*gamma(n + S(2)/3)
+    assert gammasimp(e) == e
+    assert gammasimp(gamma(4*n + S(1)/2)/gamma(2*n - S(3)/4)) == \
+        2**(4*n - S(5)/2)*(8*n - 3)*gamma(2*n + S(3)/4)/sqrt(pi)
+
+    i, m = symbols('i m', integer = True)
+    e = gamma(exp(i))
+    assert gammasimp(e) == e
+    e = gamma(m + 3)
+    assert gammasimp(e) == e
+    e = gamma(m + 1)/(gamma(i + 1)*gamma(-i + m + 1))
+    assert gammasimp(e) == e

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -346,7 +346,7 @@ def can_do_meijer(a1, a2, b1, b2, numeric=True):
 
 @slow
 def test_meijerg_expand():
-    from sympy import combsimp, simplify
+    from sympy import gammasimp, simplify
     # from mpmath docs
     assert hyperexpand(meijerg([[], []], [[0], []], -z)) == exp(z)
 
@@ -396,7 +396,7 @@ def test_meijerg_expand():
                   (meijerg([0, 2], [], [], [-1, 1], z), True))
 
     # Test that the simplest possible answer is returned:
-    assert combsimp(simplify(hyperexpand(
+    assert gammasimp(simplify(hyperexpand(
         meijerg([1], [1 - a], [-a/2, -a/2 + S(1)/2], [], 1/z)))) == \
         -2*sqrt(pi)*(sqrt(z + 1) + 1)**a/a
 
@@ -564,7 +564,7 @@ def test_meijerg_with_Floats():
 
 
 def test_lerchphi():
-    from sympy import combsimp, exp_polar, polylog, log, lerchphi
+    from sympy import gammasimp, exp_polar, polylog, log, lerchphi
     assert hyperexpand(hyper([1, a], [a + 1], z)/a) == lerchphi(z, 1, a)
     assert hyperexpand(
         hyper([1, a, a], [a + 1, a + 1], z)/a**2) == lerchphi(z, 2, a)
@@ -572,11 +572,11 @@ def test_lerchphi():
         lerchphi(z, 3, a)
     assert hyperexpand(hyper([1] + [a]*10, [a + 1]*10, z)/a**10) == \
         lerchphi(z, 10, a)
-    assert combsimp(hyperexpand(meijerg([0, 1 - a], [], [0],
+    assert gammasimp(hyperexpand(meijerg([0, 1 - a], [], [0],
         [-a], exp_polar(-I*pi)*z))) == lerchphi(z, 1, a)
-    assert combsimp(hyperexpand(meijerg([0, 1 - a, 1 - a], [], [0],
+    assert gammasimp(hyperexpand(meijerg([0, 1 - a, 1 - a], [], [0],
         [-a, -a], exp_polar(-I*pi)*z))) == lerchphi(z, 2, a)
-    assert combsimp(hyperexpand(meijerg([0, 1 - a, 1 - a, 1 - a], [], [0],
+    assert gammasimp(hyperexpand(meijerg([0, 1 - a, 1 - a, 1 - a], [], [0],
         [-a, -a, -a], exp_polar(-I*pi)*z))) == lerchphi(z, 3, a)
 
     assert hyperexpand(z*hyper([1, 1], [2], z)) == -log(1 + -z)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -632,7 +632,7 @@ def ChiSquared(name, k):
     ========
 
     >>> from sympy.stats import ChiSquared, density, E, variance
-    >>> from sympy import Symbol, simplify, combsimp, expand_func
+    >>> from sympy import Symbol, simplify, gammasimp, expand_func
 
     >>> k = Symbol("k", integer=True, positive=True)
     >>> z = Symbol("z")
@@ -642,7 +642,7 @@ def ChiSquared(name, k):
     >>> density(X)(z)
     2**(-k/2)*z**(k/2 - 1)*exp(-z/2)/gamma(k/2)
 
-    >>> combsimp(E(X))
+    >>> gammasimp(E(X))
     k
 
     >>> simplify(expand_func(variance(X)))

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -542,7 +542,7 @@ def test_weibull_numeric():
     bvals = [S.Half, 1, S(3)/2, 5]
     for b in bvals:
         X = Weibull('x', a, b)
-        assert simplify(E(X)) == simplify(a * gamma(1 + 1/S(b)))
+        assert simplify(E(X)) == expand_func(a * gamma(1 + 1/S(b)))
         assert simplify(variance(X)) == simplify(
             a**2 * gamma(1 + 2/S(b)) - E(X)**2)
         # Not testing Skew... it's slow with int/frac values > 3/2

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2027,8 +2027,8 @@ def test_S4():
 
 def test_S5():
     n, k = symbols('n k', integer=True, positive=True)
-    assert (Product((2*k - 1)/(2*k), (k, 1, n)).doit().combsimp() ==
-            factorial(n - Rational(1, 2))/(sqrt(pi)*factorial(n)))
+    assert (Product((2*k - 1)/(2*k), (k, 1, n)).doit().gammasimp() ==
+            gamma(n + Rational(1, 2))/(sqrt(pi)*gamma(n + 1)))
 
 
 @SKIP("https://github.com/sympy/sympy/issues/7133")


### PR DESCRIPTION
* Removed original `as_gamma`, `as_factorial`, `as_binomial` flags
* Removed rewriting binomial coefficient to `_rf((n - k + 1).expand(), k.expand())/_rf(1, k.expand()))`. Fixes #11548 and fixes #8156
* Added binomial coefficient simplification with `binomial(n, n-r) = binomial(n, r)`. Fixes #6658 
* Expand gamma functions with rational number argument. Fixes #6153 and fixes #10101
* Added rewrite as binomial coefficient: finds `(a+b)!/a!b!` and replaces with binomial coefficient. Fixes #7135 and #6341

---

* Separated gamma function simplification(`gammasimp`) from `combsimp`. Fixes #9785, see #9785 and #13132 for related dicussions and table below.
* `combsimp` does not apply gamma function simplifications that may make an integer argument non-integer. Fixes #6341
* Using `combsimp` to simplify expression involving gamma functions or combinatorial functions with non-integer argument is passed to `gammasimp` automatically

Arguments | combsimp() | gammasimp()
----------- | ------------ | ------------
integer | factorial, binomial | gamma 
non-integer | gamma | gamma 