### PR TITLE
Use SYMPY_INTS for integer check

### DIFF
--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -5,7 +5,7 @@ from sympy.core import S, Integer
 from sympy.core.mul import prod
 from sympy.core.logic import fuzzy_not
 from sympy.utilities.iterables import (has_dups, default_sort_key)
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, SYMPY_INTS
 
 ###############################################################################
 ###################### Kronecker Delta, Levi-Civita etc. ######################
@@ -72,7 +72,7 @@ class LeviCivita(Function):
 
     @classmethod
     def eval(cls, *args):
-        if all(isinstance(a, (int, Integer)) for a in args):
+        if all(isinstance(a, (SYMPY_INTS, Integer)) for a in args):
             return eval_levicivita(*args)
         if has_dups(args):
             return S.Zero

--- a/sympy/functions/special/tests/test_tensor_functions.py
+++ b/sympy/functions/special/tests/test_tensor_functions.py
@@ -2,7 +2,7 @@ from sympy import (
     adjoint, conjugate, Dummy, Eijk, KroneckerDelta, LeviCivita, Symbol,
     symbols, transpose,
 )
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, long
 from sympy.physics.secondquant import evaluate_deltas, F
 
 x, y = symbols('x y')
@@ -11,6 +11,7 @@ x, y = symbols('x y')
 def test_levicivita():
     assert Eijk(1, 2, 3) == LeviCivita(1, 2, 3)
     assert LeviCivita(1, 2, 3) == 1
+    assert LeviCivita(long(1), long(2), long(3)) == 1
     assert LeviCivita(1, 3, 2) == -1
     assert LeviCivita(1, 2, 2) == 0
     i, j, k = symbols('i j k')

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 from sympy.core import S, Symbol, Tuple, Integer, Basic, Expr, Eq
 from sympy.core.decorators import call_highest_priority
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, SYMPY_INTS
 from sympy.core.sympify import SympifyError, sympify
 from sympy.functions import conjugate, adjoint
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -248,7 +248,7 @@ class MatrixExpr(Basic):
                 return self._entry(i, j)
             else:
                 raise IndexError("Invalid indices (%s, %s)" % (i, j))
-        elif isinstance(key, (int, Integer)):
+        elif isinstance(key, (SYMPY_INTS, Integer)):
             # row-wise decomposition of matrix
             rows, cols = self.shape
             # allow single indexing if number of columns is known

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -2,6 +2,7 @@ from sympy import KroneckerDelta, diff, Piecewise, And
 from sympy import Sum
 
 from sympy.core import S, symbols, Add, Mul
+from sympy.core.compatibility import long
 from sympy.functions import transpose, sin, cos, sqrt
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
@@ -212,6 +213,7 @@ def test_indexing():
 def test_single_indexing():
     A = MatrixSymbol('A', 2, 3)
     assert A[1] == A[0, 1]
+    assert A[long(1)] == A[0, 1]
     assert A[3] == A[1, 0]
     assert list(A[:2, :2]) == [A[0, 0], A[0, 1], A[1, 0], A[1, 1]]
     raises(IndexError, lambda: A[6])

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -12,7 +12,7 @@ import math
 
 from sympy import Integer, log, Mul, Add, Pow, conjugate
 from sympy.core.basic import sympify
-from sympy.core.compatibility import string_types, range
+from sympy.core.compatibility import string_types, range, SYMPY_INTS
 from sympy.matrices import Matrix, zeros
 from sympy.printing.pretty.stringpict import prettyForm
 
