### PR TITLE
Correct the handling of keyword arguments in Derivative.__new__

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1097,7 +1097,7 @@ class Derivative(Expr):
         else:
             return False
 
-    def __new__(cls, expr, *variables, **assumptions):
+    def __new__(cls, expr, *variables, **kwargs):
 
         from sympy.matrices.common import MatrixCommon
         from sympy import Integer
@@ -1192,9 +1192,7 @@ class Derivative(Expr):
         if len(variable_count) == 0:
             return expr
 
-        # Pop evaluate because it is not really an assumption and we will need
-        # to track it carefully below.
-        evaluate = assumptions.pop('evaluate', False)
+        evaluate = kwargs.pop('evaluate', False)
 
         # Look for a quick exit if there are symbols that don't appear in
         # expression at all. Note, this cannot check non-symbols like
@@ -1219,10 +1217,7 @@ class Derivative(Expr):
             if evaluate:
                 #TODO: check if assumption of discontinuous derivatives exist
                 variable_count = cls._sort_variable_count(variable_count)
-            # Here we *don't* need to reinject evaluate into assumptions
-            # because we are done with it and it is not an assumption that
-            # Expr knows about.
-            obj = Expr.__new__(cls, expr, *variable_count, **assumptions)
+            obj = Expr.__new__(cls, expr, *variable_count)
             return obj
 
         # Compute the derivative now by repeatedly calling the
@@ -1292,7 +1287,7 @@ class Derivative(Expr):
 
         if unhandled_variable_count:
             unhandled_variable_count = cls._sort_variable_count(unhandled_variable_count)
-            expr = Expr.__new__(cls, expr, *unhandled_variable_count, **assumptions)
+            expr = Expr.__new__(cls, expr, *unhandled_variable_count)
         else:
             # We got a Derivative at the end of it all, and we rebuild it by
             # sorting its variables.
@@ -1301,7 +1296,7 @@ class Derivative(Expr):
                     expr.args[0], *cls._sort_variable_count(expr.args[1:])
                 )
 
-        if (nderivs > 1) == True and assumptions.get('simplify', True):
+        if (nderivs > 1) == True and kwargs.get('simplify', True):
             from sympy.core.exprtools import factor_terms
             from sympy.simplify.simplify import signsimp
             expr = factor_terms(signsimp(expr))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1192,7 +1192,7 @@ class Derivative(Expr):
         if len(variable_count) == 0:
             return expr
 
-        evaluate = kwargs.pop('evaluate', False)
+        evaluate = kwargs.get('evaluate', False)
 
         # Look for a quick exit if there are symbols that don't appear in
         # expression at all. Note, this cannot check non-symbols like

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -740,6 +740,12 @@ def test_issue_8469():
     expr = functools.reduce(g,ws)
 
 
+def test_issue_12996():
+    # foo=True imitates the sort of arguments that Derivative can get
+    # from Integral when it passes doit to the expression
+    assert Derivative(im(x), x).doit(foo=True) == Derivative(im(x), x)
+
+
 def test_should_evalf():
     # This should not take forever to run (see #8506)
     assert isinstance(sin((1.0 + 1.0*I)**10000 + 1), sin)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1166,6 +1166,10 @@ def test_issue_8901():
     assert integrate(tanh(1.0*x)) == 1.0*x - 1.0*log(tanh(1.0*x) + 1)
     assert integrate(tanh(x)) == x - log(tanh(x) + 1)
 
+@slow
+def test_issue_12996():
+    # can't integrate it yet, but at least don't throw an exception
+    assert isinstance(integrate(log(abs(x)), x), Expr)
 
 @slow
 def test_issue_7130():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1167,12 +1167,6 @@ def test_issue_8901():
     assert integrate(tanh(x)) == x - log(tanh(x) + 1)
 
 
-def test_issue_12996():
-    # foo=True imitates the sort of arguments that Derivative can get
-    # from Integral when it passes doit to the expression
-    assert Derivative(im(x), x).doit(foo=True) == Derivative(im(x), x)
-
-
 @slow
 def test_issue_7130():
     if ON_TRAVIS:

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1166,10 +1166,12 @@ def test_issue_8901():
     assert integrate(tanh(1.0*x)) == 1.0*x - 1.0*log(tanh(1.0*x) + 1)
     assert integrate(tanh(x)) == x - log(tanh(x) + 1)
 
-@slow
+
 def test_issue_12996():
-    # can't integrate it yet, but at least don't throw an exception
-    assert isinstance(integrate(log(abs(x)), x), Expr)
+    # foo=True imitates the sort of arguments that Derivative can get
+    # from Integral when it passes doit to the expression
+    assert Derivative(im(x), x).doit(foo=True) == Derivative(im(x), x)
+
 
 @slow
 def test_issue_7130():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #12996

#### Brief description of what is fixed or changed

Currently, the `__new__` method of Derivative accepts keyword arguments, handles two of them (evaluate and simplify) and tries to pass the rest to any new derivatives created in the process, which raises an error because there are no keyword arguments for `Expr.__new__`. This is corrected now: it no longer passes the rest to `Expr.__new__`.

#### Other comments

We cannot yet change the method signature to `__new__(cls, expr, *variables, evaluate=False, simplify=True`) because Python 2.7 does not support keyword-only arguments appearing after `*args`.

The bug manifested itself in #12996 because a derivative was created in the process of integration, and then received `manual=False` parameter (intended for Integral) which it tried to pass to `Expr.__new__`.

Thanks to @asmeurer for proposing this solution in Gitter chat.  