### PR TITLE
Fix conditions for exceptions for Partition Numbers

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1162,18 +1162,19 @@ class partition(Function):
 
     @classmethod
     def eval(cls, n):
-        if not n.is_integer:
+        is_int = n.is_integer
+        if is_int == False:
             raise ValueError("Partition numbers are defined only for " +
                              "integers")
+        elif is_int:
+            if n.is_negative:
+                return S.Zero
 
-        if n.is_Integer:
-            return Integer(cls._partition(n))
+            if n.is_zero or (n - 1).is_zero:
+                return S.One
 
-        if n.is_negative:
-            return S.Zero
-
-        if n.is_zero or (n - 1).is_zero:
-            return S.One
+            if n.is_Integer:
+                return Integer(cls._partition(n))
 
 
     def _eval_is_integer(self):
@@ -1185,7 +1186,8 @@ class partition(Function):
             return False
 
     def _eval_is_positive(self):
-        if self.args[0].is_nonnegative:
+        n = self.args[0]
+        if n.is_nonnegative and n.is_integer:
             return True
 
 

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -403,6 +403,8 @@ def test_partition():
     for n, p in enumerate(partition_nums):
         assert partition(n) == p
 
+    x = Symbol('x')
+    y = Symbol('y', real=True)
     m = Symbol('m', integer=True)
     n = Symbol('n', integer=True, negative=True)
     p = Symbol('p', integer=True, nonnegative=True)
@@ -411,6 +413,8 @@ def test_partition():
     assert partition(m).is_nonnegative
     assert partition(n).is_zero
     assert partition(p).is_positive
+    assert partition(x).subs(x, 7) == 15
+    assert partition(y).subs(y, 8) == 22
     raises(ValueError, lambda: partition(S(5)/4))
 
 

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -403,8 +403,6 @@ def test_partition():
     for n, p in enumerate(partition_nums):
         assert partition(n) == p
 
-    x = Symbol('x')
-    y = Symbol('y', real=True)
     m = Symbol('m', integer=True)
     n = Symbol('n', integer=True, negative=True)
     p = Symbol('p', integer=True, nonnegative=True)
@@ -413,8 +411,6 @@ def test_partition():
     assert partition(m).is_nonnegative
     assert partition(n).is_zero
     assert partition(p).is_positive
-    raises(ValueError, lambda: partition(x))
-    raises(ValueError, lambda: partition(y))
     raises(ValueError, lambda: partition(S(5)/4))
 
 


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
#14617 Fix conditions for exceptions for partition

#### Brief description of what is fixed or changed
Exception is thrown only if `arg.is_integer` returns `False`.

#### Other comments
@smichr @asmeurer Thanks for the suggestion.