### PR TITLE
Min/Max simplification consolidated

### DIFF
--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -555,9 +555,22 @@ def test_DiagramGrid():
     assert grid[0, 0] == A
     assert grid[0, 1] == B
 
+
+def test_DiagramGrid_pseudopod():
     # Test a diagram in which even growing a pseudopod does not
     # eventually help.
+    A = Object("A")
+    B = Object("B")
+    C = Object("C")
+    D = Object("D")
+    E = Object("E")
     F = Object("F")
+    A_ = Object("A'")
+    B_ = Object("B'")
+    C_ = Object("C'")
+    D_ = Object("D'")
+    E_ = Object("E'")
+
     f1 = NamedMorphism(A, B, "f1")
     f2 = NamedMorphism(A, C, "f2")
     f3 = NamedMorphism(A, D, "f3")

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -262,12 +262,9 @@ class AssocOp(Basic):
             # this is not the same as args_cnc because here
             # we don't assume expr is a Mul -- hence deal with args --
             # and always return a set.
-            cpart, ncpart = [], []
+            sifted = ncpart, cpart = [], []
             for arg in expr.args:
-                if arg.is_commutative:
-                    cpart.append(arg)
-                else:
-                    ncpart.append(arg)
+                sifted[arg.is_commutative is True].append(arg)
             return set(cpart), ncpart
 
         c, nc = _ncsplit(self)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -495,18 +495,21 @@ def test_issue_10323():
 
 
 def test_AssocOp_Function():
-    e = S('''
+    # the first arg of Min is not comparable in the imaginary part
+    raises(ValueError, lambda: S('''
     Min(-sqrt(3)*cos(pi/18)/6 + re(1/((-1/2 - sqrt(3)*I/2)*(1/6 +
     sqrt(3)*I/18)**(1/3)))/3 + sin(pi/18)/2 + 2 + I*(-cos(pi/18)/2 -
     sqrt(3)*sin(pi/18)/6 + im(1/((-1/2 - sqrt(3)*I/2)*(1/6 +
     sqrt(3)*I/18)**(1/3)))/3), re(1/((-1/2 + sqrt(3)*I/2)*(1/6 +
     sqrt(3)*I/18)**(1/3)))/3 - sqrt(3)*cos(pi/18)/6 - sin(pi/18)/2 + 2 +
     I*(im(1/((-1/2 + sqrt(3)*I/2)*(1/6 + sqrt(3)*I/18)**(1/3)))/3 -
-    sqrt(3)*sin(pi/18)/6 + cos(pi/18)/2))''')
-    # the following should not raise a recursion error; it
-    # should raise a value error because the first arg computes
-    # a non-comparable (prec=1) imaginary part
-    raises(ValueError, lambda: e._eval_evalf(2))
+    sqrt(3)*sin(pi/18)/6 + cos(pi/18)/2))'''))
+    # if that is changed so a non-comparable number remains as
+    # an arg, then the Min/Max instantiation needs to be changed
+    # to watch out for non-comparable args when making simplifications
+    # and the following test should be added instead (with e being
+    # the sympified expression above):
+    # raises(ValueError, lambda: e._eval_evalf(2))
 
 
 def test_issue_10395():

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -343,54 +343,203 @@ class MinMaxBase(Expr, LatticeOp):
         # first standard filter, for cls.zero and cls.identity
         # also reshape Max(a, Max(b, c)) to Max(a, b, c)
         try:
-            _args = frozenset(cls._new_args_filter(args))
+            args = frozenset(cls._new_args_filter(args))
         except ShortCircuit:
             return cls.zero
 
-        # second filter
-        # variant I: remove ones which can be removed
-        # args = cls._collapse_arguments(set(_args), **assumptions)
+        evaluate = assumptions.pop('evaluate', True)
+        check = assumptions.pop('check', True)
+        if evaluate:
+            uargs = set(args)
+            # second filter
+            # variant II: remove redundant args that are easily identified
+            args = cls._collapse_arguments(args, **assumptions)
 
-        # variant II: find local zeros
-        args = cls._find_localzeros(set(_args), **assumptions)
+        # variant I: find local zeros
+        args = cls._find_localzeros(args, **assumptions)
 
         if not args:
-            return cls.identity
+            rv = cls.identity
         elif len(args) == 1:
-            return args.pop()
+            rv = list(args).pop()
         else:
             # base creation
             # XXX should _args be made canonical with sorting?
             _args = frozenset(args)
             obj = Expr.__new__(cls, _args, **assumptions)
             obj._argset = _args
-            return obj
+            rv = obj
 
