### PR TITLE
integrate: Correctly handle manual, meijerg, risch flags

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1150,6 +1150,18 @@ def test_powers():
     assert integrate(2**x + 3**x, x) == 2**x/log(2) + 3**x/log(3)
 
 
+def test_manual_option():
+    raises(ValueError, lambda: integrate(1/x, x, manual=True, meijerg=True))
+    # an example of a function that manual integration cannot handle
+    assert integrate(exp(x**2), x, manual=True) == Integral(exp(x**2), x)
+
+
+def test_meijerg_option():
+    raises(ValueError, lambda: integrate(1/x, x, meijerg=True, risch=True))
+    # an example of a function that meijerg integration cannot handle
+    assert integrate(tan(x), x, meijerg=True) == Integral(tan(x), x)
+
+
 def test_risch_option():
     # risch=True only allowed on indefinite integrals
     raises(ValueError, lambda: integrate(1/log(x), (x, 0, oo), risch=True))


### PR DESCRIPTION
Only one of manual, meijerg, risch can be True, since True means "use only this method" (per [the documentation of`integrate`](http://docs.sympy.org/latest/modules/integrals/integrals.html#api-reference)). But this was not checked.
```
>>> integrate(1/x, x, risch=True, manual=True)
log(x)
```
Also, the option manual=True did not actually prevent other integration methods
```
>>> integrate(exp(x**2), x, manual=True)
sqrt(pi)*erfi(x)/2      # from meijerint
```
Both are corrected now: ValueError is raised if more than one True is given, and whenever one is True, the others are set to False.