### PR TITLE
parameter_value method added to geometric entities

### DIFF
--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -166,6 +166,10 @@ class Curve(GeometrySet):
         return free
 
     @property
+    def ambient_dimension(self):
+        return len(self.args[0])
+
+    @property
     def functions(self):
         """The functions specifying the curve.
 

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -29,6 +29,7 @@ from sympy.core.sympify import sympify
 from sympy.functions import cos, sin
 from sympy.matrices import eye
 from sympy.sets import Set
+from sympy.utilities.misc import func_name
 
 # How entities are ordered; used by __cmp__ in GeometryEntity
 ordering_of_classes = [
@@ -456,7 +457,7 @@ class GeometryEntity(Basic):
         Triangle(Point2D(1, 0), Point2D(-1/2, sqrt(3)/2), Point2D(-1/2, -sqrt(3)/2))
         >>> t.scale(2)
         Triangle(Point2D(2, 0), Point2D(-1, sqrt(3)/2), Point2D(-1, -sqrt(3)/2))
-        >>> t.scale(2,2)
+        >>> t.scale(2, 2)
         Triangle(Point2D(2, 0), Point2D(-1, sqrt(3)), Point2D(-1, -sqrt(3)))
 
         """
@@ -496,16 +497,17 @@ class GeometryEntity(Basic):
                 newargs.append(a)
         return self.func(*newargs)
 
-    def parameter_value(self,other):
-        """Return the parameter corresponding to the given point. Evaluating
-        the entity at this parameter value will return the given point.
+    def parameter_value(self, other):
+        """Return the parameter corresponding to the given point.
+        Evaluating an arbitrary point of the entity at this parameter
+        value will return the given point.
 
         Examples
         ========
 
         >>> from sympy import Line, Point
         >>> from sympy.abc import t
-        >>> a = Point(0,0)
+        >>> a = Point(0, 0)
         >>> b = Point(2, 2)
         >>> Line(a, b).parameter_value((1, 1))
         1/2
@@ -515,16 +517,16 @@ class GeometryEntity(Basic):
         from sympy.geometry.point import Point
         from sympy.core.symbol import Dummy
         from sympy.solvers.solvers import solve
-        if not isinstance(other,GeometryEntity):
+        if not isinstance(other, GeometryEntity):
             other = Point(other, dim=self.ambient_dimension)
-        if not isinstance(other,Point):
+        if not isinstance(other, Point):
             raise ValueError("other must be a point")
-        t = Dummy()
+        t = Dummy('t', real=True)
         sol = solve(self.arbitrary_point(t) - other, t, dict=True)
-        if len(sol) == 0:
-            raise ValueError("Given point is not on %s" %type(self).__name__)
-        v = sol[0].get(t)
-        return v
+        if not sol:
+            raise ValueError("Given point is not on %s" % func_name(self))
+        return sol[0].get(t)
+
 
 class GeometrySet(GeometryEntity, Set):
     """Parent class of all GeometryEntity that are also Sets

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -516,14 +516,15 @@ class GeometryEntity(Basic):
         from sympy.core.symbol import Dummy
         from sympy.solvers.solvers import solve
         if not isinstance(other,GeometryEntity):
-            other = Point(other,dim = self.ambient_dimension)
+            other = Point(other, dim=self.ambient_dimension)
         if not isinstance(other,Point):
             raise ValueError("other must be a point")
         t = Dummy()
-        sol = solve(self.arbitrary_point(t) - other,t,dict = True)
+        sol = solve(self.arbitrary_point(t) - other, t, dict=True)
         if len(sol) == 0:
-            raise ValueError("Given point is not on %s" %type(self))
-        return sol[0].values()[0]
+            raise ValueError("Given point is not on %s" %type(self).__name__)
+        v = sol[0].get(t)
+        return v
 
 class GeometrySet(GeometryEntity, Set):
     """Parent class of all GeometryEntity that are also Sets

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -496,6 +496,35 @@ class GeometryEntity(Basic):
                 newargs.append(a)
         return self.func(*newargs)
 
