### PR TITLE
Unmask iszerofunc parameter for nullspace() and eigenvects()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -932,7 +932,7 @@ class MatrixSubspaces(MatrixReductions):
 
         return [self.col(i) for i in pivots]
 
-    def nullspace(self, iszerofunc=_iszero, simplify=False):
+    def nullspace(self, simplify=False, iszerofunc=_iszero):
         """Returns list of vectors (Matrix objects) that span nullspace of self
 
         Examples

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1177,7 +1177,7 @@ class MatrixEigen(MatrixSubspaces):
         else:
             return [simplify(value) for value in eigs]
 
-    def eigenvects(self, error_when_incomplete=True, **flags):
+    def eigenvects(self, error_when_incomplete=True, iszerofunc=_iszero, **flags):
         """Return list of triples (eigenval, multiplicity, basis).
 
         The flag ``simplify`` has two effects:
@@ -1218,12 +1218,12 @@ class MatrixEigen(MatrixSubspaces):
         def eigenspace(eigenval):
             """Get a basis for the eigenspace for a particular eigenvalue"""
             m = mat - self.eye(mat.rows) * eigenval
-            ret = m.nullspace()
+            ret = m.nullspace(iszerofunc=iszerofunc)
             # the nullspace for a real eigenvalue should be
             # non-trivial.  If we didn't find an eigenvector, try once
             # more a little harder
             if len(ret) == 0 and simplify:
-                ret = m.nullspace(simplify=True)
+                ret = m.nullspace(iszerofunc=iszerofunc, simplify=True)
             if len(ret) == 0:
                 raise NotImplementedError(
                         "Can't evaluate eigenvector for eigenvalue %s" % eigenval)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -932,7 +932,7 @@ class MatrixSubspaces(MatrixReductions):
 
         return [self.col(i) for i in pivots]
 
-    def nullspace(self, simplify=False):
+    def nullspace(self, iszerofunc=_iszero, simplify=False):
         """Returns list of vectors (Matrix objects) that span nullspace of self
 
         Examples
@@ -958,7 +958,7 @@ class MatrixSubspaces(MatrixReductions):
         rowspace
         """
 
-        reduced, pivots = self.rref(simplify=simplify)
+        reduced, pivots = self.rref(iszerofunc=iszerofunc, simplify=simplify)
 
         free_vars = [i for i in range(self.cols) if i not in pivots]
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#15141, #10120, [Gitter](https://gitter.im/sympy/sympy?at=5b7c3e8ee5b40332abdb206c)

#### Brief description of what is fixed or changed

The unreliability of zero detection of symbolic expression would be one of the clear reason matrix operations relying on gaussian elimination method failing.

However, in some circumstances, injecting some user-specified ad-hoc zero testing method can be a possible solution, as in below.

```
from sympy import *

q = Symbol("q", positive = True)
m = Matrix([
[-2*cosh(q/3),      exp(-q),            1],
[      exp(q), -2*cosh(q/3),            1],
[           1,            1, -2*cosh(q/3)]])
```
```
m.nullspace() #Wrong Result
```
```
def my_iszero(x):
    if isinstance(x, Expr):
        result = simplify(x.rewrite(exp)).is_zero
    else:
        result = x == 0
    return result

m.nullspace(iszerofunc=my_iszero) #Correct Result
```
Though this change would only encourage highly manual work from the user end, however, since the [Richardson's Theorem](https://en.wikipedia.org/wiki/Richardson%27s_theorem) clearly states that there would be no general solution for zero testing, I think that it is totally natural that zero testing should be manual, dealing with uncertainty if anything gets automated.

And it would be only approach if introducing some strategies as default would cause performance degradation.

#### Other comments

Not only these two methods, I have found other numerous methods in `matrices.py` dependent on either `_iszero` or `rref`, but they mask `iszerofunc` keyword.

If you agree on my initial idea, I would also plan on every `iszerofunc` keyword explicit in the module.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. If there is no release notes entry for this PR,
write "NO ENTRY". The bot will check your release notes automatically to see
if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- matrices
  - Added `iszerofunc` parameter for `nullspace()` and `eigenvects()`

<!-- END RELEASE NOTES -->
