### PR TITLE
Fix binomial(n, k) for negative integer k

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -851,20 +851,18 @@ class binomial(CombinatorialFunction):
     @classmethod
     def eval(cls, n, k):
         n, k = map(sympify, (n, k))
-        d = n - k
-        if d.is_zero or k.is_zero:
+        if k.is_zero:
             return S.One
         if (k - 1).is_zero:
             return n
         if k.is_integer:
-            if k.is_negative:
+            if k.is_negative or (n.is_integer and n.is_nonnegative
+                    and (n - k).is_negative):
                 return S.Zero
-            if n.is_integer and n.is_nonnegative and d.is_negative:
-                return S.Zero
-            if n.is_number:
+            elif n.is_number:
                 res = cls._eval(n, k)
                 return res.expand(basic=True) if res else res
-        elif n.is_negative and n.is_integer and not k.is_integer:
+        elif n.is_negative and n.is_integer:
             # a special case when binomial evaluates to complex infinity
             return S.ComplexInfinity
         elif k.is_number:

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -291,13 +291,14 @@ def test_binomial():
     assert binomial(10, 10) == 1
     assert binomial(n, z) == 1
     assert binomial(1, 2) == 0
+    assert binomial(-1, 2) == 1
     assert binomial(1, -1) == 0
     assert binomial(-1, 1) == -1
-    assert binomial(-1, -1) == 1
+    assert binomial(-1, -1) == 0
     assert binomial(S.Half, S.Half) == 1
     assert binomial(-10, 1) == -10
     assert binomial(-10, 7) == -11440
-    assert binomial(n, -1) == 0
+    assert binomial(n, -1) == 0 # holds for all integers (negative, zero, positive)
     assert binomial(kp, -1) == 0
     assert binomial(nz, 0) == 1
     assert expand_func(binomial(n, 1)) == n
@@ -307,7 +308,7 @@ def test_binomial():
     assert binomial(n, 3).func == binomial
     assert binomial(n, 3).expand(func=True) ==  n**3/6 - n**2/2 + n/3
     assert expand_func(binomial(n, 3)) ==  n*(n - 2)*(n - 1)/6
-    assert binomial(n, n) == 1
+    assert binomial(n, n).func == binomial # e.g. (-1, -1) == 0, (2, 2) == 1
     assert binomial(n, n + 1).func == binomial  # e.g. (-1, 0) == 1
     assert binomial(kp, kp + 1) == 0
     assert binomial(n, u).func == binomial

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -311,6 +311,7 @@ def test_binomial():
     assert binomial(n, n).func == binomial # e.g. (-1, -1) == 0, (2, 2) == 1
     assert binomial(n, n + 1).func == binomial  # e.g. (-1, 0) == 1
     assert binomial(kp, kp + 1) == 0
+    assert binomial(kn, kn) == 0 # issue #14529
     assert binomial(n, u).func == binomial
     assert binomial(kp, u).func == binomial
     assert binomial(n, p).func == binomial


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #14529, reference to #14537 
Helps #14528 (no longer gives 0 as incorrect result, gives `nan` for the last case), reference to #14557  

Issues #13980 #13981 already fixed with #14019 
#### Brief description of what is fixed or changed
```python
>>> binomial(-1, -1)
0
>>> kn = Symbol('kn', integer=True, negative=True)
>>> binomial(kn, kn)
0
```