### PR TITLE
Added angular quantities printing in latex and pretty

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -401,18 +401,8 @@ class LatexPrinter(Printer):
                     args = list(expr.args)
 
                 # If quantities are present append them at the back
-                quantities_index = []
-                for i in range(len(args)):
-                    if isinstance(args[i], Quantity) or (isinstance(args[i], Pow) and
-                                                        isinstance(args[i].base, Quantity)):
-                        args.append(args[i])
-                        quantities_index.append(i)
-
-                if quantities_index != []:
-                    for i in range(len(args)-1, -1, -1):
-                        if quantities_index != [] and i == quantities_index[-1]:
-                            del quantities_index[-1]
-                            del args[i]
+                args = sorted(args, key=lambda x: isinstance(x, Quantity) or
+                             (isinstance(x, Pow) and isinstance(x.base, Quantity)))
 
                 for i, term in enumerate(args):
                     term_tex = self._print(term)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -116,6 +116,9 @@ _between_two_numbers_p = (
     re.compile(r'[{ ]*[-+0-9]'),  # match
 )
 
+quantity = [
+    'degree'
+]
 
 class LatexPrinter(Printer):
     printmethod = "_latex"
@@ -398,6 +401,12 @@ class LatexPrinter(Printer):
                     args = expr.as_ordered_factors()
                 else:
                     args = expr.args
+
+                # If quantity is present append them at the back
+                for i in range(len(args)):
+                    if str(args[i]) in quantity:
+                        args.append(args[i])
+                        del args[i]
 
                 for i, term in enumerate(args):
                     term_tex = self._print(term)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -376,6 +376,7 @@ class LatexPrinter(Printer):
 
     def _print_Mul(self, expr):
         from sympy.core.power import Pow
+        from sympy.physics.units import Quantity
         include_parens = False
         if _coeff_isneg(expr):
             expr = -expr
@@ -404,9 +405,10 @@ class LatexPrinter(Printer):
 
                 # If angular quantity is present append them at the back
                 for i in range(len(args)):
-                    if str(args[i]) in angular_quantity:
-                        args.append(args[i])
-                        del args[i]
+                    if isinstance(args[i], Quantity):
+                        if args[i].name.name in angular_quantity:
+                            args.append(args[i])
+                            del args[i]
 
                 for i, term in enumerate(args):
                     term_tex = self._print(term)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2058,6 +2058,10 @@ class LatexPrinter(Printer):
                     self._print(exp))
         return r'\Omega\left(%s\right)' % self._print(expr.args[0])
 
+    def _print_Quantity(self, expr):
+        if str(expr) == 'degree':
+            return r"^\circ"
+        return r"%s" %expr
 
 def translate(s):
     r'''

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -116,9 +116,6 @@ _between_two_numbers_p = (
     re.compile(r'[{ ]*[-+0-9]'),  # match
 )
 
-angular_quantity = [
-    'degree', 'radian'
-]
 
 class LatexPrinter(Printer):
     printmethod = "_latex"
@@ -403,11 +400,18 @@ class LatexPrinter(Printer):
                 else:
                     args = list(expr.args)
 
-                # If angular quantity is present append them at the back
+                # If quantities are present append them at the back
+                quantities_index = []
                 for i in range(len(args)):
-                    if isinstance(args[i], Quantity):
-                        if args[i].name.name in angular_quantity:
-                            args.append(args[i])
+                    if isinstance(args[i], Quantity) or (isinstance(args[i], Pow) and
+                                                        isinstance(args[i].base, Quantity)):
+                        args.append(args[i])
+                        quantities_index.append(i)
+
+                if quantities_index != []:
+                    for i in range(len(args)-1, -1, -1):
+                        if quantities_index != [] and i == quantities_index[-1]:
+                            del quantities_index[-1]
                             del args[i]
 
                 for i, term in enumerate(args):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2059,7 +2059,7 @@ class LatexPrinter(Printer):
         return r'\Omega\left(%s\right)' % self._print(expr.args[0])
 
     def _print_Quantity(self, expr):
-        if str(expr) == 'degree':
+        if expr.name.name == 'degree':
             return r"^\circ"
         return r"%s" % expr
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2061,7 +2061,7 @@ class LatexPrinter(Printer):
     def _print_Quantity(self, expr):
         if str(expr) == 'degree':
             return r"^\circ"
-        return r"%s" %expr
+        return r"%s" % expr
 
 def translate(s):
     r'''

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -116,8 +116,8 @@ _between_two_numbers_p = (
     re.compile(r'[{ ]*[-+0-9]'),  # match
 )
 
