### PR TITLE
Improved legendre polynomial for negative n, added test cases for itself

### DIFF
--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -799,10 +799,8 @@ class legendre(OrthogonalPolynomial):
         else:
             # n is a given fixed integer, evaluate into polynomial
             if n.is_negative:
-                raise ValueError(
-                    "The index n must be nonnegative integer (got %r)" % n)
-            else:
-                return cls._eval_at_order(n, x)
+                n = -n - S.One
+            return cls._eval_at_order(n, x)
 
     def fdiff(self, argindex=2):
         if argindex == 1:

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -797,7 +797,8 @@ class legendre(OrthogonalPolynomial):
             elif x == S.Infinity:
                 return S.Infinity
         else:
-            # n is a given fixed integer, evaluate into polynomial
+            # n is a given fixed integer, evaluate into polynomial;
+            # L_{-n}(x)  --->  L_{n-1}(x)
             if n.is_negative:
                 n = -n - S.One
             return cls._eval_at_order(n, x)

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -108,7 +108,7 @@ def test_legendre():
 
     assert legendre(-1, x) == 1
     
-    var('k')
+    k = Symbol('k')
     assert legendre(5 - k, x).subs(k, 2) == ((5*x**3 - 3*x)/2).expand()
 
     assert roots(legendre(4, x), x) == {

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -91,7 +91,6 @@ def test_gegenbauer():
 
 
 def test_legendre():
-    raises(ValueError, lambda: legendre(-1, x))
     assert legendre(0, x) == 1
     assert legendre(1, x) == x
     assert legendre(2, x) == ((3*x**2 - 1)/2).expand()
@@ -174,9 +173,6 @@ def test_assoc_legendre():
     assert isinstance(X, assoc_legendre)
 
     assert Plm(n, 0, x) == legendre(n, x)
-
-    raises(ValueError, lambda: Plm(-1, 0, x))
-    raises(ValueError, lambda: Plm(0, 1, x))
 
     assert conjugate(assoc_legendre(n, m, x)) == \
         assoc_legendre(n, conjugate(m), conjugate(x))

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -107,6 +107,9 @@ def test_legendre():
     assert legendre(11, 0) == 0
 
     assert legendre(-1, x) == 1
+    
+    var('k')
+    assert legendre(5 - k, x).subs(k, 2) == ((5*x**3 - 3*x)/2).expand()
 
     assert roots(legendre(4, x), x) == {
         sqrt(Rational(3, 7) - Rational(2, 35)*sqrt(30)): 1,

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -107,6 +107,21 @@ def test_legendre():
     assert legendre(10, 0) != 0
     assert legendre(11, 0) == 0
 
+    assert legendre(-1, x) == 1
+    assert legendre(-2, x) == x
+    assert legendre(-3, x) == ((3*x**2 - 1)/2).expand()
+    assert legendre(-4, x) == ((5*x**3 - 3*x)/2).expand()
+    assert legendre(-5, x) == ((35*x**4 - 30*x**2 + 3)/8).expand()
+    assert legendre(-6, x) == ((63*x**5 - 70*x**3 + 15*x)/8).expand()
+    assert legendre(-7, x) == ((231*x**6 - 315*x**4 + 105*x**2 - 5)/16).expand()
+
+    assert legendre(-11, -1) == 1
+    assert legendre(-12, -1) == -1
+    assert legendre(-11, 1) == 1
+    assert legendre(-12, 1) == 1
+    assert legendre(-11, 0) != 0
+    assert legendre(-12, 0) == 0
+
     assert roots(legendre(4, x), x) == {
         sqrt(Rational(3, 7) - Rational(2, 35)*sqrt(30)): 1,
         -sqrt(Rational(3, 7) - Rational(2, 35)*sqrt(30)): 1,

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -107,7 +107,6 @@ def test_legendre():
     assert legendre(11, 0) == 0
 
     assert legendre(-1, x) == 1
-    
     k = Symbol('k')
     assert legendre(5 - k, x).subs(k, 2) == ((5*x**3 - 3*x)/2).expand()
 

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -176,6 +176,7 @@ def test_assoc_legendre():
 
     assert conjugate(assoc_legendre(n, m, x)) == \
         assoc_legendre(n, conjugate(m), conjugate(x))
+    raises(ValueError, lambda: Plm(0, 1, x))
 
 
 def test_chebyshev():

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -107,19 +107,6 @@ def test_legendre():
     assert legendre(11, 0) == 0
 
     assert legendre(-1, x) == 1
-    assert legendre(-2, x) == x
-    assert legendre(-3, x) == ((3*x**2 - 1)/2).expand()
-    assert legendre(-4, x) == ((5*x**3 - 3*x)/2).expand()
-    assert legendre(-5, x) == ((35*x**4 - 30*x**2 + 3)/8).expand()
-    assert legendre(-6, x) == ((63*x**5 - 70*x**3 + 15*x)/8).expand()
-    assert legendre(-7, x) == ((231*x**6 - 315*x**4 + 105*x**2 - 5)/16).expand()
-
-    assert legendre(-11, -1) == 1
-    assert legendre(-12, -1) == -1
-    assert legendre(-11, 1) == 1
-    assert legendre(-12, 1) == 1
-    assert legendre(-11, 0) != 0
-    assert legendre(-12, 0) == 0
 
     assert roots(legendre(4, x), x) == {
         sqrt(Rational(3, 7) - Rational(2, 35)*sqrt(30)): 1,
@@ -180,7 +167,6 @@ def test_assoc_legendre():
 
 
 def test_chebyshev():
-
     assert chebyshevt(0, x) == 1
     assert chebyshevt(1, x) == x
     assert chebyshevt(2, x) == 2*x**2 - 1


### PR DESCRIPTION
Fixes #13916 
Instead of giving `ValueError` for negative integer in Legendre polynomial

- Replaced negative number `n` by `-n - 1`
- Used [this](http://functions.wolfram.com/Polynomials/LegendreP/02/) convention for Legendre polynomial of negative number which is 
` L_{n}(x)  = L_{-n -1}(x)` where `n` belongs to negative integer  
- Added test cases for this implementation in test_spec_polynomials.py to pass test in build.