### PR TITLE
Expand Max and Min in fcode and octave

### DIFF
--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -50,7 +50,9 @@ known_functions = {
     "exp": "exp",
     "erf": "erf",
     "Abs": "abs",
-    "conjugate": "conjg"
+    "conjugate": "conjg",
+    "Max": "max",
+    "Min": "min"
 }
 
 

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -435,21 +435,20 @@ class OctaveCodePrinter(CodePrinter):
         return "lambertw(" + args + ")"
 
 
-    def _print_math_func(self, expr):
-        known = self.known_functions[expr.__class__.__name__]
+    def _nested_binary_math_func(self, expr):
         args = self._print(expr.args[0])
         args += ', %s' % self._print(expr.func(*expr.args[1:]))
 
         return '{name}({args})'.format(
-            name=known,
+            name=self.known_functions[expr.__class__.__name__],
             args=args
         )
 
     def _print_Max(self, expr):
-        return self._print_math_func(expr)
+        return self._nested_binary_math_func(expr)
 
     def _print_Min(self, expr):
-        return self._print_math_func(expr)
+        return self._nested_binary_math_func(expr)
 
 
     def _print_Piecewise(self, expr):

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -86,8 +86,6 @@ class OctaveCodePrinter(CodePrinter):
         self.known_functions.update(dict(known_fcns_src2))
         userfuncs = settings.get('user_functions', {})
         self.known_functions.update(userfuncs)
-        self.headers = set()
-        self.libraries = set()
 
 
     def _rate_index_position(self, p):
@@ -438,17 +436,9 @@ class OctaveCodePrinter(CodePrinter):
         args = ", ".join([self._print(x) for x in reversed(expr.args)])
         return "lambertw(" + args + ")"
 
-    @requires(headers={'math.h'}, libraries={'m'})
+
     def _print_math_func(self, expr, nest=False):
         known = self.known_functions[expr.__class__.__name__]
-        if not isinstance(known, string_types):
-            for cb, name in known:
-                if cb(*expr.args):
-                    known = name
-                    break
-            else:
-                raise ValueError("No matching printer")
-
         if nest:
             args = self._print(expr.args[0])
             if len(expr.args) > 1:

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -436,13 +436,11 @@ class OctaveCodePrinter(CodePrinter):
 
 
     def _nested_binary_math_func(self, expr):
-        args = self._print(expr.args[0])
-        args += ', %s' % self._print(expr.func(*expr.args[1:]))
-
-        return '{name}({args})'.format(
+        return '{name}({arg1}, {arg2})'.format(
             name=self.known_functions[expr.__class__.__name__],
-            args=args
-        )
+            arg1=self._print(expr.args[0]),
+            arg2=self._print(expr.func(*expr.args[1:]))
+            )
 
     _print_Max = _print_Min = _nested_binary_math_func
 

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -43,6 +43,8 @@ known_fcns_src2 = {
     "laguerre": "laguerreL",
     "li": "logint",
     "loggamma": "gammaln",
+    "Max": "max",
+    "Min": "min",
     "polygamma": "psi",
     "Shi": "sinhint",
     "Si": "sinint",

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -15,8 +15,7 @@ from sympy.core import Mul, Pow, S, Rational
 from sympy.core.compatibility import string_types, range
 from sympy.core.mul import _keep_coeff
 from sympy.codegen.ast import Assignment
-from sympy.printing.ccode import _as_macro_if_defined
-from sympy.printing.codeprinter import CodePrinter, requires
+from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence, PRECEDENCE
 from re import search
 

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -444,11 +444,7 @@ class OctaveCodePrinter(CodePrinter):
             args=args
         )
 
-    def _print_Max(self, expr):
-        return self._nested_binary_math_func(expr)
-
-    def _print_Min(self, expr):
-        return self._nested_binary_math_func(expr)
+    _print_Max = _print_Min = _nested_binary_math_func
 
 
     def _print_Piecewise(self, expr):

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -438,9 +438,8 @@ class OctaveCodePrinter(CodePrinter):
     def _print_math_func(self, expr):
         known = self.known_functions[expr.__class__.__name__]
         args = self._print(expr.args[0])
-        if len(expr.args) > 1:
-            args += ', %s' % self._print(expr.func(*expr.args[1:]))
-        
+        args += ', %s' % self._print(expr.func(*expr.args[1:]))
+
         return '{name}({args})'.format(
             name=known,
             args=args

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -435,24 +435,22 @@ class OctaveCodePrinter(CodePrinter):
         return "lambertw(" + args + ")"
 
 
-    def _print_math_func(self, expr, nest=False):
+    def _print_math_func(self, expr):
         known = self.known_functions[expr.__class__.__name__]
-        if nest:
-            args = self._print(expr.args[0])
-            if len(expr.args) > 1:
-                args += ', %s' % self._print(expr.func(*expr.args[1:]))
-        else:
-            args = ', '.join(map(self._print, expr.args))
+        args = self._print(expr.args[0])
+        if len(expr.args) > 1:
+            args += ', %s' % self._print(expr.func(*expr.args[1:]))
+        
         return '{name}({args})'.format(
             name=known,
             args=args
         )
 
     def _print_Max(self, expr):
-        return self._print_math_func(expr, nest=True)
+        return self._print_math_func(expr)
 
     def _print_Min(self, expr):
-        return self._print_math_func(expr, nest=True)
+        return self._print_math_func(expr)
 
 
     def _print_Piecewise(self, expr):

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -78,7 +78,6 @@ class OctaveCodePrinter(CodePrinter):
     # assignment (if False).  FIXME: this should be looked a more carefully
     # for Octave.
 
-    _ns = ''
 
     def __init__(self, settings={}):
         super(OctaveCodePrinter, self).__init__(settings)
@@ -445,8 +444,7 @@ class OctaveCodePrinter(CodePrinter):
                 args += ', %s' % self._print(expr.func(*expr.args[1:]))
         else:
             args = ', '.join(map(self._print, expr.args))
-        return '{ns}{name}({args})'.format(
-            ns=self._ns,
+        return '{name}({args})'.format(
             name=known,
             args=args
         )

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -1,6 +1,7 @@
 from sympy import (sin, cos, atan2, log, exp, gamma, conjugate, sqrt,
     factorial, Integral, Piecewise, Add, diff, symbols, S, Float, Dummy, Eq,
-    Range, Catalan, EulerGamma, E, GoldenRatio, I, pi, Function, Rational, Integer, Lambda, sign)
+    Range, Catalan, EulerGamma, E, GoldenRatio, I, pi, Function, Rational, Integer, Lambda, sign,
+    Max, Min)
 
 from sympy.codegen import For, Assignment
 from sympy.codegen.ast import Declaration, Type, Variable, float32, float64, value_const, real, bool_
@@ -74,6 +75,7 @@ def test_fcode_Float():
 def test_fcode_functions():
     x, y = symbols('x,y')
     assert fcode(sin(x) ** cos(y)) == "      sin(x)**cos(y)"
+    assert fcode(Max(x, y) + Min(x, y)) == "      max(x, y) + min(x, y)"
 
 
 #issue 6814

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -2,7 +2,7 @@ from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer,
                         Tuple, Symbol)
 from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda
 from sympy.functions import (Piecewise, sqrt, ceiling, exp, sin, cos, LambertW,
-                             sinc)
+                             sinc, Max, Min)
 from sympy.utilities.pytest import raises
 from sympy.utilities.lambdify import implemented_function
 from sympy.matrices import (eye, Matrix, MatrixSymbol, Identity,
@@ -38,6 +38,7 @@ def test_Function():
     assert mcode(sin(x) ** cos(x)) == "sin(x).^cos(x)"
     assert mcode(abs(x)) == "abs(x)"
     assert mcode(ceiling(x)) == "ceil(x)"
+    assert mcode(Max(x, y) + Min(x, y)) == "max(x, y) + min(x, y)"
 
 
 def test_Pow():

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -39,6 +39,8 @@ def test_Function():
     assert mcode(abs(x)) == "abs(x)"
     assert mcode(ceiling(x)) == "ceil(x)"
     assert mcode(Max(x, y) + Min(x, y)) == "max(x, y) + min(x, y)"
+    assert mcode(Max(x, y, z)) == "max(x, max(y, z))"
+    assert mcode(Min(x, y, z)) == "min(x, min(y, z))"
 
 
 def test_Pow():


### PR DESCRIPTION
Fixes #13887 .

Max and Min function dependencies have been expanded to Fortran and Octave , known to fcode.py and octave.py .
Test cases have also been added.

@normalhuman, @jksuom  please review.