### PR TITLE
Remove automatic distribution of infinite factors

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -617,8 +617,8 @@ class Mul(Expr, AssocOp):
             c_part.insert(0, coeff)
 
         # we are done
-        if (global_distribute[0] and not nc_part and len(c_part) == 2 and c_part[0].is_Number and
-                c_part[1].is_Add):
+        if (global_distribute[0] and not nc_part and len(c_part) == 2 and
+                c_part[0].is_Number and c_part[0].is_finite and c_part[1].is_Add):
             # 2*(1+a) -> 2 + 2 * a
             coeff = c_part[0]
             c_part = [Add(*[coeff*f for f in c_part[1].args])]

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1948,6 +1948,17 @@ def test_Mul_does_not_cancel_infinities():
     expr = (1/(a+b) + 1/(a-b))/(1/(a+b) - 1/(a-b))
     assert expr.subs(b, a) is nan
 
+
+def test_Mul_does_not_distribute_infinity():
+    a, b = symbols('a b')
+    assert ((1 + I)*oo).is_Mul
+    assert ((a + b)*(-oo)).is_Mul
+    assert ((a + 1)*zoo).is_Mul
+    assert ((1 + I)*oo).is_finite is False
+    z = (1 + I)*oo
+    assert ((1 - I)*z).expand() is oo
+
+
 def test_issue_8247_8354():
     from sympy import tan
     z = sqrt(1 + sqrt(3)) + sqrt(3 + 3*sqrt(3)) - sqrt(10 + 6*sqrt(3))


### PR DESCRIPTION
A small step toward #4596

Infinity no longer distributes over addition, for example `(1 + I)*oo` stays as it was, instead of becoming `oo + I*oo`. Automatic distribution of infinite factors is particularly problematic because it can change the meaning of expression. 

- `(1 + I)*oo` means going along the line y=x toward infinity
- `oo + I*oo` means both real and imaginary part go to infinity independently.

This loss of information affects subsequent computations with the expression.  
```
>>> expand((1 - I)*(1 + I)*oo)
oo  # correct, as 2*oo is oo
>>> z = (1 + I)*oo
>>> expand((1 - I)*z)
nan # wrong
```
The distribution also makes it less obvious that the quantity `(1 + I)*oo` is infinite (#14356). 