### PR TITLE
Made changes to ensure no precision loss of Float on computing Jordan_form

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1335,14 +1335,15 @@ class MatrixEigen(MatrixSubspaces):
 
         def dps(expr):
             C = log(10)/log(2)
-            return max(1, int(round(int(expr) / C - 1)))
+            return max(1, int(round((int(expr) / C - 1).evalf())))
 
         if has_floats:
             max_prec = 0
             for term in self._mat:
                 if isinstance(term, Float):
                     max_prec = max(max_prec, term._prec)
-            max_dps = dps(max_prec)
+            # setting minimum value of max_dps to 15
+            max_dps = max(dps(max_prec), 15)
 
         def restore_floats(*args):
             """If `has_floats` is `True`, cast all `args` as

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -12,7 +12,7 @@ from sympy.core.numbers import Integer, ilcm, Float
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
-from sympy.functions import Abs, exp, factorial
+from sympy.functions import Abs, exp, factorial, log
 from sympy.polys import PurePoly, roots, cancel, gcd
 from sympy.printing import sstr
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
@@ -1333,11 +1333,22 @@ class MatrixEigen(MatrixSubspaces):
         mat = self
         has_floats = any(v.has(Float) for v in self)
 
+        def dps(expr):
+            C = log(10)/log(2)
+            return max(1, int(round(int(max_prec) / C - 1)))
+
+        if has_floats:
+            max_prec = 0
+            for term in self._mat:
+                if isinstance(term, Float):
+                    max_prec = max(max_prec, term._prec)
+            max_dps = dps(max_prec)
+
         def restore_floats(*args):
             """If `has_floats` is `True`, cast all `args` as
             matrices of floats."""
             if has_floats:
-                args = [m.evalf(chop=chop) for m in args]
+                args = [m.evalf(prec=max_dps, chop=chop) for m in args]
             if len(args) == 1:
                 return args[0]
             return args

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1335,7 +1335,7 @@ class MatrixEigen(MatrixSubspaces):
 
         def dps(expr):
             C = log(10)/log(2)
-            return max(1, int(round(int(max_prec) / C - 1)))
+            return max(1, int(round(int(expr) / C - 1)))
 
         if has_floats:
             max_prec = 0

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 import collections
+from mpmath.libmp.libmpf import prec_to_dps
 from sympy.assumptions.refine import refine
 from sympy.core.add import Add
 from sympy.core.basic import Basic, Atom
@@ -12,7 +13,7 @@ from sympy.core.numbers import Integer, ilcm, Float
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
-from sympy.functions import Abs, exp, factorial, log
+from sympy.functions import Abs, exp, factorial
 from sympy.polys import PurePoly, roots, cancel, gcd
 from sympy.printing import sstr
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
@@ -1333,14 +1334,10 @@ class MatrixEigen(MatrixSubspaces):
         mat = self
         has_floats = any(v.has(Float) for v in self)
 
-        def dps(expr):
-            C = log(10)/log(2)
-            return max(1, int(round((int(expr) / C - 1).evalf())))
-
         if has_floats:
             max_prec = max(term._prec for term in self._mat if isinstance(term, Float))
             # setting minimum value of max_dps to 15
-            max_dps = max(dps(max_prec), 15)
+            max_dps = max(prec_to_dps(max_prec), 15)
 
         def restore_floats(*args):
             """If `has_floats` is `True`, cast all `args` as

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1338,10 +1338,7 @@ class MatrixEigen(MatrixSubspaces):
             return max(1, int(round((int(expr) / C - 1).evalf())))
 
         if has_floats:
-            max_prec = 0
-            for term in self._mat:
-                if isinstance(term, Float):
-                    max_prec = max(max_prec, term._prec)
+            max_prec = max(term._prec for term in self._mat if isinstance(term, Float))
             # setting minimum value of max_dps to 15
             max_dps = max(dps(max_prec), 15)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1335,8 +1335,14 @@ class MatrixEigen(MatrixSubspaces):
         has_floats = any(v.has(Float) for v in self)
 
         if has_floats:
-            max_prec = max(term._prec for term in self._mat if isinstance(term, Float))
-            # setting minimum value of max_dps to 15
+            try:
+                max_prec = max(term._prec for term in self._mat if isinstance(term, Float))
+            except ValueError:
+                # if no term in the matrix is explicitly a Float calling max()
+                # will throw a error so setting max_prec to default value of 53
+                max_prec = 53
+            # setting minimum max_dps to 15 to prevent loss of precision in
+            # matrix containing non evaluated expressions
             max_dps = max(prec_to_dps(max_prec), 15)
 
         def restore_floats(*args):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1690,6 +1690,14 @@ def test_jordan_form():
     P, J = m.jordan_form()
     assert Jmust == J
 
+    # checking for maximum precision to remain unchanged
+    m = Matrix([[Float('1.0', precision=110), Float('2.0', precision=110)],
+                [Float('3.14159265358979323846264338327', precision=110), Float('4.0', precision=110)]])
+    P, J = m.jordan_form()
+    for term in J._mat:
+        if isinstance(term, Float):
+            assert term._prec == 110
+
 
 def test_jordan_form_complex_issue_9274():
     A = Matrix([[ 2,  4,  1,  0],


### PR DESCRIPTION
Earlier while computing Jordan_form of a matrix the precision of Float was set to default which led to loss of precision in some cases.


**Earlier**:
```
>>> A = Matrix([[Float('1.0', precision=110), Float('2.0', precision=110)], [Float('3.1415926535897932384626433832795028', precision=110), Float('4.0', precision=110)]])
>>> J = A.jordan_form(calc_transform=False)
>>> srepr(J)
"MutableDenseMatrix([[Float('5.4211616366061612', precision=53), Integer(0)], [Integer(0), Float('-0.42116163660616124', precision=53)]])"
```
**Now**:
```
 A = Matrix([[Float('1.0', precision=110), Float('2.0', precision=110)], [Float('3.1415926535897932384626433832795028', precision=110), Float('4.0', precision=110)]])
>>> J = A.jordan_form(calc_transform=False)
>>> srepr(J)
MutableDenseMatrix([[Float('5.4211616366061612505303104879088482', precision=110), Integer(0)], [Integer(0), Float('-0.42116163660616125053031048790884671', precision=110)]])
```
Fixes #13047
