### PR TITLE
Fix the negative rational powers of negative integers and rationals

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1678,11 +1678,7 @@ class Rational(Number):
                 if (ne is S.One):
                     return Rational(self.q, self.p)
                 if self.is_negative:
-                    if expt.q != 1:
-                        return -(S.NegativeOne)**((expt.p % expt.q) /
-                               S(expt.q))*Rational(self.q, -self.p)**ne
-                    else:
-                        return S.NegativeOne**ne*Rational(self.q, -self.p)**ne
+                    return S.NegativeOne**expt*Rational(self.q, -self.p)**ne
                 else:
                     return Rational(self.q, self.p)**ne
             if expt is S.Infinity:  # -oo already caught by test for negative
@@ -2223,11 +2219,7 @@ class Integer(Rational):
             # invert base and change sign on exponent
             ne = -expt
             if self.is_negative:
-                if expt.q != 1:
-                    return -(S.NegativeOne)**((expt.p % expt.q) /
-                            S(expt.q))*Rational(1, -self)**ne
-                else:
-                    return (S.NegativeOne)**ne*Rational(1, -self)**ne
+                    return S.NegativeOne**expt*Rational(1, -self)**ne
             else:
                 return Rational(1, self.p)**ne
         # see if base is a perfect root, sqrt(4) --> 2

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1041,6 +1041,10 @@ def test_powers_Integer():
         -(-1)**Rational(2, 3)*3**Rational(2, 3)/27
     assert (-3) ** Rational(-2, 3) == \
         -(-1)**Rational(1, 3)*3**Rational(1, 3)/3
+    assert (-2) ** Rational(-10, 3) == \
+        (-1)**Rational(2, 3)*2**Rational(2, 3)/16
+    assert abs(Pow(-2, Rational(-10, 3)).n() -
+        Pow(-2, Rational(-10, 3), evaluate=False).n()) < 1e-16
 
     # negative base and rational power with some simplification
     assert (-8) ** Rational(2, 5) == \
@@ -1121,6 +1125,10 @@ def test_powers_Rational():
         -4*(-1)**Rational(2, 3)*2**Rational(1, 3)*3**Rational(2, 3)/27
     assert Rational(-3, 2)**Rational(-2, 3) == \
         -(-1)**Rational(1, 3)*2**Rational(2, 3)*3**Rational(1, 3)/3
+    assert Rational(-3, 2)**Rational(-10, 3) == \
+        8*(-1)**Rational(2, 3)*2**Rational(1, 3)*3**Rational(2, 3)/81
+    assert abs(Pow(Rational(-2, 3), Rational(-7, 4)).n() -
+        Pow(Rational(-2, 3), Rational(-7, 4), evaluate=False).n()) < 1e-16
 
     # negative integer power and negative rational base
     assert Rational(-2, 3) ** Rational(-2, 1) == Rational(9, 4)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14018

#### Brief description of what is fixed or changed

Given `b**expt` where b and expt are negative, SymPy tries to reduce this to positive base and exponent. For integer b and rational expt, it [currently rewrites](https://github.com/sympy/sympy/blob/master/sympy/core/numbers.py#L2225) as

```
-(-1)**((expt.p % expt.q) / S(expt.q))*Rational(1, -b)**(-expt)
```
which is incorrect. The correct formula would be
```
(-1)**m * (-1)**(k / S(expt.q))*Rational(1, -b)**(-expt)
```
where `m, k = divmod(p, q)`. For odd m the two formulas agree, and only this case was covered by tests.

Since the correct logic was already [implemented in NegativeOne class](https://github.com/sympy/sympy/blob/master/sympy/core/numbers.py#L2629), instead of duplicating the code I went with the rewrite
```
(-1)**expt * Rational(1, -b)**(-expt)
```

Some examples of incorrect evaluation in current master

```
>>> Pow(-2, -S(10)/3).n()
0.0496062828740062 - 0.0859206023124127*I   # wrong
>>> Pow(-2, -S(10)/3, evaluate=False).n()
-0.0496062828740062 + 0.0859206023124127*I  # correct
>>> (-2)**(-10/3)
(-0.049606282874006216+0.08592060231241266j)  # Python agrees
```

```
>>> Pow(S(-2)/3), S(-7)/4).n()
-1.43762198455411 - 1.43762198455411*I      # wrong
>>> Pow(S(-2)/3), S(-7)/4, evaluate=False).n()
1.43762198455411 + 1.43762198455411*I       # correct
>>> (-2/3)**(-7/4)
(1.437621984554113+1.4376219845541136j)     # Python agrees
```
 

 
