### PR TITLE
Improve the solver for linear 1st order ODE systems of size 2

### DIFF
--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 
 from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
-    Dummy, Eq, erf, erfi, exp, Function, I, Integral, LambertW, log, O, pi,
+    Dummy, Eq, Ne, erf, erfi, exp, Function, I, Integral, LambertW, log, O, pi,
     Rational, rootof, S, simplify, sin, sqrt, Subs, Symbol, tan, asin, sinh,
     Piecewise, symbols, Poly)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
@@ -32,53 +32,87 @@ def test_linear_2eq_order1():
     t = Symbol('t')
     x0, y0 = symbols('x0, y0')
     eq1 = (Eq(diff(x(t),t), 9*y(t)), Eq(diff(y(t),t), 12*x(t)))
-    sol1 = [Eq(x(t), 9*C1*exp(-6*sqrt(3)*t) + 9*C2*exp(6*sqrt(3)*t)), \
-    Eq(y(t), -6*sqrt(3)*C1*exp(-6*sqrt(3)*t) + 6*sqrt(3)*C2*exp(6*sqrt(3)*t))]
-    assert dsolve(eq1) == sol1
+    sol1 = [Eq(x(t), 9*C1*exp(6*sqrt(3)*t) + 9*C2*exp(-6*sqrt(3)*t)), \
+    Eq(y(t), 6*sqrt(3)*C1*exp(6*sqrt(3)*t) - 6*sqrt(3)*C2*exp(-6*sqrt(3)*t))]
+    s = dsolve(eq1)
+    assert s == sol1
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq1[0].subs(s).doit().simplify()
+    assert eq1[1].subs(s).doit().simplify()
 
     eq2 = (Eq(diff(x(t),t), 2*x(t) + 4*y(t)), Eq(diff(y(t),t), 12*x(t) + 41*y(t)))
-    sol2 = [Eq(x(t), 4*C1*exp(t*(-sqrt(1713)/2 + 43/2)) + 4*C2*exp(t*(sqrt(1713)/2 + 43/2))), \
-    Eq(y(t), C1*(-sqrt(1713)/2 + 39/2)*exp(t*(-sqrt(1713)/2 + 43/2)) + C2*(39/2 + \
-    sqrt(1713)/2)*exp(t*(sqrt(1713)/2 + 43/2)))]
-    assert dsolve(eq2) == sol2
+    sol2 = [Eq(x(t), 4*C1*exp(t*(sqrt(1713)/2 + 43/2)) + 4*C2*exp(t*(-sqrt(1713)/2 + 43/2))), \
+    Eq(y(t), C1*(39/2 + sqrt(1713)/2)*exp(t*(sqrt(1713)/2 + 43/2)) + \
+    C2*(-sqrt(1713)/2 + 39/2)*exp(t*(-sqrt(1713)/2 + 43/2)))]
+    s = dsolve(eq2)
+    assert s == sol2
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq2[0].subs(s).doit().simplify()
+    assert eq2[1].subs(s).doit().simplify()
 
     eq3 = (Eq(diff(x(t),t), x(t) + y(t)), Eq(diff(y(t),t), -2*x(t) + 2*y(t)))
-    sol3 = [Eq(x(t), (C1*sin(sqrt(7)*t/2) + C2*cos(sqrt(7)*t/2))*exp(3*t/2)), \
-    Eq(y(t), ((C1/2 - sqrt(7)*C2/2)*sin(sqrt(7)*t/2) + (sqrt(7)*C1/2 + C2/2)*cos(sqrt(7)*t/2))*exp(3*t/2))]
-    assert dsolve(eq3) == sol3
+    sol3 = [Eq(x(t), (C1*cos(sqrt(7)*t/2) + C2*sin(sqrt(7)*t/2))*exp(3*t/2)), \
+    Eq(y(t), (C1*(-sqrt(7)*sin(sqrt(7)*t/2)/2 + cos(sqrt(7)*t/2)/2) + \
+    C2*(sin(sqrt(7)*t/2)/2 + sqrt(7)*cos(sqrt(7)*t/2)/2))*exp(3*t/2))]
+    s = dsolve(eq3)
+    assert s == sol3
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq3[0].subs(s).doit().simplify()
+    assert eq3[1].subs(s).doit().simplify()
 
     eq4 = (Eq(diff(x(t),t), x(t) + y(t) + 9), Eq(diff(y(t),t), 2*x(t) + 5*y(t) + 23))
