### PR TITLE
Enable verbose output on Travis, show disabled/blacklisted (doc)tests

### DIFF
--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -56,7 +56,7 @@ if [[ "${TEST_DOCTESTS}" == "true" ]]; then
     cat << EOF | python -We:invalid
 print('Testing DOCTESTS')
 import sympy
-if not sympy.doctest():
+if not sympy.doctest(verbose=True):
     raise Exception('Tests failed')
 EOF
     cd ..
@@ -81,8 +81,9 @@ if not (sympy.test('*numpy*', 'sympy/core/tests/test_numbers.py',
                    'sympy/matrices/', 'sympy/physics/quantum/',
                    'sympy/core/tests/test_sympify.py',
                    'sympy/utilities/tests/test_lambdify.py',
-                   blacklist=['sympy/physics/quantum/tests/test_circuitplot.py'])
-        and sympy.doctest('sympy/matrices/', 'sympy/utilities/lambdify.py')):
+                   blacklist=['sympy/physics/quantum/tests/test_circuitplot.py'],
+                   verbose=True)
+        and sympy.doctest('sympy/matrices/', 'sympy/utilities/lambdify.py', verbose=True)):
     raise Exception('Tests failed')
 EOF
 fi
@@ -92,7 +93,7 @@ if [[ "${TEST_OPT_DEPENDENCY}" == *"scipy"* ]]; then
 print('Testing SCIPY')
 import sympy
 # scipy matrices are tested in numpy testing
-if not sympy.test('sympy/external/tests/test_scipy.py'):
+if not sympy.test('sympy/external/tests/test_scipy.py', verbose=True):
     raise Exception('Tests failed')
 EOF
 fi
@@ -101,8 +102,8 @@ if [[ "${TEST_OPT_DEPENDENCY}" == *"llvmlite"* ]]; then
     cat << EOF | python
 print('Testing LLVMJIT')
 import sympy
-if not (sympy.test('sympy/printing/tests/test_llvmjit.py')
-        and sympy.doctest('sympy/printing/llvmjitcode.py')):
+if not (sympy.test('sympy/printing/tests/test_llvmjit.py', verbose=True)
+        and sympy.doctest('sympy/printing/llvmjitcode.py', verbose=True)):
     raise Exception('Tests failed')
 EOF
 fi
@@ -111,7 +112,7 @@ if [[ "${TEST_OPT_DEPENDENCY}" == *"theano"* ]]; then
     cat << EOF | python
 print('Testing THEANO')
 import sympy
-if not sympy.test('*theano*'):
+if not sympy.test('*theano*', verbose=True):
     raise Exception('Tests failed')
 EOF
 fi
@@ -120,7 +121,7 @@ if [[ "${TEST_OPT_DEPENDENCY}" == *"gmpy"* ]]; then
     cat << EOF | python
 print('Testing GMPY')
 import sympy
-if not (sympy.test('sympy/polys/') and sympy.doctest('sympy/polys/')):
+if not (sympy.test('sympy/polys/', verbose=True) and sympy.doctest('sympy/polys/', verbose=True)):
     raise Exception('Tests failed')
 EOF
 fi
@@ -137,7 +138,7 @@ import sympy
 # Unfortunately, we have to use subprocess=False so that the above will be
 # applied, so no hash randomization here.
 if not (sympy.test('sympy/plotting', 'sympy/physics/quantum/tests/test_circuitplot.py',
-    subprocess=False) and sympy.doctest('sympy/plotting', subprocess=False)):
+    subprocess=False, verbose=True) and sympy.doctest('sympy/plotting', subprocess=False, verbose=True)):
     raise Exception('Tests failed')
 EOF
 fi
@@ -146,8 +147,8 @@ if [[ "${TEST_OPT_DEPENDENCY}" == *"autowrap"* ]]; then
     cat << EOF | python
 print('Testing AUTOWRAP')
 import sympy
-if not (sympy.test('sympy/external/tests/test_autowrap.py')
-        and sympy.doctest('sympy/utilities/autowrap.py')):
+if not (sympy.test('sympy/external/tests/test_autowrap.py', verbose=True)
+        and sympy.doctest('sympy/utilities/autowrap.py', verbose=True)):
     raise Exception('Tests failed')
 EOF
 fi
@@ -158,7 +159,7 @@ if [[ "${TEST_SYMPY}" == "true" ]]; then
     cat << EOF | python -We:invalid
 print('Testing SYMPY, split ${SPLIT}')
 import sympy
-if not sympy.test(split='${SPLIT}'):
+if not sympy.test(split='${SPLIT}', verbose=True):
    raise Exception('Tests failed')
 EOF
 fi
@@ -169,9 +170,9 @@ if [[ "${TEST_OPT_DEPENDENCY}" == *"symengine"* ]]; then
     cat << EOF | python
 print('Testing SYMENGINE')
 import sympy
-if not sympy.test('sympy/physics/mechanics'):
+if not sympy.test('sympy/physics/mechanics', verbose=True):
     raise Exception('Tests failed')
-if not sympy.test('sympy/liealgebras'):
+if not sympy.test('sympy/liealgebras', verbose=True):
     raise Exception('Tests failed')
 EOF
     unset USE_SYMENGINE

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -33,7 +33,7 @@ import signal
 import stat
 
 from sympy.core.cache import clear_cache
-from sympy.core.compatibility import exec_, PY3, string_types, range
+from sympy.core.compatibility import exec_, PY3, string_types, range, iterable
 from sympy.utilities.misc import find_executable
 from sympy.external import import_module
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -1454,6 +1454,8 @@ class SymPyDocTests(object):
                 if found is None:
                     return "Could not find %s" % ex
         if moduledeps is not None:
+            if not iterable(moduledeps):
+                moduledeps = [moduledeps]
             for extmod in moduledeps:
                 if extmod == 'matplotlib':
                     matplotlib = import_module(

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1200,6 +1200,8 @@ class SymPyTests(object):
                         i += 1
                 # drop functions that are not selected with the keyword expression:
                 funcs = [x for x in funcs if self.matches(x)]
+            else:
+                reporter.disabled_tests.append(filename)
 
             if not funcs:
                 return
@@ -1918,6 +1920,7 @@ class PyTestReporter(Reporter):
         self._split = split
 
         # TODO: Should these be protected?
+        self.disabled_tests = []
         self.slow_test_functions = []
         self.fast_test_functions = []
 
@@ -2191,6 +2194,12 @@ class PyTestReporter(Reporter):
             self.write_center("xpassed tests", "_")
             for e in self._xpassed:
                 self.write("%s: %s\n" % (e[0], e[1]))
+            self.write("\n")
+
+        if self.disabled_tests:
+            self.write_center('disabled tests', '_')
+            for disabled_file_name in self.disabled_tests:
+                print('%s' % disabled_file_name)
             self.write("\n")
 
         if self._tb_style != "no" and len(self._exceptions) > 0:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -838,6 +838,13 @@ def _doctest(*paths, **kwargs):
                 [test_file, ' '*(wid - len(test_file) - len(report)), report])
             )
 
+    if blacklist:
+        r.write("\n")
+        r.write_center('blacklisted tests', '_')
+        for blacklisted_file_name in blacklist:
+            print('%s' % blacklisted_file_name)
+        r.write("\n")
+
     # the doctests for *py will have printed this message already if there was
     # a failure, so now only print it if there was intervening reporting by
     # testing the *rst as evidenced by first_report no longer being True.


### PR DESCRIPTION
Enabled verbose output on Travis and made show disabled tests and blacklisted doctests at the end, to find missed tests like #13483.

Not necessarily for merge.