### PR TITLE
continuum_mechanics: added `Beam_3d` class

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1228,30 +1228,41 @@ class Beam_3d(Beam):
         A = self.area
         load = self._load_vector
         moment = self._moment_load_vector
+        defl = Function('defl')
+        theta = Function('theta')
+
+        # Finding deflection along x-axis(and corresponding slope value by differentiating it)
+        # Equation used: Derivative(E*A*Derivative(def_x(x), x), x) + load_x = 0
+        eq = Derivative(E*A*Derivative(defl(x), x), x) + load[0]
+        def_x = dsolve(Eq(eq, 0), defl(x)).args[1]
+        # Solving constants originated from dsolve
+        C1 = Symbol('C1')
+        C2 = Symbol('C2')
+        constants = list((linsolve([def_x.subs(x, 0), def_x.subs(x, l)], C1, C2).args)[0])
+        def_x = def_x.subs({C1:constants[0], C2:constants[1]})
+        slope_x = def_x.diff(x)
+        self._deflection[0] = def_x
+        self._slope[0] = slope_x
 
         # Finding deflection along y-axis and slope across z-axis. System of equation involved:
         # 1: Derivative(E*I*Derivative(theta_z(x), x), x) + G*A*(Derivative(defl_y(x), x) - theta_z(x)) + moment_z = 0
         # 2: Derivative(G*A*(Derivative(defl_y(x), x) - theta_z(x)), x) + load_y = 0
-        defl = Function('defl')
-        theta = Function('theta')
         C_i = Symbol('C_i')
         # substitute value of `G*A*(Derivative(defl_y(x), x) - theta_z(x))` from (2) in (1)
         eq1 = Derivative(E*I*Derivative(theta(x), x), x) + (integrate(-load[1], x) + C_i) + moment[2]
-        slope = dsolve(Eq(eq1, 0)).args[1]
+        slope_z = dsolve(Eq(eq1, 0)).args[1]
 
         #solve for constants originated from using dsolve on eq1
-        C1 = Symbol('C1')
-        C2 = Symbol('C2')
-        constants = list((linsolve([slope.subs(x, 0), slope.subs(x, l)], C1, C2).args)[0])
-        slope = slope.subs({C1:constants[0], C2:constants[1]})
+        constants = list((linsolve([slope_z.subs(x, 0), slope_z.subs(x, l)], C1, C2).args)[0])
+        slope_z = slope_z.subs({C1:constants[0], C2:constants[1]})
 
         # Put value of slope obtained back in (2) to solve for `C_i` and find deflection across y-axis
-        eq2 = G*A*(Derivative(defl(x), x)) + load[1]*x - C_i - G*A*slope
-        eq2 = dsolve(Eq(eq2,0)).args[1]
+        eq2 = G*A*(Derivative(defl(x), x)) + load[1]*x - C_i - G*A*slope_z
+        def_y = dsolve(Eq(eq2, 0), defl(x)).args[1]
         #solve for constants originated from using dsolve on eq2
-        constants = list((linsolve([eq2.subs(x, 0), eq2.subs(x, l)], C1, C_i).args)[0])
-        self._deflection[1] = eq2.subs({C1:constants[0], C_i:constants[1]})
-        self._slope[2] = slope.subs(C_i, constants[1])
+        constants = list((linsolve([def_y.subs(x, 0), def_y.subs(x, l)], C1, C_i).args)[0])
+        self._deflection[1] = def_y.subs({C1:constants[0], C_i:constants[1]})
+        self._slope[2] = slope_z.subs(C_i, constants[1])
 
         # Finding deflection along z-axis and slope across y-axis. System of equation involved:
         # 1: Derivative(E*I*Derivative(theta_y(x), x), x) - G*A*(Derivative(defl_z(x), x) + theta_y(x)) + moment_y = 0
@@ -1259,15 +1270,15 @@ class Beam_3d(Beam):
 
         # substitute value of `G*A*(Derivative(defl_y(x), x) + theta_z(x))` from (2) in (1)
         eq1 = Derivative(E*I*Derivative(theta(x), x), x) + (integrate(load[2], x) - C_i) + moment[1]
-        slope = dsolve(Eq(eq1, 0)).args[1]
+        slope_y = dsolve(Eq(eq1, 0)).args[1]
         #solve for constants originated from using dsolve on eq1
