### PR TITLE
Update beam.py to allow solving reaction moments

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -6,7 +6,7 @@ singularity functions in mechanics.
 
 from __future__ import print_function, division
 
-from sympy.core import S, Symbol, diff
+from sympy.core import S, Symbol, diff, expand
 from sympy.solvers import linsolve, solve
 from sympy.printing import sstr
 from sympy.functions import SingularityFunction, Piecewise

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -7,9 +7,9 @@ singularity functions in mechanics.
 from __future__ import print_function, division
 
 from sympy.core import S, Symbol, diff
-from sympy.solvers import linsolve
+from sympy.solvers import linsolve, solve
 from sympy.printing import sstr
-from sympy.functions import SingularityFunction
+from sympy.functions import SingularityFunction, Piecewise
 from sympy.core import sympify
 from sympy.integrals import integrate
 from sympy.series import limit
@@ -92,7 +92,10 @@ class Beam(object):
         self.variable = variable
         self._boundary_conditions = {'deflection': [], 'slope': []}
         self._load = 0
+        self._reaction_symbols = set()
         self._reaction_loads = {}
+        self.C3 = Symbol('C3')
+        self.C4 = Symbol('C4')
 
     def __str__(self):
         str_sol = 'Beam({}, {}, {})'.format(sstr(self._length), sstr(self._elastic_modulus), sstr(self._second_moment))
@@ -257,6 +260,8 @@ class Beam(object):
         order = sympify(order)
 
         self._load += value*SingularityFunction(x, start, order)
+        
+        self._reaction_symbols = self._reaction_symbols.union(value.free_symbols)
 
         if end:
             if order == 0:
@@ -293,49 +298,53 @@ class Beam(object):
         """
         return self._load
 
-    def solve_for_reaction_loads(self, *reactions):
-        """
-        Solves for the reaction forces.
-
-        Examples
-        ========
-        There is a beam of length 30 meters. A moment of magnitude 120 Nm is
-        applied in the clockwise direction at the end of the beam. A pointload
-        of magnitude 8 N is applied from the top of the beam at the starting
-        point. There are two simple supports below the beam. One at the end
-        and another one at a distance of 10 meters from the start. The
-        deflection is restricted at both the supports.
-
-        Using the sign convention of upward forces and clockwise moment
-        being positive.
-
-        >>> from sympy.physics.continuum_mechanics.beam import Beam
-        >>> from sympy import symbols, linsolve, limit
-        >>> E, I = symbols('E, I')
-        >>> R1, R2 = symbols('R1, R2')
-        >>> b = Beam(30, E, I)
-        >>> b.apply_load(-8, 0, -1)
-        >>> b.apply_load(R1, 10, -1)  # Reaction force at x = 10
-        >>> b.apply_load(R2, 30, -1)  # Reaction force at x = 30
-        >>> b.apply_load(120, 30, -2)
-        >>> b.bc_deflection = [(10, 0), (30, 0)]
-        >>> b.load
-        R1*SingularityFunction(x, 10, -1) + R2*SingularityFunction(x, 30, -1)
-            - 8*SingularityFunction(x, 0, -1) + 120*SingularityFunction(x, 30, -2)
-        >>> b.solve_for_reaction_loads(R1, R2)
-        >>> b.reaction_loads
-        {R1: 6, R2: 2}
-        >>> b.load
-        -8*SingularityFunction(x, 0, -1) + 6*SingularityFunction(x, 10, -1)
-            + 120*SingularityFunction(x, 30, -2) + 2*SingularityFunction(x, 30, -1)
-        """
+    def solve(self):
+        
         x = self.variable
         l = self.length
+        E = self.elastic_modulus
+        I = self.second_moment
+        C3 = self.C3
+        C4 = self.C4
         shear_curve = limit(self.shear_force(), x, l)
         moment_curve = limit(self.bending_moment(), x, l)
-        reaction_values = linsolve([shear_curve, moment_curve], reactions).args
-        self._reaction_loads = dict(zip(reactions, reaction_values[0]))
-        self._load = self._load.subs(self._reaction_loads)
+
+        slope_eqs = []
+        deflection_eqs = []
+
+        slope_curve = integrate(self.bending_moment(), x) + C3
+    
+        if not self._boundary_conditions['slope']:
+            #slope_curve = diff(self.deflection(), x)
+            pass
+        
+        else:
+            for position, value in self._boundary_conditions['slope']:
+                eqs = sympify(slope_curve.subs(x, position) - value)
+                slope_eqs.append(eqs)
+
+        if not self._boundary_conditions['deflection']:
+            pass
+
+        else:
+            deflection_curve = integrate(slope_curve, x) + C4
+
+            for position, value in self._boundary_conditions['deflection']:
+                eqs = sympify(deflection_curve.subs(x, position) - value)
+                deflection_eqs.append(eqs)
+
+        symbol_list = list(self._reaction_symbols)
+    
+        solution = list((linsolve([shear_curve, moment_curve] + slope_eqs + deflection_eqs, [C3, C4] + symbol_list).args)[0])
+       
+        self.C3 = solution[0]
+        self.C4 = solution[1]
+        
+        solution.pop(0)
+        solution.pop(0)
+
+        self._reaction_loads = dict(zip(symbol_list, solution))
+        self._load = self._load.subs(self._reaction_loads)   
 
     def shear_force(self):
         """
