### PR TITLE
Remove assumption that Quantity is_nonzero

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -21,7 +21,7 @@ class Quantity(AtomicExpr):
     is_commutative = True
     is_real = True
     is_number = False
-    is_nonzero = True
+    #is_nonzero = True
     _diff_wrt = True
 
     def __new__(cls, name, dimension, scale_factor=S.One, abbrev=None, **assumptions):

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -87,6 +87,9 @@ class Quantity(AtomicExpr):
         """
         return self._scale_factor
 
+    def _eval_is_zero(self):
+        return self.scale_factor.is_zero
+
     def _eval_is_positive(self):
         return self.scale_factor.is_positive
 

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -21,7 +21,6 @@ class Quantity(AtomicExpr):
     is_commutative = True
     is_real = True
     is_number = False
-    #is_nonzero = True
     _diff_wrt = True
 
     def __new__(cls, name, dimension, scale_factor=S.One, abbrev=None, **assumptions):

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -19,6 +19,13 @@ from sympy.utilities.pytest import XFAIL, raises
 k = PREFIXES["k"]
 
 
+def test_is_zero():
+    tim1 = Quantity('tim1', time, second)
+    tim2 = Quantity('tim2', time, 0)
+    assert tim1.is_zero == False
+    assert tim2.is_zero == True
+
+
 def test_str_repr():
     assert str(kg) == "kilogram"
 
@@ -85,6 +92,12 @@ def test_abbrev():
 
 
 def test_print():
+    u = Quantity("unitname", length, 10, "dam")
+    assert repr(u) == "unitname"
+    assert str(u) == "unitname"
+
+
+def test_print_abbrev():
     u = Quantity("unitname", length, 10, "dam")
     assert repr(u) == "unitname"
     assert str(u) == "unitname"


### PR DESCRIPTION
Removing the assumption `is_nonzero = True` for quantities. Related to Issue #13267.