### PR TITLE
Fix regression in cse with ignore

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -276,6 +276,10 @@ class Unevaluated(object):
     def as_unevaluated_basic(self):
         return self.func(*self.args, evaluate=False)
 
+    @property
+    def free_symbols(self):
+        return set().union(*[a.free_symbols for a in self.args])
+
     __repr__ = __str__
 
 

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -494,6 +494,14 @@ def test_cse_ignore():
     assert not any(y in sub.free_symbols for _, sub in subst2), "Sub-expressions containing y must be ignored"
     assert any(sub - sqrt(x + 1) == 0 for _, sub in subst2), "cse failed to identify sqrt(x + 1) as sub-expression"
 
+def test_cse_ignore_issue_15002():
+    l = [
+        w*exp(x)*exp(-z),
+        exp(y)*exp(x)*exp(-z)
+    ]
+    substs, reduced = cse(l, ignore=(x,))
+    rl = [e.subs(reversed(substs)) for e in reduced]
+    assert rl == l
 
 def test_cse__performance():
     import time


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15002 


#### Brief description of what is fixed or changed
The `Unevaluated` class in `cse_main.py` did not have a `free_symbols` property
which—for certain expressions—caused failures when kwarg `ignore` was also given to `cse`.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * fixed a bug in `cse` which triggered for certain expressions when `ignore` was also given.
<!-- END RELEASE NOTES -->
