### PR TITLE
Dimension system refactoring

### DIFF
--- a/doc/src/modules/physics/units/examples.rst
+++ b/doc/src/modules/physics/units/examples.rst
@@ -32,15 +32,27 @@ should be :math:`L^3 M^{-1} T^{-2}`.
     >>> from sympy import symbols
     >>> from sympy.physics.units import length, mass, acceleration, force
     >>> from sympy.physics.units import gravitational_constant as G
+    >>> from sympy.physics.units.dimensions import dimsys_SI
     >>> F = mass*acceleration
     >>> F
     Dimension(acceleration*mass)
-    >>> F.get_dimensional_dependencies()
+    >>> dimsys_SI.get_dimensional_dependencies(F)
     {'length': 1, 'mass': 1, 'time': -2}
-    >>> force.get_dimensional_dependencies()
+    >>> dimsys_SI.get_dimensional_dependencies(force)
     {'length': 1, 'mass': 1, 'time': -2}
+
+    Dimensions cannot compared directly, even if in the SI convention they are
+    the same:
+
     >>> F == force
+    False
+
+    Dimension system objects provide a way to test the equivalence of
+    dimensions:
+
+    >>> dimsys_SI.equivalent_dims(F, force)
     True
+
     >>> m1, m2, r = symbols("m1 m2 r")
     >>> grav_eq = G * m1 * m2 / r**2
     >>> F2 = grav_eq.subs({m1: mass, m2: mass, r: length, G: G.dimension})

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3236,6 +3236,12 @@ def test_sympy__physics__units__dimensions__Dimension():
     assert _test_args(Dimension("length", "L"))
 
 
+def test_sympy__physics__units__dimensions__DimensionSystem():
+    from sympy.physics.units.dimensions import DimensionSystem
+    from sympy.physics.units.dimensions import length, time, velocity
+    assert _test_args(DimensionSystem((length, time), (velocity,)))
+
+
 def test_sympy__physics__units__quantities__Quantity():
     from sympy.physics.units.quantities import Quantity
     from sympy.physics.units import length

--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -19,9 +19,9 @@ permille = Quantity("permille", 1, Rational(1, 1000))
 # Angular units (dimensionless)
 
 rad = radian = radians = Quantity("radian", 1, 1)
-deg = degree = degrees = Quantity("degree", 1, pi/180, "deg")
-sr = steradian = steradians = Quantity("steradian", 1, 1, "sr")
-mil = angular_mil = angular_mils = Quantity("angular_mil", 1, 2*pi/6400, "mil")
+deg = degree = degrees = Quantity("degree", 1, pi/180, abbrev="deg")
+sr = steradian = steradians = Quantity("steradian", 1, 1, abbrev="sr")
+mil = angular_mil = angular_mils = Quantity("angular_mil", 1, 2*pi/6400, abbrev="mil")
 
 # Base units:
 
@@ -29,22 +29,22 @@ m = meter = meters = Quantity("meter", length, 1, abbrev="m")
 kg = kilogram = kilograms = Quantity("kilogram", mass, kilo, abbrev="kg")
 s = second = seconds = Quantity("second", time, 1, abbrev="s")
 A = ampere = amperes = Quantity("ampere", current, 1, abbrev='A')
-K = kelvin = kelvins = Quantity('kelvin', temperature, 1, 'K')
-mol = mole = moles = Quantity("mole", amount_of_substance, 1, "mol")
-cd = candela = candelas = Quantity("candela", luminous_intensity, 1, "cd")
+K = kelvin = kelvins = Quantity('kelvin', temperature, 1, abbrev='K')
+mol = mole = moles = Quantity("mole", amount_of_substance, 1, abbrev="mol")
+cd = candela = candelas = Quantity("candela", luminous_intensity, 1, abbrev="cd")
 
 # gram; used to define its prefixed units
 
-g = gram = grams = Quantity("gram", mass, 1, "g")
-mg = milligram = milligrams = Quantity("milligram", mass, milli*gram, "mg")
-ug = microgram = micrograms = Quantity("microgram", mass, micro*gram, "ug")
+g = gram = grams = Quantity("gram", mass, 1, abbrev="g")
+mg = milligram = milligrams = Quantity("milligram", mass, milli*gram, abbrev="mg")
+ug = microgram = micrograms = Quantity("microgram", mass, micro*gram, abbrev="ug")
 
 # derived units
-newton = newtons = N = Quantity("newton", force, kilogram*meter/second**2, "N")
-joule = joules = J = Quantity("joule", energy, newton*meter, "J")
-watt = watts = W = Quantity("watt", power, joule/second, "W")
-pascal = pascals = Pa = pa = Quantity("pascal", pressure, newton/meter**2, "Pa")
-hertz = hz = Hz = Quantity("hertz", frequency, 1, "Hz")
+newton = newtons = N = Quantity("newton", force, kilogram*meter/second**2, abbrev="N")
+joule = joules = J = Quantity("joule", energy, newton*meter, abbrev="J")
+watt = watts = W = Quantity("watt", power, joule/second, abbrev="W")
+pascal = pascals = Pa = pa = Quantity("pascal", pressure, newton/meter**2, abbrev="Pa")
+hertz = hz = Hz = Quantity("hertz", frequency, 1, abbrev="Hz")
 
 # MKSA extension to MKS: derived units
 
@@ -64,17 +64,17 @@ lux = lx = Quantity("lux", luminous_intensity/length**2, steradian*candela/meter
 
 # Common length units
 
-km = kilometer = kilometers = Quantity("kilometer", length, kilo*meter, "km")
-dm = decimeter = decimeters = Quantity("decimeter", length, deci*meter, "dm")
-cm = centimeter = centimeters = Quantity("centimeter", length, centi*meter, "cm")
-mm = millimeter = millimeters = Quantity("millimeter", length, milli*meter, "mm")
-um = micrometer = micrometers = micron = microns = Quantity("micrometer", length, micro*meter, "um")
-nm = nanometer = nanometers = Quantity("nanometer", length, nano*meter, "nn")
-pm = picometer = picometers = Quantity("picometer", length, pico*meter, "pm")
+km = kilometer = kilometers = Quantity("kilometer", length, kilo*meter, abbrev="km")
+dm = decimeter = decimeters = Quantity("decimeter", length, deci*meter, abbrev="dm")
+cm = centimeter = centimeters = Quantity("centimeter", length, centi*meter, abbrev="cm")
+mm = millimeter = millimeters = Quantity("millimeter", length, milli*meter, abbrev="mm")
+um = micrometer = micrometers = micron = microns = Quantity("micrometer", length, micro*meter, abbrev="um")
+nm = nanometer = nanometers = Quantity("nanometer", length, nano*meter, abbrev="nn")
+pm = picometer = picometers = Quantity("picometer", length, pico*meter, abbrev="pm")
 
-ft = foot = feet = Quantity("foot", length, Rational(3048, 10000)*meter, "ft")
+ft = foot = feet = Quantity("foot", length, Rational(3048, 10000)*meter, abbrev="ft")
 inch = inches = Quantity("inch", length, foot/12)
-yd = yard = yards = Quantity("yard", length, 3*feet, "yd")
+yd = yard = yards = Quantity("yard", length, 3*feet, abbrev="yd")
 mi = mile = miles = Quantity("mile", length, 5280*feet)
 nmi = nautical_mile = nautical_miles = Quantity("nautical_mile", length, 6076*feet)
 
@@ -87,10 +87,10 @@ ml = milliliter = milliliters = Quantity("milliliter", length**3, liter / 1000)
 
 # Common time units
 
-ms = millisecond = milliseconds = Quantity("millisecond", time, milli*second, "ms")
-us = microsecond = microseconds = Quantity("microsecond", time, micro*second, "us")
-ns = nanosecond = nanoseconds = Quantity("nanosecond", time, nano*second, "ns")
-ps = picosecond = picoseconds = Quantity("picosecond", time, pico*second, "ps")
+ms = millisecond = milliseconds = Quantity("millisecond", time, milli*second, abbrev="ms")
+us = microsecond = microseconds = Quantity("microsecond", time, micro*second, abbrev="us")
+ns = nanosecond = nanoseconds = Quantity("nanosecond", time, nano*second, abbrev="ns")
+ps = picosecond = picoseconds = Quantity("picosecond", time, pico*second, abbrev="ps")
 
 minute = minutes = Quantity("minute", time, 60*second)
 h = hour = hours = Quantity("hour", time, 60*minute)
@@ -139,7 +139,7 @@ josephson_constant = Quantity("josephson_constant", frequency/voltage, 483597.85
 # Von Klitzing constant
 von_klitzing_constant = Quantity("von_klitzing_constant", voltage/current, 25812.8074555*ohm, abbrev="R_k")
 # Acceleration due to gravity (on the Earth surface)
-gee = gees = acceleration_due_to_gravity = Quantity("acceleration_due_to_gravity", acceleration, 9.80665*meter/second**2, "g")
+gee = gees = acceleration_due_to_gravity = Quantity("acceleration_due_to_gravity", acceleration, 9.80665*meter/second**2, abbrev="g")
 # magnetic constant:
 u0 = magnetic_constant = Quantity("magnetic_constant", force/current**2, 4*pi/10**7 * newton/ampere**2)
 # electric constat:
@@ -147,12 +147,12 @@ e0 = electric_constant = vacuum_permittivity = Quantity("vacuum_permittivity", c
 # vacuum impedance:
 Z0 = vacuum_impedance = Quantity("vacuum_impedance", impedance, u0 * c)
 # Coulomb's constant:
-coulomb_constant = electric_force_constant = Quantity("coulomb_constant", force*length**2/charge**2, 1/(4*pi*vacuum_permittivity), "k_e")
+coulomb_constant = electric_force_constant = Quantity("coulomb_constant", force*length**2/charge**2, 1/(4*pi*vacuum_permittivity), abbrev="k_e")
 
-atmosphere = atmospheres = atm = Quantity("atmosphere", pressure, 101325 * pascal, "atm")
+atmosphere = atmospheres = atm = Quantity("atmosphere", pressure, 101325 * pascal, abbrev="atm")
 
-kPa = kilopascal = Quantity("kilopascal", pressure, kilo*Pa, "kPa")
-bar = bars = Quantity("bar", pressure, 100*kPa, "bar")
+kPa = kilopascal = Quantity("kilopascal", pressure, kilo*Pa, abbrev="kPa")
+bar = bars = Quantity("bar", pressure, 100*kPa, abbrev="bar")
 pound = pounds = Quantity("pound", mass, 0.45359237 * kg)  # exact
 psi = Quantity("psi", pressure, pound * gee / inch ** 2)
 dHg0 = 13.5951  # approx value at 0 C
@@ -162,14 +162,14 @@ quart = quarts = Quantity("quart", length**3, Rational(231, 4) * inch**3)
 
 # Other convenient units and magnitudes
 
-ly = lightyear = lightyears = Quantity("lightyear", length, speed_of_light*julian_year, "ly")
-au = astronomical_unit = astronomical_units = Quantity("astronomical_unit", length, 149597870691*meter, "AU")
+ly = lightyear = lightyears = Quantity("lightyear", length, speed_of_light*julian_year, abbrev="ly")
+au = astronomical_unit = astronomical_units = Quantity("astronomical_unit", length, 149597870691*meter, abbrev="AU")
 
 # Planck units:
-planck_mass = Quantity("planck_mass", mass, sqrt(hbar*speed_of_light/G), "m_P")
-planck_time = Quantity("planck_time", time, sqrt(hbar*G/speed_of_light**5), "t_P")
-planck_temperature = Quantity("planck_temperature", temperature, sqrt(hbar*speed_of_light**5/G/boltzmann**2), "T_P")
-planck_length = Quantity("planck_length", length, sqrt(hbar*G/speed_of_light**3), "l_P")
+planck_mass = Quantity("planck_mass", mass, sqrt(hbar*speed_of_light/G), abbrev="m_P")
+planck_time = Quantity("planck_time", time, sqrt(hbar*G/speed_of_light**5), abbrev="t_P")
+planck_temperature = Quantity("planck_temperature", temperature, sqrt(hbar*speed_of_light**5/G/boltzmann**2), abbrev="T_P")
+planck_length = Quantity("planck_length", length, sqrt(hbar*G/speed_of_light**3), abbrev="l_P")
 # TODO: add more from https://en.wikipedia.org/wiki/Planck_units
 
 # Information theory units:

--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -133,7 +133,8 @@ def prefix_unit(unit, prefixes):
 
     for prefix_abbr, prefix in prefixes.items():
         prefixed_units.append(Quantity("%s%s" % (prefix.name, unit.name), unit.dimension, unit.scale_factor * prefix,
-                                       "%s%s" % (prefix.abbrev, unit.abbrev)))
+                                       abbrev=("%s%s" % (prefix.abbrev, unit.abbrev))
+                                       ))
 
     return prefixed_units
 

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -10,6 +10,7 @@ from sympy import (Abs, Add, AtomicExpr, Basic, Derivative, Function, Mul,
     Pow, S, Symbol, sympify)
 from sympy.core.compatibility import string_types
 from sympy.physics.units import Dimension, dimensions
+from sympy.physics.units.dimensions import SI_dimensional_dependencies
 from sympy.physics.units.prefixes import Prefix
 
 
@@ -24,7 +25,7 @@ class Quantity(AtomicExpr):
     is_nonzero = True
     _diff_wrt = True
 
-    def __new__(cls, name, dimension, scale_factor=S.One, abbrev=None, **assumptions):
+    def __new__(cls, name, dimension, scale_factor=S.One, abbrev=None, dim_deps=SI_dimensional_dependencies, **assumptions):
 
         if not isinstance(name, Symbol):
             name = Symbol(name)
@@ -36,15 +37,15 @@ class Quantity(AtomicExpr):
                 raise ValueError("expected dimension or 1")
         else:
             for dim_sym in dimension.name.atoms(Symbol):
-                if dim_sym.name not in dimensions.Dimension._dimensional_dependencies:
-                    raise ValueError("Dimension %s is not registered in the"
+                if dim_sym not in dim_deps._dimensional_dependencies:
+                    raise ValueError("Dimension %s is not registered in the "
                                      "dimensional dependency tree." % dim_sym)
 
         scale_factor = sympify(scale_factor)
 
         dimex = Quantity.get_dimensional_expr(scale_factor)
         if dimex != 1:
-            if dimension != Dimension(dimex):
+            if not SI_dimensional_dependencies.equivalent_dims(dimension, Dimension(dimex)):
                 raise ValueError("quantity value and dimension mismatch")
 
         # replace all prefixes by their ratio to canonical units:
@@ -146,7 +147,7 @@ class Quantity(AtomicExpr):
                 addend_factor, addend_dim = \
                     Quantity._collect_factor_and_dimension(addend)
                 if dim != addend_dim:
-                    raise TypeError(
+                    raise ValueError(
                         'Dimension of "{0}" is {1}, '
                         'but it should be {2}'.format(
                             addend, addend_dim.name, dim.name))
@@ -213,6 +214,7 @@ def _Quantity_constructor_postprocessor_Add(expr):
     if len(deset) > 1:
         raise ValueError("summation of quantities of incompatible dimensions")
     return expr
+
 
 Basic._constructor_postprocessor_mapping[Quantity] = {
     "Add" : [_Quantity_constructor_postprocessor_Add],

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -10,7 +10,7 @@ from sympy import (Abs, Add, AtomicExpr, Basic, Derivative, Function, Mul,
     Pow, S, Symbol, sympify)
 from sympy.core.compatibility import string_types
 from sympy.physics.units import Dimension, dimensions
-from sympy.physics.units.dimensions import SI_dimensional_dependencies
+from sympy.physics.units.dimensions import dimsys_default
 from sympy.physics.units.prefixes import Prefix
 
 
@@ -25,7 +25,7 @@ class Quantity(AtomicExpr):
     is_nonzero = True
     _diff_wrt = True
 
-    def __new__(cls, name, dimension, scale_factor=S.One, abbrev=None, dim_deps=SI_dimensional_dependencies, **assumptions):
+    def __new__(cls, name, dimension, scale_factor=S.One, abbrev=None, dim_sys=dimsys_default, **assumptions):
 
         if not isinstance(name, Symbol):
             name = Symbol(name)
@@ -36,8 +36,8 @@ class Quantity(AtomicExpr):
             else:
                 raise ValueError("expected dimension or 1")
         else:
-            for dim_sym in dimension.name.atoms(Symbol):
-                if dim_sym not in dim_deps._dimensional_dependencies:
+            for dim_sym in dimension.name.atoms(Dimension):
+                if dim_sym not in [i.name for i in dim_sys._dimensional_dependencies]:
                     raise ValueError("Dimension %s is not registered in the "
                                      "dimensional dependency tree." % dim_sym)
 
@@ -45,7 +45,7 @@ class Quantity(AtomicExpr):
 
         dimex = Quantity.get_dimensional_expr(scale_factor)
         if dimex != 1:
-            if not SI_dimensional_dependencies.equivalent_dims(dimension, Dimension(dimex)):
+            if not dim_sys.equivalent_dims(dimension, Dimension(dimex)):
                 raise ValueError("quantity value and dimension mismatch")
 
         # replace all prefixes by their ratio to canonical units:

--- a/sympy/physics/units/systems/mks.py
+++ b/sympy/physics/units/systems/mks.py
@@ -12,14 +12,14 @@ from sympy.physics.units import DimensionSystem, UnitSystem
 from sympy.physics.units.definitions import G, Hz, J, N, Pa, W, c, g, kg, m, s
 from sympy.physics.units.dimensions import (
     acceleration, action, energy, force, frequency, length, mass, momentum,
-    power, pressure, time, velocity)
+    power, pressure, time, velocity, dimsys_MKS)
 from sympy.physics.units.prefixes import PREFIXES, prefix_unit
 
 dims = (velocity, acceleration, momentum, force, energy, power, pressure,
         frequency, action)
 
 # dimension system
-_mks_dim = DimensionSystem(base=(length, mass, time), dims=dims, name="MKS")
+_mks_dim = dimsys_MKS
 
 units = [m, g, s, J, N, W, Pa, Hz]
 all_units = []

--- a/sympy/physics/units/systems/mksa.py
+++ b/sympy/physics/units/systems/mksa.py
@@ -11,7 +11,7 @@ from __future__ import division
 from sympy.physics.units.definitions import Z0, A, C, F, H, S, T, V, Wb, ohm
 from sympy.physics.units.dimensions import (
     capacitance, charge, conductance, current, impedance, inductance,
-    magnetic_density, magnetic_flux, voltage)
+    magnetic_density, magnetic_flux, voltage, dimsys_MKSA)
 from sympy.physics.units.prefixes import PREFIXES, prefix_unit
 from sympy.physics.units.systems.mks import MKS, _mks_dim
 
@@ -19,7 +19,7 @@ dims = (voltage, impedance, conductance, capacitance, inductance, charge,
         magnetic_density, magnetic_flux)
 
 # dimension system
-_mksa_dim = _mks_dim.extend(base=(current,), dims=dims, name='MKSA')
+_mksa_dim = dimsys_MKSA
 
 
 units = [A, V, ohm, S, F, H, C, T, Wb]

--- a/sympy/physics/units/systems/natural.py
+++ b/sympy/physics/units/systems/natural.py
@@ -18,11 +18,12 @@ from sympy.physics.units.dimensions import (
 from sympy.physics.units.prefixes import PREFIXES, prefix_unit
 from sympy.physics.units.unitsystem import UnitSystem
 
-dims = (length, mass, time, momentum, force, energy, power, frequency)
 
 # dimension system
-_natural_dim = DimensionSystem(base=(action, energy, velocity), dims=dims,
-                              name="Natural system")
+_natural_dim = DimensionSystem(
+    base_dims=(action, energy, velocity),
+    derived_dims=(length, mass, time, momentum, force, power, frequency)
+)
 
 units = prefix_unit(eV, PREFIXES)
 

--- a/sympy/physics/units/systems/si.py
+++ b/sympy/physics/units/systems/si.py
@@ -22,7 +22,7 @@ from __future__ import division
 
 from sympy.physics.units.definitions import K, cd, lux, mol
 from sympy.physics.units.dimensions import (
-    amount_of_substance, luminous_intensity, temperature)
+    amount_of_substance, luminous_intensity, temperature, dimsys_SI)
 from sympy.physics.units.prefixes import PREFIXES, prefix_unit
 from sympy.physics.units.systems.mksa import MKSA, _mksa_dim
 
@@ -30,7 +30,7 @@ derived_dims = ()
 base_dims = (amount_of_substance, luminous_intensity, temperature)
 
 # dimension system
-_si_dim = _mksa_dim.extend(base=base_dims, dims=derived_dims, name='SI')
+_si_dim = dimsys_SI
 
 
 units = [mol, cd, K, lux]

--- a/sympy/physics/units/systems/si.py
+++ b/sympy/physics/units/systems/si.py
@@ -5,17 +5,6 @@ SI unit system.
 Based on MKSA, which stands for "meter, kilogram, second, ampere".
 Added kelvin, candela and mole.
 
-Example:
-
-    >>> from sympy.physics.units.systems.si import SI
-    >>> from sympy.physics.units import avogadro, boltzmann, lux
-    >>> SI.print_unit_base(avogadro)
-    6.022140857e+23/mole
-    >>> SI.print_unit_base(boltzmann)
-    1.38064852e-23*kilogram*meter**2/(kelvin*second**2)
-    >>> SI.print_unit_base(lux)
-    candela/meter**2
-
 """
 
 from __future__ import division

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -1,17 +1,21 @@
 # -*- coding: utf-8 -*-
 
-from sympy import S, Symbol, sqrt, sympify
-from sympy.physics.units.dimensions import Dimension, length, time
+from sympy import S, Symbol, sqrt
+from sympy.physics.units.dimensions import Dimension, length, time, SI_dimensional_dependencies
 from sympy.utilities.pytest import raises
 
 
 def test_definition():
+    # TODO: filterwarnings this:
     assert length.get_dimensional_dependencies() == {"length": 1}
+    assert SI_dimensional_dependencies.get_dimensional_dependencies(length) == {"length": 1}
     assert length.name == Symbol("length")
     assert length.symbol == Symbol("L")
 
     halflength = sqrt(length)
+    # TODO: filterwarnings this:
     assert halflength.get_dimensional_dependencies() == {'length': S.Half}
+    assert SI_dimensional_dependencies.get_dimensional_dependencies(halflength) == {'length': S.Half}
 
 
 def test_error_definition():

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -1,24 +1,29 @@
 # -*- coding: utf-8 -*-
+import warnings
+
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from sympy import S, Symbol, sqrt
 from sympy.physics.units.dimensions import Dimension, length, time, dimsys_default
 from sympy.utilities.pytest import raises
 
 
-def test_definition():
-    # TODO: filterwarnings this:
-    assert length.get_dimensional_dependencies() == {"length": 1}
+def test_Dimension_definition():
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        assert length.get_dimensional_dependencies() == {"length": 1}
     assert dimsys_default.get_dimensional_dependencies(length) == {"length": 1}
     assert length.name == Symbol("length")
     assert length.symbol == Symbol("L")
 
     halflength = sqrt(length)
-    # TODO: filterwarnings this:
-    assert halflength.get_dimensional_dependencies() == {"length": S.Half}
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        assert halflength.get_dimensional_dependencies() == {"length": S.Half}
     assert dimsys_default.get_dimensional_dependencies(halflength) == {"length": S.Half}
 
 
-def test_error_definition():
+def test_Dimension_error_definition():
     # tuple with more or less than two entries
     raises(TypeError, lambda: Dimension(("length", 1, 2)))
     raises(TypeError, lambda: Dimension(["length"]))
@@ -33,12 +38,15 @@ def test_error_definition():
     raises(AssertionError, lambda: Dimension("length", symbol=1))
 
 
-def test_error_regisration():
-    # tuple with more or less than two entries
-    raises(IndexError, lambda: length._register_as_base_dim())
+def test_Dimension_error_regisration():
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
 
-    one = Dimension(1)
-    raises(TypeError, lambda: one._register_as_base_dim())
+        # tuple with more or less than two entries
+        raises(IndexError, lambda: length._register_as_base_dim())
+
+        one = Dimension(1)
+        raises(TypeError, lambda: one._register_as_base_dim())
 
 
 def test_str():
@@ -46,17 +54,17 @@ def test_str():
     assert str(Dimension("length", "L")) == "Dimension(length, L)"
 
 
-def test_properties():
-    assert length.is_dimensionless is False
-    assert (length/length).is_dimensionless is True
-    assert Dimension("undefined").is_dimensionless is True
+def test_Dimension_properties():
+    assert dimsys_default.is_dimensionless(length) is False
+    assert dimsys_default.is_dimensionless(length/length) is True
+    assert dimsys_default.is_dimensionless(Dimension("undefined")) is True
 
-    assert length.has_integer_powers is True
-    assert (length**(-1)).has_integer_powers is True
-    assert (length**1.5).has_integer_powers is False
+    assert length.has_integer_powers(dimsys_default) is True
+    assert (length**(-1)).has_integer_powers(dimsys_default) is True
+    assert (length**1.5).has_integer_powers(dimsys_default) is False
 
 
-def test_add_sub():
+def test_Dimension_add_sub():
     assert length + length == length
     assert length - length == length
     assert -length == length
@@ -67,27 +75,27 @@ def test_add_sub():
     raises(ValueError, lambda: length - time)
 
 
-def test_mul_div_exp():
+def test_Dimension_mul_div_exp():
     velo = length / time
 
     assert (length * length) == length ** 2
 
-    assert (length * length).get_dimensional_dependencies() == {"length": 2}
-    assert (length ** 2).get_dimensional_dependencies() == {"length": 2}
-    assert (length * time).get_dimensional_dependencies() == { "length": 1, "time": 1}
-    assert velo.get_dimensional_dependencies() == { "length": 1, "time": -1}
-    assert (velo ** 2).get_dimensional_dependencies() == {"length": 2, "time": -2}
+    assert dimsys_default.get_dimensional_dependencies(length * length) == {"length": 2}
+    assert dimsys_default.get_dimensional_dependencies(length ** 2) == {"length": 2}
+    assert dimsys_default.get_dimensional_dependencies(length * time) == { "length": 1, "time": 1}
+    assert dimsys_default.get_dimensional_dependencies(velo) == { "length": 1, "time": -1}
+    assert dimsys_default.get_dimensional_dependencies(velo ** 2) == {"length": 2, "time": -2}
 
-    assert (length / length).get_dimensional_dependencies() == {}
-    assert (velo / length * time).get_dimensional_dependencies() == {}
-    assert (length ** -1).get_dimensional_dependencies() == {"length": -1}
-    assert (velo ** -1.5).get_dimensional_dependencies() == {"length": -1.5, "time": 1.5}
+    assert dimsys_default.get_dimensional_dependencies(length / length) == {}
+    assert dimsys_default.get_dimensional_dependencies(velo / length * time) == {}
+    assert dimsys_default.get_dimensional_dependencies(length ** -1) == {"length": -1}
+    assert dimsys_default.get_dimensional_dependencies(velo ** -1.5) == {"length": -1.5, "time": 1.5}
 
     length_a = length**"a"
-    assert length_a.get_dimensional_dependencies() == {"length": Symbol("a")}
+    assert dimsys_default.get_dimensional_dependencies(length_a) == {"length": Symbol("a")}
 
     assert length != 1
     assert length / length != 1
 
     length_0 = length ** 0
-    assert length_0.get_dimensional_dependencies() == {}
+    assert dimsys_default.get_dimensional_dependencies(length_0) == {}

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
 
 from sympy import S, Symbol, sqrt
-from sympy.physics.units.dimensions import Dimension, length, time, SI_dimensional_dependencies
+from sympy.physics.units.dimensions import Dimension, length, time, dimsys_default
 from sympy.utilities.pytest import raises
 
 
 def test_definition():
     # TODO: filterwarnings this:
     assert length.get_dimensional_dependencies() == {"length": 1}
-    assert SI_dimensional_dependencies.get_dimensional_dependencies(length) == {"length": 1}
+    assert dimsys_default.get_dimensional_dependencies(length) == {"length": 1}
     assert length.name == Symbol("length")
     assert length.symbol == Symbol("L")
 
     halflength = sqrt(length)
     # TODO: filterwarnings this:
-    assert halflength.get_dimensional_dependencies() == {'length': S.Half}
-    assert SI_dimensional_dependencies.get_dimensional_dependencies(halflength) == {'length': S.Half}
+    assert halflength.get_dimensional_dependencies() == {"length": S.Half}
+    assert dimsys_default.get_dimensional_dependencies(halflength) == {"length": S.Half}
 
 
 def test_error_definition():

--- a/sympy/physics/units/tests/test_dimensionsystem.py
+++ b/sympy/physics/units/tests/test_dimensionsystem.py
@@ -7,45 +7,9 @@ from sympy.physics.units.dimensions import (
 from sympy.utilities.pytest import raises
 
 
-def test_definition():
-
-    base = (length, time)
-    ms = DimensionSystem(base, (velocity,), "MS", "MS system")
-
-    assert ms._base_dims == DimensionSystem.sort_dims(base)
-    assert set(ms._dims) == set(base + (velocity,))
-    assert ms.name == "MS"
-    assert ms.descr == "MS system"
-
-
-def test_error_definition():
-    raises(ValueError, lambda: DimensionSystem((current, charge, time)))
-    raises(ValueError, lambda: DimensionSystem((length, time, velocity)))
-
-
-def test_str_repr():
-    assert str(DimensionSystem((length, time), name="MS")) == "MS"
-    dimsys = DimensionSystem((length, time))
-    assert str(dimsys) == 'DimensionSystem(Dimension(length, L), Dimension(time, T))'
-
-    assert (repr(DimensionSystem((length, time), name="MS"))
-            == '<DimensionSystem: (Dimension(length, L), Dimension(time, T))>')
-
-
 def test_call():
     mksa = DimensionSystem((length, time, mass, current), (action,))
     assert mksa(action) == mksa.print_dim_base(action)
-
-
-def test_get_dim():
-    ms = DimensionSystem((length, time), (velocity,))
-
-    assert ms.get_dim("L") == length
-    assert ms.get_dim("length") == length
-    assert ms.get_dim(length) == length
-
-    assert ms["L"] == ms.get_dim("L")
-    raises(KeyError, lambda: ms["M"])
 
 
 def test_extend():
@@ -54,12 +18,11 @@ def test_extend():
     mks = ms.extend((mass,), (action,))
 
     res = DimensionSystem((length, time, mass), (velocity, action))
-    assert mks._base_dims == res._base_dims
-    assert set(mks._dims) == set(res._dims)
+    assert mks.base_dims == res.base_dims
+    assert mks.derived_dims == res.derived_dims
 
 
 def test_sort_dims():
-
     assert (DimensionSystem.sort_dims((length, velocity, time))
                                       == (length, time, velocity))
 
@@ -83,7 +46,11 @@ def test_dim_can_vector():
 
 
 def test_dim_vector():
-    dimsys = DimensionSystem((length, mass, time), (velocity, action))
+    dimsys = DimensionSystem(
+        (length, mass, time),
+        (velocity, action),
+        {velocity: {length: 1, time: -1},
+         action: {mass: 1, length: 2, time: -1}})
 
     assert dimsys.dim_vector(length) == Matrix([1, 0, 0])
     assert dimsys.dim_vector(velocity) == Matrix([1, 0, -1])
@@ -101,7 +68,7 @@ def test_inv_can_transf_matrix():
     assert dimsys.inv_can_transf_matrix == eye(3)
 
     dimsys = DimensionSystem((length, velocity, action))
-    assert dimsys.inv_can_transf_matrix == Matrix([[2, 1, 1], [1, 0, 0], [-1, 0, -1]])
+    assert dimsys.inv_can_transf_matrix == Matrix([[1, 2, 1], [0, 1, 0], [-1, -1, 0]])
 
 
 def test_can_transf_matrix():
@@ -119,11 +86,19 @@ def test_is_consistent():
 
 
 def test_print_dim_base():
-    mksa = DimensionSystem((length, time, mass, current), (action,))
+    mksa = DimensionSystem(
+        (length, time, mass, current),
+        (action,),
+        {action: {mass: 1, length: 2, time: -1}})
     L, M, T = symbols("L M T")
     assert mksa.print_dim_base(action) == L**2*M/T
 
 
 def test_dim():
-    dimsys = DimensionSystem((length, mass, time), (velocity, action))
+    dimsys = DimensionSystem(
+        (length, mass, time),
+        (velocity, action),
+        {velocity: {length: 1, time: -1},
+         action: {mass: 1, length: 2, time: -1}}
+    )
     assert dimsys.dim == 3

--- a/sympy/physics/units/tests/test_dimensionsystem.py
+++ b/sympy/physics/units/tests/test_dimensionsystem.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import warnings
+
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from sympy import Matrix, eye, symbols
 from sympy.physics.units.dimensions import (
@@ -8,8 +11,10 @@ from sympy.utilities.pytest import raises
 
 
 def test_call():
-    mksa = DimensionSystem((length, time, mass, current), (action,))
-    assert mksa(action) == mksa.print_dim_base(action)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        mksa = DimensionSystem((length, time, mass, current), (action,))
+        assert mksa(action) == mksa.print_dim_base(action)
 
 
 def test_extend():
@@ -23,7 +28,9 @@ def test_extend():
 
 
 def test_sort_dims():
-    assert (DimensionSystem.sort_dims((length, velocity, time))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        assert (DimensionSystem.sort_dims((length, velocity, time))
                                       == (length, time, velocity))
 
 

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -32,9 +32,9 @@ def test_prefix_unit():
 
     pref = {"m": PREFIXES["m"], "c": PREFIXES["c"], "d": PREFIXES["d"]}
 
-    res = [Quantity("millimeter", length, PREFIXES["m"], "mm"),
-           Quantity("centimeter", length, PREFIXES["c"], "cm"),
-           Quantity("decimeter", length, PREFIXES["d"], "dm")]
+    res = [Quantity("millimeter", length, PREFIXES["m"], abbrev="mm"),
+           Quantity("centimeter", length, PREFIXES["c"], abbrev="cm"),
+           Quantity("decimeter", length, PREFIXES["d"], abbrev="dm")]
 
     prefs = prefix_unit(m, pref)
     assert set(prefs) == set(res)

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -261,12 +261,6 @@ def test_sum_of_incompatible_quantities():
         assert i in Basic._constructor_postprocessor_mapping
 
 
-def test_quantity_dimension_not_registered():
-    d = Dimension("someDimension")
-    raises(ValueError, lambda: Quantity("q", d, 1))
-    raises(ValueError, lambda: Quantity("q", d/length, 1))
-
-
 def test_quantity_postprocessing():
     q1 = Quantity('q1', length*pressure**2*temperature/time)
     q2 = Quantity('q2', energy*pressure*temperature/(length**2*time))

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -11,7 +11,7 @@ from sympy.physics.units.definitions import (amu, au, centimeter, coulomb,
     minute, pressure, quart, s, second, speed_of_light, temperature, bit,
     byte, kibibyte, mebibyte, gibibyte, tebibyte, pebibyte, exbibyte)
 
-from sympy.physics.units.dimensions import Dimension, charge, length, time
+from sympy.physics.units.dimensions import Dimension, charge, length, time, dimsys_default
 from sympy.physics.units.prefixes import PREFIXES, kilo
 from sympy.physics.units.quantities import Quantity
 from sympy.utilities.pytest import XFAIL, raises
@@ -43,7 +43,7 @@ def test_convert_to():
 
 
 def test_Quantity_definition():
-    q = Quantity("s10", time, 10, "sabbr")
+    q = Quantity("s10", time, 10, abbrev="sabbr")
 
     assert q.scale_factor == 10
     assert q.dimension == time
@@ -73,33 +73,33 @@ def test_abbrev():
     assert u.name == Symbol("u")
     assert u.abbrev == Symbol("u")
 
-    u = Quantity("u", length, 2, "om")
+    u = Quantity("u", length, 2, abbrev="om")
     assert u.name == Symbol("u")
     assert u.abbrev == Symbol("om")
     assert u.scale_factor == 2
     assert isinstance(u.scale_factor, Number)
 
-    u = Quantity("u", length, 3*kilo, "ikm")
+    u = Quantity("u", length, 3*kilo, abbrev="ikm")
     assert u.abbrev == Symbol("ikm")
     assert u.scale_factor == 3000
 
 
 def test_print():
-    u = Quantity("unitname", length, 10, "dam")
+    u = Quantity("unitname", length, 10, abbrev="dam")
     assert repr(u) == "unitname"
     assert str(u) == "unitname"
 
 
 def test_Quantity_eq():
-    u = Quantity("u", length, 10, "dam")
+    u = Quantity("u", length, 10, abbrev="dam")
 
     v = Quantity("v1", length, 10)
     assert u != v
 
-    v = Quantity("v2", time, 10, "ds")
+    v = Quantity("v2", time, 10, abbrev="ds")
     assert u != v
 
-    v = Quantity("v3", length, 1, "dm")
+    v = Quantity("v3", length, 1, abbrev="dm")
     assert u != v
 
 
@@ -125,7 +125,7 @@ def test_quantity_abs():
     expr = v_w3 - Abs(v_w1 - v_w2)
 
     Dq = Dimension(Quantity.get_dimensional_expr(expr))
-    assert Dimension.get_dimensional_dependencies(Dq) == {
+    assert dimsys_default.get_dimensional_dependencies(Dq) == {
         'length': 1,
         'time': -1,
     }
@@ -267,7 +267,7 @@ def test_quantity_postprocessing():
     assert q1 + q2
     q = q1 + q2
     Dq = Dimension(Quantity.get_dimensional_expr(q))
-    assert Dimension.get_dimensional_dependencies(Dq) == {
+    assert dimsys_default.get_dimensional_dependencies(Dq) == {
         'length': -1,
         'mass': 2,
         'temperature': 1,

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -117,7 +117,8 @@ def test_add_sub():
     # TODO: eventually add this:
     # assert (u - v).convert_to(u) == S.Half*u
 
-def test_abs():
+
+def test_quantity_abs():
     v_w1 = Quantity('v_w1', length/time, meter/second)
     v_w2 = Quantity('v_w2', length/time, meter/second)
     v_w3 = Quantity('v_w3', length/time, meter/second)

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -22,7 +22,7 @@ def test_definition():
     assert ms.name == "MS"
     assert ms.descr == "MS system"
 
-    assert ms._system.base_dims == DimensionSystem.sort_dims(base_dim)
+    assert ms._system.base_dims == base_dim
     assert ms._system.derived_dims == (velocity,)
 
 

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -22,8 +22,8 @@ def test_definition():
     assert ms.name == "MS"
     assert ms.descr == "MS system"
 
-    assert ms._system._base_dims == DimensionSystem.sort_dims(base_dim)
-    assert set(ms._system._dims) == set(base_dim + (velocity,))
+    assert ms._system.base_dims == DimensionSystem.sort_dims(base_dim)
+    assert ms._system.derived_dims == (velocity,)
 
 
 def test_error_definition():

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import warnings
+
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy import Rational
 from sympy.physics.units.definitions import c, kg, m, s
 from sympy.physics.units.dimensions import (
@@ -38,11 +41,13 @@ def test_str_repr():
 
 
 def test_print_unit_base():
-    A = Quantity("A", current, 1)
-    Js = Quantity("Js", action, 1)
-    mksa = UnitSystem((m, kg, s, A), (Js,))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        A = Quantity("A", current, 1)
+        Js = Quantity("Js", action, 1)
+        mksa = UnitSystem((m, kg, s, A), (Js,))
 
-    assert mksa.print_unit_base(Js) == m**2*kg*s**-1/1000
+        assert mksa.print_unit_base(Js) == m**2*kg*s**-1/1000
 
 
 def test_extend():

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -2,12 +2,17 @@
 
 from __future__ import division
 
+import warnings
+
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
 from sympy import Add, Mul, Pow, Tuple, pi, sin, sqrt, sstr, sympify
 from sympy.physics.units import (
     G, centimeter, coulomb, day, degree, gram, hbar, hour, inch, joule, kelvin,
     kilogram, kilometer, length, meter, mile, minute, newton, planck,
     planck_length, planck_mass, planck_temperature, planck_time, radians,
     second, speed_of_light, steradian, time)
+from sympy.physics.units.dimensions import dimsys_default
 from sympy.physics.units.util import convert_to, dim_simplify
 
 
@@ -20,30 +25,43 @@ T = time
 
 
 def test_dim_simplify_add():
-    assert dim_simplify(Add(L, L)) == L
-    assert dim_simplify(L + L) == L
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        assert dim_simplify(Add(L, L)) == L
+        assert dim_simplify(L + L) == L
 
 
 def test_dim_simplify_mul():
-    assert dim_simplify(Mul(L, T)) == L*T
-    assert dim_simplify(L*T) == L*T
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        assert dim_simplify(Mul(L, T)) == L*T
+        assert dim_simplify(L*T) == L*T
 
 
 def test_dim_simplify_pow():
-    assert dim_simplify(Pow(L, 2)) == L**2
-    assert dim_simplify(L**2) == L**2
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        assert dim_simplify(Pow(L, 2)) == L**2
+        assert dim_simplify(L**2) == L**2
 
 
 def test_dim_simplify_rec():
-    assert dim_simplify(Mul(Add(L, L), T)) == L*T
-    assert dim_simplify((L + L) * T) == L*T
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        assert dim_simplify(Mul(Add(L, L), T)) == L*T
+        assert dim_simplify((L + L) * T) == L*T
 
 
 def test_dim_simplify_dimless():
     # TODO: this should be somehow simplified on its own,
     # without the need of calling `dim_simplify`:
-    assert dim_simplify(sin(L*L**-1)**2*L).get_dimensional_dependencies() == L.get_dimensional_dependencies()
-    assert dim_simplify(sin(L * L**(-1))**2 * L).get_dimensional_dependencies() == L.get_dimensional_dependencies()
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+
+        assert dim_simplify(sin(L*L**-1)**2*L).get_dimensional_dependencies()\
+               == dimsys_default.get_dimensional_dependencies(L)
+        assert dim_simplify(sin(L * L**(-1))**2 * L).get_dimensional_dependencies()\
+               == dimsys_default.get_dimensional_dependencies(L)
 
 
 def test_convert_to_quantities():

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -88,10 +88,10 @@ class UnitSystem(object):
         """
         SymPyDeprecationWarning(
             deprecated_since_version="1.2",
-            issue=99999,
+            issue=13336,
             feature="print_unit_base",
             useinstead="convert_to",
-        )#.warn()
+        ).warn()
         from sympy.physics.units import convert_to
         return convert_to(unit, self._base_units)
 

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -9,6 +9,7 @@ from __future__ import division
 from sympy import S
 from sympy.core.decorators import deprecated
 from sympy.physics.units.quantities import Quantity
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from .dimensions import DimensionSystem
 
@@ -28,10 +29,12 @@ class UnitSystem(object):
         self.descr = descr
 
         # construct the associated dimension system
-        self._system = DimensionSystem([u.dimension for u in base],
-                                       [u.dimension for u in units])
+        base_dims = [u.dimension for u in base]
+        derived_dims = [u.dimension for u in units if u.dimension not in base_dims]
+        self._system = DimensionSystem(base_dims, derived_dims)
 
-        assert self.is_consistent  # test is performed in DimensionSystem
+        if not self.is_consistent:
+            raise ValueError("UnitSystem is not consistent")
 
         self._units = tuple(set(base) | set(units))
 
@@ -41,7 +44,7 @@ class UnitSystem(object):
         base_dict = dict((u.dimension, u) for u in base)
         # order the base units in the same order than the dimensions in the
         # associated system, in order to ensure that we get always the same
-        self._base_units = tuple(base_dict[d] for d in self._system._base_dims)
+        self._base_units = tuple(base_dict[d] for d in self._system.base_dims)
 
     def __str__(self):
         """
@@ -75,28 +78,22 @@ class UnitSystem(object):
 
     def print_unit_base(self, unit):
         """
+        Useless method.
+
+        DO NOT USE, use instead ``convert_to``.
+
         Give the string expression of a unit in term of the basis.
 
         Units are displayed by decreasing power.
         """
-
-        res = S.One
-
-        factor = unit.scale_factor
-        vec = self._system.dim_vector(unit.dimension)
-
-        for (u, p) in sorted(zip(self._base_units, vec), key=lambda x: x[1],
-                             reverse=True):
-
-            factor /= u.scale_factor ** p
-            if p == 0:
-                continue
-            elif p == 1:
-                res *= u
-            else:
-                res *= u**p
-
-        return factor * res
+        SymPyDeprecationWarning(
+            deprecated_since_version="1.2",
+            issue=99999,
+            feature="print_unit_base",
+            useinstead="convert_to",
+        )#.warn()
+        from sympy.physics.units import convert_to
+        return convert_to(unit, self._base_units)
 
     @property
     def dim(self):
@@ -113,4 +110,5 @@ class UnitSystem(object):
         """
         Check if the underlying dimension system is consistent.
         """
+        # test is performed in DimensionSystem
         return self._system.is_consistent

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -8,9 +8,11 @@ from __future__ import division
 
 import collections
 
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+
 from sympy import Add, Function, Mul, Pow, Rational, Tuple, sympify
 from sympy.core.compatibility import reduce
-from sympy.physics.units.dimensions import Dimension
+from sympy.physics.units.dimensions import Dimension, dimsys_default
 from sympy.physics.units.quantities import Quantity
 
 
@@ -25,6 +27,12 @@ def dim_simplify(expr):
     dimension without being a dimension. This is necessary to avoid strange
     behavior when Add(L, L) be transformed into Mul(2, L).
     """
+    SymPyDeprecationWarning(
+        deprecated_since_version="1.2",
+        feature="dimensional simplification function",
+        issue=13336,
+        useinstead="don't use",
+    ).warn()
     _, expr = Quantity._collect_factor_and_dimension(expr)
     return expr
 
@@ -33,9 +41,9 @@ def _get_conversion_matrix_for_expr(expr, target_units):
     from sympy import Matrix
 
     expr_dim = Dimension(Quantity.get_dimensional_expr(expr))
-    dim_dependencies = expr_dim.get_dimensional_dependencies(mark_dimensionless=True)
+    dim_dependencies = dimsys_default.get_dimensional_dependencies(expr_dim, mark_dimensionless=True)
     target_dims = [Dimension(Quantity.get_dimensional_expr(x)) for x in target_units]
-    canon_dim_units = {i for x in target_dims for i in x.get_dimensional_dependencies(mark_dimensionless=True)}
+    canon_dim_units = {i for x in target_dims for i in dimsys_default.get_dimensional_dependencies(x, mark_dimensionless=True)}
     canon_expr_units = {i for i in dim_dependencies}
 
     if not canon_expr_units.issubset(canon_dim_units):
@@ -43,7 +51,7 @@ def _get_conversion_matrix_for_expr(expr, target_units):
 
     canon_dim_units = sorted(canon_dim_units)
 
-    camat = Matrix([[i.get_dimensional_dependencies(mark_dimensionless=True).get(j, 0)  for i in target_dims] for j in canon_dim_units])
+    camat = Matrix([[dimsys_default.get_dimensional_dependencies(i, mark_dimensionless=True).get(j, 0)  for i in target_dims] for j in canon_dim_units])
     exprmat = Matrix([dim_dependencies.get(k, 0) for k in canon_dim_units])
 
     res_exponents = camat.solve_least_squares(exprmat, method=None)


### PR DESCRIPTION
Dimensional dependencies are not absolute, they depend on the dimension system (class `DimensionSystem`).

Even relations like `velocity == length / time` actually depend on the dimension system you're currently using. If you are in special relativity, maybe you want to use `length == time` so that the `velocity` is dimensionless.

In the gaussian units, the unit of _charge_ is the _statcoulomb_, which does not depend on the _Ampere_ (the _current_ is not a fundamental dimension and the charge can be expressed as a combination of _length_, _time_, and _mass_ without _current_).

This PR makes the relation between base dimensions and derived dimensions part of `DimensionSystem`, so that they are no longer absolute.

For compatibility reasons, the SI dimension standard is kept as a reference point.

TODO:
- [ ] release deprecation warnings