### PR TITLE
Unpolarify the hypergeometric function pFq with p == q+1 in the unit disk

### DIFF
--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -10,7 +10,7 @@ from sympy.core.mul import Mul
 from sympy.core.symbol import Dummy
 
 from sympy.functions import (sqrt, exp, log, sin, cos, asin, atan,
-        sinh, cosh, asinh, acosh, atanh, acoth)
+        sinh, cosh, asinh, acosh, atanh, acoth, Abs)
 
 class TupleArg(Tuple):
     def limit(self, x, xlim, dir='+'):
@@ -184,7 +184,7 @@ class hyper(TupleParametersBase):
     @classmethod
     def eval(cls, ap, bq, z):
         from sympy import unpolarify
-        if len(ap) <= len(bq):
+        if len(ap) <= len(bq) or (len(ap) == len(bq) + 1 and (Abs(z) <= 1) == True):
             nz = unpolarify(z)
             if z != nz:
                 return hyper(ap, bq, nz)

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -211,6 +211,7 @@ def test_hyper_unpolarify():
     assert hyper([0], [], a).argument == a
     assert hyper([0], [0], a).argument == b
     assert hyper([0, 1], [0], a).argument == a
+    assert hyper([0, 1], [0], exp_polar(2*pi*I)).argument == 1
 
 
 @slow

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1309,3 +1309,7 @@ def test_issue_14096():
     assert integrate(1/(x + y)**2, (x, 0, 1)) == -1/(y + 1) + 1/y
     assert integrate(1/(1 + x + y + z)**2, (x, 0, 1), (y, 0, 1), (z, 0, 1)) == \
         -4*log(4) - 6*log(2) + 9*log(3)
+
+def test_issue_14144():
+    assert Abs(integrate(1/sqrt(1 - x**3), (x, 0, 1)).n() - 1.402182) < 1e-6
+    assert Abs(integrate(sqrt(1 - x**3), (x, 0, 1)).n() - 0.841309) < 1e-6


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14144 

#### Brief description of what is fixed or changed

Currently the argument of pFq is unpolarified if p <= q, when the function is entire. However, when p == q+1 we still have a convergent power series in the unit disk, and the results of SymPy computations refer to the branch determined by this power series. Hence, the argument can be unpolarified in this case, provided it is <=1 in absolute value.
