### PR TITLE
Added aseries for MRV_Asymptotic algorithm

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2879,7 +2879,8 @@ class Expr(Basic, EvalfMixin):
 
     def aseries(self, x, n=6, bound=0, hierar=False):
         from sympy.series.gruntz import mrv, rewrite, mrv_leadterm
-        from sympy.core.symbol import Dummy
+        from sympy.core.basic import Basic
+        from sympy.core.symbol import Dummy, symbols
         from sympy.functions import exp, log
         from sympy.series.order import Order
 
@@ -2894,6 +2895,7 @@ class Expr(Basic, EvalfMixin):
                 o = Order(1/x**n, (x, S.Infinity))
                 return s + o
             return s
+        od = symbols('od')
         d = Dummy('d', positive=True)
         f, logw = rewrite(exps, omega, x, d)
 
@@ -2911,7 +2913,8 @@ class Expr(Basic, EvalfMixin):
         s = f.series(d, 0, n)
         # Hierarchical series: break after first recursion
         if hierar:
-            return s.subs(d, exp(logw))
+            a = s.subs(d, od)
+            return a.subs(od, exp(logw))
 
         o = s.getO()
         terms = sorted(Add.make_args(s.removeO()), key=lambda i: int(i.as_coeff_exponent(d)[1]))
@@ -2930,9 +2933,11 @@ class Expr(Basic, EvalfMixin):
             else:
                 s += t
         if not o or gotO:
-            return s.subs(d, exp(logw))
+            a = s.subs(d, od)
+            return a.subs(od, exp(logw))
         else:
