### PR TITLE
Changes to `probability` in drv.py and crv.py

### DIFF
--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -16,7 +16,7 @@ from sympy.stats.rv import (RandomDomain, SingleDomain, ConditionalDomain,
 from sympy.functions.special.delta_functions import DiracDelta
 from sympy import (Interval, Intersection, symbols, sympify, Dummy, Mul,
         Integral, And, Or, Piecewise, cacheit, integrate, oo, Lambda,
-        Basic, S, exp, I, FiniteSet, Interval, Ne, Eq)
+        Basic, S, exp, I, FiniteSet, Ne, Eq, Union)
 from sympy.solvers.solveset import solveset
 from sympy.solvers.inequalities import reduce_rational_inequalities
 from sympy.polys.polyerrors import PolynomialError
@@ -346,6 +346,10 @@ class ContinuousPSpace(PSpace):
             # return S.Zero if `domain` is empty set
             if domain.set is S.EmptySet or isinstance(domain.set, FiniteSet):
                 return S.Zero if not cond_inv else S.One
+            if isinstance(domain.set, Union):
+                return sum(
+                     Integral(pdf(z), (z, subset), **kwargs) for subset in
+                     domain.set.args if isinstance(subset, Interval))
             # Integrate out the last variable over the special domain
             return Integral(pdf(z), (z, domain.set), **kwargs)
 

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import (Basic, sympify, symbols, Dummy, Lambda, summation,
-        Piecewise, S, cacheit, Sum, exp, I, oo)
+        Piecewise, S, cacheit, Sum, exp, I, oo, Ne, Eq)
 from sympy.solvers.solveset import solveset
 from sympy.solvers.inequalities import reduce_rational_inequalities
 from sympy.stats.crv import (reduce_rational_inequalities_wrap,
@@ -178,13 +178,17 @@ class SingleDiscretePSpace(SinglePSpace):
         return conditional_domain
 
     def probability(self, condition):
+        complement = isinstance(condition, Ne)
+        if complement:
+            condition = Eq(condition.args[0], condition.args[1])
         _domain = self.restricted_domain(condition)
         if condition == False or _domain is S.EmptySet:
             return S.Zero
         if condition == True or _domain == self.set:
             return S.One
         try:
-            return self.eval_prob(_domain)
+            prob = self.eval_prob(_domain)
+            return prob if not complement else S.One - prob
         except NotImplementedError:
             return Probability(condition)
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -850,3 +850,10 @@ def test_prob_neq():
     assert P(Ne(X, 4)) == 1
     assert P(Ne(X, 5)) == 1
     assert P(Ne(E, x)) == 1
+
+def test_union():
+    N = Normal('N', 3, 2)
+    assert simplify(P(N**2 - N > 2)) == \
+        -erf(sqrt(2))/2 - erfc(sqrt(2)/4)/2 + 3/2
+    assert simplify(P(N**2 - 4 > 0)) == \
+        -erf(5*sqrt(2)/4)/2 - erfc(sqrt(2)/4)/2 + 3/2


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
1) drv.py - probability where conditions is of the form `Ne(RV, a)` is now
calculated as `1 - P(Eq(RV, a))`, similar to what is done in crv.py. This
results in significant reduction in time for calculating probabilities where
the RV is a poisson variable with a large mean. Eg. Y = Poisson('Y', 1000).

2) crv.py - condition to check if the domain resulting from the given
condition is a union of intervals, and calculate the required probability by
summing up the probabilites over each interval. Also removed a duplicate
import added in #14254.
#### Other comments
The check for `Union` was added in a commit in #14254, but was removed because I didn't think of any cases where it would be used. Test cases for the same have now been added.