### PR TITLE
factor_terms: don't assume `as_coeff_Mul()[0]` is real

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1176,7 +1176,8 @@ def factor_terms(expr, radical=False, clear=False, fraction=False, sign=True):
         if p.is_Add:
             list_args = [do(a) for a in Add.make_args(p)]
             # get a common negative (if there) which gcd_terms does not remove
-            if all(a.as_coeff_Mul()[0] < 0 for a in list_args):
+            if all(a.as_coeff_Mul()[0].extract_multiplicatively(-1) is not None
+                   for a in list_args):
                 cont = -cont
                 list_args = [-a for a in list_args]
             # watch out for exp(-(x+2)) which gcd_terms will change to exp(-x-2)


### PR DESCRIPTION
As far as I can tell, this code really wants to know if -1 can be
extracted from each term.  Well, we don't need to check `< 0` to do
that; use `.extract_multiplicative(-1)` instead.  It should still be
cheap because `.as_coeff_Mul()` is supposed to be a cheap operation.

Before:
```
>>> %timeit factor_terms(-x - Catalan*I - 1)
483 µs ± 7.54 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

>>> %timeit factor_terms(-x - Catalan*I - 1)
474 µs ± 2.66 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

After:
```
>>> %timeit factor_terms(-x - Catalan*I - 1)
492 µs ± 8.87 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

>>> %timeit factor_terms(-x - Catalan*I - 1)
503 µs ± 12.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
