### PR TITLE
BooleanAtoms behave like Python booleans wrt operations

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -100,21 +100,24 @@ class BooleanAtom(Boolean):
     def _noop(self, other=None):
         raise TypeError('BooleanAtom not allowed in this context.')
 
-    __add__ = _noop
-    __radd__ = _noop
-    __sub__ = _noop
-    __rsub__ = _noop
-    __mul__ = _noop
-    __rmul__ = _noop
-    __pow__ = _noop
-    __rpow__ = _noop
-    __rdiv__ = _noop
-    __truediv__ = _noop
-    __div__ = _noop
-    __rtruediv__ = _noop
-    __mod__ = _noop
-    __rmod__ = _noop
-    _eval_power = _noop
+    def __int__(self):
+        return int(bool(self))
+
+    __add__ = lambda s, o: int(s) + o
+    __radd__ = lambda s, o: o + int(s)
+    __sub__ = lambda s, o: int(s) - o
+    __rsub__ = lambda s, o: o - int(s)
+    __mul__ = lambda s, o: int(s) * o
+    __rmul__ = lambda s, o: o * int(s)
+    __pow__ = lambda s, o: int(s) ** o
+    __rpow__ = lambda s, o: o ** int(s)
+    __div__ = lambda s, o: int(s) / o
+    __rdiv__ = lambda s, o: o / int(s)
+    __mod__ = lambda s, o: int(s) % o
+    __rmod__ = lambda s, o: o % int(s)
+    __neg__ = lambda s: -int(s)
+    __pos__ = lambda s: int(s)
+    __abs__ = lambda s: int(s)
 
 
 class BooleanTrue(with_metaclass(Singleton, BooleanAtom)):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -760,21 +760,27 @@ def test_truth_table():
 def test_issue_8571():
     x = symbols('x')
     for t in (S.true, S.false):
-        raises(TypeError, lambda: +t)
-        raises(TypeError, lambda: -t)
-        raises(TypeError, lambda: abs(t))
-        # use int(bool(t)) to get 0 or 1
-        raises(TypeError, lambda: int(t))
-
+        assert +t == int(t)
+        assert -t == -int(t)
+        assert abs(t) == int(t)
         for o in [S.Zero, S.One, x]:
-            for _ in range(2):
-                raises(TypeError, lambda: o + t)
-                raises(TypeError, lambda: o - t)
-                raises(TypeError, lambda: o % t)
-                raises(TypeError, lambda: o*t)
-                raises(TypeError, lambda: o/t)
-                raises(TypeError, lambda: o**t)
-                o, t = t, o  # do again in reversed order
+                assert o + t == o + int(t)
+                assert o - t == o - int(t)
+                if t:
+                    assert o % t == o % int(t)
+                    assert o / t == o / int(t)
+                    assert o // t == o // int(t)
+                assert o * t == o * int(t)
+                assert o ** t == o ** int(t)
+
+                assert t + o == int(t) + o
+                assert t - o == int(t) - o
+                assert t * o == int(t) * o
+                if o:
+                    assert t % o == int(t) % o
+                    assert t / o == int(t) / o
+                    assert t // o == int(t) // o
+                assert t ** o == int(t) ** o
 
 
 def test_expand_relational():


### PR DESCRIPTION
In issue #8571 we had Booleans showing up in expression where they didn't below, e.g. `x*True` instead of just `x`. The response at that time was to just disable all such operations. In response to #14327, the Booleans no longer show up as True or False but are just converted to 0 and 1 as Python booleans.

Fixes #13427