### PR TITLE
Simple optimization to speed up LCM

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -391,7 +391,7 @@ def ilcm(*args):
         return 0
     a = args[0]
     for b in args[1:]:
-        a = a*b // igcd(a, b)
+        a = a // igcd(a, b) * b # since gcd(a,b) | a
     return a
 
 
@@ -1862,7 +1862,7 @@ class Rational(Number):
     def lcm(self, other):
         if isinstance(other, Rational):
             return Rational(
-                self.p*other.p//igcd(self.p, other.p),
+                self.p // igcd(self.p, other.p) * other.p,
                 igcd(self.q, other.q))
         return Number.lcm(self, other)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1337,6 +1337,8 @@ def test_Rational_gcd_lcm_cofactors():
     assert Integer(4).lcm(2) == Integer(4)
     assert Integer(4).gcd(Integer(2)) == Integer(2)
     assert Integer(4).lcm(Integer(2)) == Integer(4)
+    a, b = 720**99911, 480**12342
+    assert Integer(a).lcm(b) == a*b/Integer(a).gcd(b)
 
     assert Integer(4).gcd(3) == Integer(1)
     assert Integer(4).lcm(3) == Integer(12)
@@ -1355,6 +1357,7 @@ def test_Rational_gcd_lcm_cofactors():
     assert Rational(4, 3).lcm(Rational(2, 9)) == Rational(4, 3)
     assert Rational(4, 5).gcd(Rational(2, 9)) == Rational(2, 45)
     assert Rational(4, 5).lcm(Rational(2, 9)) == Integer(4)
+    assert Rational(5, 9).lcm(Rational(3, 7)) == Rational(Integer(5).lcm(3),Integer(9).gcd(7))
 
     assert Integer(4).cofactors(2) == (Integer(2), Integer(2), Integer(1))
     assert Integer(4).cofactors(Integer(2)) == \


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Changed computation of `lcm(a,b)` from `a * b // gcd(a,b)` to `a // gcd(a,b) * b`, for LCM computation of integers `Z` and rational numbers `Q`.

**Performance Difference**:
The speed-up is very subtle for ordinary usage, but the difference becomes more evident when the numbers involved become very large.

**Tests**:
I ran 3 tests locally for lcm of pair of integers:
Test 1: `10**5` random pairs of `2048-bit` numbers, the former finished in `40s`, and the latter in `38s`.
Test 2: `10**4` random pairs of `8192-bit` numbers, the former finished in `32s`, and the latter in `31s`.
Test 3: `720**99911` and `480**12342`, the former finished in `0.6s`, and the latter in `0.55s`.

@normalhuman @jksuom Please review.