### PR TITLE
Matrix inverse: gcdex for inv_mod

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2718,8 +2718,6 @@ class MatrixBase(MatrixDeprecated,
         """
         try:
             return self.inverse_GE(prime=m)
-        except ZeroDivisionError:
-            raise ValueError('Matrix is not invertible (mod %d)' % m)
         except NonSquareMatrixError:
             raise NonSquareMatrixError()
         except ValueError:
@@ -2780,7 +2778,7 @@ class MatrixBase(MatrixDeprecated,
         big = Matrix.hstack(self.as_mutable(), Matrix.eye(self.rows))
         red = big.rref(iszerofunc=iszerofunc, simplify=True, prime=prime)[0]
         if any(iszerofunc(red[j, j]) for j in range(red.rows)):
-            raise ZeroDivisionError("Matrix det == 0; not invertible.")
+            raise ValueError("Matrix det == 0; not invertible.")
 
         return self._new(red[:, big.rows:])
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -762,6 +762,17 @@ def test_matrix_inverse_mod():
     assert A.inv_mod(3) == Ai
     A = Matrix(2, 2, [1, 0, 0, 1])
     assert A.inv_mod(2) == A
+    A = Matrix(3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    raises(ValueError, lambda: A.inv_mod(5))
+    A = Matrix(3, 3, [5, 1, 3, 2, 6, 0, 2, 1, 1])
+    Ai = Matrix(3, 3, [6, 8, 0, 1, 5, 6, 5, 6, 4])
+    assert A.inv_mod(9) == Ai
+    A = Matrix(3, 3, [1, 6, -3, 4, 1, -5, 3, -5, 5])
+    Ai = Matrix(3, 3, [4, 3, 3, 1, 2, 5, 1, 5, 1])
+    assert A.inv_mod(6) == Ai
+    A = Matrix(3, 3, [1, 6, 1, 4, 1, 5, 3, 2, 5])
+    Ai = Matrix(3, 3, [6, 0, 3, 6, 6, 4, 1, 6, 1])
+    assert A.inv_mod(7) == Ai
 
 
 def test_util():


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #14344 

#### Brief description of what is fixed or changed
For matrix inv_mod, changed modular inverse calculation of determinant from Euler Totient Method to mod_inverse (that uses Extended Euclidean Algorithm) - handled in this PR.

#### Other Comments
Matrix inverse for fields will be handled in different PR, as [discussed](https://github.com/sympy/sympy/pull/14347#issuecomment-377507997) with @jksuom.
See #14345 for further discussion.
