### PR TITLE
Minor fix in `ContinuousRV`

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -134,7 +134,8 @@ def ContinuousRV(symbol, density, set=Interval(-oo, oo)):
     >>> P(X>0)
     1/2
     """
-    pdf = Lambda(symbol, density)
+    pdf = Piecewise((density, set.as_relational(symbol)), (0, True))
+    pdf = Lambda(symbol, pdf)
     dist = ContinuousDistributionHandmade(pdf, set)
     return SingleContinuousPSpace(symbol, dist).value
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -165,6 +165,7 @@ def test_sample():
     assert sample(Z) in Z.pspace.domain.set
     sym, val = list(Z.pspace.sample().items())[0]
     assert sym == Z and val in Interval(0, oo)
+    assert density(Z)(-1) == 0
 
 
 def test_ContinuousRV():


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
`ContinuousRV` assumed the PDF provided by the user to be true for the
entire real line, regardless of the `set` given. This is now fixed.

#### Other comments
The same problem still persists for Discrete random variables, but piecewise is unable to handle discrete sets as of now.