### PR TITLE
The floor and ceiling of infinite quantities should be the quantity itself

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -20,7 +20,7 @@ class RoundFunction(Function):
     @classmethod
     def eval(cls, arg):
         from sympy import im
-        if arg.is_integer:
+        if arg.is_integer or arg.is_finite is False:
             return arg
         if arg.is_imaginary or (S.ImaginaryUnit*arg).is_real:
             i = im(arg)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -14,6 +14,7 @@ def test_floor():
 
     assert floor(oo) == oo
     assert floor(-oo) == -oo
+    assert floor(zoo) == zoo
 
     assert floor(0) == 0
 
@@ -48,6 +49,7 @@ def test_floor():
 
     assert floor(oo*I) == oo*I
     assert floor(-oo*I) == -oo*I
+    assert floor(exp(I*pi/4)*oo) == exp(I*pi/4)*oo
 
     assert floor(2*I) == 2*I
     assert floor(-2*I) == -2*I
@@ -117,6 +119,7 @@ def test_ceiling():
 
     assert ceiling(oo) == oo
     assert ceiling(-oo) == -oo
+    assert ceiling(zoo) == zoo
 
     assert ceiling(0) == 0
 
@@ -151,6 +154,7 @@ def test_ceiling():
 
     assert ceiling(oo*I) == oo*I
     assert ceiling(-oo*I) == -oo*I
+    assert ceiling(exp(I*pi/4)*oo) == exp(I*pi/4)*oo
 
     assert ceiling(2*I) == 2*I
     assert ceiling(-2*I) == -2*I

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -1,5 +1,5 @@
-from sympy import AccumBounds, Symbol, floor, nan, oo, E, symbols, ceiling, pi, \
-        Rational, Float, I, sin, exp, log, factorial, frac
+from sympy import AccumBounds, Symbol, floor, nan, oo, zoo, E, symbols, \
+        ceiling, pi, Rational, Float, I, sin, exp, log, factorial, frac
 
 from sympy.utilities.pytest import XFAIL
 


### PR DESCRIPTION
#### References to other Issues or PRs

Addresses #14313 (wrong result no longer returned) but does not resolve it completely (no correct result either, only NotImplementedError is raised).

#### Brief description of what is fixed or changed

Presently, floor and ceiling return the argument if it is `oo`, `-oo`, `I*oo`, or `-I*oo`. These results are all asserted by tests, and they make sense because changing the quantity by a bounded amount has no effect when it tends to infinity. However, `floor(zoo)` is returned unevaluated, while `floor(exp(I*pi/4)*oo)` (approaching infinity diagonally in the complex plane) raises an exception. The change here is that if `arg.is_finite` is False, then floor(arg) and ceiling(arg) return arg.

