### PR TITLE
Allow Geometric RVs where `p` is a symbol

### DIFF
--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -90,7 +90,8 @@ class GeometricDistribution(SingleDiscreteDistribution):
 
     @staticmethod
     def check(p):
-        _value_check(0 < p and p <= 1, "p must be between 0 and 1")
+        _value_check(0 < p, "p must be between 0 and 1")
+        _value_check(p <= 1, "p must be between 0 and 1")
 
     def pdf(self, k):
         return (1 - self.p)**(k - 1) * self.p

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.stats.drv import SingleDiscreteDistribution, SingleDiscretePSpace
-from sympy import factorial, exp, S, sympify
+from sympy import factorial, exp, S, sympify, And
 from sympy.stats.rv import _value_check
 from sympy.sets.sets import Interval
 import random
@@ -90,8 +90,7 @@ class GeometricDistribution(SingleDiscreteDistribution):
 
     @staticmethod
     def check(p):
-        _value_check(0 < p, "p must be between 0 and 1")
-        _value_check(p <= 1, "p must be between 0 and 1")
+        _value_check(And(0 < p, p<=1), "p must be between 0 and 1")
 
     def pdf(self, k):
         return (1 - self.p)**(k - 1) * self.p

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -40,6 +40,7 @@ def test_sample():
 def test_discrete_probability():
     X = Geometric('X', S(1)/5)
     Y = Poisson('Y', 4)
+    G = Geometric('e', x)
     assert P(Eq(X, 3)) == S(16)/125
     assert P(X < 3) == S(9)/25
     assert P(X > 3) == S(64)/125
@@ -55,3 +56,5 @@ def test_discrete_probability():
         13*exp(-4) + 32*(-71/32 + 3*exp(4)/32)*exp(-4)/3)
     assert P(X < S.Infinity) is S.One
     assert P(X > S.Infinity) is S.Zero
+    assert P(G < 3) == x*(-x + 1) + x
+    assert P(Eq(G, 3)) == x*(-x + 1)**2


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
Made a minor modification to drv_types.py, to allow the creation of Geometric RVs with a symbolic parameter. Added tests for the same.

#### Other comments
