### PR TITLE
If the term of a Product is Add, just factor it

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -275,18 +275,9 @@ class Product(ExprWithIntLimits):
             return poly.LC()**(n - a + 1) * A * B
 
         elif term.is_Add:
-            p, q = term.as_numer_denom()
-            q = self._eval_product(q, (k, a, n))
-            if q.is_Number:
-
-                # There is expression, which couldn't change by
-                # as_numer_denom(). E.g. n**(2/3) + 1 --> (n**(2/3) + 1, 1).
-                # We have to catch this case.
-                from sympy.concrete.summations import Sum
-                p = exp(Sum(log(p), (k, a, n)))
-            else:
-                p = self._eval_product(p, (k, a, n))
-            return p / q
+            factored = term.factor()
+            if factored.is_Mul:
+                return self._eval_product(factored, (k, a, n))
 
         elif term.is_Mul:
             exclude, include = [], []

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -5,6 +5,7 @@ from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.concrete.expr_with_intlimits import ExprWithIntLimits
+from sympy.core.exprtools import factor_terms
 from sympy.functions.elementary.exponential import exp, log
 from sympy.polys import quo, roots
 from sympy.simplify import powsimp
@@ -275,7 +276,7 @@ class Product(ExprWithIntLimits):
             return poly.LC()**(n - a + 1) * A * B
 
         elif term.is_Add:
-            factored = term.factor()
+            factored = factor_terms(term, fraction=True)
             if factored.is_Mul:
                 return self._eval_product(factored, (k, a, n))
 

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -1,5 +1,5 @@
 from sympy import (symbols, Symbol, product, factorial, rf, sqrt, cos,
-                   Function, Product, Rational, Sum, oo, exp, log, S)
+                   Function, Product, Rational, Sum, oo, exp, log, S, pi)
 from sympy.utilities.pytest import raises
 from sympy import simplify
 
@@ -360,6 +360,11 @@ def test_issue_13546():
     k = Symbol('k')
     p = Product(n + 1 / 2**k, (k, 0, n-1)).doit()
     assert p.subs(n, 2).doit() == S(15)/2
+
+
+def test_issue_14036():
+    a, n = symbols('a n')
+    assert product(1 - a**2 / (n*pi)**2, [n, 1, oo]) != 0
 
 
 def test_rewrite_Sum():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14036

#### Brief description of what is fixed or changed

The product-evaluating code handling the case `term.is_Add` was trying questionable things, such as rewriting as sum of logarithms (only possible with positive terms), or computing the product of denominators and then deciding that the rewrite didn't work if the result was is_Number (when it fact this could mean the product of computed).

Realistically, all we can do with an Add in a product is to factor it, and let the code for `term.is_Mul` do the rest. If it doesn't factor, give up. This is what is done now.