### PR TITLE
Remove "#doctest: +SKIP"

### DIFF
--- a/doc/src/tutorial/gotchas.rst
+++ b/doc/src/tutorial/gotchas.rst
@@ -266,7 +266,7 @@ division, depending on whether you are in Python 2 or Python 3, and depending
 on whether or not you have run ``from __future__ import division``:
 
     >>> from __future__ import division
-    >>> 1/2 #doctest: +SKIP
+    >>> 1/2
     0.5
 
 .. note::
@@ -282,7 +282,7 @@ To avoid this, we can construct the rational object explicitly
 This problem also comes up whenever we have a larger symbolic expression with
 ``int/int`` in it.  For example:
 
-    >>> x + 1/2 #doctest: +SKIP
+    >>> x + 1/2
     x + 0.5
 
 .. note::

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -528,7 +528,7 @@ class AssumptionKeys(object):
         False
         >>> ask(~Q.zero(I))
         True
-        >>> ask(Q.nonzero(oo))  #doctest: +SKIP
+        >>> ask(Q.nonzero(oo))  # doctest: +SKIP
         False
 
         """

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -134,7 +134,7 @@ def finite_diff_weights(order, x_list, x0=S.One):
     >>> print(x_list)
     [-h + x, -sqrt(2)*h/2 + x, x, sqrt(2)*h/2 + x, h + x]
     >>> mycoeffs = finite_diff_weights(1, x_list, 0)[1][4]
-    >>> [simplify(c) for c in  mycoeffs] #doctest: +NORMALIZE_WHITESPACE
+    >>> [simplify(c) for c in  mycoeffs]
     [(h**3/2 + h**2*x - 3*h*x**2 - 4*x**3)/h**4,
     (-sqrt(2)*h**3 - 4*h**2*x + 3*sqrt(2)*h*x**2 + 8*x**3)/h**4,
     6*x/h**2 - 8*x**3/h**4,
@@ -228,7 +228,7 @@ def apply_finite_diff(order, x_list, y_list, x0=S(0)):
     >>> from sympy.calculus import apply_finite_diff
     >>> cube = lambda arg: (1.0*arg)**3
     >>> xlist = range(-3,3+1)
-    >>> apply_finite_diff(2, xlist, map(cube, xlist), 2) - 12 # doctest: +SKIP
+    >>> apply_finite_diff(2, xlist, list(map(cube, xlist)), 2) - 12
     -3.55271367880050e-15
 
     we see that the example above only contain rounding errors.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3027,7 +3027,7 @@ class PermutationGroup(Basic):
         >>> from sympy.combinatorics.named_groups import SymmetricGroup
         >>> S = SymmetricGroup(5)
         >>> base, strong_gens = S.schreier_sims_random(consec_succ=5)
-        >>> _verify_bsgs(S, base, strong_gens) #doctest: +SKIP
+        >>> _verify_bsgs(S, base, strong_gens)
         True
 
         Notes

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1309,7 +1309,6 @@ class Permutation(Basic):
         since coercion can only handle one argument to the left. To handle
         multiple cycles it is convenient to use Cycle instead of Permutation:
 
-        >>> [[1, 2]]*[[2, 3]]*Permutation([]) # doctest: +SKIP
         >>> from sympy.combinatorics.permutations import Cycle
         >>> Cycle(1, 2)(2, 3)
         (1 3 2)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -550,12 +550,12 @@ class Max(MinMaxBase, Application):
     ========
 
     >>> from sympy import Max, Symbol, oo
-    >>> from sympy.abc import x, y
+    >>> from sympy.abc import x, y, z
     >>> p = Symbol('p', positive=True)
     >>> n = Symbol('n', negative=True)
 
-    >>> Max(x, -2)                  #doctest: +SKIP
-    Max(x, -2)
+    >>> Max(x, -2)
+    Max(-2, x)
     >>> Max(x, -2).subs(x, 3)
     3
     >>> Max(p, -2)
@@ -564,9 +564,9 @@ class Max(MinMaxBase, Application):
     Max(x, y)
     >>> Max(x, y) == Max(y, x)
     True
-    >>> Max(x, Max(y, z))           #doctest: +SKIP
+    >>> Max(x, Max(y, z))
     Max(x, y, z)
-    >>> Max(n, 8, p, 7, -oo)        #doctest: +SKIP
+    >>> Max(n, 8, p, 7, -oo)
     Max(8, p)
     >>> Max (1, x, oo)
     oo
@@ -653,16 +653,16 @@ class Min(MinMaxBase, Application):
     >>> p = Symbol('p', positive=True)
     >>> n = Symbol('n', negative=True)
 
-    >>> Min(x, -2)                  #doctest: +SKIP
-    Min(x, -2)
+    >>> Min(x, -2)
+    Min(-2, x)
     >>> Min(x, -2).subs(x, 3)
     -2
     >>> Min(p, -3)
     -3
-    >>> Min(x, y)                   #doctest: +SKIP
+    >>> Min(x, y)
     Min(x, y)
-    >>> Min(n, 8, p, -7, p, oo)     #doctest: +SKIP
-    Min(n, -7)
+    >>> Min(n, 8, p, -7, p, oo)
+    Min(-7, -n)
 
     See Also
     ========

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -71,9 +71,8 @@ class jacobi(OrthogonalPolynomial):
     1
     >>> jacobi(1, a, b, x)
     a/2 - b/2 + x*(a/2 + b/2 + 1)
-    >>> jacobi(2, a, b, x)   # doctest:+SKIP
-    (a**2/8 - a*b/4 - a/8 + b**2/8 - b/8 + x**2*(a**2/8 + a*b/4 + 7*a/8 +
-    b**2/8 + 7*b/8 + 3/2) + x*(a**2/4 + 3*a/4 - b**2/4 - 3*b/4) - 1/2)
+    >>> jacobi(2, a, b, x)
+    a**2/8 - a*b/4 - a/8 + b**2/8 - b/8 + x**2*(a**2/8 + a*b/4 + 7*a/8 + b**2/8 + 7*b/8 + 3/2) + x*(a**2/4 + 3*a/4 - b**2/4 - 3*b/4) - 1/2
 
     >>> jacobi(n, a, b, x)
     jacobi(n, a, b, x)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1218,8 +1218,8 @@ class Ellipse(GeometrySet):
         >>> e = Ellipse(Point(0,0), 3, 2)
         >>> t = e.tangent_lines(e.random_point())
         >>> p = Plot()
-        >>> p[0] = e # doctest: +SKIP
-        >>> p[1] = t # doctest: +SKIP
+        >>> p[0] = e
+        >>> p[1] = t
 
         """
         p = Point(p, dim=2)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -330,28 +330,28 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     >>> from sympy.abc import x, y
     >>> sqrt(5)
     sqrt(5)
