### PR TITLE
Add factoring to compute certain sums with negative exponents

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1056,7 +1056,13 @@ def eval_sum_symbolic(f, limits):
         if not r in (None, S.NaN):
             return r
 
-    return eval_sum_hyper(f_orig, (i, a, b))
+    h = eval_sum_hyper(f_orig, (i, a, b))
+    if h is not None:
+        return h
+
+    factored = f_orig.factor()
+    if factored != f_orig:
+        return eval_sum_symbolic(factored, (i, a, b))
 
 
 def _eval_sum_hyper(f, i, a):

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1012,17 +1012,39 @@ def test_issue_10156():
     assert e.factor() == \
         8*y**3*Sum(x, (x, 1, 3))*Sum(x**2, (x, 1, 9))
 
+
 def test_issue_14112():
     assert Sum((-1)**n/sqrt(n), (n, 1, oo)).is_absolutely_convergent() is S.false
     assert Sum((-1)**(2*n)/n, (n, 1, oo)).is_convergent() is S.false
     assert Sum((-2)**n + (-3)**n, (n, 1, oo)).is_convergent() is S.false
 
+
 def test_sin_times_absolutely_convergent():
     assert Sum(sin(n) / n**3, (n, 1, oo)).is_convergent() is S.true
     assert Sum(sin(n) * log(n) / n**3, (n, 1, oo)).is_convergent() is S.true
 
+
 def test_issue_14111():
     assert Sum(1/log(log(n)), (n, 22, oo)).is_convergent() is S.false
 
+
 def test_issue_14484():
     raises(NotImplementedError, lambda: Sum(sin(n)/log(log(n)), (n, 22, oo)).is_convergent())
+
+
+def test_issue_14640():
+    i, n = symbols("i n", integer=True)
+    a, b, c = symbols("a b c")
+
+    assert Sum(a**-i/(a - b), (i, 0, n)).doit() == Sum(
+        1/(a*a**i - a**i*b), (i, 0, n)).doit() == Piecewise(
+            (n + 1, Eq(1/a, 1)),
+            ((-a**(-n - 1) + 1)/(1 - 1/a), True))/(a - b)
+
+    assert Sum((b*a**i - c*a**i)**-2, (i, 0, n)).doit() == Piecewise(
+        (n + 1, Eq(a**(-2), 1)),
+        ((-a**(-2*n - 2) + 1)/(1 - 1/a**2), True))/(b - c)**2
+
+    s = Sum(i*(a**(n - i) - b**(n - i))/(a - b), (i, 0, n)).doit()
+    assert not s.has(Sum)
+    assert s.subs({a: 2, b: 3, n: 5}) == 122


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14640.

#### Brief description of what is fixed or changed

Factoring added in `eval_sum_symbolic` to allow computing a closed form for sums like `Sum(a**-i/(a - b), (i, 0, n))`.

#### Other comments

The last testcase, `Sum(i*(a**(n - i) - b**(n - i))/(a - b), (i, 0, n)).doit()`, requires factoring as the last step of `eval_sum_symbolic`: The sum body first needs to be expanded to `a**n*i/(a*a**i - a**i*b) - b**n*i/(a*b**i - b*b**i)`, then each term in the `Add` needs separate factoring so that `a**n*i/(a*a**i - a**i*b)` becomes `a**(-i)*a**n*i/(a - b)` which can then be handled by `gosper_sum`.