### PR TITLE
added explicit check to see if base of an exponential equation is zero

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -246,10 +246,15 @@ def _invert_real(f, g_ys, symbol):
                 s, b = integer_log(rhs, base)
                 if b:
                     return _invert_real(expo, FiniteSet(s), symbol)
-            elif rhs is S.One:
-                # special case: 0**x - 1
-                return (expo, FiniteSet(0))
-            return (expo, S.EmptySet)
+                else:
+                    return _invert_real(expo, S.EmptySet, symbol)
+            elif base.is_zero:
+                one = Eq(rhs, 1)
+                if one == S.true:
+                    # special case: 0**x - 1
+                    return _invert_real(expo, FiniteSet(0), symbol)
+                elif one == S.false:
+                    return _invert_real(expo, S.EmptySet, symbol)
 
 
     if isinstance(f, TrigonometricFunction):
@@ -1123,8 +1128,8 @@ def _solve_exponential(lhs, rhs, symbol, domain):
             Ne(a_base, 0),
             Ne(b_base, 0))
 
-    log_type_equation = expand_log(log(a), force=True) - expand_log(log(-b), force=True)
-    solutions = _solveset(log_type_equation, symbol, domain)
+    L, R = map(lambda i: expand_log(log(i), force=True), (a, -b))
+    solutions = _solveset(L - R, symbol, domain)
 
     return ConditionSet(symbol, conditions, solutions)
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -963,7 +963,7 @@ def test_conditionset():
         ) == ConditionSet(x, Eq(-x + sin(Abs(x)), 0), S.Reals)
 
     assert solveset(y**x-z, x, S.Reals) == \
-        ConditionSet(x, Eq(y**x - z, 0), Reals)
+        ConditionSet(x, Eq(y**x - z, 0), S.Reals)
 
 
 @XFAIL

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -962,6 +962,9 @@ def test_conditionset():
     assert solveset(Eq(sin(Abs(x)), x), x, domain=S.Reals
         ) == ConditionSet(x, Eq(-x + sin(Abs(x)), 0), S.Reals)
 
+    assert solveset(y**x-z, x, S.Reals) == \
+        ConditionSet(x, Eq(y**x - z, 0), Reals)
+
 
 @XFAIL
 def test_conditionset_equality():
@@ -1957,7 +1960,9 @@ def test_is_logarithmic():
 
 
 def test_solve_logarithm():
+    y = Symbol('y')
     assert _solve_logarithm(log(x**y) - y*log(x), 0, x, S.Reals) == S.Reals
+    y = Symbol('y', positive=True)
     assert _solve_logarithm(log(x)*log(y), 0, x, S.Reals) == FiniteSet(1)
 
 # end of logarithmic tests


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #15062 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
added specific condition to check whether the base of the exponent is zero, otherwise an unsolved result will be returned

```python
>>> solveset(y**x - z, x, S.Reals)
ConditionSet(x, Eq(y**x - z, 0), Reals)
```

#### Other comments
minor changes in `_solve_exponential()`: used `map` instead of explicitly writing the equation
@smichr 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
