### PR TITLE
drv_types: Updated poisson sampling and added internal cdf 

### DIFF
--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -1,10 +1,13 @@
 from __future__ import print_function, division
 
 from sympy.stats.drv import SingleDiscreteDistribution, SingleDiscretePSpace
-from sympy import factorial, exp, S, sympify
+from sympy import factorial, exp, S, sympify, floor, sqrt, log, uppergamma, sign
 from sympy.stats.rv import _value_check
 from sympy.sets.sets import Interval
+from mpmath import pi
 import random
+
+
 
 __all__ = ['Geometric', 'Poisson']
 
@@ -28,12 +31,70 @@ class PoissonDistribution(SingleDiscreteDistribution):
     def pdf(self, k):
         return self.lamda**k / factorial(k) * exp(-self.lamda)
 
+    #def _cdf(self, k):
+        #return uppergamma(floor(k+1), self.lamda) / factorial(floor(k))
+
     def sample(self):
-        u = random.uniform(0, 1)
-        inf = self.set.inf
-        while u > self.cdf(inf):
-            inf += 1
-        return inf
+        if self.lamda < 30:
+            """
+            Poisson Random Variate Generation
+            C. D. Kemp and Adrienne W. Kemp
+            Journal of the Royal Statistical Society. Series C (Applied Statistics)
+            Vol. 40, No. 1 (1991), pp. 143-158
+            Simple sequential search (Algorithm 3 in the above paper) - O(lamda) so only for use in low lamda cases
+            """
+            p_0 = exp(-self.lamda)
+            p = p_0
+            F = p
+            x = 0
+            u = random.uniform(0,1)
+            while True:
+                if u > F:
+                    x = x+1
+                    p = self.lamda*p/x
+                    F = F + p
+                else:
+                    return x
+        else:
+            """
+            https://pdfs.semanticscholar.org/00f1/8468dd53e4e3f0c28a5d504f8cd10376a673.pdf
+            Algorithm implements PTRD described in the above paper
+            """
+            log_factorial_dict = {}
+            for k in range(10):
+                log_factorial_dict[k]=log(factorial(k))
+            smu = sqrt(self.lamda)
+            b = 0.931 + 2.53*smu
+            a = -0.059 + 0.02483*b
+            alpha = 1.1239 + 1.1328 / (b - 3.4) #alpha here is defined as 1/alpha in the paper
+            v_r = 0.9277 - 3.6224 / (b - 2)
+            while True:
+                V = random.uniform(0, 1)
+                if V <= 0.86 * v_r:
+                    U = V / v_r - 0.43
+                    return floor((2 * a/ (0.5 - abs(U)) + b) * U + self.lamda + 0.445)
+                elif V >= v_r:
+                    U = random.uniform(-0.5, 0.5)
+                else:
+                    U = V / v_r - 0.93
+                    U = sign(U) * 0.5 - U
+                    V = random.uniform(0, v_r)
+
+                us = 0.5 - abs(U)
+                if us < 0.013 and V > us:
+                    break
+
+                k = floor((2 * a / us + b) * U + self.lamda + 0.445)
+                V = V * alpha / (a / us**2 + b)
+
+                if k >= 10 and log(V * smu) <= (k + 0.5) * log(self.lamda / k) - self.lamda - log(sqrt(2 * pi)) + k -(1/12 - 1/(360 * k**2)) / k:
+                    return k
+                elif k>= 0 and k <= 9 and log(V) <= k * log(self.lamda) - self.lamda - log_factorial_dict[k]:
+                    return k
+                else:
+                    continue
+
+
 
 
 def Poisson(name, lamda):

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -7,8 +7,6 @@ from sympy.sets.sets import Interval
 from mpmath import pi
 import random
 
-
-
 __all__ = ['Geometric', 'Poisson']
 
 
@@ -93,9 +91,6 @@ class PoissonDistribution(SingleDiscreteDistribution):
                     return k
                 else:
                     continue
-
-
-
 
 def Poisson(name, lamda):
     r"""

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -29,8 +29,8 @@ class PoissonDistribution(SingleDiscreteDistribution):
     def pdf(self, k):
         return self.lamda**k / factorial(k) * exp(-self.lamda)
 
-    #def _cdf(self, k):
-        #return uppergamma(floor(k+1), self.lamda) / factorial(floor(k))
+    def _cdf(self, k):
+        return uppergamma(floor(k+1), self.lamda) / factorial(floor(k))
 
     def sample(self):
         if self.lamda < 30:


### PR DESCRIPTION
The poisson sampling is split for high and low lambda. Low lambda are handled by a simple sequential search. High lambda are found using a hybrid rejection-inversion method which tends to a constant iteration limit for high lambda samples. An internal cdf for the poisson distribution has also been added.

Example:
In[1] from sympy.stats import *
In[2] import time
In[3] start_time = time.time()
         val = sample(Poisson('X',10000))
         print('val =',val,"--- %s seconds ---" % (time.time() - start_time))

Out[3] val = 9990 --- 0.004064083099365234 seconds ---

A sample of lambda equal to 1000, an order of magnitude smaller, took over 84 seconds using the previous algorithm.