### PR TITLE
solving equations with Abs in solveset

### DIFF
--- a/doc/src/modules/solvers/solveset.rst
+++ b/doc/src/modules/solvers/solveset.rst
@@ -398,7 +398,7 @@ How does ``solveset`` ensure that it is not returning any wrong solution?
     >>> from sympy import symbols, S, pprint, solveset
     >>> x, n = symbols('x, n')
     >>> pprint(solveset(abs(x) - n, x, domain=S.Reals), use_unicode=True)
-    ([0, ∞) ∩ {n}) ∪ ((-∞, 0] ∩ {-n})
+    {x | x ∊ {-n, n} ∧ (n ∈ [0, ∞))}
 
  Though, there still a lot of work needs to be done in this regard.
 

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -2,9 +2,11 @@ from __future__ import print_function, division
 
 from sympy import S
 from sympy.core.basic import Basic
+from sympy.core.containers import Tuple
 from sympy.core.function import Lambda
 from sympy.core.logic import fuzzy_bool
-from sympy.logic.boolalg import And
+from sympy.core.symbol import Symbol, Dummy
+from sympy.logic.boolalg import And, as_Boolean
 from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
                              FiniteSet)
 from sympy.utilities.iterables import sift
@@ -33,6 +35,11 @@ class ConditionSet(Set):
     True
     """
     def __new__(cls, sym, condition, base_set):
+        condition = as_Boolean(condition)
+        if isinstance(base_set, set):
+            base_set = FiniteSet(*base_set)
+        elif not isinstance(base_set, Set):
+            raise TypeError('expecting set for base_set')
         if condition == S.false:
             return S.EmptySet
         if condition == S.true:
@@ -44,16 +51,66 @@ class ConditionSet(Set):
                 base_set, lambda _: fuzzy_bool(
                     condition.subs(sym, _)))
             if sifted[None]:
-                return Union(FiniteSet(*sifted[True]), Basic.__new__(
-                    cls, sym, condition, FiniteSet(*sifted[None])))
+                return Union(FiniteSet(*sifted[True]),
+                    Basic.__new__(cls, sym, condition,
+                    FiniteSet(*sifted[None])))
             else:
                 return FiniteSet(*sifted[True])
+        if isinstance(base_set, cls):
+            s, c, base_set = base_set.args
+            if sym == s:
+                condition = And(condition, c)
+            elif sym not in c.free_symbols:
+                condition = And(condition, c.xreplace({s: sym}))
+            elif s not in condition.free_symbols:
+                condition = And(condition.xreplace({sym: s}), c)
+                sym = s
+            else:
+                # user will have to use cls.sym to get symbol
+                dum = Symbol('lambda')
+                if dum in condition.free_symbols or \
+                        dum in c.free_symbols:
+                    dum = Dummy(str(dum))
+                condition = And(
+                    condition.xreplace({sym: dum}),
+                    c.xreplace({s: dum}))
+                sym = dum
+        if sym in base_set.free_symbols or \
+                not isinstance(sym, Symbol):
+            s = Symbol('lambda')
+            if s in base_set.free_symbols:
+                s = Dummy('lambda')
+            condition = condition.xreplace({sym: s})
+            sym = s
         return Basic.__new__(cls, sym, condition, base_set)
 
     sym = property(lambda self: self.args[0])
     condition = property(lambda self: self.args[1])
     base_set = property(lambda self: self.args[2])
 
+    @property
+    def free_symbols(self):
+        s, c, b = self.args
+        return (c.free_symbols - s.free_symbols) | b.free_symbols
+
     def contains(self, other):
         return And(Lambda(self.sym, self.condition)(
             other), self.base_set.contains(other))
+
+    def _eval_subs(self, old, new):
+        if old == self.sym:
+            if new not in self.free_symbols:
+                if isinstance(new, Symbol):
+                    return self.func(*[i.subs(old, new) for i in self.args])
+            return self.func(self.sym, self.condition, self.base_set.subs(old, new))
+        return self.func(*([self.sym] + [i.subs(old, new) for i in self.args[1:]]))
+
+    def dummy_eq(self, other, symbol=None):
+        if not isinstance(other, self.func):
+            return False
+        if symbol:
+            raise ValueError('symbol arg not supported for ConditionSet')
+        o = other.func(self.sym,
+            other.condition.subs(other.sym, self.sym),
+            other.base_set)
+        return self == o

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -48,6 +48,11 @@ class ConditionSet(Set):
                     cls, sym, condition, FiniteSet(*sifted[None])))
             else:
                 return FiniteSet(*sifted[True])
+        if isinstance(base_set, ConditionSet):
+            s, c, b = base_set.args
+            if s != sym:
+                c = c.subs(s, sym)
+            return ConditionSet(sym, And(c, condition), b)
         return Basic.__new__(cls, sym, condition, base_set)
 
     sym = property(lambda self: self.args[0])

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -48,11 +48,6 @@ class ConditionSet(Set):
                     cls, sym, condition, FiniteSet(*sifted[None])))
             else:
                 return FiniteSet(*sifted[True])
-        if isinstance(base_set, ConditionSet):
-            s, c, b = base_set.args
-            if s != sym:
-                c = c.subs(s, sym)
-            return ConditionSet(sym, And(c, condition), b)
         return Basic.__new__(cls, sym, condition, base_set)
 
     sym = property(lambda self: self.args[0])

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -35,7 +35,15 @@ class ConditionSet(Set):
     True
     """
     def __new__(cls, sym, condition, base_set):
-        condition = as_Boolean(condition)
+        # nonlinsolve uses ConditionSet to return an unsolved system
+        # of equations (see _return_conditionset in solveset) so until
+        # that is changed we do minimal checking of the args
+        unsolved = isinstance(sym, (Tuple, tuple))
+        if unsolved:
+            sym = Tuple(*sym)
+            condition = FiniteSet(*condition)
+        else:
+            condition = as_Boolean(condition)
         if isinstance(base_set, set):
             base_set = FiniteSet(*base_set)
         elif not isinstance(base_set, Set):
@@ -46,42 +54,43 @@ class ConditionSet(Set):
             return base_set
         if isinstance(base_set, EmptySet):
             return base_set
-        if isinstance(base_set, FiniteSet):
-            sifted = sift(
-                base_set, lambda _: fuzzy_bool(
-                    condition.subs(sym, _)))
-            if sifted[None]:
-                return Union(FiniteSet(*sifted[True]),
-                    Basic.__new__(cls, sym, condition,
-                    FiniteSet(*sifted[None])))
-            else:
-                return FiniteSet(*sifted[True])
-        if isinstance(base_set, cls):
-            s, c, base_set = base_set.args
-            if sym == s:
-                condition = And(condition, c)
-            elif sym not in c.free_symbols:
-                condition = And(condition, c.xreplace({s: sym}))
-            elif s not in condition.free_symbols:
-                condition = And(condition.xreplace({sym: s}), c)
+        if not unsolved:
+            if isinstance(base_set, FiniteSet):
+                sifted = sift(
+                    base_set, lambda _: fuzzy_bool(
+                        condition.subs(sym, _)))
+                if sifted[None]:
+                    return Union(FiniteSet(*sifted[True]),
+                        Basic.__new__(cls, sym, condition,
+                        FiniteSet(*sifted[None])))
+                else:
+                    return FiniteSet(*sifted[True])
+            if isinstance(base_set, cls):
+                s, c, base_set = base_set.args
+                if sym == s:
+                    condition = And(condition, c)
+                elif sym not in c.free_symbols:
+                    condition = And(condition, c.xreplace({s: sym}))
+                elif s not in condition.free_symbols:
+                    condition = And(condition.xreplace({sym: s}), c)
+                    sym = s
+                else:
+                    # user will have to use cls.sym to get symbol
+                    dum = Symbol('lambda')
+                    if dum in condition.free_symbols or \
+                            dum in c.free_symbols:
+                        dum = Dummy(str(dum))
+                    condition = And(
+                        condition.xreplace({sym: dum}),
+                        c.xreplace({s: dum}))
+                    sym = dum
+            if sym in base_set.free_symbols or \
+                    not isinstance(sym, Symbol):
+                s = Symbol('lambda')
+                if s in base_set.free_symbols:
+                    s = Dummy('lambda')
+                condition = condition.xreplace({sym: s})
                 sym = s
-            else:
-                # user will have to use cls.sym to get symbol
-                dum = Symbol('lambda')
-                if dum in condition.free_symbols or \
-                        dum in c.free_symbols:
-                    dum = Dummy(str(dum))
-                condition = And(
-                    condition.xreplace({sym: dum}),
-                    c.xreplace({s: dum}))
-                sym = dum
-        if sym in base_set.free_symbols or \
-                not isinstance(sym, Symbol):
-            s = Symbol('lambda')
-            if s in base_set.free_symbols:
-                s = Dummy('lambda')
-            condition = condition.xreplace({sym: s})
-            sym = s
         return Basic.__new__(cls, sym, condition, base_set)
 
     sym = property(lambda self: self.args[0])
@@ -98,6 +107,10 @@ class ConditionSet(Set):
             other), self.base_set.contains(other))
 
     def _eval_subs(self, old, new):
+        if not isinstance(self.sym, Symbol):
+            # Don't do anything with the equation set syntax;
+            # that should go away, eventually.
+            return self
         if old == self.sym:
             if new not in self.free_symbols:
                 if isinstance(new, Symbol):
@@ -108,9 +121,17 @@ class ConditionSet(Set):
     def dummy_eq(self, other, symbol=None):
         if not isinstance(other, self.func):
             return False
+        if isinstance(self.sym, Symbol) != isinstance(other.sym, Symbol):
+            # this test won't be necessary when unsolved equations
+            # syntax is removed
+            return False
         if symbol:
             raise ValueError('symbol arg not supported for ConditionSet')
-        o = other.func(self.sym,
-            other.condition.subs(other.sym, self.sym),
-            other.base_set)
+        o = other
+        if isinstance(self.sym, Symbol) and isinstance(other.sym, Symbol):
+            # this code will not need to be in an if-block when
+            # the unsolved equations syntax is removed
+            o = other.func(self.sym,
+                other.condition.subs(other.sym, self.sym),
+                other.base_set)
         return self == o

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy.core import Basic
+from sympy.core import Basic, S
 from sympy.core.relational import Eq, Ne
 from sympy.logic.boolalg import BooleanFunction
 
@@ -28,16 +28,17 @@ class Contains(BooleanFunction):
     .. [1] http://en.wikipedia.org/wiki/Element_%28mathematics%29
     """
     @classmethod
-    def eval(cls, x, S):
+    def eval(cls, x, s):
         from sympy.sets.sets import Set
 
         if not isinstance(x, Basic):
             raise TypeError
-        if not isinstance(S, Set):
+        if not isinstance(s, Set):
             raise TypeError
 
-        ret = S.contains(x)
-        if not isinstance(ret, Contains):
+        ret = s.contains(x)
+        if not isinstance(ret, Contains) and (
+                ret in (S.true, S.false) or isinstance(ret, Set)):
             return ret
 
     @property

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -32,6 +32,7 @@ def test_issue_9849():
     assert ConditionSet(x, Eq(x, x), S.Naturals) == S.Naturals
     assert ConditionSet(x, Eq(Abs(sin(x)), -1), S.Naturals) == S.EmptySet
 
+
 def test_simplified_FiniteSet_in_CondSet():
     assert ConditionSet(x, And(x < 1, x > -3), FiniteSet(0, 1, 2)) == FiniteSet(0)
     assert ConditionSet(x, x < 0, FiniteSet(0, 1, 2)) == EmptySet()

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -1,7 +1,15 @@
-from sympy.sets import (ConditionSet, Intersection, FiniteSet, EmptySet, Union)
-from sympy import (Symbol, Eq, S, Abs, sin, pi, Lambda, Interval, And, Mod)
+from sympy.sets import (ConditionSet, Intersection, FiniteSet,
+    EmptySet, Union)
+from sympy import (Symbol, Eq, Lt, S, Abs, sin, pi, Lambda, Interval,
+    And, Mod)
+from sympy.utilities.pytest import raises
 
+
+w = Symbol('w')
 x = Symbol('x')
+y = Symbol('y')
+z = Symbol('z')
+L = Symbol('lambda')
 
 
 def test_CondSet():
@@ -12,6 +20,30 @@ def test_CondSet():
     assert 3*pi not in sin_sols_principal
     assert 5 in ConditionSet(x, x**2 > 4, S.Reals)
     assert 1 not in ConditionSet(x, x**2 > 4, S.Reals)
+
+    assert isinstance(ConditionSet(x, x < 1, {x, y}).base_set, FiniteSet)
+    raises(TypeError, lambda: ConditionSet(x, x + 1, {x, y}))
+    raises(TypeError, lambda: ConditionSet(x, x, 1))
+
+    I = S.Integers
+    C = ConditionSet
+    assert C(x, x < 1, C(x, x < 2, I)
+        ) == C(x, (x < 1) & (x < 2), I)
+    assert C(y, y < 1, C(x, y < 2, I)
+        ) == C(x, (x < 1) & (y < 2), I)
+    assert C(y, y < 1, C(x, x < 2, I)
+        ) == C(y, (y < 1) & (y < 2), I)
+    assert C(y, y < 1, C(x, y < x, I)
+        ) == C(x, (x < 1) & (y < x), I)
+    assert C(y, x < 1, C(x, y < x, I)
+        ) == C(L, (x < 1) & (y < L), I)
+    c = C(y, x < 1, C(x, L < y, I))
+    assert c == C(c.sym, (L < y) & (x < 1), I)
+    assert c.sym not in (x, y, L)
+    c = C(y, x < 1, C(x, y < x, FiniteSet(L)))
+    assert c == C(
+        c.sym, c.condition.xreplace({L: c.sym}), FiniteSet(L))
+    assert c.sym not in (x, y, L)
 
 
 def test_CondSet_intersect():
@@ -35,3 +67,34 @@ def test_simplified_FiniteSet_in_CondSet():
         Union(FiniteSet(1), ConditionSet(x, And(x > 0), FiniteSet(y))))
     assert (ConditionSet(x, Eq(Mod(x, 3), 1), FiniteSet(1, 4, 2, y)) ==
         Union(FiniteSet(1, 4), ConditionSet(x, Eq(Mod(x, 3), 1), FiniteSet(y))))
+
+
+def test_free_symbols():
+    assert ConditionSet(x, Eq(y, 0), FiniteSet(z)
+        ).free_symbols == {y, z}
+    assert ConditionSet(x, Eq(x, 0), FiniteSet(z)
+        ).free_symbols == {z}
+    assert ConditionSet(x, Eq(x, 0), FiniteSet(x, z)
+        ).free_symbols == {x, z}
+
+
+def test_subs_CondSet():
+    s = FiniteSet(z, y)
+    c = ConditionSet(x, x < 2, s)
+    # you can only replace sym with a symbol that is not in
+    # the free symbols
+    assert c.subs(x, 1) == c
+    assert c.subs(x, y) == c
+    assert c.subs(x, w) == ConditionSet(w, w < 2, s)
+    assert ConditionSet(x, x < y, s
+        ).subs(y, w) == ConditionSet(x, x < w, s.subs(y, w))
+
+
+def test_dummy_eq():
+    C = ConditionSet
+    I = S.Integers
+    c = C(x, x < 1, I)
+    assert c.dummy_eq(C(y, y < 1, I))
+    assert c.dummy_eq(1) == False
+    assert c.dummy_eq(C(x, x < 1, S.Reals)) == False
+    raises(ValueError, lambda: c.dummy_eq(C(x, x < 1, S.Reals), z))

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -2,6 +2,8 @@ from sympy.sets import (ConditionSet, Intersection, FiniteSet, EmptySet, Union)
 from sympy import (Symbol, Eq, S, Abs, sin, pi, Lambda, Interval, And, Mod)
 
 x = Symbol('x')
+y = Symbol('y')
+z = Symbol('z')
 
 
 def test_CondSet():
@@ -12,6 +14,11 @@ def test_CondSet():
     assert 3*pi not in sin_sols_principal
     assert 5 in ConditionSet(x, x**2 > 4, S.Reals)
     assert 1 not in ConditionSet(x, x**2 > 4, S.Reals)
+
+    assert ConditionSet(x, Eq(x, 0), ConditionSet(y, Eq(z, 1),
+        S.Integers)) == ConditionSet(x, And(Eq(x, 0), Eq(z, 1)), S.Integers)
+    assert ConditionSet(x, Eq(x, 0), ConditionSet(y, Eq(y, 1),
+        S.Integers)) == ConditionSet(x, And(Eq(x, 0), Eq(x, 1)), S.Integers)
 
 
 def test_CondSet_intersect():

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -89,6 +89,10 @@ def test_subs_CondSet():
     assert ConditionSet(x, x < y, s
         ).subs(y, w) == ConditionSet(x, x < w, s.subs(y, w))
 
+    # to eventually be removed
+    c = ConditionSet((x, y), {x + 1, x + y}, S.Reals)
+    assert c.subs(x, z) == c
+
 
 def test_dummy_eq():
     C = ConditionSet
@@ -98,3 +102,12 @@ def test_dummy_eq():
     assert c.dummy_eq(1) == False
     assert c.dummy_eq(C(x, x < 1, S.Reals)) == False
     raises(ValueError, lambda: c.dummy_eq(C(x, x < 1, S.Reals), z))
+
+    # to eventually be removed
+    c1 = ConditionSet((x, y), {x + 1, x + y}, S.Reals)
+    c2 = ConditionSet((x, y), {x + 1, x + y}, S.Reals)
+    c3 = ConditionSet((x, y), {x + 1, x + y}, S.Complexes)
+    assert c1.dummy_eq(c2)
+    assert c1.dummy_eq(c3) is False
+    assert c.dummy_eq(c1) is False
+    assert c1.dummy_eq(c) is False

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -2,8 +2,6 @@ from sympy.sets import (ConditionSet, Intersection, FiniteSet, EmptySet, Union)
 from sympy import (Symbol, Eq, S, Abs, sin, pi, Lambda, Interval, And, Mod)
 
 x = Symbol('x')
-y = Symbol('y')
-z = Symbol('z')
 
 
 def test_CondSet():
@@ -14,11 +12,6 @@ def test_CondSet():
     assert 3*pi not in sin_sols_principal
     assert 5 in ConditionSet(x, x**2 > 4, S.Reals)
     assert 1 not in ConditionSet(x, x**2 > 4, S.Reals)
-
-    assert ConditionSet(x, Eq(x, 0), ConditionSet(y, Eq(z, 1),
-        S.Integers)) == ConditionSet(x, And(Eq(x, 0), Eq(z, 1)), S.Integers)
-    assert ConditionSet(x, Eq(x, 0), ConditionSet(y, Eq(y, 1),
-        S.Integers)) == ConditionSet(x, And(Eq(x, 0), Eq(x, 1)), S.Integers)
 
 
 def test_CondSet_intersect():

--- a/sympy/sets/tests/test_contains.py
+++ b/sympy/sets/tests/test_contains.py
@@ -11,7 +11,8 @@ def test_contains_basic():
 
 def test_issue_6194():
     x = Symbol('x')
-    assert Contains(x, Interval(0, 1)) == (x >= 0) & (x <= 1)
+    assert Contains(x, Interval(0, 1)) != (x >= 0) & (x <= 1)
+    assert Interval(0, 1).contains(x) == (x >= 0) & (x <= 1)
     assert Contains(x, FiniteSet(0)) != S.false
     assert Contains(x, Interval(1, 1)) != S.false
     assert Contains(x, S.Integers) != S.false

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -324,32 +324,27 @@ def _invert_abs(f, g_ys, symbol):
     returned.
 
     """
-
-    n = Dummy('n', real=True)
-
-    if f.is_positive:
-        f_n = f
-    else:
-        f_n = f.args[0]
-
-    g_x, values = _invert_real(f_n, Union(imageset(Lambda(n, n), g_ys),
-                               imageset(Lambda(n, -n), g_ys)), symbol)
-
     if not isinstance(g_ys, FiniteSet):
         raise NotImplementedError
+    # before attempting to solve make sure the conditions
+    # are not invalid
+    unknown = []
+    for a in g_ys.args:
+        ok = a.is_nonnegative if a.is_Number else a.is_positive
+        if ok is None:
+            unknown.append(a)
+        elif not ok:
+            return symbol, S.EmptySet
+    if unknown:
+        conditions = And(*[Contains(i, Interval(0, oo))
+            for i in unknown])
     else:
-        unknown = []
-        for a in g_ys.args:
-            ok = a.is_nonnegative if a.is_Number else a.is_positive
-            if ok is None:
-                unknown.append(a)
-            elif not ok:
-                return g_x, S.EmptySet
-        if unknown:
-            conditions = And(*[Contains(i, Interval(0, oo))
-                for i in unknown])
-        else:
-            conditions = True
+        conditions = True
+    # none were invalid
+    f_n = f.args[0]
+    n = Dummy('n', real=True)
+    g_x, values = _invert_real(f_n, Union(imageset(Lambda(n, n), g_ys),
+        imageset(Lambda(n, -n), g_ys)), symbol)
     return g_x, ConditionSet(g_x, conditions, values)
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -327,8 +327,6 @@ def _invert_abs(f, g_ys, symbol):
 
     n = Dummy('n', real=True)
 
