### PR TITLE
Made the limit() method mathematically correct

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -53,7 +53,16 @@ def limit(e, z, z0, dir="+"):
     "x**2" and similar, so that it's fast. For all other cases, we use the
     Gruntz algorithm (see the gruntz() function).
     """
-
+    
+    check_complex_var = z.is_real
+    check_complex_func = im(e) == 0
+    if check_complex_var ==False and check_complex_func == False:
+        raise ValueError("The variable %s and function %s are not real valued"%(z, e))
+    elif check_complex_var == False:
+        raise ValueError("The variable %s is not real"%(z))
+    else:
+        raise ValueError("The function %s is not real valued"%(e))
+    
     if dir == "+-":
         llim = Limit(e, z, z0, dir="-").doit(deep=False)
         rlim = Limit(e, z, z0, dir="+").doit(deep=False)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -14,10 +14,12 @@ from sympy.series.order import Order
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.core.numbers import GoldenRatio
 from sympy.functions.combinatorial.numbers import fibonacci
+from sympy import symbols
 
-from sympy.abc import x, y, z, k
+
 n = Symbol('n', integer=True, positive=True)
 
+x,y,z,k = symbols('x y z k', real=True)
 
 def test_basic1():
     assert limit(x, x, oo) == oo


### PR DESCRIPTION
Earlier the method limit() used to give output
even for complex functions and that too on passing
direction. But this was mathematically incorrect.
After this commit this should not happen and proper
error message will pop up.

