### PR TITLE
Added script for locating syntax errors

### DIFF
--- a/bin/test_syntax.sh
+++ b/bin/test_syntax.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+REPOROOT=$(unset CDPATH && cd "$(dirname "$0")/.." && echo $PWD)
+for f in $(find $REPOROOT/sympy -name "*.py"); do
+    output=$(python3 -We:invalid -m compileall -f $f)
+    if [ $? -ne 0 ]; then
+       echo $output
+       break;
+    fi
+done

--- a/bin/test_syntax.sh
+++ b/bin/test_syntax.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 REPOROOT=$(unset CDPATH && cd "$(dirname "$0")/.." && echo $PWD)
 for f in $(find $REPOROOT/sympy -name "*.py"); do
-    output=$(python3 -We:invalid -m compileall -f $f)
+    output=$(python3 -We:invalid -m py_compile $f)
     if [ $? -ne 0 ]; then
-       echo $output
+       >&2 echo $output
        break;
     fi
 done

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -3886,7 +3886,7 @@ def test_sympy__physics__optics__medium__Medium():
     assert _test_args(Medium('m'))
 
 
-def test_sympy__codegen__ast__Assignment():
+def test_sympy__codegen__ast__Assignment):
     from sympy.codegen.ast import Assignment
     assert _test_args(Assignment(x, y))
 


### PR DESCRIPTION
I have found this script useful to find syntax errors accidentally committed.

Travis CI doesn't indicate what file contains the syntax error, making it hard for a contributor to find the error (e.g. [here](https://github.com/bjodah/sympy/pull/15#issuecomment-401947195) and [here](https://github.com/sympy/sympy/pull/13100#issuecomment-327757223)).

EDIT: Example output:
```
$ ./test_syntax.sh
  File "/home/bjorn/vc/sympy/sympy/core/tests/test_args.py", line 3889
    def test_sympy__codegen__ast__Assignment):
                                            ^
SyntaxError: invalid syntax
```