### PR TITLE
rewriting min/max to piecewise only if arguments are real

### DIFF
--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -11,8 +11,6 @@ from sympy.core.compatibility import default_sort_key, with_metaclass
 
 from sympy import sin, Lambda, Q, cos, gamma, Tuple
 from sympy.functions.elementary.exponential import exp
-from sympy.functions.elementary.miscellaneous import Max, Min
-from sympy.functions.elementary.piecewise import Piecewise
 from sympy.utilities.pytest import raises
 from sympy.core import I, pi
 
@@ -227,14 +225,6 @@ def test_rewrite():
     assert f1.rewrite([cos],sin) == sin(x) + sin(x + pi/2, evaluate=False)
     f2 = sin(x) + cos(y)/gamma(z)
     assert f2.rewrite(sin,exp) == -I*(exp(I*x) - exp(-I*x))/2 + cos(y)/gamma(z)
-    assert Max(a, b).rewrite(Piecewise) == Piecewise((a, a >= b), (b, True))
-    assert Max(x, y, z).rewrite(Piecewise) == Piecewise((x, (x >= y) & (x >= z)), (y, y >= z), (z, True))
-    assert Max(x, y, a, b).rewrite(Piecewise) == Piecewise((a, (a >= b) & (a >= x) & (a >= y)),
-        (b, (b >= x) & (b >= y)), (x, x >= y), (y, True))
-    assert Min(a, b).rewrite(Piecewise) == Piecewise((a, a <= b), (b, True))
-    assert Min(x, y, z).rewrite(Piecewise) == Piecewise((x, (x <= y) & (x <= z)), (y, y <= z), (z, True))
-    assert Min(x,  y, a, b).rewrite(Piecewise) ==  Piecewise((a, (a <= b) & (a <= x) & (a <= y)),
-        (b, (b <= x) & (b <= y)), (x, x <= y), (y, True))
 
 
 def test_literal_evalf_is_number_is_zero_is_comparable():

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -748,7 +748,9 @@ class Max(MinMaxBase, Application):
                 for j in args])
 
     def _eval_rewrite_as_Piecewise(self, *args):
-        return _minmax_as_Piecewise('>=', *args)
+        is_real = all(i.is_real for i in args)
+        if is_real:
+            return _minmax_as_Piecewise('>=', *args)
 
     def _eval_is_positive(self):
         return fuzzy_or(a.is_positive for a in self.args)
@@ -811,7 +813,9 @@ class Min(MinMaxBase, Application):
                 for j in args])
 
     def _eval_rewrite_as_Piecewise(self, *args):
-        return _minmax_as_Piecewise('<=', *args)
+        is_real = all(i.is_real for i in args)
+        if is_real:
+            return _minmax_as_Piecewise('<=', *args)
 
     def _eval_is_positive(self):
         return fuzzy_and(a.is_positive for a in self.args)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -371,6 +371,24 @@ def test_rewrite_MaxMin_as_Heaviside():
         - 2*Heaviside(-x + 2)*Heaviside(x + 2)
 
 
+def test_rewrite_MaxMin_as_Piecewise():
+    from sympy import symbols, Piecewise
+    x, y, z, a, b = symbols('x y z a b', real=True)
+    vx, vy, va = symbols('vx vy va')
+    assert Max(a, b).rewrite(Piecewise) == Piecewise((a, a >= b), (b, True))
+    assert Max(x, y, z).rewrite(Piecewise) == Piecewise((x, (x >= y) & (x >= z)), (y, y >= z), (z, True))
+    assert Max(x, y, a, b).rewrite(Piecewise) == Piecewise((a, (a >= b) & (a >= x) & (a >= y)),
+        (b, (b >= x) & (b >= y)), (x, x >= y), (y, True))
+    assert Min(a, b).rewrite(Piecewise) == Piecewise((a, a <= b), (b, True))
+    assert Min(x, y, z).rewrite(Piecewise) == Piecewise((x, (x <= y) & (x <= z)), (y, y <= z), (z, True))
+    assert Min(x,  y, a, b).rewrite(Piecewise) ==  Piecewise((a, (a <= b) & (a <= x) & (a <= y)),
+        (b, (b <= x) & (b <= y)), (x, x <= y), (y, True))
+
+    # Piecewise rewriting of Min/Max does not takes place for non-real arguments
+    assert Max(vx, vy).rewrite(Piecewise) == Max(vx, vy)
+    assert Min(va, vx, vy).rewrite(Piecewise) == Min(va, vx, vy)
+
+
 def test_issue_11099():
     from sympy.abc import x, y
     # some fixed value tests

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -201,6 +201,7 @@ def test_piecewise_integrate1b():
 
 
 def test_piecewise_integrate1c():
