### PR TITLE
Printing: Updated mpprint to behave like pprint and defined vpretty

### DIFF
--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -307,6 +307,27 @@ def vsprint(expr, **settings):
     string_printer = VectorStrPrinter(settings)
     return string_printer.doprint(expr)
 
+def vpretty(expr, **settings):
+    """Returns a string containing the prettified form of expr generated in the
+    sympy.physics vector package.
+
+    For information on keyword arguments see Sympy's pretty_print function.
+
+    """
+
+    # Note that this is copied from sympy.printing.pretty.pretty_print:
+
+    vpp = VectorPrettyPrinter(settings)
+
+    # XXX: this is an ugly hack, but at least it works
+    from sympy.printing.pretty.pretty_symbology import pretty_use_unicode
+    use_unicode = vpp._settings['use_unicode']
+    uflag = pretty_use_unicode(use_unicode)
+
+    try:
+        return vpp.doprint(expr)
+    finally:
+        pretty_use_unicode(uflag)
 
 def vpprint(expr, **settings):
     r"""Function for pretty printing of expressions generated in the

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -348,20 +348,9 @@ def vpprint(expr, **settings):
 
     """
 
-    pp = VectorPrettyPrinter(settings)
-
-    # Note that this is copied from sympy.printing.pretty.pretty_print:
-
-    # XXX: this is an ugly hack, but at least it works
-    use_unicode = pp._settings['use_unicode']
-    from sympy.printing.pretty.pretty_symbology import pretty_use_unicode
-    uflag = pretty_use_unicode(use_unicode)
-
-    try:
-        print(pp.doprint(expr))
-    finally:
-        pretty_use_unicode(uflag)
-
+    print(vpretty(expr, wrap_line=wrap_line, num_columns=num_columns,
+                 use_unicode=use_unicode, full_prec=full_prec, order=order,
+                 use_unicode_sqrt_char=use_unicode_sqrt_char))
 
 def vlatex(expr, **settings):
     r"""Function for printing latex representation of sympy.physics.vector

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 from sympy import Derivative
 from sympy.core.function import UndefinedFunction, AppliedUndef
@@ -336,7 +337,7 @@ def vpprint(expr, **settings):
     uflag = pretty_use_unicode(use_unicode)
 
     try:
-        return pp.doprint(expr)
+        print(pp.doprint(expr))
     finally:
         pretty_use_unicode(uflag)
 

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -41,37 +41,75 @@ def test_vector_pretty_print():
 
     expected = """\
  2
-a  n_x + b n_y + c*sin(alpha) n_z\
+a  n_x + b n_y + c*sin(alpha) n_z\n\
 """
     uexpected = u("""\
  2
-a  n_x + b n_y + c⋅sin(α) n_z\
+a  n_x + b n_y + c⋅sin(α) n_z\n\
 """)
+    import sys
+    from sympy.core.compatibility import StringIO
+    result = StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = result
+    try:
+        ascii_vpretty(v)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == expected
+    result = StringIO()
+    sys.stdout = result
+    try:
+        unicode_vpretty(v)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == uexpected
 
-    assert ascii_vpretty(v) == expected
-    assert unicode_vpretty(v) == uexpected
+    expected = u('alpha n_x + sin(omega) n_y + alpha*beta n_z\n')
+    uexpected = u('α n_x + sin(ω) n_y + α⋅β n_z\n')
 
-    expected = u('alpha n_x + sin(omega) n_y + alpha*beta n_z')
-    uexpected = u('α n_x + sin(ω) n_y + α⋅β n_z')
-
-    assert ascii_vpretty(w) == expected
-    assert unicode_vpretty(w) == uexpected
+    result = StringIO()
+    sys.stdout = result
+    try:
+        ascii_vpretty(w)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == expected
+    result = StringIO()
+    sys.stdout = result
+    try:
+        unicode_vpretty(w)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == uexpected
 
     expected = """\
                      2
 a       b + c       c
 - n_x + ----- n_y + -- n_z
-b         a         b\
+b         a         b\n\
 """
     uexpected = u("""\
                      2
 a       b + c       c
 ─ n_x + ───── n_y + ── n_z
-b         a         b\
+b         a         b\n\
 """)
 
-    assert ascii_vpretty(o) == expected
-    assert unicode_vpretty(o) == uexpected
+    result = StringIO()
+    sys.stdout = result
+    try:
+        ascii_vpretty(o)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == expected
+    result = StringIO()
+    sys.stdout = result
+    try:
+        unicode_vpretty(o)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == uexpected
 
 
 def test_vector_latex():
@@ -154,20 +192,47 @@ def test_dyadic_pretty_print():
 
     expected = """\
  2
-a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\
+a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\n\
 """
 
     uexpected = u("""\
  2
