### PR TITLE
simplify: Simplification of non-commutative expressions

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -856,7 +856,7 @@ class Pow(Expr):
                 if e.is_positive:
                     rv = Mul(*nc*e)
                 else:
-                    rv = 1/Mul(*nc*-e)
+                    rv = Mul(*[i**-1 for i in nc[::-1]]*-e)
                 if cargs:
                     rv *= Mul(*cargs)**e
                 return rv

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -62,13 +62,13 @@ def test_expand_non_commutative():
     assert ((a*A*B)**i).expand() == a**i*(A*B)**i
     assert ((a*A*(B*(A*B/A)**2))**i).expand() == a**i*(A*B*A*B**2/A)**i
     # issue 6558
-    assert (A*B*(A*B)**-1).expand() == A*B*(A*B)**-1
+    assert (A*B*(A*B)**-1).expand() == 1
     assert ((a*A)**i).expand() == a**i*A**i
     assert ((a*A*B*A**-1)**3).expand() == a**3*A*B**3/A
     assert ((a*A*B*A*B/A)**3).expand() == \
         a**3*A*B*(A*B**2)*(A*B**2)*A*B*A**(-1)
-    assert ((a*A*B*A*B/A)**-3).expand() == \
-        a**-3*(A*B*(A*B**2)*(A*B**2)*A*B*A**(-1))**-1
+    assert ((a*A*B*A*B/A)**-2).expand() == \
+        A*B**-1*A**-1*B**-2*A**-1*B**-1*A**-1/a**2
     assert ((a*b*A*B*A**-1)**i).expand() == a**i*b**i*(A*B/A)**i
     assert ((a*(a*b)**i)**i).expand() == a**i*a**(i**2)*b**(i**2)
     e = Pow(Mul(a, 1/a, A, B, evaluate=False), S(2), evaluate=False)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1744,8 +1744,6 @@ def nc_simplify(expr, deep=True):
             if _pre_exp == 0 or _post_exp == 0:
                 if not pre_exp:
                     start -= 1
-                if not post_exp:
-                    end += l
                 post_exp = _post_exp
                 pre_exp = _pre_exp
                 pre_arg = post_arg

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1495,7 +1495,7 @@ def clear_coefficients(expr, rhs=S.Zero):
 def nc_simplify(expr, max_subterm=None):
     '''
     Simplify a non-commutative expression composed of multiplication
-    and exponentiation by grouping repeating subterms into one power.
+    and raising to a power by grouping repeated subterms into one power.
     Priority is given to longer subterms. If `expr` is a sum of such
     terms, the sums of the simplified terms is returned.
 
@@ -1522,10 +1522,10 @@ def nc_simplify(expr, max_subterm=None):
     (a*b)**2 + 2*(a*c*a)**2
 
     '''
+    if not isinstance(expr, (Add, Mul, Pow)):
+        return expr
     args = expr.args[:]
     l = len(args)
-    if l == 0:
-        return expr
     if isinstance(expr, Pow):
         return Pow(nc_simplify(args[0]), args[1])
     elif isinstance(expr, Add):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1492,16 +1492,20 @@ def clear_coefficients(expr, rhs=S.Zero):
         rhs = -rhs
     return expr, rhs
 
