### PR TITLE
Improve isympy(IPython console)

### DIFF
--- a/isympy.py
+++ b/isympy.py
@@ -1,8 +1,5 @@
-# XXX: Don't put a newline here, or it will add an extra line with
-# isympy --help
-#  |
-#  v
-"""Python shell for SymPy.
+"""
+Python shell for SymPy.
 
 This is just a normal Python shell (IPython shell if you have the
 IPython package installed), that executes the following commands for
@@ -168,7 +165,6 @@ COMMAND LINE OPTIONS
         $isympy -q -- -colors NoColor
 
 See also isympy --help.
-
 """
 
 import os
@@ -178,13 +174,7 @@ import sys
 # by the command line will break.
 
 def main():
-    from optparse import OptionParser
-
-    if '-h' in sys.argv or '--help' in sys.argv:
-        # XXX: We can't use description=__doc__  in the OptionParser call
-        # below because optparse line wraps it weird.  The argparse module
-        # allows you to disable this, though.
-        print(__doc__)  # the docstring of this module above
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
     VERSION = None
     if '--version' in sys.argv:
@@ -194,100 +184,107 @@ def main():
         # version, which only matters with the --version flag.
         import sympy
         VERSION = sympy.__version__
-    usage = 'usage: isympy [options] -- [ipython options]'
-    parser = OptionParser(
+
+    usage = 'isympy [options] -- [ipython options]'
+    parser = ArgumentParser(
         usage=usage,
-        version=VERSION,
-        # XXX: We need a more centralized place to store the version.
-        # It is currently stored in sympy.__version__, but we can't yet
-        # import sympy at this point.
+        description=__doc__,
+        formatter_class=RawDescriptionHelpFormatter,
     )
 
-    parser.add_option(
+    parser.add_argument('--version', action='version', version=VERSION)
+
+    parser.add_argument(
         '-c', '--console',
         dest='console',
         action='store',
         default=None,
         choices=['ipython', 'python'],
+        metavar='CONSOLE',
         help='select type of interactive session: ipython | python; defaults '
         'to ipython if IPython is installed, otherwise python')
 
-    parser.add_option(
+    parser.add_argument(
         '-p', '--pretty',
         dest='pretty',
         action='store',
         default=None,
+        metavar='PRETTY',
         choices=['unicode', 'ascii', 'no'],
         help='setup pretty printing: unicode | ascii | no; defaults to '
         'unicode printing if the terminal supports it, otherwise ascii')
 
-    parser.add_option(
+    parser.add_argument(
         '-t', '--types',
         dest='types',
         action='store',
         default=None,
+        metavar='TYPES',
         choices=['gmpy', 'gmpy1', 'python'],
         help='setup ground types: gmpy | gmpy1 | python; defaults to gmpy if gmpy2 '
         'or gmpy is installed, otherwise python')
 
-    parser.add_option(
+    parser.add_argument(
         '-o', '--order',
         dest='order',
         action='store',
         default=None,
+        metavar='ORDER',
         choices=['lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old', 'none'],
         help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old | none; defaults to lex')
 
-    parser.add_option(
+    parser.add_argument(
         '-q', '--quiet',
         dest='quiet',
         action='store_true',
         default=False,
         help='print only version information at startup')
 
-    parser.add_option(
+    parser.add_argument(
         '-d', '--doctest',
         dest='doctest',
         action='store_true',
         default=False,
         help='use the doctest format for output (you can just copy and paste it)')
 
-    parser.add_option(
+    parser.add_argument(
         '-C', '--no-cache',
         dest='cache',
         action='store_false',
         default=True,
         help='disable caching mechanism')
 
-    parser.add_option(
+    parser.add_argument(
         '-a', '--auto-symbols',
         dest='auto_symbols',
         action='store_true',
         default=False,
         help='automatically construct missing symbols')
 
-    parser.add_option(
+    parser.add_argument(
         '-i', '--int-to-Integer',
         dest='auto_int_to_Integer',
         action='store_true',
         default=False,
         help="automatically wrap int literals with Integer")
 
-    parser.add_option(
+    parser.add_argument(
         '-I', '--interactive',
         dest='interactive',
         action='store_true',
         default=False,
         help="equivalent to -a -i")
 
-    parser.add_option(
+    parser.add_argument(
         '-D', '--debug',
         dest='debug',
         action='store_true',
         default=False,
         help='enable debugging output')
 
-    (options, ipy_args) = parser.parse_args()
+    (options, ipy_args) = parser.parse_known_args()
+    if '--' in ipy_args:
+        ipy_args.remove('--')
 
     if not options.cache:
         os.environ['SYMPY_USE_CACHE'] = 'no'

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -137,17 +137,12 @@ def int_to_Integer(s):
     return untokenize(result)
 
 
-def enable_automatic_int_sympification(app):
+def enable_automatic_int_sympification(shell):
     """
     Allow IPython to automatically convert integer literals to Integer.
     """
-    hasshell = hasattr(app, 'shell')
-
     import ast
-    if hasshell:
-        old_run_cell = app.shell.run_cell
-    else:
-        old_run_cell = app.run_cell
+    old_run_cell = shell.run_cell
 
     def my_run_cell(cell, *args, **kwargs):
         try:
@@ -163,13 +158,10 @@ def enable_automatic_int_sympification(app):
             cell = int_to_Integer(cell)
         old_run_cell(cell, *args, **kwargs)
 
-    if hasshell:
-        app.shell.run_cell = my_run_cell
-    else:
-        app.run_cell = my_run_cell
+    shell.run_cell = my_run_cell
 
 
-def enable_automatic_symbols(app):
+def enable_automatic_symbols(shell):
     """Allow IPython to automatially create symbols (``isympy -a``). """
     # XXX: This should perhaps use tokenize, like int_to_Integer() above.
     # This would avoid re-executing the code, which can lead to subtle
@@ -237,40 +229,37 @@ def enable_automatic_symbols(app):
             etype, value, tb, tb_offset=tb_offset)
         self._showtraceback(etype, value, stb)
 
-    if hasattr(app, 'shell'):
-        app.shell.set_custom_exc((NameError,), _handler)
-    else:
-        # This was restructured in IPython 0.13
-        app.set_custom_exc((NameError,), _handler)
+    shell.set_custom_exc((NameError,), _handler)
 
 
-def init_ipython_session(argv=[], auto_symbols=False, auto_int_to_Integer=False):
+def init_ipython_session(shell=None, argv=[], auto_symbols=False, auto_int_to_Integer=False):
     """Construct new IPython session. """
     import IPython
 
     if V(IPython.__version__) >= '0.11':
-        # use an app to parse the command line, and init config
-        # IPython 1.0 deprecates the frontend module, so we import directly
-        # from the terminal module to prevent a deprecation message from being
-        # shown.
-        if V(IPython.__version__) >= '1.0':
-            from IPython.terminal import ipapp
-        else:
-            from IPython.frontend.terminal import ipapp
-        app = ipapp.TerminalIPythonApp()
+        if not shell:
+            # use an app to parse the command line, and init config
+            # IPython 1.0 deprecates the frontend module, so we import directly
+            # from the terminal module to prevent a deprecation message from being
+            # shown.
+            if V(IPython.__version__) >= '1.0':
+                from IPython.terminal import ipapp
+            else:
+                from IPython.frontend.terminal import ipapp
+            app = ipapp.TerminalIPythonApp()
 
-        # don't draw IPython banner during initialization:
-        app.display_banner = False
-        app.initialize(argv)
+            # don't draw IPython banner during initialization:
+            app.display_banner = False
+            app.initialize(argv)
+
+            shell = app.shell
 
         if auto_symbols:
-            readline = import_module("readline")
-            if readline:
-                enable_automatic_symbols(app)
+            enable_automatic_symbols(shell)
         if auto_int_to_Integer:
-            enable_automatic_int_sympification(app)
+            enable_automatic_int_sympification(shell)
 
-        return app.shell
+        return shell
     else:
         from IPython.Shell import make_IPython
         return make_IPython(argv)
@@ -429,7 +418,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
         ip = init_python_session()
         mainloop = ip.interact
     else:
-        ip = init_ipython_session(argv=argv, auto_symbols=auto_symbols,
+        ip = init_ipython_session(ip, argv=argv, auto_symbols=auto_symbols,
             auto_int_to_Integer=auto_int_to_Integer)
 
         if V(IPython.__version__) >= '0.11':

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -450,9 +450,8 @@ def init_session(ipython=None, pretty_print=True, order=None,
         if not in_ipython:
             mainloop = ip.mainloop
 
-    readline = import_module("readline")
-    if auto_symbols and (not ipython or V(IPython.__version__) < '0.11' or not readline):
-        raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above with readline support")
+    if auto_symbols and (not ipython or V(IPython.__version__) < '0.11'):
+        raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above")
     if auto_int_to_Integer and (not ipython or V(IPython.__version__) < '0.11'):
         raise RuntimeError("automatic int to Integer transformation is possible only in IPython 0.11 or above")
 

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -11,9 +11,7 @@ from sympy.external import import_module
 # @requires('IPython', version=">=0.11")
 # def test_automatic_symbols(ipython):
 
-# run_cell was added in IPython 0.11
 ipython = import_module("IPython", min_module_version="0.11")
-readline = import_module("readline")
 
 if not ipython:
     #bin/test will not execute any tests now
@@ -21,9 +19,6 @@ if not ipython:
 
 
 def test_automatic_symbols():
-    # this implicitly requires readline
-    if not readline:
-        return None
     # NOTE: Because of the way the hook works, you have to use run_cell(code,
     # True).  This means that the code must have no Out, or it will be printed
     # during the tests.

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -29,21 +29,21 @@ def test_automatic_symbols():
 
     symbol = "verylongsymbolname"
     assert symbol not in app.user_ns
-    app.run_cell("a = %s" % symbol, True)
+    app.run_cell("a = %s" % symbol)
     assert symbol not in app.user_ns
-    app.run_cell("a = type(%s)" % symbol, True)
+    app.run_cell("a = type(%s)" % symbol)
     assert app.user_ns['a'] == Symbol
-    app.run_cell("%s = Symbol('%s')" % (symbol, symbol), True)
+    app.run_cell("%s = Symbol('%s')" % (symbol, symbol))
     assert symbol in app.user_ns
 
     # Check that built-in names aren't overridden
-    app.run_cell("a = all == __builtin__.all", True)
+    app.run_cell("a = all == __builtin__.all")
     assert "all" not in app.user_ns
     assert app.user_ns['a'] is True
 
     # Check that sympy names aren't overridden
     app.run_cell("import sympy")
-    app.run_cell("a = factorial == sympy.factorial", True)
+    app.run_cell("a = factorial == sympy.factorial")
     assert app.user_ns['a'] is True
 
 

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -29,21 +29,21 @@ def test_automatic_symbols():
 
     symbol = "verylongsymbolname"
     assert symbol not in app.user_ns
-    app.run_cell("a = %s" % symbol)
+    app.run_cell("a = %s" % symbol, True)
     assert symbol not in app.user_ns
-    app.run_cell("a = type(%s)" % symbol)
+    app.run_cell("a = type(%s)" % symbol, True)
     assert app.user_ns['a'] == Symbol
-    app.run_cell("%s = Symbol('%s')" % (symbol, symbol))
+    app.run_cell("%s = Symbol('%s')" % (symbol, symbol), True)
     assert symbol in app.user_ns
 
     # Check that built-in names aren't overridden
-    app.run_cell("a = all == __builtin__.all")
+    app.run_cell("a = all == __builtin__.all", True)
     assert "all" not in app.user_ns
     assert app.user_ns['a'] is True
 
     # Check that sympy names aren't overridden
     app.run_cell("import sympy")
-    app.run_cell("a = factorial == sympy.factorial")
+    app.run_cell("a = factorial == sympy.factorial", True)
     assert app.user_ns['a'] is True
 
 

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -122,7 +122,11 @@ def test_matplotlib_bad_latex():
 
     # Make sure no warnings are raised by IPython
     app.run_cell("import warnings")
-    app.run_cell("warnings.simplefilter('error', IPython.core.formatters.FormatterWarning)")
+    # IPython.core.formatters.FormatterWarning was introduced in IPython 2.0
+    if int(ipython.__version__.split(".")[0]) < 2:
+        app.run_cell("warnings.simplefilter('error')")
+    else:
+        app.run_cell("warnings.simplefilter('error', IPython.core.formatters.FormatterWarning)")
 
     # This should not raise an exception
     app.run_cell("a = format(Matrix([1, 2, 3]))")

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division
 import sys
 import os
 import re as _re
+import struct
 from textwrap import fill, dedent
 from sympy.core.compatibility import get_function_name, range
 
@@ -104,13 +105,7 @@ def rawlines(s):
         else:
             return "dedent('''\\\n    %s''')" % rv
 
-size = getattr(sys, "maxint", None)
-if size is None:  # Python 3 doesn't have maxint
-    size = sys.maxsize
-if size > 2**32:
-    ARCH = "64-bit"
-else:
-    ARCH = "32-bit"
+ARCH = str(struct.calcsize('P') * 8) + "-bit"
 
 
 # XXX: PyPy doesn't support hash randomization


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
See below.

#### Brief description of what is fixed or changed
- Change `optparse` to `argparse`: `optparse` is deprecated since Python version 2.7
- Use existing IPython shell if present, when initializing new IPython session: Fixes #13418, fixes #13319, and fixes #11419.
- Fixed incorrect architecture detection on 64-bit Windows. [(SO)](https://stackoverflow.com/q/1405913/1448742)
- Fixed a test failure with IPython < 2.0

#### Other comments
Split from #13300 into this and #14440.