### PR TITLE
Streamline the logic of real_root

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -7,10 +7,11 @@ from sympy.core.operations import LatticeOp, ShortCircuit
 from sympy.core.function import (Application, Lambda,
     ArgumentIndexError)
 from sympy.core.expr import Expr
+from sympy.core.mod import Mod
 from sympy.core.mul import Mul
 from sympy.core.numbers import Rational
 from sympy.core.power import Pow
-from sympy.core.relational import Equality, Relational
+from sympy.core.relational import Eq, Relational
 from sympy.core.singleton import Singleton
 from sympy.core.symbol import Dummy
 from sympy.core.rules import Transform
@@ -180,7 +181,7 @@ def cbrt(arg):
 
 def root(arg, n, k=0):
     """root(x, n, k) -> Returns the k-th n-th root of x, defaulting to the
-    principle root (k=0).
+    principal root (k=0).
 
 
     Examples
@@ -230,7 +231,7 @@ def root(arg, n, k=0):
     >>> root(-8, 3)
     2*(-1)**(1/3)
 
-    The real_root function can be used to either make the principle
+    The real_root function can be used to either make the principal
     result real (or simply to return the real root directly):
 
     >>> from sympy import real_root
@@ -271,7 +272,7 @@ def root(arg, n, k=0):
 def real_root(arg, n=None):
     """Return the real nth-root of arg if possible. If n is omitted then
     all instances of (-n)**(1/odd) will be changed to -n**(1/odd); this
-    will only create a real root of a principle root -- the presence of
+    will only create a real root of a principal root -- the presence of
     other factors may cause the result to not be real.
 
     Examples
@@ -287,7 +288,7 @@ def real_root(arg, n=None):
     >>> real_root(_)
     -2
 
-    If one creates a non-principle root and applies real_root, the
+    If one creates a non-principal root and applies real_root, the
     result will not be real (so use with caution):
 
     >>> root(-8, 3, 2)
