### PR TITLE
Caught and fixed: remove singularities from result of continuous_domain()

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -35,6 +35,10 @@ def test_continuous_domain():
     assert continuous_domain(log(x) + log(4*x - 1), x, S.Reals) == \
         Interval(1/4, oo, True, True)
     assert continuous_domain(1/sqrt(x - 3), x, S.Reals) == Interval(3, oo, True, True)
+    assert continuous_domain(1/x - 2, x, S.Reals) == \
+        Union(Interval.open(-oo, 0), Interval.open(0, oo))
+    assert continuous_domain(1/(x**2 - 4) + 2, x, S.Reals) == \
+        Union(Interval.open(-oo, -2), Interval.open(-2, 2), Interval.open(2, oo))
 
 
 def test_not_empty_in():

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -10,6 +10,8 @@ from sympy.sets.sets import (Interval, Intersection, FiniteSet, Union,
 from sympy.sets.conditionset import ConditionSet
 from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.utilities import filldedent
+from sympy.simplify.radsimp import denom
+from sympy.polys.rationaltools import together
 
 def continuous_domain(f, symbol, domain):
     """
@@ -37,8 +39,6 @@ def continuous_domain(f, symbol, domain):
     """
     from sympy.solvers.inequalities import solve_univariate_inequality
     from sympy.solvers.solveset import solveset, _has_rational_power
-    from sympy import denom
-    from sympy import together
 
     if domain.is_subset(S.Reals):
         constrained_interval = domain

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -11,7 +11,6 @@ from sympy.sets.conditionset import ConditionSet
 from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.utilities import filldedent
 
-
 def continuous_domain(f, symbol, domain):
     """
     Returns the intervals in the given domain for which the function
@@ -38,8 +37,8 @@ def continuous_domain(f, symbol, domain):
     """
     from sympy.solvers.inequalities import solve_univariate_inequality
     from sympy.solvers.solveset import solveset, _has_rational_power
-    from sympy.simplify.radsimp import denom
-    from sympy.polys.rationaltools import together
+    from sympy import denom
+    from sympy import together
 
     if domain.is_subset(S.Reals):
         constrained_interval = domain
@@ -64,17 +63,17 @@ def continuous_domain(f, symbol, domain):
         sings = S.EmptySet
         if f.has(Abs):
             sings = solveset(1/f, symbol, domain) + \
-                solveset(denom(together(f)), symbol, S.Reals)
+                solveset(denom(together(f)), symbol, domain)
         else:
             for atom in f.atoms(Pow):
                 predicate, denomin = _has_rational_power(atom, symbol)
                 if predicate and denomin == 2:
                     sings = solveset(1/f, symbol, domain) +\
-                        solveset(denom(together(f)), symbol, S.Reals)
+                        solveset(denom(together(f)), symbol, domain)
                     break
             else:
                 sings = Intersection(solveset(1/f, symbol), domain) + \
-                    solveset(denom(together(f)), symbol, S.Reals)
+                    solveset(denom(together(f)), symbol, domain)
 
     except BaseException:
         raise NotImplementedError(

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -38,13 +38,15 @@ def continuous_domain(f, symbol, domain):
     """
     from sympy.solvers.inequalities import solve_univariate_inequality
     from sympy.solvers.solveset import solveset, _has_rational_power
+    from sympy.simplify.radsimp import denom
+    from sympy.polys.rationaltools import together
 
     if domain.is_subset(S.Reals):
         constrained_interval = domain
         for atom in f.atoms(Pow):
-            predicate, denom = _has_rational_power(atom, symbol)
+            predicate, denomin = _has_rational_power(atom, symbol)
             constraint = S.EmptySet
-            if predicate and denom == 2:
+            if predicate and denomin == 2:
                 constraint = solve_univariate_inequality(atom.base >= 0,
                                                          symbol).as_set()
                 constrained_interval = Intersection(constraint,
@@ -61,15 +63,18 @@ def continuous_domain(f, symbol, domain):
     try:
         sings = S.EmptySet
         if f.has(Abs):
-            sings = solveset(1/f, symbol, domain)
+            sings = solveset(1/f, symbol, domain) + \
+                solveset(denom(together(f)), symbol, S.Reals)
         else:
             for atom in f.atoms(Pow):
-                predicate, denom = _has_rational_power(atom, symbol)
-                if predicate and denom == 2:
-                    sings = solveset(1/f, symbol, domain)
+                predicate, denomin = _has_rational_power(atom, symbol)
+                if predicate and denomin == 2:
+                    sings = solveset(1/f, symbol, domain) +\
+                        solveset(denom(together(f)), symbol, S.Reals)
                     break
             else:
-                sings = Intersection(solveset(1/f, symbol), domain)
+                sings = Intersection(solveset(1/f, symbol), domain) + \
+                    solveset(denom(together(f)), symbol, S.Reals)
 
     except BaseException:
         raise NotImplementedError(


### PR DESCRIPTION
Continuous_domain returned wrong result for certain functions, where singularities
were included in the continuous_domain.
Example(Before fix):
```
In [3]: continuous_domain(1/x - 2, x, S.Reals)
Out[3]: ℝ
```
Added condition to continuous_domain in sympy.calculus.util to remove
singularities that were being included in the domain before. Added tests to
check for the added constraints.
Example(After fix):
```
In [2]: continuous_domain(1/x - 2, x, S.Reals)
Out[2]: (-∞, 0) ∪ (0, ∞)

In [3]: continuous_domain(1/(x**2 - 1) - 2, x, S.Reals)
Out[3]: (-∞, -1) ∪ (-1, 1) ∪ (1, ∞)
```
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
