### PR TITLE
[WIP] prevent subs from changing Derivative to an inequivalent one

### DIFF
--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -562,6 +562,22 @@ def test_diff_wrt_func_subs():
     assert f(g(x)).diff(x).subs(g, Lambda(x, 2*x)).doit() == f(2*x).diff(x)
 
 
+def test_subs_in_derivative():
+    expr = sin(x*exp(y))
+    u = Function('u')
+    v = Function('v')
+    assert Derivative(expr, y).subs(y, x).doit() == \
+        Derivative(expr, y).doit().subs(y, x)
+    assert Derivative(f(x, y), y).subs(y, x) == Subs(Derivative(f(x, y), y), y, x)
+    assert Derivative(f(x, y), y).subs(x, y) == Subs(Derivative(f(x, y), y), x, y)
+    assert Derivative(f(x, y), y).subs(y, z) == Derivative(f(x, z), z)
+    assert Derivative(f(x, y), y).subs(y, g(y)) == Derivative(f(x, g(y)), g(y))
+    assert Derivative(f(g(x), h(y)), h(y)).subs(h(y), u(y)) == \
+        Derivative(f(g(x), u(y)), u(y))
+    issue_13791 = v(x, y, u(x, y)).diff(y).diff(x).diff(y)
+    # no assertion (it's a complicated formula) but in 13791 this threw an exception
+
+
 def test_diff_wrt_not_allowed():
     raises(ValueError, lambda: diff(sin(x**2), x**2))
     raises(ValueError, lambda: diff(exp(x*y), x*y))


### PR DESCRIPTION
Currently, a substitution such as `Derivative(f(x, y), y).subs(y, x)` results in `Derivative(f(x, x), x)` which is a different derivative. This severely affects the computation of derivatives of orders 2 or greater of expressions with unknown functions. This commit modifies `_eval_subs` method of Derivative class to allow substitution only in specific cases (commented in the code and listed below) when it is safe to do so. Fixes #13791; also fixes #13795.

For example, `Derivative(f(x, y), y).subs(y, z)` is allowed to become `Derivative(f(x, z), z)`. Also, `Derivative(sin(x), x).subs(sin, exp)` is permitted because the replacement of functions, rather than expressions, is inherently structural rather than mathematical manipulation. The follows is the list of situations under which `Derivative(expr, vars).subs(old, new)`  is allowed to be evaluated. 

1. `old` is an instance of UndefinedFunction, rather than an expression
2. Neither `old` nor `new` term contains any `vars`
3. Substitution replaces one of` `vars` by an expression whose variable(s) are not present in `expr`
4. Substitution replaces one of  `vars` by an expression that does not depend on other variables
5. `expr == old`, complete replacement of differentiated expression
6. Substitution does not actually change either `expr` or `vars`

Most of the added tests fail in the current master version. 