### PR TITLE
Added missing non-square matrix check to eigenvals()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1126,6 +1126,9 @@ class MatrixEigen(MatrixSubspaces):
                 mat = mat.applyfunc(lambda x: nsimplify(x, rational=True))
 
         if mat.is_upper or mat.is_lower:
+            if not self.is_square:
+                raise NonSquareMatrixError()
+
             diagonal_entries = [mat[i, i] for i in range(mat.rows)]
             multiple = flags.pop('multiple', False)
             if multiple:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1054,6 +1054,13 @@ def test_eigen():
     assert Matrix([]).eigenvals() == {}
     assert Matrix([]).eigenvects() == []
 
+    # issue 15119
+    raises(NonSquareMatrixError, lambda : Matrix([[1, 2], [0, 4], [0, 0]]).eigenvals())
+    raises(NonSquareMatrixError, lambda : Matrix([[1, 0], [3, 4], [5, 6]]).eigenvals())
+    raises(NonSquareMatrixError, lambda : Matrix([[1, 2, 3], [0, 5, 6]]).eigenvals())
+    raises(NonSquareMatrixError, lambda : Matrix([[1, 0, 0], [4, 5, 0]]).eigenvals())
+    raises(NonSquareMatrixError, lambda : Matrix([[1, 2, 3], [0, 5, 6]]).eigenvals(error_when_incomplete = False))
+    raises(NonSquareMatrixError, lambda : Matrix([[1, 0, 0], [4, 5, 0]]).eigenvals(error_when_incomplete = False))
 
 def test_subs():
     assert Matrix([[1, x], [x, 4]]).subs(x, 5) == Matrix([[1, 5], [5, 4]])


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

I have found that the newly introduced subroutine in `eigenvals()` from #15030 missing a non-square matrix exception handling.

https://github.com/sympy/sympy/blob/019d6d467302363ef8cc9dd8382c836d0ee7aa49/sympy/matrices/matrices.py#L1128-L1141

The conditional

https://github.com/sympy/sympy/blob/019d6d467302363ef8cc9dd8382c836d0ee7aa49/sympy/matrices/matrices.py#L1128

to separate the procedure into newly introduced method on upper or lower types of matrices, or the old method to operate on more generic types.
However, neither `is_upper` nor `is_lower` does anything with squareness of matrices,
as you see in the sample of docstring.

https://github.com/sympy/sympy/blob/019d6d467302363ef8cc9dd8382c836d0ee7aa49/sympy/matrices/common.py#L1397-L1399

 and it will hand down any upper or lower triangular "non-square" matrix into computation, causing some issues like samples below.

* An arbitrary sample like

```Matrix([[1, 0], [3, 4], [5, 6]]).eigenvals()```

will throw `IndexError` because of the attempts to access non-existing column while computing `diagonal_entries`.

* Another sample like

```Matrix([[1, 2, 3], [0, 5, 6]]).eigenvals()```

will fail on the check of solution of 
https://github.com/sympy/sympy/blob/019d6d467302363ef8cc9dd8382c836d0ee7aa49/sympy/matrices/matrices.py#L1145-L1147
while already having the wrong result computed and stored in the dictionary `eigs`, because  `diagonal_entry` will be completely blind of any additional column after the total count of the rows.

* An example which will succeed in computation with the wrong result.

```Matrix([[1, 2, 3], [0, 5, 6]]).eigenvals(error_when_incomplete = False)```

Setting the option to ignore the check will return the wrong result into output, contradicting the principle that eigenvalues should only exist in square matrices.
You can easily recognize that the eigenvalues returned is identical to a 'squarified' form of the matrix, totally ignore some columns from the right, like

```Matrix([[1, 2], [0, 5]]).eigenvals()```

The issue exists only in the newly introduced algorithm, because the latter routine already has square matrix check implicitly inside `charpoly()`.
So, I would like to place the `NonSquareMatrixError` exception handling statement just before the  recently implemented algorithm, so that it would be symmetrically positioned at the same level as the implicit one from `charpoly()`.

I will also write some test cases, to regard this issue, after opening this pull request

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added missing square matrix check in eigenvals()
<!-- END RELEASE NOTES -->