-def nc_simplify(expr, max_subterm=None):
+def nc_simplify(expr, deep=True):
     '''
     Simplify a non-commutative expression composed of multiplication
     and raising to a power by grouping repeated subterms into one power.
-    Priority is given to longer subterms. If `expr` is a sum of such
-    terms, the sums of the simplified terms is returned.
+    Priority is given to simplifications that give the fewest number
+    of arguments in the end (for example, in a*b*a*b*c*a*b*c simplifying
+    to (a*b)**2*c*a*b*c gives 5 arguments while a*b*(a*b*c)**2 has 3).
+    If `expr` is a sum of such terms, the sum of the simplified terms
+    is returned.
 
-    `max_subterm` is the maximal length of a subterm to be grouped by -
-    by default it is set to half the length of the expression's arguments
-    list.
+    Keyword argument `deep` controls whether or not subexpressions
+    nested deeper inside the main expression are simplified. See examples
+    below. Setting `deep` to `False` can save time on nested expressions
+    that don't need simplifying on all levels.
 
     Examples
     ========
@@ -1509,160 +1513,270 @@ def nc_simplify(expr, max_subterm=None):
     >>> from sympy import symbols
     >>> from sympy.simplify.simplify import nc_simplify
     >>> a, b, c = symbols("a b c", commutative=False)
-    >>> nc_simplify(a*b*a*b*a*b*c)
-    (a*b)**3*c
+    >>> nc_simplify(a*b*a*b*c*a*b*c)
+    a*b*(a*b*c)**2
     >>> expr = a**2*b*a**4*b*a**4
     >>> nc_simplify(expr)
-    (a**2*b*a**2)**2*a**2
-    >>> nc_simplify(expr, max_subterm = 2)
     a**2*(b*a**4)**2
     >>> nc_simplify(a*b*a*b*c**2*(a*b)**2*c**2)
     ((a*b)**2*c**2)**2
-    >>> nc_simplify(a*b*a*b + 2*a*c*a**2*c*a)
-    (a*b)**2 + 2*(a*c*a)**2
+    >>> nc_simplify(a*b*a*b + 2*a*c*a**2*c*a**2*c*a)
+    (a*b)**2 + 2*(a*c*a)**3
+    >>> nc_simplify(b**-1*a**-1*(a*b)**2)
+    a*b
+    >>> nc_simplify(a**-1*b**-1*c*a)
+    (b*a)**(-1)*c*a
+    >>> expr = (a*b*a*b)**2*a*c*a*c
+    >>> nc_simplify(expr)
+    (a*b)**4*(a*c)**2
+    >>> nc_simplify(expr, deep=False)
+    (a*b*a*b)**2*(a*c)**2
 
     '''
+
+    # =========== Auxiliary functions ========================
+    def _overlaps(args):
+        # Calculate a list of lists m such that m[i][j] contains the lengths
+        # of all possible overlaps between args[:i+1] and args[i+1+j:].
+        # An overlap is a suffix of the prefix that matches a prefix
+        # of the suffix.
+        # For example, let expr=c*a*b*a*b*a*b*a*b. Then m[3][0] contains
+        # the lengths of overlaps of c*a*b*a*b with a*b*a*b. The overlaps
+        # are a*b*a*b, a*b and the empty word so that m[3][0]=[4,2,0].
+        # All overlaps rather than only the longest one are recorded
+        # because this information helps calculate other overlap lengths.
+        m = [[([1, 0] if a == args[0] else [0]) for a in args[1:]]]
+        for i in range(1, len(args)):
+            overlaps = []
+            j = 0
+            for j in range(len(args) - i - 1):
+                overlap = []
+                for v in m[i-1][j+1]:
+                    if j + i + 1 + v < len(args) and args[i] == args[j+i+1+v]:
+                        overlap.append(v + 1)
+                overlap += [0]
+                overlaps.append(overlap)
+            m.append(overlaps)
+        return m
+
+    def _reduce_inverses(_args):
+        # replace consecutive negative powers by an inverse
+        # of a product of positive powers, e.g. a**-1*b**-1*c
+        # will simplify to (a*b)**-1*c;
+        # return that new args list and the number of negative
+        # powers in it (inv_tot)
+        inv_tot = 0 # total number of inverses
+        inverses = []
+        args = []
+        for arg in _args:
+            if isinstance(arg, Pow) and arg.args[1] < 0:
+                inverses = [arg**-1] + inverses
+                inv_tot += 1
+            else:
+                if inverses:
+                    args.append(Pow(Mul(*inverses), -1))
+                    inv_tot -= len(inverses) - 1
+                inverses = []
+                args.append(arg)
+        if inverses:
+            args.append(Pow(Mul(*inverses), -1))
+            inv_tot -= len(inverses) - 1
+        return inv_tot, tuple(args)
+    # ========================================================
+
+
     if not isinstance(expr, (Add, Mul, Pow)):
         return expr
     args = expr.args[:]
