### PR TITLE
Fixed issue of simplify error in sinc

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1742,7 +1742,7 @@ class csc(ReciprocalTrigonometricFunction):
                     bernoulli(2*k)*x**(2*k - 1)/factorial(2*k))
 
 
-class sinc(TrigonometricFunction):
+class sinc(Function):
     r"""Represents unnormalized sinc function
 
     Examples

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -430,6 +430,8 @@ def TR3(rv):
         rv = rv.func(signsimp(rv.args[0]))
         if (rv.args[0] - S.Pi/4).is_positive is (S.Pi/2 - rv.args[0]).is_positive is True:
             fmap = {cos: sin, sin: cos, tan: cot, cot: tan, sec: csc, csc: sec}
+            if not rv.func in fmap:
+                return rv
             rv = fmap[rv.func](S.Pi/2 - rv.args[0])
         return rv
 

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -430,8 +430,6 @@ def TR3(rv):
         rv = rv.func(signsimp(rv.args[0]))
         if (rv.args[0] - S.Pi/4).is_positive is (S.Pi/2 - rv.args[0]).is_positive is True:
             fmap = {cos: sin, sin: cos, tan: cot, cot: tan, sec: csc, csc: sec}
-            if not rv.func in fmap:
-                return rv
             rv = fmap[rv.func](S.Pi/2 - rv.args[0])
         return rv
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1,11 +1,11 @@
 from sympy import (
     Abs, acos, Add, atan, Basic, binomial, besselsimp, collect,cos, cosh, cot,
-    coth, count_ops, Derivative, diff, E, Eq, erf, exp, exp_polar, expand,
+    coth, count_ops, csch, Derivative, diff, E, Eq, erf, exp, exp_polar, expand,
     expand_multinomial, factor, factorial, Float, fraction, Function,
     gamma, GoldenRatio, hyper, hypersimp, I, Integral, integrate, log,
     logcombine, Matrix, MatrixSymbol, Mul, nsimplify, O, oo, pi, Piecewise,
     posify, rad, Rational, root, S, separatevars, signsimp, simplify,
-    sin, sinh, solve, sqrt, Symbol, symbols, sympify, tan, tanh, zoo,
+    sin, sinc, sinh, solve, sqrt, Symbol, symbols, sympify, tan, tanh, zoo,
     Sum, Lt, sign)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import nthroot
@@ -674,6 +674,11 @@ def test_issue_9324_simplify():
     M = MatrixSymbol('M', 10, 10)
     e = M[0, 0] + M[5, 4] + 1304
     assert simplify(e) == e
+
+
+def test_issue_13474():
+    x = Symbol('x')
+    assert simplify(x + csch(sinc(1))) == x + csch(sinc(1))
 
 
 def test_simplify_function_inverse():


### PR DESCRIPTION
Changed inheritance of sinc function.

#### References to other Issues or PRs
Fixes #13474 

For the code snippet
```
>>> from sympy import *
>>> x = Symbol('x')
>>> print(simplify(x + csch(sinc(1))))
```
Before --  `KeyError : sinc`
Now -- `x + csch(sinc(1))`