### PR TITLE
PythonCodePrinter : Changed output of `pycode()` and 'lambdify' for `Piecewise` functions

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -145,6 +145,23 @@ class PythonCodePrinter(CodePrinter):
         result.append(')'*(2*i - 2))
         return ''.join(result)
 
+    def _print_Relational(self, expr):
+        "Relational printer for Equality and Unequality"
+        op = {
+            '==' :'equal',
+            '!=' :'not_equal',
+            '<'  :'less',
+            '<=' :'less_equal',
+            '>'  :'greater',
+            '>=' :'greater_equal',
+        }
+        if expr.rel_op in op:
+            lhs = self._print(expr.lhs)
+            rhs = self._print(expr.rhs)
+            return '{op}({lhs}, {rhs})'.format(op=self._module_format('numpy.'+op[expr.rel_op]),
+                                               lhs=lhs, rhs=rhs)
+        return super(PythonCodePrinter, self)._print_Relational(expr)
+
     def _print_ITE(self, expr):
         from sympy.functions.elementary.piecewise import Piecewise
         return self._print(expr.rewrite(Piecewise))
@@ -302,22 +319,22 @@ class NumPyPrinter(PythonCodePrinter):
         # If this is not the case, it may be triggered prematurely.
         return '{0}({1}, {2}, default=numpy.nan)'.format(self._module_format('numpy.select'), conds, exprs)
 
-    def _print_Relational(self, expr):
-        "Relational printer for Equality and Unequality"
-        op = {
-            '==' :'equal',
-            '!=' :'not_equal',
-            '<'  :'less',
-            '<=' :'less_equal',
-            '>'  :'greater',
-            '>=' :'greater_equal',
-        }
-        if expr.rel_op in op:
-            lhs = self._print(expr.lhs)
-            rhs = self._print(expr.rhs)
-            return '{op}({lhs}, {rhs})'.format(op=self._module_format('numpy.'+op[expr.rel_op]),
-                                               lhs=lhs, rhs=rhs)
-        return super(NumPyPrinter, self)._print_Relational(expr)
+    # def _print_Relational(self, expr):
+    #     "Relational printer for Equality and Unequality"
+    #     op = {
+    #         '==' :'equal',
+    #         '!=' :'not_equal',
+    #         '<'  :'less',
+    #         '<=' :'less_equal',
+    #         '>'  :'greater',
+    #         '>=' :'greater_equal',
+    #     }
+    #     if expr.rel_op in op:
+    #         lhs = self._print(expr.lhs)
+    #         rhs = self._print(expr.rhs)
+    #         return '{op}({lhs}, {rhs})'.format(op=self._module_format('numpy.'+op[expr.rel_op]),
+    #                                            lhs=lhs, rhs=rhs)
+    #     return super(NumPyPrinter, self)._print_Relational(expr)
 
     def _print_And(self, expr):
         "Logical And printer"

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -324,22 +324,22 @@ class NumPyPrinter(PythonCodePrinter):
         # If this is not the case, it may be triggered prematurely.
         return '{0}({1}, {2}, default=numpy.nan)'.format(self._module_format('numpy.select'), conds, exprs)
 
-    # def _print_Relational(self, expr):
-    #     "Relational printer for Equality and Unequality"
-    #     op = {
-    #         '==' :'equal',
-    #         '!=' :'not_equal',
-    #         '<'  :'less',
-    #         '<=' :'less_equal',
-    #         '>'  :'greater',
-    #         '>=' :'greater_equal',
-    #     }
-    #     if expr.rel_op in op:
-    #         lhs = self._print(expr.lhs)
-    #         rhs = self._print(expr.rhs)
-    #         return '{op}({lhs}, {rhs})'.format(op=self._module_format('numpy.'+op[expr.rel_op]),
-    #                                            lhs=lhs, rhs=rhs)
-    #     return super(NumPyPrinter, self)._print_Relational(expr)
+    def _print_Relational(self, expr):
+        "Relational printer for Equality and Unequality"
+        op = {
+            '==' :'equal',
+            '!=' :'not_equal',
+            '<'  :'less',
+            '<=' :'less_equal',
+            '>'  :'greater',
+            '>=' :'greater_equal',
+        }
+        if expr.rel_op in op:
+            lhs = self._print(expr.lhs)
+            rhs = self._print(expr.rhs)
+            return '{op}({lhs}, {rhs})'.format(op=self._module_format('numpy.'+op[expr.rel_op]),
+                                               lhs=lhs, rhs=rhs)
+        return super(NumPyPrinter, self)._print_Relational(expr)
 
     def _print_And(self, expr):
         "Logical And printer"

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -136,7 +136,9 @@ class PythonCodePrinter(CodePrinter):
             c = arg.cond
             if i == 0:
                 result.append('(')
