### PR TITLE
Support gcd and lcm for compatible irrationals

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5205,7 +5205,7 @@ def gcd_list(seq, *gens, **args):
 
         #for gcd in domain Q[irrational]
         ls = map(sympify, seq)
-        if all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
+        if len(ls) > 1 and all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
             a = ls[-1]
             ls.pop()
             ls = [(a/ele).ratsimp() for ele in ls]
@@ -5338,7 +5338,7 @@ def lcm_list(seq, *gens, **args):
 
         #for lcm in domain Q[irrational]
         ls = map(sympify, seq)
-        if all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
+        if len(ls) > 1 and all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
             a = ls[-1]
             ls.pop()
             ls = [(a/ele).ratsimp() for ele in ls]

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5203,7 +5203,7 @@ def gcd_list(seq, *gens, **args):
     try:
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
-        #gcd for domain Q[irrational] (purely algebraic irrational)
+        # gcd for domain Q[irrational] (purely algebraic irrational)
         if len(seq) > 1 and all(elt.is_algebraic and elt.is_irrational for elt in seq):
             a = seq[-1]
             lst = [(a / elt).ratsimp() for elt in seq[:-1]]
@@ -5269,7 +5269,7 @@ def gcd(f, g=None, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
 
-        #gcd for domain Q[irrational] (purely algebraic irrational)
+        # gcd for domain Q[irrational] (purely algebraic irrational)
         a, b = map(sympify, (f, g))
         if a.is_algebraic and a.is_irrational and b.is_algebraic and b.is_irrational:
             frc = (a / b).ratsimp()
@@ -5335,7 +5335,7 @@ def lcm_list(seq, *gens, **args):
     try:
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
-        #lcm for domain Q[irrational] (purely algebraic irrational)
+        # lcm for domain Q[irrational] (purely algebraic irrational)
         if len(seq) > 1 and all(elt.is_algebraic and elt.is_irrational for elt in seq):
             a = seq[-1]
             lst = [(a / elt).ratsimp() for elt in seq[:-1]]
@@ -5398,7 +5398,7 @@ def lcm(f, g=None, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
 
-        #lcm for domain Q[irrational] (purely algebraic irrational)
+        # lcm for domain Q[irrational] (purely algebraic irrational)
         a, b = map(sympify, (f, g))
         if a.is_algebraic and a.is_irrational and b.is_algebraic and b.is_irrational:
             frc = (a / b).ratsimp()

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5203,17 +5203,15 @@ def gcd_list(seq, *gens, **args):
     try:
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
-        #for gcd in domain Q[irrational]
-        ls = [sympify(ele) for ele in seq]
-        if len(ls) > 1 and all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
-            a = ls[-1]
-            ls.pop()
-            ls = [(a/ele).ratsimp() for ele in ls]
-            if all(frc.is_rational for frc in ls):
+        #gcd for domain Q[irrational] (purely algebraic irrational)
+        if len(seq) > 1 and all(elt.is_algebraic and elt.is_irrational for elt in seq):
+            a = seq[-1]
+            lst = [(a / elt).ratsimp() for elt in seq[:-1]]
+            if all(frc.is_rational for frc in lst):
                 lc = 1
-                for frc in ls:
+                for frc in lst:
                     lc = lcm(lc, frc.as_numer_denom()[0])
-                return a/lc
+                return a / lc
 
     except PolificationFailed as exc:
         result = try_non_polynomial_gcd(exc.exprs)
@@ -5271,11 +5269,12 @@ def gcd(f, g=None, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
 
+        #gcd for domain Q[irrational] (purely algebraic irrational)
         a, b = map(sympify, (f, g))
-        if not a.has(Symbol) and a.is_irrational and not b.has(Symbol) and b.is_irrational:
-            frc = (a/b).ratsimp()
+        if a.is_algebraic and a.is_irrational and b.is_algebraic and b.is_irrational:
+            frc = (a / b).ratsimp()
             if frc.is_rational:
-                return a/frc.as_numer_denom()[0]
+                return a / frc.as_numer_denom()[0]
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)
@@ -5336,17 +5335,15 @@ def lcm_list(seq, *gens, **args):
     try:
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
-        #for lcm in domain Q[irrational]
-        ls = [sympify(ele) for ele in seq]
-        if len(ls) > 1 and all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
-            a = ls[-1]
-            ls.pop()
-            ls = [(a/ele).ratsimp() for ele in ls]
-            if all(frc.is_rational for frc in ls):
+        #lcm for domain Q[irrational] (purely algebraic irrational)
+        if len(seq) > 1 and all(elt.is_algebraic and elt.is_irrational for elt in seq):
+            a = seq[-1]
+            lst = [(a / elt).ratsimp() for elt in seq[:-1]]
+            if all(frc.is_rational for frc in lst):
                 lc = 1
-                for frc in ls:
+                for frc in lst:
                     lc = lcm(lc, frc.as_numer_denom()[1])
-                return a*lc
+                return a * lc
 
     except PolificationFailed as exc:
         result = try_non_polynomial_lcm(exc.exprs)
@@ -5401,12 +5398,12 @@ def lcm(f, g=None, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
 
-        #for lcm in domain Q[irrational]
+        #lcm for domain Q[irrational] (purely algebraic irrational)
         a, b = map(sympify, (f, g))
-        if not a.has(Symbol) and a.is_irrational and not b.has(Symbol) and b.is_irrational:
-            frc = (a/b).ratsimp()
+        if a.is_algebraic and a.is_irrational and b.is_algebraic and b.is_irrational:
+            frc = (a / b).ratsimp()
             if frc.is_rational:
-                return a*frc.as_numer_denom()[1]
+                return a * frc.as_numer_denom()[1]
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5206,12 +5206,9 @@ def gcd_list(seq, *gens, **args):
         #for gcd in domain Q[irrational]
         ls = map(sympify, seq)
         if all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
-            a = ls[0]
-
-            for i in range(1, len(ls)):
-                ls[i-1] = (a/ls[i]).ratsimp()
+            a = ls[-1]
             ls.pop()
-
+            ls = [(a/ele).ratsimp() for ele in ls]
             if all(frc.is_rational for frc in ls):
                 lc = 1
                 for frc in ls:
@@ -5342,12 +5339,9 @@ def lcm_list(seq, *gens, **args):
         #for lcm in domain Q[irrational]
         ls = map(sympify, seq)
         if all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
-            a = ls[0]
-
-            for i in range(1, len(ls)):
-                ls[i-1] = (a/ls[i]).ratsimp()
+            a = ls[-1]
             ls.pop()
-
+            ls = [(a/ele).ratsimp() for ele in ls]
             if all(frc.is_rational for frc in ls):
                 lc = 1
                 for frc in ls:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5204,15 +5204,14 @@ def gcd_list(seq, *gens, **args):
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
         #for gcd in domain Q[irrational]
-        genrs = opt['gens']
-        if len(genrs) == 1:
-            genr = genrs[0]
-            if not genr.has(Symbol) and genr.is_irrational:
-                if all((element/genr).is_rational for element in seq):
-                    g = seq[0]/genr
-                    for element in seq[1:]:
-                        g = gcd(g, element/genr)
-                    return g * genr
+        if all(not ele.has(Symbol) and ele.is_irrational for ele in seq):
+            a = seq[0]
+            ls = [(a/ele).ratsimp() for ele in seq[1:]]
+            if all(frc.is_rational for frc in ls):
+                lc = 1
+                for frc in ls:
+                    lc = lcm(lc, frc.as_numer_denom()[0])
+                return a/lc
 
     except PolificationFailed as exc:
         result = try_non_polynomial_gcd(exc.exprs)
@@ -5270,14 +5269,10 @@ def gcd(f, g=None, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
 
-        #for gcd in domain Q[irrational]
-        genrs = opt['gens']
-        if len(genrs) == 1:
-            genr = genrs[0]
-            if not genr.has(Symbol) and genr.is_irrational:
-                a, b = f/genr, g/genr
-                if a.is_rational and b.is_rational:
-                    return gcd(a, b) * genr
+        if not f.has(Symbol) and f.is_irrational and not g.has(Symbol) and g.is_irrational:
+            frc = (f/g).ratsimp()
+            if frc.is_rational:
+                return f/frc.as_numer_denom()[0]
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)
@@ -5339,15 +5334,14 @@ def lcm_list(seq, *gens, **args):
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
         #for lcm in domain Q[irrational]
-        genrs = opt['gens']
-        if len(genrs) == 1:
-            genr = genrs[0]
-            if not genr.has(Symbol) and genr.is_irrational:
-                if all((element/genr).is_rational for element in seq):
-                    l = seq[0]/genr
-                    for element in seq[1:]:
-                        l = lcm(l, element/genr)
-                    return l * genr
+        if all(not ele.has(Symbol) and ele.is_irrational for ele in seq):
+            a = seq[0]
+            ls = [(a/ele).ratsimp() for ele in seq[1:]]
+            if all(frc.is_rational for frc in ls):
+                lc = 1
+                for frc in ls:
+                    lc = lcm(lc, frc.as_numer_denom()[1])
+                return lc*a
 
     except PolificationFailed as exc:
         result = try_non_polynomial_lcm(exc.exprs)
@@ -5403,13 +5397,10 @@ def lcm(f, g=None, *gens, **args):
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
 
         #for lcm in domain Q[irrational]
-        genrs = opt['gens']
-        if len(genrs) == 1:
-            genr = genrs[0]
-            if not genr.has(Symbol) and genr.is_irrational:
-                a, b = f/genr, g/genr
-                if a.is_rational and b.is_rational:
-                    return lcm(a, b) * genr
+        if not f.has(Symbol) and f.is_irrational and not g.has(Symbol) and g.is_irrational:
+            frc = (f/g).ratsimp()
+            if frc.is_rational:
+                return f*frc.as_numer_denom()[1]
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5204,9 +5204,14 @@ def gcd_list(seq, *gens, **args):
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
         #for gcd in domain Q[irrational]
-        if all(not ele.has(Symbol) and ele.is_irrational for ele in seq):
-            a = seq[0]
-            ls = [(a/ele).ratsimp() for ele in seq[1:]]
+        ls = map(sympify, seq)
+        if all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
+            a = ls[0]
+
+            for i in range(1, len(ls)):
+                ls[i-1] = (a/ls[i]).ratsimp()
+            ls.pop()
+
             if all(frc.is_rational for frc in ls):
                 lc = 1
                 for frc in ls:
@@ -5269,10 +5274,11 @@ def gcd(f, g=None, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
 
-        if not f.has(Symbol) and f.is_irrational and not g.has(Symbol) and g.is_irrational:
-            frc = (f/g).ratsimp()
+        a, b = map(sympify, (f, g))
+        if not a.has(Symbol) and a.is_irrational and not b.has(Symbol) and b.is_irrational:
+            frc = (a/b).ratsimp()
             if frc.is_rational:
-                return f/frc.as_numer_denom()[0]
+                return a/frc.as_numer_denom()[0]
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)
@@ -5334,14 +5340,19 @@ def lcm_list(seq, *gens, **args):
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
         #for lcm in domain Q[irrational]
-        if all(not ele.has(Symbol) and ele.is_irrational for ele in seq):
-            a = seq[0]
-            ls = [(a/ele).ratsimp() for ele in seq[1:]]
+        ls = map(sympify, seq)
+        if all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
+            a = ls[0]
+
+            for i in range(1, len(ls)):
+                ls[i-1] = (a/ls[i]).ratsimp()
+            ls.pop()
+
             if all(frc.is_rational for frc in ls):
                 lc = 1
                 for frc in ls:
                     lc = lcm(lc, frc.as_numer_denom()[1])
-                return lc*a
+                return a*lc
 
     except PolificationFailed as exc:
         result = try_non_polynomial_lcm(exc.exprs)
@@ -5397,10 +5408,11 @@ def lcm(f, g=None, *gens, **args):
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
 
         #for lcm in domain Q[irrational]
-        if not f.has(Symbol) and f.is_irrational and not g.has(Symbol) and g.is_irrational:
-            frc = (f/g).ratsimp()
+        a, b = map(sympify, (f, g))
+        if not a.has(Symbol) and a.is_irrational and not b.has(Symbol) and b.is_irrational:
+            frc = (a/b).ratsimp()
             if frc.is_rational:
-                return f*frc.as_numer_denom()[1]
+                return a*frc.as_numer_denom()[1]
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5206,12 +5206,12 @@ def gcd_list(seq, *gens, **args):
         # gcd for domain Q[irrational] (purely algebraic irrational)
         if len(seq) > 1 and all(elt.is_algebraic and elt.is_irrational for elt in seq):
             a = seq[-1]
-            lst = [(a / elt).ratsimp() for elt in seq[:-1]]
+            lst = [ (a/elt).ratsimp() for elt in seq[:-1] ]
             if all(frc.is_rational for frc in lst):
                 lc = 1
                 for frc in lst:
                     lc = lcm(lc, frc.as_numer_denom()[0])
-                return a / lc
+                return a/lc
 
     except PolificationFailed as exc:
         result = try_non_polynomial_gcd(exc.exprs)
@@ -5272,9 +5272,9 @@ def gcd(f, g=None, *gens, **args):
         # gcd for domain Q[irrational] (purely algebraic irrational)
         a, b = map(sympify, (f, g))
         if a.is_algebraic and a.is_irrational and b.is_algebraic and b.is_irrational:
-            frc = (a / b).ratsimp()
+            frc = (a/b).ratsimp()
             if frc.is_rational:
-                return a / frc.as_numer_denom()[0]
+                return a/frc.as_numer_denom()[0]
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)
@@ -5338,12 +5338,12 @@ def lcm_list(seq, *gens, **args):
         # lcm for domain Q[irrational] (purely algebraic irrational)
         if len(seq) > 1 and all(elt.is_algebraic and elt.is_irrational for elt in seq):
             a = seq[-1]
-            lst = [(a / elt).ratsimp() for elt in seq[:-1]]
+            lst = [ (a/elt).ratsimp() for elt in seq[:-1] ]
             if all(frc.is_rational for frc in lst):
                 lc = 1
                 for frc in lst:
                     lc = lcm(lc, frc.as_numer_denom()[1])
-                return a * lc
+                return a*lc
 
     except PolificationFailed as exc:
         result = try_non_polynomial_lcm(exc.exprs)
@@ -5401,9 +5401,9 @@ def lcm(f, g=None, *gens, **args):
         # lcm for domain Q[irrational] (purely algebraic irrational)
         a, b = map(sympify, (f, g))
         if a.is_algebraic and a.is_irrational and b.is_algebraic and b.is_irrational:
-            frc = (a / b).ratsimp()
+            frc = (a/b).ratsimp()
             if frc.is_rational:
-                return a * frc.as_numer_denom()[1]
+                return a*frc.as_numer_denom()[1]
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5204,7 +5204,7 @@ def gcd_list(seq, *gens, **args):
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
         #for gcd in domain Q[irrational]
-        ls = map(sympify, seq)
+        ls = [sympify(ele) for ele in seq]
         if len(ls) > 1 and all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
             a = ls[-1]
             ls.pop()
@@ -5337,7 +5337,7 @@ def lcm_list(seq, *gens, **args):
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
 
         #for lcm in domain Q[irrational]
-        ls = map(sympify, seq)
+        ls = [sympify(ele) for ele in seq]
         if len(ls) > 1 and all(not ele.has(Symbol) and ele.is_irrational for ele in ls):
             a = ls[-1]
             ls.pop()

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core import (
-    S, Basic, Expr, I, Integer, Add, Mul, Dummy, Tuple
+    S, Basic, Expr, I, Integer, Rational, Add, Mul, Dummy, Tuple
 )
 
 from sympy.core.mul import _keep_coeff
@@ -13,6 +13,7 @@ from sympy.core.relational import Relational
 from sympy.core.sympify import sympify
 from sympy.core.decorators import _sympifyit
 from sympy.core.function import Derivative
+from sympy.core.numbers import igcd, ilcm
 
 from sympy.logic.boolalg import BooleanAtom
 
@@ -5202,6 +5203,19 @@ def gcd_list(seq, *gens, **args):
 
     try:
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
+
+        #for gcd in domain Q[irrational]
+        genrs = opt['gens']
+        if len(genrs) == 1:
+            genr = genrs[0]
+            if not genr.has(Symbol) and genr.is_irrational:
+                if all((element/genr).is_rational for element in seq):
+                    num, den = 0, 1
+                    for element in seq:
+                        n, d = (element/genr).as_numer_denom()
+                        num, den = igcd(num, n), ilcm(den, d)
+                    return Rational(num, den) * genr
+
     except PolificationFailed as exc:
         result = try_non_polynomial_gcd(exc.exprs)
 
@@ -5257,6 +5271,18 @@ def gcd(f, g=None, *gens, **args):
 
     try:
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
+
+        #for gcd in domain Q[irrational]
+        genrs = opt['gens']
+        if len(genrs) == 1:
+            genr = genrs[0]
+            if not genr.has(Symbol) and genr.is_irrational:
+                a, b = f/genr, g/genr
+                if a.is_rational and b.is_rational:
+                    an, ad = a.as_numer_denom()
+                    bn, bd = b.as_numer_denom()
+                    return Rational(igcd(an, bn), ilcm(ad, bd)) * genr
+
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)
 
@@ -5315,6 +5341,19 @@ def lcm_list(seq, *gens, **args):
 
     try:
         polys, opt = parallel_poly_from_expr(seq, *gens, **args)
+
+        #for lcm in domain Q[irrational]
+        genrs = opt['gens']
+        if len(genrs) == 1:
+            genr = genrs[0]
+            if not genr.has(Symbol) and genr.is_irrational:
+                if all((element/genr).is_rational for element in seq):
+                    num, den = 1, 0
+                    for element in seq:
+                        n, d = (element/genr).as_numer_denom()
+                        num, den = ilcm(num, n), igcd(den, d)
+                    return Rational(num, den) * genr
+
     except PolificationFailed as exc:
         result = try_non_polynomial_lcm(exc.exprs)
 
@@ -5367,6 +5406,18 @@ def lcm(f, g=None, *gens, **args):
 
     try:
         (F, G), opt = parallel_poly_from_expr((f, g), *gens, **args)
+
+        #for lcm in domain Q[irrational]
+        genrs = opt['gens']
+        if len(genrs) == 1:
+            genr = genrs[0]
+            if not genr.has(Symbol) and genr.is_irrational:
+                a, b = f/genr, g/genr
+                if a.is_rational and b.is_rational:
+                    an, ad = a.as_numer_denom()
+                    bn, bd = b.as_numer_denom()
+                    return Rational(ilcm(an, bn), igcd(ad, bd)) * genr
+
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -13,7 +13,6 @@ from sympy.core.relational import Relational
 from sympy.core.sympify import sympify
 from sympy.core.decorators import _sympifyit
 from sympy.core.function import Derivative
-from sympy.core.numbers import igcd, ilcm
 
 from sympy.logic.boolalg import BooleanAtom
 
@@ -5213,7 +5212,7 @@ def gcd_list(seq, *gens, **args):
                     num, den = 0, 1
                     for element in seq:
                         n, d = (element/genr).as_numer_denom()
-                        num, den = igcd(num, n), ilcm(den, d)
+                        num, den = gcd(num, n), lcm(den, d)
                     return Rational(num, den) * genr
 
     except PolificationFailed as exc:
@@ -5281,7 +5280,7 @@ def gcd(f, g=None, *gens, **args):
                 if a.is_rational and b.is_rational:
                     an, ad = a.as_numer_denom()
                     bn, bd = b.as_numer_denom()
-                    return Rational(igcd(an, bn), ilcm(ad, bd)) * genr
+                    return Rational(gcd(an, bn), lcm(ad, bd)) * genr
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)
@@ -5351,7 +5350,7 @@ def lcm_list(seq, *gens, **args):
                     num, den = 1, 0
                     for element in seq:
                         n, d = (element/genr).as_numer_denom()
