### PR TITLE
Allow numpy to be import under pypy

### DIFF
--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -125,10 +125,6 @@ def import_module(module, min_module_version=None, min_python_version=None,
                     UserWarning)
             return
 
-    # PyPy 1.6 has rudimentary NumPy support and importing it produces errors, so skip it
-    if module == 'numpy' and '__pypy__' in sys.builtin_module_names:
-        return
-
     try:
         mod = __import__(module, **__import__kwargs)
 


### PR DESCRIPTION
Pypy has evolved greatly, it might be a good idea to remove the import ban.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #14658


#### Brief description of what is fixed or changed

Remove import ban under pypy

#### Other comments
