### PR TITLE
Remove incorrectly placed apostrophes from docs

### DIFF
--- a/doc/src/modules/assumptions/index.rst
+++ b/doc/src/modules/assumptions/index.rst
@@ -54,7 +54,7 @@ Design
 ======
 
 Each time ask is called, the appropriate Handler for the current key is called. This is
-always a subclass of sympy.assumptions.AskHandler. It's classmethods have the name's of the classes
+always a subclass of sympy.assumptions.AskHandler. Its classmethods have the names of the classes
 it supports. For example, a (simplified) AskHandler for the ask 'positive' would
 look like this::
 


### PR DESCRIPTION
Trivial, but annoying, typos: apostrophe misuse