### PR TITLE
Wrong result with solveset. Fix issue 13550

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -108,6 +108,9 @@ def _invert(f_x, y, x, domain=S.Complexes):
     if not isinstance(s, FiniteSet) or x1 == f_x:
         return x1, s
 
+    if not x1 == x:
+        return x1, s
+
     return x1, s.intersection(domain)
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -105,10 +105,7 @@ def _invert(f_x, y, x, domain=S.Complexes):
     else:
         x1, s = _invert_complex(f_x, FiniteSet(y), x)
 
-    if not isinstance(s, FiniteSet) or x1 == f_x:
-        return x1, s
-
-    if not x1 == x:
+    if not isinstance(s, FiniteSet) or x1 == f_x or x1 != x:
         return x1, s
 
     return x1, s.intersection(domain)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1633,3 +1633,6 @@ def test__is_finite_with_finite_vars():
     assert all(f(1/x) is None for x in (
         Dummy(), Dummy(real=True), Dummy(complex=True)))
     assert f(1/Dummy(real=False)) is True  # b/c it's finite but not 0
+
+def test_issue_13550():
+    assert solveset(x**2 - 2*x - 15, symbol = x, domain = Interval(-oo, 0)) == FiniteSet(-3)


### PR DESCRIPTION
Fix #13550.
The expression `solveset(x**2 - 2*x - 15, symbol = x, domain = Interval(-oo, 0))`
returns `EmptySet()` instead of `FiniteSet(-3)`. The bug is due to the
function `_invert(f_x, y, x, domain=S.Complexes)` in `solveset.py`. It returns `x1, s.intersection(domain)`
but in such example `x1` is `x**2 - 2*x`, so that `s` does not represent
the inversion. Hence the intersection with the domain is meaningless.

In the case `x1` is not equal to the symbol, i.e. the function is not inverted, it is better to return `x1, s`

A test is added.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
