### PR TITLE
hyperexpand: evaluate formula as limit when it yields NaN

### DIFF
--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -79,7 +79,7 @@ from sympy.simplify import simplify
 from sympy.functions.elementary.complexes import polarify, unpolarify
 from sympy.simplify.powsimp import powdenest
 from sympy.polys import poly, Poly
-from sympy.series import residue
+from sympy.series import residue, limit
 
 # function to define "buckets"
 def _mod1(x):
@@ -1971,6 +1971,12 @@ def _hyperexpand(func, z, ops0=[], z0=Dummy('z0'), premult=1, prem=0,
         res = r[0].subs(z0, z)
         if rewrite:
             res = res.rewrite(rewrite)
+        if res is S.NaN:
+            # Can happen when the formula results in an indeterminate form like (log(0) - log(0)),
+            # which often happens when |z| == 1
+            # Try taking it as a limit
+            res = r[0].rewrite('nonrepsmall')
+            res = limit(res.subs(z0, unpolarify(z)*z0), z0, 1, dir='-')
         return res
 
     # TODO


### PR DESCRIPTION
Specifically, take the limit if evaluation results in `NaN`, which can happen when the formula results in an indeterminate form like `(log(0) - log(0))`, which often happens when `|z| == 1`. This is because many of the formulas used (if you look at their source, `Luke, Y. L. (1969), The Special Functions and Their Approximations Volume 1, section 6.2`) come with the condition that `|z| < 1`

I don't think this will lead to any invalid results, but I'm not very familiar with the hyper-geometric function.

Fixes #13133, but at the moment it returns an unevaluated limit because of an issue where limits can't deal with inverse hyperbolic functions, even though they can evaluate it if the functions are rewritten in terms of logs. This is an issue with limits that I'll open shortly.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
