### PR TITLE
Made solveset return CRootof() for unsolvable inequalities

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -519,8 +519,11 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 solns = solvify(e, gen, domain)
                 if solns is None:
                     # in which case we raise ValueError
-                    e = orig_expr.lhs - orig_expr.rhs
-                    return set((Poly(e, _gen).all_roots()))
+                    try:
+                        e = orig_expr.lhs - orig_expr.rhs
+                        return set((Poly(e, _gen).all_roots()))
+                    except PolynomialError:
+                        raise ValueError
             except (ValueError, NotImplementedError):
                 # replace gen with generic x since it's
                 # univariate anyway

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -455,6 +455,7 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
     # This keeps the function independent of the assumptions about `gen`.
     # `solveset` makes sure this function is called only when the domain is
     # real.
+    orig_expr = expr
     _gen = gen
     _domain = domain
     if gen.is_real is False:
@@ -518,7 +519,8 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 solns = solvify(e, gen, domain)
                 if solns is None:
                     # in which case we raise ValueError
-                    raise ValueError
+                    e = orig_expr.lhs - orig_expr.rhs
+                    return set((Poly(e, _gen).all_roots()))
             except (ValueError, NotImplementedError):
                 # replace gen with generic x since it's
                 # univariate anyway


### PR DESCRIPTION
Fixes #10071. 
Inqualities like `x**3 - 17*x**2 + 81*x - 118 > 0` which cannot be solved i.e. for which `solvify` returns `None` inside `solve_univariate_inequality()` will be computed via `all_roots()`.
Previous output:
```
>>> eq = x**3 - 17*x**2 + 81*x - 118
>>> solveset(eq > 0, x, domain=S.Reals)
ConditionSet(x, x**3 - 17*x**2 + 81*x - 118 > 0, S.Reals)
```
Corrected output:
```
>>> eq = x**3 - 17*x**2 + 81*x - 118
>>> solveset(eq > 0, x, domain=S.Reals)
{CRootOf(x**3 - 17*x**2 + 81*x - 118, 1), CRootOf(x**3 - 17*x**2 + 81*x - 118, 2
), CRootOf(x**3 - 17*x**2 + 81*x - 118, 0)}
```

ping @ylemkimon @smichr @Yathartha22 