### PR TITLE
Implemented Sum((-1)**n/sqrt(n), (n, 1, oo)).is_absolutely_convergent()

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -401,6 +401,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             lower_limit = -upper_limit
             upper_limit = S.Infinity
 
+        sym_ = Dummy(sym.name, integer=True, positive=True)
+        sequence_term = sequence_term.xreplace({sym: sym_})
+        sym = sym_
+
         interval = Interval(lower_limit, upper_limit)
 
         # Piecewise function handle
@@ -526,6 +530,8 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                 if dirich2 is not None:
                     return dirich2
 
+        _sym = self.limits[0][0]
+        sequence_term = sequence_term.xreplace({sym: _sym})
         raise NotImplementedError("The algorithm to find the Sum convergence of %s "
                                   "is not yet implemented" % (sequence_term))
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -433,6 +433,15 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         order = O(sequence_term, (sym, S.Infinity))
 
+        ### ----------- ratio test ---------------- ###
+        next_sequence_term = sequence_term.xreplace({sym: sym + 1})
+        ratio = simplify(next_sequence_term/sequence_term)
+        lim_ratio = limit(ratio, sym, upper_limit)
+        if (lim_ratio) > 1:
+            return S.false
+        if (lim_ratio) < 1:
+            return S.true
+
         ### --------- p-series test (1/n**p) ---------- ###
         p1_series_test = order.expr.match(sym**p)
         if p1_series_test is not None:

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -439,9 +439,9 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         next_sequence_term = sequence_term.xreplace({sym: sym + 1})
         ratio = combsimp(powsimp(next_sequence_term/sequence_term))
         lim_ratio = limit(ratio, sym, upper_limit)
-        if (lim_ratio) > 1:
+        if abs((lim_ratio)) > 1:
             return S.false
-        if (lim_ratio) < 1:
+        if abs((lim_ratio)) < 1:
             return S.true
 
         ### --------- p-series test (1/n**p) ---------- ###

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -439,9 +439,9 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         next_sequence_term = sequence_term.xreplace({sym: sym + 1})
         ratio = combsimp(powsimp(next_sequence_term/sequence_term))
         lim_ratio = limit(ratio, sym, upper_limit)
-        if abs((lim_ratio)) > 1:
+        if abs(lim_ratio) > 1:
             return S.false
-        if abs((lim_ratio)) < 1:
+        if abs(lim_ratio) < 1:
             return S.true
 
         ### --------- p-series test (1/n**p) ---------- ###

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -16,6 +16,8 @@ from sympy.polys import apart, PolynomialError
 from sympy.series.limits import limit
 from sympy.series.order import O
 from sympy.sets.sets import FiniteSet
+from sympy.simplify.combsimp import combsimp
+from sympy.simplify.powsimp import powsimp
 from sympy.solvers import solve
 from sympy.solvers.solveset import solveset
 from sympy.core.compatibility import range
@@ -435,7 +437,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         ### ----------- ratio test ---------------- ###
         next_sequence_term = sequence_term.xreplace({sym: sym + 1})
-        ratio = simplify(next_sequence_term/sequence_term)
+        ratio = combsimp(powsimp(next_sequence_term/sequence_term))
         lim_ratio = limit(ratio, sym, upper_limit)
         if (lim_ratio) > 1:
             return S.false

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1014,3 +1014,4 @@ def test_issue_10156():
 def test_issue_14112():
     assert Sum((-1)**n/sqrt(n), (n, 1, oo)).is_absolutely_convergent() is S.false
     assert Sum((-1)**(2*n)/n, (n, 1, oo)).is_convergent() is S.false
+    assert Sum((-2)**n + (-3)**n, (n, 1, oo)).is_convergent() is S.false

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1010,3 +1010,7 @@ def test_issue_10156():
     e = 2*y*Sum(2*cx*x**2, (x, 1, 9))
     assert e.factor() == \
         8*y**3*Sum(x, (x, 1, 3))*Sum(x**2, (x, 1, 9))
+
+
+def test_issue_14112():
+    assert Sum((-1)**n/sqrt(n), (n, 1, oo)).is_absolutely_convergent() is S.false

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1013,3 +1013,4 @@ def test_issue_10156():
 
 def test_issue_14112():
     assert Sum((-1)**n/sqrt(n), (n, 1, oo)).is_absolutely_convergent() is S.false
+    assert Sum((-1)**(2*n)/n, (n, 1, oo)).is_convergent() is S.false

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -936,7 +936,6 @@ def test_is_convergent():
 
     # root test --
     assert Sum((-12)**n/n, (n, 1, oo)).is_convergent() is S.false
-    assert Sum(2**n/factorial(n), (n, 1, oo)).is_convergent() is S.true
 
     # integral test --
 


### PR DESCRIPTION
Fixes #14112 .
Fixes #14152 .

This PR also introduces a new convergence test -- the **Ratio Test**. Actually, when I followed normalhuman's comment on the issue, I solved the particular issue, but I had another problem -

```
>>> from sympy import *
>>> n = symbols('n')
>>> a = Sum(factorial(n)/5**n, (n, 1, oo))
>>> a.is_convergent()
NotImplementedError : The algorithm to find the Sum convergence of 5**(-_n)*factorial(_n))**(1/_n) is not yet implemented.
```
While looking through the file, I then came to realize that the algorithm of **Ratio Test** hadn't been implemented, which can solve this problem easily. So, the code snippet of the Ratio_test algorithm has been implemented, and the issue fixed.

Test case has also been added.