### PR TITLE
[WIP]AST transformer for isympy(IPython console)

### DIFF
--- a/isympy.py
+++ b/isympy.py
@@ -1,8 +1,5 @@
-# XXX: Don't put a newline here, or it will add an extra line with
-# isympy --help
-#  |
-#  v
-"""Python shell for SymPy.
+"""
+Python shell for SymPy.
 
 This is just a normal Python shell (IPython shell if you have the
 IPython package installed), that executes the following commands for
@@ -168,7 +165,6 @@ COMMAND LINE OPTIONS
         $isympy -q -- -colors NoColor
 
 See also isympy --help.
-
 """
 
 import os
@@ -178,13 +174,7 @@ import sys
 # by the command line will break.
 
 def main():
-    from optparse import OptionParser
-
-    if '-h' in sys.argv or '--help' in sys.argv:
-        # XXX: We can't use description=__doc__  in the OptionParser call
-        # below because optparse line wraps it weird.  The argparse module
-        # allows you to disable this, though.
-        print(__doc__)  # the docstring of this module above
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
     VERSION = None
     if '--version' in sys.argv:
@@ -194,100 +184,107 @@ def main():
         # version, which only matters with the --version flag.
         import sympy
         VERSION = sympy.__version__
-    usage = 'usage: isympy [options] -- [ipython options]'
-    parser = OptionParser(
+
+    usage = 'isympy [options] -- [ipython options]'
+    parser = ArgumentParser(
         usage=usage,
-        version=VERSION,
-        # XXX: We need a more centralized place to store the version.
-        # It is currently stored in sympy.__version__, but we can't yet
-        # import sympy at this point.
+        description=__doc__,
+        formatter_class=RawDescriptionHelpFormatter,
     )
 
-    parser.add_option(
+    parser.add_argument('--version', action='version', version=VERSION)
+
+    parser.add_argument(
         '-c', '--console',
         dest='console',
         action='store',
         default=None,
         choices=['ipython', 'python'],
+        metavar='CONSOLE',
         help='select type of interactive session: ipython | python; defaults '
         'to ipython if IPython is installed, otherwise python')
 
-    parser.add_option(
+    parser.add_argument(
         '-p', '--pretty',
         dest='pretty',
         action='store',
         default=None,
+        metavar='PRETTY',
         choices=['unicode', 'ascii', 'no'],
         help='setup pretty printing: unicode | ascii | no; defaults to '
         'unicode printing if the terminal supports it, otherwise ascii')
 
-    parser.add_option(
+    parser.add_argument(
         '-t', '--types',
         dest='types',
         action='store',
         default=None,
+        metavar='TYPES',
         choices=['gmpy', 'gmpy1', 'python'],
         help='setup ground types: gmpy | gmpy1 | python; defaults to gmpy if gmpy2 '
         'or gmpy is installed, otherwise python')
 
-    parser.add_option(
+    parser.add_argument(
         '-o', '--order',
         dest='order',
         action='store',
         default=None,
+        metavar='ORDER',
         choices=['lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old', 'none'],
         help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old | none; defaults to lex')
 
-    parser.add_option(
+    parser.add_argument(
         '-q', '--quiet',
         dest='quiet',
         action='store_true',
         default=False,
         help='print only version information at startup')
 
-    parser.add_option(
+    parser.add_argument(
         '-d', '--doctest',
         dest='doctest',
         action='store_true',
         default=False,
         help='use the doctest format for output (you can just copy and paste it)')
 
-    parser.add_option(
+    parser.add_argument(
         '-C', '--no-cache',
         dest='cache',
         action='store_false',
         default=True,
         help='disable caching mechanism')
 
-    parser.add_option(
+    parser.add_argument(
         '-a', '--auto-symbols',
         dest='auto_symbols',
         action='store_true',
         default=False,
         help='automatically construct missing symbols')
 
-    parser.add_option(
+    parser.add_argument(
         '-i', '--int-to-Integer',
         dest='auto_int_to_Integer',
         action='store_true',
         default=False,
         help="automatically wrap int literals with Integer")
 
-    parser.add_option(
+    parser.add_argument(
         '-I', '--interactive',
         dest='interactive',
         action='store_true',
         default=False,
         help="equivalent to -a -i")
 
-    parser.add_option(
+    parser.add_argument(
         '-D', '--debug',
         dest='debug',
         action='store_true',
         default=False,
         help='enable debugging output')
 
-    (options, ipy_args) = parser.parse_args()
+    (options, ipy_args) = parser.parse_known_args()
+    if '--' in ipy_args:
+        ipy_args.remove('--')
 
     if not options.cache:
         os.environ['SYMPY_USE_CACHE'] = 'no'

--- a/isympy.py
+++ b/isympy.py
@@ -137,6 +137,16 @@ COMMAND LINE OPTIONS
     If you want an int, you can wrap the literal in int(), e.g. int(3)/int(2)
     gives 1.5 (with division imported from __future__).
 
+-r, --rationalize-floats (requires at least IPython 0.11)
+
+    Automatically rationalize float literals, by wrapping with Rational.
+    Note that this will not change the behavior of float literals
+    assigned to variables, functions that return float literals, and
+    those wrapped with float or Float.
+
+    If you want a float literal or Float, you can wrap the floats in
+    float() or Float(), respectively.
+
 -I, --interactive (requires at least IPython 0.11)
 
     This is equivalent to --auto-symbols --int-to-Integer.  Future options
@@ -269,6 +279,13 @@ def main():
         help="automatically wrap int literals with Integer")
 
     parser.add_argument(
+        '-r', '--rationalize-floats',
+        dest='auto_rationalize',
+        action='store_true',
+        default=False,
+        help="automatically rationalize floats")
+
+    parser.add_argument(
         '-I', '--interactive',
         dest='interactive',
         action='store_true',
@@ -334,6 +351,7 @@ def main():
     args['quiet'] = options.quiet
     args['auto_symbols'] = options.auto_symbols or options.interactive
     args['auto_int_to_Integer'] = options.auto_int_to_Integer or options.interactive
+    args['auto_rationalize'] = options.auto_rationalize
 
     from sympy.interactive import init_session
     init_session(ipython, **args)

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -227,27 +227,29 @@ def enable_automatic_rationalize(shell):
     shell.ast_transformers.append(FloatRationalizer())
 
 
-def init_ipython_session(argv=[], auto_symbols=False,
+def init_ipython_session(shell=None, argv=[], auto_symbols=False,
         auto_int_to_Integer=False, auto_rationalize=False):
     """Construct new IPython session. """
     import IPython
 
     if V(IPython.__version__) >= '0.11':
-        # use an app to parse the command line, and init config
-        # IPython 1.0 deprecates the frontend module, so we import directly
-        # from the terminal module to prevent a deprecation message from being
-        # shown.
-        if V(IPython.__version__) >= '1.0':
-            from IPython.terminal import ipapp
-        else:
-            from IPython.frontend.terminal import ipapp
-        app = ipapp.TerminalIPythonApp()
+        if not shell:
+            # use an app to parse the command line, and init config
+            # IPython 1.0 deprecates the frontend module, so we import directly
+            # from the terminal module to prevent a deprecation message from being
+            # shown.
+            if V(IPython.__version__) >= '1.0':
+                from IPython.terminal import ipapp
+            else:
+                from IPython.frontend.terminal import ipapp
+            app = ipapp.TerminalIPythonApp()
 
-        # don't draw IPython banner during initialization:
-        app.display_banner = False
-        app.initialize(argv)
+            # don't draw IPython banner during initialization:
+            app.display_banner = False
+            app.initialize(argv)
 
-        shell = app.shell
+            shell = app.shell
+
         if hasattr(shell, 'ast_transformers'):
             del shell.ast_transformers[:]
         else: # ast_transformers was introduced in IPython 1.0
@@ -434,7 +436,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
         ip = init_python_session()
         mainloop = ip.interact
     else:
-        ip = init_ipython_session(argv=argv, auto_symbols=auto_symbols,
+        ip = init_ipython_session(ip, argv=argv, auto_symbols=auto_symbols,
             auto_int_to_Integer=auto_int_to_Integer,
             auto_rationalize=auto_rationalize)
         if V(IPython.__version__) >= '0.11':

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -5,12 +5,16 @@ from __future__ import print_function, division
 from distutils.version import LooseVersion as V
 import ast
 
+from sympy.core.compatibility import builtins
 from sympy.external import import_module
 from sympy.interactive.printing import init_printing
 
-preexec_source = """\
+import_source = """\
 from __future__ import division
 from sympy import *
+"""
+
+preexec_source = """\
 x, y, z, t = symbols('x y z t')
 k, m, n = symbols('k m n', integer=True)
 f, g, h = symbols('f g h', cls=Function)
@@ -64,7 +68,7 @@ def _make_message(ipython=True, quiet=False, source=None):
     message = "%s console for SymPy %s (Python %s-%s) (%s)\n" % args
 
     if source is None:
-        source = preexec_source
+        source = import_source + preexec_source
 
     _source = ""
 
@@ -84,6 +88,59 @@ def _make_message(ipython=True, quiet=False, source=None):
                                          'version': doc_version}
 
     return message
+
+
+class IntegerWrapper(ast.NodeTransformer):
+    """Wraps all integers in a call to Integer."""
+
+    def visit_Num(self, node):
+        if isinstance(node.n, int):
+            return ast.Call(func=ast.Name(id='Integer', ctx=ast.Load()),
+                            args=[node], keywords=[],
+                            starargs=None, kwargs=None)
+        return node
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Name) and (node.func.id == "Integer"
+                or node.func.id == "int"):
+            return node
+        return self.generic_visit(node)
+
+
+class AutomaticSymbols(ast.NodeTransformer):
+    """Add missing Symbol definitions automatically."""
+
+    def __init__(self, shell):
+        super(AutomaticSymbols, self).__init__()
+        self.shell = shell
+        self.names = []
+
+    def visit_Module(self, node):
+        ignored_names = list(self.shell.user_ns.keys()) + dir(builtins)
+
+        for s in node.body:
+            self.visit(s)
+
+        for v in self.names:
+            if v in ignored_names:
+                continue
+
+            assign = ast.Assign(targets=[ast.Name(id=v, ctx=ast.Store())],
+                                value=ast.Call(func=ast.Name(id='Symbol',
+                                                             ctx=ast.Load()),
+                                               args=[ast.Str(s=v)], keywords=[],
+                                               starargs=None, kwargs=None))
+            node.body.insert(0, assign)
+
+        newnode = ast.Module(body=node.body)
+        ast.copy_location(newnode, node)
+        ast.fix_missing_locations(newnode)
+        return newnode
+
+    def visit_Name(self, node):
+        if isinstance(node.ctx, ast.Load):
+            self.names.append(node.id)
+        return node
 
 
 def int_to_Integer(s):
@@ -138,111 +195,16 @@ def int_to_Integer(s):
     return untokenize(result)
 
 
-def enable_automatic_int_sympification(app):
-    """
-    Allow IPython to automatically convert integer literals to Integer.
-    """
-    hasshell = hasattr(app, 'shell')
-
-    import ast
-    if hasshell:
-        old_run_cell = app.shell.run_cell
-    else:
-        old_run_cell = app.run_cell
-
-    def my_run_cell(cell, *args, **kwargs):
-        try:
-            # Check the cell for syntax errors.  This way, the syntax error
-            # will show the original input, not the transformed input.  The
-            # downside here is that IPython magic like %timeit will not work
-            # with transformed input (but on the other hand, IPython magic
-            # that doesn't expect transformed input will continue to work).
-            ast.parse(cell)
-        except SyntaxError:
-            pass
-        else:
-            cell = int_to_Integer(cell)
-        old_run_cell(cell, *args, **kwargs)
-
-    if hasshell:
-        app.shell.run_cell = my_run_cell
-    else:
-        app.run_cell = my_run_cell
+def enable_automatic_int_sympification(shell):
+    """Allow IPython to automatically convert integer literals to Integer."""
+    shell.ast_transformers.append(IntegerWrapper())
 
 
-def enable_automatic_symbols(app):
-    """Allow IPython to automatially create symbols (``isympy -a``). """
-    # XXX: This should perhaps use tokenize, like int_to_Integer() above.
-    # This would avoid re-executing the code, which can lead to subtle
-    # issues.  For example:
-    #
-    # In [1]: a = 1
-    #
-    # In [2]: for i in range(10):
-    #    ...:     a += 1
-    #    ...:
-    #
-    # In [3]: a
-    # Out[3]: 11
-    #
-    # In [4]: a = 1
-    #
-    # In [5]: for i in range(10):
-    #    ...:     a += 1
-    #    ...:     print b
-    #    ...:
-    # b
-    # b
-    # b
-    # b
-    # b
-    # b
-    # b
-    # b
-    # b
-    # b
-    #
-    # In [6]: a
-    # Out[6]: 12
-    #
-    # Note how the for loop is executed again because `b` was not defined, but `a`
-    # was already incremented once, so the result is that it is incremented
-    # multiple times.
+def enable_automatic_symbols(shell):
+    """Allow IPython to automatially create symbols."""
+    shell.ast_transformers.append(AutomaticSymbols(shell))
 
-    import re
-    re_nameerror = re.compile(
-        "name '(?P<symbol>[A-Za-z_][A-Za-z0-9_]*)' is not defined")
 
-    def _handler(self, etype, value, tb, tb_offset=None):
-        """Handle :exc:`NameError` exception and allow injection of missing symbols. """
-        if etype is NameError and tb.tb_next and not tb.tb_next.tb_next:
-            match = re_nameerror.match(str(value))
-
-            if match is not None:
-                # XXX: Make sure Symbol is in scope. Otherwise you'll get infinite recursion.
-                self.run_cell("%(symbol)s = Symbol('%(symbol)s')" %
-                    {'symbol': match.group("symbol")}, store_history=False)
-
-                try:
-                    code = self.user_ns['In'][-1]
-                except (KeyError, IndexError):
-                    pass
-                else:
-                    self.run_cell(code, store_history=False)
-                    return None
-                finally:
-                    self.run_cell("del %s" % match.group("symbol"),
-                                  store_history=False)
-
-        stb = self.InteractiveTB.structured_traceback(
-            etype, value, tb, tb_offset=tb_offset)
-        self._showtraceback(etype, value, stb)
-
-    if hasattr(app, 'shell'):
-        app.shell.set_custom_exc((NameError,), _handler)
-    else:
-        # This was restructured in IPython 0.13
-        app.set_custom_exc((NameError,), _handler)
 
 
 def init_ipython_session(argv=[], auto_symbols=False, auto_int_to_Integer=False):
@@ -282,11 +244,9 @@ def init_ipython_session(argv=[], auto_symbols=False, auto_int_to_Integer=False)
             shell.run_ast_nodes = types.MethodType(my_run_ast_nodes, shell)
 
         if auto_symbols:
-            readline = import_module("readline")
-            if readline:
-                enable_automatic_symbols(app)
+            enable_automatic_symbols(shell)
         if auto_int_to_Integer:
-            enable_automatic_int_sympification(app)
+            enable_automatic_int_sympification(shell)
 
         return shell
     else:
@@ -468,21 +428,19 @@ def init_session(ipython=None, pretty_print=True, order=None,
         if not in_ipython:
             mainloop = ip.mainloop
 
-    readline = import_module("readline")
-    if auto_symbols and (not ipython or V(IPython.__version__) < '0.11' or not readline):
-        raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above with readline support")
+    if auto_symbols and (not ipython or V(IPython.__version__) < '0.11'):
+        raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above")
     if auto_int_to_Integer and (not ipython or V(IPython.__version__) < '0.11'):
         raise RuntimeError("automatic int to Integer transformation is possible only in IPython 0.11 or above")
 
-    _preexec_source = preexec_source
-
-    ip.runsource(_preexec_source, symbol='exec')
+    ip.runsource(import_source, symbol='exec')
+    ip.runsource(preexec_source, symbol='exec')
     init_printing(pretty_print=pretty_print, order=order,
                   use_unicode=use_unicode, use_latex=use_latex, ip=ip,
                   str_printer=str_printer, pretty_printer=pretty_printer,
                   latex_printer=latex_printer)
 
-    message = _make_message(ipython, quiet, _preexec_source)
+    message = _make_message(ipython, quiet)
 
     if not in_ipython:
         print(message)

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -3,7 +3,7 @@
 from sympy.interactive.session import (init_ipython_session,
     enable_automatic_symbols, enable_automatic_int_sympification)
 
-from sympy.core import Symbol, Rational, Integer
+from sympy.core import Symbol, Rational, Integer, Float
 from sympy.external import import_module
 
 # TODO: The code below could be made more granular with something like:
@@ -11,9 +11,7 @@ from sympy.external import import_module
 # @requires('IPython', version=">=0.11")
 # def test_automatic_symbols(ipython):
 
-# run_cell was added in IPython 0.11
 ipython = import_module("IPython", min_module_version="0.11")
-readline = import_module("readline")
 
 if not ipython:
     #bin/test will not execute any tests now
@@ -21,9 +19,6 @@ if not ipython:
 
 
 def test_automatic_symbols():
-    # this implicitly requires readline
-    if not readline:
-        return None
     # NOTE: Because of the way the hook works, you have to use run_cell(code,
     # True).  This means that the code must have no Out, or it will be printed
     # during the tests.
@@ -34,27 +29,28 @@ def test_automatic_symbols():
 
     symbol = "verylongsymbolname"
     assert symbol not in app.user_ns
-    app.run_cell("a = %s" % symbol, True)
-    assert symbol not in app.user_ns
-    app.run_cell("a = type(%s)" % symbol, True)
+    app.run_cell("a = %s" % symbol)
+    assert symbol in app.user_ns
+    app.run_cell("a = type(%s)" % symbol)
     assert app.user_ns['a'] == Symbol
-    app.run_cell("%s = Symbol('%s')" % (symbol, symbol), True)
+    app.run_cell("%s = Symbol('%s')" % (symbol, symbol))
     assert symbol in app.user_ns
 
     # Check that built-in names aren't overridden
-    app.run_cell("a = all == __builtin__.all", True)
+    app.run_cell("a = all == __builtin__.all")
     assert "all" not in app.user_ns
     assert app.user_ns['a'] is True
 
     # Check that sympy names aren't overridden
     app.run_cell("import sympy")
-    app.run_cell("a = factorial == sympy.factorial", True)
+    app.run_cell("a = factorial == sympy.factorial")
     assert app.user_ns['a'] is True
 
 
 def test_int_to_Integer():
     # XXX: Warning, don't test with == here.  0.5 == Rational(1, 2) is True!
     app = init_ipython_session()
+    app.run_cell("from __future__ import division")
     app.run_cell("from sympy import Integer")
     app.run_cell("a = 1")
     assert isinstance(app.user_ns['a'], int)
@@ -66,7 +62,8 @@ def test_int_to_Integer():
     assert isinstance(app.user_ns['a'], Integer)
     app.run_cell("a = int(1)")
     assert isinstance(app.user_ns['a'], int)
+    app.run_cell("a = int(1)/int(2)")
+    assert isinstance(app.user_ns['a'], float)
     app.run_cell("a = (1/\n2)")
-    assert app.user_ns['a'] == Rational(1, 2)
-    # TODO: How can we test that the output of a SyntaxError is the original
-    # input, not the transformed input?
+    assert isinstance(app.user_ns['a'], Rational)
+

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -1,7 +1,8 @@
 """Tests of tools for setting up interactive IPython sessions. """
 
 from sympy.interactive.session import (init_ipython_session,
-    enable_automatic_symbols, enable_automatic_int_sympification)
+    enable_automatic_symbols, enable_automatic_int_sympification,
+    enable_automatic_rationalize)
 
 from sympy.core import Symbol, Rational, Integer, Float
 from sympy.external import import_module
@@ -67,3 +68,18 @@ def test_int_to_Integer():
     app.run_cell("a = (1/\n2)")
     assert isinstance(app.user_ns['a'], Rational)
 
+
+def test_rationalize():
+    app = init_ipython_session()
+    app.run_cell("from sympy import Integer")
+    app.run_cell("a = 0.5")
+    assert isinstance(app.user_ns['a'], float)
+
+    enable_automatic_rationalize(app)
+    app.run_cell("a = 0.5")
+    assert isinstance(app.user_ns['a'], Rational)
+    app.run_cell("a = float(0.5)")
+    assert isinstance(app.user_ns['a'], float)
+    app.run_cell("a = Float(1.234567890123456)")
+    assert isinstance(app.user_ns['a'], Float)
+    assert app.user_ns['a'] == Float(1.234567890123456)

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -122,7 +122,11 @@ def test_matplotlib_bad_latex():
 
     # Make sure no warnings are raised by IPython
     app.run_cell("import warnings")
-    app.run_cell("warnings.simplefilter('error', IPython.core.formatters.FormatterWarning)")
+    # IPython.core.formatters.FormatterWarning was introduced in IPython 2.0
+    if int(ipython.__version__.split(".")[0]) < 2:
+        app.run_cell("warnings.simplefilter('error')")
+    else:
+        app.run_cell("warnings.simplefilter('error', IPython.core.formatters.FormatterWarning)")
 
     # This should not raise an exception
     app.run_cell("a = format(Matrix([1, 2, 3]))")

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division
 import sys
 import os
 import re as _re
+import struct
 from textwrap import fill, dedent
 from sympy.core.compatibility import get_function_name, range
 
@@ -104,13 +105,7 @@ def rawlines(s):
         else:
             return "dedent('''\\\n    %s''')" % rv
 
-size = getattr(sys, "maxint", None)
-if size is None:  # Python 3 doesn't have maxint
-    size = sys.maxsize
-if size > 2**32:
-    ARCH = "64-bit"
-else:
-    ARCH = "32-bit"
+ARCH = str(struct.calcsize('P') * 8) + "-bit"
 
 
 # XXX: PyPy doesn't support hash randomization


### PR DESCRIPTION
- Implement AST transformers(IntegerWrapper and AutomaticSymbols) from Diofant(@skirpichev)
- Add automatic rationalization option: automatically wraps `float` with `Rational`, e.g., `0.5` to `Rational('0.5')`

* [ ] Implement token-based transformers or use IPython token-based transformer: #14440

- ~Change `optparse` to `argparse`: `optparse` is deprecated since Python version 2.7~
- ~Use existing IPython shell if present, when initializing new IPython session: Fixes #13418, fixes #13319, and fixes #11419.~
- ~Fixed incorrect architecture detection on 64-bit Windows. [(SO)](https://stackoverflow.com/q/1405913/1448742)~

Split into #14443 and #14440.