### PR TITLE
Limits should not be sequential by default

### DIFF
--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -485,12 +485,12 @@ def test_issue_9205():
 
 
 def test_limit_seq():
-    assert limit(Sum(1/x, (x, 1, y)) - log(y), y, oo) == EulerGamma
-    assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo) == S.Infinity
-    assert (limit(binomial(2*x, x) / Sum(binomial(2*y, y), (y, 1, x)), x, oo) ==
-            S(3) / 4)
-    assert (limit(Sum(y**2 * Sum(2**z/z, (z, 1, y)), (y, 1, x)) /
-                  (2**x*x), x, oo) == 4)
+    assert limit(Sum(1/x, (x, 1, y)) - log(y), y, oo, sequence=True) == EulerGamma
+    assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo, sequence=True) == S.Infinity
+    assert limit(binomial(2*x, x) / Sum(binomial(2*y, y), (y, 1, x)), x, oo,
+        sequence=True) == S(3) / 4
+    assert limit(Sum(y**2 * Sum(2**z/z, (z, 1, y)), (y, 1, x)) /
+        (2**x*x), x, oo, sequence=True) == 4
 
 
 def test_issue_11879():
@@ -521,3 +521,7 @@ def test_issue_12564():
     assert limit(((x + sin(x))**2).expand(), x, oo) == oo
     assert limit(((x + cos(x))**2).expand(), x, -oo) == oo
     assert limit(((x + sin(x))**2).expand(), x, -oo) == oo
+
+def test_not_assuming_sequence():
+    raises(NotImplementedError, lambda: limit(exp(I*x)*sin(pi*x), x, oo))
+    assert limit(exp(I*x)*sin(pi*x), x, oo, sequence=True) == 0


### PR DESCRIPTION
Currently, if heuristics and gruntz both fail, the limit at infinity is considered as the limit of a sequence by default: `if hints.get('sequence', True) and z0 is S.Infinity:`. This leads to wrong answers, such as
```
var('x')
limit(exp(I*x)*sin(pi*x), x, oo)  # returns 0
```
In the process of correcting this, the keywords arguments of `Limit.doit()` and of `limit` are made explicit. The default value of `sequence` is changed to None, which means to infer the limit type from the variable being integer. The tests in `test_limit_seq`, which relied on the previous behavior, are changed to use `sequence=True`. A test is added to ensure that `limit(exp(I*x)*sin(pi*x), x, oo)` now raises NotImplementedError.

#### Other comments

I don't know why `limit` raises NotImplementedError instead of just returning un-evaluated Limit expression, but there are tests that expect this behavior, so I decided to leave this as a separate issue.