### PR TITLE
Corrected latex printing of units containing underscores

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2109,7 +2109,7 @@ class LatexPrinter(Printer):
     def _print_Quantity(self, expr):
         if expr.name.name == 'degree':
             return r"^\circ"
-        return r"%s" % expr
+        return r"\detokenize {%s}" % expr
 
 def translate(s):
     r'''

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -32,7 +32,7 @@ from sympy.functions import DiracDelta, Heaviside, KroneckerDelta, LeviCivita
 from sympy.logic import Implies
 from sympy.logic.boolalg import And, Or, Xor
 from sympy.physics.quantum import Commutator, Operator
-from sympy.physics.units import degree, radian, kg, meter
+from sympy.physics.units import degree, radian, kg, meter, R
 from sympy.core.trace import Tr
 from sympy.core.compatibility import range
 from sympy.combinatorics.permutations import Cycle, Permutation
@@ -1737,8 +1737,10 @@ def test_WedgeProduct_printing():
 
 
 def test_units():
-    expr = 2*kg*x*meter**2
-    assert latex(expr, mul_symbol='dot') == r'2 \cdot x \cdot kilogram \cdot meter^{2}'
+    expr1 = 2*kg*x*meter**2
+    assert latex(expr1, mul_symbol='dot') == (r'2 \cdot x \cdot \detokenize {kilogram} \cdot \detokenize {meter}^{2}')
+    expr2 = 3*R
+    assert latex(expr2, mul_symbol='dot') == r'3 \cdot \detokenize {molar_gas_constant}'
 
 
 def test_latex_degree():


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Units containing underscores were incorrectly printed in latex as the character next to underscore was subscipted. Therefore used `\detokenize` before unit name.

