### PR TITLE
[WIP] Better dispatch of functions in ring series module

### DIFF
--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -9,11 +9,12 @@ from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
     rs_LambertW, rs_series_reversion, rs_is_puiseux, rs_series)
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
+from sympy.core.function import Function, expand
 from sympy.core.symbol import symbols
 from sympy.functions import (sin, cos, exp, tan, cot, atan, asin, atanh,
-    tanh, log, sqrt)
+    sinh, cosh, tanh, log, sqrt, LambertW)
 from sympy.core.numbers import Rational
-from sympy.core import expand
+from sympy.core.singleton import S
 
 def is_close(a, b):
     tol = 10**(-10)
@@ -629,3 +630,12 @@ def test_rs_series():
     assert rs_series(log(1 + x*a**2), x, 7).as_expr() == -x**6*a**12/6 + \
                     x**5*a**10/5 - x**4*a**8/4 + x**3*a**6/3 - \
                     x**2*a**4/2 + x*a**2
+
+    for f in [asin, atan, atanh, cosh, cot, sinh, tanh]:
+        assert rs_series(f(x), x, 5).as_expr() == f(x).series(x, 0, 5).removeO()
+
+    assert rs_series(LambertW(x), x, 6).as_expr() == \
+        S(125)/24*x**5 - S(8)/3*x**4 + S(3)/2*x**3 - x**2 + x
+
+    mycos = Function("cos")
+    raises(NotImplementedError, lambda: rs_series(mycos(x), x, 5))


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Currently, `rs_series` (ring-based expansion in a power series) dispatches a function func to `rs_func` based on str(func) being in the `_convert_func` dictionary. This has several drawbacks:

1. The dictionary has to be updated every time a new rs_func is added, and this has not happened for several of the already implemented functions;
2. If a user defines own function with matching name, the expansion will be applied to it.
3. If a function is not found in the dictionary, an unhandled KeyError is thrown.

All are corrected here. The dictionary is replaced by a lookup for `"rs_" + func.__name__` in globals(). (It would be better if these were methods of some object, but this would require refactoring and deprecation.) Undefined functions, as well as the functions for which no `rs_func` exists, raise NotImplementedError.