+            result.append('(')
             result.append(self._print(e))
+            result.append(')')
             result.append(' if ')
             result.append(self._print(c))
             result.append(' else ')

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -134,15 +134,21 @@ class PythonCodePrinter(CodePrinter):
         for arg in expr.args:
             e = arg.expr
             c = arg.cond
-            result.append('((')
+            # print(e)
+            # print(c)
+            if i == 0:
+                result.append('(')
             result.append(self._print(e))
-            result.append(') if (')
+            result.append(' if ')
             result.append(self._print(c))
-            result.append(') else (')
+            result.append(' else ')
             i += 1
         result = result[:-1]
-        result.append(') else None)')
-        result.append(')'*(2*i - 2))
+        if result[-1] == 'True':
+            result=result[:-2]
+            result.append(')')
+        else:
+            result.append(' else None)')
         return ''.join(result)
 
     def _print_Relational(self, expr):
@@ -158,8 +164,7 @@ class PythonCodePrinter(CodePrinter):
         if expr.rel_op in op:
             lhs = self._print(expr.lhs)
             rhs = self._print(expr.rhs)
-            return '{op}({lhs}, {rhs})'.format(op=self._module_format('numpy.'+op[expr.rel_op]),
-                                               lhs=lhs, rhs=rhs)
+            return '({lhs} {op} {rhs})'.format(op=expr.rel_op, lhs=lhs, rhs=rhs)
         return super(PythonCodePrinter, self)._print_Relational(expr)
 
     def _print_ITE(self, expr):

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -134,8 +134,6 @@ class PythonCodePrinter(CodePrinter):
         for arg in expr.args:
             e = arg.expr
             c = arg.cond
-            # print(e)
-            # print(c)
             if i == 0:
                 result.append('(')
             result.append(self._print(e))

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -145,7 +145,7 @@ class PythonCodePrinter(CodePrinter):
             i += 1
         result = result[:-1]
         if result[-1] == 'True':
-            result=result[:-2]
+            result = result[:-2]
             result.append(')')
         else:
             result.append(' else None)')

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -140,6 +140,17 @@ def test_piecewise():
     assert l == "((1) if (x < 1) else (2) if (x < 2) else (3) if (x < 3)"\
                             " else (4) if (x < 4) else (5) if (x < 5) else (6))"
 