@@ -588,7 +588,7 @@ def measure_partial(qubit, bits, format='sympy', normalize=True):
     """
     m = qubit_to_matrix(qubit, format)
 
-    if isinstance(bits, (int, Integer)):
+    if isinstance(bits, (SYMPY_INTS, Integer)):
         bits = (int(bits),)
 
     if format == 'sympy':

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -1,7 +1,7 @@
 import random
 
 from sympy import Integer, Matrix, Rational, sqrt, symbols
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, long
 from sympy.physics.quantum.qubit import (measure_all, measure_partial,
                                          matrix_to_qubit, matrix_to_density,
                                          qubit_to_matrix, IntQubit,
@@ -133,6 +133,8 @@ def test_measure_partial():
     #Basic test of collapse of entangled two qubits (Bell States)
     state = Qubit('01') + Qubit('10')
     assert measure_partial(state, (0,)) == \
+        [(Qubit('10'), Rational(1, 2)), (Qubit('01'), Rational(1, 2))]
+    assert measure_partial(state, long(0)) == \
         [(Qubit('10'), Rational(1, 2)), (Qubit('01'), Rational(1, 2))]
     assert measure_partial(state, (0,)) == \
         measure_partial(state, (1,))[::-1]

--- a/sympy/plotting/pygletplot/plot.py
+++ b/sympy/plotting/pygletplot/plot.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Integer
-from sympy.core.compatibility import is_sequence
+from sympy.core.compatibility import is_sequence, SYMPY_INTS
 
 from threading import RLock
 
@@ -304,7 +304,7 @@ class PygletPlot(object):
         Parses and adds a PlotMode to the function
         list.
         """
-        if not (isinstance(i, (int, Integer)) and i >= 0):
+        if not (isinstance(i, (SYMPY_INTS, Integer)) and i >= 0):
             raise ValueError("Function index must "
                              "be an integer >= 0.")
 

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -3,6 +3,7 @@ from sympy import (
     cosh, diff, cot, Subs, exp, tanh, exp, S, integrate, I,Matrix,
     Symbol, coth, pi, log, count_ops, sqrt, E, expand, Piecewise)
 
+from sympy.core.compatibility import long
 from sympy.utilities.pytest import XFAIL
 
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
@@ -328,6 +329,7 @@ def test_trigsimp_groebner():
 
     # Test quick=False works
     assert trigsimp_groebner(ex, hints=[2]) in results
+    assert trigsimp_groebner(ex, hints=[long(2)]) in results
 
     # test "I"
     assert trigsimp_groebner(sin(I*x)/cos(I*x), hints=[tanh]) == I*tanh(x)

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from sympy.core.cache import cacheit
 from sympy.core import (sympify, Basic, S, Expr, expand_mul, factor_terms,
     Mul, Dummy, igcd, FunctionClass, Add, symbols, Wild, expand)
