### PR TITLE
Derivative related modifications

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -174,8 +174,9 @@ class Quaternion(Expr):
     def _eval_Integral(self, *args):
         return self.integrate(*args)
 
-    def _eval_diff(self, *symbols, **kwargs):
-        return self.diff(*symbols)
+    def diff(self, *symbols, **kwargs):
+        kwargs.setdefault('evaluate', True)
+        return self.func(*[a.diff(*symbols, **kwargs) for a  in self.args])
 
     def add(self, other):
         """Adds quaternions.
@@ -411,10 +412,6 @@ class Quaternion(Expr):
         (v, angle) = q.to_axis_angle()
         q2 = Quaternion.from_axis_angle(v, p * angle)
         return q2 * (q.norm()**p)
-
-    def diff(self, *args):
-        return Quaternion(diff(self.a, *args), diff(self.b, *args),
-                          diff(self.c, *args), diff(self.d, *args))
 
     def integrate(self, *args):
         # TODO: is this expression correct?

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1068,6 +1068,9 @@ def test_issue_14640():
 
 
 def test_Sum_dummy_eq():
+    assert not Sum(x, (x, a, b)).dummy_eq(1)
+    assert not Sum(x, (x, a, b)).dummy_eq(Sum(x, (x, a, b), (a, 1, 2)))
+    assert not Sum(x, (x, a, b)).dummy_eq(Sum(x, (x, a, c)))
     assert Sum(x, (x, a, b)).dummy_eq(Sum(x, (x, a, b)))
     d = Dummy()
     assert Sum(x, (x, a, d)).dummy_eq(Sum(x, (x, a, c)), c)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -28,16 +28,21 @@ class Expr(Basic, EvalfMixin):
 
     __slots__ = []
 
+    is_scalar = True  # self derivative is 1
+
     @property
     def _diff_wrt(self):
-        """Is it allowed to take derivative wrt to this instance.
+        """Return True if one can differentiate with respect to this
+        object, else False.
 
-        This determines if it is allowed to take derivatives wrt this object.
-        Subclasses such as Symbol, Function and Derivative should return True
+        Subclasses such as Symbol, Function and Derivative return True
         to enable derivatives wrt them. The implementation in Derivative
-        separates the Symbol and non-Symbol _diff_wrt=True variables and
-        temporarily converts the non-Symbol vars in Symbols when performing
-        the differentiation.
+        separates the Symbol and non-Symbol (_diff_wrt=True) variables and
+        temporarily converts the non-Symbols into Symbols when performing
+        the differentiation. By default, any object deriving from Expr
+        will behave like a scalar with self.diff(self) == 1. If this is
+        not desired then the object must also set `is_scalar = False` or
+        else define an _eval_derivative routine.
 
         Note, see the docstring of Derivative for how this should work
         mathematically. In particular, note that expr.subs(yourclass, Symbol)
@@ -51,11 +56,17 @@ class Expr(Basic, EvalfMixin):
         >>> e = Expr()
         >>> e._diff_wrt
         False
-        >>> class MyClass(Expr):
+        >>> class MyScalar(Expr):
         ...     _diff_wrt = True
         ...
-        >>> (2*MyClass()).diff(MyClass())
-        2
+        >>> MyScalar().diff(MyScalar())
+        1
+        >>> class MySymbol(Expr):
+        ...     _diff_wrt = True
+        ...     is_scalar = False
+        ...
+        >>> MySymbol().diff(MySymbol())
+        Derivative(MySymbol(), MySymbol())
         """
         return False
 
@@ -2619,14 +2630,19 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy import collect, Dummy, Order, Rational, Symbol
         if x is None:
-            syms = self.atoms(Symbol)
+            syms = self.free_symbols
             if not syms:
                 return self
             elif len(syms) > 1:
                 raise ValueError('x must be given for multivariate functions.')
             x = syms.pop()
 
-        if not self.has(x):
+        if isinstance(x, Symbol):
+            dep = x in self.free_symbols
+        else:
+            d = Dummy()
+            dep = d in self.xreplace({x: d}).free_symbols
+        if not dep:
             if n is None:
                 return (s for s in [self])
             else:
@@ -3027,9 +3043,8 @@ class Expr(Basic, EvalfMixin):
     ###################################################################################
 
     def diff(self, *symbols, **assumptions):
-        new_symbols = list(map(sympify, symbols))  # e.g. x, 2, y, z
         assumptions.setdefault("evaluate", True)
-        return Derivative(self, *new_symbols, **assumptions)
+        return Derivative(self, *symbols, **assumptions)
 
     ###########################################################################
     ###################### EXPRESSION EXPANSION METHODS #######################
@@ -3377,9 +3392,9 @@ class AtomicExpr(Atom, Expr):
 
     def _eval_derivative_n_times(self, s, n):
         from sympy import Piecewise, Eq
-        from sympy import NDimArray, Tuple
+        from sympy import Tuple
         from sympy.matrices.common import MatrixCommon
-        if isinstance(s, (NDimArray, MatrixCommon, Tuple, Iterable)):
+        if isinstance(s, (MatrixCommon, Tuple, Iterable)):
             return super(AtomicExpr, self)._eval_derivative_n_times(s, n)
         if self == s:
             return Piecewise((self, Eq(n, 0)), (1, Eq(n, 1)), (0, True))

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -3455,9 +3455,9 @@ class UnevaluatedExpr(Expr):
         obj = Expr.__new__(cls, arg, **kwargs)
         return obj
 
-    def doit(self, *args, **kwargs):
+    def doit(self, **kwargs):
         if kwargs.get("deep", True):
-            return self.args[0].doit(*args, **kwargs)
+            return self.args[0].doit(**kwargs)
         else:
             return self.args[0]
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -182,6 +182,13 @@ class FunctionClass(ManagedProperties):
         return set()
 
     @property
