### PR TITLE
Remove integral from ellipse circumference calculation

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -16,6 +16,7 @@ from sympy.core.symbol import Dummy, _uniquely_named_symbol, _symbol
 from sympy.simplify import simplify, trigsimp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import cos, sin
+from sympy.functions.special.elliptic_integrals import elliptic_e
 from sympy.geometry.exceptions import GeometryError
 from sympy.geometry.line import Ray2D, Segment2D, Line2D, LinearEntity3D
 from sympy.polys import DomainError, Poly, PolynomialError
@@ -327,16 +328,10 @@ class Ellipse(GeometrySet):
         >>> p1 = Point(0, 0)
         >>> e1 = Ellipse(p1, 3, 1)
         >>> e1.circumference
-        12*Integral(sqrt((-8*_x**2/9 + 1)/(-_x**2 + 1)), (_x, 0, 1))
+        4*elliptic_e(2*sqrt(2)/3)
 
         """
-        from sympy import Integral
-        if self.eccentricity == 1:
-            return 2*pi*self.hradius
-        else:
-            x = Dummy('x', real=True)
-            return 4*self.major*Integral(
-                sqrt((1 - (self.eccentricity*x)**2)/(1 - x**2)), (x, 0, 1))
+        return 4 * self.minor * elliptic_e(self.eccentricity)
 
     @property
     def eccentricity(self):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -331,6 +331,8 @@ class Ellipse(GeometrySet):
         4*elliptic_e(2*sqrt(2)/3)
 
         """
+        if self.eccentricity == 1:
+            return 2 * pi * self.hradius
         return 4 * self.minor * elliptic_e(self.eccentricity)
 
     @property

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -151,7 +151,7 @@ class Ellipse(GeometrySet):
         if len(center) != 2:
             raise ValueError('The center of "{0}" must be a two dimensional point'.format(cls))
 
-        if len(list(filter(None, (hradius, vradius, eccentricity)))) != 2:
+        if len(list(filter(lambda x: x is not None, (hradius, vradius, eccentricity)))) != 2:
             raise ValueError('Exactly two arguments of "hradius", '
                 '"vradius", and "eccentricity" must not be None."')
 
@@ -332,8 +332,13 @@ class Ellipse(GeometrySet):
 
         """
         if self.eccentricity == 1:
+            # degenerate
+            return 4 * self.major
+        elif self.eccentricity == 0:
+            # circle
             return 2 * pi * self.hradius
-        return 4 * self.major * elliptic_e(self.eccentricity)
+        else:
+            return 4 * self.major * elliptic_e(self.eccentricity)
 
     @property
     def eccentricity(self):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -328,7 +328,7 @@ class Ellipse(GeometrySet):
         >>> p1 = Point(0, 0)
         >>> e1 = Ellipse(p1, 3, 1)
         >>> e1.circumference
-        12*elliptic_e(2*sqrt(2)/3)
+        12*elliptic_e(8/9)
 
         """
         if self.eccentricity == 1:
@@ -338,7 +338,7 @@ class Ellipse(GeometrySet):
             # circle
             return 2 * pi * self.hradius
         else:
-            return 4 * self.major * elliptic_e(self.eccentricity)
+            return 4 * self.major * elliptic_e(self.eccentricity**2)
 
     @property
     def eccentricity(self):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -328,12 +328,12 @@ class Ellipse(GeometrySet):
         >>> p1 = Point(0, 0)
         >>> e1 = Ellipse(p1, 3, 1)
         >>> e1.circumference
-        4*elliptic_e(2*sqrt(2)/3)
+        12*elliptic_e(2*sqrt(2)/3)
 
         """
         if self.eccentricity == 1:
             return 2 * pi * self.hradius
-        return 4 * self.minor * elliptic_e(self.eccentricity)
+        return 4 * self.major * elliptic_e(self.eccentricity)
 
     @property
     def eccentricity(self):

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -291,6 +291,11 @@ def test_construction():
     e3 = Ellipse(hradius=None, vradius=1, eccentricity=sqrt(3)/2)
     assert e3.hradius == 2
 
+    # filter(None, iterator) filters out anything that falsey, including 0
+    # eccentricity would be filtered out in this case and the constructor would throw an error
+    e4 = Ellipse(Point(0, 0), hradius=1, eccentricity=0)
+    assert e4.vradius == 1
+
 
 def test_ellipse_random_point():
     y1 = Symbol('y1', real=True)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -53,7 +53,7 @@ def test_ellipse_geom():
     assert e3.circumference == 2*pi*y1
     assert e1.plot_interval() == e2.plot_interval() == [t, -pi, pi]
     assert e1.plot_interval(x) == e2.plot_interval(x) == [x, -pi, pi]
-    assert Ellipse(None, 1, None, 1).circumference == 2*pi
+
     assert c1.minor == 1
     assert c1.major == 1
     assert c1.hradius == 1
@@ -76,12 +76,6 @@ def test_ellipse_geom():
     assert e1.encloses(RegularPolygon(p1, 0.5, 3)) is True
     assert e1.encloses(RegularPolygon(p1, 5, 3)) is False
     assert e1.encloses(RegularPolygon(p2, 5, 3)) is False
-
-    # with generic symbols, the hradius is assumed to contain the major radius
-    M = Symbol('M')
-    m = Symbol('m')
-    c = Ellipse(p1, M, m).circumference
-    assert c == 4*m*elliptic_e(sqrt(M**2 - m**2)/M)
 
     assert e2.arbitrary_point() in e2
 
@@ -403,3 +397,11 @@ def test_second_moment_of_area():
     assert I_yy == e.second_moment_of_area()[1]
     assert I_xx == e.second_moment_of_area()[0]
     assert I_xy == e.second_moment_of_area()[2]
+
+def test_circumference():
+    M = Symbol('M')
+    m = Symbol('m')
+    assert Ellipse(Point(0, 0), M, m).circumference == 4 * M * elliptic_e(sqrt(M ** 2 - m ** 2) / M)
+
+    assert Ellipse(Point(0, 0), 5, 4).circumference == 20 * elliptic_e(S(3) / 5)
+    assert Ellipse(None, 1, None, 1).circumference == 2 * pi

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -7,6 +7,7 @@ from sympy.geometry import (Circle, Ellipse, GeometryError, Line, Point, Polygon
 from sympy.integrals.integrals import Integral
 from sympy.utilities.pytest import raises, slow
 from sympy import integrate
+from sympy.functions.special.elliptic_integrals import elliptic_e
 
 
 @slow
@@ -80,9 +81,7 @@ def test_ellipse_geom():
     M = Symbol('M')
     m = Symbol('m')
     c = Ellipse(p1, M, m).circumference
-    _x = c.atoms(Dummy).pop()
-    assert c == 4*M*Integral(
-        sqrt((1 - _x**2*(M**2 - m**2)/M**2)/(1 - _x**2)), (_x, 0, 1))
+    assert c == 4*m*elliptic_e(sqrt(M**2 - m**2)/M)
 
     assert e2.arbitrary_point() in e2
 

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -291,7 +291,7 @@ def test_construction():
     e3 = Ellipse(hradius=None, vradius=1, eccentricity=sqrt(3)/2)
     assert e3.hradius == 2
 
-    # filter(None, iterator) filters out anything that falsey, including 0
+    # filter(None, iterator) filters out anything falsey, including 0
     # eccentricity would be filtered out in this case and the constructor would throw an error
     e4 = Ellipse(Point(0, 0), hradius=1, eccentricity=0)
     assert e4.vradius == 1

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -10,7 +10,6 @@ from sympy import integrate
 from sympy.functions.special.elliptic_integrals import elliptic_e
 
 
-@slow
 def test_ellipse_geom():
     x = Symbol('x', real=True)
     y = Symbol('y', real=True)

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -416,12 +416,15 @@ def test_second_moment_of_area():
 def test_circumference():
     M = Symbol('M')
     m = Symbol('m')
-    assert Ellipse(Point(0, 0), M, m).circumference == 4 * M * elliptic_e(sqrt(M ** 2 - m ** 2) / M)
+    assert Ellipse(Point(0, 0), M, m).circumference == 4 * M * elliptic_e((M ** 2 - m ** 2) / M**2)
 
-    assert Ellipse(Point(0, 0), 5, 4).circumference == 20 * elliptic_e(S(3) / 5)
+    assert Ellipse(Point(0, 0), 5, 4).circumference == 20 * elliptic_e(S(9) / 25)
 
     # degenerate ellipse
     assert Ellipse(None, 1, None, 1).circumference == 4
 
     # circle
     assert Ellipse(None, 1, None, 0).circumference == 2*pi
+
+    # test numerically
+    assert abs(Ellipse(None, hradius=5, vradius=3).circumference.evalf(16) - 25.52699886339813) < 1e-10

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -281,6 +281,17 @@ def test_ellipse_geom():
     assert cir.rotate(pi/3, Point(0, 1)) == Circle(Point(1/2 + sqrt(3)/2, 1/2 + sqrt(3)/2), 1)
 
 
+def test_construction():
+    e1 = Ellipse(hradius=2, vradius=1, eccentricity=None)
+    assert e1.eccentricity == sqrt(3)/2
+
+    e2 = Ellipse(hradius=2, vradius=None, eccentricity=sqrt(3)/2)
+    assert e2.vradius == 1
+
+    e3 = Ellipse(hradius=None, vradius=1, eccentricity=sqrt(3)/2)
+    assert e3.hradius == 2
+
+
 def test_ellipse_random_point():
     y1 = Symbol('y1', real=True)
     e3 = Ellipse(Point(0, 0), y1, y1)
@@ -403,4 +414,9 @@ def test_circumference():
     assert Ellipse(Point(0, 0), M, m).circumference == 4 * M * elliptic_e(sqrt(M ** 2 - m ** 2) / M)
 
     assert Ellipse(Point(0, 0), 5, 4).circumference == 20 * elliptic_e(S(3) / 5)
-    assert Ellipse(None, 1, None, 1).circumference == 2 * pi
+
+    # degenerate ellipse
+    assert Ellipse(None, 1, None, 1).circumference == 4
+
+    # circle
+    assert Ellipse(None, 1, None, 0).circumference == 2*pi


### PR DESCRIPTION
The circumference of an ellipse was calculated with an explicit integral, which meant that it was slow to evaluate. We can just use the elliptic_e function instead.