### PR TITLE
AppliedFunction instead of Function metaclassy stuff

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -751,9 +751,9 @@ def evalf_trig(v, prec, options):
     TODO: should also handle tan of complex arguments.
     """
     from sympy import cos, sin
-    if isinstance(v, cos):
+    if (v.func == cos):
         func = mpf_cos
-    elif isinstance(v, sin):
+    elif (v.func == sin):
         func = mpf_sin
     else:
         raise NotImplementedError
@@ -767,9 +767,9 @@ def evalf_trig(v, prec, options):
             v = v.subs(options['subs'])
         return evalf(v._eval_evalf(prec), prec, options)
     if not re:
-        if isinstance(v, cos):
+        if (v.func == cos):
             return fone, None, prec, None
-        elif isinstance(v, sin):
+        elif (v.func == sin):
             return None, None, None, None
         else:
             raise NotImplementedError

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -742,7 +742,7 @@ def test_issue_8469():
 
 def test_should_evalf():
     # This should not take forever to run (see #8506)
-    assert isinstance(sin((1.0 + 1.0*I)**10000 + 1), sin)
+    assert sin((1.0 + 1.0*I)**10000 + 1).func is sin
 
 
 def test_Derivative_as_finite_difference():
@@ -891,7 +891,9 @@ def test_function_assumptions():
     assert f != f_real
     assert f(x) != f_real(x)
 
+    assert f.is_real is None
     assert f(x).is_real is None
+    assert f_real.is_real is True
     assert f_real(x).is_real is True
 
     # Can also do it this way, but it won't be equal to f_real because of the

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -932,7 +932,7 @@ class tan(TrigonometricFunction):
 
     def fdiff(self, argindex=1):
         if argindex == 1:
-            return S.One + self(*args)**2
+            return S.One + self**2
         else:
             raise ArgumentIndexError(self, argindex)
 
@@ -1227,7 +1227,7 @@ class cot(TrigonometricFunction):
 
     def fdiff(self, argindex=1):
         if argindex == 1:
-            return S.NegativeOne - self(*args)**2
+            return S.NegativeOne - self**2
         else:
             raise ArgumentIndexError(self, argindex)
 
@@ -1785,7 +1785,7 @@ class sinc(TrigonometricFunction):
     """
 
     def fdiff(self, argindex=1):
-        x = args[0]
+        x = self.args[0]
         if argindex == 1:
             return (x*cos(x) - sin(x)) / x**2
         else:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -932,7 +932,7 @@ class tan(TrigonometricFunction):
 
     def fdiff(self, argindex=1):
         if argindex == 1:
-            return S.One + self**2
+            return S.One + self(*args)**2
         else:
             raise ArgumentIndexError(self, argindex)
 
@@ -1227,7 +1227,7 @@ class cot(TrigonometricFunction):
 
     def fdiff(self, argindex=1):
         if argindex == 1:
-            return S.NegativeOne - self**2
+            return S.NegativeOne - self(*args)**2
         else:
             raise ArgumentIndexError(self, argindex)
 
@@ -1785,7 +1785,7 @@ class sinc(TrigonometricFunction):
     """
 
     def fdiff(self, argindex=1):
-        x = self.args[0]
+        x = args[0]
         if argindex == 1:
             return (x*cos(x) - sin(x)) / x**2
         else:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1214,6 +1214,26 @@ class PrettyPrinter(Printer):
 
         return pform
 
+    def _print_AppliedFunction(self, e, sort=False):
+        func = e.func
+        args = e.args
+        if sort:
+            args = sorted(args, key=default_sort_key)
+
+        func_name = func.__name__
+
+        prettyFunc = self._print(Symbol(func_name))
+        prettyArgs = prettyForm(*self._print_seq(args).parens())
+
+        pform = prettyForm(
+            binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
+
+        # store pform parts so it can be reassembled e.g. when powered
+        pform.prettyFunc = prettyFunc
+        pform.prettyArgs = prettyArgs
+
+        return pform
+
     def _print_GeometryEntity(self, expr):
         # GeometryEntity is based on Tuple but should not print like a Tuple
         return self.emptyPrinter(expr)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -58,6 +58,11 @@ class ReprPrinter(Printer):
         r += '(%s)' % ', '.join([self._print(a) for a in expr.args])
         return r
 
+    def _print_AppliedFunction(self, expr):
+        r = self._print(expr.func)
+        r += '(%s)' % ', '.join([self._print(a) for a in expr.args])
+        return r
+
     def _print_FunctionClass(self, expr):
         if issubclass(expr, AppliedUndef):
             return 'Function(%r)' % (expr.__name__)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -153,6 +153,9 @@ class StrPrinter(Printer):
     def _print_Function(self, expr):
         return expr.func.__name__ + "(%s)" % self.stringify(expr.args, ", ")
 
+    def _print_AppliedFunction(self, expr):
+        return expr.func.__name__ + "(%s)" % self.stringify(expr.args, ", ")
+
     def _print_GeometryEntity(self, expr):
         # GeometryEntity is special -- it's base is tuple
         return str(expr)


### PR DESCRIPTION
Work in progress.

#### Idea:

Create a class `AppliedFunction` for functions with arguments.

For example, `sin` is the function class, `sin(x)` will not be an instance of `sin` anymore, it will rather be an object `AppliedFunction(sin, x)`.

This would eventually allow supporting 
- expressions of unapplied functions (e.g. `(sin+cos)(x)`),
- derivatives of functions (e.g. `f'(x)` as `AppliedFunction(Derivative(f), x)` instead of `Subs(Derivative(f(xi), xi), (xi, x))`).
  