### PR TITLE
improved nc_simplify and MatPow assumption handlers

### DIFF
--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -50,7 +50,7 @@ def test_symmetric():
     assert ask(Q.symmetric(Y*Y.T)) is True
     assert ask(Q.symmetric(Y.T*X*Y)) is None
     assert ask(Q.symmetric(Y.T*X*Y), Q.symmetric(X)) is True
-    assert ask(Q.symmetric(X*X*X*X*X*X*X*X*X*X), Q.symmetric(X)) is True
+    assert ask(Q.symmetric(X**10), Q.symmetric(X)) is True
     assert ask(Q.symmetric(A1x1)) is True
     assert ask(Q.symmetric(A1x1 + B1x1)) is True
     assert ask(Q.symmetric(A1x1 * B1x1)) is True
@@ -63,8 +63,10 @@ def _test_orthogonal_unitary(predicate):
     assert ask(predicate(X), predicate(X))
     assert ask(predicate(X.T), predicate(X)) is True
     assert ask(predicate(X.I), predicate(X)) is True
+    assert ask(predicate(X**2), predicate(X))
     assert ask(predicate(Y)) is False
     assert ask(predicate(X)) is None
+    assert ask(predicate(X), ~Q.invertible(X)) is False
     assert ask(predicate(X*Z*X), predicate(X) & predicate(Z)) is True
     assert ask(predicate(Identity(3))) is True
     assert ask(predicate(ZeroMatrix(3, 3))) is False
@@ -80,6 +82,7 @@ def test_unitary():
 
 def test_fullrank():
     assert ask(Q.fullrank(X), Q.fullrank(X))
+    assert ask(Q.fullrank(X**2), Q.fullrank(X))
     assert ask(Q.fullrank(X.T), Q.fullrank(X)) is True
     assert ask(Q.fullrank(X)) is None
     assert ask(Q.fullrank(Y)) is None
@@ -95,6 +98,7 @@ def test_positive_definite():
     assert ask(Q.positive_definite(X.I), Q.positive_definite(X)) is True
     assert ask(Q.positive_definite(Y)) is False
     assert ask(Q.positive_definite(X)) is None
+    assert ask(Q.positive_definite(X**3), Q.positive_definite(X))
     assert ask(Q.positive_definite(X*Z*X),
             Q.positive_definite(X) & Q.positive_definite(Z)) is True
     assert ask(Q.positive_definite(X), Q.orthogonal(X))
@@ -116,6 +120,8 @@ def test_triangular():
     assert ask(Q.lower_triangular(Identity(3))) is True
     assert ask(Q.lower_triangular(ZeroMatrix(3, 3))) is True
     assert ask(Q.triangular(X), Q.unit_triangular(X))
+    assert ask(Q.upper_triangular(X**3), Q.upper_triangular(X))
+    assert ask(Q.lower_triangular(X**3), Q.lower_triangular(X))
 
 
 def test_diagonal():
@@ -134,6 +140,7 @@ def test_diagonal():
     assert ask(Q.diagonal(V1.T*(X + Z)*V1))
     assert ask(Q.diagonal(MatrixSlice(Y, (0, 1), (1, 2)))) is True
     assert ask(Q.diagonal(V1.T*(V1 + V2))) is True
+    assert ask(Q.diagonal(X**3), Q.diagonal(X))
 
 
 def test_non_atoms():
@@ -176,6 +183,8 @@ def test_field_assumptions():
     assert ask(Q.real_elements(X), Q.real_elements(X))
     assert not ask(Q.integer_elements(X), Q.real_elements(X))
     assert ask(Q.complex_elements(X), Q.real_elements(X))
+    assert ask(Q.complex_elements(X**2), Q.real_elements(X))
+    assert ask(Q.real_elements(X**2), Q.integer_elements(X))
     assert ask(Q.real_elements(X+Y), Q.real_elements(X)) is None
     assert ask(Q.real_elements(X+Y), Q.real_elements(X) & Q.real_elements(Y))
     from sympy.matrices.expressions.hadamard import HadamardProduct
