### PR TITLE
Added warning to kilogram

### DIFF
--- a/sympy/physics/units/definitions.py
+++ b/sympy/physics/units/definitions.py
@@ -50,9 +50,22 @@ m = meter = meters = Quantity("meter", abbrev="m")
 meter.set_dimension(length)
 meter.set_scale_factor(One)
 
+# gram; used to define its prefixed units
+g = gram = grams = Quantity("gram", abbrev="g")
+gram.set_dimension(mass)
+gram.set_scale_factor(One)
+
+# NOTE: the `kilogram` has scale factor 1000. In SI, kg is a base unit, but
+# nonetheless we are trying to be compatible with the `kilo` prefix. In a
+# similar manner, people using CGS or gaussian units could argue that the
+# `centimeter` rather than `meter` is the fundamental unit for length, but the
+# scale factor of `centimeter` will be kept as 1/100 to be compatible with the
+# `centi` prefix.  The current state of the code assumes SI unit dimensions, in
+# the future this module will be modified in order to be unit system-neutral
+# (that is, support all kinds of unit systems).
 kg = kilogram = kilograms = Quantity("kilogram", abbrev="kg")
 kilogram.set_dimension(mass)
-kilogram.set_scale_factor(kilo)
+kilogram.set_scale_factor(kilo*gram)
 
 s = second = seconds = Quantity("second", abbrev="s")
 second.set_dimension(time)
@@ -74,12 +87,6 @@ cd = candela = candelas = Quantity("candela", abbrev="cd")
 candela.set_dimension(luminous_intensity)
 candela.set_scale_factor(One)
 
-
-# gram; used to define its prefixed units
-
-g = gram = grams = Quantity("gram", abbrev="g")
-gram.set_dimension(mass)
-gram.set_scale_factor(One)
 
 mg = milligram = milligrams = Quantity("milligram", abbrev="mg")
 milligram.set_dimension(mass)


### PR DESCRIPTION
There have been many people complaining that the scale factor of kilogram is 1000 rather than 1. I hereby add the explanation of why this is in the code.

The purpose of the units module of SymPy is to be independent of the unit system. Unfortunately the current implementation is based on SI.

A similar argument could arise from people using CGS: in CGS the _centimeter_ is the fundamental unit, so should we set the scale factor of _meter_ to 100? I'd say no.