### PR TITLE
added `apply_support` and `max_deflection` methods

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -247,7 +247,7 @@ class Beam(object):
         >>> R_10, R_30 = symbols('R_10, R_30')
         >>> b.solve_for_reaction_loads(R_10, R_30)
         >>> b.load
-        -8*SingularityFunction(x, 0, -1) + 6*SingularityFunction(x, 10, -1) 
+        -8*SingularityFunction(x, 0, -1) + 6*SingularityFunction(x, 10, -1)
         + 120*SingularityFunction(x, 30, -2) + 2*SingularityFunction(x, 30, -1)
         >>> b.slope()
         (-4*SingularityFunction(x, 0, 2) + 3*SingularityFunction(x, 10, 2)
@@ -268,7 +268,7 @@ class Beam(object):
             self._supports.append((loc, type))
 
     def support_locations(self):
-        """ Returns a list of tuples containing location of Support 
+        """ Returns a list of tuples containing location of Support
         and its type respectively."""
         return self._supports
 
@@ -718,3 +718,26 @@ class Beam(object):
         constants = list(linsolve(bc_eqs, C4))
         deflection_curve = deflection_curve.subs({C4: constants[0][0]})
         return S(1)/(E*I)*deflection_curve
+
+    def max_deflection(self):
+        """
+        Returns point of max deflection and its coresponding deflection value
+        in a Beam object.
+        """
+        from sympy import solve, Piecewise
+
+        # To restrict the range within length of the Beam
+        slope_curve = Piecewise((float("nan"), self.variable<=0),
+                (self.slope(), self.variable<self.length),
+                (float("nan"), True))
+
+        points = solve(slope_curve.rewrite(Piecewise), self.variable,
+                        domain=S.Reals)
+        deflection_curve = self.deflection()
+        deflections = [deflection_curve.subs(self.variable, x) for x in points]
+        deflections = list(map(abs, deflections))
+        if len(deflections) != 0:
+            max_def = max(deflections)
+            return (points[deflections.index(max_def)], max_def)
+        else:
+            return None

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -92,7 +92,6 @@ class Beam(object):
         self.variable = variable
         self._boundary_conditions = {'deflection': [], 'slope': []}
         self._load = 0
-        self._supports = []
         self._applied_loads = []
         self._reaction_loads = {}
 
@@ -210,7 +209,7 @@ class Beam(object):
     def bc_deflection(self, d_bcs):
         self._boundary_conditions['deflection'] = d_bcs
 
-    def apply_support(self, loc, type="cantilever"):
+    def apply_support(self, loc, type="fixed"):
         """
         This method applies support to a particular beam object.
 
@@ -219,10 +218,11 @@ class Beam(object):
         loc : Sympifyable
             Location of point at which support is applied.
         type : String
-            Determines type of Beam support applied.
-            - For Simple pinned Support, type = "pin"
-            - For Cantilever Support, type = "fixed"
-            - For Rolling Support, type = "roller"
+            Determines type of Beam support applied. To apply support structure
+            with
+            - zero degree of freedom, type = "fixed"
+            - one degree of freedom, type = "pin"
+            - two degrees of freedom, type = "roller"
 
         Examples
         ========
@@ -240,9 +240,9 @@ class Beam(object):
         >>> from sympy import symbols
         >>> E, I = symbols('E, I')
         >>> b = Beam(30, E, I)
-        >>> b.apply_load(-8, 0, -1)
         >>> b.apply_support(10, 'roller')
         >>> b.apply_support(30, 'roller')
+        >>> b.apply_load(-8, 0, -1)
         >>> b.apply_load(120, 30, -2)
         >>> R_10, R_30 = symbols('R_10, R_30')
         >>> b.solve_for_reaction_loads(R_10, R_30)
@@ -257,7 +257,6 @@ class Beam(object):
             reaction_load = Symbol('R_'+str(loc))
             self.apply_load(reaction_load, loc, -1)
             self.bc_deflection.append((loc, 0))
-            self._supports.append((loc, type))
         else:
             reaction_load = Symbol('R_'+str(loc))
             reaction_moment = Symbol('M_'+str(loc))
@@ -265,12 +264,6 @@ class Beam(object):
             self.apply_load(reaction_moment, loc, -2)
             self.bc_deflection = [(loc, 0)]
             self.bc_slope.append((loc, 0))
-            self._supports.append((loc, type))
-
-    def support_locations(self):
-        """ Returns a list of tuples containing location of Support
-        and its type respectively."""
-        return self._supports
 
     def apply_load(self, value, start, order, end=None):
         """

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -220,7 +220,7 @@ class Beam(object):
             Location of point at which support is applied.
         type : String
             Determines type of Beam support applied.
-            - For Hinged Support, type = "hinge"
+            - For Simple pinned Support, type = "pin"
             - For Cantilever Support, type = "fixed"
             - For Rolling Support, type = "roller"
 
@@ -241,8 +241,8 @@ class Beam(object):
         >>> E, I = symbols('E, I')
         >>> b = Beam(30, E, I)
         >>> b.apply_load(-8, 0, -1)
-        >>> b.apply_support(10, 'hinge')
-        >>> b.apply_support(30, 'hinge')
+        >>> b.apply_support(10, 'roller')
+        >>> b.apply_support(30, 'roller')
         >>> b.apply_load(120, 30, -2)
         >>> R_10, R_30 = symbols('R_10, R_30')
         >>> b.solve_for_reaction_loads(R_10, R_30)
@@ -253,7 +253,7 @@ class Beam(object):
         (-4*SingularityFunction(x, 0, 2) + 3*SingularityFunction(x, 10, 2)
             + 120*SingularityFunction(x, 30, 1) + SingularityFunction(x, 30, 2) + 4000/3)/(E*I)
         """
-        if type == "hinge" or type == "roller":
+        if type == "pin" or type == "roller":
             reaction_load = Symbol('R_'+str(loc))
             self.apply_load(reaction_load, loc, -1)
             self.bc_deflection.append((loc, 0))

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -224,16 +224,28 @@ def test_remove_load():
 def test_apply_support():
     E = Symbol('E')
     I = Symbol('I')
+
     b = Beam(4, E, I)
     b.apply_support(0, "cantilever")
     b.apply_load(20, 4, -1)
     M_0, R_0 = symbols('M_0, R_0')
     b.solve_for_reaction_loads(R_0, M_0)
-
     assert b.slope() == (80*SingularityFunction(x, 0, 1) - 10*SingularityFunction(x, 0, 2)
                 + 10*SingularityFunction(x, 4, 2))/(E*I)
     assert b.deflection() == (40*SingularityFunction(x, 0, 2) - 10*SingularityFunction(x, 0, 3)/3
                 + 10*SingularityFunction(x, 4, 3)/3)/(E*I)
+
+    b = Beam(30, E, I)
+    b.apply_support(10, "pin")
+    b.apply_support(30, "roller")
+    b.apply_load(-8, 0, -1)
+    b.apply_load(120, 30, -2)
+    R_10, R_30 = symbols('R_10, R_30')
+    b.solve_for_reaction_loads(R_10, R_30)
+    assert b.slope() == (-4*SingularityFunction(x, 0, 2) + 3*SingularityFunction(x, 10, 2)
+            + 120*SingularityFunction(x, 30, 1) + SingularityFunction(x, 30, 2) + 4000/3)/(E*I)
+    assert b.deflection() == (4000*x/3 - 4*SingularityFunction(x, 0, 3)/3 + SingularityFunction(x, 10, 3)
+            + 60*SingularityFunction(x, 30, 2) + SingularityFunction(x, 30, 3)/3 - 12000)/(E*I)
 
 
 def test_max_deflection():

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -219,3 +219,31 @@ def test_remove_load():
     b.remove_load(4, 2, -1)
     assert b.load == 0
     assert b.applied_loads == []
+
+
+def test_apply_support():
+    E = Symbol('E')
+    I = Symbol('I')
+    b = Beam(4, E, I)
+    b.apply_support(0, "cantilever")
+    b.apply_load(20, 4, -1)
+    M_0, R_0 = symbols('M_0, R_0')
+    b.solve_for_reaction_loads(R_0, M_0)
+
+    assert b.slope() == (80*SingularityFunction(x, 0, 1) - 10*SingularityFunction(x, 0, 2)
+                + 10*SingularityFunction(x, 4, 2))/(E*I)
+    assert b.deflection() == (40*SingularityFunction(x, 0, 2) - 10*SingularityFunction(x, 0, 3)/3
+                + 10*SingularityFunction(x, 4, 3)/3)/(E*I)
+
+
+def test_max_deflection():
+    E, I, l, F = symbols('E, I, l, F', positive=True)
+    b = Beam(l, E, I)
+    b.bc_deflection = [(0, 0),(l, 0)]
+    b.bc_slope = [(0, 0),(l, 0)]
+    b.apply_load(F/2, 0, -1)
+    b.apply_load(-F*l/8, 0, -2)
+    b.apply_load(F/2, l, -1)
+    b.apply_load(F*l/8, l, -2)
+    b.apply_load(-F, l/2, -1)
+    assert b.max_deflection() == (l/2, F*l**3/(192*E*I))


### PR DESCRIPTION
#### Brief description of what is fixed or changed
`apply_support` applies Support at a particular position. Support can be `cantilever`(fixed support), `roller` or `hinge`. reactional load and moment exerted by the support are represented by `R_x` and `M_x` respectively where `x` is the position of applied support.

#### Other comments