@@ -191,6 +200,9 @@ def test_field_assumptions():
     alpha = Symbol('alpha')
     assert ask(Q.real_elements(alpha*X), Q.real_elements(X) & Q.real(alpha))
     assert ask(Q.real_elements(LofLU(X)), Q.real_elements(X))
+    e = Symbol('e', integer=True, negative=True)
+    assert ask(Q.real_elements(X**e), Q.real_elements(X) & Q.invertible(X))
+    assert ask(Q.real_elements(X**e), Q.real_elements(X)) is None
 
 def test_matrix_element_sets():
     X = MatrixSymbol('X', 4, 4)

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -10,6 +10,7 @@ from sympy.utilities import sift
 from sympy.matrices.expressions.matexpr import MatrixExpr, ZeroMatrix, Identity
 from sympy.matrices.expressions.matmul import MatMul
 from sympy.matrices.expressions.matadd import MatAdd
+from sympy.matrices.expressions.matpow import MatPow
 from sympy.matrices.expressions.transpose import Transpose, transpose
 from sympy.matrices.expressions.trace import Trace
 from sympy.matrices.expressions.determinant import det, Determinant
@@ -289,6 +290,7 @@ def block_collapse(expr):
         bottom_up(exhaust(condition(hasbm, typed(
             {MatAdd: do_one(bc_matadd, bc_block_plus_ident),
              MatMul: do_one(bc_matmul, bc_dist),
+             MatPow: bc_matmul,
              Transpose: bc_transpose,
              Inverse: bc_inverse,
              BlockMatrix: do_one(bc_unpack, deblock)})))))
@@ -343,7 +345,13 @@ def bc_dist(expr):
 
 
 def bc_matmul(expr):
-    factor, matrices = expr.as_coeff_matrices()
+    if isinstance(expr, MatPow):
+        if expr.args[1].is_Integer:
+            factor, matrices = (1, [expr.args[0]]*expr.args[1])
+        else:
+            return expr
+    else:
+        factor, matrices = expr.as_coeff_matrices()
 
     i = 0
     while (i+1 < len(matrices)):

--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -11,7 +11,7 @@ class FunctionMatrix(MatrixExpr):
 
     This class is an alternative to SparseMatrix
 
-    >>> from sympy import FunctionMatrix, symbols, Lambda, MatMul, Matrix
+    >>> from sympy import FunctionMatrix, symbols, Lambda, MatPow, Matrix
     >>> i, j = symbols('i,j')
     >>> X = FunctionMatrix(3, 3, Lambda((i, j), i + j))
     >>> Matrix(X)
@@ -22,7 +22,7 @@ class FunctionMatrix(MatrixExpr):
 
     >>> Y = FunctionMatrix(1000, 1000, Lambda((i, j), i + j))
 
-    >>> isinstance(Y*Y, MatMul) # this is an expression object
+    >>> isinstance(Y*Y, MatPow) # this is an expression object
     True
 
     >>> (Y**2)[10,10] # So this is evaluated lazily

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -34,13 +34,15 @@ class Inverse(MatPow):
     is_Inverse = True
     exp = S(-1)
 
-    def __new__(cls, mat):
+    def __new__(cls, mat, exp=S(-1)):
+        # exp is there to make it consistent with
+        # inverse.func(*inverse.args) == inverse
         mat = _sympify(mat)
         if not mat.is_Matrix:
             raise TypeError("mat should be a matrix")
         if not mat.is_square:
             raise ShapeError("Inverse of non-square matrix %s" % mat)
-        return Basic.__new__(cls, mat)
+        return Basic.__new__(cls, mat, exp)
 
     @property
     def arg(self):
@@ -58,6 +60,8 @@ class Inverse(MatPow):
         return 1/det(self.arg)
 
     def doit(self, **hints):
+        if 'inv_expand' in hints and hints['inv_expand'] == False:
+            return self
         if hints.get('deep', True):
             return self.arg.doit(**hints).inverse()
         else:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -131,13 +131,11 @@ class MatrixExpr(Expr):
             raise ShapeError("Power of non-square matrix %s" % self)
         elif self.is_Identity:
             return self