-                        num, den = ilcm(num, n), igcd(den, d)
+                        num, den = lcm(num, n), gcd(den, d)
                     return Rational(num, den) * genr
 
     except PolificationFailed as exc:
@@ -5416,7 +5415,7 @@ def lcm(f, g=None, *gens, **args):
                 if a.is_rational and b.is_rational:
                     an, ad = a.as_numer_denom()
                     bn, bd = b.as_numer_denom()
-                    return Rational(ilcm(an, bn), igcd(ad, bd)) * genr
+                    return Rational(lcm(an, bn), gcd(ad, bd)) * genr
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core import (
-    S, Basic, Expr, I, Integer, Rational, Add, Mul, Dummy, Tuple
+    S, Basic, Expr, I, Integer, Add, Mul, Dummy, Tuple
 )
 
 from sympy.core.mul import _keep_coeff
@@ -5209,11 +5209,10 @@ def gcd_list(seq, *gens, **args):
             genr = genrs[0]
             if not genr.has(Symbol) and genr.is_irrational:
                 if all((element/genr).is_rational for element in seq):
-                    num, den = 0, 1
-                    for element in seq:
-                        n, d = (element/genr).as_numer_denom()
-                        num, den = gcd(num, n), lcm(den, d)
-                    return Rational(num, den) * genr
+                    g = seq[0]/genr
+                    for element in seq[1:]:
+                        g = gcd(g, element/genr)
+                    return g * genr
 
     except PolificationFailed as exc:
         result = try_non_polynomial_gcd(exc.exprs)
