### PR TITLE
Product is_add fix

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -239,7 +239,7 @@ class Product(ExprWithIntLimits):
         from sympy.functions import KroneckerDelta, RisingFactorial
 
         (k, a, n) = limits
-
+        #print(term, limits)
         if k not in term.free_symbols:
             if (term - 1).is_zero:
                 return S.One
@@ -252,6 +252,7 @@ class Product(ExprWithIntLimits):
             return deltaproduct(term, limits)
 
         dif = n - a
+
         if dif.is_Integer:
             return Mul(*[term.subs(k, a + i) for i in range(dif + 1)])
 
@@ -275,6 +276,7 @@ class Product(ExprWithIntLimits):
             return poly.LC()**(n - a + 1) * A * B
 
         elif term.is_Add:
+
             p, q = term.as_numer_denom()
             q = self._eval_product(q, (k, a, n))
             if q.is_Number:
@@ -282,8 +284,8 @@ class Product(ExprWithIntLimits):
                 # There is expression, which couldn't change by
                 # as_numer_denom(). E.g. n**(2/3) + 1 --> (n**(2/3) + 1, 1).
                 # We have to catch this case.
-
-                p = sum([self._eval_product(i, (k, a, n)) for i in p.as_coeff_Add()])
+                from sympy.concrete.summations import Sum
+                p = exp(Sum(log(p), (k, a, n)))
             else:
                 p = self._eval_product(p, (k, a, n))
             return p / q

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -239,7 +239,7 @@ class Product(ExprWithIntLimits):
         from sympy.functions import KroneckerDelta, RisingFactorial
 
         (k, a, n) = limits
-        #print(term, limits)
+
         if k not in term.free_symbols:
             if (term - 1).is_zero:
                 return S.One
@@ -252,7 +252,6 @@ class Product(ExprWithIntLimits):
             return deltaproduct(term, limits)
 
         dif = n - a
-
         if dif.is_Integer:
             return Mul(*[term.subs(k, a + i) for i in range(dif + 1)])
 
@@ -276,7 +275,6 @@ class Product(ExprWithIntLimits):
             return poly.LC()**(n - a + 1) * A * B
 
         elif term.is_Add:
-
             p, q = term.as_numer_denom()
             q = self._eval_product(q, (k, a, n))
             if q.is_Number:

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -355,6 +355,13 @@ def test_issue_9983():
     assert product(1 + 1/n**(S(2)/3), (n, 1, oo)) == p.doit()
 
 
+def test_issue_13546():
+    n = Symbol('n')
+    k = Symbol('k')
+    p = Product(n + 1 / 2**k, (k, 0, n-1)).doit()
+    assert p.subs(n, 2).doit() == S(15)/2
+
+
 def test_rewrite_Sum():
     assert Product(1 - S.Half**2/k**2, (k, 1, oo)).rewrite(Sum) == \
         exp(Sum(log(1 - 1/(4*k**2)), (k, 1, oo)))


### PR DESCRIPTION
Fixes #13546.

When the expression cannot be changed by as_numer_denom the existing transformation is invalid since it assumes that the product of a sum is the same as the sum of the products of its summands. Instead we can change the product of the numerator into a sum.