### PR TITLE
Fold expressions with Piecewise before trying to integrate them

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -19,7 +19,7 @@ from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
 from sympy.matrices import MatrixBase
 from sympy.utilities.misc import filldedent
 from sympy.polys import Poly, PolynomialError
-from sympy.functions import Piecewise, sqrt, sign
+from sympy.functions import Piecewise, sqrt, sign, piecewise_fold
 from sympy.functions.elementary.exponential import log
 from sympy.series import limit
 from sympy.series.order import Order
@@ -443,6 +443,9 @@ class Integral(AddWithLimits):
                     function = factored_function
                 continue
 
+            if function.has(Piecewise) and \
+                not isinstance(function, Piecewise):
+                    function = piecewise_fold(function)
             if isinstance(function, Piecewise):
                 if len(xab) == 1:
                     antideriv = function._eval_integral(xab[0],

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -160,6 +160,7 @@ def test_multiple_integration():
     assert integrate((y**2)*(x**2), x, y) == Rational(1, 9)*(x**3)*(y**3)
     assert integrate(1/(x + 3)/(1 + x)**3, x) == \
         -S(1)/8*log(3 + x) + S(1)/8*log(1 + x) + x/(4 + 8*x + 4*x**2)
+    assert integrate(sin(x*y)*y, (x, 0, 1), (y, 0, 1)) == -sin(1) + 1
 
 
 def test_issue_3532():


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Piecewise class has its own integration method, to which functions are dispatched if they meet the condition `if isinstance(function, Piecewise)` However, this condition fails if there is a sum (or other combination) of piecewise functions, and then the integration is unlikely to succeed. Now such expressions are folded with `piecewise_fold`, which allows the Piecewise integration method to take over.

#### Example

```
x, y = symbols('x y')
integrate(sin(x*y)*y, (x, 0, 1), (y, 0, 1))
```
does not completely evaluate because the first integration produces an expression with Piecewise:
```
-y*Piecewise((0, Eq(y, 0)), (-1/y, True)) + y*Piecewise((0, Eq(y, 0)), (-cos(y)/y, True))
```
Subsequent attempt at integration fails, even though it eventually results in folding the piecewise (too late for it to be dispatched to the right method): the final output is
```
Integral(Piecewise((0, Eq(y, 0)), (-cos(y) + 1, True)), (y, 0, 1))
```
With this commit, the output is 1-sin(1). Added as a test.