### PR TITLE
Update the signature of class-specific simplification methods

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -318,7 +318,7 @@ class Product(ExprWithIntLimits):
             else:
                 return f
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         from sympy.simplify.simplify import product_simplify
         return product_simplify(self)
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -270,7 +270,7 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         return Sum(f, (k, upper + 1, new_upper)).doit()
 
-    def _eval_simplify(self, ratio=1.7, measure=None):
+    def _eval_simplify(self, ratio=1.7, measure=None, rational=False, inverse=False):
         from sympy.simplify.simplify import factor_sum, sum_combine
         from sympy.core.function import expand
         from sympy.core.mul import Mul

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1761,7 +1761,7 @@ class Atom(Basic):
     def sort_key(self, order=None):
         return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         return self
 
     @property

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3167,7 +3167,7 @@ class Expr(Basic, EvalfMixin):
         from sympy.integrals import integrate
         return integrate(self, *args, **kwargs)
 
-    def simplify(self, ratio=1.7, measure=None):
+    def simplify(self, ratio=1.7, measure=None, rational=False, inverse=False):
         """See the simplify function in sympy.simplify"""
         from sympy.simplify import simplify
         from sympy.core.function import count_ops

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2455,7 +2455,7 @@ class AlgebraicNumber(Expr):
 
         return AlgebraicNumber((minpoly, root), self.coeffs())
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         from sympy.polys import CRootOf, minpoly
 
         for r in [r for r in self.minpoly.all_roots() if r.func != CRootOf]:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -203,9 +203,9 @@ class Relational(Boolean, Expr, EvalfMixin):
                     return r
                 return l
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         r = self
-        r = r.func(*[i.simplify(ratio=ratio, measure=measure)
+        r = r.func(*[i.simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
             for i in r.args])
         if r.is_Relational:
             dif = r.lhs - r.rhs

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -18,7 +18,7 @@ from sympy.polys.polytools import Poly
 class CombinatorialFunction(Function):
     """Base class for combinatorial functions. """
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         from sympy.simplify.combsimp import combsimp
         # combinatorial function with non-integer arguments is
         # automatically passed to gammasimp

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -378,7 +378,7 @@ class sign(Function):
         if arg.is_real:
             return Heaviside(arg)*2-1
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         return self.func(self.args[0].factor())
 
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -652,11 +652,15 @@ class log(Function):
 
         return self.func(arg)
 
-    def _eval_simplify(self, ratio, measure):
-        from sympy.simplify.simplify import expand_log, simplify
+    def _eval_simplify(self, ratio, measure, rational, inverse):
+        from sympy.simplify.simplify import expand_log, simplify, inversecombine
         if (len(self.args) == 2):
-            return simplify(self.func(*self.args), ratio=ratio, measure=measure)
-        expr = self.func(simplify(self.args[0], ratio=ratio, measure=measure))
+            return simplify(self.func(*self.args), ratio=ratio, measure=measure,
+                            rational=rational, inverse=inverse)
+        expr = self.func(simplify(self.args[0], ratio=ratio, measure=measure,
+                         rational=rational, inverse=inverse))
+        if inverse:
+            expr = inversecombine(expr)
         expr = expand_log(expr, deep=True)
         return min([expr, self], key=measure)
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -79,7 +79,7 @@ class BesselBase(Function):
                         self._a*self._b*f(nu + 2, z)._eval_expand_func())
         return self
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         from sympy.simplify.simplify import besselsimp
         return besselsimp(self)
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -302,7 +302,7 @@ class hyper(TupleParametersBase):
         c3 = And(re(e) >= 1, abs(z) < 1)
         return Or(c1, c2, c3)
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         from sympy.simplify.hyperexpand import hyperexpand
         return hyperexpand(self)
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -411,7 +411,7 @@ class BooleanFunction(Application, Boolean):
     """
     is_Boolean = True
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         return simplify_logic(self)
 
     # /// drop when Py2 is no longer supported
@@ -672,10 +672,10 @@ class Not(BooleanFunction):
         if isinstance(arg, GreaterThan):
             return StrictLessThan(*arg.args)
 
-    def _eval_simplify(self, ratio, measure):
+    def _eval_simplify(self, ratio, measure, rational, inverse):
         x = self.args[0]
         try:
-            x._eval_simplify(ratio, measure)
+            x._eval_simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
         except:
             pass
         return self.func(x)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -1769,7 +1769,7 @@ class MatrixOperations(MatrixRequired):
         """
         return self.applyfunc(lambda x: x.replace(F, G, map))
 
-    def simplify(self, ratio=1.7, measure=count_ops):
+    def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
         """Apply simplify to each element of the matrix.
 
         Examples
@@ -1783,7 +1783,8 @@ class MatrixOperations(MatrixRequired):
         >>> _.simplify()
         Matrix([[x]])
         """
-        return self.applyfunc(lambda x: x.simplify(ratio, measure))
+        return self.applyfunc(lambda x: x.simplify(ratio=ratio, measure=measure,
+                                                   rational=rational, inverse=inverse))
 
     def subs(self, *args, **kwargs):  # should mirror core.basic.subs
         """Return a new matrix with subs applied to each entry.

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -739,7 +739,7 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         for k in range(0, self.cols):
             self[i, k], self[j, k] = self[j, k], self[i, k]
 
-    def simplify(self, ratio=1.7, measure=count_ops):
+    def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
         """Applies simplify to the elements of a matrix in place.
 
         This is a shortcut for M.applyfunc(lambda x: simplify(x, ratio, measure))
@@ -750,8 +750,8 @@ class MutableDenseMatrix(DenseMatrix, MatrixBase):
         sympy.simplify.simplify.simplify
         """
         for i in range(len(self._mat)):
-            self._mat[i] = _simplify(self._mat[i], ratio=ratio,
-                                     measure=measure)
+            self._mat[i] = _simplify(self._mat[i], ratio=ratio, measure=measure,
+                                     rational=rational, inverse=inverse)
 
     def zip_row_op(self, i, k, f):
         """In-place operation on row ``i`` using two-arg functor whose args are

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -518,7 +518,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
     expr = sympify(expr)
 
     try:
-        return expr._eval_simplify(ratio=ratio, measure=measure)
+        return expr._eval_simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
     except AttributeError:
         pass
 
@@ -537,7 +537,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False):
             return expr
 
     if not isinstance(expr, (Add, Mul, Pow, ExpBase)):
