### PR TITLE
fcode : Improved printing of Fortran code

### DIFF
--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -175,18 +175,16 @@ that manual changes in the result are no longer needed.
 Two basic examples:
 
     >>> from sympy import *
-    >>> from sympy.printing.fcode import FCodePrinter
-    >>> z = FCodePrinter()
     >>> x = symbols("x")
-    >>> fcode(z, sqrt(1-x**2))
+    >>> fcode(sqrt(1-x**2))
     '      sqrt(-x**2 + 1)'
-    >>> fcode(z, (3 + 4*I)/(1 - conjugate(x)))
+    >>> fcode((3 + 4*I)/(1 - conjugate(x)))
     '      (cmplx(3,4))/(-conjg(x) + 1)'
 
 An example where line wrapping is required:
 
     >>> expr = sqrt(1-x**2).series(x,n=20).removeO()
-    >>> print(fcode(z, expr))
+    >>> print(fcode(expr))
           -715.0d0/65536.0d0*x**18 - 429.0d0/32768.0d0*x**16 - 33.0d0/
          @ 2048.0d0*x**14 - 21.0d0/1024.0d0*x**12 - 7.0d0/256.0d0*x**10 -
          @ 5.0d0/128.0d0*x**8 - 1.0d0/16.0d0*x**6 - 1.0d0/8.0d0*x**4 - 1.0d0
@@ -195,7 +193,7 @@ An example where line wrapping is required:
 In case of line wrapping, it is handy to include the assignment so that lines
 are wrapped properly when the assignment part is added.
 
-    >>> print(fcode(z, expr, assign_to="var"))
+    >>> print(fcode(expr, assign_to="var"))
           var = -715.0d0/65536.0d0*x**18 - 429.0d0/32768.0d0*x**16 - 33.0d0/
          @ 2048.0d0*x**14 - 21.0d0/1024.0d0*x**12 - 7.0d0/256.0d0*x**10 -
          @ 5.0d0/128.0d0*x**8 - 1.0d0/16.0d0*x**6 - 1.0d0/8.0d0*x**4 - 1.0d0
@@ -203,7 +201,7 @@ are wrapped properly when the assignment part is added.
 
 For piecewise functions, the ``assign_to`` option is mandatory:
 
-    >>> print(fcode(z, Piecewise((x,x<1),(x**2,True)), assign_to="var"))
+    >>> print(fcode(Piecewise((x,x<1),(x**2,True)), assign_to="var"))
           if (x < 1) then
             var = x
           else
@@ -215,7 +213,7 @@ the lack of a conditional operator in Fortran 77. Inline conditionals can be
 supported using the ``merge`` function introduced in Fortran 95 by setting of
 the kwarg ``standard=95``:
 
-    >>> print(fcode(z, Piecewise((x,x<1),(x**2,True)), standard=95))
+    >>> print(fcode(Piecewise((x,x<1),(x**2,True)), standard=95))
           merge(x, x**2, x < 1)
 
 Loops are generated if there are Indexed objects in the expression. This
@@ -224,7 +222,7 @@ also requires use of the assign_to option.
     >>> A, B = map(IndexedBase, ['A', 'B'])
     >>> m = Symbol('m', integer=True)
     >>> i = Idx('i', m)
-    >>> print(fcode(z, 2*B[i], assign_to=A[i]))
+    >>> print(fcode(2*B[i], assign_to=A[i]))
         do i = 1, m
             A(i) = 2*B(i)
         end do
@@ -233,7 +231,7 @@ Repeated indices in an expression with Indexed objects are interpreted as
 summation. For instance, code for the trace of a matrix can be generated
 with
 
-    >>> print(fcode(z, A[i, i], assign_to=x))
+    >>> print(fcode(A[i, i], assign_to=x))
           x = 0
           do i = 1, m
               x = x + A(i, i)
@@ -244,27 +242,27 @@ Fortran parameters. The precision of the constants can be tuned with the
 precision argument. Parameter definitions are easily avoided using the ``N``
 function.
 
-    >>> print(fcode(z, x - pi**2 - E))
+    >>> print(fcode(x - pi**2 - E))
           parameter (E = 2.7182818284590452d0)
           parameter (pi = 3.1415926535897932d0)
           x - pi**2 - E
-    >>> print(fcode(z, x - pi**2 - E, precision=25))
+    >>> print(fcode(x - pi**2 - E, precision=25))
           parameter (E = 2.718281828459045235360287d0)
           parameter (pi = 3.141592653589793238462643d0)
           x - pi**2 - E
-    >>> print(fcode(z, N(x - pi**2, 25)))
+    >>> print(fcode(N(x - pi**2, 25)))
           x - 9.869604401089358618834491d0
 
 When some functions are not part of the Fortran standard, it might be desirable
 to introduce the names of user-defined functions in the Fortran expression.
 
-    >>> print(fcode(z, 1 - gamma(x)**2, user_functions={'gamma': 'mygamma'}))
+    >>> print(fcode(1 - gamma(x)**2, user_functions={'gamma': 'mygamma'}))
           -mygamma(x)**2 + 1
 
 However, when the user_functions argument is not provided, ``fcode`` attempts to
 use a reasonable default and adds a comment to inform the user of the issue.
 
-    >>> print(fcode(z, 1 - gamma(x)**2))
+    >>> print(fcode(1 - gamma(x)**2))
     C     Not supported in Fortran:
     C     gamma
           -gamma(x)**2 + 1
@@ -276,11 +274,11 @@ return value is a three-tuple containing: (i) a set of number symbols that must
 be defined as 'Fortran parameters', (ii) a list functions that cannot be
 translated in pure Fortran and (iii) a string of Fortran code. A few examples:
 
-    >>> fcode(z, 1 - gamma(x)**2, human=False)
+    >>> fcode(1 - gamma(x)**2, human=False)
     (set(), {gamma(x)}, '      -gamma(x)**2 + 1')
-    >>> fcode(z, 1 - sin(x)**2, human=False)
+    >>> fcode(1 - sin(x)**2, human=False)
     (set(), set(), '      -sin(x)**2 + 1')
-    >>> fcode(z, x - pi**2, human=False)
+    >>> fcode(x - pi**2, human=False)
     ({(pi, '3.1415926535897932d0')}, set(), '      x - pi**2')
 
 Mathematica code printing

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -577,7 +577,7 @@ def fcode(expr, assign_to=None, **settings):
     name_mangling : bool, optional
         If True, then the variables that would become identical in
         case-insensitive Fortran are mangled by appending different number
-        of `_` at the end. If False, SymPy won't interfere with naming of
+        of ``_`` at the end. If False, SymPy won't interfere with naming of
         variables. [default=True]
 
     Examples

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -13,8 +13,8 @@ Fortran77" by Clive G. Page:
 http://www.star.le.ac.uk/~cgp/prof77.html
 
 Fortran is a case-insensitive language. This might cause trouble because
-SymPy is case sensitive. The implementation below does not care and leaves
-the responsibility for generating properly cased Fortran code to the user.
+SymPy is case sensitive. So, fcode adds underscores to variable names when
+it is necessary to make them different for Fortran.
 """
 
 from __future__ import print_function, division
@@ -617,7 +617,21 @@ def fcode(expr, assign_to=None, **settings):
              end if
           A(3, 1) = sin(x)
     """
+    from sympy import symbols, ordered, Symbol
+    used_name = []
+    word_map = {}
 
+    for sym in tuple(ordered(expr.atoms(Symbol))):
+        name = sym.name
+        while name.lower() in used_name:
+            name += '_'
+        used_name.append(name.lower())
+        if name == sym.name:
+            word_map[sym] = sym
+        else:
+            word_map[sym] = symbols(name, cls=sym.__class__, **sym.assumptions0)
+
+    expr = expr.xreplace(word_map)
     return FCodePrinter(settings).doprint(expr, assign_to)
 
 

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -146,15 +146,7 @@ class FCodePrinter(CodePrinter):
             expr = expr.xreplace(self.mangled_symbols)
 
         name = super(FCodePrinter, self)._print_Symbol(expr)
-
-        if name in self.reserved_words:
-            if self._settings['error_on_reserved']:
-                msg = ('This expression includes the symbol "{}" which is a '
-                       'reserved keyword in this language.')
-                raise ValueError(msg.format(name))
-            return name + self._settings['reserved_word_suffix']
-        else:
-            return name
+        return name
 
     def _rate_index_position(self, p):
         return -p*5

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -145,7 +145,7 @@ class FCodePrinter(CodePrinter):
 
             expr = expr.xreplace(self.mangled_symbols)
 
-        name = super(CodePrinter, self)._print_Symbol(expr)
+        name = super(FCodePrinter, self)._print_Symbol(expr)
 
         if name in self.reserved_words:
             if self._settings['error_on_reserved']:

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -23,8 +23,8 @@ from collections import defaultdict
 from itertools import chain
 import string
 
-from sympy.core import S, Add, N, Float, Symbol, symbols
-from sympy.core.compatibility import string_types, range, ordered
+from sympy.core import S, Add, N, Float, Symbol
+from sympy.core.compatibility import string_types, range
 from sympy.core.function import Function
 from sympy.core.relational import Eq
 from sympy.sets import Range
@@ -133,16 +133,15 @@ class FCodePrinter(CodePrinter):
 
     def _print_Symbol(self, expr):
         if self._settings['name_mangling'] == True:
-            for sym in tuple(ordered(expr.atoms(Symbol))):
-                if sym not in self.mangled_symbols:
-                    name = sym.name
-                    while name.lower() in self.used_name:
-                        name += '_'
-                    self.used_name.append(name.lower())
-                    if name == sym.name:
-                        self.mangled_symbols[sym] = sym
-                    else:
-                        self.mangled_symbols[sym] = symbols(name, cls=sym.__class__, **sym.assumptions0)
+            if expr not in self.mangled_symbols:
+                name = expr.name
+                while name.lower() in self.used_name:
+                    name += '_'
+                self.used_name.append(name.lower())
+                if name == expr.name:
+                    self.mangled_symbols[expr] = expr
+                else:
+                    self.mangled_symbols[expr] = Symbol(name)
 
             expr = expr.xreplace(self.mangled_symbols)
 

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -535,14 +535,12 @@ class FCodePrinter(CodePrinter):
         return new_code
 
 
-def fcode(fob, expr, assign_to = None, **settings):
+def fcode(expr, assign_to = None, **settings):
     """Converts an expr to a string of fortran code
 
     Parameters
     ==========
 
-    fob : FCodePrinter
-        A FCodePrinter instance.
     expr : Expr
         A sympy expression to be converted.
     assign_to : optional
@@ -577,7 +575,7 @@ def fcode(fob, expr, assign_to = None, **settings):
         Note that currently the only distinction internally is between
         standards before 95, and those 95 and after. This may change later as
         more features are added.
-    mangled_symbols : bool, optional
+    name_mangling : bool, optional
         If True, then variables (which would have been identical in
         case-insensitive Fortan) are mangled by appending different number
         of `_` at the end. If False, SymPy won't interfere with naming of
@@ -587,12 +585,10 @@ def fcode(fob, expr, assign_to = None, **settings):
     ========
 
     >>> from sympy import fcode, symbols, Rational, sin, ceiling, floor
-    >>> from sympy.printing.fcode import FCodePrinter
-    >>> ob = FCodePrinter()
     >>> x, tau = symbols("x, tau")
-    >>> fcode(ob, (2*tau)**Rational(7, 2))
+    >>> fcode((2*tau)**Rational(7, 2))
     '      8*sqrt(2.0d0)*tau**(7.0d0/2.0d0)'
-    >>> fcode(ob, sin(x), assign_to="s")
+    >>> fcode(sin(x), assign_to="s")
     '      s = sin(x)'
 
     Custom printing can be defined for certain types by passing a dictionary of
@@ -605,8 +601,18 @@ def fcode(fob, expr, assign_to = None, **settings):
     ...   "floor": [(lambda x: not x.is_integer, "FLOOR1"),
     ...             (lambda x: x.is_integer, "FLOOR2")]
     ... }
-    >>> fcode(ob, floor(x) + ceiling(x), user_functions=custom_functions)
+    >>> fcode(floor(x) + ceiling(x), user_functions=custom_functions)
     '      CEIL(x) + FLOOR1(x)'
+
+    Returned Fortan code can have different variables in comparison to ``expr``
+    whenever there are similar variables with different case.Name mangling
+    can be stopped by setting ``name_mangling`` to ``False``.
+
+    >>> Z, z = symbols('Z,z')
+    >>> fcode(Z - z)
+    '      Z - z_'
+    >>> fcode(Z - z, name_mangling= False)
+    '      Z - z'
 
     ``Piecewise`` expressions are converted into conditionals. If an
     ``assign_to`` variable is provided an if statement is created, otherwise
@@ -617,7 +623,7 @@ def fcode(fob, expr, assign_to = None, **settings):
 
     >>> from sympy import Piecewise
     >>> expr = Piecewise((x + 1, x > 0), (x, True))
-    >>> print(fcode(ob, expr, tau))
+    >>> print(fcode(expr, tau))
           if (x > 0) then
              tau = x + 1
           else
@@ -636,7 +642,7 @@ def fcode(fob, expr, assign_to = None, **settings):
     >>> Dy = IndexedBase('Dy', shape=(len_y-1,))
     >>> i = Idx('i', len_y-1)
     >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
-    >>> fcode(ob, e.rhs, assign_to=e.lhs, contract=False)
+    >>> fcode(e.rhs, assign_to=e.lhs, contract=False)
     '      Dy(i) = (y(i + 1) - y(i))/(t(i + 1) - t(i))'
 
     Matrices are also supported, but a ``MatrixSymbol`` of the same dimensions
@@ -646,7 +652,7 @@ def fcode(fob, expr, assign_to = None, **settings):
     >>> from sympy import Matrix, MatrixSymbol
     >>> mat = Matrix([x**2, Piecewise((x + 1, x > 0), (x, True)), sin(x)])
     >>> A = MatrixSymbol('A', 3, 1)
-    >>> print(fcode(ob, mat, A))
+    >>> print(fcode(mat, A))
           A(1, 1) = x**2
              if (x > 0) then
           A(2, 1) = x + 1
@@ -655,7 +661,8 @@ def fcode(fob, expr, assign_to = None, **settings):
              end if
           A(3, 1) = sin(x)
     """
