### PR TITLE
Evaluate limits of sequences with alternating signs

### DIFF
--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -5,6 +5,8 @@ from __future__ import print_function, division
 from sympy.core.sympify import sympify
 from sympy.core.singleton import S
 from sympy.core.add import Add
+from sympy.core.power import Pow
+from sympy.core.symbol import Dummy
 from sympy.core.function import PoleError
 from sympy.series.limits import Limit
 
@@ -12,7 +14,8 @@ from sympy.series.limits import Limit
 def difference_delta(expr, n=None, step=1):
     """Difference Operator.
 
-    Discrete analogous to differential operator.
+    Discrete analog of differential operator. Given a sequence x[n],
+    returns the sequence x[n + step] - x[n].
 
     Examples
     ========
@@ -42,10 +45,8 @@ def difference_delta(expr, n=None, step=1):
                              " expression, a variable must be supplied to"
                              " take the difference of %s" % expr)
     step = sympify(step)
-    if step.is_number is False:
-        raise ValueError("Step should be a number.")
-    elif step in [S.Infinity, -S.Infinity]:
-        raise ValueError("Step should be bounded.")
+    if step.is_number is False or step.is_finite is False:
+        raise ValueError("Step should be a finite number.")
 
     if hasattr(expr, '_eval_difference_delta'):
         result = expr._eval_difference_delta(n, step)
@@ -56,14 +57,14 @@ def difference_delta(expr, n=None, step=1):
 
 
 def dominant(expr, n):
-    """Finds the most dominating term in an expression.
+    """Finds the dominant term in a sum, that is a term that dominates
+    every other term.
 
-    if limit(a/b, n, oo) is oo then a dominates b.
-    if limit(a/b, n, oo) is 0 then b dominates a.
-    else a and b are comparable.
+    If limit(a/b, n, oo) is oo then a dominates b.
+    If limit(a/b, n, oo) is 0 then b dominates a.
+    Otherwise, a and b are comparable.
 
-    returns the most dominant term.
-    If no unique domiant term, then returns ``None``.
+    If there is no unique dominant term, then returns ``None``.
 
     Examples
     ========
@@ -106,64 +107,8 @@ def _limit_inf(expr, n):
         return None
 
 
-def limit_seq(expr, n=None, trials=5):
-    """Finds limits of terms having sequences at infinity.
-
-    Parameters
-    ==========
-
-    expr : Expr
-        SymPy expression that is admissible (see section below).
-    n : Symbol
-        Find the limit wrt to n at infinity.
-    trials: int, optional
-        The algorithm is highly recursive. ``trials`` is a safeguard from
-        infinite recursion incase limit is not easily computed by the
-        algorithm. Try increasing ``trials`` if the algorithm returns ``None``.
-
-    Admissible Terms
-    ================
-
-    The terms should be built from rational functions, indefinite sums,
-    and indefinite products over an indeterminate n. A term is admissible
-    if the scope of all product quantifiers are asymptotically positive.
-    Every admissible term is asymptoticically monotonous.
-
-    Examples
-    ========
-
-    >>> from sympy import limit_seq, Sum, binomial
-    >>> from sympy.abc import n, k, m
-    >>> limit_seq((5*n**3 + 3*n**2 + 4) / (3*n**3 + 4*n - 5), n)
-    5/3
-    >>> limit_seq(binomial(2*n, n) / Sum(binomial(2*k, k), (k, 1, n)), n)
-    3/4
-    >>> limit_seq(Sum(k**2 * Sum(2**m/m, (m, 1, k)), (k, 1, n)) / (2**n*n), n)
-    4
-
-    See Also
-    ========
-
-    sympy.series.limitseq.dominant
-
-    References
-    ==========
-
-    .. [1] Computing Limits of Sequences - Manuel Kauers
-    """
+def _limit_seq(expr, n, trials):
     from sympy.concrete.summations import Sum
-
-    if n is None:
-        free = expr.free_symbols
-        if len(free) == 1:
-            n = free.pop()
-        elif not free:
-            return expr
-        else:
-            raise ValueError("expr %s has more than one variables. Please"
-                             "specify a variable." % (expr))
-    elif n not in expr.free_symbols:
-        return expr
 
     for i in range(trials):
         if not expr.has(Sum):
@@ -197,3 +142,76 @@ def limit_seq(expr, n=None, trials=5):
             return None
 
         expr = (num / den).gammasimp()
+
+
+def limit_seq(expr, n=None, trials=5):
+    """Finds limits of terms having sequences at infinity.
+
+    Parameters
+    ==========
+
+    expr : Expr
+        SymPy expression for the n-th term of the sequence
+    n : Symbol
+        The index of the sequence, an integer that tends to positive infinity.
+    trials: int, optional
+        The algorithm is highly recursive. ``trials`` is a safeguard from
+        infinite recursion in case the limit is not easily computed by the
+        algorithm. Try increasing ``trials`` if the algorithm returns ``None``.
+
+    Admissible Terms
+    ================
+
+    The algorithm is designed for sequences built from rational functions,
+    indefinite sums, and indefinite products over an indeterminate n. Terms of
+    alternating sign are also allowed, but more complex oscillatory behavior is
+    not supported.
+
+    Examples
+    ========
+
+    >>> from sympy import limit_seq, Sum, binomial
+    >>> from sympy.abc import n, k, m
+    >>> limit_seq((5*n**3 + 3*n**2 + 4) / (3*n**3 + 4*n - 5), n)
+    5/3
+    >>> limit_seq(binomial(2*n, n) / Sum(binomial(2*k, k), (k, 1, n)), n)
+    3/4
+    >>> limit_seq(Sum(k**2 * Sum(2**m/m, (m, 1, k)), (k, 1, n)) / (2**n*n), n)
+    4
+
+    See Also
+    ========
+
+    sympy.series.limitseq.dominant
+
+    References
+    ==========
+
+    .. [1] Computing Limits of Sequences - Manuel Kauers
+    """
+
+    if n is None:
+        free = expr.free_symbols
+        if len(free) == 1:
+            n = free.pop()
+        elif not free:
+            return expr
+        else:
+            raise ValueError("expr %s has more than one variables. Please"
+                             "specify a variable." % (expr))
+    elif n not in expr.free_symbols:
+        return expr
+
+    n_ = Dummy("n", integer=True, positive=True)
+
+    # If there is a negative term raised to a power involving n, consider
+    # even and odd n separately.
+    powers = (p.as_base_exp() for p in expr.atoms(Pow))
+    if any(b.is_negative and e.has(n) for b, e in powers):
+        L1 = _limit_seq(expr.xreplace({n: 2*n_}), n_, trials)
+        if L1 is not None:
+            L2 = _limit_seq(expr.xreplace({n: 2*n_ + 1}), n_, trials)
+            if L1 == L2:
+                return L1
+    else:
+        return _limit_seq(expr.xreplace({n: n_}), n_, trials)

--- a/sympy/series/tests/test_limitseq.py
+++ b/sympy/series/tests/test_limitseq.py
@@ -82,6 +82,13 @@ def test_limit_seq():
     raises(ValueError, lambda: limit_seq(e * m))
 
 
+def test_alternating_sign():
+    assert limit_seq((-1)**n/n**2, n) == 0
+    assert limit_seq((-2)**(n+1)/(n + 3**n), n) == 0
+    assert limit_seq((2*n + (-1)**n)/(n + 1), n) == 2
+    assert limit_seq((-3)**n/(n + 3**n), n) is None
+
+
 @XFAIL
 def test_limit_seq_fail():
     # improve Summation algorithm or add ad-hoc criteria


### PR DESCRIPTION
#### Brief description of what is fixed or changed

At present `limit_seq` is unable to calculate the limits of sequences that have sign alternation, such as `limit_seq((-1)**n / n, n)`. Now, when the expression contains a negative term raised to a power involving n, the computation of limit splits in two cases, of even and odd n. If both subsequences `x[2*n]` and `x[2*n+1]` have the same limit, then that is the limit of x[n].

#### Other comments

This patch involves moving most of the former `limit_seq` to a helper function `_limit_seq`. Additionally, the index is now declared to be positive and integer, in case the user forgot to do so; this may improve the performance of the algorithm.

Incidentally, I cleaned up the docstrings in limitseq.py which had some typos and sometimes opaque explanations.