-    l = len(args)
     if isinstance(expr, Pow):
-        return Pow(nc_simplify(args[0]), args[1])
+        if deep:
+            return Pow(nc_simplify(args[0]), args[1])
+        else:
+            return expr
     elif isinstance(expr, Add):
-        return Add(*[nc_simplify(a) for a in args])
+        return Add(*[nc_simplify(a, deep=deep) for a in args])
 
-    change = False
+    inv_tot, args = _reduce_inverses(args)
+    # if most arguments are negative, work with the inverse
+    # of the expression, e.g. a**-1*b*a**-1*c**-1 will become
+    # (c*a*b**-1*a)**-1 at the end so can work with c*a*b**-1*a
+    invert = False
+    if inv_tot > len(args)/2:
+        invert = True
+        args = [a**-1 for a in args[::-1]]
 
-    if not max_subterm:
-        max_subterm = len(args)//2 + 1
+    if deep:
+        args = tuple(nc_simplify(a) for a in args)
 
-    for m in range(max_subterm, 1, -1):
-        # consider subterms of length m
-        # starting at position i
+    m = _overlaps(args)
 
-        i = 0
-        while i <= l - 2*m + 1:
-            j = i+m
-            subterm = args[i:j]
-            n = 1 # power of the subterm
+    # simps will be {subterm: end} where `end` is the ending
+    # index of a sequence of repetitions of subterm;
+    # this is for not wasting time with subterms that are part
+    # of longer, already considered sequences
+    simps = {}
 
-            # the following `if` clause is a bit of a mess
-            # because some of the arguments of the expression
-            # are powers; one way around it would be to expland each
-            # power so that we are left with a list of symbols
-            # in the order they appear; but expanding something
-            # like a**1000*b only to find no simplifications
-            # seems a waste of resources
-            mode = 0
-            power = False
-            if subterm[0] != args[j]:
-                # the next part of the expression is not
-                # the same as the target subterm but maybe
-                # the subterm can be modified to change that
+    post = 1
+    pre = 1
 
-                if isinstance(subterm[0], Pow):
-                    arg = subterm[0].args[0]
-                    arg_pow = subterm[0].args[1]
-                    if isinstance(args[j], Pow) and arg == args[j].args[0]:
-                        # e.g. the subterm a**2*b in a**2*b*a*b could
-                        # be changed to a*b to match the rest of the
-                        # expression
-                        p = args[j].args[1]
-                    elif arg == args[j]:
-                        p = 1
-                    elif (isinstance(subterm[-1], Pow)
-                                and subterm[-1].args[1].is_even):
-                        # e.g. the subterm a**3*b*a**4 in a**3*b*a**4*b*a**2:
-                        # if the subterm is changed to a**2*b*a**2, then it
-                        # matches the next subterm of the expression
-                        p = subterm[-1].args[1]/2
-                        mode = 1
-                    else:
-                        # modifications failed
-                        i += 1
-                        continue
-                    d = arg_pow - p
-                    if d >= 0:
-                        power = True
-                        if mode:
-                            # actually, the new subterm is
-                            # (arg**p,) + subterm[1:-1] + (arg**p) but we will
-                            # be working with subterm[1:] because it's easier:
-                            # e.g. with subterm a*b*a in a*b*a**2*b*a**2
-                            # we can count up just the `b*a**2` and remember to
-                            # sort out the first and last `a` separately
-                            subterm = subterm[1:]
-                        else:
-                            subterm = (Pow(arg, p),) + subterm[1:]
-                elif subterm[-1] == subterm[0]**2:
-                    # e.g. the subterm a*b*a**2 in a*b*a**2*b*a
-                    # could be replaced by a*b*a
-                    arg = subterm[0]
-                    p = 1
-                    mode = 1
-                    subterm = subterm[1:]
+    # the simplification coefficient is the number of
+    # arguments by which contracting a given sequence
+    # would reduce the word; e.g. in a*b*a*b*c*a*b*c,
+    # contracting a*b*a*b to (a*b)**2 removes 3 arguments
+    # while a*b*c*a*b*c to (a*b*c)**2 removes 6. It's
+    # better to contract the latter so simplification
+    # with a maximum simplification coefficient will be chosen
+    max_simp_coeff = 0
+    simp = None # information about future simplification
 
