### PR TITLE
Expand the set of R functions known to rcode

### DIFF
--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -22,7 +22,6 @@ from sympy.sets.fancysets import Range
 known_functions = {
     #"Abs": [(lambda x: not x.is_integer, "fabs")],
     "Abs": "abs",
-    "gamma": "gamma",
     "sin": "sin",
     "cos": "cos",
     "tan": "tan",
@@ -42,6 +41,13 @@ known_functions = {
     "floor": "floor",
     "ceiling": "ceiling",
     "sign": "sign",
+    "Max": "max",
+    "Min": "min",
+    "factorial": "factorial",
+    "gamma": "gamma",
+    "digamma": "digamma",
+    "trigamma": "trigamma",
+    "beta": "beta",
 }
 
 # These are the core reserved words in the R language. Taken from:

--- a/sympy/printing/tests/test_rcode.py
+++ b/sympy/printing/tests/test_rcode.py
@@ -1,7 +1,7 @@
 from sympy.core import (S, pi, oo, Symbol, symbols, Rational, Integer,
                         GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq)
 from sympy.functions import (Piecewise, sin, cos, Abs, exp, ceiling, sqrt,
-                             gamma, sign, Max)
+                             gamma, sign, Max, Min, factorial, beta)
 from sympy.sets import Range
 from sympy.logic import ITE
 from sympy.codegen import For, aug_assign, Assignment
@@ -82,6 +82,8 @@ def test_rcode_Integer():
 
 def test_rcode_functions():
     assert rcode(sin(x) ** cos(x)) == "sin(x)^cos(x)"
+    assert rcode(factorial(x) + gamma(y)) == "factorial(x) + gamma(y)"
+    assert rcode(beta(Min(x, y), Max(x, y))) == "beta(min(x, y), max(x, y))"
 
 
 def test_rcode_inline_function():


### PR DESCRIPTION
#### References to other Issues or PRs

Together with #13832 (for JS code, already merged) this closes #13831.

#### Brief description of what is fixed or changed

Added several R functions to R code printers. These are base R functions (no additional packages needed for them), and have the same meaning as in SymPy. 

### Other comments

Not included: Bessel functions (they have the opposite order of arguments in R), and numerous functions available through numerous non-base R packages. 
