### PR TITLE
Add automaton for word reduction in rewriting systems

### DIFF
--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -322,7 +322,7 @@ class RewritingSystem(object):
             for i in range (1, len(letter_word_array)):
                 letter_word_array[i] = letter_word_array[i-1]*letter_word_array[i]
             self.proper_prefixes[r] = letter_word_array
-        
+
         # Create the states in the automaton. 
         # The left-hand side of the rules are the dead states.
         # The proper left-hand side of the rules are the accept states.
@@ -346,7 +346,6 @@ class RewritingSystem(object):
         for state in fsm.states:
             current_state_name = state.name
             current_state_type = state.state_type
-            # print(current_state_type)
             if current_state_type == "start":
                 for letter in self.automaton_alphabets:
                     if letter in fsm.state_names:
@@ -357,7 +356,6 @@ class RewritingSystem(object):
                 for letter in self.automaton_alphabets:
                     next = current_state_name*letter
                     len_next_word = len(next)
-                    # print(next, len_next_word, len(current_state_name))
                     while True:
                         if len(next) <= 1:
                             if next in fsm.state_names:
@@ -370,6 +368,35 @@ class RewritingSystem(object):
                                 state.add_transition(letter, next)
                                 break
                             next = next.subword(1, len(next))
+        
+        return fsm
 
-        # for i in fsm.states:
-        #     print(i.name, i.state_type, i.transitions)
+    def reduce_using_automaton(self, word):
+        '''
+        The method for word reduction using automaton is mentioned in the section 13.1.3 of the Handook. 
+        All the elements of the automaton are stored in an array and are given as the input to the automaton.
+        If the automaton reaches a dead state that subword is replaced and the automaton is run from the beginning. 
+        This is repeated until the word reached the end and the automaton stays in the accept state.
+        
+        '''
+        fsm = self.construct_automaton()
+        while True:
+            flag = 1
+            current_state = fsm.states[0]
+            word_array = [s for s in word.letter_form_elm]
+            for i in range (0, len(word_array)):
+                next_state_name = current_state.transitions[word_array[i]]
+                next_state = None
+                for state in fsm.states:
+                    if state.name == next_state_name:
+                        next_state = state
+                if next_state.state_type == "dead":
+                    subst = self.rules[next_state_name]
+                    word = word.substituted_word(i - len(next_state_name) + 1, i+1, subst)
+                    flag = 0
+                    break
+                current_state = next_state
+            # Break if the whole word is read and no dead state is encountered. 
+            if flag == 1:
+                break
+        return word

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -37,7 +37,7 @@ class RewritingSystem(object):
         self.rules_cache = deque([], 50)
         self._init_rules()
 
-        # Automaton variables 
+        # Automaton variables
         self.automaton_alphabets = []
         self.left_hand_rules = []
         self.proper_prefixes = {}
@@ -310,7 +310,7 @@ class RewritingSystem(object):
         # Contains the alphabets that will be used for state transitions.
         self.automaton_alphabets = generators
 
-        # Store the complete left hand side of the rules - dead states.        
+        # Store the complete left hand side of the rules - dead states.
         for r in self.rules:
             if not r in self.left_hand_rules:
                 self.left_hand_rules.append(r)
@@ -323,14 +323,14 @@ class RewritingSystem(object):
                 letter_word_array[i] = letter_word_array[i-1]*letter_word_array[i]
             self.proper_prefixes[r] = letter_word_array
 
-        # Create the states in the automaton. 
+        # Create the states in the automaton.
         # The left-hand side of the rules are the dead states.
         # The proper left-hand side of the rules are the accept states.
 
         fsm = StateMachine('fsm')
         fsm.add_state('start', is_start=True)
 
-        # Add dead states. 
+        # Add dead states.
         for rule in self.left_hand_rules:
             if not rule in fsm.state_names:
                 fsm.add_state(rule, is_dead=True)
@@ -368,16 +368,15 @@ class RewritingSystem(object):
                                 state.add_transition(letter, next)
                                 break
                             next = next.subword(1, len(next))
-        
         return fsm
 
     def reduce_using_automaton(self, word):
         '''
-        The method for word reduction using automaton is mentioned in the section 13.1.3 of the Handook. 
+        The method for word reduction using automaton is mentioned in the section 13.1.3 of the Handook.
         All the elements of the automaton are stored in an array and are given as the input to the automaton.
-        If the automaton reaches a dead state that subword is replaced and the automaton is run from the beginning. 
+        If the automaton reaches a dead state that subword is replaced and the automaton is run from the beginning.
         This is repeated until the word reached the end and the automaton stays in the accept state.
-        
+
         '''
         fsm = self.construct_automaton()
         while True:
@@ -396,7 +395,7 @@ class RewritingSystem(object):
                     flag = 0
                     break
                 current_state = next_state
-            # Break if the whole word is read and no dead state is encountered. 
+            # Break if the whole word is read and no dead state is encountered.
             if flag == 1:
                 break
         return word

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -410,10 +410,7 @@ class RewritingSystem(object):
             word_array = [s for s in word.letter_form_elm]
             for i in range (0, len(word_array)):
                 next_state_name = current_state.transitions[word_array[i]]
-                next_state = None
-                for state in self.reduction_automaton.states:
-                    if state == next_state_name:
-                        next_state = self.reduction_automaton.states[state]
+                next_state = self.reduction_automaton.states[next_state_name]
                 if next_state.state_type == "dead":
                     subst = all_rules[next_state_name]
                     word = word.substituted_word(i - len(next_state_name) + 1, i+1, subst)

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -41,8 +41,12 @@ class RewritingSystem(object):
         self.rules_cache = deque([], 50)
         self._init_rules()
 
