### PR TITLE
Resolve sign of modular inverse and handle negative modulo

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -440,7 +440,7 @@ def igcdex(a, b):
 
 def mod_inverse(a, m):
     """
-    Return the number c such that, ( a * c ) % m == ( 1 ) % m
+    Return the number c such that, (a * c) = 1 (mod m)
     where c has the same sign as m. If no such value exists,
     a ValueError is raised.
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -440,9 +440,9 @@ def igcdex(a, b):
 
 def mod_inverse(a, m):
     """
-    Return the number c such that, ( a * c ) % m == 1 where
-    c has the same sign as a. If no such value exists, a
-    ValueError is raised.
+    Return the number c such that, ( a * c ) % m == ( 1 ) % m
+    where c has the same sign as m. If no such value exists,
+    a ValueError is raised.
 
     Examples
     ========
@@ -459,7 +459,7 @@ def mod_inverse(a, m):
     >>> mod_inverse(3, 11)
     4
     >>> mod_inverse(-3, 11)
-    -4
+    7
 
     When there is a common factor between the numerators of
     ``a`` and ``m`` the inverse does not exist:
@@ -477,15 +477,15 @@ def mod_inverse(a, m):
     - https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
     - https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
     """
-    c = None
+    c = m
+    def inv(a, m):
+        if -2 < a < 2: return a
+        return m + (1 - m * inv(m % a, a)) // a
+
     try:
         a, m = as_int(a), as_int(m)
-        if m > 1:
-            x, y, g = igcdex(a, m)
-            if g == 1:
-                c = x % m
-            if a < 0:
-                c -= m
+        if m != 1:
+            c = inv(a, m)
     except ValueError:
         a, m = sympify(a), sympify(m)
         if not (a.is_number and m.is_number):
@@ -500,7 +500,7 @@ def mod_inverse(a, m):
             raise ValueError('m > 1 did not evaluate; try to simplify %s' % m)
         elif big:
             c = 1/a
-    if c is None:
+    if c == m:
         raise ValueError('inverse of %s (mod %s) does not exist' % (a, m))
     return c
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -453,7 +453,7 @@ def mod_inverse(a, m):
     Suppose we wish to find multiplicative inverse x of
     3 modulo 11. This is the same as finding x such
     that 3 * x = 1 (mod 11). One value of x that satisfies
-    this congruence is 4. Because 3 * 4 = 12 and 12 = 1 mod(11).
+    this congruence is 4. Because 3 * 4 = 12 and 12 = 1 (mod 11).
     This is the value return by mod_inverse:
 
     >>> mod_inverse(3, 11)
@@ -477,15 +477,13 @@ def mod_inverse(a, m):
     - https://en.wikipedia.org/wiki/Modular_multiplicative_inverse
     - https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
     """
-    c = m
-    def inv(a, m):
-        if -2 < a < 2: return a
-        return m + (1 - m * inv(m % a, a)) // a
-
+    c = None
     try:
         a, m = as_int(a), as_int(m)
-        if m != 1:
-            c = inv(a, m)
+        if m != 1 and m != -1:
+            x, y, g = igcdex(a, m)
+            if g == 1:
+                c = x % m
     except ValueError:
         a, m = sympify(a), sympify(m)
         if not (a.is_number and m.is_number):
@@ -500,7 +498,7 @@ def mod_inverse(a, m):
             raise ValueError('m > 1 did not evaluate; try to simplify %s' % m)
         elif big:
             c = 1/a
-    if c == m:
+    if c is None:
         raise ValueError('inverse of %s (mod %s) does not exist' % (a, m))
     return c
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1709,7 +1709,10 @@ def test_mod_inverse():
     assert mod_inverse(5823991, 3299) == 1442
     assert mod_inverse(123, 44) == 39
     assert mod_inverse(2, 5) == 3
-    assert mod_inverse(-2, 5) == -3
+    assert mod_inverse(-2, 5) == 2
+    assert mod_inverse(2, -5) == -2
+    assert mod_inverse(-2, -5) == -3
+    assert mod_inverse(-3, -7) == -5
     x = Symbol('x')
     assert S(2).invert(x) == S.Half
     raises(TypeError, lambda: mod_inverse(2, x))


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #14332 

#### Brief description of what is fixed or changed
Updated mod_inverse for negative modulo.
Updated mod_inverse result to have same sign as the modulo.

```python
>> mod_inverse(2,5)
3

>> mod_inverse(-2,5)
2

>> mod_inverse(-2,-5)
-2

>> mod_inverse(2,-5)
-3
```

**Updates**
1. Switched back to gcdex for modular inverse, suggested by @normalhuman 
2. Improved the documentation for better understanding/readability, suggested by @jksuom 
