### PR TITLE
 added documentation for jordan_cell method in matrices.py 

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1391,31 +1391,6 @@ class EvalfMixin(object):
             verbose=<bool>
                 Print debug information (default=False)
 
-        Notes
-        ========
-
-        It is suggested to use expr.evalf(subs=...) over expr.subs(...).evalf()
-        or expr.evalf().subs(...) since expr.evalf(subs=...) avoids the loss of
-        significance caused due to naive substitution as the expression is run
-        through the evalf algorithm which takes into account, the various issues
-        that can cause loss of significance or precision. Naive substitution can
-        also include substitution of only a few rather than all symbols in the
-        expression.
-
-        Examples
-        ========
-
-        >>> import sympy
-        >>> from sympy.abc import x, y, z
-        >>> (x + y - z).subs({x: 1e100, y: 1, z: 1e100}) #case_1
-        0
-        >>> (x + y - z).evalf(subs={x: 1e100, y: 1, z: 1e100}) #case_2
-        1.00000000000000
-
-        In case_1, naive substitution evaluates 1e100 + 1 - 1e100 which loses 1 because of
-        the default precision setting. However, in case_2, the evalf algorithm takes care
-        of the significance.
-
         """
         from sympy import Float, Number
         n = n if n is not None else 15

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1391,25 +1391,28 @@ class EvalfMixin(object):
             verbose=<bool>
                 Print debug information (default=False)
 
-        Note :
+        Notes
+        ========
+
         It is suggested to use expr.evalf(subs=...) over expr.subs(...).evalf()
         or expr.evalf().subs(...) since expr.evalf(subs=...) avoids the loss of
         significance caused due to naive substitution as the expression is run
         through the evalf algorithm which takes into account, the various issues
-        that can cause loss of significance. Naive substitution can also include
-        substitution of only a few rather than all symbols in the expression.
+        that can cause loss of significance or precision. Naive substitution can
+        also include substitution of only a few rather than all symbols in the
+        expression.
 
         Examples
         ========
 
         >>> import sympy
-        >>> x, y, z = sympy.symbols("x, y, z")
-        >>> (x+y-z).subs({x:1e100,y:1,z:1e100}) #case_1
+        >>> from sympy.abc import x, y, z
+        >>> (x + y - z).subs({x: 1e100, y: 1, z: 1e100}) #case_1
         0
-        >>> (x+y-z).evalf(subs={x: 1e100, y: 1, z: 1e100}) #case_2
+        >>> (x + y - z).evalf(subs={x: 1e100, y: 1, z: 1e100}) #case_2
         1.00000000000000
 
-        in case_1, naive substitution evaluates 1e100 + 1 - 1e100 which looses 1 because of
+        In case_1, naive substitution evaluates 1e100 + 1 - 1e100 which loses 1 because of
         the default precision setting. However, in case_2, the evalf algorithm takes care
         of the significance.
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1391,6 +1391,28 @@ class EvalfMixin(object):
             verbose=<bool>
                 Print debug information (default=False)
 
+        Note :
+        It is suggested to use expr.evalf(subs=...) over expr.subs(...).evalf()
+        or expr.evalf().subs(...) since expr.evalf(subs=...) avoids the loss of
+        significance caused due to naive substitution as the expression is run
+        through the evalf algorithm which takes into account, the various issues
+        that can cause loss of significance. Naive substitution can also include
+        substitution of only a few rather than all symbols in the expression.
+
+        Examples
+        ========
+
+        >>> import sympy
+        >>> x, y, z = sympy.symbols("x, y, z")
+        >>> (x+y-z).subs({x:1e100,y:1,z:1e100}) #case_1
+        0
+        >>> (x+y-z).evalf(subs={x: 1e100, y: 1, z: 1e100}) #case_2
+        1.00000000000000
+
+        in case_1, naive substitution evaluates 1e100 + 1 - 1e100 which looses 1 because of
+        the default precision setting. However, in case_2, the evalf algorithm takes care
+        of the significance.
+
         """
         from sympy import Float, Number
         n = n if n is not None else 15

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -828,7 +828,6 @@ class MatrixSpecial(MatrixRequired):
         =========
 
         https://en.wikipedia.org/wiki/Jordan_matrix
