### PR TITLE
Multivariate Random symbol does not raise error if name is 'N'

### DIFF
--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -23,6 +23,7 @@ from sympy.stats.crv import (ContinuousDistribution,
     SingleContinuousDistribution, SingleContinuousPSpace)
 from sympy.stats.drv import (DiscreteDistribution,
     SingleDiscreteDistribution, SingleDiscretePSpace)
+from sympy.core.compatibility import string_types
 from sympy.matrices import ImmutableMatrix
 from sympy.core.containers import Tuple
 from sympy.utilities.misc import filldedent
@@ -34,11 +35,14 @@ class JointPSpace(ProductPSpace):
     each component and a distribution.
     """
     def __new__(cls, sym, dist):
-        sym = sympify(sym)
         if isinstance(dist, SingleContinuousDistribution):
             return SingleContinuousPSpace(sym, dist)
         if isinstance(dist, SingleDiscreteDistribution):
             return SingleDiscretePSpace(sym, dist)
+        if isinstance(sym, string_types):
+            sym = Symbol(sym)
+        if not isinstance(sym, Symbol):
+                raise TypeError("s should have been string or Symbol")
         return Basic.__new__(cls, sym, dist)
 
     @property

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -42,7 +42,7 @@ class JointPSpace(ProductPSpace):
         if isinstance(sym, string_types):
             sym = Symbol(sym)
         if not isinstance(sym, Symbol):
-                raise TypeError("s should have been string or Symbol")
+            raise TypeError("s should have been string or Symbol")
         return Basic.__new__(cls, sym, dist)
 
     @property

--- a/sympy/stats/joint_rv_types.py
+++ b/sympy/stats/joint_rv_types.py
@@ -13,7 +13,6 @@ from sympy.matrices.expressions.determinant import det
 # ]
 
 def multivariate_rv(cls, sym, *args):
-    sym = sympify(sym)
     args = list(map(sympify, args))
     dist = cls(*args)
     args = dist.args

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -18,8 +18,8 @@ def test_Normal():
     assert density(m)(x, y) == density(p)(x, y)
     assert marginal_distribution(n, 0, 1)(1, 2) == 1/(2*pi)
     assert integrate(density(m)(x, y), (x, -oo, oo), (y, -oo, oo)).evalf() == 1
-    N1 = Normal('N1', [1, 2], [[x, 0], [0, y]])
-    assert density(N1)(0, 0) == exp(-2/y - 1/(2*x))/(2*pi*sqrt(x*y))
+    N = Normal('N', [1, 2], [[x, 0], [0, y]])
+    assert density(N)(0, 0) == exp(-2/y - 1/(2*x))/(2*pi*sqrt(x*y))
 
     raises (ValueError, lambda: Normal('M', [1, 2], [[1, 1], [1, -1]]))
 


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15073 

#### Brief description of what is fixed or changed
Multivariate random variable previously raised error if name given was
`N` due to `sympify` converting it into the function `N`. This is now
fixed. Modified an exisitng test to test this change.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
