### PR TITLE
Forward 'dict' to recursive classify_ode call

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -952,7 +952,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
 
     if isinstance(eq, Equality):
         if eq.rhs != 0:
-            return classify_ode(eq.lhs - eq.rhs, func, dict, ics=ics, xi=xi,
+            return classify_ode(eq.lhs - eq.rhs, func, dict=dict, ics=ics, xi=xi,
                 n=terms, eta=eta, prep=False)
         eq = eq.lhs
     order = ode_order(eq, f(x))

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -952,7 +952,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
 
     if isinstance(eq, Equality):
         if eq.rhs != 0:
-            return classify_ode(eq.lhs - eq.rhs, func, ics=ics, xi=xi,
+            return classify_ode(eq.lhs - eq.rhs, func, dict, ics=ics, xi=xi,
                 n=terms, eta=eta, prep=False)
         eq = eq.lhs
     order = ode_order(eq, f(x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -836,7 +836,7 @@ def test_classify_ode():
     # test issue 13864
     assert classify_ode(Eq(diff(f(x), x) - f(x)**x, 0), f(x)) == \
         ('1st_power_series', 'lie_group')
-    assert isinstance(classify_ode(Eq(f(x), 5), f(x), True), dict)
+    assert isinstance(classify_ode(Eq(f(x), 5), f(x), dict=True), dict)
 
 
 def test_classify_ode_ics():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -836,6 +836,7 @@ def test_classify_ode():
     # test issue 13864
     assert classify_ode(Eq(diff(f(x), x) - f(x)**x, 0), f(x)) == \
         ('1st_power_series', 'lie_group')
+    assert isinstance(classify_ode(Eq(f(x), 5), f(x), True), dict)
 
 
 def test_classify_ode_ics():


### PR DESCRIPTION
When you call classify_ode with dict=True for isinstance(eq, Equality) == True with eq.rhs != 0 dict value is ignored and tuple returned.
It happens because of missing dict argument in recursive classify_ode call after eq simplification.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
We now forward 'dict' to classify_ode recursive call and thus have dictionary returned for isinstance(eq, Equality) == True with eq.rhs != 0 when 'dict' is True

#### Other comments
