### PR TITLE
I updated '_remove_repeated' so that the order of indices is preserved

### DIFF
--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -27,7 +27,7 @@ class IndexConformanceException(Exception):
 def _remove_repeated(inds):
     """Removes repeated objects from sequences
 
-    Returns a set of the unique objects and a tuple of all that have been
+    Returns a tuple of the unique objects and a tuple of all that have been
     removed.
 
     >>> from sympy.tensor.index_methods import _remove_repeated
@@ -43,7 +43,7 @@ def _remove_repeated(inds):
         else:
             sum_index[i] = 0
     inds = [x for x in inds if not sum_index[x]]
-    return set(inds), tuple([ i for i in sum_index if sum_index[i] ])
+    return tuple(inds), tuple([ i for i in sum_index if sum_index[i] ])
 
 
 def _get_indices_Mul(expr, return_dummies=False):


### PR DESCRIPTION
When using 'get_indices' in 'tensor.index_methods', it can be convenient for the returned indices to be in the same order as they appear in the original expression. Previously, the indices were returned in a set, which destroys this ordering. Instead, I made it so '_remove_repeated' returns a tuple of the indices, which preserves the order.