### PR TITLE
UndefinedFunction should not evalf

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -509,11 +509,12 @@ class Function(Application, Expr):
             return False
 
     def _eval_evalf(self, prec):
-        if isinstance(self.func, UndefinedFunction):
-            return
         # Lookup mpmath function based on name
-        fname = self.func.__name__
         try:
+            if isinstance(self.func, UndefinedFunction):
+                # Shouldn't lookup in mpmath but might have ._imp_
+                raise AttributeError
+            fname = self.func.__name__
             if not hasattr(mpmath, fname):
                 from sympy.utilities.lambdify import MPMATH_TRANSLATIONS
                 fname = MPMATH_TRANSLATIONS[fname]

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -509,6 +509,8 @@ class Function(Application, Expr):
             return False
 
     def _eval_evalf(self, prec):
+        if isinstance(self.func, UndefinedFunction):
+            return
         # Lookup mpmath function based on name
         fname = self.func.__name__
         try:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -333,6 +333,8 @@ def test_implemented_function_evalf():
     assert str(f(2)) == "f(2)"
     assert f(2).evalf() == 3
     assert f(x).evalf() == f(x)
+    f = implemented_function(Function('sin'), lambda x: x + 1)
+    assert f(2).evalf() != sin(2)
     del f._imp_     # XXX: due to caching _imp_ would influence all other tests
 
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -959,3 +959,13 @@ def test_function_assumptions():
     # way UndefinedFunction.__new__ works.
     f_real2 = Function('f', is_real=True)
     assert f_real2(x).is_real is True
+
+
+def test_undef_fcn_float_issue_6938():
+    f = Function('ceil')
+    assert not f(0.3).is_number
+    f = Function('sin')
+    assert not f(0.3).is_number
+    assert not f(pi).evalf().is_number
+    x = Symbol('x')
+    assert not f(x).evalf(subs={x:1.2}).is_number


### PR DESCRIPTION
Suppose we call `Function('sin')` to create an UndefinedFunction.  It has
a suspicious name but is nevertheless still an undefined function and so
it should not evalf.  Add tests.  Fixes #6938.

The fix is to return early in the `_eval_evalf` if the `func` is an
`UndefinedFunction`, instead of looking through mpmath tables for a match etc.
Thanks to @smichr for this hint.

Note I first tried to fix this by introducing `UndefinedFunction._eval_evalf`.
The reason that does not work is that `f(x)` is not itself an
`UndefinedFunction` (only `f` is).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * UndefinedFunctions which coincidentally match known functions no longer evaluate numerically
<!-- END RELEASE NOTES -->
