### PR TITLE
Improved solveset for negative base exponential equations

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -121,6 +121,31 @@ def invert_real(f_x, y, x, domain=S.Reals):
     """
     return _invert(f_x, y, x, domain)
 
+
+def power(x, y):
+    """
+    Returns an integer if `y` can be expressed in terms of power of `x`,
+    otherwise `False`.
+
+    Examples
+    ========
+
+    >>> from sympy.solvers.solveset import power
+    >>> power(2, 8)
+    3
+    >>> power(3, 7)
+    False
+    """
+    if x == 1:
+        return y == 1
+    powe = 1
+    c=0
+    while powe < y:
+        powe *= x
+        c+=1
+    return c if powe == y else False
+
+
 def _invert_real(f, g_ys, symbol):
     """Helper function for _invert."""
 
@@ -191,12 +216,18 @@ def _invert_real(f, g_ys, symbol):
                 return _invert_real(base, res, symbol)
 
         if not base_has_sym:
-            if base is not S.Zero:
+            rhs = g_ys.args[0]
+            if base is not S.Zero and rhs > 0:
                 return _invert_real(expo,
                     imageset(Lambda(n, log(n)/log(base)), g_ys), symbol)
-            elif g_ys.args[0] is S.One:
+            elif base is not S.Zero and rhs < 0:
+                powe = power(base, -rhs)
+                if powe is not False and powe%2 == 0:
+                    return (expo, FiniteSet(powe))
+            elif rhs is S.One:
                 #special case: 0**x - 1
                 return (expo, FiniteSet(0))
+            return (expo, S.EmptySet)
 
 
     if isinstance(f, TrigonometricFunction):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -122,30 +122,6 @@ def invert_real(f_x, y, x, domain=S.Reals):
     return _invert(f_x, y, x, domain)
 
 
-def power(x, y):
-    """
-    Returns an integer if `y` can be expressed in terms of power of `x`,
-    otherwise `False`.
-
-    Examples
-    ========
-
-    >>> from sympy.solvers.solveset import power
-    >>> power(2, 8)
-    3
-    >>> power(3, 7)
-    False
-    """
-    if x == 1:
-        return y == 1
-    powe = 1
-    c=0
-    while powe < y:
-        powe *= x
-        c+=1
-    return c if powe == y else False
-
-
 def _invert_real(f, g_ys, symbol):
     """Helper function for _invert."""
 
@@ -221,9 +197,13 @@ def _invert_real(f, g_ys, symbol):
                 return _invert_real(expo,
                     imageset(Lambda(n, log(n)/log(base)), g_ys), symbol)
             elif base is not S.Zero and rhs < 0:
-                powe = power(base, -rhs)
-                if powe is not False and powe%2 == 0:
-                    return (expo, FiniteSet(powe))
+                from sympy.core.power import integer_nthroot
+                from sympy.ntheory import multiplicity
+                s, b = integer_nthroot(-rhs, 2)
+                if b:
+                    m = multiplicity(base, s)
+                    if pow(base, m) == s:
+                        return expo, FiniteSet(2*m)
             elif rhs is S.One:
                 #special case: 0**x - 1
                 return (expo, FiniteSet(0))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -190,7 +190,7 @@ def test_domain_check():
     assert domain_check(0, x, oo) is False
 
 def test_issue_11536():
-    assert solveset(0**x - 100, x, S.Reals) == ConditionSet(x, Eq(0**x - 100, 0), S.Reals)
+    assert solveset(0**x - 100, x, S.Reals) == S.EmptySet
     assert solveset(0**x - 1, x, S.Reals) == FiniteSet(0)
 
 def test_is_function_class_equation():
@@ -722,6 +722,14 @@ def test_solveset_complex_exp():
     assert solveset_complex(1/exp(x), x) == S.EmptySet
     assert solveset_complex(sinh(x).rewrite(exp), x) == \
         imageset(Lambda(n, n*pi*I), S.Integers)
+
+
+def test_solveset_real_exp():
+    from sympy.abc import x
+    assert solveset(Eq(-2**x, 4), x, S.Reals) == FiniteSet(2)
+    assert solveset(Eq(-3**x, 27), x, S.Reals) == S.EmptySet
+    assert solveset(Eq(-5**(x+1),27), x, S.Reals) == S.EmptySet
+    assert solveset(Eq(2**(x-3), -16), x, S.Reals) == FiniteSet(7)
 
 
 def test_solve_complex_log():


### PR DESCRIPTION
This PR fixes: #11096 and is a part of #13045 exponential solver.

```
>>> solveset(-2**x - 4, x, S.Reals)
EmptySet() # it should rather be {2}
```
For complex domain logic is implemented in #13045 , it returns

```
⎧ⅈ⋅(2⋅n⋅π + π) + 2⋅log(2)        ⎫
⎨──────────────────────── | n ∊ ℤ⎬
⎩         log(2)                 ⎭

```
as computed [here](https://www.wolframalpha.com/input/?i=solve(-2**x+-+4,+x))