### PR TITLE
Updated prime test by adding euler psudoprimes and added Carmichael Numbers

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -8,7 +8,8 @@ the separate 'factorials' module.
 """
 
 from __future__ import print_function, division
-
+from sets import Set
+from math import sqrt
 from sympy.core import S, Symbol, Rational, Integer, Add, Dummy
 from sympy.core.compatibility import as_int, SYMPY_INTS, range
 from sympy.core.cache import cacheit
@@ -994,6 +995,162 @@ class catalan(Function):
         from sympy import gamma
         if self.args[0].is_number:
             return self.rewrite(gamma)._eval_evalf(prec)
+
+
+#----------------------------------------------------------------------------#
+#                                                                            #
+#                           Carmichael numbers                               #
+#                                                                            #
+#----------------------------------------------------------------------------#
+
+
+class carmichael(Function):
+    r"""
+     Carmichael Numbers 
+     Certain cryptographic algorithms make use of big prime numbers. However, checking whether a big number is prime is not so easy.
+     Randomized primality tests exist that offer a high degree of confidence of accurate determination at low cost, such as the 
+     Fermat test. Let a be a random number between 2 and n - 1, where n is the number whose primality we are testing.
+     Then, n is probably prime if the following equation holds:
+     an mod n = a.If a number passes the Fermat test several times, then it is prime with a high probability.
+     Unfortunately, there is bad news. Certain composite numbers (non-primes) still pass the Fermat test with every number smaller than themselves.
+     These numbers are called Carmichael numbers.
+     
+     A Carmichael number will pass a Fermat primality test to every base b relatively prime to the number,
+     even though it is not actually prime. This makes tests based on Fermat's Little Theorem less effective than 
+     strong probable prime tests such as the Baillie-PSW primality test and the Miller–Rabin primality test.
+     
+     mr functions given in sympy/sympy/ntheory/primetest.py will go wrong for each and every carmichael number
+     
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Carmichael_number
+ 
+    Examples
+    ========
+    from sympy.ntheory.primetest import mr
+    if __name__ == "__main__":
+
+    # test code
+        numCarmichaels = 10
+        print "First " + str(numCarmichaels) + " Carmichael Numbers:"
+        carmichaelSet = find_first_n_carmichaels(numCarmichaels)
+        carmichaelSet = sorted(carmichaelSet)
+
+        print str(carmichaelSet)
+        print "\n---Miller-Rabin Prime Tests---"
+        print '%10s' % "Carmichael" + \
+              '%6s' % " Miller Rabin" +\
+              '%6s' % " Truth"
+        for c in carmichaelSet:
+            print '%10s' % str(c) + "|" + \
+                  '%6s' % str(mr(c, [10,2,3,9,17,8])) + "|" + \
+                  '%6s' % str(is_prime(c))
+
+        start = 100
+        end = 10000
+        print "\nCarmichael numbers between " + str(start) + " and " + str(end) + ":"
+        print str(find_carmichaels_in_range(start, end))
+    
+     Output
+    ========
+     >>> 
+    ======================== RESTART: C:/Python27/sympycarmichael.py ========================
+    First 10 Carmichael Numbers:
+    1) 561
+    2) 1105
+    3) 1729
+    4) 2465
+    5) 2821
+    6) 6601
+    7) 8911
+    8) 10585
+    9) 15841
+    10) 29341
+    [561, 1105, 1729, 2465, 2821, 6601, 8911, 10585, 15841, 29341]
+
+    ---Fermat Prime Tests---
+    Carmichael Miller Rabin Truth
+           561| False
+          1105| False
+          1729| False
+          2465| False
+          2821| False
+          6601| False
+          8911| False
+         10585| False
+         15841| False
+         29341| False
+
+    Carmichael numbers between 100 and 10000:
+    Set([128, 512, 8192, 2821, 2048, 1729, 6601, 8911, 1105, 561, 2465])
+
+    """
+    # returns true if n is a perfect square
+    def is_perfect_square(n):
+        root = int(sqrt(n))
+        if(root**2 == n):
+            return True
+        return False
+
+    # returns true if p divides n
+    def divides(p, n):
+        return n%p == 0
+
+    # returns true if n is prime
+    def is_prime(n):
+        if(n%2 == 0):
+            return False
+        if(n<2):
+            return False
+
+        global knownPrimes
+        if(n in knownPrimes):
+            return True
+        else:
+            for i in range(3, n/2, 2):
+                if not (n%i):
+                    return False
+
+        knownPrimes.add(n)
+        return True
+    # returns true if n is a Carmichael number
+    def is_carmichael(n):
+        if(n==1):
+            return False
+        if(is_prime(n)):
+            return False
+
+        divisors = Set([1, n])
+        # get divisors
+        for i in xrange(3, n/2+1, 2):
+            if(n%i == 0):
+                divisors.add(i)
+
+        for i in divisors:
+            if(is_perfect_square(i) and i != 1):
+                return False
+            if(is_prime(i)):
+                if(not divides(i-1, n-1)):
+                    return False
+
+        return True
+
+    # returns a set object of Carmichaels in [x, y], where x and y are non-negative integers and x <= y
+    def find_carmichaels_in_range(x, y):
+        return Set([i for i in xrange(x, y) if is_carmichael(i)])
+
+    # returns a set of the first n Carmichael numbers beginning its search from 0
+    #As the numbers are added to that set they are printed out
+    def find_first_n_carmichaels(n):
+        i = 1
+        carmichaels = Set()
+        while len(carmichaels) < n:
+            if(is_carmichael(i)):
+                carmichaels.add(i)
+                print str(len(carmichaels)) + ") " + str(i)
+            i += 2
+        return carmichaels
 
 
 #----------------------------------------------------------------------------#

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -250,3 +250,34 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         if symmetric:
             return symmetric_residue(n, m), m
         return n, m
+    
+''' we are trying to define and generalize quadratic residue of a number'''    
+def sqrtmod(a,n):
+	"""sqrtmod(a,n) - Computes sqrt(a) mod n using various algorithms.
+	Currently n must be prime, this will be extended to general case n after some time."""
+	if(not isprime(n)): raise ValueError("*** Error ***:  Currently can only compute sqrtmod(a,n) for prime n.")
+	if(pow(a,(n-1)//2,n)!=1): raise ValueError("*** Error ***:  a is not quadratic residue, so sqrtmod(a,n) has no answer.")
+	return TSRsqrtmod(a,n-1,n)   #if n is prime we can fid its quadratic residue
+
+def TSRsqrtmod(a,grpord,p):
+	"""TSRsqrtmod(a,grpord,p) - Compute sqrt(a) mod n using Tonelli-Shanks-RESSOL algorithm.
+	Here integers mod n must form a cyclic group of order grpord.the paper is given below
+    http://www.cmat.edu.uy/~tornaria/pub/Tornaria-2002.pdf """
+	ordpow2=0; non2=grpord
+	while(not ((non2&0x01)==1)):
+		ordpow2+=1; non2//=2
+	# Find 2-primitive g (i.e. non-QR)
+	for g in range(2,grpord-1):
+		if (pow(g,grpord//2,p)!=1):
+			break
+	g = pow(g,non2,p)
+	# Tweak a by appropriate power of g, so result is (2^ordpow2)-residue
+	gpow=0; atweak=a
+	for pow2 in range(0,ordpow2+1):
+		if(pow(atweak,non2*2**(ordpow2-pow2),p)!=1):
+			gpow+=2**(pow2-1)
+			atweak = (atweak * pow(g,2**(pow2-1),p)) % p
+	# Now a*(g**powg) is in cyclic group of odd order non2 - can sqrt directly
+	d = invmod(2,non2)
+	tmp = pow(a*pow(g,gpow,p),d,p)  # sqrt(a*(g**gpow))
+	return (tmp*inverse_mod(pow(g,gpow//2,p),p)) % p  # sqrt(a*(g**gpow))//g**(gpow//2)	

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -250,34 +250,3 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         if symmetric:
             return symmetric_residue(n, m), m
         return n, m
-    
-''' we are trying to define and generalize quadratic residue of a number'''    
-def sqrtmod(a,n):
-	"""sqrtmod(a,n) - Computes sqrt(a) mod n using various algorithms.
-	Currently n must be prime, this will be extended to general case n after some time."""
-	if(not isprime(n)): raise ValueError("*** Error ***:  Currently can only compute sqrtmod(a,n) for prime n.")
-	if(pow(a,(n-1)//2,n)!=1): raise ValueError("*** Error ***:  a is not quadratic residue, so sqrtmod(a,n) has no answer.")
-	return TSRsqrtmod(a,n-1,n)   #if n is prime we can fid its quadratic residue
-
-def TSRsqrtmod(a,grpord,p):
-	"""TSRsqrtmod(a,grpord,p) - Compute sqrt(a) mod n using Tonelli-Shanks-RESSOL algorithm.
-	Here integers mod n must form a cyclic group of order grpord.the paper is given below
-    http://www.cmat.edu.uy/~tornaria/pub/Tornaria-2002.pdf """
-	ordpow2=0; non2=grpord
-	while(not ((non2&0x01)==1)):
-		ordpow2+=1; non2//=2
-	# Find 2-primitive g (i.e. non-QR)
-	for g in range(2,grpord-1):
-		if (pow(g,grpord//2,p)!=1):
-			break
-	g = pow(g,non2,p)
-	# Tweak a by appropriate power of g, so result is (2^ordpow2)-residue
-	gpow=0; atweak=a
-	for pow2 in range(0,ordpow2+1):
-		if(pow(atweak,non2*2**(ordpow2-pow2),p)!=1):
-			gpow+=2**(pow2-1)
-			atweak = (atweak * pow(g,2**(pow2-1),p)) % p
-	# Now a*(g**powg) is in cyclic group of odd order non2 - can sqrt directly
-	d = invmod(2,non2)
-	tmp = pow(a*pow(g,gpow,p),d,p)  # sqrt(a*(g**gpow))
-	return (tmp*inverse_mod(pow(g,gpow//2,p),p)) % p  # sqrt(a*(g**gpow))//g**(gpow//2)	

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -112,30 +112,27 @@ def mr(n, bases):
 
 
 def is_euler_pseudoprime(n, b):
+    """Return True if n is prime or an Euler pseudoprime to base b, else False."""
     from sympy.ntheory.factor_ import trailing
-    """Tests whether n is prime or an Euler pseudoprime to base b."""
+
     if not mr(n, [b]):
         return False
+
     n = as_int(n)
-    r = n-1
-    r = as_int(r)
-    s = trailing(r)
-    s = as_int(s)
-    r = r //(2**s)
-    c = pow(b, r, n)
+    r = n - 1
+    c = pow(b, r >> trailing(r), n)
     if c == 1:
         return True
-    
+
     while True:
-        if c == n-1:
+        if c == n - 1:
             return True
-        
         c = pow(c, 2, n)
         if c == 1:
             return False
-        
 
-        
+
+
 def _lucas_sequence(n, P, Q, k):
     """Return the modular Lucas sequence (U_k, V_k, Q_k).
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -110,6 +110,27 @@ def mr(n, bases):
     return True
 
 
+def is_euler_pseudoprime(n, b):
+    """Return True if n is prime or an Euler pseudoprime to base b, else False."""
+    from sympy.ntheory.factor_ import trailing
+
+    if not mr(n, [b]):
+        return False
+
+    n = as_int(n)
+    r = n - 1
+    c = pow(b, r >> trailing(r), n)
+    if c == 1:
+        return True
+
+    while True:
+        if c == n - 1:
+            return True
+        c = pow(c, 2, n)
+        if c == 1:
+            return False
+
+
 def _lucas_sequence(n, P, Q, k):
     """Return the modular Lucas sequence (U_k, V_k, Q_k).
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -110,29 +110,6 @@ def mr(n, bases):
     return True
 
 
-
-def is_euler_pseudoprime(n, b):
-    """Return True if n is prime or an Euler pseudoprime to base b, else False."""
-    from sympy.ntheory.factor_ import trailing
-
-    if not mr(n, [b]):
-        return False
-
-    n = as_int(n)
-    r = n - 1
-    c = pow(b, r >> trailing(r), n)
-    if c == 1:
-        return True
-
-    while True:
-        if c == n - 1:
-            return True
-        c = pow(c, 2, n)
-        if c == 1:
-            return False
-
-
-
 def _lucas_sequence(n, P, Q, k):
     """Return the modular Lucas sequence (U_k, V_k, Q_k).
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -111,33 +111,31 @@ def mr(n, bases):
 
 
 
-
-"""Tests whether n is prime or an Euler pseudoprime to base b."""
 def is_euler_pseudoprime(n, b):
-	if not mr(n, [b]):
+    from sympy.ntheory.factor_ import trailing
+    """Tests whether n is prime or an Euler pseudoprime to base b."""
+    if not mr(n, [b]):
         return False
-    
-    
-	r = n-1
+    n = as_int(n)
+    r = n-1
     r = as_int(r)
-	while r % 2 == 0:
-        r //= 2
-    
-	c = pow(b, r, n)
-	if c == 1:
+    s = trailing(r)
+    s = as_int(s)
+    r = r //(2**s)
+    c = pow(b, r, n)
+    if c == 1:
         return True
     
-	while True:
-		if (c == 1):
-            return False
-        
-		if (c == n-1):
+    while True:
+        if c == n-1:
             return True
         
-		c = pow(c, 2, n)
+        c = pow(c, 2, n)
+        if c == 1:
+            return False
+        
 
-
-
+        
 def _lucas_sequence(n, P, Q, k):
     """Return the modular Lucas sequence (U_k, V_k, Q_k).
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -110,21 +110,24 @@ def mr(n, bases):
     return True
 
 
-def isprimeE(n, b):
-    """Test whether n is prime or an Euler pseudoprime to base b."""
-	if (not mr(n, [b])):
+
+
+"""Tests whether n is prime or an Euler pseudoprime to base b."""
+def is_euler_pseudoprime(n, b):
+	if not mr(n, [b]):
         return False
     
-    r = int(r)
+    
 	r = n-1
-	while (r % 2 == 0):
+    r = as_int(r)
+	while r % 2 == 0:
         r //= 2
     
 	c = pow(b, r, n)
-	if (c == 1):
+	if c == 1:
         return True
     
-	while (1):
+	while True:
 		if (c == 1):
             return False
         

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -111,18 +111,25 @@ def mr(n, bases):
 
 
 def isprimeE(n, b):
-    """isprimeE(n ,b) - Test whether n is prime or an Euler pseudoprime to base b."""
-	if (not mr(n, b)): return False
+    """Test whether n is prime or an Euler pseudoprime to base b."""
+	if (not mr(n, [b])):
+        return False
     
+    r = int(r)
 	r = n-1
-	while (r % 2 == 0): r //= 2
+	while (r % 2 == 0):
+        r //= 2
     
 	c = pow(b, r, n)
-	if (c == 1): return True
+	if (c == 1):
+        return True
+    
 	while (1):
-		if (c == 1): return False
+		if (c == 1):
+            return False
         
-		if (c == n-1): return True
+		if (c == n-1):
+            return True
         
 		c = pow(c, 2, n)
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -110,17 +110,22 @@ def mr(n, bases):
     return True
 
 
-def isprimeE(n,b):
-	"""isprimeE(n) - Test whether n is prime or an Euler pseudoprime to base b."""
-	if (not mr(n,b)): return False
+def isprimeE(n, b):
+    """isprimeE(n ,b) - Test whether n is prime or an Euler pseudoprime to base b."""
+	if (not mr(n, b)): return False
+    
 	r = n-1
 	while (r % 2 == 0): r //= 2
-	c = pow(b,r,n)
+    
+	c = pow(b, r, n)
 	if (c == 1): return True
 	while (1):
 		if (c == 1): return False
+        
 		if (c == n-1): return True
-		c = pow(c,2,n)
+        
+		c = pow(c, 2, n)
+
 
 
 def _lucas_sequence(n, P, Q, k):

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -110,6 +110,19 @@ def mr(n, bases):
     return True
 
 
+def isprimeE(n,b):
+	"""isprimeE(n) - Test whether n is prime or an Euler pseudoprime to base b."""
+	if (not mr(n,b)): return False
+	r = n-1
+	while (r % 2 == 0): r //= 2
+	c = pow(b,r,n)
+	if (c == 1): return True
+	while (1):
+		if (c == 1): return False
+		if (c == n-1): return True
+		c = pow(c,2,n)
+
+
 def _lucas_sequence(n, P, Q, k):
     """Return the modular Lucas sequence (U_k, V_k, Q_k).
 

--- a/sympy/series/series.py
+++ b/sympy/series/series.py
@@ -10,4 +10,3 @@ def series(expr, x=None, x0=0, n=6, dir="+"):
     """
     expr = sympify(expr)
     return expr.series(x, x0, n, dir)
-

--- a/sympy/series/series.py
+++ b/sympy/series/series.py
@@ -6,7 +6,8 @@ from sympy.core.sympify import sympify
 def series(expr, x=None, x0=0, n=6, dir="+"):
     """Series expansion of expr around point `x = x0`.
 
-    See the doctring of Expr.series() for complete details of this wrapper.
+    See the docstring of Expr.series() for complete details of this wrapper.
     """
     expr = sympify(expr)
     return expr.series(x, x0, n, dir)
+


### PR DESCRIPTION
A Carmichael number will pass a Fermat primality test to every base b relatively prime to the number, even though it is not actually prime. This makes tests based on Fermat's Little Theorem less effective than strong probable prime tests such as the Baillie-PSW primality test and the **Miller–Rabin** primality test given in sympy/ntheory/primetest.py

However, no Carmichael number is either a Euler-Jacobi pseudoprime or a strong pseudoprime to every base relatively prime to it so, in theory, either a Euler or a strong probable prime test could prove that a Carmichael number is, in fact, composite.

Source  : https://en.wikipedia.org/wiki/Carmichael_number