### PR TITLE
tensorproduct.py - Fixing a docstring typo in TensorProduct()

### DIFF
--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -56,10 +56,10 @@ class TensorProduct(Expr):
     multiplication that is used primarily with operators and states in quantum
     mechanics.
 
-    Currently, the tensor product distinguishes between commutative and non-
-    commutative arguments.  Commutative arguments are assumed to be scalars and
-    are pulled out in front of the ``TensorProduct``. Non-commutative arguments
-    remain in the resulting ``TensorProduct``.
+    Currently, the tensor product distinguishes between commutative and
+    non-commutative arguments.  Commutative arguments are assumed to be scalars
+    and are pulled out in front of the ``TensorProduct``. Non-commutative
+    arguments remain in the resulting ``TensorProduct``.
 
     Parameters
     ==========


### PR DESCRIPTION
Fixing a typo in TensorProduct docstring (see #14794). The prefix "non-" should not be the
last word on a line. Otherwise, that would be rendered as "non- commutative"
(notice the space between a dash and a word that follows).