### PR TITLE
Implement more special values of polylogarithm, without exp_polar for s=1

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -138,7 +138,7 @@ def test_polylog_values():
     assert polylog(2, 2) == pi**2/4 - I*pi*log(2)
     assert polylog(2, S.Half) == pi**2/12 - log(2)**2/2
     for z in [S.Half, 2, (sqrt(5)-1)/2, -(sqrt(5)-1)/2, -(sqrt(5)+1)/2, (3-sqrt(5))/2]:
-        assert Abs(polylog(2, z) - polylog(2, z + 1e-13)).evalf() < 1e-12
+        assert Abs(polylog(2, z).evalf() - polylog(2, z, evaluate=False).evalf()) < 1e-15
 
 
 def test_lerchphi_expansion():

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -128,17 +128,23 @@ def test_polylog_expansion():
     assert polylog(s, 1) == zeta(s)
     assert polylog(s, -1) == -dirichlet_eta(s)
 
-    assert myexpand(polylog(1, z), -log(1 + exp_polar(-I*pi)*z))
+    assert myexpand(polylog(1, z), -log(1 - z))
     assert myexpand(polylog(0, z), z/(1 - z))
-    assert myexpand(polylog(-1, z), z**2/(1 - z)**2 + z/(1 - z))
+    assert myexpand(polylog(-1, z), z/(1 - z)**2)
+    assert ((1-z)**3 * expand_func(polylog(-2, z))).simplify() == z*(1 + z)
     assert myexpand(polylog(-5, z), None)
 
 
 def test_polylog_values():
+    import random
     assert polylog(2, 2) == pi**2/4 - I*pi*log(2)
     assert polylog(2, S.Half) == pi**2/12 - log(2)**2/2
     for z in [S.Half, 2, (sqrt(5)-1)/2, -(sqrt(5)-1)/2, -(sqrt(5)+1)/2, (3-sqrt(5))/2]:
         assert Abs(polylog(2, z).evalf() - polylog(2, z, evaluate=False).evalf()) < 1e-15
+    for s in [-1, 0, 1]:
+        for _ in range(10):
+            z = random.uniform(-5, 5) + I*random.uniform(-5, 5)
+            assert Abs(polylog(s, z).evalf() - polylog(s, z, evaluate=False).evalf()) < 1e-15
 
 
 def test_lerchphi_expansion():

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log,
                    zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I,
-                   exp_polar, polar_lift, O, stieltjes)
+                   exp_polar, polar_lift, O, stieltjes, Abs)
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically as tn)
 
@@ -132,6 +132,13 @@ def test_polylog_expansion():
     assert myexpand(polylog(0, z), z/(1 - z))
     assert myexpand(polylog(-1, z), z**2/(1 - z)**2 + z/(1 - z))
     assert myexpand(polylog(-5, z), None)
+
+
+def test_polylog_values():
+    assert polylog(2, 2) == pi**2/4 - I*pi*log(2)
+    assert polylog(2, S.Half) == pi**2/12 - log(2)**2/2
+    for z in [S.Half, 2, (sqrt(5)-1)/2, -(sqrt(5)-1)/2, -(sqrt(5)+1)/2, (3-sqrt(5))/2]:
+        assert Abs(polylog(2, z) - polylog(2, z + 1e-13)).evalf() < 1e-12
 
 
 def test_lerchphi_expansion():

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -276,7 +276,7 @@ class polylog(Function):
         elif z == -1:
             return -dirichlet_eta(s)
         elif z == 0:
-            return 0
+            return S.Zero
         if s == 2:
             if z == S.Half:
                 return pi**2/12 - log(2)**2/2

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -1,12 +1,12 @@
 """ Riemann zeta and related function. """
 from __future__ import print_function, division
 
-from sympy.core import Function, S, sympify, pi
+from sympy.core import Function, S, sympify, pi, I
 from sympy.core.function import ArgumentIndexError
 from sympy.core.compatibility import range
 from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
 from sympy.functions.elementary.exponential import log
-
+from sympy.functions.elementary.miscellaneous import sqrt
 
 ###############################################################################
 ###################### LERCH TRANSCENDENT #####################################
@@ -277,6 +277,19 @@ class polylog(Function):
             return -dirichlet_eta(s)
         elif z == 0:
             return 0
