### PR TITLE
recast solver non-Symbols to symbols; linsolve mods

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2875,7 +2875,7 @@ class Expr(Basic, EvalfMixin):
         elif not symbols:
             return self
         x = sympify(symbols[0])
-        if not x.is_Symbol:
+        if not x.is_symbol:
             raise ValueError('expecting a Symbol but got %s' % x)
         if x not in self.free_symbols:
             return self

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -87,21 +87,25 @@ def _symbol(s, matching_symbol=None, **assumptions):
 def _uniquely_named_symbol(xname, exprs=(), compare=str, modify=None, **assumptions):
     """Return a symbol which, when printed, will have a name unique
     from any other already in the expressions given. The name is made
-    unique by prepending underscores.
+    unique by prepending underscores (default) but this can be
+    customized with the keyword 'modify'.
 
     Parameters
     ==========
 
         xname : a string or a Symbol (when symbol xname <- str(xname))
         compare : a single arg function that takes a symbol and returns
-            a string to be compared with xname
-        modify : a single arg function that changes its string arg in
-            some way (default is to preppend underscores)
+            a string to be compared with xname (the default is the str
+            function which indicates how the name will look when it
+            is printed, e.g. this includes underscores that appear on
+            Dummy symbols)
+        modify : a single arg function that changes its string argument
+            in some way (the default is to preppend underscores)
 
     Examples
     ========
 
-    >>> from sympy.core.symbol import _uniquely_named_symbol as usym
+    >>> from sympy.core.symbol import _uniquely_named_symbol as usym, Dummy
     >>> from sympy.abc import x
     >>> usym('x', x)
     _x

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.assumptions import StdFactKB
-from sympy.core.compatibility import string_types, range
+from sympy.core.compatibility import string_types, range, is_sequence
 from .basic import Basic
 from .sympify import sympify
 from .singleton import S
@@ -15,6 +15,111 @@ from sympy.utilities.iterables import cartes
 import string
 import re as _re
 import random
+
+
+def _symbol(s, matching_symbol=None, **assumptions):
+    """Return s if s is a Symbol, else if s is a string, return either
+    the matching_symbol if the names are the same or else a new symbol
+    with the same assumptions as the matching symbol (or the
+    assumptions as provided).
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, Dummy
+    >>> from sympy.core.symbol import _symbol
+    >>> _symbol('y')
+    y
+    >>> _.is_real is None
+    True
+    >>> _symbol('y', real=True).is_real
+    True
+
+    >>> x = Symbol('x')
+    >>> _symbol(x, real=True)
+    x
+    >>> _.is_real is None  # ignore attribute if s is a Symbol
+    True
+
+    Below, the variable sym has the name 'foo':
+
+    >>> sym = Symbol('foo', real=True)
+
+    Since 'x' is not the same as sym's name, a new symbol is created:
+
+    >>> _symbol('x', sym).name
+    'x'
+
+    It will acquire any assumptions give:
+
+    >>> _symbol('x', sym, real=False).is_real
+    False
+
+    Since 'foo' is the same as sym's name, sym is returned
+
+    >>> _symbol('foo', sym)
+    foo
+
+    Any assumptions given are ignored:
+
+    >>> _symbol('foo', sym, real=False).is_real
+    True
+
+    NB: the symbol here may not be the same as a symbol with the same
+    name defined elsewhere as a result of different assumptions.
+
+    See Also
+    ========
+
+    sympy.core.symbol.Symbol
+
+    """
+    if isinstance(s, string_types):
+        if matching_symbol and matching_symbol.name == s:
+            return matching_symbol
+        return Symbol(s, **assumptions)
+    elif isinstance(s, Symbol):
+        return s
+    else:
+        raise ValueError('symbol must be string for symbol name or Symbol')
+
+
+def _uniquely_named_symbol(xname, exprs=(), compare=str, modify=None, **assumptions):
+    """Return a symbol which, when printed, will have a name unique
+    from any other already in the expressions given. The name is made
+    unique by prepending underscores.
+
+    Parameters
+    ==========
+
+        xname : a string or a Symbol (when symbol xname <- str(xname))
+        compare : a single arg function that takes a symbol and returns
+            a string to be compared with xname
+        modify : a single arg function that changes its string arg in
+            some way (default is to preppend underscores)
+
+    Examples
+    ========
+
+    >>> from sympy.core.symbol import _uniquely_named_symbol as usym
+    >>> from sympy.abc import x
+    >>> usym('x', x)
+    _x
+    """
+    default = None
+    if is_sequence(xname):
+        xname, default = xname
+    x = str(xname)
+    if not exprs:
+        return _symbol(x, default, **assumptions)
+    if not is_sequence(exprs):
+        exprs = [exprs]
+    syms = set().union(*[e.free_symbols for e in exprs])
+    if modify is None:
+        modify = lambda s: '_' + s
+    while any(x == compare(s) for s in syms):
+        x = modify(x)
+    return _symbol(x, default, **assumptions)
 
 
 class Symbol(AtomicExpr, Boolean):

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,6 +1,7 @@
 from sympy import (Symbol, Wild, GreaterThan, LessThan, StrictGreaterThan,
     StrictLessThan, pi, I, Rational, sympify, symbols, Dummy
 )
+from sympy.core.symbol import _uniquely_named_symbol, _symbol
 
 from sympy.utilities.pytest import raises
 
@@ -335,9 +336,29 @@ def test_call():
     assert f(2)
     raises(TypeError, lambda: Wild('x')(1))
 
+
 def test_unicode():
     xu = Symbol(u'x')
     x = Symbol('x')
     assert x == xu
 
     raises(TypeError, lambda: Symbol(1))
+
+
+def test__uniquely_named_symbol_and__symbol():
+    F = _uniquely_named_symbol
+    x = Symbol('x')
+    assert F(x) == x
+    assert F('x') == x
+    assert str(F('x', x)) == '_x'
+    assert str(F('x', (x + 1, 1/x))) == '_x'
+    _x = Symbol('x', real=True)
+    assert F(('x', _x)) == _x
+    assert F((x, _x)) == _x
+    assert F('x', real=True).is_real
+    y = Symbol('y')
+    assert F(('x', y), real=True).is_real
+    r = Symbol('x', real=True)
+    assert F(('x', r)).is_real
+    assert F(('x', r), real=False).is_real
+    assert _symbol(x, _x) == x

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -361,4 +361,8 @@ def test__uniquely_named_symbol_and__symbol():
     r = Symbol('x', real=True)
     assert F(('x', r)).is_real
     assert F(('x', r), real=False).is_real
+    assert F('x1', Symbol('x1'),
+        compare=lambda i: str(i).rstrip('1')).name == 'x1'
+    assert F('x1', Symbol('x1'),
+        modify=lambda i: i + '_').name == 'x1_'
     assert _symbol(x, _x) == x

--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -12,11 +12,10 @@ from sympy import sqrt
 from sympy.core import sympify, diff
 from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
+from sympy.core.symbol import _symbol
 from sympy.geometry.entity import GeometryEntity, GeometrySet
 from sympy.geometry.point import Point
 from sympy.integrals import integrate
-
-from .util import _symbol
 
 
 class Curve(GeometrySet):
@@ -136,7 +135,7 @@ class Curve(GeometrySet):
         if parameter is None:
             return Point(*self.functions)
 
-        tnew = _symbol(parameter, self.parameter)
+        tnew = _symbol(parameter, self.parameter, real=True)
         t = self.parameter
         if (tnew.name != t.name and
                 tnew.name in (f.name for f in self.free_symbols)):
@@ -293,7 +292,7 @@ class Curve(GeometrySet):
         [s, 1, 2]
 
         """
