### PR TITLE
Added `integrate` for joint probability spaces

### DIFF
--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -14,7 +14,7 @@ from __future__ import print_function, division
 # __all__ = ['marginal_distribution']
 
 from sympy import (Basic, Lambda, sympify, Indexed, Symbol, ProductSet, S,
- Dummy, Mul)
+ Dummy, Mul, Le)
 from sympy.concrete.summations import Sum, summation
 from sympy.integrals.integrals import Integral, integrate
 from sympy.stats.rv import (ProductPSpace, NamedArgsMixin,
@@ -101,6 +101,25 @@ class JointPSpace(ProductPSpace):
             f = Lambda(sym, summation(self.distribution(all_syms), limits))
         return f.xreplace(replace_dict)
 
+    def integrate(self, expr, rvs=None, evaluate=False, **kwargs):
+        syms = tuple(self.value[i] for i in range(self.component_count))
+        rvs = rvs or syms
+        if not any([i in rvs for i in syms]):
+            return expr
+        expr = expr*self.pdf
+        for rv in rvs:
+            if isinstance(rv, Indexed):
+                expr = expr.xreplace({rv: Indexed(str(rv.base), rv.args[1])})
+            elif isinstance(rv, RandomSymbol):
+                expr = expr.xreplace({rv: rv.symbol})
+        if self.value in random_symbols(expr):
+            raise NotImplementedError(filldedent('''
+            Expectations of expression with unindexed joint random symbols
+            cannot be calculated yet.'''))
+        limits = tuple((Indexed(str(rv.base),rv.args[1]),
+            self.distribution.set.args[rv.args[1]]) for rv in syms)
+        return Integral(expr, *limits)
+
     def where(self, condition):
         raise NotImplementedError()
 
@@ -161,6 +180,9 @@ class JointRandomSymbol(RandomSymbol):
     def __getitem__(self, key):
         from sympy.stats.joint_rv import JointPSpace
         if isinstance(self.pspace, JointPSpace):
+            if Le(self.pspace.component_count, key):
+                raise ValueError("Index keys for %s can only up to %s." %
+                    (self.name, self.pspace.component_count - 1))
             return Indexed(self, key)
 
 class JointDistributionHandmade(JointDistribution, NamedArgsMixin):

--- a/sympy/stats/joint_rv.py
+++ b/sympy/stats/joint_rv.py
@@ -14,7 +14,7 @@ from __future__ import print_function, division
 # __all__ = ['marginal_distribution']
 
 from sympy import (Basic, Lambda, sympify, Indexed, Symbol, ProductSet, S,
- Dummy, Mul, Le)
+ Dummy, Mul)
 from sympy.concrete.summations import Sum, summation
 from sympy.integrals.integrals import Integral, integrate
 from sympy.stats.rv import (ProductPSpace, NamedArgsMixin,
@@ -180,7 +180,7 @@ class JointRandomSymbol(RandomSymbol):
     def __getitem__(self, key):
         from sympy.stats.joint_rv import JointPSpace
         if isinstance(self.pspace, JointPSpace):
-            if Le(self.pspace.component_count, key):
+            if self.pspace.component_count <= key:
                 raise ValueError("Index keys for %s can only up to %s." %
                     (self.name, self.pspace.component_count - 1))
             return Indexed(self, key)

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -11,6 +11,7 @@ x, y, z, a, b = symbols('x y z a b')
 def test_Normal():
     m = Normal('A', [1, 2], [[1, 0], [0, 1]])
     assert density(m)(1, 2) == 1/(2*pi)
+    raises (ValueError, lambda:m[2])
     raises (ValueError,\
         lambda: Normal('M',[1, 2], [[0, 0], [0, 1]]))
     n = Normal('B', [1, 2, 3], [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -68,3 +69,11 @@ def test_JointRV():
     assert density(X)(1, 2) == exp(-2)/(2*pi)
     assert isinstance(X.pspace.distribution, JointDistributionHandmade)
     assert marginal_distribution(X, 0)(2) == sqrt(2)*exp(-S(1)/2)/(2*sqrt(pi))
+
+def test_expectation():
+    from sympy import simplify
+    from sympy.stats import E
+    m = Normal('A', [x, y], [[1, 0], [0, 1]])
+    assert simplify(E(m[1])) == y
+    raises (NotImplementedError, lambda: E(m))
+    raises (NotImplementedError, lambda: E(m**2))

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -3,7 +3,7 @@ from sympy.stats import density
 from sympy.stats.joint_rv import marginal_distribution
 from sympy.stats.joint_rv_types import JointRV
 from sympy.stats.crv_types import Normal
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, XFAIL
 from sympy.integrals.integrals import integrate
 from sympy.matrices import Matrix
 x, y, z, a, b = symbols('x y z a b')
@@ -75,5 +75,9 @@ def test_expectation():
     from sympy.stats import E
     m = Normal('A', [x, y], [[1, 0], [0, 1]])
     assert simplify(E(m[1])) == y
-    raises (NotImplementedError, lambda: E(m))
-    raises (NotImplementedError, lambda: E(m**2))
+
+@XFAIL
+def test_joint_vector_expectation():
+    from sympy.stats import E
+    m = Normal('A', [x, y], [[1, 0], [0, 1]])
+    assert E(m) == (x, y)


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed
This allows the user to calculate the expectation of any component of a
joint random variable. For eg., if `m` is a joint random symbol,
expectation of `m[0]` can be calculated. `E(m)`, however, would raise an
error. Added tests.
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* stats
    * Allow calculation of expectation of indexed joint random symbols
<!-- END RELEASE NOTES -->
