### PR TITLE
Convert `list` arguments to `ImmutableDenseMatrix` for multivariate RVs

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -960,6 +960,7 @@ def test_sympy__sets__contains__Contains():
 
 
 from sympy.stats.crv_types import NormalDistribution
+from sympy.matrices import ImmutableMatrix
 nd = NormalDistribution(0, 1)
 from sympy.stats.frv_types import DieDistribution
 die = DieDistribution(6)
@@ -1458,16 +1459,22 @@ def test_sympy__stats__joint_rv__JointDistribution():
 
 def test_sympy__stats__joint_rv_types__MultivariateNormalDistribution():
     from sympy.stats.joint_rv_types import MultivariateNormalDistribution
-    assert _test_args(MultivariateNormalDistribution([0, 1], [[1, 0],[0, 1]]))
+    assert _test_args(
+        MultivariateNormalDistribution(ImmutableMatrix([0, 1]),
+         ImmutableMatrix([[1, 0],[0, 1]])))
 
 def test_sympy__stats__joint_rv_types__MultivariateLaplaceDistribution():
     from sympy.stats.joint_rv_types import MultivariateLaplaceDistribution
-    assert _test_args(MultivariateLaplaceDistribution([0, 1], [[1, 0],[0, 1]]))
+    assert _test_args(
+        MultivariateLaplaceDistribution(ImmutableMatrix([0, 1]),
+            ImmutableMatrix([[1, 0],[0, 1]])))
 
 
 def test_sympy__stats__joint_rv_types__MultivariateTDistribution():
     from sympy.stats.joint_rv_types import MultivariateTDistribution
-    assert _test_args(MultivariateTDistribution([0, 1], [[1, 0],[0, 1]], 1))
+    assert _test_args(MultivariateTDistribution(
+        ImmutableMatrix([0, 1]),
+        ImmutableMatrix([[1, 0],[0, 1]]), 1))
 
 
 def test_sympy__stats__joint_rv_types__NormalGammaDistribution():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -960,7 +960,6 @@ def test_sympy__sets__contains__Contains():
 
 
 from sympy.stats.crv_types import NormalDistribution
-from sympy.matrices import ImmutableMatrix
 nd = NormalDistribution(0, 1)
 from sympy.stats.frv_types import DieDistribution
 die = DieDistribution(6)
@@ -1460,21 +1459,16 @@ def test_sympy__stats__joint_rv__JointDistribution():
 def test_sympy__stats__joint_rv_types__MultivariateNormalDistribution():
     from sympy.stats.joint_rv_types import MultivariateNormalDistribution
     assert _test_args(
-        MultivariateNormalDistribution(ImmutableMatrix([0, 1]),
-         ImmutableMatrix([[1, 0],[0, 1]])))
+        MultivariateNormalDistribution([0, 1], [[1, 0],[0, 1]]))
 
 def test_sympy__stats__joint_rv_types__MultivariateLaplaceDistribution():
     from sympy.stats.joint_rv_types import MultivariateLaplaceDistribution
-    assert _test_args(
-        MultivariateLaplaceDistribution(ImmutableMatrix([0, 1]),
-            ImmutableMatrix([[1, 0],[0, 1]])))
+    assert _test_args(MultivariateLaplaceDistribution([0, 1], [[1, 0],[0, 1]]))
 
 
 def test_sympy__stats__joint_rv_types__MultivariateTDistribution():
     from sympy.stats.joint_rv_types import MultivariateTDistribution
-    assert _test_args(MultivariateTDistribution(
-        ImmutableMatrix([0, 1]),
-        ImmutableMatrix([[1, 0],[0, 1]]), 1))
+    assert _test_args(MultivariateTDistribution([0, 1], [[1, 0],[0, 1]], 1))
 
 
 def test_sympy__stats__joint_rv_types__NormalGammaDistribution():

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -18,8 +18,6 @@ from sympy.concrete.summations import Sum, summation
 from sympy.integrals.integrals import Integral, integrate
 from sympy.stats.rv import (ProductPSpace, NamedArgsMixin,
      ProductDomain, RandomSymbol)
-from sympy.core.containers import Tuple
-
 class JointPSpace(ProductPSpace):
     """
     Represents a joint probability space. Represented using symbols for
@@ -88,9 +86,6 @@ class JointDistribution(Basic, NamedArgsMixin):
 
     def __new__(cls, *args):
         args = list(map(sympify, args))
-        for i in range(len(args)):
-            if isinstance(args[i], list):
-                args[i] = Tuple.fromiter(j for j in args[i])
         return Basic.__new__(cls, *args)
 
     @property

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -18,6 +18,7 @@ from sympy.concrete.summations import Sum, summation
 from sympy.integrals.integrals import Integral, integrate
 from sympy.stats.rv import (ProductPSpace, NamedArgsMixin,
      ProductDomain, RandomSymbol)
+from sympy.matrices import ImmutableMatrix
 class JointPSpace(ProductPSpace):
     """
     Represents a joint probability space. Represented using symbols for
@@ -86,6 +87,9 @@ class JointDistribution(Basic, NamedArgsMixin):
 
     def __new__(cls, *args):
         args = list(map(sympify, args))
+        for i in range(len(args)):
+            if isinstance(args[i], list):
+                args[i] = ImmutableMatrix(args[i])
         return Basic.__new__(cls, *args)
 
     @property

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -13,10 +13,8 @@ from sympy.matrices.expressions.determinant import det
 def multivariate_rv(cls, sym, *args):
     sym = sympify(sym)
     args = list(map(sympify, args))