@@ -303,24 +304,14 @@ def real_root(arg, n=None):
     sympy.core.power.integer_nthroot
     root, sqrt
     """
-    from sympy import im, Piecewise
+    from sympy.functions.elementary.complexes import Abs, im, sign
+    from sympy.functions.elementary.piecewise import Piecewise
     if n is not None:
-        try:
-            n = as_int(n)
-            arg = sympify(arg)
-            if arg.is_positive or arg.is_negative:
-                rv = root(arg, n)
-            else:
-                raise ValueError
-        except ValueError:
-            return root(arg, n)*Piecewise(
-                (S.One, ~Equality(im(arg), 0)),
-                (Pow(S.NegativeOne, S.One/n)**(2*floor(n/2)), And(
-                    Equality(n % 2, 1),
-                    arg < 0)),
-                (S.One, True))
-    else:
-        rv = sympify(arg)
+        return Piecewise(
+            (sign(arg)*root(Abs(arg), n), And(Eq(im(arg), S.Zero),
+                Eq(Mod(n, 2), S.One))),
+            (root(arg, n), True))
+    rv = sympify(arg)
     n1pow = Transform(lambda x: -(-x.base)**x.exp,
                       lambda x:
                       x.is_Pow and

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -18,7 +18,7 @@ from sympy.core.rules import Transform
 from sympy.core.compatibility import as_int, with_metaclass, range
 from sympy.core.logic import fuzzy_and, fuzzy_or, _torf
 from sympy.functions.elementary.integers import floor
-from sympy.logic.boolalg import And
+from sympy.logic.boolalg import And, Or
 
 def _minmax_as_Piecewise(op, *args):
     # helper for Min/Max rewrite as Piecewise
@@ -308,6 +308,7 @@ def real_root(arg, n=None):
     from sympy.functions.elementary.piecewise import Piecewise
     if n is not None:
         return Piecewise(
+            (root(arg, n), Or(Eq(n, S.One), Eq(n, S.NegativeOne))),
             (sign(arg)*root(Abs(arg), n), And(Eq(im(arg), S.Zero),
                 Eq(Mod(n, 2), S.One))),
             (root(arg, n), True))

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -11,8 +11,7 @@ from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.delta_functions import Heaviside
 
-from sympy.utilities.pytest import raises
-
+from sympy.utilities.pytest import raises, skip
 
 def test_Min():
     from sympy.abc import x, y, z

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -1,4 +1,5 @@
 import itertools as it
+import warnings
 
 from sympy.core.function import Function
 from sympy.core.numbers import I, oo, Rational
@@ -11,7 +12,9 @@ from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.delta_functions import Heaviside
 
+from sympy.utilities.lambdify import lambdify
 from sympy.utilities.pytest import raises, skip
+from sympy.external import import_module
 
 def test_Min():
     from sympy.abc import x, y, z
@@ -336,12 +339,9 @@ def test_real_root():
 
 
 def test_issue_11463():
-    from sympy.external import import_module
     numpy = import_module('numpy')
     if not numpy:
         skip("numpy not installed.")
-    from sympy.utilities.lambdify import lambdify
-    import warnings
     x = Symbol('x')
     f = lambdify(x, real_root((log(x/(x-2))), 3), 'numpy')
     # numpy.select evaluates all options before considering conditions,

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -7,6 +7,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.elementary.miscellaneous import (sqrt, cbrt, root, Min,
                                                       Max, real_root)
 from sympy.functions.elementary.trigonometric import cos, sin
+from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.delta_functions import Heaviside
 
@@ -333,6 +334,23 @@ def test_real_root():
     assert g.subs(dict(x=I, n=3)) == cbrt(I)
     assert g.subs(dict(x=-8, n=2)) == sqrt(-8)
     assert g.subs(dict(x=I, n=2)) == sqrt(I)
+
+
+def test_issue_11463():
+    from sympy.external import import_module
+    numpy = import_module('numpy')
+    if not numpy:
+        skip("numpy not installed.")
+    from sympy.utilities.lambdify import lambdify
+    import warnings
+    x = Symbol('x')
+    f = lambdify(x, real_root((log(x/(x-2))), 3), 'numpy')
+    # numpy.select evaluates all options before considering conditions,
+    # so it raises a warning about root of negative number which does
+    # not affect the outcome. This warning is suppressed here
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert f(numpy.array(-1)) < -1
 
 
 def test_rewrite_MaxMin_as_Heaviside():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -5,7 +5,7 @@ from sympy.core.relational import (Eq, Gt,
     Ne)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
-from sympy.functions.elementary.complexes import (Abs, arg, im, re)
+from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import (LambertW, exp, log)
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction,
     atanh, sinh, tanh)
@@ -1535,8 +1535,8 @@ def test_issue_9557():
 def test_issue_9778():
     assert solveset(x**3 + 1, x, S.Reals) == FiniteSet(-1)
     assert solveset(x**(S(3)/5) + 1, x, S.Reals) == S.EmptySet
-    assert solveset(x**3 + y, x, S.Reals) == Intersection(Interval(-oo, oo), \
-        FiniteSet((-y)**(S(1)/3)*Piecewise((1, Ne(-im(y), 0)), ((-1)**(S(2)/3), -y < 0), (1, True))))
+    assert solveset(x**3 + y, x, S.Reals) == \
+        FiniteSet(-Abs(y)**(S(1)/3)*sign(y))
 
 
 @XFAIL


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #11463 

#### Brief description of what is fixed or changed

Simplified the logic of returning a real root when possible. Presently, when the sign of argument is unknown, this function falls back on computing the principal root and then multiplying it by some complex factor to make the result real. This does not work well with NumPy in lambdify. Now the logic is: if x is real and n is odd, return `sign(x) * root(Abs(x), n)`. Otherwise return `root(x, n)` even though it may not be real (also current behavior).

#### Test change

One solveset test had to be changed, from
```
assert solveset(x**3 + y, x, S.Reals) == Intersection(Interval(-oo, oo), \
    FiniteSet((-y)**(S(1)/3)*Piecewise((1, Ne(-im(y), 0)), ((-1)**(S(2)/3), -y < 0), (1, True))))
```
to
```
assert solveset(x**3 + y, x, S.Reals) == \
    FiniteSet(-Abs(y)**(S(1)/3)*sign(y))
````

I consider this an improvement: y is known to be real in this test, which with the new formula returns a simple, demonstrably real, value of the real_root.