### PR TITLE
Updating Documentation of evalf(subs=...)

### DIFF
--- a/doc/src/tutorial/basic_operations.rst
+++ b/doc/src/tutorial/basic_operations.rst
@@ -141,9 +141,10 @@ To numerically evaluate an expression with a Symbol at a point, we might use
 stable to pass the substitution to ``evalf`` using the ``subs`` flag, which
 takes a dictionary of ``Symbol: point`` pairs.
 
-    >>> expr = cos(2*x)
-    >>> expr.evalf(subs={x: 2.4})
-    0.0874989834394464
+    >>> (x+y-z).subs({x:1e100,y:1,z:1e100})
+    0
+    >>> (x+y-z).evalf(subs={x: 1e100, y: 1, z: 1e100})
+    1.0000000000000
 
 Sometimes there are roundoff errors smaller than the desired precision that
 remain after an expression is evaluated. Such numbers can be removed at the

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1390,7 +1390,28 @@ class EvalfMixin(object):
 
             verbose=<bool>
                 Print debug information (default=False)
-
+        Note:
+        It is always suggested to use expr.evalf(subs=...) over,
+        expr.subs(...).evalf() or expr.evalf().subs(...) because of the
+        following reasons:-
+        i.  The subs dictionary tells the evalf algorithms which symbols should be
+            replaced with numbers when they are encountered.
+        ii. expr.evalf(subs=...) the expression is run through the evalf algorithm,
+            which takes into account various issues that can lead to loss of
+            significance;
+        iii.expr.evalf(subs=...) avoids the loss of significance caused due to
+            naive substitution.
+        Let's take an  example, in first case naive substitution evaluates 1e100 + 1 - 1e100 as 0
+        because of the default precision setting. However, in second case, the
+        evalf algorithm takes care of the significance.
+        Example
+        =======
+            >>> from sympy.core.evalf import evalf
+            >>> from sympy.abc import x,y,z
+            >>> (x+y-z).subs({x:1e100,y:1,z:1e100})
+            0
+            >>> (x+y-z).evalf(subs={x: 1e100, y: 1, z: 1e100})
+            1.0000000000000
         """
         from sympy import Float, Number
         n = n if n is not None else 15

--- a/sympy/discrete/__init__.py
+++ b/sympy/discrete/__init__.py
@@ -1,10 +1,12 @@
 """A module containing discrete functions.
 
