### PR TITLE
Added simplify in limit_seq

### DIFF
--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -8,8 +8,9 @@ from sympy.core.add import Add
 from sympy.core.power import Pow
 from sympy.core.symbol import Dummy
 from sympy.core.function import PoleError
+from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.series.limits import Limit
-from sympy.simplify.simplify import simplify
+from sympy.simplify.trigsimp import trigsimp
 
 
 def difference_delta(expr, n=None, step=1):
@@ -111,9 +112,12 @@ def _limit_inf(expr, n):
 def _limit_seq(expr, n, trials):
     from sympy.concrete.summations import Sum
 
+    _trig = TrigonometricFunction
+
     for i in range(trials):
         if not expr.has(Sum):
-            expr = simplify(expr)
+            if expr.has(_trig):
+                expr = trigsimp(expr)
             result = _limit_inf(expr, n)
             if result is not None:
                 return result

--- a/sympy/series/limitseq.py
+++ b/sympy/series/limitseq.py
@@ -9,6 +9,7 @@ from sympy.core.power import Pow
 from sympy.core.symbol import Dummy
 from sympy.core.function import PoleError
 from sympy.series.limits import Limit
+from sympy.simplify.simplify import simplify
 
 
 def difference_delta(expr, n=None, step=1):
@@ -112,6 +113,7 @@ def _limit_seq(expr, n, trials):
 
     for i in range(trials):
         if not expr.has(Sum):
+            expr = simplify(expr)
             result = _limit_inf(expr, n)
             if result is not None:
                 return result

--- a/sympy/series/tests/test_limitseq.py
+++ b/sympy/series/tests/test_limitseq.py
@@ -1,4 +1,4 @@
-from sympy import symbols, oo, Sum, harmonic, Add, S, binomial, factorial
+from sympy import symbols, oo, Sum, harmonic, Add, S, binomial, factorial, sin, cos, AccumBounds
 from sympy.series.limitseq import limit_seq
 from sympy.series.limitseq import difference_delta as dd
 from sympy.utilities.pytest import raises, XFAIL
@@ -112,3 +112,6 @@ def test_limit_seq_fail():
     e = (Sum(2**k*factorial(k) / k**2, (k, 1, 2*n)) /
          (Sum(4**k/k**2, (k, 1, n)) * Sum(factorial(k), (k, 1, 2*n))))
     assert limit_seq(e, n) == S(3) / 16
+
+def test_issue_14245():
+    assert limit_seq(sin(n)/cos(n)) == AccumBounds(-oo, oo)


### PR DESCRIPTION
Fixes #14245 .

`simplify` has been implemented in `_limit_seq` , in all those cases where the expression does not contain `Sum`.

**NOW**

```
>>> pprint(limit_seq(tan(n)))
<-∞, ∞>
>>> pprint(limit_seq(sin(n)/cos(n)))
<-∞, ∞>
```

@normalhuman @jksuom 
Please review.