### PR TITLE
Added an isinstance check to fix limits not working with symbols which have zero = True

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -11,6 +11,7 @@ from .operations import AssocOp
 from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr
+from .numbers import Zero
 
 # Key for sorting commutative args in canonical order
 _args_sortkey = cmp_to_key(Basic.compare)
@@ -781,7 +782,7 @@ class Add(Expr, AssocOp):
         seq = [(f, Order(f, *zip(symbols, point))) for f in self.args]
         for ef, of in seq:
             for e, o in lst:
-                if(isinstance(o, Order)):
+                if not isinstance(o, Zero):
                     if o.contains(of) and o != of:
                         of = None
                         break

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -782,7 +782,7 @@ class Add(Expr, AssocOp):
         seq = [(f, Order(f, *zip(symbols, point))) for f in self.args]
         for ef, of in seq:
             for e, o in lst:
-                if not isinstance(o, Zero):
+                if not o.is_zero:
                     if o.contains(of) and o != of:
                         of = None
                         break

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -11,7 +11,6 @@ from .operations import AssocOp
 from .cache import cacheit
 from .numbers import ilcm, igcd
 from .expr import Expr
-from .numbers import Zero
 
 # Key for sorting commutative args in canonical order
 _args_sortkey = cmp_to_key(Basic.compare)

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -776,7 +776,6 @@ class Add(Expr, AssocOp):
         from sympy import Order
         lst = []
         symbols = list(symbols if is_sequence(symbols) else [symbols])
-
         if not point:
             point = [0]*len(symbols)
         seq = [(f, Order(f, *zip(symbols, point))) for f in self.args]

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -776,14 +776,16 @@ class Add(Expr, AssocOp):
         from sympy import Order
         lst = []
         symbols = list(symbols if is_sequence(symbols) else [symbols])
+
         if not point:
             point = [0]*len(symbols)
         seq = [(f, Order(f, *zip(symbols, point))) for f in self.args]
         for ef, of in seq:
             for e, o in lst:
-                if o.contains(of) and o != of:
-                    of = None
-                    break
+                if(isinstance(o, Order)):
+                    if o.contains(of) and o != of:
+                        of = None
+                        break
             if of is None:
                 continue
             new_lst = [(ef, of)]

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -112,7 +112,7 @@ def test_issue_10382():
 
 def test_issue_13715():
     p = symbols('p', zero=True)
-    assert limit(x + p, x, 2) == p + 2
+    assert limit(x + p, x, 2) == 2
 
 
 def test_Limit():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -93,7 +93,8 @@ def test_basic4():
     assert limit(2*x**8 + y*x**(-3), x, -2) == 512 - y/8
     assert limit(sqrt(x + 1) - sqrt(x), x, oo) == 0
     assert integrate(1/(x**3 + 1), (x, 0, oo)) == 2*pi*sqrt(3)/9
-
+    p = symbols('p', zero = True)
+    assert limit(x + p, x, 2) == 2 
 
 def test_basic5():
     class my(Function):

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -93,8 +93,6 @@ def test_basic4():
     assert limit(2*x**8 + y*x**(-3), x, -2) == 512 - y/8
     assert limit(sqrt(x + 1) - sqrt(x), x, oo) == 0
     assert integrate(1/(x**3 + 1), (x, 0, oo)) == 2*pi*sqrt(3)/9
-    p = symbols('p', zero = True)
-    assert limit(x + p, x, 2) == 2 
 
 def test_basic5():
     class my(Function):
@@ -111,6 +109,10 @@ def test_issue_3885():
 def test_issue_10382():
     n = Symbol('n', integer=True)
     assert limit(fibonacci(n+1)/fibonacci(n), n, oo) == S.GoldenRatio
+
+def test_issue_13715():
+    p = symbols('p', zero=True)
+    assert limit(x + p, x, 2) == 2
 
 
 def test_Limit():

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -112,7 +112,7 @@ def test_issue_10382():
 
 def test_issue_13715():
     p = symbols('p', zero=True)
-    assert limit(x + p, x, 2) == 2
+    assert limit(x + p, x, 2) == p + 2
 
 
 def test_Limit():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- Refer to related issues by number putting '#' before the number;
write "fix" before each issue that is closed by this PR.
Example: This PR will fix #3 and fix #42. Issue #99 is not fixed." -->
This PR Fixes #13715.


#### Brief description of what is fixed or changed
Added an isinstance check to fix limits not working with symbols which have zero = True. It seems a Zero object is being passed instead of an Order object in that case.

#### Other comments

<!-- BEGIN RELEASE NOTES -->
* core
  * Limits are now working with symbols which have `zero = True`.
<!-- END RELEASE NOTES -->