### PR TITLE
More general unpolarification for polylog argument

### DIFF
--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -5,7 +5,7 @@ from sympy.core import Function, S, sympify, pi, I
 from sympy.core.function import ArgumentIndexError
 from sympy.core.compatibility import range
 from sympy.functions.combinatorial.numbers import bernoulli, factorial, harmonic
-from sympy.functions.elementary.exponential import log
+from sympy.functions.elementary.exponential import log, exp_polar
 from sympy.functions.elementary.miscellaneous import sqrt
 
 ###############################################################################
@@ -299,7 +299,7 @@ class polylog(Function):
         elif s == -1:
             return z/(1 - z)**2
         # polylog is branched, but not over the unit disk
-        if z.is_polar:
+        if z.has(exp_polar):
             from sympy.functions.elementary.complexes import Abs, unpolarify
             if (Abs(z) <= S.One) == True:
                 return cls(s, unpolarify(z))

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -299,10 +299,10 @@ class polylog(Function):
         elif s == -1:
             return z/(1 - z)**2
         # polylog is branched, but not over the unit disk
-        if z.has(exp_polar):
-            from sympy.functions.elementary.complexes import Abs, unpolarify
-            if (Abs(z) <= S.One) == True:
-                return cls(s, unpolarify(z))
+        from sympy.functions.elementary.complexes import (Abs, unpolarify,
+            polar_lift)
+        if z.has(exp_polar, polar_lift) and (Abs(z) <= S.One) == True:
+            return cls(s, unpolarify(z))
 
     def fdiff(self, argindex=1):
         s, z = self.args

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -288,6 +288,7 @@ def test_transcendental_functions():
 
 def test_log_polylog():
     assert integrate(log(1 - x)/x, (x, 0, 1)) == -pi**2/6
+    assert integrate(log(x)*(1 - x)**(-1), (x, 0, 1)) == -pi**2/6
 
 
 def test_issue_3740():


### PR DESCRIPTION
#### References to other Issues or PRs

A follow-up to #13965. Closes #14075.

#### Brief description of what is fixed or changed

In #13965, the argument of polylog is unpolarified if it has `is_polar` flag and is at most 1 in absolute value. It turned out that expressions like `-exp_polar(I*pi)` are not unpolarified because they have `is_polar = False`. This behavior seems intended, see
https://github.com/sympy/sympy/blob/master/sympy/core/mul.py#L1174
and the test
https://github.com/sympy/sympy/blob/master/sympy/core/tests/test_arit.py#L1714
which asserts that if p is polar, -2*p is not polar.

I can understand the logic of this approach to polarity, since multiplying a polar number by a non-positive complex number is not a well-defined operation on the Riemann surface of the logarithm. But for the purpose of evaluating polylog all that matters is that we have some exp_polar and want to get rid of it. So rather than try redefining the behavior of `is_polar`, I changed the condition from `z.is_polar` to `z.has(exp_polar)` in the `eval` method of polylog.
