### PR TITLE
Sum(sin(n), (n, 1, oo)).is_convergent() now returns S.false

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -8,6 +8,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Wild, Symbol
 from sympy.core.add import Add
 from sympy.calculus.singularities import is_decreasing
+from sympy.calculus.util import AccumulationBounds
 from sympy.concrete.gosper import gosper_sum
 from sympy.functions.special.zeta_functions import zeta
 from sympy.functions.elementary.piecewise import Piecewise
@@ -416,6 +417,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         try:
             lim_val = limit(sequence_term, sym, upper_limit)
             if lim_val.is_number and lim_val is not S.Zero:
+                return S.false
+            if isinstance(lim_val, AccumulationBounds):
                 return S.false
         except NotImplementedError:
             pass

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1010,3 +1010,6 @@ def test_issue_10156():
     e = 2*y*Sum(2*cx*x**2, (x, 1, 9))
     assert e.factor() == \
         8*y**3*Sum(x, (x, 1, 3))*Sum(x**2, (x, 1, 9))
+
+def test_issue_14103():
+    assert Sum(sin(n), (n, 1, oo)).is_convergent() is S.false


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14103 

#### Brief description of what is fixed or changed

`Sum(sin(n), (n, 1, oo)).is_convergent()` now returns `S.false`.
The limit of `sin(n)` for `n` tending to infinity is not zero and so the series
is not convergent.
In such situation, the limit of `sin(n)` returns an `AccumulationBounds`.
Thus a check for `AccumulationBounds` was added.

#### Other comments

A test for the issue is added.
