### PR TITLE
Latex: Fixed long_frac_ratio

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -128,7 +128,7 @@ class LatexPrinter(Printer):
         "fold_frac_powers": False,
         "fold_func_brackets": False,
         "fold_short_frac": None,
-        "long_frac_ratio": 2,
+        "long_frac_ratio": None,
         "mul_symbol": None,
         "inv_trig_style": "abbreviated",
         "mat_str": None,
@@ -446,9 +446,17 @@ class LatexPrinter(Printer):
             snumer = convert(numer)
             sdenom = convert(denom)
             ldenom = len(sdenom.split())
-            ratio = self._settings['long_frac_ratio']
+            if self._settings['long_frac_ratio'] == None:
+                exprfind = [x for x in expr.args if \
+                    str(x).startswith('1/')]
+                if len(exprfind)>=1:
+                    ratio = len(expr.args)-1
+                else:
+                    ratio = len(expr.args)
+            else:
+                ratio = self._settings['long_frac_ratio']
             if self._settings['fold_short_frac'] \
-                    and ldenom <= 2 and not "^" in sdenom:
+                   and ldenom <= 2 and not "^" in sdenom:
                 # handle short fractions
                 if self._needs_mul_brackets(numer, last=False):
                     tex += r"\left(%s\right) / %s" % (snumer, sdenom)
@@ -2279,7 +2287,8 @@ def latex(expr, **settings):
 
     long_frac_ratio: The allowed ratio of the width of the numerator to the
     width of the denominator before we start breaking off long fractions.
-    The default value is 2.
+    The default value is width of the numerator to the width of the
+    denominator in the expression itself.
 
     >>> print(latex(Integral(r, r)/2/pi, long_frac_ratio=2))
     \frac{\int r\, dr}{2 \pi}

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -447,14 +447,12 @@ class LatexPrinter(Printer):
             sdenom = convert(denom)
             ldenom = len(sdenom.split())
             if self._settings['long_frac_ratio'] == None:
-                exprfind = [x for x in expr.args if \
-                    str(x).startswith('1/')]
-                if len(exprfind) >= 1:
-                    ratio = len(expr.args) - 1
-                else:
-                    ratio = len(expr.args)
+                ratio = len(expr.as_numer_denom()[0].args)
+                if ratio == 0:
+                    ratio = 1
             else:
                 ratio = self._settings['long_frac_ratio']
+
             if self._settings['fold_short_frac'] \
                    and ldenom <= 2 and not "^" in sdenom:
                 # handle short fractions

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -446,13 +446,7 @@ class LatexPrinter(Printer):
             snumer = convert(numer)
             sdenom = convert(denom)
             ldenom = len(sdenom.split())
-            if self._settings['long_frac_ratio'] == None:
-                ratio = len(expr.as_numer_denom()[0].args)
-                if ratio == 0:
-                    ratio = 1
-            else:
-                ratio = self._settings['long_frac_ratio']
-
+            ratio = self._settings['long_frac_ratio']
             if self._settings['fold_short_frac'] \
                    and ldenom <= 2 and not "^" in sdenom:
                 # handle short fractions
@@ -460,7 +454,8 @@ class LatexPrinter(Printer):
                     tex += r"\left(%s\right) / %s" % (snumer, sdenom)
                 else:
                     tex += r"%s / %s" % (snumer, sdenom)
-            elif len(snumer.split()) > ratio*ldenom:
+            elif ratio is not None and \
+                    len(snumer.split()) > ratio*ldenom:
                 # handle long fractions
                 if self._needs_mul_brackets(numer, last=True):
                     tex += r"\frac{1}{%s}%s\left(%s\right)" \

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -449,8 +449,8 @@ class LatexPrinter(Printer):
             if self._settings['long_frac_ratio'] == None:
                 exprfind = [x for x in expr.args if \
                     str(x).startswith('1/')]
-                if len(exprfind)>=1:
-                    ratio = len(expr.args)-1
+                if len(exprfind) >= 1:
+                    ratio = len(expr.args) - 1
                 else:
                     ratio = len(expr.args)
             else:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2287,8 +2287,7 @@ def latex(expr, **settings):
 
     long_frac_ratio: The allowed ratio of the width of the numerator to the
     width of the denominator before we start breaking off long fractions.
