### PR TITLE
Removed some redundant checks from isprime

### DIFF
--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -483,14 +483,7 @@ def isprime(n):
     if n < 2809:
         return True
     if n <= 23001:
-        return pow(2, n, n) == 2 and n not in [341, 561, 645, 1105, 1387, 1729,
-                                               1905, 2047, 2465, 2701, 2821,
-                                               3277, 4033, 4369, 4371, 4681,
-                                               5461, 6601, 7957, 8321, 8481,
-                                               8911, 10261, 10585, 11305,
-                                               12801, 13741, 13747, 13981,
-                                               14491, 15709, 15841, 16705,
-                                               18705, 18721, 19951, 23001]
+        return pow(2, n, n) == 2 and n not in [7957, 8321, 13747, 18721, 19951]
 
     # bisection search on the sieve if the sieve is large enough
     from sympy.ntheory.generate import sieve as s


### PR DESCRIPTION
Numbers removed from a list used with an `in` test. The list is composite numbers that are exceptions to a power and modulo test. The removed numbers are divisible by previously tested values hence will not reach this point (confirmed `[n for n in range(2, 23002) if isprime(n)]` remained unchanged).

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
