### PR TITLE
Segment: add test for nonreal symbols

### DIFF
--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -286,6 +286,13 @@ def test_contains():
         assert len(w) == 1
 
 
+def test_contains_nonreal_symbols():
+    u, v, w, z = symbols('u, v, w, z')
+    l = Segment(Point(u, w), Point(v, z))
+    p = Point(2*u/3 + v/3, 2*w/3 + z/3)
+    assert l.contains(p)
+
+
 def test_distance_2d():
     p1 = Point(0, 0)
     p2 = Point(1, 1)


### PR DESCRIPTION
I think this was what the earlier commit [1] had in
mind when changing from dot prod test to triangle ineq.

[1] c5f0b00fbce9bdd253eb9c2465339c84ffad443d

@siefkenj I suggest we merge this for now.