### PR TITLE
RisingFactorial/FallingFactorial: fix high-precision floats

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -10,8 +10,8 @@ import mpmath.libmp as libmp
 from mpmath import (
     make_mpc, make_mpf, mp, mpc, mpf, nsum, quadts, quadosc, workprec)
 from mpmath import inf as mpmath_inf
-from mpmath.libmp import (from_int, from_man_exp, from_rational, from_float,
-        fhalf, fnan, fnone, fone, fzero, mpf_abs, mpf_add,
+from mpmath.libmp import (from_int, from_man_exp, from_rational, fhalf,
+        fnan, fnone, fone, fzero, mpf_abs, mpf_add,
         mpf_atan, mpf_atan2, mpf_cmp, mpf_cos, mpf_e, mpf_exp, mpf_log, mpf_lt,
         mpf_mul, mpf_neg, mpf_pi, mpf_pow, mpf_pow_int, mpf_shift, mpf_sin,
         mpf_sqrt, normalize, round_nearest, to_int, to_str)
@@ -1244,7 +1244,6 @@ evalf_table = None
 def _create_evalf_table():
     global evalf_table
     from sympy.functions.combinatorial.numbers import bernoulli
-    from sympy.functions.combinatorial.factorials import rf, ff
     from sympy.concrete.products import Product
     from sympy.concrete.summations import Sum
     from sympy.core.add import Add
@@ -1298,8 +1297,6 @@ def _create_evalf_table():
         Piecewise: evalf_piecewise,
 
         bernoulli: evalf_bernoulli,
-        rf: lambda expr, prec, options: (from_float(mp.rf(*expr.args)), None, prec, None),
-        ff: lambda expr, prec, options: (from_float(mp.ff(*expr.args)), None, prec, None),
     }
 
 

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,4 +1,4 @@
-from sympy import (S, Symbol, symbols, factorial, factorial2, binomial,
+from sympy import (S, Symbol, symbols, factorial, factorial2, Float, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
                    oo, zoo, simplify, expand_func, Product, Mul, Piecewise, Mod,
                    Eq, sqrt, Poly)
@@ -60,9 +60,6 @@ def test_rf_eval_apply():
     assert rf(x, k).rewrite(binomial) == factorial(k)*binomial(x + k - 1, k)
     assert rf(n, k).rewrite(factorial) == \
         factorial(n + k - 1) / factorial(n - 1)
-
-    assert str(rf(18, x).subs({x: S(2)/3}).evalf()) == \
-        '6.82615401311257'
 
     import random
     from mpmath import rf as mpmath_rf
@@ -129,15 +126,36 @@ def test_ff_eval_apply():
     assert ff(n, k).rewrite(factorial) == factorial(n) / factorial(n - k)
     assert ff(x, k).rewrite(binomial) == factorial(k) * binomial(x, k)
 
-    assert str(ff(18, x).subs({x: S(2)/3}).evalf()) == \
-        '6.91094012922346'
-
     import random
     from mpmath import ff as mpmath_ff
     for i in range(100):
         x = -500 + 500 * random.random()
         k = -500 + 500 * random.random()
         assert (abs(mpmath_ff(x, k) - ff(x, k)) < 10**(-15))
+
+
+def test_rf_ff_eval_hiprec():
+    maple = Float('6.9109401292234329956525265438452')
+    us = ff(18, S(2)/3).evalf(32)
+    assert abs(us - maple)/us < 1e-31
+
+    maple = Float('6.8261540131125511557924466355367')
+    us = rf(18, S(2)/3).evalf(32)
+    assert abs(us - maple)/us < 1e-31
+
+    maple = Float('34.007346127440197150854651814225')
+    us = rf(Float('4.4', 32), Float('2.2', 32));
+    assert abs(us - maple)/us < 1e-31
+
+
+def test_rf_lambdify_mpmath():
+    from sympy import lambdify
+    x, y = symbols('x,y')
+    f = lambdify((x,y), rf(x, y), 'mpmath')
+    maple = Float('34.007346127440197')
+    us = f(4.4, 2.2)
+    assert abs(us - maple)/us < 1e-15
+
 
 def test_factorial():
     x = Symbol('x')

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -66,7 +66,9 @@ MPMATH_TRANSLATIONS = {
     "Shi": "shi",
     "Chi": "chi",
     "Si": "si",
-    "Ci": "ci"
+    "Ci": "ci",
+    "RisingFactorial": "rf",
+    "FallingFactorial": "ff",
 }
 
 NUMPY_TRANSLATIONS = {}


### PR DESCRIPTION
Instead of changing the evalf table, add appropriate entries to the
`MPMATH_TRANSLATIONS` table in lambdify.  The `MPMATH_TRANSLATIONS`
fix is taken from the Diofant project, with appreciation:
skirpichev/diofant/commit/4bcd9640f83ac0e050d38b5e4772547070f7ed09

The remaining tests and changes are my own.

- - - -

Revert some earlier evalf changes: I don't really understand this code
but it seemed to be limited to double precision.  Replace two broken
tests (str comparisions of Floats are generally fragile and also the
provided strings were not accurate).  Replace with 32-digit versions of
the same tests, compared relatively to computations from another CAS.

This also makes `lambdify(..., 'mpmath')` functional: test for that.

#### References to other Issues or PRs

Fixes #14822.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
