### PR TITLE
Stats: Corrections to conditions of type `Or`

### DIFF
--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -484,8 +484,8 @@ def reduce_rational_inequalities_wrap(condition, var):
     if condition.is_Relational:
         return _reduce_inequalities([[condition]], var, relational=False)
     if condition.__class__ is Or:
-        return _reduce_inequalities([list(condition.args)],
-                var, relational=False)
+        return Union(*[_reduce_inequalities([[arg]], var, relational=False)
+            for arg in condition.args])
     if condition.__class__ is And:
         intervals = [_reduce_inequalities([[arg]], var, relational=False)
             for arg in condition.args]

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -16,7 +16,7 @@ from sympy.stats import (P, E, where, density, variance, covariance, skewness,
 from sympy import (Symbol, Abs, exp, S, N, pi, simplify, Interval, erf, erfc, Ne,
                    Eq, log, lowergamma, uppergamma, Sum, symbols, sqrt, And, gamma, beta,
                    Piecewise, Integral, sin, cos, besseli, factorial, binomial,
-                   floor, expand_func, Rational, I, re, im, lambdify, hyper, diff)
+                   floor, expand_func, Rational, I, re, im, lambdify, hyper, diff, Or)
 
 
 from sympy.stats.crv_types import NormalDistribution
@@ -864,3 +864,10 @@ def test_union():
         -erf(sqrt(2))/2 - erfc(sqrt(2)/4)/2 + 3/2
     assert simplify(P(N**2 - 4 > 0)) == \
         -erf(5*sqrt(2)/4)/2 - erfc(sqrt(2)/4)/2 + 3/2
+
+def test_Or():
+    N = Normal('N', 0, 1)
+    assert simplify(P(Or(N > 2, N < 1))) == \
+        -erf(sqrt(2))/2 - erfc(sqrt(2)/2)/2 + 3/2
+    assert P(Or(N < 0, N < 1)) == P(N < 1)
+    assert P(Or(N > 0, N < 0)) == 1

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -6,6 +6,7 @@ from sympy.stats import P, E, variance, density, characteristic_function
 from sympy.stats.rv import sample
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.exponential import exp
+from sympy.logic.boolalg import Or
 
 def test_PoissonDistribution():
     l = 3
@@ -61,3 +62,9 @@ def test_discrete_probability():
     assert P(X > S.Infinity) is S.Zero
     assert P(G < 3) == x*(-x + 1) + x
     assert P(Eq(G, 3)) == x*(-x + 1)**2
+
+def test_Or():
+    X = Geometric('X', S(1)/2)
+    P(Or(X < 3, X > 4)) == S(13)/16
+    P(Or(X > 2, X > 1)) == P(X > 1)
+    P(Or(X >= 3, X < 3)) == 1


### PR DESCRIPTION
Previously, the domain where conditions of type `Or` were valid was calculated
in a way that resulted in the condition being treated in the same way as
`And`. This PR is to fix this wrong result. Tests for the same have been
added.

Examples:
(Before Fix)
```
>>> E = Exponential('E', 1)
>>> P(Or(E < 0, E > 0))
0
>>> P(Or(E > 1, E > 2)) == P(And(E > 1, E > 2))
True
```
(After fix)
```
>>> E = Exponential('E', 1)
>>> P(Or(E < 0, E > 0))
1
>>> P(Or(E > 1, E > 2)) == P(E > 1)
True
```

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments
