### PR TITLE
Improves Floor and Ceiling classes

### DIFF
--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -147,6 +147,12 @@ class floor(RoundFunction):
     def _eval_rewrite_as_frac(self, arg):
         return arg - frac(arg)
 
+    def _eval_Eq(self, other):
+        if isinstance(self, floor):
+            if (self.rewrite(ceiling) == other) or \
+                    (self.rewrite(frac) == other):
+                return S.true
+
     def __le__(self, other):
         if self.args[0] == other and other.is_real:
             return S.true
@@ -224,6 +230,12 @@ class ceiling(RoundFunction):
 
     def _eval_rewrite_as_frac(self, arg):
         return arg + frac(-arg)
+
+    def _eval_Eq(self, other):
+        if isinstance(self, ceiling):
+            if (self.rewrite(floor) == other) or \
+                    (self.rewrite(frac) == other):
+                return S.true
 
     def __lt__(self, other):
         if self.args[0] == other and other.is_real:
@@ -326,3 +338,9 @@ class frac(Function):
 
     def _eval_rewrite_as_ceiling(self, arg):
         return arg + ceiling(-arg)
+
+    def _eval_Eq(self, other):
+        if isinstance(self, frac):
+            if (self.rewrite(floor) == other) or \
+                    (self.rewrite(ceiling) == other):
+                return S.true

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -141,6 +141,12 @@ class floor(RoundFunction):
         else:
             return r
 
+    def _eval_rewrite_as_ceiling(self, arg):
+        return -ceiling(-arg)
+
+    def _eval_rewrite_as_frac(self, arg):
+        return arg - frac(arg)
+
     def __le__(self, other):
         if self.args[0] == other and other.is_real:
             return S.true
@@ -212,6 +218,12 @@ class ceiling(RoundFunction):
                 return r
         else:
             return r
+
+    def _eval_rewrite_as_floor(self, arg):
+        return -floor(-arg)
+
+    def _eval_rewrite_as_frac(self, arg):
+        return arg + frac(-arg)
 
     def __lt__(self, other):
         if self.args[0] == other and other.is_real:
@@ -311,3 +323,6 @@ class frac(Function):
 
     def _eval_rewrite_as_floor(self, arg):
         return arg - floor(arg)
+
+    def _eval_rewrite_as_ceiling(self, arg):
+        return arg + ceiling(-arg)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -112,6 +112,13 @@ def test_floor():
     assert (floor(x) <= y).is_Relational  # arg is not same as rhs
     assert (floor(x) > y).is_Relational
 
+    assert floor(y).rewrite(frac) == y - frac(y)
+    assert floor(y).rewrite(ceiling) == -ceiling(-y)
+    assert floor(y).rewrite(frac).subs(y, -pi) == floor(-pi)
+    assert floor(y).rewrite(frac).subs(y, E) == floor(E)
+    assert floor(y).rewrite(ceiling).subs(y, E) == -ceiling(-E)
+    assert floor(y).rewrite(ceiling).subs(y, -pi) == -ceiling(pi)
+
 
 def test_ceiling():
 
@@ -217,6 +224,13 @@ def test_ceiling():
     assert (ceiling(x) >= y).is_Relational  # arg is not same as rhs
     assert (ceiling(x) < y).is_Relational
 
+    assert ceiling(y).rewrite(floor) == -floor(-y)
+    assert ceiling(y).rewrite(frac) == y + frac(-y)
+    assert ceiling(y).rewrite(floor).subs(y, -pi) == -floor(pi)
+    assert ceiling(y).rewrite(floor).subs(y, E) == -floor(-E)
+    assert ceiling(y).rewrite(frac).subs(y, pi) == ceiling(pi)
+    assert ceiling(y).rewrite(frac).subs(y, -E) == ceiling(-E)
+
 
 def test_frac():
     assert isinstance(frac(x), frac)
@@ -238,6 +252,10 @@ def test_frac():
     assert frac(x + I*n) == frac(x)
 
     assert frac(x).rewrite(floor) == x - floor(x)
+    assert frac(y).rewrite(floor).subs(y, pi) == frac(pi)
+    assert frac(y).rewrite(floor).subs(y, -E) == frac(-E)
+    assert frac(y).rewrite(ceiling).subs(y, -pi) == frac(-pi)
+    assert frac(y).rewrite(ceiling).subs(y, E) == frac(E)
 
 
 def test_series():

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -1,5 +1,5 @@
 from sympy import AccumBounds, Symbol, floor, nan, oo, zoo, E, symbols, \
-        ceiling, pi, Rational, Float, I, sin, exp, log, factorial, frac
+        ceiling, pi, Rational, Float, I, sin, exp, log, factorial, frac, Eq
 
 from sympy.utilities.pytest import XFAIL
 
@@ -119,6 +119,9 @@ def test_floor():
     assert floor(y).rewrite(ceiling).subs(y, E) == -ceiling(-E)
     assert floor(y).rewrite(ceiling).subs(y, -pi) == -ceiling(pi)
 
+    assert Eq(floor(y), y - frac(y))
+    assert Eq(floor(y), -ceiling(-y))
+
 
 def test_ceiling():
 
@@ -231,6 +234,9 @@ def test_ceiling():
     assert ceiling(y).rewrite(frac).subs(y, pi) == ceiling(pi)
     assert ceiling(y).rewrite(frac).subs(y, -E) == ceiling(-E)
 
+    assert Eq(ceiling(y), y + frac(-y))
+    assert Eq(ceiling(y), -floor(-y))
+
 
 def test_frac():
     assert isinstance(frac(x), frac)
@@ -252,10 +258,14 @@ def test_frac():
     assert frac(x + I*n) == frac(x)
 
     assert frac(x).rewrite(floor) == x - floor(x)
+    assert frac(x).rewrite(ceiling) == x + ceiling(-x)
     assert frac(y).rewrite(floor).subs(y, pi) == frac(pi)
     assert frac(y).rewrite(floor).subs(y, -E) == frac(-E)
     assert frac(y).rewrite(ceiling).subs(y, -pi) == frac(-pi)
     assert frac(y).rewrite(ceiling).subs(y, E) == frac(E)
+
+    assert Eq(frac(y), y - floor(y))
+    assert Eq(frac(y), y + ceiling(-y))
 
 
 def test_series():


### PR DESCRIPTION
#### References to other Issues or PRs
#7951

#### Brief description of what is fixed or changed
The following changes are to be covered:
- [x] Add rewrite methods for `floor`, `ceil`, `frac`.
- [x] Add equality methods for `floor(x) == -ceiling(-x)` and similar.
- [ ] Handle reversed relations `floor(x) <= x` as `x >= floor(x)` and similar.

#### Other comments