-        
         """
 
         klass = kwargs.get('cls', kls)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -784,6 +784,9 @@ class MatrixSpecial(MatrixRequired):
         """Returns a Jordan block with the specified size
         and eigenvalue.  You may call `jordan_block` with
         two args (size, eigenvalue) or with keyword arguments.
+        A jordan block is a matrix composed of 0 elements everywhere
+        except for the diagonal, which is filled with eigenvalue,
+        and for the super-diagonal, which is filled with ones.
 
         kwargs
         ======
@@ -820,6 +823,12 @@ class MatrixSpecial(MatrixRequired):
         [0, x, 1, 0],
         [0, 0, x, 1],
         [0, 0, 0, x]])
+
+        Reference
+        =========
+
+        https://en.wikipedia.org/wiki/Jordan_matrix
+        
         """
 
         klass = kwargs.get('cls', kls)

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1290,7 +1290,10 @@ def hessian(f, varlist, constraints=[]):
 
 def jordan_cell(eigenval, n):
     """
-    Create a Jordan block:
+    Generates the jordan block when eigenvalue and dimension is specified.
+    A jordan block is a matrix composed of 0 elements everywhere except for
+    the diagonal, which is filled with eigenvalue, and for the super-diagonal,
+    which is filled with ones.
 
     Examples
     ========
@@ -1303,6 +1306,19 @@ def jordan_cell(eigenval, n):
     [0, x, 1, 0],
     [0, 0, x, 1],
     [0, 0, 0, x]])
+
+    >>> jordan_cell(2, 5)
+    Matrix([
+    [2, 1, 0, 0, 0],
+    [0, 2, 1, 0, 0],
+    [0, 0, 2, 1, 0],
+    [0, 0, 0, 2, 1],
+    [0, 0, 0, 0, 2]])
+
+    Reference
+    =========
+
+    https://en.wikipedia.org/wiki/Jordan_matrix
     """
     from .dense import Matrix
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1864,6 +1864,42 @@ class MatrixDeprecated(MatrixCommon):
         return self.det(method='lu')
 
     def jordan_cell(self, eigenval, n):
+        """
+        Generates the jordan block when eigenvalue and dimension is specified.
+        A jordan block is a matrix composed of 0 elements everywhere except for
+        the diagonal, which is filled with eigenvalue, and for the super-diagonal,
+        which is filled with ones.
+
+        Examples
+        ========
+
+        >>> from sympy.matrices import jordan_cell
+        >>> from sympy.abc import x
+
+        >>> jordan_cell(2, 5)
+        Matrix([
+        [2, 1, 0, 0, 0],
+        [0, 2, 1, 0, 0],
+        [0, 0, 2, 1, 0],
+        [0, 0, 0, 2, 1],
+        [0, 0, 0, 0, 2]])
+
+        >>> jordan_cell(x, 7)
+        Matrix([
+        [x, 1, 0, 0, 0, 0, 0],
+        [0, x, 1, 0, 0, 0, 0],
+        [0, 0, x, 1, 0, 0, 0],
+        [0, 0, 0, x, 1, 0, 0],
+        [0, 0, 0, 0, x, 1, 0],
+        [0, 0, 0, 0, 0, x, 1],
+        [0, 0, 0, 0, 0, 0, x]])
+
+        Reference
+        =========
+
+        https://en.wikipedia.org/wiki/Jordan_matrix
+
+        """
         return self.jordan_block(size=n, eigenvalue=eigenval)
 
     def jordan_cells(self, calc_transformation=True):


### PR DESCRIPTION
Added documentation for `jordan_cell` method in sympy/matrices/matrices.py 

Explained what is a `jordan block` as the method `jordan_cell` uses `jordan_block` to make a `jordan_cell`. Also added Wikipedia link to jordan matrix.

Contributers, members, others please review this PR and let me know the improvements.
Any feedback is highly appreciated.
Thanks.
