### PR TITLE
Added Möbius transform to discrete module

### DIFF
--- a/sympy/discrete/__init__.py
+++ b/sympy/discrete/__init__.py
@@ -1,10 +1,12 @@
 """A module containing discrete functions.
 
-Transforms - fft, ifft, ntt, intt, fwht, ifwht, fzt, ifzt, fmt, ifmt
+Transforms - fft, ifft, ntt, intt, fwht, ifwht,
+    mobius_transform, inverse_mobius_transform
 Convolution - convolution, convolution_fft, convolution_ntt, convolution_fwht,
     convolution_subset, covering_product, intersecting_product
 Recurrence - linrec
 """
 
-from .transforms import (fft, ifft, ntt, intt, fwht, ifwht, fzt, ifzt, fmt, ifmt)
+from .transforms import (fft, ifft, ntt, intt, fwht, ifwht,
+    mobius_transform, inverse_mobius_transform)
 from .convolution import convolution

--- a/sympy/discrete/__init__.py
+++ b/sympy/discrete/__init__.py
@@ -6,5 +6,5 @@ Convolution - convolution, convolution_fft, convolution_ntt, convolution_fwht,
 Recurrence - linrec
 """
 
-from .transforms import (fft, ifft, ntt, intt, fwht, ifwht)
+from .transforms import (fft, ifft, ntt, intt, fwht, ifwht, fzt, ifzt, fmt, ifmt)
 from .convolution import convolution

--- a/sympy/discrete/tests/test_transforms.py
+++ b/sympy/discrete/tests/test_transforms.py
@@ -3,7 +3,8 @@ from __future__ import print_function, division
 from sympy import sqrt
 from sympy.core import S, Symbol, symbols, I
 from sympy.core.compatibility import range
-from sympy.discrete import fft, ifft, ntt, intt, fwht, ifwht
+from sympy.discrete import (fft, ifft, ntt, intt, fwht, ifwht,
+    mobius_transform, inverse_mobius_transform)
 from sympy.utilities.pytest import raises
 
 
@@ -107,3 +108,51 @@ def test_fwht_ifwht():
     ls = list(range(6))
 
     assert fwht(ls) == [x*8 for x in ifwht(ls)]
+
+
+def test_mobius_transform():
+    assert all(tf(ls, subset=subset) == ls
+                for ls in ([], [S(7)/4]) for subset in (True, False)
+                for tf in (mobius_transform, inverse_mobius_transform))
+
+    w, x, y, z = symbols('w x y z')
+
+    assert mobius_transform([x, y]) == [x, x + y]
+    assert inverse_mobius_transform([x, x + y]) == [x, y]
+    assert mobius_transform([x, y], subset=False) == [x + y, y]
+    assert inverse_mobius_transform([x + y, y], subset=False) == [x, y]
+
+    assert mobius_transform([w, x, y, z]) == [w, w + x, w + y, w + x + y + z]
+    assert inverse_mobius_transform([w, w + x, w + y, w + x + y + z]) == \
+            [w, x, y, z]
+    assert mobius_transform([w, x, y, z], subset=False) == \
+            [w + x + y + z, x + z, y + z, z]
+    assert inverse_mobius_transform([w + x + y + z, x + z, y + z, z], subset=False) == \
+            [w, x, y, z]
+
+    ls = [S(2)/3, S(6)/7, S(5)/8, 9, S(5)/3 + 7*I]
+    mls = [S(2)/3, S(32)/21, S(31)/24, S(1873)/168,
+            S(7)/3 + 7*I, S(67)/21 + 7*I, S(71)/24 + 7*I,
+            S(2153)/168 + 7*I]
+
+    assert mobius_transform(ls) == mls
+    assert inverse_mobius_transform(mls) == ls + [S.Zero]*3
+
+    mls = [S(2153)/168 + 7*I, S(69)/7, S(77)/8, 9, S(5)/3 + 7*I, 0, 0, 0]
+
+    assert mobius_transform(ls, subset=False) == mls
+    assert inverse_mobius_transform(mls, subset=False) == ls + [S.Zero]*3
+
+    ls = ls[:-1]
+    mls = [S(2)/3, S(32)/21, S(31)/24, S(1873)/168]
+
+    assert mobius_transform(ls) == mls
+    assert inverse_mobius_transform(mls) == ls
+
+    mls = [S(1873)/168, S(69)/7, S(77)/8, 9]
+
+    assert mobius_transform(ls, subset=False) == mls
+    assert inverse_mobius_transform(mls, subset=False) == ls
+
+    raises(TypeError, lambda: mobius_transform(x, subset=True))
+    raises(TypeError, lambda: inverse_mobius_transform(y, subset=False))

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -313,3 +313,66 @@ def ifwht(seq):
     return _walsh_hadamard_transform(seq, inverse=True)
 
 ifwht.__doc__ = fwht.__doc__
+
+
+#----------------------------------------------------------------------------#
+#                                                                            #
+#                         Zeta and Mobius Transforms                         #
+#                                                                            #
+#----------------------------------------------------------------------------#
+
+def _yate_dp(seq, sgn, subset, superset):
+    """Utility function for performing Yate's Dynamic Programming (DP) for
+    Zeta or Mobius Transform.
+
+    The sequence is automatically padded to the right with zeros, as the
+    definition of subset/superset based on bitmasks (indices) requires
+    the size of sequence to be a power of 2.
+    """
+
+    if not iterable(seq):
+        raise TypeError("Expected a sequence of coefficients")
+
+    a = [sympify(arg) for arg in seq]
+    subset, superset = map(bool, (subset, superset))
+
+    if (subset, superset).count(True) != 1:
+        raise ValueError("Exactly one of subset and superset must be True")
+
+    n = len(a)
+    if n < 2:
+        return a
+
+    if n&(n - 1):
+        n = 2**n.bit_length()
+
+    a += [S.Zero]*(n - len(a))
+
+    if superset:
+        i = 1
+        while i < n:
+            for j in range(n):
+                if j & i:
+                    continue
+                a[j] += sgn*a[j ^ i]
+            i *= 2
+    else:
+        i = 1
+        while i < n:
+            for j in range(n):
+                if j & i:
+                    a[j] += sgn*a[j ^ i]
+            i *= 2
+
+    return a
+
+
+def fzt(seq, subset=None, superset=None):
+    return _yate_dp(seq, sgn=1, subset=subset, superset=superset)
+
+
+def fmt(seq, subset=None, superset=None):
+    return _yate_dp(seq, sgn=-1, subset=subset, superset=superset)
+
+ifzt = fmt
+ifmt = fzt

--- a/sympy/discrete/transforms.py
+++ b/sympy/discrete/transforms.py
@@ -1,8 +1,9 @@
+# -*- coding: utf-8 -*-
 """
 Discrete Fourier Transform, Number Theoretic Transform,
