### PR TITLE
Fix f(x,y).diff(y,y,x,y,x)

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1298,29 +1298,11 @@ class Derivative(Expr):
 
     @classmethod
     def _sort_variable_count(cls, varcounts):
-        """Like ``_sort_variables``, but acting on variable-count pairs.
-
-        Examples
-        ========
-
-        >>> from sympy import Derivative, Function, symbols
-        >>> vsort = Derivative._sort_variable_count
-        >>> x, y, z = symbols('x y z')
-        >>> f, g, h = symbols('f g h', cls=Function)
-
-        >>> vsort([(x, 1), (y, 2), (z, 1)])
-        [(x, 1), (y, 2), (z, 1)]
-
-        >>> vsort([(z, 1), (y, 1), (x, 1), (h(x), 1), (g(x), 1), (f(x), 1)])
-        [(x, 1), (y, 1), (z, 1), (f(x), 1), (g(x), 1), (h(x), 1)]
         """
-        d = dict(varcounts)
-        varsorted = cls._sort_variables([i for i, j in varcounts])
-        return [Tuple(var, d[var]) for var in varsorted]
+        Sort (variable, count) pairs by variable, but disallow sorting of non-symbols.
 
-    @classmethod
-    def _sort_variables(cls, vars):
-        """Sort variables, but disallow sorting of non-symbols.
+        The count is not sorted. It is kept in the same order as the input
+        after sorting by variable.
 
         When taking derivatives, the following rules usually hold:
 
@@ -1332,54 +1314,54 @@ class Derivative(Expr):
         ========
 
         >>> from sympy import Derivative, Function, symbols
-        >>> vsort = Derivative._sort_variables
+        >>> vsort = Derivative._sort_variable_count
         >>> x, y, z = symbols('x y z')
         >>> f, g, h = symbols('f g h', cls=Function)
 
-        >>> vsort((x,y,z))
-        [x, y, z]
+        >>> vsort([(x, 3), (y, 2), (z, 1)])
+        [(x, 3), (y, 2), (z, 1)]
 
-        >>> vsort((h(x),g(x),f(x)))
-        [f(x), g(x), h(x)]
+        >>> vsort([(h(x), 1), (g(x), 1), (f(x), 1)])
+        [(f(x), 1), (g(x), 1), (h(x), 1)]
 
-        >>> vsort((z,y,x,h(x),g(x),f(x)))
-        [x, y, z, f(x), g(x), h(x)]
+        >>> vsort([(z, 1), (y, 2), (x, 3), (h(x), 1), (g(x), 1), (f(x), 1)])
+        [(x, 3), (y, 2), (z, 1), (f(x), 1), (g(x), 1), (h(x), 1)]
 
-        >>> vsort((x,f(x),y,f(y)))
-        [x, f(x), y, f(y)]
+        >>> vsort([(x, 1), (f(x), 1), (y, 1), (f(y), 1)])
+        [(x, 1), (f(x), 1), (y, 1), (f(y), 1)]
 
-        >>> vsort((y,x,g(x),f(x),z,h(x),y,x))
-        [x, y, f(x), g(x), z, h(x), x, y]
+        >>> vsort([(y, 1), (x, 2), (g(x), 1), (f(x), 1), (z, 1), (h(x), 1), (y, 2), (x, 1)])
+        [(x, 2), (y, 1), (f(x), 1), (g(x), 1), (z, 1), (h(x), 1), (x, 1), (y, 2)]
 
-        >>> vsort((z,y,f(x),x,f(x),g(x)))
-        [y, z, f(x), x, f(x), g(x)]
+        >>> vsort([(z, 1), (y, 1), (f(x), 1), (x, 1), (f(x), 1), (g(x), 1)])
+        [(y, 1), (z, 1), (f(x), 1), (x, 1), (f(x), 1), (g(x), 1)]
 
-        >>> vsort((z,y,f(x),x,f(x),g(x),z,z,y,x))
-        [y, z, f(x), x, f(x), g(x), x, y, z, z]
+        >>> vsort([(z, 1), (y, 2), (f(x), 1), (x, 2), (f(x), 2), (g(x), 1), (z, 2), (z, 1), (y, 1), (x, 1)])
+        [(y, 2), (z, 1), (f(x), 1), (x, 2), (f(x), 2), (g(x), 1), (x, 1), (y, 1), (z, 2), (z, 1)]
+
         """
-
         sorted_vars = []
         symbol_part = []
         non_symbol_part = []
-        for v in vars:
+        for (v, c) in varcounts:
             if not v.is_symbol:
                 if len(symbol_part) > 0:
                     sorted_vars.extend(sorted(symbol_part,
-                                              key=default_sort_key))
+                                              key=lambda i: default_sort_key(i[0])))
                     symbol_part = []
-                non_symbol_part.append(v)
+                non_symbol_part.append((v, c))
             else:
                 if len(non_symbol_part) > 0:
                     sorted_vars.extend(sorted(non_symbol_part,
-                                              key=default_sort_key))
+                                              key=lambda i: default_sort_key(i[0])))
                     non_symbol_part = []
