### PR TITLE
Fix timeouts in perm_groups tests

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1716,13 +1716,21 @@ class PermutationGroup(Basic):
 
         """
         if _random_prec is None:
+            if self._is_sym or self._is_alt:
+                return True
             n = self.degree
             if n < 8:
                 sym_order = 1
                 for i in range(2, n+1):
                     sym_order *= i
                 order = self.order()
-                return order == sym_order or 2*order == sym_order
+                if order == sym_order:
+                    self._is_sym = True
+                    return True
+                elif 2*order == sym_order:
+                    self._is_alt = True
+                    return True
+                return False
             if not self.is_transitive():
                 return False
             if n < 17:


### PR DESCRIPTION
There have been timeouts in `perm_groups` tests related to sylow subgroups as reported in #13408  and #13355. This was because `is_alt_sym()` is a Monte Carlo algorithm so about 5 percent of the time it doesn't acknowledge symmetric and alternating groups as such, and since the test includes two very large such groups, that's a problem. However, for groups that are known to be symmetric or alternating, for example, ones constructed with `SymmetricGroup` or `AlteratingGroup`, it can always return `True`. This PR makes sure this happens unless `random_prec` keyword is set to something other than `None`. Additionally, for the case when the degree of the group is less than 8, `_is_sym` or `_is_alt` are set to `True` if it's discovered to be the case during a run of `is_alt_sym()`.