### PR TITLE
Numeric check for pivot being zero in Bareiss determinant method

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -5,6 +5,7 @@ from sympy.assumptions.refine import refine
 from sympy.core.add import Add
 from sympy.core.basic import Basic, Atom
 from sympy.core.expr import Expr
+from sympy.core.function import expand_mul
 from sympy.core.power import Pow
 from sympy.core.symbol import (Symbol, Dummy, symbols,
     _uniquely_named_symbol)
@@ -18,11 +19,10 @@ from sympy.printing import sstr
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
 from sympy.core.compatibility import reduce, as_int, string_types
 
-from sympy.utilities.randtest import test_at_rationals
 from sympy.utilities.iterables import flatten, numbered_symbols
 from sympy.core.decorators import call_highest_priority
-from sympy.core.compatibility import is_sequence, default_sort_key, range, \
-    NotIterable
+from sympy.core.compatibility import (is_sequence, default_sort_key, range,
+    NotIterable)
 
 
 from types import FunctionType
@@ -39,10 +39,10 @@ def _iszero(x):
         return None
 
 
-def _is_probably_zero(x):
-    """Tests by plugging in several rational numbers. Returns True if all
-    substitutions resulted in zero, otherwise returns False."""
-    return test_at_rationals(x, 0, attempts=5, a=-5, b=5, digits=3, randomize=False)
+def _is_zero_after_expand_mul(x):
+    """Tests by expand_mul only, suitable for polynomials and rational
+    functions."""
+    return expand_mul(x) == 0
 
 
 class DeferredVector(Symbol, NotIterable):
@@ -193,7 +193,7 @@ class MatrixDeterminant(MatrixCommon):
             # the computation by the factor of 2.5 in one test.
             # Relevant issues: #10279 and #13877.
             pivot_pos, pivot_val, _, _ = _find_reasonable_pivot(mat[:, 0],
-                                         iszerofunc=_is_probably_zero)
+                                         iszerofunc=_is_zero_after_expand_mul)
             if pivot_pos == None:
                 return S.Zero
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -8,7 +8,7 @@ from sympy.core.expr import Expr
 from sympy.core.power import Pow
 from sympy.core.symbol import (Symbol, Dummy, symbols,
     _uniquely_named_symbol)
-from sympy.core.numbers import Integer, ilcm, Float, Rational
+from sympy.core.numbers import Integer, ilcm, Float
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -208,9 +208,9 @@ class MatrixDeterminant(MatrixCommon):
                 return mat[0, 0]
 
             # find a pivot and extract the remaining matrix
-            # Wuth the default iszerofunc,  _find_reasonable_pivot slows down
-            # the compotation by the factor of 2.5 in one test.
-            # Relevant issues #10279 and #13877.
+            # With the default iszerofunc, _find_reasonable_pivot slows down
+            # the computation by the factor of 2.5 in one test.
+            # Relevant issues: #10279 and #13877.
             pivot_pos, pivot_val, _, _ = _find_reasonable_pivot(mat[:, 0],
                                          iszerofunc=_is_probably_zero)
             if pivot_pos == None:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division
 
 import collections
-import random
 from sympy.assumptions.refine import refine
 from sympy.core.add import Add
 from sympy.core.basic import Basic, Atom
@@ -19,6 +18,7 @@ from sympy.printing import sstr
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
 from sympy.core.compatibility import reduce, as_int, string_types
 
+from sympy.utilities.randtest import random_complex_number
 from sympy.utilities.iterables import flatten, numbered_symbols
 from sympy.core.decorators import call_highest_priority
 from sympy.core.compatibility import is_sequence, default_sort_key, range, \
@@ -40,8 +40,12 @@ def _iszero(x):
 
 
 def _is_probably_zero(x):
-    """Returns True if x is probably zero, False if it is probably not,
-       None if undecided"""
+    """Tests by plugging in random rational numbers. Returns True if several
+    substitution resulted in zero, otherwise returns False. Does not attempt
+    floating point evaluation or any symbolic simplification, thus returns
+    quickly. Suitable for polynomials and rational functions because, for
+    example, ``x*(x+1) - x - x**2`` evaluates to zero when any rational number
+    is plugged in."""
     try:
         is_zero = x.is_zero
     except AttributeError:
@@ -50,9 +54,8 @@ def _is_probably_zero(x):
         variables = x.free_symbols
         if isinstance(variables, set) and len(variables) > 0:
             for _ in range(5):
