### PR TITLE
improved binomial() for negative and noninteger  k

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -762,13 +762,10 @@ class binomial(CombinatorialFunction):
     -195/128
 
     >>> binomial(n, 3)
-    binomial(n, 3)
+    n*(n - 2)*(n - 1)/6
 
     >>> binomial(n, 3).expand(func=True)
     n**3/6 - n**2/2 + n/3
-
-    >>> expand_func(binomial(n, 3))
-    n*(n - 2)*(n - 1)/6
 
     """
 
@@ -844,24 +841,22 @@ class binomial(CombinatorialFunction):
 
     @classmethod
     def eval(cls, n, k):
+        from sympy import gamma
         n, k = map(sympify, (n, k))
         d = n - k
-        is_int = (n.is_integer and k.is_integer)
         if d.is_zero or k.is_zero:
             return S.One
-        elif d.is_zero is False:
-            if (k - 1).is_zero:
-                return n
-            elif k.is_negative:
-                if (is_int == S.true or is_int is None) and (n.is_nonnegative or n < k):
-                    return S.Zero
-                if is_int == S.false and k.is_integer:
-                    return S.Zero
-            elif n.is_integer and n.is_nonnegative and d.is_negative and \
-                (is_int == S.true or is_int is None):
+
+        if (k - 1).is_zero:
+            return n
+        if k.is_integer:
+            if k.is_negative:
                 return S.Zero
-        if k.is_Integer and k > 0 and n.is_Number:
+            if n.is_integer and n.is_nonnegative and d.is_negative:
+                return S.Zero
             return cls._eval(n, k)
+
+        return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
 
 
     def _eval_expand_func(self, **hints):

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -861,8 +861,9 @@ class binomial(CombinatorialFunction):
                 return S.Zero
             if n.is_integer and n.is_nonnegative and d.is_negative:
                 return S.Zero
-            if n.is_Number:
-                return cls._eval(n, k)
+            if n.is_number:
+                from sympy.simplify.simplify import simplify
+                return simplify(cls._eval(n, k))
         elif n.is_negative and n.is_integer and not k.is_integer:
             # a special case when binomial evaluates to complex infinity
             return S.ComplexInfinity

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -846,17 +846,23 @@ class binomial(CombinatorialFunction):
     def eval(cls, n, k):
         n, k = map(sympify, (n, k))
         d = n - k
+        is_int = (n.is_integer and k.is_integer)
         if d.is_zero or k.is_zero:
             return S.One
         elif d.is_zero is False:
             if (k - 1).is_zero:
                 return n
             elif k.is_negative:
-                return S.Zero
-            elif n.is_integer and n.is_nonnegative and d.is_negative:
+                if (is_int == S.true or is_int is None) and (n.is_nonnegative or n < k):
+                    return S.Zero
+                if is_int == S.false and k.is_integer:
+                    return S.Zero
+            elif n.is_integer and n.is_nonnegative and d.is_negative and \
+                (is_int == S.true or is_int is None):
                 return S.Zero
         if k.is_Integer and k > 0 and n.is_Number:
             return cls._eval(n, k)
+
 
     def _eval_expand_func(self, **hints):
         """

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -866,7 +866,7 @@ class binomial(CombinatorialFunction):
         elif n.is_negative and n.is_integer and not k.is_integer:
             # a special case when binomial evaluates to complex infinity
             return S.ComplexInfinity
-        elif k.is_Number or k.has(S.ImaginaryUnit):
+        elif k.is_number:
             from sympy import gamma
             return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -862,7 +862,6 @@ class binomial(CombinatorialFunction):
             if n.is_integer and n.is_nonnegative and d.is_negative:
                 return S.Zero
             if n.is_number:
-                from sympy.core.function import expand
                 res = cls._eval(n, k)
                 return res.expand(basic=True) if res else res
         elif n.is_negative and n.is_integer and not k.is_integer:

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -866,7 +866,7 @@ class binomial(CombinatorialFunction):
         elif n.is_negative and n.is_integer and not k.is_integer:
             # a special case when binomial evaluates to complex infinity
             return S.ComplexInfinity
-        elif n.is_Number and k.is_Number:
+        elif k.is_Number or k.has(S.ImaginaryUnit):
             from sympy import gamma
             return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -716,7 +716,7 @@ class binomial(CombinatorialFunction):
     however 'k' must also be nonnegative. This case is very
     useful when evaluating summations.
 
-    For the sake of convenience for negative 'k' this function
+    For the sake of convenience for negative integer 'k' this function
     will return zero no matter what valued is the other argument.
 
     To expand the binomial when n is a symbol, use either
