### PR TITLE
CartanType_generator: Correct instantiation

### DIFF
--- a/sympy/liealgebras/cartan_type.py
+++ b/sympy/liealgebras/cartan_type.py
@@ -11,8 +11,10 @@ class CartanType_generator(Basic):
         c = args[0]
         if type(c) == list:
             letter, n = c[0], int(c[1])
-        if type(c) == str:
+        elif type(c) == str:
             letter, n = c[0], int(c[1:])
+        else:
+            raise TypeError("Argument must be a string (e.g. 'A3') or a list (e.g. ['A', 3])")
 
         if n < 0:
             raise ValueError("Lie algebra rank cannot be negative")

--- a/sympy/liealgebras/cartan_type.py
+++ b/sympy/liealgebras/cartan_type.py
@@ -9,9 +9,11 @@ class CartanType_generator(Basic):
     """
     def __call__(self, *args):
         c = args[0]
-        c = list(c)
+        if type(c) == list:
+            letter, n = c[0], int(c[1])
+        if type(c) == str:
+            letter, n = c[0], int(c[1:])
 
-        letter, n = c[0], int(c[1])
         if n < 0:
             raise ValueError("Lie algebra rank cannot be negative")
         if letter == "A":

--- a/sympy/liealgebras/tests/test_cartan_type.py
+++ b/sympy/liealgebras/tests/test_cartan_type.py
@@ -6,4 +6,7 @@ def test_Standard_Cartan():
     assert c.series == "A"
     m = Standard_Cartan("A", 2)
     assert m.rank() == 2
-    assert c.series == "A"
+    assert m.series == "A"
+    b = CartanType("B12")
+    assert b.rank() == 12
+    assert b.series == "B"


### PR DESCRIPTION
The current implementation of liealgebras has two ways to instantiate a
CartanType and hence also a RootSystem. For example,
```
c = CartanType('A7')
```
and
```
c = CartanType(['A', 7])
```
give the same thing. However, the former method only reads the first digit,
so, for example, `CartanType('A34')` will be exactly the same as `CartanType('A3')`
although it should be `CartanType(['A', 34])`.

I corrected this mistake by explicitly verifying if the argument is a list or
a string, and acting accordingly.
