### PR TITLE
integer_nthroot: Fixing OverflowError in integer_nthroot()

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -73,7 +73,8 @@ def integer_nthroot(y, n):
     try:
         guess = int(y**(1./n) + 0.5)
     except OverflowError:
-        exp = _log(y, 2)/n
+        logy = _log(y, 2)
+        exp = logy/n if logy >= n else 0
         if exp > 53:
             shift = int(exp - 53)
             guess = int(2.0**(exp - shift) + 1) << shift

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -967,6 +967,7 @@ def test_powers():
 def test_integer_nthroot_overflow():
     assert integer_nthroot(10**(50*50), 50) == (10**50, True)
     assert integer_nthroot(10**100000, 10000) == (10**10, True)
+    assert integer_nthroot(100, 10**1000) == (1, False)
 
 
 def test_integer_log():


### PR DESCRIPTION
integer_nthroot: Fixing OverflowError in integer_nthroot()

Fixes #14704 

In function integer_nthroot(), line 76 breaks, raising the OverflowError when 'n' (the denominator) becomes a very large integer -- for eg., math.factorial(171). Therefore, this PR rounding the numerator to the integer value.
