### PR TITLE
added atan support and tests for rs_series with atan 

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -30,7 +30,7 @@ Extending rs_series
 
 To make a function work with rs_series you need to do two things::
 
-    - Many sure it works with a constant term (as explained above).
+    - Make sure it works with a constant term (as explained above).
     - If the series contains constant terms, you might need to extend its ring.
       You do so by adding the new terms to the rings as generators.
       ``PolyRing.compose`` and ``PolyRing.add_gens`` are two functions that do
@@ -1843,7 +1843,8 @@ _convert_func = {
         'cos': 'rs_cos',
         'exp': 'rs_exp',
         'tan': 'rs_tan',
-        'log': 'rs_log'
+        'log': 'rs_log',
+	'atan': 'rs_atan'
         }
 
 def rs_min_pow(expr, series_rs, a):
@@ -1964,7 +1965,7 @@ def rs_series(expr, a, prec):
 
     >>> from sympy.polys.ring_series import rs_series
     >>> from sympy.functions import sin, cos, exp, tan
-    >>> from sympy.core import symbols
+    >>> from sympy import symbols
     >>> from sympy.polys.domains import QQ
     >>> a, b, c = symbols('a, b, c')
     >>> rs_series(sin(a) + exp(a), a, 5)

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -629,3 +629,7 @@ def test_rs_series():
     assert rs_series(log(1 + x*a**2), x, 7).as_expr() == -x**6*a**12/6 + \
                     x**5*a**10/5 - x**4*a**8/4 + x**3*a**6/3 - \
                     x**2*a**4/2 + x*a**2
+    assert rs_series(atan(a), a, 5).as_expr() == (atan(a).series(a, 0, 5)).removeO()
+
+    assert rs_series(atan(a)/7, a, 5).as_expr() == (atan(a)/7).series(a, 0,
+	    5).removeO()


### PR DESCRIPTION

I added `atan` in the `_convert_func` dict and then wrote tests similar to those for sin in `test_rs_series`. In all cases where `rs_atan` works, `rs_series` works properly with `atan`.