-a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
+a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\n\
 """)
-    assert ascii_vpretty(y) == expected
-    assert unicode_vpretty(y) == uexpected
+    import sys
+    from sympy.core.compatibility import StringIO
+    result = StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = result
+    try:
+        ascii_vpretty(y)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == expected
+    result = StringIO()
+    sys.stdout = result
+    try:
+        unicode_vpretty(y)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == uexpected
 
-    expected = u('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x')
-    uexpected = u('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x')
-    assert ascii_vpretty(x) == expected
-    assert unicode_vpretty(x) == uexpected
+    expected = u('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x\n')
+    uexpected = u('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x\n')
+    result = StringIO()
+    sys.stdout = result
+    try:
+        ascii_vpretty(x)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == expected
+    result = StringIO()
+    sys.stdout = result
+    try:
+        unicode_vpretty(x)
+    finally:
+        sys.stdout = old_stdout
+    assert result.getvalue() == uexpected
 
 def test_dyadic_latex():
 

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -3,7 +3,7 @@
 from sympy import symbols, sin, cos, sqrt, Function
 from sympy.core.compatibility import u_decode as u
 from sympy.physics.vector import ReferenceFrame, dynamicsymbols
-from sympy.physics.vector.printing import (VectorLatexPrinter, vpprint)
+from sympy.physics.vector.printing import (VectorLatexPrinter, vpprint, vpretty)
 
 # TODO : Figure out how to make the pretty printing tests readable like the
 # ones in sympy.printing.pretty.tests.test_printing.
@@ -22,10 +22,10 @@ y = a ** 2 * (N.x | N.y) + b * (N.y | N.y) + c * sin(alpha) * (N.z | N.y)
 x = alpha * (N.x | N.x) + sin(omega) * (N.y | N.z) + alpha * beta * (N.z | N.x)
 
 def ascii_vpretty(expr):
-    return vpprint(expr, use_unicode=False, wrap_line=False)
+    return vpretty(expr, use_unicode=False, wrap_line=False)
 
 def unicode_vpretty(expr):
-    return vpprint(expr, use_unicode=True, wrap_line=False)
+    return vpretty(expr, use_unicode=True, wrap_line=False)
 
 def test_latex_printer():
     r = Function('r')('t')
@@ -41,76 +41,37 @@ def test_vector_pretty_print():
 
     expected = """\
  2
-a  n_x + b n_y + c*sin(alpha) n_z\n\
+a  n_x + b n_y + c*sin(alpha) n_z\
 """
     uexpected = u("""\
  2
-a  n_x + b n_y + c⋅sin(α) n_z\n\
+a  n_x + b n_y + c⋅sin(α) n_z\
 """)
-    import sys
-    from sympy.core.compatibility import StringIO
-    result = StringIO()
-    old_stdout = sys.stdout
-    sys.stdout = result
-    try:
-        ascii_vpretty(v)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == expected
-    result = StringIO()
-    sys.stdout = result
-    try:
-        unicode_vpretty(v)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == uexpected
 
-    expected = u('alpha n_x + sin(omega) n_y + alpha*beta n_z\n')
-    uexpected = u('α n_x + sin(ω) n_y + α⋅β n_z\n')
+    assert ascii_vpretty(v) == expected
+    assert unicode_vpretty(v) == uexpected
 
-    result = StringIO()
-    sys.stdout = result
-    try:
-        ascii_vpretty(w)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == expected
-    result = StringIO()
-    sys.stdout = result
-    try:
-        unicode_vpretty(w)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == uexpected
+    expected = u('alpha n_x + sin(omega) n_y + alpha*beta n_z')
+    uexpected = u('α n_x + sin(ω) n_y + α⋅β n_z')
+
+    assert ascii_vpretty(w) == expected
+    assert unicode_vpretty(w) == uexpected
 
     expected = """\
                      2
 a       b + c       c
 - n_x + ----- n_y + -- n_z
-b         a         b\n\
+b         a         b\
 """
     uexpected = u("""\
                      2
 a       b + c       c
 ─ n_x + ───── n_y + ── n_z
-b         a         b\n\
+b         a         b\
 """)
 
-    result = StringIO()
-    sys.stdout = result
-    try:
-        ascii_vpretty(o)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == expected
-    result = StringIO()
-    sys.stdout = result
-    try:
-        unicode_vpretty(o)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == uexpected
-
+    assert ascii_vpretty(o) == expected
+    assert unicode_vpretty(o) == uexpected
 
 def test_vector_latex():
 
@@ -192,47 +153,22 @@ def test_dyadic_pretty_print():
 
     expected = """\
  2
-a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\n\
+a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\
 """
 
     uexpected = u("""\
  2
-a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\n\
+a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
 """)
-    import sys
-    from sympy.core.compatibility import StringIO
-    result = StringIO()
-    old_stdout = sys.stdout
-    sys.stdout = result
-    try:
-        ascii_vpretty(y)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == expected
-    result = StringIO()
-    sys.stdout = result
-    try:
-        unicode_vpretty(y)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == uexpected
 
-    expected = u('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x\n')
-    uexpected = u('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x\n')
-    result = StringIO()
-    sys.stdout = result
-    try:
-        ascii_vpretty(x)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == expected
-    result = StringIO()
-    sys.stdout = result
-    try:
-        unicode_vpretty(x)
-    finally:
-        sys.stdout = old_stdout
-    assert result.getvalue() == uexpected
+    assert ascii_vpretty(y) == expected
+    assert unicode_vpretty(y) == uexpected
+
+    expected = u('alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x')
+    uexpected = u('α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x')
+
+    assert ascii_vpretty(x) == expected
+    assert unicode_vpretty(x) == uexpected
 
 def test_dyadic_latex():
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

closes #6340 , closes #14425 
#### Brief description of what is fixed or changed
```mpprint``` will behave like ```pprint``` and will print to stdout instead of returning a string. This resolve a lot of issues considering the usage of ```mpprint``` and also print the special characters correctly.

There is also a new function defined called ```vpretty``` which does return the string and this is used for the unit tests.