### PR TITLE
 Changes to allow __matmul__ compute only matrix multiplication

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1973,7 +1973,11 @@ class MatrixArithmetic(MatrixRequired):
 
     @call_highest_priority('__rmatmul__')
     def __matmul__(self, other):
-        return self.__mul__(other)
+        if hasattr(self, 'shape') and hasattr(other, 'shape'):
+            return self.__mul__(other)
+        else:
+            raise ValueError(
+                "Scalar operands are not allowed, use '*' instead")
 
     @call_highest_priority('__rmul__')
     def __mul__(self, other):

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1340,3 +1340,9 @@ def test_limit():
     x, y = symbols('x y')
     m = CalculusOnlyMatrix(2, 1, [1/x, y])
     assert m.limit(x, 5) == Matrix(2, 1, [S(1)/5, y])
+
+
+def test_issue_13766():
+    A = Matrix([[1, 2], [3, 4]])
+    B = Matrix([[2, 3], [1, 2]])
+    raises(ValueError, lambda: MatrixArithmetic.__matmul__(B,2))


### PR DESCRIPTION
Added a extra check to allow `__matmul__`  to perform only  matrix multiplication and throws error if
scalars are passed.

#### References to other Issues or PRs
Fixes #13766 
```
