### PR TITLE
Make wigner_9j work for certain half-integer argument combinations [continuation of #13589]

### DIFF
--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -241,6 +241,18 @@ def test_wigner():
     # regression test for #8747
     half = Rational(1, 2)
     assert wigner_9j(0, 0, 0, 0, half, half, 0, half, half) == half
+    assert (wigner_9j(3, 5, 4,
+                      7 * half, 5 * half, 4,
+                      9 * half, 9 * half, 0)
+            == -sqrt(Rational(361, 205821000)))
+    assert (wigner_9j(1, 4, 3,
+                      5 * half, 4, 5 * half,
+                      5 * half, 2, 7 * half)
+            == -sqrt(Rational(3971, 373403520)))
+    assert (wigner_9j(4, 9 * half, 5 * half,
+                      2, 4, 4,
+                      5, 7 * half, 7 * half)
+            == -sqrt(Rational(3481, 5042614500)))
 
 
 def test_gaunt():

--- a/sympy/physics/tests/test_clebsch_gordan.py
+++ b/sympy/physics/tests/test_clebsch_gordan.py
@@ -238,6 +238,9 @@ def test_wigner():
         70)/(246960*sqrt(105)) - 365/(3528*sqrt(70)*sqrt(105))
     assert wigner_6j(5, 5, 5, 5, 5, 5) == Rational(1, 52)
     assert tn(wigner_6j(8, 8, 8, 8, 8, 8, prec=64), -S(12219)/965770)
+    # regression test for #8747
+    half = Rational(1, 2)
+    assert wigner_9j(0, 0, 0, 0, half, half, 0, half, half) == half
 
 
 def test_gaunt():

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -536,19 +536,14 @@ def wigner_9j(j_1, j_2, j_3, j_4, j_5, j_6, j_7, j_8, j_9, prec=None):
     for finite precision arithmetic and only useful for a computer
     algebra system [Rasch03]_.
     """
-
-    imax = min(j_1 + j_9, j_2 + j_6, j_4 + j_8)
-    j_sum = j_1 + j_2 + j_9 + j_6 + j_4 + j_8
+    imax = int(min(j_1 + j_9, j_2 + j_6, j_4 + j_8) * 2)
+    imin = imax % 2
     sumres = 0
-    for kk in range(0, 2*(int(imax) + 1)):
-        k = S.Half*kk
-        try:
-            sumres +=(-1)**(kk+2*j_sum)*(kk + 1) * \
-            racah(j_1, j_2, j_9, j_6, j_3, k, prec) * \
-            racah(j_4, j_6, j_8, j_2, j_5, k, prec) * \
-            racah(j_1, j_4, j_9, j_8, j_7, k, prec)
-        except ValueError:
-            pass
+    for kk in range(imin, int(imax) + 1, 2):
+        sumres = sumres + (kk + 1) * \
+            racah(j_1, j_2, j_9, j_6, j_3, kk / 2, prec) * \
+            racah(j_4, j_6, j_8, j_2, j_5, kk / 2, prec) * \
+            racah(j_1, j_4, j_9, j_8, j_7, kk / 2, prec)
     return sumres
 
 


### PR DESCRIPTION
This is the same as #13589 but with an additional commit to include extra tests.