@@ -5278,9 +5277,7 @@ def gcd(f, g=None, *gens, **args):
             if not genr.has(Symbol) and genr.is_irrational:
                 a, b = f/genr, g/genr
                 if a.is_rational and b.is_rational:
-                    an, ad = a.as_numer_denom()
-                    bn, bd = b.as_numer_denom()
-                    return Rational(gcd(an, bn), lcm(ad, bd)) * genr
+                    return gcd(a, b) * genr
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)
@@ -5347,11 +5344,10 @@ def lcm_list(seq, *gens, **args):
             genr = genrs[0]
             if not genr.has(Symbol) and genr.is_irrational:
                 if all((element/genr).is_rational for element in seq):
-                    num, den = 1, 0
-                    for element in seq:
-                        n, d = (element/genr).as_numer_denom()
-                        num, den = lcm(num, n), gcd(den, d)
-                    return Rational(num, den) * genr
+                    l = seq[0]/genr
+                    for element in seq[1:]:
+                        l = lcm(l, element/genr)
+                    return l * genr
 
     except PolificationFailed as exc:
         result = try_non_polynomial_lcm(exc.exprs)
@@ -5413,9 +5409,7 @@ def lcm(f, g=None, *gens, **args):
             if not genr.has(Symbol) and genr.is_irrational:
                 a, b = f/genr, g/genr
                 if a.is_rational and b.is_rational:
