### PR TITLE
values() only defined for type dict

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1130,7 +1130,7 @@ class MatrixEigen(MatrixSubspaces):
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix
-        if error_when_incomplete and type(eigs)==dict and sum(m for m in eigs.values()) != self.cols:
+        if error_when_incomplete and isinstance(eigs, dict) and sum(m for m in eigs.values()) != self.cols:
             raise MatrixError("Could not compute eigenvalues for {}".format(self))
 
         return eigs

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1130,7 +1130,8 @@ class MatrixEigen(MatrixSubspaces):
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix
-        if error_when_incomplete and (sum(eigs.values()) if isinstance(eigs, dict) else len(eigs)) != self.cols:
+        if error_when_incomplete and (sum(eigs.values()) if
+            isinstance(eigs, dict) else len(eigs)) != self.cols:
             raise MatrixError("Could not compute eigenvalues for {}".format(self))
 
         return eigs

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1130,7 +1130,7 @@ class MatrixEigen(MatrixSubspaces):
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix
-        if error_when_incomplete and sum(m for m in eigs.values()) != self.cols:
+        if error_when_incomplete and type(eigs)==dict and sum(m for m in eigs.values()) != self.cols:
             raise MatrixError("Could not compute eigenvalues for {}".format(self))
 
         return eigs

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1130,7 +1130,7 @@ class MatrixEigen(MatrixSubspaces):
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix
-        if error_when_incomplete and isinstance(eigs, dict) and sum(m for m in eigs.values()) != self.cols:
+        if error_when_incomplete and (sum(eigs.values()) if isinstance(eigs, dict) else len(eigs)) != self.cols:
             raise MatrixError("Could not compute eigenvalues for {}".format(self))
 
         return eigs

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -935,6 +935,7 @@ def test_eigen():
                 [0, 0, 1]])
 
     assert M.eigenvals(multiple=False) == {S.One: 3}
+    assert M.eigenvals(multiple=True) == [1, 1, 1]
 
     assert M.eigenvects() == (
         [(1, 3, [Matrix([1, 0, 0]),


### PR DESCRIPTION
List objects doesn't have 'values' attribute.
That is why master is giving error in : 
`Matrix([[1, -1], [1, 1]]).eigenvals(multiple=True)`

So, I have added a condition before `eigs.values()` for type of `eigs` to be equal to `dict`.