### PR TITLE
Computation of negative powers of a quaternion

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -320,6 +320,7 @@ class Quaternion(Expr):
         q = self
         if p == -1:
             return q.inverse()
+        res = 1
 
         while p > 0:
             if p & 1:
@@ -334,7 +335,7 @@ class Quaternion(Expr):
 
             while r > 0:
                 if r & 1:
-                    res = q_inv() * res
+                    res = q_inv * res
 
                 r = r >> 1
                 q_inv = q_inv * q_inv

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -325,6 +325,9 @@ class Quaternion(Expr):
         if p < 0:
             q, p = q.inverse(), -p
 
+        if (type(p) != int):
+            return NotImplemented
+
         while p > 0:
             if p & 1:
                 res = q * res

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -13,6 +13,8 @@ from sympy import Matrix, Add, Mul
 from sympy import symbols, sympify
 from sympy.printing.latex import latex
 from sympy.printing import StrPrinter
+from sympy.core.numbers import Integer
+from sympy.core.compatibility import SYMPY_INTS
 
 
 class Quaternion(Expr):
@@ -325,7 +327,7 @@ class Quaternion(Expr):
         if p < 0:
             q, p = q.inverse(), -p
 
-        if (type(p) != int):
+        if not (isinstance(p, (int, Integer, SYMPY_INTS))):
             return NotImplemented
 
         while p > 0:

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -327,7 +327,7 @@ class Quaternion(Expr):
         if p < 0:
             q, p = q.inverse(), -p
 
-        if not (isinstance(p, (int, Integer, SYMPY_INTS))):
+        if not (isinstance(p, (Integer, SYMPY_INTS))):
             return NotImplemented
 
         while p > 0:

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -320,13 +320,24 @@ class Quaternion(Expr):
         q = self
         if p == -1:
             return q.inverse()
-        res = 1
+
         while p > 0:
             if p & 1:
                 res = q * res
 
             p = p >> 1
             q = q * q
+
+        if p < -1:
+            r = abs(p)
+            q_inv = q.inverse()
+
+            while r > 0:
+                if r & 1:
+                    res = q_inv() * res
+
+                r = r >> 1
+                q_inv = q_inv * q_inv
 
         return res
 

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -322,23 +322,15 @@ class Quaternion(Expr):
             return q.inverse()
         res = 1
 
+        if p < 0:
+            q, p = q.inverse(), -p
+
         while p > 0:
             if p & 1:
                 res = q * res
 
             p = p >> 1
             q = q * q
-
-        if p < -1:
-            r = abs(p)
-            q_inv = q.inverse()
-
-            while r > 0:
-                if r & 1:
-                    res = q_inv * res
-
-                r = r >> 1
-                q_inv = q_inv * q_inv
 
         return res
 

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -56,6 +56,7 @@ def test_quaternion_functions():
     assert q.normalize() == Quaternion(x, y, z, w) / sqrt(w**2 + x**2 + y**2 + z**2)
     assert q.inverse() == Quaternion(x, -y, -z, -w) / (w**2 + x**2 + y**2 + z**2)
     assert q.pow(2) == Quaternion(-w**2 + x**2 - y**2 - z**2, 2*x*y, 2*x*z, 2*w*x)
+    assert q1.pow(2) == Quaternion(-(7/225), -(1/225), -(1/150), -(2/225))
 
     assert q1.exp() == \
     Quaternion(E * cos(sqrt(29)),

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -56,7 +56,7 @@ def test_quaternion_functions():
     assert q.normalize() == Quaternion(x, y, z, w) / sqrt(w**2 + x**2 + y**2 + z**2)
     assert q.inverse() == Quaternion(x, -y, -z, -w) / (w**2 + x**2 + y**2 + z**2)
     assert q.pow(2) == Quaternion(-w**2 + x**2 - y**2 - z**2, 2*x*y, 2*x*z, 2*w*x)
-    assert q1.pow(-2) == Quaternion(-(7/225), -(1/225), -(1/150), -(2/225))
+    assert q1.pow(-2) == Quaternion(-S(7)/225, -S(1)/225, -S(1)/150, -S(2)/225)
 
     assert q1.exp() == \
     Quaternion(E * cos(sqrt(29)),

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -57,6 +57,7 @@ def test_quaternion_functions():
     assert q.inverse() == Quaternion(x, -y, -z, -w) / (w**2 + x**2 + y**2 + z**2)
     assert q.pow(2) == Quaternion(-w**2 + x**2 - y**2 - z**2, 2*x*y, 2*x*z, 2*w*x)
     assert q1.pow(-2) == Quaternion(-S(7)/225, -S(1)/225, -S(1)/150, -S(2)/225)
+    assert q1.pow(-0.5) == NotImplemented
 
     assert q1.exp() == \
     Quaternion(E * cos(sqrt(29)),

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -56,7 +56,7 @@ def test_quaternion_functions():
     assert q.normalize() == Quaternion(x, y, z, w) / sqrt(w**2 + x**2 + y**2 + z**2)
     assert q.inverse() == Quaternion(x, -y, -z, -w) / (w**2 + x**2 + y**2 + z**2)
     assert q.pow(2) == Quaternion(-w**2 + x**2 - y**2 - z**2, 2*x*y, 2*x*z, 2*w*x)
-    assert q1.pow(2) == Quaternion(-(7/225), -(1/225), -(1/150), -(2/225))
+    assert q1.pow(-2) == Quaternion(-(7/225), -(1/225), -(1/150), -(2/225))
 
     assert q1.exp() == \
     Quaternion(E * cos(sqrt(29)),


### PR DESCRIPTION
Fixes issue #13688 

This commit now helps to calculate the negative power of a quaternion (p<-1) , which was previously being shown as -1.

**PREVIOUS**

 `>>>q` `=` `Quaternion(1,2,3,4)`
`>>>q.pow(-2)`
`>>>1`

**NOW**

`>>>q = Quaternion(1,2,3,4)`
 `>>>q.pow(-2)`
 `>>>(-7/225) + (-1/225)*i + (-1/150)*j + (-2/225)*k`

@gxyd , @jksuom , @ylemkimon  please review.