### PR TITLE
Implement Cholesky and LDL decompositions for Hermitian matrices

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -7,7 +7,7 @@ from sympy.core import SympifyError
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
 from sympy.core.compatibility import is_sequence, as_int, range, reduce
-from sympy.core.function import count_ops
+from sympy.core.function import count_ops, expand_mul
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
@@ -138,9 +138,10 @@ class DenseMatrix(MatrixBase):
         L = zeros(self.rows, self.rows)
         for i in range(self.rows):
             for j in range(i):
-                L[i, j] = (1 / L[j, j])*(self[i, j] -
+                L[i, j] = (1 / L[j, j])*expand_mul(self[i, j] -
                     sum(L[i, k]*L[j, k].conjugate() for k in range(j)))
-            Lii2 = self[i, i] - sum(Abs(L[i, k])**2 for k in range(i))
+            Lii2 = expand_mul(self[i, i] -
+                sum(L[i, k]*L[i, k].conjugate() for k in range(i)))
             if Lii2.is_positive is False:
                 raise ValueError("Matrix must be positive-definite")
             L[i, i] = sqrt(Lii2)
@@ -296,10 +297,10 @@ class DenseMatrix(MatrixBase):
         L = eye(self.rows)
         for i in range(self.rows):
             for j in range(i):
-                L[i, j] = (1 / D[j, j])*(self[i, j] - sum(
+                L[i, j] = (1 / D[j, j])*expand_mul(self[i, j] - sum(
                     L[i, k]*L[j, k].conjugate()*D[k, k] for k in range(j)))
-            D[i, i] = self[i, i] - sum(Abs(L[i, k])**2*D[k, k]
-                                       for k in range(i))
+            D[i, i] = expand_mul(self[i, i] -
+                sum(L[i, k]*L[i, k].conjugate()*D[k, k] for k in range(i)))
             if D[i, i].is_positive is False:
                 raise ValueError("Matrix must be positive-definite")
         return self._new(L), self._new(D)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -11,6 +11,7 @@ from sympy.core.function import count_ops
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
+from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.simplify import simplify as _simplify
@@ -131,14 +132,18 @@ class DenseMatrix(MatrixBase):
     def _cholesky(self):
         """Helper function of cholesky.
         Without the error checks.
-        To be used privately. """
+        To be used privately.
+        Implements the Cholesky–Banachiewicz algorithm.
+        """
         L = zeros(self.rows, self.rows)
         for i in range(self.rows):
             for j in range(i):
                 L[i, j] = (1 / L[j, j])*(self[i, j] -
-                                         sum(L[i, k]*L[j, k] for k in range(j)))
-            L[i, i] = sqrt(self[i, i] -
-                           sum(L[i, k]**2 for k in range(i)))
+                    sum(L[i, k]*L[j, k].conjugate() for k in range(j)))
+            Lii2 = self[i, i] - sum(Abs(L[i, k])**2 for k in range(i))
+            if Lii2.is_positive is False:
+                raise ValueError("Matrix must be positive-definite")
+            L[i, i] = sqrt(Lii2)
         return self._new(L)
 
     def _diagonal_solve(self, rhs):
@@ -286,14 +291,17 @@ class DenseMatrix(MatrixBase):
         Without the error checks.
         To be used privately.
         """
+        # https://en.wikipedia.org/wiki/Cholesky_decomposition#LDL_decomposition_2
         D = zeros(self.rows, self.rows)
         L = eye(self.rows)
         for i in range(self.rows):
             for j in range(i):
                 L[i, j] = (1 / D[j, j])*(self[i, j] - sum(
-                    L[i, k]*L[j, k]*D[k, k] for k in range(j)))
-            D[i, i] = self[i, i] - sum(L[i, k]**2*D[k, k]
+                    L[i, k]*L[j, k].conjugate()*D[k, k] for k in range(j)))
+            D[i, i] = self[i, i] - sum(Abs(L[i, k])**2*D[k, k]
                                        for k in range(i))
+            if D[i, i].is_positive is False:
+                raise ValueError("Matrix must be positive-definite")
         return self._new(L), self._new(D)
 
     def _lower_triangular_solve(self, rhs):

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -59,13 +59,14 @@ def test_function_return_types():
     assert type(X.LUsolve(Y)) == ImmutableMatrix
     assert type(X.QRsolve(Y)) == ImmutableMatrix
 
-    X = ImmutableMatrix([[1, 2], [2, 1]])
+    X = ImmutableMatrix([[5, 2], [2, 7]])
     assert X.T == X
     assert X.is_symmetric
     assert type(X.cholesky()) == ImmutableMatrix
     L, D = X.LDLdecomposition()
     assert (type(L), type(D)) == (ImmutableMatrix, ImmutableMatrix)
 
+    X = ImmutableMatrix([[1, 2], [2, 1]])
     assert X.is_diagonalizable()
     assert X.det() == -3
     assert X.norm(2) == 3

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -4,7 +4,7 @@ import warnings
 
 from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
-    S, Symbol, cos, exp, oo, pi, signsimp, simplify, sin, sqrt, symbols,
+    S, Symbol, cos, exp, expand, oo, pi, signsimp, simplify, sin, sqrt, symbols,
     sympify, trigsimp, tan, sstr, diff, Function)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
     NonSquareMatrixError, DeferredVector, _find_reasonable_pivot_naive,
@@ -2042,15 +2042,21 @@ def test_hessenberg():
 def test_cholesky():
     raises(NonSquareMatrixError, lambda: Matrix((1, 2)).cholesky())
     raises(ValueError, lambda: Matrix(((1, 2), (3, 4))).cholesky())
+    raises(ValueError, lambda: Matrix(((5 + I, 0), (0, 1))).cholesky())
+    raises(ValueError, lambda: Matrix(((1, 5), (5, 1))).cholesky())
     A = Matrix(((25, 15, -5), (15, 18, 0), (-5, 0, 11)))
     assert A.cholesky() * A.cholesky().T == A
     assert A.cholesky().is_lower
     assert A.cholesky() == Matrix([[5, 0, 0], [3, 3, 0], [-1, 1, 3]])
+    A = Matrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
+    assert expand(A.cholesky()) == Matrix(((2, 0, 0), (I, 1, 0), (1 - I, 0, 3)))
 
 
 def test_LDLdecomposition():
     raises(NonSquareMatrixError, lambda: Matrix((1, 2)).LDLdecomposition())
     raises(ValueError, lambda: Matrix(((1, 2), (3, 4))).LDLdecomposition())
+    raises(ValueError, lambda: Matrix(((5 + I, 0), (0, 1))).LDLdecomposition())
+    raises(ValueError, lambda: Matrix(((1, 5), (5, 1))).LDLdecomposition())
     A = Matrix(((25, 15, -5), (15, 18, 0), (-5, 0, 11)))
     L, D = A.LDLdecomposition()
     assert L * D * L.T == A
@@ -2058,6 +2064,11 @@ def test_LDLdecomposition():
     assert L == Matrix([[1, 0, 0], [ S(3)/5, 1, 0], [S(-1)/5, S(1)/3, 1]])
     assert D.is_diagonal()
     assert D == Matrix([[25, 0, 0], [0, 9, 0], [0, 0, 9]])
+    A = Matrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
+    L, D = A.LDLdecomposition()
+    assert expand(L * D * L.H) == A
+    assert expand(L) == Matrix(((1, 0, 0), (I/2, 1, 0), (S(1)/2 - I/2, 0, 1)))
+    assert D == Matrix(((4, 0, 0), (0, 1, 0), (0, 0, 9)))
 
 
 def test_cholesky_solve():
@@ -2075,6 +2086,16 @@ def test_cholesky_solve():
     b = A*x
     soln = A.cholesky_solve(b)
     assert soln == x
+    A = Matrix(((9, 3*I), (-3*I, 5)))
+    x = Matrix((-2, 1))
+    b = A*x
+    soln = A.cholesky_solve(b)
+    assert expand(soln) == x
+    A = Matrix(((9*I, 3), (-3 + I, 5)))
+    x = Matrix((2 + 3*I, -1))
+    b = A*x
+    soln = A.cholesky_solve(b)
+    assert expand(soln) == x
 
 
 def test_LDLsolve():
@@ -2092,6 +2113,16 @@ def test_LDLsolve():
     b = A*x
     soln = A.LDLsolve(b)
     assert soln == x
+    A = Matrix(((9, 3*I), (-3*I, 5)))
+    x = Matrix((-2, 1))
+    b = A*x
+    soln = A.LDLsolve(b)
+    assert expand(soln) == x
+    A = Matrix(((9*I, 3), (-3 + I, 5)))
+    x = Matrix((2 + 3*I, -1))
+    b = A*x
+    soln = A.cholesky_solve(b)
+    assert expand(soln) == x
 
 
 def test_lower_triangular_solve():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -4,7 +4,7 @@ import warnings
 
 from sympy import (
     Abs, Add, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
-    S, Symbol, cos, exp, expand, oo, pi, signsimp, simplify, sin, sqrt, symbols,
+    S, Symbol, cos, exp, expand_mul, oo, pi, signsimp, simplify, sin, sqrt, symbols,
     sympify, trigsimp, tan, sstr, diff, Function)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
     NonSquareMatrixError, DeferredVector, _find_reasonable_pivot_naive,
@@ -2049,7 +2049,7 @@ def test_cholesky():
     assert A.cholesky().is_lower
     assert A.cholesky() == Matrix([[5, 0, 0], [3, 3, 0], [-1, 1, 3]])
     A = Matrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
-    assert expand(A.cholesky()) == Matrix(((2, 0, 0), (I, 1, 0), (1 - I, 0, 3)))
+    assert A.cholesky() == Matrix(((2, 0, 0), (I, 1, 0), (1 - I, 0, 3)))
 
 
 def test_LDLdecomposition():
@@ -2066,8 +2066,8 @@ def test_LDLdecomposition():
     assert D == Matrix([[25, 0, 0], [0, 9, 0], [0, 0, 9]])
     A = Matrix(((4, -2*I, 2 + 2*I), (2*I, 2, -1 + I), (2 - 2*I, -1 - I, 11)))
     L, D = A.LDLdecomposition()
-    assert expand(L * D * L.H) == A
-    assert expand(L) == Matrix(((1, 0, 0), (I/2, 1, 0), (S(1)/2 - I/2, 0, 1)))
+    assert expand_mul(L * D * L.H) == A
+    assert L == Matrix(((1, 0, 0), (I/2, 1, 0), (S(1)/2 - I/2, 0, 1)))
     assert D == Matrix(((4, 0, 0), (0, 1, 0), (0, 0, 9)))
 
 
@@ -2090,12 +2090,12 @@ def test_cholesky_solve():
     x = Matrix((-2, 1))
     b = A*x
     soln = A.cholesky_solve(b)
-    assert expand(soln) == x
+    assert expand_mul(soln) == x
     A = Matrix(((9*I, 3), (-3 + I, 5)))
     x = Matrix((2 + 3*I, -1))
     b = A*x
     soln = A.cholesky_solve(b)
-    assert expand(soln) == x
+    assert expand_mul(soln) == x
 
 
 def test_LDLsolve():
@@ -2117,12 +2117,12 @@ def test_LDLsolve():
     x = Matrix((-2, 1))
     b = A*x
     soln = A.LDLsolve(b)
-    assert expand(soln) == x
+    assert expand_mul(soln) == x
     A = Matrix(((9*I, 3), (-3 + I, 5)))
     x = Matrix((2 + 3*I, -1))
     b = A*x
     soln = A.cholesky_solve(b)
-    assert expand(soln) == x
+    assert expand_mul(soln) == x
 
 
 def test_lower_triangular_solve():


### PR DESCRIPTION
Currently, the `cholesky` method checks whether the matrix is symmetric. This is wrong in two ways:
complex symmetric matrices get through (and they shouldn't), while complex Hermitian matrices do not
(and they should). The check is adjusted, and the implementation is extended to Hermitian matrices. 

Additionally, a ValueError is raised if the matrix is found to not be positive definite. Previously
there was no check for that, so one would get, for example
```
>>> Matrix([[1, 5], [5, 1]]).cholesky()
Matrix([
[1,           0],
[5, 2*sqrt(6)*I]])
```

Similar adjustments are made to `cholesky_solve`, `LDLdecomposition`, and `LDLsolve`, which had the same issues. (Basically, any time you multiply a matrix `M` by `M.T`, you probably mean `M.H`.)

Test are added.  One of existing tests asserted that `ImmutableMatrix([[1, 2], [2, 1]]).cholesky()` returns an ImmutableMatrix; this was adjusted. 