### PR TITLE
sympify: Made it so that basic numpy datatypes can be cast as Float

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -8,7 +8,7 @@ import re as regex
 from collections import defaultdict
 
 from .containers import Tuple
-from .sympify import converter, sympify, _sympify, SympifyError
+from .sympify import converter, sympify, _sympify, SympifyError, convert_numpy_types
 from .singleton import S, Singleton
 from .expr import Expr, AtomicExpr
 from .decorators import _sympifyit
@@ -967,6 +967,8 @@ class Float(Number):
             num = '+inf'
         elif num is S.NegativeInfinity:
             num = '-inf'
+        elif type(num).__module__ == 'numpy': # support for numpy datatypes
+            num = convert_numpy_types(num)
         elif isinstance(num, mpmath.mpf):
             if precision is None:
                 if dps is None:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -968,7 +968,7 @@ class Float(Number):
         elif num is S.NegativeInfinity:
             num = '-inf'
         elif type(num).__module__ == 'numpy': # support for numpy datatypes
-            num = convert_numpy_types(num)
+            num = sympify(num)
         elif isinstance(num, mpmath.mpf):
             if precision is None:
                 if dps is None:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -968,7 +968,7 @@ class Float(Number):
         elif num is S.NegativeInfinity:
             num = '-inf'
         elif type(num).__module__ == 'numpy': # support for numpy datatypes
-            num = sympify(num)
+            num = convert_numpy_types(num)
         elif isinstance(num, mpmath.mpf):
             if precision is None:
                 if dps is None:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -8,7 +8,6 @@ from .core import all_classes as sympy_classes
 from .compatibility import iterable, string_types, range
 from .evaluate import global_evaluate
 
-
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):
         self.expr = expr
@@ -52,23 +51,19 @@ class CantSympify(object):
 
 
 def convert_numpy_types(a):
-    """
-    Converts a numpy datatype input to an appropriate sympy type.
+    """Converts a numpy datatype input to an appropriate sympy type.
 
     Examples
     ========
 
-    >>> from sympy import Float
-    >>> from numpy import int64, float128, float32
+    >>> from sympy.core.sympify import convert_numpy_types
 
-    >>> Float(np.int64(5))
+    >>> convert_numpy_types(numpy.int64(5))
     5.00000000000000
 
-    >>> Float(np.float128(5))
-    5.00000000000000000
-
-    >>> Float(np.float32(5))
+    >>> convert_numpy_types(numpy.float32(5))
     5.00000
+
     """
     import numpy as np
     if not isinstance(a, np.floating):
@@ -84,6 +79,8 @@ def convert_numpy_types(a):
         except NotImplementedError:
             raise SympifyError('Translation for numpy float : %s '
                                'is not implemented' % a)
+# doctests must be set manually here to avoid circular imports
+convert_numpy_types._doctest_depends_on = {'modules': ['numpy']}
 
 
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
@@ -293,6 +290,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
             return a
 
     # Support for basic numpy datatypes
+    # Note that this check exists to avoid importing NumPy when not necessary
     if type(a).__module__ == 'numpy':
         import numpy as np
         if np.isscalar(a):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -51,6 +51,45 @@ class CantSympify(object):
     pass
 
 
+def convert_numpy_types(a):
+    """
+    Converts a numpy datatype input to an appropriate sympy type.
+
+    Examples
+    ========
+
+    >>> import sympy as sp
+    >>> import numpy as np
+
+    >>> sp.Float(np.int64(5))
+    5.00000000000000
+
+    >>> sp.Float(np.float128(5))
+    5.00000000000000000
+
+    >>> sp.Float(np.float32(5))
+    5.00000
+
+    >>> x = sp.symbols('x')
+    >>> print(x * np.int64(1))
+    x
+    """
+    import numpy as np
+    if not isinstance(a, np.floating):
+        func = converter[complex] if np.iscomplex(a) else sympify
+        return func(np.asscalar(a))
+    else:
+        try:
+            from sympy.core.numbers import Float
+            prec = np.finfo(a).nmant
+            a = str(list(np.reshape(np.asarray(a),
+                                    (1, np.size(a)))[0]))[1:-1]
+            return Float(a, precision=prec)
+        except NotImplementedError:
+            raise SympifyError('Translation for numpy float : %s '
+                               'is not implemented' % a)
+
+
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         evaluate=None):
     """Converts an arbitrary expression to a type that can be used inside SymPy.
