### PR TITLE
Fix test_issue_8061 (gruntz now able to compute this limit)

### DIFF
--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -412,12 +412,12 @@ def test_function__eval_nseries():
     assert sin(x)._eval_nseries(x, 2, None) == x + O(x**2)
     assert sin(x + 1)._eval_nseries(x, 2, None) == x*cos(1) + sin(1) + O(x**2)
     assert sin(pi*(1 - x))._eval_nseries(x, 2, None) == pi*x + O(x**2)
-    assert acos(1 - x**2)._eval_nseries(x, 2, None) == sqrt(2)*x + O(x**2)
+    assert acos(1 - x**2)._eval_nseries(x, 2, None) == sqrt(2)*sqrt(x**2) + O(x**2)
     assert polygamma(n, x + 1)._eval_nseries(x, 2, None) == \
         polygamma(n, 1) + polygamma(n + 1, 1)*x + O(x**2)
     raises(PoleError, lambda: sin(1/x)._eval_nseries(x, 2, None))
-    raises(PoleError, lambda: acos(1 - x)._eval_nseries(x, 2, None))
-    raises(PoleError, lambda: acos(1 + x)._eval_nseries(x, 2, None))
+    assert acos(1 - x)._eval_nseries(x, 2, None) == sqrt(2)*sqrt(x) + O(x)
+    assert acos(1 + x)._eval_nseries(x, 2, None) == sqrt(2)*sqrt(-x) + O(x)  # XXX: wrong, branch cuts
     assert loggamma(1/x)._eval_nseries(x, 0, None) == \
         log(x)/2 - log(x)/x - 1/x + O(1, x)
     assert loggamma(log(1/x)).nseries(x, n=1, logx=y) == loggamma(-y)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2117,6 +2117,9 @@ class acos(InverseTrigonometricFunction):
         x = self.args[0]
         return x.is_real and (1 - abs(x)).is_nonnegative
 
+    def _eval_nseries(self, x, n, logx):
+        return self._eval_rewrite_as_log(self.args[0])._eval_nseries(x, n, logx)
+
     def _eval_rewrite_as_log(self, x):
         return S.Pi/2 + S.ImaginaryUnit * \
             log(S.ImaginaryUnit * x + sqrt(1 - x**2))


### PR DESCRIPTION
Simple taylor expansion will not work for x0=1, that's
why we do rewrite(log) first.

Taken from the diofant commit:
https://github.com/diofant/diofant/commit/dab49f21add9905c3b71d6b1a6ea92cdee78db40

Part (but not all) of PR:
https://github.com/diofant/diofant/pull/139

Fixes:
https://github.com/sympy/sympy/issues/8061