### PR TITLE
continuum_mechanics : Added applied_loads and remove_load methods

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -92,6 +92,7 @@ class Beam(object):
         self.variable = variable
         self._boundary_conditions = {'deflection': [], 'slope': []}
         self._load = 0
+        self._applied_loads = []
         self._reaction_loads = {}
 
     def __str__(self):
@@ -256,6 +257,7 @@ class Beam(object):
         start = sympify(start)
         order = sympify(order)
 
+        self._applied_loads.append((value, start, order, end))
         self._load += value*SingularityFunction(x, start, order)
 
         if end:
@@ -263,6 +265,73 @@ class Beam(object):
                 self._load -= value*SingularityFunction(x, end, order)
             elif order.is_positive:
                 self._load -= value*SingularityFunction(x, end, order) + value*SingularityFunction(x, end, 0)
+            else:
+                raise ValueError("""Order of the load should be positive.""")
+
+    def remove_load(self, value, start, order, end=None):
+        """
+        This method removes a particular load present on the beam object.
+        Returns a ValueError if the load passed as an argument is not
+        present on the beam.
+
+        Parameters
+        ==========
+        value : Sympifyable
+            The magnitude of an applied load.
+        start : Sympifyable
+            The starting point of the applied load. For point moments and
+            point forces this is the location of application.
+        order : Integer
+            The order of the applied load.
+            - For moments, order= -2
+            - For point loads, order=-1
+            - For constant distributed load, order=0
+            - For ramp loads, order=1
+            - For parabolic ramp loads, order=2
+            - ... so on.
+        end : Sympifyable, optional
+            An optional argument that can be used if the load has an end point
+            within the length of the beam.
+
+        Examples
+        ========
+        There is a beam of length 4 meters. A moment of magnitude 3 Nm is
+        applied in the clockwise direction at the starting point of the beam.
+        A pointload of magnitude 4 N is applied from the top of the beam at
+        2 meters from the starting point and a parabolic ramp load of magnitude
+        2 N/m is applied below the beam starting from 2 meters to 3 meters
+        away from the starting point of the beam.
+
+        >>> from sympy.physics.continuum_mechanics.beam import Beam
+        >>> from sympy import symbols
+        >>> E, I = symbols('E, I')
+        >>> b = Beam(4, E, I)
+        >>> b.apply_load(-3, 0, -2)
+        >>> b.apply_load(4, 2, -1)
+        >>> b.apply_load(-2, 2, 2, end = 3)
+        >>> b.load
+        -3*SingularityFunction(x, 0, -2) + 4*SingularityFunction(x, 2, -1) - 2*SingularityFunction(x, 2, 2)
+            + 2*SingularityFunction(x, 3, 0) + 2*SingularityFunction(x, 3, 2)
+        >>> b.remove_load(-2, 2, 2, end = 3)
+        >>> b.load
+        -3*SingularityFunction(x, 0, -2) + 4*SingularityFunction(x, 2, -1)
+        """
+        x = self.variable
+        value = sympify(value)
+        start = sympify(start)
+        order = sympify(order)
+
+        if (value, start, order, end) in self._applied_loads:
+            self._load -= value*SingularityFunction(x, start, order)
+            self._applied_loads.remove((value, start, order, end))
+        else:
+            raise ValueError("""No such load distribution exists on the beam object.""")
+
+        if end:
+            if order == 0:
+                self._load += value*SingularityFunction(x, end, order)
+            elif order.is_positive:
+                self._load += value*SingularityFunction(x, end, order) + value*SingularityFunction(x, end, 0)
             else:
                 raise ValueError("""Order of the load should be positive.""")
 
@@ -292,6 +361,34 @@ class Beam(object):
         -3*SingularityFunction(x, 0, -2) + 4*SingularityFunction(x, 2, -1) - 2*SingularityFunction(x, 3, 2)
         """
         return self._load
+
+    @property
+    def applied_loads(self):
+        """
+        Returns a list of all loads applied on the beam object.
+        Each load in the list is a tuple of form (value, start, order, end).
+
+        Examples
+        ========
+        There is a beam of length 4 meters. A moment of magnitude 3 Nm is
+        applied in the clockwise direction at the starting point of the beam.
+        A pointload of magnitude 4 N is applied from the top of the beam at
+        2 meters from the starting point. Another pointload of magnitude 5 N
+        is applied at same position.
+
+        >>> from sympy.physics.continuum_mechanics.beam import Beam
+        >>> from sympy import symbols
+        >>> E, I = symbols('E, I')
+        >>> b = Beam(4, E, I)
+        >>> b.apply_load(-3, 0, -2)
+        >>> b.apply_load(4, 2, -1)
+        >>> b.apply_load(5, 2, -1)
+        >>> b.load
+        -3*SingularityFunction(x, 0, -2) + 9*SingularityFunction(x, 2, -1)
+        >>> b.applied_loads
+        [(-3, 0, -2, None), (4, 2, -1, None), (5, 2, -1, None)]
+        """
+        return self._applied_loads
 
     def solve_for_reaction_loads(self, *reactions):
         """

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -171,3 +171,38 @@ def test_Beam():
     raises(ValueError, lambda: b4.apply_load(-3, 0, -1, end=3))
     with raises(TypeError):
         b4.variable = 1
+
+
+def test_remove_load():
+    E = Symbol('E')
+    I = Symbol('I')
+    b = Beam(4, E, I)
+
+    try:
+        b.remove_load(2, 1, -1)
+    # As no load is applied on beam, ValueError should be returned.
+    except ValueError:
+        assert True
+    else:
+        assert False
+
+    b.apply_load(-3, 0, -2)
+    b.apply_load(4, 2, -1)
+    b.apply_load(-2, 2, 2, end = 3)
+    b.remove_load(-2, 2, 2, end = 3)
+    assert b.load == -3*SingularityFunction(x, 0, -2) + 4*SingularityFunction(x, 2, -1)
+    assert b.applied_loads == [(-3, 0, -2, None), (4, 2, -1, None)]
+
+    try:
+        b.remove_load(1, 2, -1)
+    # As load of this magnitude was never applied at
+    # this position, method should return a ValueError.
+    except ValueError:
+        assert True
+    else:
+        assert False
+
+    b.remove_load(-3, 0, -2)
+    b.remove_load(4, 2, -1)
+    assert b.load == 0
+    assert b.applied_loads == []


### PR DESCRIPTION
#### Brief description of what is fixed or changed
This PR implements `remove_load` method to remove previously applied loads on the beam object.
This is little different from adding a negative load to make net equal to zero and would work only if that particular load exists on beam. example:
```
>>> b.apply_load(4, 2, -1)
>>> b.remove_load(1, 2, -1)  # will give ValueError as no such load was present on beam
>>> b.remove_load(4, 2, -1)  # will remove the load
```

I also implemented `applied_loads` method which keeps a track of all load applied on beam. 
It is different from `b.load` as it treat each load as a separate entity. `load` property  would sum up all the loads at a particular point but `applied_loads` will still show them as separate loads. For example
```
>>> b.apply_load(4, 2, -1)
>>> b.apply_load(2, 2, -1)
>>> b.load
6*SingularityFunction(x, 2, -1)
>>> b.applied_loads
[(4, 2, -1, None), (2, 2, -1, None)]
```
ping @parsoyaarihant @moorepants 