### PR TITLE
Fix incompatibility with python 2 and the unicode_literals future import

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -466,7 +466,7 @@ def _get_namespace(m):
     """
     This is used by _lambdify to parse its arguments.
     """
-    if isinstance(m, str):
+    if isinstance(m, string_types):
         _import(m)
         return MODULES[m][0]
     elif isinstance(m, dict):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -609,6 +609,13 @@ def test_namespace_order():
     assert if1(1) == 'first f'
 
 
+def test_namespace_type():
+    # lambdify had a bug where it would reject modules of type unicode
+    # on Python 2.
+    x = sympy.Symbol('x')
+    lambdify(x, x, modules=u'math')
+
+
 def test_imps():
     # Here we check if the default returned functions are anonymous - in
     # the sense that we can have more than one function with the same name


### PR DESCRIPTION
This PR fixes a minor incompatibility with Python 2, after the `from __future__ import unicode_literals` import has been executed. This makes it harder to write code that is compatible with Python 2 and Python 3 that uses `lambdify`. Absent this fix, the only options which work with `unicode_literals` on are:
```
lambdify(variable, expr, modules=b'numpy')  # Fails on Python 3, since you cannot import b'strings'.
lambdify(variable, expr, modules=str('numpy'))  # Somewhat cryptic.
```

## Testing

On master, the code fails in the following way, with a confusing error message:
```python
>>> from __future__ import unicode_literals
>>> from sympy import *
>>> x = Symbol('x')
>>> lambdify(x, x, modules='numpy')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy/utilities/lambdify.py", line 358, in lambdify
    buf = _get_namespace(m)
  File "sympy/utilities/lambdify.py", line 477, in _get_namespace
    raise TypeError("Argument must be either a string, dict or module but it is: %s" % m)
TypeError: Argument must be either a string, dict or module but it is: numpy
```

After the changes in this commit are applied, the code works as expected:
```python
>>> from __future__ import unicode_literals
>>> from sympy import *
>>> x = Symbol('x')
>>> lambdify(x, x, modules='numpy')
<function <lambda> at 0x1090b86e0>
```

Please let me know if you would like me to add a testcase for this.