-    def _eval_simplify(self, ratio, measure):
-        # simplify Min(foo, y, Max(foo, x)) to Min(foo, y)
-        # Like And/Or, anything in common between the two
-        # is cause to eliminate the opposite arg.
-        cls = self.func
+        if evaluate and check and uargs:
+            # check the result against the unevaluate result
+            u = cls(*uargs, evaluate=False)
+            free = u.free_symbols
+            from sympy.core.relational import Eq
+            from sympy.core.numbers import Number
+            from itertools import permutations
+            eq = Eq(u, rv)
+            n = u.atoms(Number)
+            if 1 or not n:
+                for i in permutations(range(len(free))):
+                    reps = dict(zip(free, i))
+                    if eq.xreplace(reps) != True:
+                        print('logic error')
+                        print('unevaluated',u, u.xreplace(reps))
+                        print('evaluated', rv, rv.xreplace(reps))
+                        print(reps)
+                        print('-'*22)
+                        break
+            else:
+                from random import randint
+                for i in range(100):
+                    reps = dict(zip(free, [
+                        randint(min(n) -1, max(n)+2)
+                        for i in range(len(free))]))
+                    if eq.xreplace(reps) != True:
+                        print('logic error')
+                        print('unevaluated',u,u.xreplace(reps))
+                        print('evaluated', rv,rv.xreplace(reps))
+                        print('-'*22)
+                        break
+        return rv
+
+    @classmethod
+    def _collapse_arguments(cls, args, **assumptions):
+        """Remove redundant args.
+
+        Examples
+        ========
+
+        >>> from sympy import Min, Max
+        >>> from sympy.abc import a, b, c, d, e
+
+        Any arg in parent that appears in any
+        parent-like function in any of the flat args
+        of parent can be removed from that sub-arg:
+
+        >>> Min(a, Max(b, Min(a, c, d)))
+        Min(a, Max(b, Min(c, d)))
+
+        If the arg of parent appears in an opposite-than parent
+        function in any of the flat args of parent that function
+        can be replaced with the arg:
+
+        >>> Min(a, Max(b, Min(c, d, Max(a, e))))
+        Min(a, Max(b, Min(a, c, d)))
+
+        """
+        from sympy.utilities.iterables import ordered
+        from sympy.utilities.iterables import sift
+        from sympy.simplify.simplify import walk
+
+        if not args:
+            return args
+        args = list(ordered(args))
         if cls == Min:
-            op = Max
-        elif cls == Max:
-            op = Min
+            other = Max
         else:
-            op = None
-        if op:
-            unnested = set()
-            nested = []
+            other = Min
+
+        # find global comparable max of Max and min of Min if a new
+        # value is being introduced in these args at position 0 of
+        # the ordered args
+        if args[0].is_number:
+            minmax = []
+            for i in args:
+                minmax.extend([v for v in walk(i, (Min, Max))
+                    if v.args[0].is_comparable])
+            ismin = sift(minmax, lambda x: isinstance(x, Min))
+            mins = ismin[True]
+            small = Min.identity
+            for i in mins:
+                v = i.args[0]
+                if v.is_number and (v < small) == True:
+                    small = v
+            maxs = ismin[False]
+            big = Max.identity
+            if maxs:
+                for i in maxs:
+                    v = i.args[0]
+                    if v.is_number and (v > big) == True:
+                        big = v
+            # at the point when this function is called from __new__,
+            # there may be more than one numeric arg present since
+            # local zeros have not been handled yet, so look through
+            # more than the first arg
+            if cls == Min:
+                for i in range(len(args)):
+                    if not args[i].is_number:
+                        break
+                    if (args[i] < small) == True:
+                        small = args[i]
+            elif cls == Max:
+                for i in range(len(args)):
+                    if not args[i].is_comparable:
+                        break
+                    if (args[i] > big) == True:
+                        big = args[i]
+            small = small if small != Min.identity else None
+            big = big if big != Max.identity else None
+            T = None
+            if cls == Min:
+                other = Max
+                T = small
+            else:
+                other = Min
+                T = big
+            if T is not None:
+                # remove numerical redundancy
+                for i in range(len(args)):
+                    a = args[i]
+                    if isinstance(a, other):
+                        a0 = a.args[0]
+                        if ((a0 > T) if other == Max else (a0 < T)) == True:
+                            args[i] = cls.identity
+
+        # remove redundant symbolic args
+        def do(ai, a):
+            if not isinstance(ai, (Min, Max)):
+                return ai
+            cond = a in ai.args
+            if not cond:
+                return ai.func(*[do(i, a) for i in ai.args],
+                    evaluate=False)
+            if isinstance(ai, cls):
+                return ai.func(*[do(i, a) for i in ai.args if i != a],
+                    evaluate=False)
+            return a
+        for i, a in enumerate(args):
+            args[i + 1:] = [do(ai, a) for ai in args[i + 1:]]
+
+        # rewrite Min(Max(x, y), Max(x, z)) as Max(x, Min(y, z))
+        # and vice versa when swapping Min/Max -- do this only for the
+        # easy case where all functions contain something in common;
+        # trying to find some optimal subset of args to modify takes
+        # too long
+        if len(args) > 1:
+            common = None
             remove = []
