### PR TITLE
 Add support for tensorflow 1.0+

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division
+from distutils.version import LooseVersion as V
 
 from .str import StrPrinter
 from .pycode import (
@@ -6,8 +7,14 @@ from .pycode import (
     MpmathPrinter,  # MpmathPrinter is imported for backward compatibility
     NumPyPrinter  # NumPyPrinter is imported for backward compatibility
 )
+from sympy.external import import_module
 from sympy.utilities import default_sort_key
 
+tensorflow = import_module('tensorflow')
+if tensorflow and V(tensorflow.__version__) < '1.0':
+    tensorflow_piecewise = "select"
+else:
+    tensorflow_piecewise = "where"
 
 class LambdaPrinter(PythonCodePrinter):
     """
@@ -107,12 +114,14 @@ class TensorflowPrinter(LambdaPrinter):
         from sympy import Piecewise
         e, cond = expr.args[0].args
         if len(expr.args) == 1:
-            return 'select({0}, {1}, {2})'.format(
+            return '{0}({1}, {2}, {3})'.format(
+                tensorflow_piecewise,
                 self._print(cond, **kwargs),
                 self._print(e, **kwargs),
                 0)
 
-        return 'select({0}, {1}, {2})'.format(
+        return '{0}({1}, {2}, {3})'.format(
+            tensorflow_piecewise,
             self._print(cond, **kwargs),
             self._print(e, **kwargs),
             self._print(Piecewise(*expr.args[1:]), **kwargs))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion as V
 from itertools import product
 import math
 
@@ -506,7 +507,10 @@ def test_tensorflow_variables():
     func = lambdify(x, expr, modules="tensorflow")
     a = tensorflow.Variable(0, dtype=tensorflow.float32)
     s = tensorflow.Session()
-    s.run(tensorflow.initialize_all_variables())
+    if V(tensorflow.__version__) < '1.0':
+        s.run(tensorflow.initialize_all_variables())
+    else:
+        s.run(tensorflow.global_variables_initializer())
     assert func(a).eval(session=s) == 0.5
 
 def test_tensorflow_logical_operations():


### PR DESCRIPTION
Added support for Tensorflow 1.0+, per [Tensorflow documentation](https://www.tensorflow.org/install/migration):
* `tf.initialize_all_variables` should be renamed to `tf.global_variables_initializer`
* `tf.select` should be renamed to `tf.where`

Fixes #12863 and fixes #12278