-        constants = list((linsolve([slope.subs(x, 0), slope.subs(x, l)], C1, C2).args)[0])
-        slope = slope.subs({C1:constants[0], C2:constants[1]})
+        constants = list((linsolve([slope_y.subs(x, 0), slope_y.subs(x, l)], C1, C2).args)[0])
+        slope_y = slope_y.subs({C1:constants[0], C2:constants[1]})
 
         # Put value of slope obtained back in (2) to solve for `C_i` and find deflection across z-axis
-        eq2 = G*A*(Derivative(defl(x), x)) + load[2]*x - C_i + G*A*slope
-        eq2 = dsolve(Eq(eq2,0)).args[1]
+        eq2 = G*A*(Derivative(defl(x), x)) + load[2]*x - C_i + G*A*slope_y
+        def_z = dsolve(Eq(eq2,0)).args[1]
         #solve for constants originated from using dsolve on eq2
-        constants = list((linsolve([eq2.subs(x, 0), eq2.subs(x, l)], C1, C_i).args)[0])
-        self._deflection[2] = eq2.subs({C1:constants[0], C_i:constants[1]})
-        self._slope[1] = slope.subs(C_i, constants[1])
+        constants = list((linsolve([def_z.subs(x, 0), def_z.subs(x, l)], C1, C_i).args)[0])
+        self._deflection[2] = def_z.subs({C1:constants[0], C_i:constants[1]})
+        self._slope[1] = slope_y.subs(C_i, constants[1])

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1229,13 +1229,14 @@ class Beam_3d(Beam):
         load = self._load_vector
         moment = self._moment_load_vector
 
-        # Finding deflection along y and slope across z axis. System of equation involved:
-        # eq1 = Derivative(E*I*Derivative(theta(x), x), x) + G*A*(Derivative(defl(x), x) - theta(x))+m
-        # eq2 = Derivative(G*A*(Derivative(defl(x), x) - theta(x)), x) + q
+        # Finding deflection along y-axis and slope across z-axis. System of equation involved:
+        # 1: Derivative(E*I*Derivative(theta_z(x), x), x) + G*A*(Derivative(defl_y(x), x) - theta_z(x)) + moment_z = 0
+        # 2: Derivative(G*A*(Derivative(defl_y(x), x) - theta_z(x)), x) + load_y = 0
         defl = Function('defl')
         theta = Function('theta')
         C_i = Symbol('C_i')
-        eq1 = Derivative(E*I*Derivative(theta(x), x), x) + integrate(-load[1], x) + C_i + moment[2]
+        # substitute value of `G*A*(Derivative(defl_y(x), x) - theta_z(x))` from (2) in (1)
+        eq1 = Derivative(E*I*Derivative(theta(x), x), x) + (integrate(-load[1], x) + C_i) + moment[2]
         slope = dsolve(Eq(eq1, 0)).args[1]
 
         #solve for constants originated from using dsolve on eq1
@@ -1244,9 +1245,29 @@ class Beam_3d(Beam):
         constants = list((linsolve([slope.subs(x, 0), slope.subs(x, l)], C1, C2).args)[0])
         slope = slope.subs({C1:constants[0], C2:constants[1]})
 
+        # Put value of slope obtained back in (2) to solve for `C_i` and find deflection across y-axis
         eq2 = G*A*(Derivative(defl(x), x)) + load[1]*x - C_i - G*A*slope
         eq2 = dsolve(Eq(eq2,0)).args[1]
         #solve for constants originated from using dsolve on eq2
         constants = list((linsolve([eq2.subs(x, 0), eq2.subs(x, l)], C1, C_i).args)[0])
-        deflection = eq2.subs({C1:constants[0], C_i:constants[1]})
-        slope = slope.subs(C_i, constants[1])
+        self._deflection[1] = eq2.subs({C1:constants[0], C_i:constants[1]})
+        self._slope[2] = slope.subs(C_i, constants[1])
+
+        # Finding deflection along z-axis and slope across y-axis. System of equation involved:
+        # 1: Derivative(E*I*Derivative(theta_y(x), x), x) - G*A*(Derivative(defl_z(x), x) + theta_y(x)) + moment_y = 0
+        # 2: Derivative(G*A*(Derivative(defl_z(x), x) + theta_y(x)), x) + load_z = 0
+
+        # substitute value of `G*A*(Derivative(defl_y(x), x) + theta_z(x))` from (2) in (1)
+        eq1 = Derivative(E*I*Derivative(theta(x), x), x) + (integrate(load[2], x) - C_i) + moment[1]
+        slope = dsolve(Eq(eq1, 0)).args[1]
+        #solve for constants originated from using dsolve on eq1
+        constants = list((linsolve([slope.subs(x, 0), slope.subs(x, l)], C1, C2).args)[0])
+        slope = slope.subs({C1:constants[0], C2:constants[1]})
+
+        # Put value of slope obtained back in (2) to solve for `C_i` and find deflection across z-axis
+        eq2 = G*A*(Derivative(defl(x), x)) + load[2]*x - C_i + G*A*slope
+        eq2 = dsolve(Eq(eq2,0)).args[1]
+        #solve for constants originated from using dsolve on eq2
+        constants = list((linsolve([eq2.subs(x, 0), eq2.subs(x, l)], C1, C_i).args)[0])
+        self._deflection[2] = eq2.subs({C1:constants[0], C_i:constants[1]})
+        self._slope[1] = slope.subs(C_i, constants[1])

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1127,8 +1127,8 @@ class Beam_3d(Beam):
        While solving a beam bending problem, a user should choose its
        own sign convention and should stick to it. The results will
        automatically follow the chosen sign convention.
