### PR TITLE
Use _as_mpf_val methods when creating new Floats

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1053,7 +1053,10 @@ class Float(Number):
             if precision < num._prec:
                 _mpf_ = mpf_norm(_mpf_, precision)
         else:
-            _mpf_ = mpmath.mpf(num, prec=precision)._mpf_
+            try:
+                _mpf_ = num._as_mpf_val(precision)
+            except (NotImplementedError, AttributeError):
+                _mpf_ = mpmath.mpf(num, prec=precision)._mpf_
 
         # special cases
         if _mpf_ == _mpf_zero:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1943,7 +1943,7 @@ class Integer(Rational):
     __slots__ = ['p']
 
     def _as_mpf_val(self, prec):
-        return mlib.from_int(self.p, prec)
+        return mlib.from_int(self.p, prec, rnd)
 
     def _mpmath_(self, prec, rnd):
         return mpmath.make_mpf(self._as_mpf_val(prec))

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1033,8 +1033,6 @@ class Float(Number):
                     _mpf_ = _mpf_ninf
             else:
                 raise ValueError("unexpected decimal value %s" % str(num))
-        elif isinstance(num, Rational):
-            _mpf_ = mlib.from_rational(num.p, num.q, precision, rnd)
         elif isinstance(num, tuple) and len(num) in (3, 4):
             if type(num[1]) is str:
                 # it's a hexadecimal (coming from a pickled object)
@@ -1048,10 +1046,6 @@ class Float(Number):
                     return Float._new(num, precision)
                 else:
                     return (S.NegativeOne**num[0]*num[1]*S(2)**num[2]).evalf(precision)
-        elif isinstance(num, Float):
-            _mpf_ = num._mpf_
-            if precision < num._prec:
-                _mpf_ = mpf_norm(_mpf_, precision)
         else:
             try:
                 _mpf_ = num._as_mpf_val(precision)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -533,6 +533,10 @@ def test_Float():
     raises(ValueError, lambda: Float("1.23", dps=3, precision=""))
     raises(ValueError, lambda: Float("1.23", dps="", precision=""))
 
+    # from NumberSymbol
+    assert same_and_same_prec(Float(pi, 32), pi.evalf(32))
+    assert same_and_same_prec(Float(Catalan), Catalan.evalf())
+
 
 @conserve_mpmath_dps
 def test_float_mpf():

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1488,7 +1488,7 @@ class Segment(LinearEntity):
                 try:
                     # the triangle inequality says that |d1|+|d2| >= |d| and is strict
                     # only if other lies in the line segment
-                    return bool(Eq(simplify(abs(d1) + abs(d2) - abs(d)), 0))
+                    return bool(simplify(Eq(abs(d1) + abs(d2) - abs(d), 0)))
                 except TypeError:
                     raise Undecidable("Cannot determine if {} is in {}".format(other, self))
         if isinstance(other, Segment):


### PR DESCRIPTION
This adds support for `Float(S.Pi)` (which previously gave an error).

Having done that, I noticed the same mechanisgm could de-dupes the code a bit.  I don't think this has any performance implications; same code is being called, just in the `_as_mpf_val` method now.