### PR TITLE
enforce Boolean args in BooleanFunction

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2117,7 +2117,7 @@ def test_sympy__liealgebras__type_g__TypeG():
 
 def test_sympy__logic__boolalg__And():
     from sympy.logic.boolalg import And
-    assert _test_args(And(x, y, 2))
+    assert _test_args(And(x, y, 1))
 
 
 @SKIP("abstract class")
@@ -2158,7 +2158,7 @@ def test_sympy__logic__boolalg__Implies():
 
 def test_sympy__logic__boolalg__Nand():
     from sympy.logic.boolalg import Nand
-    assert _test_args(Nand(x, y, 2))
+    assert _test_args(Nand(x, y, 1))
 
 
 def test_sympy__logic__boolalg__Nor():

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -95,17 +95,17 @@ def test_count_ops_visual():
     assert count(Basic()) == 0
     assert count(Basic(Basic(),Basic(x,x+y))) == ADD + 2*BASIC
     assert count(Basic(x, x + y)) == ADD + BASIC
-    assert count(Or(x,y)) == OR
-    assert count(And(x,y)) == AND
-    assert count(And(x**y,z)) == AND + POW
-    assert count(Or(x,Or(y,And(z,a)))) == AND + OR
-    assert count(Nor(x,y)) == NOT + OR
-    assert count(Nand(x,y)) == NOT + AND
-    assert count(Xor(x,y)) == XOR
-    assert count(Implies(x,y)) == IMPLIES
-    assert count(Equivalent(x,y)) == EQUIVALENT
-    assert count(ITE(x,y,z)) == ITE
-    assert count([Or(x,y), And(x,y), Basic(x+y)]) == ADD + AND + BASIC + OR
+    assert count(Or(x, y)) == OR
+    assert count(And(x, y)) == AND
+    assert count(Or(x, Or(y, And(z, a)))) == AND + OR
+    assert count(Nor(x, y)) == NOT + OR
+    assert count(Nand(x, y)) == NOT + AND
+    assert count(Xor(x, y)) == XOR
+    assert count(Implies(x, y)) == IMPLIES
+    assert count(Equivalent(x, y)) == EQUIVALENT
+    assert count(ITE(x, y, z)) == ITE
+    assert count([Or(x, y), And(x, y), Basic(x + y)]
+        ) == ADD + AND + BASIC + OR
 
     assert count(Basic(Tuple(x))) == BASIC + TUPLE
     #It checks that TUPLE is counted as an operation.

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -6,7 +6,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 from itertools import combinations, product
 
-from sympy.core.basic import Atom, Basic
+from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
 from sympy.core.numbers import Number
 from sympy.core.operations import LatticeOp
@@ -1010,13 +1010,7 @@ class ITE(BooleanFunction):
                 return Not(a)
 
     def to_nnf(self, simplify=True):
-        B = _bool(self)
-        if not isinstance(B, ITE):
-            try:
-                return B.to_nnf()
-            except AttributeError:
-                return B
-        a, b, c = B.args
+        a, b, c = _bool(self).args
         return And._to_nnf(Or(~a, b), Or(a, c), simplify=simplify)
 
     def _eval_derivative(self, x):

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -6,7 +6,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 from itertools import combinations, product
 
-from sympy.core.basic import Basic
+from sympy.core.basic import Atom, Basic
 from sympy.core.cache import cacheit
 from sympy.core.numbers import Number
 from sympy.core.operations import LatticeOp
@@ -15,6 +15,41 @@ from sympy.core.compatibility import ordered, range, with_metaclass, as_int
 from sympy.core.sympify import converter, _sympify, sympify
 from sympy.core.singleton import Singleton, S
 
+
+def _bool(e):
+    """Like bool, return the Boolean value of an expression, e,
+    which can be any instance of Boolean or bool.
+
+    Examples
+    ========
+
+    >>> from sympy import true, false, nan
+    >>> from sympy.logic.boolalg import _bool as Bool
+    >>> from sympy.abc import x
+    >>> Bool(1) is true
+    True
+    >>> Bool(x)
+    x
+    >>> Bool(2)
+    Traceback (most recent call last):
+    ...
+    TypeError: expecting bool, Boolean or ITE, not `2`
+    """
+    from sympy.core.symbol import Symbol
+    if e == True:
+        return S.true
+    if e == False:
+        return S.false
+    if isinstance(e, Symbol):
+        z = e.is_zero
+        if z is None:
+            return e
+        return S.false if z else S.true
+    if isinstance(e, ITE):
+        return ITE(*map(_bool, e.args))
+    if isinstance(e, Boolean):
+        return e
+    raise TypeError('expecting bool, Boolean or ITE, not `%s`' % e)
 
 class Boolean(Basic):
     """A boolean object is an object for which logic operations make sense."""
@@ -77,6 +112,10 @@ class Boolean(Basic):
             raise NotImplementedError('handling of relationals')
         return self.atoms() == other.atoms() and \
                 not satisfiable(Not(Equivalent(self, other)))
