### PR TITLE
Implement Kronecker product of Matrices

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2358,6 +2358,13 @@ def test_sympy__matrices__expressions__hadamard__HadamardProduct():
     Y = MatrixSymbol('Y', x, y)
     assert _test_args(HadamardProduct(X, Y))
 
+def test_sympy__matrices__expressions__kronecker__KroneckerProduct():
+    from sympy.matrices.expressions.kronecker import KroneckerProduct
+    from sympy.matrices.expressions import MatrixSymbol
+    X = MatrixSymbol('X', x, y)
+    Y = MatrixSymbol('Y', x, y)
+    assert _test_args(KroneckerProduct(X, Y))
+
 
 def test_sympy__matrices__expressions__matpow__MatPow():
     from sympy.matrices.expressions.matpow import MatPow

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -4,7 +4,7 @@ Includes functions for fast creating matrices like zero, one/eye, random
 matrix, etc.
 """
 from .matrices import (DeferredVector, ShapeError, NonSquareMatrixError,
-    MatrixBase)
+                       MatrixBase)
 
 from .dense import (
     GramSchmidt, Matrix, casoratian, diag, eye, hessian, jordan_cell,
@@ -21,7 +21,7 @@ SparseMatrix = MutableSparseMatrix
 from .immutable import ImmutableMatrix, ImmutableDenseMatrix, ImmutableSparseMatrix
 
 from .expressions import (MatrixSlice, BlockDiagMatrix, BlockMatrix,
-        FunctionMatrix, Identity, Inverse, MatAdd, MatMul, MatPow, MatrixExpr,
-        MatrixSymbol, Trace, Transpose, ZeroMatrix, blockcut, block_collapse,
-        matrix_symbols, Adjoint, hadamard_product, HadamardProduct,
-        Determinant, det, DiagonalMatrix, DiagonalOf, trace, DotProduct)
+                          FunctionMatrix, Identity, Inverse, MatAdd, MatMul, MatPow, MatrixExpr,
+                          MatrixSymbol, Trace, Transpose, ZeroMatrix, blockcut, block_collapse,
+                          matrix_symbols, Adjoint, hadamard_product, HadamardProduct,
+                          Determinant, det, DiagonalMatrix, DiagonalOf, trace, DotProduct, kronecker_product, KroneckerProduct)

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -16,4 +16,4 @@ from .adjoint import Adjoint
 from .hadamard import hadamard_product, HadamardProduct
 from .diagonal import DiagonalMatrix, DiagonalOf
 from .dotproduct import DotProduct
-from .kronecker import kronecker_product, KroneckerProduct
+from .kronecker import kronecker_product, KroneckerProduct, combine_kronecker

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -6,7 +6,7 @@ from .funcmatrix import FunctionMatrix
 from .inverse import Inverse
 from .matadd import MatAdd
 from .matexpr import (Identity, MatrixExpr, MatrixSymbol, ZeroMatrix,
-     matrix_symbols)
+                      matrix_symbols)
 from .matmul import MatMul
 from .matpow import MatPow
 from .trace import Trace, trace
@@ -16,3 +16,4 @@ from .adjoint import Adjoint
 from .hadamard import hadamard_product, HadamardProduct
 from .diagonal import DiagonalMatrix, DiagonalOf
 from .dotproduct import DotProduct
+from .kronecker import kronecker_product, KroneckerProduct

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -1,0 +1,252 @@
+"""Implementation of the Kronecker product"""
+
+from __future__ import print_function, division
+
+
+from sympy.core import Add, Mul, Pow, sympify, prod
+from sympy.core.compatibility import range
+from sympy.strategies import unpack, flatten, condition, exhaust, do_one
+
+from sympy.functions import adjoint
+from sympy.matrices.expressions.transpose import transpose
+
+from sympy.printing.pretty.stringpict import prettyForm
+from sympy.matrices.expressions.matexpr import MatrixExpr, ShapeError
+from sympy.matrices.matrices import MatrixBase
+
+
+def kronecker_product(*matrices):
+    """
+    The Kronecker product of two or more arguments.
+
+    Returns a symbolic ``KroneckerProduct`` object.
+
+    Examples
+    ========
+
+    >>> from sympy import pprint
+    >>> from sympy.matrices import kronecker_product, MatrixSymbol
+    >>> A = MatrixSymbol('A', 2, 2)
+    >>> B = MatrixSymbol('B', 2, 2)
+    >>> kronecker_product(A)
+    A
+    >>> kronecker_product(A, B)
+    AxB
+    >>> kronecker_product(A, B)[0, 1]
+    A[0, 0]*B[0, 1]
+    >>> pprint(kronecker_product(A, B).as_explicit(), use_unicode=True)
+    ⎡A₀₀⋅B₀₀  A₀₀⋅B₀₁  A₀₁⋅B₀₀  A₀₁⋅B₀₁⎤
+    ⎢                                  ⎥
+    ⎢A₀₀⋅B₁₀  A₀₀⋅B₁₁  A₀₁⋅B₁₀  A₀₁⋅B₁₁⎥
+    ⎢                                  ⎥
+    ⎢A₁₀⋅B₀₀  A₁₀⋅B₀₁  A₁₁⋅B₀₀  A₁₁⋅B₀₁⎥
+    ⎢                                  ⎥
+    ⎣A₁₀⋅B₁₀  A₁₀⋅B₁₁  A₁₁⋅B₁₀  A₁₁⋅B₁₁⎦
+    """
+    if not matrices:
+        raise TypeError("Empty Kronecker product is undefined")
+    validate(*matrices)
+    if len(matrices) == 1:
+        return matrices[0]
+    else:
+        return KroneckerProduct(*matrices).doit()
+
+
+class KroneckerProduct(MatrixExpr):
+    """
+    The Kronecker product is a non-commutative product of matrices.
+    Given two matrices of dimension (m, n) and (s, t) it produces a matrix
+    of of dimension (m s, n t).
+
+    This is a symbolic object that simply stores its argument without
+    evaluating it. To actually compute the product, use the function
+    ``kronecker_product()`` or call the the ``.doit()`` or  ``.as_explicit()``
+    methods.
+
+    >>> from sympy.matrices import kronecker_product, KroneckerProduct, MatrixSymbol
+    >>> A = MatrixSymbol('A', 5, 5)
+    >>> B = MatrixSymbol('B', 5, 5)
+    >>> isinstance(kronecker_product(A, B), KroneckerProduct)
+    True
+    """
+    is_KroneckerProduct = True
+
+    def __new__(cls, *args, **kwargs):
+        args = list(map(sympify, args))
+        check = kwargs.get('check', True)
+        if check:
+            validate(*args)
+        return super(KroneckerProduct, cls).__new__(cls, *args)
+
+    @property
+    def shape(self):
+        rows, cols = self.args[0].shape
+        for mat in self.args[1:]:
+            rows *= mat.rows
+            cols *= mat.cols
+        return (rows, cols)
+
+    def _entry(self, i, j):
+        result = 1
+        for mat in reversed(self.args):
+            i, m = divmod(i, mat.rows)
+            j, n = divmod(j, mat.cols)
+            result *= mat[m, n]
+        return result
+
+    def _eval_adjoint(self):
+        return KroneckerProduct(*list(map(adjoint, self.args))).doit()
+
+    def _eval_conjugate(self):
+        return KroneckerProduct(*[a.conjugate() for a in self.args]).doit()
+
+    def _eval_transpose(self):
+        return KroneckerProduct(*list(map(transpose, self.args))).doit()
+
+    def _eval_trace(self):
+        from .trace import trace
+        return prod(trace(a) for a in self.args)
+
+    def _eval_determinant(self):
+        from .determinant import det, Determinant
+        if not all(a.is_square for a in self.args):
+            return Determinant(self)
+
+        m = self.rows
+        return prod(det(a)**(m/a.rows) for a in self.args)
+
+    def _eval_inverse(self):
+        try:
+            return KroneckerProduct(*[a.inverse() for a in self.args])
+        except ShapeError:
+            from sympy.matrices.expressions.inverse import Inverse
+            return Inverse(self)
+
+    def doit(self, **kwargs):
+        deep = kwargs.get('deep', True)
+        if deep:
+            args = [arg.doit(**kwargs) for arg in self.args]
+        else:
+            args = self.args
+        return canonicalize(KroneckerProduct(*args))
+
+    def _sympystr(self, printer, *args):
+        from sympy.printing.str import sstr
+        length = len(self.args)
+        s = ''
+        for i in range(length):
+            if isinstance(self.args[i], (Add, Pow, Mul)):
+                s = s + '('
+            s = s + sstr(self.args[i])
+            if isinstance(self.args[i], (Add, Pow, Mul)):
+                s = s + ')'
+            if i != length - 1:
+                s = s + 'x'
+        return s
+
+    def _pretty(self, printer, *args):
+        length = len(self.args)
+        pform = printer._print('', *args)
+        for i in range(length):
+            next_pform = printer._print(self.args[i], *args)
+            if isinstance(self.args[i], (Add, Mul)):
+                next_pform = prettyForm(
+                    *next_pform.parens(left='(', right=')')
+                )
+            pform = prettyForm(*pform.right(next_pform))
+            if i != length - 1:
+                if printer._use_unicode:
+                    pform = prettyForm(
+                        *pform.right(u'\N{N-ARY CIRCLED TIMES OPERATOR}' + u' '))
+                else:
+                    pform = prettyForm(*pform.right('x' + ' '))
+        return pform
+
+    def _latex(self, printer, *args):
+        length = len(self.args)
+        s = ''
+        for i in range(length):
+            if isinstance(self.args[i], (Add, Mul)):
+                s = s + '\\left('
+            # The extra {} brackets are needed to get matplotlib's latex
+            # rendered to render this properly.
+            s = s + '{' + printer._print(self.args[i], *args) + '}'
+            if isinstance(self.args[i], (Add, Mul)):
+                s = s + '\\right)'
+            if i != length - 1:
+                s = s + '\\otimes '
+        return s
+
+
+def validate(*args):
+    if not all(arg.is_Matrix for arg in args):
+        raise TypeError("Mix of Matrix and Scalar symbols")
+
+
+def extract_commutative(kron):
+    c_part = []
+    nc_part = []
+    for arg in kron.args:
+        c, nc = arg.args_cnc()
+        c_part.extend(c)
+        nc_part.append(Mul._from_args(nc))
+
+    c_part = Mul(*c_part)
+    if c_part != 1:
+        return c_part*KroneckerProduct(*nc_part)
+    return kron
+
+
+def matrix_kronecker_product(*matrices):
+
+    # Make sure we have a sequence of Matrices
+    if not all(isinstance(m, MatrixBase) for m in matrices):
+        raise TypeError(
+            'Sequence of Matrices expected, got: %s' % repr(matrices)
+        )
+
+    # Pull out the first element in the product.
+    matrix_expansion = matrices[-1]
+    # Do the kronecker product working from right to left.
+    for mat in reversed(matrices[:-1]):
+        rows = mat.rows
+        cols = mat.cols
+        # Go through each row appending kronecker product to.
+        # running matrix_expansion.
+        for i in range(rows):
+            start = matrix_expansion*mat[i*cols]
+            # Go through each column joining each item
+            for j in range(cols - 1):
+                start = start.row_join(
+                    matrix_expansion*mat[i*cols + j + 1]
+                )
+            # If this is the first element, make it the start of the
+            # new row.
+            if i == 0:
+                next = start
+            else:
+                next = next.col_join(start)
+        matrix_expansion = next
+
+    MatrixClass = max(matrices, key=lambda M: M._class_priority).__class__
+    if isinstance(matrix_expansion, MatrixClass):
+        return matrix_expansion
+    else:
+        return MatrixClass(matrix_expansion)
+
+
+def explicit_kronecker_product(kron):
+    # Make sure we have a sequence of Matrices
+    if not all(isinstance(m, MatrixBase) for m in kron.args):
+        return kron
+
+    return matrix_kronecker_product(*kron.args)
+
+
+rules = (unpack,
+         explicit_kronecker_product,
+         flatten,
+         extract_commutative)
+
+canonicalize = exhaust(condition(lambda x: isinstance(x, KroneckerProduct),
+                                 do_one(*rules)))

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -15,6 +15,7 @@ from sympy.utilities import sift
 
 from .matadd import MatAdd
 from .matmul import MatMul
+from .matpow import MatPow
 
 
 def kronecker_product(*matrices):
@@ -200,6 +201,9 @@ class KroneckerProduct(MatrixExpr):
                 and self.cols == other.rows
                 and len(self.args) == len(other.args)
                 and all(a.cols == b.rows for (a, b) in zip(self.args, other.args)))
+
+    def _eval_expand_kroneckerproduct(self, **hints):
+        return flatten(canon(typed({KroneckerProduct: distribute(KroneckerProduct, MatAdd)}))(self))
 
     def _kronecker_add(self, other):
         if self.structurally_equal(other):

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -41,7 +41,7 @@ def kronecker_product(*matrices):
     >>> kronecker_product(A)
     A
     >>> kronecker_product(A, B)
-    AxB
+    KroneckerProduct(A, B)
     >>> kronecker_product(A, B)[0, 1]
     A[0, 0]*B[0, 1]
     >>> kronecker_product(A, B).as_explicit()
@@ -370,11 +370,11 @@ def combine_kronecker(expr):
     >>> A = MatrixSymbol('A', m, n)
     >>> B = MatrixSymbol('B', n, m)
     >>> combine_kronecker(KroneckerProduct(A, B)*KroneckerProduct(B, A))
-    (A*B)x(B*A)
+    KroneckerProduct(A*B, B*A)
     >>> combine_kronecker(KroneckerProduct(A, B)+KroneckerProduct(B.T, A.T))
-    (A + B.T)x(B + A.T)
+    KroneckerProduct(A + B.T, B + A.T)
     >>> combine_kronecker(KroneckerProduct(A, B)**m)
-    A**mxB**m
+    KroneckerProduct(A**m, B**m)
     """
     def haskron(expr):
         return isinstance(expr, MatrixExpr) and expr.has(KroneckerProduct)

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function
 from sympy.core import Add, Mul, Pow, prod, sympify
 from sympy.core.compatibility import range
 from sympy.functions import adjoint
