### PR TITLE
second_moment_of_area_of_ellipse

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1268,6 +1268,45 @@ class Ellipse(GeometrySet):
         return self.args[2]
 
 
+    def second_moment_of_area(self, p=None):
+        """Returns the second moment of area of a ellipse.
+
+        Parameters
+        ==========
+
+        p : Point, two-tuple of sympifiable objects, or None(default=None)
+            p is the point about which second moment of area is to be found.
+            If "p=None" it will be calculated about the axis passing through the
+            centroid of the ellipse.
+
+        Examples
+        ========
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.second_moment_of_area()
+        (3*pi/4, 27*pi/4)
+
+        References
+        ==========
+
+        https://en.wikipedia.org/wiki/List_of_second_moments_of_area
+
+        """
+
+        I_xx = (S.Pi*(self.hradius)*(self.vradius**3))/4
+        I_yy = (S.Pi*(self.hradius**3)*(self.vradius))/4
+
+        if(p == None):
+            return I_xx, I_yy
+
+        # parallel axis theorem
+        I_xx = I_xx + self.area*(p[1]**2)
+        I_yy = I_yy + self.area*(p[0]**2)
+
+        return I_xx, I_yy
+
+
 class Circle(Ellipse):
     """A circle in space.
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1286,6 +1286,7 @@ class Ellipse(GeometrySet):
 
         Examples
         ========
+
         >>> from sympy import Point, Ellipse
         >>> p1 = Point(0, 0)
         >>> e1 = Ellipse(p1, 3, 1)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1283,6 +1283,8 @@ class Ellipse(GeometrySet):
         =======
 
         I_xx, I_yy, I_xy : number or sympy expression
+                           I_xx, I_yy are second moment of area of an ellise.
+                           I_xy is product moment of area of an ellipse
 
         Examples
         ========

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1268,15 +1268,15 @@ class Ellipse(GeometrySet):
         return self.args[2]
 
 
-    def second_moment_of_area(self, p=None):
+    def second_moment_of_area(self, point=None):
         """Returns the second moment of area of a ellipse.
 
         Parameters
         ==========
 
-        p : Point, two-tuple of sympifiable objects, or None(default=None)
-            p is the point about which second moment of area is to be found.
-            If "p=None" it will be calculated about the axis passing through the
+        point : Point, two-tuple of sympifiable objects, or None(default=None)
+            point is the point about which second moment of area is to be found.
+            If "point=None" it will be calculated about the axis passing through the
             centroid of the ellipse.
 
         Examples
@@ -1297,12 +1297,12 @@ class Ellipse(GeometrySet):
         I_xx = (S.Pi*(self.hradius)*(self.vradius**3))/4
         I_yy = (S.Pi*(self.hradius**3)*(self.vradius))/4
 
-        if(p == None):
+        if(point == None):
             return I_xx, I_yy
 
         # parallel axis theorem
-        I_xx = I_xx + self.area*(p[1]**2)
-        I_yy = I_yy + self.area*(p[0]**2)
+        I_xx = I_xx + self.area*(point[1]**2)
+        I_yy = I_yy + self.area*(point[0]**2)
 
         return I_xx, I_yy
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1269,7 +1269,7 @@ class Ellipse(GeometrySet):
 
 
     def second_moment_of_area(self, point=None):
-        """Returns the second moment of area of a ellipse.
+        """Returns the second moment and product moment area of an ellipse.
 
         Parameters
         ==========
@@ -1296,15 +1296,17 @@ class Ellipse(GeometrySet):
 
         I_xx = (S.Pi*(self.hradius)*(self.vradius**3))/4
         I_yy = (S.Pi*(self.hradius**3)*(self.vradius))/4
+        I_xy = 0
 
-        if(point == None):
-            return I_xx, I_yy
+        if point is None:
+            return I_xx, I_yy, I_xy
 
         # parallel axis theorem