-                    an, ad = a.as_numer_denom()
-                    bn, bd = b.as_numer_denom()
-                    return Rational(lcm(an, bn), gcd(ad, bd)) * genr
+                    return lcm(a, b) * genr
 
     except PolificationFailed as exc:
         domain, (a, b) = construct_domain(exc.exprs)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -53,7 +53,7 @@ from sympy.polys.orderings import lex, grlex, grevlex
 
 from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, sqrt, Piecewise, Derivative,
-    exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff)
+    exp, sin, tanh, expand, oo, I, pi, E, re, im, rootof, Eq, Tuple, Expr, diff)
 
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
@@ -3246,14 +3246,18 @@ def test_issue_12400():
 
 def test_issue_14364():
     assert gcd(S(4)/7, S(2)/3) == S(2)/21
+    assert gcd(S(6)*(1 + sqrt(3))/5, S(3)*(1 + sqrt(3))/10) == S(3)/10 * (1 + sqrt(3))
     assert gcd(pi*S(4)/7, pi*S(2)/3) == pi*S(2)/21
 
     assert lcm(S(2)/3*sqrt(3), S(5)/6*sqrt(3)) == S(10)*sqrt(3)/3
     assert lcm(3*sqrt(3), S(4)/sqrt(3)) == 12*sqrt(3)
