### PR TITLE
Don't trade one logarithm for another when integrating by parts

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -24,10 +24,12 @@ import sympy
 
 from sympy.core.compatibility import reduce
 from sympy.core.logic import fuzzy_not
+from sympy.core.singleton import S
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.core.relational import Eq, Ne
+from sympy.polys.polytools import degree
 
 ZERO = sympy.S.Zero
 
@@ -391,6 +393,12 @@ def _parts_rule(integrand, symbol):
             # Don't pick a non-polynomial algebraic to be differentiated
             if rule == pull_out_algebraic and not u.is_polynomial(symbol):
                 return
+            # Don't trade one logarithm for another
+            if isinstance(u, sympy.log):
+                rec_dv = sympy.Pow(dv, S.NegativeOne)
+                if (rec_dv.is_polynomial(symbol) and
+                    degree(rec_dv, symbol) is S.One):
+                        return
 
             for rule in liate_rules[index + 1:]:
                 r = rule(integrand)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -24,7 +24,6 @@ import sympy
 
 from sympy.core.compatibility import reduce
 from sympy.core.logic import fuzzy_not
-from sympy.core.singleton import S
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.strategies.core import switch, do_one, null_safe, condition
@@ -395,9 +394,9 @@ def _parts_rule(integrand, symbol):
                 return
             # Don't trade one logarithm for another
             if isinstance(u, sympy.log):
-                rec_dv = sympy.Pow(dv, S.NegativeOne)
+                rec_dv = 1/dv
                 if (rec_dv.is_polynomial(symbol) and
-                    degree(rec_dv, symbol) is S.One):
+                    degree(rec_dv, symbol) == 1):
                         return
 
             for rule in liate_rules[index + 1:]:

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -48,6 +48,8 @@ def test_manualintegrate_parts():
     assert manualintegrate((3*x**2 + 5) * exp(x), x) == \
         3*x**2*exp(x) - 6*x*exp(x) + 11*exp(x)
     assert manualintegrate(atan(x), x) == x*atan(x) - log(x**2 + 1)/2
+    # Make sure _parts_rule does not go into an infinite loop here
+    assert manualintegrate(log(1/x)/(x + 1), x).has(Integral)
 
     # Make sure _parts_rule doesn't pick u = constant but can pick dv =
     # constant if necessary, e.g. for integrate(atan(x))


### PR DESCRIPTION
#### Brief description of what is fixed or changed

In current master (and in 1.1.1) `integrate(log(1/x)/(1+x), x)` and similar integrals hang because manualintegrate keeps applying integration by parts, turning logarithm into 1/x and the other factor into logarithm. This is now prevented.

#### Other comments

Aside: Meijer G can handle this integral if x is declared positive, because then log(1/x) can be rewritten to -log(x). But it fails without this assumption.





