### PR TITLE
polyroots: Exclude zero roots of resultant in the Descartes method for quartics

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3090,3 +3090,14 @@ def test_issue_14489():
 
     assert Mod(A, 3) == Matrix([2, 1, 2])
     assert Mod(B, 4) == Matrix([2, 0, 1])
+
+def test_issue_14517():
+    M = Matrix([
+        [   0, 10*I,    10*I,       0],
+        [10*I,    0,       0,    10*I],
+        [10*I,    0, 5 + 2*I,    10*I],
+        [   0, 10*I,    10*I, 5 + 2*I]])
+    ev = M.eigenvals()
+    # test one random eigenvalue, the computation is a little slow
+    test_ev = random.choice(list(ev.keys()))
+    assert (M - test_ev*eye(4)).det() == 0

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -230,7 +230,7 @@ def _roots_quartic_euler(p, q, r, a):
     x = Symbol('x')
     eq = 64*x**3 + 32*p*x**2 + (4*p**2 - 16*r)*x - q**2
     xsols = list(roots(Poly(eq, x), cubics=False).keys())
-    xsols = [sol for sol in xsols if sol.is_rational]
+    xsols = [sol for sol in xsols if sol.is_rational and sol.is_nonzero]
     if not xsols:
         return None
     R = max(xsols)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -6,7 +6,7 @@ import math
 
 from sympy.core.symbol import Dummy, Symbol, symbols
 from sympy.core import S, I, pi
-from sympy.core.compatibility import ordered
+from sympy.core.compatibility import ordered, range, reduce
 from sympy.core.mul import expand_2arg, Mul
 from sympy.core.power import Pow
 from sympy.core.relational import Eq
@@ -28,8 +28,6 @@ from sympy.polys.rationaltools import together
 
 from sympy.simplify import simplify, powsimp
 from sympy.utilities import public
-
-from sympy.core.compatibility import reduce, range
 
 
 def roots_linear(f):
@@ -310,8 +308,8 @@ def roots_quartic(f):
     else:
         a2 = a**2
         e = b - 3*a2/8
-        f = c + a*(a2/8 - b/2)
-        g = d - a*(a*(3*a2/256 - b/16) + c/4)
+        f = (c + a*(a2/8 - b/2)).expand()
+        g = (d - a*(a*(3*a2/256 - b/16) + c/4)).expand()
         aon4 = a/4
 
         if f is S.Zero:

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -14,6 +14,7 @@ from sympy.core.sympify import sympify
 from sympy.core.numbers import Rational, igcd, comp
 from sympy.core.exprtools import factor_terms
 from sympy.core.logic import fuzzy_not
+from sympy.core.function import _mexpand
 
 from sympy.ntheory import divisors, isprime, nextprime
 from sympy.functions import exp, sqrt, im, cos, acos, Piecewise
@@ -308,8 +309,8 @@ def roots_quartic(f):
     else:
         a2 = a**2
         e = b - 3*a2/8
-        f = (c + a*(a2/8 - b/2)).expand()
-        g = (d - a*(a*(3*a2/256 - b/16) + c/4)).expand()
+        f = _mexpand(c + a*(a2/8 - b/2))
+        g = _mexpand(d - a*(a*(3*a2/256 - b/16) + c/4))
         aon4 = a/4
 
         if f is S.Zero:

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -103,6 +103,12 @@ def test_issue_13340():
     assert len(roots_d) == 3
 
 
+def test_issue_14522():
+    eq = Poly(x**4 + x**3*(16 + 32*I) + x**2*(-285 + 386*I) + x*(-2824 - 448*I) - 2058 - 6053*I, x)
+    roots_eq = roots(eq)
+    assert all(eq(r) == 0 for r in roots_eq)
+
+
 def test_roots_cubic():
     assert roots_cubic(Poly(2*x**3, x)) == [0, 0, 0]
     assert roots_cubic(Poly(x**3 - 3*x**2 + 3*x - 1, x)) == [1, 1, 1]


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14517

#### Brief description of what is fixed or changed

The method `_roots_quartic_euler`  of polyroots picks the largest rational root of the resolvent `64*x**3 + 32*p*x**2 + (4*p**2 - 16*r)*x - q**2` expecting it to be positive because the constant term is `-q**2`. This expectation is unwarranted since the coefficients may be complex, or q could be zero. This is not necessarily a problem, unless the root is zero. Zero root of resolvent cannot be used by this method, as it's being divided by.  

Now the zero root is filtered out. Taking the maximum is fine after that; positive roots are preferred. 