### PR TITLE
directed segments, self-intersecting poly

### DIFF
--- a/doc/src/modules/geometry/index.rst
+++ b/doc/src/modules/geometry/index.rst
@@ -54,8 +54,6 @@ geometry module.
     1/2
     >>> t.medians[x]
     Segment2D(Point2D(0, 0), Point2D(1, 1/2))
-    >>> Segment(Point(1, S(1)/2), Point(0, 0))
-    Segment2D(Point2D(0, 0), Point2D(1, 1/2))
     >>> m = t.medians
     >>> intersection(m[x], m[y], m[zp])
     [Point2D(2/3, 1/3)]

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -365,7 +365,7 @@ class GeometryEntity(Basic):
         >>> pent = RegularPolygon((1, 2), 1, 5)
         >>> rpent = pent.reflect(l)
         >>> rpent
-        RegularPolygon(Point2D(-2*sqrt(2)*pi/3 - 1/3 + 4*sqrt(2)/3, 2/3 + 2*sqrt(2)/3 + 2*pi/3), -1, 5, -pi/5 + acos(1/3))
+        RegularPolygon(Point2D(-2*sqrt(2)*pi/3 - 1/3 + 4*sqrt(2)/3, 2/3 + 2*sqrt(2)/3 + 2*pi/3), -1, 5, -atan(2*sqrt(2)) + 3*pi/5)
 
         >>> from sympy import pi, Line, Circle, Point
         >>> l = Line((0, pi), slope=1)

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -16,7 +16,7 @@ from sympy.utilities.iterables import has_dups, has_variety, uniq
 from .entity import GeometryEntity, GeometrySet
 from .point import Point
 from .ellipse import Circle
-from .line import Line, Segment
+from .line import Line, Segment, Ray
 
 from sympy import sqrt
 
@@ -50,8 +50,6 @@ class Polygon(GeometrySet):
     GeometryError
         If all parameters are not Points.
 
-        If the Polygon has intersecting sides.
-
     See Also
     ========
 
@@ -83,16 +81,14 @@ class Polygon(GeometrySet):
     >>> Polygon(p1, p2, p5)
     Segment2D(Point2D(0, 0), Point2D(3, 0))
 
-    While the sides of a polygon are not allowed to cross implicitly, they
-    can do so explicitly. For example, a polygon shaped like a Z with the top
-    left connecting to the bottom right of the Z must have the point in the
-    middle of the Z explicitly given:
+    The area of a polygon is calculated as positive when vertices are
+    traversed in a ccw direction. When the sides of a polygon cross the
+    area will have positive and negative contributions. The following
+    defines a Z shape where the bottom right connects back to the top
+    left.
 
-    >>> mid = Point(1, 1)
-    >>> Polygon((0, 2), (2, 2), mid, (0, 0), (2, 0), mid).area
+    >>> Polygon((0, 2), (2, 2), (0, 0), (2, 0)).area
     0
-    >>> Polygon((0, 2), (2, 2), mid, (2, 0), (0, 0), mid).area
-    -2
 
     When the the keyword `n` is used to define the number of sides of the
     Polygon then a RegularPolygon is created and the other arguments are
@@ -136,19 +132,11 @@ class Polygon(GeometrySet):
         if len(nodup) > 1 and nodup[-1] == nodup[0]:
             nodup.pop()  # last point was same as first
 
-        # remove collinear points unless they are shared points
-        got = set()
-        shared = set()
-        for p in nodup:
-            if p in got:
-                shared.add(p)
-            else:
-                got.add(p)
-        del got
+        # remove collinear points
         i = -3
         while i < len(nodup) - 3 and len(nodup) > 2:
             a, b, c = nodup[i], nodup[i + 1], nodup[i + 2]
-            if b not in shared and Point.is_collinear(a, b, c):
+            if Point.is_collinear(a, b, c):
                 nodup.pop(i + 1)
                 if a == c:
                     nodup.pop(i)
@@ -158,49 +146,13 @@ class Polygon(GeometrySet):
         vertices = list(nodup)
 
         if len(vertices) > 3:
-            rv = GeometryEntity.__new__(cls, *vertices, **kwargs)
+            return GeometryEntity.__new__(cls, *vertices, **kwargs)
         elif len(vertices) == 3:
             return Triangle(*vertices, **kwargs)
         elif len(vertices) == 2:
             return Segment(*vertices, **kwargs)
         else:
             return Point(*vertices, **kwargs)
