### PR TITLE
bin/doctest: Typos fixed

### DIFF
--- a/bin/doctest
+++ b/bin/doctest
@@ -4,7 +4,7 @@
 Program to execute doctests using the py.test like interface.
 
 The advantage over py.test is that it only depends on sympy and should just
-work in any circumstances. See "sympy.dotest?" for documentation.
+work in any circumstances. See "sympy.doctest?" for documentation.
 """
 
 from __future__ import print_function


### PR DESCRIPTION
Earlier, there was a typo in bin/doctest.
I corrected it from "sympy.dotest?" to "sympy.doctest?"
