### PR TITLE
Mul behaviour with AccumBounds

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -359,3 +359,6 @@ def test_contains_AccumBounds():
         (cos(1)**2 + sin(1)**2 - 1) in AccumBounds(-1, 0))
     assert (-oo in AccumBounds(1, oo)) == S.true
     assert (oo in AccumBounds(-oo, 0)) == S.true
+
+    # issue 13159
+    assert Mul(0, AccumBounds(-1, 1)) == Mul(AccumBounds(-1, 1), 0) == 0

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -180,6 +180,7 @@ class Mul(Expr, AssocOp):
             a, b = seq
             if b.is_Rational:
                 a, b = b, a
+                seq = [a, b]
             assert not a is S.One
             if not a.is_zero and a.is_Rational:
                 r, b = b.as_coeff_Mul()


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #13159


#### Brief description of what is fixed or changed

`Mul(AccumBounds(-1, 1), 0)` returns `AccumBounds(-1, 1)` instead of `0`.

Debugging, I noticed that `flatten()` in `Mul` behaves in a non completely
correct way. Indeed in `flatten()`, `seq` is equal to `[AccumBounds(-1, 1), 0]` and at line 181 the
if statement `b.is_Rational` is `True`; hence the order of the list `seq` is reversed in the
variables `a` and `b`, but not in the list itself.



#### Other comments

Added a test.
