### PR TITLE
logarithm : handling of different bases symbolically

### DIFF
--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -210,7 +210,7 @@ def test_log_symbolic():
     assert log(x**y).expand() != y*log(x)
     assert log(x**y).expand(force=True) == y*log(x)
 
-    assert log(x, 2) == log(x)/log(2)
+    assert log(x, 2) == log(x, 2)
     assert log(E, 2) == 1/log(2)
 
     p, q = symbols('p,q', positive=True)


### PR DESCRIPTION
As @asmeurer suggested in issue #6888 that `log(x, b)` should return `log(x, b)` instead of `log(x)/log(b)`, this returns `log(x, b)`