### PR TITLE
use headings for separate section of PR number and explanation

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,13 @@
-<!-- Do not include the issue number in the title. Give a brief
-description of what was changed; someone interested in that
-area of SymPy is more likely to review your work. -->
-
+<!-- Your title above should be a short description of what
+was changed. Do not include the issue number in the title. -->
 
 #### References to other Issues or PRs
-<!-- Include references to related issues or PRs here.
-Refer to issues or PRs in your discussion by typing '#' before
-the number of the issue/PR, e.g. "...this is related to issue #12345".
-Use the words like "fix", "close" or "resolve" before the issue number only
-if the issue should be closed if this PR is merged. For example, issues
-3, 12 and 42 would be closed if this opening paragraph said,
-"This PR will fix #3. It resolves #12. It closed #42." -->
+<!-- Refer to related issues by number putting '#' before the number;
+write "fix" before each issue that is closed by this PR.
+Example: This PR will fix #3 and fix #42. Issue #99 is not fixed." -->
 
 
-#### What does this implement/fix? Explain your changes.
+#### Brief description of what is fixed or changed
 
 
-#### Any other comments?
+#### Other comments

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,12 +4,19 @@ descriptive titles are more likely to receive reviews. Describe what you
 changed! A title that only references an issue number is not descriptive.
 -->
 
-### Reference Issues/PRs
-
+#### References to other Issues or PRs
 <!--
-If this pull request fixes an issue please indicate which issue by typing
-"Fixes #NNNN" below.
--->
+Include references to related issues or PRs here.
+You can refer to issues or PRs in your discussion by typing '#' before
+the number of the issue/PR, e.g. #12345.
+
+If this pull request completely fixes an issue please include
+-- on its own line -- the text which will automatically close
+the issue if this PR is merged, .e.g.
+
+fixes #12345
++-->
+
 
 #### What does this implement/fix? Explain your changes.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,17 @@
-<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
+<!--
+Please give this pull request a descriptive title. Pull requests with
+descriptive titles are more likely to receive reviews. Describe what you
+changed! A title that only references an issue number is not descriptive.
+-->
 
-<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
+### Reference Issues/PRs
+
+<!--
+If this pull request fixes an issue please indicate which issue by typing
+"Fixes #NNNN" below.
+-->
+
+#### What does this implement/fix? Explain your changes.
+
+
+#### Any other comments?

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,16 @@
-<!--
-Please give this pull request a descriptive title. Pull requests with
-descriptive titles are more likely to receive reviews. Describe what you
-changed! A title that only references an issue number is not descriptive.
--->
+<!-- Do not include the issue number in the title. Give a brief
+description of what was changed; someone interested in that
+area of SymPy is more likely to review your work. -->
+
 
 #### References to other Issues or PRs
-<!--
-Include references to related issues or PRs here.
-You can refer to issues or PRs in your discussion by typing '#' before
-the number of the issue/PR, e.g. #12345.
-
-If this pull request completely fixes an issue please include
--- on its own line -- the text which will automatically close
-the issue if this PR is merged, .e.g.
-
-fixes #12345
-+-->
+<!-- Include references to related issues or PRs here.
+Refer to issues or PRs in your discussion by typing '#' before
+the number of the issue/PR, e.g. "...this is related to issue #12345".
+Use the words like "fix", "close" or "resolve" before the issue number only
+if the issue should be closed if this PR is merged. For example, issues
+3, 12 and 42 would be closed if this opening paragraph said,
+"This PR will fix #3. It resolves #12. It closed #42." -->
 
 
 #### What does this implement/fix? Explain your changes.


### PR DESCRIPTION
using heading easily separates the issue number, the pull request
fixes from the rest of explanation.

Idea taken from
https://github.com/scikit-learn/scikit-learn/blame/master/PULL_REQUEST_TEMPLATE.md

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
