### PR TITLE
Fix a bug in _block_verify for strong group presentations

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3816,7 +3816,7 @@ class PermutationGroup(Basic):
         return C.sylow_subgroup(p)
 
     def _block_verify(H, L, alpha):
-        delta = list(H.orbit(alpha))
+        delta = sorted(list(H.orbit(alpha)))
         H_gens = H.generators
         L_gens = L.generators
         # p[i] will be the number of the block
@@ -3852,7 +3852,7 @@ class PermutationGroup(Basic):
                     p[i_d] = sigma
                     rep = d
                     blocks[i_d] = rep
-                    newb = [d]
+                    newb = [rep]
                     for gamma in B[rho][1:]:
                         i_gamma = delta.index(gamma)
                         d = gamma^g


### PR DESCRIPTION
`_block_verify` should return a list whose i-th element is a representative of the block containing the i-th _least_ element of the orbit - hence the ordering of the orbit at the start of the function is important. This PR makes sure it is sorted.

By sheer luck (it seems), the orbits were being ordered appropriately in all tests when run on CPython but in PyPy, lists obtained from sets are ordered differently. Hence the test failures as in issue #14827.

Fixes #14827