### PR TITLE
Remove ast.Statement

### DIFF
--- a/sympy/codegen/algorithms.py
+++ b/sympy/codegen/algorithms.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 from sympy import And, Gt, Lt, Abs, Dummy, oo, Tuple, Symbol, Function, Pow
 from sympy.codegen.ast import (
     Assignment, AddAugmentedAssignment, CodeBlock, Declaration, FunctionDefinition,
-    Print, Return, Scope, Statement, While, Variable, Pointer, real
+    Print, Return, Scope, While, Variable, Pointer, real
 )
 
 """ This module collects functions for constructing ASTs representing algorithms. """
@@ -62,10 +62,10 @@ def newtons_method(expr, wrt, atol=1e-12, delta=None, debug=False,
     delta_expr = -expr/expr.diff(wrt)
     whl_bdy = [Assignment(delta, delta_expr), AddAugmentedAssignment(wrt, delta)]
     if debug:
-        prnt = Statement(Print([wrt, delta], r"{0}=%12.5g {1}=%12.5g\n".format(wrt.name, name_d)))
+        prnt = Print([wrt, delta], r"{0}=%12.5g {1}=%12.5g\n".format(wrt.name, name_d))
         whl_bdy = [whl_bdy[0], prnt] + whl_bdy[1:]
     req = Gt(Abs(delta), atol)
-    declars = [Statement(Declaration(Variable(delta, type=real, value=oo)))]
+    declars = [Declaration(Variable(delta, type=real, value=oo))]
     if itermax is not None:
         counter = counter or Dummy(integer=True)
         v_counter = Variable.deduced(counter, 0)
@@ -142,5 +142,5 @@ def newtons_method_function(expr, wrt, params=None, func_name="newton", attrs=Tu
     if not_in_params:
         raise ValueError("Missing symbols in params: %s" % ', '.join(map(str, not_in_params)))
     declars = tuple(Variable(p, real) for p in params)
-    body = CodeBlock(algo, Statement(Return(wrt)))
+    body = CodeBlock(algo, Return(wrt))
     return FunctionDefinition(real, func_name, declars, body, attrs=attrs)

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1586,11 +1586,6 @@ class Scope(Token):
             return CodeBlock(*itr)
 
 
-class Statement(Basic):
-    """ Represents a statement """
-    nargs = 1
-
-
 class Stream(Token):
     """ Represents a stream.
 
@@ -1719,8 +1714,8 @@ class FunctionDefinition(FunctionPrototype):
     >>> fp = FunctionPrototype(real, 'foo', [x, y])
     >>> ccode(fp)
     'double foo(double x, double y)'
-    >>> from sympy.codegen.ast import FunctionDefinition, Return, Statement
-    >>> body = [Statement(Return(x*y))]
+    >>> from sympy.codegen.ast import FunctionDefinition, Return
+    >>> body = [Return(x*y)]
     >>> fd = FunctionDefinition.from_FunctionPrototype(fp, body)
     >>> print(ccode(fd))
     double foo(double x, double y){

--- a/sympy/codegen/cnodes.py
+++ b/sympy/codegen/cnodes.py
@@ -6,7 +6,7 @@ from sympy.core.basic import Basic
 from sympy.core.compatibility import string_types
 from sympy.core.containers import Tuple
 from sympy.core.sympify import sympify
-from sympy.codegen.ast import Attribute, Declaration, Node, Statement, String, Token, Type, none, FunctionCall
+from sympy.codegen.ast import Attribute, Declaration, Node, String, Token, Type, none, FunctionCall
 
 void = Type('void')
 

--- a/sympy/codegen/fnodes.py
+++ b/sympy/codegen/fnodes.py
@@ -13,7 +13,7 @@ from sympy.core.function import Function
 from sympy.core.numbers import Float, Integer
 from sympy.core.sympify import sympify
 from sympy.codegen.ast import (
-    Attribute, CodeBlock, Declaration, FunctionCall, Node, none, Statement, String,
+    Attribute, CodeBlock, Declaration, FunctionCall, Node, none, String,
     Token, Type, _mk_Tuple, Variable
 )
 from sympy.logic import true, false

--- a/sympy/codegen/tests/test_applications.py
+++ b/sympy/codegen/tests/test_applications.py
@@ -8,7 +8,7 @@ from sympy.utilities.pytest import skip
 from sympy.sets import Range
 from sympy.codegen.ast import (
     FunctionDefinition, FunctionPrototype, Variable, Pointer, real, Assignment,
-    integer, Variable, CodeBlock, While, Statement
+    integer, Variable, CodeBlock, While
 )
 from sympy.codegen.cnodes import void, PreIncrement
 from sympy.codegen.cutils import render_as_source_file
@@ -19,8 +19,8 @@ np = import_module('numpy')
 def _mk_func1():
     declars = n, inp, out = Variable('n', integer), Pointer('inp', real), Pointer('out', real)
     i = Variable('i', integer)
-    whl = While(i<n, [Assignment(out[i], inp[i]), Statement(PreIncrement(i))])
-    body = CodeBlock(Statement(i.as_Declaration(value=0)), whl)
+    whl = While(i<n, [Assignment(out[i], inp[i]), PreIncrement(i)])
+    body = CodeBlock(i.as_Declaration(value=0), whl)
     return FunctionDefinition(void, 'our_test_function', declars, body)
 
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -286,11 +286,6 @@ def test_sympy__codegen__ast__Scope():
     assert _test_args(Scope([AddAugmentedAssignment(x, -1)]))
 
 
-def test_sympy__codegen__ast__Statement():
-    from sympy.codegen.ast import Statement, AddAugmentedAssignment
-    assert _test_args(Statement(AddAugmentedAssignment(x, -1)))
-
-
 def test_sympy__codegen__ast__Stream():
     from sympy.codegen.ast import Stream
     assert _test_args(Stream('stdin'))

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -259,7 +259,8 @@ class C89CodePrinter(CodePrinter):
         return p*5
 
     def _get_statement(self, codestring):
-        return "%s;" % codestring
+        """ Get code string as a statement - i.e. ending with a semicolon. """
+        return codestring if codestring.endswith(';') else codestring + ';'
 
     def _get_comment(self, text):
         return "// {0}".format(text)
@@ -541,6 +542,10 @@ class C89CodePrinter(CodePrinter):
             symb=self._print(elem.symbol),
             idxs=idxs
         )
+
+    def _print_CodeBlock(self, expr):
+        """ Elements of code blocks printed as statements. """
+        return '\n'.join([self._get_statement(self._print(i)) for i in expr.args])
 
     def _print_While(self, expr):
         return 'while ({condition}) {{\n{body}\n}}'.format(**expr.kwargs(

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -15,7 +15,7 @@ from sympy.utilities.pytest import raises, XFAIL
 from sympy.printing.ccode import CCodePrinter, C89CodePrinter, C99CodePrinter, get_math_macros
 from sympy.codegen.ast import (
     AddAugmentedAssignment, Element, Type, FloatType, Declaration, Pointer, Variable, value_const, pointer_const,
-    While, Scope, Print, FunctionPrototype, FunctionDefinition, FunctionCall, Statement, Return,
+    While, Scope, Print, FunctionPrototype, FunctionDefinition, FunctionCall, Return,
     real, float32, float64, float80, float128, intc, Comment
 )
 from sympy.codegen.cfunctions import expm1, log1p, exp2, log2, fma, log10, Cbrt, hypot, Sqrt
@@ -827,7 +827,7 @@ def test_ccode_codegen_ast():
     )
 
     # explicit wrapping node for statement:
-    assert ccode(Statement(x)) == 'x;'
-    assert ccode(Statement(Print([x, y], "%d %d"))) == 'printf("%d %d", x, y);'
-    assert ccode(Statement(FunctionCall('pwer', [x]))) == 'pwer(x);'
-    assert ccode(Statement(Return(x))) == 'return x;'
+    assert ccode(x) == 'x;'
+    assert ccode(Print([x, y], "%d %d")) == 'printf("%d %d", x, y);'
+    assert ccode(FunctionCall('pwer', [x])) == 'pwer(x);'
+    assert ccode(Return(x)) == 'return x;'

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -16,7 +16,7 @@ from sympy.printing.ccode import CCodePrinter, C89CodePrinter, C99CodePrinter, g
 from sympy.codegen.ast import (
     AddAugmentedAssignment, Element, Type, FloatType, Declaration, Pointer, Variable, value_const, pointer_const,
     While, Scope, Print, FunctionPrototype, FunctionDefinition, FunctionCall, Return,
-    real, float32, float64, float80, float128, intc, Comment
+    real, float32, float64, float80, float128, intc, Comment, CodeBlock
 )
 from sympy.codegen.cfunctions import expm1, log1p, exp2, log2, fma, log10, Cbrt, hypot, Sqrt
 from sympy.codegen.cnodes import restrict
@@ -826,8 +826,16 @@ def test_ccode_codegen_ast():
         '}'
     )
 
-    # explicit wrapping node for statement:
-    assert ccode(x) == 'x;'
-    assert ccode(Print([x, y], "%d %d")) == 'printf("%d %d", x, y);'
-    assert ccode(FunctionCall('pwer', [x])) == 'pwer(x);'
-    assert ccode(Return(x)) == 'return x;'
+    # Elements of CodeBlock are formatted as statements:
+    block = CodeBlock(
+        x,
+        Print([x, y], "%d %d"),
+        FunctionCall('pwer', [x]),
+        Return(x),
+    )
+    assert ccode(block) == '\n'.join([
+        'x;',
+        'printf("%d %d", x, y);',
+        'pwer(x);',
+        'return x;',
+    ])


### PR DESCRIPTION
The `ast.Statement` class no longer seems to be needed or does nothing in most of the test cases. I think I've fixed the remaining cases by having the C code printer print elements of `CodeBlock`s as statements automatically (i.e. adding semicolons). I've also changed the C printer's `_get_statement()` method to be idempotent, so it won't add an another semicolon to a code string that already has one.