+    def xreplace(self):
+        # Function needs args so we define a property that returns
+        # a function that takes args...and then use that function
+        # to return the right value
+        return lambda rule, **_: rule.get(self, self)
+
+    @property
     def nargs(self):
         """Return a set of the allowed number of arguments for the function.
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1018,7 +1018,7 @@ class Derivative(Expr):
         ValueError: Can't calculate derivative wrt x*y.
 
     To make it easier to work with variational calculus, however,
-    derivatives wrt AppliedUnder and Derivatives are allowed.
+    derivatives wrt AppliedUndef and Derivatives are allowed.
     For example, in the Euler-Lagrange method one may write
     F(t, u, v) where u = f(t) and v = f'(t). These variables can be
     written explicity as functions of time::
@@ -1071,6 +1071,25 @@ class Derivative(Expr):
 
         >>> _.doit()
         0
+
+    Replacing undefined functions with concrete expressions
+
+    One must be careful to replace undefined functions with expressions
+    that contain variables consistent with the function definition and
+    the variables of differentiation or else insconsistent result will
+    be obtained. Consider the following example:
+
+    >>> eq = f(x)*g(y)
+    >>> eq.subs(f(x), x*y).diff(x, y).doit()
+    y*Derivative(g(y), y) + g(y)
+    >>> eq.diff(x, y).subs(f(x), x*y).doit()
+    y*Derivative(g(y), y)
+
+    The results differ because `f(x)` was replaced with an expression
+    that involved both variables of differentiation. In the abstract
+    case, differentiation of `f(x)` by `y` is 0; in the concrete case,
+    the presence of `y` made that derivative nonvanishing and produced
+    the extra `g(y)` term.
 
     Defining differentiation for an object
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1469,13 +1469,24 @@ class Derivative(Expr):
         return self._args[0]
 
     @property
+    def _wrt_variables(self):
+        # return the variables of differentiation without
+        # respect to the type of count (int or symbolic)
+        return [i[0] for i in self.variable_count]
+
+    @property
     def variables(self):
-        # TODO: deprecate?
+        # TODO: deprecate?  YES, make this 'enumerated_variables' and
+        #       name _wrt_variables as variables
         # TODO: support for `d^n`?
         rv = []
         for v, count in self.variable_count:
-            if count.is_Integer:
-                rv.extend([v]*count)
+            if not count.is_Integer:
+                raise TypeError(filldedent('''
+                Cannot give expansion for symbolic count. If you just
+                want a list of all variables of differentiation, use
+                _wrt_variables.'''))
+            rv.extend([v]*count)
         return tuple(rv)
 
     @property

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2083,14 +2083,15 @@ class Subs(Expr):
             # x is the variable being substituted into
             apos = self.point.index(x)
             other = self.variables[apos]
-            arg = self.expr.nseries(other, n=n, logx=logx)
-            o = arg.getO()
-            subs_args = [self.func(a, *self.args[1:]) for a in arg.removeO().args]
-            return Add(*subs_args) + o.subs(other, x)
-        arg = self.expr.nseries(x, n=n, logx=logx)
+        else:
+            other = x
+        arg = self.expr.nseries(other, n=n, logx=logx)
         o = arg.getO()
-        subs_args = [self.func(a, *self.args[1:]) for a in arg.removeO().args]
-        return Add(*subs_args) + o
+        terms = Add.make_args(arg.removeO())
+        rv = Add(*[self.func(a, *self.args[1:]) for a in terms])
+        if o:
+            rv += o.subs(other, x)
+        return rv
 
     def _eval_as_leading_term(self, x):
         if x in self.point:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -907,41 +907,32 @@ class Mul(Expr, AssocOp):
 
     @cacheit
     def _eval_derivative_n_times(self, s, n):
-        # https://en.wikipedia.org/wiki/General_Leibniz_rule#More_than_two_factors
-        from sympy import Integer, factorial, prod, Dummy, symbols, Sum
-        args = [arg for arg in self.args if arg.free_symbols & s.free_symbols]
-        coeff_args = [arg for arg in self.args if arg not in args]
-        m = len(args)
-        if m == 1:
-            return args[0].diff((s, n))*Mul.fromiter(coeff_args)
-
-        if isinstance(n, (int, Integer)):
+        from sympy import Integer, factorial, prod, Sum, Max
+        from sympy.ntheory.multinomial import multinomial_coefficients_iterator
+        from .function import AppliedUndef
+        from .symbol import Symbol, symbols, Dummy
+        if not isinstance(s, AppliedUndef) and not isinstance(s, Symbol):
+            # other types of s may not be well behaved, e.g.
+            # (cos(x)*sin(y)).diff([[x, y, z]])
             return super(Mul, self)._eval_derivative_n_times(s, n)
-
-            # Code not yet activated:
-            def sum_to_n(n, m):
-                if m == 1:
-                    yield (n,)
-                else:
-                    for x in range(n+1):
-                        for y in sum_to_n(n-x, m-1):
-                            yield (x,) + y
-            accum_sum = S.Zero
-            for kvals in sum_to_n(n, m):
-                part1 = factorial(n)/prod([factorial(k) for k in kvals])
-                part2 = prod([arg.diff((s, k)) for k, arg in zip(kvals, args)])
-                accum_sum += part1 * part2
-            return accum_sum * Mul.fromiter(coeff_args)
-
+        args = self.args
+        m = len(args)
+        if isinstance(n, (int, Integer)):
+            # https://en.wikipedia.org/wiki/General_Leibniz_rule#More_than_two_factors
+            terms = []
+            for kvals, c in multinomial_coefficients_iterator(m, n):
+                p = prod([arg.diff((s, k)) for k, arg in zip(kvals, args)])
+                terms.append(c * p)
+            return Add(*terms)
         kvals = symbols("k1:%i" % m, cls=Dummy)
         klast = n - sum(kvals)
-        result = Sum(
-            # better to use the multinomial?
-            factorial(n)/prod(map(factorial, kvals))/factorial(klast)*\
+        nfact = factorial(n)
+        e, l = (# better to use the multinomial?
+            nfact/prod(map(factorial, kvals))/factorial(klast)*\
             prod([args[t].diff((s, kvals[t])) for t in range(m-1)])*\
-            args[-1].diff((s, klast)),
-            *[(k, 0, n) for k in kvals])
-        return result*Mul.fromiter(coeff_args)
+            args[-1].diff((s, Max(0, klast))),
+            [(k, 0, n) for k in kvals])
+        return Sum(e, *l)
 
     def _eval_difference_delta(self, n, step):
         from sympy.series.limitseq import difference_delta as dd

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -144,7 +144,11 @@ def test_xreplace():
     assert Atom(b1).xreplace({Atom(b1): b2}) == b2
     raises(TypeError, lambda: b1.xreplace())
     raises(TypeError, lambda: b1.xreplace([b1, b2]))
-
+    for f in (exp, Function('f')):
+        assert f.xreplace({}) == f
+        assert f.xreplace({}, hack2=True) == f
+        assert f.xreplace({f: b1}) == b1
+        assert f.xreplace({f: b1}, hack2=True) == b1
 
 
 def test_preorder_traversal():

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -1,5 +1,6 @@
-from sympy import Symbol, Rational, cos, sin, tan, cot, exp, log, Function, \
-    Derivative, Expr, symbols, pi, I, S, diff, Piecewise, Eq, ff, Sum
+from sympy import (Symbol, Rational, cos, sin, tan, cot, exp, log,
+    Function, Derivative, Expr, symbols, pi, I, S, diff, Piecewise,
+    Eq, ff, Sum, And, factorial, Max, NDimArray)
 from sympy.utilities.pytest import raises
 
 
@@ -109,6 +110,7 @@ def test_diff_nth_derivative():
     f =  Function("f")
     x = Symbol("x")
     y = Symbol("y")
+    z = Symbol("z")
     n = Symbol("n", integer=True)
 
     expr = diff(sin(x), (x, n))
@@ -125,7 +127,11 @@ def test_diff_nth_derivative():
     assert expr3 == Derivative(f(x), (x, n))
 
     assert diff(x, (x, n)) == Piecewise((x, Eq(n, 0)), (1, Eq(n, 1)), (0, True))
-    assert diff(2*x, (x, n)) == 2*Piecewise((x, Eq(n, 0)), (1, Eq(n, 1)), (0, True))
+    assert diff(2*x, (x, n)).dummy_eq(
+        Sum(Piecewise((2*x*factorial(n)/(factorial(y)*factorial(-y + n)),
+        Eq(y, 0) & Eq(Max(0, -y + n), 0)),
+        (2*factorial(n)/(factorial(y)*factorial(-y + n)), Eq(y, 0) & Eq(Max(0,
+        -y + n), 1)), (0, True)), (y, 0, n)))
     # TODO: assert diff(x**2, (x, n)) == x**(2-n)*ff(2, n)
     exprm = x*sin(x)
     mul_diff = diff(exprm, (x, n))
@@ -135,6 +141,10 @@ def test_diff_nth_derivative():
 
     exprm2 = 2*y*x*sin(x)*cos(x)*log(x)*exp(x)
     dex = exprm2.diff((x, n))
-    assert isinstance(dex/2/y, Sum)
+    assert isinstance(dex, Sum)
     for i in range(7):
-        assert dex.subs(n, i).doit().expand() == exprm2.diff((x, i)).expand()
+        assert dex.subs(n, i).doit().expand() == \
+        exprm2.diff((x, i)).expand()
+
+    assert (cos(x)*sin(y)).diff([[x, y, z]]) == NDimArray([
+        -sin(x)*sin(y), cos(x)*cos(y), 0])

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -763,6 +763,11 @@ def test_count():
     assert expr.count(sin(a)) == 1
     assert expr.count(lambda u: type(u) is sin) == 1
 
+    f = Function('f')
+    assert f(x).count(f(x)) == 1
+    assert f(x).diff(x).count(f(x)) == 1
+    assert f(x).diff(x).count(x) == 2
+
 
 def test_has_basics():
     f = Function('f')
@@ -1734,6 +1739,9 @@ def test_held_expression_UnevaluatedExpr():
     assert isinstance(e1, Mul)
     assert e1.args == (x, he)
     assert e1.doit() == 1
+    assert UnevaluatedExpr(Derivative(x, x)).doit(deep=False
+        ) == Derivative(x, x)
+    assert UnevaluatedExpr(Derivative(x, x)).doit() == 1
 
     xx = Mul(x, x, evaluate=False)
     assert xx != x**2

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -286,6 +286,14 @@ def test_Subs():
 
     assert f(x).diff(x).subs(x, 0).subs(x, y) == f(x).diff(x).subs(x, 0)
     assert (x*f(x).diff(x).subs(x, 0)).subs(x, y) == y*f(x).diff(x).subs(x, 0)
+    assert Subs(Derivative(g(x)**2, g(x), x), g(x), exp(x)
+        ).doit() == 2*exp(x)
+    assert Subs(Derivative(g(x)**2, g(x), x), g(x), exp(x)
+        ).doit(deep=False) == 2*Derivative(exp(x), x)
+
+    assert Derivative(f(x, g(x)), x).doit() == Derivative(g(x), x
+        )*Subs(Derivative(f(x, y), y), y, g(x)
+        ) + Subs(Derivative(f(y, g(x)), y), y, x)
 
 
 @XFAIL
@@ -1033,6 +1041,7 @@ def test_undef_fcn_float_issue_6938():
     x = Symbol('x')
     assert not f(x).evalf(subs={x:1.2}).is_number
 
+
 def test_undefined_function_eval():
     # Issue 15170. Make sure UndefinedFunction with eval defined works
     # properly. The issue there was that the hash was determined before _nargs
@@ -1068,3 +1077,7 @@ def test_issue_15241():
     assert (G + y*Gy).diff(Gy, y) == 1
     assert (y*G + y*Gy*G).diff(G, y) == y*Gy.diff(y) + Gy + 1
     assert (y*G + y*Gy*G).diff(y, G) == y*Gy.diff(y) + Gy + 1
+
+
+def test_issue_15266():
+    assert Subs(Derivative(f(y), x, y), y, g(x)).doit() != 0

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -206,6 +206,10 @@ def test_Lambda_symbols():
     assert Lambda((), x*y).free_symbols == {x,y}
 
 
+def test_functionclas_symbols():
+    assert f.free_symbols == set()
+
+
 def test_Lambda_arguments():
     raises(TypeError, lambda: Lambda(x, 2*x)(x, y))
     raises(TypeError, lambda: Lambda((x, y), x + y)(x))
@@ -594,10 +598,10 @@ def test_subs_in_derivative():
         Derivative(expr, y).doit().subs(y, x)
     assert Derivative(f(x, y), y).subs(y, x) == Subs(Derivative(f(x, y), y), y, x)
     assert Derivative(f(x, y), y).subs(x, y) == Subs(Derivative(f(x, y), y), x, y)
-    assert Derivative(f(x, y), y).subs(y, g(x, y)) == Subs(Derivative(f(x, y), y), y, g(x, y))
+    assert Derivative(f(x, y), y).subs(y, g(x, y)) == Subs(Derivative(f(x, y), y), y, g(x, y)).doit()
     assert Derivative(f(x, y), y).subs(x, g(x, y)) == Subs(Derivative(f(x, y), y), x, g(x, y))
     assert Derivative(f(u(x), h(y)), h(y)).subs(h(y), g(x, y)) == \
-        Subs(Derivative(f(u(x), h(y)), h(y)), h(y), g(x, y))
+        Subs(Derivative(f(u(x), h(y)), h(y)), h(y), g(x, y)).doit()
     assert Derivative(f(x, y), y).subs(y, z) == Derivative(f(x, z), z)
     assert Derivative(f(x, y), y).subs(y, g(y)) == Derivative(f(x, g(y)), g(y))
     assert Derivative(f(g(x), h(y)), h(y)).subs(h(y), u(y)) == \
@@ -612,9 +616,10 @@ def test_subs_in_derivative():
 
 
 def test_diff_wrt_not_allowed():
-    raises(ValueError, lambda: diff(sin(x**2), x**2))
-    raises(ValueError, lambda: diff(exp(x*y), x*y))
-    raises(ValueError, lambda: diff(1 + x, 1 + x))
+    # issue 7027 included
+    for wrt in (
+            cos(x), re(x), Derivative(cos(x), x), x**2, x*y, 1 + x):
+        raises(ValueError, lambda: diff(f(x), wrt))
 
 
 def test_klein_gordon_lagrangian():

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -12,10 +12,11 @@ from sympy.solvers.solveset import solveset
 from sympy.utilities.iterables import subsets, variations
 from sympy.core.cache import clear_cache
 from sympy.core.compatibility import range
+from sympy.tensor.array import NDimArray
 
-from sympy.abc import t, u, v, w, x, y, z
+from sympy.abc import t, w, x, y, z
 f, g, h = symbols('f g h', cls=Function)
-
+_xi_1, _xi_2, _xi_3 = [Dummy() for i in range(3)]
 
 def test_f_expand_complex():
     x = Symbol('x', real=True)
@@ -91,6 +92,7 @@ def test_derivative_evaluate():
 
     assert Derivative(Derivative(f(x), x), x) == diff(f(x), x, x)
     assert Derivative(sin(x), x, 0) == sin(x)
+    assert Derivative(sin(x), (x, y), (x, -y)) == sin(x)
 
 
 def test_diff_symbols():
@@ -107,6 +109,9 @@ def test_diff_symbols():
         Derivative(f(x, y, z), x, y, z, z)
     assert Derivative(Derivative(f(x, y, z), x), y)._eval_derivative(z) == \
         Derivative(f(x, y, z), x, y, z)
+
+    raises(TypeError, lambda: cos(x).diff((x, y)).variables)
+    assert cos(x).diff((x, y))._wrt_variables == [x]
 
 
 def test_Function():
@@ -229,6 +234,8 @@ def test_Subs():
     assert Subs(1, (), ()) is S.One
     # check null subs influence on hashing
     assert Subs(x, y, z) != Subs(x, y, 1)
+    # neutral subs works
+    assert Subs(x, x, 1).subs(x, y).has(y)
     # self mapping var/point
     assert Subs(Derivative(f(x), (x, 2)), x, x).doit() == f(x).diff(x, x)
     assert Subs(x, x, 0).has(x)  # it's a structural answer
@@ -283,7 +290,7 @@ def test_Subs():
     assert Subs(z*f(x + 1), x, 1) not in [ e1, e2 ]
     assert Derivative(f(x), x).subs(x, g(x)) == Derivative(f(g(x)), g(x))
     assert Derivative(f(x), x).subs(x, x + y) == Subs(Derivative(f(x), x),
-        (x,), (x + y))
+        x, x + y)
     assert Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).n(2) == \
         Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).evalf(2) == \
         z + Rational('1/2').n(2)*f(0)
@@ -298,6 +305,11 @@ def test_Subs():
     assert Derivative(f(x, g(x)), x).doit() == Derivative(g(x), x
         )*Subs(Derivative(f(x, y), y), y, g(x)
         ) + Subs(Derivative(f(y, g(x)), y), y, x)
+
+
+def test_doitdoit():
+    done = Derivative(f(x, g(x)), x, g(x)).doit()
+    assert done == done.doit()
 
 
 @XFAIL
@@ -355,6 +367,8 @@ def test_deriv1():
     assert f(x, x**2).diff(x) == (
         2*x*Subs(Derivative(f(x, y), y), y, x**2) +
         Subs(Derivative(f(y, x**2), y), y, x))
+    # but Subs is not always necessary
+    assert f(x, g(y)).diff(g(y)) == Derivative(f(x, g(y)), g(y))
 
 
 def test_deriv2():
@@ -574,14 +588,14 @@ def test_diff_wrt():
 
     # Chain rule cases
     assert f(g(x)).diff(x) == \
-        Derivative(g(x), x)*Subs(Derivative(f(y), y), y, g(x))
+        Derivative(g(x), x)*Derivative(f(g(x)), g(x))
     assert diff(f(g(x), h(y)), x) == \
-        Derivative(g(x), x)*Subs(Derivative(f(x, h(y)), x), x, g(x))
+        Derivative(g(x), x)*Derivative(f(g(x), h(y)), g(x))
     assert diff(f(g(x), h(x)), x) == (
         Subs(Derivative(f(y, h(x)), y), y, g(x))*Derivative(g(x), x) +
         Subs(Derivative(f(g(x), y), y), y, h(x))*Derivative(h(x), x))
     assert f(
-        sin(x)).diff(x) == Subs(Derivative(f(x), x), x, sin(x))*cos(x)
+        sin(x)).diff(x) == cos(x)*Subs(Derivative(f(x), x), x, sin(x))
 
     assert diff(f(g(x)), g(x)) == Derivative(f(g(x)), g(x))
 
@@ -594,32 +608,63 @@ def test_subs_in_derivative():
     expr = sin(x*exp(y))
     u = Function('u')
     v = Function('v')
+    assert Derivative(expr, y).subs(expr, y) == Derivative(y, y)
     assert Derivative(expr, y).subs(y, x).doit() == \
         Derivative(expr, y).doit().subs(y, x)
     assert Derivative(f(x, y), y).subs(y, x) == Subs(Derivative(f(x, y), y), y, x)
     assert Derivative(f(x, y), y).subs(x, y) == Subs(Derivative(f(x, y), y), x, y)
     assert Derivative(f(x, y), y).subs(y, g(x, y)) == Subs(Derivative(f(x, y), y), y, g(x, y)).doit()
     assert Derivative(f(x, y), y).subs(x, g(x, y)) == Subs(Derivative(f(x, y), y), x, g(x, y))
+    assert Derivative(f(x, y), g(y)).subs(x, g(x, y)) == Derivative(f(g(x, y), y), g(y))
     assert Derivative(f(u(x), h(y)), h(y)).subs(h(y), g(x, y)) == \
         Subs(Derivative(f(u(x), h(y)), h(y)), h(y), g(x, y)).doit()
     assert Derivative(f(x, y), y).subs(y, z) == Derivative(f(x, z), z)
     assert Derivative(f(x, y), y).subs(y, g(y)) == Derivative(f(x, g(y)), g(y))
     assert Derivative(f(g(x), h(y)), h(y)).subs(h(y), u(y)) == \
         Derivative(f(g(x), u(y)), u(y))
+    assert Derivative(f(x, f(x, x)), f(x, x)).subs(
+        f, Lambda((x, y), x + y)) == Subs(
+        Derivative(z + x, z), z, 2*x)
+    assert Subs(Derivative(f(f(x)), x), f, cos).doit() == sin(x)*sin(cos(x))
+    assert Subs(Derivative(f(f(x)), f(x)), f, cos).doit() == -sin(cos(x))
     # Issue 13791. No comparison (it's a long formula) but this used to raise an exception.
     assert isinstance(v(x, y, u(x, y)).diff(y).diff(x).diff(y), Expr)
-    # This is also related to issues 13791 and 13795
+    # This is also related to issues 13791 and 13795; issue 15190
     F = Lambda((x, y), exp(2*x + 3*y))
     abstract = f(x, f(x, x)).diff(x, 2)
     concrete = F(x, F(x, x)).diff(x, 2)
-    assert (abstract.replace(f, F).doit() - concrete).simplify() == 0
+    assert (abstract.subs(f, F).doit() - concrete).simplify() == 0
+    # don't introduce a new symbol if not necessary
+    assert x in f(x).diff(x).subs(x, 0).atoms()
+    # case (4)
+    assert Derivative(f(x,f(x,y)), x, y).subs(x, g(y)
+        ) == Subs(Derivative(f(x, f(x, y)), x, y), x, g(y))
+
+    assert Derivative(f(x, x), x).subs(x, 0
+        ) == Subs(Derivative(f(x, x), x), x, 0)
+    # issue 15194
+    assert Derivative(f(y, g(x)), (x, z)).subs(z, x
+        ) == Derivative(f(y, g(x)), (x, x))
+
+    df = f(x).diff(x)
+    assert df.subs(df, 1) is S.One
+    assert df.diff(df) is S.One
+    dxy = Derivative(f(x, y), x, y)
+    dyx = Derivative(f(x, y), y, x)
+    assert dxy.subs(Derivative(f(x, y), y, x), 1) is S.One
+    assert dxy.diff(dyx) is S.One
+    assert Derivative(f(x, y), x, 2, y, 3).subs(
+        dyx, g(x, y)) == Derivative(g(x, y), x, 1, y, 2)
 
 
 def test_diff_wrt_not_allowed():
     # issue 7027 included
     for wrt in (
-            cos(x), re(x), Derivative(cos(x), x), x**2, x*y, 1 + x):
+            cos(x), re(x), x**2, x*y, 1 + x,
+            Derivative(cos(x), x), Derivative(f(f(x)), x)):
         raises(ValueError, lambda: diff(f(x), wrt))
+    # if we don't differentiate wrt then don't raise error
+    assert diff(exp(x*y), x*y, 0) == exp(x*y)
 
 
 def test_klein_gordon_lagrangian():
@@ -743,9 +788,12 @@ def test_unhandled():
             else:
                 return None
 
-    expr = MyExpr(x, y, z)
-    assert diff(expr, x, y, f(x), z) == Derivative(expr, z, f(x))
-    assert diff(expr, f(x), x) == Derivative(expr, x, f(x))
+    d = Dummy()
+    eq = MyExpr(f(x), y, z)
+    assert diff(eq, x, y, f(x), z) == Derivative(eq, f(x))
+    assert diff(eq, f(x), x) == Derivative(eq, f(x))
+    assert f(x, y).diff(x,(y, z)) == Derivative(f(x, y), x, (y, z))
+    assert f(x, y).diff(x,(y, 0)) == Derivative(f(x, y), x)
 
 
 def test_nfloat():
@@ -990,11 +1038,6 @@ def test_issue_13843():
     assert Derivative(f(x), (x, n)).doit() == Derivative(f(x), (x, n))
 
 
-def test_issue_13873():
-    from sympy.abc import x
-    assert sin(x).diff((x, -1)).is_Derivative
-
-
 def test_order_could_be_zero():
     x, y = symbols('x, y')
     n = symbols('n', integer=True, nonnegative=True)
@@ -1086,3 +1129,92 @@ def test_issue_15241():
 
 def test_issue_15266():
     assert Subs(Derivative(f(y), x, y), y, g(x)).doit() != 0
+
+
+def test_issue_7027():
+    for wrt in (cos(x), re(x), Derivative(cos(x), x)):
+        raises(ValueError, lambda: diff(f(x), wrt))
+
+
+def test_derivative_quick_exit():
+    assert f(x).diff(y) == 0
+    assert f(x).diff(y, f(x)) == 0
+    assert f(x).diff(x, f(y)) == 0
+    assert f(f(x)).diff(x, f(x), f(y)) == 0
+    assert f(f(x)).diff(x, f(x), y) == 0
+    assert f(x).diff(g(x)) == 0
+    assert f(x).diff(x, f(x).diff(x)) == 1
+    df = f(x).diff(x)
+    assert f(x).diff(df) == 0
+    dg = g(x).diff(x)
+    assert dg.diff(df).doit() == 0
+
+
+def test_issue_15084_13166():
+    eq = f(x, g(x))
+    assert eq.diff((g(x), y)) == Derivative(f(x, g(x)), (g(x), y))
+    # issue 13166
+    assert eq.diff(x, 2).doit() == (
+        (Derivative(f(x, g(x)), (g(x), 2))*Derivative(g(x), x) +
+        Subs(Derivative(f(x, _xi_2), _xi_2, x), _xi_2, g(x)))*Derivative(g(x),
+        x) + Derivative(f(x, g(x)), g(x))*Derivative(g(x), (x, 2)) +
+        Derivative(g(x), x)*Subs(Derivative(f(_xi_1, g(x)), _xi_1, g(x)),
+        _xi_1, x) + Subs(Derivative(f(_xi_1, g(x)), (_xi_1, 2)), _xi_1, x))
+    # issue 6681
+    assert diff(f(x, t, g(x, t)), x).doit() == (
+        Derivative(f(x, t, g(x, t)), g(x, t))*Derivative(g(x, t), x) +
+        Subs(Derivative(f(_xi_1, t, g(x, t)), _xi_1), _xi_1, x))
+    # make sure the order doesn't matter when using diff
+    assert eq.diff(x, g(x)) == eq.diff(g(x), x)
+
+
+def test_negative_counts():
+    # issue 13873
+    raises(ValueError, lambda: sin(x).diff(x, -1))
+
+
+def test_Derivative__new__():
+    raises(TypeError, lambda: f(x).diff((x, 2), 0))
+    assert f(x, y).diff([(x, y), 0]) == f(x, y)
+    assert f(x, y).diff([(x, y), 1]) == NDimArray([
+        Derivative(f(x, y), x), Derivative(f(x, y), y)])
+    assert f(x,y).diff(y, (x, z), y, x) == Derivative(
+        f(x, y), (x, z + 1), (y, 2))
+    assert Matrix([x]).diff(x, 2) == Matrix([0])  # is_zero exit
+
+
+def test_issue_14719_10150():
+    class V(Expr):
+        _diff_wrt = True
+        is_scalar = False
+    assert V().diff(V()) == Derivative(V(), V())
+    assert (2*V()).diff(V()) == 2*Derivative(V(), V())
+    class X(Expr):
+        _diff_wrt = True
+    assert X().diff(X()) == 1
+    assert (2*X()).diff(X()) == 2
+
+
+def test_noncommutative_issue_15131():
+    x = Symbol('x', commutative=False)
+    t = Symbol('t', commutative=False)
+    fx = Function('Fx', commutative=False)(x)
+    ft = Function('Ft', commutative=False)(t)
+    A = Symbol('A', commutative=False)
+    eq = fx * A * ft
+    eqdt = eq.diff(t)
+    assert eqdt.args[-1] == ft.diff(t)
+
+
+def test_Subs_Derivative():
+    a = Derivative(f(g(x), h(x)), g(x), h(x),x)
+    b = Derivative(Derivative(f(g(x), h(x)), g(x), h(x)),x)
+    c = f(g(x), h(x)).diff(g(x), h(x), x)
+    d = f(g(x), h(x)).diff(g(x), h(x)).diff(x)
+    e = Derivative(f(g(x), h(x)), x)
+    eqs = (a, b, c, d, e)
+    subs = lambda arg: arg.subs(f, Lambda((x, y), exp(x + y))
+        ).subs(g(x), 1/x).subs(h(x), x**3)
+    ans = 3*x**2*exp(1/x)*exp(x**3) - exp(1/x)*exp(x**3)/x**2
+    assert all(subs(i).doit().expand() == ans for i in eqs)
+    assert all(subs(i.doit()).doit().expand() == ans for i in eqs)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -655,6 +655,8 @@ def test_subs_in_derivative():
     assert dxy.diff(dyx) is S.One
     assert Derivative(f(x, y), x, 2, y, 3).subs(
         dyx, g(x, y)) == Derivative(g(x, y), x, 1, y, 2)
+    assert Derivative(f(x, x - y), y).subs(x, x + y) == Subs(
+        Derivative(f(x, x - y), y), x, x + y)
 
 
 def test_diff_wrt_not_allowed():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -585,7 +585,7 @@ def test_issue_8449():
     assert Le(oo, -p) is S.false
 
 
-def test_simplify():
+def test_simplify_relational():
     assert simplify(x*(y + 1) - x*y - x + 1 < x) == (x > 1)
     r = S(1) < x
     # canonical operations are not the same as simplification,
@@ -599,6 +599,15 @@ def test_simplify():
     # _eval_simplify routine
     assert simplify(-(2**(3*pi/2) + 6**pi)**(1/pi) +
         2*(2**(pi/2) + 3**pi)**(1/pi) < 0) is S.false
+    # canonical at least
+    for f in (Eq, Ne):
+        f(y, x).simplify() == f(x, y)
+        f(x - 1, 0).simplify() == f(x, 1)
+        f(x - 1, x).simplify() == S.false
+        f(2*x - 1, x).simplify() == f(x, 1)
+        f(2*x, 4).simplify() == f(x, 2)
+        z = cos(1)**2 + sin(1)**2 - 1  # z.is_zero is None
+        f(z*x, 0).simplify() == f(z*x, 0)
 
 
 def test_equals():

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -7,7 +7,7 @@ from sympy import (
     AccumBounds, Matrix, zeros)
 from sympy.core.basic import _aresame
 from sympy.utilities.pytest import XFAIL
-from sympy.abc import x, y, z
+from sympy.abc import a, x, y, z
 
 
 def test_subs():
@@ -128,9 +128,6 @@ def test_dict_set():
 
 
 def test_dict_ambigous():   # see issue 3566
-    y = Symbol('y')
-    z = Symbol('z')
-
     f = x*exp(x)
     g = z*exp(z)
 
@@ -156,7 +153,6 @@ def test_dict_ambigous():   # see issue 3566
 
 
 def test_deriv_sub_bug3():
-    y = Symbol('y')
     f = Function('f')
     pat = Derivative(f(x), x, x)
     assert pat.subs(y, y**2) == Derivative(f(x), x, x)
@@ -178,14 +174,11 @@ def test_equality_subs2():
 
 
 def test_issue_3742():
-    y = Symbol('y')
-
     e = sqrt(x)*exp(y)
     assert e.subs(sqrt(x), 1) == exp(y)
 
 
 def test_subs_dict1():
-    x, y = symbols('x y')
     assert (1 + x*y).subs(x, pi) == 1 + pi*y
     assert (1 + x*y).subs({x: pi, y: 2}) == 1 + 2*pi
 
@@ -471,7 +464,6 @@ def test_subs_issue_4009():
 
 
 def test_functions_subs():
-    x, y = symbols('x y')
     f, g = symbols('f g', cls=Function)
     l = Lambda((x, y), sin(x) + y)
     assert (g(y, x) + cos(x)).subs(g, l) == sin(y) + x + cos(x)
@@ -484,8 +476,8 @@ def test_functions_subs():
 
 
 def test_derivative_subs():
-    y = Symbol('y')
     f = Function('f')
+    g = Function('g')
     assert Derivative(f(x), x).subs(f(x), y) != 0
     # need xreplace to put the function back, see #13803
     assert Derivative(f(x), x).subs(f(x), y).xreplace({y: f(x)}) == \
@@ -494,10 +486,13 @@ def test_derivative_subs():
     assert cse(Derivative(f(x), x) + f(x))[1][0].has(Derivative)
     assert cse(Derivative(f(x, y), x) +
                Derivative(f(x, y), y))[1][0].has(Derivative)
+    eq = Derivative(g(x), g(x))
+    assert eq.subs(g, f) == Derivative(f(x), f(x))
+    assert eq.subs(g(x), f(x)) == Derivative(f(x), f(x))
+    assert eq.subs(g, cos) == Subs(Derivative(y, y), y, cos(x))
 
 
 def test_derivative_subs2():
-    x, y, z = symbols('x y z')
     f_func, g_func = symbols('f g', cls=Function)
     f, g = f_func(x, y, z), g_func(x, y, z)
     assert Derivative(f, x, y).subs(Derivative(f, x, y), g) == g
@@ -521,7 +516,6 @@ def test_derivative_subs2():
 
 
 def test_derivative_subs3():
-    x = Symbol('x')
     dex = Derivative(exp(x), x)
     assert Derivative(dex, x).subs(dex, exp(x)) == dex
     assert dex.subs(exp(x), dex) == Derivative(exp(x), x, x)
@@ -543,7 +537,6 @@ def test_subs_iter():
 
 def test_subs_dict():
     a, b, c, d, e = symbols('a b c d e')
-    z = symbols('z')
 
     assert (2*x + y + z).subs(dict(x=1, y=2)) == 4 + z
 
@@ -576,8 +569,6 @@ def test_subs_dict():
 
 
 def test_no_arith_subs_on_floats():
-    a, x, y = symbols('a x y')
-
     assert (x + 3).subs(x + 3, a) == a
     assert (x + 3).subs(x + 2, a) == a + 1
 
@@ -593,7 +584,6 @@ def test_no_arith_subs_on_floats():
 
 def test_issue_5651():
     a, b, c, K = symbols('a b c K', commutative=True)
-    x, y, z = symbols('x y z')
     assert (a/(b*c)).subs(b*c, K) == a/K
     assert (a/(b**2*c**3)).subs(b*c, K) == a/(c*K**2)
     assert (1/(x*y)).subs(x*y, 2) == S.Half
@@ -608,7 +598,6 @@ def test_issue_6075():
 
 def test_issue_6079():
     # since x + 2.0 == x + 2 we can't do a simple equality test
-    x = symbols('x')
     assert _aresame((x + 2.0).subs(2, 3), x + 2.0)
     assert _aresame((x + 2.0).subs(2.0, 3), x + 3)
     assert not _aresame(x + 2, x + 2.0)

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -543,7 +543,7 @@ class BaseVectorField(AtomicExpr):
      d
     ---(g(x0, y0))
     dy0
-    >>> pprint(v(s_field).rcall(point_p).doit())
+    >>> pprint(v(s_field).rcall(point_p))
     /  d                           \|
     |-----(g(r0*cos(theta0), xi_2))||
     \dxi_2                         /|xi_2=r0*sin(theta0)
@@ -595,7 +595,7 @@ class BaseVectorField(AtomicExpr):
         # Remove the dummies
         result = d_result.subs(list(zip(d_funcs, base_scalars)))
         result = result.subs(list(zip(coords, self._coord_sys.coord_functions())))
-        return result.doit()  # XXX doit for the Subs instances
+        return result.doit()
 
 
 class Commutator(Expr):
@@ -628,7 +628,7 @@ class Commutator(Expr):
     >>> c_xr
     Commutator(e_x, e_r)
 
-    >>> simplify(c_xr(R2.y**2).doit())
+    >>> simplify(c_xr(R2.y**2))
     -2*y**2*cos(theta)/(x**2 + y**2)
 
     """
