### PR TITLE
Changes to `solve_univariate_inequality` for finite set domains

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -7,7 +7,7 @@ from sympy.core.compatibility import iterable
 from sympy.core.exprtools import factor_terms
 from sympy.core.relational import Relational, Eq, Ge, Lt, Ne
 from sympy.sets import Interval
-from sympy.sets.sets import FiniteSet, Union, EmptySet
+from sympy.sets.sets import FiniteSet, Union, EmptySet, Intersection
 from sympy.sets.fancysets import ImageSet
 from sympy.core.singleton import S
 from sympy.core.function import expand_mul
@@ -451,6 +451,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     # `solveset` makes sure this function is called only when the domain is
     # real.
     _gen = gen
+    _domain = domain
     if gen.is_real is False:
         rv = S.EmptySet
         return rv if not relational else rv.as_relational(_gen)
@@ -649,9 +650,10 @@ satisfying the inequality, leading to relations like I < 0.
                 sol_sets.append(Interval.open(start, end))
 
             if im(expanded_e) != S.Zero and check:
-                rv = (make_real)
+                rv = (make_real).intersect(_domain)
             else:
-                rv = (Union(*sol_sets)).intersect(make_real).subs(gen, _gen)
+                rv = Intersection(
+                    (Union(*sol_sets)), make_real, _domain).subs(gen, _gen)
 
     return rv if not relational else rv.as_relational(_gen)
 

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -268,6 +268,8 @@ def test_solve_univariate_inequality():
         Union(Interval(1, 2), Interval(3, oo))
     assert isolve((x - 1)*(x - 2)*(x - 3) >= 0, x) == \
         Or(And(Le(1, x), Le(x, 2)), And(Le(3, x), Lt(x, oo)))
+    assert isolve((x - 1)*(x - 2)*(x - 4) < 0, x, domain = FiniteSet(0, 3)) == \
+        Or(Eq(x, 0), Eq(x, 3))
     # issue 2785:
     assert isolve(x**3 - 2*x - 1 > 0, x, relational=False) == \
         Union(Interval(-1, -sqrt(5)/2 + S(1)/2, True, True),


### PR DESCRIPTION
Solve_univariate_inequality previously returned incorrect results if the
domain specified was an instance of `FiniteSet`. This commit fixes this issue.
Tests were added.

Example(Before fix):

>>> x = Symbol('x')
>>> solve_univariate_inequality(x < 2, x, domain = FiniteSet(1, 2))
(1 <= x) & (x < 2)

Example(After fix):

>>> x = Symbol('x')
>>> solve_univariate_inequality(x < 2, x, domain = FiniteSet(1, 2))
Eq(x, 1)

To do before commiting this PR:
- [x] Review and commit #13479  
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
