### PR TITLE
assert_error_message function added

### DIFF
--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -5,7 +5,6 @@ from __future__ import print_function, division
 import sys
 import functools
 import os
-import re
 
 from sympy.core.compatibility import get_function_name
 
@@ -112,21 +111,23 @@ if not USE_PYTEST:
         AssertionError: DID NOT RAISE
 
         """
+        import re
+
         if code is None:
             return RaisesContext(expectedException)
         elif callable(code):
             try:
                 code()
             except expectedException as message:
-                message = message.args[0]
-                found = re.search(err_msg, message, re.M|re.I)
+                message = str(message)
+                found = err_msg.search(message)
                 if found:
                     return
                 else:
                     raise AssertionError("DID NOT RAISE")
         else:
             raise TypeError(
-                'assert_raise_message() expects a callable for the 2nd argument.')
+                'assert_raise_message() expects a callable for the 3rd argument.')
 
     class RaisesContext(object):
         def __init__(self, expectedException):

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -120,6 +120,7 @@ if not USE_PYTEST:
                 code()
             except expectedException as message:
                 message = str(message)
+                err_msg = re.compile(err_msg, re.IGNORECASE)
                 found = err_msg.search(message)
                 if found:
                     return

--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -64,6 +64,18 @@ def test_second_argument_should_be_callable_or_string():
 
 
 def test_assert_raise_message():
-    assert_raise_message(ZeroDivisionError, 'integer division or modulo by zero', lambda: 1/0) # error message: 'integer division or modulo by zero'
-    assert_raise_message(ZeroDivisionError, 'zero', lambda: 1/0)
-    raises(AssertionError, lambda: assert_raise_message(ZeroDivisionError, 'one', lambda: 1/0))
+    import re
+
+    message1 = re.compile(r"division by zero", re.IGNORECASE)
+    message2 = re.compile(r"zero", re.IGNORECASE)
+    message3 = re.compile(r"one", re.IGNORECASE)
+    message4 = re.compile(r"some error message", re.IGNORECASE)
+
+    assert_raise_message(ZeroDivisionError, message1, lambda: 1/0) # error message: 'division by zero'
+    assert_raise_message(ZeroDivisionError, message2, lambda: 1/0)
+
+    raises(AssertionError, lambda: assert_raise_message(ZeroDivisionError, message3, lambda: 1/0))
+
+    #with assert_raise_message(ValueError, message4) as exc_wrapper:
+    #    raise ValueError("some error message")
+    #assert isinstance(exc_wrapper, ValueError)

--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -64,18 +64,13 @@ def test_second_argument_should_be_callable_or_string():
 
 
 def test_assert_raise_message():
-    import re
 
-    message1 = re.compile(r"division by zero", re.IGNORECASE)
-    message2 = re.compile(r"zero", re.IGNORECASE)
-    message3 = re.compile(r"one", re.IGNORECASE)
-    message4 = re.compile(r"some error message", re.IGNORECASE)
+    message1 = "division by zero"
+    message2 = "zero"
+    message3 = "one"
+    message4 = "some error message"
 
     assert_raise_message(ZeroDivisionError, message1, lambda: 1/0) # error message: 'division by zero'
     assert_raise_message(ZeroDivisionError, message2, lambda: 1/0)
 
     raises(AssertionError, lambda: assert_raise_message(ZeroDivisionError, message3, lambda: 1/0))
-
-    #with assert_raise_message(ValueError, message4) as exc_wrapper:
-    #    raise ValueError("some error message")
-    #assert isinstance(exc_wrapper, ValueError)

--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -1,4 +1,4 @@
-from sympy.utilities.pytest import raises, USE_PYTEST
+from sympy.utilities.pytest import raises, USE_PYTEST, assert_raise_message
 
 if USE_PYTEST:
     import py.test
@@ -61,3 +61,9 @@ def test_unexpected_exception_is_passed_through_with():
 
 def test_second_argument_should_be_callable_or_string():
     raises(TypeError, lambda: raises("irrelevant", 42))
+
+
+def test_assert_raise_message():
+    assert_raise_message(ZeroDivisionError, 'integer division or modulo by zero', lambda: 1/0) # error message: 'integer division or modulo by zero'
+    assert_raise_message(ZeroDivisionError, 'zero', lambda: 1/0)
+    raises(AssertionError, lambda: assert_raise_message(ZeroDivisionError, 'one', lambda: 1/0))


### PR DESCRIPTION
`raise_error_message` function is added in pytest.py .

#### References to other Issues or PRs
https://github.com/sympy/sympy/issues/14122


#### Brief description of what is fixed or changed
`rasie_error_message` takes three argument `expectedException`, `err_msg` and `code`.
If the exception raised is the expected one then, it matches the `err_msg` in the error message of the exception and verifies that the error message is same as expected.

#### Other comments
[This](https://github.com/sympy/sympy/pull/14161/files#diff-61c63cfea277d3f9016865b7c8d33819R67) should be passed as `assert_raise_message(ZeroDivisionError, 'integer division or modulo by zero', lambda: 1/0)` does nothing (raises no `AssertionError` when run normally). But I don't know why this test is failing!

@asmeurer @gxyd please review.