### PR TITLE
sign of number ignored

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2387,10 +2387,6 @@ class AlgebraicNumber(Expr):
             rep = DMP.from_list([1, 0], 0, dom)
             scoeffs = Tuple(1, 0)
 
-            if root.is_negative:
-                rep = -rep
-                scoeffs = Tuple(-1, 0)
-
         sargs = (root, scoeffs)
 
         if alias is not None:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -587,7 +587,8 @@ def test_issue_14289():
 
     a = 1 - sqrt(2)
     b = to_number_field(a)
-    assert b.args[0] == a
+    assert b.as_expr() == a
+    assert b.minpoly(a).expand() == 0
 
 
 def test_Float_from_tuple():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -582,6 +582,14 @@ def test_Float_issue_2107():
     assert S.Zero + b + (-b) == 0
 
 
+def test_issue_14289():
+    from sympy.polys.numberfields import to_number_field
+
+    a = 1 - sqrt(2)
+    b = to_number_field(a)
+    assert b.args[0] == a
+
+
 def test_Float_from_tuple():
     a = Float((0, '1L', 0, 1))
     b = Float((0, '1', 0, 1))

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -591,7 +591,7 @@ def test_AlgebraicNumber():
     assert a.is_aliased is False
 
     assert AlgebraicNumber( sqrt(3)).rep == DMP([ QQ(1), QQ(0)], QQ)
-    assert AlgebraicNumber(-sqrt(3)).rep == DMP([-QQ(1), QQ(0)], QQ)
+    assert AlgebraicNumber(-sqrt(3)).rep == DMP([ QQ(1), QQ(0)], QQ)
 
     a = AlgebraicNumber(sqrt(2))
     b = AlgebraicNumber(sqrt(2))


### PR DESCRIPTION
Sign change in `AlgebraicNumber` ignored(code for negative root is removed).

Fixes #14289 

@jksuom @skirpichev Please review!