### PR TITLE
Reduces nested floor ceiling expressions

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -122,9 +122,8 @@ class floor(RoundFunction):
     def _eval_number(cls, arg):
         if arg.is_Number:
             return arg.floor()
-        elif any(isinstance(i, ceiling) for i in (arg, -arg)):
-            return arg
-        elif any(isinstance(i, floor) for i in (arg, -arg)):
+        elif any(isinstance(i, j)
+                for i in (arg, -arg) for j in (floor, ceiling)):
             return arg
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[0]
@@ -195,9 +194,8 @@ class ceiling(RoundFunction):
     def _eval_number(cls, arg):
         if arg.is_Number:
             return arg.ceiling()
-        elif any(isinstance(i, ceiling) for i in (arg, -arg)):
-            return arg
-        elif any(isinstance(i, floor) for i in (arg, -arg)):
+        elif any(isinstance(i, j)
+                for i in (arg, -arg) for j in (floor, ceiling)):
             return arg
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[1]

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -122,9 +122,9 @@ class floor(RoundFunction):
     def _eval_number(cls, arg):
         if arg.is_Number:
             return arg.floor()
-        elif isinstance(arg, ceiling):
+        elif any(isinstance(i, ceiling) for i in (arg, -arg)):
             return arg
-        elif isinstance(arg, floor):
+        elif any(isinstance(i, floor) for i in (arg, -arg)):
             return arg
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[0]
@@ -195,9 +195,9 @@ class ceiling(RoundFunction):
     def _eval_number(cls, arg):
         if arg.is_Number:
             return arg.ceiling()
-        elif isinstance(arg, ceiling):
+        elif any(isinstance(i, ceiling) for i in (arg, -arg)):
             return arg
-        elif isinstance(arg, floor):
+        elif any(isinstance(i, floor) for i in (arg, -arg)):
             return arg
         if arg.is_NumberSymbol:
             return arg.approximation_interval(Integer)[1]

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -258,8 +258,16 @@ def test_issue_4149():
     assert floor(3*I + pi*I + y*I) == floor(3 + pi + y)*I
     assert floor(3 + E + pi*I + y*I) == 5 + floor(pi + y)*I
 
+
 def test_issue_11207():
     assert floor(floor(x)) == floor(x)
     assert floor(ceiling(x)) == ceiling(x)
     assert ceiling(floor(x)) == floor(x)
     assert ceiling(ceiling(x)) == ceiling(x)
+
+
+def test_nested_floor_ceiling():
+    assert floor(-floor(ceiling(x**3)/y)) == -floor(ceiling(x**3)/y)
+    assert ceiling(-floor(ceiling(x**3)/y)) == -floor(ceiling(x**3)/y)
+    assert floor(ceiling(-floor(x**Rational(7, 2)/y))) == -floor(x**Rational(7, 2)/y)
+    assert -ceiling(-ceiling(floor(x)/y)) == ceiling(floor(x)/y)


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #14630

#### Brief description of what is fixed or changed
Detect negative instances of floor and ceiling functions
```python
>>> -ceiling(-ceiling(floor(x)/y))
⎡⌊x⌋⎤
⎢───⎥
⎢ y ⎥
```
#### Other comments
