### PR TITLE
Use explicit keywords in MatrixEigen methods

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -935,6 +935,8 @@ def test_eigen():
                 [0, 0, 1]])
 
     assert M.eigenvals(multiple=False) == {S.One: 3}
+    assert M.eigenvals(multiple=True) == [S.One, S.One, S.One]
+    raises(NotImplementedError, lambda: M.eigenvects(multiple=True))
 
     assert M.eigenvects() == (
         [(1, 3, [Matrix([1, 0, 0]),
@@ -1621,15 +1623,10 @@ def test_diagonalization():
     assert m.is_diagonalizable()
 
 
-@XFAIL
-def test_eigen_vects():
+def test_diagonalizable_over_reals():
     m = Matrix(2, 2, [1, 0, 0, I])
-    raises(NotImplementedError, lambda: m.is_diagonalizable(True))
-    # !!! bug because of eigenvects() or roots(x**2 + (-1 - I)*x + I, x)
-    # see issue 5292
-    assert not m.is_diagonalizable(True)
-    raises(MatrixError, lambda: m.diagonalize(True))
-    (P, D) = m.diagonalize(True)
+    assert not m.is_diagonalizable(reals_only=True)
+    raises(MatrixError, lambda: m.diagonalize(reals_only=True))
 
 
 def test_jordan_form():


### PR DESCRIPTION
#### References to other Issues or PRs

A special case of #14030.

#### Brief description of what is fixed or changed

The `eigenvals`, `eigenvects`, `is_diagonalizable`, and `jordan_form` of MatrixEigen class now use explicit and documented keywords when possible. Some of them pass `**flags` to `roots`, and this is left as it was, because the nature of those flags depends on the `roots` method of another module.

One such flag is "multiple", meaning return the roots of a polynomial as a list instead of a dictionary (multiple roots are repeated in the list). Using `eigenvals(multiple=True)` previously caused an error because the eigenvalue-counting code expected a dictionary. This is corrected, so that, for example,
```
Matrix([[1, 1], [0, 1]]).eigenvals(multiple=True)
```
returns [1, 1].

In the process, a test marked XFAIL was found, which referred to an already-resolved issue. XFAIL removed.

#### Other comments

The `simplify` flag of eigenvects was used in two ways, with different default values:  
```
simplify = flags.get('simplify', True)
primitive = flags.get('simplify', False)
```
To retain this logic while changing simplify to an explicit argument, the default value of simplify in this method is set to None. Some internal logic is cleaned up too:  e.g., there was a line
```
simpfunc = _simplify if simplify else lambda x: x
```
but simpfunc would never be used unless `simplify` were true, making the ternary statement redundant. 