### PR TITLE
Implemented _eval_Mod methods for binomial, factorial

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -201,7 +201,7 @@ class factorial(CombinatorialFunction):
         if x.is_integer and x.is_nonnegative and q.is_integer:
             aq = abs(q)
             d = aq - x
-            if d.is_negative:
+            if d.is_nonpositive:
                 return 0
             else:
                 isprime = aq.is_prime

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -175,7 +175,14 @@ class factorial(CombinatorialFunction):
 
     def _facmod(self, n, q):
         res, N = 1, int(_sqrt(n))
-        m, pw = 2, [1]*N
+
+        # exponent of prime p in n! is e_p(n) = [n/p] + [n/p**2] + ...
+        # for p > sqrt(n), e_p(n) < sqrt(n), the primes with [n/p] = m,
+        # occur consecutively and are grouped together in pw[m] for
+        # simultaneous exponentiation at a later stage
+        pw = [1]*N
+
+        m = 2 # to initialize the if condition below
         for prime in sieve.primerange(2, n + 1):
             if m > 1:
                 m, y = 0, n // prime

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -165,6 +165,22 @@ def test_factorial():
     assert factorial(oo) == oo
 
 
+def test_factorial_Mod():
+    pr = Symbol('pr', prime=True)
+    p, q = 10**9 + 9, 10**9 + 33 # prime modulo
+    r, s = 10**7 + 5, 33333333 # composite modulo
+    assert Mod(factorial(pr - 1), pr) == pr - 1
+    assert Mod(factorial(pr - 1), -pr) == -1
+    assert Mod(factorial(r - 1, evaluate=False), r) == 0
+    assert Mod(factorial(s - 1, evaluate=False), s) == 0
+    assert Mod(factorial(p - 1, evaluate=False), p) == p - 1
+    assert Mod(factorial(q - 1, evaluate=False), q) == q - 1
+    assert Mod(factorial(p - 50, evaluate=False), p) == 854928834
+    assert Mod(factorial(q - 1800, evaluate=False), q) == 905504050
+    assert Mod(factorial(153, evaluate=False), r) == Mod(factorial(153), r)
+    assert Mod(factorial(255, evaluate=False), s) == Mod(factorial(255), s)
+
+
 def test_factorial_diff():
     n = Symbol('n', integer=True)
 
@@ -334,6 +350,13 @@ def test_binomial():
     assert binomial(4321, 51) == 124595639629264868916081001263541480185227731958274383287107643816863897851139048158022599533438936036467601690983780576
 
     assert binomial(a, b).is_nonnegative is True
+    assert binomial(-1, 2, evaluate=False).is_nonnegative is True
+    assert binomial(10, 5, evaluate=False).is_nonnegative is True
+    assert binomial(10, -3, evaluate=False).is_nonnegative is True
+    assert binomial(-10, -3, evaluate=False).is_nonnegative is True
+    assert binomial(-10, 2, evaluate=False).is_nonnegative is True
+    assert binomial(-10, 1, evaluate=False).is_nonnegative is False
+    assert binomial(-10, 7, evaluate=False).is_nonnegative is False
 
     # issue #14625
     for _ in (pi, -pi, nt, v, a):
@@ -372,6 +395,27 @@ def test_binomial():
     assert binomial(I, 5) == S(1)/3 - I/S(12)
     assert binomial((2*I + 3), 7) == -13*I/S(63)
     assert isinstance(binomial(I, n), binomial)
+
+
+def test_binomial_Mod():
+    p, q = 10**5 + 3, 10**9 + 33 # prime modulo
+    r, s = 10**7 + 5, 33333333 # composite modulo
+
+    # Lucas Theorem
+    assert Mod(binomial(156675, 4433, evaluate=False), p) == Mod(binomial(156675, 4433), p)
+    assert Mod(binomial(123456, 43253, evaluate=False), p) == Mod(binomial(123456, 43253), p)
+    assert Mod(binomial(177911, 23856, evaluate=False), p) == Mod(binomial(177911, 23856), p)
+
+    # factorial Mod
+    assert Mod(binomial(1234, 432, evaluate=False), q) == Mod(binomial(1234, 432), q)
+    assert Mod(binomial(9734, 451, evaluate=False), q) == Mod(binomial(9734, 451), q)
+    assert Mod(binomial(10733, 4459, evaluate=False), q) == Mod(binomial(10733, 4459), q)
+
+    # binomial factorize
+    assert Mod(binomial(253, 113, evaluate=False), r) == Mod(binomial(253, 113), r)
+    assert Mod(binomial(753, 119, evaluate=False), r) == Mod(binomial(753, 119), r)
+    assert Mod(binomial(3781, 948, evaluate=False), s) == Mod(binomial(3781, 948), s)
+    assert Mod(binomial(25773, 1793, evaluate=False), s) == Mod(binomial(25773, 1793), s)
 
 
 def test_binomial_diff():

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -404,18 +404,22 @@ def test_binomial_Mod():
     # Lucas Theorem
     assert Mod(binomial(156675, 4433, evaluate=False), p) == Mod(binomial(156675, 4433), p)
     assert Mod(binomial(123456, 43253, evaluate=False), p) == Mod(binomial(123456, 43253), p)
