### PR TITLE
Inverse of zero and infinite quaternion

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -13,7 +13,6 @@ from sympy import Matrix, Add, Mul
 from sympy import symbols, sympify
 from sympy.printing.latex import latex
 from sympy.printing import StrPrinter
-from sympy import oo
 
 
 class Quaternion(Expr):
@@ -305,10 +304,6 @@ class Quaternion(Expr):
         """Returns the inverse of the quaternion."""
         q = self
         return conjugate(q) * (1/q.norm()**2)
-        if not q.norm() :
-            raise ValueError("Cannot compute inverse of a quaternion with zero norm")
-        if q.norm() == oo :
-            raise ValueError("Cannot compute inverse of a quaternion with infinite norm")
 
     def pow(self, p):
         """Finds the pth power of the quaternion.

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -13,6 +13,7 @@ from sympy import Matrix, Add, Mul
 from sympy import symbols, sympify
 from sympy.printing.latex import latex
 from sympy.printing import StrPrinter
+from sympy import oo
 
 
 class Quaternion(Expr):
@@ -304,6 +305,10 @@ class Quaternion(Expr):
         """Returns the inverse of the quaternion."""
         q = self
         return conjugate(q) * (1/q.norm()**2)
+        if not q.norm() :
+            raise ValueError("Cannot compute inverse of a quaternion with zero norm")
+        if q.norm() == oo :
+            raise ValueError("Cannot compute inverse of a quaternion with infinite norm")
 
     def pow(self, p):
         """Finds the pth power of the quaternion.

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -51,17 +51,12 @@ def test_quaternion_complex_real_addition():
 def test_quaternion_functions():
     q = Quaternion(x, y, z, w)
     q1 = Quaternion(1, 2, 3, 4)
-    q2 = Quaternion(0,0,0,0)
 
     assert conjugate(q) == Quaternion(x, -y, -z, -w)
     assert q.norm() == sqrt(w**2 + x**2 + y**2 + z**2)
     assert q.normalize() == Quaternion(x, y, z, w) / sqrt(w**2 + x**2 + y**2 + z**2)
     assert q.inverse() == Quaternion(x, -y, -z, -w) / (w**2 + x**2 + y**2 + z**2)
     assert q.pow(2) == Quaternion(-w**2 + x**2 - y**2 - z**2, 2*x*y, 2*x*z, 2*w*x)
-
-    def test1(p):
-+        p1 = p.inverse()
-+   raises(ValueError, lambda: test1(q0))
 
     assert q1.exp() == \
     Quaternion(E * cos(sqrt(29)),

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -1,4 +1,5 @@
 from sympy.algebras.quaternion import Quaternion
+from sympy.utilities.pytest import raises
 from sympy import symbols, re, im, Add, Mul, I, Abs
 from sympy import cos, sin, sqrt, conjugate, exp, log, acos, E, pi
 from sympy import Matrix
@@ -13,7 +14,7 @@ def test_quaternion_construction():
 
     q2 = Quaternion.from_axis_angle((sqrt(3)/3, sqrt(3)/3, sqrt(3)/3), 2*pi/3)
     assert q2 == Quaternion(Rational(1/2), Rational(1/2),
-                            Rational(1/2), Rational(1,2))
+                            Rational(1/2), Rational(1/2))
 
     M = Matrix([[cos(x), -sin(x), 0], [sin(x), cos(x), 0], [0, 0, 1]])
     q3 = trigsimp(Quaternion.from_rotation_matrix(M))
@@ -50,12 +51,17 @@ def test_quaternion_complex_real_addition():
 def test_quaternion_functions():
     q = Quaternion(x, y, z, w)
     q1 = Quaternion(1, 2, 3, 4)
+    q2 = Quaternion(0,0,0,0)
 
     assert conjugate(q) == Quaternion(x, -y, -z, -w)
     assert q.norm() == sqrt(w**2 + x**2 + y**2 + z**2)
     assert q.normalize() == Quaternion(x, y, z, w) / sqrt(w**2 + x**2 + y**2 + z**2)
     assert q.inverse() == Quaternion(x, -y, -z, -w) / (w**2 + x**2 + y**2 + z**2)
     assert q.pow(2) == Quaternion(-w**2 + x**2 - y**2 - z**2, 2*x*y, 2*x*z, 2*w*x)