@@ -432,27 +441,17 @@ class Beam(object):
         >>> b.apply_load(R2, 30, -1)
         >>> b.apply_load(120, 30, -2)
         >>> b.bc_deflection = [(10, 0), (30, 0)]
-        >>> b.solve_for_reaction_loads(R1, R2)
+        >>> b.solve()
         >>> b.slope()
         (-4*SingularityFunction(x, 0, 2) + 3*SingularityFunction(x, 10, 2)
             + 120*SingularityFunction(x, 30, 1) + SingularityFunction(x, 30, 2) + 4000/3)/(E*I)
         """
+        
         x = self.variable
         E = self.elastic_modulus
         I = self.second_moment
-        if not self._boundary_conditions['slope']:
-            return diff(self.deflection(), x)
 
-        C3 = Symbol('C3')
-        slope_curve = integrate(self.bending_moment(), x) + C3
-
-        bc_eqs = []
-        for position, value in self._boundary_conditions['slope']:
-            eqs = slope_curve.subs(x, position) - value
-            bc_eqs.append(eqs)
-
-        constants = list(linsolve(bc_eqs, C3))
-        slope_curve = slope_curve.subs({C3: constants[0][0]})
+        slope_curve = integrate(self.bending_moment(), x) + self.C3
         return S(1)/(E*I)*slope_curve
 
     def deflection(self):
@@ -482,39 +481,29 @@ class Beam(object):
         >>> b.apply_load(R2, 30, -1)
         >>> b.apply_load(120, 30, -2)
         >>> b.bc_deflection = [(10, 0), (30, 0)]
-        >>> b.solve_for_reaction_loads(R1, R2)
+        >>> b.solve()
         >>> b.deflection()
         (4000*x/3 - 4*SingularityFunction(x, 0, 3)/3 + SingularityFunction(x, 10, 3)
             + 60*SingularityFunction(x, 30, 2) + SingularityFunction(x, 30, 3)/3 - 12000)/(E*I)
         """
+        
         x = self.variable
         E = self.elastic_modulus
         I = self.second_moment
-        if not self._boundary_conditions['deflection'] and not self._boundary_conditions['slope']:
-            return S(1)/(E*I)*integrate(integrate(self.bending_moment(), x), x)
-        elif not self._boundary_conditions['deflection']:
-            return integrate(self.slope(), x)
-        elif not self._boundary_conditions['slope'] and self._boundary_conditions['deflection']:
-            C3 = Symbol('C3')
-            C4 = Symbol('C4')
-            slope_curve = integrate(self.bending_moment(), x) + C3
-            deflection_curve = integrate(slope_curve, x) + C4
-            bc_eqs = []
-            for position, value in self._boundary_conditions['deflection']:
-                eqs = deflection_curve.subs(x, position) - value
-                bc_eqs.append(eqs)
-            constants = list(linsolve(bc_eqs, (C3, C4)))
-            deflection_curve = deflection_curve.subs({C3: constants[0][0], C4: constants[0][1]})
-            return S(1)/(E*I)*deflection_curve
 
