### PR TITLE
integrals: added property is_number

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -106,6 +106,13 @@ class Integral(AddWithLimits):
         """
         return AddWithLimits.free_symbols.fget(self)
 
+    @property
+    def is_number(self):
+        if (self.free_symbols == set()) and not isinstance(type(self.args[0]), UndefinedFunction):
+            return True
+        else:
+            return False
+
     def _eval_is_zero(self):
         # This is a very naive and quick test, not intended to do the integral to
         # answer whether it is zero or not, e.g. Integral(sin(x), (x, 0, 2*pi))

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -109,9 +109,6 @@ class Integral(AddWithLimits):
     @property
     def is_number(self):
         from sympy.core.function import UndefinedFunction
-        from sympy.core.numbers import Float
-        if isinstance(self.evalf(), Float):
-            return True
         if (self.free_symbols == set()) and not isinstance(type(self.args[0]), UndefinedFunction):
             return True
         else:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -108,6 +108,7 @@ class Integral(AddWithLimits):
 
     @property
     def is_number(self):
+        from sympy.core.function import UndefinedFunction
         if (self.free_symbols == set()) and not isinstance(type(self.args[0]), UndefinedFunction):
             return True
         else:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -109,6 +109,9 @@ class Integral(AddWithLimits):
     @property
     def is_number(self):
         from sympy.core.function import UndefinedFunction
+        from sympy.core.numbers import Float
+        if isinstance(self.evalf(), Float):
+            return True
         if (self.free_symbols == set()) and not isinstance(type(self.args[0]), UndefinedFunction):
             return True
         else:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -108,7 +108,7 @@ class Integral(AddWithLimits):
 
     @property
     def is_number(self):
-        from sympy.core.function import UndefinedFunction
+        from sympy.core.function import Function, UndefinedFunction
         return not self.free_symbols and not any(isinstance(f.func, UndefinedFunction) for f in self.atoms(Function))
 
     def _eval_is_zero(self):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -108,8 +108,8 @@ class Integral(AddWithLimits):
 
     @property
     def is_number(self):
-        from sympy.core.function import Function, UndefinedFunction
-        return not self.free_symbols and not any(isinstance(f.func, UndefinedFunction) for f in self.atoms(Function))
+        from sympy.core.function import AppliedUndef
+        return not self.free_symbols and not self.atoms(AppliedUndef)
 
     def _eval_is_zero(self):
         # This is a very naive and quick test, not intended to do the integral to

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -109,10 +109,7 @@ class Integral(AddWithLimits):
     @property
     def is_number(self):
         from sympy.core.function import UndefinedFunction
-        if (self.free_symbols == set()) and not isinstance(type(self.args[0]), UndefinedFunction):
-            return True
-        else:
-            return False
+        return not self.free_symbols and not any(isinstance(f.func, UndefinedFunction) for f in self.atoms(Function))
 
     def _eval_is_zero(self):
         # This is a very naive and quick test, not intended to do the integral to

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -830,7 +830,7 @@ def test_is_number():
     # it is possible to get a false negative if the integrand is
     # actually an unsimplified zero, but this is true of is_number in general.
     assert Integral(sin(x)**2 + cos(x)**2 - 1, x).is_number is False
-    assert Integral(f(x), (x, 0, 1)).is_number is True
+    assert Integral(f(x), (x, 0, 1)).is_number is False
 
 
 def test_symbols():


### PR DESCRIPTION
Fixes #13847 

**Brief description of what is fixed or changed**

Added the property `is_number` for `Integral`, now `Integral(f(x), (x, 0, 1)).is_number` returns False if argument contains no free symbols and no undefined function.

**Other comments**
I have not added the test for bound symbols, I am not sure but it worked without adding a check for that

@normalhuman @jksuom please ping!

<!-- BEGIN RELEASE NOTES -->

* integrals
  * added is_number property to Integral which is True if there is no free symbol and no undefined function

<!-- END RELEASE NOTES -->