@@ -944,7 +944,7 @@ class LieDerivative(Expr):
     >>> tp = TensorProduct(R2.dx, R2.dy)
     >>> LieDerivative(R2.e_x, tp)
     LieDerivative(e_x, TensorProduct(dx, dy))
-    >>> LieDerivative(R2.e_x, tp).doit()
+    >>> LieDerivative(R2.e_x, tp)
     LieDerivative(e_x, TensorProduct(dx, dy))
     """
     def __new__(cls, v_field, expr):
@@ -1039,7 +1039,9 @@ class BaseCovarDerivativeOp(Expr):
         to_subs = [wrt_vector(d) for d in d_funcs]
         result = d_result.subs(list(zip(to_subs, derivs)))
 
-        return result  # TODO .doit() # XXX doit for the Subs instances
+        # Remove the dummies
+        result = result.subs(list(zip(d_funcs, vectors)))
+        return result.doit()
 
 
 class CovarDerivativeOp(Expr):

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -361,7 +361,19 @@ def test_piecewise_simplify():
     p = Piecewise(((x**2 + 1)/x**2, Eq(x*(1 + x) - x**2, 0)),
                   ((-1)**x*(-1), True))
     assert p.simplify() == \
-        Piecewise((1 + 1/x**2, Eq(x, 0)), ((-1)**(x + 1), True))
+        Piecewise((zoo, Eq(x, 0)), ((-1)**(x + 1), True))
+    # simplify when there are Eq in conditions
+    assert Piecewise(
+        (a, And(Eq(a, 0), Eq(a + b, 0))), (1, True)).simplify(
+        ) == Piecewise(
+        (0, And(Eq(a, 0), Eq(b, 0))), (1, True))
+    assert Piecewise((2*x*factorial(a)/(factorial(y)*factorial(-y + a)),
+        Eq(y, 0) & Eq(-y + a, 0)), (2*factorial(a)/(factorial(y)*factorial(-y
+        + a)), Eq(y, 0) & Eq(-y + a, 1)), (0, True)).simplify(
+        ) == Piecewise(
+            (2*x, And(Eq(a, 0), Eq(y, 0))),
+            (2, And(Eq(a, 1), Eq(y, 0))),
+            (0, True))
 
 
 def test_piecewise_solve():
@@ -453,6 +465,11 @@ def test_piecewise_fold():
 
     assert piecewise_fold(Piecewise((x, ITE(x > 0, y < 1, y > 1)))
         ) == Piecewise((x, ((x <= 0) | (y < 1)) & ((x > 0) | (y > 1))))
+
+    a, b = (Piecewise((2, Eq(x, 0)), (0, True)),
+        Piecewise((x, Eq(-x + y, 0)), (1, Eq(-x + y, 1)), (0, True)))
+    assert piecewise_fold(Mul(a, b, evaluate=False)
+        ) == piecewise_fold(Mul(b, a, evaluate=False))
 
 
 def test_piecewise_fold_piecewise_in_cond():

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -834,7 +834,7 @@ class HolonomicFunction(object):
 
         return HolonomicFunction(self.annihilator * D, self.x)
 
-    def diff(self, *args):
+    def diff(self, *args, **kwargs):
         r"""
         Differentiation of the given Holonomic function.
 