-                substitutions = {v: random.randint(-10, 10) + \
-                    + Rational(random.randint(100, 200), random.randint(201, 300)) \
-                    for v in variables}
+                substitutions = {v: random_complex_number(-5, 0, 5, 0, rational=True,
+                    tolerance=0.001) for v in variables}
                 if x.xreplace(substitutions) != 0:
                     is_zero = False
                     break

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -177,18 +177,22 @@ class MatrixDeterminant(MatrixCommon):
         # XXX included as a workaround for issue #12362.  Should use `_find_reasonable_pivot` instead
         # As of 2018-01-09, `_find_reasonable_pivot` could be used but it slows down the computation,
         # by the factor of 2.5 in one test. The issue #10279 is relevant.
-        # As a compromise, check for the value being nonzero at a random rational point
+        # As a compromise, check for the value being nonzero at several random rational points
         def _find_pivot(l):
             for pos, val in enumerate(l):
                 if val:
                     variables = val.free_symbols
+                    good_pivot = True
                     if len(variables) > 0:
-                        substitutions = {v: Rational(random.choice((-1, 1)) * \
-                            random.randint(100, 200), random.randint(201, 300)) \
-                            for v in variables}
-                        if val.xreplace(substitutions) == 0:
-                            continue
-                    return (pos, val, None, None)
+                        for _ in range(5):
+                            substitutions = {v: random.randint(-10, 10) + Rational(
+                                random.randint(100, 200), random.randint(201, 300)) \
+                                for v in variables}
+                            if val.xreplace(substitutions) == 0:
+                                good_pivot = False
+                                break
+                    if good_pivot:
+                        return (pos, val, None, None)
             return (None, None, None, None)
 
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -18,7 +18,7 @@ from sympy.printing import sstr
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
 from sympy.core.compatibility import reduce, as_int, string_types
 
-from sympy.utilities.randtest import random_complex_number
+from sympy.utilities.randtest import test_at_rationals
 from sympy.utilities.iterables import flatten, numbered_symbols
 from sympy.core.decorators import call_highest_priority
 from sympy.core.compatibility import is_sequence, default_sort_key, range, \
@@ -40,28 +40,9 @@ def _iszero(x):
 
 
 def _is_probably_zero(x):
-    """Tests by plugging in random rational numbers. Returns True if several
-    substitution resulted in zero, otherwise returns False. Does not attempt
-    floating point evaluation or any symbolic simplification, thus returns
-    quickly. Suitable for polynomials and rational functions because, for
-    example, ``x*(x+1) - x - x**2`` evaluates to zero when any rational number
-    is plugged in."""
-    try:
-        is_zero = x.is_zero
-    except AttributeError:
-        is_zero = None
-    if is_zero is None:
-        variables = x.free_symbols
-        if isinstance(variables, set) and len(variables) > 0:
-            for _ in range(5):
-                substitutions = {v: random_complex_number(-5, 0, 5, 0, rational=True,
-                    tolerance=0.001) for v in variables}
-                if x.xreplace(substitutions) != 0:
-                    is_zero = False
-                    break
-            if is_zero is None:
-                is_zero = True
-    return is_zero
+    """Tests by plugging in several rational numbers. Returns True if all
+    substitutions resulted in zero, otherwise returns False."""
+    return test_at_rationals(x, 0, attempts=5, a=-5, b=5, digits=3, randomize=False)
 
 
 class DeferredVector(Symbol, NotIterable):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -402,6 +402,14 @@ def test_determinant():
     assert M.det(method="bareiss") == z**2 - x*y
     assert M.det(method="berkowitz") == z**2 - x*y
 
+    # issue 13835
+    a = symbols('a')
+    M = lambda n: Matrix([[i + a*j for i in range(n)] \
+        for j in range(n)])
+    assert M(5).det() == 0
+    assert M(6).det() == 0
+    assert M(7).det() == 0
+
 
 def test_det_LU_decomposition():
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -404,8 +404,8 @@ def test_determinant():
 
     # issue 13835
     a = symbols('a')
-    M = lambda n: Matrix([[i + a*j for i in range(n)] \
-        for j in range(n)])
+    M = lambda n: Matrix([[i + a*j for i in range(n)]
+                          for j in range(n)])
     assert M(5).det() == 0
     assert M(6).det() == 0
     assert M(7).det() == 0

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -13,17 +13,21 @@ from sympy.core.symbol import Symbol
 from sympy.core.compatibility import is_sequence, as_int
 
 
-def random_complex_number(a=2, b=-1, c=3, d=1, rational=False):
+def random_complex_number(a=2, b=-1, c=3, d=1, rational=False, tolerance=None):
     """
     Return a random complex number.
 
     To reduce chance of hitting branch cuts or anything, we guarantee
     b <= Im z <= d, a <= Re z <= c
+
+    When rational is True, a rational approximation to a random number
+    is obtained within specified tolerance, if any.
     """
     A, B = uniform(a, c), uniform(b, d)
     if not rational:
         return A + I*B
