### PR TITLE
Inverse trigonometric evaluation for compatible arguments

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1568,6 +1568,7 @@ def test_issue_14320():
     assert asin(cos(2)) == -2 + pi/2 and (-pi/2 <= -2 + pi/2 <= pi/2) and cos(2) == sin(-2 + pi/2)
     assert acos(sin(2)) == -pi/2 + 2 and (0 <= -pi/2 + 2 <= pi) and sin(2) == cos(-pi/2 + 2)
     assert acos(cos(20)) == -6*pi + 20 and (0 <= -6*pi + 20 <= pi) and cos(20) == cos(-6*pi + 20)
+    assert acos(cos(30)) == -30 + 10*pi and (0 <= -30 + 10*pi <= pi) and cos(30) == cos(-30 + 10*pi)
 
     assert atan(tan(17)) == -5*pi + 17 and (-pi/2 < -5*pi + 17 < pi/2) and tan(17) == tan(-5*pi + 17)
     assert atan(cot(12)) == -12 + 7*pi/2 and (-pi/2 < -12 + 7*pi/2 < pi/2) and cot(12) == tan(-12 + 7*pi/2)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1573,8 +1573,8 @@ def test_issue_14320():
     assert atan(tan(17)) == -5*pi + 17 and (-pi/2 < -5*pi + 17 < pi/2) and tan(17) == tan(-5*pi + 17)
     assert atan(tan(15)) == -5*pi + 15 and (-pi/2 < -5*pi + 15 < pi/2) and tan(15) == tan(-5*pi + 15)
     assert atan(cot(12)) == -12 + 7*pi/2 and (-pi/2 < -12 + 7*pi/2 < pi/2) and cot(12) == tan(-12 + 7*pi/2)
-    assert acot(cot(15)) == -4*pi + 15 and (0 < -4*pi + 15 < pi) and cot(15) == cot(-4*pi + 15)
-    assert acot(tan(19)) == -19 + 13*pi/2 and (0 < -19 + 13*pi/2 < pi) and tan(19) == cot(-19 + 13*pi/2)
+    assert acot(cot(15)) == -5*pi + 15 and (-pi/2 < -5*pi + 15 <= pi/2) and cot(15) == cot(-5*pi + 15)
+    assert acot(tan(19)) == -19 + 13*pi/2 and (-pi/2 < -19 + 13*pi/2 <= pi/2) and tan(19) == cot(-19 + 13*pi/2)
 
     assert asec(sec(11)) == -11 + 4*pi and (0 <= -11 + 4*pi <= pi) and cos(11) == cos(-11 + 4*pi)
     assert asec(csc(13)) == -13 + 9*pi/2 and (0 <= -13 + 9*pi/2 <= pi) and sin(13) == cos(-13 + 9*pi/2)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1562,3 +1562,19 @@ def test_real_assumptions():
     assert atan(n).is_negative is True
     assert acot(p).is_positive is True
     assert acot(n).is_negative is True
