### PR TITLE
Fixed a bug whereby numpy arrays of size one were treated as scalars.

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -8,7 +8,8 @@ import re as regex
 from collections import defaultdict
 
 from .containers import Tuple
-from .sympify import converter, sympify, _sympify, SympifyError, _convert_numpy_types
+from .sympify import (SympifyError, converter, sympify, _convert_numpy_types, _sympify,
+                      _is_numpy_instance)
 from .singleton import S, Singleton
 from .expr import Expr, AtomicExpr
 from .decorators import _sympifyit
@@ -980,7 +981,7 @@ class Float(Number):
             num = '+inf'
         elif num is S.NegativeInfinity:
             num = '-inf'
-        elif type(num).__module__ == 'numpy': # support for numpy datatypes
+        elif _is_numpy_instance(num):  # support for numpy datatypes
             num = _convert_numpy_types(num)
         elif isinstance(num, mpmath.mpf):
             if precision is None:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -57,10 +57,8 @@ def _is_numpy_instance(a):
     """
     # This check avoids unnecessarily importing NumPy.  We check the whole
     # __mro__ in case any base type is a numpy type.
-    for type_ in type(a).__mro__:
-        if type_.__module__ == 'numpy':
-            return True
-    return False
+    return any(type_.__module__ == 'numpy'
+               for type_ in type(a).__mro__)
 
 
 def _convert_numpy_types(a):

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -326,14 +326,18 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     if not isinstance(a, string_types):
         if _is_numpy_instance(a):
             import numpy as np
-            if isinstance(a, np.number):
-                return sympify(a)
-            elif isinstance(a, np.ndarray):
+            assert not isinstance(a, np.number)
+            if isinstance(a, np.ndarray):
                 # Scalar arrays (those with zero dimensions) have sympify
                 # called on the scalar element.
                 if a.ndim == 0:
                     try:
-                        return sympify(a.item())
+                        return sympify(a.item(),
+                                       locals=locals,
+                                       convert_xor=convert_xor,
+                                       strict=strict,
+                                       rational=rational,
+                                       evaluate=evaluate)
                     except SympifyError:
                         pass
         else:

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -615,3 +615,23 @@ def test_issue_13924():
     a = sympify(numpy.array([1]))
     assert isinstance(a, ImmutableDenseNDimArray)
     assert a[0] == 1
+
+
+def test_issue_14706():
+    if not numpy:
+        skip("numpy not installed.")
+
+    from sympy import symbols
+
+    x = symbols('x')
+
+    z1 = np.zeros((1,1), dtype=np.float)
+    z2 = np.zeros((2,2), dtype=np.float)
+    z3 = np.zeros((), dtype=np.float)
+
+    assert np.all(x + z1 == np.full((1, 1), x))
+    assert np.all(x + z2 == np.full((2, 2), x))
+    assert x + z3 == x
+    assert x + np.int(0) == x
+    assert x + np.float(0) == x
+    assert x + np.complex(0) == x

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -631,7 +631,12 @@ def test_issue_14706():
 
     assert np.all(x + z1 == np.full((1, 1), x))
     assert np.all(x + z2 == np.full((2, 2), x))
-    assert x + z3 == x
-    assert x + np.int(0) == x
-    assert x + np.float(0) == x
-    assert x + np.complex(0) == x
+    for z in [z3,
+              np.int(0),
+              np.float(0),
+              np.complex(0)]:
+        assert x + z == x
+        assert isinstance(x + z, Symbol)
+
+    assert x + np.array(x) == 2 * x
+    assert x + np.array([x]) == np.array([2*x], dtype=object)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -625,18 +625,20 @@ def test_issue_14706():
 
     x = symbols('x')
 
-    z1 = np.zeros((1,1), dtype=np.float)
-    z2 = np.zeros((2,2), dtype=np.float)
-    z3 = np.zeros((), dtype=np.float)
+    z1 = numpy.zeros((1,1), dtype=numpy.float)
+    z2 = numpy.zeros((2,2), dtype=numpy.float)
+    z3 = numpy.zeros((), dtype=numpy.float)
 
-    assert np.all(x + z1 == np.full((1, 1), x))
-    assert np.all(x + z2 == np.full((2, 2), x))
+    assert numpy.all(x + z1 == numpy.full((1, 1), x))
+    assert numpy.all(x + z2 == numpy.full((2, 2), x))
     for z in [z3,
-              np.int(0),
-              np.float(0),
-              np.complex(0)]:
+              numpy.int(0),
+              numpy.float(0),
+              numpy.complex(0)]:
         assert x + z == x
         assert isinstance(x + z, Symbol)
 
-    assert x + np.array(x) == 2 * x
-    assert x + np.array([x]) == np.array([2*x], dtype=object)
+    assert x + numpy.array(x) == 2 * x
+    assert x + numpy.array([x]) == numpy.array([2*x], dtype=object)
+
+    assert isinstance(sympify(numpy.array([1]), strict=True), numpy.ndarray)


### PR DESCRIPTION
Fixes #14706.

Rather than trying to call float and int on arrays passed to sympify, a separate path is used for numpy arrays.  Only true scalars (those with dimension zero) are treated as scalar.

Made the check for whether an object is a numpy instance support `ndarray` subtypes.