### PR TITLE
Add AppVeyor Windows 32/64-bit optional dependencies testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+environment:
+  matrix:
+    # http://www.appveyor.com/docs/installed-software#python
+    # TEST_OPT_DEPENDENCY: space separated list of optional dependencies(conda packages)
+    # to install and test, theano installs mkl-service libpython m2w64-toolchain theano
+
+    - MINICONDA: "C:\\Miniconda"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+      TEST_OPT_DEPENDENCY: "numpy scipy gmpy2 matplotlib theano llvmlite numexpr ipython"
+
+    - MINICONDA: "C:\\Miniconda-x64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+      TEST_OPT_DEPENDENCY: "numpy scipy gmpy2 matplotlib theano llvmlite numexpr ipython"
+
+    - MINICONDA: "C:\\Miniconda36"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+      TEST_OPT_DEPENDENCY: "numpy scipy gmpy2 matplotlib theano llvmlite numexpr ipython python-symengine=0.3.*"
+
+    - MINICONDA: "C:\\Miniconda36-x64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      TEST_OPT_DEPENDENCY: "numpy scipy gmpy2 matplotlib theano llvmlite numexpr ipython python-symengine=0.3.* tensorflow"
+
+install:
+  - SET PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%
+  - SET TEST_OPT_DEPENDENCY=%TEST_OPT_DEPENDENCY:theano=mkl-service libpython m2w64-toolchain theano%
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda config --prepend channels conda-forge --prepend channels symengine/label/dev
+  - conda info -a
+  # gmpy2 for Windows Python 2.7 is not available on Anaconda and the packages on PyPI
+  # needs compilation, so use precompiled binaries.
+  - IF "%PYTHON_VERSION%" == "2.7" (
+      conda create -q -n test-environment python=%PYTHON_VERSION% pip fastcache mpmath %TEST_OPT_DEPENDENCY:gmpy2=%
+    ) ELSE (
+      conda create -q -n test-environment python=%PYTHON_VERSION% pip fastcache mpmath %TEST_OPT_DEPENDENCY%
+    )
+  - activate test-environment
+  - IF "%PYTHON_VERSION%" == "2.7" IF NOT "%TEST_OPT_DEPENDENCY:gmpy2=%" == "%TEST_OPT_DEPENDENCY%" (
+      IF "%PYTHON_ARCH%" == "32" (
+        pip install https://github.com/ylemkimon/gmpy/raw/master/gmpy2-2.0.8-cp27-cp27m-win32.whl
+      ) ELSE (
+        pip install https://github.com/ylemkimon/gmpy/raw/master/gmpy2-2.0.8-cp27-cp27m-win_amd64.whl
+      )
+    )
+
+build_script:
+  - python setup.py install
+
+test_script:
+  - ps: "& bin\\test_appveyor.ps1"

