### PR TITLE
Improve Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -258,19 +258,22 @@ before_install:
 install:
   # If a command fails, fail the build.
   - set -e
-#The install cycle below is to test installation on systems without setuptools.
   - if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ];
       then virtualenv -p /usr/bin/pypy ~/.venv;
            . ~/.venv/bin/activate;
     fi
   # -We:invalid makes invalid escape sequences error in Python 3.6. See
   # -#12028.
-  - if [[ "${TEST_SAGE}" != "true" ]]; then
+  - |
+    if [[ "${TEST_SAGE}" != "true" ]]; then
       pip install mpmath;
-      pip uninstall -y setuptools;
-      python -We:invalid setup.py install;
-      pip uninstall -y sympy;
-      pip install --upgrade setuptools;
+      if [[ "${TEST_SETUP}" == "true" ]]; then
+      # The install cycle below is to test installation on systems without setuptools.
+        pip uninstall -y setuptools;
+        python -We:invalid setup.py install;
+        pip uninstall -y sympy;
+        pip install --upgrade setuptools;
+      fi
       python -We:invalid -m compileall -f sympy/ || (echo "ERROR Invalid escape sequence found. You likely need to use a raw string." && exit 1);
       python -We:invalid setup.py install;
       pip list --format=columns;

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
             - libatlas-base-dev
             - liblapack-dev
             - gfortran
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_ASCII="true"
         - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow"
@@ -47,7 +47,7 @@ matrix:
             - gfortran
             - python-scipy
 
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_SPHINX="true"
         - FASTCACHE="false"
@@ -78,15 +78,15 @@ matrix:
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_SLOW="true"
         - SPLIT="1/3"
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_SLOW="true"
         - SPLIT="2/3"
-    - python: 3.5
+    - python: 3.6
       env:
         - TEST_SLOW="true"
         - SPLIT="3/3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -274,7 +274,7 @@ install:
         pip uninstall -y sympy;
         pip install --upgrade setuptools;
       fi
-      python -We:invalid -m compileall -f sympy/ || (echo "ERROR Invalid escape sequence found. You likely need to use a raw string." && exit 1);
+      python -We:invalid -m compileall -f sympy/;
       python -We:invalid setup.py install;
       pip list --format=columns;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -231,9 +231,9 @@ before_install:
     # We do this conditionally because it saves us some downloading if the
     # version is the same.
         if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-          wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+          wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -q -O miniconda.sh;
         else
-          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -q -O miniconda.sh;
         fi
         bash miniconda.sh -b -p $HOME/miniconda;
         export PATH="$HOME/miniconda/bin:$PATH";

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
         # autowrap installs libgfortran libgcc gcc cython
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.*"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow"
       addons:
         apt:
           packages:
@@ -36,7 +36,7 @@ matrix:
     - python: 3.5
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.*"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow"
       addons:
         apt:
           packages:
@@ -97,9 +97,7 @@ matrix:
       env:
         - TEST_SAGE="true"
         - FASTCACHE="false"
-        - TEST_TENSORFLOW="true"
       sudo: true
-      dist: trusty
 
     - python: "pypy"
       env:
@@ -163,9 +161,7 @@ matrix:
       env:
         - TEST_SAGE="true"
         - FASTCACHE="false"
-        - TEST_TENSORFLOW="true"
       sudo: true
-      dist: trusty
     # PyPy randomly fails because of some PyPy bugs (Fatal RPython error: AssertionError)
     - python: "pypy"
       env:
@@ -250,17 +246,6 @@ before_install:
         source activate test-environment;
     elif [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then
         pip list --format=legacy | grep "numpy" && pip uninstall -y numpy;
-    fi
-  - |
-    if [[ "${TEST_TENSORFLOW}" == "true" ]]; then
-      pip install mpmath;
-      if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp27-none-linux_x86_64.whl;
-      elif [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
-        pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp34-cp34m-linux_x86_64.whl;
-      elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
-        pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.9.0-cp35-cp35m-linux_x86_64.whl;
-      fi
     fi
   - if [[ "${TEST_SAGE}" == "true" ]]; then
       sudo apt-add-repository -y ppa:aims/sagemath;

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -24,6 +24,7 @@ if [[ "${TEST_SAGE}" == "true" ]]; then
     echo "Testing SAGE"
     sage -v
     sage -python bin/test sympy/external/tests/test_sage.py
+    sage -t sympy/external/tests/test_sage.py
 fi
 
 # We change directories to make sure that we test the installed version of

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -24,7 +24,6 @@ if [[ "${TEST_SAGE}" == "true" ]]; then
     echo "Testing SAGE"
     sage -v
     sage -python bin/test sympy/external/tests/test_sage.py
-    ./bin/test -k tensorflow
 fi
 
 # We change directories to make sure that we test the installed version of
@@ -67,6 +66,7 @@ if not sympy.test(split='${SPLIT}', slow=True, verbose=True):
 EOF
 fi
 
+# lambdify with tensorflow is tested here
 if [[ "${TEST_OPT_DEPENDENCY}" == *"numpy"* ]]; then
     cat << EOF | python
 print('Testing NUMPY')

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -33,16 +33,21 @@ mkdir empty
 cd empty
 
 if [[ "${TEST_ASCII}" == "true" ]]; then
-    export OLD_LANG=$LANG
-    export LANG=c
+    export OLD_LC_ALL=$LC_ALL
+    export LC_ALL=C
     cat <<EOF | python
 print('Testing ASCII')
+try:
+    print(u'\u2713')
+except UnicodeEncodeError:
+    pass
+else:
+    raise Exception('Not an ASCII-only environment')
 import sympy
-sympy.test('print')
+if not (sympy.test('print') and sympy.doctest()):
+    raise Exception('Tests failed')
 EOF
-    cd ..
-    bin/doctest
-    export LANG=$OLD_LANG
+    export LC_ALL=$OLD_LC_ALL
 fi
 
 if [[ "${TEST_DOCTESTS}" == "true" ]]; then


### PR DESCRIPTION
* Moved Tensorflow testing to optional dependencies testing and use latest version, as all builds use trusty distribution by https://github.com/sympy/sympy/commit/143c7a5d7ec764523ea0cbba4eb9a93a3a9b81c3, see https://github.com/sympy/sympy/pull/11439#r72668938
* Replaced 3.5 builds—optional dependencies, Sphinx(docs), and slow—with 3.6: Fixes #12814 
* Added quiet flag(`-q`) to `wget Miniconda` to hide the progress bar. (It takes about 1K lines of log and may exceed Travis view log limit)
* Test installation without setuptools only once in TEST_SETUP builds.
* Removed invalid escape error message, as compile can fail from various reasons, e.g., `SyntaxError`.
* Fixed TEST_ASCII:  Fixes #13412.

**Needs decision/Blocked by:**
* Added sage doctest of sympy/external/tests/test_sage.py to TEST_SAGE build, but does not work. Move sage interface into sage and remove `TEST_SAGE`?: #13395, #13430