### PR TITLE
made solveset to work with eq having Max(),Min()

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -34,7 +34,8 @@ from sympy.solvers.inequalities import solve_univariate_inequality
 from sympy.utilities import filldedent
 from sympy.calculus.util import periodicity, continuous_domain
 from sympy.core.compatibility import ordered, default_sort_key, is_sequence
-
+from sympy.functions.elementary.piecewise import Piecewise
+from sympy.functions.elementary.miscellaneous import Max, Min
 from types import GeneratorType
 
 
@@ -932,7 +933,6 @@ def solveset(f, symbol=None, domain=S.Complexes):
                 relationship between value and 0 is unknown: %s''' % b))
 
     if f.has(Max) or f.has(Min):
-        from sympy.functions.elementary.piecewise import Piecewise
         f = f.rewrite(Piecewise())
 
     if isinstance(f, Eq):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -932,7 +932,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
             raise NotImplementedError(filldedent('''
                 relationship between value and 0 is unknown: %s''' % b))
 
-    if f.has(Max) or f.has(Min):
+    if not f.has(Abs):
         f = f.rewrite(Piecewise)
 
     if isinstance(f, Eq):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -931,6 +931,10 @@ def solveset(f, symbol=None, domain=S.Complexes):
             raise NotImplementedError(filldedent('''
                 relationship between value and 0 is unknown: %s''' % b))
 
+    if f.has(Max) or f.has(Min):
+        from sympy.functions.elementary.piecewise import Piecewise
+        f = f.rewrite(Piecewise())
+
     if isinstance(f, Eq):
         from sympy.core import Add
         f = Add(f.lhs, - f.rhs, evaluate=False)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -38,7 +38,6 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.miscellaneous import Max, Min
 from types import GeneratorType
 from sympy.utilities.iterables import numbered_symbols
-from collections import OrderedDict
 
 
 def _invert(f_x, y, x, domain=S.Complexes):
@@ -934,7 +933,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
             raise NotImplementedError(filldedent('''
                 relationship between value and 0 is unknown: %s''' % b))
 
-    reps = OrderedDict(zip(
+    reps = list(zip(
         # do larger expressions first in case they contain
         # other Abs
         reversed(list(ordered(
@@ -946,8 +945,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
     f = f.rewrite(Piecewise)
 
     if reps:
-        ireps = dict([(v, k) for k, v in reps.items()])
-        f = f.xreplace(ireps)
+        f = f.xreplace(dict([(n, o) for o, n in reps]))
 
 
     if isinstance(f, Eq):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -597,11 +597,6 @@ def _solve_abs(f, symbol, domain):
         return ConditionSet(symbol, Eq(f, 0), domain)
 
 
-def _solve_min_max(f, symbol, domain):
-    f = f.rewrite(Piecewise)
-    return _solveset(f, symbol, domain, _check=True)
-
-
 def solve_decomposition(f, symbol, domain):
     """
     Function to solve equations via the principle of "Decomposition
@@ -768,10 +763,6 @@ def _solveset(f, symbol, domain, _check=False):
                                                  solver)
                     elif equation.has(Abs):
                         result += _solve_abs(f, symbol, domain)
-
-                    elif equation.has(Max) or equation.has(Min):
-                        result = _solve_min_max(equation, symbol, domain)
-
                     else:
                         result += _solve_as_rational(equation, symbol, domain)
                 else:
@@ -940,6 +931,9 @@ def solveset(f, symbol=None, domain=S.Complexes):
         else:
             raise NotImplementedError(filldedent('''
                 relationship between value and 0 is unknown: %s''' % b))
+
+    if f.has(Max) or f.has(Min):
+        f = f.rewrite(Piecewise)
 
     if isinstance(f, Eq):
         from sympy.core import Add

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -933,7 +933,7 @@ def solveset(f, symbol=None, domain=S.Complexes):
                 relationship between value and 0 is unknown: %s''' % b))
 
     if f.has(Max) or f.has(Min):
-        f = f.rewrite(Piecewise())
+        f = f.rewrite(Piecewise)
 
     if isinstance(f, Eq):
         from sympy.core import Add

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -597,6 +597,11 @@ def _solve_abs(f, symbol, domain):
         return ConditionSet(symbol, Eq(f, 0), domain)
 
 
