### PR TITLE
Fixed 'simplify' keyword not working in eigenvals()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1114,6 +1114,15 @@ class MatrixEigen(MatrixSubspaces):
             Raise an error when not all eigenvalues are computed. This is
             caused by ``roots`` not returning a full list of eigenvalues.
 
+        simplify : bool or function
+            If simplify is set to True, it attempts to return the most
+            simplified form of expressions returned by applying default
+            simplification method in every routine.
+            If simplify is set to False, it will skip simplification in this
+            particular routine to save computation resources.
+            If you pass a function to simplify, it will attempt to apply 
+            the partucular function as simplification method.
+
         Since the roots routine doesn't always work well with Floats,
         they will be replaced with Rationals before calling that
         routine. If this is not desired, set flag ``rational`` to False.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1120,7 +1120,7 @@ class MatrixEigen(MatrixSubspaces):
             simplification method in every routine.
             If simplify is set to False, it will skip simplification in this
             particular routine to save computation resources.
-            If you pass a function to simplify, it will attempt to apply 
+            If you pass a function to simplify, it will attempt to apply
             the partucular function as simplification method.
 
         Since the roots routine doesn't always work well with Floats,

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1121,7 +1121,7 @@ class MatrixEigen(MatrixSubspaces):
             If simplify is set to False, it will skip simplification in this
             particular routine to save computation resources.
             If you pass a function to simplify, it will attempt to apply
-            the partucular function as simplification method.
+            the particular function as simplification method.
 
         Since the roots routine doesn't always work well with Floats,
         they will be replaced with Rationals before calling that

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1118,8 +1118,19 @@ class MatrixEigen(MatrixSubspaces):
         they will be replaced with Rationals before calling that
         routine. If this is not desired, set flag ``rational`` to False.
         """
-        simplify = flags.get('simplify', _simplify) # Collect simplify flag before popped up, to reuse later in the routine.
+        simplify = flags.get('simplify', False) # Collect simplify flag before popped up, to reuse later in the routine.
         multiple = flags.get('multiple', False) # Collect multiple flag to decide whether return as a dict or list.
+
+        if isinstance(simplify, FunctionType):
+            simpfunc_1 = simplify
+            simpfunc_2 = simplify
+        else:
+            if simplify:
+                simpfunc_1 = lambda x: x
+                simpfunc_2 = _simplify
+            else:
+                simpfunc_1 = _simplify
+                simpfunc_2 = lambda x: x
 
         mat = self
         if not mat:
@@ -1144,7 +1155,7 @@ class MatrixEigen(MatrixSubspaces):
                     eigs[diagonal_entry] += 1
         else:
             flags.pop('simplify', None)  # pop unsupported flag
-            eigs = roots(mat.charpoly(x=Dummy('x'), simplify=simplify), **flags)
+            eigs = roots(mat.charpoly(x=Dummy('x'), simplify=simpfunc_1), **flags)
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix
@@ -1160,9 +1171,9 @@ class MatrixEigen(MatrixSubspaces):
             # With 'multiple' flag set true, simplify() will be mapped for the list
             # Otherwise, simplify() will be mapped for the keys of the dictionary
             if not multiple:
-                return dict(map(lambda item: (simplify(item[0]), item[1]), eigs.items()))
+                return dict(map(lambda item: (simpfunc_2(item[0]), item[1]), eigs.items()))
             else:
-                return list(map(lambda item: simplify(item), eigs))
+                return list(map(lambda item: simpfunc_2(item), eigs))
 
     def eigenvects(self, error_when_incomplete=True, **flags):
         """Return list of triples (eigenval, multiplicity, basis).

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1118,7 +1118,7 @@ class MatrixEigen(MatrixSubspaces):
         they will be replaced with Rationals before calling that
         routine. If this is not desired, set flag ``rational`` to False.
         """
-        simplify = flags.get('simplify', False) # Collect simplify flag before popped up, to reuse later in the routine.
+        simplify = flags.get('simplify', _simplify) # Collect simplify flag before popped up, to reuse later in the routine.
         multiple = flags.get('multiple', False) # Collect multiple flag to decide whether return as a dict or list.
 
         mat = self
@@ -1144,7 +1144,7 @@ class MatrixEigen(MatrixSubspaces):
                     eigs[diagonal_entry] += 1
         else:
             flags.pop('simplify', None)  # pop unsupported flag
-            eigs = roots(mat.charpoly(x=Dummy('x')), **flags)
+            eigs = roots(mat.charpoly(x=Dummy('x'), simplify=simplify), **flags)
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix
@@ -1160,9 +1160,9 @@ class MatrixEigen(MatrixSubspaces):
             # With 'multiple' flag set true, simplify() will be mapped for the list
             # Otherwise, simplify() will be mapped for the keys of the dictionary
             if not multiple:
-                return dict(map(lambda item: (_simplify(item[0]), item[1]), eigs.items()))
+                return dict(map(lambda item: (simplify(item[0]), item[1]), eigs.items()))
             else:
-                return list(map(lambda item: _simplify(item), eigs))
+                return list(map(lambda item: simplify(item), eigs))
 
     def eigenvects(self, error_when_incomplete=True, **flags):
         """Return list of triples (eigenval, multiplicity, basis).

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1119,6 +1119,7 @@ class MatrixEigen(MatrixSubspaces):
         routine. If this is not desired, set flag ``rational`` to False.
         """
         simplify = flags.get('simplify', False) # Collect simplify flag before popped up, to reuse later in the routine.
+        multiple = flags.get('multiple', False) # Collect multiple flag to decide whether return as a dict or list.
 
         mat = self
         if not mat:
@@ -1132,7 +1133,7 @@ class MatrixEigen(MatrixSubspaces):
                 raise NonSquareMatrixError()
 
             diagonal_entries = [mat[i, i] for i in range(mat.rows)]
-            multiple = flags.pop('multiple', False)
+
             if multiple:
                 eigs = diagonal_entries
             else:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1126,7 +1126,7 @@ class MatrixEigen(MatrixSubspaces):
             simpfunc_2 = simplify
         else:
             if simplify:
-                simpfunc_1 = lambda x: x
+                simpfunc_1 = _simplify
                 simpfunc_2 = _simplify
             else:
                 simpfunc_1 = _simplify

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1173,9 +1173,9 @@ class MatrixEigen(MatrixSubspaces):
         # With 'multiple' flag set true, simplify() will be mapped for the list
         # Otherwise, simplify() will be mapped for the keys of the dictionary
         if not multiple:
-            return dict(map(lambda item: (simplify(item[0]), item[1]), eigs.items()))
+            return {simplify(key): value for key, value in eigs.items()}
         else:
-            return list(map(simplify, eigs))
+            return [simplify(value) for value in eigs]
 
     def eigenvects(self, error_when_incomplete=True, **flags):
         """Return list of triples (eigenval, multiplicity, basis).

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1152,7 +1152,17 @@ class MatrixEigen(MatrixSubspaces):
             isinstance(eigs, dict) else len(eigs)) != self.cols:
             raise MatrixError("Could not compute eigenvalues for {}".format(self))
 
