### PR TITLE
In C/C++ code use multiplication for small integer exponents instead of pow function

### DIFF
--- a/doc/src/modules/codegen.rst
+++ b/doc/src/modules/codegen.rst
@@ -95,10 +95,10 @@ Here is a simple example of printing a C version of a SymPy expression::
     ────────
       2⋅r
     >>> ccode(expr)
-    -1.0/2.0*Z*pow(e, 2)*k/r
+    -1.0/2.0*Z*(e*e)*k/r
     >>> from sympy.codegen.ast import real, float80
     >>> ccode(expr, assign_to="E", type_aliases={real: float80})
-    E = -1.0L/2.0L*Z*powl(e, 2)*k/r;
+    E = -1.0L/2.0L*Z*(e*e)*k/r;
 
 To generate code with some math functions provided by e.g. the C99 standard we need
 to import functions from :mod:`sympy.codegen.cfunctions`::
@@ -196,7 +196,7 @@ how it works::
     >>> print(jscode(expr, assign_to="H_is"))
     H_is = I*S*gamma_1*gamma_2*k*(3*Math.pow(Math.cos(beta), 2) - 1)/Math.pow(r, 3);
     >>> print(ccode(expr, assign_to="H_is", standard='C89'))
-    H_is = I*S*gamma_1*gamma_2*k*(3*pow(cos(beta), 2) - 1)/pow(r, 3);
+    H_is = I*S*gamma_1*gamma_2*k*(3*(cos(beta)*cos(beta)) - 1)/(r*r*r);
     >>> print(fcode(expr, assign_to="H_is"))
           H_is = I*S*gamma_1*gamma_2*k*(3*cos(beta)**2 - 1)/r**3
     >>> print(julia_code(expr, assign_to="H_is"))

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -69,7 +69,7 @@ Usage::
     >>> print_ccode(Abs(x**5), standard='C89')
     fabs(pow(x, 5))
     >>> print_ccode(gamma(x**2), standard='C99')
-    tgamma(x*x))
+    tgamma((x*x))
 
 .. autodata:: sympy.printing.ccode.known_functions_C89
 .. autodata:: sympy.printing.ccode.known_functions_C99

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -62,14 +62,14 @@ Usage::
     >>> from sympy.printing import print_ccode
     >>> from sympy.functions import sin, cos, Abs, gamma
     >>> from sympy.abc import x
-    >>> print_ccode(sin(x)**2 + cos(x)**2, standard='C89')
-    pow(sin(x), 2) + pow(cos(x), 2)
+    >>> print_ccode(sin(x)**2 + cos(x)**5, standard='C89')
+    (sin(x)*sin(x)) + pow(cos(x), 5)
     >>> print_ccode(2*x + cos(x), assign_to="result", standard='C89')
     result = 2*x + cos(x);
-    >>> print_ccode(Abs(x**2), standard='C89')
-    fabs(pow(x, 2))
+    >>> print_ccode(Abs(x**5), standard='C89')
+    fabs(pow(x, 5))
     >>> print_ccode(gamma(x**2), standard='C99')
-    tgamma(pow(x, 2))
+    tgamma(x*x))
 
 .. autodata:: sympy.printing.ccode.known_functions_C89
 .. autodata:: sympy.printing.ccode.known_functions_C99

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -752,10 +752,10 @@ def ccode(expr, assign_to=None, standard='c99', **settings):
     generated normally can also exist inside a Matrix:
 
     >>> from sympy import Matrix, MatrixSymbol
-    >>> mat = Matrix([x**2, Piecewise((x + 1, x > 0), (x, True)), sin(x)])
+    >>> mat = Matrix([x**5, Piecewise((x + 1, x > 0), (x, True)), sin(x)])
     >>> A = MatrixSymbol('A', 3, 1)
     >>> print(ccode(mat, A, standard='C89'))
-    A[0] = pow(x, 2);
+    A[0] = pow(x, 5);
     if (x > 0) {
        A[1] = x + 1;
     }

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -275,6 +275,16 @@ class C89CodePrinter(CodePrinter):
             return '%ssqrt%s(%s)' % (self._ns, suffix, self._print(expr.base))
         elif expr.exp == S.One/3 and self.standard != 'C89':
             return '%scbrt%s(%s)' % (self._ns, suffix, self._print(expr.base))
+        elif expr.exp == 2:
+            b=self._print(expr.base)
+            return '(%s*%s)' % (b, b)
+        elif expr.exp == 3:
+            b=self._print(expr.base)
+            return '(%s*%s*%s)' % (b, b, b)
+        elif expr.exp == 4:
+            b=self._print(expr.base)
+            b2='(%s*%s)' % (b, b)
+            return '(%s*%s)' % (b2, b2)
         else:
             return '%spow%s(%s, %s)' % (self._ns, suffix, self._print(expr.base),
                                    self._print(expr.exp))

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -301,7 +301,6 @@ def test_ccode_Piecewise_deep():
             ": (\n"
             "   1\n"
             ")) + cos(z) - 1;")
