### PR TITLE
Corrects symbolic binomial base cases

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -828,18 +828,18 @@ class binomial(CombinatorialFunction):
     @classmethod
     def eval(cls, n, k):
         n, k = map(sympify, (n, k))
-        if k.is_zero:
+        d, nonneg = n - k, n.is_nonnegative
+        if k.is_zero or (nonneg and d.is_zero):
             return S.One
-        if (k - 1).is_zero:
+        if (k - 1).is_zero or (nonneg and (d - 1).is_zero):
             return n
         if k.is_integer:
-            if k.is_negative or (n.is_integer and n.is_nonnegative
-                    and (n - k).is_negative):
+            if k.is_negative or (nonneg and n.is_integer and d.is_negative):
                 return S.Zero
             elif n.is_number:
                 res = cls._eval(n, k)
                 return res.expand(basic=True) if res else res
-        elif n.is_negative and n.is_integer:
+        elif nonneg == False and n.is_integer:
             # a special case when binomial evaluates to complex infinity
             return S.ComplexInfinity
         elif k.is_number:

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -828,18 +828,21 @@ class binomial(CombinatorialFunction):
     @classmethod
     def eval(cls, n, k):
         n, k = map(sympify, (n, k))
-        d, nonneg = n - k, n.is_nonnegative
-        if k.is_zero or (nonneg and d.is_zero):
+        d = n - k
+        n_nonneg, n_isint = n.is_nonnegative, n.is_integer
+        if k.is_zero or ((n_nonneg or n_isint == False)
+                and d.is_zero):
             return S.One
-        if (k - 1).is_zero or (nonneg and (d - 1).is_zero):
+        if (k - 1).is_zero or ((n_nonneg or n_isint == False)
+                and (d - 1).is_zero):
             return n
         if k.is_integer:
-            if k.is_negative or (nonneg and n.is_integer and d.is_negative):
+            if k.is_negative or (n_nonneg and n_isint and d.is_negative):
                 return S.Zero
             elif n.is_number:
                 res = cls._eval(n, k)
                 return res.expand(basic=True) if res else res
-        elif nonneg == False and n.is_integer:
+        elif n_nonneg == False and n_isint:
             # a special case when binomial evaluates to complex infinity
             return S.ComplexInfinity
         elif k.is_number:

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -371,7 +371,7 @@ def test_binomial():
     assert binomial((1+2*I), (1+3*I)) == gamma(2 + 2*I)/(gamma(1 - I)*gamma(2 + 3*I))
     assert binomial(I, 5) == S(1)/3 - I/S(12)
     assert binomial((2*I + 3), 7) == -13*I/S(63)
-    assert isintance(binomial(I, n), binomial)
+    assert isinstance(binomial(I, n), binomial)
 
 
 def test_binomial_diff():

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -336,18 +336,13 @@ def test_binomial():
     assert binomial(a, b).is_nonnegative is True
 
     # issue #14625
-    assert binomial(a, a) == 1
-    assert binomial(a, a - 1) == a
+    for _ in (pi, -pi, nt, v, a):
+        assert binomial(_, _) == 1
+        assert binomial(_, _ - 1) == nt
     assert isinstance(binomial(u, u), binomial)
     assert isinstance(binomial(u, u - 1), binomial)
-    assert binomial(v, v) == 1
-    assert binomial(v, v - 1) == v
-    assert binomial(-pi, -pi - 1) == -pi
-    assert binomial(pi, pi - 1) == pi
-    assert binomial(pi, pi) == 1
-    assert binomial(-pi, -pi) == 1
-    assert isinstance(binomial(x, x - 1), binomial)
     assert isinstance(binomial(x, x), binomial)
+    assert isinstance(binomial(x, x - 1), binomial)
 
     # issue #13980 and #13981
     assert binomial(-7, -5) == 0
@@ -376,8 +371,7 @@ def test_binomial():
     assert binomial((1+2*I), (1+3*I)) == gamma(2 + 2*I)/(gamma(1 - I)*gamma(2 + 3*I))
     assert binomial(I, 5) == S(1)/3 - I/S(12)
     assert binomial((2*I + 3), 7) == -13*I/S(63)
-    assert binomial(I, n).func == binomial
-
+    assert isintance(binomial(I, n), binomial)
 
 
 def test_binomial_diff():

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -279,6 +279,7 @@ def test_binomial():
     kp = Symbol('kp', integer=True, positive=True)
     kn = Symbol('kn', integer=True, negative=True)
     u = Symbol('u', negative=True)
+    v = Symbol('v', nonnegative=True)
     p = Symbol('p', positive=True)
     z = Symbol('z', zero=True)
     nt = Symbol('nt', integer=False)
@@ -333,6 +334,14 @@ def test_binomial():
     assert binomial(4321, 51) == 124595639629264868916081001263541480185227731958274383287107643816863897851139048158022599533438936036467601690983780576
 
     assert binomial(a, b).is_nonnegative is True
+
+    # issue #14625
+    assert binomial(a, a) == 1
+    assert binomial(a, a - 1) == a
+    assert isinstance(binomial(u, u), binomial)
+    assert isinstance(binomial(u, u - 1), binomial)
+    assert binomial(v, v) == 1
+    assert binomial(v, v - 1) == v
 
     # issue #13980 and #13981
     assert binomial(-7, -5) == 0

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -342,6 +342,12 @@ def test_binomial():
     assert isinstance(binomial(u, u - 1), binomial)
     assert binomial(v, v) == 1
     assert binomial(v, v - 1) == v
+    assert binomial(-pi, -pi - 1) == -pi
+    assert binomial(pi, pi - 1) == pi
+    assert binomial(pi, pi) == 1
+    assert binomial(-pi, -pi) == 1
+    assert isinstance(binomial(x, x - 1), binomial)
+    assert isinstance(binomial(x, x), binomial)
 
     # issue #13980 and #13981
     assert binomial(-7, -5) == 0

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -338,7 +338,7 @@ def test_binomial():
     # issue #14625
     for _ in (pi, -pi, nt, v, a):
         assert binomial(_, _) == 1
-        assert binomial(_, _ - 1) == nt
+        assert binomial(_, _ - 1) == _
     assert isinstance(binomial(u, u), binomial)
     assert isinstance(binomial(u, u - 1), binomial)
     assert isinstance(binomial(x, x), binomial)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #14625 
Reference to #14575 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
Added the following conditions in base cases for binomial eval: (where `d = n - k`)
`if k.is_zero or (n.is_nonnegative and d.is_zero)`
`if (k - 1).is_zero or (n.is_nonnegative and (d - 1).is_zero)`

