### PR TITLE
Modified coeffs-generator to remove runtime error in solve/nonlinsolve

### DIFF
--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -813,8 +813,11 @@ __all__.append('minpoly')
 
 def _coeffs_generator(n):
     """Generate coefficients for `primitive_element()`. """
-    for coeffs in variations([1, -1], n, repetition=True):
-        yield list(coeffs)
+    for coeffs in variations([1, -1, 2, -2, 3, -3], n, repetition=True):
+        # Two linear combinations with coeffs of opposite signs are
+        # opposites of each other. Hence it suffices to test only one.
+        if coeffs[0] > 0:
+            yield list(coeffs)
 
 
 @public

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1885,3 +1885,8 @@ def test_issue_12476():
             {x0: 1, x3: -S(1)/3, x2: S(1)/3, x4: -sqrt(5)/3, x1: sqrt(5)/3, x5: -1}]
 
     assert solve(eqns) == sols
+
+
+def test_issue_13849():
+    t = symbols('t')
+    assert solve((t*(sqrt(5) + sqrt(2)) - sqrt(2), t), t) == []

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1638,6 +1638,6 @@ def test_issue_13550():
     assert solveset(x**2 - 2*x - 15, symbol = x, domain = Interval(-oo, 0)) == FiniteSet(-3)
 
 
-def test_issue_13842():
+def test_issue_13849():
     t = symbols('t')
     assert nonlinsolve((t*(sqrt(5) + sqrt(2)) - sqrt(2), t), t) == EmptySet()

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1636,3 +1636,8 @@ def test__is_finite_with_finite_vars():
 
 def test_issue_13550():
     assert solveset(x**2 - 2*x - 15, symbol = x, domain = Interval(-oo, 0)) == FiniteSet(-3)
+
+
+def test_issue_13842():
+    t = symbols('t')
+    assert nonlinsolve((t*(sqrt(5) + sqrt(2)) - sqrt(2), t), t) == EmptySet()


### PR DESCRIPTION
Fixes #13849 .

** NOW **

`>>> from sympy import *`
`>>> t = Symbol('t')`
`>>> solve((t*(sqrt(5) + sqrt(2)) - sqrt(2), t), t)`
`[]`
`>>> nonlinsolve((t*(sqrt(5) + sqrt(2)) - sqrt(2), t), t)`
`EmptySet()`

The above don't show the runtime error as it used to show before, sine the coefficient generator has been modified.
