### PR TITLE
latex : added ln printing to latex

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -134,6 +134,7 @@ class LatexPrinter(Printer):
         "mat_str": None,
         "mat_delim": "[",
         "symbol_names": {},
+        "ln_notation": False,
     }
 
     def __init__(self, settings=None):
@@ -699,6 +700,8 @@ class LatexPrinter(Printer):
         func = self._deal_with_super_sub(func)
         if func in accepted_latex_functions:
             name = r"\%s" % func
+            if self._settings["ln_notation"] and name == r"\log":
+                name = r"\ln"
         elif len(func) == 1 or func.startswith('\\'):
             name = func
         else:
@@ -2123,7 +2126,7 @@ def latex(expr, **settings):
     r"""
     Convert the given expression to LaTeX representation.
 
-    >>> from sympy import latex, pi, sin, asin, Integral, Matrix, Rational
+    >>> from sympy import latex, pi, sin, asin, Integral, Matrix, Rational, log
     >>> from sympy.abc import x, y, mu, r, tau
 
     >>> print(latex((2*tau)**Rational(7,2)))
@@ -2241,6 +2244,14 @@ def latex(expr, **settings):
 
     >>> print(latex([2/x, y], mode='inline'))
     $\left [ 2 / x, \quad y\right ]$
+
+    ln_notation: If set to `True` "\ln" is used instead of default "\log"
+
+    >>> print(latex(log(10)))
+    \log{\left (10 \right )}
+
+    >>> print(latex(log(10), ln_notation=True))
+    \ln{\left (10 \right )}
 
     """
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -700,8 +700,6 @@ class LatexPrinter(Printer):
         func = self._deal_with_super_sub(func)
         if func in accepted_latex_functions:
             name = r"\%s" % func
-            if self._settings["ln_notation"] and name == r"\log":
-                name = r"\ln"
         elif len(func) == 1 or func.startswith('\\'):
             name = func
         else:
@@ -843,6 +841,17 @@ class LatexPrinter(Printer):
 
     def _print_ceiling(self, expr, exp=None):
         tex = r"\lceil{%s}\rceil" % self._print(expr.args[0])
+
+        if exp is not None:
+            return r"%s^{%s}" % (tex, exp)
+        else:
+            return tex
+
+    def _print_log(self, expr, exp=None):
+        if not self._settings["ln_notation"]:
+            tex = r"\log{\left (%s \right )}" % self._print(expr.args[0])
+        else:
+            tex = r"\ln{\left (%s \right )}" % self._print(expr.args[0])
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
@@ -2245,7 +2254,7 @@ def latex(expr, **settings):
     >>> print(latex([2/x, y], mode='inline'))
     $\left [ 2 / x, \quad y\right ]$
 
-    ln_notation: If set to `True` "\ln" is used instead of default "\log"
+    ln_notation: If set to ``True`` "\ln" is used instead of default "\log"
 
     >>> print(latex(log(10)))
     \log{\left (10 \right )}

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -141,6 +141,9 @@ def test_latex_basic():
     p = Symbol('p', positive=True)
     assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left (p \right )}"
 
+    assert latex(log(x)+log(y)) == r"\log{\left (x \right )} + \log{\left (y \right )}"
+    assert latex(log(x)+log(y), ln_notation=True) == r"\ln{\left (x \right )} + \ln{\left (y \right )}"
+
 
 def test_latex_builtins():
     assert latex(True) == r"\mathrm{True}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -836,6 +836,8 @@ def test_latex_log():
     assert latex(log(x), ln_notation=True) == r"\ln{\left (x \right )}"
     assert latex(log(x)+log(y)) == r"\log{\left (x \right )} + \log{\left (y \right )}"
     assert latex(log(x)+log(y), ln_notation=True) == r"\ln{\left (x \right )} + \ln{\left (y \right )}"
+    assert latex(pow(log(x),x)) == r"\log{\left (x \right )}^{x}"
+    assert latex(pow(log(x),x), ln_notation=True) == r"\ln{\left (x \right )}^{x}"
 
 
 def test_issue_3568():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -35,7 +35,7 @@ from sympy.physics.quantum import Commutator, Operator
 from sympy.core.trace import Tr
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
-from sympy import MatrixSymbol
+from sympy import MatrixSymbol, ln
 from sympy.vector import CoordSys3D, Cross, Curl, Dot, Divergence, Gradient
 from sympy.sets.setexpr import SetExpr
 
@@ -140,9 +140,6 @@ def test_latex_basic():
 
     p = Symbol('p', positive=True)
     assert latex(exp(-p)*log(p)) == r"e^{- p} \log{\left (p \right )}"
-
-    assert latex(log(x)+log(y)) == r"\log{\left (x \right )} + \log{\left (y \right )}"
-    assert latex(log(x)+log(y), ln_notation=True) == r"\ln{\left (x \right )} + \ln{\left (y \right )}"
 
 
 def test_latex_builtins():
@@ -831,6 +828,14 @@ def test_latex_limits():
     assert latex(Limit(f(x), x, 0)**2) == r"\left(\lim_{x \to 0^+} f{\left (x \right )}\right)^{2}"
     # bi-directional limit
     assert latex(Limit(f(x), x, 0, dir='+-')) == r"\lim_{x \to 0} f{\left (x \right )}"
+
+
+def test_latex_log():
+    assert latex(log(x)) == r"\log{\left (x \right )}"
+    assert latex(ln(x)) == r"\log{\left (x \right )}"
+    assert latex(log(x), ln_notation=True) == r"\ln{\left (x \right )}"
+    assert latex(log(x)+log(y)) == r"\log{\left (x \right )} + \log{\left (y \right )}"
+    assert latex(log(x)+log(y), ln_notation=True) == r"\ln{\left (x \right )} + \ln{\left (y \right )}"
 
 
 def test_issue_3568():


### PR DESCRIPTION
Fixes #14175 

#### Brief description of what is fixed or changed
`"ln_notation": False` is added to `_default_settings`. With `ln_notation = True`, `\ln` would be used instead of `\log` in latex printing.
```
>>> latex(ln(10))
'\\log{\\left (10 \\right )}'
>>> latex(ln(10), ln_notation=True)
'\\ln{\\left (10 \\right )}'
```


