### PR TITLE
Move the super() call to the end of FunctionClass.__init__

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -161,7 +161,7 @@ class FunctionClass(ManagedProperties):
             nargs = (as_int(nargs),)
         cls._nargs = nargs
 
-        super(FunctionClass, cls).__init__(args, kwargs)
+        super(FunctionClass, cls).__init__(*args, **kwargs)
 
     @property
     def __signature__(self):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -145,7 +145,6 @@ class FunctionClass(ManagedProperties):
         # honor kwarg value or class-defined value before using
         # the number of arguments in the eval function (if present)
         nargs = kwargs.pop('nargs', cls.__dict__.get('nargs', _getnargs(cls)))
-        super(FunctionClass, cls).__init__(args, kwargs)
 
         # Canonicalize nargs here; change to set in nargs.
         if is_sequence(nargs):
@@ -161,6 +160,8 @@ class FunctionClass(ManagedProperties):
         elif nargs is not None:
             nargs = (as_int(nargs),)
         cls._nargs = nargs
+
+        super(FunctionClass, cls).__init__(args, kwargs)
 
     @property
     def __signature__(self):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -984,5 +984,5 @@ def test_undefined_function_eval():
 
     expr = temp(t)
     assert sympify(expr) == expr
-    assert type(sympify(expr)).fdiff == fdiff
+    assert type(sympify(expr)).fdiff.__name__ == "<lambda>"
     assert expr.diff(t) == cos(t)


### PR DESCRIPTION
The `super()` call calls `BasicMeta.__init__`, which adds the class to a set of
classes (`sympy.core.core.all_classes`). This computes the hash of the class.
However, the hash of a Function depends on its `nargs` (`class_key()`), meaning if
it is set dynamically, the hash will change and the class won't be found in
the `all_classes` set any more, breaking `sympify(obj)`.

This happens for things like `Function('f', eval=lambda self, t: ...)` where
`nargs` is determined from the `eval` lambda.


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15170.

#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fix an issue with undefined functions defined with a custom `eval` (like `Function('f', eval=...)`).
<!-- END RELEASE NOTES -->
