### PR TITLE
improved documentation for collect_const()

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -555,6 +555,27 @@ def collect_const(expr, *vars, **kwargs):
     >>> collect_const(2*x - 2*y - 2*z, -2)
     2*x - 2*(y + z)
 
+    ---->> According to documentation, we have the second argument as *vars.
+          *vars - implies that you can pass on as many arguments as possible.
+
+    Examples -- 
+
+    >>> collect_const(3*x-3*y+2*z+2*s,3, 2)
+    2*(s + z) + 3*(x - y)
+    >>> collect_const(x-y+2*z+2*s, 1, 2)
+    x - y + 2*(s + z)
+
+    ---->> According to documentation, we have the third argument as **kwargs.
+           **kwargs - implies that you can pass keyworded variable length of arguments to a function.
+
+    Examples --
+
+    >>> kwargs = {"arg1":3, "arg2":2}
+    >>> collect_const(3*x-3*y+2*z+2*s ,**kwargs)
+    2*(s + z) + 3*(x - y)
+
+    Both can be used together also as specified in the function definition.
+
     See Also
     ========
     collect, collect_sqrt, rcollect


### PR DESCRIPTION
Partial fix for #13683

The above pull request modifies the documentation for the function definition for collect_const function, where the *vars and **kwargs are now specified.
