### PR TITLE
use of fuzzy_bool instead of ternary_sort

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -218,12 +218,8 @@ class Set(Basic):
 
         elif isinstance(other, FiniteSet):
             from sympy.utilities.iterables import sift
-
-            def ternary_sift(el):
-                contains = self.contains(el)
-                return contains if contains in [True, False] else None
-
-            sifted = sift(other, ternary_sift)
+            from sympy.core.logic import fuzzy_bool
+            sifted = sift(other, lambda x: fuzzy_bool(x))
             # ignore those that are contained in self
             return Union(FiniteSet(*(sifted[False])),
                 Complement(FiniteSet(*(sifted[None])), self, evaluate=False)


### PR DESCRIPTION
changed ternary_sort to predefined fuzzy_bool

<!-- Please give this pull request a descriptive title. Pull requests with descriptive titles are more likely to receive reviews. Describe what you changed! A title that only references an issue number is not descriptive. -->
Fixes #13720 #13699 
<!-- If this pull request fixes an issue please indicate which issue by typing "Fixes #NNNN" below. -->
