### PR TITLE
Misc typos followup

### DIFF
--- a/doc/src/modules/integrals/g-functions.rst
+++ b/doc/src/modules/integrals/g-functions.rst
@@ -115,7 +115,7 @@ Suppose now we want to rewrite as a product of two G-functions. To do this,
 we (try to) find all inequivalent ways of splitting `f(x)` into a product
 `f_1(x) f_2(x)`.
 We could try these splittings in any order, but it is often a good idea to
-minimise (a) the number of powers occurring in `f_i(x)` and (b) the number of
+minimize (a) the number of powers occurring in `f_i(x)` and (b) the number of
 different functions occurring in `f_i(x)`. Thus given e.g.
 `f(x) = \sin{x}\, e^{x} \sin{2x}` we should try `f_1(x) = \sin{x}\, \sin{2x}`,
 `f_2(x) = e^{x}` first.

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -439,7 +439,7 @@ class DiagramGrid(object):
         aspects of layout.  For triangles with only simple morphisms
         in the edge, this assures that triangles with all three edges
         visible will get typeset after triangles with less visible
-        edges, which sometimes minimises the necessity in diagonal
+        edges, which sometimes minimizes the necessity in diagonal
         arrows.  For triangles with composite morphisms in the edges,
         this assures that objects connected with shorter morphisms
         will be laid out first, resulting the visual proximity of

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -11,7 +11,7 @@ def test_GrowableGrid():
     assert grid.width == 1
     assert grid.height == 2
 
-    # Check initialisation of elements.
+    # Check initialization of elements.
     assert grid[0, 0] is None
     assert grid[1, 0] is None
 

--- a/sympy/polys/rationaltools.py
+++ b/sympy/polys/rationaltools.py
@@ -29,7 +29,7 @@ def together(expr, deep=False):
     so ``apart(together(expr))`` should return expr unchanged. Note
     however, that :func:`together` uses only symbolic methods, so
     it might be necessary to use :func:`cancel` to perform algebraic
-    simplification and minimise degree of the numerator and denominator.
+    simplification and minimize degree of the numerator and denominator.
 
     Examples
     ========

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -942,7 +942,7 @@ class Operator(object):
     *not* blindly differentiate but instead use a different representation
     of the z*d/dz operator (see make_derivative_operator).
 
-    To subclass from this, define a __init__ method that initialises a
+    To subclass from this, define a __init__ method that initializes a
     self._poly variable. This variable stores a polynomial. By convention
     the generator is z*d/dz, and acts to the right of all coefficients.
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -667,7 +667,7 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
     r"""
     Helper function of dsolve that calls the respective
     :py:mod:`~sympy.solvers.ode` functions to solve for the ordinary
-    differential equations. This minimises the computation in calling
+    differential equations. This minimizes the computation in calling
     :py:meth:`~sympy.solvers.deutils._desolve` multiple times.
     """
     r = match
@@ -4622,7 +4622,7 @@ def ode_1st_power_series(eq, func, order, match):
     if not h:
         return Eq(f(x), value)
 
-    # Initialisation
+    # Initialization
     series = value
     if terms > 1:
         hc = h.subs({x: point, y: value})

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1121,7 +1121,7 @@ def linear_eq_to_matrix(equations, *symbols):
         symbols = symbols[0]
 
     M = Matrix([symbols])
-    # initialise Matrix with symbols + 1 columns
+    # initialize Matrix with symbols + 1 columns
     M = M.col_insert(len(symbols), Matrix([1]))
     row_no = 1
 
@@ -1142,7 +1142,7 @@ def linear_eq_to_matrix(equations, *symbols):
         M = M.row_insert(row_no, Matrix([coeff_list]))
         row_no += 1
 
-    # delete the initialised (Ist) trivial row
+    # delete the initialized (Ist) trivial row
     M.row_del(0)
     A, b = M[:, :-1], M[:, -1:]
     return A, b

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -1082,7 +1082,7 @@ def test_M37():
 
 
 def test_M38():
-    variabes = vring("k1:50", vfield("a,b,c", ZZ).to_domain())
+    variables = vring("k1:50", vfield("a,b,c", ZZ).to_domain())
     system = [
         -b*k8/a + c*k8/a, -b*k11/a + c*k11/a, -b*k10/a + c*k10/a + k2, -k3 - b*k9/a + c*k9/a,
         -b*k14/a + c*k14/a, -b*k15/a + c*k15/a, -b*k18/a + c*k18/a - k2, -b*k17/a + c*k17/a,
@@ -1133,7 +1133,7 @@ def test_M38():
         k2:  0, k1:  0,
         k34: b/c*k42, k31: k39, k26: a/c*k42, k23: k39
     }
-    assert solve_lin_sys(system, variabes) == solution
+    assert solve_lin_sys(system, variables) == solution
 
 
 def test_M39():


### PR DESCRIPTION
This is a follow-up to 93d6672000a8a0a1706bfacdfc50ab6d6a628dd0 (#13900).
Added Americanized spelling of `initialize` and `minimize` + a couple of source changes. Please review. 