@@ -856,7 +856,7 @@ class HolonomicFunction(object):
 
         .integrate()
         """
-
+        kwargs.setdefault('evaluate', True)
         if args:
             if args[0] != self.x:
                 return S(0)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -709,7 +709,8 @@ class Integral(AddWithLimits):
                           for l in f.limits]
                 f = self.func(f.function, *limits)
             return f.subs(x, ab)*dab_dsym
-        rv = 0
+
+        rv = S.Zero
         if b is not None:
             rv += _do(f, b)
         if a is not None:
@@ -725,7 +726,8 @@ class Integral(AddWithLimits):
             # while differentiating
             u = Dummy('u')
             arg = f.subs(x, u).diff(sym).subs(u, x)
-            rv += self.func(arg, Tuple(x, a, b))
+            if arg:
+                rv += self.func(arg, Tuple(x, a, b))
         return rv
 
     def _eval_integral(self, f, x, meijerg=None, risch=None, manual=None,

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -95,7 +95,7 @@ def test_basics():
     assert diff(Integral(y, y), x) == 0
     assert diff(Integral(x, (x, 0, 1)), x) == 0
     assert diff(Integral(x, x), x) == x
-    assert diff(Integral(t, (t, 0, x)), x) == x + Integral(0, (t, 0, x))
+    assert diff(Integral(t, (t, 0, x)), x) == x
 
     e = (t + 1)**2
     assert diff(integrate(e, (t, 0, x)), x) == \
@@ -142,6 +142,7 @@ def test_diff_wrt():
 
     raises(ValueError, lambda: integrate(x + 1, x + 1))
     raises(ValueError, lambda: integrate(x + 1, (x + 1, 0, 1)))
+
 
 def test_basics_multiple():
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -6,16 +6,18 @@ from __future__ import print_function, division
 from collections import defaultdict
 from itertools import combinations, product
 
+from sympy.core.add import Add
 from sympy.core.basic import Basic, as_Basic
 from sympy.core.cache import cacheit
 from sympy.core.numbers import Number, oo
 from sympy.core.operations import LatticeOp
-from sympy.core.function import Application, Derivative
+from sympy.core.function import Application, Derivative, count_ops
 from sympy.core.compatibility import (ordered, range, with_metaclass,
     as_int, reduce)
 from sympy.core.sympify import converter, _sympify, sympify
 from sympy.core.singleton import Singleton, S
 from sympy.utilities.misc import filldedent
+from sympy.utilities.iterables import sift
 
 
 def as_Boolean(e):
@@ -412,7 +414,12 @@ class BooleanFunction(Application, Boolean):
     is_Boolean = True
 
     def _eval_simplify(self, ratio, measure, rational, inverse):
-        return simplify_logic(self)
+        rv = self.func(*[a._eval_simplify(ratio=ratio, measure=measure,
+            rational=rational, inverse=inverse) for a in self.args])
+        return simplify_logic(rv)
+
+    def simplify(self, ratio=1.7, measure=count_ops, rational=False, inverse=False):
+        return self._eval_simplify(ratio, measure, rational, inverse)
 
     # /// drop when Py2 is no longer supported
     def __lt__(self, other):
@@ -541,6 +548,63 @@ class And(LatticeOp, BooleanFunction):
                 rel.append(c)
             newargs.append(x)
         return LatticeOp._new_args_filter(newargs, And)
+
+    def _eval_simplify(self, ratio, measure, rational, inverse):
+        from sympy.core.relational import Equality, Relational
+        from sympy.solvers.solveset import linear_coeffs
+        # standard simplify
+        rv = super(And, self)._eval_simplify(
+            ratio, measure, rational, inverse)
+        if not isinstance(rv, And):
+            return rv
+        # simplify args that are equalities involving
+        # symbols so x == 0 & x == y -> x==0 & y == 0
+        Rel, nonRel = sift(rv.args, lambda i: isinstance(i, Relational), binary=True)
+        if not Rel:
+            return rv
+        eqs, other = sift(Rel, lambda i: isinstance(i, Equality), binary=True)
+        if not eqs:
+            return rv
+        reps = {}
+        sifted = {}
+        if eqs:
+            # group by length of free symbols
+            sifted = sift(ordered([
+                (i.free_symbols, i) for i in eqs]),
+                lambda x: len(x[0]))
+            eqs = []
+            while 1 in sifted:
+                for free, e in sifted.pop(1):
+                    x = free.pop()
+                    if e.lhs != x or x in e.rhs.free_symbols:
+                        try:
+                            m, b = linear_coeffs(
+                                e.rewrite(Add, evaluate=False), x)
+                            enew = e.func(x, -b/m)
+                            if measure(enew) <= ratio*measure(e):
+                                e = enew
+                            else:
+                                eqs.append(e)
+                                continue
+                        except ValueError:
+                            pass
+                    if x in reps:
+                        eqs.append(e.func(e.rhs, reps[x]))
+                    else:
+                        reps[x] = e.rhs
+                        eqs.append(e)
+                resifted = defaultdict(list)
+                for k in sifted:
+                    for f, e in sifted[k]:
+                        e = e.subs(reps)
+                        f = e.free_symbols
+                        resifted[len(f)].append((f, e))
+                sifted = resifted
+        for k in sifted:
+            eqs.extend([e for f, e in sifted[k]])
+        other = [ei.subs(reps) for ei in other]
+        rv = rv.func(*([i.canonical for i in (eqs + other)] + nonRel))
+        return rv
 
     def _eval_as_set(self):
         from sympy.sets.sets import Intersection
@@ -671,14 +735,6 @@ class Not(BooleanFunction):
             return StrictGreaterThan(*arg.args)
         if isinstance(arg, GreaterThan):
             return StrictLessThan(*arg.args)
-
-    def _eval_simplify(self, ratio, measure, rational, inverse):
-        x = self.args[0]
-        try:
-            x._eval_simplify(ratio=ratio, measure=measure, rational=rational, inverse=inverse)
-        except:
-            pass
-        return self.func(x)
 
     def _eval_as_set(self):
         """

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -264,6 +264,17 @@ def test_simplification():
     assert simplify((A & B) | (A & C)) == And(A, Or(B, C))
     assert simplify(And(x, Not(x))) == False
     assert simplify(Or(x, Not(x))) == True
+    assert simplify(And(Eq(x, 0), Eq(x, y))) == And(Eq(x, 0), Eq(y, 0))
+    assert And(Eq(x - 1, 0), Eq(x, y)).simplify() == And(Eq(x, 1), Eq(y, 1))
+    assert And(Ne(x - 1, 0), Ne(x, y)).simplify() == And(Ne(x, 1), Ne(x, y))
+    assert And(Eq(x - 1, 0), Ne(x, y)).simplify() == And(Eq(x, 1), Ne(y, 1))
+    assert And(Eq(x - 1, 0), Eq(x, z + y), Eq(y + x, 0)).simplify(
+        ) == And(Eq(x, 1), Eq(y, -1), Eq(z, 2))
+    assert And(Eq(x - 1, 0), Eq(x + 2, 3)).simplify() == Eq(x, 1)
+    assert And(Ne(x - 1, 0), Ne(x + 2, 3)).simplify() == Ne(x, 1)
+    assert And(Eq(x - 1, 0), Eq(x + 2, 2)).simplify() == False
+    assert And(Ne(x - 1, 0), Ne(x + 2, 2)).simplify(
+        ) == And(Ne(x, 1), Ne(x, 0))
 
 
 def test_bool_map():
@@ -818,4 +829,4 @@ def test_binary_symbols():
 
 
 def test_BooleanFunction_diff():