-
-    ref : http://homes.civil.aau.dk/jc/FemteSemester/Beams3D.pdf
+       This class assumes that any kind of distributed load/moment is
+       applied through out the span of a beam.
 
     Examples
     ========
@@ -1160,6 +1160,12 @@ class Beam_3d(Beam):
     [0, -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I))
     + l*m*x**2/(4*E*I) - l*x**3*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I)) - m*x**3/(6*E*I)
     + q*x**4/(24*E*I) + l*x*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I)) - q*x**2/(2*A*G), 0]
+
+    References
+    ==========
+
+    .. [1] http://homes.civil.aau.dk/jc/FemteSemester/Beams3D.pdf
+
     """
 
     def __init__(self, length, elastic_modulus, shear_modulus , second_moment, area, variable=Symbol('x')):
@@ -1246,11 +1252,29 @@ class Beam_3d(Beam):
         """
         return self._moment_load_vector
 
-    def apply_load(self, value, dir="y"):
+    def apply_load(self, value, dir="y", order=0):
         """
         This method adds up the force load to a particular beam object.
+
+        Parameters
+        ==========
+        value : Sympifyable
+            The magnitude of an applied load.
+        dir : String
+            Axis along which load is applied.
+        order : Integer
+            The order of the applied load.
+            - For point loads, order=-1
+            - For constant distributed load, order=0
+            - For ramp loads, order=1
+            - For parabolic ramp loads, order=2
+            - ... so on.
         """
         value = sympify(value)
+        order = sympify(order)
+        if order == -1:
+            raise NotImplementedError("This class doesn't support point loads")
+
         if dir == "x":
             self._load_vector[0] += value
         elif dir == "y":
@@ -1258,11 +1282,29 @@ class Beam_3d(Beam):
         else:
             self._load_vector[2] += value
 
-    def apply_moment_load(self, value, dir="y"):
+    def apply_moment_load(self, value, dir="y", order=-1, end=None):
         """
         This method adds up the moment loads to a particular beam object.
+
+        Parameters
+        ==========
+        value : Sympifyable
+            The magnitude of an applied moment.
+        dir : String
+            Axis along which moment is applied.
+        order : Integer
+            The order of the applied load.
+            - For point moments, order=-2
+            - For constant distributed moment, order=-1
+            - For ramp moments, order=0
+            - For parabolic ramp moments, order=1
+            - ... so on.
         """
         value = sympify(value)
+        order = sympify(order)
+        if order == -2:
+            raise NotImplementedError("This class doesn't support point moments")
+
         if dir == "x":
             self._moment_load_vector[0] += value
         elif dir == "y":

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1355,18 +1355,18 @@ class Beam_3d(Beam):
         # 1: Derivative(E*I_z*Derivative(theta_z(x), x), x) + G*A*(Derivative(defl_y(x), x) - theta_z(x)) + moment_z = 0
         # 2: Derivative(G*A*(Derivative(defl_y(x), x) - theta_z(x)), x) + load_y = 0
         C_i = Symbol('C_i')
-        # substitute value of `G*A*(Derivative(defl_y(x), x) - theta_z(x))` from (2) in (1)
+        # Substitute value of `G*A*(Derivative(defl_y(x), x) - theta_z(x))` from (2) in (1)
         eq1 = Derivative(E*I_z*Derivative(theta(x), x), x) + (integrate(-load[1], x) + C_i) + moment[2]
         slope_z = dsolve(Eq(eq1, 0)).args[1]
 
