### PR TITLE
Fixed omitted dotprint() function from the sympy.printing module

### DIFF
--- a/sympy/printing/__init__.py
+++ b/sympy/printing/__init__.py
@@ -22,3 +22,4 @@ from .repr import srepr
 from .tree import print_tree
 from .str import StrPrinter, sstr, sstrrepr
 from .tableform import TableForm
+from .dot import dotprint

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -1,7 +1,12 @@
 from __future__ import print_function, division
-
-from sympy import (Basic, Expr, Symbol, Integer, Rational, Float,
-    default_sort_key, Add, Mul)
+	
+from sympy.core.basic import Basic
+from sympy.core.expr import Expr
+from sympy.core.symbol import Symbol
+from sympy.core.numbers import Integer, Rational, Float
+from sympy.core.compatibility import default_sort_key
+from sympy.core.add import Add
+from sympy.core.mul import Mul
 
 __all__ = ['dotprint']
 

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, division
-	
+
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
 from sympy.core.symbol import Symbol


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#15088 

#### Brief description of what is fixed or changed

I had appended a single line of import statement into `__init__.py` file, so that the function can be accessible via the main `sympy` package.

However, my fix was not just as simple as a single line of code, as it had caused the main `sympy` package failing to load while importing the `default_sort_key()` function. 

So I had tracked down the issue in the `dot.py` module, and had modified the import statements to fix  circular importing problem, which is dormant if it is used as an isolated module, but would cause problems if it gets incorporated into the main `sympy` package.

#### Other comments

Other than the import statement of the `default_sort_key()` function in the `dot.py` module, I also had changed other import statements in the same file to match the conventions as I find in other `printing` modules.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * The `dotprint()` function is now included with `from sympy import *`.


<!-- END RELEASE NOTES -->
