### PR TITLE
Plotting constant function

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1808,7 +1808,7 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
             for symbol in free_symbols:
                 ranges.append(Tuple(symbol) + default_range)
 
-            for i in range(len(free_symbols) - nb_of_free_symbols):
+            for i in range(nb_of_free_symbols - len(free_symbols)):
                 ranges.append(Tuple(Dummy()) + default_range)
             ranges = Tuple(*ranges)
             plots = [expr + ranges for expr in exprs]

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -87,6 +87,13 @@ def plot_and_save(name):
     p.save(tmp_file('%s_plot_piecewise_2' % name))
     p._backend.close()
 
+    # test issue 7471
+    p1 = plot(x)
+    p2 = plot(3)
+    p1.extend(p2)
+    p.save(tmp_file('%s_horizontal_line' % name))
+    p._backend.close()
+
     # test issue 10925
     f = Piecewise((-1, x < -1), (x, And(-1 <= x, x < 0)), \
         (x**2, And(0 <= x, x < 1)), (x**3, x >= 1))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #7471

#### Brief description of what is fixed or changed

Currently `plot(3)` (plotting a constant function with default range) raises an error for lack of a range tuple such (x, -10, 10). There was already some code to add range tuples with Dummy() as needed, but it had a minus sign error, and was only adding dummies if there were *more* symbols than expected. The off-by-minus error is corrected.