### PR TITLE
[WIP] Modified _eval_nseries of Mul

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1652,7 +1652,10 @@ class Mul(Expr, AssocOp):
         ord_sum = 0
         for o in ord_list:
             ord_sum += o
-        n0 = ord_sum.expr.exp
+        if isinstance(ord_sum.expr, Pow):
+            n0 = ord_sum.expr.exp
+        else:
+            n0 = 0
 
         terms = [t.nseries(x, n=n-n0, logx=logx) for t in self.args]
         res = powsimp(self.func(*terms).expand(), combine='exp', deep=True)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1648,7 +1648,13 @@ class Mul(Expr, AssocOp):
 
     def _eval_nseries(self, x, n, logx):
         from sympy import Order, powsimp
-        terms = [t.nseries(x, n=n, logx=logx) for t in self.args]
+        ord_list = [Order(t.nseries(x, n=10, logx=logx).as_leading_term(x)) for t in self.args]
+        ord_sum = 0
+        for o in ord_list:
+            ord_sum += o
+        n0 = ord_sum.expr.exp
+
+        terms = [t.nseries(x, n=n-n0, logx=logx) for t in self.args]
         res = powsimp(self.func(*terms).expand(), combine='exp', deep=True)
         if res.has(Order):
             res += Order(x**n, x)


### PR DESCRIPTION
Fixes #14068 .

Modified `_eval_nseries` in class `Mul` in `sympy.core.mul` according to the lines of @jksuom 's [comment](https://github.com/sympy/sympy/issues/14068#issue-293993872) here.

**NOW**

```
>>> f = Function("f")
>>> x, logx = symbols('x logx')
>>> self = f(x)/x**10
>>> self._eval_nseries(x, 10, logx)
f(0)/x**10 + Subs(Derivative(f(_x), _x), (_x,), (0,))/x**9 + Subs(Derivative(f(_x), (_x, 2)), (_x,), (0,))/(2*x**8) + Subs(Derivative(f(_x), (_x, 3)), (_x,), (0,))/(6*x**7) + Subs(Derivative(f(_x), (_x, 4)), (_x,), (0,))/(24*x**6) + Subs(Derivative(f(_x), (_x, 5)), (_x,), (0,))/(120*x**5) + Subs(Derivative(f(_x), (_x, 6)), (_x,), (0,))/(720*x**4) + Subs(Derivative(f(_x), (_x, 7)), (_x,), (0,))/(5040*x**3) + Subs(Derivative(f(_x), (_x, 8)), (_x,), (0,))/(40320*x**2) + Subs(Derivative(f(_x), (_x, 9)), (_x,), (0,))/(362880*x) + Subs(Derivative(f(_x), (_x, 10)), (_x,), (0,))/3628800 + x*Subs(Derivative(f(_x), (_x, 11)), (_x,), (0,))/39916800 + x**2*Subs(Derivative(f(_x), (_x, 12)), (_x,), (0,))/479001600 + x**3*Subs(Derivative(f(_x), (_x, 13)), (_x,), (0,))/6227020800 + x**4*Subs(Derivative(f(_x), (_x, 14)), (_x,), (0,))/87178291200 + x**5*Subs(Derivative(f(_x), (_x, 15)), (_x,), (0,))/1307674368000 + x**6*Subs(Derivative(f(_x), (_x, 16)), (_x,), (0,))/20922789888000 + x**7*Subs(Derivative(f(_x), (_x, 17)), (_x,), (0,))/355687428096000 + x**8*Subs(Derivative(f(_x), (_x, 18)), (_x,), (0,))/6402373705728000 + x**9*Subs(Derivative(f(_x), (_x, 19)), (_x,), (0,))/121645100408832000 + O(x**10)
```

Previously , the same function gave only 10 terms with the last term coming upto `O(1)`.
Here, it gives 20 terms with the last term being `O(x**10)`.
 