### PR TITLE
Fix eval(srepr(f)) when f is Add/Mul with more than 255 args

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -47,8 +47,9 @@ class ReprPrinter(Printer):
 
     def _print_Add(self, expr, order=None):
         args = self._as_ordered_terms(expr, order=order)
+        nargs = len(args)
         args = map(self._print, args)
-        if len(args) > 255:  # Issue #10259, Python < 3.7
+        if nargs > 255:  # Issue #10259, Python < 3.7
             return "Add(*[%s])" % ", ".join(args)
         return "Add(%s)" % ", ".join(args)
 
@@ -124,8 +125,9 @@ class ReprPrinter(Printer):
         else:
             args = terms
 
+        nargs = len(args)
         args = map(self._print, args)
-        if len(args) > 255:  # Issue #10259, Python < 3.7
+        if nargs > 255:  # Issue #10259, Python < 3.7
             return "Mul(*[%s])" % ", ".join(args)
         return "Mul(%s)" % ", ".join(args)
 

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -48,6 +48,8 @@ class ReprPrinter(Printer):
     def _print_Add(self, expr, order=None):
         args = self._as_ordered_terms(expr, order=order)
         args = map(self._print, args)
+        if len(args) > 255:  # Issue #10259, Python < 3.7
+            return "Add(*[%s])" % ", ".join(args)
         return "Add(%s)" % ", ".join(args)
 
     def _print_Cycle(self, expr):
@@ -123,6 +125,8 @@ class ReprPrinter(Printer):
             args = terms
 
         args = map(self._print, args)
+        if len(args) > 255:  # Issue #10259, Python < 3.7
+            return "Mul(*[%s])" % ", ".join(args)
         return "Mul(%s)" % ", ".join(args)
 
     def _print_Rational(self, expr):

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -41,6 +41,13 @@ def test_Add():
     assert srepr(x**2 + 1, order='old') == "Add(Integer(1), Pow(Symbol('x'), Integer(2)))"
 
 
+def test_more_than_255_args_issue_10259():
+    from sympy import Add, Mul
+    for op in (Add, Mul):
+        expr = op(*symbols('x:256'))
+        assert eval(srepr(expr)) == expr
+
+
 def test_Function():
     sT(Function("f")(x), "Function('f')(Symbol('x'))")
     # test unapplied Function


### PR DESCRIPTION
This change is unnecessary (but harmless) on Python >= 3.7.  But
earlier versions of Python limit the number of function arguments
to 255.  We workaround by printing `Add(*[...])` when there are
more than 255 arguments; this avoids the limit.  Fixes #10259.