### PR TITLE
Misc. trivial typo fixes

### DIFF
--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -144,11 +144,11 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, c_sph, f, f_md, f_mdt,
                     print('  * ' + md)
             if c_idt:
                 # Use "# indirect doctest" in the docstring to
-                # supress this warning.
+                # suppress this warning.
                 print_header('Indirect doctests', '-', not no_color and small_header_color)
                 for md in c_idt:
                     print('  * ' + md)
-                print('\n    Use \"# indirect doctest\" in the docstring to supress this warning')
+                print('\n    Use \"# indirect doctest\" in the docstring to suppress this warning')
             if c_sph:
                 print_header('Not imported into Sphinx', '-', not no_color and small_header_color)
                 for md in c_sph:
@@ -170,7 +170,7 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, c_sph, f, f_md, f_mdt,
                 print_header('Indirect doctests', '-', not no_color and small_header_color)
                 for md in f_idt:
                     print('  * ' + md)
-                print('\n    Use \"# indirect doctest\" in the docstring to supress this warning')
+                print('\n    Use \"# indirect doctest\" in the docstring to suppress this warning')
             if f_sph:
                 print_header('Not imported into Sphinx', '-', not no_color and small_header_color)
                 for md in f_sph:

--- a/data/TeXmacs/bin/tm_sympy
+++ b/data/TeXmacs/bin/tm_sympy
@@ -13,9 +13,9 @@
 # in a sequence. However you can and must indent your
 # expression using standard Pyhon rules.
 #
-# You can retrive the last output using '_' built-in
+# You can retrieve the last output using '_' built-in
 # symbol. If the previous command did not generate
-# any ouput, it will be assigned with None.
+# any output, it will be assigned with None.
 #
 # For a complete Python interface visit:
 #

--- a/examples/advanced/autowrap_integrators.py
+++ b/examples/advanced/autowrap_integrators.py
@@ -118,7 +118,7 @@ def main():
         # To get inline expressions in the low level code, we attach the
         # wave function expressions to a regular SymPy function using the
         # implemented_function utility.  This is an extra step needed to avoid
-        # erronous summations in the wave function expressions.
+        # erroneous summations in the wave function expressions.
         #
         # Such function objects carry around the expression they represent,
         # but the expression is not exposed unless explicit measures are taken.

