### PR TITLE
Logic: algebraic normal form (Zhegalkin polynomial)

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -2577,14 +2577,16 @@ def anf_coeffs(truthvalues):
 
     Examples
     ========
-    >>> from sympy.logic.boolalg import anf_coeffs, monomial, Xor
+    >>> from sympy.logic.boolalg import anf_coeffs, bool_monomial, Xor
     >>> from sympy.abc import a, b, c
     >>> truthvalues = [0, 1, 1, 0, 0, 1, 0, 1]
     >>> coeffs = anf_coeffs(truthvalues)
     >>> coeffs
     [0, 1, 1, 0, 0, 0, 1, 0]
-    >>> polynomial = Xor(*[monomial(k, [a, b, c])
-    ...         for k, coeff in enumerate(coeffs) if coeff==1])
+    >>> polynomial = Xor(*[
+    ...     bool_monomial(k, [a, b, c])
+    ...     for k, coeff in enumerate(coeffs) if coeff == 1
+    ... ])
     >>> polynomial
     b ^ c ^ (a & b)
 
@@ -2609,7 +2611,7 @@ def anf_coeffs(truthvalues):
     return coeffs[0]
 
 
-def minterm(k, variables):
+def bool_minterm(k, variables):
     """
     Return the k-th minterm.
 
@@ -2625,11 +2627,11 @@ def minterm(k, variables):
 
     Examples
     ========
-    >>> from sympy.logic.boolalg import minterm
+    >>> from sympy.logic.boolalg import bool_minterm
     >>> from sympy.abc import x, y, z
-    >>> minterm([1, 0, 1], [x, y, z])
+    >>> bool_minterm([1, 0, 1], [x, y, z])
     x & z & ~y
-    >>> minterm(6, [x, y, z])
+    >>> bool_minterm(6, [x, y, z])
     x & y & ~z
 
     References
@@ -2644,7 +2646,7 @@ def minterm(k, variables):
     return _convert_to_varsSOP(k, variables)
 
 
-def maxterm(k, variables):
+def bool_maxterm(k, variables):
     """
     Return the k-th maxterm.
 
@@ -2661,11 +2663,11 @@ def maxterm(k, variables):
 
     Examples
     ========
-    >>> from sympy.logic.boolalg import maxterm
+    >>> from sympy.logic.boolalg import bool_maxterm
     >>> from sympy.abc import x, y, z
-    >>> maxterm([1, 0, 1], [x, y, z])
+    >>> bool_maxterm([1, 0, 1], [x, y, z])
     y | ~x | ~z
-    >>> maxterm(6, [x, y, z])
+    >>> bool_maxterm(6, [x, y, z])
     z | ~x | ~y
 
     References
@@ -2680,7 +2682,7 @@ def maxterm(k, variables):
     return _convert_to_varsPOS(k, variables)
 
 
-def monomial(k, variables):
+def bool_monomial(k, variables):
     """
     Return the k-th monomial.
 
@@ -2707,11 +2709,11 @@ def monomial(k, variables):
 
     Examples
     ========
-    >>> from sympy.logic.boolalg import monomial
+    >>> from sympy.logic.boolalg import bool_monomial
     >>> from sympy.abc import x, y, z
-    >>> monomial([1, 0, 1], [x, y, z])
+    >>> bool_monomial([1, 0, 1], [x, y, z])
     x & z
-    >>> monomial(6, [x, y, z])
+    >>> bool_monomial(6, [x, y, z])
     x & y
 
     """

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1592,7 +1592,7 @@ def distribute_xor_over_and(expr):
     >>> from sympy.logic.boolalg import distribute_xor_over_and, And, Xor, Not
     >>> from sympy.abc import A, B, C
     >>> distribute_xor_over_and(And(Xor(Not(A), B), C))
-    Xor(B & C, C & ~A)
+    (B & C) ^ (C & ~A)
     """
     return _distribute((expr, Xor, And))
 
@@ -1648,11 +1648,11 @@ def to_anf(expr, deep=True):
     >>> from sympy.logic.boolalg import to_anf
     >>> from sympy.abc import A, B, C
     >>> to_anf(Not(A))
-    Xor(A, True)
+    A ^ True
     >>> to_anf(And(Or(A, B), Not(C)))
-    Xor(A, B, A & B, A & C, B & C, A & B & C)
+    A ^ B ^ (A & B) ^ (A & C) ^ (B & C) ^ (A & B & C)
     >>> to_anf(Implies(Not(A), Equivalent(B, C)), deep=False)
-    Xor(True, ~A, ~A & (Equivalent(B, C)))
+    True ^ ~A ^ (~A & (Equivalent(B, C)))
 
     """
     expr = sympify(expr)
