### PR TITLE
Hypergeometric Expansion : Changed Less_than_Equal_to(<=) operator with .is_nonpositive

### DIFF
--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1341,7 +1341,7 @@ class ReduceOrder(Operator):
         n = ai - bj
         if not n.is_Integer or n < 0:
             return None
-        if bj.is_integer and bj <= 0:
+        if bj.is_integer and bj.is_nonpositive:
             return None
 
         expr = Operator.__new__(cls)

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -9,7 +9,7 @@ from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
                        hyperexpand, Hyper_Function, G_Function,
                        reduce_order_meijer,
                        build_hypergeometric_formula)
-from sympy import hyper, I, S, meijerg, Piecewise, Tuple
+from sympy import hyper, I, S, meijerg, Piecewise, Tuple, Sum, binomial, Expr
 from sympy.abc import z, a, b, c
 from sympy.utilities.pytest import XFAIL, raises, slow, ON_TRAVIS, skip
 from sympy.utilities.randtest import verify_numerically as tn
@@ -38,6 +38,7 @@ def test_hyperexpand():
     assert hyperexpand(z*hyper([], [S('3/2')], -z**2/4)) == sin(z)
     assert hyperexpand(hyper([S('1/2'), S('1/2')], [S('3/2')], z**2)*z) \
         == asin(z)
+    assert isinstance(Sum(binomial(2, z)*z**2, (z, 0, a)).doit(), Expr)
 
 
 def can_do(ap, bq, numerical=True, div=1, lowerplane=False):


### PR DESCRIPTION
### Whenever we use a relational operator such as  **`x <= 0`**, the value of **`x`** has to be known so that this expression can get evaluated to either **True** or **False**.

But this is not always the case in symbolic maths, so we use expressions like `.is_integer` or `.is_nonpositive`. There was an issue I was working on which exposed [this line](https://github.com/sympy/sympy/blob/master/sympy/simplify/hyperexpand.py#L1344).
`if bj.is_integer and bj <= 0: return None`
Here `.is_integer` doesn't requires `bj` to be known integer whereas `bj <= 0` creates a problem. 
A suitable test case is : 

***>>>*** `k, m = symbols('k m', integer=True)`
***>>>*** `Sum(binomial(2, k)*k**2, (k, 0, m)).doit()`

Above commands give an error because they cant determine the truth value of 'bj<=0' expression. changing it with `.is_nonpositive` gets us to answer.
