### PR TITLE
stats: Non-recursive Poisson sampling

### DIFF
--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -29,26 +29,24 @@ class PoissonDistribution(SingleDiscreteDistribution):
         return self.lamda**k / factorial(k) * exp(-self.lamda)
 
     def sample(self):
-        u = random.uniform(0, 1)
-        inf = self.set.inf
-
         def search(x, y, u):
-            mid = (x + y)//2
-            if x == y:
-                return x
-            elif self.cdf(mid) >= u:
-                return search(x, mid, u)
-            else:
-                return search(mid + 1, y, u)
+            while x < y:
+                mid = (x + y)//2
+                if u <= self.cdf(mid):
+                    y = mid
+                else:
+                    x = mid + 1
+            return x
 
-        count = 0
+        u = random.uniform(0, 1)
+        if u <= self.cdf(S.Zero):
+            return S.Zero
+        n = S.One
         while True:
-            if u > self.cdf(inf):
-                inf = 2**count
-                count += 1
+            if u > self.cdf(2*n):
+                n *= 2
             else:
-                prev_inf, inf = 2**(count - 2), 2**(count - 1)
-                return search(prev_inf, inf, u)
+                return search(n, 2*n, u)
 
 
 def Poisson(name, lamda):

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -34,9 +34,11 @@ def test_GeometricDistribution():
 
 def test_sample():
     X, Y, Z = Geometric('X', S(1)/2), Poisson('Y', 4), Poisson('Z', 1000)
+    W = Poisson('W', S(1)/100)
     assert sample(X) in X.pspace.domain.set
     assert sample(Y) in Y.pspace.domain.set
     assert sample(Z) in Z.pspace.domain.set
+    assert sample(W) in W.pspace.domain.set
 
 def test_discrete_probability():
     X = Geometric('X', S(1)/5)


### PR DESCRIPTION
The current sampling algorithm for the Poisson distribution uses the strategy of doubling n, which  does not work when the sample to return is 0. Now the case of 0 is dispatched before entering the doubling loop. Also, the binary search is made non-recursive to avoid potential stack overflow issues when the search has to take many steps. 

### Other comments

Because of the above, the current implementation has an issue with small values of the parameter lamda; for example, `sample(Poisson("X", 0.01))` is almost assured to result in stack overflow or an incorrect answer such as 1/4.  For the same reason, the test case `sample(Poisson("Y", 4))` sometimes fails in current master branch. 

