### PR TITLE
MatrixSymbol, expand negation

### DIFF
--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -232,7 +232,23 @@ def factor_in_front(mul):
         return newmul(factor, *matrices)
     return mul
 
-rules = (any_zeros, remove_ids, xxinv, unpack, rm_id(lambda x: x == 1),
+def expand_neg(mul):
+    """
+    expand factor -1
+    e.g. -(-A + B) -> A - B
+
+    This is helpful for e.g. -(-A + B) + A - B = 0
+    """
+    factor, matrices = mul.as_coeff_matrices()
+    if factor == -1:
+        len_matrices = len(matrices)
+        for i in range(len_matrices):
+            if matrices[i].is_MatAdd:
+                matrices[i] = Add(*tuple(-arg for arg in matrices[i].args))
+                return newmul(*matrices)
+    return mul
+
+rules = (expand_neg, any_zeros, remove_ids, xxinv, unpack, rm_id(lambda x: x == 1),
          merge_explicit, factor_in_front, flatten)
 
 canonicalize = exhaust(typed({MatMul: do_one(*rules)}))

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -135,3 +135,6 @@ def test_matmul_args_cnc():
 def test_issue_12950():
     M = Matrix([[Symbol("x")]]) * MatrixSymbol("A", 1, 1)
     assert MatrixSymbol("A", 1, 1).as_explicit()[0]*Symbol('x') == M.as_explicit()[0]
+
+def test_issue_13508():
+    assert -(-C + D) - C + D == ZeroMatrix(n,n)


### PR DESCRIPTION
expand
```python
 -(-A + B) --> A - B

```

helpful for simplification for expression like

```python
  -(-A + B) - A + B = 0
```

- added test

"Fixes #13508"
