### PR TITLE
make factor tail recursive for MatrixSymbol

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -14,6 +14,8 @@ from sympy.core.sympify import sympify
 from sympy.core.decorators import _sympifyit
 from sympy.core.function import Derivative
 
+from sympy.core.compatibility import string_types
+
 from sympy.logic.boolalg import BooleanAtom
 
 from sympy.polys.polyclasses import DMP
@@ -5924,7 +5926,7 @@ def _symbolic_factor(expr, opt, method):
         coeff, factors = _symbolic_factor_list(together(expr), opt, method)
         return _keep_coeff(coeff, _factors_product(factors))
     elif hasattr(expr, 'args'):
-        return expr.func(*[_symbolic_factor(arg, opt, method) for arg in expr.args])
+        return expr.func(*[_symbolic_factor(arg, opt, method) if not isinstance(arg, string_types) else arg for arg in expr.args])
     elif hasattr(expr, '__iter__'):
         return expr.__class__([_symbolic_factor(arg, opt, method) for arg in expr])
     else:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -675,6 +675,11 @@ def test_issue_9324_simplify():
     e = M[0, 0] + M[5, 4] + 1304
     assert simplify(e) == e
 
+def test_MatrixSymbol_factor():
+    n, m = symbols('n m')
+    A = MatrixSymbol('A', n, m)
+    assert factor(A) == A
+
 
 def test_simplify_function_inverse():
     x, y = symbols('x, y')


### PR DESCRIPTION
following example was failed
```python

  n,m = symbols('n m')
  A = MatrixSymbol('A', n, m)
  A = factor(A)

```
with max recorsion for

```bash

File"/usr/local/lib/python3.5/dist-packages/sympy/polys/polytools.py",line
5808, in _symbolic_factor
if isinstance(expr, Expr) and not expr.is_Relational:

```

tested with python3.5

