### PR TITLE
solveset is now able to solve XFAIL

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -169,20 +169,19 @@ def _invert_real(f, g_ys, symbol):
             res = imageset(Lambda(n, real_root(n, expo)), g_ys)
             if expo.is_rational:
                 numer, denom = expo.as_numer_denom()
-                if numer is S.One or numer is S.NegativeOne:
-                    if denom % 2 == 0:
-                        base_positive = solveset(base >= 0, symbol, S.Reals)
-                        res = imageset(Lambda(n, real_root(n, expo)
-                            ), g_ys.intersect(
-                            Interval.Ropen(S.Zero, S.Infinity)))
-                        _inv, _set = _invert_real(base, res, symbol)
-                        return (_inv, _set.intersect(base_positive))
-                    else:
-                        return _invert_real(base, res, symbol)
+                if denom % 2 == 0:
+                    base_positive = solveset(base >= 0, symbol, S.Reals)
+                    res = imageset(Lambda(n, real_root(n, expo)
+                        ), g_ys.intersect(
+                        Interval.Ropen(S.Zero, S.Infinity)))
+                    _inv, _set = _invert_real(base, res, symbol)
+                    return (_inv, _set.intersect(base_positive))
+
                 elif numer % 2 == 0:
                         n = Dummy('n')
                         neg_res = imageset(Lambda(n, -n), res)
                         return _invert_real(base, res + neg_res, symbol)
+
                 else:
                     return _invert_real(base, res, symbol)
             else:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1540,6 +1540,12 @@ def test_issue_10214():
     assert solveset(x**(S(3)/2) + 4, x, S.Reals) == S.EmptySet
     assert solveset(x**(S(-3)/2) + 4, x, S.Reals) == S.EmptySet
 
+    ans = FiniteSet(-2**(S(2)/3))
+    assert solveset(x**(S(3)) + 4, x, S.Reals) == ans
+    assert (x**(S(3)) + 4).subs(x,list(ans)[0]) == 0 # substituting ans and verifying the result.
+    assert (x**(S(3)) + 4).subs(x,-(-2)**(2/S(3))) == 0
+
+
 def test_issue_9849():
     assert solveset(Abs(sin(x)) + 1, x, S.Reals) == S.EmptySet
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1536,10 +1536,9 @@ def test_issue_9778():
         FiniteSet((-y)**(S(1)/3)*Piecewise((1, Ne(-im(y), 0)), ((-1)**(S(2)/3), -y < 0), (1, True))))
 
 
-@XFAIL
-def test_issue_failing_pow():
+def test_issue_10214():
     assert solveset(x**(S(3)/2) + 4, x, S.Reals) == S.EmptySet
-
+    assert solveset(x**(S(-3)/2) + 4, x, S.Reals) == S.EmptySet
 
 def test_issue_9849():
     assert solveset(Abs(sin(x)) + 1, x, S.Reals) == S.EmptySet


### PR DESCRIPTION
Fixes #10214
closes #10460
Below is the `XFAIL` to which `solveset` currently gives  `{2*2**(1/3)}` which is wrong.
```
solveset(x**(S(3)/2) + 4, x, S.Reals) == S.EmptySet
```
Rational exponents with denominators divisible by `2` should return `EmptySet` for a -ve `rhs`(as in the above case).
 
ping @smichr @ylemkimon @Yathartha22 