### PR TITLE
fix bug in derivative of matrix trace

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -399,7 +399,7 @@ class MatrixExpr(Expr):
         return 1, MatMul(self)
 
     @staticmethod
-    def from_index_summation(expr, first_index=None, last_index=None):
+    def from_index_summation(expr, first_index=None, last_index=None, dimensions=None):
         r"""
         Parse expression of matrices with explicitly summed indices into a
         matrix expression without indices, if possible.
@@ -548,7 +548,11 @@ class MatrixExpr(Expr):
                 return [(MatrixElement(Add.fromiter(v), *k), k) for k, v in d.items()]
             elif isinstance(expr, KroneckerDelta):
                 i1, i2 = expr.args
-                return [(MatrixElement(S.One, i1, i2), (i1, i2))]
+                if dimensions is not None:
+                    identity = Identity(dimensions[0])
+                else:
+                    identity = S.One
+                return [(MatrixElement(identity, i1, i2), (i1, i2))]
             elif isinstance(expr, MatrixElement):
                 matrix_symbol, i1, i2 = expr.args
                 if i1 in index_ranges:

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -4,7 +4,7 @@ Some examples have been taken from:
 http://www.math.uwaterloo.ca/~hwolkowi//matrixcookbook.pdf
 """
 from sympy import MatrixSymbol, Inverse, symbols, Determinant, Trace, Derivative
-from sympy import MatAdd
+from sympy import MatAdd, Identity
 
 k = symbols("k")
 
@@ -86,3 +86,106 @@ def test_matrix_derivative_with_inverse():
     # Cookbook example 64:
     expr = Trace(Inverse(X + A))
     assert expr.diff(X) == -(Inverse(X + A)*Inverse(X + A)).T
+
+
+def test_matrix_derivatives_of_traces():
+
+    ## First order:
+
+    # Cookbook example 99:
+    expr = Trace(X)
+    assert expr.diff(X) == Identity(k)
+
+    # Cookbook example 100:
+    expr = Trace(X*A)
+    assert expr.diff(X) == A.T
+
+    # Cookbook example 101:
+    expr = Trace(A*X*B)
+    assert expr.diff(X) == A.T*B.T
+
+    # Cookbook example 102:
+    expr = Trace(A*X.T*B)
+    assert expr.diff(X) == B*A
+
+    # Cookbook example 103:
+    expr = Trace(X.T*A)
+    assert expr.diff(X) == A
+
+    # Cookbook example 104:
+    expr = Trace(A*X.T)
+    assert expr.diff(X) == A
+
+    # Cookbook example 105:
+    # TODO: TensorProduct is not supported
+    #expr = Trace(TensorProduct(A, X))
+    #assert expr.diff(X) == Trace(A)*Identity(k)
+
+    ## Second order:
+
+    # Cookbook example 106:
+    expr = Trace(X**2)
+    assert expr.diff(X) == 2*X.T
+
+    # Cookbook example 107:
+    expr = Trace(X**2*B)
+    # TODO: wrong result
+    #assert expr.diff(X) == (X*B + B*X).T
+    expr = Trace(X*X*B)
+    assert expr.diff(X) == (X*B + B*X).T
+
+    # Cookbook example 108:
+    expr = Trace(X.T*B*X)
+    assert expr.diff(X) == B*X + B.T*X
+
+    # Cookbook example 109:
+    expr = Trace(B*X*X.T)
+    assert expr.diff(X) == B*X + B.T*X
+
+    # Cookbook example 110:
+    expr = Trace(X*X.T*B)
+    assert expr.diff(X) == B*X + B.T*X
+
+    # Cookbook example 111:
+    expr = Trace(X*B*X.T)
+    assert expr.diff(X) == X*B.T + X*B
+
+    # Cookbook example 112:
+    expr = Trace(B*X.T*X)
+    assert expr.diff(X) == X*B.T + X*B
+
+    # Cookbook example 113:
+    expr = Trace(X.T*X*B)
+    assert expr.diff(X) == X*B.T + X*B
+
+    # Cookbook example 114:
+    expr = Trace(A*X*B*X)
+    assert expr.diff(X) == A.T*X.T*B.T + B.T*X.T*A.T
+
+    # Cookbook example 115:
+    expr = Trace(X.T*X)
+    assert expr.diff(X) == 2*X
+    expr = Trace(X*X.T)
+    assert expr.diff(X) == 2*X
+
+    # Cookbook example 116:
+    expr = Trace(B.T*X.T*C*X*B)
+    assert expr.diff(X) == C.T*X*B*B.T + C*X*B*B.T
+
+    # Cookbook example 117:
+    expr = Trace(X.T*B*X*C)
+    assert expr.diff(X) == B*X*C + B.T*X*C.T
+
+    # Cookbook example 118:
+    expr = Trace(A*X*B*X.T*C)
+    assert expr.diff(X) == A.T*C.T*X*B.T + C*A*X*B
+
+    # Cookbook example 119:
+    expr = Trace((A*X*B + C)*(A*X*B + C).T)
+    assert expr.diff(X) == 2*A.T*(A*X*B + C)*B.T
+
+    # Cookbook example 120:
+    # TODO: no support for TensorProduct.
+    # expr = Trace(TensorProduct(X, X))
+    # expr = Trace(X)*Trace(X)
+    # expr.diff(X) == 2*Trace(X)*Identity(k)

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -44,7 +44,8 @@ class Trace(Expr):
         n = Dummy("n")
         return MatrixExpr.from_index_summation(
                 Sum(self.args[0][t1, t1].diff(v[m, n]), (t1, 0, self.args[0].shape[0]-1)),
-                m
+                m,
+                dimensions=(v.args[1:])
             )
 
     @property


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15126 


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
  * derivative of trace of matrix now returns the correct result.

<!-- END RELEASE NOTES -->
