### PR TITLE
sympy.lambdify breaks if differentiated function is in equation: Issue #14648

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -500,7 +500,7 @@ def lambdastr(args, expr, printer=None, dummify=False):
     """
     # Transforming everything to strings.
     from sympy.matrices import DeferredVector
-    from sympy import Dummy, sympify, Symbol, Function, flatten
+    from sympy import Dummy, sympify, Symbol, Function, flatten, Derivative
 
     if printer is not None:
         if inspect.isfunction(printer):
@@ -524,7 +524,7 @@ def lambdastr(args, expr, printer=None, dummify=False):
             return ",".join(str(a) for a in dummies)
         else:
             #Sub in dummy variables for functions or symbols
-            if isinstance(args, (Function, Symbol)):
+            if isinstance(args, (Function, Symbol, Derivative)):
                 dummies = Dummy()
                 dummies_dict.update({args : dummies})
                 return str(dummies)


### PR DESCRIPTION
# Problem:
Sympy won't lambdify expression if derivative is present.
Solution is provided.

Sympy version: 1.1.2.dev
Minimum failing example:

```
import sympy
print("sympy version: ", sympy.__version__)

t = sympy.symbols('t')
f = sympy.Function('f')(t)
expr = f + f.diff()

eval_expr = sympy.lambdify((f, f.diff()), expr)
print("eval_expr = ", eval_expr(10, 5))
```
Output:

```
sympy version:  1.1.2.dev
(f(t), Derivative(f(t), t))
args =  _Dummy_18,Derivative(f(t), t)
expr =    # Not supported in Python:
  # Derivative
_Dummy_18 + Derivative(_Dummy_18, t)
Traceback (most recent call last):
  File "tmp.py", line 8, in <module>
    eval_expr = sympy.lambdify((f, f.diff()), expr)
  File "lambdify.py", line 426, in lambdify
    func = eval(lstr, namespace)
  File "<string>", line 1
    lambda _Dummy_18,Derivative(f(t), t): (  # Not supported in Python:
                               ^
SyntaxError: invalid syntax
```

# Solution:
In lambdify.py, line 528 has to be changed from:
`if isinstance(args, (Function, Symbol)):`
to
`if isinstance(args, (Function, Symbol, Derivative)):`

and "Derivative" needs import on line 504:
`from sympy import Dummy, sympify, Symbol, Function, flatten, Derivative`

So complete sub_args() function looks like:

```
    def sub_args(args, dummies_dict):
        if isinstance(args, str):
            return args
        elif isinstance(args, DeferredVector):
            return str(args)
        elif iterable(args):
            dummies = flatten([sub_args(a, dummies_dict) for a in args])
            return ",".join(str(a) for a in dummies)
        else:
            #Sub in dummy variables for functions or symbols
            if isinstance(args, (Function, Symbol, Derivative)):  # add Derivative?
                dummies = Dummy()
                dummies_dict.update({args : dummies})
                return str(dummies)
            else:
                return str(args)
```

and lambdified function works with scipy's odeint.
Core unittest shows no problems. Full test is running. Will update if there's an error.

Thanks for this awesome package!
<!-- BEGIN RELEASE NOTES -->
- utilities
  - lambdify is now compatible with Derivative objects
<!-- END RELEASE NOTES -->