+    assert lcm(S(5)*(1 + 2**(S(1)/3))/6, S(3)*(1 + 2**(S(1)/3))/8) == S(15)/2 * (1 + 2**(S(1)/3))
 
     assert gcd(S(2)/3*sqrt(3), S(5)/6/sqrt(3)) == sqrt(3)/18
     assert gcd(S(4)*pi/7, S(3)*pi/14) == pi/14
 
     # gcd_list and lcm_list
     assert gcd([S(2)*pi/7, S(6)*pi/5, S(8)*pi/5]) == S(2)*pi/35
+    assert gcd([S(6)*(1 + pi)/5, S(2)*(1 + pi)/7, S(4)*(1 + pi)/13]) == S(2)/455 * (1 + pi)
     assert lcm((S(7)/pi/2, S(5)/pi/6, S(5)/pi/8)) == S(35)/(2*pi)
+    assert lcm([S(5)*(2 + E)/6, S(7)*(2 + E)/2, S(13)*(2 + E)/4]) == S(455)/2 * (2 + E)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -53,7 +53,7 @@ from sympy.polys.orderings import lex, grlex, grevlex
 
 from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, sqrt, Piecewise, Derivative,
-    exp, sin, tanh, expand, oo, I, pi, E, re, im, rootof, Eq, Tuple, Expr, diff)
+    exp, sin, tanh, expand, oo, I, pi, re, im, rootof, Eq, Tuple, Expr, diff)
 
 from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