-        I_xx = I_xx + self.area*(point[1]**2)
-        I_yy = I_yy + self.area*(point[0]**2)
+        I_xx = I_xx + self.area*((point[1] - self.center.y)**2)
+        I_yy = I_yy + self.area*((point[0] - self.center.x)**2)
+        I_xy = I_xy + self.area*(point[0] - self.center.x)*(point[1] - self.center.y)
 
-        return I_xx, I_yy
+        return I_xx, I_yy, I_xy
 
 
 class Circle(Ellipse):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1279,13 +1279,18 @@ class Ellipse(GeometrySet):
             If "point=None" it will be calculated about the axis passing through the
             centroid of the ellipse.
 
+        Returns
+        =======
+
+        I_xx, I_yy, I_xy : number or sympy expression
+
         Examples
         ========
         >>> from sympy import Point, Ellipse
         >>> p1 = Point(0, 0)
         >>> e1 = Ellipse(p1, 3, 1)
         >>> e1.second_moment_of_area()
-        (3*pi/4, 27*pi/4)
+        (3*pi/4, 27*pi/4, 0)
 
         References
         ==========

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1283,8 +1283,8 @@ class Ellipse(GeometrySet):
         =======
 
         I_xx, I_yy, I_xy : number or sympy expression
-                           I_xx, I_yy are second moment of area of an ellise.
-                           I_xy is product moment of area of an ellipse
+            I_xx, I_yy are second moment of area of an ellise.
+            I_xy is product moment of area of an ellipse.
 
         Examples
         ========

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -390,6 +390,8 @@ class Polygon(GeometrySet):
         =======
 
         I_xx, I_yy, I_xy : number or sympy expression
+                           I_xx, I_yy are second moment of area of a two dimensional polygon.
+                           I_xy is product moment of area of a two dimensional polygon.
 
         Examples
         ========

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -375,15 +375,15 @@ class Polygon(GeometrySet):
         return Point(simplify(A*cx), simplify(A*cy))
 
 
-    def second_moment_of_area(self, p='centroid'):
+    def second_moment_of_area(self, p=None):
         """Returns the second moment and product moment of area of a two dimensional polygon.
 
         Parameters
         ==========
 
-        p : Point, two-tuple of sympifiable objects, or 'centroid'(default='centroid')
+        p : Point, two-tuple of sympifiable objects, or None(default=None)
             p is the point about which second moment of area is to be found.
-            If "p='centroid'" it will be calculated about the axis passing through the
+            If "p=None" it will be calculated about the axis passing through the
             centroid of the polygon.
 
         Examples
@@ -421,7 +421,7 @@ class Polygon(GeometrySet):
         I_xx_c = (I_xx/12) - (A*(c_y**2))
         I_yy_c = (I_yy/12) - (A*(c_x**2))
         I_xy_c = (I_xy/24) - (A*(c_x*c_y))
-        if(p == 'centroid'):
+        if(p == None):
             return I_xx_c, I_yy_c, I_xy_c
 
         I_xx = (I_xx_c + A*((p[1]-c_y)**2))

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -421,7 +421,7 @@ class Polygon(GeometrySet):
         I_xx_c = (I_xx/12) - (A*(c_y**2))
         I_yy_c = (I_yy/12) - (A*(c_x**2))
         I_xy_c = (I_xy/24) - (A*(c_x*c_y))
-        if(point == None):
+        if point is None:
             return I_xx_c, I_yy_c, I_xy_c
 
         I_xx = (I_xx_c + A*((point[1]-c_y)**2))

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -375,15 +375,15 @@ class Polygon(GeometrySet):
         return Point(simplify(A*cx), simplify(A*cy))
 
 
-    def second_moment_of_area(self, p=None):
+    def second_moment_of_area(self, point=None):
         """Returns the second moment and product moment of area of a two dimensional polygon.
 
         Parameters
         ==========
 
