### PR TITLE
 Implement Polygon.distance for overlapped polygons

### DIFF
--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1262,7 +1262,7 @@ class Polygon(GeometrySet):
 
             e2_segment = Segment(e2_current, e2_next)
             min_dist_current = e2_segment.distance(e1_current)
-            if min_dist_current.evalf() < min_dist.evalf():
+            if min_dist_current < min_dist:
                 min_dist = min_dist_current
 
         return min_dist

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1108,7 +1108,7 @@ class Polygon(GeometrySet):
         >>> e1 = Polygon(Point(0, 0), Point(0, 1), Point(1, 1), Point(1, 0))
         >>> e2 = Polygon(Point(0, 2), Point(0, 3), Point(1, 3), Point(1, 2))
         >>> e1.critical_support_lines(e2)
-        [Line2D(Point2D(1, 1), Point2D(0, 2)), Line2D(Point2D(0, 1), Point2D(1, 2))]
+        [Line2D(Point2D(0, 1), Point2D(1, 2)), Line2D(Point2D(1, 1), Point2D(0, 2))]
 
         References
         ==========
@@ -1130,7 +1130,7 @@ class Polygon(GeometrySet):
         >>> e1 = Polygon((-1, 0), (0, 1), (1, 0), (0, -1))
         >>> e2 = Polygon((2, 0), (3, 0), (3, 1), (2, 1))
         >>> e1.bridges(e2)
-        [Line2D(Point2D(0, 1), Point2D(2, 1)), Line2D(Point2D(0, -1), Point2D(3, 0))]
+        [Line2D(Point2D(0, -1), Point2D(3, 0)), Line2D(Point2D(0, 1), Point2D(3, 1))]
 
         References
         ==========
@@ -1154,7 +1154,7 @@ class Polygon(GeometrySet):
         >>> e1 = Polygon((-1, 0), (0, 1), (1, 0), (0, -1))
         >>> e2 = Polygon((2, 0), (3, 0), (3, 1), (2, 1))
         >>> e1._bridges(e2)
-        [Line2D(Point2D(0, 1), Point2D(2, 1)), Line2D(Point2D(0, -1), Point2D(3, 0))]
+        [Line2D(Point2D(0, -1), Point2D(3, 0)), Line2D(Point2D(0, 1), Point2D(3, 1))]
 
         References
         ==========
@@ -1190,7 +1190,7 @@ class Polygon(GeometrySet):
         >>> e1 = Polygon(Point(0, 0), Point(0, 1), Point(1, 1), Point(1, 0))
         >>> e2 = Polygon(Point(0, 2), Point(0, 3), Point(1, 3), Point(1, 2))
         >>> e1.critical_support_lines(e2)
-        [Line2D(Point2D(1, 1), Point2D(0, 2)), Line2D(Point2D(0, 1), Point2D(1, 2))]
+        [Line2D(Point2D(0, 1), Point2D(1, 2)), Line2D(Point2D(1, 1), Point2D(0, 2))]
 
         References
         ==========

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1383,7 +1383,7 @@ class Polygon(GeometrySet):
         pts = list(p.args)
         pts.append(pts[0])  # close it
         cw = Polygon._isright(*pts[:3])
-        if cw:
+        if cw == 1:
             pts = list(reversed(pts))
         for v, a in p.angles.items():
             i = pts.index(v)
@@ -2827,7 +2827,7 @@ class Triangle(Polygon):
         return Line(self.orthocenter, self.circumcenter)
 
 
