### PR TITLE
changed the order of heuristics and gruntz

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -206,13 +206,13 @@ class Limit(Expr):
             return Order(limit(e.expr, z, z0), *e.args[1:])
 
         try:
-            r = gruntz(e, z, z0, dir)
-            if r is S.NaN:
-                raise PoleError()
-        except (PoleError, ValueError):
             r = heuristics(e, z, z0, dir)
             if r is None:
                 return self
+        except (PoleError, ValueError):
+            r = gruntz(e, z, z0, dir)
+            if r is S.NaN:
+                raise PoleError()
         except NotImplementedError:
             # Trying finding limits of sequences
             if hints.get('sequence', True) and z0 is S.Infinity:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -206,13 +206,13 @@ class Limit(Expr):
             return Order(limit(e.expr, z, z0), *e.args[1:])
 
         try:
-            r = heuristics(e, z, z0, dir)
-            if r is None:
-                return self
-        except (PoleError, ValueError):
             r = gruntz(e, z, z0, dir)
             if r is S.NaN:
                 raise PoleError()
+        except (PoleError, ValueError):
+            r = heuristics(e, z, z0, dir)
+            if r is None:
+                return self
         except NotImplementedError:
             # Trying finding limits of sequences
             if hints.get('sequence', True) and z0 is S.Infinity:

--- a/wrapper_module_0.pyx
+++ b/wrapper_module_0.pyx
@@ -1,0 +1,11 @@
+import numpy as np
+cimport numpy as np
+
+cdef extern from 'wrapped_code_0.h':
+    void test(double x, double y, double *z)
+
+def test_c(double x, double y):
+
+    cdef double z = 0
+    test(x, y, &z)
+    return z

--- a/wrapper_module_0.pyx
+++ b/wrapper_module_0.pyx
@@ -1,11 +1,1 @@
-import numpy as np
-cimport numpy as np
 
-cdef extern from 'wrapped_code_0.h':
-    void test(double x, double y, double *z)
-
-def test_c(double x, double y):
-
-    cdef double z = 0
-    test(x, y, &z)
-    return z


### PR DESCRIPTION
The heuristics code is placed before the gruntz code so that the limit for expressions like `1/x`, `x` and `x**2` is calculated by heuristics instead of Gruntz algorithm

Fixes #14459 