### PR TITLE
Absolute value of a polar number should not be polar

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -153,8 +153,8 @@ class exp_polar(ExpBase):
     is_comparable = False  # cannot be evalf'd
 
     def _eval_Abs(self):   # Abs is never a polar number
-        from sympy.functions.elementary.complexes import Abs
-        return Abs(exp(self.args[0]), evaluate=True)
+        from sympy.functions.elementary.complexes import re
+        return exp(re(self.args[0]))
 
     def _eval_evalf(self, prec):
         """ Careful! any evalf of polar numbers is flaky """

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -152,9 +152,9 @@ class exp_polar(ExpBase):
     is_polar = True
     is_comparable = False  # cannot be evalf'd
 
-    def _eval_Abs(self):
-        from sympy import expand_mul
-        return sqrt( expand_mul(self * self.conjugate()) )
+    def _eval_Abs(self):   # Abs is never a polar number
+        from sympy.functions.elementary.complexes import Abs
+        return Abs(exp(self.args[0]), evaluate=True)
 
     def _eval_evalf(self, prec):
         """ Careful! any evalf of polar numbers is flaky """

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -419,6 +419,8 @@ def test_polar():
     x, y = symbols('x y', polar=True)
 
     assert abs(exp_polar(I*4)) == 1
+    assert abs(exp_polar(0)) == 1
+    assert abs(exp_polar(2 + 3*I)) == exp(2)
     assert exp_polar(I*10).n() == exp_polar(I*10)
 
     assert log(exp_polar(z)) == z


### PR DESCRIPTION
#### Brief description of what is fixed or changed

`Abs(exp_polar(z))` now returns `Abs(exp(z))` because any winding around the origin does not affect the absolute value. This is done by changing the `_eval_Abs` method of `exp_polar` to return `exp(re(self.args[0]))`.

#### Explanation

The range of function Abs is [0, oo], not the complex plane or any Riemann surface. So it should return nonnegative numbers even when the argument is polar. SymPy already does so when the argument of `exp_polar` is purely imaginary:

```
t = symbols('t', real=True)
Abs(exp_polar(I*t))   #  1
```
Indeed, one of existing tests is `assert abs(exp_polar(I*4)) == 1`.

But this does not happen for real numbers, or for complex numbers with nonzero real part:
```
Abs(exp_polar(0))    # exp_polar(0)
Abs(exp_polar(2))    # exp_polar(2)
Abs(exp_polar(2+3*I))  #  exp_polar(1 - 3*I/2)*exp_polar(1 + 3*I/2)
```
The reason is the current implementation of `_eval_Abs`, which is `sqrt(z*z.conjugate())`. This isn't the right formula because the product of polar numbers is another polar number. One should switch to normal exponential function for the evaluation of Abs.