### PR TITLE
Missing equality condition in p-series test

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -434,14 +434,14 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         if p1_series_test is not None:
             if p1_series_test[p] < -1:
                 return S.true
-            if p1_series_test[p] > -1:
+            if p1_series_test[p] >= -1:
                 return S.false
 
         p2_series_test = order.expr.match((1/sym)**p)
         if p2_series_test is not None:
             if p2_series_test[p] > 1:
                 return S.true
-            if p2_series_test[p] < 1:
+            if p2_series_test[p] <= 1:
                 return S.false
 
         ### ----------- root test ---------------- ###

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -934,6 +934,7 @@ def test_is_convergent():
     assert Sum(1/(n**2 + 1), (n, 1, oo)).is_convergent() is S.true
     assert Sum(1/n**(S(6)/5), (n, 1, oo)).is_convergent() is S.true
     assert Sum(2/(n*sqrt(n - 1)), (n, 2, oo)).is_convergent() is S.true
+    assert Sum(1/(sqrt(n)*sqrt(n)), (n, 2, oo)).is_convergent() is S.false
 
     # comparison test --
     assert Sum(1/(n + log(n)), (n, 1, oo)).is_convergent() is S.false


### PR DESCRIPTION
Condition for equality missing

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
None

#### Brief description of what is fixed or changed
The `p-series convergence test` was not defined in sympy at `equality`, however it is.(check [here)](https://en.wikipedia.org/wiki/Harmonic_series_(mathematics)#P-series) 

#### Other comments
None
