### PR TITLE
replace python 3.5 with 3.6 on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
             - libatlas-base-dev
             - liblapack-dev
             - gfortran
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_ASCII="true"
         - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.*"
@@ -47,7 +47,7 @@ matrix:
             - gfortran
             - python-scipy
 
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_SPHINX="true"
         - FASTCACHE="false"
@@ -78,22 +78,22 @@ matrix:
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_SLOW="true"
         - SPLIT="1/3"
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_SLOW="true"
         - SPLIT="2/3"
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"
 
     # Everything here and below is in the allow_failures. The need to be
     # duplicated here and in that section below.
-    - python: 3.5 # Dummy value
+    - python: 3.6 # Dummy value
       env:
         - TEST_SAGE="true"
         - FASTCACHE="false"
@@ -159,7 +159,7 @@ matrix:
 
   allow_failures:
     # The apt installation of sage fails sometimes
-    - python: 3.5 # Dummy value
+    - python: 3.6 # Dummy value
       env:
         - TEST_SAGE="true"
         - FASTCACHE="false"
@@ -258,7 +258,7 @@ before_install:
         pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp27-none-linux_x86_64.whl;
       elif [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
         pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp34-cp34m-linux_x86_64.whl;
-      elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
+      elif [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
         pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp35-cp35m-linux_x86_64.whl;
       fi
     fi


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #12814 
Just wonder if sympy plan to use tensorflow version 1.0 or above because with the current version sympy is using, i.e 0.9.0, i think that tensorflow only support up to python 3.5.