-    assert And(x, y).diff(x) == Piecewise((0, Eq(False, y)), (1, True))
+    assert And(x, y).diff(x) == Piecewise((0, Eq(y, False)), (1, True))

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -205,12 +205,6 @@ class DenseMatrix(MatrixBase):
         mat = [a*b for a,b in zip(self._mat, other._mat)]
         return classof(self, other)._new(self.rows, self.cols, mat, copy=False)
 
-    def _eval_diff(self, *args, **kwargs):
-        if kwargs.pop("evaluate", True):
-            return self.diff(*args)
-        else:
-            return Derivative(self, *args, **kwargs)
-
     def _eval_inverse(self, **kwargs):
         """Return the matrix inverse using the method indicated (default
         is Gauss elimination).

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1685,7 +1685,7 @@ class MatrixEigen(MatrixSubspaces):
 class MatrixCalculus(MatrixCommon):
     """Provides calculus-related matrix operations."""
 
-    def diff(self, *args):
+    def diff(self, *args, **kwargs):
         """Calculate the derivative of each element in the matrix.
         ``args`` will be passed to the ``integrate`` function.
 
@@ -1706,8 +1706,10 @@ class MatrixCalculus(MatrixCommon):
         integrate
         limit
         """
+        # XXX this should be handled here rather than in Derivative
         from sympy import Derivative
-        return Derivative(self, *args, evaluate=True)
+        kwargs.setdefault('evaluate', True)
+        return Derivative(self, *args, **kwargs)
 
     def _eval_derivative(self, arg):
         return self.applyfunc(lambda x: x.diff(arg))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1958,15 +1958,7 @@ def test_diff():
     assert A.diff(a) == MutableDenseMatrix([[0, 0], [0, 0]])
 
     B = ImmutableDenseMatrix([a, b])
-    assert A.diff(B) == Array(
-        [[[
-            [0,0],
-            [0,0]
-        ]],
-        [[
-            [0,0],
-            [0,0]
-        ]]])
+    assert A.diff(B) == A.zeros(2)
 
     # Test diff with tuples:
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -726,7 +726,7 @@ class LatexPrinter(Printer):
         '''
         func = expr.func.__name__
         if hasattr(self, '_print_' + func) and \
-            not isinstance(expr.func, UndefinedFunction):
+            not isinstance(expr, AppliedUndef):
             return getattr(self, '_print_' + func)(expr, exp)
         else:
             args = [ str(self._print(arg)) for arg in expr.args ]

--- a/sympy/series/formal.py
+++ b/sympy/series/formal.py
@@ -366,6 +366,8 @@ def _compute_formula(f, x, P, Q, k, m, k_max):
 
     sol = []
     for i in range(k_max + 1, k_max + m + 1):
+        if (i < 0) == True:
+            continue
         r = f.diff(x, i).limit(x, 0) / factorial(i)
         if r is S.Zero:
             continue

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -114,6 +114,9 @@ def test_series_of_Subs():
     assert subs3.series(x).doit() == subs3.doit().series(x)
     assert subs3.series(z).doit() == sin(x*y)
 
+    raises(ValueError, lambda: Subs(x + 2*y, y, z).series())
+    assert Subs(x + y, y, z).series(x).doit() == x + z
+
 
 def test_issue_3978():
     f = Function('f')

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -108,9 +108,13 @@ def test_series_of_Subs():
     subs3 = Subs(sin(x * z), (x, z), (y, x))
 
     assert subs1.series(x) == subs1
-    assert subs1.series(y) == Subs(x, x, y) + Subs(-x**3/6, x, y) + Subs(x**5/120, x, y) + O(y**6)
+    subs1_series = (Subs(x, x, y) + Subs(-x**3/6, x, y) +
+        Subs(x**5/120, x, y) + O(y**6))
+    assert subs1.series() == subs1_series
+    assert subs1.series(y) == subs1_series
     assert subs1.series(z) == subs1
-    assert subs2.series(z) == Subs(z**4*sin(x)/24, x, y) + Subs(-z**2*sin(x)/2, x, y) + Subs(sin(x), x, y) + O(z**6)
+    assert subs2.series(z) == (Subs(z**4*sin(x)/24, x, y) +
+        Subs(-z**2*sin(x)/2, x, y) + Subs(sin(x), x, y) + O(z**6))
     assert subs3.series(x).doit() == subs3.doit().series(x)
     assert subs3.series(z).doit() == sin(x*y)
 

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -351,7 +351,8 @@ def test_cse_MatrixExpr():
 def test_Piecewise():
     f = Piecewise((-z + x*y, Eq(y, 0)), (-z - x*y, True))
     ans = cse(f)
-    actual_ans = ([(x0, -z), (x1, x*y)], [Piecewise((x0+x1, Eq(y, 0)), (x0 - x1, True))])
+    actual_ans = ([(x0, -z), (x1, x*y)],
+        [Piecewise((x0 + x1, Eq(y, 0)), (x0 - x1, True))])
     assert ans == actual_ans
 
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -625,10 +625,10 @@ def test_checkodesol():
         solve_for_func=False) == (True, 0)
     assert checkodesol(f(x).diff(x, 2), [Eq(f(x), C1 + C2*x),
         Eq(f(x), C2 + C1*x), Eq(f(x), C1*x + C2*x**2)]) == \
-        [(True, 0), (True, 0), (False, 2*C2)]
+        [(True, 0), (True, 0), (False, C2)]
     assert checkodesol(f(x).diff(x, 2), set([Eq(f(x), C1 + C2*x),
         Eq(f(x), C2 + C1*x), Eq(f(x), C1*x + C2*x**2)])) == \
-        set([(True, 0), (True, 0), (False, 2*C2)])
+        set([(True, 0), (True, 0), (False, C2)])
     assert checkodesol(f(x).diff(x) - 1/f(x)/2, Eq(f(x)**2, x)) == \
         [(True, 0), (True, 0)]
     assert checkodesol(f(x).diff(x) - f(x), Eq(C1*exp(x), f(x))) == (True, 0)

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -209,7 +209,7 @@ class NDimArray(object):
         """
         return self._rank
 