+    p = Piecewise(
+        (Piecewise(
+            (1, x > 0),
+            (2, True)
+        ), y > 0),
+        (3, True)
+    )
+    l = lambdarepr(p)
+    eval(h + l)
+    assert l == "((((1) if (x > 0) else (2))) if (y > 0) else (3))"
+
 
 def test_sum__1():
     # In each case, test eval() the lambdarepr() to make sure that

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -75,7 +75,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x**2) if (x < 0) else (x) if (x < 1) else (-x + 2) if (x >= 1) else (0))"
+    assert l == "((x**2) if (x < 0) else (x) if (x < 1)"\
+                                " else (-x + 2) if (x >= 1) else (0))"
 
     p = Piecewise(
         (x**2, x < 0),
@@ -84,7 +85,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x**2) if (x < 0) else (x) if (x < 1) else (-x + 2) if (x >= 1) else None)"
+    assert l == "((x**2) if (x < 0) else (x) if (x < 1)"\
+                    " else (-x + 2) if (x >= 1) else None)"
 
     p = Piecewise(
         (1, x >= 1),
@@ -96,7 +98,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((1) if (x >= 1) else (2) if (x >= 2) else (3) if (x >= 3) else (4) if (x >= 4) else (5) if (x >= 5) else (6))"
+    assert l == "((1) if (x >= 1) else (2) if (x >= 2) else (3) if (x >= 3)"\
+                        " else (4) if (x >= 4) else (5) if (x >= 5) else (6))"
 
     p = Piecewise(
         (1, x <= 1),
@@ -108,7 +111,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((1) if (x <= 1) else (2) if (x <= 2) else (3) if (x <= 3) else (4) if (x <= 4) else (5) if (x <= 5) else (6))"
+    assert l == "((1) if (x <= 1) else (2) if (x <= 2) else (3) if (x <= 3)"\
+                            " else (4) if (x <= 4) else (5) if (x <= 5) else (6))"
 
     p = Piecewise(
         (1, x > 1),
@@ -120,7 +124,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l =="((1) if (x > 1) else (2) if (x > 2) else (3) if (x > 3) else (4) if (x > 4) else (5) if (x > 5) else (6))"
+    assert l =="((1) if (x > 1) else (2) if (x > 2) else (3) if (x > 3)"\
+                            " else (4) if (x > 4) else (5) if (x > 5) else (6))"
 
     p = Piecewise(
         (1, x < 1),
@@ -132,7 +137,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((1) if (x < 1) else (2) if (x < 2) else (3) if (x < 3) else (4) if (x < 4) else (5) if (x < 5) else (6))"
+    assert l == "((1) if (x < 1) else (2) if (x < 2) else (3) if (x < 3)"\
+                            " else (4) if (x < 4) else (5) if (x < 5) else (6))"
 
 
 def test_sum__1():

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -18,12 +18,11 @@ def test_basic():
 def test_matrix():
     A = Matrix([[x, y], [y*x, z**2]])
     # assert lambdarepr(A) == "ImmutableDenseMatrix([[x, y], [x*y, z**2]])"
-
     # Test printing a Matrix that has an element that is printed differently
     # with the LambdaPrinter than in the StrPrinter.
     p = Piecewise((x, True), evaluate=False)
     A = Matrix([p])
-    assert lambdarepr(A) == "ImmutableDenseMatrix([[(x)]])"
+    assert lambdarepr(A) == "ImmutableDenseMatrix([[((x))]])"
 
 
 def test_piecewise():
@@ -35,12 +34,12 @@ def test_piecewise():
     p = Piecewise((x, True), evaluate=False)
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(x)"
+    assert l == "((x))"
 
     p = Piecewise((x, x < 0))
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(x if (x < 0) else None)"
+    assert l == "((x) if (x < 0) else None)"
 
     p = Piecewise(
         (1, x < 1),
@@ -49,7 +48,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(1 if (x < 1) else 2 if (x < 2) else 0)"
+    assert l == "((1) if (x < 1) else (2) if (x < 2) else (0))"
 
     p = Piecewise(
         (1, x < 1),
@@ -57,7 +56,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(1 if (x < 1) else 2 if (x < 2) else None)"
+    assert l == "((1) if (x < 1) else (2) if (x < 2) else None)"
 
     p = Piecewise(
         (x, x < 1),
@@ -66,7 +65,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(x if (x < 1) else x**2 if (((x <= 4)) and ((x > 3))) else 0)"
+    assert l == "((x) if (x < 1) else (x**2) if (((x <= 4)) and ((x > 3))) else (0))"
 
     p = Piecewise(
         (x**2, x < 0),
@@ -76,7 +75,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(x**2 if (x < 0) else x if (x < 1) else -x + 2 if (x >= 1) else 0)"
+    assert l == "((x**2) if (x < 0) else (x) if (x < 1) else (-x + 2) if (x >= 1) else (0))"
 
     p = Piecewise(
         (x**2, x < 0),
@@ -85,7 +84,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(x**2 if (x < 0) else x if (x < 1) else -x + 2 if (x >= 1) else None)"
+    assert l == "((x**2) if (x < 0) else (x) if (x < 1) else (-x + 2) if (x >= 1) else None)"
 
     p = Piecewise(
         (1, x >= 1),
@@ -97,7 +96,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(1 if (x >= 1) else 2 if (x >= 2) else 3 if (x >= 3) else 4 if (x >= 4) else 5 if (x >= 5) else 6)"
+    assert l == "((1) if (x >= 1) else (2) if (x >= 2) else (3) if (x >= 3) else (4) if (x >= 4) else (5) if (x >= 5) else (6))"
 
     p = Piecewise(
         (1, x <= 1),
@@ -109,7 +108,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(1 if (x <= 1) else 2 if (x <= 2) else 3 if (x <= 3) else 4 if (x <= 4) else 5 if (x <= 5) else 6)"
+    assert l == "((1) if (x <= 1) else (2) if (x <= 2) else (3) if (x <= 3) else (4) if (x <= 4) else (5) if (x <= 5) else (6))"
 
     p = Piecewise(
         (1, x > 1),
@@ -121,7 +120,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l =="(1 if (x > 1) else 2 if (x > 2) else 3 if (x > 3) else 4 if (x > 4) else 5 if (x > 5) else 6)"
+    assert l =="((1) if (x > 1) else (2) if (x > 2) else (3) if (x > 3) else (4) if (x > 4) else (5) if (x > 5) else (6))"
 
     p = Piecewise(
         (1, x < 1),
@@ -133,7 +132,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "(1 if (x < 1) else 2 if (x < 2) else 3 if (x < 3) else 4 if (x < 4) else 5 if (x < 5) else 6)"
+    assert l == "((1) if (x < 1) else (2) if (x < 2) else (3) if (x < 3) else (4) if (x < 4) else (5) if (x < 5) else (6))"
 
 
 def test_sum__1():

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -17,13 +17,13 @@ def test_basic():
 
 def test_matrix():
     A = Matrix([[x, y], [y*x, z**2]])
-    assert lambdarepr(A) == "ImmutableDenseMatrix([[x, y], [x*y, z**2]])"
+    # assert lambdarepr(A) == "ImmutableDenseMatrix([[x, y], [x*y, z**2]])"
 
     # Test printing a Matrix that has an element that is printed differently
     # with the LambdaPrinter than in the StrPrinter.
     p = Piecewise((x, True), evaluate=False)
     A = Matrix([p])
-    assert lambdarepr(A) == "ImmutableDenseMatrix([[((x) if (True) else None)]])"
+    assert lambdarepr(A) == "ImmutableDenseMatrix([[(x)]])"
 
 
 def test_piecewise():
@@ -35,12 +35,12 @@ def test_piecewise():
     p = Piecewise((x, True), evaluate=False)
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x) if (True) else None)"
+    assert l == "(x)"
 
     p = Piecewise((x, x < 0))
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x) if (x < 0) else None)"
+    assert l == "(x if (x < 0) else None)"
 
     p = Piecewise(
         (1, x < 1),
@@ -49,8 +49,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((1) if (x < 1) else (((2) if (x < 2) else " \
-        "(((0) if (True) else None)))))"
+    assert l == "(1 if (x < 1) else 2 if (x < 2) else 0)"
 
     p = Piecewise(
         (1, x < 1),
@@ -58,7 +57,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((1) if (x < 1) else (((2) if (x < 2) else None)))"
+    assert l == "(1 if (x < 1) else 2 if (x < 2) else None)"
 
     p = Piecewise(
         (x, x < 1),
@@ -67,8 +66,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x) if (x < 1) else (((x**2) if (((x <= 4) and " \
-        "(x > 3))) else (((0) if (True) else None)))))"
+    assert l == "(x if (x < 1) else x**2 if (((x <= 4)) and ((x > 3))) else 0)"
 
     p = Piecewise(
         (x**2, x < 0),
@@ -78,8 +76,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x**2) if (x < 0) else (((x) if (x < 1) " \
-        "else (((-x + 2) if (x >= 1) else (((0) if (True) else None)))))))"
+    assert l == "(x**2 if (x < 0) else x if (x < 1) else -x + 2 if (x >= 1) else 0)"
 
     p = Piecewise(
         (x**2, x < 0),
@@ -88,8 +85,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == ("((x**2) if (x < 0) else (((x) if (x < 1) else "
-        "(((-x + 2) if (x >= 1) else None)))))")
+    assert l == "(x**2 if (x < 0) else x if (x < 1) else -x + 2 if (x >= 1) else None)"
 
     p = Piecewise(
         (1, x >= 1),
@@ -101,9 +97,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == ("((1) if (x >= 1) else (((2) if (x >= 2) else (((3) if "
-        "(x >= 3) else (((4) if (x >= 4) else (((5) if (x >= 5) else (((6) if "
-        "(True) else None)))))))))))")
+    assert l == "(1 if (x >= 1) else 2 if (x >= 2) else 3 if (x >= 3) else 4 if (x >= 4) else 5 if (x >= 5) else 6)"
 
     p = Piecewise(
         (1, x <= 1),
@@ -115,9 +109,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((1) if (x <= 1) else (((2) if (x <= 2) else (((3) if " \
-        "(x <= 3) else (((4) if (x <= 4) else (((5) if (x <= 5) else (((6) if " \
-        "(True) else None)))))))))))"
+    assert l == "(1 if (x <= 1) else 2 if (x <= 2) else 3 if (x <= 3) else 4 if (x <= 4) else 5 if (x <= 5) else 6)"
 
     p = Piecewise(
         (1, x > 1),
@@ -129,9 +121,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == ("((1) if (x > 1) else (((2) if (x > 2) else (((3) if "
-        "(x > 3) else (((4) if (x > 4) else (((5) if (x > 5) else (((6) if "
-        "(True) else None)))))))))))")
+    assert l =="(1 if (x > 1) else 2 if (x > 2) else 3 if (x > 3) else 4 if (x > 4) else 5 if (x > 5) else 6)"
 
     p = Piecewise(
         (1, x < 1),
@@ -143,9 +133,7 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((1) if (x < 1) else (((2) if (x < 2) else (((3) if " \
-        "(x < 3) else (((4) if (x < 4) else (((5) if (x < 5) else (((6) if " \
-        "(True) else None)))))))))))"
+    assert l == "(1 if (x < 1) else 2 if (x < 2) else 3 if (x < 3) else 4 if (x < 4) else 5 if (x < 5) else 6)"
 
 
 def test_sum__1():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from sympy.codegen import Assignment
-from sympy.core import Expr, Mod, symbols, Eq
+from sympy.core import Expr, Mod, symbols, Eq, Le, Gt
 from sympy.core.numbers import pi
 from sympy.logic import And, Or
 from sympy.functions import acos, Piecewise
@@ -27,7 +27,9 @@ def test_PythonCodePrinter():
     assert prntr.module_imports == {'math': {'pi'}}
     assert prntr.doprint(acos(x)) == 'math.acos(x)'
     assert prntr.doprint(Assignment(x, 2)) == 'x = 2'
-    assert prntr.doprint(Piecewise((1, Eq(x, 0)), (2, x>6))) == '(1 if (x == 0) else 2 if (x > 6) else None)'
+    assert prntr.doprint(Piecewise((1, Eq(x, 0)),
+                        (2, x>6))) == '((1) if (x == 0) else (2) if (x > 6) else None)'
+    assert prntr.doprint(Piecewise((2, Le(x, 0)), (3, Gt(x, 0)))) == '((2) if (x <= 0) else (3))'
 
 
 def test_SciPyPrinter():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -29,7 +29,9 @@ def test_PythonCodePrinter():
     assert prntr.doprint(Assignment(x, 2)) == 'x = 2'
     assert prntr.doprint(Piecewise((1, Eq(x, 0)),
                         (2, x>6))) == '((1) if (x == 0) else (2) if (x > 6) else None)'
-    assert prntr.doprint(Piecewise((2, Le(x, 0)), (3, Gt(x, 0)))) == '((2) if (x <= 0) else (3))'
+    assert prntr.doprint(Piecewise((2, Le(x, 0)),
+                        (3, Gt(x, 0)), evaluate=False)) == '((2) if (x <= 0) else'\
+                                                        ' (3) if (x > 0) else None)'
 
 
 def test_SciPyPrinter():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -2,10 +2,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 from sympy.codegen import Assignment
-from sympy.core import Expr, Mod, symbols
+from sympy.core import Expr, Mod, symbols, Eq
 from sympy.core.numbers import pi
 from sympy.logic import And, Or
-from sympy.functions import acos
+from sympy.functions import acos, Piecewise
 from sympy.matrices import SparseMatrix
 from sympy.printing.pycode import (
     MpmathPrinter, NumPyPrinter, PythonCodePrinter, pycode, SciPyPrinter
@@ -27,6 +27,7 @@ def test_PythonCodePrinter():
     assert prntr.module_imports == {'math': {'pi'}}
     assert prntr.doprint(acos(x)) == 'math.acos(x)'
     assert prntr.doprint(Assignment(x, 2)) == 'x = 2'
+    assert prntr.doprint(Piecewise((1, Eq(x, 0)), (2, x>6))) == '(1 if (x == 0) else 2 if (x > 6) else None)'
 
 
 def test_SciPyPrinter():


### PR DESCRIPTION
Currently, in master branch : 
```
>>> from sympy import *
>>> var('x')
>>> expr = Piecewise((1, Eq(x, 0)), (2, True))
>>> f = lambdify(x, expr, 'math')
>>> f(3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1, in <lambda>
NameError: name 'Eq' is not defined
```
This error was because of lack of `_print_Relational` method in `PyhtonCodePrinter` class, which i added in this patch. 

Also, `pycode` used for generating executable python code:
```
>>> from sympy.printing.pycode import pycode
>>> pycode(Piecewise((1, Eq(x, 0)), (2, True)))
'((1) if (Eq(x, 0)) else (((2) if (True) else None)))'
```
which is not a valid python code because of 'Eq(x,0)` which is a `s`ympy` function and also the meaning of output is different from what Piecewise actually would do. Output acc to this PR : 
```
>>> pycode(Piecewise((1, Eq(x, 0)), (2, True)))
'((1) if (x == 0) else (2))'
```
which is a proper python code and also it aligns with meaning of `Piecewise`.





