### PR TITLE
 Enable Piecewise plots by fixing a fallback in experimental_lambdify

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -211,7 +211,7 @@ class lambdify(object):
             elif isinstance(e, TypeError) and ('no ordering relation is'
                                                ' defined for complex numbers'
                                                in str(e) or 'unorderable '
-                                               'types' in str(e) or "'>' not "
+                                               'types' in str(e) or "not "
                                                "supported between instances of"
                                                in str(e)):
                 self.lambda_func = experimental_lambdify(self.args, self.expr,

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -78,8 +78,13 @@ def plot_and_save(name):
 
     raises(ValueError, lambda: plot(x, y))
 
-    p = plot(Piecewise((1, x > 0), (0, True)),(x,-1,1))
+    #Piecewise plots
+    p = plot(Piecewise((1, x > 0), (0, True)), (x, -1, 1))
     p.save(tmp_file('%s_plot_piecewise' % name))
+    p._backend.close()
+
+    p = plot(Piecewise((x, x < 1), (x**2, True)), (x, -3, 3))
+    p.save(tmp_file('%s_plot_piecewise_2' % name))
     p._backend.close()
 
     #parametric 2d plots.

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -1,5 +1,5 @@
 from sympy import (pi, sin, cos, Symbol, Integral, Sum, sqrt, log,
-                   oo, LambertW, I, meijerg, exp_polar, Max, Piecewise)
+                   oo, LambertW, I, meijerg, exp_polar, Max, Piecewise, And)
 from sympy.plotting import (plot, plot_parametric, plot3d_parametric_line,
                             plot3d, plot3d_parametric_surface)
 from sympy.plotting.plot import unset_show
@@ -85,6 +85,13 @@ def plot_and_save(name):
 
     p = plot(Piecewise((x, x < 1), (x**2, True)), (x, -3, 3))
     p.save(tmp_file('%s_plot_piecewise_2' % name))
+    p._backend.close()
+
+    # test issue 10925
+    f = Piecewise((-1, x < -1), (x, And(-1 <= x, x < 0)), \
+        (x**2, And(0 <= x, x < 1)), (x**3, x >= 1))
+    p = plot(f, (x, -3, 3))
+    p.save(tmp_file('%s_plot_piecewise_3' % name))
     p._backend.close()
 
     #parametric 2d plots.


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Plotting piecewise functions was impossible when the conditions in Piecewise contained inequalities `<`.  Fixes #10925. Also fixes #13320.

#### Brief description of what is fixed or changed

`experimental_lambdify` attempts to use `python_cmath` first, casting the arguments as complex. If this leads to an error due to inequality comparison with complex type, it falls back on real arguments and `python_math`. However there was a bug where only errors due to '>' comparison led to fallback, while errors due to '<' comparison were not caught. This is now corrected. 

For example,
```
plot(Piecewise((x, x < 1), (x**2, True)))
```
now works but it fails in current master.

More tests are added. The only previous test for Piecewise plotting had `>` sign in it but no `<` sign, which is why it passed.