+
+    def to_nnf(self):
+        # override where necessary
+        return self
 
 
 class BooleanAtom(Boolean):
@@ -349,10 +388,7 @@ class And(LatticeOp, BooleanFunction):
     def _new_args_filter(cls, args):
         newargs = []
         rel = []
-        for x in reversed(list(args)):
-            if isinstance(x, Number) or x in (0, 1):
-                newargs.append(True if x else False)
-                continue
+        for x in reversed(list(map(_bool, args))):
             if x.is_Relational:
                 c = x.canonical
                 if c in rel:
@@ -420,10 +456,7 @@ class Or(LatticeOp, BooleanFunction):
     def _new_args_filter(cls, args):
         newargs = []
         rel = []
-        for x in args:
-            if isinstance(x, Number) or x in (0, 1):
-                newargs.append(True if x else False)
-                continue
+        for x in map(_bool, args):
             if x.is_Relational:
                 c = x.canonical
                 if c in rel:
@@ -935,7 +968,8 @@ class ITE(BooleanFunction):
     If then else clause.
 
     ITE(A, B, C) evaluates and returns the result of B if A is true
-    else it returns the result of C
+    else it returns the result of C. A is enforced to be a Boolean
+    but B and C can be arbitrary expressions.
 
     Examples
     ========
@@ -954,16 +988,18 @@ class ITE(BooleanFunction):
     y
     >>> ITE(x, y, y)
     y
+    >>> ITE(True, [], ())
+    []
     """
     @classmethod
     def eval(cls, *args):
-        try:
-            a, b, c = args
-        except ValueError:
+        if len(args) != 3:
             raise ValueError("ITE expects exactly 3 arguments")
-        if a == True:
+        a, b, c= args
+        a = _bool(a)
+        if a is S.true:
             return b
-        if a == False:
+        if a is S.false:
             return c
         if b == c:
             return b
@@ -974,7 +1010,13 @@ class ITE(BooleanFunction):
                 return Not(a)
 
     def to_nnf(self, simplify=True):
-        a, b, c = self.args
+        B = _bool(self)
+        if not isinstance(B, ITE):
+            try:
+                return B.to_nnf()
+            except AttributeError:
+                return B
+        a, b, c = B.args
         return And._to_nnf(Or(~a, b), Or(a, c), simplify=simplify)
 
     def _eval_derivative(self, x):
@@ -1741,9 +1783,6 @@ def simplify_logic(expr, form=None, deep=True):
         If 'cnf' or 'dnf', the simplest expression in the corresponding
         normal form is returned; if None, the answer is returned
         according to the form with fewest args (in CNF by default).
-    deep : boolean (default True)
-        indicates whether to recursively simplify any
-        non-boolean functions contained within the input.
 
     Examples
     ========
@@ -1772,9 +1811,6 @@ def simplify_logic(expr, form=None, deep=True):
             t = list(t)
             if expr.xreplace(dict(zip(variables, t))) == True:
                 truthtable.append(t)
-        if deep:
-            from sympy.simplify.simplify import simplify
-            variables = [simplify(v) for v in variables]
         if form == 'dnf' or \
            (form is None and len(truthtable) >= (2 ** (len(variables) - 1))):
             return SOPform(variables, truthtable)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -402,8 +402,6 @@ def test_to_nnf():
     assert ITE(A, 0, 1).to_nnf() == ~A
     # although ITE can hold non-Boolean, it will complain if
     # an attempt is made to convert the ITE to Boolean nnf
-    assert ITE(A < 1, [1], []).subs(A, 0) == [1]
-    assert ITE(A < 1, [1], []).subs(A, 2) == []
     raises(TypeError, lambda: ITE(A < 1, [1], B).to_nnf())
 
 


### PR DESCRIPTION
Current modifications:

* SymPy now enforces Boolean args where and when appropriate, e.g. `And(1, 0)` -> False but `And(1, 2)` and `And(x + 1, y)` raise a TypeError b/c of 2 and `x + 1`, respectively.
* ITE is still allowed to contain arbitrary, unsympified args.
* `Boolean.to_nnf` was added so `ITE(x, 1, 0).to_nnf()` does not generate an error.
```
>>> ITE(x, 1, 0)
x  # didn't have to_nnf method
```

=============== old comments

The Bool function was added which converts, when possible, its argument to
a True or a False value. This is similar to the bool function of python
with the following difference: **plain symbols and values which cannot be
determined to be zero or nonzero are not converted (and nan, being a
Number which is neither zero nor non-zero, is not converted)**. This opens
the posibility of representing Piecewise with no default condition as
an ITE with a nan for the default, e.g.

Piecewise((x, x > 1)).rewrite(ITE) -> ITE(x > 1, x, S.NaN)

(This change is not part of this commit, however.)

```
>>> bool(x)
True
>>> x.is_Boolean, isinstance(x, Boolean)
False, True  # is that right?
>>> Bool(x)
x
>>> Bool(S.NaN)
S.NaN
>>> ITE(x<1,(1,2),S.NaN).to_nnf()  # from #13223
nan | (x < 1)
```

closes #13223 
