### PR TITLE
added contour plotting method in sympy/plotting/plot.py

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -819,8 +819,8 @@ class ParametricSurfaceSeries(SurfaceBaseSeries):
 ### Contours
 class ContourSeries(BaseSeries):
     """Representation for a contour plot."""
-    #The code is mostly repetition of SurfaceOver2DRange.
-    #Presently used in contour_plot function
+    # The code is mostly repetition of SurfaceOver2DRange.
+    # Presently used in contour_plot function
 
     is_contour = True
 

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1794,37 +1794,6 @@ def plot_contour(*args, **kwargs):
 
     ``title`` : str. Title of the plot.
 
-    Examples
-    ========
-
-    >>> from sympy import symbols, sin, cos
-    >>> from sympy.plotting.plot import plot_contour
-    >>> x, y = symbols('x y')
-
-    Single plot
-
-    >>> plot_contour(sin(x)*sin(y), (x, -5, 5), (y, -5, 5))
-    Plot object containing:
-    [0]: cartesian surface: sin(x)*sin(y) for x over (-5.0, 5.0) and y over (-5.0, 5.0)
-
-
-    Multiple plots with same range
-
-    >>> plot_contour(x**2 + y**2, x**3 + y**3, (x, -5, 5), (y, -5, 5))
-    Plot object containing:
-    [0]: cartesian surface: x**2 + y**2 for x over (-5.0, 5.0) and y over (-5.0, 5.0)
-    [1]: cartesian surface: x**3 + y**3 for x over (-5.0, 5.0) and y over (-5.0, 5.0)
-
-
-    Multiple plots with different ranges.
-
-    >>> plot_contour((x**2 + y**2, (x, -5, 5), (y, -5, 5)),
-    ...     (x**3 + y**3, (x, -3, 3), (y, -3, 3)))
-    Plot object containing:
-    [0]: cartesian surface: x**2 + y**2 for x over (-5.0, 5.0) and y over (-5.0, 5.0)
-    [1]: cartesian surface: x**3 + y**3 for x over (-3.0, 3.0) and y over (-3.0, 3.0)
-
-
     See Also
     ========
     Plot, ContourSeries

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1810,7 +1810,6 @@ def plot_contour(*args, **kwargs):
         plot_contours.show()
     return plot_contours
 
-
 def check_arguments(args, expr_len, nb_of_free_symbols):
     """
     Checks the arguments and converts into tuples of the

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -820,8 +820,7 @@ class ParametricSurfaceSeries(SurfaceBaseSeries):
 class ContourSeries(BaseSeries):
     """Representation for a contour plot."""
     #The code is mostly repetition of SurfaceOver2DRange.
-    #XXX: Presently not used in any of those functions.
-    #XXX: Add contour plot and use this seties.
+    #XXX: Presently used in contour_plot function
 
     is_contour = True
 
@@ -1731,6 +1730,116 @@ def plot3d_parametric_surface(*args, **kwargs):
     if show:
         plots.show()
     return plots
+
+def plot_contour(*args, **kwargs):
+    """
+    Draws contour plot of a function
+
+    Usage
+    =====
+
+    Single plot
+
+    ``plot_contour(expr, range_x, range_y, **kwargs)``
+
+    If the ranges are not specified, then a default range of (-10, 10) is used.
+
+    Multiple plot with the same range.
+
+    ``plot_contour(expr1, expr2, range_x, range_y, **kwargs)``
+
+    If the ranges are not specified, then a default range of (-10, 10) is used.
+
+    Multiple plots with different ranges.
+
+    ``plot_contour((expr1, range_x, range_y), (expr2, range_x, range_y), ..., **kwargs)``
+
+    Ranges have to be specified for every expression.
+
+    Default range may change in the future if a more advanced default range
+    detection algorithm is implemented.
+
+    Arguments
+    =========
+
+    ``expr`` : Expression representing the function along x.
+
+    ``range_x``: (x, 0, 5), A 3-tuple denoting the range of the x
+    variable.
+
+    ``range_y``: (y, 0, 5), A 3-tuple denoting the range of the y
+     variable.
+
+    Keyword Arguments
+    =================
+
+    Arguments for ``ContourSeries`` class:
+
+    ``nb_of_points_x``: int. The x range is sampled uniformly at
+    ``nb_of_points_x`` of points.
+
+    ``nb_of_points_y``: int. The y range is sampled uniformly at
+    ``nb_of_points_y`` of points.
+
+    Aesthetics:
+
+    ``surface_color``: Function which returns a float. Specifies the color for
+    the surface of the plot. See ``sympy.plotting.Plot`` for more details.
+
+    If there are multiple plots, then the same series arguments are applied to
+    all the plots. If you want to set these options separately, you can index
+    the returned ``Plot`` object and set it.
+
+    Arguments for ``Plot`` class:
+
+    ``title`` : str. Title of the plot.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols, sin, cos
+    >>> from sympy.plotting.plot import plot_contour
+    >>> x, y = symbols('x y')
+
+    Single plot
+
+    >>> plot_contour(sin(x)*sin(y), (x, -5, 5), (y, -5, 5))
+    Plot object containing:
+    [0]: cartesian surface: sin(x)*sin(y) for x over (-5.0, 5.0) and y over (-5.0, 5.0)
+
+
+    Multiple plots with same range
+
+    >>> plot_contour(x**2 + y**2, x**3 + y**3, (x, -5, 5), (y, -5, 5))
+    Plot object containing:
+    [0]: cartesian surface: x**2 + y**2 for x over (-5.0, 5.0) and y over (-5.0, 5.0)
+    [1]: cartesian surface: x**3 + y**3 for x over (-5.0, 5.0) and y over (-5.0, 5.0)
+
+
+    Multiple plots with different ranges.
+
+    >>> plot_contour((x**2 + y**2, (x, -5, 5), (y, -5, 5)),
+    ...     (x**3 + y**3, (x, -3, 3), (y, -3, 3)))
+    Plot object containing:
+    [0]: cartesian surface: x**2 + y**2 for x over (-5.0, 5.0) and y over (-5.0, 5.0)
+    [1]: cartesian surface: x**3 + y**3 for x over (-3.0, 3.0) and y over (-3.0, 3.0)
+
+
+    See Also
+    ========
+    Plot, ContourSeries
+    """
+
+    args = list(map(sympify, args))
+    show = kwargs.pop('show', True)
+    plot_expr = check_arguments(args, 1, 2)
+    series = [ContourSeries(*arg) for arg in plot_expr]
+    plot_contours = Plot(*series, **kwargs)
+    if len(plot_expr[0].free_symbols) > 2:
+        raise ValueError('Contour Plot cannot Plot for more than two variables.')
+    if show:
+        plot_contours.show()
+    return plot_contours
 
 
 def check_arguments(args, expr_len, nb_of_free_symbols):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -820,7 +820,7 @@ class ParametricSurfaceSeries(SurfaceBaseSeries):
 class ContourSeries(BaseSeries):
     """Representation for a contour plot."""
     #The code is mostly repetition of SurfaceOver2DRange.
-    #XXX: Presently used in contour_plot function
+    #Presently used in contour_plot function
 
     is_contour = True
 

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -177,6 +177,21 @@ def plot_and_save(name):
     p.save(tmp_file('%s_parametric_surface' % name))
     p._backend.close()
 
+    # Single Contour plot.
+    p = plot_contour(sin(x)*sin(y), (x, -5, 5), (y, -5, 5))
+    p.save(tmp_file('%s_contour_plot' % name))
+    p._backend.close()
+
+    # Multiple Contour plots with same range.
+    p = plot_contour(x**2 + y**2, x**3 + y**3, (x, -5, 5), (y, -5, 5))
+    p.save(tmp_file('%s_contour_plot' % name))
+    p._backend.close()
+
+    # Multiple Contour plots with different range.
+    p = plot_contour((x**2 + y**2, (x, -5, 5), (y, -5, 5)), (x**3 + y**3, (x, -3, 3), (y, -3, 3)))
+    p.save(tmp_file('%s_contour_plot' % name))
+    p._backend.close()
+
     ###
     # Examples from the 'colors' notebook
     ###

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -2,7 +2,7 @@ from sympy import (pi, sin, cos, Symbol, Integral, Sum, sqrt, log,
                    oo, LambertW, I, meijerg, exp_polar, Max, Piecewise, And)
 from sympy.plotting import (plot, plot_parametric, plot3d_parametric_line,
                             plot3d, plot3d_parametric_surface)
-from sympy.plotting.plot import unset_show
+from sympy.plotting.plot import unset_show, plot_contour
 from sympy.utilities import lambdify as lambdify_
 from sympy.utilities.pytest import skip, raises
 from sympy.plotting.experimental_lambdify import lambdify


### PR DESCRIPTION
Added contour plotting method in sympy/plotting/plot.py and modified test_plot.py for contour plotting

#12034
Fixes #12034
Took help and reviews from #12049

For documentation, reused the documentation of `plot3d`; however the examples were changed
Also, `plot3d` documents arguments taken on behalf of the `SurfaceOver2DRangeSeries` constructor, whereas `conplot` documents arguments using `ContourSeries`constructor.
The comment under class `ContourSeries` is updated as well now that there is contour plotting function that makes use of it.
In `test_plot.py` 3 tests have been added providing basis for the 3 examples present in the function's documentation. 

Note : 
I took the reviews of the PR made by @ArifAhmed1995 (https://github.com/sympy/sympy/pull/12049) and made this PR. I also took ideas from #12049 ( working code ).
Thus I have implemented the suggestions made there ( PR #12049 ) by @chrstphrchvz and @asmeurer 


Pls review this PR. Thank you.