### PR TITLE
Correct the docstring of sympify: ints become instances of sympy.Integer

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -75,7 +75,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
         evaluate=None):
     """Converts an arbitrary expression to a type that can be used inside SymPy.
 
-    For example, it will convert Python ints into instance of sympy.Rational,
+    For example, it will convert Python ints into instances of sympy.Integer,
     floats into instances of sympy.Float, etc. It is also able to coerce symbolic
     expressions which inherit from Basic. This can be useful in cooperation
     with SAGE.


### PR DESCRIPTION
The current version, "it will convert Python ints into instance of sympy.Rational" is not completely wrong, since Integer is a subclass of Rational, but stating Integer makes more sense; this is what type(S(42)) will show. Also fixed a pluralization typo.

**Add entry(ies) to the release notes?** No