-
-        # reject polygons that have intersecting sides unless the
-        # intersection is a shared point or a generalized intersection.
-        # A self-intersecting polygon is easier to detect than a
-        # random set of segments since only those sides that are not
-        # part of the convex hull can possibly intersect with other
-        # sides of the polygon...but for now we use the n**2 algorithm
-        # and check if any side intersects with any preceding side,
-        # excluding the ones it is connected to
-        try:
-            convex = rv.is_convex()
-        except ValueError:
-            convex = True
-        if not convex:
-            sides = rv.sides
-            for i, si in enumerate(sides):
-                pts = si.args
-                # exclude the sides connected to si
-                for j in range(1 if i == len(sides) - 1 else 0, i - 1):
-                    sj = sides[j]
-                    if sj.p1 not in pts and sj.p2 not in pts:
-                        hit = si.intersection(sj)
-                        if not hit:
-                            continue
-                        hit = hit[0]
-                        # don't complain unless the intersection is definite;
-                        # if there are symbols present then the intersection
-                        # might not occur; this may not be necessary since if
-                        # the convex test passed, this will likely pass, too.
-                        # But we are about to raise an error anyway so it
-                        # won't matter too much.
-                        if all(i.is_number for i in hit.args):
-                            raise GeometryError(
-                                "Polygon has intersecting sides.")
-
-        return rv
 
     @property
     def area(self):
@@ -211,7 +163,8 @@ class Polygon(GeometrySet):
         =====
 
         The area calculation can be positive or negative based on the
-        orientation of the points.
+        orientation of the points. If any side of the polygon crosses
+        any other side, there will be areas having opposite signs.
 
         See Also
         ========
@@ -226,6 +179,20 @@ class Polygon(GeometrySet):
         >>> poly = Polygon(p1, p2, p3, p4)
         >>> poly.area
         3
+
+        In the Z shaped polygon (with the lower right connecting back
+        to the upper left) the areas cancel out:
+
+        >>> Z = Polygon((0, 1), (1, 1), (0, 0), (1, 0))
+        >>> Z.area
+        0
+
+        In the M shaped polygon, areas do not cancel because no side
+        crosses any other (though there is a point of contact).
+
+        >>> M = Polygon((0, 0), (0, 1), (2, 0), (3, 1), (3, 0))
+        >>> M.area
+        -3/2
 
         """
         area = 0
@@ -295,7 +262,7 @@ class Polygon(GeometrySet):
         ret = {}
         for i in range(len(args)):
             a, b, c = args[i - 2], args[i - 1], args[i]
-            ang = Line.angle_between(Line(b, a), Line(b, c))
+            ang = Ray(b, a).angle_between(Ray(b, c))
             if cw ^ self._isright(a, b, c):
                 ret[b] = 2*S.Pi - ang
             else:
@@ -404,20 +371,13 @@ class Polygon(GeometrySet):
 
     @property
     def sides(self):
-        """The line segments that form the sides of the polygon.
+        """The directed line segments that form the sides of the polygon.
 
         Returns
         =======
 
         sides : list of sides
-            Each side is a Segment.
-
-        Notes
-        =====
-
-        The Segments that represent the sides are an undirected
-        line segment so cannot be used to tell the orientation of
-        the polygon.
+            Each side is a directed Segment.
 
         See Also
         ========
@@ -433,7 +393,7 @@ class Polygon(GeometrySet):
         >>> poly.sides
         [Segment2D(Point2D(0, 0), Point2D(1, 0)),
         Segment2D(Point2D(1, 0), Point2D(5, 1)),
-        Segment2D(Point2D(0, 1), Point2D(5, 1)), Segment2D(Point2D(0, 0), Point2D(0, 1))]
+        Segment2D(Point2D(5, 1), Point2D(0, 1)), Segment2D(Point2D(0, 1), Point2D(0, 0))]
 
         """
         res = []
@@ -458,7 +418,7 @@ class Polygon(GeometrySet):
         """Is the polygon convex?
 
         A polygon is convex if all its interior angles are less than 180
-        degrees.
+        degrees and there are no intersections between sides.
 
         Returns
         =======
@@ -481,14 +441,23 @@ class Polygon(GeometrySet):
         True
 
         """
