### PR TITLE
Corrected is_tangent in ellipse.py

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -711,7 +711,7 @@ class Ellipse(GeometrySet):
         elif isinstance(o, Ray2D):
             intersect = self.intersection(o)
             if len(intersect) == 1:
-                return intersect[0] != o.source and not self.encloses_point(o.source)
+                return o in self.tangent_lines(intersect[0])[0]
             else:
                 return False
         elif isinstance(o, (Segment2D, Polygon)):
@@ -719,15 +719,16 @@ class Ellipse(GeometrySet):
             segments = o.sides if isinstance(o, Polygon) else [o]
             for segment in segments:
                 intersect = self.intersection(segment)
-                if len(intersect) == 1:
-                    if not any(intersect[0] in i for i in segment.points)\
-                                   and all(not self.encloses_point(i) for i in segment.points):
-                        all_tangents = True
-                        continue
+                if intersect:
+                    if len(intersect) == 1:
+                        if segment in self.tangent_lines(intersect[0])[0]:
+                            all_tangents = True
+                        else:
+                            return False
                     else:
                         return False
                 else:
-                    return all_tangents
+                    continue
             return all_tangents
         elif isinstance(o, (LinearEntity3D, Point3D)):
             raise TypeError('Entity must be two dimensional, not three dimensional')

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -694,6 +694,11 @@ class Ellipse(GeometrySet):
         >>> l1 = Line(p1, p2)
         >>> e1.is_tangent(l1)
         True
+        
+        References
+        ==========
+
+        [1] http://jwilson.coe.uga.edu/emt669/student.folders/banker.teresa/unitstdy/unitstdy.html
 
         """
         if isinstance(o, Point2D):

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -362,6 +362,7 @@ def test_is_tangent():
     assert c1.is_tangent(Ray((-3, -2), (-15, -20))) is False
     assert c1.is_tangent(Ray((-3, -22), (15, 20))) is False
     assert c1.is_tangent(Ray((9, 20), (9, -20))) is True
+    assert c1.is_tangent(Ray((2, 5), (9, 5))) is True
     assert e1.is_tangent(Segment((2, 2), (-7, 7))) is False
     assert e1.is_tangent(Segment((0, 0), (1, 2))) is False
     assert c1.is_tangent(Segment((0, 0), (-5, -2))) is False
@@ -378,6 +379,7 @@ def test_is_tangent():
     assert e1.is_tangent(Polygon((-3, 0), (3, 0), (0, 5))) is False
     assert e1.is_tangent(Polygon((-3, 0), (0, -5), (3, 0), (0, 5))) is False
     assert e1.is_tangent(Polygon((-3, -5), (-3, 5), (3, 5), (3, -5))) is True
+    assert e1.is_tangent(Polygon((3, 5), (3, -5), (-3, -5), (-3, 5))) is True
     assert c1.is_tangent(Polygon((-3, -5), (-3, 5), (3, 5), (3, -5))) is False
     assert e1.is_tangent(Polygon((0, 0), (3, 0), (7, 7), (0, 5))) is False
     assert e1.is_tangent(Polygon((3, 12), (3, -12), (6, 5))) is True


### PR DESCRIPTION
What's Wrong: #19471
```python
>>> from sympy import *
>>> c = Circle(Point(0,0),2)
>>> poly1 = Polygon((-2,-2),(-2,2),(2,2),(3,0),(2,-2))
>>> c.is_tangent(poly1)
True
>>> poly2 = Polygon((2,2),(3,0),(2,-2),(-2,-2),(-2,2))
>>> c.is_tangent(poly2)
False
>>> r = Ray(Point(0,2),Point(2,2))
>>> c.is_tangent(r)
False
```

notice that poly1 and poly2 are giving different results,
but are same polygon except there starting points are different.
Further, in my opinion( I found very less on this topic on internet but by definition in google),  tangent is a straight line or plane that touches a curve or curved surface at a point, but if EXTENDED does not cross it at that point.
the ray,r touches the circle,c at r.source but when extended does not cross circle,c at any point. by this definition r is a tangent to circle c.

Changes I made:
change 1-
Line Number:720-730
       if one or more sides of polygon are tangent to ellipse and other does not touch it, polygon is a tangent
      

change 2-
Line Number: 714
       original content : 
                return intersect[0] != o.source and not self.encloses_point(o.source)
       my change:
                return o in self.tangent_lines(intersect[0])[0]