-            for a in self.args:
-                if isinstance(a, op):
-                    nested.append(a)
-                else:
-                    unnested.add(a)
-            N = len(nested) - 1
-            for i, n in enumerate(reversed(nested)):
-                if set(n.args) & unnested:
-                    nested.pop(N - i)
-            return cls(*(list(unnested) + nested))
+            sets = []
+            for i in range(len(args)):
+                a = args[i]
+                if not isinstance(a, other):
+                    continue
+                s = set(a.args)
+                common = s if common is None else (common & s)
+                if not common:
+                    break
+                sets.append(s)
+                remove.append(i)
+            else:
+                sets = [s - common for s in sets]
+                if sets and all(len(i) == 1 for i in sets):
+                    for i in reversed(remove):
+                        args.pop(i)
+                    oargs = [cls(*set.union(*sets))]
+                    oargs.extend(common)
+                    args.append(other(*oargs))
+
+        return args
 
     @classmethod
     def _new_args_filter(cls, arg_sequence):
@@ -404,7 +553,8 @@ class MinMaxBase(Expr, LatticeOp):
         for arg in arg_sequence:
 
             # pre-filter, checking comparability of arguments
-            if (not isinstance(arg, Expr)) or (arg.is_real is False) or (arg is S.ComplexInfinity):
+            if not isinstance(arg, Expr) or arg.is_real is False or (
+                    arg.is_number and not arg.is_comparable):
                 raise ValueError("The argument '%s' is not comparable." % arg)
 
             if arg == cls.zero:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -4,7 +4,8 @@ from sympy.core import S, sympify
 from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.operations import LatticeOp, ShortCircuit
-from sympy.core.function import Application, Lambda, ArgumentIndexError
+from sympy.core.function import (Application, Lambda,
+    ArgumentIndexError, AppliedUndef)
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
@@ -554,7 +555,9 @@ class MinMaxBase(Expr, LatticeOp):
 
             # pre-filter, checking comparability of arguments
             if not isinstance(arg, Expr) or arg.is_real is False or (
-                    arg.is_number and not arg.is_comparable):
+                    arg.is_number and
+                    not arg.has(AppliedUndef) and
+                    not arg.is_comparable):
                 raise ValueError("The argument '%s' is not comparable." % arg)
 
             if arg == cls.zero:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -653,7 +653,8 @@ class Piecewise(Function):
         for a, b, i in done:
             if i == -1:
                 if upto is None:
-                    return S.NaN
+                    return Undefined
+                # TODO simplify hi <= upto
                 return Piecewise((sum, hi <= upto), (Undefined, True))
             sum += abei[i][-2]._eval_interval(x, a, b)
             upto = b

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -617,6 +617,8 @@ class Piecewise(Function):
 
                 if rv == Undefined:
                     raise ValueError("Can't integrate across undefined region.")
