### PR TITLE
Add an option to fail the test if it times out and enable on Travis

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -63,8 +63,6 @@ if [[ "${TEST_SLOW}" == "true" ]]; then
 print('Testing SLOW')
 import sympy
 if not sympy.test(split='${SPLIT}', slow=True, verbose=True):
-    # Travis times out if no activity is seen for 10 minutes. It also times
-    # out if the whole tests run for more than 50 minutes.
     raise Exception('Tests failed')
 EOF
 fi

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -11,25 +11,6 @@ from sympy.utilities.pytest import XFAIL, SKIP, slow, skip, ON_TRAVIS
 
 from sympy.abc import x, k, c, y, R, b, h, a, m
 
-import signal
-
-
-class TimeOutError(Exception):
-    pass
-
-
-def timeout(signum, frame, time):
-    raise TimeOutError("Timed out after %d seconds" % time)
-
-
-def run_with_timeout(test, time):
-    # Set the signal handler and a 5-second alarm
-    signal.signal(signal.SIGALRM, lambda s, f: timeout(s, f, time))
-    signal.alarm(time)
-    r = eval(test)
-    signal.alarm(0)          # Disable the alarm
-    return r
-
 
 @SKIP("Too slow for @slow")
 @XFAIL

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -39,6 +39,7 @@ from sympy.external import import_module
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 IS_WINDOWS = (os.name == 'nt')
+ON_TRAVIS = os.getenv('TRAVIS_BUILD_NUMBER', None)
 
 # emperically generated list of the proportion of time spent running
 # an even split of tests.  This should periodically be regenerated.
@@ -513,6 +514,10 @@ def _test(*paths, **kwargs):
         seed = random.randrange(100000000)
     timeout = kwargs.get("timeout", False)
     fail_on_timeout = kwargs.get("fail_on_timeout", False)
+    if ON_TRAVIS and timeout is False:
+        # Travis times out if no activity is seen for 10 minutes.
+        timeout = 595
+        fail_on_timeout = True
     slow = kwargs.get("slow", False)
     enhance_asserts = kwargs.get("enhance_asserts", False)
     split = kwargs.get('split', None)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -571,8 +571,8 @@ def _test(*paths, **kwargs):
 
     t._testfiles.extend(matched)
 
-    return int(not t.test(sort=sort, timeout=timeout, fail_on_timeout=
-        fail_on_timeout, slow=slow, enhance_asserts=enhance_asserts))
+    return int(not t.test(sort=sort, timeout=timeout, slow=slow,
+        enhance_asserts=enhance_asserts, fail_on_timeout=fail_on_timeout))
 
 
 def doctest(*paths, **kwargs):
@@ -1067,8 +1067,8 @@ class SymPyTests(object):
         else:
             self._slow_threshold = 10
 
-    def test(self, sort=False, timeout=False, fail_on_timeout=False, slow=False,
-            enhance_asserts=False):
+    def test(self, sort=False, timeout=False, slow=False,
+            enhance_asserts=False, fail_on_timeout=False):
         """
         Runs the tests returning True if all tests pass, otherwise False.
 
@@ -1084,8 +1084,8 @@ class SymPyTests(object):
         self._reporter.start(self._seed)
         for f in self._testfiles:
             try:
-                self.test_file(f, sort, timeout, fail_on_timeout, slow,
-                    enhance_asserts)
+                self.test_file(f, sort, timeout, slow,
+                    enhance_asserts, fail_on_timeout)
             except KeyboardInterrupt:
                 print(" interrupted by user")
                 self._reporter.finish()
@@ -1123,8 +1123,8 @@ class SymPyTests(object):
         new_tree = Transform().visit(tree)
         return fix_missing_locations(new_tree)
 
-    def test_file(self, filename, sort=True, timeout=False, fail_on_timeout=False,
-            slow=False, enhance_asserts=False):
+    def test_file(self, filename, sort=True, timeout=False, slow=False,
+            enhance_asserts=False, fail_on_timeout=False):
         reporter = self._reporter
         funcs = []
         try:


### PR DESCRIPTION
* Added `fail_on_timeout` option to fail the test by raising TimeOutError and print traceback if it times out.
* Enabled 595 seconds timeout on Travis builds. ([Example](https://travis-ci.org/ylemkimon/sympy/jobs/280894080))

See comments of #13355.