+    for i in range(1, len(args)):
+        simp_coeff = 0
+        l = 0 # length of a subterm
+        p = 0 # the power of a subterm
+        if i < len(args) - 1:
+            rep = m[i][0]
+        start = i # starting index of the repeated sequence
+        end = i+1 # ending index of the repeated sequence
+        if i == len(args)-1 or rep == [0]:
+            # no subterm is repeated at this stage, at least as
+            # far as the arguments are concerned - there may be
+            # a repetition if powers are taken into account
+            if isinstance(args[i], Pow) and len(args[i].args[0].args) > 0:
+                subterm = args[i].args[0].args
+                l = len(subterm)
+                if args[i-l:i] == subterm:
+                    # e.g. a*b in a*b*(a*b)**2 is not repeated
+                    # in args (= [a, b, (a*b)**2]) but it
+                    # can be matched here
+                    p += 1
+                    start -= l
+                if args[i+1:i+1+l] == subterm:
+                    # e.g. a*b in (a*b)**2*a*b
+                    p += 1
+                    end += l
+            if p:
+                p += args[i].args[1]
+            else:
+                continue
+        else:
+            l = rep[0] # length of the longest repeated subterm at this point
+            start -= l - 1
+            subterm = args[start:end]
+            p = 2
+            end += l
 
-            # match the subterm
-            while (j < len(args) - (m - mode) + 1
-                                    and args[j:j + m - mode] == subterm):
-                j += m - mode
-                n += 1
+        if subterm in simps and simps[subterm] >= start:
+            # the subterm is part of a sequence that
+            # has already been considered
+            continue
 
-            # sometimes another match can be made, e.g.
-            # for b*a**2 in b*a**2*b*a**3
-            d2 = -1
-            last_arg = 1
-            if (j < len(args) - (m - mode) + 1
-                            and args[j:j + m - mode - 1] == subterm[:-1]):
-                if mode:
-                    last_arg = arg
-                else:
-                    if isinstance(subterm[-1], Pow):
-                        p = subterm[-1].args[1]
-                        last_arg = subterm[-1].args[0]
-                    else:
-                        p = 1
-                        last_arg = subterm[-1]
+        # count how many times it's repeated
+        while end < len(args):
+            if l in m[end-1][0]:
+                p += 1
+                end += l
+            elif isinstance(args[end], Pow) and args[end].args[0].args == subterm:
+                # for cases like a*b*a*b*(a*b)**2*a*b
+                p += args[end].args[1]
+                end += 1
+            else:
+                break
 
-                to_match = args[j + m - mode - 1]
-                if (isinstance(to_match, Pow) and to_match.args[0] == last_arg
-                                                 and to_match.args[1] >= p):
-                    d2 = to_match.args[1] - p
-                    n += 1
-                    j += m - mode
-                elif p == 1 and to_match == last_arg:
-                    d2 = 0
-                    n += 1
-                    j += m - mode
-            if mode and d2 < 0:
-                # no new match has been made but
-                # the last match has to be treated differently
-                # because the subterm we've been matching is not
-                # the actual target subterm. E.g. in a*b*a**2*b*a**2
-                # we are matching b*a**2 when the subterm is a*b*a
-                d2 = p
-                last_arg = arg
+        # see if another match can be made, e.g.
+        # for b*a**2 in b*a**2*b*a**3 or a*b in
+        # a**2*b*a*b
 
