### PR TITLE
Resolves RecursionError in latex representation

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -416,9 +416,13 @@ class LatexPrinter(Printer):
                     _tex += term_tex
                     last_term_tex = term_tex
                 return _tex
-        one_by_one =  Pow(1, -1, evaluate=False)
 
-        if not denom is S.One or one_by_one in expr.args:
+        if denom is S.One and Pow(1, -1, evaluate=False) not in expr.args:
+            # use the original expression here, since fraction() may have
+            # altered it when producing numer and denom
+            tex += convert(expr)
+
+        else:
             snumer = convert(numer)
             sdenom = convert(denom)
             ldenom = len(sdenom.split())
@@ -456,11 +460,6 @@ class LatexPrinter(Printer):
                     tex += r"\frac{1}{%s}%s%s" % (sdenom, separator, snumer)
             else:
                 tex += r"\frac{%s}{%s}" % (snumer, sdenom)
-
-        elif denom is S.One:
-            # use the original expression here, since fraction() may have
-            # altered it when producing numer and denom
-            tex += convert(expr)
 
         if include_parens:
             tex += ")"

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -372,6 +372,7 @@ class LatexPrinter(Printer):
         return r"\nabla\cdot %s" % self.parenthesize(func, PRECEDENCE['Mul'])
 
     def _print_Mul(self, expr):
+        from sympy.parsing.sympy_parser import parse_expr
         include_parens = False
         if _coeff_isneg(expr):
             expr = -expr
@@ -415,12 +416,9 @@ class LatexPrinter(Printer):
                     _tex += term_tex
                     last_term_tex = term_tex
                 return _tex
+        one_by_one =  parse_expr('1/1', evaluate=False)
 
-        if denom is S.One:
-            # use the original expression here, since fraction() may have
-            # altered it when producing numer and denom
-            tex += convert(expr)
-        else:
+        if not denom is S.One or one_by_one in expr.args:
             snumer = convert(numer)
             sdenom = convert(denom)
             ldenom = len(sdenom.split())
@@ -458,6 +456,11 @@ class LatexPrinter(Printer):
                     tex += r"\frac{1}{%s}%s%s" % (sdenom, separator, snumer)
             else:
                 tex += r"\frac{%s}{%s}" % (snumer, sdenom)
+
+        elif denom is S.One:
+            # use the original expression here, since fraction() may have
+            # altered it when producing numer and denom
+            tex += convert(expr)
 
         if include_parens:
             tex += ")"

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -372,7 +372,7 @@ class LatexPrinter(Printer):
         return r"\nabla\cdot %s" % self.parenthesize(func, PRECEDENCE['Mul'])
 
     def _print_Mul(self, expr):
-        from sympy.parsing.sympy_parser import parse_expr
+        from sympy.core.power import Pow
         include_parens = False
         if _coeff_isneg(expr):
             expr = -expr
@@ -416,7 +416,7 @@ class LatexPrinter(Printer):
                     _tex += term_tex
                     last_term_tex = term_tex
                 return _tex
-        one_by_one =  parse_expr('1/1', evaluate=False)
+        one_by_one =  Pow(1, -1, evaluate=False)
 
         if not denom is S.One or one_by_one in expr.args:
             snumer = convert(numer)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1629,6 +1629,12 @@ def test_issue_12886():
     assert latex(m__1**2 + l__1**2) == r'\left(l^{1}\right)^{2} + \left(m^{1}\right)^{2}'
 
 
+def test_issue_13559():
+    from sympy.parsing.sympy_parser import parse_expr
+    expr = parse_expr('5/1', evaluate=False)
+    assert latex(expr) == r"\frac{5}{1}"
+
+
 def test_latex_UnevaluatedExpr():
     x = symbols("x")
     he = UnevaluatedExpr(1/x)


### PR DESCRIPTION
fixes #13559. It was due to factor of `1/1`  
```python
expr = parse_expr('5/1', evaluate=False)
expr.args
```
it gives `(5 , 1/1)` , which was not handled properly in latex conversion . So everytime an expression was divided by 1 , it resulted in RecursionError