### PR TITLE
[WIP] Allow expressions with multiple discrete random variables

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -737,7 +737,6 @@ nd = NormalDistribution(0, 1)
 from sympy.stats.frv_types import DieDistribution
 die = DieDistribution(6)
 
-
 def test_sympy__stats__crv__ContinuousDomain():
     from sympy.stats.crv import ContinuousDomain
     assert _test_args(ContinuousDomain({x}, Interval(-oo, oo)))
@@ -787,6 +786,12 @@ def test_sympy__stats__drv__SingleDiscreteDomain():
     from sympy.stats.drv import SingleDiscreteDomain
     assert _test_args(SingleDiscreteDomain(x, S.Naturals))
 
+def test_sympy__stats__drv__ProductDiscreteDomain():
+    from sympy.stats.drv import SingleDiscreteDomain, ProductDiscreteDomain
+    X = SingleDiscreteDomain(x, S.Naturals)
+    Y = SingleDiscreteDomain(y, S.Integers)
+    assert _test_args(ProductDiscreteDomain(X, Y))
+
 def test_sympy__stats__drv__SingleDiscretePSpace():
     from sympy.stats.drv import SingleDiscretePSpace
     from sympy.stats.drv_types import PoissonDistribution
@@ -798,6 +803,12 @@ def test_sympy__stats__drv__DiscretePSpace():
     domain = SingleDiscreteDomain(x, S.Naturals)
     assert _test_args(DiscretePSpace(domain, density))
 
+def test_sympy__stats__drv__ProductDiscretePSpace():
+    from sympy.stats.drv import SingleDiscretePSpace, ProductDiscretePSpace
+    from sympy.stats.drv_types import PoissonDistribution as pd
+    assert _test_args(ProductDiscretePSpace(SingleDiscretePSpace(
+        x, pd(1)), SingleDiscretePSpace(y, pd(2))))
+
 def test_sympy__stats__drv__ConditionalDiscreteDomain():
     from sympy.stats.drv import ConditionalDiscreteDomain, SingleDiscreteDomain
     X = SingleDiscreteDomain(x, S.Naturals0)
@@ -805,6 +816,11 @@ def test_sympy__stats__drv__ConditionalDiscreteDomain():
 
 @SKIP("abstract class")
 def test_sympy__stats__drv__SingleDiscreteDistribution():
+    pass
+
+
+@SKIP("abstract class")
+def test_sympy__stats__drv__DiscreteDistribution():
     pass
 
 @SKIP("abstract class")
@@ -900,8 +916,7 @@ def test_sympy__stats__frv_types__DiscreteUniformDistribution():
 
 
 def test_sympy__stats__frv_types__DieDistribution():
-    from sympy.stats.frv_types import DieDistribution
-    assert _test_args(DieDistribution(6))
+    assert _test_args(die)
 
 
 def test_sympy__stats__frv_types__BernoulliDistribution():
@@ -988,6 +1003,10 @@ def test_sympy__stats__crv__ContinuousDistributionHandmade():
     from sympy import Symbol, Interval
     assert _test_args(ContinuousDistributionHandmade(Symbol('x'),
                                                      Interval(0, 2)))
+
+def test_sympy__stats__drv__DiscreteDistributionHandmade():
+    from sympy.stats.drv import DiscreteDistributionHandmade
+    assert _test_args(DiscreteDistributionHandmade(x, S.Naturals))
 
 def test_sympy__stats__rv__Density():
     from sympy.stats.rv import Density

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -323,7 +323,7 @@ class ContinuousPSpace(PSpace):
         cf = integrate(exp(I*t*x)*d(x), (x, -oo, oo), **kwargs)
         return Lambda(t, cf)
 
-    def probability(self, condition, **kwargs):
+    def probability(self, condition, evaluate = True, **kwargs):
         z = Dummy('z', real=True, finite=True)
         cond_inv = False
         if isinstance(condition, Ne):

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -205,7 +205,7 @@ class DiscretePSpace(PSpace):
     def eval_prob(self, _domain):
         sym = list(self.symbols)[0]
         if isinstance(_domain, Range):
-            n = symbols('n', real = True, finite = True)
+            n = symbols('n', integer=True, finite=True)
             inf, sup, step = (r for r in _domain.args)
             summand = ((self.pdf).replace(
               sym, n*step))

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -196,9 +196,8 @@ class DiscretePSpace(PSpace):
             from sympy.stats.rv import density
             expr = condition.lhs - condition.rhs
             dens = density(expr)
-            domain = Intersection(*[i.set for i in self.domain.domains])
             if not isinstance(dens, DiscreteDistribution):
-                dens = DiscreteDistributionHandmade(dens, domain)
+                dens = DiscreteDistributionHandmade(dens)
             z = Dummy('z', real = True)
             space = SingleDiscretePSpace(z, dens)
             return space.probability(condition.__class__(space.value, 0))

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -296,7 +296,7 @@ class FinitePSpace(PSpace):
         return sum([expr.xreplace(dict(elem)) * self.prob_of(elem)
                 for elem in self.domain])
 
-    def probability(self, condition):
+    def probability(self, condition, evaluate=True):
         cond_symbols = frozenset(rs.symbol for rs in random_symbols(condition))
         assert cond_symbols.issubset(self.symbols)
         return sum(self.prob_of(elem) for elem in self.where(condition))

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -37,6 +37,7 @@ class RandomDomain(Basic):
     is_ProductDomain = False
     is_Finite = False
     is_Continuous = False
