### PR TITLE
Limit comparison test introduced

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -464,8 +464,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         # (1/n) comparison
         try:
             lim_comp = limit(sym*sequence_term, sym, S.Infinity)
-            if lim_comp.is_number:
-                if lim_comp > 0:
+            if lim_comp.is_number and lim_comp > 0:
                     return S.false
         except NotImplementedError:
             pass

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -4,7 +4,6 @@ from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.concrete.expr_with_intlimits import ExprWithIntLimits
 from sympy.core.function import Derivative
 from sympy.core.relational import Eq
-from sympy.core.numbers import oo
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Wild, Symbol
 from sympy.core.add import Add
@@ -476,7 +475,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         ### ------------- Limit comparison test -----------###
         # (1/n) comparison
-        lim_comp = limit(sym*sequence_term, sym, oo)
+        lim_comp = limit(sym*sequence_term, sym, S.Infinity)
         if lim_comp is S.Infinity:
             return S.false
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -459,6 +459,15 @@ class Sum(AddWithLimits, ExprWithIntLimits):
             if p2_series_test[p] <= 1:
                 return S.false
 
+        ### ------------- Limit comparison test -----------###
+        # (1/n) comparison
+        try:
+            lim_comp = limit(sym*sequence_term, sym, S.Infinity)
+            if lim_comp is S.Infinity:
+                return S.false
+        except NotImplementedError:
+            pass
+
         ### ----------- root test ---------------- ###
         lim = Limit(abs(sequence_term)**(1/sym), sym, S.Infinity)
         lim_evaluated = lim.doit()
@@ -472,12 +481,6 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         dict_val = sequence_term.match((-1)**(sym + p)*q)
         if not dict_val[p].has(sym) and is_decreasing(dict_val[q], interval):
             return S.true
-
-        ### ------------- Limit comparison test -----------###
-        # (1/n) comparison
-        lim_comp = limit(sym*sequence_term, sym, S.Infinity)
-        if lim_comp is S.Infinity:
-            return S.false
 
         ### ------------- comparison test ------------- ###
         # (1/log(n)**p) comparison

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -463,7 +463,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         # (1/n) comparison
         try:
             lim_comp = limit(sym*sequence_term, sym, S.Infinity)
-            if lim_comp is S.Infinity:
+            if lim_comp > S.Zero:
                 return S.false
         except NotImplementedError:
             pass

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -474,6 +474,12 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         if not dict_val[p].has(sym) and is_decreasing(dict_val[q], interval):
             return S.true
 
+        ### ------------- Limit comparison test -----------###
+        # (1/n) comparison
+        lim_comp = limit(sym*sequence_term, sym, oo)
+        if lim_comp is S.Infinity:
+            return S.false
+
         ### ------------- comparison test ------------- ###
         # (1/log(n)**p) comparison
         log_test = order.expr.match(1/(log(sym)**p))
@@ -518,12 +524,6 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                         return S(integral_val_evaluated.is_finite)
                 except NotImplementedError:
                     pass
-
-        ### ------------- Limit comparison test -----------###
-        # (1/n) comparison
-        lim_comp = limit((sequence_term/(1/sym)), sym, oo)
-        if lim_comp is S.Infinity:
-            return S.false
 
         ### -------------- Dirichlet tests -------------- ###
         if order.expr.is_Mul:

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -521,8 +521,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         ### ------------- Limit comparison test -----------###
         # (1/n) comparison
-        ref_sequence_term = Sum(1/sym, (sym, 1, S.Infinity)).function
-        lim_comp = limit((sequence_term/ref_sequence_term), sym, oo)
+        lim_comp = limit((sequence_term/(1/sym)), sym, oo)
         if lim_comp is S.Infinity:
             return S.false
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -439,10 +439,11 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         next_sequence_term = sequence_term.xreplace({sym: sym + 1})
         ratio = combsimp(powsimp(next_sequence_term/sequence_term))
         lim_ratio = limit(ratio, sym, upper_limit)
