### PR TITLE
det(matrix) supports "method" argument.

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1450,7 +1450,7 @@ def wronskian(functions, var, method='bareiss'):
     if n == 0:
         return 1
     W = Matrix(n, n, lambda i, j: functions[i].diff(var, j))
-    return W.det(method)
+    return W.det(method='bareiss')
 
 
 def zeros(*args, **kwargs):

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1450,7 +1450,7 @@ def wronskian(functions, var, method='bareiss'):
     if n == 0:
         return 1
     W = Matrix(n, n, lambda i, j: functions[i].diff(var, j))
-    return W.det(method='bareiss')
+    return W.det(method=method)
 
 
 def zeros(*args, **kwargs):

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -44,11 +44,11 @@ def det(matexpr, **kwargs):
 
     Possible 'kwargs' are:
     method : string, optional (default='bareiss')
-            specifies the algorithm to be used for computing the algorithm.
-            It must be one of 'bareiss', 'lu' or 'berkowitz'.
-            If matexpr is a concrete matrix, the determinant takes
-            a keyword argument 'method" which can be one of "bareiss", "berkowitz", and
-            "lu"; the default is "bareiss".
+        specifies the algorithm to be used for computing the algorithm.
+        It must be one of 'bareiss', 'lu' or 'berkowitz'.
+        If matexpr is a concrete matrix, the determinant takes
+        a keyword argument 'method" which can be one of "bareiss", "berkowitz", and
+        "lu"; the default is "bareiss".
 
     >>> from sympy import MatrixSymbol, det, eye
     >>> A = MatrixSymbol('A', 3, 3)

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -51,7 +51,7 @@ def det(matexpr, method=None):
     1
     """
 
-    if isinstance(matexpr, MatrixExpr) and not method:
+    if isinstance(matexpr, MatrixExpr) and  method is not None:
         raise ValueError("Keyword arguments not supported for matrix expressions.")
 
     return Determinant(matexpr).doit(method=method)

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -33,13 +33,13 @@ class Determinant(Expr):
     def arg(self):
         return self.args[0]
 
-    def doit(self, expand=False, **kwargs):
+    def doit(self, expand=False, method=None):
         try:
-            return self.arg._eval_determinant(**kwargs)
+            return self.arg._eval_determinant(method=method)
         except (AttributeError, NotImplementedError):
             return self
 
-def det(matexpr, **kwargs):
+def det(matexpr, method=None):
     """ Matrix Determinant
 
     >>> from sympy import MatrixSymbol, det, eye
@@ -51,10 +51,10 @@ def det(matexpr, **kwargs):
     1
     """
 
-    if isinstance(matexpr, MatrixExpr) and kwargs:
+    if isinstance(matexpr, MatrixExpr) and not method:
         raise ValueError("Keyword arguments not supported for matrix expressions.")
 
-    return Determinant(matexpr).doit(**kwargs)
+    return Determinant(matexpr).doit(method=method)
 
 
 from sympy.assumptions.ask import ask, Q

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy import Basic, Expr, S, sympify
 from .matexpr import ShapeError
+from sympy.matrices.expressions.matexpr import MatrixExpr
 
 
 class Determinant(Expr):

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -46,7 +46,7 @@ def det(matexpr, **kwargs):
     method : string, optional (default='bareiss')
         specifies the algorithm to be used for computing the algorithm.
         It must be one of 'bareiss', 'lu' or 'berkowitz'.
-        "method" is only applicable for a concrete matrix.
+        ``method`` is only applicable for a concrete matrix.
 
     >>> from sympy import MatrixSymbol, det, eye
     >>> A = MatrixSymbol('A', 3, 3)
@@ -57,7 +57,7 @@ def det(matexpr, **kwargs):
     1
     """
 
-    if isinstance(matexpr, MatrixExpr) and  kwargs:
+    if isinstance(matexpr, MatrixExpr) and kwargs:
         raise ValueError(
             "Keyword arguments not supported for matrix expressions.")
 

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -40,8 +40,10 @@ class Determinant(Expr):
             return self
 
 def det(matexpr, **kwargs):
-    """ Matrix Determinant
-
+    """ Matrix Determinant. If matexpr is a concrete matrix, the determinant takes
+    a keyword argument 'method" which can be one of "bareiss", "berkowitz", and 
+    "lu"; the default is "bareiss".
+    
     >>> from sympy import MatrixSymbol, det, eye
     >>> A = MatrixSymbol('A', 3, 3)
     >>> det(A)

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -33,7 +33,7 @@ class Determinant(Expr):
     def arg(self):
         return self.args[0]
 