+    is_Discrete = False
 
     def __new__(cls, symbols, *args):
         symbols = FiniteSet(*symbols)
@@ -292,6 +293,9 @@ class ProductPSpace(PSpace):
         if all(space.is_Continuous for space in spaces):
             from sympy.stats.crv import ProductContinuousPSpace
             cls = ProductContinuousPSpace
+        if all(space.is_Discrete for space in spaces):
+            from sympy.stats.drv import ProductDiscretePSpace
+            cls = ProductDiscretePSpace
 
         obj = Basic.__new__(cls, *FiniteSet(*spaces))
 
@@ -366,6 +370,9 @@ class ProductDomain(RandomDomain):
         if all(domain.is_Continuous for domain in domains2):
             from sympy.stats.crv import ProductContinuousDomain
             cls = ProductContinuousDomain
+        if all(domain.is_Discrete for domain in domains2):
+            from sympy.stats.drv import ProductDiscreteDomain
+            cls = ProductDiscreteDomain
 
         return Basic.__new__(cls, *domains2)
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -650,7 +650,7 @@ def probability(condition, given_condition=None, numsamples=None,
         return probability(given(condition, given_condition, **kwargs), **kwargs)
 
     # Otherwise pass work off to the ProbabilitySpace
-    result = pspace(condition).probability(condition, **kwargs)
+    result = pspace(condition).probability(condition, evaluate, **kwargs)
     if evaluate and hasattr(result, 'doit'):
         return result.doit()
     else:

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -96,5 +96,5 @@ def test_product_spaces():
     assert P(X1 + X2 < 3, evaluate=False) == Probability(X1 + X2 < 3)
     assert P(X1 + X2 > 3, evaluate=False) == Probability(X1 + X2 > 3)
     assert P(Eq(X1 + X2, 3), evaluate=False) == Probability(Eq(X1 + X2, 3))
-    assert P(Eq(X1 + X2, 3)).Sum(Piecewise(
-        (2**(X2 - 2)*(2/3)**(X2 - 1)/6, X2 <= 2), (0, True)), (X2, 1, oo))
+    assert P(Eq(X1 + X2, 3)) == Sum(
+        Piecewise((2**(X2 - 2)*(2/3)**(X2 - 1)/6, X2 <= 2), (0, True)), (X2, 1, oo))

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -96,5 +96,5 @@ def test_product_spaces():
     assert P(X1 + X2 < 3, evaluate=False) == Probability(X1 + X2 < 3)
     assert P(X1 + X2 > 3, evaluate=False) == Probability(X1 + X2 > 3)
     assert P(Eq(X1 + X2, 3), evaluate=False) == Probability(Eq(X1 + X2, 3))
-    assert P(Eq(X1 + X2, 3)) == Sum(
-        Piecewise((2**(X2 - 2)*(2/3)**(X2 - 1)/6, X2 <= 2), (0, True)), (X2, 1, oo))
+    assert str(P(Eq(X1 + X2, 3)) == Sum(
+        Piecewise((2**(X2 - 2)*(S(2)/3)**(X2 - 1)/6, X2 <= 2), (0, True)), (X2, 1, oo)))

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -86,3 +86,9 @@ def test_conditional():
     assert P(X > 3, X > 2) == S(1)/3
     assert P(Y > 2, Y < 2) == 0
     assert P(Eq(Y, 3), Y >= 0) == 9*exp(-3)/2
+
+def test_product_spaces():
+    X1 = Geometric('X1', S(1)/2)
+    X2 = Geometric('X2', S(1)/3)
+    assert P(X1 + X2) < 3 == S(1)/6
+    assert P(X1 + X2) > 3 == S(5)/6

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -5,8 +5,10 @@ from sympy import S, Sum
 from sympy.stats import (P, E, variance, density, characteristic_function,
         where)
 from sympy.stats.rv import sample
+from sympy.stats.symbolic_probability import Probability
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.sets.fancysets import Range
 from sympy.logic.boolalg import Or
 
@@ -90,5 +92,9 @@ def test_conditional():
 def test_product_spaces():
     X1 = Geometric('X1', S(1)/2)
     X2 = Geometric('X2', S(1)/3)
-    assert P(X1 + X2) < 3 == S(1)/6
-    assert P(X1 + X2) > 3 == S(5)/6
+    oo = S.Infinity
+    assert P(X1 + X2 < 3, evaluate=False) == Probability(X1 + X2 < 3)
+    assert P(X1 + X2 > 3, evaluate=False) == Probability(X1 + X2 > 3)
+    assert P(Eq(X1 + X2, 3), evaluate=False) == Probability(Eq(X1 + X2, 3))
+    assert P(Eq(X1 + X2, 3)).Sum(Piecewise(
+        (2**(X2 - 2)*(2/3)**(X2 - 1)/6, X2 <= 2), (0, True)), (X2, 1, oo))


### PR DESCRIPTION
Added classes `ProductDiscretePSpace`, `ProductDiscreteDomain` and
`DiscreteDistributionHandmade` to allow expressions containing multiple
discrete random variables.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments
This PR is not yet complete and requires some changes before merging.