### PR TITLE
Fix Documentation of Gamma Function

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -9,6 +9,7 @@ from .sympify import _sympify, sympify, SympifyError
 from .compatibility import (iterable, Iterator, ordered,
     string_types, with_metaclass, zip_longest, range)
 from .singleton import S
+from .core import all_classes as sympy_classes
 
 from inspect import getmro
 
@@ -868,7 +869,10 @@ class Basic(with_metaclass(ManagedProperties)):
                     si = sympify(si, strict=True)
                 except SympifyError:
                     if type(si) is str:
-                        si = Symbol(si)
+                        si_prev = si
+                        si = sympify(si)
+                        if type(si) not in sympy_classes:
+                            si = Symbol(si_prev)
                     else:
                         # if it can't be sympified, skip it
                         sequence[i] = None

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -779,3 +779,11 @@ def test_issue_12657():
     reps = [(-oo, 2), (oo, 1)]
     assert (x < oo).subs(reps) == (x < 1)
     assert (x < oo).subs(list(reversed(reps))) == (x < 1)
+
+
+def test_issue_13654():
+    fct = S("1/f")
+    A = {"f": "(1 / 2)"}
+    B = {"f": "1 / 2"}
+    assert fct.subs(A) == 2
+    assert fct.subs(B) == 2

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -781,6 +781,12 @@ def test_issue_12657():
     assert (x < oo).subs(list(reversed(reps))) == (x < 1)
 
 
+def test_issue_13333():
+    expr = S('R*F')
+    val = {'R':'8314.4*mjoule/(mole*kelvin)', 'F':'96484.6*(coulomb/mole)'}
+    assert str(expr.subs(val)) == '802211558.24*coulomb*mjoule/(kelvin*mole**2)'
+
+
 def test_issue_13654():
     fct = S("1/f")
     A = {"f": "(1 / 2)"}

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -23,7 +23,7 @@ class gamma(Function):
     The gamma function
 
     .. math::
-        \Gamma(x) := \int^{\infty}_{0} t^{x-1} e^{t} \mathrm{d}t.
+        \Gamma(x) := \int^{\infty}_{0} t^{x-1} e^{-t} \mathrm{d}t.
 
     The ``gamma`` function implements the function which passes through the
     values of the factorial function, i.e. `\Gamma(n) = (n - 1)!` when n is


### PR DESCRIPTION
Corrected the error in documentation of gamma Function.

The earlier code showed
Γ(x):=∫ (t**(x−1))*(e**(t)) dt

New output
Γ(x):=∫ (t**(x−1))*(e**(-t)) dt

Fixes #13746 
