### PR TITLE
Improve Travis optional dependencies testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,10 @@ matrix:
   include:
     - python: 2.7
       env:
-        - TEST_GMPY="true"
-        - TEST_MATPLOTLIB="true"
-        - TEST_THEANO="true"
         - TEST_ASCII="true"
-        - TEST_AUTOWRAP="true"
-        - TEST_SYMENGINE="true"
+        # space separated list of optional dependencies(conda packages) to install and test
+        # autowrap installs libgfortran libgcc gcc cython
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.*"
       addons:
         apt:
           packages:
@@ -37,12 +35,8 @@ matrix:
             - gfortran
     - python: 3.5
       env:
-        - TEST_GMPY="true"
-        - TEST_MATPLOTLIB="true"
-        - TEST_THEANO="true"
         - TEST_ASCII="true"
-        - TEST_AUTOWRAP="true"
-        - TEST_SYMENGINE="true"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.*"
       addons:
         apt:
           packages:
@@ -237,7 +231,7 @@ before_install:
       pip install "sphinx" "docutils" doctr;
     fi
   - |
-    if [[ "${TEST_MATPLOTLIB}" == "true" || "${TEST_SYMENGINE}" == "true" ]]; then
+    if [[ "${TEST_OPT_DEPENDENCY}" ]]; then
     # We do this conditionally because it saves us some downloading if the
     # version is the same.
         if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -250,27 +244,10 @@ before_install:
         hash -r;
         conda config --set always_yes yes --set changeps1 no;
         conda update -q conda;
+        conda config --prepend channels conda-forge --prepend channels symengine/label/dev;
         conda info -a;
-        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION matplotlib numpy scipy pip llvmlite;
+        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip ${TEST_OPT_DEPENDENCY/autowrap/libgfortran libgcc gcc cython};
         source activate test-environment;
