### PR TITLE
A fix allowing to convert numpy types (np.bool, np.int, np.float) to sympy Float

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -975,6 +975,9 @@ class Float(Number):
 
         if dps is None and precision is None:
             dps = 15
+            if type(num).__module__ == 'numpy':
+                from .sympify import convert_np_to_sympy_float
+                return convert_np_to_sympy_float(num)
             if isinstance(num, Float):
                 return num
             if isinstance(num, string_types) and _literal_float(num):
@@ -1020,6 +1023,8 @@ class Float(Number):
         precision = int(precision)
 
         if isinstance(num, float):
+            _mpf_ = mlib.from_float(num, precision, rnd)
+        elif type(num).__module__ == 'numpy':
             _mpf_ = mlib.from_float(num, precision, rnd)
         elif isinstance(num, string_types):
             _mpf_ = mlib.from_str(num, precision, rnd)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -977,10 +977,7 @@ class Float(Number):
             dps = 15
             if type(num).__module__ == 'numpy':
                 from .sympify import convert_numpy_to_sympy
-                if not type(num).__name__=='bool_':
-                    return 1.0*convert_numpy_to_sympy(num)
-                else:
-                    return convert_numpy_to_sympy(num)
+                return 1.0*convert_numpy_to_sympy(num)
             if isinstance(num, Float):
                 return num
             if isinstance(num, string_types) and _literal_float(num):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -8,7 +8,7 @@ import re as regex
 from collections import defaultdict
 
 from .containers import Tuple
-from .sympify import converter, sympify, _sympify, SympifyError
+from .sympify import converter, sympify, _sympify, SympifyError, convert_numpy_to_sympy
 from .singleton import S, Singleton
 from .expr import Expr, AtomicExpr
 from .decorators import _sympifyit
@@ -967,6 +967,8 @@ class Float(Number):
             num = '+inf'
         elif num is S.NegativeInfinity:
             num = '-inf'
+        elif type(num).__module__ == 'numpy':
+            num = convert_numpy_to_sympy(num)
         elif isinstance(num, mpmath.mpf):
             if precision is None:
                 if dps is None:
@@ -976,8 +978,7 @@ class Float(Number):
         if dps is None and precision is None:
             dps = 15
             if type(num).__module__ == 'numpy':
-                from .sympify import convert_numpy_to_sympy
-                return 1.0*convert_numpy_to_sympy(num)
+                return convert_numpy_to_sympy(num)
             if isinstance(num, Float):
                 return num
             if isinstance(num, string_types) and _literal_float(num):
@@ -1023,8 +1024,6 @@ class Float(Number):
         precision = int(precision)
 
         if isinstance(num, float):
-            _mpf_ = mlib.from_float(num, precision, rnd)
-        elif type(num).__module__ == 'numpy':
             _mpf_ = mlib.from_float(num, precision, rnd)
         elif isinstance(num, string_types):
             _mpf_ = mlib.from_str(num, precision, rnd)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -977,8 +977,6 @@ class Float(Number):
 
         if dps is None and precision is None:
             dps = 15
-            if type(num).__module__ == 'numpy':
-                return convert_numpy_to_sympy(num)
             if isinstance(num, Float):
                 return num
             if isinstance(num, string_types) and _literal_float(num):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -976,8 +976,11 @@ class Float(Number):
         if dps is None and precision is None:
             dps = 15
             if type(num).__module__ == 'numpy':
-                from .sympify import convert_np_to_sympy_float
-                return convert_np_to_sympy_float(num)
+                from .sympify import convert_numpy_to_sympy
+                if not type(num).__name__=='bool_':
+                    return 1.0*convert_numpy_to_sympy(num)
+                else:
+                    return convert_numpy_to_sympy(num)
             if isinstance(num, Float):
                 return num
             if isinstance(num, string_types) and _literal_float(num):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -8,6 +8,8 @@ from .core import all_classes as sympy_classes
 from .compatibility import iterable, string_types, range
 from .evaluate import global_evaluate
 
+from sympy.external import import_module
+
 
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):
@@ -53,7 +55,7 @@ class CantSympify(object):
 # Support for basic numpy datatypes
 
 def convert_numpy_to_sympy(a):
-    import numpy as np
+    np=import_module('numpy')
     if not isinstance(a, np.floating):
         func = converter[complex] if np.iscomplex(a) else sympify
         return func(np.asscalar(a))

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -52,7 +52,7 @@ class CantSympify(object):
 
 # Support for basic numpy datatypes
 
-def convert_np_to_sympy_float(a):
+def convert_numpy_to_sympy(a):
     import numpy as np
     if not isinstance(a, np.floating):
         func = converter[complex] if np.iscomplex(a) else sympify
