### PR TITLE
Fix typos in some headers of simplify module documentation

### DIFF
--- a/doc/src/modules/simplify/simplify.rst
+++ b/doc/src/modules/simplify/simplify.rst
@@ -98,7 +98,7 @@ powdenest
 .. autofunction:: powdenest
 
 Combinatorial simplification
----------------------------
+----------------------------
 .. module:: sympy.simplify.combsimp
 
 combsimp
@@ -106,7 +106,7 @@ combsimp
 .. autofunction:: combsimp
 
 Square Root Denesting
-------------------
+---------------------
 .. module:: sympy.simplify.sqrtdenest
 
 sqrtdenest
@@ -114,7 +114,7 @@ sqrtdenest
 .. autofunction:: sqrtdenest
 
 Common Subexpression Elimination
--------------------------------
+--------------------------------
 .. module:: sympy.simplify.cse_main
 
 cse

--- a/doc/src/modules/simplify/simplify.rst
+++ b/doc/src/modules/simplify/simplify.rst
@@ -97,7 +97,7 @@ powdenest
 ^^^^^^^^^
 .. autofunction:: powdenest
 
-Combinatrial simplification
+Combinatorial simplification
 ---------------------------
 .. module:: sympy.simplify.combsimp
 
@@ -105,7 +105,7 @@ combsimp
 ^^^^^^^^
 .. autofunction:: combsimp
 
-Square Root Denest
+Square Root Denesting
 ------------------
 .. module:: sympy.simplify.sqrtdenest
 
@@ -113,7 +113,7 @@ sqrtdenest
 ^^^^^^^^^^
 .. autofunction:: sqrtdenest
 
-Common Subexpresion Elimination
+Common Subexpression Elimination
 -------------------------------
 .. module:: sympy.simplify.cse_main
 


### PR DESCRIPTION
Supplied missing letters in "combinatrial" and "subexpresion"; replaced "denest" by "denesting"
