### PR TITLE
solving equations if floating point numbers are used

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -39,7 +39,8 @@ from sympy.utilities import filldedent
 from sympy.utilities.iterables import numbered_symbols
 from sympy.calculus.util import periodicity, continuous_domain
 from sympy.core.compatibility import ordered, default_sort_key, is_sequence
-
+from sympy import Float, nfloat
+from sympy.simplify import nsimplify
 from types import GeneratorType
 
 
@@ -851,6 +852,13 @@ def _solveset(f, symbol, domain, _check=False):
     from sympy.simplify.simplify import signsimp
 
     orig_f = f
+
+    # rationalize float
+    floats = False
+    if f.has(Float):
+        floats = True
+        f = nsimplify(f, rational=True)
+
     if f.is_Mul:
         coeff, f = f.as_independent(symbol, as_Add=False)
         if coeff in set([S.ComplexInfinity, S.NegativeInfinity, S.Infinity]):
@@ -970,6 +978,9 @@ def _solveset(f, symbol, domain, _check=False):
             result = FiniteSet(*[s for s in result
                       if isinstance(s, RootOf)
                       or domain_check(fx, symbol, s)])
+    # restore floats
+    if floats and isinstance(result, FiniteSet):
+        result = FiniteSet(*(nfloat(list(result), exponent=False)))
 
     return result
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1027,10 +1027,6 @@ def test_solvify():
     assert solvify(cos(x), x, S.Reals) == [pi/2, 3*pi/2]
     assert solvify(sin(x) + 1, x, S.Reals) == [3*pi/2]
     raises(NotImplementedError, lambda: solvify(sin(exp(x)), x, S.Complexes))
-
-
-@XFAIL
-def test_abs_invert_solvify():
     assert solvify(sin(Abs(x)), x, S.Reals) is None
 
 
@@ -1749,3 +1745,10 @@ def test_issue_14454():
     number = CRootOf(x**4 + x - 1, 2)
     raises(ValueError, lambda: invert_real(number, 0, x, S.Reals))
     assert invert_real(x**2, number, x, S.Reals)  # no error
+
+def test_issue_14541():
+    x = Symbol('x')
+    y = FiniteSet(-sqrt(2).evalf()*I,  sqrt(2).evalf()*I)
+    z = FiniteSet(-sqrt(2)*I, sqrt(2)*I)
+    assert solveset(sqrt(-x**2 - 2.0), x) == y
+    assert solveset(sqrt(-x**2 - 2), x) == z


### PR DESCRIPTION
Fixes #14541 
Equations containing floats may fail to solve at times. So here floats will be  recasted to rationals via `nsimplify` and the final answer would again be restored to floats via `nfloat`.
```(python 3)
>>> solveset(sqrt(-x**2 - 2), x)
{-sqrt(2)*I, sqrt(2)*I}
>>> eq = sqrt(-x**2 - 2.0)
>>> solveset(eq, x)
EmptySet()                  # current master

# solution
>>> eq = nsimplify(eq, rational=True)
>>> eq
sqrt(-x**2 - 2)
>>> ans  = solveset(eq, x)
>>> nfloat(list(ans), exponent=False)
[-1.4142135623731*I, 1.4142135623731*I]
```
Now `solveset()` would give:
```
>>> solveset(eq, x)
{-1.4142135623731*I, 1.4142135623731*I}
```
Also removed `XFAIL` that was fixed by PR #14449 

ping @smichr @aktech 