-    sol4 = [Eq(x(t), C1*exp(t*(-sqrt(6) + 3)) + C2*exp(t*(sqrt(6) + 3)) - S(22)/3), \
-    Eq(y(t), C1*(-sqrt(6) + 2)*exp(t*(-sqrt(6) + 3)) + C2*(2 + sqrt(6))*exp(t*(sqrt(6) + 3)) - S(5)/3)]
-    assert dsolve(eq4) == sol4
+    sol4 = [Eq(x(t), C1*exp(t*(sqrt(6) + 3)) + C2*exp(t*(-sqrt(6) + 3)) - S(22)/3), \
+    Eq(y(t), C1*(2 + sqrt(6))*exp(t*(sqrt(6) + 3)) + C2*(-sqrt(6) + 2)*exp(t*(-sqrt(6) + 3)) - S(5)/3)]
+    s = dsolve(eq4)
+    assert s == sol4
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq4[0].subs(s).doit().simplify()
+    assert eq4[1].subs(s).doit().simplify()
 
     eq5 = (Eq(diff(x(t),t), x(t) + y(t) + 81), Eq(diff(y(t),t), -2*x(t) + y(t) + 23))
-    sol5 = [Eq(x(t), (C1*sin(sqrt(2)*t) + C2*cos(sqrt(2)*t))*exp(t) - S(58)/3), \
-    Eq(y(t), (sqrt(2)*C1*cos(sqrt(2)*t) - sqrt(2)*C2*sin(sqrt(2)*t))*exp(t) - S(185)/3)]
-    assert dsolve(eq5) == sol5
+    sol5 = [Eq(x(t), (C1*cos(sqrt(2)*t) + C2*sin(sqrt(2)*t))*exp(t) - S(58)/3), \
+    Eq(y(t), (-sqrt(2)*C1*sin(sqrt(2)*t) + sqrt(2)*C2*cos(sqrt(2)*t))*exp(t) - S(185)/3)]
+    s = dsolve(eq5)
+    assert s == sol5
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq5[0].subs(s).doit().simplify()
+    assert eq5[1].subs(s).doit().simplify()
 
     eq6 = (Eq(diff(x(t),t), 5*t*x(t) + 2*y(t)), Eq(diff(y(t),t), 2*x(t) + 5*t*y(t)))
     sol6 = [Eq(x(t), (C1*exp(Integral(2, t)) + C2*exp(-Integral(2, t)))*exp(Integral(5*t, t))), \
     Eq(y(t), (C1*exp(Integral(2, t)) - C2*exp(-Integral(2, t)))*exp(Integral(5*t, t)))]
-    assert dsolve(eq6) == sol6
+    s = dsolve(eq6)
+    assert s == sol6
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq6[0].subs(s).doit().simplify()
+    assert eq6[1].subs(s).doit().simplify()
 
     eq7 = (Eq(diff(x(t),t), 5*t*x(t) + t**2*y(t)), Eq(diff(y(t),t), -t**2*x(t) + 5*t*y(t)))
     sol7 = [Eq(x(t), (C1*cos(Integral(t**2, t)) + C2*sin(Integral(t**2, t)))*exp(Integral(5*t, t))), \
     Eq(y(t), (-C1*sin(Integral(t**2, t)) + C2*cos(Integral(t**2, t)))*exp(Integral(5*t, t)))]
-    assert dsolve(eq7) == sol7
+    s = dsolve(eq7)
+    assert s == sol7
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq7[0].subs(s).doit().simplify()
+    assert eq7[1].subs(s).doit().simplify()
 
     eq8 = (Eq(diff(x(t),t), 5*t*x(t) + t**2*y(t)), Eq(diff(y(t),t), -t**2*x(t) + (5*t+9*t**2)*y(t)))