+def _solve_min_max(f, symbol, domain):
+    f = f.rewrite(Piecewise)
+    return _solveset(f, symbol, domain, _check=True)
+
+
 def solve_decomposition(f, symbol, domain):
     """
     Function to solve equations via the principle of "Decomposition
@@ -763,6 +768,10 @@ def _solveset(f, symbol, domain, _check=False):
                                                  solver)
                     elif equation.has(Abs):
                         result += _solve_abs(f, symbol, domain)
+
+                    elif equation.has(Max) or equation.has(Min):
+                        result = _solve_min_max(equation, symbol, domain)
+
                     else:
                         result += _solve_as_rational(equation, symbol, domain)
                 else:
@@ -931,9 +940,6 @@ def solveset(f, symbol=None, domain=S.Complexes):
         else:
             raise NotImplementedError(filldedent('''
                 relationship between value and 0 is unknown: %s''' % b))
-
-    if f.has(Max) or f.has(Min):
-        f = f.rewrite(Piecewise)
 
     if isinstance(f, Eq):
         from sympy.core import Add

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -38,7 +38,6 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.miscellaneous import Max, Min
 from types import GeneratorType
 from sympy.utilities.iterables import numbered_symbols
-from collections import OrderedDict
 
 
 def _invert(f_x, y, x, domain=S.Complexes):
@@ -934,20 +933,19 @@ def solveset(f, symbol=None, domain=S.Complexes):
             raise NotImplementedError(filldedent('''
                 relationship between value and 0 is unknown: %s''' % b))
 
-    reps = OrderedDict(zip(
+    reps = list(zip(
         # do larger expressions first in case they contain
         # other Abs
         reversed(list(ordered(
             [i for i in f.atoms(Abs) if symbol in i.free_symbols]))),
         numbered_symbols("t", cls=Dummy)))
     for k in reps:
-        f = f.replace(k, reps[k])
+        f = f.replace(k[0], k[1])
 
     f = f.rewrite(Piecewise)
 
     if reps:
-        ireps = dict([(v, k) for k, v in reps.items()])
-        f = f.xreplace(ireps)
+        f = f.xreplace(dict([(n, o) for o, n in reps]))
 
 
     if isinstance(f, Eq):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -931,7 +931,8 @@ def test_solveset():
                                                   S.Integers)
     # issue 13825
     assert solveset(x**2 + f(0) + 1, x) == {-sqrt(-f(0) - 1), sqrt(-f(0) - 1)}
-    assert solveset(x*Max(x, 15) - 10, x) == FiniteSet(S("2/3"))                                #issue 10158
+    #issue 10158
+    assert solveset(x*Max(x, 15) - 10, x) == FiniteSet(S("2/3"))
     assert solveset(x*Min(x, 15) - 10, x) == FiniteSet(-sqrt(10), sqrt(10))
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -931,6 +931,8 @@ def test_solveset():
                                                   S.Integers)
     # issue 13825
     assert solveset(x**2 + f(0) + 1, x) == {-sqrt(-f(0) - 1), sqrt(-f(0) - 1)}
+    assert solveset(x*Max(x, 15) - 10, x) == {2/3}                                #issue 10158
+    assert solveset(x*Min(x, 15) - 10, x) == {10}
 
 
 def test_conditionset():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -900,7 +900,7 @@ def test_solve_lambert():
 
 
 def test_solveset():
-    x = Symbol('x')
+    x, y = symbols('x, y')
     f = Function('f')
     raises(ValueError, lambda: solveset(x + y))
     assert solveset(x, 1) == S.EmptySet
@@ -934,6 +934,8 @@ def test_solveset():
     #issue 10158
     assert solveset(x*Max(x, 15) - 10, x) == FiniteSet(S("2/3"))
     assert solveset(x*Min(x, 15) - 10, x) == FiniteSet(-sqrt(10), sqrt(10))
+    assert solveset(Max(abs(x-3)-1,x+2)-3, x, S.Reals) == FiniteSet(-1, 1)
+    assert solveset(Abs(x-1) - Abs(y), x, S.Reals) == FiniteSet(-Abs(y) + 1, Abs(y) + 1)
 
 
 def test_conditionset():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -36,7 +36,7 @@ from sympy.solvers.solveset import (
     linsolve, _is_function_class_equation, invert_real, invert_complex,
     solveset, solve_decomposition, substitution, nonlinsolve, solvify,
     _is_finite_with_finite_vars)
-
+from sympy.functions.elementary.miscellaneous import Max, Min
 
 a = Symbol('a', real=True)
 b = Symbol('b', real=True)
@@ -931,8 +931,8 @@ def test_solveset():
                                                   S.Integers)
     # issue 13825
     assert solveset(x**2 + f(0) + 1, x) == {-sqrt(-f(0) - 1), sqrt(-f(0) - 1)}
-    assert solveset(x*Max(x, 15) - 10, x) == {2/3}                                #issue 10158
-    assert solveset(x*Min(x, 15) - 10, x) == {10}
+    assert solveset(x*Max(x, 15) - 10, x) == FiniteSet(S("2/3"))                                #issue 10158
+    assert solveset(x*Min(x, 15) - 10, x) == FiniteSet(-sqrt(10), sqrt(10))
 
 
 def test_conditionset():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -936,6 +936,7 @@ def test_solveset():
     assert solveset(x*Min(x, 15) - 10, x) == FiniteSet(-sqrt(10), sqrt(10))
     assert solveset(Max(abs(x-3)-1,x+2)-3, x, S.Reals) == FiniteSet(-1, 1)
     assert solveset(Abs(x-1) - Abs(y), x, S.Reals) == FiniteSet(-Abs(y) + 1, Abs(y) + 1)
+    assert solveset(Abs(x**3 + 4*Abs(x+1)), x, S.Reals) == FiniteSet(-(54 + 6*sqrt(129))**S((S(1)/3))/3 + 4/(54 + 6*sqrt(129))**(S(1)/3))
 
 
 def test_conditionset():


### PR DESCRIPTION
Partial fix to issue #10158.
As mentioned in the issue ,equations having Max() and Min() will now be converted to Piecewise before
entering _solveset() via rewrite()-->(as implemented in PR #13309)

ping @smichr @asmeurer 

