### PR TITLE
register_handler: 2**n +1 ==> 2**n - 1

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -1328,7 +1328,7 @@ def register_handler(key, handler):
         >>> from sympy.assumptions import register_handler, ask, Q
         >>> from sympy.assumptions.handlers import AskHandler
         >>> class MersenneHandler(AskHandler):
-        ...     # Mersenne numbers are in the form 2**n + 1, n integer
+        ...     # Mersenne numbers are in the form 2**n - 1, n integer
         ...     @staticmethod
         ...     def Integer(expr, assumptions):
         ...         from sympy import log


### PR DESCRIPTION
	modified:   ask.py

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

Fixes: #14584

A wrong comment of the run code block of the `register_handler` method is modified.

> Mersenne numbers are `2**n  -  1` but not `2**n + 1`

#### Other comments
