### PR TITLE
Correctly printing 4th derivative

### DIFF
--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -148,6 +148,8 @@ class VectorLatexPrinter(LatexPrinter):
             base = r"\ddot{%s}" % base
         elif dots == 3:
             base = r"\dddot{%s}" % base
+        elif dots == 4:
+            base = r"\ddddot{%s}" % base
         if len(base_split) is not 1:
             base += '_' + base_split[1]
         return base


### PR DESCRIPTION
Adding elif statement to _print_Derivative function to handle 4th derivatives

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #10173

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * printing._print_Derivative now prints the 4th derivative
<!-- END RELEASE NOTES -->
