### PR TITLE
solve_univariate_inequality: solving inequality with imaginary coefficients

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -587,22 +587,21 @@ The inequality cannot be solved using solve_univariate_inequality.
                                 im_sol += FiniteSet(z)
                     else:
                         start, end = a.inf, a.sup
-                        valid_start = valid(start)
                         for z in _nsort(critical_points + FiniteSet(end)):
+                            valid_start = valid(start)
                             if start != end:
                                 valid_z = valid(z)
                                 pt = _pt(start, z)
-                                if pt not in singularities and valid(pt) and pt.is_real:
+                                if pt not in singularities and pt.is_real and valid(pt):
                                     if valid_start and valid_z:
                                         im_sol += Interval(start, z)
-                                    elif valid_start and not valid_z:
+                                    elif valid_start:
                                         im_sol += Interval.Ropen(start, z)
-                                    elif not valid_start and valid_z:
+                                    elif valid_z:
                                         im_sol += Interval.Lopen(start, z)
                                     else:
                                         im_sol += Interval.open(start, z)
                             start = z
-                            valid_start = valid(start)
                         for s in singularities:
                             im_sol -= FiniteSet(s)
                 except (TypeError):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -587,19 +587,22 @@ The inequality cannot be solved using solve_univariate_inequality.
                                 im_sol += FiniteSet(z)
                     else:
                         start, end = a.inf, a.sup
+                        valid_start = valid(start)
                         for z in _nsort(critical_points + FiniteSet(end)):
                             if start != end:
+                                valid_z = valid(z)
                                 pt = _pt(start, z)
                                 if pt not in singularities and valid(pt) and pt.is_real:
-                                    if valid(start) and valid(z):
+                                    if valid_start and valid_z:
                                         im_sol += Interval(start, z)
-                                    elif valid(start) and not valid(z):
+                                    elif valid_start and not valid_z:
                                         im_sol += Interval.Ropen(start, z)
-                                    elif not valid(start) and valid(z):
+                                    elif not valid_start and valid_z:
                                         im_sol += Interval.Lopen(start, z)
                                     else:
                                         im_sol += Interval.open(start, z)
                             start = z
+                            valid_start = valid(start)
                         for s in singularities:
                             im_sol -= FiniteSet(s)
                 except (TypeError):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -625,7 +625,6 @@ satisfying the inequality, leading to relations like I < 0.
 
             if expanded_e.coeff(I) != S.Zero:
                 rv = (make_real)
-
             else:
                 rv = (Union(*sol_sets)).intersect(make_real).subs(gen, _gen)
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -700,7 +700,7 @@ def _solveset(f, symbol, domain, _check=False):
     elif _is_function_class_equation(TrigonometricFunction, f, symbol) or \
             _is_function_class_equation(HyperbolicFunction, f, symbol):
         result = _solve_trig(f, symbol, domain)
-    elif _is_function_class_equation(arg, f, symbol):
+    elif isinstance(f, arg):
         a = f.args[0]
         result = solveset_real(a > 0, symbol)
     elif f.is_Piecewise:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -700,6 +700,9 @@ def _solveset(f, symbol, domain, _check=False):
     elif _is_function_class_equation(TrigonometricFunction, f, symbol) or \
             _is_function_class_equation(HyperbolicFunction, f, symbol):
         result = _solve_trig(f, symbol, domain)
+    elif _is_function_class_equation(arg, f, symbol):
+        a = f.args[0]
+        result = solveset_real(a > 0, symbol)
     elif f.is_Piecewise:
         dom = domain
         result = EmptySet()

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -275,6 +275,11 @@ def test_solve_univariate_inequality():
     # issue 2794:
     assert isolve(x**3 - x**2 + x - 1 > 0, x, relational=False) == \
         Interval(1, oo, True)
+    #issue 13105
+    assert isolve((x + I)*(x + 2*I) < 0, x) == Eq(x, 0)
+    assert isolve(((x - 1)*(x - 2) + I)*((x - 1)*(x - 2) + 2*I) < 0, x) == Or(Eq(x, 1), Eq(x, 2))
+    assert isolve((((x - 1)*(x - 2) + I)*((x - 1)*(x - 2) + 2*I))/(x - 2) > 0, x) == Eq(x, 1)
+    raises (ValueError, lambda: isolve((x**2 - 3*x*I + 2)/x < 0, x))
 
     # numerical testing in valid() is needed
     assert isolve(x**7 - x - 2 > 0, x) == \

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1570,6 +1570,11 @@ def test_issue_12429():
     assert eq == sol
 
 
+def test_solveset_arg():
+    assert solveset(arg(x), x, S.Reals)  == Interval.open(0, oo)
+    assert solveset(arg(4*x -3), x) == Interval.open(3/4, oo)
+
+
 def test__is_finite_with_finite_vars():
     f = _is_finite_with_finite_vars
     # issue 12482


### PR DESCRIPTION


Added support for solving inequalities involving rational functions with
imaginary coefficients. solve_univariate_inequality() has been modified to
return those values of the generator for which the function assumes a real
value and satisfies the inequality. Tests have been added.

Examples:
```
>>> isolve = solve_univariate_inequality
>>> eq = (x + I)*(x + 2*I) < 0
>>> isolve(eq, x)
Eq(x, 0)
>>> x12 = (x - 1)*(x - 2)
>>> isolve(eq.subs(x, x12), x)
Eq(x, 1) | Eq(x, 2)
```

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #13105 