### PR TITLE
Convert trig products/powers to sums when integration requires

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -26,6 +26,7 @@ from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.series import limit
 from sympy.series.order import Order
 from sympy.series.formal import FormalPowerSeries
+from sympy.simplify.fu import sincos_to_sum
 
 
 class Integral(AddWithLimits):
@@ -1005,7 +1006,7 @@ class Integral(AddWithLimits):
             # collection on the expressions if they are already
             # in an expanded form
             if not h and len(args) == 1:
-                f = f.expand(mul=True, deep=False)
+                f = sincos_to_sum(f).expand(mul=True, deep=False)
                 if f.is_Add:
                     # Note: risch will be identical on the expanded
                     # expression, but maybe it will be able to pick out parts,

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -36,12 +36,14 @@ from sympy.core.compatibility import range
 from sympy.core.cache import cacheit
 from sympy.core.symbol import Dummy, Wild
 from sympy.simplify import hyperexpand, powdenest, collect
+from sympy.simplify.fu import sincos_to_sum
 from sympy.logic.boolalg import And, Or, BooleanAtom
 from sympy.functions.special.delta_functions import Heaviside
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
 from sympy.functions.elementary.hyperbolic import \
     _rewrite_hyperbolics_as_exp, HyperbolicFunction
+from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.functions.special.hyper import meijerg
 from sympy.utilities.iterables import multiset_partitions, ordered
 from sympy.utilities.misc import debug as _debug
@@ -1879,6 +1881,12 @@ def _guess_expansion(f, x):
         if expanded not in saw:
             res += [(expanded, 'expand_trig, expand_mul')]
             saw.add(expanded)
+
+    if orig.has(cos, sin):
+        reduced = sincos_to_sum(orig)
+        if reduced not in saw:
+            res += [(reduced, 'trig power reduction')]
+            saw.add(reduced)
 
     return res
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1223,6 +1223,10 @@ def test_issue_8901():
     assert integrate(tanh(1.0*x)) == 1.0*x - 1.0*log(tanh(1.0*x) + 1)
     assert integrate(tanh(x)) == x - log(tanh(x) + 1)
 
+def test_issue_8945():
+    assert integrate(sin(x)**3/x, (x, 0, 1)) == -Si(3)/4 + 3*Si(1)/4
+    assert integrate(sin(x)**3/x, (x, 0, oo)) == pi/4
+    assert integrate(cos(x)**2/x**2, x) == -Si(2*x) - cos(2*x)/(2*x) - 1/(2*x)
 
 @slow
 def test_issue_7130():

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -2204,4 +2204,7 @@ def sincos_to_sum(expr):
     7*sin(x) - 5*sin(3*x) + 3*sin(5*x) - sin(7*x)
     """
 
-    return TR8(expand_mul(TRpower(expr)))
+    if not expr.has(cos, sin):
+        return expr
+    else:
+        return TR8(expand_mul(TRpower(expr)))

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -196,6 +196,7 @@ from sympy.functions.elementary.trigonometric import (
     cos, sin, tan, cot, sec, csc, sqrt, TrigonometricFunction)
 from sympy.functions.elementary.hyperbolic import (
     cosh, sinh, tanh, coth, sech, csch, HyperbolicFunction)
+from sympy.functions.combinatorial.factorials import binomial
 from sympy.core.compatibility import ordered, range
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
@@ -1581,6 +1582,52 @@ def TR22(rv, max=4, pow=False):
     return bottom_up(rv, f)
 
 
+def TRpower(rv):
+    """Convert sin(x)**n and cos(x)**n with positive n to sums.
+
+    Examples
+    ========
+
+    >>> from sympy.simplify.fu import TRpower
+    >>> from sympy.abc import x
+    >>> from sympy import cos, sin
+    >>> TRpower(sin(x)**6)
+    -15*cos(2*x)/32 + 3*cos(4*x)/16 - cos(6*x)/32 + 5/16
+    >>> TRpower(sin(x)**3*cos(2*x)**4)
+    (3*sin(x)/4 - sin(3*x)/4)*(cos(4*x)/2 + cos(8*x)/8 + 3/8)
+
+    References
+    ==========
+
+    https://en.wikipedia.org/wiki/List_of_trigonometric_identities#Power-reduction_formulae
+
+    """
+
+    def f(rv):
+        if not (isinstance(rv, Pow) and isinstance(rv.base, (sin, cos))):
+            return rv
+        b, n = rv.as_base_exp()
+        x = b.args[0]
+        if n.is_Integer and n.is_positive:
+            if n.is_odd and isinstance(b, cos):
+                rv = 2**(1-n)*Add(*[binomial(n, k)*cos((n - 2*k)*x)
+                    for k in range((n + 1)/2)])
+            elif n.is_odd and isinstance(b, sin):
+                rv = 2**(1-n)*(-1)**((n-1)/2)*Add(*[binomial(n, k)*
+                    (-1)**k*sin((n - 2*k)*x) for k in range((n + 1)/2)])
+            elif n.is_even and isinstance(b, cos):
+                rv = 2**(1-n)*Add(*[binomial(n, k)*cos((n - 2*k)*x)
+                    for k in range(n/2)])
+            elif n.is_even and isinstance(b, sin):
+                rv = 2**(1-n)*(-1)**(n/2)*Add(*[binomial(n, k)*
+                    (-1)**k*cos((n - 2*k)*x) for k in range(n/2)])
+            if n.is_even:
+                rv += 2**(-n)*binomial(n, n/2)
+        return rv
+
+    return bottom_up(rv, f)
+
+
 def L(rv):
     """Return count of trigonometric functions in expression.
 
@@ -2139,3 +2186,22 @@ def hyper_as_trig(rv):
 
     return _osborne(masked, d), lambda x: collect(signsimp(
         _osbornei(x, d).xreplace(dict(reps))), S.ImaginaryUnit)
+
+
+def sincos_to_sum(expr):
+    """Convert products and powers of sin and cos to sums.
+
+    Applied power reduction TRpower first, then expands products, and
+    converts products to sums with TR8.
+
+    Examples
+    ========
+
+    >>> from sympy.simplify.fu import sincos_to_sum
+    >>> from sympy.abc import x
+    >>> from sympy import cos, sin
+    >>> sincos_to_sum(16*sin(x)**3*cos(2*x)**2)
+    7*sin(x) - 5*sin(3*x) + 3*sin(5*x) - sin(7*x)
+    """
+
+    return TR8(expand_mul(TRpower(expr)))

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -4,7 +4,7 @@ from sympy import (
 from sympy.simplify.fu import (
     L, TR1, TR10, TR10i, TR11, TR12, TR12i, TR13, TR14, TR15, TR16,
     TR111, TR2, TR2i, TR3, TR5, TR6, TR7, TR8, TR9, TRmorrie, _TR56 as T,
-    hyper_as_trig, fu, process_common_addends, trig_split,
+    TRpower, hyper_as_trig, fu, process_common_addends, trig_split,
     as_f_sign_1)
 from sympy.utilities.randtest import verify_numerically
 from sympy.core.compatibility import range
@@ -333,6 +333,15 @@ def test_TRmorrie():
     assert TR8(TRmorrie(e)) == -S(1)/8
     e = Mul(*[cos(2**i*pi/17) for i in range(1, 17)])
     assert TR8(TR3(TRmorrie(e))) == S(1)/65536
+
+
+def test_TRpower():
+    assert TRpower(1/sin(x)**2) == 1/sin(x)**2
+    assert TRpower(cos(x)**3*sin(x/2)**4) == \
+        (3*cos(x)/4 + cos(3*x)/4)*(-cos(x)/2 + cos(2*x)/8 + S(3)/8)
+    for k in range(2, 8):
+        assert verify_numerically(sin(x)**k, TRpower(sin(x)**k))
+        assert verify_numerically(cos(x)**k, TRpower(cos(x)**k))
 
 
 def test_hyper_as_trig():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #8945

#### Brief description of what is fixed or changed

At a final stage of integration, if all methods failed so far, the expression is currently turned into an Add with `expand`. This PR amplifies this transformation to Add by also converting products/powers of sin and cos to their sums. For example, `sin(x)**3/x` and `cos(x)**4/x**3` are now integrated, while they return unevaluated in current master.

#### Other comments

To this end, two methods are added to simplify.fu: TRpower, which implements power reduction formulas, and `sincos_to_sum`, which applies TRpower followed by expand_mul followed by TR8 (products to sums).

Additionally, a `sincos_to_sum` rewrite is added to the list of rewrites that `meijerint_definite` attempts for integrals over (0, oo).
 