### PR TITLE
cse : added condition for Tuples containing matrices

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -685,7 +685,9 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
 
     # Handle the case if just one expression was passed.
     if isinstance(exprs, (Basic, MatrixBase)):
-        exprs = [exprs]
+        if not(isinstance(exprs, Tuple) and  (any(isinstance(n, (Matrix, ImmutableMatrix,
+            SparseMatrix, ImmutableSparseMatrix)) for n in exprs))):
+              exprs = [exprs]
 
     copy = exprs
     temp = []

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -2,7 +2,7 @@
 """
 from __future__ import print_function, division
 
-from sympy.core import Basic, Mul, Add, Pow, sympify, Symbol
+from sympy.core import Expr, Basic, Mul, Add, Pow, sympify, Symbol
 from sympy.core.containers import Tuple, OrderedSet
 from sympy.core.singleton import S
 from sympy.core.function import _coeff_isneg
@@ -14,7 +14,7 @@ from sympy.utilities.iterables import filter_symbols, \
 from . import cse_opts
 
 # (preprocessor, postprocessor) pairs which are commonly useful. They should
-# each take a sympy expression and return a possibly transformed expression.
+# each take a SymPy expression and return a possibly transformed expression.
 # When used in the function ``cse()``, the target expressions will be transformed
 # by each of the preprocessor functions in order. After the common
 # subexpressions are eliminated, each resulting expression will have the
@@ -97,14 +97,14 @@ def preprocess_for_cse(expr, optimizations):
 
     Parameters
     ----------
-    expr : sympy expression
+    expr : SymPy expression
         The target expression to optimize.
     optimizations : list of (callable, callable) pairs
         The (preprocessor, postprocessor) pairs.
 
     Returns
     -------
-    expr : sympy expression
+    expr : SymPy expression
         The transformed expression.
     """
     for pre, post in optimizations:
@@ -115,11 +115,11 @@ def preprocess_for_cse(expr, optimizations):
 
 def postprocess_for_cse(expr, optimizations):
     """ Postprocess an expression after common subexpression elimination to
-    return the expression to canonical sympy form.
+    return the expression to canonical SymPy form.
 
     Parameters
     ----------
-    expr : sympy expression
+    expr : SymPy expression
         The target expression to transform.
     optimizations : list of (callable, callable) pairs, optional
         The (preprocessor, postprocessor) pairs.  The postprocessors will be
@@ -128,7 +128,7 @@ def postprocess_for_cse(expr, optimizations):
 
     Returns
     -------
-    expr : sympy expression
+    expr : SymPy expression
         The transformed expression.
     """
     for pre, post in reversed(optimizations):
@@ -375,7 +375,7 @@ def opt_cse(exprs, order='canonical'):
 
     Parameters
     ----------
-    exprs : list of sympy expressions
+    exprs : list of SymPy expressions
         The expressions to optimize.
     order : string, 'none' or 'canonical'
         The order by which Mul and Add arguments are processed. For large
@@ -471,7 +471,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
     Parameters
     ==========
 
-    exprs : list of sympy expressions
+    exprs : list of SymPy expressions
         The expressions to reduce.
     symbols : infinite iterator yielding unique Symbols
         The symbols used to label the common subexpressions which are pulled
@@ -613,7 +613,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     Parameters
     ==========
 
-    exprs : list of sympy expressions, or a single sympy expression
+    exprs : list of SymPy expressions, or a single SymPy expression
         The expressions to reduce.
     symbols : infinite iterator yielding unique Symbols
         The symbols used to label the common subexpressions which are pulled
@@ -646,7 +646,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
         All of the common subexpressions that were replaced. Subexpressions
         earlier in this list might show up in subexpressions later in this
         list.
-    reduced_exprs : list of sympy expressions
+    reduced_exprs : list of SymPy expressions
         The reduced expressions with all of the replacements above.
 
     Examples
@@ -665,7 +665,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     List of expressions with recursive substitutions:
 
     >>> m = SparseMatrix([x + y, x + y + z])