+
+def test_issue_14320():
+    assert asin(sin(2)) == -2 + pi and (-pi/2 <= -2 + pi <= pi/2) and sin(2) == sin(-2 + pi)
+    assert asin(cos(2)) == -2 + pi/2 and (-pi/2 <= -2 + pi/2 <= pi/2) and cos(2) == sin(-2 + pi/2)
+    assert acos(sin(2)) == -pi/2 + 2 and (0 <= -pi/2 + 2 <= pi) and sin(2) == cos(-pi/2 + 2)
+    assert acos(cos(20)) == -6*pi + 20 and (0 <= -6*pi + 20 <= pi) and cos(20) == cos(-6*pi + 20)
+
+    assert atan(tan(17)) == -5*pi + 17 and (-pi/2 < -5*pi + 17 < pi/2) and tan(17) == tan(-5*pi + 17)
+    assert atan(cot(12)) == -12 + 7*pi/2 and (-pi/2 < -12 + 7*pi/2 < pi/2) and cot(12) == tan(-12 + 7*pi/2)
+    assert acot(cot(15)) == -4*pi + 15 and (0 < -4*pi + 15 < pi) and cot(15) == cot(-4*pi + 15)
+    assert acot(tan(19)) == -19 + 13*pi/2 and (0 < -19 + 13*pi/2 < pi) and tan(19) == cot(-19 + 13*pi/2)
+
+    assert asec(sec(11)) == -11 + 4*pi and (0 <= -11 + 4*pi <= pi) and cos(11) == cos(-11 + 4*pi)
+    assert asec(csc(13)) == -13 + 9*pi/2 and (0 <= -13 + 9*pi/2 <= pi) and sin(13) == cos(-13 + 9*pi/2)
+    assert acsc(csc(14)) == -4*pi + 14 and (-pi/2 <= -4*pi + 14 <= pi/2) and sin(14) == sin(-4*pi + 14)
+    assert acsc(sec(10)) == -7*pi/2 + 10 and (-pi/2 <= -7*pi/2 + 10 <= pi/2) and cos(10) == sin(-7*pi/2 + 10)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1571,6 +1571,7 @@ def test_issue_14320():
     assert acos(cos(30)) == -30 + 10*pi and (0 <= -30 + 10*pi <= pi) and cos(30) == cos(-30 + 10*pi)
 
     assert atan(tan(17)) == -5*pi + 17 and (-pi/2 < -5*pi + 17 < pi/2) and tan(17) == tan(-5*pi + 17)
+    assert atan(tan(15)) == -5*pi + 15 and (-pi/2 < -5*pi + 15 < pi/2) and tan(15) == tan(-5*pi + 15)
     assert atan(cot(12)) == -12 + 7*pi/2 and (-pi/2 < -12 + 7*pi/2 < pi/2) and cot(12) == tan(-12 + 7*pi/2)
     assert acot(cot(15)) == -4*pi + 15 and (0 < -4*pi + 15 < pi) and cot(15) == cot(-4*pi + 15)
     assert acot(tan(19)) == -19 + 13*pi/2 and (0 < -19 + 13*pi/2 < pi) and tan(19) == cot(-19 + 13*pi/2)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2300,7 +2300,7 @@ class atan(InverseTrigonometricFunction):
             if ang.is_comparable:
                 ang %= pi # restrict to [0,pi)
                 if ang > pi/2: # restrict to [-pi/2,pi/2]
-                    ang = pi - ang
+                    ang -= pi
 
                 return ang
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1950,22 +1950,22 @@ class asin(InverseTrigonometricFunction):
 
         if isinstance(arg, sin):
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 ang %= 2*pi # restrict to [0,2*pi)
                 if ang > pi: # restrict to (-pi,pi]
-                    ang = pi-ang
+                    ang = pi - ang
 
                 # restrict to [-pi/2,pi/2]
                 if ang > pi/2:
-                    ang = pi-ang
+                    ang = pi - ang
                 if ang < -pi/2:
-                    ang = -pi-ang
+                    ang = -pi - ang
 
                 return ang
 
         if isinstance(arg, cos): # acos(x) + asin(x) = pi/2
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 return pi/2 - acos(arg)
 
     @staticmethod
@@ -2112,7 +2112,7 @@ class acos(InverseTrigonometricFunction):
 
         if isinstance(arg, cos):
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 ang %= 2*pi # restrict to [0,2*pi)
                 if ang > pi: # restrict to [0,pi]
                     ang = 2*pi - ang
@@ -2121,7 +2121,7 @@ class acos(InverseTrigonometricFunction):
 
         if isinstance(arg, sin): # acos(x) + asin(x) = pi/2
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 return pi/2 - asin(arg)
 
     @staticmethod
@@ -2297,7 +2297,7 @@ class atan(InverseTrigonometricFunction):
 
         if isinstance(arg, tan):
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 ang %= pi # restrict to [0,pi)
                 if ang > pi/2: # restrict to [-pi/2,pi/2]
                     ang = pi - ang
