### PR TITLE
resolve expr-int(expr) in calc_integer_part

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -329,17 +329,36 @@ def get_integer_part(expr, no, options, return_ints=False):
     margin = 10
 
     if gap >= -margin:
-        ire, iim, ire_acc, iim_acc = \
-            evalf(expr, margin + assumed_size + gap, options)
+        prec = margin + assumed_size + gap
+        ire, iim, ire_acc, iim_acc = evalf(
+            expr, prec, options)
+    else:
+        prec = assumed_size
 
     # We can now easily find the nearest integer, but to find floor/ceil, we
     # must also calculate whether the difference to the nearest integer is
     # positive or negative (which may fail if very close).
-    def calc_part(expr, nexpr):
+    def calc_part(re_im, nexpr):
         from sympy.core.add import Add
-        nint = int(to_int(nexpr, rnd))
         n, c, p, b = nexpr
         is_int = (p == 0)
+        nint = int(to_int(nexpr, rnd))
+        if is_int:
+            # make sure that we had enough precision to distinguish
+            # bewteen nint and the re or im part (re_im) of expr that
+            # was passed to calc_part
+            ire, iim, ire_acc, iim_acc = evalf(
+                re_im - nint, 10, options)  # don't need much precision
+            assert not iim
+            size = -fastlog(ire) + 2  # -ve b/c ire is less than 1
+            if size > prec:
+                ire, iim, ire_acc, iim_acc = evalf(
+                    re_im, size, options)
+                assert not iim
+                nexpr = ire
+                n, c, p, b = nexpr
+                is_int = (p == 0)
+                nint = int(to_int(nexpr, rnd))
         if not is_int:
             # if there are subs and they all contain integer re/im parts
             # then we can (hopefully) safely substitute them into the
@@ -359,14 +378,14 @@ def get_integer_part(expr, no, options, return_ints=False):
                             doit = False
                             break
                 if doit:
-                    expr = expr.subs(s)
+                    re_im = re_im.subs(s)
 
-            expr = Add(expr, -nint, evaluate=False)
-            x, _, x_acc, _ = evalf(expr, 10, options)
+            re_im = Add(re_im, -nint, evaluate=False)
+            x, _, x_acc, _ = evalf(re_im, 10, options)
             try:
-                check_target(expr, (x, None, x_acc, None), 3)
+                check_target(re_im, (x, None, x_acc, None), 3)
             except PrecisionExhausted:
-                if not expr.equals(0):
+                if not re_im.equals(0):
                     raise PrecisionExhausted
                 x = fzero
             nint += int(no*(mpf_cmp(x or fzero, fzero) == no))

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -518,3 +518,10 @@ def test_issue_10395():
     eq = x*Max(y, -1.1)
     assert nfloat(eq) == eq
     assert Max(y, 4).n() == Max(4.0, y)
+
+
+def test_issue_13098():
+    assert floor(log(S('9.'+'9'*20), 10)) == 0
+    assert ceiling(log(S('9.'+'9'*20), 10)) == 1
+    assert floor(log(20 - S('9.'+'9'*20), 10)) == 1
+    assert ceiling(log(20 - S('9.'+'9'*20), 10)) == 2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #13098

#### Brief description of what is fixed or changed

The portion of the code used in floor and ceiling calculations already checks to see
that enough precision is used to capture large numbers. Now increased precision
is used if the result is so close to an integer that the default precision cannot distinguish
between the two. 

This is done by computing the magnitude of  `(expr - int(expr)` to see if the precision must be
increased to resolve the difference between the two.

#### Other comments

n/a