### PR TITLE
Improve integer assumptions, Mod, and prime factorization of factorial

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -189,6 +189,7 @@ _assume_rules = FactRules([
 
     'prime          ->  integer & positive',
     'composite      ->  integer & positive & !prime',
+    '!composite     ->  !positive | !even | prime',
 
     'irrational     ==  real & !rational',
 

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -79,9 +79,17 @@ def _monotonic_sign(self):
                 return S(3)
             else:
                 return S(2)
+        elif s.is_composite:
+            if s.is_odd:
+                return S(9)
+            else:
+                return S(4)
         elif s.is_positive:
             if s.is_even:
-                return S(2)
+                if s.is_prime is False:
+                    return S(4)
+                else:
+                    return S(2)
             elif s.is_integer:
                 return S.One
             else:

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -40,10 +40,7 @@ class Mod(Function):
                 raise ZeroDivisionError("Modulo by zero")
             if p.is_infinite or q.is_infinite or p is nan or q is nan:
                 return nan
-            if (p == q or p == -q or
-                    p.is_Pow and p.exp.is_integer and p.base == q and q.is_integer
-                    and p.exp.is_positive or
-                    p.is_integer and q == 1):
+            if p == S.Zero or p == q or p == -q or (p.is_integer and q == 1):
                 return S.Zero
 
             if q.is_Number:
@@ -54,6 +51,11 @@ class Mod(Function):
                         return S.Zero
                     elif p.is_odd:
                         return S.One
+
+            if hasattr(p, '_eval_Mod'):
+                rv = getattr(p, '_eval_Mod')(q)
+                if rv is not None:
+                    return rv
 
             # by ratio
             r = p/q

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -92,11 +92,20 @@ class Mod(Function):
 
         # denest
         if p.func is cls:
-            # easy
             qinner = p.args[1]
-            if qinner == q:
+            if qinner % q == 0:
+                return cls(p.args[0], q)
+            elif (qinner*(q - qinner)).is_nonnegative:
+                # |qinner| < |q| and have same sign
                 return p
-            # XXX other possibilities?
+        elif (-p).func is cls:
+            qinner = (-p).args[1]
+            if qinner % q == 0:
+                return cls(-(-p).args[0], q)
+            elif (qinner*(q + qinner)).is_nonpositive:
+                # |qinner| < |q| and have different sign
+                return p
+        # XXX other possibilities?
 
         # extract gcd; any further simplification should be done by the user
         G = gcd(p, q)

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -36,6 +36,8 @@ class Mod(Function):
             to be less than or equal q.
             """
 
+            if q == S.Zero:
+                raise ZeroDivisionError("Modulo by zero")
             if p.is_infinite or q.is_infinite or p is nan or q is nan:
                 return nan
             if (p == q or p == -q or

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -69,12 +69,22 @@ class Mod(Function):
                     return rv
 
             # by difference
-            d = p - q
-            if d.is_negative:
-                if q.is_negative:
-                    return d
-                elif q.is_positive:
-                    return p
+            # -2|q| < p < 2|q|
+            d = abs(p)
+            for _ in range(2):
+                d -= abs(q)
+                if d.is_negative:
+                    if q.is_positive:
+                        if p.is_positive:
+                            return d + q
+                        elif p.is_negative:
+                            return -d
+                    elif q.is_negative:
+                        if p.is_positive:
+                            return d
+                        elif p.is_negative:
+                            return -d + q
+                    break
 
         rv = doit(p, q)
         if rv is not None:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1315,29 +1315,7 @@ class Mul(Expr, AssocOp):
         elif is_integer is False:
             return False
 
-    def _eval_is_prime(self):
-        if self.is_number:
-            """
-            If input is a number that is not completely simplified.
-            e.g. Mul(sqrt(3), sqrt(3), evaluate=False)
-            So we manually evaluate it and return whether that is prime or not.
-            """
-            # Note: `doit()` was not used due to test failing (Infinite Recursion)
-            r = S.One
-            for arg in self.args:
-                r *= arg
-            return r.is_prime
-
     def _eval_is_composite(self):
-        if self.is_number:
-            """
-            Same as _eval_is_prime
-            """
-            r = S.One
-            for arg in self.args:
-                r *= arg
-            return r.is_composite
-
         if self.is_integer and self.is_positive:
             """
             Here we count the number of arguments that have a minimum value

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1316,10 +1316,6 @@ class Mul(Expr, AssocOp):
             return False
 
     def _eval_is_prime(self):
-        """
-        If product is a positive integer, multiplication
-        will never result in a prime number.
-        """
         if self.is_number:
             """
             If input is a number that is not completely simplified.
@@ -1332,11 +1328,21 @@ class Mul(Expr, AssocOp):
                 r *= arg
             return r.is_prime
 
+    def _eval_is_composite(self):
+        if self.is_number:
+            """
+            Same as _eval_is_prime
+            """
+            r = S.One
+            for arg in self.args:
+                r *= arg
+            return r.is_composite
+
         if self.is_integer and self.is_positive:
             """
             Here we count the number of arguments that have a minimum value
             greater than two.
-            If there are more than one of such a symbol then the result is not prime.
+            If there are more than one of such a symbol then the result is composite.
             Else, the result cannot be determined.
             """
             number_of_args = 0 # count of symbols with minimum value greater than one
@@ -1345,7 +1351,7 @@ class Mul(Expr, AssocOp):
                     number_of_args += 1
 
             if number_of_args > 1:
-                return False
+                return True
 
     def _eval_subs(self, old, new):
         from sympy.functions.elementary.complexes import sign

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -338,6 +338,11 @@ class Pow(Expr):
         if s is not None:
             return s*Pow(b, e*other)
 
+    def _eval_Mod(self, q):
+        if self.exp.is_integer and self.exp.is_positive:
+            if q.is_integer and self.base % q == 0:
+                return S.Zero
+
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:
             return self.base.is_even

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -343,6 +343,13 @@ class Pow(Expr):
             if q.is_integer and self.base % q == 0:
                 return S.Zero
 
+            '''
+            For unevaluated Integer power, use built-in pow modular
+            exponentiation.
+            '''
+            if self.base.is_Integer and self.exp.is_Integer and q.is_Integer:
+                return pow(int(self.base), int(self.exp), int(q))
+
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:
             return self.base.is_even

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -545,18 +545,26 @@ class Pow(Expr):
                 return True
 
     def _eval_is_prime(self):
-        if self.exp == S.One:
-            return self.base.is_prime
+        '''
+        An integer raised to the n(>=2)-th power cannot be a prime.
+        '''
+        if self.base.is_integer and self.exp.is_integer and (self.exp-1).is_positive:
+            return False
+
         if self.is_number:
             return self.doit().is_prime
 
-        if self.is_integer and self.is_positive:
-            """
-            a Power will be non-prime only if both base and exponent
-            are greater than 1
-            """
-            if (self.base-1).is_positive or (self.exp-1).is_positive:
-                return False
+    def _eval_is_composite(self):
+        """
+        A power is composite if both base and exponent are greater than 1
+        """
+        if (self.base.is_integer and self.exp.is_integer and
+            ((self.base-1).is_positive and (self.exp-1).is_positive or
+            (self.base+1).is_negative and self.exp.is_positive and self.exp.is_even)):
+            return True
+
+        if self.is_number:
+            return self.doit().is_composite
 
     def _eval_is_polar(self):
         return self.base.is_polar

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -563,9 +563,6 @@ class Pow(Expr):
         if self.base.is_integer and self.exp.is_integer and (self.exp-1).is_positive:
             return False
 
-        if self.is_number:
-            return self.doit().is_prime
-
     def _eval_is_composite(self):
         """
         A power is composite if both base and exponent are greater than 1
@@ -574,9 +571,6 @@ class Pow(Expr):
             ((self.base-1).is_positive and (self.exp-1).is_positive or
             (self.base+1).is_negative and self.exp.is_positive and self.exp.is_even)):
             return True
-
-        if self.is_number:
-            return self.doit().is_composite
 
     def _eval_is_polar(self):
         return self.base.is_polar

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1544,13 +1544,18 @@ def test_Mod():
             assert Mod(3*x + y, 9).subs(reps) == (3*_x + _y) % 9
 
     # denesting
-    #   easy case
-    assert Mod(Mod(x, y), y) == Mod(x, y)
-    #   in case someone attempts more denesting
-    for i in [-3, -2, 2, 3]:
-        for j in [-3, -2, 2, 3]:
-            for k in range(3):
-                assert Mod(Mod(k, i), j) == (k % i) % j
+    t = Symbol('t', real=True)
+    assert Mod(Mod(x, t), t) == Mod(x, t)
+    assert Mod(-Mod(x, t), t) == Mod(-x, t)
+    assert Mod(Mod(x, 2*t), t) == Mod(x, t)
+    assert Mod(-Mod(x, 2*t), t) == Mod(-x, t)
+    assert Mod(Mod(x, t), 2*t) == Mod(x, t)
+    assert Mod(-Mod(x, t), -2*t) == -Mod(x, t)
+    for i in [-4, -2, 2, 4]:
+        for j in [-4, -2, 2, 4]:
+            for k in range(4):
+                assert Mod(Mod(x, i), j).subs({x: k}) == (k % i) % j
+                assert Mod(-Mod(x, i), j).subs({x: k}) == -(k % i) % j
 
     # known difference
     assert Mod(5*sqrt(2), sqrt(5)) == 5*sqrt(2) - 3*sqrt(5)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1617,6 +1617,9 @@ def test_Mod():
     # issue 8677
     n = Symbol('n', integer=True, positive=True)
     assert (factorial(n) % n).equals(0) is not False
+    # modular exponentiation
+    assert Mod(Pow(4, 13, evaluate=False), 497) == Mod(Pow(4, 13), 497)
+
 
     # symbolic with known parity
     n = Symbol('n', even=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1616,10 +1616,21 @@ def test_Mod():
 
     # issue 8677
     n = Symbol('n', integer=True, positive=True)
-    assert (factorial(n) % n).equals(0) is not False
+    assert factorial(n) % n == 0
+    assert factorial(n + 2) % n == 0
+    assert (factorial(n + 4) % (n + 5)).func is Mod
+
     # modular exponentiation
     assert Mod(Pow(4, 13, evaluate=False), 497) == Mod(Pow(4, 13), 497)
 
+    # Wilson's theorem
+    factorial(18042, evaluate=False) % 18043 == 18042
+    p = Symbol('n', prime=True)
+    factorial(p - 1) % p == p - 1
+    factorial(p - 1) % -p == -1
+    (factorial(3, evaluate=False) % 4).doit() == 2
+    n = Symbol('n', composite=True, odd=True)
+    factorial(n - 1) % n == 0
 
     # symbolic with known parity
     n = Symbol('n', even=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1555,11 +1555,15 @@ def test_Mod():
     # known difference
     assert Mod(5*sqrt(2), sqrt(5)) == 5*sqrt(2) - 3*sqrt(5)
     p = symbols('p', positive=True)
-    assert Mod(p + 1, p + 3) == p + 1
-    n = symbols('n', negative=True)
-    assert Mod(n - 3, n - 1) == -2
-    assert Mod(n - 2*p, n - p) == -p
-    assert Mod(p - 2*n, p - n) == -n
+    assert Mod(2, p + 3) == 2
+    assert Mod(-2, p + 3) == p + 1
+    assert Mod(2, -p - 3) == -p - 1
+    assert Mod(-2, -p - 3) == -2
+    assert Mod(p + 5, p + 3) == 2
+    assert Mod(-p - 5, p + 3) == p + 1
+    assert Mod(p + 5, -p - 3) == -p - 1
+    assert Mod(-p - 5, -p - 3) == -2
+    assert Mod(p + 1, p - 1).func is Mod
 
     # handling sums
     assert (x + 3) % 1 == Mod(x, 1)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1513,8 +1513,16 @@ def test_Mod():
     assert Mod(1, nan) == nan
     assert Mod(nan, nan) == nan
 
+    Mod(0, x) == 0
     with raises(ZeroDivisionError):
         Mod(x, 0)
+
+    k = Symbol('k', integer=True)
+    m = Symbol('m', integer=True, positive=True)
+    assert (x**m % x).func is Mod
+    assert (k**(-m) % k).func is Mod
+    assert k**m % k == 0
+    assert (-2*k)**m % k == 0
 
     # Float handling
     point3 = Float(3.3) % 1

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1513,6 +1513,9 @@ def test_Mod():
     assert Mod(1, nan) == nan
     assert Mod(nan, nan) == nan
 
+    with raises(ZeroDivisionError):
+        Mod(x, 0)
+
     # Float handling
     point3 = Float(3.3) % 1
     assert (x - 3.3) % 1 == Mod(1.*x + 1 - point3, 1)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -779,13 +779,6 @@ def test_Mul_is_prime_composite():
     assert ( (x+1)*(y+1) ).is_prime is None
     assert ( (x+1)*(y+1) ).is_composite is None
 
-    assert Mul(6, S.Half, evaluate=False).is_prime is True
-    assert Mul(6, S.Half, evaluate=False).is_composite is False
-    assert Mul(sqrt(3), sqrt(3), evaluate=False).is_prime is True
-    assert Mul(sqrt(3), sqrt(3), evaluate=False).is_composite is False
-    assert Mul(5, S.Half, evaluate=False).is_prime is False
-    assert Mul(5, S.Half, evaluate=False).is_composite is False
-
 def test_Pow_is_prime_composite():
     from sympy import Pow
     x = Symbol('x', positive=True, integer=True)
@@ -798,13 +791,6 @@ def test_Pow_is_prime_composite():
 
     x = Symbol('x', positive=True)
     assert (x**y).is_prime is None
-
-    assert Pow(6, S.One, evaluate=False).is_prime is False
-    assert Pow(6, S.One, evaluate=False).is_composite is True
-    assert Pow(9, S.Half, evaluate=False).is_prime is True
-    assert Pow(9, S.Half, evaluate=False).is_composite is False
-    assert Pow(5, S.One, evaluate=False).is_prime is True
-    assert Pow(5, S.One, evaluate=False).is_composite is False
 
 
 def test_Mul_is_infinite():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -520,6 +520,9 @@ def test_composite():
     x = Dummy(integer=True, positive=True, prime=False)
     assert x.is_composite is None # x could be 1
     assert (x + 1).is_composite is None
+    x = Dummy(positive=True, even=True, prime=False)
+    assert x.is_integer is True
+    assert x.is_composite is True
 
 
 def test_prime_symbol():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -767,19 +767,24 @@ def test_Pow_is_algebraic():
     assert (pi**r).is_algebraic is True
 
 
-def test_Mul_is_prime():
+def test_Mul_is_prime_composite():
     from sympy import Mul
     x = Symbol('x', positive=True, integer=True)
     y = Symbol('y', positive=True, integer=True)
     assert (x*y).is_prime is None
     assert ( (x+1)*(y+1) ).is_prime is False
+    assert ( (x+1)*(y+1) ).is_composite is True
 
     x = Symbol('x', positive=True)
-    assert (x*y).is_prime is None
+    assert ( (x+1)*(y+1) ).is_prime is None
+    assert ( (x+1)*(y+1) ).is_composite is None
 
     assert Mul(6, S.Half, evaluate=False).is_prime is True
+    assert Mul(6, S.Half, evaluate=False).is_composite is False
     assert Mul(sqrt(3), sqrt(3), evaluate=False).is_prime is True
+    assert Mul(sqrt(3), sqrt(3), evaluate=False).is_composite is False
     assert Mul(5, S.Half, evaluate=False).is_prime is False
+    assert Mul(5, S.Half, evaluate=False).is_composite is False
 
 def test_Pow_is_prime():
     from sympy import Pow

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -786,18 +786,25 @@ def test_Mul_is_prime_composite():
     assert Mul(5, S.Half, evaluate=False).is_prime is False
     assert Mul(5, S.Half, evaluate=False).is_composite is False
 
-def test_Pow_is_prime():
+def test_Pow_is_prime_composite():
     from sympy import Pow
     x = Symbol('x', positive=True, integer=True)
     y = Symbol('y', positive=True, integer=True)
     assert (x**y).is_prime is None
+    assert ( x**(y+1) ).is_prime is False
+    assert ( x**(y+1) ).is_composite is None
+    assert ( (x+1)**(y+1) ).is_composite is True
+    assert ( (-x-1)**(2*y) ).is_composite is True
 
     x = Symbol('x', positive=True)
     assert (x**y).is_prime is None
 
     assert Pow(6, S.One, evaluate=False).is_prime is False
+    assert Pow(6, S.One, evaluate=False).is_composite is True
     assert Pow(9, S.Half, evaluate=False).is_prime is True
+    assert Pow(9, S.Half, evaluate=False).is_composite is False
     assert Pow(5, S.One, evaluate=False).is_prime is True
+    assert Pow(5, S.One, evaluate=False).is_composite is False
 
 
 def test_Mul_is_infinite():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -994,10 +994,14 @@ def test_issues_8632_8633_8638_8675_8992():
     assert (n - 3).is_nonpositive
 
 
-def test_issue_9115():
+def test_issue_9115_9150():
     n = Dummy('n', integer=True, nonnegative=True)
     assert (factorial(n) >= 1) == True
     assert (factorial(n) < 1) == False
+
+    assert factorial(n + 1).is_even is None
+    assert factorial(n + 2).is_even is True
+    assert factorial(n + 2) >= 2
 
 
 def test_issue_9165():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1771,7 +1771,7 @@ def test_issue_6325():
 def test_issue_7426():
     f1 = a % c
     f2 = x % z
-    assert f1.equals(f2) == False
+    assert f1.equals(f2) is None
 
 
 def test_issue_1112():

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -384,8 +384,11 @@ def test_monotonic_sign():
     assert F(-x) is None
     assert F(Dummy(prime=True)) == 2
     assert F(Dummy(prime=True, odd=True)) == 3
+    assert F(Dummy(composite=True)) == 4
+    assert F(Dummy(composite=True, odd=True)) == 9
     assert F(Dummy(positive=True, integer=True)) == 1
     assert F(Dummy(positive=True, even=True)) == 2
+    assert F(Dummy(positive=True, even=True, prime=False)) == 4
     assert F(Dummy(negative=True, integer=True)) == -1
     assert F(Dummy(negative=True, even=True)) == -2
     assert F(Dummy(zero=True)) == 0

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -77,7 +77,6 @@ def test_mod():
 
     p = Symbol('p', infinite=True)
 
-    assert zoo % 0 == nan
     assert oo % oo == nan
     assert zoo % oo == nan
     assert 5 % oo == nan

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -121,20 +121,6 @@ def test_mod():
     assert Integer(10) % 4 == Integer(2)
     assert 15 % Integer(4) == Integer(3)
 
-    h = Symbol('h')
-    m = h ** 2 % h
-    k = h ** -2 % h
-    l = Symbol('l', integer=True)
-    p = Symbol('p', integer=True, positive=True)
-    q = Symbol('q', integer=True, negative=True)
-
-    assert m == h * (h % 1)
-    assert k == Mod(h ** -2, h, evaluate=False)
-    assert Mod(l ** p, l) == 0
-    assert Mod(l ** 2, l) == 0
-    assert (l ** q % l) == Mod(l ** q, l, evaluate=False)
-    assert (l ** -2 % l) == Mod(l ** -2, l, evaluate=False)
-
 
 def test_divmod():
     assert divmod(S(12), S(8)) == Tuple(1, 4)

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -204,6 +204,25 @@ class factorial(CombinatorialFunction):
         if x.is_nonnegative or x.is_noninteger:
             return True
 
+    def _eval_Mod(self, q):
+        x = self.args[0]
+        if x.is_integer and x.is_nonnegative and q.is_integer:
+            aq = abs(q)
+            d = x - aq
+            if d.is_nonnegative:
+                return 0
+            elif d == -1:
+                '''
+                Apply Wilson's theorem-if a natural number n > 1
+                is a prime number, (n-1)! = -1 mod n-and its
+                inverse-if n > 4 is a composite number,
+                (n-1)! = 0 mod n
+                '''
+                if aq.is_prime:
+                    return -1 % q
+                elif aq.is_composite and (aq - 6).is_nonnegative:
+                    return 0
+
 
 class MultiFactorial(CombinatorialFunction):
     pass

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -189,9 +189,14 @@ class factorial(CombinatorialFunction):
         if self.args[0].is_integer and self.args[0].is_nonnegative:
             return True
 
+    def _eval_is_even(self):
+        x = self.args[0]
+        if x.is_integer and x.is_nonnegative:
+            return (x - 2).is_nonnegative
+
     def _eval_is_composite(self):
         x = self.args[0]
-        if x.is_integer:
+        if x.is_integer and x.is_nonnegative:
             return (x - 3).is_nonnegative
 
     def _eval_is_real(self):

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -128,7 +128,6 @@ def test_factorial():
     s = Symbol('s', integer=False, negative=True)
     t = Symbol('t', nonnegative=True)
     u = Symbol('u', noninteger=True)
-    v = Symbol('v', integer=True, negative=True)
 
     assert factorial(-2) == zoo
     assert factorial(0) == 1
@@ -162,7 +161,6 @@ def test_factorial():
     assert factorial(s).is_composite is None
     assert factorial(t).is_composite is None
     assert factorial(u).is_composite is None
-    assert factorial(v).is_composite is False
 
     assert factorial(oo) == oo
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -942,6 +942,8 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     ``factorint`` also periodically checks if the remaining part is
     a prime number or a perfect power, and in those cases stops.
 
+    For unevaluated factorial, it uses Legendre's formula(theorem).
+
 
     If ``verbose`` is set to ``True``, detailed progress is printed.
 
@@ -999,6 +1001,28 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         return factordict
 
     assert use_trial or use_rho or use_pm1
+
+    # for unevaluated factorial, if n < 20!, direct computation is faster
+    # since it uses lookup table
+    from sympy.functions.combinatorial.factorials import factorial
+    if isinstance(n, factorial) and n.args[0].is_Integer and n.args[0] >= 20:
+        x = n.args[0]
+        factors = {}
+        for p in sieve.primerange(2, x):
+            m = 0
+            d = p
+            q = x // p
+            while q != 0:
+                m += q
+                d *= p
+                q = x // d
+            factors[p] = m
+        if factors and verbose:
+            for k in sorted(factors):
+                print(factor_msg % (k, factors[k]))
+        if verbose:
+            print(complete_msg)
+        return factors
 
     n = as_int(n)
     if limit:

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -174,13 +174,17 @@ def test_factorint():
     assert factorint(2**(2**6) + 1, multiple=True) == [274177, 67280421310721]
 
     assert multiproduct(factorint(fac(200))) == fac(200)
+    assert multiproduct(factorint(fac(200, evaluate=False))) == fac(200)
     for b, e in factorint(fac(150)).items():
+        assert e == fac_multiplicity(150, b)
+    for b, e in factorint(fac(150, evaluate=False)).items():
         assert e == fac_multiplicity(150, b)
     assert factorint(103005006059**7) == {103005006059: 7}
     assert factorint(31337**191) == {31337: 191}
     assert factorint(2**1000 * 3**500 * 257**127 * 383**60) == \
         {2: 1000, 3: 500, 257: 127, 383: 60}
     assert len(factorint(fac(10000))) == 1229
+    assert len(factorint(fac(10000, evaluate=False))) == 1229
     assert factorint(12932983746293756928584532764589230) == \
         {2: 1, 5: 1, 73: 1, 727719592270351: 1, 63564265087747: 1, 383: 1}
     assert factorint(727719592270351) == {727719592270351: 1}


### PR DESCRIPTION
**Integer assumptions:**
* positive non-prime even -> composite
* odd composite >= 9
* composite >= 4
* even non-prime >= 4
* Mul and Pow: added _eval_is_composite
* Pow: improved _eval_is_prime: fixes #9151
* factorial: added _eval_is_even: fixes #9150
* factorial: non-negative check for _eval_is_composite

**Mod**
* raise ZeroDivisionError when modulo divisor is zero
* evaluate to zero when dividend is zero
* fixed incorrect result of Mod by difference: fixes #13125
* improved mod denesting
* call _eval_Mod for function-specific implementation of modulo operation
* Pow: evaluate to zero when base % q == 0
* Pow: use built-in pow modular exponentiation
* factorial: evaluate to zero when >=q!: fixes #8677
* factorial: implemented Wilson's theorem and its inverse

**Prime factorization**
* implemented Legendre's formula for prime factorization(factorint) of unevaluated factorial.