### PR TITLE
Double dispatch on _eval_derivative through visitor pattern

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1581,6 +1581,21 @@ class Basic(with_metaclass(ManagedProperties)):
                     return rewritten
         return self.func(*args)
 
+    def _accept_eval_derivative(self, s):
+        # This method needs to be overridden by array-like objects
+        return s._visit_eval_derivative_scalar(self)
+
+    def _visit_eval_derivative_scalar(self, base):
+        # Base is a scalar
+        # Types are (base: scalar, self: scalar)
+        return base._eval_derivative(self)
+
+    def _visit_eval_derivative_array(self, base):
+        # Types are (base: array/matrix, self: scalar)
+        # Base is some kind of array/matrix,
+        # it should have `.applyfunc(lambda x: x.diff(self)` implemented:
+        return base._eval_derivative(self)
+
     def _eval_derivative_n_times(self, s, n):
         # This is the default evaluator for derivatives (as called by `diff`
         # and `Derivative`), it will attempt a loop to derive the expression
@@ -1588,8 +1603,17 @@ class Basic(with_metaclass(ManagedProperties)):
         # while leaving the derivative unevaluated if `n` is symbolic.  This
         # method should be overridden if the object has a closed form for its
         # symbolic n-th derivative.
-        from sympy import Derivative
-        return Derivative._apply_for_loop_n_times(self, s, n, lambda x, s: x._eval_derivative(s))
+        from sympy import Integer
+        if isinstance(n, (int, Integer)):
+            obj = self
+            for i in range(n):
+                obj2 = obj._accept_eval_derivative(s)
+                if obj == obj2:
+                    break
+                obj = obj2
+            return obj
+        else:
+            return None
 
     def rewrite(self, *args, **hints):
         """ Rewrite functions in terms of other functions.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1589,7 +1589,7 @@ class Basic(with_metaclass(ManagedProperties)):
         # method should be overridden if the object has a closed form for its
         # symbolic n-th derivative.
         from sympy import Derivative
-        return Derivative._helper_apply_n_times(self, s, n, lambda x, s: x._eval_derivative(s))
+        return Derivative._apply_for_loop_n_times(self, s, n, lambda x, s: x._eval_derivative(s))
 
     def rewrite(self, *args, **hints):
         """ Rewrite functions in terms of other functions.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3354,10 +3354,10 @@ class AtomicExpr(Atom, Expr):
 
     def _eval_derivative_n_times(self, s, n):
         from sympy import Piecewise, Eq
-        from sympy import NDimArray, Tuple, derive_by_array
+        from sympy import NDimArray, Tuple
         from sympy.matrices.common import MatrixCommon
         if isinstance(s, (NDimArray, MatrixCommon, Tuple, Iterable)):
-            return Derivative._apply_for_loop_n_times(self, s, n, derive_by_array)
+            return super(AtomicExpr, self)._eval_derivative_n_times(s, n)
         if self == s:
             return Piecewise((self, Eq(n, 0)), (1, Eq(n, 1)), (0, True))
         else:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -9,7 +9,7 @@ from .cache import cacheit
 from .compatibility import reduce, as_int, default_sort_key, range
 from mpmath.libmp import mpf_log, prec_to_dps
 
