### PR TITLE
Use https webfont and MathJax on docs pages

### DIFF
--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -10,7 +10,7 @@
  */
 
 @import url("basic.css");
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
 
 /* -- page layout ----------------------------------------------------------- */
 

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -31,8 +31,8 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.mathjax',
 # To stop docstrings inheritance.
 autodoc_inherit_docstrings = False
 
-# MathJax file, which is free to use.  See http://www.mathjax.org/docs/2.0/start.html
-mathjax_path = 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full'
+# MathJax file, which is free to use.  See https://www.mathjax.org/#gettingstarted
+mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS_HTML-full'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
[Related issue in sympy.github.io repo: Support https](https://github.com/sympy/sympy.github.com/issues/105)

Currently, accessing https://docs.sympy.org results in some mixed content being blocked: a web font and most notably MathJax. MathJax CDN at http://cdn.mathjax.org was retired in April 2017, see https://www.mathjax.org/cdn-shutting-down/ A link to it is replaced by the current MathJax-recommended CDN, at https://cdnjs.cloudflare.com

The remaining http content is SymPy Live shell, which is not available over https. For this reason the canonical URL of docs in layout.html is kept as http, we can switch it to https when the secure pages are fully operational.