### PR TITLE
group theory: bug in order method

### DIFF
--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -212,6 +212,8 @@ class FpGroup(DefaultPrinting):
             return self._order
         if self._coset_table != None:
             self._order = len(self._coset_table.table)
+        elif len(self.relators) == 0:
+            self._order = S.Infinity
         elif len(self.generators) == 1:
             self._order = gcd([r.array_form[0][1] for r in self.relators])
         elif self._is_infinite():

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -129,7 +129,10 @@ class FpGroup(DefaultPrinting):
         if not all([g.group == self.free_group for g in gens]):
                 raise ValueError("Given generators are not members of the group")
         g, rels = reidemeister_presentation(self, gens, C=C)
-        g = FpGroup(g[0].group, rels)
+        if g:
+            g = FpGroup(g[0].group, rels)
+        else:
+            g = FpGroup(free_group('')[0], [])
         return g
 
     def coset_enumeration(self, H, strategy="relator_based", max_cosets=None,
@@ -212,6 +215,8 @@ class FpGroup(DefaultPrinting):
             return self._order
         if self._coset_table != None:
             self._order = len(self._coset_table.table)
+        elif len(self.generators) == 0:
+            self._order = 1
         elif len(self.relators) == 0:
             self._order = S.Infinity
         elif len(self.generators) == 1:

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -215,10 +215,8 @@ class FpGroup(DefaultPrinting):
             return self._order
         if self._coset_table != None:
             self._order = len(self._coset_table.table)
-        elif len(self.generators) == 0:
-            self._order = 1
         elif len(self.relators) == 0:
-            self._order = S.Infinity
+            self._order = self.free_group.order()
         elif len(self.generators) == 1:
             self._order = gcd([r.array_form[0][1] for r in self.relators])
         elif self._is_infinite():

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -159,6 +159,9 @@ def test_order():
     f = FpGroup(F, [a**250, b**2, c*b*c**-1*b, c**4, c**-1*a**-1*c*a, a**-1*b**-1*a*b])
     assert f.order() == 2000
 
+    f = FpGroup(F, [])
+    assert f.order() == S.Infinity
+
 def test_fp_subgroup():
     F, x, y = free_group("x, y")
     f = FpGroup(F, [x**4, y**2, x*y*x**-1*y])

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -163,6 +163,9 @@ def test_order():
     f = FpGroup(F, [])
     assert f.order() == S.Infinity
 
+    f = FpGroup(free_group('')[0], [])
+    assert f.order() == 1
+
 def test_fp_subgroup():
     F, x, y = free_group("x, y")
     f = FpGroup(F, [x**4, y**2, x*y*x**-1*y])

--- a/sympy/combinatorics/tests/test_fp_groups.py
+++ b/sympy/combinatorics/tests/test_fp_groups.py
@@ -159,6 +159,7 @@ def test_order():
     f = FpGroup(F, [a**250, b**2, c*b*c**-1*b, c**4, c**-1*a**-1*c*a, a**-1*b**-1*a*b])
     assert f.order() == 2000
 
+    F, x = free_group("x")
     f = FpGroup(F, [])
     assert f.order() == S.Infinity
 


### PR DESCRIPTION
This PR fixes a small bug in the `order` method: the size of an `FpGroup` on one generator with no relators returns 0 but should return `S.Infinity`.
