### PR TITLE
When integrating by parts, do not use u = non-poly algebraic

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -351,8 +351,6 @@ def _parts_rule(integrand, symbol):
         if algebraic:
             u = sympy.Mul(*algebraic)
             dv = (integrand / u).cancel()
-            if not u.is_polynomial() and isinstance(dv, sympy.exp):
-                return
             return u, dv
 
     def pull_out_u(*functions):
@@ -385,6 +383,10 @@ def _parts_rule(integrand, symbol):
 
             # Don't pick u to be a constant if possible
             if symbol not in u.free_symbols and not u.has(dummy):
+                return
+
+            # Don't pick a non-polynomial algebraic to be differentiated
+            if rule == pull_out_algebraic and not u.is_polynomial():
                 return
 
             u = u.subs(dummy, 1)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -385,12 +385,12 @@ def _parts_rule(integrand, symbol):
             if symbol not in u.free_symbols and not u.has(dummy):
                 return
 
-            # Don't pick a non-polynomial algebraic to be differentiated
-            if rule == pull_out_algebraic and not u.is_polynomial():
-                return
-
             u = u.subs(dummy, 1)
             dv = dv.subs(dummy, 1)
+
+            # Don't pick a non-polynomial algebraic to be differentiated
+            if rule == pull_out_algebraic and not u.is_polynomial(symbol):
+                return
 
             for rule in liate_rules[index + 1:]:
                 r = rule(integrand)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -395,7 +395,7 @@ def _parts_rule(integrand, symbol):
             for rule in liate_rules[index + 1:]:
                 r = rule(integrand)
                 # make sure dv is amenable to integration
-                if r and sympy.simplify(r[0].subs(dummy, 1)) == sympy.simplify(dv):
+                if r and r[0].subs(dummy, 1).equals(dv):
                     du = u.diff(symbol)
                     v_step = integral_steps(sympy.simplify(dv), symbol)
                     v = _manualintegrate(v_step)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -5,7 +5,7 @@ from sympy import (
     Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
     Ne, O, oo, pi, Piecewise, polar_lift, Poly, Rational, re, S, sign,
     simplify, sin, SingularityFunction, sqrt, sstr, Sum, Symbol,
-    symbols, sympify, tan, trigsimp, Tuple
+    symbols, sympify, tan, trigsimp, Tuple, Si, Ci
 )
 from sympy.functions.elementary.complexes import periodic_argument
 from sympy.integrals.risch import NonElementaryIntegral
@@ -858,6 +858,14 @@ def test_series():
     i = Integral(cos(x), (x, x))
     e = i.lseries(x)
     assert i.nseries(x, n=8).removeO() == Add(*[next(e) for j in range(4)])
+
+
+def test_trig_nonelementary_integrals():
+    x = Symbol('x')
+    assert integrate((1 + sin(x))/x, x) == log(x) + Si(x)
+    # next one comes out as log(x) + log(x**2)/2 + Ci(x)
+    # so not hardcoding this log ugliness
+    assert integrate((cos(x) + 2)/x, x).has(Ci)
 
 
 def test_issue_4403():


### PR DESCRIPTION
#### Brief description of what is fixed or changed

There is no gain in differentiating non-polynomial algebraic  expressions when integrating by parts, at least in the elementary  situations that manualintegrate deals with. Trying to do this leads to  infinite loops, Now this choice of u, dv is prevented.

#### Other comments

Example: in current master `integrate((1+sin(x))/x, x)` gets stuck in an infinite loop of this kind, as the exponent of x becomes more and  more negative under differentiation. Now this integral gets evaluated,  because after manualintegrate fails, it goes back to meijerint as two  terms 1/x and sin(x)/x, resulting in log(x) + Si(x).

There was already a check to prevent this when the algebraic is  multiplied by exp, but this was overly specific.