### PR TITLE
Allow itermonomials to respect non-commutative variables

### DIFF
--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -37,6 +37,7 @@ def itermonomials(variables, degree):
     Consider monomials in commutative variables `x` and `y`
     and non-commutative variables `a` and `b`::
 
+        >>> from sympy import symbols
         >>> from sympy.polys.monomials import itermonomials
         >>> from sympy.polys.orderings import monomial_key
         >>> from sympy.abc import x, y
@@ -48,8 +49,8 @@ def itermonomials(variables, degree):
         [1, x, y, x**2, x*y, y**2, x**3, x**2*y, x*y**2, y**3]
 
         >>> a, b = symbols('a, b', commutative=False)
-        >>> sorted(itermonomials([a, b, x], 2))
-        [1, a, b, x, a**2, a*b, b*a, b**2, xa, xb, x**2]
+        >>> itermonomials([a, b, x], 2)
+        {1, a, a**2, b, b**2, x, x**2, a*b, b*a, x*a, x*b}
 
 
     """

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -2,9 +2,10 @@
 
 from __future__ import print_function, division
 
+from itertools import combinations_with_replacement, product
 from textwrap import dedent
 
-from sympy.core import S, Mul, Tuple, sympify
+from sympy.core import Mul, S, Tuple, sympify
 from sympy.core.compatibility import exec_, iterable, range
 from sympy.polys.polyutils import PicklableWithSlots, dict_from_expr
 from sympy.polys.polyerrors import ExactQuotientFailed
@@ -17,7 +18,8 @@ def itermonomials(variables, degree):
 
     Given a set of variables `V` and a total degree `N` generate
     a set of monomials of degree at most `N`. The total number of
-    monomials is huge and is given by the following formula:
+    monomials in commutative variables is huge and is given by the
+    following formula:
 
     .. math::
 
@@ -32,7 +34,8 @@ def itermonomials(variables, degree):
     Examples
     ========
 
-    Consider monomials in variables `x` and `y`::
+    Consider monomials in commutative variables `x` and `y`
+    and non-commutative variables `a` and `b`::
 
         >>> from sympy.polys.monomials import itermonomials
         >>> from sympy.polys.orderings import monomial_key
@@ -44,18 +47,20 @@ def itermonomials(variables, degree):
         >>> sorted(itermonomials([x, y], 3), key=monomial_key('grlex', [y, x]))
         [1, x, y, x**2, x*y, y**2, x**3, x**2*y, x*y**2, y**3]
 
+        >>> a, b = symbols('a, b', commutative=False)
+        >>> sorted(itermonomials([a, b, x], 2))
+        [1, a, b, x, a**2, a*b, b*a, b**2, xa, xb, x**2]
+
+
     """
-    if not variables:
-        return set([S.One])
+    if not variables or degree < 1:
+        return {S(1)}
+    # Force to list in case of passed tuple or other incompatible collection
+    variables = list(variables) + [S(1)]
+    if all(variable.is_commutative for variable in variables):
+        return {Mul(*item) for item in combinations_with_replacement(variables, degree)}
     else:
-        x, tail = variables[0], variables[1:]
-
-        monoms = itermonomials(tail, degree)
-
-        for i in range(1, degree + 1):
-            monoms |= set([ x**i * m for m in itermonomials(tail, degree - i) ])
-
-        return monoms
+        return {Mul(*item) for item in product(variables, repeat=degree)}
 
 def monomial_count(V, N):
     r"""

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -54,7 +54,9 @@ def itermonomials(variables, degree):
 
 
     """
-    if not variables or degree < 1:
+    if degree < 0:
+        return set()
+    if not variables or degree == 0:
         return {S(1)}
     # Force to list in case of passed tuple or other incompatible collection
     variables = list(variables) + [S(1)]

--- a/sympy/polys/tests/test_monomials.py
+++ b/sympy/polys/tests/test_monomials.py
@@ -17,11 +17,13 @@ from sympy.utilities.pytest import raises
 
 
 def test_monomials():