+    def parameter_value(self,other):
+        """Return the parameter corresponding to the given point. Evaluating
+        the entity at this parameter value will return the given point.
+
+        Examples
+        ========
+
+        >>> from sympy import Line, Point
+        >>> from sympy.abc import t
+        >>> a = Point(0,0)
+        >>> b = Point(2, 2)
+        >>> Line(a, b).parameter_value((1, 1))
+        1/2
+        >>> Line(a, b).arbitrary_point(t).subs(t, 0.5)
+        Point2D(1, 1)
+        """
+        from sympy.geometry.point import Point
+        from sympy.core.symbol import Dummy
+        from sympy.solvers.solvers import solve
+        if not isinstance(other,GeometryEntity):
+            other = Point(other,dim = self.ambient_dimension)
+        if not isinstance(other,Point):
+            raise ValueError("other must be a point")
+        t = Dummy()
+        sol = solve(self.arbitrary_point(t) - other,t,dict = True)
+        if len(sol) == 0:
+            raise ValueError("Given point is not on %s" %type(self))
+        return sol[0].values()[0]
+
 class GeometrySet(GeometryEntity, Set):
     """Parent class of all GeometryEntity that are also Sets
     (compatible with sympy.sets)

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -25,6 +25,7 @@ from __future__ import division, print_function
 from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
 from sympy.core.basic import Basic
+from sympy.core.symbol import _symbol
 from sympy.core.sympify import sympify
 from sympy.functions import cos, sin
 from sympy.matrices import eye
@@ -497,7 +498,7 @@ class GeometryEntity(Basic):
                 newargs.append(a)
         return self.func(*newargs)
 
-    def parameter_value(self, other):
+    def parameter_value(self, other, t):
         """Return the parameter corresponding to the given point.
         Evaluating an arbitrary point of the entity at this parameter
         value will return the given point.
@@ -509,8 +510,8 @@ class GeometryEntity(Basic):
         >>> from sympy.abc import t
         >>> a = Point(0, 0)
         >>> b = Point(2, 2)
-        >>> Line(a, b).parameter_value((1, 1))
-        1/2
+        >>> Line(a, b).parameter_value((1, 1), t)
+        {t: 1/2}
         >>> Line(a, b).arbitrary_point(t).subs(t, 0.5)
         Point2D(1, 1)
         """
@@ -521,11 +522,11 @@ class GeometryEntity(Basic):
             other = Point(other, dim=self.ambient_dimension)
         if not isinstance(other, Point):
             raise ValueError("other must be a point")
-        t = Dummy('t', real=True)
-        sol = solve(self.arbitrary_point(t) - other, t, dict=True)
+        T = Dummy('t', real=True)
+        sol = solve(self.arbitrary_point(T) - other, T, dict=True)
         if not sol:
             raise ValueError("Given point is not on %s" % func_name(self))
-        return sol[0].get(t)
+        return {t: sol[0][T]}
 
 
 class GeometrySet(GeometryEntity, Set):

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -512,7 +512,7 @@ class GeometryEntity(Basic):
         >>> b = Point(2, 2)
         >>> Line(a, b).parameter_value((1, 1), t)
         {t: 1/2}
-        >>> Line(a, b).arbitrary_point(t).subs(t, 0.5)
+        >>> Line(a, b).arbitrary_point(t).subs(_)
         Point2D(1, 1)
         """
         from sympy.geometry.point import Point

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -147,7 +147,7 @@ class Plane(GeometryEntity):
         ========
 
         >>> from sympy.geometry import Plane, Ray
-        >>> from sympy.abc import u, v, t
+        >>> from sympy.abc import u, v, t, r
         >>> p = Plane((1, 1, 1), normal_vector=(1, 0, 0))
         >>> p.arbitrary_point(u, v)
         Point3D(1, u + 1, v + 1)
@@ -155,13 +155,12 @@ class Plane(GeometryEntity):
         Point3D(1, cos(t) + 1, sin(t) + 1)
 
         While arbitrary values of u and v can move the point anywhere in
-        the plane, the single-parameter point can be moved on a ray
-        relative to the p1 value. For example, to locate it a distance
-        of 2 from p1 one could do:
+        the plane, the single-parameter point can be used to construct a
+        ray whose arbitrary point can be located at angle t and radius
+        r from p.p1:
 
-        >>> delta = (_ - p.p1)
-        >>> p.p1 + delta*2
-        Point3D(1, 2*cos(t) + 1, 2*sin(t) + 1)
+        >>> Ray(p.p1, _).arbitrary_point(r)
+        Point3D(1, r*cos(t) + 1, r*sin(t) + 1)
 
         Returns
         =======

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -795,3 +795,7 @@ class Plane(GeometryEntity):
         u, v = Dummy('u'), Dummy('v')
         params = {u: Rational(rng.random()), v: Rational(rng.random())}
         return self.arbitrary_point(u, v).subs(params)
