### PR TITLE
added documentation for Assignment class in sympy/codegen/ast.py

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -121,7 +121,6 @@ class Assignment(Relational):
     As shown in case_1, the C loop runs from [0, n], i.e. the upper limit is
     included, unlike what we would expect from ranges. We can also use Idx in
     summation, thereby utilizing the fact of the inclusion of upper limit.
-    
     >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0)) #case_2
     '      do i = 1, n + 1\n         A(i) = 0\n      end do'
 

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -113,7 +113,7 @@ class Assignment(Relational):
     'for (int i=0; i<n + 1; i++){\n   A[i] = 0;\n}'
 
     >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0))  #case_2
-    '      do i = 1, n + 1\n         A(i) = 0\n      end do'
+    'do i = 1, n + 1\n  A(i) = 0\n  end do'
 
     As shown in case_1, the C loop runs from [0, n], i.e. the upper limit is
     included, unlike what we would expect from ranges. We can also use Idx in

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -115,10 +115,10 @@ class Assignment(Relational):
 
     >>> n = symbols('n', integer=True)
 
-    >>> ccode(Assignment(Indexed("A", Idx('i', (0, n))), 0))
+    >>> ccode(Assignment(Indexed("A", Idx('i', (0, n))), 0)) #case_1
     'for (int i=0; i<n + 1; i++){\n   A[i] = 0;\n}'
 
-    >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0))
+    >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0)) #case_2
     '      do i = 1, n + 1\n         A(i) = 0\n      end do'
 
     As shown in case_1, the C loop runs from [0, n], i.e. the upper limit is

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -118,12 +118,12 @@ class Assignment(Relational):
     >>> ccode(Assignment(Indexed("A", Idx('i', (0, n))), 0)) #case_1
     'for (int i=0; i<n + 1; i++){\n   A[i] = 0;\n}'
 
-    >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0)) #case_2
-    '      do i = 1, n + 1\n         A(i) = 0\n      end do'
-
     As shown in case_1, the C loop runs from [0, n], i.e. the upper limit is
     included, unlike what we would expect from ranges. We can also use Idx in
     summation, thereby utilizing the fact of the inclusion of upper limit.
+    
+    >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0)) #case_2
+    '      do i = 1, n + 1\n         A(i) = 0\n      end do'
 
     Also, as shown in case_2, the Fortran loop runs from [1, n+1] because in
     1-indexing languages like Fortran and Julia, the loop indices are increased

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -107,13 +107,19 @@ class Assignment(Relational):
     >>> Assignment(A[0, 1], x)
     Assignment(A[0, 1], x)
 
+    >>> from sympy import ccode
+    >>> from sympy import fcode
+    >>> from sympy.tensor import Indexed
+    >>> from sympy.tensor import Idx
+
+
     >>> n = symbols('n', integer=True)
 
-    >>> ccode(Assignment(Indexed("A", Idx('i', (0, n))), 0))  #case_1
+    >>> ccode(Assignment(Indexed("A", Idx('i', (0, n))), 0))
     'for (int i=0; i<n + 1; i++){\n   A[i] = 0;\n}'
 
-    >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0))  #case_2
-    'do i = 1, n + 1\n  A(i) = 0\n  end do'
+    >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0))
+    '      do i = 1, n + 1\n         A(i) = 0\n      end do'
 
     As shown in case_1, the C loop runs from [0, n], i.e. the upper limit is
     included, unlike what we would expect from ranges. We can also use Idx in

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -73,7 +73,7 @@ from sympy.sets import FiniteSet
 from sympy.utilities.iterables import iterable
 
 class Assignment(Relational):
-    """
+    r"""
     Represents variable assignment for code generation.
 
     Parameters

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -106,6 +106,22 @@ class Assignment(Relational):
     Assignment(A, Matrix([[x, y, z]]))
     >>> Assignment(A[0, 1], x)
     Assignment(A[0, 1], x)
+
+    >>> n = symbols('n', integer=True)
+
+    >>> ccode(Assignment(Indexed("A", Idx('i', (0, n))), 0))  #case_1
+    'for (int i=0; i<n + 1; i++){\n   A[i] = 0;\n}'
+
+    >>> fcode(Assignment(Indexed("A", Idx('i', (0, n))), 0))  #case_2
+    '      do i = 1, n + 1\n         A(i) = 0\n      end do'
+
+    As shown in case_1, the C loop runs from [0, n], i.e. the upper limit is
+    included, unlike what we would expect from ranges. We can also use Idx in
+    summation, thereby utilizing the fact of the inclusion of upper limit.
+
+    Also, as shown in case_2, the Fortran loop runs from [1, n+1] because in
+    1-indexing languages like Fortran and Julia, the loop indices are increased
+    by 1.
     """
 
     rel_op = ':='


### PR DESCRIPTION
Documentation for `Assignment` class regarding indexed docs has been added using examples, highlighting the inclusion of end points while indexing for languages like `C` and `Fortran`.

#12781
Fix for issue #12781

Contributers, members, others please review this PR and let me know the improvements.
Any feedback is highly appreciated.
Thanks.