### PR TITLE
Integrals: special treatment for substitutions u=(a*x+b)**(1/n)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -130,6 +130,19 @@ def find_substitutions(integrand, symbol, u_var):
         if symbol not in substituted.free_symbols:
             return substituted.as_independent(u_var, as_Add=False)
 
+        # special treatment for substitutions u = (a*x+b)**(1/n)
+        if (isinstance(u, sympy.Pow) and (1/u.exp).is_Integer and
+            sympy.Abs(u.exp) < 1):
+                a = sympy.Wild('a', exclude=[symbol])
+                b = sympy.Wild('b', exclude=[symbol])
+                match = u.base.match(a*symbol + b)
+                if match:
+                    a, b = [match.get(i, ZERO) for i in (a, b)]
+                    if a != 0 and b != 0:
+                        substituted = substituted.subs(symbol,
+                            (u_var**(1/u.exp) - b)/a)
+                        return substituted.as_independent(u_var, as_Add=False)
+
         return False
 
     def possible_subterms(term):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1324,3 +1324,7 @@ def test_issue_14437():
     f = Function('f')(x, y, z)
     assert integrate(f, (x, 0, 1), (y, 0, 2), (z, 0, 3)) == \
                 Integral(f, (x, 0, 1), (y, 0, 2), (z, 0, 3))
+
+def test_issue_14470():
+    assert integrate(1/sqrt(exp(x) + 1), x) == \
+        log(-1 + 1/sqrt(exp(x) + 1)) - log(1 + 1/sqrt(exp(x) + 1))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -352,3 +352,7 @@ def test_issue_12641():
 
 def test_issue_13297():
     assert manualintegrate(sin(x) * cos(x)**5, x) == -cos(x)**6 / 6
+
+def test_issue_14470():
+    assert manualintegrate(1/(x*sqrt(x + 1)), x) == \
+        log(-1 + 1/sqrt(x + 1)) - log(1 + 1/sqrt(x + 1))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14470

#### Brief description of what is fixed or changed

Substitutions `u = (a*x+b)**(1/n)`, with integer n, are useful because x is a simple expression in u: `x = (u**n - b)/a`. This makes it reasonable to use this inverse to perform substitution in manualintegrate. The general check for substitutions, namely that `(f/u').subs(u, Dummy)` does not have the original variable of integration, would not necessarily apply here.
