### PR TITLE
[WIP] In definite integrals, infer assumptions from the given limits

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -140,10 +140,15 @@ class Integral(AddWithLimits):
     # Variables may be temporarily replaced by dummies to enforce assumptions
     # inferred from limits. This is done by _rewrite_with_assumptions method.
     # The _restore_vars will get the original variables back if they remain.
+    # This is only attempted when _replace_variables is true
+
+    _replace_variables = False
+    _replacement_dict = {}
+    _restoration_dict = {}
 
     def _rewrite_with_assumptions(self, function):
-        replacement = {}
-        restoration = {}
+        self._replacement_dict = {}
+        self._restoration_dict = {}
         dummy_number = 0
         for xab in self.limits:
             if len(xab) < 3:
@@ -154,17 +159,21 @@ class Integral(AddWithLimits):
                 if getattr(xab[1], "is_" + property) and \
                     getattr(xab[2], "is_" + property):
                     assumptions[property] = True
-            _nu = Dummy("nu_%s" % dummy_number, **assumptions)
-            dummy_number += 1
-            replacement[xab[0]] = _nu
-            restoration[_nu] = xab[0]
-        function = function.xreplace(replacement)
-        limits = sympify(self.limits).xreplace(replacement)
-        return function, limits, restoration
+            if assumptions != xab[0].assumptions0:
+                _nu = Dummy("nu_%s" % dummy_number, **assumptions)
+                dummy_number += 1
+                self._replacement_dict[xab[0]] = _nu
+                self._restoration_dict[_nu] = xab[0]
+        function = function.xreplace(self._replacement_dict)
+        limits = sympify(self.limits).xreplace(self._replacement_dict)
+        return function, limits
 
-    def _restore_vars(self, expr, restoration):
+    def _restore_vars(self, expr):
         # expr is sometimes a Python tuple, so sympify to make a SymPy tuple
-        return sympify(expr).xreplace(restoration)
+        restored_expr = sympify(expr).xreplace(self._restoration_dict)
+        # reset the flag for replacing variables
+        self._replace_variables = False
+        return restored_expr
 
     def transform(self, x, u):
         r"""
@@ -446,7 +455,15 @@ class Integral(AddWithLimits):
 
         # There is no trivial answer and special handling
         # is done so continue
-        function, limits, restoration = self._rewrite_with_assumptions(function)
+
+        # Consider rewriting the integral using assumptions inferred from limits
+        # (so we know if this is even possible), but don't use the rewritten form
+        # unless the flag _replace_variables is set
+        new_function, new_limits = self._rewrite_with_assumptions(function)
+        if self._replace_variables:
+            function, limits = new_function, new_limits
+        else:
+            limits = self.limits
 
         undone_limits = []
         # ulj = free symbols of any undone limits' upper and lower limits
@@ -616,7 +633,16 @@ class Integral(AddWithLimits):
                             factored_function = function.factor()
                             if not isinstance(factored_function, Integral):
                                 function = factored_function
-        return self._restore_vars(function, restoration)
+
+        if self._replace_variables:
+            function = self._restore_vars(function)
+        elif isinstance(function, Integral) and self._replacement_dict:
+            # Did not quite succeed with this definite integral,
+            # so let's try again with assumptions inferred
+            self._replace_variables = True
+            function = self.doit()
+
+        return function
 
     def _eval_derivative(self, sym):
         """Evaluate the derivative of the current Integral object by

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -137,6 +137,35 @@ class Integral(AddWithLimits):
         if self.function.is_zero is False and got_none is False:
             return False
 
+    # Variables may be temporarily replaced by dummies to enforce assumptions
+    # inferred from limits. This is done by _rewrite_with_assumptions method.
+    # The _restore_vars will get the original variables back if they remain.
+
+    def _rewrite_with_assumptions(self, function):
+        replacement = {}
+        restoration = {}
+        dummy_number = 0
+        for xab in self.limits:
+            if len(xab) < 3:
+                continue
+            assumptions = xab[0].assumptions0
+            for property in ["real", "nonnegative", "positive", "nonpositive",
+                             "negative"]:
+                if getattr(xab[1], "is_" + property) and \
+                    getattr(xab[2], "is_" + property):
+                    assumptions[property] = True
+            _nu = Dummy("nu_%s" % dummy_number, **assumptions)
+            dummy_number += 1
+            replacement[xab[0]] = _nu
+            restoration[_nu] = xab[0]
+        function = function.xreplace(replacement)
+        limits = sympify(self.limits).xreplace(replacement)
+        return function, limits, restoration
+
+    def _restore_vars(self, expr, restoration):
+        # expr is sometimes a Python tuple, so sympify to make a SymPy tuple
+        return sympify(expr).xreplace(restoration)
+
     def transform(self, x, u):
         r"""
         Performs a change of variables from `x` to `u` using the relationship
@@ -417,11 +446,12 @@ class Integral(AddWithLimits):
 
         # There is no trivial answer and special handling
         # is done so continue
+        function, limits, restoration = self._rewrite_with_assumptions(function)
 
         undone_limits = []
         # ulj = free symbols of any undone limits' upper and lower limits
         ulj = set()
-        for xab in self.limits:
+        for xab in limits:
             # compute uli, the free symbols in the
             # Upper and Lower limits of limit I
             if len(xab) == 1:
@@ -586,7 +616,7 @@ class Integral(AddWithLimits):
                             factored_function = function.factor()
                             if not isinstance(factored_function, Integral):
                                 function = factored_function
-        return function
+        return self._restore_vars(function, restoration)
 
     def _eval_derivative(self, sym):
         """Evaluate the derivative of the current Integral object by

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1193,3 +1193,12 @@ def test_issue_12645():
 
 def test_issue_12677():
     assert integrate(sin(x) / (cos(x)**3) , (x, 0, pi/6)) == Rational(1,6)
+
+def test_abs_value_issue_8430():
+    assert integrate(Abs(x), (x, 0, 1)) == S(1)/2
+    assert integrate(Abs(x), (x, -2, 0)) == 2
+    assert integrate(Abs(2*x + 1), (x, 1, 3)) == 10
+
+def test_inferred_assumptions():
+    assert integrate(exp(-x*y)*y, (x, 1, oo), (y, 1, oo)) == exp(-1)
+    assert integrate(exp(-x*y)*x, (x, 1, oo), (y, 1, oo)) == exp(-1)


### PR DESCRIPTION
#### References to other Issues or PRs

Infers assumptions on a variable of integration from its limits. Fixes #8430

#### Brief description of what is fixed or changed

In definite integrals, the variable of integration is replaced by a dummy variable on which additional assumptions are imposed, according to the limits of integration. At the end of computation, this replacement is undone. The result is that more integrals work "out of the box", without users being puzzled by unexpectedly complex or un-evaluated output.

#### Examples

An example from current master branch:
```
>>> from sympy import *
>>> from sympy.abc import x, y
>>> integrate(exp(-x*y)*y, (x, 1, oo), (y, 1, oo))
Integral(Piecewise((exp(-y), pi/2 > Abs(periodic_argument(y, oo))), (Integral(y*exp(-x*y), (x, 1, oo)), True)), (y, 1, oo))
```
With this PR, the output is `exp(-1)`.

For another example, `integrate(abs(x), (x, 0, 1))` is now 1/2 instead of being returned unevaluated.

#### Other comments

One may be tempted to be more aggressive and declare the variable positive when the interval of integration is [0, b], thinking that one point shouldn't matter for integration. This turns out to be not a good idea, because the integrator may end up producing something that will make nan when 0 is plugged in.