### PR TITLE
Add functionality for infinity norm of matrices

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3378,7 +3378,7 @@ class MatrixBase(MatrixDeprecated,
         =====  ============================  ==========================
         None   Frobenius norm                2-norm
         'fro'  Frobenius norm                - does not exist
-        inf    --                            max(abs(x))
+        inf    maximum row sum               max(abs(x))
         -inf   --                            min(abs(x))
         1      maximum column sum            as below
         -1     --                            as below
@@ -3405,6 +3405,8 @@ class MatrixBase(MatrixDeprecated,
         >>> A.norm(-2) # Inverse spectral norm (smallest singular value)
         0
         >>> A.norm() # Frobenius Norm
+        2
+        >>> A.norm(oo) # Infinity Norm
         2
         >>> Matrix([1, -2]).norm(oo)
         2
@@ -3451,6 +3453,10 @@ class MatrixBase(MatrixDeprecated,
             elif ord == -2:
                 # Minimum singular value
                 return Min(*self.singular_values())
+
+            elif ord == S.Infinity:   # Infinity Norm - Maximum row sum
+                m = self.applyfunc(abs)
+                return Max(*[sum(m.row(i)) for i in range(m.rows)])
 
             elif (ord is None or isinstance(ord,
                                             string_types) and ord.lower() in

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2131,6 +2131,7 @@ def test_matrix_norm():
     assert A.norm(-2) == 0
     assert A.norm('frobenius') == 2
     assert eye(10).norm(2) == eye(10).norm(-2) == 1
+    assert A.norm(oo) == 2
 
     # Test with Symbols and more complex entries
     A = Matrix([[3, y, y], [x, S(1)/2, -pi]])


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13985.

#### Brief description of what is fixed or changed

Functionality for the infinity norm (maximum of absolute row sums) has been added.
DocString has been modified and also the corresponding test has been added.  