### PR TITLE
Use abbreviated form of quantities when printing

### DIFF
--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -7,9 +7,9 @@ from sympy import (Abs, Add, Basic, Function, Number, Rational, S, Symbol,
 from sympy.physics.units import (amount_of_substance, convert_to, find_unit,
     volume)
 from sympy.physics.units.definitions import (amu, au, centimeter, coulomb,
-    day, energy, foot, grams, hour, inch, kg, km, m, meter, mile, millimeter,
-    minute, pressure, quart, s, second, speed_of_light, temperature, bit,
-    byte, kibibyte, mebibyte, gibibyte, tebibyte, pebibyte, exbibyte)
+    day, energy, foot, grams, hour, inch, kilogram, kg, km, m, meter, mile,
+    millimeter, minute, pressure, quart, s, second, speed_of_light, temperature,
+    bit, byte, kibibyte, mebibyte, gibibyte, tebibyte, pebibyte, exbibyte)
 
 from sympy.physics.units.dimensions import Dimension, charge, length, time
 from sympy.physics.units.prefixes import PREFIXES, kilo
@@ -20,7 +20,7 @@ k = PREFIXES["k"]
 
 
 def test_str_repr():
-    assert str(kg) == "kilogram"
+    assert str(kilogram) == "kg"
 
 def test_eq():
     # simple test
@@ -86,8 +86,8 @@ def test_abbrev():
 
 def test_print():
     u = Quantity("unitname", length, 10, "dam")
-    assert repr(u) == "unitname"
-    assert str(u) == "unitname"
+    assert repr(u) == "dam"
+    assert str(u) == "dam"
 
 
 def test_Quantity_eq():

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -711,7 +711,7 @@ class StrPrinter(Printer):
         return r' \ '.join(self._print(set) for set in expr.args)
 
     def _print_Quantity(self, expr):
-        return "%s" % expr.name
+        return "%s" % expr.abbrev
 
     def _print_Dimension(self, expr):
         return str(expr)


### PR DESCRIPTION
Currently, the abbreviation used in the definition of quantities, e.g. `m` in the definition of `meter`, is hardly used anywhere. For example:
```python
from sympy.physics.units import meter 
print meter
```
returns:
```
meter
```

This PR modifies printing of quantities to use the abbreviation if one was provided. Example:
```python
from sympy.physics.units import meter 
print meter
```
now returns:
```
m
```

NOTE: I changed an existing test that explicitly expected the non-abbreviated name to be printed. I just do not see the point of such behaviour, but I am happy to be educated otherwise.
Fixes #13269.
