### PR TITLE
Modified `restricted_domain` to `where` and modified `eval_prob` in drv.py

### DIFF
--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -166,7 +166,7 @@ class SingleDiscretePSpace(SinglePSpace):
         else:
             raise NotImplementedError()
 
-    def restricted_domain(self, condition):
+    def where(self, condition):
         rvs = random_symbols(condition)
         assert all(r.symbol in self.symbols for r in rvs)
         if (len(rvs) > 1):
@@ -175,22 +175,21 @@ class SingleDiscretePSpace(SinglePSpace):
         conditional_domain = reduce_rational_inequalities_wrap(condition,
             rvs[0])
         conditional_domain = conditional_domain.intersect(self.domain.set)
-        return conditional_domain
+        return SingleDiscreteDomain(rvs[0].symbol, conditional_domain)
 
     def probability(self, condition):
         complement = isinstance(condition, Ne)
         if complement:
             condition = Eq(condition.args[0], condition.args[1])
-        _domain = self.restricted_domain(condition)
+        _domain = self.where(condition).set
         if condition == False or _domain is S.EmptySet:
             return S.Zero
         if condition == True or _domain == self.set:
             return S.One
-        try:
-            prob = self.eval_prob(_domain)
-            return prob if not complement else S.One - prob
-        except NotImplementedError:
-            return Probability(condition)
+        prob = self.eval_prob(_domain)
+        if prob == None:
+            prob = Probability(condition)
+        return prob if not complement else S.One - prob
 
     def eval_prob(self, _domain):
         if isinstance(_domain, Range):
@@ -208,6 +207,3 @@ class SingleDiscretePSpace(SinglePSpace):
         elif isinstance(_domain, Union):
             rv = sum(self.eval_prob(x) for x in _domain.args)
             return rv
-        else:
-            raise NotImplementedError(filldedent('''Probability for
-                the domain %s cannot be calculated.'''%(_domain)))

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -2,10 +2,12 @@ from sympy.stats.drv_types import (PoissonDistribution, GeometricDistribution,
         Poisson, Geometric)
 from sympy.abc import x
 from sympy import S, Sum
-from sympy.stats import P, E, variance, density, characteristic_function
+from sympy.stats import (P, E, variance, density, characteristic_function,
+        where)
 from sympy.stats.rv import sample
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.exponential import exp
+from sympy.sets.fancysets import Range
 from sympy.logic.boolalg import Or
 
 def test_PoissonDistribution():
@@ -68,3 +70,11 @@ def test_Or():
     P(Or(X < 3, X > 4)) == S(13)/16
     P(Or(X > 2, X > 1)) == P(X > 1)
     P(Or(X >= 3, X < 3)) == 1
+
+def test_where():
+    X = Geometric('X', S(1)/5)
+    Y = Poisson('Y', 4)
+    assert where(X**2 > 4).set == Range(3, S.Infinity, 1)
+    assert where(X**2 >= 4).set == Range(2, S.Infinity, 1)
+    assert where(Y**2 < 9).set == Range(0, 3, 1)
+    assert where(Y**2 <= 9).set == Range(0, 4, 1)


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Changes made to `eval_prob` were made as per the discussion [here](https://github.com/sympy/sympy/pull/14119#discussion_r179368527)

#### Brief description of what is fixed or changed
Modified and renamed `restricted_domain` to `where`, to return an instance
of `SingleDiscreteDomain`, like in crv.py and frv.py. Also changed
`eval_prob` to return `None` instead of raising an error.


#### Other comments
