### PR TITLE
Raise exception for negative order derivatives

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1189,8 +1189,10 @@ class Derivative(Expr):
 
         # Since only non-negative order derivatives are meaningfull, we make a special
         # case to raise ValueError if the order is not non-negative
-        if not all(count.is_nonnegative for v, count in variable_count):
-            raise ValueError("Derivative order invalid")
+        if any(count.is_nonnegative is False or
+               count.is_integer is False or
+               count.is_finite is False for v, count in variable_count):
+            raise ValueError("Derivative order must be a non negative integer")
 
         # We make a special case for 0th derivative, because there is no
         # good way to unambiguously print this.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1187,6 +1187,11 @@ class Derivative(Expr):
                     variable_count.append(Tuple(v, count))
                     j += 1
 
+        # Since negative order derivatives are meaningless, we make a special
+        # case to raise ValueError for them.
+        if any(count.is_negative for v, count in variable_count):
+            raise ValueError("Negative order derivatives are not allowed")
+
         # We make a special case for 0th derivative, because there is no
         # good way to unambiguously print this.
         if len(variable_count) == 0:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1187,10 +1187,10 @@ class Derivative(Expr):
                     variable_count.append(Tuple(v, count))
                     j += 1
 
-        # Since negative order derivatives are meaningless, we make a special
-        # case to raise ValueError for them.
-        if any(count.is_negative for v, count in variable_count):
-            raise ValueError("Negative order derivatives are not allowed")
+        # Since only non-negative order derivatives are meaningfull, we make a special
+        # case to raise ValueError if the order is not non-negative
+        if not all(count.is_nonnegative for v, count in variable_count):
+            raise ValueError("Derivative order invalid")
 
         # We make a special case for 0th derivative, because there is no
         # good way to unambiguously print this.

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -109,7 +109,7 @@ def test_diff_nth_derivative():
     f =  Function("f")
     x = Symbol("x")
     y = Symbol("y")
-    n = Symbol("n", integer=True)
+    n = Symbol("n", integer=True, nonnegative=True)
 
     expr = diff(sin(x), (x, n))
     expr2 = diff(f(x), (x, 2))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -862,7 +862,7 @@ def test_issue_12005():
 def test_issue_13843():
     x = symbols('x')
     f = Function('f')
-    m, n = symbols('m n', integer=True)
+    m, n = symbols('m n', integer=True, nonnegative=True)
     assert Derivative(Derivative(f(x), (x, m)), (x, n)) == Derivative(f(x), (x, m + n))
     assert Derivative(Derivative(f(x), (x, m+5)), (x, n+3)) == Derivative(f(x), (x, m + n + 8))
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -868,6 +868,10 @@ def test_issue_13843():
 
     assert Derivative(f(x), (x, n)).doit() == Derivative(f(x), (x, n))
 
+def test_issue_13873():
+    from sympy.abc import x
+    raises(ValueError, lambda: Derivative(sin(x), (x,-1)))
+
 def test_undefined_function_eq():
     f = Function('f')
     f2 = Function('f')

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2450,7 +2450,7 @@ dα      \
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
-
+    n = symbols('n', integer=True, nonnegative=True)
     expr = Derivative(f(x), (x, n))
 
     ascii_str = \

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -531,6 +531,7 @@ def test_latex_derivatives():
 
     # mixed partial derivatives
     f = Function("f")
+    n = symbols('n', integer=True, nonnegative=True)
     assert latex(diff(diff(f(x,y), x, evaluate=False), y, evaluate=False)) == \
         r"\frac{\partial^{2}}{\partial y\partial x} " + latex(f(x,y))
 

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -366,6 +366,7 @@ def _compute_formula(f, x, P, Q, k, m, k_max):
 
     sol = []
     for i in range(k_max + 1, k_max + m + 1):
+        i = abs(i)
         r = f.diff(x, i).limit(x, 0) / factorial(i)
         if r is S.Zero:
             continue
@@ -430,6 +431,7 @@ def _rsolve_hypergeometric(f, x, P, Q, k, m):
 
     ind, mp = S.Zero, -oo
     for i in range(k_max + m + 1):
+        i = abs(i)
         r = f.diff(x, i).limit(x, 0) / factorial(i)
         if r.is_finite is False:
             old_f = f


### PR DESCRIPTION
Fixes #13873 

Currently, diff(sin(x), (x, -1)) returns sin(x) which is basically meaningless. An if statement is added to check for negative order derivatives and raise a ValueError. Corresponding tests are also added.