### PR TITLE
Pass sympify args through when sympifying numpy types

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -51,14 +51,16 @@ class CantSympify(object):
     pass
 
 
-def _convert_numpy_types(a):
+def _convert_numpy_types(a, **sympify_args):
     """
     Converts a numpy datatype input to an appropriate sympy type.
     """
     import numpy as np
     if not isinstance(a, np.floating):
-        func = converter[complex] if np.iscomplex(a) else sympify
-        return func(np.asscalar(a))
+        if np.iscomplex(a):
+            return converter[complex](np.asscalar(a))
+        else:
+            return sympify(np.asscalar(a), **sympify_args)
     else:
         try:
             from sympy.core.numbers import Float
@@ -284,7 +286,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
     if type(a).__module__ == 'numpy':
         import numpy as np
         if np.isscalar(a):
-            return _convert_numpy_types(a)
+            return _convert_numpy_types(a, locals=locals,
+                convert_xor=convert_xor, strict=strict, rational=rational,
+                evaluate=evaluate)
 
     try:
         return converter[cls](a)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda,
     Function, I, S, N, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,
-    Pow, Or, true, false, Abs, pi, Range)
+    Pow, Or, true, false, Abs, pi, Range, Xor)
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError, kernS
 from sympy.core.decorators import _sympifyit
@@ -615,3 +615,41 @@ def test_issue_13924():
     a = sympify(numpy.array([1]))
     assert isinstance(a, ImmutableDenseNDimArray)
     assert a[0] == 1
+
+def test_numpy_sympify_args():
+    # Issue 15098. Make sure sympify args work with numpy types (like numpy.str_)
+    if not numpy:
+        skip("numpy not installed.")
+
+    a = sympify(numpy.str_('a'))
+    assert type(a) is Symbol
+    assert a == Symbol('a')
+
+    class CustomSymbol(Symbol):
+        pass
+
+    a = sympify(numpy.str_('a'), {"Symbol": CustomSymbol})
+    assert isinstance(a, CustomSymbol)
+
+    a = sympify(numpy.str_('x^y'))
+    assert a == x**y
+    a = sympify(numpy.str_('x^y'), convert_xor=False)
+    assert a == Xor(x, y)
+
+    raises(SympifyError, lambda: sympify(numpy.str_('x'), strict=True))
+
+    a = sympify(numpy.str_('1.1'))
+    assert isinstance(a, Float)
+    assert a == 1.1
+
+    a = sympify(numpy.str_('1.1'), rational=True)
+    assert isinstance(a, Rational)
+    assert a == Rational(11, 10)
+
+    a = sympify(numpy.str_('x + x'))
+    assert isinstance(a, Mul)
+    assert a == 2*x
+
+    a = sympify(numpy.str_('x + x'), evaluate=False)
+    assert isinstance(a, Add)
+    assert a == Add(x, x, evaluate=False)


### PR DESCRIPTION
Fixes #15098

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `sympify` keyword arguments now work properly when sympify NumPy types
<!-- END RELEASE NOTES -->
