### PR TITLE
Add missing tests for laplacian for different kind of coordinate systems.

### DIFF
--- a/sympy/vector/tests/test_field_functions.py
+++ b/sympy/vector/tests/test_field_functions.py
@@ -104,6 +104,10 @@ def test_del_operator():
     assert laplacian(x**2) == S(2)
     assert laplacian(x**2*y**2*z**2) == \
                     2*y**2*z**2 + 2*x**2*z**2 + 2*x**2*y**2
+    A = CoordSys3D('A', transformation="spherical", variable_names=["r", "theta", "phi"])
+    B = CoordSys3D('B', transformation='cylindrical', variable_names=["r", "theta", "z"])
+    assert laplacian(A.r + A.theta + A.phi) == 2/A.r + cos(A.theta)/(A.r**2*sin(A.theta))
+    assert laplacian(B.r + B.theta + B.z) == 1/B.r
 
     # Tests for laplacian on vector fields
     assert laplacian(x*y*z*(i + j + k)) == Vector.zero


### PR DESCRIPTION
This PR corresponds to #12261, where I asked for more tests. 
`laplacian` can be calculated also in new type of coordinate systems, so we need to be sure that it works OK.

ping @ArifAhmed1995 , @gxyd 