### PR TITLE
Checks 'None' after using match

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -19,6 +19,8 @@ from sympy.functions import hankel1, hankel2, jn, yn
 from sympy.functions.elementary.exponential import LambertW
 from sympy.functions.elementary.piecewise import Piecewise
 
+from sympy.simplify.radsimp import collect
+
 from sympy.logic.boolalg import And, Or
 from sympy.utilities.iterables import uniq
 

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -608,19 +608,20 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
 
         log_part, atan_part = [], []
 
-        x, y = symbols('x y', cls=Wild, exclude=[I])
         for poly in list(irreducibles):
-            m = poly.match(x + I*y)
-            if m is not None:
-                if m[y] == 0:  # No coefficient of I
-                    continue
-                pairs.add((m[x], m[y]))  # It is enough to save the coefficients
+            m = collect(poly, I, evaluate=False)
+            y = m.get(I, S.Zero)
+            if y:
+                x = m.get(S.One, S.Zero)
+                if x.has(I) or y.has(I):
+                    continue  # nontrivial x + I*y
+                pairs.add((x, y))
                 irreducibles.remove(poly)
 
         while pairs:
             x, y = pairs.pop()
-            if (x,-y) in pairs:
-                pairs.remove((x,-y))
+            if (x, -y) in pairs:
+                pairs.remove((x, -y))
                 # Choosing b with no minus sign
                 if y.could_extract_minus_sign():
                     y = -y

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -611,10 +611,11 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         x, y = symbols('x y', cls=Wild, exclude=[I])
         for poly in list(irreducibles):
             m = poly.match(x + I*y)
-            if m[y] == 0:  # No coefficient of I
-                continue
-            pairs.add((m[x], m[y]))  # It is enough to save the coefficients
-            irreducibles.remove(poly)
+            if m is not None:
+                if m[y] == 0:  # No coefficient of I
+                    continue
+                pairs.add((m[x], m[y]))  # It is enough to save the coefficients
+                irreducibles.remove(poly)
 
         while pairs:
             x, y = pairs.pop()


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy/issues/14624 .
Checked `m` for None value.
Output of this branch(It took very long time for this unsolved output): 
```
>>> sym.inverse_fourier_transform(a, w, -t)
R*InverseFourierTransform(1/(-lambda + I*omega), omega, -t) + InverseFourierTransform(1/(I*omega - conjugate(lambda)), omega, -t)*conjugate(R)
```
@asmeurer please review.