--- a/bin/test_appveyor.ps1
+++ b/bin/test_appveyor.ps1
@@ -1,0 +1,113 @@
+function StartTest($name) {
+    Add-AppveyorTest -Name "$name Test" -Outcome Running
+    Write-Output "Testing $name"
+}
+
+function EndTest($name) {
+    If ($output | Select-String -Pattern "Exception: Tests failed") {
+        Update-AppveyorTest -Name "$name Test" -Outcome Failed -StdOut $output
+        # Uncomment this to fail the build when test fails
+        # throw "$name test failed!"
+    } Else {
+        Update-AppveyorTest -Name "$name Test" -Outcome Passed -StdOut $output
+    }
+}
+
+# lambdify with tensorflow and numexpr is tested here
+If ($env:TEST_OPT_DEPENDENCY -match "numpy") {
+    StartTest "NUMPY"
+    @"
+import sympy
+if not (sympy.test('*numpy*', 'sympy/matrices/', 'sympy/physics/quantum/',
+        'sympy/core/tests/test_numbers.py', 'sympy/core/tests/test_sympify.py',
+        'sympy/utilities/tests/test_lambdify.py',
+        blacklist=['sympy/physics/quantum/tests/test_circuitplot.py']) and sympy.
+         doctest('sympy/matrices/', 'sympy/utilities/lambdify.py')):
+    raise Exception('Tests failed')
+"@ | python -We:invalid 2>&1 | Tee-Object -Variable output
+    EndTest "NUMPY"
+}
+
+If ($env:TEST_OPT_DEPENDENCY -match "scipy") {
+    StartTest "SCIPY"
+    @"
+import sympy
+# scipy matrices are tested in numpy testing
+if not sympy.test('sympy/external/tests/test_scipy.py'):
+    raise Exception('Tests failed')
+"@ | python -We:invalid 2>&1 | Tee-Object -Variable output
+    EndTest "SCIPY"
+}
+
+If ($env:TEST_OPT_DEPENDENCY -match "llvmlite") {
+    StartTest "LLVMJIT"
+    @"
+import sympy
+if not (sympy.test('sympy/printing/tests/test_llvmjit.py')
+        and sympy.doctest('sympy/printing/llvmjitcode.py')):
+    raise Exception('Tests failed')
+"@ | python -We:invalid 2>&1 | Tee-Object -Variable output
+    EndTest "LLVMJIT"
+}
+
+If ($env:TEST_OPT_DEPENDENCY -match "theano") {
+    StartTest "THEANO"
+    @"
+import sympy
+if not sympy.test('*theano*'):
+    raise Exception('Tests failed')
+"@ | python -We:invalid 2>&1 | Tee-Object -Variable output
+    EndTest "THEANO"
+}
+
+If ($env:TEST_OPT_DEPENDENCY -match "gmpy") {
+    StartTest "GMPY"
+    @"
+import sympy
+if not (sympy.test('sympy/polys/') and sympy.doctest('sympy/polys/')):
+    raise Exception('Tests failed')
+"@ | python -We:invalid 2>&1 | Tee-Object -Variable output
+    EndTest "GMPY"
+}
+
+If ($env:TEST_OPT_DEPENDENCY -match "matplotlib") {
+    StartTest "MATPLOTLIB"
+    @"
+# Set matplotlib so that it works correctly in headless environment. We have to do
+# this here because it doesn't work after the sympy plotting module is
+# imported.
+import matplotlib
+matplotlib.use("Agg")
+import sympy
+# Unfortunately, we have to use subprocess=False so that the above will be
+# applied, so no hash randomization here.
+if not (sympy.test('sympy/plotting', 'sympy/physics/quantum/tests/test_circuitplot.py',
+    subprocess=False) and sympy.doctest('sympy/plotting', subprocess=False)):
+    raise Exception('Tests failed')
+"@ | python -We:invalid 2>&1 | Tee-Object -Variable output
+    EndTest "MATPLOTLIB"
+}
+
+If ($env:TEST_OPT_DEPENDENCY -match "ipython") {
+    StartTest "IPYTHON"
+    @"
+import sympy
+if not sympy.test('*ipython*'):
+    raise Exception('Tests failed')
+"@ | python -We:invalid 2>&1 | Tee-Object -Variable output
+    EndTest "IPYTHON"
+}
+
+If ($env:TEST_OPT_DEPENDENCY -match "symengine") {
+    StartTest "SYMENGINE"
+    $env:USE_SYMENGINE=1
+    @"
+import sympy
+if not sympy.test('sympy/physics/mechanics'):
+    raise Exception('Tests failed')
+if not sympy.test('sympy/liealgebras'):
+    raise Exception('Tests failed')
+"@ | python -We:invalid 2>&1 | Tee-Object -Variable output
+    Remove-Item Env:\USE_SYMENGINE
+    EndTest "SYMENGINE"
+}

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division
 import sys
 import os
 import re as _re
+import struct
 from textwrap import fill, dedent
 from sympy.core.compatibility import get_function_name, range
 
@@ -104,13 +105,7 @@ def rawlines(s):
         else:
             return "dedent('''\\\n    %s''')" % rv
 
-size = getattr(sys, "maxint", None)
-if size is None:  # Python 3 doesn't have maxint
-    size = sys.maxsize
-if size > 2**32:
-    ARCH = "64-bit"
-else:
-    ARCH = "32-bit"
+ARCH = str(struct.calcsize('P') * 8) + "-bit"
 
 
 # XXX: PyPy doesn't support hash randomization

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     USE_PYTEST = False
 
-ON_TRAVIS = os.getenv('TRAVIS_BUILD_NUMBER', None)
+ON_TRAVIS = os.getenv('CI', None)
 
 if not USE_PYTEST:
     def raises(expectedException, code=None):

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -230,7 +230,7 @@ def test_files():
         "%(sep)splotting%(sep)spygletplot%(sep)s" % sepd,
     ])
     check_files(top_level_files, test)
-    check_directory_tree(BIN_PATH, test, set(["~", ".pyc", ".sh"]), "*")
+    check_directory_tree(BIN_PATH, test, set(["~", ".pyc", ".sh", ".ps1"]), "*")
     check_directory_tree(SYMPY_PATH, test, exclude)
     check_directory_tree(EXAMPLES_PATH, test, exclude)
 


### PR DESCRIPTION
Added AppVeyor Windows 32/64-bit Python 2.7/3.6 testing, for optional dependencies, which uses C/C++ extensions that may have different behaviors across platforms/architectures: [Example](https://ci.appveyor.com/project/ylemkimon/sympy/build/1.0.1)

I'm don't know if there is difference between Windows CPython and Linux CPython, that leads to different results. Also, since AppVeyor allows only one concurrent build for open source projects, it takes `(build time)*(the number of builds)` to complete a job. Therefore, only optional dependencies are tested.

During test of this PR, following issues were discovered and fixed: #13454, #13503