-    def diff(self, *args):
+    def diff(self, *args, **kwargs):
         """
         Calculate the derivative of each element in the array.
 
@@ -224,7 +224,8 @@ class NDimArray(object):
 
         """
         from sympy import Derivative
-        return Derivative(self.as_immutable(), *args, evaluate=True)
+        kwargs.setdefault('evaluate', True)
+        return Derivative(self.as_immutable(), *args, **kwargs)
 
     def _accept_eval_derivative(self, s):
         return s._visit_eval_derivative_array(self)

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -19,7 +19,8 @@ from sympy import (Rational, symbols, Dummy, factorial, sqrt, log, exp, oo, zoo,
     continued_fraction_periodic as cf_p, continued_fraction_convergents as cf_c,
     continued_fraction_reduce as cf_r, FiniteSet, elliptic_e, elliptic_f,
     powsimp, hessian, wronskian, fibonacci, sign, Lambda, Piecewise, Subs,
-    residue, Derivative, logcombine, Symbol, Intersection, Union, EmptySet, Interval)
+    residue, Derivative, logcombine, Symbol, Intersection, Union,
+    EmptySet, Interval, Integral, idiff)
 
 import mpmath
 from sympy.functions.combinatorial.numbers import stirling
@@ -1197,7 +1198,6 @@ def test_N8():
                Q.is_true((x >= y) & (y >= z) & (z >= x)))
 
 
-@XFAIL
 def test_N9():
     x = Symbol('x')
     assert solveset(abs(x - 1) > 2, domain=S.Reals) == Union(Interval(-oo, -1, False, True),
@@ -1379,11 +1379,10 @@ def test_P7():
                          x*(5*z + 11) + y*(6*z - 12)]])
 
 
-@XFAIL
 def test_P8():
     M = Matrix([[1, -2*I],
                 [-3*I, 4]])
-    assert M.norm(ord=S.Infinity) == 7  # Matrix.norm(ord=inf) not implemented
+    assert M.norm(ord=S.Infinity) == 7
 
 
 def test_P9():
@@ -1459,7 +1458,7 @@ def test_P16():
                 [6*sqrt(6), 24*sqrt(3)]])
     assert M.rank() == 1
 