-    assert Mod(binomial(177911, 23856, evaluate=False), p) == Mod(binomial(177911, 23856), p)
+    assert Mod(binomial(-178911, 237, evaluate=False), p) == Mod(-binomial(178911 + 237 - 1, 237), p)
+    assert Mod(binomial(-178911, 238, evaluate=False), p) == Mod(binomial(178911 + 238 - 1, 238), p)
 
     # factorial Mod
     assert Mod(binomial(1234, 432, evaluate=False), q) == Mod(binomial(1234, 432), q)
     assert Mod(binomial(9734, 451, evaluate=False), q) == Mod(binomial(9734, 451), q)
-    assert Mod(binomial(10733, 4459, evaluate=False), q) == Mod(binomial(10733, 4459), q)
+    assert Mod(binomial(-10733, 4459, evaluate=False), q) == Mod(binomial(-10733, 4459), q)
+    assert Mod(binomial(-15733, 4458, evaluate=False), q) == Mod(binomial(-15733, 4458), q)
 
     # binomial factorize
     assert Mod(binomial(253, 113, evaluate=False), r) == Mod(binomial(253, 113), r)
     assert Mod(binomial(753, 119, evaluate=False), r) == Mod(binomial(753, 119), r)
     assert Mod(binomial(3781, 948, evaluate=False), s) == Mod(binomial(3781, 948), s)
     assert Mod(binomial(25773, 1793, evaluate=False), s) == Mod(binomial(25773, 1793), s)
+    assert Mod(binomial(-753, 118, evaluate=False), r) == Mod(binomial(-753, 118), r)
+    assert Mod(binomial(-25773, 1793, evaluate=False), s) == Mod(binomial(-25773, 1793), s)
 
 
 def test_binomial_diff():

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1008,7 +1008,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
         if x >= 20:
             factors = {}
             m = 2 # to initialize the if condition below
-            for p in sieve.primerange(2, x):
+            for p in sieve.primerange(2, x + 1):
                 if m > 1:
                     m, q = 0, x // p
                     while q != 0:

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -179,6 +179,9 @@ def test_factorint():
         {2: 11, 3: 6, 5: 3, 7: 2, 11: 1, 13: 1}
     assert factorint(fac(20, evaluate=False)) == \
         {2: 18, 3: 8, 5: 4, 7: 2, 11: 1, 13: 1, 17: 1, 19: 1}
+    assert factorint(fac(23, evaluate=False)) == \
+        {2: 19, 3: 9, 5: 4, 7: 3, 11: 2, 13: 1, 17: 1, 19: 1, 23: 1}
+
     assert multiproduct(factorint(fac(200))) == fac(200)
     assert multiproduct(factorint(fac(200, evaluate=False))) == fac(200)
     for b, e in factorint(fac(150)).items():


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Changes made in this PR:
1. `factorial`: Added method `_facmod` for evaluation in `_eval_Mod`.
2. `binomial`: Added method `_eval_Mod`, improved `_eval_is_nonnegative` and `_eval_expand_func`.

Brief Summary of Implementation:
`p`: prime modulo, `m`: composite modulo

`factorial`:
1. `_facmod` uses `Legendre's Formula` for calculation with speed-up by collecting primes for same powers.
2. `_eval_Mod` can now compute following type of factorials :
`x! mod p` (even for large `p`) where `x` is either close to `0` or close to `p`
`x! mod m`

`binomial`:
`_eval_Mod` uses `3` different approaches for calculation:
1. `binomial(n, k) mod p` uses `Lucas Theorem`, for `p < n` - `O(p * lg(n))`
2. `binomial(n, k) mod p` uses `factorial mod`, for `n < p` - `O(n + lg(p))`
3. `binomial(n, k) mod m` uses `binomial factorization` (similar to the one used before #14576)

