### PR TITLE
improve safety of sift for binary expectation

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -6,6 +6,7 @@ from sympy.core.cache import cacheit
 from sympy.core.compatibility import ordered, range
 from sympy.core.logic import fuzzy_and
 from sympy.core.evaluate import global_evaluate
+from sympy.utilities.iterables import sift
 
 
 class AssocOp(Basic):
@@ -180,11 +181,9 @@ class AssocOp(Basic):
         # eliminate exact part from pattern: (2+a+w1+w2).matches(expr) -> (w1+w2).matches(expr-a-2)
         from .function import WildFunction
         from .symbol import Wild
-        from sympy.utilities.iterables import sift
-        sifted = sift(self.args, lambda p:
-            p.has(Wild, WildFunction) and not expr.has(p))
-        wild_part = sifted[True]
-        exact_part = sifted[False]
+        wild_part, exact_part = sift(self.args, lambda p:
+            p.has(Wild, WildFunction) and not expr.has(p),
+            binary=True)
         if not exact_part:
             wild_part = list(ordered(wild_part))
         else:
@@ -262,9 +261,8 @@ class AssocOp(Basic):
             # this is not the same as args_cnc because here
             # we don't assume expr is a Mul -- hence deal with args --
             # and always return a set.
-            sifted = ncpart, cpart = [], []
-            for arg in expr.args:
-                sifted[arg.is_commutative is True].append(arg)
+            cpart, ncpart = sift(expr.args,
+                lambda arg: arg.is_commutative is True, binary=True)
             return set(cpart), ncpart
 
         c, nc = _ncsplit(self)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -797,9 +797,8 @@ class Pow(Expr):
             nc = [Mul(*nc)]
 
         # sift the commutative bases
-        sifted = sift(cargs, lambda x: x.is_real)
-        maybe_real = sifted[True] + sifted[None]
-        other = sifted[False]
+        other, maybe_real = sift(cargs, lambda x: x.is_real is False,
+            binary=True)
         def pred(x):
             if x is S.ImaginaryUnit:
                 return S.ImaginaryUnit

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Basic, Symbol, symbols, lambdify
+from sympy.utilities.iterables import sift
 from util import interpolate, rinterpolate, create_bounds, update_bounds
 from sympy.core.compatibility import range
 
@@ -202,10 +203,8 @@ class ColorScheme(object):
         return vars
 
     def _sort_args(self, args):
-        sifted = atoms, lists = [], []
-        for a in args:
-            sifted[isinstance(a, (tuple, list))].append(a)
-        return atoms, lists
+        lists, atoms = sift(args,
+            lambda a: isinstance(a, (tuple, list)), binary=True)
 
     def _test_color_function(self):
         if not callable(self.f):

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -134,8 +134,8 @@ def _separate_sq(p):
             else:
                 raise NotImplementedError
             continue
-        sifted = sift(y.args, is_sqrt)
-        a.append((Mul(*sifted[False]), Mul(*sifted[True])**2))
+        T, F = sift(y.args, is_sqrt, binary=True)
+        a.append((Mul(*F), Mul(*T)**2))
     a.sort(key=lambda z: z[1])
     if a[-1][1] is S.One:
         # there are no surds

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6076,8 +6076,7 @@ def to_rational_coeffs(f):
                 func = c.func
             else:
                 args = [c]
-            sifted = sift(args, lambda z: z.is_rational)
-            c1, c2 = sifted[True], sifted[False]
+            c1, c2 = sift(args, lambda z: z.is_rational, binary=True)
             alpha = -func(*c2)/n
             f2 = f1.shift(alpha)
             return alpha, f2
@@ -6563,8 +6562,9 @@ def cancel(f, *gens, **args):
             raise PolynomialError(msg)
         # Handling of noncommutative and/or piecewise expressions
         if f.is_Add or f.is_Mul:
-            sifted = sift(f.args, lambda x: x.is_commutative is True and not x.has(Piecewise))
-            c, nc = sifted[True], sifted[False]
+            c, nc = sift(f.args, lambda x:
+                x.is_commutative is True and not x.has(Piecewise),
+                binary=True)
             nc = [cancel(i) for i in nc]
             return f.func(cancel(f.func._from_args(c)), *nc)
         else:

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -31,7 +31,7 @@ from sympy.polys.domains import QQ
 from mpmath import mpf, mpc, findroot, workprec
 from mpmath.libmp.libmpf import prec_to_dps
 
-from sympy.utilities import lambdify, public
+from sympy.utilities import lambdify, public, sift
 
 from sympy.core.compatibility import range
 
@@ -272,7 +272,6 @@ class ComplexRootOf(RootOf):
 
     @classmethod
     def _separate_imaginary_from_complex(cls, complexes):
-        from sympy.utilities.iterables import sift
 
         def is_imag(c):
             '''

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -17,6 +17,7 @@ from sympy.core.mul import Mul
 from sympy.core.relational import Eq, Ne
 from sympy.core.symbol import Symbol, Dummy, _uniquely_named_symbol
 from sympy.sets.contains import Contains
+from sympy.utilities.iterables import sift
 from sympy.utilities.misc import func_name, filldedent
 
 from mpmath import mpi, mpf
@@ -1551,15 +1552,13 @@ class Intersection(Set):
     def _handle_finite_sets(args):
         from sympy.core.logic import fuzzy_and, fuzzy_bool
         from sympy.core.compatibility import zip_longest
-        from sympy.utilities.iterables import sift
 
-        sifted = sift(args, lambda x: x.is_FiniteSet)
-        fs_args = sifted.pop(True, [])
+        fs_args, other = sift(args, lambda x: x.is_FiniteSet,
+            binary=True)
         if not fs_args:
             return
         s = fs_args[0]
         fs_args = fs_args[1:]
-        other = sifted.pop(False, [])
 
         res = []
         unk = []

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -154,12 +154,11 @@ def _gammasimp(expr, as_comb):
                 return rule_gamma(Mul._from_args(args), level + 1)*Mul._from_args(nc)
             level += 1
 
-        # pure gamma handling, not factor absorbtion
+        # pure gamma handling, not factor absorption
         if level == 2:
-            sifted = sift(expr.args, gamma_factor)
-            gamma_ind = Mul(*sifted.pop(False, []))
-            d = Mul(*sifted.pop(True, []))
-            assert not sifted
+            T, F = sift(expr.args, gamma_factor, binary=True)
+            gamma_ind = Mul(*F)
+            d = Mul(*T)
 
             nd, dd = d.as_numer_denom()
             for ipass in range(2):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -16,6 +16,7 @@ from sympy.functions import Abs
 from sympy.logic import And
 from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
 from sympy.polys.polyutils import _nsort
+from sympy.utilities.iterables import sift
 from sympy.utilities.misc import filldedent
 
 def solve_poly_inequality(poly, rel):
@@ -573,7 +574,6 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 if all(r.is_number for r in critical_points):
                     reals = _nsort(critical_points, separated=True)[0]
                 else:
-                    from sympy.utilities.iterables import sift
                     sifted = sift(critical_points, lambda x: x.is_real)
                     if sifted[None]:
                         # there were some roots that weren't known

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -621,19 +621,24 @@ def capture(func):
     return file.getvalue()
 
 
-def sift(seq, keyfunc):
+def sift(seq, keyfunc, binary=False):
     """
-    Sift the sequence, ``seq`` into a dictionary according to keyfunc.
+    Sift the sequence, ``seq`` according to ``keyfunc``.
 
-    OUTPUT: each element in expr is stored in a list keyed to the value
-    of keyfunc for the element.
+    OUTPUT: When binary is False (default), the output is a dictionary
+    where elements of ``seq`` are stored in a list keyed to the value
+    of keyfunc for that element. If ``binary`` is True then a tuple
+    with lists ``T`` and ``F`` are returned where ``T`` is a list
+    containing elements of seq for which ``keyfunc`` was True and
+    ``F`` containing those elements for which ``keyfunc`` was False;
+    a ValueError is raised if the ``keyfunc`` is not binary.
 
     Examples
     ========
 
     >>> from sympy.utilities import sift
     >>> from sympy.abc import x, y
-    >>> from sympy import sqrt, exp
+    >>> from sympy import sqrt, exp, pi, Tuple
 
     >>> sift(range(5), lambda x: x % 2)
     {0: [0, 2, 4], 1: [1, 3]}
@@ -652,6 +657,30 @@ def sift(seq, keyfunc):
     ...      lambda x: x.as_base_exp()[0])
     {E: [exp(x)], x: [sqrt(x)], y: [y**(2*x)]}
 
+    Sometimes you expect the results to be binary; the
+    results can be unpacked by setting ``binary`` to True:
+
+    >>> sift(range(4), lambda x: x % 2, binary=True)
+    ([1, 3], [0, 2])
+    >>> sift(Tuple(1, pi), lambda x: x.is_rational, binary=True)
+    ([1], [pi])
+
+    A ValueError is raised if the predicate was not actually binary
+    (which is a good test for the logic where sifting is used and
+    binary results were expected):
+
+    >>> unknown = exp(1) - pi  # this rationality of this is unknown
+    >>> args = Tuple(1, pi, unknown)
+    >>> sift(args, lambda x: x.is_rational, binary=True)
+    Traceback (most recent call last):
+    ...
+    ValueError: keyfunc gave non-binary output
+
+    The non-binary sifting shows that there were 3 keys generated:
+
+    >>> set(sift(args, lambda x: x.is_rational).keys())
+    {None, False, True}
+
     If you need to sort the sifted items it might be better to use
     ``ordered`` which can economically apply multiple sort keys
     to a squence while sorting.
@@ -660,10 +689,18 @@ def sift(seq, keyfunc):
     ========
     ordered
     """
-    m = defaultdict(list)
+    if not binary:
+        m = defaultdict(list)
+        for i in seq:
+            m[keyfunc(i)].append(i)
+        return m
+    sift = F, T = [], []
     for i in seq:
-        m[keyfunc(i)].append(i)
-    return m
+        try:
+            sift[keyfunc(i)].append(i)
+        except (IndexError, TypeError):
+            raise ValueError('keyfunc gave non-binary output')
+    return T, F
 
 
 def take(iter, n):

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -669,7 +669,7 @@ def sift(seq, keyfunc, binary=False):
     (which is a good test for the logic where sifting is used and
     binary results were expected):
 
-    >>> unknown = exp(1) - pi  # this rationality of this is unknown
+    >>> unknown = exp(1) - pi  # the rationality of this is unknown
     >>> args = Tuple(1, pi, unknown)
     >>> sift(args, lambda x: x.is_rational, binary=True)
     Traceback (most recent call last):

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -182,6 +182,12 @@ def test_sift():
     assert sift(list(range(5)), lambda _: _ % 2) == {1: [1, 3], 0: [0, 2, 4]}
     assert sift([x, y], lambda _: _.has(x)) == {False: [y], True: [x]}
     assert sift([S.One], lambda _: _.has(x)) == {False: [1]}
+    assert sift([0, 1, 2, 3], lambda x: x % 2, binary=True) == (
+        [1, 3], [0, 2])
+    assert sift([0, 1, 2, 3], lambda x: x % 3 == 1, binary=True) == (
+        [1], [0, 2, 3])
+    raises(ValueError, lambda:
+        sift([0, 1, 2, 3], lambda x: x % 3, binary=True))
 
 
 def test_take():


### PR DESCRIPTION
<!-- Briefly explain what this pull request changes in each line below, with appropriate heading—'M' for major changes, 'm' for minor changes, 'n' for new features, and 'b' for backwards compatibility breaks and deprecations—and a colon(:), e.g., "M: Added changelogs". Write '[skip changelog]' if changes are trivial or not related to SymPy itself. -->
## This PR changes `sift` by adding keyword `binary`
n: `sift` will now take a keyword 'binary' and when it is true, will unpack the dict and check that the results truly were binary.
<!-- [CHANGELOG END] -->

The use of `sift` is updated in several places across SymPy.