### PR TITLE
primitive_element: improvement

### DIFF
--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -840,7 +840,12 @@ def primitive_element(extension, x=None, **args):
 
     if not args.get('ex', False):
         gen, coeffs = extension[0], [1]
-        g = minimal_polynomial(gen, x, polys=True)
+        # XXX when minimal_polynomial is extended to work
+        # with AlgebraicNumbers this test can be removed
+        if isinstance(gen, AlgebraicNumber):
+            g = gen.minpoly
+        else:
+            g = minimal_polynomial(gen, x, polys=True)
         for ext in extension[1:]:
             _, factors = factor_list(g, extension=ext)
             g = _choose_factor(factors, x, gen)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -843,7 +843,7 @@ def primitive_element(extension, x=None, **args):
         # XXX when minimal_polynomial is extended to work
         # with AlgebraicNumbers this test can be removed
         if isinstance(gen, AlgebraicNumber):
-            g = gen.minpoly
+            g = gen.minpoly.replace(x)
         else:
             g = minimal_polynomial(gen, x, polys=True)
         for ext in extension[1:]:

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -837,14 +837,16 @@ def primitive_element(extension, x=None, **args):
         x, cls = sympify(x), Poly
     else:
         x, cls = Dummy('x'), PurePoly
+
     if not args.get('ex', False):
-        extension = [ AlgebraicNumber(ext, gen=x) for ext in extension ]
-
-        g, coeffs = extension[0].minpoly.replace(x), [1]
-
+        gen, coeffs = extension[0], [1]
+        g = minimal_polynomial(gen, x, polys=True)
         for ext in extension[1:]:
-            s, _, g = sqf_norm(g, x, extension=ext)
-            coeffs = [ s*c for c in coeffs ] + [1]
+            _, factors = factor_list(g, extension=ext)
+            g = _choose_factor(factors, x, gen)
+            s, _, g = g.sqf_norm()
+            gen += s*ext
+            coeffs.append(s)
 
         if not args.get('polys', False):
             return g.as_expr(), coeffs

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -280,6 +280,9 @@ def test_primitive_element():
     raises(ValueError, lambda: primitive_element([], x, ex=False))
     raises(ValueError, lambda: primitive_element([], x, ex=True))
 
+    # Issue 14117
+    a, b = I*sqrt(2*sqrt(2) + 3), I*sqrt(-2*sqrt(2) + 3)
+    assert primitive_element([a, b, I], x) == (x**4 + 6*x**2 + 1, [1, 0, 0])
 
 def test_field_isomorphism_pslq():
     a = AlgebraicNumber(I)


### PR DESCRIPTION
#### References to other Issues or PRs

#14117 

#### Brief description of what is fixed or changed

Currently, primitive_element (non-experimental version) does not
correctly handle sequences of input extensions that are not
linearly disjoint because the minimal polynomial (over Q) of one
extension may be reducible over another extension. (See
https://github.com/sympy/sympy/issues/14117#issuecomment-364207683)

Here, the minimal polynomial of each incrementally constructed
extension is replaced by a factor that is irreducible over the
next input extension.

Also, the polynomials whose sqf_norm is computed are chosen so that
the coefficients s need not be cumulatively multiplied.

Finally, input extension generators are not converted to AlgebraicNumbers
as it seems unnecessary.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
