### PR TITLE
None for rational(Float) query

### DIFF
--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -19,6 +19,10 @@ class CommonHandler(AskHandler):
     def AlwaysFalse(expr, assumptions):
         return False
 
+    @staticmethod
+    def AlwaysNone(expr, assumptions):
+        return None
+
     NaN = AlwaysFalse
 
 

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -12,6 +12,10 @@ class CommonHandler(AskHandler):
     """Defines some useful methods common to most Handlers """
 
     @staticmethod
+    def Float(expr, assumptions):
+        return None
+
+    @staticmethod
     def AlwaysTrue(expr, assumptions):
         return True
 

--- a/sympy/assumptions/handlers/common.py
+++ b/sympy/assumptions/handlers/common.py
@@ -12,10 +12,6 @@ class CommonHandler(AskHandler):
     """Defines some useful methods common to most Handlers """
 
     @staticmethod
-    def Float(expr, assumptions):
-        return None
-
-    @staticmethod
     def AlwaysTrue(expr, assumptions):
         return True
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -135,7 +135,9 @@ class AskRationalHandler(CommonHandler):
 
     Rational = staticmethod(CommonHandler.AlwaysTrue)
 
-    Float = staticmethod(CommonHandler.Float)
+    @staticmethod
+    def Float(expr, assumptions):
+        return None
 
     ImaginaryUnit, Infinity, NegativeInfinity, Pi, Exp1, GoldenRatio = \
         [staticmethod(CommonHandler.AlwaysFalse)]*6

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -135,9 +135,7 @@ class AskRationalHandler(CommonHandler):
 
     Rational = staticmethod(CommonHandler.AlwaysTrue)
 
-    @staticmethod
-    def Float(expr, assumptions):
-        return None
+    Float = staticmethod(CommonHandler.AlwaysNone)
 
     ImaginaryUnit, Infinity, NegativeInfinity, Pi, Exp1, GoldenRatio = \
         [staticmethod(CommonHandler.AlwaysFalse)]*6

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -132,8 +132,10 @@ class AskRationalHandler(CommonHandler):
             if ask(Q.prime(expr.base), assumptions):
                 return False
 
-    Rational, Float = \
-        [staticmethod(CommonHandler.AlwaysTrue)]*2 # Float is finite-precision
+
+    Rational = staticmethod(CommonHandler.AlwaysTrue)
+
+    Float = staticmethod(CommonHandler.Float)
 
     ImaginaryUnit, Infinity, NegativeInfinity, Pi, Exp1, GoldenRatio = \
         [staticmethod(CommonHandler.AlwaysFalse)]*6

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -19,7 +19,7 @@ from sympy.logic.boolalg import Equivalent, Implies, Xor, And, to_cnf
 from sympy.utilities.pytest import XFAIL, slow, raises
 from sympy.assumptions.assume import assuming
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-
+import math
 
 def test_int_1():
     z = 1
@@ -85,10 +85,10 @@ def test_float_1():
     z = 1.0
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is True
+    assert ask(Q.rational(z)) is None
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
-    assert ask(Q.irrational(z)) is False
+    assert ask(Q.irrational(z)) is None
     assert ask(Q.imaginary(z)) is False
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
@@ -103,10 +103,10 @@ def test_float_1():
     z = 7.2123
     assert ask(Q.commutative(z)) is True
     assert ask(Q.integer(z)) is False
-    assert ask(Q.rational(z)) is True
+    assert ask(Q.rational(z)) is None
     assert ask(Q.real(z)) is True
     assert ask(Q.complex(z)) is True
-    assert ask(Q.irrational(z)) is False
+    assert ask(Q.irrational(z)) is None
     assert ask(Q.imaginary(z)) is False
     assert ask(Q.positive(z)) is True
     assert ask(Q.negative(z)) is False
@@ -2214,6 +2214,10 @@ def test_issue_9636():
     assert ask(Q.composite(4.0)) is False
     assert ask(Q.even(2.0)) is False
     assert ask(Q.odd(3.0)) is False
+
+
+def test_issue_12168():
+    assert ask(Q.rational(math.pi)) is None
 
 
 @XFAIL

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -118,6 +118,9 @@ def test_float_1():
     assert ask(Q.hermitian(z)) is True
     assert ask(Q.antihermitian(z)) is False
 
+    # test for issue #12168
+    assert ask(Q.rational(math.pi)) is None
+
 
 def test_zero_0():
     z = Integer(0)
@@ -2214,10 +2217,6 @@ def test_issue_9636():
     assert ask(Q.composite(4.0)) is False
     assert ask(Q.even(2.0)) is False
     assert ask(Q.odd(3.0)) is False
-
-
-def test_issue_12168():
-    assert ask(Q.rational(math.pi)) is None
 
 
 @XFAIL


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes issue #12168 

#### Brief description of what is fixed or changed
A ```CommonHandler``` function  with ```@staticmethod``` returning ```None``` for ```Float``` values.
Changed existing Float tests for rational to assert for ```None``` instead of ```False```
#### Other comments
```
 >>> ask(Q.rational(math.pi))
 None
```