### PR TITLE
Partitioned test_matplotlib into chunks

### DIFF
--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -36,7 +36,7 @@ class TmpFileManager:
                 # If the file doesn't exist, for instance, if the test failed.
                 pass
 
-def plot_and_save(name):
+def plot_and_save_1(name):
     tmp_file = TmpFileManager.tmp_file
 
     x = Symbol('x')
@@ -105,6 +105,13 @@ def plot_and_save(name):
     p = plot(f, (x, -3, 3))
     p.save(tmp_file('%s_plot_piecewise_3' % name))
     p._backend.close()
+
+def plot_and_save(name):
+    tmp_file = TmpFileManager.tmp_file
+
+    x = Symbol('x')
+    y = Symbol('y')
+    z = Symbol('z')
 
     #parametric 2d plots.
     #Single plot with default range.

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -350,12 +350,12 @@ def test_matplotlib_3():
     else:
         skip("Matplotlib not the default backend")
 
-def test_matplotlib():
+def test_matplotlib_4():
 
     matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
     if matplotlib:
         try:
-            plot_and_save('test')
+            plot_and_save_4('test')
         finally:
             # clean up
             TmpFileManager.cleanup()

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -289,6 +289,13 @@ def plot_and_save_4(name):
             assert issubclass(i.category, UserWarning)
             assert "The evaluation of the expression is problematic" in str(i.message)
 
+def plot_and_save_5(name):
+    tmp_file = TmpFileManager.tmp_file
+
+    x = Symbol('x')
+    y = Symbol('y')
+    z = Symbol('z')
+
     s = Sum(1/x**y, (x, 1, oo))
     p = plot(s, (y, 2, 10))
     p.save(tmp_file('%s_advanced_inf_sum' % name))
@@ -363,6 +370,18 @@ def test_matplotlib_4():
     if matplotlib:
         try:
             plot_and_save_4('test')
+        finally:
+            # clean up
+            TmpFileManager.cleanup()
+    else:
+        skip("Matplotlib not the default backend")
+
+def test_matplotlib_5():
+
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if matplotlib:
+        try:
+            plot_and_save_5('test')
         finally:
             # clean up
             TmpFileManager.cleanup()

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -319,6 +319,18 @@ def test_matplotlib_1():
     else:
         skip("Matplotlib not the default backend")
 
+def test_matplotlib_2():
+
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if matplotlib:
+        try:
+            plot_and_save_2('test')
+        finally:
+            # clean up
+            TmpFileManager.cleanup()
+    else:
+        skip("Matplotlib not the default backend")
+
 def test_matplotlib():
 
     matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -262,7 +262,7 @@ def plot_and_save_3(name):
     p.save(tmp_file('%s_colors_param_surf_arity3' % name))
     p._backend.close()
 
-def plot_and_save(name):
+def plot_and_save_4(name):
     tmp_file = TmpFileManager.tmp_file
 
     x = Symbol('x')

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -300,7 +300,7 @@ def plot_and_save_4(name):
     p.save(tmp_file('%s_advanced_fin_sum' % name))
     p._backend.close()
 
-def plot_and_save_5(name):
+def plot_and_save_6(name):
     tmp_file = TmpFileManager.tmp_file
 
     x = Symbol('x')
@@ -369,12 +369,12 @@ def test_matplotlib_4():
     else:
         skip("Matplotlib not the default backend")
 
-def test_matplotlib_5():
+def test_matplotlib_6():
 
     matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
     if matplotlib:
         try:
-            plot_and_save_5('test')
+            plot_and_save_6('test')
         finally:
             # clean up
             TmpFileManager.cleanup()

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -106,7 +106,7 @@ def plot_and_save_1(name):
     p.save(tmp_file('%s_plot_piecewise_3' % name))
     p._backend.close()
 
-def plot_and_save(name):
+def plot_and_save_2(name):
     tmp_file = TmpFileManager.tmp_file
 
     x = Symbol('x')
@@ -198,6 +198,13 @@ def plot_and_save(name):
     p = plot_contour((x**2 + y**2, (x, -5, 5), (y, -5, 5)), (x**3 + y**3, (x, -3, 3), (y, -3, 3)))
     p.save(tmp_file('%s_contour_plot' % name))
     p._backend.close()
+
+def plot_and_save(name):
+    tmp_file = TmpFileManager.tmp_file
+
+    x = Symbol('x')
+    y = Symbol('y')
+    z = Symbol('z')
 
     ###
     # Examples from the 'colors' notebook

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -338,6 +338,18 @@ def test_matplotlib_2():
     else:
         skip("Matplotlib not the default backend")
 
