### PR TITLE
simplify: logcombine is fixed

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -994,7 +994,9 @@ def logcombine(expr, force=False):
                 num, den = k, -k
                 if num.count_ops() > den.count_ops():
                     num, den = den, num
-                other.append(num*log(log1.pop(num).args[0]/log1.pop(den).args[0] , evaluate = False))
+                other.append(
+                    num*log(log1.pop(num).args[0]/log1.pop(den).args[0] ,
+                            evaluate = False))
             else:
                 other.append(k*log1.pop(k))
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -994,16 +994,24 @@ def logcombine(expr, force=False):
                 num, den = k, -k
                 if num.count_ops() > den.count_ops():
                     num, den = den, num
-                abc = log1.pop(num).args[0]
-                pqr = log1.pop(den).args[0]
-                if (abc.is_Number) and (pqr.is_Number) :
-                    abc1 = int(abc)
-                    pqr1 = int(pqr)
-                    xyz = (abc1/pqr1)
-                    other.append(log(num*xyz , evaluate = False))
+                abc = log1.pop(num)
+                pqr = log1.pop(den)
+                if (len(abc.args) == 2) :
+                    var1 = int(abc.args[0].args[1].args[0])
+                    var2 = int(abc.args[1].args[0])
+                    var3 = var2/var1
+                    pqr1 = int(pqr.args[0])
+                    final = var3/pqr1
+                    other.append(log(num*final , evaluate = False))
                 else :
-                    xyz = abc/pqr
-                    other.append(log(num*xyz , evaluate = False))
+                    abc1 = abc.args[0]
+                    pqr1 = pqr.args[0]
+                    if (abc1.is_Number) and (pqr1.is_Number) :
+                        final = float(abc1/pqr1)
+                        other.append(log(num*final , evaluate = False))
+                    else :
+                        final = (abc1/pqr1)
+                        other.append(log(num*final , evaluate = False))
             else:
                 other.append(k*log1.pop(k))
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -994,10 +994,16 @@ def logcombine(expr, force=False):
                 num, den = k, -k
                 if num.count_ops() > den.count_ops():
                     num, den = den, num
-                abc = int(log1.pop(num).args[0])
-                pqr = int(log1.pop(den).args[0])
-                xyz = abc/pqr
-                other.append(log(num*xyz , evaluate = False))
+                abc = log1.pop(num).args[0]
+                pqr = log1.pop(den).args[0]
+                if (abc.is_Number) and (pqr.is_Number) :
+                    abc1 = int(abc)
+                    pqr1 = int(pqr)
+                    xyz = (abc1/pqr1)
+                    other.append(log(num*xyz , evaluate = False))
+                else :
+                    xyz = abc/pqr
+                    other.append(log(num*xyz , evaluate = False))
             else:
                 other.append(k*log1.pop(k))
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -982,7 +982,7 @@ def logcombine(expr, force=False):
         for k in list(log1.keys()):
             log1[Mul(*k)] = log(logcombine(Mul(*[
                 l.args[0]**Mul(*c) for c, l in log1.pop(k)]),
-                force=force) , evaluate = False)
+                force=force), evaluate=False)
 
         # logs that have oppositely signed coefficients can divide
         for k in ordered(list(log1.keys())):
@@ -995,8 +995,8 @@ def logcombine(expr, force=False):
                 if num.count_ops() > den.count_ops():
                     num, den = den, num
                 other.append(
-                    num*log(log1.pop(num).args[0]/log1.pop(den).args[0] ,
-                            evaluate = False))
+                    num*log(log1.pop(num).args[0]/log1.pop(den).args[0],
+                            evaluate=False))
             else:
                 other.append(k*log1.pop(k))
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -994,7 +994,10 @@ def logcombine(expr, force=False):
                 num, den = k, -k
                 if num.count_ops() > den.count_ops():
                     num, den = den, num
-                other.append(num*log(log1.pop(num).args[0]/log1.pop(den).args[0]))
+                abc = int(log1.pop(num).args[0])
+                pqr = int(log1.pop(den).args[0])
+                xyz = abc/pqr
+                other.append(log(num*xyz , evaluate = False))
             else:
                 other.append(k*log1.pop(k))
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -982,7 +982,7 @@ def logcombine(expr, force=False):
         for k in list(log1.keys()):
             log1[Mul(*k)] = log(logcombine(Mul(*[
                 l.args[0]**Mul(*c) for c, l in log1.pop(k)]),
-                force=force))
+                force=force) , evaluate = False)
 
         # logs that have oppositely signed coefficients can divide
         for k in ordered(list(log1.keys())):
