### PR TITLE
Updated intersection method in class Plane

### DIFF
--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -418,7 +418,7 @@ class Plane(GeometryEntity):
                     p = a.subs(t, c[0])
                     if p not in self:
                         return []  # e.g. a segment might not intersect a plane
-                    return [p]
+                    return [x for x in [p] if x in o]
         if isinstance(o, Plane):
             if self.equals(o):
                 return [self]

--- a/sympy/geometry/plane.py
+++ b/sympy/geometry/plane.py
@@ -416,9 +416,9 @@ class Plane(GeometryEntity):
                     return []
                 else:
                     p = a.subs(t, c[0])
-                    if p not in self:
+                    if p not in o:
                         return []  # e.g. a segment might not intersect a plane
-                    return [x for x in [p] if x in o]
+                    return [p]
         if isinstance(o, Plane):
             if self.equals(o):
                 return [self]

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -22,9 +22,11 @@ def test_plane():
     pl9 = Plane(p1, normal_vector=(0, 12, 0))
     pl10 = Plane(p1, normal_vector=(-2, 0, 0))
     pl11 = Plane(p2, normal_vector=(0, 0, 1))
+    pl12 = Plane(p1, normal_vector=(1, 1, 1))
     l1 = Line3D(Point3D(5, 0, 0), Point3D(1, -1, 1))
     l2 = Line3D(Point3D(0, -2, 0), Point3D(3, 1, 1))
     l3 = Line3D(Point3D(0, -1, 0), Point3D(5, -1, 9))
+    s1 = Segment3D(Point3D(0, 0, 1), Point3D(0, 0, 2))
 
     assert Plane(p1, p2, p3) != Plane(p1, p3, p2)
     assert Plane(p1, p2, p3).is_coplanar(Plane(p1, p3, p2))
@@ -197,6 +199,9 @@ def test_plane():
     assert pl8.equals(pl8)
     assert pl8.equals(Plane(p1, normal_vector=(0, 0, -12)))
     assert pl8.equals(Plane(p1, normal_vector=(0, 0, -12*sqrt(3))))
+
+    # issue 15069
+    assert pl12.intersection(s1) == []
 
     # issue 8570
     l2 = Line3D(Point3D(S(50000004459633)/5000000000000,

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -93,7 +93,7 @@ def test_plane():
     assert pl6.distance(pl6.p1) == 0
     assert pl7.distance(pl6) == 0
     assert pl7.distance(l1) == 0
-    assert pl6.distance(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == 0
+    assert pl6.distance(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == 4*sqrt(3)/3
     pl6.distance(Plane(Point3D(5, 5, 5), normal_vector=(8, 8, 8))) == sqrt(3)
 
     assert pl6.angle_between(pl3) == pi/2


### PR DESCRIPTION
Updated the isinstance(o, (LinearEntity, LinearEntity3D)) part of intersection method in Plane class so that the returned points lie in both the intersection objects.
Fixes #15069
<!-- BEGIN RELEASE NOTES -->
* geometry
  * updated the intersection method of plane class so that
    intersection points lie in both the intersection objects if 
    the other entity is LinearEntity.
<!-- END RELEASE NOTES -->
