### PR TITLE
fix combinatorics failures from repeated test runs

### DIFF
--- a/doc/src/modules/combinatorics/fp_groups.rst
+++ b/doc/src/modules/combinatorics/fp_groups.rst
@@ -174,12 +174,12 @@ manipulate the algorithm, like
   have finite index, and even if it has it may take many more intermediate
   cosets than the actual index of the subgroup is. To avoid a coset enumeration
   "running away" therefore SymPy has a "safety stop" built-in. This is
-  controlled by this variable. For example:
+  controlled by this variable. To change it, use `max_cosets` keyword.
+  For example:
 
-  >>> CosetTable.coset_table_max_limit = 50
   >>> F, a, b = free_group("a, b")
   >>> Cox = FpGroup(F, [a**6, b**6, (a*b)**2, (a**2*b**2)**2, (a**3*b**3)**5])
-  >>> C_r = coset_enumeration_r(Cox, [a])
+  >>> C_r = coset_enumeration_r(Cox, [a], max_cosets=50)
   Traceback (most recent call last):
     ...
   ValueError: the coset enumeration has defined more than 50 cosets

--- a/sympy/combinatorics/coset_table.py
+++ b/sympy/combinatorics/coset_table.py
@@ -49,6 +49,8 @@ class CosetTable(DefaultPrinting):
     # default limit for the number of cosets allowed in a
     # coset enumeration.
     coset_table_max_limit = 4096000
+    # limit for the current instance
+    coset_table_limit = None
     # maximum size of deduction stack above or equal to
     # which it is emptied
     max_stack_size = 100
@@ -58,7 +60,7 @@ class CosetTable(DefaultPrinting):
             max_cosets = CosetTable.coset_table_max_limit
         self.fp_group = fp_grp
         self.subgroup = subgroup
-        self.coset_table_max_limit = max_cosets
+        self.coset_table_limit = max_cosets
         # "p" is setup independent of Ω and n
         self.p = [0]
         # a list of the form `[gen_1, gen_1^{-1}, ... , gen_k, gen_k^{-1}]`
@@ -148,11 +150,11 @@ class CosetTable(DefaultPrinting):
         A = self.A
         table = self.table
         len_table = len(table)
-        if len_table >= self.coset_table_max_limit:
+        if len_table >= self.coset_table_limit:
             # abort the further generation of cosets
             raise ValueError("the coset enumeration has defined more than "
                     "%s cosets. Try with a greater value max number of cosets "
-                    % self.coset_table_max_limit)
+                    % self.coset_table_limit)
         table.append([None]*len(A))
         self.P.append([None]*len(self.A))
         # beta is the new coset generated
@@ -181,11 +183,11 @@ class CosetTable(DefaultPrinting):
         A = self.A
         table = self.table
         len_table = len(table)
-        if len_table >= self.coset_table_max_limit:
+        if len_table >= self.coset_table_limit:
             # abort the further generation of cosets
             raise ValueError("the coset enumeration has defined more than "
                     "%s cosets. Try with a greater value max number of cosets "
-                    % self.coset_table_max_limit)
+                    % self.coset_table_limit)
         table.append([None]*len(A))
         # beta is the new coset generated
         beta = len_table

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -428,6 +428,7 @@ class Polyhedron(Basic):
 
         >>> from sympy.combinatorics import Permutation, Cycle
         >>> from sympy.combinatorics.polyhedron import tetrahedron
+        >>> tetrahedron = tetrahedron.copy()
         >>> tetrahedron.array_form
         [0, 1, 2, 3]
 
@@ -533,6 +534,7 @@ class Polyhedron(Basic):
 
         >>> from sympy.combinatorics import Polyhedron, Permutation
         >>> from sympy.combinatorics.polyhedron import cube
+        >>> cube = cube.copy()
         >>> cube.corners
         (0, 1, 2, 3, 4, 5, 6, 7)
         >>> cube.rotate(0)
@@ -578,6 +580,7 @@ class Polyhedron(Basic):
         ========
 
         >>> from sympy.combinatorics.polyhedron import tetrahedron as T
+        >>> T = T.copy()
         >>> T.corners
         (0, 1, 2, 3)
         >>> T.rotate(0)


### PR DESCRIPTION
Part of what's being done in #15163
See #15149 for other failures

Before the introduction of keyword `max_cosets`, the only way to
control the maximum number of cosets in a coset enumeration was
by changing the class attribute `CosetTable.coset_table_max_limit`. If not
restored to the original value, the change in attribute affects
all subsequent coset enumerations. This caused doctests to fail if run
twice in the same process. This PR changes the tests to use
`max_cosets` instead and modifies the code of `CosetTable` to
allow the attribute change to be preserved even if `max_cosets`
is used after the change.

The failures in `polyhedron` were due to the fact that `Polyhedron` is a mutable object and the doctests imported pre-computed standard polyhedra (like `tetrahedron` and `cube`) and performed operations so that  when they were imported next time, they were no longer in their standard state. I've changed doctests to create a copy first

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* combinatorics
    * `CosetTable.coset_table_max_limit` is no longer overwritten when `max_cosets` keyword is used
<!-- END RELEASE NOTES -->
