### PR TITLE
test_plot: Ignore errors while cleaning up temp plot files

### DIFF
--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -29,7 +29,13 @@ class TmpFileManager:
 
     @classmethod
     def cleanup(cls):
-        map(os.remove, cls.tmp_files)
+        def removeSilently(file):
+            try:
+                os.remove(file)
+            except OSError:
+                pass
+
+        map(removeSilently, cls.tmp_files)
 
 def plot_and_save(name):
     tmp_file = TmpFileManager.tmp_file


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #13730

#### Brief description of what is fixed or changed
Ignore OSError while cleaning up temp plot files

#### Other comments
I'm not sure what change in matplotlib v2.1.0...v2.1.1 has caused it.