-    return FCodePrinter(settings, fob.mangled_symbols).doprint(expr, assign_to)
+
+    return FCodePrinter(settings).doprint(expr, assign_to)
 
 
 def print_fcode(expr, **settings):

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -1,7 +1,6 @@
 from sympy import (sin, cos, atan2, log, exp, gamma, conjugate, sqrt,
     factorial, Integral, Piecewise, Add, diff, symbols, S, Float, Dummy, Eq,
-    Range, Catalan, EulerGamma, E, GoldenRatio, I, pi, Function, Rational, Integer, Lambda, sign,
-    Max, Min)
+    Range, Catalan, EulerGamma, E, GoldenRatio, I, pi, Function, Rational, Integer, Lambda, sign)
 
 from sympy.codegen import For, Assignment
 from sympy.codegen.ast import Declaration, Type, Variable, float32, float64, value_const, real, bool_
@@ -14,8 +13,6 @@ from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.matrices import Matrix, MatrixSymbol
 
-dub = FCodePrinter()
-
 
 def test_printmethod():
     x = symbols('x')
@@ -23,69 +20,68 @@ def test_printmethod():
     class nint(Function):
         def _fcode(self, printer):
             return "nint(%s)" % printer._print(self.args[0])
-    assert fcode(dub, nint(x)) == "      nint(x)"
+    assert fcode(nint(x)) == "      nint(x)"
 
 
 def test_fcode_sign():  #issue 12267
     x=symbols('x')
     y=symbols('y', integer=True)
     z=symbols('z', complex=True)
-    assert fcode(dub, sign(x), standard=95, source_format='free') == "merge(0d0, dsign(1d0, x), x == 0d0)"
-    assert fcode(dub, sign(y), standard=95, source_format='free') == "merge(0, isign(1, y), y == 0)"
-    assert fcode(dub, sign(z), standard=95, source_format='free') == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
-    raises(NotImplementedError, lambda: fcode(dub, sign(x)))
+    assert fcode(sign(x), standard=95, source_format='free') == "merge(0d0, dsign(1d0, x), x == 0d0)"
+    assert fcode(sign(y), standard=95, source_format='free') == "merge(0, isign(1, y), y == 0)"
+    assert fcode(sign(z), standard=95, source_format='free') == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
+    raises(NotImplementedError, lambda: fcode(sign(x)))
 
 
 def test_fcode_Pow():
     x, y = symbols('x,y')
     n = symbols('n', integer=True)
 
-    assert fcode(dub, x**3) == "      x**3"
-    assert fcode(dub, x**(y**3)) == "      x**(y**3)"
-    assert fcode(dub, 1/(sin(x)*3.5)**(x - y**x)/(x**2 + y)) == \
+    assert fcode(x**3) == "      x**3"
+    assert fcode(x**(y**3)) == "      x**(y**3)"
+    assert fcode(1/(sin(x)*3.5)**(x - y**x)/(x**2 + y)) == \
         "      (3.5d0*sin(x))**(-x + y**x)/(x**2 + y)"
-    assert fcode(dub, sqrt(x)) == '      sqrt(x)'
-    assert fcode(dub, sqrt(n)) == '      sqrt(dble(n))'
-    assert fcode(dub, x**0.5) == '      sqrt(x)'
-    assert fcode(dub, sqrt(x)) == '      sqrt(x)'
-    assert fcode(dub, sqrt(10)) == '      sqrt(10.0d0)'
-    assert fcode(dub, x**-1.0) == '      1.0/x'
-    assert fcode(dub, x**-2.0, 'y', source_format='free') == 'y = x**(-2.0d0)'  # 2823
-    assert fcode(dub, x**Rational(3, 7)) == '      x**(3.0d0/7.0d0)'
+    assert fcode(sqrt(x)) == '      sqrt(x)'
+    assert fcode(sqrt(n)) == '      sqrt(dble(n))'
+    assert fcode(x**0.5) == '      sqrt(x)'
+    assert fcode(sqrt(x)) == '      sqrt(x)'
+    assert fcode(sqrt(10)) == '      sqrt(10.0d0)'
+    assert fcode(x**-1.0) == '      1.0/x'
+    assert fcode(x**-2.0, 'y', source_format='free') == 'y = x**(-2.0d0)'  # 2823
+    assert fcode(x**Rational(3, 7)) == '      x**(3.0d0/7.0d0)'
 
 
 def test_fcode_Rational():
     x = symbols('x')
-    assert fcode(dub, Rational(3, 7)) == "      3.0d0/7.0d0"
-    assert fcode(dub, Rational(18, 9)) == "      2"
-    assert fcode(dub, Rational(3, -7)) == "      -3.0d0/7.0d0"
-    assert fcode(dub, Rational(-3, -7)) == "      3.0d0/7.0d0"
-    assert fcode(dub, x + Rational(3, 7)) == "      x + 3.0d0/7.0d0"
-    assert fcode(dub, Rational(3, 7)*x) == "      (3.0d0/7.0d0)*x"
+    assert fcode(Rational(3, 7)) == "      3.0d0/7.0d0"
+    assert fcode(Rational(18, 9)) == "      2"
+    assert fcode(Rational(3, -7)) == "      -3.0d0/7.0d0"
+    assert fcode(Rational(-3, -7)) == "      3.0d0/7.0d0"
+    assert fcode(x + Rational(3, 7)) == "      x + 3.0d0/7.0d0"
+    assert fcode(Rational(3, 7)*x) == "      (3.0d0/7.0d0)*x"
 
 
 def test_fcode_Integer():
-    assert fcode(dub, Integer(67)) == "      67"
-    assert fcode(dub, Integer(-1)) == "      -1"
+    assert fcode(Integer(67)) == "      67"
+    assert fcode(Integer(-1)) == "      -1"
 
 
 def test_fcode_Float():
-    assert fcode(dub, Float(42.0)) == "      42.0000000000000d0"
-    assert fcode(dub, Float(-1e20)) == "      -1.00000000000000d+20"
+    assert fcode(Float(42.0)) == "      42.0000000000000d0"
+    assert fcode(Float(-1e20)) == "      -1.00000000000000d+20"
 
 
 def test_fcode_functions():
     x, y = symbols('x,y')
-    assert fcode(dub, sin(x) ** cos(y)) == "      sin(x)**cos(y)"
-    assert fcode(dub, Max(x, y) + Min(x, y)) == "      max(x, y) + min(x, y)"
+    assert fcode(sin(x) ** cos(y)) == "      sin(x)**cos(y)"
 
 
 def test_case():
     x,x_,x__,y,X,X_,Y = symbols('x,x_,x__,y,X,X_,Y')
-    assert fcode(dub, exp(x_) + sin(x*y) + cos(X*Y)) == \
+    assert fcode(exp(x_) + sin(x*y) + cos(X*Y)) == \
                         '      exp(x_) + sin(x*y) + cos(X*Y)'
 
-    assert fcode(dub, exp(x__) + 2*x*Y*X_**Rational(7, 2)) == \
+    assert fcode(exp(x__) + 2*x*Y*X_**Rational(7, 2)) == \
                         '      2*X_**(7.0d0/2.0d0)*Y*x + exp(x__)'
 
 
@@ -94,95 +90,95 @@ def test_fcode_functions_with_integers():
     x= symbols('x')
     log10_17 = log(10).evalf(17)
     loglog10_17 = '0.8340324452479558d0'
-    assert fcode(dub, x * log(10)) == "      x*%sd0" % log10_17
-    assert fcode(dub, x * log(10)) == "      x*%sd0" % log10_17
-    assert fcode(dub, x * log(S(10))) == "      x*%sd0" % log10_17
-    assert fcode(dub, log(S(10))) == "      %sd0" % log10_17
-    assert fcode(dub, exp(10)) == "      %sd0" % exp(10).evalf(17)
-    assert fcode(dub, x * log(log(10))) == "      x*%s" % loglog10_17
-    assert fcode(dub, x * log(log(S(10)))) == "      x*%s" % loglog10_17
+    assert fcode(x * log(10)) == "      x*%sd0" % log10_17
+    assert fcode(x * log(10)) == "      x*%sd0" % log10_17
+    assert fcode(x * log(S(10))) == "      x*%sd0" % log10_17
+    assert fcode(log(S(10))) == "      %sd0" % log10_17
+    assert fcode(exp(10)) == "      %sd0" % exp(10).evalf(17)
+    assert fcode(x * log(log(10))) == "      x*%s" % loglog10_17
+    assert fcode(x * log(log(S(10)))) == "      x*%s" % loglog10_17
 
 
 def test_fcode_NumberSymbol():
     prec = 17
     p = FCodePrinter()
