### PR TITLE
Clean up some cruft in the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -243,6 +243,7 @@ before_install:
 
         conda info -a;
         conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip ${TEST_OPT_DEPENDENCY/autowrap/libgfortran libgcc gcc cython};
+        deactivate; # Deactivate the Travis virtualenv
         source activate test-environment;
     elif [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then
         pip list --format=legacy | grep "numpy" && pip uninstall -y numpy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,7 +235,7 @@ before_install:
         conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip ${TEST_OPT_DEPENDENCY};
         source activate test-environment;
         conda clean --all;
-        if [[ "$TEST_OPT_DEPENDENCY" == *"sage"* ]]; then
+        if [[ "$TEST_SAGE" == "true" ]]; then
             # Use a separate environment because sage downgrades matplotlib
             conda create -n sage sage=8.1;
             conda remove -n sage --force sympy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
         # autowrap installs libgfortran libgcc gcc cython
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 sage=8.1"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8"
         - TEST_SAGE="true"
       addons:
         apt:
@@ -237,7 +237,9 @@ before_install:
         source activate test-environment;
         conda clean --all;
         if [[ "$TEST_OPT_DEPENDENCY" == *"sage"* ]]; then
-            conda remove --force sympy;
+            # Use a separate environment because sage downgrades matplotlib
+            conda create -n sage sage=8.1;
+            conda remove -n sage --force sympy;
             conda clean --all;
         fi
         if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -240,11 +240,11 @@ before_install:
             conda remove --force sympy;
             conda clean --all;
         fi
+        if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+            conda install matchpy;
+        fi
     elif [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then
         pip list --format=legacy | grep "numpy" && pip uninstall -y numpy;
-    fi
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
-      pip install matchpy;
     fi
 install:
   # If a command fails, fail the build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -218,8 +218,8 @@ before_install:
     if [[ -n "${TEST_OPT_DEPENDENCY}" ]]; then
     # We do this conditionally because it saves us some downloading if the
     # version is the same.
+        deactivate; # Deactivate the Travis virtualenv
         if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-          deactivate; # Deactivate the Travis virtualenv
           wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -q -O miniconda.sh;
         else
           wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -q -O miniconda.sh;
@@ -246,6 +246,7 @@ before_install:
     elif [ "$TRAVIS_PYTHON_VERSION" != "pypy" ]; then
         pip list --format=legacy | grep "numpy" && pip uninstall -y numpy;
     fi
+
 install:
   # If a command fails, fail the build.
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -207,6 +207,7 @@ matrix:
             - pypy
 
 before_install:
+  - set -x # echo each command
   - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
   - if [[ "${FASTCACHE}" != "false" ]]; then
       pip install fastcache;

--- a/.travis.yml
+++ b/.travis.yml
@@ -207,7 +207,6 @@ matrix:
             - pypy
 
 before_install:
-  - set -x # echo each command
   - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
   - if [[ "${FASTCACHE}" != "false" ]]; then
       pip install fastcache;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - TEST_ASCII="true"
         # space separated list of optional dependencies(conda packages) to install and test
         # autowrap installs libgfortran libgcc gcc cython
-        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 sage"
+        - TEST_OPT_DEPENDENCY="numpy scipy gmpy2 matplotlib>=2.2 theano llvmlite autowrap python-symengine=0.3.* tensorflow numexpr ipython antlr-python-runtime>=4.7,<4.8 antlr>=4.7,<4.8 sage=8.1"
         - TEST_SAGE="true"
       addons:
         apt:
@@ -233,11 +233,10 @@ before_install:
         conda config --prepend channels conda-forge --prepend channels symengine/label/dev;
 
         conda info -a;
-        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip ${TEST_OPT_DEPENDENCY/sage};
+        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip ${TEST_OPT_DEPENDENCY};
         source activate test-environment;
         conda clean --all;
         if [[ "$TEST_OPT_DEPENDENCY" == *"sage"* ]]; then
-            conda install -q "sage==8.1";
             conda remove --force sympy;
             conda clean --all;
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,6 +219,7 @@ before_install:
     # We do this conditionally because it saves us some downloading if the
     # version is the same.
         if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+          deactivate; # Deactivate the Travis virtualenv
           wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -q -O miniconda.sh;
         else
           wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -q -O miniconda.sh;
@@ -231,7 +232,6 @@ before_install:
         conda config --prepend channels conda-forge --prepend channels symengine/label/dev;
 
         conda info -a;
-        deactivate; # Deactivate the Travis virtualenv
         conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip ${TEST_OPT_DEPENDENCY/sage};
         source activate test-environment;
         conda clean --all;

--- a/bin/test_external_imports.py
+++ b/bin/test_external_imports.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""
+Test that
+
+from sympy import *
+
+Doesn't import anything other than SymPy, it's hard dependencies (mpmath), and
+hard optional dependencies (gmpy2, fastcache). Importing unnecessary libraries
+can accidentally add hard dependencies to SymPy in the worst case, or at best
+slow down the SymPy import time when they are installed.
+
+Note, for this test to be effective, every external library that could
+potentially be imported by SymPy must be installed.
+
+TODO: Monkeypatch the importer to detect non-standard library imports even
+when they aren't installed.
+
+Based on code from
+https://stackoverflow.com/questions/22195382/how-to-check-if-a-module-library-package-is-part-of-the-python-standard-library.
+"""
+
+# These libraries will always be imported with SymPy
+hard_dependencies = ['mpmath']
+
+# These libraries are optional, but are always imported at SymPy import time
+# when they are installed. External libraries should only be added to this
+# list if they are required for core SymPy functionality.
+hard_optional_dependencies = ['gmpy', 'gmpy2', 'fastcache']
+
+import sys
+import os
+
+stdlib = {p for p in sys.path if p.startswith(sys.prefix) and
+    'site-packages' not in p}
+
+existing_modules = list(sys.modules.keys())
+
+
+# hook in-tree SymPy into Python path, if possible
+
+this_path = os.path.abspath(__file__)
+this_dir = os.path.dirname(this_path)
+sympy_top = os.path.split(this_dir)[0]
+sympy_dir = os.path.join(sympy_top, 'sympy')
+
+if os.path.isdir(sympy_dir):
+    sys.path.insert(0, sympy_top)
+
+def test_external_imports():
+    exec("from sympy import *", {})
+
+    bad = []
+    for mod in sys.modules:
+        if '.' in mod and mod.split('.')[0] in sys.modules:
+            # Only worry about the top-level modules
+            continue
+
+        if mod in existing_modules:
+            continue
+
+        if any(mod == i or mod.startswith(i + '.') for i in ['sympy'] +
+            hard_dependencies + hard_optional_dependencies):
+            continue
+
+        if mod in sys.builtin_module_names:
+            continue
+
+        # if not hasattr(mod, '__file__'):
+        #     # bad.append(mod)
+        #     continue
+
+        try:
+            fname = sys.modules[mod].__file__
+        except AttributeError:
+            bad.append(mod)
+            continue
+
+        if fname.endswith(('__init__.py', '__init__.pyc', '__init__.pyo')):
+            fname = os.path.dirname(fname)
+
+        if os.path.dirname(fname) in stdlib:
+            continue
+
+        bad.append(mod)
+
+    if bad:
+        raise RuntimeError("""Unexpected external modules found when running 'from sympy import *':
+    """ + '\n    '.join(bad))
+
+    print("No unexpected external modules were imported with 'from sympy import *'!")
+
+if __name__ == '__main__':
+    test_external_imports()

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -148,6 +148,10 @@ doctest_list = [
 
     # antlr
     'sympy/parsing/latex',
+
+    # matchpy
+    '*rubi*',
+
 ]
 
 if not (sympy.test(*test_list, blacklist=blacklist) and sympy.doctest(*doctest_list)):

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -128,6 +128,8 @@ blacklist = [
 ]
 
 doctest_list = [
+    'doc/',
+
     # numpy
     'sympy/matrices/',
     'sympy/utilities/lambdify.py',

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -72,6 +72,11 @@ if not sympy.test(split='${SPLIT}', slow=True, verbose=True):
 EOF
 fi
 
+if [[ -z "${TEST_OPT_DEPENDENCY}" ]]; then
+    python bin/test_external_imports.py;
+
+fi
+
 # lambdify with tensorflow and numexpr is tested here
 if [[ "${TEST_OPT_DEPENDENCY}" == *"numpy"* ]]; then
     cat << EOF | python

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -27,6 +27,10 @@ if [[ "${TEST_SAGE}" == "true" ]]; then
     sage -t sympy/external/tests/test_sage.py
 fi
 
+if [[ -n "${TEST_OPT_DEPENDENCY}" ]]; then
+    python bin/test_external_imports.py;
+fi
+
 # We change directories to make sure that we test the installed version of
 # sympy.
 mkdir empty
@@ -70,11 +74,6 @@ import sympy
 if not sympy.test(split='${SPLIT}', slow=True, verbose=True):
     raise Exception('Tests failed')
 EOF
-fi
-
-if [[ -z "${TEST_OPT_DEPENDENCY}" ]]; then
-    python bin/test_external_imports.py;
-
 fi
 
 # lambdify with tensorflow and numexpr is tested here

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -128,8 +128,6 @@ blacklist = [
 ]
 
 doctest_list = [
-    'doc/',
-
     # numpy
     'sympy/matrices/',
     'sympy/utilities/lambdify.py',
@@ -163,6 +161,8 @@ doctest_list = [
 if not (sympy.test(*test_list, blacklist=blacklist) and sympy.doctest(*doctest_list)):
     raise Exception('Tests failed')
 EOF
+    cd ..
+    bin/doctest doc/
 fi
 
 # This is separate because it needs to be run with subprocess=False

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -114,6 +114,9 @@ test_list = [
 
     # antlr
     'sympy/parsing/tests/test_latex',
+
+    # matchpy
+    '*rubi*',
 ]
 
 blacklist = [

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -146,7 +146,7 @@ doctest_list = [
     'sympy/parsing/latex',
 ]
 
-if not (sympy.test(test_list, blacklist=blacklist) and sympy.doctest(doctest_list)):
+if not (sympy.test(*test_list, blacklist=blacklist) and sympy.doctest(doctest_list)):
     raise Exception('Tests failed')
 EOF
 fi

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -22,10 +22,14 @@ fi
 
 if [[ "${TEST_SAGE}" == "true" ]]; then
     echo "Testing SAGE"
+    source deactivate
+    source activate sage
     sage -v
     sage -python bin/test sympy/external/tests/test_sage.py
     PYTHONPATH=. sage -t sympy/external/tests/test_sage.py
     export MPMATH_NOSAGE=1
+    source deactivate
+    source activate test-environment
 fi
 
 if [[ -n "${TEST_OPT_DEPENDENCY}" ]]; then

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -77,58 +77,81 @@ EOF
 fi
 
 # lambdify with tensorflow and numexpr is tested here
-if [[ "${TEST_OPT_DEPENDENCY}" == *"numpy"* ]]; then
+
+# TODO: Generate these tests automatically
+if [[ -n "${TEST_OPT_DEPENDENCY}" ]]; then
     cat << EOF | python
-print('Testing NUMPY')
+print('Testing optional dependencies')
+
 import sympy
-if not (sympy.test('*numpy*', 'sympy/core/tests/test_numbers.py',
-                   'sympy/matrices/', 'sympy/physics/quantum/',
-                   'sympy/core/tests/test_sympify.py',
-                   'sympy/utilities/tests/test_lambdify.py',
-                   blacklist=['sympy/physics/quantum/tests/test_circuitplot.py'])
-        and sympy.doctest('sympy/matrices/', 'sympy/utilities/lambdify.py')):
+test_list = [
+    # numpy
+    '*numpy*',
+    'sympy/core/tests/test_numbers.py',
+    'sympy/matrices/',
+    'sympy/physics/quantum/',
+    'sympy/core/tests/test_sympify.py',
+    'sympy/utilities/tests/test_lambdify.py',
+
+    # scipy
+    '*scipy*',
+
+    # llvmlite
+    '*llvm*',
+
+    # theano
+    '*theano*',
+
+    # gmpy
+    'polys',
+
+    # autowrap
+    '*autowrap*',
+
+    # ipython
+    '*ipython*',
+
+    # antlr
+    'sympy/parsing/tests/test_latex',
+]
+
+blacklist = [
+    'sympy/physics/quantum/tests/test_circuitplot.py',
+]
+
+doctest_list = [
+    # numpy
+    'sympy/matrices/',
+    'sympy/utilities/lambdify.py',
+
+    # scipy
+    '*scipy*',
+
+    # llvmlite
+    '*llvm*',
+
+    # theano
+    '*theano*',
+
+    # gmpy
+    'polys',
+
+    # autowrap
+    '*autowrap*',
+
+    # ipython
+    '*ipython*',
+
+    # antlr
+    'sympy/parsing/latex',
+]
+
+if not (sympy.test(test_list, blacklist=blacklist) and sympy.doctest(doctest_list)):
     raise Exception('Tests failed')
 EOF
 fi
 
-if [[ "${TEST_OPT_DEPENDENCY}" == *"scipy"* ]]; then
-    cat << EOF | python
-print('Testing SCIPY')
-import sympy
-# scipy matrices are tested in numpy testing
-if not sympy.test('sympy/external/tests/test_scipy.py'):
-    raise Exception('Tests failed')
-EOF
-fi
-
-if [[ "${TEST_OPT_DEPENDENCY}" == *"llvmlite"* ]]; then
-    cat << EOF | python
-print('Testing LLVMJIT')
-import sympy
-if not (sympy.test('sympy/printing/tests/test_llvmjit.py')
-        and sympy.doctest('sympy/printing/llvmjitcode.py')):
-    raise Exception('Tests failed')
-EOF
-fi
-
-if [[ "${TEST_OPT_DEPENDENCY}" == *"theano"* ]]; then
-    cat << EOF | python
-print('Testing THEANO')
-import sympy
-if not sympy.test('*theano*'):
-    raise Exception('Tests failed')
-EOF
-fi
-
-if [[ "${TEST_OPT_DEPENDENCY}" == *"gmpy"* ]]; then
-    cat << EOF | python
-print('Testing GMPY')
-import sympy
-if not (sympy.test('sympy/polys/') and sympy.doctest('sympy/polys/')):
-    raise Exception('Tests failed')
-EOF
-fi
-
+# This is separate because it needs to be run with subprocess=False
 if [[ "${TEST_OPT_DEPENDENCY}" == *"matplotlib"* ]]; then
     cat << EOF | python
 print('Testing MATPLOTLIB')
@@ -146,37 +169,6 @@ if not (sympy.test('sympy/plotting', 'sympy/physics/quantum/tests/test_circuitpl
 EOF
 fi
 
-if [[ "${TEST_OPT_DEPENDENCY}" == *"autowrap"* ]]; then
-    cat << EOF | python
-print('Testing AUTOWRAP')
-import sympy
-if not (sympy.test('sympy/external/tests/test_autowrap.py')
-        and sympy.doctest('sympy/utilities/autowrap.py')):
-    raise Exception('Tests failed')
-EOF
-fi
-
-if [[ "${TEST_OPT_DEPENDENCY}" == *"ipython"* ]]; then
-    cat << EOF | python
-print('Testing IPYTHON')
-import sympy
-if not sympy.test('*ipython*'):
-    raise Exception('Tests failed')
-EOF
-fi
-
-if [[ "${TEST_SYMPY}" == "true" ]]; then
-    # -We:invalid makes invalid escape sequences error in Python 3.6. See
-    # -#12028.
-    cat << EOF | python -We:invalid
-print('Testing SYMPY, split ${SPLIT}')
-import sympy
-if not sympy.test(split='${SPLIT}'):
-   raise Exception('Tests failed')
-EOF
-fi
-
-
 if [[ "${TEST_OPT_DEPENDENCY}" == *"symengine"* ]]; then
     export USE_SYMENGINE=1
     cat << EOF | python
@@ -190,11 +182,13 @@ EOF
     unset USE_SYMENGINE
 fi
 
-if [[ "${TEST_OPT_DEPENDENCY}" == *"antlr"* ]]; then
+if [[ "${TEST_SYMPY}" == "true" ]]; then
+    # -We:invalid makes invalid escape sequences error in Python 3.6. See
+    # -#12028.
     cat << EOF | python -We:invalid
-print('Testing ANTLR')
+print('Testing SYMPY, split ${SPLIT}')
 import sympy
-if not sympy.test('sympy/parsing/tests/test_latex'):
-    raise Exception('Tests failed')
+if not sympy.test(split='${SPLIT}'):
+   raise Exception('Tests failed')
 EOF
 fi

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -146,7 +146,7 @@ doctest_list = [
     'sympy/parsing/latex',
 ]
 
-if not (sympy.test(*test_list, blacklist=blacklist) and sympy.doctest(doctest_list)):
+if not (sympy.test(*test_list, blacklist=blacklist) and sympy.doctest(*doctest_list)):
     raise Exception('Tests failed')
 EOF
 fi

--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -7,7 +7,10 @@ import inspect
 import textwrap
 import re
 import pydoc
-import collections.abc
+try:
+    from collections.abc import Mapping
+except ImportError: # Python 2
+    from collections import Mapping
 import sys
 
 
@@ -87,7 +90,7 @@ class Reader(object):
         return not ''.join(self._str).strip()
 
 
-class NumpyDocString(collections.abc.Mapping):
+class NumpyDocString(Mapping):
     def __init__(self, docstring, config={}):
         docstring = textwrap.dedent(docstring).split('\n')
 

--- a/doc/ext/docscrape.py
+++ b/doc/ext/docscrape.py
@@ -7,7 +7,7 @@ import inspect
 import textwrap
 import re
 import pydoc
-import collections
+import collections.abc
 import sys
 
 
@@ -87,7 +87,7 @@ class Reader(object):
         return not ''.join(self._str).strip()
 
 
-class NumpyDocString(collections.Mapping):
+class NumpyDocString(collections.abc.Mapping):
     def __init__(self, docstring, config={}):
         docstring = textwrap.dedent(docstring).split('\n')
 

--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -23,7 +23,7 @@ import re
 import pydoc
 import sphinx
 import inspect
-import collections
+import collections.abc
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
@@ -101,7 +101,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
             'initializes x; see ' in pydoc.getdoc(obj.__init__))):
         return '', ''
 
-    if not (isinstance(obj, collections.Callable) or
+    if not (isinstance(obj, collections.abc.Callable) or
             hasattr(obj, '__argspec_is_invalid_')):
         return
 

--- a/doc/ext/numpydoc.py
+++ b/doc/ext/numpydoc.py
@@ -23,7 +23,10 @@ import re
 import pydoc
 import sphinx
 import inspect
-import collections.abc
+try:
+    from collections.abc import Callable
+except ImportError: # Python 2
+    from collections import Callable
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
@@ -101,7 +104,7 @@ def mangle_signature(app, what, name, obj, options, sig, retann):
             'initializes x; see ' in pydoc.getdoc(obj.__init__))):
         return '', ''
 
-    if not (isinstance(obj, collections.abc.Callable) or
+    if not (isinstance(obj, Callable) or
             hasattr(obj, '__argspec_is_invalid_')):
         return
 

--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -66,8 +66,8 @@ powerful vectorized ufuncs that are backed by compiled C code.
     >>> import numpy
     >>> data = numpy.linspace(1, 10, 10000)
     >>> f(data)
-    [ 0.84147098  0.84119981  0.84092844 ..., -0.05426074 -0.05433146
-                               -0.05440211]
+    [ 0.84147098  0.84119981  0.84092844 ... -0.05426074 -0.05433146
+     -0.05440211]
 
 If you have array-based data this can confer a considerable speedup, on the
 order of 10 nano-seconds per element. Unfortunately numpy incurs some start-up

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
-from collections import MutableMapping, defaultdict
+from collections import defaultdict
+from collections.abc import MutableMapping
 
 from sympy.core import (Add, Mul, Pow, Integer, Number, NumberSymbol,)
 from sympy.core.numbers import ImaginaryUnit

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -1,9 +1,9 @@
 from __future__ import print_function, division
 
 from collections import defaultdict
-from collections.abc import MutableMapping
 
 from sympy.core import (Add, Mul, Pow, Integer, Number, NumberSymbol,)
+from sympy.core.compatibility import MutableMapping
 from sympy.core.numbers import ImaginaryUnit
 from sympy.core.sympify import _sympify
 from sympy.core.rules import Transform

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,14 +1,13 @@
 """Base class for all the objects in SymPy"""
 from __future__ import print_function, division
 from collections import defaultdict
-from collections.abc import Mapping
 from itertools import chain
 
 from .assumptions import BasicMeta, ManagedProperties
 from .cache import cacheit
 from .sympify import _sympify, sympify, SympifyError
 from .compatibility import (iterable, Iterator, ordered,
-    string_types, with_metaclass, zip_longest, range)
+    string_types, with_metaclass, zip_longest, range, Mapping)
 from .singleton import S
 
 from inspect import getmro

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,6 +1,7 @@
 """Base class for all the objects in SymPy"""
 from __future__ import print_function, division
-from collections import Mapping, defaultdict
+from collections import defaultdict
+from collections.abc import Mapping
 from itertools import chain
 
 from .assumptions import BasicMeta, ManagedProperties

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -93,6 +93,9 @@ if PY3:
     exec_=getattr(builtins, "exec")
 
     range=range
+
+    from collections.abc import (Mapping, Callable, MutableMapping,
+        MutableSet, Iterable, Hashable)
 else:
     import codecs
     import types
@@ -136,6 +139,9 @@ else:
             _locs_ = _globs_
         exec("exec _code_ in _globs_, _locs_")
     range=xrange
+
+    from collections import (Mapping, Callable, MutableMapping,
+        MutableSet, Iterable, Hashable)
 
 def with_metaclass(meta, *bases):
     """

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,12 +8,13 @@
 
 from __future__ import print_function, division
 
+from collections import OrderedDict
+
 from sympy.core.basic import Basic
-from sympy.core.compatibility import as_int, range
+from sympy.core.compatibility import as_int, range, MutableSet
 from sympy.core.sympify import sympify, converter
 from sympy.utilities.iterables import iterable
 
-import collections.abc
 
 
 class Tuple(Basic):
@@ -268,12 +269,12 @@ class Dict(Basic):
         return tuple(sorted(self.args, key=default_sort_key))
 
 
-class OrderedSet(collections.abc.MutableSet):
+class OrderedSet(MutableSet):
     def __init__(self, iterable=None):
         if iterable:
-            self.map = collections.OrderedDict((item, None) for item in iterable)
+            self.map = OrderedDict((item, None) for item in iterable)
         else:
-            self.map = collections.OrderedDict()
+            self.map = OrderedDict()
 
     def __len__(self):
         return len(self.map)

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -13,7 +13,7 @@ from sympy.core.compatibility import as_int, range
 from sympy.core.sympify import sympify, converter
 from sympy.utilities.iterables import iterable
 
-import collections
+import collections.abc
 
 
 class Tuple(Basic):
@@ -268,7 +268,7 @@ class Dict(Basic):
         return tuple(sorted(self.args, key=default_sort_key))
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
     def __init__(self, iterable=None):
         if iterable:
             self.map = collections.OrderedDict((item, None) for item in iterable)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -6,11 +6,10 @@ from .singleton import S
 from .evalf import EvalfMixin, pure_complex
 from .decorators import _sympifyit, call_highest_priority
 from .cache import cacheit
-from .compatibility import reduce, as_int, default_sort_key, range
+from .compatibility import reduce, as_int, default_sort_key, range, Iterable
 from mpmath.libmp import mpf_log, prec_to_dps
 
 from collections import defaultdict
-from collections.abc import Iterable
 
 class Expr(Basic, EvalfMixin):
     """

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -9,7 +9,8 @@ from .cache import cacheit
 from .compatibility import reduce, as_int, default_sort_key, range
 from mpmath.libmp import mpf_log, prec_to_dps
 
-from collections import defaultdict, Iterable
+from collections import defaultdict
+from collections.abc import Iterable
 
 class Expr(Basic, EvalfMixin):
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -35,7 +35,7 @@ from .add import Add
 from .assumptions import ManagedProperties, _assume_defined
 from .basic import Basic
 from .cache import cacheit
-from .compatibility import iterable, is_sequence, as_int, ordered
+from .compatibility import iterable, is_sequence, as_int, ordered, Iterable
 from .decorators import _sympifyit
 from .expr import Expr, AtomicExpr
 from .numbers import Rational, Float
@@ -58,7 +58,7 @@ import mpmath
 import mpmath.libmp as mlib
 
 import inspect
-import collections.abc
+from collections import Counter
 
 def _coeff_isneg(a):
     """Return True if the leading Number is negative.
@@ -1242,7 +1242,7 @@ class Derivative(Expr):
             elif (count < 0) == True:
                 obj = None
             else:
-                if isinstance(v, (collections.abc.Iterable, Tuple, MatrixCommon, NDimArray)):
+                if isinstance(v, (Iterable, Tuple, MatrixCommon, NDimArray)):
                     # Treat derivatives by arrays/matrices as much as symbols.
                     is_symbol = True
                 if not is_symbol:
@@ -1481,9 +1481,9 @@ class Derivative(Expr):
         # If both are Derivatives with the same expr, check if old is
         # equivalent to self or if old is a subderivative of self.
         if old.is_Derivative and old.expr == self.expr:
-            # Check if canonnical order of variables is equal.
-            old_vars = collections.Counter(dict(reversed(old.variable_count)))
-            self_vars = collections.Counter(dict(reversed(self.variable_count)))
+            # Check if canonical order of variables is equal.
+            old_vars = Counter(dict(reversed(old.variable_count)))
+            self_vars = Counter(dict(reversed(self.variable_count)))
             if old_vars == self_vars:
                 return new
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -58,7 +58,7 @@ import mpmath
 import mpmath.libmp as mlib
 
 import inspect
-import collections
+import collections.abc
 
 def _coeff_isneg(a):
     """Return True if the leading Number is negative.
@@ -1242,7 +1242,7 @@ class Derivative(Expr):
             elif (count < 0) == True:
                 obj = None
             else:
-                if isinstance(v, (collections.Iterable, Tuple, MatrixCommon, NDimArray)):
+                if isinstance(v, (collections.abc.Iterable, Tuple, MatrixCommon, NDimArray)):
                     # Treat derivatives by arrays/matrices as much as symbols.
                     is_symbol = True
                 if not is_symbol:

--- a/sympy/integrals/rubi/parsetools/parse.py
+++ b/sympy/integrals/rubi/parsetools/parse.py
@@ -32,6 +32,7 @@ import os
 import inspect
 from sympy import sympify, Function, Set, Symbol
 from sympy.printing import sstr, StrPrinter
+from sympy.utilities.misc import debug
 
 replacements = dict( # Mathematica equivalent functions in SymPy
         Times="Mul",
@@ -349,7 +350,7 @@ def downvalues_rules(r, parsed):
     res = []
     index = 0
     for i in r:
-        print('parsing rule {}'.format(r.index(i) + 1))
+        debug('parsing rule {}'.format(r.index(i) + 1))
         # Parse Pattern
         if i[1][1][0] == 'Condition':
             p = i[1][1][1].copy()

--- a/sympy/integrals/rubi/rubi.py
+++ b/sympy/integrals/rubi/rubi.py
@@ -210,7 +210,7 @@ def rubi_integrate(expr, var, showsteps=False):
 @doctest_depends_on(modules=('matchpy',))
 def get_matching_rule_definition(expr, var):
     '''
-    Returns the list or rules which match to `expr`.
+    Prints the list or rules which match to `expr`.
 
     Parameters
     ==========

--- a/sympy/integrals/rubi/rules/miscellaneous_trig.py
+++ b/sympy/integrals/rubi/rules/miscellaneous_trig.py
@@ -602,7 +602,6 @@ def miscellaneous_trig(rubi):
     pattern136 = Pattern(Integral(u_, x_), CustomConstraint(lambda x, u, d, v: Not(FalseQ(v)) and TryPureTanSubst(ActivateTrig(u), x) and FunctionOfQ(NonfreeFactors(tan(v), x), u, x, True)))
     def With136(u, x):
         v = FunctionOfTrig(u, x)
-        print(u, v)
         d = FreeFactors(tan(v), x)
 
         return Dist(d/Coefficient(v, x, S(1)), Subst(Int(SubstFor(1/(d**S(2)*x**S(2) + S(1)), tan(v)/d, u, x), x), x, tan(v)/d), x)

--- a/sympy/integrals/rubi/utility_function.py
+++ b/sympy/integrals/rubi/utility_function.py
@@ -6203,7 +6203,6 @@ def Gamma(*args):
         a = args[0]
         return gamma(a)
     else:
-        print('gammainc is not implemented in SymPy')
         return S(0)
 
 def FunctionOfTrigOfLinearQ(u, x):

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -6,7 +6,7 @@ etc.).
 
 from __future__ import print_function, division
 
-import collections
+import collections.abc
 from sympy.core.add import Add
 from sympy.core.basic import Basic, Atom
 from sympy.core.expr import Expr
@@ -2027,7 +2027,7 @@ class MatrixArithmetic(MatrixRequired):
             return MatrixArithmetic._eval_matrix_mul(self, other)
 
         # if 'other' is not iterable then scalar multiplication.
-        if not isinstance(other, collections.Iterable):
+        if not isinstance(other, collections.abc.Iterable):
             try:
                 return self._eval_scalar_mul(other)
             except TypeError:
@@ -2099,7 +2099,7 @@ class MatrixArithmetic(MatrixRequired):
             return MatrixArithmetic._eval_matrix_rmul(self, other)
 
         # if 'other' is not iterable then scalar multiplication.
-        if not isinstance(other, collections.Iterable):
+        if not isinstance(other, collections.abc.Iterable):
             try:
                 return self._eval_scalar_rmul(other)
             except TypeError:

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -6,7 +6,6 @@ etc.).
 
 from __future__ import print_function, division
 
-import collections.abc
 from sympy.core.add import Add
 from sympy.core.basic import Basic, Atom
 from sympy.core.expr import Expr
@@ -15,7 +14,7 @@ from sympy.core.function import count_ops
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
 from sympy.core.compatibility import is_sequence, default_sort_key, range, \
-    NotIterable
+    NotIterable, Iterable
 
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
 from sympy.utilities.iterables import flatten
@@ -25,7 +24,7 @@ from sympy.assumptions.refine import refine
 from sympy.core.decorators import call_highest_priority
 
 from types import FunctionType
-
+from collections import defaultdict
 
 class MatrixError(Exception):
     pass
@@ -741,7 +740,7 @@ class MatrixSpecial(MatrixRequired):
                                                                          diag_rows, diag_cols))
 
         # fill a default dict with the diagonal entries
-        diag_entries = collections.defaultdict(lambda: S.Zero)
+        diag_entries = defaultdict(lambda: S.Zero)
         row_pos, col_pos = 0, 0
         for m in args:
             if hasattr(m, 'rows'):
@@ -2027,7 +2026,7 @@ class MatrixArithmetic(MatrixRequired):
             return MatrixArithmetic._eval_matrix_mul(self, other)
 
         # if 'other' is not iterable then scalar multiplication.
-        if not isinstance(other, collections.abc.Iterable):
+        if not isinstance(other, Iterable):
             try:
                 return self._eval_scalar_mul(other)
             except TypeError:
@@ -2099,7 +2098,7 @@ class MatrixArithmetic(MatrixRequired):
             return MatrixArithmetic._eval_matrix_rmul(self, other)
 
         # if 'other' is not iterable then scalar multiplication.
-        if not isinstance(other, collections.abc.Iterable):
+        if not isinstance(other, Iterable):
             try:
                 return self._eval_scalar_rmul(other)
             except TypeError:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
-import collections.abc
 from mpmath.libmp.libmpf import prec_to_dps
+
 from sympy.assumptions.refine import refine
 from sympy.core.add import Add
 from sympy.core.basic import Basic, Atom
@@ -18,7 +18,7 @@ from sympy.functions import Abs, exp, factorial
 from sympy.polys import PurePoly, roots, cancel, gcd
 from sympy.printing import sstr
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
-from sympy.core.compatibility import reduce, as_int, string_types
+from sympy.core.compatibility import reduce, as_int, string_types, Callable
 
 from sympy.utilities.iterables import flatten, numbered_symbols
 from sympy.core.decorators import call_highest_priority
@@ -2104,7 +2104,7 @@ class MatrixBase(MatrixDeprecated,
                                  "Both dimensions must be positive".format(rows, cols))
 
             # Matrix(2, 2, lambda i, j: i+j)
-            if len(args) == 3 and isinstance(args[2], collections.abc.Callable):
+            if len(args) == 3 and isinstance(args[2], Callable):
                 op = args[2]
                 flat_list = []
                 for i in range(rows):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-import collections
+import collections.abc
 from mpmath.libmp.libmpf import prec_to_dps
 from sympy.assumptions.refine import refine
 from sympy.core.add import Add
@@ -2104,7 +2104,7 @@ class MatrixBase(MatrixDeprecated,
                                  "Both dimensions must be positive".format(rows, cols))
 
             # Matrix(2, 2, lambda i, j: i+j)
-            if len(args) == 3 and isinstance(args[2], collections.Callable):
+            if len(args) == 3 and isinstance(args[2], collections.abc.Callable):
                 op = args[2]
                 flat_list = []
                 for i in range(rows):

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -14,7 +14,7 @@ from sympy.utilities.iterables import uniq
 
 from .matrices import MatrixBase, ShapeError, a2idx
 from .dense import Matrix
-import collections
+import collections.abc
 
 
 class SparseMatrix(MatrixBase):
@@ -53,7 +53,7 @@ class SparseMatrix(MatrixBase):
             self.rows = as_int(args[0])
             self.cols = as_int(args[1])
 
-            if isinstance(args[2], collections.Callable):
+            if isinstance(args[2], collections.abc.Callable):
                 op = args[2]
                 for i in range(self.rows):
                     for j in range(self.cols):

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from sympy.core.containers import Dict
 from sympy.core.expr import Expr
-from sympy.core.compatibility import is_sequence, as_int, range
+from sympy.core.compatibility import is_sequence, as_int, range, Callable
 from sympy.core.logic import fuzzy_and
 from sympy.core.singleton import S
 from sympy.functions import Abs
@@ -14,7 +14,6 @@ from sympy.utilities.iterables import uniq
 
 from .matrices import MatrixBase, ShapeError, a2idx
 from .dense import Matrix
-import collections.abc
 
 
 class SparseMatrix(MatrixBase):
@@ -53,7 +52,7 @@ class SparseMatrix(MatrixBase):
             self.rows = as_int(args[0])
             self.cols = as_int(args[1])
 
-            if isinstance(args[2], collections.abc.Callable):
+            if isinstance(args[2], Callable):
                 op = args[2]
                 for i in range(self.rows):
                     for j in range(self.cols):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,4 +1,3 @@
-import collections.abc
 import random
 import warnings
 
@@ -14,7 +13,7 @@ from sympy.matrices import (
     SparseMatrix, casoratian, diag, eye, hessian,
     matrix_multiply_elementwise, ones, randMatrix, rot_axis1, rot_axis2,
     rot_axis3, wronskian, zeros, MutableDenseMatrix, ImmutableDenseMatrix)
-from sympy.core.compatibility import long, iterable, range
+from sympy.core.compatibility import long, iterable, range, Hashable
 from sympy.core import Tuple
 from sympy.utilities.iterables import flatten, capture
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
@@ -2634,7 +2633,7 @@ def test_hash():
         assert len(s) == 1 and s.pop() == cls.eye(1)
     # issue 3979
     for cls in classes[:2]:
-        assert not isinstance(cls.eye(1), collections.abc.Hashable)
+        assert not isinstance(cls.eye(1), Hashable)
 
 
 @XFAIL

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import random
 import warnings
 
@@ -2634,7 +2634,7 @@ def test_hash():
         assert len(s) == 1 and s.pop() == cls.eye(1)
     # issue 3979
     for cls in classes[:2]:
-        assert not isinstance(cls.eye(1), collections.Hashable)
+        assert not isinstance(cls.eye(1), collections.abc.Hashable)
 
 
 @XFAIL

--- a/sympy/parsing/latex/_build_latex_antlr.py
+++ b/sympy/parsing/latex/_build_latex_antlr.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import glob
 
+from sympy.utilities.misc import debug
+
 here = os.path.dirname(__file__)
 grammar_file = os.path.join(here, "LaTeX.g4")
 dir_latex_antlr = os.path.join(here, "_antlr")
@@ -20,14 +22,14 @@ header = '''
 
 
 def check_antlr_version():
-    print("Checking antlr4 version...")
+    debug("Checking antlr4 version...")
 
     try:
-        print(subprocess.check_output(["antlr4"])
+        debug(subprocess.check_output(["antlr4"])
               .decode('utf-8').split("\n")[0])
         return True
     except (subprocess.CalledProcessError, FileNotFoundError):
-        print("The antlr4 command line tool is not installed, "
+        debug("The antlr4 command line tool is not installed, "
               "or not on your PATH\n"
               "> Please install it via your preferred package manager")
         return False
@@ -36,7 +38,7 @@ def check_antlr_version():
 def build_parser(output_dir=dir_latex_antlr):
     check_antlr_version()
 
-    print("Updating ANTLR-generated code in {}".format(output_dir))
+    debug("Updating ANTLR-generated code in {}".format(output_dir))
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -53,10 +55,10 @@ def build_parser(output_dir=dir_latex_antlr):
         "-no-listener",
     ]
 
-    print("Running code generation...\n\t$ {}".format(" ".join(args)))
+    debug("Running code generation...\n\t$ {}".format(" ".join(args)))
     subprocess.check_output(args, cwd=output_dir)
 
-    print("Applying headers and renaming...")
+    debug("Applying headers and renaming...")
     for path in glob.glob(os.path.join(output_dir, "LaTeX*.*")):
         offset = 0
         new_path = os.path.join(output_dir,
@@ -71,7 +73,7 @@ def build_parser(output_dir=dir_latex_antlr):
                     for line in in_file.readlines()[offset:]
                 ])
         os.unlink(path)
-        print("\t{}".format(new_path))
+        debug("\t{}".format(new_path))
 
     return True
 

--- a/sympy/parsing/latex/_build_latex_antlr.py
+++ b/sympy/parsing/latex/_build_latex_antlr.py
@@ -5,7 +5,7 @@ import glob
 from sympy.utilities.misc import debug
 
 here = os.path.dirname(__file__)
-grammar_file = os.path.join(here, "LaTeX.g4")
+grammar_file = os.path.abspath(os.path.join(here, "LaTeX.g4"))
 dir_latex_antlr = os.path.join(here, "_antlr")
 
 header = '''

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -7,7 +7,7 @@ from sympy import Dummy
 from sympy.utilities.iterables import flatten
 from sympy.physics.vector import dynamicsymbols
 from sympy.physics.mechanics.functions import msubs
-import collections
+import collections.abc
 
 
 class Linearizer(object):
@@ -262,7 +262,7 @@ class Linearizer(object):
         # Compose dict of operating conditions
         if isinstance(op_point, dict):
             op_point_dict = op_point
-        elif isinstance(op_point, collections.Iterable):
+        elif isinstance(op_point, collections.abc.Iterable):
             op_point_dict = {}
             for op in op_point:
                 op_point_dict.update(op)

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -3,12 +3,13 @@ from __future__ import print_function, division
 __all__ = ['Linearizer']
 
 from sympy.core.backend import Matrix, eye, zeros
+from sympy.core.compatibility import Iterable
 from sympy import Dummy
 from sympy.utilities.iterables import flatten
 from sympy.physics.vector import dynamicsymbols
 from sympy.physics.mechanics.functions import msubs
-import collections.abc
 
+from collections import namedtuple
 
 class Linearizer(object):
     """This object holds the general model form for a dynamic system.
@@ -92,7 +93,7 @@ class Linearizer(object):
         o = len(self.u)
         s = len(self.r)
         k = len(self.lams)
-        dims = collections.namedtuple('dims', ['l', 'm', 'n', 'o', 's', 'k'])
+        dims = namedtuple('dims', ['l', 'm', 'n', 'o', 's', 'k'])
         self._dims = dims(l, m, n, o, s, k)
 
         self._setup_done = False
@@ -262,7 +263,7 @@ class Linearizer(object):
         # Compose dict of operating conditions
         if isinstance(op_point, dict):
             op_point_dict = op_point
-        elif isinstance(op_point, collections.abc.Iterable):
+        elif isinstance(op_point, Iterable):
             op_point_dict = {}
             for op in op_point:
                 op_point_dict.update(op)

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -6,7 +6,7 @@ Several methods to simplify expressions involving unit objects.
 
 from __future__ import division
 
-import collections
+import collections.abc
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -104,7 +104,7 @@ def convert_to(expr, target_units):
     7.62950196312651e-20*gravitational_constant**(-0.5)*hbar**0.5*speed_of_light**0.5
 
     """
-    if not isinstance(target_units, (collections.Iterable, Tuple)):
+    if not isinstance(target_units, (collections.abc.Iterable, Tuple)):
         target_units = [target_units]
 
     if isinstance(expr, Add):

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -6,12 +6,10 @@ Several methods to simplify expressions involving unit objects.
 
 from __future__ import division
 
-import collections.abc
-
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from sympy import Add, Function, Mul, Pow, Rational, Tuple, sympify
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, Iterable
 from sympy.physics.units.dimensions import Dimension, dimsys_default
 from sympy.physics.units.quantities import Quantity
 from sympy.physics.units.prefixes import Prefix
@@ -104,7 +102,7 @@ def convert_to(expr, target_units):
     7.62950196312651e-20*gravitational_constant**(-0.5)*hbar**0.5*speed_of_light**0.5
 
     """
-    if not isinstance(target_units, (collections.abc.Iterable, Tuple)):
+    if not isinstance(target_units, (Iterable, Tuple)):
         target_units = [target_units]
 
     if isinstance(expr, Add):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -25,13 +25,12 @@ every time you call ``show()`` and the old one is left to the garbage collector.
 from __future__ import print_function, division
 
 import inspect
-from collections.abc import Callable
 import warnings
 import sys
 
 from sympy import sympify, Expr, Tuple, Dummy, Symbol
 from sympy.external import import_module
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, Callable
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import is_sequence
 from .experimental_lambdify import (vectorized_lambdify, lambdify)

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -25,7 +25,7 @@ every time you call ``show()`` and the old one is left to the garbage collector.
 from __future__ import print_function, division
 
 import inspect
-from collections import Callable
+from collections.abc import Callable
 import warnings
 import sys
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -48,6 +48,9 @@ _show = True
 
 
 def unset_show():
+    """
+    Disable show(). For use in the tests.
+    """
     global _show
     _show = False
 
@@ -1030,6 +1033,8 @@ class MatplotlibBackend(BaseBackend):
         #self.fig.show()
         if _show:
             self.plt.show()
+        else:
+            self.close()
 
     def save(self, path):
         self.process_series()

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -29,7 +29,12 @@ class TmpFileManager:
 
     @classmethod
     def cleanup(cls):
-        map(os.remove, cls.tmp_files)
+        for file in cls.tmp_files:
+            try:
+                os.remove(file)
+            except OSError:
+                # If the file doesn't exist, for instance, if the test failed.
+                pass
 
 def plot_and_save(name):
     tmp_file = TmpFileManager.tmp_file

--- a/sympy/plotting/tests/test_plot_implicit.py
+++ b/sympy/plotting/tests/test_plot_implicit.py
@@ -60,7 +60,7 @@ def plot_implicit_tests(name):
             assert "Adaptive meshing could not be applied" in str(i.message)
 
     with warnings.catch_warnings(record=True) as w:
-        plot_and_save(x**2 - 1, legend='An implicit plot')
+        plot_and_save(x**2 - 1, title='An implicit plot')
         for i in w:
             assert issubclass(i.category, UserWarning)
             assert 'No labelled objects found' in str(i.message)

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -5,8 +5,8 @@ A few practical conventions common to all printers.
 from __future__ import print_function, division
 
 import re
-import collections.abc
 
+from sympy.core.compatibility import Iterable
 
 _name_with_digits_p = re.compile(r'^([a-zA-Z]+)([0-9]+)$')
 
@@ -77,7 +77,7 @@ def requires_partial(expr):
     get the context of the expression.
     """
 
-    if not isinstance(expr.free_symbols, collections.abc.Iterable):
+    if not isinstance(expr.free_symbols, Iterable):
         return len(set(expr.variables)) > 1
 
     return sum(not s.is_integer for s in expr.free_symbols) > 1

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -5,7 +5,7 @@ A few practical conventions common to all printers.
 from __future__ import print_function, division
 
 import re
-import collections
+import collections.abc
 
 
 _name_with_digits_p = re.compile(r'^([a-zA-Z]+)([0-9]+)$')
@@ -77,7 +77,7 @@ def requires_partial(expr):
     get the context of the expression.
     """
 
-    if not isinstance(expr.free_symbols, collections.Iterable):
+    if not isinstance(expr.free_symbols, collections.abc.Iterable):
         return len(set(expr.variables)) > 1
 
     return sum(not s.is_integer for s in expr.free_symbols) > 1

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -10,12 +10,6 @@ from .pycode import (
 from sympy.external import import_module
 from sympy.utilities import default_sort_key
 
-tensorflow = import_module('tensorflow')
-if tensorflow and V(tensorflow.__version__) < '1.0':
-    tensorflow_piecewise = "select"
-else:
-    tensorflow_piecewise = "where"
-
 class LambdaPrinter(PythonCodePrinter):
     """
     This printer converts expressions into strings that can be used by
@@ -111,6 +105,12 @@ class TensorflowPrinter(LambdaPrinter):
             self._print(Max(*expr.args[1:]), **kwargs))
 
     def _print_Piecewise(self, expr, **kwargs):
+        tensorflow = import_module('tensorflow')
+        if tensorflow and V(tensorflow.__version__) < '1.0':
+            tensorflow_piecewise = "select"
+        else:
+            tensorflow_piecewise = "where"
+
         from sympy import Piecewise
         e, cond = expr.args[0].args
         if len(expr.args) == 1:

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -1,8 +1,15 @@
+import logging
+
 from sympy.external import import_module
 from sympy.utilities.pytest import raises, SKIP
 from sympy.core.compatibility import range
 
+theanologger = logging.getLogger('theano.configdefaults')
+theanologger.setLevel(logging.CRITICAL)
 theano = import_module('theano')
+theanologger.setLevel(logging.WARNING)
+
+
 if theano:
     import numpy as np
     ts = theano.scalar

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -1,12 +1,10 @@
 import itertools
 
-import collections.abc
-
 from sympy import S, Tuple, diff
 
+from sympy.core.compatibility import Iterable
 from sympy.tensor.array import ImmutableDenseNDimArray
 from sympy.tensor.array.ndim_array import NDimArray
-
 
 def _arrayfy(a):
     from sympy.matrices import MatrixBase
@@ -103,7 +101,7 @@ def tensorcontraction(array, *contraction_axes):
     # Verify contraction_axes:
     taken_dims = set([])
     for axes_group in contraction_axes:
-        if not isinstance(axes_group, collections.abc.Iterable):
+        if not isinstance(axes_group, Iterable):
             raise ValueError("collections of contraction axes expected")
 
         dim = array.shape[axes_group[0]]
@@ -190,7 +188,7 @@ def derive_by_array(expr, dx):
 
     """
     from sympy.matrices import MatrixBase
-    array_types = (collections.abc.Iterable, MatrixBase, NDimArray)
+    array_types = (Iterable, MatrixBase, NDimArray)
 
     if isinstance(dx, array_types):
         dx = ImmutableDenseNDimArray(dx)

--- a/sympy/tensor/array/arrayop.py
+++ b/sympy/tensor/array/arrayop.py
@@ -1,6 +1,6 @@
 import itertools
 
-import collections
+import collections.abc
 
 from sympy import S, Tuple, diff
 
@@ -103,7 +103,7 @@ def tensorcontraction(array, *contraction_axes):
     # Verify contraction_axes:
     taken_dims = set([])
     for axes_group in contraction_axes:
-        if not isinstance(axes_group, collections.Iterable):
+        if not isinstance(axes_group, collections.abc.Iterable):
             raise ValueError("collections of contraction axes expected")
 
         dim = array.shape[axes_group[0]]
@@ -190,7 +190,7 @@ def derive_by_array(expr, dx):
 
     """
     from sympy.matrices import MatrixBase
-    array_types = (collections.Iterable, MatrixBase, NDimArray)
+    array_types = (collections.abc.Iterable, MatrixBase, NDimArray)
 
     if isinstance(dx, array_types):
         dx = ImmutableDenseNDimArray(dx)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, division
-import collections
+import collections.abc
 
 from sympy import Basic
 from sympy.core.compatibility import SYMPY_INTS
@@ -104,13 +104,13 @@ class NDimArray(object):
 
     def _setter_iterable_check(self, value):
         from sympy.matrices.matrices import MatrixBase
-        if isinstance(value, (collections.Iterable, MatrixBase, NDimArray)):
+        if isinstance(value, (collections.abc.Iterable, MatrixBase, NDimArray)):
             raise NotImplementedError
 
     @classmethod
     def _scan_iterable_shape(cls, iterable):
         def f(pointer):
-            if not isinstance(pointer, collections.Iterable):
+            if not isinstance(pointer, collections.abc.Iterable):
                 return [pointer], ()
 
             result = []
@@ -135,7 +135,7 @@ class NDimArray(object):
             shape = iterable.shape
             iterable = list(iterable)
         # Construct N-dim array from an iterable (numpy arrays included):
-        elif shape is None and isinstance(iterable, collections.Iterable):
+        elif shape is None and isinstance(iterable, collections.abc.Iterable):
             iterable, shape = cls._scan_iterable_shape(iterable)
 
         # Construct N-dim array from a Matrix:
@@ -245,7 +245,7 @@ class NDimArray(object):
         from sympy import derive_by_array
         from sympy import Derivative, Tuple
         from sympy.matrices.common import MatrixCommon
-        if isinstance(arg, (collections.Iterable, Tuple, MatrixCommon, NDimArray)):
+        if isinstance(arg, (collections.abc.Iterable, Tuple, MatrixCommon, NDimArray)):
             return derive_by_array(self, arg)
         else:
             return self.applyfunc(lambda x: x.diff(arg))
@@ -342,7 +342,7 @@ class NDimArray(object):
     def __mul__(self, other):
         from sympy.matrices.matrices import MatrixBase
 
-        if isinstance(other, (collections.Iterable,NDimArray, MatrixBase)):
+        if isinstance(other, (collections.abc.Iterable,NDimArray, MatrixBase)):
             raise ValueError("scalar expected, use tensorproduct(...) for tensorial product")
         other = sympify(other)
         result_list = [i*other for i in self]
@@ -351,7 +351,7 @@ class NDimArray(object):
     def __rmul__(self, other):
         from sympy.matrices.matrices import MatrixBase
 
-        if isinstance(other, (collections.Iterable,NDimArray, MatrixBase)):
+        if isinstance(other, (collections.abc.Iterable,NDimArray, MatrixBase)):
             raise ValueError("scalar expected, use tensorproduct(...) for tensorial product")
         other = sympify(other)
         result_list = [other*i for i in self]
@@ -360,7 +360,7 @@ class NDimArray(object):
     def __div__(self, other):
         from sympy.matrices.matrices import MatrixBase
 
-        if isinstance(other, (collections.Iterable,NDimArray, MatrixBase)):
+        if isinstance(other, (collections.abc.Iterable,NDimArray, MatrixBase)):
             raise ValueError("scalar expected")
         other = sympify(other)
         result_list = [i/other for i in self]

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -1,8 +1,7 @@
 from __future__ import print_function, division
-import collections.abc
 
 from sympy import Basic
-from sympy.core.compatibility import SYMPY_INTS
+from sympy.core.compatibility import SYMPY_INTS, Iterable
 
 
 class NDimArray(object):
@@ -104,13 +103,13 @@ class NDimArray(object):
 
     def _setter_iterable_check(self, value):
         from sympy.matrices.matrices import MatrixBase
-        if isinstance(value, (collections.abc.Iterable, MatrixBase, NDimArray)):
+        if isinstance(value, (Iterable, MatrixBase, NDimArray)):
             raise NotImplementedError
 
     @classmethod
     def _scan_iterable_shape(cls, iterable):
         def f(pointer):
-            if not isinstance(pointer, collections.abc.Iterable):
+            if not isinstance(pointer, Iterable):
                 return [pointer], ()
 
             result = []
@@ -135,7 +134,7 @@ class NDimArray(object):
             shape = iterable.shape
             iterable = list(iterable)
         # Construct N-dim array from an iterable (numpy arrays included):
-        elif shape is None and isinstance(iterable, collections.abc.Iterable):
+        elif shape is None and isinstance(iterable, Iterable):
             iterable, shape = cls._scan_iterable_shape(iterable)
 
         # Construct N-dim array from a Matrix:
@@ -245,7 +244,7 @@ class NDimArray(object):
         from sympy import derive_by_array
         from sympy import Derivative, Tuple
         from sympy.matrices.common import MatrixCommon
-        if isinstance(arg, (collections.abc.Iterable, Tuple, MatrixCommon, NDimArray)):
+        if isinstance(arg, (Iterable, Tuple, MatrixCommon, NDimArray)):
             return derive_by_array(self, arg)
         else:
             return self.applyfunc(lambda x: x.diff(arg))
@@ -342,7 +341,7 @@ class NDimArray(object):
     def __mul__(self, other):
         from sympy.matrices.matrices import MatrixBase
 
-        if isinstance(other, (collections.abc.Iterable,NDimArray, MatrixBase)):
+        if isinstance(other, (Iterable, NDimArray, MatrixBase)):
             raise ValueError("scalar expected, use tensorproduct(...) for tensorial product")
         other = sympify(other)
         result_list = [i*other for i in self]
@@ -351,7 +350,7 @@ class NDimArray(object):
     def __rmul__(self, other):
         from sympy.matrices.matrices import MatrixBase
 
-        if isinstance(other, (collections.abc.Iterable,NDimArray, MatrixBase)):
+        if isinstance(other, (Iterable, NDimArray, MatrixBase)):
             raise ValueError("scalar expected, use tensorproduct(...) for tensorial product")
         other = sympify(other)
         result_list = [other*i for i in self]
@@ -360,7 +359,7 @@ class NDimArray(object):
     def __div__(self, other):
         from sympy.matrices.matrices import MatrixBase
 
-        if isinstance(other, (collections.abc.Iterable,NDimArray, MatrixBase)):
+        if isinstance(other, (Iterable, NDimArray, MatrixBase)):
             raise ValueError("scalar expected")
         other = sympify(other)
         result_list = [i/other for i in self]

--- a/sympy/tensor/functions.py
+++ b/sympy/tensor/functions.py
@@ -1,4 +1,4 @@
-import collections.abc
+from sympy.core.compatibility import Iterable
 from sympy.core.evaluate import global_evaluate
 from sympy import Expr, S, Mul, sympify
 
@@ -25,7 +25,7 @@ class TensorProduct(Expr):
         other = []
         scalar = S.One
         for arg in args:
-            if isinstance(arg, (collections.abc.Iterable, MatrixBase, NDimArray)):
+            if isinstance(arg, (Iterable, MatrixBase, NDimArray)):
                 arrays.append(Array(arg))
             elif isinstance(arg, (MatrixExpr,)):
                 other.append(arg)

--- a/sympy/tensor/functions.py
+++ b/sympy/tensor/functions.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 from sympy.core.evaluate import global_evaluate
 from sympy import Expr, S, Mul, sympify
 
@@ -25,7 +25,7 @@ class TensorProduct(Expr):
         other = []
         scalar = S.One
         for arg in args:
-            if isinstance(arg, (collections.Iterable, MatrixBase, NDimArray)):
+            if isinstance(arg, (collections.abc.Iterable, MatrixBase, NDimArray)):
                 arrays.append(Array(arg))
             elif isinstance(arg, (MatrixExpr,)):
                 other.append(arg)

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -107,7 +107,7 @@ matrix element ``M[i, j]`` as in the following diagram::
 
 from __future__ import print_function, division
 
-import collections
+import collections.abc
 
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta
@@ -152,7 +152,7 @@ class Indexed(Expr):
             raise TypeError(filldedent("""
                 Indexed expects string, Symbol, or IndexedBase as base."""))
         args = list(map(sympify, args))
-        if isinstance(base, (NDimArray, collections.Iterable, Tuple, MatrixBase)) and all([i.is_number for i in args]):
+        if isinstance(base, (NDimArray, collections.abc.Iterable, Tuple, MatrixBase)) and all([i.is_number for i in args]):
             if len(args) == 1:
                 return base[args[0]]
             else:
@@ -384,7 +384,7 @@ class IndexedBase(Expr, NotIterable):
             pass
         elif isinstance(label, (MatrixBase, NDimArray)):
             return label
-        elif isinstance(label, collections.Iterable):
+        elif isinstance(label, collections.abc.Iterable):
             return _sympify(label)
         else:
             label = _sympify(label)

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -107,12 +107,11 @@ matrix element ``M[i, j]`` as in the following diagram::
 
 from __future__ import print_function, division
 
-import collections.abc
-
 from sympy.core.sympify import _sympify
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.core import Expr, Tuple, Symbol, sympify, S
-from sympy.core.compatibility import is_sequence, string_types, NotIterable, range
+from sympy.core.compatibility import (is_sequence, string_types, NotIterable,
+    range, Iterable)
 
 
 class IndexException(Exception):
@@ -152,7 +151,7 @@ class Indexed(Expr):
             raise TypeError(filldedent("""
                 Indexed expects string, Symbol, or IndexedBase as base."""))
         args = list(map(sympify, args))
-        if isinstance(base, (NDimArray, collections.abc.Iterable, Tuple, MatrixBase)) and all([i.is_number for i in args]):
+        if isinstance(base, (NDimArray, Iterable, Tuple, MatrixBase)) and all([i.is_number for i in args]):
             if len(args) == 1:
                 return base[args[0]]
             else:
@@ -384,7 +383,7 @@ class IndexedBase(Expr, NotIterable):
             pass
         elif isinstance(label, (MatrixBase, NDimArray)):
             return label
-        elif isinstance(label, collections.abc.Iterable):
+        elif isinstance(label, Iterable):
             return _sympify(label)
         else:
             label = _sympify(label)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1916,6 +1916,8 @@ class PyTestReporter(Reporter):
         self._terminal_width = None
         self._default_width = 80
         self._split = split
+        self._active_file = ''
+        self._active_f = None
 
         # TODO: Should these be protected?
         self.slow_test_functions = []

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -26,6 +26,11 @@ numpy = import_module('numpy')
 numexpr = import_module('numexpr')
 tensorflow = import_module('tensorflow')
 
+if tensorflow:
+    # Hide Tensorflow warnings
+    import os
+    os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+
 w, x, y, z = symbols('w,x,y,z')
 
 #================== Test different arguments =======================

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -11,7 +11,7 @@ from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol, sin, cos,\
 import sympy.vector
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-import collections
+import collections.abc
 
 
 def CoordSysCartesian(*args, **kwargs):
@@ -84,7 +84,7 @@ class CoordSys3D(Basic):
                 else:
                     transformation = Lambda(transformation[0],
                                             transformation[1])
-            elif isinstance(transformation, collections.Callable):
+            elif isinstance(transformation, collections.abc.Callable):
                 x1, x2, x3 = symbols('x1 x2 x3', cls=Dummy)
                 transformation = Lambda((x1, x2, x3),
                                         transformation(x1, x2, x3))

--- a/sympy/vector/coordsysrect.py
+++ b/sympy/vector/coordsysrect.py
@@ -1,6 +1,6 @@
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.basic import Basic
-from sympy.core.compatibility import string_types, range
+from sympy.core.compatibility import string_types, range, Callable
 from sympy.core.cache import cacheit
 from sympy.core import S, Dummy, Lambda
 from sympy import symbols, MatrixBase, ImmutableDenseMatrix
@@ -11,7 +11,6 @@ from sympy import eye, trigsimp, ImmutableMatrix as Matrix, Symbol, sin, cos,\
 import sympy.vector
 from sympy.vector.orienters import (Orienter, AxisOrienter, BodyOrienter,
                                     SpaceOrienter, QuaternionOrienter)
-import collections.abc
 
 
 def CoordSysCartesian(*args, **kwargs):
@@ -84,7 +83,7 @@ class CoordSys3D(Basic):
                 else:
                     transformation = Lambda(transformation[0],
                                             transformation[1])
-            elif isinstance(transformation, collections.abc.Callable):
+            elif isinstance(transformation, Callable):
                 x1, x2, x3 = symbols('x1 x2 x3', cls=Dummy)
                 transformation = Lambda((x1, x2, x3),
                                         transformation(x1, x2, x3))


### PR DESCRIPTION
TODO:

- [ ] Theano warnings
- [ ] LLVMPY warnings
- [x] IPython warnings
- [x] Consolidate optional dependency tests
- [x] Plotting warnings in doctests
- [x] Tensorflow warnings in lambdify tests
- [x] LaTeX parsing warnings
- [x] Antlr stuff printed during parsing tests
- [x] Stuff printed during rubi tests
- [x] NumPy warnings in the plot tests
- [ ] Java warnings in the LaTeX parser
- [ ] Matplotlib building the font cache
- [x] NumPy ABI warning
