### PR TITLE
Added simplification of mul having args as units, prefixes and other arguments.

### DIFF
--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -115,7 +115,7 @@ def test_convert_to_tuples_of_quantities():
 
 
 def test_eval_simplify():
-    from sympy.physics.units import cm, mm, km, m, K, Quantity
+    from sympy.physics.units import cm, mm, km, m, K, Quantity, kilo
     from sympy.simplify.simplify import simplify
     from sympy.core.symbol import symbols
     from sympy.utilities.pytest import raises
@@ -128,3 +128,7 @@ def test_eval_simplify():
     assert ((km/cm).simplify()) == 100000
     assert ((10*x*K*km**2/m/cm).simplify()) == 1000000000*x*kelvin
     assert ((cm/km/m).simplify()) == 1/(100*kilometer)
+
+    assert (3*kilo*meter).simplify() == 3000*meter
+    assert (4*kilo*meter/(2*kilometer)).simplify() == 2
+    assert (4*kilometer**2/(kilo*meter)**2).simplify() == 4

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -14,6 +14,7 @@ from sympy import Add, Function, Mul, Pow, Rational, Tuple, sympify
 from sympy.core.compatibility import reduce
 from sympy.physics.units.dimensions import Dimension, dimsys_default
 from sympy.physics.units.quantities import Quantity
+from sympy.physics.units.prefixes import Prefix
 from sympy.utilities.iterables import sift
 
 
@@ -136,6 +137,17 @@ def quantity_simplify(expr):
         return expr
     if not expr.is_Mul:
         return expr.func(*map(quantity_simplify, expr.args))
+
+    if expr.has(Prefix):
+        coeff, args = expr.as_coeff_mul(Prefix)
+        args = list(args)
+        for arg in args:
+            if isinstance(arg, Pow):
+                coeff = coeff * (arg.args[0].scale_factor ** arg.args[1])
+            else:
+                coeff = coeff * arg.scale_factor
+        expr = coeff
+
     coeff, args = expr.as_coeff_mul(Quantity)
     args_pow = [arg.as_base_exp() for arg in args]
     quantity_pow, other_pow = sift(args_pow, lambda x: isinstance(x[0], Quantity), binary=True)

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -143,7 +143,7 @@ def quantity_simplify(expr):
         args = list(args)
         for arg in args:
             if isinstance(arg, Pow):
-                coeff = coeff * (arg.args[0].scale_factor ** arg.args[1])
+                coeff = coeff * (arg.base.scale_factor ** arg.exp)
             else:
                 coeff = coeff * arg.scale_factor
         expr = coeff


### PR DESCRIPTION
#### Brief description of what is fixed or changed

In #14286 simplification for quantities was added. However it was unable to simplify expressions like
```
>>> (3*kilo*meter).simplify()
3*meter*Prefix(kilo, k, 3, 10)
```
while 
```
>>> kilo*meter
1000*meter
```
After changes on this branch
```
>>> (3*kilo*meter).simplify()
3000*meter
```

