### PR TITLE
Avoid recursive calls for upper and lower gamma

### DIFF
--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -299,7 +299,6 @@ class lowergamma(Function):
 
         # Special values.
         if a.is_Number:
-            # TODO this should be non-recursive
             if a is S.One:
                 return S.One - exp(-x)
             elif a is S.Half:
@@ -449,7 +448,6 @@ class uppergamma(Function):
 
         # Special values.
         if a.is_Number:
-            # TODO this should be non-recursive
             if a is S.One:
                 return exp(-z)
             elif a is S.Half:

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -313,7 +313,7 @@ class lowergamma(Function):
                         return gamma(a) * (lowergamma(S.Half, x)/sqrt(pi) - exp(-x) * Add(*[x**(k-S.Half) / gamma(S.Half+k) for k in range(1, a+S.Half)]))
 
                 if not a.is_Integer:
-                    return (cls(a + 1, x) + x**a * exp(-x))/a
+                    return (-1)**(S.Half - a) * pi*erf(sqrt(x)) / gamma(1-a) + exp(-x) * Add(*[x**(k+a-1)*gamma(a) / gamma(a+k) for k in range(1, S(3)/2-a)])
 
     def _eval_evalf(self, prec):
         from mpmath import mp, workprec
@@ -460,12 +460,12 @@ class uppergamma(Function):
                     if a.is_integer:
                         return exp(-z) * factorial(b) * Add(*[z**k / factorial(k) for k in range(a)])
                     else:
-                        return gamma(a) * erfc(sqrt(z)) + (-1)**(a - S(3)/2) * exp(-z) * sqrt(z) * Add(*[gamma(-S(1)/2 - k) * (-z)**k / gamma(1-a) for k in range(a - S(1)/2)])
+                        return gamma(a) * erfc(sqrt(z)) + (-1)**(a - S(3)/2) * exp(-z) * sqrt(z) * Add(*[gamma(-S.Half - k) * (-z)**k / gamma(1-a) for k in range(a - S.Half)])
                 elif b.is_Integer:
                     return expint(-b, z)*unpolarify(z)**(b + 1)
 
                 if not a.is_Integer:
-                    return (cls(a + 1, z) - z**a * exp(-z))/a
+                    return (-1)**(S.Half - a) * pi*erfc(sqrt(z))/gamma(1-a) - z**a * exp(-z) * Add(*[z**k * gamma(a) / gamma(a+k+1) for k in range(S.Half - a)])
 
     def _eval_conjugate(self):
         z = self.args[1]

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -307,6 +307,8 @@ class lowergamma(Function):
             elif a.is_Integer or (2*a).is_Integer:
                 b = a - 1
                 if b.is_positive:
+                    if a.is_integer:
+                        return factorial(b) - exp(-x) * factorial(b) * sum([x ** k / factorial(k) for k in range(a)])
                     return b*cls(b, x) - x**b * exp(-x)
 
                 if not a.is_Integer:
@@ -454,6 +456,8 @@ class uppergamma(Function):
             elif a.is_Integer or (2*a).is_Integer:
                 b = a - 1
                 if b.is_positive:
+                    if a.is_integer:
+                        return exp(-z) * factorial(b) * sum([z**k / factorial(k) for k in range(a)])
                     return b*cls(b, z) + z**b * exp(-z)
                 elif b.is_Integer:
                     return expint(-b, z)*unpolarify(z)**(b + 1)

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -308,8 +308,9 @@ class lowergamma(Function):
                 b = a - 1
                 if b.is_positive:
                     if a.is_integer:
-                        return factorial(b) - exp(-x) * factorial(b) * sum([x ** k / factorial(k) for k in range(a)])
-                    return b*cls(b, x) - x**b * exp(-x)
+                        return factorial(b) - exp(-x) * factorial(b) * Add(*[x ** k / factorial(k) for k in range(a)])
+                    else:
+                        return gamma(a) * (lowergamma(S.Half, x)/sqrt(pi) - exp(-x) * Add(*[x**(k-S.Half) / gamma(S.Half+k) for k in range(1, a+S.Half)]))
 
                 if not a.is_Integer:
                     return (cls(a + 1, x) + x**a * exp(-x))/a
@@ -457,8 +458,9 @@ class uppergamma(Function):
                 b = a - 1
                 if b.is_positive:
                     if a.is_integer:
-                        return exp(-z) * factorial(b) * sum([z**k / factorial(k) for k in range(a)])
-                    return b*cls(b, z) + z**b * exp(-z)
+                        return exp(-z) * factorial(b) * Add(*[z**k / factorial(k) for k in range(a)])
+                    else:
+                        return gamma(a) * erfc(sqrt(z)) + (-1)**(a - S(3)/2) * exp(-z) * sqrt(z) * Add(*[gamma(-S(1)/2 - k) * (-z)**k / gamma(1-a) for k in range(a - S(1)/2)])
                 elif b.is_Integer:
                     return expint(-b, z)*unpolarify(z)**(b + 1)
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -226,7 +226,7 @@ class lowergamma(Function):
     >>> lowergamma(s, x)
     lowergamma(s, x)
     >>> lowergamma(3, x)
-    -x**2*exp(-x) - 2*x*exp(-x) + 2 - 2*exp(-x)
+    -2*(x**2/2 + x + 1)*exp(-x) + 2
     >>> lowergamma(-S(1)/2, x)
     -2*sqrt(pi)*erf(sqrt(x)) - 2*exp(-x)/sqrt(x)
 
@@ -372,7 +372,7 @@ class uppergamma(Function):
     >>> uppergamma(s, x)
     uppergamma(s, x)
     >>> uppergamma(3, x)