@@ -854,19 +854,21 @@ class binomial(CombinatorialFunction):
         d = n - k
         if d.is_zero or k.is_zero:
             return S.One
-        elif d.is_zero is False:
-            if (k - 1).is_zero:
-                return n
-            if k.is_integer:
-                if k.is_negative:
-                    return S.Zero
-                if n.is_integer and n.is_nonnegative and d.is_negative:
-                    return S.Zero
-                if n.is_Number:
-                    return cls._eval(n, k)
-            elif n.is_Number and k.is_Number:
-                from sympy import gamma
-                return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
+        if (k - 1).is_zero:
+            return n
+        if k.is_integer:
+            if k.is_negative:
+                return S.Zero
+            if n.is_integer and n.is_nonnegative and d.is_negative:
+                return S.Zero
+            if n.is_Number:
+                return cls._eval(n, k)
+        elif n.is_negative and n.is_integer and not k.is_integer:
+            # a special case when binomial evaluates to complex infinity
+            return S.ComplexInfinity
+        elif n.is_Number and k.is_Number:
+            from sympy import gamma
+            return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
 
 
     def _eval_expand_func(self, **hints):

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -864,7 +864,7 @@ class binomial(CombinatorialFunction):
                     return S.Zero
                 if n.is_Number:
                     return cls._eval(n, k)
-            elif k.is_Number and k.is_Number:
+            elif n.is_Number and k.is_Number:
                 from sympy import gamma
                 return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -862,8 +862,9 @@ class binomial(CombinatorialFunction):
             if n.is_integer and n.is_nonnegative and d.is_negative:
                 return S.Zero
             if n.is_number:
-                from sympy.simplify.simplify import simplify
-                return simplify(cls._eval(n, k))
+                from sympy.core.function import expand
+                res = cls._eval(n, k)
+                return res.expand(basic=True) if res else res
         elif n.is_negative and n.is_integer and not k.is_integer:
             # a special case when binomial evaluates to complex infinity
             return S.ComplexInfinity

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -762,10 +762,19 @@ class binomial(CombinatorialFunction):
     -195/128
 
     >>> binomial(n, 3)
-    n*(n - 2)*(n - 1)/6
+    binomial(n, 3)
 
     >>> binomial(n, 3).expand(func=True)
     n**3/6 - n**2/2 + n/3