-    >>> cse([(x+y)**2, x + y + z, y + z, x + z + y, m])
+    >>> cse([(x + y)**2, x + y + z, y + z, x + z + y, m])
     ([(x0, x + y), (x1, x0 + z)], [x0**2, x1, y + z, x1, Matrix([
     [x0],
     [x1]])])
@@ -683,11 +683,15 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
                                 SparseMatrix, ImmutableSparseMatrix)
 
-    # Handle the case if just one expression was passed.
-    if isinstance(exprs, (Basic, MatrixBase)):
-        if not(isinstance(exprs, Tuple) and  (any(isinstance(n, (Matrix, ImmutableMatrix,
-            SparseMatrix, ImmutableSparseMatrix)) for n in exprs))):
-              exprs = [exprs]
+    # sanitize input
+    if isinstance(exprs, (Expr, MatrixBase)):
+        exprs = [exprs]
+    elif iterable(exprs):
+        exprs = list(exprs)
+        if any((iterable(e) and not isinstance(e, MatrixBase)) for e in exprs):
+            raise TypeError('Only expression iterations allowed')
+    else:
+        raise TypeError('unrecognized input')
 
     copy = exprs
     temp = []

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -526,3 +526,13 @@ def test_issue_13000():
 def test_unevaluated_mul():
     eq = Mul(x + y, x + y, evaluate=False)
     assert cse(eq) == ([(x0, x + y)], [x0**2])
+
+
+def test_issue():
+    x, y = symbols('x,y')
+    m1, m2 = Matrix([[x, sin(y)],[3, 4]]), Matrix([[sin(y), 2*sin(y)], [sin(y)**2, 7]])
+    assert cse(Tuple(m1, m2)) == ([(x0, sin(y))], [Matrix([
+                                [x, x0],
+                                [3,  4]]), Matrix([
+                                [   x0, 2*x0],
+                                [x0**2,    7]])])

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -288,8 +288,8 @@ def test_issue_4499():
         [(x0, 2*a), (x1, -b), (x2, x0 + x1), (x3, x2 + 1), (x4, sqrt(z)), (x5,
         B(b - 1, x4)), (x6, -x0), (x7, (x4/2)**(x6 + 1)*G(b)*G(x3)), (x8,
         x7*B(x2, x4)), (x9, B(b, x4)), (x10, x7*B(x3, x4))],
-        [(a, a + 1/2, x0, b, x3, x5*x8, x4*x8*x9, x10*x4*x5, x10*x9,
-        1, 0, 1/2, z/2, x1 + 1, b + x6, x6)])
+        [a, a + 1/2, x0, b, x3, x5*x8, x4*x8*x9, x10*x4*x5, x10*x9,
+        1, 0, 1/2, z/2, x1 + 1, b + x6, x6])
     assert ans == c
 
 
@@ -528,7 +528,7 @@ def test_unevaluated_mul():
     assert cse(eq) == ([(x0, x + y)], [x0**2])
 
 
-def test_issue():
+def test_issue_14118():
     x, y = symbols('x,y')
     m1, m2 = Matrix([[x, sin(y)],[3, 4]]), Matrix([[sin(y), 2*sin(y)], [sin(y)**2, 7]])
     assert cse(Tuple(m1, m2)) == ([(x0, sin(y))], [Matrix([


### PR DESCRIPTION
Fixes #14118

Whenever any `Matrix` is passed inside `cse`, it gets flattened [here](https://github.com/sympy/sympy/blob/53bf458a0a03d7d9611c8850afaf5803e6d0ce63/sympy/simplify/cse_main.py#L692). But [this](https://github.com/sympy/sympy/blob/53bf458a0a03d7d9611c8850afaf5803e6d0ce63/sympy/simplify/cse_main.py#L688) converted the `Tuple`(a `basic` class instance) into a list containing those tuples. So iterating object inside the loop was a `Tuple` indeed rather than matrices. Hence they never entered into the condition which flattened matrices.

I just added a check to avoid that (also there is no need to convert those Tuple instances into a list as `tree_cse` can take them as an argument as it is).