-        elif other is S.NegativeOne:
-            return Inverse(self)
         elif other is S.Zero:
             return Identity(self.rows)
         elif other is S.One:
             return self
-        return MatPow(self, other)
+        return MatPow(self, other).doit()
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__pow__')

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -9,6 +9,7 @@ from sympy.strategies import (rm_id, unpack, typed, flatten, exhaust,
         do_one, new)
 from sympy.matrices.expressions.matexpr import (MatrixExpr, ShapeError,
         Identity, ZeroMatrix)
+from sympy.matrices.expressions.matpow import MatPow
 from sympy.matrices.matrices import MatrixBase
 
 
@@ -30,7 +31,6 @@ class MatMul(MatrixExpr):
 
     def __new__(cls, *args, **kwargs):
         check = kwargs.get('check', True)
-
         args = list(map(sympify, args))
         obj = Basic.__new__(cls, *args)
         factor, matrices = obj.as_coeff_matrices()
@@ -121,7 +121,10 @@ class MatMul(MatrixExpr):
             args = [arg.doit(**kwargs) for arg in self.args]
         else:
             args = self.args
-        return canonicalize(MatMul(*args))
+        # treat scalar*MatrixSymbol or scalar*MatPow separately
+        mats = [arg for arg in self.args if arg.is_Matrix]
+        expr = canonicalize(MatMul(*args))
+        return expr
 
     # Needed for partial compatibility with Mul
     def args_cnc(self, **kwargs):
@@ -199,15 +202,25 @@ def merge_explicit(matmul):
 
 def xxinv(mul):
     """ Y * X * X.I -> Y """
+    from sympy.matrices.expressions.inverse import Inverse
     factor, matrices = mul.as_coeff_matrices()
     for i, (X, Y) in enumerate(zip(matrices[:-1], matrices[1:])):
         try:
-            if X.is_square and Y.is_square and X == Y.inverse():
-                I = Identity(X.rows)
-                return newmul(factor, *(matrices[:i] + [I] + matrices[i+2:]))
+            if X.is_square and Y.is_square:
+                _X, x_exp = X, 1
+                _Y, y_exp = Y, 1
+                if isinstance(X, MatPow) and not isinstance(X, Inverse):
+                    _X, x_exp = X.args
+                if isinstance(Y, MatPow) and not isinstance(Y, Inverse):
+                    _Y, y_exp = Y.args
+                if _X == _Y.inverse():
+                    if x_exp - y_exp > 0:
+                        I = _X**(x_exp-y_exp)
+                    else:
+                        I = _Y**(y_exp-x_exp)
+                    return newmul(factor, *(matrices[:i] + [I] + matrices[i+2:]))
         except ValueError:  # Y might not be invertible
             pass
-
     return mul
 
 def remove_ids(mul):
@@ -236,9 +249,40 @@ def factor_in_front(mul):
         return newmul(factor, *matrices)
     return mul
 
-rules = (any_zeros, remove_ids, xxinv, unpack, rm_id(lambda x: x == 1),
-         merge_explicit, factor_in_front, flatten)
+def combine_powers(mul):
+    # combine consecutive powers with the same base into one
+    # e.g. A*A**2 -> A**3
+    from sympy.matrices.expressions import MatPow
+    factor, mmul = mul.as_coeff_mmul()
+    args = []
+    base = None
+    exp = 0
+    for arg in mmul.args:
+        if isinstance(arg, MatPow):
+            current_base = arg.args[0]
+            current_exp = arg.args[1]
+        else:
+            current_base = arg
+            current_exp = 1
+        if current_base == base:
+            exp += current_exp
+        else:
+            if not base is None:
+                if exp == 1:
+                    args.append(base)
+                else:
+                    args.append(base**exp)
+            exp = current_exp
+            base = current_base
+    if exp == 1:
+        args.append(base)
+    else:
+        args.append(base**exp)
 
