### PR TITLE
fixed matrix derivatives and .diff( )

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -504,10 +504,10 @@ class Quaternion(Expr):
         >>> q = Quaternion(cos(x/2), 0, 0, sin(x/2))
         >>> trigsimp(q.to_rotation_matrix((1, 1, 1)))
          Matrix([
-        [cos(x), -sin(x), 0, -sqrt(2)*cos(x + pi/4) + 1],
-        [sin(x),  cos(x), 0, -sqrt(2)*sin(x + pi/4) + 1],
-        [     0,       0, 1,                          0],
-        [     0,       0, 0,                          1]])
+        [cos(x), -sin(x), 0,  sin(x) - cos(x) + 1],
+        [sin(x),  cos(x), 0, -sin(x) - cos(x) + 1],
+        [     0,       0, 1,                    0],
+        [     0,       0, 0,                    1]])
         """
 
         q = self

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -111,7 +111,7 @@ def test_quaternion_conversions():
                                    2*acos(cos(theta/2)))
 
     assert trigsimp(q2.to_rotation_matrix((1, 1, 1))) == Matrix([
-               [cos(theta), -sin(theta), 0, -sqrt(2)*cos(theta + pi/4) + 1],
-               [sin(theta),  cos(theta), 0, -sqrt(2)*sin(theta + pi/4) + 1],
-               [0,           0,          1,  0                            ],
-               [0,           0,          0,  1                            ]])
+               [cos(theta), -sin(theta), 0, sin(theta) - cos(theta) + 1],
+               [sin(theta),  cos(theta), 0, -sin(theta) - cos(theta) + 1],
+               [0,           0,          1,  0],
+               [0,           0,          0,  1]])

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -90,6 +90,8 @@ class Basic(with_metaclass(ManagedProperties)):
     is_Matrix = False
     is_Vector = False
     is_Point = False
+    is_MatAdd = False
+    is_MatMul = False
 
     def __new__(cls, *args):
         obj = object.__new__(cls)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2531,7 +2531,7 @@ def count_ops(expr, visual=False):
                     if a.q != 1:
                         ops.append(DIV)
                     continue
-            elif a.is_Mul:
+            elif a.is_Mul or a.is_MatMul:
                 if _coeff_isneg(a):
                     ops.append(NEG)
                     if a.args[0] is S.NegativeOne:
@@ -2551,7 +2551,7 @@ def count_ops(expr, visual=False):
                     ops.append(DIV)
                     args.append(n)
                     continue  # could be -Mul
-            elif a.is_Add:
+            elif a.is_Add or a.is_MatAdd:
                 aargs = list(a.args)
                 negs = 0
                 for i, ai in enumerate(aargs):

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -126,7 +126,7 @@ def test_issue_9324():
     assert count(2 * M[0, 0] + M[5, 7]) == 2
     P = MatrixSymbol('P', 3, 3)
     Q = MatrixSymbol('Q', 3, 3)
-    assert count(P + Q) == 3
+    assert count(P + Q) == 1
     m = Symbol('m', integer=True)
     n = Symbol('n', integer=True)
     M = MatrixSymbol('M', m + n, m * m)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1881,6 +1881,10 @@ class MatrixOperations(MatrixRequired):
 
     _eval_simplify = simplify
 
+    def _eval_trigsimp(self, **opts):
+        from sympy.simplify import trigsimp
+        return self.applyfunc(lambda x: trigsimp(x, **opts))
+
 
 class MatrixArithmetic(MatrixRequired):
     """Provides basic matrix arithmetic operations.

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -30,7 +30,7 @@ def _sympifyit(arg, retval=None):
     return deco
 
 
