### PR TITLE
Convert E to an element of fields such as Z(exp(1/2))

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1262,3 +1262,7 @@ def test_issue_12645():
 
 def test_issue_12677():
     assert integrate(sin(x) / (cos(x)**3) , (x, 0, pi/6)) == Rational(1,6)
+
+def test_issue_14027():
+    assert integrate(1/(1 + exp(x - S(1)/2)/(1 + exp(x))), x) == \
+        x - exp(S(1)/2)*log(exp(x) + exp(S(1)/2)/(1 + exp(S(1)/2)))/(exp(S(1)/2) + E)

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -6,7 +6,7 @@ from sympy.polys.domains import ZZ, QQ
 from sympy.polys.orderings import lex
 
 from sympy.utilities.pytest import raises, XFAIL
-from sympy.core import symbols, E
+from sympy.core import symbols, E, S
 from sympy import sqrt, Rational, exp, log
 
 def test_FracField___init__():
@@ -132,6 +132,8 @@ def test_FracElement_from_expr():
     assert isinstance(ZZ[2**x].get_field().convert(2**(-x)),
         FracElement)
     assert isinstance(ZZ[x**2].get_field().convert(x**(-6)),
+        FracElement)
+    assert isinstance(ZZ[exp(S(1)/3)].get_field().convert(E),
         FracElement)
 
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14027

#### Brief description of what is fixed or changed

The number E was not recognized as an element of the field Z(exp(1/2)) and similar. The code intended to handle such issues did not deal with E because it does not inherit from ExpBase. Now E is treated along with  `Pow` and `exp` objects.