### PR TITLE
treat sympify(C) like NameError

### DIFF
--- a/sympy/deprecated/class_registry.py
+++ b/sympy/deprecated/class_registry.py
@@ -32,9 +32,17 @@ class ClassRegistry(Registry):
         useinstead='direct imports from the defining module',
         issue=9371,
         deprecated_since_version='1.0')
+
     def __getattr__(self, name):
         return any(cls.__name__ == name for cls in all_classes)
 
+    @property
+    def _sympy_(self):
+        # until C is deprecated, any sympification of an expression
+        # with C when C has not been defined can raise this error
+        # since the user is trying to use C like a symbol -- and if
+        # we get here, it hasn't been defined as a symbol
+        raise NameError("name 'C' is not defined as a Symbol")
 
 C = ClassRegistry()
 C.BasicMeta = BasicMeta


### PR DESCRIPTION
C is being deprecated but an odd error is printed when C is the ClassRegistry and it is used in a context where a Symbol is intended. During sympification a TypeError in master is raised:

```
>>> A+C
sympy\core\decorators.py:38: SymPyDeprecationWarning:

C, including its class ClassRegistry, has been deprecated since SymPy
1.0. It will be last supported in SymPy version 1.0. Use direct
imports from the defining module instead. See
https://github.com/sympy/sympy/issues/9371 for more info.

  _warn_deprecation(wrapped, 3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\core\decorators.py", line 91, in __sympifyit_wrapper
    return func(a, b)
  File "sympy\core\decorators.py", line 132, in binary_op_wrapper
    return func(self, other)
  File "sympy\core\expr.py", line 120, in __add__
    return Add(self, other)
  File "sympy\core\cache.py", line 95, in wrapper
    retval = func(*args, **kwargs)
  File "sympy\core\operations.py", line 30, in __new__
    args = list(map(_sympify, args))
  File "sympy\core\sympify.py", line 387, in _sympify
    return sympify(a, strict=True)
  File "sympy\core\sympify.py", line 291, in sympify
    return a._sympy_()
TypeError: 'bool' object is not callable
```

The reason for this is that C supplies any requested attribute as a boolean; in `sympify` the attempt is made to sympify something like `a._sympy_()`. Since C return False and False() raises a TypeError, the above error is produced.  With the modifications of this PR the slightly bent truth will be reported as:

```
>>> A + C
sympy\core\decorators.py:38: SymPyDeprecationWarning:

C, including its class ClassRegistry, has been deprecated since SymP
1.0. It will be last supported in SymPy version 1.0. Use direct
imports from the defining module instead. See
https://github.com/sympy/sympy/issues/9371 for more info.

  _warn_deprecation(wrapped, 3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\core\decorators.py", line 91, in __sympifyit_wrapper
    return func(a, b)
  File "sympy\core\decorators.py", line 132, in binary_op_wrapper
    return func(self, other)
  File "sympy\core\expr.py", line 120, in __add__
    return Add(self, other)
  File "sympy\core\cache.py", line 93, in wrapper
    retval = cfunc(*args, **kwargs)
  File "sympy\core\compatibility.py", line 809, in wrapper
    result = user_function(*args, **kwds)
  File "sympy\core\operations.py", line 30, in __new__
    args = list(map(_sympify, args))
  File "sympy\core\sympify.py", line 387, in _sympify
    return sympify(a, strict=True)
  File "sympy\core\sympify.py", line 291, in sympify
    return a._sympy_()
  File "sympy\deprecated\class_registry.py", line 41, in _sympy_

NameError: name 'C' is not defined as a Symbol
```