### PR TITLE
Added `Joint_Handmade` and `MarginalDistribution` in stats 

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1655,7 +1655,7 @@ class Lambda(Expr):
         from sympy.sets.sets import FiniteSet
         v = list(variables) if iterable(variables) else [variables]
         for i in v:
-            if not getattr(i, 'is_Symbol', False):
+            if not getattr(i, 'is_symbol', False):
                 raise TypeError('variable is not a symbol: %s' % i)
         if len(v) == 1 and v[0] == expr:
             return S.IdentityFunction

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1052,6 +1052,13 @@ def test_sympy__stats__joint_rv__JointDistributionHandmade():
     x1, x2 = (Indexed('x', i) for i in (1, 2))
     assert _test_args(JointDistributionHandmade(x1 + x2, S.Reals**2))
 
+
+def test_sympy__stats__joint_rv__MarginalDistribution():
+    from sympy.stats.rv import RandomSymbol
+    from sympy.stats.joint_rv import MarginalDistribution
+    r = RandomSymbol(S('r'))
+    assert _test_args(MarginalDistribution(r, (r,)))
+
 @SKIP("abstract class")
 def test_sympy__stats__drv__SingleDiscreteDistribution():
     pass

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1046,6 +1046,12 @@ def test_sympy__stats__joint_rv__JointRandomSymbol():
     from sympy.stats.joint_rv import JointRandomSymbol
     assert _test_args(JointRandomSymbol(x))
 
+def test_sympy__stats__joint_rv__JointDistributionHandmade():
+    from sympy import Indexed
+    from sympy.stats.joint_rv import JointDistributionHandmade
+    x1, x2 = (Indexed('x', i) for i in (1, 2))
+    assert _test_args(JointDistributionHandmade(x1 + x2, S.Reals**2))
+
 @SKIP("abstract class")
 def test_sympy__stats__drv__SingleDiscreteDistribution():
     pass

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1059,6 +1059,13 @@ def test_sympy__stats__joint_rv__MarginalDistribution():
     r = RandomSymbol(S('r'))
     assert _test_args(MarginalDistribution(r, (r,)))
 
+
+def test_sympy__stats__joint_rv__CompoundDistribution():
+    from sympy.stats.joint_rv import CompoundDistribution
+    from sympy.stats.drv_types import PoissonDistribution
+    r = PoissonDistribution(x)
+    assert _test_args(CompoundDistribution(PoissonDistribution(r)))
+
 @SKIP("abstract class")
 def test_sympy__stats__drv__SingleDiscreteDistribution():
     pass

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1,7 +1,7 @@
 from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         E, expand, pi, O, Sum, S, polygamma, loggamma, expint,
-        Tuple, Dummy, Eq, Expr, symbols, nfloat, Piecewise)
+        Tuple, Dummy, Eq, Expr, symbols, nfloat, Piecewise, Indexed)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import t, w, x, y, z
 from sympy.core.function import PoleError, _mexpand
@@ -175,6 +175,9 @@ def test_Lambda():
     assert Lambda(x, f(x))(x) == f(x)
     assert Lambda(x, x**2)(e(x)) == x**4
     assert e(e(x)) == x**4
+
+    x1, x2 = (Indexed('x', i) for i in (1, 2))
+    assert Lambda((x1, x2), x1 + x2)(x, y) == x + y
 
     assert Lambda((x, y), x + y).nargs == FiniteSet(2)
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -56,7 +56,8 @@ from sympy.stats.crv import (SingleContinuousPSpace, SingleContinuousDistributio
         ContinuousDistributionHandmade)
 from sympy.stats.rv import _value_check, RandomSymbol
 from sympy.matrices import MatrixBase
-from sympy.stats.joint_rv_types import multivariate_rv, JointRV
+from sympy.stats.joint_rv_types import multivariate_rv
+from sympy.stats.joint_rv import MarginalDistribution, JointPSpace
 from sympy.external import import_module
 import random
 
@@ -146,7 +147,7 @@ def rv(symbol, cls, args):
     dist.check(*args)
     pspace = SingleContinuousPSpace(symbol, dist)
     if any(isinstance(arg, RandomSymbol) for arg in args):
-        return JointRV(symbol, pspace.pdf)
+        pspace = JointPSpace(symbol, MarginalDistribution(dist, (pspace.value, )))
     return pspace.value
 
 ########################################

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -54,9 +54,9 @@ from sympy import beta as beta_fn
 from sympy import cos, sin, exp, besseli, besselj, besselk
 from sympy.stats.crv import (SingleContinuousPSpace, SingleContinuousDistribution,
         ContinuousDistributionHandmade)
-from sympy.stats.rv import _value_check
+from sympy.stats.rv import _value_check, RandomSymbol
 from sympy.matrices import MatrixBase
-from sympy.stats.joint_rv_types import multivariate_rv
+from sympy.stats.joint_rv_types import multivariate_rv, JointRV
 from sympy.external import import_module
 import random
 
@@ -144,7 +144,10 @@ def rv(symbol, cls, args):
     args = list(map(sympify, args))
     dist = cls(*args)
     dist.check(*args)
-    return SingleContinuousPSpace(symbol, dist).value
+    pspace = SingleContinuousPSpace(symbol, dist)
+    if any(isinstance(arg, RandomSymbol) for arg in args):
+        return JointRV(symbol, pspace.pdf)
+    return pspace.value
 
 ########################################
 # Continuous Probability Distributions #

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -147,8 +147,7 @@ def rv(symbol, cls, args):
     dist.check(*args)
     pspace = SingleContinuousPSpace(symbol, dist)
     if any(isinstance(arg, RandomSymbol) for arg in args):
-        dist = CompoundDistribution(dist)
-        pspace = JointPSpace(symbol, MarginalDistribution(dist, (pspace.value, )))
+        pspace = JointPSpace(symbol, CompoundDistribution(dist))
     return pspace.value
 
 ########################################

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -57,7 +57,7 @@ from sympy.stats.crv import (SingleContinuousPSpace, SingleContinuousDistributio
 from sympy.stats.rv import _value_check, RandomSymbol
 from sympy.matrices import MatrixBase
 from sympy.stats.joint_rv_types import multivariate_rv
-from sympy.stats.joint_rv import MarginalDistribution, JointPSpace
+from sympy.stats.joint_rv import MarginalDistribution, JointPSpace, CompoundDistribution
 from sympy.external import import_module
 import random
 
@@ -147,6 +147,7 @@ def rv(symbol, cls, args):
     dist.check(*args)
     pspace = SingleContinuousPSpace(symbol, dist)
     if any(isinstance(arg, RandomSymbol) for arg in args):
+        dist = CompoundDistribution(dist)
         pspace = JointPSpace(symbol, MarginalDistribution(dist, (pspace.value, )))
     return pspace.value
 

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -24,7 +24,7 @@ class DiscreteDistribution(Basic):
         return self.pdf(*args)
 
 
-class SingleDiscreteDistribution(Basic, NamedArgsMixin):
+class SingleDiscreteDistribution(DiscreteDistribution, NamedArgsMixin):
     """ Discrete distribution of a single variable
 
     Serves as superclass for PoissonDistribution etc....

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -5,6 +5,7 @@ from sympy import (factorial, exp, S, sympify, And, I, zeta, polylog, log, beta,
                    Piecewise, floor)
 from sympy.stats.rv import _value_check, RandomSymbol
 from sympy.stats.joint_rv_types import JointRV
+from sympy.stats.joint_rv import MarginalDistribution, JointPSpace
 from sympy.stats import density
 import random
 
@@ -17,7 +18,7 @@ def rv(symbol, cls, *args):
     dist.check(*args)
     pspace = SingleDiscretePSpace(symbol, dist)
     if any(isinstance(arg, RandomSymbol) for arg in args):
-        return JointRV(symbol, pspace.pdf)
+        pspace = JointPSpace(symbol, MarginalDistribution(dist, (pspace.value, )))
     return pspace.value
 
 

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -3,9 +3,9 @@ from __future__ import print_function, division
 from sympy.stats.drv import SingleDiscreteDistribution, SingleDiscretePSpace
 from sympy import (factorial, exp, S, sympify, And, I, zeta, polylog, log, beta, hyper, binomial,
                    Piecewise, floor)
-from sympy.stats.rv import _value_check
+from sympy.stats.rv import _value_check, RandomSymbol
+from sympy.stats.joint_rv_types import JointRV
 from sympy.stats import density
-from sympy.sets.sets import Interval
 import random
 
 __all__ = ['Geometric', 'Logarithmic', 'NegativeBinomial', 'Poisson', 'YuleSimon', 'Zeta']
@@ -15,7 +15,10 @@ def rv(symbol, cls, *args):
     args = list(map(sympify, args))
     dist = cls(*args)
     dist.check(*args)
-    return SingleDiscretePSpace(symbol, dist).value
+    pspace = SingleDiscretePSpace(symbol, dist)
+    if any(isinstance(arg, RandomSymbol) for arg in args):
+        return JointRV(symbol, pspace.pdf)
+    return pspace.value
 
 
 #-------------------------------------------------------------------------------

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -18,8 +18,7 @@ def rv(symbol, cls, *args):
     dist.check(*args)
     pspace = SingleDiscretePSpace(symbol, dist)
     if any(isinstance(arg, RandomSymbol) for arg in args):
-        dist = CompoundDistribution(dist)
-        pspace = JointPSpace(symbol, MarginalDistribution(dist, (pspace.value, )))
+        pspace = JointPSpace(symbol, CompoundDistribution(dist))
     return pspace.value
 
 

--- a/sympy/stats/drv_types.py
+++ b/sympy/stats/drv_types.py
@@ -5,7 +5,7 @@ from sympy import (factorial, exp, S, sympify, And, I, zeta, polylog, log, beta,
                    Piecewise, floor)
 from sympy.stats.rv import _value_check, RandomSymbol
 from sympy.stats.joint_rv_types import JointRV
-from sympy.stats.joint_rv import MarginalDistribution, JointPSpace
+from sympy.stats.joint_rv import MarginalDistribution, JointPSpace, CompoundDistribution
 from sympy.stats import density
 import random
 
@@ -18,6 +18,7 @@ def rv(symbol, cls, *args):
     dist.check(*args)
     pspace = SingleDiscretePSpace(symbol, dist)
     if any(isinstance(arg, RandomSymbol) for arg in args):
+        dist = CompoundDistribution(dist)
         pspace = JointPSpace(symbol, MarginalDistribution(dist, (pspace.value, )))
     return pspace.value
 

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -25,6 +25,8 @@ from sympy.stats.drv import (DiscreteDistribution,
     SingleDiscreteDistribution, SingleDiscretePSpace)
 from sympy.matrices import ImmutableMatrix
 from sympy.core.containers import Tuple
+from sympy.utilities.misc import filldedent
+
 
 class JointPSpace(ProductPSpace):
     """
@@ -58,9 +60,7 @@ class JointPSpace(ProductPSpace):
     @property
     def component_count(self):
         _set = self.distribution.set
-        if isinstance(_set, ProductSet):
-            return len(_set.args)
-        return 1
+        return len(_set.args) if isinstance(_set, ProductSet) else 1
 
     @property
     def pdf(self):
@@ -217,7 +217,10 @@ class CompoundDistribution(Basic, NamedArgsMixin):
     distributed according to some given distribution.
     """
     def __new__(cls, dist):
-        assert isinstance(dist, (ContinuousDistribution, DiscreteDistribution))
+        if not isinstance(dist, (ContinuousDistribution, DiscreteDistribution)):
+            raise ValueError(filldedent('''CompoundDistribution can only be
+             initialized from ContinuousDistribution or DiscreteDistribution
+             '''))
         _args = dist.args
         if not any([isinstance(i, RandomSymbol) for i in _args]):
             return dist
@@ -244,9 +247,19 @@ class CompoundDistribution(Basic, NamedArgsMixin):
 
 
 class MarginalDistribution(Basic):
+    """
+    Represents the marginal distribution of a joint probability space.
+
+    Initialised using a probability distribution and random variables(or
+    their indexed components) which should be a part of the resultant
+    distribution.
+    """
 
     def __new__(cls,dist, rvs):
-        assert all([isinstance(rv, (Indexed, RandomSymbol))] for rv in rvs)
+        if not all([isinstance(rv, (Indexed, RandomSymbol))] for rv in rvs):
+            raise ValueError(filldedent('''Marginal distribution can be
+             intitialised only in terms of random variables or indexed random
+             variables'''))
         rvs = Tuple.fromiter(rv for rv in rvs)
         if not isinstance(dist, JointDistribution) and len(random_symbols(dist)) == 0:
             return dist

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -13,11 +13,11 @@ from __future__ import print_function, division
 
 # __all__ = ['marginal_distribution']
 
-from sympy import Basic, Lambda, sympify, Indexed, Symbol
+from sympy import Basic, Lambda, sympify, Indexed, Symbol, ProductSet, S
 from sympy.concrete.summations import Sum, summation
 from sympy.integrals.integrals import Integral, integrate
 from sympy.stats.rv import (ProductPSpace, NamedArgsMixin,
-     ProductDomain, RandomSymbol)
+     ProductDomain, RandomSymbol, random_symbols)
 from sympy.matrices import ImmutableMatrix
 class JointPSpace(ProductPSpace):
     """
@@ -47,9 +47,17 @@ class JointPSpace(ProductPSpace):
     @property
     def component_count(self):
         return len(self.distribution.set.args)
+    @property
+    def pdf(self):
+        sym = [Indexed(self.symbol, i) for i in range(self.component_count)]
+        return self.distribution(*sym)
 
-    def pdf(self, *args):
-        return self.distribution(*args)
+    def component_domain(self, index):
+        return self.set.args[index]
+
+    @property
+    def symbols(self):
+        return self.distribution.symbols
 
     def marginal_distribution(self, *indices):
         count = self.component_count
@@ -177,3 +185,62 @@ def marginal_distribution(rv, *indices):
     if hasattr(prob_space.distribution, 'marginal_distribution'):
         return prob_space.distribution.marginal_distribution(indices, rv.symbol)
     return prob_space.marginal_distribution(*indices)
+
+class MarginalDistribution(Basic):
+
+    def __new__(cls, pdf, rvs):
+        assert all([isinstance(rv, (Indexed, RandomSymbol))] for rv in rvs)
+        return Basic.__new__(cls, pdf, rvs)
+
+    def check(self):
+        pass
+
+    def set(self):
+        rvs = (i for i in random_symbols(self.args[1]))
+        return ProductSet((i.pspace.set for i in rvs))
+
+    @property
+    def symbols(self):
+        rvs = self.args[1]
+        return set([rv.pspace.symbol for rv in rvs])
+
+    def pdf(self, x):
+        expr = self.args[0]
+        rvs = self.args[1]
+        marginalise_out = [i for i in random_symbols(expr) if i not in self.args[1]]
+        for i in expr.atoms(Indexed):
+            if isinstance(i, Indexed) and isinstance(i.base, RandomSymbol)\
+             and i not in rvs:
+                marginalise_out.append(i)
+        syms = [i.pspace.symbol for i in self.args[1]]
+        return Lambda(syms, self.compute_pdf(expr, marginalise_out))(x)
+
+    def compute_pdf(self, expr, rvs):
+        for rv in rvs:
+            lpdf = 1
+            if isinstance(rv, RandomSymbol):
+                lpdf = rv.pspace.pdf
+            expr = self.marginalise_out(expr*lpdf, rv)
+        return expr
+
+    def marginalise_out(self, expr, rv):
+        from sympy.concrete.summations import summation
+        if isinstance(rv, RandomSymbol):
+            dom = rv.pspace.set
+        elif isinstance(rv, Indexed):
+            dom = rv.base.component_domain(
+                rv.pspace.component_domain(rv.args[1]))
+        expr = expr.xreplace({rv: rv.pspace.symbol})
+        if rv.pspace.is_Continuous:
+            #TODO: Modify to support integration
+            #for all kinds of sets.
+            expr = integrate(expr, (rv.pspace.symbol, dom))
+        elif rv.pspace.is_Discrete:
+            #incorporate this into `Sum`/`summation`
+            if dom in (S.Integers, S.Naturals, S.Naturals0):
+                dom = (dom.inf, dom.sup)
+            expr = summation(expr, (rv.pspace.symbol, dom))
+        return expr
+
+    def __call__(self, args):
+        return self.pdf(args)

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -19,6 +19,8 @@ from sympy.integrals.integrals import Integral, integrate
 from sympy.stats.rv import (ProductPSpace, NamedArgsMixin,
      ProductDomain, RandomSymbol, random_symbols)
 from sympy.matrices import ImmutableMatrix
+from sympy.core.containers import Tuple
+
 class JointPSpace(ProductPSpace):
     """
     Represents a joint probability space. Represented using symbols for
@@ -190,6 +192,7 @@ class MarginalDistribution(Basic):
 
     def __new__(cls, pdf, rvs):
         assert all([isinstance(rv, (Indexed, RandomSymbol))] for rv in rvs)
+        rvs = Tuple.fromiter(rv for rv in rvs)
         return Basic.__new__(cls, pdf, rvs)
 
     def check(self):
@@ -204,7 +207,7 @@ class MarginalDistribution(Basic):
         rvs = self.args[1]
         return set([rv.pspace.symbol for rv in rvs])
 
-    def pdf(self, x):
+    def pdf(self, x, evaluate=True):
         expr = self.args[0]
         rvs = self.args[1]
         marginalise_out = [i for i in random_symbols(expr) if i not in self.args[1]]
@@ -213,18 +216,20 @@ class MarginalDistribution(Basic):
              and i not in rvs:
                 marginalise_out.append(i)
         syms = [i.pspace.symbol for i in self.args[1]]
-        return Lambda(syms, self.compute_pdf(expr, marginalise_out))(x)
+        return Lambda(syms, self.compute_pdf(expr, marginalise_out, evaluate))(x)
 
-    def compute_pdf(self, expr, rvs):
+    def compute_pdf(self, expr, rvs, evaluate):
         for rv in rvs:
             lpdf = 1
             if isinstance(rv, RandomSymbol):
                 lpdf = rv.pspace.pdf
             expr = self.marginalise_out(expr*lpdf, rv)
+        if evaluate and hasattr(expr, 'doit'):
+            return expr.doit()
         return expr
 
     def marginalise_out(self, expr, rv):
-        from sympy.concrete.summations import summation
+        from sympy.concrete.summations import Sum
         if isinstance(rv, RandomSymbol):
             dom = rv.pspace.set
         elif isinstance(rv, Indexed):
@@ -234,12 +239,12 @@ class MarginalDistribution(Basic):
         if rv.pspace.is_Continuous:
             #TODO: Modify to support integration
             #for all kinds of sets.
-            expr = integrate(expr, (rv.pspace.symbol, dom))
+            expr = Integral(expr, (rv.pspace.symbol, dom))
         elif rv.pspace.is_Discrete:
             #incorporate this into `Sum`/`summation`
             if dom in (S.Integers, S.Naturals, S.Naturals0):
                 dom = (dom.inf, dom.sup)
-            expr = summation(expr, (rv.pspace.symbol, dom))
+            expr = Sum(expr, (rv.pspace.symbol, dom))
         return expr
 
     def __call__(self, args):

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -85,6 +85,8 @@ class JointDistribution(Basic, NamedArgsMixin):
     Contains methods for PDF, CDF, sampling, marginal densities, etc.
     """
 
+    _argnames = ('pdf', )
+
     def __new__(cls, *args):
         args = list(map(sympify, args))
         for i in range(len(args)):
@@ -126,6 +128,15 @@ class JointRandomSymbol(RandomSymbol):
         from sympy.stats.joint_rv import JointPSpace
         if isinstance(self.pspace, JointPSpace):
             return Indexed(self, key)
+
+class JointDistributionHandmade(JointDistribution, NamedArgsMixin):
+
+    _argnames = ('pdf',)
+    is_Continuous = True
+
+    @property
+    def set(self):
+        return self.args[1]
 
 def marginal_distribution(rv, *indices):
     """

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -20,7 +20,7 @@ from sympy.stats.rv import (ProductPSpace, NamedArgsMixin,
      ProductDomain, RandomSymbol, random_symbols, SingleDomain)
 from sympy.stats.crv import (ContinuousDistribution,
     SingleContinuousDistribution, SingleContinuousPSpace)
-from sympy.stats.drv import (DiscreteDistribution, 
+from sympy.stats.drv import (DiscreteDistribution,
     SingleDiscreteDistribution, SingleDiscretePSpace)
 from sympy.matrices import ImmutableMatrix
 from sympy.core.containers import Tuple

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,7 +1,8 @@
 from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt,
     IndexedBase)
-from sympy.stats.rv import _value_check
-from sympy.stats.joint_rv import JointDistribution, JointPSpace
+from sympy.stats.rv import _value_check, random_symbols
+from sympy.stats.joint_rv import (JointDistribution, JointPSpace,
+    JointDistributionHandmade, MarginalDistribution)
 from sympy.matrices import ImmutableMatrix
 from sympy.matrices.expressions.determinant import det
 
@@ -48,15 +49,20 @@ def JointRV(symbol, pdf, _set=None):
     exp(-2)/(2*pi)
     """
     #TODO: Add support for sets provided by the user
-
     symbol = sympify(symbol)
     syms = list(i for i in pdf.free_symbols if isinstance(i, Indexed)
         and i.base == IndexedBase(symbol))
     syms.sort(key = lambda index: index.args[1])
-    pdf = Lambda(syms, pdf)
     _set = S.Reals**len(syms)
+
+    pdf = Lambda(syms, pdf)
     dist = JointDistributionHandmade(pdf, _set)
-    return JointPSpace(symbol, dist).value
+    jrv = JointPSpace(symbol, dist).value
+    rvs = random_symbols(pdf)
+    if len(rvs) != 0:
+        dist = MarginalDistribution(pdf.expr, (jrv,))
+        return JointPSpace(symbol, dist).value
+    return jrv
 
 #-------------------------------------------------------------------------------
 # Multivariate Normal distribution ---------------------------------------------------------

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -54,13 +54,12 @@ def JointRV(symbol, pdf, _set=None):
         and i.base == IndexedBase(symbol))
     syms.sort(key = lambda index: index.args[1])
     _set = S.Reals**len(syms)
