### PR TITLE
The exponent n in Bernoulli ODE must be constant

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -974,7 +974,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     d = Wild('d', exclude=[df, f(x).diff(x, 2)])
     e = Wild('e', exclude=[df])
     k = Wild('k', exclude=[df])
-    n = Wild('n', exclude=[f(x)])
+    n = Wild('n', exclude=[x, f(x), df])
     c1 = Wild('c1', exclude=[x])
     a2 = Wild('a2', exclude=[x, f(x), df])
     b2 = Wild('b2', exclude=[x, f(x), df])

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -740,6 +740,9 @@ def test_classify_ode():
          'separable_Integral', '1st_linear_Integral')
     assert classify_ode(Eq(2*f(x)**3*f(x).diff(x), 0), f(x)) == \
         ('separable', '1st_power_series', 'lie_group', 'separable_Integral')
+    # test issue 13864
+    assert classify_ode(Eq(diff(f(x), x) - f(x)**x, 0), f(x)) == \
+        ('1st_power_series', 'lie_group')
 
 
 def test_classify_ode_ics():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13864

#### Brief description of what is fixed or changed

Changed the definition of Wild('n') in `.match(a*df + b*f(x) + c*f(x)**n)` to exclude x, f(x), and the derivative of f(x). Added a test.