-
         # Determine orientation of points
         args = self.vertices
         cw = self._isright(args[-2], args[-1], args[0])
         for i in range(1, len(args)):
             if cw ^ self._isright(args[i - 2], args[i - 1], args[i]):
                 return False
-
+        # check for intersecting sides
+        sides = self.sides
+        for i, si in enumerate(sides):
+            pts = si.args
+            # exclude the sides connected to si
+            for j in range(1 if i == len(sides) - 1 else 0, i - 1):
+                sj = sides[j]
+                if sj.p1 not in pts and sj.p2 not in pts:
+                    hit = si.intersection(sj)
+                    if hit:
+                        return False
         return True
 
     def encloses_point(self, p):
@@ -1124,7 +1093,7 @@ class RegularPolygon(Polygon):
         obj._n = n
         obj._center = c
         obj._radius = r
-        obj._rot = rot
+        obj._rot = rot % (2*S.Pi/n) if rot.is_number else rot
         return obj
 
     @property
@@ -1290,9 +1259,17 @@ class RegularPolygon(Polygon):
         ========
 
         >>> from sympy import pi
+        >>> from sympy.abc import a
         >>> from sympy.geometry import RegularPolygon, Point
+        >>> RegularPolygon(Point(0, 0), 3, 4, pi/4).rotation
+        pi/4
+
+        Numerical rotation angles are made canonical:
+
+        >>> RegularPolygon(Point(0, 0), 3, 4, a).rotation
+        a
         >>> RegularPolygon(Point(0, 0), 3, 4, pi).rotation
-        pi
+        0
 
         """
         return self._rot
@@ -1598,19 +1575,28 @@ class RegularPolygon(Polygon):
         """Override GeometryEntity.reflect since this is not made of only
         points.
 
+        Examples
+        ========
+
         >>> from sympy import RegularPolygon, Line
 
         >>> RegularPolygon((0, 0), 1, 4).reflect(Line((0, 1), slope=-2))
-        RegularPolygon(Point2D(4/5, 2/5), -1, 4, acos(3/5))
+        RegularPolygon(Point2D(4/5, 2/5), -1, 4, atan(4/3))
 
         """
         c, r, n, rot = self.args
-        cc = c.reflect(line)
         v = self.vertices[0]
+        d = v - c
+        cc = c.reflect(line)
         vv = v.reflect(line)
-        # see how much it must get spun at the new center
-        ang = Segment(cc, vv).angle_between(Segment(c, v))
-        rot = (rot + ang + pi) % (2*pi/n)
+        dd = vv - cc
+        # calculate rotation about the new center
+        # which will align the vertices
+        l1 = Ray((0, 0), dd)
+        l2 = Ray((0, 0), d)
+        ang = l1.closing_angle(l2)
+        rot += ang
+        # change sign of radius as point traversal is reversed
         return self.func(cc, -r, n, rot)
 
     @property
@@ -2117,7 +2103,7 @@ class Triangle(Polygon):
         >>> p1, p2, p3 = Point(0, 0), Point(1, 0), Point(0, 1)
         >>> t = Triangle(p1, p2, p3)
         >>> from sympy import sqrt
-        >>> t.bisectors()[p2] == Segment(Point(0, sqrt(2) - 1), Point(1, 0))
+        >>> t.bisectors()[p2] == Segment(Point(1, 0), Point(0, sqrt(2) - 1))
         True
 
         """

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -54,8 +54,27 @@ def test_reflect_entity_overrides():
     l = Line((0, pi), slope=sqrt(2))
     rpent = pent.reflect(l)
     assert rpent.center == pent.center.reflect(l)
-    assert str([w.n(3) for w in rpent.vertices]) == (
-        '[Point2D(-0.586, 4.27), Point2D(-1.69, 4.66), '
-        'Point2D(-2.41, 3.73), Point2D(-1.74, 2.76), '
-        'Point2D(-0.616, 3.10)]')
+    rvert = [i.reflect(l) for i in pent.vertices]
+    for v in rpent.vertices:
+        for i in range(len(rvert)):
+            ri = rvert[i]
+            if ri.equals(v):
+                rvert.remove(ri)
+                break
+    assert not rvert
     assert pent.area.equals(-rpent.area)
