### PR TITLE
Catalan numbers: fix latex printing with exponents

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1818,8 +1818,11 @@ class LatexPrinter(Printer):
     def _print_euler(self, expr):
         return r"E_{%s}" % self._print(expr.args[0])
 
-    def _print_catalan(self, expr):
-        return r"C_{%s}" % self._print(expr.args[0])
+    def _print_catalan(self, expr, exp=None):
+        tex = r"C_{%s}" % self._print(expr.args[0])
+        if exp is not None:
+            tex = r"%s^{%s}" % (tex, self._print(exp))
+        return tex
 
     def _print_MellinTransform(self, expr):
         return r"\mathcal{M}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1114,6 +1114,7 @@ def test_settings():
 
 def test_latex_numbers():
     assert latex(catalan(n)) == r"C_{n}"
+    assert latex(catalan(n)**2) == r"C_{n}^{2}"
 
 
 def test_lamda():


### PR DESCRIPTION
Previously, a Catalan number raised to a power gave an error when
printed to latex.  Add test.
