### PR TITLE
exception handling to make the function work as intended

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -119,8 +119,9 @@ class Basic(with_metaclass(ManagedProperties)):
     def __hash__(self):
         # hash cannot be cached using cache_it because infinite recurrence
         # occurs as hash is needed for setting cache dictionary keys
-        h = self._mhash
-        if h is None:
+        try:
+            h = self._mhash
+        except AttributeError:
             h = hash((type(self).__name__,) + self._hashable_content())
             self._mhash = h
         return h


### PR DESCRIPTION
I have simply inserted a try and except block to catch the case that self._mhash does not exist. 

Because in that case, the function will try to look self._mhash up, will not find it and throw an AttributeError. Which is appropriate, but since the purpose of __hash__ is to define that very variable, in the next two lines, that error should be silenced and instead the variable should be defined.
