### PR TITLE
Clean up Theano printer, add comments and docstrings

### DIFF
--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -103,12 +103,12 @@ compiled using the Theano compiler chain.
     >>> expr = sin(x)/x
 
     >>> from sympy.printing.theanocode import theano_function
-    >>> f = theano_function([x], [expr])
+    >>> f = theano_function([x], expr)
 
 If array broadcasting or types are desired then Theano requires this extra
 information
 
-    >>> f = theano_function([x], [expr], dims={x: 1}, dtypes={x: 'float64'})
+    >>> f = theano_function([x], expr, dims={x: 1}, dtypes={x: 'float64'})
 
 Theano has a more sophisticated code generation system than SymPy's C/Fortran
 code printers.  Among other things it handles common sub-expressions and

--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -365,6 +365,8 @@ Theano Code printing
 
    .. autoattribute:: TheanoPrinter.printmethod
 
+.. autofunction:: sympy.printing.theanocode.theano_code
+
 .. autofunction:: sympy.printing.theanocode.theano_function
 
 Gtk

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -1,8 +1,16 @@
+"""
+Important note on tests in this module - the Theano printing functions use a
+global cache by default, which means that tests using it will modify global
+state and thus not be independent from each other. Instead of using the "cache"
+keyword argument each time, this module uses the theano_code_ and
+theano_function_ functions defined below which default to using a new, empty
+cache instead.
+"""
+
 import logging
 
 from sympy.external import import_module
 from sympy.utilities.pytest import raises, SKIP
-from sympy.core.compatibility import range
 
 theanologger = logging.getLogger('theano.configdefaults')
 theanologger.setLevel(logging.CRITICAL)
@@ -15,26 +23,66 @@ if theano:
     ts = theano.scalar
     tt = theano.tensor
     xt, yt, zt = [tt.scalar(name, 'floatX') for name in 'xyz']
+    Xt, Yt, Zt = [tt.tensor('floatX', (False, False), name=n) for n in 'XYZ']
 else:
     #bin/test will not execute any tests now
     disabled = True
 
-import sympy
+import sympy as sy
 from sympy import S
-sy = sympy
-from sympy.abc import x, y, z
+from sympy.abc import x, y, z, t
 from sympy.printing.theanocode import (theano_code, dim_handling,
         theano_function)
 
+
+# Default set of matrix symbols for testing - make square so we can both
+# multiply and perform elementwise operations between them.
+X, Y, Z = [sy.MatrixSymbol(n, 4, 4) for n in 'XYZ']
+
+# For testing AppliedUndef
+f_t = sy.Function('f')(t)
+
+
+def theano_code_(expr, **kwargs):
+    """ Wrapper for theano_code that uses a new, empty cache by default. """
+    kwargs.setdefault('cache', {})
+    return theano_code(expr, **kwargs)
+
+def theano_function_(inputs, outputs, **kwargs):
+    """ Wrapper for theano_function that uses a new, empty cache by default. """
+    kwargs.setdefault('cache', {})
+    return theano_function(inputs, outputs, **kwargs)
+
+
 def fgraph_of(*exprs):
-    """ Transform SymPy expressions into Theano Computation """
-    outs = list(map(theano_code, exprs))
+    """ Transform SymPy expressions into Theano Computation.
+
+    Parameters
+    ==========
+    exprs
+        Sympy expressions
+
+    Returns
+    =======
+    theano.gof.FunctionGraph
+    """
+    outs = list(map(theano_code_, exprs))
     ins = theano.gof.graph.inputs(outs)
     ins, outs = theano.gof.graph.clone(ins, outs)
     return theano.gof.FunctionGraph(ins, outs)
 
+
 def theano_simplify(fgraph):
-    """ Simplify a Theano Computation """
+    """ Simplify a Theano Computation.
+
+    Parameters
+    ==========
+    fgraph : theano.gof.FunctionGraph
+
+    Returns
+    =======
+    theano.gof.FunctionGraph
+    """
     mode = theano.compile.get_default_mode().excluding("fusion")
     fgraph = fgraph.clone()
     mode.optimizer.optimize(fgraph)
@@ -42,82 +90,211 @@ def theano_simplify(fgraph):
 
 
 def theq(a, b):
-    """ theano equality """
+    """ Test two Theano objects for equality.
+
+    Also accepts numeric types and lists/tuples of supported types.
+
+    Note - debugprint() has a bug where it will accept numeric types but does
+    not respect the "file" argument and in this case and instead prints the number
+    to stdout and returns an empty string. This can lead to tests passing where
+    they should fail because any two numbers will always compare as equal. To
+    prevent this we treat numbers as a separate case.
+    """
+    numeric_types = (int, float, np.number)
+    a_is_num = isinstance(a, numeric_types)
+    b_is_num = isinstance(b, numeric_types)
+
+    # Compare numeric types using regular equality
+    if a_is_num or b_is_num:
+        if not (a_is_num and b_is_num):
+            return False
+
+        return a == b
+
+    # Compare sequences element-wise
+    a_is_seq = isinstance(a, (tuple, list))
+    b_is_seq = isinstance(b, (tuple, list))
+
+    if a_is_seq or b_is_seq:
+        if not (a_is_seq and b_is_seq) or type(a) != type(b):
+            return False
+
+        return list(map(theq, a)) == list(map(theq, b))
+
+    # Otherwise, assume debugprint() can handle it
     astr = theano.printing.debugprint(a, file='str')
     bstr = theano.printing.debugprint(b, file='str')
 
-    if not astr == bstr:
-        print()
-        print(astr)
-        print(bstr)
+    # Check for bug mentioned above
+    for argname, argval, argstr in [('a', a, astr), ('b', b, bstr)]:
+        if argstr == '':
+            raise TypeError(
+                'theano.printing.debugprint(%s) returned empty string '
+                '(%s is instance of %r)'
+                % (argname, argname, type(argval))
+            )
 
     return astr == bstr
 
-def test_symbol():
-    xt = theano_code(x)
-    assert isinstance(xt, (tt.TensorVariable, ts.ScalarVariable))
-    assert xt.name == x.name
 
