### PR TITLE
Add lambdified functions to the Python linecache

### DIFF
--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,6 +1,7 @@
 from distutils.version import LooseVersion as V
 from itertools import product
 import math
+import inspect
 
 import mpmath
 from sympy.utilities.pytest import XFAIL, raises
@@ -870,3 +871,9 @@ def test_tensorflow_array_arg():
 
     s = tensorflow.Session()
     assert s.run(fcall) == 5
+
+def test_lambdify_inspect():
+    f = lambdify(x, x**2)
+    # Test that inspect.getsource works but don't hard-code implementation
+    # details
+    assert 'x**2' in inspect.getsource(f)


### PR DESCRIPTION
This allows things like inspect.getsource (?? in IPython) to work, and the
code will show up in the tracebacks in IPython.

Presently, the docstring is not included in the source code, because it is
added after the function is execed.

Example:

```
In [1]: f = lambdify(x, 1/x)

In [2]: f(0)
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-2-6bfbdbfff9c4> in <module>()
----> 1 f(0)

<lambdifygenerated-1> in _lambdifygenerated(x)
      1 def _lambdifygenerated(x):
----> 2     return (1/x)

ZeroDivisionError: division by zero

In [3]: f??
Signature: f(x)
Docstring:
Created with lambdify. Signature:

func(x)

Expression:

1/x

Source code:

def _lambdifygenerated(x):
    return (1/x)

Imported modules:
Source:
def _lambdifygenerated(x):
    return (1/x)
File:      ~/Documents/Python/sympy/sympy/<lambdifygenerated-1>
Type:      function
```

CC @caley 