-Walsh Hadamard Transform, Zeta Transform, Mobius Transform
+Walsh Hadamard Transform, Mobius Transform
 """
-from __future__ import print_function, division
+from __future__ import print_function, division, unicode_literals
 
 from sympy.core import S, Symbol, sympify
 from sympy.core.compatibility import as_int, range, iterable
@@ -284,6 +285,12 @@ def fwht(seq):
     The sequence is automatically padded to the right with zeros, as the
     radix 2 FWHT requires the number of sample points to be a power of 2.
 
+    Parameters
+    ==========
+
+    seq : iterable
+        The sequence on which WHT is to be applied.
+
     Examples
     ========
 
@@ -317,27 +324,18 @@ ifwht.__doc__ = fwht.__doc__
 
 #----------------------------------------------------------------------------#
 #                                                                            #
-#                         Zeta and Mobius Transforms                         #
+#                    Mobius Transform for Subset Lattice                     #
 #                                                                            #
 #----------------------------------------------------------------------------#
 
-def _yate_dp(seq, sgn, subset, superset):
-    """Utility function for performing Yate's Dynamic Programming (DP) for
-    Zeta or Mobius Transform.
-
-    The sequence is automatically padded to the right with zeros, as the
-    definition of subset/superset based on bitmasks (indices) requires
-    the size of sequence to be a power of 2.
-    """
+def _mobius_transform(seq, sgn, subset):
+    r"""Utility function for performing Möbius Transform using
+    Yate's Dynamic Programming (DP)"""
 
     if not iterable(seq):
         raise TypeError("Expected a sequence of coefficients")
 
     a = [sympify(arg) for arg in seq]
