### PR TITLE
DiracDelta(-x) == DiracDelta(x)

### DIFF
--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -193,8 +193,16 @@ class DiracDelta(Function):
             return S.NaN
         if arg.is_nonzero:
             return S.Zero
+        c, nc = arg.args_cnc()
+        if c and c[0] == -1:
+            # keep this fast and simple instead of using
+            # could_extract_minus_sign
+            return cls(-arg, k) if k else cls(-arg)
         if fuzzy_not(im(arg).is_zero):
-            raise ValueError("Function defined only for Real Values. Complex part: %s  found in %s ." % (repr(im(arg)), repr(arg)) )
+            raise ValueError(filldedent('''
+                Function defined only for Real Values.
+                Complex part: %s  found in %s .''' % (
+                repr(im(arg)), repr(arg))))
 
     @deprecated(useinstead="expand(diracdelta=True, wrt=x)", issue=12859, deprecated_since_version="1.1")
     def simplify(self, x):

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -208,7 +208,7 @@ class DiracDelta(Function):
             if k % 2 == 1:
                 return -cls(-arg, k)
             elif k % 2 == 0:
-                return cls(-arg)
+                return cls(-arg, k) if k else cls(-arg)
 
     @deprecated(useinstead="expand(diracdelta=True, wrt=x)", issue=12859, deprecated_since_version="1.1")
     def simplify(self, x):

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -40,16 +40,19 @@ class DiracDelta(Function):
 
     DiracDelta function has the following properties:
 
-    1) ``diff(Heaviside(x),x) = DiracDelta(x)``
-    2) ``integrate(DiracDelta(x-a)*f(x),(x,-oo,oo)) = f(a)`` and
-       ``integrate(DiracDelta(x-a)*f(x),(x,a-e,a+e)) = f(a)``
+    1) ``diff(Heaviside(x), x) = DiracDelta(x)``
+    2) ``integrate(DiracDelta(x - a)*f(x),(x, -oo, oo)) = f(a)`` and
+       ``integrate(DiracDelta(x - a)*f(x),(x, a - e, a + e)) = f(a)``
     3) ``DiracDelta(x) = 0`` for all ``x != 0``
-    4) ``DiracDelta(g(x)) = Sum_i(DiracDelta(x-x_i)/abs(g'(x_i)))``
+    4) ``DiracDelta(g(x)) = Sum_i(DiracDelta(x - x_i)/abs(g'(x_i)))``
        Where ``x_i``-s are the roots of ``g``
+    5) ``DiracDelta(-x) = DiracDelta(x)``
 
     Derivatives of ``k``-th order of DiracDelta have the following property:
 
-    5) ``DiracDelta(x,k) = 0``, for all ``x != 0``
+    6) ``DiracDelta(x, k) = 0``, for all ``x != 0``
+    7) ``DiracDelta(-x, k) = -DiracDelta(x, k)`` for odd ``k``
+    8) ``DiracDelta(-x, k) = DiracDelta(x, k)`` for even ``k``
 
     Examples
     ========
@@ -156,13 +159,13 @@ class DiracDelta(Function):
         >>> DiracDelta(x)
         DiracDelta(x)
 
-        >>> DiracDelta(x,1)
-        DiracDelta(x, 1)
+        >>> DiracDelta(-x, 1)
+        -DiracDelta(x, 1)
 
         >>> DiracDelta(1)
         0
 
-        >>> DiracDelta(5,1)
+        >>> DiracDelta(5, 1)
         0
 
         >>> DiracDelta(0)
@@ -193,16 +196,19 @@ class DiracDelta(Function):
             return S.NaN
         if arg.is_nonzero:
             return S.Zero
-        c, nc = arg.args_cnc()
-        if c and c[0] == -1:
-            # keep this fast and simple instead of using
-            # could_extract_minus_sign
-            return cls(-arg, k) if k else cls(-arg)
         if fuzzy_not(im(arg).is_zero):
             raise ValueError(filldedent('''
                 Function defined only for Real Values.
                 Complex part: %s  found in %s .''' % (
                 repr(im(arg)), repr(arg))))
+        c, nc = arg.args_cnc()
+        if c and c[0] == -1:
+            # keep this fast and simple instead of using
+            # could_extract_minus_sign
+            if k % 2 == 1:
+                return -cls(-arg, k)
+            elif k % 2 == 0:
+                return cls(-arg)
 
     @deprecated(useinstead="expand(diracdelta=True, wrt=x)", issue=12859, deprecated_since_version="1.1")
     def simplify(self, x):

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -58,6 +58,7 @@ def test_DiracDelta():
 
     assert DiracDelta(2*x) != DiracDelta(x)  # scaling property
     assert DiracDelta(x) == DiracDelta(-x)  # even function