+    return newmul(factor, *args)
+
+rules = (any_zeros, remove_ids, xxinv, unpack, rm_id(lambda x: x == 1),
+         merge_explicit, factor_in_front, flatten, combine_powers)
 canonicalize = exhaust(typed({MatMul: do_one(*rules)}))
 
 def only_squares(*matrices):

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -85,4 +85,4 @@ def test_matrix_derivative_with_inverse():
 
     # Cookbook example 64:
     expr = Trace(Inverse(X + A))
-    assert expr.diff(X) == -(Inverse(X + A)*Inverse(X + A)).T
+    assert expr.diff(X) == -(Inverse(X + A)).T**2

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -152,9 +152,9 @@ def test_matrix_expression_from_index_summation():
     expr = Sum((A[a, b] + B[b, a])*C[b, c], (b, 0, k-1))
     assert MatrixExpr.from_index_summation(expr, a) == (A+B.T)*C
     expr = Sum(A[a, b]*A[b, c]*A[c, d], (b, 0, k-1), (c, 0, k-1))
-    assert MatrixExpr.from_index_summation(expr, a) == MatMul(A, A, A)
+    assert MatrixExpr.from_index_summation(expr, a) == A**3
     expr = Sum(A[a, b]*A[b, c]*B[c, d], (b, 0, k-1), (c, 0, k-1))
-    assert MatrixExpr.from_index_summation(expr, a) == MatMul(A, A, B)
+    assert MatrixExpr.from_index_summation(expr, a) == A**2*B
 
     # Parse the trace of a matrix:
 

--- a/sympy/matrices/expressions/tests/test_inverse.py
+++ b/sympy/matrices/expressions/tests/test_inverse.py
@@ -1,4 +1,4 @@
-from sympy.core import symbols
+from sympy.core import symbols, S
 from sympy.matrices.expressions import MatrixSymbol, Inverse
 from sympy.matrices import eye, Identity, ShapeError
 from sympy.utilities.pytest import raises
@@ -16,11 +16,14 @@ def test_inverse():
     raises(ShapeError, lambda: Inverse(A))
     raises(ShapeError, lambda: Inverse(A*B))
 
+    assert Inverse(C).args == (C, S(-1))
     assert Inverse(C).shape == (n, n)
     assert Inverse(A*E).shape == (n, n)
     assert Inverse(E*A).shape == (m, m)
     assert Inverse(C).inverse() == C
     assert isinstance(Inverse(Inverse(C)), Inverse)
+
+    assert Inverse(*Inverse(E*A).args) == Inverse(E*A)
 
     assert C.inverse().inverse() == C
 
@@ -33,6 +36,7 @@ def test_inverse():
     assert (C*D).inverse() == D.I*C.I
     # But still works when not possible
     assert isinstance((A*E).inverse(), Inverse)
+    assert Inverse(C*D).doit(inv_expand=False) == Inverse(C*D)
 
     assert Inverse(eye(3)).doit() == eye(3)
     assert Inverse(eye(3)).doit(deep=False) == eye(3)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -142,6 +142,10 @@ def test_multiplication():
     B = MatrixSymbol('B', n, n)
     assert Identity(n) * (A + B) == A + B
 
+    assert A**2*A == A**3
+    assert A**2*(A.I)**3 == A.I
+    assert A**3*(A.I)**2 == A
+
 
 def test_MatPow():
     A = MatrixSymbol('A', n, n)
@@ -155,6 +159,8 @@ def test_MatPow():
     assert A**1 == A
     assert A**2 == AA
     assert A**-1 == Inverse(A)
+    assert (A**-1)**-1 == A
+    assert (A**2)**3 == A**6
     assert A**S.Half == sqrt(A)
     raises(ShapeError, lambda: MatrixSymbol('B', 3, 2)**2)
 

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -64,7 +64,7 @@ def test_doit_nonsquare_MatrixSymbol():
 def test_doit_square_MatrixSymbol_symsize():
     assert MatPow(C, 0).doit() == Identity(n)
     assert MatPow(C, 1).doit() == C
