### PR TITLE
function: Added the differentiability test in Subs class method doit()

### DIFF
--- a/bin/doctest
+++ b/bin/doctest
@@ -4,7 +4,7 @@
 Program to execute doctests using the py.test like interface.
 
 The advantage over py.test is that it only depends on sympy and should just
-work in any circumstances. See "sympy.dotest?" for documentation.
+work in any circumstances. See "sympy.doctest?" for documentation.
 """
 
 from __future__ import print_function

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1805,7 +1805,25 @@ class Subs(Expr):
     def _eval_is_commutative(self):
         return self.expr.is_commutative
 
+    def is_continuous(expression,symbol,points):
+        left_hand_limit = expression.subs(symbol,points-10**(-20))
+        right_hand_limit = expression.subs(symbol,points+10**(-20))
+        value=expression.subs(symbol.points)
+        if left_hand_limit == right_hand_limit and left_hand_limit == value:
+           return True
+        else:
+           return False
+         
     def doit(self):
+        type_of_expr = type(self.expr)
+        type_of_drivative = type(Derivative(x,x))
+        symbol = self.variables
+        point = self.point
+        if type_of_expr == type_of_derivative and len(symbol) == 1:
+              if is_continuous(self.expr, symbol, point) == True:
+                  return self.expr.doit().subs(list(zip(self.variables, self.point)))
+              else:
+                  return "Derivative doesn't exists at the specified point" 
         return self.expr.doit().subs(list(zip(self.variables, self.point)))
 
     def evalf(self, prec=None, **options):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -217,6 +217,7 @@ def test_Lambda_equality():
 
 
 def test_Subs():
+    
     assert Subs(x, x, 0) == Subs(y, y, 0)
     assert Subs(x, x, 0).subs(x, 1) == Subs(x, x, 0)
     assert Subs(y, x, 0).subs(y, 1) == Subs(1, x, 0)


### PR DESCRIPTION
In Subs class the doit() method earlier used to return values even
at points where the derivative of the function doesn't exists.
After making this commit this should not happen for single variable
functions. However, the work on multi-variable functions is in progress
and soon, a PR on that will be made.