-Transforms - fft, ifft, ntt, intt, fwht, ifwht, fzt, ifzt, fmt, ifmt
+Transforms - fft, ifft, ntt, intt, fwht, ifwht,
+    mobius_transform, inverse_mobius_transform
 Convolution - convolution, convolution_fft, convolution_ntt, convolution_fwht,
     convolution_subset, covering_product, intersecting_product
 Recurrence - linrec
 """
 
-from .transforms import (fft, ifft, ntt, intt, fwht, ifwht)
+from .transforms import (fft, ifft, ntt, intt, fwht, ifwht,
+    mobius_transform, inverse_mobius_transform)
 from .convolution import convolution

--- a/sympy/discrete/tests/test_transforms.py
+++ b/sympy/discrete/tests/test_transforms.py
@@ -3,7 +3,8 @@ from __future__ import print_function, division
 from sympy import sqrt
 from sympy.core import S, Symbol, symbols, I
 from sympy.core.compatibility import range
-from sympy.discrete import fft, ifft, ntt, intt, fwht, ifwht
+from sympy.discrete import (fft, ifft, ntt, intt, fwht, ifwht,
+    mobius_transform, inverse_mobius_transform)
 from sympy.utilities.pytest import raises
 
 
@@ -107,3 +108,51 @@ def test_fwht_ifwht():
     ls = list(range(6))
 
     assert fwht(ls) == [x*8 for x in ifwht(ls)]
+
+
+def test_mobius_transform():
+    assert all(tf(ls, subset=subset) == ls
+                for ls in ([], [S(7)/4]) for subset in (True, False)
+                for tf in (mobius_transform, inverse_mobius_transform))
+
+    w, x, y, z = symbols('w x y z')
+
+    assert mobius_transform([x, y]) == [x, x + y]
+    assert inverse_mobius_transform([x, x + y]) == [x, y]
+    assert mobius_transform([x, y], subset=False) == [x + y, y]
+    assert inverse_mobius_transform([x + y, y], subset=False) == [x, y]
+
+    assert mobius_transform([w, x, y, z]) == [w, w + x, w + y, w + x + y + z]
+    assert inverse_mobius_transform([w, w + x, w + y, w + x + y + z]) == \
+            [w, x, y, z]
+    assert mobius_transform([w, x, y, z], subset=False) == \
+            [w + x + y + z, x + z, y + z, z]
+    assert inverse_mobius_transform([w + x + y + z, x + z, y + z, z], subset=False) == \
+            [w, x, y, z]
+
+    ls = [S(2)/3, S(6)/7, S(5)/8, 9, S(5)/3 + 7*I]
+    mls = [S(2)/3, S(32)/21, S(31)/24, S(1873)/168,
+            S(7)/3 + 7*I, S(67)/21 + 7*I, S(71)/24 + 7*I,
+            S(2153)/168 + 7*I]
+
+    assert mobius_transform(ls) == mls
+    assert inverse_mobius_transform(mls) == ls + [S.Zero]*3
+
+    mls = [S(2153)/168 + 7*I, S(69)/7, S(77)/8, 9, S(5)/3 + 7*I, 0, 0, 0]
+
+    assert mobius_transform(ls, subset=False) == mls
+    assert inverse_mobius_transform(mls, subset=False) == ls + [S.Zero]*3
+
+    ls = ls[:-1]
+    mls = [S(2)/3, S(32)/21, S(31)/24, S(1873)/168]
+
+    assert mobius_transform(ls) == mls
+    assert inverse_mobius_transform(mls) == ls
+
+    mls = [S(1873)/168, S(69)/7, S(77)/8, 9]
+
+    assert mobius_transform(ls, subset=False) == mls
+    assert inverse_mobius_transform(mls, subset=False) == ls
+
+    raises(TypeError, lambda: mobius_transform(x, subset=True))
+    raises(TypeError, lambda: inverse_mobius_transform(y, subset=False))

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -1,8 +1,9 @@
+# -*- coding: utf-8 -*-
 """
 Discrete Fourier Transform, Number Theoretic Transform,
