### PR TITLE
Raise exception for non-prime p in FiniteFIeld(p)

### DIFF
--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -10,6 +10,8 @@ from sympy.polys.domains.modularinteger import ModularIntegerFactory
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 
+from sympy.ntheory import isprime
+
 @public
 class FiniteField(Field, SimpleDomain):
     """General class for finite fields. """
@@ -28,6 +30,8 @@ class FiniteField(Field, SimpleDomain):
     def __init__(self, mod, dom=None, symmetric=True):
         if mod <= 0:
             raise ValueError('modulus must be a positive integer, got %s' % mod)
+        if not(isprime(mod)):
+            raise ValueError("Only fields of prime order are supported")
         if dom is None:
             from sympy.polys.domains import ZZ
             dom = ZZ

--- a/sympy/polys/domains/tests/test_finitefield.py
+++ b/sympy/polys/domains/tests/test_finitefield.py
@@ -1,0 +1,8 @@
+"""Tests for Finite Fields."""
+
+from sympy.polys.domains.finitefield import FiniteField
+
+from sympy.utilities.pytest import raises
+
+def test_finitefield():
+    raises(ValueError, lambda: FiniteField(42))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #13886 

#### Brief description of what is fixed or changed
Add check for prime using isprime module of sympy

#### Other comments
Created a new file for testing FiniteField module as test_finitefield.py