### PR TITLE
Improved sub-routine for string `quantity` arguments for find_unit

### DIFF
--- a/sympy/physics/units/__init__.py
+++ b/sympy/physics/units/__init__.py
@@ -210,12 +210,17 @@ from .definitions import (
 
 def find_unit(quantity):
     """
-    Return a list of matching units or dimension names.
+    This function returns a list of matching unit and dimension names to a
+    input keyword, dimension or unit. If `quantity` is a string -- keyword/units
+    /dimensions, it returns all instances of units/dimensions with these arguments.
+    This function also returns all units/dimensions which have string input keyword
+    as substring. If input `quantity` is a Quantity/ Dimension -- unit or dimension,
+    then all units having matching base units or dimensions are returned.
 
-    - If ``quantity`` is a string -- units/dimensions containing the string
-    `quantity`.
-    - If ``quantity`` is a unit or dimension -- units having matching base
-    units or dimensions.
+    Parameters
+    ==========
+
+    quantity : string, Dimension or Quantity
 
     Examples
     ========
@@ -233,8 +238,8 @@ def find_unit(quantity):
     ['J', 'eV', 'joule', 'energy', 'joules', 'electronvolt', 'electronvolts', 'planck_energy', 'planck_energy_density']
     >>> u.find_unit(u.inch**3)[:5]
     ['l', 'cl', 'dl', 'ml', 'liter']
-    """
 
+    """
     import sympy.physics.units as u
     rv = []
     if isinstance(quantity, string_types):

--- a/sympy/physics/units/__init__.py
+++ b/sympy/physics/units/__init__.py
@@ -210,13 +210,13 @@ from .definitions import (
 
 def find_unit(quantity):
     """
-    This function returns a list of matching unit and dimension names to a
-    input keyword, dimension or unit. If `quantity` is a string -- keyword/
-    units/dimensions, it returns all instances of units/dimensions with
-    these arguments. This function also returns all units/dimensions
-    which have string input keyword as sub-string. If input `quantity` is
-    a Quantity/Dimension -- unit or dimension, then all units having
-    matching base units or dimensions are returned.
+    This function returns a list of units matching to input keyword,
+    dimension or unit. If `quantity` is a string -- keyword/
+    unit/dimension, it returns units which have input keyword as its
+    sub-script/same dimensions as input unit/dimensions matching to
+    input dimension. If input `quantity` is a Quantity/ Dimension --
+    unit or dimension, then all units having matching base units or
+    dimensions are returned.
 
     Parameters
     ==========
@@ -228,15 +228,15 @@ def find_unit(quantity):
 
     >>> from sympy.physics import units as u
     >>> u.find_unit('charge')
-    ['C', 'charge', 'coulomb', 'coulombs', 'planck_charge']
+    ['C', 'coulomb', 'coulombs', 'planck_charge']
     >>> u.find_unit(u.charge)
     ['C', 'coulomb', 'coulombs', 'planck_charge']
     >>> u.find_unit("ampere")
     ['A', 'ampere', 'amperes', 'planck_current']
     >>> u.find_unit('volt')
-    ['V', 'v', 'volt', 'volts', 'voltage', 'electronvolt', 'electronvolts', 'planck_voltage']
+    ['V', 'v', 'volt', 'volts', 'electronvolt', 'electronvolts', 'planck_voltage']
     >>> u.find_unit('energy')
-    ['J', 'eV', 'joule', 'energy', 'joules', 'electronvolt', 'electronvolts', 'planck_energy', 'planck_energy_density']
+    ['J', 'eV', 'joule', 'joules', 'electronvolt', 'electronvolts', 'planck_energy', 'planck_energy_density']
     >>> u.find_unit(u.inch**3)[:5]
     ['l', 'cl', 'dl', 'ml', 'liter']
 
@@ -249,7 +249,8 @@ def find_unit(quantity):
         for i in dir(u):
             quant_attr = getattr(u, i)
             if quantity in i or (isinstance(quant_attr, Quantity) and quant_attr.dimension == dim):
-                rv.append(i)
+                if not isinstance(quant_attr, Dimension): rv.append(i)
+
     else:
         for i in sorted(dir(u)):
             other = getattr(u, i)

--- a/sympy/physics/units/__init__.py
+++ b/sympy/physics/units/__init__.py
@@ -226,19 +226,24 @@ def find_unit(quantity):
     >>> u.find_unit(u.charge)
     ['C', 'coulomb', 'coulombs', 'planck_charge']
     >>> u.find_unit("ampere")
-    ['ampere', 'amperes']
+    ['A', 'ampere', 'amperes', 'planck_current']
     >>> u.find_unit('volt')
-    ['volt', 'volts', 'electronvolt', 'electronvolts', 'planck_voltage']
+    ['V', 'v', 'volt', 'volts', 'planck_voltage']
+    >>> u.find_unit('energy')
+    ['J', 'eV', 'joule', 'joules', 'electronvolt', 'electronvolts', 'planck_energy']
     >>> u.find_unit(u.inch**3)[:5]
     ['l', 'cl', 'dl', 'ml', 'liter']
     """
+
     import sympy.physics.units as u
     rv = []
     if isinstance(quantity, string_types):
-        rv = [i for i in dir(u) if quantity in i and isinstance(getattr(u, i), Quantity)]
         dim = getattr(u, quantity)
-        if isinstance(dim, Dimension):
-            rv.extend(find_unit(dim))
+        if isinstance(dim, Quantity): dim = dim.dimension
+        for i in dir(u):
+            quant_attr = getattr(u, i)
+            if isinstance(quant_attr, Quantity) and quant_attr.dimension == dim:
+                rv.append(i)
     else:
         for i in sorted(dir(u)):
             other = getattr(u, i)
@@ -252,7 +257,7 @@ def find_unit(quantity):
                     rv.append(str(i))
             elif other.dimension == Dimension(Quantity.get_dimensional_expr(quantity)):
                 rv.append(str(i))
-    return sorted(set(rv), key=lambda x: (len(x), x))
+    return sorted(rv, key=len)
 
 # NOTE: the old units module had additional variables:
 # 'density', 'illuminance', 'resistance'.

--- a/sympy/physics/units/__init__.py
+++ b/sympy/physics/units/__init__.py
@@ -210,35 +210,42 @@ from .definitions import (
 
 def find_unit(quantity):
     """
-    This function returns a list of units matching to input keyword,
-    dimension or unit. If `quantity` is a string -- keyword/
-    unit/dimension, it returns units which have input keyword as its
-    sub-script/same dimensions as input unit/dimensions matching to
-    input dimension. If input `quantity` is a Quantity/ Dimension --
-    unit or dimension, then all units having matching base units or
-    dimensions are returned.
+    Return the list of units that match the given quantity.
 
     Parameters
     ==========
 
-    quantity : string, Dimension or Quantity
+    quantity : Dimension Quantity or string
 
     Examples
     ========
 
     >>> from sympy.physics import units as u
-    >>> u.find_unit('charge')
-    ['C', 'coulomb', 'coulombs', 'planck_charge']
+
+    # When the input quantity is a Dimension, it returns all units
+    # corresponding to it.
+
     >>> u.find_unit(u.charge)
     ['C', 'coulomb', 'coulombs', 'planck_charge']
-    >>> u.find_unit("ampere")
-    ['A', 'ampere', 'amperes', 'planck_current']
-    >>> u.find_unit('volt')
-    ['V', 'v', 'volt', 'volts', 'electronvolt', 'electronvolts', 'planck_voltage']
-    >>> u.find_unit('energy')
-    ['J', 'eV', 'joule', 'joules', 'electronvolt', 'electronvolts', 'planck_energy', 'planck_energy_density']
+
+    # Similarly, when the input is a unit(Quantity), it returns
+    # all the units congruous to it.
+
     >>> u.find_unit(u.inch**3)[:5]
     ['l', 'cl', 'dl', 'ml', 'liter']
+
+    # When the input is a string, it returns units which have input
+    # keyword as its sub-script or units corresponding to the input
+    # unit or dimension.
+
+    >>> u.find_unit('charge')
+    ['C', 'coulomb', 'coulombs', 'planck_charge']
+    >>> u.find_unit('volt')
+    ['V', 'v', 'volt', 'volts', 'electronvolt', 'electronvolts', 'planck_voltage']
+    >>> u.find_unit("ampere")
+    ['A', 'ampere', 'amperes', 'planck_current']
+    >>> u.find_unit('energy')
+    ['J', 'eV', 'joule', 'joules', 'electronvolt', 'electronvolts', 'planck_energy', 'planck_energy_density']
 
     """
     import sympy.physics.units as u

--- a/sympy/physics/units/__init__.py
+++ b/sympy/physics/units/__init__.py
@@ -222,15 +222,15 @@ def find_unit(quantity):
 
     >>> from sympy.physics import units as u
     >>> u.find_unit('charge')
-    ['C', 'coulomb', 'coulombs', 'planck_charge']
+    ['C', 'charge', 'coulomb', 'coulombs', 'planck_charge']
     >>> u.find_unit(u.charge)
     ['C', 'coulomb', 'coulombs', 'planck_charge']
     >>> u.find_unit("ampere")
     ['A', 'ampere', 'amperes', 'planck_current']
     >>> u.find_unit('volt')
-    ['V', 'v', 'volt', 'volts', 'planck_voltage']
+    ['V', 'v', 'volt', 'volts', 'voltage', 'electronvolt', 'electronvolts', 'planck_voltage']
     >>> u.find_unit('energy')
-    ['J', 'eV', 'joule', 'joules', 'electronvolt', 'electronvolts', 'planck_energy']
+    ['J', 'eV', 'joule', 'energy', 'joules', 'electronvolt', 'electronvolts', 'planck_energy', 'planck_energy_density']
     >>> u.find_unit(u.inch**3)[:5]
     ['l', 'cl', 'dl', 'ml', 'liter']
     """
@@ -242,7 +242,7 @@ def find_unit(quantity):
         if isinstance(dim, Quantity): dim = dim.dimension
         for i in dir(u):
             quant_attr = getattr(u, i)
-            if isinstance(quant_attr, Quantity) and quant_attr.dimension == dim:
+            if quantity in i or (isinstance(quant_attr, Quantity) and quant_attr.dimension == dim):
                 rv.append(i)
     else:
         for i in sorted(dir(u)):

--- a/sympy/physics/units/__init__.py
+++ b/sympy/physics/units/__init__.py
@@ -250,6 +250,8 @@ def find_unit(quantity):
     IA = [(i, getattr(u, i)) for i in dir(u)]
     IA = [(i, a) for i, a in IA if isinstance(a, (Quantity, Dimension))]
     if isinstance(quantity, string_types):
+        if quantity is '':
+            return []
         dim = getattr(u, quantity, None)
         if dim is None:
             for i, a in IA:

--- a/sympy/physics/units/__init__.py
+++ b/sympy/physics/units/__init__.py
@@ -211,11 +211,12 @@ from .definitions import (
 def find_unit(quantity):
     """
     This function returns a list of matching unit and dimension names to a
-    input keyword, dimension or unit. If `quantity` is a string -- keyword/units
-    /dimensions, it returns all instances of units/dimensions with these arguments.
-    This function also returns all units/dimensions which have string input keyword
-    as substring. If input `quantity` is a Quantity/ Dimension -- unit or dimension,
-    then all units having matching base units or dimensions are returned.
+    input keyword, dimension or unit. If `quantity` is a string -- keyword/
+    units/dimensions, it returns all instances of units/dimensions with
+    these arguments. This function also returns all units/dimensions
+    which have string input keyword as sub-string. If input `quantity` is
+    a Quantity/Dimension -- unit or dimension, then all units having
+    matching base units or dimensions are returned.
 
     Parameters
     ==========

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -218,6 +218,7 @@ def test_issue_5565():
 
 
 def test_find_unit():
+    assert find_unit('') == []
     assert find_unit('coulomb') == ['C', 'coulomb', 'coulombs',
                                     'planck_charge', 'coulomb_constant']
     assert find_unit('char') == ['C', 'charge', 'coulomb', 'coulombs',

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -218,7 +218,8 @@ def test_issue_5565():
 
 
 def test_find_unit():
-    assert find_unit('coulomb') == ['coulomb', 'coulombs', 'coulomb_constant']
+    assert find_unit('coulomb') == ['C', 'coulomb', 'coulombs',
+                                    'planck_charge', 'coulomb_constant']
     assert find_unit(coulomb) == ['C', 'coulomb', 'coulombs', 'planck_charge']
     assert find_unit(charge) == ['C', 'coulomb', 'coulombs', 'planck_charge']
     assert find_unit(inch) == [
@@ -236,7 +237,7 @@ def test_find_unit():
         'l', 'cl', 'dl', 'ml', 'liter', 'quart', 'liters', 'quarts',
         'deciliter', 'centiliter', 'deciliters', 'milliliter',
         'centiliters', 'milliliters', 'planck_volume']
-    assert find_unit('voltage') == ['V', 'v', 'volt', 'volts', 'planck_voltage']
+    assert find_unit('voltage') == ['V', 'v', 'volt', 'volts', 'voltage', 'planck_voltage']
 
 
 def test_Quantity_derivative():

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -220,6 +220,10 @@ def test_issue_5565():
 def test_find_unit():
     assert find_unit('coulomb') == ['C', 'coulomb', 'coulombs',
                                     'planck_charge', 'coulomb_constant']
+    assert find_unit('char') == ['C', 'charge', 'coulomb', 'coulombs',
+                                    'planck_charge']
+    assert find_unit('char') == ['C', 'charge', 'coulomb', 'coulombs',
+                                    'planck_charge']
     assert find_unit(coulomb) == ['C', 'coulomb', 'coulombs', 'planck_charge']
     assert find_unit(charge) == ['C', 'coulomb', 'coulombs', 'planck_charge']
     assert find_unit(inch) == [
@@ -237,7 +241,7 @@ def test_find_unit():
         'l', 'cl', 'dl', 'ml', 'liter', 'quart', 'liters', 'quarts',
         'deciliter', 'centiliter', 'deciliters', 'milliliter',
         'centiliters', 'milliliters', 'planck_volume']
-    assert find_unit('voltage') == ['V', 'v', 'volt', 'volts', 'planck_voltage']
+    assert find_unit('voltage') == ['V', 'v', 'volt', 'volts', 'voltage', 'planck_voltage']
 
 
 def test_Quantity_derivative():

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -237,7 +237,7 @@ def test_find_unit():
         'l', 'cl', 'dl', 'ml', 'liter', 'quart', 'liters', 'quarts',
         'deciliter', 'centiliter', 'deciliters', 'milliliter',
         'centiliters', 'milliliters', 'planck_volume']
-    assert find_unit('voltage') == ['V', 'v', 'volt', 'volts', 'voltage', 'planck_voltage']
+    assert find_unit('voltage') == ['V', 'v', 'volt', 'volts', 'planck_voltage']
 
 
 def test_Quantity_derivative():


### PR DESCRIPTION
Re-written sub-routine for string quantity arguments for find_unit.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #13874
#### Brief description of what is fixed or changed
The input element is searched with all the elements of `units` dictionary and matched for their`dimensions`. 
#### Other comments
Moreover, in PR #13438 problem of multiple instances of `plank_length` and `plank_charge` in resultant list for  `find_unit('charge')` and `find_unit('length')` was raised. 

Example:
```
>>> u.find_unit('charge')
['C', 'coulomb', 'coulombs', 'planck_charge', 'planck_charge']
```
To counter this problem, `set` was used. However, there is no special need for it, as all the `definitions` are inherently unique. This problem has also been eliminated.

