### PR TITLE
Add 'whats_new' to keep track of changes in this version

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -1,0 +1,20 @@
+Version 1.1.2 (under development)
+=================================
+
+Changelog
+---------
+
+New features
+------------
+
+
+Enhancements
+------------
+
+
+Bug fixes
+---------
+
+
+API changes
+-----------


### PR DESCRIPTION
See discussion on https://groups.google.com/forum/#!topic/sympy/6eJW2qNT6dk , I have made a few 'headings' that I saw fit. But we discuss on this PR for what is the best solution.

We can slowly mention all the 'changes' from version 1.1.1 to 1.2 .
From this issue onwards any bug fixed or new feature introduced would require to make a new entry to doc/whats_new/v1.2rst file.