### PR TITLE
sympify : prevent evaluation of negative terms inside sympy_parser

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -397,11 +397,13 @@ def test_evaluate_false():
         '2 + 3': Add(2, 3, evaluate=False),
         '2**2 / 3': Mul(Pow(2, 2, evaluate=False), Pow(3, -1, evaluate=False), evaluate=False),
         '2 + 3 * 5': Add(2, Mul(3, 5, evaluate=False), evaluate=False),
-        '2 - 3 * 5': Add(2, Mul(3, Mul(-1, 5, evaulate=False), evaluate=False), evaluate=False),
+        '2 - 3 * 5': Add(2, Mul(-1, Mul(3, 5,evaluate=False), evaluate=False), evaluate=False),
         '1 / 3': Mul(1, Pow(3, -1, evaluate=False), evaluate=False),
         'True | False': Or(True, False, evaluate=False),
         '1 + 2 + 3 + 5*3 + integrate(x)': Add(1, 2, 3, Mul(5, 3, evaluate=False), x**2/2, evaluate=False),
         '2 * 4 * 6 + 8': Add(Mul(2, 4, 6, evaluate=False), 8, evaluate=False),
+        '2 - 8 / 4': Add(2, Mul(-1, Mul(8, Pow(4, -1, evaluate=False), evaluate=False), evaluate=False), evaluate=False),
+        '2 - 2**2': Add(2, Mul(-1, Pow(2, 2, evaluate=False), evaluate=False), evaluate=False),
     }
     for case, result in cases.items():
         assert sympify(case, evaluate=False) == result

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -397,7 +397,7 @@ def test_evaluate_false():
         '2 + 3': Add(2, 3, evaluate=False),
         '2**2 / 3': Mul(Pow(2, 2, evaluate=False), Pow(3, -1, evaluate=False), evaluate=False),
         '2 + 3 * 5': Add(2, Mul(3, 5, evaluate=False), evaluate=False),
-        '2 - 3 * 5': Add(2, -Mul(3, 5, evaluate=False), evaluate=False),
+        '2 - 3 * 5': Add(2, Mul(3, Mul(-1, 5, evaulate=False), evaluate=False), evaluate=False),
         '1 / 3': Mul(1, Pow(3, -1, evaluate=False), evaluate=False),
         'True | False': Or(True, False, evaluate=False),
         '1 + 2 + 3 + 5*3 + integrate(x)': Add(1, 2, 3, Mul(5, 3, evaluate=False), x**2/2, evaluate=False),

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -991,19 +991,13 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             if isinstance(node.left, ast.UnaryOp) and (isinstance(node.right, ast.UnaryOp) == 0) and sympy_class in ('Mul',):
                 left, right = right, left
             if isinstance(node.op, ast.Sub):
-                from ast import Call
-                if not isinstance(node.right, Call):
-                    sympy_class2 = self.operators[node.right.op.__class__]
-                    if sympy_class2 ==  'Mul':
-                        right = ast.Call(
-                            func=ast.Name(id=sympy_class2, ctx=ast.Load()),
-                            args=[node.right.left, ast.UnaryOp(op=ast.USub(), operand=node.right.right)],
-                            keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
-                            starargs=None,
-                            kwargs=None
-                        )
-                else:
-                    right = ast.UnaryOp(op=ast.USub(), operand=right)
+                right = ast.Call(
+                    func=ast.Name(id='Mul', ctx=ast.Load()),
+                    args=[ast.UnaryOp(op=ast.USub(), operand=ast.Num(1)), right],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
+                    starargs=None,
+                    kwargs=None
+                )
             if isinstance(node.op, ast.Div):
                 if isinstance(node.left, ast.UnaryOp):
                     if isinstance(node.right,ast.UnaryOp):

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -991,7 +991,19 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
             if isinstance(node.left, ast.UnaryOp) and (isinstance(node.right, ast.UnaryOp) == 0) and sympy_class in ('Mul',):
                 left, right = right, left
             if isinstance(node.op, ast.Sub):
-                right = ast.UnaryOp(op=ast.USub(), operand=right)
+                from ast import Call
+                if not isinstance(node.right, Call):
+                    sympy_class2 = self.operators[node.right.op.__class__]
+                    if sympy_class2 ==  'Mul':
+                        right = ast.Call(
+                            func=ast.Name(id=sympy_class2, ctx=ast.Load()),
+                            args=[node.right.left, ast.UnaryOp(op=ast.USub(), operand=node.right.right)],
+                            keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
+                            starargs=None,
+                            kwargs=None
+                        )
+                else:
+                    right = ast.UnaryOp(op=ast.USub(), operand=right)
             if isinstance(node.op, ast.Div):
                 if isinstance(node.left, ast.UnaryOp):
                     if isinstance(node.right,ast.UnaryOp):


### PR DESCRIPTION
Fixes #11095 

**Updated** : 
Instead of wrapping negative nodes with `UnaryOp()`, I wrapped the negative terms with a `Mul` with `-1` as one of its argument. On seeing the code I observed not only `Mul` was being evaluated unecessarily but any Binary operator/function was facing this problem.
```
>>> sympify('2 - 2*2 ', evaluate=False)
-4 + 2
>>> sympify('2 - 8 / 4', evaluate=False)
-2 + 2
>>> sympify('2 - 2**2 ', evaluate=False)
-4 + 2
```

On this branch : 
```
>>> sympify('2 - 2*2 ', evaluate=False)
-2*2 + 2
>>> sympify('2 - 8 / 4', evaluate=False)
-8/4 + 2
>>> sympify('2 - 2**2 ', evaluate=False)
-2**2 + 2
```
