### PR TITLE
Correctly dispatch the printing of custom vs built-in functions

### DIFF
--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -366,11 +366,6 @@ class DiracDelta(Function):
                 rewrite(SingularityFunction) doesn't support
                 arguments with more that 1 variable.'''))
 
-
-    @staticmethod
-    def _latex_no_arg(printer):
-        return r'\delta'
-
     def _sage_(self):
         import sage.all as sage
         return sage.dirac_delta(self.args[0]._sage_())

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1969,20 +1969,6 @@ class Chi(TrigonometricIntegral):
         from sympy import exp_polar
         return -I*pi/2 - (E1(z) + E1(exp_polar(I*pi)*z))/2
 
-    def _latex(self, printer, exp=None):
-        if len(self.args) != 1:
-            raise ValueError("Arg length should be 1")
-        if exp:
-            return r'\operatorname{Chi}^{%s}{\left (%s \right )}' \
-                % (printer._print(exp), printer._print(self.args[0]))
-        else:
-            return r'\operatorname{Chi}{\left (%s \right )}' \
-                % printer._print(self.args[0])
-
-    @staticmethod
-    def _latex_no_arg(printer):
-        return r'\operatorname{Chi}'
-
     def _sage_(self):
         import sage.all as sage
         return sage.cosh_integral(self.args[0]._sage_())

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -184,19 +184,6 @@ class gamma(Function):
         t = self.args[0] - x0
         return (self.func(t + 1)/rf(self.args[0], -x0 + 1))._eval_nseries(x, n, logx)
 
-    def _latex(self, printer, exp=None):
-        if len(self.args) != 1:
-            raise ValueError("Args length should be 1")
-        aa = printer._print(self.args[0])
-        if exp:
-            return r'\Gamma^{%s}{\left(%s \right)}' % (printer._print(exp), aa)
-        else:
-            return r'\Gamma{\left(%s \right)}' % aa
-
-    @staticmethod
-    def _latex_no_arg(printer):
-        return r'\Gamma'
-
 
 ###############################################################################
 ################## LOWER and UPPER INCOMPLETE GAMMA FUNCTIONS #################
@@ -335,9 +322,6 @@ class lowergamma(Function):
             return self
         return self.rewrite(uppergamma).rewrite(expint)
 
-    @staticmethod
-    def _latex_no_arg(printer):
-        return r'\gamma'
 
 class uppergamma(Function):
     r"""

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -437,10 +437,6 @@ class KroneckerDelta(Function):
         else:
             return 0
 
-    @staticmethod
-    def _latex_no_arg(printer):
-        return r'\delta'
-
     @property
     def indices(self):
         return self.args[0:2]

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sympy import Derivative
-from sympy.core.function import UndefinedFunction
+from sympy.core.function import UndefinedFunction, AppliedUndef
 from sympy.core.symbol import Symbol
 from sympy.interactive.printing import init_printing
 from sympy.printing.conventions import split_super_sub
@@ -50,7 +50,8 @@ class VectorLatexPrinter(LatexPrinter):
         func = expr.func.__name__
         t = dynamicsymbols._t
 
-        if hasattr(self, '_print_' + func):
+        if hasattr(self, '_print_' + func) and \
+            not isinstance(type(expr), UndefinedFunction):
             return getattr(self, '_print_' + func)(expr, exp)
         elif isinstance(type(expr), UndefinedFunction) and (expr.args == (t,)):
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -782,7 +782,7 @@ class LatexPrinter(Printer):
 
     def _print_FunctionClass(self, expr):
         for cls in self._special_function_classes:
-            if issubclass(expr, cls):
+            if issubclass(expr, cls) and expr.__name__ == cls.__name__:
                 return self._special_function_classes[cls]
         return self._hprint_Function(str(expr))
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -779,10 +779,10 @@ class LatexPrinter(Printer):
                          beta: r'\operatorname{B}',
                          DiracDelta: r'\delta',
                          Chi: r'\operatorname{Chi}'}
-        if expr in special_cases:
-            return special_cases[expr]
-        else:
-            return self._hprint_Function(str(expr))
+        for cls in special_cases:
+            if issubclass(expr, cls):
+                return special_cases[cls]
+        return self._hprint_Function(str(expr))
 
     def _print_Lambda(self, expr):
         symbols, expr = expr.args

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -766,21 +766,24 @@ class LatexPrinter(Printer):
     def _print_UndefinedFunction(self, expr):
         return self._hprint_Function(str(expr))
 
-    def _print_FunctionClass(self, expr):
+    @property
+    def _special_function_classes(self):
         from sympy.functions.special.tensor_functions import KroneckerDelta
         from sympy.functions.special.gamma_functions import gamma, lowergamma
         from sympy.functions.special.beta_functions import beta
         from sympy.functions.special.delta_functions import DiracDelta
         from sympy.functions.special.error_functions import Chi
-        special_cases = {KroneckerDelta: r'\delta',
-                         gamma:  r'\Gamma',
-                         lowergamma: r'\gamma',
-                         beta: r'\operatorname{B}',
-                         DiracDelta: r'\delta',
-                         Chi: r'\operatorname{Chi}'}
-        for cls in special_cases:
+        return {KroneckerDelta: r'\delta',
+                gamma:  r'\Gamma',
+                lowergamma: r'\gamma',
+                beta: r'\operatorname{B}',
+                DiracDelta: r'\delta',
+                Chi: r'\operatorname{Chi}'}
+
+    def _print_FunctionClass(self, expr):
+        for cls in self._special_function_classes:
             if issubclass(expr, cls):
-                return special_cases[cls]
+                return self._special_function_classes[cls]
         return self._hprint_Function(str(expr))
 
     def _print_Lambda(self, expr):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -708,7 +708,6 @@ class LatexPrinter(Printer):
         '''
         func = expr.func.__name__
         if hasattr(self, '_print_' + func) and \
-            not isinstance(expr.func, AppliedUndef) and \
             not isinstance(expr.func, UndefinedFunction):
             return getattr(self, '_print_' + func)(expr, exp)
         else:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1216,24 +1216,27 @@ class PrettyPrinter(Printer):
 
         return pform
 
-    def _print_FunctionClass(self, expr):
+    @property
+    def _special_function_classes(self):
         from sympy.functions.special.tensor_functions import KroneckerDelta
         from sympy.functions.special.gamma_functions import gamma, lowergamma
         from sympy.functions.special.beta_functions import beta
         from sympy.functions.special.delta_functions import DiracDelta
         from sympy.functions.special.error_functions import Chi
-        special_cases = {KroneckerDelta: [greek_unicode['delta'], 'delta'],
-            gamma: [greek_unicode['Gamma'], 'Gamma'],
-            lowergamma: [greek_unicode['gamma'], 'gamma'],
-            beta: [greek_unicode['Beta'], 'B'],
-            DiracDelta: [greek_unicode['delta'], 'delta'],
-            Chi: ['Chi', 'Chi']}
-        for cls in special_cases:
+        return {KroneckerDelta: [greek_unicode['delta'], 'delta'],
+                gamma: [greek_unicode['Gamma'], 'Gamma'],
+                lowergamma: [greek_unicode['gamma'], 'gamma'],
+                beta: [greek_unicode['Beta'], 'B'],
+                DiracDelta: [greek_unicode['delta'], 'delta'],
+                Chi: ['Chi', 'Chi']}
+
+    def _print_FunctionClass(self, expr):
+        for cls in self._special_function_classes:
             if issubclass(expr, cls):
                 if self._use_unicode:
-                    return prettyForm(special_cases[cls][0])
+                    return prettyForm(self._special_function_classes[cls][0])
                 else:
-                    return prettyForm(special_cases[cls][1])
+                    return prettyForm(self._special_function_classes[cls][1])
         func_name = expr.__name__
         return prettyForm(pretty_symbol(func_name))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1232,7 +1232,7 @@ class PrettyPrinter(Printer):
 
     def _print_FunctionClass(self, expr):
         for cls in self._special_function_classes:
-            if issubclass(expr, cls):
+            if issubclass(expr, cls) and expr.__name__ == cls.__name__:
                 if self._use_unicode:
                     return prettyForm(self._special_function_classes[cls][0])
                 else:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1228,14 +1228,14 @@ class PrettyPrinter(Printer):
             beta: [greek_unicode['Beta'], 'B'],
             DiracDelta: [greek_unicode['delta'], 'delta'],
             Chi: ['Chi', 'Chi']}
-        if expr in special_cases:
-            if self._use_unicode:
-                return prettyForm(special_cases[expr][0])
-            else:
-                return prettyForm(special_cases[expr][1])
-        else:
-            func_name = expr.__name__
-            return prettyForm(pretty_symbol(func_name))
+        for cls in special_cases:
+            if issubclass(expr, cls):
+                if self._use_unicode:
+                    return prettyForm(special_cases[cls][0])
+                else:
+                    return prettyForm(special_cases[cls][1])
+        func_name = expr.__name__
+        return prettyForm(pretty_symbol(func_name))
 
     def _print_GeometryEntity(self, expr):
         # GeometryEntity is based on Tuple but should not print like a Tuple

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -13,7 +13,7 @@ from sympy.core.expr import UnevaluatedExpr
 from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
     Piecewise, Shi, Si, atan2, beta, binomial, catalan, ceiling, cos,
     euler, exp, expint, factorial, factorial2, floor, gamma, hyper, log,
-    lowergamma, meijerg, sin, sqrt, subfactorial, tan, uppergamma,
+    meijerg, sin, sqrt, subfactorial, tan, uppergamma,
     elliptic_k, elliptic_f, elliptic_e, elliptic_pi, DiracDelta)
 
 from sympy.codegen.ast import (Assignment, AddAugmentedAssignment,
@@ -37,6 +37,9 @@ from sympy.core.compatibility import range
 from sympy.vector import CoordSys3D, Gradient, Curl, Divergence, Dot, Cross
 from sympy.tensor.functions import TensorProduct
 
+import sympy as sym
+class lowergamma(sym.lowergamma):
+    pass   # testing notation inheritance by a subclass with same name
 
 a, b, c, d, x, y, z, k, n = symbols('a,b,c,d,x,y,z,k,n')
 f = Function("f")

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -11,8 +11,8 @@ from sympy import (
 from sympy.core.expr import UnevaluatedExpr
 
 from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
-    Piecewise, Shi, Si, atan2, binomial, catalan, ceiling, cos,
-    euler, exp, expint, factorial, factorial2, floor, hyper, log,
+    Piecewise, Shi, Si, atan2, beta, binomial, catalan, ceiling, cos,
+    euler, exp, expint, factorial, factorial2, floor, gamma, hyper, log,
     lowergamma, meijerg, sin, sqrt, subfactorial, tan, uppergamma,
     elliptic_k, elliptic_f, elliptic_e, elliptic_pi, DiracDelta)
 
@@ -4803,11 +4803,23 @@ u("""\
 
 
 def test_gammas():
-    from sympy import gamma
     assert upretty(lowergamma(x, y)) == u"γ(x, y)"
     assert upretty(uppergamma(x, y)) == u"Γ(x, y)"
     assert xpretty(gamma(x), use_unicode=True) == u'Γ(x)'
+    assert xpretty(gamma, use_unicode=True) == u'Γ'
     assert xpretty(symbols('gamma', cls=Function)(x), use_unicode=True) == u'γ(x)'
+    assert xpretty(symbols('gamma', cls=Function), use_unicode=True) == u'γ'
+
+
+def test_beta():
+    assert xpretty(beta(x,y), use_unicode=True) == u'Β(x, y)'
+    assert xpretty(beta(x,y), use_unicode=False) == u'B(x, y)'
+    assert xpretty(beta, use_unicode=True) == u'Β'
+    assert xpretty(beta, use_unicode=False) == u'B'
+    mybeta = Function('beta')
+    assert xpretty(mybeta(x), use_unicode=True) == u'β(x)'
+    assert xpretty(mybeta(x, y, z), use_unicode=False) == u'beta(x, y, z)'
+    assert xpretty(mybeta, use_unicode=True) == u'β'
 
 
 def test_SingularityFunction():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4822,12 +4822,12 @@ def test_beta():
     assert xpretty(mybeta, use_unicode=True) == u'β'
 
 
-# test that notation passes to subclasses if not overridden there
-def test_function_subclass():
-    class Subgamma(gamma):
+# test that notation passes to subclasses of the same name only
+def test_function_subclass_different_name():
+    class mygamma(gamma):
         pass
-    assert xpretty(Subgamma, use_unicode=True) == u'Γ'
-    assert xpretty(Subgamma(x), use_unicode=True) == u'Γ(x)'
+    assert xpretty(mygamma, use_unicode=True) == r"mygamma"
+    assert xpretty(mygamma(x), use_unicode=True) == r"mygamma(x)"
 
 
 def test_SingularityFunction():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4822,6 +4822,14 @@ def test_beta():
     assert xpretty(mybeta, use_unicode=True) == u'β'
 
 
+# test that notation passes to subclasses if not overridden there
+def test_function_subclass():
+    class Subgamma(gamma):
+        pass
+    assert xpretty(Subgamma, use_unicode=True) == u'Γ'
+    assert xpretty(Subgamma(x), use_unicode=True) == u'Γ(x)'
+
+
 def test_SingularityFunction():
     assert xpretty(SingularityFunction(x, 0, n), use_unicode=True) == (
 """\

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -258,9 +258,9 @@ class Printer(object):
             # Function('gamma') does not get dispatched to _print_gamma
             classes = type(expr).__mro__
             if AppliedUndef in classes:
-                classes = classes[1 + classes.index(AppliedUndef):]
+                classes = classes[classes.index(AppliedUndef):]
             if UndefinedFunction in classes:
-                classes = classes[1 + classes.index(UndefinedFunction):]
+                classes = classes[classes.index(UndefinedFunction):]
             for cls in classes:
                 printmethod = '_print_' + cls.__name__
                 if hasattr(self, printmethod):

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -175,6 +175,7 @@ from __future__ import print_function, division
 from sympy import Basic, Add
 
 from sympy.core.core import BasicMeta
+from sympy.core.function import AppliedUndef, UndefinedFunction
 
 from functools import cmp_to_key
 
@@ -253,7 +254,14 @@ class Printer(object):
 
             # See if the class of expr is known, or if one of its super
             # classes is known, and use that print function
-            for cls in type(expr).__mro__:
+            # Exception: ignore the subclasses of Undefined, so that, e.g.,
+            # Function('gamma') does not get dispatched to _print_gamma
+            classes = type(expr).__mro__
+            if AppliedUndef in classes:
+                classes = classes[1 + classes.index(AppliedUndef):]
+            if UndefinedFunction in classes:
+                classes = classes[1 + classes.index(UndefinedFunction):]
+            for cls in classes:
                 printmethod = '_print_' + cls.__name__
                 if hasattr(self, printmethod):
                     return getattr(self, printmethod)(expr, *args, **kwargs)

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -175,7 +175,7 @@ from __future__ import print_function, division
 from sympy import Basic, Add
 
 from sympy.core.core import BasicMeta
-from sympy.core.function import AppliedUndef, UndefinedFunction
+from sympy.core.function import AppliedUndef, UndefinedFunction, Function
 
 from functools import cmp_to_key
 
@@ -261,6 +261,13 @@ class Printer(object):
                 classes = classes[classes.index(AppliedUndef):]
             if UndefinedFunction in classes:
                 classes = classes[classes.index(UndefinedFunction):]
+            # Another exception: if someone subclasses a known function, e.g.,
+            # gamma, and changes the name, then ignore _print_gamma
+            if Function in classes:
+                i = classes.index(Function)
+                classes = tuple(c for c in classes[:i] if \
+                    c.__name__ == classes[0].__name__ or \
+                    c.__name__.endswith("Base")) + classes[i:]
             for cls in classes:
                 printmethod = '_print_' + cls.__name__
                 if hasattr(self, printmethod):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -7,7 +7,7 @@ from sympy import (
     Order, Piecewise, Poly, ring, field, ZZ, Pow, Product, Range, Rational,
     RisingFactorial, rootof, RootSum, S, Shi, Si, SineTransform, Subs,
     Sum, Symbol, ImageSet, Tuple, Union, Ynm, Znm, arg, asin, Mod,
-    assoc_laguerre, assoc_legendre, binomial, catalan, ceiling, Complement,
+    assoc_laguerre, assoc_legendre, beta, binomial, catalan, ceiling, Complement,
     chebyshevt, chebyshevu, conjugate, cot, coth, diff, dirichlet_eta, euler,
     exp, expint, factorial, factorial2, floor, gamma, gegenbauer, hermite,
     hyper, im, jacobi, laguerre, legendre, lerchphi, log, lowergamma,
@@ -257,11 +257,19 @@ def test_latex_functions():
     assert latex(Li) == r'\operatorname{Li}'
     assert latex(Li(x)) == r'\operatorname{Li}{\left (x \right )}'
 
-    beta = Function('beta')
-
+    mybeta = Function('beta')
     # not to be confused with the beta function
-    assert latex(beta(x)) == r"\beta{\left (x \right )}"
-    assert latex(beta) == r"\beta"
+    assert latex(mybeta(x, y, z)) == r"\beta{\left (x,y,z \right )}"
+    assert latex(beta(x, y)) == r'\operatorname{B}\left(x, y\right)'
+    assert latex(mybeta(x)) == r"\beta{\left (x \right )}"
+    assert latex(mybeta) == r"\beta"
+
+    g = Function('gamma')
+    # not to be confused with the gamma function
+    assert latex(g(x, y, z)) == r"\gamma{\left (x,y,z \right )}"
+    assert latex(g(x)) == r"\gamma{\left (x \right )}"
+    assert latex(g) == r"\gamma"
+
 
     a1 = Function('a_1')
 
@@ -314,9 +322,9 @@ def test_latex_functions():
     assert latex(re(x + y)) == r"\Re{\left(x\right)} + \Re{\left(y\right)}"
     assert latex(im(x)) == r"\Im{x}"
     assert latex(conjugate(x)) == r"\overline{x}"
-    assert latex(gamma(x)) == r"\Gamma{\left(x \right)}"
+    assert latex(gamma(x)) == r"\Gamma\left(x\right)"
     w = Wild('w')
-    assert latex(gamma(w)) == r"\Gamma{\left(w \right)}"
+    assert latex(gamma(w)) == r"\Gamma\left(w\right)"
     assert latex(Order(x)) == r"\mathcal{O}\left(x\right)"
     assert latex(Order(x, x)) == r"\mathcal{O}\left(x\right)"
     assert latex(Order(x, (x, 0))) == r"\mathcal{O}\left(x\right)"
@@ -368,9 +376,8 @@ def test_latex_functions():
     assert latex(Shi(x)**2) == r'\operatorname{Shi}^{2}{\left (x \right )}'
     assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left (x \right )}'
     assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left (x \right )}'
-    assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}{\left (x \right )}'
-    assert latex(Chi(x)) == r'\operatorname{Chi}{\left (x \right )}'
-
+    assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}\left(x\right)'
+    assert latex(Chi(x)) == r'\operatorname{Chi}\left(x\right)'
     assert latex(
         jacobi(n, a, b, x)) == r'P_{n}^{\left(a,b\right)}\left(x\right)'
     assert latex(jacobi(n, a, b, x)**2) == r'\left(P_{n}^{\left(a,b\right)}\left(x\right)\right)^{2}'
@@ -1564,6 +1571,7 @@ def test_builtin_without_args_mismatched_names():
 
 def test_builtin_no_args():
     assert latex(Chi) == r'\operatorname{Chi}'
+    assert latex(beta) == r'\operatorname{B}'
     assert latex(gamma) == r'\Gamma'
     assert latex(KroneckerDelta) == r'\delta'
     assert latex(DiracDelta) == r'\delta'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -10,7 +10,7 @@ from sympy import (
     assoc_laguerre, assoc_legendre, beta, binomial, catalan, ceiling, Complement,
     chebyshevt, chebyshevu, conjugate, cot, coth, diff, dirichlet_eta, euler,
     exp, expint, factorial, factorial2, floor, gamma, gegenbauer, hermite,
-    hyper, im, jacobi, laguerre, legendre, lerchphi, log, lowergamma,
+    hyper, im, jacobi, laguerre, legendre, lerchphi, log,
     meijerg, oo, polar_lift, polylog, re, root, sin, sqrt, symbols,
     uppergamma, zeta, subfactorial, totient, elliptic_k, elliptic_f,
     elliptic_e, elliptic_pi, cos, tan, Wild, true, false, Equivalent, Not,
@@ -18,7 +18,6 @@ from sympy import (
     SeqAdd, SeqMul, fourier_series, pi, ConditionSet, ComplexRegion, fps,
     AccumBounds, reduced_totient, primenu, primeomega, SingularityFunction,
      UnevaluatedExpr, Quaternion)
-
 
 from sympy.ntheory.factor_ import udivisor_sigma
 
@@ -38,6 +37,10 @@ from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
 from sympy import MatrixSymbol
 from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient
+
+import sympy as sym
+class lowergamma(sym.lowergamma):
+    pass   # testing notation inheritance by a subclass with same name
 
 x, y, z, t, a, b, c = symbols('x y z t a b c')
 k, m, n = symbols('k m n', integer=True)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -270,7 +270,6 @@ def test_latex_functions():
     assert latex(g(x)) == r"\gamma{\left (x \right )}"
     assert latex(g) == r"\gamma"
 
-
     a1 = Function('a_1')
 
     assert latex(a1) == r"\operatorname{a_{1}}"
@@ -449,6 +448,14 @@ def test_latex_functions():
     assert latex(fjlkd(x)) == r'\operatorname{fjlkd}{\left (x \right )}'
     # even when it is referred to without an argument
     assert latex(fjlkd) == r'\operatorname{fjlkd}'
+
+
+# test that notation passes to subclasses if not overridden there
+def test_function_subclass():
+    class Subgamma(gamma):
+        pass
+    assert latex(Subgamma) == r"\Gamma"
+    assert latex(Subgamma(x)) == r"\Gamma\left(x\right)"
 
 
 def test_hyper_printing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -450,12 +450,12 @@ def test_latex_functions():
     assert latex(fjlkd) == r'\operatorname{fjlkd}'
 
 
-# test that notation passes to subclasses if not overridden there
-def test_function_subclass():
-    class Subgamma(gamma):
+# test that notation passes to subclasses of the same name only
+def test_function_subclass_different_name():
+    class mygamma(gamma):
         pass
-    assert latex(Subgamma) == r"\Gamma"
-    assert latex(Subgamma(x)) == r"\Gamma\left(x\right)"
+    assert latex(mygamma) == r"\operatorname{mygamma}"
+    assert latex(mygamma(x)) == r"\operatorname{mygamma}{\left (x \right )}"
 
 
 def test_hyper_printing():

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -332,7 +332,7 @@ def Beta(name, alpha, beta):
      alpha - 1         beta - 1
     z         *(-z + 1)
     ---------------------------
-         beta(alpha, beta)
+           B(alpha, beta)
 
     >>> expand_func(simplify(E(X, meijerg=True)))
     alpha/(alpha + beta)
@@ -402,7 +402,7 @@ def BetaPrime(name, alpha, beta):
      alpha - 1        -alpha - beta
     z         *(z + 1)
     -------------------------------
-           beta(alpha, beta)
+             B(alpha, beta)
 
     References
     ==========
@@ -761,14 +761,14 @@ def Erlang(name, k, l):
      k  k - 1  -l*z
     l *z     *e
     ---------------
-        gamma(k)
+        Gamma(k)
 
     >>> C = cdf(X, meijerg=True)(z)
     >>> pprint(C, use_unicode=False)
     /   -2*I*pi*k
     |k*e         *lowergamma(k, l*z)
     |-------------------------------  for z >= 0
-    <          gamma(k + 1)
+    <          Gamma(k + 1)
     |
     |               0                 otherwise
     \
@@ -942,9 +942,9 @@ def FDistribution(name, d1, d2):
       2    /       d1            -d1 - d2
     d2  *\/  (d1*z)  *(d1*z + d2)
     --------------------------------------
-                      /d1  d2\
-                z*beta|--, --|
-                      \2   2 /
+                    /d1  d2\
+                 z*B|--, --|
+                    \2   2 /
 
     References
     ==========
@@ -1010,9 +1010,9 @@ def FisherZ(name, d1, d2):
         2    2  /    2*z     \           d1*z
     2*d1  *d2  *\d1*e    + d2/         *e
     -----------------------------------------
-                       /d1  d2\
-                   beta|--, --|
-                       \2   2 /
+                     /d1  d2\
+                    B|--, --|
+                     \2   2 /
 
     References
     ==========
@@ -1150,7 +1150,7 @@ def Gamma(name, k, theta):
          -k  k - 1  theta
     theta  *z     *e
     ---------------------
-           gamma(k)
+           Gamma(k)
 
     >>> C = cdf(X, meijerg=True)(z)
     >>> pprint(C, use_unicode=False)
@@ -1158,7 +1158,7 @@ def Gamma(name, k, theta):
     |k*lowergamma|k, -----|
     |            \   theta/
     <----------------------  for z >= 0
-    |     gamma(k + 1)
+    |     Gamma(k + 1)
     |
     \          0             otherwise
 
@@ -1239,7 +1239,7 @@ def GammaInverse(name, a, b):
      a  -a - 1   z
     b *z      *e
     ---------------
-       gamma(a)
+       Gamma(a)
 
     References
     ==========
@@ -1752,7 +1752,7 @@ def Nakagami(name, mu, omega):
         mu      -mu  2*mu - 1  omega
     2*mu  *omega   *z        *e
     ----------------------------------
-                gamma(mu)
+                Gamma(mu)
 
     >>> simplify(E(X, meijerg=True))
     sqrt(mu)*sqrt(omega)*gamma(mu + 1/2)/gamma(mu + 1)
@@ -1760,9 +1760,9 @@ def Nakagami(name, mu, omega):
     >>> V = simplify(variance(X, meijerg=True))
     >>> pprint(V, use_unicode=False)
                         2
-             omega*gamma (mu + 1/2)
+             omega*Gamma (mu + 1/2)
     omega - -----------------------
-            gamma(mu)*gamma(mu + 1)
+            Gamma(mu)*Gamma(mu + 1)
 
     References
     ==========
@@ -2256,17 +2256,17 @@ def StudentT(name, nu):
 
     >>> D = density(X)(z)
     >>> pprint(D, use_unicode=False)
-                nu   1
-              - -- - -
-                2    2
-      /     2\
-      |    z |
-      |1 + --|
-      \    nu/
-    --------------------
-      ____     /     nu\
-    \/ nu *beta|1/2, --|
-               \     2 /
+               nu   1
+             - -- - -
+               2    2
+     /     2\
+     |    z |
+     |1 + --|
+     \    nu/
+    -----------------
+      ____  /     nu\
+    \/ nu *B|1/2, --|
+            \     2 /
 
     References
     ==========

--- a/t.py
+++ b/t.py
@@ -1,0 +1,5 @@
+import sympy as sym
+x, g, K, m, t = sym.symbols('x, g, K, m, t', positive=True, real=True)
+dxx = sym.Eq(x(t).diff(t, 2), g - K/m*x(t).diff(t))
+ics = {x(0): 0, x(t).diff(t).subs(t, 0): 0}
+print(sym.dsolve(dxx, ics=ics))

--- a/t.py
+++ b/t.py
@@ -1,5 +1,0 @@
-import sympy as sym
-x, g, K, m, t = sym.symbols('x, g, K, m, t', positive=True, real=True)
-dxx = sym.Eq(x(t).diff(t, 2), g - K/m*x(t).diff(t))
-ics = {x(0): 0, x(t).diff(t).subs(t, 0): 0}
-print(sym.dsolve(dxx, ics=ics))


### PR DESCRIPTION
Undefined functions (whether applied or not) are not longer sent to custom `_print_foo` methods designed for printing built-in functions. Additionally, correct printing for beta function is added for both LaTeX and pretty print (this function incorrectly printed as lowercase beta, in all printers). The logic for LaTeX printing of un-applied built-in functions like gamma or DiracDelta is moved from assorted classes to LaTeX printer. The same logic is now applied to pretty printer as well. Fixes #2832.

#### Minor changes

#### Centralization of printing rules

Although it's been decided long ago that the LaTeX printing logic should be in LaTeX printer, some classes such as gamma function retained it. (As a result, the codebase had two functions responsible solely for LaTeX printing gamma). Now the methods `_latex` and `_latex_no_arg` are removed from the special functions module and their content is expressed in latex.py

#### All printers

The printer driver in printer.py uses `type(expr).__mro__` to locate an appropriate custom printer, trying the classes in order. Since for `Function('gamma')` the class 'gamma' precedes "UndefinedFunction" in the MRO list, this resulted in an incorrect dispatch responsible for #2832. Change: now, if the MRO list contains AppliedUndef or UndefinedFunction, their subclasses are ignored for printing purposes.

#### LaTeX printing

- The method `_print_Function` of LaTeX printer no longer sends undefined functions to custom print methods
- The method  `_print_FunctionClass` (for unapplied functions) has a dictionary of rules for Kronecker Delta, gamma, lowergamma, beta, DiracDelta, and Chi (the hyperbolic cosine integral), which were previously scattered among those classes.
- Added methods `_print_beta` and `_print_Chi` for beta function and hyperbolic cosine integral (applied versions). The correct symbol for [beta function](https://en.wikipedia.org/wiki/Beta_function) is uppercase Greek letter Beta, which unfortunately is absent in LaTeX. `\operatorname{B}` is used as an approximation to it.

#### Pretty Printing

- Added method `_print_FunctionClass` paralleling the LaTeX treatment of certain unapplied functions. Previously there was no such logic: for example, `pprint(gamma)` printed as "gamma" not as Γ.
- Added an optional keyword argument `func_name` to `_print_Function` method, so that some `_print_foo` methods could reduced to simply passing a suitable Unicode/non-Unicode name to this function. Besides shorter code, this improved the consistency of rendering: previously, the exponent 2 in `pprint(gamma(x)**2)` was positioned differently in Unicode and non-Unicode versions.
- Corrected the names of beta and gamma functions. Previously, gamma was printed as "gamma" instead of "Gamma" in non-Unicode mode. And beta was printed as "beta" instead of Greek letter Beta (Unicode) or Latin letter B (non-Unicode). Also, `_print_gamma` is simplified because it no longer receives incorrectly dispatched undefined functions.

#### Tests

New tests for beta and gamma are added. Some tests in crv_types.py were corrected because they had the incorrect notation for beta and gamma functions baked in.