@@ -260,20 +299,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     # Support for basic numpy datatypes
     if type(a).__module__ == 'numpy':
         import numpy as np
-        if np.isscalar(a):
-            if not isinstance(a, np.floating):
-                func = converter[complex] if np.iscomplex(a) else sympify
-                return func(np.asscalar(a))
-            else:
-                try:
-                    from sympy.core.numbers import Float
-                    prec = np.finfo(a).nmant
-                    a = str(list(np.reshape(np.asarray(a),
-                                            (1, np.size(a)))[0]))[1:-1]
-                    return Float(a, precision=prec)
-                except NotImplementedError:
-                    raise SympifyError('Translation for numpy float : %s '
-                                       'is not implemented' % a)
+        if np.isscalar(a): return convert_numpy_types(a)
 
     try:
         return converter[cls](a)

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -58,21 +58,17 @@ def convert_numpy_types(a):
     Examples
     ========
 
-    >>> import sympy as sp
-    >>> import numpy as np
+    >>> from sympy import Float
+    >>> from numpy import int64, float128, float32
 
-    >>> sp.Float(np.int64(5))
+    >>> Float(np.int64(5))
     5.00000000000000
 
-    >>> sp.Float(np.float128(5))
+    >>> Float(np.float128(5))
     5.00000000000000000
 
-    >>> sp.Float(np.float32(5))
+    >>> Float(np.float32(5))
     5.00000
-
-    >>> x = sp.symbols('x')
-    >>> print(x * np.int64(1))
-    x
     """
     import numpy as np
     if not isinstance(a, np.floating):
@@ -299,7 +295,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     # Support for basic numpy datatypes
     if type(a).__module__ == 'numpy':
         import numpy as np
-        if np.isscalar(a): return convert_numpy_types(a)
+        if np.isscalar(a):
+            return convert_numpy_types(a)
 
     try:
         return converter[cls](a)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1749,3 +1749,39 @@ def test_Integer_precision():
     assert Float('1.0', precision=Integer(15))._prec == 15
     assert type(Float('1.0', precision=Integer(15))._prec) == int
     assert sympify(srepr(Float('1.0', precision=15))) == Float('1.0', precision=15)
+
+
+def test_numpy():
+    from sympy.external import import_module
+    from sympy.utilities.pytest import skip
+    np = import_module('numpy')
+
+    if not np:
+        skip('numpy not installed. Abort numpy tests.')
+
+    def equal(x, y):
+        return x == y and type(x) == type(y)
+    try:
+        assert equal(
+            Float(np.int_(12345678912345678)), S(12345678912345678.))
+        assert equal(
+            Float(np.intp(12345678912345678)), S(12345678912345678.))
+    except OverflowError:
+        # May fail on 32-bit systems: Python int too large to convert to C long
+        pass
+    assert equal(Float(np.intc(1234567891)), S(1234567891.))
+    assert equal(Float(np.int8(-123)), S(-123.))
+    assert equal(Float(np.int16(-12345)), S(-12345.))
+    assert equal(Float(np.int32(-1234567891)), S(-1234567891.))
+    assert equal(
+        Float(np.int64(-12345678912345678)), S(-12345678912345678.))
+    assert equal(Float(np.uint8(123)), S(123.))
+    assert equal(Float(np.uint16(12345)), S(12345.))
+    assert equal(Float(np.uint32(1234567891)), S(1234567891.))
+    assert equal(
+        Float(np.uint64(1234567891234567891)), S(1234567891234567891.))
+    assert equal(Float(np.float32(1.123456)), Float(1.123456, precision=24))
+    assert equal(Float(np.float64(1.1234567891234)),
+                 Float(1.1234567891234, precision=53))
+    assert equal(Float(np.longdouble(1.123456789)),
+                 Float(1.123456789, precision=80))


### PR DESCRIPTION
Factored out changes made in #11666 into a separate function called
convert_numpy_types() in sympify.py. Also called that function both in
sympify.py and in Float() when the input is a numpy type. If the input is a
numpy type that can't be cast as a Float, it passes through to the rest of
sympify. Fixes #13275.

Previously, the following would fail:

```
>>> Float(np.float128(5))
>>> Float(np.float32(5))
```

but now they don't.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