@@ -3245,19 +3245,18 @@ def test_issue_12400():
             Poly(1/(1+sqrt(2)), x , domain='EX')
 
 def test_issue_14364():
-    assert gcd(S(4)/7, S(2)/3) == S(2)/21
     assert gcd(S(6)*(1 + sqrt(3))/5, S(3)*(1 + sqrt(3))/10) == S(3)/10 * (1 + sqrt(3))
-    assert gcd(pi*S(4)/7, pi*S(2)/3) == pi*S(2)/21
+    assert gcd(sqrt(5)*S(4)/7, sqrt(5)*S(2)/3) == sqrt(5)*S(2)/21
 
     assert lcm(S(2)/3*sqrt(3), S(5)/6*sqrt(3)) == S(10)*sqrt(3)/3
     assert lcm(3*sqrt(3), S(4)/sqrt(3)) == 12*sqrt(3)
     assert lcm(S(5)*(1 + 2**(S(1)/3))/6, S(3)*(1 + 2**(S(1)/3))/8) == S(15)/2 * (1 + 2**(S(1)/3))
 
     assert gcd(S(2)/3*sqrt(3), S(5)/6/sqrt(3)) == sqrt(3)/18
-    assert gcd(S(4)*pi/7, S(3)*pi/14) == pi/14
+    assert gcd(S(4)*sqrt(13)/7, S(3)*sqrt(13)/14) == sqrt(13)/14
 
     # gcd_list and lcm_list
