### PR TITLE
User guide: replace Rational(2) by Integer(2), etc, in a SymPy expression example 

### DIFF
--- a/doc/src/guide.rst
+++ b/doc/src/guide.rst
@@ -137,7 +137,7 @@ SymPy types through the ``sympify()`` function. Thus, ``cos(x).__add__(1)``
 returns  ``Add(cos(x), Integer(1))``.
 
 Similarly, ``2/cos(x)`` is equal to ``cos(x).__rdiv__(2)`` is equal to
-``Mul(Rational(2), Pow(cos(x), Rational(-1)))``.
+``Mul(Integer(2), Pow(cos(x), Integer(-1)))``.
 
 Note that ``2/cos(x)`` calls ``cos(x).__rdiv__(2)`` instead of
 ``(2).__div__(cos(x))`` because ``2`` (type ``int``) does not know how to


### PR DESCRIPTION
Maybe the example `Mul(Rational(2), Pow(cos(x), Rational(-1)))` is from the time when Integer class did not exist. Today, SymPy representation of that formula would use Integer(2) and Integer(-1). I don't see Rational(2) used at all. 