-    assert theano_code(x, broadcastables={x: (False,)}).broadcastable == (False,)
-    assert theano_code(x, broadcastables={x: (False,)}).name == x.name
+def test_example_symbols():
+    """
+    Check that the example symbols in this module print to their Theano
+    equivalents, as many of the other tests depend on this.
+    """
+    assert theq(xt, theano_code_(x))
+    assert theq(yt, theano_code_(y))
+    assert theq(zt, theano_code_(z))
+    assert theq(Xt, theano_code_(X))
+    assert theq(Yt, theano_code_(Y))
+    assert theq(Zt, theano_code_(Z))
+
+
+def test_Symbol():
+    """ Test printing a Symbol to a theano variable. """
+    xx = theano_code_(x)
+    assert isinstance(xx, (tt.TensorVariable, ts.ScalarVariable))
+    assert xx.broadcastable == ()
+    assert xx.name == x.name
+
+    xx2 = theano_code_(x, broadcastables={x: (False,)})
+    assert xx2.broadcastable == (False,)
+    assert xx2.name == x.name
+
+def test_MatrixSymbol():
+    """ Test printing a MatrixSymbol to a theano variable. """
+    XX = theano_code_(X)
+    assert isinstance(XX, tt.TensorVariable)
+    assert XX.broadcastable == (False, False)
+
+@SKIP  # TODO - this is currently not checked but should be implemented
+def test_MatrixSymbol_wrong_dims():
+    """ Test MatrixSymbol with invalid broadcastable. """
+    bcs = [(), (False,), (True,), (True, False), (False, True,), (True, True)]
+    for bc in bcs:
+        with raises(ValueError):
+            theano_code_(X, broadcastables={X: bc})
+
+def test_AppliedUndef():
+    """ Test printing AppliedUndef instance, which works similarly to Symbol. """
+    ftt = theano_code_(f_t)
+    assert isinstance(ftt, tt.TensorVariable)
+    assert ftt.broadcastable == ()
+    assert ftt.name == 'f_t'
+
 
 def test_add():
     expr = x + y
-    comp = theano_code(expr)
+    comp = theano_code_(expr)
     assert comp.owner.op == theano.tensor.add
 
-    comp = theano_code(expr, broadcastables={x: (False,), y: (False,)})
-    assert comp.broadcastable == (False,)
-
-    comp = theano_code(expr, broadcastables={x: (False, True), y: (False, False)})
-    assert comp.broadcastable == (False, False)
-
-
 def test_trig():
-    assert theq(theano_code(sympy.sin(x)), tt.sin(xt))
-    assert theq(theano_code(sympy.tan(x)), tt.tan(xt))
+    assert theq(theano_code_(sy.sin(x)), tt.sin(xt))
+    assert theq(theano_code_(sy.tan(x)), tt.tan(xt))
 
 def test_many():
+    """ Test printing a complex expression with multiple symbols. """
     expr = sy.exp(x**2 + sy.cos(y)) * sy.log(2*z)
-    comp = theano_code(expr)
+    comp = theano_code_(expr)
     expected = tt.exp(xt**2 + tt.cos(yt)) * tt.log(2*zt)
-    # assert theq(comp, expected)
+    assert theq(comp, expected)
+
 
 def test_dtype():
-    assert theano_code(x, dtypes={x: 'float32'}).type.dtype == 'float32'
-    assert theano_code(x, dtypes={x: 'float64'}).type.dtype == 'float64'
-    assert theano_code(x+1, dtypes={x: 'float32'}).type.dtype == 'float32'
-    assert theano_code(x+y, dtypes={x: 'float64', y: 'float32'}).type.dtype == 'float64'
+    """ Test specifying specific data types through the dtype argument. """
+    for dtype in ['float32', 'float64', 'int8', 'int16', 'int32', 'int64']:
+        assert theano_code_(x, dtypes={x: dtype}).type.dtype == dtype
 
-def test_MatrixSymbol():
-    X = sympy.MatrixSymbol('X', 4, 5)
-    Xt = theano_code(X)
-    assert isinstance(Xt, tt.TensorVariable)
-    assert Xt.broadcastable == (False, False)
+    # "floatX" type
+    assert theano_code_(x, dtypes={x: 'floatX'}).type.dtype in ('float32', 'float64')
+
+    # Type promotion
+    assert theano_code_(x + 1, dtypes={x: 'float32'}).type.dtype == 'float32'
+    assert theano_code_(x + y, dtypes={x: 'float64', y: 'float32'}).type.dtype == 'float64'
+
+
+def test_broadcastables():
+    """ Test the "broadcastables" argument when printing symbol-like objects. """
+
+    # No restrictions on shape
+    for s in [x, f_t]:
+        for bc in [(), (False,), (True,), (False, False), (True, False)]:
+            assert theano_code_(s, broadcastables={s: bc}).broadcastable == bc
+
+    # TODO - matrix broadcasting?
+
+def test_broadcasting():
+    """ Test "broadcastable" attribute after applying element-wise binary op. """
+
+    expr = x + y
+
+    cases = [
+        [(), (), ()],
+        [(False,), (False,), (False,)],
+        [(True,), (False,), (False,)],
+        [(False, True), (False, False), (False, False)],
+        [(True, False), (False, False), (False, False)],
+    ]
+
+    for bc1, bc2, bc3 in cases:
+        comp = theano_code_(expr, broadcastables={x: bc1, y: bc2})
+        assert comp.broadcastable == bc3
+
 
 def test_MatMul():
-    X = sympy.MatrixSymbol('X', 4, 4)
-    Y = sympy.MatrixSymbol('X', 4, 4)
-    Z = sympy.MatrixSymbol('X', 4, 4)
     expr = X*Y*Z
-    assert isinstance(theano_code(expr).owner.op, tt.Dot)
+    expr_t = theano_code_(expr)
+    assert isinstance(expr_t.owner.op, tt.Dot)
+    assert theq(expr_t, Xt.dot(Yt).dot(Zt))
 
 def test_Transpose():
