### PR TITLE
linear_coeffs function added to solveset

### DIFF
--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1490,13 +1490,13 @@ class Beam3D(Beam):
     >>> b.bc_deflection = [(0, [0, 0, 0]), (l, [0, 0, 0])]
     >>> b.solve_slope_deflection()
     >>> b.slope()
-    [0, 0, l*x*(-l*q + 3*l*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(2*(A*G*l**2 + 12*E*I)) + 3*m)/(6*E*I)
-    + q*x**3/(6*E*I) + x**2*(-l*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(2*(A*G*l**2 + 12*E*I))
+    [0, 0, l*x*(-l*q + 3*l*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*(A*G*l**2 + 12*E*I)) + 3*m)/(6*E*I)
+    + q*x**3/(6*E*I) + x**2*(-l*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*(A*G*l**2 + 12*E*I))
     - m)/(2*E*I)]
     >>> b.deflection()
-    [0, -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I))
-    + l*m*x**2/(4*E*I) - l*x**3*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I)) - m*x**3/(6*E*I)
-    + q*x**4/(24*E*I) + l*x*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I)) - q*x**2/(2*A*G), 0]
+    [0, -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I))
+    + l*m*x**2/(4*E*I) - l*x**3*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I)) - m*x**3/(6*E*I)
+    + q*x**4/(24*E*I) + l*x*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I)) - q*x**2/(2*A*G), 0]
 
     References
     ==========

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -472,10 +472,11 @@ def test_Beam3D():
 
     assert b.shear_force() == [0, -q*x, 0]
     assert b.bending_moment() == [0, 0, -m*x + q*x**2/2]
-    assert b.deflection() == [0, -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l**2*q - 2*A*G*l*m
-            + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I)) + l*m*x**2/(4*E*I) - l*x**3*(A*G*l**2*q
-            - 2*A*G*l*m + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I)) - m*x**3/(6*E*I) + q*x**4/(24*E*I)
-            + l*x*(A*G*l**2*q - 2*A*G*l*m + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I))
+    assert b.deflection() == [0, -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l*(l*q - 2*m)
+            + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I)) + l*m*x**2/(4*E*I)
+            - l*x**3*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I))
+            - m*x**3/(6*E*I) + q*x**4/(24*E*I)
+            + l*x*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I))
             - q*x**2/(2*A*G), 0]
 
 

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1828,7 +1828,7 @@ def linear_coeffs(eq, *syms):
     {0: y*(2*z + 3), x: 3*y*z + 1}
 
     But if there are nonlinear or cross terms -- even if they would
-    cancel after simplification-- an error is raised so the situation
+    cancel after simplification -- an error is raised so the situation
     does not pass silently past the caller's attention:
 
     >>> eq = 1/x*(x - 1) + 1/x
@@ -1959,9 +1959,7 @@ def linear_eq_to_matrix(equations, *symbols):
             ''' % i))
 
     if has_dups(symbols):
-        raise ValueError(filldedent('''
-            Symbols must be unique.
-            '''))
+        raise ValueError('Symbols must be unique')
 
     equations = sympify(equations)
     if isinstance(equations, MatrixBase):
@@ -2134,8 +2132,8 @@ def linsolve(system, *symbols):
     >>> linsolve([], x)
     EmptySet()
 
-    * Although removable singularities and nonlinearity
-      will not raise an error, non-linear systems will:
+    * An error is raised if, after expansion, any nonlinearity
+      is detected:
 
     >>> linsolve([x*(1/x - 1), (y - 1)**2 - y**2 + 1], x, y)
     {(1, 1)}

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -19,8 +19,8 @@ from sympy.core.containers import Tuple
 from sympy.core.facts import InconsistentAssumptions
 from sympy.core.numbers import I, Number, Rational, oo
 from sympy.core.function import (Lambda, expand_complex, AppliedUndef,
-                                expand_log)
-from sympy.core.relational import Eq
+                                expand_log, _mexpand)
+from sympy.core.relational import Eq, Ne
 from sympy.core.symbol import Symbol
 from sympy.simplify.simplify import simplify, fraction, trigsimp
 from sympy.simplify import powdenest, logcombine
@@ -34,7 +34,7 @@ from sympy.logic.boolalg import And
 from sympy.sets import (FiniteSet, EmptySet, imageset, Interval, Intersection,
                         Union, ConditionSet, ImageSet, Complement, Contains)
 from sympy.sets.sets import Set
-from sympy.matrices import Matrix
+from sympy.matrices import Matrix, MatrixBase
 from sympy.polys import (roots, Poly, degree, together, PolynomialError,
                          RootOf, factor)
 from sympy.solvers.solvers import (checksol, denoms, unrad,
@@ -42,10 +42,9 @@ from sympy.solvers.solvers import (checksol, denoms, unrad,
 from sympy.solvers.polysys import solve_poly_system
 from sympy.solvers.inequalities import solve_univariate_inequality
 from sympy.utilities import filldedent
-from sympy.utilities.iterables import numbered_symbols, uniq
+from sympy.utilities.iterables import numbered_symbols, has_dups
 from sympy.calculus.util import periodicity, continuous_domain
 from sympy.core.compatibility import ordered, default_sort_key, is_sequence
-from sympy.core.function import diff, expand_mul
 
 from types import GeneratorType
 
@@ -1813,7 +1812,10 @@ def linear_eq_to_matrix(equations, *symbols):
     Here `equations` must be a linear system of equations in
     `symbols`. The order of symbols in input `symbols` will
     determine the order of coefficients in the returned
-    Matrix.
+    Matrix. No simplification of the equations is performed
+    other than converting `Eq(a, b) -> a - b` so equations
+    that might be linear after simplification will raise
+    an error.
 
     The Matrix form corresponds to the augmented matrix form.
     For example:
@@ -1830,93 +1832,142 @@ def linear_eq_to_matrix(equations, *symbols):
      A = [ 3  1  1 ]   b  =   [-6 ]
          [ 2  4  9 ]          [ 2 ]
 
+    Raises
+    ======
+
+    ValueError
+        The equations are not linear in symbols given.
+        The symbols are not given or are not unique.
+
     Examples
     ========
 
     >>> from sympy import linear_eq_to_matrix, symbols
-    >>> x, y, z = symbols('x, y, z')
-    >>> eqns = [x + 2*y + 3*z - 1, 3*x + y + z + 6, 2*x + 4*y + 9*z - 2]
+    >>> c, x, y, z = symbols('c, x, y, z')
+
+    The coefficients (numerical or symbolic) of the symbols will
+    be returned as matrices:
+
+    >>> eqns = [c*x + z - 1 - c, y + z, x - y]
     >>> A, b = linear_eq_to_matrix(eqns, [x, y, z])
     >>> A
     Matrix([
-    [1, 2, 3],
-    [3, 1, 1],
-    [2, 4, 9]])
-    >>> b
-    Matrix([
-    [ 1],
-    [-6],
-    [ 2]])
-    >>> eqns = [x + z - 1, y + z, x - y]
-    >>> A, b = linear_eq_to_matrix(eqns, [x, y, z])
-    >>> A
-    Matrix([
-    [1,  0, 1],
+    [c,  0, 1],
     [0,  1, 1],
     [1, -1, 0]])
     >>> b
     Matrix([
-    [1],
-    [0],
-    [0]])
+    [c + 1],
+    [    0],
+    [    0]])
 
-    * Symbolic coefficients are also supported
+    This routine does not simplify expressions and will raise an error
+    if nonlinear equations are encountered:
 
-    >>> a, b, c, d, e, f = symbols('a, b, c, d, e, f')
-    >>> eqns = [a*x + b*y - c, d*x + e*y - f]
-    >>> A, B = linear_eq_to_matrix(eqns, x, y)
-    >>> A
-    Matrix([
-    [a, b],
-    [d, e]])
-    >>> B
-    Matrix([
-    [c],
-    [f]])
+    >>> eqns = [
+    ...     (x**2 - 3*x)/(x - 3) - 3,
+    ...     y**2 - 3*y - y*(y - 4) + x - 4]
+    >>> linear_eq_to_matrix(eqns, [x, y])
+    Traceback (most recent call last):
+    ...
+    ValueError:
+    The term (x**2 - 3*x)/(x - 3) is nonlinear in {x, y}
 
+    Simplifying these equations will discard the removable singularity
+    in the first, reveal the linear structure of the second, and allow
+    a solution to be returned:
+
+    >>> [e.simplify() for e in eqns]
+    [x - 3, x + y - 4]
+    >>> linear_eq_to_matrix(_, [x, y])
+    (Matrix([
+    [1, 0],
+    [1, 1]]), Matrix([
+    [3],
+    [4]]))
+
+
+    Any simplification (expansion, factoring, etc...) needed
+    to make the equations linear must be done before calling this
+    routine.
     """
-
     if not symbols:
-        raise ValueError('Symbols must be given, for which coefficients \
-                         are to be found.')
+        raise ValueError(filldedent('''
+            Symbols must be given, for which coefficients
+            are to be found.
+            '''))
 
     if hasattr(symbols[0], '__iter__'):
         symbols = symbols[0]
 
-    free = set(symbols)
-    zero = dict(zip(symbols, [S.Zero]*len(symbols)))
-    if len(symbols) != len(free):
-        raise ValueError('Symbols must be unique.')
+    equations = sympify(equations)
+    if isinstance(equations, MatrixBase):
+        equations = list(equations)
+    elif isinstance(equations, Expr):
+        equations = [equations]
+    elif not is_sequence(equations):
+        raise ValueError(filldedent('''
+            Equation(s) must be given as a sequence, Expr or Matrix.
+            '''))
 
-    M = Matrix([symbols])
+    if has_dups(symbols):
+        raise ValueError(filldedent('''
+            Symbols must be unique.
+            '''))
+
     # initialize Matrix with symbols + 1 columns
+    M = Matrix([symbols])
     M = M.col_insert(len(symbols), Matrix([1]))
-    row_no = 1
 
-    for equation in equations:
-        f = sympify(equation)
+    for row_no, f in enumerate(equations):
         if isinstance(f, Equality):
             f = f.lhs - f.rhs
 
-        # Extract coeff of symbols
-        coeff_list = []
-        for symbol in symbols:
-            coeff_list.append(f.coeff(symbol))
+        # initialize args for each coeff to empty
+        coeff_list = [[] for s in symbols]
 
-        # append constant term (term free from symbols);
-        coeff_list.append(-f.xreplace(zero))
+        # get pointers for locations of symbols
+        ix = dict(zip(symbols, range(len(symbols))))
 
-        # Checking linearity
-        if coeff_list[-1] is S.NaN or any(c.free_symbols & free for c in coeff_list):
-            raise ValueError('Equation %s may need simplification before processing here.'%(equation))
+        # separate into terms
+        # e.g. (x + 2*y + x*y + 4*x**3 + 6).as_coeff_add(x,y)
+        # (6, (x, 2*y, 4*x**3, x*y))
+        const, terms = f.as_coeff_add(*symbols)
 
-        # insert equations coeff's into rows
-        M = M.row_insert(row_no, Matrix([coeff_list]))
-        row_no += 1
+        # store constant term
+        coeff_list.append([-const])  # 6 as -6
+
+        # collect coefficients of symbols
+        valid_form = False
+        for t in terms:
+            c, factors = t.as_coeff_mul(*symbols)
+            if len(factors) != 1:
+                # e.g. x*y -> (1, (x, y))
+                break
+            if factors[0] not in symbols:
+                # e.g. x**3 -> (1, (x**3,))
+                break
+            coeff_list[ix[factors[0]]].append(c)
+        else:
+            valid_form = True
+
+        # check if all equations were in valid form
+        if not valid_form:
+            __ = (t, set(symbols))
+            raise ValueError(filldedent('''
+                The term %s is nonlinear in %s
+                ''' % __))
+
+        # rebuild coefficients
+        coeff_list = [Add(*i) for i in coeff_list]
+
+        # insert coefficients as a row in M
+        M = M.row_insert(row_no + 1, Matrix([coeff_list]))
 
     # delete the initialized (Ist) trivial row
     M.row_del(0)
     A, b = M[:, :-1], M[:, -1:]
+
     return A, b
 
 
@@ -2063,6 +2114,16 @@ def linsolve(system, *symbols):
     >>> linsolve([], x)
     EmptySet()
 
+    * Although removable singularities and nonlinearity
+      will not raise an error, non-linear systems will:
+
+    >>> linsolve([x*(1/x - 1), (y - 1)**2 - y**2 + 1], x, y)
+    {(1, 1)}
+    >>> linsolve([x**2 - 1], x)
+    Traceback (most recent call last):
+    ...
+    ValueError:
+    The term x**2 is nonlinear in {x}
     """
     if not system:
         return S.EmptySet
@@ -2092,19 +2153,7 @@ def linsolve(system, *symbols):
                     symbols for which a solution is being sought must
                     be given as a sequence, too.
                 '''))
-            system = list(system)
-            for i, eq in enumerate(system):
-                try:
-                    # since we are checking it, we might as well take the
-                    # expanded expr that it will give
-                    system[i] = Poly(eq, symbols).as_expr()
-                    if any (degree(eq, sym) > 1 for sym in symbols):
-                        raise PolynomialError
-                except PolynomialError:
-                    raise ValueError(filldedent('''
-                        %s contains non-linear terms in the
-                        variables to be evaluated
-                    ''') % eq)
+            system = [_mexpand(i, recursive=True) for i in system]
             system, symbols, swap = recast_to_symbols(system, symbols)
             A, b = linear_eq_to_matrix(system, symbols)
             syms_needed_msg = 'free symbols in the equations provided'

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -2173,7 +2173,9 @@ def linsolve(system, *symbols):
                     symbols for which a solution is being sought must
                     be given as a sequence, too.
                 '''))
-            system = [_mexpand(i, recursive=True) for i in system]
+            system = [
+                _mexpand(i.lhs - i.rhs if isinstance(i, Eq) else i,
+                recursive=True) for i in system]
             system, symbols, swap = recast_to_symbols(system, symbols)
             A, b = linear_eq_to_matrix(system, symbols)
             syms_needed_msg = 'free symbols in the equations provided'

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1049,6 +1049,9 @@ def test_linear_eq_to_matrix():
     raises(ValueError, lambda: linear_eq_to_matrix(Eq(1/x + x, 1/x)))
 
     assert linear_eq_to_matrix(1, x) == (Matrix([[0]]), Matrix([[-1]]))
+    # issue 15195
+    assert linear_eq_to_matrix(x + y*(z*(3*x + 2) + 3), x) == (
+        Matrix([[3*y*z + 1]]), Matrix([[-y*(2*z + 3)]]))
     assert linear_eq_to_matrix(Matrix(
         [[a*x + b*y - 7], [5*x + 6*y - c]]), x, y) == (
         Matrix([[a, b], [5, 6]]), Matrix([[7], [c]]))

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1038,9 +1038,15 @@ def test_linear_eq_to_matrix():
     assert A == Matrix([[a*b, b, c], [d + e, f, g], [i, j, k]])
     assert B == Matrix([[d], [h], [l]])
 
-    # raise ValueError if no symbols are given or duplicates are given
+    # raise ValueError if
+    # 1) no symbols are given
     raises(ValueError, lambda: linear_eq_to_matrix(eqns3))
+    # 2) there are duplicates
     raises(ValueError, lambda: linear_eq_to_matrix(eqns3, [x, x, y]))
+    # 3) there are non-symbols
+    raises(ValueError, lambda: linear_eq_to_matrix(eqns3, [x, 1/a, y]))
+    # 4) a nonlinear term is detected in the original expression
+    raises(ValueError, lambda: linear_eq_to_matrix(Eq(1/x + x, 1/x)))
 
     assert linear_eq_to_matrix(1, x) == (Matrix([[0]]), Matrix([[-1]]))
     assert linear_eq_to_matrix(Matrix(

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1591,6 +1591,15 @@ def test_issue_10397():
     assert solveset(sqrt(x), x, S.Complexes) == FiniteSet(0)
 
 
+def test_issue_14987():
+    raises(ValueError, lambda: linear_eq_to_matrix([x**2], x))
+    raises(ValueError, lambda: linear_eq_to_matrix([x*(-3/x + 1) + 2*y - a], [x, y]))
+    assert linear_eq_to_matrix([(x**2-3*x)/(x-3) - 3], x) == (Matrix([[0]]), Matrix([[3]]))
+    assert linear_eq_to_matrix([(x+1)**3-x**3-3*x**2 + 7], x) == (Matrix([[0]]), Matrix([[-8]]))
+    raises(ValueError, lambda: linear_eq_to_matrix([x*(1/x+1) + y], [x, y]))
+    raises(ValueError, lambda: linear_eq_to_matrix([(x + 1)*y], [x, y]))
+
+
 def test_simplification():
     eq = x + (a - b)/(-2*a + 2*b)
     assert solveset(eq, x) == FiniteSet(S.Half)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1146,6 +1146,13 @@ def test_linsolve():
     Eqns = [8*kilo*newton + x + y, 28*kilo*newton*meter + 3*x*meter]
     assert linsolve(Eqns, x, y) == {(-28000*newton/3, 4000*newton/3)}
 
+    # linsolve fully expands expressions, so removable singularities
+    # and other nonlinearity does not raise an error
+    assert linsolve([Eq(x, x + y)], [x, y]) == {(x, 0)}
+    assert linsolve([Eq(1/x, 1/x + y)], [x, y]) == {(x, 0)}
+    assert linsolve([Eq(y/x, y/x + y)], [x, y]) == {(x, 0)}
+    assert linsolve([Eq(x*(x + 1), x**2 + y)], [x, y]) == {(y, y)}
+
 
 def test_solve_decomposition():
     x = Symbol('x')
@@ -1605,12 +1612,24 @@ def test_issue_10397():
 
 
 def test_issue_14987():
-    raises(ValueError, lambda: linear_eq_to_matrix([x**2], x))
-    raises(ValueError, lambda: linear_eq_to_matrix([x*(-3/x + 1) + 2*y - a], [x, y]))
-    raises(ValueError, lambda: linear_eq_to_matrix([(x**2-3*x)/(x-3) - 3], x))
-    raises(ValueError, lambda: linear_eq_to_matrix([(x+1)**3-x**3-3*x**2 + 7], x))
-    raises(ValueError, lambda: linear_eq_to_matrix([x*(1/x+1) + y], [x, y]))
-    raises(ValueError, lambda: linear_eq_to_matrix([(x + 1)*y], [x, y]))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [x**2], x))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [x*(-3/x + 1) + 2*y - a], [x, y]))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [(x**2 - 3*x)/(x - 3) - 3], x))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [(x + 1)**3 - x**3 - 3*x**2 + 7], x))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [x*(1/x + 1) + y], [x, y]))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [(x + 1)*y], [x, y]))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [Eq(1/x, 1/x + y)], [x, y]))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [Eq(y/x, y/x + y)], [x, y]))
+    raises(ValueError, lambda: linear_eq_to_matrix(
+        [Eq(x*(x + 1), x**2 + y)], [x, y]))
 
 
 def test_simplification():

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1019,26 +1019,33 @@ def test_abs_invert_solvify():
 
 def test_linear_eq_to_matrix():
     x, y, z = symbols('x, y, z')
+    a, b, c, d, e, f, g, h, i, j, k, l = symbols('a:l')
+
     eqns1 = [2*x + y - 2*z - 3, x - y - z, x + y + 3*z - 12]
     eqns2 = [Eq(3*x + 2*y - z, 1), Eq(2*x - 2*y + 4*z, -2), -2*x + y - 2*z]
 
-    A, b = linear_eq_to_matrix(eqns1, x, y, z)
+    A, B = linear_eq_to_matrix(eqns1, x, y, z)
     assert A == Matrix([[2, 1, -2], [1, -1, -1], [1, 1, 3]])
-    assert b == Matrix([[3], [0], [12]])
+    assert B == Matrix([[3], [0], [12]])
 
-    A, b = linear_eq_to_matrix(eqns2, x, y, z)
+    A, B = linear_eq_to_matrix(eqns2, x, y, z)
     assert A == Matrix([[3, 2, -1], [2, -2, 4], [-2, 1, -2]])
-    assert b == Matrix([[1], [-2], [0]])
+    assert B == Matrix([[1], [-2], [0]])
 
     # Pure symbolic coefficients
-    from sympy.abc import a, b, c, d, e, f, g, h, i, j, k, l
-    eqns3 = [a*x + b*y + c*z - d, e*x + f*y + g*z - h, i*x + j*y + k*z - l]
+    eqns3 = [a*b*x + b*y + c*z - d, e*x + d*x + f*y + g*z - h, i*x + j*y + k*z - l]
     A, B = linear_eq_to_matrix(eqns3, x, y, z)
-    assert A == Matrix([[a, b, c], [e, f, g], [i, j, k]])
+    assert A == Matrix([[a*b, b, c], [d + e, f, g], [i, j, k]])
     assert B == Matrix([[d], [h], [l]])
 
-    # raise ValueError if no symbols are given
+    # raise ValueError if no symbols are given or duplicates are given
     raises(ValueError, lambda: linear_eq_to_matrix(eqns3))
+    raises(ValueError, lambda: linear_eq_to_matrix(eqns3, [x, x, y]))
+
+    assert linear_eq_to_matrix(1, x) == (Matrix([[0]]), Matrix([[-1]]))
+    assert linear_eq_to_matrix(Matrix(
+        [[a*x + b*y - 7], [5*x + 6*y - c]]), x, y) == (
+        Matrix([[a, b], [5, 6]]), Matrix([[7], [c]]))
 
 
 def test_linsolve():
@@ -1594,8 +1601,8 @@ def test_issue_10397():
 def test_issue_14987():
     raises(ValueError, lambda: linear_eq_to_matrix([x**2], x))
     raises(ValueError, lambda: linear_eq_to_matrix([x*(-3/x + 1) + 2*y - a], [x, y]))
-    assert linear_eq_to_matrix([(x**2-3*x)/(x-3) - 3], x) == (Matrix([[0]]), Matrix([[3]]))
-    assert linear_eq_to_matrix([(x+1)**3-x**3-3*x**2 + 7], x) == (Matrix([[0]]), Matrix([[-8]]))
+    raises(ValueError, lambda: linear_eq_to_matrix([(x**2-3*x)/(x-3) - 3], x))
+    raises(ValueError, lambda: linear_eq_to_matrix([(x+1)**3-x**3-3*x**2 + 7], x))
     raises(ValueError, lambda: linear_eq_to_matrix([x*(1/x+1) + y], [x, y]))
     raises(ValueError, lambda: linear_eq_to_matrix([(x + 1)*y], [x, y]))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

fixes #15195 
fixes #14987
closes #14999 as a consolidation of work there

#### Brief description of what is fixed or changed

Raise an error when nonlinearity in equations passed to `linear_eq_to_matrix` is encountered.

#### Other comments

This PR arises from the work started by @czgdp1807 to add non-linearity detection into `linear_eq_to_matrix`. The function `linear_coeffs` was written to provide an efficient way to extract linear coefficients without having to simplify an expression: if the expression is linear and has no nonlinear terms appearing in its unsimplified form, the coefficients of the requested symbols will be returned.

```python
    >>> linear_coeffs(x + y*(z*(3*x + 2) + 3), x)
    {0: y*(2*z + 3), x: 3*y*z + 1}
```
It also warns when nonlinear terms are encountered:
```python
    >>> eq = 1/x*(x - 1) + 1/x
    >>> linear_coeffs(eq, x)
    Traceback (most recent call last):
    ...
    ValueError: nonlinear term encountered: 1/x

    >>> linear_coeffs(x*(y + 1) - x*y, x, y)
    Traceback (most recent call last):
    ...
    ValueError: nonlinear term encountered: x*(y + 1)
```

Note: `linsolve` is a higher level function which uses expansion on its arguments before passing them to `linear_eq_to_matrix` and is not (currently) sensitive to removable nonlinearity.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * `linear_coeffs` added to solveset
  * nonlinear terms encountered by `linear_eq_to_matrix` will raise an error; repeated symbols and non-symbols will also raise an error
  * as a convenience, `linear_eq_to_matrix` now accepts a single Expr as its first argument.
<!-- END RELEASE NOTES -->