-
     pdf = Lambda(syms, pdf)
     dist = JointDistributionHandmade(pdf, _set)
     jrv = JointPSpace(symbol, dist).value
     rvs = random_symbols(pdf)
     if len(rvs) != 0:
-        dist = MarginalDistribution(pdf.expr, (jrv,))
+        dist = MarginalDistribution(dist, (jrv,))
         return JointPSpace(symbol, dist).value
     return jrv
 

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,4 +1,4 @@
-from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Symbol, Gt,
+from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Gt,
     IndexedBase)
 from sympy.stats.rv import _value_check
 from sympy.stats.joint_rv import JointDistribution, JointPSpace
@@ -50,8 +50,9 @@ def JointRV(symbol, pdf, _set=None):
     #TODO: Add support for sets provided by the user
 
     symbol = sympify(symbol)
-    syms = tuple(i for i in pdf.free_symbols if isinstance(i, Indexed)
+    syms = list(i for i in pdf.free_symbols if isinstance(i, Indexed)
         and i.base == IndexedBase(symbol))
+    syms.sort(key = lambda index: index.args[1])
     pdf = Lambda(syms, pdf)
     _set = S.Reals**len(syms)
     dist = JointDistributionHandmade(pdf, _set)
@@ -87,7 +88,7 @@ class MultivariateNormalDistribution(JointDistribution):
                 x))[0]
 
     def marginal_distribution(self, indices, sym):
