### PR TITLE
Integration of orthogonal polynomials of general degree

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -25,6 +25,7 @@ import sympy
 from sympy.core.compatibility import reduce
 from sympy.core.logic import fuzzy_not
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
+from sympy.functions.special.polynomials import OrthogonalPolynomial
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.core.relational import Eq, Ne
@@ -65,6 +66,14 @@ TrigSubstitutionRule = Rule("TrigSubstitutionRule",
 ArctanRule = Rule("ArctanRule", "a b c")
 ArccothRule = Rule("ArccothRule", "a b c")
 ArctanhRule = Rule("ArctanhRule", "a b c")
+JacobiRule = Rule("JacobiRule", "n a b")
+GegenbauerRule = Rule("GegenbauerRule", "n a")
+ChebyshevTRule = Rule("ChebyshevTRule", "n")
+ChebyshevURule = Rule("ChebyshevURule", "n")
+LegendreRule = Rule("LegendreRule", "n")
+HermiteRule = Rule("HermiteRule", "n")
+LaguerreRule = Rule("LaguerreRule", "n")
+AssocLaguerreRule = Rule("AssocLaguerreRule", "n a")
 
 IntegralInfo = namedtuple('IntegralInfo', 'integrand symbol')
 
@@ -150,6 +159,13 @@ def find_substitutions(integrand, symbol, u_var):
                              sympy.asin, sympy.acos, sympy.atan,
                              sympy.exp, sympy.log, sympy.Heaviside)):
             return [term.args[0]]
+        elif isinstance(term, (sympy.chebyshevt, sympy.chebyshevu,
+                        sympy.legendre, sympy.hermite, sympy.laguerre)):
+            return [term.args[1]]
+        elif isinstance(term, (sympy.gegenbauer, sympy.assoc_laguerre)):
+            return [term.args[2]]
+        elif isinstance(term, sympy.jacobi):
+            return [term.args[3]]
         elif isinstance(term, sympy.Mul):
             r = []
             for u in term.args:
@@ -270,6 +286,33 @@ def exp_rule(integral):
     integrand, symbol = integral
     if isinstance(integrand.args[0], sympy.Symbol):
         return ExpRule(sympy.E, integrand.args[0], integrand, symbol)
+
+
+def orthogonal_poly_rule(integral):
+    orthogonal_poly_classes = {
+        sympy.jacobi: JacobiRule,
+        sympy.gegenbauer: GegenbauerRule,
+        sympy.chebyshevt: ChebyshevTRule,
+        sympy.chebyshevu: ChebyshevURule,
+        sympy.legendre: LegendreRule,
+        sympy.hermite: HermiteRule,
+        sympy.laguerre: LaguerreRule,
+        sympy.assoc_laguerre: AssocLaguerreRule
+        }
+    orthogonal_poly_var_index = {
+        sympy.jacobi: 3,
+        sympy.gegenbauer: 2,
+        sympy.assoc_laguerre: 2
+        }
+    integrand, symbol = integral
+    for klass in orthogonal_poly_classes:
+        if isinstance(integrand, klass):
+            var_index = orthogonal_poly_var_index.get(klass, 1)
+            if (integrand.args[var_index] is symbol and not
+                any(v.has(symbol) for v in integrand.args[:var_index])):
+                    args = integrand.args[:var_index] + (integrand, symbol)
+                    return orthogonal_poly_classes[klass](*args)
+
 
 def inverse_trig_rule(integral):
     integrand, symbol = integral
@@ -412,6 +455,16 @@ def _parts_rule(integrand, symbol):
                     degree(rec_dv, symbol) == 1):
                         return
 
+            # Can integrate a polynomial times OrthogonalPolynomial
+            if rule == pull_out_algebraic and isinstance(dv, OrthogonalPolynomial):
+                    v_step = integral_steps(dv, symbol)
+                    if isinstance(v_step, DontKnowRule):
+                        return
+                    else:
+                        du = u.diff(symbol)
+                        v = _manualintegrate(v_step)
+                        return u, dv, v, du, v_step
+
             for rule in liate_rules[index + 1:]:
                 r = rule(integrand)
                 # make sure dv is amenable to integration