-        #solve for constants originated from using dsolve on eq1
+        # Solve for constants originated from using dsolve on eq1
         constants = list((linsolve([slope_z.subs(x, 0), slope_z.subs(x, l)], C1, C2).args)[0])
         slope_z = slope_z.subs({C1:constants[0], C2:constants[1]})
 
         # Put value of slope obtained back in (2) to solve for `C_i` and find deflection across y-axis
         eq2 = G*A*(Derivative(defl(x), x)) + load[1]*x - C_i - G*A*slope_z
         def_y = dsolve(Eq(eq2, 0), defl(x)).args[1]
-        #solve for constants originated from using dsolve on eq2
+        # Solve for constants originated from using dsolve on eq2
         constants = list((linsolve([def_y.subs(x, 0), def_y.subs(x, l)], C1, C_i).args)[0])
         self._deflection[1] = def_y.subs({C1:constants[0], C_i:constants[1]})
         self._slope[2] = slope_z.subs(C_i, constants[1])
@@ -1375,17 +1375,17 @@ class Beam_3d(Beam):
         # 1: Derivative(E*I_y*Derivative(theta_y(x), x), x) - G*A*(Derivative(defl_z(x), x) + theta_y(x)) + moment_y = 0
         # 2: Derivative(G*A*(Derivative(defl_z(x), x) + theta_y(x)), x) + load_z = 0
 
-        # substitute value of `G*A*(Derivative(defl_y(x), x) + theta_z(x))` from (2) in (1)
+        # Substitute value of `G*A*(Derivative(defl_y(x), x) + theta_z(x))` from (2) in (1)
         eq1 = Derivative(E*I_y*Derivative(theta(x), x), x) + (integrate(load[2], x) - C_i) + moment[1]
         slope_y = dsolve(Eq(eq1, 0)).args[1]
-        #solve for constants originated from using dsolve on eq1
+        # Solve for constants originated from using dsolve on eq1
         constants = list((linsolve([slope_y.subs(x, 0), slope_y.subs(x, l)], C1, C2).args)[0])
         slope_y = slope_y.subs({C1:constants[0], C2:constants[1]})
 
         # Put value of slope obtained back in (2) to solve for `C_i` and find deflection across z-axis
         eq2 = G*A*(Derivative(defl(x), x)) + load[2]*x - C_i + G*A*slope_y
         def_z = dsolve(Eq(eq2,0)).args[1]
-        #solve for constants originated from using dsolve on eq2
+        # Solve for constants originated from using dsolve on eq2
         constants = list((linsolve([def_z.subs(x, 0), def_z.subs(x, l)], C1, C_i).args)[0])
         self._deflection[2] = def_z.subs({C1:constants[0], C_i:constants[1]})
         self._slope[1] = slope_y.subs(C_i, constants[1])

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1156,5 +1156,38 @@ class Beam_3d(Beam):
         self.variable = variable
         self._boundary_conditions = {'deflection': [], 'slope': []}
         self._load = 0
-        self._applied_loads = []
+        self._load_vector = [0, 0, 0]
         self._reaction_loads = {}
+
+    @property
+    def load_vector(self):
+        """
+        Returns a list of load applied on object in terms of SingularityFunction.
+        """
+        return self._load_vector
+
+    def apply_load(self, value, start, order, end=None, dir="y"):
+        """
+        This method adds up the loads given to a particular beam object.
+        """
+        x = self.variable
+        value = sympify(value)
+        start = sympify(start)
+        order = sympify(order)
+        direction = str(dir)
+
+        load = value*SingularityFunction(x, start, order)
+        if end:
+            if order == 0:
+                load -= value*SingularityFunction(x, end, order)
+            elif order.is_positive:
+                load -= value*SingularityFunction(x, end, order) + value*SingularityFunction(x, end, 0)
+            else:
+                raise ValueError("""Order of the load should be positive.""")
+
+        if dir == "x":
+            self._load_vector[0] += load
+        elif dir == "y":
+            self._load_vector[1] += load
+        else:
+            self._load_vector[2] += load

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1115,3 +1115,46 @@ class Beam(object):
             return (points[deflections.index(max_def)], max_def)
         else:
             return None
