### PR TITLE
Fixes products with arrays with only one element convert to float

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -302,7 +302,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         pass
 
     if not isinstance(a, string_types):
-        for coerce in (float, int):
+        for coerce in (int, float):
             try:
                 return sympify(coerce(a))
             except (TypeError, ValueError, AttributeError, SympifyError):


### PR DESCRIPTION
By change the order to iteration in the for loop, while only one element is present considering int first will resolve the issue.

This change fixes the issue #13637 
