### PR TITLE
Generalize grover algorithm for an unknown function

### DIFF
--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -329,33 +329,33 @@ def apply_grover(oracle, nqubits, iterations=None):
 def random_oracle(nqubits, min_img=1, max_img=1, q_type='bin'):
     """Create a random OracleGate under the given parameter
 
-        Parameters
-        ==========
+    Parameters
+    ==========
 
-        nqubits : int
-            The number of qubits for OracleGate
-        min_pic : int
-            Minimum number of invers images that are mapped to 1
-        max_pic : int
-            Maximum number of invers images that are mapped to 1
-        q_type : OracleGate
-            Type of the Qubits that the oracle should be applied on.
-            Can be 'bin' for binary (Qubit()) or 'int' for integer (IntQubit()).
+    nqubits : int
+        The number of qubits for OracleGate
+    min_pic : int
+        Minimum number of invers images that are mapped to 1
+    max_pic : int
+        Maximum number of invers images that are mapped to 1
+    q_type : OracleGate
+        Type of the Qubits that the oracle should be applied on.
+        Can be 'bin' for binary (Qubit()) or 'int' for integer (IntQubit()).
 
-        Returns
-        =======
+    Returns
+    =======
 
-        OracleGate : random OracleGate under the given parameter
+    OracleGate : random OracleGate under the given parameter
 
-        Examples
-        ========
+    Examples
+    ========
 
-        Generate random OracleGate that outputs 1 for 2-4 inputs::
+    Generate random OracleGate that outputs 1 for 2-4 inputs::
 
-            >>> from sympy.physics.quantum.grover import random_oracle
-            >>> oracle = random_oracle(4, min_img=2, max_img=4, q_type="bin")
+        >>> from sympy.physics.quantum.grover import random_oracle
+        >>> oracle = random_oracle(4, min_img=2, max_img=4, q_type="bin")
 
-        """
+    """
     if q_type != 'bin' and q_type != 'int':
         raise QuantumError("q_type must be 'int' or 'bin'")
 
@@ -386,34 +386,35 @@ def g_bbht_search(qstate, oracle):
     G-BBHT-Search is an algorithm based on Grover's algorithm,
     but designed for an unknown oracle function that returns 1
     for an unknown number of qubit states. Its based on this
-    paper: Boyer, M., Brassard, G., Høyer, P., & Tapp, A. (1998).
-    Tight bounds on quantum searching. Fortschritte der Physik:
-    Progress of Physics, 46(4‐5), 493-505.
+    paper: Boyer, M., Brassard, G., Hoyer, P.,  Tapp, A. (1998).
+    Tight bounds on quantum searching: Progress of Physics,
+    46(4-5), 493-505.
 
-        Parameters
-        ==========
+    Parameters
+    ==========
 
-        qstate : Qubit
-            State the G-BBHT-Search should be applied on
-        oracle : OracleGate
-            The black box operator that flips the sign of the desired basis qubits.
+    qstate : Qubit
+        State the G-BBHT-Search should be applied on
+    oracle : OracleGate
+        The black box operator that flips the sign of the desired basis qubits.
 
-        Returns
-        =======
+    Returns
+    =======
 
-        (Qubit, int) : (single Qubit that fullfilles oracle, numberof grover iterations applied)
+    (Qubit, int) : (single Qubit that fullfilles oracle, numberof grover iterations applied)
 
-        Examples
-        ========
+    Examples
+    ========
 
-        G-BBHT-Search for a orcale that returns 1 for a unkown number of statesbetween 5 - 15::
+    G-BBHT-Search for a orcale that returns 1 for a unkown number of statesbetween 5 - 15::
 
-            >>> basis_states = superposition_basis(5)
-            >>> oracle = random_oracle(5, min_img=5, max_img=15, q_type="bin")
-            >>> g_bbht_search(basis_states, oracle)
-            (|00111>, 1)
+        >>> from sympy.physics.quantum.grover import random_oracle, superposition_basis, g_bbht_search
+        >>> basis_states = superposition_basis(5)
+        >>> oracle = random_oracle(5, min_img=5, max_img=15, q_type="bin")
+        >>> g_bbht_search(basis_states, oracle)
+        (|00111>, 1)
 
-        """
+    """
     import random
     import math
     from sympy.physics.quantum.qubit import measure_all_oneshot
@@ -423,7 +424,7 @@ def g_bbht_search(qstate, oracle):
     count_grover_iterations = 0
 
     while True:
-        for _ in range(random.choice(list(range(0, math.ceil(max_iterations))))):
+        for _ in range(random.choice(list(range(0, int(math.ceil(max_iterations)))))):
             count_grover_iterations += 1
             qstate = qapply(grover_iteration(qstate, oracle))
 

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -411,8 +411,9 @@ def g_bbht_search(qstate, oracle):
         >>> from sympy.physics.quantum.grover import random_oracle, superposition_basis, g_bbht_search
         >>> basis_states = superposition_basis(5)
         >>> oracle = random_oracle(5, min_img=5, max_img=15, q_type="bin")
-        >>> g_bbht_search(basis_states, oracle)
-        (|00111>, 1)
+        >>> x = g_bbht_search(basis_states, oracle)[0]
+        >>> oracle.search_function(x)
+        True
 
     """
     import random

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -369,13 +369,12 @@ def random_oracle(nqubits, min_img=1, max_img=1, q_type='bin'):
         raise QuantumError("min_pic must be < 2**nqubits and max_pic must be <= 2**nqubits")
 
     import random