-quantity = [
-    'degree'
+angular_quantity = [
+    'degree', 'radian'
 ]
 
 class LatexPrinter(Printer):
@@ -400,11 +400,11 @@ class LatexPrinter(Printer):
                 if self.order not in ('old', 'none'):
                     args = expr.as_ordered_factors()
                 else:
-                    args = expr.args
+                    args = list(expr.args)
 
-                # If quantity is present append them at the back
+                # If angular quantity is present append them at the back
                 for i in range(len(args)):
-                    if str(args[i]) in quantity:
+                    if str(args[i]) in angular_quantity:
                         args.append(args[i])
                         del args[i]
 
@@ -2070,6 +2070,8 @@ class LatexPrinter(Printer):
     def _print_Quantity(self, expr):
         if expr.name.name == 'degree':
             return r"^\circ"
+        elif expr.name.name == 'radian':
+            return r"^rad"
         return r"%s" % expr
 
 def translate(s):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2066,8 +2066,6 @@ class LatexPrinter(Printer):
     def _print_Quantity(self, expr):
         if expr.name.name == 'degree':
             return r"^\circ"
-        elif expr.name.name == 'radian':
-            return r"^rad"
         return r"%s" % expr
 
 def translate(s):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1479,18 +1479,8 @@ class PrettyPrinter(Printer):
             args = list(product.args)
 
         # If quantities are present append them at the back
-        quantities_index = []
-        for i in range(len(args)):
-            if isinstance(args[i], Quantity) or (isinstance(args[i], Pow) and
-                                                isinstance(args[i].base, Quantity)):
-                args.append(args[i])
-                quantities_index.append(i)
-
-        if quantities_index != []:
-            for i in range(len(args)-1, -1, -1):
-                if quantities_index != [] and i == quantities_index[-1]:
-                    del quantities_index[-1]
-                    del args[i]
+        args = sorted(args, key=lambda x: isinstance(x, Quantity) or
+                     (isinstance(x, Pow) and isinstance(x.base, Quantity)))
 
         # Gather terms for numerator/denominator
         for item in args:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1473,6 +1473,7 @@ class PrettyPrinter(Printer):
         return prettyForm.__add__(*pforms)
 
     def _print_Mul(self, product):
+        from sympy.physics.units import Quantity
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
@@ -1483,9 +1484,10 @@ class PrettyPrinter(Printer):
 
         # If quantity is present append them at the back
         for i in range(len(args)):
-            if str(args[i]) in angular_quantity:
-                args.append(args[i])
-                del args[i]
+            if isinstance(args[i], Quantity):
+                if args[i].name.name in angular_quantity:
+                    args.append(args[i])
+                    del args[i]
 
         # Gather terms for numerator/denominator
         for item in args:
@@ -2250,7 +2252,7 @@ class PrettyPrinter(Printer):
             pform = self._print(u"\N{DEGREE SIGN}")
             return pform
         elif e.name.name == 'radian':
-            pform = self._print(u"\N{ZERO WIDTH NO-BREAK SPACE}")
+            pform = self._print(' '*len('rad'))
             return prettyForm(*pform.above(self._print('rad')))
         else:
             return self.emptyPrinter(e)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2244,9 +2244,6 @@ class PrettyPrinter(Printer):
         if e.name.name == 'degree':
             pform = self._print(u"\N{DEGREE SIGN}")
             return pform
-        elif e.name.name == 'radian':
-            pform = self._print(' '*len('rad'))
-            return prettyForm(*pform.above(self._print('rad')))
         else:
             return self.emptyPrinter(e)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2236,7 +2236,7 @@ class PrettyPrinter(Printer):
         return pform
 
     def _print_Quantity(self, e):
-        if str(e) == 'degree':
+        if e.name.name == 'degree':
             pform = self._print(u"\N{DEGREE SIGN}")
             return pform
         else:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -33,10 +33,6 @@ from sympy.utilities import default_sort_key
 pprint_use_unicode = pretty_use_unicode
 pprint_try_use_unicode = pretty_try_use_unicode
 
-angular_quantity = [
-    'degree', 'radian'
-]
-
 
 class PrettyPrinter(Printer):
     """Printer, which converts an expression into 2D ASCII-art figure."""
@@ -1482,11 +1478,18 @@ class PrettyPrinter(Printer):
         else:
             args = list(product.args)
 
-        # If quantity is present append them at the back
+        # If quantities are present append them at the back
+        quantities_index = []
         for i in range(len(args)):
-            if isinstance(args[i], Quantity):
-                if args[i].name.name in angular_quantity:
-                    args.append(args[i])
+            if isinstance(args[i], Quantity) or (isinstance(args[i], Pow) and
+                                                isinstance(args[i].base, Quantity)):
+                args.append(args[i])
+                quantities_index.append(i)
+
+        if quantities_index != []:
+            for i in range(len(args)-1, -1, -1):
+                if quantities_index != [] and i == quantities_index[-1]:
+                    del quantities_index[-1]
                     del args[i]
 
         # Gather terms for numerator/denominator

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -33,6 +33,10 @@ from sympy.utilities import default_sort_key
 pprint_use_unicode = pretty_use_unicode
 pprint_try_use_unicode = pretty_try_use_unicode
 
+quantity = [
+    'degree'
+]
+
 
 class PrettyPrinter(Printer):
     """Printer, which converts an expression into 2D ASCII-art figure."""
@@ -1476,6 +1480,12 @@ class PrettyPrinter(Printer):
             args = product.as_ordered_factors()
         else:
             args = product.args
+
+        # If quantity is present append them at the back
+        for i in range(len(args)):
+            if str(args[i]) in quantity:
+                args.append(args[i])
+                del args[i]
 
         # Gather terms for numerator/denominator
         for item in args:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -33,8 +33,8 @@ from sympy.utilities import default_sort_key
 pprint_use_unicode = pretty_use_unicode
 pprint_try_use_unicode = pretty_try_use_unicode
 
-quantity = [
-    'degree'
+angular_quantity = [
+    'degree', 'radian'
 ]
 
 
@@ -1479,11 +1479,11 @@ class PrettyPrinter(Printer):
         if self.order not in ('old', 'none'):
             args = product.as_ordered_factors()
         else:
-            args = product.args
+            args = list(product.args)
 
         # If quantity is present append them at the back
         for i in range(len(args)):
-            if str(args[i]) in quantity:
+            if str(args[i]) in angular_quantity:
                 args.append(args[i])
                 del args[i]
 
@@ -2249,6 +2249,9 @@ class PrettyPrinter(Printer):
         if e.name.name == 'degree':
             pform = self._print(u"\N{DEGREE SIGN}")
             return pform
+        elif e.name.name == 'radian':
+            pform = self._print(u"\N{ZERO WIDTH NO-BREAK SPACE}")
+            return prettyForm(*pform.above(self._print('rad')))
         else:
             return self.emptyPrinter(e)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2235,6 +2235,13 @@ class PrettyPrinter(Printer):
             pform = prettyForm(*pform.left('Omega'))
         return pform
 
+    def _print_Quantity(self, e):
+        if str(e) == 'degree':
+            pform = self._print(u"\N{DEGREE SIGN}")
+            return pform
+        else:
+            return self.emptyPrinter(e)
+
 
 def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -431,8 +431,7 @@ class prettyForm(stringPict):
         Parentheses are needed around +, - and neg.
         """
         quantity = {
-            'degree': u"\N{DEGREE SIGN}",
-            'radian': u"rad"
+            'degree': u"\N{DEGREE SIGN}"
         }
 
         if len(others) == 0:

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -430,6 +430,10 @@ class prettyForm(stringPict):
         """Make a pretty multiplication.
         Parentheses are needed around +, - and neg.
         """
+        quantity = {
+            'degree': u"\N{DEGREE SIGN}"
+        }
+
         if len(others) == 0:
             return self # We aren't actually multiplying... So nothing to do here.
 
@@ -438,7 +442,8 @@ class prettyForm(stringPict):
             arg = stringPict(*args.parens())
         result = [args]
         for arg in others:
-            result.append(xsym('*'))
+            if arg.s not in quantity.values():
+                result.append(xsym('*'))
             #add parentheses for weak binders
             if arg.binding > prettyForm.MUL:
                 arg = stringPict(*arg.parens())

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -431,18 +431,18 @@ class prettyForm(stringPict):
         Parentheses are needed around +, - and neg.
         """
         quantity = {
-            'degree': u"\N{DEGREE SIGN}"
+            'degree': u"\N{DEGREE SIGN}",
+            'radian': u"rad"
         }
 
         if len(others) == 0:
             return self # We aren't actually multiplying... So nothing to do here.
-
         args = self
         if args.binding > prettyForm.MUL:
             arg = stringPict(*args.parens())
         result = [args]
         for arg in others:
-            if arg.s not in quantity.values():
+            if arg.picture[0] not in quantity.values():
                 result.append(xsym('*'))
             #add parentheses for weak binders
             if arg.binding > prettyForm.MUL:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -24,7 +24,7 @@ from sympy.matrices import Adjoint, Inverse, MatrixSymbol, Transpose
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
 
-from sympy.physics.units import joule, degree
+from sympy.physics.units import joule, degree, radian
 from sympy.tensor.array import (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
                                 MutableDenseNDimArray, MutableSparseNDimArray, tensorproduct)
 
@@ -5990,6 +5990,26 @@ def test_degree_printing():
     assert pretty(expr2) == u'x°'
     expr3 = cos(x*degree + 90*degree)
     assert pretty(expr3) == u'cos(x° + 90°)'
+
+
+def test_radian_printing():
+    space = u"\N{ZERO WIDTH NO-BREAK SPACE}"
+    ucode_str1 = \
+u('''\
+  rad\n\
+90 %s \
+''') % space
+
+    ucode_str2 = \
+u('''\
+ rad\n\
+x %s \
+''') % space
+
+    expr1 = 90*radian
+    assert pretty(expr1) == ucode_str1
+    expr2 = x*radian
+    assert pretty(expr2) == ucode_str2
 
 
 def test_vector_expr_pretty_printing():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4701,7 +4701,7 @@ k = ─────                                \n\
 
 def test_units():
     expr = joule
-    ascii_str = \
+    ascii_str1 = \
 """\
               2\n\
 kilogram*meter \n\
@@ -4709,7 +4709,7 @@ kilogram*meter \n\
           2    \n\
     second     \
 """
-    unicode_str = \
+    unicode_str1 = \
 u("""\
               2\n\
 kilogram⋅meter \n\
@@ -4717,12 +4717,31 @@ kilogram⋅meter \n\
           2    \n\
     second     \
 """)
+
+    ascii_str2 = \
+"""\
+                    2\n\
+3*x*y*kilogram*meter \n\
+---------------------\n\
+             2       \n\
+       second        \
+"""
+    unicode_str2 = \
+u("""\
+                    2\n\
+3⋅x⋅y⋅kilogram⋅meter \n\
+─────────────────────\n\
+             2       \n\
+       second        \
+""")
+
     from sympy.physics.units import kg, m, s
     assert upretty(expr) == u("joule")
     assert pretty(expr) == "joule"
-    assert upretty(expr.convert_to(kg*m**2/s**2)) == unicode_str
-    assert pretty(expr.convert_to(kg*m**2/s**2)) == ascii_str
-
+    assert upretty(expr.convert_to(kg*m**2/s**2)) == unicode_str1
+    assert pretty(expr.convert_to(kg*m**2/s**2)) == ascii_str1
+    assert upretty(3*kg*x*m**2*y/s**2) == unicode_str2
+    assert pretty(3*kg*x*m**2*y/s**2) == ascii_str2
 
 def test_pretty_Subs():
     f = Function('f')

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -24,7 +24,7 @@ from sympy.matrices import Adjoint, Inverse, MatrixSymbol, Transpose
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
 
-from sympy.physics.units import joule
+from sympy.physics.units import joule, degree
 from sympy.tensor.array import (ImmutableDenseNDimArray, ImmutableSparseNDimArray,
                                 MutableDenseNDimArray, MutableSparseNDimArray, tensorproduct)
 
@@ -5981,6 +5981,11 @@ def test_MatrixElement_printing():
     F = C[0, 0].subs(C, A - B)
     assert pretty(F)  == ascii_str1
     assert upretty(F) == ucode_str1
+
+
+def test_degree_printing():
+    deg = 90*degree
+    assert pretty(deg) == u'90°'
 
 
 def test_vector_expr_pretty_printing():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5993,18 +5993,17 @@ def test_degree_printing():
 
 
 def test_radian_printing():
-    space = u"\N{ZERO WIDTH NO-BREAK SPACE}"
     ucode_str1 = \
 u('''\
   rad\n\
-90 %s \
-''') % space
+90   \
+''')
 
     ucode_str2 = \
 u('''\
  rad\n\
-x %s \
-''') % space
+x   \
+''')
 
     expr1 = 90*radian
     assert pretty(expr1) == ucode_str1

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6011,25 +6011,6 @@ def test_degree_printing():
     assert pretty(expr3) == u'cos(x° + 90°)'
 
 
-def test_radian_printing():
-    ucode_str1 = \
-u('''\
-  rad\n\
-90   \
-''')
-
-    ucode_str2 = \
-u('''\
- rad\n\
-x   \
-''')
-
-    expr1 = 90*radian
-    assert pretty(expr1) == ucode_str1
-    expr2 = x*radian
-    assert pretty(expr2) == ucode_str2
-
-
 def test_vector_expr_pretty_printing():
     A = CoordSys3D('A')
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -5984,8 +5984,12 @@ def test_MatrixElement_printing():
 
 
 def test_degree_printing():
-    deg = 90*degree
-    assert pretty(deg) == u'90°'
+    expr1 = 90*degree
+    assert pretty(expr1) == u'90°'
+    expr2 = x*degree
+    assert pretty(expr2) == u'x°'
+    expr3 = cos(x*degree + 90*degree)
+    assert pretty(expr3) == u'cos(x° + 90°)'
 
 
 def test_vector_expr_pretty_printing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1699,12 +1699,3 @@ def test_latex_degree():
     assert latex(expr2) == r"x ^\circ"
     expr3 = cos(x*degree + 90*degree)
     assert latex(expr3) == r'\cos{\left (x ^\circ + 90 ^\circ \right )}'
-
-
-def test_latex_radian():
-    expr1 = 90*radian
-    assert latex(expr1) == r"90 ^rad"
-    expr2 = x*radian
-    assert latex(expr2) == r"x ^rad"
-    expr3 = cos(x*radian + 90*radian)
-    assert latex(expr3) == r'\cos{\left (x ^rad + 90 ^rad \right )}'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -32,7 +32,7 @@ from sympy.functions import DiracDelta, Heaviside, KroneckerDelta, LeviCivita
 from sympy.logic import Implies
 from sympy.logic.boolalg import And, Or, Xor
 from sympy.physics.quantum import Commutator, Operator
-from sympy.physics.units import degree
+from sympy.physics.units import degree, radian
 from sympy.core.trace import Tr
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
@@ -1694,3 +1694,12 @@ def test_latex_degree():
     assert latex(expr2) == r"x ^\circ"
     expr3 = cos(x*degree + 90*degree)
     assert latex(expr3) == r'\cos{\left (x ^\circ + 90 ^\circ \right )}'
+
+
+def test_latex_radian():
+    expr1 = 90*radian
+    assert latex(expr1) == r"90 ^rad"
+    expr2 = x*radian
+    assert latex(expr2) == r"x ^rad"
+    expr3 = cos(x*radian + 90*radian)
+    assert latex(expr3) == r'\cos{\left (x ^rad + 90 ^rad \right )}'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -32,6 +32,7 @@ from sympy.functions import DiracDelta, Heaviside, KroneckerDelta, LeviCivita
 from sympy.logic import Implies
 from sympy.logic.boolalg import And, Or, Xor
 from sympy.physics.quantum import Commutator, Operator
+from sympy.physics.units import degree
 from sympy.core.trace import Tr
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
@@ -1684,3 +1685,8 @@ def test_WedgeProduct_printing():
     from sympy.diffgeom import WedgeProduct
     wp = WedgeProduct(R2.dx, R2.dy)
     assert latex(wp) == r"\mathrm{d}x \wedge \mathrm{d}y"
+
+
+def test_latex_degree():
+    deg = 90*degree
+    assert latex(deg) == r"90 ^\circ"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -32,7 +32,7 @@ from sympy.functions import DiracDelta, Heaviside, KroneckerDelta, LeviCivita
 from sympy.logic import Implies
 from sympy.logic.boolalg import And, Or, Xor
 from sympy.physics.quantum import Commutator, Operator
-from sympy.physics.units import degree, radian
+from sympy.physics.units import degree, radian, kg, meter
 from sympy.core.trace import Tr
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
@@ -1685,6 +1685,11 @@ def test_WedgeProduct_printing():
     from sympy.diffgeom import WedgeProduct
     wp = WedgeProduct(R2.dx, R2.dy)
     assert latex(wp) == r"\mathrm{d}x \wedge \mathrm{d}y"
+
+
+def test_units():
+    expr = 2*kg*x*meter**2
+    assert latex(expr, mul_symbol='dot') == r'2 \cdot x \cdot kilogram \cdot meter^{2}'
 
 
 def test_latex_degree():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1688,5 +1688,9 @@ def test_WedgeProduct_printing():
 
 
 def test_latex_degree():
-    deg = 90*degree
-    assert latex(deg) == r"90 ^\circ"
+    expr1 = 90*degree
+    assert latex(expr1) == r"90 ^\circ"
+    expr2 = x*degree
+    assert latex(expr2) == r"x ^\circ"
+    expr3 = cos(x*degree + 90*degree)
+    assert latex(expr3) == r'\cos{\left (x ^\circ + 90 ^\circ \right )}'


### PR DESCRIPTION
Added a function `_print_Quantity` that allows latex printing of degree and radian.
```
>>> latex(90*degree)
r"90 ^\circ"
```
Also made changes so that quantities print at the end of a expression.
```
>>> expr = 2*kg*x*meter**2
>>> latex(expr, mul_symbol='dot')
2 \cdot x \cdot kilogram \cdot meter^{2}
```
#### References to other Issues or PRs
Fixes #12874
