### PR TITLE
Removed bug from Complement

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -222,7 +222,7 @@ class Set(Basic):
             non_num = FiniteSet(*non_num)
             out_range = FiniteSet(*[el for el in num if self.contains(el) != True])
             if non_num:
-                return Union(out_range, Complement(non_num , self , evaluate =False))
+                return Union(out_range, Complement(non_num, self, evaluate = False))
             else:
                 return out_range
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -215,7 +215,7 @@ class Set(Basic):
         elif isinstance(other, EmptySet):
             return S.EmptySet
 
-        elif isinstance(other, FiniteSet): 
+        elif isinstance(other, FiniteSet):
             both_l = non_num, num = [], []
             for el in other:
                 both_l[el.is_number].append(el)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -215,8 +215,16 @@ class Set(Basic):
         elif isinstance(other, EmptySet):
             return S.EmptySet
 
-        elif isinstance(other, FiniteSet):
-            return FiniteSet(*[el for el in other if self.contains(el) != True])
+        elif isinstance(other, FiniteSet): 
+            both_l = non_num, num = [], []
+            for el in other:
+                both_l[el.is_number].append(el)
+            non_num = FiniteSet(*non_num)
+            out_range = FiniteSet(*[el for el in num if self.contains(el) != True])
+            if non_num:
+                return Union(out_range, Complement(non_num , self , evaluate =False))
+            else:
+                return out_range
 
     def symmetric_difference(self, other):
         """

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -189,7 +189,7 @@ def test_Complement():
             Intersection(S.Reals - S.Naturals, S.Reals - FiniteSet(pi))
     # isssue 12712
     assert Complement(FiniteSet(x, y, 2), Interval(-10, 10)) == \
-            Complement(FiniteSet(x, y), Interval(-10, 10)) 
+            Complement(FiniteSet(x, y), Interval(-10, 10))
 
 
 def test_complement():

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -187,6 +187,10 @@ def test_Complement():
 
     assert S.Reals - Union(S.Naturals, FiniteSet(pi)) == \
             Intersection(S.Reals - S.Naturals, S.Reals - FiniteSet(pi))
+    # isssue 12712
+    assert Complement(FiniteSet(x, y, 2), Interval(-10, 10)) == \
+            Complement(FiniteSet(x, y), Interval(-10, 10)) 
+
 
 def test_complement():
     assert Interval(0, 1).complement(S.Reals) == \


### PR DESCRIPTION
Complement didn't work when input was a mixture of Symbols and numbers. So Fixed it 
Now it gives the correct result . Example
```
a=FiniteSet(x,y,11,2)
b=Interval(-10,10)
(Complement(a,b))
```
gives `Union({11}, {x, y} \ Interval(-10, 10))`
Fixes #12712
