### PR TITLE
Solving trignometric equations which previously gave error

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -413,12 +413,12 @@ def _solve_trig(f, symbol, domain):
 
     else :
         raise NotImplementedError(filldedent('''
-            Solution to this kind of triginometric equations
+            Solution to this kind of trigonometric equations
             is yet to be implemented'''))
 
 
 def _solve_trig1(f, symbol, domain):
-    """ Helper to solve trigonometric equations """
+    """Primary Helper to solve trigonometric equations """
     f = trigsimp(f)
     f_original = f
     f = f.rewrite(exp)
@@ -439,34 +439,41 @@ def _solve_trig1(f, symbol, domain):
     elif solns is S.EmptySet:
         return S.EmptySet
     else:
-        return ConditionSet(symbol, Eq(f_original, 0), domain)
+        return ConditionSet(symbol, Eq(f_original, 0), S.Reals)
 
 
 def _solve_trig2(f, symbol, domain):
-    """ Helper to solve trigonometric equations """
-    from sympy import lcm, expand_trig
+    """Secondary helper to solve trigonometric equations,
+    called when first helper fails """
+    from sympy import ilcm, igcd, expand_trig, degree, simplify
     f = trigsimp(f)
     f_original = f
     trig_functions = f.atoms(sin, cos, tan, sec, cot, csc)
-    trig_arguments = [e.args for e in trig_functions]
+    trig_arguments = [e.args[0] for e in trig_functions]
     denominators = []
+    numerators = []
+
     for ar in trig_arguments:
         try:
             poly_ar = Poly(ar, symbol)
+
         except ValueError:
             raise ValueError("give up, we can't solve if this is not a polynomial in x")
         if poly_ar.degree() > 1:  # degree >1 still bad
-            raise ValueError("degree of variable inside polynomail should not exceed one")
-        if poly_ar.degree() == 0:  # degree 0, no x, don't care
+            raise ValueError("degree of variable inside polynomial should not exceed one")
+        if poly_ar.degree() == 0:  # degree 0, don't care
             continue
-        c = poly_ar.all_coeffs(x)[0]   # got the coefficient of x
+        c = poly_ar.all_coeffs()[0]   # got the coefficient of 'symbol'
+        numerators.append(Rational(c).p)
         denominators.append(Rational(c).q)
 
     x = Dummy('x')
-    f = f.subs(symbol, 2*lcm(denominators)*x)
+    mu = Rational(2)*ilcm(*denominators)/igcd(*numerators)
+    f = f.subs(symbol, mu*x)
     f = f.rewrite(tan)
     f = expand_trig(f)
     f = together(f)
+
     g, h = fraction(f)
     y = Dummy('y')
     g, h = g.expand(), h.expand()
@@ -474,12 +481,14 @@ def _solve_trig2(f, symbol, domain):
 
     if g.has(x) or h.has(x):
         return ConditionSet(symbol, Eq(f_original, 0), domain)
-
     solns = solveset(g, y, S.Reals) - solveset(h, y, S.Reals)
 
     if isinstance(solns, FiniteSet):
