### PR TITLE
Lambdify modified to handle functions and their derivatives simultaneously

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -500,7 +500,7 @@ def lambdastr(args, expr, printer=None, dummify=False):
     """
     # Transforming everything to strings.
     from sympy.matrices import DeferredVector
-    from sympy import Dummy, sympify, Symbol, Function, flatten
+    from sympy import Dummy, sympify, Symbol, Function, flatten, Derivative
 
     if printer is not None:
         if inspect.isfunction(printer):
@@ -527,6 +527,12 @@ def lambdastr(args, expr, printer=None, dummify=False):
             if isinstance(args, (Function, Symbol)):
                 dummies = Dummy()
                 dummies_dict.update({args : dummies})
+                return str(dummies)
+            elif isinstance(args ,(Function, Derivative)):
+                arg = [str(a) for a in args]
+                arg.sort()
+                dummies = Dummy()
+                dummies_dict.update({arg : dummies})
                 return str(dummies)
             else:
                 return str(args)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -5,10 +5,10 @@ import math
 import mpmath
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
-    symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
+    symbols, Function, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
     Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
     true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum,
-    DotProduct, Eq, Dummy)
+    DotProduct, Eq, Dummy, diff)
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import skip
@@ -26,6 +26,7 @@ numexpr = import_module('numexpr')
 tensorflow = import_module('tensorflow')
 
 w, x, y, z = symbols('w,x,y,z')
+func = Function('func')(x)
 
 #================== Test different arguments =======================
 
@@ -218,6 +219,15 @@ def test_issue_9334():
     func_numexpr = lambdify((a,b), expr, modules=[numexpr], dummify=False)
     foo, bar = numpy.random.random((2, 4))
     func_numexpr(foo, bar)
+
+#================== Test derivatives ===============================
+
+
+def test_derivative():
+    expr = func + func.diff()
+    f = lambdify((func, func.diff()), expr)
+    assert f(sin(x)) == sin(x) + cos(x)
+    assert f(cos(x)) == cos(x) - sin(x)
 
 #================== Test some functions ============================
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -229,6 +229,12 @@ def test_derivative():
     assert f(sin(x)) == sin(x) + cos(x)
     assert f(cos(x)) == cos(x) - sin(x)
 
+def test_double_derivative():
+    expr = func + func.diff(x) + func.diff(x, x)
+    f = lambdify((func, func.diff(x), func.diff(x, x)), expr)
+    assert f(sin(x)) == cos(x)
+    assert f(cos(x)) == -sin(x)
+
 #================== Test some functions ============================
 
 


### PR DESCRIPTION
Fixes Issue #13753 .

**NOW**

`>>>from sympy import *`
`>>>x = symbols('x')`
`>>>fun = Function('fun')(x)`
`>>>expr = fun + fun.diff()`
`>>>f = lambdify((fun,fun.diff()),expr)`
`>>>f(sin(x))`

`sin(x) + cos(x)`

The lambdify function is now modified to handle both functions and their derivatives simultaneously.