-from collections import defaultdict
+from collections import defaultdict, Iterable
 
 class Expr(Basic, EvalfMixin):
     """
@@ -3354,6 +3354,10 @@ class AtomicExpr(Atom, Expr):
 
     def _eval_derivative_n_times(self, s, n):
         from sympy import Piecewise, Eq
+        from sympy import NDimArray, Tuple, derive_by_array
+        from sympy.matrices.common import MatrixCommon
+        if isinstance(s, (NDimArray, MatrixCommon, Tuple, Iterable)):
+            return Derivative._apply_for_loop_n_times(self, s, n, derive_by_array)
         if self == s:
             return Piecewise((self, Eq(n, 0)), (1, Eq(n, 1)), (0, True))
         else:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1242,6 +1242,8 @@ class Derivative(Expr):
 
             if unhandled_non_symbol:
                 obj = None
+            elif (count < 0) == True:
+                obj = None
             else:
                 if isinstance(v, (collections.Iterable, Tuple, MatrixCommon, NDimArray)):
                     # Treat derivatives by arrays/matrices as much as symbols.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1294,24 +1294,8 @@ class Derivative(Expr):
         return expr
 
     @staticmethod
-    def _helper_apply_n_times(expr, s, n, func):
-        from sympy import Integer, Tuple, NDimArray
-        from sympy.matrices.common import MatrixCommon
-
-        # This `if` could be avoided with double dispatch, combinations of type
-        # requiring `derive_by_array`:
-        # 1. (array, array) ==> this is managed by the following `if`.
-        # 2. (array, scalar)
-        # 3. (scalar, array) ==> this is managed by the following `if`.
-        # 4. (scalar, scalar)
-        #
-        # Case 1. is handled by `_eval_derivative` of `NDimArray`.
-        # Case 4., i.e. pair (x=scalar, y=scalar) should be passed to
-        # x._eval_derivative(y).
-        if isinstance(s, (collections.Iterable, Tuple, MatrixCommon, NDimArray)):
-            from sympy import derive_by_array
-            func = derive_by_array
-
+    def _apply_for_loop_n_times(expr, s, n, func):
+        from sympy import Integer
         if isinstance(n, (int, Integer)):
             obj = expr
             for i in range(n):
@@ -1326,7 +1310,6 @@ class Derivative(Expr):
                 dict_var_count[s] += n
             else:
                 dict_var_count[s] = n
-            from sympy import Derivative
             return Derivative(expr.expr, *dict_var_count.items())
         else:
             return None

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1293,27 +1293,6 @@ class Derivative(Expr):
             expr = factor_terms(signsimp(expr))
         return expr
 
-    @staticmethod
-    def _apply_for_loop_n_times(expr, s, n, func):
-        from sympy import Integer
-        if isinstance(n, (int, Integer)):
-            obj = expr
-            for i in range(n):
-                obj2 = func(obj, s)
-                if obj == obj2:
-                    break
-                obj = obj2
-            return obj
-        elif expr.is_Derivative:
-            dict_var_count = dict(expr.variable_count)
-            if s in dict_var_count:
-                dict_var_count[s] += n
-            else:
-                dict_var_count[s] = n
-            return Derivative(expr.expr, *dict_var_count.items())
-        else:
-            return None
-
     @classmethod
     def _remove_derived_once(cls, v):
         return [i[0] if i[1] == 1 else i for i in v]
@@ -1406,6 +1385,19 @@ class Derivative(Expr):
 
     def _eval_is_commutative(self):
         return self.expr.is_commutative
+
+    def _eval_derivative_n_times(self, s, n):
+        from sympy import Integer
+        if isinstance(n, (int, Integer)):
+            # TODO: it would be desirable to squash `_eval_derivative` into
+            # this code.
+            return super(Derivative, self)._eval_derivative_n_times(s, n)
+        dict_var_count = dict(self.variable_count)
+        if s in dict_var_count:
+            dict_var_count[s] += n
+        else:
+            dict_var_count[s] = n
+        return Derivative(self.expr, *dict_var_count.items())
 
     def _eval_derivative(self, v):
         # If the variable s we are diff wrt is not in self.variables, we

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -894,14 +894,16 @@ class Mul(Expr, AssocOp):
         for i in range(len(args)):
             d = args[i].diff(s)
             if d:
-                terms.append(self.func(*(args[:i] + [d] + args[i + 1:])))
-        return Add(*terms)
+                # Note: reduce is used in step of Mul as Mul is unable to
+                # handle subtypes and operation priority:
+                terms.append(reduce(lambda x, y: x*y, (args[:i] + [d] + args[i + 1:]), S.One))
+        return reduce(lambda x, y: x+y, terms, S.Zero)
 
     @cacheit
     def _eval_derivative_n_times(self, s, n):
         # https://en.wikipedia.org/wiki/General_Leibniz_rule#More_than_two_factors
         from sympy import Integer, factorial, prod, Dummy, symbols, Sum
-        args = [arg for arg in self.args if arg.has(s)]
+        args = [arg for arg in self.args if arg.free_symbols & s.free_symbols]
         coeff_args = [arg for arg in self.args if arg not in args]
         m = len(args)
         if m == 1:

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -868,10 +868,11 @@ def test_issue_13843():
 
     assert Derivative(f(x), (x, n)).doit() == Derivative(f(x), (x, n))
 
+
 def test_issue_13873():
     from sympy.abc import x
-    raises(ValueError, lambda: Derivative(sin(x), (x,-1)))
-    raises(ValueError, lambda: Derivative(sin(x), (x, sqrt(-1))))
+    assert sin(x).diff((x, -1)).is_Derivative
+
 
 def test_order_could_be_zero():
     x, y = symbols('x, y')

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -868,6 +868,11 @@ def test_issue_13843():
 
     assert Derivative(f(x), (x, n)).doit() == Derivative(f(x), (x, n))
 
+def test_issue_13873():
+    from sympy.abc import x
+    raises(ValueError, lambda: Derivative(sin(x), (x,-1)))
+    raises(ValueError, lambda: Derivative(sin(x), (x, sqrt(-1))))
+
 def test_order_could_be_zero():
     x, y = symbols('x, y')
     n = symbols('n', integer=True, nonnegative=True)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1571,8 +1571,7 @@ class MatrixCalculus(MatrixCommon):
 
     def _visit_eval_derivative_scalar(self, base):
         # Types are (base: scalar, self: matrix)
-        from sympy import derive_by_array
-        return derive_by_array(base, self)
+        return self.applyfunc(lambda x: base.diff(x))
 
     def _visit_eval_derivative_array(self, base):
         # Types are (base: array/matrix, self: matrix)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1566,6 +1566,19 @@ class MatrixCalculus(MatrixCommon):
     def _eval_derivative(self, arg):
         return self.applyfunc(lambda x: x.diff(arg))
 
+    def _accept_eval_derivative(self, s):
+        return s._visit_eval_derivative_array(self)
+
+    def _visit_eval_derivative_scalar(self, base):
+        # Types are (base: scalar, self: matrix)
+        from sympy import derive_by_array
+        return derive_by_array(base, self)
+
+    def _visit_eval_derivative_array(self, base):
+        # Types are (base: array/matrix, self: matrix)
+        from sympy import derive_by_array
+        return derive_by_array(base, self)
+
     def integrate(self, *args):
         """Integrate each element of the matrix.  ``args`` will
         be passed to the ``integrate`` function.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1990,6 +1990,14 @@ def test_diff():
     fxyz.diff(z).diff(y).diff(x) == fxyz.diff(((x, y, z),), 3)[2, 1, 0]
     fxyz.diff([[x, y, z]], ((z, y, x),)) == Array([[fxyz.diff(i).diff(j) for i in (x, y, z)] for j in (z, y, x)])
 