@@ -2518,9 +2518,9 @@ def ANFform(variables, truthvalues):
     >>> from sympy.logic.boolalg import ANFform
     >>> from sympy.abc import x, y
     >>> ANFform([x], [1, 0])
-    Xor(x, True)
+    x ^ True
     >>> ANFform([x, y], [0, 1, 1, 1])
-    Xor(x, y, x & y)
+    x ^ y ^ (x & y)
 
     References
     ==========
@@ -2578,7 +2578,7 @@ def anf_coeffs(truthvalues):
     >>> polynomial = Xor(*[monomial(k, [a, b, c])
     ...         for k, coeff in enumerate(coeffs) if coeff==1])
     >>> polynomial
-    Xor(b, c, a & b)
+    b ^ c ^ (a & b)
 
     """
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -463,9 +463,14 @@ def test_distribute():
 
 
 def test_to_anf():
-    x, y = symbols('x,y')
+    x, y, z = symbols('x,y,z')
     assert to_anf(And(x, y)) == And(x, y)
     assert to_anf(Or(x, y)) == Xor(x, y, And(x, y))
+    assert to_anf(Or(Implies(x, y), And(x, y), y)) == \
+            Xor(x, True, x & y, remove_true=False)
+    assert to_anf(Or(Nand(x, y), Nor(x, y), Xnor(x, y), Implies(x, y))) == True
+    assert to_anf(Or(x, Not(y), Nor(x,z), And(x, y), Nand(y, z))) == \
+            Xor(True, And(y, z), And(x, y, z), remove_true=False)
     assert to_anf(Xor(x, y)) == Xor(x, y)
     assert to_anf(Not(x)) == Xor(x, True, remove_true=False)
     assert to_anf(Nand(x, y)) == Xor(True, And(x, y), remove_true=False)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -16,7 +16,7 @@ from sympy.logic.boolalg import (
     to_nnf, to_cnf, to_dnf, to_int_repr, bool_map, true, false,
     BooleanAtom, is_literal, term_to_integer, integer_to_term,
     truth_table, as_Boolean, to_anf, is_anf, distribute_xor_over_and,
-    anf_coeffs, ANFform, minterm, maxterm, monomial)
+    anf_coeffs, ANFform, bool_minterm, bool_maxterm, bool_monomial)
 from sympy.assumptions.cnf import CNF
 
 from sympy.testing.pytest import raises, XFAIL, slow
@@ -1143,19 +1143,19 @@ def test_ANFform():
         Xor(True, And(x, y), remove_true=False)
 
 
-def test_minterm():
+def test_bool_minterm():
     x, y = symbols('x,y')
-    assert minterm(3, [x, y]) == And(x, y)
-    assert minterm([1, 0], [x, y]) == And(Not(y), x)
+    assert bool_minterm(3, [x, y]) == And(x, y)
+    assert bool_minterm([1, 0], [x, y]) == And(Not(y), x)
 
 
-def test_maxterm():
+def test_bool_maxterm():
     x, y = symbols('x,y')
-    assert maxterm(2, [x, y]) == Or(Not(x), y)
-    assert maxterm([0, 1], [x, y]) == Or(Not(y), x)
+    assert bool_maxterm(2, [x, y]) == Or(Not(x), y)
+    assert bool_maxterm([0, 1], [x, y]) == Or(Not(y), x)
 
 
-def test_monomial():
+def test_bool_monomial():
     x, y = symbols('x,y')
-    assert monomial(1, [x, y]) == y
-    assert monomial([1, 1], [x, y]) == And(x, y)
+    assert bool_monomial(1, [x, y]) == y
+    assert bool_monomial([1, 1], [x, y]) == And(x, y)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -15,7 +15,8 @@ from sympy.logic.boolalg import (
     eliminate_implications, is_nnf, is_cnf, is_dnf, simplify_logic,
     to_nnf, to_cnf, to_dnf, to_int_repr, bool_map, true, false,
     BooleanAtom, is_literal, term_to_integer, integer_to_term,
-    truth_table, as_Boolean)
+    truth_table, as_Boolean, to_anf, is_anf, distribute_xor_over_and,
+    anf_coeffs, ANFform, minterm, maxterm, monomial)
 from sympy.assumptions.cnf import CNF
 
 from sympy.testing.pytest import raises, XFAIL, slow
@@ -458,6 +459,23 @@ def test_disjuncts():
 def test_distribute():
     assert distribute_and_over_or(Or(And(A, B), C)) == And(Or(A, C), Or(B, C))
     assert distribute_or_over_and(And(A, Or(B, C))) == Or(And(A, B), And(A, C))
+    assert distribute_xor_over_and(And(A, Xor(B, C))) == Xor(And(A, B), And(A, C))
+
+
+def test_to_anf():
+    x, y = symbols('x,y')
+    assert to_anf(And(x, y)) == And(x, y)
+    assert to_anf(Or(x, y)) == Xor(x, y, And(x, y))
+    assert to_anf(Xor(x, y)) == Xor(x, y)
+    assert to_anf(Not(x)) == Xor(x, True, remove_true=False)
+    assert to_anf(Nand(x, y)) == Xor(True, And(x, y), remove_true=False)
+    assert to_anf(Nor(x, y)) == Xor(x, y, True, And(x, y), remove_true=False)
+    assert to_anf(Implies(x, y)) == Xor(x, True, And(x, y), remove_true=False)
+    assert to_anf(Equivalent(x, y)) == Xor(x, y, True, remove_true=False)
+    assert to_anf(Nand(x | y, x >> y), deep=False) == \
+            Xor(True, And(Or(x, y), Implies(x, y)), remove_true=False)
+    assert to_anf(Nor(x ^ y, x & y), deep=False) == \
+            Xor(True, Or(Xor(x, y), And(x, y)), remove_true=False)
 
 
 def test_to_nnf():
@@ -540,6 +558,17 @@ def test_to_int_repr():
         sorted_recursive([[1, 2], [1, 3]])
     assert sorted_recursive(to_int_repr([x | y, z | ~x], [x, y, z])) == \
         sorted_recursive([[1, 2], [3, -1]])
+
+
+def test_is_anf():
+    x, y = symbols('x,y')
+    assert is_anf(true) is True
+    assert is_anf(false) is True
+    assert is_anf(x) is True
+    assert is_anf(And(x, y)) is True
+    assert is_anf(Xor(x, y, And(x, y))) is True
+    assert is_anf(Xor(x, y, Or(x, y))) is False
+    assert is_anf(Xor(Not(x), y)) is False
 
 
 def test_is_nnf():
@@ -1088,3 +1117,40 @@ def test_issue_17530():
     raises(TypeError, lambda: Or(x + y < 0, x - y < 0).subs(r))
     raises(TypeError, lambda: And(x + y > 0, x - y < 0).subs(r))
     raises(TypeError, lambda: And(x + y > 0, x - y < 0).subs(r))
+
+
+def test_anf_coeffs():
+    assert anf_coeffs([1, 0]) == [1, 1]
+    assert anf_coeffs([0, 0, 0, 1]) == [0, 0, 0, 1]
+    assert anf_coeffs([0, 1, 1, 1]) == [0, 1, 1, 1]
+    assert anf_coeffs([1, 1, 1, 0]) == [1, 0, 0, 1]
+    assert anf_coeffs([1, 0, 0, 0]) == [1, 1, 1, 1]
+    assert anf_coeffs([1, 0, 0, 1]) == [1, 1, 1, 0]
+    assert anf_coeffs([1, 1, 0, 1]) == [1, 0, 1, 1]
+
+
+def test_ANFform():
+    x, y = symbols('x,y')
+    assert ANFform([x], [1, 1]) == True
+    assert ANFform([x], [0, 0]) == False
+    assert ANFform([x], [1, 0]) == Xor(x, True, remove_true=False)
+    assert ANFform([x, y], [1, 1, 1, 0]) == \
+        Xor(True, And(x, y), remove_true=False)
+
+
+def test_minterm():
+    x, y = symbols('x,y')
+    assert minterm(3, [x, y]) == And(x, y)
+    assert minterm([1, 0], [x, y]) == And(Not(y), x)
+
+
+def test_maxterm():
+    x, y = symbols('x,y')
+    assert maxterm(2, [x, y]) == Or(Not(x), y)
+    assert maxterm([0, 1], [x, y]) == Or(Not(y), x)
+
+
+def test_monomial():
+    x, y = symbols('x,y')
+    assert monomial(1, [x, y]) == y
+    assert monomial([1, 1], [x, y]) == And(x, y)


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
* logic
  * Added a new normal form - `ANFform`. Function `ANFform` converts a list of truth values to an expression in Algebraic Normal Form (ANF).
  * Added a new method `BooleanFunction.to_anf` that converts an expression to ANF by equivalent transformations.
  * Added a new function `is_anf` that checks if an expression is ANF.
  * Added a new function `to_anf` that converts an expression to ANF if it is not ANF.
  * Added a new function `distribute_xor_over_and`. Given a sentence `s` consisting of conjunction and exclusive disjunctions of literals, it returns an equivalent exclusive disjunction.
  * Added a new function `bool_minterm` that returns the k-th minterm of a fixed ordered set of binary variables.
  * Added a new function `bool_maxterm` that returns the k-th maxterm of a fixed ordered set of binary variables.
  * Added a new function `bool_monomial` that returns the k-th monomial of a fixed ordered set of binary variables.
<!-- END RELEASE NOTES -->