### PR TITLE
Correct the docstring of as_independent method of expressions

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1550,7 +1550,8 @@ class Expr(Basic, EvalfMixin):
         following interpretation:
 
         * i will has no variable that appears in deps
-        * d will be 1 or else have terms that contain variables that are in deps
+        * d will either have terms that contain variables that are in deps, or
+          be equal to 0 (when self is an Add) or 1 (when self is a Mul)
         * if self is an Add then self = i + d
         * if self is a Mul then self = i*d
         * otherwise (self, S.One) or (S.One, self) is returned.


### PR DESCRIPTION
The docstring claims that the second part of the tuple returned by `as_independent(self, *deps, **hint)`

> will be 1 or else have terms that contain variables that are in deps. 

This is only true if self is a Mul. For an Add in the same situation the second term will be 0 rather than 1.

For example, `(x+y).as_independent(z)` returns `(x + y, 0)` as it should, since the expression is separated as (x+y) + 0.   

I changed the docstring to reflect the actual behavior. 

**Add entry(ies) to the release notes?** No