-            if n > 1:
-                # group the subterm with its matches taking care
-                # of the special cases because of modifications to
-                # the subterm in the big if clause above
-                s = tuple()
-                if power:
-                    s = (Pow(arg, d),)
-                    power = False
-                if mode:
-                    subterm = (Pow(arg, p),) + subterm[:-1] + (Pow(arg, p),)
-                t = (Pow(Mul(*subterm), n),)
-                args = args[:i] + s + t + (Pow(last_arg, d2),) + args[j:]
-                l = len(args)
-                change = True
-            i += 1
+        pre_exp = 0
+        pre_arg = 1
+        if start - l >= 0 and args[start-l+1:start] == subterm[1:]:
+            if isinstance(subterm[0], Pow):
+                pre_arg = subterm[0].args[0]
+                exp = subterm[0].args[1]
+            else:
+                pre_arg = subterm[0]
+                exp = 1
+            if isinstance(args[start-l], Pow) and args[start-l].args[0] == pre_arg:
+                pre_exp = args[start-l].args[1] - exp
+                start -= l
+                p += 1
+            elif args[start-l] == pre_arg:
+                pre_exp = 1 - exp
+                start -= l
+                p += 1
 
-    if change:
-        new = Mul(*args)
-        return nc_simplify(new)
+        post_exp = 0
+        post_arg = 1
+        if end + l - 1 < len(args) and args[end:end+l-1] == subterm[:-1]:
+            if isinstance(subterm[-1], Pow):
+                post_arg = subterm[-1].args[0]
+                exp = subterm[-1].args[1]
+            else:
+                post_arg = subterm[-1]
+                exp = 1
+            if isinstance(args[end+l-1], Pow) and args[end+l-1].args[0] == post_arg:
+                post_exp = args[end+l-1].args[1] - exp
+                end += l
+                p += 1
+            elif args[end+l-1] == post_arg:
+                post_exp = 1 - exp
+                end += l
+                p += 1
 
-    new = Mul(*[nc_simplify(arg) for arg in args])
-    return new
+        # Consider a*b*a**2*b*a**2*b*a:
+        # b*a**2 is explicitly repeated, but note
+        # that in this case a*b*a is also repeated
+        # so there are two possible simplifications:
+        # a*(b*a**2)**3*a**-1 or (a*b*a)**3
+        # The latter is obviously simpler.
+        # But in a*b*a**2*b**2*a**2 the simplifications are
+        # a*(b*a**2)**2 and (a*b*a)**3*a in which case
+        # it's better to stick with the shorter subterm
+        if post_exp and exp % 2 == 0 and start > 0:
+            exp = exp/2
+            _pre_exp = 1
+            _post_exp = 1
+            if isinstance(args[start-1], Pow) and args[start-1].args[0] == post_arg:
+                _post_exp = post_exp + exp
+                _pre_exp = args[start-1].args[1] - exp
+            elif args[start-1] == post_arg:
+                _post_exp = post_exp + exp
+                _pre_exp = 1 - exp
+            if _pre_exp == 0 or _post_exp == 0:
+                if not pre_exp:
+                    start -= 1
+                if not post_exp:
+                    end += l
+                post_exp = _post_exp
+                pre_exp = _pre_exp
+                pre_arg = post_arg
+                subterm = (post_arg**exp,) + subterm[:-1] + (post_arg**exp,)
+
+        simp_coeff += end-start
+
+        if post_exp:
+            simp_coeff -= 1
+        if pre_exp:
+            simp_coeff -= 1
+
+        simps[subterm] = end
+
+        if simp_coeff > max_simp_coeff:
+            max_simp_coeff = simp_coeff
+            simp = (start, Mul(*subterm), p, end, l)
+            pre = pre_arg**pre_exp
+            post = post_arg**post_exp
+
+    if simp:
+        subterm = Pow(nc_simplify(simp[1], deep=deep), simp[2])
+        pre = nc_simplify(Mul(*args[:simp[0]])*pre, deep=deep)
+        post = post*nc_simplify(Mul(*args[simp[3]:]), deep=deep)
+        simp = pre*subterm*post
+        if pre != 1 or post != 1:
+            # new simplifications may be possible but no need
+            # to recurse over arguments
+            simp = nc_simplify(simp, deep=False)
+    else:
+        simp = Mul(*args)
+    if invert:
+        simp = simp**-1
+    return simp

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -728,6 +728,7 @@ def test_nc_simplify():
 
     def _check(expr, simplified, deep=True):
         assert nc_simplify(expr, deep=deep) == simplified
