### PR TITLE
Remove unused import of Pow from Basic.__eq__

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -315,7 +315,6 @@ class Basic(with_metaclass(ManagedProperties)):
 
         from http://docs.python.org/dev/reference/datamodel.html#object.__hash__
         """
-        from sympy import Pow
         if self is other:
             return True
 


### PR DESCRIPTION
Per #12942, a special case for Pow was removed from `Basic.__eq__` by #13518. However, the import of Pow remained in `Basic.__eq__`. Now it is removed as well. 