+        if s == 2:
+            if z == S.Half:
+                return pi**2/12 - log(2)**2/2
+            elif z == 2:
+                return pi**2/4 - I*pi*log(2)
+            elif z == -(sqrt(5) - 1)/2:
+                return -pi**2/15 + log((sqrt(5)-1)/2)**2/2
+            elif z == -(sqrt(5) + 1)/2:
+                return -pi**2/10 - log((sqrt(5)+1)/2)**2
+            elif z == (3 - sqrt(5))/2:
+                return pi**2/15 - log((sqrt(5)-1)/2)**2
+            elif z == (sqrt(5) - 1)/2:
+                return pi**2/10 - log((sqrt(5)-1)/2)**2
 
     def fdiff(self, argindex=1):
         s, z = self.args

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -253,7 +253,7 @@ class polylog(Function):
     >>> from sympy import expand_func
     >>> from sympy.abc import z
     >>> expand_func(polylog(1, z))
-    -log(1 - z)
+    -log(-z + 1)
     >>> expand_func(polylog(0, z))
     z/(-z + 1)
 
@@ -290,8 +290,9 @@ class polylog(Function):
                 return pi**2/15 - log((sqrt(5)-1)/2)**2
             elif z == (sqrt(5) - 1)/2:
                 return pi**2/10 - log((sqrt(5)-1)/2)**2
-        elif s == 1:
-            return -log(1 - z)
+        # For s = 0 or -1 use explicit formulas to evaluate, but
+        # automatically expanding polylog(1, z) to -log(1-z) seems undesirable
+        # for summation methods based on hypergeometric functions
         elif s == 0:
             return z/(1 - z)
         elif s == -1:

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -253,7 +253,7 @@ class polylog(Function):
     >>> from sympy import expand_func
     >>> from sympy.abc import z
     >>> expand_func(polylog(1, z))
-    -log(z*exp_polar(-I*pi) + 1)
+    -log(1 - z)
     >>> expand_func(polylog(0, z))
     z/(-z + 1)
 
@@ -277,7 +277,7 @@ class polylog(Function):
             return -dirichlet_eta(s)
         elif z == 0:
             return S.Zero
-        if s == 2:
+        elif s == 2:
             if z == S.Half:
                 return pi**2/12 - log(2)**2/2
             elif z == 2:
@@ -290,6 +290,12 @@ class polylog(Function):
                 return pi**2/15 - log((sqrt(5)-1)/2)**2
             elif z == (sqrt(5) - 1)/2:
                 return pi**2/10 - log((sqrt(5)-1)/2)**2
+        elif s == 1:
+            return -log(1 - z)
+        elif s == 0:
+            return z/(1 - z)
+        elif s == -1:
+            return z/(1 - z)**2
 
     def fdiff(self, argindex=1):
         s, z = self.args
@@ -304,7 +310,7 @@ class polylog(Function):
         from sympy import log, expand_mul, Dummy, exp_polar, I
         s, z = self.args
         if s == 1:
-            return -log(1 + exp_polar(-I*pi)*z)
+            return -log(1 - z)
         if s.is_Integer and s <= 0:
             u = Dummy('u')
             start = u/(1 - u)


### PR DESCRIPTION
#### References to other Issues or PRs

Closes #7132, also closes #13853.

#### Brief description of what is fixed or changed

`polylog(s, z)` has simple formulas for s = 0 and s = -1, These are now directly used by eval, just as it uses the formulas for z in -1, 0, 1 without the user needing to expand_func. For example:
```
>>> polylog(0, 2)
-2    # previously this returned unevaluated
```
One has to draw the line somewhere, and I left s = -2 and the rest un-evaluated, subject to the user applying `expand_func`. Also, keeping `polylog(1, z)` in the zeta-function family is better for series summation methods in cases when such sums end up being represented as zeta-function.

Per the discussion at #13853 the function expansion for s = 1 is now simply `-log(1 - z)`, as it appears in Wikipedia, Wolfram, etc.

#### Dilogarithm

Expressions such as polylog(2, 2) and polylog(2, 1/2) now also evaluate in closed form. The values are confirmed by comparing [Wikipedia](https://en.wikipedia.org/wiki/Spence%27s_function#Special_values) and [Wolfram Functions](http://functions.wolfram.com/ZetaFunctionsandPolylogarithms/PolyLog2/03/02/) and additionally checked by floating point evaluation.

**Add entry(ies) to the release notes?** No
  