### PR TITLE
Fix randMatrix's percentage argument

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1394,7 +1394,7 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
         c = r
     # Note that ``Random()`` is equivalent to ``Random(None)``
     prng = prng or random.Random(seed)
-    
+ 
     if not symmetric:
         m = Matrix._new(r, c, lambda i, j: prng.randint(min, max))
         if percent == 100:
@@ -1416,7 +1416,6 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
     for i, j in ij:
         value = prng.randint(min, max)
         m[i, j] = m[j, i] = value
-
     return m
 
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1386,9 +1386,9 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
     >>> A == randMatrix(3, seed=1)
     True
     >>> randMatrix(3, symmetric=True, percent=50) # doctest:+SKIP
-    [0, 68, 43]
-    [0, 68,  0]
-    [0, 91, 34]
+    [77, 70,  0],
+    [70,  0,  0],
+    [ 0,  0, 88]
     """
     if c is None:
         c = r

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1400,7 +1400,7 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
         m = Matrix._new(r, c, lambda i, j: prng.randint(min, max))
         if percent == 100:
             return m
-        z = int(r * c * (100 - percent) // 100)
+        z = int(r*c*(100 - percent) // 100)
         m._mat[:z] = [S.Zero]*z
         prng.shuffle(m._mat)
 
@@ -1412,7 +1412,7 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
     m = zeros(r)
     ij = [(i, j) for i in range(r) for j in range(i, r)]
     if percent != 100:
-        ij = prng.sample(ij, int(len(ij) *  percent // 100))
+        ij = prng.sample(ij, int(len(ij)*percent // 100))
 
     for i, j in ij:
         value = prng.randint(min, max)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1278,6 +1278,7 @@ def hessian(f, varlist, constraints=[]):
             out[j, i] = out[i, j]
     return out
 
+
 def jordan_cell(eigenval, n):
     """
     Create a Jordan block:
@@ -1394,7 +1395,7 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
         c = r
     # Note that ``Random()`` is equivalent to ``Random(None)``
     prng = prng or random.Random(seed)
- 
+
     if not symmetric:
         m = Matrix._new(r, c, lambda i, j: prng.randint(min, max))
         if percent == 100:

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1394,25 +1394,29 @@ def randMatrix(r, c=None, min=0, max=99, seed=None, symmetric=False,
         c = r
     # Note that ``Random()`` is equivalent to ``Random(None)``
     prng = prng or random.Random(seed)
-    if symmetric and r != c:
-        raise ValueError(
-            'For symmetric matrices, r must equal c, but %i != %i' % (r, c))
+    
     if not symmetric:
         m = Matrix._new(r, c, lambda i, j: prng.randint(min, max))
-    else:
-        m = zeros(r)
-        for i in range(r):
-            for j in range(i, r):
-                m[i, j] = prng.randint(min, max)
-        for i in range(r):
-            for j in range(i):
-                m[i, j] = m[j, i]
-    if percent == 100:
-        return m
-    else:
-        z = int(r*c*percent // 100)
+        if percent == 100:
+            return m
+        z = int(r * c * (100 - percent) // 100)
         m._mat[:z] = [S.Zero]*z
         prng.shuffle(m._mat)
+
+        return m
+
+    # Symmetric case
+    if r != c:
+        raise ValueError('For symmetric matrices, r must equal c, but %i != %i' % (r, c))
+    m = zeros(r)
+    ij = [(i, j) for i in range(r) for j in range(i, r)]
+    if percent != 100:
+        ij = prng.sample(ij, int(len(ij) *  percent // 100))
+
+    for i, j in ij:
+        value = prng.randint(min, max)
+        m[i, j] = m[j, i] = value
+
     return m
 
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -585,7 +585,7 @@ def test_random():
     for size in (10, 11): # Test odd and even
         for percent in (100, 70, 30):
             M = randMatrix(size, symmetric=True, percent=percent, prng=rng)
-            assert M = M.T
+            assert M == M.T
 
     M = randMatrix(10, min=1, percent=70)
     zero_count = 0

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -595,13 +595,6 @@ def test_random():
                 zero_count += 1
     assert zero_count == 30
 
-    M = randMatrix(10, min=1, percent=99.5)
-    zero_count = 0
-    for i in range(M.shape[0]):
-        for j in range(M.shape[1]):
-            if M[i, j] == 0:
-                zero_count += 1
-    assert zero_count == 0
 
 def test_LUdecomp():
     testmat = Matrix([[0, 2, 5, 3],

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -581,6 +581,27 @@ def test_random():
     rng = random.Random(4)
     assert M == randMatrix(3, symmetric=True, prng=rng)
 
+    # Ensure symmetry
+    for size in (10, 11): # Test odd and even
+        for percent in (100, 70, 30):
+            M = randMatrix(size, symmetric=True, percent=percent, prng=rng)
+            assert M = M.T
+
+    M = randMatrix(10, min=1, percent=70)
+    zero_count = 0
+    for i in range(M.shape[0]):
+        for j in range(M.shape[1]):
+            if M[i, j] == 0:
+                zero_count += 1
+    assert zero_count == 30
+
+    M = randMatrix(10, min=1, percent=99.5)
+    zero_count = 0
+    for i in range(M.shape[0]):
+        for j in range(M.shape[1]):
+            if M[i, j] == 0:
+                zero_count += 1
+    assert zero_count == 0
 
 def test_LUdecomp():
     testmat = Matrix([[0, 2, 5, 3],


### PR DESCRIPTION
The documentation and behaviour of percentage in randMatrix was the opposite. Furthermore, sparse symmetric matrices were not symmetrical.

Fixes #13573.