-        result = Union(*[invert_complex(tan(symbol/(2*lcm(denominators))), s, symbol)[1]
+        result = Union(*[invert_real(tan(symbol/mu), s, symbol)[1]
                        for s in solns])
+        dsol = invert_real(tan(symbol/mu), oo, symbol)[1]
+        if degree(h) > degree(g):                   # If degree(denom)>degree(num) then there
+            result = Union(result, dsol)            # would be another sol at Lim(denom-->oo)
         return Intersection(result, domain)
     elif solns is S.EmptySet:
         return S.EmptySet

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -407,51 +407,74 @@ def _solve_trig(f, symbol, domain):
     """ Helper to solve trigonometric equations """
     from sympy import lcm
     f = trigsimp(f)
-    # print(f)
     f_original = f
-    trig_functions = f.atoms(sin, cos, tan, sec, cot, csc)
-    trig_arguments = [e.args for e in trig_functions]
-    denominators = []
-    for ar in trig_arguments:
-        try:
-            poly_ar = Poly(ar, symbol)
-        except ValueError:
-            raise ValueError("give up, we can't solve if this is not a polynomial in x")
-        if poly_ar.degree() > 1:  # degree >1 still bad
-            raise ValueError("degree of variable inside polynomail should not exceed one")
-        if poly_ar.degree() == 0:  # degree 0, no x, don't care
-            continue
-        c = poly_ar.all_coeffs(x)[0]   # got the coefficient of x
-        denominators.append(Rational(c).q)
+    try:
+        f = f.rewrite(exp)
+        f = together(f)
+        g, h = fraction(f)
+        y = Dummy('y')
+        g, h = g.expand(), h.expand()
+        g, h = g.subs(exp(I*symbol), y), h.subs(exp(I*symbol), y)
+        if g.has(symbol) or h.has(symbol):
+            return ConditionSet(symbol, Eq(f, 0), S.Reals)
+
+        solns = solveset_complex(g, y) - solveset_complex(h, y)
+
+        if isinstance(solns, FiniteSet):
+            result = Union(*[invert_complex(exp(I*symbol), s, symbol)[1]
+                           for s in solns])
+            return Intersection(result, domain)
+        elif solns is S.EmptySet:
+            return S.EmptySet
+        else:
+            return ConditionSet(symbol, Eq(f_original, 0), S.Reals)
+
+    except PolynomialError:
+        from sympy import expand_trig
+        trig_functions = f.atoms(sin, cos, tan, sec, cot, csc)
+        trig_arguments = [e.args for e in trig_functions]
+        denominators = []
+        for ar in trig_arguments:
+            try:
+                poly_ar = Poly(ar, symbol)
+            except ValueError:
+                raise ValueError("give up, we can't solve if this is not a polynomial in x")
+            if poly_ar.degree() > 1:  # degree >1 still bad
+                raise ValueError("degree of variable inside polynomail should not exceed one")
+            if poly_ar.degree() == 0:  # degree 0, no x, don't care
+                continue
+            c = poly_ar.all_coeffs(x)[0]   # got the coefficient of x
+            denominators.append(Rational(c).q)
+
+        x = Dummy('x')
+        f=f.subs(symbol, 2*lcm(denominators)*x)
+        f = f.rewrite(tan)
+        f = together(f)
+        g, h = fraction(f)
+        y = Dummy('y')
+        g, h = expand_trig(g), expand_trig(h)
+        g, h = g.subs(tan(x), y), h.subs(tan(x), y)
 
 
-    x = Dummy('x')
-    melow=lcm(denominators)
-    f=f.subs(symbol, 2*melow*x)
-    f = f.rewrite(tan)
-    # print(f)
-    f = f.rewrite(exp)
-    # print(f)
-    f = together(f)
-    g, h = fraction(f)
-    y = Dummy('y')
-    g, h = g.expand(), h.expand()
-    g, h = g.subs(exp(I*x), y), h.subs(exp(I*x), y)
-    if g.has(x) or h.has(x):
-        f=f.subs(x, symbol/(2*lcm(denominators)))
-        return ConditionSet(symbol, Eq(f, 0), S.Reals)
+        if g.has(x) or h.has(x):
+            f=f.subs(x, symbol/(2*lcm(denominators)))
+            return ConditionSet(symbol, Eq(f, 0), S.Reals)
 
-    solns = solveset_complex(g, y) - solveset_complex(h, y)
-    # print((solns))
-    if isinstance(solns, FiniteSet):
-        result = Union(*[invert_complex(exp(I*symbol/(2*melow)), s, symbol)[1]
-                       for s in solns])
-        # print(result)
-        return Intersection(result, domain)
-    elif solns is S.EmptySet:
-        return S.EmptySet
-    else:
-        return ConditionSet(symbol, Eq(f_original, 0), S.Reals)
+        solns = solveset_complex(g, y) - solveset_complex(h, y)
+        print(solns)
+        print(" ")
+
+        # print((solns))
+        if isinstance(solns, FiniteSet):
+            result = Union(*[invert_real(tan(symbol/(2*lcm(denominators))), s, symbol)[1]
+                           for s in solns])
+
+            return Intersection(result, domain)
+        elif solns is S.EmptySet:
+            return S.EmptySet
+        else:
+            return ConditionSet(symbol, Eq(f_original, 0), S.Reals)
+
 
 
 def _solve_as_poly(f, symbol, domain=S.Complexes):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -405,24 +405,49 @@ def _solve_as_rational(f, symbol, domain):
 
 def _solve_trig(f, symbol, domain):
     """ Helper to solve trigonometric equations """
+    from sympy import lcm
     f = trigsimp(f)
+    # print(f)
     f_original = f
+    trig_functions = f.atoms(sin, cos, tan, sec, cot, csc)
+    trig_arguments = [e.args for e in trig_functions]
+    denominators = []
+    for ar in trig_arguments:
+        try:
+            poly_ar = Poly(ar, symbol)
+        except ValueError:
+            raise ValueError("give up, we can't solve if this is not a polynomial in x")
+        if poly_ar.degree() > 1:  # degree >1 still bad
+            raise ValueError("degree of variable inside polynomail should not exceed one")
+        if poly_ar.degree() == 0:  # degree 0, no x, don't care
+            continue
+        c = poly_ar.all_coeffs(x)[0]   # got the coefficient of x
+        denominators.append(Rational(c).q)
+
+
+    x = Dummy('x')
+    melow=lcm(denominators)
+    f=f.subs(symbol, 2*melow*x)
+    f = f.rewrite(tan)
+    # print(f)
     f = f.rewrite(exp)
+    # print(f)
     f = together(f)
     g, h = fraction(f)
     y = Dummy('y')
     g, h = g.expand(), h.expand()
-    g, h = g.subs(exp(I*symbol), y), h.subs(exp(I*symbol), y)
-    if g.has(symbol) or h.has(symbol):
+    g, h = g.subs(exp(I*x), y), h.subs(exp(I*x), y)
+    if g.has(x) or h.has(x):
+        f=f.subs(x, symbol/(2*lcm(denominators)))
         return ConditionSet(symbol, Eq(f, 0), S.Reals)
 
     solns = solveset_complex(g, y) - solveset_complex(h, y)
+    # print((solns))
     if isinstance(solns, FiniteSet):
-
-        result = Union(*[invert_complex(exp(I*symbol), s, symbol)[1]
+        result = Union(*[invert_complex(exp(I*symbol/(2*melow)), s, symbol)[1]
                        for s in solns])
+        # print(result)
         return Intersection(result, domain)
-
     elif solns is S.EmptySet:
         return S.EmptySet
     else:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -417,11 +417,19 @@ def _solve_trig(f, symbol, domain):
         return ConditionSet(symbol, Eq(f, 0), S.Reals)
 
     solns = solveset_complex(g, y) - solveset_complex(h, y)
-
     if isinstance(solns, FiniteSet):
+        from sympy.polys.rootoftools import CRootOf
+        solns=list(solns)
+        j=0
+        for el in solns:
+            if isinstance(el, CRootOf):
+                solns[j] = el.evalf()
+            j=j+1
+
         result = Union(*[invert_complex(exp(I*symbol), s, symbol)[1]
                        for s in solns])
         return Intersection(result, domain)
+
     elif solns is S.EmptySet:
         return S.EmptySet
     else:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -418,13 +418,6 @@ def _solve_trig(f, symbol, domain):
 
     solns = solveset_complex(g, y) - solveset_complex(h, y)
     if isinstance(solns, FiniteSet):
-        from sympy.polys.rootoftools import CRootOf
-        solns=list(solns)
-        j=0
-        for el in solns:
-            if isinstance(el, CRootOf):
-                solns[j] = el.evalf()
-            j=j+1
 
         result = Union(*[invert_complex(exp(I*symbol), s, symbol)[1]
                        for s in solns])

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -772,6 +772,24 @@ def test_solve_trig():
     assert solveset(sin(y + a) - sin(y), a, domain=S.Reals) == \
         imageset(Lambda(n, 2*n*pi), S.Integers)
 
+    # Tests for _solve_trig2() function
+    assert solveset_real(2*cos(x)*cos(2*x) - 1, x) == \
+          Union(ImageSet(Lambda(n, 2*n*pi + 2*atan(sqrt(-2*2**(S(1)/3)*(67 +
+                  9*sqrt(57))**(S(2)/3) + 8*2**(S(2)/3) + 11*(67 +
+                  9*sqrt(57))**(S(1)/3))/(3*(67 + 9*sqrt(57))**(S(1)/6)))), S.Integers),
+                  ImageSet(Lambda(n, 2*n*pi - 2*atan(sqrt(-2*2**(S(1)/3)*(67 +
+                  9*sqrt(57))**(S(2)/3) + 8*2**(S(2)/3) + 11*(67 +
+                  9*sqrt(57))**(S(1)/3))/(3*(67 + 9*sqrt(57))**(S(1)/6))) +
+                  2*pi), S.Integers))
+
+    assert solveset_real(2*tan(x)*sin(x) + 1, x) == \
+        Union(ImageSet(Lambda(n, 2*n*pi + 2*atan(sqrt(4
+                + sqrt(17)))), S.Integers), ImageSet(Lambda(n, 2*n*pi
+                - 2*atan(sqrt(4 + sqrt(17))) + 2*pi), S.Integers))
+
+    assert solveset_real(cos(2*x)*cos(4*x) - 1, x) == \
+                            ImageSet(Lambda(n, n*pi), S.Integers)
+
 
 @XFAIL
 def test_solve_trig_abs():


### PR DESCRIPTION
### Fixes #13899

Previously all trigonometric equations were solved by changing all trigino functions in their respective Euler form. This many times leads to the introduction of two variables leading to formation of multivariate polynomials leading to a `PolyError`.
So,  i added `_solve_trig2()` helper function (as explained by @normalhuman in the issue) which gets called everytime the primary helper function (`_solve_trig1()`) cant solve the equation. 
It first coverts coefficients of all `angle` into integer and then write all trigonometric functions in form of `tan` using half-angle substitution. After that `tan` is substituted with a 'Dummy' variable, thus transforming it into a polynomial which is at the end solved to get the solution.

Some examples which give an error in current master :
`>>> x=Symbol('x')`
`>>> solveset(2*tan(x)*sin(x) + 1, x)`

`>>> x=Symbol('x')`
`>>> solveset(2*cos(x)*cos(2*x) - 1, x)`

