### PR TITLE
group theory: correct FreeGroupElement multiplication

### DIFF
--- a/sympy/combinatorics/free_groups.py
+++ b/sympy/combinatorics/free_groups.py
@@ -1348,7 +1348,7 @@ def letter_form_to_array_form(array_form, group):
 
 def zero_mul_simp(l, index):
     """Used to combine two reduced words."""
-    while index >=0 and index < len(l) - 1 and l[index][0] is l[index + 1][0]:
+    while index >=0 and index < len(l) - 1 and l[index][0] == l[index + 1][0]:
         exp = l[index][1] + l[index + 1][1]
         base = l[index][0]
         l[index] = (base, exp)

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -113,7 +113,6 @@ class RewritingSystem(object):
             s1 = s1.subword(0, len(s1)-1)
             s2 = s2*g**-1
             if len(s1) - len(s2) < 0:
-                #print("this", len(s1)-len(s2))
                 if s2 not in self.rules:
                     if not check:
                         self._add_rule(s2, s1)

--- a/sympy/combinatorics/tests/test_free_groups.py
+++ b/sympy/combinatorics/tests/test_free_groups.py
@@ -131,6 +131,9 @@ def test_FreeGroupElm_ext_rep():
 
 
 def test_FreeGroupElm__mul__pow__():
+    x1 = x.group.dtype(((Symbol('x'), 1),))
+    assert x**2 == x1*x
+
     assert (x**2*y*x**-2)**4 == x**2*y**4*x**-2
     assert (x**2)**2 == x**4
     assert (x**-1)**-1 == x


### PR DESCRIPTION
At the moment, multiplication of `FreeGroupElement`s treats two elements as non-equal unless the symbols representing them are the same object. But it is sufficient for the symbols to be equal via `==`, and the current behaviour causes problems. For example, the added test fails in master.

Fixes #13737.