### PR TITLE
Make minimal polynomial of I irreducible

### DIFF
--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -528,7 +528,8 @@ def _minpoly_compose(ex, x, dom):
     if ex.is_Rational:
         return ex.q*x - ex.p
     if ex is I:
-        return x**2 + 1
+        _, factors = factor_list(x**2 + 1, x, domain=dom)
+        return x**2 + 1 if len(factors) == 1 else x - I
     if hasattr(dom, 'symbols') and ex in dom.symbols:
         return x - ex
 

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -143,6 +143,12 @@ def test_minimal_polynomial():
     assert minimal_polynomial(sqrt(2)*I + I*(1 + sqrt(2)), x,
             compose=False) ==  x**4 + 18*x**2 + 49
 
+    # minimal polynomial of I
+    assert minimal_polynomial(I, x, domain=QQ.algebraic_field(I)) == x - I
+    K = QQ.algebraic_field(I*(sqrt(2) + 1))
+    assert minimal_polynomial(I, x, domain=K) == x - I
+
+
 def test_minimal_polynomial_hi_prec():
     p = 1/sqrt(1 - 9*sqrt(2) + 7*sqrt(3) + S(1)/10**30)
     mp = minimal_polynomial(p, x)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -147,6 +147,8 @@ def test_minimal_polynomial():
     assert minimal_polynomial(I, x, domain=QQ.algebraic_field(I)) == x - I
     K = QQ.algebraic_field(I*(sqrt(2) + 1))
     assert minimal_polynomial(I, x, domain=K) == x - I
+    assert minimal_polynomial(I, x, domain=QQ) == x**2 + 1
+    assert minimal_polynomial(I, x, domain='QQ(y)') == x**2 + 1
 
 
 def test_minimal_polynomial_hi_prec():


### PR DESCRIPTION
Currently, the minimal polynomial of I is hard-coded `x**2 + 1`
over all domains. This PR returns `x - I` over domains that
contain I.

Current master:
    >>> minimal_polynomial(I, x, domain=QQ.algebraic_field(I))
    x**2 + 1

This PR:
    >>> minimal_polynomial(I, x, domain=QQ.algebraic_field(I))
    x - I