-Walsh Hadamard Transform, Zeta Transform, Mobius Transform
+Walsh Hadamard Transform, Mobius Transform
 """
-from __future__ import print_function, division
+from __future__ import print_function, division, unicode_literals
 
 from sympy.core import S, Symbol, sympify
 from sympy.core.compatibility import as_int, range, iterable
@@ -284,6 +285,12 @@ def fwht(seq):
     The sequence is automatically padded to the right with zeros, as the
     radix 2 FWHT requires the number of sample points to be a power of 2.
 
+    Parameters
+    ==========
+
+    seq : iterable
+        The sequence on which WHT is to be applied.
+
     Examples
     ========
 
@@ -313,3 +320,107 @@ def ifwht(seq):
     return _walsh_hadamard_transform(seq, inverse=True)
 
 ifwht.__doc__ = fwht.__doc__
+
+
+#----------------------------------------------------------------------------#
+#                                                                            #
+#                    Mobius Transform for Subset Lattice                     #
+#                                                                            #
+#----------------------------------------------------------------------------#
+
+def _mobius_transform(seq, sgn, subset):
+    r"""Utility function for performing Möbius Transform using
+    Yate's Dynamic Programming (DP)"""
+
+    if not iterable(seq):
+        raise TypeError("Expected a sequence of coefficients")
+
+    a = [sympify(arg) for arg in seq]
+
+    n = len(a)
+    if n < 2:
+        return a
+
+    if n&(n - 1):
+        n = 2**n.bit_length()
+
+    a += [S.Zero]*(n - len(a))
+
+    if subset:
+        i = 1
+        while i < n:
+            for j in range(n):
+                if j & i:
+                    a[j] += sgn*a[j ^ i]
+            i *= 2
+
+    else:
+        i = 1
+        while i < n:
+            for j in range(n):
+                if j & i:
+                    continue
+                a[j] += sgn*a[j ^ i]
+            i *= 2
+
+    return a
+
+
+def mobius_transform(seq, subset=True):
+    r"""
+    Performs the Möbius Transform for subset lattice with indices of
+    sequence as bitmasks.
+
+    The sequence is automatically padded to the right with zeros, as the
+    definition of subset/superset based on bitmasks (indices) requires
+    the size of sequence to be a power of 2.
+
+    Parameters
+    ==========
+
+    seq : iterable
+        The sequence on which Möbius Transform is to be applied.
+    subset : bool
+        Specifies if Möbius Transform is applied by enumerating subsets
+        or supersets of the given set.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols
+    >>> from sympy import mobius_transform, inverse_mobius_transform
+    >>> x, y, z = symbols('x y z')
+
+    >>> mobius_transform([x, y, z])
+    [x, x + y, x + z, x + y + z]
+    >>> inverse_mobius_transform(_)
+    [x, y, z, 0]
+
+    >>> mobius_transform([x, y, z], subset=False)
+    [x + y + z, y, z, 0]
+    >>> inverse_mobius_transform(_, subset=False)
+    [x, y, z, 0]
+
+    >>> mobius_transform([1, 2, 3, 4])
+    [1, 3, 4, 10]
+    >>> inverse_mobius_transform(_)
+    [1, 2, 3, 4]
+    >>> mobius_transform([1, 2, 3, 4], subset=False)
+    [10, 6, 7, 4]
+    >>> inverse_mobius_transform(_, subset=False)
+    [1, 2, 3, 4]
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Möbius_inversion_formula
+    .. [2] https://arxiv.org/pdf/1211.0189.pdf
+
+    """
+
+    return _mobius_transform(seq, sgn=+1, subset=subset)
+
+def inverse_mobius_transform(seq, subset=True):
+    return _mobius_transform(seq, sgn=-1, subset=subset)
+
+inverse_mobius_transform.__doc__ = mobius_transform.__doc__

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -23,7 +23,6 @@ from sympy.polys import DomainError, Poly, PolynomialError
 from sympy.polys.polyutils import _not_a_coeff, _nsort
 from sympy.solvers import solve
 from sympy.utilities.misc import filldedent, func_name
-from sympy.utilities.decorator import doctest_depends_on
 
 from .entity import GeometryEntity, GeometrySet
 from .point import Point, Point2D, Point3D

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -130,21 +130,24 @@ class no_attrs_in_subclass(object):
 def doctest_depends_on(exe=None, modules=None, disable_viewers=None):
     """Adds metadata about the dependencies which need to be met for doctesting
     the docstrings of the decorated objects."""
-    pyglet = False
-    if modules is not None and 'pyglet' in modules:
-        pyglet = True
 
     def depends_on_deco(fn):
-        fn._doctest_depends_on = dict(exe=exe, modules=modules,
-                                      disable_viewers=disable_viewers,
-                                      pyglet=pyglet)
+        dependencies = {}
+        if exe is not None:
+            dependencies['executables'] = exe
+        if modules is not None:
+            dependencies['modules'] = modules
+        if disable_viewers is not None:
+            dependencies['disable_viewers'] = disable_viewers
 
-        # once we drop py2.5 support and use class decorators this evaluates
-        # to True
+        fn._doctest_depends_on = dependencies
+
         if inspect.isclass(fn):
-            fn._doctest_depdends_on = no_attrs_in_subclass(fn, fn._doctest_depends_on)
+            fn._doctest_depdends_on = no_attrs_in_subclass(
+                fn, fn._doctest_depends_on)
         return fn
     return depends_on_deco
+
 
 def public(obj):
     """


### PR DESCRIPTION
Fixes #14732 
I have updated the doc string method in sympy.core.evalf so that it becomes clear why should we use expr.evalf(subs=...) over expr.evalf().subs(...) or expr.subs(...).evalf().
Also i have updated doc/src/tutorial/basic_operations.rst to show updated changes in main documentation.