-        C4 = Symbol('C4')
-        deflection_curve = integrate((E*I)*self.slope(), x) + C4
-
-        bc_eqs = []
-        for position, value in self._boundary_conditions['deflection']:
-            eqs = deflection_curve.subs(x, position) - value
-            bc_eqs.append(eqs)
-
-        constants = list(linsolve(bc_eqs, C4))
-        deflection_curve = deflection_curve.subs({C4: constants[0][0]})
+        slope_curve = integrate(self.bending_moment(), x) + self.C3
+        deflection_curve = integrate(slope_curve, x) + self.C4
         return S(1)/(E*I)*deflection_curve
+
+    def extrema(self):
+        """
+        Return a list of extrema in form of tuple of x and deflection
+        """
+
+        extrema = []
+        
+        extreme_points = solve(self.slope().rewrite(Piecewise), self.variable, domain=S.Reals)
+        for ep in extreme_points:
+            extrema.append( (ep, self.deflection().subs(self.variable, ep)) )
+            
+        return extrema

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -551,7 +551,7 @@ class Beam(object):
         ========
         There is a beam of length l with simple supports at both ends. A point load F is applied at the center of the beam.
         >>> from sympy.physics.continuum_mechanics.beam import Beam
-        >>> from sympy import symbols
+        >>> from sympy import symbols, Symbol
         >>> E, I = symbols('E, I')
         >>> l = Symbol('l', positive=True)
         >>> R1, R2 = symbols('R1, R2')

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -171,3 +171,26 @@ def test_Beam():
     raises(ValueError, lambda: b4.apply_load(-3, 0, -1, end=3))
     with raises(TypeError):
         b4.variable = 1
+
+    M1, M2 = symbols('M1, M2')
+    F = Symbol('F')
+    l = Symbol('l', positive=True)
+    
+    b5 = Beam(l, E, I)
+    b5.bc_deflection = [(0, 0),(l, 0)]
+    b5.bc_slope = [(0, 0),(l, 0)]
+
+    b5.apply_load(R1, 0, -1)
+    b5.apply_load(M1, 0, -2)
+    b5.apply_load(R2, l, -1)
+    b5.apply_load(M2, l, -2)
+    b5.apply_load(-F, l/2, -1)
+
+    b5.solve_for_reaction_loads(R1, R2, M1, M2)
+    p = b5.reaction_loads
+    q = {R1: F/2, R2: F/2, M1: -F*l/8, M2: F*l/8}
+    assert p == q
+
+    p = b5.max_deflection()
+    q = (l/2, -F*l**3/(192*E*I))
+    assert p == q


### PR DESCRIPTION
The previous version doesn't allow applying reaction moments.

Example, a beam has length l and fixed supports at both ends. A 1000N load is applied at the center.

E = Symbol('E')
I = Symbol('I')
l = Symbol('l', positive=True)
R1, R2 = symbols('R1, R2')
M1, M2 = symbols('M1, M2')

b = Beam(l, E, I)
b.bc_deflection = [(0, 0),(l, 0)]
b.bc_slope = [(0, 0),(l, 0)]

b.apply_load(R1, 0, -1)
b.apply_load(M1, 0, -2)
b.apply_load(R2, l, -1)
b.apply_load(M2, l, -2)
b.apply_load(-1000, 0.5*l, -1)

Method solve_for_reaction_loads will not solve M1 and M2. A new method solve() is proposed here to find M1, M2.

A new method extrema() also proposed to find the maximum deflection points

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments
