### PR TITLE
Explicit documentation of floor and ceiling for complex numbers

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -86,8 +86,7 @@ class floor(RoundFunction):
     value not greater than its argument. This implementation
     generalizes floor to complex numbers as follows:
 
-    .. math::
-        \lfloor{a + b i}\rfloor = \lfloor{a}\rfloor + \lfloor{b}\rfloor i
+    .. math:: \lfloor{a + b i}\rfloor = \lfloor{a}\rfloor + \lfloor{b}\rfloor i
 
     Examples
     ========
@@ -161,8 +160,7 @@ class ceiling(RoundFunction):
     value not less than its argument. This implementation
     generalizes ceiling to complex numbers as follows:
 
-    .. math::
-        \lceil{a + b i}\rceil = \lceil{a}\rceil + \lceil{b}\rceil i
+    .. math:: \lceil{a + b i}\rceil = \lceil{a}\rceil + \lceil{b}\rceil i
 
     Examples
     ========

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -85,6 +85,7 @@ class floor(RoundFunction):
     Floor is a univariate function which returns the largest integer
     value not greater than its argument. This implementation
     generalizes floor to complex numbers as follows:
+
     .. math::
         \lfloor{a + b i}\rfloor = \lfloor{a}\rfloor + \lfloor{b}\rfloor i
 
@@ -159,6 +160,7 @@ class ceiling(RoundFunction):
     Ceiling is a univariate function which returns the smallest integer
     value not less than its argument. This implementation
     generalizes ceiling to complex numbers as follows:
+
     .. math::
         \lceil{a + b i}\rceil = \lceil{a}\rceil + \lceil{b}\rceil i
 

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -83,13 +83,14 @@ class RoundFunction(Function):
 class floor(RoundFunction):
     """
     Floor is a univariate function which returns the largest integer
-    value not greater than its argument. However this implementation
-    generalizes floor to complex numbers.
+    value not greater than its argument. This implementation
+    generalizes floor to complex numbers as follows:
+        floor(a + b*I) -> floor(a) + floor(b)*I
 
     Examples
     ========
 
-    >>> from sympy import floor, E, I, Float, Rational
+    >>> from sympy import floor, E, I, S, Float, Rational
     >>> floor(17)
     17
     >>> floor(Rational(23, 10))
@@ -100,6 +101,8 @@ class floor(RoundFunction):
     -1
     >>> floor(-I/2)
     -I
+    >>> floor(S(5)/2 + 5*I/2)
+    2 + 2*I
 
     See Also
     ========
@@ -153,13 +156,14 @@ class floor(RoundFunction):
 class ceiling(RoundFunction):
     """
     Ceiling is a univariate function which returns the smallest integer
-    value not less than its argument. Ceiling function is generalized
-    in this implementation to complex numbers.
+    value not less than its argument. This implementation
+    generalizes ceiling to complex numbers as follows:
+        ceiling(a + b*I) -> ceiling(a) + ceiling(b)*I
 
     Examples
     ========
 
-    >>> from sympy import ceiling, E, I, Float, Rational
+    >>> from sympy import ceiling, E, I, S, Float, Rational
     >>> ceiling(17)
     17
     >>> ceiling(Rational(23, 10))
@@ -170,6 +174,8 @@ class ceiling(RoundFunction):
     0
     >>> ceiling(I/2)
     I
+    >>> ceiling(S(5)/2 + 5*I/2)
+    3 + 3*I
 
     See Also
     ========

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -85,7 +85,8 @@ class floor(RoundFunction):
     Floor is a univariate function which returns the largest integer
     value not greater than its argument. This implementation
     generalizes floor to complex numbers as follows:
-        floor(a + b*I) -> floor(a) + floor(b)*I
+    .. math::
+        \lfloor{a + b i}\rfloor = \lfloor{a}\rfloor + \lfloor{b}\rfloor i
 
     Examples
     ========
@@ -158,7 +159,8 @@ class ceiling(RoundFunction):
     Ceiling is a univariate function which returns the smallest integer
     value not less than its argument. This implementation
     generalizes ceiling to complex numbers as follows:
-        ceiling(a + b*I) -> ceiling(a) + ceiling(b)*I
+    .. math::
+        \lceil{a + b i}\rceil = \lceil{a}\rceil + \lceil{b}\rceil i
 
     Examples
     ========


### PR DESCRIPTION
The documentation of floor and ceiling simply said that the implementation was generalized to complex numbers without specifying what that generalization was.