-    assert gcd([S(2)*pi/7, S(6)*pi/5, S(8)*pi/5]) == S(2)*pi/35
-    assert gcd([S(6)*(1 + pi)/5, S(2)*(1 + pi)/7, S(4)*(1 + pi)/13]) == S(2)/455 * (1 + pi)
-    assert lcm((S(7)/pi/2, S(5)/pi/6, S(5)/pi/8)) == S(35)/(2*pi)
-    assert lcm([S(5)*(2 + E)/6, S(7)*(2 + E)/2, S(13)*(2 + E)/4]) == S(455)/2 * (2 + E)
+    assert gcd([S(2)*sqrt(47)/7, S(6)*sqrt(47)/5, S(8)*sqrt(47)/5]) == S(2)*sqrt(47)/35
+    assert gcd([S(6)*(1 + sqrt(7))/5, S(2)*(1 + sqrt(7))/7, S(4)*(1 + sqrt(7))/13]) == S(2)/455 * (1 + sqrt(7))
+    assert lcm((S(7)/sqrt(15)/2, S(5)/sqrt(15)/6, S(5)/sqrt(15)/8)) == S(35)/(2*sqrt(15))
+    assert lcm([S(5)*(2 + 2**(S(5)/7))/6, S(7)*(2 + 2**(S(5)/7))/2, S(13)*(2 + 2**(S(5)/7))/4]) == S(455)/2 * (2 + 2**(S(5)/7))

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3243,3 +3243,17 @@ def test_issue_12400():
     # Correction of check for negative exponents
     assert poly(1/(1+sqrt(2)), x) == \
             Poly(1/(1+sqrt(2)), x , domain='EX')
