### PR TITLE
Remove `import pytest` from test_rewriting.py and skip test_integrals.py:test_issue_7130 on Travis

### DIFF
--- a/sympy/codegen/tests/test_rewriting.py
+++ b/sympy/codegen/tests/test_rewriting.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import (absolute_import, division, print_function)
 
-import pytest
 from sympy import log, exp, Symbol, Pow
 from sympy.codegen.cfunctions import log2, exp2, expm1, log1p
 from sympy.codegen.rewriting import optimize, log2_opt, exp2_opt, expm1_opt, log1p_opt, optims_c99

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -10,7 +10,7 @@ from sympy.functions.elementary.complexes import periodic_argument
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.physics import units
 from sympy.core.compatibility import range
-from sympy.utilities.pytest import XFAIL, raises, slow
+from sympy.utilities.pytest import XFAIL, raises, slow, skip, ON_TRAVIS
 from sympy.utilities.randtest import verify_numerically
 
 
@@ -1152,6 +1152,8 @@ def test_issue_8901():
 
 @slow
 def test_issue_7130():
+    if ON_TRAVIS:
+        skip("Too slow for travis.")
     i, L, a, b = symbols('i L a b')
     integrand = (cos(pi*i*x/L)**2 / (a + b*x)).rewrite(exp)
     assert x not in integrate(integrand, (x, 0, L)).free_symbols


### PR DESCRIPTION
- Removed `import pytest` which is redundant and may cause ImportError where pytest is not installed.
- Skip test_integrals.py:test_issue_7130 on Travis.
Latest Travis builds of `2/3 slow test` seem to fail due to timeout during it:

**Master branch:**
[Job #23898.25](https://travis-ci.org/sympy/sympy/jobs/271651060)
[Job #23922.25](https://travis-ci.org/sympy/sympy/jobs/272074899)
[Job #23924.28](https://travis-ci.org/sympy/sympy/jobs/272184407)
**PR:**
[Job #23903.25](https://travis-ci.org/sympy/sympy/jobs/271703188)
[Job #23905.25](https://travis-ci.org/sympy/sympy/jobs/271726535)
[Job #23908.25](https://travis-ci.org/sympy/sympy/jobs/271764127)
[Job #23914.28](https://travis-ci.org/sympy/sympy/jobs/271909704)
[Job #23918.25](https://travis-ci.org/sympy/sympy/jobs/271942860)
[Job #23919.25](https://travis-ci.org/sympy/sympy/jobs/271981204)
[Job #23920.28](https://travis-ci.org/sympy/sympy/jobs/272018213)
(and more)

Fixes #13270.