### PR TITLE
Polylogarithm is unbranched over the unit disk

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log,
                    zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I,
-                   exp_polar, polar_lift, O, stieltjes, Abs)
+                   exp_polar, polar_lift, O, stieltjes, Abs, Sum)
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically as tn)
 
@@ -127,12 +127,20 @@ def test_polylog_expansion():
     assert polylog(s, 0) == 0
     assert polylog(s, 1) == zeta(s)
     assert polylog(s, -1) == -dirichlet_eta(s)
+    assert polylog(s, exp_polar(4*I*pi/3)) == polylog(s, exp(4*I*pi/3))
+    assert polylog(s, exp_polar(I*pi)/3) == polylog(s, exp(I*pi)/3)
 
     assert myexpand(polylog(1, z), -log(1 - z))
     assert myexpand(polylog(0, z), z/(1 - z))
     assert myexpand(polylog(-1, z), z/(1 - z)**2)
     assert ((1-z)**3 * expand_func(polylog(-2, z))).simplify() == z*(1 + z)
     assert myexpand(polylog(-5, z), None)
+
+
+def test_issue_8404():
+    i = Symbol('i', integer=True)
+    assert Abs(Sum(1/(3*i + 1)**2, (i, 0, S.Infinity)).doit().n(4)
+        - 1.122) < 0.001
 
 
 def test_polylog_values():

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -271,6 +271,7 @@ class polylog(Function):
 
     @classmethod
     def eval(cls, s, z):
+        s, z = sympify((s, z))
         if z == 1:
             return zeta(s)
         elif z == -1:
@@ -297,6 +298,11 @@ class polylog(Function):
             return z/(1 - z)
         elif s == -1:
             return z/(1 - z)**2
+        # polylog is branched, but not over the unit disk
+        if z.is_polar:
+            from sympy.functions.elementary.complexes import Abs, unpolarify
+            if (Abs(z) <= S.One) == True:
+                return cls(s, unpolarify(z))
 
     def fdiff(self, argindex=1):
         s, z = self.args

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -286,6 +286,10 @@ def test_transcendental_functions():
         -x + x*LambertW(2*x) + x/LambertW(2*x)
 
 
+def test_log_polylog():
+    assert integrate(log(1 - x)/x, (x, 0, 1)) == -pi**2/6
+
+
 def test_issue_3740():
     f = 4*log(x) - 2*log(x)**2
     fid = diff(integrate(f, x), x)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #8404

#### Brief description of what is fixed or changed

Integration and summation sometimes produce polylogarithm of a polar number. When this polar number lies over the unit disk, for example `exp_polar(2*pi*I)` or `exp_polar(I*pi)/3`, it can be unpolarified because going around the origin within the unit disk does not change the value of polylog (it is given by a convergent power series in that disk).

#### Example 

`integrate(log(1 - x)/x, (x, 0, 1))` now returns `-pi**2/6` instead of `-polylog(2, exp_polar(2*I*pi))`.