+
+        # All the transition symbols in the automaton
+        generators = list(self.alphabet)
+        generators += [gen**-1 for gen in generators]
         # Create a finite state machine as an instance of the StateMachine object
-        self.reduction_automaton = StateMachine('fsm')
+        self.reduction_automaton = StateMachine('Reduction automaton for '+ repr(self.group), generators)
         self.construct_automaton()
 
     def set_max(self, n):
@@ -343,7 +347,7 @@ class RewritingSystem(object):
             rules (dictionary) -- Dictionary of the newly added rules.
 
         '''
-        # Automaton vairables
+        # Automaton variables
         automaton_alphabet = []
         proper_prefixes = {}
 
@@ -351,10 +355,6 @@ class RewritingSystem(object):
         all_rules = rules
         inverse_rules = self._compute_inverse_rules(all_rules)
         all_rules.update(inverse_rules)
-
-        # All the transition symbols in the automaton
-        generators = list(self.alphabet)
-        generators += [gen**-1 for gen in generators]
 
         # Keep track of the accept_states.
         accept_states = []
@@ -392,7 +392,7 @@ class RewritingSystem(object):
             current_state_type = self.reduction_automaton.states[state].state_type
             # Transitions will be modified only when current_state belongs to the proper_perfixes of the new rules.
             # The rest are ignored if they cannot lead to a dead state after a finite number of transisitons.
-            if current_state_type == "start":
+            if current_state_type == 's':
                 for letter in automaton_alphabet:
                     if letter in self.reduction_automaton.states:
                         self.reduction_automaton.states[state].add_transition(letter, letter)
@@ -409,7 +409,7 @@ class RewritingSystem(object):
                 for sub_word in current_state_name_array:
                     if sub_word in accept_states:
                         # Add accept states.
-                        if current_state_type == "accept":
+                        if current_state_type == 'a':
                             for letter in automaton_alphabet:
                                 next = current_state_name*letter
                                 while True:
@@ -427,11 +427,11 @@ class RewritingSystem(object):
                         break
 
         # Add transitions for new states. All symbols used in the automaton are considered here.
-        # Ignore this if `generators` = `automaton_alphabet`.
-        if len(generators) != len(automaton_alphabet):
+        # Ignore this if `self.automaton_alphabet` = `automaton_alphabet`.
+        if len(self.reduction_automaton.automaton_alphabet) != len(automaton_alphabet):
             for state in proper_prefixes:
                 current_state_name = state
-                for letter in generators:
+                for letter in self.reduction_automaton.automaton_alphabet:
                     next = current_state_name*letter
                     len_next_word = len(next)
                     while True:
@@ -474,7 +474,7 @@ class RewritingSystem(object):
             for i in range (0, len(word_array)):
                 next_state_name = current_state.transitions[word_array[i]]
                 next_state = self.reduction_automaton.states[next_state_name]
-                if next_state.state_type == "dead":
+                if next_state.state_type == 'd':
                     subst = next_state.rh_rule
                     word = word.substituted_word(i - len(next_state_name) + 1, i+1, subst)
                     flag = 1

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -375,7 +375,7 @@ class RewritingSystem(object):
         The method for word reduction using automaton is mentioned in the section 13.1.3 of the Handook.
         All the elements of the automaton are stored in an array and are given as the input to the automaton.
         If the automaton reaches a dead state that subword is replaced and the automaton is run from the beginning.
-        This is repeated until the word reached the end and the automaton stays in the accept state.
+        This is repeated until the word reaches the end and the automaton stays in the accept state.
 
         '''
         fsm = self.construct_automaton()

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -38,7 +38,7 @@ class RewritingSystem(object):
         self._init_rules()
 
         # Automaton variables
-        self.automaton_alphabets = []
+        self.automaton_alphabet = []
         self.left_hand_rules = []
         self.proper_prefixes = {}
 
@@ -302,18 +302,14 @@ class RewritingSystem(object):
 
         '''
 
-        generators = [x for x in self.alphabet]
-        for gen in generators:
-            if not gen**-1 in generators:
-                generators.append(gen**-1)
+        generators = list(self.alphabet)
+        generators += [gen**-1 for gen in generators]
 
         # Contains the alphabets that will be used for state transitions.
-        self.automaton_alphabets = generators
+        self.automaton_alphabet = generators
 
         # Store the complete left hand side of the rules - dead states.
-        for r in self.rules:
-            if not r in self.left_hand_rules:
-                self.left_hand_rules.append(r)
+        self.left_hand_rules = list(self.rules)
 
         # Compute the proper prefixes for every rule.
         for r in self.rules:
@@ -347,13 +343,13 @@ class RewritingSystem(object):
             current_state_name = state.name
             current_state_type = state.state_type
             if current_state_type == "start":
-                for letter in self.automaton_alphabets:
+                for letter in self.automaton_alphabet:
                     if letter in fsm.state_names:
                         state.add_transition(letter, letter)
                     else:
                         state.add_transition(letter, current_state_name)
             elif current_state_type == "accept":
-                for letter in self.automaton_alphabets:
+                for letter in self.automaton_alphabet:
                     next = current_state_name*letter
                     len_next_word = len(next)
                     while True:
@@ -372,7 +368,7 @@ class RewritingSystem(object):
 
     def reduce_using_automaton(self, word):
         '''
-        The method for word reduction using automaton is mentioned in the section 13.1.3 of the Handook.
+        The method for word reduction using automaton is mentioned in the section 13.1.3 of the Handbook.
         All the elements of the automaton are stored in an array and are given as the input to the automaton.
         If the automaton reaches a dead state that subword is replaced and the automaton is run from the beginning.
         This is repeated until the word reaches the end and the automaton stays in the accept state.

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -36,6 +36,11 @@ class RewritingSystem(object):
         self.rules_cache = deque([], 50)
         self._init_rules()
 
