### PR TITLE
Check that args are numeric in _eval_evalf of incomplete gammas

### DIFF
--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -305,11 +305,14 @@ class lowergamma(Function):
     def _eval_evalf(self, prec):
         from mpmath import mp, workprec
         from sympy import Expr
-        a = self.args[0]._to_mpmath(prec)
-        z = self.args[1]._to_mpmath(prec)
-        with workprec(prec):
-            res = mp.gammainc(a, 0, z)
-        return Expr._from_mpmath(res, prec)
+        if all(x.is_number for x in self.args):
+            a = self.args[0]._to_mpmath(prec)
+            z = self.args[1]._to_mpmath(prec)
+            with workprec(prec):
+                res = mp.gammainc(a, 0, z)
+            return Expr._from_mpmath(res, prec)
+        else:
+            return self
 
     def _eval_conjugate(self):
         z = self.args[1]
@@ -401,11 +404,13 @@ class uppergamma(Function):
     def _eval_evalf(self, prec):
         from mpmath import mp, workprec
         from sympy import Expr
-        a = self.args[0]._to_mpmath(prec)
-        z = self.args[1]._to_mpmath(prec)
-        with workprec(prec):
-            res = mp.gammainc(a, z, mp.inf)
-        return Expr._from_mpmath(res, prec)
+        if all(x.is_number for x in self.args):
+            a = self.args[0]._to_mpmath(prec)
+            z = self.args[1]._to_mpmath(prec)
+            with workprec(prec):
+                res = mp.gammainc(a, z, mp.inf)
+            return Expr._from_mpmath(res, prec)
+        return self
 
     @classmethod
     def eval(cls, a, z):

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -433,3 +433,11 @@ def test_issue_8524():
     assert gamma(r).is_positive is None
     assert gamma(e + S.Half).is_positive is True
     assert gamma(e - S.Half).is_positive is False
+
+def test_issue_14450():
+    assert uppergamma(3/8, x).evalf() == uppergamma(0.375, x)
+    assert lowergamma(x, 3/8).evalf() == lowergamma(x, 0.375)
+    # some values from Wolfram Alpha for comparison
+    assert abs(uppergamma(S(3)/8, 2).evalf() - 0.07105675881) < 1e-9
+    assert abs(lowergamma(S(3)/8, 2).evalf() - 2.2993794256) < 1e-9
+

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -440,4 +440,3 @@ def test_issue_14450():
     # some values from Wolfram Alpha for comparison
     assert abs(uppergamma(S(3)/8, 2).evalf() - 0.07105675881) < 1e-9
     assert abs(lowergamma(S(3)/8, 2).evalf() - 2.2993794256) < 1e-9
-


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14450 

#### Brief description of what is fixed or changed

The incomplete gamma functions lowergamma and uppergamma have their own `_eval_evalf` method because some work is needed before passing the values to mpmath.gammainc. This work now includes checking that the arguments are numeric.