### PR TITLE
Extracting common codes from Latex.py

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -810,25 +810,17 @@ class LatexPrinter(Printer):
 
         return tex
 
-    def _print_Min(self, expr, exp=None):
+    def _hprint_variadic_function(self, expr, exp=None):
         args = sorted(expr.args, key=default_sort_key)
         texargs = [r"%s" % self._print(symbol) for symbol in args]
-        tex = r"\min\left(%s\right)" % ", ".join(texargs)
+        tex = r"\%s\left(%s\right)" % (self._print((str(expr.func)).lower()), ", ".join(texargs))
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
         else:
             return tex
 
-    def _print_Max(self, expr, exp=None):
-        args = sorted(expr.args, key=default_sort_key)
-        texargs = [r"%s" % self._print(symbol) for symbol in args]
-        tex = r"\max\left(%s\right)" % ", ".join(texargs)
-
-        if exp is not None:
-            return r"%s^{%s}" % (tex, exp)
-        else:
-            return tex
+    _print_Min = _print_Max = _hprint_variadic_function
 
     def _print_floor(self, expr, exp=None):
         tex = r"\lfloor{%s}\rfloor" % self._print(expr.args[0])
@@ -981,13 +973,15 @@ class LatexPrinter(Printer):
         else:
             return r"\operatorname{B}%s" % tex
 
-    def _print_gamma(self, expr, exp=None):
+    def _hprint_one_args_func(self, expr, exp=None):
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 
         if exp is not None:
-            return r"\Gamma^{%s}%s" % (exp, tex)
+            return r"%s^{%s}%s" % (self._print(expr.func), exp, tex)
         else:
-            return r"\Gamma%s" % tex
+            return r"%s%s" % (self._print(expr.func), tex)
+
+    _print_gamma = _hprint_one_args_func
 
     def _print_uppergamma(self, expr, exp=None):
         tex = r"\left(%s, %s\right)" % (self._print(expr.args[0]),


### PR DESCRIPTION

#### Brief description of what is fixed or changed
functions having the same name in sympy/printing/latex.py extracted into one function and fixed printers having different methods of printing the name of the function used and function class the function definition of      _print_Min and _print_Max has been changed to function with name             _hprint_variadic_function as both of the functions had the same code and      _print_gamma definition is changed to _hprint_one_args_func.               


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
It fixes issue #14044 .