### PR TITLE
Remove _print_Integer from MpmathPrinter

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -206,9 +206,6 @@ class MpmathPrinter(PythonCodePrinter):
         [(k, 'mpmath.' + v) for k, v in _known_functions_mpmath.items()]
     ))
 
-    def _print_Integer(self, e):
-        return '%s(%d)' % (self._module_format('mpmath.mpf'), e)
-
     def _print_Float(self, e):
         # XXX: This does not handle setting mpmath.mp.dps. It is assumed that
         # the caller of the lambdified function will have set it to sufficient

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -390,10 +390,6 @@ def test_issue9474():
         f = lambdify(x, floor(sympy.S(1)/x), modules=mod)
         assert f(2) == 0
 
-    if mpmath:
-        f = lambdify(x, sympy.S(1)/sympy.Abs(x), modules=['mpmath'])
-        assert isinstance(f(2), mpmath.mpf)
-
     for absfunc, modules in product([Abs, abs], mods):
         f = lambdify(x, absfunc(x), modules=modules)
         assert f(-1) == 1

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -302,7 +302,7 @@ def test_math():
 
 def test_sin():
     f = lambdify(x, sin(x)**2)
-    assert isinstance(f(2), (float, mpmath.ctx_mp_python.mpf))
+    assert isinstance(f(2), float)
     f = lambdify(x, sin(x)**2, modules="math")
     assert isinstance(f(2), float)
 


### PR DESCRIPTION
Remove Integer to mpf conversion in MpmathPrinter, as Integers in mpf operation is automatically converted and Integers in other operations should not be converted.

This conversion results in unnecessary float approximation and possibly incorrect result in Integer(Rational) and power operation when using lambdify, e.g., `eval_rational` in `.polys.rootoftools` and `hypsum` in `.core.evalf`.

Fixes #13168 and partially #13326.