### PR TITLE
FiniteFields: Raise an exeption for non-prime p in FiniteField(p)

### DIFF
--- a/sympy/polys/domains/__init__.py
+++ b/sympy/polys/domains/__init__.py
@@ -10,6 +10,10 @@ from . import finitefield
 __all__.extend(finitefield.__all__)
 from .finitefield import *
 
+from . import finitering
+__all__.extend(finitering.__all__)
+from .finitering import *
+
 from . import integerring
 __all__.extend(integerring.__all__)
 from .integerring import *

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -10,6 +10,8 @@ from sympy.polys.domains.modularinteger import ModularIntegerFactory
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 
+from sympy.ntheory import isprime
+
 @public
 class FiniteField(Field, SimpleDomain):
     """General class for finite fields. """
@@ -31,6 +33,8 @@ class FiniteField(Field, SimpleDomain):
         if dom is None:
             from sympy.polys.domains import ZZ
             dom = ZZ
+        if not isprime(mod):
+            raise ValueError("Only fields of prime order are supported")
 
         self.dtype = ModularIntegerFactory(mod, dom, symmetric, self)
         self.zero = self.dtype(0)

--- a/sympy/polys/domains/finitering.py
+++ b/sympy/polys/domains/finitering.py
@@ -1,0 +1,106 @@
+"""Implementation of :class:`FiniteRing` class. """
+
+from __future__ import print_function, division
+
+from sympy.polys.domains.field import Field
+from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.groundtypes import SymPyInteger
+from sympy.polys.domains.modularinteger import ModularIntegerFactory
+
+from sympy.polys.polyerrors import CoercionFailed
+from sympy.utilities import public
+
+
+@public
+class FiniteRing(Field, SimpleDomain):
+    """General class for finite rings. """
+
+    rep = 'FR'
+
+    is_FiniteRing = is_FR = True
+    is_Numerical = True
+
+    has_assoc_Ring = False
+    has_assoc_Field = True
+
+    dom = None
+    mod = None
+
+    def __init__(self, mod, dom=None, symmetric=True):
+        if mod <= 0:
+            raise ValueError('modulus must be a positive integer, got %s' % mod)
+        if dom is None:
+            from sympy.polys.domains import ZZ
+            dom = ZZ
+
+        self.dtype = ModularIntegerFactory(mod, dom, symmetric, self)
+        self.zero = self.dtype(0)
+        self.one = self.dtype(1)
+        self.dom = dom
+        self.mod = mod
+
+    def __str__(self):
+        return 'GF(%s)' % self.mod
+
+    def __hash__(self):
+        return hash((self.__class__.__name__, self.dtype, self.mod, self.dom))
+
+    def __eq__(self, other):
+        """Returns ``True`` if two domains are equivalent. """
+        return isinstance(other, FiniteRing) and \
+            self.mod == other.mod and self.dom == other.dom
+
+    def characteristic(self):
+        """Return the characteristic of this domain. """
+        return self.mod
+
+    def get_field(self):
+        """Returns a field associated with ``self``. """
+        return self
+
+    def to_sympy(self, a):
+        """Convert ``a`` to a SymPy object. """
+        return SymPyInteger(int(a))
+
+    def from_sympy(self, a):
+        """Convert SymPy's Integer to SymPy's ``Integer``. """
+        if a.is_Integer:
+            return self.dtype(self.dom.dtype(int(a)))
+        elif a.is_Float and int(a) == a:
+            return self.dtype(self.dom.dtype(int(a)))
+        else:
+            raise CoercionFailed("expected an integer, got %s" % a)
+
+    def from_FF_python(K1, a, K0=None):
+        """Convert ``ModularInteger(int)`` to ``dtype``. """
+        return K1.dtype(K1.dom.from_ZZ_python(a.val, K0.dom))
+
+    def from_ZZ_python(K1, a, K0=None):
+        """Convert Python's ``int`` to ``dtype``. """
+        return K1.dtype(K1.dom.from_ZZ_python(a, K0))
+
+    def from_QQ_python(K1, a, K0=None):
+        """Convert Python's ``Fraction`` to ``dtype``. """
+        if a.denominator == 1:
+            return K1.from_ZZ_python(a.numerator)
+
+    def from_FF_gmpy(K1, a, K0=None):
+        """Convert ``ModularInteger(mpz)`` to ``dtype``. """
+        return K1.dtype(K1.dom.from_ZZ_gmpy(a.val, K0.dom))
+
+    def from_ZZ_gmpy(K1, a, K0=None):
+        """Convert GMPY's ``mpz`` to ``dtype``. """
+        return K1.dtype(K1.dom.from_ZZ_gmpy(a, K0))
+
+    def from_QQ_gmpy(K1, a, K0=None):
+        """Convert GMPY's ``mpq`` to ``dtype``. """
+        if a.denominator == 1:
+            return K1.from_ZZ_gmpy(a.numerator)
+
+    def from_RealField(K1, a, K0):
+        """Convert mpmath's ``mpf`` to ``dtype``. """
+        p, q = K0.to_rational(a)
+
+        if q == 1:
+            return K1.dtype(self.dom.dtype(p))
+

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -3,7 +3,7 @@
 from sympy import S, sqrt, sin, oo, Poly, Float
 from sympy.abc import x, y, z
 
