### PR TITLE
 Remove unused arguments from contour in plot.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -267,9 +267,6 @@ before_install:
       sudo apt-get update;
       sudo apt-get install -y sagemath-upstream-binary;
     fi
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
-      pip install matchpy;
-    fi
 install:
   # If a command fails, fail the build.
   - set -e

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -942,8 +942,7 @@ class MatplotlibBackend(BaseBackend):
                     colormap = ListedColormap(["white", s.line_color])
                     xarray, yarray, zarray, plot_type = points
                     if plot_type == 'contour':
-                        self.ax.contour(xarray, yarray, zarray,
-                                contours=(0, 0), fill=False, cmap=colormap)
+                        self.ax.contour(xarray, yarray, zarray, cmap=colormap)
                     else:
                         self.ax.contourf(xarray, yarray, zarray, cmap=colormap)
             else:


### PR DESCRIPTION
Removed unused arguments, fill and contours, from contour.

I'm not sure why it has `contours` and `fill` arguments in the first place, as it is not documented in matplotlib anywhere. If I remove them, test seems to pass.

See #13355.

Depends on #13405.