### PR TITLE
Corrected the output of latex method in latex.py to return valid latex command

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -608,8 +608,7 @@ class LatexPrinter(Printer):
 
     def _print_Indexed(self, expr):
         tex_base = self._print(expr.base)
-        tex_base = '{'+tex_base+'}'
-        tex = tex_base+'_{%s}' % ','.join(
+        tex = '{'+tex_base+'}'+'_{%s}' % ','.join(
             map(self._print, expr.indices))
         return tex
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -607,7 +607,9 @@ class LatexPrinter(Printer):
         return outstr
 
     def _print_Indexed(self, expr):
-        tex = self._print(expr.base)+'_{%s}' % ','.join(
+        tex_base = self._print(expr.base)
+        tex_base = '{'+tex_base+'}'
+        tex = tex_base+'_{%s}' % ','.join(
             map(self._print, expr.indices))
         return tex
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -523,8 +523,8 @@ def test_latex_indexed():
     symbol_latex = latex(Psi_symbol * conjugate(Psi_symbol))
     indexed_latex = latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
     # \\overline{{\\Psi}_{0}} {\\Psi}_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
-    assert symbol_latex=='\\Psi_{0} \\overline{\\Psi_{0}}'
-    assert indexed_latex=='\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
+    assert symbol_latex == '\\Psi_{0} \\overline{\\Psi_{0}}'
+    assert indexed_latex == '\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
 
     # Symbol('gamma') gives r'\gamma'
     assert latex(IndexedBase('gamma')) == r'\gamma'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1,6 +1,6 @@
 from sympy import (
     Add, Abs, Chi, Ci, CosineTransform, Dict, Ei, Eq, FallingFactorial,
-    FiniteSet, Float, FourierTransform, Function,Indexed, IndexedBase, Integral,
+    FiniteSet, Float, FourierTransform, Function, Indexed, IndexedBase, Integral,
     Interval, InverseCosineTransform, InverseFourierTransform,
     InverseLaplaceTransform, InverseMellinTransform, InverseSineTransform,
     Lambda, LaplaceTransform, Limit, Matrix, Max, MellinTransform, Min, Mul,

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -523,8 +523,8 @@ def test_latex_indexed():
     symbol_latex = latex(Psi_symbol * conjugate(Psi_symbol))
     indexed_latex = latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
     # \\overline{{\\Psi}_{0}} {\\Psi}_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
-    assert symbol_latex=='\\Psi_{0} \\overline{\\Psi_{0}}' \
-        and indexed_latex=='\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
+    assert symbol_latex=='\\Psi_{0} \\overline{\\Psi_{0}}' 
+    assert indexed_latex=='\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
 
     # Symbol('gamma') gives r'\gamma'
     assert latex(IndexedBase('gamma')) == r'\gamma'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1,6 +1,6 @@
 from sympy import (
     Add, Abs, Chi, Ci, CosineTransform, Dict, Ei, Eq, FallingFactorial,
-    FiniteSet, Float, FourierTransform, Function, IndexedBase, Integral,
+    FiniteSet, Float, FourierTransform, Function,Indexed, IndexedBase, Integral,
     Interval, InverseCosineTransform, InverseFourierTransform,
     InverseLaplaceTransform, InverseMellinTransform, InverseSineTransform,
     Lambda, LaplaceTransform, Limit, Matrix, Max, MellinTransform, Min, Mul,
@@ -527,6 +527,7 @@ def test_latex_indexed():
     assert indexed_latex == '\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
 
     # Symbol('gamma') gives r'\gamma'
+    assert latex(Indexed('x1',Symbol('i'))) == '{x_{1}}_{i}'
     assert latex(IndexedBase('gamma')) == r'\gamma'
     assert latex(IndexedBase('a b')) == 'a b'
     assert latex(IndexedBase('a_b')) == 'a_{b}'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -523,7 +523,7 @@ def test_latex_indexed():
     symbol_latex = latex(Psi_symbol * conjugate(Psi_symbol))
     indexed_latex = latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
     # \\overline{{\\Psi}_{0}} {\\Psi}_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
-    assert symbol_latex=='\\Psi_{0} \\overline{\\Psi_{0}}' 
+    assert symbol_latex=='\\Psi_{0} \\overline{\\Psi_{0}}'
     assert indexed_latex=='\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
 
     # Symbol('gamma') gives r'\gamma'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -522,9 +522,9 @@ def test_latex_indexed():
     Psi_indexed = IndexedBase(Symbol('Psi', complex=True, real=False))
     symbol_latex = latex(Psi_symbol * conjugate(Psi_symbol))
     indexed_latex = latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
-    # \\overline{\\Psi_{0}} \\Psi_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
-    assert symbol_latex.split() == indexed_latex.split() \
-        or symbol_latex.split() == indexed_latex.split()[::-1]
+    # \\overline{{\\Psi}_{0}} {\\Psi}_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
+    assert symbol_latex=='\\Psi_{0} \\overline{\\Psi_{0}}' \
+        or indexed_latex=='\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
 
     # Symbol('gamma') gives r'\gamma'
     assert latex(IndexedBase('gamma')) == r'\gamma'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -524,7 +524,7 @@ def test_latex_indexed():
     indexed_latex = latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
     # \\overline{{\\Psi}_{0}} {\\Psi}_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
     assert symbol_latex=='\\Psi_{0} \\overline{\\Psi_{0}}' \
-        or indexed_latex=='\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
+        and indexed_latex=='\\overline{{\\Psi}_{0}} {\\Psi}_{0}'
 
     # Symbol('gamma') gives r'\gamma'
     assert latex(IndexedBase('gamma')) == r'\gamma'


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15059



#### Brief description of what is fixed or changed
The problem was that latex function wasn't printing valid Latex commands for Indexed results.In order to overcome this issue we altered the code to wrap the indexedbase in {} so that printer would print valid latex command.

Example:-

![43878942-9caaee84-9b6f-11e8-9f49-44800d684ceb](https://user-images.githubusercontent.com/22992482/44660055-00935400-aa24-11e8-8702-2a279d87f4e2.png)

```
Before Correction in code.
Output:-x_{1}_{i} which was not a valid latex command.

After correction in code.
Output:-{x_{1}}_{i} which is valid latex command.
```
#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
    * fix latex printing of Indexed results #15059
<!-- END RELEASE NOTES -->