+    # Test scalar derived by matrix remains matrix:
+    res = x.diff(Matrix([[x, y]]))
+    assert isinstance(res, ImmutableDenseMatrix)
+    assert res == Matrix([[1, 0]])
+    res = (x**3).diff(Matrix([[x, y]]))
+    assert isinstance(res, ImmutableDenseMatrix)
+    assert res == Matrix([[3*x**2, 0]])
+
 
 def test_getattr():
     A = Matrix(((1, 4, x), (y, 2, 4), (10, 5, x**2 + 1)))

--- a/sympy/tensor/array/dense_ndim_array.py
+++ b/sympy/tensor/array/dense_ndim_array.py
@@ -199,3 +199,7 @@ class MutableDenseNDimArray(DenseNDimArray, MutableNDimArray):
 
     def as_immutable(self):
         return ImmutableDenseNDimArray(self)
+
+    @property
+    def free_symbols(self):
+        return {i for j in self._array for i in j.free_symbols}

--- a/sympy/tensor/array/mutable_ndim_array.py
+++ b/sympy/tensor/array/mutable_ndim_array.py
@@ -8,3 +8,6 @@ class MutableNDimArray(NDimArray):
 
     def as_mutable(self):
         return self
+
+    def _sympy_(self):
+        return self.as_immutable()

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -226,6 +226,18 @@ class NDimArray(object):
         from sympy import Derivative
         return Derivative(self.as_immutable(), *args, evaluate=True)
 
