### PR TITLE
Optimizing _eval_Mod in cores.power for very large powers

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -404,15 +404,17 @@ class Pow(Expr):
 
             '''
             For unevaluated Integer power, use built-in pow modular
-            exponentiation.
+            exponentiation, if powers are not too large wrt base.
             '''
             if self.base.is_Integer and self.exp.is_Integer and q.is_Integer:
                 b, e, m = int(self.base), int(self.exp), int(q)
-                # for very large powers
-                if m <= 10**18 and _log(e, 2) > 4*m**(1/4):
-                    # pollard rho for modulo will not be
-                    # slower than binary exponentiation
-                    
+                '''
+                For very large powers, use totient reduction.
+                Bound on m, is for safe factorization memory wise ie m^(1/4).
+                For pollard-rho to be faster than built-in pow and for e >= lg(m),
+                lg(e) > 4 m^(1/4) check is added.
+                '''
+                if m.bit_length() <= 80  and _log(e,2) > 4*m**(1/4):
                     from sympy.ntheory import totient
                     phi = totient(m)
                     return pow(b, phi + e%phi, m)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -408,13 +408,11 @@ class Pow(Expr):
             '''
             if self.base.is_Integer and self.exp.is_Integer and q.is_Integer:
                 b, e, m = int(self.base), int(self.exp), int(q)
-                '''
-                For very large powers, use totient reduction.
-                Bound on m, is for safe factorization memory wise ie m^(1/4).
-                For pollard-rho to be faster than built-in pow and for e >= lg(m),
-                lg(e) > 4 m^(1/4) check is added.
-                '''
-                if m.bit_length() <= 80  and _log(e,2) > 4*m**(1/4):
+                # For very large powers, use totient reduction.
+                # Bound on m, is for safe factorization memory wise ie m^(1/4).
+                # For pollard-rho to be faster than built-in pow and for e >= lg(m),
+                # lg(e) > m^(1/4) check is added.
+                if m.bit_length() <= 80  and _log(e,2) > m**(1/4):
                     from sympy.ntheory import totient
                     phi = totient(m)
                     return pow(b, phi + e%phi, m)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -409,12 +409,15 @@ class Pow(Expr):
             if self.base.is_Integer and self.exp.is_Integer and q.is_Integer:
                 b, e, m = int(self.base), int(self.exp), int(q)
                 # for very large powers
-                if m<=10**18 and _log(e,2)>4*m**(1/4): # pollard rho for modulo would not be slower than binary exponentiation
+                if m <= 10**18 and _log(e, 2) > 4*m**(1/4): 
+                    # pollard rho for modulo will not be 
+                    # slower than binary exponentiation
+                    
                     from sympy.ntheory import totient
                     phi = totient(m)
-                    return pow(b,phi + e%phi,m) # reduction by euler totient theorem and crt
+                    return pow(b, phi + e%phi, m) 
                 else:
-                    return pow(b,e,m)
+                    return pow(b, e, m)
 
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -407,7 +407,14 @@ class Pow(Expr):
             exponentiation.
             '''
             if self.base.is_Integer and self.exp.is_Integer and q.is_Integer:
-                return pow(int(self.base), int(self.exp), int(q))
+                b, e, m = int(self.base), int(self.exp), int(q)
+                # for very large powers
+                if m<=10**18 and _log(e,2)>4*m**(1/4): # pollard rho for modulo would not be slower than binary exponentiation
+                    from sympy.ntheory import totient
+                    phi = totient(m)
+                    return pow(b,phi + e%phi,m) # reduction by euler totient theorem and crt
+                else:
+                    return pow(b,e,m)
 
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -409,13 +409,13 @@ class Pow(Expr):
             if self.base.is_Integer and self.exp.is_Integer and q.is_Integer:
                 b, e, m = int(self.base), int(self.exp), int(q)
                 # for very large powers
-                if m <= 10**18 and _log(e, 2) > 4*m**(1/4): 
-                    # pollard rho for modulo will not be 
+                if m <= 10**18 and _log(e, 2) > 4*m**(1/4):
+                    # pollard rho for modulo will not be
                     # slower than binary exponentiation
                     
                     from sympy.ntheory import totient
                     phi = totient(m)
-                    return pow(b, phi + e%phi, m) 
+                    return pow(b, phi + e%phi, m)
                 else:
                     return pow(b, e, m)
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -408,11 +408,12 @@ class Pow(Expr):
             '''
             if self.base.is_Integer and self.exp.is_Integer and q.is_Integer:
                 b, e, m = int(self.base), int(self.exp), int(q)
-                # For very large powers, use totient reduction.
+                # For very large powers, use totient reduction if e >= lg(m).
                 # Bound on m, is for safe factorization memory wise ie m^(1/4).
-                # For pollard-rho to be faster than built-in pow and for e >= lg(m),
-                # lg(e) > m^(1/4) check is added.
-                if m.bit_length() <= 80  and _log(e,2) > m**(1/4):
+                # For pollard-rho to be faster than built-in pow lg(e) > m^(1/4)
+                # check is added.
+                mb = m.bit_length()
+                if mb <= 80  and e >= mb and e.bit_length()**4 >= m:
                     from sympy.ntheory import totient
                     phi = totient(m)
                     return pow(b, phi + e%phi, m)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1636,6 +1636,9 @@ def test_Mod():
     # modular exponentiation
     assert Mod(Pow(4, 13, evaluate=False), 497) == Mod(Pow(4, 13), 497)
     assert Mod(Pow(2, 10000000000, evaluate=False), 3) == 1
+    assert Mod(Pow(32131231232, 9**10**6, evaluate=False),10**12) == pow(32131231232,9**10**6,10**12)
+    assert Mod(Pow(33284959323, 123**999, evaluate=False),11**13) == pow(33284959323,123**999,11**13)
+    assert Mod(Pow(78789849597, 333**555, evaluate=False),12**9) == pow(78789849597,333**555,12**9)
 
     # Wilson's theorem
     factorial(18042, evaluate=False) % 18043 == 18042


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Integer modular exponentiation is optimized for very large powers, by calculating Totient Function of the modulo (if it is not the slow step) and using Euler Totient Theorem, CRT to get a simpler expression for faster evaluation.

#### Other comments
Test:
`a, b, c = 32131231232, 9**10**6, 10**12`
Computing pow(a,b,c) takes about 1s in the original version, and the updated version takes <0.5s.

@normalhuman @jksuom @smichr Please review the changes.

#### Update
1. Commit: Add checks for optimized Mod Pow
2. Commit: Improved documentation, added spaces
3. Added [explanation](https://github.com/sympy/sympy/pull/14249#issuecomment-367199918) on @jksuom 's recommendation.
4. Updated check conditions on @asmeurer @jksuom suggestions.