### PR TITLE
minimal_blocks: make block representatives minimal

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2291,12 +2291,7 @@ class PermutationGroup(Basic):
 
         # rewrite result so that block representatives are minimal
         new_reps = {}
-        for i, r in enumerate(parents):
-            if r not in new_reps:
-                new_reps[r] = i
-            if new_reps[r] != r:
-                parents[i] = new_reps[r]
-        return parents
+        return [new_reps.setdefault(r, i) for i, r in enumerate(parents)]
 
     def normal_closure(self, other, k=10):
         r"""Return the normal closure of a subgroup/set of permutations.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1894,7 +1894,7 @@ class PermutationGroup(Basic):
         >>> from sympy.combinatorics.perm_groups import PermutationGroup
         >>> from sympy.combinatorics.named_groups import DihedralGroup
         >>> DihedralGroup(6).minimal_blocks()
-        [[0, 3, 0, 3, 0, 3], [0, 4, 2, 0, 4, 2]]
+        [[0, 1, 0, 1, 0, 1], [0, 1, 2, 0, 1, 2]]
         >>> G = PermutationGroup(Permutation(1,2,5))
         >>> G.minimal_blocks()
         False
@@ -2242,7 +2242,7 @@ class PermutationGroup(Basic):
         >>> from sympy.combinatorics.named_groups import DihedralGroup
         >>> D = DihedralGroup(10)
         >>> D.minimal_block([0, 5])
-        [0, 6, 2, 8, 4, 0, 6, 2, 8, 4]
+        [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
         >>> D.minimal_block([0, 1])
         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
@@ -2288,6 +2288,14 @@ class PermutationGroup(Basic):
             # force path compression to get the final state of the equivalence
             # relation
             self._union_find_rep(i, parents)
+
+        # rewrite result so that block representatives are minimal
+        new_reps = {}
+        for i, r in enumerate(parents):
+            if r not in new_reps:
+                new_reps[r] = i
+            if new_reps[r] != r:
+                parents[i] = new_reps[r]
         return parents
 
     def normal_closure(self, other, k=10):

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -457,12 +457,12 @@ def test_minimal_block():
 
     P1 = PermutationGroup(Permutation(1, 5)(2, 4), Permutation(0, 1, 2, 3, 4, 5))
     P2 = PermutationGroup(Permutation(0, 1, 2, 3, 4, 5), Permutation(1, 5)(2, 4))
-    assert P1.minimal_block([0, 2]) == [0, 3, 0, 3, 0, 3]
-    assert P2.minimal_block([0, 2]) == [0, 3, 0, 3, 0, 3]
+    assert P1.minimal_block([0, 2]) == [0, 1, 0, 1, 0, 1]
+    assert P2.minimal_block([0, 2]) == [0, 1, 0, 1, 0, 1]
 
 def test_minimal_blocks():
     P = PermutationGroup(Permutation(1, 5)(2, 4), Permutation(0, 1, 2, 3, 4, 5))
-    assert P.minimal_blocks() == [[0, 3, 0, 3, 0, 3], [0, 4, 5, 0, 4, 5]]
+    assert P.minimal_blocks() == [[0, 1, 0, 1, 0, 1], [0, 1, 2, 0, 1, 2]]
 
     P = SymmetricGroup(5)
     assert P.minimal_blocks() == [[0]*5]


### PR DESCRIPTION
This PR changes `minimal_block` so that a block system is returned with minimal representatives for each block. For example, a block that was previously `[0, 4, 2, 0, 4, 2]` is now `[0, 1, 2, 0, 1, 2]`. This is mostly for consistency and to avoid test failures in PyPy (see #8972) but theoretically could also be useful in applications.