-    for r in [2, -1, pi]:
+    for r in [2, pi]:
         assert MatPow(C, r).doit() == MatPow(C, r)
 
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6126,7 +6126,12 @@ def test_MatrixSymbol_printing():
     x = MatrixSymbol('x', n, n)
     y = MatrixSymbol('y*', n, n)
     assert pretty(x + y) == "x + y*"
-    assert pretty(-a*x + -2*y*y) == "-a*x -2*y**y*"
+    ascii_str = \
+"""\
+     2     \n\
+-2*y*  -a*x\
+"""
+    assert pretty(-a*x + -2*y*y) == ascii_str
 
 
 def test_degree_printing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1415,7 +1415,7 @@ def test_Hadamard():
     from sympy.matrices import MatrixSymbol, HadamardProduct
     X = MatrixSymbol('X', 2, 2)
     Y = MatrixSymbol('Y', 2, 2)
-    assert latex(HadamardProduct(X, Y*Y)) == r'X \circ \left(Y Y\right)'
+    assert latex(HadamardProduct(X, Y*Y)) == r'X \circ Y^{2}'
     assert latex(HadamardProduct(X, Y)*Y) == r'\left(X \circ Y\right) Y'
 
 

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -56,6 +56,7 @@ if theano:
             sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
             # Matrices
             sympy.MatAdd: tt.Elemwise(ts.add),
+            sympy.MatPow: tt.pow
             sympy.HadamardProduct: tt.Elemwise(ts.mul),
             sympy.Trace: tlinalg.trace,
             sympy.Determinant : tlinalg.det,

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -134,7 +134,7 @@ class TheanoPrinter(Printer):
     def _print_MatPow(self, expr, **kwargs):
         children = [self._print(arg, **kwargs) for arg in expr.args]
         result = 1
-        if isinstance(children[1], int):
+        if isinstance(children[1], int) and children[1] > 0:
             for i in range(children[1]):
                 result = tt.dot(result, children[0])
         return result

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -137,6 +137,9 @@ class TheanoPrinter(Printer):
         if isinstance(children[1], int) and children[1] > 0:
             for i in range(children[1]):
                 result = tt.dot(result, children[0])
+        else:
+            raise NotImplementedError('''Only non-negative integer
+           powers of matrices can be handled by Theano at the moment''')
         return result
 
     def _print_MatrixSlice(self, expr, **kwargs):

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -56,7 +56,7 @@ if theano:
             sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
             # Matrices
             sympy.MatAdd: tt.Elemwise(ts.add),
-            sympy.MatPow: tt.pow
+            sympy.MatPow: tt.pow,
             sympy.HadamardProduct: tt.Elemwise(ts.mul),
             sympy.Trace: tlinalg.trace,
             sympy.Determinant : tlinalg.det,

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -56,7 +56,6 @@ if theano:
             sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
             # Matrices
             sympy.MatAdd: tt.Elemwise(ts.add),
-            sympy.MatPow: tt.pow,
             sympy.HadamardProduct: tt.Elemwise(ts.mul),
             sympy.Trace: tlinalg.trace,
             sympy.Determinant : tlinalg.det,
@@ -130,6 +129,14 @@ class TheanoPrinter(Printer):
         result = children[0]
         for child in children[1:]:
             result = tt.dot(result, child)
