### PR TITLE
added and modified a function in sympy/tensor/index_methods.py to preserve order of indices

### DIFF
--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -23,6 +23,25 @@ from sympy.core.compatibility import reduce
 class IndexConformanceException(Exception):
     pass
 
+def _unique_and_repeated(inds):
+    """returns the unique and repeated indices. This is used in the function
+    _remove_repeated to remove the recurring indices.
+
+    Examples :
+    ========
+
+    >>> from sympy.tensor.index_methods import _unique_and_repeated
+    >>> _unique_and_repeated([1,2,3,2,3,4,5,3,4,7,2,7])
+    ([1, 5], [2, 3, 4, 7])
+
+    """
+    uniq = OrderedDict()
+    for i in inds:
+        if i in uniq:
+            uniq[i] = 0
+        else:
+            uniq[i] = 1
+    return sift(uniq, lambda x: uniq[x], binary=True)
 
 def _remove_repeated(inds):
     """Removes repeated objects from sequences
@@ -30,20 +49,17 @@ def _remove_repeated(inds):
     Returns a set of the unique objects and a tuple of all that have been
     removed.
 
+    Examples :
+    ========
+
     >>> from sympy.tensor.index_methods import _remove_repeated
     >>> l1 = [1, 2, 3, 2]
     >>> _remove_repeated(l1)
     ({1, 3}, (2,))
 
     """
-    sum_index = {}
-    for i in inds:
-        if i in sum_index:
-            sum_index[i] += 1
-        else:
-            sum_index[i] = 0
-    inds = [x for x in inds if not sum_index[x]]
-    return set(inds), tuple([ i for i in sum_index if sum_index[i] ])
+    u, r = _unique_and_repeated([1, 2, 3, 2, 3, 4, 5, 3, 4, 7, 2, 7])
+    return set(u), tuple(r)
 
 
 def _get_indices_Mul(expr, return_dummies=False):

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -36,7 +36,6 @@ def _unique_and_repeated(inds):
 
     >>> _unique_and_repeated([2, 3, 1, 3, 0, 4, 0])
     ([2, 1, 4], [3, 0])
-    
     """
     uniq = OrderedDict()
     for i in inds:

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -12,28 +12,31 @@
 
 from __future__ import print_function, division
 
+
 from sympy.core.function import Function
 from sympy.functions import exp, Piecewise
 from sympy.tensor.indexed import Idx, Indexed
 
 
 from sympy.core.compatibility import reduce
-
-
+from collections import OrderedDict
+from sympy.utilities import sift
 class IndexConformanceException(Exception):
     pass
 
 def _unique_and_repeated(inds):
-    """returns the unique and repeated indices. This is used in the function
-    _remove_repeated to remove the recurring indices.
+    """
+    Returns the unique and repeated indices. Also note, from the examples given below
+    that the order of indices is maintained as given in the input.
 
     Examples :
     ========
 
     >>> from sympy.tensor.index_methods import _unique_and_repeated
-    >>> _unique_and_repeated([1,2,3,2,3,4,5,3,4,7,2,7])
-    ([1, 5], [2, 3, 4, 7])
 
+    >>> _unique_and_repeated([2, 3, 1, 3, 0, 4, 0])
+    ([2, 1, 4], [3, 0])
+    
     """
     uniq = OrderedDict()
     for i in inds:
@@ -44,7 +47,8 @@ def _unique_and_repeated(inds):
     return sift(uniq, lambda x: uniq[x], binary=True)
 
 def _remove_repeated(inds):
-    """Removes repeated objects from sequences
+    """
+    Removes repeated objects from sequences
 
     Returns a set of the unique objects and a tuple of all that have been
     removed.
@@ -58,7 +62,7 @@ def _remove_repeated(inds):
     ({1, 3}, (2,))
 
     """
-    u, r = _unique_and_repeated([1, 2, 3, 2, 3, 4, 5, 3, 4, 7, 2, 7])
+    u, r = _unique_and_repeated(inds)
     return set(u), tuple(r)
 
 


### PR DESCRIPTION
Added `_unique_and_repeated` method and modified `_remove_repeated` method in `sympy/tensor/index_methods.py`

Took help and reviews from #14790 

Added a `_unique_and_repeated` method which returns the unique and repeated indices. This is used in the function `_remove_repeated`  which calls it to  remove the repeated indices and make them occur once only as also shown in the example.

Note : I have taken the review given by @smichr in PR #14790 and made this PR (since I found this particularly helpful and no-one else was addressing it)

Pls review this PR and let me know the improvements.