### PR TITLE
Don't run TEST_SETUP in PyPy on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,7 +167,6 @@ matrix:
       env:
         - TEST_DOCTESTS="true"
         - FASTCACHE="false"
-        - TEST_SETUP="true"
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,6 @@ matrix:
       env:
         - TEST_DOCTESTS="true"
         - FASTCACHE="false"
-        - TEST_SETUP="true"
       addons:
         apt:
           sources:


### PR DESCRIPTION
PyPy apparently doesn't have setuptools when SymPy is installed, meaning pip
cannot uninstall SymPy. Since the whole point of the test is to test
installing without setuptools, we don't need to test this here if that is the
case.

See issue #13036.