+        # Automaton variables 
+        self.automaton_alphabets = []
+        self.prefixes = []
+        self.proper_prefixes = {}
+
     def set_max(self, n):
         '''
         Set the maximum number of rules that can be defined
@@ -285,3 +290,37 @@ class RewritingSystem(object):
                 if new != prev:
                     again = True
         return new
+
+    def construct_automaton(self):
+        '''
+        Construct the automaton based on the set of reduction rules of the system.
+
+        Automata Design:
+        1. The accept states of the automaton are the proper prefixes of the left hand side of the rules.
+        2. The complete left hand side of the rules are the dead states of the automaton
+
+        '''
+
+        generators = [x for x in self.alphabet]
+        for gen in generators:
+            if not gen**-1 in generators:
+                generators.append(gen**-1)
+
+        # Contains the alphabets that will be used for state transitions
+        self.automaton_alphabets = generators
+
+        for r in self.rules:
+            if not r in self.prefixes:
+                self.prefixes.append(r)
+
+        # Compute the proper prefixes for every rule.
+        for r in self.rules:
+            self.proper_prefixes[r] = []
+            letter_word_array = [s for s in r.letter_form_elm]
+            for i in range (1, len(letter_word_array)):
+                letter_word_array[i] = letter_word_array[i-1]*letter_word_array[i]
+            self.proper_prefixes[r] = letter_word_array
+        
+        print(self.automaton_alphabets)
+        print(self.prefixes)
+        print(self.proper_prefixes)

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -43,7 +43,6 @@ class RewritingSystem(object):
 
         # Create a finite state machine as an instance of the StateMachine object
         self.reduction_automaton = StateMachine('fsm')
-        self.reduction_automaton.add_state('start', state_type='s')
         self.construct_automaton()
 
     def set_max(self, n):

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -318,7 +318,7 @@ class RewritingSystem(object):
 
         Automata Design:
         The accept states of the automaton are the proper prefixes of the left hand side of the rules.
-        The complete left hand side of the rules are the dead states of the automaton
+        The complete left hand side of the rules are the dead states of the automaton.
 
         '''
         automaton_alphabet = []
@@ -355,7 +355,7 @@ class RewritingSystem(object):
         # This is essentially checking the left hand side of the rules.
         for rule in all_rules:
             if not rule in fsm.states:
-                fsm.add_state(rule, is_dead=True, subst=all_rules[rule])
+                fsm.add_state(rule, is_dead=True, rh_rule=all_rules[rule])
 
         # Add accept states.
         for r in all_rules:
@@ -435,7 +435,7 @@ class RewritingSystem(object):
         # This is essentially checking the left hand side of the rules.
         for rule in all_rules:
             if not rule in self.reduction_automaton.states:
-                self.reduction_automaton.add_state(rule, is_dead=True, subst=all_rules[rule])
+                self.reduction_automaton.add_state(rule, is_dead=True, rh_rule=all_rules[rule])
 
         # Add accept states.
         for r in all_rules:

--- a/sympy/combinatorics/rewritingsystem.py
+++ b/sympy/combinatorics/rewritingsystem.py
@@ -323,7 +323,7 @@ class RewritingSystem(object):
         '''
         # Create a finite state machine as an instance of the StateMachine object
         fsm = StateMachine('fsm')
-        fsm.add_state('start', is_start=True)
+        fsm.add_state('start', state_type='s')
 
         self.reduction_automaton = fsm
         self.add_to_automaton(self.rules)
@@ -374,14 +374,14 @@ class RewritingSystem(object):
         # This is essentially checking the left hand side of the rules.
         for rule in all_rules:
             if not rule in self.reduction_automaton.states:
-                self.reduction_automaton.add_state(rule, is_dead=True, rh_rule=all_rules[rule])
+                self.reduction_automaton.add_state(rule, state_type='d', rh_rule=all_rules[rule])
 
         # Add accept states.
         for r in all_rules:
             prop_prefix = proper_prefixes[r]
             for elem in prop_prefix:
                 if not elem in self.reduction_automaton.states:
-                    self.reduction_automaton.add_state(elem, is_accept=True)
+                    self.reduction_automaton.add_state(elem, state_type='a')
                     accept_states.append(elem)
 
         # Add new transitions for every state.
@@ -436,7 +436,7 @@ class RewritingSystem(object):
 
     def reduce_using_automaton(self, word):
         '''
-        Reduces a word using an automaton.
+        Reduce a word using an automaton.
 
         Summary:
         All the elements of the automaton are stored in an array and are given as the input to the automaton.

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -8,7 +8,7 @@ class State(object):
         is_dead (boolean): To mark if the state is a dead state.
         is_accept (boolean): To mark if te state is an accept state.
     """
-    
+
 
     def __init__(self, name, is_start=False, is_dead=False, is_accept=False):
         self.name = name
@@ -56,7 +56,7 @@ class StateMachine(object):
         states (list of States): Collection of all registered.
         name (str): Name of the state machine.
     """
-    
+
     def __init__(self, name):
         self.name = name
         self.states = [] # Contains all the states in the machine.

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -11,14 +11,13 @@ class State(object):
         rh_rule (instance of FreeGroupElement): right hand rule for dead state.
     '''
 
-
-    def __init__(self, name, is_start=False, is_dead=False, is_accept=False, subst=None):
+    def __init__(self, name, is_start=False, is_dead=False, is_accept=False, rh_rule=None):
         self.name = name
         self.is_start = is_start
         self.is_dead = is_dead
         self.is_accept = is_accept
         self.transitions = {}
-        self.rh_rule = subst
+        self.rh_rule = rh_rule
         self.state_type = None
         if is_start:
             self.state_type = "start"
@@ -51,7 +50,7 @@ class StateMachine(object):
         self.name = name
         self.states = {} # Contains all the states in the machine.
 
-    def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False, subst=None):
+    def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False, rh_rule=None):
         '''
         Instantiate a state object and stores it in the 'states' dictionary.
 
