### PR TITLE
Handle case where exp is a sympy integer

### DIFF
--- a/sympy/polys/domains/modularinteger.py
+++ b/sympy/polys/domains/modularinteger.py
@@ -136,7 +136,7 @@ class ModularInteger(PicklableWithSlots, DomainElement):
         else:
             val = self.val
 
-        return self.__class__(pow(val, exp, self.mod))
+        return self.__class__(pow(val, int(exp), self.mod))
 
     def _compare(self, other, op):
         val = self._get_val(other)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -681,6 +681,8 @@ def test_ModularInteger():
     assert isinstance(a, F7.dtype) and a == 4
     a = F7(3)**-100000000000
     assert isinstance(a, F7.dtype) and a == 2
+    a = F7(3)**S(2)
+    assert isinstance(a, F7.dtype) and a == 2
 
     assert bool(F3(3)) is False
     assert bool(F3(4)) is True


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Given test was failing with `TypeError: unsupported operand type(s) for pow(): 'mpz', 'Integer', 'mpz'`

cc @bjodah, this was the issue with the symengine.py test failure