@@ -276,23 +276,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     if type(a).__module__ == 'numpy':
         import numpy as np
         if np.isscalar(a):
-            return convert_np_to_sympy_float(a)
-        '''import numpy 
-        if numpy.isscalar(a):
-            if not isinstance(a, numpy.floating):
-                func = converter[complex] if numpy.iscomplex(a) else sympify
-                return func(numpy.asscalar(a))
-            else:
-                try:
-                    from sympy.core.numbers import Float
-                    prec = numpy.finfo(a).nmant
-                    a = str(list(numpy.reshape(numpy.asarray(a),
-                                            (1, numpy.size(a)))[0]))[1:-1]
-                    return Float(a, precision=prec)
-                except NotImplementedError:
-                    raise SympifyError('Translation for numpy float : %s '
-                                       'is not implemented' % a)
-           '''     
+            return convert_numpy_to_sympy(a)
+
     try:
         return converter[cls](a)
     except KeyError:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -54,20 +54,19 @@ class CantSympify(object):
 
 def convert_np_to_sympy_float(a):
     import numpy as np
-    if np.isscalar(a):
-        if not isinstance(a, np.floating):
-            func = converter[complex] if np.iscomplex(a) else sympify
-            return func(np.asscalar(a))
-        else:
-            try:
-                from sympy.core.numbers import Float
-                prec = np.finfo(a).nmant
-                a = str(list(np.reshape(np.asarray(a),
-                                        (1, np.size(a)))[0]))[1:-1]
-                return Float(a, precision=prec)
-            except NotImplementedError:
-                raise SympifyError('Translation for numpy float : %s '
-                                   'is not implemented' % a)
+    if not isinstance(a, np.floating):
+        func = converter[complex] if np.iscomplex(a) else sympify
+        return func(np.asscalar(a))
+    else:
+        try:
+            from sympy.core.numbers import Float
+            prec = np.finfo(a).nmant
+            a = str(list(np.reshape(np.asarray(a),
+                                    (1, np.size(a)))[0]))[1:-1]
+            return Float(a, precision=prec)
+        except NotImplementedError:
+            raise SympifyError('Translation for numpy float : %s '
+                               'is not implemented' % a)
 
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         evaluate=None):
@@ -275,7 +274,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         else:
             return a
     if type(a).__module__ == 'numpy':
