### PR TITLE
Made changes to resolve errors with mul and div in prefixes

### DIFF
--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -6,7 +6,7 @@ Module defining unit prefixe class and some constants.
 Constant dict for SI and binary prefixes are defined as PREFIXES and
 BIN_PREFIXES.
 """
-from sympy import Expr, sympify, Number
+from sympy import Expr, sympify
 
 
 class Prefix(Expr):
@@ -73,10 +73,10 @@ class Prefix(Expr):
     __repr__ = __str__
 
     def __mul__(self, other):
-        if not isinstance(other, Prefix):
+        try:
+            fact = self.scale_factor * other.scale_factor
+        except AttributeError:
             return super(Prefix, self).__mul__(other)
-
-        fact = self.scale_factor * other.scale_factor
 
         if fact == 1:
             return 1
@@ -90,7 +90,10 @@ class Prefix(Expr):
         return self.scale_factor * other
 
     def __div__(self, other):
-        fact = self.scale_factor / other.scale_factor
+        try:
+            fact = self.scale_factor / other.scale_factor
+        except AttributeError:
+            return super(Prefix, self).__div__(other)
 
         if fact == 1:
             return 1

--- a/sympy/physics/units/prefixes.py
+++ b/sympy/physics/units/prefixes.py
@@ -73,10 +73,10 @@ class Prefix(Expr):
     __repr__ = __str__
 
     def __mul__(self, other):
-        try:
-            fact = self.scale_factor * other.scale_factor
-        except AttributeError:
+        if not hasattr(other, "scale_factor"):
             return super(Prefix, self).__mul__(other)
+
+        fact = self.scale_factor * other.scale_factor
 
         if fact == 1:
             return 1
@@ -90,10 +90,10 @@ class Prefix(Expr):
         return self.scale_factor * other
 
     def __div__(self, other):
-        try:
-            fact = self.scale_factor / other.scale_factor
-        except AttributeError:
+        if not hasattr(other, "scale_factor"):
             return super(Prefix, self).__div__(other)
+
+        fact = self.scale_factor / other.scale_factor
 
         if fact == 1:
             return 1

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from sympy import symbols, log, Mul, Symbol
-from sympy.physics.units import Quantity, Dimension
+from sympy.physics.units import Quantity, Dimension, meter
 from sympy.physics.units.prefixes import PREFIXES, Prefix, prefix_unit, kilo, \
     kibi
 
@@ -24,15 +24,24 @@ def test_prefix_operations():
     assert dodeca / dodeca == 1
 
     m = Quantity("meter", 1, 6)
+    assert dodeca * m == 12 * m
     assert dodeca / m == 12 / m
 
-    expr1 = kilo*3
+    expr1 = kilo * 3
     assert isinstance(expr1, Mul)
     assert (expr1).args == (3, kilo)
 
-    expr2 = kilo*x
+    expr2 = kilo * x
     assert isinstance(expr2, Mul)
     assert (expr2).args == (x, kilo)
+
+    expr3 = kilo / 3
+    assert isinstance(expr3, Mul)
+    assert (expr3).args == (1/3, kilo)
+
+    expr3 = kilo / x
+    assert isinstance(expr3, Mul)
+    assert (expr3).args == (1/x, kilo)
 
 
 def test_prefix_unit():

--- a/sympy/physics/units/tests/test_prefixes.py
+++ b/sympy/physics/units/tests/test_prefixes.py
@@ -39,9 +39,9 @@ def test_prefix_operations():
     assert isinstance(expr3, Mul)
     assert (expr3).args == (1/3, kilo)
 
-    expr3 = kilo / x
-    assert isinstance(expr3, Mul)
-    assert (expr3).args == (1/x, kilo)
+    expr4 = kilo / x
+    assert isinstance(expr4, Mul)
+    assert (expr4).args == (1/x, kilo)
 
 
 def test_prefix_unit():


### PR DESCRIPTION
In PR #13983 changes were made to resolve errors during prefix multiplication with non-prefix. However it led to an undesirable behaviour.
For the code snippet
```
>>> from sympy.physics.units import kilo,meter
>>> kilo*meter
meter*Prefix('kilo', 'k', 3) 
```
whereas earlier it gave `1000*meter`. 
Therefore this PR tries to compute the product of `scale_factors` first. This PR also removes the error that were present in prefix div in the same way as mul.