-    assert fcode(dub, Catalan) == '      parameter (Catalan = %sd0)\n      Catalan' % Catalan.evalf(prec)
-    assert fcode(dub, EulerGamma) == '      parameter (EulerGamma = %sd0)\n      EulerGamma' % EulerGamma.evalf(prec)
-    assert fcode(dub, E) == '      parameter (E = %sd0)\n      E' % E.evalf(prec)
-    assert fcode(dub, GoldenRatio) == '      parameter (GoldenRatio = %sd0)\n      GoldenRatio' % GoldenRatio.evalf(prec)
-    assert fcode(dub, pi) == '      parameter (pi = %sd0)\n      pi' % pi.evalf(prec)
-    assert fcode(dub,
+    assert fcode(Catalan) == '      parameter (Catalan = %sd0)\n      Catalan' % Catalan.evalf(prec)
+    assert fcode(EulerGamma) == '      parameter (EulerGamma = %sd0)\n      EulerGamma' % EulerGamma.evalf(prec)
+    assert fcode(E) == '      parameter (E = %sd0)\n      E' % E.evalf(prec)
+    assert fcode(GoldenRatio) == '      parameter (GoldenRatio = %sd0)\n      GoldenRatio' % GoldenRatio.evalf(prec)
+    assert fcode(pi) == '      parameter (pi = %sd0)\n      pi' % pi.evalf(prec)
+    assert fcode(
         pi, precision=5) == '      parameter (pi = %sd0)\n      pi' % pi.evalf(5)
-    assert fcode(dub, Catalan, human=False) == (set(
+    assert fcode(Catalan, human=False) == (set(
         [(Catalan, p._print(Catalan.evalf(prec)))]), set([]), '      Catalan')
-    assert fcode(dub, EulerGamma, human=False) == (set([(EulerGamma, p._print(
+    assert fcode(EulerGamma, human=False) == (set([(EulerGamma, p._print(
         EulerGamma.evalf(prec)))]), set([]), '      EulerGamma')
-    assert fcode(dub, E, human=False) == (
+    assert fcode(E, human=False) == (
         set([(E, p._print(E.evalf(prec)))]), set([]), '      E')
-    assert fcode(dub, GoldenRatio, human=False) == (set([(GoldenRatio, p._print(
+    assert fcode(GoldenRatio, human=False) == (set([(GoldenRatio, p._print(
         GoldenRatio.evalf(prec)))]), set([]), '      GoldenRatio')
-    assert fcode(dub, pi, human=False) == (
+    assert fcode(pi, human=False) == (
         set([(pi, p._print(pi.evalf(prec)))]), set([]), '      pi')
-    assert fcode(dub, pi, precision=5, human=False) == (
+    assert fcode(pi, precision=5, human=False) == (
         set([(pi, p._print(pi.evalf(5)))]), set([]), '      pi')
 
 
 def test_fcode_complex():
-    assert fcode(dub, I) == "      cmplx(0,1)"
+    assert fcode(I) == "      cmplx(0,1)"
     x = symbols('x')
-    assert fcode(dub, 4*I) == "      cmplx(0,4)"
-    assert fcode(dub, 3 + 4*I) == "      cmplx(3,4)"
-    assert fcode(dub, 3 + 4*I + x) == "      cmplx(3,4) + x"
-    assert fcode(dub, I*x) == "      cmplx(0,1)*x"
-    assert fcode(dub, 3 + 4*I - x) == "      cmplx(3,4) - x"
+    assert fcode(4*I) == "      cmplx(0,4)"
+    assert fcode(3 + 4*I) == "      cmplx(3,4)"
+    assert fcode(3 + 4*I + x) == "      cmplx(3,4) + x"
+    assert fcode(I*x) == "      cmplx(0,1)*x"
+    assert fcode(3 + 4*I - x) == "      cmplx(3,4) - x"
     x = symbols('x', imaginary=True)
-    assert fcode(dub, 5*x) == "      5*x"
-    assert fcode(dub, I*x) == "      cmplx(0,1)*x"
-    assert fcode(dub, 3 + x) == "      x + 3"
+    assert fcode(5*x) == "      5*x"
+    assert fcode(I*x) == "      cmplx(0,1)*x"
+    assert fcode(3 + x) == "      x + 3"
 
 
 def test_implicit():
     x, y = symbols('x,y')
-    assert fcode(dub, sin(x)) == "      sin(x)"
-    assert fcode(dub, atan2(x, y)) == "      atan2(x, y)"
-    assert fcode(dub, conjugate(x)) == "      conjg(x)"
+    assert fcode(sin(x)) == "      sin(x)"
+    assert fcode(atan2(x, y)) == "      atan2(x, y)"
+    assert fcode(conjugate(x)) == "      conjg(x)"
 
 
 def test_not_fortran():
     x = symbols('x')
     g = Function('g')
-    assert fcode(dub,
+    assert fcode(
         gamma(x)) == "C     Not supported in Fortran:\nC     gamma\n      gamma(x)"
-    assert fcode(dub, Integral(sin(x))) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
-    assert fcode(dub, g(x)) == "C     Not supported in Fortran:\nC     g\n      g(x)"
+    assert fcode(Integral(sin(x))) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
+    assert fcode(g(x)) == "C     Not supported in Fortran:\nC     g\n      g(x)"
 
 
 def test_user_functions():
     x = symbols('x')
-    assert fcode(dub, sin(x), user_functions={"sin": "zsin"}) == "      zsin(x)"
+    assert fcode(sin(x), user_functions={"sin": "zsin"}) == "      zsin(x)"
     x = symbols('x')
-    assert fcode(dub,
+    assert fcode(
         gamma(x), user_functions={"gamma": "mygamma"}) == "      mygamma(x)"
     g = Function('g')
-    assert fcode(dub, g(x), user_functions={"g": "great"}) == "      great(x)"
+    assert fcode(g(x), user_functions={"g": "great"}) == "      great(x)"
     n = symbols('n', integer=True)
-    assert fcode(dub,
+    assert fcode(
         factorial(n), user_functions={"factorial": "fct"}) == "      fct(n)"
 
 
 def test_inline_function():
     x = symbols('x')
     g = implemented_function('g', Lambda(x, 2*x))
-    assert fcode(dub, g(x)) == "      2*x"
+    assert fcode(g(x)) == "      2*x"
     g = implemented_function('g', Lambda(x, 2*pi/x))
-    assert fcode(dub, g(x)) == (
+    assert fcode(g(x)) == (
         "      parameter (pi = %sd0)\n"
         "      2*pi/x"
     ) % pi.evalf(17)
     A = IndexedBase('A')
     i = Idx('i', symbols('n', integer=True))
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
-    assert fcode(dub, g(A[i]), assign_to=A[i]) == (
+    assert fcode(g(A[i]), assign_to=A[i]) == (
         "      do i = 1, n\n"
         "         A(i) = (A(i) + 1)*(A(i) + 2)*A(i)\n"
         "      end do"
@@ -191,18 +187,18 @@ def test_inline_function():
 
 def test_assign_to():
     x = symbols('x')
-    assert fcode(dub, sin(x), assign_to="s") == "      s = sin(x)"
+    assert fcode(sin(x), assign_to="s") == "      s = sin(x)"
 
 
 def test_line_wrapping():
     x, y = symbols('x,y')
-    assert fcode(dub, ((x + y)**10).expand(), assign_to="var") == (
+    assert fcode(((x + y)**10).expand(), assign_to="var") == (
         "      var = x**10 + 10*x**9*y + 45*x**8*y**2 + 120*x**7*y**3 + 210*x**6*\n"
         "     @ y**4 + 252*x**5*y**5 + 210*x**4*y**6 + 120*x**3*y**7 + 45*x**2*y\n"
         "     @ **8 + 10*x*y**9 + y**10"
     )
     e = [x**i for i in range(11)]
-    assert fcode(dub, Add(*e)) == (
+    assert fcode(Add(*e)) == (
         "      x**10 + x**9 + x**8 + x**7 + x**6 + x**5 + x**4 + x**3 + x**2 + x\n"
         "     @ + 1"
     )
@@ -210,183 +206,183 @@ def test_line_wrapping():
 
 def test_fcode_precedence():
     x, y = symbols("x y")
-    assert fcode(dub, And(x < y, y < x + 1), source_format="free") == \
+    assert fcode(And(x < y, y < x + 1), source_format="free") == \
         "x < y .and. y < x + 1"
-    assert fcode(dub, Or(x < y, y < x + 1), source_format="free") == \
+    assert fcode(Or(x < y, y < x + 1), source_format="free") == \
         "x < y .or. y < x + 1"
-    assert fcode(dub, Xor(x < y, y < x + 1, evaluate=False),
+    assert fcode(Xor(x < y, y < x + 1, evaluate=False),
         source_format="free") == "x < y .neqv. y < x + 1"
-    assert fcode(dub, Equivalent(x < y, y < x + 1), source_format="free") == \
+    assert fcode(Equivalent(x < y, y < x + 1), source_format="free") == \
         "x < y .eqv. y < x + 1"
 
 
 def test_fcode_Logical():
     x, y, z = symbols("x y z")
     # unary Not
-    assert fcode(dub, Not(x), source_format="free") == ".not. x"
+    assert fcode(Not(x), source_format="free") == ".not. x"
     # binary And
-    assert fcode(dub, And(x, y), source_format="free") == "x .and. y"
-    assert fcode(dub, And(x, Not(y)), source_format="free") == "x .and. .not. y"
-    assert fcode(dub, And(Not(x), y), source_format="free") == "y .and. .not. x"
-    assert fcode(dub, And(Not(x), Not(y)), source_format="free") == \
+    assert fcode(And(x, y), source_format="free") == "x .and. y"
+    assert fcode(And(x, Not(y)), source_format="free") == "x .and. .not. y"
+    assert fcode(And(Not(x), y), source_format="free") == "y .and. .not. x"
+    assert fcode(And(Not(x), Not(y)), source_format="free") == \
         ".not. x .and. .not. y"
-    assert fcode(dub, Not(And(x, y), evaluate=False), source_format="free") == \
+    assert fcode(Not(And(x, y), evaluate=False), source_format="free") == \
         ".not. (x .and. y)"
     # binary Or
-    assert fcode(dub, Or(x, y), source_format="free") == "x .or. y"
-    assert fcode(dub, Or(x, Not(y)), source_format="free") == "x .or. .not. y"
-    assert fcode(dub, Or(Not(x), y), source_format="free") == "y .or. .not. x"
-    assert fcode(dub, Or(Not(x), Not(y)), source_format="free") == \
+    assert fcode(Or(x, y), source_format="free") == "x .or. y"
+    assert fcode(Or(x, Not(y)), source_format="free") == "x .or. .not. y"
+    assert fcode(Or(Not(x), y), source_format="free") == "y .or. .not. x"
+    assert fcode(Or(Not(x), Not(y)), source_format="free") == \
         ".not. x .or. .not. y"
-    assert fcode(dub, Not(Or(x, y), evaluate=False), source_format="free") == \
+    assert fcode(Not(Or(x, y), evaluate=False), source_format="free") == \
         ".not. (x .or. y)"
     # mixed And/Or
-    assert fcode(dub, And(Or(y, z), x), source_format="free") == "x .and. (y .or. z)"
-    assert fcode(dub, And(Or(z, x), y), source_format="free") == "y .and. (x .or. z)"
-    assert fcode(dub, And(Or(x, y), z), source_format="free") == "z .and. (x .or. y)"
-    assert fcode(dub, Or(And(y, z), x), source_format="free") == "x .or. y .and. z"
-    assert fcode(dub, Or(And(z, x), y), source_format="free") == "y .or. x .and. z"
-    assert fcode(dub, Or(And(x, y), z), source_format="free") == "z .or. x .and. y"
+    assert fcode(And(Or(y, z), x), source_format="free") == "x .and. (y .or. z)"
+    assert fcode(And(Or(z, x), y), source_format="free") == "y .and. (x .or. z)"
+    assert fcode(And(Or(x, y), z), source_format="free") == "z .and. (x .or. y)"
+    assert fcode(Or(And(y, z), x), source_format="free") == "x .or. y .and. z"
+    assert fcode(Or(And(z, x), y), source_format="free") == "y .or. x .and. z"
+    assert fcode(Or(And(x, y), z), source_format="free") == "z .or. x .and. y"
     # trinary And
-    assert fcode(dub, And(x, y, z), source_format="free") == "x .and. y .and. z"
-    assert fcode(dub, And(x, y, Not(z)), source_format="free") == \
+    assert fcode(And(x, y, z), source_format="free") == "x .and. y .and. z"
+    assert fcode(And(x, y, Not(z)), source_format="free") == \
         "x .and. y .and. .not. z"
-    assert fcode(dub, And(x, Not(y), z), source_format="free") == \
+    assert fcode(And(x, Not(y), z), source_format="free") == \
         "x .and. z .and. .not. y"
-    assert fcode(dub, And(Not(x), y, z), source_format="free") == \
+    assert fcode(And(Not(x), y, z), source_format="free") == \
         "y .and. z .and. .not. x"
-    assert fcode(dub, Not(And(x, y, z), evaluate=False), source_format="free") == \
+    assert fcode(Not(And(x, y, z), evaluate=False), source_format="free") == \
         ".not. (x .and. y .and. z)"
     # trinary Or
-    assert fcode(dub, Or(x, y, z), source_format="free") == "x .or. y .or. z"
-    assert fcode(dub, Or(x, y, Not(z)), source_format="free") == \
+    assert fcode(Or(x, y, z), source_format="free") == "x .or. y .or. z"
+    assert fcode(Or(x, y, Not(z)), source_format="free") == \
         "x .or. y .or. .not. z"
-    assert fcode(dub, Or(x, Not(y), z), source_format="free") == \
+    assert fcode(Or(x, Not(y), z), source_format="free") == \
         "x .or. z .or. .not. y"
-    assert fcode(dub, Or(Not(x), y, z), source_format="free") == \
+    assert fcode(Or(Not(x), y, z), source_format="free") == \
         "y .or. z .or. .not. x"
-    assert fcode(dub, Not(Or(x, y, z), evaluate=False), source_format="free") == \
+    assert fcode(Not(Or(x, y, z), evaluate=False), source_format="free") == \
         ".not. (x .or. y .or. z)"
 
 
 def test_fcode_Xlogical():
     x, y, z = symbols("x y z")
     # binary Xor
-    assert fcode(dub, Xor(x, y, evaluate=False), source_format="free") == \
+    assert fcode(Xor(x, y, evaluate=False), source_format="free") == \
         "x .neqv. y"
-    assert fcode(dub, Xor(x, Not(y), evaluate=False), source_format="free") == \
+    assert fcode(Xor(x, Not(y), evaluate=False), source_format="free") == \
         "x .neqv. .not. y"
-    assert fcode(dub, Xor(Not(x), y, evaluate=False), source_format="free") == \
+    assert fcode(Xor(Not(x), y, evaluate=False), source_format="free") == \
         "y .neqv. .not. x"
-    assert fcode(dub, Xor(Not(x), Not(y), evaluate=False),
+    assert fcode(Xor(Not(x), Not(y), evaluate=False),
         source_format="free") == ".not. x .neqv. .not. y"
-    assert fcode(dub, Not(Xor(x, y, evaluate=False), evaluate=False),
+    assert fcode(Not(Xor(x, y, evaluate=False), evaluate=False),
         source_format="free") == ".not. (x .neqv. y)"
     # binary Equivalent
-    assert fcode(dub, Equivalent(x, y), source_format="free") == "x .eqv. y"
-    assert fcode(dub, Equivalent(x, Not(y)), source_format="free") == \
+    assert fcode(Equivalent(x, y), source_format="free") == "x .eqv. y"
+    assert fcode(Equivalent(x, Not(y)), source_format="free") == \
         "x .eqv. .not. y"
-    assert fcode(dub, Equivalent(Not(x), y), source_format="free") == \
+    assert fcode(Equivalent(Not(x), y), source_format="free") == \
         "y .eqv. .not. x"
-    assert fcode(dub, Equivalent(Not(x), Not(y)), source_format="free") == \
+    assert fcode(Equivalent(Not(x), Not(y)), source_format="free") == \
         ".not. x .eqv. .not. y"
-    assert fcode(dub, Not(Equivalent(x, y), evaluate=False),
+    assert fcode(Not(Equivalent(x, y), evaluate=False),
         source_format="free") == ".not. (x .eqv. y)"
     # mixed And/Equivalent
-    assert fcode(dub, Equivalent(And(y, z), x), source_format="free") == \
+    assert fcode(Equivalent(And(y, z), x), source_format="free") == \
         "x .eqv. y .and. z"
-    assert fcode(dub, Equivalent(And(z, x), y), source_format="free") == \
+    assert fcode(Equivalent(And(z, x), y), source_format="free") == \
         "y .eqv. x .and. z"
-    assert fcode(dub, Equivalent(And(x, y), z), source_format="free") == \
+    assert fcode(Equivalent(And(x, y), z), source_format="free") == \
         "z .eqv. x .and. y"
-    assert fcode(dub, And(Equivalent(y, z), x), source_format="free") == \
+    assert fcode(And(Equivalent(y, z), x), source_format="free") == \
         "x .and. (y .eqv. z)"
-    assert fcode(dub, And(Equivalent(z, x), y), source_format="free") == \
+    assert fcode(And(Equivalent(z, x), y), source_format="free") == \
         "y .and. (x .eqv. z)"
-    assert fcode(dub, And(Equivalent(x, y), z), source_format="free") == \
+    assert fcode(And(Equivalent(x, y), z), source_format="free") == \
         "z .and. (x .eqv. y)"
     # mixed Or/Equivalent
-    assert fcode(dub, Equivalent(Or(y, z), x), source_format="free") == \
+    assert fcode(Equivalent(Or(y, z), x), source_format="free") == \
         "x .eqv. y .or. z"
-    assert fcode(dub, Equivalent(Or(z, x), y), source_format="free") == \
+    assert fcode(Equivalent(Or(z, x), y), source_format="free") == \
         "y .eqv. x .or. z"
-    assert fcode(dub, Equivalent(Or(x, y), z), source_format="free") == \
+    assert fcode(Equivalent(Or(x, y), z), source_format="free") == \
         "z .eqv. x .or. y"
-    assert fcode(dub, Or(Equivalent(y, z), x), source_format="free") == \
+    assert fcode(Or(Equivalent(y, z), x), source_format="free") == \
         "x .or. (y .eqv. z)"
-    assert fcode(dub, Or(Equivalent(z, x), y), source_format="free") == \
+    assert fcode(Or(Equivalent(z, x), y), source_format="free") == \
         "y .or. (x .eqv. z)"
-    assert fcode(dub, Or(Equivalent(x, y), z), source_format="free") == \
+    assert fcode(Or(Equivalent(x, y), z), source_format="free") == \
         "z .or. (x .eqv. y)"
     # mixed Xor/Equivalent
-    assert fcode(dub, Equivalent(Xor(y, z, evaluate=False), x),
+    assert fcode(Equivalent(Xor(y, z, evaluate=False), x),
         source_format="free") == "x .eqv. (y .neqv. z)"
-    assert fcode(dub, Equivalent(Xor(z, x, evaluate=False), y),
+    assert fcode(Equivalent(Xor(z, x, evaluate=False), y),
         source_format="free") == "y .eqv. (x .neqv. z)"
-    assert fcode(dub, Equivalent(Xor(x, y, evaluate=False), z),
+    assert fcode(Equivalent(Xor(x, y, evaluate=False), z),
         source_format="free") == "z .eqv. (x .neqv. y)"
-    assert fcode(dub, Xor(Equivalent(y, z), x, evaluate=False),
+    assert fcode(Xor(Equivalent(y, z), x, evaluate=False),
         source_format="free") == "x .neqv. (y .eqv. z)"
-    assert fcode(dub, Xor(Equivalent(z, x), y, evaluate=False),
+    assert fcode(Xor(Equivalent(z, x), y, evaluate=False),
         source_format="free") == "y .neqv. (x .eqv. z)"
-    assert fcode(dub, Xor(Equivalent(x, y), z, evaluate=False),
+    assert fcode(Xor(Equivalent(x, y), z, evaluate=False),
         source_format="free") == "z .neqv. (x .eqv. y)"
     # mixed And/Xor
-    assert fcode(dub, Xor(And(y, z), x, evaluate=False), source_format="free") == \
+    assert fcode(Xor(And(y, z), x, evaluate=False), source_format="free") == \
         "x .neqv. y .and. z"
-    assert fcode(dub, Xor(And(z, x), y, evaluate=False), source_format="free") == \
+    assert fcode(Xor(And(z, x), y, evaluate=False), source_format="free") == \
         "y .neqv. x .and. z"
-    assert fcode(dub, Xor(And(x, y), z, evaluate=False), source_format="free") == \
+    assert fcode(Xor(And(x, y), z, evaluate=False), source_format="free") == \
         "z .neqv. x .and. y"
-    assert fcode(dub, And(Xor(y, z, evaluate=False), x), source_format="free") == \
+    assert fcode(And(Xor(y, z, evaluate=False), x), source_format="free") == \
         "x .and. (y .neqv. z)"
-    assert fcode(dub, And(Xor(z, x, evaluate=False), y), source_format="free") == \
+    assert fcode(And(Xor(z, x, evaluate=False), y), source_format="free") == \
         "y .and. (x .neqv. z)"
-    assert fcode(dub, And(Xor(x, y, evaluate=False), z), source_format="free") == \
+    assert fcode(And(Xor(x, y, evaluate=False), z), source_format="free") == \
         "z .and. (x .neqv. y)"
     # mixed Or/Xor
-    assert fcode(dub, Xor(Or(y, z), x, evaluate=False), source_format="free") == \
+    assert fcode(Xor(Or(y, z), x, evaluate=False), source_format="free") == \
         "x .neqv. y .or. z"
-    assert fcode(dub, Xor(Or(z, x), y, evaluate=False), source_format="free") == \
+    assert fcode(Xor(Or(z, x), y, evaluate=False), source_format="free") == \
         "y .neqv. x .or. z"
-    assert fcode(dub, Xor(Or(x, y), z, evaluate=False), source_format="free") == \
+    assert fcode(Xor(Or(x, y), z, evaluate=False), source_format="free") == \
         "z .neqv. x .or. y"
-    assert fcode(dub, Or(Xor(y, z, evaluate=False), x), source_format="free") == \
+    assert fcode(Or(Xor(y, z, evaluate=False), x), source_format="free") == \
         "x .or. (y .neqv. z)"
-    assert fcode(dub, Or(Xor(z, x, evaluate=False), y), source_format="free") == \
+    assert fcode(Or(Xor(z, x, evaluate=False), y), source_format="free") == \
         "y .or. (x .neqv. z)"
-    assert fcode(dub, Or(Xor(x, y, evaluate=False), z), source_format="free") == \
+    assert fcode(Or(Xor(x, y, evaluate=False), z), source_format="free") == \
         "z .or. (x .neqv. y)"
     # trinary Xor
-    assert fcode(dub, Xor(x, y, z, evaluate=False), source_format="free") == \
+    assert fcode(Xor(x, y, z, evaluate=False), source_format="free") == \
         "x .neqv. y .neqv. z"
-    assert fcode(dub, Xor(x, y, Not(z), evaluate=False), source_format="free") == \
+    assert fcode(Xor(x, y, Not(z), evaluate=False), source_format="free") == \
         "x .neqv. y .neqv. .not. z"
-    assert fcode(dub, Xor(x, Not(y), z, evaluate=False), source_format="free") == \
+    assert fcode(Xor(x, Not(y), z, evaluate=False), source_format="free") == \
         "x .neqv. z .neqv. .not. y"
-    assert fcode(dub, Xor(Not(x), y, z, evaluate=False), source_format="free") == \
+    assert fcode(Xor(Not(x), y, z, evaluate=False), source_format="free") == \
         "y .neqv. z .neqv. .not. x"
 
 
 def test_fcode_Relational():
     x, y = symbols("x y")
-    assert fcode(dub, Relational(x, y, "=="), source_format="free") == "x == y"
-    assert fcode(dub, Relational(x, y, "!="), source_format="free") == "x /= y"
-    assert fcode(dub, Relational(x, y, ">="), source_format="free") == "x >= y"
-    assert fcode(dub, Relational(x, y, "<="), source_format="free") == "x <= y"
-    assert fcode(dub, Relational(x, y, ">"), source_format="free") == "x > y"
-    assert fcode(dub, Relational(x, y, "<"), source_format="free") == "x < y"
+    assert fcode(Relational(x, y, "=="), source_format="free") == "x == y"
+    assert fcode(Relational(x, y, "!="), source_format="free") == "x /= y"
+    assert fcode(Relational(x, y, ">="), source_format="free") == "x >= y"
+    assert fcode(Relational(x, y, "<="), source_format="free") == "x <= y"
+    assert fcode(Relational(x, y, ">"), source_format="free") == "x > y"
+    assert fcode(Relational(x, y, "<"), source_format="free") == "x < y"
 
 
 def test_fcode_Piecewise():
     x = symbols('x')
     expr = Piecewise((x, x < 1), (x**2, True))
     # Check that inline conditional (merge) fails if standard isn't 95+
-    raises(NotImplementedError, lambda: fcode(dub, expr))
-    code = fcode(dub, expr, standard=95)
+    raises(NotImplementedError, lambda: fcode(expr))
+    code = fcode(expr, standard=95)
     expected = "      merge(x, x**2, x < 1)"
     assert code == expected
-    assert fcode(dub, Piecewise((x, x < 1), (x**2, True)), assign_to="var") == (
+    assert fcode(Piecewise((x, x < 1), (x**2, True)), assign_to="var") == (
         "      if (x < 1) then\n"
         "         var = x\n"
         "      else\n"
@@ -411,14 +407,14 @@ def test_fcode_Piecewise():
         "     @ )/x**10 + 3628800*sin(x)/x**11\n"
         "      end if"
     )
-    code = fcode(dub, Piecewise((a, x < 0), (b, True)), assign_to="weird_name")
+    code = fcode(Piecewise((a, x < 0), (b, True)), assign_to="weird_name")
     assert code == expected
-    code = fcode(dub, Piecewise((x, x < 1), (x**2, x > 1), (sin(x), True)), standard=95)
+    code = fcode(Piecewise((x, x < 1), (x**2, x > 1), (sin(x), True)), standard=95)
     expected = "      merge(x, merge(x**2, sin(x), x > 1), x < 1)"
     assert code == expected
     # Check that Piecewise without a True (default) condition error
     expr = Piecewise((x, x < 1), (x**2, x > 1), (sin(x), x > 0))
-    raises(ValueError, lambda: fcode(dub, expr))
+    raises(ValueError, lambda: fcode(expr))
 
 
 def test_wrap_fortran():
@@ -508,17 +504,17 @@ def test_wrap_fortran_keep_d0():
 
 
 def test_settings():
-    raises(TypeError, lambda: fcode(dub, S(4), method="garbage"))
+    raises(TypeError, lambda: fcode(S(4), method="garbage"))
 
 
 def test_free_form_code_line():
     x, y = symbols('x,y')
-    assert fcode(dub, cos(x) + sin(y), source_format='free') == "sin(y) + cos(x)"
+    assert fcode(cos(x) + sin(y), source_format='free') == "sin(y) + cos(x)"
 
 
 def test_free_form_continuation_line():
     x, y = symbols('x,y')
-    result = fcode(dub, ((cos(x) + sin(y))**(7)).expand(), source_format='free')
+    result = fcode(((cos(x) + sin(y))**(7)).expand(), source_format='free')
     expected = (
         'sin(y)**7 + 7*sin(y)**6*cos(x) + 21*sin(y)**5*cos(x)**2 + 35*sin(y)**4* &\n'
         '      cos(x)**3 + 35*sin(y)**3*cos(x)**4 + 21*sin(y)**2*cos(x)**5 + 7* &\n'
@@ -555,7 +551,7 @@ def test_loops():
         'end do'
     )
 
-    code = fcode(dub, A[i, j]*x[j], assign_to=y[i], source_format='free')
+    code = fcode(A[i, j]*x[j], assign_to=y[i], source_format='free')
     assert (code == expected % {'rhs': 'y(i) + A(i, j)*x(j)'} or
             code == expected % {'rhs': 'y(i) + x(j)*A(i, j)'} or
             code == expected % {'rhs': 'x(j)*A(i, j) + y(i)'} or
@@ -573,7 +569,7 @@ def test_dummy_loops():
         '   y(i_%(icount)i) = x(i_%(icount)i)\n'
         'end do'
     ) % {'icount': i.label.dummy_index, 'mcount': m.dummy_index}
-    code = fcode(dub, x[i], assign_to=y[i], source_format='free')
+    code = fcode(x[i], assign_to=y[i], source_format='free')
     assert code == expected
 
 def test_fcode_Indexed_without_looking_for_contraction():
@@ -583,7 +579,7 @@ def test_fcode_Indexed_without_looking_for_contraction():
     Dy = IndexedBase('Dy', shape=(len_y-1,))
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
-    code0 = fcode(dub, e.rhs, assign_to=e.lhs, contract=False)
+    code0 = fcode(e.rhs, assign_to=e.lhs, contract=False)
     assert code0.endswith('Dy(i) = (y(i + 1) - y(i))/(x(i + 1) - x(i))')
 
 
@@ -664,7 +660,7 @@ def test_Matrix_printing():
     # Test returning a Matrix
     mat = Matrix([x*y, Piecewise((2 + x, y>0), (y, True)), sin(z)])
     A = MatrixSymbol('A', 3, 1)
-    assert fcode(dub, mat, A) == (
+    assert fcode(mat, A) == (
         "      A(1, 1) = x*y\n"
         "      if (y > 0) then\n"
         "         A(2, 1) = x + 2\n"
@@ -674,7 +670,7 @@ def test_Matrix_printing():
         "      A(3, 1) = sin(z)")
     # Test using MatrixElements in expressions
     expr = Piecewise((2*A[2, 0], x > 0), (A[2, 0], True)) + sin(A[1, 0]) + A[0, 0]
-    assert fcode(dub, expr, standard=95) == (
+    assert fcode(expr, standard=95) == (
         "      merge(2*A(3, 1), A(3, 1), x > 0) + sin(A(2, 1)) + A(1, 1)")
     # Test using MatrixElements in a Matrix
     q = MatrixSymbol('q', 5, 1)
@@ -682,7 +678,7 @@ def test_Matrix_printing():
     m = Matrix([[sin(q[1,0]), 0, cos(q[2,0])],
         [q[1,0] + q[2,0], q[3, 0], 5],
         [2*q[4, 0]/q[1,0], sqrt(q[0,0]) + 4, 0]])
-    assert fcode(dub, m, M) == (
+    assert fcode(m, M) == (
         "      M(1, 1) = sin(q(2, 1))\n"
         "      M(2, 1) = q(2, 1) + q(3, 1)\n"
         "      M(3, 1) = 2*q(5, 1)/q(2, 1)\n"
@@ -698,7 +694,7 @@ def test_fcode_For():
     x, y = symbols('x y')
 
     f = For(x, Range(0, 10, 2), [Assignment(y, x * y)])
-    sol = fcode(dub, f)
+    sol = fcode(f)
     assert sol == ("      do x = 0, 10, 2\n"
                    "         y = x*y\n"
                    "      end do")
@@ -706,7 +702,7 @@ def test_fcode_For():
 
 def test_fcode_Declaration():
     def check(expr, ref, **kwargs):
-        assert fcode(dub, expr, standard=95, source_format='free', **kwargs) == ref
+        assert fcode(expr, standard=95, source_format='free', **kwargs) == ref
 
     i = symbols('i', integer=True)
     var1 = Variable.deduced(i)
@@ -735,8 +731,8 @@ def test_MatrixElement_printing():
     B = MatrixSymbol("B", 1, 3)
     C = MatrixSymbol("C", 1, 3)
 
-    assert(fcode(dub, A[0, 0]) == "      A(1, 1)")
-    assert(fcode(dub, 3 * A[0, 0]) == "      3*A(1, 1)")
+    assert(fcode(A[0, 0]) == "      A(1, 1)")
+    assert(fcode(3 * A[0, 0]) == "      3*A(1, 1)")
 
     F = C[0, 0].subs(C, A - B)
-    assert(fcode(dub, F) == "      ((-1)*B + A)(1, 1)")
+    assert(fcode(F) == "      ((-1)*B + A)(1, 1)")

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -14,6 +14,8 @@ from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
 from sympy.matrices import Matrix, MatrixSymbol
 
+dub = FCodePrinter()
+
 
 def test_printmethod():
     x = symbols('x')
@@ -21,69 +23,69 @@ def test_printmethod():
     class nint(Function):
         def _fcode(self, printer):
             return "nint(%s)" % printer._print(self.args[0])
-    assert fcode(nint(x)) == "      nint(x)"
+    assert fcode(dub, nint(x)) == "      nint(x)"
 
 
 def test_fcode_sign():  #issue 12267
     x=symbols('x')
     y=symbols('y', integer=True)
     z=symbols('z', complex=True)
-    assert fcode(sign(x), standard=95, source_format='free') == "merge(0d0, dsign(1d0, x), x == 0d0)"
-    assert fcode(sign(y), standard=95, source_format='free') == "merge(0, isign(1, y), y == 0)"
-    assert fcode(sign(z), standard=95, source_format='free') == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
-    raises(NotImplementedError, lambda: fcode(sign(x)))
+    assert fcode(dub, sign(x), standard=95, source_format='free') == "merge(0d0, dsign(1d0, x), x == 0d0)"
+    assert fcode(dub, sign(y), standard=95, source_format='free') == "merge(0, isign(1, y), y == 0)"
+    assert fcode(dub, sign(z), standard=95, source_format='free') == "merge(cmplx(0d0, 0d0), z/abs(z), abs(z) == 0d0)"
+    raises(NotImplementedError, lambda: fcode(dub, sign(x)))
 
 
 def test_fcode_Pow():
     x, y = symbols('x,y')
     n = symbols('n', integer=True)
 
-    assert fcode(x**3) == "      x**3"
-    assert fcode(x**(y**3)) == "      x**(y**3)"
-    assert fcode(1/(sin(x)*3.5)**(x - y**x)/(x**2 + y)) == \
+    assert fcode(dub, x**3) == "      x**3"
+    assert fcode(dub, x**(y**3)) == "      x**(y**3)"
+    assert fcode(dub, 1/(sin(x)*3.5)**(x - y**x)/(x**2 + y)) == \
         "      (3.5d0*sin(x))**(-x + y**x)/(x**2 + y)"
-    assert fcode(sqrt(x)) == '      sqrt(x)'
-    assert fcode(sqrt(n)) == '      sqrt(dble(n))'
-    assert fcode(x**0.5) == '      sqrt(x)'
-    assert fcode(sqrt(x)) == '      sqrt(x)'
-    assert fcode(sqrt(10)) == '      sqrt(10.0d0)'
-    assert fcode(x**-1.0) == '      1.0/x'
-    assert fcode(x**-2.0, 'y', source_format='free') == 'y = x**(-2.0d0)'  # 2823
-    assert fcode(x**Rational(3, 7)) == '      x**(3.0d0/7.0d0)'
+    assert fcode(dub, sqrt(x)) == '      sqrt(x)'
+    assert fcode(dub, sqrt(n)) == '      sqrt(dble(n))'
+    assert fcode(dub, x**0.5) == '      sqrt(x)'
+    assert fcode(dub, sqrt(x)) == '      sqrt(x)'
+    assert fcode(dub, sqrt(10)) == '      sqrt(10.0d0)'
+    assert fcode(dub, x**-1.0) == '      1.0/x'
+    assert fcode(dub, x**-2.0, 'y', source_format='free') == 'y = x**(-2.0d0)'  # 2823
+    assert fcode(dub, x**Rational(3, 7)) == '      x**(3.0d0/7.0d0)'
 
 
 def test_fcode_Rational():
     x = symbols('x')
-    assert fcode(Rational(3, 7)) == "      3.0d0/7.0d0"
-    assert fcode(Rational(18, 9)) == "      2"
-    assert fcode(Rational(3, -7)) == "      -3.0d0/7.0d0"
-    assert fcode(Rational(-3, -7)) == "      3.0d0/7.0d0"
-    assert fcode(x + Rational(3, 7)) == "      x + 3.0d0/7.0d0"
-    assert fcode(Rational(3, 7)*x) == "      (3.0d0/7.0d0)*x"
+    assert fcode(dub, Rational(3, 7)) == "      3.0d0/7.0d0"
+    assert fcode(dub, Rational(18, 9)) == "      2"
+    assert fcode(dub, Rational(3, -7)) == "      -3.0d0/7.0d0"
+    assert fcode(dub, Rational(-3, -7)) == "      3.0d0/7.0d0"
+    assert fcode(dub, x + Rational(3, 7)) == "      x + 3.0d0/7.0d0"
+    assert fcode(dub, Rational(3, 7)*x) == "      (3.0d0/7.0d0)*x"
 
 
 def test_fcode_Integer():
-    assert fcode(Integer(67)) == "      67"
-    assert fcode(Integer(-1)) == "      -1"
+    assert fcode(dub, Integer(67)) == "      67"
+    assert fcode(dub, Integer(-1)) == "      -1"
 
 
 def test_fcode_Float():
-    assert fcode(Float(42.0)) == "      42.0000000000000d0"
-    assert fcode(Float(-1e20)) == "      -1.00000000000000d+20"
+    assert fcode(dub, Float(42.0)) == "      42.0000000000000d0"
+    assert fcode(dub, Float(-1e20)) == "      -1.00000000000000d+20"
 
 
 def test_fcode_functions():
     x, y = symbols('x,y')
-    assert fcode(sin(x) ** cos(y)) == "      sin(x)**cos(y)"
-    assert fcode(Max(x, y) + Min(x, y)) == "      max(x, y) + min(x, y)"
+    assert fcode(dub, sin(x) ** cos(y)) == "      sin(x)**cos(y)"
+    assert fcode(dub, Max(x, y) + Min(x, y)) == "      max(x, y) + min(x, y)"
 
 
 def test_case():
     x,x_,x__,y,X,X_,Y = symbols('x,x_,x__,y,X,X_,Y')
-    assert fcode(exp(x_) + sin(x*y) + cos(X*Y)) == \
-                        '      exp(x__) + sin(x_*y_) + cos(X*Y)'
+    assert fcode(dub, exp(x_) + sin(x*y) + cos(X*Y)) == \
+                        '      exp(x_) + sin(x*y) + cos(X*Y)'
 
-    assert fcode(exp(x__) + 2*x*Y*X_**Rational(7, 2)) == \
+    assert fcode(dub, exp(x__) + 2*x*Y*X_**Rational(7, 2)) == \
                         '      2*X_**(7.0d0/2.0d0)*Y*x + exp(x__)'
 
 
@@ -92,95 +94,95 @@ def test_fcode_functions_with_integers():
     x= symbols('x')
     log10_17 = log(10).evalf(17)
     loglog10_17 = '0.8340324452479558d0'
-    assert fcode(x * log(10)) == "      x*%sd0" % log10_17
-    assert fcode(x * log(10)) == "      x*%sd0" % log10_17
-    assert fcode(x * log(S(10))) == "      x*%sd0" % log10_17
-    assert fcode(log(S(10))) == "      %sd0" % log10_17
-    assert fcode(exp(10)) == "      %sd0" % exp(10).evalf(17)
-    assert fcode(x * log(log(10))) == "      x*%s" % loglog10_17
-    assert fcode(x * log(log(S(10)))) == "      x*%s" % loglog10_17
+    assert fcode(dub, x * log(10)) == "      x*%sd0" % log10_17
+    assert fcode(dub, x * log(10)) == "      x*%sd0" % log10_17
+    assert fcode(dub, x * log(S(10))) == "      x*%sd0" % log10_17
+    assert fcode(dub, log(S(10))) == "      %sd0" % log10_17
+    assert fcode(dub, exp(10)) == "      %sd0" % exp(10).evalf(17)
+    assert fcode(dub, x * log(log(10))) == "      x*%s" % loglog10_17
+    assert fcode(dub, x * log(log(S(10)))) == "      x*%s" % loglog10_17
 
 
 def test_fcode_NumberSymbol():
     prec = 17
     p = FCodePrinter()
-    assert fcode(Catalan) == '      parameter (Catalan = %sd0)\n      Catalan' % Catalan.evalf(prec)
-    assert fcode(EulerGamma) == '      parameter (EulerGamma = %sd0)\n      EulerGamma' % EulerGamma.evalf(prec)
-    assert fcode(E) == '      parameter (E = %sd0)\n      E' % E.evalf(prec)
-    assert fcode(GoldenRatio) == '      parameter (GoldenRatio = %sd0)\n      GoldenRatio' % GoldenRatio.evalf(prec)
-    assert fcode(pi) == '      parameter (pi = %sd0)\n      pi' % pi.evalf(prec)
-    assert fcode(
+    assert fcode(dub, Catalan) == '      parameter (Catalan = %sd0)\n      Catalan' % Catalan.evalf(prec)
+    assert fcode(dub, EulerGamma) == '      parameter (EulerGamma = %sd0)\n      EulerGamma' % EulerGamma.evalf(prec)
+    assert fcode(dub, E) == '      parameter (E = %sd0)\n      E' % E.evalf(prec)
+    assert fcode(dub, GoldenRatio) == '      parameter (GoldenRatio = %sd0)\n      GoldenRatio' % GoldenRatio.evalf(prec)
+    assert fcode(dub, pi) == '      parameter (pi = %sd0)\n      pi' % pi.evalf(prec)
+    assert fcode(dub,
         pi, precision=5) == '      parameter (pi = %sd0)\n      pi' % pi.evalf(5)
-    assert fcode(Catalan, human=False) == (set(
+    assert fcode(dub, Catalan, human=False) == (set(
         [(Catalan, p._print(Catalan.evalf(prec)))]), set([]), '      Catalan')
-    assert fcode(EulerGamma, human=False) == (set([(EulerGamma, p._print(
+    assert fcode(dub, EulerGamma, human=False) == (set([(EulerGamma, p._print(
         EulerGamma.evalf(prec)))]), set([]), '      EulerGamma')
-    assert fcode(E, human=False) == (
+    assert fcode(dub, E, human=False) == (
         set([(E, p._print(E.evalf(prec)))]), set([]), '      E')
-    assert fcode(GoldenRatio, human=False) == (set([(GoldenRatio, p._print(
+    assert fcode(dub, GoldenRatio, human=False) == (set([(GoldenRatio, p._print(
         GoldenRatio.evalf(prec)))]), set([]), '      GoldenRatio')
-    assert fcode(pi, human=False) == (
+    assert fcode(dub, pi, human=False) == (
         set([(pi, p._print(pi.evalf(prec)))]), set([]), '      pi')
-    assert fcode(pi, precision=5, human=False) == (
+    assert fcode(dub, pi, precision=5, human=False) == (
         set([(pi, p._print(pi.evalf(5)))]), set([]), '      pi')
 
 
 def test_fcode_complex():
-    assert fcode(I) == "      cmplx(0,1)"
+    assert fcode(dub, I) == "      cmplx(0,1)"
     x = symbols('x')
-    assert fcode(4*I) == "      cmplx(0,4)"
-    assert fcode(3 + 4*I) == "      cmplx(3,4)"
-    assert fcode(3 + 4*I + x) == "      cmplx(3,4) + x"
-    assert fcode(I*x) == "      cmplx(0,1)*x"
-    assert fcode(3 + 4*I - x) == "      cmplx(3,4) - x"
+    assert fcode(dub, 4*I) == "      cmplx(0,4)"
+    assert fcode(dub, 3 + 4*I) == "      cmplx(3,4)"
+    assert fcode(dub, 3 + 4*I + x) == "      cmplx(3,4) + x"
+    assert fcode(dub, I*x) == "      cmplx(0,1)*x"
+    assert fcode(dub, 3 + 4*I - x) == "      cmplx(3,4) - x"
     x = symbols('x', imaginary=True)
-    assert fcode(5*x) == "      5*x"
-    assert fcode(I*x) == "      cmplx(0,1)*x"
-    assert fcode(3 + x) == "      x + 3"
+    assert fcode(dub, 5*x) == "      5*x"
+    assert fcode(dub, I*x) == "      cmplx(0,1)*x"
+    assert fcode(dub, 3 + x) == "      x + 3"
 
 
 def test_implicit():
     x, y = symbols('x,y')
-    assert fcode(sin(x)) == "      sin(x)"
-    assert fcode(atan2(x, y)) == "      atan2(x, y)"
-    assert fcode(conjugate(x)) == "      conjg(x)"
+    assert fcode(dub, sin(x)) == "      sin(x)"
+    assert fcode(dub, atan2(x, y)) == "      atan2(x, y)"
+    assert fcode(dub, conjugate(x)) == "      conjg(x)"
 
 
 def test_not_fortran():
     x = symbols('x')
     g = Function('g')
-    assert fcode(
+    assert fcode(dub,
         gamma(x)) == "C     Not supported in Fortran:\nC     gamma\n      gamma(x)"
-    assert fcode(Integral(sin(x))) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
-    assert fcode(g(x)) == "C     Not supported in Fortran:\nC     g\n      g(x)"
+    assert fcode(dub, Integral(sin(x))) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
+    assert fcode(dub, g(x)) == "C     Not supported in Fortran:\nC     g\n      g(x)"
 
 
 def test_user_functions():
     x = symbols('x')
-    assert fcode(sin(x), user_functions={"sin": "zsin"}) == "      zsin(x)"
+    assert fcode(dub, sin(x), user_functions={"sin": "zsin"}) == "      zsin(x)"
     x = symbols('x')
-    assert fcode(
+    assert fcode(dub,
         gamma(x), user_functions={"gamma": "mygamma"}) == "      mygamma(x)"
     g = Function('g')
-    assert fcode(g(x), user_functions={"g": "great"}) == "      great(x)"
+    assert fcode(dub, g(x), user_functions={"g": "great"}) == "      great(x)"
     n = symbols('n', integer=True)
-    assert fcode(
+    assert fcode(dub,
         factorial(n), user_functions={"factorial": "fct"}) == "      fct(n)"
 
 
 def test_inline_function():
     x = symbols('x')
     g = implemented_function('g', Lambda(x, 2*x))
-    assert fcode(g(x)) == "      2*x"
+    assert fcode(dub, g(x)) == "      2*x"
     g = implemented_function('g', Lambda(x, 2*pi/x))
-    assert fcode(g(x)) == (
+    assert fcode(dub, g(x)) == (
         "      parameter (pi = %sd0)\n"
         "      2*pi/x"
     ) % pi.evalf(17)
     A = IndexedBase('A')
     i = Idx('i', symbols('n', integer=True))
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
-    assert fcode(g(A[i]), assign_to=A[i]) == (
+    assert fcode(dub, g(A[i]), assign_to=A[i]) == (
         "      do i = 1, n\n"
         "         A(i) = (A(i) + 1)*(A(i) + 2)*A(i)\n"
         "      end do"
@@ -189,18 +191,18 @@ def test_inline_function():
 
 def test_assign_to():
     x = symbols('x')
-    assert fcode(sin(x), assign_to="s") == "      s = sin(x)"
+    assert fcode(dub, sin(x), assign_to="s") == "      s = sin(x)"
 
 
 def test_line_wrapping():
     x, y = symbols('x,y')
-    assert fcode(((x + y)**10).expand(), assign_to="var") == (
+    assert fcode(dub, ((x + y)**10).expand(), assign_to="var") == (
         "      var = x**10 + 10*x**9*y + 45*x**8*y**2 + 120*x**7*y**3 + 210*x**6*\n"
         "     @ y**4 + 252*x**5*y**5 + 210*x**4*y**6 + 120*x**3*y**7 + 45*x**2*y\n"
         "     @ **8 + 10*x*y**9 + y**10"
     )
     e = [x**i for i in range(11)]
-    assert fcode(Add(*e)) == (
+    assert fcode(dub, Add(*e)) == (
         "      x**10 + x**9 + x**8 + x**7 + x**6 + x**5 + x**4 + x**3 + x**2 + x\n"
         "     @ + 1"
     )
@@ -208,183 +210,183 @@ def test_line_wrapping():
 
 def test_fcode_precedence():
     x, y = symbols("x y")
-    assert fcode(And(x < y, y < x + 1), source_format="free") == \
+    assert fcode(dub, And(x < y, y < x + 1), source_format="free") == \
         "x < y .and. y < x + 1"
-    assert fcode(Or(x < y, y < x + 1), source_format="free") == \
+    assert fcode(dub, Or(x < y, y < x + 1), source_format="free") == \
         "x < y .or. y < x + 1"
-    assert fcode(Xor(x < y, y < x + 1, evaluate=False),
+    assert fcode(dub, Xor(x < y, y < x + 1, evaluate=False),
         source_format="free") == "x < y .neqv. y < x + 1"
-    assert fcode(Equivalent(x < y, y < x + 1), source_format="free") == \
+    assert fcode(dub, Equivalent(x < y, y < x + 1), source_format="free") == \
         "x < y .eqv. y < x + 1"
 
 
 def test_fcode_Logical():
     x, y, z = symbols("x y z")
     # unary Not
-    assert fcode(Not(x), source_format="free") == ".not. x"
+    assert fcode(dub, Not(x), source_format="free") == ".not. x"
     # binary And
-    assert fcode(And(x, y), source_format="free") == "x .and. y"
-    assert fcode(And(x, Not(y)), source_format="free") == "x .and. .not. y"
-    assert fcode(And(Not(x), y), source_format="free") == "y .and. .not. x"
-    assert fcode(And(Not(x), Not(y)), source_format="free") == \
+    assert fcode(dub, And(x, y), source_format="free") == "x .and. y"
+    assert fcode(dub, And(x, Not(y)), source_format="free") == "x .and. .not. y"
+    assert fcode(dub, And(Not(x), y), source_format="free") == "y .and. .not. x"
+    assert fcode(dub, And(Not(x), Not(y)), source_format="free") == \
         ".not. x .and. .not. y"
-    assert fcode(Not(And(x, y), evaluate=False), source_format="free") == \
+    assert fcode(dub, Not(And(x, y), evaluate=False), source_format="free") == \
         ".not. (x .and. y)"
     # binary Or
-    assert fcode(Or(x, y), source_format="free") == "x .or. y"
-    assert fcode(Or(x, Not(y)), source_format="free") == "x .or. .not. y"
-    assert fcode(Or(Not(x), y), source_format="free") == "y .or. .not. x"
-    assert fcode(Or(Not(x), Not(y)), source_format="free") == \
+    assert fcode(dub, Or(x, y), source_format="free") == "x .or. y"
+    assert fcode(dub, Or(x, Not(y)), source_format="free") == "x .or. .not. y"
+    assert fcode(dub, Or(Not(x), y), source_format="free") == "y .or. .not. x"
+    assert fcode(dub, Or(Not(x), Not(y)), source_format="free") == \
         ".not. x .or. .not. y"
-    assert fcode(Not(Or(x, y), evaluate=False), source_format="free") == \
+    assert fcode(dub, Not(Or(x, y), evaluate=False), source_format="free") == \
         ".not. (x .or. y)"
     # mixed And/Or
-    assert fcode(And(Or(y, z), x), source_format="free") == "x .and. (y .or. z)"
-    assert fcode(And(Or(z, x), y), source_format="free") == "y .and. (x .or. z)"
-    assert fcode(And(Or(x, y), z), source_format="free") == "z .and. (x .or. y)"
-    assert fcode(Or(And(y, z), x), source_format="free") == "x .or. y .and. z"
-    assert fcode(Or(And(z, x), y), source_format="free") == "y .or. x .and. z"
-    assert fcode(Or(And(x, y), z), source_format="free") == "z .or. x .and. y"
+    assert fcode(dub, And(Or(y, z), x), source_format="free") == "x .and. (y .or. z)"
+    assert fcode(dub, And(Or(z, x), y), source_format="free") == "y .and. (x .or. z)"
+    assert fcode(dub, And(Or(x, y), z), source_format="free") == "z .and. (x .or. y)"
+    assert fcode(dub, Or(And(y, z), x), source_format="free") == "x .or. y .and. z"
+    assert fcode(dub, Or(And(z, x), y), source_format="free") == "y .or. x .and. z"
+    assert fcode(dub, Or(And(x, y), z), source_format="free") == "z .or. x .and. y"
     # trinary And
-    assert fcode(And(x, y, z), source_format="free") == "x .and. y .and. z"
-    assert fcode(And(x, y, Not(z)), source_format="free") == \
+    assert fcode(dub, And(x, y, z), source_format="free") == "x .and. y .and. z"
+    assert fcode(dub, And(x, y, Not(z)), source_format="free") == \
         "x .and. y .and. .not. z"
-    assert fcode(And(x, Not(y), z), source_format="free") == \
+    assert fcode(dub, And(x, Not(y), z), source_format="free") == \
         "x .and. z .and. .not. y"
-    assert fcode(And(Not(x), y, z), source_format="free") == \
+    assert fcode(dub, And(Not(x), y, z), source_format="free") == \
         "y .and. z .and. .not. x"
-    assert fcode(Not(And(x, y, z), evaluate=False), source_format="free") == \
+    assert fcode(dub, Not(And(x, y, z), evaluate=False), source_format="free") == \
         ".not. (x .and. y .and. z)"
     # trinary Or
-    assert fcode(Or(x, y, z), source_format="free") == "x .or. y .or. z"
-    assert fcode(Or(x, y, Not(z)), source_format="free") == \
+    assert fcode(dub, Or(x, y, z), source_format="free") == "x .or. y .or. z"
+    assert fcode(dub, Or(x, y, Not(z)), source_format="free") == \
         "x .or. y .or. .not. z"
-    assert fcode(Or(x, Not(y), z), source_format="free") == \
+    assert fcode(dub, Or(x, Not(y), z), source_format="free") == \
         "x .or. z .or. .not. y"
-    assert fcode(Or(Not(x), y, z), source_format="free") == \
+    assert fcode(dub, Or(Not(x), y, z), source_format="free") == \
         "y .or. z .or. .not. x"
-    assert fcode(Not(Or(x, y, z), evaluate=False), source_format="free") == \
+    assert fcode(dub, Not(Or(x, y, z), evaluate=False), source_format="free") == \
         ".not. (x .or. y .or. z)"
 
 
 def test_fcode_Xlogical():
     x, y, z = symbols("x y z")
     # binary Xor
-    assert fcode(Xor(x, y, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(x, y, evaluate=False), source_format="free") == \
         "x .neqv. y"
-    assert fcode(Xor(x, Not(y), evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(x, Not(y), evaluate=False), source_format="free") == \
         "x .neqv. .not. y"
-    assert fcode(Xor(Not(x), y, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(Not(x), y, evaluate=False), source_format="free") == \
         "y .neqv. .not. x"
-    assert fcode(Xor(Not(x), Not(y), evaluate=False),
+    assert fcode(dub, Xor(Not(x), Not(y), evaluate=False),
         source_format="free") == ".not. x .neqv. .not. y"
-    assert fcode(Not(Xor(x, y, evaluate=False), evaluate=False),
+    assert fcode(dub, Not(Xor(x, y, evaluate=False), evaluate=False),
         source_format="free") == ".not. (x .neqv. y)"
     # binary Equivalent
-    assert fcode(Equivalent(x, y), source_format="free") == "x .eqv. y"
-    assert fcode(Equivalent(x, Not(y)), source_format="free") == \
+    assert fcode(dub, Equivalent(x, y), source_format="free") == "x .eqv. y"
+    assert fcode(dub, Equivalent(x, Not(y)), source_format="free") == \
         "x .eqv. .not. y"
-    assert fcode(Equivalent(Not(x), y), source_format="free") == \
+    assert fcode(dub, Equivalent(Not(x), y), source_format="free") == \
         "y .eqv. .not. x"
-    assert fcode(Equivalent(Not(x), Not(y)), source_format="free") == \
+    assert fcode(dub, Equivalent(Not(x), Not(y)), source_format="free") == \
         ".not. x .eqv. .not. y"
-    assert fcode(Not(Equivalent(x, y), evaluate=False),
+    assert fcode(dub, Not(Equivalent(x, y), evaluate=False),
         source_format="free") == ".not. (x .eqv. y)"
     # mixed And/Equivalent
-    assert fcode(Equivalent(And(y, z), x), source_format="free") == \
+    assert fcode(dub, Equivalent(And(y, z), x), source_format="free") == \
         "x .eqv. y .and. z"
-    assert fcode(Equivalent(And(z, x), y), source_format="free") == \
+    assert fcode(dub, Equivalent(And(z, x), y), source_format="free") == \
         "y .eqv. x .and. z"
-    assert fcode(Equivalent(And(x, y), z), source_format="free") == \
+    assert fcode(dub, Equivalent(And(x, y), z), source_format="free") == \
         "z .eqv. x .and. y"
-    assert fcode(And(Equivalent(y, z), x), source_format="free") == \
+    assert fcode(dub, And(Equivalent(y, z), x), source_format="free") == \
         "x .and. (y .eqv. z)"
-    assert fcode(And(Equivalent(z, x), y), source_format="free") == \
+    assert fcode(dub, And(Equivalent(z, x), y), source_format="free") == \
         "y .and. (x .eqv. z)"
-    assert fcode(And(Equivalent(x, y), z), source_format="free") == \
+    assert fcode(dub, And(Equivalent(x, y), z), source_format="free") == \
         "z .and. (x .eqv. y)"
     # mixed Or/Equivalent
-    assert fcode(Equivalent(Or(y, z), x), source_format="free") == \
+    assert fcode(dub, Equivalent(Or(y, z), x), source_format="free") == \
         "x .eqv. y .or. z"
-    assert fcode(Equivalent(Or(z, x), y), source_format="free") == \
+    assert fcode(dub, Equivalent(Or(z, x), y), source_format="free") == \
         "y .eqv. x .or. z"
-    assert fcode(Equivalent(Or(x, y), z), source_format="free") == \
+    assert fcode(dub, Equivalent(Or(x, y), z), source_format="free") == \
         "z .eqv. x .or. y"
-    assert fcode(Or(Equivalent(y, z), x), source_format="free") == \
+    assert fcode(dub, Or(Equivalent(y, z), x), source_format="free") == \
         "x .or. (y .eqv. z)"
-    assert fcode(Or(Equivalent(z, x), y), source_format="free") == \
+    assert fcode(dub, Or(Equivalent(z, x), y), source_format="free") == \
         "y .or. (x .eqv. z)"
-    assert fcode(Or(Equivalent(x, y), z), source_format="free") == \
+    assert fcode(dub, Or(Equivalent(x, y), z), source_format="free") == \
         "z .or. (x .eqv. y)"
     # mixed Xor/Equivalent
-    assert fcode(Equivalent(Xor(y, z, evaluate=False), x),
+    assert fcode(dub, Equivalent(Xor(y, z, evaluate=False), x),
         source_format="free") == "x .eqv. (y .neqv. z)"
-    assert fcode(Equivalent(Xor(z, x, evaluate=False), y),
+    assert fcode(dub, Equivalent(Xor(z, x, evaluate=False), y),
         source_format="free") == "y .eqv. (x .neqv. z)"
-    assert fcode(Equivalent(Xor(x, y, evaluate=False), z),
+    assert fcode(dub, Equivalent(Xor(x, y, evaluate=False), z),
         source_format="free") == "z .eqv. (x .neqv. y)"
-    assert fcode(Xor(Equivalent(y, z), x, evaluate=False),
+    assert fcode(dub, Xor(Equivalent(y, z), x, evaluate=False),
         source_format="free") == "x .neqv. (y .eqv. z)"
-    assert fcode(Xor(Equivalent(z, x), y, evaluate=False),
+    assert fcode(dub, Xor(Equivalent(z, x), y, evaluate=False),
         source_format="free") == "y .neqv. (x .eqv. z)"
-    assert fcode(Xor(Equivalent(x, y), z, evaluate=False),
+    assert fcode(dub, Xor(Equivalent(x, y), z, evaluate=False),
         source_format="free") == "z .neqv. (x .eqv. y)"
     # mixed And/Xor
-    assert fcode(Xor(And(y, z), x, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(And(y, z), x, evaluate=False), source_format="free") == \
         "x .neqv. y .and. z"
-    assert fcode(Xor(And(z, x), y, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(And(z, x), y, evaluate=False), source_format="free") == \
         "y .neqv. x .and. z"
-    assert fcode(Xor(And(x, y), z, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(And(x, y), z, evaluate=False), source_format="free") == \
         "z .neqv. x .and. y"
-    assert fcode(And(Xor(y, z, evaluate=False), x), source_format="free") == \
+    assert fcode(dub, And(Xor(y, z, evaluate=False), x), source_format="free") == \
         "x .and. (y .neqv. z)"
-    assert fcode(And(Xor(z, x, evaluate=False), y), source_format="free") == \
+    assert fcode(dub, And(Xor(z, x, evaluate=False), y), source_format="free") == \
         "y .and. (x .neqv. z)"
-    assert fcode(And(Xor(x, y, evaluate=False), z), source_format="free") == \
+    assert fcode(dub, And(Xor(x, y, evaluate=False), z), source_format="free") == \
         "z .and. (x .neqv. y)"
     # mixed Or/Xor
-    assert fcode(Xor(Or(y, z), x, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(Or(y, z), x, evaluate=False), source_format="free") == \
         "x .neqv. y .or. z"
-    assert fcode(Xor(Or(z, x), y, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(Or(z, x), y, evaluate=False), source_format="free") == \
         "y .neqv. x .or. z"
-    assert fcode(Xor(Or(x, y), z, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(Or(x, y), z, evaluate=False), source_format="free") == \
         "z .neqv. x .or. y"
-    assert fcode(Or(Xor(y, z, evaluate=False), x), source_format="free") == \
+    assert fcode(dub, Or(Xor(y, z, evaluate=False), x), source_format="free") == \
         "x .or. (y .neqv. z)"
-    assert fcode(Or(Xor(z, x, evaluate=False), y), source_format="free") == \
+    assert fcode(dub, Or(Xor(z, x, evaluate=False), y), source_format="free") == \
         "y .or. (x .neqv. z)"
-    assert fcode(Or(Xor(x, y, evaluate=False), z), source_format="free") == \
+    assert fcode(dub, Or(Xor(x, y, evaluate=False), z), source_format="free") == \
         "z .or. (x .neqv. y)"
     # trinary Xor
-    assert fcode(Xor(x, y, z, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(x, y, z, evaluate=False), source_format="free") == \
         "x .neqv. y .neqv. z"
-    assert fcode(Xor(x, y, Not(z), evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(x, y, Not(z), evaluate=False), source_format="free") == \
         "x .neqv. y .neqv. .not. z"
-    assert fcode(Xor(x, Not(y), z, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(x, Not(y), z, evaluate=False), source_format="free") == \
         "x .neqv. z .neqv. .not. y"
-    assert fcode(Xor(Not(x), y, z, evaluate=False), source_format="free") == \
+    assert fcode(dub, Xor(Not(x), y, z, evaluate=False), source_format="free") == \
         "y .neqv. z .neqv. .not. x"
 
 
 def test_fcode_Relational():
     x, y = symbols("x y")
-    assert fcode(Relational(x, y, "=="), source_format="free") == "x == y"
-    assert fcode(Relational(x, y, "!="), source_format="free") == "x /= y"
-    assert fcode(Relational(x, y, ">="), source_format="free") == "x >= y"
-    assert fcode(Relational(x, y, "<="), source_format="free") == "x <= y"
-    assert fcode(Relational(x, y, ">"), source_format="free") == "x > y"
-    assert fcode(Relational(x, y, "<"), source_format="free") == "x < y"
+    assert fcode(dub, Relational(x, y, "=="), source_format="free") == "x == y"
+    assert fcode(dub, Relational(x, y, "!="), source_format="free") == "x /= y"
+    assert fcode(dub, Relational(x, y, ">="), source_format="free") == "x >= y"
+    assert fcode(dub, Relational(x, y, "<="), source_format="free") == "x <= y"
+    assert fcode(dub, Relational(x, y, ">"), source_format="free") == "x > y"
+    assert fcode(dub, Relational(x, y, "<"), source_format="free") == "x < y"
 
 
 def test_fcode_Piecewise():
     x = symbols('x')
     expr = Piecewise((x, x < 1), (x**2, True))
     # Check that inline conditional (merge) fails if standard isn't 95+
-    raises(NotImplementedError, lambda: fcode(expr))
-    code = fcode(expr, standard=95)
+    raises(NotImplementedError, lambda: fcode(dub, expr))
+    code = fcode(dub, expr, standard=95)
     expected = "      merge(x, x**2, x < 1)"
     assert code == expected
-    assert fcode(Piecewise((x, x < 1), (x**2, True)), assign_to="var") == (
+    assert fcode(dub, Piecewise((x, x < 1), (x**2, True)), assign_to="var") == (
         "      if (x < 1) then\n"
         "         var = x\n"
         "      else\n"
@@ -409,14 +411,14 @@ def test_fcode_Piecewise():
         "     @ )/x**10 + 3628800*sin(x)/x**11\n"
         "      end if"
     )
-    code = fcode(Piecewise((a, x < 0), (b, True)), assign_to="weird_name")
+    code = fcode(dub, Piecewise((a, x < 0), (b, True)), assign_to="weird_name")
     assert code == expected
-    code = fcode(Piecewise((x, x < 1), (x**2, x > 1), (sin(x), True)), standard=95)
+    code = fcode(dub, Piecewise((x, x < 1), (x**2, x > 1), (sin(x), True)), standard=95)
     expected = "      merge(x, merge(x**2, sin(x), x > 1), x < 1)"
     assert code == expected
     # Check that Piecewise without a True (default) condition error
     expr = Piecewise((x, x < 1), (x**2, x > 1), (sin(x), x > 0))
-    raises(ValueError, lambda: fcode(expr))
+    raises(ValueError, lambda: fcode(dub, expr))
 
 
 def test_wrap_fortran():
@@ -506,17 +508,17 @@ def test_wrap_fortran_keep_d0():
 
 
 def test_settings():
-    raises(TypeError, lambda: fcode(S(4), method="garbage"))
+    raises(TypeError, lambda: fcode(dub, S(4), method="garbage"))
 
 
 def test_free_form_code_line():
     x, y = symbols('x,y')
-    assert fcode(cos(x) + sin(y), source_format='free') == "sin(y) + cos(x)"
+    assert fcode(dub, cos(x) + sin(y), source_format='free') == "sin(y) + cos(x)"
 
 
 def test_free_form_continuation_line():
     x, y = symbols('x,y')
-    result = fcode(((cos(x) + sin(y))**(7)).expand(), source_format='free')
+    result = fcode(dub, ((cos(x) + sin(y))**(7)).expand(), source_format='free')
     expected = (
         'sin(y)**7 + 7*sin(y)**6*cos(x) + 21*sin(y)**5*cos(x)**2 + 35*sin(y)**4* &\n'
         '      cos(x)**3 + 35*sin(y)**3*cos(x)**4 + 21*sin(y)**2*cos(x)**5 + 7* &\n'
@@ -553,7 +555,7 @@ def test_loops():
         'end do'
     )
 
-    code = fcode(A[i, j]*x[j], assign_to=y[i], source_format='free')
+    code = fcode(dub, A[i, j]*x[j], assign_to=y[i], source_format='free')
     assert (code == expected % {'rhs': 'y(i) + A(i, j)*x(j)'} or
             code == expected % {'rhs': 'y(i) + x(j)*A(i, j)'} or
             code == expected % {'rhs': 'x(j)*A(i, j) + y(i)'} or
@@ -571,7 +573,7 @@ def test_dummy_loops():
         '   y(i_%(icount)i) = x(i_%(icount)i)\n'
         'end do'
     ) % {'icount': i.label.dummy_index, 'mcount': m.dummy_index}
-    code = fcode(x[i], assign_to=y[i], source_format='free')
+    code = fcode(dub, x[i], assign_to=y[i], source_format='free')
     assert code == expected
 
 def test_fcode_Indexed_without_looking_for_contraction():
@@ -581,7 +583,7 @@ def test_fcode_Indexed_without_looking_for_contraction():
     Dy = IndexedBase('Dy', shape=(len_y-1,))
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
-    code0 = fcode(e.rhs, assign_to=e.lhs, contract=False)
+    code0 = fcode(dub, e.rhs, assign_to=e.lhs, contract=False)
     assert code0.endswith('Dy(i) = (y(i + 1) - y(i))/(x(i + 1) - x(i))')
 
 
@@ -662,7 +664,7 @@ def test_Matrix_printing():
     # Test returning a Matrix
     mat = Matrix([x*y, Piecewise((2 + x, y>0), (y, True)), sin(z)])
     A = MatrixSymbol('A', 3, 1)
-    assert fcode(mat, A) == (
+    assert fcode(dub, mat, A) == (
         "      A(1, 1) = x*y\n"
         "      if (y > 0) then\n"
         "         A(2, 1) = x + 2\n"
@@ -672,7 +674,7 @@ def test_Matrix_printing():
         "      A(3, 1) = sin(z)")
     # Test using MatrixElements in expressions
     expr = Piecewise((2*A[2, 0], x > 0), (A[2, 0], True)) + sin(A[1, 0]) + A[0, 0]
-    assert fcode(expr, standard=95) == (
+    assert fcode(dub, expr, standard=95) == (
         "      merge(2*A(3, 1), A(3, 1), x > 0) + sin(A(2, 1)) + A(1, 1)")
     # Test using MatrixElements in a Matrix
     q = MatrixSymbol('q', 5, 1)
@@ -680,7 +682,7 @@ def test_Matrix_printing():
     m = Matrix([[sin(q[1,0]), 0, cos(q[2,0])],
         [q[1,0] + q[2,0], q[3, 0], 5],
         [2*q[4, 0]/q[1,0], sqrt(q[0,0]) + 4, 0]])
-    assert fcode(m, M) == (
+    assert fcode(dub, m, M) == (
         "      M(1, 1) = sin(q(2, 1))\n"
         "      M(2, 1) = q(2, 1) + q(3, 1)\n"
         "      M(3, 1) = 2*q(5, 1)/q(2, 1)\n"
@@ -696,7 +698,7 @@ def test_fcode_For():
     x, y = symbols('x y')
 
     f = For(x, Range(0, 10, 2), [Assignment(y, x * y)])
-    sol = fcode(f)
+    sol = fcode(dub, f)
     assert sol == ("      do x = 0, 10, 2\n"
                    "         y = x*y\n"
                    "      end do")
@@ -704,7 +706,7 @@ def test_fcode_For():
 
 def test_fcode_Declaration():
     def check(expr, ref, **kwargs):
-        assert fcode(expr, standard=95, source_format='free', **kwargs) == ref
+        assert fcode(dub, expr, standard=95, source_format='free', **kwargs) == ref
 
     i = symbols('i', integer=True)
     var1 = Variable.deduced(i)
@@ -733,8 +735,8 @@ def test_MatrixElement_printing():
     B = MatrixSymbol("B", 1, 3)
     C = MatrixSymbol("C", 1, 3)
 
-    assert(fcode(A[0, 0]) == "      A(1, 1)")
-    assert(fcode(3 * A[0, 0]) == "      3*A(1, 1)")
+    assert(fcode(dub, A[0, 0]) == "      A(1, 1)")
+    assert(fcode(dub, 3 * A[0, 0]) == "      3*A(1, 1)")
 
     F = C[0, 0].subs(C, A - B)
-    assert(fcode(F) == "      ((-1)*B + A)(1, 1)")
+    assert(fcode(dub, F) == "      ((-1)*B + A)(1, 1)")

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -89,6 +89,14 @@ def test_case():
     assert ob.doprint(X*sin(x) + x_, assign_to='me') == '      me = X*sin(x_) + x__'
     assert ob.doprint(X*sin(x), assign_to='mu') == '      mu = X*sin(x_)'
     assert ob.doprint(x_, assign_to='ad') == '      ad = x__'
+    A = IndexedBase('A')
+    i = Idx('i', symbols('n', integer=True))
+    sq = implemented_function('sq', Lambda(x, x**2))
+    assert fcode(sq(A[i]), assign_to=A[i]) == (
+        '      do i = 1, n\n'
+        '         A(i) = A(i)**2\n'
+        '      end do'
+    )
 
 
 #issue 6814

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -78,6 +78,15 @@ def test_fcode_functions():
     assert fcode(Max(x, y) + Min(x, y)) == "      max(x, y) + min(x, y)"
 
 
+def test_case():
+    x,x_,x__,y,X,X_,Y = symbols('x,x_,x__,y,X,X_,Y')
+    assert fcode(exp(x_) + sin(x*y) + cos(X*Y)) == \
+                        '      exp(x__) + sin(x_*y_) + cos(X*Y)'
+
+    assert fcode(exp(x__) + 2*x*Y*X_**Rational(7, 2)) == \
+                        '      2*X_**(7.0d0/2.0d0)*Y*x + exp(x__)'
+
+
 #issue 6814
 def test_fcode_functions_with_integers():
     x= symbols('x')

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -77,12 +77,18 @@ def test_fcode_functions():
 
 
 def test_case():
+    ob = FCodePrinter()
     x,x_,x__,y,X,X_,Y = symbols('x,x_,x__,y,X,X_,Y')
     assert fcode(exp(x_) + sin(x*y) + cos(X*Y)) == \
-                        '      exp(x_) + sin(x*y) + cos(X*Y)'
-
+                        '      exp(x_) + sin(x*y) + cos(X__*Y_)'
     assert fcode(exp(x__) + 2*x*Y*X_**Rational(7, 2)) == \
                         '      2*X_**(7.0d0/2.0d0)*Y*x + exp(x__)'
+    assert fcode(exp(x_) + sin(x*y) + cos(X*Y), name_mangling=False) == \
+                        '      exp(x_) + sin(x*y) + cos(X*Y)'
+    assert fcode(x - cos(X), name_mangling=False) == '      x - cos(X)'
+    assert ob.doprint(X*sin(x) + x_, assign_to='me') == '      me = X*sin(x_) + x__'
+    assert ob.doprint(X*sin(x), assign_to='mu') == '      mu = X*sin(x_)'
+    assert ob.doprint(x_, assign_to='ad') == '      ad = x__'
 
 
 #issue 6814

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -89,14 +89,21 @@ def test_case():
     assert ob.doprint(X*sin(x) + x_, assign_to='me') == '      me = X*sin(x_) + x__'
     assert ob.doprint(X*sin(x), assign_to='mu') == '      mu = X*sin(x_)'
     assert ob.doprint(x_, assign_to='ad') == '      ad = x__'
+    n, m = symbols('n,m', integer=True)
     A = IndexedBase('A')
-    i = Idx('i', symbols('n', integer=True))
-    sq = implemented_function('sq', Lambda(x, x**2))
-    assert fcode(sq(A[i]), assign_to=A[i]) == (
-        '      do i = 1, n\n'
-        '         A(i) = A(i)**2\n'
-        '      end do'
-    )
+    x = IndexedBase('x')
+    y = IndexedBase('y')
+    i = Idx('i', m)
+    I = Idx('I', n)
+    assert fcode(A[i, I]*x[I], assign_to=y[i], source_format='free') == (
+                                            "do i = 1, m\n"
+                                            "   y(i) = 0\n"
+                                            "end do\n"
+                                            "do i = 1, m\n"
+                                            "   do I_ = 1, n\n"
+                                            "      y(i) = A(i, I_)*x(I_) + y(i)\n"
+                                            "   end do\n"
+                                            "end do" )
 
 
 #issue 6814


### PR DESCRIPTION
Current implementation of `fcode` doesn't print different cases as different variable in Fortran code.
Example:
```
>>> fcode(X + 2*x*Y**Rational(7, 2))
'      X + 2*Y**(7.0d0/2.0d0)*x'
```
In this, though `X` and `x` were different variables in python but they both are same for Fortan.

So to change this behaviour, this patch appends `_` (till it's unique in the pool of words without considering case ) to similar symbols (but with a different case).
```
>>> fcode(X + 2*x*Y**Rational(7, 2))
'      X + 2*Y**(7.0d0/2.0d0)*x_'
``` 
