### PR TITLE
Fixed issue of wrong prefixes under multiplication

### DIFF
--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -73,8 +73,8 @@ class Prefix(Expr):
     __repr__ = __str__
 
     def __mul__(self, other):
-        if isinstance(sympify(other), Number):
-            return other*self
+        if not isinstance(other, Prefix):
+            return super(Prefix, self).__mul__(other)
 
         fact = self.scale_factor * other.scale_factor
 

--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -6,7 +6,7 @@ Module defining unit prefixe class and some constants.
 Constant dict for SI and binary prefixes are defined as PREFIXES and
 BIN_PREFIXES.
 """
-from sympy import Expr, sympify
+from sympy import Expr, sympify, Number
 
 
 class Prefix(Expr):
@@ -73,6 +73,9 @@ class Prefix(Expr):
     __repr__ = __str__
 
     def __mul__(self, other):
+        if isinstance(sympify(other), Number):
+            return other*self
+
         fact = self.scale_factor * other.scale_factor
 
         if fact == 1:

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from sympy import symbols, log
+from sympy import symbols, log, Mul, Symbol
 from sympy.physics.units import Quantity, Dimension
 from sympy.physics.units.prefixes import PREFIXES, Prefix, prefix_unit, kilo, \
     kibi
 
+x = Symbol('x')
 
 def test_prefix_operations():
     m = PREFIXES['m']
@@ -25,7 +26,13 @@ def test_prefix_operations():
     m = Quantity("meter", 1, 6)
     assert dodeca / m == 12 / m
 
-    assert kilo*3 == kilo*3
+    expr1 = kilo*3
+    assert isinstance(expr1, Mul)
+    assert (expr1).args == (3, kilo)
+
+    expr2 = kilo*x
+    assert isinstance(expr2, Mul)
+    assert (expr2).args == (x, kilo)
 
 
 def test_prefix_unit():

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -25,6 +25,8 @@ def test_prefix_operations():
     m = Quantity("meter", 1, 6)
     assert dodeca / m == 12 / m
 
+    assert kilo*3 == kilo*3
+
 
 def test_prefix_unit():
     length = Dimension("length")


### PR DESCRIPTION
Fixes  #13033
 **Before**
```
>>> from sympy.physics.units import *
>>> 3*kilo
3*Prefix(kilo, k, 3, 10)
>>> kilo*3
AttributeError: 'int' object has no attribute 'scale_factor'
```
**Now**
```
>>> from sympy.physics.units import *
>>> 3*kilo
3*Prefix(kilo, k, 3, 10)
>>> kilo*3
3*Prefix(kilo, k, 3, 10)
```