### PR TITLE
Add methods for isomorphism computation

### DIFF
--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
-
-from sympy.combinatorics.fp_groups import FpGroup, FpSubgroup
+import itertools
+from sympy.combinatorics.fp_groups import FpGroup, FpSubgroup, simplify_presentation
 from sympy.combinatorics.free_groups import FreeGroup, FreeGroupElement
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy import S

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -468,9 +468,9 @@ def group_isomorphism(G, H, isomorphism=True):
 
     '''
     if not isinstance(G, (PermutationGroup, FpGroup)):
-        raise TypeError("The group must be a PermutationGroup or a finite FpGroup")
+        raise TypeError("The group must be a PermutationGroup or an FpGroup")
     if not isinstance(H, (PermutationGroup, FpGroup)):
-        raise TypeError("The group must be a PermutationGroup or a finite FpGroup")
+        raise TypeError("The group must be a PermutationGroup or an FpGroup")
 
     if isinstance(G, FpGroup) and isinstance(H, FpGroup):
         G = simplify_presentation(G)
@@ -482,9 +482,8 @@ def group_isomorphism(G, H, isomorphism=True):
                 return True
             return (True, homomorphism(G, H, G.generators, H.generators))
 
-    #  `_H` is the permutation groups isomorphic to `H`.
+    #  `_H` is the permutation group isomorphic to `H`.
     _H = H
-    h_isomorphism = None
     g_order = G.order()
     h_order = H.order()
 
@@ -496,39 +495,33 @@ def group_isomorphism(G, H, isomorphism=True):
             raise NotImplementedError("Isomorphism methods are not implemented for infinite groups.")
         _H, h_isomorphism = H._to_perm_group()
 
-    if (g_order != h_order) and (G.is_abelian != H.is_abelian):
+    if (g_order != h_order) or (G.is_abelian != H.is_abelian):
         if not isomorphism:
             return False
         return (False, None)
 
     if not isomorphism:
-        # Two groups of same cyclic numbered order
-        # are ismorphic to each other.
+        # Two groups of the same cyclic numbered order
+        # are isomorphic to each other.
         n = g_order
-        if (g_order == h_order) and (igcd(n, totient(n))) == 1:
+        if (igcd(n, totient(n))) == 1:
             return True
 
-    # Match the generators of `_G` with the subsets of `_H`
-    gens = G.generators
+    # Match the generators of `G` with subsets of `_H`
+    gens = list(G.generators)
     for subset in itertools.permutations(_H, len(gens)):
-        gens = list(gens)
         images = list(subset)
         images.extend([_H.identity]*(len(G.generators)-len(images)))
-        gens.extend([g for g in G.generators if g not in gens])
         _images = dict(zip(gens,images))
         if _check_homomorphism(G, _H, _images):
-            images = []
             if isinstance(H, FpGroup):
-                images = h_isomorphism.invert(list(subset))
-            else:
-                images = subset
+                images = h_isomorphism.invert(images)
             T =  homomorphism(G, H, G.generators, images, check=False)
             if T.is_isomorphism():
                 # It is a valid isomorphism
                 if not isomorphism:
                     return True
-                else:
-                    return (True, T)
+                return (True, T)
 
     if not isomorphism:
         return False

--- a/sympy/combinatorics/homomorphisms.py
+++ b/sympy/combinatorics/homomorphisms.py
@@ -507,7 +507,7 @@ def group_isomorphism(G, H, isomorphism=False):
 
     if not isomorphism:
         n = g_order
-        if igcd(n, totient(n)) == 1:
+        if (g_order == h_order) and (igcd(n, totient(n))) == 1:
             return True
 
     # Match the generators of `_G` with the subsets of `_H`

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -1,9 +1,9 @@
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.perm_groups import PermutationGroup
-from sympy.combinatorics.homomorphisms import homomorphism
+from sympy.combinatorics.homomorphisms import homomorphism, group_isomorphism
 from sympy.combinatorics.free_groups import free_group
 from sympy.combinatorics.fp_groups import FpGroup
-from sympy.combinatorics.named_groups import AlternatingGroup, DihedralGroup
+from sympy.combinatorics.named_groups import AlternatingGroup, DihedralGroup, CyclicGroup
 
 def test_homomorphism():
     # FpGroup -> PermutationGroup
@@ -55,3 +55,48 @@ def test_homomorphism():
     assert T.domain == F
     assert T.codomain == D
     assert T(a*b) == p
+
+def test_isomorphisms():
+
+    F, a, b = free_group("a, b")
+    E, c, d = free_group("c, d")
+    # Infinite groups with differently ordered relators.
+    G = FpGroup(F, [a**2, b**3])
+    H = FpGroup(F, [b**3, a**2])
+    assert group_isomorphism(G, H)
+
+    # Trivial Case
+    # FpGroup -> FpGroup
+    H = FpGroup(F, [a**3, b**3, (a*b)**2])
+    F, c, d = free_group("c, d")
+    G = FpGroup(F, [c**3, d**3, (c*d)**2])
+    check, T =  group_isomorphism(G, H, isomorphism=True)
+    assert check
+    T(c**3*d**2) == a**3*b**2
+
+    # FpGroup -> PermutationGroup
+    # FpGroup is converted to the equivalent isomorphic group.
+    F, a, b = free_group("a, b")
+    G = FpGroup(F, [a**3, b**3, (a*b)**2])
+    H = AlternatingGroup(4)
+    check, T = group_isomorphism(G, H, isomorphism=True)
+    assert check
+    assert T(b*a*b**-1*a**-1*b**-1) == Permutation(0, 2, 3)
+    assert T(b*a*b*a**-1*b**-1) == Permutation(0, 3, 2)
+
+    # PermutationGroup -> PermutationGroup
+    D = DihedralGroup(8)
+    p = Permutation(0, 1, 2, 3, 4, 5, 6, 7)
+    P = PermutationGroup(p)
+    assert not group_isomorphism(D, P)
+
+    # Cyclic Groups of different prime order are not isomorphic to each other.
+    A = CyclicGroup(5)
+    B = CyclicGroup(7)
+    assert not group_isomorphism(A, B)
+
+    # Two groups of same prime order are isomorphic to each other.
+    G = FpGroup(F, [a, b**5])
+    H = CyclicGroup(5)
+    assert G.order() == H.order()
+    assert group_isomorphism(G, H)

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -90,12 +90,11 @@ def test_isomorphisms():
     P = PermutationGroup(p)
     assert not is_isomorphic(D, P)
 
-    # Cyclic Groups of different prime order are not isomorphic to each other.
     A = CyclicGroup(5)
     B = CyclicGroup(7)
     assert not is_isomorphic(A, B)
 
-    # Two groups of same prime order are isomorphic to each other.
+    # Two groups of the same prime order are isomorphic to each other.
     G = FpGroup(F, [a, b**5])
     H = CyclicGroup(5)
     assert G.order() == H.order()

--- a/sympy/combinatorics/tests/test_homomorphisms.py
+++ b/sympy/combinatorics/tests/test_homomorphisms.py
@@ -1,6 +1,6 @@
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.perm_groups import PermutationGroup
-from sympy.combinatorics.homomorphisms import homomorphism, group_isomorphism
+from sympy.combinatorics.homomorphisms import homomorphism, group_isomorphism, is_isomorphic
 from sympy.combinatorics.free_groups import free_group
 from sympy.combinatorics.fp_groups import FpGroup
 from sympy.combinatorics.named_groups import AlternatingGroup, DihedralGroup, CyclicGroup
@@ -63,14 +63,14 @@ def test_isomorphisms():
     # Infinite groups with differently ordered relators.
     G = FpGroup(F, [a**2, b**3])
     H = FpGroup(F, [b**3, a**2])
-    assert group_isomorphism(G, H)
+    assert is_isomorphic(G, H)
 
     # Trivial Case
     # FpGroup -> FpGroup
     H = FpGroup(F, [a**3, b**3, (a*b)**2])
     F, c, d = free_group("c, d")
     G = FpGroup(F, [c**3, d**3, (c*d)**2])
-    check, T =  group_isomorphism(G, H, isomorphism=True)
+    check, T =  group_isomorphism(G, H)
     assert check
     T(c**3*d**2) == a**3*b**2
 
@@ -79,7 +79,7 @@ def test_isomorphisms():
     F, a, b = free_group("a, b")
     G = FpGroup(F, [a**3, b**3, (a*b)**2])
     H = AlternatingGroup(4)
-    check, T = group_isomorphism(G, H, isomorphism=True)
+    check, T = group_isomorphism(G, H)
     assert check
     assert T(b*a*b**-1*a**-1*b**-1) == Permutation(0, 2, 3)
     assert T(b*a*b*a**-1*b**-1) == Permutation(0, 3, 2)
@@ -88,15 +88,15 @@ def test_isomorphisms():
     D = DihedralGroup(8)
     p = Permutation(0, 1, 2, 3, 4, 5, 6, 7)
     P = PermutationGroup(p)
-    assert not group_isomorphism(D, P)
+    assert not is_isomorphic(D, P)
 
     # Cyclic Groups of different prime order are not isomorphic to each other.
     A = CyclicGroup(5)
     B = CyclicGroup(7)
-    assert not group_isomorphism(A, B)
+    assert not is_isomorphic(A, B)
 
     # Two groups of same prime order are isomorphic to each other.
     G = FpGroup(F, [a, b**5])
     H = CyclicGroup(5)
     assert G.order() == H.order()
-    assert group_isomorphism(G, H)
+    assert is_isomorphic(G, H)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### Brief description of what is fixed or changed
A `group_isomorphism`method has been added to compute the isomorphism between 2 groups. Corresponding tests have also been added. 


#### Other comments
The isomorphism methods are currently implemented for finite groups and only a few special cases of infinite groups. 

#### To-do 
* Imrove the documentation. 
* Add isomorphism computaion for a few special cases. 
 