### PR TITLE
Correctly handle derivatives of unknown order that may be 0

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1201,7 +1201,7 @@ class Derivative(Expr):
         # functions and Derivatives as those can be created by intermediate
         # derivatives.
         if evaluate and all(isinstance(sc[0], Symbol) for sc in variable_count):
-            symbol_set = set(sc[0] for sc in variable_count)
+            symbol_set = set(sc[0] for sc in variable_count if sc[1].is_positive)
             if symbol_set.difference(expr.free_symbols):
                 if isinstance(expr, (MatrixCommon, NDimArray)):
                     return expr.zeros(*expr.shape)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -868,6 +868,14 @@ def test_issue_13843():
 
     assert Derivative(f(x), (x, n)).doit() == Derivative(f(x), (x, n))
 
+def test_order_could_be_zero():
+    x, y = symbols('x, y')
+    n = symbols('n', integer=True, nonnegative=True)
+    m = symbols('m', integer=True, positive=True)
+    assert diff(y, (x, n)) == Derivative(y, (x, n))
+    assert diff(y, (x, n + 1)) == S.Zero
+    assert diff(y, (x, m)) == S.Zero
+
 def test_undefined_function_eq():
     f = Function('f')
     f2 = Function('f')


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Presently, `diff(y, (x, n))` returns 0 because there is no x in y. However, this is incorrect if n happens to be 0, because the 0th order derivative leaves the expression intact. A check is added for the positivity of order in such cases, and tests are added as well.