### PR TITLE
Tighten check of list of dictionary solutions in solvers

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1212,8 +1212,8 @@ def solve(f, *symbols, **flags):
             solution and
             ordered_symbols and
             type(solution) is not dict and
-            type(solution[0]) is dict and
-            all(s in solution[0] for s in symbols)
+            all(type(sol) is dict for sol in solution) and
+            all(sym in sol for sym in symbols for sol in solution)
     ):
         solution = [tuple([r[s].subs(r) for s in symbols]) for r in solution]
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1212,10 +1212,10 @@ def solve(f, *symbols, **flags):
             solution and
             ordered_symbols and
             not isinstance(solution, dict) and
-            all(isinstance(sol, dict) for sol in solution) and
-            all(sym in sol for sym in symbols for sol in solution)
+            all(isinstance(sol, dict) for sol in solution)
     ):
-        solution = [tuple([r[s].subs(r) for s in symbols]) for r in solution]
+        solution = [tuple([r.get(s, s).subs(r) for s in symbols])
+                    for r in solution]
 
     # Get assumptions about symbols, to filter solutions.
     # Note that if assumptions about a solution can't be verified, it is still

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1166,14 +1166,14 @@ def solve(f, *symbols, **flags):
             return dict([(k, v.subs(non_inverts)) for k, v in
                          solution.items()])
         for i in range(1):
-            if type(solution) is dict:
+            if isinstance(solution, dict):
                 solution = _do_dict(solution)
                 break
-            elif solution and type(solution) is list:
-                if type(solution[0]) is dict:
+            elif solution and isinstance(solution, list):
+                if isinstance(solution[0], dict):
                     solution = [_do_dict(s) for s in solution]
                     break
-                elif type(solution[0]) is tuple:
+                elif isinstance(solution[0], tuple):
                     solution = [tuple([v.subs(non_inverts) for v in s]) for s
                                 in solution]
                     break
@@ -1197,10 +1197,10 @@ def solve(f, *symbols, **flags):
     #    above.
     if swap_sym:
         symbols = [swap_sym.get(k, k) for k in symbols]
-        if type(solution) is dict:
+        if isinstance(solution, dict):
             solution = dict([(swap_sym.get(k, k), v.subs(swap_sym))
                              for k, v in solution.items()])
-        elif solution and type(solution) is list and type(solution[0]) is dict:
+        elif solution and isinstance(solution, list) and isinstance(solution[0], dict):
             for i, sol in enumerate(solution):
                 solution[i] = dict([(swap_sym.get(k, k), v.subs(swap_sym))
                               for k, v in sol.items()])
@@ -1211,8 +1211,8 @@ def solve(f, *symbols, **flags):
             not flags.get('dict', False) and
             solution and
             ordered_symbols and
-            type(solution) is not dict and
-            all(type(sol) is dict for sol in solution) and
+            not isinstance(solution, dict) and
+            all(isinstance(sol, dict) for sol in solution) and
             all(sym in sol for sym in symbols for sol in solution)
     ):
         solution = [tuple([r[s].subs(r) for s in symbols]) for r in solution]
@@ -1231,11 +1231,11 @@ def solve(f, *symbols, **flags):
         warn = flags.get('warn', False)
         got_None = []  # solutions for which one or more symbols gave None
         no_False = []  # solutions for which no symbols gave False
-        if type(solution) is tuple:
+        if isinstance(solution, tuple):
             # this has already been checked and is in as_set form
             return solution
-        elif type(solution) is list:
-            if type(solution[0]) is tuple:
+        elif isinstance(solution, list):
+            if isinstance(solution[0], tuple):
                 for sol in solution:
                     for symb, val in zip(symbols, sol):
                         test = check_assumptions(val, **symb.assumptions0)
@@ -1245,7 +1245,7 @@ def solve(f, *symbols, **flags):
                             got_None.append(sol)
                     else:
                         no_False.append(sol)
-            elif type(solution[0]) is dict:
+            elif isinstance(solution[0], dict):
                 for sol in solution:
                     a_None = False
                     for symb, val in sol.items():
@@ -1268,7 +1268,7 @@ def solve(f, *symbols, **flags):
                     if test is None:
                         got_None.append(sol)
 
-        elif type(solution) is dict:
+        elif isinstance(solution, dict):
             a_None = False
             for symb, val in solution.items():
                 test = check_assumptions(val, **symb.assumptions0)
@@ -1368,19 +1368,19 @@ def _solve(f, *symbols, **flags):
                 pass
         if soln:
             if flags.get('simplify', True):
-                if type(soln) is dict:
+                if isinstance(soln, dict):
                     for k in soln:
                         soln[k] = simplify(soln[k])
-                elif type(soln) is list:
-                    if type(soln[0]) is dict:
+                elif isinstance(soln, list):
+                    if isinstance(soln[0], dict):
                         for d in soln:
                             for k in d:
                                 d[k] = simplify(d[k])
-                    elif type(soln[0]) is tuple:
+                    elif isinstance(soln[0], tuple):
                         soln = [tuple(simplify(i) for i in j) for j in soln]
                     else:
                         raise TypeError('unrecognized args in list')
-                elif type(soln) is tuple:
+                elif isinstance(soln, tuple):
                     sym, sols = soln
                     soln = sym, {tuple(simplify(i) for i in j) for j in sols}
                 else:
@@ -1843,7 +1843,7 @@ def _solve_system(exprs, symbols, **flags):
                     result = [dict(list(zip(solved_syms, r))) for r in result]
 
     if result:
-        if type(result) is dict:
+        if isinstance(result, dict):
             result = [result]
     else:
         result = [{}]
@@ -2096,7 +2096,7 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     all_zero = True
     for xi in sorted(symbols, key=default_sort_key):  # canonical order
         # if there are derivatives in this var, calculate them now
-        if type(derivs[xi]) is list:
+        if isinstance(derivs[xi], list):
             derivs[xi] = {der: der.doit() for der in derivs[xi]}
         newn = n.subs(derivs[xi])
         dnewn_dxi = newn.diff(xi)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1212,7 +1212,8 @@ def solve(f, *symbols, **flags):
             solution and
             ordered_symbols and
             not isinstance(solution, dict) and
-            all(isinstance(sol, dict) for sol in solution)
+            all(isinstance(sol, dict) for sol in solution) and
+            all(sym in sol for sol in solution for sym in symbols)
     ):
         solution = [tuple([r.get(s, s).subs(r) for s in symbols])
                     for r in solution]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1447,7 +1447,7 @@ def test_issue_6792():
          CRootOf(x**6 - x + 1, 4), CRootOf(x**6 - x + 1, 5)]
 
 
-def test_issues_6819_6820_6821_6248_8692_14607():
+def test_issues_6819_6820_6821_6248_8692():
     # issue 6821
     x, y = symbols('x y', real=True)
     assert solve(abs(x + 3) - 2*abs(x - 3)) == [1, 9]
@@ -1495,6 +1495,8 @@ def test_issues_6819_6820_6821_6248_8692_14607():
     x = symbols('x')
     assert solve(2**x + 4**x) == [I*pi/log(2)]
 
+
+def test_issue_14607():
     # issue 14607
     s, tau_c, tau_1, tau_2, phi, K = symbols(
         's, tau_c, tau_1, tau_2, phi, K')
@@ -1510,17 +1512,17 @@ def test_issues_6819_6820_6821_6248_8692_14607():
     eq = Poly(eq, s)
     c = eq.coeffs()
 
-    s = solve(c, [K_C, tau_I, tau_D])
+    vars = [K_C, tau_I, tau_D]
+    s = solve(c, vars)
 
     assert len(s) == 1
 
-    s = [simplify(si) for si in s[0]]
+    knownsolution = {K_C: -(tau_1 + tau_2)/(K*(phi - tau_c)),
+                     tau_I: tau_1 + tau_2,
+                     tau_D: tau_1*tau_2/(tau_1 + tau_2)}
 
-    knownsolution = [-(tau_1 + tau_2)/(K*(phi - tau_c)),
-                     tau_1 + tau_2,
-                     tau_1*tau_2/(tau_1 + tau_2)]
-
-    assert s == [simplify(si) for si in knownsolution]
+    for var in vars:
+        assert s[0][var].simplify() == knownsolution[var].simplify()
 
 
 def test_lambert_multivariate():


### PR DESCRIPTION
Fixes #14607 

We were checking if the first solution dictionary contained all the 
symbols, but relying on all of them to contain all the symbols in the
following assignment

The logic in this code block is not clear. I've written the checks to match the
assignment, but it may be that this should only be when one solution is returned. 
In that case we should actually check `len(solution) == 1` instead of what I have here.