### PR TITLE
increase safety of ConditionSet

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1798,6 +1798,11 @@ class LatexPrinter(Printer):
 
     def _print_ConditionSet(self, s):
         vars_print = ', '.join([self._print(var) for var in Tuple(s.sym)])
+        if s.base_set is S.UniversalSet:
+            return r"\left\{%s\; |\; %s \right\}" % (
+            vars_print,
+            self._print(s.condition.as_expr()))
+
         return r"\left\{%s\; |\; %s \in %s \wedge %s \right\}" % (
             vars_print,
             vars_print,

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1799,11 +1799,11 @@ class LatexPrinter(Printer):
     def _print_ConditionSet(self, s):
         vars_print = ', '.join([self._print(var) for var in Tuple(s.sym)])
         if s.base_set is S.UniversalSet:
-            return r"\left\{%s\; |\; %s \right\}" % (
+            return r"\left\{%s \mid %s \right\}" % (
             vars_print,
             self._print(s.condition.as_expr()))
 
-        return r"\left\{%s\; |\; %s \in %s \wedge %s \right\}" % (
+        return r"\left\{%s \mid %s \in %s \wedge %s \right\}" % (
             vars_print,
             vars_print,
             self._print(s.base_set),

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1778,8 +1778,11 @@ class PrettyPrinter(Printer):
                 cond = self._print_seq(cond, "(", ")")
 
         bar = self._print("|")
-        base = self._print(ts.base_set)
 
+        if ts.base_set is S.UniversalSet:
+            return self._print_seq((variables, bar, cond), "{", "}", ' ')
+
+        base = self._print(ts.base_set)
         return self._print_seq((variables, bar, variables, inn,
                                 base, _and, cond), "{", "}", ' ')
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -103,6 +103,13 @@ class StrPrinter(Printer):
     def _print_ComplexInfinity(self, expr):
         return 'zoo'
 
+    def _print_ConditionSet(self, s):
+        args = tuple([self._print(i) for i in (s.sym, s.condition)])
+        if s.base_set is S.UniversalSet:
+            return 'ConditionSet(%s, %s)' % args
+        args += (self._print(s.base_set),)
+        return 'ConditionSet(%s, %s, %s)' % args
+
     def _print_Derivative(self, expr):
         dexpr = expr.expr
         dvars = [i[0] if i[1] == 1 else i for i in expr.variable_count]

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -781,7 +781,9 @@ def test_latex_ImageSet():
 def test_latex_ConditionSet():
     x = Symbol('x')
     assert latex(ConditionSet(x, Eq(x**2, 1), S.Reals)) == \
-        r"\left\{x\; |\; x \in \mathbb{R} \wedge x^{2} = 1 \right\}"
+        r"\left\{x \mid x \in \mathbb{R} \wedge x^{2} = 1 \right\}"
+    assert latex(ConditionSet(x, Eq(x**2, 1), S.UniversalSet)) == \
+        r"\left\{x \mid x^{2} = 1 \right\}"
 
 
 def test_latex_ComplexRegion():

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -81,6 +81,11 @@ class ConditionSet(Set):
     Notes
     =====
 
+    If no base set is specified, the universal set is implied:
+
+    >>> ConditionSet(x, x < 1).base_set
+    UniversalSet()
+
     Although expressions other than symbols may be used, this
     is discouraged and will raise an error if the expression
     is not found in the condition:
@@ -107,7 +112,7 @@ class ConditionSet(Set):
     >>> _.subs(_.sym, Symbol('_x'))
     ConditionSet(_x, (_x < y) & (_x + x < 2), S.Integers)
     """
-    def __new__(cls, sym, condition, base_set):
+    def __new__(cls, sym, condition, base_set=S.UniversalSet):
         # nonlinsolve uses ConditionSet to return an unsolved system
         # of equations (see _return_conditionset in solveset) so until
         # that is changed we do minimal checking of the args

--- a/sympy/sets/conditionset.py
+++ b/sympy/sets/conditionset.py
@@ -1,8 +1,10 @@
 from __future__ import print_function, division
 
 from sympy import S
+from sympy.sets.contains import Contains
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
+from sympy.core.expr import Expr
 from sympy.core.function import Lambda
 from sympy.core.logic import fuzzy_bool
 from sympy.core.symbol import Symbol, Dummy
@@ -10,6 +12,7 @@ from sympy.logic.boolalg import And, as_Boolean
 from sympy.sets.sets import (Set, Interval, Intersection, EmptySet, Union,
                              FiniteSet)
 from sympy.utilities.iterables import sift
+from sympy.utilities.misc import filldedent
 from sympy.multipledispatch import dispatch
 
 
@@ -23,7 +26,8 @@ class ConditionSet(Set):
     ========
 
     >>> from sympy import Symbol, S, ConditionSet, pi, Eq, sin, Interval
-    >>> x = Symbol('x')
+    >>> from sympy.abc import x, y
+
     >>> sin_sols = ConditionSet(x, Eq(sin(x), 0), Interval(0, 2*pi))
     >>> 2*pi in sin_sols
     True
@@ -33,6 +37,53 @@ class ConditionSet(Set):
     False
     >>> 5 in ConditionSet(x, x**2 > 4, S.Reals)
     True
+
+    If the value is not in the base set, the result is false:
+
+    >>> 5 in ConditionSet(x, x**2 > 4, Interval(2, 4))
+    False
+
+    Notes
+    =====
+
+    Symbols with assumptions should be avoided or else the
+    condition may evaluate without consideration of the set:
+
+    >>> n = Symbol('n', negative=True)
+    >>> cond = (n > 0); cond
+    False
+    >>> ConditionSet(n, cond, S.Integers)
+    EmptySet()
+
+    In addition, substitution of a dummy symbol can only be
+    done with a generic symbol with matching commutativity
+    or else a symbol that has identical assumptions.
+
+    Although expressions other than symbols may be used, this
+    is discouraged and will raise an error if the expression
+    is not found in the condition:
+
+    >>> ConditionSet(x + 1, x + 1 < 1, S.Integers)
+    ConditionSet(x + 1, x + 1 < 1, S.Integers)
+
+    >>> ConditionSet(x + 1, x < 1, S.Integers)
+    Traceback (most recent call last):
+    ...
+    ValueError: non-symbol dummy not recognized in condition
+
+    Although the name is usually respected, it must be replaced if
+    the base set is another ConditionSet and the dummy symbol
+    and appears as a free symbol in the base set and the dummy symbol
+    of the base set appears as a free symbol in the condition:
+
+    >>> ConditionSet(x, x < y, ConditionSet(y, x + y < 2, S.Integers))
+    ConditionSet(lambda, (lambda < y) & (lambda + x < 2), S.Integers)
+
+    The best way to do anything with the dummy symbol is to access
+    it with the sym property.
+
+    >>> _.subs(_.sym, Symbol('_x'))
+    ConditionSet(_x, (_x < y) & (_x + x < 2), S.Integers)
     """
     def __new__(cls, sym, condition, base_set):
         # nonlinsolve uses ConditionSet to return an unsolved system
@@ -84,13 +135,16 @@ class ConditionSet(Set):
                         condition.xreplace({sym: dum}),
                         c.xreplace({s: dum}))
                     sym = dum
-            if sym in base_set.free_symbols or \
-                    not isinstance(sym, Symbol):
-                s = Symbol('lambda')
-                if s in base_set.free_symbols:
-                    s = Dummy('lambda')
-                condition = condition.xreplace({sym: s})
-                sym = s
+            inbase = sym in base_set.free_symbols
+            if inbase or not isinstance(sym, Symbol):
+                s = Dummy('lambda')
+                cond = condition.xreplace({sym: s})
+                if s not in cond.free_symbols:
+                    raise ValueError(
+                        'non-symbol dummy not recognized in condition')
+                if inbase:
+                    condition = cond
+                    sym = s
         return Basic.__new__(cls, sym, condition, base_set)
 
     sym = property(lambda self: self.args[0])
@@ -107,16 +161,40 @@ class ConditionSet(Set):
             other), self.base_set.contains(other))
 
     def _eval_subs(self, old, new):
-        if not isinstance(self.sym, Symbol):
+        if not isinstance(self.sym, Expr):
             # Don't do anything with the equation set syntax;
             # that should go away, eventually.
             return self
-        if old == self.sym:
-            if new not in self.free_symbols:
-                if isinstance(new, Symbol):
-                    return self.func(*[i.subs(old, new) for i in self.args])
-            return self.func(self.sym, self.condition, self.base_set.subs(old, new))
-        return self.func(*([self.sym] + [i.subs(old, new) for i in self.args[1:]]))
+        sym, cond, base = self.args
+        if old == sym:
+            # we try to be as lenient as possible to allow
+            # the dummy symbol to be changed
+            base = base.subs(old, new)
+            if base != self.base_set:
+                # deference is given to the base set
+                return self.func(sym, cond, base)
+            if isinstance(new, Symbol):
+                # if the assumptions don't match, the cond
+                # might evaluate or change
+                if (new.assumptions0 == old.assumptions0 or
+                        len(new.assumptions0) == 1 and
+                        old.is_commutative == new.is_commutative):
+                    return self.func(new, cond.subs(old, new), base)
+                raise ValueError(filldedent('''
+                    A dummy symbol can only be
+                    replaced with a symbol having the same
+                    assumptions or one having a single assumption
+                    having the same commutativity.
+                '''))
+            # don't target cond: it is there to tell how
+            # the base set should be filtered and if new is not in
+            # the base set then this substitution is ignored
+            return self
+        cond = self.condition.subs(old, new)
+        base = self.base_set.subs(old, new)
+        if cond is S.true:
+            return ConditionSet(new, Contains(new, base), base)
+        return self.func(self.sym, cond, base)
 
     def dummy_eq(self, other, symbol=None):
         if not isinstance(other, self.func):

--- a/sympy/sets/tests/test_conditionset.py
+++ b/sympy/sets/tests/test_conditionset.py
@@ -1,7 +1,7 @@
 from sympy.sets import (ConditionSet, Intersection, FiniteSet,
     EmptySet, Union)
 from sympy import (Symbol, Eq, Lt, S, Abs, sin, pi, Lambda, Interval,
-    And, Mod)
+    And, Mod, oo, Function)
 from sympy.utilities.pytest import raises
 
 