-from sympy.core.compatibility import reduce, iterable
+from sympy.core.compatibility import reduce, iterable, SYMPY_INTS
 from sympy.core.numbers import I, Integer
 from sympy.core.function import count_ops, _mexpand
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
@@ -206,7 +206,7 @@ def trigsimp_groebner(expr, hints=[], quick=False, order="grlex",
         n = 1
         funcs, iterables, gens = [], [], []
         for e in hints:
-            if isinstance(e, (int, Integer)):
+            if isinstance(e, (SYMPY_INTS, Integer)):
                 n = e
             elif isinstance(e, FunctionClass):
                 funcs.append(e)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 import collections
 
 from sympy import Basic
+from sympy.core.compatibility import SYMPY_INTS
 
 
 class NDimArray(object):
@@ -62,7 +63,7 @@ class NDimArray(object):
 
     def _parse_index(self, index):
 
-        if isinstance(index, (int, Integer)):
+        if isinstance(index, (SYMPY_INTS, Integer)):
             if index >= self._loop_size:
                 raise ValueError("index out of range")
             return index
@@ -150,10 +151,10 @@ class NDimArray(object):
             shape = ()
             iterable = (iterable,)
 
-        if isinstance(shape, (int, Integer)):
+        if isinstance(shape, (SYMPY_INTS, Integer)):
             shape = (shape,)
 
-        if any([not isinstance(dim, (int, Integer)) for dim in shape]):
+        if any([not isinstance(dim, (SYMPY_INTS, Integer)) for dim in shape]):
             raise TypeError("Shape should contain integers only.")
 
         return tuple(shape), iterable

--- a/sympy/tensor/array/tests/test_immutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_immutable_ndim_array.py
@@ -2,6 +2,7 @@ from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 from sympy import Symbol, Rational, SparseMatrix, Dict, diff, symbols, Indexed, IndexedBase
+from sympy.core.compatibility import long
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import ImmutableSparseNDimArray
 from sympy.utilities.pytest import raises
@@ -56,6 +57,19 @@ def test_ndim_array_initiation():
     assert array_with_many_args.shape == shape
     assert array_with_many_args[0, 0] == 0
     assert array_with_many_args.rank() == 2
+
+    shape = (long(3), long(3))
+    array_with_long_shape = ImmutableSparseNDimArray.zeros(*shape)
+    assert len(array_with_long_shape) == 3 * 3
+    assert array_with_long_shape.shape == shape
+    assert array_with_long_shape[long(0), long(0)] == 0
+    assert array_with_long_shape.rank() == 2
+
+    vector_with_long_shape = ImmutableDenseNDimArray(range(5), long(5))
+    assert len(vector_with_long_shape) == 5
+    assert vector_with_long_shape.shape == (long(5),)
+    assert vector_with_long_shape.rank() == 1
+    raises(ValueError, lambda: vector_with_long_shape[long(5)])
 
 
 def test_reshape():

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -2,6 +2,7 @@ from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
 from sympy import Symbol, Rational, SparseMatrix, diff
+from sympy.core.compatibility import long
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import MutableSparseNDimArray
 from sympy.utilities.pytest import raises
@@ -59,6 +60,19 @@ def test_ndim_array_initiation():
     assert array_with_many_args.shape == shape
     assert array_with_many_args[0, 0] == 0
     assert array_with_many_args.rank() == 2
+
+    shape = (long(3), long(3))
+    array_with_long_shape = MutableSparseNDimArray.zeros(*shape)
+    assert len(array_with_long_shape) == 3 * 3
+    assert array_with_long_shape.shape == shape
+    assert array_with_long_shape[long(0), long(0)] == 0
+    assert array_with_long_shape.rank() == 2
+
+    vector_with_long_shape = MutableDenseNDimArray(range(5), long(5))
+    assert len(vector_with_long_shape) == 5
+    assert vector_with_long_shape.shape == (long(5),)
+    assert vector_with_long_shape.rank() == 1
+    raises(ValueError, lambda: vector_with_long_shape[long(5)])
 
 
 def test_reshape():

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -37,7 +37,7 @@ from sympy import Matrix, Rational, prod, Integer
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, \
     bsgs_direct_product, canonicalize, riemann_bsgs
 from sympy.core import Basic, sympify, Add, S
-from sympy.core.compatibility import string_types, reduce, range
+from sympy.core.compatibility import string_types, reduce, range, SYMPY_INTS
 from sympy.core.containers import Tuple
 from sympy.core.decorators import deprecated
 from sympy.core.symbol import Symbol, symbols
@@ -1535,7 +1535,7 @@ class TensorIndexType(Basic):
     ``delta`` : ``Kronecker delta``
     ``epsilon`` : the ``Levi-Civita epsilon`` tensor
     ``dim``
-    ``dim_eps``
+    ``eps_dim``
     ``dummy_fmt``
     ``data`` : a property to add ``ndarray`` values, to work in a specified basis.
 
@@ -1723,7 +1723,7 @@ class TensorIndexType(Basic):
         return delta
 
     def get_epsilon(self):
-        if not isinstance(self._eps_dim, (int, Integer)):
+        if not isinstance(self._eps_dim, (SYMPY_INTS, Integer)):
             return None
         sym = TensorSymmetry(get_symmetric_group_sgs(self._eps_dim, 1))
         Sdim = TensorType([self]*self._eps_dim, sym)


### PR DESCRIPTION
Use SYMPY_INTS for integer instance check for compatibility with Python 2 long and gmpy mpz.

Fixes #13454.