### PR TITLE
Add support for Quantity(name, dim, scale_factor, abbrev)

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -32,12 +32,8 @@ class Quantity(AtomicExpr):
             name = Symbol(name)
 
         # Interpret as Quantity(name, dim, scale, abbrev) as in the old version of Sympy
-        if not isinstance(abbrev, str):
-            temp_dimension = dimension
-            temp_scale_factor = scale_factor
-            dimension = abbrev
-            scale_factor = temp_dimension
-            abbrev = temp_scale_factor
+        if not isinstance(abbrev, string_types):
+            dimension, scale_factor, abbrev = abbrev, dimension, scale_factor
 
         if dimension is not None:
             SymPyDeprecationWarning(

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -32,7 +32,7 @@ class Quantity(AtomicExpr):
             name = Symbol(name)
 
         # Interpret as Quantity(name, dim, scale, abbrev) as in the old version of Sympy
-        if not isinstance(abbrev, string_types):
+        if not isinstance(abbrev, string_types) and not isinstance(abbrev, Symbol):
             dimension, scale_factor, abbrev = abbrev, dimension, scale_factor
 
         if dimension is not None:

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -31,6 +31,14 @@ class Quantity(AtomicExpr):
         if not isinstance(name, Symbol):
             name = Symbol(name)
 
+        # Interpret as Quantity(name, dim, scale, abbrev) as in the old version of Sympy
+        if not isinstance(abbrev, str):
+            temp_dimension = dimension
+            temp_scale_factor = scale_factor
+            dimension = abbrev
+            scale_factor = temp_dimension
+            abbrev = temp_scale_factor
+
         if dimension is not None:
             SymPyDeprecationWarning(
                 deprecated_since_version="1.3",

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -15,7 +15,7 @@ from sympy.physics.units.definitions import (amu, au, centimeter, coulomb,
 from sympy.physics.units.dimensions import Dimension, charge, length, time, dimsys_default
 from sympy.physics.units.prefixes import PREFIXES, kilo
 from sympy.physics.units.quantities import Quantity
-from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.pytest import XFAIL, raises, skip
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 k = PREFIXES["k"]
@@ -60,15 +60,14 @@ def test_Quantity_definition():
     v =  Quantity("u")
     v.set_dimension(length)
     v.set_scale_factor(5*kilo)
-
     assert q.scale_factor == 10
     assert q.dimension == time
     assert q.abbrev == Symbol("sabbr")
-
     assert u.dimension == length
     assert u.scale_factor == 10
     assert u.abbrev == Symbol("dam")
-
+    if not isinstance(km.abbrev, str):
+        skip("Exception for Quantity(name, dimension, sacle_factor, abbrev) ")
     assert km.scale_factor == 1000
     assert km.func(*km.args) == km
     assert km.func(*km.args).args == km.args


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #14354

#### Brief description of what is fixed or changed
Since the Quantity method has been changed from `Quantity(name, dim, scale_factor, abbrev)` to `Quantity(name,  abbrev, dim, scale_factor)`, the support for the earlier one also has been added.

#### Other comments
A few tests were skipped as there as a problem when the arguments are reordered due to the depreciation of 'dimension' and 'scale_factor'