### PR TITLE
In log_to_real, pair conjugate roots without losing any pairs

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -361,7 +361,7 @@ def log_to_real(h, q, x, t):
         R_v_paired = [] # take one from each pair of conjugate roots
         for r_v in R_v:
             if r_v not in R_v_paired and -r_v not in R_v_paired:
-                if r_v.is_negative:
+                if r_v.is_negative or r_v.could_extract_minus_sign():
                     R_v_paired.append(-r_v)
                 elif not r_v.is_zero:
                     R_v_paired.append(r_v)

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -358,9 +358,15 @@ def log_to_real(h, q, x, t):
         if len(R_v) != C.count_roots():
             return None
 
+        R_v_paired = [] # take one from each pair of conjugate roots
         for r_v in R_v:
-            if not r_v.is_positive:
-                continue
+            if r_v not in R_v_paired and -r_v not in R_v_paired:
+                if r_v.is_negative:
+                    R_v_paired.append(-r_v)
+                elif not r_v.is_zero:
+                    R_v_paired.append(r_v)
+
+        for r_v in R_v_paired:
 
             D = d.subs({u: r_u, v: r_v})
 

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -133,6 +133,20 @@ def test_issue_10488():
     a,b,c,x = symbols('a b c x', real=True, positive=True)
     assert integrate(x/(a*x+b),x) == x/a - b*log(a*x + b)/a**2
 
+
+def test_issues_8246_12050_13501_14080():
+    a = symbols('a', real=True)
+    assert integrate(a/(x**2 + a**2), x) == atan(x/a)
+    assert integrate(1/(x**2 + a**2), x) == atan(x/a)/a
+    assert integrate(1/(1 + a**2*x**2), x) == atan(a*x)/a
+
+
+def test_issue_6308():
+    k, a0 = symbols('k a0', real=True)
+    assert integrate((x**2 + 1 - k**2)/(x**2 + 1 + a0**2), x) == \
+        x - (a0**2 + k**2)*atan(x/sqrt(a0**2 + 1))/sqrt(a0**2 + 1)
+
+
 def test_log_to_atan():
     f, g = (Poly(x + S(1)/2, x, domain='QQ'), Poly(sqrt(3)/2, x, domain='EX'))
     fg_ans = 2*atan(2*sqrt(3)*x/3 + sqrt(3)/3)

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -147,6 +147,12 @@ def test_issue_6308():
         x - (a0**2 + k**2)*atan(x/sqrt(a0**2 + 1))/sqrt(a0**2 + 1)
 
 
+def test_issue_5907():
+    a = symbols('a', real=True)
+    assert integrate(1/(x**2 + a**2)**2, x) == \
+         x/(2*a**4 + 2*a**2*x**2) + atan(x/a)/(2*a**3)
+
+
 def test_log_to_atan():
     f, g = (Poly(x + S(1)/2, x, domain='QQ'), Poly(sqrt(3)/2, x, domain='EX'))
     fg_ans = 2*atan(2*sqrt(3)*x/3 + sqrt(3)/3)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #5907. Fixes #6308. Fixes #8246. Fixes #12050. Fixes #13501. Fixes #14080.

#### Brief description of what is fixed or changed

This implements the solution [proposed by @jksuom](https://github.com/sympy/sympy/issues/12050#issuecomment-339047735). Presently, when `log_to_real` converts complex logarithms to atan, it only picks roots with positive imaginary part, to avoid duplication. This is a problem because it's not always known which of two roots has positive imaginary part. In the latter case, we should just pick one instead of ignoring the pair of roots completely.