-        return eigs
+        # Since 'simplify' flag is unsupported in roots()
+        # simplify() function will be applied once at the end of the routine.
+        if not simplify:
+            return eigs
+        else:
+            # With 'multiple' flag set true, simplify() will be mapped for the list
+            # Otherwise, simplify() will be mapped for the keys of the dictionary
+            if not multiple:
+                return dict(map(lambda item: (_simplify(item[0]), item[1]), eigs.items()))
+            else:
+                return list(map(lambda item: _simplify(item), eigs))
 
     def eigenvects(self, error_when_incomplete=True, **flags):
         """Return list of triples (eigenval, multiplicity, basis).

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1118,6 +1118,8 @@ class MatrixEigen(MatrixSubspaces):
         they will be replaced with Rationals before calling that
         routine. If this is not desired, set flag ``rational`` to False.
         """
+        simplify = flags.get('simplify', False) # Collect simplify flag before popped up, to reuse later in the routine.
+
         mat = self
         if not mat:
             return {}

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1156,7 +1156,7 @@ class MatrixEigen(MatrixSubspaces):
             if isinstance(simplify, FunctionType):
                 eigs = roots(mat.charpoly(x=Dummy('x'), simplify=simplify), **flags)
             else:
-                eigs = roots(mat.charpoly(x=Dummy('x'), simplify=_simplify), **flags)
+                eigs = roots(mat.charpoly(x=Dummy('x')), **flags)
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1175,7 +1175,7 @@ class MatrixEigen(MatrixSubspaces):
         if not multiple:
             return dict(map(lambda item: (simplify(item[0]), item[1]), eigs.items()))
         else:
-            return list(map(lambda item: simplify(item), eigs))
+            return list(map(simplify, eigs))
 
     def eigenvects(self, error_when_incomplete=True, **flags):
         """Return list of triples (eigenval, multiplicity, basis).

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1153,7 +1153,10 @@ class MatrixEigen(MatrixSubspaces):
                     eigs[diagonal_entry] += 1
         else:
             flags.pop('simplify', None)  # pop unsupported flag
-            eigs = roots(mat.charpoly(x=Dummy('x'), simplify=simplify if isinstance(simplify, FunctionType) else _simplify), **flags)
+            if isinstance(simplify, FunctionType):
+                eigs = roots(mat.charpoly(x=Dummy('x'), simplify=simplify), **flags)
+            else:
+                eigs = roots(mat.charpoly(x=Dummy('x'), simplify=_simplify), **flags)
 
         # make sure the algebraic multiplicty sums to the
         # size of the matrix

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1066,13 +1066,13 @@ def test_eigen():
     from sympy.core.function import count_ops
     q = Symbol("q", positive = True)
     m = Matrix([[-2, exp(-q), 1], [exp(q), -2, 1], [1, 1, -2]])
-    assert count_ops(m.eigenvals(simplify = False)) > count_ops(m.eigenvals(simplify = True))
-    assert count_ops(m.eigenvals(simplify = lambda x: x)) > count_ops(m.eigenvals(simplify = True))
+    assert count_ops(m.eigenvals(simplify=False)) > count_ops(m.eigenvals(simplify=True))
+    assert count_ops(m.eigenvals(simplify=lambda x: x)) > count_ops(m.eigenvals(simplify=True))
 
-    assert isinstance(m.eigenvals(simplify = True, multiple=False), dict)
-    assert isinstance(m.eigenvals(simplify = True, multiple=True), list)
-    assert isinstance(m.eigenvals(simplify = lambda x: x, multiple=False), dict)
-    assert isinstance(m.eigenvals(simplify = lambda x: x, multiple=True), list)
+    assert isinstance(m.eigenvals(simplify=True, multiple=False), dict)
+    assert isinstance(m.eigenvals(simplify=True, multiple=True), list)
+    assert isinstance(m.eigenvals(simplify=lambda x: x, multiple=False), dict)
+    assert isinstance(m.eigenvals(simplify=lambda x: x, multiple=True), list)
 
 def test_subs():
     assert Matrix([[1, x], [x, 4]]).subs(x, 5) == Matrix([[1, 5], [5, 4]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1062,6 +1062,13 @@ def test_eigen():
     raises(NonSquareMatrixError, lambda : Matrix([[1, 2, 3], [0, 5, 6]]).eigenvals(error_when_incomplete = False))
     raises(NonSquareMatrixError, lambda : Matrix([[1, 0, 0], [4, 5, 0]]).eigenvals(error_when_incomplete = False))
 
+    # issue 15125
+    from sympy.core.function import count_ops
+    q = Symbol("q", positive = True)
+    m = Matrix([[-2, exp(-q), 1], [exp(q), -2, 1], [1, 1, -2]])
+    assert count_ops(m.eigenvals(simplify = False)) > count_ops(m.eigenvals(simplify = True))
+    assert count_ops(m.eigenvals(simplify = lambda x: x)) > count_ops(m.eigenvals(simplify = True))
+
 def test_subs():
     assert Matrix([[1, x], [x, 4]]).subs(x, 5) == Matrix([[1, 5], [5, 4]])
     assert Matrix([[x, 2], [x + y, 4]]).subs([[x, -1], [y, -2]]) == \

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1069,6 +1069,11 @@ def test_eigen():
     assert count_ops(m.eigenvals(simplify = False)) > count_ops(m.eigenvals(simplify = True))
     assert count_ops(m.eigenvals(simplify = lambda x: x)) > count_ops(m.eigenvals(simplify = True))
 
+    assert isinstance(m.eigenvals(simplify = True, multiple=False), dict)
+    assert isinstance(m.eigenvals(simplify = True, multiple=True), list)
+    assert isinstance(m.eigenvals(simplify = lambda x: x, multiple=False), dict)
+    assert isinstance(m.eigenvals(simplify = lambda x: x, multiple=True), list)
+
 def test_subs():
     assert Matrix([[1, x], [x, 4]]).subs(x, 5) == Matrix([[1, 5], [5, 4]])
     assert Matrix([[x, 2], [x + y, 4]]).subs([[x, -1], [y, -2]]) == \


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#15118

#### Brief description of what is fixed or changed

I have found the line
https://github.com/sympy/sympy/blob/c6cf6914e2599d1bf83650873795fc48088470cf/sympy/matrices/matrices.py#L1143
popping up the `'simplify'` flag.
Also, I had found that there was no procedure to handle to key, even if the key exists, in the function.

First I had defined new some variables to collect the keywords at the beginning of the procedure, to be able to use their informations regardless of any mutations in `**flags`,
and also changed the position of the flag collector `'multiple'` below the line, to make it more explicitly noticeable.

I could trace down that every procedure in the `eigenvals()` function would return eigenvalues either as a list, or dictionary,
So, secondly, I had created two separate procedures, to handle every possible cases of returns without any missing ones.

Any feedback would be welcomed.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed `simplify` flag not working in `eigenvals()`
<!-- END RELEASE NOTES -->
