### PR TITLE
Fix import filldedent in line.py

### DIFF
--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -32,7 +32,7 @@ from sympy.matrices import Matrix
 
 from .entity import GeometryEntity, GeometrySet
 from .point import Point, Point3D
-from sympy.utilities.misc import Undecidable
+from sympy.utilities.misc import Undecidable, filldedent
 
 
 class LinearEntity(GeometrySet):

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -76,6 +76,12 @@ def test_arbitrary_point():
     assert Segment3D(Point3D(x1, x1, x1), Point3D(y1, y1, y1)).length == sqrt(3) * sqrt((x1 - y1) ** 2)
     assert Segment3D((1, 1, 1), (2, 3, 4)).arbitrary_point() == \
            Point3D(t + 1, 2 * t + 1, 3 * t + 1)
+    try:
+        Line((x,1),(2,3)).arbitrary_point(x)
+    except ValueError:
+        assert True
+    except BaseException:
+        assert False
 
 
 def test_are_concurrent_2d():


### PR DESCRIPTION
<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
Made changes to line.py according to the original posting of issue #13705 . We wrote a test in test_line.py that verifies incorrect input to the arbitrary_point() function throws the correct error (ValueError).

Output before:
```
>>> Line((x,1),(2,3)).arbitrary_point(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\geometry\line.py", line 236, in arbitrary_point
    raise ValueError(filldedent('''
NameError: global name 'filldedent' is not defined
```
Output after:
```
>>> Line((x,1),(2,3)).arbitrary_point(x)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/sympy-1.1.2.dev0-py3.6.egg/sympy/geometry/line.py", line 235, in arbitrary_point
    ''' % t.name))
ValueError: 
Symbol x already appears in object and cannot be used as a parameter.
```
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
Fixes #13705 