+def test_matplotlib_3():
+
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if matplotlib:
+        try:
+            plot_and_save_3('test')
+        finally:
+            # clean up
+            TmpFileManager.cleanup()
+    else:
+        skip("Matplotlib not the default backend")
+
 def test_matplotlib():
 
     matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -199,7 +199,7 @@ def plot_and_save_2(name):
     p.save(tmp_file('%s_contour_plot' % name))
     p._backend.close()
 
-def plot_and_save(name):
+def plot_and_save_3(name):
     tmp_file = TmpFileManager.tmp_file
 
     x = Symbol('x')
@@ -261,6 +261,13 @@ def plot_and_save(name):
     p[0].surface_color = lambdify_((x, y, z), sqrt(x**2 + y**2 + z**2))
     p.save(tmp_file('%s_colors_param_surf_arity3' % name))
     p._backend.close()
+
+def plot_and_save(name):
+    tmp_file = TmpFileManager.tmp_file
+
+    x = Symbol('x')
+    y = Symbol('y')
+    z = Symbol('z')
 
     ###
     # Examples from the 'advanced' notebook

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -300,6 +300,13 @@ def plot_and_save_4(name):
     p.save(tmp_file('%s_advanced_fin_sum' % name))
     p._backend.close()
 
+def plot_and_save_5(name):
+    tmp_file = TmpFileManager.tmp_file
+
+    x = Symbol('x')
+    y = Symbol('y')
+    z = Symbol('z')
+
     ###
     # Test expressions that can not be translated to np and generate complex
     # results.
@@ -356,6 +363,18 @@ def test_matplotlib_4():
     if matplotlib:
         try:
             plot_and_save_4('test')
+        finally:
+            # clean up
+            TmpFileManager.cleanup()
+    else:
+        skip("Matplotlib not the default backend")
+
+def test_matplotlib_5():
+
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if matplotlib:
+        try:
+            plot_and_save_5('test')
         finally:
             # clean up
             TmpFileManager.cleanup()

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -300,6 +300,18 @@ def plot_and_save(name):
             + meijerg(((1/2,), ()), ((5, 0, 1/2), ()),
                 5*x**2 * exp_polar(I*pi)/2)) / (48 * pi), (x, 1e-6, 1e-2)).save(tmp_file())
 
+def test_matplotlib_1():
+
+    matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))
+    if matplotlib:
+        try:
+            plot_and_save_1('test')
+        finally:
+            # clean up
+            TmpFileManager.cleanup()
+    else:
+        skip("Matplotlib not the default backend")
+
 def test_matplotlib():
 
     matplotlib = import_module('matplotlib', min_module_version='1.1.0', catch=(RuntimeError,))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15157 

#### Brief description of what is fixed or changed

Slow plotting test from `test_matplotlib()` had caused timeouts of travis test.
I had split the test into chunks.
Each chunks would contain according plots in some context.
And I had also separated some singular ones especially causing slowdowns.

```
from sympy import *
from sympy.plotting.tests.test_plot import (
    test_matplotlib_1,
    test_matplotlib_2,
    test_matplotlib_3,
    test_matplotlib_4,
    test_matplotlib_5,
    test_matplotlib_6,
)
import cProfile
```
I had profiled each chunk, to see how much time each consumes.

`cProfile.run('test_matplotlib_1()')`
`3728712 function calls (3538533 primitive calls) in 2.892 seconds`

`cProfile.run('test_matplotlib_2()')`
`5065657 function calls (5023640 primitive calls) in 3.994 seconds`

`cProfile.run('test_matplotlib_3()')`
`3599549 function calls (3567069 primitive calls) in 3.046 seconds`

`cProfile.run('test_matplotlib_4()')`
`114295797 function calls (111800749 primitive calls) in 63.097 seconds`

`cProfile.run('test_matplotlib_5()')`
`58893695 function calls (56346966 primitive calls) in 47.473 seconds`

`cProfile.run('test_matplotlib_6()')`
`15024550 function calls (14673172 primitive calls) in 10.916 seconds`

You can clearly see that 4th and 5th partitions were the main reasons of slowdown.
The total time consumed would be abruptly 120 seconds, which equals to measure from my issue #15157 .
Splitting out in half would make timeouts less likely to happen, and also branching out some minor things would further make it ease.

However, repetitions in `test_matplotlib` and `plot_and_save` can possibly be factored.
But I don't think that it is possible to make any consensus with ones in `test_plot_implicit.py`,
because this one clearly has many tests about mutating properties of plots. 

#### Other comments

There can also be some performance bottleneck in `plot` itself,
as I don't find much reason that the two tests are taking extraordinarily long time than its context.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
