### PR TITLE
Sympy Stats assume expressions to be equal to zero

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -643,10 +643,10 @@ def probability(condition, given_condition=None, numsamples=None,
         return S.One
     if condition is S.false:
         return S.Zero
-    if not isinstance(condition, Relational):
+    if not isinstance(condition, Relational) and isinstance(condition, Expr):
         condition = Eq(condition, S(0))
-    if not given_condition is None and \
-        not isinstance(given_condition, Relational):
+    if not given_condition is None and isinstance(given_condition, Expr) \
+        and not isinstance(given_condition, Relational):
         given_condition = Eq(given_condition, S(0))
     if numsamples:
         return sampling_P(condition, given_condition, numsamples=numsamples,

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -20,6 +20,7 @@ from sympy.core.relational import Relational
 from sympy.core.compatibility import string_types
 from sympy.logic.boolalg import Boolean
 from sympy.solvers.solveset import solveset
+from sympy.utilities.misc import filldedent
 from sympy.sets.sets import FiniteSet, ProductSet, Intersection
 from sympy.abc import x
 
@@ -621,19 +622,32 @@ def probability(condition, given_condition=None, numsamples=None,
     given_condition = sympify(given_condition)
 
     if given_condition is not None and \
-            not isinstance(given_condition, (Relational, Boolean)):
-        raise ValueError("%s is not a relational or combination of relationals"
-                % (given_condition))
+            not isinstance(given_condition, (Relational, Boolean, Expr)):
+        raise ValueError(filldedent('''
+            %s is not a relational, combination of
+            relationals, or an expression that can be equated to zero.
+            ''') % (given_condition))
+    if isinstance(given_condition, Expr) and not \
+            random_symbols(given_condition):
+        raise ValueError(filldedent('''
+            Expression containing Random Variable expected, not %s
+            ''') % (given_condition))
     if given_condition == False:
         return S.Zero
-    if not isinstance(condition, (Relational, Boolean)):
-        raise ValueError("%s is not a relational or combination of relationals"
-                % (condition))
+    if not isinstance(condition, (Relational, Boolean, Expr)):
+        raise ValueError(filldedent('''
+            %s is not a relational, combination of relationals, or an
+            expression that can be equated to zero.
+            ''') % (condition))
     if condition is S.true:
         return S.One
     if condition is S.false:
         return S.Zero
-
+    if not isinstance(condition, Relational):
+        condition = Eq(condition, S(0))
+    if not given_condition is None and \
+        not isinstance(given_condition, Relational):
+        given_condition = Eq(given_condition, S(0))
     if numsamples:
         return sampling_P(condition, given_condition, numsamples=numsamples,
                 **kwargs)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -227,3 +227,9 @@ def test_issue_8129():
     assert P(X >= X) == 1
     assert P(X > X) == 0
     assert P(X > X+1) == 0
+
+def test_issue_6700():
+    X = Die('X', 6)
+    assert P(X - 3) == S(1)/6
+    assert P(X - 4, X > 3) == S(1)/3
+    assert P(X**2 - 4) == S(1)/6


### PR DESCRIPTION
Expressions in sympy.stats are now assumed to be equal to zero. Tests were added.
For example:
```
>>> X = Die('X', 6)
>>> P(X - 3) # This is same as P(Eq(X - 3, 0))
1/6
```

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #6700