-                symbol_part.append(v)
+                symbol_part.append((v, c))
         if len(non_symbol_part) > 0:
             sorted_vars.extend(sorted(non_symbol_part,
-                                      key=default_sort_key))
+                                      key=lambda i: default_sort_key(i[0])))
         if len(symbol_part) > 0:
             sorted_vars.extend(sorted(symbol_part,
-                                      key=default_sort_key))
+                                      key=lambda i: default_sort_key(i[0])))
         return sorted_vars
 
     def _eval_is_commutative(self):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1362,7 +1362,7 @@ class Derivative(Expr):
         if len(symbol_part) > 0:
             sorted_vars.extend(sorted(symbol_part,
                                       key=lambda i: default_sort_key(i[0])))
-        return sorted_vars
+        return [Tuple(*i) for i in sorted_vars]
 
     def _eval_is_commutative(self):
         return self.expr.is_commutative

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -628,18 +628,29 @@ def test_straight_line():
 
 
 def test_sort_variable():
-    vsort = Derivative._sort_variables
+    vsort = Derivative._sort_variable_count
 
-    assert vsort((x, y, z)) == [x, y, z]
-    assert vsort((h(x), g(x), f(x))) == [f(x), g(x), h(x)]
-    assert vsort((z, y, x, h(x), g(x), f(x))) == [x, y, z, f(x), g(x), h(x)]
-    assert vsort((x, f(x), y, f(y))) == [x, f(x), y, f(y)]
-    assert vsort((y, x, g(x), f(x), z, h(x), y, x)) == \
-        [x, y, f(x), g(x), z, h(x), x, y]
-    assert vsort((z, y, f(x), x, f(x), g(x))) == [y, z, f(x), x, f(x), g(x)]
-    assert vsort((z, y, f(x), x, f(x), g(x), z, z, y, x)) == \
-        [y, z, f(x), x, f(x), g(x), x, y, z, z]
+    assert vsort([(x, 3), (y, 2), (z, 1)]) == [(x, 3), (y, 2), (z, 1)]
 
+    assert vsort([(h(x), 1), (g(x), 1), (f(x), 1)]) == [(f(x), 1), (g(x), 1), (h(x), 1)]
+
+    assert vsort([(z, 1), (y, 2), (x, 3), (h(x), 1), (g(x), 1), (f(x), 1)]) == [(x, 3), (y, 2), (z, 1), (f(x), 1), (g(x), 1), (h(x), 1)]
+
+    assert vsort([(x, 1), (f(x), 1), (y, 1), (f(y), 1)]) == [(x, 1), (f(x), 1), (y, 1), (f(y), 1)]
+
+    assert vsort([(y, 1), (x, 2), (g(x), 1), (f(x), 1), (z, 1), (h(x), 1), (y, 2), (x, 1)]) == [(x, 2), (y, 1), (f(x), 1), (g(x), 1), (z, 1), (h(x), 1), (x, 1), (y, 2)]
+
+    assert vsort([(z, 1), (y, 1), (f(x), 1), (x, 1), (f(x), 1), (g(x), 1)]) == [(y, 1), (z, 1), (f(x), 1), (x, 1), (f(x), 1), (g(x), 1)]
+
+    assert vsort([(z, 1), (y, 2), (f(x), 1), (x, 2), (f(x), 2), (g(x), 1),
+    (z, 2), (z, 1), (y, 1), (x, 1)]) == [(y, 2), (z, 1), (f(x), 1), (x, 2), (f(x), 2), (g(x), 1), (x, 1), (y, 1), (z, 2), (z, 1)]
+
+
+    assert vsort(((y, 2), (x, 1), (y, 1), (x, 1))) == [(x, 1), (x, 1), (y, 2), (y, 1)]
+
+def test_multiple_derivative():
+    # Issue #15007
+    assert f(x,y).diff(y,y,x,y,x) == Derivative(f(x, y), (x, 2), (y, 3))
 
 def test_unhandled():
     class MyExpr(Expr):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -648,6 +648,8 @@ def test_sort_variable():
 
     assert vsort(((y, 2), (x, 1), (y, 1), (x, 1))) == [(x, 1), (x, 1), (y, 2), (y, 1)]
 
+    assert isinstance(vsort([(x, 3), (y, 2), (z, 1)])[0], Tuple)
+
 def test_multiple_derivative():
     # Issue #15007
     assert f(x,y).diff(y,y,x,y,x) == Derivative(f(x, y), (x, 2), (y, 3))


### PR DESCRIPTION
It used to give `Derivative(f(x, y), (x, 2), (y, 2))`. Now it correctly gives
`Derivative(f(x, y), (x, 2), (y, 3))`.

`Derivative._sort_variables` was removed and merged into
`Derivative._sort_variable_count`. The separation does not make sense as it
needs to keep the counts together with the variables when sorting. The issue
was that `Derivative._sort_variable_count` was sorting `((y, 2), (x, 1), (y, 1),
(x, 1))` with `Derivative._sort_variables`, which sorted into `[x, x, y, y]`, but
the count information was lost and it created `[(x, 1), (x, 1), (y, 1), (y,
1)]`.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15007.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * fixed a wrong result with certain multivariable derivatives like `f(x, y).diff(y, y, x, y, x)`
<!-- END RELEASE NOTES -->
