### PR TITLE
Change in `arg` documentation

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -586,7 +586,7 @@ class Abs(Function):
 
 class arg(Function):
     """
-    Returns the argument (in radians) of a complex number. For a real
+    Returns the argument (in radians) of a complex number. For a positive
     number, the argument is always 0.
 
     Examples


### PR DESCRIPTION
Small change in the documentation of `arg`, which incorrectly stated that the argument for any real number is zero.

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
