### PR TITLE
pprint : changed instance type inside `_print_DiracDelta` function

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1309,8 +1309,8 @@ class PrettyPrinter(Printer):
                 c = self._print(e.args[0])
                 c = prettyForm(*c.parens())
                 pform = a**b
-                pform = stringPict(*pform.right(' '))
-                pform = stringPict(*pform.right(c))
+                pform = prettyForm(*pform.right(' '))
+                pform = prettyForm(*pform.right(c))
                 return pform
             pform = self._print(e.args[0])
             pform = prettyForm(*pform.parens())

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4870,6 +4870,11 @@ u("""\
  (1)    \n\
 δ    (x)\
 """)
+    assert xpretty(x*DiracDelta(x, 1), use_unicode=True) == \
+u("""\
+   (1)    \n\
+x⋅δ    (x)\
+""")
 
 
 def test_hyper():


### PR DESCRIPTION
Fixes #14101

`prettyForm` is a subclass of `stringPict`. But whenever derivative of Diracdelta was passed as an argument in `pprint`, `_print_DiracDelta` returned a `stringPict` instance, which caused the error inside `prettyForm.__mul__`.