@@ -10,6 +10,7 @@ x = Symbol('x')
 y = Symbol('y')
 z = Symbol('z')
 L = Symbol('lambda')
+f = Function('f')
 
 
 def test_CondSet():
@@ -20,6 +21,16 @@ def test_CondSet():
     assert 3*pi not in sin_sols_principal
     assert 5 in ConditionSet(x, x**2 > 4, S.Reals)
     assert 1 not in ConditionSet(x, x**2 > 4, S.Reals)
+    # in this case, 0 is not part of the base set so
+    # it can't be in any subset selected by the condition
+    assert 0 not in ConditionSet(x, y > 5, Interval(1, 7))
+    # since 'in' requires a true/false, the following raises
+    # an error because the given value provides no information
+    # for the condition to evaluate (since the condition does
+    # not depend on the dummy symbol): the result is `y > 5`.
+    # In this case, ConditionSet is just acting like
+    # Piecewise((Interval(1, 7), y > 5), (S.EmptySet, True)).
+    raises(TypeError, lambda: 6 in ConditionSet(x, y > 5, Interval(1, 7)))
 
     assert isinstance(ConditionSet(x, x < 1, {x, y}).base_set, FiniteSet)
     raises(TypeError, lambda: ConditionSet(x, x + 1, {x, y}))
