### PR TITLE
User defined values in mul_symbol in latex 

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -165,8 +165,13 @@ class LatexPrinter(Printer):
             self._settings['mul_symbol_latex_numbers'] = \
                 mul_symbol_table[self._settings['mul_symbol'] or 'dot']
         except KeyError:
-            self._settings['mul_symbol_latex_numbers'] = \
-                self._settings['mul_symbol'] or mul_symbol_table['dot']
+            if (self._settings['mul_symbol'] == ' ' or
+                    self._settings['mul_symbol'] == '\\,'):
+                self._settings['mul_symbol_latex_numbers'] = \
+                    mul_symbol_table['dot']
+            else:
+                self._settings['mul_symbol_latex_numbers'] = \
+                    self._settings['mul_symbol']
 
         self._delim_dict = {'(': ')', '[': ']'}
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -155,12 +155,18 @@ class LatexPrinter(Printer):
             "dot": r" \cdot ",
             "times": r" \times "
         }
-
-        self._settings['mul_symbol_latex'] = \
-            mul_symbol_table[self._settings['mul_symbol']]
-
-        self._settings['mul_symbol_latex_numbers'] = \
-            mul_symbol_table[self._settings['mul_symbol'] or 'dot']
+        try:
+            self._settings['mul_symbol_latex'] = \
+                mul_symbol_table[self._settings['mul_symbol']]
+        except KeyError:
+            self._settings['mul_symbol_latex'] = \
+                self._settings['mul_symbol']
+        try:
+            self._settings['mul_symbol_latex_numbers'] = \
+                mul_symbol_table[self._settings['mul_symbol'] or 'dot']
+        except KeyError:
+            self._settings['mul_symbol_latex_numbers'] = \
+                self._settings['mul_symbol'] or mul_symbol_table['dot']
 
         self._delim_dict = {'(': ')', '[': ']'}
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -165,8 +165,8 @@ class LatexPrinter(Printer):
             self._settings['mul_symbol_latex_numbers'] = \
                 mul_symbol_table[self._settings['mul_symbol'] or 'dot']
         except KeyError:
-            if (self._settings['mul_symbol'] == ' ' or
-                    self._settings['mul_symbol'] == '\\,'):
+            if (self._settings['mul_symbol'].strip() in
+                    ['', ' ', '\\', '\\,', '\\:', '\\;', '\\quad']):
                 self._settings['mul_symbol_latex_numbers'] = \
                     mul_symbol_table['dot']
             else:

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -63,6 +63,7 @@ def test_latex_basic():
     assert latex(2*x*y) == "2 x y"
     assert latex(2*x*y, mul_symbol='dot') == r"2 \cdot x \cdot y"
     assert latex(3*x**2*y, mul_symbol='\\,') == r"3\,x^{2}\,y"
+    assert latex(1.5*3**x, mul_symbol='\\,') == r"1.5 \cdot 3^{x}"
 
     assert latex(1/x) == r"\frac{1}{x}"
     assert latex(1/x, fold_short_frac=True) == "1 / x"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -62,7 +62,7 @@ def test_latex_basic():
 
     assert latex(2*x*y) == "2 x y"
     assert latex(2*x*y, mul_symbol='dot') == r"2 \cdot x \cdot y"
-    assert latex(3*x**2*y, mul_symbol='\,') == r"3\,x^{2}\,y"
+    assert latex(3*x**2*y, mul_symbol='\\,') == r"3\,x^{2}\,y"
 
     assert latex(1/x) == r"\frac{1}{x}"
     assert latex(1/x, fold_short_frac=True) == "1 / x"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -62,6 +62,7 @@ def test_latex_basic():
 
     assert latex(2*x*y) == "2 x y"
     assert latex(2*x*y, mul_symbol='dot') == r"2 \cdot x \cdot y"
+    assert latex(3*x**2*y, mul_symbol='\,') == r"3\,x^{2}\,y"
 
     assert latex(1/x) == r"\frac{1}{x}"
     assert latex(1/x, fold_short_frac=True) == "1 / x"


### PR DESCRIPTION
`mul_symbol` can now take user defined values other than the four values defined in `mul_symbol_table`.

For example
```
>>> latex(3*x**2*y, mul_symbol='\,')
3\,x^{2}\,y
```

#### References to other Issues or PRs
Fixes #13055