@@ -419,8 +472,8 @@ def _parts_rule(integrand, symbol):
                     du = u.diff(symbol)
                     v_step = integral_steps(sympy.simplify(dv), symbol)
                     v = _manualintegrate(v_step)
-
                     return u, dv, v, du, v_step
+
 
 def parts_rule(integral):
     integrand, symbol = integral
@@ -1017,9 +1070,11 @@ def integral_steps(integrand, symbol, **options):
             return sympy.Number
         else:
             for cls in (sympy.Pow, sympy.Symbol, sympy.exp, sympy.log,
-                        sympy.Add, sympy.Mul, sympy.atan, sympy.asin, sympy.acos, sympy.Heaviside):
+                        sympy.Add, sympy.Mul, sympy.atan, sympy.asin,
+                        sympy.acos, sympy.Heaviside, OrthogonalPolynomial):
                 if isinstance(integrand, cls):
                     return cls
+
 
     def integral_is_subclass(*klasses):
         def _integral_is_subclass(integral):
@@ -1040,6 +1095,7 @@ def integral_steps(integrand, symbol, **options):
             sympy.Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
             sympy.Heaviside: heaviside_rule,
+            OrthogonalPolynomial: orthogonal_poly_rule,
             sympy.Number: constant_rule
         })),
         do_one(
@@ -1220,6 +1276,48 @@ def eval_heaviside(harg, ibnd, substep, integrand, symbol):
     # then there needs to be continuity at -b/m == ibnd,
     # so we subtract the appropriate term.
     return sympy.Heaviside(harg)*(substep - substep.subs(symbol, ibnd))
+
+@evaluates(JacobiRule)
+def eval_jacobi(n, a, b, integrand, symbol):
+    return Piecewise(
+        (2*sympy.jacobi(n + 1, a - 1, b - 1, symbol)/(n + a + b), Ne(n + a + b, 0)),
+        (symbol, Eq(n, 0)),
+        ((a + b + 2)*symbol**2/4 + (a - b)*symbol/2, Eq(n, 1)))
+
+@evaluates(GegenbauerRule)
+def eval_gegenbauer(n, a, integrand, symbol):
+    return Piecewise(
+        (sympy.gegenbauer(n + 1, a - 1, symbol)/(2*(a - 1)), Ne(a, 1)),
+        (sympy.chebyshevt(n + 1, symbol)/(n + 1), Ne(n, -1)),
+        (sympy.S.Zero, True))
+
+@evaluates(ChebyshevTRule)
+def eval_chebyshevt(n, integrand, symbol):
+    return Piecewise(((sympy.chebyshevt(n + 1, symbol)/(n + 1) -
+        sympy.chebyshevt(n - 1, symbol)/(n - 1))/2, Ne(sympy.Abs(n), 1)),
+        (symbol**2/2, True))
+
+@evaluates(ChebyshevURule)
+def eval_chebyshevu(n, integrand, symbol):
+    return Piecewise(
+        (sympy.chebyshevt(n + 1, symbol)/(n + 1), Ne(n, -1)),
+        (sympy.S.Zero, True))
+
+@evaluates(LegendreRule)
+def eval_legendre(n, integrand, symbol):
+    return (sympy.legendre(n + 1, symbol) - sympy.legendre(n - 1, symbol))/(2*n + 1)
+
+@evaluates(HermiteRule)
+def eval_hermite(n, integrand, symbol):
+    return sympy.hermite(n + 1, symbol)/(2*(n + 1))
+
+@evaluates(LaguerreRule)
+def eval_laguerre(n, integrand, symbol):
+    return sympy.laguerre(n, symbol) - sympy.laguerre(n + 1, symbol)
+
+@evaluates(AssocLaguerreRule)
+def eval_assoclaguerre(n, a, integrand, symbol):
+    return -sympy.assoc_laguerre(n + 1, a - 1, symbol)
 
 @evaluates(DontKnowRule)
 def eval_dontknowrule(integrand, symbol):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -235,8 +235,12 @@ def test_manualintegrate_orthogonal_poly():
         for deg in [2, 4, 7]:
             assert (integral.subs(n, deg).diff(x) - q.subs(n, deg)).expand() == 0
 
-        # cannot integrate with respect to parameters
-        assert manualintegrate(jacobi(n, a + x, b, x), x).has(Integral)
+        # cannot integrate with respect to any other parameter
+        t = symbols('t')
+        for i in range(len(p.args) - 1):
+            new_args = list(p.args)
+            new_args[i] = t
+            assert isinstance(manualintegrate(p.func(*new_args), t), Integral)
 
 def test_issue_6799():
     r, x, phi = map(Symbol, 'r x phi'.split())


### PR DESCRIPTION
Implemented manualintegrate formulas for eight types of orthogonal polynomials.  Integration is possible for polynomials themselves, as well as their linear transformations and  products with explicit polynomials. 

For example, `integrate(legendre(n, x), x)` previously was unevaluated. Now it returns `(legendre(n + 1, x) - legendre(n - 1, x))/(2*n + 1)`. The formulas are tested by differentiation with several values of n.  

Integration by parts also works.
```
>>> integrate(x**2*hermite(n, 2*x - 1), x)
x**2*hermite(n + 1, 2*x - 1)/(2*(2*n + 2)) - x*hermite(n + 2, 2*x - 1)/(4*(n + 1)*(2*n + 4)) + hermite(n + 3, 2*x - 1)/(8*(n + 1)*(2*n + 4)*(2*n + 6))
```

### References

- [Jacobi](http://functions.wolfram.com/Polynomials/JacobiP/21/01/01/0001/)
- [Gegenbauer](http://functions.wolfram.com/Polynomials/GegenbauerC3/21/01/01/0001/)
- [Chebyshev T](http://functions.wolfram.com/Polynomials/ChebyshevT/21/01/01/0002/)
- [Chebyshev U](http://functions.wolfram.com/Polynomials/ChebyshevU/21/01/01/0002/)
- [Legendre](http://functions.wolfram.com/Polynomials/LegendreP/21/01/01/)
- [Laguerre](http://functions.wolfram.com/Polynomials/LaguerreL/21/01/01/0001/)
- [Generalized Laguerre](http://functions.wolfram.com/Polynomials/LaguerreL3/21/01/01/)
- [Hermite](http://functions.wolfram.com/Polynomials/HermiteH/21/01/01/0001/)

### Tangential comments

The choice of manualintegrate is based on the following. 

Meijer G method isn't great for polynomials, as rewriting them in terms of G and back is difficult.
```
>>> integrate(x**2, meijerg=True)
Piecewise((x**3/3, Abs(x) < 1), (meijerg(((1,), (4,)), ((3,), (0,)), x) + meijerg(((4, 1), ()), ((), (3, 0)), x), True))
```

Holonomic module is not integrated with `integrate`, and struggles even with explicit orthogonal polynomials.
``` 
>>> expr_to_holonomic(legendre(3, x)).integrate((x, 0, x)).to_expr()
x**2*(5*x**2 - 6)/8
>>> expr_to_holonomic(legendre(4, x)).integrate((x, 0, x)).to_expr()
sympy.holonomic.holonomicerrors.NotHyperSeriesError: Power series expansion of HolonomicFunction((-35*x**3/2 + 15*x/2)*Dx + (35*x**4/8 - 15*x**2/4 + 3/8)*Dx**2, x, 0, [0, 3/8]) about 0 is not hypergeometric
```
It also does not recognize general-degree `legendre(n, x)` as a holonomic function, and cannot return the antiderivative in terms of legendre itself.