@@ -84,11 +95,35 @@ def test_subs_CondSet():
     # you can only replace sym with a symbol that is not in
     # the free symbols
     assert c.subs(x, 1) == c
-    assert c.subs(x, y) == c
+    assert c.subs(x, y) == ConditionSet(y, y < 2, s)
+    assert ConditionSet(y, y < 2, s).subs(
+        y, w) == ConditionSet(y, y < 2, {w, z})
     assert c.subs(x, w) == ConditionSet(w, w < 2, s)
     assert ConditionSet(x, x < y, s
         ).subs(y, w) == ConditionSet(x, x < w, s.subs(y, w))
+    # if the user uses assumptions that cause the condition
+    # to evaluate, that can't be helped from SymPy's end
+    n = Symbol('n', negative=True)
+    assert ConditionSet(n, 0 < n, S.Integers) is S.EmptySet
+    p = Symbol('p', positive=True)
+    assert ConditionSet(n, n < y, S.Integers
+        ).subs(n, x) == ConditionSet(x, x < y, S.Integers)
+    nc = Symbol('nc', commutative=False)
+    raises(ValueError, lambda: ConditionSet(
+        x, x < p, S.Integers).subs(x, nc))
+    raises(ValueError, lambda: ConditionSet(
+        x, x < p, S.Integers).subs(x, n))
+    raises(ValueError, lambda: ConditionSet(
+        x + 1, x < 1, S.Integers))
+    assert ConditionSet(
+        n, n < x, Interval(0, oo)).subs(x, p) == Interval(0, oo)
+    assert ConditionSet(
+        n, n < x, Interval(-oo, 0)).subs(x, p) == S.EmptySet
+    assert ConditionSet(f(x), f(x) < 1, {w, z}
+        ).subs(f(x), y) == ConditionSet(y, y < 1, {w, z})
 
