### PR TITLE
Expand modified error functions in terms of the standard one

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -378,6 +378,9 @@ class erfc(Function):
     def _eval_rewrite_as_expint(self, z):
         return S.One - sqrt(z**2)/z + z*expint(S.Half, z**2)/sqrt(S.Pi)
 
+    def _eval_expand_func(self, **hints):
+        return self.rewrite(erf)
+
     def _eval_as_leading_term(self, x):
         from sympy import Order
         arg = self.args[0].as_leading_term(x)
@@ -556,6 +559,9 @@ class erfi(Function):
     def _eval_rewrite_as_expint(self, z):
         return sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
 
+    def _eval_expand_func(self, **hints):
+        return self.rewrite(erf)
+
     def as_real_imag(self, deep=True, **hints):
         if self.args[0].is_real:
             if deep:
@@ -705,6 +711,10 @@ class erf2(Function):
     def _eval_rewrite_as_expint(self, x, y):
         return erf(y).rewrite(expint) - erf(x).rewrite(expint)
 
+    def _eval_expand_func(self, **hints):
+        return self.rewrite(erf)
+
+
 class erfinv(Function):
     r"""
     Inverse Error Function. The erfinv function is defined as:
@@ -789,6 +799,7 @@ class erfinv(Function):
     def _eval_rewrite_as_erfcinv(self, z):
        return erfcinv(1-z)
 
+
 class erfcinv (Function):
     r"""
     Inverse Complementary Error Function. The erfcinv function is defined as:
@@ -858,6 +869,7 @@ class erfcinv (Function):
 
     def _eval_rewrite_as_erfinv(self, z):
         return erfinv(1-z)
+
 
 class erf2inv(Function):
     r"""
@@ -1780,6 +1792,9 @@ class Ci(TrigonometricIntegral):
 
     def _eval_rewrite_as_expint(self, z):
         return -(E1(polar_lift(I)*z) + E1(polar_lift(-I)*z))/2
+
+    def _eval_expand_func(self, **hints):
+        return self.rewrite(expint)
 
     def _sage_(self):
         import sage.all as sage

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1793,9 +1793,6 @@ class Ci(TrigonometricIntegral):
     def _eval_rewrite_as_expint(self, z):
         return -(E1(polar_lift(I)*z) + E1(polar_lift(-I)*z))/2
 
-    def _eval_expand_func(self, **hints):
-        return self.rewrite(expint)
-
     def _sage_(self):
         import sage.all as sage
         return sage.cos_integral(self.args[0]._sage_())

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -127,6 +127,7 @@ def test_erfc():
     assert erfc(z).rewrite('meijerg') == 1 - z*meijerg([S.Half], [], [0], [-S.Half], z**2)/sqrt(pi)
     assert erfc(z).rewrite('uppergamma') == 1 - sqrt(z**2)*(1 - erfc(sqrt(z**2)))/z
     assert erfc(z).rewrite('expint') == S.One - sqrt(z**2)/z + z*expint(S.Half, z**2)/sqrt(S.Pi)
+    assert expand_func(erf(x) + erfc(x)) == S.One
 
     assert erfc(x).as_real_imag() == \
         ((erfc(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
@@ -180,6 +181,7 @@ def test_erfi():
     assert erfi(z).rewrite('uppergamma') == (sqrt(-z**2)/z*(uppergamma(S.Half,
         -z**2)/sqrt(S.Pi) - S.One))
     assert erfi(z).rewrite('expint') == sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
+    assert expand_func(erfi(I*z)) == I*erf(z)
 
     assert erfi(x).as_real_imag() == \
         ((erfi(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +
@@ -224,6 +226,8 @@ def test_erf2():
 
     assert erf2(I, 0).is_real is False
     assert erf2(0, 0).is_real is True
+
+    assert expand_func(erf(x) + erf2(x, y)) == erf(y)
 
     assert conjugate(erf2(x, y)) == erf2(conjugate(x), conjugate(y))
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Added `_eval_expand_func` method to error functions erfc, erfi, and erf2, which expresses them in terms of erf. The motivation is to be able to simplify expressions like `erf(x) + erfc(x)`.

#### Other comments

Current behavior: this sum, which is 1 by the definition of erfc, resist simplification:
```
>>> simplify(erf(x) + erfc(x))
erf(x) + erfc(x)
>>> expand_func(erf(x) + erfc(x))
erf(x) + erfc(x)
```
With this change, the second attempt will succeed in returning 1.

Hopefully, simplify will eventually use `expand_func`, expressing the variety of more obscure functions in terms of fewer common / more familiar functions, which also increases the chance of functions canceling each other. 