-    sol8 = [Eq(x(t), (C1*exp((-sqrt(77)/2 + 9/2)*Integral(t**2, t)) + \
-    C2*exp((sqrt(77)/2 + 9/2)*Integral(t**2, t)))*exp(Integral(5*t, t))), \
-    Eq(y(t), (C1*(-sqrt(77)/2 + 9/2)*exp((-sqrt(77)/2 + 9/2)*Integral(t**2, t)) + \
-    C2*(sqrt(77)/2 + 9/2)*exp((sqrt(77)/2 + 9/2)*Integral(t**2, t)))*exp(Integral(5*t, t)))]
-    assert dsolve(eq8) == sol8
+    sol8 = [Eq(x(t), (C1*exp((sqrt(77)/2 + 9/2)*Integral(t**2, t)) + \
+    C2*exp((-sqrt(77)/2 + 9/2)*Integral(t**2, t)))*exp(Integral(5*t, t))), \
+    Eq(y(t), (C1*(sqrt(77)/2 + 9/2)*exp((sqrt(77)/2 + 9/2)*Integral(t**2, t)) + \
+    C2*(-sqrt(77)/2 + 9/2)*exp((-sqrt(77)/2 + 9/2)*Integral(t**2, t)))*exp(Integral(5*t, t)))]
+    s = dsolve(eq8)
+    assert s == sol8
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq8[0].subs(s).doit().simplify()
+    assert eq8[1].subs(s).doit().simplify()
 
     eq10 = (Eq(diff(x(t),t), 5*t*x(t) + t**2*y(t)), Eq(diff(y(t),t), (1-t**2)*x(t) + (5*t+9*t**2)*y(t)))
     sol10 = [Eq(x(t), C1*x0 + C2*x0*Integral(t**2*exp(Integral(5*t, t))*exp(Integral(9*t**2 + 5*t, t))/x0**2, t)), \
     Eq(y(t), C1*y0 + C2(y0*Integral(t**2*exp(Integral(5*t, t))*exp(Integral(9*t**2 + 5*t, t))/x0**2, t) + \
     exp(Integral(5*t, t))*exp(Integral(9*t**2 + 5*t, t))/x0))]
-    assert dsolve(eq10) == sol10
+    s = dsolve(eq10)
+    assert s == sol10   # too complicated to test with subs and simplify
 
 
 def test_linear_2eq_order1_nonhomog_linear():
@@ -97,7 +131,7 @@ def test_linear_2eq_order1_nonhomog():
 def test_linear_2eq_order1_type2_degen():
     e = [Eq(diff(f(x), x), f(x) + 5),
          Eq(diff(g(x), x), f(x) + 7)]
-    s1 = [Eq(f(x), C2*exp(x) - 5), Eq(g(x), C2*exp(x) - C1 + 2*x - 5)]
+    s1 = [Eq(f(x), C1*exp(x) - 5), Eq(g(x), C1*exp(x) - C2 + 2*x - 5)]
     s = dsolve(e)
     assert s == s1
     s = [(l.lhs, l.rhs) for l in s]
@@ -108,7 +142,7 @@ def test_linear_2eq_order1_type2_degen():
 def test_dsolve_linear_2eq_order1_diag_triangular():
     e = [Eq(diff(f(x), x), f(x)),
          Eq(diff(g(x), x), g(x))]
-    s1 = [Eq(f(x), C2*exp(x)), Eq(g(x), C1*exp(x))]
+    s1 = [Eq(f(x), C1*exp(x)), Eq(g(x), C2*exp(x))]
     s = dsolve(e)
     assert s == s1
     s = [(l.lhs, l.rhs) for l in s]
@@ -117,8 +151,8 @@ def test_dsolve_linear_2eq_order1_diag_triangular():
 
     e = [Eq(diff(f(x), x), 2*f(x)),
          Eq(diff(g(x), x), 3*f(x) + 7*g(x))]
