### PR TITLE
Allow CodePrinter to generate code for any Function

### DIFF
--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -259,10 +259,17 @@ to introduce the names of user-defined functions in the Fortran expression.
     >>> print(fcode(1 - gamma(x)**2, user_functions={'gamma': 'mygamma'}))
           -mygamma(x)**2 + 1
 
-However, when the user_functions argument is not provided, ``fcode`` attempts to
-use a reasonable default and adds a comment to inform the user of the issue.
+However, when the user_functions argument is not provided, ``fcode`` will
+generate code which assumes that a function of the same name will be provided
+by the user:
 
     >>> print(fcode(1 - gamma(x)**2))
+          -gamma(x)**2 + 1
+
+If this assumption is considered too optimistic, the printer can be configured
+to add a comment to inform the user of the issue.
+
+    >>> print(fcode(1 - gamma(x)**2, allow_unknown_functions=False))
     C     Not supported in Fortran:
     C     gamma
           -gamma(x)**2 + 1
@@ -274,7 +281,7 @@ return value is a three-tuple containing: (i) a set of number symbols that must
 be defined as 'Fortran parameters', (ii) a list functions that cannot be
 translated in pure Fortran and (iii) a string of Fortran code. A few examples:
 
-    >>> fcode(1 - gamma(x)**2, human=False)
+    >>> fcode(1 - gamma(x)**2, human=False, allow_unknown_functions=False)
     (set(), {gamma(x)}, '      -gamma(x)**2 + 1')
     >>> fcode(1 - sin(x)**2, human=False)
     (set(), set(), '      -sin(x)**2 + 1')

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -168,6 +168,7 @@ class C89CodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
+        'allow_unknown_functions': True,
         'contract': True,
         'dereference': set(),
         'error_on_reserved': False,

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -381,6 +381,8 @@ class CodePrinter(StrPrinter):
         elif hasattr(expr, '_imp_') and isinstance(expr._imp_, Lambda):
             # inlined function
             return self._print(expr._imp_(*expr.args))
+        elif expr.is_Function:
+            return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
         else:
             return self._print_not_supported(expr)
 
@@ -489,11 +491,8 @@ class CodePrinter(StrPrinter):
             return sign + '*'.join(a_str) + "/(%s)" % '*'.join(b_str)
 
     def _print_not_supported(self, expr):
-        if expr.is_Function:
-            return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
-        else:
-            self._not_supported.add(expr)
-            return self.emptyPrinter(expr)
+        self._not_supported.add(expr)
+        return self.emptyPrinter(expr)
 
     # The following can not be simply translated into C or Fortran
     _print_Basic = _print_not_supported

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -53,7 +53,8 @@ class CodePrinter(StrPrinter):
         'error_on_reserved': False,
         'reserved_word_suffix': '_',
         'human': True,
-        'inline': False
+        'inline': False,
+        'allow_unknown_functions': True,
     }
 
     def __init__(self, settings=None):
@@ -381,7 +382,7 @@ class CodePrinter(StrPrinter):
         elif hasattr(expr, '_imp_') and isinstance(expr._imp_, Lambda):
             # inlined function
             return self._print(expr._imp_(*expr.args))
-        elif expr.is_Function:
+        elif expr.is_Function and self._settings.get('allow_unknown_functions', True):
             return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
         else:
             return self._print_not_supported(expr)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -489,8 +489,11 @@ class CodePrinter(StrPrinter):
             return sign + '*'.join(a_str) + "/(%s)" % '*'.join(b_str)
 
     def _print_not_supported(self, expr):
-        self._not_supported.add(expr)
-        return self.emptyPrinter(expr)
+        if expr.is_Function:
+            return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
+        else:
+            self._not_supported.add(expr)
+            return self.emptyPrinter(expr)
 
     # The following can not be simply translated into C or Fortran
     _print_Basic = _print_not_supported

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -98,6 +98,7 @@ class FCodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
+        'allow_unknown_functions': True,
         'source_format': 'fixed',
         'contract': True,
         'standard': 77,

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -50,6 +50,7 @@ class GLSLPrinter(CodePrinter):
         'precision': 9,
         'user_functions': {},
         'human': True,
+        'allow_unknown_functions': True,
         'contract': True,
         'error_on_reserved': False,
         'reserved_word_suffix': '_'

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -55,6 +55,7 @@ class JavascriptCodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
+        'allow_unknown_functions': True,
         'contract': True
     }
 

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -62,6 +62,7 @@ class JuliaCodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
+        'allow_unknown_functions': True,
         'contract': True,
         'inline': True,
     }

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -47,6 +47,7 @@ class MCodePrinter(CodePrinter):
         'precision': 15,
         'user_functions': {},
         'human': True,
+        'allow_unknown_functions': True,
     }
 
     _number_symbols = set()

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -73,6 +73,7 @@ class OctaveCodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
+        'allow_unknown_functions': True,
         'contract': True,
         'inline': True,
     }

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -106,6 +106,12 @@ class PythonCodePrinter(CodePrinter):
         self.known_constants = dict(self._kc, **(settings or {}).get(
             'user_constants', {}))
 
+    def _print_not_supported(self, expr):
+        if expr.is_Function:
+            return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
+        else:
+            return super(PythonCodePrinter, self)._print_not_supported(expr)
+
     def _get_statement(self, codestring):
         return codestring
 

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -106,12 +106,6 @@ class PythonCodePrinter(CodePrinter):
         self.known_constants = dict(self._kc, **(settings or {}).get(
             'user_constants', {}))
 
