### PR TITLE
Various fixes to preview()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
         # autowrap installs libgfortran libgcc gcc cython
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython pyglet"
       addons:
         apt:
           packages:
@@ -36,7 +36,7 @@ matrix:
     - python: 3.6
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython pyglet"
       addons:
         apt:
           packages:

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -98,6 +98,11 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     'dvi'+output conversion tool. These options have to be in the form of a
     list of strings (see subprocess.Popen).
 
+    For example, to output a png with white text on a black background:
+
+    >>> dvioptions = ["-T", "tight", "--truecolor", "-fg", "White", "-bg", "Black"]
+    >>> preview(x + y, output='png', dvioptions=dvioptions)
+
     Additional keyword args will be passed to the latex call, e.g., the
     symbol_names flag.
 

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -109,6 +109,11 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     >>> phidd = Symbol('phidd')
     >>> preview(phidd, symbol_names={phidd:r'\ddot{\varphi}'})
 
+    Or the mode flag (the default mode is set to 'inline')
+
+    >>> from sympy import Integral
+    >>> preview(Integral(x**2, x), mode='equation*')
+
     For post-processing the generated TeX File can be written to a file by
     passing the desired filename to the 'outputTexFile' keyword
     argument. To write the TeX code to a file named
@@ -187,10 +192,11 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                              "custom LaTeX preamble was specified")
     latex_main = preamble + '\n%s\n\n' + r"\end{document}"
 
+    latex_settings.setdefault('mode', 'inline')
     if isinstance(expr, str):
         latex_string = expr
     else:
-        latex_string = latex(expr, mode='inline', **latex_settings)
+        latex_string = latex(expr, **latex_settings)
 
     try:
         workdir = tempfile.mkdtemp()

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -85,8 +85,12 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     argument. This can be used, e.g., to set a different font size, use a
     custom documentclass or import certain set of LaTeX packages.
 
-    >>> preamble = "\\documentclass[10pt]{article}\n" \
-    ...            "\\usepackage{amsmath,amsfonts}\\begin{document}"
+    >>> preamble = r'''
+    ... \documentclass[10pt]{article}
+    ... \pagestyle{empty}
+    ... \usepackage{amsmath,amsfonts}
+    ... \begin{document}
+    ... '''
     >>> preview(x + y, output='png', preamble=preamble)
 
     If the value of 'output' is different from 'dvi' then command line


### PR DESCRIPTION
- Document the `preamble` and `dvioptions` flags better, to make it clearer what the defaults are. 
- Allow passing the `mode` flag through to `latex`. 

#### Release notes

<!-- BEGIN RELEASE NOTES -->
* printing
  - Document the `preamble` and `dvioptions` flags to `preview()` better, to make it clearer what the defaults are. 
  - Allow passing the `mode` flag through to `latex` in `preview()`. 
