### PR TITLE
sympify : passing `evaluate=False` flag to `Basic` class methods

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -977,7 +977,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
     def flatten(self, args, func):
         result = []
         for arg in args:
-            if isinstance(arg, ast.Call) and arg.func.id == func:
+            if isinstance(arg, ast.Call) and hasattr(arg.func, 'id') and arg.func.id == func:
                 result.extend(self.flatten(arg.args, func))
             else:
                 result.append(arg)
@@ -986,7 +986,9 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
     def visit_Call(self, node):
         from sympy import sympify
         from sympy.core.expr import Expr, AtomicExpr
-        node_class = sympify(node.func.id)
+        node_class = None
+        if hasattr(node.func, 'id'):
+            node_class = sympify(node.func.id)
         if isinstance(node_class, type) and issubclass(node_class, Basic) and not issubclass(node_class, AtomicExpr):
             args = []
             for arg in node.args:

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -2,7 +2,7 @@ import sys
 
 from sympy.core import Symbol, Function, Float, Rational, Integer, I, Mul, Pow, Eq
 from sympy.core.compatibility import PY3
-from sympy.functions import exp, factorial, factorial2, sin
+from sympy.functions import exp, factorial, factorial2, sin, Abs, log
 from sympy.logic import And
 from sympy.series import Limit
 from sympy.utilities.pytest import raises, skip
@@ -106,6 +106,15 @@ def test_global_dict():
     }
     for text, result in inputs.items():
         assert parse_expr(text, global_dict=global_dict) == result
+
+
+def test_evaluate_false():
+    x = Symbol('x')
+    parse_expr("Abs(x+x)", evaluate=False) == Abs(x + x)
+    parse_expr("Mul(3, 5.5)", evaluate=False) == 3*5.5
+    parse_expr("log(5.5)", evaluate=False) == log(5.5)
+    parse_expr("log(5 - 3)", evaluate=False) == log(-3 + 5)
+    parse_expr("log(log(5 - 3))", evaluate=False) == log(log(-3 + 5))
 
 
 def test_issue_2515():

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -115,6 +115,7 @@ def test_evaluate_false():
     parse_expr("log(5.5)", evaluate=False) == log(5.5)
     parse_expr("log(5 - 3)", evaluate=False) == log(-3 + 5)
     parse_expr("log(log(5 - 3))", evaluate=False) == log(log(-3 + 5))
+    parse_expr("1 + log(log(5 - 3))", evaluate=False) == log(log(-3 + 5)) + 1
 
 
 def test_issue_2515():


### PR DESCRIPTION
Fixes #13999
Added `visit_call` method inside `EvaluateFalseTransformer` to stop evaluation of functions which inherits from `Basic`.
```
>>> sympify("log(5.5)", evaluate=False)
log(5.5)
>>> sympify("log(5 - 3)", evaluate=False)
log(-3 + 5)
>>> sympify("Mul(3, 5.5)", evaluate=False)
3*5.5
>>> sympify("log(log(5 - 3))", evaluate=False)
log(log(-3 + 5))
```
Also fixes  #11441
```
>>> parse_expr("Abs(x+x)", evaluate=False) 
Abs(x + x)
```