-        sym = ImmutableMatrix([Symbol(str(Indexed(sym, i))) for i in indices])
+        sym = ImmutableMatrix([Indexed(sym, i) for i in indices])
         _mu, _sigma = self.mu, self.sigma
         k = len(self.mu)
         for i in range(k):

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -1,4 +1,5 @@
-from sympy import sympify, S, pi, sqrt, exp, Lambda, Indexed, Symbol, Gt
+from sympy import (sympify, S, pi, sqrt, exp, Lambda, Indexed, Symbol, Gt,
+    IndexedBase)
 from sympy.stats.rv import _value_check
 from sympy.stats.joint_rv import JointDistribution, JointPSpace
 from sympy.matrices import ImmutableMatrix
@@ -17,6 +18,44 @@ def multivariate_rv(cls, sym, *args):
     args = dist.args
     dist.check(*args)
     return JointPSpace(sym, dist).value
+
+def JointRV(symbol, pdf, _set=None):
+    """
+    Create a Joint Random Variable where each of its component is conitinuous,
+    given the following:
+
+    -- a symbol
+    -- a PDF in terms of indexed symbols of the symbol given
+     as the first argument
+
+    NOTE: As of now, the set for each component for a `JointRV` is
+    equal to the set of all integers, which can not be changed.
+
+    Returns a RandomSymbol.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols, exp, pi, Indexed, S
+    >>> from sympy.stats import density
+    >>> from sympy.stats.joint_rv_types import JointRV
+
+    >>> x1, x2 = (Indexed('x', i) for i in (1, 2))
+    >>> pdf = exp(-x1**2/2 + x1 - x2**2/2 - S(1)/2)/(2*pi)
+
+    >>> N1 = JointRV('x', pdf) #Multivariate Normal distribution
+    >>> density(N1)(1, 2)
+    exp(-2)/(2*pi)
+    """
+    #TODO: Add support for sets provided by the user
+
+    symbol = sympify(symbol)
+    syms = tuple(i for i in pdf.free_symbols if isinstance(i, Indexed)
+        and i.base == IndexedBase(symbol))
+    pdf = Lambda(syms, pdf)
+    _set = S.Reals**len(syms)
+    dist = JointDistributionHandmade(pdf, _set)
+    return JointPSpace(symbol, dist).value
 
 #-------------------------------------------------------------------------------
 # Multivariate Normal distribution ---------------------------------------------------------

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -228,6 +228,7 @@ class RandomSymbol(Expr):
     """
 
     def __new__(cls, symbol, pspace=None):
+        from sympy.stats.joint_rv import JointRandomSymbol
         if pspace is None:
             # Allow single arg, representing pspace == PSpace()
             pspace = PSpace()
@@ -235,6 +236,8 @@ class RandomSymbol(Expr):
             raise TypeError("symbol should be of type Symbol")
         if not isinstance(pspace, PSpace):
             raise TypeError("pspace variable should be of type PSpace")
+        if cls == JointRandomSymbol and isinstance(pspace, SinglePSpace):
+            cls = RandomSymbol
         return Basic.__new__(cls, symbol, pspace)
 
     is_finite = True

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -150,7 +150,7 @@ class PSpace(Basic):
 
     @property
     def values(self):
-        return frozenset(RandomSymbol(sym, self) for sym in self.domain.symbols)
+        return frozenset(RandomSymbol(sym, self) for sym in self.symbols)
 
     @property
     def symbols(self):
@@ -300,7 +300,8 @@ class IndependentProductPSpace(ProductPSpace):
         symbols = FiniteSet(*[val.symbol for val in rs_space_dict.keys()])
 
         # Overlapping symbols
-        if len(symbols) < sum(len(space.symbols) for space in spaces):
+        from sympy.stats.joint_rv import MarginalDistribution
+        if len(symbols) < sum(len(space.symbols) for space in spaces if not isinstance(space.distribution, MarginalDistribution)):
             raise ValueError("Overlapping Random Variables")
 
         if all(space.is_Finite for space in spaces):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -517,6 +517,8 @@ def pspace(expr):
     True
     """
     expr = sympify(expr)
