### PR TITLE
Piecewise._intervals better handles Eq

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -663,17 +663,20 @@ class Piecewise(Function):
         return sum
 
     def _intervals(self, sym):
-        """Return a list of tuples, (a, b, e, i), where a and b
-        are the lower and upper bounds in which the expression e
-        of argument i in self is defined.
+        """Return a list of unique tuples, (a, b, e, i), where a and b
+        are the lower and upper bounds in which the expression e of
+        argument i in self is defined and a < b (when involving
+        numbers) or a <= b when involving symbols.
 
-        If there are any relationals not involving sym, or
-        any relational cannot be solved for sym,
-        NotImplementedError is raised. The evaluated conditions will
-        be returned as ranges. Discontinuous ranges will be
-        returned separately with identical expressions and
-        the first condition that evaluates to True will be
-        returned as the last tuple with a, b = -oo, oo.
+        If there are any relationals not involving sym, or any
+        relational cannot be solved for sym, NotImplementedError is
+        raised. The calling routine should have removed such
+        relationals before calling this routine.
+
+        The evaluated conditions will be returned as ranges.
+        Discontinuous ranges will be returned separately with
+        identical expressions. The first condition that evaluates to
+        True will be returned as the last tuple with a, b = -oo, oo.
         """
         from sympy.solvers.inequalities import _solve_inequality
         from sympy.logic.boolalg import to_cnf, distribute_or_over_and
@@ -681,20 +684,29 @@ class Piecewise(Function):
         assert isinstance(self, Piecewise)
 
         def _solve_relational(r):
+            if sym not in r.free_symbols:
+                nonsymfail(r)
             rv = _solve_inequality(r, sym)
-            if isinstance(rv, Relational) and \
-                    sym in rv.free_symbols:
-                if rv.args[0] != sym:
+            if isinstance(rv, Relational):
+                free = rv.args[1].free_symbols
+                if rv.args[0] != sym or sym in free:
                     raise NotImplementedError(filldedent('''
                         Unable to solve relational
                         %s for %s.''' % (r, sym)))
-                if rv.rel_op == '!=':
+                if rv.rel_op == '==':
+                    # this equality has been affirmed to have the form
+                    # Eq(sym, rhs) where rhs is sym-free; it represents
+                    # a zero-width interval which will be ignored
+                    # whether it is an isolated condition or contained
+                    # within an And or an Or
+                    rv = S.false
+                elif rv.rel_op == '!=':
                     try:
                         rv = Or(sym < rv.rhs, sym > rv.rhs)
                     except TypeError:
                         # e.g. x != I ==> all real x satisfy
                         rv = S.true
-            if rv == (S.NegativeInfinity < sym) & (sym < S.Infinity):
+            elif rv == (S.NegativeInfinity < sym) & (sym < S.Infinity):
                 rv = S.true
             return rv
 
@@ -704,8 +716,8 @@ class Piecewise(Function):
                 %s appeared: %s''' % (sym, cond)))
 
         # make self canonical wrt Relationals
-        reps = dict(
-            [(r,_solve_relational(r)) for r in self.atoms(Relational)])
+        reps = dict([
+            (r, _solve_relational(r)) for r in self.atoms(Relational)])
         # process args individually so if any evaluate, their position
         # in the original Piecewise will be known
         args = [i.xreplace(reps) for i in self.args]
@@ -714,14 +726,12 @@ class Piecewise(Function):
         expr_cond = []
         default = idefault = None
         for i, (expr, cond) in enumerate(args):
-            if cond == False:
+            if cond is S.false:
                 continue
-            elif cond == True:
+            elif cond is S.true:
                 default = expr
                 idefault = i
                 break
-            elif sym not in cond.free_symbols:
-                nonsymfail(cond)
 
             cond = to_cnf(cond)
             if isinstance(cond, And):
@@ -729,61 +739,27 @@ class Piecewise(Function):
 
             if isinstance(cond, Or):
                 expr_cond.extend(
-                    [(i, expr, o) for o in cond.args])
-            elif cond != False:
+                    [(i, expr, o) for o in cond.args
+                    if not isinstance(o, Equality)])
+            elif cond is not S.false:
                 expr_cond.append((i, expr, cond))
 
         # determine intervals represented by conditions
         int_expr = []
         for iarg, expr, cond in expr_cond:
-            if isinstance(cond, Equality):
-                if cond.lhs == sym:
-                    v = cond.rhs
-                    int_expr.append((v, v, expr.subs(sym, v), iarg))
-                    continue
-                else:
-                    nonsymfail(cond)
-
             if isinstance(cond, And):
                 lower = S.NegativeInfinity
                 upper = S.Infinity
-                nonsym = False
-                rhs = None
                 for cond2 in cond.args:
                     if isinstance(cond2, Equality):
-                        # all relationals were solved and
-                        # only sym-dependent ones made it to here
-                        assert cond2.lhs == sym
-                        assert sym not in cond2.rhs.free_symbols
-                        if rhs is None:
-                            rhs = cond2.rhs
-                        else:
-                            same = Eq(cond2.rhs, rhs)
-                            if same == False:
-                                cond = S.false
-                                break
-                            elif same != True:
-                                raise Undecidable('%s did not evaluate' % same)
+                        lower = upper  # ignore
+                        break
                     elif cond2.lts == sym:
                         upper = Min(cond2.gts, upper)
                     elif cond2.gts == sym:
                         lower = Max(cond2.lts, lower)
                     else:
-                        # mark but don't fail until later
-                        nonsym = cond2
-                if rhs is not None and cond not in (S.true, S.false):
-                    lower = upper = rhs
-                    cond = cond.subs(sym, lower)
-                # cond might have evaluated b/c of an Eq
-                if cond is S.true:
-                    default = expr
-                    continue
-                elif cond is S.false:
-                    continue
-                elif nonsym is not False:
-                    nonsymfail(nonsym)
-                else:
-                    pass  # for coverage
+                        nonsymfail(cond2)  # should never get here
             elif isinstance(cond, Relational):
                 lower, upper = cond.lts, cond.gts  # part 1: initialize with givens
                 if cond.lts == sym:                # part 1a: expand the side ...
@@ -797,14 +773,14 @@ class Piecewise(Function):
                     'unrecognized condition: %s' % cond)
 
             lower, upper = lower, Max(lower, upper)
-            if (lower > upper) is not S.true:
+            if (lower >= upper) is not S.true:
                 int_expr.append((lower, upper, expr, iarg))
 
         if default is not None:
             int_expr.append(
                 (S.NegativeInfinity, S.Infinity, default, idefault))
 
-        return int_expr
+        return list(uniq(int_expr))
 
     def _eval_nseries(self, x, n, logx):
         args = [(ec.expr._eval_nseries(x, n, logx), ec.cond) for ec in self.args]

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -2,7 +2,7 @@ from sympy import (
     adjoint, And, Basic, conjugate, diff, expand, Eq, Function, I, ITE,
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, solve, symbols, transpose,
-    cos, exp, Abs, Ne, Not, Symbol, S, sqrt, Tuple, zoo,
+    cos, sin, exp, Abs, Ne, Not, Symbol, S, sqrt, Tuple, zoo,
     factor_terms, DiracDelta, Heaviside)
 from sympy.printing import srepr
 from sympy.utilities.pytest import XFAIL, raises
@@ -928,13 +928,19 @@ def test_issue_4313():
 
 
 def test__intervals():
-    assert Piecewise((x + 2, Eq(x, 3)))._intervals(x) == [(3, 3, 5, 0)]
+    assert Piecewise((x + 2, Eq(x, 3)))._intervals(x) == []
     assert Piecewise(
         (1, x > x + 1),
         (Piecewise((1, x < x + 1)), 2*x < 2*x + 1),
         (1, True))._intervals(x) == [(-oo, oo, 1, 1)]
     assert Piecewise((1, Ne(x, I)), (0, True))._intervals(x) == [
         (-oo, oo, 1, 0)]
+    assert Piecewise((-cos(x), sin(x) >= 0), (cos(x), True)
+        )._intervals(x) == [(0, pi, -cos(x), 0), (-oo, oo, cos(x), 1)]
+    # the following tests that duplicates are removed and that non-Eq
+    # generated zero-width intervals are removed
+    assert Piecewise((1, Abs(x**(-2)) > 1), (0, True)
+        )._intervals(x) == [(-1, 0, 1, 0), (0, 1, 1, 0), (-oo, oo, 0, 1)]
 
 
 def test_containment():
@@ -1069,3 +1075,7 @@ def test_Piecewise_rewrite_as_ITE():
     # used to detect this
     raises(NotImplementedError, lambda: _ITE((x, x < y), (y, x >= a)))
     raises(ValueError, lambda: _ITE((a, x < 2), (b, x > 3)))
+
+
+def test_issue_14052():
+    assert integrate(abs(sin(x)), (x, 0, 2*pi)) == 4


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

fixes #14052 
closes #14054 

#### Brief description of what is fixed or changed
Any intervals of zero width are ignored; this also removes
the incorrect identification of a condition that is true
at a given value of sym as being a default condition.

And(x<2, Eq(x, 1)) is true, but this doesn't mean that
the domain in which it is true is (-oo, oo), only that
it is true at x == 1.


#### Other comments
