### PR TITLE
Get the vector from one point to another expressible in a single reference frame

### DIFF
--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -275,7 +275,7 @@ class Point(object):
                     # dcm-connected (Direction Cosine Matrix).
                     # This means that rotation matrices are defined that allow
                     # all contituent vectors to be expressed in a single frame.
-                    outvec.check_expressable()
+                    outvec.check_expressible()
             except ValueError as e:
                 last_error = e
                 continue

--- a/sympy/physics/vector/tests/test_point.py
+++ b/sympy/physics/vector/tests/test_point.py
@@ -112,6 +112,19 @@ def test_point_pos():
     assert Q.pos_from(O) == 10 * N.x + 10 * N.y + 5 * B.x + 5 * B.y
     assert O.pos_from(Q) == -10 * N.x - 10 * N.y - 5 * B.x - 5 * B.y
 
+    q = dynamicsymbols('q')
+    N = ReferenceFrame('N')
+    B = ReferenceFrame('B')
+    C = ReferenceFrame('C')
+    O = Point('O')
+    P = O.locatenew('P', 10 * N.x + 5 * B.x)
+    raises(ValueError, lambda: P.pos_from(O, dcm_connected=True))
+    B.orient(N, 'Axis', [q, N.z])
+    assert P.pos_from(O, dcm_connected=True) == 10 * N.x + 5 * B.x
+    assert P.pos_from(O, frame=N) == 10 * N.x + 5 * B.x
+    assert P.pos_from(O, frame=B) == 10 * N.x + 5 * B.x
+    raises(ValueError, lambda: P.pos_from(O, frame=C))
+
 def test_point_partial_velocity():
 
     N = ReferenceFrame('N')

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -557,7 +557,7 @@ class Vector(object):
 
     def check_expressible(self, otherframe=None):
         """
-        Returns if this vector is expressable in the given frame, otherwise, raises an exception. 
+        Returns if this vector is expressable in the given frame, otherwise, raises an exception.
 
         Parameters
         ==========

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -555,6 +555,31 @@ class Vector(object):
 
         return Vector(inlist)
 
+    def check_expressable(self, otherframe=None):
+        """
+        Returns if this vector is expressable in the given frame, otherwise, raises an exception. 
+
+        Parameters
+        ==========
+
+        otherframe : ReferenceFrame
+            The frame for this Vector to be described in.
+            If None, checks if this vector can be expressed in *any* single frame.
+        """
+        if len(self.args) == 0:
+            return
+
+        if otherframe is None:
+            otherframe = self.args[0][1]  # The frame of the first constituent part
+
+        # If we can get a dcm for each contituent of this vector
+        # then it is expressable in otherframe
+        for v in self.args:
+            if v[1] != otherframe:
+                v[1].dcm(otherframe)  # raises ValueError
+
+        return
+
     def express(self, otherframe, variables=False):
         """
         Returns a Vector equivalent to this one, expressed in otherframe.

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -555,7 +555,7 @@ class Vector(object):
 
         return Vector(inlist)
 
-    def check_expressable(self, otherframe=None):
+    def check_expressible(self, otherframe=None):
         """
         Returns if this vector is expressable in the given frame, otherwise, raises an exception. 
 


### PR DESCRIPTION
Added the ability to get the vector from one point to another that is expressed, or expressible, in a single reference frame.

#### References to other Issues or PRs


#### Brief description of what is fixed or changed
Added options to the `pos_from` method of the `Point` class in order to specify that the resultant vector should be expressible in the given reference frame, or any reference frame at all.

This is needed because the pos_from method was previously creating a vector along the shortest number of connected points, even if there was no orientation specified between the reference frames through which those relative point locations were defined.  The new options will allow the selection of the smallest chain of connected points whose resultant vector is expressible in a single frame.


#### Other comments
A new method was added to the `Vector` class called `check_expressible` in order avoid having to go through the entire dcm transformation of the vector just to find out if the connection exists.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* physics.vector
  * `Point.pos_from` method is now able to return the resultant vector in a specified reference frame, if provided.

<!-- END RELEASE NOTES -->