+                if any(isinstance(i, Piecewise) for i in (pos, neg)):
+                    rv = piecewise_fold(rv)
                 return rv
 
         # handle a Piecewise with lo <= hi and no x-independent relationals

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1023,9 +1023,9 @@ def _clip(A, B, k):
     interval (3, 4) was not covered by (1, 3) and is keyed to -1.
     """
     a, b = B
-    a, b = Min(a, b), b
     c, d = A
     c, d = Min(Max(c, a), b), Min(Max(d, a), b)
+    a, b = Min(a, b), b
     p = []
     if a != c:
         p.append((a, c, -1))

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -575,8 +575,8 @@ class Piecewise(Function):
             else:
                 _a = Dummy('lo')
                 _b = Dummy('hi')
-                a = a if a.is_comparable else _a
-                b = b if b.is_comparable else _b
+                a = lo if lo.is_comparable else _a
+                b = hi if hi.is_comparable else _b
                 pos = self._eval_interval(x, a, b, _first=False)
                 if a == _a and b == _b:
                     # it's purely symbolic so just swap lo and hi and
@@ -589,6 +589,7 @@ class Piecewise(Function):
                     # the interval with lo and hi reversed
                     neg, pos = (-self._eval_interval(x, hi, lo, _first=False),
                         pos.xreplace({_a: lo, _b: hi}))
+
                 # allow simplification based on ordering of lo and hi
                 p = Dummy('', positive=True)
                 if lo.is_Symbol:
@@ -597,8 +598,11 @@ class Piecewise(Function):
                 elif hi.is_Symbol:
                     pos = pos.xreplace({hi: lo + p}).xreplace({p: hi - lo})
                     neg = neg.xreplace({hi: lo - p}).xreplace({p: lo - hi})
-                # assemble return expression
-                if a == _a:
+
+                # assemble return expression; make the first condition be Lt
+                # b/c then the first expression will look the same whether
+                # the lo or hi limit is symbolic
+                if a == _a:  # the lower limit was symbolic
                     rv = Piecewise(
                         (pos,
                             lo < hi),
@@ -611,9 +615,6 @@ class Piecewise(Function):
                         (pos,
                             True))
 
-                # apply simplification of Min/Max expressions which may
-                # respond differently now that some simplification may
-                # have occured given the ordering of lo and hi
                 if rv == Undefined:
                     raise ValueError("Can't integrate across undefined region.")
                 return rv

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -494,7 +494,7 @@ class Piecewise(Function):
         oo = S.Infinity
         done = [(-oo, oo, -1)]
         for k, p in enumerate(pieces):
-            if p[:2] == (-oo, oo):
+            if p == (-oo, oo):
                 # all undone intervals will get this key
                 for j, (a, b, i) in enumerate(done):
                     if i == -1:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -647,14 +647,16 @@ class Piecewise(Function):
                     done[j: j + 1] = _clip(p, (a, b), k)
         done = [(a, b, i) for a, b, i in done if a != b]
 
-        # check for holes
-        if any(i == -1 for (a, b, i) in done):
-            return S.NaN
-
         # return the sum of the intervals
         sum = S.Zero
+        upto = None
         for a, b, i in done:
+            if i == -1:
+                if upto is None:
+                    return S.NaN
+                return Piecewise((sum, hi <= upto), (Undefined, True))
             sum += abei[i][-2]._eval_interval(x, a, b)
+            upto = b
         return sum
 
     def _intervals(self, sym):

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -373,6 +373,6 @@ def test_issue_11099():
 
 def test_issue_12638():
     from sympy.abc import a, b, c, d
-    assert Min(a, b, c, Max(a, b)).simplify() == Min(a, b, c)
-    assert Min(a, b, Max(a, b, c)).simplify() == Min(a, b)
-    assert Min(a, b, Max(a, c)).simplify() == Min(a, b)
+    assert Min(a, b, c, Max(a, b)) == Min(a, b, c)
+    assert Min(a, b, Max(a, b, c)) == Min(a, b)
+    assert Min(a, b, Max(a, c)) == Min(a, b)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -379,7 +379,7 @@ def test_issue_12638():
 
 
 def test_instantiation_evaluation():
-    from sympy.abc import w, x, y, z
+    from sympy.abc import v, w, x, y, z
     assert Min(1, Max(2, x)) == 1
     assert Max(3, Min(2, x)) == 3
     assert Min(Max(x, y), Max(x, z)) == Max(x, Min(y, z))
@@ -392,3 +392,5 @@ def test_instantiation_evaluation():
         assert A(x, B(x, y)) == x
         assert A(x, B(y, A(x, w, z))) == A(x, B(y, A(w, z)))
         A, B = B, A
+    assert Min(w, Max(x, y), Max(v, x, z)) == Min(
+        w, Max(x, Min(y, Max(v, z))))

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -376,3 +376,19 @@ def test_issue_12638():
     assert Min(a, b, c, Max(a, b)) == Min(a, b, c)
     assert Min(a, b, Max(a, b, c)) == Min(a, b)
     assert Min(a, b, Max(a, c)) == Min(a, b)
+
+
+def test_instantiation_evaluation():
+    from sympy.abc import w, x, y, z
+    assert Min(1, Max(2, x)) == 1
+    assert Max(3, Min(2, x)) == 3
+    assert Min(Max(x, y), Max(x, z)) == Max(x, Min(y, z))
+    assert set(Min(Max(w, x), Max(y, z)).args) == set(
+        [Max(w, x), Max(y, z)])
+    assert Min(Max(x, y), Max(x, z), w) == Min(
+        w, Max(x, Min(y, z)))
+    A, B = Min, Max
+    for i in range(2):
+        assert A(x, B(x, y)) == x
+        assert A(x, B(y, A(x, w, z))) == A(x, B(y, A(w, z)))
+        A, B = B, A

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1014,10 +1014,10 @@ def test_issue_8919():
         (0, (x >= y) | (x < 0) | (b > c)),
         (a, True)), (x, 0, z))
     ans = I.doit()
-    assert ans == Piecewise((0, b > c), (a*z - a*Min(0, z), True))
+    assert ans == Piecewise((0, b > c), (a*Min(y, z) - a*Min(0, z), True))
     for cond in (True, False):
          for yy in range(1, 3):
-             for zz in range(-1, 0, 1):
+             for zz in range(-yy, 0, yy):
                  reps = [(b > c, cond), (y, yy), (z, zz)]
                  assert ans.subs(reps) == I.subs(reps).doit()
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -710,12 +710,12 @@ def test_issue_11045():
     i = p.integrate((x, 1, y))
     assert i == Piecewise(
         (y - 1, y < 1),
-        (Piecewise(
-            (Min(3, y)**2/2 - Min(3, y) + Min(4, y) - 1/2,
-                y <= Min(4, y)),
-            (nan, True)), True))
+        (Min(3, y)**2/2 - Min(3, y) + Min(4, y) - 1/2,
+            y <= Min(4, y)),
+        (nan, True))
     assert p.integrate((x, 1, -1)) == i.subs(y, -1)
     assert p.integrate((x, 1, 4)) == 5
+    assert p.integrate((x, 1, 5)) == nan
 
     # handle Not
     p = Piecewise((1, x > 1), (2, Not(And(x > 1, x< 3))), (3, True))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -221,43 +221,16 @@ def test_piecewise_integrate1c():
             (y**2/2 + y - 1/2, y <= 0),
             (-y**2/2 + y - 1/2, y < 1),
             (0, True))
-        if i == 0:
-            assert gy1 == Piecewise(
-                (-Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
-                    Min(1, Max(0, y))**2 + 1/2, y < 1),
-                (0, True))
-            assert g1y == Piecewise(
-                (Min(1, Max(-1, y))**2/2 + Min(1, Max(-1, y)) -
-                    Min(1, Max(0, y))**2 - 1/2, y < 1),
-                (0, True))
-        else:
-            assert gy1 == Piecewise(
-                (-Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
-                    Min(1, Max(0, y))**2 + 1/2, y < 1),
-                (0, True))
-            assert g1y == Piecewise(
-                (Min(1, Max(-1, y))**2/2 + Min(1, Max(-1, y)) -
-                    Min(1, Max(0, y))**2 - 1/2, y < 1),
-                (0, True))
-        # the following are also possible:
-        #if i == 0:
-        #    assert gy1 == Piecewise(
-        #        (-Max(-1, y)**2/2 - Max(-1, y) +
-        #             Max(0, y)**2 + 1/2, y < 1),
-        #         (0, True))
-        #    assert g1y == Piecewise(
-        #        (Max(-1, y)**2/2 + Max(-1, y) -
-        #            Max(0, y)**2 - 1/2, y < 1),
-        #        (0, True))
-        #else:
-        #    assert gy1 == Piecewise(
-        #        (Max(0, y)**2 - Min(1, Max(-1, y))**2/2 -
-        #            Min(1, Max(-1, y)) + 1/2, y < 1),
-        #        (0, True))
-        #    assert g1y == Piecewise(
-        #        (-Max(0, y)**2 + Min(1, Max(-1, y))**2/2 +
-        #            Min(1, Max(-1, y)) - 1/2, y < 1),
-        #        (0, True))
+        # g1y and gy1 should simplify if the condition that y < 1
+        # is applied, e.g. Min(1, Max(-1, y)) --> Max(-1, y)
+        assert gy1 == Piecewise(
+            (-Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
+                Min(1, Max(0, y))**2 + 1/2, y < 1),
+            (0, True))
+        assert g1y == Piecewise(
+            (Min(1, Max(-1, y))**2/2 + Min(1, Max(-1, y)) -
+                Min(1, Max(0, y))**2 - 1/2, y < 1),
+            (0, True))
 
 
 def test_piecewise_integrate2():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -173,6 +173,8 @@ def test_piecewise_integrate1():
     assert integrate(g, (x, -2, 2)) == 2 * Rational(14, 3)
     assert integrate(g, (x, -2, 5)) == -Rational(673, 6)
 
+
+def test_piecewise_integrate1b():
     g = Piecewise((1, x > 0), (0, Eq(x, 0)), (-1, x < 0))
     assert integrate(g, (x, -1, 1)) == 0
 
@@ -185,68 +187,77 @@ def test_piecewise_integrate1():
     assert integrate(g, (y, -oo, oo)) == -x + oo
 
     g = Piecewise((0, x < 0), (x, x <= 1), (1, True))
-    assert integrate(g, (x, -5, 1)) == Rational(1, 2)
-    assert integrate(g, (x, -5, y)).subs(y, 1) == Rational(1, 2)
-    assert integrate(g, (x, y, 1)).subs(y, -5) == Rational(1, 2)
-    assert integrate(g, (x, 1, -5)) == -Rational(1, 2)
-    assert integrate(g, (x, 1, y)).subs(y, -5) == -Rational(1, 2)
-    assert integrate(g, (x, y, -5)).subs(y, 1) == -Rational(1, 2)
-    assert integrate(g, (x, -5, y)) == Piecewise(
-        (y - Min(0, y)**2/2 + Min(1, y)**2/2 - Min(1, y), y > -5),
-        (0, True))
-    assert integrate(g, (x, y, 1)) == Piecewise(
+    gy1 = g.integrate((x, y, 1))
+    g1y = g.integrate((x, 1, y))
+    for yy in (-1, S.Half, 2):
+        assert g.integrate((x, yy, 1)) == gy1.subs(y, yy)
+        assert g.integrate((x, 1, yy)) == g1y.subs(y, yy)
+    assert gy1 == Piecewise(
         (-Min(1, Max(0, y))**2/2 + 1/2, y < 1),
         (-y + 1, True))
+    assert g1y == Piecewise(
+        (Min(1, Max(0, y))**2/2 - 1/2, y < 1),
+        (y - 1, True))
 
-    for j, g in enumerate([
+
+def test_piecewise_integrate1c():
+    for i, g in enumerate([
         Piecewise((1 - x, Interval(0, 1).contains(x)),
             (1 + x, Interval(-1, 0).contains(x)), (0, True)),
         Piecewise((0, Or(x <= -1, x >= 1)), (1 - x, x > 0),
             (1 + x, True))]):
-        assert integrate(g, (x, -5, 1)) == 1
-        assert integrate(g, (x, 1, -5)) == -1
-        assert integrate(g, (x, 1, y)).subs(y, -5) == -1
-        assert integrate(g, (x, y, -5)).subs(y, 1) == -1
-        i = integrate(g, (x, -5, y))
-        assert i.subs(y, 1) == 1
-        assert piecewise_fold(i.rewrite(Piecewise)
-            ) == Piecewise(
-            (1, y >= 1),
-            (-y**2/2 + y + 1/2, y >= 0),
-            (y**2/2 + y + 1/2, y >= -1),
-            (0, True))
-        assert i == Piecewise(
-            (-Min(-1, y)**2/2 - Min(-1, y) +
-                Min(0, y)**2 - Min(1, y)**2/2 + Min(1, y), y > -5),
-            (0, True))
-        i = integrate(g, (x, y, 1))
-        assert i.subs(y, -5) == 1
-        assert piecewise_fold(i.rewrite(Piecewise)
-            )== Piecewise(
+        gy1 = g.integrate((x, y, 1))
+        g1y = g.integrate((x, 1, y))
+        for yy in (-2, 0, 2):
+            assert g.integrate((x, yy, 1)) == gy1.subs(y, yy)
+            assert g.integrate((x, 1, yy)) == g1y.subs(y, yy)
+        assert piecewise_fold(gy1.rewrite(Piecewise)) == Piecewise(
             (1, y <= -1),
             (-y**2/2 - y + 1/2, y <= 0),
             (y**2/2 - y + 1/2, y < 1),
             (0, True))
-        # the solutions are different because
-        # Min(1, Max(-1, y), Max(0, y)) is not
-        # simplifying to Min(1, Max(-1, y))
-        assert i == [
-            Piecewise(
-                (
-                -Min(1, Max(-1, y), Max(0, y))**2/2
-                -Min(1, Max(-1, y), Max(0, y))
-                +Min(1, Max(0, y))**2
-                +1/2,
-                    y < 1),
-                (0, True)),
-            Piecewise(
-                (
-                -Min(1, Max(-1, y))**2/2
-                -Min(1, Max(-1, y))
-                +Min(1, Max(0, y))**2
-                +1/2,
-                    y < 1),
-                (0, True))][j]
+        assert piecewise_fold(g1y.rewrite(Piecewise)) == Piecewise(
+            (-1, y <= -1),
+            (y**2/2 + y - 1/2, y <= 0),
+            (-y**2/2 + y - 1/2, y < 1),
+            (0, True))
+        if i == 0:
+            assert gy1 == Piecewise(
+                (-Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
+                    Min(1, Max(0, y))**2 + 1/2, y < 1),
+                (0, True))
+            assert g1y == Piecewise(
+                (Min(1, Max(-1, y))**2/2 + Min(1, Max(-1, y)) -
+                    Min(1, Max(0, y))**2 - 1/2, y < 1),
+                (0, True))
+        else:
+            assert gy1 == Piecewise(
+                (-Min(1, Max(-1, y))**2/2 - Min(1, Max(-1, y)) +
+                    Min(1, Max(0, y))**2 + 1/2, y < 1),
+                (0, True))
+            assert g1y == Piecewise(
+                (Min(1, Max(-1, y))**2/2 + Min(1, Max(-1, y)) -
+                    Min(1, Max(0, y))**2 - 1/2, y < 1),
+                (0, True))
+        # the following are also possible:
+        #if i == 0:
+        #    assert gy1 == Piecewise(
+        #        (-Max(-1, y)**2/2 - Max(-1, y) +
+        #             Max(0, y)**2 + 1/2, y < 1),
+        #         (0, True))
+        #    assert g1y == Piecewise(
+        #        (Max(-1, y)**2/2 + Max(-1, y) -
+        #            Max(0, y)**2 - 1/2, y < 1),
+        #        (0, True))
+        #else:
+        #    assert gy1 == Piecewise(
+        #        (Max(0, y)**2 - Min(1, Max(-1, y))**2/2 -
+        #            Min(1, Max(-1, y)) + 1/2, y < 1),
+        #        (0, True))
+        #    assert g1y == Piecewise(
+        #        (-Max(0, y)**2 + Min(1, Max(-1, y))**2/2 +
+        #            Min(1, Max(-1, y)) - 1/2, y < 1),
+        #        (0, True))
 
 
 def test_piecewise_integrate2():
@@ -722,11 +733,12 @@ def test_issue_11045():
         ).integrate((x, 1, 4)) == 5
 
     p = Piecewise((x, (x > 1) & (x < 3)), (1, (x < 4)))
-    # with y unknown, this fails because there might be a hole
-    # in intervals [Min(1, Max(4, y)), 1] and [Min(4, y), y]. The
-    # first one should simplify (i.e. since 1 is less than the
-    # minumum value of Max(4, y) that interval should be [1, 1]
-    raises(ValueError, lambda: p.integrate((x, 1, y)))
+    # Although the function is undefined past x = 4, the following
+    # limits the known result to y being less than 1; XXX fix this
+    nan = Undefined
+    i = p.integrate((x, 1, y))
+    assert i == Piecewise((y - 1, y < 1), (nan, True))
+    assert p.integrate((x, 1, -1)) == i.subs(y, -1)
     assert p.integrate((x, 1, 4)) == 5
 
     # handle Not
@@ -880,15 +892,30 @@ def test_issue_12557():
 
 
 def test_issue_6900():
+    from itertools import permutations
     t0, t1, T, t = symbols('t0, t1 T t')
     f = Piecewise((0, t < t0), (x, And(t0 <= t, t < t1)), (0, t >= t1))
-    assert f.integrate(t) == Piecewise(
+    g = f.integrate(t)
+    assert g == Piecewise(
         (0, t <= t0),
         (t*x - t0*x, t <= Max(t0, t1)),
         (-t0*x + x*Max(t0, t1), True))
-    assert f.integrate((t, t0, T)) == Piecewise(
+    for i in permutations(range(2)):
+        reps = dict(zip((t0,t1), i))
+        for tt in range(-1,3):
+            assert (g.xreplace(reps).subs(t,tt) ==
+                f.xreplace(reps).integrate(t).subs(t,tt))
+    lim = Tuple(t, t0, T)
+    g = f.integrate(lim)
+    ans = Piecewise(
         (-t0*x + x*Min(T, Max(t0, t1)), T > t0),
         (0, True))
+    for i in permutations(range(3)):
+        reps = dict(zip((t0,t1,T), i))
+        tru = f.xreplace(reps).integrate(lim.xreplace(reps))
+        assert tru == ans.xreplace(reps)
+    assert g == ans
+
 
 def test_issue_10122():
     assert solve(abs(x) + abs(x - 1) - 1 > 0, x

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -706,11 +706,14 @@ def test_issue_11045():
         ).integrate((x, 1, 4)) == 5
 
     p = Piecewise((x, (x > 1) & (x < 3)), (1, (x < 4)))
-    # Although the function is undefined past x = 4, the following
-    # limits the known result to y being less than 1; XXX fix this
     nan = Undefined
     i = p.integrate((x, 1, y))
-    assert i == Piecewise((y - 1, y < 1), (nan, True))
+    assert i == Piecewise(
+        (y - 1, y < 1),
+        (Piecewise(
+            (Min(3, y)**2/2 - Min(3, y) + Min(4, y) - 1/2,
+                y <= Min(4, y)),
+            (nan, True)), True))
     assert p.integrate((x, 1, -1)) == i.subs(y, -1)
     assert p.integrate((x, 1, 4)) == 5
 

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -202,12 +202,9 @@ class ColorScheme(object):
         return vars
 
     def _sort_args(self, args):
-        atoms, lists = [], []
+        sifted = atoms, lists = [], []
         for a in args:
-            if isinstance(a, (tuple, list)):
-                lists.append(a)
-            else:
-                atoms.append(a)
+            sifted[isinstance(a, (tuple, list))].append(a)
         return atoms, lists
 
     def _test_color_function(self):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1003,6 +1003,33 @@ def logcombine(expr, force=False):
     return bottom_up(expr, f)
 
 
+def walk(e, *target):
+    """iterate through the args that are the given types (target) and
+    return a list of the args that were traversed; arguments
+    that are not of the specified types are not traversed.
+
+    Examples
+    ========
+
+    >>> from sympy.simplify.simplify import walk
+    >>> from sympy import Min, Max
+    >>> from sympy.abc import x, y, z
+    >>> list(walk(Min(x, Max(y, Min(1, z))), Min))
+    [Min(x, Max(y, Min(1, z)))]
+    >>> list(walk(Min(x, Max(y, Min(1, z))), Min, Max))
+    [Min(x, Max(y, Min(1, z))), Max(y, Min(1, z)), Min(1, z)]
+
+    See Also
+    ========
+    bottom_up
+    """
+    if isinstance(e, target):
+        yield e
+        for i in e.args:
+            for w in walk(i, *target):
+                yield w
+
+
 def bottom_up(rv, F, atoms=False, nonbasic=False):
     """Apply ``F`` to all expressions in an expression tree from the
     bottom up. If ``atoms`` is True, apply ``F`` even if there are no args;

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2571,8 +2571,8 @@ def test_W22():
     t, u = symbols('t u', real=True)
     s = Lambda(x, Piecewise((1, And(x >= 1, x <= 2)), (0, True)))
     assert integrate(s(t)*cos(t), (t, 0, u)) == Piecewise(
-        (-sin(Min(1, u)) + sin(Min(2, u)), u > 0),
-        (0, True))
+        (0, u < 0),
+        (-sin(Min(1, u)) + sin(Min(2, u)), True))
 
 
 @XFAIL
