### PR TITLE
Corrected the output of latex method in latex.py to return valid latex commands

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -607,8 +607,10 @@ class LatexPrinter(Printer):
         return outstr
 
     def _print_Indexed(self, expr):
-        tex = self._print(expr.base)+'_{%s}' % ','.join(
-            map(self._print, expr.indices))
+        tex_base = self._print(expr.base)
+        if re.search(r'_\{.\}$', tex_base) is not None:
+            tex_base = '{'+tex_base+'}'
+        tex = tex_base+'_{%s}' % ','.join(map(self._print, expr.indices))
         return tex
 
     def _print_IndexedBase(self, expr):


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15059 

#### Brief description of what is fixed or changed

```
Example:-
ln[1]:-from sympy import*
ln[2]:-from sympy import init_printing;init_printing()
ln[3]:-i=symbols('i')
ln[4]:-print(latex(Indexed('x1',i))
```
Before Correction in code.
Output:-x_{1}_{i} which was not a valid latex command.

After correction in code.
Output:- {x_{1}}_{i} which is valid latex command.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * fix latex printing of Indexed results #15059
<!-- END RELEASE NOTES -->
