### PR TITLE
Make lambdify decorator a little faster

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -427,11 +427,11 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     # This is a fix for gh-11306.
     if module_provided and _module_present('numpy',namespaces):
         def array_wrap(funcarg):
+            builtin_numerics = integer_types + (float, complex)
+            array = namespace['array']
             @wraps(funcarg)
             def wrapper(*argsx, **kwargsx):
-                asarray = namespace['asarray']
-                newargs = [asarray(i) if isinstance(i, integer_types + (float,
-                    complex)) else i for i in argsx]
+                newargs = [array(i) if isinstance(i, builtin_numerics) else i for i in argsx]
                 return funcarg(*newargs, **kwargsx)
             return wrapper
         func = array_wrap(func)


### PR DESCRIPTION
I pulled out the common functionality to be evaluated once, and used array()
instead of asarray() (they are equivalent, but array() is faster).

This is a partial fix to #14671. It isn't as fast as it used to be yet. I
don't know how to make the decorator faster, other than code generating the
array wrapping directly, which would require improvements to lambdify to work
(lambdify would need to be able to code generation full Python functions).
