### PR TITLE
Change ast assignment base

### DIFF
--- a/doc/src/modules/codegen.rst
+++ b/doc/src/modules/codegen.rst
@@ -66,19 +66,13 @@ special cases of the other prints in SymPy (str printer, pretty printer, etc.).
 An important distinction is that the code printer has to deal with assignments
 (using the :class:`sympy.codegen.ast.Assignment` object). This serves as
 building blocks for the code printers and hence the ``codegen`` module.  An
-example that shows the use of ``Assignment``::
+example that shows the use of ``Assignment`` in C code::
 
     >>> from sympy.codegen.ast import Assignment
-    >>> mat = Matrix([x, y, z]).T
-    >>> known_mat = MatrixSymbol('K', 1, 3)
-    >>> Assignment(known_mat, mat)
-    K := [x  y  z]
-    >>> Assignment(known_mat, mat).lhs
-    K
-    >>> Assignment(known_mat, mat).rhs
-    [x  y  z]
+    >>> print(ccode(Assignment(x, y + 1)))
+    x = y + 1;
 
-Here is a simple example of printing a C version of a SymPy expression::
+Here is another simple example of printing a C version of a SymPy expression::
 
     >>> expr = (Rational(-1, 2) * Z * k * (e**2) / r)
     >>> expr

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -10,7 +10,8 @@ AST Type Tree
 ::
 
   *Basic*
-       |--->Assignment
+       |--->AssignmentBase
+       |             |--->Assignment
        |             |--->AugmentedAssignment
        |                                    |--->AddAugmentedAssignment
        |                                    |--->SubAugmentedAssignment
@@ -131,7 +132,7 @@ from sympy.core.basic import Basic
 from sympy.core.expr import Expr
 from sympy.core.compatibility import string_types
 from sympy.core.numbers import Float, Integer, oo
-from sympy.core.relational import Relational, Lt, Le, Ge, Gt
+from sympy.core.relational import Lt, Le, Ge, Gt
 from sympy.core.sympify import _sympify, sympify, SympifyError
 from sympy.logic import true, false
 from sympy.utilities.iterables import iterable
@@ -387,7 +388,64 @@ class NoneToken(Token):
 none = NoneToken()
 
 
-class Assignment(Relational):
+class AssignmentBase(Basic):
+    """ Abstract base class for Assignment and AugmentedAssignment.
+
+    Attributes:
+    ===========
+
+    op : str
+        Symbol for assignment operator, e.g. "=", "+=", etc.
+    """
+
+    def __new__(cls, lhs, rhs):
+        lhs = _sympify(lhs)
+        rhs = _sympify(rhs)
+
+        cls._check_args(lhs, rhs)
+
+        return super(AssignmentBase, cls).__new__(cls, lhs, rhs)
+
+    @property
+    def lhs(self):
+        return self.args[0]
+
+    @property
+    def rhs(self):
+        return self.args[1]
+
+    @classmethod
+    def _check_args(cls, lhs, rhs):
+        """ Check arguments to __new__ and raise exception if any problems found.
+
+        Derived classes may wish to override this.
+        """
+        from sympy.matrices.expressions.matexpr import (
+            MatrixElement, MatrixSymbol)
+        from sympy.tensor.indexed import Indexed
+
+        # Tuple of things that can be on the lhs of an assignment
+        assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed, Element, Variable)
+        if not isinstance(lhs, assignable):
+            raise TypeError("Cannot assign to lhs of type %s." % type(lhs))
+
+        # Indexed types implement shape, but don't define it until later. This
+        # causes issues in assignment validation. For now, matrices are defined
+        # as anything with a shape that is not an Indexed
+        lhs_is_mat = hasattr(lhs, 'shape') and not isinstance(lhs, Indexed)
+        rhs_is_mat = hasattr(rhs, 'shape') and not isinstance(rhs, Indexed)
+
+        # If lhs and rhs have same structure, then this assignment is ok
+        if lhs_is_mat:
+            if not rhs_is_mat:
+                raise ValueError("Cannot assign a scalar to a matrix.")
+            elif lhs.shape != rhs.shape:
+                raise ValueError("Dimensions of lhs and rhs don't align.")
+        elif rhs_is_mat and not lhs_is_mat:
+            raise ValueError("Cannot assign a matrix to a scalar.")
+
+
+class Assignment(AssignmentBase):
     """
     Represents variable assignment for code generation.
 
@@ -424,72 +482,54 @@ class Assignment(Relational):
     Assignment(A[0, 1], x)
     """
 
