### PR TITLE
Mul commutativity with AccumBounds

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -362,3 +362,6 @@ def test_contains_AccumBounds():
 
     # issue 13159
     assert Mul(0, AccumBounds(-1, 1)) == Mul(AccumBounds(-1, 1), 0) == 0
+    import itertools
+    for perm in itertools.permutations([0, AccumBounds(-1, 1), x]):
+        assert Mul(*perm) == 0

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -262,7 +262,7 @@ class Mul(Expr, AssocOp):
                 if o is S.NaN or coeff is S.ComplexInfinity and o is S.Zero:
                     # we know for sure the result will be nan
                     return [S.NaN], [], None
-                elif coeff.is_Number:  # it could be zoo
+                elif coeff.is_Number or isinstance(coeff, AccumBounds):  # it could be zoo
                     coeff *= o
                     if coeff is S.NaN:
                         # we know for sure the result will be nan


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #13159 

#### Brief description of what is fixed or changed

Changing the line 265 of `mul.py` in the following way:
`elif coeff.is_Number: # it could be zoo` (original line)
`elif coeff.is_Number or isinstance(coeff, AccumBounds): # it could be zoo` (modified)

the code

```
                    coeff *= o
                    if coeff is S.NaN:
                        # we know for sure the result will be nan
                        return [S.NaN], [], None

```
is executed also in the case `coeff` is `AccumBounds(-1, 1)` (or similar) and,
in case `o` is `0`, then `coeff` becomes `0`.

#### Other comments

A test is added.


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * fixed a bug about commutativity of Mul with AccumBounds

<!-- END RELEASE NOTES -->
