### PR TITLE
numbers: modified the message of an error of Integer

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2015,7 +2015,7 @@ class Integer(Rational):
             ival = int(i)
         except TypeError:
             raise TypeError(
-                'Integer can only work with integer expressions.')
+                'Integer can only work with expressions that can be rounded off to integer type.')
         try:
             return _intcache[ival]
         except KeyError:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2015,7 +2015,7 @@ class Integer(Rational):
             ival = int(i)
         except TypeError:
             raise TypeError(
-                'Integer can only work with expressions that can be rounded off to integer type.')
+                "Argument of Integer should be of numeric type, got %s." % i)
         try:
             return _intcache[ival]
         except KeyError:


### PR DESCRIPTION
**Brief description of what is fixed or changed**

On giving input as `Integer(oo)`, it produces an error : `Integer can only work with integer expressions.`, but Integer also works on inputs such as `log(5)`, `exp(3)` and more such inputs which can be rounded off to integer (`int`) type. The error message is a bit inaccurate and I have modified it.
@jksuom  ping please! Is the modified error message upto the mark?

**Other comments**

This does not fix any issue. I just bumped into this error while working around with SymPy