### PR TITLE
Make wigner_9j work for certain half-integer argument combinations

### DIFF
--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -238,6 +238,9 @@ def test_wigner():
         70)/(246960*sqrt(105)) - 365/(3528*sqrt(70)*sqrt(105))
     assert wigner_6j(5, 5, 5, 5, 5, 5) == Rational(1, 52)
     assert tn(wigner_6j(8, 8, 8, 8, 8, 8, prec=64), -S(12219)/965770)
+    # regression test for #8747
+    half = Rational(1, 2)
+    assert wigner_9j(0, 0, 0, 0, half, half, 0, half, half) == half
 
 
 def test_gaunt():

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -536,19 +536,14 @@ def wigner_9j(j_1, j_2, j_3, j_4, j_5, j_6, j_7, j_8, j_9, prec=None):
     for finite precision arithmetic and only useful for a computer
     algebra system [Rasch03]_.
     """
-
-    imax = min(j_1 + j_9, j_2 + j_6, j_4 + j_8)
-    j_sum = j_1 + j_2 + j_9 + j_6 + j_4 + j_8
+    imax = int(min(j_1 + j_9, j_2 + j_6, j_4 + j_8) * 2)
+    imin = imax % 2
     sumres = 0
-    for kk in range(0, 2*(int(imax) + 1)):
-        k = S.Half*kk
-        try:
-            sumres +=(-1)**(kk+2*j_sum)*(kk + 1) * \
-            racah(j_1, j_2, j_9, j_6, j_3, k, prec) * \
-            racah(j_4, j_6, j_8, j_2, j_5, k, prec) * \
-            racah(j_1, j_4, j_9, j_8, j_7, k, prec)
-        except ValueError:
-            pass
+    for kk in range(imin, int(imax) + 1, 2):
+        sumres = sumres + (kk + 1) * \
+            racah(j_1, j_2, j_9, j_6, j_3, kk / 2, prec) * \
+            racah(j_4, j_6, j_8, j_2, j_5, kk / 2, prec) * \
+            racah(j_1, j_4, j_9, j_8, j_7, kk / 2, prec)
     return sumres
 
 


### PR DESCRIPTION
This is #9941 rebased on top of the latest master (conflicts were resolved by using the version in #9941, instead of master).