### PR TITLE
WYSIWYG formula display - initial draft

### DIFF
--- a/sympy/interactive/htmleditor.py
+++ b/sympy/interactive/htmleditor.py
@@ -1,0 +1,39 @@
+from IPython.core.magic import register_line_magic
+from IPython.display import display, HTML
+
+html_data = """
+<link rel="stylesheet" type="text/css" href="http://mathquill.com/lib/mathquill.css">
+<script type="text/javascript" src="http://mathquill.com/lib/mathquill.js"></script>
+<p>Expression: <span id="mathfld%i"></span>
+<script>
+    var mathFieldSpan = document.getElementById('mathfld%i');
+
+    var MQ = MathQuill.getInterface(2); // for backcompat
+    var mathField = MQ.MathField(mathFieldSpan, {
+      spaceBehavesLikeTab: true, // configurable
+      handlers: {
+        edit: function() { // useful event handlers
+          //latexSpan.textContent = mathField.latex(); // simple API
+        }
+      }
+    });
+</script>
+<script>
+mathField.__controller.writeLatex("%s")
+</script>
+"""
+
+formula_counter = 0
+
+
+@register_line_magic
+def formula(expr):
+    from sympy import sympify, latex
+    global formula_counter
+    expr = sympify(expr)
+    out_html = html_data % (formula_counter, formula_counter, latex(expr).replace("\\", "\\\\"))
+    formula_counter += 1
+    display(HTML(out_html))
+
+
+del formula

--- a/sympy/interactive/htmleditor.py
+++ b/sympy/interactive/htmleditor.py
@@ -1,39 +1,59 @@
-from IPython.core.magic import register_line_magic
-from IPython.display import display, HTML
+from __future__ import print_function, division
+from sympy.external import import_module
 
-html_data = """
+
+def load_ipython_formula_editor():
+    from IPython.core.magic import register_line_magic
+    from IPython.display import display, HTML
+
+    html_data = """
 <link rel="stylesheet" type="text/css" href="http://mathquill.com/lib/mathquill.css">
 <script type="text/javascript" src="http://mathquill.com/lib/mathquill.js"></script>
-<p>Expression: <span id="mathfld%i"></span>
+<p>Expression: <span id="mathfld%i"></span></p>
 <script>
+function sendToIPython() {
+    var kernel = IPython.notebook.kernel;
+    var execcmd = 'resultVar = \"\"\"' + document.getElementById("mathfld%i").innerHTML + '\"\"\"';
+    kernel.execute(execcmd);
+}
+
+function loadMathquill() {
+    var script = document.createElement("script")
+    script.type = "text/javascript";
+    script.onload = function() {
+        loadMathField();
+    }
+    script.src = "http://mathquill.com/lib/mathquill.js";
+    document.getElementsByTagName("head")[0].appendChild(script);
+}
+
+function loadMathField() {
     var mathFieldSpan = document.getElementById('mathfld%i');
+
 
     var MQ = MathQuill.getInterface(2); // for backcompat
     var mathField = MQ.MathField(mathFieldSpan, {
       spaceBehavesLikeTab: true, // configurable
       handlers: {
-        edit: function() { // useful event handlers
-          //latexSpan.textContent = mathField.latex(); // simple API
-        }
+    edit: function() {
+        sendToIPython();
+    }
       }
     });
-</script>
-<script>
-mathField.__controller.writeLatex("%s")
+
+    mathField.__controller.writeLatex("%s")
+}
+//loadMathquill();
+loadMathField();
 </script>
 """
 
-formula_counter = 0
+    @register_line_magic
+    def formula(expr):
+        from sympy import sympify, latex
+        expr = sympify(expr)
+        out_html = html_data % (formula.counter, formula.counter, formula.counter, latex(expr).replace("\\", "\\\\"))
+        formula.counter += 1
+        display(HTML(out_html))
 
-
-@register_line_magic
-def formula(expr):
-    from sympy import sympify, latex
-    global formula_counter
-    expr = sympify(expr)
-    out_html = html_data % (formula_counter, formula_counter, latex(expr).replace("\\", "\\\\"))
-    formula_counter += 1
-    display(HTML(out_html))
-
-
-del formula
+    formula.counter = 0


### PR DESCRIPTION
Go to a Jupyter Notebook in the browser, type
```
from sympy.interactive.htmleditor import load_ipython_formula_editor
load_ipython_formula_editor()
```

at this point a new IPython magic `%formula` will be available. Type something like:
```
%formula sqrt(y)/x**2
```

An HTML editor with the typed formula will appear.

A new Python variable called `resultVar` will appear containing the _innerHTML_ of the edit box with the formula.

TODOs:

- [x] find a way to read the edited formula back into SymPy.
- [ ] start the second script after the _mathquill.js_ library has been loaded (probably requires `script.onload`)
- [ ] shall we support a format like `a = %formula expr` where after editing `expr` the result is stored in `a`?