### PR TITLE
Fixed Documentation of gamma function

### DIFF
--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -23,7 +23,7 @@ class gamma(Function):
     The gamma function
 
     .. math::
-        \Gamma(x) := \int^{\infty}_{0} t^{x-1} e^{t} \mathrm{d}t.
+        \Gamma(x) := \int^{\infty}_{0} t^{x-1} e^{-t} \mathrm{d}t.
 
     The ``gamma`` function implements the function which passes through the
     values of the factorial function, i.e. `\Gamma(n) = (n - 1)!` when n is


### PR DESCRIPTION
Corrected the error in documentation of gamma Function.

The earlier code showed
Γ(x):=∫ (t**(x−1))*(e**(t)) dt

New output
Γ(x):=∫ (t**(x−1))*(e**(-t)) dt

Fixes #13746