-    fi
-  - if [[ "${TEST_GMPY}" == "true" ]]; then
-        conda install gmpy2 -c conda-forge;
-    fi
-  - if [[ "${TEST_SYMENGINE}" == "true" ]]; then
-        conda config --add channels conda-forge;
-        conda config --add channels symengine/label/dev;
-        conda install python-symengine=0.3.*;
-    fi
-  - |
-    if [[ "${TEST_THEANO}" == "true" ]]; then
-        # this assumes TEST_THEANO runs in the same build as TEST_MATPLOTLIB
-        conda install theano;
-    fi
-  - |
-    if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
-        # this assumes TEST_AUTOWRAP runs in the same build as TEST_MATPLOTLIB
-        conda install libgfortran libgcc gcc cython;
     fi
   - |
     if [[ "${TEST_TENSORFLOW}" == "true" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -248,6 +248,8 @@ before_install:
         conda info -a;
         conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip ${TEST_OPT_DEPENDENCY/autowrap/libgfortran libgcc gcc cython};
         source activate test-environment;
+    elif [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then
+        pip list --format=legacy | grep "numpy" && pip uninstall -y numpy;
     fi
   - |
     if [[ "${TEST_TENSORFLOW}" == "true" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -288,6 +288,7 @@ install:
       pip install --upgrade setuptools;
       python -We:invalid -m compileall -f sympy/ || (echo "ERROR Invalid escape sequence found. You likely need to use a raw string." && exit 1);
       python -We:invalid setup.py install;
+      pip list --format=columns;
     fi
 script:
   # Don't run doctr if the build fails

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -69,6 +69,38 @@ if not sympy.test(split='${SPLIT}', slow=True, verbose=True):
 EOF
 fi
 
+if [[ "${TEST_OPT_DEPENDENCY}" == *"numpy"* ]]; then
+    cat << EOF | python
+print('Testing NUMPY')
+import sympy
+if not (sympy.test('*numpy*', 'sympy/matrices/', 'sympy/physics/quantum/',
+        'sympy/core/tests/test_sympify.py', 'sympy/utilities/tests/test_lambdify.py',
+        blacklist=['sympy/physics/quantum/tests/test_circuitplot.py']) and sympy.
+        doctest('sympy/matrices/', 'sympy/utilities/lambdify.py')):
+    raise Exception('Tests failed')
+EOF
+fi
+
+if [[ "${TEST_OPT_DEPENDENCY}" == *"scipy"* ]]; then
+    cat << EOF | python
+print('Testing SCIPY')
+import sympy
+# scipy matrices are tested in numpy testing
+if not sympy.test('sympy/external/tests/test_scipy.py'):
+    raise Exception('Tests failed')
+EOF
+fi
+
+if [[ "${TEST_OPT_DEPENDENCY}" == *"llvmlite"* ]]; then
+    cat << EOF | python
+print('Testing LLVMJIT')
+import sympy
+if not (sympy.test('sympy/printing/tests/test_llvmjit.py')
+        and sympy.doctest('sympy/printing/llvmjitcode.py')):
+    raise Exception('Tests failed')
+EOF
+fi
+
 if [[ "${TEST_OPT_DEPENDENCY}" == *"theano"* ]]; then
     cat << EOF | python
 print('Testing THEANO')
@@ -98,8 +130,8 @@ matplotlib.use("Agg")
 import sympy
 # Unfortunately, we have to use subprocess=False so that the above will be
 # applied, so no hash randomization here.
-if not (sympy.test('sympy/plotting', subprocess=False) and
-    sympy.doctest('sympy/plotting', subprocess=False)):
+if not (sympy.test('sympy/plotting', 'sympy/physics/quantum/tests/test_circuitplot.py',
+    subprocess=False) and sympy.doctest('sympy/plotting', subprocess=False)):
     raise Exception('Tests failed')
 EOF
 fi
@@ -108,7 +140,8 @@ if [[ "${TEST_OPT_DEPENDENCY}" == *"autowrap"* ]]; then
     cat << EOF | python
 print('Testing AUTOWRAP')
 import sympy
-if not sympy.test('sympy/external/tests/test_autowrap.py'):
+if not (sympy.test('sympy/external/tests/test_autowrap.py')
+        and sympy.doctest('sympy/utilities/autowrap.py')):
     raise Exception('Tests failed')
 EOF
 fi

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -69,7 +69,7 @@ if not sympy.test(split='${SPLIT}', slow=True, verbose=True):
 EOF
 fi
 
-if [[ "${TEST_THEANO}" == "true" ]]; then
+if [[ "${TEST_OPT_DEPENDENCY}" == *"theano"* ]]; then
     cat << EOF | python
 print('Testing THEANO')
 import sympy
@@ -78,7 +78,7 @@ if not sympy.test('*theano*'):
 EOF
 fi
 
-if [[ "${TEST_GMPY}" == "true" ]]; then
+if [[ "${TEST_OPT_DEPENDENCY}" == *"gmpy"* ]]; then
     cat << EOF | python
 print('Testing GMPY')
 import sympy
@@ -87,7 +87,7 @@ if not (sympy.test('sympy/polys/') and sympy.doctest('sympy/polys/')):
 EOF
 fi
 
-if [[ "${TEST_MATPLOTLIB}" == "true" ]]; then
+if [[ "${TEST_OPT_DEPENDENCY}" == *"matplotlib"* ]]; then
     cat << EOF | python
 print('Testing MATPLOTLIB')
 # Set matplotlib so that it works correctly in headless Travis. We have to do
@@ -104,7 +104,7 @@ if not (sympy.test('sympy/plotting', subprocess=False) and
 EOF
 fi
 
-if [[ "${TEST_AUTOWRAP}" == "true" ]]; then
+if [[ "${TEST_OPT_DEPENDENCY}" == *"autowrap"* ]]; then
     cat << EOF | python
 print('Testing AUTOWRAP')
 import sympy
@@ -125,7 +125,7 @@ EOF
 fi
 
 
-if [[ "${TEST_SYMENGINE}" == "true" ]]; then
+if [[ "${TEST_OPT_DEPENDENCY}" == *"symengine"* ]]; then
     echo "Testing SYMENGINE"
     export USE_SYMENGINE=1
     cat << EOF | python

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -159,10 +159,9 @@ fi
 
 
 if [[ "${TEST_OPT_DEPENDENCY}" == *"symengine"* ]]; then
-    echo "Testing SYMENGINE"
     export USE_SYMENGINE=1
     cat << EOF | python
-print('Testing SymEngine')
+print('Testing SYMENGINE')
 import sympy
 if not sympy.test('sympy/physics/mechanics'):
     raise Exception('Tests failed')


### PR DESCRIPTION
* Combined TEST_(OPTIONAL DEPENDENCY) environment variables, e.g., TEST_GMPY, into TEST_OPT_DEPENDENCY for better management of them. Also, combined the install process of them.
* Added not tested optional dependency tests:
  * NumPy: It was installed in Travis by default.
    * Removed(Added pip uninstall) it from normal builds. Fixes #13148.
    * test: `*numpy*`, `sympy/matrices/`, `sympy/physics/quantum/` (except `sympy/physics/quantum/tests/test_circuitplot.py`), `sympy/core/tests/test_sympify.py`, `sympy/utilities/tests/test_lambdify.py`
    * doctest: `sympy/matrices/`, `sympy/utilities/lambdify.py`
  * SciPy
    * test: `sympy/external/tests/test_scipy.py`
    * scipy matrices are tested in numpy testing
  * llvmlite
    * test: `sympy/printing/tests/test_llvmjit.py`
    * doctest: `sympy/printing/llvmjitcode.py`
  * matplotlib: `sympy/physics/quantum/tests/test_circuitplot.py`
  * autowrap: `sympy/utilities/autowrap.py` (doctest)
* Show installed python packages(pip list) before test.