### PR TITLE
More conditions on rising factorial _eval_rewrite_as_factorial

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -496,7 +496,7 @@ class RisingFactorial(CombinatorialFunction):
 
     >>> from sympy import rf, symbols, factorial, ff, binomial, Poly
     >>> from sympy.abc import x
-    >>> n, k = symbols('n k', integer=True)
+    >>> n, k = symbols('n k', integer=True, positive=True)
     >>> rf(x, 0)
     1
     >>> rf(1, 5)
@@ -588,7 +588,13 @@ class RisingFactorial(CombinatorialFunction):
 
     def _eval_rewrite_as_factorial(self, x, k):
         if x.is_integer and k.is_integer:
-            return factorial(k + x - 1) / factorial(x - 1)
+
+            if k.is_positive:
+                return factorial(k + x - 1) / factorial(x - 1)
+
+            if x == 0:
+                if k.is_negative or k == 0:
+                    return (-1)**(-k) / factorial(-k)
 
     def _eval_rewrite_as_binomial(self, x, k):
         if k.is_integer:

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,7 +1,7 @@
 from sympy import (S, Symbol, symbols, factorial, factorial2, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func, Product, Mul, Piecewise, Mod,
-                   Eq, sqrt, Poly, Sum)
+                   Eq, sqrt, Poly)
 from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.functions.special.gamma_functions import uppergamma
 from sympy.utilities.pytest import XFAIL, raises
@@ -59,6 +59,7 @@ def test_rf_eval_apply():
 
     assert rf(x, k).rewrite(ff) == ff(x + k - 1, k)
     assert rf(x, k).rewrite(binomial) == factorial(k)*binomial(x + k - 1, k)
+    assert rf(x, k).rewrite(factorial) == rf(x, k)
 
     assert rf(n, z).rewrite(factorial) == \
         factorial(n + z - 1) / factorial(n - 1)

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,7 +1,7 @@
 from sympy import (S, Symbol, symbols, factorial, factorial2, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func, Product, Mul, Piecewise, Mod,
-                   Eq, sqrt, Poly)
+                   Eq, sqrt, Poly, Sum)
 from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.functions.special.gamma_functions import uppergamma
 from sympy.utilities.pytest import XFAIL, raises
@@ -12,6 +12,7 @@ def test_rf_eval_apply():
     x, y = symbols('x,y')
     n, k = symbols('n k', integer=True)
     m = Symbol('m', integer=True, nonnegative=True)
+    z = Symbol('z', integer=True, positive=True)
 
     assert rf(nan, y) == nan
     assert rf(x, nan) == nan
@@ -58,8 +59,15 @@ def test_rf_eval_apply():
 
     assert rf(x, k).rewrite(ff) == ff(x + k - 1, k)
     assert rf(x, k).rewrite(binomial) == factorial(k)*binomial(x + k - 1, k)
-    assert rf(n, k).rewrite(factorial) == \
-        factorial(n + k - 1) / factorial(n - 1)
+
+    assert rf(n, z).rewrite(factorial) == \
+        factorial(n + z - 1) / factorial(n - 1)
+
+    assert rf(0, -z).rewrite(factorial) == \
+           (-1)**z / factorial(z)
+
+    assert rf(0, m).rewrite(factorial) != 0
+    assert rf(0, z).rewrite(factorial) == 0
 
 
 def test_ff_eval_apply():


### PR DESCRIPTION
Fixes #14871. `factorial(k + x - 1) / factorial(x - 1)` is valid if `x` and `k` are integers and `k` is positive. If `x == 0` and `k` is non-positive, we can rewrite as `(-1)**(-k) / factorial(-k)`.