### PR TITLE
Minor change in operations._has_matcher

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -279,7 +279,7 @@ class AssocOp(Basic):
                     if not nc:
                         return True
                     elif len(nc) <= len(_nc):
-                        for i in range(len(_nc) - len(nc)):
+                        for i in range(len(_nc) - len(nc) + 1):
                             if _nc[i:i + len(nc)] == nc:
                                 return True
             return False

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -1,4 +1,4 @@
-from sympy import Integer, S
+from sympy import Integer, S, symbols, Mul
 from sympy.core.operations import LatticeOp
 from sympy.utilities.pytest import raises
 from sympy.core.sympify import SympifyError
@@ -39,3 +39,10 @@ def test_lattice_make_args():
     assert join.make_args(0) == {0}
     assert list(join.make_args(0))[0] is S.Zero
     assert Add.make_args(0)[0] is S.Zero
+
+
+def test_issue_14025():
+    a, b, c, d = symbols('a,b,c,d', commutative=False)
+    assert Mul(a, b, c).has(c*b) == False
+    assert Mul(a, b, c).has(b*c) == True
+    assert Mul(a, b, c, d).has(b*c*d) == True


### PR DESCRIPTION
### Fixes #14025 

`has` gave error only when the last `symbol` of a non-commutative `Mul` was involved. 
```
>>> (a*b*c*d).has(b*c)
True
>>> (a*b*c*d).has(b*c*d)
False
```
This was fixed by increasing one iteration inside `_has_matcher` function.
I was unable to find dedicated tests for `has` functions so i added `test_issue_14025` inside `operations.py`.