### PR TITLE
Un-randomize the test of polylog values

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -136,15 +136,16 @@ def test_polylog_expansion():
 
 
 def test_polylog_values():
-    import random
     assert polylog(2, 2) == pi**2/4 - I*pi*log(2)
     assert polylog(2, S.Half) == pi**2/12 - log(2)**2/2
     for z in [S.Half, 2, (sqrt(5)-1)/2, -(sqrt(5)-1)/2, -(sqrt(5)+1)/2, (3-sqrt(5))/2]:
         assert Abs(polylog(2, z).evalf() - polylog(2, z, evaluate=False).evalf()) < 1e-15
     for s in [-1, 0, 1]:
-        for _ in range(10):
-            z = random.uniform(-5, 5) + I*random.uniform(-5, 5)
-            assert Abs(polylog(s, z).evalf() - polylog(s, z, evaluate=False).evalf()) < 1e-15
+        for x in [0, 1.34, 3.2, -2.13, 0.34, -0.63, -4.212]:
+            for y in [0, 1.76, -1.42, -3.45, 3.232, 4.5, -0.1, 0.3]:
+                z = x + I*y
+                assert Abs(polylog(s, z).evalf() - polylog(s, z, evaluate=False).evalf()) \
+                    < 1e-15
 
 
 def test_lerchphi_expansion():


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Random numbers in test_polylog_values, introduced in #13852,  are replaced by a fixed set of complex numbers.

#### Explanation

I recently added (in #13852) a test to check that the values of polylog for special values of s agree with the mpmath floating point evaluation. The test picked random complex numbers and asserted Abs(difference) < 1e-15.

This turned out to be a bad idea because polylog has a pole at 1, so when a random number is very close to 1, the absolute error of mpmath computation may sometimes (rarely) be greater than 1e-15.

#### Other comments

It is only fair that this random test failure occurred on my own, unrelated, PR.