-class MatrixExpr(Basic):
+class MatrixExpr(Expr):
     """ Superclass for Matrix Expressions
 
     MatrixExprs represent abstract matrices, linear transformations represented
@@ -70,7 +70,8 @@ class MatrixExpr(Basic):
     is_MatMul = False
 
     is_commutative = False
-
+    is_number = False
+    is_symbol = True
 
     def __new__(cls, *args, **kwargs):
         args = map(sympify, args)

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -23,56 +23,56 @@ d = MatrixSymbol("d", k, 1)
 
 def test_matrix_derivative_trivial_cases():
     # Cookbook example 33:
-    assert X._eval_derivative(A) == 0
+    assert X.diff(A) == 0
 
 
 def test_matrix_derivative_vectors_and_scalars():
 
     # Cookbook example 69:
     expr = x.T*a
-    assert expr._eval_derivative(x) == a
+    assert expr.diff(x) == a
     expr = a.T*x
-    assert expr._eval_derivative(x) == a
+    assert expr.diff(x) == a
 
     # Cookbook example 70:
     expr = a.T*X*b
-    assert expr._eval_derivative(X) == a*b.T
+    assert expr.diff(X) == a*b.T
 
     # Cookbook example 71:
     expr = a.T*X.T*b
-    assert expr._eval_derivative(X) == b*a.T
+    assert expr.diff(X) == b*a.T
 
     # Cookbook example 77:
     expr = b.T*X.T*X*c
-    assert expr._eval_derivative(X) == X*b*c.T + X*c*b.T
+    assert expr.diff(X) == X*b*c.T + X*c*b.T
 
     # Cookbook example 78:
     expr = (B*x + b).T*C*(D*x + d)
-    assert expr._eval_derivative(x) == B.T*C*(D*x + d) + D.T*C.T*(B*x + b)
+    assert expr.diff(x) == B.T*C*(D*x + d) + D.T*C.T*(B*x + b)
 
     # Cookbook example 81:
     expr = x.T*B*x
-    assert expr._eval_derivative(x) == B*x + B.T*x
+    assert expr.diff(x) == B*x + B.T*x
 
     # Cookbook example 82:
     expr = b.T*X.T*D*X*c
-    assert expr._eval_derivative(X) == D.T*X*b*c.T + D*X*c*b.T
+    assert expr.diff(X) == D.T*X*b*c.T + D*X*c*b.T
 
     # Cookbook example 83:
     expr = (X*b + c).T*D*(X*b + c)
-    assert expr._eval_derivative(X) == D*(X*b + c)*b.T + D.T*(X*b + c)*b.T
+    assert expr.diff(X) == D*(X*b + c)*b.T + D.T*(X*b + c)*b.T
 
 
 def test_matrix_derivative_with_inverse():
 
     # Cookbook example 61:
     expr = a.T*Inverse(X)*b
-    assert expr._eval_derivative(X) == -Inverse(X).T*a*b.T*Inverse(X).T
+    assert expr.diff(X) == -Inverse(X).T*a*b.T*Inverse(X).T
 
     # Cookbook example 63:
     expr = Trace(A*Inverse(X)*B)
-    assert expr._eval_derivative(X) == -(X**(-1)*B*A*X**(-1)).T
+    assert expr.diff(X) == -(X**(-1)*B*A*X**(-1)).T
 
     # Cookbook example 64:
     expr = Trace(Inverse(X + A))
-    assert expr._eval_derivative(X) == -(Inverse(X + A)*Inverse(X + A)).T
+    assert expr.diff(X) == -(Inverse(X + A)*Inverse(X + A)).T

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -351,8 +351,9 @@ def test_issue_2827_trigsimp_methods():
     # all methods should work with Basic expressions even if they
     # aren't Expr
     M = Matrix.eye(1)
+    # NOTE: "groebner" is currently not tested as it raises an exception:
     assert all(trigsimp(M, method=m) == M for m in
-        'fu matching groebner old'.split())
+        'fu matching old'.split())
     # watch for E in exptrigsimp, not only exp()
     eq = 1/sqrt(E) + E
     assert exptrigsimp(eq) == eq

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -351,9 +351,8 @@ def test_issue_2827_trigsimp_methods():
     # all methods should work with Basic expressions even if they
     # aren't Expr
     M = Matrix.eye(1)
-    # NOTE: "groebner" is currently not tested as it raises an exception:
     assert all(trigsimp(M, method=m) == M for m in
-        'fu matching old'.split())
+        'fu matching groebner old'.split())
     # watch for E in exptrigsimp, not only exp()
     eq = 1/sqrt(E) + E
     assert exptrigsimp(eq) == eq


### PR DESCRIPTION

- `MatrixExpr` now inherits `Expr`
- Matrix expressions can now be derived the usual way (using `diff` and/or `Derivative`).
