### PR TITLE
linsolve: `linsolve` now raises error for non-linear equations

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1288,15 +1288,17 @@ def linsolve(system, *symbols):
 
         # 3). List of equations Form
         if not system[0].is_Matrix:
-            for eq in system:
+            system = list(system)
+            for i, eq in enumerate(system):
                 try:
-                    Poly(eq, symbols)
+                    # since we are checking it, we might as well take the
+                    # expanded expr that it will give
+                    system[i] = Poly(eq, symbols).as_expr()
                     if any (degree(eq, sym) > 1 for sym in symbols):
-                        raise ValueError(filldedent(
-'%s contains non-linear terms of variables to  be evaluated') %(eq))
+                        raise PolynomialError
                 except PolynomialError:
                         raise ValueError(filldedent(
-'%s contains non-linear terms of variables to  be evaluated') %(eq))
+'%s contains non-linear terms of variables to be evaluated') %(eq))
             A, b = linear_eq_to_matrix(system, symbols)
 
     else:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1288,6 +1288,15 @@ def linsolve(system, *symbols):
 
         # 3). List of equations Form
         if not system[0].is_Matrix:
+            for eq in system:
+                try:
+                    Poly(eq, symbols)
+                    if any (degree(eq, sym) > 1 for sym in symbols):
+                        raise ValueError(filldedent(
+'%s contains non-linear terms of variables to  be evaluated') %(eq))
+                except PolynomialError:
+                        raise ValueError(filldedent(
+'%s contains non-linear terms of variables to  be evaluated') %(eq))
             A, b = linear_eq_to_matrix(system, symbols)
 
     else:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1011,6 +1011,11 @@ def test_linsolve():
     # raise ValueError for garbage value
     raises(ValueError, lambda: linsolve(Eqns[0], x1, x2, x3, x4))
 
+    #raise ValueError if equations are non-linear in given variables
+    raises(ValueError, lambda: linsolve([x + y - 1, x ** 2 + y - 3], [x, y]))
+    raises(ValueError, lambda: linsolve([cos(x) + y, x + y], [x, y]))
+    assert linsolve([x + z - 1, x ** 2 + y - 3], [z, y]) == {(-x + 1, -x**2 + 3)}
+
     # Fully symbolic test
     a, b, c, d, e, f = symbols('a, b, c, d, e, f')
     A = Matrix([[a, b], [c, d]])


### PR DESCRIPTION
Error is raised in cases when equations are non-linear in terms of the
variables whose value is to be calculated. Tests were added.
```
In [1]: linsolve([cos(x) + y, x + y],(x, y))

ValueError:
y + cos(x) contains non-linear terms of variables to  be evaluated

In [2]: linsolve([x**2 + y + z, y + 2*z], (y, z))

Out[2]: {(-2*x**2, x**2)}
```
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #13322 