+    if isinstance(expr, RandomSymbol) and expr.pspace != None:
+        return expr.pspace
     rvs = random_symbols(expr)
     if not rvs:
         raise ValueError("Expression containing Random Variable expected, not %s" % (expr))
@@ -1213,6 +1215,9 @@ def pspace_independent(a, b):
     """
     a_symbols = set(pspace(b).symbols)
     b_symbols = set(pspace(a).symbols)
+
+    if len(set(random_symbols(a)).intersection(random_symbols(b))) != 0:
+        return False
 
     if len(a_symbols.intersection(b_symbols)) == 0:
         return True

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -300,8 +300,10 @@ class IndependentProductPSpace(ProductPSpace):
         symbols = FiniteSet(*[val.symbol for val in rs_space_dict.keys()])
 
         # Overlapping symbols
-        from sympy.stats.joint_rv import MarginalDistribution
-        if len(symbols) < sum(len(space.symbols) for space in spaces if not isinstance(space.distribution, MarginalDistribution)):
+        from sympy.stats.joint_rv import MarginalDistribution, CompoundDistribution
+        if len(symbols) < sum(len(space.symbols) for space in spaces if not
+         isinstance(space.distribution, (
+            CompoundDistribution, MarginalDistribution))):
             raise ValueError("Overlapping Random Variables")
 
         if all(space.is_Finite for space in spaces):

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -16,7 +16,7 @@ from sympy.stats import (P, E, where, density, variance, covariance, skewness,
 from sympy import (Symbol, Abs, exp, S, N, pi, simplify, Interval, erf, erfc, Ne,
                    Eq, log, lowergamma, uppergamma, Sum, symbols, sqrt, And, gamma, beta,
                    Piecewise, Integral, sin, cos, besseli, factorial, binomial,
-                   floor, expand_func, Rational, I, re, im, lambdify, hyper, diff, Or)
+                   floor, expand_func, Rational, I, re, im, lambdify, hyper, diff, Or, Mul)
 
 
 from sympy.stats.crv_types import NormalDistribution
@@ -735,7 +735,7 @@ def test_conjugate_priors():
     mu = Normal('mu', 2, 3)
     x = Normal('x', mu, 1)
     assert isinstance(simplify(density(mu, Eq(x, y), evaluate=False)(z)),
-            Integral)
+            Mul)
 
 
 def test_difficult_univariate():

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -20,7 +20,7 @@ from sympy import (Symbol, Abs, exp, S, N, pi, simplify, Interval, erf, erfc, Ne
 
 
 from sympy.stats.crv_types import NormalDistribution
-from sympy.stats.rv import IndependentProductPSpace
+from sympy.stats.joint_rv import JointPSpace
 
 from sympy.utilities.pytest import raises, XFAIL, slow, skip
 from sympy.external import import_module
@@ -720,7 +720,7 @@ def test_random_parameters():
     mu = Normal('mu', 2, 3)
     meas = Normal('T', mu, 1)
     assert density(meas, evaluate=False)(z)
-    assert isinstance(pspace(meas), IndependentProductPSpace)
+    assert isinstance(pspace(meas), JointPSpace)
     #assert density(meas, evaluate=False)(z) == Integral(mu.pspace.pdf *
     #        meas.pspace.pdf, (mu.symbol, -oo, oo)).subs(meas.symbol, z)
 

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -1,4 +1,4 @@
-from sympy import symbols, pi, oo, S, exp, sqrt, besselk, Indexed, simplify, erf
+from sympy import symbols, pi, oo, S, exp, sqrt, besselk, Indexed, erf
 from sympy.stats import density
 from sympy.stats.joint_rv import marginal_distribution
 from sympy.stats.joint_rv_types import JointRV
@@ -67,5 +67,4 @@ def test_JointRV():
     X = JointRV('x', pdf)
     density(X)(1, 2) == exp(-1)/(2*pi)
     assert isinstance(X.pspace.distribution, JointDistributionHandmade)
-    assert str(marginal_distribution(X, 0)(0)) == \
-     str(sqrt(2)*exp(-S(1)/2)*erf(sqrt(2)*x1/2)/(4*sqrt(pi)))
+    assert marginal_distribution(X, 0)(2) == sqrt(2)*exp(-S(1)/2)/(2*sqrt(pi))

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -65,6 +65,6 @@ def test_JointRV():
     x1, x2 = (Indexed('x', i) for i in (1, 2))
     pdf = exp(-x1**2/2 + x1 - x2**2/2 - S(1)/2)/(2*pi)
     X = JointRV('x', pdf)
-    density(X)(1, 2) == exp(-1)/(2*pi)
+    assert density(X)(1, 2) == exp(-2)/(2*pi)
     assert isinstance(X.pspace.distribution, JointDistributionHandmade)
     assert marginal_distribution(X, 0)(2) == sqrt(2)*exp(-S(1)/2)/(2*sqrt(pi))

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -1,6 +1,7 @@
-from sympy import symbols, pi, oo, S, exp, sqrt, besselk
+from sympy import symbols, pi, oo, S, exp, sqrt, besselk, Indexed, simplify, erf
 from sympy.stats import density
 from sympy.stats.joint_rv import marginal_distribution
+from sympy.stats.joint_rv_types import JointRV
 from sympy.stats.crv_types import Normal
 from sympy.utilities.pytest import raises
 from sympy.integrals.integrals import integrate
@@ -58,3 +59,13 @@ def test_JointPSpace_margial_distribution():
     assert marginal_distribution(T, T[1])(x) == sqrt(2)*(x**2 + 2)/(
         8*polar_lift(x**2/2 + 1)**(5/2))
     assert integrate(marginal_distribution(T, 1)(x), (x, -oo, oo)) == 1
+
+def test_JointRV():
+    from sympy.stats.joint_rv import JointDistributionHandmade
+    x1, x2 = (Indexed('x', i) for i in (1, 2))
+    pdf = exp(-x1**2/2 + x1 - x2**2/2 - S(1)/2)/(2*pi)
+    X = JointRV('x', pdf)
+    density(X)(1, 2) == exp(-1)/(2*pi)
+    assert isinstance(X.pspace.distribution, JointDistributionHandmade)
+    assert str(marginal_distribution(X, 0)(0)) == \
+     str(sqrt(2)*exp(-S(1)/2)*erf(sqrt(2)*x1/2)/(4*sqrt(pi)))

--- a/sympy/stats/tests/test_mix.py
+++ b/sympy/stats/tests/test_mix.py
@@ -2,7 +2,7 @@ from sympy.stats import Poisson, Beta, Exponential, P
 from sympy.stats.rv import pspace, density
 from sympy.stats.drv_types import PoissonDistribution
 from sympy.stats.crv_types import Normal
-from sympy.stats.joint_rv import JointPSpace
+from sympy.stats.joint_rv import JointPSpace, MarginalDistribution
 from sympy import Symbol, Eq, Ne, simplify, sqrt, exp, pi
 
 def test_density():
@@ -16,6 +16,12 @@ def test_density():
     N2 = Normal('N2', N1, 2)
     assert simplify(density(N2, Eq(N1, 1))(x)) == \
         sqrt(2)*exp(-(x - 1)**2/8)/(4*sqrt(pi))
+
+def test_compound_distribution():
+    Y = Poisson('Y', 1)
+    Z = Poisson('Z', Y)
+    assert isinstance(pspace(Z), JointPSpace)
+    assert isinstance(pspace(Z).distribution, MarginalDistribution)
 
 def test_mix_expression():
     Y, E = Poisson('Y', 1), Exponential('E', 1)

--- a/sympy/stats/tests/test_mix.py
+++ b/sympy/stats/tests/test_mix.py
@@ -1,6 +1,7 @@
-from sympy.stats import Poisson, Beta, Exponential, P
+from sympy.stats import Poisson, Beta, Exponential, P, simplify, sqrt, exp, pi
 from sympy.stats.rv import pspace, density
 from sympy.stats.drv_types import PoissonDistribution
+from sympy.stats.crv import Normal
 from sympy.stats.joint_rv import JointPSpace
 from sympy import Symbol, Eq, Ne
 
@@ -11,6 +12,10 @@ def test_density():
     X = Poisson(x, rate)
     assert isinstance(pspace(X), JointPSpace)
     assert density(X, Eq(rate, rate.symbol)) == PoissonDistribution(l)
+    N1 = Normal('N1', 0, 1)
+    N2 = Normal('N2', N1, 2)
+    assert simplify(density(N2, Eq(N1, 1))(x)) == \
+        sqrt(2)*exp(-(x - 1)**2/8)/(4*sqrt(pi))
 
 def test_mix_expression():
     Y, E = Poisson('Y', 1), Exponential('E', 1)

--- a/sympy/stats/tests/test_mix.py
+++ b/sympy/stats/tests/test_mix.py
@@ -1,6 +1,7 @@
 from sympy.stats import Poisson, Beta, Exponential, P
-from sympy.stats.rv import pspace, IndependentProductPSpace, density
+from sympy.stats.rv import pspace, density
 from sympy.stats.drv_types import PoissonDistribution
+from sympy.stats.joint_rv import JointPSpace
 from sympy import Symbol, Eq, Ne
 
 def test_density():
@@ -8,7 +9,7 @@ def test_density():
     l = Symbol('l', positive=True)
     rate = Beta(l, 2, 3)
     X = Poisson(x, rate)
-    assert isinstance(pspace(X), IndependentProductPSpace)
+    assert isinstance(pspace(X), JointPSpace)
     assert density(X, Eq(rate, rate.symbol)) == PoissonDistribution(l)
 
 def test_mix_expression():

--- a/sympy/stats/tests/test_mix.py
+++ b/sympy/stats/tests/test_mix.py
@@ -1,9 +1,9 @@
-from sympy.stats import Poisson, Beta, Exponential, P, simplify, sqrt, exp, pi
+from sympy.stats import Poisson, Beta, Exponential, P
 from sympy.stats.rv import pspace, density
 from sympy.stats.drv_types import PoissonDistribution
-from sympy.stats.crv import Normal
+from sympy.stats.crv_types import Normal
 from sympy.stats.joint_rv import JointPSpace
-from sympy import Symbol, Eq, Ne
+from sympy import Symbol, Eq, Ne, simplify, sqrt, exp, pi
 
 def test_density():
     x = Symbol('x')

--- a/sympy/stats/tests/test_mix.py
+++ b/sympy/stats/tests/test_mix.py
@@ -2,8 +2,8 @@ from sympy.stats import Poisson, Beta, Exponential, P
 from sympy.stats.rv import pspace, density
 from sympy.stats.drv_types import PoissonDistribution
 from sympy.stats.crv_types import Normal
-from sympy.stats.joint_rv import JointPSpace, MarginalDistribution
-from sympy import Symbol, Eq, Ne, simplify, sqrt, exp, pi
+from sympy.stats.joint_rv import JointPSpace, CompoundDistribution
+from sympy import S, Symbol, Eq, Ne, simplify, sqrt, exp, pi, Integral
 
 def test_density():
     x = Symbol('x')
@@ -14,6 +14,7 @@ def test_density():
     assert density(X, Eq(rate, rate.symbol)) == PoissonDistribution(l)
     N1 = Normal('N1', 0, 1)
     N2 = Normal('N2', N1, 2)
+    assert density(N2)(0).doit() == sqrt(10)/(10*sqrt(pi))
     assert simplify(density(N2, Eq(N1, 1))(x)) == \
         sqrt(2)*exp(-(x - 1)**2/8)/(4*sqrt(pi))
 
@@ -21,7 +22,7 @@ def test_compound_distribution():
     Y = Poisson('Y', 1)
     Z = Poisson('Z', Y)
     assert isinstance(pspace(Z), JointPSpace)
-    assert isinstance(pspace(Z).distribution, MarginalDistribution)
+    assert isinstance(pspace(Z).distribution, CompoundDistribution)
 
 def test_mix_expression():
     Y, E = Poisson('Y', 1), Exponential('E', 1)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
Added `JointRV`, which allows the user to create a joint random variable
with each of its component varying over the real line. Also added
`JointDistributionHandmade` for this purpose. 
Added `MarginalDistribution` to allow random variables with components marginalized out. This also adds the ability to handle compound random variables by marginalizing over latent distributions, with or without a given condition.

#### Other comments
Same code as #14951 is added, which has to be closed due to some extra commits showing up.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
    * Add `JointRV` to allow user to create Joint random variables
    * Add `MarginalDistribution`, `CompoundDistribution`
    * Ability to handle compound distributions 
<!-- END RELEASE NOTES -->