-    rel_op = ':='
-    __slots__ = []
-
-    def __new__(cls, lhs, rhs=0, **assumptions):
-        from sympy.matrices.expressions.matexpr import (
-            MatrixElement, MatrixSymbol)
-        from sympy.tensor.indexed import Indexed
-        lhs = _sympify(lhs)
-        rhs = _sympify(rhs)
-        # Tuple of things that can be on the lhs of an assignment
-        assignable = (Symbol, MatrixSymbol, MatrixElement, Indexed, Element, Variable)
-        if not isinstance(lhs, assignable):
-            raise TypeError("Cannot assign to lhs of type %s." % type(lhs))
-        # Indexed types implement shape, but don't define it until later. This
-        # causes issues in assignment validation. For now, matrices are defined
-        # as anything with a shape that is not an Indexed
-        lhs_is_mat = hasattr(lhs, 'shape') and not isinstance(lhs, Indexed)
-        rhs_is_mat = hasattr(rhs, 'shape') and not isinstance(rhs, Indexed)
-        # If lhs and rhs have same structure, then this assignment is ok
-        if lhs_is_mat:
-            if not rhs_is_mat:
-                raise ValueError("Cannot assign a scalar to a matrix.")
-            elif lhs.shape != rhs.shape:
-                raise ValueError("Dimensions of lhs and rhs don't align.")
-        elif rhs_is_mat and not lhs_is_mat:
-            raise ValueError("Cannot assign a matrix to a scalar.")
-        return Relational.__new__(cls, lhs, rhs, **assumptions)
-
-# XXX: This should be handled better
-Relational.ValidRelationOperator[':='] = Assignment
+    op = ':='
 
 
-class AugmentedAssignment(Assignment):
+class AugmentedAssignment(AssignmentBase):
     """
-    Base class for augmented assignments
+    Base class for augmented assignments.
+
+    Attributes:
+    ===========
+
+    binop : str
+       Symbol for binary operation being applied in the assignment, such as "+",
+       "*", etc.
     """
 
     @property
-    def rel_op(self):
-        return self._symbol + '='
+    def op(self):
+        return self.binop + '='
+
 
 class AddAugmentedAssignment(AugmentedAssignment):
-    _symbol = '+'
+    binop = '+'
 
 
 class SubAugmentedAssignment(AugmentedAssignment):
-    _symbol = '-'
+    binop = '-'
 
 
 class MulAugmentedAssignment(AugmentedAssignment):
-    _symbol = '*'
+    binop = '*'
 
 
 class DivAugmentedAssignment(AugmentedAssignment):
-    _symbol = '/'
+    binop = '/'
 
 
 class ModAugmentedAssignment(AugmentedAssignment):
-    _symbol = '%'
+    binop = '%'
 
 
-Relational.ValidRelationOperator['+='] = AddAugmentedAssignment
-Relational.ValidRelationOperator['-='] = SubAugmentedAssignment
-Relational.ValidRelationOperator['*='] = MulAugmentedAssignment
-Relational.ValidRelationOperator['/='] = DivAugmentedAssignment
-Relational.ValidRelationOperator['%='] = ModAugmentedAssignment
+# Mapping from binary op strings to AugmentedAssignment subclasses
+augassign_classes = {
+    cls.binop: cls for cls in [
+        AddAugmentedAssignment, SubAugmentedAssignment, MulAugmentedAssignment,
+        DivAugmentedAssignment, ModAugmentedAssignment
+    ]
+}
+
 
 def aug_assign(lhs, op, rhs):
     """
@@ -526,9 +566,9 @@ def aug_assign(lhs, op, rhs):
     >>> aug_assign(x, '+', y)
     AddAugmentedAssignment(x, y)
     """
-    if op + '=' not in Relational.ValidRelationOperator:
+    if op not in augassign_classes:
         raise ValueError("Unrecognized operator %s" % op)