-    s1 = [Eq(f(x), -5*C1*exp(2*x)),
-          Eq(g(x), 3*C1*exp(2*x) + 8*C2*exp(7*x))];
+    s1 = [Eq(f(x), -5*C2*exp(2*x)),
+          Eq(g(x), 5*C1*exp(7*x) + 3*C2*exp(2*x))]
     s = dsolve(e)
     assert s == s1
     s = [(l.lhs, l.rhs) for l in s]
@@ -126,27 +160,81 @@ def test_dsolve_linear_2eq_order1_diag_triangular():
     assert e[1].subs(s).doit()
 
 
-@XFAIL
 def test_sysode_linear_2eq_order1_type1_D_lt_0():
     e = [Eq(diff(f(x), x), -9*I*f(x) - 4*g(x)),
          Eq(diff(g(x), x), -4*I*g(x))]
+    s1 = [Eq(f(x), -4*C1*exp(-4*I*x) - 4*C2*exp(-9*I*x)), \
+    Eq(g(x), 5*I*C1*exp(-4*I*x))]
     s = dsolve(e)
     s = [(l.lhs, l.rhs) for l in s]
-    # bit of a hassle to get these to clean up
-    assert (e[0].lhs - e[0].rhs).subs(s).doit().simplify().doit() == 0
-    assert (e[1].lhs - e[1].rhs).subs(s).doit().simplify().doit() == 0
+    assert e[0].subs(s).doit().simplify()
+    assert e[1].subs(s).doit().simplify()
 
 
-@XFAIL
 def test_sysode_linear_2eq_order1_type1_D_lt_0_b_eq_0():
     e = [Eq(diff(f(x), x), -9*I*f(x)),
          Eq(diff(g(x), x), -4*I*g(x))]
-    s1 = [Eq(f(x), C1*exp(-9*I*x)), Eq(g(x), C2*exp(-4*I*x))]
+    s1 = [Eq(f(x), -5*I*C2*exp(-9*I*x)), Eq(g(x), 5*I*C1*exp(-4*I*x))]
     s = dsolve(e)
     assert s == s1
     s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
