### PR TITLE
Prevent infinite recursion in as_real_imag

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1087,7 +1087,8 @@ class Pow(Expr):
                 if re.is_Number and im.is_Number:
                     # We can be more efficient in this case
                     expr = expand_multinomial(self.base**exp)
-                    return expr.as_real_imag()
+                    if expr != self:
+                        return expr.as_real_imag()
 
                 expr = poly(
                     (a + b)**exp)  # a = re, b = im; expr = (a + b*I)**exp
@@ -1097,7 +1098,8 @@ class Pow(Expr):
                 if re.is_Number and im.is_Number:
                     # We can be more efficient in this case
                     expr = expand_multinomial((re + im*S.ImaginaryUnit)**-exp)
-                    return expr.as_real_imag()
+                    if expr != self:
+                        return expr.as_real_imag()
 
                 expr = poly((a + b)**-exp)
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1981,3 +1981,7 @@ def test_issue_8247_8354():
 def test_Add_is_zero():
     x, y = symbols('x y', zero=True)
     assert (x + y).is_zero
+
+
+def test_issue_14392():
+    assert (sin(zoo)**2).as_real_imag() == (nan, nan)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14392

#### Brief description of what is fixed or changed

The method `as_real_imag` calls itself in certain cases, after supposedly transforming the expression into something that can be expanded more efficiently. In some edge cases this transform results in the same expression, forcing infinite recursion. A check is added to prevent this; if the transformed expr is the same as the original, the "more efficient" route is abandoned. 

A test example is `(sin(zoo)**2).as_real_imag()` which results in infinite recursion in current master.