### PR TITLE
wrote Min/Max in terms of Abs

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -604,6 +604,12 @@ class MinMaxBase(Expr, LatticeOp):
             l.append(df * da)
         return Add(*l)
 
+    def _eval_rewrite_as_Abs(self, *args):
+        from sympy.functions.elementary.complexes import Abs
+        s = (args[0] + self.func(*args[1:]))/2
+        d = abs(args[0] - self.func(*args[1:]))/2
+        return (s + d if isinstance(self, Max) else s - d).rewrite(Abs)
+
     def evalf(self, prec=None, **options):
         return self.func(*[a.evalf(prec, **options) for a in self.args])
     n = evalf

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -402,6 +402,7 @@ def test_rewrite_as_Abs():
     def test(e):
         free = e.free_symbols
         a = e.rewrite(Abs)
+        assert not a.has(Min, Max)
         for i in permutations(range(len(free))):
             reps = dict(zip(free, i))
             assert a.xreplace(reps) == e.xreplace(reps)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -394,3 +394,17 @@ def test_instantiation_evaluation():
         A, B = B, A
     assert Min(w, Max(x, y), Max(v, x, z)) == Min(
         w, Max(x, Min(y, Max(v, z))))
+
+def test_rewrite_as_Abs():
+    from itertools import permutations
+    from sympy.functions.elementary.complexes import Abs
+    from sympy.abc import x, y, z
+    def test(e):
+        free = e.free_symbols
+        a = e.rewrite(Abs)
+        for i in permutations(range(len(free))):
+            reps = dict(zip(free, i))
+            assert a.xreplace(reps) == e.xreplace(reps)
+    test(Min(x, y))
+    test(Max(x, y))
+    test(Min(x, y, z))

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -398,7 +398,7 @@ def test_instantiation_evaluation():
 def test_rewrite_as_Abs():
     from itertools import permutations
     from sympy.functions.elementary.complexes import Abs
-    from sympy.abc import x, y, z
+    from sympy.abc import x, y, z, w
     def test(e):
         free = e.free_symbols
         a = e.rewrite(Abs)
@@ -408,3 +408,4 @@ def test_rewrite_as_Abs():
     test(Min(x, y))
     test(Max(x, y))
     test(Min(x, y, z))
+    test(Min(Max(w, x), Max(y, z)))


### PR DESCRIPTION
<!-- Briefly explain what this pull request changes in each line below, with appropriate heading—'M' for major changes, 'm' for minor changes, 'n' for new features, and 'b' for backwards compatibility breaks and deprecations—and a colon(:), e.g., "M: Added changelogs". Write '[skip changelog]' if changes are trivial or not related to SymPy itself. -->
## This PR changes Min/Max rewriting
n: Min and Max can be rewritten in terms of Abs
<!-- [CHANGELOG END] -->

Fixes #13611 