### PR TITLE
Added implementation of IndexError for non int-indices in row_insert() and col_insert()

### DIFF
--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -203,11 +203,7 @@ class MatrixShaping(MatrixRequired):
         if not self:
             return type(self)(other)
 
-        try:
-            as_int(pos)
-        except ValueError:
-            raise TypeError("Index is not an integer: 'pos = %s', valid : %s must be an integer" % (
-            pos, pos))
+        pos = as_int(pos)
 
         if pos < 0:
             pos = self.cols + pos

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -206,21 +206,21 @@ class MatrixShaping(MatrixRequired):
         try:
             as_int(pos)
         except ValueError:
-            raise IndexError("Index is not an integer: 'pos = %s', valid : %s must be an integer" % (
+            raise TypeError("Index is not an integer: 'pos = %s', valid : %s must be an integer" % (
             pos, pos))
-        else:
-            if pos < 0:
-                pos = self.cols + pos
-            if pos < 0:
-                pos = 0
-            elif pos > self.cols:
-                pos = self.cols
 
-            if self.rows != other.rows:
-                raise ShapeError(
-                    "`self` and `other` must have the same number of rows.")
+        if pos < 0:
+            pos = self.cols + pos
+        if pos < 0:
+            pos = 0
+        elif pos > self.cols:
+            pos = self.cols
 
-            return self._eval_col_insert(pos, other)
+        if self.rows != other.rows:
+            raise ShapeError(
+                "`self` and `other` must have the same number of rows.")
+
+        return self._eval_col_insert(pos, other)
 
     def col_join(self, other):
         """Concatenates two matrices along self's last and other's first row.
@@ -449,21 +449,21 @@ class MatrixShaping(MatrixRequired):
         try:
             as_int(pos)
         except ValueError:
-            raise IndexError("Index is not an integer: 'pos = %s', valid : %s must be an integer" % (
+            raise TypeError("Index is not an integer: 'pos = %s', valid : %s must be an integer" % (
                 pos, pos))
-        else:
-            if pos < 0:
-                pos = self.rows + pos
-            if pos < 0:
-                pos = 0
-            elif pos > self.rows:
-                pos = self.rows
 
-            if self.cols != other.cols:
-                raise ShapeError(
-                    "`self` and `other` must have the same number of columns.")
+        if pos < 0:
+            pos = self.rows + pos
+        if pos < 0:
+            pos = 0
+        elif pos > self.rows:
+            pos = self.rows
 
-            return self._eval_row_insert(pos, other)
+        if self.cols != other.cols:
+            raise ShapeError(
+                "`self` and `other` must have the same number of columns.")
+
+        return self._eval_row_insert(pos, other)
 
     def row_join(self, other):
         """Concatenates two matrices along self's last and rhs's first column

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -446,11 +446,7 @@ class MatrixShaping(MatrixRequired):
         if not self:
             return self._new(other)
 
-        try:
-            as_int(pos)
-        except ValueError:
-            raise TypeError("Index is not an integer: 'pos = %s', valid : %s must be an integer" % (
-                pos, pos))
+        pos = as_int(pos)
 
         if pos < 0:
             pos = self.rows + pos

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -203,12 +203,11 @@ class MatrixShaping(MatrixRequired):
         if not self:
             return type(self)(other)
 
+        i = pos
         if pos < 0:
             pos = self.cols + pos
-        if pos < 0:
-            pos = 0
-        elif pos > self.cols:
-            pos = self.cols
+        if pos < 0 or pos > self.cols:
+            raise IndexError("Index out of bounds: 'pos = %s', valid -%s <= pos <= %s" % (i, self.cols, self.cols))
 
         if self.rows != other.rows:
             raise ShapeError(
@@ -440,12 +439,11 @@ class MatrixShaping(MatrixRequired):
         if not self:
             return self._new(other)
 
+        i = pos
         if pos < 0:
             pos = self.rows + pos
-        if pos < 0:
-            pos = 0
-        elif pos > self.rows:
-            pos = self.rows
+        if pos < 0 or pos > self.rows:
+            raise IndexError("Index out of bounds: 'pos = %s', valid -%s <= pos <= %s" % (i, self.rows, self.rows))
 
         if self.cols != other.cols:
             raise ShapeError(

--- a/sympy/matrices/common.py
+++ b/sympy/matrices/common.py
@@ -203,17 +203,24 @@ class MatrixShaping(MatrixRequired):
         if not self:
             return type(self)(other)
 
-        i = pos
-        if pos < 0:
-            pos = self.cols + pos
-        if pos < 0 or pos > self.cols:
-            raise IndexError("Index out of bounds: 'pos = %s', valid -%s <= pos <= %s" % (i, self.cols, self.cols))
+        try:
+            as_int(pos)
+        except ValueError:
+            raise IndexError("Index is not an integer: 'pos = %s', valid : %s must be an integer" % (
+            pos, pos))
+        else:
+            if pos < 0:
+                pos = self.cols + pos
+            if pos < 0:
+                pos = 0
+            elif pos > self.cols:
+                pos = self.cols
 
-        if self.rows != other.rows:
-            raise ShapeError(
-                "self and other must have the same number of rows.")
+            if self.rows != other.rows:
+                raise ShapeError(
+                    "`self` and `other` must have the same number of rows.")
 
-        return self._eval_col_insert(pos, other)
+            return self._eval_col_insert(pos, other)
 
     def col_join(self, other):
         """Concatenates two matrices along self's last and other's first row.
@@ -439,17 +446,24 @@ class MatrixShaping(MatrixRequired):
         if not self:
             return self._new(other)
 
-        i = pos
-        if pos < 0:
-            pos = self.rows + pos
-        if pos < 0 or pos > self.rows:
-            raise IndexError("Index out of bounds: 'pos = %s', valid -%s <= pos <= %s" % (i, self.rows, self.rows))
+        try:
+            as_int(pos)
+        except ValueError:
+            raise IndexError("Index is not an integer: 'pos = %s', valid : %s must be an integer" % (
+                pos, pos))
+        else:
+            if pos < 0:
+                pos = self.rows + pos
+            if pos < 0:
+                pos = 0
+            elif pos > self.rows:
+                pos = self.rows
 
-        if self.cols != other.cols:
-            raise ShapeError(
-                "`self` and `other` must have the same number of columns.")
+            if self.cols != other.cols:
+                raise ShapeError(
+                    "`self` and `other` must have the same number of columns.")
 
-        return self._eval_row_insert(pos, other)
+            return self._eval_row_insert(pos, other)
 
     def row_join(self, other):
         """Concatenates two matrices along self's last and rhs's first column

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -189,14 +189,14 @@ def test_col_join():
 
 def test_row_insert():
     r4 = Matrix([[4, 4, 4]])
-    for i in range(-4, 5):
+    for i in range(-3, 3):
         l = [1, 0, 0]
         l.insert(i, 4)
         assert flatten(eye_Shaping(3).row_insert(i, r4).col(0).tolist()) == l
 
 def test_col_insert():
     c4 = Matrix([4, 4, 4])
-    for i in range(-4, 5):
+    for i in range(-3, 3):
         l = [0, 0, 0]
         l.insert(i, 4)
         assert flatten(zeros_Shaping(3).col_insert(i, c4).row(0).tolist()) == l

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -189,14 +189,14 @@ def test_col_join():
 
 def test_row_insert():
     r4 = Matrix([[4, 4, 4]])
-    for i in range(-3, 3):
+    for i in range(-4, 5):
         l = [1, 0, 0]
         l.insert(i, 4)
         assert flatten(eye_Shaping(3).row_insert(i, r4).col(0).tolist()) == l
 
 def test_col_insert():
     c4 = Matrix([4, 4, 4])
-    for i in range(-3, 3):
+    for i in range(-4, 5):
         l = [0, 0, 0]
         l.insert(i, 4)
         assert flatten(zeros_Shaping(3).col_insert(i, c4).row(0).tolist()) == l

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2328,7 +2328,7 @@ def test_col_join():
 
 def test_row_insert():
     r4 = Matrix([[4, 4, 4]])
-    for i in range(-3, 3):
+    for i in range(-4, 5):
         l = [1, 0, 0]
         l.insert(i, 4)
         assert flatten(eye(3).row_insert(i, r4).col(0).tolist()) == l
@@ -2336,7 +2336,7 @@ def test_row_insert():
 
 def test_col_insert():
     c4 = Matrix([4, 4, 4])
-    for i in range(-3, 3):
+    for i in range(-4, 5):
         l = [0, 0, 0]
         l.insert(i, 4)
         assert flatten(zeros(3).col_insert(i, c4).row(0).tolist()) == l
@@ -2351,13 +2351,13 @@ def test_row_and_column_insert_for_indices():
     assert M.row_insert(3, V) == Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5], [10, 10, 10]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.row_insert(4, V))
+    raises(IndexError, lambda: M.row_insert(4.7, V))
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     assert M.row_insert(-1, V) == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.row_insert(-4, V))
+    raises(IndexError, lambda: M.row_insert(2.8, V))
 
     # for column insert
 
@@ -2370,7 +2370,7 @@ def test_row_and_column_insert_for_indices():
     assert M.col_insert(0, V) == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.col_insert(-4, V))
