### PR TITLE
Prevent substitution inside Derivative in some cases

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1484,17 +1484,12 @@ class Derivative(Expr):
         # Derivative(expr, vars). Disallowed:
         # (1) changing expr by introducing a variable among vars
         # (2) changing vars by introducing a variable contained in expr
-        # However, it is always allowed to replace the entire expr by new,
-        # as this is useful for temporarily replacing an expression with
-        # a dummy variable, which `solve` sometimes does.
         old_symbols = (old.free_symbols if isinstance(old.free_symbols, set)
             else set())
         new_symbols = (new.free_symbols if isinstance(new.free_symbols, set)
             else set())
         introduced_symbols = new_symbols - old_symbols
         args_subbed = tuple(x._subs(old, new) for x in self.args)
-        if self.expr == old:   # complete replacement
-            return Derivative(*args_subbed)
         if ((self.args[0] != args_subbed[0] and
             len(set(self.variables) & introduced_symbols) > 0
             ) or

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1480,7 +1480,28 @@ class Derivative(Expr):
             if _subset(old_vars, self_vars):
                 return Derivative(new, *(self_vars - old_vars).items())
 
-        return Derivative(*(x._subs(old, new) for x in self.args))
+        # Check whether the substitution (old, new) cannot be done inside
+        # Derivative(expr, vars). Disallowed:
+        # (1) changing expr by introducing a variable among vars
+        # (2) changing vars by introducing a variable contained in expr
+        # However, it is always allowed to replace the entire expr by new.
+        old_symbols = old.free_symbols if isinstance(old.free_symbols, set) \
+            else set()
+        new_symbols = new.free_symbols if isinstance(new.free_symbols, set) \
+            else set()
+        introduced_symbols = new_symbols - old_symbols
+        args_subbed = tuple(x._subs(old, new) for x in self.args)
+        if self.args[0] == old:   # complete replacement
+            return Derivative(*args_subbed)
+        if (self.args[0] != args_subbed[0] and \
+            len(set(self.variables) & introduced_symbols) > 0
+            ) or \
+            (self.args[1:] != args_subbed[1:] and \
+            len(self.args[0].free_symbols & introduced_symbols) > 0
+            ):
+            return Subs(self, old, new)
+        else:
+            return Derivative(*args_subbed)
 
     def _eval_lseries(self, x, logx):
         dx = self.variables

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1259,8 +1259,8 @@ class Derivative(Expr):
                     if obj is not None:
                         if not old_v.is_symbol and obj.is_Derivative:
                             # Derivative evaluated at a point that is not a
-                            # symbol
-                            obj = Subs(obj, v, old_v)
+                            # symbol, let subs check if this is okay to replace
+                            obj = obj.subs(v, old_v)
                         else:
                             obj = obj.xreplace({v: old_v})
                     v = old_v
@@ -1484,7 +1484,9 @@ class Derivative(Expr):
         # Derivative(expr, vars). Disallowed:
         # (1) changing expr by introducing a variable among vars
         # (2) changing vars by introducing a variable contained in expr
-        # However, it is always allowed to replace the entire expr by new.
+        # However, it is always allowed to replace the entire expr by new,
+        # as this is useful for temporarily replacing an expression with
+        # a dummy variable, which `solve` sometimes does.
         old_symbols = (old.free_symbols if isinstance(old.free_symbols, set)
             else set())
         new_symbols = (new.free_symbols if isinstance(new.free_symbols, set)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1485,20 +1485,20 @@ class Derivative(Expr):
         # (1) changing expr by introducing a variable among vars
         # (2) changing vars by introducing a variable contained in expr
         # However, it is always allowed to replace the entire expr by new.
-        old_symbols = old.free_symbols if isinstance(old.free_symbols, set) \
-            else set()
-        new_symbols = new.free_symbols if isinstance(new.free_symbols, set) \
-            else set()
+        old_symbols = (old.free_symbols if isinstance(old.free_symbols, set)
+            else set())
+        new_symbols = (new.free_symbols if isinstance(new.free_symbols, set)
+            else set())
         introduced_symbols = new_symbols - old_symbols
         args_subbed = tuple(x._subs(old, new) for x in self.args)
-        if self.args[0] == old:   # complete replacement
+        if self.expr == old:   # complete replacement
             return Derivative(*args_subbed)
-        if (self.args[0] != args_subbed[0] and \
+        if ((self.args[0] != args_subbed[0] and
             len(set(self.variables) & introduced_symbols) > 0
-            ) or \
-            (self.args[1:] != args_subbed[1:] and \
-            len(self.args[0].free_symbols & introduced_symbols) > 0
-            ):
+            ) or
+            (self.args[1:] != args_subbed[1:] and
+            len(self.free_symbols & introduced_symbols) > 0
+            )):
             return Subs(self, old, new)
         else:
             return Derivative(*args_subbed)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -555,7 +555,7 @@ def test_diff_wrt():
     assert f(
         sin(x)).diff(x) == Subs(Derivative(f(x), x), (x,), (sin(x),))*cos(x)
 
-    assert diff(f(g(x)), g(x)) == Subs(Derivative(f(x), x), (x,), (g(x),))
+    assert diff(f(g(x)), g(x)) == Derivative(f(g(x)), g(x))
 
 
 def test_diff_wrt_func_subs():
@@ -882,7 +882,7 @@ def test_issue_12005():
     assert e4.diff(y) == S.Zero
     e5 = Subs(Derivative(f(x), x), (y, z), (y, z))
     assert e5.diff(x) == Derivative(f(x), x, x)
-    assert f(g(x)).diff(g(x), g(x)) == Subs(Derivative(f(y), y, y), (y,), (g(x),))
+    assert f(g(x)).diff(g(x), g(x)) == Derivative(f(g(x)), g(x), g(x))
 
 def test_undefined_function_eq():
     f = Function('f')

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -579,7 +579,11 @@ def test_subs_in_derivative():
     assert Derivative(f(g(x), h(y)), h(y)).subs(h(y), u(y)) == \
         Derivative(f(g(x), u(y)), u(y))
     issue_13791 = v(x, y, u(x, y)).diff(y).diff(x).diff(y)
-    # no assertion (it's a complicated formula) but in 13791 this threw an exception
+    # no assertion (it's a long formula) but in 13791 this threw an exception. Related:
+    F = lambda x, y: exp(2*x + 3*y)
+    abstract = f(x, f(x, x)).diff(x, 2)
+    concrete = F(x, F(x, x)).diff(x, 2)
+    assert (abstract.replace(f, F).doit() - concrete).simplify() == 0
 
 
 def test_diff_wrt_not_allowed():

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -562,6 +562,26 @@ def test_diff_wrt_func_subs():
     assert f(g(x)).diff(x).subs(g, Lambda(x, 2*x)).doit() == f(2*x).diff(x)
 
 
+def test_subs_in_derivative():
+    expr = sin(x*exp(y))
+    u = Function('u')
+    v = Function('v')
+    assert Derivative(expr, y).subs(y, x).doit() == \
+        Derivative(expr, y).doit().subs(y, x)
+    assert Derivative(f(x, y), y).subs(y, x) == Subs(Derivative(f(x, y), y), y, x)
+    assert Derivative(f(x, y), y).subs(x, y) == Subs(Derivative(f(x, y), y), x, y)
+    assert Derivative(f(x, y), y).subs(y, g(x, y)) == Subs(Derivative(f(x, y), y), y, g(x, y))
+    assert Derivative(f(x, y), y).subs(x, g(x, y)) == Subs(Derivative(f(x, y), y), x, g(x, y))
+    assert Derivative(f(u(x), h(y)), h(y)).subs(h(y), g(x, y)) == \
+        Subs(Derivative(f(u(x), h(y)), h(y)), h(y), g(x, y))
+    assert Derivative(f(x, y), y).subs(y, z) == Derivative(f(x, z), z)
+    assert Derivative(f(x, y), y).subs(y, g(y)) == Derivative(f(x, g(y)), g(y))
+    assert Derivative(f(g(x), h(y)), h(y)).subs(h(y), u(y)) == \
+        Derivative(f(g(x), u(y)), u(y))
+    issue_13791 = v(x, y, u(x, y)).diff(y).diff(x).diff(y)
+    # no assertion (it's a complicated formula) but in 13791 this threw an exception
+
+
 def test_diff_wrt_not_allowed():
     raises(ValueError, lambda: diff(sin(x**2), x**2))
     raises(ValueError, lambda: diff(exp(x*y), x*y))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -578,9 +578,10 @@ def test_subs_in_derivative():
     assert Derivative(f(x, y), y).subs(y, g(y)) == Derivative(f(x, g(y)), g(y))
     assert Derivative(f(g(x), h(y)), h(y)).subs(h(y), u(y)) == \
         Derivative(f(g(x), u(y)), u(y))
-    issue_13791 = v(x, y, u(x, y)).diff(y).diff(x).diff(y)
-    # no assertion (it's a long formula) but in 13791 this threw an exception. Related:
-    F = lambda x, y: exp(2*x + 3*y)
+    # Issue 13791. No comparison (it's a long formula) but this used to raise an exception.
+    assert isinstance(v(x, y, u(x, y)).diff(y).diff(x).diff(y), Expr)
+    # This is also related to issues 13791 and 13795
+    F = Lambda((x, y), exp(2*x + 3*y))
     abstract = f(x, f(x, x)).diff(x, 2)
     concrete = F(x, F(x, x)).diff(x, 2)
     assert (abstract.replace(f, F).doit() - concrete).simplify() == 0

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -487,7 +487,8 @@ def test_derivative_subs():
     y = Symbol('y')
     f = Function('f')
     assert Derivative(f(x), x).subs(f(x), y) != 0
-    assert Derivative(f(x), x).subs(f(x), y).subs(y, f(x)) == \
+    # need xreplace to put the function back, see #13803
+    assert Derivative(f(x), x).subs(f(x), y).xreplace({y: f(x)}) == \
         Derivative(f(x), x)
     # issues 5085, 5037
     assert cse(Derivative(f(x), x) + f(x))[1][0].has(Derivative)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1095,7 +1095,9 @@ def solve(f, *symbols, **flags):
     non_inverts = dict(list(zip(non_inverts, [Dummy() for d in non_inverts])))
     f = [fi.subs(non_inverts) for fi in f]
 
-    non_inverts = [(v, k.subs(swap_sym)) for k, v in non_inverts.items()]
+    # Both xreplace and subs are needed below: xreplace to force substitution
+    # inside Derivative, subs to handle non-straightforward substitutions
+    non_inverts = [(v, k.xreplace(swap_sym).subs(swap_sym)) for k, v in non_inverts.items()]
 
     # rationalize Floats
     floats = False


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #11737. Fixes #13791. Fixes #13795. Fixes #13848.

#### Brief description of what is fixed or changed

Currently, a substitution such as `Derivative(f(x, y), y).subs(y, x)` results in `Derivative(f(x, x), x)` which is a different derivative. This affects the computation of derivatives of orders 2 or greater of expressions with undefined functions. This patch modifies _eval_subs method of Derivative class to disallow substitution when it is clearly wrong to do.

This is an alternative approach to #13801 which attempted to codify all _allowed_ substitutions; this one codifies _disallowed_ ones as follows. Substitution (old, new) cannot be done inside Derivative(expr, vars) if it is:

1. changing expr by introducing a variable among vars, or
2. changing vars by introducing a variable contained in expr

Exception: complete replacement of expr by new (expr == old) is always allowed, so for example `Derivative(f(x), x).subs(f(x), y).subs(y, f(x))` results in Derivative(f(x), x) although one may call this abuse of notation. This is something that `solve` relies on:

> when an object other than a Symbol is given as a symbol, it is isolated algebraically and an implicit solution may be obtained. This is mostly provided as a convenience to save one from replacing the object with a Symbol and solving for that Symbol. It will only work if the specified object can be replaced with a Symbol using the subs method.
```
>> solve(f(x).diff(x) - f(x) - x, f(x))
[-x + Derivative(f(x), x)]
```
Temporarily replacing an expression being differentiated by a dummy symbols seems a reasonable thing to do. 

The rules 1 and 2 still allow for mathematically questionable but convenient operations of replacing a function being differentiated. Some such operations are baked into Physics module, e.g., 
```
Derivative((-R*u3(t) - b*u1(t) + u2(t))/R, t).subs(u3(t), 0)
Derivative(r*Derivative(f(r, th), r), r).subs(f(r, th), r**2*sin(th))  
```
where the authors expect the substitution to be carried out. The logic is that first a general expression with derivatives is formed, and then a specific function is put in to replace an abstract one.

Another example, found many times in `test_ode`, is applying `subs(f(x), sol)` to a differential equation such as `Eq(diff(f(x), x), 2*f(x))`. Technically, this substitution does not commute with the derivative here, but the meaning is clear and the substitution is allowed to proceed, so that Eq evaluates to True. 