--- a/examples/intermediate/schwarzschild.ipynb
+++ b/examples/intermediate/schwarzschild.ipynb
@@ -187,7 +187,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The matrix $M$ representing the two-form as a bilinear map $V,U\\to V^tMU$ over the column vectors $V$ and $U$ in the canonical basis of the choosen coordinate system is:"
+      "The matrix $M$ representing the two-form as a bilinear map $V,U\\to V^tMU$ over the column vectors $V$ and $U$ in the canonical basis of the chosen coordinate system is:"
      ]
     },
     {

--- a/examples/notebooks/spin.ipynb
+++ b/examples/notebooks/spin.ipynb
@@ -1361,7 +1361,7 @@
       "\n",
       "$$H=\\frac{p^2}{2\\mu} - \\frac{Ze^2}{r}$$\n",
       "\n",
-      "The resulting eigenfunctions have a seperate radial and angular compents, $\\psi=R_{n,l}(r)Y_{l,m}(\\phi,\\theta)$. While the radial component is a complicated function involving Laguere polynomials, the radial part is the familiar spherical harmonics with orbital angular momentum $\\vec{L}$, where $l$ and $m$ give the orbital angular momentum quantum numbers. We represent this as a angular momentum state:"
+      "The resulting eigenfunctions have a separate radial and angular compents, $\\psi=R_{n,l}(r)Y_{l,m}(\\phi,\\theta)$. While the radial component is a complicated function involving Laguere polynomials, the radial part is the familiar spherical harmonics with orbital angular momentum $\\vec{L}$, where $l$ and $m$ give the orbital angular momentum quantum numbers. We represent this as a angular momentum state:"
      ]
     },
     {

--- a/release/fabfile.py
+++ b/release/fabfile.py
@@ -402,7 +402,7 @@ git_whitelist = {
     'bin/test_isolated',
     'bin/test_travis.sh',
     # The notebooks are not ready for shipping yet. They need to be cleaned
-    # up, and preferrably doctested.  See also
+    # up, and preferably doctested.  See also
     # https://github.com/sympy/sympy/issues/6039.
     'examples/advanced/identitysearch_example.ipynb',
     'examples/beginner/plot_advanced.ipynb',

--- a/release/rever.xsh
+++ b/release/rever.xsh
@@ -1009,7 +1009,7 @@ git_whitelist = {
     'bin/test_setup.py',
     'bin/test_travis.sh',
     # The notebooks are not ready for shipping yet. They need to be cleaned
-    # up, and preferrably doctested.  See also
+    # up, and preferably doctested.  See also
     # https://github.com/sympy/sympy/issues/6039.
     'examples/advanced/identitysearch_example.ipynb',
     'examples/beginner/plot_advanced.ipynb',

--- a/sympy/combinatorics/fp_groups.py
+++ b/sympy/combinatorics/fp_groups.py
@@ -968,7 +968,7 @@ def elimination_technique_1(gens, rels, identity):
     redundant_gens = {}
     redundant_rels = []
     used_gens = set()
-    # examine each relator in relator list for any generator occuring exactly
+    # examine each relator in relator list for any generator occurring exactly
     # once
     for rel in rels:
         # don't look for a redundant generator in a relator which

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -303,7 +303,7 @@ class IntegerPartition(Basic):
 
         The partition can be given as a list of positive integers or a
         dictionary of (integer, multiplicity) items. If the partition is
-        preceeded by an integer an error will be raised if the partition
+        preceded by an integer an error will be raised if the partition
         does not sum to that given integer.
 
         Examples
@@ -318,7 +318,7 @@ class IntegerPartition(Basic):
         >>> IntegerPartition({1:3, 2:1})
         IntegerPartition(5, (2, 1, 1, 1))
 
-        If the value that the partion should sum to is given first, a check
+        If the value that the partition should sum to is given first, a check
         will be made to see n error will be raised if there is a discrepancy:
 
         >>> IntegerPartition(10, [5, 4, 3, 1])

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1958,7 +1958,7 @@ class PermutationGroup(Basic):
                 to_remove = []
                 for i, r in enumerate(rep_blocks):
                     if len(r) > len(rep) and rep.issubset(r):
-                        # i-th block sytem is not minimal
+                        # i-th block system is not minimal
                         del num_blocks[i], blocks[i]
                         to_remove.append(rep_blocks[i])
                     elif len(r) < len(rep) and r.issubset(rep):

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -65,7 +65,7 @@ class RewritingSystem(object):
 
     def _add_rule(self, r1, r2):
         '''
-        Add the rule r1 -> r2 with no checking or futher
+        Add the rule r1 -> r2 with no checking or further
         deductions
 
         '''

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1110,7 +1110,7 @@ class Expr(Basic, EvalfMixin):
         self is treated as a Mul and the ordering of the factors is maintained.
         If ``cset`` is True the commutative factors will be returned in a set.
         If there were repeated factors (as may happen with an unevaluated Mul)
-        then an error will be raised unless it is explicitly supressed by
+        then an error will be raised unless it is explicitly suppressed by
         setting ``warn`` to False.
 
         Note: -1 is always separated from a Number unless split_1 is False.
@@ -1319,8 +1319,8 @@ class Expr(Basic, EvalfMixin):
 
         def find(l, sub, first=True):
             """ Find where list sub appears in list l. When ``first`` is True
-            the first occurance from the left is returned, else the last
-            occurance is returned. Return None if sub is not in l.
+            the first occurrence from the left is returned, else the last
+            occurrence is returned. Return None if sub is not in l.
 
             >> l = range(5)*2
             >> find(l, [2, 3])

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -766,7 +766,7 @@ class Function(Application, Expr):
 
             else:
                 # the function defined in sympy is not known in sage
-                # this exception is catched in sage
+                # this exception is caught in sage
                 raise AttributeError
 
         return func(*args)
@@ -1172,7 +1172,7 @@ class Derivative(Expr):
         evaluate = assumptions.pop('evaluate', False)
 
         # Look for a quick exit if there are symbols that don't appear in
-        # expression at all. Note, this cannnot check non-symbols like
+        # expression at all. Note, this cannot check non-symbols like
         # functions and Derivatives as those can be created by intermediate
         # derivatives.
         if evaluate and all(isinstance(sc[0], Symbol) for sc in variable_count):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1499,7 +1499,7 @@ class Mul(Expr, AssocOp):
 
                 # the bases must be equivalent in succession, and
                 # the powers must be extractively compatible on the
-                # first and last factor but equal inbetween.
+                # first and last factor but equal in between.
 
                 rat = []
                 for j in range(take):

--- a/sympy/core/multidimensional.py
+++ b/sympy/core/multidimensional.py
@@ -23,7 +23,7 @@ def apply_on_element(f, args, kwargs, n):
         structure = kwargs[n]
         is_arg = False
 
-    # Define reduced function that is only dependend of the specified argument.
+    # Define reduced function that is only dependent on the specified argument.
     def f_reduced(x):
         if hasattr(x, "__iter__"):
             return list(map(f_reduced, x))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1464,7 +1464,7 @@ def test_issue_4122():
     x = Symbol('x', finite=True, real=True)
     assert oo + x == oo
 
-    # similarily for negative infinity
+    # similarly for negative infinity
     x = Symbol('x', nonnegative=True)
     assert (-oo + x).is_Add
     x = Symbol('x', finite=True)

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -451,7 +451,7 @@ def test_add():
     assert ((x - 1)*y).subs(x + 1, t) == y*(t - 2)
     assert ((-x + 1)*y).subs(x + 1, t) == y*(-t + 2)
 
-    # this should work everytime:
+    # this should work every time:
     e = a**2 - b - c
     assert e.subs(Add(*e.args[:2]), d) == d + e.args[2]
     assert e.subs(a**2 - c, d) == d - b

--- a/sympy/core/trace.py
+++ b/sympy/core/trace.py
@@ -43,7 +43,7 @@ def _cycle_permute(l):
     indices.append(len(l) + indices[0])
 
     # create sublist of items with first item as min_item and last_item
-    # in each of the sublist is item just before the next occurence of
+    # in each of the sublist is item just before the next occurrence of
     # minitem in the cycle formed.
     sublist = [[le[indices[i]:indices[i + 1]]] for i in
                range(len(indices) - 1)]

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -1935,7 +1935,7 @@ def dh_private_key(digit=10, seed=None):
     =======
 
     (p, g, a) : p = prime number, g = primitive root of p,
-                a = random number from 2 thru p - 1
+                a = random number from 2 through p - 1
 
     Notes
     =====

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -901,7 +901,7 @@ class catalan(Function):
     8/(3*pi)
 
     We can differentiate the Catalan numbers C(n) interpreted as a
-    continuous real funtion in n:
+    continuous real function in n:
 
     >>> diff(catalan(n), n)
     (polygamma(0, n + 1/2) - polygamma(0, n + 2) + log(4))*catalan(n)
@@ -1356,7 +1356,7 @@ def nC(n, k=None, replacement=False):
     35
 
     If there are ``k`` items with multiplicities ``m_1, m_2, ..., m_k``
-    then the total of all combinations of length 0 hrough ``k`` is the
+    then the total of all combinations of length 0 through ``k`` is the
     product, ``(m_1 + 1)*(m_2 + 1)*...*(m_k + 1)``. When the multiplicity
     of each item is 1 (i.e., k unique items) then there are 2**k
     combinations. For example, if there are 4 unique items, the total number

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -129,7 +129,7 @@ def sqrt(arg):
 
 
 def cbrt(arg):
-    """This function computes the principial cube root of `arg`, so
+    """This function computes the principal cube root of `arg`, so
     it's just a shortcut for `arg**Rational(1, 3)`.
 
     Examples

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -351,7 +351,7 @@ def test_sign_issue_3068():
     assert (n - i).round() == 1  # doesn't hang
     assert sign(n - i) == 1
     # perhaps it's not possible to get the sign right when
-    # only 1 digit is being requested for this situtation;
+    # only 1 digit is being requested for this situation;
     # 2 digits works
     assert (n - x).n(1, subs={x: i}) > 0
     assert (n - x).n(2, subs={x: i}) > 0

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2501,7 +2501,7 @@ class asec(InverseTrigonometricFunction):
     .. [1] http://en.wikipedia.org/wiki/Inverse_trigonometric_functions
     .. [2] http://dlmf.nist.gov/4.23
     .. [3] http://functions.wolfram.com/ElementaryFunctions/ArcSec
-    .. [4] http://refrence.wolfram.com/language/ref/ArcSec.html
+    .. [4] http://reference.wolfram.com/language/ref/ArcSec.html
     """
 
     @classmethod

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -360,7 +360,7 @@ class DiracDelta(Function):
                 return SingularityFunction(x, solve(args[0], x)[0], -1)
             return SingularityFunction(x, solve(args[0], x)[0], -args[1] - 1)
         else:
-            # I dont know how to handle the case for DiracDelta expressions
+            # I don't know how to handle the case for DiracDelta expressions
             # having arguments with more than one variable.
             raise TypeError(filldedent('''
                 rewrite(SingularityFunction) doesn't support
@@ -606,7 +606,7 @@ class Heaviside(Function):
             # ((x - 5)**3*Heaviside(x - 5)).rewrite(SingularityFunction) should output
             # SingularityFunction(x, 5, 0) instead of (x - 5)**3*SingularityFunction(x, 5, 0)
         else:
-            # I dont know how to handle the case for Heaviside expressions
+            # I don't know how to handle the case for Heaviside expressions
             # having arguments with more than one variable.
             raise TypeError(filldedent('''
                 rewrite(SingularityFunction) doesn't

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -220,7 +220,7 @@ class Plane(GeometryEntity):
             return True
 
     def distance(self, o):
-        """Distance beteen the plane and another geometric entity.
+        """Distance between the plane and another geometric entity.
 
         Parameters
         ==========

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -33,7 +33,7 @@ def warn_with_traceback(message, category, filename, lineno, file=None, line=Non
 
 
 warnings.showwarning = warn_with_traceback
-warnings.simplefilter('always', UserWarning)  # make sure to show warnings every time they occurr
+warnings.simplefilter('always', UserWarning)  # make sure to show warnings every time they occur
 
 
 def feq(a, b):

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -17,7 +17,7 @@ def warn_with_traceback(message, category, filename, lineno, file=None, line=Non
     log = file if hasattr(file,'write') else sys.stderr
     log.write(warnings.formatwarning(message, category, filename, lineno, line))
 warnings.showwarning = warn_with_traceback
-warnings.simplefilter('always', UserWarning)     # make sure to show warnings every time they occurr
+warnings.simplefilter('always', UserWarning)     # make sure to show warnings every time they occur
 
 
 def test_point():

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -461,7 +461,7 @@ class HolonomicFunction(object):
 
         # initial condition
         self.y0 = y0
-        # the point for initial conditions, defualt is zero.
+        # the point for initial conditions, default is zero.
         self.x0 = x0
         # differential operator L such that L.f = 0
         self.annihilator = annihilator
@@ -988,7 +988,7 @@ class HolonomicFunction(object):
         # until a non trivial solution is found
         while sol[0].is_zero:
 
-            # updating the coefficents Dx^i(f).Dx^j(g) for next degree
+            # updating the coefficients Dx^i(f).Dx^j(g) for next degree
             for i in range(a - 1, -1, -1):
                 for j in range(b - 1, -1, -1):
                     coeff_mul[i][j + 1] += coeff_mul[i][j]
@@ -1030,7 +1030,7 @@ class HolonomicFunction(object):
             # if both the conditions are at same point
             if self.x0 == other.x0:
 
-                # try to find more inital conditions
+                # try to find more initial conditions
                 y0_self = _extend_y0(self, sol_ann.order)
                 y0_other = _extend_y0(other, sol_ann.order)
                 # h(x0) = f(x0) * g(x0)
@@ -2565,7 +2565,7 @@ def _hyper_to_meijerg(func):
 
     z = func.args[2]
 
-    # paramters of the `meijerg` function.
+    # parameters of the `meijerg` function.
     an = (1 - i for i in ap)
     anp = ()
     bm = (S(0), )

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -193,6 +193,6 @@ def deltaintegrate(f, x):
                         else:
                             return r*DiracDelta(x,m-1)
                 # In some very weak sense, x=0 is still a singularity,
-                # but we hope will not be of any practial consequence.
+                # but we hope will not be of any practical consequence.
                 return S.Zero
     return None

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -605,7 +605,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
 
         # TODO: Currently it's better to use symbolic expressions here instead
         # of rational functions, because it's simpler and FracElement doesn't
-        # give big speed improvement yet. This is because cancelation is slow
+        # give big speed improvement yet. This is because cancellation is slow
         # due to slow polynomial GCD algorithms. If this gets improved then
         # revise this code.
         candidate = poly_part/poly_denom + Add(*log_part)

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -794,7 +794,7 @@ def best_origin(a, b, lineseg, expr):
     3 > First check if a point exists on the line segment where the value of
         the highest power generator becomes 0. If not check if the value of
         the next highest becomes 0. If none becomes 0 within line segment
-        constraints then pick the first boundary point of the line segement.
+        constraints then pick the first boundary point of the line segment.
         Actually, any point lying on the segment can be picked as best origin
         in the last case.
 

--- a/sympy/integrals/rubi/parsetools/parse.py
+++ b/sympy/integrals/rubi/parsetools/parse.py
@@ -348,9 +348,9 @@ def downvalues_rules(r, parsed):
         free_symbols = list(set(free_symbols)) #remove common symbols
 
         # Parse Transformed Expression and Constraints
-        if i[2][0] == 'Condition': # parse rules without constraints seperately
-            constriant = divide_constraint(i[2][2], free_symbols) # seperate And constraints into indivdual constraints
-            FreeQ_vars, FreeQ_x = seperate_freeq(i[2][2].copy()) # seperate FreeQ into indivdual constraints
+        if i[2][0] == 'Condition': # parse rules without constraints separately
+            constriant = divide_constraint(i[2][2], free_symbols) # separate And constraints into individual constraints
+            FreeQ_vars, FreeQ_x = seperate_freeq(i[2][2].copy()) # separate FreeQ into individual constraints
             transformed = generate_sympy_from_parsed(i[2][1].copy(), symbols=free_symbols)
         else:
             constriant = ''
@@ -364,7 +364,7 @@ def downvalues_rules(r, parsed):
         transformed = sympify(transformed)
 
         index += 1
-        if type(transformed) == Function('With') or type(transformed) == Function('Module'): # define seperate function when With appears
+        if type(transformed) == Function('With') or type(transformed) == Function('Module'): # define separate function when With appears
             transformed, With_constraints = replaceWith(transformed, free_symbols, index)
             parsed += '    pattern' + str(index) +' = Pattern(' + pattern + '' + FreeQ_constraint + '' + constriant + With_constraints + ')'
             parsed += '\n{}'.format(transformed)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -911,7 +911,7 @@ def test_issue_3940():
 
 
 def test_issue_5413():
-    # Note that this is not the same as testing ratint() becuase integrate()
+    # Note that this is not the same as testing ratint() because integrate()
     # pulls out the coefficient.
     assert integrate(-a/(a**2 + x**2), x) == I*log(-I*a + x)/2 - I*log(I*a + x)/2
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -745,7 +745,7 @@ def _inverse_mellin_transform(F, s, x_, strip, as_meijerg=False):
         # See [L], 5.2
         cond = [abs(arg(G.argument)) < G.delta*pi]
         # Note: we allow ">=" here, this corresponds to convergence if we let
-        # limits go to oo symetrically. ">" corresponds to absolute convergence.
+        # limits go to oo symmetrically. ">" corresponds to absolute convergence.
         cond += [And(Or(len(G.ap) != len(G.bq), 0 >= re(G.nu) + 1),
                      abs(arg(G.argument)) == G.delta*pi)]
         cond = Or(*cond)
@@ -869,7 +869,7 @@ def inverse_mellin_transform(F, s, x, strip, **hints):
 
 def _simplifyconds(expr, s, a):
     r"""
-    Naively simplify some conditions occuring in ``expr``, given that `\operatorname{Re}(s) > a`.
+    Naively simplify some conditions occurring in ``expr``, given that `\operatorname{Re}(s) > a`.
 
     >>> from sympy.integrals.transforms import _simplifyconds as simp
     >>> from sympy.abc import x

--- a/sympy/liealgebras/type_a.py
+++ b/sympy/liealgebras/type_a.py
@@ -36,7 +36,7 @@ class TypeA(Standard_Cartan):
         """
         This is a method just to generate roots
         with a 1 iin the ith position and a -1
-        in the jth postion.
+        in the jth position.
 
         """
 

--- a/sympy/liealgebras/type_b.py
+++ b/sympy/liealgebras/type_b.py
@@ -29,7 +29,7 @@ class TypeB(Standard_Cartan):
         """
         This is a method just to generate roots
         with a 1 iin the ith position and a -1
-        in the jth postion.
+        in the jth position.
 
         """
         root = [0]*self.n

--- a/sympy/liealgebras/type_c.py
+++ b/sympy/liealgebras/type_c.py
@@ -25,7 +25,7 @@ class TypeC(Standard_Cartan):
         return n
 
     def basic_root(self, i, j):
-        """Generate roots with 1 in ith position and a -1 in jth postion
+        """Generate roots with 1 in ith position and a -1 in jth position
         """
         n = self.n
         root = [0]*n

--- a/sympy/liealgebras/type_d.py
+++ b/sympy/liealgebras/type_d.py
@@ -28,7 +28,7 @@ class TypeD(Standard_Cartan):
         """
         This is a method just to generate roots
         with a 1 iin the ith position and a -1
-        in the jth postion.
+        in the jth position.
 
         """
 

--- a/sympy/liealgebras/type_e.py
+++ b/sympy/liealgebras/type_e.py
@@ -28,7 +28,7 @@ class TypeE(Standard_Cartan):
         """
         This is a method just to generate roots
         with a -1 in the ith position and a 1
-        in the jth postion.
+        in the jth position.
 
         """
 

--- a/sympy/liealgebras/type_f.py
+++ b/sympy/liealgebras/type_f.py
@@ -26,7 +26,7 @@ class TypeF(Standard_Cartan):
 
 
     def basic_root(self, i, j):
-        """Generate roots with 1 in ith position and -1 in jth postion
+        """Generate roots with 1 in ith position and -1 in jth position
 
         """
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -56,7 +56,7 @@ class MatrixRequired(object):
         raise NotImplementedError("Subclasses must implement this.")
 
     def __eq__(self, other):
-        raise NotImplementedError("Subclasses must impliment this.")
+        raise NotImplementedError("Subclasses must implement this.")
 
     def __getitem__(self, key):
         """Implementations of __getitem__ should accept ints, in which
@@ -736,7 +736,7 @@ class MatrixSpecial(MatrixRequired):
         rows = kwargs.get('rows', diag_rows)
         cols = kwargs.get('cols', diag_cols)
         if rows < diag_rows or cols < diag_cols:
-            raise ValueError("A {} x {} diagnal matrix cannot accomodate a"
+            raise ValueError("A {} x {} diagnal matrix cannot accommodate a"
                              "diagonal of size at least {} x {}.".format(rows, cols,
                                                                          diag_rows, diag_cols))
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -181,7 +181,7 @@ class MatrixDeterminant(MatrixCommon):
             return (None, None, None, None)
 
 
-        # Recursively implimented Bareiss' algorithm as per Deanna Richelle Leggett's
+        # Recursively implemented Bareiss' algorithm as per Deanna Richelle Leggett's
         # thesis http://www.math.usm.edu/perry/Research/Thesis_DRL.pdf
         def bareiss(mat, cumm=1):
             if mat.rows == 0:

--- a/sympy/ntheory/bbp_pi.py
+++ b/sympy/ntheory/bbp_pi.py
@@ -63,7 +63,7 @@ some of the constant modifications that were made):
 2. The while loop to evaluate whether the series has converged quits
 when the addition amount `dt` has dropped to zero.
 
-3. the formatting string to convert the decimal to hexidecimal is
+3. the formatting string to convert the decimal to hexadecimal is
 calculated for the given precision.
 
 4. pi_hex_digits(n) changed to have coefficient to the formula in an

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -500,7 +500,7 @@ def primerange(a, b):
         Notes
         =====
 
-        Some famous conjectures about the occurence of primes in a given
+        Some famous conjectures about the occurrence of primes in a given
         range are [1]:
 
         - Twin primes: though often not, the following will give 2 primes

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -192,7 +192,7 @@ class MathematicaParser(object):
             # get arguments of Mathematica function
             args, end = cls._get_args(m)
 
-            # funciton side check. (e.g.) '2*Func[x]' is invalid.
+            # function side check. (e.g.) '2*Func[x]' is invalid.
             if m.start() != 0 or end != len(fm):
                 err = "'{f}' function form is invalid.".format(f=fm)
                 raise ValueError(err)
@@ -315,7 +315,7 @@ class MathematicaParser(object):
             # get a start position of the model argument
             xbgn = m.start()
 
-            # add the correspoinding actual argument
+            # add the corresponding actual argument
             scanned += template[:xbgn] + d[x]
 
             # update cursor to the end of the model arugment

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -33,7 +33,7 @@ class Beam(object):
     There is a beam of length 4 meters. A constant distributed load of 6 N/m
     is applied from half of the beam till the end. There are two simple supports
     below the beam, one at the starting point and another at the ending point
-    of the beam. The deflection of the beam at the end is resticted.
+    of the beam. The deflection of the beam at the end is restricted.
 
     Using the sign convention of downwards forces being positive.
 

--- a/sympy/physics/mechanics/tests/test_system.py
+++ b/sympy/physics/mechanics/tests/test_system.py
@@ -195,7 +195,7 @@ def test_property_attributes():
 
 def test_not_specified_errors():
     """This test will cover errors that arise from trying to access attributes
-    that were not specificed upon object creation or were specified on creation
+    that were not specified upon object creation or were specified on creation
     and the user trys to recalculate them."""
     # Trying to access form 2 when form 1 given
     # Trying to access form 3 when form 2 given

--- a/sympy/physics/optics/medium.py
+++ b/sympy/physics/optics/medium.py
@@ -22,7 +22,7 @@ class Medium(Symbol):
 
     """
     This class represents an optical medium. The prime reason to implement this is
-    to facilitate refraction, Fermat's priciple, etc.
+    to facilitate refraction, Fermat's principle, etc.
 
     An optical medium is a material through which electromagnetic waves propagate.
     The permittivity and permeability of the medium define how electromagnetic

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -24,7 +24,7 @@ class AntiCommutator(Expr):
     This class returns the anticommutator in an unevaluated form.  To evaluate
     the anticommutator, use the ``.doit()`` method.
 
-    Cannonical ordering of an anticommutator is ``{A, B}`` for ``A < B``. The
+    Canonical ordering of an anticommutator is ``{A, B}`` for ``A < B``. The
     arguments of the anticommutator are put into canonical order using
     ``__cmp__``. If ``B < A``, then ``{A, B}`` is returned as ``{B, A}``.
 

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -45,7 +45,7 @@ class Wigner3j(Expr):
     Examples
     ========
 
-    Declare a Wigner-3j coefficient and calcualte its value
+    Declare a Wigner-3j coefficient and calculate its value
 
         >>> from sympy.physics.quantum.cg import Wigner3j
         >>> w3j = Wigner3j(6,0,4,0,2,0)
@@ -594,7 +594,7 @@ def _check_cg_simp(expr, simp, sign, lt, term_list, variables, dep_variables, bu
 
     dep_variables: list
         A list of the variables that must match for all the terms in the sum,
-        i.e. the dependant variables
+        i.e. the dependent variables
 
     build_index_expr: expression
         Expression with Wild terms giving the number of elements in cg_index

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -25,7 +25,7 @@ class Commutator(Expr):
     class returns the commutator in an unevaluated form. To evaluate the
     commutator, use the ``.doit()`` method.
 
-    Cannonical ordering of a commutator is ``[A, B]`` for ``A < B``. The
+    Canonical ordering of a commutator is ``[A, B]`` for ``A < B``. The
     arguments of the commutator are put into canonical order using ``__cmp__``.
     If ``B < A``, then ``[B, A]`` is returned as ``-[A, B]``.
 

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -81,7 +81,7 @@ class Density(HermitianOperator):
         return Tuple(*[arg[1] for arg in self.args])
 
     def get_state(self, index):
-        """Return specfic state by index.
+        """Return specific state by index.
 
         Parameters
         ==========

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -579,7 +579,7 @@ class DifferentialOperator(Operator):
     @property
     def expr(self):
         """
-        Returns the arbitary expression which is to have the Wavefunction
+        Returns the arbitrary expression which is to have the Wavefunction
         substituted into it
 
         Examples

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -364,7 +364,7 @@ class QExpr(Expr):
             def _represent_Position(self, basis, **options):
 
         Usually, basis object will be instances of Operator subclasses, but
-        there is a chance we will relax this in the future to accomodate other
+        there is a chance we will relax this in the future to accommodate other
         types of basis sets that are not associated with an operator.
 
         If the ``format`` option is given it can be ("sympy", "numpy",

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -99,7 +99,7 @@ def represent(expr, **options):
     ========
 
     Here we subclass ``Operator`` and ``Ket`` to create the z-spin operator
-    and its spin 1/2 up eigenstate. By definining the ``_represent_SzOp``
+    and its spin 1/2 up eigenstate. By defining the ``_represent_SzOp``
     method, the ket can be represented in the z-spin basis.
 
     >>> from sympy.physics.quantum import Operator, represent, Ket

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2264,7 +2264,7 @@ def evaluate_deltas(e):
         return e.func(*[evaluate_deltas(arg) for arg in e.args])
 
     elif isinstance(e, Mul):
-        # find all occurences of delta function and count each index present in
+        # find all occurrences of delta function and count each index present in
         # expression.
         deltas = []
         indices = {}
@@ -2835,7 +2835,7 @@ def wicks(e, **kw_args):
     # For Mul-objects we can actually do something
     if isinstance(e, Mul):
 
-        # we dont want to mess around with commuting part of Mul
+        # we don't want to mess around with commuting part of Mul
         # so we factorize it out before starting recursion
         c_part = []
         string1 = []

--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -143,7 +143,7 @@ class Dimension(Expr):
 
         name = self.name
         if name in dimsys_default.dimensional_dependencies:
-            raise IndexError("already in dependecies dict")
+            raise IndexError("already in dependencies dict")
         # Horrible code:
         d = dict(dimsys_default.dimensional_dependencies)
         d[name] = Dict({name: 1})

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -68,7 +68,7 @@ class UnitSystem(object):
 
         Take the base and normal units of the current system to merge
         them to the base and normal units given in argument.
-        If not provided, name and description are overriden by empty strings.
+        If not provided, name and description are overridden by empty strings.
         """
 
         base = self._base_units + tuple(base)

--- a/sympy/physics/vector/fieldfunctions.py
+++ b/sympy/physics/vector/fieldfunctions.py
@@ -137,7 +137,7 @@ def is_conservative(field):
     """
     Checks if a field is conservative.
 
-    Paramaters
+    Parameters
     ==========
 
     field : Vector
@@ -169,7 +169,7 @@ def is_solenoidal(field):
     """
     Checks if a field is solenoidal.
 
-    Paramaters
+    Parameters
     ==========
 
     field : Vector

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -76,7 +76,7 @@ from sympy.utilities.iterables import numbered_symbols
 from sympy.external import import_module
 import warnings
 
-#TODO debuging output
+#TODO debugging output
 
 
 class vectorized_lambdify(object):
@@ -130,7 +130,7 @@ class vectorized_lambdify(object):
                       or 'negative dimensions are not allowed' in str(e)  # XXX
                       or 'sequence too large; must be smaller than 32' in str(e)))):  # XXX
                 # Almost all functions were translated to numpy, but some were
-                # left as sympy functions. They recieved an ndarray as an
+                # left as sympy functions. They received an ndarray as an
                 # argument and failed.
                 #   sin(ndarray(...)) raises "unhashable type"
                 #   Integral(x, (x, 0, ndarray(...))) raises "Invalid limits"
@@ -201,7 +201,7 @@ class lambdify(object):
             # hence it is not possible to specify all the exceptions that
             # are to be caught. Presently there are no cases for which the code
             # reaches this block other than ZeroDivisionError and complex
-            # comparision. Also the exception is caught only once. If the
+            # comparison. Also the exception is caught only once. If the
             # exception repeats itself,
             # then it is not caught and the corresponding error is raised.
             # XXX: Remove catching all exceptions once the plotting module
@@ -617,7 +617,7 @@ class Lambdifier(object):
     def sympy_expression_namespace(cls, expr):
         """Traverses the (func, args) tree of an expression and creates a sympy
         namespace. All other modules are imported only as a module name. That way
-        the namespace is not poluted and rests quite small. It probably causes much
+        the namespace is not polluted and rests quite small. It probably causes much
         more variable lookups and so it takes more time, but there are no tests on
         that for the moment."""
         if expr is None:

--- a/sympy/polys/agca/modules.py
+++ b/sympy/polys/agca/modules.py
@@ -687,7 +687,7 @@ class SubModule(Module):
 
         Some implementations allow further options to be passed. Currently, the
         only one implemented is ``relations=True``, which may only be passed
-        if ``other`` is prinicipal. In this case the function
+        if ``other`` is principal. In this case the function
         will return a pair ``(res, rel)`` where ``res`` is the ideal, and
         ``rel`` is a list of coefficient vectors, expressing the generators of
         the ideal, multiplied by the generator of ``other`` in terms of

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1289,7 +1289,7 @@ def dmp_zz_heu_gcd(f, g, u, K):
     The algorithm computes the polynomial GCD by evaluating polynomials
     f and g at certain points and computing (fast) integer GCD of those
     evaluations. The polynomial GCD is recovered from the integer image
-    by interpolation. The evaluation proces reduces f and g variable by
+    by interpolation. The evaluation process reduces f and g variable by
     variable into a large integer.  The final step is to verify if the
     interpolated polynomial is the correct GCD. This gives cofactors of
     the input polynomials as a side effect.

--- a/sympy/polys/fglmtools.py
+++ b/sympy/polys/fglmtools.py
@@ -51,7 +51,7 @@ def matrix_fglm(F, ring, O_to):
             if g:
                 G.append(g)
         else:
-            # v is linearly independant from V
+            # v is linearly independent from V
             P = _update(s, _lambda, P)
             S.append(_incr_k(S[t[1]], t[0]))
             V.append(v)

--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -521,7 +521,7 @@ def f5_reduce(f, B):
     """
     F5-reduce a labeled polynomial f by B.
 
-    Continously searches for non-zero labeled polynomial h in B, such
+    Continuously searches for non-zero labeled polynomial h in B, such
     that the leading term lt_h of h divides the leading term lt_f of
     f and Sign(lt_h * h) < Sign(f). If such a labeled polynomial h is
     found, f gets replaced by f - lt_f / lt_h * h. If no such h can be

--- a/sympy/polys/heuristicgcd.py
+++ b/sympy/polys/heuristicgcd.py
@@ -23,7 +23,7 @@ def heugcd(f, g):
     The algorithm computes the polynomial GCD by evaluating polynomials
     ``f`` and ``g`` at certain points and computing (fast) integer GCD
     of those evaluations. The polynomial GCD is recovered from the integer
-    image by interpolation. The evaluation proces reduces f and g variable
+    image by interpolation. The evaluation process reduces f and g variable
     by variable into a large integer. The final step is to verify if the
     interpolated polynomial is the correct GCD. This gives cofactors of
     the input polynomials as a side effect.

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -491,7 +491,7 @@ def assemble_partfrac_list(partial_list):
             func = Lambda(an, nu/de**ex)
             pfd += RootSum(r, func, auto=False, quadratic=False)
         else:
-            # Assemble in case the roots are given explicitely by a list of algebraic numbers
+            # Assemble in case the roots are given explicitly by a list of algebraic numbers
             for root in r:
                 pfd += nf(root)/df(root)**ex
 

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -501,7 +501,7 @@ def roots_cyclotomic(f, factor=False):
 
 def roots_quintic(f):
     """
-    Calulate exact roots of a solvable quintic
+    Calculate exact roots of a solvable quintic
     """
     result = []
     coeff_5, coeff_4, p, q, r, s = f.all_coeffs()

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -309,7 +309,7 @@ def test_dmp_zz_wang():
 
 
 def test_issue_6355():
-    # This tests a bug in the Wang algorithm that occured only with a very
+    # This tests a bug in the Wang algorithm that occurred only with a very
     # specific set of random numbers.
     random_sequence = [-1, -1, 0, 0, 0, 0, -1, -1, 0, -1, 3, -1, 3, 3, 3, 3, -1, 3]
 

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -409,7 +409,7 @@ class FCodePrinter(CodePrinter):
                 if pos == 0:
                     return endpos
             return pos
-        # split line by line and add the splitted lines to result
+        # split line by line and add the split lines to result
         result = []
         if self._settings['source_format'] == 'free':
             trailing = ' &'

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -554,7 +554,7 @@ def julia_code(expr, assign_to=None, **settings):
 
     Matrices are supported using Julia inline notation.  When using
     ``assign_to`` with matrices, the name can be specified either as a string
-    or as a ``MatrixSymbol``.  The dimenions must align in the latter case.
+    or as a ``MatrixSymbol``.  The dimensions must align in the latter case.
 
     >>> from sympy import Matrix, MatrixSymbol
     >>> mat = Matrix([[x**2, sin(x), ceiling(x)]])

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -580,7 +580,7 @@ def octave_code(expr, assign_to=None, **settings):
 
     Matrices are supported using Octave inline notation.  When using
     ``assign_to`` with matrices, the name can be specified either as a string
-    or as a ``MatrixSymbol``.  The dimenions must align in the latter case.
+    or as a ``MatrixSymbol``.  The dimensions must align in the latter case.
 
     >>> from sympy import Matrix, MatrixSymbol
     >>> mat = Matrix([[x**2, sin(x), ceiling(x)]])

--- a/sympy/printing/tests/test_precedence.py
+++ b/sympy/printing/tests/test_precedence.py
@@ -73,7 +73,7 @@ def test_Symbol():
 
 
 def test_And_Or():
-    # precendence relations between logical operators, ...
+    # precedence relations between logical operators, ...
     assert precedence(x & y) > precedence(x | y)
     assert precedence(~y) > precedence(x & y)
     # ... and with other operators (cfr. other programming languages)

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -40,7 +40,7 @@ def rational_algorithm(f, x, k, order=4, full=False):
     instead.
 
     Looks for derivative of a function up to 4'th order (by default).
-    This can be overriden using order option.
+    This can be overridden using order option.
 
     Returns
     =======

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -189,7 +189,7 @@ class SubsSet(dict):
         {d3: exp(x-d2)}.
 
     The function rewrite uses all this information to correctly rewrite our
-    expression in terms of w. In this case w can be choosen to be exp(-x),
+    expression in terms of w. In this case w can be chosen to be exp(-x),
     i.e. d2. The correct rewriting then is::
 
         exp(-w)/w + 1/w + x.
@@ -363,7 +363,7 @@ def sign(e, x):
         e <  0 for x sufficiently large ... -1
 
     The result of this function is currently undefined if e changes sign
-    arbitarily often for arbitrarily large x (e.g. sin(x)).
+    arbitrarily often for arbitrarily large x (e.g. sin(x)).
 
     Note that this returns zero only if e is *constantly* zero
     for x sufficiently large. [If e is constant, of course, this is just

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -187,7 +187,7 @@ def test_Complement():
 
     assert S.Reals - Union(S.Naturals, FiniteSet(pi)) == \
             Intersection(S.Reals - S.Naturals, S.Reals - FiniteSet(pi))
-    # isssue 12712
+    # issue 12712
     assert Complement(FiniteSet(x, y, 2), Interval(-10, 10)) == \
             Complement(FiniteSet(x, y), Interval(-10, 10))
 

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1621,7 +1621,7 @@ RL1 = (TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0)
 
 
 # XXX it's a little unclear how this one is to be implemented
-# see Fu paper of reference, page 7. What is the Union symbol refering to?
+# see Fu paper of reference, page 7. What is the Union symbol referring to?
 # The diagram shows all these as one chain of transformations, but the
 # text refers to them being applied independently. Also, a break
 # if L starts to increase has not been implemented.

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -382,7 +382,7 @@ def _gammasimp(expr, as_comb):
                                     (denom_gammas, denom_others, numer_others)]:
                 _mult_thm(l, numer, denom)
 
-        # =========== level >= 2 work: factor absorbtion =========
+        # =========== level >= 2 work: factor absorption =========
 
         if level >= 2:
             # Try to absorb factors into the gammas: x*gamma(x) -> gamma(x + 1)

--- a/sympy/simplify/ratsimp.py
+++ b/sympy/simplify/ratsimp.py
@@ -165,7 +165,7 @@ def ratsimpmodprime(expr, G, *gens, **args):
                 c = c_hat.subs(sol)
                 d = d_hat.subs(sol)
 
-                # The "free" variables occuring before as parameters
+                # The "free" variables occurring before as parameters
                 # might still be in the substituted c, d, so set them
                 # to the value chosen before:
                 c = c.subs(dict(list(zip(Cs + Ds, [1] * (len(Cs) + len(Ds))))))

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -293,7 +293,7 @@ def trigsimp_groebner(expr, hints=[], quick=False, order="grlex",
             # If hint tan is provided, also work with tan(x). Moreover, if
             # n > 1, also work with sin(k*x) for k <= n, and similarly for cos
             # (and tan if the hint is provided). Finally, any generators which
-            # the ideal does not work with but we need to accomodate (either
+            # the ideal does not work with but we need to accommodate (either
             # because it was in expr or because it was provided as a hint)
             # we also build into the ideal.
             # This selection process is expressed in the list ``terms``.

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2194,7 +2194,7 @@ def odesimp(eq, func, order, constants, hint):
 
     # Lastly, now that we have cleaned up the expression, try solving for func.
     # When CRootOf is implemented in solve(), we will want to return a CRootOf
-    # everytime instead of an Equality.
+    # every time instead of an Equality.
 
     # Get the f(x) on the left if possible.
     if eq.rhs == func and not eq.lhs.has(func):
@@ -5217,7 +5217,7 @@ def _solve_variation_of_parameters(eq, func, order, match):
         wr = simplify(wr)  # We need much better simplification for
                            # some ODEs. See issue 4662, for example.
 
-        # To reduce commonly occuring sin(x)**2 + cos(x)**2 to 1
+        # To reduce commonly occurring sin(x)**2 + cos(x)**2 to 1
         wr = trigsimp(wr, deep=True, recursive=True)
     if not wr:
         # The wronskian will be 0 iff the solutions are not linearly
@@ -5408,7 +5408,7 @@ def ode_lie_group(eq, func, order, match):
                  \frac{\partial r}{\partial x} + h(x, y)\frac{\partial r}{\partial y}}
 
     After finding the solution by integration, it is then converted back to the original
-    coordinate system by subsituting `r` and `s` in terms of `x` and `y` again.
+    coordinate system by substituting `r` and `s` in terms of `x` and `y` again.
 
     Examples
     ========
@@ -6581,7 +6581,7 @@ def _linear_2eq_order1_type1(x, y, t, r, eq):
 
     .. math:: y = C_1 (\lambda_1 - a) e^{\lambda_1 t} + C_2 (\lambda_2 - a) e^{\lambda_2 t}
 
-    where `C_1` and `C_2` being arbitary constants
+    where `C_1` and `C_2` being arbitrary constants
 
     1.2. If `D < 0`. The characteristics equation has two conjugate
     roots, `\lambda_1 = \sigma + i \beta` and `\lambda_2 = \sigma - i \beta`.
@@ -6607,7 +6607,7 @@ def _linear_2eq_order1_type1(x, y, t, r, eq):
     .. math:: x = (b C_1 t + C_2) e^{a t} , y = C_1 e^{a t}
 
     2. Case when `ad - bc = 0` and `a^{2} + b^{2} > 0`. The whole straight
-    line `ax + by = 0` consists of singular points. The orginal system of differential
+    line `ax + by = 0` consists of singular points. The original system of differential
     equaitons can be rewritten as
 
     .. math:: x' = ax + by , y' = k (ax + by)
@@ -6732,7 +6732,7 @@ def _linear_2eq_order1_type3(x, y, t, r, eq):
 
     .. math:: x = e^{F} (C_1 e^{G} + C_2 e^{-G}) , y = e^{F} (C_1 e^{G} - C_2 e^{-G})
 
-    where `C_1` and `C_2` are arbitary constants, and
+    where `C_1` and `C_2` are arbitrary constants, and
 
     .. math:: F = \int f(t) \,dt , G = \int g(t) \,dt
 
@@ -6756,7 +6756,7 @@ def _linear_2eq_order1_type4(x, y, t, r, eq):
 
     .. math:: x = F (C_1 \cos(G) + C_2 \sin(G)), y = F (-C_1 \sin(G) + C_2 \cos(G))
 
-    where `C_1` and `C_2` are arbitary constants, and
+    where `C_1` and `C_2` are arbitrary constants, and
 
     .. math:: F = \int f(t) \,dt , G = \int g(t) \,dt
 
@@ -6891,7 +6891,7 @@ def _linear_2eq_order1_type7(x, y, t, r, eq):
 
     .. math:: y = C_1 y_0(t) + C_2 [\frac{F(t) P(t)}{x_0(t)} + y_0(t) \int \frac{g(t) F(t) P(t)}{x_0^{2}(t)} \,dt]
 
-    where C1 and C2 are arbitary constants and
+    where C1 and C2 are arbitrary constants and
 
     .. math:: F(t) = e^{\int f(t) \,dt} , P(t) = e^{\int p(t) \,dt}
 
@@ -6998,7 +6998,7 @@ def _linear_2eq_order2_type1(x, y, t, r, eq):
 
     .. math:: y = C_1 (\lambda_1^{2} - a) e^{\lambda_1 t} + C_2 (\lambda_2^{2} - a) e^{\lambda_2 t} + C_3 (\lambda_3^{2} - a) e^{\lambda_3 t} + C_4 (\lambda_4^{2} - a) e^{\lambda_4 t}
 
-    where `C_1,..., C_4` are arbitary constants.
+    where `C_1,..., C_4` are arbitrary constants.
 
     1.2. If `D = 0` and `a \neq d`:
 
@@ -7006,7 +7006,7 @@ def _linear_2eq_order2_type1(x, y, t, r, eq):
 
     .. math:: y = C_1 (d - a) t e^{\frac{kt}{2}} + C_2 (d - a) t e^{\frac{-kt}{2}} + C_3 [(d - a) t + 2k] e^{\frac{kt}{2}} + C_4 [(d - a) t - 2k] e^{\frac{-kt}{2}}
 
-    where `C_1,..., C_4` are arbitary constants and `k = \sqrt{2 (a + d)}`
+    where `C_1,..., C_4` are arbitrary constants and `k = \sqrt{2 (a + d)}`
 
     1.3. If `D = 0` and `a = d \neq 0` and `b = 0`:
 
@@ -7241,7 +7241,7 @@ def _linear_2eq_order2_type4(x, y, t, r, eq):
 
 def _linear_2eq_order2_type5(x, y, t, r, eq):
     r"""
-    The equation which come under this catagory are
+    The equation which come under this category are
 
     .. math:: x'' = a (t y' - y)
 
@@ -7269,7 +7269,7 @@ def _linear_2eq_order2_type5(x, y, t, r, eq):
 
     .. math:: v = C_1 \sqrt{\left|ab\right|} \sin(\frac{1}{2} \sqrt{\left|ab\right|} t^2) + C_2 \sqrt{\left|ab\right|} \cos(-\frac{1}{2} \sqrt{\left|ab\right|} t^2)
 
-    where `C_1` and `C_2` are arbitary constants. On substituting the value of `u` and `v`
+    where `C_1` and `C_2` are arbitrary constants. On substituting the value of `u` and `v`
     in above equations and integrating the resulting expressions, the general solution will become
 
     .. math:: x = C_3 t + t \int \frac{u}{t^2} \,dt, y = C_4 t + t \int \frac{u}{t^2} \,dt
@@ -7382,7 +7382,7 @@ def _linear_2eq_order2_type7(x, y, t, r, eq):
 
 def _linear_2eq_order2_type8(x, y, t, r, eq):
     r"""
-    The equation of this catagory are
+    The equation of this category are
 
     .. math:: x'' = a f(t) (t y' - y)
 
@@ -7410,7 +7410,7 @@ def _linear_2eq_order2_type8(x, y, t, r, eq):
 
     .. math:: v = C_1 \sqrt{\left|ab\right|} \sin(\sqrt{\left|ab\right|} \int t f(t) \,dt) + C_2 \sqrt{\left|ab\right|} \cos(-\sqrt{\left|ab\right|} \int t f(t) \,dt)
 
-    where `C_1` and `C_2` are arbitary constants. On substituting the value of `u` and `v`
+    where `C_1` and `C_2` are arbitrary constants. On substituting the value of `u` and `v`
     in above equations and integrating the resulting expressions, the general solution will become
 
     .. math:: x = C_3 t + t \int \frac{u}{t^2} \,dt, y = C_4 t + t \int \frac{u}{t^2} \,dt
@@ -7495,7 +7495,7 @@ def _linear_2eq_order2_type9(x, y, t, r, eq):
 
 def _linear_2eq_order2_type10(x, y, t, r, eq):
     r"""
-    The equation of this catagory are
+    The equation of this category are
 
     .. math:: (\alpha t^2 + \beta t + \gamma)^{2} x'' = ax + by
 
@@ -7695,7 +7695,7 @@ def _linear_3eq_order1_type3(x, y, z, t, r, eq):
 
     .. math:: a^2 x + b^2 y + c^2 z = A
 
-    where A is an arbitary constant. It follows that the integral lines are plane curves.
+    where A is an arbitrary constant. It follows that the integral lines are plane curves.
 
     2. Solution:
 
@@ -7789,7 +7789,7 @@ def _linear_neq_order1_type1(match_):
     .. math:: r \vec{v} = A \vec{v}
 
     where `r` comes out to be eigenvalue of `A` and vector `\vec{v}` is the eigenvector
-    of `A` corresponding to `r`. There are three possiblities of eigenvalues of `A`
+    of `A` corresponding to `r`. There are three possibilities of eigenvalues of `A`
 
     - `n` distinct real eigenvalues
     - complex conjugate eigenvalues

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2301,7 +2301,7 @@ def solve_linear_system(system, *symbols, **flags):
                     return dict()
                 continue
 
-            # we want to change the order of colums so
+            # we want to change the order of columns so
             # the order of variables must also change
             syms[i], syms[k] = syms[k], syms[i]
             matrix.col_swap(i, k)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1343,7 +1343,7 @@ def test_exclude():
             Vout: 0},
     ]
 
-    # TODO: Investingate why currently solution [0] is preferred over [1].
+    # TODO: Investigate why currently solution [0] is preferred over [1].
     assert solve(eqs, exclude=[Vplus, s, C]) in [[{
         Vminus: Vplus,
         V1: Vout/2 + Vplus/2 + sqrt((Vout - 5*Vplus)*(Vout - Vplus))/2,

--- a/sympy/stats/error_prop.py
+++ b/sympy/stats/error_prop.py
@@ -1,4 +1,4 @@
-"""Tools for arithmetic error propogation."""
+"""Tools for arithmetic error propagation."""
 from __future__ import print_function, division
 from itertools import repeat, combinations
 

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -314,7 +314,7 @@ class FinitePSpace(PSpace):
         cdf = self.sorted_cdf(expr, python_float=True)
 
         x = random.uniform(0, 1)
-        # Find first occurence with cumulative probability less than x
+        # Find first occurrence with cumulative probability less than x
         # This should be replaced with binary search
         for value, cum_prob in cdf:
             if x < cum_prob:

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -275,7 +275,7 @@ def get_contraction_structure(expr):
 
     By *dummy* we mean indices that are summation indices.
 
-    The stucture of the expression is determined and described as follows:
+    The structure of the expression is determined and described as follows:
 
     1) A conforming summation of Indexed objects is described with a dict where
        the keys are summation indices and the corresponding values are sets
@@ -289,7 +289,7 @@ def get_contraction_structure(expr):
        itself will be stored as a key in the dict.  For that key, the
        corresponding value is a list of dicts, each of which is the result of a
        recursive call to get_contraction_structure().  The list contains only
-       dicts for the non-trivial deeper contractions, ommitting dicts with None
+       dicts for the non-trivial deeper contractions, omitting dicts with None
        as the one and only key.
 
     .. Note:: The presence of expressions among the dictinary keys indicates

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -24,7 +24,7 @@ from sympy.core.compatibility import range
 class Compound(object):
     """ A little class to represent an interior node in the tree
 
-    This is analagous to SymPy.Basic for non-Atoms
+    This is analogous to SymPy.Basic for non-Atoms
     """
     def __init__(self, op, args):
         self.op = op

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -555,7 +555,7 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
         If True, autowrap will not mute the command line backends. This can be
         helpful for debugging.
     helpers : iterable, optional
-        Used to define auxillary expressions needed for the main expr. If the
+        Used to define auxiliary expressions needed for the main expr. If the
         main expression needs to call a specialized function it should be put
         in the ``helpers`` iterable. Autowrap will then make sure that the
         compiled main expression can link to the helper routine. Items should
@@ -993,7 +993,7 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
         If True, autowrap will not mute the command line backends. This can
         be helpful for debugging.
     helpers : iterable, optional
-        Used to define auxillary expressions needed for the main expr. If
+        Used to define auxiliary expressions needed for the main expr. If
         the main expression needs to call a specialized function it should
         be put in the ``helpers`` iterable. Autowrap will then make sure
         that the compiled main expression can link to the helper routine.

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -1136,7 +1136,7 @@ class FCodeGen(CodeGen):
             elif isinstance(arg, OutputArgument):
                 typeinfo = "%s, intent(out)" % arg.get_datatype('fortran')
             else:
-                raise CodeGenError("Unkown Argument type: %s" % type(arg))
+                raise CodeGenError("Unknown Argument type: %s" % type(arg))
 
             fprint = self._get_symbol
 

--- a/sympy/utilities/enumerative.py
+++ b/sympy/utilities/enumerative.py
@@ -36,7 +36,7 @@ partition A is greater than partition B if A's leftmost/greatest
 part is greater than B's leftmost part.  If the leftmost parts are
 equal, compare the second parts, and so on.
 
-In this ordering, the greatest partion of a given multiset has only
+In this ordering, the greatest partition of a given multiset has only
 one part.  The least partition is the one in which the components
 are spread out, one per part.
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1068,7 +1068,7 @@ def multiset_permutations(m, size=None, g=None):
 
 def _partition(seq, vector, m=None):
     """
-    Return the partion of seq as specified by the partition vector.
+    Return the partition of seq as specified by the partition vector.
 
     Examples
     ========

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1791,7 +1791,7 @@ SymPyDocTestRunner._SymPyDocTestRunner__record_outcome = \
 class SymPyOutputChecker(pdoctest.OutputChecker):
     """
     Compared to the OutputChecker from the stdlib our OutputChecker class
-    supports numerical comparison of floats occuring in the output of the
+    supports numerical comparison of floats occurring in the output of the
     doctest examples
     """
 

--- a/sympy/utilities/tests/test_enumerative.py
+++ b/sympy/utilities/tests/test_enumerative.py
@@ -9,7 +9,7 @@ from sympy.utilities.pytest import slow
 
 # first some functions only useful as test scaffolding - these provide
 # straightforward, but slow reference implementations against which to
-# compare the real versions, and also a comparision to verify that
+# compare the real versions, and also a comparison to verify that
 # different versions are giving identical results.
 
 def part_range_filter(partition_iterator, lb, ub):

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -42,7 +42,7 @@ class CoordSys3D(Basic):
             The name of the new CoordSys3D instance.
 
         transformation : Lambda, Tuple, str
-            Transformation defined by transformation equations or choosen
+            Transformation defined by transformation equations or chosen
             from predefined ones.
 
         location : Vector
@@ -997,7 +997,7 @@ class CoordSys3D(Basic):
             The name of the new CoordSys3D instance.
 
         transformation : Lambda, Tuple, str
-            Transformation defined by transformation equations or choosen
+            Transformation defined by transformation equations or chosen
             from predefined ones.
 
         vector_names, variable_names : iterable(optional)

--- a/sympy/vector/functions.py
+++ b/sympy/vector/functions.py
@@ -208,7 +208,7 @@ def is_conservative(field):
     """
     Checks if a field is conservative.
 
-    Paramaters
+    Parameters
     ==========
 
     field : Vector
@@ -241,7 +241,7 @@ def is_solenoidal(field):
     """
     Checks if a field is solenoidal.
 
-    Paramaters
+    Parameters
     ==========
 
     field : Vector

--- a/tox.ini.sample
+++ b/tox.ini.sample
@@ -34,9 +34,9 @@ basepython=/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7
 commands = python bin/test []
     python bin/doctest []
 
-# Example of testing with a dependancy.
+# Example of testing with a dependency.
 [testenv:py27-gmpy]
-# deps is used to specify the dependancies we need. Tox will
+# deps is used to specify the dependencies we need. Tox will
 # automatically download them from PyPi using easy_install/pip.
 # Note that you have to provide the download link because
 # deps = gmpy will try to install gmpy2.


### PR DESCRIPTION
Typos found via `codespell`. Typos discovered are mainly trivial source comment typos. There is an occasional important typo fix. 