### PR TITLE
Duplicate a2idx() and classof() functions existing in matrices.py and common.py

### DIFF
--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -516,8 +516,6 @@ Matrix Exceptions Reference
 Matrix Functions Reference
 --------------------------
 
-.. autofunction:: classof
-
 .. autofunction:: sympy.matrices.dense.matrix_multiply_elementwise
 
 .. autofunction:: sympy.matrices.dense.zeros

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2311,7 +2311,7 @@ def classof(A, B):
     ========
 
     >>> from sympy import Matrix, ImmutableMatrix
-    >>> from sympy.matrices.matrices import classof
+    >>> from sympy.matrices.common import classof
     >>> M = Matrix([[1, 2], [3, 4]]) # a Mutable Matrix
     >>> IM = ImmutableMatrix([[1, 2], [3, 4]])
     >>> classof(M, IM)

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2330,6 +2330,6 @@ def classof(A, B):
             return B.__class__
         if isinstance(B, numpy.ndarray):
             return A.__class__
-    except AttributeError, ImportError:
+    except (AttributeError, ImportError):
         pass
     raise TypeError("Incompatible classes %s, %s" % (A.__class__, B.__class__))

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2292,12 +2292,12 @@ def a2idx(j, n=None):
         try:
             j = j.__index__()
         except AttributeError:
-            raise IndexError("Invalid index a[%r]" % (j,))
+            raise IndexError("Invalid index a[%r]" % j)
     if n is not None:
         if j < 0:
             j += n
         if not (j >= 0 and j < n):
-            raise IndexError("Index out of range: a[%s]" % (j,))
+            raise IndexError("Index out of range: a[%s]" % j)
     return int(j)
 
 
@@ -2322,7 +2322,7 @@ def classof(A, B):
             return A.__class__
         else:
             return B.__class__
-    except Exception:
+    except AttributeError:
         pass
     try:
         import numpy
@@ -2330,6 +2330,6 @@ def classof(A, B):
             return B.__class__
         if isinstance(B, numpy.ndarray):
             return A.__class__
-    except Exception:
+    except AttributeError:
         pass
     raise TypeError("Incompatible classes %s, %s" % (A.__class__, B.__class__))

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2292,12 +2292,12 @@ def a2idx(j, n=None):
         try:
             j = j.__index__()
         except AttributeError:
-            raise IndexError("Invalid index a[%r]" % j)
+            raise IndexError("Invalid index a[%r]" % (j,))
     if n is not None:
         if j < 0:
             j += n
         if not (j >= 0 and j < n):
-            raise IndexError("Index out of range: a[%s]" % j)
+            raise IndexError("Index out of range: a[%s]" % (j,))
     return int(j)
 
 

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -2330,6 +2330,6 @@ def classof(A, B):
             return B.__class__
         if isinstance(B, numpy.ndarray):
             return A.__class__
-    except AttributeError:
+    except AttributeError, ImportError:
         pass
     raise TypeError("Incompatible classes %s, %s" % (A.__class__, B.__class__))

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -18,8 +18,8 @@ from sympy.simplify import simplify as _simplify
 from sympy.utilities.misc import filldedent
 from sympy.utilities.decorator import doctest_depends_on
 
