### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+## Contributing
+
+We welcome contributions from anyone, even if you are new to open
+source. Please read our [introduction to contributing](
+https://github.com/sympy/sympy/wiki/Introduction-to-contributing). If you are new and
+looking for some way to contribute a good place to start is to look at the
+issues tagged [Easy to Fix](
+https://github.com/sympy/sympy/issues?q=is%3Aopen+is%3Aissue+label%3A%22Easy+to+Fix%22).
+
+Please note that all participants of this project are expected to follow our
+Code of Conduct. By participating in this project you agree to abide by its
+terms. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Added CONTRIBUTING.md, excerpted from README.rst.

GitHub shows a link to it, like CODE_OF_CONDUCT.md, at the top of issues/PR page for first-time contributors and when submitting new issue/PR.

![issue](https://user-images.githubusercontent.com/888148/31647431-1e4a5954-b343-11e7-81e1-1e9d4ce5d1c6.png)
![pr](https://user-images.githubusercontent.com/888148/31647433-1ee12e9c-b343-11e7-8999-e2fd8821c6b9.png)
![new](https://user-images.githubusercontent.com/888148/31647432-1e927644-b343-11e7-8d84-d8473548df9f.png)