+
+    # regular polygon test
+    pent = RegularPolygon((0,0), 1, 5)
+    p = pent.vertices[1]
+    for slope in range(-1, 2):
+        l = Line(p, slope=slope)
+        rpent = pent.reflect(l)
+        rvert = [i.reflect(l) for i in pent.vertices]
+        for v in rpent.vertices:
+            for i in range(len(rvert)):
+                ri = rvert[i]
+                if ri.equals(v):
+                    rvert.remove(ri)
+                    break
+        assert not rvert

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -1,10 +1,12 @@
 from __future__ import division
 
-from sympy import Rational, Float, S, Symbol, cos, oo, pi, simplify, sin, sqrt, symbols, acos
+from sympy import (Rational, Float, S, Symbol, cos, oo, pi, simplify,
+    sin, sqrt, symbols, acos)
 from sympy.core.compatibility import range
 from sympy.functions.elementary.trigonometric import tan
-from sympy.geometry import (Circle, GeometryError, Line, Point, Ray, Segment, Triangle, intersection, Point3D, Line3D,
-                            Ray3D, Segment3D, Point2D, Line2D)
+from sympy.geometry import (Circle, GeometryError, Line, Point, Ray,
+    Segment, Triangle, intersection, Point3D, Line3D, Ray3D, Segment3D,
+    Point2D, Line2D)
 from sympy.geometry.line import Undecidable
 from sympy.geometry.polygon import _asa as asa
 from sympy.utilities.iterables import cartes
@@ -201,7 +203,7 @@ def test_basic_properties_2d():
     assert p_r3.x >= p1.x and p_r3.y >= p1.y
     assert p_r4.x <= p2.x and p_r4.y <= p2.y
     assert p1.x <= p_s1.x <= p10.x and p1.y <= p_s1.y <= p10.y
-    assert hash(s1) == hash(Segment(p10, p1))
+    assert hash(s1) != hash(Segment(p10, p1))
 
     assert s1.plot_interval() == [t, 0, 1]
     assert Line(p1, p10).plot_interval() == [t, -5, 5]
