### PR TITLE
EX domain polynomials with coefficients that cannot be rationalized #13340

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -1012,6 +1012,10 @@ def roots(f, *gens, **flags):
                             if not result:
                                 for root in _try_decompose(f):
                                     _update_dict(result, root, 1)
+                        else:
+                            for factor, k in factors:
+                                for r in _try_heuristics(Poly(factor, f.gen, field=True)):
+                                    _update_dict(result, r, k)
                     else:
                         for root in _try_decompose(f):
                             _update_dict(result, root, 1)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -1013,7 +1013,7 @@ def roots(f, *gens, **flags):
                                 for root in _try_decompose(f):
                                     _update_dict(result, root, 1)
                         else:
-                            for r in _try_heuristics(Poly(factors[0][0], f.gen, field=True)):
+                            for r in _try_heuristics(f):
                                 _update_dict(result, r, 1)
                     else:
                         for root in _try_decompose(f):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -1013,9 +1013,8 @@ def roots(f, *gens, **flags):
                                 for root in _try_decompose(f):
                                     _update_dict(result, root, 1)
                         else:
-                            for factor, k in factors:
-                                for r in _try_heuristics(Poly(factor, f.gen, field=True)):
-                                    _update_dict(result, r, k)
+                            for r in _try_heuristics(Poly(factors[0][0], f.gen, field=True)):
+                                _update_dict(result, r, 1)
                     else:
                         for root in _try_decompose(f):
                             _update_dict(result, root, 1)

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -97,6 +97,12 @@ def test_issue_8289():
     assert roots == _nsort(roots)
 
 
+def test_issue_13340():
+    eq = Poly(y**3 + exp(x)*y + x, y, domain='EX')
+    roots_d = roots(eq)
+    assert len(roots_d) == 3
+
+
 def test_roots_cubic():
     assert roots_cubic(Poly(2*x**3, x)) == [0, 0, 0]
     assert roots_cubic(Poly(x**3 - 3*x**2 + 3*x - 1, x)) == [1, 1, 1]


### PR DESCRIPTION
Fixes #13340 

I added a simple test just to show that the roots dictionary returned was not empty, but I could be more explicit (the roots are complicated expressions, but this was the most minimal example I could find).