### PR TITLE
Test for convergence in Sum

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1016,4 +1016,5 @@ def test_issue_14112():
     assert Sum((-2)**n + (-3)**n, (n, 1, oo)).is_convergent() is S.false
 
 def test_sin_times_absolutely_convergent():
-    assert Sum(sin(n)/n**3, (n, 1, oo)).is_convergent() is S.true
+    assert Sum(sin(n) / n**3, (n, 1, oo)).is_convergent() is S.true
+    assert Sum(sin(n) * log(n) / n**3, (n, 1, oo)).is_convergent() is S.true

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -989,8 +989,6 @@ def test_is_absolutely_convergent():
 
 @XFAIL
 def test_convergent_failing():
-    assert Sum(sin(n)/n**3, (n, 1, oo)).is_convergent() is S.true
-
     # dirichlet tests
     assert Sum(sin(n)/n, (n, 1, oo)).is_convergent() is S.true
     assert Sum(sin(2*n)/n, (n, 1, oo)).is_convergent() is S.true
@@ -1016,3 +1014,6 @@ def test_issue_14112():
     assert Sum((-1)**n/sqrt(n), (n, 1, oo)).is_absolutely_convergent() is S.false
     assert Sum((-1)**(2*n)/n, (n, 1, oo)).is_convergent() is S.false
     assert Sum((-2)**n + (-3)**n, (n, 1, oo)).is_convergent() is S.false
+
+def test_sin_times_absolutely_convergent():
+    assert Sum(sin(n)/n**3, (n, 1, oo)).is_convergent() is S.true


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fix issue #14463.


#### Brief description of what is fixed or changed

A test for convergence in `is_convergent()` method for `Sum` is added. Such a test aims to treat the series whose general term is a product between a bounded term `a_n` and a term `b_n`, such
that the sum of `b_n` is absolutely convergent.

Files changed:
   sympy/concrete/summations.py
   sympy/concrete/tests/test_sums_products.py


#### Other comments

`test_sums_products.py` includes `assert Sum(sin(n)/n**3, (n, 1, oo)).is_convergent() is S.true`.

