### PR TITLE
Remove reference to NO ENTRY from the pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,9 +17,8 @@ https://github.com/blog/1506-closing-issues-via-pull-requests .-->
 
 <!-- Write the release notes for this release below. See
 https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
-on how to write release notes. If there is no release notes entry for this PR,
-write "NO ENTRY". The bot will check your release notes automatically to see
-if they are formatted correctly. -->
+on how to write release notes. The bot will check your release notes
+automatically to see if they are formatted correctly. -->
 
 <!-- BEGIN RELEASE NOTES -->
 


### PR DESCRIPTION
It now mentioned only in the guide on the wiki. This is to make it less likely
for people to write "NO ENTRY" on pull requests that need a release notes
entry.

Fixes sympy/sympy-bot#30.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
(yes ironic I know)