### PR TITLE
Blacklist sympy.this from the doctester

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -670,6 +670,7 @@ def _doctest(*paths, **kwargs):
         "doc/src/modules/plotting.rst",  # generates live plots
         "sympy/physics/gaussopt.py", # raises deprecation warning
         "sympy/galgebra.py", # raises ImportError
+        "sympy/this.py", # Prints text to the terminal
         "sympy/matrices/densearith.py", # raises deprecation warning
         "sympy/matrices/densesolve.py", # raises deprecation warning
         "sympy/matrices/densetools.py", # raises deprecation warning


### PR DESCRIPTION
Otherwise it prints it during ./bin/doctest when the doctester tries to import
it.