### PR TITLE
address issues with _commutative_match and _combine_inverse

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -396,13 +396,26 @@ class Add(Expr, AssocOp):
     @staticmethod
     def _combine_inverse(lhs, rhs):
         """
-        Returns lhs - rhs, but treats arguments like symbols, so things like
-        oo - oo return 0, instead of a nan.
+        Returns lhs - rhs, but treats oo like a symbol so oo - oo
+        returns 0, instead of a nan.
         """
-        from sympy import oo, I, expand_mul
-        if lhs == oo and rhs == oo or lhs == oo*I and rhs == oo*I:
-            return S.Zero
-        return expand_mul(lhs - rhs)
+        from sympy.core.function import expand_mul
+        from sympy.core.symbol import Dummy
+        inf = (S.Infinity, S.NegativeInfinity)
+        if lhs.has(*inf) or rhs.has(*inf):
+            oo = Dummy('oo')
+            reps = {
+                S.Infinity: oo,
+                S.NegativeInfinity: -oo}
+            ireps = dict([(v, k) for k, v in reps.items()])
+            eq = expand_mul(lhs.xreplace(reps) - rhs.xreplace(reps))
+            if eq.has(oo):
+                eq = eq.replace(
+                    lambda x: x.is_Pow and x.base == oo,
+                    lambda x: x.base)
+            return eq.xreplace(ireps)
+        else:
+            return expand_mul(lhs - rhs)
 
     @cacheit
     def as_two_terms(self):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -456,17 +456,15 @@ class Function(Application, Expr):
 
         Returns the precision to evalf to, or -1 if it shouldn't evalf.
         """
-        from sympy.core.symbol import Wild
+        from sympy.core.evalf import pure_complex
         if arg.is_Float:
             return arg._prec
         if not arg.is_Add:
             return -1
-        # Don't use as_real_imag() here, that's too much work
-        a, b = Wild('a'), Wild('b')
-        m = arg.match(a + b*S.ImaginaryUnit)
-        if not m or not (m[a].is_Float or m[b].is_Float):
+        m = pure_complex(arg)
+        if m is None or not (m[0].is_Float or m[1].is_Float):
             return -1
-        l = [m[i]._prec for i in m if m[i].is_Float]
+        l = [i._prec for i in m if i.is_Float]
         l.append(-1)
         return max(l)
 

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -396,7 +396,7 @@ def test_match_wild_wild():
     assert p.match(q*r) is None
 
 
-def test_combine_inverse():
+def test__combine_inverse():
     x, y = symbols("x y")
     assert Mul._combine_inverse(x*I*y, x*I) == y
     assert Mul._combine_inverse(x*I*y, y*I) == x
@@ -404,6 +404,9 @@ def test_combine_inverse():
     assert Mul._combine_inverse(oo*I*y, oo*I) == y
     assert Add._combine_inverse(oo, oo) == S(0)
     assert Add._combine_inverse(oo*I, oo*I) == S(0)
+    assert Add._combine_inverse(x*oo, x*oo) == S(0)
+    assert Add._combine_inverse(-x*oo, -x*oo) == S(0)
+    assert Add._combine_inverse((x - oo)*(x + oo), -oo)
 
 
 def test_issue_3773():


### PR DESCRIPTION
fixes #10979 (as best as I can see how); I suspect the slowdown is coming from the `_should_evalf` procedure rather than `count_ops`.