### PR TITLE
llvmjit: Replace deprecated get_pointer_to_function

### DIFF
--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -281,8 +281,7 @@ class LLVMJitCode(object):
             print("Assembly")
             print(target_machine.emit_assembly(llmod))
 
-        fptr = exe_eng.get_pointer_to_function(
-            llmod.get_function(self.link_name))
+        fptr = exe_eng.get_function_address(self.link_name)
 
         return fptr
 


### PR DESCRIPTION
... with get_function_address

`get_pointer_to_function` was deprecated(https://github.com/numba/llvmlite/pull/83) and removed in https://github.com/numba/llvmlite/pull/307.

Fixes #13711 

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->

<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
