### PR TITLE
WIP fix codegen

### DIFF
--- a/doc/src/modules/codegen.rst
+++ b/doc/src/modules/codegen.rst
@@ -224,9 +224,9 @@ For instance::
     #include "test.h"
     #include <math.h>
     double volume(double breadth, double height, double length) {
-       double volume_result;
-       volume_result = breadth*height*length;
-       return volume_result;
+       double out1;
+       out1 = breadth*height*length;
+       return out1;
     }
     >>> print(h_name)
     test.h

--- a/sympy/codegen/__init__.py
+++ b/sympy/codegen/__init__.py
@@ -13,7 +13,7 @@ There are several submodules available:
 
 """
 from .ast import (
-    Assignment, aug_assign, CodeBlock, For, Attribute, Variable, Declaration,
+    Assignment, aug_assign, CodeBlock, WithBody, For, Attribute, Variable, Declaration,
     While, Scope, Print, FunctionPrototype, FunctionDefinition, FunctionCall
 )
 

--- a/sympy/codegen/__init__.py
+++ b/sympy/codegen/__init__.py
@@ -18,7 +18,7 @@ from .ast import (
 )
 
 __all__ = [
-    'Assignment', 'aug_assign', 'CodeBlock', 'For', 'Attribute', 'Variable',
+    'Assignment', 'aug_assign', 'CodeBlock', 'WithBody', 'For', 'Attribute', 'Variable',
     'Declaration', 'While', 'Scope', 'Print', 'FunctionPrototype',
     'FunctionDefinition', 'FunctionCall',
 ]

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -154,6 +154,8 @@ def _mk_Tuple(args):
     args = [String(arg) if isinstance(arg, str) else arg for arg in args]
     return Tuple(*args)
 
+class WithBody:
+    pass
 
 class Token(Basic):
     """ Base class for the AST types.
@@ -786,7 +788,7 @@ class CodeBlock(Basic):
         return self.topological_sort(new_assignments + new_block)
 
 
-class For(Token):
+class For(Token, WithBody):
     """Represents a 'for-loop' in the code.
 
     Expressions are of the form:
@@ -1579,7 +1581,7 @@ class Declaration(Token):
     _construct_variable = Variable
 
 
-class While(Token):
+class While(Token, WithBody):
     """ Represents a 'for-loop' in the code.
 
     Expressions are of the form:

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -126,17 +126,17 @@ def runtest_issue_10274(language, backend):
                 "\n",
                 "double helper(double a, double b, double c) {\n",
                 "\n",
-                "   double helper_result;\n",
-                "   helper_result = a - b + c;\n",
-                "   return helper_result;\n",
+                "   double out1;\n",
+                "   out1 = a - b + c;\n",
+                "   return out1;\n",
                 "\n",
                 "}\n",
                 "\n",
                 "double autofunc(double a, double b, double c) {\n",
                 "\n",
-                "   double autofunc_result;\n",
-                "   autofunc_result = pow(helper(a, b, c), 13);\n",
-                "   return autofunc_result;\n",
+                "   double out1;\n",
+                "   out1 = pow(helper(a, b, c), 13);\n",
+                "   return out1;\n",
                 "\n",
                 "}\n",
                 ]
@@ -275,9 +275,9 @@ def test_autowrap_custom_printer():
         '\n'
         'double autofunc(double a) {\n'
         '\n'
