### PR TITLE
evalf with subs argument incorrectly evaluates expressions with floor #13359

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -371,11 +371,7 @@ def get_integer_part(expr, no, options, return_ints=False):
                 x = fzero
             nint += int(no*(mpf_cmp(x or fzero, fzero) == no))
         nint = from_int(nint)
-        if nint != fzero:
-            return nint, fastlog(nint) + 10
-        else:
-            # avoid calculating fastlog(fzero)
-            return nint, 10
+        return nint, INF
 
     re_, im_, re_acc, im_acc = None, None, None, None
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -371,7 +371,11 @@ def get_integer_part(expr, no, options, return_ints=False):
                 x = fzero
             nint += int(no*(mpf_cmp(x or fzero, fzero) == no))
         nint = from_int(nint)
-        return nint, fastlog(nint) + 10
+        if nint != fzero:
+            return nint, fastlog(nint) + 10
+        else:
+            # avoid calculating fastlog(fzero)
+            return nint, 10
 
     re_, im_, re_acc, im_acc = None, None, None, None
 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -255,6 +255,8 @@ def test_evalf_integer_parts():
     assert ceiling(x).evalf(subs={x: 3.*I}) == 3*I
     assert ceiling(x).evalf(subs={x: 2. + 3*I}) == 2 + 3*I
 
+    assert float((floor(1.5, evaluate=False)+1/9).evalf()) == 1 + 1/9
+    assert float((floor(0.5, evaluate=False)+20).evalf()) == 20
 
 def test_evalf_trig_zero_detection():
     a = sin(160*pi, evaluate=False)


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

`get_integer_part()` used `fastlog(nint)` as a way of approximating precision. This failed when `nint=fzero`

Now: 
```
x = Symbol('x')
expr = floor(x)+20
srepr(expr.evalf(subs={x:0.5}))
```

Will give `"Float('20.0', precision=15)"` instead of  `"Float('16.0', precision=1)"` .

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #13359 