-
-    integers = list(range(nqubits ** 2))
     pics = random.randint(min_img, max_img)
+    integers = random.sample(range(2 ** nqubits), pics)
     if q_type == "int":
-        items = [IntQubit(integers.pop(integers.index(random.choice(integers))), nqubits) for _ in range(pics)]
+        items = [IntQubit(integers.pop()) for _ in range(pics)]
     else:
-        items = [Qubit(IntQubit(integers.pop(integers.index(random.choice(integers))), nqubits)) for _ in range(pics)]
+        items = [Qubit(IntQubit(integers.pop())) for _ in range(pics)]
 
     return OracleGate(nqubits, lambda qubits: qubits in items)
 

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -420,11 +420,11 @@ def g_bbht_search(qstate, oracle):
     from sympy.physics.quantum.qubit import measure_all_oneshot
 
     max_iterations = 1
-    factor_iterations = 6 / 5
+    factor_iterations = 6.0 / 5.0
     count_grover_iterations = 0
 
     while True:
-        for _ in range(random.choice(list(range(0, int(math.ceil(max_iterations)))))):
+        for _ in range(random.choice(list(range(int(math.ceil(max_iterations)))))):
             count_grover_iterations += 1
             qstate = qapply(grover_iteration(qstate, oracle))
 

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -409,8 +409,8 @@ def g_bbht_search(qstate, oracle):
     G-BBHT-Search for a orcale that returns 1 for a unkown number of statesbetween 5 - 15::
 
         >>> from sympy.physics.quantum.grover import random_oracle, superposition_basis, g_bbht_search
-        >>> basis_states = superposition_basis(5)
-        >>> oracle = random_oracle(5, min_img=5, max_img=15, q_type="bin")
+        >>> basis_states = superposition_basis(4)
+        >>> oracle = random_oracle(4, min_img=5, max_img=15, q_type="bin")
         >>> x = g_bbht_search(basis_states, oracle)[0]
         >>> oracle.search_function(x)
         True

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -335,9 +335,9 @@ def random_oracle(nqubits, min_img=1, max_img=1, q_type='bin'):
     nqubits : int
         The number of qubits for OracleGate
     min_pic : int
-        Minimum number of invers images that are mapped to 1
+        Minimum number of inverse images that are mapped to 1
     max_pic : int
-        Maximum number of invers images that are mapped to 1
+        Maximum number of inverse images that are mapped to 1
     q_type : OracleGate
         Type of the Qubits that the oracle should be applied on.
         Can be 'bin' for binary (Qubit()) or 'int' for integer (IntQubit()).
@@ -384,7 +384,7 @@ def g_bbht_search(qstate, oracle):
 
     G-BBHT-Search is an algorithm based on Grover's algorithm,
     but designed for an unknown oracle function that returns 1
