### PR TITLE
Fix Float when precision is passed in as a SymPy Integer

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1017,6 +1017,8 @@ class Float(Number):
         if precision is None or precision == '':
             precision = mlib.libmpf.dps_to_prec(dps)
 
+        precision = int(precision)
+
         if isinstance(num, float):
             _mpf_ = mlib.from_float(num, precision, rnd)
         elif isinstance(num, string_types):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1737,3 +1737,9 @@ def test_NumberSymbol_comparison():
     assert (fpi <= pi) == (pi >= fpi)
     assert (fpi > pi) == (pi < fpi)
     assert (fpi >= pi) == (pi <= fpi)
+
+def Integer_precision():
+    # Make sure none of these crash
+    assert Float('1.0', dps=Integer(15))._prec == 53
+    assert Float('1.0', precision=Integer(15))._prec == 15
+    assert type(Float('1.0', precision=Integer(15))) == int

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2,7 +2,8 @@ import decimal
 from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow, Tuple, latex, Gt, Lt, Ge, Le,
-                   AlgebraicNumber, simplify, sin, fibonacci, RealField)
+                   AlgebraicNumber, simplify, sin, fibonacci, RealField,
+                   sympify, srepr)
 from sympy.core.compatibility import long
 from sympy.core.power import integer_nthroot, isqrt
 from sympy.core.logic import fuzzy_not
@@ -1738,8 +1739,9 @@ def test_NumberSymbol_comparison():
     assert (fpi > pi) == (pi < fpi)
     assert (fpi >= pi) == (pi <= fpi)
 
-def Integer_precision():
+def test_Integer_precision():
     # Make sure none of these crash
     assert Float('1.0', dps=Integer(15))._prec == 53
     assert Float('1.0', precision=Integer(15))._prec == 15
-    assert type(Float('1.0', precision=Integer(15))) == int
+    assert type(Float('1.0', precision=Integer(15))._prec) == int
+    assert sympify(srepr(Float('1.0', precision=15))) == Float('1.0', precision=15)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1740,7 +1740,7 @@ def test_NumberSymbol_comparison():
     assert (fpi >= pi) == (pi <= fpi)
 
 def test_Integer_precision():
-    # Make sure none of these crash
+    # Make sure Integer inputs for keyword args work
     assert Float('1.0', dps=Integer(15))._prec == 53
     assert Float('1.0', precision=Integer(15))._prec == 15
     assert type(Float('1.0', precision=Integer(15))._prec) == int


### PR DESCRIPTION
This happens when you sympify the srepr() of a Float, because sympify converts the precision argument to an Integer. Without this fix, you get errors in mpmath or from gmpy2 (if it is installed) because Integer isn't supported. 
