### PR TITLE
Use S.true in the conditions in integral transforms

### DIFF
--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -219,7 +219,7 @@ def _mellin_transform(f, x, s_, integrator=_default_integrator, simplify=True):
     F = integrator(x**(s - 1) * f, x)
 
     if not F.has(Integral):
-        return _simplify(F.subs(s, s_), simplify), (-oo, oo), True
+        return _simplify(F.subs(s, s_), simplify), (-oo, oo), S(True)
 
     if not F.is_Piecewise:  # XXX can this work if integration gives continuous result now?
         raise IntegralTransformError('Mellin', f, 'could not compute integral')
@@ -235,7 +235,7 @@ def _mellin_transform(f, x, s_, integrator=_default_integrator, simplify=True):
         """
         a = -oo
         b = oo
-        aux = True
+        aux = S(True)
         conds = conjuncts(to_cnf(cond))
         t = Dummy('t', real=True)
         for c in conds:
@@ -951,7 +951,7 @@ def _simplifyconds(expr, s, a):
     expr = repl(expr, StrictLessThan, replie)
     expr = repl(expr, StrictGreaterThan, lambda x, y: replie(y, x))
     expr = repl(expr, Unequality, replue)
-    return expr
+    return S(expr)
 
 
 @_noconds
@@ -963,7 +963,7 @@ def _laplace_transform(f, t, s_, simplify=True):
     F = integrate(exp(-s*t) * f, (t, 0, oo))
 
     if not F.has(Integral):
-        return _simplify(F.subs(s, s_), simplify), -oo, True
+        return _simplify(F.subs(s, s_), simplify), -oo, S(True)
 
     if not F.is_Piecewise:
         raise IntegralTransformError(
@@ -977,7 +977,7 @@ def _laplace_transform(f, t, s_, simplify=True):
     def process_conds(conds):
         """ Turn ``conds`` into a strip and auxiliary conditions. """
         a = -oo
-        aux = True
+        aux = S(True)
         conds = conjuncts(to_cnf(conds))
         u = Dummy('u', real=True)
         p, q, w1, w2, w3, w4, w5 = symbols(
@@ -1052,8 +1052,6 @@ def _laplace_transform(f, t, s_, simplify=True):
     a, aux = conds[0]
 
     def sbs(expr):
-        if expr == S.true or expr == S.false:
-            return bool(expr)
         return expr.subs(s, s_)
     if simplify:
         F = _simplifyconds(F, s, a)
@@ -1169,7 +1167,7 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
                 raise IntegralTransformError('Inverse Laplace', f,
                                      'inversion integral of unrecognised form.')
         else:
-            cond = True
+            cond = S(True)
         f = f.replace(Piecewise, pw_simp)
 
     if f.is_Piecewise:
@@ -1297,7 +1295,7 @@ def _fourier_transform(f, x, k, a, b, name, simplify=True):
     F = integrate(a*f*exp(b*I*x*k), (x, -oo, oo))
 
     if not F.has(Integral):
-        return _simplify(F, simplify), True
+        return _simplify(F, simplify), S(True)
 
     integral_f = integrate(f, (x, -oo, oo))
     if integral_f in (-oo, oo, S.NaN) or integral_f.has(Integral):
@@ -1466,7 +1464,7 @@ def _sine_cosine_transform(f, x, k, a, b, K, name, simplify=True):
     F = integrate(a*f*K(b*x*k), (x, 0, oo))
 
     if not F.has(Integral):
-        return _simplify(F, simplify), True
+        return _simplify(F, simplify), S(True)
 
     if not F.is_Piecewise:
         raise IntegralTransformError(name, f, 'could not compute integral')
@@ -1734,7 +1732,7 @@ def _hankel_transform(f, r, k, nu, name, simplify=True):
     F = integrate(f*besselj(nu, k*r)*r, (r, 0, oo))
 
     if not F.has(Integral):
-        return _simplify(F, simplify), True
+        return _simplify(F, simplify), S(True)
 
     if not F.is_Piecewise:
         raise IntegralTransformError(name, f, 'could not compute integral')

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -219,7 +219,7 @@ def _mellin_transform(f, x, s_, integrator=_default_integrator, simplify=True):
     F = integrator(x**(s - 1) * f, x)
 
     if not F.has(Integral):
-        return _simplify(F.subs(s, s_), simplify), (-oo, oo), S(True)
+        return _simplify(F.subs(s, s_), simplify), (-oo, oo), S.true
 
     if not F.is_Piecewise:  # XXX can this work if integration gives continuous result now?
         raise IntegralTransformError('Mellin', f, 'could not compute integral')
@@ -235,7 +235,7 @@ def _mellin_transform(f, x, s_, integrator=_default_integrator, simplify=True):
         """
         a = -oo
         b = oo
