### PR TITLE
Attribute inv() added in matexpr.py

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -261,8 +261,7 @@ class MatrixExpr(Expr):
     def inverse(self):
         return self._eval_inverse()
 
-    def inv(self):
-        return self**-1
+    inv = inverse
 
     @property
     def I(self):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -261,6 +261,9 @@ class MatrixExpr(Expr):
     def inverse(self):
         return self._eval_inverse()
 
+    def inv(self):
+        return self**-1
+
     @property
     def I(self):
         return self.inverse()

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -322,3 +322,7 @@ def test_MatrixElement_with_values():
     raises(ValueError, lambda: M[i, -1])
     raises(ValueError, lambda: M[2, i])
     raises(ValueError, lambda: M[-1, i])
+
+def test_inv():
+    B = MatrixSymbol('B', 3, 3)
+    assert B.inv() == B**-1


### PR DESCRIPTION
Fixes #13541  
A new attribute function `inv` is added in matexpr.py which return `self**-1`. And, test case added.
Ping @gxyd @asmeurer 