-        p : Point, two-tuple of sympifiable objects, or None(default=None)
-            p is the point about which second moment of area is to be found.
-            If "p=None" it will be calculated about the axis passing through the
+        point : Point, two-tuple of sympifiable objects, or None(default=None)
+            point is the point about which second moment of area is to be found.
+            If "point=None" it will be calculated about the axis passing through the
             centroid of the polygon.
 
         Examples
@@ -421,12 +421,12 @@ class Polygon(GeometrySet):
         I_xx_c = (I_xx/12) - (A*(c_y**2))
         I_yy_c = (I_yy/12) - (A*(c_x**2))
         I_xy_c = (I_xy/24) - (A*(c_x*c_y))
-        if(p == None):
+        if(point == None):
             return I_xx_c, I_yy_c, I_xy_c
 
-        I_xx = (I_xx_c + A*((p[1]-c_y)**2))
-        I_yy = (I_yy_c + A*((p[0]-c_x)**2))
-        I_xy = (I_xy_c + A*((p[0]-c_x)*(p[1]-c_y)))
+        I_xx = (I_xx_c + A*((point[1]-c_y)**2))
+        I_yy = (I_yy_c + A*((point[0]-c_x)**2))
+        I_xy = (I_xy_c + A*((point[0]-c_x)*(point[1]-c_y)))
 
         return I_xx, I_yy, I_xy
 

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -386,6 +386,11 @@ class Polygon(GeometrySet):
             If "point=None" it will be calculated about the axis passing through the
             centroid of the polygon.
 
+        Returns
+        =======
+
+        I_xx, I_yy, I_xy : number or sympy expression
+
         Examples
         ========
 

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -1,11 +1,12 @@
 from __future__ import division
 
-from sympy import Dummy, Rational, S, Symbol, pi, sqrt, oo
+from sympy import Dummy, Rational, S, Symbol, symbols, pi, sqrt, oo
 from sympy.core.compatibility import range
 from sympy.geometry import (Circle, Ellipse, GeometryError, Line, Point, Polygon, Ray, RegularPolygon, Segment,
                             Triangle, intersection)
 from sympy.integrals.integrals import Integral
 from sympy.utilities.pytest import raises, slow
+from sympy import integrate
 
 
 @slow

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -392,3 +392,11 @@ def test_parameter_value():
     e = Ellipse(Point(0, 0), 3, 5)
     assert e.parameter_value((3, 0), t) == {t: 0}
     raises(ValueError, lambda: e.parameter_value((4, 0), t))
+
+def test_second_moment_of_area():
+    x, y = symbols('x, y')
+    e = Ellipse(Point(0, 0), 5, 4)
+    I_yy = 2*4*integrate(sqrt(25 - x**2)*x**2, (x, -5, 5))/5
+    I_xx = 2*5*integrate(sqrt(16 - y**2)*y**2, (y, -4, 4))/4
+    assert I_yy == e.second_moment_of_area()[1]
+    assert I_xx == e.second_moment_of_area()[0]

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -399,5 +399,8 @@ def test_second_moment_of_area():
     e = Ellipse(Point(0, 0), 5, 4)
     I_yy = 2*4*integrate(sqrt(25 - x**2)*x**2, (x, -5, 5))/5
     I_xx = 2*5*integrate(sqrt(16 - y**2)*y**2, (y, -4, 4))/4
+    Y = 3*sqrt(1 - x**2/5**2)
+    I_xy = integrate(integrate(y, (y, -Y, Y))*x, (x, -5, 5))
     assert I_yy == e.second_moment_of_area()[1]
     assert I_xx == e.second_moment_of_area()[0]
+    assert I_xy == e.second_moment_of_area()[2]


### PR DESCRIPTION
Implemented a function for the calculation of second-moment of area of an ellipse. which can be used in continuum mechanics for solving beam having elliptical or circular cross section. 
change p='centroid' to point=None #13939