### PR TITLE
Add support for fmod in ccode

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -32,6 +32,17 @@ from sympy.sets.fancysets import Range
 # Used in C89CodePrinter._print_Function(self)
 known_functions_C89 = {
     "Abs": [(lambda x: not x.is_integer, "fabs"), (lambda x: x.is_integer, "abs")],
+    "Mod": [
+        (
+            lambda numer, denom: numer.is_integer and denom.is_integer,
+            lambda printer, numer, denom, *args, **kwargs: "((%s) %% (%s))" % (
+                printer._print(numer, *args, **kwargs), printer._print(denom, *args, **kwargs))
+        ),
+        (
+            lambda numer, denom: not numer.is_integer or not denom.is_integer,
+            "fmod"
+        )
+    ],
     "sin": "sin",
     "cos": "cos",
     "tan": "tan",
@@ -577,7 +588,11 @@ class C99CodePrinter(_C9XCodePrinter, C89CodePrinter):
                     break
             else:
                 raise ValueError("No matching printer")
-        suffix = self._get_func_suffix(real) if self._ns + known in self._prec_funcs else ''
+        try:
+            return known(self, *expr.args)
+        except TypeError:
+            suffix = self._get_func_suffix(real) if self._ns + known in self._prec_funcs else ''
+
         if nest:
             args = self._print(expr.args[0])
             if len(expr.args) > 1:
@@ -598,7 +613,7 @@ class C99CodePrinter(_C9XCodePrinter, C89CodePrinter):
         return self._print_math_func(expr, nest=True)
 
 
-for k in ('Abs Sqrt exp exp2 expm1 log log10 log2 log1p Cbrt hypot fma '
+for k in ('Abs Sqrt exp exp2 expm1 log log10 log2 log1p Cbrt hypot fma Mod'
           ' loggamma sin cos tan asin acos atan atan2 sinh cosh tanh asinh acosh '
           'atanh erf erfc loggamma gamma ceiling floor').split():
     setattr(C99CodePrinter, '_print_%s' % k, C99CodePrinter._print_math_func)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -331,7 +331,7 @@ class CodePrinter(StrPrinter):
         else:
             return name
 
-    def _print_Function(self, expr):
+    def _print_Function(self, expr, **kwargs):
         if expr.func.__name__ in self.known_functions:
             cond_func = self.known_functions[expr.func.__name__]
             func = None
@@ -343,9 +343,12 @@ class CodePrinter(StrPrinter):
                         break
             if func is not None:
                 try:
-                    return func(*[self.parenthesize(item, 0) for item in expr.args])
+                    return func(self, *[self.parenthesize(item, 0) for item in expr.args], **kwargs)
                 except TypeError:
-                    return "%s(%s)" % (func, self.stringify(expr.args, ", "))
+                    try:
+                        return func(*[self.parenthesize(item, 0) for item in expr.args])
+                    except TypeError:
+                        return "%s(%s)" % (func, self.stringify(expr.args, ", "))
         elif hasattr(expr, '_imp_') and isinstance(expr._imp_, Lambda):
             # inlined function
             return self._print(expr._imp_(*expr.args))

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -1,5 +1,5 @@
 import warnings
-from sympy.core import (S, pi, oo, symbols, Rational, Integer, Float,
+from sympy.core import (S, pi, oo, symbols, Rational, Integer, Float, Mod,
                         GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq, nan)
 from sympy.functions import (Abs, acos, acosh, asin, asinh, atan, atanh, atan2,
                              ceiling, cos, cosh, erf, erfc, exp, floor, gamma, log,
@@ -129,6 +129,9 @@ def test_ccode_exceptions():
     assert ccode(ceiling(x)) == "ceil(x)"
     assert ccode(Abs(x)) == "fabs(x)"
     assert ccode(gamma(x)) == "tgamma(x)"
+    r, s = symbols('r,s', real=True)
+    assert ccode(Mod(ceiling(r), ceiling(s))) == "((ceil(r)) % (ceil(s)))"
+    assert ccode(Mod(r, s)) == "fmod(r, s)"
 
 
 def test_ccode_user_functions():
@@ -626,6 +629,10 @@ def test_C99CodePrinter__precision():
         check(exp(x*8.0), 'exp{s}(8.0{S}*x)')
         check(exp2(x), 'exp2{s}(x)')
         check(expm1(x*4.0), 'expm1{s}(4.0{S}*x)')
+        check(Mod(n, 2), '((n) % (2))')
+        check(Mod(2*n + 3, 3*n + 5), '((2*n + 3) % (3*n + 5))')
+        check(Mod(x + 2.0, 3.0), 'fmod{s}(1.0{S}*x + 2.0{S}, 3.0{S})')
+        check(Mod(x, 2.0*x + 3.0), 'fmod{s}(1.0{S}*x, 2.0{S}*x + 3.0{S})')
         check(log(x/2), 'log{s}((1.0{S}/2.0{S})*x)')
         check(log10(3*x/2), 'log10{s}((3.0{S}/2.0{S})*x)')
         check(log2(x*8.0), 'log2{s}(8.0{S}*x)')


### PR DESCRIPTION
This should enable the C code printer to print instances of SymPy's `Mod`, integer modulo operator (`%`) is used when both arguments are known to be integers, `fmod` is used otherwise.

I needed to adjust `_print_Function` in `codeprinter.py` to pass the printer instance so that arguments are formated correctly (e.g. `ceiling` -> `ceil`).