-    for i in range(len(args)):
-        if isinstance(args[i], list):
-            args[i] = ImmutableMatrix(args[i])
     dist = cls(*args)
+    args = dist.args
     dist.check(*args)
     return JointPSpace(sym, dist).value
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,7 +1,7 @@
 from sympy import sympify, S, pi, sqrt, exp, Lambda, Indexed, Symbol, Gt
 from sympy.stats.rv import _value_check
 from sympy.stats.joint_rv import JointDistribution, JointPSpace
-from sympy.matrices.dense import Matrix
+from sympy.matrices import ImmutableMatrix
 from sympy.matrices.expressions.determinant import det
 
 # __all__ = ['MultivariateNormal',
@@ -13,6 +13,9 @@ from sympy.matrices.expressions.determinant import det
 def multivariate_rv(cls, sym, *args):
     sym = sympify(sym)
     args = list(map(sympify, args))
+    for i in range(len(args)):
+        if isinstance(args[i], list):
+            args[i] = ImmutableMatrix(args[i])
     dist = cls(*args)
     dist.check(*args)
     return JointPSpace(sym, dist).value
@@ -31,7 +34,6 @@ class MultivariateNormalDistribution(JointDistribution):
         return S.Reals**k
 
     def check(self, mu, sigma):
-        mu, sigma = Matrix([mu]), Matrix(sigma)
         _value_check(len(mu) == len(sigma.col(0)),
             "Size of the mean vector and covariance matrix are incorrect.")
         #check if covariance matrix is positive definite or not.
@@ -39,23 +41,23 @@ class MultivariateNormalDistribution(JointDistribution):
             "The covariance matrix must be positive definite. ")
 
     def pdf(self, *args):
-        mu, sigma = Matrix(self.mu), Matrix(self.sigma)
+        mu, sigma = self.mu, self.sigma
         k = len(mu)
-        args = Matrix(args)
+        args = ImmutableMatrix(args)
         x = args - mu
         return  S(1)/sqrt((2*pi)**(k)*det(sigma))*exp(
             -S(1)/2*x.transpose()*(sigma.inv()*\
                 x))[0]
 
     def marginal_distribution(self, indices, sym):
-        sym = Matrix([Symbol(str(Indexed(sym, i))) for i in indices])
-        _mu, _sigma = Matrix(self.mu), Matrix(self.sigma)
+        sym = ImmutableMatrix([Symbol(str(Indexed(sym, i))) for i in indices])
+        _mu, _sigma = self.mu, self.sigma
         k = len(self.mu)
         for i in range(k):
             if i not in indices:
-                _mu.row_del(i)
-                _sigma.col_del(i)
-                _sigma.row_del(i)
+                _mu = _mu.row_del(i)
+                _sigma = _sigma.col_del(i)
+                _sigma = _sigma.row_del(i)
         return Lambda(sym, S(1)/sqrt((2*pi)**(len(_mu))*det(_sigma))*exp(
             -S(1)/2*(_mu - sym).transpose()*(_sigma.inv()*\
                 (_mu - sym)))[0])
@@ -73,7 +75,6 @@ class MultivariateLaplaceDistribution(JointDistribution):
         return S.Reals**k
 
     def check(self, mu, sigma):
-        mu, sigma = Matrix([mu]), Matrix(sigma)
         _value_check(len(mu) == len(sigma.col(0)),
             "Size of the mean vector and covariance matrix are incorrect.")
         #check if covariance matrix is positive definite or not.
@@ -82,11 +83,11 @@ class MultivariateLaplaceDistribution(JointDistribution):
 
     def pdf(self, *args):
         from sympy.functions.special.bessel import besselk
-        mu, sigma = Matrix(self.mu), Matrix(self.sigma)
+        mu, sigma = self.mu, self.sigma
         mu_T = mu.transpose()
         k = S(len(mu))
         sigma_inv = sigma.inv()
-        args = Matrix(args)
+        args = ImmutableMatrix(args)
         args_T = args.transpose()
         x = (mu_T*sigma_inv*mu)[0]
         y = (args_T*sigma_inv*args)[0]
@@ -109,7 +110,6 @@ class MultivariateTDistribution(JointDistribution):
         return S.Reals**k
 
     def check(self, mu, sigma, v):
-        mu, sigma = Matrix([mu]), Matrix(sigma)
         _value_check(len(mu) == len(sigma.col(0)),
             "Size of the location vector and shape matrix are incorrect.")
         #check if covariance matrix is positive definite or not.
@@ -118,11 +118,11 @@ class MultivariateTDistribution(JointDistribution):
 
     def pdf(self, *args):
         from sympy.functions.special.gamma_functions import gamma
-        mu, sigma = Matrix(self.mu), Matrix(self.shape_mat)
+        mu, sigma = self.mu, self.shape_mat
         v = S(self.dof)
         k = S(len(mu))
         sigma_inv = sigma.inv()
-        args = Matrix(args)
+        args = ImmutableMatrix(args)
         x = args - mu
         return gamma((k + v)/2)/(gamma(v/2)*(v*pi)**(k/2)*sqrt(det(sigma)))\
         *(1 + 1/v*(x.transpose()*sigma_inv*x)[0])**((-v - k)/2)


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #14929 

#### Brief description of what is fixed or changed
Arguments of type `list` for Multivariate distributions are converted to `ImmutableDenseMatrix` before
the object is returned.

#### Other comments
