### PR TITLE
inverse laplace and mellin transforms missing 2*pi*I

### DIFF
--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -48,7 +48,7 @@ def test_as_integral():
         Integral(f(x)*exp(-s*x), (x, 0, oo))
     assert str(inverse_mellin_transform(f(s), s, x, (a, b)).rewrite('Integral')) \
         == "Integral(x**(-s)*f(s), (s, _c - oo*I, _c + oo*I))"
-    assert str(inverse_laplace_transform(f(s), s, x).rewrite('Integral')) == \
+    assert str(2*pi*I*inverse_laplace_transform(f(s), s, x).rewrite('Integral')) == \
         "Integral(f(s)*exp(s*x), (s, _c - oo*I, _c + oo*I))"
     assert inverse_fourier_transform(f(s), s, x).rewrite('Integral') == \
         Integral(f(s)*exp(2*I*pi*s*x), (s, -oo, oo))

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -46,7 +46,7 @@ def test_as_integral():
         Integral(f(x)*exp(-2*I*pi*s*x), (x, -oo, oo))
     assert laplace_transform(f(x), x, s).rewrite('Integral') == \
         Integral(f(x)*exp(-s*x), (x, 0, oo))
-    assert str(inverse_mellin_transform(f(s), s, x, (a, b)).rewrite('Integral')) \
+    assert str(2*pi*I*inverse_mellin_transform(f(s), s, x, (a, b)).rewrite('Integral')) \
         == "Integral(x**(-s)*f(s), (s, _c - oo*I, _c + oo*I))"
     assert str(2*pi*I*inverse_laplace_transform(f(s), s, x).rewrite('Integral')) == \
         "Integral(f(s)*exp(s*x), (s, _c - oo*I, _c + oo*I))"

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1234,14 +1234,14 @@ class InverseLaplaceTransform(IntegralTransform):
     def _as_integral(self, F, s, t):
         from sympy import I, exp
         c = self.__class__._c
-        return Integral(exp(s*t)*F, (s, c - I*oo, c + I*oo))
+        return Integral(exp(s*t)*F, (s, c - I*oo, c + I*oo))/(2*S.Pi*S.ImaginaryUnit)
 
 
 def inverse_laplace_transform(F, s, t, plane=None, **hints):
     r"""
     Compute the inverse Laplace transform of `F(s)`, defined as
 
-    .. math :: f(t) = \int_{c-i\infty}^{c+i\infty} e^{st} F(s) \mathrm{d}s,
+    .. math :: f(t) = \frac{1}{2\pi i} \int_{c-i\infty}^{c+i\infty} e^{st} F(s) \mathrm{d}s,
 
     for `c` so large that `F(s)` has no singularites in the
     half-plane `\operatorname{Re}(s) > c-\epsilon`.

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -809,7 +809,7 @@ class InverseMellinTransform(IntegralTransform):
     def _as_integral(self, F, s, x):
         from sympy import I
         c = self.__class__._c
-        return Integral(F*x**(-s), (s, c - I*oo, c + I*oo))
+        return Integral(F*x**(-s), (s, c - I*oo, c + I*oo))/(2*S.Pi*S.ImaginaryUnit)
 
 
 def inverse_mellin_transform(F, s, x, strip, **hints):
@@ -819,7 +819,7 @@ def inverse_mellin_transform(F, s, x, strip, **hints):
 
     This can be defined as
 
-    .. math:: f(x) = \int_{c - i\infty}^{c + i\infty} x^{-s} F(s) \mathrm{d}s,
+    .. math:: f(x) = \frac{1}{2\pi i} \int_{c - i\infty}^{c + i\infty} x^{-s} F(s) \mathrm{d}s,
 
     for any `c` in the fundamental strip. Under certain regularity
     conditions on `F` and/or `f`,


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Fixes bug #14946, missing factor of `2*pi*I` in some inverse integral transforms.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fix missing factor of `2*pi*I` in inverse Laplace and Mellin transforms.
<!-- END RELEASE NOTES -->
