### PR TITLE
integrals: simplified convergence conditions

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -901,7 +901,7 @@ class periodic_argument(Function):
         unbranched = cls._getunbranched(ar)
         if unbranched is None:
             return None
-        if unbranched.has(periodic_argument, atan2, arg, atan):
+        if unbranched.has(periodic_argument, atan2, atan):
             return None
         if period == oo:
             return unbranched

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -8,7 +8,7 @@ from sympy.integrals.transforms import (mellin_transform,
     InverseLaplaceTransform, InverseFourierTransform,
     InverseSineTransform, InverseCosineTransform, IntegralTransformError)
 from sympy import (
-    gamma, exp, oo, Heaviside, symbols, Symbol, re, factorial, pi,
+    gamma, exp, oo, Heaviside, symbols, Symbol, re, factorial, pi, arg,
     cos, S, Abs, And, Or, sin, sqrt, I, log, tan, hyperexpand, meijerg,
     EulerGamma, erf, erfc, besselj, bessely, besseli, besselk,
     exp_polar, polar_lift, unpolarify, Function, expint, expand_mul,
@@ -771,17 +771,18 @@ def test_issue_8882():
 
 def test_issue_7173():
     from sympy import cse
-    x0, x1, x2 = symbols('x:3')
+    x0, x1, x2, x3 = symbols('x:4')
     ans = laplace_transform(sinh(a*x)*cosh(a*x), x, s)
     r, e = cse(ans)
     assert r == [
         (x0, pi/2),
-        (x1, Abs(periodic_argument(a, oo))),
-        (x2, Abs(periodic_argument(exp_polar(I*pi)*polar_lift(a), oo)))]
+        (x1, arg(a)),
+        (x2, Abs(x1)),
+        (x3, Abs(x1 + pi))]
     assert e == [
         a/(-4*a**2 + s**2),
         0,
-        ((x0 >= x1) | (x1 < x0)) & ((x0 >= x2) | (x2 < x0))]
+        ((x0 >= x2) | (x2 < x0)) & ((x0 >= x3) | (x3 < x0))]
 
 
 def test_issue_8514():

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -957,8 +957,8 @@ def _simplifyconds(expr, s, a):
 @_noconds
 def _laplace_transform(f, t, s_, simplify=True):
     """ The backend function for Laplace transforms. """
-    from sympy import (re, Max, exp, pi, Min, periodic_argument as arg,
-                       cos, Wild, symbols, polar_lift)
+    from sympy import (re, Max, exp, pi, Min, periodic_argument as arg_,
+                       arg, cos, Wild, symbols, polar_lift)
     s = Dummy('s')
     F = integrate(exp(-s*t) * f, (t, 0, oo))
 
@@ -982,27 +982,33 @@ def _laplace_transform(f, t, s_, simplify=True):
         u = Dummy('u', real=True)
         p, q, w1, w2, w3, w4, w5 = symbols(
             'p q w1 w2 w3 w4 w5', cls=Wild, exclude=[s])
+        patterns = (
+            p*abs(arg((s + w3)*q)) < w2,
+            p*abs(arg((s + w3)*q)) <= w2,
+            abs(arg_((s + w3)**p*q, w1)) < w2,
+            abs(arg_((s + w3)**p*q, w1)) <= w2,
+            abs(arg_((polar_lift(s + w3))**p*q, w1)) < w2,
+            abs(arg_((polar_lift(s + w3))**p*q, w1)) <= w2)
         for c in conds:
             a_ = oo
             aux_ = []
             for d in disjuncts(c):
                 if d.is_Relational and s in d.rhs.free_symbols:
                     d = d.reversed
-                m = d.match(abs(arg((s + w3)**p*q, w1)) < w2)
-                if not m:
-                    m = d.match(abs(arg((s + w3)**p*q, w1)) <= w2)
-                if not m:
-                    m = d.match(abs(arg((polar_lift(s + w3))**p*q, w1)) < w2)
-                if not m:
-                    m = d.match(abs(arg((polar_lift(s + w3))**p*q, w1)) <= w2)
+                for pat in patterns:
+                    m = d.match(pat)
+                    if m:
+                        break
                 if m:
                     if m[q].is_positive and m[w2]/m[p] == pi/2:
                         d = re(s + m[w3]) > 0
-                m = d.match(
-                    cos(abs(arg(s**w1*w5, q))*w2)*abs(s**w3)**w4 - p > 0)
+                m = d.match(cos(w1*abs(arg(s*w5))*w2)*abs(s**w3)**w4 - p > 0)
                 if not m:
                     m = d.match(
-                        cos(abs(arg(polar_lift(s)**w1*w5, q))*w2
+                        cos(abs(arg_(s**w1*w5, q))*w2)*abs(s**w3)**w4 - p > 0)
+                if not m:
+                    m = d.match(
+                        cos(abs(arg_(polar_lift(s)**w1*w5, q))*w2
                             )*abs(s**w3)**w4 - p > 0)
                 if m and all(m[wild].is_positive for wild in [w1, w2, w3, w4, w5]):
                     d = re(s) > m[p]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed
Allow `arg` in `periodic_argument`.

`periodic_argument` does currently leave unevaluated all expressions that
contain `periodic_argument`, `atan2`, `arg` or `atan` after simplifications.
Therefore expressions of the following type will often appear in the
 convergence conditions of integrals computed by meijerint.

    >>> unbranched_argument(1/polar_lift(x))
    periodic_argument(1/polar_lift(x), oo)
These expressions will be more readable if `periodic_argument`
is allowed to return values containing `arg`.
    
    >>> unbranched_argument(1/polar_lift(x))
    -arg(x)

#### Other comments
Some conditions are currently simplified in `transforms` and
`meijerint` modules. The pattern tables are extended for `arg`
in order to maintain the simplified output format.
