### PR TITLE
Added abbreviated printing for units

### DIFF
--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -784,7 +784,8 @@ def sstr(expr, **settings):
     """Returns the expression as a string.
 
     For large expressions where speed is a concern, use the setting
-    order='none'.
+    order='none'. If abbrev=True setting is used then units are printed in
+    abbreviated form.
 
     Examples
     ========

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -21,6 +21,7 @@ class StrPrinter(Printer):
         "order": None,
         "full_prec": "auto",
         "sympy_integers": False,
+        "abbrev": False,
     }
 
     _relationals = dict()
@@ -706,6 +707,8 @@ class StrPrinter(Printer):
         return r' \ '.join(self._print(set) for set in expr.args)
 
     def _print_Quantity(self, expr):
+        if self._settings.get("abbrev", True):
+            return "%s" % expr.abbrev
         return "%s" % expr.name
 
     def _print_Quaternion(self, expr):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -707,7 +707,7 @@ class StrPrinter(Printer):
         return r' \ '.join(self._print(set) for set in expr.args)
 
     def _print_Quantity(self, expr):
-        if self._settings.get("abbrev", True):
+        if self._settings.get("abbrev", False):
             return "%s" % expr.abbrev
         return "%s" % expr.name
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -593,6 +593,8 @@ def test_Quaternion_str_printer():
 
 
 def test_Quantity_str():
+    assert sstr(second, abbrev=True) == "s"
+    assert sstr(joule, abbrev=True) == "J"
     assert str(second) == "second"
     assert str(joule) == "joule"
 


### PR DESCRIPTION
Added `abbrev` parameter which prints units in abbreviated form.
fixes #13269
closes #13310
