### PR TITLE
Added tests for normalized hydrogen wavefunctions Psi_{nlm}

### DIFF
--- a/sympy/functions/special/tests/test_spherical_harmonics.py
+++ b/sympy/functions/special/tests/test_spherical_harmonics.py
@@ -10,7 +10,6 @@ def test_Ynm():
     assert Ynm(0, 0, th, ph).expand(func=True) == 1/(2*sqrt(pi))
     assert Ynm(1, -1, th, ph) == -exp(-2*I*ph)*Ynm(1, 1, th, ph)
     assert Ynm(1, -1, th, ph).expand(func=True) == sqrt(6)*sin(th)*exp(-I*ph)/(4*sqrt(pi))
-    assert Ynm(1, -1, th, ph).expand(func=True) == sqrt(6)*sin(th)*exp(-I*ph)/(4*sqrt(pi))
     assert Ynm(1, 0, th, ph).expand(func=True) == sqrt(3)*cos(th)/(2*sqrt(pi))
     assert Ynm(1, 1, th, ph).expand(func=True) == -sqrt(6)*sin(th)*exp(I*ph)/(4*sqrt(pi))
     assert Ynm(2, 0, th, ph).expand(func=True) == 3*sqrt(5)*cos(th)**2/(4*sqrt(pi)) - sqrt(5)/(4*sqrt(pi))

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import factorial, sqrt, exp, S, assoc_laguerre, Float
+from sympy.functions.special.spherical_harmonics import Ynm
 
 
 def R_nl(n, l, r, Z=1):
@@ -81,6 +82,64 @@ def R_nl(n, l, r, Z=1):
     # some books. Both coefficients seem to be the same fast:
     # C =  S(2)/n**2 * sqrt(1/a**3 * factorial(n_r) / (factorial(n+l)))
     return C * r0**l * assoc_laguerre(n_r, 2*l + 1, r0).expand() * exp(-r0/2)
+
+def Psi_nlm(n, l, m, r, phi, theta, Z=1):
+    """
+    Returns the Hydrogen wave function psi_{nlm}. It's the product of
+    the radial wavefunction R_{nl} and the spherical harmonic Y_{l}^{m}.
+
+    n, l, m
+        quantum numbers 'n', 'l' and 'm'
+    r
+        radial coordinate
+    phi
+        azimuthal angle
+    theta
+        polar angle
+    Z
+        atomic number (1 for Hydrogen, 2 for Helium, ...)
+
+    Everything is in Hartree atomic units.
+
+    Examples
+    ========
+
+    >>> from sympy.physics.hydrogen import Psi_nlm
+    >>> from sympy import Symbol
+    >>> r=Symbol("r", real=True, positive=True)
+    >>> phi=Symbol("phi", real=True)
+    >>> theta=Symbol("theta", real=True)
+    >>> Z=Symbol("Z", positive=True, integer=True, nonzero=True)
+    >>> Psi_nlm(1,0,0,r,phi,theta,Z)
+    Z**(3/2)*exp(-Z*r)/sqrt(pi)
+    >>> Psi_nlm(2,1,1,r,phi,theta,Z)
+    -Z**(5/2)*r*exp(I*phi)*exp(-Z*r/2)*sin(theta)/(8*sqrt(pi))
+
+    Integrating the absolute square of a hydrogen wavefunction psi_{nlm}
+    over the whole space leads 1.
+
+    The normalization of the hydrogen wavefunctions Psi_nlm is:
+
+    >>> from sympy import integrate, conjugate, pi, oo, sin
+    >>> wf=Psi_nlm(2,1,1,r,phi,theta,Z)
+    >>> abs_sqrd=wf*conjugate(wf)
+    >>> jacobi=r**2*sin(theta)
+    >>> integrate(abs_sqrd*jacobi, (r,0,oo), (phi,0,2*pi), (theta,0,pi))
+    1
+    """
+
+    # sympify arguments
+    n, l, m, r, phi, theta, Z = S(n), S(l), S(m), S(r), S(phi), S(theta), S(Z)
+    # check if values for n,l,m make physically sense
+    if n.is_integer and n<1:
+        raise ValueError("'n' must be positive integer")
+    if l.is_integer and not (n > l):
+        raise ValueError("'n' must be greater than 'l'")
+    if m.is_integer and not (abs(m)<=l):
+        raise ValueError("|'m'| must be less or equal 'l'")
+    # return the hydrogen wave function
+    return R_nl(n, l, r, Z)*Ynm(l,m,theta,phi).expand(func=True)
+
 
 
 def E_nl(n, Z=1):

--- a/sympy/physics/tests/test_hydrogen.py
+++ b/sympy/physics/tests/test_hydrogen.py
@@ -1,6 +1,6 @@
-from sympy import exp, integrate, oo, S, simplify, sqrt, symbols
+from sympy import exp, integrate, oo, S, simplify, sqrt, symbols, pi, sin, cos, I
 from sympy.core.compatibility import range
-from sympy.physics.hydrogen import R_nl, E_nl, E_nl_dirac
+from sympy.physics.hydrogen import R_nl, E_nl, E_nl_dirac, Psi_nlm
 from sympy.utilities.pytest import raises
 
 n, r, Z = symbols('n r Z')
@@ -50,6 +50,16 @@ def test_norm():
         for l in range(n):
             assert integrate(R_nl(n, l, r)**2 * r**2, (r, 0, oo)) == 1
 
+def test_psi_nlm():
+    r=S('r')
+    phi=S('phi')
+    theta=S('theta')
+    assert (Psi_nlm(1, 0, 0, r, phi, theta) == exp(-r) / sqrt(pi))
+    assert (Psi_nlm(2, 1, -1, r, phi, theta)) == S(1) / 2 * exp(-r / (2)) * r \
+        * (sin(theta) * exp(-I * phi) / (4 * sqrt(pi)))
+    assert (Psi_nlm(3, 2, 1, r, phi, theta, 2) == -sqrt(2) * sin(theta) \
+         * exp(I * phi) * cos(theta) / (4 * sqrt(pi)) * S(2) / 81 \
+        * sqrt(2 * 2 ** 3) * exp(-2 * r / (3)) * (r * 2) ** 2)
 
 def test_hydrogen_energies():
     assert E_nl(n, Z) == -Z**2/(2*n**2)


### PR DESCRIPTION
Psi_{nlm} = R_{nl}*Y_{lm} so the tests on R_{nl} and 
Y_{lm} guarantee correct results for Psi_{nlm} -
combined a few of those to check this explicitly.

Fixes #13481 which originated from #12164