### PR TITLE
Convert latex() docstring to the numpydoc format.

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2275,7 +2275,7 @@ def latex(expr, **settings):
     >>> print(latex((2*tau)**Rational(7,2)))
     8 \sqrt{2} \tau^{\frac{7}{2}}
 
-    ``mode`` and `itex` options:
+    ``mode`` and ``itex`` options:
 
     >>> print(latex((2*mu)**Rational(7,2), mode='plain'))
     8 \sqrt{2} \mu^{\frac{7}{2}}

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2198,93 +2198,129 @@ def translate(s):
                 return modifier_dict[key](translate(s[:-len(key)]))
         return s
 
+
 def latex(expr, **settings):
-    r"""
-    Convert the given expression to LaTeX representation.
+    r"""Convert the given expression to LaTeX string representation.
 
-    >>> from sympy import latex, pi, sin, asin, Integral, Matrix, Rational, log
-    >>> from sympy.abc import x, y, mu, r, tau
+    Parameters
+    ==========
+    fold_frac_powers : boolean, optional
+        Emit ``^{p/q}`` instead of ``^{\frac{p}{q}}`` for fractional powers.
+    fold_func_brackets : boolean, optional
+        Fold function brackets where applicable.
+    fold_short_frac : boolean, optional
+        Emit ``p / q`` instead of ``\frac{p}{q}`` when the denominator is
+        simple enough (at most two terms and no powers). The default value is
+        ``True`` for inline mode, ``False`` otherwise.
+    inv_trig_style : string, optional
+        How inverse trig functions should be displayed. Can be one of
+        ``abbreviated``, ``full``, or ``power``. Defaults to ``abbreviated``.
+    itex : boolean, optional
+        Specifies if itex-specific syntax is used, including emitting
+        ``$$...$$``.
+    ln_notation : boolean, optional
+        If set to ``True``, ``\ln`` is used instead of default ``\log``.
+    long_frac_ratio : float or None, optional
+        The allowed ratio of the width of the numerator to the width of the
+        denominator before the printer breaks off long fractions. If ``None``
+        (the default value), long fractions are not broken up.
+    mat_delim : string, optional
+        The delimiter to wrap around matrices. Can be one of ``[``, ``(``, or
+        the empty string. Defaults to ``[``.
+    mat_str : string, optional
+        Which matrix environment string to emit. ``smallmatrix``, ``matrix``,
+        ``array``, etc. Defaults to ``smallmatrix`` for inline mode, ``matrix``
+        for matrices of no more than 10 columns, and ``array`` otherwise.
+    mode: string, optional
+        Specifies how the generated code will be delimited. ``mode`` can be one
+        of ``plain``, ``inline``, ``equation`` or ``equation*``.  If ``mode``
+        is set to ``plain``, then the resulting code will not be delimited at
+        all (this is the default). If ``mode`` is set to ``inline`` then inline
+        LaTeX ``$...$`` will be used. If ``mode`` is set to ``equation`` or
+        ``equation*``, the resulting code will be enclosed in the ``equation``
+        or ``equation*`` environment (remember to import ``amsmath`` for
+        ``equation*``), unless the ``itex`` option is set. In the latter case,
+        the ``$$...$$`` syntax is used.
+    mul_symbol : string or None, optional
+        The symbol to use for multiplication. Can be one of ``None``, ``ldot``,
+        ``dot``, or ``times``.
+    order: string, optional
+        Any of the supported monomial orderings (currently ``lex``, ``grlex``,
+        or ``grevlex``), ``old``, and ``none``. This parameter does nothing for
+        Mul objects. Setting order to ``old`` uses the compatibility ordering
+        for Add defined in Printer. For very large expressions, set the
+        ``order`` keyword to ``none`` if speed is a concern.
+    symbol_names : dictionary of strings mapped to symbols, optional
+        Dictionary of symbols and the custom strings they should be emitted as.
 
-    >>> print(latex((2*tau)**Rational(7,2)))
-    8 \sqrt{2} \tau^{\frac{7}{2}}
+    Notes
+    =====
 
     Not using a print statement for printing, results in double backslashes for
     latex commands since that's the way Python escapes backslashes in strings.
 
     >>> latex((2*tau)**Rational(7,2))
     '8 \\sqrt{2} \\tau^{\\frac{7}{2}}'
+    >>> print(latex((2*tau)**Rational(7,2)))
+    '8 \sqrt{2} \tau^{\frac{7}{2}}'
 
-    order: Any of the supported monomial orderings (currently "lex", "grlex", or
-    "grevlex"), "old", and "none". This parameter does nothing for Mul objects.
-    Setting order to "old" uses the compatibility ordering for Add defined in
-    Printer. For very large expressions, set the 'order' keyword to 'none' if
-    speed is a concern.
+    Examples
+    ========
 
-    mode: Specifies how the generated code will be delimited. 'mode' can be one
-    of 'plain', 'inline', 'equation' or 'equation*'.  If 'mode' is set to
-    'plain', then the resulting code will not be delimited at all (this is the
-    default). If 'mode' is set to 'inline' then inline LaTeX $ $ will be used.
-    If 'mode' is set to 'equation' or 'equation*', the resulting code will be
-    enclosed in the 'equation' or 'equation*' environment (remember to import
-    'amsmath' for 'equation*'), unless the 'itex' option is set. In the latter
-    case, the ``$$ $$`` syntax is used.
+    >>> from sympy import latex, pi, sin, asin, Integral, Matrix, Rational, log
+    >>> from sympy.abc import x, y, mu, r, tau
+
+    Basic usage:
+
+    >>> print(latex((2*tau)**Rational(7,2)))
+    8 \sqrt{2} \tau^{\frac{7}{2}}
+
+    ``mode`` and `itex` options:
 
     >>> print(latex((2*mu)**Rational(7,2), mode='plain'))
     8 \sqrt{2} \mu^{\frac{7}{2}}
-
     >>> print(latex((2*tau)**Rational(7,2), mode='inline'))
     $8 \sqrt{2} \tau^{7 / 2}$
-
     >>> print(latex((2*mu)**Rational(7,2), mode='equation*'))
     \begin{equation*}8 \sqrt{2} \mu^{\frac{7}{2}}\end{equation*}
-
     >>> print(latex((2*mu)**Rational(7,2), mode='equation'))
     \begin{equation}8 \sqrt{2} \mu^{\frac{7}{2}}\end{equation}
-
-    itex: Specifies if itex-specific syntax is used, including emitting ``$$ $$``.
-
+    >>> print(latex((2*mu)**Rational(7,2), mode='equation', itex=True))
+    $$8 \sqrt{2} \mu^{\frac{7}{2}}$$
+    >>> print(latex((2*mu)**Rational(7,2), mode='plain'))
+    8 \sqrt{2} \mu^{\frac{7}{2}}
+    >>> print(latex((2*tau)**Rational(7,2), mode='inline'))
+    $8 \sqrt{2} \tau^{7 / 2}$
+    >>> print(latex((2*mu)**Rational(7,2), mode='equation*'))
+    \begin{equation*}8 \sqrt{2} \mu^{\frac{7}{2}}\end{equation*}
+    >>> print(latex((2*mu)**Rational(7,2), mode='equation'))
+    \begin{equation}8 \sqrt{2} \mu^{\frac{7}{2}}\end{equation}
     >>> print(latex((2*mu)**Rational(7,2), mode='equation', itex=True))
     $$8 \sqrt{2} \mu^{\frac{7}{2}}$$
 
-    fold_frac_powers: Emit "^{p/q}" instead of "^{\frac{p}{q}}" for fractional
-    powers.
+    Fraction options:
 
     >>> print(latex((2*tau)**Rational(7,2), fold_frac_powers=True))
     8 \sqrt{2} \tau^{7/2}
-
-    fold_func_brackets: Fold function brackets where applicable.
-
     >>> print(latex((2*tau)**sin(Rational(7,2))))
     \left(2 \tau\right)^{\sin{\left (\frac{7}{2} \right )}}
-    >>> print(latex((2*tau)**sin(Rational(7,2)), fold_func_brackets = True))
+    >>> print(latex((2*tau)**sin(Rational(7,2)), fold_func_brackets=True))
     \left(2 \tau\right)^{\sin {\frac{7}{2}}}
-
-    fold_short_frac: Emit "p / q" instead of "\frac{p}{q}" when the
-    denominator is simple enough (at most two terms and no powers).
-    The default value is `True` for inline mode, False otherwise.
-
     >>> print(latex(3*x**2/y))
     \frac{3 x^{2}}{y}
     >>> print(latex(3*x**2/y, fold_short_frac=True))
     3 x^{2} / y
-
-    long_frac_ratio: The allowed ratio of the width of the numerator to the
-    width of the denominator before we start breaking off long fractions.
-    If None (the default value), long fractions are not broken up.
-
     >>> print(latex(Integral(r, r)/2/pi, long_frac_ratio=2))
     \frac{\int r\, dr}{2 \pi}
     >>> print(latex(Integral(r, r)/2/pi, long_frac_ratio=0))
     \frac{1}{2 \pi} \int r\, dr
 
-    mul_symbol: The symbol to use for multiplication. Can be one of None,
-    "ldot", "dot", or "times".
+    Multiplication options:
 
     >>> print(latex((2*tau)**sin(Rational(7,2)), mul_symbol="times"))
     \left(2 \times \tau\right)^{\sin{\left (\frac{7}{2} \right )}}
 
-    inv_trig_style: How inverse trig functions should be displayed. Can be one
-    of "abbreviated", "full", or "power". Defaults to "abbreviated".
+    Trig options:
 
     >>> print(latex(asin(Rational(7,2))))
     \operatorname{asin}{\left (\frac{7}{2} \right )}
@@ -2293,41 +2329,32 @@ def latex(expr, **settings):
     >>> print(latex(asin(Rational(7,2)), inv_trig_style="power"))
     \sin^{-1}{\left (\frac{7}{2} \right )}
 
-    mat_str: Which matrix environment string to emit. "smallmatrix", "matrix",
-    "array", etc. Defaults to "smallmatrix" for inline mode, "matrix" for
-    matrices of no more than 10 columns, and "array" otherwise.
+    Matrix options::
 
     >>> print(latex(Matrix(2, 1, [x, y])))
     \left[\begin{matrix}x\\y\end{matrix}\right]
-
     >>> print(latex(Matrix(2, 1, [x, y]), mat_str = "array"))
     \left[\begin{array}{c}x\\y\end{array}\right]
-
-    mat_delim: The delimiter to wrap around matrices. Can be one of "[", "(",
-    or the empty string. Defaults to "[".
-
     >>> print(latex(Matrix(2, 1, [x, y]), mat_delim="("))
     \left(\begin{matrix}x\\y\end{matrix}\right)
 
-    symbol_names: Dictionary of symbols and the custom strings they should be
-    emitted as.
+    Custom printing of symbols::
 
-    >>> print(latex(x**2, symbol_names={x:'x_i'}))
+    >>> print(latex(x**2, symbol_names={x: 'x_i'}))
     x_i^{2}
 
-    ``latex`` also supports the builtin container types list, tuple, and
+    Logarithms::
+
+    >>> print(latex(log(10)))
+    \log{\left (10 \right )}
+    >>> print(latex(log(10), ln_notation=True))
+    \ln{\left (10 \right )}
+
+    ``latex()`` also supports the builtin container types list, tuple, and
     dictionary.
 
     >>> print(latex([2/x, y], mode='inline'))
     $\left [ 2 / x, \quad y\right ]$
-
-    ln_notation: If set to ``True`` "\ln" is used instead of default "\log"
-
-    >>> print(latex(log(10)))
-    \log{\left (10 \right )}
-
-    >>> print(latex(log(10), ln_notation=True))
-    \ln{\left (10 \right )}
 
     """
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2331,7 +2331,7 @@ def latex(expr, **settings):
     >>> print(latex(asin(Rational(7,2)), inv_trig_style="power"))
     \sin^{-1}{\left (\frac{7}{2} \right )}
 
-    Matrix options::
+    Matrix options:
 
     >>> print(latex(Matrix(2, 1, [x, y])))
     \left[\begin{matrix}x\\y\end{matrix}\right]
@@ -2340,12 +2340,12 @@ def latex(expr, **settings):
     >>> print(latex(Matrix(2, 1, [x, y]), mat_delim="("))
     \left(\begin{matrix}x\\y\end{matrix}\right)
 
-    Custom printing of symbols::
+    Custom printing of symbols:
 
     >>> print(latex(x**2, symbol_names={x: 'x_i'}))
     x_i^{2}
 
-    Logarithms::
+    Logarithms:
 
     >>> print(latex(log(10)))
     \log{\left (10 \right )}
@@ -2364,5 +2364,6 @@ def latex(expr, **settings):
 
 
 def print_latex(expr, **settings):
-    """Prints LaTeX representation of the given expression."""
+    """Prints LaTeX representation of the given expression. Takes the same
+    settings as ``latex()``."""
     print(latex(expr, **settings))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2259,6 +2259,8 @@ def latex(expr, **settings):
     Not using a print statement for printing, results in double backslashes for
     latex commands since that's the way Python escapes backslashes in strings.
 
+    >>> from sympy import latex, Rational
+    >>> from sympy.abc import tau
     >>> latex((2*tau)**Rational(7,2))
     '8 \\sqrt{2} \\tau^{\\frac{7}{2}}'
     >>> print(latex((2*tau)**Rational(7,2)))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2264,7 +2264,7 @@ def latex(expr, **settings):
     >>> latex((2*tau)**Rational(7,2))
     '8 \\sqrt{2} \\tau^{\\frac{7}{2}}'
     >>> print(latex((2*tau)**Rational(7,2)))
-    '8 \sqrt{2} \tau^{\frac{7}{2}}'
+    8 \sqrt{2} \tau^{\frac{7}{2}}
 
     Examples
     ========


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

The latex() function had an arbitrary style for the docstring. It now
follows the numpydoc style and separates the options from the examples.
This renders more favorably with Sphinx processing.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Improved the `latex()` function docstring format.
<!-- END RELEASE NOTES -->

New Sphinx render:
![selection_222](https://user-images.githubusercontent.com/276007/43692702-7f54bd1c-98de-11e8-9549-4f8b2309735b.png)
![selection_223](https://user-images.githubusercontent.com/276007/43692703-8193d48c-98de-11e8-8013-63afffdb3be5.png)

