### PR TITLE
AppliedUndef.is_number = False

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -354,5 +354,8 @@ def test_comparison_AccumBounds():
 def test_contains_AccumBounds():
     assert (1 in AccumBounds(1, 2)) == S.true
     raises(TypeError, lambda: a in AccumBounds(1, 2))
+    assert 0 in AccumBounds(-1, 0)
+    raises(TypeError, lambda:
+        (cos(1)**2 + sin(1)**2 - 1) in AccumBounds(-1, 0))
     assert (-oo in AccumBounds(1, oo)) == S.true
     assert (oo in AccumBounds(-oo, 0)) == S.true

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -1225,15 +1225,16 @@ class AccumulationBounds(AtomicExpr):
 
         """
         other = _sympify(other)
-        if not (other.is_Symbol or other.is_number):
-            raise TypeError("Input of type real symbol or Number expected")
 
         if other is S.Infinity or other is S.NegativeInfinity:
             if self.min is S.NegativeInfinity or self.max is S.Infinity:
                 return True
             return False
 
-        return And(self.min <= other and self.max >= other)
+        rv = And(self.min <= other, self.max >= other)
+        if rv not in (True, False):
+            raise TypeError("input failed to evaluate")
+        return rv
 
     def intersection(self, other):
         """

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -600,12 +600,13 @@ class Basic(with_metaclass(ManagedProperties)):
         is_real = self.is_real
         if is_real is False:
             return False
-        is_number = self.is_number
-        if is_number is False:
+        if not self.is_number:
             return False
+        # don't re-eval numbers that are already evaluated since
+        # this will create spurious precision
         n, i = [p.evalf(2) if not p.is_Number else p
             for p in self.as_real_imag()]
-        if not i.is_Number or not n.is_Number:
+        if not (i.is_Number and n.is_Number):
             return False
         if i:
             # if _prec = 1 we can't decide and if not,

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -359,27 +359,53 @@ class Expr(Basic, EvalfMixin):
 
     @property
     def is_number(self):
-        """Returns True if ``self`` has no free symbols.
-        It will be faster than ``if not self.free_symbols``, however, since
-        ``is_number`` will fail as soon as it hits a free symbol.
+        """Returns True if ``self`` has no free symbols and no
+        undefined functions (AppliedUndef, to be precise). It will be
+        faster than ``if not self.free_symbols``, however, since
+        ``is_number`` will fail as soon as it hits a free symbol
+        or undefined function.
 
         Examples
         ========
 
-        >>> from sympy import log, Integral
+        >>> from sympy import log, Integral, cos, sin, pi
+        >>> from sympy.core.function import Function
         >>> from sympy.abc import x
+        >>> f = Function('f')
 
         >>> x.is_number
         False
+        >>> f(1).is_number
+        False
         >>> (2*x).is_number
         False
-        >>> (2 + log(2)).is_number
-        True
         >>> (2 + Integral(2, x)).is_number
         False
         >>> (2 + Integral(2, (x, 1, 2))).is_number
         True
 
+        Not all numbers are Numbers in the SymPy sense:
+
+        >>> pi.is_number, pi.is_Number
+        (True, False)
+
+        If something is a number it should evaluate to a number with
+        real and imaginary parts that are Numbers; the result may not
+        be comparable, however, since the real and/or imaginary part
+        of the result may not have precision.
+
+        >>> cos(1).is_number and cos(1).is_comparable
+        True
+
+        >>> z = cos(1)**2 + sin(1)**2 - 1
+        >>> z.is_number
+        True
+        >>> z.is_comparable
+        False
+
+        See Also
+        ========
+        sympy.core.basic.is_comparable
         """
         return all(obj.is_number for obj in self.args)
 
@@ -531,20 +557,11 @@ class Expr(Basic, EvalfMixin):
 
         simplify = flags.get('simplify', True)
 
-        # Except for expressions that contain units, only one of these should
-        # be necessary since if something is
-        # known to be a number it should also know that there are no
-        # free symbols. But is_number quits as soon as it hits a non-number
-        # whereas free_symbols goes until all free symbols have been collected,
-        # thus is_number should be faster. But a double check on free symbols
-        # is made just in case there is a discrepancy between the two.
-        free = self.free_symbols
-        if self.is_number or not free:
-            # if the following assertion fails then that object's free_symbols
-            # method needs attention: if an expression is a number it cannot
-            # have free symbols
-            assert not free
+        if self.is_number:
             return True
+        free = self.free_symbols
+        if not free:
+            return True  # assume f(1) is some constant
 
         # if we are only interested in some symbols and they are not in the
         # free symbols then this expression is constant wrt those symbols
@@ -3411,12 +3428,10 @@ class UnevaluatedExpr(Expr):
 
 
 def _n2(a, b):
-    """Return (a - b).evalf(2) if it, a and b are comparable, else None.
+    """Return (a - b).evalf(2) if a and b are comparable, else None.
     This should only be used when a and b are already sympified.
     """