@@ -60,10 +59,10 @@ class StateMachine(object):
             is_start (boolean) -- To mark if the state is a start state.
             is_dead (boolean) -- To mark if the state is a dead state.
             is_accept (boolean) -- To mark if the state is an accept state.
-            subt (instance of FreeGroupElement) -- right hand rule for dead state.
+            rh_rule (instance of FreeGroupElement) -- right hand rule for dead state.
 
         '''
-        new_state = State(state_name, is_start, is_dead, is_accept, subst)
+        new_state = State(state_name, is_start, is_dead, is_accept, rh_rule)
         self.states[state_name] = new_state
 
     def __repr__(self):

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -1,0 +1,71 @@
+class State(object):
+    """A representation of a state managed by a ``StateMachine``.
+
+    Attributes:
+        name (str): State name which is also assigned to the Machine.
+        transisitons (OrderedDict): Represents all the transitions of the state object.
+        is_start (boolean): To mark if the state is a start state.
+        is_dead (boolean): To mark if the state is a dead state.
+        is_accept (boolean): To mark if te state is an accept state.
+    """
+    transistions = []
+
+    def __init__(self, name, is_start=False, is_dead=False, is_accept=False):
+        self.name = name
+        self.is_start = is_start
+        self.is_dead = is_dead
+        self.is_accept = is_accept 
+
+    def add_transisiton(self, alphabet, state) 
+        """
+        This method is to add a transition from the current state to a new state. 
+
+        Arguments: 
+            alphabet: The alphabet the current state reads to make the state transition. 
+            state: This will be an instance of the State object which represents a new state after in the transition after the alphabet is read. 
+        """
+        self.transistions[alphabet] = state
+
+    def set_start(self):
+        self.is_start = True
+    
+    def set_dead(self):
+        self.is_accept = False
+        self.is_dead = True
+
+    def set_accept(self):
+        self.is_dead = False
+        self.is_accept = True
+    
+    def __repr__(self):
+        return "%s" % (self.name)
+
+class StateMachine(object):
+    """ The state machine class which manages the states and their transisitons of the automata.
+
+    Attribute:
+        states (OrderedDict): Collection of all registered states.
+        name (str): Name of the state machine.
+    """
+
+    states = [] # Contains all the states in the machine.
+
+    def __init__(self, name):
+        self.name = name
+
+    def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False):
+        """
+        This instantiates a state object and stores this in the 'states' list.
+
+        Arguments: 
+            Same as the __init__ function of the State class. 
+        """
+        new_state = State(state_name, is_start, is_dead, is_accept)
+        states.append(new_state) 
+
+    def __repr__(self):
+        return "%s" % (self.name)
+    
+
+
+

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -3,27 +3,22 @@ class State(object):
     A representation of a state managed by a ``StateMachine``.
 
     Attributes:
-        name (instance of FreeGroupElement or string): State name which is also assigned to the Machine.
-        transisitons (OrderedDict): Represents all the transitions of the state object.
-        is_start (boolean): To mark if the state is a start state.
-        is_dead (boolean): To mark if the state is a dead state.
-        is_accept (boolean): To mark if the state is an accept state.
-        rh_rule (instance of FreeGroupElement): right hand rule for dead state.
+        name (instance of FreeGroupElement or string) -- State name which is also assigned to the Machine.
+        transisitons (OrderedDict) -- Represents all the transitions of the state object.
+        state_type (string) -- Denotes the type (accept/start/dead) of the state.
+        rh_rule (instance of FreeGroupElement) -- right hand rule for dead state.
     '''
 
-    def __init__(self, name, is_start=False, is_dead=False, is_accept=False, rh_rule=None):
+    def __init__(self, name, state_type=None, rh_rule=None):
         self.name = name
-        self.is_start = is_start
-        self.is_dead = is_dead
-        self.is_accept = is_accept
         self.transitions = {}
+        self.state_type = state_type
         self.rh_rule = rh_rule
-        self.state_type = None
-        if is_start:
+        if self.state_type == 's':
             self.state_type = "start"
-        elif is_accept:
+        elif self.state_type == 'a':
             self.state_type = "accept"
-        elif is_dead:
+        elif self.state_type == 'd':
             self.state_type = "dead"
 
     def add_transition(self, letter, state):
@@ -39,7 +34,7 @@ class State(object):
 
 class StateMachine(object):
     '''
-    Represents the attributes and methods of a finite state machine.
+    Representation of a finite state machine the manages the states and the transitions of the automaton.
 
     Attributes:
         states (dictionary) -- Collection of all registered `State` objects.
@@ -50,19 +45,17 @@ class StateMachine(object):
         self.name = name
         self.states = {} # Contains all the states in the machine.
 
-    def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False, rh_rule=None):
+    def add_state(self, state_name, state_type=None, rh_rule=None):
         '''
         Instantiate a state object and stores it in the 'states' dictionary.
 
         Arguments:
             state_name (instance of FreeGroupElement or string) -- name of the new states.
