### PR TITLE
Added Deprecation Warnings in stats module

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -13,6 +13,7 @@ sympy.stats.rv_interface
 """
 
 from __future__ import print_function, division
+import warnings
 
 from sympy import (Basic, S, Expr, Symbol, Tuple, And, Add, Eq, lambdify,
         Equality, Lambda, DiracDelta, sympify)
@@ -21,6 +22,7 @@ from sympy.core.compatibility import string_types
 from sympy.logic.boolalg import Boolean
 from sympy.solvers.solveset import solveset
 from sympy.sets.sets import FiniteSet, ProductSet, Intersection
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.abc import x
 
 
@@ -562,6 +564,12 @@ def expectation(expr, condition=None, numsamples=None, evaluate=True, **kwargs):
     5
     """
 
+    if numsamples is not None:
+            SymPyDeprecationWarning(
+                            feature="numsamples parameter no longer needed",
+                            issue=14261,
+                            deprecated_since_version="1.2").warn()
+
     if not random_symbols(expr):  # expr isn't random?
         return expr
     if numsamples:  # Computing by monte carlo sampling?
@@ -619,6 +627,12 @@ def probability(condition, given_condition=None, numsamples=None,
 
     condition = sympify(condition)
     given_condition = sympify(given_condition)
+
+    if numsamples is not None:
+            SymPyDeprecationWarning(
+                            feature="numsamples parameter no longer needed",
+                            issue=14261,
+                            deprecated_since_version="1.2").warn()
 
     if given_condition is not None and \
             not isinstance(given_condition, (Relational, Boolean)):
@@ -715,6 +729,12 @@ def density(expr, condition=None, evaluate=True, numsamples=None, **kwargs):
     >>> density(X)(x)
     sqrt(2)*exp(-x**2/2)/(2*sqrt(pi))
     """
+
+    if numsamples is not None:
+            SymPyDeprecationWarning(
+                            feature="numsamples parameter no longer needed",
+                            issue=14261,
+                            deprecated_since_version="1.2").warn()
 
     if numsamples:
         return sampling_density(expr, condition, numsamples=numsamples,
@@ -842,6 +862,13 @@ def sample(expr, condition=None, **kwargs):
 
     >>> die_roll = sample(X + Y + Z) # A random realization of three dice
     """
+
+    if condition is not None:
+            SymPyDeprecationWarning(
+                            feature="sample method no longer needed",
+                            issue=14261,
+                            deprecated_since_version="1.2").warn()
+
     return next(sample_iter(expr, condition, numsamples=1))
 
 
@@ -872,6 +899,13 @@ def sample_iter(expr, condition=None, numsamples=S.Infinity, **kwargs):
     sample_iter_subs
     """
     # lambdify is much faster but not as robust
+
+    if condition is not None and numsamples is not S.Infinity:
+            SymPyDeprecationWarning(
+                            feature="sample_iter method no longer needed",
+                            issue=14261,
+                            deprecated_since_version="1.2").warn()
+
     try:
         return sample_iter_lambdify(expr, condition, numsamples, **kwargs)
     # use subs when lambdify fails

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -1,3 +1,4 @@
+import warnings
 from sympy.core.compatibility import range
 from sympy import (FiniteSet, S, Symbol, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, Or, Dict, sympify, binomial,
@@ -10,6 +11,7 @@ from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial,
     correlation, moment, cmoment, smoment, characteristic_function)
 from sympy.stats.frv_types import DieDistribution
 from sympy.utilities.pytest import raises, slow
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.abc import p, x, i
 
 oo = S.Infinity
@@ -97,10 +99,12 @@ def test_dice():
 
 
 def test_given():
-    X = Die('X', 6)
-    assert density(X, X > 5) == {S(6): S(1)}
-    assert where(X > 2, X > 5).as_boolean() == Eq(X.symbol, 6)
-    assert sample(X, X > 5) == 6
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        X = Die('X', 6)
+        assert density(X, X > 5) == {S(6): S(1)}
+        assert where(X > 2, X > 5).as_boolean() == Eq(X.symbol, 6)
+        assert sample(X, X > 5) == 6
 
 
 def test_domains():

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import warnings
 from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic,
         DiracDelta)
@@ -8,6 +9,7 @@ from sympy.stats import (Die, Normal, Exponential, FiniteRV, P, E, variance, cov
 from sympy.stats.rv import (ProductPSpace, rs_swap, Density, NamedArgsMixin,
         RandomSymbol, PSpace)
 from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.compatibility import range
 from sympy.abc import x
 
@@ -109,28 +111,31 @@ def test_E():
 
 
 def test_Sample():
-    X = Die('X', 6)
-    Y = Normal('Y', 0, 1)
-    z = Symbol('z')
+    #issue-14261
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+        X = Die('X', 6)
+        Y = Normal('Y', 0, 1)
+        z = Symbol('z')
 
-    assert sample(X) in [1, 2, 3, 4, 5, 6]
-    assert sample(X + Y).is_Float
+        assert sample(X) in [1, 2, 3, 4, 5, 6]
+        assert sample(X + Y).is_Float
 
-    P(X + Y > 0, Y < 0, numsamples=10).is_number
-    assert E(X + Y, numsamples=10).is_number
-    assert variance(X + Y, numsamples=10).is_number
+        P(X + Y > 0, Y < 0, numsamples=10).is_number
+        assert E(X + Y, numsamples=10).is_number
+        assert variance(X + Y, numsamples=10).is_number
 
-    raises(ValueError, lambda: P(Y > z, numsamples=5))
+        raises(ValueError, lambda: P(Y > z, numsamples=5))
 
-    assert P(sin(Y) <= 1, numsamples=10) == 1
-    assert P(sin(Y) <= 1, cos(Y) < 1, numsamples=10) == 1
+        assert P(sin(Y) <= 1, numsamples=10) == 1
+        assert P(sin(Y) <= 1, cos(Y) < 1, numsamples=10) == 1
 
-    # Make sure this doesn't raise an error
-    E(Sum(1/z**Y, (z, 1, oo)), Y > 2, numsamples=3)
+        # Make sure this doesn't raise an error
+        E(Sum(1/z**Y, (z, 1, oo)), Y > 2, numsamples=3)
 
 
-    assert all(i in range(1, 7) for i in density(X, numsamples=10))
-    assert all(i in range(4, 7) for i in density(X, X>3, numsamples=10))
+        assert all(i in range(1, 7) for i in density(X, numsamples=10))
+        assert all(i in range(4, 7) for i in density(X, X>3, numsamples=10))
 
 
 def test_given():


### PR DESCRIPTION
Fixes #14261 .

This PR adds `SympyDeprecationWarnings` to five methods of the `stats` module, namely the `probability`, `expectation`, `density`, `sample` and `sample_iter` methods.
Feature message have been included, and `test_rv.py` has been infused with the code -

```
with warnings.catch_warnings():
        warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
```