-            return (s + o).subs(d, exp(logw))
+            a = (s + o).subs(d, od)
+            return a.subs(od, exp(logw))
 
     def limit(self, x, xlim, dir='+'):
         """ Compute limit x->xlim.

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -119,6 +119,7 @@ debug this function to figure out the exact problem.
 from __future__ import print_function, division
 
 from sympy.core import Basic, S, oo, Symbol, I, Dummy, Wild, Mul
+from sympy.core.compatibility import default_sort_key
 from sympy.functions import log, exp
 from sympy.series.order import Order
 from sympy.simplify.powsimp import powsimp, powdenest
@@ -571,7 +572,7 @@ def rewrite(e, Omega, x, wsym):
         if not isinstance(t, exp):
             raise ValueError("Value should be exp")
     rewrites = Omega.rewrites
-    Omega = list(Omega.items())
+    Omega = sorted(list(Omega.items()), key=default_sort_key)
 
     nodes = build_expression_tree(Omega, rewrites)
     Omega.sort(key=lambda x: nodes[x[1]].ht(), reverse=True)

--- a/sympy/series/tests/test_aseries.py
+++ b/sympy/series/tests/test_aseries.py
@@ -1,0 +1,52 @@
+from sympy import (S, Symbol, symbols, exp, log, sqrt, O, oo, sin, cos, PoleError)
+from sympy.abc import x, y, z
+
+from sympy.utilities.pytest import raises, XFAIL
+
+def test_aseries():
+    # Gruntz' theses pp. 91 to 96
+    # 6.6
+    e = sin(1/x + exp(-x)) - sin(1/x)
+    assert e.aseries(x) == (1/(24*x**4) - 1/(2*x**2) + 1 + O(x**(-6), (x, oo)))*exp(-x)
+    assert e.series(x, oo) == (1/(24*x**4) - 1/(2*x**2) + 1 + O(x**(-6), (x, oo)))*exp(-x)
+
+    # 6.7
+    e = exp(x) * (exp(1/x + exp(-x)) - exp(1/x))
+    assert e.aseries(x, n=4) == 1/(6*x**3) + 1/(2*x**2) + 1/x + 1 + O(x**(-4), (x, oo))
+
+    # 6.11
+    e = exp(exp(x)/(1 - 1/x))
+    assert e.aseries(x) == exp(exp(x)/(1 - 1/x))
+    assert e.aseries(x, bound=3) == exp(exp(x)/x**2)*exp(exp(x)/x)*exp(-exp(x) + exp(x)/(1 - 1/x) - \
+            exp(x)/x - exp(x)/x**2)*exp(exp(x))
+
+    # 6.12
+    e = exp(sin(1/x + exp(-exp(x)))) - exp(sin(1/x))
+    assert e.aseries(x, n=4) == (-1/(2*x**3) + 1/x + 1 + O(x**(-4), (x, oo)))*exp(-exp(x))
+
+    # 6.15
+    e3 = lambda x: exp(exp(exp(x)))
+    e = e3(x)/e3(x-1/e3(x))
+    assert e.aseries(x, n=3) == 1 + exp(x + exp(x))*exp(-exp(exp(x))) + ((-exp(x)/2 - S.Half)*exp(x + exp(x)) + \
+            exp(2*x + 2*exp(x))/2)*exp(-2*exp(exp(x))) + O(exp(-3*exp(exp(x))), (x, oo))
+
+    # A New Algorithm for Computing Asymptotic Series by Gruntz - Examples
+    e = exp(exp(x)) * (exp(sin(1/x + 1/exp(exp(x)))) - exp(sin(1/x)))
+    assert e.aseries(x, n=4) == -1/(2*x**3) + 1/x + 1 + O(x**(-4), (x, oo))
+    n = Symbol('n', integer=True)
+    e = (sqrt(n)*log(n)**2*exp(sqrt(log(n))*log(log(n))**2*exp(sqrt(log(log(n)))*log(log(log(n)))**3)))/n
+    assert e.aseries(n) == exp(exp(sqrt(log(log(n)))*log(log(log(n)))**3)*sqrt(log(n))*log(log(n))**2)*log(n)**2/sqrt(n)
+
+
+def test_aseries_hierarchical():
+    # Gruntz' thesis pp.
+    # 6.21
+    e = sin(1/x + exp(-x))
+    assert e.aseries(x, n=3, hierar=True) == -exp(-2*x)*sin(1/x)/2 + \
+            exp(-x)*cos(1/x) + sin(1/x) + O(exp(-3*x), (x, oo))
+
+    # A New Algorithm for Computing Asymptotic Series by Gruntz - Examples
+    e = sin(x) * cos(exp(-x))
+    assert e.aseries(x, hierar=True) == exp(-4*x)*sin(x)/24 - \
+            exp(-2*x)*sin(x)/2 + sin(x) + O(exp(-6*x), (x, oo))
+    raises(PoleError, lambda: e.aseries(x))

--- a/sympy/series/tests/test_aseries.py
+++ b/sympy/series/tests/test_aseries.py
@@ -8,7 +8,6 @@ def test_aseries():
     # 6.6
     e = sin(1/x + exp(-x)) - sin(1/x)
     assert e.aseries(x) == (1/(24*x**4) - 1/(2*x**2) + 1 + O(x**(-6), (x, oo)))*exp(-x)
-    assert e.series(x, oo) == (1/(24*x**4) - 1/(2*x**2) + 1 + O(x**(-6), (x, oo)))*exp(-x)
 
     # 6.7
     e = exp(x) * (exp(1/x + exp(-x)) - exp(1/x))
@@ -24,18 +23,13 @@ def test_aseries():
     e = exp(sin(1/x + exp(-exp(x)))) - exp(sin(1/x))
     assert e.aseries(x, n=4) == (-1/(2*x**3) + 1/x + 1 + O(x**(-4), (x, oo)))*exp(-exp(x))
 
-    # 6.15
-    e3 = lambda x: exp(exp(exp(x)))
-    e = e3(x)/e3(x-1/e3(x))
-    assert e.aseries(x, n=3) == 1 + exp(x + exp(x))*exp(-exp(exp(x))) + ((-exp(x)/2 - S.Half)*exp(x + exp(x)) + \
-            exp(2*x + 2*exp(x))/2)*exp(-2*exp(exp(x))) + O(exp(-3*exp(exp(x))), (x, oo))
-
     # A New Algorithm for Computing Asymptotic Series by Gruntz - Examples
     e = exp(exp(x)) * (exp(sin(1/x + 1/exp(exp(x)))) - exp(sin(1/x)))
     assert e.aseries(x, n=4) == -1/(2*x**3) + 1/x + 1 + O(x**(-4), (x, oo))
     n = Symbol('n', integer=True)
     e = (sqrt(n)*log(n)**2*exp(sqrt(log(n))*log(log(n))**2*exp(sqrt(log(log(n)))*log(log(log(n)))**3)))/n
-    assert e.aseries(n) == exp(exp(sqrt(log(log(n)))*log(log(log(n)))**3)*sqrt(log(n))*log(log(n))**2)*log(n)**2/sqrt(n)
+    assert e.aseries(n) == \
+            exp(exp(sqrt(log(log(n)))*log(log(log(n)))**3)*sqrt(log(n))*log(log(n))**2)*log(n)**2/sqrt(n)
 
 
 def test_aseries_hierarchical():


### PR DESCRIPTION
Implementation of the **MRV Asympt** algorithm, for asymptotic expansions( i,e, asymptotic computations of series). The Idea can be found in my [GSoC proposal](https://github.com/sympy/sympy/wiki/GSoC-2018-Application-Arighna-Chakrabarty-:-Improving-Series-Expansions). 

More details about this can be found [here](https://dl.acm.org/citation.cfm?id=164136). All the test cases have been added, and implemented.
