### PR TITLE
Float: fix accidental usage of deprecated keyword

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -947,6 +947,7 @@ class Float(Number):
                             issue=12820,
                             deprecated_since_version="1.1").warn()
             dps = prec
+        del prec  # avoid using this deprecated kwarg
 
         if dps is not None and precision is not None:
             raise ValueError('Both decimal and binary precision supplied. '
@@ -1052,7 +1053,7 @@ class Float(Number):
             if precision < num._prec:
                 _mpf_ = mpf_norm(_mpf_, precision)
         else:
-            _mpf_ = mpmath.mpf(num, prec=prec)._mpf_
+            _mpf_ = mpmath.mpf(num, prec=precision)._mpf_
 
         # special cases
         if _mpf_ == _mpf_zero:


### PR DESCRIPTION
I'm sure `del` is not a very pythonic thing to be doing.  But lo and
behold, it hath caught a bug; looks like a `prec` was not renamed to
`precision` when all the others where.