### PR TITLE
_print_Mul : parenthesize non-evaluated Pow with `exp=-1`

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -420,6 +420,8 @@ class CodePrinter(StrPrinter):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
+        pow_paren = []  # Will collect all pow with more than one base element and exp = -1
+
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
         else:
@@ -432,6 +434,8 @@ class CodePrinter(StrPrinter):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
+                    if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
+                        pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             else:
                 a.append(item)
@@ -440,6 +444,11 @@ class CodePrinter(StrPrinter):
 
         a_str = [self.parenthesize(x, prec) for x in a]
         b_str = [self.parenthesize(x, prec) for x in b]
+
+        # To parenthesize Pow with exp = -1 and having more than one Symbol
+        for item in pow_paren:
+            if item.base in b:
+                b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         if len(b) == 0:
             return sign + '*'.join(a_str)

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -134,6 +134,8 @@ class JuliaCodePrinter(CodePrinter):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
+        pow_paren = []  # Will collect all pow with more than one base element and exp = -1
+
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
         else:
@@ -147,6 +149,8 @@ class JuliaCodePrinter(CodePrinter):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
+                    if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
+                        pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
                 if item.p != 1:
@@ -160,6 +164,11 @@ class JuliaCodePrinter(CodePrinter):
 
         a_str = [self.parenthesize(x, prec) for x in a]
         b_str = [self.parenthesize(x, prec) for x in b]
+
+        # To parenthesize Pow with exp = -1 and having more than one Symbol
+        for item in pow_paren:
+            if item.base in b:
+                b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         # from here it differs from str.py to deal with "*" and ".*"
         def multjoin(a, a_str):

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -146,6 +146,8 @@ class OctaveCodePrinter(CodePrinter):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
+        pow_paren = []  # Will collect all pow with more than one base element and exp = -1
+
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
         else:
@@ -159,6 +161,8 @@ class OctaveCodePrinter(CodePrinter):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
+                    if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
+                        pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
                 if item.p != 1:
@@ -172,6 +176,11 @@ class OctaveCodePrinter(CodePrinter):
 
         a_str = [self.parenthesize(x, prec) for x in a]
         b_str = [self.parenthesize(x, prec) for x in b]
+
+        # To parenthesize Pow with exp = -1 and having more than one Symbol
+        for item in pow_paren:
+            if item.base in b:
+                b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         # from here it differs from str.py to deal with "*" and ".*"
         def multjoin(a, a_str):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -270,6 +270,8 @@ class StrPrinter(Printer):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
+        pow_paran=[]  # Will collect all pow with more than one base element and exp = -1
+
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
         else:
@@ -282,6 +284,8 @@ class StrPrinter(Printer):
                 if item.exp != -1:
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
+                    if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
+                        pow_paran.append(item)
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
                 if item.p != 1:
@@ -295,6 +299,11 @@ class StrPrinter(Printer):
 
         a_str = [self.parenthesize(x, prec, strict=False) for x in a]
         b_str = [self.parenthesize(x, prec, strict=False) for x in b]
+
+        # To parenthesize Pow with exp = -1 and having more than one Symbol
+        for item in pow_paran:
+            if item.base in b:
+                b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 
         if len(b) == 0:
             return sign + '*'.join(a_str)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -270,7 +270,7 @@ class StrPrinter(Printer):
         a = []  # items in the numerator
         b = []  # items that are in the denominator (if any)
 
-        pow_paran=[]  # Will collect all pow with more than one base element and exp = -1
+        pow_paren = []  # Will collect all pow with more than one base element and exp = -1
 
         if self.order not in ('old', 'none'):
             args = expr.as_ordered_factors()
@@ -285,7 +285,7 @@ class StrPrinter(Printer):
                     b.append(Pow(item.base, -item.exp, evaluate=False))
                 else:
                     if len(item.args[0].args) != 1 and isinstance(item.base, Mul):   # To avoid situations like #14160
-                        pow_paran.append(item)
+                        pow_paren.append(item)
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
                 if item.p != 1:
@@ -301,7 +301,7 @@ class StrPrinter(Printer):
         b_str = [self.parenthesize(x, prec, strict=False) for x in b]
 
         # To parenthesize Pow with exp = -1 and having more than one Symbol
-        for item in pow_paran:
+        for item in pow_paren:
             if item.base in b:
                 b_str[b.index(item.base)] = "(%s)" % b_str[b.index(item.base)]
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -1,6 +1,6 @@
 import warnings
-from sympy.core import (S, pi, oo, symbols, Rational, Integer, Float, Mod,
-                        GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq, nan)
+from sympy.core import (S, pi, oo, symbols, Rational, Integer, Float, Mod, GoldenRatio,
+                        EulerGamma, Catalan, Lambda, Dummy, Eq, nan, Mul, Pow)
 from sympy.functions import (Abs, acos, acosh, asin, asinh, atan, atanh, atan2,
                              ceiling, cos, cosh, erf, erfc, exp, floor, gamma, log,
                              loggamma, Max, Min, Piecewise,
@@ -58,6 +58,9 @@ def test_ccode_Pow():
     # Related to gh-11353
     assert ccode(2**x, user_functions={'Pow': _cond_cfunc2}) == 'exp2(x)'
     assert ccode(x**2, user_functions={'Pow': _cond_cfunc2}) == 'pow(x, 2)'
+    # For issue 14160
+    assert ccode(Mul(-2, x, Pow(Mul(y,y,evaluate=False), -1, evaluate=False),
+                                                evaluate=False)) == '-2*x/(y*y)'
 
 
 def test_ccode_Max():

--- a/sympy/printing/tests/test_julia.py
+++ b/sympy/printing/tests/test_julia.py
@@ -1,6 +1,6 @@
 from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer,
                         Tuple, Symbol)
