### PR TITLE
Modified the TR3 function in simplify.fu

### DIFF
--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -4,7 +4,7 @@ from sympy import (
     limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
     atan, gamma, Symbol, S, pi, Integral, Rational, I, EulerGamma,
     tan, cot, integrate, Sum, sign, Function, subfactorial, symbols,
-    binomial, simplify, frac, Float)
+    binomial, simplify, frac, Float, sec)
 
 from sympy.calculus.util import AccumBounds
 from sympy.core.add import Add

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -521,3 +521,6 @@ def test_issue_12564():
     assert limit(((x + sin(x))**2).expand(), x, oo) == oo
     assert limit(((x + cos(x))**2).expand(), x, -oo) == oo
     assert limit(((x + sin(x))**2).expand(), x, -oo) == oo
+
+def test_issue_14411():
+    assert limit(3*sec(4*pi*x-x/3), x, 3*pi/(-2 + 24*pi)) == -oo

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -523,4 +523,4 @@ def test_issue_12564():
     assert limit(((x + sin(x))**2).expand(), x, -oo) == oo
 
 def test_issue_14411():
-    assert limit(3*sec(4*pi*x-x/3), x, 3*pi/(-2 + 24*pi)) == -oo
+    assert limit(3*sec(4*pi*x - x/3), x, 3*pi/(24*pi - 2)) == -oo

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -429,6 +429,8 @@ def TR3(rv):
         if not isinstance(rv, TrigonometricFunction):
             return rv
         rv = rv.func(signsimp(rv.args[0]))
+        if not isinstance(rv, TrigonometricFunction):
+            return rv
         if (rv.args[0] - S.Pi/4).is_positive is (S.Pi/2 - rv.args[0]).is_positive is True:
             fmap = {cos: sin, sin: cos, tan: cot, cot: tan, sec: csc, csc: sec}
             rv = fmap[rv.func](S.Pi/2 - rv.args[0])


### PR DESCRIPTION
Fixes #14411 .

The `isinstance` check for `Trigonometric function` has been repeated again after `rv = rv.func(signsimp(rv.args[0]))`, so that if rv becomes a number, it should be returned at that point.
The `IndexError` no longer appears.

@jksuom , @normalhuman Please review.