### PR TITLE
Fixed Rational(numpy.int64(1), 2)) failure in python3

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -17,6 +17,7 @@ from .logic import fuzzy_not
 from sympy.core.compatibility import (
     as_int, integer_types, long, string_types, with_metaclass, HAS_GMPY,
     SYMPY_INTS, int_info)
+import numpy as np
 import mpmath
 import mpmath.libmp as mlib
 from mpmath.libmp.backend import MPZ
@@ -1470,6 +1471,10 @@ class Rational(Number):
     @cacheit
     def __new__(cls, p, q=None, gcd=None):
         if q is None:
+
+            if isinstance(p, np.generic):
+                p = np.asscalar(p)
+
             if isinstance(p, Rational):
                 return p
 
@@ -1504,6 +1509,12 @@ class Rational(Number):
             q = q or S.One
             gcd = 1
         else:
+
+            if isinstance(p, np.generic):
+                p = np.asscalar(p)
+            if isinstance(q, np.generic):
+                q = np.asscalar(q)
+
             p = Rational(p)
             q = Rational(q)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -16,7 +16,7 @@ from sympy.utilities.pytest import XFAIL, raises
 
 from mpmath import mpf
 import mpmath
-
+import numpy as np
 
 
 t = Symbol('t', real=False)
@@ -1781,3 +1781,6 @@ def test_numpy_to_float():
 
     raises(TypeError, lambda: Float(np.complex64(1+2j)))
     raises(TypeError, lambda: Float(np.complex128(1+2j)))
+
+def test_numpy_dtypes_rational():
+    assert Rational(np.int64(1),2) == 1/2


### PR DESCRIPTION
Fixed the issue and added test case

Fixes #13618 