### PR TITLE
Added prec_to_dps() method to piecewise._eval_evalf()

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -329,9 +329,7 @@ class Piecewise(Function):
         return self.func(*[(diff(e, x), c) for e, c in self.args])
 
     def _eval_evalf(self, prec):
-        from mpmath.libmp.libmpf import prec_to_dps
-        prec = prec_to_dps(prec)
-        return self.func(*[(e.evalf(prec), c) for e, c in self.args])
+        return self.func(*[(e._evalf(prec), c) for e, c in self.args])
 
     def piecewise_integrate(self, x, **kwargs):
         """Return the Piecewise with each expression being

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -329,6 +329,8 @@ class Piecewise(Function):
         return self.func(*[(diff(e, x), c) for e, c in self.args])
 
     def _eval_evalf(self, prec):
+        from mpmath.libmp.libmpf import prec_to_dps
+        prec = prec_to_dps(prec)
         return self.func(*[(e.evalf(prec), c) for e, c in self.args])
 
     def piecewise_integrate(self, x, **kwargs):

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1098,3 +1098,9 @@ def test_issue_14240():
     assert piecewise_fold(Mul(*[
         Piecewise((i, a), (0, True)) for i in range(1, 41)])
         ) == Piecewise((factorial(40), a), (0, True))
+
+def test_issue_14787():
+    x = Symbol('x')
+    f = Piecewise((x, x < 1), ((S(58) / 7), True))
+    assert str(f.evalf()) == "Piecewise((x, x < 1), (8.28571428571429, True))"
+

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1098,3 +1098,8 @@ def test_issue_14240():
     assert piecewise_fold(Mul(*[
         Piecewise((i, a), (0, True)) for i in range(1, 41)])
         ) == Piecewise((factorial(40), a), (0, True))
+
+def test_issue_14787():
+    x = Symbol('x')
+    f = Piecewise((x, x < 1), ((S(58) / 7), True))
+    assert str(f.evalf()) == "Piecewise((x, x < 1), (8.28571428571429, True))"

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1098,9 +1098,3 @@ def test_issue_14240():
     assert piecewise_fold(Mul(*[
         Piecewise((i, a), (0, True)) for i in range(1, 41)])
         ) == Piecewise((factorial(40), a), (0, True))
-
-def test_issue_14787():
-    x = Symbol('x')
-    f = Piecewise((x, x < 1), ((S(58) / 7), True))
-    assert str(f.evalf()) == "Piecewise((x, x < 1), (8.28571428571429, True))"
-


### PR DESCRIPTION
Added prec_to_dps() method ( which convert number of bits of memory required to number of decimal places of the number i.e. precision ) to piecewise._eval_evalf()

It is a fix to issue #14787 
https://github.com/sympy/sympy/issues/14787

The problem was when program runs it calls evalf() function in /sympy/core/evalf.py In evalf function on line 1411, you can see it stores number of bits required to prec and that prec is further passed to _eval_evalf() in sympy/functions/elementary/piecewise.py. whose original line 332 passes that prec (number of bits required) again to evalf function in /sympy/core/evalf.py while it should pass the original number of digits required(which default is 15). Thats why i converted prec back to number of digits using prec_to_dps().

It passed all the test cases on my local pc along with the error faced.
Some statements to check if this fixes the issue:

import sympy as sym
print((sym.S(58) / 7).evalf())
x = sym.Symbol('x')
f = sym.Piecewise((x, x < 1), ((sym.S(58) / 7), True))
print(f.evalf())

P.S. - This is my first pull request, so please give some feedback. Thanks alot.