### PR TITLE
Remove weird characters from TeX source

### DIFF
--- a/doc/cheatsheet/combinatoric_cheatsheet.tex
+++ b/doc/cheatsheet/combinatoric_cheatsheet.tex
@@ -425,7 +425,7 @@ Test if permutation \verb!g! belong to self.
 
 
 \verb!coset_factor(g, af=False)!\\
-Return G‘s (self’s) coset factorization, \verb!f,! of \verb!g!.
+Return G's (self's) coset factorization, \verb!f,! of \verb!g!.
 
 
 
@@ -458,7 +458,7 @@ Return iterator to generate the elements of the group
 
 
 \verb!generate_dimino(af=False)!\\
-Yield group elements using Dimino’s algorithm
+Yield group elements using Dimino's algorithm
 
 
 \verb!generate_schreier_sims(af=False)!\\


### PR DESCRIPTION
Not sure what encoding was this, but I was getting:

```
! Package inputenc Error: Invalid UTF-8 byte sequence.
See the inputenc package documentation for explanation.
Type  H <return>  for immediate help.
 ...

l.428 Return G?s
                 (self?s) coset factorization, \verb!f,! of \verb!g!.
?
! Emergency stop.
 ...

l.428 Return G?s
                 (self?s) coset factorization, \verb!f,! of \verb!g!.
!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on _build/cheatsheet/combinatoric_cheatsheet.log.
```

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->



<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->