### PR TITLE
Missing parentheses in LaTeX output corrected

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -295,8 +295,12 @@ class LatexPrinter(Printer):
             if i == 0:
                 pass
             elif _coeff_isneg(term):
-                tex += " - "
-                term = -term
+                if term.is_Add :
+                    tex += " - "
+                    term = -term
+                else:
+                    if self._print(-term)[0]=='-':
+                        tex+= " + "
             else:
                 tex += " + "
             term_tex = self._print(term)


### PR DESCRIPTION
Fixes: #13651 .
The current latex representation first adds a negative sign and then manipulates the negative of the term. However if a term involves addition it should first manipulate the term and then add the '+' to the `tex` variable according to the sign of the leading term .