-    for an unknown number of qubit states. Its based on this
+    for an unknown number of qubit states. It is based on the
     paper: Boyer, M., Brassard, G., Hoyer, P.,  Tapp, A. (1998).
     Tight bounds on quantum searching: Progress of Physics,
     46(4-5), 493-505.
@@ -400,12 +400,12 @@ def g_bbht_search(qstate, oracle):
     Returns
     =======
 
-    (Qubit, int) : (single Qubit that fullfilles oracle, numberof grover iterations applied)
+    (Qubit, int) : (single Qubit that fulfills oracle, number of grover iterations applied)
 
     Examples
     ========
 
-    G-BBHT-Search for a orcale that returns 1 for a unkown number of statesbetween 5 - 15::
+    G-BBHT-Search for an orcale that returns 1 for an unkown number of statesbetween 5 - 15::
 
         >>> from sympy.physics.quantum.grover import random_oracle, superposition_basis, g_bbht_search
         >>> basis_states = superposition_basis(4)
@@ -416,7 +416,6 @@ def g_bbht_search(qstate, oracle):
 
     """
     import random
-    import math
     from sympy.physics.quantum.qubit import measure_all_oneshot
 
     max_iterations = 1
@@ -424,7 +423,7 @@ def g_bbht_search(qstate, oracle):
     count_grover_iterations = 0
 
     while True:
-        for _ in range(random.choice(list(range(int(math.ceil(max_iterations)))))):
+        for _ in range(1 if max_iterations == 1 else random.randint(0, int(max_iterations))):
             count_grover_iterations += 1
             qstate = qapply(grover_iteration(qstate, oracle))
 

--- a/sympy/physics/quantum/grover.py
+++ b/sympy/physics/quantum/grover.py
@@ -372,9 +372,9 @@ def random_oracle(nqubits, min_img=1, max_img=1, q_type='bin'):
     pics = random.randint(min_img, max_img)
     integers = random.sample(range(2 ** nqubits), pics)
     if q_type == "int":
-        items = [IntQubit(integers.pop()) for _ in range(pics)]
+        items = [IntQubit(i) for i in integers]
     else:
-        items = [Qubit(IntQubit(integers.pop())) for _ in range(pics)]
+        items = [Qubit(IntQubit(i)) for i in integers]
 
     return OracleGate(nqubits, lambda qubits: qubits in items)
 

--- a/sympy/physics/quantum/tests/test_grover.py
+++ b/sympy/physics/quantum/tests/test_grover.py
@@ -3,7 +3,7 @@ from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qubit import IntQubit
 from sympy.physics.quantum.grover import (apply_grover, superposition_basis,
-        OracleGate, grover_iteration, WGate)
+        OracleGate, grover_iteration, WGate, random_oracle, g_bbht_search)
 
 
 def return_one_on_two(qubits):
@@ -80,6 +80,11 @@ def test_grover_iteration_2():
     expected = (-13*basis_states)/64 + 264*IntQubit(2, numqubits)/256
     assert qapply(expected) == iterated
 
+def test_g_bbht_search(nqubits=5):
+    basis_states = superposition_basis(nqubits)
+    oracle = random_oracle(nqubits, min_img=5, max_img=15, q_type="bin")
+    x = g_bbht_search(basis_states, oracle)[0]
+    assert oracle.search_function(x) == 1
 
 def test_grover():
     nqubits = 2


### PR DESCRIPTION
I've implemented the todo 'Generalize the algorithm for an unknown function that returns 1 on multiple qubit states, not just one.'

in grover.py with the methode described in this Paper: Boyer, M., Brassard, G., Høyer, P., & Tapp, A. (1998). Tight bounds on
quantum searching. Fortschritte der Physik: Progress of Physics, 46(4‐5), 493-505.
I've deletet the correspondig todos

To make testing easier I also wrote a method that can generate a random OracleGate (which can also maps more then on state to 1)

Both methodes are documented and with examples

I also added a simple test in the test_grover.py vor the G_BBHT_Search

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
    * added function for G_BBHT_Search: Generalize grover algorithm for an unknown function
    * added function for generating a random OracleGate 
<!-- END RELEASE NOTES -->
