### PR TITLE
stats: precompute the CDF of uniform distribution

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2446,18 +2446,16 @@ class UniformDistribution(SingleContinuousDistribution):
         left, right = self.left, self.right
         return Piecewise(
             (S.One/(right - left), And(left <= x, x <= right)),
-            (S.Zero, True))
+            (S.Zero, True)
+        )
 
-    def compute_cdf(self, **kwargs):
-        from sympy import Lambda, Min
-        z = Dummy('z', real=True, finite=True)
-        result = SingleContinuousDistribution.compute_cdf(self, **kwargs)(z)
-        reps = {
-            Min(z, self.right): z,
-            Min(z, self.left, self.right): self.left,
-            Min(z, self.left): self.left}
-        result = result.subs(reps)
-        return Lambda(z, result)
+    def _cdf(self, x):
+        left, right = self.left, self.right
+        return Piecewise(
+            (S.Zero, x < left),
+            ((x - left)/(right - left), x <= right),
+            (S.One, True)
+        )
 
     def expectation(self, expr, var, **kwargs):
         from sympy import Max, Min

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -379,6 +379,7 @@ def test_lognormal():
     X = LogNormal('x', 0, 1)  # Mean 0, standard deviation 1
     assert density(X)(x) == sqrt(2)*exp(-log(x)**2/2)/(2*x*sqrt(pi))
 
+
 def test_maxwell():
     a = Symbol("a", positive=True)
 
@@ -444,17 +445,20 @@ def test_rayleigh():
     assert E(X) == sqrt(2)*sqrt(pi)*sigma/2
     assert variance(X) == -pi*sigma**2/2 + 2*sigma**2
 
+
 def test_shiftedgompertz():
     b = Symbol("b", positive=True)
     eta = Symbol("eta", positive=True)
     X = ShiftedGompertz("x", b, eta)
     assert density(X)(x) == b*(eta*(1 - exp(-b*x)) + 1)*exp(-b*x)*exp(-eta*exp(-b*x))
 
+
 def test_studentt():
     nu = Symbol("nu", positive=True)
 
     X = StudentT('x', nu)
     assert density(X)(x) == (1 + x**2/nu)**(-nu/2 - 1/2)/(sqrt(nu)*beta(1/2, nu/2))
+
 
 def test_trapezoidal():
     a = Symbol("a", real=True)
@@ -495,6 +499,7 @@ def test_quadratic_u():
     assert density(X)(x) == (Piecewise((12*(x - a/2 - b/2)**2/(-a + b)**3,
                           And(x <= b, a <= x)), (0, True)))
 
+
 def test_uniform():
     l = Symbol('l', real=True, finite=True)
     w = Symbol('w', positive=True, finite=True)
@@ -503,11 +508,21 @@ def test_uniform():
     assert simplify(E(X)) == l + w/2
     assert simplify(variance(X)) == w**2/12
 
-
     # With numbers all is well
     X = Uniform('x', 3, 5)
     assert P(X < 3) == 0 and P(X > 5) == 0
     assert P(X < 4) == P(X > 4) == S.Half
+
+    z = Symbol('z')
+    p = density(X)(z)
+    assert p.subs(z, 3.7) == S(1)/2
+    assert p.subs(z, -1) == 0
+    assert p.subs(z, 6) == 0
+
+    c = cdf(X)
+    assert c(2) == 0 and c(3) == 0
+    assert c(S(7)/2) == S(1)/4
+    assert c(5) == 1 and c(6) == 1
 
 
 def test_uniform_P():


### PR DESCRIPTION
Adds internal `_cdf` method to UniformDistribution, so that the cumulative density function is returned in a correct and usable form. Closes #13788. Also closes #11258 (which was mostly corrected earlier). 

The uniform distribution has piecewise-defined density, which causes difficulties in computing cdf from it. For example, the following is wrong in current master branch:
```
from sympy.stats import *
X = Uniform("x", 1, 3)
cdf(X)(7)   # returns 3 instead of 1
```
Several other continuous distributions already have precomputed CDFs, and I hope more will be added later. There are other distributions where the integration of PDF does not result in a formula that a user would want to see.

**Add entry(ies) to the release notes?** No