### PR TITLE
Mention expand_log in the docstring of logcombine

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -908,6 +908,8 @@ def logcombine(expr, force=False):
     See Also
     ========
     posify: replace all symbols with symbols having positive assumptions
+    sympy.core.function.expand_log: expand the logarithms of products
+        and powers; the opposite of logcombine
 
     """
 


### PR DESCRIPTION
The [documentation of simplify module](http://docs.sympy.org/dev/modules/simplify/simplify.html) mentions logcombine but not its opposite, expand_log. Often it's `expand_log` that one needs to simplify an expression with logarithms. Added a reference to `expand_log` to the "See Also" section of logcombine docstring.

