### PR TITLE
Fix for issue #12773 rust printer running wrong method

### DIFF
--- a/sympy/printing/rust.py
+++ b/sympy/printing/rust.py
@@ -449,7 +449,6 @@ class RustCodePrinter(CodePrinter):
     # method from higher up the class hierarchy (see _print_NumberSymbol).
     # Then subclasses like us would not need to repeat all this.
     _print_Matrix = \
-        _print_MatrixElement = \
         _print_DenseMatrix = \
         _print_MutableDenseMatrix = \
         _print_ImmutableMatrix = \

--- a/sympy/printing/tests/test_rust.py
+++ b/sympy/printing/tests/test_rust.py
@@ -41,6 +41,8 @@ def test_printmethod():
         def _rust_code(self, printer):
             return "%s.fabs()" % printer._print(self.args[0])
     assert rust_code(fabs(x)) == "x.fabs()"
+    a = MatrixSymbol("a", 1 ,3)
+    assert rust_code(a[0,0]) == 'a[0]'
 
 
 def test_Functions():


### PR DESCRIPTION
Function overiding print function removed in rust.py
Test added in test_rust.py