### PR TITLE
Fix pickling/deepcopying of floats when using gmpy2 backend

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -29,6 +29,7 @@ from sympy.utilities.misc import debug, filldedent
 from .evaluate import global_evaluate
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from mpmath.libmp.backend import MPZ
 
 rnd = mlib.round_nearest
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -19,6 +19,7 @@ from sympy.core.compatibility import (
     SYMPY_INTS, int_info)
 import mpmath
 import mpmath.libmp as mlib
+from mpmath.libmp.backend import MPZ
 from mpmath.libmp import mpf_pow, mpf_pi, mpf_e, phi_fixed
 from mpmath.ctx_mp import mpnumeric
 from mpmath.libmp.libmpf import (
@@ -29,7 +30,6 @@ from sympy.utilities.misc import debug, filldedent
 from .evaluate import global_evaluate
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-from mpmath.libmp.backend import MPZ
 
 rnd = mlib.round_nearest
 
@@ -1048,7 +1048,7 @@ class Float(Number):
                 # of a shim for int on Python 3, see issue #13470.
                 if num[1].endswith('L'):
                     num[1] = num[1][:-1]
-                num[1] = long(num[1], 16)
+                num[1] = MPZ(num[1], 16)
                 _mpf_ = tuple(num)
             else:
                 if len(num) == 4:

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -103,6 +103,12 @@ def test_core_numbers():
         check(c)
 
 
+def test_core_float_copy():
+    # See gh-7457
+    y = Symbol("x") + 1.0
+    check(y)  # does not raise TypeError ("argument is not an mpz")
+
+
 def test_core_relational():
     x = Symbol("x")
     y = Symbol("y")


### PR DESCRIPTION
Fixes gh-7457, closes gh-10674, and fixes gh-12895.

This is a rebased fix by @ovolve and a minimal test to address a bad interaction with pickling/deepcopying of `Float` objects when `gmpy2` is installed (i.e., the "Argument is not an mpz" ValueError). When a future version of `gmpy2` is released to address the underlying issue, this fix should be forward-compatible.

cc @asmeurer @casevh 