### PR TITLE
Trying to fix experimental_lambdify bug. Need some opinions

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -272,21 +272,12 @@ class Lambdifier(object):
         # Constructing the translation dictionaries and making the translation
         self.dict_str = self.get_dict_str()
         self.dict_fun = self.get_dict_fun()
-        exprstr = str(expr)
-        ## The regular "and" and "or" operators don't work correctly on tuples either!
-        # the & and | operators don't work on tuples, see discussion #12108
-        # exprstr = exprstr.replace(" & "," and ").replace(" | "," or ")
-        ## This function only works for the very specific case of not having
-        ## And and Or in the same expression and not nesting them at all. It's by no means
-        ## a real bug fix and needs to be entirely rewritten, or another solution needs to
-        ## be taken.
-        def replaceAndOr(exprstr):
-            if ' & ' in exprstr:
-                exprstr = "And(%s)" % exprstr.replace(" & ", ", ")
-            elif ' | ' in exprstr:
-                exprstr = "Or(%s)" % exprstr.replace(" | ", ", ")
-            return exprstr
-        exprstr = replaceAndOr(exprstr)
+        
+        # The abbreviate_and and abbreviate_or settings are used to avoid having to handle
+        # & and | for tuples, since simply replacing them with "and" and "or" doesn't lead to
+        # the expected results
+        from sympy.printing.str import sstr
+        exprstr = sstr(expr, abbreviate_and=False, abbreviate_or=False)
 
         newexpr = self.tree2str_translate(self.str2tree(exprstr))
 

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -273,8 +273,20 @@ class Lambdifier(object):
         self.dict_str = self.get_dict_str()
         self.dict_fun = self.get_dict_fun()
         exprstr = str(expr)
+        ## The regular "and" and "or" operators don't work correctly on tuples either!
         # the & and | operators don't work on tuples, see discussion #12108
-        exprstr = exprstr.replace(" & "," and ").replace(" | "," or ")
+        # exprstr = exprstr.replace(" & "," and ").replace(" | "," or ")
+        ## This function only works for the very specific case of not having
+        ## And and Or in the same expression and not nesting them at all. It's by no means
+        ## a real bug fix and needs to be entirely rewritten, or another solution needs to
+        ## be taken.
+        def replaceAndOr(exprstr):
+            if ' & ' in exprstr:
+                exprstr = "And(%s)" % exprstr.replace(" & ", ", ")
+            elif ' | ' in exprstr:
+                exprstr = "Or(%s)" % exprstr.replace(" | ", ", ")
+            return exprstr
+        exprstr = replaceAndOr(exprstr)
 
         newexpr = self.tree2str_translate(self.str2tree(exprstr))
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -21,6 +21,8 @@ class StrPrinter(Printer):
         "order": None,
         "full_prec": "auto",
         "sympy_integers": False,
+        "abbreviate_and": True,     # Currently needed for experimental_lambdify.py
+        "abbreviate_or": True,      # TODO: Find a better solution for this
     }
 
     _relationals = dict()
@@ -79,10 +81,16 @@ class StrPrinter(Printer):
         return '~%s' %(self.parenthesize(expr.args[0],PRECEDENCE["Not"]))
 
     def _print_And(self, expr):
-        return self.stringify(expr.args, " & ", PRECEDENCE["BitwiseAnd"])
+        if self._settings.get("abbreviate_and", True):
+            return self.stringify(expr.args, " & ", PRECEDENCE["BitwiseAnd"])
+        else:
+            return self._print_Basic(expr)
 
     def _print_Or(self, expr):
-        return self.stringify(expr.args, " | ", PRECEDENCE["BitwiseOr"])
+        if self._settings.get("abbreviate_or", True):
+            return self.stringify(expr.args, " | ", PRECEDENCE["BitwiseOr"])
+        else:
+            return self._print_Basic(expr)
 
     def _print_AppliedPredicate(self, expr):
         return '%s(%s)' % (expr.func, expr.arg)


### PR DESCRIPTION
I edited the code in `sympy.plotting.experimental_lambdify` so that the code from issue #13252 produces the expected result. See issue #13389 for what the problem is. Now this is by no means a real fix yet, because I don't want to waste time writing code that might not get implemented because people decide for an entirely different approach. 

One possible workaround to this bug would be to write a function that turns the string `'a & b'` to `'And(a, b)'`. This is what I started doing, but my function only works if you don't use `And` and `Or` in the same expression and if they're not inside any brackets. I think that writing a function to do that would be very ugly, though. There must be other ways to fix this. So what ideas do you have?