### PR TITLE
Raise an error in Derivative when expr.free_symbols is not a set

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1102,8 +1102,17 @@ class Derivative(Expr):
         from sympy.matrices.common import MatrixCommon
         from sympy import Integer
         from sympy.tensor.array import Array, NDimArray, derive_by_array
+        from sympy.utilities.misc import filldedent
 
         expr = sympify(expr)
+        try:
+            has_symbol_set = isinstance(expr.free_symbols, set)
+        except AttributeError:
+            has_symbol_set = False
+        if not has_symbol_set:
+            raise ValueError(filldedent('''
+                Since there are no variables in the expression %s,
+                it cannot be differentiated.''' % expr))
 
         # There are no variables, we differentiate wrt all of the free symbols
         # in expr.
@@ -1112,7 +1121,6 @@ class Derivative(Expr):
             if len(variables) != 1:
                 if expr.is_number:
                     return S.Zero
-                from sympy.utilities.misc import filldedent
                 if len(variables) == 0:
                     raise ValueError(filldedent('''
                         Since there are no variables in the expression,
@@ -1168,7 +1176,6 @@ class Derivative(Expr):
                 if count == 0:
                     continue
                 if not v._diff_wrt:
-                    from sympy.utilities.misc import filldedent
                     last_digit = int(str(count)[-1])
                     ordinal = 'st' if last_digit == 1 else 'nd' if last_digit == 2 else 'rd' if last_digit == 3 else 'th'
                     raise ValueError(filldedent('''

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -81,6 +81,14 @@ def test_requires_partial():
     g = sum(f)
     assert requires_partial(Derivative(g, t)) is False
 
+    f = symbols('f', cls=Function)
+    assert requires_partial(Derivative(f(x), x)) is False
+    assert requires_partial(Derivative(f(x), y)) is False
+    assert requires_partial(Derivative(f(x, y), x)) is True
+    assert requires_partial(Derivative(f(x, y), y)) is True
+    assert requires_partial(Derivative(f(x, y), z)) is True
+    assert requires_partial(Derivative(f(x, y), x, y)) is True
+
 
 @XFAIL
 def test_requires_partial_unspecified_variables():

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -3,7 +3,7 @@ from sympy.functions.special.bessel import besselj
 from sympy.functions.special.polynomials import legendre
 from sympy.functions.combinatorial.numbers import bell
 from sympy.printing.conventions import split_super_sub, requires_partial
-
+from sympy.utilities.pytest import raises, XFAIL
 
 def test_super_sub():
     assert split_super_sub("beta_13_2") == ("beta", [], ["13", "2"])
@@ -81,6 +81,10 @@ def test_requires_partial():
     g = sum(f)
     assert requires_partial(Derivative(g, t)) is False
 
+
+@XFAIL
+def test_requires_partial_unspecified_variables():
+    x, y = symbols('x y')
     # function of unspecified variables
     f = symbols('f', cls=Function)
     assert requires_partial(Derivative(f, x)) is False


### PR DESCRIPTION
The __new__ method of `Derivative(expr, *symbols)` assumes that `expr.free_symbols` is a set without checking it. As a result, the user trying to construct the derivative of an undefined function is faced with uninformative TypeError messages shown below. A check and an informative message are added. Closes #13802. 

New SymPy users sometimes try to differentiate an undefined function f in order to express the concept of f'. ([A very recent example](https://stackoverflow.com/q/47998930)). It does not go well: 
```
from sympy import *
x = Symbol('x')
f = Function('f')
diff(f, x)          # TypeError: 'property' object is not iterable
diff(f)             # TypeError: object of type 'property' has no len()
Derivative(f, x)    # no error but the returned object is useless
```
To see how bad that last object is, try for example
```
Derivative(f, x).subs(f, sin(x)) # TypeError: _subs() missing 1 required positional argument: 'new'
Derivative(sin, x).doit() # TypeError: doit() missing 1 required positional argument: 'self'
```

#### Minor changes

All three examples given above will now raise 
> ValueError:
> Since there are no variables in the expression f, it cannot be differentiated.  

which will guide the user to put f(x) in place of f. 

There is a longstanding issue #4787 but this PR is independent of it; all that's changed here is that errors are raised with a custom message instead of being thrown later. Even if unknown functions become objects, it would still make sense to check if `free_symbols` is a set before treating it as such. Basic objects don't have this property, so even its existence is not guaranteed.