### PR TITLE
Fix recursion error when printing latex(Pow(1, -1, evaluate=False))

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -514,6 +514,9 @@ class LatexPrinter(Printer):
                 return self._print(expr.base, exp="%s/%s" % (p, q))
             return r"%s^{%s/%s}" % (base, p, q)
         elif expr.exp.is_Rational and expr.exp.is_negative and expr.base.is_commutative:
+            # special case for 1^(-1), issue 9216
+            if expr.base == 1 and expr.exp == -1:
+                return r"%s^{%s}" %(expr.base, expr.exp)
             # things like 1/x
             return self._print_Mul(expr)
         else:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -514,8 +514,8 @@ class LatexPrinter(Printer):
                 return self._print(expr.base, exp="%s/%s" % (p, q))
             return r"%s^{%s/%s}" % (base, p, q)
         elif expr.exp.is_Rational and expr.exp.is_negative and expr.base.is_commutative:
-            # special case for 1^(-1), issue 9216
-            if expr.base == 1 and expr.exp == -1:
+            # special case for 1^(-x), issue 9216
+            if expr.base == 1:
                 return r"%s^{%s}" % (expr.base, expr.exp)
             # things like 1/x
             return self._print_Mul(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -516,7 +516,7 @@ class LatexPrinter(Printer):
         elif expr.exp.is_Rational and expr.exp.is_negative and expr.base.is_commutative:
             # special case for 1^(-1), issue 9216
             if expr.base == 1 and expr.exp == -1:
-                return r"%s^{%s}" %(expr.base, expr.exp)
+                return r"%s^{%s}" % (expr.base, expr.exp)
             # things like 1/x
             return self._print_Mul(expr)
         else:

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1784,3 +1784,9 @@ def test_issue_9216():
 
     expr_2 = Pow(1, Pow(1, -1, evaluate=False), evaluate=False)
     assert latex(expr_2) == r"1^{1^{-1}}"
+
+    expr_3 = Pow(3, -2, evaluate=False)
+    assert latex(expr_3) == r"\frac{1}{9}"
+
+    expr_4 = Pow(1, -2, evaluate=False)
+    assert latex(expr_4) == r"1^{-2}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1776,3 +1776,11 @@ def test_issue_14041():
         r"\left(\dot{\phi} + \dot{\theta}\right)^{2}\mathbf{\hat{a}_x}"
     assert latex((phid*thetad)**a*A_frame.x) == \
         r"\left(\dot{\phi} \dot{\theta}\right)^{a}\mathbf{\hat{a}_x}"
+
+
+def test_issue_9216():
+    expr_1 = Pow(1, -1, evaluate=False)
+    assert latex(expr_1) == r"1^{-1}"
+
+    expr_2 = Pow(1, Pow(1, -1, evaluate=False), evaluate=False)
+    assert latex(expr_2) == r"1^{1^{-1}}"


### PR DESCRIPTION
Fixes #9216.

Added a special case to not send the execution to _print_Mul when the base is 1 which would lead to a recursion error.

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug when latex printing unevaluated pow with 1 as the base
<!-- END RELEASE NOTES -->
