### PR TITLE
More general comparison test for convergence

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -955,6 +955,9 @@ def test_is_convergent():
     assert Sum(1/(n*log(n)*log(log(n))), (n, 5, oo)).is_convergent() is S.false
     assert Sum((n - 1)/(n*log(n)**3), (n, 3, oo)).is_convergent() is S.false
     assert Sum(2/(n**2*log(n)), (n, 2, oo)).is_convergent() is S.true
+    assert Sum(1/(n*sqrt(log(n))*log(log(n))), (n, 100, oo)).is_convergent() is S.false
+    assert Sum(log(log(n))/(n*log(n)**2), (n, 100, oo)).is_convergent() is S.true
+    assert Sum(log(n)/n**2, (n, 5, oo)).is_convergent() is S.true
 
     # alternating series tests --
     assert Sum((-1)**(n - 1)/(n**2 - 1), (n, 3, oo)).is_convergent() is S.true


### PR DESCRIPTION
The current comparison tests match the order of the expression against four patterns:
- `1/log(n)**p`
- `1/(n*log(n)**p)`
- `1/(n*log(n)*log(log(n))*p`
- `1/(n**p*log(n))`

This missed many series that could be handled here, such as `1/(n**2*log(n)**3)`, `1/log(log(n))`, etc. All these are replaced by one pattern

- `1/(n**p*log(n)**q*log(log(n))**r)`

with the logic: if p>1 or (p=1 and q>1) or (p=q=1 and r>1) then converges, otherwise diverges. This allows the method to handle series such as `log(log(n))/(n*log(n)**2)` or `1/(n*sqrt(log(n))*log(log(n)))` which previously raised exceptions.

Incidental corrections:
- Ratio and root tests computed a limit without a try-except block, risking NotImplementedError
- Integral test failed on `Sum(log(n)/n**2, (n, 5, oo))` because an if-block was incorrectly indented.
- Tests are rearranged so that those that do not require limit computations (apart from initial Order) are carried out first.