### PR TITLE
Expression having "I"(iota) be rewritten in terms of 'exp'/'log' in DifferentialExtension

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -783,7 +783,15 @@ class Integral(AddWithLimits):
             else:
                 if i:
                     # There was a nonelementary integral. Try integrating it.
-                    return result + i.doit(risch=False)
+
+                    # if no part of the NonElementaryIntegral is integrated by
+                    # the Risch algorithm, then use the original function to
+                    # integrate, instead of re-written one
+                    if result == 0:
+                        from sympy.integrals.risch import NonElementaryIntegral
+                        return NonElementaryIntegral(f, x).doit(risch=False)
+                    else:
+                        return result + i.doit(risch=False)
                 else:
                     return result
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -28,7 +28,7 @@ from __future__ import print_function, division
 from sympy import real_roots, default_sort_key
 from sympy.abc import z
 from sympy.core.function import Lambda
-from sympy.core.numbers import ilcm, oo
+from sympy.core.numbers import ilcm, oo, I
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.relational import Eq
@@ -218,14 +218,14 @@ class DifferentialExtension(object):
         self.dummy = dummy
         self.reset()
         exp_new_extension, log_new_extension = True, True
-        if rewrite_complex:
+        if rewrite_complex or I in self.f.atoms():
             rewritables = {
                 (sin, cos, cot, tan, sinh, cosh, coth, tanh): exp,
                 (asin, acos, acot, atan): log,
             }
         # rewrite the trigonometric components
             for candidates, rule in rewritables.items():
-                self.newf = self.newf.rewrite(candidates, rule)
+                self.newf = cancel(self.newf.rewrite(candidates, rule))
         else:
             if any(i.has(x) for i in self.f.atoms(sin, cos, tan, atan, asin, acos)):
                 raise NotImplementedError("Trigonometric extensions are not "

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -161,7 +161,7 @@ class DifferentialExtension(object):
         'exts', 'extargs', 'cases', 'case', 't', 'd', 'newf', 'level',
         'ts', 'dummy')
 
-    def __init__(self, f=None, x=None, handle_first='log', dummy=False, extension=None, rewrite_complex=False):
+    def __init__(self, f=None, x=None, handle_first='log', dummy=False, extension=None, rewrite_complex=None):
         """
         Tries to build a transcendental extension tower from f with respect to x.
 
@@ -218,14 +218,20 @@ class DifferentialExtension(object):
         self.dummy = dummy
         self.reset()
         exp_new_extension, log_new_extension = True, True
-        if rewrite_complex or I in self.f.atoms():
+
+        # case of 'automatic' choosing
+        if rewrite_complex is None:
+            rewrite_complex = I in self.f.atoms()
+
+        if rewrite_complex:
             rewritables = {
                 (sin, cos, cot, tan, sinh, cosh, coth, tanh): exp,
                 (asin, acos, acot, atan): log,
             }
-        # rewrite the trigonometric components
+            # rewrite the trigonometric components
             for candidates, rule in rewritables.items():
-                self.newf = cancel(self.newf.rewrite(candidates, rule))
+                self.newf = self.newf.rewrite(candidates, rule)
+            self.newf = cancel(self.newf)
         else:
             if any(i.has(x) for i in self.f.atoms(sin, cos, tan, atan, asin, acos)):
                 raise NotImplementedError("Trigonometric extensions are not "
@@ -1626,7 +1632,7 @@ class NonElementaryIntegral(Integral):
 
 
 def risch_integrate(f, x, extension=None, handle_first='log',
-                    separate_integral=False, rewrite_complex=False,
+                    separate_integral=False, rewrite_complex=None,
                     conds='piecewise'):
     r"""
     The Risch Integration Algorithm.

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1107,7 +1107,7 @@ def test_issue_2708():
     assert integrate(2*f + exp(z), (z, 2, 3)) == \
         2*integral_f - exp(2) + exp(3)
     assert integrate(exp(1.2*n*s*z*(-t + z)/t), (z, 0, x)) == \
-        1.0*NonElementaryIntegral(exp(-1.2*n*s*z)*exp(1.2*n*s*z**2/t),
+        NonElementaryIntegral(exp(-1.2*n*s*z)*exp(1.2*n*s*z**2/t),
                                   (z, 0, x))
 
 def test_issue_8368():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1,7 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from sympy import (Poly, I, S, Function, log, symbols, exp, tan, sqrt,
     Symbol, Lambda, sin, Eq, Piecewise, factor, expand_log, cancel,
-    expand, diff, pi)
+    expand, diff, pi, atan)
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     derivation, splitfactor, splitfactor_sqf, canonical_representation,
     hermite_reduce, polynomial_reduce, residue_reduce, residue_reduce_to_basic,
@@ -568,6 +568,9 @@ def test_DifferentialExtension_misc():
         [Lambda(i, log(i))], [], [None, 'log'], [None, x])]
     assert DifferentialExtension(S.Zero, x)._important_attrs == \
         (Poly(0, x), Poly(1, x), [Poly(1, x)], [x], [], [], [None], [None])
+    assert DifferentialExtension(tan(atan(x).rewrite(log)), x)._important_attrs == \
+        (Poly(x, x, domain='ZZ'), Poly(1, x, domain='ZZ'), 
+        [Poly(1, x, domain='ZZ')], [x], [], [], [None], [None])
 
 
 def test_DifferentialExtension_Rothstein():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -569,8 +569,7 @@ def test_DifferentialExtension_misc():
     assert DifferentialExtension(S.Zero, x)._important_attrs == \
         (Poly(0, x), Poly(1, x), [Poly(1, x)], [x], [], [], [None], [None])
     assert DifferentialExtension(tan(atan(x).rewrite(log)), x)._important_attrs == \
-        (Poly(x, x, domain='ZZ'), Poly(1, x, domain='ZZ'), 
-        [Poly(1, x, domain='ZZ')], [x], [], [], [None], [None])
+        (Poly(x, x), Poly(1, x), [Poly(1, x)], [x], [], [], [None], [None])
 
 
 def test_DifferentialExtension_Rothstein():


### PR DESCRIPTION
Any expression containing `I` be rewritten in terms of `exp`/`log`. Also use `cancel` to remove factors from numerator and denominator of expression.