+
+def test_subs_CondSet_tebr():
     # to eventually be removed
     c = ConditionSet((x, y), {x + 1, x + y}, S.Reals)
     assert c.subs(x, z) == c
@@ -111,3 +146,18 @@ def test_dummy_eq():
     assert c1.dummy_eq(c3) is False
     assert c.dummy_eq(c1) is False
     assert c1.dummy_eq(c) is False
+
+
+def test_contains():
+    assert 6 in ConditionSet(x, x > 5, Interval(1, 7))
+    assert (8 in ConditionSet(x, y > 5, Interval(1, 7))) is False
+    # `in` should give True or False; in this case there is not
+    # enough information for that result
+    raises(TypeError,
+        lambda: 6 in ConditionSet(x, y > 5, Interval(1, 7)))
+    assert ConditionSet(x, y > 5, Interval(1, 7)
+        ).contains(6) == (y > 5)
+    assert ConditionSet(x, y > 5, Interval(1, 7)
+        ).contains(8) is S.false
+    assert ConditionSet(x, y > 5, Interval(1, 7)
+        ).contains(w) == And(w >= 1, w <= 7, y > 5)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

fixes #14495 
fixes #14500

#### Brief description of what is fixed or changed

ConditionSet uses more caution when undergoing substitution. For the most part, that first argument should be treated like a dummy and not touched. But when possible, it can be changed to a new symbol provided that the assumptions are less restrictive and matching in commutativity.
```
>>> ConditionSet(x, x < 2, {y, z}).subs(x, 1)
ConditionSet(x, x < 2, {y, z})  <-- formerly {y, z}

>>> ConditionSet(x, x > 5, Interval(1, 7)).subs(x, Symbol('n', negative=True))  <-- formerly EmptySet
Traceback (most recent call last):
...
ValueError:
A dummy symbol can only be replaced with a symbol having the same
assumptions or one having a single assumption having the same
commutativity.
```

#### Other comments
