### PR TITLE
init_printing: don't print builtin container subtypes that have custom printers

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -111,7 +111,13 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             # If you're adding another type, make sure you add it to printable_types
             # later in this file as well
 
-            if isinstance(o, (list, tuple, set, frozenset)):
+            builtin_types = (list, tuple, set, frozenset)
+            if isinstance(o, builtin_types):
+                # If the object is a custom subclass with a custom str or
+                # repr, use that instead.
+                if (o.__str__ not in (i.__str__ for i in builtin_types) or
+                    o.__repr__ not in (i.__repr__ for i in builtin_types)):
+                    return False
                 return all(_can_print_latex(i) for i in o)
             elif isinstance(o, dict):
                 return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -112,17 +112,17 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             # later in this file as well
 
             if isinstance(o, (list, tuple, set, frozenset)):
-               return all(_can_print_latex(i) for i in o)
+                return all(_can_print_latex(i) for i in o)
             elif isinstance(o, dict):
-               return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
+                return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
             elif isinstance(o, bool):
-               return False
+                return False
             # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
             # to use here, than these explicit imports.
             elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic, NDimArray)):
-               return True
+                return True
             elif isinstance(o, (float, integer_types)) and print_builtin:
-               return True
+                return True
             return False
         except RuntimeError:
             return False

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -115,8 +115,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             if isinstance(o, builtin_types):
                 # If the object is a custom subclass with a custom str or
                 # repr, use that instead.
-                if (o.__str__ not in (i.__str__ for i in builtin_types) or
-                    o.__repr__ not in (i.__repr__ for i in builtin_types)):
+                if (type(o).__str__ not in (i.__str__ for i in builtin_types) or
+                    type(o).__repr__ not in (i.__repr__ for i in builtin_types)):
                     return False
                 return all(_can_print_latex(i) for i in o)
             elif isinstance(o, dict):

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -115,25 +115,39 @@ def test_builtin_containers():
     app.run_cell("inst = ip.instance()")
     app.run_cell("format = inst.display_formatter.format")
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
-    app.run_cell("from sympy import init_printing")
-    app.run_cell('init_printing(use_latex=True)')
+    app.run_cell("from sympy import init_printing, Matrix")
+    app.run_cell('init_printing(use_latex=True, use_unicode=False)')
 
     # Make sure containers that shouldn't pretty print don't.
     app.run_cell('a = format((True, False))')
     app.run_cell('import sys')
     app.run_cell('b = format(sys.flags)')
-
+    app.run_cell('c = format((Matrix([1, 2]),))')
     # Deal with API change starting at IPython 1.0
     if int(ipython.__version__.split(".")[0]) < 1:
         assert app.user_ns['a']['text/plain'] ==  '(True, False)'
         assert 'text/latex' not in app.user_ns['a']
         assert app.user_ns['b']['text/plain'][:10] == 'sys.flags('
         assert 'text/latex' not in app.user_ns['b']
+        assert app.user_ns['c']['text/plain'] == \
+"""\
+ [1]  \n\
+([ ],)
+ [2]  \
+"""
+        assert app.user_ns['c']['text/latex'] == '$$\\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )$$'
     else:
         assert app.user_ns['a'][0]['text/plain'] ==  '(True, False)'
         assert 'text/latex' not in app.user_ns['a'][0]
         assert app.user_ns['b'][0]['text/plain'][:10] == 'sys.flags('
         assert 'text/latex' not in app.user_ns['b'][0]
+        assert app.user_ns['c'][0]['text/plain'] == \
+"""\
+ [1]  \n\
+([ ],)
+ [2]  \
+"""
+        assert app.user_ns['c'][0]['text/latex'] == '$$\\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )$$'
 
 def test_matplotlib_bad_latex():
     # Initialize and setup IPython session

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -107,6 +107,30 @@ def test_print_builtin_option():
     # Python 2.7.5 + IPython 1.1.0 gives: '{pi: 3.14, n_i: 3}'
     assert text in ("{pi: 3.14, n_i: 3}", "{n_i: 3, pi: 3.14}")
 
+
+def test_builtin_containers():
+    # Initialize and setup IPython session
+    app = init_ipython_session()
+    app.run_cell("ip = get_ipython()")
+    app.run_cell("inst = ip.instance()")
+    app.run_cell("format = inst.display_formatter.format")
+    app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
+    app.run_cell("from sympy import init_printing")
+    app.run_cell('init_printing(use_latex=True)')
+
+    # Make sure containers that shouldn't pretty print don't.
+    app.run_cell('a = format((True, False))')
+    app.run_cell('import sys')
+    app.run_cell('b = format(sys.flags)')
+
+    # Deal with API change starting at IPython 1.0
+    if int(ipython.__version__.split(".")[0]) < 1:
+        assert app.user_ns['a']['text/plain'] == app.user_ns['a']['text/latex'] == '(True, False)'
+        assert app.user_ns['b']['text/plain'][:10] == app.user_ns['b']['text/latex'][:10] == 'sys.flags('
+    else:
+        assert app.user_ns['a'][0]['text/plain'] == app.user_ns['a'][0]['text/latex'] == '(True, False)'
+        assert app.user_ns['b'][0]['text/plain'][:10] == app.user_ns['b'][0]['text/latex'][:10] == 'sys.flags('
+
 def test_matplotlib_bad_latex():
     # Initialize and setup IPython session
     app = init_ipython_session()

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -125,11 +125,15 @@ def test_builtin_containers():
 
     # Deal with API change starting at IPython 1.0
     if int(ipython.__version__.split(".")[0]) < 1:
-        assert app.user_ns['a']['text/plain'] == app.user_ns['a']['text/latex'] == '(True, False)'
-        assert app.user_ns['b']['text/plain'][:10] == app.user_ns['b']['text/latex'][:10] == 'sys.flags('
+        assert app.user_ns['a']['text/plain'] ==  '(True, False)'
+        assert 'text/latex' not in app.user_ns['a']
+        assert app.user_ns['b']['text/plain'][:10] == 'sys.flags('
+        assert 'text/latex' not in app.user_ns['b']
     else:
-        assert app.user_ns['a'][0]['text/plain'] == app.user_ns['a'][0]['text/latex'] == '(True, False)'
-        assert app.user_ns['b'][0]['text/plain'][:10] == app.user_ns['b'][0]['text/latex'][:10] == 'sys.flags('
+        assert app.user_ns['a'][0]['text/plain'] ==  '(True, False)'
+        assert 'text/latex' not in app.user_ns['a'][0]
+        assert app.user_ns['b'][0]['text/plain'][:10] == 'sys.flags('
+        assert 'text/latex' not in app.user_ns['b'][0]
 
 def test_matplotlib_bad_latex():
     # Initialize and setup IPython session


### PR DESCRIPTION
For example, sys.flags should print like

sys.flags(debug=0, py3k_warning=0, division_warning=0, division_new=0,
inspect=0, interactive=0, optimize=0, dont_write_bytecode=0, no_user_site=0,
no_site=0, ignore_environment=0, tabcheck=0, verbose=0, unicode=0,
bytes_warning=0, hash_randomization=0)

but before this it would print as

(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0)

with init_printing() used.

There is a test failure here that I'm not yet sure how to fix.

<!-- BEGIN RELEASE NOTES -->
- interactive
  - `init_printing()` no longer LaTeX prints builtin container types that have custom printers (like `sys.flags`).