### PR TITLE
Fourier transforms as boundary values

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1716,6 +1716,35 @@ class Basic(with_metaclass(ManagedProperties)):
 
         return obj
 
+    def at_reals(self, x, side):
+        """
+        Evaluate a possibly branched function of x on the real line.
+
+        If side < 0, return the value on the boundary of the lower
+        half-plane, otherwise return the value on the boundary of
+        the upper half-plane.
+
+        Examples
+        ========
+
+        >>> from sympy.functions import log
+        >>> from sympy.abc import x
+        >>> log(x).at_reals(x, 1)
+        log(x)
+        >>> log(x).at_reals(x, -1)
+        Piecewise((-2*I*pi, x < 0), (0, True)) + log(x)
+
+        """
+        if not self.args:
+            return self
+
+        args = [a.at_reals(x, side) for a in self.args]
+        res = self.func(*args)
+        if hasattr(res, '_eval_at_reals'):
+            return res._eval_at_reals(x, side)
+        else:
+            return res
+
 
 class Atom(Basic):
     """

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1649,6 +1649,14 @@ class Pow(Expr):
             new_e = e.subs(n, n + step)
             return (b**(new_e - e) - 1) * self
 
+    def _eval_at_reals(self, x, side):
+        # Preliminary version, for sqrt only.
+        if self.exp is not S.Half:
+            return self
+        from sympy.functions import Piecewise, unpolarify
+        z = unpolarify(self.base)
+        cond = (z < 0) & (z.diff(x)*side < 0)
+        return Piecewise((-self, cond), (self, True))
 
 from .add import Add
 from .numbers import Integer

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -229,6 +229,14 @@ def test_pow_as_base_exp():
     assert Pow(1, 2, evaluate=False).as_base_exp() == (S(1), S(2))
 
 
+def test_Pow_at_reals():
+    from sympy.functions import Piecewise
+    x = Symbol('x')
+    f = sqrt(1 - x**2)
+    assert f.at_reals(x, 1) == Piecewise((-f, x > 1), (f, True))
+    assert f.at_reals(x, -1) == Piecewise((-f, x < -1), (f, True))
+
+
 def test_issue_6100_12942():
     x = Symbol('x')
     y = Symbol('y')

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy.core import S, Add, Mul, sympify, Symbol, Dummy, Basic
+from sympy.core import S, Add, Mul, sympify, Symbol, Dummy, Basic, Tuple
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import (Function, Derivative, ArgumentIndexError,
     AppliedUndef)
@@ -1105,6 +1105,7 @@ def _unpolarify(eq, exponents_only, pause=False):
             return _unpolarify(eq.args[0], exponents_only)
         if (
             eq.is_Add or eq.is_Mul or eq.is_Boolean or
+            isinstance(eq, Tuple) or
             eq.is_Relational and (
                 eq.rel_op in ('==', '!=') and 0 in eq.args or
                 eq.rel_op not in ('==', '!='))

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -770,6 +770,12 @@ class log(Function):
             return (self.args[0] - 1).as_leading_term(x)
         return self.func(arg)
 
+    def _eval_at_reals(self, x, side):
+        from sympy.functions import Piecewise, unpolarify
+        # unpolarify(log(z)) does not touch the argument
+        z = unpolarify(self.args[0])
+        cond = (z < 0) & (z.diff(x)*side < 0)
+        return log(z) + Piecewise((-2*S.Pi*S.ImaginaryUnit, cond), (0, True))
 
 class LambertW(Function):
     r"""

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -118,6 +118,7 @@ class Piecewise(Function):
 
     nargs = None
     is_Piecewise = True
+    unbranched = True
 
     def __new__(cls, *args, **options):
         # (Try to) sympify args first

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -708,7 +708,7 @@ def test_polarify():
 
 def test_unpolarify():
     from sympy import (exp_polar, polar_lift, exp, unpolarify,
-                       principal_branch)
+                       principal_branch, Piecewise)
     from sympy import gamma, erf, sin, tanh, uppergamma, Eq, Ne
     from sympy.abc import x
     p = exp_polar(7*I) + 1
@@ -746,6 +746,9 @@ def test_unpolarify():
     assert unpolarify(Eq(p, 0)) == Eq(u, 0)
     assert unpolarify(Ne(p, 0)) == Ne(u, 0)
     assert unpolarify(polar_lift(x) > 0) == (x > 0)
+    assert unpolarify(Piecewise(
+                  (exp(x), x*exp_polar(pi*I) < 0), (0, True))) == \
+        Piecewise((exp(x), -x < 0), (0, True))
 
     # Test bools
     assert unpolarify(True) is True

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -359,6 +359,19 @@ def test_log_AccumBounds():
     assert log(AccumBounds(1, E)) == AccumBounds(0, 1)
 
 
