### PR TITLE
Make kilogram unit of mass, w/ scale_factor 1

### DIFF
--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -52,7 +52,7 @@ meter.set_scale_factor(One)
 
 kg = kilogram = kilograms = Quantity("kilogram", abbrev="kg")
 kilogram.set_dimension(mass)
-kilogram.set_scale_factor(kilo)
+kilogram.set_scale_factor(One)
 
 s = second = seconds = Quantity("second", abbrev="s")
 second.set_dimension(time)
@@ -79,7 +79,7 @@ candela.set_scale_factor(One)
 
 g = gram = grams = Quantity("gram", abbrev="g")
 gram.set_dimension(mass)
-gram.set_scale_factor(One)
+gram.set_scale_factor(milli*kilogram)
 
 mg = milligram = milligrams = Quantity("milligram", abbrev="mg")
 milligram.set_dimension(mass)
@@ -430,7 +430,7 @@ psi = Quantity("psi")
 psi.set_dimension(pressure)
 psi.set_scale_factor(pound * gee / inch ** 2)
 
-dHg0 = 13.5951  # approx value at 0 C
+dHg0 = 13595.1  # approx value at 0 C in kg/m^3
 mmHg = torr = Quantity("mmHg")
 mmHg.set_dimension(pressure)
 mmHg.set_scale_factor(dHg0 * acceleration_due_to_gravity * kilogram / meter**2)

--- a/sympy/physics/units/tests/test_unitsystem.py
+++ b/sympy/physics/units/tests/test_unitsystem.py
@@ -56,7 +56,7 @@ def test_print_unit_base():
         Js.set_scale_factor(S.One)
 
         mksa = UnitSystem((m, kg, s, A), (Js,))
-        assert mksa.print_unit_base(Js) == m**2*kg*s**-1/1000
+        assert mksa.print_unit_base(Js) == m**2*kg*s**-1
 
 
 def test_extend():


### PR DESCRIPTION
- gram is milli*kg
- density of Hg is in kg/m^3
- fix test of joule-second, no need to divide by 1000

#### References to other Issues or PRs

Fixes #14734

#### Brief description of what is fixed or changed

This PR changes the unit of mass from gram to kilogram. scale_factor for kilogram is 1 (was 1000) and gram is 1/1000 (was 1). This change also required updating the density of Hg into kg/m^3 for correct calculation of mmHg/torr. 

Also required fixing a test of a unit system with joule-second (Js) which used require dividing through by 1000 due to scale_factor on kilogram unit, but division is no longer required.

#### Other comments
