### PR TITLE
fixing input bug with ReferenceFrame.orientnew

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -698,7 +698,7 @@ class ReferenceFrame(object):
         """
 
         newframe = self.__class__(newname, variables=variables,
-                                  indices=indices,latexs=latexs)
+                                  indices=indices, latexs=latexs)
         newframe.orient(self, rot_type, amounts, rot_order)
         return newframe
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -697,7 +697,7 @@ class ReferenceFrame(object):
 
         """
 
-        newframe = self.__class__(newname, variables=variables, 
+        newframe = self.__class__(newname, variables=variables,
                                   indices=indices,latexs=latexs)
         newframe.orient(self, rot_type, amounts, rot_order)
         return newframe

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -697,7 +697,8 @@ class ReferenceFrame(object):
 
         """
 
-        newframe = self.__class__(newname, variables, indices, latexs)
+        newframe = self.__class__(newname, variables=variables, 
+                                  indices=indices,latexs=latexs)
         newframe.orient(self, rot_type, amounts, rot_order)
         return newframe
 

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -166,6 +166,59 @@ def test_orientnew_respects_parent_class():
     assert isinstance(C, MyReferenceFrame)
 
 
+def test_orientnew_respects_input_indices():
+    N = ReferenceFrame('N')
+    q1 = dynamicsymbols('q1')
+    A = N.orientnew('a', 'Axis', [q1, N.z])
+    #modify default indices:
+    minds = [x+'1' for x in N.indices]
+    B = N.orientnew('b', 'Axis', [q1, N.z], indices=minds)
+
+    assert N.indices == A.indices
+    assert B.indices == minds
+
+def test_orientnew_respects_input_latexs():
+    N = ReferenceFrame('N')
+    q1 = dynamicsymbols('q1')
+    A = N.orientnew('a', 'Axis', [q1, N.z])
+
+    #build default and alternate latex_vecs:
+    def_latex_vecs = [(r"\mathbf{\hat{%s}_%s}" % (A.name.lower(),
+                      A.indices[0])), (r"\mathbf{\hat{%s}_%s}" %
+                      (A.name.lower(), A.indices[1])),
+                      (r"\mathbf{\hat{%s}_%s}" % (A.name.lower(),
+                      A.indices[2]))]
+
+    name = 'b'
+    indices = [x+'1' for x in N.indices]
+    new_latex_vecs = [(r"\mathbf{\hat{%s}_{%s}}" % (name.lower(),
+                      indices[0])), (r"\mathbf{\hat{%s}_{%s}}" %
+                      (name.lower(), indices[1])),
+                      (r"\mathbf{\hat{%s}_{%s}}" % (name.lower(),
+                      indices[2]))]
+
+    B = N.orientnew(name, 'Axis', [q1, N.z], latexs=new_latex_vecs)
+
+    assert A.latex_vecs == def_latex_vecs
+    assert B.latex_vecs == new_latex_vecs
+    assert B.indices != indices
+
+def test_orientnew_respects_input_variables():
+    N = ReferenceFrame('N')
+    q1 = dynamicsymbols('q1')
+    A = N.orientnew('a', 'Axis', [q1, N.z])
+
+    #build non-standard variable names
+    name = 'b'
+    new_variables = ['notb_'+x+'1' for x in N.indices]
+    B = N.orientnew(name, 'Axis', [q1, N.z], variables=new_variables)
+
+    for j,var in enumerate(A.varlist):
+        assert var.name == A.name + '_' + A.indices[j]
+
+    for j,var in enumerate(B.varlist):
+        assert var.name == new_variables[j]
+
 def test_issue_10348():
     u = dynamicsymbols('u:3')
     I = ReferenceFrame('I')


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #5880

#### Brief description of what is fixed or changed
Although support was previously added for indices and latex_vecs in orientnew, the order of the inputs implemented is different from the order of the constructor keywords, thus leading to incorrect behavior.  This trivial fix simply changes the inputs to named keywords and resolves any ordering ambiguities. 

#### Other comments
Example of previous bad behavior:

```
from sympy import *
from sympy.physics.mechanics import *
I = ReferenceFrame('e',indices=['1','2','3'])
psi = symbol('psi')
B = I.orientnew('b','Axis',[psi,I.z],indices=['1','2','3'])

I.latex_vecs
B.latex_vecs
```

Original output:
```
['\\mathbf{\\hat{e}_{1}}', '\\mathbf{\\hat{e}_{2}}', '\\mathbf{\\hat{e}_{3}}']
['1', '2', '3']
```

Output with fix:

```
['\\mathbf{\\hat{e}_{1}}', '\\mathbf{\\hat{e}_{2}}', '\\mathbf{\\hat{e}_{3}}']
['\\mathbf{\\hat{b}_{1}}', '\\mathbf{\\hat{b}_{2}}', '\\mathbf{\\hat{b}_{3}}']
```