### PR TITLE
Modifications to `function_range` for periodic functions

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -40,6 +40,10 @@ def test_function_range():
         ) == Interval(-1, 1)
     raises(NotImplementedError, lambda : function_range(
         exp(x)*(sin(x) - cos(x))/2 - x, x, S.Reals))
+    raises(NotImplementedError, lambda : function_range(
+        log(x), x, S.Integers))
+    raises(NotImplementedError, lambda : function_range(
+        sin(x)/2, x, S.Naturals))
 
 
 def test_continuous_domain():

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -34,6 +34,8 @@ def test_function_range():
         ) == FiniteSet(0)
     assert function_range(x*(x - 1) - (x**2 - x) + y, x, S.Reals
         ) == FiniteSet(y)
+    assert function_range(sin(x), x, Union(Interval(-5, -3), FiniteSet(4))
+        ) == Union(Interval(-sin(3), 1), FiniteSet(sin(4)))
     raises(NotImplementedError, lambda : function_range(
         exp(x)*(sin(x) - cos(x))/2 - x, x, S.Reals))
 

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -36,6 +36,8 @@ def test_function_range():
         ) == FiniteSet(y)
     assert function_range(sin(x), x, Union(Interval(-5, -3), FiniteSet(4))
         ) == Union(Interval(-sin(3), 1), FiniteSet(sin(4)))
+    assert function_range(cos(x), x, Interval(-oo, -4)
+        ) == Interval(-1, 1)
     raises(NotImplementedError, lambda : function_range(
         exp(x)*(sin(x) - cos(x))/2 - x, x, S.Reals))
 

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -112,17 +112,23 @@ def function_range(f, symbol, domain):
     """
     from sympy.solvers.solveset import solveset
 
+    if isinstance(domain, EmptySet):
+        return S.EmptySet
+
     period = periodicity(f, symbol)
     if period is S.Zero:
         # the expression is constant wrt symbol
         return FiniteSet(f.expand())
 
     if period is not None:
-        inf = domain.inf
-        inf_period = S.Zero if inf.is_infinite else inf
-        sup_period = inf_period + period
-        periodic_interval = Interval(inf_period, sup_period)
-        domain = domain.intersect(periodic_interval)
+        if isinstance(domain, Interval):
+            if (domain.inf - domain.sup).is_infinite:
+                domain = Interval(0, period)
+        elif isinstance(domain, Union):
+            for sub_dom in domain.args:
+                if isinstance(sub_dom, Interval) and \
+                ((sub_dom.inf - sub_dom.sup).is_infinite):
+                    domain = Interval(0, period)
 
     intervals = continuous_domain(f, symbol, domain)
     range_int = S.EmptySet

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -135,15 +135,20 @@ def function_range(f, symbol, domain):
     if isinstance(intervals,(Interval, FiniteSet)):
         interval_iter = (intervals,)
 
-    else:
+    elif isinstance(intervals, Union):
         interval_iter = intervals.args
+
+    else:
+            raise NotImplementedError(filldedent('''
+                Unable to find range for the given domain.
+                '''))
 
     for interval in interval_iter:
         if isinstance(interval, FiniteSet):
             for singleton in interval:
                 if singleton in domain:
                     range_int += FiniteSet(f.subs(symbol, singleton))
-        else:
+        elif isinstance(interval, Interval):
             vals = S.EmptySet
             critical_points = S.EmptySet
             critical_values = S.EmptySet
@@ -178,6 +183,10 @@ def function_range(f, symbol, domain):
                     right_open = True
 
             range_int += Interval(vals.inf, vals.sup, left_open, right_open)
+        else:
+            raise NotImplementedError(filldedent('''
+                Unable to find range for the given domain.
+                '''))
 
     return range_int
 


### PR DESCRIPTION
Modified part of function_range dealing with periodic function.
Added test for previously incorrect result.
Example:
```
>>>function_range(sin(x), x, Interval(-oo, -3))
Interval(-1, 1)
>>>function_range(sin(x),  x, Union(Interval(-5, -3), FiniteSet(4)))
Union({sin(4)}, Interval(-sin(3), 1))
```
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