+    y = symbols('y', real=True)
     for i, g in enumerate([
         Piecewise((1 - x, Interval(0, 1).contains(x)),
             (1 + x, Interval(-1, 0).contains(x)), (0, True)),

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -552,6 +552,7 @@ def test_integrate_returns_piecewise():
         (exp(y*z)/y - 1/y, (y > -oo) & (y < oo) & Ne(y, 0)), (z, True))
 
 def test_integrate_max_min():
+    x = symbols('x', real=True)
     assert integrate(Min(x, 2), (x, 0, 3)) == 4
     assert integrate(Max(x**2, x**3), (x, 0, 2)) == S(49)/12
     assert integrate(Min(exp(x), exp(-x))**2, x) == Piecewise( \

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -68,18 +68,16 @@ def _masked(f, *atoms):
     >>> f
     cos(cos(x) + 1)
     """
-    sym = numbered_symbols('a', cls=Dummy)
+    sym = numbered_symbols('a', cls=Dummy, real=True)
     mask = []
     for a in ordered(f.atoms(*atoms)):
         for i in mask:
             a = a.replace(*i)
         mask.append((a, next(sym)))
-    mask = list(reversed(mask))
     for i, (o, n) in enumerate(mask):
         f = f.replace(o, n)
         mask[i] = (n, o)
-    if mask and f == mask[0][1]:
-        f = mask[0][0]
+    mask = list(reversed(mask))
     return f, mask
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1716,12 +1716,12 @@ def test_issue_10158():
     assert solveset(Max(Abs(x - 3) - 1, x + 2) - 3, x, dom) == FiniteSet(-1, 1)
     assert solveset(Abs(x - 1) - Abs(y), x, dom) == FiniteSet(-Abs(y) + 1, Abs(y) + 1)
     assert solveset(Abs(x + 4*Abs(x + 1)), x, dom) == FiniteSet(-4/S(3), -4/S(5))
-    assert solveset(2*Abs(x + Abs(x + Max(3, x))) - 2, x, S.Reals
-        ) == FiniteSet(-1, -2)
+    assert solveset(2*Abs(x + Abs(x + Max(3, x))) - 2, x, S.Reals) == FiniteSet(-1, -2)
     dom = S.Complexes
-    raises(ValueError, lambda: solveset(x*Max(x, 15) - 10, x, dom))
-    raises(ValueError, lambda: solveset(x*Min(x, 15) - 10, x, dom))
-    raises(ValueError, lambda:
-        solveset(Max(Abs(x - 3) - 1, x + 2) - 3, x, dom))
+    assert solveset(x*Max(x, 15) - 10, x, dom) == \
+        ConditionSet(x, Eq(x*Max(15, x) - 10, 0), dom)
+    assert solveset(x*Min(x, 15) - 10, x, dom) == \
+        ConditionSet(x, Eq(x*Min(15, x) - 10, 0), dom)
+    raises(ValueError, lambda: solveset(Max(Abs(x - 3) - 1, x + 2) - 3, x, dom))
     raises(ValueError, lambda: solveset(Abs(x - 1) - Abs(y), x, dom))
     raises(ValueError, lambda: solveset(Abs(x + 4*Abs(x + 1)), x, dom))


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Currently piecewise rewriting for min/max is done assuming that the args are real even though it is not defined for complex values. This PR tries to add this constraint.
If args are not real, the expression is returned as it is.
#### Other comments

- Tests are shifted to `test_miscellaneous` as it seems more appropriate.

- There are some tests failing in `solveset` for equations like `Max(Abs(x - 3) - 1, x + 2) - 3`, because this equation gets masked to `Max(_a0 - 1, x + 2) - 3` which cannot be rewritten to Piecewise (because it has non-real args) and hence a conditionset is returned.
As of now, I am not sure how to fix this.

@smichr 