### PR TITLE
Fix issue 13936: Link Geometry class names to their descriptors.

### DIFF
--- a/doc/src/modules/geometry/index.rst
+++ b/doc/src/modules/geometry/index.rst
@@ -18,10 +18,10 @@ Available Entities
 
 The following entities are currently available in the geometry module:
 
-* ``Point``
-* ``Line``, ``Ray``, ``Segment``
-* ``Ellipse``, ``Circle``
-* ``Polygon``, ``RegularPolygon``, ``Triangle``
+* :class:`~sympy.geometry.point.Point`
+* :class:`~sympy.geometry.line.Segment`, :class:`~sympy.geometry.line.Ray`, :class:`~sympy.geometry.line.Segment`
+* :class:`~sympy.geometry.ellipse.Ellipse`, :class:`~sympy.geometry.ellipse.Circle`
+* :class:`~sympy.geometry.polygon.Polygon`, :class:`~sympy.geometry.polygon.RegularPolygon`, :class:`~sympy.geometry.polygon.Triangle`
 
 Most of the work one will do will be through the properties and methods of
 these entities, but several global methods exist:

--- a/doc/src/modules/geometry/index.rst
+++ b/doc/src/modules/geometry/index.rst
@@ -19,7 +19,7 @@ Available Entities
 The following entities are currently available in the geometry module:
 
 * :class:`~sympy.geometry.point.Point`
-* :class:`~sympy.geometry.line.Line`, :class:`~sympy.geometry.line.Segment`, :class:`~sympy.geometry.line.Ray`, :class:`~sympy.geometry.line.Segment`
+* :class:`~sympy.geometry.line.Line`, :class:`~sympy.geometry.line.Segment`, :class:`~sympy.geometry.line.Ray`
 * :class:`~sympy.geometry.ellipse.Ellipse`, :class:`~sympy.geometry.ellipse.Circle`
 * :class:`~sympy.geometry.polygon.Polygon`, :class:`~sympy.geometry.polygon.RegularPolygon`, :class:`~sympy.geometry.polygon.Triangle`
 

--- a/doc/src/modules/geometry/index.rst
+++ b/doc/src/modules/geometry/index.rst
@@ -19,7 +19,7 @@ Available Entities
 The following entities are currently available in the geometry module:
 
 * :class:`~sympy.geometry.point.Point`
-* :class:`~sympy.geometry.line.Segment`, :class:`~sympy.geometry.line.Ray`, :class:`~sympy.geometry.line.Segment`
+* :class:`~sympy.geometry.line.Line`, :class:`~sympy.geometry.line.Segment`, :class:`~sympy.geometry.line.Ray`, :class:`~sympy.geometry.line.Segment`
 * :class:`~sympy.geometry.ellipse.Ellipse`, :class:`~sympy.geometry.ellipse.Circle`
 * :class:`~sympy.geometry.polygon.Polygon`, :class:`~sympy.geometry.polygon.RegularPolygon`, :class:`~sympy.geometry.polygon.Triangle`
 

--- a/doc/src/modules/geometry/plane.rst
+++ b/doc/src/modules/geometry/plane.rst
@@ -1,5 +1,7 @@
 Plane
 -----
 
-.. automodule:: sympy.geometry.plane
+.. module:: sympy.geometry.plane
+
+.. autoclass:: Plane
    :members:


### PR DESCRIPTION
Fixes #13936 . 

Added link to the descriptors of the Geometry classes in the documentation of the Geometry module.


