### PR TITLE
14547: avoid evaluation of (Dimension|Quantity - 1)

### DIFF
--- a/sympy/physics/units/dimensions.py
+++ b/sympy/physics/units/dimensions.py
@@ -157,10 +157,8 @@ class Dimension(Expr):
         if isinstance(other, Basic):
             if other.has(Quantity):
                 other = Dimension(Quantity.get_dimensional_expr(other))
-            if isinstance(other, Dimension):
-                if self == other:
-                    return self
-                raise ValueError('mismatched dimensions of addends')
+            if isinstance(other, Dimension) and self == other:
+                return self
             return super(Dimension, self).__add__(other)
         return self
 

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -247,31 +247,3 @@ class Quantity(AtomicExpr):
     def free_symbols(self):
         """Return free symbols from quantity."""
         return self.scale_factor.free_symbols
-
-
-def _Quantity_constructor_postprocessor_Add(expr):
-    # Construction postprocessor for the addition,
-    # checks for dimension mismatches of the addends, thus preventing
-    # expressions like `meter + second` to be created. For sake of
-    # core operations involving assumptions, the case of `unit + number`
-    # will be ignored.
-
-    deset = {
-        tuple(sorted(dimsys_default.get_dimensional_dependencies(
-            Dimension(Quantity.get_dimensional_expr(i))).items()))
-        for i in expr.args
-        if not i.free_symbols # do not raise if there are symbols
-                              # (free symbols could contain the units
-                              # corrections)
-        and not i.is_number
-    }
-    # If `deset` has more than one element, then some dimensions do not
-    # match in the sum:
-    if len(deset) > 1:
-        raise ValueError("summation of quantities of incompatible dimensions")
-    return expr
-
-
-Basic._constructor_postprocessor_mapping[Quantity] = {
-    "Add" : [_Quantity_constructor_postprocessor_Add],
-}

--- a/sympy/physics/units/quantities.py
+++ b/sympy/physics/units/quantities.py
@@ -252,15 +252,18 @@ class Quantity(AtomicExpr):
 def _Quantity_constructor_postprocessor_Add(expr):
     # Construction postprocessor for the addition,
     # checks for dimension mismatches of the addends, thus preventing
-    # expressions like `meter + second` to be created.
+    # expressions like `meter + second` to be created. For sake of
+    # core operations involving assumptions, the case of `unit + number`
+    # will be ignored.
 
     deset = {
         tuple(sorted(dimsys_default.get_dimensional_dependencies(
-            Dimension(Quantity.get_dimensional_expr(i) if not i.is_number else 1
-        )).items()))
+            Dimension(Quantity.get_dimensional_expr(i))).items()))
         for i in expr.args
-        if i.free_symbols == set()  # do not raise if there are symbols
-                    # (free symbols could contain the units corrections)
+        if not i.free_symbols # do not raise if there are symbols
+                              # (free symbols could contain the units
+                              # corrections)
+        and not i.is_number
     }
     # If `deset` has more than one element, then some dimensions do not
     # match in the sum:

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -66,12 +66,13 @@ def test_Dimension_properties():
 
 
 def test_Dimension_add_sub():
-    assert length + length == length + foot == foot + length == length
+    assert length + length == length
     assert length - length == length
     assert -length == length
 
-    raises(ValueError, lambda: length + time)
-    raises(ValueError, lambda: length - time)
+    assert length + foot == foot + length == length
+    assert length - foot == foot - length == length
+    assert length + time == length - time != length
 
     # issue 14547 - only raise error for dimensional args; allow
     # others to pass

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -76,8 +76,10 @@ def test_Dimension_add_sub():
     # issue 14547 - only raise error for dimensional args; allow
     # others to pass
     x = Symbol('x')
-    assert (length + x).is_Add
-    assert (length + 1).is_Add
+    e = length + x
+    assert e.is_Add and set(e.args) == {length, x}
+    e = length + 1
+    assert e.is_Add and set(e.args) == {length, 1}
 
 
 def test_Dimension_mul_div_exp():

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -5,6 +5,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 from sympy import S, Symbol, sqrt
 from sympy.physics.units.dimensions import Dimension, length, time, dimsys_default
+from sympy.physics.units import foot
 from sympy.utilities.pytest import raises
 
 
