### PR TITLE
Invert_real modified to use free symbols, not has

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -139,10 +139,10 @@ def _invert(f_x, y, x, domain=S.Complexes):
     if not x.is_Symbol:
         raise ValueError("x must be a symbol")
     f_x = sympify(f_x)
-    if not f_x.has(x):
+    if x not in f_x.free_symbols:
         raise ValueError("Inverse of constant function doesn't exist")
     y = sympify(y)
-    if y.has(x):
+    if x in y.free_symbols:
         raise ValueError("y should be independent of x ")
 
     if domain.is_subset(S.Reals):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1725,3 +1725,12 @@ def test_issue_10158():
         solveset(Max(Abs(x - 3) - 1, x + 2) - 3, x, dom))
     raises(ValueError, lambda: solveset(Abs(x - 1) - Abs(y), x, dom))
     raises(ValueError, lambda: solveset(Abs(x + 4*Abs(x + 1)), x, dom))
+
+
+def test_issue_14454():
+    x = Symbol('x')
+    raises(ValueError, lambda: invert_real(CRootOf(x**4 + x - 1, 2), 0, x, S.Reals))
+
+    y = invert_real(x**2, CRootOf(x**4 + x - 1, 2), x, S.Reals)
+    assert y[1].has(Intersection) == True
+    assert y[1].has(CRootOf) == True


### PR DESCRIPTION
Fixes #14454 .
Function containing `Dummy Symbols` will now throw an error, for example, the `complex_root` function, which has `x` as its dummy, not free, symbol.

**NOW**

```
>>> from sympy import *
>>> x = symbols('x')
>>> from sympy.solvers.solveset import invert_real

>>> invert_real(CRootOf(x**4 + x - 1, 2), 0, x, S.Reals)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy/solvers/solveset.py", line 167, in invert_real
    return _invert(f_x, y, x, domain)
  File "sympy/solvers/solveset.py", line 143, in _invert
    raise ValueError("Inverse of constant function doesn't exist")
ValueError: Inverse of constant function doesn't exist

>>> invert_real(x**2, CRootOf(x**4 + x - 1, 2), x, S.Reals)
(x, Intersection(S.Reals, {-sqrt(CRootOf(x**4 + x - 1, 2)), sqrt(CRootOf(x**4 + x - 1, 2))}))
```