### PR TITLE
Zeta printing in octave

### DIFF
--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -496,7 +496,7 @@ class OctaveCodePrinter(CodePrinter):
 
     def _print_zeta(self, expr):
         if len(expr.args) == 1:
-            return "zeta(%s)" % expr.args[0]
+            return "zeta(%s)" % self._print(expr.args[0])
         else:
             # Matlab two argument zeta is not equivalent to SymPy's
             return self._print_not_supported(expr)

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -494,6 +494,14 @@ class OctaveCodePrinter(CodePrinter):
             return "\n".join(lines)
 
 
+    def _print_zeta(self, expr):
+        if len(expr.args) == 1:
+            return "zeta(%s)" % expr.args[0]
+        else:
+            # Matlab two argument zeta is not equivalent to SymPy's
+            return self._print_not_supported(expr)
+
+
     def indent_code(self, code):
         """Accepts a string of code or a list of code lines"""
 

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -2,7 +2,7 @@ from sympy.core import (S, pi, oo, symbols, Function, Rational, Integer,
                         Tuple, Symbol)
 from sympy.core import EulerGamma, GoldenRatio, Catalan, Lambda, Mul, Pow
 from sympy.functions import (Piecewise, sqrt, ceiling, exp, sin, cos, LambertW,
-                             sinc, Max, Min, arg, im, re)
+                             sinc, Max, Min, arg, im, re, zeta)
 from sympy.utilities.pytest import raises
 from sympy.utilities.lambdify import implemented_function
 from sympy.matrices import (eye, Matrix, MatrixSymbol, Identity,
@@ -398,3 +398,12 @@ def test_MatrixElement_printing():
 
     F = C[0, 0].subs(C, A - B)
     assert mcode(F) == "(-B + A)(1, 1)"
+
+
+def test_zeta_printing():
+    # test cases for issue #14820
+    x = Symbol('x')
+    n = Symbol('n')
+
+    assert octave_code(zeta(x)) == 'zeta(x)'
+    assert octave_code(zeta(x, n)) == '% Not supported in Octave:\n% zeta\nzeta(x, n)'

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -400,10 +400,7 @@ def test_MatrixElement_printing():
     assert mcode(F) == "(-B + A)(1, 1)"
 
 
-def test_zeta_printing():
-    # test cases for issue #14820
-    x = Symbol('x')
-    n = Symbol('n')
+def test_zeta_printing_issue_14820():
 
     assert octave_code(zeta(x)) == 'zeta(x)'
-    assert octave_code(zeta(x, n)) == '% Not supported in Octave:\n% zeta\nzeta(x, n)'
+    assert octave_code(zeta(x, y)) == '% Not supported in Octave:\n% zeta\nzeta(x, y)'

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -401,6 +401,5 @@ def test_MatrixElement_printing():
 
 
 def test_zeta_printing_issue_14820():
-
     assert octave_code(zeta(x)) == 'zeta(x)'
     assert octave_code(zeta(x, y)) == '% Not supported in Octave:\n% zeta\nzeta(x, y)'


### PR DESCRIPTION
Two method zeta function is not equivalent to SymPy's. Fixes #14820.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * made Octave printing of the two-argument zeta function unsupported, as it differs from SymPy's definition
<!-- END RELEASE NOTES -->
