### PR TITLE
Modifications to `periodicity`

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -5,6 +5,7 @@ from sympy.calculus.util import (function_range, continuous_domain, not_empty_in
 from sympy.core import Add, Mul, Pow
 from sympy.sets.sets import Interval, FiniteSet, Complement, Union
 from sympy.utilities.pytest import raises
+from sympy.functions.special.gamma_functions import gamma
 from sympy.abc import x
 
 a = Symbol('a', real=True)
@@ -140,6 +141,8 @@ def test_periodicity():
 
     assert periodicity((x**2 + 4)%2, x) is None
     assert periodicity((E**x)%3, x) is None
+
+    assert periodicity(gamma(S(1)/7 + 1/x), x) is None
 
 def test_periodicity_check():
     x = Symbol('x')

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -476,7 +476,9 @@ def periodicity(f, symbol, check=False):
             for index, g in enumerate(reversed(g_s)):
                 start_index = num_of_gs - 1 - index
                 g = compogen(g_s[start_index:], symbol)
-                if g != orig_f and g != f: # Fix for issue 12620
+                # Fix for issue 12620
+                if decompogen(g, symbol) != decompogen(orig_f, symbol) \
+                 and decompogen(g, symbol) != decompogen(f, symbol):
                     period = periodicity(g, symbol)
                     if period is not None:
                         break

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -473,12 +473,13 @@ def periodicity(f, symbol, check=False):
         g_s = decompogen(f, symbol)
         num_of_gs = len(g_s)
         if num_of_gs > 1:
-            for index, g in enumerate(reversed(g_s)):
+            for index in range(num_of_gs):
                 start_index = num_of_gs - 1 - index
                 g = compogen(g_s[start_index:], symbol)
                 # Fix for issue 12620
-                if decompogen(g, symbol) != decompogen(orig_f, symbol) \
-                 and decompogen(g, symbol) != decompogen(f, symbol):
+                decomp = decompogen(g, symbol)
+                if decomp != decompogen(orig_f, symbol) \
+                 and decomp != decompogen(f, symbol):
                     period = periodicity(g, symbol)
                     if period is not None:
                         break


### PR DESCRIPTION
`periodicity` earlier used  a check after splitting the given function
using `decompogen` to check that the function being tested for periodicity during recursion
is not same as the original function, to avoid infinite recursion. This
check equated both the functions. This, however, led to the `periodicity` being
stuck, if the decomposition of the functions were the same. Equating the
decomposition of the functions during the check solves this issue.

Example when this happened:
```
>>> from sympy import *
>>> x = Symbol('x')
>>> periodicity(gamma(S(1)/7 + 1/x))

```

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments
