### PR TITLE
Revert "Set matplotlib version to 2.1.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
         # autowrap installs libgfortran libgcc gcc cython
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib=2.1.0 theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython"
       addons:
         apt:
           packages:
@@ -36,7 +36,7 @@ matrix:
     - python: 3.6
       env:
         - TEST_ASCII="true"
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib=2.1.0 theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython"
       addons:
         apt:
           packages:


### PR DESCRIPTION
Reverts sympy/sympy#13740
Closes #13730 

matplotlib 2.1.2 was released 5 days ago.