-    return Relational.ValidRelationOperator[op + '='](lhs, rhs)
+    return augassign_classes[op](lhs, rhs)
 
 
 class CodeBlock(Basic):

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -2,7 +2,7 @@ import math
 from sympy import (
     Float, Idx, IndexedBase, Integer, Matrix, MatrixSymbol, Range, sin, symbols, Symbol, Tuple, Lt, nan, oo
 )
-from sympy.core.relational import Relational, StrictLessThan
+from sympy.core.relational import StrictLessThan
 from sympy.utilities.pytest import raises, XFAIL
 
 
@@ -43,6 +43,7 @@ def test_Assignment():
     Assignment(B[i], 0)
     a = Assignment(x, y)
     assert a.func(*a.args) == a
+    assert a.op == ':='
     # Here we test things to show that they error
     # Matrix to scalar
     raises(ValueError, lambda: Assignment(B[i], A))
@@ -60,7 +61,6 @@ def test_Assignment():
     raises(TypeError, lambda: Assignment(A + A, mat))
     raises(TypeError, lambda: Assignment(B, 0))
 
-    assert Relational(x, y, ':=') == Assignment(x, y)
 
 def test_AugAssign():
     # Here we just do things to show they don't error
@@ -72,25 +72,19 @@ def test_AugAssign():
     aug_assign(B[i], '+', x)
     aug_assign(B[i], '+', 0)
 
-    a = aug_assign(x, '+', y)
-    b = AddAugmentedAssignment(x, y)
-    assert a.func(*a.args) == a == b
-
-    a = aug_assign(x, '-', y)
-    b = SubAugmentedAssignment(x, y)
-    assert a.func(*a.args) == a == b
-
-    a = aug_assign(x, '*', y)
-    b = MulAugmentedAssignment(x, y)
-    assert a.func(*a.args) == a == b
-
-    a = aug_assign(x, '/', y)
-    b = DivAugmentedAssignment(x, y)
-    assert a.func(*a.args) == a == b
-
-    a = aug_assign(x, '%', y)
-    b = ModAugmentedAssignment(x, y)
-    assert a.func(*a.args) == a == b
+    # Check creation via aug_assign vs constructor
+    for binop, cls in [
+            ('+', AddAugmentedAssignment),
+            ('-', SubAugmentedAssignment),
+            ('*', MulAugmentedAssignment),
+            ('/', DivAugmentedAssignment),
+            ('%', ModAugmentedAssignment),
+        ]:
+        a = aug_assign(x, binop, y)
+        b = cls(x, y)
+        assert a.func(*a.args) == a == b
+        assert a.binop == binop
+        assert a.op == binop + '='
 
     # Here we test things to show that they error
     # Matrix to scalar
@@ -108,6 +102,7 @@ def test_AugAssign():
     raises(TypeError, lambda: aug_assign(x * x, '+', 1))
     raises(TypeError, lambda: aug_assign(A + A, '+', mat))
     raises(TypeError, lambda: aug_assign(B, '+', 0))
+
 
 def test_CodeBlock():
     c = CodeBlock(Assignment(x, 1), Assignment(y, x + 1))

--- a/sympy/codegen/tests/test_ast.py
+++ b/sympy/codegen/tests/test_ast.py
@@ -27,12 +27,6 @@ B22 = MatrixSymbol('B22',2,2)
 
 
 def test_Assignment():
-    x, y = symbols("x, y")
-    A = MatrixSymbol('A', 3, 1)
-    mat = Matrix([1, 2, 3])
-    B = IndexedBase('B')
-    n = symbols("n", integer=True)
-    i = Idx("i", n)
     # Here we just do things to show they don't error
     Assignment(x, y)
     Assignment(x, 0)
@@ -102,6 +96,28 @@ def test_AugAssign():
     raises(TypeError, lambda: aug_assign(x * x, '+', 1))
     raises(TypeError, lambda: aug_assign(A + A, '+', mat))
     raises(TypeError, lambda: aug_assign(B, '+', 0))