+    assert DiracDelta(-x, 1) == -DiracDelta(x, 1)  # odd deriv is odd
     assert DiracDelta(-oo*x) == DiracDelta(oo*x)
     assert DiracDelta(x - y) != DiracDelta(y - x)
     assert signsimp(DiracDelta(x - y) - DiracDelta(y - x)) == 0

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -58,6 +58,7 @@ def test_DiracDelta():
 
     assert DiracDelta(2*x) != DiracDelta(x)  # scaling property
     assert DiracDelta(x) == DiracDelta(-x)  # even function
+    assert DiracDelta(-x, 2) == DiracDelta(x, 2)
     assert DiracDelta(-x, 1) == -DiracDelta(x, 1)  # odd deriv is odd
     assert DiracDelta(-oo*x) == DiracDelta(oo*x)
     assert DiracDelta(x - y) != DiracDelta(y - x)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -1,6 +1,7 @@
 from sympy import (
     adjoint, conjugate, DiracDelta, Heaviside, nan, pi, sign, sqrt,
-    symbols, transpose, Symbol, Piecewise, I, S, Eq, oo, SingularityFunction
+    symbols, transpose, Symbol, Piecewise, I, S, Eq, oo,
+    SingularityFunction, signsimp
 )
 
 from sympy.utilities.pytest import raises
@@ -54,6 +55,12 @@ def test_DiracDelta():
     assert DiracDelta(y).expand(diracdelta=True, wrt=x) == DiracDelta(y)
     assert DiracDelta((x - 1)*(x - 2)*(x - 3)).expand(diracdelta=True, wrt=x) == (
         DiracDelta(x - 3)/2 + DiracDelta(x - 2) + DiracDelta(x - 1)/2)
+
+    assert DiracDelta(2*x) != DiracDelta(x)  # scaling property
+    assert DiracDelta(x) == DiracDelta(-x)  # even function
+    assert DiracDelta(-oo*x) == DiracDelta(oo*x)
+    assert DiracDelta(x - y) != DiracDelta(y - x)
+    assert signsimp(DiracDelta(x - y) - DiracDelta(y - x)) == 0
 
     with raises(SymPyDeprecationWarning):
         assert DiracDelta(x*y).simplify(x) == DiracDelta(x)/abs(y)

--- a/sympy/functions/special/tests/test_singularity_functions.py
+++ b/sympy/functions/special/tests/test_singularity_functions.py
@@ -79,7 +79,7 @@ def test_rewrite():
     assert expr_in.rewrite('HeavisideDiracDelta') == expr_out
 
     expr_in = SingularityFunction(x, a, n) + SingularityFunction(x, a, -1) - SingularityFunction(x, a, -2)
-    expr_out = (x - a)**n*Heaviside(x - a) + DiracDelta(x - a) - DiracDelta(x - a, 1)
+    expr_out = (x - a)**n*Heaviside(x - a) + DiracDelta(x - a) - DiracDelta(a - x, 1)
     assert expr_in.rewrite(Heaviside) == expr_out
     assert expr_in.rewrite(DiracDelta) == expr_out
     assert expr_in.rewrite('HeavisideDiracDelta') == expr_out

--- a/sympy/functions/special/tests/test_singularity_functions.py
+++ b/sympy/functions/special/tests/test_singularity_functions.py
@@ -79,7 +79,7 @@ def test_rewrite():
     assert expr_in.rewrite('HeavisideDiracDelta') == expr_out
 
     expr_in = SingularityFunction(x, a, n) + SingularityFunction(x, a, -1) - SingularityFunction(x, a, -2)
-    expr_out = (x - a)**n*Heaviside(x - a) + DiracDelta(x - a) - DiracDelta(a - x, 1)
+    expr_out = (x - a)**n*Heaviside(x - a) + DiracDelta(x - a) + DiracDelta(a - x, 1)
     assert expr_in.rewrite(Heaviside) == expr_out
     assert expr_in.rewrite(DiracDelta) == expr_out
     assert expr_in.rewrite('HeavisideDiracDelta') == expr_out

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -376,7 +376,7 @@ def signsimp(expr, evaluate=None):
     if not isinstance(e, Expr) or e.is_Atom:
         return e
     if e.is_Add:
-        return e.func(*[signsimp(a) for a in e.args])
+        return e.func(*[signsimp(a, evaluate) for a in e.args])
     if evaluate:
         e = e.xreplace({m: -(-m) for m in e.atoms(Mul) if -(-m) != m})
     return e

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -556,6 +556,8 @@ def test_signsimp():
     e = x*(-x + 1) + x*(x - 1)
     assert signsimp(Eq(e, 0)) is S.true
     assert Abs(x - 1) == Abs(1 - x)
+    assert signsimp(y - x) == y - x
+    assert signsimp(y - x, evaluate=False) == Mul(-1, x - y, evaluate=False)
 
 
 def test_besselsimp():


### PR DESCRIPTION
* Minimal simplification to DiracDelta is done when the argument presents an explicit literal, negative coefficient. More complicated expressions will respond to `signsimp` as in the added tests.

* signsimp will now pass along the `evaluate` flag during its recursive step.