### PR TITLE
fix the imaginary number printing

### DIFF
--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -128,7 +128,7 @@ class OctaveCodePrinter(CodePrinter):
         # print complex numbers nicely in Octave
         if (expr.is_number and expr.is_imaginary and
                 expr.as_coeff_Mul()[0].is_integer):
-            return "%si" % self._print(-S.ImaginaryUnit*expr)
+            return "%s*i" % self._print(-S.ImaginaryUnit*expr)
 
         # cribbed from str.py
         prec = precedence(expr)

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -127,8 +127,8 @@ class OctaveCodePrinter(CodePrinter):
     def _print_Mul(self, expr):
         # print complex numbers nicely in Octave
         if (expr.is_number and expr.is_imaginary and
-                expr.as_coeff_Mul()[0].is_integer):
-            return "%s*i" % self._print(-S.ImaginaryUnit*expr)
+                (S.ImaginaryUnit*expr).is_Integer):
+            return "%si" % self._print(-S.ImaginaryUnit*expr)
 
         # cribbed from str.py
         prec = precedence(expr)

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -115,6 +115,7 @@ def test_imag():
     assert mcode(5*I) == "5i"
     assert mcode((S(3)/2)*I) == "3*1i/2"
     assert mcode(3+4*I) == "3 + 4i"
+    assert mcode(sqrt(3)*I) == "sqrt(3)*1i"
 
 
 def test_constants():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13977
 
#### Brief description of what is fixed or changed

As pointed out in the issue https://github.com/sympy/sympy/issues/13977, before this fix the program generates wrong octave code when it comes to imaginary numbers, e.g.```sqrt(3)i```. Now it is set to make multiplication explicit, i.e., ```sqrt(3)*i```. It may not be the best way since i dont know this project, but it is the fastest that solved my personal issue.