### PR TITLE
Make the derivative of a _diff_wrt object with respect to itself, 1

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1213,6 +1213,8 @@ class Derivative(Expr):
         # derivative class by calling Expr.__new__.
         if (not (hasattr(expr, '_eval_derivative') and evaluate) and
            (not isinstance(expr, Derivative))):
+            if evaluate and variables == [expr]:
+                return S.One
             # If we wanted to evaluate, we sort the variables into standard
             # order for later comparisons. This is too aggressive if evaluate
             # is False, so we don't do it in that case.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1213,6 +1213,8 @@ class Derivative(Expr):
         # derivative class by calling Expr.__new__.
         if (not (hasattr(expr, '_eval_derivative') and evaluate) and
            (not isinstance(expr, Derivative))):
+            # If we try to differentiate a variable with respect to itself,
+            # the result should always be 1.
             if evaluate and variables == [expr]:
                 return S.One
             # If we wanted to evaluate, we sort the variables into standard

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1208,24 +1208,6 @@ class Derivative(Expr):
                 else:
                     return S.Zero
 
-        # If we can't compute the derivative of expr (but we wanted to) and
-        # expr is itself not a Derivative, finish building an unevaluated
-        # derivative class by calling Expr.__new__.
-        if (not (hasattr(expr, '_eval_derivative') and evaluate) and
-           (not isinstance(expr, Derivative))):
-            # If we try to differentiate a variable with respect to itself,
-            # the result should always be 1.
-            if evaluate and variables == [expr]:
-                return S.One
-            # If we wanted to evaluate, we sort the variables into standard
-            # order for later comparisons. This is too aggressive if evaluate
-            # is False, so we don't do it in that case.
-            if evaluate:
-                #TODO: check if assumption of discontinuous derivatives exist
-                variable_count = cls._sort_variable_count(variable_count)
-            obj = Expr.__new__(cls, expr, *variable_count)
-            return obj
-
         # Compute the derivative now by repeatedly calling the
         # _eval_derivative method of expr for each variable. When this method
         # returns None, the derivative couldn't be computed wrt that variable
@@ -1254,6 +1236,21 @@ class Derivative(Expr):
                     expr = expr.xreplace({v: new_v})
                     old_v = v
                     v = new_v
+
+                # If we can't compute the derivative of expr (but we wanted to) and
+                # expr is itself not a Derivative, finish building an unevaluated
+                # derivative class by calling Expr.__new__.
+                if (not (hasattr(expr, '_eval_derivative') and evaluate) and
+                (not isinstance(expr, Derivative))):
+                    # If we wanted to evaluate, we sort the variables into standard
+                    # order for later comparisons. This is too aggressive if evaluate
+                    # is False, so we don't do it in that case.
+                    if evaluate:
+                        #TODO: check if assumption of discontinuous derivatives exist
+                        variable_count = cls._sort_variable_count(variable_count)
+                    obj = Expr.__new__(cls, expr, *variable_count)
+                    return obj
+
                 # Evaluate the derivative `n` times.  If
                 # `_eval_derivative_n_times` is not overridden by the current
                 # object, the default in `Basic` will call a loop over

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1231,6 +1231,7 @@ class Derivative(Expr):
                 if isinstance(v, (collections.Iterable, Tuple, MatrixCommon, NDimArray)):
                     # Treat derivatives by arrays/matrices as much as symbols.
                     is_symbol = True
+                old_expr = expr
                 if not is_symbol:
                     new_v = Dummy('xi_%i' % i, dummy_index=hash(v))
                     expr = expr.xreplace({v: new_v})
@@ -1248,7 +1249,7 @@ class Derivative(Expr):
                     if evaluate:
                         #TODO: check if assumption of discontinuous derivatives exist
                         variable_count = cls._sort_variable_count(variable_count)
-                    obj = Expr.__new__(cls, expr, *variable_count)
+                    obj = Expr.__new__(cls, old_expr, *variable_count)
                     return obj
 
                 # Evaluate the derivative `n` times.  If

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -98,7 +98,7 @@ def test_diff_wrt_itself():
             return Expr.__new__(cls)
 
     v = Value()
-    assert diff(v, v) == 1
+    assert diff(v, v) is S.One
 
 def test_speed():
     # this should return in 0.0s. If it takes forever, it's wrong.

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -90,6 +90,15 @@ def test_diff_no_eval_derivative():
     # it doesn't have y so it shouldn't need a method for this case
     assert My(x).diff(y) == 0
 
+def test_diff_wrt_itself():
+    class Value(Expr):
+        _diff_wrt = True
+
+        def __new__(cls):
+            return Expr.__new__(cls)
+
+    v = Value()
+    assert diff(v, v) == 1
 
 def test_speed():
     # this should return in 0.0s. If it takes forever, it's wrong.


### PR DESCRIPTION
This fixes #10150. Now taking the derivative of an object with `_diff_wrt = True`, with respect to itself, returns 1 rather than the unevaluated derivative. 