### PR TITLE
kinematic_equation returns zero if speeds are zero

### DIFF
--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -280,6 +280,8 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
         w1, w2, w3 = speeds
         s1, s2, s3 = [sin(q1), sin(q2), sin(q3)]
         c1, c2, c3 = [cos(q1), cos(q2), cos(q3)]
+        if w1==w2==w3==0:
+            return [0,0,0]
         if rot_type.lower() == 'body':
             if rot_order == '123':
                 return [q1d - (w1 * c3 - w2 * s3) / c2, q2d - w1 * s3 - w2 *

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -280,7 +280,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
         w1, w2, w3 = speeds
         s1, s2, s3 = [sin(q1), sin(q2), sin(q3)]
         c1, c2, c3 = [cos(q1), cos(q2), cos(q3)]
-        if w1==w2==w3==0:
+        if w1==w2==w3==0: #if speeds are all zero
             return [0,0,0]
         if rot_type.lower() == 'body':
             if rot_order == '123':

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -810,25 +810,17 @@ class LatexPrinter(Printer):
 
         return tex
 
-    def _print_Min(self, expr, exp=None):
+    def _hprint_variadic_function(self, expr, exp=None):
         args = sorted(expr.args, key=default_sort_key)
         texargs = [r"%s" % self._print(symbol) for symbol in args]
-        tex = r"\min\left(%s\right)" % ", ".join(texargs)
+        tex = r"\%s\left(%s\right)" % (self._print((str(expr.func)).lower()), ", ".join(texargs))
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
         else:
             return tex
 
-    def _print_Max(self, expr, exp=None):
-        args = sorted(expr.args, key=default_sort_key)
-        texargs = [r"%s" % self._print(symbol) for symbol in args]
-        tex = r"\max\left(%s\right)" % ", ".join(texargs)
-
-        if exp is not None:
-            return r"%s^{%s}" % (tex, exp)
-        else:
-            return tex
+    _print_Min = _print_Max = _hprint_variadic_function
 
     def _print_floor(self, expr, exp=None):
         tex = r"\lfloor{%s}\rfloor" % self._print(expr.args[0])
@@ -981,13 +973,15 @@ class LatexPrinter(Printer):
         else:
             return r"\operatorname{B}%s" % tex
 
-    def _print_gamma(self, expr, exp=None):
+    def _hprint_one_args_func(self, expr, exp=None):
         tex = r"\left(%s\right)" % self._print(expr.args[0])
 
         if exp is not None:
-            return r"\Gamma^{%s}%s" % (exp, tex)
+            return r"%s^{%s}%s" % (self._print(expr.func), exp, tex)
         else:
-            return r"\Gamma%s" % tex
+            return r"%s%s" % (self._print(expr.func), tex)
+
+    _print_gamma = _hprint_one_args_func
 
     def _print_uppergamma(self, expr, exp=None):
         tex = r"\left(%s, %s\right)" % (self._print(expr.args[0]),


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
earlier kinematic equations returned a non-zero vector if the speeds were zero. Now if the speeds are zero kinematic_equation returns a zero vector.
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
fixes #12600 