-        return convert_np_to_sympy_float(a)
+        import numpy as np
+        if np.isscalar(a):
+            return convert_np_to_sympy_float(a)
         '''import numpy 
         if numpy.isscalar(a):
             if not isinstance(a, numpy.floating):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -51,6 +51,7 @@ class CantSympify(object):
     pass
 
 # Support for basic numpy datatypes
+
 def convert_np_to_sympy_float(a):
     import numpy as np
     if np.isscalar(a):
@@ -273,7 +274,24 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
             raise SympifyError(a)
         else:
             return a
-
+    if type(a).__module__ == 'numpy':
+        return convert_np_to_sympy_float(a)
+        '''import numpy 
+        if numpy.isscalar(a):
+            if not isinstance(a, numpy.floating):
+                func = converter[complex] if numpy.iscomplex(a) else sympify
+                return func(numpy.asscalar(a))
+            else:
+                try:
+                    from sympy.core.numbers import Float
+                    prec = numpy.finfo(a).nmant
+                    a = str(list(numpy.reshape(numpy.asarray(a),
+                                            (1, numpy.size(a)))[0]))[1:-1]
+                    return Float(a, precision=prec)
+                except NotImplementedError:
+                    raise SympifyError('Translation for numpy float : %s '
+                                       'is not implemented' % a)
+           '''     
     try:
         return converter[cls](a)
     except KeyError:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -8,8 +8,6 @@ from .core import all_classes as sympy_classes
 from .compatibility import iterable, string_types, range
 from .evaluate import global_evaluate
 
-from sympy.external import import_module
-
 
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):
@@ -55,7 +53,9 @@ class CantSympify(object):
 # Support for basic numpy datatypes
 
 def convert_numpy_to_sympy(a):
-    np=import_module('numpy')
+    assert type(a).__module__ == 'numpy'
+    from sympy.external import import_module
+    np = import_module('numpy')
     if not isinstance(a, np.floating):
         func = converter[complex] if np.iscomplex(a) else sympify
         return func(np.asscalar(a))

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -50,8 +50,8 @@ class CantSympify(object):
     """
     pass
 
-# Support for basic numpy datatypes
 
+# Support for basic numpy datatypes
 def convert_numpy_to_sympy(a):
     assert type(a).__module__ == 'numpy'
     from sympy.external import import_module

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -50,6 +50,23 @@ class CantSympify(object):
     """
     pass
 
+# Support for basic numpy datatypes
+def convert_np_to_sympy_float(a):
+    import numpy as np
+    if np.isscalar(a):
+        if not isinstance(a, np.floating):
+            func = converter[complex] if np.iscomplex(a) else sympify
+            return func(np.asscalar(a))
+        else:
+            try:
+                from sympy.core.numbers import Float
+                prec = np.finfo(a).nmant
+                a = str(list(np.reshape(np.asarray(a),
+                                        (1, np.size(a)))[0]))[1:-1]
+                return Float(a, precision=prec)
+            except NotImplementedError:
+                raise SympifyError('Translation for numpy float : %s '
+                                   'is not implemented' % a)
 
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         evaluate=None):
@@ -256,24 +273,6 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
             raise SympifyError(a)
         else:
             return a
-
-    # Support for basic numpy datatypes
-    if type(a).__module__ == 'numpy':
-        import numpy as np
-        if np.isscalar(a):
-            if not isinstance(a, np.floating):
-                func = converter[complex] if np.iscomplex(a) else sympify
-                return func(np.asscalar(a))
-            else:
-                try:
-                    from sympy.core.numbers import Float
-                    prec = np.finfo(a).nmant
-                    a = str(list(np.reshape(np.asarray(a),
-                                            (1, np.size(a)))[0]))[1:-1]
-                    return Float(a, precision=prec)
-                except NotImplementedError:
-                    raise SympifyError('Translation for numpy float : %s '
-                                       'is not implemented' % a)
 
     try:
         return converter[cls](a)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1749,3 +1749,42 @@ def test_Integer_precision():
     assert Float('1.0', precision=Integer(15))._prec == 15
     assert type(Float('1.0', precision=Integer(15))._prec) == int
     assert sympify(srepr(Float('1.0', precision=15))) == Float('1.0', precision=15)
+
+def test_numpy():
+    from sympy.utilities.pytest import skip
+    np = import_module('numpy')
+
+    def equal(x, y):
+        return x == y and type(x) == type(y)
+
+    if not np:
+        skip('numpy not installed.Abort numpy tests.')
+
+    assert Float(np.bool_(1)) is S(True)
+    try:
+        assert equal(
+            Float(np.int_(1234567891234567891)), S(1234567891234567891))
+        assert equal(
+            Float(np.intp(1234567891234567891)), S(1234567891234567891))
+    except OverflowError:
+        # May fail on 32-bit systems: Python int too large to convert to C long
+        pass
+    assert equal(Float(np.intc(1234567891)), S(1234567891))
+    assert equal(Float(np.int8(-123)), S(-123))
+    assert equal(Float(np.int16(-12345)), S(-12345))
+    assert equal(Float(np.int32(-1234567891)), S(-1234567891))
+    assert equal(
+        Float(np.int64(-1234567891234567891)), S(-1234567891234567891))
+    assert equal(Float(np.uint8(123)), S(123))
+    assert equal(Float(np.uint16(12345)), S(12345))
+    assert equal(Float(np.uint32(1234567891)), S(1234567891))
+    assert equal(
+        Float(np.uint64(1234567891234567891)), S(1234567891234567891))
+    assert equal(Float(np.float32(1.123456)), Float(1.123456, precision=24))
+    assert equal(Float(np.float64(1.1234567891234)),
+                 Float(1.1234567891234, precision=53))
+    assert equal(Float(np.longdouble(1.123456789)),
+                 Float(1.123456789, precision=80))
+    assert equal(Float(np.complex64(1 + 2j)), S(1.0 + 2.0 * I))
+    assert equal(Float(np.complex128(1 + 2j)), S(1.0 + 2.0 * I))
+    assert equal(Float(np.longcomplex(1 + 2j)), S(1.0 + 2.0 * I))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1749,6 +1749,37 @@ def test_Integer_precision():
     assert type(Float('1.0', precision=Integer(15))._prec) == int
     assert sympify(srepr(Float('1.0', precision=15))) == Float('1.0', precision=15)
 
+def test_numpy_to_float(): 
+    def check_approximate_equality(numpyval, testnum):
+            fromnumpy = Float(numpyval)
+            fromS = Float(S(testnum), precision = fromnumpy._prec)
+            assert (np.finfo(numpyval).nmant == fromnumpy._prec)
+            assert(abs(fromnumpy-fromS)/fromS<2**(-fromnumpy._prec+1))
+
+    from sympy.external import import_module
+    np = import_module('numpy')
+    testnum = 123456789
+
+    a1 = np.float32(testnum)
+    check_approximate_equality(a1, testnum)
+    a2 = np.float64(testnum)
+    check_approximate_equality(a2, testnum)
+    a3 = np.float128(testnum)
+    check_approximate_equality(a3, testnum)
+
+    fromnumpy = Float(a3)
+    fromS = Float(S(testnum), precision = fromnumpy._prec)
+    assert(fromnumpy._prec == 63)
+    assert(fromnumpy == fromS)
+
+    fromnumpy = Float(a3, precision = 10)
+    fromS = Float(S(testnum), precision = fromnumpy._prec)
+    assert(fromnumpy._prec == 10)
+    assert(fromnumpy == fromS)
+
+    raises(TypeError, lambda: Float(np.complex64(1+2j)))
+    raises(TypeError, lambda: Float(np.complex128(1+2j)))
+'''
 def test_numpy():
     from sympy.external import import_module
     from sympy.utilities.pytest import skip
