### PR TITLE
Added implementation of Cauchy's principal value in integrals.py

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1269,6 +1269,7 @@ class Integral(AddWithLimits):
         0
         >>> Integral(f, (x, -10, oo)).principal_value() + Integral(f, (x, -oo, 10)).principal_value()
         0
+
         References
         ==========
         .. [1] http://en.wikipedia.org/wiki/Cauchy_principal_value
@@ -1296,14 +1297,11 @@ class Integral(AddWithLimits):
         if F.has(Integral):
             return self
         if a is -oo and b is oo:
-            if len(singularities_list) == 0:
-                I = limit(F - F.subs(x, -x), x, oo)
-            else:
-                I = limit(F.subs(x, u) - F.subs(x, -u), u, oo)
+            I = limit(F.subs(x, u) - F.subs(x, -u), u, oo)
         else:
             I = limit(F, x, b, '-') - limit(F, x, a, '+')
-        for s in range(len(singularities_list)):
-            I += limit(((F.subs(x, singularities_list[s] - r)) - F.subs(x, singularities_list[s] + r)), r, 0, '+')
+        for s in singularities_list:
+            I += limit(((F.subs(x, s - r)) - F.subs(x, s + r)), r, 0, '+')
         return I
 
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1255,6 +1255,7 @@ class Integral(AddWithLimits):
 
         Examples
         ========
+
         >>> from sympy import Dummy, symbols, integrate, limit, oo
         >>> from sympy.integrals.integrals import Integral
         >>> from sympy.calculus.singularities import singularities
@@ -1286,10 +1287,9 @@ class Integral(AddWithLimits):
         if a == b:
             return 0
         r = Dummy('r')
-        u = Dummy('u')
         singularities_list = [s for s in singularities(self.function, x) if s.is_comparable and a <= s <= b]
         for i in singularities_list:
-            if ((i == b) or (i == a)):
+            if (i == b) or (i == a):
                 raise ValueError(
                     'The principal value is not defined in the given interval due to singularity at %d.' % (i))
         f = self.function
@@ -1297,7 +1297,7 @@ class Integral(AddWithLimits):
         if F.has(Integral):
             return self
         if a is -oo and b is oo:
-            I = limit(F.subs(x, u) - F.subs(x, -u), u, oo)
+            I = limit(F - F.subs(x, -x), x, oo)
         else:
             I = limit(F, x, b, '-') - limit(F, x, a, '+')
         for s in singularities_list:

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1250,17 +1250,21 @@ class Integral(AddWithLimits):
         """
         Compute the Cauchy Principal Value of the definite integral of a real function in the given interval
         on the real axis.
+
         In mathematics, the Cauchy principal value, is a method for assigning values to certain improper
         integrals which would otherwise be undefined.
+
         Examples
         ========
         >>> from sympy import Dummy, symbols, integrate, limit, oo
         >>> from sympy.integrals.integrals import Integral
         >>> from sympy.calculus.singularities import singularities
         >>> x = symbols('x')
+
         >>> g = x + 1
         >>> Integral(g, (x, -oo, oo)).principal_value()
         oo
+
         >>> f = 1 / (x**3)
         >>> Integral(f, (x, -oo, oo)).principal_value()
         0
@@ -1268,6 +1272,7 @@ class Integral(AddWithLimits):
         0
         >>> Integral(f, (x, -10, oo)).principal_value() + Integral(f, (x, -oo, 10)).principal_value()
         0
+        
         References
         ==========
         .. [1] http://en.wikipedia.org/wiki/Cauchy_principal_value

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1246,6 +1246,89 @@ class Integral(AddWithLimits):
                                     hold=True)
         return f
 
+    def principal_value(self):
+        """
+        Compute the Cauchy Principal Value of the definite integral of a real function in the given interval
+        on the real axis.
+        In mathematics, the Cauchy principal value, is a method for assigning values to certain improper
+        integrals which would otherwise be undefined.
+        Examples
+        ========
+        >>> from sympy import Dummy, symbols, integrate, limit, oo
+        >>> from sympy.integrals.integrals import Integral
+        >>> from sympy.calculus.singularities import singularities
+        >>> x = symbols('x')
+        >>> g = x + 1
+        >>> Integral(g, (x, -oo, oo)).principal_value()
+        oo
+        >>> f = 1 / (x**3)
+        >>> Integral(f, (x, -oo, oo)).principal_value()
+        0
+        >>> Integral(f, (x, -10, 10)).principal_value()
+        0
+        >>> Integral(f, (x, -10, oo)).principal_value() + Integral(f, (x, -oo, 10)).principal_value()
+        0
+        References
+        ==========
+        .. [1] http://en.wikipedia.org/wiki/Cauchy_principal_value
+        .. [2] http://mathworld.wolfram.com/CauchyPrincipalValue.html
+        """
+
+        from sympy.calculus import singularities
+
+        if len(self.limits) != 1 or len(list(self.limits[0])) != 3:
+            raise ValueError("You need to insert a variable, lower_limit, and upper_limit correctly to calculate "
+                             "cauchy's principal value")
+
+        x, a, b = self.limits[0]
+
+        if not (a.is_comparable and b.is_comparable and a <= b):
+            raise ValueError("The lower_limit must be smaller than or equal to the upper_limit to calculate "
+                             "cauchy's principal value. Also, a and b need to be comparable.")
+
+        if a == b:
+            return 0
+
+        r = Dummy('r')
+        u = Dummy('u')
+
+        singularities_list = [s for s in singularities(self.function, x) if s.is_comparable and a <= s <= b]
+
+        for i in singularities_list:
+            if ((i == b) or (i == a)):
+                raise ValueError(
+                    'The principal value is not defined in the given interval due to singularity at %d.' % (i))
+
+        f = self.function
+        F = integrate(f, x)
+
+        if F.has(Integral):
+            return self
+
+        if len(singularities_list) == 0:
+            if a is -oo and b is oo:
+                I = limit(F - F.subs(x, -x), x, oo)
+                return I
+            else:
+                I = limit(F, x, b, '-') - limit(F, x, a, '+')
+                return I
+
+        if len(singularities_list) == 1 and not (a is -oo and b is oo):
+            I = limit(((F.subs(x, singularities_list[0] - r)) - F.subs(x, singularities_list[0] + r)), r, 0,
+                      '+') - limit(F, x, a, '+') + limit(F, x, b, '-')
+            return I
+
+        else:
+            I = 0
+            for singular_element in range(len(singularities_list)):
+                I += limit(((F.subs(x, singularities_list[singular_element] - r)) - F.subs(x, singularities_list[
+                    singular_element] + r)), r, 0, '+')
+            if a is -oo and b is oo:
+                I1 = limit(F.subs(x, u) - F.subs(x, -u), u, oo)
+            else:
+                I1 = limit(F, x, b, '-') - limit(F, x, a, '+')
+            return I + I1
+
 
 def integrate(*args, **kwargs):
     """integrate(f, var, ...)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1262,11 +1262,12 @@ class Integral(AddWithLimits):
         >>> x = symbols('x')
         >>> Integral(x+1, (x, -oo, oo)).principal_value()
         oo
-        >>> Integral(1/(x**3), (x, -oo, oo)).principal_value()
+        >>> f = 1 / (x**3)
+        >>> Integral(f, (x, -oo, oo)).principal_value()
         0
-        >>> Integral(1/(x**3), (x, -10, 10)).principal_value()
+        >>> Integral(f, (x, -10, 10)).principal_value()
         0
-        >>> Integral(1/(x**3), (x, -10, oo)).principal_value() + Integral(f, (x, -oo, 10)).principal_value()
+        >>> Integral(f, (x, -10, oo)).principal_value() + Integral(f, (x, -oo, 10)).principal_value()
         0
 
         References

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1286,12 +1286,12 @@ class Integral(AddWithLimits):
         if a == b:
             return 0
         r = Dummy('r')
+        f = self.function
         singularities_list = [s for s in singularities(self.function, x) if s.is_comparable and a <= s <= b]
         for i in singularities_list:
             if (i == b) or (i == a):
                 raise ValueError(
                     'The principal value is not defined in the given interval due to singularity at %d.' % (i))
-        f = self.function
         F = integrate(f, x, **kwargs)
         if F.has(Integral):
             return self

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1246,11 +1246,10 @@ class Integral(AddWithLimits):
                                     hold=True)
         return f
 