-        t = _symbol(parameter, self.parameter)
+        t = _symbol(parameter, self.parameter, real=True)
         return [t] + list(self.limits[1:])
 
     def rotate(self, angle=0, pt=None):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -12,7 +12,7 @@ from sympy.core import S, pi, sympify
 from sympy.core.logic import fuzzy_bool
 from sympy.core.numbers import Rational, oo
 from sympy.core.compatibility import range, ordered
-from sympy.core.symbol import Dummy
+from sympy.core.symbol import Dummy, _uniquely_named_symbol, _symbol
 from sympy.simplify import simplify, trigsimp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import cos, sin
@@ -27,7 +27,7 @@ from sympy.utilities.decorator import doctest_depends_on
 from .entity import GeometryEntity, GeometrySet
 from .point import Point, Point2D, Point3D
 from .line import Line, LinearEntity
-from .util import _symbol, idiff
+from .util import idiff
 
 import random
 
@@ -252,7 +252,7 @@ class Ellipse(GeometrySet):
         Point2D(3*cos(t), 2*sin(t))
 
         """
-        t = _symbol(parameter)
+        t = _symbol(parameter, real=True)
         if t.name in (f.name for f in self.free_symbols):
             raise ValueError(filldedent('Symbol %s already appears in object '
                 'and cannot be used as a parameter.' % t.name))
@@ -442,8 +442,8 @@ class Ellipse(GeometrySet):
         y**2/4 + (x/3 - 1/3)**2 - 1
 
         """
-        x = _symbol(x)
-        y = _symbol(y)
+        x = _symbol(x, real=True)
+        y = _symbol(y, real=True)
         t1 = ((x - self.center.x) / self.hradius)**2
         t2 = ((y - self.center.y) / self.vradius)**2
         return t1 + t2 - 1
@@ -474,8 +474,8 @@ class Ellipse(GeometrySet):
         """
         if len(self.args) != 3:
             raise NotImplementedError('Evolute of arbitrary Ellipse is not supported.')
-        x = _symbol(x)
-        y = _symbol(y)
+        x = _symbol(x, real=True)
+        y = _symbol(y, real=True)
         t1 = (self.hradius*(x - self.center.x))**Rational(2, 3)
         t2 = (self.vradius*(y - self.center.y))**Rational(2, 3)
         return t1 + t2 - (self.hradius**2 - self.vradius**2)**Rational(2, 3)
@@ -1002,7 +1002,7 @@ class Ellipse(GeometrySet):
         [t, -pi, pi]
 
         """
-        t = _symbol(parameter)
+        t = _symbol(parameter, real=True)
         return [t, -S.Pi, S.Pi]
 
     def random_point(self, seed=None):
@@ -1067,7 +1067,7 @@ class Ellipse(GeometrySet):
 
         """
         from sympy import sin, cos, Rational
-        t = _symbol('t')
+        t = _symbol('t', real=True)
         x, y = self.arbitrary_point(t).args
         # get a random value in [-1, 1) corresponding to cos(t)
         # and confirm that it will test as being in the ellipse
@@ -1112,14 +1112,14 @@ class Ellipse(GeometrySet):
         zeros define the rotated ellipse is given.
 
         """
-        from .util import _uniquely_named_symbol
 
         if line.slope in (0, oo):
             c = self.center
             c = c.reflect(line)
             return self.func(c, -self.hradius, self.vradius)
         else:
-            x, y = [_uniquely_named_symbol(name, self, line) for name in 'xy']
+            x, y = [_uniquely_named_symbol(
+                name, (self, line), real=True) for name in 'xy']
             expr = self.equation(x, y)
             p = Point(x, y).reflect(line)
             result = expr.subs(zip((x, y), p.args
@@ -1405,8 +1405,8 @@ class Circle(Ellipse):
         x**2 + y**2 - 25
 
         """
-        x = _symbol(x)
-        y = _symbol(y)
+        x = _symbol(x, real=True)
+        y = _symbol(y, real=True)
         t1 = (x - self.center.x)**2
         t2 = (y - self.center.y)**2
         return t1 + t2 - self.major**2

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -20,6 +20,7 @@ from __future__ import division, print_function
 
 from sympy.core import S, sympify
 from sympy.core.relational import Eq
+from sympy.core.symbol import _symbol
 from sympy.functions.elementary.trigonometric import (_pi_coeff as pi_coeff, acos, tan, atan2)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.logic.boolalg import And
@@ -31,7 +32,6 @@ from sympy.matrices import Matrix
 
 from .entity import GeometryEntity, GeometrySet
 from .point import Point, Point3D
-from .util import _symbol
 from sympy.utilities.misc import Undecidable
 
 
@@ -227,7 +227,7 @@ class LinearEntity(GeometrySet):
         Point3D(4*t + 1, 3*t, t)
 
         """
-        t = _symbol(parameter)
+        t = _symbol(parameter, real=True)
         if t.name in (f.name for f in self.free_symbols):
             raise ValueError(filldedent('''
                 Symbol %s already appears in object
@@ -1140,7 +1140,7 @@ class Line(LinearEntity):
         [t, -5, 5]
 
         """
-        t = _symbol(parameter)
+        t = _symbol(parameter, real=True)
         return [t, -5, 5]
 
 
@@ -1354,7 +1354,7 @@ class Ray(LinearEntity):
         [t, 0, 10]
 
         """
-        t = _symbol(parameter)
+        t = _symbol(parameter, real=True)
         return [t, 0, 10]
 
     @property
@@ -1660,7 +1660,7 @@ class Segment(LinearEntity):
         [t, 0, 1]
 
         """
-        t = _symbol(parameter)
+        t = _symbol(parameter, real=True)
         return [t, 0, 1]
 
 
@@ -1938,7 +1938,8 @@ class Line2D(LinearEntity2D, Line):
         -3*x + 4*y + 3
 
         """
-        x, y = _symbol(x), _symbol(y)
+        x = _symbol(x, real=True)
+        y = _symbol(y, real=True)
         p1, p2 = self.points
         if p1.x == p2.x:
             return x - p1.x
@@ -2380,7 +2381,7 @@ class Line3D(LinearEntity3D, Line):
         (x/4 - 1/4, y/3, zoo*z, k)
 
         """
-        x, y, z, k = _symbol(x), _symbol(y), _symbol(z), _symbol(k)
+        x, y, z, k = [_symbol(i, real=True) for i in (x, y, z, k)]
         p1, p2 = self.points
         a = p1.direction_ratio(p2)
         return (((x - p1.x)/a[0]), ((y - p1.y)/a[1]),

--- a/sympy/geometry/parabola.py
+++ b/sympy/geometry/parabola.py
@@ -8,11 +8,11 @@ Contains
 from __future__ import division, print_function
 from sympy.core import S
 from sympy.core.compatibility import ordered
+from sympy.core.symbol import _symbol
 from sympy import symbols, simplify, solve
 from sympy.geometry.entity import GeometryEntity, GeometrySet
 from sympy.geometry.point import Point, Point2D
 from sympy.geometry.line import Line, Line2D, Ray2D, Segment2D, LinearEntity3D
-from sympy.geometry.util import _symbol
 from sympy.geometry.ellipse import Ellipse
 
 
@@ -212,8 +212,8 @@ class Parabola(GeometrySet):
         -x**2 - 16*z + 64
 
         """
-        x = _symbol(x)
-        y = _symbol(y)
+        x = _symbol(x, real=True)
+        y = _symbol(y, real=True)
 
         if (self.axis_of_symmetry.slope == 0):
             t1 = 4 * (self.p_parameter) * (x - self.vertex.x)

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -2,6 +2,7 @@ from __future__ import division, print_function
 
 from sympy.core import Expr, S, Symbol, oo, pi, sympify
 from sympy.core.compatibility import as_int, range, ordered
+from sympy.core.symbol import _symbol
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import cos, sin, tan
@@ -16,7 +17,6 @@ from .entity import GeometryEntity, GeometrySet
 from .point import Point
 from .ellipse import Circle
 from .line import Line, Segment
-from .util import _symbol
 
 from sympy import sqrt
 
@@ -622,7 +622,7 @@ class Polygon(GeometrySet):
         Point2D(1, 1/2)
 
         """
-        t = _symbol(parameter)
+        t = _symbol(parameter, real=True)
         if t.name in (f.name for f in self.free_symbols):
             raise ValueError('Symbol %s already appears in object and cannot be used as a parameter.' % t.name)
         sides = []

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -23,61 +23,6 @@ def _ordered_points(p):
     return tuple(sorted(p, key=lambda x: x.args))
 
 
-def _symbol(s, matching_symbol=None):
-    """Return s if s is a Symbol, else return either a new Symbol (real=True)
-    with the same name s or the matching_symbol if s is a string and it matches
-    the name of the matching_symbol.
-
-    >>> from sympy import Symbol
-    >>> from sympy.geometry.util import _symbol
-    >>> x = Symbol('x')
-    >>> _symbol('y')
-    y
-    >>> _.is_real
-    True
-    >>> _symbol(x)
-    x
-    >>> _.is_real is None
-    True
-    >>> arb = Symbol('foo')
-    >>> _symbol('arb', arb) # arb's name is foo so foo will not be returned
-    arb
-    >>> _symbol('foo', arb) # now it will
-    foo
-
-    NB: the symbol here may not be the same as a symbol with the same
-    name defined elsewhere as a result of different assumptions.
-
-    See Also
-    ========
-
-    sympy.core.symbol.Symbol
-
-    """
-    if isinstance(s, string_types):
-        if matching_symbol and matching_symbol.name == s:
-            return matching_symbol
-        return Symbol(s, real=True)
-    elif isinstance(s, Symbol):
-        return s
-    else:
-        raise ValueError('symbol must be string for symbol name or Symbol')
-
-
-def _uniquely_named_symbol(xname, *exprs):
-    """Return a symbol which, when printed, will have a name unique
-    from any other already in the expressions given. The name is made
-    unique by prepending underscores.
-    """
-    prefix = '%s'
-    x = prefix % xname
-    syms = set().union(*[e.free_symbols for e in exprs])
-    while any(x == str(s) for s in syms):
-        prefix = '_' + prefix
-        x = prefix % xname
-    return _symbol(x)
-
-
 def are_coplanar(*e):
     """ Returns True if the given entities are coplanar otherwise False
 

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -1222,10 +1222,10 @@ class HolonomicFunction(object):
 
             # check for linear relations
             system.append(coeffs)
-            sol_tuple = (Matrix(system).transpose()).gauss_jordan_solve(homogeneous)
-            sol = sol_tuple[0]
+            sol, taus = (Matrix(system).transpose()
+                ).gauss_jordan_solve(homogeneous)
 
-        tau = sol.atoms(Dummy).pop()
+        tau = list(taus)[0]
         sol = sol.subs(tau, 1)
         sol = _normalize(sol[0:], R, negative=False)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2606,13 +2606,9 @@ class MatrixBase(MatrixDeprecated,
 
         # Free parameters
         # what are current unnumbered free symbol names?
-        free_basenames = [str(i).rstrip('1234567890') for i in aug.free_symbols]
-        # preppend 'tau' with underscores if it matches any current base name
-        stau = 'tau'
-        while stau in free_basenames:
-            stau = '_' + stau
-        # create the matrix of numbered tau symbols, tau0, tau1, etc...
-        gen = numbered_symbols(stau)
+        name = _uniquely_named_symbol('tau', aug,
+            compare=lambda i: str(i).rstrip('1234567890')).name
+        gen = numbered_symbols(name)
         tau = Matrix([next(gen) for k in range(col - rank)]).reshape(col - rank, 1)
 
         # Full parametric solution

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,26 +1,28 @@
 from __future__ import print_function, division
 
 import collections
+from sympy.assumptions.refine import refine
 from sympy.core.add import Add
 from sympy.core.basic import Basic, Atom
 from sympy.core.expr import Expr
 from sympy.core.power import Pow
-from sympy.core.symbol import Symbol, Dummy, symbols
+from sympy.core.symbol import (Symbol, Dummy, symbols,
+    _uniquely_named_symbol)
 from sympy.core.numbers import Integer, ilcm, Float
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
+from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
+from sympy.functions import Abs, exp, factorial
+from sympy.polys import PurePoly, roots, cancel, gcd
+from sympy.printing import sstr
+from sympy.simplify import simplify as _simplify, signsimp, nsimplify
+from sympy.core.compatibility import reduce, as_int, string_types
+
+from sympy.utilities.iterables import flatten, numbered_symbols
+from sympy.core.decorators import call_highest_priority
 from sympy.core.compatibility import is_sequence, default_sort_key, range, \
     NotIterable
 
-from sympy.polys import PurePoly, roots, cancel, gcd
-from sympy.simplify import simplify as _simplify, signsimp, nsimplify
-from sympy.utilities.iterables import flatten, numbered_symbols
-from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
-from sympy.functions import Abs, exp, factorial
-from sympy.printing import sstr
-from sympy.core.compatibility import reduce, as_int, string_types
-from sympy.assumptions.refine import refine
-from sympy.core.decorators import call_highest_priority
 
 from types import FunctionType
 
@@ -284,7 +286,7 @@ class MatrixDeterminant(MatrixCommon):
         """
         return self.cofactor_matrix(method).transpose()
 
-    def charpoly(self, x=Dummy('lambda'), simplify=_simplify):
+    def charpoly(self, x='lambda', simplify=_simplify):
         """Computes characteristic polynomial det(x*I - self) where I is
         the identity matrix.
 
@@ -300,21 +302,27 @@ class MatrixDeterminant(MatrixCommon):
         >>> A.charpoly(x) == A.charpoly(y)
         True
 
-        Specifying ``x`` is optional; a Dummy with name ``lambda`` is used by
+        Specifying ``x`` is optional; a symbol named ``lambda`` is used by
         default (which looks good when pretty-printed in unicode):
 
         >>> A.charpoly().as_expr()
-        _lambda**2 - _lambda - 6
+        lambda**2 - lambda - 6
 
-        No test is done to see that ``x`` doesn't clash with an existing
-        symbol, so using the default (``lambda``) or your own Dummy symbol is
-        the safest option:
+        And if ``x`` clashes with an existing symbol, underscores will
+        be preppended to the name to make it unique:
 
         >>> A = Matrix([[1, 2], [x, 0]])
-        >>> A.charpoly().as_expr()
-        _lambda**2 - _lambda - 2*x
         >>> A.charpoly(x).as_expr()
-        x**2 - 3*x
+        _x**2 - _x - 2*x
+
+        Whether you pass a symbol or not, the generator can be obtained
+        with the gen attribute since it may not be the same as the symbol
+        that was passed:
+
+        >>> A.charpoly(x).gen
+        _x
+        >>> A.charpoly(x).gen == x
+        False
 
         Notes
         =====
@@ -334,6 +342,7 @@ class MatrixDeterminant(MatrixCommon):
             raise NonSquareMatrixError()
 
         berk_vector = self._eval_berkowitz_vector()
+        x = _uniquely_named_symbol(x, berk_vector)
         return PurePoly([simplify(a) for a in berk_vector], x)
 
     def cofactor(self, i, j, method="berkowitz"):
@@ -2501,7 +2510,7 @@ class MatrixBase(MatrixDeprecated,
 
         freevar : List
             If the system is underdetermined (e.g. A has more columns than
-            rows), infinite solutions are possible, in terms of an arbitrary
+            rows), infinite solutions are possible, in terms of arbitrary
             values of free variables. Then the index of the free variables
             in the solutions (column Matrix) will be returned by freevar, if
             the flag `freevar` is set to `True`.
@@ -2515,7 +2524,7 @@ class MatrixBase(MatrixDeprecated,
 
         params : Matrix
             If the system is underdetermined (e.g. A has more columns than
-            rows), infinite solutions are possible, in terms of an arbitrary
+            rows), infinite solutions are possible, in terms of arbitrary
             parameters. These arbitrary parameters are returned as params
             Matrix.
 
@@ -2528,14 +2537,14 @@ class MatrixBase(MatrixDeprecated,
         >>> sol, params = A.gauss_jordan_solve(b)
         >>> sol
         Matrix([
-        [-2*_tau0 - 3*_tau1 + 2],
-        [                 _tau0],
-        [           2*_tau1 + 5],
-        [                 _tau1]])
+        [-2*tau0 - 3*tau1 + 2],
+        [                 tau0],
+        [           2*tau1 + 5],
+        [                 tau1]])
         >>> params
         Matrix([
-        [_tau0],
-        [_tau1]])
+        [tau0],
+        [tau1]])
 
         >>> A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
         >>> b = Matrix([3, 6, 9])
@@ -2596,9 +2605,15 @@ class MatrixBase(MatrixDeprecated,
                          len(pivots):]  # non-pivots columns are free variables
 
         # Free parameters
-        dummygen = numbered_symbols("tau", Dummy)
-        tau = Matrix([next(dummygen) for k in range(col - rank)]).reshape(
-            col - rank, 1)
+        # what are current unnumbered free symbol names?
+        free_basenames = [str(i).rstrip('1234567890') for i in aug.free_symbols]
+        # preppend 'tau' with underscores if it matches any current base name
+        stau = 'tau'
+        while stau in free_basenames:
+            stau = '_' + stau
+        # create the matrix of numbered tau symbols, tau0, tau1, etc...
+        gen = numbered_symbols(stau)
+        tau = Matrix([next(gen) for k in range(col - rank)]).reshape(col - rank, 1)
 
         # Full parametric solution
         V = A[:rank, rank:]
@@ -2808,8 +2823,9 @@ class MatrixBase(MatrixDeprecated,
         if not self.is_square:
             raise NonSquareMatrixError(
                 "Nilpotency is valid only for square matrices")
-        x = Dummy('x')
-        if self.charpoly(x).args[0] == x ** self.rows:
+        x = _uniquely_named_symbol('x', self)
+        p = self.charpoly(x)
+        if p.args[0] == x ** self.rows:
             return True
         return False
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1728,8 +1728,12 @@ def test_Matrix_berkowitz_charpoly():
     assert type(charpoly) is PurePoly
 
     A = Matrix([[1, 3], [2, 0]])
-
     assert A.charpoly() == A.charpoly(x) == PurePoly(x**2 - x - 6)
+
+    A = Matrix([[1, 2], [x, 0]])
+    p = A.charpoly(x)
+    assert p.gen != x
+    assert p.as_expr().subs(p.gen, x) == x**2 - 3*x
 
 
 def test_exp():
@@ -2751,6 +2755,14 @@ def test_gauss_jordan_solve():
                          [-2*w['tau0'] - 3*w['tau1'] - 1/S(4)],
                          [w['tau0']], [w['tau1']]])
     assert params == Matrix([[w['tau0']], [w['tau1']]])
+    # watch out for clashing symbols
+    x0, x1, x2, _x0 = symbols('_tau0 _tau1 _tau2 tau1')
+    M = Matrix([[0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, _x0]])
+    A = M[:, :-1]
+    b = M[:, -1:]
+    sol, params = A.gauss_jordan_solve(b)
+    assert params == Matrix(3, 1, [x0, x1, x2])
+    assert sol == Matrix(5, 1, [x1, 0, x0, _x0, x2])
 
     # Rectangular, wide, reduced rank, no solution
     A = Matrix([[1, 2, 3, 4], [5, 6, 7, 8], [2, 4, 6, 8]])

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2639,8 +2639,8 @@ def _determine_ambiguous(term, ordered, ambiguous_groups):
         # handle this needs to be implemented.  In order to return something
         # useful nevertheless, we choose arbitrarily the first dummy and
         # determine the rest from this one.  This method is dependent on the
-        # actual dummy labels which violates an assumption for the canonization
-        # procedure.  A better implementation is needed.
+        # actual dummy labels which violates an assumption for the
+        # canonicalization procedure.  A better implementation is needed.
         group = [ d for d in ordered if d in ambiguous_groups[0] ]
         d = group[0]
         all_ordered.add(d)

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -639,7 +639,7 @@ def gruntz(e, z, z0, dir="+"):
     file. It relies heavily on the series expansion. Most frequently, gruntz()
     is only used if the faster limit() function (which uses heuristics) fails.
     """
-    if not z.is_Symbol:
+    if not z.is_symbol:
         raise NotImplementedError("Second argument must be a Symbol")
 
     # convert all limits to the limit z->oo; sign of z is handled in limitinf

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -148,7 +148,7 @@ class Order(Expr):
                 variables = list(map(sympify, args))
                 point = [S.Zero]*len(variables)
 
-        if not all(v.is_Symbol for v in variables):
+        if not all(v.is_symbol for v in variables):
             raise TypeError('Variables are not symbols, got %s' % variables)
 
         if len(list(uniq(variables))) != len(variables):
@@ -368,7 +368,7 @@ class Order(Expr):
                 common_symbols = expr.variables
             if not common_symbols:
                 return None
-            if (self.expr.is_Pow and self.expr.base.is_Symbol
+            if (self.expr.is_Pow and self.expr.base.is_symbol
                 and self.expr.exp.is_positive):
                 if expr.expr.is_Pow and self.expr.base == expr.expr.base:
                     return not (self.expr.exp-expr.expr.exp).is_positive
@@ -395,7 +395,7 @@ class Order(Expr):
                     if r != l:
                         return
             return r
-        if (self.expr.is_Pow and self.expr.base.is_Symbol
+        if (self.expr.is_Pow and self.expr.base.is_symbol
             and self.expr.exp.is_positive):
             if expr.is_Pow and self.expr.base == expr.base:
                 return not (self.expr.exp-expr.exp).is_positive
@@ -421,7 +421,7 @@ class Order(Expr):
             i = self.variables.index(old)
             newvars = list(self.variables)
             newpt = list(self.point)
-            if new.is_Symbol:
+            if new.is_symbol:
                 newvars[i] = new
             else:
                 syms = new.free_symbols

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -15,7 +15,7 @@ from sympy.core.evaluate import global_evaluate
 from sympy.core.function import FunctionClass
 from sympy.core.mul import Mul
 from sympy.core.relational import Eq
-from sympy.core.symbol import Symbol, Dummy
+from sympy.core.symbol import Symbol, Dummy, _uniquely_named_symbol
 from sympy.sets.contains import Contains
 from sympy.utilities.misc import func_name, filldedent
 
@@ -2164,7 +2164,6 @@ def imageset(*args):
     """
     from sympy.core import Lambda
     from sympy.sets.fancysets import ImageSet
-    from sympy.geometry.util import _uniquely_named_symbol
 
     if len(args) not in (2, 3):
         raise ValueError('imageset expects 2 or 3 args, got: %s' % len(args))

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -14,6 +14,7 @@ from sympy.core import S, Pow, Dummy, pi, Expr, Wild, Mul, Equality
 from sympy.core.numbers import I, Number, Rational, oo
 from sympy.core.function import (Lambda, expand_complex)
 from sympy.core.relational import Eq
+from sympy.core.symbol import Symbol
 from sympy.simplify.simplify import simplify, fraction, trigsimp
 from sympy.functions import (log, Abs, tan, cot, sin, cos, sec, csc, exp,
                              acos, asin, acsc, asec, arg,
@@ -26,12 +27,13 @@ from sympy.sets import (FiniteSet, EmptySet, imageset, Interval, Intersection,
 from sympy.matrices import Matrix
 from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf)
-from sympy.solvers.solvers import checksol, denoms, unrad, _simple_dens
+from sympy.solvers.solvers import (checksol, denoms, unrad,
+    _simple_dens, recast_to_symbols)
 from sympy.solvers.polysys import solve_poly_system
 from sympy.solvers.inequalities import solve_univariate_inequality
 from sympy.utilities import filldedent
 from sympy.calculus.util import periodicity, continuous_domain
-from sympy.core.compatibility import ordered, default_sort_key
+from sympy.core.compatibility import ordered, default_sort_key, is_sequence
 
 
 def _invert(f_x, y, x, domain=S.Complexes):
@@ -906,9 +908,11 @@ def solveset(f, symbol=None, domain=S.Complexes):
             raise ValueError(filldedent('''
                 The independent variable must be specified for a
                 multivariate equation.'''))
-    elif not getattr(symbol, 'is_Symbol', False):
-        raise ValueError('A Symbol must be given, not type %s: %s' %
-            (type(symbol), symbol))
+    elif not isinstance(symbol, Symbol):
+        s = Dummy()
+        f = f.subs(symbol, s)
+        # the xreplace will be needed if a ConditionSet is returned
+        return solveset(f, s, domain).xreplace({s: symbol})
 
     if isinstance(f, Eq):
         from sympy.core import Add
@@ -1166,31 +1170,25 @@ def linsolve(system, *symbols):
 
     `system = (A, b)`
 
-    Symbols to solve for should be given as input in all the
-    cases either in an iterable or as comma separated arguments.
-    This is done to maintain consistency in returning solutions
-    in the form of variable input by the user.
+    Symbols can always be passed but are actually only needed
+    when 1) a system of equations is being passed and 2) the
+    system is passed as an underdetermined matrix and one wants
+    to control the name of the free variables in the result.
+    An error is raised if no symbols are used for case 1, but if
+    no symbols are provided for case 2, internally generated symbols
+    will be provided. When providing symbols for case 2, there should
+    be at least as many symbols are there are columns in matrix A.
 
     The algorithm used here is Gauss-Jordan elimination, which
-    results, after elimination, in an row echelon form matrix.
+    results, after elimination, in a row echelon form matrix.
 
     Returns
     =======
 
-    A FiniteSet of ordered tuple of values of `symbols` for which
-    the `system` has solution.
-
-    Please note that general FiniteSet is unordered, the solution
-    returned here is not simply a FiniteSet of solutions, rather
-    it is a FiniteSet of ordered tuple, i.e. the first & only
-    argument to FiniteSet is a tuple of solutions, which is ordered,
-    & hence the returned solution is ordered.
-
-    Also note that solution could also have been returned as an
-    ordered tuple, FiniteSet is just a wrapper `{}` around
-    the tuple. It has no other significance except for
-    the fact it is just used to maintain a consistent output
-    format throughout the solveset.
+    A FiniteSet containing an ordered tuple of values for the
+    unknowns for which the `system` has a solution. (Wrapping
+    the tuple in FiniteSet is used to maintain a consistent
+    output format throughout solveset.)
 
     Returns EmptySet(), if the linear system is inconsistent.
 
@@ -1221,20 +1219,27 @@ def linsolve(system, *symbols):
     >>> linsolve((A, b), [x, y, z])
     {(-1, 2, 0)}
 
-    * Parametric Solution: In case the system is under determined, the function
-      will return parametric solution in terms of the given symbols.
-      Free symbols in the system are returned as it is. For e.g. in the system
-      below, `z` is returned as the solution for variable z, which means z is a
-      free symbol, i.e. it can take arbitrary values.
+    * Parametric Solution: In case the system is underdetermined, the
+      function will return a parametric solution in terms of the given
+      symbols. Those that are free will be returned unchanged. e.g. in
+      the system below, `z` is returned as the solution for variable z;
+      it can take on any value.
 
     >>> A = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> b = Matrix([3, 6, 9])
-    >>> linsolve((A, b), [x, y, z])
+    >>> linsolve((A, b), x, y, z)
     {(z - 1, -2*z + 2, z)}
+
+    If no symbols are given, internally generated symbols will be used.
+    The `tau0` in the 3rd position indicates (as before) that the 3rd
+    variable -- whatever it's named -- can take on any value:
+
+    >>> linsolve((A, b))
+    {(tau0 - 1, -2*tau0 + 2, tau0)}
 
     * List of Equations as input
 
-    >>> Eqns = [3*x + 2*y - z - 1, 2*x - 2*y + 4*z + 2, - x + S(1)/2*y - z]
+    >>> Eqns = [3*x + 2*y - z - 1, 2*x - 2*y + 4*z + 2, - x + y/2 - z]
     >>> linsolve(Eqns, x, y, z)
     {(1, -2, -2)}
 
@@ -1273,25 +1278,28 @@ def linsolve(system, *symbols):
         return S.EmptySet
 
     # If second argument is an iterable
-    if hasattr(symbols[0], '__iter__'):
+    if symbols and hasattr(symbols[0], '__iter__'):
         symbols = symbols[0]
 
-    if not any([hasattr(symbols[0], attr) for attr in ['is_Symbol', 'is_Function']]):
-        raise ValueError('Symbols or iterable of symbols must be given as '
-                         'second argument, not type %s: %s' % (type(symbols[0]), symbols[0]))
+    swap = {}
+    b = needed_msg = None
 
-    # 1). Augmented Matrix input Form
-    if isinstance(system, Matrix):
-        A, b = system[:, :-1], system[:, -1:]
+    # unpack system
 
-    elif hasattr(system, '__iter__'):
+    if hasattr(system, '__iter__'):
 
-        # 2). A & b as input Form
-        if len(system) == 2 and system[0].is_Matrix:
+        # 1). (A, b)
+        if len(system) == 2 and isinstance(system[0], Matrix):
             A, b = system
 
-        # 3). List of equations Form
-        if not system[0].is_Matrix:
+        # 2). (eq1, eq2, ...)
+        if not isinstance(system[0], Matrix):
+            if not symbols:
+                raise ValueError(filldedent('''
+                    When passing a system of equations, the symbols
+                    for which a solution is being sought must be
+                    given, too.
+                '''))
             system = list(system)
             for i, eq in enumerate(system):
                 try:
@@ -1301,12 +1309,23 @@ def linsolve(system, *symbols):
                     if any (degree(eq, sym) > 1 for sym in symbols):
                         raise PolynomialError
                 except PolynomialError:
-                        raise ValueError(filldedent(
-'%s contains non-linear terms of variables to be evaluated') %(eq))
+                    raise ValueError(filldedent('''
+                        %s contains non-linear terms in the
+                        variables to be evaluated
+                    ''') % eq)
+            system, symbols, swap = recast_to_symbols(system, symbols)
             A, b = linear_eq_to_matrix(system, symbols)
+            needed_msg = 'free symbols in the equations provided'
 
-    else:
+    elif isinstance(system, Matrix) and not (
+            symbols and isinstance(symbols[0], Matrix)):
+        # 3). A augmented with b
+        A, b = system[:, :-1], system[:, -1:]
+
+    if b is None:
         raise ValueError("Invalid arguments")
+
+    needed_msg  = needed_msg or 'columns of A'
 
     try:
         solution, params, free_syms = A.gauss_jordan_solve(b, freevar=True)
@@ -1315,9 +1334,26 @@ def linsolve(system, *symbols):
         return S.EmptySet
 
     # Replace free parameters with free symbols
-    replace_dict = {v: symbols[free_syms[k]] for k, v in enumerate(params)}
-    solution = [simplify(sol.xreplace(replace_dict)) for sol in solution]
+    if params:
+        if not symbols:
+            symbols = [_ for _ in params]
+            # re-use the parameters but put them in order
+            # params       [x, y, z]
+            # free_symbols [2, 0, 4]
+            # idx          [1, 0, 2]
+            idx = list(zip(*sorted(zip(free_syms, range(len(free_syms)))))[1])
+            # simultaneous replacements {y: x, x: y, z: z}
+            replace_dict = dict(zip(symbols, [symbols[i] for i in idx]))
+        elif len(symbols) >= A.cols:
+            replace_dict = {v: symbols[free_syms[k]] for k, v in enumerate(params)}
+        else:
+            raise IndexError(filldedent('''
+                the number of symbols passed should have a length
+                equal to the number of %s.
+                ''' % needed_msg))
+        solution = [sol.xreplace(replace_dict) for sol in solution]
 
+    solution = [simplify(sol).xreplace(swap) for sol in solution]
     return FiniteSet(tuple(solution))
 
 
@@ -2114,19 +2150,15 @@ def nonlinsolve(system, *symbols):
     if hasattr(symbols[0], '__iter__'):
         symbols = symbols[0]
 
-    try:
-        sym = symbols[0].is_Symbol
-    except AttributeError:
-        sym = False
-    except IndexError:
+    if not is_sequence(symbols) or not symbols:
         msg = ('Symbols must be given, for which solution of the '
                'system is to be found.')
         raise IndexError(filldedent(msg))
 
-    if not sym:
-        msg = ('Symbols or iterable of symbols must be given as '
-               'second argument, not type %s: %s')
-        raise ValueError(filldedent(msg % (type(symbols[0]), symbols[0])))
+    system, symbols, swap = recast_to_symbols(system, symbols)
+    if swap:
+        soln = nonlinsolve(system, symbols)
+        return FiniteSet(*[tuple(i.xreplace(swap) for i in s) for s in soln])
 
     if len(system) == 1 and len(symbols) == 1:
         return _solveset_work(system, symbols)
@@ -2136,7 +2168,7 @@ def nonlinsolve(system, *symbols):
         system, symbols)
 
     if len(symbols) == len(polys):
-        # If all the equations in the system is poly
+        # If all the equations in the system are poly
         if is_zero_dimensional(polys, symbols):
             # finite number of soln (Zero dimensional system)
             try:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,21 +1,30 @@
-from sympy import (
-    Abs, Dummy, Eq, Gt, Function, Mod,
-    LambertW, Piecewise, Poly, Rational, S, Symbol, Matrix,
-    asin, acos, acsc, asec, atan, atanh, cos, csc, erf, erfinv, erfc, erfcinv,
-    exp, log, pi, sin, sinh, sec, sqrt, symbols,
-    tan, tanh, atan2, arg,
-    Lambda, imageset, cot, acot, I, EmptySet, Union, E, Interval, Intersection,
-    oo, Indexed)
-
-from sympy.core.function import nfloat
-from sympy.core.relational import Unequality as Ne
-from sympy.functions.elementary.complexes import im, re
-from sympy.functions.elementary.hyperbolic import HyperbolicFunction
-from sympy.functions.elementary.trigonometric import TrigonometricFunction
-
+from sympy.core.function import (Function, Lambda, nfloat)
+from sympy.core.mod import Mod
+from sympy.core.numbers import (E, I, Rational, oo, pi)
+from sympy.core.relational import (Eq, Gt,
+    Ne)
+from sympy.core.singleton import S
+from sympy.core.symbol import (Dummy, Symbol, symbols)
+from sympy.functions.elementary.complexes import (Abs, arg, im, re)
+from sympy.functions.elementary.exponential import (LambertW, exp, log)
+from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
+    atanh, sinh, tanh)
+from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.piecewise import Piecewise
+from sympy.functions.elementary.trigonometric import (
+    TrigonometricFunction, acos, acot, acsc, asec, asin, atan, atan2,
+    cos, cot, csc, sec, sin, tan)
+from sympy.functions.special.error_functions import (erf, erfc,
+    erfcinv, erfinv)
+from sympy.matrices.dense import MutableDenseMatrix as Matrix
+from sympy.polys.polytools import Poly
 from sympy.polys.rootoftools import CRootOf
-
-from sympy.sets import (FiniteSet, ConditionSet, Complement, ImageSet)
+from sympy.sets.conditionset import ConditionSet
+from sympy.sets.fancysets import ImageSet
+from sympy.sets.sets import (Complement, EmptySet, FiniteSet,
+    Intersection, Interval, Union, imageset)
+from sympy.tensor.indexed import Indexed
+from sympy.utilities.iterables import numbered_symbols
 
 from sympy.utilities.pytest import XFAIL, raises, skip, slow, SKIP
 from sympy.utilities.randtest import verify_numerically as tn

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1055,10 +1055,32 @@ def test_linsolve():
     a, b, c, d, e = symbols('a, b, c, d, e')
     Augmatrix = Matrix([[0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, 0]])
     assert linsolve(Augmatrix, a, b, c, d, e) == FiniteSet((a, 0, c, 0, e))
+    raises(IndexError, lambda: linsolve(Augmatrix, a, b, c))
+
+    x0, x1, x2, _x0 = symbols('tau0 tau1 tau2 _tau0')
+    assert linsolve(Matrix([[0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, _x0]])
+        ) == FiniteSet((x0, 0, x1, _x0, x2))
+    x0, x1, x2, _x0 = symbols('_tau0 _tau1 _tau2 tau0')
+    assert linsolve(Matrix([[0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, _x0]])
+        ) == FiniteSet((x0, 0, x1, _x0, x2))
+    x0, x1, x2, _x0 = symbols('_tau0 _tau1 _tau2 tau1')
+    assert linsolve(Matrix([[0, 1, 0, 0, 0, 0], [0, 0, 0, 1, 0, _x0]])
+        ) == FiniteSet((x0, 0, x1, _x0, x2))
+    # symbols can be given as generators
+    x0, x2, x4 = symbols('x0, x2, x4')
+    assert linsolve(Augmatrix, numbered_symbols('x')
+        ) == FiniteSet((x0, 0, x2, 0, x4))
+    Augmatrix[-1, -1] = x0
+    # use Dummy to avoid clash; the names may clash but the symbols
+    # will not
+    Augmatrix[-1, -1] = symbols('_x0')
+    assert len(linsolve(
+        Augmatrix, numbered_symbols('x', cls=Dummy)).free_symbols) == 4
 
     # Issue #12604
     f = Function('f')
     assert linsolve([f(x) - 5], f(x)) == FiniteSet((5,))
+
 
 def test_solve_decomposition():
     x = Symbol('x')

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -235,7 +235,6 @@ class RandomSymbol(Expr):
         return Basic.__new__(cls, symbol, pspace)
 
     is_finite = True
-    is_Symbol = True
     is_symbol = True
     is_Atom = True
 

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -309,11 +309,12 @@ class Indexed(Expr):
     @property
     def free_symbols(self):
         base_free_symbols = self.base.free_symbols
-        indices_free_symbols = {fs for i in self.indices for fs in i.free_symbols}
+        indices_free_symbols = {
+            fs for i in self.indices for fs in i.free_symbols}
         if base_free_symbols:
             return {self} | base_free_symbols | indices_free_symbols
         else:
-            return base_free_symbols | indices_free_symbols
+            return indices_free_symbols
 
 
 class IndexedBase(Expr, NotIterable):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -136,7 +136,6 @@ class Indexed(Expr):
     """
     is_commutative = True
     is_Indexed = True
-    is_Symbol = True
     is_symbol = True
     is_Atom = True
 
@@ -369,7 +368,6 @@ class IndexedBase(Expr, NotIterable):
 
     """
     is_commutative = True
-    is_Symbol = True
     is_symbol = True
     is_Atom = True
 
@@ -560,7 +558,6 @@ class Idx(Expr):
     is_integer = True
     is_finite = True
     is_real = True
-    is_Symbol = True
     is_symbol = True
     is_Atom = True
     _diff_wrt = True


### PR DESCRIPTION
closes #13331 as a replacement, allowing solvers to use a unified system of solving for non-Symbol generators

linsolve now allows symbols to be optional or to be passed as a generator for matrix systems

moved `_uniquely_named_symbol` and `_symbol` to symbols.py and use those in a few places in addition to the use in geometry.

fixes #13341 by removing `is_Symbol` from Indexed and using `is_symbol` in code where `is_Symbol` was used before. 