### PR TITLE
Change the printing imports in sympy/__init__.py to import from *

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -79,11 +79,7 @@ from .algebras import *
 # This module is slow to import:
 #from physics import units
 from .plotting import plot, textplot, plot_backends, plot_implicit
-from .printing import pretty, pretty_print, pprint, pprint_use_unicode, \
-    pprint_try_use_unicode, print_gtk, print_tree, pager_print, TableForm
-from .printing import rcode, ccode, fcode, jscode, julia_code, mathematica_code, \
-    octave_code, latex, preview, rust_code, mathml, glsl_code, cxxcode
-from .printing import python, print_python, srepr, sstr, sstrrepr
+from .printing import *
 from .interactive import init_session, init_printing
 
 evalf._create_evalf_table()

--- a/sympy/printing/__init__.py
+++ b/sympy/printing/__init__.py
@@ -1,25 +1,69 @@
 """Printing subsystem"""
 
-from .pretty import pager_print, pretty, pretty_print, pprint, \
-    pprint_use_unicode, pprint_try_use_unicode
+__all__ = []
+
+from .pretty import pager_print, pretty, pretty_print, pprint, pprint_use_unicode, pprint_try_use_unicode
+__all__ += ['pager_print', 'pretty', 'pretty_print', 'pprint', 'pprint_use_unicode', 'pprint_try_use_unicode']
+
 from .latex import latex, print_latex
+__all__ += ['latex', 'print_latex']
+
 from .mathml import mathml, print_mathml
+__all__ += ['mathml', 'print_mathml']
+
 from .python import python, print_python
+__all__ += ['python', 'print_python']
+
 from .pycode import pycode
+__all__ += ['pycode']
+
 from .ccode import ccode, print_ccode
+__all__ += ['ccode', 'print_ccode']
+
 from .glsl import glsl_code, print_glsl
+__all__ += ['glsl_code', 'print_glsl']
+
 from .cxxcode import cxxcode
+__all__ += ['cxxcode']
+
 from .fcode import fcode, print_fcode
+__all__ += ['fcode', 'print_fcode']
+
 from .rcode import rcode, print_rcode
+__all__ += ['rcode', 'print_rcode']
+
 from .jscode import jscode, print_jscode
+__all__ += ['jscode', 'print_jscode']
+
 from .julia import julia_code
+__all__ += ['julia_code']
+
 from .mathematica import mathematica_code
+__all__ += ['mathematica_code']
+
 from .octave import octave_code
+__all__ += ['octave_code']
+
 from .rust import rust_code
+__all__ += ['rust_code']
+
 from .gtk import print_gtk
+__all__ += ['print_gtk']
+
 from .preview import preview
+__all__ += ['preview']
+
 from .repr import srepr
+__all__ += ['srepr']
+
 from .tree import print_tree
+__all__ += ['print_tree']
+
 from .str import StrPrinter, sstr, sstrrepr
+__all__ += ['StrPrinter', 'sstr', 'sstrrepr']
+
 from .tableform import TableForm
+__all__ += ['TableForm']
+
 from .dot import dotprint
+__all__ += ['dotprint']


### PR DESCRIPTION
Also added `__all__` to `sympy/printing/__init__.py` to prevent the importing of
submodules (which mask some builtins).

This adds the following functions to 'from sympy import *':

StrPrinter
dotprint
print_ccode
print_fcode
print_glsl
print_jscode
print_latex
print_mathml
print_rcode
pycode

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15088.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Add `StrPrinter`, `print_ccode`, `print_fcode`, `print_glsl`, `print_jscode`, `print_latex`, `print_mathml`, `print_rcode`, and `pycode` to `from sympy import *`.

<!-- END RELEASE NOTES -->
