### PR TITLE
Fix evaluation of Reciprocal Trigonometric Functions

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1600,3 +1600,14 @@ def test_issue_14543():
     assert csc(2*pi - 17) == -csc(17)
     assert csc(pi + 17) == -csc(17)
     assert csc(pi - 17) == csc(17)
+
+    x = Symbol('x')
+    assert csc(pi/2 + x) == sec(x)
+    assert csc(pi/2 - x) == sec(x)
+    assert csc(3*pi/2 + x) == -sec(x)
+    assert csc(3*pi/2 - x) == -sec(x)
+
+    assert sec(pi/2 - x) == csc(x)
+    assert sec(pi/2 + x) == -csc(x)
+    assert sec(3*pi/2 + x) == csc(x)
+    assert sec(3*pi/2 - x) == -csc(x)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1589,3 +1589,14 @@ def test_issue_14320():
     assert asec(csc(13)) == -13 + 9*pi/2 and (0 <= -13 + 9*pi/2 <= pi) and sin(13) == cos(-13 + 9*pi/2)
     assert acsc(csc(14)) == -4*pi + 14 and (-pi/2 <= -4*pi + 14 <= pi/2) and sin(14) == sin(-4*pi + 14)
     assert acsc(sec(10)) == -7*pi/2 + 10 and (-pi/2 <= -7*pi/2 + 10 <= pi/2) and cos(10) == sin(-7*pi/2 + 10)
+
+def test_issue_14543():
+    assert sec(2*pi + 11) == sec(11)
+    assert sec(2*pi - 11) == sec(11)
+    assert sec(pi + 11) == -sec(11)
+    assert sec(pi - 11) == -sec(11)
+
+    assert csc(2*pi + 17) == csc(17)
+    assert csc(2*pi - 17) == -csc(17)
+    assert csc(pi + 17) == -csc(17)
+    assert csc(pi - 17) == csc(17)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1527,10 +1527,18 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
                     elif cls._is_even:
                         return -cls(narg)
 
-        t = cls._reciprocal_of.eval(arg)
         if hasattr(arg, 'inverse') and arg.inverse() == cls:
             return arg.args[0]
-        return 1/t if t != None else t
+
+        t = cls._reciprocal_of.eval(arg)
+        if t == None:
+            return t
+        elif isinstance(t, cls._reciprocal_of):
+            return (1/t).rewrite(cls)
+        elif isinstance(-t, cls._reciprocal_of):
+            return -(1/(-t)).rewrite(cls)
+        else:
+            return 1/t
 
     def _call_reciprocal(self, method_name, *args, **kwargs):
         # Calls method_name on _reciprocal_of

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1533,14 +1533,10 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
         t = cls._reciprocal_of.eval(arg)
         if t == None:
             return t
-        elif isinstance(t, cos):
+        elif any(isinstance(i, cos) for i in (t, -t)):
             return (1/t).rewrite(sec)
-        elif isinstance(-t, cos):
-            return -(-1/t).rewrite(sec)
-        elif isinstance(t, sin):
+        elif any(isinstance(i, sin) for i in (t, -t)):
             return (1/t).rewrite(csc)
-        elif isinstance(-t, sin):
-            return -(-1/t).rewrite(csc)
         else:
             return 1/t
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1533,10 +1533,14 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
         t = cls._reciprocal_of.eval(arg)
         if t == None:
             return t
-        elif isinstance(t, cls._reciprocal_of):
-            return (1/t).rewrite(cls)
-        elif isinstance(-t, cls._reciprocal_of):
-            return -(1/(-t)).rewrite(cls)
+        elif isinstance(t, cos):
+            return (1/t).rewrite(sec)
+        elif isinstance(-t, cos):
+            return -(-1/t).rewrite(sec)
+        elif isinstance(t, sin):
+            return (1/t).rewrite(csc)
+        elif isinstance(-t, sin):
+            return -(-1/t).rewrite(csc)
         else:
             return 1/t
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #14543 

#### Brief description of what is fixed or changed
Reciprocal Trigonometric Functions: `sec`, `csc`
```python
>>> sec(11)
sec(11)

>>> sec(pi + 11)
-sec(11)

>>> sec(2*pi + 11)
sec(11)

>>> print(sec(11) == sec(2*pi + 11))
True
```

#### Other comments