+
+    @property
+    def ambient_dimension(self):
+        return self.p1.ambient_dimension

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -270,6 +270,10 @@ class Polygon(GeometrySet):
         return ret
 
     @property
+    def ambient_dimension(self):
+        return self.vertices[0].ambient_dimension
+
+    @property
     def perimeter(self):
         """The perimeter of the polygon.
 
@@ -606,6 +610,26 @@ class Polygon(GeometrySet):
                 (pt, (And(perim_fraction_start <= t, t < perim_fraction_end))))
             perim_fraction_start = perim_fraction_end
         return Piecewise(*sides)
+
+    def parameter_value(self,other):
+        from sympy.geometry.point import Point
+        from sympy.core.symbol import Dummy
+        from sympy.solvers.solvers import solve
+        if not isinstance(other,GeometryEntity):
+            other = Point(other,dim = self.ambient_dimension)
+        if not isinstance(other,Point):
+            raise ValueError("other must be a point")
+        t = Dummy()
+        p = self.arbitrary_point(t)
+        num_conditions = len(p.args)
+        for c in p.args:
+            arb_point = c.args[0]
+            sol = solve(arb_point - other,t,dict = True)
+            if len(sol) != 0:
+                value = sol[0].values()[0]
+                if c.args[1].subs(t,value):
+                        return value
+        raise ValueError("Given point is not on %s" %type(self))
 
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the polygon.

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -616,7 +616,7 @@ class Polygon(GeometrySet):
         from sympy.core.symbol import Dummy
         from sympy.solvers.solvers import solve
         if not isinstance(other,GeometryEntity):
-            other = Point(other,dim = self.ambient_dimension)
+            other = Point(other, dim=self.ambient_dimension)
         if not isinstance(other,Point):
             raise ValueError("other must be a point")
         t = Dummy()
@@ -624,12 +624,12 @@ class Polygon(GeometrySet):
         num_conditions = len(p.args)
         for c in p.args:
             arb_point = c.args[0]
-            sol = solve(arb_point - other,t,dict = True)
+            sol = solve(arb_point - other, t, dict=True)
             if len(sol) != 0:
-                value = sol[0].values()[0]
+                value = sol[0].get(t)
                 if c.args[1].subs(t,value):
                         return value
-        raise ValueError("Given point is not on %s" %type(self))
+        raise ValueError("Given point is not on %s" %type(self).__name__)
 
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the polygon.

--- a/sympy/geometry/tests/test_curve.py
+++ b/sympy/geometry/tests/test_curve.py
@@ -100,8 +100,9 @@ def test_length():
     c3 = Curve((t ** 2, t), (t, 2, 5))
     assert c3.length == -sqrt(17) - asinh(4) / 4 + asinh(10) / 4 + 5 * sqrt(101) / 2
 
+
 def test_parameter_value():
     t = Symbol('t')
     C = Curve([2*t, t**2], (t, 0, 2))
-    assert C.parameter_value((2, 1)) == 1
-    raises(ValueError, lambda: C.parameter_value((2, 0)))
+    assert C.parameter_value((2, 1), t) == {t: 1}
+    raises(ValueError, lambda: C.parameter_value((2, 0), t))

--- a/sympy/geometry/tests/test_curve.py
+++ b/sympy/geometry/tests/test_curve.py
@@ -99,3 +99,14 @@ def test_length():
 
     c3 = Curve((t ** 2, t), (t, 2, 5))
     assert c3.length == -sqrt(17) - asinh(4) / 4 + asinh(10) / 4 + 5 * sqrt(101) / 2
+
+def test_paramater_value():
+    t = Symbol('t')
+    C = Curve([2*t, t**2], (t, 0, 2))
+
+    param = C.parameter_value((2,1))
+    assert param == 1
+
+    # Not on curve
+    with raises(ValueError):
+        C.parameter_value((2,0))

--- a/sympy/geometry/tests/test_curve.py
+++ b/sympy/geometry/tests/test_curve.py
@@ -100,7 +100,7 @@ def test_length():
     c3 = Curve((t ** 2, t), (t, 2, 5))
     assert c3.length == -sqrt(17) - asinh(4) / 4 + asinh(10) / 4 + 5 * sqrt(101) / 2
 
-def test_paramater_value():
+def test_parameter_value():
     t = Symbol('t')
     C = Curve([2*t, t**2], (t, 0, 2))
 

--- a/sympy/geometry/tests/test_curve.py
+++ b/sympy/geometry/tests/test_curve.py
@@ -103,10 +103,5 @@ def test_length():
 def test_parameter_value():
     t = Symbol('t')
     C = Curve([2*t, t**2], (t, 0, 2))
-
-    param = C.parameter_value((2,1))
-    assert param == 1
-
-    # Not on curve
-    with raises(ValueError):
-        C.parameter_value((2,0))
+    assert C.parameter_value((2, 1)) == 1
+    raises(ValueError, lambda: C.parameter_value((2, 0)))

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -388,6 +388,7 @@ def test_is_tangent():
 
 
 def test_parameter_value():
+    t = Symbol('t')
     e = Ellipse(Point(0, 0), 3, 5)
-    assert e.parameter_value((3, 0)) == 0
-    raises(ValueError, lambda: e.parameter_value((4, 0)))
+    assert e.parameter_value((3, 0), t) == {t: 0}
+    raises(ValueError, lambda: e.parameter_value((4, 0), t))

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -386,7 +386,7 @@ def test_is_tangent():
     raises(TypeError, lambda: e1.is_tangent(Point(0, 0, 0)))
     raises(TypeError, lambda: e1.is_tangent(Rational(5)))
 
-def test_paramater_value():
+def test_parameter_value():
     e = Ellipse(Point(0,0), 3, 5)
 
     param = e.parameter_value((3,0))

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -194,7 +194,7 @@ def test_ellipse_geom():
     assert e1.intersection(Circle(Point(0, 2), 1)) == [Point(0, 1)]
     assert e1.intersection(Circle(Point(5, 0), 1)) == []
     assert e1.intersection(Ellipse(Point(2, 0), 1, 1)) == [Point(1, 0)]
-    assert e1.intersection(Ellipse(Point(5, 0), 1, 1,)) == []
+    assert e1.intersection(Ellipse(Point(5, 0), 1, 1)) == []
     assert e1.intersection(Point(2, 0)) == []
     assert e1.intersection(e1) == e1
     assert intersection(Ellipse(Point(0, 0), 2, 1), Ellipse(Point(3, 0), 1, 2)) == [Point(2, 0)]
@@ -205,7 +205,7 @@ def test_ellipse_geom():
     assert Circle((0, 0), 1/2).intersection(
         Triangle((-1, 0), (1, 0), (0, 1))) == [
         Point(-1/2, 0), Point(1/2, 0)]
-    raises(TypeError, lambda: intersection(e2, Line((0, 0, 0), (0,0,1))))
+    raises(TypeError, lambda: intersection(e2, Line((0, 0, 0), (0, 0, 1))))
     raises(TypeError, lambda: intersection(e2, Rational(12)))
     # some special case intersections
     csmall = Circle(p1, 3)
@@ -325,7 +325,7 @@ def test_transform():
 
 
 def test_bounds():
-    e1 = Ellipse(Point(0,0), 3, 5)
+    e1 = Ellipse(Point(0, 0), 3, 5)
     e2 = Ellipse(Point(2, -2), 7, 7)
     c1 = Circle(Point(2, -2), 7)
     c2 = Circle(Point(-2, 0), Point(0, 2), Point(2, 0))
@@ -348,7 +348,7 @@ def test_reflect():
 
 
 def test_is_tangent():
-    e1 = Ellipse(Point(0,0), 3, 5)
+    e1 = Ellipse(Point(0, 0), 3, 5)
     c1 = Circle(Point(2, -2), 7)
     assert e1.is_tangent(Point(0, 0)) is False
     assert e1.is_tangent(Point(3, 0)) is False
@@ -386,12 +386,8 @@ def test_is_tangent():
     raises(TypeError, lambda: e1.is_tangent(Point(0, 0, 0)))
     raises(TypeError, lambda: e1.is_tangent(Rational(5)))
 
+
 def test_parameter_value():
-    e = Ellipse(Point(0,0), 3, 5)
-
-    param = e.parameter_value((3,0))
-    assert param == 0
-
-    # Outise ellipse
-    with raises(ValueError):
-        e.parameter_value((4,0))
+    e = Ellipse(Point(0, 0), 3, 5)
+    assert e.parameter_value((3, 0)) == 0
+    raises(ValueError, lambda: e.parameter_value((4, 0)))

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -385,3 +385,13 @@ def test_is_tangent():
     assert e1.is_tangent(Polygon((3, 0), (5, 7), (6, -5))) is False
     raises(TypeError, lambda: e1.is_tangent(Point(0, 0, 0)))
     raises(TypeError, lambda: e1.is_tangent(Rational(5)))
+
+def test_paramater_value():
+    e = Ellipse(Point(0,0), 3, 5)
+
+    param = e.parameter_value((3,0))
+    assert param == 0
+
+    # Outise ellipse
+    with raises(ValueError):
+        e.parameter_value((4,0))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -716,7 +716,7 @@ def test_issue_2941():
     c, d = (-2, -3), (-2, 0)
     _check()
 
-def test_paramater_value():
+def test_parameter_value():
     p1, p2 = Point(0,1), Point(5,6)
     l = Line(p1,p2)
 

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -717,12 +717,7 @@ def test_issue_2941():
     _check()
 
 def test_parameter_value():
-    p1, p2 = Point(0,1), Point(5,6)
-    l = Line(p1,p2)
-
-    param = l.parameter_value((5,6))
-    assert param == 1
-
-    # Point not on Line
-    with raises(ValueError):
-        l.parameter_value((0,0))
+    p1, p2 = Point(0, 1), Point(5, 6)
+    l = Line(p1, p2)
+    assert l.parameter_value((5, 6)) == 1
+    raises(ValueError, lambda: l.parameter_value((0, 0)))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -715,3 +715,14 @@ def test_issue_2941():
     # midline intersection
     c, d = (-2, -3), (-2, 0)
     _check()
+
+def test_paramater_value():
+    p1, p2 = Point(0,1), Point(5,6)
+    l = Line(p1,p2)
+
+    param = l.parameter_value((5,6))
+    assert param == 1
+
+    # Point not on Line
+    with raises(ValueError):
+        l.parameter_value((0,0))

--- a/sympy/geometry/tests/test_line.py
+++ b/sympy/geometry/tests/test_line.py
@@ -716,8 +716,10 @@ def test_issue_2941():
     c, d = (-2, -3), (-2, 0)
     _check()
 
+
 def test_parameter_value():
+    t = Symbol('t')
     p1, p2 = Point(0, 1), Point(5, 6)
     l = Line(p1, p2)
-    assert l.parameter_value((5, 6)) == 1
-    raises(ValueError, lambda: l.parameter_value((0, 0)))
+    assert l.parameter_value((5, 6), t) == {t: 1}
+    raises(ValueError, lambda: l.parameter_value((0, 0), t))

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -228,9 +228,10 @@ def test_dimension_normalization():
     assert Plane((1, 2, 1), (2, 1, 0), (3, 1, 2)
         ).intersection((2, 1)) == [Point(2, 1, 0)]
 
+
 def test_parameter_value():
-    u, v = symbols("u v")
+    t, u, v = symbols("t, u v")
     p = Plane((0, 0, 0), (0, 0, 1), (0, 1, 0))
-    assert p.parameter_value((0, -3, 2)) == asin(2*sqrt(13)/13)
+    assert p.parameter_value((0, -3, 2), t) == {t: asin(2*sqrt(13)/13)}
     assert p.parameter_value((0, -3, 2), u, v) == {u: 3, v: 2}
-    raises(ValueError, lambda: p.parameter_value((1, 0, 0)))
+    raises(ValueError, lambda: p.parameter_value((1, 0, 0), t))

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -227,3 +227,13 @@ def test_dimension_normalization():
     assert p.perpendicular_plane(a, b) == Plane(Point3D(0, 0, 0), (1, 0, 0))
     assert Plane((1, 2, 1), (2, 1, 0), (3, 1, 2)
         ).intersection((2, 1)) == [Point(2, 1, 0)]
+
+def test_paramater_value():
+    p = Plane((0, 0, 0), (0, 0, 1), (0, 1, 0))
+
+    param = p.parameter_value((0,1,0))
+    # (0,cos(t),sin(t))
+    assert param == 0
+
+    with raises(ValueError):
+        p.parameter_value((1,0,0))

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -229,11 +229,8 @@ def test_dimension_normalization():
         ).intersection((2, 1)) == [Point(2, 1, 0)]
 
 def test_parameter_value():
+    u, v = symbols("u v")
     p = Plane((0, 0, 0), (0, 0, 1), (0, 1, 0))
-
-    param = p.parameter_value((0,1,0))
-    # (0,cos(t),sin(t))
-    assert param == 0
-
-    with raises(ValueError):
-        p.parameter_value((1,0,0))
+    assert p.parameter_value((0, -3, 2)) == asin(2*sqrt(13)/13)
+    assert p.parameter_value((0, -3, 2), u, v) == {u: 3, v: 2}
+    raises(ValueError, lambda: p.parameter_value((1, 0, 0)))

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -228,7 +228,7 @@ def test_dimension_normalization():
     assert Plane((1, 2, 1), (2, 1, 0), (3, 1, 2)
         ).intersection((2, 1)) == [Point(2, 1, 0)]
 
-def test_paramater_value():
+def test_parameter_value():
     p = Plane((0, 0, 0), (0, 0, 1), (0, 1, 0))
 
     param = p.parameter_value((0,1,0))

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -413,7 +413,7 @@ def test_intersection():
 
 def test_issue_12966():
     poly = Polygon(Point(0, 0), Point(0, 10), Point(5, 10), Point(5, 5),
-    Point(10, 5), Point(10, 0))
+        Point(10, 5), Point(10, 0))
     t = Symbol('t')
     pt = poly.arbitrary_point(t)
     DELTA = 5/poly.perimeter

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -412,9 +412,12 @@ def test_intersection():
 
 
 def test_parameter_value():
+    t = Symbol('t')
     sq = Polygon((0, 0), (0, 1), (1, 1), (1, 0))
-    assert sq.parameter_value((0.5, 1)) == 3/8
-    raises(ValueError, lambda: sq.parameter_value((5, 6)))
+    assert sq.parameter_value((0.5, 1), t) == {t: 3/8}
+    q = Polygon((0, 0), (2, 1), (2, 4), (4, 0))
+    assert q.parameter_value((4, 0), t) == {t: -6 + 3*sqrt(5)}  # ~= 0.708
+    raises(ValueError, lambda: sq.parameter_value((5, 6), t))
 
 
 def test_issue_12966():

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -411,6 +411,12 @@ def test_intersection():
     assert poly1.intersection(RegularPolygon((-12, -15), 3, 3)) == []
 
 
+def test_parameter_value():
+    sq = Polygon((0, 0), (0, 1), (1, 1), (1, 0))
+    assert sq.parameter_value((0.5, 1)) == 3/8
+    raises(ValueError, lambda: sq.parameter_value((5, 6)))
+
+
 def test_issue_12966():
     poly = Polygon(Point(0, 0), Point(0, 10), Point(5, 10), Point(5, 5),
         Point(10, 5), Point(10, 0))
@@ -420,13 +426,3 @@ def test_issue_12966():
     assert [pt.subs(t, DELTA*i) for i in range(int(1/DELTA))] == [
         Point(0, 0), Point(0, 5), Point(0, 10), Point(5, 10),
         Point(5, 5), Point(10, 5), Point(10, 0), Point(5, 0)]
-
-
-def test_parameter_value():
-    sq = Polygon((0,0),(0,1),(1,1),(1,0))
-
-    param = sq.parameter_value((0.5,1))
-    assert param == 3/8
-
-    with raises(ValueError):
-        sq.parameter_value((5,6))

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -420,3 +420,13 @@ def test_issue_12966():
     assert [pt.subs(t, DELTA*i) for i in range(int(1/DELTA))] == [
         Point(0, 0), Point(0, 5), Point(0, 10), Point(5, 10),
         Point(5, 5), Point(10, 5), Point(10, 0), Point(5, 0)]
+
+
+def test_parameter_value():
+    sq = Polygon((0,0),(0,1),(1,1),(1,0))
+
+    param = sq.parameter_value((0.5,1))
+    assert param == 3/8
+
+    with raises(ValueError):
+        sq.parameter_value((5,6))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

fixes #13789 
closes #13790 as an extension and modification of those commits
closes #13539 
closes #13515

#### Brief description of what is fixed or changed

The parameter value corresponding to a given point on a geometric entity is now implemented.

#### Other comments

* remove multiple attempts to compute an arbitrary point for ellipse
  since the float is not being used (it is made Rational and that
  should not fail)
* removed multiple tests of RegularPolygon.reflect and replaced them
  with a single random test
* minor edits of bsplines lines