### PR TITLE
Updating Documentation of evalf(subs=...) 

### DIFF
--- a/doc/src/tutorial/basic_operations.rst
+++ b/doc/src/tutorial/basic_operations.rst
@@ -155,6 +155,16 @@ user's discretion by setting the ``chop`` flag to True.
     >>> (one - 1).evalf(chop=True)
     0
 
+It is always suggested to use ``expr.evalf(subs=...)`` over,
+``expr.subs(...).evalf()`` or ``expr.evalf().subs(...)`` because it
+avoids the loss of significance caused due to naive substitution.
+
+    >>> (x+y-z).subs({x:1e100,y:1,z:1e100})
+    0
+    >>> (x+y-z).evalf(subs={x: 1e100, y: 1, z: 1e100})
+    1.0000000000000
+
+
 ``lambdify``
 ============
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -871,7 +871,31 @@ def evalf_atan(v, prec, options):
 
 
 def evalf_subs(prec, subs):
-    """ Change all Float entries in `subs` to have precision prec. """
+    """
+    Change all Float entries in `subs` to have precision prec.
+    Note:
+    It is always suggested to use expr.evalf(subs=...) over,
+    expr.subs(...).evalf() or expr.evalf().subs(...) because of the
+    following reasons:-
+    i.  The subs dictionary tells the evalf algorithms which symbols should be
+        replaced with numbers when they are encountered.
+    ii. expr.evalf(subs=...) the expression is run through the evalf algorithm,
+        which takes into account various issues that can lead to loss of
+        significance;
+    iii.expr.evalf(subs=...) avoids the loss of significance caused due to
+        naive substitution.
+    Let's take an  example, in first case naive substitution evaluates 1e100 + 1 - 1e100 as 0
+    because of the default precision setting. However, in second case, the
+    evalf algorithm takes care of the significance.
+    Example
+    =======
+        >>> from sympy.core.evalf import evalf
+        >>> from sympy.abc import x,y,z
+        >>> (x+y-z).subs({x:1e100,y:1,z:1e100})
+        0
+        >>> (x+y-z).evalf(subs={x: 1e100, y: 1, z: 1e100})
+        1.0000000000000
+    """
     newsubs = {}
     for a, b in subs.items():
         b = S(b)


### PR DESCRIPTION
Fixes 
I have updated the doc string method in sympy.core.evalf so that it becomes clear why should we use expr.evalf(subs=...) over expr.evalf().subs(...) or expr.subs(...).evalf().
Also i have updated doc/src/tutorial/basic_operations.rst to show updated changes in main documentation.