### PR TITLE
improved solveset for improper symbols

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -980,10 +980,15 @@ def solveset(f, symbol=None, domain=S.Complexes):
             raise ValueError(filldedent('''
                 The independent variable must be specified for a
                 multivariate equation.'''))
-    elif not isinstance(symbol, Symbol):
-        f, s, swap = recast_to_symbols([f], [symbol])
-        # the xreplace will be needed if a ConditionSet is returned
-        return solveset(f[0], s[0], domain).xreplace(swap)
+    elif not getattr(symbol, 'is_Symbol', False):
+        from sympy import Function, Indexed
+        if isinstance(symbol, (Function, Indexed)):
+            f, s, swap = recast_to_symbols([f], [symbol])
+            # the xreplace will be needed if a ConditionSet is returned
+            return solveset(f[0], s[0], domain).xreplace(swap)
+        else:
+            raise ValueError('A Symbol must be given, not type %s: %s' %
+                (type(symbol), symbol))
 
     elif not free_symbols:
         b = Eq(f, 0)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -254,14 +254,15 @@ def test_is_function_class_equation():
 
 
 def test_garbage_input():
+    # see issue 12217
     raises(ValueError, lambda: solveset_real([x], x))
-    assert solveset_real(x, 1) == S.EmptySet
-    assert solveset_real(x - 1, 1) == FiniteSet(x)
-    assert solveset_real(x, pi) == S.EmptySet
-    assert solveset_real(x, x**2) == S.EmptySet
-
+    raises(ValueError, lambda: solveset_real(x, 1))
+    raises(ValueError, lambda: solveset(x - 1, 1))
+    raises(ValueError, lambda: solveset_real(x, pi))
+    raises(ValueError, lambda: solveset_real(x, x**2))
     raises(ValueError, lambda: solveset_complex([x], x))
-    assert solveset_complex(x, pi) == S.EmptySet
+    raises(ValueError, lambda: solveset_complex(x, pi))
+    raises(ValueError, lambda: solveset(x + 1, S.Reals))
 
 
 def test_solve_mul():
@@ -924,13 +925,7 @@ def test_solveset():
     x = Symbol('x')
     f = Function('f')
     raises(ValueError, lambda: solveset(x + y))
-    assert solveset(x, 1) == S.EmptySet
-    assert solveset(f(1)**2 + y + 1, f(1)
-        ) == FiniteSet(-sqrt(-y - 1), sqrt(-y - 1))
-    assert solveset(f(1)**2 - 1, f(1), S.Reals) == FiniteSet(-1, 1)
-    assert solveset(f(1)**2 + 1, f(1)) == FiniteSet(-I, I)
-    assert solveset(x - 1, 1) == FiniteSet(x)
-    assert solveset(sin(x) - cos(x), sin(x)) == FiniteSet(cos(x))
+    raises(ValueError, lambda: solveset(x, 1))
 
     assert solveset(0, domain=S.Reals) == S.Reals
     assert solveset(1) == S.EmptySet
@@ -952,6 +947,18 @@ def test_solveset():
                                                   S.Integers)
     # issue 13825
     assert solveset(x**2 + f(0) + 1, x) == {-sqrt(-f(0) - 1), sqrt(-f(0) - 1)}
+
+
+def test_other_symbols():
+    #  see issue 12239
+    x = Symbol('x')
+    f = Function('f')
+
+    assert solveset(f(1)**2 + y + 1, f(1)) == FiniteSet(-sqrt(-y - 1), sqrt(-y - 1))
+    assert solveset(f(1)**2 - 1, f(1), S.Reals) == FiniteSet(-1, 1)
+    assert solveset(f(1)**2 + 1, f(1)) == FiniteSet(-I, I)
+    assert solveset(sin(x) - cos(x), sin(x)) == FiniteSet(cos(x))
+
 
 
 def test_conditionset():


### PR DESCRIPTION
It seems that #13415 got some issues:

Suppose
```
>>> solveset(x+1, S.Reals)
EmptySet()
```
Here it sees `S.Reals` as a symbol and `S.Complexes` as the domain (which is not quite the users intention), therefore it should raise a `ValueError`.

Also, the discussions in #12217 concludes that solveset should not be made to give result for unknown symbols instead a `ValueError` should be raised.

As @Shekharrajak quoted:

> solveset 2nd arg should be symbol not any expression. So solveset should not return that ans, it is not made for solving expression. (There must be ValueError in this case)

ping @asmeurer @smichr @Shekharrajak 