+    def _accept_eval_derivative(self, s):
+        return s._visit_eval_derivative_array(self)
+
+    def _visit_eval_derivative_scalar(self, base):
+        # Types are (base: scalar, self: array)
+        return self.applyfunc(lambda x: base.diff(x))
+
+    def _visit_eval_derivative_array(self, base):
+        # Types are (base: array/matrix, self: array)
+        from sympy import derive_by_array
+        return derive_by_array(base, self)
+
     def _eval_derivative_n_times(self, s, n):
         return Basic._eval_derivative_n_times(self, s, n)
 

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -226,6 +226,9 @@ class NDimArray(object):
         from sympy import Derivative
         return Derivative(self.as_immutable(), *args, evaluate=True)
 
+    def _eval_derivative_n_times(self, s, n):
+        return Basic._eval_derivative_n_times(self, s, n)
+
     def _eval_derivative(self, arg):
         from sympy import derive_by_array
         from sympy import Derivative, Tuple
@@ -388,12 +391,6 @@ class NDimArray(object):
 
     __truediv__ = __div__
     __rtruediv__ = __rdiv__
-
-    def _eval_diff(self, *args, **kwargs):
-        if kwargs.pop("evaluate", True):
-            return self.diff(*args)
-        else:
-            return Derivative(self, *args, **kwargs)
 
     def _eval_transpose(self):
         if self.rank() != 2:

--- a/sympy/tensor/array/sparse_ndim_array.py
+++ b/sympy/tensor/array/sparse_ndim_array.py
@@ -211,3 +211,7 @@ class MutableSparseNDimArray(MutableNDimArray, SparseNDimArray):
 
     def as_immutable(self):
         return ImmutableSparseNDimArray(self)
+
+    @property
+    def free_symbols(self):
+        return {i for j in self._sparse_array.values() for i in j.free_symbols}

--- a/sympy/tensor/array/tests/test_mutable_ndim_array.py
+++ b/sympy/tensor/array/tests/test_mutable_ndim_array.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 from sympy.tensor.array.dense_ndim_array import MutableDenseNDimArray
-from sympy import Symbol, Rational, SparseMatrix, diff
+from sympy import Symbol, Rational, SparseMatrix, diff, sympify
 from sympy.core.compatibility import long
 from sympy.matrices import Matrix
 from sympy.tensor.array.sparse_ndim_array import MutableSparseNDimArray
@@ -73,6 +73,14 @@ def test_ndim_array_initiation():
     assert vector_with_long_shape.shape == (long(5),)
     assert vector_with_long_shape.rank() == 1
     raises(ValueError, lambda: vector_with_long_shape[long(5)])
+
+
+def test_sympify():
+    from sympy.abc import x, y, z, t
+    arr = MutableDenseNDimArray([[x, y], [1, z*t]])
+    arr_other = sympify(arr)
+    assert arr_other.shape == (2, 2)
+    assert arr_other == arr
 
 
 def test_reshape():


### PR DESCRIPTION
When calling `x._eval_derivative(s)` there is the problem of type dispatching, consider the types for the tuple `(x, s)`:

1. scalar, scalar
2. scalar, matrix
3. matrix, scalar
4. matrix, matrix

The standard version will call 1., if `x` is a matrix cases 3. and 4. will work fine. Unfortunately case 2. cannot be properly dispatched.

The solution: call `x._accept_eval_derivative(s)`, which will call `s._visit_eval_derivative_<type of x>(x)`. At this point the visit method will be dispatched according to the type of `x` and `_visit_eval_derivative_array` can be added to `Basic` to handle case 2.