### PR TITLE
Improve handling of MatrixSymbols in gcd_terms and trigsimp

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -3,7 +3,8 @@
 from __future__ import print_function, division
 
 from sympy.core.add import Add
-from sympy.core.compatibility import iterable, is_sequence, SYMPY_INTS, range
+from sympy.core.compatibility import (iterable, is_sequence, SYMPY_INTS,
+    range, string_types)
 from sympy.core.mul import Mul, _keep_coeff
 from sympy.core.power import Pow
 from sympy.core.basic import Basic, preorder_traversal
@@ -1090,6 +1091,8 @@ def gcd_terms(terms, isprimitive=False, clear=True, fraction=True):
         if not isinstance(a, Expr):
             if isinstance(a, Basic):
                 return a.func(*[handle(i) for i in a.args])
+            elif isinstance(a, string_types):
+                return a
             return type(a)([handle(i) for i in a])
         return gcd_terms(a, isprimitive, clear, fraction)
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -689,6 +689,13 @@ def test_issue_13474():
     assert simplify(x + csch(sinc(1))) == x + csch(sinc(1))
 
 
+def test_issue_14421():
+    t = symbols('t')
+    V = MatrixSymbol('V', 2, 1)
+    expr = sin(t)**2*V[1,0]/V[0,0]**2 + cos(t)*sin(t) + cos(t)**2*V[1,0]/V[0,0]**2
+    assert expr.simplify() == sin(2*t)/2 + V[1, 0]/V[0, 0]**2
+
+
 def test_simplify_function_inverse():
     x, y = symbols('x, y')
     g = Function('g')

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -1,7 +1,8 @@
 from sympy import (
     symbols, sin, simplify, cos, trigsimp, rad, tan, exptrigsimp,sinh,
     cosh, diff, cot, Subs, exp, tanh, exp, S, integrate, I,Matrix,
-    Symbol, coth, pi, log, count_ops, sqrt, E, expand, Piecewise)
+    Symbol, coth, pi, log, count_ops, sqrt, E, expand, Piecewise,
+    MatrixSymbol)
 
 from sympy.core.compatibility import long
 from sympy.utilities.pytest import XFAIL
@@ -415,6 +416,13 @@ def test_issue_6811_fail():
     xp, y, x, z = symbols('xp, y, x, z')
     eq = 4*(-19*sin(x)*y + 5*sin(3*x)*y + 15*cos(2*x)*z - 21*z)*xp/(9*cos(x) - 5*cos(3*x))
     assert trigsimp(eq) == -2*(2*cos(x)*tan(x)*y + 3*z)*xp/cos(x)
+
+
+def test_issue_14421():
+    t = symbols('t')
+    V = MatrixSymbol('V', 2, 1)
+    expr = sin(t)**2*V[1,0] + cos(t)**2*V[1,0]
+    assert trigsimp(expr) == V[1, 0]
 
 
 def test_Piecewise():

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1170,12 +1170,12 @@ def _futrig(e, **kwargs):
 def _is_Expr(e):
     """_eapply helper to tell whether ``e`` and all its args
     are Exprs."""
-    from sympy import Derivative
+    from sympy.core.function import Derivative
     if isinstance(e, Derivative):
         return _is_Expr(e.expr)
     if not isinstance(e, Expr):
         return False
-    return all(_is_Expr(i) for i in e.args)
+    return all(isinstance(i, Expr) for i in e.args)
 
 
 def _eapply(func, e, cond=None):


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14421.

#### Brief description of what is fixed or changed

MatrixSymbol objects sometimes cause trouble because one of their args is a string, which is unusual for SymPy.
```
>>> M = MatrixSymbol('M', 3, 3)
>>> M.args
('M', 3, 3)
```
The helper function `handle` of `gcd_terms` applies itself recursively to non-Expr objects `a` as follows:
```
type(a)([handle(i) for i in a])
```
This is a problem when a is a string, since `[i for i in a]` is a list of characters; so the function gets applied to the first character again. This is fixed now.

Issue #14421 also exposed a defect in trigsimp:
```
trigsimp(sin(t)**2*V[1,0] + cos(t)**2*V[1,0])  # no simplification
```
The reason was an unnecessarily recursive check in `_is_Expr` part of `_eapply` helper. This check was intended to ensure that an object and all of its args are instances of Expr. But in fact it demanded also args of args, etc, to be Expr. Thus, any expression containing MatrixSymbol failed the check. The recursive behavior was unnecessary, because the functions used by `_eapply` do not recurse through expression tree. Checking that the first-level arguments are Expr is sufficient, and this is what is done now.