### PR TITLE
Tutorial: Fix mixup between structural and symbolic equality

### DIFF
--- a/doc/src/tutorial/gotchas.rst
+++ b/doc/src/tutorial/gotchas.rst
@@ -183,7 +183,7 @@ not the same symbolically. One is the power of an addition of two terms, and
 the other is the addition of three terms.
 
 It turns out that when using SymPy as a library, having ``==`` test for exact
-symbolic equality is far more useful than having it represent symbolic
+structural equality is far more useful than having it represent symbolic
 equality, or having it test for mathematical equality.  However, as a new
 user, you will probably care more about the latter two.  We have already seen
 an alternative to representing equalities symbolically, ``Eq``.  To test if


### PR DESCRIPTION
The text talks of "exact symbolic equality" versus "symbolic equality", but "exact structural equality" is meant (as in the previous paragraphs).