+        return result
+
+    def _print_MatPow(self, expr, **kwargs):
+        children = [self._print(arg, **kwargs) for arg in expr.args]
+        result = 1
+        if isinstance(children[1], int):
+            for i in range(children[1]):
+                result = tt.dot(result, children[0])
         return result
 
     def _print_MatrixSlice(self, expr, **kwargs):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1535,6 +1535,7 @@ def nc_simplify(expr, deep=True):
     '''
     from sympy.matrices.expressions import (MatrixExpr, MatAdd, MatMul,
                                                 MatPow, MatrixSymbol)
+    from sympy.core.exprtools import factor_nc
     # =========== Auxiliary functions ========================
     def _overlaps(args):
         # Calculate a list of lists m such that m[i][j] contains the lengths
@@ -1813,9 +1814,9 @@ def nc_simplify(expr, deep=True):
     if invert:
         simp = _Pow(simp, -1)
 
-    # see if factor(expr) is simplified better
+    # see if factor_nc(expr) is simplified better
     if not isinstance(expr, MatrixExpr):
-        f_expr = factor(expr)
+        f_expr = factor_nc(expr)
         if f_expr != expr:
             alt_simp = nc_simplify(f_expr, deep=deep)
             simp = compare(simp, alt_simp)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1536,6 +1536,13 @@ def nc_simplify(expr, deep=True):
     from sympy.matrices.expressions import (MatrixExpr, MatAdd, MatMul,
                                                 MatPow, MatrixSymbol)
     from sympy.core.exprtools import factor_nc
+
+    if isinstance(expr, MatrixExpr):
+        expr = expr.doit(inv_expand=False)
+        _Add, _Mul, _Pow, _Symbol = MatAdd, MatMul, MatPow, MatrixSymbol
+    else:
+        _Add, _Mul, _Pow, _Symbol = Add, Mul, Pow, Symbol
+
     # =========== Auxiliary functions ========================
     def _overlaps(args):
         # Calculate a list of lists m such that m[i][j] contains the lengths
@@ -1605,11 +1612,6 @@ def nc_simplify(expr, deep=True):
         return s
     # ========================================================
 
-    if isinstance(expr, MatrixExpr):
-        expr = expr.doit(inv_expand=False)
-        _Add, _Mul, _Pow, _Symbol = MatAdd, MatMul, MatPow, MatrixSymbol
-    else:
-        _Add, _Mul, _Pow, _Symbol = Add, Mul, Pow, Symbol
     if not isinstance(expr, (_Add, _Mul, _Pow)) or expr.is_commutative:
         return expr
     args = expr.args[:]
@@ -1622,11 +1624,8 @@ def nc_simplify(expr, deep=True):
         return _Add(*[nc_simplify(a, deep=deep) for a in args]).doit()
     else:
         # get the non-commutative part
-        com_coeff = 1
-        i = 0
-        while args[i].is_commutative:
-            com_coeff *= args[i]
-            i += 1
+        c_args, args = expr.args_cnc()
+        com_coeff = Mul(*c_args)
         if com_coeff != 1:
             return com_coeff*nc_simplify(expr/com_coeff, deep=deep)
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1609,7 +1609,7 @@ def nc_simplify(expr, deep=True):
         _Add, _Mul, _Pow, _Symbol = MatAdd, MatMul, MatPow, MatrixSymbol
     else:
         _Add, _Mul, _Pow, _Symbol = Add, Mul, Pow, Symbol
-    if not isinstance(expr, (_Add, _Mul, _Pow)):
+    if not isinstance(expr, (_Add, _Mul, _Pow)) or expr.is_commutative:
         return expr
     args = expr.args[:]
     if isinstance(expr, _Pow):

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -729,16 +729,40 @@ def test_clear_coefficients():
 
 def test_nc_simplify():
     from sympy.simplify.simplify import nc_simplify
-    a, b, c = symbols('a b c', commutative = False)
-    x = Symbol('x')
+    from sympy.matrices.expressions import (MatrixExpr, MatAdd, MatMul,
+                                                       MatPow, Identity)
+    from sympy.core import Pow
+    from functools import reduce
 
-    def _check(expr, simplified, deep=True):
+    a, b, c, d = symbols('a b c d', commutative = False)
+    x = Symbol('x')
+    A = MatrixSymbol("A", x, x)
+    B = MatrixSymbol("B", x, x)
+    C = MatrixSymbol("C", x, x)
+    D = MatrixSymbol("D", x, x)
+    subst = {a: A, b: B, c: C, d:D}
+    funcs = {Add: lambda x,y: x+y, Mul: lambda x,y: x*y }
+
+    def _to_matrix(expr):
+        if expr in subst:
+            return subst[expr]
+        if isinstance(expr, Pow):
+            return MatPow(_to_matrix(expr.args[0]), expr.args[1])
+        elif isinstance(expr, (Add, Mul)):
+            return reduce(funcs[expr.func],[_to_matrix(a) for a in expr.args])
+        else:
+            return expr*Identity(x)
+
+    def _check(expr, simplified, deep=True, matrix=True):
         assert nc_simplify(expr, deep=deep) == simplified
         assert expand(expr) == expand(simplified)
+        if matrix:
+            m_simp = _to_matrix(simplified).doit(inv_expand=False)
+            assert nc_simplify(_to_matrix(expr), deep=deep) == m_simp
 
     _check(a*b*a*b*a*b*c*(a*b)**3*c, ((a*b)**3*c)**2)
     _check(a*b*(a*b)**-2*a*b, 1)
-    _check(a**2*b*a*b*a*b*(a*b)**-1, a*(a*b)**2)
+    _check(a**2*b*a*b*a*b*(a*b)**-1, a*(a*b)**2, matrix=False)
     _check(b*a*b**2*a*b**2*a*b**2, b*(a*b**2)**3)
     _check(a*b*a**2*b*a**2*b*a**3, (a*b*a)**3*a**2)
     _check(a**2*b*a**4*b*a**4*b*a**2, (a**2*b*a**2)**3)
@@ -753,3 +777,5 @@ def test_nc_simplify():
     _check(expr, a**3*(b*a**4)**2*(b*a**2)**6*(a*b)**10)
     _check((a*b*a*b)**2, (a*b*a*b)**2, deep=False)
     _check(a*b*(c*d)**2, a*b*(c*d)**2)
+    expr = b**-1*(a**-1*b**-1 - a**-1*c*b**-1)**-1*a**-1
+    assert nc_simplify(expr) == (1-c)**-1

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -779,3 +779,5 @@ def test_nc_simplify():
     _check(a*b*(c*d)**2, a*b*(c*d)**2)
     expr = b**-1*(a**-1*b**-1 - a**-1*c*b**-1)**-1*a**-1
     assert nc_simplify(expr) == (1-c)**-1
+    # commutative expressions should be returned without an error
+    assert nc_simplify(2*x**2) == 2*x**2


### PR DESCRIPTION
This PR is relevant to #15120

**nc_simplify**
* Sometimes better simplifications can be obtained if an expression if factorised first, but that's not true in general. This PR makes `nc_simplify(expr)` try both `expr` and `factor(expr)` and choose the better simplification.
* Works on matrix expressions now

**Matrix Expressions**
Getting `nc_simplify` to work on matrix expressions required some changes
* `Inverse.args` is now a 2-tuple to be consistent with its superclass `MatPow`
* `MatPow.doit()` can combine powers into one (e.g. `A**3*A == A**4`).
* New `doit` keyword argument: `Inverse.doit(inv_expand=False)` makes sure inverses are not
expanded (`Inverse(A*B).doit() == B**-1*A**-1` but `Inverse(A*B).doit(inv_expand=False) == (A*B)**-1`).

These changes caused some test failures in matrix assumptions so I implemented some basic
**MatPow assumption handlers** for almost all matrix handlers.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * `nc_simplify` can get better simplifications and now works on instances of `MatrixExpr`
* matrices
    * `MatrixExpr` operations via `*, **, +` or `.doit()` produce more simplified expressions
    * `Inverse.args` are a 2-tuple `(matrix, -1)` to be consistent with `MatPow`
    * Keep inverses in matrix expressions unexpanded with keyword `inv_expand`; for example, `Inverse(A*B).doit() == B**-1*A**-1` but `Inverse(A*B).doit(inv_expand=False) == (A*B)**-1`
* assumptions
    * improved matrix assumptions so `ask` can make deductions about instances of `MatPow`
* printing
  * add theano printing for MatPow
<!-- END RELEASE NOTES -->
