### PR TITLE
Fix docstring section headers

### DIFF
--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -142,13 +142,13 @@ def _mk_Tuple(args):
     Create a Sympy Tuple object from an iterable, converting Python strings to
     AST strings.
 
-    Parameters:
-    ===========
+    Parameters
+    ==========
     args: iterable
         Arguments to :class:`sympy.Tuple`.
 
-    Returns:
-    ========
+    Returns
+    =======
     sympy.Tuple
     """
     args = [String(arg) if isinstance(arg, string_types) else arg for arg in args]
@@ -308,8 +308,8 @@ class Token(Basic):
     def kwargs(self, exclude=(), apply=None):
         """ Get instance's attributes as dict of keyword arguments.
 
-        Parameters:
-        ===========
+        Parameters
+        ==========
         exclude : collection of str
             Collection of keywords to exclude.
 

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -815,8 +815,8 @@ def best_origin(a, b, lineseg, expr):
     def x_axis_cut(ls):
         """Returns the point where the input line segment
         intersects the x-axis.
-        Parameters:
-        ===========
+        Parameters
+        ==========
         ls : Line segment
         """
         p, q = ls.points
@@ -832,8 +832,8 @@ def best_origin(a, b, lineseg, expr):
     def y_axis_cut(ls):
         """Returns the point where the input line segment
         intersects the y-axis.
-        Parameters:
-        ===========
+        Parameters
+        ==========
         ls : Line segment
         """
         p, q = ls.points
@@ -926,8 +926,8 @@ def decompose(expr, separate=False):
     ==========
     expr : Polynomial(SymPy expression)
 
-    Optional Parameters :
-    ---------------------
+    Optional Parameters:
+    --------------------
     separate : If True then simply return a list of the constituent monomials
                If not then break up the polynomial into constituent homogeneous
                polynomials.

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -806,8 +806,8 @@ def convert_equals_signs(result, local_dict, global_dict):
     ========
     convert_equality_operators
 
-    Examples:
-    =========
+    Examples
+    ========
 
     >>> from sympy.parsing.sympy_parser import (parse_expr,
     ... standard_transformations, convert_equals_signs)

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -267,7 +267,7 @@ def fidelity(state1, state2):
     The arguments provided to this function should be a square matrix or a
     Density object. If it is a square matrix, it is assumed to be diagonalizable.
 
-    Parameters:
+    Parameters
     ==========
 
     state1, state2 : a density matrix or Matrix

--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -275,7 +275,7 @@ def rational_interpolate(data, degnum, X=symbols('x')):
     function. Setting it too high will decrease the maximal degree in the
     denominator for the same amount of data.
 
-    Example:
+    Examples
     ========
     >>> from sympy.polys.polyfuncs import rational_interpolate
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3282,13 +3282,13 @@ class Poly(Expr):
 
         For real roots the Vincent-Akritas-Strzebonski (VAS) continued fractions method is used.
 