@@ -994,24 +994,7 @@ def logcombine(expr, force=False):
                 num, den = k, -k
                 if num.count_ops() > den.count_ops():
                     num, den = den, num
-                abc = log1.pop(num)
-                pqr = log1.pop(den)
-                if (len(abc.args) == 2) :
-                    var1 = int(abc.args[0].args[1].args[0])
-                    var2 = int(abc.args[1].args[0])
-                    var3 = var2/var1
-                    pqr1 = int(pqr.args[0])
-                    final = var3/pqr1
-                    other.append(log(num*final , evaluate = False))
-                else :
-                    abc1 = abc.args[0]
-                    pqr1 = pqr.args[0]
-                    if (abc1.is_Number) and (pqr1.is_Number) :
-                        final = float(abc1/pqr1)
-                        other.append(log(num*final , evaluate = False))
-                    else :
-                        final = (abc1/pqr1)
-                        other.append(log(num*final , evaluate = False))
+                other.append(num*log(log1.pop(num).args[0]/log1.pop(den).args[0] , evaluate = False))
             else:
                 other.append(k*log1.pop(k))
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -471,9 +471,9 @@ def test_logcombine_complex_coeff():
         
         
 def test_issue_5950():
-    assert logcombine(log(3) - log(2)) == log(3/2)
+    assert logcombine(log(3) - log(2)) == log(Rational(3,2), evaluate=False)
     assert logcombine(log(x) - log(y)) == log(x/y)
-    assert logcombine(log(Rational(3,2), evaluate=False) - log(2)) == log(3/4)
+    assert logcombine(log(Rational(3,2), evaluate=False) - log(2)) == log(Rational(3,4), evaluate=False)
 
 
 def test_posify():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -473,7 +473,7 @@ def test_logcombine_complex_coeff():
 def test_issue_5950():
     assert logcombine(log(3) - log(2)) == log(3/2)
     assert logcombine(log(x) - log(y)) == log(x/y)
-    assert logcombine(log(Rational(3,2) , evaluate = False) - log(2)) == log(3/4)
+    assert logcombine(log(Rational(3,2), evaluate=False) - log(2)) == log(3/4)
 
 
 def test_posify():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -468,6 +468,12 @@ def test_logcombine_complex_coeff():
     assert logcombine(i, force=True) == i
     assert logcombine(i + 2*log(x), force=True) == \
         i + log(x**2)
+        
+        
+def test_issue_5950():
+    assert logcombine(log(3) - log(2)) == log(3/2)
+    assert logcombine(log(x) - log(y)) == log(x/y)
+    assert logcombine(log(Rational(3,2) , evaluate = False) - log(2))
 
 
 def test_posify():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -473,7 +473,8 @@ def test_logcombine_complex_coeff():
 def test_issue_5950():
     assert logcombine(log(3) - log(2)) == log(Rational(3,2), evaluate=False)
     assert logcombine(log(x) - log(y)) == log(x/y)
-    assert logcombine(log(Rational(3,2), evaluate=False) - log(2)) == log(Rational(3,4), evaluate=False)
+    assert logcombine(log(Rational(3,2), evaluate=False) - log(2)) == \
+        log(Rational(3,4), evaluate=False)
 
 
 def test_posify():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -468,9 +468,10 @@ def test_logcombine_complex_coeff():
     assert logcombine(i, force=True) == i
     assert logcombine(i + 2*log(x), force=True) == \
         i + log(x**2)
-        
-        
+
+
 def test_issue_5950():
+    x, y = symbols("x,y", positive=True)
     assert logcombine(log(3) - log(2)) == log(Rational(3,2), evaluate=False)
     assert logcombine(log(x) - log(y)) == log(x/y)
     assert logcombine(log(Rational(3,2), evaluate=False) - log(2)) == \

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -473,7 +473,7 @@ def test_logcombine_complex_coeff():
 def test_issue_5950():
     assert logcombine(log(3) - log(2)) == log(3/2)
     assert logcombine(log(x) - log(y)) == log(x/y)
-    assert logcombine(log(Rational(3,2) , evaluate = False) - log(2))
+    assert logcombine(log(Rational(3,2) , evaluate = False) - log(2)) == log(3/4)
 
 
 def test_posify():


### PR DESCRIPTION
Fixes the problem of logcombine
Fixes #5950
It gives the output as log(x/y) instead of -log(y)+log(x) when we give the input as logcombine(log(x) - log(y))