@@ -65,17 +66,23 @@ def test_Dimension_properties():
 
 
 def test_Dimension_add_sub():
-    assert length + length == length
+    assert length + length == length + foot == foot + length == length
     assert length - length == length
     assert -length == length
 
-    raises(TypeError, lambda: length + 1)
-    raises(TypeError, lambda: length - 1)
     raises(ValueError, lambda: length + time)
     raises(ValueError, lambda: length - time)
 
+    # issue 14547 - only raise error for dimensional args; allow
+    # others to pass
+    x = Symbol('x')
+    assert (length + x).is_Add
+    assert (length + 1).is_Add
+
 
 def test_Dimension_mul_div_exp():
+    assert 2*length == length*2 == length
+
     velo = length / time
 
     assert (length * length) == length ** 2

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -79,7 +79,7 @@ def test_Dimension_add_sub():
     e = length + x
     assert e == x + length and e.is_Add and set(e.args) == {length, x}
     e = length + 1
-    assert e == 1 + length == 1 - length == length + 1 and e.is_Add and set(e.args) == {length, 1}
+    assert e == 1 + length == 1 - length and e.is_Add and set(e.args) == {length, 1}
 
 
 def test_Dimension_mul_div_exp():

--- a/sympy/physics/units/tests/test_dimensions.py
+++ b/sympy/physics/units/tests/test_dimensions.py
@@ -77,13 +77,21 @@ def test_Dimension_add_sub():
     # others to pass
     x = Symbol('x')
     e = length + x
-    assert e.is_Add and set(e.args) == {length, x}
+    assert e == x + length and e.is_Add and set(e.args) == {length, x}
     e = length + 1
-    assert e.is_Add and set(e.args) == {length, 1}
+    assert e == 1 + length == 1 - length == length + 1 and e.is_Add and set(e.args) == {length, 1}
 
 
 def test_Dimension_mul_div_exp():
-    assert 2*length == length*2 == length
+    assert 2*length == length*2 == length/2 == length
+    assert 2/length == 1/length
+    x = Symbol('x')
+    m = x*length
+    assert m == length*x and m.is_Mul and set(m.args) == {x, length}
+    d = x/length
+    assert d == x*length**-1 and d.is_Mul and set(d.args) == {x, 1/length}
+    d = length/x
+    assert d == length*x**-1 and d.is_Mul and set(d.args) == {1/x, length}
 
     velo = length / time
 

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -459,3 +459,7 @@ def test_eval_subs():
     expr2 = force/mass
     units = {force:gravitational_constant*kilogram**2/meter**2, mass:kilogram}
     assert expr2.subs(units) == gravitational_constant*kilogram/meter**2
+
+
+def test_issue_14923():
+    assert (log(inch) - log(2)).simplify() == log(inch/2)

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -283,8 +283,7 @@ def test_issue_quart():
 
 
 def test_issue_5565():
-    raises(ValueError, lambda: m < s)
-    assert (m < km).is_Relational
+    assert (m < s).is_Relational
 
 
 def test_find_unit():
@@ -315,19 +314,6 @@ def test_Quantity_derivative():
     assert diff(x**3*meter**2, x) == 3*x**2*meter**2
     assert diff(meter, meter) == 1
     assert diff(meter**2, meter) == 2*meter
-
-
-def test_sum_of_incompatible_quantities():
-    raises(ValueError, lambda: meter + second)
-    raises(ValueError, lambda: 2 * meter + second)
-    raises(ValueError, lambda: 2 * meter + 3 * second)
-    raises(ValueError, lambda: 1 / second + 1 / meter)
-    raises(ValueError, lambda: 2 * meter*(mile + centimeter) + km)
-
-    expr = 2 * (mile + centimeter)/second + km/hour
-    assert expr in Basic._constructor_postprocessor_mapping
-    for i in expr.args:
-        assert i in Basic._constructor_postprocessor_mapping
 
 
 def test_quantity_postprocessing():

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -483,5 +483,7 @@ def test_issue_14547():
     assert Eq(log(foot), log(inch)) is not None  # might be False or unevaluated
 
     x = Symbol('x')
