### PR TITLE
 Rewrite mathematica parsing function and add tests

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from re import match
+import re
 from sympy import sympify
 
 
@@ -14,40 +14,151 @@ def parse(s):
     # Begin rules
     rules = (
         # Arithmetic operation between a constant and a function
-        (r"\A(\d+)([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",
-        lambda m: m.group(
-            1) + translateFunction(m.group(2)) + parse(m.group(3))),
+        (r"""
+            \A          # Matches only at the start of the string
+            (           # group1 
+            [+-]?       # + or - sign with 0 or 1 repetition 
+            \d+         # any number with 1 or more repetition 
+            [*/+^-]     # either of arithmetic operands 
+            )
+            (           # group1
+            \w+         # alphanumeric character and the underscore
+            \[          # [ as a character
+            [^\]]+      # character except ] with 1 or more repetittion
+            [^[]*       # character except [ with 0 or more repetittion
+            \]          # ] as a character
+            ) 
+            \Z          # Matches only at the end of the string
+            """,
+        lambda m: m.group(1) + parse(m.group(2))),
 
         # Arithmetic operation between two functions
-        (r"\A(\w+\[[^\]]+[^\[]*\])([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",
-        lambda m: parse(m.group(1)) + translateFunction(
-            m.group(2)) + parse(m.group(3))),
+        (r"""
+            \A
+            (           # group1
+            \w+         
+            \[          
+            [^\]]+      
+            [^\[]*      
+            \]          
+            ) 
+            (           # group2
+            [*/+-^]     
+            ) 
+            (           # group3
+            \w+
+            \[
+            [^\]]+
+            [^\[]*
+            \]
+            )
+            \Z
+            """,
+        lambda m: parse(m.group(1)) + m.group(2) + parse(m.group(3))),
 
-        (r"\A([+-]?)(\w+)\[([^\]]+[^\[]*)\]\Z",  # Function call
+        # Function call
+        (r"""
+            \A
+            ([+-]?)     # group1, + or - sign with 0 or 1 repetition 
+            (\w+)       # group2 
+            \[          
+            (           # group3
+            [^\]]+      
+            [^[]*       
+            ) 
+            \]          
+            \Z
+            """,  
         lambda m: m.group(1) + translateFunction(
             m.group(2)) + "(" + parse(m.group(3)) + ")"),
 
-        (r"\((.+)\)\((.+)\)",  # Parenthesized implied multiplication
+        # Parenthesized implied multiplication
+        (r"""
+            \(          # ( as a character
+            (.+)        # group1, any character with 1 or more repetition
+            \)          # ) as a character
+            \(
+            (.+)        # group2
+            \)
+            """,  
         lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(2)) + ")"),
 
-        (r"\A\((.+)\)\Z",  # Parenthesized expression
-        lambda m: "(" + parse(m.group(1)) + ")"),
+        # Parenthesized expression
+        (r"""
+            \A
+            ([+-]?)     # group1, + or - sign with 0 or 1 repetition
+            \(      
+            (.+)        # group2
+            \)      
+            \Z
+            """,  
+        lambda m: m.group(1) + "(" + parse(m.group(2)) + ")"),
 
-        (r"\A(.*[\w\.])\((.+)\)\Z",  # Implied multiplication - a(b)
+        # Implied multiplication - a(b)
+        (r"""
+            \A
+            (           # group1
+            .*          
+            [\w.]       # either of alphanumeric character, the underscore or dot
+            )
+            \(          
+            (.+)        # group2
+            \)      
+            \Z
+            """, 
         lambda m: parse(m.group(1)) + "*(" + parse(m.group(2)) + ")"),
 
-        (r"\A\((.+)\)([\w\.].*)\Z",  # Implied multiplication - (a)b
+        # Implied multiplication - (a)b
+        (r"""
+            \A
+            \(      
+            (.+)        # group1
+            \)      
+            (           # group2
+            [\w.]
+            .*
+            )
+            \Z
+            """,  
         lambda m: "(" + parse(m.group(1)) + ")*" + parse(m.group(2))),
 
-        (r"\A(-? *[\d\.]+)([a-zA-Z].*)\Z",  # Implied multiplication - 2a
+        # Implied multiplication - 2a
+        (r"""
+            \A
+            (           # group1
+            -?          # - sign with 0 or 1 repetition
+            \ *         # space with 0 or more repetition
+            [\d.]+     # either of number or dot with 1 or more repetition
+            )
+            (           # group2
+            [a-zA-Z]    
+            .*
+            )
+            \Z
+            """,  
         lambda m: parse(m.group(1)) + "*" + parse(m.group(2))),
 
-        (r"\A([^=]+)([\^\-\*/\+=]=?)(.+)\Z",  # Infix operator
-        lambda m: parse(m.group(1)) + translateOperator(m.group(2)) + parse(m.group(3))))
+        # Infix operator
+        (r"""
+            \A
+            (           # group1
+            [^=]+       # any characters except = with 1 or more repetition
+            )
+            (           # group2
+            [*/+^=-]    # operands and = 
+            =?          # = with 0 or 1 repetition
+            )
+            (.+)        # group3
+            \Z
+            """,  
+        lambda m: parse(m.group(1)) + translateOperator(
+            m.group(2)) + parse(m.group(3))),
+        )
     # End rules
 
     for rule, action in rules:
-        m = match(rule, s)
+        rule = re.compile(rule, re.VERBOSE)
+        m = re.match(rule, s)
         if m:
             return action(m)
 

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -8,171 +8,126 @@ def mathematica(s):
     return sympify(parse(s))
 
 
-def parse(s):
-    s = s.strip()
+class _Parse(object):
+    '''An instance of this class converts basic Mathematica expression to
+    Python.'''
 
-    # Begin rules
-    rules = (
-        # Arithmetic operation between a constant and a function
-        (r"""
-            \A          # Matches only at the start of the string
-            (           # group1 
-            [+-]?       # + or - sign with 0 or 1 repetition 
-            \d+         # any number with 1 or more repetition 
-            [*/+^-]     # either of arithmetic operands 
-            )
-            (           # group1
-            \w+         # alphanumeric character and the underscore
-            \[          # [ as a character
-            [^\]]+      # character except ] with 1 or more repetittion
-            [^[]*       # character except [ with 0 or more repetittion
-            \]          # ] as a character
-            ) 
-            \Z          # Matches only at the end of the string
-            """,
-        lambda m: m.group(1) + parse(m.group(2))),
+    replaces1 = (
+        (' ', ''),
+        ('^', '**'),
+    )
 
-        # Arithmetic operation between two functions
-        (r"""
-            \A
-            (           # group1
-            \w+         
-            \[          
-            [^\]]+      
-            [^\[]*      
-            \]          
-            ) 
-            (           # group2
-            [*/+-^]     
-            ) 
-            (           # group3
-            \w+
-            \[
-            [^\]]+
-            [^\[]*
-            \]
-            )
-            \Z
-            """,
-        lambda m: parse(m.group(1)) + m.group(2) + parse(m.group(3))),
+    replaces2 = (
+        ('[', '('),
+        (']', ')'),
+    )
 
-        # Function call
-        (r"""
-            \A
-            ([+-]?)     # group1, + or - sign with 0 or 1 repetition 
-            (\w+)       # group2 
-            \[          
-            (           # group3
-            [^\]]+      
-            [^[]*       
-            ) 
-            \]          
-            \Z
-            """,  
-        lambda m: m.group(1) + translateFunction(
-            m.group(2)) + "(" + parse(m.group(3)) + ")"),
+    rules1 = (
+        # 'Arc' to 'a'
+        (r'''
+                (               # group1
+                .*              # any characters
+                [^a-zA-Z]       # a single character except alphabet
+                )
+                Arc             # detect 'Arc'
+                (               # group2
+                [a-zA-Z]        # a single alphabet
+                .*              # any characters
+                )
+                ''',
+         lambda m: m.group(1) + 'a' + m.group(2)),
 
-        # Parenthesized implied multiplication
-        (r"""
-            \(          # ( as a character
-            (.+)        # group1, any character with 1 or more repetition
-            \)          # ) as a character
-            \(
-            (.+)        # group2
-            \)
-            """,  
-        lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(2)) + ")"),
+        # 'Arc' (at the top) to 'a'
+        (r'''
+                \AArc           # detect 'Arc' at the top of the string
+                (               # group1
+                [a-zA-Z]        # a single alphabet
+                .*              # any characters
+                )
+                ''',
+         lambda m: 'a' + m.group(1)),
 
-        # Parenthesized expression
-        (r"""
-            \A
-            ([+-]?)     # group1, + or - sign with 0 or 1 repetition
-            \(      
-            (.+)        # group2
-            \)      
-            \Z
-            """,  
-        lambda m: m.group(1) + "(" + parse(m.group(2)) + ")"),
+        # Add omitted '*' character
+        (r'''
+                (               # group1
+                .*              # any characters
+                [])\d]          # ], ) or a single number
+                )
+                (               # group2
+                [(a-zA-Z]       # ( or a single alphabet
+                .*              # any characters
+                )
+                ''',
+         lambda m: m.group(1) + '*' + m.group(2)),
 
-        # Implied multiplication - a(b)
-        (r"""
-            \A
-            (           # group1
-            .*          
-            [\w.]       # either of alphanumeric character, the underscore or dot
-            )
-            \(          
-            (.+)        # group2
-            \)      
-            \Z
-            """, 
-        lambda m: parse(m.group(1)) + "*(" + parse(m.group(2)) + ")"),
+        # Add omitted '*' character (variable letter preceding)
+        (r'''
+                (               # group1
+                .*              # any characters
+                [a-zA-Z]        # a single alphabet
+                )
+                \(              # ( as a character
+                (.*)            # group2, any characters
+                ''',
+         lambda m: m.group(1) + '*(' + m.group(2)),
+    )
 
-        # Implied multiplication - (a)b
-        (r"""
-            \A
-            \(      
-            (.+)        # group1
-            \)      
-            (           # group2
-            [\w.]
-            .*
-            )
-            \Z
-            """,  
-        lambda m: "(" + parse(m.group(1)) + ")*" + parse(m.group(2))),
+    rules2 = (
+        # 'mod' to 'Mod'
+        (r'''
+                (               # group1
+                .*              # any characters
+                [^a-zA-Z]       # a single character except alphabet
+                )
+                mod             # detect 'mod'
+                (.*)            # group2, any characters
+                ''',
+         lambda m: m.group(1) + 'Mod' + m.group(2)),
 
-        # Implied multiplication - 2a
-        (r"""
-            \A
-            (           # group1
-            -?          # - sign with 0 or 1 repetition
-            \ *         # space with 0 or more repetition
-            [\d.]+     # either of number or dot with 1 or more repetition
-            )
-            (           # group2
-            [a-zA-Z]    
-            .*
-            )
-            \Z
-            """,  
-        lambda m: parse(m.group(1)) + "*" + parse(m.group(2))),
+        # 'mod' (at the top) to 'Mod'
+        (r'''
+                \Amod           # detect 'mod' at the top of the string
+                (.*)            # group1, any characters
+                ''',
+         lambda m: 'Mod' + m.group(1)),
+    )
 
-        # Infix operator
-        (r"""
-            \A
-            (           # group1
-            [^=]+       # any characters except = with 1 or more repetition
-            )
-            (           # group2
-            [*/+^=-]    # operands and = 
-            =?          # = with 0 or 1 repetition
-            )
-            (.+)        # group3
-            \Z
-            """,  
-        lambda m: parse(m.group(1)) + translateOperator(
-            m.group(2)) + parse(m.group(3))),
-        )
-    # End rules
+    @staticmethod
+    def _replace(s, replaces):
+        for bef, aft in replaces:
+            s = s.replace(bef, aft)
+        return s
 
-    for rule, action in rules:
-        rule = re.compile(rule, re.VERBOSE)
-        m = re.match(rule, s)
-        if m:
-            return action(m)
+    @staticmethod
+    def _apply_rules(s, rules):
+        for rule, action in rules:
+            pat = re.compile(rule, re.VERBOSE)  # VERBOSE: for readable code
+            while True:
+                m = re.search(pat, s)
+                if m:
+                    s = action(m)
+                else:
+                    break
+        return s
 
-    return s
+    def __call__(self, s):
+        # '^' to '**' and remove Whitespace(s)
+        s = self._replace(s, self.replaces1)
+
+        # 'Arc' to 'a' and add omitted '*' character
+        s = self._apply_rules(s, self.rules1)
+
+        # convert to lower letters
+        s = s.lower()
+
+        # 'mod' to 'Mod'
+        s = self._apply_rules(s, self.rules2)
+
+        # '[', ']' to '(', ')', respectively
+        s = self._replace(s, self.replaces2)
+
+        return s
 
 
-def translateFunction(s):
-    if s.startswith("Arc"):
-        return "a" + s[3:]
-    return s.lower()
-
-
-def translateOperator(s):
-    dictionary = {'^': '**'}
-    if s in dictionary:
-        return dictionary[s]
-    return s
+# instantiate _Parse
+parse = _Parse()

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -22,6 +22,18 @@ def test_mathematica():
         'Sin[Cos[x]]': 'sin(cos(x))',
         '2*Sqrt[x+y]': '2*sqrt(x+y)',   # Test case from the issue 4259
         '+Sqrt[2]': 'sqrt(2)',
-        '-Sqrt[2]': '-sqrt(2)'}
+        '-Sqrt[2]': '-sqrt(2)',
+        '-1/Sqrt[2]': '-1/sqrt(2)',
+        '-(1/Sqrt[3])': '-(1/sqrt(3))',
+        '1/(2*Sqrt[5])': '1/(2*sqrt(5))',
+        'Mod[5,3]': 'Mod(5,3)',
+        '-Mod[5,3]': '-Mod(5,3)',
+        '(x+1)y': '(x+1)*y',
+        'x(y+1)': 'x*(y+1)',
+        'Sin[x]Cos[y]': 'sin(x)*cos(y)',
+        'Sin[x]**2Cos[y]**2': 'sin(x)**2 * cos(y)**2',
+        'Cos[x]^2(1 - Cos[y]^2)': 'cos(x)**2*(1-cos(y)**2)',
+        }
+
     for e in d:
         assert mathematica(e) == sympify(d[e])


### PR DESCRIPTION
After commiting #13529, there were also some problems found in mathematica parsing. For example, the curent version cannot parse -1/(2*Sqrt[2]). So I renewed the function. I also added several tests. Both all the conventional tests and newly added tests were confirmed to be passed.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
