### PR TITLE
Added two possibilities in Mod( )

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -117,6 +117,27 @@ class Mod(Function):
                 net = sum(non_mod_l) + sum(i.args[0] for i in mod_l)
                 return cls(net, q)
 
+        elif isinstance(p, Mul):
+            #separating into modulus and non modulus
+            both_l = non_mod_l, mod_l = [], []
+            for arg in p.args:
+                both_l[isinstance(arg, cls)].append(arg)
+
+            prod_mod = prod_mod1 = prod_non_mod = 1
+
+            if mod_l and all(inner.args[1] == q for inner in mod_l):
+                #finding distributive term
+                non_mod_l = [cls(x, q) for x in non_mod_l]
+                for j in non_mod_l:
+                    if isinstance(j, cls):
+                        prod_mod *= j.args[0]
+                    else:
+                        prod_non_mod *= j
+
+                for i in mod_l: prod_mod1 *= i.args[0]
+                net = prod_mod1*prod_mod
+                return prod_non_mod*cls(net, q)
+
         # XXX other possibilities?
 
         # extract gcd; any further simplification should be done by the user

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -107,6 +107,17 @@ class Mod(Function):
             elif (qinner*(q + qinner)).is_nonpositive:
                 # |qinner| < |q| and have different sign
                 return p
+        elif any(isinstance(arg, cls) for arg in p.args):
+            #separating into modulus and non modulus
+            both_l = non_mod_l, mod_l = [], []
+            for arg in p.args:
+                both_l[isinstance(arg,cls)].append(arg)
+            #if q same for all
+            if all(inner.args[1] == q for inner in mod_l) and \
+                    all(cls(z,q) == z for z in non_mod_l):
+                net = sum(non_mod_l) + sum(i.args[0] for i in mod_l)
+                return cls(net,q)
+
         # XXX other possibilities?
 
         # extract gcd; any further simplification should be done by the user

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -108,33 +108,34 @@ class Mod(Function):
                 # |qinner| < |q| and have different sign
                 return p
         elif isinstance(p, Add):
-            #separating into modulus and non modulus
+            # separating into modulus and non modulus
             both_l = non_mod_l, mod_l = [], []
             for arg in p.args:
                 both_l[isinstance(arg, cls)].append(arg)
-            #if q same for all
+            # if q same for all
             if mod_l and all(inner.args[1] == q for inner in mod_l):
-                net = sum(non_mod_l) + sum(i.args[0] for i in mod_l)
+                net = Add(*non_mod_l) + Add(*[i.args[0] for i in mod_l])
                 return cls(net, q)
 
         elif isinstance(p, Mul):
-            #separating into modulus and non modulus
+            # separating into modulus and non modulus
             both_l = non_mod_l, mod_l = [], []
             for arg in p.args:
                 both_l[isinstance(arg, cls)].append(arg)
 
-            prod_mod = prod_mod1 = prod_non_mod = 1
-
             if mod_l and all(inner.args[1] == q for inner in mod_l):
-                #finding distributive term
+                # finding distributive term
                 non_mod_l = [cls(x, q) for x in non_mod_l]
+                mod = []
+                non_mod = []
                 for j in non_mod_l:
                     if isinstance(j, cls):
-                        prod_mod *= j.args[0]
+                        mod.append(j.args[0])
                     else:
-                        prod_non_mod *= j
-
-                for i in mod_l: prod_mod1 *= i.args[0]
+                        non_mod.append(j)
+                prod_mod = Mul(*mod)
+                prod_non_mod = Mul(*non_mod)
+                prod_mod1 = Mul(*[i.args[0] for i in mod_l])
                 net = prod_mod1*prod_mod
                 return prod_non_mod*cls(net, q)
 

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -111,12 +111,12 @@ class Mod(Function):
             #separating into modulus and non modulus
             both_l = non_mod_l, mod_l = [], []
             for arg in p.args:
-                both_l[isinstance(arg,cls)].append(arg)
+                both_l[isinstance(arg, cls)].append(arg)
             #if q same for all
             if mod_l:
                 if all(inner.args[1] == q for inner in mod_l):
                     net = sum(non_mod_l) + sum(i.args[0] for i in mod_l)
-                    return cls(net,q)
+                    return cls(net, q)
 
         # XXX other possibilities?
 

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -113,10 +113,9 @@ class Mod(Function):
             for arg in p.args:
                 both_l[isinstance(arg, cls)].append(arg)
             #if q same for all
-            if mod_l:
-                if all(inner.args[1] == q for inner in mod_l):
-                    net = sum(non_mod_l) + sum(i.args[0] for i in mod_l)
-                    return cls(net, q)
+            if mod_l and all(inner.args[1] == q for inner in mod_l):
+                net = sum(non_mod_l) + sum(i.args[0] for i in mod_l)
+                return cls(net, q)
 
         # XXX other possibilities?
 

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -107,16 +107,16 @@ class Mod(Function):
             elif (qinner*(q + qinner)).is_nonpositive:
                 # |qinner| < |q| and have different sign
                 return p
-        elif any(isinstance(arg, cls) for arg in p.args):
+        elif isinstance(p, Add):
             #separating into modulus and non modulus
             both_l = non_mod_l, mod_l = [], []
             for arg in p.args:
                 both_l[isinstance(arg,cls)].append(arg)
             #if q same for all
-            if all(inner.args[1] == q for inner in mod_l) and \
-                    all(cls(z,q) == z for z in non_mod_l):
-                net = sum(non_mod_l) + sum(i.args[0] for i in mod_l)
-                return cls(net,q)
+            if mod_l:
+                if all(inner.args[1] == q for inner in mod_l):
+                    net = sum(non_mod_l) + sum(i.args[0] for i in mod_l)
+                    return cls(net,q)
 
         # XXX other possibilities?
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1658,6 +1658,9 @@ def test_Mod():
     #issue 13543
     assert Mod(Mod(x + 1, 2) + 1 , 2) == Mod(x,2)
 
+    assert Mod(Mod(x + 2, 4)*(x + 4), 4) == Mod(x*(x + 2), 4)
+    assert Mod(Mod(x + 2, 4)*4, 4) == 0
+
 
 def test_Mod_is_integer():
     p = Symbol('p', integer=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1655,6 +1655,9 @@ def test_Mod():
     # issue 10963
     assert (x**6000%400).args[1] == 400
 
+    #issue 13543
+    assert Mod(Mod(x + 1, 2) + 1 , 2) == Mod(x,2)
+
 
 def test_Mod_is_integer():
     p = Symbol('p', integer=True)


### PR DESCRIPTION
case where `(A mod c + B)mod c` can be simplified was missing.
 ` Mod(Mod(A, c) + B, c) == Mod(A + B, c)`
used the above concept to add a possibilty which was missing
Fixes #13543 

<!-- Briefly explain what this pull request changes in each line below, with appropriate heading—'M' for major changes, 'm' for minor changes, 'n' for new features, and 'b' for backwards compatibility breaks and deprecations—and a colon(:), e.g., "M: Added changelogs". Write '[skip changelog]' if changes are trivial or not related to SymPy itself. -->
## This PR changes how Mod autosimplifies arguments
m: Mod is now distributed over Add and Mul args to provide additional simplification
<!-- [CHANGELOG END] -->