### PR TITLE
Improve simplification of hyperbolic functions

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1018,10 +1018,10 @@ class tan(TrigonometricFunction):
             x, m = _peeloff_pi(arg)
             if m:
                 tanm = tan(m)
-                tanx = tan(x)
                 if tanm is S.ComplexInfinity:
                     return -cot(x)
-                return (tanm + tanx)/(1 - tanm*tanx)
+                else: # tanm == 0
+                    return tan(x)
 
         if arg.func is atan:
             return arg.args[0]
@@ -1300,14 +1300,10 @@ class cot(TrigonometricFunction):
             x, m = _peeloff_pi(arg)
             if m:
                 cotm = cot(m)
-                if cotm == 0:
-                    return -tan(x)
-                cotx = cot(x)
                 if cotm is S.ComplexInfinity:
-                    return cotx
-                if cotm.is_Rational:
-                    return (cotm*cotx - 1) / (cotm + cotx)
-            return None
+                    return cot(x)
+                else: # cotm == 0
+                    return -tan(x)
 
         if arg.func is acot:
             return arg.args[0]

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -195,7 +195,7 @@ from sympy.core.sympify import sympify
 from sympy.functions.elementary.trigonometric import (
     cos, sin, tan, cot, sec, csc, sqrt, TrigonometricFunction)
 from sympy.functions.elementary.hyperbolic import (
-    cosh, sinh, tanh, coth, HyperbolicFunction)
+    cosh, sinh, tanh, coth, sech, csch, HyperbolicFunction)
 from sympy.core.compatibility import ordered, range
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
@@ -2049,6 +2049,10 @@ def _osborne(e, d):
             return I*tan(a)
         elif rv.func is coth:
             return cot(a)/I
+        elif rv.func is sech:
+            return sec(a)
+        elif rv.func is csch:
+            return csc(a)/I
         else:
             raise NotImplementedError('unhandled %s' % rv.func)
 
@@ -2074,7 +2078,8 @@ def _osbornei(e, d):
     def f(rv):
         if not isinstance(rv, TrigonometricFunction):
             return rv
-        a = rv.args[0].xreplace({d: S.One})
+        const, x = rv.args[0].as_independent(d, as_Add=True)
+        a = x.xreplace({d: S.One}) + const*I
         if rv.func is sin:
             return sinh(a)/I
         elif rv.func is cos:
@@ -2084,9 +2089,9 @@ def _osbornei(e, d):
         elif rv.func is cot:
             return coth(a)*I
         elif rv.func is sec:
-            return 1/cosh(a)
+            return sech(a)
         elif rv.func is csc:
-            return I/sinh(a)
+            return csch(a)*I
         else:
             raise NotImplementedError('unhandled %s' % rv.func)
 

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -1,10 +1,10 @@
 from sympy import (
-    Add, Mul, S, Symbol, cos, cot, pi, I, sin, sqrt, tan, root,
-    powsimp, symbols, sinh, cosh, tanh, coth, Dummy)
+    Add, Mul, S, Symbol, cos, cot, pi, I, sin, sqrt, tan, root, csc, sec,
+    powsimp, symbols, sinh, cosh, tanh, coth, sech, csch, Dummy)
 from sympy.simplify.fu import (
     L, TR1, TR10, TR10i, TR11, TR12, TR12i, TR13, TR14, TR15, TR16,
     TR111, TR2, TR2i, TR3, TR5, TR6, TR7, TR8, TR9, TRmorrie, _TR56 as T,
-    hyper_as_trig, csc, fu, process_common_addends, sec, trig_split,
+    hyper_as_trig, fu, process_common_addends, trig_split,
     as_f_sign_1)
 from sympy.utilities.randtest import verify_numerically
 from sympy.core.compatibility import range
@@ -349,18 +349,20 @@ def test_hyper_as_trig():
     assert o(tanh(x), d) == I*tan(x*d)
     assert o(coth(x), d) == cot(x*d)/I
     assert o(cosh(x), d) == cos(x*d)
-    for func in (sinh, cosh, tanh, coth):
+    assert o(sech(x), d) == sec(x*d)
+    assert o(csch(x), d) == csc(x*d)/I
+    for func in (sinh, cosh, tanh, coth, sech, csch):
         h = func(pi)
         assert i(o(h, d), d) == h
     # /!\ the _osborne functions are not meant to work
     # in the o(i(trig, d), d) direction so we just check
     # that they work as they are supposed to work
-    assert i(cos(x*y), y) == cosh(x)
-    assert i(sin(x*y), y) == sinh(x)/I
-    assert i(tan(x*y), y) == tanh(x)/I
-    assert i(cot(x*y), y) == coth(x)*I
-    assert i(sec(x*y), y) == 1/cosh(x)
-    assert i(csc(x*y), y) == I/sinh(x)
+    assert i(cos(x*y + z), y) == cosh(x + z*I)
+    assert i(sin(x*y + z), y) == sinh(x + z*I)/I
+    assert i(tan(x*y + z), y) == tanh(x + z*I)/I
+    assert i(cot(x*y + z), y) == coth(x + z*I)*I
+    assert i(sec(x*y + z), y) == sech(x + z*I)
+    assert i(csc(x*y + z), y) == csch(x + z*I)*I
 
 
 def test_TR12i():

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -276,6 +276,10 @@ def test_hyperbolic_simp():
     assert trigsimp(y*tanh(x)**2/sinh(x)**2) == y/cosh(x)**2
     assert trigsimp(coth(x)/cosh(x)) == 1/sinh(x)
 
+    for a in (pi/6*I, pi/4*I, pi/3*I):
+        assert trigsimp(sinh(a)*cosh(x) + cosh(a)*sinh(x)) == sinh(x + a)
+        assert trigsimp(-sinh(a)*cosh(x) + cosh(a)*sinh(x)) == sinh(x - a)
+
     e = 2*cosh(x)**2 - 2*sinh(x)**2
     assert trigsimp(log(e)) == log(2)
 


### PR DESCRIPTION
- Fixed incorrect hyper to trig conversion in hyper_as_trig(_osbornei) when constant is intoduced during simplification: Fixes #11685.
- Fixed simplifying expressions with sech or csch raising NotImplementedError.
- Improved tan/cot _peeloff_pi logic, as m is guaranteed to be Rational multiple of pi/2.
- Added _peeloff_ipi and simplification in hyperbolic functions, which makes Rational pi coefficient of imaginary part to be in [0, pi/2), same behavior as trigonometric functions.