### PR TITLE
Address gh-15082: Call sympify at beginning of cse

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -656,7 +656,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     Examples
     ========
 
-    >>> from sympy import cse, SparseMatrix
+    >>> from sympy import cse, SparseMatrix, ImmutableSparseMatrix
     >>> from sympy.abc import x, y, z, w
     >>> cse(((w + x + y + z)*(w + y + z))/(w + x)**3)
     ([(x0, y + z), (x1, w + x)], [(w + x0)*(x0 + x1)/x1**3])
@@ -676,7 +676,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
 
     Note: the type and mutability of input matrices is retained.
 
-    >>> isinstance(_[1][-1], SparseMatrix)
+    >>> isinstance(_[1][-1], ImmutableSparseMatrix)
     True
 
     The user may disallow substitutions containing certain symbols:
@@ -687,6 +687,13 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     """
     from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
                                 SparseMatrix, ImmutableSparseMatrix)
+
+    from sympy.core.compatibility import string_types, NotIterable
+
+    if iterable(exprs, exclude=(string_types, dict, NotIterable, Basic, MatrixBase)):
+        exprs = list(exprs)
+
+    exprs = sympify(exprs)
 
     # Handle the case if just one expression was passed.
     if isinstance(exprs, (Basic, MatrixBase)):


### PR DESCRIPTION
Call sympify at beginning of cse to handle pure number expressions

#### References to other Issues or PRs
Fixes #15082
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

sympify is called at the beginning of cse to convert the input into a format that later operations understand. Additionally, this results in a few of the tests needing changes as the return types of matrices change to the immutable version.
The change also includes a simple test case that caused an exception before.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * cse now calls sympify on the input
<!-- END RELEASE NOTES -->
