### PR TITLE
(FIX): last lambdify example in the basic_operation

### DIFF
--- a/doc/src/tutorial/basic_operations.rst
+++ b/doc/src/tutorial/basic_operations.rst
@@ -195,6 +195,7 @@ dictionary of ``sympy_name:numerical_function`` pairs.  For example
     ...     My sine. Note that this is only accurate for small x.
     ...     """
     ...     return x
+    >>> expr=sin(x)
     >>> f = lambdify(x, expr, {"sin":mysin})
     >>> f(0.1)
     0.1


### PR DESCRIPTION
Referring to issue #13675.

`expr` was not defined properly.