+
+
+def test_Assignment_printing():
+    assignment_classes = [
+        Assignment,
+        AddAugmentedAssignment,
+        SubAugmentedAssignment,
+        MulAugmentedAssignment,
+        DivAugmentedAssignment,
+        ModAugmentedAssignment,
+    ]
+    pairs = [
+        (x, 2 * y + 2),
+        (B[i], x),
+        (A22, B22),
+        (A[0, 0], x),
+    ]
+
+    for cls in assignment_classes:
+        for lhs, rhs in pairs:
+            a = cls(lhs, rhs)
+            assert repr(a) == '%s(%s, %s)' % (cls.__name__, repr(lhs), repr(rhs))
 
 
 def test_CodeBlock():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -137,6 +137,12 @@ def test_sympy__assumptions__sathandlers__CheckIsPrime():
     assert _test_args(CheckIsPrime(Q.positive))
     assert _test_args(CheckIsPrime(Q.positive(5)))
 
+
+@SKIP("abstract Class")
+def test_sympy__codegen__ast__AssignmentBase():
+    from sympy.codegen.ast import AssignmentBase
+    assert _test_args(AssignmentBase(x, 1))
+
 @SKIP("abstract Class")
 def test_sympy__codegen__ast__AugmentedAssignment():
     from sympy.codegen.ast import AugmentedAssignment

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -332,7 +332,7 @@ class CodePrinter(StrPrinter):
         rhs_code = self._print(expr.rhs)
         return self._get_statement("{0} {1} {2}".format(
             *map(lambda arg: self._print(arg),
-                 [lhs_code, expr.rel_op, rhs_code])))
+                 [lhs_code, expr.op, rhs_code])))
 
     def _print_FunctionCall(self, expr):
         return '%s(%s)' % (

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -361,7 +361,7 @@ class FCodePrinter(CodePrinter):
         rhs_code = self._print(expr.rhs)
         return self._get_statement("{0} = {0} {1} {2}".format(
             *map(lambda arg: self._print(arg),
-                 [lhs_code, expr._symbol, rhs_code])))
+                 [lhs_code, expr.binop, rhs_code])))
 
     def _print_sum_(self, sm):
         params = self._print(sm.array)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2315,6 +2315,15 @@ class PrettyPrinter(Printer):
         else:
             return self.emptyPrinter(e)
 
+    def _print_AssignmentBase(self, e):
+
+        op = prettyForm(' ' + xsym(e.op) + ' ')
+
+        l = self._print(e.lhs)
+        r = self._print(e.rhs)
+        pform = prettyForm(*stringPict.next(l, op, r))
+        return pform
+
 
 def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.

--- a/sympy/printing/rcode.py
+++ b/sympy/printing/rcode.py
@@ -259,7 +259,7 @@ class RCodePrinter(CodePrinter):
 
     def _print_AugmentedAssignment(self, expr):
         lhs_code = self._print(expr.lhs)
-        op = expr.rel_op
+        op = expr.op
         rhs_code = self._print(expr.rhs)
         return "{0} {1} {2};".format(lhs_code, op, rhs_code)
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -525,7 +525,6 @@ def test_Relational():
     assert str(Rel(x, y, "<")) == "x < y"
     assert str(Rel(x + y, y, "==")) == "Eq(x + y, y)"
     assert str(Rel(x, y, "!=")) == "Ne(x, y)"
-    assert str(Rel(x, y, ':=')) == "Assignment(x, y)"
     assert str(Eq(x, 1) | Eq(x, 2)) == "Eq(x, 1) | Eq(x, 2)"
     assert str(Ne(x, 1) & Ne(x, 2)) == "Ne(x, 1) & Ne(x, 2)"
 


### PR DESCRIPTION
Original PR to @bjodah's fork [here](https://github.com/bjodah/sympy/pull/15).

Removed `sympy.Relational` from class hierarchy as it doesn't really fit - they are structurally similar in that they have a left-hand side, a right-hand side, and a binary operation, but the semantics are very different. I doubt anyone has been directly making use of the fact that Assignment inherits from Relational, but this may break backward compatibility because the `rel_op` attribute has been changed to just `op`. Perhaps `rel_op` could be left in as an alias.

This removes the ~~fancy string printing~~ `repr()`, which makes it more consistent with other classes in the `ast` module. The pretty printing behavior has been retained. Doctests have been updated to match.

Also added common base class for both Assignment and AugmentedAssignment so it is easier to differentiate between them using isinstance().

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->