+        assert expand(expr) == expand(simplified)
 
     _check(a*b*a*b*a*b*c*(a*b)**3*c, ((a*b)**3*c)**2)
     _check(a*b*(a*b)**-2*a*b, 1)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -720,3 +720,15 @@ def test_clear_coefficients():
     assert clear_coefficients(S.Infinity, x) == (S.Infinity, x)
     assert clear_coefficients(-S.Pi, x) == (S.Pi, -x)
     assert clear_coefficients(2 - S.Pi/3, x) == (pi, -3*x + 6)
+
+def test_nc_simplify():
+    from sympy.simplify.simplify import nc_simplify
+    a, b, c = symbols('a b c', commutative = False)
+    x = Symbol('x')
+    assert nc_simplify(a*b*a*b*a*b*c*(a*b)**3*c) == ((a*b)**3*c)**2
+    assert nc_simplify(a**2*b*a*b*a*b) == a*(a*b)**3
+    expr = a*b*a**2*b*a**2*b*a**3
+    assert nc_simplify(expr) == (a*b*a)**3*a**2
+    assert nc_simplify(expr, max_subterm=2) == a*(b*a**2)**3*a
+    assert nc_simplify(a*b*a*b + a*b*c*x*a*b*c) == (a*b)**2 + x*(a*b*c)**2
+    assert nc_simplify(a*b*a*b*c*a*b*a*b*c) == ((a*b)**2*c)**2

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -725,17 +725,24 @@ def test_nc_simplify():
     from sympy.simplify.simplify import nc_simplify
     a, b, c = symbols('a b c', commutative = False)
     x = Symbol('x')
-    assert nc_simplify(a*b*a*b*a*b*c*(a*b)**3*c) == ((a*b)**3*c)**2
-    assert nc_simplify(a**2*b*a*b*a*b) == a*(a*b)**3
-    expr = a*b*a**2*b*a**2*b*a**3
-    assert nc_simplify(expr) == (a*b*a)**3*a**2
-    assert nc_simplify(a**2*b*a**4*b*a**4*b*a**2) == (a**2*b*a**2)**3
-    assert nc_simplify(a**3*b*a**4*b*a**4*b*a) == a**3*(b*a**4)**3*a**-3
-    assert nc_simplify(a*b*a*b + a*b*c*x*a*b*c) == (a*b)**2 + x*(a*b*c)**2
-    assert nc_simplify(a*b*a*b*c*a*b*a*b*c) == ((a*b)**2*c)**2
-    assert nc_simplify(b**-1*a**-1*(a*b)**2) == a*b
-    assert nc_simplify(a**-1*b**-1*c**-1*d) == (d**-1*c*b*a)**-1
-    expr = a**3*b*a**4*b*a**4*b*a**2*b*a**2*b*a**2*b*a**2*b*a**2*b*a**2
+
+    def _check(expr, simplified, deep=True):
+        assert nc_simplify(expr, deep=deep) == simplified
+
+    _check(a*b*a*b*a*b*c*(a*b)**3*c, ((a*b)**3*c)**2)
+    _check(a*b*(a*b)**-2*a*b, 1)
+    _check(a**2*b*a*b*a*b*(a*b)**-1, a*(a*b)**2)
+    _check(b*a*b**2*a*b**2*a*b**2, b*(a*b**2)**3)
+    _check(a*b*a**2*b*a**2*b*a**3, (a*b*a)**3*a**2)
+    _check(a**2*b*a**4*b*a**4*b*a**2, (a**2*b*a**2)**3)
+    _check(a**3*b*a**4*b*a**4*b*a, a**3*(b*a**4)**3*a**-3)
+    _check(a*b*a*b + a*b*c*x*a*b*c, (a*b)**2 + x*(a*b*c)**2)
+    _check(a*b*a*b*c*a*b*a*b*c, ((a*b)**2*c)**2)
+    _check(b**-1*a**-1*(a*b)**2, a*b)
+    _check(a**-1*b*c**-1, (c*b**-1*a)**-1)
+    expr = a**3*b*a**4*b*a**4*b*a**2*b*a**2*(b*a**2)**2*b*a**2*b*a**2
     for i in range(10):
         expr *= a*b
