### PR TITLE
documentation: Updated installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,10 @@ to ask us anything there. We have a very welcoming and helpful community.
 Download
 --------
 
-Get the latest version of SymPy from
+The recommended installation method is through Anaconda,
+https://www.anaconda.com/download/
+
+You can also get the latest version of SymPy from
 https://pypi.python.org/pypi/sympy/
 
 To get the git version do
@@ -146,16 +149,6 @@ to get it is::
 After making changes to `sympy/parsing/latex/LaTeX.g4`, run::
 
     $ ./setup.py antlr
-
-Usage in Python 3
------------------
-
-SymPy also supports Python 3. If you want to install the latest version in
-Python 3, get the Python 3 tarball from
-https://pypi.python.org/pypi/sympy/
-
-To install the SymPy for Python 3, simply run the above commands with a Python
-3 interpreter.
 
 Clean
 -----

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -5,17 +5,16 @@ Installation
 
 The SymPy CAS can be installed on virtually any computer with Python 2.7 or
 above. SymPy does require `mpmath`_ Python library to be installed first.  The
-current recommended method of installation is through Anaconda, which includes
-mpmath, as well as several other useful libraries.  Alternatively, executables
-are available for Windows, and some Linux distributions have SymPy packages
-available.
+recommended method of installation is through Anaconda, which includes
+mpmath, as well as several other useful libraries.  Alternatively, some Linux
+distributions have SymPy packages available.
 
 SymPy officially supports Python 2.7, 3.4, 3.5, 3.6 and PyPy.
 
 Anaconda
 ========
 
-`Anaconda <http://continuum.io/downloads>`_ is a free Python distribution from
+`Anaconda <https://www.anaconda.com/download/>`_ is a free Python distribution from
 Continuum Analytics that includes SymPy, Matplotlib, IPython, NumPy, and many
 more useful packages for scientific computing. This is recommended because
 many nice features of SymPy are only enabled when certain libraries are
@@ -52,9 +51,8 @@ directory.
 Other Methods
 =============
 
-An installation executable (.exe) is available for Windows users at the
-`downloads site`_. In addition, various Linux distributions have SymPy
-available as a package. You may also install SymPy from source or using pip.
+Various Linux distributions have SymPy available as a package. You may also
+install SymPy from source or using pip.
 
 Run SymPy
 =========


### PR DESCRIPTION
#### Brief description of what is fixed or changed

- Windows executables are no longer available. 
- Anaconda is the recommended installation method. 
- Updated the link to Anaconda download page. 
- Removed outdated Python 3 section.