### PR TITLE
Implement intersecting product using Möbius transform

### DIFF
--- a/sympy/discrete/__init__.py
+++ b/sympy/discrete/__init__.py
@@ -3,9 +3,9 @@
 Transforms - fft, ifft, ntt, intt, fwht, ifwht,
     mobius_transform, inverse_mobius_transform
 Convolution - convolution, convolution_fft, convolution_ntt, convolution_fwht,
-    convolution_subset, covering_product
+    convolution_subset, covering_product, intersecting_product
 """
 
 from .transforms import (fft, ifft, ntt, intt, fwht, ifwht,
     mobius_transform, inverse_mobius_transform)
-from .convolution import convolution, covering_product
+from .convolution import convolution, covering_product, intersecting_product

--- a/sympy/discrete/convolution.py
+++ b/sympy/discrete/convolution.py
@@ -415,3 +415,73 @@ def covering_product(a, b):
     a = inverse_mobius_transform(a)
 
     return a
+
+
+#----------------------------------------------------------------------------#
+#                                                                            #
+#                            Intersecting Product                            #
+#                                                                            #
+#----------------------------------------------------------------------------#
+
+def intersecting_product(a, b):
+    """
+    Returns the intersecting product of given sequences.
+
+    The indices of each argument, considered as bit strings, correspond to
+    subsets of a finite set.
+
+    The intersecting product of given sequences is a sequence which contains
+    sum of products of the elements of the given sequences grouped by
+    bitwise AND of the corresponding indices.
+
+    The sequence is automatically padded to the right with zeros, as the
+    definition of subset based on bitmasks (indices) requires the size of
+    sequence to be a power of 2.
+
+    Parameters
+    ==========
+
+    a, b : iterables
+        The sequences for which intersecting product is to be obtained.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols, S, I, intersecting_product
+    >>> u, v, x, y, z = symbols('u v x y z')
+
+    >>> intersecting_product([u, v], [x, y])
+    [u*x + u*y + v*x, v*y]
+    >>> intersecting_product([u, v, x], [y, z])
+    [u*y + u*z + v*y + x*y + x*z, v*z, 0, 0]
+
+    >>> intersecting_product([1, S(2)/3], [3, 4 + 5*I])
+    [9 + 5*I, 8/3 + 10*I/3]
+    >>> intersecting_product([1, 3, S(5)/7], [7, 8])
+    [327/7, 24, 0, 0]
+
+    References
+    ==========
+
+    .. [1] https://people.csail.mit.edu/rrw/presentations/subset-conv.pdf
+
+    """
+
+    if not a or not b:
+        return []
+
+    a, b = a[:], b[:]
+    n = max(len(a), len(b))
+
+    if n&(n - 1): # not a power of 2
+        n = 2**n.bit_length()
+
+    # padding with zeros
+    a += [S.Zero]*(n - len(a))
+    b += [S.Zero]*(n - len(b))
+
+    a, b = mobius_transform(a, subset=False), mobius_transform(b, subset=False)
+    a = [expand_mul(x*y) for x, y in zip(a, b)]
+    a = inverse_mobius_transform(a, subset=False)
+
+    return a

--- a/sympy/discrete/convolution.py
+++ b/sympy/discrete/convolution.py
@@ -360,8 +360,8 @@ def covering_product(a, b):
     The indices of each argument, considered as bit strings, correspond to
     subsets of a finite set.
 
-    The covering product of given sequences is a sequence which contains
-    sum of products of the elements of the given sequences grouped by
+    The covering product of given sequences is the sequence which contains
+    the sums of products of the elements of the given sequences grouped by
     bitwise OR of the corresponding indices.
 
     The sequence is automatically padded to the right with zeros, as the
@@ -430,9 +430,9 @@ def intersecting_product(a, b):
     The indices of each argument, considered as bit strings, correspond to
     subsets of a finite set.
 
-    The intersecting product of given sequences is a sequence which contains
-    sum of products of the elements of the given sequences grouped by
-    bitwise AND of the corresponding indices.
+    The intersecting product of given sequences is the sequence which
+    contains the sums of products of the elements of the given sequences
+    grouped by bitwise AND of the corresponding indices.
 
     The sequence is automatically padded to the right with zeros, as the
     definition of subset based on bitmasks (indices) requires the size of

--- a/sympy/discrete/tests/test_convolution.py
+++ b/sympy/discrete/tests/test_convolution.py
@@ -5,7 +5,7 @@ from sympy.core import S, Symbol, symbols, I
 from sympy.core.compatibility import range
 from sympy.discrete.convolution import (
     convolution, convolution_fft, convolution_ntt, convolution_fwht,
-    convolution_subset, covering_product)
+    convolution_subset, covering_product, intersecting_product)
 from sympy.utilities.pytest import raises
 from sympy.abc import x, y
 
@@ -324,3 +324,42 @@ def test_covering_product():
 
     raises(TypeError, lambda: covering_product(x, z))
     raises(TypeError, lambda: covering_product(S(7)/3, u))
+
+
+def test_intersecting_product():
+    assert intersecting_product([], []) == []
+    assert intersecting_product([], [S(1)/3]) == []
+    assert intersecting_product([6 + 3*I/7], [S(2)/3]) == [4 + 2*I/7]
+
+    a = [1, sqrt(5), S(3)/8 + 5*I, 4 + 7*I]
+    b = [67, 51, 65, 48, 36, 79, 27]
+    c = [3 + 2*I/5, 5 + 9*I, 7, S(7)/19, 13]
+
+    assert intersecting_product(a, b) == [195*sqrt(5) + 6979/S(8) + 1886*I,
+                                178*sqrt(5) + 520 + 910*I, 841/S(2) + 1344*I,
+                                192 + 336*I, 0, 0, 0, 0]
+
+    assert intersecting_product(b, c) == [128553/S(19) + 9521*I/5,
+                S(17820)/19 + 1602*I, S(19264)/19, S(336)/19, 1846, 0, 0, 0]
+
+    assert intersecting_product(a, c) == intersecting_product(c, a)
+    assert intersecting_product(b[1:], c[:-1]) == [64788/S(19) + 8622*I/5,
+                    12804/S(19) + 1152*I, 11508/S(19), 252/S(19), 0, 0, 0, 0]
+
+    assert intersecting_product(a, c[:-2]) == \
+                    [-99/S(5) + 10*sqrt(5) + 2*sqrt(5)*I/5 + 3021*I/40,
+                    -43 + 5*sqrt(5) + 9*sqrt(5)*I + 71*I, 245/S(8) + 84*I, 0]
+
+    u, v, w, x, y, z = symbols('u v w x y z')
+
+    assert intersecting_product([u, v, w], [x, y]) == \
+                            [u*x + u*y + v*x + w*x + w*y, v*y, 0, 0]
+
+    assert intersecting_product([u, v, w, x], [y, z]) == \
+                        [u*y + u*z + v*y + w*y + w*z + x*y, v*z + x*z, 0, 0]
+
+    assert intersecting_product([u, v], [x, y, z]) == \
+                    intersecting_product([x, y, z], [u, v])
+
+    raises(TypeError, lambda: intersecting_product(x, z))
+    raises(TypeError, lambda: intersecting_product(u, S(8)/3))


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Möbius transform is used for calculating intersecting product (returns list of sum of products of elements grouped by bitwise AND of the corresponding sequence indices).
Usage for the same is:
```
>>> from sympy import symbols, S, I, intersecting_product
>>> u, v, x, y, z = symbols('u v x y z')

>>> intersecting_product([u, v], [x, y])
[u*x + u*y + v*x, v*y]

>>> intersecting_product([u, v, x], [y, z])
[u*y + u*z + v*y + x*y + x*z, v*z, 0, 0]
```
#### Other comments
