### PR TITLE
Sympy.fps modified to return a formal power series

### DIFF
--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -20,6 +20,7 @@ from sympy.functions.combinatorial.factorials import binomial, factorial, rf
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.integers import floor, frac, ceiling
 from sympy.functions.elementary.miscellaneous import Min, Max
+from sympy.polys.polytools import degree
 from sympy.series.sequences import sequence
 from sympy.series.series_class import SeriesBase
 from sympy.series.order import Order
@@ -782,7 +783,15 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
         c = Symbol('c')
         ind = f.coeff(x, 0)
         xk = sequence(x**k, (k, 0, oo))
-        ak = sequence(c, (k, 0, oo))
+
+        ak = list()
+        deg = degree(f, gen=x) + 1
+        m = 0
+        while(deg != 0):
+            ak.append(f.coeff(x, m))
+            m += 1
+            deg -= 1
+
         return ak, xk, ind
 
     #  Break instances of Add

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -1020,7 +1020,7 @@ class FormalPowerSeries(SeriesBase):
 
     def _eval_term(self, pt):
         if (self.args[0].is_polynomial()):
-            return (self.args[0].coeff(self.x, pt))*(self.x)**pt
+            return (self.function.coeff(self.x, pt))*(self.x)**pt
         try:
             pt_xk = self.xk.coeff(pt)
             pt_ak = self.ak.coeff(pt).simplify()  # Simplify the coefficients

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -777,8 +777,13 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
         return (result[0], result[1].subs(x, rep2 + rep2b),
                 result[2].subs(x, rep2 + rep2b))
 
+    k = Dummy('k')
     if f.is_polynomial(x):
-        return None
+        c = Symbol('c')
+        ind = f.coeff(x, 0)
+        xk = sequence(x**k, (k, 0, oo))
+        ak = sequence(c, (k, 0, oo))
+        return ak, xk, ind
 
     #  Break instances of Add
     #  this allows application of different
@@ -812,7 +817,6 @@ def _compute_fps(f, x, x0, dir, hyper, order, rational, full):
     result = None
 
     # from here on it's x0=0 and dir=1 handling
-    k = Dummy('k')
     if rational:
         result = rational_algorithm(f, x, k, order, full)
 
@@ -1015,6 +1019,8 @@ class FormalPowerSeries(SeriesBase):
         return self.polynomial(n) + Order(pt_xk, (x, x0))
 
     def _eval_term(self, pt):
+        if (self.args[0].is_polynomial()):
+            return (self.args[0].coeff(self.x, pt))*(self.x)**pt
         try:
             pt_xk = self.xk.coeff(pt)
             pt_ak = self.ak.coeff(pt).simplify()  # Simplify the coefficients

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -499,10 +499,8 @@ def test_fps__operations():
 def test_issue_12310():
     x, c=symbols('x c')
     f = fps(x**2 + x**3/3 + x**8/12)
-    k = f.ak.variables[0]
     assert f[0] == 0
     assert f[3] == x**3/3
     assert f[8] == x**8/12
     assert f.truncate(4) == x**2 + x**3/3 + O(x**4)
     assert f.polynomial() == x**2 + x**3/3
-    assert f.infinite == Sum(c*x**k, (k, 0, oo))

--- a/sympy/series/tests/test_formal.py
+++ b/sympy/series/tests/test_formal.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, factorial, sqrt, Rational, atan, I, log, fps, O,
                    Sum, oo, S, pi, cos, sin, Function, exp, Derivative, asin,
                    airyai, acos, acosh, gamma, erf, asech, Add, Integral, Mul,
-                   integrate)
+                   integrate, Dummy)
 from sympy.series.formal import (rational_algorithm, FormalPowerSeries,
                                  rational_independent, simpleDE, exp_re,
                                  hyper_re)
@@ -146,7 +146,6 @@ def test_fps():
     assert fps(2, x) == 2
     assert fps(2, x, dir='+') == 2
     assert fps(2, x, dir='-') == 2
-    assert fps(x**2 + x + 1) == x**2 + x + 1
     assert fps(1/x + 1/x**2) == 1/x + 1/x**2
     assert fps(log(1 + x), hyper=False, rational=False) == log(1 + x)
 
@@ -495,3 +494,15 @@ def test_fps__operations():
     fi = f2.integrate(x)
     assert fi.function == sin(x)
     assert fi.truncate() == x - x**3/6 + x**5/120 + O(x**6)
+
+
+def test_issue_12310():
+    x, c=symbols('x c')
+    f = fps(x**2 + x**3/3 + x**8/12)
+    k = f.ak.variables[0]
+    assert f[0] == 0
+    assert f[3] == x**3/3
+    assert f[8] == x**8/12
+    assert f.truncate(4) == x**2 + x**3/3 + O(x**4)
+    assert f.polynomial() == x**2 + x**3/3
+    assert f.infinite == Sum(c*x**k, (k, 0, oo))


### PR DESCRIPTION
Fixes #12310 

formal.py in series has been modified such that sympy.fps returns a formal power series always.

**PREVIOUS**

`>>> from sympy import Symbol, fps`
`>>> x = Symbol('x')`
`>>> p = fps(x ** 2)`
`>>> p`
`x**2`
`>>> type(p)`
`<class 'sympy.core.power.Pow'>`
`>>> p[0]`
`Traceback (most recent call last):`
 ` File "<stdin>", line 1, in <module>`
`TypeError: 'Pow' object does not support indexing `

**NOW**

`>>> from sympy import Symbol, fps`
`>>> x = Symbol('x')`
`>>> p = fps(x ** 2)`
`>>> p`
`FormalPowerSeries(x**2, x, 0, 1, (SeqFormula(c, (_k, 0, oo)), SeqFormula(x**_k, (_k, 0, oo)), 0))`
`>>> type(p)`
`<class 'sympy.series.formal.FormalPowerSeries'>`
`>>> p[0]`
`0`

@smichr , @jksuom , @ylemkimon , please review.