+def test_log_at_reals():
+    x = symbols('x', positive=True)
+    assert log(x).at_reals(x, 1) == log(x)
+    assert log(x).at_reals(x, -1) == log(x)
+    # branch cut along the positive x-axis
+    # (upper for x is lower for -x)
+    assert log(-x).at_reals(x, 1) == log(-x) - 2*I*pi
+    assert log(-x).at_reals(x, -1) == log(-x)
+
+    y = symbols('y', negative=True)
+    assert log(y).at_reals(y, 1) == log(y)
+    assert log(y).at_reals(y, -1) == log(y) - 2*I*pi
+
 def test_lambertw():
     k = Symbol('k')
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -9,7 +9,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import factorial
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt, root
-from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.exponential import exp, log, exp_polar
 from sympy.functions.elementary.complexes import polar_lift
 from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.trigonometric import cos, sin, sinc
@@ -1254,6 +1254,14 @@ class expint(Function):
 
     def _eval_expand_func(self, **hints):
         return self.rewrite(Ei).rewrite(expint, **hints)
+
+    def _eval_at_reals(self, x, side):
+        from sympy.functions import Piecewise, unpolarify
+        nu, z = self.args
+        z = unpolarify(z)
+        cond = (z < 0) & (z.diff(x)*side < 0)
+        return Piecewise((expint(nu, z*exp_polar(-2*pi*I)), cond),
+                         (expint(nu, z), True))
 
     def _eval_rewrite_as_Si(self, nu, z):
         if nu != 1:

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -389,6 +389,14 @@ def test_expint():
         z**5/240 + O(z**6)
 
 
+def test_expint_at_reals():
+    t = Symbol('t', negative=True)
+    assert expint(1, t).at_reals(t, 1) == expint(1, t)
+    assert expint(1, t).at_reals(t, -1) == expint(1, t) + 2*I*pi
+    assert expint(2, t).at_reals(t, 1) == expint(2, t)
+    assert expint(2, t).at_reals(t, -1) == expint(2, t) - 2*I*pi*t
+
+
 def test__eis():
     assert _eis(z).diff(z) == -_eis(z) + 1/z
 

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -159,6 +159,14 @@ def test_polylog_values():
                 a=2, b=-2, c=5, d=2)
 
 
+def test_polylog_at_reals():
+    x = Symbol('x', positive=True)
+    assert polylog(1, x+1).at_reals(x, 1) == polylog(1, x+1) + 2*pi*I
+    assert polylog(1, x+1).at_reals(x, -1) == polylog(1, x+1)
+    assert polylog(2, x+1).at_reals(x, 1) == polylog(2, x+1) + 2*pi*I*log(x+1)
+    assert polylog(2, x+1).at_reals(x, -1) == polylog(2, x+1)
+
+
 def test_lerchphi_expansion():
     assert myexpand(lerchphi(1, s, a), zeta(s, a))
     assert myexpand(lerchphi(z, s, 1), polylog(s, z)/z)

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -326,6 +326,19 @@ class polylog(Function):
             return expand_mul(start).subs(u, z)
         return polylog(s, z)
 
+    def _eval_at_reals(self, x, side):
+        # polylog is a branched function with the branch cut of the
+        # principal branch along the interval [1, oo), where it is
+        # continous from below by convention. Reference:
+        # http://functions.wolfram.com/ZetaFunctionsandPolylogarithms/PolyLog/04/05/01/
+        from sympy.functions import Piecewise, gamma, unpolarify
+        s, z = self.args
+        z = unpolarify(z)
+        cond = (z > 1) & (z.diff(x)*side > 0)
+        return polylog(s, z) + Piecewise((2*pi*I*log(z)**(s-1)/gamma(s), cond),
+                                         (0, True))
+
+
 ###############################################################################
 ###################### HURWITZ GENERALIZED ZETA FUNCTION ######################
 ###############################################################################

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -600,8 +600,11 @@ def test_messy():
 
     # NOTE s < 0 can be done, but argument reduction is not good enough yet
     assert fourier_transform(besselj(1, x)/x, x, s, noconds=False) == \
