### PR TITLE
Update and remove redundant Python <= 2.6, 3.0-3.3 code

### DIFF
--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -10,7 +10,7 @@ mpmath, as well as several other useful libraries.  Alternatively, executables
 are available for Windows, and some Linux distributions have SymPy packages
 available.
 
-SymPy officially supports Python 2.7, 3.3, 3.4, 3.5, and PyPy.
+SymPy officially supports Python 2.7, 3.4, 3.5, 3.6 and PyPy.
 
 Anaconda
 ========

--- a/isympy.py
+++ b/isympy.py
@@ -183,8 +183,7 @@ def main():
     if '-h' in sys.argv or '--help' in sys.argv:
         # XXX: We can't use description=__doc__  in the OptionParser call
         # below because optparse line wraps it weird.  The argparse module
-        # allows you to disable this, though, but it's only available in
-        # Python 2.7+.
+        # allows you to disable this, though.
         print(__doc__)  # the docstring of this module above
 
     VERSION = None

--- a/release/rever.xsh
+++ b/release/rever.xsh
@@ -37,7 +37,6 @@ $ACTIVITIES = [
     'copy_release_files',
     'compare_tar_against_git',
     'test_tarball27',
-    'test_tarball33',
     'test_tarball34',
     'test_tarball35',
     'test_tarball36',
@@ -114,10 +113,6 @@ def copy_release_files():
 @activity(deps={'source_tarball'})
 def test_tarball27():
     test_tarball('2.7')
-
-@activity(deps={'source_tarball'})
-def test_tarball33():
-    test_tarball('3.3')
 
 @activity(deps={'source_tarball'})
 def test_tarball34():
@@ -218,7 +213,7 @@ def _md5(print_=True, local=False):
         print(out)
     return out
 
-@activity(deps={'mailmap_update', 'md5', 'print_authors', 'source_tarball', 'build_docs', 'compare_tar_against_git', 'test_tarball27', 'test_tarball33', 'test_tarball34', 'test_tarball35', 'test_tarball36', 'test_sympy'})
+@activity(deps={'mailmap_update', 'md5', 'print_authors', 'source_tarball', 'build_docs', 'compare_tar_against_git', 'test_tarball27', 'test_tarball34', 'test_tarball35', 'test_tarball36', 'test_sympy'})
 def release():
     pass
 
@@ -252,8 +247,8 @@ def test_tarball(py_version):
     Test that the tarball can be unpacked and installed, and that sympy
     imports in the install.
     """
-    if py_version not in {'2.7', '3.3', '3.4', '3.5', '3.6'}: # TODO: Add win32
-        raise ValueError("release must be one of 2.7, 3.3, 3.4, 3.5, or 3.6 not %s" % py_version)
+    if py_version not in {'2.7', '3.4', '3.5', '3.6'}: # TODO: Add win32
+        raise ValueError("release must be one of 2.7, 3.4, 3.5, or 3.6 not %s" % py_version)
 
 
     with run_in_conda_env(['python=%s' % py_version], 'test-install-%s' % py_version):

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,9 @@ except ImportError:
 PY3 = sys.version_info[0] > 2
 
 # Make sure I have the right Python version.
-if sys.version_info[:2] < (2, 7):
-    print("SymPy requires Python 2.7 or newer. Python %d.%d detected"
+if ((sys.version_info[0] == 2 and sys.version_info[1] < 7) or
+    (sys.version_info[0] == 3 and sys.version_info[1] < 4)):
+    print("SymPy requires Python 2.7 or 3.4 or newer. Python %d.%d detected"
           % sys.version_info[:2])
     sys.exit(-1)
 
@@ -377,11 +378,11 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.2',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: Implementation :: CPython',
+            'Programming Language :: Python :: Implementation :: PyPy',
             ],
           install_requires=['mpmath>=%s' % mpmath_version],
           **extra_kwargs

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -35,11 +35,10 @@ if 'dev' in __version__:
 
 
 import sys
-if sys.version_info[0] == 2 and sys.version_info[1] < 6:
-    raise ImportError("Python Version 2.6 or above is required for SymPy.")
-else:  # Python 3
-    pass
-    # Here we can also check for specific Python 3 versions, if needed
+if ((sys.version_info[0] == 2 and sys.version_info[1] < 7) or
+    (sys.version_info[0] == 3 and sys.version_info[1] < 4)):
+    raise ImportError("Python version 2.7 or 3.4 or above "
+                      "is required for SymPy.")
 
 del sys
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -294,11 +294,12 @@ def is_sequence(i, include=None):
 
 try:
     from itertools import zip_longest
-except ImportError: # <= Python 2.7
+except ImportError:  # Python 2.7
     from itertools import izip_longest as zip_longest
 
 
 try:
+    # Python 2.7
     from string import maketrans
 except ImportError:
     maketrans = str.maketrans
@@ -684,7 +685,7 @@ if GROUND_TYPES == 'gmpy':
     SYMPY_INTS += (type(gmpy.mpz(0)),)
 
 
-# lru_cache compatible with py2.6->py3.2 copied directly from
+# lru_cache compatible with py2.7 copied directly from
 #   http://code.activestate.com/
 #   recipes/578078-py26-and-py30-backport-of-python-33s-lru-cache/
 from collections import namedtuple
@@ -863,6 +864,6 @@ if sys.version_info[:2] >= (3, 3):
 
 try:
     from itertools import filterfalse
-except ImportError:
+except ImportError:  # Python 2.7
     def filterfalse(pred, itr):
         return filter(lambda x: not pred(x), itr)

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -106,10 +106,9 @@ def test_subs():
     assert b21.subs([(b2, b1), (b1, b2)]) == Basic(b2, b2)
 
     assert b21.subs({b1: b2, b2: b1}) == Basic(b2, b2)
-    if sys.version_info >= (3, 3):
+    if sys.version_info >= (3, 4):
         assert b21.subs(collections.ChainMap({b1: b2}, {b2: b1})) == Basic(b2, b2)
-    if sys.version_info >= (2, 7):
-        assert b21.subs(collections.OrderedDict([(b2, b1), (b1, b2)])) == Basic(b2, b2)
+    assert b21.subs(collections.OrderedDict([(b2, b1), (b1, b2)])) == Basic(b2, b2)
 
     raises(ValueError, lambda: b21.subs('bad arg'))
     raises(ValueError, lambda: b21.subs(b1, b2, b3))

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -41,9 +41,7 @@ def check(a, exclude=[], check_attr=True):
     protocols = [0, 1, 2, copy.copy, copy.deepcopy]
     # Python 2.x doesn't support the third pickling protocol
     if sys.version_info >= (3,):
-        protocols.extend([3])
-    if sys.version_info >= (3, 4):
-        protocols.extend([4])
+        protocols.extend([3, 4])
     if cloudpickle:
         protocols.extend([cloudpickle])
 
@@ -169,9 +167,7 @@ def test_core_multidimensional():
 def test_Singletons():
     protocols = [0, 1, 2]
     if sys.version_info >= (3,):
-        protocols.extend([3])
-    if sys.version_info >= (3, 4):
-        protocols.extend([4])
+        protocols.extend([3, 4])
     copiers = [copy.copy, copy.deepcopy]
     copiers += [lambda x: pickle.loads(pickle.dumps(x, proto))
             for proto in protocols]


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->

EOL Python 2.6 and 3.0-3.3 have already been dropped (eg. https://github.com/sympy/sympy/issues/10463, https://github.com/sympy/sympy/pull/10778, https://github.com/sympy/sympy/pull/12923, https://github.com/sympy/sympy/pull/13248).

Here's some extra version updates and cleanup to remove redundant code for those old versions.

