### PR TITLE
Add conjugate to mathematica printing

### DIFF
--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -30,6 +30,7 @@ known_functions = {
     "acoth": [(lambda x: True, "ArcCoth")],
     "asech": [(lambda x: True, "ArcSech")],
     "acsch": [(lambda x: True, "ArcCsch")],
+    "conjugate": [(lambda x: True, "Conjugate")],
 
 }
 

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -2,7 +2,7 @@ from sympy.core import (S, pi, oo, symbols, Function,
                         Rational, Integer, Tuple, Derivative)
 from sympy.integrals import Integral
 from sympy.concrete import Sum
-from sympy.functions import exp, sin, cos
+from sympy.functions import exp, sin, cos, conjugate
 
 from sympy import mathematica_code as mcode
 
@@ -27,6 +27,7 @@ def test_Rational():
 def test_Function():
     assert mcode(f(x, y, z)) == "f[x, y, z]"
     assert mcode(sin(x) ** cos(x)) == "Sin[x]^Cos[x]"
+    assert mcode(conjugate(x)) == "Conjugate[x]"
 
 
 def test_Pow():


### PR DESCRIPTION
mathematica_code does not print the correct mathematica conjugate function. Therefore I added conjugate to known functions.