### PR TITLE
Convert more Pow expressions to field elements

### DIFF
--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -353,6 +353,13 @@ def test_integrate_hyperexponential_returns_piecewise():
     # TODO: Add a test where two different parts of the extension use a
     # Piecewise, like y**x + z**x.
 
+def test_issue_13947():
+    a, t, s = symbols('a t s')
+    assert risch_integrate(2**(-pi)/(2**t + 1), t) == \
+        2**(-pi)*t - 2**(-pi)*log(2**t + 1)/log(2)
+    assert risch_integrate(a**(t - s)/(a**t + 1), t) == \
+        exp(-s*log(a))*log(a**t + 1)/log(a)
+
 def test_integrate_primitive():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
         'Tfuncs': [log]})

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -223,7 +223,7 @@ class FracField(DefaultPrinting):
                 # look for bg**eg whose integer power may be b**e
                 choices = tuple((gen, bg, eg) for gen, (bg, eg) in powers
                     if bg == b and Mod(e, eg) == 0)
-                if len(choices) > 0:
+                if choices:
                     gen, bg, eg = choices[0]
                     return mapping.get(gen)**(e/eg)
                 elif e.is_Integer:

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -206,7 +206,7 @@ class FracField(DefaultPrinting):
 
     def _rebuild_expr(self, expr, mapping):
         domain = self.domain
-        powers = tuple((gen, *gen.as_base_exp()) for gen in mapping.keys()
+        powers = tuple((gen, gen.as_base_exp()) for gen in mapping.keys()
             if gen.is_Pow or isinstance(gen, ExpBase))
 
         def _rebuild(expr):
@@ -221,7 +221,7 @@ class FracField(DefaultPrinting):
             elif expr.is_Pow or isinstance(expr, ExpBase):
                 b, e = expr.as_base_exp()
                 # look for bg**eg whose integer power may be b**e
-                choices = tuple((gen, bg, eg) for gen, bg, eg in powers
+                choices = tuple((gen, bg, eg) for gen, (bg, eg) in powers
                     if bg == b and Mod(e, eg) == 0)
                 if len(choices) > 0:
                     gen, bg, eg = choices[0]

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -1,6 +1,6 @@
 """Test sparse rational functions. """
 
-from sympy.polys.fields import field, sfield, FracField
+from sympy.polys.fields import field, sfield, FracField, FracElement
 from sympy.polys.rings import ring
 from sympy.polys.domains import ZZ, QQ
 from sympy.polys.orderings import lex
@@ -128,6 +128,12 @@ def test_FracElement_from_expr():
 
     raises(ValueError, lambda: F.from_expr(2**x))
     raises(ValueError, lambda: F.from_expr(7*x + sqrt(2)))
+
+    assert isinstance(ZZ[2**x].get_field().convert(2**(-x)),
+        FracElement)
+    assert isinstance(ZZ[x**2].get_field().convert(x**(-6)),
+        FracElement)
+
 
 def test_FracElement__lt_le_gt_ge__():
     F, x, y = field("x,y", ZZ)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13947

#### Brief description of what is fixed or changed

The `FracField._rebuild_expr` method did not try hard enough to express a given Pow in terms of field generators: it just expected the exponent to be integer, and the base be in the field. This missed, for example, that `Z(2**pi)` contains `2**(-pi)`. Now the Pow and ExpBase instances are treated more carefully, by comparing their bases to the bases of Pow or ExpBase among generators, and seeking an integer ratio of exponents.