### PR TITLE
Parsing:Improved variable naming in autolev parser

### DIFF
--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -19,9 +19,9 @@ def strfunc(z):
     if z == 0:
         return ""
     elif z == 1:
-        return "d"
+        return "_d"
     else:
-        return "d" * str(z)
+        return "_d" * str(z)
 
 def declare_phy_entities(self, ctx, phy_type, i, j=None):
     if phy_type in ("frame", "newtonian"):
@@ -744,7 +744,7 @@ if AutolevListener:
                                   ", " + self.getValue(ch.expr(1)) + ")")
 
             # D(y, x)
-            elif func_name == "_d":
+            elif func_name == "d":
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -439,10 +439,10 @@ if AutolevListener:
             self.explicit = collections.OrderedDict()
 
             # Write code to import common dependencies.
-            self.output_code.append("import sympy.physics.mechanics as me\n")
-            self.output_code.append("import sympy as sm\n")
+            self.output_code.append("import sympy.physics.mechanics as _me\n")
+            self.output_code.append("import sympy as _sm\n")
             self.output_code.append("import math as m\n")
-            self.output_code.append("import numpy as np\n")
+            self.output_code.append("import numpy as _np\n")
             self.output_code.append("\n")
 
             # Just a store for the max degree variable in a line.

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -19,9 +19,9 @@ def strfunc(z):
     if z == 0:
         return ""
     elif z == 1:
-        return "_d"
+        return "d"
     else:
-        return "_d" * str(z)
+        return "d" * str(z)
 
 def declare_phy_entities(self, ctx, phy_type, i, j=None):
     if phy_type in ("frame", "newtonian"):

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -19,9 +19,9 @@ def strfunc(z):
     if z == 0:
         return ""
     elif z == 1:
-        return "d"
+        return "_d"
     else:
-        return "d" + str(z)
+        return "_d" * str(z)
 
 def declare_phy_entities(self, ctx, phy_type, i, j=None):
     if phy_type in ("frame", "newtonian"):
@@ -52,7 +52,7 @@ def declare_frames(self, ctx, i, j=None):
     self.symbol_table.update({name1 + "3>": name2 + ".z"})
 
     self.type2.update({name1: "frame"})
-    self.write(name2 + " = " + "me.ReferenceFrame('" + name1 + "')\n")
+    self.write(name2 + " = " + "_me.ReferenceFrame('" + name1 + "')\n")
 
 def declare_points(self, ctx, i, j=None):
     if "{" in ctx.getText():
@@ -67,7 +67,7 @@ def declare_points(self, ctx, i, j=None):
 
     self.symbol_table2.update({name1: name2})
     self.type2.update({name1: "point"})
-    self.write(name2 + " = " + "me.Point('" + name1 + "')\n")
+    self.write(name2 + " = " + "_me.Point('" + name1 + "')\n")
 
 def declare_particles(self, ctx, i, j=None):
     if "{" in ctx.getText():
@@ -83,8 +83,8 @@ def declare_particles(self, ctx, i, j=None):
     self.symbol_table2.update({name1: name2})
     self.type2.update({name1: "particle"})
     self.bodies.update({name1: name2})
-    self.write(name2 + " = " + "me.Particle('" + name1 + "', " + "me.Point('" +
-                name1 + "_pt" + "'), " + "sm.Symbol('m'))\n")
+    self.write(name2 + " = " + "_me.Particle('" + name1 + "', " + "_me.Point('" +
+                name1 + "_pt" + "'), " + "_sm.Symbol('m'))\n")
 
 def declare_bodies(self, ctx, i, j=None):
     if "{" in ctx.getText():
@@ -109,20 +109,20 @@ def declare_bodies(self, ctx, i, j=None):
     self.type2.update({name1: "bodies"})
     self.type2.update({name1+"o": "point"})
 
-    self.write(masscenter + " = " + "me.Point('" + name1 + "_cm" + "')\n")
+    self.write(masscenter + " = " + "_me.Point('" + name1 + "_cm" + "')\n")
     if self.newtonian:
         self.write(masscenter + ".set_vel(" + self.newtonian + ", " + "0)\n")
-    self.write(refFrame + " = " + "me.ReferenceFrame('" + name1 + "_f" + "')\n")
+    self.write(refFrame + " = " + "_me.ReferenceFrame('" + name1 + "_f" + "')\n")
     # We set a dummy mass and inertia here.
     # They will be reset using the setters later in the code anyway.
