### PR TITLE
Use different tractable forms of erf for different points

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -181,7 +181,16 @@ class erf(Function):
         return sqrt(z**2)/z - z*expint(S.Half, z**2)/sqrt(S.Pi)
 
     def _eval_rewrite_as_tractable(self, z):
-        return S.One - _erfs(z)*exp(-z**2)
+        from sympy.series.limits import limit
+        if len(z.free_symbols) == 1:
+            sym = next(iter(z.free_symbols))
+            L = limit(z, sym, S.Infinity)
+            if L is S.Infinity:
+                return S.One - _erfs(z)*exp(-z**2)
+            elif L is S.NegativeInfinity:
+                return S.NegativeOne + _erfs(-z)*exp(-z**2)
+        else: # fall back on old behavior for compatibility
+            return S.One - _erfs(z)*exp(-z**2)
 
     def _eval_rewrite_as_erfc(self, z):
         return S.One - erfc(z)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -64,6 +64,11 @@ def test_erf():
     assert limit((1 - erf(z))*exp(z**2)*z, z, oo) == 1/sqrt(pi)
     assert limit((1 - erf(x))*exp(x**2)*sqrt(pi)*x, x, oo) == 1
     assert limit(((1 - erf(x))*exp(x**2)*sqrt(pi)*x - 1)*2*x**2, x, oo) == -1
+    assert limit(erf(x), x, oo) == 1
+    assert limit(erf(sqrt(x) - x), x, oo) == -1
+    assert limit(erf(x), x, -oo) == -1
+    assert limit(erf(x)/x, x, 0) == 2/sqrt(pi)
+    assert limit(x**(-4) - sqrt(pi)*erf(x**2) / (2*x**6), x, 0) == S(1)/3
 
     assert erf(x).as_real_imag() == \
         ((erf(re(x) - I*re(x)*Abs(im(x))/Abs(re(x)))/2 +


### PR DESCRIPTION
#### References to other Issues or PRs

Addresses a part of #13750 but does not solve it.

#### Brief description of what is fixed or changed

Presently, every time a limit involving erf is taken, erf is rewritten as "1 - (something small as x->oo)", which operates under assumption that the argument of erf tends to oo. As noted in #13750, this leads to wrong limit values: e.g., limit(erf(sqrt(x) - x), x, oo) is claimed to be 1 (it's -1). Also, very basic limits at finite points, such as limit(erf(x)/x, x, 0), return unevaluated. Both of these are corrected by this patch, which changes `erf.eval_rewrite_as_tractable` so it depends on the limit of the argument of erf.

#### Other comments

This is only a partial solution, because it only works if the argument of erf has 1 symbol. With multiple symbols, the rewriting method has no knowledge of which symbol tends to oo. The possibility of passing this information to `_eval_rewrite` methods should be considered.