### PR TITLE
[WIP] Fix wrong result for solve_univariate_inequality for periodic function

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -444,7 +444,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     Interval.open(0, pi)
 
     """
-    from sympy import im
+    from sympy import im, Lambda
     from sympy.calculus.util import (continuous_domain, periodicity,
         function_range)
     from sympy.solvers.solvers import denoms
@@ -667,6 +667,20 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
             if im(expanded_e) != S.Zero and check:
                 rv = (make_real).intersect(_domain)
             else:
+                if period is not None and sup - inf is S.Infinity:
+                    n =  Symbol('n')
+                    sol_sets_dummy  = sol_sets
+                    for i in sol_sets_dummy:
+                        if isinstance(i, FiniteSet):
+                            for j in i:
+                                sol_sets.append(ImageSet(
+                                    Lambda(n,j + n*period), S.Integers))
+                        elif isinstance(i, Interval):
+                            inf, sup = i.inf, i.sup
+                            left, right = i.left_open, i.right_open
+                            sol_sets.append(ImageSet(
+                                Lambda(n, Interval(inf + n*period,
+                                 sup + n*period, left, right)), S.Integers))
                 rv = Intersection(
                     (Union(*sol_sets)), make_real, _domain).subs(gen, _gen)
 


### PR DESCRIPTION
This PR adds some changes to `solve_univariate_inequality` to return an ImageSet
for periodic functions in case the domain is of infinite length. Previously, an incorrect result was returned for such cases, as mentioned [here](https://github.com/sympy/sympy/pull/13458#issuecomment-338879239).
The code added in this PR raises an exception while [taking the Union](https://github.com/sympy/sympy/blob/master/sympy/solvers/inequalities.py#L671) of the solution sets, but the sets calculated in `sol_sets` look correct individually.  

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