@@ -1785,6 +1816,7 @@ def test_numpy():
                  Float(1.1234567891234, precision=53))
     assert equal(Float(np.longdouble(1.123456789)),
                  Float(1.123456789, precision=80))
-    assert equal(Float(np.complex64(1 + 2j)), S(1.0 + 2.0 * I))
-    assert equal(Float(np.complex128(1 + 2j)), S(1.0 + 2.0 * I))
-    assert equal(Float(np.longcomplex(1 + 2j)), S(1.0 + 2.0 * I))
+ #   assert equal(Float(np.complex64(1 + 2j)), S(1.0 + 2.0 * I))
+ #   assert equal(Float(np.complex128(1 + 2j)), S(1.0 + 2.0 * I))
+ #   assert equal(Float(np.longcomplex(1 + 2j)), S(1.0 + 2.0 * I))
+ '''

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -18,6 +18,7 @@ from mpmath import mpf
 import mpmath
 
 
+
 t = Symbol('t', real=False)
 
 def same_and_same_prec(a, b):
@@ -1758,6 +1759,7 @@ def test_numpy_to_float():
 
     from sympy.external import import_module
     np = import_module('numpy')
+    assert(np is not None)
     testnum = 123456789
 
     a1 = np.float32(testnum)
@@ -1768,55 +1770,15 @@ def test_numpy_to_float():
     check_approximate_equality(a3, testnum)
 
     fromnumpy = Float(a3)
-    fromS = Float(S(testnum), precision = fromnumpy._prec)
+    fromS = Float(S(testnum), precision=fromnumpy._prec)
     assert(fromnumpy._prec == 63)
     assert(fromnumpy == fromS)
 
-    fromnumpy = Float(a3, precision = 10)
-    fromS = Float(S(testnum), precision = fromnumpy._prec)
+    fromnumpy = Float(a3, precision=10)
+    fromS = Float(S(testnum), precision=fromnumpy._prec)
     assert(fromnumpy._prec == 10)
     assert(fromnumpy == fromS)
 
     raises(TypeError, lambda: Float(np.complex64(1+2j)))
     raises(TypeError, lambda: Float(np.complex128(1+2j)))
-'''
-def test_numpy():
-    from sympy.external import import_module
-    from sympy.utilities.pytest import skip
-    np = import_module('numpy')
-    
-    if not np:
-        skip('numpy not installed. Abort numpy tests.')
 
