### PR TITLE
lambdify: handle MatrixSymbols and add check for dummify in _preprocess default case

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -739,7 +739,14 @@ class _EvaluatorPrinter(object):
                 argstrs.append(self._argrepr(dummy))
                 expr = self._subexpr(expr, {arg: dummy})
             else:
-                argstrs.append(str(arg))
+                argrep = self._argrepr(arg)
+
+                if dummify:
+                    dummy = Dummy()
+                    argstrs.append(self._argrepr(dummy))
+                    expr = self._subexpr(expr, {arg: dummy})
+                else:
+                    argstrs.append(str(arg))
 
         return argstrs, expr
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -700,14 +700,13 @@ class _EvaluatorPrinter(object):
             return isinstance(ident, str) and cls._safe_ident_re.match(ident) \
                 and not (keyword.iskeyword(ident) or ident == 'None')
 
-
     def _preprocess(self, args, expr):
         """Preprocess args, expr to replace arguments that do not map
         to valid Python identifiers.
 
         Returns string form of args, and updated expr.
         """
-        from sympy import Dummy, Symbol, Function, flatten
+        from sympy import Dummy, Symbol, MatrixSymbol, Function, flatten
         from sympy.matrices import DeferredVector
 
         dummify = self._dummify
@@ -725,7 +724,7 @@ class _EvaluatorPrinter(object):
                 argstrs.append(nested_argstrs)
             elif isinstance(arg, DeferredVector):
                 argstrs.append(str(arg))
-            elif isinstance(arg, Symbol):
+            elif isinstance(arg, Symbol) or isinstance(arg, MatrixSymbol):
                 argrep = self._argrepr(arg)
 
                 if dummify or not self._is_safe_ident(argrep):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -728,6 +728,12 @@ def test_dummification():
     raises(SyntaxError, lambda: lambdify(2 * F(t), 2 * F(t) + 5))
     raises(SyntaxError, lambda: lambdify(2 * F(t), 4 * F(t) + 5))
 
+def test_curlyMatrixSymbol():
+    # Issue #15009
+    curlyv = sympy.MatrixSymbol("{v}", 2, 1)
+    lam = sympy.lambdify(curlyv, curlyv, dummify=True)
+    assert lam(1)==1
+
 def test_python_keywords():
     # Test for issue 7452. The automatic dummification should ensure use of
     # Python reserved keywords as symbol names will create valid lambda

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -728,10 +728,12 @@ def test_dummification():
     raises(SyntaxError, lambda: lambdify(2 * F(t), 2 * F(t) + 5))
     raises(SyntaxError, lambda: lambdify(2 * F(t), 4 * F(t) + 5))
 
-def test_curlyMatrixSymbol():
+def test_curly_matrix_symbol():
     # Issue #15009
     curlyv = sympy.MatrixSymbol("{v}", 2, 1)
-    lam = sympy.lambdify(curlyv, curlyv, dummify=True)
+    lam = lambdify(curlyv, curlyv)
+    assert lam(1)==1
+    lam = lambdify(curlyv, curlyv, dummify=True)
     assert lam(1)==1
 
 def test_python_keywords():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15009
#### Brief description of what is fixed or changed
- instances of MatrixSymbols are treated the same way as instances of Symbols are treated in _preprocess 

- added check for dummify in _preprocess default case

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * fixed a bug with lambdify on curly bracket symbols 
<!-- END RELEASE NOTES -->
