### PR TITLE
core: Do not over-simplify rational powers of negative integers

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2248,11 +2248,9 @@ class Integer(Rational):
         if p is not False:
             dict = {p[0]: p[1]}
         else:
-            dict = Integer(self).factors(limit=2**15)
+            dict = Integer(b_pos).factors(limit=2**15)
 
         # now process the dict of factors
-        if self.is_negative:
-            dict[-1] = 1
         out_int = 1  # integer part
         out_rad = 1  # extracted radicals
         sqr_int = 1
@@ -2282,10 +2280,12 @@ class Integer(Rational):
                     break
         for k, v in sqr_dict.items():
             sqr_int *= k**(v//sqr_gcd)
-        if sqr_int == self and out_int == 1 and out_rad == 1:
+        if sqr_int == b_pos and out_int == 1 and out_rad == 1:
             result = None
         else:
             result = out_int*out_rad*Pow(sqr_int, Rational(sqr_gcd, expt.q))
+            if self.is_negative:
+                result *= Pow(-1, expt)
         return result
 
     def _eval_is_prime(self):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2285,7 +2285,7 @@ class Integer(Rational):
         else:
             result = out_int*out_rad*Pow(sqr_int, Rational(sqr_gcd, expt.q))
             if self.is_negative:
-                result *= Pow(-1, expt)
+                result *= Pow(S.NegativeOne, expt)
         return result
 
     def _eval_is_prime(self):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1021,6 +1021,12 @@ def test_powers_Integer():
     assert (-3) ** Rational(-2, 3) == \
         -(-1)**Rational(1, 3)*3**Rational(1, 3)/3
 
+    # negative base and rational power with some simplification
+    assert (-8) ** Rational(2, 5) == \
+        2*(-1)**Rational(2, 5)*2**Rational(1, 5)
+    assert (-4) ** Rational(9, 5) == \
+        -8*(-1)**Rational(4, 5)*2**Rational(3, 5)
+
     assert S(1234).factors() == {617: 1, 2: 1}
     assert Rational(2*3, 3*5*7).factors() == {2: 1, 5: -1, 7: -1}
 
@@ -1192,6 +1198,14 @@ def test_issue_3423():
 def test_issue_3449():
     x = Symbol("x")
     assert sqrt(x - 1).subs(x, 5) == 2
+
+
+def test_issue_13890():
+    x = Symbol("x")
+    e = (-x/4 - S(1)/12)**x - 1
+    f = simplify(e)
+    a = S(9)/5
+    assert abs(e.subs(x,a).evalf() - f.subs(x,a).evalf()) < 1e-15
 
 
 def test_Integer_factors():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13890

#### Brief description of what is fixed or changed

The method `_eval_power` of Integer class attempts various simplifications when the exponent is rational. In doing so, it expands the base into prime factors, and when the base is negative, it puts -1 among the prime factors. This leads to incorrect simplification because the handling of prime factors assumes `a**(p/q)` being equal to `(a**p)**(1/q)`, which is false for negative a (consider `(-1)**(2/3)` for example). Now this is no longer done; only positive prime factors are simplified in the above way.

#### Example of current behavior

```
for k in range(1, 11):
    print((-k)**Rational(4, 5))

(-1)**(4/5)
(-2)**(4/5)
(-3)**(4/5)
2*2**(3/5)
(-5)**(4/5)
(-6)**(4/5)
(-7)**(4/5)
4*2**(2/5)
3*3**(3/5)
(-10)**(4/5)
```

When the base contains some prime powers suitable for factorization, the result suddenly becomes positive instead of a complex number as the rest. This violates the assumption (which is used by `simplify`) that it is possible to factor a positive number out of the base, e.g., `(-4)**(4/5)` is expected to be the same as `(-1)**(4/5) * 4**(4/5)`. 

With this patch, the above loop shows that the argument of the output remains consistent regardless of the simplifications performed on the base. We always get a positive multiple of (-1)**(4/5) as a result:
```
(-1)**(4/5)
(-2)**(4/5)
(-3)**(4/5)
2*(-1)**(4/5)*2**(3/5)
(-5)**(4/5)
(-6)**(4/5)
(-7)**(4/5)
4*(-1)**(4/5)*2**(2/5)
3*(-1)**(4/5)*3**(3/5)
(-10)**(4/5)
```




#### Other comments
