### PR TITLE
Evaluate the argument of polar numbers

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -4,14 +4,15 @@ from sympy.core import S, Add, Mul, sympify, Symbol, Dummy
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import (Function, Derivative, ArgumentIndexError,
     AppliedUndef)
-from sympy.core.numbers import pi
+from sympy.core.numbers import pi, I, oo
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.core.expr import Expr
 from sympy.core.relational import Eq
 from sympy.core.logic import fuzzy_not
-from sympy.functions.elementary.exponential import exp, exp_polar
-from sympy.functions.elementary.trigonometric import atan2
+from sympy.functions.elementary.exponential import exp, exp_polar, log
+from sympy.functions.elementary.trigonometric import atan, atan2
+from sympy.functions.elementary.integers import ceiling
 
 ###############################################################################
 ######################### REAL and IMAGINARY PARTS ############################
@@ -367,7 +368,7 @@ class sign(Function):
             return Piecewise((1, arg > 0), (-1, arg < 0), (0, True))
 
     def _eval_rewrite_as_Heaviside(self, arg):
-        from sympy import Heaviside
+        from sympy.functions.special.delta_functions import Heaviside
         if arg.is_real:
             return Heaviside(arg)*2-1
 
@@ -571,7 +572,7 @@ class Abs(Function):
     def _eval_rewrite_as_Heaviside(self, arg):
         # Note this only holds for real arg (since Heaviside is not defined
         # for complex arguments).
-        from sympy import Heaviside
+        from sympy.functions.special.delta_functions import Heaviside
         if arg.is_real:
             return arg*(Heaviside(arg) - Heaviside(-arg))
 
@@ -580,7 +581,6 @@ class Abs(Function):
             return Piecewise((arg, arg >= 0), (-arg, True))
 
     def _eval_rewrite_as_sign(self, arg):
-        from sympy import sign
         return arg/sign(arg)
 
 
@@ -608,8 +608,8 @@ class arg(Function):
 
     @classmethod
     def eval(cls, arg):
-        if isinstance(arg, exp_polar):
-            return im(arg.exp)
+        if arg.is_polar:
+            return periodic_argument(arg, oo)
         if not arg.is_Atom:
             c, arg_ = factor_terms(arg).as_coeff_Mul()
             if arg_.is_Mul:
@@ -620,7 +620,7 @@ class arg(Function):
             arg_ = arg
         if arg_.atoms(AppliedUndef):
             return
-        x, y = re(arg_), im(arg_)
+        x, y = arg_.as_real_imag()
         rv = atan2(y, x)
         if rv.is_number:
             return rv
@@ -628,12 +628,12 @@ class arg(Function):
             return cls(arg_, evaluate=False)
 
     def _eval_derivative(self, t):
-        x, y = re(self.args[0]), im(self.args[0])
+        x, y = self.args[0].as_real_imag()
         return (x * Derivative(y, t, evaluate=True) - y *
                     Derivative(x, t, evaluate=True)) / (x**2 + y**2)
 
     def _eval_rewrite_as_atan2(self, arg):
-        x, y = re(self.args[0]), im(self.args[0])
+        x, y = self.args[0].as_real_imag()
         return atan2(y, x)
 
 
@@ -793,7 +793,7 @@ class polar_lift(Function):
 
     @classmethod
     def eval(cls, arg):
-        from sympy import exp_polar, pi, I, arg as argument
+        from sympy.functions.elementary.complexes import arg as argument
         if arg.is_number:
             ar = argument(arg)
             # In general we want to affirm that something is known,
@@ -862,7 +862,6 @@ class periodic_argument(Function):
 
     @classmethod
     def _getunbranched(cls, ar):
-        from sympy import exp_polar, log, polar_lift
         if ar.is_Mul:
             args = ar.args
         else:
@@ -889,7 +888,6 @@ class periodic_argument(Function):
         # logarithm, and then reduce.
         # NOTE evidently this means it is a rather bad idea to use this with
         # period != 2*pi and non-polar numbers.
-        from sympy import ceiling, oo, atan2, atan, polar_lift, pi, Mul
         if not period.is_positive:
             return None
         if period == oo and isinstance(ar, principal_branch):
@@ -913,7 +911,6 @@ class periodic_argument(Function):
                 return unbranched - n
 
     def _eval_evalf(self, prec):
-        from sympy import ceiling, oo
         z, period = self.args
         if period == oo:
             unbranched = periodic_argument._getunbranched(z)
@@ -925,7 +922,6 @@ class periodic_argument(Function):
 
 
 def unbranched_argument(arg):
-    from sympy import oo
     return periodic_argument(arg, oo)
 
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -608,7 +608,7 @@ class arg(Function):
 
     @classmethod
     def eval(cls, arg):
-        if arg.is_polar:
+        if isinstance(arg, exp_polar):
             return periodic_argument(arg, oo)
         if not arg.is_Atom:
             c, arg_ = factor_terms(arg).as_coeff_Mul()

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -608,6 +608,8 @@ class arg(Function):
 
     @classmethod
     def eval(cls, arg):
+        if isinstance(arg, exp_polar):
+            return im(arg.exp)
         if not arg.is_Atom:
             c, arg_ = factor_terms(arg).as_coeff_Mul()
             if arg_.is_Mul:

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -523,6 +523,9 @@ def test_arg():
     assert arg(1 + I) == pi/4
     assert arg(-1 + I) == 3*pi/4
     assert arg(1 - I) == -pi/4
+    assert arg(exp_polar(4*pi*I)) == 4*pi
+    assert arg(exp_polar(-7*pi*I)) == -7*pi
+    assert arg(exp_polar(5 - 3*pi*I/4)) == -3*pi/4
     f = Function('f')
     assert not arg(f(0) + I*f(1)).atoms(re)
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The argument, like logarithm, is unbranched on the Riemann surface where polar numbers live. So it is computed as unbranched when the argument is a polar number. For example, `arg(exp_polar(4*pi*I))` is returned as `4*pi`, consistent with the purpose of polar numbers: provide continuous evaluation of branched functions such as log and arg.

The current behavior is
```
>>> arg(exp_polar(4*pi*I))
-I*log((re(exp_polar(4*I*pi)) + I*im(exp_polar(4*I*pi))) /
    sqrt(re(exp_polar(4*I*pi))**2 + im(exp_polar(4*I*pi))**2))
```

#### Other comments

Minor changes: `arg` function now uses `as_real_imag` because using re and im just ends up calling the same `as_real_imag` method twice, for real and imaginary parts. 

In the process I also reorganized the import statements, which were under-specific (from sympy import) and scattered throughout the module.