-    condition_interval = Interval(0, oo)
-
     if f.is_positive:
         f_n = f
     else:
@@ -337,31 +335,21 @@ def _invert_abs(f, g_ys, symbol):
     g_x, values = _invert_real(f_n, Union(imageset(Lambda(n, n), g_ys),
                                imageset(Lambda(n, -n), g_ys)), symbol)
 
-    satisfied_ys = S.EmptySet
-    for condition_atom in g_ys.args:
-        if condition_atom.is_Number:
-            if condition_atom not in condition_interval:
-                return g_x, S.EmptySet
-            else:
-                satisfied_ys = Union(FiniteSet(condition_atom),
-                                     satisfied_ys)
-        elif condition_atom.is_positive:
-            satisfied_ys = Union(FiniteSet(condition_atom), satisfied_ys)
-        elif condition_atom.is_positive is False:
-            return g_x, S.EmptySet
-        else:
-            pass
-    condition_ys = g_ys - satisfied_ys
-
-
-    if not condition_ys:
-        return g_x, values
-
-    if not isinstance(condition_ys, FiniteSet):
+    if not isinstance(g_ys, FiniteSet):
         raise NotImplementedError
-
-    conditions = And(*[Contains(i, Interval(0, oo))
-        for i in condition_ys])
+    else:
+        unknown = []
+        for a in g_ys.args:
+            ok = a.is_nonnegative if a.is_Number else a.is_positive
+            if ok is None:
+                unknown.append(a)
+            elif not ok:
+                return g_x, S.EmptySet
+        if unknown:
+            conditions = And(*[Contains(i, Interval(0, oo))
+                for i in unknown])
+        else:
+            conditions = True
     return g_x, ConditionSet(g_x, conditions, values)
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1558,7 +1558,7 @@ def linsolve(system, *symbols):
 def _return_conditionset(eqs, symbols):
         # return conditionset
         condition_set = ConditionSet(
-            FiniteSet(*symbols),
+            Tuple(*symbols),
             FiniteSet(*eqs),
             S.Complexes)
         return condition_set

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -350,12 +350,10 @@ def _invert_abs(f, g_ys, symbol):
                 condition_base_set = Union(condition_base_set,
                                            FiniteSet(*values_condition.args[0]))
                 conditions = Contains(condition_base_set.args,
-                                      condition_interval,
-                                      evaluate=False)
+                                      condition_interval)
             else:
                 condition = Contains(condition_base_set.args,
-                                     condition_interval,
-                                     evaluate=False)
+                                     condition_interval)
                 conditions = And(values_condition, condition)
         else:
             pass  # No possible usecase
