### PR TITLE
@/__matmul__ now only performs matrix multiplication

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1977,9 +1977,8 @@ class MatrixArithmetic(MatrixRequired):
         # matrix-like objects can have shapes.  This is our check.
         # Non matrice operands will throw error
         if not(hasattr(other, 'shape')):
-            raise ValueError("Scalar operands are not allowed, use '*' instead");
-            return
-
+            raise ValueError("Scalar operands are not allowed, use '*' instead")
+            
         return self.__mul__(other)
 
     @call_highest_priority('__rmul__')
@@ -2077,8 +2076,8 @@ class MatrixArithmetic(MatrixRequired):
         # matrix-like objects can have shapes.  This is our check.
         # Non matrice operands will throw error
         if not(hasattr(other, 'shape')):
-            raise ValueError("Scalar operands are not allowed, use '*' instead");
-            return
+            raise ValueError("Scalar operands are not allowed, use '*' instead")
+
         return self.__rmul__(other)
 
     @call_highest_priority('__mul__')

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1978,7 +1978,7 @@ class MatrixArithmetic(MatrixRequired):
         # Non matrice operands will throw error
         if not(hasattr(other, 'shape')):
             raise ValueError("Scalar operands are not allowed, use '*' instead")
-            
+
         return self.__mul__(other)
 
     @call_highest_priority('__rmul__')

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1973,6 +1973,13 @@ class MatrixArithmetic(MatrixRequired):
 
     @call_highest_priority('__rmatmul__')
     def __matmul__(self, other):
+        other = _matrixify(other)
+        # matrix-like objects can have shapes.  This is our check.
+        # Non matrice operands will throw error
+        if not(hasattr(other, 'shape')):
+            raise ValueError("Scalar operands are not allowed, use '*' instead");
+            return
+
         return self.__mul__(other)
 
     @call_highest_priority('__rmul__')
@@ -2066,6 +2073,12 @@ class MatrixArithmetic(MatrixRequired):
 
     @call_highest_priority('__matmul__')
     def __rmatmul__(self, other):
+        other = _matrixify(other)
+        # matrix-like objects can have shapes.  This is our check.
+        # Non matrice operands will throw error
+        if not(hasattr(other, 'shape')):
+            raise ValueError("Scalar operands are not allowed, use '*' instead");
+            return
         return self.__rmul__(other)
 
     @call_highest_priority('__mul__')

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1977,7 +1977,7 @@ class MatrixArithmetic(MatrixRequired):
         # matrix-like objects can have shapes.  This is our check.
         # Non matrice operands will throw error
         if not(hasattr(other, 'shape')):
-            raise ValueError("Scalar operands are not allowed, use '*' instead")
+            return NotImplemented
 
         return self.__mul__(other)
 
@@ -2076,7 +2076,7 @@ class MatrixArithmetic(MatrixRequired):
         # matrix-like objects can have shapes.  This is our check.
         # Non matrice operands will throw error
         if not(hasattr(other, 'shape')):
-            raise ValueError("Scalar operands are not allowed, use '*' instead")
+            return NotImplemented
 
         return self.__rmul__(other)
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1974,9 +1974,7 @@ class MatrixArithmetic(MatrixRequired):
     @call_highest_priority('__rmatmul__')
     def __matmul__(self, other):
         other = _matrixify(other)
-        # matrix-like objects can have shapes.  This is our check.
-        # Non matrice operands will throw error
-        if not(hasattr(other, 'shape')):
+        if not getattr(other, 'is_Matrix', False) and not getattr(other, 'is_MatrixLike', False):
             return NotImplemented
 
         return self.__mul__(other)
@@ -2073,9 +2071,7 @@ class MatrixArithmetic(MatrixRequired):
     @call_highest_priority('__matmul__')
     def __rmatmul__(self, other):
         other = _matrixify(other)
-        # matrix-like objects can have shapes.  This is our check.
-        # Non matrice operands will throw error
-        if not(hasattr(other, 'shape')):
+        if not getattr(other, 'is_Matrix', False) and not getattr(other, 'is_MatrixLike', False):
             return NotImplemented
 
         return self.__rmul__(other)

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -677,14 +677,15 @@ def test_multiplication():
 def test_matmul():
     a = Matrix([[1, 2], [3, 4]])
 
-    raises(ValueError, lambda: a.__matmul__(2))
+    #Check a@2 case
+    assert a.__matmul__(2) == NotImplemented
 
     #To check 2@a case
     try:
         eval('2 @ a')
     except SyntaxError:
         pass
-    except ValueError:
+    except TypeError:  #TypeError is raised in case of NotImplemented is returned
         pass
 
 def test_power():

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -674,6 +674,13 @@ def test_multiplication():
         assert c[1, 0] == 3*5
         assert c[1, 1] == 0
 
+def test_matmul():
+    a = Matrix([[1, 2], [3, 4]])
+    b = Matrix([[2, 3], [1, 2]])
+    raises(ValueError, lambda: a@2)
+    raises(ValueError, lambda: 2@a)
+        
+
 def test_power():
     raises(NonSquareMatrixError, lambda: Matrix((1, 2))**2)
 

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -676,9 +676,16 @@ def test_multiplication():
 
 def test_matmul():
     a = Matrix([[1, 2], [3, 4]])
-    b = Matrix([[2, 3], [1, 2]])
-    raises(ValueError, lambda: a@2)
-    raises(ValueError, lambda: 2@a)
+
+    raises(ValueError, lambda: a.__matmul__(2))
+
+    #To check 2@a case
+    try:
+        eval('2 @ a')
+    except SyntaxError:
+        pass
+    except ValueError:
+        pass
         
 
 def test_power():

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -686,7 +686,6 @@ def test_matmul():
         pass
     except ValueError:
         pass
-        
 
 def test_power():
     raises(NonSquareMatrixError, lambda: Matrix((1, 2))**2)

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -677,12 +677,22 @@ def test_multiplication():
 def test_matmul():
     a = Matrix([[1, 2], [3, 4]])
 
-    #Check a@2 case
     assert a.__matmul__(2) == NotImplemented
 
+    assert a.__rmatmul__(2) == NotImplemented
+
+    #This is done this way because @ is only supported in Python 3.5+
     #To check 2@a case
     try:
         eval('2 @ a')
+    except SyntaxError:
+        pass
+    except TypeError:  #TypeError is raised in case of NotImplemented is returned
+        pass
+
+    #Check a@2 case
+    try:
+        eval('a @ 2')
     except SyntaxError:
         pass
     except TypeError:  #TypeError is raised in case of NotImplemented is returned


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Add check to allow __matmul__ to perform only matrix multiplication and throws ValueError if
scalars are used as operators or operands.

#### References to other Issues or PRs

This PR will fix #13766 .

#### Brief description of what is fixed or changed
```
>>> B = Matrix([[2, 3], [1, 2]])
>>> 2@B
```
and
```
>>> B@2
```
now throws ValueError: Scalar operands are not allowed, use '*' instead