@@ -2582,17 +2582,14 @@ def test_W23():
     r1 = integrate(integrate(x/(x**2 + y**2), (x, a, b)), (y, -oo, oo))
     assert r1.simplify() == pi*(-a + b)
 
+
 @SKIP("integrate raises RuntimeError: maximum recursion depth exceeded")
 @slow
 def test_W23b():
-    # this used to be test_W23.  Can't really split since r1 is needed
-    # in the second assert
+    # like W23 but limits are reversed
     a, b = symbols('a b', real=True, positive=True)
-    r1 = integrate(integrate(x/(x**2 + y**2), (x, a, b)), (y, -oo, oo))
-    assert r1.simplify() == pi*(-a + b)
-    # integrate raises RuntimeError: maximum recursion depth exceeded
     r2 = integrate(integrate(x/(x**2 + y**2), (y, -oo, oo)), (x, a, b))
-    assert r1 == r2
+    assert r2 == pi*(-a + b)
 
 
 @XFAIL
@@ -2611,8 +2608,9 @@ def test_W25():
     if ON_TRAVIS:
         skip("Too slow for travis.")
     a, x, y = symbols('a x y', real=True)
-    i1 = integrate(sin(a)*sin(y)/sqrt(1- sin(a)**2*sin(x)**2*sin(y)**2),
-                   (x, 0, pi/2))
+    i1 = integrate(
+        sin(a)*sin(y)/sqrt(1 - sin(a)**2*sin(x)**2*sin(y)**2),
+        (x, 0, pi/2))
     i2 = integrate(i1, (y, 0, pi/2))
     assert (i2 - pi*a/2).simplify() == 0
 