-    subset, superset = map(bool, (subset, superset))
-
-    if (subset, superset).count(True) != 1:
-        raise ValueError("Exactly one of subset and superset must be True")
 
     n = len(a)
     if n < 2:
@@ -348,15 +346,7 @@ def _yate_dp(seq, sgn, subset, superset):
 
     a += [S.Zero]*(n - len(a))
 
-    if superset:
-        i = 1
-        while i < n:
-            for j in range(n):
-                if j & i:
-                    continue
-                a[j] += sgn*a[j ^ i]
-            i *= 2
-    else:
+    if subset:
         i = 1
         while i < n:
             for j in range(n):
@@ -364,15 +354,73 @@ def _yate_dp(seq, sgn, subset, superset):
                     a[j] += sgn*a[j ^ i]
             i *= 2
 
+    else:
+        i = 1
+        while i < n:
+            for j in range(n):
+                if j & i:
+                    continue
+                a[j] += sgn*a[j ^ i]
+            i *= 2
+
     return a
 
 
-def fzt(seq, subset=None, superset=None):
-    return _yate_dp(seq, sgn=1, subset=subset, superset=superset)
+def mobius_transform(seq, subset=True):
+    r"""
+    Performs the Möbius Transform for subset lattice with indices of
+    sequence as bitmasks.
 
+    The sequence is automatically padded to the right with zeros, as the
+    definition of subset/superset based on bitmasks (indices) requires
+    the size of sequence to be a power of 2.
 
-def fmt(seq, subset=None, superset=None):
-    return _yate_dp(seq, sgn=-1, subset=subset, superset=superset)
+    Parameters
+    ==========
 
-ifzt = fmt
-ifmt = fzt
+    seq : iterable
+        The sequence on which Möbius Transform is to be applied.
+    subset : bool
+        Specifies if Möbius Transform is applied by enumerating subsets
+        or supersets of the given set.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols
+    >>> from sympy import mobius_transform, inverse_mobius_transform
+    >>> x, y, z = symbols('x y z')
+
+    >>> mobius_transform([x, y, z])
+    [x, x + y, x + z, x + y + z]
+    >>> inverse_mobius_transform(_)
+    [x, y, z, 0]
+
+    >>> mobius_transform([x, y, z], subset=False)
+    [x + y + z, y, z, 0]
+    >>> inverse_mobius_transform(_, subset=False)
+    [x, y, z, 0]
+
+    >>> mobius_transform([1, 2, 3, 4])
+    [1, 3, 4, 10]
+    >>> inverse_mobius_transform(_)
+    [1, 2, 3, 4]
+    >>> mobius_transform([1, 2, 3, 4], subset=False)
+    [10, 6, 7, 4]
+    >>> inverse_mobius_transform(_, subset=False)
+    [1, 2, 3, 4]
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Möbius_inversion_formula
+    .. [2] https://arxiv.org/pdf/1211.0189.pdf
+
+    """
+
+    return _mobius_transform(seq, sgn=+1, subset=subset)
+
+def inverse_mobius_transform(seq, subset=True):
+    return _mobius_transform(seq, sgn=-1, subset=subset)
+
+inverse_mobius_transform.__doc__ = mobius_transform.__doc__


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Möbius transform is implemented using Yate's Dynamic Programming (DP) method.
The method `mobius_transform` takes `subset` as the argument, which specifies if the enumeration is over subsets or supersets for the transform.
having the usage as:
```
In []: seq = list(symbols('w x y z'))

In []: mobius_transform(seq)
Out[]: [w, w + x, w + y, w + x + y + z]

In []: inverse_mobius_transform(_)
Out[]: [w, x, y, z]

In []: inverse_mobius_transform(seq, subset=False)
Out[]: [w - x - y + z, x - z, y - z, z]

In []: mobius_transform(_, subset=False)
Out[]: [w, x, y, z]
```
#### Other comments