+
+    def test1(p):
++        p1 = p.inverse()
++   raises(ValueError, lambda: test1(q0))
 
     assert q1.exp() == \
     Quaternion(E * cos(sqrt(29)),

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -555,6 +555,27 @@ def collect_const(expr, *vars, **kwargs):
     >>> collect_const(2*x - 2*y - 2*z, -2)
     2*x - 2*(y + z)
 
+    ---->> According to documentation, we have the second argument as *vars.
+          *vars - implies that you can pass on as many arguments as possible.
+
+    Examples -- 
+
+    >>> collect_const(3*x-3*y+2*z+2*s,3, 2)
+    2*(s + z) + 3*(x - y)
+    >>> collect_const(x-y+2*z+2*s, 1, 2)
+    x - y + 2*(s + z)
+
+    ---->> According to documentation, we have the third argument as **kwargs.
+           **kwargs - implies that you can pass keyworded variable length of arguments to a function.
+
+    Examples --
+
+    >>> kwargs = {"arg1":3, "arg2":2}
+    >>> collect_const(3*x-3*y+2*z+2*s ,**kwargs)
+    2*(s + z) + 3*(x - y)
+
+    Both can be used together also as specified in the function definition.
+
     See Also
     ========
     collect, collect_sqrt, rcollect

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -521,11 +521,33 @@ def collect_sqrt(expr, evaluate=None):
     return coeff*d
 
 
-def collect_const(expr, *vars, **kwargs):
+def collect_const(expr, *vars, Numbers=True):
     """A non-greedy collection of terms with similar number coefficients in
     an Add expr. If ``vars`` is given then only those constants will be
     targeted. Although any Number can also be targeted, if this is not
     desired set ``Numbers=False`` and no Float or Rational will be collected.
+
+    Parameters
+    ==========
+
+    expr : Numbers,Symbols
+           This parameter defines the expression to be worked upon by the function.
+
+    *vars : Numbers,Symbols
+            Used to specify the different number coefficients explicitly, for grouping of terms.
+            Can be multiple in number.
+
+    **kwargs : Optional(Numbers=True)
+               Default is targeting the Numbers set. If this is not the desrired set, 
+               ''Numbers=False'' can be the arg value.
+
+
+    Returns
+    =======
+
+    expr : Numbers,Symbols
+           Returns a collection of terms with similar number coefficients,
+           which may be Numbers or Symbols.
 
     Examples
     ========
@@ -555,26 +577,7 @@ def collect_const(expr, *vars, **kwargs):
     >>> collect_const(2*x - 2*y - 2*z, -2)
     2*x - 2*(y + z)
 
-    ---->> According to documentation, we have the second argument as *vars.
-          *vars - implies that you can pass on as many arguments as possible.
-
-    Examples -- 
-
-    >>> collect_const(3*x-3*y+2*z+2*s,3, 2)
-    2*(s + z) + 3*(x - y)
-    >>> collect_const(x-y+2*z+2*s, 1, 2)
-    x - y + 2*(s + z)
-
-    ---->> According to documentation, we have the third argument as **kwargs.
-           **kwargs - implies that you can pass keyworded variable length of arguments to a function.
-
-    Examples --
-
-    >>> kwargs = {"arg1":3, "arg2":2}
-    >>> collect_const(3*x-3*y+2*z+2*s ,**kwargs)
-    2*(s + z) + 3*(x - y)
-
-    Both can be used together also as specified in the function definition.
+    
 
     See Also
     ========
@@ -584,7 +587,6 @@ def collect_const(expr, *vars, **kwargs):
         return expr
 
     recurse = False
-    Numbers = kwargs.get('Numbers', True)
 
     if not vars:
         recurse = True


### PR DESCRIPTION
In lieu of issue #13690 and PR #13693  , this modified code throws a Value Error whenever we try to find out the inverse of zero and infinite quaternion.

The tests for zero quaternion have been added.

Fixes the unsolved issue of PR #13693 