-        if abs(lim_ratio) > 1:
-            return S.false
-        if abs(lim_ratio) < 1:
-            return S.true
+        if lim_ratio.is_number:
+            if abs(lim_ratio) > 1:
+                return S.false
+            if abs(lim_ratio) < 1:
+                return S.true
 
         ### --------- p-series test (1/n**p) ---------- ###
         p1_series_test = order.expr.match(sym**p)
@@ -463,8 +464,9 @@ class Sum(AddWithLimits, ExprWithIntLimits):
         # (1/n) comparison
         try:
             lim_comp = limit(sym*sequence_term, sym, S.Infinity)
-            if lim_comp > S.Zero:
-                return S.false
+            if lim_comp.is_number:
+                if lim_comp > 0:
+                    return S.false
         except NotImplementedError:
             pass
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -4,6 +4,7 @@ from sympy.concrete.expr_with_limits import AddWithLimits
 from sympy.concrete.expr_with_intlimits import ExprWithIntLimits
 from sympy.core.function import Derivative
 from sympy.core.relational import Eq
+from sympy.core.numbers import oo
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy, Wild, Symbol
 from sympy.core.add import Add
@@ -517,6 +518,12 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                         return S(integral_val_evaluated.is_finite)
                 except NotImplementedError:
                     pass
+
+        ### ------------- Limit comparison test -----------###
+        # (n) comparison
+        lim_comp = limit((sequence_term/sym), sym, oo)
+        if lim_comp is not S.Infinity:
+            return S.false
 
         ### -------------- Dirichlet tests -------------- ###
         if order.expr.is_Mul:

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -520,9 +520,10 @@ class Sum(AddWithLimits, ExprWithIntLimits):
                     pass
 
         ### ------------- Limit comparison test -----------###
-        # (n) comparison
-        lim_comp = limit((sequence_term/sym), sym, oo)
-        if lim_comp is not S.Infinity:
+        # (1/n) comparison
+        ref_sequence_term = Sum(1/sym, (sym, 1, S.Infinity)).function
+        lim_comp = limit((sequence_term/ref_sequence_term), sym, oo)
+        if lim_comp is S.Infinity:
             return S.false
 
         ### -------------- Dirichlet tests -------------- ###

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1019,3 +1019,6 @@ def test_issue_14112():
 
 def test_issue_14111():
     assert Sum(1/log(log(n)), (n, 22, oo)).is_convergent() is S.false
+
+def test_issue_14484():
+    raises(NotImplementedError, lambda: Sum(sin(n)/log(log(n)), (n, 22, oo)).is_convergent())

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1016,3 +1016,6 @@ def test_issue_14112():
     assert Sum((-1)**n/sqrt(n), (n, 1, oo)).is_absolutely_convergent() is S.false
     assert Sum((-1)**(2*n)/n, (n, 1, oo)).is_convergent() is S.false
     assert Sum((-2)**n + (-3)**n, (n, 1, oo)).is_convergent() is S.false
+
+def test_issue_14111():
+    assert Sum(1/log(log(n)), (n, 22, oo)).is_convergent() is S.false


### PR DESCRIPTION
Fixes #14111 
Fixes #14484 

This PR introduces a new way of finding whether a `Sum` series is `convergent` or not. The `Limit Comparison Test` has been added in the `is_convergent` method.
See [here](https://math.oregonstate.edu/home/programs/undergrad/CalculusQuestStudyGuides/SandS/SeriesTests/limit_comparison.html) for more theory about how the Limit Comparison test works.

I have compared the `sequence_term` with `Sum(1/n, (n, 1, oo))` because we know that the harmonic series diverges, and if the limit turns out to be infinite, then the series in question, is `divergent`. Only the comparison for divergence has been implemented.

Also, it fixes the `TypeError` returned by `Sum(sin(n)/log(log(n)), (n, 22, oo)).is_convergent()`, according to @jksuom 's [comment](https://github.com/sympy/sympy/pull/14401#issuecomment-372310836).

@normalhuman @jksuom Please review.