### PR TITLE
Indexed matrix expressions can now be parsed into TensorProduct

### DIFF
--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -2,6 +2,7 @@ from sympy import (symbols, MatrixSymbol, MatPow, BlockMatrix, KroneckerDelta,
         Identity, ZeroMatrix, ImmutableMatrix, eye, Sum, Dummy, MatMul, trace,
         Symbol, Mul)
 from sympy.utilities.pytest import raises
+from sympy.tensor.functions import TensorProduct
 from sympy.matrices.expressions.matexpr import MatrixElement, MatrixExpr
 
 k, l, m, n = symbols('k l m n', integer=True)
@@ -163,6 +164,10 @@ def test_matrix_expression_from_index_summation():
     expr = Sum(A[a, a]*B[b, c]*C[c, d], (a, 0, k-1), (c, 0, k-1))
     assert MatrixExpr.from_index_summation(expr, b) == trace(A)*B*C
 
+    # TODO: add support for `Trace(A, B)`:
+    expr = Sum(A[i,j]*B[j,i], (i,0,2), (j,0,2))
+    # assert MatrixExpr.from_index_summation(expr) == trace(A*B)
+
     # Check wrong sum ranges (should raise an exception):
 
     ## Case 1: 0 to m instead of 0 to m-1
@@ -181,7 +186,7 @@ def test_matrix_expression_from_index_summation():
     assert MatrixExpr.from_index_summation(expr, a) == A*B
 
     expr = Sum(KroneckerDelta(i1, m)*KroneckerDelta(i2, n)*A[i, i1]*A[j, i2], (i1, 0, k-1), (i2, 0, k-1))
-    assert MatrixExpr.from_index_summation(expr, m) == A.T*A[j, n]
+    assert MatrixExpr.from_index_summation(expr, m) == TensorProduct(A.T, A.T)
 
     # Test numbered indices:
     expr = Sum(A[i1, i2]*w1[i2, 0], (i2, 0, k-1))
@@ -189,3 +194,7 @@ def test_matrix_expression_from_index_summation():
 
     expr = Sum(A[i1, i2]*B[i2, 0], (i2, 0, k-1))
     assert MatrixExpr.from_index_summation(expr, i1) == MatrixElement(A*B, i1, 0)
+
+    # Test Kronecker delta expressions:
+    expr = KroneckerDelta(i1, i2)
+    assert MatrixExpr.from_index_summation(expr, i1, dimension_hint={i1: 5}) == Identity(5)


### PR DESCRIPTION
So this PR tries to solve the issue of matrix derivative returning higher-rank tensors. A matrix is a rank-2 tensor (i.e. an object with 2 indices). Sometimes, the derivative of a matrix expression may be a higher rank tensor, for example `X.diff(X)` is the rank-4 identity tensor (a tensor where all the ones are on the principal diagonal).

This PR tries to introduce results based on `TensorProduct`:

- [ ] `X.diff(X) == TensorProduct(I, I)`, where `I` is the identity matrix (TODO: this result is not yet achieved).
- [ ] more examples to add from the matrix derivative cookbook.

**Reasoning**:

`X.diff(X)` can be rewritten into index-form as `X[i, j].diff(X[m, n])`, this returns `KroneckerDelta(m, i)*KroneckerDelta(n, j)`. This last expression can be re-interpreted as the tensor product of two identity matrices: `TensorProduct(I, I)`, by assigning indices `(m, i)` to the first term, and `(n,  j)` to the second term.