### PR DESCRIPTION
This is a fix of an error (see correct test for issue 8919) introduced by the simplification of #12587. Casting Min/Max to And/Or had an unintended consequence when non-vanilla symbols simplified in And/Or in ways that they would not have simplified in the original Min/Max functions.  That recasting simplification has been removed and consolidated in the MinMaxBase instantiation routine, specifically in the `_collapse_arguments` routine.

The DiagramGrid test was split since it was timing out.

Changelog notes from #12587 are included here, too

<!-- changelog -->
## This PR changes Piecewise integration
M: a new integration technique has been implemented that should eliminate errors that formerly arose with complex conditions and should be robust for Piecewise functions that contain conditions in more than one variable
m: integration hints are passed along during piecewise integration
m: indefinite integration of Piecewise now returns a continuous result; the old result (integration of pieces) is now called by method `piecewise_integrate`
n: `piecewise_integrate` can be used to independently integrate the pieces of Piecewise
b: `_sort_expr_cond` has been removed and replaced with `_intervals` which gives unsorted intervals and expressions generated by the Piecewise function; there is not a 1:1 correspondence between the items returned and the Piecewise arguments
n: `walk` has been added to simplify (but has not been exposed). It basically implements a method to traverse a given type of arguments in a flat fashion
n: `_collapse_arguments` for MinMaxBase has now been implemented and will automatically (via instantiation) result in simpler expressions when there are redundant arguments; the collapsing can be disabled by using "evaluate=False". local zeroes are always removed (but that could easily be changed to happen only if `evaluate=True`
<!-- [CHANGELOG END] -->