-    def principal_value(self):
+    def principal_value(self, **kwargs):
         """
         Compute the Cauchy Principal Value of the definite integral of a real function in the given interval
         on the real axis.
-
         In mathematics, the Cauchy principal value, is a method for assigning values to certain improper
         integrals which would otherwise be undefined.
 
@@ -1260,11 +1259,9 @@ class Integral(AddWithLimits):
         >>> from sympy.integrals.integrals import Integral
         >>> from sympy.calculus.singularities import singularities
         >>> x = symbols('x')
-
         >>> g = x + 1
         >>> Integral(g, (x, -oo, oo)).principal_value()
         oo
-
         >>> f = 1 / (x**3)
         >>> Integral(f, (x, -oo, oo)).principal_value()
         0
@@ -1272,67 +1269,43 @@ class Integral(AddWithLimits):
         0
         >>> Integral(f, (x, -10, oo)).principal_value() + Integral(f, (x, -oo, 10)).principal_value()
         0
-        
         References
         ==========
         .. [1] http://en.wikipedia.org/wiki/Cauchy_principal_value
         .. [2] http://mathworld.wolfram.com/CauchyPrincipalValue.html
         """
-
         from sympy.calculus import singularities
-
         if len(self.limits) != 1 or len(list(self.limits[0])) != 3:
             raise ValueError("You need to insert a variable, lower_limit, and upper_limit correctly to calculate "
                              "cauchy's principal value")
-
         x, a, b = self.limits[0]
-
         if not (a.is_comparable and b.is_comparable and a <= b):
             raise ValueError("The lower_limit must be smaller than or equal to the upper_limit to calculate "
                              "cauchy's principal value. Also, a and b need to be comparable.")
-
         if a == b:
             return 0
-
         r = Dummy('r')
         u = Dummy('u')
-
         singularities_list = [s for s in singularities(self.function, x) if s.is_comparable and a <= s <= b]
-
         for i in singularities_list:
             if ((i == b) or (i == a)):
                 raise ValueError(
                     'The principal value is not defined in the given interval due to singularity at %d.' % (i))
-
         f = self.function
-        F = integrate(f, x)
-
+        F = integrate(f, x, **kwargs)
         if F.has(Integral):
             return self
-
-        if len(singularities_list) == 0:
-            if a is -oo and b is oo:
+        if a is -oo and b is oo:
+            if len(singularities_list) == 0:
                 I = limit(F - F.subs(x, -x), x, oo)
-                return I
             else:
-                I = limit(F, x, b, '-') - limit(F, x, a, '+')
-                return I
-
-        if len(singularities_list) == 1 and not (a is -oo and b is oo):
-            I = limit(((F.subs(x, singularities_list[0] - r)) - F.subs(x, singularities_list[0] + r)), r, 0,
-                      '+') - limit(F, x, a, '+') + limit(F, x, b, '-')
-            return I
-
+                I = limit(F.subs(x, u) - F.subs(x, -u), u, oo)
         else:
-            I = 0
-            for singular_element in range(len(singularities_list)):
-                I += limit(((F.subs(x, singularities_list[singular_element] - r)) - F.subs(x, singularities_list[
-                    singular_element] + r)), r, 0, '+')
-            if a is -oo and b is oo:
-                I1 = limit(F.subs(x, u) - F.subs(x, -u), u, oo)
-            else:
-                I1 = limit(F, x, b, '-') - limit(F, x, a, '+')
-            return I + I1
+            I = limit(F, x, b, '-') - limit(F, x, a, '+')
+        for s in range(len(singularities_list)):
+            I += limit(((F.subs(x, singularities_list[s] - r)) - F.subs(x, singularities_list[s] + r)), r, 0, '+')
+        return I
+
 
 
 def integrate(*args, **kwargs):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1287,7 +1287,7 @@ class Integral(AddWithLimits):
             return 0
         r = Dummy('r')
         f = self.function