-        (Piecewise((0, 4*abs(pi**2*s**2) > 1),
-                   (2*sqrt(-4*pi**2*s**2 + 1), True)), s > 0)
+        (Piecewise((0, (s > 1/(2*pi)) | (s < -1/(2*pi))),
+                   (2*sqrt(-4*pi**2*s**2 + 1), True)), True)
+    #    (Piecewise((0, 4*abs(pi**2*s**2) > 1),
+    #               (2*sqrt(-4*pi**2*s**2 + 1), True)), s > 0)
+
     # TODO FT(besselj(0,x)) - conditions are messy (but for acceptable reasons)
     #                       - folding could be better
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -12,7 +12,8 @@ from sympy import (
     cos, S, Abs, And, Or, sin, sqrt, I, log, tan, hyperexpand, meijerg,
     EulerGamma, erf, erfc, besselj, bessely, besseli, besselk,
     exp_polar, polar_lift, unpolarify, Function, expint, expand_mul,
-    gammasimp, trigsimp, atan, sinh, cosh, Ne, periodic_argument, atan2, Abs)
+    gammasimp, trigsimp, atan, sinh, cosh, Ne, periodic_argument, atan2,
+    Abs, Piecewise)
 from sympy.utilities.pytest import XFAIL, slow, skip, raises
 from sympy.matrices import Matrix, eye
 from sympy.abc import x, s, a, b, c, d
@@ -618,11 +619,14 @@ def test_fourier_transform():
     # NOTE: the ift comes out in pieces
     assert IFT(1/(a + 2*pi*I*x), x, posk,
             noconds=False) == (exp(-a*posk), True)
-    assert IFT(1/(a + 2*pi*I*x), x, -posk,
-            noconds=False) == (0, True)
+    # Boundary value implementation assumes that x and k are symbols.
+    # assert IFT(1/(a + 2*pi*I*x), x, -posk,
+    #        noconds=False) == (0, True)
     assert IFT(1/(a + 2*pi*I*x), x, symbols('k', negative=True),
             noconds=False) == (0, True)
-    # TODO IFT without factoring comes out as meijer g
+    # IFT without factoring comes out as Piecewise
+    assert IFT(1/(a + 2*pi*I*x), x, k) == \
+        Piecewise((exp(-a*k), -a*k < 0), (0, True))
 
     assert factor(FT(x*exp(-a*x)*Heaviside(x), x, k), extension=I) == \
         1/(a + 2*pi*I*k)**2

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1303,9 +1303,9 @@ def _fourier_transform(f, x, k, a, b, name, simplify=True):
     # A positive auxiliary variable is used for selecting the
     # relevant half-plane.
     p = Dummy('p', positive=True)
-    Fp = integrate(a*f*exp(-p*x), (x, 0, oo))
+    Fp = _simplify(integrate(a*f*exp(-p*x), (x, 0, oo)), simplify)
     Fp = Fp.subs(p, -b*I*k).at_reals(k, b)
-    Fn = integrate(a*f*exp(p*x), (x, -oo, 0))
+    Fn = _simplify(integrate(a*f*exp(p*x), (x, -oo, 0)), simplify)
     Fn = Fn.subs(p, b*I*k).at_reals(k, -b)
     F = unpolarify(Fp + Fn)  # remove polar numbers from conditions
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1293,8 +1293,21 @@ def _fourier_transform(f, x, k, a, b, name, simplify=True):
     For suitable choice of a and b, this reduces to the standard Fourier
     and inverse Fourier transforms.
     """
-    from sympy import exp, I
-    F = integrate(a*f*exp(b*I*x*k), (x, -oo, oo))
+    from sympy import exp, I, unpolarify
+    # The integral is computed in two parts, Fp from 0 to oo, and
+    # Fn from -oo to 0. If f is bounded (or polynomially growing)
+    # these are analytic functions of k in the upper or lower
+    # half-plane, depending on the sign of b. The (generalized)
+    # transform is obtained from their boundary values at the
+    # real line.
+    # A positive auxiliary variable is used for selecting the
+    # relevant half-plane.
+    p = Dummy('p', positive=True)
+    Fp = integrate(a*f*exp(-p*x), (x, 0, oo))
+    Fp = Fp.subs(p, -b*I*k).at_reals(k, b)
+    Fn = integrate(a*f*exp(p*x), (x, -oo, 0))
+    Fn = Fn.subs(p, b*I*k).at_reals(k, -b)
+    F = unpolarify(Fp + Fn)  # remove polar numbers from conditions
 
     if not F.has(Integral):
         return _simplify(F, simplify), True


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Closes #8712

#### Brief description of what is fixed or changed

The Fourier transform of a possibly non-integrable function like 1/(1 + I*x) is computed by combining
the boundary values of two functions analytic in the upper and lower half-planes, respectively.
The boundary values are directly accessed instead of by means of an enhanced polar_lift as suggested in #8712. This now seems a better implementation to me.

#### Other comments

This is only a pilot implementation. The boundary values of many functions remain undefined. This method can be extended to finding Fourier transforms of functions defining tempered distributions
(bounded or polynomially growing functions). The transform will contain Dirac deltas and its derivatives, in general.