### PR TITLE
Fix LaTeX dagger rendering

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -738,7 +738,7 @@ class adjoint(Function):
 
     def _latex(self, printer, exp=None, *args):
         arg = printer._print(self.args[0])
-        tex = r'%s^{\dag}' % arg
+        tex = r'%s^{\dagger}' % arg
         if exp:
             tex = r'\left(%s\right)^{%s}' % (tex, printer._print(exp))
         return tex

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -160,7 +160,6 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         """
         if _can_print_latex(o):
             s = latex(o, mode='plain', **settings)
-            s = s.replace(r'\dag', r'\dagger')
             s = s.strip('$')
             return '$$%s$$' % s
 

--- a/sympy/physics/quantum/boson.py
+++ b/sympy/physics/quantum/boson.py
@@ -106,7 +106,7 @@ class BosonOp(Operator):
         if self.is_annihilation:
             return r'{%s}' % str(self.name)
         else:
-            return r'{{%s}^\dag}' % str(self.name)
+            return r'{{%s}^\dagger}' % str(self.name)
 
     def _print_contents(self, printer, *args):
         if self.is_annihilation:

--- a/sympy/physics/quantum/fermion.py
+++ b/sympy/physics/quantum/fermion.py
@@ -92,7 +92,7 @@ class FermionOp(Operator):
         if self.is_annihilation:
             return r'{%s}' % str(self.name)
         else:
-            return r'{{%s}^\dag}' % str(self.name)
+            return r'{{%s}^\dagger}' % str(self.name)
 
     def _print_contents(self, printer, *args):
         if self.is_annihilation:

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -161,7 +161,7 @@ class RaisingOp(SHOOp):
 
     def _print_contents_latex(self, printer, *args):
         arg = printer._print(self.args[0])
-        return '%s^{\\dag}' % arg
+        return '%s^{\\dagger}' % arg
 
 class LoweringOp(SHOOp):
     """The Lowering Operator or 'a'.

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -222,7 +222,7 @@ x \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
-    assert latex(expr) == r'x^{\dag}'
+    assert latex(expr) == r'x^{\dagger}'
     sT(expr, "Dagger(Symbol('x'))")
 
 