-        singularities_list = [s for s in singularities(self.function, x) if s.is_comparable and a <= s <= b]
+        singularities_list = [s for s in singularities(f, x) if s.is_comparable and a <= s <= b]
         for i in singularities_list:
             if (i == b) or (i == a):
                 raise ValueError(

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1260,15 +1260,13 @@ class Integral(AddWithLimits):
         >>> from sympy.integrals.integrals import Integral
         >>> from sympy.calculus.singularities import singularities
         >>> x = symbols('x')
-        >>> g = x + 1
-        >>> Integral(g, (x, -oo, oo)).principal_value()
+        >>> Integral(x+1, (x, -oo, oo)).principal_value()
         oo
-        >>> f = 1 / (x**3)
-        >>> Integral(f, (x, -oo, oo)).principal_value()
+        >>> Integral(1/(x**3), (x, -oo, oo)).principal_value()
         0
-        >>> Integral(f, (x, -10, 10)).principal_value()
+        >>> Integral(1/(x**3), (x, -10, 10)).principal_value()
         0
-        >>> Integral(f, (x, -10, oo)).principal_value() + Integral(f, (x, -oo, 10)).principal_value()
+        >>> Integral(1/(x**3), (x, -10, oo)).principal_value() + Integral(f, (x, -oo, 10)).principal_value()
         0
 
         References

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -14,12 +14,42 @@ from sympy.physics import units
 from sympy.core.compatibility import range
 from sympy.utilities.pytest import XFAIL, raises, slow, skip, ON_TRAVIS
 from sympy.utilities.randtest import verify_numerically
-
+from sympy.integrals.integrals import Integral
 
 x, y, a, t, x_1, x_2, z, s = symbols('x y a t x_1 x_2 z s')
 n = Symbol('n', integer=True)
 f = Function('f')
 
+def test_principal_value():
+
+    g = 1 / x
+    assert Integral(g, (x, -oo, oo)).principal_value() == 0
+    assert Integral(g, (y, -oo, oo)).principal_value() == oo * sign(1 / x)
+    raises(ValueError, lambda: Integral(g, (x)).principal_value())
+    raises(ValueError, lambda: Integral(g).principal_value())
+
+    l = 1 / ((x ** 3) - 1)
+    assert Integral(l, (x, -oo, oo)).principal_value() == -sqrt(3)*pi/3
+    raises(ValueError, lambda: Integral(l, (x, -oo, 1)).principal_value())
+
+    d = 1 / (x ** 2 - 1)
+    assert Integral(d, (x, -oo, oo)).principal_value() == 0
+    assert Integral(d, (x, -2, 2)).principal_value() == -log(3)
+
+    v = x / (x ** 2 - 1)
+    assert Integral(v, (x, -oo, oo)).principal_value() == 0
+    assert Integral(v, (x, -2, 2)).principal_value() == 0
+
+    s = x ** 2 / (x ** 2 - 1)
+    assert Integral(s, (x, -oo, oo)).principal_value() == oo
+    assert Integral(s, (x, -2, 2)).principal_value() == -log(3) + 4
+
+    f = 1 / ((x ** 2 - 1) * (1 + x ** 2))
+    assert Integral(f, (x, -oo, oo)).principal_value() == -pi / 2
+    assert Integral(f, (x, -2, 2)).principal_value() == -atan(2) - log(3) / 2
+
+    k = 1 / (x ** 4 - 1)
+    assert Integral(k, (x, -oo, oo)).principal_value() == -pi / 2
 
 def diff_test(i):
     """Return the set of symbols, s, which were used in testing that

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -21,7 +21,6 @@ n = Symbol('n', integer=True)
 f = Function('f')
 
 def test_principal_value():
-
     g = 1 / x
     assert Integral(g, (x, -oo, oo)).principal_value() == 0
     assert Integral(g, (y, -oo, oo)).principal_value() == oo * sign(1 / x)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -47,9 +47,6 @@ def test_principal_value():
     assert Integral(f, (x, -oo, oo)).principal_value() == -pi / 2
     assert Integral(f, (x, -2, 2)).principal_value() == -atan(2) - log(3) / 2
 
-    k = 1 / (x ** 4 - 1)
-    assert Integral(k, (x, -oo, oo)).principal_value() == -pi / 2
-
 def diff_test(i):
     """Return the set of symbols, s, which were used in testing that
     i.diff(s) agrees with i.doit().diff(s). If there is an error then


### PR DESCRIPTION
Added function `cauchy_principal_value` in `sympy/integrals/integrals.py` to implement calculation of Cauchy's principal value

Closes #14538 
Closes #14926 
Note : This PR was created due to some issues in the previous (original) PR #14926   as suggested by @certik and @jksuom .

A method `principal_value` has been added to `class Integral` in `sympy/integrals/integrals.py`. This method implements the evaluation of `Cauchy's Principal Value` for functions which would otherwise be undefined. Also, tests for the same have also been added.

Note : Special Thanks to @jksuom  for helping me out on all ends where I got stuck and thereby making the PR more robust and better. 
Also, Thanks to @certik  for suggesting me to move to a new PR as the earlier one got quite long.

Please review this PR and give me a feedback.
Thanks 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * added method `principal_value` to class `Integral` to calculate Cauchy's principal value along with tests.
<!-- END RELEASE NOTES -->