+    assert e[0].subs(s).doit().simplify()
+    assert e[1].subs(s).doit().simplify()
+
+
+def test_sysode_linear_2eq_order1_many_zeros():
+    t = Symbol('t')
+    corner_cases = [(0, 0, 0, 0), (1, 0, 0, 0), (0, 1, 0, 0),
+                    (0, 0, 1, 0), (0, 0, 0, 1), (1, 0, 0, I),
+                    (I, 0, 0, -I), (0, I, 0, 0), (0, I, I, 0)]
+    s1 = [[Eq(f(t), C1), Eq(g(t), C2)],
+          [Eq(f(t), C1*exp(t)), Eq(g(t), -C2)],
+          [Eq(f(t), C1 + C2*t), Eq(g(t), C2)],
+          [Eq(f(t), C2), Eq(g(t), C1 + C2*t)],
+          [Eq(f(t), -C2), Eq(g(t), C1*exp(t))],
+          [Eq(f(t), C1*(1 - I)*exp(t)), Eq(g(t), C2*(-1 + I)*exp(I*t))],
+          [Eq(f(t), 2*I*C1*exp(I*t)), Eq(g(t), -2*I*C2*exp(-I*t))],
+          [Eq(f(t), I*C1 + I*C2*t), Eq(g(t), C2)],
+          [Eq(f(t), I*C1*exp(I*t) + I*C2*exp(-I*t)), \
+           Eq(g(t), I*C1*exp(I*t) - I*C2*exp(-I*t))]
+         ]
+    for r, sol in zip(corner_cases, s1):
+        eq = [Eq(diff(f(t), t), r[0]*f(t) + r[1]*g(t)),
+              Eq(diff(g(t), t), r[2]*f(t) + r[3]*g(t))]
+        s = dsolve(eq)
+        assert s == sol
+        s = [(l.lhs, l.rhs) for l in s]
+        assert eq[0].subs(s).doit().simplify()
+        assert eq[1].subs(s).doit().simplify()
+
+
+def test_dsolve_linsystem_symbol_piecewise():
+    u = Symbol('u')
+    eq = (Eq(diff(f(x), x), f(x) + g(x)),
+           Eq(diff(g(x), x), u*f(x)))
+    s1 = [Eq(f(x), Piecewise((C1*exp(x*(sqrt(4*u + 1)/2 + 1/2)) + \
+          C2*exp(x*(-sqrt(4*u + 1)/2 + 1/2)), Ne(4*u + 1, 0)), \
+          ((C1 + C2*(x + 1/(-sqrt(4*u + 1)/2 + 1/2)))*exp(x*(sqrt(4*u + 1)/2 \
+          + 1/2)), True))), Eq(g(x), Piecewise((C1*(sqrt(4*u + 1)/2 - 1/2) * \
+          exp(x*(sqrt(4*u + 1)/2 + 1/2)) + C2*(-sqrt(4*u + 1)/2 - 1/2) * \
+          exp(x*(-sqrt(4*u + 1)/2 + 1/2)), Ne(4*u + 1, 0)), \
+          ((C1*(sqrt(4*u + 1)/2 - 1/2) + C2*x*(sqrt(4*u + 1)/2 - 1/2)) * \
+          exp(x*(sqrt(4*u + 1)/2 + 1/2)), True)))]
+    s = dsolve(eq)
+    assert s == s1
+    s = [(l.lhs, l.rhs) for l in s]
+    for v in [0, 7, -42, 5*I, 3 + 4*I]:
+        assert eq[0].subs(s).subs(u, v).doit().simplify()
+        assert eq[1].subs(s).subs(u, v).doit().simplify()
+
+    # example from https://groups.google.com/d/msg/sympy/xmzoqW6tWaE/sf0bgQrlCgAJ
+    i, r1, c1, r2, c2, t = symbols('i, r1, c1, r2, c2, t')
+    x1 = Function('x1')
+    x2 = Function('x2')
+    eq1 = r1*c1*Derivative(x1(t), t) + x1(t) - x2(t) - r1*i
+    eq2 = r2*c1*Derivative(x1(t), t) + r2*c2*Derivative(x2(t), t) + x2(t) - r2*i
+    sol = dsolve((eq1, eq2))
+    # no assertion (it's a complicated Piecewise), but this was previously a TypeError
 
 
 def test_linear_2eq_order2():
@@ -2817,27 +2905,40 @@ def test_issue_7093():
 def test_dsolve_linsystem_symbol():
     eps = Symbol('epsilon', positive=True)
     eq1 = (Eq(diff(f(x), x), -eps*g(x)), Eq(diff(g(x), x), eps*f(x)))
-    sol1 = [Eq(f(x), -eps*(C1*sin(eps*x) + C2*cos(eps*x))),
-            Eq(g(x), C1*eps*cos(eps*x) - C2*eps*sin(eps*x))]
-    assert dsolve(eq1) == sol1
+    sol1 = [Eq(f(x), -C1*eps*cos(eps*x) - C2*eps*sin(eps*x)),
+            Eq(g(x), -C1*eps*sin(eps*x) + C2*eps*cos(eps*x))]
+    s = dsolve(eq1)
+    assert s == sol1
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq1[0].subs(s).doit().simplify()
+    assert eq1[1].subs(s).doit().simplify()
+
 
 def test_C1_function_9239():
     t = Symbol('t')
-    eq = (Eq(diff(C1(t),t), 9*C2(t)), Eq(diff(C2(t),t), 12*C1(t)))
-    sol = [Eq(C1(t), 9*C1*exp(-6*sqrt(3)*t) + 9*C2*exp(6*sqrt(3)*t)), \
-    Eq(C2(t), -6*sqrt(3)*C1*exp(-6*sqrt(3)*t) + 6*sqrt(3)*C2*exp(6*sqrt(3)*t))]
-    assert dsolve(eq) == sol
+    eq = (Eq(diff(C1(t), t), 9*C2(t)), Eq(diff(C2(t), t), 12*C1(t)))
+    sol = [Eq(C1(t), 9*C1*exp(6*sqrt(3)*t) + 9*C2*exp(-6*sqrt(3)*t)),
+           Eq(C2(t), 6*sqrt(3)*C1*exp(6*sqrt(3)*t) - 6*sqrt(3)*C2*exp(-6*sqrt(3)*t))]
+    s = dsolve(eq)
+    assert s == sol
+    s = [(l.lhs, l.rhs) for l in s]
+    assert eq[0].subs(s).doit().simplify()
+    assert eq[1].subs(s).doit().simplify()
+
 
 def test_issue_10379():
     t,y = symbols('t,y')
     sol =  dsolve(f(t).diff(t)-(1-51.05*y*f(t)), rational=False)
     ans =  Eq(f(t), (0.019588638589618*exp(y*(C1 - 51.05*t)) + 0.019588638589618)/y)
     assert str(sol) == str(ans)
