### PR TITLE
Added support for naming of Indexed types and avoid passing unnecessary kw_args

### DIFF
--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -161,11 +161,7 @@ class Indexed(Expr):
 
     @property
     def name(self):
-        indices_str = "["
-        for index in self.args[1:-1]:
-            indices_str += str(index) + ","
-        indices_str += str(self.args[-1]) + "]"
-        return self.base.name + indices_str
+        return str(self)
 
     @property
     def _diff_wrt(self):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -401,9 +401,9 @@ class IndexedBase(Expr, NotIterable):
         strides = kw_args.pop('strides', None)
 
         if shape is not None:
-            obj = Expr.__new__(cls, label, shape, **kw_args)
+            obj = Expr.__new__(cls, label, shape)
         else:
-            obj = Expr.__new__(cls, label, **kw_args)
+            obj = Expr.__new__(cls, label)
         obj._shape = shape
         obj._offset = offset
         obj._strides = strides

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -407,12 +407,12 @@ class IndexedBase(Expr, NotIterable):
         obj._shape = shape
         obj._offset = offset
         obj._strides = strides
-        obj.__name__ = str(label)
+        obj._name = str(label)
         return obj
 
     @property
     def name(self):
-        return self.__name__
+        return self._name
 
     def __getitem__(self, indices, **kw_args):
         if is_sequence(indices):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -160,6 +160,14 @@ class Indexed(Expr):
         return Expr.__new__(cls, base, *args, **kw_args)
 
     @property
+    def name(self):
+        indices_str = "["
+        for index in self.args[1:-1]:
+            indices_str += str(index) + ","
+        indices_str += str(self.args[-1]) + "]"
+        return self.base.name + indices_str
+
+    @property
     def _diff_wrt(self):
         """Allow derivatives with respect to an ``Indexed`` object."""
         return True
@@ -403,7 +411,12 @@ class IndexedBase(Expr, NotIterable):
         obj._shape = shape
         obj._offset = offset
         obj._strides = strides
+        obj.__name__ = str(label)
         return obj
+
+    @property
+    def name(self):
+        return self.__name__
 
     def __getitem__(self, indices, **kw_args):
         if is_sequence(indices):

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -229,6 +229,7 @@ def test_Indexed_subs():
 def test_Indexed_properties():
     i, j = symbols('i j', integer=True)
     A = Indexed('A', i, j)
+    assert A.name == 'A[i,j]'
     assert A.rank == 2
     assert A.indices == (i, j)
     assert A.base == IndexedBase('A')

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -229,7 +229,7 @@ def test_Indexed_subs():
 def test_Indexed_properties():
     i, j = symbols('i j', integer=True)
     A = Indexed('A', i, j)
-    assert A.name == 'A[i,j]'
+    assert A.name == 'A[i, j]'
     assert A.rank == 2
     assert A.indices == (i, j)
     assert A.base == IndexedBase('A')


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #14960 

#### Brief description of what is fixed or changed
* IndexedBase and Indexed types have been given a name attribute. 
* kw_args are not unnecessarily passed to Expr when creating an IndexedBase object
#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added naming for IndexedBase and Indexed types
  * Avoid passing kw_args to Expr during IndexedBase object creation
<!-- END RELEASE NOTES -->