@@ -479,7 +481,7 @@ def test_intersection_2d():
     assert Segment3D((0, 0), (3, 0)).intersection(
         Segment3D((3, 0), (4, 0))) == [Point3D((3, 0))]
     assert Segment3D((0, 0), (3, 0)).intersection(
-        Segment3D((2, 0), (5, 0))) == [Segment3D((3, 0), (2, 0))]
+        Segment3D((2, 0), (5, 0))) == [Segment3D((2, 0), (3, 0))]
     assert Segment3D((0, 0), (3, 0)).intersection(
         Segment3D((-2, 0), (1, 0))) == [Segment3D((0, 0), (1, 0))]
     assert Segment3D((0, 0), (3, 0)).intersection(
@@ -626,7 +628,7 @@ def test_projection():
 
     assert Line(Point(x1, x1), Point(y1, y1)).projection(Point(y1, y1)) == Point(y1, y1)
     assert Line(Point(x1, x1), Point(x1, 1 + x1)).projection(Point(1, 1)) == Point(x1, 1)
-    assert Segment(Point(0, 4), Point(-2, 2)).projection(r1) == Segment(Point(0, 4), Point(-1, 3))
+    assert Segment(Point(-2, 2), Point(0, 4)).projection(r1) == Segment(Point(-1, 3), Point(0, 4))
     assert Segment(Point(0, 4), Point(-2, 2)).projection(r1) == Segment(Point(0, 4), Point(-1, 3))
     assert l1.projection(p3) == p1
     assert l1.projection(Ray(p1, Point(-1, 5))) == Ray(Point(0, 0), Point(2, 2))
@@ -650,7 +652,7 @@ def test_perpendicular_bisector():
     on_line = Segment(Point(1 / 2, 1 / 2), Point(3 / 2, -1 / 2)).midpoint
 
     assert s1.perpendicular_bisector().equals(aline)
-    assert s1.perpendicular_bisector(on_line) == Segment(s1.midpoint, on_line)
+    assert s1.perpendicular_bisector(on_line).equals(Segment(s1.midpoint, on_line))
     assert s1.perpendicular_bisector(on_line + (1, 0)).equals(aline)
 
 

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -96,7 +96,7 @@ def test_plane():
     assert pl6.angle_between(Ray3D(Point3D(2, 4, 1), Point3D(6, 5, 3))) == \
         asin(sqrt(7)/3)
     assert pl7.angle_between(Segment3D(Point3D(5, 6, 1), Point3D(1, 2, 4))) == \
-        -asin(7*sqrt(246)/246)
+        asin(7*sqrt(246)/246)
 
     assert are_coplanar(l1, l2, l3) is False
     assert are_coplanar(l1) is False

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -29,7 +29,6 @@ def test_polygon():
     # 2 "remove folded" tests
     assert Polygon(a, Point(3, 0), b, c) == t
     assert Polygon(a, b, Point(3, -1), b, c) == t
-    raises(GeometryError, lambda: Polygon((0, 0), (1, 0), (0, 1), (1, 1)))
     # remove multiple collinear points
     assert Polygon(Point(-4, 15), Point(-11, 15), Point(-15, 15),
         Point(-15, 33/5), Point(-15, -87/10), Point(-15, -15),
@@ -68,6 +67,8 @@ def test_polygon():
     assert p1.perimeter == 5 + 2*sqrt(10) + sqrt(29) + sqrt(8)
     assert p1.area == 22
     assert not p1.is_convex()
+    assert Polygon((-1, 1), (2, -1), (2, 1), (-1, -1), (3, 0)
+        ).is_convex() is False
     # ensure convex for both CW and CCW point specification
     assert p3.is_convex()
     assert p4.is_convex()
@@ -238,7 +239,7 @@ def test_polygon():
     # Perpendicular
     altitudes = t1.altitudes
     assert altitudes[p1] == Segment(p1, Point(Rational(5, 2), Rational(5, 2)))
-    assert altitudes[p2] == s1[0]
+    assert altitudes[p2].equals(s1[0])
     assert altitudes[p3] == s1[2]
     assert t1.orthocenter == p1
     t = S('''Triangle(
@@ -386,22 +387,36 @@ def test_intersection():
     poly2 = Polygon(Point(0, 1), Point(-5, 0),
                     Point(0, -4), Point(0, 1/5), Point(1/2, -0.1), Point(1,0), Point(0, 1))
 
-    assert poly1.intersection(poly2) == [Point(1/3, 0), Segment(Point(0, 0), Point(0, 1/5)),
-                                         Segment(Point(0, 1), Point(1, 0))]
-    assert poly2.intersection(poly1) == [Point2D(1/3, 0), Segment(Point2D(0, 0), Point(0, 1/5)),
-                                         Segment(Point(0, 1), Point(1, 0))]
+    assert poly1.intersection(poly2) == [Point2D(1/3, 0),
+        Segment(Point(0, 1/5), Point(0, 0)),
+        Segment(Point(1, 0), Point(0, 1))]
+    assert poly2.intersection(poly1) == [Point(1/3, 0),
+        Segment(Point(0, 0), Point(0, 1/5)),
+        Segment(Point(1, 0), Point(0, 1))]
     assert poly1.intersection(Point(0, 0)) == [Point(0, 0)]
     assert poly1.intersection(Point(-12,  -43)) == []
     assert poly2.intersection(Line((-12, 0), (12, 0))) == [Point(-5, 0), Point(0, 0),
                                                            Point(1/3, 0), Point(1, 0)]
     assert poly2.intersection(Line((-12, 12), (12, 12))) == []
-    assert poly2.intersection(Ray((-3,4), (1,0))) == [Segment(Point(0, 1), Point(1, 0))]
+    assert poly2.intersection(Ray((-3,4), (1,0))) == [Segment(Point(1, 0), Point(0, 1))]
     assert poly2.intersection(Circle((0, -1), 1)) == [Point(0, -2), Point(0, 0)]
-    assert poly1.intersection(poly1) == [Segment(Point(0, 0), Point(0, 1)), Segment(Point(0, 0), Point(1, 0)),
-                                         Segment(Point(0, 1), Point(1, 0))]
-    assert poly2.intersection(poly2) == [Segment(Point(-5, 0), Point(0, -4)), Segment(Point(-5, 0), Point(0, 1)),
-                                         Segment(Point(0, -4), Point(0, 1/5)), Segment(Point(0, 1/5), Point(1/2, -1/10)),
-                                         Segment(Point(0, 1), Point(1, 0)), Segment(Point(1/2, -1/10), Point(1, 0))]
+    assert poly1.intersection(poly1) == [Segment(Point(0, 0), Point(1, 0)),
+        Segment(Point(0, 1), Point(0, 0)), Segment(Point(1, 0), Point(0, 1))]
+    assert poly2.intersection(poly2) == [Segment(Point(-5, 0), Point(0, -4)),
+        Segment(Point(0, -4), Point(0, 1/5)), Segment(Point(0, 1/5), Point(1/2, -1/10)),
+        Segment(Point(0, 1), Point(-5, 0)), Segment(Point(1/2, -1/10), Point(1, 0)),
+        Segment(Point(1, 0), Point(0, 1))]
     assert poly2.intersection(Triangle(Point(0, 1), Point(1, 0), Point(-1, 1))) == [Point(-5/7, 6/7),
                                                                                     Segment(Point2D(0, 1), Point(1, 0))]
     assert poly1.intersection(RegularPolygon((-12, -15), 3, 3)) == []
+
+
+def test_issue_12966():
+    poly = Polygon(Point(0, 0), Point(0, 10), Point(5, 10), Point(5, 5),
+    Point(10, 5), Point(10, 0))
+    t = Symbol('t')
+    pt = poly.arbitrary_point(t)
+    DELTA = 5/poly.perimeter
+    assert [pt.subs(t, DELTA*i) for i in range(int(1/DELTA))] == [
+        Point(0, 0), Point(0, 5), Point(0, 10), Point(5, 10),
+        Point(5, 5), Point(10, 5), Point(10, 0), Point(5, 0)]

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -15,6 +15,7 @@ from __future__ import division, print_function
 from sympy import Function, Symbol, solve
 from sympy.core.compatibility import (
     is_sequence, range, string_types, ordered)
+from sympy.core.containers import OrderedSet
 from .point import Point, Point2D
 
 
@@ -363,7 +364,7 @@ def convex_hull(*args, **kwargs):
     from .polygon import Polygon
 
     polygon = kwargs.get('polygon', True)
-    p = set()
+    p = OrderedSet()
     for e in args:
         if not isinstance(e, GeometryEntity):
             try:

--- a/sympy/integrals/tests/test_intpoly.py
+++ b/sympy/integrals/tests/test_intpoly.py
@@ -12,7 +12,6 @@ from sympy.geometry.polygon import Polygon
 from sympy.geometry.point import Point
 from sympy.abc import x, y, z
 
-from sympy.utilities.pytest import XFAIL
 
 
 def test_decompose():
@@ -494,11 +493,7 @@ def test_polytope_integrate():
          z: 625 / S(2), x * y: 3125 / S(4), x ** 2: 3125 / S(3)}
 
 
-@XFAIL
 def test_polytopes_intersecting_sides():
-    #  Intersecting polygons not implemented yet in SymPy. Will be implemented
-    #  soon. As of now, the intersection point will have to be manually
-    #  supplied by user.
     fig5 = Polygon(Point(-4.165, -0.832), Point(-3.668, 1.568),
                    Point(-3.266, 1.279), Point(-1.090, -2.080),
                    Point(3.313, -0.683), Point(3.033, -4.845),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

fixes #12966
closes #12985
closes #12931 (and unXFAILs the intpoly test)

This should make #13539 or #13790 easier to implement parameter finding for the arbitrary point on the plane. But there will always be two parameters needed for the plane: the current arbitrary point comes back with a single parameter and assumes the second parameter (radius) is 1 OR returns 2 parameters. I think the 2-parameter form is what should be returned from the parameter finding routine. Eventually the arbitrary-point-on-a-circle should be deprecated and passed off to a separate routine/method like `Plane.circle(center, radius=1)`. What do you think, @normalhuman?

#### Brief description of what is fixed or changed

The points defining a segment are no longer reordered making Segment the same as other Line entities.

It is now "user beware" when it comes to computing area since self-crossing polygons will have areas of differently signs.

`is_convex` is updated to do the test of self-intersection there (which relieves instantiation of polygons from this calculation)

The docstring of `angle_between` was modified to clarify what angle is returned.

A new method was added to compute the `smallest_angle between` linear entities.

The reflect method for RegularPolygon was corrected and a more robust test added (and the incorrect but close test modified).

#### Other comments


Now that segments retain the order of their args
some attention for computing projections was needed
since the order of the
points computed in sets is not canonical. There is an
awareness of this issue for Partition -- see line 1515
in sets.py. The same could be done for GeometryEntity
as an alternative to the changes here.

The `smallest_angle_between` method computes
the smallest angle between two lines as opposed to the
non-reflex (oriented) angle between lines as is computed
in the `angle_between` method.

smallest_angle_between -> 0 <= angle <= pi/2
angle_between -> 0 <= angle < pi

  
  