+
+    >>> expand_func(binomial(n, 3))
+    n*(n - 2)*(n - 1)/6
+
+    References
+    ==========
+
+    .. [1] https://www.johndcook.com/blog/binomial_coefficients/
+
 
     """
 
@@ -841,22 +850,23 @@ class binomial(CombinatorialFunction):
 
     @classmethod
     def eval(cls, n, k):
-        from sympy import gamma
         n, k = map(sympify, (n, k))
         d = n - k
         if d.is_zero or k.is_zero:
             return S.One
-
-        if (k - 1).is_zero:
-            return n
-        if k.is_integer:
-            if k.is_negative:
-                return S.Zero
-            if n.is_integer and n.is_nonnegative and d.is_negative:
-                return S.Zero
-            return cls._eval(n, k)
-
-        return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
+        elif d.is_zero is False:
+            if (k - 1).is_zero:
+                return n
+            if k.is_integer:
+                if k.is_negative:
+                    return S.Zero
+                if n.is_integer and n.is_nonnegative and d.is_negative:
+                    return S.Zero
+                if n.is_Number:
+                    return cls._eval(n, k)
+            elif k.is_Number and k.is_Number:
+                from sympy import gamma
+                return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
 
 
     def _eval_expand_func(self, **hints):

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -295,31 +295,31 @@ def test_binomial():
     assert binomial(S.Half, S.Half) == 1
     assert binomial(-10, 1) == -10
     assert binomial(-10, 7) == -11440
-    assert binomial(n, -1).func == binomial
+    assert binomial(n, -1) == 0
     assert binomial(kp, -1) == 0
     assert binomial(nz, 0) == 1
     assert expand_func(binomial(n, 1)) == n
     assert expand_func(binomial(n, 2)) == n*(n - 1)/2
     assert expand_func(binomial(n, n - 2)) == n*(n - 1)/2
     assert expand_func(binomial(n, n - 1)) == n
-    assert binomial(n, 3).func == binomial
+    assert binomial(n, 3) == n*(n - 2)*(n - 1)/6
     assert binomial(n, 3).expand(func=True) ==  n**3/6 - n**2/2 + n/3
     assert expand_func(binomial(n, 3)) ==  n*(n - 2)*(n - 1)/6
     assert binomial(n, n) == 1
     assert binomial(n, n + 1).func == binomial  # e.g. (-1, 0) == 1
     assert binomial(kp, kp + 1) == 0
-    assert binomial(n, u).func == binomial
-    assert binomial(kp, u) == 0
-    assert binomial(n, p).func == binomial
+    assert binomial(n, u) == gamma(n + 1)/(gamma(u + 1)*gamma(n - u + 1))
+    assert binomial(kp, u) == gamma(kp + 1)/(gamma(u + 1)*gamma(kp - u + 1))
+    assert binomial(n, p) == gamma(n + 1)/(gamma(p + 1)*gamma(n - p + 1))
     assert binomial(n, k).func == binomial
-    assert binomial(n, n + p).func == binomial
-    assert binomial(kp, kp + p) == 0
+    assert binomial(n, n + p) == gamma(n + 1)/(gamma(-p + 1)*gamma(n + p + 1))
+    assert binomial(kp, kp + p) == gamma(kp + 1)/(gamma(-p + 1)*gamma(kp + p + 1))
 
     assert expand_func(binomial(n, n - 3)) == n*(n - 2)*(n - 1)/6
 
     assert binomial(n, k).is_integer
     assert binomial(nt, k).is_integer is None
-    assert binomial(x, nt).is_integer is False
+    assert binomial(x, nt) == gamma(x + 1)/(gamma(nt + 1)*gamma(-nt + x + 1))
 
     assert binomial(gamma(25), 6) == 79232165267303928292058750056084441948572511312165380965440075720159859792344339983120618959044048198214221915637090855535036339620413440000
 
@@ -330,18 +330,16 @@ def test_binomial():
     assert binomial(-23, -12) == 0
     assert binomial(13/2, -10) == 0
 
-    assert binomial(-49, -51) == binomial(-49, -51)
-    assert binomial(19, -7/2).rewrite(gamma) == -68719476736/(911337863661225*pi.evalf())
-    assert binomial(-3, -7/2).rewrite(gamma) == zoo
-    assert binomial(0, S(3)/2).rewrite(gamma) == -2/(3*pi)
+    assert binomial(-49, -51) == 0
+    assert binomial(19, S(-7)/2) == -68719476736/(911337863661225*pi)
+    assert binomial(-3, S(-7)/2) == zoo
+    assert binomial(0, S(3)/2) == -2/(3*pi)
 
-    assert binomial(20/3, -10/8) == binomial(20/3, -5/4)
-    assert binomial(19/2, -7/2) == -1615/8388608
-    assert binomial(-13/5, -7/8) == gamma(-13/5 + 1)/(gamma(-7/8 + 1)*gamma(-13/5 - (-7/8) + 1))
+    assert binomial(S(20)/3, S(-10)/8) == gamma(S(23)/3)/(gamma(S(-1)/4)*gamma(S(107)/12))
+    assert binomial(S(19)/2, S(-7)/2) == S(-1615)/8388608
+    assert binomial(S(-13)/5, S(-7)/8) == gamma(S(-8)/5)/(gamma(S(-29)/40)*gamma(S(1)/8))
 
-    b1 = binomial(S("-19/8"), S("-13/5")).rewrite(gamma)
-    g1 = gamma(S("-11/8"))/(gamma(S("-8/5"))*gamma(S("49/40")))
-    assert b1 == g1
+    assert binomial(S(-19)/8, S(-13)/5) == gamma(S(-11)/8)/(gamma(S(-8)/5)*gamma(S(49)/40))
 
 
 def test_binomial_diff():

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -277,7 +277,7 @@ def test_binomial():
     nz = Symbol('nz', integer=True, nonzero=True)
     k = Symbol('k', integer=True)
     kp = Symbol('kp', integer=True, positive=True)
-    kn =Symbol('kn', integer=True, negative=True)
+    kn = Symbol('kn', integer=True, negative=True)
     u = Symbol('u', negative=True)
     p = Symbol('p', positive=True)
     z = Symbol('z', zero=True)

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -295,31 +295,32 @@ def test_binomial():
     assert binomial(S.Half, S.Half) == 1
     assert binomial(-10, 1) == -10
     assert binomial(-10, 7) == -11440
-    assert binomial(n, -1) == 0
+    assert binomial(n, -1).func == binomial
     assert binomial(kp, -1) == 0
     assert binomial(nz, 0) == 1
     assert expand_func(binomial(n, 1)) == n
     assert expand_func(binomial(n, 2)) == n*(n - 1)/2
     assert expand_func(binomial(n, n - 2)) == n*(n - 1)/2
     assert expand_func(binomial(n, n - 1)) == n
-    assert binomial(n, 3) == n*(n - 2)*(n - 1)/6
+    assert binomial(n, 3).func == binomial
     assert binomial(n, 3).expand(func=True) ==  n**3/6 - n**2/2 + n/3
     assert expand_func(binomial(n, 3)) ==  n*(n - 2)*(n - 1)/6
     assert binomial(n, n) == 1
     assert binomial(n, n + 1).func == binomial  # e.g. (-1, 0) == 1
     assert binomial(kp, kp + 1) == 0
-    assert binomial(n, u) == gamma(n + 1)/(gamma(u + 1)*gamma(n - u + 1))
-    assert binomial(kp, u) == gamma(kp + 1)/(gamma(u + 1)*gamma(kp - u + 1))
-    assert binomial(n, p) == gamma(n + 1)/(gamma(p + 1)*gamma(n - p + 1))
+    assert binomial(n, u).func == binomial
+    assert binomial(kp, u).func == binomial
+    assert binomial(n, p).func == binomial
     assert binomial(n, k).func == binomial
-    assert binomial(n, n + p) == gamma(n + 1)/(gamma(-p + 1)*gamma(n + p + 1))
-    assert binomial(kp, kp + p) == gamma(kp + 1)/(gamma(-p + 1)*gamma(kp + p + 1))
+    assert binomial(n, n + p).func == binomial
+    assert binomial(kp, kp + p).func == binomial
+
 
     assert expand_func(binomial(n, n - 3)) == n*(n - 2)*(n - 1)/6
 
     assert binomial(n, k).is_integer
     assert binomial(nt, k).is_integer is None
-    assert binomial(x, nt) == gamma(x + 1)/(gamma(nt + 1)*gamma(-nt + x + 1))
+    assert binomial(x, nt).is_integer is False
 
     assert binomial(gamma(25), 6) == 79232165267303928292058750056084441948572511312165380965440075720159859792344339983120618959044048198214221915637090855535036339620413440000
 

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -352,6 +352,9 @@ def test_binomial():
     assert binomial(-7, I) == zoo
     assert binomial(-7/S(6), I) == gamma(-1/S(6))/(gamma(-1/S(6) - I)*gamma(1 + I))
     assert binomial((1+2*I), (1+3*I)) == gamma(2 + 2*I)/(gamma(1 - I)*gamma(2 + 3*I))
+    assert binomial(I, 5) == S(1)/3 - I/S(12)
+    assert binomial((2*I + 3), 7) == -13*I/S(63)
+    assert binomial(I, n).func == binomial
 
 
 

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -277,10 +277,12 @@ def test_binomial():
     nz = Symbol('nz', integer=True, nonzero=True)
     k = Symbol('k', integer=True)
     kp = Symbol('kp', integer=True, positive=True)
+    kn =Symbol('kn', integer=True, negative=True)
     u = Symbol('u', negative=True)
     p = Symbol('p', positive=True)
     z = Symbol('z', zero=True)
     nt = Symbol('nt', integer=False)
+    kt = Symbol('kt', integer=False)
     a = Symbol('a', integer=True, nonnegative=True)
     b = Symbol('b', integer=True, nonnegative=True)
 
@@ -295,7 +297,7 @@ def test_binomial():
     assert binomial(S.Half, S.Half) == 1
     assert binomial(-10, 1) == -10
     assert binomial(-10, 7) == -11440
-    assert binomial(n, -1).func == binomial
+    assert binomial(n, -1) == 0
     assert binomial(kp, -1) == 0
     assert binomial(nz, 0) == 1
     assert expand_func(binomial(n, 1)) == n
@@ -315,7 +317,6 @@ def test_binomial():
     assert binomial(n, n + p).func == binomial
     assert binomial(kp, kp + p).func == binomial
 
-
     assert expand_func(binomial(n, n - 3)) == n*(n - 2)*(n - 1)/6
 
     assert binomial(n, k).is_integer
@@ -329,17 +330,18 @@ def test_binomial():
     # issue #13980 and #13981
     assert binomial(-7, -5) == 0
     assert binomial(-23, -12) == 0
-    assert binomial(13/2, -10) == 0
-
+    assert binomial(S(13)/2, -10) == 0
     assert binomial(-49, -51) == 0
-    assert binomial(19, S(-7)/2) == -68719476736/(911337863661225*pi)
-    assert binomial(-3, S(-7)/2) == zoo
-    assert binomial(0, S(3)/2) == -2/(3*pi)
 
+    assert binomial(19, S(-7)/2) == S(-68719476736)/(911337863661225*pi)
+    assert binomial(0, S(3)/2) == S(-2)/(3*pi)
+    assert binomial(-3, S(-7)/2) == zoo
+    assert binomial(kn, kt) == zoo
+
+    assert binomial(nt, kt).func == binomial
     assert binomial(S(20)/3, S(-10)/8) == gamma(S(23)/3)/(gamma(S(-1)/4)*gamma(S(107)/12))
     assert binomial(S(19)/2, S(-7)/2) == S(-1615)/8388608
     assert binomial(S(-13)/5, S(-7)/8) == gamma(S(-8)/5)/(gamma(S(-29)/40)*gamma(S(1)/8))
-
     assert binomial(S(-19)/8, S(-13)/5) == gamma(S(-11)/8)/(gamma(S(-8)/5)*gamma(S(49)/40))
 
 

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -325,6 +325,25 @@ def test_binomial():
 
     assert binomial(a, b).is_nonnegative is True
 
+    # issue #13980 and #13981
+    assert binomial(-7, -5) == 0
+    assert binomial(-23, -12) == 0
+    assert binomial(13/2, -10) == 0
+
+    assert binomial(-49, -51) == binomial(-49, -51)
+    assert binomial(19, -7/2).rewrite(gamma) == -68719476736/(911337863661225*pi.evalf())
+    assert binomial(-3, -7/2).rewrite(gamma) == zoo
+    assert binomial(0, S(3)/2).rewrite(gamma) == -2/(3*pi)
+
+    assert binomial(20/3, -10/8) == binomial(20/3, -5/4)
+    assert binomial(19/2, -7/2) == -1615/8388608
+    assert binomial(-13/5, -7/8) == gamma(-13/5 + 1)/(gamma(-7/8 + 1)*gamma(-13/5 - (-7/8) + 1))
+
+    b1 = binomial(S("-19/8"), S("-13/5")).rewrite(gamma)
+    g1 = gamma(S("-11/8"))/(gamma(S("-8/5"))*gamma(S("49/40")))
+    assert b1 == g1
+
+
 def test_binomial_diff():
     n = Symbol('n', integer=True)
     k = Symbol('k', integer=True)

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -339,10 +339,20 @@ def test_binomial():
     assert binomial(kn, kt) == zoo
 
     assert binomial(nt, kt).func == binomial
+    assert binomial(nt, S(15)/6) == 8*gamma(nt + 1)/(15*sqrt(pi)*gamma(nt - S(3)/2))
     assert binomial(S(20)/3, S(-10)/8) == gamma(S(23)/3)/(gamma(S(-1)/4)*gamma(S(107)/12))
     assert binomial(S(19)/2, S(-7)/2) == S(-1615)/8388608
     assert binomial(S(-13)/5, S(-7)/8) == gamma(S(-8)/5)/(gamma(S(-29)/40)*gamma(S(1)/8))
     assert binomial(S(-19)/8, S(-13)/5) == gamma(S(-11)/8)/(gamma(S(-8)/5)*gamma(S(49)/40))
+
+    # binomial for complexes
+    from sympy import I
+    assert binomial(I, S(-89)/8) == gamma(1 + I)/(gamma(S(-81)/8)*gamma(S(97)/8 + I))
+    assert binomial(I, 2*I) == gamma(1 + I)/(gamma(1 - I)*gamma(1 + 2*I))
+    assert binomial(-7, I) == zoo
+    assert binomial(-7/S(6), I) == gamma(-1/S(6))/(gamma(-1/S(6) - I)*gamma(1 + I))
+    assert binomial((1+2*I), (1+3*I)) == gamma(2 + 2*I)/(gamma(1 - I)*gamma(2 + 3*I))
+
 
 
 def test_binomial_diff():

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -1152,7 +1152,7 @@ class assoc_laguerre(OrthogonalPolynomial):
         x*(-a**2/2 - 5*a/2 - 3) + 1
 
     >>> assoc_laguerre(n, a, 0)
-    binomial(a + n, a)
+    gamma(a + n + 1)/(gamma(a + 1)*gamma(n + 1))
 
     >>> assoc_laguerre(n, a, x)
     assoc_laguerre(n, a, x)

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -1152,7 +1152,7 @@ class assoc_laguerre(OrthogonalPolynomial):
         x*(-a**2/2 - 5*a/2 - 3) + 1
 
     >>> assoc_laguerre(n, a, 0)
-    gamma(a + n + 1)/(gamma(a + 1)*gamma(n + 1))
+    binomial(a + n, a)
 
     >>> assoc_laguerre(n, a, x)
     assoc_laguerre(n, a, x)


### PR DESCRIPTION
Fixes: #13980 
Fixes: #13981 

This PR tries to make binomial more  powerful for negative and nonintegers value of `k` as stated in above issues.

ping @normalhuman @ethankward 