### PR TITLE
Fix for printing of physics vectors

### DIFF
--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -3,6 +3,7 @@ from sympy.core.backend import (S, sympify, expand, sqrt, Add, zeros,
 from sympy import trigsimp
 from sympy.core.compatibility import unicode
 from sympy.utilities.misc import filldedent
+from sympy.printing.pretty.pretty import prettyForm
 
 __all__ = ['Vector']
 
@@ -279,6 +280,8 @@ class Vector(object):
                             if isinstance(ar[i][0][j], Add):
                                 pform = vp._print(
                                     ar[i][0][j]).parens()
+                                # Necessary becaus parens() returns a string.
+                                pform = prettyForm(*pform)
                             else:
                                 pform = vp._print(
                                     ar[i][0][j])


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #13354

#### Brief description of what is fixed or changed
Printing of physics vectors raised errors when the coefficient in front of one of the basis vectors
was _composite_, i.e. of the form (a+b).
This was caused by the parentheses: we have to call the .parens() method to group the terms,
but this method returns a string, instead of a prettyForm object.
Solved by re-building a prettyForm object from the string.


#### Other comments