@@ -383,8 +381,7 @@ def _invert_abs(f, g_ys, symbol):
             condition_base = condition_ys.args[0]
         else:
             condition_base = condition_ys.args
-        conditions = Contains(condition_base,
-                              condition_interval, evaluate=False)
+        conditions = Contains(condition_base, condition_interval)
 
     return g_x, ConditionSet(g_x, conditions, values)
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -312,7 +312,22 @@ def _invert_complex(f, g_ys, symbol):
 
 
 def _invert_abs(f, g_ys, symbol):
-    """Helper function for inverting absolute value functions"""
+    """Helper function for inverting absolute value functions.
+
+    Returns the complete result of inverting an absolute value function.
+    Alongwith finding all the possible solutions of the given function,
+    the routine determines a set of conditions which must be satified
+    for their existence.
+
+    The returned values are determined by the condition
+    If it is certain that all these conditions are met, a `FiniteSet` of all
+    possible solutions is returned.
+    If it can be concluded that atleast one condition cannot be satified, an
+    `EmptySet` is returned.
+    In all other cases, a `ConditionSet` of the solutions, with all the required
+    conditions specified, is returned.
+
+    """
 
     n = Dummy('n', real=True)
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1025,8 +1025,12 @@ def test_solvify():
     assert solvify(log(x), x, S.Reals) == [1]
     assert solvify(cos(x), x, S.Reals) == [pi/2, 3*pi/2]
     assert solvify(sin(x) + 1, x, S.Reals) == [3*pi/2]
-    assert solvify(sin(Abs(x)), x, S.Reals) is None
     raises(NotImplementedError, lambda: solvify(sin(exp(x)), x, S.Complexes))
+
+
+@XFAIL
+def test_abs_invert_solvify():
+    assert solvify(sin(Abs(x)), x, S.Reals) is None
 
 
 def test_linear_eq_to_matrix():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -61,13 +61,6 @@ def test_invert_real():
     # issue 14223
     assert invert_real(x, 0, x, Interval(1, 2)) == (x, S.EmptySet)
 
-    assert solveset(abs(x) - n, x, S.Reals) == ConditionSet(
-        x, Contains(n, Interval(0, oo), evaluate=False), {-n, n})
-
-    conditions = Contains(n, Interval(0, oo), evaluate=False)
-    assert solveset(abs(x) - n, x, S.Reals) == ConditionSet(
-        x, conditions, FiniteSet(n, -n))
-
     assert invert_real(exp(x), y, x) == (x, ireal(FiniteSet(log(y))))
 
     y = Symbol('y', positive=True)
@@ -592,6 +585,8 @@ def test_uselogcombine_2():
 
 
 def test_solve_abs():
+    assert solveset(Abs(x) - n, x, S.Reals) == ConditionSet(
+        x, Contains(n, Interval(0, oo)), {-n, n})
     assert solveset_real(Abs(x) - 2, x) == FiniteSet(-2, 2)
     assert solveset_real(Abs(x + 3) - 2*Abs(x - 3), x) == \
         FiniteSet(1, 9)
@@ -600,7 +595,7 @@ def test_solve_abs():
 
     assert solveset_real(Abs(x - 7) - 8, x) == FiniteSet(-S(1), S(15))
 
