### PR TITLE
Abs of real powers can be applied to the base

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -480,7 +480,7 @@ class Abs(Function):
                 if base.is_negative:
                     return (-base)**re(exponent)*exp(-S.Pi*im(exponent))
                 return
-            elif exponent.is_real:
+            elif not base.has(Symbol) and exponent.is_real:
                 return Abs(base)**exponent
         if isinstance(arg, exp):
             return exp(re(arg.args[0]))

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -480,6 +480,8 @@ class Abs(Function):
                 if base.is_negative:
                     return (-base)**re(exponent)*exp(-S.Pi*im(exponent))
                 return
+            elif exponent.is_integer:
+                return Abs(base)**exponent
         if isinstance(arg, exp):
             return exp(re(arg.args[0]))
         if isinstance(arg, AppliedUndef):

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -480,7 +480,7 @@ class Abs(Function):
                 if base.is_negative:
                     return (-base)**re(exponent)*exp(-S.Pi*im(exponent))
                 return
-            elif exponent.is_integer:
+            elif exponent.is_real:
                 return Abs(base)**exponent
         if isinstance(arg, exp):
             return exp(re(arg.args[0]))

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -388,6 +388,8 @@ def test_Abs():
     x = Symbol('x', real=True)
     n = Symbol('n', integer=True)
     assert Abs((-1)**n) == 1
+    assert Abs(I**n) == 1  # issue 14260
+    assert Abs((3 + 4*I)**n) == 5**n
     assert x**(2*n) == Abs(x)**(2*n)
     assert Abs(x).diff(x) == sign(x)
     assert abs(x) == Abs(x)  # Python built-in

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -387,9 +387,11 @@ def test_Abs():
 
     x = Symbol('x', real=True)
     n = Symbol('n', integer=True)
+    z = Symbol('z')
     assert Abs((-1)**n) == 1
     assert Abs(I**n) == 1  # issue 14260
-    assert Abs((3 + 4*I)**n) == 5**n
+    assert Abs((3 + 4*I)**x) == 5**x
+    assert Abs(I**z).has(Abs)
     assert x**(2*n) == Abs(x)**(2*n)
     assert Abs(x).diff(x) == sign(x)
     assert abs(x) == Abs(x)  # Python built-in


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14260

#### Brief description of what is fixed or changed
 
The current implementation of `Abs(Pow(base, exponent))` evaluates it only if the base is real. But when the exponent is real,, it is always true that we get `Pow(Abs(base), exponent)`. For integer powers this is true because Abs is multiplicative; this extends to rationals by considering roots, and then to all real numbers by density. Alternatively, consider that `x**y` is `exp(y*log(x))`, and taking absolute value amounts to taking the real part of the exponent. When y is real, it can be pulled out of `re(y*log(x))`.

For example, `Abs(I**n)` now evaluates to 1 when n is an integer symbol. In current master it returns
`sqrt(I**n*(-I)**n)` which isn't as easy to SymPy algorithms (in particular, `limit_seq`) to deal with.

The change is not applied when base contains symbols, because it would not result in evaluation (`Abs(x**n)` versus `Abs(x)**n`) and because some methods, like  `_simplifyconds` in integral transforms, expect symbolic expressions with Abs to satisfy `isinstance(expr, Abs)` -- [an example](https://github.com/sympy/sympy/blob/master/sympy/integrals/transforms.py#L909).