### PR TITLE
Fix args of Quantity.__new__ as in older version of Sympy

### DIFF
--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -31,6 +31,12 @@ class Quantity(AtomicExpr):
         if not isinstance(name, Symbol):
             name = Symbol(name)
 
+        # For Quantity(name, dim, scale, abbrev) to work like in the
+        # old version of Sympy:
+        if not isinstance(abbrev, string_types) and not \
+                   isinstance(abbrev, Symbol):
+            dimension, scale_factor, abbrev = abbrev, dimension, scale_factor
+
         if dimension is not None:
             SymPyDeprecationWarning(
                 deprecated_since_version="1.3",


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes: https://github.com/sympy/sympy/issues/14354
#### Brief description of what is fixed or changed
To make sure that Quantity(name, dim, scale, abbrev) still works like in
older version of sympy.

#### Other comments
