### PR TITLE
Making `Eq(True, 1)` type commands evaluate to False

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -319,7 +319,7 @@ class Equality(Relational):
             # If expressions have the same structure, they must be equal.
             if lhs == rhs:
                 return S.true
-            elif any(isinstance(i, BooleanAtom) for i in (rhs, lhs)):
+            elif isinstance(lhs, Boolean) != isinstance(rhs, Boolean):
                 return S.false
 
             # check finiteness

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -319,7 +319,7 @@ class Equality(Relational):
             # If expressions have the same structure, they must be equal.
             if lhs == rhs:
                 return S.true
-            elif all(isinstance(i, BooleanAtom) for i in (rhs, lhs)):
+            elif any(isinstance(i, BooleanAtom) for i in (rhs, lhs)):
                 return S.false
 
             # check finiteness

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -318,11 +318,13 @@ class Equality(Relational):
                     return r
             # If expressions have the same structure, they must be equal.
             if lhs == rhs:
-                return S.true
+                return S.true  # e.g. True == True
+            elif all(isinstance(i, BooleanAtom) for i in (rhs, lhs)):
+                return S.false  # True != False
             elif not (lhs.is_Symbol or rhs.is_Symbol) and (
                     isinstance(lhs, Boolean) !=
                     isinstance(rhs, Boolean)):
-                return S.false
+                return S.false  # only Booleans can equal Booleans
 
             # check finiteness
             fin = L, R = [i.is_finite for i in (lhs, rhs)]

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -319,7 +319,9 @@ class Equality(Relational):
             # If expressions have the same structure, they must be equal.
             if lhs == rhs:
                 return S.true
-            elif isinstance(lhs, Boolean) != isinstance(rhs, Boolean):
+            elif not (lhs.is_Symbol or rhs.is_Symbol) and (
+                    isinstance(lhs, Boolean) !=
+                    isinstance(rhs, Boolean)):
                 return S.false
 
             # check finiteness

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -94,6 +94,8 @@ def test_Eq():
     p = Symbol('p', positive=True)
     assert Eq(p, 0) is S.false
 
+    # issue 13348
+    assert Eq(True, 1) is S.false
 
 def test_rel_Infinity():
     # NOTE: All of these are actually handled by sympy.core.Number, and do


### PR DESCRIPTION
Fixes issue #13348.
closes #13445 
