### PR TITLE
polyclasses : added to_list and to_sympy_list methods

### DIFF
--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -247,6 +247,14 @@ class DMP(PicklableWithSlots, CantSympify):
 
         return rep
 
+    def to_list(f):
+        """Convert ``f`` to a list representation with native coefficients. """
+        return f.rep
+
+    def to_sympy_list(f):
+        """Convert ``f`` to a list representation with SymPy coefficients. """
+        return [ f.dom.to_sympy(c) for c in f.rep ]
+
     def to_tuple(f):
         """
         Convert ``f`` to a tuple representation with native coefficients.

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -253,7 +253,16 @@ class DMP(PicklableWithSlots, CantSympify):
 
     def to_sympy_list(f):
         """Convert ``f`` to a list representation with SymPy coefficients. """
-        return [ f.dom.to_sympy(c) for c in f.rep ]
+        def sympify_nested_list(rep):
+            out = []
+            for val in rep:
+                if isinstance(val, list):
+                    out.append(sympify_nested_list(val))
+                else:
+                    out.append(f.dom.to_sympy(val))
+            return out
+
+        return sympify_nested_list(f.rep)
 
     def to_tuple(f):
         """

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3233,6 +3233,9 @@ def test_factor_terms():
 def test_as_list():
     # issue 14496
     assert Poly(x**3 + 2, x, domain='ZZ').as_list() == [1, 0, 0, 2]
+    assert Poly(x**2 + y + 1, x, y, domain='ZZ').as_list() == [[1], [], [1, 1]]
+    assert Poly(x**2 + y + 1, x, y, z, domain='ZZ').as_list() == \
+                                                    [[[1]], [[]], [[1], [1]]]
 
 
 def test_issue_11198():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3230,14 +3230,21 @@ def test_factor_terms():
     assert sqf_list(x*(x + y)) == (1, [(x, 1), (x + y, 1)])
 
 
+def test_as_list():
+    # issue 14496
+    assert Poly(x**3 + 2, x, domain='ZZ').as_list() == [1, 0, 0, 2]
+
+
 def test_issue_11198():
     assert factor_list(sqrt(2)*x) == (sqrt(2), [(x, 1)])
     assert factor_list(sqrt(2)*sin(x), sin(x)) == (sqrt(2), [(sin(x), 1)])
+
 
 def test_Poly_precision():
     # Make sure Poly doesn't lose precision
     p = Poly(pi.evalf(100)*x)
     assert p.as_expr() == pi.evalf(100)*x
+
 
 def test_issue_12400():
     # Correction of check for negative exponents


### PR DESCRIPTION
Fixes #14496 

`to_list` and `to_sympy_list` methods were missing from `DMP` class.