### PR TITLE
Derivative doit() fixed

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1414,7 +1414,7 @@ class Derivative(Expr):
         if hints.get('deep', True):
             expr = expr.doit(**hints)
         hints['evaluate'] = True
-        return self.func(expr, *self.variables, **hints)
+        return self.func(expr, *self.variable_count, **hints)
 
     @_sympifyit('z0', NotImplementedError)
     def doit_numerically(self, z0):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1235,7 +1235,7 @@ class Derivative(Expr):
 
             if unhandled_non_symbol:
                 obj = None
-            elif not count.is_Integer:
+            elif not count.is_Integer and not count.is_integer:
                 obj = None
             else:
                 if isinstance(v, (collections.Iterable, Tuple, MatrixCommon, NDimArray)):
@@ -1249,11 +1249,15 @@ class Derivative(Expr):
                     old_v = v
                     v = new_v
                 obj = expr
-                for i in range(count):
-                    obj2 = deriv_fun(obj, v)
-                    if obj == obj2:
-                        break
-                    obj = obj2
+                try:
+                    for i in range(count):
+                        obj2 = deriv_fun(obj, v)
+                        if obj == obj2:
+                            break
+                        obj = obj2
+                        nderivs += 1
+                except TypeError:
+                    obj = deriv_fun(obj, Tuple(v, count))
                     nderivs += 1
                 if not is_symbol:
                     if obj is not None:
@@ -1388,7 +1392,11 @@ class Derivative(Expr):
         # If the variable s we are diff wrt is not in self.variables, we
         # assume that we might be able to take the derivative.
         if v not in self.variables:
-            obj = self.expr.diff(v)
+            if type(v) == Tuple and v[1].is_integer:
+                obj = self.expr.diff(v[0])
+                return obj.func(obj.expr, *(self.variable_count + ((v),)))
+            else:
+                obj = self.expr.diff(v)
             if obj is S.Zero:
                 return S.Zero
             if isinstance(obj, Derivative):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1235,7 +1235,7 @@ class Derivative(Expr):
 
             if unhandled_non_symbol:
                 obj = None
-            elif not count.is_Integer and not count.is_integer:
+            elif not count.is_Integer and not count.is_symbol:
                 obj = None
             else:
                 if isinstance(v, (collections.Iterable, Tuple, MatrixCommon, NDimArray)):
@@ -1249,14 +1249,14 @@ class Derivative(Expr):
                     old_v = v
                     v = new_v
                 obj = expr
-                try:
+                if not n.is_symbol:
                     for i in range(count):
                         obj2 = deriv_fun(obj, v)
                         if obj == obj2:
                             break
                         obj = obj2
                         nderivs += 1
-                except TypeError:
+                else:
                     obj = deriv_fun(obj, Tuple(v, count))
                     nderivs += 1
                 if not is_symbol:
@@ -1392,7 +1392,7 @@ class Derivative(Expr):
         # If the variable s we are diff wrt is not in self.variables, we
         # assume that we might be able to take the derivative.
         if v not in self.variables:
-            if type(v) == Tuple and v[1].is_integer:
+            if type(v) == Tuple and v[1].is_symbol:
                 obj = self.expr.diff(v[0])
                 return obj.func(obj.expr, *(self.variable_count + ((v),)))
             else:

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -859,6 +859,13 @@ def test_issue_12005():
     assert e5.diff(x) == Derivative(f(x), x, x)
     assert f(g(x)).diff(g(x), g(x)) == Subs(Derivative(f(y), y, y), (y,), (g(x),))
 
+def test_issue_13843():
+    x = symbols('x')
+    f = Function('f')
+    m, n = symbols('m n', integer=True)
+    assert Derivative(Derivative(f(x), (x, m)), (x, n)) == Derivative(f(x), (x, m + n))
+    assert Derivative(Derivative(f(x), (x, m+5)), (x, n+3)) == Derivative(f(x), (x, m + n + 8))
+
 def test_undefined_function_eq():
     f = Function('f')
     f2 = Function('f')

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -866,6 +866,8 @@ def test_issue_13843():
     assert Derivative(Derivative(f(x), (x, m)), (x, n)) == Derivative(f(x), (x, m + n))
     assert Derivative(Derivative(f(x), (x, m+5)), (x, n+3)) == Derivative(f(x), (x, m + n + 8))
 
+    assert Derivative(f(x), (x, n)).doit() == Derivative(f(x), (x, n))
+
 def test_undefined_function_eq():
     f = Function('f')
     f2 = Function('f')


### PR DESCRIPTION
Fixes `Derivative(f(x), (x, n)).doit()` in https://github.com/sympy/sympy/issues/13843
For `n` the value of `self.variables = ()` which is removing `n` from Derivative. `self.variable_count = (x, n)` and hence returns correct Derivative.
```
>>> from sympy import *
>>> m, n = symbols('m n', integer=True)
>>> x = symbols('x')
>>> f = Function('f')
>>> Derivative(f(x), (x, n)).doit()
Derivative(f(x), (x, n))
```

`Derivative(Derivative(f(x), (x, m)), (x, n))` I'am still fixing, following is changes that I have done but its still not solved! Please have a look.
```
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -561,7 +561,10 @@ def _eval_derivative(self, s):
         l = []
         for a in self.args:
             i += 1
-            da = a.diff(s)
+            if type(s) == tuple:
+                da = a.diff(s[0])
+            else:
+                da = a.diff(s)
             if da is S.Zero:
                 continue
             try:
@@ -1104,7 +1107,8 @@ def __new__(cls, expr, *variables, **assumptions):
         from sympy.tensor.array import Array, NDimArray, derive_by_array
 
         expr = sympify(expr)
-
+        import pdb
+        pdb.set_trace()
         # There are no variables, we differentiate wrt all of the free symbols
         # in expr.
         if not variables:
@@ -1235,7 +1239,7 @@ def __new__(cls, expr, *variables, **assumptions):
 
             if unhandled_non_symbol:
                 obj = None
-            elif not count.is_Integer:
+            elif not count.is_Integer and not count.is_integer:
                 obj = None
             else:
                 if isinstance(v, (collections.Iterable, Tuple, MatrixCommon, NDimArray)):
@@ -1249,11 +1253,16 @@ def __new__(cls, expr, *variables, **assumptions):
                     old_v = v
                     v = new_v
                 obj = expr
-                for i in range(count):
-                    obj2 = deriv_fun(obj, v)
-                    if obj == obj2:
-                        break
-                    obj = obj2
+                pdb.set_trace()
+                try:
+                    for i in range(count):
+                        obj2 = deriv_fun(obj, v)
+                        if obj == obj2:
+                            break
+                        obj = obj2
+                        nderivs += 1
+                except TypeError:
+                    obj = deriv_fun(obj, Tuple(v, count))
                     nderivs += 1
                 if not is_symbol:
                     if obj is not None:
@@ -1414,7 +1423,7 @@ def doit(self, **hints):
         if hints.get('deep', True):
             expr = expr.doit(**hints)
         hints['evaluate'] = True
-        return self.func(expr, *self.variables, **hints)
+        return self.func(expr, *self.variable_count, **hints)
 
     @_sympifyit('z0', NotImplementedError)
     def doit_numerically(self, z0):
```