-    def equal(x, y):
-        return x == y and type(x) == type(y)
-    print(type(S(123)))
-    print(type(Float(np.int_(123))))
-    try:
-        assert equal(
-            Float(np.int_(12345678912345678)), S(12345678912345678.))
-        assert equal(
-            Float(np.intp(12345678912345678)), S(12345678912345678.))
-    except OverflowError:
-        # May fail on 32-bit systems: Python int too large to convert to C long
-        pass
-    assert equal(Float(np.intc(1234567891)), S(1234567891.))
-    assert equal(Float(np.int8(-123)), S(-123.))
-    assert equal(Float(np.int16(-12345)), S(-12345.))
-    assert equal(Float(np.int32(-1234567891)), S(-1234567891.))
-    assert equal(
-        Float(np.int64(-12345678912345678)), S(-12345678912345678.))
-    assert equal(Float(np.uint8(123)), S(123.))
-    assert equal(Float(np.uint16(12345)), S(12345.))
-    assert equal(Float(np.uint32(1234567891)), S(1234567891.))
-    assert equal(
-        Float(np.uint64(1234567891234567891)), S(1234567891234567891.))
-    assert equal(Float(np.float32(1.123456)), Float(1.123456, precision=24))
-    assert equal(Float(np.float64(1.1234567891234)),
-                 Float(1.1234567891234, precision=53))
-    assert equal(Float(np.longdouble(1.123456789)),
-                 Float(1.123456789, precision=80))
- #   assert equal(Float(np.complex64(1 + 2j)), S(1.0 + 2.0 * I))
- #   assert equal(Float(np.complex128(1 + 2j)), S(1.0 + 2.0 * I))
- #   assert equal(Float(np.longcomplex(1 + 2j)), S(1.0 + 2.0 * I))
- '''

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -16,7 +16,6 @@ from sympy.utilities.pytest import XFAIL, raises
 
 from mpmath import mpf
 import mpmath
-from sympy.external import import_module
 
 
 t = Symbol('t', real=False)
@@ -1751,6 +1750,7 @@ def test_Integer_precision():
     assert sympify(srepr(Float('1.0', precision=15))) == Float('1.0', precision=15)
 
 def test_numpy():
+    from sympy.external import import_module
     from sympy.utilities.pytest import skip
     np = import_module('numpy')
     def equal(x, y):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1759,7 +1759,10 @@ def test_numpy_to_float():
 
     from sympy.external import import_module
     np = import_module('numpy')
-    assert(np is not None)
+    
+    if not np:
+        skip('numpy not installed. Abort numpy tests.')
+
     testnum = 123456789
 
     a1 = np.float32(testnum)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -16,7 +16,7 @@ from sympy.utilities.pytest import XFAIL, raises
 
 from mpmath import mpf
 import mpmath
-
+from sympy.external import import_module
 
 
 t = Symbol('t', real=False)
@@ -1752,7 +1752,7 @@ def test_Integer_precision():
 
 def test_numpy():
     from sympy.utilities.pytest import skip
-    import numpy as np
+    np = import_module('numpy')
     def equal(x, y):
         return x == y and type(x) == type(y)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1753,13 +1753,14 @@ def test_numpy():
     from sympy.external import import_module
     from sympy.utilities.pytest import skip
     np = import_module('numpy')
+    
+    if not np:
+        skip('numpy not installed. Abort numpy tests.')
+
     def equal(x, y):
         return x == y and type(x) == type(y)
-
-    if not np:
-        skip('numpy not installed.Abort numpy tests.')
-
-    assert Float(np.bool_(1)) is S(True)
+    print(type(S(123)))
+    print(type(Float(np.int_(123))))
     try:
         assert equal(
             Float(np.int_(12345678912345678)), S(12345678912345678.))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1752,8 +1752,7 @@ def test_Integer_precision():
 
 def test_numpy():
     from sympy.utilities.pytest import skip
-    np = import_module('numpy')
-
+    import numpy as np
     def equal(x, y):
         return x == y and type(x) == type(y)
 
@@ -1788,3 +1787,4 @@ def test_numpy():
     assert equal(Float(np.complex64(1 + 2j)), S(1.0 + 2.0 * I))
     assert equal(Float(np.complex128(1 + 2j)), S(1.0 + 2.0 * I))
     assert equal(Float(np.longcomplex(1 + 2j)), S(1.0 + 2.0 * I))
+

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1759,26 +1759,26 @@ def test_numpy():
     if not np:
         skip('numpy not installed.Abort numpy tests.')
 
-    assert Float(np.bool_(1)) is S(True)
+    assert Float(np.bool_(1)) is S(True) 
     try:
         assert equal(
-            Float(np.int_(1234567891234567891)), S(1234567891234567891))
+            Float(np.int_(12345678912345678)), S(12345678912345678.))
         assert equal(
-            Float(np.intp(1234567891234567891)), S(1234567891234567891))
+            Float(np.intp(12345678912345678)), S(12345678912345678.))
     except OverflowError:
         # May fail on 32-bit systems: Python int too large to convert to C long
         pass
-    assert equal(Float(np.intc(1234567891)), S(1234567891))
-    assert equal(Float(np.int8(-123)), S(-123))
-    assert equal(Float(np.int16(-12345)), S(-12345))
-    assert equal(Float(np.int32(-1234567891)), S(-1234567891))
+    assert equal(Float(np.intc(1234567891)), S(1234567891.))
+    assert equal(Float(np.int8(-123)), S(-123.))
+    assert equal(Float(np.int16(-12345)), S(-12345.))
+    assert equal(Float(np.int32(-1234567891)), S(-1234567891.))
     assert equal(
-        Float(np.int64(-1234567891234567891)), S(-1234567891234567891))
-    assert equal(Float(np.uint8(123)), S(123))
-    assert equal(Float(np.uint16(12345)), S(12345))
-    assert equal(Float(np.uint32(1234567891)), S(1234567891))
+        Float(np.int64(-12345678912345678)), S(-12345678912345678.))
+    assert equal(Float(np.uint8(123)), S(123.))
+    assert equal(Float(np.uint16(12345)), S(12345.))
+    assert equal(Float(np.uint32(1234567891)), S(1234567891.))
     assert equal(
-        Float(np.uint64(1234567891234567891)), S(1234567891234567891))
+        Float(np.uint64(1234567891234567891)), S(1234567891234567891.))
     assert equal(Float(np.float32(1.123456)), Float(1.123456, precision=24))
     assert equal(Float(np.float64(1.1234567891234)),
                  Float(1.1234567891234, precision=53))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1759,7 +1759,7 @@ def test_numpy():
     if not np:
         skip('numpy not installed.Abort numpy tests.')
 
-    assert Float(np.bool_(1)) is S(True) 
+    assert Float(np.bool_(1)) is S(True)
     try:
         assert equal(
             Float(np.int_(12345678912345678)), S(12345678912345678.))
@@ -1787,4 +1787,3 @@ def test_numpy():
     assert equal(Float(np.complex64(1 + 2j)), S(1.0 + 2.0 * I))
     assert equal(Float(np.complex128(1 + 2j)), S(1.0 + 2.0 * I))
     assert equal(Float(np.longcomplex(1 + 2j)), S(1.0 + 2.0 * I))
-

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -500,8 +500,9 @@ def test_issue_8821_highprec_from_str():
     p = sympify(s)
     assert Abs(sin(p)) < 1e-127
 
-'''
+
 def test_issue_10295():
