### PR TITLE
latex print with parenthesis

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -414,11 +414,11 @@ class LatexPrinter(Printer):
 
                 for i, term in enumerate(args):
                     power = False
-                    if not term.is_Pow:
-                        term_tex = self._print(term)
-                    else:
+                    if term.is_Pow and bool(term.args[0].free_symbols) and term.args[1].is_Integer:
                         term_tex = self._print(term.args[0])
                         term, power = term.args[0], term.args[1]
+                    else:
+                        term_tex = self._print(term)
 
                     if self._needs_mul_brackets(term, first=(i == 0),
                                                 last=(i == len(args) - 1)):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -413,11 +413,19 @@ class LatexPrinter(Printer):
                     args = expr.args
 
                 for i, term in enumerate(args):
-                    term_tex = self._print(term)
+                    power = False
+                    if not term.is_Pow:
+                        term_tex = self._print(term)
+                    else:
+                        term_tex = self._print(term.args[0])
+                        term, power = term.args[0], term.args[1]
 
                     if self._needs_mul_brackets(term, first=(i == 0),
                                                 last=(i == len(args) - 1)):
                         term_tex = r"\left(%s\right)" % term_tex
+
+                    if power:
+                        term_tex = r"%s^{%s}" % (term_tex, power)
 
                     if _between_two_numbers_p[0].search(last_term_tex) and \
                             _between_two_numbers_p[1].match(term_tex):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1682,7 +1682,7 @@ def test_issue_14041():
     r_dot = r.diff(t,N_frame).simplify()
     r_ddot = r_dot.diff(t,N_frame).simplify()
 
-    assert latex(r_ddot) == r"-  L \left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{b}_x} + L \left(\ddot{\phi} + \ddot{\theta}\right)\mathbf{\hat{b}_y} -  R \dot{\theta}^{2}\mathbf{\hat{a}_x} + R \ddot{\theta}\mathbf{\hat{a}_y}"
+    assert latex(r_ddot) == '-  L \\left(\\dot{\\phi} + \\dot{\\theta}\\right)^{2}\\mathbf{\\hat{b}_x} + L \\left(\\ddot{\\phi} + \\ddot{\\theta}\\right)\\mathbf{\\hat{b}_y} -  R \\dot{\\theta}^{2}\\mathbf{\\hat{a}_x} + R \\ddot{\\theta}\\mathbf{\\hat{a}_y}'
 
 
 def test_latex_UnevaluatedExpr():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1655,34 +1655,12 @@ def test_issue_13651():
 def test_issue_14041():
     import sympy.physics.mechanics as me
 
-    N_frame = me.ReferenceFrame('N')
     A_frame = me.ReferenceFrame('A')
-    B_frame = me.ReferenceFrame('B')
-
-    R_length = symbols('R')
-    L_length = symbols('L')
-
-    theta, phi  = me.dynamicsymbols('theta, phi')
     thetad, phid  = me.dynamicsymbols('theta, phi', 1)
-    t = Symbol('t')
+    L = Symbol('L')
 
-    A_frame.orient(N_frame, 'Axis', (theta, N_frame.z))
-    B_frame.orient(A_frame, 'Axis', (phi, A_frame.z))
-
-    O_point = me.Point('O')
-    O_point.set_vel(N_frame, 0)
-
-    O_point = me.Point('O')
-    O_point.set_vel(N_frame, 0)
-
-    Q_point = O_point.locatenew('A', R_length*A_frame.x)
-    P_point = Q_point.locatenew('B', L_length*B_frame.x)
-
-    r = P_point.pos_from(O_point)
-    r_dot = r.diff(t,N_frame).simplify()
-    r_ddot = r_dot.diff(t,N_frame).simplify()
-
-    assert latex(r_ddot) == '-  L \\left(\\dot{\\phi} + \\dot{\\theta}\\right)^{2}\\mathbf{\\hat{b}_x} + L \\left(\\ddot{\\phi} + \\ddot{\\theta}\\right)\\mathbf{\\hat{b}_y} -  R \\dot{\\theta}^{2}\\mathbf{\\hat{a}_x} + R \\ddot{\\theta}\\mathbf{\\hat{a}_y}'
+    assert latex(L*(phid + thetad)**2*A_frame.x) == \
+        r"L \left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{a}_x}"
 
 
 def test_latex_UnevaluatedExpr():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1682,8 +1682,6 @@ def test_issue_14041():
     r_dot = r.diff(t,N_frame).simplify()
     r_ddot = r_dot.diff(t,N_frame).simplify()
 
-    import pdb
-    #pdb.set_trace()
     assert latex(r_ddot) == r"-  L \left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{b}_x} + L \left(\ddot{\phi} + \ddot{\theta}\right)\mathbf{\hat{b}_y} -  R \dot{\theta}^{2}\mathbf{\hat{a}_x} + R \ddot{\theta}\mathbf{\hat{a}_y}"
 
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1652,6 +1652,41 @@ def test_issue_13651():
     assert latex(expr) == r"c - \left(a + b\right)"
 
 
+def test_issue_14041():
+    import sympy.physics.mechanics as me
+
+    N_frame = me.ReferenceFrame('N')
+    A_frame = me.ReferenceFrame('A')
+    B_frame = me.ReferenceFrame('B')
+
+    R_length = symbols('R')
+    L_length = symbols('L')
+
+    theta, phi  = me.dynamicsymbols('theta, phi')
+    thetad, phid  = me.dynamicsymbols('theta, phi', 1)
+    t = Symbol('t')
+
+    A_frame.orient(N_frame, 'Axis', (theta, N_frame.z))
+    B_frame.orient(A_frame, 'Axis', (phi, A_frame.z))
+
+    O_point = me.Point('O')
+    O_point.set_vel(N_frame, 0)
+
+    O_point = me.Point('O')
+    O_point.set_vel(N_frame, 0)
+
+    Q_point = O_point.locatenew('A', R_length*A_frame.x)
+    P_point = Q_point.locatenew('B', L_length*B_frame.x)
+
+    r = P_point.pos_from(O_point)
+    r_dot = r.diff(t,N_frame).simplify()
+    r_ddot = r_dot.diff(t,N_frame).simplify()
+
+    import pdb
+    #pdb.set_trace()
+    assert latex(r_ddot) == r"-  L \left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{b}_x} + L \left(\ddot{\phi} + \ddot{\theta}\right)\mathbf{\hat{b}_y} -  R \dot{\theta}^{2}\mathbf{\hat{a}_x} + R \ddot{\theta}\mathbf{\hat{a}_y}"
+
+
 def test_latex_UnevaluatedExpr():
     x = symbols("x")
     he = UnevaluatedExpr(1/x)


### PR DESCRIPTION
Fixes #14041 .

If `term` is of class `Pow` then, `_needs_mul_brackets` returns False and no parenthesis were added. So I split `term` in base and power, then added latex form of base(which came with parenthesis) with latex form of power separately.

@moorepants please review!