### PR TITLE
Fix mathematica parsing bug and add tests

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -23,9 +23,9 @@ def parse(s):
         lambda m: parse(m.group(1)) + translateFunction(
             m.group(2)) + parse(m.group(3))),
 
-        (r"\A(\w+)\[([^\]]+[^\[]*)\]\Z",  # Function call
-        lambda m: translateFunction(
-            m.group(1)) + "(" + parse(m.group(2)) + ")"),
+        (r"\A([+-]?)(\w+)\[([^\]]+[^\[]*)\]\Z",  # Function call
+        lambda m: m.group(1) + translateFunction(
+            m.group(2)) + "(" + parse(m.group(3)) + ")"),
 
         (r"\((.+)\)\((.+)\)",  # Parenthesized implied multiplication
         lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(2)) + ")"),

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -20,6 +20,8 @@ def test_mathematica():
         '2*Sin[x+y]': '2*sin(x+y)',
         'Sin[x]+Cos[y]': 'sin(x)+cos(y)',
         'Sin[Cos[x]]': 'sin(cos(x))',
-        '2*Sqrt[x+y]': '2*sqrt(x+y)'}   # Test case from the issue 4259
+        '2*Sqrt[x+y]': '2*sqrt(x+y)',   # Test case from the issue 4259
+        '+Sqrt[2]': 'sqrt(2)',
+        '-Sqrt[2]': '-sqrt(2)'}
     for e in d:
         assert mathematica(e) == sympify(d[e])


### PR DESCRIPTION
I came across a bug when parsing some mathematica output to python. The problem is that a function with + or - sign cannot be parsed correctly. So, I added a regex to handle this issue. I also put additional tests and confirmed all the parsing tests were passed.

### Examples (Before modification)

In [1]: s = 'Sqrt[2]'

In [2]: mathematica(s)
Out[2]: sqrt(2)

In [3]: s = '-Sqrt[2]'

In [4]: mathematica(s)
\---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/test/parse.py in <module>()
----> 1 mathematica(s)

~/test/parse.py in mathematica(s)
      6 
      7 def mathematica(s):
----> 8     return sympify(parse(s))
      9 
     10 def translateFunction(s):

/usr/local/lib/python3.5/dist-packages/sympy/core/sympify.py in sympify(a, locals, convert_xor, strict, rational, evaluate)
    352     try:
    353         a = a.replace('\n', '')
--> 354         expr = parse_expr(a, local_dict=locals, transformations=transformations, evaluate=evaluate)
    355     except (TokenError, SyntaxError) as exc:
    356         raise SympifyError('could not parse %r' % a, exc)

/usr/local/lib/python3.5/dist-packages/sympy/parsing/sympy_parser.py in parse_expr(s, local_dict, transformations, global_dict, evaluate)
    892         code = compile(evaluateFalse(code), '<string>', 'eval')
    893 
--> 894     return eval_expr(code, local_dict, global_dict)
    895 
    896 

/usr/local/lib/python3.5/dist-packages/sympy/parsing/sympy_parser.py in eval_expr(code, local_dict, global_dict)
    805     """
    806     expr = eval(
--> 807         code, global_dict, local_dict)  # take local objects in preference
    808 
    809     return expr

<string> in <module>()

TypeError: 'Symbol' object does not support indexing

### Examples (After modification)

In [1]: s = 'Sqrt[2]'

In [2]: mathematica(s)
Out[2]: sqrt(2)

In [3]: s = '-Sqrt[2]'

In [4]: mathematica(s)
Out[4]: -sqrt(2)

In [5]: s = '+Sqrt[2]'

In [6]: mathematica(s)
Out[6]: sqrt(2)
 

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