-            is_start (boolean) -- To mark if the state is a start state.
-            is_dead (boolean) -- To mark if the state is a dead state.
-            is_accept (boolean) -- To mark if the state is an accept state.
+            state_type (string) -- Denotes the type (accept/start/dead) of the state added.
             rh_rule (instance of FreeGroupElement) -- right hand rule for dead state.
 
         '''
-        new_state = State(state_name, is_start, is_dead, is_accept, rh_rule)
+        new_state = State(state_name, state_type, rh_rule)
         self.states[state_name] = new_state
 
     def __repr__(self):

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -6,7 +6,7 @@ class State(object):
         transisitons (OrderedDict): Represents all the transitions of the state object.
         is_start (boolean): To mark if the state is a start state.
         is_dead (boolean): To mark if the state is a dead state.
-        is_accept (boolean): To mark if te state is an accept state.
+        is_accept (boolean): To mark if the state is an accept state.
     """
 
 
@@ -24,30 +24,15 @@ class State(object):
         elif is_dead:
             self.state_type = "dead"
 
-    def add_transition(self, alphabet, state):
+    def add_transition(self, letter, state):
         """
         This method is to add a transition from the current state to a new state.
 
         Arguments:
-            alphabet: The alphabet the current state reads to make the state transition.
+            letter: The alphabet element the current state reads to make the state transition.
             state: This will be an instance of the State object which represents a new state after in the transition after the alphabet is read.
         """
-        self.transitions[alphabet] = state
-
-    def set_start(self):
-        self.is_start = True
-        self.state_type = "start"
-
-    def set_dead(self):
-        self.is_accept = False
-        self.is_dead = True
-        self.transisitons = {} # empty the transitions if it is a dead state.
-        self.state_type = "dead"
-
-    def set_accept(self):
-        self.is_dead = False
-        self.is_accept = True
-        self.state_type = "accept"
+        self.transitions[letter] = state
 
 class StateMachine(object):
     """ The state machine class which manages the states and their transisitons of the automata.

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -44,6 +44,7 @@ class StateMachine(object):
     def __init__(self, name):
         self.name = name
         self.states = {} # Contains all the states in the machine.
+        self.add_state('start', state_type='s')
 
     def add_state(self, state_name, state_type=None, rh_rule=None):
         '''

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -2,7 +2,7 @@ class State(object):
     """A representation of a state managed by a ``StateMachine``.
 
     Attributes:
-        name (str): State name which is also assigned to the Machine.
+        name (instance of FreeGroupElement or string): State name which is also assigned to the Machine.
         transisitons (OrderedDict): Represents all the transitions of the state object.
         is_start (boolean): To mark if the state is a start state.
         is_dead (boolean): To mark if the state is a dead state.
@@ -35,28 +35,30 @@ class State(object):
         self.transitions[letter] = state
 
 class StateMachine(object):
-    """ The state machine class which manages the states and their transisitons of the automata.
+    """
+    The state machine class which manages the states and their transisitons of the automata.
 
-    Attribute:
-        states (list of States): Collection of all registered.
+    Attributes:
+        states (dictionary): Collection of all registered.
         name (str): Name of the state machine.
     """
 
     def __init__(self, name):
         self.name = name
-        self.states = [] # Contains all the states in the machine.
-        self.state_names = []
+        self.states = {} # Contains all the states in the machine.
 
     def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False):
         """
         This instantiates a state object and stores this in the 'states' list.
 
         Arguments:
-            Same as the __init__ function of the State class.
+            state_name (instance of FreeGroupElement or string): name of the new states.
+            is_start (boolean): To mark if the state is a start state.
+            is_dead (boolean): To mark if the state is a dead state.
+            is_accept (boolean): To mark if the state is an accept state.
         """
         new_state = State(state_name, is_start, is_dead, is_accept)
-        self.states.append(new_state)
-        self.state_names.append(new_state.name)
+        self.states[state_name] = new_state
 
     def __repr__(self):
         return "%s" % (self.name)

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -22,22 +22,22 @@ class State(object):
         elif is_accept:
             self.state_type = "accept"
         elif is_dead:
-            self.state_type = "dead"           
+            self.state_type = "dead"
 
     def add_transition(self, alphabet, state):
         """
-        This method is to add a transition from the current state to a new state. 
+        This method is to add a transition from the current state to a new state.
 
         Arguments:
-            alphabet: The alphabet the current state reads to make the state transition. 
-            state: This will be an instance of the State object which represents a new state after in the transition after the alphabet is read. 
+            alphabet: The alphabet the current state reads to make the state transition.
+            state: This will be an instance of the State object which represents a new state after in the transition after the alphabet is read.
         """
         self.transitions[alphabet] = state
 
     def set_start(self):
         self.is_start = True
         self.state_type = "start"
-    
+
     def set_dead(self):
         self.is_accept = False
         self.is_dead = True
@@ -66,7 +66,7 @@ class StateMachine(object):
         """
         This instantiates a state object and stores this in the 'states' list.
 
-        Arguments: 
+        Arguments:
             Same as the __init__ function of the State class.
         """
         new_state = State(state_name, is_start, is_dead, is_accept)

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -7,19 +7,21 @@ class State(object):
         transisitons (OrderedDict) -- Represents all the transitions of the state object.
         state_type (string) -- Denotes the type (accept/start/dead) of the state.
         rh_rule (instance of FreeGroupElement) -- right hand rule for dead state.
+        state_machine (instance of StateMachine object) -- The finite state machine that the state belongs to.
     '''
 
-    def __init__(self, name, state_type=None, rh_rule=None):
+    def __init__(self, name, state_machine, state_type=None, rh_rule=None):
         self.name = name
         self.transitions = {}
+        self.state_machine = state_machine
         self.state_type = state_type
         self.rh_rule = rh_rule
-        if self.state_type == 's':
-            self.state_type = "start"
-        elif self.state_type == 'a':
-            self.state_type = "accept"
-        elif self.state_type == 'd':
-            self.state_type = "dead"
+        if self.state_type == "start":
+            self.state_type = 's'
+        elif self.state_type == "accept":
+            self.state_type = 'a'
+        elif self.state_type == "dead":
+            self.state_type = 'd'
 
     def add_transition(self, letter, state):
         '''
