### PR TITLE
Replace **kwargs with explicit keyword arguments, for sympy/solvers module

### DIFF
--- a/sympy/solvers/bivariate.py
+++ b/sympy/solvers/bivariate.py
@@ -305,7 +305,7 @@ def _solve_lambert(f, symbol, gens):
     return list(ordered(soln))
 
 
-def bivariate_type(f, x, y, **kwargs):
+def bivariate_type(f, x, y, first=True):
     """Given an expression, f, 3 tests will be done to see what type
     of composite bivariate it might be, options for u(x, y) are::
 
@@ -324,6 +324,10 @@ def bivariate_type(f, x, y, **kwargs):
     ``P(u) = 0`` when ``p`` are the solutions of ``P(u) = 0``.
 
     Only positive values of ``u`` are considered.
+
+    If the first is True, this will result, the variables of the ``f`` will
+    be replaced by the dummy variables _x, _y and bivariate_type() will be called
+    back with first=False, which will calculate the actual bivarients, if possible
 
     Examples
     ========
@@ -346,7 +350,7 @@ def bivariate_type(f, x, y, **kwargs):
 
     u = Dummy('u', positive=True)
 
-    if kwargs.pop('first', True):
+    if first:
         p = Poly(f, x, y)
         f = p.as_expr()
         _x = Dummy()

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -663,7 +663,7 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             hint = hints['hint']
             return _helper_simplify(eq, hint, hints, simplify, ics=ics)
 
-def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
+def _helper_simplify(eq, hint, match, simplify=True, ics=None):
     r"""
     Helper function of dsolve that calls the respective
     :py:mod:`~sympy.solvers.ode` functions to solve for the ordinary
@@ -812,7 +812,8 @@ def solve_ics(sols, funcs, constants, ics):
 
     return solved_constants[0]
 
-def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
+def classify_ode(eq, func=None, dict=False, ics=None, xi=None, eta=None,
+        n=None, x0=0, prep=True):
     r"""
     Returns a tuple of possible :py:meth:`~sympy.solvers.ode.dsolve`
     classifications for an ODE.
@@ -840,6 +841,18 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     See :py:data:`~sympy.solvers.ode.allhints` or the
     :py:mod:`~sympy.solvers.ode` docstring for a list of all supported hints
     that can be returned from :py:meth:`~sympy.solvers.ode.classify_ode`.
+
+    Keyword arguments
+    :prep -- True/False, if true then it preprocess the equality and then generate a function from it,
+    which is _preprocess()
+
+    :n -- no. of terms
+
+    :eta -- Used for the lie_group hint
+
+    :x0 -- Point, to find out a definite power series solution
+
+    :xi -- Used for the lie_group hint
 
     Notes
     =====
@@ -910,7 +923,6 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         will evaluate all hints and return the best, using the same
         considerations as the normal ``best`` meta-hint.
 
-
     Examples
     ========
 
@@ -934,7 +946,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     """
     ics = sympify(ics)
 
-    prep = kwargs.pop('prep', True)
+    # prep = kwargs.pop('prep', True)
 
     if func and len(func.args) != 1:
         raise ValueError("dsolve() and classify_ode() only "
@@ -946,10 +958,10 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     x = func.args[0]
     f = func.func
     y = Dummy('y')
-    xi = kwargs.get('xi')
-    eta = kwargs.get('eta')
-    terms = kwargs.get('n')
-
+    # xi = kwargs.get('xi')
+    # eta = kwargs.get('eta')
+    # terms = kwargs.get('n')
+    terms = n
     if isinstance(eq, Equality):
         if eq.rhs != 0:
             return classify_ode(eq.lhs - eq.rhs, func, ics=ics, xi=xi,
@@ -1311,7 +1323,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
             if all([r[key].is_polynomial() for key in r]):
                 p = cancel(r[b3]/r[a3])  # Used below
                 q = cancel(r[c3]/r[a3])  # Used below
-                point = kwargs.get('x0', 0)
+                point = x0
                 check = p.subs(x, point)
                 if not check.has(oo) and not check.has(NaN) and \
                     not check.has(zoo) and not check.has(-oo):
@@ -1414,7 +1426,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     else:
         return tuple(retlist)
 
-def classify_sysode(eq, funcs=None, **kwargs):
+def classify_sysode(eq, funcs=None):
     r"""
     Returns a dictionary of parameter names and values that define the system
     of ordinary differential equations in ``eq``.

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -230,7 +230,8 @@ def _handle_Integral(expr, func, order, hint):
         return expr
 
 
-def classify_pde(eq, func=None, dict=False, **kwargs):
+def classify_pde(eq, func=None, dict=False, ics=None, xi=None, eta=0,
+        n=None, x0=0, prep=True):
     """
     Returns a tuple of possible pdsolve() classifications for a PDE.
 
@@ -246,6 +247,9 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     hint:match expression terms. This is intended for internal use by
     pdsolve().  Note that because dictionaries are ordered arbitrarily,
     this will most likely not be in the same order as the tuple.
+
+    If ``prep`` is true, and func is None then it will preprocess the equation and
+    will get the function from preprocessing of the equation
 
     You can get help on different hints by doing help(pde.pde_hintname),
     where hintname is the name of the hint without "_Integral".
@@ -268,9 +272,6 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     >>> classify_pde(eq)
     ('1st_linear_constant_coeff_homogeneous',)
     """
-
-    prep = kwargs.pop('prep', True)
-
     if func and len(func.args) != 2:
         raise NotImplementedError("Right now only partial "
             "differential equations of two variables are supported")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Partial fix for #14030 and have reference with #13683

#### Brief description of what is fixed or changed
Removed unnecessary `**kwargs`, replaced `**kwargs` with the explicit keyword arguments, and documented explicit keyword arguments
Changes are
For the sympy/solvers module
  - removed unnecessary **kwargs from the arguments of the `_helper_simplify()`, in ode.py
  - removed unnecessary **kwargs from the arguments of the `classify_sysode()`, in ode.py
  - replaced `**kwargs` to `prep=True` in the arguments of the `classify_pde()`, in pde.py
  - replaced `**kwargs` to `first=True` in the arguments of the `bivariate_type()`, in bivariate.py
  - replaced `**kwargs` to `xi=None, eta=None, n=None, x0=0, prep=True` in the `classify_ode`, in ode.py



#### Other comments
