### PR TITLE
Correct check for exp to use matrix exponentiation

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -230,6 +230,7 @@ class exp(ExpBase):
         from sympy.assumptions import ask, Q
         from sympy.calculus import AccumBounds
         from sympy.sets.setexpr import SetExpr
+        from sympy.matrices.matrices import MatrixBase
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -301,7 +302,7 @@ class exp(ExpBase):
             if out:
                 return Mul(*out)*cls(Add(*add), evaluate=False)
 
-        elif arg.is_Matrix:
+        elif isinstance(arg, MatrixBase):
             return arg.exp()
 
     @property

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -2,7 +2,7 @@ from sympy import (
     symbols, log, ln, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
     LambertW, sqrt, Rational, expand_log, S, sign, conjugate, refine,
     sin, cos, sinh, cosh, tanh, exp_polar, re, Function, simplify,
-    AccumBounds)
+    AccumBounds, MatrixSymbol)
 from sympy.abc import x, y, z
 
 
@@ -125,6 +125,11 @@ def test_exp_taylor_term():
     assert exp(x).taylor_term(1, x) == x
     assert exp(x).taylor_term(3, x) == x**3/6
     assert exp(x).taylor_term(4, x) == x**4/24
+
+
+def test_exp_MatrixSymbol():
+    A = MatrixSymbol("A", 2, 2)
+    assert exp(A).has(exp)
 
 
 def test_log_values():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14256. 

#### Brief description of what is fixed or changed

Currently, `exp(arg)` returns `arg.exp()` if `arg.is_Matrix` is true, so that the matrix exponential is taken. However, MatrixSymbol objects do not have `.exp()` method despite having `is_Matrix == True`. Since the matrix exponential method exp is implemented in MatrixBase class, it is better to check for `isinstance(arg, MatrixBase)`.