-            
     p = ccode(2*Piecewise((x, x < 1), (x + 1, x < 2), (x**2, True)))
     assert p == (
             "2*((x < 1) ? (\n"

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -40,11 +40,18 @@ def test_ccode_sqrt():
 
 
 def test_ccode_Pow():
-    assert ccode(x**3) == "pow(x, 3)"
-    assert ccode(x**(y**3)) == "pow(x, pow(y, 3))"
+    assert ccode(x**2) == "(x*x)"
+    assert ccode(x**3) == "(x*x*x)"
+    assert ccode(x**4) == "((x*x)*(x*x))"
+    assert ccode(x**5) == "pow(x, 5)"
+    assert ccode(x**3.5) == "pow(x, 3.5)"
+    assert ccode(x**(y**2)) == "pow(x, (y*y))"
+    assert ccode(x**(y**5)) == "pow(x, pow(y, 5))"
     g = implemented_function('g', Lambda(x, 2*x))
     assert ccode(1/(g(x)*3.5)**(x - y**x)/(x**2 + y)) == \
-        "pow(3.5*2*x, -x + pow(y, x))/(pow(x, 2) + y)"
+        "pow(3.5*2*x, -x + pow(y, x))/((x*x) + y)"
+    assert ccode(1/(g(x)*3.5)**(x - y**x)/(x**5 + y)) == \
+        "pow(3.5*2*x, -x + pow(y, x))/(pow(x, 5) + y)"
     assert ccode(x**-1.0) == '1.0/x'
     assert ccode(x**Rational(2, 3)) == 'pow(x, 2.0/3.0)'
     assert ccode(x**Rational(2, 3), type_aliases={real: float80}) == 'powl(x, 2.0L/3.0L)'
@@ -171,20 +178,21 @@ def test_ccode_Relational():
 
 
 def test_ccode_Piecewise():
+    #Exponent as multiplication
     expr = Piecewise((x, x < 1), (x**2, True))
     assert ccode(expr) == (
             "((x < 1) ? (\n"
             "   x\n"
             ")\n"
             ": (\n"
-            "   pow(x, 2)\n"
+            "   (x*x)\n"
             "))")
     assert ccode(expr, assign_to="c") == (
             "if (x < 1) {\n"
             "   c = x;\n"
             "}\n"
             "else {\n"
-            "   c = pow(x, 2);\n"
+            "   c = (x*x);\n"
             "}")
     expr = Piecewise((x, x < 1), (x + 1, x < 2), (x**2, True))
     assert ccode(expr) == (
@@ -195,7 +203,7 @@ def test_ccode_Piecewise():
             "   x + 1\n"
             ")\n"
             ": (\n"
-            "   pow(x, 2)\n"
+            "   (x*x)\n"
             ")))")
     assert ccode(expr, assign_to='c') == (
             "if (x < 1) {\n"
@@ -205,10 +213,51 @@ def test_ccode_Piecewise():
             "   c = x + 1;\n"
             "}\n"
             "else {\n"
-            "   c = pow(x, 2);\n"
+            "   c = (x*x);\n"
             "}")
     # Check that Piecewise without a True (default) condition error
     expr = Piecewise((x, x < 1), (x**2, x > 1), (sin(x), x > 0))
+    raises(ValueError, lambda: ccode(expr))
+
+    #Exponent as pow
+    expr = Piecewise((x, x < 1), (x**5, True))
+    assert ccode(expr) == (
+            "((x < 1) ? (\n"
+            "   x\n"
+            ")\n"
+            ": (\n"
+            "   pow(x, 5)\n"
+            "))")
+    assert ccode(expr, assign_to="c") == (
+            "if (x < 1) {\n"
+            "   c = x;\n"
+            "}\n"
+            "else {\n"
+            "   c = pow(x, 5);\n"
+            "}")
+    expr = Piecewise((x, x < 1), (x + 1, x < 2), (x**5, True))
+    assert ccode(expr) == (
+            "((x < 1) ? (\n"
+            "   x\n"
+            ")\n"
+            ": ((x < 2) ? (\n"
+            "   x + 1\n"
+            ")\n"
+            ": (\n"
+            "   pow(x, 5)\n"
+            ")))")
+    assert ccode(expr, assign_to='c') == (
+            "if (x < 1) {\n"
+            "   c = x;\n"
+            "}\n"
+            "else if (x < 2) {\n"
+            "   c = x + 1;\n"
+            "}\n"
+            "else {\n"
+            "   c = pow(x, 5);\n"
+            "}")
+    # Check that Piecewise without a True (default) condition error
+    expr = Piecewise((x, x < 1), (x**5, x > 1), (sin(x), x > 0))
     raises(ValueError, lambda: ccode(expr))
 
 
@@ -225,6 +274,7 @@ def test_ccode_sinc():
 
 
 def test_ccode_Piecewise_deep():
+    #Exponent as multiplication
     p = ccode(2*Piecewise((x, x < 1), (x + 1, x < 2), (x**2, True)))
     assert p == (
             "2*((x < 1) ? (\n"
@@ -234,24 +284,105 @@ def test_ccode_Piecewise_deep():
             "   x + 1\n"
             ")\n"
             ": (\n"
-            "   pow(x, 2)\n"
+            "   (x*x)\n"
             ")))")
     expr = x*y*z + x**2 + y**2 + Piecewise((0, x < 0.5), (1, True)) + cos(z) - 1
     assert ccode(expr) == (
-            "pow(x, 2) + x*y*z + pow(y, 2) + ((x < 0.5) ? (\n"
+            "(x*x) + x*y*z + (y*y) + ((x < 0.5) ? (\n"
             "   0\n"
             ")\n"
             ": (\n"
             "   1\n"
             ")) + cos(z) - 1")
     assert ccode(expr, assign_to='c') == (
-            "c = pow(x, 2) + x*y*z + pow(y, 2) + ((x < 0.5) ? (\n"
+            "c = (x*x) + x*y*z + (y*y) + ((x < 0.5) ? (\n"
+            "   0\n"
+            ")\n"
+            ": (\n"
+            "   1\n"
+            ")) + cos(z) - 1;")
+            
+    p = ccode(2*Piecewise((x, x < 1), (x + 1, x < 2), (x**2, True)))
+    assert p == (
+            "2*((x < 1) ? (\n"
+            "   x\n"
+            ")\n"
+            ": ((x < 2) ? (\n"
+            "   x + 1\n"
+            ")\n"
+            ": (\n"
+            "   (x*x)\n"
+            ")))")
+    expr = x*y*z + x**2 + y**2 + Piecewise((0, x < 0.5), (1, True)) + cos(z) - 1
+    assert ccode(expr) == (
+            "(x*x) + x*y*z + (y*y) + ((x < 0.5) ? (\n"
+            "   0\n"
+            ")\n"
+            ": (\n"
+            "   1\n"
+            ")) + cos(z) - 1")
+    assert ccode(expr, assign_to='c') == (
+            "c = (x*x) + x*y*z + (y*y) + ((x < 0.5) ? (\n"
             "   0\n"
             ")\n"
             ": (\n"
             "   1\n"
             ")) + cos(z) - 1;")
 
+    #Exponent as pow
+    p = ccode(2*Piecewise((x, x < 1), (x + 1, x < 2), (x**5, True)))
+    assert p == (
+            "2*((x < 1) ? (\n"
+            "   x\n"
+            ")\n"
+            ": ((x < 2) ? (\n"
+            "   x + 1\n"
+            ")\n"
+            ": (\n"
+            "   pow(x, 5)\n"
+            ")))")
+    expr = x*y*z + x**5 + y**5 + Piecewise((0, x < 0.5), (1, True)) + cos(z) - 1
+    assert ccode(expr) == (
+            "pow(x, 5) + x*y*z + pow(y, 5) + ((x < 0.5) ? (\n"
+            "   0\n"
+            ")\n"
+            ": (\n"
+            "   1\n"
+            ")) + cos(z) - 1")
+    assert ccode(expr, assign_to='c') == (
+            "c = pow(x, 5) + x*y*z + pow(y, 5) + ((x < 0.5) ? (\n"
+            "   0\n"
+            ")\n"
+            ": (\n"
+            "   1\n"
+            ")) + cos(z) - 1;")
+            
+    p = ccode(2*Piecewise((x, x < 1), (x + 1, x < 2), (x**5, True)))
+    assert p == (
+            "2*((x < 1) ? (\n"
+            "   x\n"
+            ")\n"
+            ": ((x < 2) ? (\n"
+            "   x + 1\n"
+            ")\n"
+            ": (\n"
+            "   pow(x, 5)\n"
+            ")))")
+    expr = x*y*z + x**5 + y**5 + Piecewise((0, x < 0.5), (1, True)) + cos(z) - 1
+    assert ccode(expr) == (
+            "pow(x, 5) + x*y*z + pow(y, 5) + ((x < 0.5) ? (\n"
+            "   0\n"
+            ")\n"
+            ": (\n"
+            "   1\n"
+            ")) + cos(z) - 1")
+    assert ccode(expr, assign_to='c') == (
+            "c = pow(x, 5) + x*y*z + pow(y, 5) + ((x < 0.5) ? (\n"
+            "   0\n"
+            ")\n"
+            ": (\n"
+            "   1\n"
+            ")) + cos(z) - 1;")
 
 def test_ccode_ITE():
     expr = ITE(x < 1, y, z)
@@ -530,15 +661,18 @@ def test_ccode_reserved_words():
     x, y = symbols('x, if')
     with raises(ValueError):
         ccode(y**2, error_on_reserved=True, standard='C99')
-    assert ccode(y**2) == 'pow(if_, 2)'
-    assert ccode(x * y**2, dereference=[y]) == 'pow((*if_), 2)*x'
-    assert ccode(y**2, reserved_word_suffix='_unreserved') == 'pow(if_unreserved, 2)'
+    assert ccode(y**2) == '(if_*if_)'
+    assert ccode(y**5) == 'pow(if_, 5)'
+    assert ccode(x * y**2, dereference=[y]) == '((*if_)*(*if_))*x'
+    assert ccode(x * y**5, dereference=[y]) == 'pow((*if_), 5)*x'
+    assert ccode(y**2, reserved_word_suffix='_unreserved') == '(if_unreserved*if_unreserved)'
+    assert ccode(y**5, reserved_word_suffix='_unreserved') == 'pow(if_unreserved, 5)'
 
 
 def test_ccode_sign():
     expr1, ref1 = sign(x) * y, 'y*(((x) > 0) - ((x) < 0))'
     expr2, ref2 = sign(cos(x)), '(((cos(x)) > 0) - ((cos(x)) < 0))'
-    expr3, ref3 = sign(2 * x + x**2) * x + x**2, 'pow(x, 2) + x*(((pow(x, 2) + 2*x) > 0) - ((pow(x, 2) + 2*x) < 0))'
+    expr3, ref3 = sign(2 * x + x**2) * x + x**2, '(x*x) + x*((((x*x) + 2*x) > 0) - (((x*x) + 2*x) < 0))'
     assert ccode(expr1) == ref1
     assert ccode(expr1, 'z') == 'z = %s;' % ref1
     assert ccode(expr2) == ref2
@@ -596,7 +730,8 @@ def test_C99CodePrinter():
     assert C99CodePrinter().doprint(Cbrt(x)) == 'cbrt(x)'  # note Cbrt due to cbrt already taken.
     assert C99CodePrinter().doprint(hypot(x, y)) == 'hypot(x, y)'
     assert C99CodePrinter().doprint(loggamma(x)) == 'lgamma(x)'
-    assert C99CodePrinter().doprint(Max(x, 3, x**2)) == 'fmax(3, fmax(x, pow(x, 2)))'
+    assert C99CodePrinter().doprint(Max(x, 3, x**2)) == 'fmax(3, fmax(x, (x*x)))'
+    assert C99CodePrinter().doprint(Max(x, 3, x**5)) == 'fmax(3, fmax(x, pow(x, 5)))'
     assert C99CodePrinter().doprint(Min(x, 3)) == 'fmin(3, x)'
     c99printer = C99CodePrinter()
     assert c99printer.language == 'C'
@@ -639,8 +774,8 @@ def test_C99CodePrinter__precision():
         check(log1p(x), 'log1p{s}(x)')
         check(2**x, 'pow{s}(2, x)')
         check(2.0**x, 'pow{s}(2.0{S}, x)')
-        check(x**3, 'pow{s}(x, 3)')
-        check(x**4.0, 'pow{s}(x, 4.0{S})')
+        check(x**5, 'pow{s}(x, 5)')
+        check(x**6.0, 'pow{s}(x, 6.0{S})')
         check(sqrt(3+x), 'sqrt{s}(x + 3)')
         check(Cbrt(x-2.0), 'cbrt{s}(x - 2.0{S})')
         check(hypot(x, y), 'hypot{s}(x, y)')
@@ -666,7 +801,7 @@ def test_C99CodePrinter__precision():
         check(ceiling(x + 2.), "ceil{s}(x + 2.0{S})")
         check(floor(x + 2.), "floor{s}(x + 2.0{S})")
         check(fma(x, y, -z), 'fma{s}(x, y, -z)')
-        check(Max(x, 8.0, x**4.0), 'fmax{s}(8.0{S}, fmax{s}(x, pow{s}(x, 4.0{S})))')
+        check(Max(x, 8.0, x**5.0), 'fmax{s}(8.0{S}, fmax{s}(x, pow{s}(x, 5.0{S})))')
         check(Min(x, 2.0), 'fmin{s}(2.0{S}, x)')
 
 


### PR DESCRIPTION
In tight loops, especially for float type, the cost of pow / std::pow calls for small integer exponents (2...4) can be much greater than the equivalent multiplication. This PR adds code to automatically transform x**y to multiplication for y=(2...4). In all other cases function pow is used, as before.

This PR also includes test which exercise both multiplicative and pow code paths.