+    print('was here')
     if not numpy:
         skip("numpy not installed.")
 
@@ -530,7 +531,7 @@ def test_issue_10295():
     a2.resize(2, 4, 3)
     assert sympify(a1) == ImmutableDenseNDimArray([1, 2, 3])
     assert sympify(a2) == ImmutableDenseNDimArray([i for i in range(24)], (2, 4, 3))
-'''
+
 
 def test_Range():
     # Only works in Python 3 where range returns a range type

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -26,6 +26,7 @@ def test_issue_3538():
     assert v == exp(x)
     assert type(v) == type(exp(x))
     assert str(type(v)) == str(type(exp(x)))
+    print('here')
 
 
 def test_sympify1():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -2,7 +2,7 @@ from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
     Function, I, S, N, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,
     Pow, Or, true, false, Abs, pi, Range)
 from sympy.abc import x, y
-from sympy.core.sympify import sympify, _sympify, SympifyError, kernS
+from sympy.core.sympify import sympify, _sympify, SympifyError, kernS, convert_np_to_sympy_float
 from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
 from sympy.utilities.pytest import raises, XFAIL, skip
@@ -26,7 +26,6 @@ def test_issue_3538():
     assert v == exp(x)
     assert type(v) == type(exp(x))
     assert str(type(v)) == str(type(exp(x)))
-    print('here')
 
 
 def test_sympify1():
@@ -501,7 +500,7 @@ def test_issue_8821_highprec_from_str():
     p = sympify(s)
     assert Abs(sin(p)) < 1e-127
 
-
+'''
 def test_issue_10295():
     if not numpy:
         skip("numpy not installed.")
@@ -509,6 +508,7 @@ def test_issue_10295():
     A = numpy.array([[1, 3, -1],
                      [0, 1, 7]])
     sA = S(A)
+    print(type(sA))
     assert sA.shape == (2, 3)
     for (ri, ci), val in numpy.ndenumerate(A):
         assert sA[ri, ci] == val
@@ -530,7 +530,7 @@ def test_issue_10295():
     a2.resize(2, 4, 3)
     assert sympify(a1) == ImmutableDenseNDimArray([1, 2, 3])
     assert sympify(a2) == ImmutableDenseNDimArray([i for i in range(24)], (2, 4, 3))