+
+def test_issue_14364():
+    assert gcd(S(4)/7, S(2)/3) == S(2)/21
+    assert gcd(pi*S(4)/7, pi*S(2)/3) == pi*S(2)/21
+
+    assert lcm(S(2)/3*sqrt(3), S(5)/6*sqrt(3)) == S(10)*sqrt(3)/3
+    assert lcm(3*sqrt(3), S(4)/sqrt(3)) == 12*sqrt(3)
+
+    assert gcd(S(2)/3*sqrt(3), S(5)/6/sqrt(3)) == sqrt(3)/18
+    assert gcd(S(4)*pi/7, S(3)*pi/14) == pi/14
+
+    # gcd_list and lcm_list
+    assert gcd([S(2)*pi/7, S(6)*pi/5,S(8)*pi/5]) == S(2)*pi/35
+    assert lcm((S(7)/pi/2, S(5)/pi/6,S(5)/pi/8)) == S(35)/(2*pi)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3255,5 +3255,5 @@ def test_issue_14364():
     assert gcd(S(4)*pi/7, S(3)*pi/14) == pi/14
 
     # gcd_list and lcm_list
-    assert gcd([S(2)*pi/7, S(6)*pi/5,S(8)*pi/5]) == S(2)*pi/35
-    assert lcm((S(7)/pi/2, S(5)/pi/6,S(5)/pi/8)) == S(35)/(2*pi)
+    assert gcd([S(2)*pi/7, S(6)*pi/5, S(8)*pi/5]) == S(2)*pi/35
+    assert lcm((S(7)/pi/2, S(5)/pi/6, S(5)/pi/8)) == S(35)/(2*pi)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #14364 


#### Brief description of what is fixed or changed
Updated gcd, gcd_list to support similar type of irrationals
Updated lcm, lcm_list to support similar type of irrationals

```python
>>> pprint(lcm(3*sqrt(3), S(4)/sqrt(3)))

12⋅√3

>>> pprint(gcd(sqrt(5)*S(4)/7, sqrt(5)*S(2)/3))

2⋅√5
────
 21 

>>> pprint(gcd([S(2)*sqrt(47)/7, S(6)*sqrt(47)/5, S(8)*sqrt(47)/5]))

2⋅√47
─────
  35 
```

#### Other comments
As discussed with @jksuom, the irrationals considered have to be purely algebraic. 
Behaviour with transcendental elements (like `pi`, `E`) is unclear.