-        return expr.func(*[simplify(x, ratio=ratio, measure=measure, rational=rational)
+        return expr.func(*[simplify(x, ratio=ratio, measure=measure, rational=rational, inverse=inverse)
                          for x in expr.args])
 
     if not expr.is_commutative:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -707,6 +707,10 @@ def test_simplify_function_inverse():
     assert simplify(f(g(sin(x)**2 + cos(x)**2)), inverse=True) == 1
     assert simplify(f(g(x, y)), inverse=True) == f(g(x, y))
     assert simplify(2*asin(sin(3*x)), inverse=True) == 6*x
+    assert simplify(log(exp(x))) == log(exp(x))
+    assert simplify(log(exp(x)), inverse=True) == x
+    assert simplify(log(exp(x), 2), inverse=True) == x/log(2)
+    assert simplify(log(exp(x), 2, evaluate=False), inverse=True) == x/log(2)
 
 
 def test_clear_coefficients():

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -72,7 +72,7 @@ class BasisDependent(Expr):
 
     n = evalf
 
-    def simplify(self, ratio=1.7, measure=count_ops):
+    def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
         """
         Implements the SymPy simplify routine for this quantity.
 
@@ -80,7 +80,8 @@ class BasisDependent(Expr):
         ========================
 
         """
-        simp_components = [simp(v, ratio, measure) * k for
+        simp_components = [simp(v, ratio=ratio, measure=measure,
+                           rational=rational, inverse=inverse) * k for
                            k, v in self.components.items()]
         return self._add_func(*simp_components)
 
@@ -100,8 +101,8 @@ class BasisDependent(Expr):
 
     trigsimp.__doc__ += tsimp.__doc__
 
-    def _eval_simplify(self, ratio, measure):
-        return self.simplify(ratio, measure)
+    def _eval_simplify(self, ratio, measure, rational, inverse):
+        return self.simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
 
     def _eval_trigsimp(self, **opts):
         return self.trigsimp(**opts)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15032

#### Brief description of what is fixed or changed

Updates the signature of various class-specific simplification methods `_eval_simplify` to include `rational` and `inverse` flags that are used by `simplify` function (which calls these methods). In case of log class, the `inverse` method is used right there; but usually these flags are passed through.
 
#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * fixed a bug in the simplification of inverses, such as `simplify(log(exp(x)), inverse=True)`.
<!-- END RELEASE NOTES -->