+    raises(IndexError, lambda: M.col_insert(-4.2, V))
 
 
 def test_normalized():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2328,7 +2328,7 @@ def test_col_join():
 
 def test_row_insert():
     r4 = Matrix([[4, 4, 4]])
-    for i in range(-4, 5):
+    for i in range(-3, 3):
         l = [1, 0, 0]
         l.insert(i, 4)
         assert flatten(eye(3).row_insert(i, r4).col(0).tolist()) == l
@@ -2336,10 +2336,41 @@ def test_row_insert():
 
 def test_col_insert():
     c4 = Matrix([4, 4, 4])
-    for i in range(-4, 5):
+    for i in range(-3, 3):
         l = [0, 0, 0]
         l.insert(i, 4)
         assert flatten(zeros(3).col_insert(i, c4).row(0).tolist()) == l
+
+def test_row_and_column_insert_for_indices():
+    V = Matrix([[10, 10, 10]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    assert M.row_insert(1, V) == Matrix([[1, 2, 3], [10, 10, 10], [2, 3, 4], [3, 4, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    assert M.row_insert(3, V) == Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5], [10, 10, 10]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(4, V))
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    assert M.row_insert(-1, V) == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.row_insert(-4, V))
+
+    # for column insert
+
+    V = Matrix([[10, 10, 10]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    assert M.col_insert(-1, V) == Matrix([[1, 2, 10, 3], [2, 3, 10, 4], [3, 4, 10, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    assert M.col_insert(0, V) == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(IndexError, lambda: M.col_insert(-4, V))
 
 
 def test_normalized():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1940,9 +1940,9 @@ def test_errors():
     raises(ValueError, lambda: M.det('method=LU_decomposition()'))
     V = Matrix([[10, 10, 10]])
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(TypeError, lambda: M.row_insert(4.7, V))
+    raises(ValueError, lambda: M.row_insert(4.7, V))
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(TypeError, lambda: M.col_insert(-4.2, V))
+    raises(ValueError, lambda: M.col_insert(-4.2, V))
 
 def test_len():
     assert len(Matrix()) == 0

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2364,9 +2364,6 @@ def test_row_and_column_insert_for_indices():
     V = Matrix([[10, 10, 10]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    assert M.col_insert(-1, V) == Matrix([[1, 2, 10, 3], [2, 3, 10, 4], [3, 4, 10, 5]])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     assert M.col_insert(0, V) == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1938,7 +1938,11 @@ def test_errors():
     raises(IndexError, lambda: eye(3)[2, 5])
     M = Matrix(((1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12), (13, 14, 15, 16)))
     raises(ValueError, lambda: M.det('method=LU_decomposition()'))
-
+    V = Matrix([[10, 10, 10]])
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(TypeError, lambda: M.row_insert(4.7, V))
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    raises(TypeError, lambda: M.col_insert(-4.2, V))
 
 def test_len():
     assert len(Matrix()) == 0
@@ -2340,37 +2344,6 @@ def test_col_insert():
         l = [0, 0, 0]
         l.insert(i, 4)
         assert flatten(zeros(3).col_insert(i, c4).row(0).tolist()) == l
-
-def test_row_and_column_insert_for_indices():
-    V = Matrix([[10, 10, 10]])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    assert M.row_insert(1, V) == Matrix([[1, 2, 3], [10, 10, 10], [2, 3, 4], [3, 4, 5]])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    assert M.row_insert(3, V) == Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5], [10, 10, 10]])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.row_insert(4.7, V))
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    assert M.row_insert(-1, V) == Matrix([[1, 2, 3], [2, 3, 4], [10, 10, 10], [3, 4, 5]])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.row_insert(2.8, V))
-
-    # for column insert
-
-    V = Matrix([10, 10, 10])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    assert M.col_insert(-1, V) == Matrix([[1, 2, 10, 3], [2, 3, 10, 4], [3, 4, 10, 5]])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    assert M.col_insert(0, V) == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])
-
-    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    raises(IndexError, lambda: M.col_insert(-4.2, V))
 
 
 def test_normalized():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2361,7 +2361,10 @@ def test_row_and_column_insert_for_indices():
 
     # for column insert
 
-    V = Matrix([[10, 10, 10]])
+    V = Matrix([10, 10, 10])
+
+    M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    assert M.col_insert(-1, V) == Matrix([[1, 2, 10, 3], [2, 3, 10, 4], [3, 4, 10, 5]])
 
     M = Matrix([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
     assert M.col_insert(0, V) == Matrix([[10, 1, 2, 3], [10, 2, 3, 4], [10, 3, 4, 5]])


### PR DESCRIPTION
#### Issue before : 
`M.row_insert()` and `M.col_insert()` does not raise error for non-int indices
```
>>> M = Matrix([ [1, 2, 3], [2, 3, 4], [3, 4, 5] ])
>>> M.row_insert(5.3,  Matrix([ [1, 1, 1] ])
Matrix([ [1, 2, 3], [2, 3, 4], [3, 4, 5], [1, 1, 1] ])
```
This has been fixed in this PR. Now such a non-int input results in an `IndexError`.

Please take a look and suggest improvements.
Thanks.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
    * added implementation of `IndexError` for non int-indices in`row_insert()` and `col_insert()`
<!-- END RELEASE NOTES -->
