### PR TITLE
srepr of polynomial rings and fraction fields

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -199,6 +199,23 @@ class ReprPrinter(Printer):
         denom = self._print(denom_terms)
         return "%s(%s, %s, %s)" % (frac.__class__.__name__, self._print(frac.field), numer, denom)
 
+    def _print_FractionField(self, domain):
+        cls = domain.__class__.__name__
+        field = self._print(domain.field)
+        return "%s(%s)" % (cls, field)
+
+    def _print_PolynomialRingBase(self, ring):
+        cls = ring.__class__.__name__
+        dom = self._print(ring.domain)
+        gens = ', '.join(map(self._print, ring.gens))
+        order = str(ring.order)
+        if order != ring.default_order:
+            orderstr = ", order=" + order
+        else:
+            orderstr = ""
+        return "%s(%s, %s%s)" % (cls, dom, gens, orderstr)
+
+
 def srepr(expr, **settings):
     """return expr in repr form"""
     return ReprPrinter(settings).doprint(expr)

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -213,6 +213,22 @@ def test_FracElement():
     F, x, y = field("x,y", ZZ)
     assert srepr((3*x**2*y + 1)/(x - y**2)) == "FracElement(FracField((Symbol('x'), Symbol('y')), ZZ, lex), [((2, 1), 3), ((0, 0), 1)], [((1, 0), 1), ((0, 2), -1)])"
 
+def test_FractionField():
+    assert srepr(QQ.frac_field(x)) == \
+        "FractionField(FracField((Symbol('x'),), QQ, lex))"
+    assert srepr(QQ.frac_field(x, y, order=grlex)) == \
+        "FractionField(FracField((Symbol('x'), Symbol('y')), QQ, grlex))"
+
+
+def test_PolynomialRingBase():
+    assert srepr(ZZ.old_poly_ring(x)) == \
+        "GlobalPolynomialRing(ZZ, Symbol('x'))"
+    assert srepr(ZZ[x].old_poly_ring(y)) == \
+        "GlobalPolynomialRing(ZZ[x], Symbol('y'))"
+    assert srepr(QQ.frac_field(x).old_poly_ring(y)) == \
+        "GlobalPolynomialRing(FractionField(FracField((Symbol('x'),), QQ, lex)), Symbol('y'))"
+
+
 def test_BooleanAtom():
     assert srepr(true) == "S.true"
     assert srepr(false) == "S.false"


### PR DESCRIPTION
The old polynomial ring currently prints in the same way as the
new one and its string representation only creates the new ring.
```
>>> A = ZZ.old_poly_ring(x)
>>> sstr(A)
'ZZ[x]'
>>> srepr(A)
'ZZ[x]'
>>> type(ZZ[x])
<class 'sympy.polys.domains.polynomialring.PolynomialRing'>
>>> type(A)
<class 'sympy.polys.domains.old_polynomialring.GlobalPolynomialRing'>
```
This commit defines a representation string that can be used to
construct the old polynomial ring.
```
>>> srepr(A)
"GlobalPolynomialRing(ZZ, Symbol('x'))"
```
With fraction fields, there is another issue. The printed string
of type QQ(x) cannot be used at all to create a SymPy object.
Therefore a new representation is defined.
```
>>> K = QQ.frac_field(x)
>>> sstr(K)
'QQ(x)'
>>> srepr(K)
"FractionField(FracField((Symbol('x'),), QQ, lex))"
```
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
