### PR TITLE
changes in piecewise_intervals

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -775,7 +775,8 @@ class Piecewise(Function):
                     lower = upper = rhs
                     cond = cond.subs(sym, lower)
                     if cond is S.true:
-                        cond = Eq(sym, lower)
+                        int_expr.append((rhs, rhs, expr.subs(sym, rhs), iarg))
+                        continue
 
                 # cond might have evaluated b/c of an Eq
                 if cond is S.true:
@@ -807,7 +808,7 @@ class Piecewise(Function):
             int_expr.append(
                 (S.NegativeInfinity, S.Infinity, default, idefault))
 
-        return int_expr
+        return list(uniq(int_expr))
 
     def _eval_nseries(self, x, n, logx):
         args = [(ec.expr._eval_nseries(x, n, logx), ec.cond) for ec in self.args]

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -773,11 +773,8 @@ class Piecewise(Function):
                         nonsym = cond2
                 if rhs is not None and cond not in (S.true, S.false):
                     lower = upper = rhs
-                    cond_temp = cond.subs(sym, lower)
-
-                    if cond_temp is S.false:
-                        cond = S.false
-                    if cond_temp is S.true:
+                    cond = cond.subs(sym, lower)
+                    if cond is S.true:
                         cond = Eq(sym, lower)
 
                 # cond might have evaluated b/c of an Eq

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy.core import Basic, S, Function, diff, Tuple, Dummy, Number
+from sympy.core import Basic, S, Function, diff, Tuple, Dummy, Number, Eq
 from sympy.core.basic import as_Basic
 from sympy.core.sympify import SympifyError
 from sympy.core.relational import Equality, Relational, _canonical
@@ -773,7 +773,13 @@ class Piecewise(Function):
                         nonsym = cond2
                 if rhs is not None and cond not in (S.true, S.false):
                     lower = upper = rhs
-                    cond = cond.subs(sym, lower)
+                    cond_temp = cond.subs(sym, lower)
+
+                    if cond_temp is S.false:
+                        cond = S.false
+                    if cond_temp is S.true:
+                        cond = Eq(sym, lower)
+
                 # cond might have evaluated b/c of an Eq
                 if cond is S.true:
                     default = expr

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -2,7 +2,7 @@ from sympy import (
     adjoint, And, Basic, conjugate, diff, expand, Eq, Function, I, ITE,
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, solve, symbols, transpose,
-    cos, exp, Abs, Ne, Not, Symbol, S, sqrt, Tuple, zoo,
+    cos, sin, exp, Abs, Ne, Not, Symbol, S, sqrt, Tuple, zoo,
     factor_terms, DiracDelta, Heaviside)
 from sympy.printing import srepr
 from sympy.utilities.pytest import XFAIL, raises
@@ -936,6 +936,9 @@ def test__intervals():
         (1, True))._intervals(x) == [(-oo, oo, 1, 1)]
     assert Piecewise((1, Ne(x, I)), (0, True))._intervals(x) == [
         (-oo, oo, 1, 0)]
+    assert Piecewise((-cos(x), sin(x) >= 0), (cos(x), True))._intervals(x) == [
+        (2*pi, 2*pi, -1, 0), (0, pi, -cos(x), 0), (2*pi, 2*pi, -cos(x), 0),
+         (-oo, oo, cos(x), 1)]
 
 
 def test_containment():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -937,8 +937,7 @@ def test__intervals():
     assert Piecewise((1, Ne(x, I)), (0, True))._intervals(x) == [
         (-oo, oo, 1, 0)]
     assert Piecewise((-cos(x), sin(x) >= 0), (cos(x), True))._intervals(x) == [
-        (2*pi, 2*pi, -1, 0), (0, pi, -cos(x), 0), (2*pi, 2*pi, -cos(x), 0),
-         (-oo, oo, cos(x), 1)]
+        (2*pi, 2*pi, -1, 0), (0, pi, -cos(x), 0), (-oo, oo, cos(x), 1)]
 
 
 def test_containment():


### PR DESCRIPTION
Fixes #14052

Apparently, [this](https://github.com/sympy/sympy/blob/03c95790b622f6be146ea707bc13a86784f61043/sympy/functions/elementary/piecewise.py#L774l) `if` block is used whenever the `cond` have both an equality relation (`Eq`) and as well as some inequalities. It tries to evaluate that condition to either `True` or `False` at that point of equality. example: if `cond = (x <= pi) & Eq(x, 2*pi) ` then this `if` condition will make `cond =False` as both cant occur simultaneously.

In the example that @normalhuman gave, it was this line which evaluated `(0 <= x) & Eq(x, 2*pi)` to `True` without any constraint of `Eq(x, 2*pi)`, which is wrong. Now for that case:
```
>>> x = symbols('x')
>>> Piecewise((-cos(x), sin(x) >= 0), (cos(x), True))._intervals(x)
[(2*pi, 2*pi, -1, 0), (0, pi, -cos(x), 0), (2*pi, 2*pi, -cos(x), 0), (-oo, oo, cos(x), 1)]
```
We can stop this repetition of tuples at point {2*pi} by simply adding a check maybe. But as this method is used for various other purposes, i didnt tried to change this output much.