-        '   double autofunc_result;\n'
-        '   autofunc_result = S_PI*a;\n'
-        '   return autofunc_result;\n'
+        '   double out1;\n'
+        '   out1 = S_PI*a;\n'
+        '   return out1;\n'
         '\n'
         '}\n'
     )

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -54,7 +54,7 @@ __all__ = [
 
     'MatrixSlice', 'BlockDiagMatrix', 'BlockMatrix', 'FunctionMatrix',
     'Identity', 'Inverse', 'MatAdd', 'MatMul', 'MatPow', 'MatrixExpr',
-    'MatrixSymbol', 'Trace', 'Transpose', 'ZeroMatrix', 'OneMatrix',
+    'MatrixSymbol', 'MatrixElement', 'Trace', 'Transpose', 'ZeroMatrix', 'OneMatrix',
     'blockcut', 'block_collapse', 'matrix_symbols', 'Adjoint',
     'hadamard_product', 'HadamardProduct', 'HadamardPower', 'Determinant',
     'det', 'diagonalize_vector', 'DiagMatrix', 'DiagonalMatrix',

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -23,7 +23,7 @@ SparseMatrix = MutableSparseMatrix
 
 from .expressions import (
     MatrixSlice, BlockDiagMatrix, BlockMatrix, FunctionMatrix, Identity,
-    Inverse, MatAdd, MatMul, MatPow, MatrixExpr, MatrixSymbol, Trace,
+    Inverse, MatAdd, MatMul, MatPow, MatrixExpr, MatrixSymbol, MatrixElement, Trace,
     Transpose, ZeroMatrix, OneMatrix, blockcut, block_collapse, matrix_symbols, Adjoint,
     hadamard_product, HadamardProduct, HadamardPower, Determinant, det,
     diagonalize_vector, DiagMatrix, DiagonalMatrix, DiagonalOf, trace,

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -32,8 +32,8 @@ __all__ = [
 
     'MatAdd',
 
-    'Identity', 'MatrixExpr', 'MatrixSymbol', 'ZeroMatrix', 'OneMatrix',
-    'matrix_symbols',
+    'Identity', 'MatrixExpr', 'MatrixSymbol', 'MatrixElement', 'ZeroMatrix',
+    'OneMatrix', 'matrix_symbols',
 
     'MatMul',
 

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -6,8 +6,8 @@ from .companion import CompanionMatrix
 from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
-from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix, OneMatrix,
-                      matrix_symbols)
+from .matexpr import (Identity, MatrixExpr, MatrixElement, MatrixSymbol, ZeroMatrix,
+                      OneMatrix, matrix_symbols)
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -18,7 +18,9 @@ from typing import Any, Dict, Tuple
 from functools import wraps
 from itertools import chain
 
-from sympy.core import S
+from sympy.core import S, Number
+from sympy.core.compatibility import string_types, range
+from sympy.core.decorators import deprecated
 from sympy.codegen.ast import (
     Assignment, Pointer, Variable, Declaration, Type,
     real, complex_, integer, bool_, float32, float64, float80,
@@ -405,7 +407,7 @@ class C89CodePrinter(CodePrinter):
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
         body = self._print(expr.body)
-        return ('for ({target} = {start}; {target} < {stop}; {target} += '
+        return ('for (int {target} = {start}; {target} < {stop}; {target} += '
                 '{step}) {{\n{body}\n}}').format(target=target, start=start,
                 stop=stop, step=step, body=body)
 
@@ -618,6 +620,40 @@ class C89CodePrinter(CodePrinter):
         return 'continue'
 
     _print_union = _print_struct
+
+
+# TODO Loic: Fix
+# class _C9XCodePrinter(object):
+#     # Move these methods to C99CodePrinter when removing CCodePrinter
+#     def _get_loop_opening_ending(self, indices):
+#         open_lines = []
+#         close_lines = []
+#         loopstart = "for (int %(var)s=%(start)s; %(var)s<%(end)s; %(var)s++){"  # C99
+#         for i in indices:
+#             # C arrays start at 0 and end at dimension-1
+#             if not isinstance(i, Number):
+#                 open_lines.append(loopstart % {
+#                     'var': self._print(i.label),
+#                     'start': self._print(i.lower),
+#                     'end': self._print(i.upper + 1)})
+#                 close_lines.append("}")
+#         return open_lines, close_lines
+
+
+# @deprecated(
+#     last_supported_version='1.0',
+#     useinstead="C89CodePrinter or C99CodePrinter, e.g. ccode(..., standard='C99')",
+#     issue=12220,
+#     deprecated_since_version='1.1')
+
+# class CCodePrinter(_C9XCodeC89CodePrinter):
+#     """
+#     Deprecated.
+
+#     Alias for C89CodePrinter, for backwards compatibility.
+#     """
+#     _kf = _known_functions_C9X  # known_functions-dict to copy
+
 
 class C99CodePrinter(C89CodePrinter):
     standard = 'C99'

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -19,8 +19,6 @@ from functools import wraps
 from itertools import chain
 
 from sympy.core import S, Number
-from sympy.core.compatibility import string_types, range
-from sympy.core.decorators import deprecated
 from sympy.codegen.ast import (
     Assignment, Pointer, Variable, Declaration, Type,
     real, complex_, integer, bool_, float32, float64, float80,
@@ -407,7 +405,7 @@ class C89CodePrinter(CodePrinter):
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
         body = self._print(expr.body)
-        return ('for ({target} = {start}; {target} < {stop}; {target} += '
+        return ('for (int {target} = {start}; {target} < {stop}; {target} += '
                 '{step}) {{\n{body}\n}}').format(target=target, start=start,
                 stop=stop, step=step, body=body)
 

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Tuple
 from functools import wraps
 from itertools import chain
 
-from sympy.core import S, Number
+from sympy.core import S
 from sympy.codegen.ast import (
     Assignment, Pointer, Variable, Declaration, Type,
     real, complex_, integer, bool_, float32, float64, float80,

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -407,7 +407,7 @@ class C89CodePrinter(CodePrinter):
         else:
             raise NotImplementedError("Only iterable currently supported is Range")
         body = self._print(expr.body)
-        return ('for (int {target} = {start}; {target} < {stop}; {target} += '
+        return ('for ({target} = {start}; {target} < {stop}; {target} += '
                 '{step}) {{\n{body}\n}}').format(target=target, start=start,
                 stop=stop, step=step, body=body)
 

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -217,9 +217,9 @@ class CodePrinter(StrPrinter):
         # support broadcast of scalar
         if linds and not rinds:
             rinds = linds
-        if rinds != linds:
-            raise ValueError("lhs indices must match non-dummy"
-                    " rhs indices in %s" % expr)
+        # if rinds != linds:
+        #     raise ValueError("lhs indices must match non-dummy"
+        #             " rhs indices in %s" % expr)
 
         return self._sort_optimized(rinds, assign_to)
 
@@ -304,9 +304,11 @@ class CodePrinter(StrPrinter):
     def _print_Assignment(self, expr):
         from sympy.functions.elementary.piecewise import Piecewise
         from sympy.matrices.expressions.matexpr import MatrixSymbol
+        from sympy.matrices import MatrixBase, MatrixSlice
         from sympy.tensor.indexed import IndexedBase
         lhs = expr.lhs
         rhs = expr.rhs
+
         # We special case assignments that take multiple lines
         if isinstance(expr.rhs, Piecewise):
             # Here we modify Piecewise so each expression is now
@@ -318,7 +320,7 @@ class CodePrinter(StrPrinter):
                 conditions.append(c)
             temp = Piecewise(*zip(expressions, conditions))
             return self._print(temp)
-        elif isinstance(lhs, MatrixSymbol):
+        elif isinstance(lhs, (MatrixBase, MatrixSymbol, MatrixSlice)):
             # Here we form an Assignment for each element in the array,
             # printing each one.
             lines = []

--- a/sympy/printing/cython.py
+++ b/sympy/printing/cython.py
@@ -188,21 +188,6 @@ class CythonCodePrinter(CodePrinter):
         rows, cols = mat.shape
         return ((i, j) for i in range(rows) for j in range(cols))
 
-    # def _get_loop_opening_ending(self, indices):
-    #     from sympy.tensor.indexed import Idx
-
-    #     open_lines = []
-    #     close_lines = []
-    #     for i in indices:
-    #         # Cython arrays start at 0 and end at dimension-1
-    #         if isinstance(i, Idx):
-    #             var, start, stop = map(self._print,
-    #                 [i.label, i.lower, i.upper + 1])
-    #             open_lines.append('for %s in range(%s, %s):' % (var, start, stop))
-    #             close_lines.append("#end\n")
-    #     return open_lines, close_lines
-        
-
     def _print_Pow(self, expr):
         if "Pow" in self.known_functions:
             return self._print_Function(expr)

--- a/sympy/printing/cython.py
+++ b/sympy/printing/cython.py
@@ -1,5 +1,4 @@
 from sympy.core import S
-from sympy.core.compatibility import string_types, range
 from sympy.printing.codeprinter import CodePrinter
 
 from sympy.core import Add, Mul, Pow, S, Eq
@@ -113,7 +112,7 @@ class CythonCodePrinter(CodePrinter):
         """
         from sympy.matrices.expressions.matexpr import MatrixSymbol
 
-        if isinstance(assign_to, string_types):
+        if isinstance(assign_to, str):
             if expr.is_Matrix:
                 assign_to = MatrixSymbol(assign_to, *expr.shape)
             else:
@@ -379,7 +378,7 @@ class CythonCodePrinter(CodePrinter):
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
 
-        if isinstance(code, string_types):
+        if isinstance(code, str):
             code_lines = self.indent_code(code.splitlines(True))
             return ''.join(code_lines)
 

--- a/sympy/printing/cython.py
+++ b/sympy/printing/cython.py
@@ -1,0 +1,442 @@
+from sympy.core import S
+from sympy.core.compatibility import string_types, range
+from sympy.printing.codeprinter import CodePrinter
+
+from sympy.core import Add, Mul, Pow, S, Eq
+from sympy.core.basic import Basic
+from sympy.core.relational import Relational
+from sympy.core.sympify import _sympify, sympify
+from sympy.core.symbol import Symbol
+from sympy.printing.str import StrPrinter
+
+from sympy.printing.precedence import precedence
+from sympy.sets.fancysets import Range
+
+# dictionary mapping sympy function to (argument_conditions, C_function).
+# Used in CCodePrinter._print_Function(self)
+known_functions = {
+    "Abs": [(lambda x: not x.is_integer, "fabs")],
+    "gamma": "tgamma",
+    "sin": "sin",
+    "cos": "cos",
+    "tan": "tan",
+    "asin": "asin",
+    "acos": "acos",
+    "atan": "atan",
+    "atan2": "atan2",
+    "exp": "exp",
+    "log": "log",
+    "erf": "erf",
+    "sinh": "sinh",
+    "cosh": "cosh",
+    "tanh": "tanh",
+    "asinh": "asinh",
+    "acosh": "acosh",
+    "atanh": "atanh",
+    "floor": "floor",
+    "ceiling": "ceil",
+}
+
+reserved_words = ['auto',
+                  'if',
+                  'break',
+                  'int',
+                  'case',
+                  'long',
+                  'char',
+                  'register',
+                  'continue',
+                  'return',
+                  'default',
+                  'short',
+                  'do',
+                  'sizeof',
+                  'double',
+                  'static',
+                  'else',
+                  'struct',
+                  'entry',
+                  'switch',
+                  'extern',
+                  'typedef',
+                  'float',
+                  'union',
+                  'for',
+                  'unsigned',
+                  'goto',
+                  'while',
+                  'enum',
+                  'void',
+                  'const',
+                  'signed',
+                  'volatile']
+
+class CythonCodePrinter(CodePrinter):
+    """A printer to convert python expressions to strings of cython code"""
+    printmethod = "_cythoncode"
+    language = "Cython"
+
+    _default_settings = {
+        'order': None,
+        'full_prec': 'auto',
+        'precision': 16,
+        'user_functions': {},
+        'human': True,
+        'contract': True,
+        'inline': True,
+        'dereference': set(),
+        'error_on_reserved': False,
+        'reserved_word_suffix': '_',
+    }
+
+    def __init__(self, settings={}):
+        super(CythonCodePrinter, self).__init__(settings)
+        self.known_functions = dict(known_functions)
+        userfuncs = settings.get('user_functions', {})
+        self.known_functions.update(userfuncs)
+        self._dereference = set(settings.get('dereference', []))
+        self.reserved_words = set(reserved_words)
+
+    def doprint(self, expr, assign_to=None):
+        """
+        Print the expression as code.
+
+        Parameters
+        ----------
+        expr : Expression
+            The expression to be printed.
+
+        assign_to : Symbol, MatrixSymbol, or string (optional)
+            If provided, the printed code will set the expression to a
+            variable with name ``assign_to``.
+        """
+        from sympy.matrices.expressions.matexpr import MatrixSymbol
+
+        if isinstance(assign_to, string_types):
+            if expr.is_Matrix:
+                assign_to = MatrixSymbol(assign_to, *expr.shape)
+            else:
+                assign_to = Symbol(assign_to)
+        elif not isinstance(assign_to, (Basic, type(None))):
+            raise TypeError("{0} cannot assign to object of type {1}".format(
+                    type(self).__name__, type(assign_to)))
+
+        if assign_to:
+            expr = Assignment(assign_to, expr)
+        else:
+            # _sympify is not enough b/c it errors on iterables
+            expr = sympify(expr)
+
+        # keep a set of expressions that are not strictly translatable to Code
+        # and number constants that must be declared and initialized
+        self._not_supported = set()
+        self._number_symbols = set()
+
+        if isinstance(expr, Eq):
+            expr = Assignment(expr.lhs, expr.rhs)
+
+        lines = self._print(expr).splitlines()
+
+        # format the output
+        if self._settings["human"]:
+            frontlines = []
+            if len(self._not_supported) > 0:
+                frontlines.append(self._get_comment(
+                        "Not supported in {0}:".format(self.language)))
+                for expr in sorted(self._not_supported, key=str):
+                    frontlines.append(self._get_comment(type(expr).__name__))
+            for name, value in sorted(self._number_symbols, key=str):
+                frontlines.append(self._declare_number_const(name, value))
+            lines = frontlines + lines
+            lines = self._format_code(lines)
+            result = "\n".join(lines)
+        else:
+            lines = self._format_code(lines)
+            result = (self._number_symbols, self._not_supported,
+                    "\n".join(lines))
+        return result
+
+    def _get_expression_indices(self, expr, assign_to):
+        from sympy.tensor import get_indices
+        from sympy.tensor.indexed import Idx
+
+        # need to remove not Idx indices !!!
+        rinds = expr.atoms(Idx)
+        linds = assign_to.atoms(Idx)
+
+        # support broadcast of scalar
+        if linds and not rinds:
+            rinds = linds
+        return self._sort_optimized(rinds, assign_to)
+
+    def _rate_index_position(self, p):
+        return p*5
+
+    def _get_statement(self, codestring):
+        return "%s" % codestring
+
+    def _get_comment(self, text):
+        return "# {0}".format(text)
+
+    def _declare_number_const(self, name, value):
+        return "cdef double const {0} = {1}".format(name, value)
+
+    def _format_code(self, lines):
+        return self.indent_code(lines)
+
+    def _traverse_matrix_indices(self, mat):
+        rows, cols = mat.shape
+        return ((i, j) for i in range(rows) for j in range(cols))
+
+    # def _get_loop_opening_ending(self, indices):
+    #     from sympy.tensor.indexed import Idx
+
+    #     open_lines = []
+    #     close_lines = []
+    #     for i in indices:
+    #         # Cython arrays start at 0 and end at dimension-1
+    #         if isinstance(i, Idx):
+    #             var, start, stop = map(self._print,
+    #                 [i.label, i.lower, i.upper + 1])
+    #             open_lines.append('for %s in range(%s, %s):' % (var, start, stop))
+    #             close_lines.append("#end\n")
+    #     return open_lines, close_lines
+        
+
+    def _print_Pow(self, expr):
+        if "Pow" in self.known_functions:
+            return self._print_Function(expr)
+        PREC = precedence(expr)
+        if expr.exp == -1:
+            return '1.0/%s' % (self.parenthesize(expr.base, PREC))
+        elif expr.exp == 0.5:
+            return 'sqrt(%s)' % self._print(expr.base)
+        elif expr.exp > 0 and expr.exp.is_integer:
+            line = "%s"%(self.parenthesize(expr.base, PREC))
+            for i in range(1, expr.exp):
+                line += '*' + "%s"%(self.parenthesize(expr.base, PREC))
+            return '(%s)' % line
+        else:
+            return 'pow(%s, %s)' % (self._print(expr.base),
+                                 self._print(expr.exp))
+
+    def _print_Rational(self, expr):
+        return self._print(expr.evalf(self._settings["precision"]))
+
+    def _print_Indexed(self, expr):
+        elem = []
+        for i in range(expr.rank):
+            elem.append(self._print(expr.indices[i]))
+        return "%s[%s]" % (self._print(expr.base.label), ', '.join(elem))
+
+    def _print_Idx(self, expr):
+        return self._print(expr.label)
+
+    def _print_Exp1(self, expr):
+        return "M_E"
+
+    def _print_Pi(self, expr):
+        return 'M_PI'
+
+    def _print_Infinity(self, expr):
+        return 'HUGE_VAL'
+
+    def _print_NegativeInfinity(self, expr):
+        return '-HUGE_VAL'
+
+    def _print_If(self, expr):
+        lines = []
+        for c, e in expr.statement:
+            #temp1, temp2, cond = self.doprint(c)
+            c = c.replace(Eq, AssignmentIf)
+            lines.append("if %s:"%self._print(c))
+            for ee in e:
+                temp1, temp2, output = self.doprint(ee)
+                lines.append(output)
+        lines.append("#end")
+        return "\n".join(lines)
+
+    def _print_Piecewise(self, expr):
+        if expr.args[-1].cond != True:
+            # We need the last conditional to be a True, otherwise the resulting
+            # function may not return a result.
+            raise ValueError("All Piecewise expressions must contain an "
+                             "(expr, True) statement to be used as a default "
+                             "condition. Without one, the generated "
+                             "expression may not evaluate to anything under "
+                             "some condition.")
+        lines = []
+        if expr.has(Assignment):
+            for i, (e, c) in enumerate(expr.args):
+                if i == 0:
+                    lines.append("if (%s):" % self._print(c))
+                elif i == len(expr.args) - 1 and c == True:
+                    lines.append("else:")
+                else:
+                    lines.append("else if (%s):" % self._print(c))
+                code0 = self._print(e)
+                lines.append(code0)
+                lines.append("}")
+            return "\n".join(lines)
+        else:
+            # The piecewise was used in an expression, need to do inline
+            # operators. This has the downside that inline operators will
+            # not work for statements that span multiple lines (Matrix or
+            # Indexed expressions).
+            ecpairs = ["((%s) ? (\n%s\n)\n" % (self._print(c), self._print(e))
+                    for e, c in expr.args[:-1]]
+            last_line = ": (\n%s\n)" % self._print(expr.args[-1].expr)
+            return ": ".join(ecpairs) + last_line + " ".join([")"*len(ecpairs)])
+
+    def _print_ITE(self, expr):
+        from sympy.functions import Piecewise
+        _piecewise = Piecewise((expr.args[1], expr.args[0]), (expr.args[2], True))
+        return self._print(_piecewise)
+
+    def _print_MatrixElement(self, expr):
+        return "{0}[{1}]".format(expr.parent, expr.j +
+                expr.i*expr.parent.shape[1])
+
+    def _print_Symbol(self, expr):
+
+        name = super(CythonCodePrinter, self)._print_Symbol(expr)
+
+        if expr in self._dereference:
+            return '(*{0})'.format(name)
+        else:
+            return name
+
+    def _print_For(self, expr):
+        target = self._print(expr.target)
+        if isinstance(expr.iterable, Range):
+            start, stop, step = expr.iterable.args
+        else:
+            raise NotImplementedError("Only iterable currently supported is Range")
+        body = self._print(expr.body)
+        return ('for {target} in range({start}, {stop}, {step}):\n{body}\n#end\n').format(target=target, start=start,
+                stop=stop, step=step, body=body)
+
+    def _print_Assignment(self, expr):
+        from sympy.functions.elementary.piecewise import Piecewise
+        from sympy.matrices.expressions.matexpr import MatrixSymbol
+        from sympy.matrices import MatrixBase, MatrixSlice
+        from sympy.tensor.indexed import IndexedBase
+        lhs = expr.lhs
+        rhs = expr.rhs
+        # We special case assignments that take multiple lines
+        if isinstance(expr.rhs, Piecewise):
+            # Here we modify Piecewise so each expression is now
+            # an Assignment, and then continue on the print.
+            expressions = []
+            conditions = []
+            for (e, c) in rhs.args:
+                expressions.append(Assignment(lhs, e))
+                conditions.append(c)
+            temp = Piecewise(*zip(expressions, conditions))
+            return self._print(temp)
+        #elif isinstance(lhs, MatrixSymbol):
+        elif isinstance(lhs, (MatrixBase, MatrixSymbol, MatrixSlice)):
+            # Here we form an Assignment for each element in the array,
+            # printing each one.
+            lines = []
+            for (i, j) in self._traverse_matrix_indices(lhs):
+                temp = Assignment(lhs[i, j], rhs[i, j])
+                code0 = self._print(temp)
+                lines.append(code0)
+            return "\n".join(lines)
+        else:
+            lhs_code = self._print(lhs)
+            rhs_code = self._print(rhs)
+            # hack to avoid the printing of m[i] = m[i]
+            if lhs_code == rhs_code:
+                return ""
+            return self._get_statement("%s = %s" % (lhs_code, rhs_code))
+
+    def _print_AssignmentIf(self, expr):
+        from sympy.functions.elementary.piecewise import Piecewise
+        from sympy.matrices.expressions.matexpr import MatrixSymbol
+        from sympy.matrices import MatrixBase
+        from sympy.tensor.indexed import IndexedBase
+        lhs = expr.lhs
+        rhs = expr.rhs
+        # We special case assignments that take multiple lines
+        if isinstance(expr.rhs, Piecewise):
+            # Here we modify Piecewise so each expression is now
+            # an Assignment, and then continue on the print.
+            expressions = []
+            conditions = []
+            for (e, c) in rhs.args:
+                expressions.append(Assignment(lhs, e))
+                conditions.append(c)
+            temp = Piecewise(*zip(expressions, conditions))
+            return self._print(temp)
+        elif isinstance(lhs, (MatrixBase, MatrixSymbol)):
+            # Here we form an Assignment for each element in the array,
+            # printing each one.
+            lines = []
+            for (i, j) in self._traverse_matrix_indices(lhs):
+                temp = Assignment(lhs[i, j], rhs[i, j])
+                code0 = self._print(temp)
+                lines.append(code0)
+            return "\n".join(lines)
+        else:
+            lhs_code = self._print(lhs)
+            rhs_code = self._print(rhs)
+            # hack to avoid the printing of m[i] = m[i]
+            if lhs_code == rhs_code:
+                return ""
+            return self._get_statement("%s == %s" % (lhs_code, rhs_code))
+
+    def _print_sign(self, func):
+        return '((({0}) > 0) - (({0}) < 0))'.format(self._print(func.args[0]))
+
+    def indent_code(self, code):
+        """Accepts a string of code or a list of code lines"""
+
+        if isinstance(code, string_types):
+            code_lines = self.indent_code(code.splitlines(True))
+            return ''.join(code_lines)
+
+        tab = "    "
+        inc_token = (':', ":\n")
+        dec_token = ('end\n',)
+
+        code = [ line.lstrip(' \t') for line in code ]
+
+
+        increase = [ int(any(map(line.endswith, inc_token))) for line in code ]
+        decrease = [ int(any(map(line.endswith, dec_token)))
+                     for line in code ]
+        
+        pretty = []
+        level = 0
+        for n, line in enumerate(code):
+            if line == '' or line == '\n':
+                pretty.append(line)
+                continue
+            level -= decrease[n]
+            pretty.append("%s%s" % (tab*level, line))
+            level += increase[n]
+
+        return pretty
+
+    def _print_MatrixBase(self, A):
+        # Handle zero dimensions:
+        if A.rows == 0 or A.cols == 0:
+            return 'zeros(%s, %s)' % (A.rows, A.cols)
+        elif (A.rows, A.cols) == (1, 1):
+            return "[%s]" % A[0, 0]
+        elif A.rows == 1:
+            return "[%s]" % A.table(self, rowstart='', rowend='', colsep=' ')
+        elif A.cols == 1:
+            # note .table would unnecessarily equispace the rows
+            return "[%s]" % ", ".join([self._print(a) for a in A])
+        return "[%s]" % A.table(self, rowstart='', rowend='',
+                                rowsep=';\n', colsep=' ')
+
+    _print_Matrix = \
+        _print_DenseMatrix = \
+        _print_MutableDenseMatrix = \
+        _print_ImmutableMatrix = \
+        _print_ImmutableDenseMatrix = \
+        _print_MatrixBase

--- a/sympy/printing/cython.py
+++ b/sympy/printing/cython.py
@@ -392,7 +392,7 @@ class CythonCodePrinter(CodePrinter):
         increase = [ int(any(map(line.endswith, inc_token))) for line in code ]
         decrease = [ int(any(map(line.endswith, dec_token)))
                      for line in code ]
-        
+
         pretty = []
         level = 0
         for n, line in enumerate(code):

--- a/sympy/printing/cython.py
+++ b/sympy/printing/cython.py
@@ -8,6 +8,7 @@ from sympy.core.relational import Relational
 from sympy.core.sympify import _sympify, sympify
 from sympy.core.symbol import Symbol
 from sympy.printing.str import StrPrinter
+from sympy.codegen.ast import Assignment
 
 from sympy.printing.precedence import precedence
 from sympy.sets.fancysets import Range

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -5,8 +5,7 @@ This module contains python code printers for plain python as well as NumPy & Sc
 """
 from collections import defaultdict
 from itertools import chain
-from sympy.core import sympify, S
-from sympy.core import Add
+from sympy.core import S, Add
 from .precedence import precedence
 from .codeprinter import CodePrinter
 
@@ -869,6 +868,8 @@ class NumPyPrinter(PythonCodePrinter):
         return self._expand_fold_binary_op('numpy.add', expr.args)
 
     def _print_Indexed(self, expr):
+        from sympy.tensor.indexed import Idx
+
         elem = []
         for i in range(expr.rank):
             e = expr.indices[i]
@@ -904,7 +905,8 @@ class NumPyPrinter(PythonCodePrinter):
         from sympy.functions.elementary.piecewise import Piecewise
         from sympy.matrices.expressions.matexpr import MatrixSymbol
         from sympy.matrices import MatrixBase, MatrixSlice
-        from sympy.tensor.indexed import IndexedBase
+        from sympy.codegen.ast import Assignment
+
         lhs = expr.lhs
         rhs = expr.rhs
         # We special case assignments that take multiple lines

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from itertools import chain
 from sympy.core import sympify, S
 from sympy.core import Add
-from sympy.core.compatibility import string_types
 from .precedence import precedence
 from .codeprinter import CodePrinter
 
@@ -940,7 +939,7 @@ class NumPyPrinter(PythonCodePrinter):
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
 
-        if isinstance(code, string_types):
+        if isinstance(code, str):
             code_lines = self.indent_code(code.splitlines(True))
             return ''.join(code_lines)
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -573,7 +573,7 @@ def test_ccode_Assignment():
 
 def test_ccode_For():
     f = For(x, Range(0, 10, 2), [aug_assign(y, '*', x)])
-    assert ccode(f) == ("for (int x = 0; x < 10; x += 2) {\n"
+    assert ccode(f) == ("for (x = 0; x < 10; x += 2) {\n"
                         "   y *= x;\n"
                         "}")
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -573,7 +573,7 @@ def test_ccode_Assignment():
 
 def test_ccode_For():
     f = For(x, Range(0, 10, 2), [aug_assign(y, '*', x)])
-    assert ccode(f) == ("for (x = 0; x < 10; x += 2) {\n"
+    assert ccode(f) == ("for (int x = 0; x < 10; x += 2) {\n"
                         "   y *= x;\n"
                         "}")
 

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -137,7 +137,7 @@ class CodeWrapper:
             routines, self.filename, True, self.include_header,
             self.include_empty)
 
-    def wrap_code(self, routine, helpers=None):
+    def wrap_code(self, routines, helpers=None):
         helpers = helpers or []
         if self.filepath:
             workdir = os.path.abspath(self.filepath)

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -100,6 +100,11 @@ class CodeWrapper:
     _module_basename = "wrapper_module"
     _module_counter = 0
 
+    default_datatypes = None
+
+    def _get_type(self, stype):
+        return self.default_datatypes[stype]
+
     @property
     def filename(self):
         return "%s_%s" % (self._filename, CodeWrapper._module_counter)
@@ -254,6 +259,8 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
         "{body}")
 
     std_compile_flag = '-std=c99'
+
+    default_datatypes = C99CodeGen.default_datatypes
 
     def __init__(self, *args, **kwargs):
         """Instantiates a Cython code wrapper.
@@ -438,7 +445,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
         mat_dec = "np.ndarray[{mtype}, ndim={ndim}] {name}"
         np_types = {'double': 'np.double_t',
                     'int': 'np.int_t'}
-        t = arg.get_datatype('c')
+        t = self._get_type(arg.datatype)
         if arg.dimensions:
             self._need_numpy = True
             ndim = len(arg.dimensions)
@@ -457,7 +464,7 @@ setup(ext_modules=cythonize(ext_mods, **cy_opts))
 
     def _call_arg(self, arg):
         if arg.dimensions:
-            t = arg.get_datatype('c')
+            t = self._get_type(arg.datatype)
             return "<{}*> {}.data".format(t, self._string_var(arg.name))
         elif isinstance(arg, ResultBase):
             return "&{}".format(self._string_var(arg.name))

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -537,8 +537,8 @@ def _validate_backend_language(backend, language):
 
 @cacheit
 @doctest_depends_on(exe=('f2py', 'gfortran'), modules=('numpy',))
-def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
-             flags=None, verbose=False, helpers=None, code_gen=None, **kwargs):
+def autowrap(expr_or_routines, language=None, backend='f2py', tempdir=None, args=None,
+             flags=None, verbose=False, helpers=None, code_gen=None, user_local_vars=None, settings={}, **kwargs):
     """Generates python callable binaries based on the math expression.
 
     Parameters
@@ -619,7 +619,7 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
     args = list(args) if iterable(args, exclude=set) else args
 
     if code_gen is None:
-        code_gen = get_code_generator(language, "autowrap")
+        code_gen = get_code_generator(language, "autowrap", settings=settings)
 
     CodeWrapperClass = {
         'F2PY': F2PyCodeWrapper,

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -709,13 +709,13 @@ def autowrap(expr_or_routines, language=None, backend='f2py', tempdir=None, args
     for name_h, expr_h, args_h in helpers:
         helps.append(code_gen.routine(name_h, expr_h, args_h))
 
-    for name_h, expr_h, args_h in helpers:
-        if expr.has(expr_h):
-            name_h = binary_function(name_h, expr_h, backend='dummy')
-            expr = expr.subs(expr_h, name_h(*args_h))
 
     if isinstance(expr_or_routines, Basic):
         expr = expr_or_routines
+        for name_h, expr_h, args_h in helpers:
+            if expr.has(expr_h):
+                name_h = binary_function(name_h, expr_h, backend='dummy')
+                expr = expr.subs(expr_h, name_h(*args_h))
         try:
             routines = [code_gen.routine('autofunc', expr, args, user_local_vars)]
         except CodeGenArgumentListError as e:

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -99,7 +99,7 @@ from sympy.matrices import (MatrixSymbol, ImmutableMatrix, MatrixBase,
 
 __all__ = [
     # description of routines
-    "Routine", "DataType", "default_datatypes", "get_default_datatype",
+    "Routine", "get_default_datatype",
     "Argument", "InputArgument", "OutputArgument", "Result",
     # routines -> code
     "CodeGen", "CCodeGen", "FCodeGen", "JuliaCodeGen", "OctaveCodeGen",

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -1980,14 +1980,19 @@ class RustCodeGen(CodeGen):
         else:
             rstype = ""
 
-        type_args = []
+        type_args_in = []
+        type_args_inout = []
         for arg in routine.arguments:
             name = self.printer.doprint(arg.name)
+            if isinstance(arg, InputArgument):
+                type_args = type_args_in
+            if isinstance(arg, InOutArgument):
+                type_args = type_args_inout
             if arg.dimensions:# or isinstance(arg, ResultBase):
                 type_args.append(("*%s" % name, self._get_type(arg.datatype)))
             else:
                 type_args.append((name, self._get_type(arg.datatype)))
-        arguments = ", ".join([ "%s: %s" % t for t in type_args])
+        arguments = ", ".join([ "%s: %s" % t for t in type_args_inout + type_args_in])
         return "fn %s(%s)%s" % (routine.name, arguments, rstype)
 
     def _preprocessor_statements(self, prefix):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -864,7 +864,6 @@ class CCodeGen(CodeGen):
         def extract(expressions, return_index=1):
             new_expr = []
             for iexpr, expr in enumerate(expressions):
-                print(iexpr, expr)
                 if isinstance(expr, (Equality, Assignment)):
                     new_expr.append(expr)
                     out_arg = expr.lhs
@@ -1885,9 +1884,9 @@ def codegen(name_expr, language=None, prefix=None, project="project",
     #include "test.h"
     #include <math.h>
     double f(double x, double y, double z) {
-       double f_result;
-       f_result = x + y*z;
-       return f_result;
+       double out1;
+       out1 = x + y*z;
+       return out1;
     }
     <BLANKLINE>
     >>> print(h_name)
@@ -1913,9 +1912,9 @@ def codegen(name_expr, language=None, prefix=None, project="project",
     #include "myfcn.h"
     #include <math.h>
     double myfcn(double x, double y) {
-       double myfcn_result;
-       myfcn_result = x + y;
-       return myfcn_result;
+       double out1;
+       out1 = x + y;
+       return out1;
     }
     void fcn2(double x, double y, double *f, double *g) {
        (*f) = 2*x;

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -87,7 +87,7 @@ from collections import OrderedDict
 from sympy import __version__ as sympy_version
 from sympy.codegen import Assignment, WithBody
 from sympy.core import Symbol, S, Expr, Tuple, Equality, Function, Basic
-from sympy.core.compatibility import is_sequence, StringIO, string_types
+from sympy.core.compatibility import is_sequence, StringIO
 from sympy.printing.ccode import c_code_printers
 from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.fcode import FCodePrinter
@@ -906,7 +906,8 @@ class CCodeGen(CodeGen):
     standard = 'c99'
 
     default_datatypes = {'int': 'int',
-                         'float': 'double'}
+                         'float': 'double',
+                         'complex': 'double'}
 
     def __init__(self, project="project", printer=None,
                  preprocessor_statements=None, cse=False, settings={}):
@@ -1143,16 +1144,18 @@ class FCodeGen(CCodeGen):
     interface_extension = "h"
 
     default_datatypes = {'int': 'INTEGER*4',
-                         'float': 'REAL*8'}
+                         'float': 'REAL*8',
+                         'complex': 'COMPLEX*16'}
 
     def __init__(self, project='project', printer=None, settings={}):
         super().__init__(project)
         self.printer = printer or FCodePrinter(settings)
 
-    def __init__(self, project='project', printer=None, settings={}):
+    def _get_header(self):
         """Writes a common header for the generated files."""
         code_lines = []
         code_lines.append("!" + "*"*78 + '\n')
+        tmp = header_comment % {"version": sympy_version,
             "project": self.project}
         for line in tmp.splitlines():
             code_lines.append("!*%s*\n" % line.center(76))
@@ -1362,7 +1365,8 @@ class CythonCodeGen(CodeGen):
     has_output = False
 
     default_datatypes = {'int': 'int',
-                         'float': 'double'}
+                         'float': 'double',
+                         'complex': 'double'}
 
     def __init__(self, project='project', printer=None, settings={}):
         super(CythonCodeGen, self).__init__(project)
@@ -1538,7 +1542,7 @@ class NumPyCodeGen(CodeGen):
                 code_lines.append("#\n")
             else:
                 code_lines.append("#   %s\n" % line)
-        code_lines.append("import numpy")
+        code_lines.append("import numpy\n")
         return code_lines
 
     def _preprocessor_statements(self, prefix):
@@ -1943,7 +1947,8 @@ class RustCodeGen(CodeGen):
     code_extension = "rs"
 
     default_datatypes = {'int': 'i32',
-                         'float': 'f64'}
+                         'float': 'f64',
+                         'complex': 'float'}
 
     has_output = False
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -1661,14 +1661,17 @@ class JuliaCodeGen(CodeGen):
         code_list.append("function ")
 
         # Inputs
-        args = []
+        args_in = []
+        args_inout = []
         for i, arg in enumerate(routine.arguments):
             if isinstance(arg, OutputArgument):
                 raise CodeGenError("Julia: invalid argument of type %s" %
                                    str(type(arg)))
-            if isinstance(arg, (InputArgument, InOutArgument)):
-                args.append("%s" % self._get_symbol(arg.name))
-        args = ", ".join(args)
+            if isinstance(arg, InputArgument):
+                args_in.append("%s" % self._get_symbol(arg.name))
+            if isinstance(arg, InOutArgument):
+                args_inout.append("%s" % self._get_symbol(arg.name))
+        args = ", ".join(args_inout + args_in)
         code_list.append("%s(%s)\n" % (routine.name, args))
         code_list = [ "".join(code_list) ]
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -260,9 +260,9 @@ def get_default_datatype(expr, complex_allowed=None):
     else:
         final_dtype = "float"
     if expr.is_integer:
-        return default_datatypes["int"]
+        return "int"
     elif expr.is_real:
-        return default_datatypes["float"]
+        return "float"
     elif isinstance(expr, MatrixBase):
         #check all entries
         dt = "int"
@@ -270,10 +270,10 @@ def get_default_datatype(expr, complex_allowed=None):
             if dt == "int" and not element.is_integer:
                 dt = "float"
             if dt == "float" and not element.is_real:
-                return default_datatypes[final_dtype]
-        return default_datatypes[dt]
+                return final_dtype
+        return dt
     else:
-        return default_datatypes[final_dtype]
+        return final_dtype
 
 
 class Variable:

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -2224,7 +2224,7 @@ def codegen(name_expr, language=None, prefix=None, project="project",
     routines = []
     for name, expr in name_expr:
         routines.append(code_gen.routine(name, expr, argument_sequence,
-                                         global_vars))
+                                         global_vars=global_vars))
 
     # Write the code.
     return code_gen.write(routines, prefix, to_files, header, empty)

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -86,10 +86,9 @@ from collections import OrderedDict
 
 from sympy import __version__ as sympy_version
 from sympy.codegen import Assignment, WithBody
-from sympy.core import Symbol, S, Expr, Tuple, Equality, Function, Basic
+from sympy.core import Symbol, S, Tuple, Equality, Function, Basic
 from sympy.core.compatibility import is_sequence, StringIO
 from sympy.printing.ccode import c_code_printers
-from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.fcode import FCodePrinter
 from sympy.printing.pycode import NumPyPrinter
 from sympy.printing.cython import CythonCodePrinter
@@ -542,7 +541,6 @@ class CodeGen:
             for e in expr:
                 if not e.is_Equality:
                     raise CodeGenError("Lists of expressions must all be Equalities. {} is not.".format(e))
-            lhs = [e.lhs for e in expr]
 
             # create a list of right hand sides and simplify them
             rhs = [e.rhs for e in expr]
@@ -635,7 +633,6 @@ class CodeGen:
                         # avoid duplicate arguments
                         symbols.remove(symbol)
                 elif isinstance(expr, WithBody): # we should add all the classes which have a CodeBlock
-                    body = extract(expr.body.args, return_index)
                     new_expr.append(expr)
                 elif isinstance(expr, (ImmutableMatrix, MatrixSlice)):
                     # Create a "dummy" MatrixSymbol to use as the Output arg
@@ -1475,13 +1472,11 @@ class CythonCodeGen(CodeGen):
             if isinstance(arg, ResultBase) and not arg.dimensions:
                 dereference.append(arg.name)
 
-        return_val = None
         for result in routine.result_variables:
             if isinstance(result, Result):
                 assign_to = result.name
                 t = self._get_type(result.datatype)
                 code_lines.append("{0} {1};\n".format(t, str(assign_to)))
-                return_val = assign_to
 
         for statement in routine.statements:
             expr = statement
@@ -1789,7 +1784,6 @@ class OctaveCodeGen(CodeGen):
                         # it doesn't become an input.
                         symbols.remove(symbol)
                 elif isinstance(expr, WithBody): # we should add all the classes which have a CodeBlock
-                    body = extract(expr.body.args, return_index)
                     new_expr.append(expr)
                 else:
                     r = Result(expr, 'out' + str(return_index))

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -150,9 +150,9 @@ class Routine:
             language-specific.
 
         statements : list of Expressions
-            These are the different lines corresponding to the body of a 
+            These are the different lines corresponding to the body of a
             routine.
- 
+
         local_vars : list of Results
             These are variables that will be defined at the beginning of the
             function.
@@ -238,29 +238,15 @@ class Routine:
         args.extend(self.results)
         return args
 
-
-class DataType:
-    """Holds strings for a certain datatype in different languages."""
-    def __init__(self, cname, fname, pyname, jlname, octname, rsname):
-        self.cname = cname
-        self.fname = fname
-        self.pyname = pyname
-        self.jlname = jlname
-        self.octname = octname
-        self.rsname = rsname
+<<<<<<< HEAD
 
 
-default_datatypes = {
-    "int": DataType("int", "INTEGER*4", "int", "", "", "i32"),
-    "float": DataType("double", "REAL*8", "float", "", "", "f64"),
-    "complex": DataType("double", "COMPLEX*16", "complex", "", "", "float") #FIXME:
-       # complex is only supported in fortran, python, julia, and octave.
-       # So to not break c or rust code generation, we stick with double or
-       # float, respecitvely (but actually should raise an exception for
-       # explicitly complex variables (x.is_complex==True))
-}
-
-
+# TODO Loic: Must be added
+# "complex": DataType("double", "COMPLEX*16", "complex", "", "", "float") #FIXME:
+# complex is only supported in fortran, python, julia, and octave.
+# So to not break c or rust code generation, we stick with double or
+# float, respecitvely (but actually should raise an exception for
+# explicitly complex variables (x.is_complex==True))
 COMPLEX_ALLOWED = False
 def get_default_datatype(expr, complex_allowed=None):
     """Derives an appropriate datatype based on the expression."""
@@ -315,22 +301,15 @@ class Variable:
             raise TypeError("The first argument must be a sympy symbol.")
         if datatype is None:
             datatype = get_default_datatype(name)
-        elif not isinstance(datatype, DataType):
-            raise TypeError("The (optional) `datatype' argument must be an "
-                            "instance of the DataType class.")
+        # elif not isinstance(datatype, DataType):
+        #     raise TypeError("The (optional) `datatype' argument must be an "
+        #                     "instance of the DataType class.")
         if dimensions and not isinstance(dimensions, (tuple, list)):
             raise TypeError(
                 "The dimension argument must be a sequence of tuples")
 
         self._name = name
-        self._datatype = {
-            'C': datatype.cname,
-            'FORTRAN': datatype.fname,
-            'JULIA': datatype.jlname,
-            'OCTAVE': datatype.octname,
-            'PYTHON': datatype.pyname,
-            'RUST': datatype.rsname,
-        }
+        self.datatype = datatype
         self.dimensions = dimensions
         self.precision = precision
 
@@ -342,28 +321,6 @@ class Variable:
     @property
     def name(self):
         return self._name
-
-    def get_datatype(self, language):
-        """Returns the datatype string for the requested language.
-
-        Examples
-        ========
-
-        >>> from sympy import Symbol
-        >>> from sympy.utilities.codegen import Variable
-        >>> x = Variable(Symbol('x'))
-        >>> x.get_datatype('c')
-        'double'
-        >>> x.get_datatype('fortran')
-        'REAL*8'
-
-        """
-        try:
-            return self._datatype[language.upper()]
-        except KeyError:
-            raise CodeGenError("Has datatypes for languages: %s" %
-                    ", ".join(self._datatype))
-
 
 class Argument(Variable):
     """An abstract Argument data structure: a name and a data type.

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -85,7 +85,7 @@ import textwrap
 from collections import OrderedDict
 
 from sympy import __version__ as sympy_version
-from sympy.codegen import For, Assignment
+from sympy.codegen import Assignment, WithBody
 from sympy.core import Symbol, S, Expr, Tuple, Equality, Function, Basic
 from sympy.core.compatibility import is_sequence, StringIO, string_types
 from sympy.printing.ccode import c_code_printers
@@ -634,9 +634,9 @@ class CodeGen:
                     if symbol not in local_vars:
                         # avoid duplicate arguments
                         symbols.remove(symbol)
-                elif isinstance(expr, For): # we should add all the classes which have a CodeBlock
+                elif isinstance(expr, WithBody): # we should add all the classes which have a CodeBlock
                     body = extract(expr.body.args, return_index)
-                    new_expr.append(For(expr.target, expr.iterable, body))
+                    new_expr.append(expr)
                 elif isinstance(expr, (ImmutableMatrix, MatrixSlice)):
                     # Create a "dummy" MatrixSymbol to use as the Output arg
                     out_arg = MatrixSymbol('out' + str(return_index), *expr.shape)
@@ -1781,9 +1781,9 @@ class OctaveCodeGen(CodeGen):
                         # this is a pure output: remove from the symbols list, so
                         # it doesn't become an input.
                         symbols.remove(symbol)
-                elif isinstance(expr, For): # we should add all the classes which have a CodeBlock
+                elif isinstance(expr, WithBody): # we should add all the classes which have a CodeBlock
                     body = extract(expr.body.args, return_index)
-                    new_expr.append(For(expr.target, expr.iterable, body))
+                    new_expr.append(expr)
                 else:
                     r = Result(expr, 'out' + str(return_index))
                     return_index += 1

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -87,7 +87,7 @@ def test_cython_wrapper_inoutarg():
 def test_cython_wrapper_compile_flags():
     from sympy import Equality
     x, y, z = symbols('x,y,z')
-    routine = make_routine("test", Equality(z, x + y))
+    routine = [make_routine("test", Equality(z, x + y))]
 
     code_gen = CythonCodeWrapper(CCodeGen())
 

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -595,9 +595,9 @@ def test_ccode_unused_array_arg():
         '#include "test.h"\n'
         '#include <math.h>\n'
         'double test(double *x) {\n'
-        '   double test_result;\n'
-        '   test_result = 1.0;\n'
-        '   return test_result;\n'
+        '   double out1;\n'
+        '   out1 = 1.0;\n'
+        '   return out1;\n'
         '}\n'
     )
     assert source == expected

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -614,7 +614,7 @@ def test_c_for():
     expected = (
         '#include "test.h"\n'
         '#include <math.h>\n'
-        'void test(int n, double *y, double *x) {\n'
+        'void test(int n, double *x, double *y) {\n'
         '   for (int i = 0; i < 5; i += 1) {\n'
         '      y[i] = x[i];\n'
         '   }\n'

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1360,24 +1360,20 @@ def test_fcode_matrix_output():
     result = codegen(name_expr, "f95", "test", header=False, empty=False)
     source = result[0][1]
     expected = (
-        "REAL*8 function test(x, y, z, out_%(hash)s)\n"
+        "REAL*8 function test(x, y, z, out%(number)s)\n"
         "implicit none\n"
         "REAL*8, intent(in) :: x\n"
         "REAL*8, intent(in) :: y\n"
         "REAL*8, intent(in) :: z\n"
-        "REAL*8, intent(out), dimension(1:2, 1:2) :: out_%(hash)s\n"
-        "out_%(hash)s(1, 1) = x\n"
-        "out_%(hash)s(2, 1) = z\n"
-        "out_%(hash)s(1, 2) = y\n"
-        "out_%(hash)s(2, 2) = 16\n"
+        "REAL*8, intent(out), dimension(1:2, 1:2) :: out%(number)s\n"
+        "out%(number)s(1, 1) = x\n"
+        "out%(number)s(2, 1) = z\n"
+        "out%(number)s(1, 2) = y\n"
+        "out%(number)s(2, 2) = 16\n"
         "test = x + y\n"
         "end function\n"
     )
-    # look for the magic number
-    a = source.splitlines()[5]
-    b = a.split('_')
-    out = b[1]
-    expected = expected % {'hash': out}
+    expected = expected % {'number': 2}
     assert source == expected
 
 
@@ -1448,19 +1444,15 @@ def test_fcode_matrixsymbol_slice_autoname():
     result = codegen(name_expr, "f95", "test", header=False, empty=False)
     source = result[0][1]
     expected = (
-        "subroutine test(A, out_%(hash)s)\n"
+        "subroutine test(A, out%(number)s)\n"
         "implicit none\n"
         "REAL*8, intent(in), dimension(1:2, 1:3) :: A\n"
-        "REAL*8, intent(out), dimension(1:2, 1:1) :: out_%(hash)s\n"
-        "out_%(hash)s(1, 1) = A(1, 2)\n"
-        "out_%(hash)s(2, 1) = A(2, 2)\n"
+        "REAL*8, intent(out), dimension(1:2, 1:1) :: out%(number)s\n"
+        "out%(number)s(1, 1) = A(1, 2)\n"
+        "out%(number)s(2, 1) = A(2, 2)\n"
         "end subroutine\n"
     )
-    # look for the magic number
-    a = source.splitlines()[3]
-    b = a.split('_')
-    out = b[1]
-    expected = expected % {'hash': out}
+    expected = expected % {'number': 1}
     assert source == expected
 
 

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -96,9 +96,9 @@ def test_simple_c_code():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test(double x, double y, double z) {\n"
-        "   double test_result;\n"
-        "   test_result = z*(x + y);\n"
-        "   return test_result;\n"
+        "   double out1;\n"
+        "   out1 = z*(x + y);\n"
+        "   return out1;\n"
         "}\n"
     )
     assert source == expected
@@ -114,9 +114,9 @@ def test_c_code_reserved_words():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test(double if_, double typedef_, double while_) {\n"
-        "   double test_result;\n"
-        "   test_result = while_*(if_ + typedef_);\n"
-        "   return test_result;\n"
+        "   double out1;\n"
+        "   out1 = while_*(if_ + typedef_);\n"
+        "   return out1;\n"
         "}\n"
     )
     assert source == expected
@@ -130,10 +130,10 @@ def test_numbersymbol_c_code():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test() {\n"
-        "   double test_result;\n"
+        "   double out1;\n"
         "   double const Catalan = %s;\n"
-        "   test_result = pow(M_PI, Catalan);\n"
-        "   return test_result;\n"
+        "   out1 = pow(M_PI, Catalan);\n"
+        "   return out1;\n"
         "}\n"
     ) % Catalan.evalf(17)
     assert source == expected
@@ -149,9 +149,9 @@ def test_c_code_argument_order():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test(double z, double x, double y) {\n"
-        "   double test_result;\n"
-        "   test_result = x + y;\n"
-        "   return test_result;\n"
+        "   double out1;\n"
+        "   out1 = x + y;\n"
+        "   return out1;\n"
         "}\n"
     )
     assert source == expected
@@ -180,9 +180,9 @@ def test_simple_c_codegen():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test(double x, double y, double z) {\n"
-        "   double test_result;\n"
-        "   test_result = z*(x + y);\n"
-        "   return test_result;\n"
+        "   double out1;\n"
+        "   out1 = z*(x + y);\n"
+        "   return out1;\n"
         "}\n"),
         ("file.h",
         "#ifndef PROJECT__FILE__H\n"
@@ -236,21 +236,21 @@ def test_ansi_math1_codegen():
     assert result[0][0] == "file.c"
     assert result[0][1] == (
         '#include "file.h"\n#include <math.h>\n'
-        'double test_fabs(double x) {\n   double test_fabs_result;\n   test_fabs_result = fabs(x);\n   return test_fabs_result;\n}\n'
-        'double test_acos(double x) {\n   double test_acos_result;\n   test_acos_result = acos(x);\n   return test_acos_result;\n}\n'
-        'double test_asin(double x) {\n   double test_asin_result;\n   test_asin_result = asin(x);\n   return test_asin_result;\n}\n'
-        'double test_atan(double x) {\n   double test_atan_result;\n   test_atan_result = atan(x);\n   return test_atan_result;\n}\n'
-        'double test_ceil(double x) {\n   double test_ceil_result;\n   test_ceil_result = ceil(x);\n   return test_ceil_result;\n}\n'
-        'double test_cos(double x) {\n   double test_cos_result;\n   test_cos_result = cos(x);\n   return test_cos_result;\n}\n'
-        'double test_cosh(double x) {\n   double test_cosh_result;\n   test_cosh_result = cosh(x);\n   return test_cosh_result;\n}\n'
-        'double test_floor(double x) {\n   double test_floor_result;\n   test_floor_result = floor(x);\n   return test_floor_result;\n}\n'
-        'double test_log(double x) {\n   double test_log_result;\n   test_log_result = log(x);\n   return test_log_result;\n}\n'
-        'double test_ln(double x) {\n   double test_ln_result;\n   test_ln_result = log(x);\n   return test_ln_result;\n}\n'
-        'double test_sin(double x) {\n   double test_sin_result;\n   test_sin_result = sin(x);\n   return test_sin_result;\n}\n'
-        'double test_sinh(double x) {\n   double test_sinh_result;\n   test_sinh_result = sinh(x);\n   return test_sinh_result;\n}\n'
-        'double test_sqrt(double x) {\n   double test_sqrt_result;\n   test_sqrt_result = sqrt(x);\n   return test_sqrt_result;\n}\n'
-        'double test_tan(double x) {\n   double test_tan_result;\n   test_tan_result = tan(x);\n   return test_tan_result;\n}\n'
-        'double test_tanh(double x) {\n   double test_tanh_result;\n   test_tanh_result = tanh(x);\n   return test_tanh_result;\n}\n'
+        'double test_fabs(double x) {\n   double out1;\n   out1 = fabs(x);\n   return out1;\n}\n'
+        'double test_acos(double x) {\n   double out1;\n   out1 = acos(x);\n   return out1;\n}\n'
+        'double test_asin(double x) {\n   double out1;\n   out1 = asin(x);\n   return out1;\n}\n'
+        'double test_atan(double x) {\n   double out1;\n   out1 = atan(x);\n   return out1;\n}\n'
+        'double test_ceil(double x) {\n   double out1;\n   out1 = ceil(x);\n   return out1;\n}\n'
+        'double test_cos(double x) {\n   double out1;\n   out1 = cos(x);\n   return out1;\n}\n'
+        'double test_cosh(double x) {\n   double out1;\n   out1 = cosh(x);\n   return out1;\n}\n'
+        'double test_floor(double x) {\n   double out1;\n   out1 = floor(x);\n   return out1;\n}\n'
+        'double test_log(double x) {\n   double out1;\n   out1 = log(x);\n   return out1;\n}\n'
+        'double test_ln(double x) {\n   double out1;\n   out1 = log(x);\n   return out1;\n}\n'
+        'double test_sin(double x) {\n   double out1;\n   out1 = sin(x);\n   return out1;\n}\n'
+        'double test_sinh(double x) {\n   double out1;\n   out1 = sinh(x);\n   return out1;\n}\n'
+        'double test_sqrt(double x) {\n   double out1;\n   out1 = sqrt(x);\n   return out1;\n}\n'
+        'double test_tan(double x) {\n   double out1;\n   out1 = tan(x);\n   return out1;\n}\n'
+        'double test_tanh(double x) {\n   double out1;\n   out1 = tanh(x);\n   return out1;\n}\n'
     )
     assert result[1][0] == "file.h"
     assert result[1][1] == (
@@ -278,8 +278,8 @@ def test_ansi_math2_codegen():
     assert result[0][0] == "file.c"
     assert result[0][1] == (
         '#include "file.h"\n#include <math.h>\n'
-        'double test_atan2(double x, double y) {\n   double test_atan2_result;\n   test_atan2_result = atan2(x, y);\n   return test_atan2_result;\n}\n'
-        'double test_pow(double x, double y) {\n   double test_pow_result;\n   test_pow_result = pow(x, y);\n   return test_pow_result;\n}\n'
+        'double test_atan2(double x, double y) {\n   double out1;\n   out1 = atan2(x, y);\n   return out1;\n}\n'
+        'double test_pow(double x, double y) {\n   double out1;\n   out1 = pow(x, y);\n   return out1;\n}\n'
     )
     assert result[1][0] == "file.h"
     assert result[1][1] == (
@@ -302,8 +302,8 @@ def test_complicated_codegen():
     assert result[0][1] == (
         '#include "file.h"\n#include <math.h>\n'
         'double test1(double x, double y, double z) {\n'
-        '   double test1_result;\n'
-        '   test1_result = '
+        '   double out1;\n'
+        '   out1 = '
         'pow(sin(x), 7) + '
         '7*pow(sin(x), 6)*cos(y) + '
         '7*pow(sin(x), 6)*tan(z) + '
@@ -340,12 +340,12 @@ def test_complicated_codegen():
         '21*pow(cos(y), 2)*pow(tan(z), 5) + '
         '7*cos(y)*pow(tan(z), 6) + '
         'pow(tan(z), 7);\n'
-        '   return test1_result;\n'
+        '   return out1;\n'
         '}\n'
         'double test2(double x, double y, double z) {\n'
-        '   double test2_result;\n'
-        '   test2_result = cos(cos(cos(cos(cos(cos(cos(cos(x + y + z))))))));\n'
-        '   return test2_result;\n'
+        '   double out1;\n'
+        '   out1 = cos(cos(cos(cos(cos(cos(cos(cos(x + y + z))))))));\n'
+        '   return out1;\n'
         '}\n'
     )
     assert result[1][0] == "file.h"
@@ -478,10 +478,10 @@ def test_output_arg_c():
         '#include "test.h"\n'
         '#include <math.h>\n'
         'double foo(double x, double *y) {\n'
+        '   double out1;\n'
         '   (*y) = sin(x);\n'
-        '   double foo_result;\n'
-        '   foo_result = cos(x);\n'
-        '   return foo_result;\n'
+        '   out1 = cos(x);\n'
+        '   return out1;\n'
         '}\n'
     )
     assert result[0][1] == expected
@@ -498,10 +498,10 @@ def test_output_arg_c_reserved_words():
         '#include "test.h"\n'
         '#include <math.h>\n'
         'double foo(double if_, double *while_) {\n'
+        '   double out1;\n'
         '   (*while_) = sin(if_);\n'
-        '   double foo_result;\n'
-        '   foo_result = cos(if_);\n'
-        '   return foo_result;\n'
+        '   out1 = cos(if_);\n'
+        '   return out1;\n'
         '}\n'
     )
     assert result[0][1] == expected
@@ -519,10 +519,10 @@ def test_ccode_results_named_ordered():
         '#include "test.h"\n'
         '#include <math.h>\n'
         'void test(double x, double *C, double z, double y, double *A, double *B) {\n'
-        '   (*C) = z*(x + y);\n'
         '   A[0] = 1;\n'
         '   A[1] = 2;\n'
         '   A[2] = x;\n'
+        '   (*C) = z*(x + y);\n'
         '   (*B) = 2*x;\n'
         '}\n'
     )
@@ -1461,9 +1461,9 @@ def test_global_vars():
         '#include "f.h"\n'
         '#include <math.h>\n'
         'double f(double x, double y) {\n'
-        '   double f_result;\n'
-        '   f_result = x*y + z;\n'
-        '   return f_result;\n'
+        '   double out1;\n'
+        '   out1 = x*y + z;\n'
+        '   return out1;\n'
         '}\n'
     )
     result = codegen(('f', x*y+z), "C", header=False, empty=False,
@@ -1488,9 +1488,9 @@ def test_custom_codegen():
         '#include "expr.h"\n'
         '#include "fastexp.h"\n'
         'double expr(double x, double y) {\n'
-        '   double expr_result;\n'
-        '   expr_result = fastexp(x + y);\n'
-        '   return expr_result;\n'
+        '   double out1;\n'
+        '   out1 = fastexp(x + y);\n'
+        '   return out1;\n'
         '}\n'
     )
 
@@ -1507,9 +1507,9 @@ def test_custom_codegen():
         '#include <math.h>\n'
         '#include "fastexp.h"\n'
         'double expr(double x, double y) {\n'
-        '   double expr_result;\n'
-        '   expr_result = fastexp(x + y);\n'
-        '   return expr_result;\n'
+        '   double out1;\n'
+        '   out1 = fastexp(x + y);\n'
+        '   return out1;\n'
         '}\n'
     )
 
@@ -1532,9 +1532,9 @@ def test_c_with_printer():
         "#include \"file.h\"\n"
         "#include <math.h>\n"
         "double test(double x) {\n"
-        "   double test_result;\n"
-        "   test_result = fastpow(x, 3);\n"
-        "   return test_result;\n"
+        "   double out1;\n"
+        "   out1 = fastpow(x, 3);\n"
+        "   return out1;\n"
         "}\n"),
         ("file.h",
         "#ifndef PROJECT__FILE__H\n"

--- a/sympy/utilities/tests/test_codegen_julia.py
+++ b/sympy/utilities/tests/test_codegen_julia.py
@@ -484,7 +484,7 @@ def test_jl_loops():
                       header=False, empty=False)
     source = result[1]
     expected = (
-        'function mat_vec_mult(A, m, n, x, y)\n'
+        'function mat_vec_mult(y, A, m, n, x)\n'
         '    for i = 1:m\n'
         '        y[i] = 0\n'
         '    end\n'
@@ -516,7 +516,7 @@ def test_jl_tensor_loops_multiple_contractions():
                       "Julia", header=False, empty=False)
     source = result[1]
     expected = (
-        'function tensorthing(A, B, m, n, o, p, y)\n'
+        'function tensorthing(y, A, B, m, n, o, p)\n'
         '    for i = 1:m\n'
         '        y[i] = 0\n'
         '    end\n'
@@ -569,7 +569,7 @@ def test_jl_InOutArgument_order():
     result, = codegen(name_expr, "Julia", header=False, empty=False)
     source = result[1]
     expected = (
-        "function test(y, x)\n"
+        "function test(x, y)\n"
         "    x = x.^2 + y\n"
         "    return x\n"
         "end\n"

--- a/sympy/utilities/tests/test_codegen_julia.py
+++ b/sympy/utilities/tests/test_codegen_julia.py
@@ -205,9 +205,9 @@ def test_jl_output_arg_mixed_unordered():
         'function foo(x)\n'
         '    out1 = cos(2*x)\n'
         '    y = sin(x)\n'
-        '    out3 = cos(x)\n'
+        '    out2 = cos(x)\n'
         '    a = sin(2*x)\n'
-        '    return out1, y, out3, a\n'
+        '    return out1, y, out2, a\n'
         'end\n'
     )
     assert source == expected
@@ -458,10 +458,10 @@ def test_jl_matrixsymbol_slice_autoname():
     expected = (
         "function test(A)\n"
         "    B = A[1,:]\n"
-        "    out2 = A[2,:]\n"
-        "    out3 = A[:,1]\n"
-        "    out4 = A[:,2]\n"
-        "    return B, out2, out3, out4\n"
+        "    out1 = A[2,:]\n"
+        "    out2 = A[:,1]\n"
+        "    out3 = A[:,2]\n"
+        "    return B, out1, out2, out3\n"
         "end\n"
     )
     assert source == expected
@@ -569,7 +569,7 @@ def test_jl_InOutArgument_order():
     result, = codegen(name_expr, "Julia", header=False, empty=False)
     source = result[1]
     expected = (
-        "function test(x, y)\n"
+        "function test(y, x)\n"
         "    x = x.^2 + y\n"
         "    return x\n"
         "end\n"

--- a/sympy/utilities/tests/test_codegen_julia.py
+++ b/sympy/utilities/tests/test_codegen_julia.py
@@ -484,7 +484,7 @@ def test_jl_loops():
                       header=False, empty=False)
     source = result[1]
     expected = (
-        'function mat_vec_mult(y, A, m, n, x)\n'
+        'function mat_vec_mult(A, m, n, x, y)\n'
         '    for i = 1:m\n'
         '        y[i] = 0\n'
         '    end\n'
@@ -516,7 +516,7 @@ def test_jl_tensor_loops_multiple_contractions():
                       "Julia", header=False, empty=False)
     source = result[1]
     expected = (
-        'function tensorthing(y, A, B, m, n, o, p)\n'
+        'function tensorthing(A, B, m, n, o, p, y)\n'
         '    for i = 1:m\n'
         '        y[i] = 0\n'
         '    end\n'

--- a/sympy/utilities/tests/test_codegen_rust.py
+++ b/sympy/utilities/tests/test_codegen_rust.py
@@ -350,7 +350,7 @@ def test_InOutArgument_order():
     result, = codegen(name_expr, "Rust", header=False, empty=False)
     source = result[1]
     expected = (
-        "fn test(y: f64, x: f64) -> f64 {\n"
+        "fn test(x: f64, y: f64) -> f64 {\n"
         "    let x = x.powi(2) + y;\n"
         "    x\n"
         "}\n"

--- a/sympy/utilities/tests/test_codegen_rust.py
+++ b/sympy/utilities/tests/test_codegen_rust.py
@@ -212,9 +212,9 @@ def test_output_arg_mixed_unordered():
         "fn foo(x: f64) -> (f64, f64, f64, f64) {\n"
         "    let out1 = (2*x).cos();\n"
         "    let y = x.sin();\n"
-        "    let out3 = x.cos();\n"
+        "    let out2 = x.cos();\n"
         "    let a = (2*x).sin();\n"
-        "    (out1, y, out3, a)\n"
+        "    (out1, y, out2, a)\n"
         "}\n"
     )
     assert source == expected
@@ -350,7 +350,7 @@ def test_InOutArgument_order():
     result, = codegen(name_expr, "Rust", header=False, empty=False)
     source = result[1]
     expected = (
-        "fn test(x: f64, y: f64) -> f64 {\n"
+        "fn test(y: f64, x: f64) -> f64 {\n"
         "    let x = x.powi(2) + y;\n"
         "    x\n"
         "}\n"


### PR DESCRIPTION
This PR is a fix and improvement of codegen.

<!-- BEGIN RELEASE NOTES -->
* codegen
  * fix the recursion when you have mutliple CodeBlocks
  * support other Matrix types
  * remove datatype function and define each datatype inside codegen classes for more flexibility
  * add settings in Routine to manage the printer for each routine when you have multiple
  * add idx_vars in Routine that stores the indexes contained in For (they need particular treatment sometimes)
* utilities
    * autowrap: wrap several routines in one go and export the module
    * autowrap: add NumPy and Pure Cython wrapper
<!-- END RELEASE NOTES -->

This short example shows the issue for the recursion of For

```
x, y = symbols('x,y', real=True) 
i = Idx('i') 
test = For(i, Range(10), [Assignment(x, y)]) 
routine = make_routine('test', test) 
code_gen = C89CodeGen() 
source = get_string(code_gen.dump_c, [routine]) 
print(routine) 
print(source)
```

The output is

```
Routine('test', [InputArgument(x), InputArgument(y)], [Result(For(i, Range(0, 10, 1), CodeBlock(Assignment(x, y))), result_6824502057046278987, result_6824502057046278987)], {i}, set())
#include "file.h"
#include <math.h>
double test(double x, double y) {
   double test_result;
   test_result = for (i = 0; i < 10; i += 1) {
      x = y;
   };
   return test_result;
}
```

The problem is that For expression has a CodeBlock (list of statements) which can contain important information for output parameters and return values.

So, the idea is to inspect output parameters and result values recursively and not to see a routine as a result but as a list of statements where you can have results, input, output, input/output.

Now, the main issue is to change the sympy expression where you have a result parameter like in this expression

```
For(i, Range(10), [x*y])
```

The idea would be to replace `x*y` by `Assignment(result.name, x*y)`. In that way, all the work done for printing in a target language should be the same. 

I don't know how to do this correctly because each method `subs`, `replace`, ... returns a copy and we need to change tuple element of CodeBlock for example.

If you have some ideas ...

 