-    >>> init_printing(pretty_print=True) # doctest: +SKIP
-    >>> sqrt(5) # doctest: +SKIP
+    >>> init_printing(pretty_print=True)
+    >>> sqrt(5)
       ___
     \/ 5
-    >>> theta = Symbol('theta') # doctest: +SKIP
-    >>> init_printing(use_unicode=True) # doctest: +SKIP
-    >>> theta # doctest: +SKIP
-    \u03b8
-    >>> init_printing(use_unicode=False) # doctest: +SKIP
-    >>> theta # doctest: +SKIP
+    >>> theta = Symbol('theta')
+    >>> init_printing(use_unicode=True)
+    >>> theta
+    θ
+    >>> init_printing(use_unicode=False)
+    >>> theta
     theta
-    >>> init_printing(order='lex') # doctest: +SKIP
-    >>> str(y + x + y**2 + x**2) # doctest: +SKIP
+    >>> init_printing(order='lex')
+    >>> str(y + x + y**2 + x**2)
     x**2 + x + y**2 + y
-    >>> init_printing(order='grlex') # doctest: +SKIP
-    >>> str(y + x + y**2 + x**2) # doctest: +SKIP
+    >>> init_printing(order='grlex')
+    >>> str(y + x + y**2 + x**2)
     x**2 + x + y**2 + y
-    >>> init_printing(order='grevlex') # doctest: +SKIP
-    >>> str(y * x**2 + x * y**2) # doctest: +SKIP
+    >>> init_printing(order='grevlex')
+    >>> str(y * x**2 + x * y**2)
     x**2*y + x*y**2
-    >>> init_printing(order='old') # doctest: +SKIP
-    >>> str(x**2 + y**2 + x + y) # doctest: +SKIP
+    >>> init_printing(order='old')
+    >>> str(x**2 + y**2 + x + y)
     x**2 + x + y**2 + y
     >>> init_printing(num_columns=10) # doctest: +SKIP
     >>> x**2 + x + y**2 + y # doctest: +SKIP

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1244,7 +1244,7 @@ class FockStateFermionKet(FermionState, FockStateKet):
     ========
 
     >>> from sympy.physics.secondquant import FKet
-    >>> FKet([1, 2]) #doctest: +SKIP
+    >>> FKet([1, 2])
     FockStateFermionKet((1, 2))
     """
     def _dagger_(self):
@@ -1262,7 +1262,7 @@ class FockStateFermionBra(FermionState, FockStateBra):
     ========
 
     >>> from sympy.physics.secondquant import FBra
-    >>> FBra([1, 2]) #doctest: +SKIP
+    >>> FBra([1, 2])
     FockStateFermionBra((1, 2))
     """
     def _dagger_(self):


### PR DESCRIPTION
Considering the PR #11652 (it has a large number of unnecessary commits). It wasn't easy to separate out commits, so I have created a clean PR to remove some `doctest: +SKIP`.

I'll close the other PR.