-    return nsimplify(A, rational=True) + I*nsimplify(B, rational=True)
+    return (nsimplify(A, rational=True, tolerance=tolerance) +
+        I*nsimplify(B, rational=True, tolerance=tolerance))
 
 
 def verify_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -11,7 +11,6 @@ from sympy.core.containers import Tuple
 from sympy.core.numbers import comp
 from sympy.core.symbol import Symbol
 from sympy.core.compatibility import is_sequence, as_int
-from sympy.functions.elementary.miscellaneous import sqrt
 
 
 def random_complex_number(a=2, b=-1, c=3, d=1, rational=False, tolerance=None):
@@ -55,56 +54,6 @@ def verify_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     z1 = f.subs(reps).n()
     z2 = g.subs(reps).n()
     return comp(z1, z2, tol)
-
-
-def test_at_rationals(f, g, z=None, attempts=5, a=-5, b=5, digits=3,
-        randomize=True):
-    """
-    Tests whether f and g yield exactly the same expression when symbol
-    z is replaced by a rational number. Does not attempt floating point
-    evaluation or any symbolic simplification, thus returns quickly.
-    Suitable for polynomials with rational coefficients because, for
-    example, ``x*(x+1) - x - x**2`` evaluates to zero when any rational
-    number is plugged in.
-
-    If z is None, all symbols will be tested. The test consists of n
-    substitutions of rational numbers, which are taken from interval
-    [a, b]. The parameter digits prescribes the approximate number of
-    digits in the denominator.
-
-    Examples
-    ========
-
-    >>> from sympy.abc import x
-    >>> from sympy.utilities.randtest import test_at_rationals
-    >>> test_at_rationals(x*(x + 1), x + x**2)
-    True
-    """
-    f, g, z = Tuple(f, g, z)
-    h = f - g
-    z = {z} if isinstance(z, Symbol) else h.free_symbols
-    if not z:
-        return h == 0
-    tol = 10**(-digits)
-    if randomize:   # use random rational numbers
-        for _ in range(attempts):
-            substitutions = {v: random_complex_number(a, 0, b, 0, rational=True,
-                tolerance=tol) for v in z}
-            if h.xreplace(substitutions) != 0:
-                return False
-    else:  # use cyclic shifts by golden ratio within [a, b]
-        counter = 0
-        golden_ratio = ((sqrt(5) + 1)/2).n(digits + 1)
-        z = sorted(list(z), key=lambda v: v.name)
-        for _ in range(attempts):
-            substitutions = {}
-            for v in z:
-                counter += 1
-                x = a + (counter*golden_ratio % 1)*(b - a)
-                substitutions[v] = nsimplify(x, rational=True, tolerance=tol)
-            if h.xreplace(substitutions) != 0:
-                return False
-    return True
 
 
 def test_derivative_numerically(f, z, tol=1.0e-6, a=2, b=-1, c=3, d=1):


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13835

#### Brief description of what is fixed or changed

Currently, the default determinant computation method, Bareiss, accepts as a pivot any entry `!= 0`. This leads to "nan" output when the pivot is a symbolic expression that simplifies to zero. The added check to `_find_pivot` tests it for `== 0` after substituting random rational numbers for any variables. This has no noticeable impact on speed, and prevents zero pivot choices in practice. There is a small chance of rejecting a valid pivot, though.

#### Other comments

A comment next to `_find_pivot` method suggest using `_find_reasonable_pivot` instead, which implements zero detection. A note in the code says it's blocked by #12362 but I cannot reproduce #12362 and there are no errors thrown if using `_find_reasonable_pivot`. So I considered doing that but found the performance impact to be quite high. 

My timing test was a symbolic dense 7 by 7 matrix, similar to the example in #13835 but with nonzero determinant:

```
M = Matrix([[i + a*j + S(1)/(i+j+1) for i in range(7)] for j in range(7)])
```

Timing of a loop with 20 `M.det()`

 - Bareiss 165 seconds
 - Bareiss with `_find_reasonable_pivot`: 423 seconds
 - LU: 0.26 seconds (In fairness, Bareiss returns a nice formula `-391*a/1758426061161369600000 + 107/187991731629615513600000` while the output of LU is enormous and simplify hangs on it for much longer than the entire computation with the Bareiss method).

Increasing the execution time by the factor of 2.5 seemed undesirable, which is why the random numeric test was chosen instead. Timing test showed no measurable impact on performance. 

Numeric zero testing was also considered in #10279.  
  