-    assert nc_simplify(expr) == a**3*(b*a**4)**2*(b*a**2)**6*(a*b)**10
+    _check(expr, a**3*(b*a**4)**2*(b*a**2)**6*(a*b)**10)
+    _check((a*b*a*b)**2, (a*b*a*b)**2, deep=False)
+    _check(a*b*(c*d)**2, a*b*(c*d)**2)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -729,6 +729,13 @@ def test_nc_simplify():
     assert nc_simplify(a**2*b*a*b*a*b) == a*(a*b)**3
     expr = a*b*a**2*b*a**2*b*a**3
     assert nc_simplify(expr) == (a*b*a)**3*a**2
-    assert nc_simplify(expr, max_subterm=2) == a*(b*a**2)**3*a
+    assert nc_simplify(a**2*b*a**4*b*a**4*b*a**2) == (a**2*b*a**2)**3
+    assert nc_simplify(a**3*b*a**4*b*a**4*b*a) == a**3*(b*a**4)**3*a**-3
     assert nc_simplify(a*b*a*b + a*b*c*x*a*b*c) == (a*b)**2 + x*(a*b*c)**2
     assert nc_simplify(a*b*a*b*c*a*b*a*b*c) == ((a*b)**2*c)**2
+    assert nc_simplify(b**-1*a**-1*(a*b)**2) == a*b
+    assert nc_simplify(a**-1*b**-1*c**-1*d) == (d**-1*c*b*a)**-1
+    expr = a**3*b*a**4*b*a**4*b*a**2*b*a**2*b*a**2*b*a**2*b*a**2*b*a**2
+    for i in range(10):
+        expr *= a*b
+    assert nc_simplify(expr) == a**3*(b*a**4)**2*(b*a**2)**6*(a*b)**10


### PR DESCRIPTION
This PR introduces `nc_simplify` - a function for simplifying expressions with non-commutative symbols. Specifically, it simplifies the terms of the expression that involve only multiplication and raising to a power by grouping together repeated subterms, e.g. `nc_simplify(a*b*a*b) == (a*b)**2`.

At present, SymPy doesn't really do much to simplify such expressions so that `simplify(a*b*a*b) == a*b*a*b`. On this branch, `simplify` uses `nc_simplify` if the expression is non-commutative, before attempting further simplifications as it normally would.

Other examples of `nc_simplify` with non-commutative symbols `a, b, c` are:
```
>>> nc_simplify(a**3*b*a*b*a*b)
a**2*(a*b)**3
>>> nc_simplify(a*b*a**2*b*a**2*b*a)
(a*b*a)**3
>>> nc_simplify(a*b*a*b*c*(a*b)**2*c)
((a*b)**2*c)**2
```

More examples are included in the docstring and the tests.