-from sympy.matrices.expressions.matexpr import MatrixExpr, ShapeError
+from sympy.matrices.expressions.matexpr import MatrixExpr, ShapeError, Identity
 from sympy.matrices.expressions.transpose import transpose
 from sympy.matrices.matrices import MatrixBase
 from sympy.strategies import (
@@ -106,6 +106,13 @@ class KroneckerProduct(MatrixExpr):
 
     def __new__(cls, *args, **kwargs):
         args = list(map(sympify, args))
+        if all(a.is_Identity for a in args):
+            ret = Identity(prod(a.rows for a in args))
+            if all(isinstance(a, MatrixBase) for a in args):
+                return ret.as_explicit()
+            else:
+                return ret
+
         check = kwargs.get('check', True)
         if check:
             validate(*args)

--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -10,7 +10,6 @@ from sympy.strategies import unpack, flatten, condition, exhaust, do_one
 from sympy.functions import adjoint
 from sympy.matrices.expressions.transpose import transpose
 
-from sympy.printing.pretty.stringpict import prettyForm
 from sympy.matrices.expressions.matexpr import MatrixExpr, ShapeError
 from sympy.matrices.matrices import MatrixBase
 
@@ -129,54 +128,6 @@ class KroneckerProduct(MatrixExpr):
         else:
             args = self.args
         return canonicalize(KroneckerProduct(*args))
-
-    def _sympystr(self, printer, *args):
-        from sympy.printing.str import sstr
-        length = len(self.args)
-        s = ''
-        for i in range(length):
-            if isinstance(self.args[i], (Add, Pow, Mul)):
-                s = s + '('
-            s = s + sstr(self.args[i])
-            if isinstance(self.args[i], (Add, Pow, Mul)):
-                s = s + ')'
-            if i != length - 1:
-                s = s + 'x'
-        return s
-
-    def _pretty(self, printer, *args):
-        length = len(self.args)
-        pform = printer._print('', *args)
-        for i in range(length):
-            next_pform = printer._print(self.args[i], *args)
-            if isinstance(self.args[i], (Add, Mul)):
-                next_pform = prettyForm(
-                    *next_pform.parens(left='(', right=')')
-                )
-            pform = prettyForm(*pform.right(next_pform))
-            if i != length - 1:
-                if printer._use_unicode:
-                    pform = prettyForm(
-                        *pform.right(u'\N{N-ARY CIRCLED TIMES OPERATOR}' + u' '))
-                else:
-                    pform = prettyForm(*pform.right('x' + ' '))
-        return pform
-
-    def _latex(self, printer, *args):
-        length = len(self.args)
-        s = ''
-        for i in range(length):
-            if isinstance(self.args[i], (Add, Mul)):
-                s = s + '\\left('
-            # The extra {} brackets are needed to get matplotlib's latex
-            # rendered to render this properly.
-            s = s + '{' + printer._print(self.args[i], *args) + '}'
-            if isinstance(self.args[i], (Add, Mul)):
-                s = s + '\\right)'
-            if i != length - 1:
-                s = s + '\\otimes '
-        return s
-
 
 def validate(*args):
     if not all(arg.is_Matrix for arg in args):

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -22,6 +22,8 @@ def test_KroneckerProduct():
     assert isinstance(KroneckerProduct(A, B), KroneckerProduct)
     assert KroneckerProduct(A, B).subs(A, C) == KroneckerProduct(C, B)
     assert KroneckerProduct(A, C).shape == (n*m, m*k)
+    assert (KroneckerProduct(A, C) + KroneckerProduct(-A, C)).is_ZeroMatrix
+    assert (KroneckerProduct(W, Z) * KroneckerProduct(W.I, Z.I)).is_Identity
 
 
 def test_KroneckerProduct_identity():

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -1,5 +1,5 @@
-from sympy import I, symbols, Matrix
-from sympy.matrices import ShapeError, MatrixSymbol
+from sympy import I, symbols, Matrix, eye
+from sympy.matrices import ShapeError, MatrixSymbol, Identity
 from sympy.matrices.expressions import det, trace
 
 from sympy.matrices.expressions.kronecker import (KroneckerProduct,
@@ -22,6 +22,11 @@ def test_KroneckerProduct():
     assert isinstance(KroneckerProduct(A, B), KroneckerProduct)
     assert KroneckerProduct(A, B).subs(A, C) == KroneckerProduct(C, B)
     assert KroneckerProduct(A, C).shape == (n*m, m*k)
+
+
+def test_KroneckerProduct_identity():
+    assert KroneckerProduct(Identity(m), Identity(n)) == Identity(m*n)
+    assert KroneckerProduct(eye(2), eye(3)) == eye(6)
 
 
 def test_KroneckerProduct_explicit():

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -1,0 +1,112 @@
+from sympy import I, symbols, Matrix
+from sympy.matrices import ShapeError, MatrixSymbol
+from sympy.matrices.expressions import det, trace
+
+from sympy.matrices.expressions.kronecker import KroneckerProduct
+from sympy.matrices.expressions.kronecker import kronecker_product
+from sympy.core.trace import Tr
+
+mat1 = Matrix([[1, 2 * I], [1 + I, 3]])
+mat2 = Matrix([[2 * I, 3], [4 * I, 2]])
+
+n, m, k, x = symbols('n,m,k,x')
+Z = MatrixSymbol('Z', n, n)
+W = MatrixSymbol('W', m, m)
+A = MatrixSymbol('A', n, m)
+B = MatrixSymbol('B', n, m)
+C = MatrixSymbol('C', m, k)
+
+
+def test_KroneckerProduct():
+    assert isinstance(KroneckerProduct(A, B), KroneckerProduct)
+    assert KroneckerProduct(A, B).subs(A, C) == KroneckerProduct(C, B)
+    assert KroneckerProduct(A, C).shape == (n*m, m*k)
+
+
+def test_KroneckerProduct_explicit():
+    X = MatrixSymbol('X', 2, 2)
+    Y = MatrixSymbol('Y', 2, 2)
+    kp = KroneckerProduct(X, Y)
+    assert kp.shape == (4, 4)
+    assert kp.as_explicit() == Matrix(
+        [
+            [X[0, 0]*Y[0, 0], X[0, 0]*Y[0, 1], X[0, 1]*Y[0, 0], X[0, 1]*Y[0, 1]],
+            [X[0, 0]*Y[1, 0], X[0, 0]*Y[1, 1], X[0, 1]*Y[1, 0], X[0, 1]*Y[1, 1]],
+            [X[1, 0]*Y[0, 0], X[1, 0]*Y[0, 1], X[1, 1]*Y[0, 0], X[1, 1]*Y[0, 1]],
+            [X[1, 0]*Y[1, 0], X[1, 0]*Y[1, 1], X[1, 1]*Y[1, 0], X[1, 1]*Y[1, 1]]
+        ]
+    )
+
+
+def test_tensor_product_adjoint():
+    assert KroneckerProduct(I*A, B).adjoint() == \
+        -I*KroneckerProduct(A.adjoint(), B.adjoint())
+    assert KroneckerProduct(mat1, mat2).adjoint() == \
+        kronecker_product(mat1.adjoint(), mat2.adjoint())
+
+
+def test_tensor_product_conjugate():
+    assert KroneckerProduct(I*A, B).conjugate() == \
+        -I*KroneckerProduct(A.conjugate(), B.conjugate())
+    assert KroneckerProduct(mat1, mat2).conjugate() == \
+        kronecker_product(mat1.conjugate(), mat2.conjugate())
+
+
+def test_tensor_product_transpose():
+    assert KroneckerProduct(I*A, B).transpose() == \
+        I*KroneckerProduct(A.transpose(), B.transpose())
+    assert KroneckerProduct(mat1, mat2).transpose() == \
+        kronecker_product(mat1.transpose(), mat2.transpose())
+
+
+def test_KroneckerProduct_is_associative():
+    assert kronecker_product(A, kronecker_product(
+        B, C)) == kronecker_product(kronecker_product(A, B), C)
+    assert kronecker_product(A, kronecker_product(
+        B, C)) == KroneckerProduct(A, B, C)
+
+
+def test_KroneckerProduct_is_bilinear():
+    assert kronecker_product(x*A, B) == x*kronecker_product(A, B)
+    assert kronecker_product(A, x*B) == x*kronecker_product(A, B)
+
+
+def test_KroneckerProduct_determinant():
+    kp = kronecker_product(W, Z)
+    assert det(kp) == det(W)**n * det(Z)**m
+
+
+def test_KroneckerProduct_trace():
+    kp = kronecker_product(W, Z)
+    assert trace(kp) == trace(W)*trace(Z)
+
+
+def test_KroneckerProduct_isnt_commutative():
+    assert KroneckerProduct(A, B) != KroneckerProduct(B, A)
+    assert KroneckerProduct(A, B).is_commutative is False
+
+
+def test_KroneckerProduct_extracts_commutative_part():
+    assert kronecker_product(x * A, 2 * B) == x * \
+        2 * KroneckerProduct(A, B)
+
+
+def test_KroneckerProduct_inverse():
+    kp = kronecker_product(W, Z)
+    assert kp.inverse() == kronecker_product(W.inverse(), Z.inverse())
+
+
+# def test_kronecker_product_expand():
+#     assert KroneckerProduct(A + B, B + C).expand(kroneckerproduct=True) == \
+#         KroneckerProduct(A, B) + KroneckerProduct(A, C) + KroneckerProduct(B, B) + KroneckerProduct(B, C)
+
+
+# def test_kronecker_product_simp():
+#     assert kronecker_product_simp(KroneckerProduct(A, B) * KroneckerProduct(B, C)) == KroneckerProduct(A * B, B * C)
+#     # tests for Pow-expressions
+#     assert kronecker_product_simp(KroneckerProduct(A, B)**x) == KroneckerProduct(A**x, B**x)
+#     assert kronecker_product_simp(x * KroneckerProduct(A, B)**2) == x * KroneckerProduct(A**2, B**2)
+#     assert kronecker_product_simp(
+#         x * (KroneckerProduct(A, B)**2) * KroneckerProduct(C, D)) == x * KroneckerProduct(A**2 * C, B**2 * D)
+#     assert kronecker_product_simp(KroneckerProduct(A, B) - KroneckerProduct(C, D)**x) == KroneckerProduct(A, B) - KroneckerProduct(
+#         C**x, D**x)

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -2,8 +2,9 @@ from sympy import I, symbols, Matrix
 from sympy.matrices import ShapeError, MatrixSymbol
 from sympy.matrices.expressions import det, trace
 
-from sympy.matrices.expressions.kronecker import KroneckerProduct
-from sympy.matrices.expressions.kronecker import kronecker_product
+from sympy.matrices.expressions.kronecker import (KroneckerProduct,
+                                                  kronecker_product,
+                                                  combine_kronecker)
 from sympy.core.trace import Tr
 
 mat1 = Matrix([[1, 2 * I], [1 + I, 3]])
@@ -96,9 +97,29 @@ def test_KroneckerProduct_inverse():
     assert kp.inverse() == kronecker_product(W.inverse(), Z.inverse())
 
 
-# def test_kronecker_product_expand():
-#     assert KroneckerProduct(A + B, B + C).expand(kroneckerproduct=True) == \
-#         KroneckerProduct(A, B) + KroneckerProduct(A, C) + KroneckerProduct(B, B) + KroneckerProduct(B, C)
+def test_KroneckerProduct_combine_add():
+    kp1 = kronecker_product(A, B)
+    kp2 = kronecker_product(C, W)
+    assert combine_kronecker(kp1*kp2) == kronecker_product(A*C, B*W)
+
+
+def test_KroneckerProduct_combine_mul():
+    X = MatrixSymbol('X', m, n)
+    Y = MatrixSymbol('Y', m, n)
+    kp1 = kronecker_product(A, X)
+    kp2 = kronecker_product(B, Y)
+    assert combine_kronecker(kp1+kp2) == kronecker_product(A+B, X+Y)
+
+
+def test_KroneckerProduct_combine_pow():
+    X = MatrixSymbol('X', n, n)
+    Y = MatrixSymbol('Y', n, n)
+    assert combine_kronecker(KroneckerProduct(
+        X, Y)**x) == KroneckerProduct(X**x, Y**x)
+    assert combine_kronecker(x * KroneckerProduct(X, Y)
+                             ** 2) == x * KroneckerProduct(X**2, Y**2)
+    assert combine_kronecker(
+        x * (KroneckerProduct(X, Y)**2) * KroneckerProduct(A, B)) == x * KroneckerProduct(X**2 * A, Y**2 * B)
 
 
 # def test_kronecker_product_simp():

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -122,12 +122,10 @@ def test_KroneckerProduct_combine_pow():
         x * (KroneckerProduct(X, Y)**2) * KroneckerProduct(A, B)) == x * KroneckerProduct(X**2 * A, Y**2 * B)
 
 
-# def test_kronecker_product_simp():
-#     assert kronecker_product_simp(KroneckerProduct(A, B) * KroneckerProduct(B, C)) == KroneckerProduct(A * B, B * C)
-#     # tests for Pow-expressions
-#     assert kronecker_product_simp(KroneckerProduct(A, B)**x) == KroneckerProduct(A**x, B**x)
-#     assert kronecker_product_simp(x * KroneckerProduct(A, B)**2) == x * KroneckerProduct(A**2, B**2)
-#     assert kronecker_product_simp(
-#         x * (KroneckerProduct(A, B)**2) * KroneckerProduct(C, D)) == x * KroneckerProduct(A**2 * C, B**2 * D)
-#     assert kronecker_product_simp(KroneckerProduct(A, B) - KroneckerProduct(C, D)**x) == KroneckerProduct(A, B) - KroneckerProduct(
-#         C**x, D**x)
+def test_KroneckerProduct_expand():
+    X = MatrixSymbol('X', n, n)
+    Y = MatrixSymbol('Y', n, n)
+
+    assert KroneckerProduct(X + Y, Y + Z).expand(kroneckerproduct=True) == \
+        KroneckerProduct(X, Y) + KroneckerProduct(X, Z) + \
+        KroneckerProduct(Y, Y) + KroneckerProduct(Y, Z)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1489,6 +1489,15 @@ class LatexPrinter(Printer):
             return self._print(x)
         return r' \circ '.join(map(parens, expr.args))
 
+    def _print_KroneckerProduct(self, expr):
+        from sympy import Add, MatAdd, MatMul
+
+        def parens(x):
+            if isinstance(x, (Add, MatAdd, MatMul)):
+                return r"\left(%s\right)" % self._print(x)
+            return self._print(x)
+        return r' \otimes '.join(map(parens, expr.args))
+
     def _print_MatPow(self, expr):
         base, exp = expr.base, expr.exp
         from sympy.matrices import MatrixSymbol

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -41,6 +41,7 @@ PRECEDENCE_VALUES = {
     "MatMul": PRECEDENCE["Mul"],
     "MatPow": PRECEDENCE["Pow"],
     "HadamardProduct": PRECEDENCE["Mul"],
+    "KroneckerProduct": PRECEDENCE["Mul"],
     "Equality": PRECEDENCE["Mul"],
     "Unequality": PRECEDENCE["Mul"],
 }

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -857,6 +857,15 @@ class PrettyPrinter(Printer):
         return self._print_seq(expr.args, None, None, delim,
                 parenthesize=lambda x: isinstance(x, (MatAdd, MatMul)))
 
+    def _print_KroneckerProduct(self, expr):
+        from sympy import MatAdd, MatMul
+        if self._use_unicode:
+            delim = u' \N{N-ARY CIRCLED TIMES OPERATOR} '
+        else:
+            delim = 'x'
+        return self._print_seq(expr.args, None, None, delim,
+                parenthesize=lambda x: isinstance(x, (MatAdd, MatMul)))
+
     _print_MatrixSymbol = _print_Symbol
 
     def _print_FunctionMatrix(self, X):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -862,7 +862,7 @@ class PrettyPrinter(Printer):
         if self._use_unicode:
             delim = u' \N{N-ARY CIRCLED TIMES OPERATOR} '
         else:
-            delim = 'x'
+            delim = ' x '
         return self._print_seq(expr.args, None, None, delim,
                 parenthesize=lambda x: isinstance(x, (MatAdd, MatMul)))
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -311,10 +311,6 @@ class StrPrinter(Printer):
         return '.*'.join([self.parenthesize(arg, precedence(expr))
             for arg in expr.args])
 
-    def _print_KroneckerProduct(self, expr):
-        return 'x'.join([self.parenthesize(arg, precedence(expr))
-            for arg in expr.args])
-
     def _print_MatAdd(self, expr):
         return ' + '.join([self.parenthesize(arg, precedence(expr))
             for arg in expr.args])

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -311,6 +311,10 @@ class StrPrinter(Printer):
         return '.*'.join([self.parenthesize(arg, precedence(expr))
             for arg in expr.args])
 
+    def _print_KroneckerProduct(self, expr):
+        return 'x'.join([self.parenthesize(arg, precedence(expr))
+            for arg in expr.args])
+
     def _print_MatAdd(self, expr):
         return ' + '.join([self.parenthesize(arg, precedence(expr))
             for arg in expr.args])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

This pull request adds a `MatrixExpr` class which represents the [Kronecker product](https://en.wikipedia.org/wiki/Kronecker_product) of matrices.

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
This PR can be seen as a stepping stone to resolving #10771, #10734 , and  #11832 but these commits do not touch the `physics.quantum.tensorproduct` module.


#### Brief description of what is fixed or changed

Add in this PR is the `sympy.matrices.expressions.kronecker` module which exports

* The `kronecker_product()` function, *which attempts to take the Kronecker product of its arguments*
* The `KroneckerProduct` class, *which represents and unevaluated Kronecker product of matrices*
* The `combine_kronecker()` function, *which attempts to combine operations on Kronecker products into Kronecker products of those operations*

The only changes to existing modules in this PR are to add KroneckerProduct to the printing systems and to import the aforementioned functions and class into the `sympy.matrices.expressions` module.
