### PR TITLE
Expression should be NaN when Mul "cancels out infinity"

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -424,7 +424,7 @@ class Mul(Expr, AssocOp):
             for b, e in c_powers:
                 if e.is_zero:
                     # canceling out infinities yields NaN
-                    if (b.is_Add or b.is_Mul) and any(infty in b.args \
+                    if (b.is_Add or b.is_Mul) and any(infty in b.args
                         for infty in (S.ComplexInfinity, S.Infinity,
                                       S.NegativeInfinity)):
                         return [S.NaN], [], None

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -423,6 +423,11 @@ class Mul(Expr, AssocOp):
             changed = False
             for b, e in c_powers:
                 if e.is_zero:
+                    # canceling out infinities yields NaN
+                    if (b.is_Add or b.is_Mul) and any(infty in b.args \
+                        for infty in (S.ComplexInfinity, S.Infinity,
+                                      S.NegativeInfinity)):
+                        return [S.NaN], [], None
                     continue
                 if e is S.One:
                     if b.is_Number:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
-        sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, Integer,
+        sympify, Add, Mul, Pow, Mod, I, log, S, Max, symbols, oo, zoo, Integer,
         sign, im, nan, Dummy, factorial, comp, refine
 )
 from sympy.core.compatibility import long, range
@@ -1936,6 +1936,14 @@ def test_Mul_with_zero_infinite():
     e = Mul(inf, zer, evaluate=False)
     assert e.is_positive is None
     assert e.is_hermitian is None
+
+def test_Mul_does_not_cancel_infinities():
+    a, b = symbols('a b')
+    assert ((zoo + 3*a)/(3*a + zoo)) is nan
+    assert ((b - oo)/(b - oo)) is nan
+    # issue 13904
+    expr = (1/(a+b) + 1/(a-b))/(1/(a+b) - 1/(a-b))
+    assert expr.subs(b, a) is nan
 
 def test_issue_8247_8354():
     from sympy import tan


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13904

#### Brief description of what is fixed or changed

Mul combines powers with identical base, adding their exponents. When this results in zero as exponent, the term is simply dropped, which is wrong to do when the base is infinite. There is already a simple check that suffices for oo/oo (returning NaN) but it does not recognize (x+oo)/(x+oo) as a meaningless expression. A more careful check is added: canceling a term where the base is an Add or Mul with an infinite argument results in NaN.

#### Other comments

The full analysis of base expression seems impractical for such a basic method as Mul, which needs to be very fast. Many expressions containing oo are in fact finite, like `Pow(2, -oo)` or `periodic_argument(I, oo)`. The check for Add and Mul should be enough for common cases like substitution in a rational function that presently results in an incorrect value:
```
var('a b')
r = (1/(a+b) + 1/(a-b))/(1/(a+b) - 1/(a-b))
r.subs(b, a)   
```
The above returns 1, contrary to any interpretation of the formula (the limit as b->a would be -1).
