### PR TITLE
FIX: `solve` now acknowledges `dict=True` for Relational args

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -55,6 +55,7 @@ from sympy.solvers.inequalities import reduce_inequalities
 
 from types import GeneratorType
 from collections import defaultdict
+import itertools
 import warnings
 
 
@@ -944,6 +945,30 @@ def solve(f, *symbols, **flags):
             f[i] = fi
 
         if isinstance(fi, (bool, BooleanAtom)) or fi.is_Relational:
+            if flags.get('dict', False):
+                solution = reduce_inequalities(f, symbols=symbols)
+                if isinstance(solution, Equality):
+                    return [{solution.lhs: solution.rhs}]
+                solution = list(solution.args)
+                for sol in solution:
+                    # Behavior for types like StrictLessThan is not defined
+                    if not isinstance(sol, (Or, Equality)):
+                        warnings.warn(filldedent('''
+                            Warning: Ignoring dict=True due to
+                            incompatible type of %s.''' % sol))
+                        return reduce_inequalities(f, symbols=symbols)
+                intermediate = [sol for sol in solution
+                                if isinstance(sol, Equality)]
+                solution[:] = [sol.args for sol in solution
+                               if sol not in intermediate]
+                solutions = [intermediate + list(sol)
+                             for sol in itertools.product(*solution)]
+                for i in range(len(solutions)):
+                    ele = {}
+                    for sol in solutions[i]:
+                        ele[sol.lhs] = sol.rhs
+                    solutions[i] = ele
+                return solutions
             return reduce_inequalities(f, symbols=symbols)
 
         if isinstance(fi, Poly):

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -160,6 +160,16 @@ def test_solve_args():
     assert solve((x + y - 2, 2*x + 2*y - 4)) == {x: -y + 2}
 
 
+def test_solve_dict():
+    assert solve(Eq(2*x,1), dict=True) == [{x: 1/2}]
+    assert solve([Eq(x**2-1, 0), Gt(x, 0)], (x,), dict=True) == [{x: 1}]
+    assert solve([Eq(x**3-6*x**2+11*x-6, 0), Eq(y**2, 1), Eq(z, 1)],
+            (x, y, z,), dict=True) == [{x: 1, y: -1, z: 1}, {x: 1, y: 1, z: 1},
+                                       {x: 2, y: -1, z: 1}, {x: 2, y: 1, z: 1},
+                                       {x: 3, y: -1, z: 1}, {x: 3, y: 1, z: 1}]
+    assert solve(Gt(x, 0), (x,), dict=True) == And(Lt(0, x), Lt(x, oo))
+
+
 def test_solve_polynomial1():
     assert solve(3*x - 2, x) == [Rational(2, 3)]
     assert solve(Eq(3*x, 2), x) == [Rational(2, 3)]


### PR DESCRIPTION
Solve method will return a list of dictionaries for Relational args.
Currently, it only supports solution with And, Or only.

Fixes #13534.

(Accidentally closed previous PR https://github.com/sympy/sympy/pull/13537)