### PR TITLE
Fixes issue #14547: false error messages with Eq()

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -514,9 +514,11 @@ class log(Function):
                 for j in range(len(multiplicands_list)):
                     r = list(multiplicands_list[j].as_numer_denom())
                     if Quantity.get_dimensional_expr(r[0]) != Quantity.get_dimensional_expr(1):
-                        r[0] = Quantity(r[0].name, Quantity.get_dimensional_expr(1))
+                        r[0] = Quantity(r[0].name)
+                        r[0].set_dimension(Quantity.get_dimensional_expr(1))
                     if Quantity.get_dimensional_expr(r[1]) != Quantity.get_dimensional_expr(1):
-                        r[1] = Quantity(r[1].name, Quantity.get_dimensional_expr(1))
+                        r[1] = Quantity(r[1].name)
+                        r[1].set_dimension(Quantity.get_dimensional_expr(1))
                     multiplicands_list[j] = r[0]/r[1]
                 addends_list[i] = 1
                 for multiplicand in multiplicands_list:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -501,7 +501,31 @@ class log(Function):
         from sympy import unpolarify
         from sympy.calculus import AccumBounds
         from sympy.sets.setexpr import SetExpr
+        from sympy.physics.units import Quantity
 
+        arg = sympify(arg)
+
+        addends = arg.as_coeff_add()
+        addends_list = list(addends[1])
+        for i in range(len(addends_list)):
+            if Quantity.get_dimensional_expr(addends_list[i]) != Quantity.get_dimensional_expr(1):
+                multiplicands = addends_list[i].as_coeff_mul()
+                multiplicands_list = list(multiplicands[1])
+                for j in range(len(multiplicands_list)):
+                    r = list(multiplicands_list[j].as_numer_denom())
+                    if Quantity.get_dimensional_expr(r[0]) != Quantity.get_dimensional_expr(1):
+                        r[0] = Quantity(r[0].name, Quantity.get_dimensional_expr(1))
+                    if Quantity.get_dimensional_expr(r[1]) != Quantity.get_dimensional_expr(1):
+                        r[1] = Quantity(r[1].name, Quantity.get_dimensional_expr(1))
+                    multiplicands_list[j] = r[0]/r[1]
+                addends_list[i] = 1
+                for multiplicand in multiplicands_list:
+                    addends_list[i] *= multiplicand
+                addends_list[i] *= multiplicands[0]
+        arg = 0
+        for addend in addends_list:
+            arg += addend
+        arg += addends[0]
         arg = sympify(arg)
 
         if base is not None:

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -364,8 +364,7 @@ def test_factor_and_dimension():
 
     pH = -log(cH)
 
-    assert (1, volume/amount_of_substance) == Quantity._collect_factor_and_dimension(
-        exp(pH))
+    assert (1, 1) == Quantity._collect_factor_and_dimension(exp(pH))
 
     v_w1 = Quantity('v_w1')
     v_w2 = Quantity('v_w2')

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -364,7 +364,7 @@ def test_factor_and_dimension():
 
     pH = -log(cH)
 
-    assert (1, 1) == Quantity._collect_factor_and_dimension(exp(pH))
+    assert (1, Quantity.get_dimensional_expr(1)) == Quantity._collect_factor_and_dimension(exp(pH))
 
     v_w1 = Quantity('v_w1')
     v_w2 = Quantity('v_w2')

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -364,7 +364,7 @@ def test_factor_and_dimension():
 
     pH = -log(cH)
 
-    assert (1, Quantity.get_dimensional_expr(1)) == Quantity._collect_factor_and_dimension(exp(pH))
+    assert (1, Dimension(1)) == Quantity._collect_factor_and_dimension(exp(pH))
 
     v_w1 = Quantity('v_w1')
     v_w2 = Quantity('v_w2')


### PR DESCRIPTION
I have added a mechanism in exponential.py which solves the issue of false error messages with Eq() and quantities in log(). I have applied the concepts given in [this](https://cdn-pubs.acs.org/doi/pdfplus/10.1021/ed072p954) paper. My mechanism converts any expression passed to log() into dimensionless expressions which is in accordance with concepts of dimensional analysis. The paper also says that whenever we pass any dimensional quantity into log() we convert it into dimensionless quantity by dividing it by its units. In a certain way, my added coded works in a similar way.