### PR TITLE
Fixes #15086

### DIFF
--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -184,13 +184,14 @@ class DenseMatrix(MatrixBase):
             # cache self._mat and other._mat for performance
             mat = self._mat
             other_mat = other._mat
+            poly = any(i.is_Poly for i in mat)
             for i in range(len(new_mat)):
                 row, col = i // new_mat_cols, i % new_mat_cols
                 row_indices = range(self_cols*row, self_cols*(row+1))
                 col_indices = range(col, other_len, other_cols)
                 vec = (mat[a]*other_mat[b] for a,b in zip(row_indices, col_indices))
                 try:
-                    new_mat[i] = Add(*vec)
+                    new_mat[i] = sum(vec, S.Zero) if poly else Add(*vec)
                 except (TypeError, SympifyError):
                     # Block matrices don't work with `sum` or `Add` (ISSUE #11599)
                     # They don't work with `sum` because `sum` tries to add `0`

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3155,3 +3155,10 @@ def test_issue_8240():
     assert len(eigenvals) == 3
     assert eigenvals.count(x) == 2
     assert eigenvals.count(y) == 1
+
+def test_issue_15086():
+    M = Matrix([[x, x, 0, 0], [x, 0, x, 0], [0, x, x, 0], [0, 0, x, x]])
+    to_poly = lambda e: Poly(e, x)
+    N = M.applyfunc(to_poly)
+    assert N.det(method="berkowitz") == Poly(M.det())
+    assert M.det(method="berkowitz") == M.det()


### PR DESCRIPTION
Regression: Degradation of det function performance when applied to large matrices of polynomials between 1.0 and 1.1.1 onwards.

For example:

```
poly_mat = eval(poly_mat_str)
det = poly_mat.det(method="berkowitz")
```
where `poly_mat_str` is the string repr for some complex polynomial matrix. The degradation is observed as vastly increased resultant det size and calculation times. Note that smaller polynomial matrices do not seem affected, see the ticket for more information.

The table below shown typical changes to the calculation times and resultant det sizes for the three attached polynomials. [good_poly_matrix.zip](https://github.com/sympy/sympy/files/2303670/good_poly_matrix.zip)

| Poly File Name   | Matrix Size | Max Poly Power | File Size v1.0 (KB) | File Size v1.1.1 (KB) | Time taken v1.0 (s) | Time taken v1.1.1 (s) |
|------------------|-------------|----------------|--------------------|----------------------|--------------------|----------------------|
| good_poly_matrix | 3x3         | 13             | 1.54               | 1.29                 | 0.0699             | 0.0632               |
| bad_poly_matrix  | 6x6         | 9              | 9.89               | 1750                 | 1.30               | 193                  |
| bad_poly_matrix2 | 6x6         | 2              | 0.303              | 290                  | 0.104              | 14.5                 |

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15086

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * fixed regression bug affecting calculation of determinant for large polynomial matrices
<!-- END RELEASE NOTES -->
