### PR TITLE
One cannot import xrange from core.compatibility anymore

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -45,8 +45,8 @@ Moved modules:
     * Python 2 `__builtins__`, access with Python 3 name, `builtins`
 
 Iterator/list changes:
-    * `xrange` removed in Python 3, import `xrange` for Python 2/3 compatible
-      iterator version of range
+    * `xrange` renamed as `range` in Python 3, import `range` for Python 2/3
+      compatible iterator version of range.
 
 exec:
     * Use `exec_()`, with parameters `exec_(code, globs=None, locs=None)`


### PR DESCRIPTION
xrange was removed from SymPy codebase in #8936, and compatibility.py no longer defines it. So it should not recommend importing it, either.