-        aux = S(True)
+        aux = S.true
         conds = conjuncts(to_cnf(cond))
         t = Dummy('t', real=True)
         for c in conds:
@@ -963,7 +963,7 @@ def _laplace_transform(f, t, s_, simplify=True):
     F = integrate(exp(-s*t) * f, (t, 0, oo))
 
     if not F.has(Integral):
-        return _simplify(F.subs(s, s_), simplify), -oo, S(True)
+        return _simplify(F.subs(s, s_), simplify), -oo, S.true
 
     if not F.is_Piecewise:
         raise IntegralTransformError(
@@ -977,7 +977,7 @@ def _laplace_transform(f, t, s_, simplify=True):
     def process_conds(conds):
         """ Turn ``conds`` into a strip and auxiliary conditions. """
         a = -oo
-        aux = S(True)
+        aux = S.true
         conds = conjuncts(to_cnf(conds))
         u = Dummy('u', real=True)
         p, q, w1, w2, w3, w4, w5 = symbols(
@@ -1167,7 +1167,7 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
                 raise IntegralTransformError('Inverse Laplace', f,
                                      'inversion integral of unrecognised form.')
         else:
-            cond = S(True)
+            cond = S.true
         f = f.replace(Piecewise, pw_simp)
 
     if f.is_Piecewise:
@@ -1295,7 +1295,7 @@ def _fourier_transform(f, x, k, a, b, name, simplify=True):
     F = integrate(a*f*exp(b*I*x*k), (x, -oo, oo))
 
     if not F.has(Integral):
-        return _simplify(F, simplify), S(True)
+        return _simplify(F, simplify), S.true
 
     integral_f = integrate(f, (x, -oo, oo))
     if integral_f in (-oo, oo, S.NaN) or integral_f.has(Integral):
@@ -1464,7 +1464,7 @@ def _sine_cosine_transform(f, x, k, a, b, K, name, simplify=True):
     F = integrate(a*f*K(b*x*k), (x, 0, oo))
 
     if not F.has(Integral):
-        return _simplify(F, simplify), S(True)
+        return _simplify(F, simplify), S.true
 
     if not F.is_Piecewise:
         raise IntegralTransformError(name, f, 'could not compute integral')
@@ -1732,7 +1732,7 @@ def _hankel_transform(f, r, k, nu, name, simplify=True):
     F = integrate(f*besselj(nu, k*r)*r, (r, 0, oo))
 
     if not F.has(Integral):
-        return _simplify(F, simplify), S(True)
+        return _simplify(F, simplify), S.true
 
     if not F.is_Piecewise:
         raise IntegralTransformError(name, f, 'could not compute integral')


### PR DESCRIPTION
S.true should be used anywhere that a full symbolic condition can be used,
which is the case. Among other things, this makes transforms with
noconds=False pretty print properly, as the _can_print_latex ignores bool.

<!-- BEGIN RELEASE NOTES -->
- integrals
  * fix pretty printing of integral transforms `noconds=False`
