### PR TITLE
Reorder Piecewise output of integration, so that generic answer is first

### DIFF
--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -854,13 +854,12 @@ def test_issue_12557():
     True))*cos(_n*x)/pi, (_n, 1, oo)), SeqFormula(0, (_k, 1, oo))))
     '''
     x = symbols("x", real=True)
-    k = symbols('k', integer=True)
+    k = symbols('k', integer=True, finite=True)
     abs2 = lambda x: Piecewise((-x, x <= 0), (x, x > 0))
     assert integrate(abs2(x), (x, -pi, pi)) == pi**2
     func = cos(k*x)*sqrt(x**2)
-    assert factor_terms(integrate(func, (x, -pi, pi))) == Piecewise(
-        (pi**2, Eq(k, 0)), (((-1)**k - 1)/k**2*2, True))
-
+    assert integrate(func, (x, -pi, pi)) == Piecewise(
+        (2*(-1)**k/k**2 - 2/k**2, Ne(k, 0)), (pi**2, True))
 
 def test_issue_6900():
     from itertools import permutations

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -9,7 +9,7 @@ from sympy.core.expr import Expr
 from sympy.core.function import diff
 from sympy.core.mul import Mul
 from sympy.core.numbers import oo
-from sympy.core.relational import Eq
+from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, Wild)
 from sympy.core.sympify import sympify
@@ -364,7 +364,8 @@ class Integral(AddWithLimits):
         >>> from sympy import Integral
         >>> from sympy.abc import x, i
         >>> Integral(x**i, (i, 1, 3)).doit()
-        Piecewise((2, Eq(log(x), 0)), (x**3/log(x) - x/log(x), True))
+        Piecewise((x**3/log(x) - x/log(x),
+            (x > 1) | ((x >= 0) & (x < 1))), (2, True))
 
         See Also
         ========
@@ -899,7 +900,7 @@ class Integral(AddWithLimits):
                     else:
                         h1 = log(g.base)
                         h2 = g.base**(g.exp + 1) / (g.exp + 1)
-                        h = Piecewise((h1, Eq(g.exp, -1)), (h2, True))
+                        h = Piecewise((h2, Ne(g.exp, -1)), (h1, True))
 
                     parts.append(coeff * h / M[a])
                     continue

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -25,8 +25,9 @@ import sympy
 from sympy.core.compatibility import reduce
 from sympy.core.logic import fuzzy_not
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.strategies.core import switch, do_one, null_safe, condition
-
+from sympy.core.relational import Eq, Ne
 
 ZERO = sympy.S.Zero
 
@@ -247,8 +248,8 @@ def power_rule(integral):
             return ConstantRule(1, 1, symbol)
 
         return PiecewiseRule([
-            (ConstantRule(1, 1, symbol), sympy.Eq(sympy.log(base), 0)),
-            (rule, True)
+            (rule, sympy.Ne(sympy.log(base), 0)),
+            (ConstantRule(1, 1, symbol), True)
         ], integrand, symbol)
 
 def exp_rule(integral):
@@ -1048,8 +1049,10 @@ def eval_constanttimes(constant, other, substep, integrand, symbol):
 
 @evaluates(PowerRule)
 def eval_power(base, exp, integrand, symbol):
-    return sympy.Piecewise((sympy.log(base), sympy.Eq(exp, -1)),
-        ((base**(exp + 1))/(exp + 1), True))
+    return sympy.Piecewise(
+        ((base**(exp + 1))/(exp + 1), sympy.Ne(exp, -1)),
+        (sympy.log(base), True),
+        )
 
 @evaluates(ExpRule)
 def eval_exp(base, exp, integrand, symbol):
@@ -1246,4 +1249,12 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral.doit
     sympy.integrals.integrals.Integral
     """
-    return _manualintegrate(integral_steps(f, var))
+    result = _manualintegrate(integral_steps(f, var))
+    # If we got Piecewise with two parts, put generic first
+    if isinstance(result, Piecewise) and len(result.args) == 2:
+        cond = result.args[0][1]
+        if isinstance(cond, Eq) and result.args[1][1] == True:
+            result = result.func(
+                (result.args[1][0], sympy.Ne(*cond.args)),
+                (result.args[0][0], True))
+    return result

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -31,7 +31,7 @@ from sympy.core.function import Lambda
 from sympy.core.numbers import ilcm, oo, I
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
-from sympy.core.relational import Eq
+from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.compatibility import reduce, ordered, range
@@ -1511,8 +1511,8 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
         # XXX: Does qd = 0 always necessarily correspond to the exponential
         # equaling 1?
         ret += Piecewise(
-                (integrate((p - i).subs(DE.t, 1).subs(s), DE.x), Eq(qds, 0)),
-                (qas/qds, True)
+                (qas/qds, Ne(qds, 0)),
+                (integrate((p - i).subs(DE.t, 1).subs(s), DE.x), True)
             )
     else:
         ret += qas/qds

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -1,6 +1,6 @@
 from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, erf, tan, asin, asinh, acos, Function, Derivative, diff, simplify, \
-    LambertW, Eq, Piecewise, Symbol, Add, ratsimp, Integral, Sum, \
+    LambertW, Ne, Piecewise, Symbol, Add, ratsimp, Integral, Sum, \
     besselj, besselk, bessely, jn
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
 from sympy.utilities.pytest import XFAIL, skip, slow, ON_TRAVIS
@@ -124,8 +124,8 @@ def test_heurisch_radicals():
     assert heurisch(sin(y*sqrt(x)), x) == 2/y**2*sin(y*sqrt(x)) - \
         2*sqrt(x)*cos(y*sqrt(x))/y
     assert heurisch_wrapper(sin(y*sqrt(x)), x) == Piecewise(
-        (0, Eq(y, 0)),
-        (-2*sqrt(x)*cos(sqrt(x)*y)/y + 2*sin(sqrt(x)*y)/y**2, True))
+        (-2*sqrt(x)*cos(sqrt(x)*y)/y + 2*sin(sqrt(x)*y)/y**2, Ne(y, 0)),
+        (0, True))
     y = Symbol('y', positive=True)
     assert heurisch_wrapper(sin(y*sqrt(x)), x) == 2/y**2*sin(y*sqrt(x)) - \
         2*sqrt(x)*cos(y*sqrt(x))/y
@@ -145,8 +145,9 @@ def test_heurisch_symbolic_coeffs():
 def test_heurisch_symbolic_coeffs_1130():
     y = Symbol('y')
     assert heurisch_wrapper(1/(x**2 + y), x) == Piecewise(
-        (-1/x, Eq(y, 0)),
-        (-I*log(x - I*sqrt(y))/(2*sqrt(y)) + I*log(x + I*sqrt(y))/(2*sqrt(y)), True))
+        (-I*log(x - I*sqrt(y))/(2*sqrt(y))
+         + I*log(x + I*sqrt(y))/(2*sqrt(y)), Ne(y, 0)),
+        (-1/x, True))
     y = Symbol('y', positive=True)
     assert heurisch_wrapper(1/(x**2 + y), x) in [I/sqrt(y)*log(x + sqrt(-y))/2 -
     I/sqrt(y)*log(x - sqrt(-y))/2, I*log(x + I*sqrt(y)) /
@@ -194,8 +195,8 @@ def test_heurisch_wrapper():
     f = 1/(y - x)
     assert heurisch_wrapper(f, x) == -log(x - y)
     f = 1/((y - x)*(y + x))
-    assert heurisch_wrapper(f, x) == \
-        Piecewise((1/x, Eq(y, 0)), (log(x + y)/2/y - log(x - y)/2/y, True))
+    assert heurisch_wrapper(f, x) == Piecewise(
+        (-log(x - y)/(2*y) + log(x + y)/(2*y), Ne(y, 0)), (1/x, True))
     # issue 6926
     f = sqrt(x**2/((y - x)*(y + x)))
     assert heurisch_wrapper(f, x) == x*sqrt(x**2)*sqrt(1/(-x**2 + y**2)) \

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -249,12 +249,12 @@ def test_issue_3618():
 
 def test_issue_3623():
     assert integrate(cos((n + 1)*x), x) == Piecewise(
-        (x, Eq(n + 1, 0)), (sin((n + 1)*x)/(n + 1), True))
+        (sin(x*(n + 1))/(n + 1), Ne(n + 1, 0)), (x, True))
     assert integrate(cos((n - 1)*x), x) == Piecewise(
-        (x, Eq(n - 1, 0)), (sin((n - 1)*x)/(n - 1), True))
+        (sin(x*(n - 1))/(n - 1), Ne(n - 1, 0)), (x, True))
     assert integrate(cos((n + 1)*x) + cos((n - 1)*x), x) == \
-        Piecewise((x, Eq(n + 1, 0)), (sin((n + 1)*x)/(n + 1), True)) + \
-        Piecewise((x, Eq(n - 1, 0)), (sin((n - 1)*x)/(n - 1), True))
+        Piecewise((sin(x*(n - 1))/(n - 1), Ne(n - 1, 0)), (x, True)) + \
+        Piecewise((sin(x*(n + 1))/(n + 1), Ne(n + 1, 0)), (x, True))
 
 
 def test_issue_3664():
@@ -505,32 +505,31 @@ def test_integrate_DiracDelta_fails():
 
 def test_integrate_returns_piecewise():
     assert integrate(x**y, x) == Piecewise(
-        (log(x), Eq(y, -1)), (x**(y + 1)/(y + 1), True))
+        (x**(y + 1)/(y + 1), Ne(y, -1)), (log(x), True))
     assert integrate(x**y, y) == Piecewise(
-        (y, Eq(log(x), 0)), (x**y/log(x), True))
+        (x**y/log(x), Ne(log(x), 0)), (y, True))
     assert integrate(exp(n*x), x) == Piecewise(
-        (x, Eq(n, 0)), (exp(n*x)/n, True))
+        (exp(n*x)/n, Ne(n, 0)), (x, True))
     assert integrate(x*exp(n*x), x) == Piecewise(
-        (x**2/2, Eq(n**3, 0)), ((x*n**2 - n)*exp(n*x)/n**3, True))
+        ((n**2*x - n)*exp(n*x)/n**3, Ne(n**3, 0)), (x**2/2, True))
     assert integrate(x**(n*y), x) == Piecewise(
-        (log(x), Eq(n*y, -1)), (x**(n*y + 1)/(n*y + 1), True))
+        (x**(n*y + 1)/(n*y + 1), Ne(n*y, -1)), (log(x), True))
     assert integrate(x**(n*y), y) == Piecewise(
-        (y, Eq(n*log(x), 0)), (x**(n*y)/(n*log(x)), True))
+        (x**(n*y)/(n*log(x)), Ne(n*log(x), 0)), (y, True))
     assert integrate(cos(n*x), x) == Piecewise(
-        (x, Eq(n, 0)), (sin(n*x)/n, True))
+        (sin(n*x)/n, Ne(n, 0)), (x, True))
     assert integrate(cos(n*x)**2, x) == Piecewise(
-        (x, Eq(n, 0)), ((n*x/2 + sin(n*x)*cos(n*x)/2)/n, True))
+        ((n*x/2 + sin(n*x)*cos(n*x)/2)/n, Ne(n, 0)), (x, True))
     assert integrate(x*cos(n*x), x) == Piecewise(
-        (x**2/2, Eq(n, 0)), (x*sin(n*x)/n + cos(n*x)/n**2, True))
+        (x*sin(n*x)/n + cos(n*x)/n**2, Ne(n, 0)), (x**2/2, True))
     assert integrate(sin(n*x), x) == Piecewise(
-        (0, Eq(n, 0)), (-cos(n*x)/n, True))
+        (-cos(n*x)/n, Ne(n, 0)), (0, True))
     assert integrate(sin(n*x)**2, x) == Piecewise(
-        (0, Eq(n, 0)), ((n*x/2 - sin(n*x)*cos(n*x)/2)/n, True))
+        ((n*x/2 - sin(n*x)*cos(n*x)/2)/n, Ne(n, 0)), (0, True))
     assert integrate(x*sin(n*x), x) == Piecewise(
-        (0, Eq(n, 0)), (-x*cos(n*x)/n + sin(n*x)/n**2, True))
-    assert integrate(exp(x*y),(x,0,z)) == Piecewise( \
-        (z, Eq(y,0)), (exp(y*z)/y - 1/y, True))
-
+        (-x*cos(n*x)/n + sin(n*x)/n**2, Ne(n, 0)), (0, True))
+    assert integrate(exp(x*y), (x, 0, z)) == Piecewise(
+        (exp(y*z)/y - 1/y, (y > -oo) & (y < oo) & Ne(y, 0)), (z, True))
 
 def test_integrate_max_min():
     assert integrate(Min(x, 2), (x, 0, 3)) == 4

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,6 +1,6 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Integral, integrate, pi, Dummy, Derivative,
-                   diff, I, sqrt, erf, Piecewise, Eq, symbols, Rational,
+                   diff, I, sqrt, erf, Piecewise, Eq, Ne, symbols, Rational,
                    And, Heaviside, S, asinh, acosh, atanh, acoth, expand,
                    Function)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
@@ -220,7 +220,7 @@ def test_issue_6799():
 
 def test_issue_12251():
     assert manualintegrate(x**y, x) == Piecewise(
-        (log(x), Eq(y, -1)), (x**(y + 1)/(y + 1), True))
+        (x**(y + 1)/(y + 1), Ne(y, -1)), (log(x), True))
 
 
 def test_issue_3796():
@@ -238,16 +238,16 @@ def test_manual_true():
 def test_issue_6746():
     y = Symbol('y')
     n = Symbol('n')
-    assert manualintegrate(y**x, x) == \
-        Piecewise((x, Eq(log(y), 0)), (y**x/log(y), True))
-    assert manualintegrate(y**(n*x), x) == \
-        Piecewise(
-            (x, Eq(n, 0)),
-            (Piecewise(
-                (n*x, Eq(log(y), 0)),
-                (y**(n*x)/log(y), True))/n, True))
-    assert manualintegrate(exp(n*x), x) == \
-        Piecewise((x, Eq(n, 0)), (exp(n*x)/n, True))
+    assert manualintegrate(y**x, x) == Piecewise(
+        (y**x/log(y), Ne(log(y), 0)), (x, True))
+    assert manualintegrate(y**(n*x), x) == Piecewise(
+        (Piecewise(
+            (y**(n*x)/log(y), Ne(log(y), 0)),
+            (n*x, True)
+        )/n, Ne(n, 0)),
+        (x, True))
+    assert manualintegrate(exp(n*x), x) == Piecewise(
+        (exp(n*x)/n, Ne(n, 0)), (x, True))
 
     y = Symbol('y', positive=True)
     assert manualintegrate((y + 1)**x, x) == (y + 1)**x/log(y + 1)
@@ -255,8 +255,8 @@ def test_issue_6746():
     assert manualintegrate((y + 1)**x, x) == x
     y = Symbol('y')
     n = Symbol('n', nonzero=True)
-    assert manualintegrate(y**(n*x), x) == \
-        Piecewise((n*x, Eq(log(y), 0)), (y**(n*x)/log(y), True))/n
+    assert manualintegrate(y**(n*x), x) == Piecewise(
+        (y**(n*x)/log(y), Ne(log(y), 0)), (n*x, True))/n
     y = Symbol('y', positive=True)
     assert manualintegrate((y + 1)**(n*x), x) == \
         (y + 1)**(n*x)/(n*log(y + 1))

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1,6 +1,6 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from sympy import (Poly, I, S, Function, log, symbols, exp, tan, sqrt,
-    Symbol, Lambda, sin, Eq, Piecewise, factor, expand_log, cancel,
+    Symbol, Lambda, sin, Eq, Ne, Piecewise, factor, expand_log, cancel,
     expand, diff, pi, atan)
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     derivation, splitfactor, splitfactor_sqf, canonical_representation,
@@ -329,27 +329,29 @@ def test_integrate_hyperexponential_returns_piecewise():
     a, b = symbols('a b')
     DE = DifferentialExtension(a**x, x)
     assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
-        (x, Eq(log(a), 0)), (exp(x*log(a))/log(a), True)), 0, True)
+        (exp(x*log(a))/log(a), Ne(log(a), 0)), (x, True)), 0, True)
     DE = DifferentialExtension(a**(b*x), x)
     assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
-        (x, Eq(b*log(a), 0)), (exp(b*x*log(a))/(b*log(a)), True)), 0, True)
+        (exp(b*x*log(a))/(b*log(a)), Ne(b*log(a), 0)), (x, True)), 0, True)
     DE = DifferentialExtension(exp(a*x), x)
     assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
-        (x, Eq(a, 0)), (exp(a*x)/a, True)), 0, True)
+        (exp(a*x)/a, Ne(a, 0)), (x, True)), 0, True)
     DE = DifferentialExtension(x*exp(a*x), x)
     assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
-        (x**2/2, Eq(a**3, 0)), ((x*a**2 - a)*exp(a*x)/a**3, True)), 0, True)
+        ((x*a**2 - a)*exp(a*x)/a**3, Ne(a**3, 0)), (x**2/2, True)), 0, True)
     DE = DifferentialExtension(x**2*exp(a*x), x)
     assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
-        (x**3/3, Eq(a**6, 0)),
-        ((x**2*a**5 - 2*x*a**4 + 2*a**3)*exp(a*x)/a**6, True)), 0, True)
+        ((x**2*a**5 - 2*x*a**4 + 2*a**3)*exp(a*x)/a**6, Ne(a**6, 0)),
+        (x**3/3, True)), 0, True)
     DE = DifferentialExtension(x**y + z, y)
-    assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise((y,
-        Eq(log(x), 0)), (exp(log(x)*y)/log(x), True)), z, True)
+    assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
+        (exp(log(x)*y)/log(x), Ne(log(x), 0)), (y, True)), z, True)
     DE = DifferentialExtension(x**y + z + x**(2*y), y)
-    assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise((2*y,
-        Eq(2*log(x)**2, 0)), ((exp(2*log(x)*y)*log(x) +
-            2*exp(log(x)*y)*log(x))/(2*log(x)**2), True)), z, True)
+    assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
+        ((exp(2*log(x)*y)*log(x) +
+            2*exp(log(x)*y)*log(x))/(2*log(x)**2), Ne(2*log(x)**2, 0)),
+            (2*y, True),
+        ), z, True)
     # TODO: Add a test where two different parts of the extension use a
     # Piecewise, like y**x + z**x.
 

--- a/sympy/integrals/tests/test_trigonometry.py
+++ b/sympy/integrals/tests/test_trigonometry.py
@@ -1,4 +1,4 @@
-from sympy.core import Eq, Rational, Symbol
+from sympy.core import Ne, Rational, Symbol
 from sympy.functions import sin, cos, tan, csc, sec, cot, log, Piecewise
 from sympy.integrals.trigonometry import trigintegrate
 
@@ -17,16 +17,16 @@ def test_trigintegrate_odd():
     assert trigintegrate(cos(3*x), x) == sin(3*x)/3
 
     y = Symbol('y')
-    assert trigintegrate(sin(y*x), x) == \
-        Piecewise((0, Eq(y, 0)), (-cos(y*x)/y, True))
-    assert trigintegrate(cos(y*x), x) == \
-        Piecewise((x, Eq(y, 0)), (sin(y*x)/y, True))
-    assert trigintegrate(sin(y*x)**2, x) == \
-        Piecewise((0, Eq(y, 0)), ((x*y/2 - sin(x*y)*cos(x*y)/2)/y, True))
-    assert trigintegrate(sin(y*x)*cos(y*x), x) == \
-        Piecewise((0, Eq(y, 0)), (sin(x*y)**2/(2*y), True))
-    assert trigintegrate(cos(y*x)**2, x) == \
-        Piecewise((x, Eq(y, 0)), ((x*y/2 + sin(x*y)*cos(x*y)/2)/y, True))
+    assert trigintegrate(sin(y*x), x) == Piecewise(
+        (-cos(y*x)/y, Ne(y, 0)), (0, True))
+    assert trigintegrate(cos(y*x), x) == Piecewise(
+        (sin(y*x)/y, Ne(y, 0)), (x, True))
+    assert trigintegrate(sin(y*x)**2, x) == Piecewise(
+        ((x*y/2 - sin(x*y)*cos(x*y)/2)/y, Ne(y, 0)), (0, True))
+    assert trigintegrate(sin(y*x)*cos(y*x), x) == Piecewise(
+        (sin(x*y)**2/(2*y), Ne(y, 0)), (0, True))
+    assert trigintegrate(cos(y*x)**2, x) == Piecewise(
+        ((x*y/2 + sin(x*y)*cos(x*y)/2)/y, Ne(y, 0)), (x, True))
 
     y = Symbol('y', positive=True)
     # TODO: remove conds='none' below. For this to work we would have to rule

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core.compatibility import range
-from sympy.core import cacheit, Dummy, Eq, Integer, Rational, S, Wild
+from sympy.core import cacheit, Dummy, Ne, Integer, Rational, S, Wild
 from sympy.functions import binomial, sin, cos, Piecewise
 
 # TODO sin(a*x)*cos(b*x) -> sin((a+b)x) + sin((a-b)x) ?
@@ -114,7 +114,7 @@ def trigintegrate(f, x, conds='piecewise'):
         fi = integrate(ff, u)  # XXX cyclic deps
         fx = fi.subs(u, uu)
         if conds == 'piecewise':
-            return Piecewise((zz, Eq(a, 0)), (fx / a, True))
+            return Piecewise((fx / a, Ne(a, 0)), (zz, True))
         return fx / a
 
     # n & m are both even
@@ -242,7 +242,7 @@ def trigintegrate(f, x, conds='piecewise'):
                        Rational(n - 1, m + 1) *
                        integrate(cos(x)**(m + 2)*sin(x)**(n - 2), x))
     if conds == 'piecewise':
-        return Piecewise((zz, Eq(a, 0)), (res.subs(x, a*x) / a, True))
+        return Piecewise((res.subs(x, a*x) / a, Ne(a, 0)), (zz, True))
     return res.subs(x, a*x) / a
 
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4313,17 +4313,17 @@ def ode_almost_linear(eq, func, order, match):
         f(x)*--(l(y)) + g(x) + k(x)*l(y) = 0
              dy
         >>> pprint(dsolve(genform, hint = 'almost_linear'))
-               /     //   -y*g(x)                  \\
-               |     ||   --------     for k(x) = 0||
-               |     ||     f(x)                   ||  -y*k(x)
-               |     ||                            ||  --------
-               |     ||       y*k(x)               ||    f(x)
-        l(y) = |C1 + |<       ------               ||*e
-               |     ||        f(x)                ||
-               |     ||-g(x)*e                     ||
-               |     ||--------------   otherwise  ||
-               |     ||     k(x)                   ||
-               \     \\                            //
+               /     //       y*k(x)                \\
+               |     ||       ------                ||
+               |     ||        f(x)                 ||  -y*k(x)
+               |     ||-g(x)*e                      ||  --------
+               |     ||--------------  for k(x) != 0||    f(x)
+        l(y) = |C1 + |<     k(x)                    ||*e
+               |     ||                             ||
+               |     ||   -y*g(x)                   ||
+               |     ||   --------       otherwise  ||
+               |     ||     f(x)                    ||
+               \     \\                             //
 
 
     See Also

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 
 from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
-    Dummy, Eq, erf, erfi, exp, Function, I, Integral, LambertW, log, O, pi,
+    Dummy, Eq, Ne, erf, erfi, exp, Function, I, Integral, LambertW, log, O, pi,
     Rational, rootof, S, simplify, sin, sqrt, Subs, Symbol, tan, asin, sinh,
     Piecewise, symbols, Poly)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
@@ -2512,16 +2512,17 @@ def test_issue_6879():
 def test_issue_6989():
     f = Function('f')
     k = Symbol('k')
-    assert dsolve(f(x).diff(x) - x*exp(-k*x), f(x)) == \
-        Eq(f(x), C1 + Piecewise(
-            (x**2/2, Eq(k**3, 0)),
-            ((-k**2*x - k)*exp(-k*x)/k**3, True)
+    assert dsolve(f(x).diff(x) - x*exp(-k*x), f(x)) == Eq(f(x),
+        C1 + Piecewise(
+            ((-k**2*x - k)*exp(-k*x)/k**3, Ne(k**3, 0)),
+            (x**2/2, True)
         ))
     eq = -f(x).diff(x) + x*exp(-k*x)
     sol = dsolve(eq, f(x))
-    actual_sol = Eq(f(x), Piecewise((C1 + x**2/2, Eq(k**3, 0)),
-            (C1 - x*exp(-k*x)/k - exp(-k*x)/k**2, True)
-        ))
+    actual_sol = Eq(f(x), Piecewise(
+        (C1 - x*exp(-k*x)/k - exp(-k*x)/k**2, Ne(k**3, 0)),
+        (C1 + x**2/2, True)
+    ))
     errstr = str(eq) + ' : ' + str(sol) + ' == ' + str(actual_sol)
     assert sol == actual_sol, errstr
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #7032

#### Brief description of what is fixed or changed

Currently, when `integrate` presents a solution as a Piecewise, it puts an edge case first, for example

```
>>> var('x y')
>>> integrate(exp(x*y), x)
Piecewise((x, Eq(y, 0)), (exp(x*y)/y, True))
```

With this patch, the output is

```
Piecewise((exp(x*y)/y, Ne(y, 0)), (x, True))
```

#### Other comments

An exception is made for Piecewise with multiple edge cases, such as Eq(k, 0), Eq(m, 0), Eq(k, m), Eq(k, -m)... In such a situation, putting the generic case would necessarily decorate it with a long condition, and then negated pieces of that condition would be repeated again in the edge cases. The result is a formula that is not only longer but also harder for SymPy to work with.

Naturally, a lot of test cases had to be changed.
 