+
+
+class Beam_3d(Beam):
+    """
+    A Beam is a structural element that is capable of withstanding load
+    primarily by resisting against bending. Beams are characterized by
+    their cross sectional profile(Second moment of area), their length
+    and their material.
+    This class can handle loads applied in any direction of a 3D space.
+
+    .. note::
+       While solving a beam bending problem, a user should choose its
+       own sign convention and should stick to it. The results will
+       automatically follow the chosen sign convention.
+    """
+
+    def __init__(self, length, elastic_modulus, second_moment, variable=Symbol('x')):
+        """Initializes the class.
+
+        Parameters
+        ==========
+        length : Sympifyable
+            A Symbol or value representing the Beam's length.
+        elastic_modulus : Sympifyable
+            A SymPy expression representing the Beam's Modulus of Elasticity.
+            It is a measure of the stiffness of the Beam material.
+        second_moment : Sympifyable
+            A SymPy expression representing the Beam's Second moment of area.
+            It is a geometrical property of an area which reflects how its
+            points are distributed with respect to its neutral axis.
+        variable : Symbol, optional
+            A Symbol object that will be used as the variable along the beam
+            while representing the load, shear, moment, slope and deflection
+            curve. By default, it is set to ``Symbol('x')``.
+        """
+        self.length = length
+        self.elastic_modulus = elastic_modulus
+        self.second_moment = second_moment
+        self.variable = variable
+        self._boundary_conditions = {'deflection': [], 'slope': []}
+        self._load = 0
+        self._applied_loads = []
+        self._reaction_loads = {}

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -365,3 +365,22 @@ def test_max_deflection():
     b.apply_load(F*l/8, l, -2)
     b.apply_load(-F, l/2, -1)
     assert b.max_deflection() == (l/2, F*l**3/(192*E*I))
+
+def test_Beam_3d():
+    from sympy.physics.continuum_mechanics.beam import Beam, Beam_3d
+    l, E, G, I, A = symbols('l, E, G, I, A')
+    b = Beam_3d(l, E, G, I, A)
+    b.apply_support(0, "fixed")
+    b.apply_support(l, "fixed")
+    m, q = symbols('m, q')
+    b.apply_load(q, dir="y")
+    b.apply_moment_load(m, dir="z")
+    b.solve_slope_deflection()
+
+    assert b.shear_force() == [0, -q*x, 0]
+    assert b.bending_moment() == [0, 0, -m*x + q*x**2/2]
+    assert b.deflection() == [0, -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l**2*q - 2*A*G*l*m
+            + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I)) + l*m*x**2/(4*E*I) - l*x**3*(A*G*l**2*q
+            - 2*A*G*l*m + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I)) - m*x**3/(6*E*I) + q*x**4/(24*E*I)
+            + l*x*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I))
+            - q*x**2/(2*A*G), 0]

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -367,7 +367,7 @@ def test_max_deflection():
     assert b.max_deflection() == (l/2, F*l**3/(192*E*I))
 
 def test_Beam_3d():
-    from sympy.physics.continuum_mechanics.beam import Beam, Beam_3d
+    from sympy.physics.continuum_mechanics.beam import Beam_3d
     l, E, G, I, A = symbols('l, E, G, I, A')
     b = Beam_3d(l, E, G, I, A)
     b.apply_support(0, "fixed")


### PR DESCRIPTION
#### Brief description of what is fixed or changed
`Beam_3d` can be used to find _Shear force_, _Bending moment_,  _Slope_ and _Deflection_ in the beam.

**Equations used**
From the [Reference](http://homes.civil.aau.dk/jc/FemteSemester/Beams3D.pdf), following equations are used:

- To find _Shear force_ and _Bending moment_
![shear](https://user-images.githubusercontent.com/31389737/42560335-0c45e50e-8514-11e8-9fb1-f9d27040b4d8.png)
where _[N, Q<sub>y</sub>, Q<sub>z</sub>]_ and  _[M<sub>x</sub>, M<sub>y</sub>, M<sub>z</sub>]_ are shear force and bending moment along x-y-z axes respectively (_q_ and _m_ are applied load and moment).
- To find _Slope_ and _Deflection_:
![def_1](https://user-images.githubusercontent.com/31389737/42560803-2e2ea592-8515-11e8-81cc-b511e1286ff5.png)
![def_2](https://user-images.githubusercontent.com/31389737/42560832-466c2986-8515-11e8-9ac7-4a0939a41a52.png)
where _[w<sub>x</sub>, w<sub>y</sub>, w<sub>z</sub>]_  and _[&theta;<sub>x</sub>, &theta;<sub>y</sub>, &theta;<sub>z</sub>]_ are deflection and slope along three axes respectively.


#### Other comments
As `Beam_3d` doesn't use `SingularityFunction`, I was unable to find a way to represent point load/moments (also I wasn't able to find any online resource regarding it). So for now `Beam_3d` only supports continous load applied over whole span of beam.