-from sympy.matrices.matrices import (MatrixBase,
-                                     ShapeError, a2idx, classof)
+from sympy.matrices.matrices import MatrixBase, ShapeError
+from sympy.matrices.common import a2idx, classof
 
 def _iszero(x):
     """Returns True if x is zero."""

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2929,7 +2929,7 @@ class MatrixBase(MatrixDeprecated,
 
         key2ij
         """
-        from sympy.matrices.common import a2idx # Remove this line after deprecation of a2idx from matrices.py
+        from sympy.matrices.common import a2idx as a2idx_ # Remove this line after deprecation of a2idx from matrices.py
 
         islice, jslice = [isinstance(k, slice) for k in keys]
         if islice:
@@ -2938,7 +2938,7 @@ class MatrixBase(MatrixDeprecated,
             else:
                 rlo, rhi = keys[0].indices(self.rows)[:2]
         else:
-            rlo = a2idx(keys[0], self.rows)
+            rlo = a2idx_(keys[0], self.rows)
             rhi = rlo + 1
         if jslice:
             if not self.cols:
@@ -2946,7 +2946,7 @@ class MatrixBase(MatrixDeprecated,
             else:
                 clo, chi = keys[1].indices(self.cols)[:2]
         else:
-            clo = a2idx(keys[1], self.cols)
+            clo = a2idx_(keys[1], self.cols)
             chi = clo + 1
         return rlo, rhi, clo, chi
 
@@ -2960,17 +2960,17 @@ class MatrixBase(MatrixDeprecated,
 
         key2bounds
         """
-        from sympy.matrices.common import a2idx # Remove this line after deprecation of a2idx from matrices.py
+        from sympy.matrices.common import a2idx as a2idx_ # Remove this line after deprecation of a2idx from matrices.py
 		
         if is_sequence(key):
             if not len(key) == 2:
                 raise TypeError('key must be a sequence of length 2')
-            return [a2idx(i, n) if not isinstance(i, slice) else i
+            return [a2idx_(i, n) if not isinstance(i, slice) else i
                     for i, n in zip(key, self.shape)]
         elif isinstance(key, slice):
             return key.indices(len(self))[:2]
         else:
-            return divmod(a2idx(key, len(self)), self.cols)
+            return divmod(a2idx_(key, len(self)), self.cols)
 
     def LDLdecomposition(self):
         """Returns the LDL Decomposition (L, D) of matrix A,
@@ -4115,16 +4115,16 @@ class MatrixBase(MatrixDeprecated,
     useinstead="from sympy.matrices.common import classof",
     deprecated_since_version="1.3")
 def classof(A, B):
-	from sympy.matrices.common import classof
-	return classof(A, B)
+	from sympy.matrices.common import classof as classof_
+	return classof_(A, B)
 
 @deprecated(
     issue=15109,
     deprecated_since_version="1.3",
     useinstead="from sympy.matrices.common import a2idx")
 def a2idx(j, n=None):
-	from sympy.matrices.common import a2idx
-	return a2idx(j, n)
+	from sympy.matrices.common import a2idx as a2idx_
+	return a2idx_(j, n)
 
 
 def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -31,6 +31,8 @@ from types import FunctionType
 
 from .common import (a2idx, classof, MatrixError, ShapeError,
         NonSquareMatrixError, MatrixCommon)
+		
+from sympy.core.decorators import deprecated
 
 
 def _iszero(x):
@@ -4104,6 +4106,23 @@ class MatrixBase(MatrixDeprecated,
                     v[count] = self[i, j]
                     count += 1
         return v
+
+@deprecated(
+    issue=15109,
+    useinstead="from sympy.matrices.common import classof",
+    deprecated_since_version="1.3")
+def classof(A, B):
+	from sympy.matrices.common import classof
+	return classof(A, B)
+
+@deprecated(
+    issue=15109,
+    deprecated_since_version="1.3",
+    useinstead="from sympy.matrices.common import a2idx")
+def a2idx(j, n=None):
+	from sympy.matrices.common import a2idx
+	return a2idx(j, n)
+
 
 def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):
     """ Find the lowest index of an item in `col` that is

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2929,6 +2929,7 @@ class MatrixBase(MatrixDeprecated,
 
         key2ij
         """
+        from sympy.matrices.common import a2idx # Remove this line after deprecation of a2idx from matrices.py
 
         islice, jslice = [isinstance(k, slice) for k in keys]
         if islice:
@@ -2959,6 +2960,8 @@ class MatrixBase(MatrixDeprecated,
 
         key2bounds
         """
+        from sympy.matrices.common import a2idx # Remove this line after deprecation of a2idx from matrices.py
+		
         if is_sequence(key):
             if not len(key) == 2:
                 raise TypeError('key must be a sequence of length 2')

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4105,56 +4105,6 @@ class MatrixBase(MatrixDeprecated,
                     count += 1
         return v
 
-
-def classof(A, B):
-    """
-    Get the type of the result when combining matrices of different types.
-
-    Currently the strategy is that immutability is contagious.
-
-    Examples
-    ========
-
-    >>> from sympy import Matrix, ImmutableMatrix
-    >>> from sympy.matrices.matrices import classof
-    >>> M = Matrix([[1, 2], [3, 4]]) # a Mutable Matrix
-    >>> IM = ImmutableMatrix([[1, 2], [3, 4]])
-    >>> classof(M, IM)
-    <class 'sympy.matrices.immutable.ImmutableDenseMatrix'>
-    """
-    try:
-        if A._class_priority > B._class_priority:
-            return A.__class__
-        else:
-            return B.__class__
-    except AttributeError:
-        pass
-    try:
-        import numpy
-        if isinstance(A, numpy.ndarray):
-            return B.__class__
-        if isinstance(B, numpy.ndarray):
-            return A.__class__
-    except (AttributeError, ImportError):
-        pass
-    raise TypeError("Incompatible classes %s, %s" % (A.__class__, B.__class__))
-
-
-def a2idx(j, n=None):
-    """Return integer after making positive and validating against n."""
-    if type(j) is not int:
-        try:
-            j = j.__index__()
-        except AttributeError:
-            raise IndexError("Invalid index a[%r]" % (j,))
-    if n is not None:
-        if j < 0:
-            j += n
-        if not (j >= 0 and j < n):
-            raise IndexError("Index out of range: a[%s]" % j)
-    return int(j)
-
-
 def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):
     """ Find the lowest index of an item in `col` that is
     suitable for a pivot.  If `col` consists only of

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2961,7 +2961,7 @@ class MatrixBase(MatrixDeprecated,
         key2bounds
         """
         from sympy.matrices.common import a2idx as a2idx_ # Remove this line after deprecation of a2idx from matrices.py
-		
+
         if is_sequence(key):
             if not len(key) == 2:
                 raise TypeError('key must be a sequence of length 2')
@@ -4115,16 +4115,16 @@ class MatrixBase(MatrixDeprecated,
     useinstead="from sympy.matrices.common import classof",
     deprecated_since_version="1.3")
 def classof(A, B):
-	from sympy.matrices.common import classof as classof_
-	return classof_(A, B)
+    from sympy.matrices.common import classof as classof_
+    return classof_(A, B)
 
 @deprecated(
     issue=15109,
     deprecated_since_version="1.3",
     useinstead="from sympy.matrices.common import a2idx")
 def a2idx(j, n=None):
-	from sympy.matrices.common import a2idx as a2idx_
-	return a2idx_(j, n)
+    from sympy.matrices.common import a2idx as a2idx_
+    return a2idx_(j, n)
 
 
 def _find_reasonable_pivot(col, iszerofunc=_iszero, simpfunc=_simplify):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -31,7 +31,7 @@ from types import FunctionType
 
 from .common import (a2idx, classof, MatrixError, ShapeError,
         NonSquareMatrixError, MatrixCommon)
-		
+
 from sympy.core.decorators import deprecated
 
 

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -12,8 +12,9 @@ from sympy.functions import Abs
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.utilities.iterables import uniq
 
-from .matrices import MatrixBase, ShapeError, a2idx
+from .matrices import MatrixBase, ShapeError
 from .dense import Matrix
+from .common import a2idx
 
 
 class SparseMatrix(MatrixBase):

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -10,7 +10,7 @@ from sympy.matrices import (Matrix, MatrixSymbol, eye, Identity,
         ImmutableMatrix)
 from sympy.core.compatibility import range
 from sympy.matrices.expressions import MatrixExpr, MatAdd
-from sympy.matrices.matrices import classof
+from sympy.matrices.common import classof
 from sympy.utilities.pytest import raises
 
 SM = MatrixSymbol('X', 3, 3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
#15109

#### Brief description of what is fixed or changed

I had found that `matrices.py` imports `a2idx()` and `classof()` functions from `common.py`, but copies of the functions also existing within `matrices.py` itself, overriding the ones it had imported.
 
https://github.com/sympy/sympy/blob/4a0f7981ddd6a611e48779bb212c151c23cd9b54/sympy/matrices/matrices.py#L4109-L4155

https://github.com/sympy/sympy/blob/4a0f7981ddd6a611e48779bb212c151c23cd9b54/sympy/matrices/common.py#L2289-L2335

It will cause problems if any of the twins undergo some changes in the future commits.

I had also found that there exists some mutations, like in below.

https://github.com/sympy/sympy/blob/4a0f7981ddd6a611e48779bb212c151c23cd9b54/sympy/matrices/matrices.py#L4154

https://github.com/sympy/sympy/blob/4a0f7981ddd6a611e48779bb212c151c23cd9b54/sympy/matrices/common.py#L2300

https://github.com/sympy/sympy/blob/4a0f7981ddd6a611e48779bb212c151c23cd9b54/sympy/matrices/matrices.py#L4130-L4131

https://github.com/sympy/sympy/blob/4a0f7981ddd6a611e48779bb212c151c23cd9b54/sympy/matrices/common.py#L2325-L2326

I propose an opinion to remove the one from `matrices.py`, because they are more older than the ones from `common.py`.
And I think that it can be more harmless change, because the ones from `common.py` handles more generic exceptions and string formatting.

I would like to hear some opinions about this.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Deprecated copies of `a2idx()` and `classof()` found in `matrices.py`
<!-- END RELEASE NOTES -->
