### PR TITLE
modified experimental_lamdify.py to fix UserWarning error in plot3d and added tests

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -116,6 +116,8 @@ class vectorized_lambdify(object):
         np_old_err = np.seterr(invalid='raise')
         try:
             temp_args = (np.array(a, dtype=np.complex) for a in args)
+            self.lambda_func = experimental_lambdify(self.args, self.expr, use_evalf=True, complex_wrap_evalf=True)
+            self.vector_func = np.vectorize(self.lambda_func, otypes=[np.complex])
             results = self.vector_func(*temp_args)
             results = np.ma.masked_where(
                                 np.abs(results.imag) > 1e-7 * np.abs(results),

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -11,7 +11,7 @@ from sympy.external import import_module
 from tempfile import NamedTemporaryFile
 import os
 import warnings
-
+import sympy
 unset_show()
 
 
@@ -189,6 +189,17 @@ def plot_and_save(name):
 
     # Multiple Contour plots with different range.
     p = plot_contour((x**2 + y**2, (x, -5, 5), (y, -5, 5)), (x**3 + y**3, (x, -3, 3), (y, -3, 3)))
+    p.save(tmp_file('%s_contour_plot' % name))
+    p._backend.close()
+
+    # __call__ method from vectorised lamdify.py file. Tests for issue #10612
+    p = plot3d(sympy.atan2(y, x), (x, -1, 1), (y, -1, 1))
+    p.save(tmp_file('%s_contour_plot' % name))
+    p._backend.close()
+    p = plot3d(sympy.atan2(y ** 2, x ** 2), (x, -2, 2), (y, -2, 2))
+    p.save(tmp_file('%s_contour_plot' % name))
+    p._backend.close()
+    p = plot3d(sympy.atan2(cos(y), sin(x)), (x, -2, 2), (y, -2, 2))
     p.save(tmp_file('%s_contour_plot' % name))
     p._backend.close()
 


### PR DESCRIPTION
Modified `experimental_lamdify.py` to fix `UserWarning` error and added tests in `test_plot.py`.

Fixes #10612
Closes #10811

Earlier
on running this command
```
import sympy as sym
from sympy.plotting import plot3d
x, y = sym.symbols("x y")
plot3d(sym.atan2(y, x), (x, -1, 1), (y, -1, 1))
```

this was the associated message in the terminal (with the correct output)
```
C:\Python27\lib\site-packages\sympy\plotting\experimental_lambdify.py:165:
UserWarning: The evaluation of the expression is problematic. We are trying
a failback method that may still work. Please report this as a bug.
```

This PR fixes the associated `UserWarning` error message.
Also, tests have been added in `test_plot.py`.

Note: I have taken reviews from #10811 by @debugger22  and @asmeurer . Since this (#10811) PR was open since a long time and there was no ongoing activity, I decided to take it up.

Please review this PR and let me know the improvements. Thanks