### PR TITLE
Correct casting of NumPy floats to SymPy floats

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -62,7 +62,9 @@ def _convert_numpy_types(a):
     else:
         try:
             from sympy.core.numbers import Float
-            prec = np.finfo(a).nmant
+            prec = np.finfo(a).nmant + 1
+            # E.g. double precision means prec=53 but nmant=52
+            # Leading bit of mantissa is always 1, so is not stored
             a = str(list(np.reshape(np.asarray(a),
                                     (1, np.size(a)))[0]))[1:-1]
             return Float(a, precision=prec)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1764,15 +1764,15 @@ def test_numpy_to_float():
         skip('numpy not installed. Abort numpy tests.')
 
     def check_prec_and_relerr(npval, ratval):
-        prec = np.finfo(npval).nmant
+        prec = np.finfo(npval).nmant + 1
         x = Float(npval)
         assert x._prec == prec
         y = Float(ratval, precision=prec)
-        assert abs((x - y)/y) < 2**(-(prec+1))
+        assert abs((x - y)/y) < 2**(-(prec + 1))
 
-    check_prec_and_relerr(np.float16(2)/3, S(2)/3)
-    check_prec_and_relerr(np.float32(2)/3, S(2)/3)
-    check_prec_and_relerr(np.float64(2)/3, S(2)/3)
+    check_prec_and_relerr(np.float16(2/3), S(2)/3)
+    check_prec_and_relerr(np.float32(2/3), S(2)/3)
+    check_prec_and_relerr(np.float64(2/3), S(2)/3)
     # extended precision, on some arch/compilers:
     x = np.longdouble(2)/3
     check_prec_and_relerr(x, S(2)/3)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Use the correct value of binary precision: `np.finfo(x).nmant + 1` instead of the current `np.finfo(x).nmant`. Fix the tests in test_number which did not detect the above error because they were not implemented correctly either.

#### Explanation

Sympify interprets np.finfo(x).nmant as binary precision. In fact, nmant is the number of bits used to store the mantissa, for example 52 in double precision. But this does not count the leading bit of mantissa, which is always 1 and therefore not stored. The binary precision, in the sense of the parameter used by SymPy and mpmath, is 53 for double precision floats, not 52.

As a result of this discrepancy, sympify loses 1 bit of precision for NumPy types float16 and float32 (not for default float64, which is treated same as Python float). Examples:
```
np.float16(2/3)            #  0.6665
srepr(S(np.float16(2/3)))  #  Float('0.66602', precision=10)")
```
and
```
int(np.float32(2/3) * 2**24)     # 11184811
int(S(np.float32(2/3)) * 2**24)  # 11184812
```

The tests in test_number did not detect this because they tested on `np.float16(2)/3` and `np.float32(2)/3`.
In the process of division by 3, NumPy upcasts these floats, so both of these numbers are identical to each other and to `np.float64(2)/3` (and the error did not affect float64). The correct way is test is with `np.float16(2/3)` and `np.float32(2/3)`.  (For the longdouble, however, `np.longdouble(2)/3` is the correct way to get a longdouble representing 2/3. The upshot is that the output will use the higher precision of two available, because NumPy needs a format that can represent both terms)