-    X = sympy.MatrixSymbol('X', 4, 4)
-    assert isinstance(theano_code(X.T).owner.op, tt.DimShuffle)
+    assert isinstance(theano_code_(X.T).owner.op, tt.DimShuffle)
 
 def test_MatAdd():
-    X = sympy.MatrixSymbol('X', 4, 4)
-    Y = sympy.MatrixSymbol('X', 4, 4)
-    Z = sympy.MatrixSymbol('X', 4, 4)
     expr = X+Y+Z
-    assert isinstance(theano_code(expr).owner.op, tt.Elemwise)
+    assert isinstance(theano_code_(expr).owner.op, tt.Elemwise)
 
-def test_symbols_are_created_once():
-    expr = x**x
-    comp = theano_code(expr)
 
-    assert theq(comp, xt**xt)
+def test_Rationals():
+    assert theq(theano_code_(sy.Integer(2) / 3), tt.true_div(2, 3))
+    assert theq(theano_code_(S.Half), tt.true_div(1, 2))
+
+def test_Integers():
+    assert theano_code_(sy.Integer(3)) == 3
+
+def test_factorial():
+    n = sy.Symbol('n')
+    assert theano_code_(sy.factorial(n))
+
+def test_Derivative():
+    simp = lambda expr: theano_simplify(fgraph_of(expr))
+    assert theq(simp(theano_code_(sy.Derivative(sy.sin(x), x, evaluate=False))),
+                simp(theano.grad(tt.sin(xt), xt)))
+
+
+def test_theano_function_simple():
+    """ Test theano_function() with single output. """
+    f = theano_function_([x, y], [x+y])
+    assert f(2, 3) == 5
+
+def test_theano_function_multi():
+    """ Test theano_function() with multiple outputs. """
+    f = theano_function_([x, y], [x+y, x-y])
+    o1, o2 = f(2, 3)
+    assert o1 == 5
+    assert o2 == -1
+
+def test_theano_function_numpy():
+    """ Test theano_function() vs Numpy implementation. """
+    f = theano_function_([x, y], [x+y], dim=1,
+                         dtypes={x: 'float64', y: 'float64'})
+    assert np.linalg.norm(f([1, 2], [3, 4]) - np.asarray([4, 6])) < 1e-9
+
+    f = theano_function_([x, y], [x+y], dtypes={x: 'float64', y: 'float64'},
+                                     dim=1)
+    xx = np.arange(3).astype('float64')
+    yy = 2*np.arange(3).astype('float64')
+    assert np.linalg.norm(f(xx, yy) - 3*np.arange(3)) < 1e-9
 
 def test_dim_handling():
     assert dim_handling([x], dim=2) == {x: (False, False)}
@@ -125,44 +302,16 @@ def test_dim_handling():
                                                        y: (False, False)}
     assert dim_handling([x], broadcastables={x: (False,)}) == {x: (False,)}
 
-def test_Rationals():
-    assert theq(theano_code(sympy.Integer(2) / 3), tt.true_div(2, 3))
-    assert theq(theano_code(S.Half), tt.true_div(1, 2))
-
-def test_Integers():
-    assert theano_code(sympy.Integer(3)) == 3
-
-def test_factorial():
-    n = sympy.Symbol('n')
-    assert theano_code(sympy.factorial(n))
-
-def test_Derivative():
-    simp = lambda expr: theano_simplify(fgraph_of(expr))
-    assert theq(simp(theano_code(sy.Derivative(sy.sin(x), x, evaluate=False))),
-                simp(theano.grad(tt.sin(xt), xt)))
-
-def test_theano_function_simple():
-    f = theano_function([x, y], [x+y])
-    assert f(2, 3) == 5
-
-def test_theano_function_numpy():
-    f = theano_function([x, y], [x+y], dim=1,
-                        dtypes={x: 'float64', y: 'float64'})
-    assert np.linalg.norm(f([1, 2], [3, 4]) - np.asarray([4, 6])) < 1e-9
-
-    f = theano_function([x, y], [x+y], dtypes={x: 'float64', y: 'float64'},
-                                     dim=1)
-    xx = np.arange(3).astype('float64')
-    yy = 2*np.arange(3).astype('float64')
-    assert np.linalg.norm(f(xx, yy) - 3*np.arange(3)) < 1e-9
-
 def test_theano_function_kwargs():
+    """
+    Test passing additional kwargs from theano_function() to theano.function().
+    """
     import numpy as np