@@ -41,8 +43,9 @@ class StateMachine(object):
         name (str) -- Name of the state machine.
     '''
 
-    def __init__(self, name):
+    def __init__(self, name, automaton_alphabet):
         self.name = name
+        self.automaton_alphabet = automaton_alphabet
         self.states = {} # Contains all the states in the machine.
         self.add_state('start', state_type='s')
 
@@ -56,7 +59,7 @@ class StateMachine(object):
             rh_rule (instance of FreeGroupElement) -- right hand rule for dead state.
 
         '''
-        new_state = State(state_name, state_type, rh_rule)
+        new_state = State(state_name, self, state_type, rh_rule)
         self.states[state_name] = new_state
 
     def __repr__(self):

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -14,14 +14,8 @@ class State(object):
         self.name = name
         self.transitions = {}
         self.state_machine = state_machine
-        self.state_type = state_type
+        self.state_type = state_type[0]
         self.rh_rule = rh_rule
-        if self.state_type == "start":
-            self.state_type = 's'
-        elif self.state_type == "accept":
-            self.state_type = 'a'
-        elif self.state_type == "dead":
-            self.state_type = 'd'
 
     def add_transition(self, letter, state):
         '''

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -1,5 +1,6 @@
 class State(object):
-    """A representation of a state managed by a ``StateMachine``.
+    '''
+    A representation of a state managed by a ``StateMachine``.
 
     Attributes:
         name (instance of FreeGroupElement or string): State name which is also assigned to the Machine.
@@ -7,8 +8,8 @@ class State(object):
         is_start (boolean): To mark if the state is a start state.
         is_dead (boolean): To mark if the state is a dead state.
         is_accept (boolean): To mark if the state is an accept state.
-        subt (instance of FreeGroupElement): right hand rule for dead state.
-    """
+        rh_rule (instance of FreeGroupElement): right hand rule for dead state.
+    '''
 
 
     def __init__(self, name, is_start=False, is_dead=False, is_accept=False, subst=None):
@@ -27,39 +28,41 @@ class State(object):
             self.state_type = "dead"
 
     def add_transition(self, letter, state):
-        """
-        This method is to add a transition from the current state to a new state.
+        '''
+        Add a transition from the current state to a new state.
 
-        Arguments:
-            letter: The alphabet element the current state reads to make the state transition.
-            state: This will be an instance of the State object which represents a new state after in the transition after the alphabet is read.
-        """
+        Keyword Arguments:
+            letter -- The alphabet element the current state reads to make the state transition.
+            state -- This will be an instance of the State object which represents a new state after in the transition after the alphabet is read.
+
+        '''
         self.transitions[letter] = state
 
 class StateMachine(object):
-    """
-    The state machine class which manages the states and their transisitons of the automata.
+    '''
+    Represents the attributes and methods of a finite state machine.
 
     Attributes:
-        states (dictionary): Collection of all registered.
-        name (str): Name of the state machine.
-    """
+        states (dictionary) -- Collection of all registered `State` objects.
+        name (str) -- Name of the state machine.
+    '''
 
     def __init__(self, name):
         self.name = name
         self.states = {} # Contains all the states in the machine.
 
     def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False, subst=None):
-        """
-        This instantiates a state object and stores this in the 'states' list.
+        '''
+        Instantiate a state object and stores it in the 'states' dictionary.
 
         Arguments:
-            state_name (instance of FreeGroupElement or string): name of the new states.
-            is_start (boolean): To mark if the state is a start state.
-            is_dead (boolean): To mark if the state is a dead state.
-            is_accept (boolean): To mark if the state is an accept state.
-            subt (instance of FreeGroupElement): right hand rule for dead state.
-        """
+            state_name (instance of FreeGroupElement or string) -- name of the new states.
+            is_start (boolean) -- To mark if the state is a start state.
+            is_dead (boolean) -- To mark if the state is a dead state.
+            is_accept (boolean) -- To mark if the state is an accept state.
+            subt (instance of FreeGroupElement) -- right hand rule for dead state.
+
+        '''
         new_state = State(state_name, is_start, is_dead, is_accept, subst)
         self.states[state_name] = new_state
 

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -8,19 +8,27 @@ class State(object):
         is_dead (boolean): To mark if the state is a dead state.
         is_accept (boolean): To mark if te state is an accept state.
     """
-    transitions = {}
+    
 
     def __init__(self, name, is_start=False, is_dead=False, is_accept=False):
         self.name = name
         self.is_start = is_start
         self.is_dead = is_dead
         self.is_accept = is_accept
+        self.transitions = {}
+        self.state_type = None
+        if is_start:
+            self.state_type = "start"
+        elif is_accept:
+            self.state_type = "accept"
+        elif is_dead:
+            self.state_type = "dead"           
 
     def add_transition(self, alphabet, state):
         """
         This method is to add a transition from the current state to a new state. 
 
-        Arguments: 
+        Arguments:
             alphabet: The alphabet the current state reads to make the state transition. 
             state: This will be an instance of the State object which represents a new state after in the transition after the alphabet is read. 
         """
@@ -28,41 +36,42 @@ class State(object):
 
     def set_start(self):
         self.is_start = True
+        self.state_type = "start"
     
     def set_dead(self):
         self.is_accept = False
         self.is_dead = True
         self.transisitons = {} # empty the transitions if it is a dead state.
+        self.state_type = "dead"
 
     def set_accept(self):
         self.is_dead = False
         self.is_accept = True
