### PR TITLE
Fixes #14528, by leaving unevaluated `gamma(p)` for p integer and nonpositive

### DIFF
--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -134,9 +134,6 @@ class gamma(Function):
                     else:
                         return 2**n*sqrt(S.Pi) / coeff
 
-        if arg.is_integer and arg.is_nonpositive:
-            return S.ComplexInfinity
-
     def _eval_expand_func(self, **hints):
         arg = self.args[0]
         if arg.is_Rational:

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -68,11 +68,6 @@ def test_gamma():
     assert gamma(3*exp_polar(I*pi)/4).is_nonnegative is False
     assert gamma(3*exp_polar(I*pi)/4).is_nonpositive is True
 
-    # Issue 8526
-    k = Symbol('k', integer=True, nonnegative=True)
-    assert isinstance(gamma(k), gamma)
-    assert gamma(-k) == zoo
-
 
 def test_gamma_rewrite():
     assert gamma(n).rewrite(factorial) == factorial(n - 1)
@@ -410,7 +405,7 @@ def test_issue_8657():
     m = Symbol('m', integer=True)
     o = Symbol('o', positive=True)
     p = Symbol('p', negative=True, integer=False)
-    assert gamma(n).is_real is False
+    assert gamma(n).is_real is None
     assert gamma(m).is_real is None
     assert gamma(o).is_real is True
     assert gamma(p).is_real is True
@@ -440,3 +435,7 @@ def test_issue_14450():
     # some values from Wolfram Alpha for comparison
     assert abs(uppergamma(S(3)/8, 2).evalf() - 0.07105675881) < 1e-9
     assert abs(lowergamma(S(3)/8, 2).evalf() - 2.2993794256) < 1e-9
+
+def test_issue_14528():
+    k = Symbol('k', integer=True, nonpositive=True)
+    assert isinstance(gamma(k), gamma)

--- a/sympy/simplify/gammasimp.py
+++ b/sympy/simplify/gammasimp.py
@@ -78,7 +78,7 @@ def _gammasimp(expr, as_comb):
 
     if as_comb:
         expr = expr.replace(_rf,
-            lambda a, b: binomial(a + b - 1, b)*gamma(b + 1))
+            lambda a, b: gamma(b + 1))
     else:
         expr = expr.replace(_rf,
             lambda a, b: gamma(a + b)/gamma(a))

--- a/sympy/simplify/tests/test_combsimp.py
+++ b/sympy/simplify/tests/test_combsimp.py
@@ -60,3 +60,8 @@ def test_combsimp():
         n*(n - 1)*(n - 2)
     assert combsimp(6*RisingFactorial(4, -n - 1)/factorial(-n - 1)) == \
         -n*(n - 1)*(n - 2)
+
+def test_issue_14528():
+    p = symbols("p", integer=True, positive=True)
+    assert combsimp(binomial(1,p)) == 1/(factorial(p)*factorial(1-p))
+    assert combsimp(factorial(2-p)) == factorial(2-p)

--- a/sympy/simplify/tests/test_gammasimp.py
+++ b/sympy/simplify/tests/test_gammasimp.py
@@ -100,3 +100,6 @@ def test_gammasimp():
     assert gammasimp(e) == e
     e = gamma(m + 1)/(gamma(i + 1)*gamma(-i + m + 1))
     assert gammasimp(e) == e
+
+    p = symbols("p", integer=True, positive=True)
+    assert gammasimp(gamma(-p+4)) == gamma(-p+4)


### PR DESCRIPTION
The problem in issue #14528 is that when we evaluate `gamma(p)` in SymPy where p is integer and nonpositive it gives `zoo`, but this is not a wise thing because is better to leave it unevaluated as other symbolic mathematical software like Wolfram Mathematica 8.0 gives it. If we evaluate it to `zoo` then we have problems like the one described in the issue. This pull request alters this behaviour of evaluating `gamma(p)`, leaving it non evaluated, an fixes the issue.