-    if not all(i.is_number for i in (a, b)):
-        return
-    # /!\ if is very important (see issue 8245) not to
+    # /!\ it is very important (see issue 8245) not to
     # use a re-evaluated number in the calculation of dif
     if a.is_comparable and b.is_comparable:
         dif = (a - b).evalf(2)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -778,6 +778,8 @@ class AppliedUndef(Function):
     function.
     """
 
+    is_number = False
+
     def __new__(cls, *args, **options):
         args = list(map(sympify, args))
         obj = super(AppliedUndef, cls).__new__(cls, *args, **options)

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -245,11 +245,10 @@ def test_literal_evalf_is_number_is_zero_is_comparable():
     x = symbols('x')
     f = Function('f')
 
-    # the following should not be changed without a lot of dicussion
-    # `foo.is_number` should be equivalent to `not foo.free_symbols`
-    # it should not attempt anything fancy; see is_zero, is_constant
-    # and equals for more rigorous tests.
-    assert f(1).is_number is True
+    # issue 5033
+    assert f.is_number is False
+    # issue 6646
+    assert f(1).is_number is False
     i = Integral(0, (x, x, x))
     # expressions that are symbolically 0 can be difficult to prove
     # so in case there is some easy way to know if something is 0

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1522,6 +1522,7 @@ def test_is_constant():
     assert checksol(x, x, Sum(x, (x, 1, n))) is False
     assert checksol(x, x, Sum(x, (x, 1, n))) is False
     f = Function('f')
+    assert f(1).is_constant
     assert checksol(x, x, f(x)) is False
 
     p = symbols('p', positive=True)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -5,7 +5,7 @@ from sympy.core.add import Add
 from sympy.core.containers import Tuple
 from sympy.core.operations import LatticeOp, ShortCircuit
 from sympy.core.function import (Application, Lambda,
-    ArgumentIndexError, AppliedUndef)
+    ArgumentIndexError)
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
@@ -516,7 +516,6 @@ class MinMaxBase(Expr, LatticeOp):
             # pre-filter, checking comparability of arguments
             if not isinstance(arg, Expr) or arg.is_real is False or (
                     arg.is_number and
-                    not arg.has(AppliedUndef) and
                     not arg.is_comparable):
                 raise ValueError("The argument '%s' is not comparable." % arg)
 


### PR DESCRIPTION
<!-- Briefly explain what this pull request changes in each line below, with appropriate heading—'M' for major changes, 'm' for minor changes, 'n' for new features, and 'b' for backwards compatibility breaks and deprecations—and a colon(:), e.g., "M: Added changelogs". Write '[skip changelog]' if changes are trivial or not related to SymPy itself. -->
## This PR changes is_number behavior and AccumBound.contains error handling
b: f(1).is_number is now False when f is an AppliedUndef; the former `foo.is_number` is now equivalent to `not foo.free_symbols`. `is_number` is generally used to detect expressions that might be evaluated.
m: AccumBounds.contains only raises an error if the condition is unevaluated
<!-- [CHANGELOG END] -->
* `is_number` now is only True for something that will evaluate to a number (though it may not do so with precision).
* `is_comparable` (for reference) is only True if something is a number and evaluates with precision
* The `contains` method of AccumBounds was overly optimistic since something being a number does not guarantee that the condition tested will be evaluated. An error is now raised if the condition is not evaluated and the `and` separating args in the `And` was changed to a comma: `And(c1, c2)` not `And(c1 and c2)`.

fixes #5033
fixes #6646