-    
-    def __repr__(self):
-        return "%s" % (self.name)
+        self.state_type = "accept"
 
 class StateMachine(object):
     """ The state machine class which manages the states and their transisitons of the automata.
 
     Attribute:
-        states (list of States): Collection of all registered states.
+        states (list of States): Collection of all registered.
         name (str): Name of the state machine.
     """
-
-    states = [] # Contains all the states in the machine.
-
+    
     def __init__(self, name):
         self.name = name
+        self.states = [] # Contains all the states in the machine.
+        self.state_names = []
 
     def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False):
         """
         This instantiates a state object and stores this in the 'states' list.
 
         Arguments: 
-            Same as the __init__ function of the State class. 
+            Same as the __init__ function of the State class.
         """
         new_state = State(state_name, is_start, is_dead, is_accept)
-        self.states.append(new_state) 
+        self.states.append(new_state)
+        self.state_names.append(new_state.name)
 
     def __repr__(self):
         return "%s" % (self.name)

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -7,15 +7,17 @@ class State(object):
         is_start (boolean): To mark if the state is a start state.
         is_dead (boolean): To mark if the state is a dead state.
         is_accept (boolean): To mark if the state is an accept state.
+        subt (instance of FreeGroupElement): right hand rule for dead state.
     """
 
 
-    def __init__(self, name, is_start=False, is_dead=False, is_accept=False):
+    def __init__(self, name, is_start=False, is_dead=False, is_accept=False, subst=None):
         self.name = name
         self.is_start = is_start
         self.is_dead = is_dead
         self.is_accept = is_accept
         self.transitions = {}
+        self.rh_rule = subst
         self.state_type = None
         if is_start:
             self.state_type = "start"
@@ -47,7 +49,7 @@ class StateMachine(object):
         self.name = name
         self.states = {} # Contains all the states in the machine.
 
-    def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False):
+    def add_state(self, state_name, is_start=False, is_dead=False, is_accept=False, subst=None):
         """
         This instantiates a state object and stores this in the 'states' list.
 
@@ -56,8 +58,9 @@ class StateMachine(object):
             is_start (boolean): To mark if the state is a start state.
             is_dead (boolean): To mark if the state is a dead state.
             is_accept (boolean): To mark if the state is an accept state.
+            subt (instance of FreeGroupElement): right hand rule for dead state.
         """
-        new_state = State(state_name, is_start, is_dead, is_accept)
+        new_state = State(state_name, is_start, is_dead, is_accept, subst)
         self.states[state_name] = new_state
 
     def __repr__(self):

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -14,7 +14,7 @@ class State(object):
         self.name = name
         self.is_start = is_start
         self.is_dead = is_dead
-        self.is_accept = is_accept 
+        self.is_accept = is_accept
 
     def add_transition(self, alphabet, state):
         """

--- a/sympy/combinatorics/rewritingsystem_fsm.py
+++ b/sympy/combinatorics/rewritingsystem_fsm.py
@@ -8,7 +8,7 @@ class State(object):
         is_dead (boolean): To mark if the state is a dead state.
         is_accept (boolean): To mark if te state is an accept state.
     """
-    transistions = []
+    transitions = {}
 
     def __init__(self, name, is_start=False, is_dead=False, is_accept=False):
         self.name = name
@@ -16,7 +16,7 @@ class State(object):
         self.is_dead = is_dead
         self.is_accept = is_accept 
 
-    def add_transisiton(self, alphabet, state) 
+    def add_transition(self, alphabet, state):
         """
         This method is to add a transition from the current state to a new state. 
 
@@ -24,7 +24,7 @@ class State(object):
             alphabet: The alphabet the current state reads to make the state transition. 
             state: This will be an instance of the State object which represents a new state after in the transition after the alphabet is read. 
         """
-        self.transistions[alphabet] = state
+        self.transitions[alphabet] = state
 
     def set_start(self):
         self.is_start = True
@@ -32,6 +32,7 @@ class State(object):
     def set_dead(self):
         self.is_accept = False
         self.is_dead = True
+        self.transisitons = {} # empty the transitions if it is a dead state.
 
     def set_accept(self):
         self.is_dead = False
@@ -44,7 +45,7 @@ class StateMachine(object):
     """ The state machine class which manages the states and their transisitons of the automata.
 
     Attribute:
-        states (OrderedDict): Collection of all registered states.
+        states (list of States): Collection of all registered states.
         name (str): Name of the state machine.
     """
 
@@ -61,11 +62,7 @@ class StateMachine(object):
             Same as the __init__ function of the State class. 
         """
         new_state = State(state_name, is_start, is_dead, is_accept)
-        states.append(new_state) 
+        self.states.append(new_state) 
 
     def __repr__(self):
         return "%s" % (self.name)
-    
-
-
-

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -12,6 +12,10 @@ def test_rewriting():
     assert G.reduce(b**3*a**4*b**-2*a) == a**5*b
     assert G.equals(b**2*a**-1*b, b**4*a**-1*b**-1)
 
+    assert R.reduce_using_automaton(b*a*a**2*b**-1) == a**3
+    assert R.reduce_using_automaton(b**3*a**4*b**-2*a) == a**5*b
+    assert R.reduce_using_automaton(b**-1*a) == a*b**-1
+
     G = FpGroup(F, [a**3, b**3, (a*b)**2])
     R = G._rewriting_system
     R.make_confluent()

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -37,3 +37,4 @@ def test_rewriting():
     # Check after adding a rule
     R.add_rule(a**2, b)
     assert R.reduce_using_automaton(a**2*b**-2*a**2*b) == b**-1
+    assert R.reduce_using_automaton(a**4*b**-2*a**2*b**3) == b

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -16,6 +16,17 @@ def test_rewriting():
     assert R.reduce_using_automaton(b**3*a**4*b**-2*a) == a**5*b
     assert R.reduce_using_automaton(b**-1*a) == a*b**-1
 
