### PR TITLE
Avoid arg(0) < pi error by checking the argument of arg first

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1013,23 +1013,24 @@ def _check_antecedents(g1, g2, x):
                   Or(Ne(zos, 1), re(mu + rho + v - u) < 1,
                      re(mu + rho + q - p) < 1))
     else:
-        c14 = And(Eq(phi, 0), bstar - 1 + cstar <= 0,
-                  Or(And(Ne(zos, 1), abs(arg_(1 - zos)) < pi),
-                     And(re(mu + rho + v - u) < 1, Eq(zos, 1))))
+        def _cond(z):
+            '''Returns True if abs(arg(1-z)) < pi, avoiding arg(0).
 
-        def _cond():
-            '''
-            Note: if `zso` is 1 then tmp will be NaN.  This raises a
-            TypeError on `NaN < pi`.  Previously this gave `False` so
+            Note: if `z` is 1 then arg is NaN. This raises a
+            TypeError on `NaN < pi`. Previously this gave `False` so
             this behavior has been hardcoded here but someone should
             check if this NaN is more serious! This NaN is triggered by
             test_meijerint() in test_meijerint.py:
             `meijerint_definite(exp(x), x, 0, I)`
             '''
-            tmp = abs(arg_(1 - zso))
-            return False if tmp is S.NaN else tmp < pi
+            return False if z == 1 else abs(arg_(1 - z)) < pi
+
+        c14 = And(Eq(phi, 0), bstar - 1 + cstar <= 0,
+                  Or(And(Ne(zos, 1), _cond(zos)),
+                     And(re(mu + rho + v - u) < 1, Eq(zos, 1))))
+
         c14_alt = And(Eq(phi, 0), cstar - 1 + bstar <= 0,
-                  Or(And(Ne(zso, 1), _cond()),
+                  Or(And(Ne(zso, 1), _cond(zso)),
                      And(re(mu + rho + q - p) < 1, Eq(zso, 1))))
 
         # Since r=k=l=1, in our case there is c14_alt which is the same as calling

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1023,7 +1023,7 @@ def _check_antecedents(g1, g2, x):
             test_meijerint() in test_meijerint.py:
             `meijerint_definite(exp(x), x, 0, I)`
             '''
-            return False if z == 1 else abs(arg_(1 - z)) < pi
+            return z != 1 and abs(arg_(1 - z)) < pi
 
         c14 = And(Eq(phi, 0), bstar - 1 + cstar <= 0,
                   Or(And(Ne(zos, 1), _cond(zos)),

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,11 +1,11 @@
 from sympy import (
     Abs, acos, acosh, Add, And, asin, asinh, atan, Ci, cos, sinh, cosh,
-    tanh, Derivative, diff, DiracDelta, E, Eq, exp, erf, erfi,
+    tanh, Derivative, diff, DiracDelta, E, Ei, Eq, exp, erf, erfi,
     EulerGamma, Expr, factor, Function, I, im, Integral, integrate,
     Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
-    Ne, O, oo, pi, Piecewise, polar_lift, Poly, Rational, re, S, sign,
+    Ne, O, oo, pi, Piecewise, polar_lift, Poly, Rational, re, S, Si, sign,
     simplify, sin, sinc, SingularityFunction, sqrt, sstr, Sum, Symbol,
-    symbols, sympify, tan, trigsimp, Tuple, Si, Ci
+    symbols, sympify, tan, trigsimp, Tuple
 )
 from sympy.functions.elementary.complexes import periodic_argument
 from sympy.functions.elementary.integers import floor
@@ -1313,3 +1313,8 @@ def test_issue_14096():
 def test_issue_14144():
     assert Abs(integrate(1/sqrt(1 - x**3), (x, 0, 1)).n() - 1.402182) < 1e-6
     assert Abs(integrate(sqrt(1 - x**3), (x, 0, 1)).n() - 0.841309) < 1e-6
+
+def test_issue_14375():
+    # This raised a TypeError. The antiderivative has exp_polar, which
+    # may be possible to unpolarify, so the exact output is not asserted here.
+    assert integrate(exp(I*x)*log(x), x).has(Ei)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14375

#### Brief description of what is fixed or changed

In two places in meijerint the condition |arg(1-z)| < pi needs to be checked. The direct evaluation is problematic because if z is 1, the left side is NaN, and NaN < pi is a TypeError. For this reason, `z == 1` has to be checked first in a helper function. And this was already done, but only in one of two places.

Specifically, the variables `zos` and `zso` are checked in the above way; previously only `zso` was. The helper function `_cond` is changed to take a parameter, and its logic is simplified to 
```
return False if z == 1 else abs(arg_(1 - z)) < pi
```

Note that `And(Ne(zos, 1), ... ` part remains in c14 (as it does in c14_alt), because it's still a part of the condition (in case zos was symbolic, and the condition did not evaluate to a boolean). 