### PR TITLE
Rearranged the flags used in eigenvects() and eigenvals()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1118,16 +1118,19 @@ class MatrixEigen(MatrixSubspaces):
         they will be replaced with Rationals before calling that
         routine. If this is not desired, set flag ``rational`` to False.
         """
+        rational = flags.pop('rational', True)
+        multiple = flags.pop('multiple', False)
+        simplify = flags.pop('simplify', None)  # pop unsupported flag
+
         mat = self
         if not mat:
             return {}
-        if flags.pop('rational', True):
+        if rational:
             if any(v.has(Float) for v in mat):
                 mat = mat.applyfunc(lambda x: nsimplify(x, rational=True))
 
         if mat.is_upper or mat.is_lower:
             diagonal_entries = [mat[i, i] for i in range(mat.rows)]
-            multiple = flags.pop('multiple', False)
             if multiple:
                 eigs = diagonal_entries
             else:
@@ -1137,7 +1140,6 @@ class MatrixEigen(MatrixSubspaces):
                         eigs[diagonal_entry] = 0
                     eigs[diagonal_entry] += 1
         else:
-            flags.pop('simplify', None)  # pop unsupported flag
             eigs = roots(mat.charpoly(x=Dummy('x')), **flags)
 
         # make sure the algebraic multiplicty sums to the
@@ -1173,12 +1175,12 @@ class MatrixEigen(MatrixSubspaces):
         from sympy.matrices import eye
 
         simplify = flags.get('simplify', True)
-        if not isinstance(simplify, FunctionType):
-            simpfunc = _simplify if simplify else lambda x: x
         primitive = flags.get('simplify', False)
         chop = flags.pop('chop', False)
+        multiple = flags.pop('multiple', None)  # remove this if it's there
 
-        flags.pop('multiple', None)  # remove this if it's there
+        if not isinstance(simplify, FunctionType):
+            simpfunc = _simplify if simplify else lambda x: x
 
         mat = self
         # roots doesn't like Floats, so replace them with Rationals


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

The methods `eigenvects()` and `eigenvals()` handles various `**flags`, and it seems that the function eventually passes unhandled `**flags` to the `roots()` function.

However, I find that it would be hard to track down how the flags are used, if it is spread all over the routine.

So I had made some harmless changes to factor the flags to the head of the function, as in the example of the `roots()` function of `polys.polyroots`, where all the flags are inherited from.

https://github.com/sympy/sympy/blob/8a601f4a562bf9b658fa7fbf56add597c8e5deda/sympy/polys/polyroots.py#L856-L863

#### Other comments

I also had found that the flags `'multiple', 'simplify'` from `eigenvals()` and a flag `'multiple'` from `eigenvects()` lacking documentation.

Also the documentation does not state that the functions inherit every flags from `roots()` 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