-from sympy.polys.domains import ZZ, QQ, RR, CC, FF, GF, EX
+from sympy.polys.domains import ZZ, QQ, RR, CC, FF, GF, EX, FiniteField
 from sympy.polys.domains.realfield import RealField
 
 from sympy.polys.rings import ring
@@ -485,6 +485,9 @@ def test_PolynomialRing__init():
     R, = ring("", ZZ)
     assert ZZ.poly_ring() == R.to_domain()
 
+
+def test_FiniteField__init():
+    raises(ValueError, lambda: FiniteField(42))
 
 def test_FractionField__init():
     F, = field("", ZZ)

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -39,7 +39,7 @@ from sympy.polys.polyerrors import (
 )
 
 from sympy.polys.specialpolys import f_polys
-from sympy.polys.domains import FF, ZZ, QQ
+from sympy.polys.domains import FF, ZZ, QQ, FiniteRing
 
 from sympy.utilities.pytest import raises
 
@@ -450,7 +450,7 @@ def test_dup_mul():
 
     assert dup_mul(f, f, ZZ) == h
 
-    K = FF(6)
+    K = FiniteRing(6)
 
     assert dup_mul([K(2), K(1)], [K(3), K(4)], K) == [K(5), K(4)]
 
@@ -670,7 +670,7 @@ def test_dmp_mul():
     assert dmp_mul([[[QQ(2, 7)]]], [[[QQ(1, 3)]]], 2, QQ) == [[[QQ(2, 21)]]]
     assert dmp_mul([[[QQ(1, 7)]]], [[[QQ(2, 3)]]], 2, QQ) == [[[QQ(2, 21)]]]
 
-    K = FF(6)
+    K = FiniteRing(6)
 
     assert dmp_mul(
         [[K(2)], [K(1)]], [[K(3)], [K(4)]], 1, K) == [[K(5)], [K(4)]]
@@ -689,7 +689,7 @@ def test_dup_sqr():
 
     assert dup_sqr(f, ZZ) == dup_normal([4, 0, 0, 4, 28, 0, 1, 14, 49], ZZ)
 
-    K = FF(9)
+    K = FiniteRing(9)
 
     assert dup_sqr([K(3), K(4)], K) == [K(6), K(7)]
 
@@ -704,7 +704,7 @@ def test_dmp_sqr():
     assert dmp_sqr([[[]]], 2, QQ) == [[[]]]
     assert dmp_sqr([[[QQ(2, 3)]]], 2, QQ) == [[[QQ(4, 9)]]]
 
-    K = FF(9)
+    K = FiniteRing(9)
 
     assert dmp_sqr([[K(3)], [K(4)]], 1, K) == [[K(6)], [K(7)]]
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #13886
related to #9544

#### Brief description of what is fixed or changed
FiniteField checks for primality of p using sympy.ntheory.isprime() and raises a ValueError if p is non-prime.

#### Other comments
