### PR TITLE
  fix the dimension mismatches when using (dot)

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2388,7 +2388,10 @@ class MatrixBase(MatrixDeprecated,
         multiply_elementwise
         """
         from .dense import Matrix
-
+        
+        if (b.cols !=1 and b.rows != 1):
+            raise ShapeError("Matrices size mismatch")
+        
         if not isinstance(b, MatrixBase):
             if is_sequence(b):
                 if len(b) != self.cols and len(b) != self.rows:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2388,7 +2388,6 @@ class MatrixBase(MatrixDeprecated,
         multiply_elementwise
         """
         from .dense import Matrix
-        
         if not isinstance(b, MatrixBase):
             if is_sequence(b):
                 if len(b) != self.cols and len(b) != self.rows:
@@ -2404,7 +2403,6 @@ class MatrixBase(MatrixDeprecated,
             b = Matrix(b)
         if (b.cols !=1 and b.rows != 1):
             raise ShapeError("`b` must has only one row or one column")
-        
         mat = self
         if mat.cols == b.rows:
             if b.cols != 1:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2399,8 +2399,6 @@ class MatrixBase(MatrixDeprecated,
                 raise TypeError(
                     "`b` must be an ordered iterable or Matrix, not %s." %
                     type(b))
-        if (type(b) == list or type(b) == tuple):
-            b = Matrix(b)
         if (b.cols !=1 and b.rows != 1):
             raise ShapeError("`b` must has only one row or one column")
         mat = self

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2389,9 +2389,6 @@ class MatrixBase(MatrixDeprecated,
         """
         from .dense import Matrix
         
-        if (b.cols !=1 and b.rows != 1):
-            raise ShapeError("Matrices size mismatch")
-        
         if not isinstance(b, MatrixBase):
             if is_sequence(b):
                 if len(b) != self.cols and len(b) != self.rows:
@@ -2403,7 +2400,11 @@ class MatrixBase(MatrixDeprecated,
                 raise TypeError(
                     "`b` must be an ordered iterable or Matrix, not %s." %
                     type(b))
-
+        if (type(b) == list or type(b) == tuple):
+            b = Matrix(b)
+        if (b.cols !=1 and b.rows != 1):
+            raise ShapeError("`b` must has only one row or one column")
+        
         mat = self
         if mat.cols == b.rows:
             if b.cols != 1:


### PR DESCRIPTION
fix #13765 the dimension mismatched when using A.dot(B) where A is matrix  B is
1 x m or n x 1  matrix before fixing it, if we used B as m x n matrix where
n or m != 1 it gives a strange answer, but after fixing it raises error if m or
n not equal 1