-    def doit(self, expand=False, **kwargs):
+    def doit(self, **kwargs):
         try:
             return self.arg._eval_determinant(**kwargs)
         except (AttributeError, NotImplementedError):
@@ -46,9 +46,7 @@ def det(matexpr, **kwargs):
     method : string, optional (default='bareiss')
         specifies the algorithm to be used for computing the algorithm.
         It must be one of 'bareiss', 'lu' or 'berkowitz'.
-        If matexpr is a concrete matrix, the determinant takes
-        a keyword argument 'method" which can be one of "bareiss", "berkowitz", and
-        "lu"; the default is "bareiss".
+        "method" is only applicable for a concrete matrix.
 
     >>> from sympy import MatrixSymbol, det, eye
     >>> A = MatrixSymbol('A', 3, 3)
@@ -60,7 +58,8 @@ def det(matexpr, **kwargs):
     """
 
     if isinstance(matexpr, MatrixExpr) and  kwargs:
-        raise ValueError("Keyword arguments not supported for matrix expressions.")
+        raise ValueError(
+            "Keyword arguments not supported for matrix expressions.")
 
     return Determinant(matexpr).doit(**kwargs)
 

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -41,9 +41,9 @@ class Determinant(Expr):
 
 def det(matexpr, **kwargs):
     """ Matrix Determinant. If matexpr is a concrete matrix, the determinant takes
-    a keyword argument 'method" which can be one of "bareiss", "berkowitz", and 
+    a keyword argument 'method" which can be one of "bareiss", "berkowitz", and
     "lu"; the default is "bareiss".
-    
+
     >>> from sympy import MatrixSymbol, det, eye
     >>> A = MatrixSymbol('A', 3, 3)
     >>> det(A)

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -33,13 +33,13 @@ class Determinant(Expr):
     def arg(self):
         return self.args[0]
 
-    def doit(self, expand=False, method=None):
+    def doit(self, expand=False, **kwargs):
         try:
-            return self.arg._eval_determinant(method=method)
+            return self.arg._eval_determinant(**kwargs)
         except (AttributeError, NotImplementedError):
             return self
 
-def det(matexpr, method=None):
+def det(matexpr, **kwargs):
     """ Matrix Determinant
 
     >>> from sympy import MatrixSymbol, det, eye
@@ -51,10 +51,10 @@ def det(matexpr, method=None):
     1
     """
 
-    if isinstance(matexpr, MatrixExpr) and  method is not None:
+    if isinstance(matexpr, MatrixExpr) and  kwargs:
         raise ValueError("Keyword arguments not supported for matrix expressions.")
 
-    return Determinant(matexpr).doit(method=method)
+    return Determinant(matexpr).doit(**kwargs)
 
 
 from sympy.assumptions.ask import ask, Q

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -40,9 +40,15 @@ class Determinant(Expr):
             return self
 
 def det(matexpr, **kwargs):
-    """ Matrix Determinant. If matexpr is a concrete matrix, the determinant takes
-    a keyword argument 'method" which can be one of "bareiss", "berkowitz", and
-    "lu"; the default is "bareiss".
+    """ Matrix Determinant.
+
+    Possible 'kwargs' are:
+    method : string, optional (default='bareiss')
+            specifies the algorithm to be used for computing the algorithm.
+            It must be one of 'bareiss', 'lu' or 'berkowitz'.
+            If matexpr is a concrete matrix, the determinant takes
+            a keyword argument 'method" which can be one of "bareiss", "berkowitz", and
+            "lu"; the default is "bareiss".
 
     >>> from sympy import MatrixSymbol, det, eye
     >>> A = MatrixSymbol('A', 3, 3)

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -50,6 +50,9 @@ def det(matexpr, **kwargs):
     1
     """
 
+    if isinstance(matexpr, MatrixExpr) and kwargs:
+        raise ValueError("Keyword arguments not supported for matrix expressions.")
+
     return Determinant(matexpr).doit(**kwargs)
 
 

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -32,13 +32,13 @@ class Determinant(Expr):
     def arg(self):
         return self.args[0]
 
-    def doit(self, expand=False):
+    def doit(self, expand=False, **kwargs):
         try:
-            return self.arg._eval_determinant()
+            return self.arg._eval_determinant(**kwargs)
         except (AttributeError, NotImplementedError):
             return self
 
-def det(matexpr):
+def det(matexpr, **kwargs):
     """ Matrix Determinant
 
     >>> from sympy import MatrixSymbol, det, eye