-@XFAIL
+
 def test_P17():
     t = symbols('t', real=True)
     M=Matrix([
@@ -1946,12 +1945,9 @@ def test_R17():
                - 2.8469909700078206) < 1e-15
 
 
-@XFAIL
 def test_R18():
     k = symbols('k', integer=True, positive=True)
     Sm = Sum(1/(2**k*k**2), (k, 1, oo))
-    # returns polylog(2, 1/2),  particular value for 1/2 is not known.
-    # https://github.com/sympy/sympy/issues/7132
     T = Sm.doit()
     assert T.simplify() == -log(2)**2/2 + pi**2/12
 
@@ -2086,9 +2082,8 @@ def test_T2():
     assert limit((3**x + 5**x)**(1/x), x, oo) == 5
 
 
-@XFAIL
 def test_T3():
-    assert limit(log(x)/(log(x) + sin(x)), x, oo) == 1  # raises PoleError
+    assert limit(log(x)/(log(x) + sin(x)), x, oo) == 1
 
 
 def test_T4():
@@ -2181,21 +2176,21 @@ def test_U4():
     assert diff(x**n, x, n).rewrite(factorial) == factorial(n)
 
 
-@XFAIL
 def test_U5():
-    # https://github.com/sympy/sympy/issues/6681
-    # f(g(x)).diff(x,2) returns Derivative(g(x), x)**2*Subs(Derivative(
-    #  f(_xi_1), _xi_1, _xi_1), (_xi_1,), (g(x),)) + Derivative(g(x), x, x)*
-    #  Subs(Derivative(f(_xi_1), _xi_1), (_xi_1,), (g(x),))
-    raise NotImplementedError("f(g(t)).diff(t,2) Subs not performed")
+    # issue 6681
+    t = symbols('t')
+    ans = (
+        Derivative(f(g(t)), g(t))*Derivative(g(t), (t, 2)) +
+        Derivative(f(g(t)), (g(t), 2))*Derivative(g(t), t)**2)
+    assert f(g(t)).diff(t, 2) == ans
+    assert ans.doit() == ans
 
 
-@XFAIL
 def test_U6():
     h = Function('h')
-    # raises ValueError: Invalid limits given: (y, h(x), g(x))
-    T = integrate(f(y), y, h(x), g(x))
-    T.diff(x)
+    T = integrate(f(y), (y, h(x), g(x)))
+    assert T.diff(x) == (
+        f(g(x))*Derivative(g(x), x) - f(h(x))*Derivative(h(x), x))
 
 
 @XFAIL
@@ -2211,14 +2206,11 @@ def test_U7():
 def test_U8():
     x, y = symbols('x y', real=True)
     eq = cos(x*y) + x
-    eq = eq.subs(y, f(x))
     #  If SymPy had implicit_diff() function this hack could be avoided
     # TODO: Replace solve with solveset, current test fails for solveset
-    assert (solve((f(x) - eq).diff(x), f(x).diff(x))[0].subs(f(x), y) ==
-            (-y*sin(x*y) + 1)/(x*sin(x*y) + 1))
+    assert idiff(y - eq, y, x) == (-y*sin(x*y) + 1)/(x*sin(x*y) + 1)
 
 
-@XFAIL
 def test_U9():
     # Wester sample case for Maple:
     # O29 := diff(f(x, y), x) + diff(f(x, y), y);
@@ -2231,19 +2223,17 @@ def test_U9():
     #                        2 D(g)(x  + y ) (x + y)
     x, y = symbols('x y', real=True)
     su = diff(f(x, y), x) + diff(f(x, y), y)
-    s2 = Subs(su, f(x, y), g(x**2 + y**2)).doit()
+    s2 = su.subs(f(x, y), g(x**2 + y**2))
     s3 = s2.doit().factor()
     # Subs not performed, s3 = 2*(x + y)*Subs(Derivative(
-    #   g(_xi_1), _xi_1), (_xi_1,), (x**2 + y**2,))
+    #   g(_xi_1), _xi_1), _xi_1, x**2 + y**2)
     # Derivative(g(x*2 + y**2), x**2 + y**2) is not valid in SymPy,
     # and probably will remain that way. You can take derivatives with respect
     # to other expressions only if they are atomic, like a symbol or a
     # function.
     # D operator should be added to SymPy
     # See https://github.com/sympy/sympy/issues/4719.
-
-    # raises ValueError: Can't differentiate wrt the variable: x**2 + y**2
-    assert s3 == 2*(x + y)*Derivative(g(x**2 + y**2), x**2 + y**2)
+    assert s3 == (x + y)*Subs(Derivative(g(x), x), x, x**2 + y**2)*2
 
 
 def test_U10():
@@ -2298,12 +2288,9 @@ def test_U17():
 supported in SymPy")
 
 
-@XFAIL
 def test_V1():
     x = symbols('x', real=True)
-    # integral not calculated
-    # https://github.com/sympy/sympy/issues/4212
-    assert integrate(abs(x), x) == x*abs(x)/2
+    assert integrate(abs(x), x) == Piecewise((-x**2/2, x <= 0), (x**2/2, True))
 
 
 def test_V2():
@@ -2315,7 +2302,6 @@ def test_V3():
     assert integrate(1/(x**3 + 2),x).diff().simplify() == 1/(x**3 + 2)
 
 
-@XFAIL
 def test_V4():
     assert integrate(2**x/sqrt(1 + 4**x), x) == asinh(2**x)/log(2)
 
@@ -2615,11 +2601,9 @@ def test_W25():
     assert (i2 - pi*a/2).simplify() == 0
 
 
-@XFAIL
+
 def test_W26():
     x, y = symbols('x y', real=True)
-    # integrate(abs(y - x**2), (y,0,2)) raises ValueError: gamma function pole
-    # https://github.com/sympy/sympy/issues/7165
     assert integrate(integrate(abs(y - x**2), (y, 0, 2)),
                      (x, -1, 1)) == S(46)/15
 

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -115,9 +115,6 @@ class BasisDependent(Expr):
                                for k, v in self.components.items()]
         return self._add_func(*integral_components)
 
-    def _eval_diff(self, *args, **kwargs):
-        return self.diff(*args, **kwargs)
-
     def as_numer_denom(self):
         """
         Returns the expression as a tuple wrt the following


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
fixes #7027
closes #10597
closes #11962 
fixes #14719 
fixes #15028 
fixes #15084 
closes #13166 
fixes #13873
fixes #15131
fixes #6681
fixes #13457
fixes #15190 
fixes #6403
fixes #10150
closes #14221
fixes #15266

#### Brief description of what is fixed or changed

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Derivative has faster quick exit for 0
  * subs involving changing UndefinedFunction to Function in Derivative wrt variables will now create a Subs instance
  * error message for differentiation wrt bad variable no longer raised if the count is 0 and no longer refers to the count
  * error message for differentiation wrt variable that has a negative count
  * Derivative has `canonical` property which returns Derivative with `variable_count` canonically sorted
  * Derivative.variables is not a reliable way to see which are the variables of differentiation: it gives an expanded list of those variables, e.g `f(x,y).diff(x,2,y).variables -> (x,x,y)` or raises an error if some order of   differentiation is symbolic, e.g. `f(x).diff(x,y).variables -> TypeError`
  * Derivative has `_wrt_variables` which lists, in order, the variables of differentiation, even if the count is symbolic.
  * defined function and non-elementary Derivatives (like `Derivative(f(g(x)), x)`) give False for _diff_wrt
  * subs involving Subs now give a result that should be the same whether doit is applied before or after the subs, e.g. `Subs(x*y, x, x + 1).subs(x, y).doit() == Subs(x*y, x, x + 1).doit().subs(x, y)`
  * a change of symbols is now possible with Subs so `Subs(x, x, 1).subs(x, y) -> Subs(y, y, 1)`
  * `Function.fdiff` returns Subs less often, e.g. `f(g(x)).diff(x)` no longer creates a Subs instance
  * Expr has a default attribute `is_scalar=True` which makes Expr().diff(Expr()) == 1
  * bug involving derivatives of non-commutative expressions is fixed
  * Mul now implements the nth derivative in terms of multinomials
  * piecewise_fold is canonical wrt ordering of final Piecewise arguments
  * Piecewise uses information from Eq or And conditions to simplify the corresponding expression, e.g. (f(x), Eq(x, 0)) -> (f(0), Eq(x, 0))
  * BooleanFunction has `simplify` method
  * And will simplify args of type `Eq` when simple opportunities are presented, e.g. And(Eq(x, 0), Eq(x, y)) -> And(Eq(x, 0), Eq(y, 0))
* diffgeom
  * better removal of dummies from expressions involving derivatives
<!-- END RELEASE NOTES -->

- [x] check #14719 -- made a note on the issue page describing how to handle this

<!-- null -->
:100: All lines shown as added in the diff have nominal coverage. 