### PR TITLE
Add support for sympy.sign in .printing.pycode

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -125,7 +125,7 @@ class PythonCodePrinter(CodePrinter):
         return "float('inf')"
 
     def _print_sign(self, e):
-        return '(0 if {e} == 0 else {f}(1, {e}))'.format(
+        return '(0.0 if {e} == 0 else {f}(1, {e}))'.format(
             f=self._module_format('math.copysign'), e=self._print(e.args[0]))
 
     def _print_Mod(self, expr):

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -124,6 +124,10 @@ class PythonCodePrinter(CodePrinter):
     def _print_Infinity(self, expr):
         return "float('inf')"
 
+    def _print_sign(self, e):
+        return '(0 if {e} == 0 else {f}(1, {e}))'.format(
+            f=self._module_format('math.copysign'), e=self._print(e.args[0]))
+
     def _print_Mod(self, expr):
         PREC = precedence(expr)
         return ('{0} % {1}'.format(*map(lambda x: self.parenthesize(x, PREC), expr.args)))
@@ -214,7 +218,9 @@ def pycode(expr, **settings):
 
 _not_in_mpmath = 'log1p log2'.split()
 _in_mpmath = [(k, v) for k, v in _known_functions_math.items() if k not in _not_in_mpmath]
-_known_functions_mpmath = dict(_in_mpmath)
+_known_functions_mpmath = dict(_in_mpmath, **{
+    'sign': 'sign',
+})
 _known_constants_mpmath = {
     'Pi': 'pi'
 }
@@ -276,6 +282,7 @@ _known_functions_numpy = dict(_in_numpy, **{
     'atan2': 'arctan2',
     'atanh': 'arctanh',
     'exp2': 'exp2',
+    'sign': 'sign',
 })
 
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -5,7 +5,7 @@ from sympy.codegen import Assignment
 from sympy.core import Expr, Mod, symbols, Eq, Le, Gt
 from sympy.core.numbers import pi
 from sympy.logic import And, Or
-from sympy.functions import acos, Piecewise
+from sympy.functions import acos, Piecewise, sign
 from sympy.matrices import SparseMatrix
 from sympy.printing.pycode import (
     MpmathPrinter, NumPyPrinter, PythonCodePrinter, pycode, SciPyPrinter
@@ -32,6 +32,17 @@ def test_PythonCodePrinter():
     assert prntr.doprint(Piecewise((2, Le(x, 0)),
                         (3, Gt(x, 0)), evaluate=False)) == '((2) if (x <= 0) else'\
                                                         ' (3) if (x > 0) else None)'
+    assert prntr.doprint(sign(x)) == '(0 if x == 0 else math.copysign(1, x))'
+
+
+def test_MpmathPrinter():
+    p = MpmathPrinter()
+    assert p.doprint(sign(x)) == 'mpmath.sign(x)'
+
+
+def test_NumPyPrinter():
+    p = NumPyPrinter()
+    assert p.doprint(sign(x)) == 'numpy.sign(x)'
 
 
 def test_SciPyPrinter():

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -32,7 +32,7 @@ def test_PythonCodePrinter():
     assert prntr.doprint(Piecewise((2, Le(x, 0)),
                         (3, Gt(x, 0)), evaluate=False)) == '((2) if (x <= 0) else'\
                                                         ' (3) if (x > 0) else None)'
-    assert prntr.doprint(sign(x)) == '(0 if x == 0 else math.copysign(1, x))'
+    assert prntr.doprint(sign(x)) == '(0.0 if x == 0 else math.copysign(1, x))'
 
 
 def test_MpmathPrinter():


### PR DESCRIPTION
Python doesn't have a `math.sign` function, it does have a `copysign` function though, however, just wrapping copysign would not give the right answer for `sign(0)` (hence the use of the ternary operator).