@@ -50,7 +50,7 @@ def det(matexpr):
     1
     """
 
-    return Determinant(matexpr).doit()
+    return Determinant(matexpr).doit(**kwargs)
 
 
 from sympy.assumptions.ask import ask, Q

--- a/sympy/matrices/expressions/tests/test_determinant.py
+++ b/sympy/matrices/expressions/tests/test_determinant.py
@@ -34,3 +34,9 @@ def test_eval_determinant():
 def test_refine():
     assert refine(det(A), Q.orthogonal(A)) == 1
     assert refine(det(A), Q.singular(A)) == 0
+
+
+def test_issue_13842():
+    assert det(eye(3), method="bareiss") == 1
+    assert det(eye(3), method="berkowitz") == 1
+    raises(ValueError, lambda: det(C, method="bareiss"))

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -266,10 +266,10 @@ class MatrixDeterminant(MatrixCommon):
         # return det(P)*det(U)
         return det
 
-    def _eval_determinant(self, **kwargs):
+    def _eval_determinant(self, method=None):
         """Assumed to exist by matrix expressions; If we subclass
         MatrixDeterminant, we can fully evaluate determinants."""
-        return self.det(**kwargs)
+        return self.det(method=method)
 
     def adjugate(self, method="berkowitz"):
         """Returns the adjugate, or classical adjoint, of

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -266,10 +266,10 @@ class MatrixDeterminant(MatrixCommon):
         # return det(P)*det(U)
         return det
 
-    def _eval_determinant(self):
+    def _eval_determinant(self, **kwargs):
         """Assumed to exist by matrix expressions; If we subclass
         MatrixDeterminant, we can fully evaluate determinants."""
-        return self.det()
+        return self.det(**kwargs)
 
     def adjugate(self, method="berkowitz"):
         """Returns the adjugate, or classical adjoint, of
@@ -379,7 +379,7 @@ class MatrixDeterminant(MatrixCommon):
         return self._new(self.rows, self.cols,
                          lambda i, j: self.cofactor(i, j, method))
 
-    def det(self, method="bareiss"):
+    def det(self, **kwargs):
         """Computes the determinant of a matrix.  If the matrix
         is at most 3x3, a hard-coded formula is used.
         Otherwise, the determinant using the method `method`.
@@ -392,6 +392,7 @@ class MatrixDeterminant(MatrixCommon):
         """
 
         # sanitize `method`
+        method = kwargs.get('method', "bareiss")
         method = method.lower()
         if method == "bareis":
             method = "bareiss"

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -266,13 +266,10 @@ class MatrixDeterminant(MatrixCommon):
         # return det(P)*det(U)
         return det
 
-    def _eval_determinant(self, method=None):
+    def _eval_determinant(self, **kwargs):
         """Assumed to exist by matrix expressions; If we subclass
         MatrixDeterminant, we can fully evaluate determinants."""
-        if method is None:
-            return self.det()
-        else:
-            return self.det(method=method)
+        return self.det(**kwargs)
 
     def adjugate(self, method="berkowitz"):
         """Returns the adjugate, or classical adjoint, of

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -269,7 +269,10 @@ class MatrixDeterminant(MatrixCommon):
     def _eval_determinant(self, method=None):
         """Assumed to exist by matrix expressions; If we subclass
         MatrixDeterminant, we can fully evaluate determinants."""
-        return self.det(method=method)
+        if method is None:
+            return self.det()
+        else:
+            return self.det(method=method)
 
     def adjugate(self, method="berkowitz"):
         """Returns the adjugate, or classical adjoint, of

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -379,7 +379,7 @@ class MatrixDeterminant(MatrixCommon):
         return self._new(self.rows, self.cols,
                          lambda i, j: self.cofactor(i, j, method))
 
-    def det(self, **kwargs):
+    def det(self, method="bareiss"):
         """Computes the determinant of a matrix.  If the matrix
         is at most 3x3, a hard-coded formula is used.
         Otherwise, the determinant using the method `method`.
@@ -392,7 +392,6 @@ class MatrixDeterminant(MatrixCommon):
         """
 
         # sanitize `method`
-        method = kwargs.get('method', "bareiss")
         method = method.lower()
         if method == "bareis":
             method = "bareiss"

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1897,7 +1897,7 @@ def test_errors():
     raises(IndexError, lambda: eye(3)[5, 2])
     raises(IndexError, lambda: eye(3)[2, 5])
     M = Matrix(((1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12), (13, 14, 15, 16)))
-    raises(ValueError, lambda: M.det('method=LU_decomposition()'))
+    raises(ValueError, lambda: M.det(method='LU_decomposition()'))
 
 
 def test_len():


### PR DESCRIPTION
Fixes #13842 .

**kwargs have been passed through the det method, just like M.det().

@normalhuman , @smichr , @gxyd , please review.