### PR TITLE
singularities should specify domain when calling solveset

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -62,7 +62,8 @@ def singularities(expression, symbol):
             " functions are not yet implemented."
         )
     else:
-        return solveset(simplify(1 / expression), symbol)
+        domain = S.Reals if symbol.is_real else S.Complexes
+        return solveset(simplify(1 / expression), symbol, domain)
 
 
 ###########################################################################

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -13,6 +13,7 @@ from sympy.abc import x, y
 
 
 def test_singularities():
+    x = Symbol('x')
     assert singularities(x**2, x) == S.EmptySet
     assert singularities(x/(x**2 + 3*x + 2), x) == FiniteSet(-2, -1)
     assert singularities(1/(x**2 + 1), x) == FiniteSet(I, -I)
@@ -20,6 +21,9 @@ def test_singularities():
         FiniteSet(-1, (1 - sqrt(3) * I) / 2, (1 + sqrt(3) * I) / 2)
     assert singularities(1/(y**2 + 2*I*y + 1), y) == \
         FiniteSet(-I + sqrt(2)*I, -I - sqrt(2)*I)
+
+    x = Symbol('x', real=True)
+    assert singularities(1/(x**2 + 1), x) == S.EmptySet
 
 
 @XFAIL


### PR DESCRIPTION
Discussions [here](https://github.com/sympy/sympy/pull/14097#discussion_r200837228) led to the  conclusion that the `singularities` should specify the domain before calling `solveset`

```python
# in current master
>>> x = symbols('x', real=True)
>>> singularities(1/(x**2 + 1),  x)
FiniteSet(I, -I)

# in this PR
>>> x = symbols('x', real=True)
>>> singularities(1/(x**2 + 1),  x)
EmptySet()
``` 
The reason to specify `domain` is when the user wants to get singularities only in the real domain.

ping @jksuom @aktech @smichr 