+    # Add rules
+    R.add_rule(a*b**5, b**2)
+    assert G.reduce(b**2*a*b**3) == a**-1*b**-1
+    assert R.reduce_using_automaton(b**2*a*b**3) == a**-1*b**-1
+
+    G = FpGroup(F, [a**2, b**3, (a*b)**4])
+    a, b = G.generators
+    R = G._rewriting_system
+    assert G.reduce(a**2*b**-2*a**2*b) == b**-1
+    assert R.reduce_using_automaton(a**2*b**-2*a**2*b) == b**-1
+
     G = FpGroup(F, [a**3, b**3, (a*b)**2])
     R = G._rewriting_system
     R.make_confluent()
@@ -25,3 +36,8 @@ def test_rewriting():
     # but also the system should actually be confluent
     assert R._check_confluence()
     assert G.reduce(b*a**-1*b**-1*a**3*b**4*a**-1*b**-15) == a**-1*b**-1
+    # Additional tests
+    assert G.reduce(a**2*b**-1*a) == b*a**-1
+    assert R.reduce_using_automaton(a**2*b**-1*a) == b*a**-1
+    assert G.reduce(a**2*b**-1*a*b**3*a**-2) == b
+    assert R.reduce_using_automaton(a**2*b**-1*a*b**3*a**-2) == b

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -16,11 +16,6 @@ def test_rewriting():
     assert R.reduce_using_automaton(b**3*a**4*b**-2*a) == a**5*b
     assert R.reduce_using_automaton(b**-1*a) == a*b**-1
 
-    # Add rules
-    R.add_rule(a*b**5, b**2)
-    assert G.reduce(b**2*a*b**3) == a**-1*b**-1
-    assert R.reduce_using_automaton(b**2*a*b**3) == a**-1*b**-1
-
     G = FpGroup(F, [a**2, b**3, (a*b)**4])
     a, b = G.generators
     R = G._rewriting_system
@@ -39,5 +34,3 @@ def test_rewriting():
     # Additional tests
     assert G.reduce(a**2*b**-1*a) == b*a**-1
     assert R.reduce_using_automaton(a**2*b**-1*a) == b*a**-1
-    assert G.reduce(a**2*b**-1*a*b**3*a**-2) == b
-    assert R.reduce_using_automaton(a**2*b**-1*a*b**3*a**-2) == b

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -34,3 +34,6 @@ def test_rewriting():
     assert R.reduce_using_automaton(a**2*b**-2*a**2*b) == b**-1
     assert G.reduce(a**3*b**-2*a**2*b) == a**-1*b**-1
     assert R.reduce_using_automaton(a**3*b**-2*a**2*b) == a**-1*b**-1
+    # Check after adding a rule
+    R.add_rule(a**2, b)
+    assert R.reduce_using_automaton(a**2*b**-2*a**2*b) == b**-1

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -16,12 +16,6 @@ def test_rewriting():
     assert R.reduce_using_automaton(b**3*a**4*b**-2*a) == a**5*b
     assert R.reduce_using_automaton(b**-1*a) == a*b**-1
 
-    G = FpGroup(F, [a**2, b**3, (a*b)**4])
-    a, b = G.generators
-    R = G._rewriting_system
-    assert G.reduce(a**2*b**-2*a**2*b) == b**-1
-    assert R.reduce_using_automaton(a**2*b**-2*a**2*b) == b**-1
-
     G = FpGroup(F, [a**3, b**3, (a*b)**2])
     R = G._rewriting_system
     R.make_confluent()
@@ -31,6 +25,3 @@ def test_rewriting():
     # but also the system should actually be confluent
     assert R._check_confluence()
     assert G.reduce(b*a**-1*b**-1*a**3*b**4*a**-1*b**-15) == a**-1*b**-1
-    # Additional tests
-    assert G.reduce(a**2*b**-1*a) == b*a**-1
-    assert R.reduce_using_automaton(a**2*b**-1*a) == b*a**-1

--- a/sympy/combinatorics/tests/test_rewriting.py
+++ b/sympy/combinatorics/tests/test_rewriting.py
@@ -25,3 +25,12 @@ def test_rewriting():
     # but also the system should actually be confluent
     assert R._check_confluence()
     assert G.reduce(b*a**-1*b**-1*a**3*b**4*a**-1*b**-15) == a**-1*b**-1
+    # check for automaton reduction
+    assert R.reduce_using_automaton(b*a**-1*b**-1*a**3*b**4*a**-1*b**-15) == a**-1*b**-1
+
+    G = FpGroup(F, [a**2, b**3, (a*b)**4])
+    R = G._rewriting_system
+    assert G.reduce(a**2*b**-2*a**2*b) == b**-1
+    assert R.reduce_using_automaton(a**2*b**-2*a**2*b) == b**-1
+    assert G.reduce(a**3*b**-2*a**2*b) == a**-1*b**-1
+    assert R.reduce_using_automaton(a**3*b**-2*a**2*b) == a**-1*b**-1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Implement an automaton for word reduction.
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
A custom class for a `StateMachine` and the `State` of the finite state machine have been added in a new file `rewriting_fsm`.
Two new methods, `construct_automaton` and `reduce_using_automaton` have been added to the `RewritingSystem` class. 

#### Other comments
Currently, the word is reduced using automaton as:
```
>>> from sympy.combinatorics.fp_groups import FpGroup
>>> from sympy.combinatorics.free_groups import free_group
>>> F, a, b = free_group("a, b")
>>> G = FpGroup(F, [a*b*a**-1*b**-1])
>>> a, b = G.generators
>>> R = G._rewriting_system
>>> R.reduce_using_automaton(b**2*a*b**3)
a*b**5
```


