### PR TITLE
Fix python2->3 pickle bug for exprs with floats

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1042,6 +1042,10 @@ class Float(Number):
                 # it's a hexadecimal (coming from a pickled object)
                 # assume that it is in standard form
                 num = list(num)
+                # long uses a shim for int on Python 3, so we need to
+                # remove any trailing 'L' on the num[1] string
+                if num[1].endswith('L'):
+                    num[1] = num[1][:-1]
                 num[1] = long(num[1], 16)
                 _mpf_ = tuple(num)
             else:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1042,8 +1042,9 @@ class Float(Number):
                 # it's a hexadecimal (coming from a pickled object)
                 # assume that it is in standard form
                 num = list(num)
-                # long uses a shim for int on Python 3, so we need to
-                # remove any trailing 'L' on the num[1] string
+                # If we're loading an object pickled in Python 2 into
+                # Python 3, we may need to strip a tailing 'L' because
+                # of a shim for int on Python 3, see issue #13470.
                 if num[1].endswith('L'):
                     num[1] = num[1][:-1]
                 num[1] = long(num[1], 16)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -582,6 +582,12 @@ def test_Float_issue_2107():
     assert S.Zero + b + (-b) == 0
 
 
+def test_Float_from_tuple():
+    a = Float((0, '1L', 0, 1))
+    b = Float((0, '1', 0, 1))
+    assert a == b
+
+
 def test_Infinity():
     assert oo != 1
     assert 1*oo == oo


### PR DESCRIPTION
Dumping a pickled sympy expression containing a float in Python 2,
then loading it in Python 3 generates an error. This is due to
sympy's compatibility shim for `long` on Python 3 using `int`, which
doesn't support the "L" suffix when converting from a string. This
commit removes that suffix if present.

Fixes #13470