### PR TITLE
Fixed triple integral

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -411,7 +411,7 @@ class AddWithLimits(ExprWithLimits):
                 return Mul(*out[True])*self.func(Mul(*out[False]), \
                     *self.limits)
         else:
-            summand = self.func(self.function, self.limits[0:-1]).factor()
+            summand = self.func(self.function, *self.limits[0:-1]).factor()
             if not summand.has(self.variables[-1]):
                 return self.func(1, [self.limits[-1]]).doit()*summand
             elif isinstance(summand, Mul):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1321,8 +1321,5 @@ def test_issue_14375():
 
 def test_issue_14437():
     f = Function('f')(x, y, z)
-    f = exp(x + y + z)
-    Ix = integrate(f, (x, 0, 1))
-    Ixy = integrate(Ix, (y, 0, 2))
-    Ixyz = integrate(Ixy, (z, 0, 3))
-    assert Ixyz == -exp(3) - 1 + E + exp(2) + (-exp(2) - E + 1 + exp(3))*exp(3)
+    assert integrate(f, (x, 0, 1), (y, 0, 2), (z, 0, 3)) == \
+                Integral(f, (x, 0, 1), (y, 0, 2), (z, 0, 3))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1318,3 +1318,11 @@ def test_issue_14375():
     # This raised a TypeError. The antiderivative has exp_polar, which
     # may be possible to unpolarify, so the exact output is not asserted here.
     assert integrate(exp(I*x)*log(x), x).has(Ei)
+
+def test_issue_14437():
+    f = Function('f')(x, y, z)
+    f = exp(x + y + z)
+    Ix = integrate(f, (x, 0, 1))
+    Ixy = integrate(Ix, (y, 0, 2))
+    Ixyz = integrate(Ixy, (z, 0, 3))
+    assert Ixyz == -exp(3) - 1 + E + exp(2) + (-exp(2) - E + 1 + exp(3))*exp(3)


### PR DESCRIPTION
Fixes #14437 .

Changed `self.limits[0:-1]).factor()` to `*self.limits[0:-1]).factor()`, according to the line of @jksuom 's comment [here](https://github.com/sympy/sympy/issues/14437#issuecomment-371749731)
Test case has been added.

@normalhuman @jksuom,
Please review.