-    f = theano_function([x, y, z], [x+y], dim=1, on_unused_input='ignore',
+    f = theano_function_([x, y, z], [x+y], dim=1, on_unused_input='ignore',
             dtypes={x: 'float64', y: 'float64', z: 'float64'})
     assert np.linalg.norm(f([1, 2], [3, 4], [0, 0]) - np.asarray([4, 6])) < 1e-9
 
-    f = theano_function([x, y, z], [x+y],
+    f = theano_function_([x, y, z], [x+y],
                         dtypes={x: 'float64', y: 'float64', z: 'float64'},
                         dim=1, on_unused_input='ignore')
     xx = np.arange(3).astype('float64')
@@ -170,50 +319,63 @@ def test_theano_function_kwargs():
     zz = 2*np.arange(3).astype('float64')
     assert np.linalg.norm(f(xx, yy, zz) - 3*np.arange(3)) < 1e-9
 
+def test_theano_function_bad_kwarg():
+    """
+    Passing an unknown keyword argument to theano_function() should raise an
+    exception.
+    """
+    raises(Exception, lambda : theano_function_([x], [x+1], foobar=3))
+
+
 def test_slice():
-    assert theano_code(slice(1, 2, 3)) == slice(1, 2, 3)
-    assert str(theano_code(slice(1, x, 3), dtypes={x: 'int32'})) ==\
-           str(slice(1, xt, 3))
+    assert theano_code_(slice(1, 2, 3)) == slice(1, 2, 3)
+
+    def theq_slice(s1, s2):
+        for attr in ['start', 'stop', 'step']:
+            a1 = getattr(s1, attr)
+            a2 = getattr(s2, attr)
+            if a1 is None or a2 is None:
+                if not (a1 is None or a2 is None):
+                    return False
+            elif not theq(a1, a2):
+                return False
+        return True
+
+    dtypes = {x: 'int32', y: 'int32'}
+    assert theq_slice(theano_code_(slice(x, y), dtypes=dtypes), slice(xt, yt))
+    assert theq_slice(theano_code_(slice(1, x, 3), dtypes=dtypes), slice(1, xt, 3))
 
 def test_MatrixSlice():
-    n = sympy.Symbol('n', integer=True)
-    X = sympy.MatrixSymbol('X', n, n)
-
-    Y = X[1:2:3, 4:5:6]
-    Yt = theano_code(Y)
-    from theano.scalar import Scalar
     from theano import Constant
 
-    s = Scalar('int64')
+    cache = {}
+
+    n = sy.Symbol('n', integer=True)
+    X = sy.MatrixSymbol('X', n, n)
+
+    Y = X[1:2:3, 4:5:6]
+    Yt = theano_code_(Y, cache=cache)
+
+    s = ts.Scalar('int64')
     assert tuple(Yt.owner.op.idx_list) == (slice(s, s, s), slice(s, s, s))
-    assert Yt.owner.inputs[0] == theano_code(X)
+    assert Yt.owner.inputs[0] == theano_code_(X, cache=cache)
     # == doesn't work in theano like it does in SymPy. You have to use
     # equals.
-    assert [i.equals(j) for i, j in zip(Yt.owner.inputs[1:],[
-        Constant(s, 1),
-        Constant(s, 2),
-        Constant(s, 3),
-        Constant(s, 4),
-        Constant(s, 5),
-        Constant(s, 6),
-    ])]
+    assert all(Yt.owner.inputs[i].equals(Constant(s, i)) for i in range(1, 7))
 
-    k = sympy.Symbol('k')
-    kt = theano_code(k, dtypes={k: 'int32'})
+    k = sy.Symbol('k')
+    kt = theano_code_(k, dtypes={k: 'int32'})
     start, stop, step = 4, k, 2
     Y = X[start:stop:step]
-    Yt = theano_code(Y, dtypes={n: 'int32', k: 'int32'})
+    Yt = theano_code_(Y, dtypes={n: 'int32', k: 'int32'})
     # assert Yt.owner.op.idx_list[0].stop == kt
 
 def test_BlockMatrix():
-    n = sympy.Symbol('n', integer=True)
-    A = sympy.MatrixSymbol('A', n, n)
-    B = sympy.MatrixSymbol('B', n, n)
-    C = sympy.MatrixSymbol('C', n, n)
-    D = sympy.MatrixSymbol('D', n, n)
-    At, Bt, Ct, Dt = map(theano_code, (A, B, C, D))
-    Block = sympy.BlockMatrix([[A, B], [C, D]])
-    Blockt = theano_code(Block)
+    n = sy.Symbol('n', integer=True)
+    A, B, C, D = [sy.MatrixSymbol(name, n, n) for name in 'ABCD']
+    At, Bt, Ct, Dt = map(theano_code_, (A, B, C, D))
+    Block = sy.BlockMatrix([[A, B], [C, D]])
+    Blockt = theano_code_(Block)
     solutions = [tt.join(0, tt.join(1, At, Bt), tt.join(1, Ct, Dt)),
                  tt.join(1, tt.join(0, At, Ct), tt.join(0, Bt, Dt))]
     assert any(theq(Blockt, solution) for solution in solutions)
@@ -222,20 +384,20 @@ def test_BlockMatrix():
 def test_BlockMatrix_Inverse_execution():
     k, n = 2, 4
     dtype = 'float32'
-    A = sympy.MatrixSymbol('A', n, k)
-    B = sympy.MatrixSymbol('B', n, n)
+    A = sy.MatrixSymbol('A', n, k)
+    B = sy.MatrixSymbol('B', n, n)
     inputs = A, B
     output = B.I*A
 
     cutsizes = {A: [(n//2, n//2), (k//2, k//2)],
                 B: [(n//2, n//2), (n//2, n//2)]}
-    cutinputs = [sympy.blockcut(i, *cutsizes[i]) for i in inputs]
+    cutinputs = [sy.blockcut(i, *cutsizes[i]) for i in inputs]
     cutoutput = output.subs(dict(zip(inputs, cutinputs)))
 
     dtypes = dict(zip(inputs, [dtype]*len(inputs)))
-    f = theano_function(inputs, [output], dtypes=dtypes, cache={})
-    fblocked = theano_function(inputs, [sympy.block_collapse(cutoutput)],
-                               dtypes=dtypes, cache={})
+    f = theano_function_(inputs, [output], dtypes=dtypes, cache={})
+    fblocked = theano_function_(inputs, [sy.block_collapse(cutoutput)],
+                                dtypes=dtypes, cache={})
 
     ninputs = [np.random.rand(*x.shape).astype(dtype) for x in inputs]
     ninputs = [np.arange(n*k).reshape(A.shape).astype(dtype),
@@ -248,52 +410,135 @@ def test_DenseMatrix():
     t = sy.Symbol('theta')
     for MatrixType in [sy.Matrix, sy.ImmutableMatrix]:
         X = MatrixType([[sy.cos(t), -sy.sin(t)], [sy.sin(t), sy.cos(t)]])
-        tX = theano_code(X)
+        tX = theano_code_(X)
         assert isinstance(tX, tt.TensorVariable)
         assert tX.owner.op == tt.join_
 
-def test_AppliedUndef():
-    t = sy.Symbol('t')
-    f = sy.Function('f')
-    ft = theano_code(f(t))
-    assert isinstance(ft, tt.TensorVariable)
-    assert ft.name == 'f_t'
 
-def test_bad_keyword_args_raise_error():
-    raises(Exception, lambda : theano_function([x], [x+1], foobar=3))
+def test_cache_basic():
+    """ Test single symbol-like objects are cached when printed by themselves. """
 
-def test_cache():
-    sx = sy.Symbol('x')
-    cache = {}
-    tx = theano_code(sx, cache=cache)
-    assert theano_code(sx, cache=cache) is tx
-    assert theano_code(sx, cache={}) is not tx
+    # Pairs of objects which should be considered equivalent with respect to caching
+    pairs = [
+        (x, sy.Symbol('x')),
+        (X, sy.MatrixSymbol('X', *X.shape)),
+        (f_t, sy.Function('f')(sy.Symbol('t'))),
+    ]
+
+    for s1, s2 in pairs:
+        cache = {}
+        st = theano_code_(s1, cache=cache)
+
+        # Test hit with same instance
+        assert theano_code_(s1, cache=cache) is st
+
+        # Test miss with same instance but new cache
+        assert theano_code_(s1, cache={}) is not st
+
+        # Test hit with different but equivalent instance
+        assert theano_code_(s2, cache=cache) is st
+
+def test_global_cache():
+    """ Test use of the global cache. """
+    from sympy.printing.theanocode import global_cache
+
+    backup = dict(global_cache)
+    try:
+        # Temporarily empty global cache
+        global_cache.clear()
+
+        for s in [x, X, f_t]:
+            st = theano_code(s)
+            assert theano_code(s) is st
+
+    finally:
+        # Restore global cache
+        global_cache.update(backup)
+
+def test_cache_types_distinct():
+    """
+    Test that symbol-like objects of different types (Symbol, MatrixSymbol,
+    AppliedUndef) are distinguished by the cache even if they have the same
+    name.
+    """
+    symbols = [sy.Symbol('f_t'), sy.MatrixSymbol('f_t', 4, 4), f_t]
+
+    cache = {}  # Single shared cache
+    printed = {}
+
+    for s in symbols:
+        st = theano_code_(s, cache=cache)
+        assert st not in printed.values()
+        printed[s] = st
+
+    # Check all printed objects are distinct
+    assert len(set(map(id, printed.values()))) == len(symbols)
+
+    # Check retrieving
+    for s, st in printed.items():
+        assert theano_code(s, cache=cache) is st
+
+def test_symbols_are_created_once():
+    """
+    Test that a symbol is cached and reused when it appears in an expression
+    more than once.
+    """
+    expr = sy.Add(x, x, evaluate=False)
+    comp = theano_code_(expr)
+
+    assert theq(comp, xt + xt)
+    assert not theq(comp, xt + theano_code_(x))
+
+def test_cache_complex():
+    """
+    Test caching on a complicated expression with multiple symbols appearing
+    multiple times.
+    """
+    expr = x ** 2 + (y - sy.exp(x)) * sy.sin(z - x * y)
+    symbol_names = {s.name for s in expr.free_symbols}
+    expr_t = theano_code_(expr)
+
+    # Iterate through variables in the Theano computational graph that the
+    # printed expression depends on
+    seen = set()
+    for v in theano.gof.graph.ancestors([expr_t]):
+        # Owner-less, non-constant variables should be our symbols
+        if v.owner is None and not isinstance(v, theano.gof.graph.Constant):
+            # Check it corresponds to a symbol and appears only once
+            assert v.name in symbol_names
+            assert v.name not in seen
+            seen.add(v.name)
+
+    # Check all were present
+    assert seen == symbol_names
+
 
 def test_Piecewise():
     # A piecewise linear
-    xt, yt = theano_code(x), theano_code(y)
     expr = sy.Piecewise((0, x<0), (x, x<2), (1, True))  # ___/III
-    result = theano_code(expr)
+    result = theano_code_(expr)
     assert result.owner.op == tt.switch
 
     expected = tt.switch(xt<0, 0, tt.switch(xt<2, xt, 1))
     assert theq(result, expected)
 
     expr = sy.Piecewise((x, x < 0))
-    result = theano_code(expr)
+    result = theano_code_(expr)
     expected = tt.switch(xt < 0, xt, np.nan)
     assert theq(result, expected)
 
     expr = sy.Piecewise((0, sy.And(x>0, x<2)), \
         (x, sy.Or(x>2, x<0)))
-    result = theano_code(expr)
+    result = theano_code_(expr)
     expected = tt.switch(tt.and_(xt>0,xt<2), 0, \
         tt.switch(tt.or_(xt>2, xt<0), xt, np.nan))
     assert theq(result, expected)
 
+
 def test_Relationals():
-    xt, yt = theano_code(x), theano_code(y)
-    assert theq(theano_code(x > y), xt > yt)
-    assert theq(theano_code(x < y), xt < yt)
-    assert theq(theano_code(x >= y), xt >= yt)
-    assert theq(theano_code(x <= y), xt <= yt)
+    assert theq(theano_code_(sy.Eq(x, y)), tt.eq(xt, yt))
+    # assert theq(theano_code_(sy.Ne(x, y)), tt.neq(xt, yt))  # TODO - implement
+    assert theq(theano_code_(x > y), xt > yt)
+    assert theq(theano_code_(x < y), xt < yt)
+    assert theq(theano_code_(x >= y), xt >= yt)
+    assert theq(theano_code_(x <= y), xt <= yt)

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -1,15 +1,14 @@
 from __future__ import print_function, division
-import inspect
-import sys
 
 from sympy.external import import_module
-
 from sympy.printing.printer import Printer
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, is_sequence
 import sympy
 from functools import partial
 
+
 theano = import_module('theano')
+
 if theano:
     ts = theano.scalar
     tt = theano.tensor
@@ -63,37 +62,90 @@ if theano:
             sympy.Transpose: tt.DimShuffle((False, False), [1, 0]),
     }
 
+
 class TheanoPrinter(Printer):
-    """ Code printer for Theano computations """
+    """ Code printer which creates Theano symbolic expression graphs.
+
+    Parameters
+    ==========
+    cache : dict
+        Cache dictionary to use (see :attr:`cache`). If None (default) will use
+        the global cache. To create a printer which does not depend on or alter
+        global state pass an empty dictionary. Note: the dictionary is not
+        copied on initialization of the printer and will be updated in-place,
+        so using the same dict object when creating multiple printers or making
+        multiple calls to :func:`.theano_code` or :func:`.theano_function` means
+        the cache is shared between all these applications.
+
+    Attributes
+    ==========
+
+    cache : dict
+        A cache of Theano variables which have been created for Sympy
+        symbol-like objects (e.g. :class:`sympy.core.symbol.Symbol` or
+        :class:`sympy.matrices.expressions.MatrixSymbol`). This is used to
+        ensure that all references to a given symbol in an expression (or
+        multiple expressions) are printed as the same Theano variable, which is
+        created only once. Symbols are differentiated only by name and type. The
+        format of the cache's contents should be considered opaque to the user.
+    """
     printmethod = "_theano"
 
     def __init__(self, *args, **kwargs):
         self.cache = kwargs.pop('cache', dict())
         super(TheanoPrinter, self).__init__(*args, **kwargs)
 
-    def _print_Symbol(self, s, dtypes={}, broadcastables={}):
-        dtype = dtypes.get(s, 'floatX')
-        broadcastable = broadcastables.get(s, ())
-        key = (s.name, dtype, broadcastable, type(s))
+    def _get_key(self, s, name=None, dtype=None, broadcastable=None):
+        """ Get the cache key for a Sympy object.
+
+        Parameters
+        ==========
+
+        s : sympy.core.basic.Basic
+            Sympy object to get key for.
+
+        name : str
+            Name of object, if it does not have a ``name`` attribute.
+        """
+
+        if name is None:
+            name = s.name
+
+        return (name, type(s), s.args, dtype, broadcastable)
+
+    def _get_or_create(self, s, name=None, dtype=None, broadcastable=None):
+        """
+        Get the Theano variable for a Sympy symbol from the cache, or create it
+        if it does not exist.
+        """
+
+        # Defaults
+        if name is None:
+            name = s.name
+        if dtype is None:
+            dtype = 'floatX'
+        if broadcastable is None:
+            broadcastable = ()
+
+        key = self._get_key(s, name, dtype=dtype, broadcastable=broadcastable)
+
         if key in self.cache:
             return self.cache[key]
-        else:
-            value = tt.tensor(name=s.name, dtype=dtype, broadcastable=broadcastable)
-            self.cache[key] = value
-            return value
 
-    def _print_AppliedUndef(self, s, dtypes={}, broadcastables={}):
-        dtype = dtypes.get(s, 'floatX')
-        broadcastable = broadcastables.get(s, ())
+        value = tt.tensor(name=name, dtype=dtype, broadcastable=broadcastable)
+        self.cache[key] = value
+        return value
+
+    def _print_Symbol(self, s, **kwargs):
+        dtype = kwargs.get('dtypes', {}).get(s)
+        bc = kwargs.get('broadcastables', {}).get(s)
+        return self._get_or_create(s, dtype=dtype, broadcastable=bc)
+
+    def _print_AppliedUndef(self, s, **kwargs):
         name = str(type(s)) + '_' + str(s.args[0])
-        key = (name, dtype, broadcastable, type(s), s.args)
-        if key in self.cache:
-            return self.cache[key]
-        else:
-            value = tt.tensor(name=name, dtype=dtype, broadcastable=broadcastable)
-            self.cache[key] = value
-            return value
-
+        dtype = kwargs.get('dtypes', {}).get(s)
+        bc = kwargs.get('broadcastables', {}).get(s)
+        return self._get_or_create(s, name=name, dtype=dtype, broadcastable=bc)
 
     def _print_Basic(self, expr, **kwargs):
         op = mapping[type(expr)]
@@ -101,17 +153,12 @@ class TheanoPrinter(Printer):
         return op(*children)
 
     def _print_Number(self, n, **kwargs):
-        return eval(str(n))
+        # Integers already taken care of below, interpret as float
+        return float(n.evalf())
 
-    def _print_MatrixSymbol(self, X, dtypes={}, **kwargs):
-        dtype = dtypes.get(X, 'floatX')
-        key = (X.name, dtype, type(X))
-        if key in self.cache:
-            return self.cache[key]
-        else:
-            value = tt.Tensor(dtype, (False, False))(X.name)
-            self.cache[key] = value
-            return value
+    def _print_MatrixSymbol(self, X, **kwargs):
+        dtype = kwargs.get('dtypes', {}).get(X)
+        return self._get_or_create(X, dtype=dtype, broadcastable=(None, None))
 
     def _print_DenseMatrix(self, X, **kwargs):
         try:
@@ -119,9 +166,12 @@ class TheanoPrinter(Printer):
         except AttributeError:
             raise NotImplementedError(
                "Matrix translation not yet supported in this version of Theano")
-        else:
-            return tt.stacklists([[self._print(arg, **kwargs) for arg in L]
-                                         for L in X.tolist()])
+
+        return tt.stacklists([
+            [self._print(arg, **kwargs) for arg in L]
+            for L in X.tolist()
+        ])
+
     _print_ImmutableMatrix = _print_ImmutableDenseMatrix = _print_DenseMatrix
 
     def _print_MatMul(self, expr, **kwargs):
@@ -155,14 +205,20 @@ class TheanoPrinter(Printer):
 
     def _print_Piecewise(self, expr, **kwargs):
         import numpy as np
-        e, cond = expr.args[0].args
+        e, cond = expr.args[0].args  # First condition and corresponding value
+
+        # Print conditional expression and value for first condition
+        p_cond = self._print(cond, **kwargs)
+        p_e = self._print(e, **kwargs)
+
+        # One condition only
         if len(expr.args) == 1:
-            return tt.switch(self._print(cond, **kwargs),
-                             self._print(e, **kwargs),
-                             np.nan)
-        return tt.switch(self._print(cond, **kwargs),
-                         self._print(e, **kwargs),
-                         self._print(sympy.Piecewise(*expr.args[1:]), **kwargs))
+            # Return value if condition else NaN
+            return tt.switch(p_cond, p_e, np.nan)
+
+        # Return value_1 if condition_1 else evaluate remaining conditions
+        p_remaining = self._print(sympy.Piecewise(*expr.args[1:]), **kwargs)
+        return tt.switch(p_cond, p_e, p_remaining)
 
     def _print_Rational(self, expr, **kwargs):
         return tt.true_div(self._print(expr.p, **kwargs),
@@ -184,54 +240,252 @@ class TheanoPrinter(Printer):
     def emptyPrinter(self, expr):
         return expr
 
-    def doprint(self, expr, **kwargs):
-        """Returns printer's representation for expr (as a string)"""
-        return self._print(expr, **kwargs)
+    def doprint(self, expr, dtypes=None, broadcastables=None):
+        """ Convert a Sympy expression to a Theano graph variable.
+
+        The ``dtypes`` and ``broadcastables`` arguments are used to specify the
+        data type, dimension, and broadcasting behavior of the Theano variables
+        corresponding to the free symbols in ``expr``. Each is a mapping from
+        Sympy symbols to the value of the corresponding argument to
+        :func:`theano.tensor.Tensor`.
+
+        See the corresponding `documentation page`__ for more information on
+        broadcasting in Theano.
+
+        .. __: http://deeplearning.net/software/theano/tutorial/broadcasting.html
+
+        Parameters
+        ==========
+
+        expr : sympy.core.expr.Expr
+            Sympy expression to print.
+
+        dtypes : dict
+            Mapping from Sympy symbols to Theano datatypes to use when creating
+            new Theano variables for those symbols. Corresponds to the ``dtype``
+            argument to :func:`theano.tensor.Tensor`. Defaults to ``'floatX'``
+            for symbols not included in the mapping.
+
+        broadcastables : dict
+            Mapping from Sympy symbols to the value of the ``broadcastable``
+            argument to :func:`theano.tensor.Tensor` to use when creating Theano
+            variables for those symbols. Defaults to the empty tuple for symbols
+            not included in the mapping (resulting in a scalar).
+
+        Returns
+        =======
+
+        theano.gof.graph.Variable
+            A variable corresponding to the expression's value in a Theano
+            symbolic expression graph.
+
+        See Also
+        ========
+        theano.tensor.Tensor
+        """
+        if dtypes is None:
+            dtypes = {}
+        if broadcastables is None:
+            broadcastables = {}
+
+        return self._print(expr, dtypes=dtypes, broadcastables=broadcastables)
+
 
 global_cache = {}
 
-def theano_code(expr, cache=global_cache, **kwargs):
+
+def theano_code(expr, cache=None, **kwargs):
+    """ Convert a Sympy expression into a Theano graph variable.
+
+    Parameters
+    ==========
+
+    expr : sympy.core.expr.Expr
+        Sympy expression object to convert.
+
+    cache : dict
+       Cached Theano variables (see :attr:`.TheanoPrinter.cache`). Defaults to
+       the module-level global cache.
+
+    dtypes : dict
+        Passed to :meth:`.TheanoPrinter.doprint`.
+
+    broadcastables : dict
+        Passed to :meth:`.TheanoPrinter.doprint`.
+
+    Returns
+    =======
+
+    theano.gof.graph.Variable
+        A variable corresponding to the expression's value in a Theano symbolic
+        expression graph.
+    """
     if not theano:
         raise ImportError("theano is required for theano_code")
+
+    if cache is None:
+        cache = global_cache
+
     return TheanoPrinter(cache=cache, settings={}).doprint(expr, **kwargs)
 
 
-def dim_handling(inputs, dim=None, dims={}, broadcastables={}, keys=(),
-        **kwargs):
-    """ Handle various input types for dimensions in tensor_wrap
-
-    See Also:
-        tensor_wrap
-        theano_funciton
+def dim_handling(inputs, dim=None, dims=None, broadcastables=None):
     """
-    if dim:
-        dims = dict(zip(inputs, [dim]*len(inputs)))
-    if dims:
+    Get value of ``broadcastables`` argument to :func:`.theano_code` from
+    keyword arguments to :func:`.theano_function`.
+
+    Included for backwards compatibility.
+
+    Parameters
+    ==========
+
+    inputs
+        Sequence of input symbols.
+
+    dim : int
+        Common number of dimensions for all inputs. Overrides other arguments
+        if given.
+
+    dims : dict
+        Mapping from input symbols to number of dimensions. Overrides
+        ``broadcastables`` argument if given.
+
+    broadcastables : dict
+        Explicit value of ``broadcastables`` argument to
+        :meth:`.TheanoPrinter.doprint`. If not None function will return this value unchanged.
+
+    Returns
+    =======
+    dict
+        Dictionary mapping elements of ``inputs`` to their "broadcastable"
+        values (tuple of ``bool``s).
+    """
+    if dim is not None:
+        return {s: (False,) * dim for s in inputs}
+
+    if dims is not None:
         maxdim = max(dims.values())
-        broadcastables = dict((i, (False,)*dims[i] + (True,)*(maxdim-dims[i]))
-                         for i in inputs)
-    return broadcastables
+        return {
+            s: (False,) * d + (True,) * (maxdim - d)
+            for s, d in dims.items()
+        }
+
+    if broadcastables != None:
+        return broadcastables
+
+    return {}
 
 
-def theano_function(inputs, outputs, dtypes={}, cache=None, **kwargs):
-    """ Create Theano function from SymPy expressions """
+def theano_function(inputs, outputs, **kwargs):
+    """ Create a Theano function from SymPy expressions.
+
+    The inputs and outputs are converted to Theano variables using
+    :func:`.theano_code` and then passed to :func:`theano.function`.
+
+    Parameters
+    ==========
+
+    inputs
+        Sequence of symbols which constitute the inputs of the function.
+
+    outputs
+        Sequence of expressions which constitute the outputs(s) of the function.
+        The free symbols of each expression must be a subset of ``inputs``.
+
+    cache : dict
+       Cached Theano variables (see :attr:`.TheanoPrinter.cache`). Defaults to
+       the module-level global cache.
+
+    dtypes : dict
+        Passed to :meth:`.TheanoPrinter.doprint`.
+
+    broadcastables : dict
+        Passed to :meth:`.TheanoPrinter.doprint`.
+
+    dims : dict
+        Alternative to ``broadcastables`` argument. Mapping from elements of
+        ``inputs`` to integers indicating the dimension of their associated
+        arrays/tensors. Overrides ``broadcastables`` argument if given.
+
+    dim : int
+        Another alternative to the ``broadcastables`` argument. Common number of
+        dimensions to use for all arrays/tensors.
+        ``theano_function([x, y], [...], dim=2)`` is equivalent to using
+        ``broadcastables={x: (False, False), y: (False, False)}``.
+
+    Returns
+    =======
+    callable
+        A callable object which takes values of ``inputs`` as positional
+        arguments and returns an output array for each of the expressions
+        in ``outputs``. If ``outputs`` is a single expression the function will
+        return a Numpy array, if it is a list of multiple expressions the
+        function will return a list of arrays. See description of the ``squeeze``
+        argument above for the behavior when a single output is passed in a list.
+        The returned object will either be an instance of
+        :class:`theano.compile.function_module.Function` or a Python wrapper
+        function around one. In both cases, the returned value will have a
+        ``theano_function`` attribute which points to the return value of
+        :func:`theano.function`.
+
+    Examples
+    ========
+
+    >>> from sympy.abc import x, y, z
+    >>> from sympy.printing.theanocode import theano_function
+
+    A simple function with one input and one output:
+
+    >>> f1 = theano_function([x], [x**2 - 1])
+    >>> f1(3)
+    array(8.0)
+
+    A function with multiple inputs and one output:
+
+    >>> f2 = theano_function([x, y, z], [(x**z + y**z)**(1/z)])
+    >>> f2(1, 2, 3)
+    array(2.080083823051904)
+
+    A function with multiple inputs and multiple outputs:
+
+    >>> f3 = theano_function([x, y], [x**2 + y**2, x**2 - y**2])
+    >>> f3(2, 3)
+    [array(13.0), array(-5.0)]
+
+    Returns
+    =======
+    theano.compile.function_module.Function
+        A callable object which takes values of ``inputs`` as positional
+        arguments and returns a list of output arrays for each of the expressions
+        in ``outputs``, unless the length of ``outputs`` is one in which case a
+        single array will be returned.
+
+    See also
+    ========
+    theano.function
+    dim_handling
+    """
     if not theano:
         raise ImportError("theano is required for theano_function")
-    cache = {} if cache == None else cache
-    broadcastables = dim_handling(inputs, **kwargs)
 
-    # Remove keyword arguments corresponding to dim_handling
-    if sys.version_info < (3,):
-        dim_names = inspect.getargspec(dim_handling)[0]
-    else:
-        param = inspect.signature(dim_handling).parameters.items()
-        dim_names = [n for n,p in param if p.kind == p.POSITIONAL_OR_KEYWORD]
-    theano_kwargs = dict((k, v) for k, v in kwargs.items()
-                                if k not in dim_names)
+    # Pop off non-theano keyword args
+    cache = kwargs.pop('cache', {})
+    dtypes = kwargs.pop('dtypes', {})
 
+    broadcastables = dim_handling(
+        inputs,
+        dim=kwargs.pop('dim', None),
+        dims=kwargs.pop('dims', None),
+        broadcastables=kwargs.pop('broadcastables', None),
+    )
+
+    # Print inputs/outputs
     code = partial(theano_code, cache=cache, dtypes=dtypes,
                    broadcastables=broadcastables)
     tinputs  = list(map(code, inputs))
     toutputs = list(map(code, outputs))
-    toutputs = toutputs[0] if len(toutputs) == 1 else toutputs
-    return theano.function(tinputs, toutputs, **theano_kwargs)
+
+    if len(toutputs) == 1:
+        toutputs = toutputs[0]
+
+    return theano.function(tinputs, toutputs, **kwargs)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -713,7 +713,10 @@ def _doctest(*paths, **kwargs):
         blacklist.extend(["sympy/plotting/pygletplot"])
 
     if import_module('theano') is None:
-        blacklist.extend(["doc/src/modules/numeric-computation.rst"])
+        blacklist.extend([
+            "sympy/printing/theanocode.py",
+            "doc/src/modules/numeric-computation.rst",
+        ])
 
     # disabled because of doctest failures in asmeurer's bot
     blacklist.extend([


### PR DESCRIPTION
### Overview

Made the following changes to the Theano code printer:

* Added docstrings to major parts of user API with detailed information on parameters
* Unified some of the code for caching Theano variables which the printer has created for Sympy symbols.
* Fixed bugs in test cases that caused tests to pass when the should have failed and added additional test cases.
* General cleanup of code in base module and test module.
* Changed the way `theano_function()` works when there is only one output - now accepts a single expression as the output instead of forcing you to wrap it in a list, and has an option to enable a more consistent list-in-list-out behavior. The new behavior is opt-in via a keyword argument in order to avoid breaking backwards compatibility, but the old behavior has been deprecated. See #14986.
* `theano_function()` now optionally returns a wrapper around the Theano function object which converts 0-dimensional arrays in the output (which can be annoying to work with) to scalars.


### Remaining issues

I will resolve these in a 2nd PR:

* The `dim_handling` function only serves to process arguments to `theano_function()`, but seems to be part of the public API. I think this function should be deprecated and the functionality moved to `TheanoPrinter.doprint()` so that it is available through all parts of the public API (see #14985).
* The current logic behind caching Theano variables created for Sympy symbols is opaque to the user. The key incorporates the requested data type, so different Theano variables may be created for the same symbol in different calls to `TheanoPrinter.doprint()` if the user gives that data type the first time but not the 2nd. I have started trying to make this process more transparent with a defined contract with the user.
* The user should be able to associate existing Theano variables (created by themselves or by another library) with Sympy symbols.


### Release notes:
<!-- BEGIN RELEASE NOTES -->
* printing
  * Added `squeeze=False` option to `theanocode.theano_function` to give more consistent sequence-in-sequence-out behavior, keep old behavior as default for now but deprecate it.
  * Added `scalar=True` option to `theanocode.theano_function` to create a function which returns scalars instead of 0-dimensional arrays.
<!-- END RELEASE NOTES -->