-    def _print_not_supported(self, expr):
-        if expr.is_Function:
-            return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
-        else:
-            return super(PythonCodePrinter, self)._print_not_supported(expr)
-
     def _get_statement(self, codestring):
         return codestring
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -133,7 +133,8 @@ def test_ccode_inline_function():
 
 def test_ccode_exceptions():
     assert ccode(gamma(x), standard='C99') == "tgamma(x)"
-    assert 'not supported in c' in ccode(gamma(x), standard='C89').lower()
+    gamma_c89 = ccode(gamma(x), standard='C89', allow_unknown_functions=False)
+    assert 'not supported in c' in gamma_c89.lower()
     assert ccode(ceiling(x)) == "ceil(x)"
     assert ccode(Abs(x)) == "fabs(x)"
     assert ccode(gamma(x)) == "tgamma(x)"

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -168,10 +168,10 @@ def test_implicit():
 def test_not_fortran():
     x = symbols('x')
     g = Function('g')
-    assert fcode(
-        gamma(x)) == "C     Not supported in Fortran:\nC     gamma\n      gamma(x)"
+    gamma_f = fcode(gamma(x), allow_unknown_functions=False)
+    assert gamma_f == "C     Not supported in Fortran:\nC     gamma\n      gamma(x)"
     assert fcode(Integral(sin(x))) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
-    assert fcode(g(x)) == "C     Not supported in Fortran:\nC     g\n      g(x)"
+    assert fcode(g(x), allow_unknown_functions=False) == "C     Not supported in Fortran:\nC     g\n      g(x)"
 
 
 def test_user_functions():

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -361,6 +361,12 @@ def test_numpy_matrix():
     #Check that the types are arrays and matrices
     assert isinstance(f(1, 2, 3), numpy.ndarray)
 
+    # gh-15071 (not really a fix but a modified test case for the new syntax)
+    class dot(Function):
+        pass
+    f_dot = lambdify(x, dot(x, Matrix([[2], [1], [0]])), [{'dot': numpy.dot}, 'numpy'])
+    assert numpy.all(f_dot(numpy.zeros((17, 3))) == 0)
+
 def test_numpy_transpose():
     if not numpy:
         skip("numpy not installed.")

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -361,11 +361,14 @@ def test_numpy_matrix():
     #Check that the types are arrays and matrices
     assert isinstance(f(1, 2, 3), numpy.ndarray)
 
-    # gh-15071 (not really a fix but a modified test case for the new syntax)
+    # gh-15071
     class dot(Function):
         pass
-    f_dot = lambdify(x, dot(x, Matrix([[2], [1], [0]])), [{'dot': numpy.dot}, 'numpy'])
-    assert numpy.all(f_dot(numpy.zeros((17, 3))) == 0)
+    f_dot1 = lambdify(x, dot(x, Matrix([[2], [1], [0]])), [{'dot': numpy.dot}, 'numpy'])
+    assert numpy.all(f_dot1(numpy.zeros((17, 3))) == 0)
+
+    f_dot2 = lambdify(x, dot(x, Matrix([[2], [1], [0]])))
+    assert numpy.all(f_dot2(numpy.zeros((17, 3))) == 0)
 
 def test_numpy_transpose():
     if not numpy:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -12,6 +12,7 @@ from sympy import (
     DotProduct, Eq, Dummy, sinc, erf, erfc, factorial, gamma, loggamma,
     digamma, RisingFactorial, besselj, bessely, besseli, besselk)
 from sympy.printing.lambdarepr import LambdaPrinter
+from sympy.printing.pycode import NumPyPrinter
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import skip
 from sympy.utilities.decorator import conserve_mpmath_dps
@@ -364,11 +365,19 @@ def test_numpy_matrix():
     # gh-15071
     class dot(Function):
         pass
-    f_dot1 = lambdify(x, dot(x, Matrix([[2], [1], [0]])), [{'dot': numpy.dot}, 'numpy'])
-    assert numpy.all(f_dot1(numpy.zeros((17, 3))) == 0)
+    x_dot_mtx = dot(x, Matrix([[2], [1], [0]]))
+    f_dot1 = lambdify(x, x_dot_mtx)
+    inp = numpy.zeros((17, 3))
+    assert numpy.all(f_dot1(inp) == 0)
 
-    f_dot2 = lambdify(x, dot(x, Matrix([[2], [1], [0]])))
-    assert numpy.all(f_dot2(numpy.zeros((17, 3))) == 0)
+    strict_kw = dict(allow_unknown_functions=False, inline=True, fully_qualified_modules=False)
+    p2 = NumPyPrinter(dict(user_functions={'dot': 'dot'}, **strict_kw))
+    f_dot2 = lambdify(x, x_dot_mtx, printer=p2)
+    assert numpy.all(f_dot2(inp) == 0)
+
+    p3 = NumPyPrinter(strict_kw)
+    # The line below should probably fail upon construction (before calling with "(inp)"):
+    raises(Exception, lambda: lambdify(x, x_dot_mtx, printer=p3)(inp))
 
 def test_numpy_transpose():
     if not numpy:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
~~Not really a fix, but rather a test case showing the new syntax.~~
~~Perhaps a proper fix is needed, providing this to start with for discussion.~~

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15071

#### Brief description of what is fixed or changed
Fixed regression in lambdify.

#### Other comments


#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * CodePrinter now generates code for unkown `Function` instances unless the new printer option `allow_unknown_functions` is set to `False`.
<!-- END RELEASE NOTES -->
