### PR TITLE
Fix comparisons with None performed with equality instead of is

### DIFF
--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3221,7 +3221,7 @@ def test_noncommutative():
 
 def test_to_rational_coeffs():
     assert to_rational_coeffs(
-        Poly(x**3 + y*x**2 + sqrt(y), x, domain='EX')) == None
+        Poly(x**3 + y*x**2 + sqrt(y), x, domain='EX')) is None
 
 
 def test_factor_terms():

--- a/sympy/polys/tests/test_solvers.py
+++ b/sympy/polys/tests/test_solvers.py
@@ -20,7 +20,8 @@ def test_solve_lin_sys_2x4_none():
            x1 - x2,
            x1 - 2*x2,
            x2 - 1]
-    assert solve_lin_sys(eqs, domain) == None
+    assert solve_lin_sys(eqs, domain) is None
+
 
 def test_solve_lin_sys_3x4_one():
     domain, x1,x2,x3 = ring("x1,x2,x3", QQ)
@@ -44,7 +45,8 @@ def test_solve_lin_sys_3x4_none():
     eqs = [2*x1 + x2 + 7*x3 - 7*x4 - 2,
            -3*x1 + 4*x2 - 5*x3 - 6*x4 - 3,
            x1 + x2 + 4*x3 - 5*x4 - 2]
-    assert solve_lin_sys(eqs, domain) == None
+    assert solve_lin_sys(eqs, domain) is None
+
 
 def test_solve_lin_sys_4x7_inf():
     domain, x1,x2,x3,x4,x5,x6,x7 = ring("x1,x2,x3,x4,x5,x6,x7", QQ)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1368,7 +1368,7 @@ class Complement(Set, EvalfMixin):
             return Intersection(s.complement(A) for s in B.args)
 
         result = B._complement(A)
-        if result != None:
+        if result is not None:
             return result
         else:
             return Complement(A, B, evaluate=False)


### PR DESCRIPTION
#### Brief description of what is fixed or changed

I replace comparisons with None performed with = with is

#### Other comments

 That type of comparisons should always be done with 'is' or 'is not', never the equality operators.