### PR TITLE
binomial(n,k) nonnegative for nonnegative integers n,k

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -907,3 +907,8 @@ class binomial(CombinatorialFunction):
             return True
         elif k.is_integer is False:
             return False
+
+    def _eval_is_nonnegative(self):
+        if self.args[0].is_integer and self.args[1].is_integer:
+            if self.args[0].is_nonnegative and self.args[1].is_nonnegative:
+                return True

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -281,6 +281,8 @@ def test_binomial():
     p = Symbol('p', positive=True)
     z = Symbol('z', zero=True)
     nt = Symbol('nt', integer=False)
+    a = Symbol('a', integer=True, nonnegative=True)
+    b = Symbol('b', integer=True, nonnegative=True)
 
     assert binomial(0, 0) == 1
     assert binomial(1, 1) == 1
@@ -320,6 +322,8 @@ def test_binomial():
     assert binomial(x, nt).is_integer is False
 
     assert binomial(gamma(25), 6) == 79232165267303928292058750056084441948572511312165380965440075720159859792344339983120618959044048198214221915637090855535036339620413440000
+
+    assert binomial(a, b).is_nonnegative is True
 
 def test_binomial_diff():
     n = Symbol('n', integer=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
This PR will fixes #13617 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Brief description of what is fixed or changed
binomial(n, k).is_nonnegative  for negative integers n,k return True
```
>>> n = Symbol('n', integer=True, nonnegative=True)
>>> k = Symbol('k', integer=True, nonnegative=True)
>>> binomial(n, k).is_nonnegative  
True
```


#### Other comments
