### PR TITLE
Add dtype to matrix __array__ method for numpy

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1899,9 +1899,9 @@ class MatrixBase(MatrixDeprecated,
 
     __hash__ = None  # Mutable
 
-    def __array__(self):
+    def __array__(self, dtype=object):
         from .dense import matrix2numpy
-        return matrix2numpy(self)
+        return matrix2numpy(self, dtype=dtype)
 
     def __getattr__(self, attr):
         if attr in ('diff', 'integrate', 'limit'):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3117,3 +3117,13 @@ def test_issue_14517():
     # test one random eigenvalue, the computation is a little slow
     test_ev = random.choice(list(ev.keys()))
     assert (M - test_ev*eye(4)).det() == 0
+
+def test_issue_14943():
+    # Test that __array__ accepts the optional dtype argument
+    try:
+        from numpy import array
+    except ImportError:
+        skip('NumPy must be available to test creating matrices from ndarrays')
+
+    M = Matrix([[1,2], [3,4]])
+    assert len(array(M, dtype=float)) == 2

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3126,4 +3126,4 @@ def test_issue_14943():
         skip('NumPy must be available to test creating matrices from ndarrays')
 
     M = Matrix([[1,2], [3,4]])
-    assert len(array(M, dtype=float)) == 2
+    assert array(M, dtype=float).dtype.name == 'float64'


### PR DESCRIPTION
Added dtype as an optional argument to `__array__` for matrices for use by numpy

Fixes #14943


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * fixed `np.array(Matrix(...), dtype=float)`
<!-- END RELEASE NOTES -->