@@ -2306,7 +2306,7 @@ class atan(InverseTrigonometricFunction):
 
         if isinstance(arg, cot): # atan(x) + acot(x) = pi/2
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 return pi/2 - acot(arg)
 
     @staticmethod
@@ -2455,12 +2455,12 @@ class acot(InverseTrigonometricFunction):
 
         if isinstance(arg, cot):
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 return ang % pi # restrict to [0,pi)
 
         if isinstance(arg, tan): # atan(x) + acot(x) = pi/2
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 return pi/2 - atan(arg)
 
     @staticmethod
@@ -2591,7 +2591,7 @@ class asec(InverseTrigonometricFunction):
 
         if isinstance(arg, sec):
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 ang %= 2*pi # restrict to [0,2*pi)
                 if ang > pi: # restrict to [0,pi]
                     ang = 2*pi - ang
@@ -2600,7 +2600,7 @@ class asec(InverseTrigonometricFunction):
 
         if isinstance(arg, csc): # asec(x) + acsc(x) = pi/2
             ang = arg.args[0]
-            if not ang.has(Symbol):
+            if ang.is_comparable:
                 return pi/2 - acsc(arg)
 
     def fdiff(self, argindex=1):
@@ -2697,22 +2697,22 @@ class acsc(InverseTrigonometricFunction):
 
         if isinstance(arg, csc):
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 ang %= 2*pi # restrict to [0,2*pi)
                 if ang > pi: # restrict to (-pi,pi]
-                    ang = pi-ang
+                    ang = pi - ang
 
                 # restrict to [-pi/2,pi/2]
                 if ang > pi/2:
-                    ang = pi-ang
+                    ang = pi - ang
                 if ang < -pi/2:
-                    ang = -pi-ang
+                    ang = -pi - ang
 
                 return ang
 
         if isinstance(arg, sec): # asec(x) + acsc(x) = pi/2
             ang = arg.args[0]
-            if not ang.has(Symbol) and ang.is_real:
+            if ang.is_comparable:
                 return pi/2 - asec(arg)
 
     def fdiff(self, argindex=1):

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1948,6 +1948,26 @@ class asin(InverseTrigonometricFunction):
         if i_coeff is not None:
             return S.ImaginaryUnit * asinh(i_coeff)
 
+        if isinstance(arg, sin):
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                ang %= 2*pi # restrict to [0,2*pi)
+                if ang > pi: # restrict to (-pi,pi]
+                    ang = pi-ang
+
+                # restrict to [-pi/2,pi/2]
+                if ang > pi/2:
+                    ang = pi-ang
+                if ang < -pi/2:
+                    ang = -pi-ang
+
+                return ang
+
+        if isinstance(arg, cos): # acos(x) + asin(x) = pi/2
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                return pi/2 - acos(arg)
+
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -2089,6 +2109,20 @@ class acos(InverseTrigonometricFunction):
 
             if arg in cst_table:
                 return cst_table[arg]
+
+        if isinstance(arg, cos):
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                ang %= 2*pi # restrict to [0,2*pi)
+                if ang > pi: # restrict to [0,pi]
+                    ang = 2*pi - ang
+
+                return ang
+
+        if isinstance(arg, sin): # acos(x) + asin(x) = pi/2
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                return pi/2 - asin(arg)
 
     @staticmethod
     @cacheit
@@ -2261,6 +2295,20 @@ class atan(InverseTrigonometricFunction):
         if i_coeff is not None:
             return S.ImaginaryUnit * atanh(i_coeff)
 
+        if isinstance(arg, tan):
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                ang %= pi # restrict to [0,pi)
+                if ang > pi/2: # restrict to [-pi/2,pi/2]
+                    ang = pi - ang
+
+                return ang
+
+        if isinstance(arg, cot): # atan(x) + acot(x) = pi/2
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                return pi/2 - acot(arg)
+
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -2405,6 +2453,16 @@ class acot(InverseTrigonometricFunction):
         if i_coeff is not None:
             return -S.ImaginaryUnit * acoth(i_coeff)
 