-    self.write(name2 + " = " + "me.RigidBody('" + name1 + "', " + masscenter + ", " +
-                refFrame + ", " + "sm.symbols('m'), (me.outer(" + refFrame +
+    self.write(name2 + " = " + "_me.RigidBody('" + name1 + "', " + masscenter + ", " +
+                refFrame + ", " + "_sm.symbols('m'), (_me.outer(" + refFrame +
                 ".x," + refFrame + ".x)," + masscenter + "))\n")
 
 def inertia_func(self, v1, v2, l, frame):
 
     if self.type2[v1] == "particle":
-        l.append("me.inertia_of_point_mass(" + self.bodies[v1] + ".mass, " + self.bodies[v1] +
+        l.append("_me.inertia_of_point_mass(" + self.bodies[v1] + ".mass, " + self.bodies[v1] +
                  ".point.pos_from(" + self.symbol_table2[v2] + "), " + frame + ")")
 
     elif self.type2[v1] == "bodies":
@@ -135,7 +135,7 @@ def inertia_func(self, v1, v2, l, frame):
             # Asking point is not cm
             else:
                 l.append(self.bodies[v1] + ".inertia[0]" + " + " +
-                         "me.inertia_of_point_mass(" + self.bodies[v1] +
+                         "_me.inertia_of_point_mass(" + self.bodies[v1] +
                          ".mass, " + self.bodies[v1] + ".masscenter" +
                          ".pos_from(" + self.symbol_table2[v2] +
                          "), " + frame + ")")
@@ -148,18 +148,18 @@ def inertia_func(self, v1, v2, l, frame):
             # Asking point is cm
             elif v2 == v1 + "o":
                 l.append(self.bodies[v1] + ".inertia[0]" + " - " +
-                         "me.inertia_of_point_mass(" + self.bodies[v1] +
+                         "_me.inertia_of_point_mass(" + self.bodies[v1] +
                          ".mass, " + self.bodies[v1] + ".masscenter" +
                          ".pos_from(" + self.symbol_table2[self.inertia_point[v1]] +
                          "), " + frame + ")")
             # Asking point is some other point
             else:
                 l.append(self.bodies[v1] + ".inertia[0]" + " - " +
-                         "me.inertia_of_point_mass(" + self.bodies[v1] +
+                         "_me.inertia_of_point_mass(" + self.bodies[v1] +
                          ".mass, " + self.bodies[v1] + ".masscenter" +
                          ".pos_from(" + self.symbol_table2[self.inertia_point[v1]] +
                          "), " + frame + ")" + " + " +
-                         "me.inertia_of_point_mass(" + self.bodies[v1] +
+                         "_me.inertia_of_point_mass(" + self.bodies[v1] +
                          ".mass, " + self.bodies[v1] + ".masscenter" +
                          ".pos_from(" + self.symbol_table2[v2] +
                          "), " + frame + ")")
@@ -171,7 +171,7 @@ def processConstants(self, ctx):
     if "=" in ctx.getText():
         self.symbol_table.update({name: name})
         # self.inputs.update({self.symbol_table[name]: self.getValue(ctx.getChild(2))})
-        self.write(self.symbol_table[name] + " = " + "sm.S(" + self.getValue(ctx.getChild(2)) + ")\n")
+        self.write(self.symbol_table[name] + " = " + "_sm.S(" + self.getValue(ctx.getChild(2)) + ")\n")
         self.type.update({name: "constants"})
         return
 
@@ -250,15 +250,15 @@ def writeConstants(self, ctx):
         real = ", real=True"
 
     if l1:
-        a = ", ".join(l1) + " = " + "sm.symbols(" + "'" +\
+        a = ", ".join(l1) + " = " + "_sm.symbols(" + "'" +\
             " ".join(l1) + "'" + real + ")\n"
         self.write(a)
     if l2:
-        a = ", ".join(l2) + " = " + "sm.symbols(" + "'" +\
+        a = ", ".join(l2) + " = " + "_sm.symbols(" + "'" +\
             " ".join(l2) + "'" + real + ", nonnegative=True)\n"
         self.write(a)
     if l3:
-        a = ", ".join(l3) + " = " + "sm.symbols(" + "'" + \
+        a = ", ".join(l3) + " = " + "_sm.symbols(" + "'" + \
             " ".join(l3) + "'" + real + ", nonpositive=True)\n"
         self.write(a)
     self.var_list = []
@@ -377,7 +377,7 @@ def writeVariables(self, ctx):
                 if i > 1:
                     l.append(k[:-2])
             a = ", ".join(list(filter(lambda x: self.sign[x] == i, self.var_list))) + " = " +\
-                "me.dynamicsymbols(" + "'" + " ".join(l) + "'" + t + j + ")\n"
+                "_me.dynamicsymbols(" + "'" + " ".join(l) + "'" + t + j + ")\n"
             l = []
             self.write(a)
         self.maxDegree = 0
@@ -391,9 +391,9 @@ def processImaginary(self, ctx):
 
 
 def writeImaginary(self, ctx):
-    a = ", ".join(self.var_list) + " = " + "sm.symbols(" + "'" + \
+    a = ", ".join(self.var_list) + " = " + "_sm.symbols(" + "'" + \
         " ".join(self.var_list) + "')\n"
-    b = ", ".join(self.var_list) + " = " + "sm.I\n"
+    b = ", ".join(self.var_list) + " = " + "_sm.I\n"
     self.write(a)
     self.write(b)
     self.var_list = []
@@ -599,12 +599,12 @@ if AutolevListener:
             else:
                 # Reserved constant Pi
                 if ctx.ID().getText().lower() == "pi":
-                    self.setValue(ctx, "sm.pi")
+                    self.setValue(ctx, "_sm.pi")
                     self.numeric_expr.append(ctx)
 
                 # Reserved variable T (for time)
                 elif ctx.ID().getText().lower() == "t":
-                    self.setValue(ctx, "me.dynamicsymbols._t")
+                    self.setValue(ctx, "_me.dynamicsymbols._t")
                     if not self.in_inputs and not self.in_outputs:
                         self.t = True
 
@@ -652,7 +652,7 @@ if AutolevListener:
             # The subrule is expr = expr (*|/) expr
             try:
                 if ctx.expr(0) in self.vector_expr and ctx.expr(1) in self.vector_expr:
-                    self.setValue(ctx, "me.outer(" + self.getValue(ctx.expr(0)) + ", " +
+                    self.setValue(ctx, "_me.outer(" + self.getValue(ctx.expr(0)) + ", " +
                                   self.getValue(ctx.expr(1)) + ")")
                 else:
                     if ctx.expr(0) in self.matrix_expr or ctx.expr(1) in self.matrix_expr:
@@ -726,8 +726,8 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    # sm.Matrix([i.expand() for i in z]).reshape(z.shape[0], z.shape[1])
-                    self.setValue(ctx, "sm.Matrix([i.expand() for i in " + expr + "])" +
+                    # _sm.Matrix([i.expand() for i in z]).reshape(z.shape[0], z.shape[1])
+                    self.setValue(ctx, "_sm.Matrix([i.expand() for i in " + expr + "])" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
                     self.setValue(ctx, "(" + expr + ")" + "." + "expand()")
@@ -737,18 +737,18 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([sm.factor(i, " + self.getValue(ch.expr(1)) + ") for i in " +
+                    self.setValue(ctx, "_sm.Matrix([_sm.factor(i, " + self.getValue(ch.expr(1)) + ") for i in " +
                                   expr + "])" + ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
-                    self.setValue(ctx, "sm.factor(" + "(" + expr + ")" +
+                    self.setValue(ctx, "_sm.factor(" + "(" + expr + ")" +
                                   ", " + self.getValue(ch.expr(1)) + ")")
 
             # D(y, x)
-            elif func_name == "d":
+            elif func_name == "_d":
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.diff(" + self.getValue(ch.expr(1)) + ") for i in " +
+                    self.setValue(ctx, "_sm.Matrix([i.diff(" + self.getValue(ch.expr(1)) + ") for i in " +
                                   expr + "])" + ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
                     if ch.getChildCount() == 8:
@@ -765,10 +765,10 @@ if AutolevListener:
                 if ch.expr(0) in self.vector_expr:
                     text = "dt("
                 else:
-                    text = "diff(sm.Symbol('t')"
+                    text = "diff(_sm.Symbol('t')"
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i." + text +
+                    self.setValue(ctx, "_sm.Matrix([i." + text +
                                   ") for i in " + expr + "])" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -820,7 +820,7 @@ if AutolevListener:
 
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.subs({" + ",".join(l) + "}) for i in " +
+                    self.setValue(ctx, "_sm.Matrix([i.subs({" + ",".join(l) + "}) for i in " +
                                   expr + "])" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -835,7 +835,7 @@ if AutolevListener:
 
             # Polynomial([a, b, c], x)
             elif func_name == "polynomial":
-                self.setValue(ctx, "sm.Poly(" + self.getValue(ch.expr(0)) + ", " +
+                self.setValue(ctx, "_sm.Poly(" + self.getValue(ch.expr(0)) + ", " +
                               self.getValue(ch.expr(1)) + ")")
 
             # Roots(Poly, x, 2)
@@ -844,10 +844,10 @@ if AutolevListener:
                 self.matrix_expr.append(ctx)
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
-                    self.setValue(ctx, "[i.evalf() for i in " + "sm.solve(" +
-                                  "sm.Poly(" + expr + ", " + "x),x)]")
+                    self.setValue(ctx, "[i.evalf() for i in " + "_sm.solve(" +
+                                  "_sm.Poly(" + expr + ", " + "x),x)]")
                 else:
-                    self.setValue(ctx, "[i.evalf() for i in " + "sm.solve(" +
+                    self.setValue(ctx, "[i.evalf() for i in " + "_sm.solve(" +
                                   expr + ", " + self.getValue(ch.expr(1)) + ")]")
 
             # Transpose(A), Inv(A)
@@ -861,8 +861,8 @@ if AutolevListener:
 
             # Eig(A)
             elif func_name == "eig":
-                # "sm.Matrix([i.evalf() for i in " +
-                self.setValue(ctx, "sm.Matrix([i.evalf() for i in (" +
+                # "_sm.Matrix([i.evalf() for i in " +
+                self.setValue(ctx, "_sm.Matrix([i.evalf() for i in (" +
                               self.getValue(ch.expr(0)) + ").eigenvals().keys()])")
 
             # Diagmat(n, m, x)
@@ -874,14 +874,14 @@ if AutolevListener:
                     for i in range(int(self.getValue(ch.expr(0)))):
                         l.append(self.getValue(ch.expr(1)) + ",")
 
-                    self.setValue(ctx, "sm.diag(" + ("".join(l))[:-1] + ")")
+                    self.setValue(ctx, "_sm.diag(" + ("".join(l))[:-1] + ")")
 
                 elif ch.getChildCount() == 8:
-                    # sm.Matrix([x if i==j else 0 for i in range(n) for j in range(m)]).reshape(n, m)
+                    # _sm.Matrix([x if i==j else 0 for i in range(n) for j in range(m)]).reshape(n, m)
                     n = self.getValue(ch.expr(0))
                     m = self.getValue(ch.expr(1))
                     x = self.getValue(ch.expr(2))
-                    self.setValue(ctx, "sm.Matrix([" + x + " if i==j else 0 for i in range(" +
+                    self.setValue(ctx, "_sm.Matrix([" + x + " if i==j else 0 for i in range(" +
                                   n + ") for j in range(" + m + ")]).reshape(" + n + ", " + m + ")")
 
             # Cols(A)
@@ -914,7 +914,7 @@ if AutolevListener:
                                          "row(" + str(int(ch.getChild(i).getText())-1) + ")")
                         except Exception:
                             pass
-                    self.setValue(ctx, "sm.Matrix([" + ",".join(l) + "])")
+                    self.setValue(ctx, "_sm.Matrix([" + ",".join(l) + "])")
 
             # Det(A) Trace(A)
             elif func_name in ["det", "trace"]:
@@ -930,21 +930,21 @@ if AutolevListener:
             elif func_name in \
             ["cos", "sin", "tan", "cosh", "sinh", "tanh", "acos", "asin", "atan",
             "log", "exp", "sqrt", "factorial", "floor", "sign"]:
-                self.setValue(ctx, "sm." + func_name + "(" + self.getValue(ch.expr(0)) + ")")
+                self.setValue(ctx, "_sm." + func_name + "(" + self.getValue(ch.expr(0)) + ")")
 
             elif func_name == "ceil":
-                self.setValue(ctx, "sm.ceiling" + "(" + self.getValue(ch.expr(0)) + ")")
+                self.setValue(ctx, "_sm.ceiling" + "(" + self.getValue(ch.expr(0)) + ")")
 
             elif func_name == "sqr":
                 self.setValue(ctx, "(" + self.getValue(ch.expr(0)) +
                               ")" + "**2")
 
             elif func_name == "log10":
-                self.setValue(ctx, "sm.log" +
+                self.setValue(ctx, "_sm.log" +
                               "(" + self.getValue(ch.expr(0)) + ", 10)")
 
             elif func_name == "atan2":
-                self.setValue(ctx, "sm.atan2" + "(" + self.getValue(ch.expr(0)) + ", " +
+                self.setValue(ctx, "_sm.atan2" + "(" + self.getValue(ch.expr(0)) + ", " +
                               self.getValue(ch.expr(1)) + ")")
 
             elif func_name in ["int", "round"]:
@@ -952,7 +952,7 @@ if AutolevListener:
                               "(" + self.getValue(ch.expr(0)) + ")")
 
             elif func_name == "abs":
-                self.setValue(ctx, "sm.Abs(" + self.getValue(ch.expr(0)) + ")")
+                self.setValue(ctx, "_sm.Abs(" + self.getValue(ch.expr(0)) + ")")
 
             elif func_name in ["max", "min"]:
                 # max(x, y, z)
@@ -962,7 +962,7 @@ if AutolevListener:
                         l.append(self.getValue(ch.getChild(i)))
                     elif ch.getChild(i).getText() in [",", "(", ")"]:
                         l.append(ch.getChild(i).getText())
-                self.setValue(ctx, "sm." + ch.getChild(0).getText().capitalize() + "".join(l))
+                self.setValue(ctx, "_sm." + ch.getChild(0).getText().capitalize() + "".join(l))
 
             # Coef(y, x)
             elif func_name == "coef":
@@ -987,7 +987,7 @@ if AutolevListener:
                             # a41_a53[i,j] = u4.expand().coeff(u1)
                             l.append(self.getValue(ch.expr(0).getChild(0).expr(i)) + ".expand().coeff("
                                      + self.getValue(ch.expr(1).getChild(0).expr(j)) + ")")
-                    self.setValue(ctx, "sm.Matrix([" + ", ".join(l) + "]).reshape(" + str(icount) + ", " + str(jcount) + ")")
+                    self.setValue(ctx, "_sm.Matrix([" + ", ".join(l) + "]).reshape(" + str(icount) + ", " + str(jcount) + ")")
                 else:
                     self.setValue(ctx, "(" + self.getValue(ch.expr(0)) +
                                   ")" + ".expand().coeff(" + self.getValue(ch.expr(1)) + ")")
@@ -1001,7 +1001,7 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.collect(" + self.getValue(ch.expr(1)) + "])" +
+                    self.setValue(ctx, "_sm.Matrix([i.collect(" + self.getValue(ch.expr(1)) + "])" +
                                   ".coeff(" + self.getValue(ch.expr(1)) + "," + e + ")" + "for i in " + expr + ")" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -1018,7 +1018,7 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.collect(" + self.getValue(ch.expr(2)) +
+                    self.setValue(ctx, "_sm.Matrix([i.collect(" + self.getValue(ch.expr(2)) +
                                   ")" + "for i in " + expr + "])"+
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -1038,7 +1038,7 @@ if AutolevListener:
                 expr = self.getValue(ch.expr(0))
                 if ch.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
                     self.matrix_expr.append(ctx)
-                    self.setValue(ctx, "sm.Matrix([i.subs({" + ",".join(l) + "}) for i in " +
+                    self.setValue(ctx, "_sm.Matrix([i.subs({" + ",".join(l) + "}) for i in " +
                                   expr + "])" +
                                   ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])")
                 else:
@@ -1051,14 +1051,14 @@ if AutolevListener:
                 num = (ch.expr(1).getChild(0).getChildCount()-1)//2
                 if ch.expr(1) in self.matrix_expr:
                     for i in range(num):
-                        l.append("me.dot(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1).getChild(0).expr(i)) + ")")
-                    self.setValue(ctx, "sm.Matrix([" + ",".join(l) + "]).reshape(" + str(num) + ", " + "1)")
+                        l.append("_me.dot(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1).getChild(0).expr(i)) + ")")
+                    self.setValue(ctx, "_sm.Matrix([" + ",".join(l) + "]).reshape(" + str(num) + ", " + "1)")
                 else:
-                    self.setValue(ctx, "me.dot(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1)) + ")")
+                    self.setValue(ctx, "_me.dot(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1)) + ")")
             # Cross(w_A_N>, P_NA_AB>)
             elif func_name == "cross":
                 self.vector_expr.append(ctx)
-                self.setValue(ctx, "me.cross(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1)) + ")")
+                self.setValue(ctx, "_me.cross(" + self.getValue(ch.expr(0)) + ", " + self.getValue(ch.expr(1)) + ")")
 
             # Mag(P_O_Q>)
             elif func_name == "mag":
@@ -1094,7 +1094,7 @@ if AutolevListener:
                 else:
                     frame = self.symbol_table2[ch.expr(1).getText().lower()] + "_f"
                 if ch.expr(0).getText().lower() == "1>>":
-                    self.setValue(ctx, "me.inertia(" + frame + ", 1, 1, 1)")
+                    self.setValue(ctx, "_me.inertia(" + frame + ", 1, 1, 1)")
 
                 elif '_' in ch.expr(0).getText().lower() and ch.expr(0).getText().lower().count('_') == 2\
                 and ch.expr(0).getText().lower()[0] == "i" and ch.expr(0).getText().lower()[-2:] == ">>":
@@ -1132,13 +1132,13 @@ if AutolevListener:
                 else:
                     text = ".point"
                 if ch.getChildCount() == 4:
-                    self.setValue(ctx, "me.functions.center_of_mass(" + self.symbol_table2[ch.expr(0).getText().lower()] +
+                    self.setValue(ctx, "_me.functions.center_of_mass(" + self.symbol_table2[ch.expr(0).getText().lower()] +
                                   text + "," + ", ".join(self.bodies.values()) + ")")
                 else:
                     bodies = []
                     for i in range(1, (ch.getChildCount()-1)//2):
                         bodies.append(self.symbol_table2[ch.expr(i).getText().lower()])
-                    self.setValue(ctx, "me.functions.center_of_mass(" + self.symbol_table2[ch.expr(0).getText().lower()] +
+                    self.setValue(ctx, "_me.functions.center_of_mass(" + self.symbol_table2[ch.expr(0).getText().lower()] +
                                   text + "," + ", ".join(bodies) + ")")
 
             # PARTIALS(V_P1_E>,U1)
@@ -1182,7 +1182,7 @@ if AutolevListener:
                     self.setValue(ctx, "+".join(l))
 
             # Fr() FrStar()
-            # me.KanesMethod(n, q_ind, u_ind, kd, velocity_constraints).kanes_equations(pl, fl)[0]
+            # _me.KanesMethod(n, q_ind, u_ind, kd, velocity_constraints).kanes_equations(pl, fl)[0]
             elif func_name in ["fr", "frstar"]:
                 if not self.kane_parsed:
                     if self.kd_eqs:
@@ -1205,7 +1205,7 @@ if AutolevListener:
                                 elif self.sign[self.symbol_table[i.lower()]] == 1:
                                     name = "u_" + self.symbol_table[i.lower()]
                                     self.symbol_table.update({name: name})
-                                    self.write(name + " = " + "me.dynamicsymbols('" + name + "')\n")
+                                    self.write(name + " = " + "_me.dynamicsymbols('" + name + "')\n")
                                     if self.symbol_table[i.lower()] not in self.dependent_variables:
                                         self.u_ind.append(name)
                                         self.kd_equivalents.update({name: self.symbol_table[i.lower()]})
@@ -1244,7 +1244,7 @@ if AutolevListener:
                 if ctx.parentCtx not in self.fr_expr:
                     self.write("kd_eqs = [" + ", ".join(self.kd_eqs) + "]\n")
                     self.write("forceList = " + "[" + ", ".join(force_list) + "]\n")
-                    self.write("kane = me.KanesMethod(" + self.newtonian + ", " + "q_ind=[" +
+                    self.write("kane = _me.KanesMethod(" + self.newtonian + ", " + "q_ind=[" +
                             ",".join(self.q_ind) + "], " + "u_ind=[" +
                             ", ".join(self.u_ind) + "]" + u_dep_text + ", " +
                             "kd_eqs = kd_eqs" + velocity_constraints_text + ")\n")
@@ -1258,7 +1258,7 @@ if AutolevListener:
             # Tree annotation for Matrices which is a labeled subrule of the parser rule expr.
 
             # MO = [a, b; c, d]
-            # we generate sm.Matrix([a, b, c, d]).reshape(2, 2)
+            # we generate _sm.Matrix([a, b, c, d]).reshape(2, 2)
             # The reshape values are determined by counting the "," and ";" in the Autolev matrix
 
             # Eg:
@@ -1292,7 +1292,7 @@ if AutolevListener:
             num_of_rows = semicolon_count + 1
             num_of_cols = (comma_count//num_of_rows) + 1
 
-            self.setValue(ctx, "sm.Matrix(" + "".join(l) + ")" + ".reshape(" +
+            self.setValue(ctx, "_sm.Matrix(" + "".join(l) + ")" + ".reshape(" +
                           str(num_of_rows) + ", " + str(num_of_cols) + ")")
 
         def exitVectorOrDyadic(self, ctx):
@@ -1454,12 +1454,12 @@ if AutolevListener:
                     if ctx.index().getChild(0).getText() == "1":
                         self.type.update({text: "matrix"})
                         self.symbol_table.update({text: text})
-                        self.write(text + " = " + "sm.Matrix([[0]])\n")
+                        self.write(text + " = " + "_sm.Matrix([[0]])\n")
                         self.write(text + "[0] = " + self.getValue(ctx.expr()) + "\n")
                     else:
-                        # m = m.row_insert(m.shape[0], sm.Matrix([[0]]))
+                        # m = m.row_insert(m.shape[0], _sm.Matrix([[0]]))
                         self.write(text + " = " + text +
-                                   ".row_insert(" + text + ".shape[0]" + ", " + "sm.Matrix([[0]])" + ")\n")
+                                   ".row_insert(" + text + ".shape[0]" + ", " + "_sm.Matrix([[0]])" + ")\n")
                         self.write(text + "[" + text + ".shape[0]-1" + "] = " + self.getValue(ctx.expr()) + "\n")
 
                 # Handle assignments of type ID[2, 2] = expr
@@ -1624,7 +1624,7 @@ if AutolevListener:
                 self.write(matrix_name + "_list" + " = " + "[]\n")
                 self.write("for i in " + matrix_name + ":  " + matrix_name +
                            "_list" + ".append(i.subs({" + ", ".join(d) + "}))\n")
-                self.write("print(sm.linsolve(" + matrix_name + "_list" + ", " + ",".join(e) + "))\n")
+                self.write("print(_sm.linsolve(" + matrix_name + "_list" + ", " + ",".join(e) + "))\n")
 
             elif ctx.functionCall().getChild(0).getText().lower() == "nonlinear":
                 e = []
@@ -1643,19 +1643,19 @@ if AutolevListener:
                             z = ""
                         if i not in e:
                             if z == "deg":
-                                d.append(i + ":" + "np.deg2rad(" + j + ")")
+                                d.append(i + ":" + "_np.deg2rad(" + j + ")")
                             else:
                                 d.append(i + ":" + j)
                         else:
                             if z == "deg":
-                                guess.append("np.deg2rad(" + j + ")")
+                                guess.append("_np.deg2rad(" + j + ")")
                             else:
                                 guess.append(j)
 
                 self.write("matrix_list" + " = " + "[]\n")
                 self.write("for i in " + self.getValue(ctx.functionCall().expr(0)) + ":")
                 self.write("matrix_list" + ".append(i.subs({" + ", ".join(d) + "}))\n")
-                self.write("print(sm.nsolve(matrix_list," + "(" + ",".join(e) + ")" +
+                self.write("print(_sm.nsolve(matrix_list," + "(" + ",".join(e) + ")" +
                            ",(" + ",".join(guess) + ")" + "))\n")
 
             elif ctx.functionCall().getChild(0).getText().lower() in ["ode", "dynamics"] and self.include_numeric:
@@ -1673,7 +1673,7 @@ if AutolevListener:
                             if i in self.inputs.keys():
                                 if type(self.inputs[i]) is tuple:
                                     if self.inputs[i][1] == "deg":
-                                        x0.append(i + ":" + "np.deg2rad(" + self.inputs[i][0] + ")")
+                                        x0.append(i + ":" + "_np.deg2rad(" + self.inputs[i][0] + ")")
                                     else:
                                         x0.append(i + ":" + self.inputs[i][0])
                                 else:
@@ -1706,7 +1706,7 @@ if AutolevListener:
                             const_list.append(self.constants[i] + ":" + numerical_constants[i])
                     specifieds = []
                     if self.t:
-                        specifieds.append("me.dynamicsymbols('t')" + ":" + "lambda x, t: t")
+                        specifieds.append("_me.dynamicsymbols('t')" + ":" + "lambda x, t: t")
 
                     for i in self.inputs:
                         if i in self.symbol_table.keys() and self.symbol_table[i] not in\
@@ -1716,7 +1716,7 @@ if AutolevListener:
                     self.write("sys = System(kane, constants = {" + ", ".join(const_list) + "},\n" +
                                "specifieds={" + ", ".join(specifieds) + "},\n" +
                                "initial_conditions={" + ", ".join(x0) + "},\n" +
-                               "times = np.linspace(0.0, " + str(t_final) + ", " + str(t_final) +
+                               "times = _np.linspace(0.0, " + str(t_final) + ", " + str(t_final) +
                                "/" + str(integ_stp) + "))\n\ny=sys.integrate()\n")
 
                     # For outputs other than qs and us.
@@ -1754,7 +1754,7 @@ if AutolevListener:
                     expr = self.getValue(ctx.expr(0))
                     symbol = self.symbol_table[ctx.expr(0).getText().lower()]
                     if ctx.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
-                        self.write(symbol + " = " + "sm.Matrix([i.expand() for i in " + expr + "])" +
+                        self.write(symbol + " = " + "_sm.Matrix([i.expand() for i in " + expr + "])" +
                                    ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])\n")
                     else:
                         self.write(symbol + " = " + symbol + "." + "expand()\n")
@@ -1764,11 +1764,11 @@ if AutolevListener:
                     expr = self.getValue(ctx.expr(0))
                     symbol = self.symbol_table[ctx.expr(0).getText().lower()]
                     if ctx.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
-                        self.write(symbol + " = " + "sm.Matrix([sm.factor(i," + self.getValue(ctx.expr(1)) +
+                        self.write(symbol + " = " + "_sm.Matrix([_sm.factor(i," + self.getValue(ctx.expr(1)) +
                                    ") for i in " + expr + "])" +
                                    ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])\n")
                     else:
-                        self.write(expr + " = " + "sm.factor(" + expr + ", " +
+                        self.write(expr + " = " + "_sm.factor(" + expr + ", " +
                                    self.getValue(ctx.expr(1)) + ")\n")
 
                 # Solve(Zero, x, y)
@@ -1791,9 +1791,9 @@ if AutolevListener:
                                 pass
 
                     for i in l2:
-                        self.explicit.update({i: "sm.solve" + "".join(l) + "[" + i + "]"})
+                        self.explicit.update({i: "_sm.solve" + "".join(l) + "[" + i + "]"})
 
-                    self.write("print(sm.solve" + "".join(l) + ")\n")
+                    self.write("print(_sm.solve" + "".join(l) + ")\n")
 
                 # Arrange(y, n, x) *
                 elif func_name == "arrange":
@@ -1801,7 +1801,7 @@ if AutolevListener:
                     symbol = self.symbol_table[ctx.expr(0).getText().lower()]
 
                     if ctx.expr(0) in self.matrix_expr or (expr in self.type.keys() and self.type[expr] == "matrix"):
-                        self.write(symbol + " = " + "sm.Matrix([i.collect(" + self.getValue(ctx.expr(2)) +
+                        self.write(symbol + " = " + "_sm.Matrix([i.collect(" + self.getValue(ctx.expr(2)) +
                                    ")" + "for i in " + expr + "])" +
                                    ".reshape((" + expr + ").shape[0], " + "(" + expr + ").shape[1])\n")
                     else:
@@ -1812,13 +1812,13 @@ if AutolevListener:
                 elif func_name == "eig":
                     self.symbol_table.update({ctx.expr(1).getText().lower(): ctx.expr(1).getText().lower()})
                     self.symbol_table.update({ctx.expr(2).getText().lower(): ctx.expr(2).getText().lower()})
-                    # sm.Matrix([i.evalf() for i in (i_s_so).eigenvals().keys()])
+                    # _sm.Matrix([i.evalf() for i in (i_s_so).eigenvals().keys()])
                     self.write(ctx.expr(1).getText().lower() + " = " +
-                               "sm.Matrix([i.evalf() for i in " +
+                               "_sm.Matrix([i.evalf() for i in " +
                                "(" + self.getValue(ctx.expr(0)) + ")" + ".eigenvals().keys()])\n")
-                    # sm.Matrix([i[2][0].evalf() for i in (i_s_o).eigenvects()]).reshape(i_s_o.shape[0], i_s_o.shape[1])
+                    # _sm.Matrix([i[2][0].evalf() for i in (i_s_o).eigenvects()]).reshape(i_s_o.shape[0], i_s_o.shape[1])
                     self.write(ctx.expr(2).getText().lower() + " = " +
-                               "sm.Matrix([i[2][0].evalf() for i in " + "(" + self.getValue(ctx.expr(0)) + ")" +
+                               "_sm.Matrix([i[2][0].evalf() for i in " + "(" + self.getValue(ctx.expr(0)) + ")" +
                                ".eigenvects()]).reshape(" + self.getValue(ctx.expr(0)) + ".shape[0], " +
                                self.getValue(ctx.expr(0)) + ".shape[1])\n")
 
@@ -1850,7 +1850,7 @@ if AutolevListener:
                         value = self.getValue(ctx.expr(3))
                     else:
                         if ctx.expr(3) in self.numeric_expr:
-                            value = "np.deg2rad(" + self.getValue(ctx.expr(3)) + ")"
+                            value = "_np.deg2rad(" + self.getValue(ctx.expr(3)) + ")"
                         else:
                             value = self.getValue(ctx.expr(3))
                     self.write(frame2 + ".orient(" + frame1 +
@@ -2021,7 +2021,7 @@ if AutolevListener:
             particle = self.symbol_table2[ctx.getChild(0).getText().lower()]
             if ctx.getText().count("=") == 2:
                 if ctx.expr().expr(1) in self.numeric_expr:
-                    e = "sm.S(" + self.getValue(ctx.expr().expr(1)) + ")"
+                    e = "_sm.S(" + self.getValue(ctx.expr().expr(1)) + ")"
                 else:
                     e = self.getValue(ctx.expr().expr(1))
                 self.symbol_table.update({ctx.expr().expr(0).getText().lower(): ctx.expr().expr(0).getText().lower()})
@@ -2030,14 +2030,14 @@ if AutolevListener:
             else:
                 try:
                     if ctx.expr() in self.numeric_expr:
-                        mass = "sm.S(" + self.getValue(ctx.expr()) + ")"
+                        mass = "_sm.S(" + self.getValue(ctx.expr()) + ")"
                     else:
                         mass = self.getValue(ctx.expr())
                 except Exception:
                     a_text = ctx.expr().getText().lower()
                     self.symbol_table.update({a_text: a_text})
                     self.type.update({a_text: "constants"})
-                    self.write(a_text + " = " + "sm.symbols('" + a_text + "')\n")
+                    self.write(a_text + " = " + "_sm.symbols('" + a_text + "')\n")
                     mass = a_text
 
             self.write(particle + ".mass = " + mass + "\n")
@@ -2052,32 +2052,32 @@ if AutolevListener:
             for i in range((ctx.getChildCount()-num)//2):
                 try:
                     if ctx.expr(i) in self.numeric_expr:
-                        inertia_list.append("sm.S(" + self.getValue(ctx.expr(i)) + ")")
+                        inertia_list.append("_sm.S(" + self.getValue(ctx.expr(i)) + ")")
                     else:
                         inertia_list.append(self.getValue(ctx.expr(i)))
                 except Exception:
                     a_text = ctx.expr(i).getText().lower()
                     self.symbol_table.update({a_text: a_text})
                     self.type.update({a_text: "constants"})
-                    self.write(a_text + " = " + "sm.symbols('" + a_text + "')\n")
+                    self.write(a_text + " = " + "_sm.symbols('" + a_text + "')\n")
                     inertia_list.append(a_text)
 
             if len(inertia_list) < 6:
                 for i in range(6-len(inertia_list)):
                     inertia_list.append("0")
-            # body_a.inertia = (me.inertia(body_a, I1, I2, I3, 0, 0, 0), body_a_cm)
+            # body_a.inertia = (_me.inertia(body_a, I1, I2, I3, 0, 0, 0), body_a_cm)
             try:
                 frame = self.symbol_table2[ctx.ID(1).getText().lower()]
                 point = self.symbol_table2[ctx.ID(0).getText().lower().split('_')[1]]
                 body = self.symbol_table2[ctx.ID(0).getText().lower().split('_')[0]]
                 self.inertia_point.update({ctx.ID(0).getText().lower().split('_')[0]
                                           : ctx.ID(0).getText().lower().split('_')[1]})
-                self.write(body + ".inertia" + " = " + "(me.inertia(" + frame + ", " +
+                self.write(body + ".inertia" + " = " + "(_me.inertia(" + frame + ", " +
                            ", ".join(inertia_list) + "), " + point + ")\n")
 
             except Exception:
                 body_name = self.symbol_table2[ctx.ID(0).getText().lower()]
                 body_name_cm = body_name + "_cm"
                 self.inertia_point.update({ctx.ID(0).getText().lower(): ctx.ID(0).getText().lower() + "o"})
-                self.write(body_name + ".inertia" + " = " + "(me.inertia(" + body_name + "_f" + ", " +
+                self.write(body_name + ".inertia" + " = " + "(_me.inertia(" + body_name + "_f" + ", " +
                            ", ".join(inertia_list) + "), " + body_name_cm + ")\n")

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -21,7 +21,7 @@ def strfunc(z):
     elif z == 1:
         return "_d"
     else:
-        return "_d" * str(z)
+        return "_d" * z
 
 def declare_phy_entities(self, ctx, phy_type, i, j=None):
     if phy_type in ("frame", "newtonian"):

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -23,18 +23,10 @@ def _test_examples(in_filename, out_filename, test_name=""):
     with open(in_file_path) as f:
         generated_code = parse_autolev(f, include_numeric=True)
 
-    with open(correct_file_path) as f:
-        for idx, line1 in enumerate(f):
-            if line1.startswith("#"):
-                break
-            try:
-                line2 = generated_code.split('\n')[idx]
-                assert line1.rstrip() == line2.rstrip()
-            except Exception:
-                msg = 'mismatch in ' + test_name + ' in line no: {0}'
-                raise AssertionError(msg.format(idx+1))
+    with open(correct_file_path,"w") as f:
+        f.write(generated_code)
 def test_rule_tests():
-
+    
     l = ["ruletest1", "ruletest2", "ruletest3", "ruletest4", "ruletest5",
          "ruletest6", "ruletest7", "ruletest8", "ruletest9", "ruletest10",
          "ruletest11", "ruletest12"]

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -26,7 +26,7 @@ def _test_examples(in_filename, out_filename, test_name=""):
                line2 = generated_code.split('\n')[idx]
                assert line1.rstrip() == line2.rstrip()
             except Exception:
-                raise AssertionError('mismatch in ' + test_name + ' in line no: {0}'.format(idx+1))                
+                raise AssertionError('mismatch in ' + test_name + ' in line no: {0}'.format(idx+1))
 def test_rule_tests():
     l = ["ruletest1", "ruletest2", "ruletest3", "ruletest4", "ruletest5", "ruletest6",\
          "ruletest7", "ruletest8", "ruletest9", "ruletest10", "ruletest11", "ruletest12"]

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -27,8 +27,7 @@ def _test_examples(in_filename, out_filename, test_name=""):
                assert line1.rstrip() == line2.rstrip()
             except Exception:
                 raise AssertionError('mismatch in ' + test_name + ' in line no: {0}'.format(idx+1))
-    
-    
+                
 def test_rule_tests():
     l = ["ruletest1", "ruletest2", "ruletest3", "ruletest4", "ruletest5", "ruletest6",\
          "ruletest7", "ruletest8", "ruletest9", "ruletest10", "ruletest11", "ruletest12"]

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -26,7 +26,8 @@ def _test_examples(in_filename, out_filename, test_name=""):
                line2 = generated_code.split('\n')[idx]
                assert line1.rstrip() == line2.rstrip()
             except Exception:
-                raise AssertionError('mismatch in ' + test_name + ' in line no: {0}'.format(idx+1))
+                msg = 'mismatch in ' + test_name + ' in line no: {0}'
+                raise AssertionError(msg.format(idx+1))
 def test_rule_tests():
     l = ["ruletest1", "ruletest2", "ruletest3", "ruletest4", "ruletest5", "ruletest6",\
          "ruletest7", "ruletest8", "ruletest9", "ruletest10", "ruletest11", "ruletest12"]

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -23,8 +23,16 @@ def _test_examples(in_filename, out_filename, test_name=""):
     with open(in_file_path) as f:
         generated_code = parse_autolev(f, include_numeric=True)
 
-    with open(correct_file_path,"w") as f:
-        f.write(generated_code)
+    with open(correct_file_path) as f:
+        for idx, line1 in enumerate(f):
+            if line1.startswith("#"):
+                break
+            try:
+                line2 = generated_code.split('\n')[idx]
+                assert line1.rstrip() == line2.rstrip()
+            except Exception:
+                msg = 'mismatch in ' + test_name + ' in line no: {0}'
+                raise AssertionError(msg.format(idx+1))
 def test_rule_tests():
     l = ["ruletest1", "ruletest2", "ruletest3", "ruletest4", "ruletest5",
          "ruletest6", "ruletest7", "ruletest8", "ruletest9", "ruletest10",

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -26,8 +26,7 @@ def _test_examples(in_filename, out_filename, test_name=""):
                line2 = generated_code.split('\n')[idx]
                assert line1.rstrip() == line2.rstrip()
             except Exception:
-                raise AssertionError('mismatch in ' + test_name + ' in line no: {0}'.format(idx+1))
-                
+                raise AssertionError('mismatch in ' + test_name + ' in line no: {0}'.format(idx+1))                
 def test_rule_tests():
     l = ["ruletest1", "ruletest2", "ruletest3", "ruletest4", "ruletest5", "ruletest6",\
          "ruletest7", "ruletest8", "ruletest9", "ruletest10", "ruletest11", "ruletest12"]

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -26,7 +26,6 @@ def _test_examples(in_filename, out_filename, test_name=""):
     with open(correct_file_path,"w") as f:
         f.write(generated_code)
 def test_rule_tests():
-    
     l = ["ruletest1", "ruletest2", "ruletest3", "ruletest4", "ruletest5",
          "ruletest6", "ruletest7", "ruletest8", "ruletest9", "ruletest10",
          "ruletest11", "ruletest12"]

--- a/sympy/parsing/tests/test_autolev.py
+++ b/sympy/parsing/tests/test_autolev.py
@@ -27,8 +27,8 @@ def _test_examples(in_filename, out_filename, test_name=""):
                assert line1.rstrip() == line2.rstrip()
             except Exception:
                 raise AssertionError('mismatch in ' + test_name + ' in line no: {0}'.format(idx+1))
-
-
+    
+    
 def test_rule_tests():
     l = ["ruletest1", "ruletest2", "ruletest3", "ruletest4", "ruletest5", "ruletest6",\
          "ruletest7", "ruletest8", "ruletest9", "ruletest10", "ruletest11", "ruletest12"]


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15187 
#### Brief description of what is fixed or changed
Added underscore in prefix of all occurences of `me.`,` sm.`,`np.` and `"d"` and in `str_func(z)`,
changed `"d" + str(z)` to `"d" * str(z)` in `sympy/parsing/autolev/_listener_autolev_antlr.py`
to avoid name clashes which vary likely happen with the primary import names: me, sm, np

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
   * Improved variable naming in autolev parser
<!-- END RELEASE NOTES -->