-
+'''
 
 def test_Range():
     # Only works in Python 3 where range returns a range type
@@ -551,52 +551,52 @@ def test_sympify_set():
 
 def test_numpy():
     from sympy.utilities.pytest import skip
-    np = import_module('numpy')
+    #np = import_module('numpy')
 
 
     def equal(x, y):
         return x == y and type(x) == type(y)
 
-    if not np:
+    if not numpy:
         skip('numpy not installed.Abort numpy tests.')
 
-    assert sympify(np.bool_(1)) is S(True)
+    assert sympify(numpy.bool_(1)) is S(True)
     try:
         assert equal(
-            sympify(np.int_(1234567891234567891)), S(1234567891234567891))
+            sympify(numpy.int_(1234567891234567891)), S(1234567891234567891))
         assert equal(
-            sympify(np.intp(1234567891234567891)), S(1234567891234567891))
+            sympify(numpy.intp(1234567891234567891)), S(1234567891234567891))
     except OverflowError:
         # May fail on 32-bit systems: Python int too large to convert to C long
         pass
-    assert equal(sympify(np.intc(1234567891)), S(1234567891))
-    assert equal(sympify(np.int8(-123)), S(-123))
-    assert equal(sympify(np.int16(-12345)), S(-12345))
-    assert equal(sympify(np.int32(-1234567891)), S(-1234567891))
+    assert equal(sympify(numpy.intc(1234567891)), S(1234567891))
+    assert equal(sympify(numpy.int8(-123)), S(-123))
+    assert equal(sympify(numpy.int16(-12345)), S(-12345))
+    assert equal(sympify(numpy.int32(-1234567891)), S(-1234567891))
     assert equal(
-        sympify(np.int64(-1234567891234567891)), S(-1234567891234567891))
-    assert equal(sympify(np.uint8(123)), S(123))
-    assert equal(sympify(np.uint16(12345)), S(12345))
-    assert equal(sympify(np.uint32(1234567891)), S(1234567891))
+        sympify(numpy.int64(-1234567891234567891)), S(-1234567891234567891))
+    assert equal(sympify(numpy.uint8(123)), S(123))
+    assert equal(sympify(numpy.uint16(12345)), S(12345))
+    assert equal(sympify(numpy.uint32(1234567891)), S(1234567891))
     assert equal(
-        sympify(np.uint64(1234567891234567891)), S(1234567891234567891))
-    assert equal(sympify(np.float32(1.123456)), Float(1.123456, precision=24))
-    assert equal(sympify(np.float64(1.1234567891234)),
+        sympify(numpy.uint64(1234567891234567891)), S(1234567891234567891))
+    assert equal(sympify(numpy.float32(1.123456)), Float(1.123456, precision=24))
+    assert equal(sympify(numpy.float64(1.1234567891234)),
                 Float(1.1234567891234, precision=53))
-    assert equal(sympify(np.longdouble(1.123456789)),
+    assert equal(sympify(numpy.longdouble(1.123456789)),
                  Float(1.123456789, precision=80))
-    assert equal(sympify(np.complex64(1 + 2j)), S(1.0 + 2.0*I))
-    assert equal(sympify(np.complex128(1 + 2j)), S(1.0 + 2.0*I))
-    assert equal(sympify(np.longcomplex(1 + 2j)), S(1.0 + 2.0*I))
+    assert equal(sympify(numpy.complex64(1 + 2j)), S(1.0 + 2.0*I))
+    assert equal(sympify(numpy.complex128(1 + 2j)), S(1.0 + 2.0*I))
+    assert equal(sympify(numpy.longcomplex(1 + 2j)), S(1.0 + 2.0*I))
 
     try:
-        assert equal(sympify(np.float96(1.123456789)),
+        assert equal(sympify(numpy.float96(1.123456789)),
                     Float(1.123456789, precision=80))
     except AttributeError:  #float96 does not exist on all platforms
         pass
 
     try:
-        assert equal(sympify(np.float128(1.123456789123)),
+        assert equal(sympify(numpy.float128(1.123456789123)),
                     Float(1.123456789123, precision=80))
     except AttributeError:  #float128 does not exist on all platforms
         pass

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -2,7 +2,7 @@ from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
     Function, I, S, N, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,
     Pow, Or, true, false, Abs, pi, Range)
 from sympy.abc import x, y
-from sympy.core.sympify import sympify, _sympify, SympifyError, kernS, convert_numpy_to_sympy
+from sympy.core.sympify import sympify, _sympify, SympifyError, kernS 
 from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
 from sympy.utilities.pytest import raises, XFAIL, skip
@@ -502,14 +502,12 @@ def test_issue_8821_highprec_from_str():
 
 
 def test_issue_10295():
-    print('was here')
     if not numpy:
         skip("numpy not installed.")
 
     A = numpy.array([[1, 3, -1],
                      [0, 1, 7]])
     sA = S(A)
-    print(type(sA))
     assert sA.shape == (2, 3)
     for (ri, ci), val in numpy.ndenumerate(A):
         assert sA[ri, ci] == val
@@ -554,12 +552,11 @@ def test_numpy():
     from sympy.utilities.pytest import skip
     np = import_module('numpy')
 
+    if not np:
+        skip('numpy not installed. Abort numpy tests.')
 
     def equal(x, y):
         return x == y and type(x) == type(y)
-
-    if not np:
-        skip('np not installed.Abort np tests.')
 
     assert sympify(np.bool_(1)) is S(True)
     try:

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -2,7 +2,7 @@ from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
     Function, I, S, N, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,
     Pow, Or, true, false, Abs, pi, Range)
 from sympy.abc import x, y
-from sympy.core.sympify import sympify, _sympify, SympifyError, kernS, convert_np_to_sympy_float
+from sympy.core.sympify import sympify, _sympify, SympifyError, kernS, convert_numpy_to_sympy
 from sympy.core.decorators import _sympifyit
 from sympy.external import import_module
 from sympy.utilities.pytest import raises, XFAIL, skip
@@ -552,52 +552,52 @@ def test_sympify_set():
 
 def test_numpy():
     from sympy.utilities.pytest import skip
-    #np = import_module('numpy')
+    np = import_module('numpy')
 
 
     def equal(x, y):
         return x == y and type(x) == type(y)
 
-    if not numpy:
-        skip('numpy not installed.Abort numpy tests.')
+    if not np:
+        skip('np not installed.Abort np tests.')
 
-    assert sympify(numpy.bool_(1)) is S(True)
+    assert sympify(np.bool_(1)) is S(True)
     try:
         assert equal(
-            sympify(numpy.int_(1234567891234567891)), S(1234567891234567891))
+            sympify(np.int_(1234567891234567891)), S(1234567891234567891))
         assert equal(
-            sympify(numpy.intp(1234567891234567891)), S(1234567891234567891))
+            sympify(np.intp(1234567891234567891)), S(1234567891234567891))
     except OverflowError:
         # May fail on 32-bit systems: Python int too large to convert to C long
         pass
-    assert equal(sympify(numpy.intc(1234567891)), S(1234567891))
-    assert equal(sympify(numpy.int8(-123)), S(-123))
-    assert equal(sympify(numpy.int16(-12345)), S(-12345))
-    assert equal(sympify(numpy.int32(-1234567891)), S(-1234567891))
+    assert equal(sympify(np.intc(1234567891)), S(1234567891))
+    assert equal(sympify(np.int8(-123)), S(-123))
+    assert equal(sympify(np.int16(-12345)), S(-12345))
+    assert equal(sympify(np.int32(-1234567891)), S(-1234567891))
     assert equal(
-        sympify(numpy.int64(-1234567891234567891)), S(-1234567891234567891))
-    assert equal(sympify(numpy.uint8(123)), S(123))
-    assert equal(sympify(numpy.uint16(12345)), S(12345))
-    assert equal(sympify(numpy.uint32(1234567891)), S(1234567891))
+        sympify(np.int64(-1234567891234567891)), S(-1234567891234567891))
+    assert equal(sympify(np.uint8(123)), S(123))
+    assert equal(sympify(np.uint16(12345)), S(12345))
+    assert equal(sympify(np.uint32(1234567891)), S(1234567891))
     assert equal(
-        sympify(numpy.uint64(1234567891234567891)), S(1234567891234567891))
-    assert equal(sympify(numpy.float32(1.123456)), Float(1.123456, precision=24))
-    assert equal(sympify(numpy.float64(1.1234567891234)),
+        sympify(np.uint64(1234567891234567891)), S(1234567891234567891))
+    assert equal(sympify(np.float32(1.123456)), Float(1.123456, precision=24))
+    assert equal(sympify(np.float64(1.1234567891234)),
                 Float(1.1234567891234, precision=53))
-    assert equal(sympify(numpy.longdouble(1.123456789)),
+    assert equal(sympify(np.longdouble(1.123456789)),
                  Float(1.123456789, precision=80))
-    assert equal(sympify(numpy.complex64(1 + 2j)), S(1.0 + 2.0*I))
-    assert equal(sympify(numpy.complex128(1 + 2j)), S(1.0 + 2.0*I))
-    assert equal(sympify(numpy.longcomplex(1 + 2j)), S(1.0 + 2.0*I))
+    assert equal(sympify(np.complex64(1 + 2j)), S(1.0 + 2.0*I))
+    assert equal(sympify(np.complex128(1 + 2j)), S(1.0 + 2.0*I))
+    assert equal(sympify(np.longcomplex(1 + 2j)), S(1.0 + 2.0*I))
 
     try:
-        assert equal(sympify(numpy.float96(1.123456789)),
+        assert equal(sympify(np.float96(1.123456789)),
                     Float(1.123456789, precision=80))
     except AttributeError:  #float96 does not exist on all platforms
         pass
 
     try:
-        assert equal(sympify(numpy.float128(1.123456789123)),
+        assert equal(sympify(np.float128(1.123456789123)),
                     Float(1.123456789123, precision=80))
     except AttributeError:  #float128 does not exist on all platforms
         pass


### PR DESCRIPTION
The code from #11666 was factored into a separate function (inside sympify.py) that can be called by both sympify and Float. Now can do

Float(np.int64(5))
Float(np.float128(5),12)
Float(np.float32(5.1200000),dps=5)

These previously gave an error but now evaluate to:

5
5.00000000000
5.1200

Corresponding tests have been added in sympy/core/tests/test_numbers.py
Fixes #13275 