-    assert set((foot + 1).args) == set((foot, 1))
-    assert set((foot + x).args) == set((foot, x))
+    e = foot + x
+    assert e.is_Add and set(e.args) == {foot, x}
+    e = foot + 1
+    assert e.is_Add and set(e.args) == {foot, 1}

--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -318,7 +318,6 @@ def test_Quantity_derivative():
 
 
 def test_sum_of_incompatible_quantities():
-    raises(ValueError, lambda: meter + 1)
     raises(ValueError, lambda: meter + second)
     raises(ValueError, lambda: 2 * meter + second)
     raises(ValueError, lambda: 2 * meter + 3 * second)
@@ -461,5 +460,28 @@ def test_eval_subs():
     assert expr2.subs(units) == gravitational_constant*kilogram/meter**2
 
 
-def test_issue_14923():
+def test_issue_14932():
     assert (log(inch) - log(2)).simplify() == log(inch/2)
+    assert (log(inch) - log(foot)).simplify() == -log(12)
+    p = symbols('p', positive=True)
+    assert (log(inch) - log(p)).simplify() == log(inch/p)
+
+
+def test_issue_14547():
+    # the root issue is that an argument with dimensions should
+    # not raise an error when the the `arg - 1` calculation is
+    # performed in the assumptions system
+    from sympy.physics.units import foot, inch
+    from sympy import Eq
+    assert log(foot).is_zero is None
+    assert log(foot).is_positive is None
+    assert log(foot).is_nonnegative is None
+    assert log(foot).is_negative is None
+    assert log(foot).is_algebraic is None
+    assert log(foot).is_rational is None
+    # doesn't raise error
+    assert Eq(log(foot), log(inch)) is not None  # might be False or unevaluated
+
+    x = Symbol('x')
+    assert set((foot + 1).args) == set((foot, 1))
+    assert set((foot + x).args) == set((foot, x))

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -6,14 +6,17 @@ import warnings
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
-from sympy import Add, Mul, Pow, Tuple, pi, sin, sqrt, sstr, sympify
+from sympy import (Add, Mul, Pow, Tuple, pi, sin, sqrt, sstr, sympify,
+    symbols)
 from sympy.physics.units import (
     G, centimeter, coulomb, day, degree, gram, hbar, hour, inch, joule, kelvin,
     kilogram, kilometer, length, meter, mile, minute, newton, planck,
     planck_length, planck_mass, planck_temperature, planck_time, radians,
     second, speed_of_light, steradian, time)
 from sympy.physics.units.dimensions import dimsys_default
-from sympy.physics.units.util import convert_to, dim_simplify
+from sympy.physics.units.util import convert_to, dim_simplify, check_dimensions
+from sympy.utilities.pytest import raises
+
 
 
 def NS(e, n=15, **options):
@@ -146,3 +149,11 @@ def test_quantity_simplify():
     assert quantity_simplify(foot*inch*(foot*foot + inch*(foot + inch))) == foot**2*(foot**2 + inch*(foot + inch))/12
     assert quantity_simplify(2**(foot/inch*kilo/1000)*inch) == 4096*inch
     assert quantity_simplify(foot**2*inch + inch**2*foot) == 13*foot**3/144
+
+
+def test_check_dimensions():
+    x = symbols('x')
+    assert check_dimensions(inch + x) == inch + x
+    assert check_dimensions(length + x) == length + x
+    raises(ValueError, lambda: check_dimensions(inch + 1))
+    raises(ValueError, lambda: check_dimensions(length + 1))

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -155,5 +155,7 @@ def test_check_dimensions():
     x = symbols('x')
     assert check_dimensions(inch + x) == inch + x
     assert check_dimensions(length + x) == length + x
+    # after subs we get 2*length; check will clear the constant
+    assert check_dimensions((length + x).subs(x, length)) == length
     raises(ValueError, lambda: check_dimensions(inch + 1))
     raises(ValueError, lambda: check_dimensions(length + 1))

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -145,9 +145,9 @@ def test_quantity_simplify():
     x, y = symbols('x y')
 
     assert quantity_simplify(x*(8*kilo*newton*meter + y)) == x*(8000*meter*newton + y)
