### PR TITLE
Remove unnecessary inner loop in matrix.nullspace

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -969,8 +969,7 @@ class MatrixSubspaces(MatrixReductions):
             vec = [S.Zero]*self.cols
             vec[free_var] = S.One
             for piv_row, piv_col in enumerate(pivots):
-                for pos in pivots[piv_row+1:] + (free_var,):
-                    vec[piv_col] -= reduced[piv_row, pos]
+                vec[piv_col] -= reduced[piv_row, free_var]
             basis.append(vec)
 
         return [self._new(self.cols, 1, b) for b in basis]


### PR DESCRIPTION
The inner loop would be needed if the matrix was only put in row echelon
form. However, since the matrix is reduced all pivot columns are zero
except for the pivot itself.

'.bin/test matrices' seem to pass

Please, please, double check this someone.

Fixes #14620 