-class _PodalPair(Iterator):
+class _PodalPair(object):
     """
     An iterable for generating (anti)podal pairs.
 

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -103,10 +103,8 @@ def test_polygon():
         Polygon(Point(10, 10), Point(14, 14), Point(10, 14))) == 6 * sqrt(2)
     assert p5.distance(
         Polygon(Point(1, 8), Point(5, 8), Point(8, 12), Point(1, 12))) == 4
-    with warns(UserWarning, \
-               match="Polygons may intersect producing erroneous output"):
-        Polygon(Point(0, 0), Point(1, 0), Point(1, 1)).distance(
-                Polygon(Point(0, 0), Point(0, 1), Point(1, 1)))
+    Polygon(Point(0, 0), Point(1, 0), Point(1, 1)).distance(
+            Polygon(Point(0, 0), Point(0, 1), Point(1, 1))) == 0
     assert hash(p5) == hash(Polygon(Point(0, 0), Point(4, 4), Point(0, 4)))
     assert hash(p1) == hash(p2)
     assert hash(p7) == hash(p8)
@@ -313,16 +311,11 @@ def test_polygon():
 
     '''Polygon to Polygon'''
     # p1.distance(p2) emits a warning
-    with warns(UserWarning, \
-               match="Polygons may intersect producing erroneous output"):
-        assert p1.distance(p2) == half/2
-
+    assert p1.distance(p2) == half/2
     assert p1.distance(p3) == sqrt(2)/2
 
     # p3.distance(p4) emits a warning
-    with warns(UserWarning, \
-               match="Polygons may intersect producing erroneous output"):
-        assert p3.distance(p4) == (sqrt(2)/2 - sqrt(Rational(2)/25)/2)
+    assert p3.distance(p4) == (sqrt(2)/2 - sqrt(Rational(2)/25)/2)
 
     # Now, test overlaping
     p = Polygon((0, 0), (0, 1), (1, 1), (1, 0))

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -4,7 +4,7 @@ from sympy.functions.elementary.trigonometric import tan
 from sympy.geometry import (Circle, Ellipse, GeometryError, Point, Point2D, \
                             Polygon, Ray, RegularPolygon, Segment, Triangle, \
                             are_similar, convex_hull, intersection, Line, Ray2D)
-from sympy.testing.pytest import raises, slow, warns
+from sympy.testing.pytest import raises, slow
 from sympy.testing.randtest import verify_numerically
 from sympy.geometry.polygon import rad, deg
 from sympy import integrate

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -340,15 +340,29 @@ def test_polygon():
     assert p.distance(p6) == 1/2
 
     # Critical support lines
-    assert set(p.critical_support_lines(p1)) == set([Line(Point(1, 1), Point(2, 0)), Line(Point(1, 0), Point(sqrt(2)/2 + 2, sqrt(2)/2))])
+    assert set(p.critical_support_lines(p1)) == set([
+        Line(Point(1, 1), Point(2, 0)),
+        Line(Point(1, 0), Point(sqrt(2)/2 + 2, sqrt(2)/2))
+    ])
     assert p.critical_support_lines(p2) == [Line(Point(1, 0), Point(1, 1/2))]
     assert p.critical_support_lines(p3) == [Line(Point(0, 0), Point(2, 0))]
     assert p.critical_support_lines(p5) == []
     assert p.critical_support_lines(p6) == []
 
     # Bridges
-    assert set(p.bridges(p1)) == set([Line(Point(1, 1), Point(sqrt(2)/2 + 2, sqrt(2)/2)), Line(Point(0, 0), Point(sqrt(2)/2 + 2, -sqrt(2)/2))])
-    assert set(p.bridges(p4)) == set([Line(Point(1, 1), Point(-sqrt(2)/2 + 1, 1/2 + sqrt(2)/2)), Line(Point(1, 0), Point(1, 1/2)), Line(Point(1, 0), Point(-sqrt(2)/2 + 1, -sqrt(2)/2 + 1/2)), Line(Point(0, 0), Point(-sqrt(2)/2 + 1, -sqrt(2)/2 + 1/2)), Line(Point(0, 0), Point(-sqrt(2) + 1, 1/2)), Line(Point(0, 1), Point(-sqrt(2) + 1, 1/2)), Line(Point(0, 1), Point(-sqrt(2)/2 + 1, 1/2 + sqrt(2)/2))])
+    assert set(p.bridges(p1)) == set([
+        Line(Point(1, 1), Point(sqrt(2)/2 + 2, sqrt(2)/2)),
+        Line(Point(0, 0), Point(sqrt(2)/2 + 2, -sqrt(2)/2))
+    ])
+    assert set(p.bridges(p4)) == set([
+        Line(Point(1, 1), Point(-sqrt(2)/2 + 1, 1/2 + sqrt(2)/2)),
+        Line(Point(1, 0), Point(1, 1/2)),
+        Line(Point(1, 0), Point(-sqrt(2)/2 + 1, -sqrt(2)/2 + 1/2)),
+        Line(Point(0, 0), Point(-sqrt(2)/2 + 1, -sqrt(2)/2 + 1/2)),
+        Line(Point(0, 0), Point(-sqrt(2) + 1, 1/2)),
+        Line(Point(0, 1), Point(-sqrt(2) + 1, 1/2)),
+        Line(Point(0, 1), Point(-sqrt(2)/2 + 1, 1/2 + sqrt(2)/2))
+    ])
     assert p.bridges(p5) == []
     assert p.bridges(p6) == []
 

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -316,6 +316,7 @@ def test_polygon():
     with warns(UserWarning, \
                match="Polygons may intersect producing erroneous output"):
         assert p1.distance(p2) == half/2
+    assert p1.distance(p2) == half/2
 
     assert p1.distance(p3) == sqrt(2)/2
 
@@ -323,6 +324,33 @@ def test_polygon():
     with warns(UserWarning, \
                match="Polygons may intersect producing erroneous output"):
         assert p3.distance(p4) == (sqrt(2)/2 - sqrt(Rational(2)/25)/2)
+
+    # Now, test overlaping
+    p = Polygon((0, 0), (0, 1), (1, 1), (1, 0))
+    p1 = p.translate(2, -1).rotate('pi/4', (2, 0)) # disjoint
+    p2 = p.translate(1, -0.5) # side-side overlap
+    p3 = p.translate(1, -1) # vertex-vertex overlap
+    p4 = p.rotate('pi/4', (1, 0)).translate(0, 0.5) # overlap
+    p5 = p.scale(0.5, 0.5, (0.5, 0.5)) # containing
+    p6 = p.scale(2, 2, (0.5, 0.5)) # contained
+    assert p.distance(p2) == 0
+    assert p.distance(p3) == 0
+    assert p.distance(p4) == 0
+    assert p.distance(p5) == 1/4
+    assert p.distance(p6) == 1/2
+
+    # Critical support lines
+    assert set(p.critical_support_lines(p1)) == set([Line(Point(1, 1), Point(2, 0)), Line(Point(1, 0), Point(sqrt(2)/2 + 2, sqrt(2)/2))])
+    assert p.critical_support_lines(p2) == [Line(Point(1, 0), Point(1, 1/2))]
+    assert p.critical_support_lines(p3) == [Line(Point(0, 0), Point(2, 0))]
+    assert p.critical_support_lines(p5) == []
+    assert p.critical_support_lines(p6) == []
+
+    # Bridges
+    assert set(p.bridges(p1)) == set([Line(Point(1, 1), Point(sqrt(2)/2 + 2, sqrt(2)/2)), Line(Point(0, 0), Point(sqrt(2)/2 + 2, -sqrt(2)/2))])
+    assert set(p.bridges(p4)) == set([Line(Point(1, 1), Point(-sqrt(2)/2 + 1, 1/2 + sqrt(2)/2)), Line(Point(1, 0), Point(1, 1/2)), Line(Point(1, 0), Point(-sqrt(2)/2 + 1, -sqrt(2)/2 + 1/2)), Line(Point(0, 0), Point(-sqrt(2)/2 + 1, -sqrt(2)/2 + 1/2)), Line(Point(0, 0), Point(-sqrt(2) + 1, 1/2)), Line(Point(0, 1), Point(-sqrt(2) + 1, 1/2)), Line(Point(0, 1), Point(-sqrt(2)/2 + 1, 1/2 + sqrt(2)/2))])
+    assert p.bridges(p5) == []
+    assert p.bridges(p6) == []
 
 
 def test_convex_hull():

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -316,7 +316,6 @@ def test_polygon():
     with warns(UserWarning, \
                match="Polygons may intersect producing erroneous output"):
         assert p1.distance(p2) == half/2
-    assert p1.distance(p2) == half/2
 
     assert p1.distance(p3) == sqrt(2)/2
 
@@ -686,12 +685,8 @@ def test_do_poly_distance():
 
     # Polygons which sides intersect
     square2 = Polygon(Point(1, 0), Point(2, 0), Point(2, 1), Point(1, 1))
-    with warns(UserWarning, \
-               match="Polygons may intersect producing erroneous output"):
-        assert square1._do_poly_distance(square2) == 0
+    assert square1._do_poly_distance(square2) == 0
 
     # Polygons which bodies intersect
     triangle2 = Polygon(Point(0, -1), Point(2, -1), Point(S.Half, S.Half))
-    with warns(UserWarning, \
-               match="Polygons may intersect producing erroneous output"):
-        assert triangle2._do_poly_distance(square1) == 0
+    assert triangle2._do_poly_distance(square1) == 0


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Main points:
- At present, `Polygon.distance` raises a warning when the two polygons are detected to be possibly overlapping, while this pr gives an correct detection of overlapping then calculates the distance with slightly different methods according to their relationship disjoint/overlapping/nested. Both detection of overlapping and calculation use rotating calipers.

Other changes:
- `Polygon._isright` now returns `-1`, `0`, `1` for left/collinear/right
- Replaced `e1_connections` in `_do_poly_distance` with an iterator `e1_vertices`.
- Abstracted an iterator `_PodalPair`
- Implemented by the way two methods `critical_support_lines` and `bridges`

Bugs fixed:
- Present code in `Polygon._do_poly_distance` writes `if (e1_angle < e2_angle) is True:`, while `e1_angle < e2_angle` is a `Boolean` object rather than a built-in `bool` type.

<!-- BEGIN RELEASE NOTES -->
* geometry
  * Implemented `Polygon.distance` for overlapping polygons.
  * Implemented `Polygon.critical_support_lines`.
  * Implemented `Polygon.bridges`.
<!-- END RELEASE NOTES -->