-    assert quantity_simplify(foot*inch*(foot + inch)) == foot**2*(foot + inch)/12
-    assert quantity_simplify(foot*inch*(foot*foot + inch*(foot + inch))) == foot**2*(foot**2 + inch*(foot + inch))/12
-    assert quantity_simplify(2**(foot/inch*kilo/1000)*inch) == 4096*inch
+    assert quantity_simplify(foot*inch*(foot + inch)) == foot**2*(foot + foot/12)/12
+    assert quantity_simplify(foot*inch*(foot*foot + inch*(foot + inch))) == foot**2*(foot**2 + foot/12*(foot + foot/12))/12
+    assert quantity_simplify(2**(foot/inch*kilo/1000)*inch) == 4096*foot/12
     assert quantity_simplify(foot**2*inch + inch**2*foot) == 13*foot**3/144
 
 

--- a/sympy/physics/units/tests/test_util.py
+++ b/sympy/physics/units/tests/test_util.py
@@ -12,7 +12,7 @@ from sympy.physics.units import (
     G, centimeter, coulomb, day, degree, gram, hbar, hour, inch, joule, kelvin,
     kilogram, kilometer, length, meter, mile, minute, newton, planck,
     planck_length, planck_mass, planck_temperature, planck_time, radians,
-    second, speed_of_light, steradian, time)
+    second, speed_of_light, steradian, time, km)
 from sympy.physics.units.dimensions import dimsys_default
 from sympy.physics.units.util import convert_to, dim_simplify, check_dimensions
 from sympy.utilities.pytest import raises
@@ -159,3 +159,9 @@ def test_check_dimensions():
     assert check_dimensions((length + x).subs(x, length)) == length
     raises(ValueError, lambda: check_dimensions(inch + 1))
     raises(ValueError, lambda: check_dimensions(length + 1))
+    raises(ValueError, lambda: check_dimensions(length + time))
+    raises(ValueError, lambda: check_dimensions(meter + second))
+    raises(ValueError, lambda: check_dimensions(2 * meter + second))
+    raises(ValueError, lambda: check_dimensions(2 * meter + 3 * second))
+    raises(ValueError, lambda: check_dimensions(1 / second + 1 / meter))
+    raises(ValueError, lambda: check_dimensions(2 * meter*(mile + centimeter) + km))

--- a/sympy/physics/units/util.py
+++ b/sympy/physics/units/util.py
@@ -174,3 +174,22 @@ def quantity_simplify(expr):
             new_quantities.append(Mul.fromiter((
                 (ref*b.scale_factor)**p for b, p in bp)))
     return coeff*Mul.fromiter(new_quantities)
+
+
+def check_dimensions(expr):
+    """Return expr if there are not unitless values added to
+    dimensional quantities, else raise a ValueError."""
+    from sympy.solvers.solveset import _term_factors
+    # the case of adding a number to a dimensional quantity
+    # is ignored for the sake of SymPy core routines, so this
+    # function will raise an error now if such an addend is
+    # found
+    adds = expr.atoms(Add)
+    for a in adds:
+        con = any(ai.is_number for ai in a.args)
+        for ai in _term_factors(a):
+            if isinstance(ai, Pow):
+                ai = ai.base
+            if isinstance(ai, (Quantity, Dimension)) and con:
+                raise ValueError('dimensional mismatch in addends')
+    return expr


### PR DESCRIPTION
Issue #14547 has, at its root, a dimensional quantity being subtracted from 1 to see how it compares to 1. This raises an error for dimensional mismatch of addends. 

Addition of numbers (and expressions containing free symbols) to quantities or dimensions is now ignored but can be tested with the added `check_dimensions` function.

closes #14886 by replacement
fixes #14547
fixes #14932 

Better unification of units with the `quantity_simplify` function is now given, too.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * checking for consistency of terms is no longer done at instantiation
  * `check_dimensions` was added to units/util.py to check expressions for dimensional consistency
  * `__radd__` and `__rmul__` are defined for Dimensions
  * `quantity_simplify` now reduces all Quantities in an Expr with the same Dimension to the same internally canonical Quantity
<!-- END RELEASE NOTES -->

TODO
- [x] see if `__rsub__` and `__rdiv__` need to be defined for Dimension
`__rsub__` is not needed because negation turns `-Dim` into `Dim`
- [x] keep sign of other when subtracting?
This is being left unchanged