### PR TITLE
Added new subs property in ConditionSet

### DIFF
--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy import S
+from sympy import S, Symbol
 from sympy.core.basic import Basic
 from sympy.core.function import Lambda
 from sympy.core.logic import fuzzy_bool
@@ -57,3 +57,10 @@ class ConditionSet(Set):
     def contains(self, other):
         return And(Lambda(self.sym, self.condition)(
             other), self.base_set.contains(other))
+
+    def subs(self, *args):
+        if len(args) == 2:
+            if isinstance(args[0], Symbol) and isinstance(args[1], Symbol):
+                return self.xreplace({args[0]:args[1]})
+            else:
+                return self

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -2,6 +2,7 @@ from sympy.sets import (ConditionSet, Intersection, FiniteSet, EmptySet, Union)
 from sympy import (Symbol, Eq, S, Abs, sin, pi, Lambda, Interval, And, Mod)
 
 x = Symbol('x')
+y = Symbol('x')
 
 
 def test_CondSet():
@@ -34,3 +35,9 @@ def test_simplified_FiniteSet_in_CondSet():
         Union(FiniteSet(1), ConditionSet(x, And(x > 0), FiniteSet(y))))
     assert (ConditionSet(x, Eq(Mod(x, 3), 1), FiniteSet(1, 4, 2, y)) ==
         Union(FiniteSet(1, 4), ConditionSet(x, Eq(Mod(x, 3), 1), FiniteSet(y))))
+
+def test_issue_14495():
+    assert ConditionSet(x, Eq(y, 0), S.Integers).subs(x, 1) == \
+        ConditionSet(x, Eq(y, 0), S.Integers)
+    assert ConditionSet(x, Eq(y, 0), S.Integers).subs(x, y) == \
+        ConditionSet(y, Eq(y, 0), S.Integers)


### PR DESCRIPTION
Fixes #14495 .

A new `subs` method has been defined in class `ConditionSet`, which allows substitution only if both the arguments are `Symbols`.

@smichr,
Please review.