### PR TITLE
Fix the doctr command on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -295,7 +295,7 @@ script:
   - set -e
   - bin/test_travis.sh
   - if [[ "${TEST_SPHINX}" == "true" ]]; then
-        doctr deploy dev --deploy-repo sympy/sympy_doc --command './generate_indexes.py';
+        doctr deploy dev --deploy-repo sympy/sympy_doc --command 'git checkout doctr_remote/gh-pages generate_indexes.py && ./generate_indexes.py';
     fi
 notifications:
   email: false


### PR DESCRIPTION
Doctr 1.6.0 now runs --command on the local branch, not the remote, so we have
to pull in the generate_indexes script manually before running it.

I'm not sure if we'll able to tell if this works until after merging this. I think doctr will run the command even on the Travis PR build, but I'm not positive. 