+    assert itermonomials([], -1) == set()
     assert itermonomials([], 0) == {S(1)}
     assert itermonomials([], 1) == {S(1)}
     assert itermonomials([], 2) == {S(1)}
     assert itermonomials([], 3) == {S(1)}
 
+    assert itermonomials([x], -1) == set()
     assert itermonomials([x], 0) == {S(1)}
     assert itermonomials([x], 1) == {S(1), x}
     assert itermonomials([x], 2) == {S(1), x, x**2}

--- a/sympy/polys/tests/test_monomials.py
+++ b/sympy/polys/tests/test_monomials.py
@@ -12,7 +12,7 @@ from sympy.polys.monomials import (
 from sympy.polys.polyerrors import ExactQuotientFailed
 
 from sympy.abc import a, b, c, x, y, z
-from sympy.core import S
+from sympy.core import S, symbols
 from sympy.utilities.pytest import raises
 
 
@@ -33,6 +33,34 @@ def test_monomials():
     assert itermonomials([x, y], 3) == \
         {S(1), x, y, x**2, x**3, y**2, y**3, x*y, x*y**2, y*x**2}
 
+
+    i, j, k = symbols('i j k', commutative=False)
+    assert itermonomials([i, j, k], 0) == {S(1)}
+    assert itermonomials([i, j, k], 1) == {S(1), i, j, k}
+    assert itermonomials([i, j, k], 2) == \
+            {S(1), i, j, k, i**2, j**2, k**2, i*j, i*k, j*i, j*k, k*i, k*j}
+
+    assert itermonomials([i, j, k], 3) == \
+            {S(1), i, j, k, i**2, j**2, k**2, i*j, i*k, j*i, j*k, k*i, k*j,
+                        i**3, j**3, k**3,
+                        i**2 * j, i**2 * k, j * i**2, k * i**2,
+                        j**2 * i, j**2 * k, i * j**2, k * j**2,
+                        k**2 * i, k**2 * j, i * k**2, j * k**2,
+                        i*j*i, i*k*i, j*i*j, j*k*j, k*i*k, k*j*k,
+                        i*j*k, i*k*j, j*i*k, j*k*i, k*i*j, k*j*i,
+                    }
+
+    assert itermonomials([x, i, j], 0) == {S(1)}
+    assert itermonomials([x, i, j], 1) == {S(1), x, i, j}
+    assert itermonomials([x, i, j], 2) == {S(1), x, i, j, x*i, x*j, i*j, j*i, x**2, i**2, j**2}
+    assert itermonomials([x, i, j], 3) == \
+            {S(1), x, i, j, x*i, x*j, i*j, j*i, x**2, i**2, j**2,
+                        x**3, i**3, j**3,
+                        x**2 * i, x**2 * j,
+                        x * i**2, j * i**2, i**2 * j, i*j*i,
+                        x * j**2, i * j**2, j**2 * i, j*i*j,
+                        x * i * j, x * j * i,
+                    }
 
 def test_monomial_count():
     assert monomial_count(2, 2) == 6


### PR DESCRIPTION
Example:
\>\>\> from sympy import itermonomials, symbols
\>\>\> itermonomials(symbols('a b', commutative=False), 2)
{1, a, b, a\*b, b\*a, a\*\*2, b\*\*2}

Previous implementation would yield:
{1, a, b, a\*b, a\*\*2, b\*\*2}

Efficiency Tests:

from timeit import timeit

timeit("itermonomials( symbols('a b'), 2)",
    setup="from sympy import itermonomials, symbols",
    number=10000)

timeit("itermonomials( symbols('a b'), 7)",
    setup="from sympy import itermonomials, symbols",
    number=10000)

timeit("itermonomials( symbols('a b c'), 2)",
    setup="from sympy import itermonomials, symbols",
    number=10000)

timeit("itermonomials( symbols('a b c'), 4)",
    setup="from sympy import itermonomials, symbols",
    number=10000)

old:
    0.5966764690001582
    4.53667760999997
    1.209770285000559
    4.8836658829986845

new:
    0.22628378899935342
    0.596607915000277
    0.30169753399968613
    0.7843536450000101

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
