### PR TITLE
Matrix .subs does not properly handle generators #13330

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1789,6 +1789,12 @@ class MatrixOperations(MatrixRequired):
     def subs(self, *args, **kwargs):  # should mirror core.basic.subs
         """Return a new matrix with subs applied to each entry.
 
+        `args` is either:
+          - two arguments, e.g. foo.subs(old, new)
+          - one iterable argument, e.g. foo.subs(iterable).
+
+        The substitution is applied to each element of the matrix as implemented in core.basic.subs.
+
         Examples
         ========
 
@@ -1801,7 +1807,18 @@ class MatrixOperations(MatrixRequired):
         >>> Matrix(_).subs(y, x)
         Matrix([[x]])
         """
-        return self.applyfunc(lambda x: x.subs(*args, **kwargs))
+
+        if len(args) == 1:
+            sequence = args[0]
+            # test if the sequence is a generator
+            if hasattr(sequence, '__iter__') and not hasattr(sequence, '__len__'):
+                sequence = list(sequence)
+        elif len(args) == 2:
+            sequence = [args]
+        else:
+            raise ValueError("subs accepts either 1 or 2 arguments")
+
+        return self.applyfunc(lambda x: x.subs(sequence, **kwargs))
 
     def trace(self):
         """

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -531,6 +531,8 @@ def test_subs():
            Matrix([[-1, 2], [-3, 4]])
     assert OperationsOnlyMatrix([[x*y]]).subs({x: y - 1, y: x - 1}, simultaneous=True) == \
            Matrix([[(x - 1)*(y - 1)]])
+    assert OperationsOnlyMatrix([[x, y], [y, z]]).subs(zip((x, y), (z, z))) == \
+           Matrix([[z, z], [z, z]])
 
 
 def test_trace():


### PR DESCRIPTION
Test if argument to matrix subs method is a generator, and convert to list.

Fixes #13330 
