### PR TITLE
Adjust for the difference between numpy.sinc and sympy.sinc

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from functools import wraps
 from itertools import chain
-from sympy.core import sympify
+from sympy.core import sympify, S
 from .precedence import precedence
 from .codeprinter import CodePrinter
 
@@ -385,6 +385,9 @@ class NumPyPrinter(PythonCodePrinter):
 
     def _print_re(self, expr):
         return "%s(%s)" % (self._module_format('numpy.real'), self._print(expr.args[0]))
+
+    def _print_sinc(self, expr):
+        return "%s(%s)" % (self._module_format('numpy.sinc'), self._print(expr.args[0]/S.Pi))
 
     def _print_MatrixBase(self, expr):
         func = self.known_functions.get(expr.__class__.__name__, None)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -8,7 +8,7 @@ from sympy import (
     symbols, lambdify, sqrt, sin, cos, tan, pi, acos, acosh, Rational,
     Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
     true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum,
-    DotProduct, Eq, Dummy)
+    DotProduct, Eq, Dummy, sinc)
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import skip
@@ -802,6 +802,16 @@ def test_issue_12173():
     exp2 = lambdify((x, y), lowergamma(x, y),"mpmath")(1, 2)
     assert exp1 == uppergamma(1, 2).evalf()
     assert exp2 == lowergamma(1, 2).evalf()
+
+def test_issue_13642():
+    if not numpy:
+        skip("numpy not installed")
+    f = lambdify(x, sinc(x))
+    assert Abs(f(1) - sinc(1)).n() < 1e-15
+
+def test_sinc_mpmath():
+    f = lambdify(x, sinc(x), "mpmath")
+    assert Abs(f(1) - sinc(1)).n() < 1e-15
 
 def test_lambdify_dummy_arg():
     d1 = Dummy()


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #13642.

#### Brief description of what is fixed or changed

In SymPy, sinc(x) is sin(x)/x. But NumPy uses normalized sinc, which is `sin(pi*x)/(pi*x)`. Accordingly, NumPyPrinter should print sinc as `numpy.sinc(x/pi)`