### PR TITLE
Added support of continuum_mechanics with units

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -110,7 +110,7 @@ class Beam(object):
 
     @length.setter
     def length(self, l):
-        self._length = sympify(l)
+        self._length = sympify(l).simplify()
 
     @property
     def variable(self):
@@ -152,7 +152,7 @@ class Beam(object):
 
     @elastic_modulus.setter
     def elastic_modulus(self, e):
-        self._elastic_modulus = sympify(e)
+        self._elastic_modulus = sympify(e).simplify()
 
     @property
     def second_moment(self):
@@ -161,7 +161,7 @@ class Beam(object):
 
     @second_moment.setter
     def second_moment(self, i):
-        self._second_moment = sympify(i)
+        self._second_moment = sympify(i).simplify()
 
     @property
     def boundary_conditions(self):
@@ -198,7 +198,12 @@ class Beam(object):
 
     @bc_slope.setter
     def bc_slope(self, s_bcs):
-        self._boundary_conditions['slope'] = s_bcs
+        slope = []
+        for (pos, val) in s_bcs:
+            pos = sympify(pos).simplify()
+            val = sympify(val).simplify()
+            slope.append((pos, val))
+        self._boundary_conditions['slope'] = slope
 
     @property
     def bc_deflection(self):
@@ -206,7 +211,12 @@ class Beam(object):
 
     @bc_deflection.setter
     def bc_deflection(self, d_bcs):
-        self._boundary_conditions['deflection'] = d_bcs
+        deflection = []
+        for (pos, val) in d_bcs:
+            pos = sympify(pos).simplify()
+            val = sympify(val).simplify()
+            deflection.append((pos, val))
+        self._boundary_conditions['deflection'] = deflection
 
     def apply_load(self, value, start, order, end=None):
         """
@@ -252,13 +262,14 @@ class Beam(object):
             + 2*SingularityFunction(x, 3, 0) + 2*SingularityFunction(x, 3, 2)
         """
         x = self.variable
-        value = sympify(value)
-        start = sympify(start)
+        value = sympify(value).simplify()
+        start = sympify(start).simplify()
         order = sympify(order)
 
         self._load += value*SingularityFunction(x, start, order)
 
         if end:
+            end = sympify(end).simplify()
             if order == 0:
                 self._load -= value*SingularityFunction(x, end, order)
             elif order.is_positive:


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Earlier while solving beams gave error when used with units. This was due to non simplification of units.
For the code snippet
```
>>> from sympy import *
>>> from sympy.physics.units import meter, kilogram, newton, second, kilo
>>> from sympy.physics.continuum_mechanics.beam import Beam
>>> E, I = symbols('E, I')
>>> R1, R2 = symbols('R1, R2')
>>> b = Beam(3*meter, E*newton/meter**2, I*meter**4)
>>> b.apply_load(8*kilo*newton, 1*meter, -1)
>>> b.apply_load(R1*kilo*newton, 0*meter, -1)
>>> b.apply_load(R2*kilo*newton, 3*meter, -1)
>>> b.apply_load(12*kilo*newton*meter, 2*meter, -2)
>>> b.bc_deflection = [(0*meter, 0*meter), (3*meter, 0*meter)]
>>> b.solve_for_reaction_loads(R1, R2)
>>> b.reaction_loads
``` 
Earlier it gave Value Error
Now it correctly solves the beam and gives `{R1: -28/3, R2: 4/3}`

