### PR TITLE
Remove setting of random.seed from ntheory test

### DIFF
--- a/sympy/ntheory/tests/test_generate.py
+++ b/sympy/ntheory/tests/test_generate.py
@@ -146,8 +146,6 @@ def test_generate():
 
 
 def test_randprime():
-    import random
-    random.seed(1234)
     assert randprime(10, 1) is None
     assert randprime(2, 3) == 2
     assert randprime(1, 3) == 2


### PR DESCRIPTION
This messes up the setting of the seed in the test runner itself. Also, the
test should pass with any random value, as I understand it.
