### PR TITLE
Unmask iszerofunc from _eval_det_bareiss() and det()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -426,11 +426,11 @@ class MatrixDeterminant(MatrixCommon):
                    - self[0, 1] * self[1, 0] * self[2, 2])
 
         if method == "bareiss":
-            return self._eval_det_bareiss()
+            return self._eval_det_bareiss(iszerofunc=_is_zero_after_expand_mul)
         elif method == "berkowitz":
             return self._eval_det_berkowitz()
         elif method == "lu":
-            return self._eval_det_lu()
+            return self._eval_det_lu(iszerofunc=_iszero)
 
     def minor(self, i, j, method="berkowitz"):
         """Return the (i,j) minor of `self`.  That is,

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -383,7 +383,7 @@ class MatrixDeterminant(MatrixCommon):
         return self._new(self.rows, self.cols,
                          lambda i, j: self.cofactor(i, j, method))
 
-    def det(self, method="bareiss", iszerofunc=_iszero):
+    def det(self, method="bareiss"):
         """Computes the determinant of a matrix.  If the matrix
         is at most 3x3, a hard-coded formula is used.
         Otherwise, the determinant using the method `method`.
@@ -430,7 +430,7 @@ class MatrixDeterminant(MatrixCommon):
         elif method == "berkowitz":
             return self._eval_det_berkowitz()
         elif method == "lu":
-            return self._eval_det_lu(iszerofunc=iszerofunc)
+            return self._eval_det_lu()
 
     def minor(self, i, j, method="berkowitz"):
         """Return the (i,j) minor of `self`.  That is,

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -383,7 +383,7 @@ class MatrixDeterminant(MatrixCommon):
         return self._new(self.rows, self.cols,
                          lambda i, j: self.cofactor(i, j, method))
 
-    def det(self, method="bareiss"):
+    def det(self, method="bareiss", iszerofunc=_iszero):
         """Computes the determinant of a matrix.  If the matrix
         is at most 3x3, a hard-coded formula is used.
         Otherwise, the determinant using the method `method`.
@@ -430,7 +430,7 @@ class MatrixDeterminant(MatrixCommon):
         elif method == "berkowitz":
             return self._eval_det_berkowitz()
         elif method == "lu":
-            return self._eval_det_lu()
+            return self._eval_det_lu(iszerofunc=iszerofunc)
 
     def minor(self, i, j, method="berkowitz"):
         """Return the (i,j) minor of `self`.  That is,

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -404,6 +404,13 @@ class MatrixDeterminant(MatrixCommon):
         if method not in ("bareiss", "berkowitz", "lu"):
             raise ValueError("Determinant method '%s' unrecognized" % method)
 
+        if iszerofunc is None:
+            if method == "bareiss":
+                iszerofunc = _is_zero_after_expand_mul
+            elif method == "lu":
+                iszerofunc = _iszero
+        elif not isinstance(iszerofunc, FunctionType):
+            raise ValueError("Zero testing method '%s' unrecognized" % iszerofunc)
 
         # if methods were made internal and all determinant calculations
         # passed through here, then these lines could be factored out of
@@ -427,12 +434,10 @@ class MatrixDeterminant(MatrixCommon):
                    - self[0, 1] * self[1, 0] * self[2, 2])
 
         if method == "bareiss":
-            iszerofunc = _is_zero_after_expand_mul if iszerofunc is None else iszerofunc
             return self._eval_det_bareiss(iszerofunc=iszerofunc)
         elif method == "berkowitz":
             return self._eval_det_berkowitz()
         elif method == "lu":
-            iszerofunc = _iszero if iszerofunc is None else iszerofunc
             return self._eval_det_lu(iszerofunc=iszerofunc)
 
     def minor(self, i, j, method="berkowitz"):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -170,7 +170,7 @@ class MatrixDeterminant(MatrixCommon):
         submat, toeplitz = self._eval_berkowitz_toeplitz_matrix()
         return toeplitz * submat._eval_berkowitz_vector()
 
-    def _eval_det_bareiss(self):
+    def _eval_det_bareiss(self, iszerofunc=_is_zero_after_expand_mul):
         """Compute matrix determinant using Bareiss' fraction-free
         algorithm which is an extension of the well known Gaussian
         elimination method. This approach is best suited for dense
@@ -195,7 +195,7 @@ class MatrixDeterminant(MatrixCommon):
             # the computation by the factor of 2.5 in one test.
             # Relevant issues: #10279 and #13877.
             pivot_pos, pivot_val, _, _ = _find_reasonable_pivot(mat[:, 0],
-                                         iszerofunc=_is_zero_after_expand_mul)
+                                         iszerofunc=iszerofunc)
             if pivot_pos == None:
                 return S.Zero
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -383,7 +383,7 @@ class MatrixDeterminant(MatrixCommon):
         return self._new(self.rows, self.cols,
                          lambda i, j: self.cofactor(i, j, method))
 
-    def det(self, method="bareiss"):
+    def det(self, method="bareiss", iszerofunc=None):
         """Computes the determinant of a matrix.  If the matrix
         is at most 3x3, a hard-coded formula is used.
         Otherwise, the determinant using the method `method`.
@@ -403,6 +403,7 @@ class MatrixDeterminant(MatrixCommon):
             method = "lu"
         if method not in ("bareiss", "berkowitz", "lu"):
             raise ValueError("Determinant method '%s' unrecognized" % method)
+
 
         # if methods were made internal and all determinant calculations
         # passed through here, then these lines could be factored out of
@@ -426,11 +427,13 @@ class MatrixDeterminant(MatrixCommon):
                    - self[0, 1] * self[1, 0] * self[2, 2])
 
         if method == "bareiss":
-            return self._eval_det_bareiss(iszerofunc=_is_zero_after_expand_mul)
+            iszerofunc = _is_zero_after_expand_mul if iszerofunc is None else iszerofunc
+            return self._eval_det_bareiss(iszerofunc=iszerofunc)
         elif method == "berkowitz":
             return self._eval_det_berkowitz()
         elif method == "lu":
-            return self._eval_det_lu(iszerofunc=_iszero)
+            iszerofunc = _iszero if iszerofunc is None else iszerofunc
+            return self._eval_det_lu(iszerofunc=iszerofunc)
 
     def minor(self, i, j, method="berkowitz"):
         """Return the (i,j) minor of `self`.  That is,


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#15169

#### Brief description of what is fixed or changed

Adding iszerofunc parameter was discussed in #15169 
And I had looked up for the methods in `MatrixDeterminant` to make changes.

However, the PR #13877 had introduced a different zero testing method `_is_zero_after_expand_mul` for `_eval_det_bareiss()`.

The problem is, if we are going to make make the keyword explicit in `det()`, it will not be possible without overriding any defaults set by each evaluation routines.

```
        if method == "bareiss":
            return self._eval_det_bareiss(iszerofunc=_is_zero_after_expand_mul)
        elif method == "berkowitz":
            return self._eval_det_berkowitz()
        elif method == "lu":
            return self._eval_det_lu(iszerofunc=_iszero)
```

One possible workaround can be using implicit way `kwargs.pop('iszerofunc', None)` and mapping `None` in terms of each `'method'`, like `_is_zero_after_expand_mul` for `'bareiss'` and `_iszero` for `'lu'`.

But I am not sure how each one can introduce complexity to the higher level functions.

I would like to here your opinions.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- matrices
  - Added `iszerofunc` parameter for `_eval_det_bareiss()` and `det()`
<!-- END RELEASE NOTES -->
