### PR TITLE
meijerint: another missing factor of 2*pi*I in a transform

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -2047,7 +2047,6 @@ def meijerint_inversion(f, x, t):
     t_ = t
     t = Dummy('t', polar=True)  # We don't want sqrt(t**2) = abs(t) etc
     f = f.subs(t_, t)
-    c = Dummy('c')
     _debug('Laplace-inverting', f)
     if not _is_analytic(f, x):
         _debug('But expression is not analytic.')
@@ -2114,5 +2113,6 @@ def meijerint_inversion(f, x, t):
             res = res.subs(t, t + shift)
             if not isinstance(cond, bool):
                 cond = cond.subs(t, t + shift)
+            from sympy import InverseLaplaceTransform
             return Piecewise((res.subs(t, t_), cond),
-                             (Integral(f_*exp(x*t), (x, c - oo*I, c + oo*I)).subs(t, t_), True))
+                             (InverseLaplaceTransform(f_.subs(t, t_), x, t_, None), True))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -286,6 +286,26 @@ def test_inversion():
     assert meijerint_inversion(exp(-s**2), s, t) is None
 
 
+def test_inversion_conditional_output():
+    from sympy import Symbol, InverseLaplaceTransform
+
+    a = Symbol('a', positive=True)
+    F = sqrt(pi/a)*exp(-2*sqrt(a)*sqrt(s))
+    f = meijerint_inversion(F, s, t)
+    assert not f.is_Piecewise
+
+    b = Symbol('b', real=True)
+    F = F.subs(a, b)
+    f2 = meijerint_inversion(F, s, t)
+    assert f2.is_Piecewise
+    # first piece is same as f
+    assert f2.args[0][0] == f.subs(a, b)
+    # last piece is an unevaluated transform
+    assert f2.args[-1][1]
+    ILT = InverseLaplaceTransform(F, s, t, None)
+    assert f2.args[-1][0] == ILT or f2.args[-1][0] == ILT.as_integral
+
+
 @slow
 def test_lookup_table():
     from random import uniform, randrange


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The Integral returned here was missing a `2*pi*I` as in the previous
commit 36c18025fae8276509ae371e44c068b1ba893ef6.  Instead of hardcoding
the integral, build an unevaluated `InverseLaplaceTransform`.  If we
really want an Integral here, can use `.as_integral` in the future.

Fixes #14946.  Again.  Also, this code path didn't seem to be tested.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fix missing factor of `2*pi*I` in inverse Laplace and Mellin transforms.
<!-- END RELEASE NOTES -->