-    x**2*exp(-x) + 2*x*exp(-x) + 2*exp(-x)
+    2*(x**2/2 + x + 1)*exp(-x)
     >>> uppergamma(-S(1)/2, x)
     -2*sqrt(pi)*erfc(sqrt(x)) + 2*exp(-x)/sqrt(x)
     >>> uppergamma(-2, x)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -139,7 +139,9 @@ def test_lowergamma():
     assert lowergamma(k, y).rewrite(expint) == lowergamma(k, y)
     assert lowergamma(x, y).rewrite(uppergamma) == gamma(x) - uppergamma(x, y)
 
-    assert lowergamma(70, 6) == factorial(69) - 69035724522603011058660187038367026272747334489677105069435923032634389419656200387949342530805432320*exp(-6)
+    assert lowergamma(70, 6) == factorial(69) - 69035724522603011058660187038367026272747334489677105069435923032634389419656200387949342530805432320 * exp(-6)
+    assert (lowergamma(S(77) / 2, 6) - lowergamma(S(77) / 2, 6, evaluate=False)).evalf() < 1e-16
+
 
 def test_uppergamma():
     from sympy import meijerg, exp_polar, I, expint
@@ -180,6 +182,7 @@ def test_uppergamma():
     assert uppergamma(x, y).rewrite(lowergamma) == gamma(x) - lowergamma(x, y)
 
     assert uppergamma(70, 6) == 69035724522603011058660187038367026272747334489677105069435923032634389419656200387949342530805432320*exp(-6)
+    assert (uppergamma(S(77) / 2, 6) - uppergamma(S(77) / 2, 6, evaluate=False)).evalf() < 1e-16
 
 
 def test_polygamma():

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -139,6 +139,8 @@ def test_lowergamma():
     assert lowergamma(k, y).rewrite(expint) == lowergamma(k, y)
     assert lowergamma(x, y).rewrite(uppergamma) == gamma(x) - uppergamma(x, y)
 
+    assert lowergamma(70, 6) == factorial(69) - 69035724522603011058660187038367026272747334489677105069435923032634389419656200387949342530805432320*exp(-6)
+
 def test_uppergamma():
     from sympy import meijerg, exp_polar, I, expint
     assert uppergamma(4, 0) == 6
@@ -176,6 +178,8 @@ def test_uppergamma():
 
     assert uppergamma(x, y).rewrite(expint) == y**x*expint(-x + 1, y)
     assert uppergamma(x, y).rewrite(lowergamma) == gamma(x) - lowergamma(x, y)
+
+    assert uppergamma(70, 6) == 69035724522603011058660187038367026272747334489677105069435923032634389419656200387949342530805432320*exp(-6)
 
 
 def test_polygamma():

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -141,6 +141,7 @@ def test_lowergamma():
 
     assert lowergamma(70, 6) == factorial(69) - 69035724522603011058660187038367026272747334489677105069435923032634389419656200387949342530805432320 * exp(-6)
     assert (lowergamma(S(77) / 2, 6) - lowergamma(S(77) / 2, 6, evaluate=False)).evalf() < 1e-16
+    assert (lowergamma(-S(77) / 2, 6) - lowergamma(-S(77) / 2, 6, evaluate=False)).evalf() < 1e-16
 
 
 def test_uppergamma():
@@ -183,7 +184,7 @@ def test_uppergamma():
 
     assert uppergamma(70, 6) == 69035724522603011058660187038367026272747334489677105069435923032634389419656200387949342530805432320*exp(-6)
     assert (uppergamma(S(77) / 2, 6) - uppergamma(S(77) / 2, 6, evaluate=False)).evalf() < 1e-16
-
+    assert (uppergamma(-S(77) / 2, 6) - uppergamma(-S(77) / 2, 6, evaluate=False)).evalf() < 1e-16
 
 def test_polygamma():
     from sympy import I


### PR DESCRIPTION
lowergamma(70,6) / uppergamma(70,6) would cause recursion errors. Added cases to compute these without recursion and testcases.

Recursion error example:

```
>>> sympy.__version__
'1.1.2.dev'
>>> sympy.uppergamma(70,6)
Traceback (most recent call last):
  File "<pyshell#2>", line 1, in <module>
    sympy.uppergamma(70,6)
  File "C:\Users\ethan\Desktop\sympy-master\sympy\core\cache.py", line 93, in wrapper
    retval = cfunc(*args, **kwargs)
  File "C:\Users\ethan\Desktop\sympy-master\sympy\core\function.py", line 439, in __new__
    result = super(Function, cls).__new__(cls, *args, **options)
...
  File "C:\Users\ethan\Desktop\sympy-master\sympy\functions\special\gamma_functions.py", line 438, in eval
    nx = unpolarify(z)
  File "C:\Users\ethan\Desktop\sympy-master\sympy\functions\elementary\complexes.py", line 1157, in unpolarify
    return res.subs({exp_polar(0): 1, polar_lift(0): 0})
  File "C:\Users\ethan\Desktop\sympy-master\sympy\core\basic.py", line 878, in subs
    sequence[i] = None if _aresame(*s) else tuple(s)
  File "C:\Users\ethan\Desktop\sympy-master\sympy\core\basic.py", line 1765, in _aresame
    if i != j or type(i) != type(j):
  File "C:\Users\ethan\Desktop\sympy-master\sympy\core\basic.py", line 342, in __ne__
    return not self == other
  File "C:\Users\ethan\Desktop\sympy-master\sympy\core\basic.py", line 318, in __eq__
    from sympy import Pow
  File "<frozen importlib._bootstrap>", line 1000, in _handle_fromlist
RecursionError: maximum recursion depth exceeded in comparison
```