### PR TITLE
Add sampling for GammaInverse Distribution

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1260,6 +1260,12 @@ class GammaInverseDistribution(SingleContinuousDistribution):
         return Piecewise((uppergamma(a,b/x)/gamma(a), x > 0),
                         (S.Zero, True))
 
+    def sample(self):
+        try :
+            from scipy.stats import invgamma
+        except ImportError:
+            raise ImportError("can't find invgamma in scipy.stats")
+        return invgamma.rvs(float(self.a), 0, float(self.b))    
 
 def GammaInverse(name, a, b):
     r"""
@@ -1287,7 +1293,7 @@ def GammaInverse(name, a, b):
     Examples
     ========
 
-    >>> from sympy.stats import GammaInverse, density, cdf, E, variance
+    >>> from sympy.stats import GammaInverse, density, cdf, E, variance, sample
     >>> from sympy import Symbol, pprint
 
     >>> a = Symbol("a", positive=True)
@@ -1308,6 +1314,9 @@ def GammaInverse(name, a, b):
     >>> cdf(X)(z)
     Piecewise((uppergamma(a, b/z)/gamma(a), z > 0), (0, True))
 
+    >>> Y = GammaInverse("y", 1, 1)
+    >>> isinstance(sample(Y), float)
+    True
 
     References
     ==========

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -55,7 +55,7 @@ from sympy import cos, sin, exp, besseli, besselj
 from sympy.stats.crv import (SingleContinuousPSpace, SingleContinuousDistribution,
         ContinuousDistributionHandmade)
 from sympy.stats.rv import _value_check
-from sympy.utilities.pytest import skip
+from sympy.external import import_module
 import random
 
 oo = S.Infinity
@@ -1262,12 +1262,12 @@ class GammaInverseDistribution(SingleContinuousDistribution):
                         (S.Zero, True))
 
     def sample(self):
-        try :
+        scipy = import_module('scipy')
+        if scipy:
             from scipy.stats import invgamma
-        except ImportError:
-            skip("Scipy not found")
-            raise ImportError("can't find invgamma in scipy.stats")
-        return invgamma.rvs(float(self.a), 0, float(self.b))
+            return invgamma.rvs(float(self.a), 0, float(self.b))
+        else:
+            raise NotImplementedError('Sampling the inverse Gamma Distribution requires Scipy.')
 
 def GammaInverse(name, a, b):
     r"""
@@ -1295,7 +1295,7 @@ def GammaInverse(name, a, b):
     Examples
     ========
 
-    >>> from sympy.stats import GammaInverse, density, cdf, E, variance, sample
+    >>> from sympy.stats import GammaInverse, density, cdf, E, variance
     >>> from sympy import Symbol, pprint
 
     >>> a = Symbol("a", positive=True)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -55,6 +55,7 @@ from sympy import cos, sin, exp, besseli, besselj
 from sympy.stats.crv import (SingleContinuousPSpace, SingleContinuousDistribution,
         ContinuousDistributionHandmade)
 from sympy.stats.rv import _value_check
+from sympy.utilities.pytest import skip
 import random
 
 oo = S.Infinity
@@ -1264,8 +1265,9 @@ class GammaInverseDistribution(SingleContinuousDistribution):
         try :
             from scipy.stats import invgamma
         except ImportError:
+            skip("Scipy not found")
             raise ImportError("can't find invgamma in scipy.stats")
-        return invgamma.rvs(float(self.a), 0, float(self.b))    
+        return invgamma.rvs(float(self.a), 0, float(self.b))
 
 def GammaInverse(name, a, b):
     r"""
@@ -1314,9 +1316,6 @@ def GammaInverse(name, a, b):
     >>> cdf(X)(z)
     Piecewise((uppergamma(a, b/z)/gamma(a), z > 0), (0, True))
 
-    >>> Y = GammaInverse("y", 1, 1)
-    >>> isinstance(sample(Y), float)
-    True
 
     References
     ==========

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -351,9 +351,10 @@ def test_gamma_inverse():
     b = Symbol("b", positive=True)
 
     X = GammaInverse("x", a, b)
+    Y = GammaInverse("y", 1, 1)
     assert density(X)(x) == x**(-a - 1)*b**a*exp(-b/x)/gamma(a)
     assert cdf(X)(x) == Piecewise((uppergamma(a, b/x)/gamma(a), x > 0), (0, True))
-
+    assert sample(Y) in Y.pspace.domain.set
 
 def test_gompertz():
     b = Symbol("b", positive=True)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -22,7 +22,8 @@ from sympy import (Symbol, Abs, exp, S, N, pi, simplify, Interval, erf, erfc,
 from sympy.stats.crv_types import NormalDistribution
 from sympy.stats.rv import ProductPSpace
 
-from sympy.utilities.pytest import raises, XFAIL, slow
+from sympy.utilities.pytest import raises, XFAIL, slow, skip
+from sympy.external import import_module
 
 from sympy.core.compatibility import range
 
@@ -351,10 +352,15 @@ def test_gamma_inverse():
     b = Symbol("b", positive=True)
 
     X = GammaInverse("x", a, b)
-    Y = GammaInverse("y", 1, 1)
     assert density(X)(x) == x**(-a - 1)*b**a*exp(-b/x)/gamma(a)
     assert cdf(X)(x) == Piecewise((uppergamma(a, b/x)/gamma(a), x > 0), (0, True))
-    assert sample(Y) in Y.pspace.domain.set
+
+def test_sampling_gamma_inverse():
+    scipy = import_module('scipy')
+    if not scipy:
+        skip('Scipy not installed. Abort tests for sampling of gamma inverse.')
+    X = GammaInverse("x", 1, 1)
+    assert sample(X) in X.pspace.domain.set
 
 def test_gompertz():
     b = Symbol("b", positive=True)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Added sampling, docstring, and unit tests for GammaInverse Distribution

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes  #13879. Closes #11699. 
Is a part of #7358.

#### Brief description of what is fixed or changed
Used scipy for the sampling of inverse gamma distribution as mentioned in the issue #7358. Added unit tests and modified the corresponding docstring.

#### Other comments
The docstring of the sampling method has been removed because the tests fail if scipy is not installed