### PR TITLE
The values of transcendental functions at complex infinity

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -818,6 +818,7 @@ class Expr(Basic, EvalfMixin):
         from sympy.solvers.solveset import solveset
         from sympy.sets.sets import Interval
         from sympy.functions.elementary.exponential import log
+        from sympy.calculus.util import AccumBounds
 
         if (a is None and b is None):
             raise ValueError('Both interval ends cannot be None.')
@@ -829,7 +830,7 @@ class Expr(Basic, EvalfMixin):
             A = 0
         else:
             A = self.subs(x, a)
-            if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
+            if A.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity, AccumBounds):
                 if (a < b) != False:
                     A = limit(self, x, a,"+")
                 else:
@@ -844,7 +845,7 @@ class Expr(Basic, EvalfMixin):
             B = 0
         else:
             B = self.subs(x, b)
-            if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity):
+            if B.has(S.NaN, S.Infinity, S.NegativeInfinity, S.ComplexInfinity, AccumBounds):
                 if (a < b) != False:
                     B = limit(self, x, b,"-")
                 else:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -242,6 +242,8 @@ class exp(ExpBase):
                 return S.Infinity
             elif arg is S.NegativeInfinity:
                 return S.Zero
+        elif arg is S.ComplexInfinity:
+            return S.NaN
         elif isinstance(arg, log):
             return arg.args[0]
         elif isinstance(arg, AccumBounds):
@@ -542,6 +544,8 @@ class log(Function):
             elif arg.is_Rational and arg.p == 1:
                 return -cls(arg.q)
 
+        if arg is S.ComplexInfinity:
+                return S.ComplexInfinity
         if isinstance(arg, exp) and arg.args[0].is_real:
             return arg.args[0]
         elif isinstance(arg, exp_polar):

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -9,7 +9,6 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.combinatorial.factorials import factorial, RisingFactorial
 
-
 def _rewrite_hyperbolics_as_exp(expr):
     expr = sympify(expr)
     return expr.xreplace(dict([(h, h.rewrite(exp))
@@ -1028,8 +1027,12 @@ class acosh(InverseHyperbolicFunction):
                     return cst_table[arg]*S.ImaginaryUnit
                 return cst_table[arg]
 
-        if arg.is_infinite:
-            return S.Infinity
+        if arg is S.ComplexInfinity:
+            return S.ComplexInfinity
+        if arg == S.ImaginaryUnit*S.Infinity:
+            return S.Infinity + S.ImaginaryUnit*S.Pi/2
+        if arg == -S.ImaginaryUnit*S.Infinity:
+            return S.Infinity - S.ImaginaryUnit*S.Pi/2
 
     @staticmethod
     @cacheit
@@ -1108,7 +1111,8 @@ class atanh(InverseHyperbolicFunction):
                 return -cls(-arg)
         else:
             if arg is S.ComplexInfinity:
-                return S.NaN
+                from sympy.calculus.util import AccumBounds
+                return S.ImaginaryUnit*AccumBounds(-S.Pi/2, S.Pi/2)
 
             i_coeff = arg.as_coefficient(S.ImaginaryUnit)
 
@@ -1181,7 +1185,7 @@ class acoth(InverseHyperbolicFunction):
                 return -cls(-arg)
         else:
             if arg is S.ComplexInfinity:
-                return 0
+                return S.Zero
 
             i_coeff = arg.as_coefficient(S.ImaginaryUnit)
 
@@ -1318,7 +1322,8 @@ class asech(InverseHyperbolicFunction):
                 return cst_table[arg]
 
         if arg is S.ComplexInfinity:
-            return S.NaN
+            from sympy.calculus.util import AccumBounds
+            return S.ImaginaryUnit*AccumBounds(-S.Pi/2, S.Pi/2)
 
     @staticmethod
     @cacheit

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -81,6 +81,7 @@ def test_exp_infinity():
     assert refine(exp(I*oo)) == nan
     assert refine(exp(-I*oo)) == nan
     assert exp(y*I*oo) != nan
+    assert exp(zoo) == nan
 
 
 def test_exp_subs():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1,6 +1,7 @@
-from sympy import symbols, Symbol, sinh, nan, oo, zoo, pi, asinh, acosh, log, sqrt, \
-    coth, I, cot, E, tanh, tan, cosh, cos, S, sin, Rational, atanh, acoth, \
-    Integer, O, exp, sech, sec, csch, asech, acsch, acos, asin, expand_mul
+from sympy import (symbols, Symbol, sinh, nan, oo, zoo, pi, asinh, acosh, log,
+    sqrt, coth, I, cot, E, tanh, tan, cosh, cos, S, sin, Rational, atanh, acoth,
+    Integer, O, exp, sech, sec, csch, asech, acsch, acos, asin, expand_mul,
+    AccumBounds)
 
 from sympy.utilities.pytest import raises
 
@@ -475,10 +476,10 @@ def test_acosh():
     assert acosh(oo) == oo
     assert acosh(-oo) == oo
 
-    assert acosh(I*oo) == oo
-    assert acosh(-I*oo) == oo
+    assert acosh(I*oo) == oo + I*pi/2
+    assert acosh(-I*oo) == oo - I*pi/2
 
-    assert acosh(zoo) == oo
+    assert acosh(zoo) == zoo
 
     assert acosh(I) == log(I*(1 + sqrt(2)))
     assert acosh(-I) == log(-I*(1 + sqrt(2)))
@@ -530,7 +531,7 @@ def test_asech():
     # at infinites
     assert asech(oo) == I*pi/2
     assert asech(-oo) == I*pi/2
-    assert asech(zoo) == nan
+    assert asech(zoo) == I*AccumBounds(-pi/2, pi/2)
 
     assert asech(I) == log(1 + sqrt(2)) - I*pi/2
     assert asech(-I) == log(1 + sqrt(2)) + I*pi/2
@@ -670,7 +671,7 @@ def test_atanh():
     assert atanh(I*oo) == I*pi/2
     assert atanh(-I*oo) == -I*pi/2
 
-    assert atanh(zoo) == nan
+    assert atanh(zoo) == I*AccumBounds(-pi/2, pi/2)
 
     #properties
     assert atanh(-x) == -atanh(x)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -23,6 +23,7 @@ def test_sin():
 
     assert sin.nargs == FiniteSet(1)
     assert sin(nan) == nan
+    assert sin(zoo) == nan
 
     assert sin(oo) == AccumBounds(-1, 1)
     assert sin(oo) - sin(oo) == AccumBounds(-2, 2)
@@ -244,6 +245,7 @@ def test_cos():
     assert cos(oo) - cos(oo) == AccumBounds(-2, 2)
     assert cos(oo*I) == oo
     assert cos(-oo*I) == oo
+    assert cos(zoo) == nan
 
     assert cos(0) == 1
 
@@ -398,6 +400,7 @@ def test_cos_AccumBounds():
 def test_tan():
     assert tan(nan) == nan
 
+    assert tan(zoo) == nan
     assert tan(oo) == AccumBounds(-oo, oo)
     assert tan(oo) - tan(oo) == AccumBounds(-oo, oo)
     assert tan.nargs == FiniteSet(1)
@@ -548,6 +551,7 @@ def test_cot():
     assert cot.nargs == FiniteSet(1)
     assert cot(oo*I) == -I
     assert cot(-oo*I) == I
+    assert cot(zoo) == nan
 
     assert cot(0) == zoo
     assert cot(2*pi) == zoo
@@ -723,6 +727,7 @@ def test_asin():
     assert asin.nargs == FiniteSet(1)
     assert asin(oo) == -I*oo
     assert asin(-oo) == I*oo
+    assert asin(zoo) == zoo
 
     # Note: asin(-x) = - asin(x)
     assert asin(0) == 0
@@ -836,6 +841,7 @@ def test_atan():
     assert atan.nargs == FiniteSet(1)
     assert atan(oo) == pi/2
     assert atan(-oo) == -pi/2
+    assert atan(zoo) == AccumBounds(-pi/2, pi/2)
 
     assert atan(0) == 0
     assert atan(1) == pi/4
@@ -928,6 +934,7 @@ def test_acot():
     assert acot.nargs == FiniteSet(1)
     assert acot(-oo) == 0
     assert acot(oo) == 0
+    assert acot(zoo) == 0
     assert acot(1) == pi/4
     assert acot(0) == pi/2
     assert acot(sqrt(3)/3) == pi/3
@@ -1308,6 +1315,7 @@ def test_sec():
 
     assert sec.nargs == FiniteSet(1)
 
+    assert sec(zoo) == nan
     assert sec(0) == 1
     assert sec(pi) == -1
     assert sec(pi/2) == zoo
@@ -1390,6 +1398,7 @@ def test_csc():
 
     assert csc(0) == zoo
     assert csc(pi) == zoo
+    assert csc(zoo) == nan
 
     assert csc(pi/2) == 1
     assert csc(-pi/2) == -1

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -265,6 +265,9 @@ class sin(TrigonometricFunction):
             elif arg is S.Infinity or arg is S.NegativeInfinity:
                 return AccumBounds(-1, 1)
 
+        if arg is S.ComplexInfinity:
+            return S.NaN
+
         if isinstance(arg, AccumBounds):
             min, max = arg.min, arg.max
             d = floor(min/(2*S.Pi))
@@ -540,6 +543,9 @@ class cos(TrigonometricFunction):
                 # preserves the information that sin(oo) is between
                 # -1 and 1, where S.NaN does not do that.
                 return AccumBounds(-1, 1)
+
+        if arg is S.ComplexInfinity:
+            return S.NaN
 
         if isinstance(arg, AccumBounds):
             return sin(arg + S.Pi/2)
@@ -959,6 +965,9 @@ class tan(TrigonometricFunction):
             elif arg is S.Infinity or arg is S.NegativeInfinity:
                 return AccumBounds(S.NegativeInfinity, S.Infinity)
 
+        if arg is S.ComplexInfinity:
+            return S.NaN
+
         if isinstance(arg, AccumBounds):
             min, max = arg.min, arg.max
             d = floor(min/S.Pi)
@@ -1251,6 +1260,9 @@ class cot(TrigonometricFunction):
                 return S.NaN
             if arg is S.Zero:
                 return S.ComplexInfinity
+
+        if arg is S.ComplexInfinity:
+            return S.NaN
 
         if isinstance(arg, AccumBounds):
             return -tan(arg + S.Pi/2)
@@ -1916,6 +1928,9 @@ class asin(InverseTrigonometricFunction):
             elif arg is S.NegativeOne:
                 return -S.Pi / 2
 
+        if arg is S.ComplexInfinity:
+            return S.ComplexInfinity
+
         if arg.could_extract_minus_sign():
             return -cls(-arg)
 
@@ -2267,6 +2282,11 @@ class atan(InverseTrigonometricFunction):
                 return S.Pi / 4
             elif arg is S.NegativeOne:
                 return -S.Pi / 4
+
+        if arg is S.ComplexInfinity:
+            from sympy.calculus.util import AccumBounds
+            return AccumBounds(-S.Pi/2, S.Pi/2)
+
         if arg.could_extract_minus_sign():
             return -cls(-arg)
 
@@ -2425,6 +2445,9 @@ class acot(InverseTrigonometricFunction):
                 return S.Pi / 4
             elif arg is S.NegativeOne:
                 return -S.Pi / 4
+
+        if arg is S.ComplexInfinity:
+            return S.Zero
 
         if arg.could_extract_minus_sign():
             return -cls(-arg)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Added or corrected the values of exponential, trigonometric, and hyperbolic functions (with inverses) at complex infinity.

I noticed the inconsistency in that `sin(zoo)` is unevaluated but `re(sin(zoo))` is NaN. Indeed, `sin(zoo).rewrite(exp)` is NaN. I think that for any function that does not have a (finite or infinite) limit at complex infinity, eval should return NaN when the argument is zoo (unless AccumBounds can be used for more specific result). The current behavior of exp and trigonometric functions at zoo:

- exp, sin, cos, tan, cot, sec, csc, asin, atan, acot return unevaluated
- acos returns zoo   (correct)
- asec returns pi/2  (correct, since it is acos(1/z))
- acsc returns 0     (correct, since it is asin(1/z)

For the previously unevaluated functions, the following should be the values at zoo:

- exp, sin, cos, tan, cot, sec, csc should return NaN
- asin should return zoo, as acos does.
- atan should return AccumBounds(-pi/2, pi/2) as its imaginary part tends to 0 while the real part is between these bounds.
- acot should return 0, being atan(1/z).

For the hyperbolic trigonometric functions and their inverses:

- sinh, cosh, tanh, coth, sech, csch presently return NaN at zoo (correct)
- asinh returns zoo, correct
- acosh returns oo; incorrect. Should be zoo as for asinh. There is also a test asserting `acosh(I*oo) == oo` and `acosh(-I*oo) == oo`, but the actual limits of `acosh(I*y)` are `oo+I*pi/2` at oo and `oo-I*pi/2` at -oo.
- atanh returns nan; correct but `I*AccumBounds(-pi/2, pi/2)` would be more accurate
- acoth and acsch return 0; correct
- asech returns NaN; correct but `I*AccumBounds(-pi/2, pi/2)` would be more accurate. (Note the difference from asec: although `asech(z) = acosh(1/z)`, we don't get a limit because the principal branch of acosh is discontinuous at 0.)

Side effect: when testing, I noticed that `Expr._eval_interval` does not pay attention to AccumBounds in the result of substitution. Added them to the list of things that necessitate taking a limit instead of direct substitution.