-        References:
-        ===========
-           1. Alkiviadis G. Akritas and Adam W. Strzebonski: A Comparative Study of Two Real Root
-           Isolation Methods . Nonlinear Analysis: Modelling and Control, Vol. 10, No. 4, 297-304, 2005.
-           2. Alkiviadis G. Akritas, Adam W. Strzebonski and Panagiotis S. Vigklas: Improving the
-           Performance of the Continued Fractions Method Using new Bounds of Positive Roots. Nonlinear
-           Analysis: Modelling and Control, Vol. 13, No. 3, 265-279, 2008.
+        References
+        ==========
+        .. [#] Alkiviadis G. Akritas and Adam W. Strzebonski: A Comparative Study of Two Real Root
+            Isolation Methods . Nonlinear Analysis: Modelling and Control, Vol. 10, No. 4, 297-304, 2005.
+        .. [#] Alkiviadis G. Akritas, Adam W. Strzebonski and Panagiotis S. Vigklas: Improving the
+            Performance of the Continued Fractions Method Using new Bounds of Positive Roots. Nonlinear
+            Analysis: Modelling and Control, Vol. 13, No. 3, 265-279, 2008.
 
         Examples
         ========

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -75,11 +75,11 @@ def dup_root_upper_bound(f, K):
     """Compute the LMQ upper bound for the positive roots of `f`;
        LMQ (Local Max Quadratic) was developed by Akritas-Strzebonski-Vigklas.
 
-       Reference:
-       ==========
-       Alkiviadis G. Akritas: "Linear and Quadratic Complexity Bounds on the
-           Values of the Positive Roots of Polynomials"
-           Journal of Universal Computer Science, Vol. 15, No. 3, 523-537, 2009.
+    References
+    ==========
+    .. [#] Alkiviadis G. Akritas: "Linear and Quadratic Complexity Bounds on the
+        Values of the Positive Roots of Polynomials"
+        Journal of Universal Computer Science, Vol. 15, No. 3, 523-537, 2009.
     """
     n, P = len(f), []
     t = n * [K.one]
@@ -119,7 +119,7 @@ def dup_root_lower_bound(f, K):
     """Compute the LMQ lower bound for the positive roots of `f`;
        LMQ (Local Max Quadratic) was developed by Akritas-Strzebonski-Vigklas.
 
-       Reference:
+       References
        ==========
        Alkiviadis G. Akritas: "Linear and Quadratic Complexity Bounds on the
            Values of the Positive Roots of Polynomials"
@@ -290,8 +290,8 @@ def dup_refine_real_root(f, s, t, K, eps=None, steps=None, disjoint=None, fast=F
 def dup_inner_isolate_real_roots(f, K, eps=None, fast=False):
     """Internal function for isolation positive roots up to given precision.
 
-       References:
-       ===========
+       References
+       ==========
            1. Alkiviadis G. Akritas and Adam W. Strzebonski: A Comparative Study of Two Real Root
            Isolation Methods . Nonlinear Analysis: Modelling and Control, Vol. 10, No. 4, 297-304, 2005.
            2. Alkiviadis G. Akritas, Adam W. Strzebonski and Panagiotis S. Vigklas: Improving the
@@ -490,8 +490,8 @@ def _isolate_zero(f, K, inf, sup, basis=False, sqf=False):
 def dup_isolate_real_roots_sqf(f, K, eps=None, inf=None, sup=None, fast=False, blackbox=False):
     """Isolate real roots of a square-free polynomial using the Vincent-Akritas-Strzebonski (VAS) CF approach.
 
-       References:
-       ===========
+       References
+       ==========
        1. Alkiviadis G. Akritas and Adam W. Strzebonski: A Comparative Study of Two Real Root Isolation Methods.
        Nonlinear Analysis: Modelling and Control, Vol. 10, No. 4, 297-304, 2005.
        2. Alkiviadis G. Akritas, Adam W. Strzebonski and Panagiotis S. Vigklas: Improving the Performance
@@ -521,8 +521,8 @@ def dup_isolate_real_roots_sqf(f, K, eps=None, inf=None, sup=None, fast=False, b
 def dup_isolate_real_roots(f, K, eps=None, inf=None, sup=None, basis=False, fast=False):
     """Isolate real roots using Vincent-Akritas-Strzebonski (VAS) continued fractions approach.
 
-       References:
-       ===========
+       References
+       ==========
        1. Alkiviadis G. Akritas and Adam W. Strzebonski: A Comparative Study of Two Real Root Isolation Methods.
        Nonlinear Analysis: Modelling and Control, Vol. 10, No. 4, 297-304, 2005.
        2. Alkiviadis G. Akritas, Adam W. Strzebonski and Panagiotis S. Vigklas: Improving the Performance
@@ -558,8 +558,8 @@ def dup_isolate_real_roots(f, K, eps=None, inf=None, sup=None, basis=False, fast
 def dup_isolate_real_roots_list(polys, K, eps=None, inf=None, sup=None, strict=False, basis=False, fast=False):
     """Isolate real roots of a list of square-free polynomial using Vincent-Akritas-Strzebonski (VAS) CF approach.
 
-       References:
-       ===========
+       References
+       ==========
        1. Alkiviadis G. Akritas and Adam W. Strzebonski: A Comparative Study of Two Real Root Isolation Methods.
        Nonlinear Analysis: Modelling and Control, Vol. 10, No. 4, 297-304, 2005.
        2. Alkiviadis G. Akritas, Adam W. Strzebonski and Panagiotis S. Vigklas: Improving the Performance

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -239,8 +239,8 @@ def sylvester(f, g, x, method = 1):
       Applications of these Matrices can be found in the references below.
       Especially, for applications of sylvester2, see the first reference!!
 
-      References:
-      ===========
+      References
+      ==========
       1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On a Theorem
       by Van Vleck Regarding Sturm Sequences. Serdica Journal of Computing,
       Vol. 7, No 4, 101–134, 2013.
@@ -364,8 +364,8 @@ def bezout(p, q, x, method='bz'):
 
     where backward_eye() is the backward identity function.
 
-    References:
-    ===========
+    References
+    ==========
     1. G.M.Diaz-Toca,L.Gonzalez-Vega: Various New Expressions for Subresultants
     and Their Applications. Appl. Algebra in Engin., Communic. and Comp.,
     Vol. 15, 233–266, 2004.
@@ -480,8 +480,8 @@ def subresultants_bezout(p, q, x):
     If the subresultant prs is complete, then the output coincides
     with the Euclidean sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. G.M.Diaz-Toca,L.Gonzalez-Vega: Various New Expressions for Subresultants
     and Their Applications. Appl. Algebra in Engin., Communic. and Comp.,
     Vol. 15, 233–266, 2004.
@@ -551,8 +551,8 @@ def modified_subresultants_bezout(p, q, x):
     If the modified subresultant prs is complete, and LC( p ) > 0, the output
     coincides with the (generalized) Sturm's sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
     and Modified Subresultant Polynomial Remainder Sequences.''
     Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
@@ -643,8 +643,8 @@ def sturm_pg(p, q, x, method=0):
     subresultants with the help of the Pell-Gordon Theorem of 1917.
     See also the function euclid_pg(p, q, x).
 
-    References:
-    ===========
+    References
+    ==========
     1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
     the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
@@ -753,8 +753,8 @@ def sturm_q(p, q, x):
 
         (b) the subresultant prs (reference 3).
 
-    References:
-    ===========
+    References
+    ==========
     1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
     the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
@@ -853,8 +853,8 @@ def sturm_amv(p, q, x, method=0):
     Abs( LC(p)**( deg(p)- deg(q)) ) to make them modified subresultants.
     See also the function sturm_pg(p, q, x).
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
@@ -940,8 +940,8 @@ def euclid_pg(p, q, x):
     see Lemma 1 in the 1st reference or Theorem 3 in the 2nd reference as well as
     the function sturm_pg(p, q, x).
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
@@ -1008,8 +1008,8 @@ def euclid_q(p, q, x):
 
         (b) the subresultant polynomial remainder sequence (references 3).
 
-    References:
-    ===========
+    References
+    ==========
     1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
     the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
@@ -1092,8 +1092,8 @@ def euclid_amv(f, g, x):
     computed this way become subresultants with the help of the
     Collins-Brown-Traub formula for coefficient reduction.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
@@ -1165,8 +1165,8 @@ def modified_subresultants_pg(p, q, x):
     If the ``modified'' subresultant prs is complete, and LC( p ) > 0, it coincides
     with the (generalized) Sturm sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. Pell A. J., R. L. Gordon. The Modified Remainders Obtained in Finding
     the Highest Common Factor of Two Polynomials. Annals of MatheMatics,
     Second Series, 18 (1917), No. 4, 188–193.
@@ -1350,8 +1350,8 @@ def subresultants_pg(p, q, x):
     If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders
     Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
     Serdica Journal of Computing, to appear.
@@ -1415,8 +1415,8 @@ def subresultants_amv_q(p, q, x):
     If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
@@ -1538,8 +1538,8 @@ def rem_z(p, q, x):
     Sturmian prs of p, q, on one hand, and the subresultant prs of p, q,
     on the other.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``On the Remainders
     Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
     Serdica Journal of Computing, to appear.
@@ -1593,8 +1593,8 @@ def subresultants_amv(f, g, x):
     If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``A Basic Result
     on the Theory of Subresultants.'' Submitted for publication.
 
@@ -1733,8 +1733,8 @@ def modified_subresultants_amv(p, q, x):
     If the modified subresultant prs is complete, and LC( p ) > 0, it coincides
     with the (generalized) Sturm's sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ‘‘On the Remainders
     Obtained in Finding the Greatest Common Divisor of Two Polynomials.''
     Serdica Journal of Computing, to appear.
@@ -1798,8 +1798,8 @@ def correct_sign(deg_f, deg_g, s1, rdel, cdel):
     it is the number of columns to be deleted --- starting with the last column
     forming the square matrix --- from the matrix resulting after the row deletions.
 
-    References:
-    ===========
+    References
+    ==========
     Akritas, A. G., G.I. Malaschonok and P.S. Vigklas: ``Sturm Sequences
     and Modified Subresultant Polynomial Remainder Sequences.''
     Serdica Journal of Computing, Vol. 8, No 1, 29–46, 2014.
@@ -1845,8 +1845,8 @@ def subresultants_rem(p, q, x):
     If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G.:``Three New Methods for Computing Subresultant
     Polynomial Remainder Sequences (PRS’s).'' Serdica Journal of Computing,
     to appear.
@@ -1905,8 +1905,8 @@ def pivot(M, i, j):
     be zeroed, if they are not already 0, according to
     Dodgson-Bareiss' integer preserving transformations.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G.: ``A new method for computing polynomial greatest
     common divisors and polynomial remainder sequences.''
     Numerische MatheMatik 52, 119-127, 1988.
@@ -2078,8 +2078,8 @@ def subresultants_vv(p, q, x, method = 0):
             of the last rows in s2 will remain unprocessed;
         (b) if deg(p) - deg(q) == 0, p will not appear in the final matrix.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G.: ``A new method for computing polynomial greatest
     common divisors and polynomial remainder sequences.''
     Numerische MatheMatik 52, 119-127, 1988.
@@ -2218,8 +2218,8 @@ def subresultants_vv_2(p, q, x):
     If the subresultant prs is complete, then it coincides with the
     Euclidean sequence of the polynomials p, q.
 
-    References:
-    ===========
+    References
+    ==========
     1. Akritas, A. G.: ``A new method for computing polynomial greatest
     common divisors and polynomial remainder sequences.''
     Numerische MatheMatik 52, 119-127, 1988.

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -131,19 +131,19 @@ def marginal_distribution(rv, *indices):
     """
     Marginal distribution function of a joint random variable.
 
-    Parameters:
+    Parameters
     ==========
 
     rv: A random variable with a joint probability distribution.
     indices: component indices or the indexed random symbol
         for whom the joint distribution is to be calculated
 
-    Returns:
+    Returns
     =======
     A Lambda expression n `sym`.
 
-    Example:
-    =======
+    Examples
+    ========
     >>> from sympy.stats.crv_types import Normal
     >>> from sympy.stats.joint_rv import marginal_distribution
     >>> m = Normal('X', [1, 2], [[2, 1], [1, 2]])

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -129,7 +129,7 @@ def MultivariateT(syms, mu, sigma, v):
     """
     Creates a joint random variable with multivariate T-distribution.
 
-    Parameters:
+    Parameters
     ==========
 
     syms: list/tuple/set of symbols for identifying each component
@@ -137,7 +137,7 @@ def MultivariateT(syms, mu, sigma, v):
         dimensional location vector
     sigma: The shape matrix for the distribution
 
-    Returns:
+    Returns
     =======
 
     A random symbol
@@ -194,7 +194,7 @@ def NormalGamma(syms, mu, lamda, alpha, beta):
     Creates a bivariate joint random variable with multivariate Normal gamma
     distribution.
 
-    Parameters:
+    Parameters
     ==========
 
     syms: list/tuple/set of two symbols for identifying each component
@@ -203,7 +203,7 @@ def NormalGamma(syms, mu, lamda, alpha, beta):
     beta: a positive integer
     lamda: a positive integer
 
-    Returns:
+    Returns
     =======
 
     A random symbol

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -29,7 +29,7 @@ def _unique_and_repeated(inds):
     Returns the unique and repeated indices. Also note, from the examples given below
     that the order of indices is maintained as given in the input.
 
-    Examples :
+    Examples
     ========
 
     >>> from sympy.tensor.index_methods import _unique_and_repeated
@@ -52,7 +52,7 @@ def _remove_repeated(inds):
     Returns a set of the unique objects and a tuple of all that have been
     removed.
 
-    Examples :
+    Examples
     ========
 
     >>> from sympy.tensor.index_methods import _remove_repeated


### PR DESCRIPTION
Realized that I had been writing section headers in Numpy-style docstrings with a trailing semicolon, and that the Napoleon Sphinx extension does not recognize these. Corrected them in my code and also did a global find-and-replace, which fixed a few other instances. These were specifically in the "Parameters," "Returns," "Examples," and "References" sections.


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->