### PR TITLE
Change certain http:// urls to https://

### DIFF
--- a/doc/ext/sympylive.py
+++ b/doc/ext/sympylive.py
@@ -2,7 +2,7 @@
     sympylive
     ~~~~~~~~~
 
-    Allow `SymPy Live <http://live.sympy.org/>`_ to be used for interactive
+    Allow `SymPy Live <https://live.sympy.org/>`_ to be used for interactive
     evaluation of SymPy's code examples.
 
     :copyright: Copyright 2014 by the SymPy Development Team, see AUTHORS.
@@ -30,5 +30,5 @@ def builder_inited(app):
 
 
 def setup(app):
-    app.add_config_value('sympylive_url', 'http://live.sympy.org', False)
+    app.add_config_value('sympylive_url', 'https://live.sympy.org', False)
     app.connect('builder-inited', builder_inited)

--- a/doc/src/_static/default.css_t
+++ b/doc/src/_static/default.css_t
@@ -10,7 +10,7 @@
  */
 
 @import url("basic.css");
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
 
 /* -- page layout ----------------------------------------------------------- */
 

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -32,7 +32,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.mathjax',
 autodoc_inherit_docstrings = False
 
 # MathJax file, which is free to use.  See http://www.mathjax.org/docs/2.0/start.html
-mathjax_path = 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full'
+mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
These are just the URLs that result in mixed content errors when loading the
docs over https.

I have already manually fixed the old docs pages on the sympy_doc repo. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
