### PR TITLE
Fixed a typo

### DIFF
--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -211,7 +211,8 @@ def _parallel_dict_from_expr_if_gens(exprs, opt):
                         if not factor.free_symbols.intersection(opt.gens):
                             coeff.append(factor)
                         else:
-                            raise PolynomialError("%s contains an element of the generators set" % factor)
+                            raise PolynomialError("%s contains an element of "
+                                                  "the set of generators." % factor)
 
             monom = tuple(monom)
 


### PR DESCRIPTION
Fixes the typo issue of #14214 .

**BEFORE**

`PolynomialError: x**n contains an element of the generators set`

**NOW**

`PolynomialError: x**n contains an element of the set of generators`