-from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda
+from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda, Mul, Pow
 from sympy.functions import Piecewise, sqrt, ceiling, exp, sin, cos
 from sympy.utilities.pytest import raises
 from sympy.utilities.lambdify import implemented_function
@@ -44,6 +44,9 @@ def test_Pow():
     g = implemented_function('g', Lambda(x, 2*x))
     assert julia_code(1/(g(x)*3.5)**(x - y**x)/(x**2 + y)) == \
         "(3.5*2*x).^(-x + y.^x)./(x.^2 + y)"
+    # For issue 14160
+    assert julia_code(Mul(-2, x, Pow(Mul(y,y,evaluate=False), -1, evaluate=False),
+                                                evaluate=False)) == '-2*x./(y.*y)'
 
 
 def test_basic_ops():

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -1,6 +1,6 @@
 from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer,
                         Tuple, Symbol)
-from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda
+from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda, Mul, Pow
 from sympy.functions import (Piecewise, sqrt, ceiling, exp, sin, cos, LambertW,
                              sinc, Max, Min, arg, im, re)
 from sympy.utilities.pytest import raises
@@ -53,6 +53,9 @@ def test_Pow():
     g = implemented_function('g', Lambda(x, 2*x))
     assert mcode(1/(g(x)*3.5)**(x - y**x)/(x**2 + y)) == \
         "(3.5*2*x).^(-x + y.^x)./(x.^2 + y)"
+    # For issue 14160
+    assert mcode(Mul(-2, x, Pow(Mul(y,y,evaluate=False), -1, evaluate=False),
+                                                evaluate=False)) == '-2*x./(y.*y)'
 
 
 def test_basic_ops():

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -43,6 +43,9 @@ def test_python_basic():
         "y = Symbol('y')\nx = Symbol('x')\ne = 1 - 3*y/(2*x)"]
 
     # Multiplication
+    from sympy import Mul, Pow
+    assert python(Mul(-2, x, Pow(Mul(y,y,evaluate=False), -1, evaluate=False)
+        , evaluate=False)) == "x = Symbol('x')\ny = Symbol('y')\ne = -2*x/(y*y)"
     assert python(x/y) == "x = Symbol('x')\ny = Symbol('y')\ne = x/y"
     assert python(-x/y) == "x = Symbol('x')\ny = Symbol('y')\ne = -x/y"
     assert python((x + 2)/y) in [

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -43,9 +43,6 @@ def test_python_basic():
         "y = Symbol('y')\nx = Symbol('x')\ne = 1 - 3*y/(2*x)"]
 
     # Multiplication
-    from sympy import Mul, Pow
-    assert python(Mul(-2, x, Pow(Mul(y,y,evaluate=False), -1, evaluate=False)
-        , evaluate=False)) == "x = Symbol('x')\ny = Symbol('y')\ne = -2*x/(y*y)"
     assert python(x/y) == "x = Symbol('x')\ny = Symbol('y')\ne = x/y"
     assert python(-x/y) == "x = Symbol('x')\ny = Symbol('y')\ne = -x/y"
     assert python((x + 2)/y) in [

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -7,7 +7,7 @@ from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
     AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion)
-from sympy.core import Expr
+from sympy.core import Expr, Mul
 from sympy.physics.units import second, joule
 from sympy.polys import Poly, rootof, RootSum, groebner, ring, field, ZZ, QQ, lex, grlex
 from sympy.geometry import Point, Circle
@@ -214,6 +214,10 @@ def test_Mul():
     assert str(-2*x/3) == '-2*x/3'
     assert str(-1.0*x) == '-1.0*x'
     assert str(1.0*x) == '1.0*x'
+    # For issue 14160
+    assert str(Mul(-2, x, Pow(Mul(y,y,evaluate=False), -1, evaluate=False),
+                                                evaluate=False)) == '-2*x/(y*y)'
+
 
     class CustomClass1(Expr):
         is_commutative = True


### PR DESCRIPTION
Fixes #14160 
The issue occurs only for non-evaluated `Pow` with exponent `-1`.  `_print_Mul` prints such terms as it is  (like `Pow(Mul(a,a,evaluate=False), -1, evaluate=False)` gets printed to `a*a` in the denominator)
#### Brief description of what is fixed or changed
I just added a list `pow_paran` which takes account of all such vulnerable `pow` and paranthesize them explicitly. `isinstance(item.base, Mul)` has been included because `Add` (such as `y+1`) wont face this issue(there precedence matches negative integer with a value of `40`).
I was not able to find explicit tests for `Mul`, so I added them inside `test_python.py`.

Output in this branch :
```
>>> Mul(-2, u, Pow(Mul(a,a,evaluate=False), -1, evaluate=False), evaluate=False)
-2*u/(a*a)
>>> Mul(-2, u, Pow(Mul(a,b,a,evaluate=False), -1, evaluate=False), evaluate=False)
-2*u/(a*a*b)
```


Identical changes are added to `CodePrinter`, `JuliaCodePrinter` and `OctaveCodePrinter`