-    The default value is width of the numerator to the width of the
-    denominator in the expression itself.
+    If None (the default value), long fractions are not broken up.
 
     >>> print(latex(Integral(r, r)/2/pi, long_frac_ratio=2))
     \frac{\int r\, dr}{2 \pi}

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -84,13 +84,13 @@ def test_latex_basic():
         r"\left(x + y\right) / 2 x"
     assert latex((x + y)/(2*x), long_frac_ratio=0) == \
         r"\frac{1}{2 x} \left(x + y\right)"
-    assert latex((x + y)/x) == r"\frac{1}{x} \left(x + y\right)"
+    assert latex((x + y)/x) == r"\frac{x + y}{x}"
     assert latex((x + y)/x, long_frac_ratio=3) == r"\frac{x + y}{x}"
     assert latex((2*sqrt(2)*x)/3) == r"\frac{2 \sqrt{2} x}{3}"
     assert latex((2*sqrt(2)*x)/3, long_frac_ratio=2) == \
         r"\frac{2 x}{3} \sqrt{2}"
 
-    assert latex(2*Integral(x, x)/3) == r"\frac{2}{3} \int x\, dx"
+    assert latex(2*Integral(x, x)/3) == r"\frac{2 \int x\, dx}{3}"
     assert latex(2*Integral(x, x)/3, fold_short_frac=True) == \
         r"\left(2 \int x\, dx\right) / 3"
 
@@ -692,12 +692,12 @@ def test_latex_sequences():
 
 
 def test_latex_FourierSeries():
-    latex_str = r'2 \sin{\left (x \right )} - \sin{\left (2 x \right )} + \frac{2}{3} \sin{\left (3 x \right )} + \ldots'
+    latex_str = r'2 \sin{\left (x \right )} - \sin{\left (2 x \right )} + \frac{2 \sin{\left (3 x \right )}}{3} + \ldots'
     assert latex(fourier_series(x, (x, -pi, pi))) == latex_str
 
 
 def test_latex_FormalPowerSeries():
-    latex_str = r'\sum_{k=1}^{\infty} - \frac{\left(-1\right)^{- k}}{k} x^{k}'
+    latex_str = r'\sum_{k=1}^{\infty} - \frac{\left(-1\right)^{- k} x^{k}}{k}'
     assert latex(fps(log(1 + x))) == latex_str
 
 
@@ -1634,7 +1634,7 @@ def test_Mul():
     e = Mul(2, x + 1, evaluate=False)
     assert latex(e)  == r'2 \left(x + 1\right)'
     e = Mul(S.One/2, x + 1, evaluate=False)
-    assert latex(e)  == r'\frac{1}{2} \left(x + 1\right)'
+    assert latex(e)  == r'\frac{x + 1}{2}'
     e = Mul(y, x + 1, evaluate=False)
     assert latex(e)  == r'y \left(x + 1\right)'
     e = Mul(-y, x + 1, evaluate=False)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -86,6 +86,9 @@ def test_latex_basic():
         r"\frac{1}{2 x} \left(x + y\right)"
     assert latex((x + y)/x) == r"\frac{1}{x} \left(x + y\right)"
     assert latex((x + y)/x, long_frac_ratio=3) == r"\frac{x + y}{x}"
+    assert latex((2*sqrt(2)*x)/3) == r"\frac{2 \sqrt{2} x}{3}"
+    assert latex((2*sqrt(2)*x)/3, long_frac_ratio=2) == \
+        r"\frac{2 x}{3} \sqrt{2}"
 
     assert latex(2*Integral(x, x)/3) == r"\frac{2}{3} \int x\, dx"
     assert latex(2*Integral(x, x)/3, fold_short_frac=True) == \


### PR DESCRIPTION
Correct output for fractions involving terms
in numerator more than twice the terms in
denominator.

Fixes https://github.com/sympy/sympy/issues/14309

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments
