### PR TITLE
Added root_notation flag to latex and pretty printers

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2166,9 +2166,7 @@ def latex(expr, **settings):
     >>> print(latex((2*mu)**Rational(7,2), mode='equation', itex=True))
     $$8 \sqrt{2} \mu^{\frac{7}{2}}$$
 
-    root_notation: Specifies if expressions having rational powers of the form
-    1/n are to be printed in their root form or fractional form. The default
-    value is 'True' for root form, False otherwise.
+    root_notation: Use root form for powers with exponent of the form 1/n. Default is True.
 
     >>> print(latex(x**Rational(1, 7)))
     \sqrt[7]{x}

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2166,6 +2166,15 @@ def latex(expr, **settings):
     >>> print(latex((2*mu)**Rational(7,2), mode='equation', itex=True))
     $$8 \sqrt{2} \mu^{\frac{7}{2}}$$
 
+    root_notation: Specifies if expressions having rational powers of the form
+    1/n are to be printed in their root form or fractional form. The default
+    value is 'True' for root form, False otherwise.
+
+    >>> print(latex(x**Rational(1, 7)))
+    \sqrt[7]{x}
+    >>> print(latex(x**Rational(1, 7), root_notation = False))
+    x^{\frac{1}{7}}
+
     fold_frac_powers: Emit "^{p/q}" instead of "^{\frac{p}{q}}" for fractional
     powers.
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -125,6 +125,7 @@ class LatexPrinter(Printer):
         "order": None,
         "mode": "plain",
         "itex": False,
+        "root_notation": True,
         "fold_frac_powers": False,
         "fold_func_brackets": False,
         "fold_short_frac": None,
@@ -481,7 +482,7 @@ class LatexPrinter(Printer):
 
     def _print_Pow(self, expr):
         # Treat x**Rational(1,n) as special case
-        if expr.exp.is_Rational and abs(expr.exp.p) == 1 and expr.exp.q != 1:
+        if expr.exp.is_Rational and abs(expr.exp.p) == 1 and expr.exp.q != 1 and self._settings['root_notation']:
             base = self._print(expr.base)
             expq = expr.exp.q
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2285,10 +2285,8 @@ def pretty_print(expr, **settings):
     use_unicode : bool or None, optional
         use unicode characters, such as the Greek letter pi instead of
         the string pi.
-    root_notation : bool, optional
-        use root form or fractional form for expressions having rational
-        roots of the form 1/n. Set to False for fractional form;
-        default is True.
+    root_notation : bool
+        use root form for powers with exponent of the form 1/n. Default is True.
     full_prec : bool or string, optional
         use full precision. Default to "auto"
     order : bool or string, optional

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2285,6 +2285,10 @@ def pretty_print(expr, **settings):
     use_unicode : bool or None, optional
         use unicode characters, such as the Greek letter pi instead of
         the string pi.
+    root_notation : bool, optional
+        use root form or fractional form for expressions having rational
+        roots of the form 1/n. Set to False for fractional form;
+        default is True.
     full_prec : bool or string, optional
         use full precision. Default to "auto"
     order : bool or string, optional

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -42,6 +42,7 @@ class PrettyPrinter(Printer):
         "order": None,
         "full_prec": "auto",
         "use_unicode": None,
+        "root_notation": True,
         "wrap_line": True,
         "num_columns": None,
         "use_unicode_sqrt_char": True,
@@ -1584,7 +1585,7 @@ class PrettyPrinter(Printer):
             if e is S.NegativeOne:
                 return prettyForm("1")/self._print(b)
             n, d = fraction(e)
-            if n is S.One and d.is_Atom and not e.is_Integer:
+            if n is S.One and d.is_Atom and not e.is_Integer and self._settings['root_notation']:
                 return self._print_nth_root(b, e)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -457,6 +457,23 @@ x \
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+    #see issue #14033
+    expr = x**Rational(1, 3)
+    ascii_str = \
+"""\
+ 1/3\n\
+x   \
+"""
+    ucode_str = \
+u("""\
+ 1/3\n\
+x   \
+""")
+    assert xpretty(expr, use_unicode=False, wrap_line=False,\
+    root_notation = False) == ascii_str
+    assert xpretty(expr, use_unicode=True, wrap_line=False,\
+    root_notation = False) == ucode_str
+
     expr = x**Rational(-5, 2)
     ascii_str = \
 """\
@@ -470,21 +487,6 @@ u("""\
  1  \n\
 ────\n\
  5/2\n\
-x   \
-""")
-    assert pretty(expr, root_notation = False) == ascii_str
-    assert upretty(expr, root_notation = False) == ucode_str
-
-    #see issue #14033
-    expr = x**Rational(1, 3)
-    ascii_str = \
-"""\
- 1/3\n\
-x   \
-"""
-    ucode_str = \
-u("""\
- 1/3\n\
 x   \
 """)
     assert pretty(expr) == ascii_str

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -59,6 +59,7 @@ oo
 1/x
 y*x**-2
 x**Rational(-5,2)
+x**Rational(1, 3)
 (-2)**x
 Pow(3, 1, evaluate=False)
 (x**2 + x + 1)  #
@@ -469,6 +470,21 @@ u("""\
  1  \n\
 ────\n\
  5/2\n\
+x   \
+""")
+    assert pretty(expr, root_notation = False) == ascii_str
+    assert upretty(expr, root_notation = False) == ucode_str
+
+    #see issue #14033
+    expr = x**Rational(1, 3)
+    ascii_str = \
+"""\
+ 1/3\n\
+x   \
+"""
+    ucode_str = \
+u("""\
+ 1/3\n\
 x   \
 """)
     assert pretty(expr) == ascii_str

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -91,6 +91,7 @@ def test_latex_basic():
 
     assert latex(sqrt(x)) == r"\sqrt{x}"
     assert latex(x**Rational(1, 3)) == r"\sqrt[3]{x}"
+    assert latex(x**Rational(1, 3), root_notation = False) == r"x^{\frac{1}{3}}"
     assert latex(sqrt(x)**3) == r"x^{\frac{3}{2}}"
     assert latex(sqrt(x), itex=True) == r"\sqrt{x}"
     assert latex(x**Rational(1, 3), itex=True) == r"\root{3}{x}"


### PR DESCRIPTION
Fixes #14033

This PR fixes the issue of not being able to use fractional form for powers with exponents of the form 1/n in LaTex and pretty printers. 

`root_notation` flag is added to [LaTeX](http://docs.sympy.org/dev/_modules/sympy/printing/latex.html)  and [pretty](http://docs.sympy.org/dev/_modules/sympy/printing/pretty/pretty.html) printers, which specifies whether the above-mentioned expressions are to be printed in their root form or fractional form. 

The default value of `root_notation` in both printers is set to `True`, which prints the root form of the expression.

Example:

In LaTex
```
>>> print(latex(x**Rational(1, 7)))
\sqrt[7]{x}

>>> print(latex(x**Rational(1, 7),  root_notation = False))
x^{\frac{1}{7}}

```
In prettyprinting

```
>>> print(pretty(x**Rational(1, 5), use_unicode = False))
5 ___
\/ x 

>>> print(pretty(x**Rational(1, 5), use_unicode = False, root_notation = False))
 1/5
x   

```