### PR TITLE
Closes #12564. Can't solve limit(x**2 + x*sin(x) + cos(x), x, -oo).

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -12,6 +12,7 @@ from .gruntz import gruntz
 from sympy.core.exprtools import factor_terms
 from sympy.simplify.ratsimp import ratsimp
 from sympy.polys import PolynomialError, factor
+from sympy.simplify.simplify import together
 
 def limit(e, z, z0, dir="+"):
     """
@@ -62,7 +63,9 @@ def heuristics(e, z, z0, dir):
             if l.has(S.Infinity) and l.is_finite is None:
                 if isinstance(e, Add):
                     m = factor_terms(e)
-                    if not isinstance(m, Mul): # try factor if factor_terms fails
+                    if not isinstance(m, Mul): # try together
+                        m = together(m)
+                    if not isinstance(m, Mul): # try factor if the previous methods failed
                         m = factor(e)
                     if isinstance(m, Mul):
                         return heuristics(m, z, z0, dir)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -11,7 +11,7 @@ from sympy.series.order import Order
 from .gruntz import gruntz
 from sympy.core.exprtools import factor_terms
 from sympy.simplify.ratsimp import ratsimp
-from sympy.polys import PolynomialError
+from sympy.polys import PolynomialError, factor
 
 def limit(e, z, z0, dir="+"):
     """
@@ -60,6 +60,13 @@ def heuristics(e, z, z0, dir):
         for a in e.args:
             l = limit(a, z, z0, dir)
             if l.has(S.Infinity) and l.is_finite is None:
+                if isinstance(e, Add):
+                    m = factor_terms(e)
+                    if not isinstance(m, Mul): # try factor if factor_terms fails
+                        m = factor(e)
+                    if isinstance(m, Mul):
+                        return heuristics(m, z, z0, dir)
+                    return
                 return
             elif isinstance(l, Limit):
                 return

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -505,3 +505,7 @@ def test_issue_6599():
 def test_issue_12555():
     assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, -oo) == 2
     assert limit((3**x + 2* x**10) / (x**10 + exp(x)), x, oo) == oo
+
+def test_issue_12564():
+    assert limit(x**2 + x*sin(x) + cos(x), x, -oo) == oo
+    assert limit(x**2 + x*sin(x) + cos(x), x, oo) == oo

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -509,3 +509,7 @@ def test_issue_12555():
 def test_issue_12564():
     assert limit(x**2 + x*sin(x) + cos(x), x, -oo) == oo
     assert limit(x**2 + x*sin(x) + cos(x), x, oo) == oo
+    assert limit(((x + cos(x))**2).expand(), x, oo) == oo
+    assert limit(((x + sin(x))**2).expand(), x, oo) == oo
+    assert limit(((x + cos(x))**2).expand(), x, -oo) == oo
+    assert limit(((x + sin(x))**2).expand(), x, -oo) == oo


### PR DESCRIPTION
In some situation, for example if `expr = x**2 + x*sin(x)`, `limit(expr, x, oo)` fails
since `heuristics()` in `limits.py` calculates the limit of `x**2` and `x*sin(x)` separately.
The second one returns all the real line as limit points.
If such happens, then the procedure stops.
Instead, if `expr = x * (x + sin(x))`, then sympy gives the correct answer.
Therefore some lines to `limits.py` are added in order to check whether
`factor_terms(expr)` or `factor(expr)` can help in solving the limit.

`factor(expr)` is more expensive than `factor_terms(expr)`. Hence we inserted some conditional
in order to prevent, if possible, the use of `factor(expr)`.

Moreover, two tests are  added.

This PR is a duplicate of PR #12607. This in order to make more clear the changes done in such PR, as suggested by a comment. 

Closes #12607 

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