@@ -822,7 +822,7 @@ u("""\
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == \
-        r'{J_z^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} f{\left (x \right )},f{\left (x \right )}\right)^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
+        r'{J_z^{2}}\otimes \left({A^{\dagger} + B^{\dagger}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} f{\left (x \right )},f{\left (x \right )}\right)^{\dagger}\right)^{3},A^{\dagger} + B^{\dagger}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
     sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x')))), Integer(3)),Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
     assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
     ascii_str = \
@@ -840,7 +840,7 @@ u("""\
     assert pretty(e2) == ascii_str
     assert upretty(e2) == ucode_str
     assert latex(e2) == \
-        r'\left[J_z^{2},A + B\right] \left\{E^{-2},D^{\dag} C^{\dag}\right\} \left[J^2,J_z\right]'
+        r'\left[J_z^{2},A + B\right] \left\{E^{-2},D^{\dagger} C^{\dagger}\right\} \left[J^2,J_z\right]'
     sT(e2, "Mul(Commutator(Pow(JzOp(Symbol('J')), Integer(2)),Add(Operator(Symbol('A')), Operator(Symbol('B')))), AntiCommutator(Pow(Operator(Symbol('E')), Integer(-2)),Mul(Dagger(Operator(Symbol('D'))), Dagger(Operator(Symbol('C'))))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
     assert str(e3) == \
         "Wigner3j(1, 2, 3, 4, 5, 6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,j1=1,j2=1> + |1,1,j1=1,j2=1>)x|1,-1,j1=1,j2=1>"
@@ -861,7 +861,7 @@ u("""\
     assert pretty(e3) == ascii_str
     assert upretty(e3) == ucode_str
     assert latex(e3) == \
-        r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dag} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,j_{1}=1,j_{2}=1\right\rangle } + {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }}\right)\otimes {{\left|1,-1,j_{1}=1,j_{2}=1\right\rangle }}'
+        r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dagger} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,j_{1}=1,j_{2}=1\right\rangle } + {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }}\right)\otimes {{\left|1,-1,j_{1}=1,j_{2}=1\right\rangle }}'
     sT(e3, "Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))), JzKetCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))), JzKetCoupled(Integer(1),Integer(-1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))))")
     assert str(e4) == '(C(1)*C(2)+F**2)*(L2(Interval(0, oo))+H)'
     ascii_str = \
@@ -884,4 +884,4 @@ u("""\
 def _test_sho1d():
     ad = RaisingOp('a')
     assert pretty(ad) == u' \N{DAGGER}\na '
-    assert latex(ad) == 'a^{\\dag}'
+    assert latex(ad) == 'a^{\\dagger}'

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1426,9 +1426,9 @@ class LatexPrinter(Printer):
         mat = expr.arg
         from sympy.matrices import MatrixSymbol
         if not isinstance(mat, MatrixSymbol):
-            return r"\left(%s\right)^\dag" % self._print(mat)
+            return r"\left(%s\right)^\dagger" % self._print(mat)
         else:
-            return r"%s^\dag" % self._print(mat)
+            return r"%s^\dagger" % self._print(mat)
 
     def _print_MatAdd(self, expr):
         terms = list(expr.args)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1338,17 +1338,17 @@ def test_Adjoint():
     from sympy.matrices import MatrixSymbol, Adjoint, Inverse, Transpose
     X = MatrixSymbol('X', 2, 2)
     Y = MatrixSymbol('Y', 2, 2)
-    assert latex(Adjoint(X)) == r'X^\dag'
-    assert latex(Adjoint(X + Y)) == r'\left(X + Y\right)^\dag'
-    assert latex(Adjoint(X) + Adjoint(Y)) == r'X^\dag + Y^\dag'
-    assert latex(Adjoint(X*Y)) == r'\left(X Y\right)^\dag'
-    assert latex(Adjoint(Y)*Adjoint(X)) == r'Y^\dag X^\dag'
-    assert latex(Adjoint(X**2)) == r'\left(X^{2}\right)^\dag'
-    assert latex(Adjoint(X)**2) == r'\left(X^\dag\right)^{2}'
-    assert latex(Adjoint(Inverse(X))) == r'\left(X^{-1}\right)^\dag'
-    assert latex(Inverse(Adjoint(X))) == r'\left(X^\dag\right)^{-1}'
-    assert latex(Adjoint(Transpose(X))) == r'\left(X^T\right)^\dag'
-    assert latex(Transpose(Adjoint(X))) == r'\left(X^\dag\right)^T'
+    assert latex(Adjoint(X)) == r'X^\dagger'
+    assert latex(Adjoint(X + Y)) == r'\left(X + Y\right)^\dagger'
+    assert latex(Adjoint(X) + Adjoint(Y)) == r'X^\dagger + Y^\dagger'
+    assert latex(Adjoint(X*Y)) == r'\left(X Y\right)^\dagger'
+    assert latex(Adjoint(Y)*Adjoint(X)) == r'Y^\dagger X^\dagger'
+    assert latex(Adjoint(X**2)) == r'\left(X^{2}\right)^\dagger'
+    assert latex(Adjoint(X)**2) == r'\left(X^\dagger\right)^{2}'
+    assert latex(Adjoint(Inverse(X))) == r'\left(X^{-1}\right)^\dagger'
+    assert latex(Inverse(Adjoint(X))) == r'\left(X^\dagger\right)^{-1}'
+    assert latex(Adjoint(Transpose(X))) == r'\left(X^T\right)^\dagger'
+    assert latex(Transpose(Adjoint(X))) == r'\left(X^\dagger\right)^T'
 
 
 def test_Hadamard():


### PR DESCRIPTION
Change LaTeX rendering of daggers from `\dag` to `\dagger`, since `\dag` is a text-mode command and `\dagger` is the math-mode command that is relevant for output of mathematical expressions in LaTeX.

Fixes #13671