### PR TITLE
unset_show now works with TextBackend too

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -31,7 +31,6 @@ import sys
 from sympy import sympify, Expr, Tuple, Dummy, Symbol
 from sympy.external import import_module
 from sympy.core.compatibility import range, Callable
-from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import is_sequence
 from .experimental_lambdify import (vectorized_lambdify, lambdify)
 
@@ -218,7 +217,6 @@ class Plot(object):
     def __delitem__(self, index):
         del self._series[index]
 
-    @doctest_depends_on(modules=('numpy', 'matplotlib',))
     def append(self, arg):
         """Adds an element from a plot's series to an existing plot.
 
@@ -250,7 +248,6 @@ class Plot(object):
         else:
             raise TypeError('Must specify element of plot to append.')
 
-    @doctest_depends_on(modules=('numpy', 'matplotlib',))
     def extend(self, arg):
         """Adds all series from another plot.
 
@@ -1142,7 +1139,6 @@ def _matplotlib_list(interval_list):
 # TODO: Add more plotting options for 3d plots.
 # TODO: Adaptive sampling for 3D plots.
 
-@doctest_depends_on(modules=('numpy', 'matplotlib',))
 def plot(*args, **kwargs):
     """
     Plots a function of a single variable and returns an instance of
@@ -1300,7 +1296,6 @@ def plot(*args, **kwargs):
     return plots
 
 
-@doctest_depends_on(modules=('numpy', 'matplotlib',))
 def plot_parametric(*args, **kwargs):
     """
     Plots a 2D parametric plot.
@@ -1431,7 +1426,6 @@ def plot_parametric(*args, **kwargs):
     return plots
 
 
-@doctest_depends_on(modules=('numpy', 'matplotlib',))
 def plot3d_parametric_line(*args, **kwargs):
     """
     Plots a 3D parametric line plot.
@@ -1527,7 +1521,6 @@ def plot3d_parametric_line(*args, **kwargs):
     return plots
 
 
-@doctest_depends_on(modules=('numpy', 'matplotlib',))
 def plot3d(*args, **kwargs):
     """
     Plots a 3D surface plot.
@@ -1639,7 +1632,6 @@ def plot3d(*args, **kwargs):
     return plots
 
 
-@doctest_depends_on(modules=('numpy', 'matplotlib',))
 def plot3d_parametric_surface(*args, **kwargs):
     """
     Plots a 3D parametric surface plot.

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1048,6 +1048,8 @@ class TextBackend(BaseBackend):
         super(TextBackend, self).__init__(parent)
 
     def show(self):
+        if not _show:
+            return
         if len(self.parent._series) != 1:
             raise ValueError(
                 'The TextBackend supports only one graph per Plot.')

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -738,6 +738,10 @@ def _doctest(*paths, **kwargs):
     sympy.external.importtools.WARN_OLD_VERSION = False
     sympy.external.importtools.WARN_NOT_INSTALLED = False
 
+    # Disable showing up of plots
+    from sympy.plotting.plot import unset_show
+    unset_show()
+
     # Show deprecation warnings
     import warnings
     warnings.simplefilter("error", SymPyDeprecationWarning)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -707,10 +707,6 @@ def _doctest(*paths, **kwargs):
             import matplotlib
             matplotlib.use('Agg')
 
-            # don't display matplotlib windows
-            from sympy.plotting.plot import unset_show
-            unset_show()
-
 
     if import_module('pyglet') is None:
         blacklist.extend(["sympy/plotting/pygletplot"])


### PR DESCRIPTION
#### Brief description of what is fixed or changed
Also added `unset_show` in `utilities/runtests` to stop showing up of plots in doctest.

Based on conversation happened on Gitter.
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
