### PR TITLE
Changed ModularInteger to use fast exponentiation

### DIFF
--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -132,11 +132,11 @@ class ModularInteger(PicklableWithSlots, DomainElement):
             return self.__class__(self.dom.one)
 
         if exp < 0:
-            val, exp = self.invert(), -exp
+            val, exp = self.invert().val, -exp
         else:
             val = self.val
 
-        return self.__class__(pow(int(val), exp, self.mod))
+        return self.__class__(pow(val, exp, self.mod))
 
     def _compare(self, other, op):
         val = self._get_val(other)

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -136,7 +136,15 @@ class ModularInteger(PicklableWithSlots, DomainElement):
         else:
             val = self.val
 
-        return self.__class__(val**exp)
+        m = self.mod
+        r = self.dom.one
+        while exp > 0:
+            if exp % 2:
+                r = (r * val) % m
+            val = (val * val) % m
+            exp //= 2
+
+        return self.__class__(r)
 
     def _compare(self, other, op):
         val = self._get_val(other)

--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -136,15 +136,7 @@ class ModularInteger(PicklableWithSlots, DomainElement):
         else:
             val = self.val
 
-        m = self.mod
-        r = self.dom.one
-        while exp > 0:
-            if exp % 2:
-                r = (r * val) % m
-            val = (val * val) % m
-            exp //= 2
-
-        return self.__class__(r)
+        return self.__class__(pow(int(val), exp, self.mod))
 
     def _compare(self, other, op):
         val = self._get_val(other)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -675,6 +675,13 @@ def test_ModularInteger():
     a = F3(2)**2
     assert isinstance(a, F3.dtype) and a == 1
 
+    F7 = FF(7)
+
+    a = F7(3)**100000000000
+    assert isinstance(a, F7.dtype) and a == 4
+    a = F7(3)**-100000000000
+    assert isinstance(a, F7.dtype) and a == 2
+
     assert bool(F3(3)) is False
     assert bool(F3(4)) is True
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #8202

#### Brief description of what is fixed or changed
Changed the ModularInteger pow method to use fast exponentiation
instead of the usual python exponentiation operator. This is a speed-up
since the intermittent results never exceed mod.