### PR TITLE
core: Patch to fix OverflowError when calling subsn on certain power expressions

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -73,7 +73,7 @@ def integer_nthroot(y, n):
     try:
         guess = int(y**(1./n) + 0.5)
     except OverflowError:
-        exp = _log(y, 2)/n
+        exp = int(_log(y, 2))/n
         if exp > 53:
             shift = int(exp - 53)
             guess = int(2.0**(exp - shift) + 1) << shift


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Brief description of what is fixed or changed
This patch fixes #14704 

This patch will fix the Overflow Error encountered when the value for n is too large, such  that Python is not able to convert it to a float in the expression exp = _log(y,2)/n. It can be fixed simply by changing the expression to exp = int(_log(y,2))/n. Thanks @jksuom for your inputs!

For example: @DRMacIver stated in the Issue #14704 that -
from sympy.abc import a

if __name__ == '__main__':
    b = a ** a
    c = b ** b
    c.subs({a: -144})

produces an OverflowError: int too large to convert to float. This short change fixes that

#### Other comments
This is my first patch for this project. Any constructive feedbacks are most appreciated! :)