### PR TITLE
limit(sqrt(x)*cos(x - x**2) / (x + 1), x, oo) causes recursion error

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -97,6 +97,21 @@ def heuristics(e, z, z0, dir):
                 r.append(l)
         if r:
             rv = e.func(*r)
+            from sympy.calculus.util import AccumBounds
+            if rv is S.NaN and e.is_Mul and any(isinstance(rr, AccumBounds) for rr in r):
+                r2 = []
+                e2 = []
+                for ii in range(len(r)):
+                    if isinstance(r[ii], AccumBounds):
+                        r2.append(r[ii])
+                    else:
+                        e2.append(e.args[ii])
+
+                if len(e2) > 0:
+                    e3 = Mul(*e2).simplify()
+                    l = limit(e3, z, z0, dir)
+                    rv = l * Mul(*r2)
+
             if rv is S.NaN:
                 try:
                     rat_e = ratsimp(e)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -69,6 +69,7 @@ def limit(e, z, z0, dir="+"):
 
 
 def heuristics(e, z, z0, dir):
+    from sympy.calculus.util import AccumBounds
     rv = None
     if abs(z0) is S.Infinity:
         rv = limit(e.subs(z, 1/z), z, S.Zero, "+" if z0 is S.Infinity else "-")
@@ -97,7 +98,6 @@ def heuristics(e, z, z0, dir):
                 r.append(l)
         if r:
             rv = e.func(*r)
-            from sympy.calculus.util import AccumBounds
             if rv is S.NaN and e.is_Mul and any(isinstance(rr, AccumBounds) for rr in r):
                 r2 = []
                 e2 = []

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -532,3 +532,6 @@ def test_issue_14456():
 
 def test_issue_14411():
     assert limit(3*sec(4*pi*x - x/3), x, 3*pi/(24*pi - 2)) == -oo
+
+def test_issue_14574():
+    assert limit(sqrt(x)*cos(x - x**2) / (x + 1), x, oo) == 0


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes  #14574 

#### Brief description of what is fixed or changed

`limit(sqrt(x)*cos(x - x**2) / (x + 1), x, oo)` causes recursion error. I noticed
that `heuristics()` in `limits.py` was not able to find the result.
After a change of variable, i.e. `x -> 1/x`, `heuristics()` calculates the limits
of each of the three factors and put them in the list `r`. At the end,
`r = [0, oo, AccumBounds(-1,1)]` and in this way the code `rv = e.func(*r)` returns
`S.Nan`.

My idea is to separate the factors of type `AccumBounds`, collected in `r2`, from the others,
collected in `e2`. Then calculate the limit for the expression obtained by the product
of elements of `e2` and finally try to resolve the original limit.

#### Other comments

A test was added.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * added a heuristic method for solving indefinite forms in limits 

<!-- END RELEASE NOTES -->