+
+
 def test_issue_10867():
     x, g = symbols('x g')
     v = Eq(g(x).diff(x).diff(x), (x-2)**2 + (x-3)**3)
     ans = Eq(g(x), C1 + C2*x + x**5/20 - 2*x**4/3 + 23*x**3/6 - 23*x**2/2)
     assert dsolve(v, g(x)) == ans
+
 
 def test_issue_11290():
     sol_1 = dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x), f(x), simplify=False, hint='1st_exact_Integral')

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -210,16 +210,20 @@ def test_sysode_linear_2eq_order1_many_zeros():
 
 def test_dsolve_linsystem_symbol_piecewise():
     u = Symbol('u')
-    eq = (Eq(diff(f(x), x), f(x) + g(x)),
+    eq = (Eq(diff(f(x), x), 2*f(x) + g(x)),
            Eq(diff(g(x), x), u*f(x)))
-    s1 = [Eq(f(x), Piecewise((C1*exp(x*(sqrt(4*u + 1)/2 + 1/2)) + \
-          C2*exp(x*(-sqrt(4*u + 1)/2 + 1/2)), Ne(4*u + 1, 0)), \
-          ((C1 + C2*(x + 1/(-sqrt(4*u + 1)/2 + 1/2)))*exp(x*(sqrt(4*u + 1)/2 \
-          + 1/2)), True))), Eq(g(x), Piecewise((C1*(sqrt(4*u + 1)/2 - 1/2) * \
-          exp(x*(sqrt(4*u + 1)/2 + 1/2)) + C2*(-sqrt(4*u + 1)/2 - 1/2) * \
-          exp(x*(-sqrt(4*u + 1)/2 + 1/2)), Ne(4*u + 1, 0)), \
-          ((C1*(sqrt(4*u + 1)/2 - 1/2) + C2*x*(sqrt(4*u + 1)/2 - 1/2)) * \
-          exp(x*(sqrt(4*u + 1)/2 + 1/2)), True)))]
+    s1 = [
+        Eq(f(x), Piecewise((C1*exp(x*(sqrt(4*u + 4)/2 + 1))
+            + C2*exp(x*(-sqrt(4*u + 4)/2 + 1)), Ne(4*u + 4, 0)),
+            ((C1 + C2*(x + Piecewise((0, Eq(sqrt(4*u + 4)/2 + 1, 2)),
+            (1/(-sqrt(4*u + 4)/2 + 1), True))))*exp(x*(sqrt(4*u + 4)/2 + 1)),
+            True))),
+        Eq(g(x), Piecewise((C1*(sqrt(4*u + 4)/2 - 1)*exp(x*(sqrt(4*u + 4)/2 + 1))
+            + C2*(-sqrt(4*u + 4)/2 - 1)*exp(x*(-sqrt(4*u + 4)/2 + 1)),
+            Ne(4*u + 4, 0)), ((C1*(sqrt(4*u + 4)/2 - 1) + C2*(x*(sqrt(4*u + 4)/2 - 1)
+            + Piecewise((1, Eq(sqrt(4*u + 4)/2 + 1, 2)),
+            (0, True))))*exp(x*(sqrt(4*u + 4)/2 + 1)), True)))
+    ]
     s = dsolve(eq)
     assert s == s1
     s = [(l.lhs, l.rhs) for l in s]
@@ -234,7 +238,8 @@ def test_dsolve_linsystem_symbol_piecewise():
     eq1 = r1*c1*Derivative(x1(t), t) + x1(t) - x2(t) - r1*i
     eq2 = r2*c1*Derivative(x1(t), t) + r2*c2*Derivative(x2(t), t) + x2(t) - r2*i
     sol = dsolve((eq1, eq2))
-    # no assertion (it's a complicated Piecewise), but this was previously a TypeError
+    # it's a complicated formula, was previously a TypeError
+    assert all(s.has(Piecewise) for s in sol)
 
 
 def test_linear_2eq_order2():


### PR DESCRIPTION
This pull request improves the handling of linear ODE systems 
`x' = a*x + b*y`
`y' = c*x + d*y`
with constant coefficients, with particular attention to complex and symbolic coefficients, as well as to edge cases not previously covered.

#### References to other Issues or PRs

Some issues with the current implementation: 

1. [FIXME note](https://github.com/sympy/sympy/blob/master/sympy/solvers/ode.py#L6628) note says: "at least some of these can fail to give two linearly independent solutions e.g., because they make assumptions about zero/nonzero of certain coefficients. [...] this should probably just be re-written in terms of eigenvectors..." Indeed, the nested if statements are hard to track and their mathematical meaning is not always clear. 

2. The solver `_linear_2eq_order1_type1` tacitly assumes that the coefficients are real numbers when it computes the discriminant D and then proceeds with `if D > 0:` and so on. As a result, errors are thrown for complex coefficients and for symbolic coefficients. The latter was reported [on the mailing list](https://groups.google.com/forum/#!topic/sympy/xmzoqW6tWaE). Examples of the former include coefficient matrices such as `[[I, 0], [0, -I]]` and `[[0, 1], [I, 0]]`. 

3. If either a=b=0 or c=d=0 (so one of two functions has zero derivative), `dsolve` either returns [] or throws an error. 

A related older PR #11510 was also intended to improve `_linear_2eq_order1_type1` (and it would be an improvement indeed) but it still assumed that D can be compared with 0, hence it would have the same problem with complex or symbolic coefficients as the current master branch.

#### Brief description of what is fixed or changed

#### Major changes

1. The solver `_linear_2eq_order1_type1` is rewritten in terms of eigenvectors and generalized eigenvectors of the coefficient matrix. This allowed for streamlined logic; in particular, there is no need to handle the case when one of eigenvalues is zero as something special. Comments are added to explain the mathematical meaning of formulas.

2. When the solver cannot determine whether the solution should be in exponential, trigonometric, or polynomial-exponential form, it returns a Piecewise solution instead of throwing an error. 

#### Minor changes

3. The linearity check of `classify_sysode` method now gives the hint `as_Add=True` to the  method `as_independent`. The absence of this hint was responsible for incorrect classification of ODEs with a=b=0 or c=d=0. E.g., `Derivative(x(t), t).as_independent(y(t))` returns 
`(Derivative(x(t), t), 1)` and the method assumed that 1 was the coefficient of y(t) in the equation. Now, with `Derivative(x(t), t).as_independent(y(t), as_Add=True)`, the coefficient is correctly identified as 0. 

4. New tests are added. Two tests previously marked XFAIL, with complex coefficient matrices, now pass and so XFAIL is removed.

5. As noted in test_ode.py, "in differently formatted solutions, the arbitrary constants might not be equal." The refactoring of `_linear_2eq_order1_type1` solver resulted in superficially different solutions: for example, a solution that was previously given as
```
[Eq(f(x), C2*exp(x) - 5), Eq(g(x), -C1 + C2*exp(x) + 2*x - 5)]
```
is now 
```
[Eq(f(x), C1*exp(x) - 5), Eq(g(x), C1*exp(x) - C2 + 2*x - 5)]
```
In my opinion, this is a slight improvement in that C1 naturally goes with the 1st function. In any case, tests had to be adjusted for this discrepancy. I checked that these changes were indeed cosmetic; the solution was essentially the same. To be extra sure, I added checks like `assert eq[0].subs(s).doit().simplify()` which were missing in places. These confirm that the solutions indeed solve the ODE system. 