### PR TITLE
Do not apply expand_complex to expressions with AppliedUndef

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -12,7 +12,7 @@ from __future__ import print_function, division
 from sympy.core.sympify import sympify
 from sympy.core import S, Pow, Dummy, pi, Expr, Wild, Mul, Equality
 from sympy.core.numbers import I, Number, Rational, oo
-from sympy.core.function import (Lambda, expand_complex)
+from sympy.core.function import (Lambda, expand_complex, AppliedUndef)
 from sympy.core.relational import Eq
 from sympy.core.symbol import Symbol
 from sympy.simplify.simplify import simplify, fraction, trigsimp
@@ -478,10 +478,10 @@ def _solve_as_poly(f, symbol, domain=S.Complexes):
     if result is not None:
         if isinstance(result, FiniteSet):
             # this is to simplify solutions like -sqrt(-I) to sqrt(2)/2
-            # - sqrt(2)*I/2. We are not expanding for solution with free
-            # variables because that makes the solution more complicated. For
-            # example expand_complex(a) returns re(a) + I*im(a)
-            if all([s.free_symbols == set() and not isinstance(s, RootOf)
+            # - sqrt(2)*I/2. We are not expanding for solution with symbols
+            # or undefined functions because that makes the solution more complicated.
+            # For example, expand_complex(a) returns re(a) + I*im(a)
+            if all([s.atoms(Symbol, AppliedUndef) == set() and not isinstance(s, RootOf)
                     for s in result]):
                 s = Dummy('s')
                 result = imageset(Lambda(s, expand_complex(s)), result)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -893,6 +893,7 @@ def test_solve_lambert():
 
 def test_solveset():
     x = Symbol('x')
+    f = Function('f')
     raises(ValueError, lambda: solveset(x + y))
     assert solveset(x, 1) == S.EmptySet
     assert solveset(x - 1, 1) == FiniteSet(x)
@@ -915,6 +916,8 @@ def test_solveset():
     assert solveset(exp(x) - 1, x) == imageset(Lambda(n, 2*I*pi*n), S.Integers)
     assert solveset(Eq(exp(x), 1), x) == imageset(Lambda(n, 2*I*pi*n),
                                                   S.Integers)
+    # issue 13825
+    assert solveset(x**2 + f(0) + 1, x) == {-sqrt(-f(0) - 1), sqrt(-f(0) - 1)}
 
 
 def test_conditionset():


### PR DESCRIPTION
#### References to other Issues or PRs
 Fixes #13825

#### Brief description of what is fixed or changed 

It was noted in #13825 that solveset returns unnecessarily complicated solutions when the equation contains applied undefined functions such as f(0).  This has been corrected.

#### Other comments

`solveset` sometimes sends solutions to expand_complex in order to separate the real and imaginary parts of numeric answers. Since this only complicates the expressions with symbols, there is a check
```
expr.free_symbols == set()
```
However this check does not detect the presence of applied undefined functions such as f(0), which also make the complex expansion complicated. So the check was changed to
```
expr.atoms(Symbol, AppliedUndef) == set()
```
The test case `solveset(x**2 + f(0) + 1, x)` is added, and it now returns `{-sqrt(-f(0) - 1), sqrt(-f(0) - 1)}` as one would expect.

The presence of bound symbols will now also prevent the expression from being complex-expanded. For example, trying `expand_complex(Integral(x**2, (x, 0, 1)))` is unlikely to be useful (in fact, it throws an exception).
  