-    raises(ValueError, lambda: solveset(abs(x) - 1, x))
+    raises(ValueError, lambda: solveset(Abs(x) - 1, x))
 
 
 def test_issue_9565():
@@ -1197,6 +1192,7 @@ def test_nonlinsolve_basic():
     assert nonlinsolve([x**2 -1], sin(x)) == FiniteSet((S.EmptySet,))
     assert nonlinsolve([x**2 -1], 1) == FiniteSet((x**2,))
     assert nonlinsolve([x**2 -1], x + y) == FiniteSet((S.EmptySet,))
+
 
 @XFAIL
 def test_nonlinsolve_abs():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -61,13 +61,12 @@ def test_invert_real():
     # issue 14223
     assert invert_real(x, 0, x, Interval(1, 2)) == (x, S.EmptySet)
 
-    minus_n = Intersection(Interval(-oo, 0), FiniteSet(-n))
-    plus_n = Intersection(Interval(0, oo), FiniteSet(n))
-    assert solveset(abs(x) - n, x, S.Reals) == Union(minus_n, plus_n)
+    assert solveset(abs(x) - n, x, S.Reals) == ConditionSet(
+        x, Contains(n, Interval(0, oo), evaluate=False), {-n, n})
 
     conditions = Contains(n, Interval(0, oo), evaluate=False)
-    assert solveset(abs(x) - n, x, S.Reals) == ConditionSet(x, conditions,
-                                                            FiniteSet(n, -n))
+    assert solveset(abs(x) - n, x, S.Reals) == ConditionSet(
+        x, conditions, FiniteSet(n, -n))
 
     assert invert_real(exp(x), y, x) == (x, ireal(FiniteSet(log(y))))
 
@@ -157,7 +156,7 @@ def test_invert_real():
     n = Dummy('n')
     x = Symbol('x')
 
-    conditions = Contains((b, a + b, a - b), Interval(0, oo), evaluate=False)
+    conditions = Contains((b, a + b, a - b), Interval(0, oo))
     base_values = FiniteSet(- a - b - 3, - a + b - 3, a - b - 3, a + b - 3)
     assert invert_real(Abs(Abs(x + 3) - a) - b, 0, x) == \
         (x, ConditionSet(x, conditions, base_values))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1750,8 +1750,6 @@ def test_issue_14300():
 
 def test_issue_14454():
     x = Symbol('x')
-    raises(ValueError, lambda: invert_real(CRootOf(x**4 + x - 1, 2), 0, x, S.Reals))
-
-    y = invert_real(x**2, CRootOf(x**4 + x - 1, 2), x, S.Reals)
-    assert y[1].has(Intersection) == True
-    assert y[1].has(CRootOf) == True
+    number = CRootOf(x**4 + x - 1, 2)
+    raises(ValueError, lambda: invert_real(number, 0, x, S.Reals))
+    assert invert_real(x**2, number, x, S.Reals)  # no error

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1184,8 +1184,6 @@ def test_nonlinsolve_basic():
     assert nonlinsolve([sin(x) - 1], [x]) == FiniteSet(tuple(soln))
     assert nonlinsolve([x**2 - 1], [x]) == FiniteSet((-1,), (1,))
 
-    soln = FiniteSet((- y, y), (y, y))
-    assert nonlinsolve([Abs(x) - y], x, y) == soln
     soln = FiniteSet((y, y))
     assert nonlinsolve([x - y, 0], x, y) == soln
     assert nonlinsolve([0, x - y], x, y) == soln
@@ -1200,6 +1198,11 @@ def test_nonlinsolve_basic():
     assert nonlinsolve([x**2 -1], sin(x)) == FiniteSet((S.EmptySet,))
     assert nonlinsolve([x**2 -1], 1) == FiniteSet((x**2,))
     assert nonlinsolve([x**2 -1], x + y) == FiniteSet((S.EmptySet,))
+
+@XFAIL
+def test_nonlinsolve_abs():
+    soln = FiniteSet((- y, y), (y, y))
+    assert nonlinsolve([Abs(x) - y], x, y) == soln
 
 
 def test_raise_exception_nonlinsolve():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -150,19 +150,27 @@ def test_invert_real():
     n = Dummy('n')
     x = Symbol('x')
 
-    # XXX this is ugly
-    sol = (x,
-        ConditionSet(x,
-            Contains(b, Interval(0, oo)),
-            ConditionSet(x,
-                Contains(a + b, Interval(0, oo)) & Contains(a - b, Interval(0, oo)),
-                FiniteSet(-a - b - 3, -a + b - 3, a - b - 3, a + b - 3))))
+    sol = ConditionSet(
+            x, 
+            And(
+                Contains(b, Interval(0, oo)),
+                Contains(a + b, Interval(0, oo)),
+                Contains(a - b, Interval(0, oo))),
+            FiniteSet(-a - b - 3, -a + b - 3, a - b - 3, a + b - 3))
     eq = Abs(Abs(x + 3) - a) - b
-    assert invert_real(eq, 0, x) == sol
+    assert invert_real(eq, 0, x)[1] == sol
     reps = {a: 3, b: 1}
     eqab = eq.subs(reps)
-    for i in sol[1].subs(reps):
+    for i in sol.subs(reps):
         assert not eqab.subs(x, i)
+
+
+@XFAIL
+def test_solve_abs_with_imageset():
+    # not sure how to represent this: how do convert something
+    # like imageset(x, (-1)**x, S.Integers) into a set of positive
+    # numbers using set operations or solveset?
+    assert solveset(Eq(sin(Abs(x)), 1), x, domain=S.Reals)
 
 
 def test_invert_complex():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -151,7 +151,7 @@ def test_invert_real():
     x = Symbol('x')
 
     sol = ConditionSet(
-            x, 
+            x,
             And(
                 Contains(b, Interval(0, oo)),
                 Contains(a + b, Interval(0, oo)),

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -16,6 +16,7 @@ from sympy.functions.elementary.trigonometric import (
     cos, cot, csc, sec, sin, tan)
 from sympy.functions.special.error_functions import (erf, erfc,
     erfcinv, erfinv)
+from sympy.logic.boolalg import And
 from sympy.matrices.dense import MutableDenseMatrix as Matrix
 from sympy.polys.polytools import Poly
 from sympy.polys.rootoftools import CRootOf
@@ -149,10 +150,19 @@ def test_invert_real():
     n = Dummy('n')
     x = Symbol('x')
 
-    conditions = Contains((b, a + b, a - b), Interval(0, oo))
-    base_values = FiniteSet(- a - b - 3, - a + b - 3, a - b - 3, a + b - 3)
-    assert invert_real(Abs(Abs(x + 3) - a) - b, 0, x) == \
-        (x, ConditionSet(x, conditions, base_values))
+    # XXX this is ugly
+    sol = (x,
+        ConditionSet(x,
+            Contains(b, Interval(0, oo)),
+            ConditionSet(x,
+                Contains(a + b, Interval(0, oo)) & Contains(a - b, Interval(0, oo)),
+                FiniteSet(-a - b - 3, -a + b - 3, a - b - 3, a + b - 3))))
+    eq = Abs(Abs(x + 3) - a) - b
+    assert invert_real(eq, 0, x) == sol
+    reps = {a: 3, b: 1}
+    eqab = eq.subs(reps)
+    for i in sol[1].subs(reps):
+        assert not eqab.subs(x, i)
 
 
 def test_invert_complex():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,3 +1,4 @@
+from sympy.core.containers import Tuple
 from sympy.core.function import (Function, Lambda, nfloat)
 from sympy.core.mod import Mod
 from sympy.core.numbers import (E, I, Rational, oo, pi)
@@ -1492,14 +1493,14 @@ def test_nonlinsolve_conditionset():
     # return conditionset
     f = Function('f')
     f1 = f(x) - pi/2
-    f2 = f(x) - 3*pi/2
-    intermediate_system = FiniteSet(2*f(x) - 3*pi, 2*f(x) - pi)
-    symbols = FiniteSet(x, y)
+    f2 = f(y) - 3*pi/2
+    intermediate_system = FiniteSet(2*f(x) - pi, 2*f(y) - 3*pi)
+    symbols = Tuple(x, y)
     soln = ConditionSet(
         symbols,
         intermediate_system,
         S.Complexes)
-    assert nonlinsolve([f1, f2], [x,y]) == soln
+    assert nonlinsolve([f1, f2], [x, y]) == soln
 
 
 def test_substitution_basic():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

closes #10751 as a continuation of that work
closes #10532
closes #14485 
closes #14501 

#### Brief description of what is fixed or changed

see #10751

#### Other comments

Contains will no longer return relationals for things like `Contains(x, Interval(0, oo))`; it will now only evaluate if a Set is produced or evaluates to true or false. An alternative might be to make it `evaluate=False` by default and give Contains a doit method.

ConditionSet has an `_eval_subs` routine and `free_symbols` that tries to handle correctly the dummy symbol of the ConditionSet. It also allows the continued (ab)use of ConditionSet as a container for an unsolved system of equations.