+        if isinstance(arg, cot):
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                return ang % pi # restrict to [0,pi)
+
+        if isinstance(arg, tan): # atan(x) + acot(x) = pi/2
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                return pi/2 - atan(arg)
+
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -2531,6 +2589,20 @@ class asec(InverseTrigonometricFunction):
         if arg in [S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
             return S.Pi/2
 
+        if isinstance(arg, sec):
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                ang %= 2*pi # restrict to [0,2*pi)
+                if ang > pi: # restrict to [0,pi]
+                    ang = 2*pi - ang
+
+                return ang
+
+        if isinstance(arg, csc): # asec(x) + acsc(x) = pi/2
+            ang = arg.args[0]
+            if not ang.has(Symbol):
+                return pi/2 - acsc(arg)
+
     def fdiff(self, argindex=1):
         if argindex == 1:
             return 1/(self.args[0]**2*sqrt(1 - 1/self.args[0]**2))
@@ -2622,6 +2694,26 @@ class acsc(InverseTrigonometricFunction):
                 return -S.Pi/2
         if arg in [S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
             return S.Zero
+
+        if isinstance(arg, csc):
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                ang %= 2*pi # restrict to [0,2*pi)
+                if ang > pi: # restrict to (-pi,pi]
+                    ang = pi-ang
+
+                # restrict to [-pi/2,pi/2]
+                if ang > pi/2:
+                    ang = pi-ang
+                if ang < -pi/2:
+                    ang = -pi-ang
+
+                return ang
+
+        if isinstance(arg, sec): # asec(x) + acsc(x) = pi/2
+            ang = arg.args[0]
+            if not ang.has(Symbol) and ang.is_real:
+                return pi/2 - asec(arg)
 
     def fdiff(self, argindex=1):
         if argindex == 1:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2307,7 +2307,10 @@ class atan(InverseTrigonometricFunction):
         if isinstance(arg, cot): # atan(x) + acot(x) = pi/2
             ang = arg.args[0]
             if ang.is_comparable:
-                return pi/2 - acot(arg)
+                ang = pi/2 - acot(arg)
+                if ang > pi/2: # restrict to [-pi/2,pi/2]
+                    ang -= pi
+                return ang
 
     @staticmethod
     @cacheit
@@ -2456,12 +2459,18 @@ class acot(InverseTrigonometricFunction):
         if isinstance(arg, cot):
             ang = arg.args[0]
             if ang.is_comparable:
-                return ang % pi # restrict to [0,pi)
+                ang %= pi # restrict to [0,pi)
+                if ang > pi/2: # restrict to (-pi/2,pi/2]
+                    ang -= pi;
+                return ang
 
         if isinstance(arg, tan): # atan(x) + acot(x) = pi/2
             ang = arg.args[0]
             if ang.is_comparable:
-                return pi/2 - atan(arg)
+                ang = pi/2 - atan(arg)
+                if ang > pi/2: # restrict to (-pi/2,pi/2]
+                    ang -= pi
+                return ang
 
     @staticmethod
     @cacheit


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #14320 

#### Brief description of what is fixed or changed
Added support for evaluation of inverse trigonometric non-symbolic expressions with real arguments, taking into account the range of inverse trigonometric functions.
This has the advantage of directly evaluating expressions of `sin/cos` arguments in `asin/acos`, `tan/cot` arguments in `atan/acot` and `sec/csc` arguments in `asec/acsc`.
This can even complicated expressions (of compatible functions).
```python
>> pprint(asin(sin(2)))
-2 + π

>> pprint(atan(cot(7)))
     5⋅π
-7 + ───
      2 

>> pprint(asin(sin(acos(cos(20)) + acos(cos(30)))))
-3⋅π + 10
```
@normalhuman @jksuom @asmeurer Please review.
