### PR TITLE
codegen: revert to printing comments with unknown fcns

### DIFF
--- a/doc/src/modules/printing.rst
+++ b/doc/src/modules/printing.rst
@@ -261,17 +261,16 @@ to introduce the names of user-defined functions in the Fortran expression.
 
 However, when the user_functions argument is not provided, ``fcode`` will
 generate code which assumes that a function of the same name will be provided
-by the user:
+by the user.  A comment will be added to inform the user of the issue:
 
     >>> print(fcode(1 - gamma(x)**2))
-          -gamma(x)**2 + 1
-
-If this assumption is considered too optimistic, the printer can be configured
-to add a comment to inform the user of the issue.
-
-    >>> print(fcode(1 - gamma(x)**2, allow_unknown_functions=False))
     C     Not supported in Fortran:
     C     gamma
+          -gamma(x)**2 + 1
+
+The printer can be configured to omit these comments:
+
+    >>> print(fcode(1 - gamma(x)**2, allow_unknown_functions=True))
           -gamma(x)**2 + 1
 
 By default the output is human readable code, ready for copy and paste. With the
@@ -281,7 +280,7 @@ return value is a three-tuple containing: (i) a set of number symbols that must
 be defined as 'Fortran parameters', (ii) a list functions that cannot be
 translated in pure Fortran and (iii) a string of Fortran code. A few examples:
 
-    >>> fcode(1 - gamma(x)**2, human=False, allow_unknown_functions=False)
+    >>> fcode(1 - gamma(x)**2, human=False)
     (set(), {gamma(x)}, '      -gamma(x)**2 + 1')
     >>> fcode(1 - sin(x)**2, human=False)
     (set(), set(), '      -sin(x)**2 + 1')

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -168,7 +168,7 @@ class C89CodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
-        'allow_unknown_functions': True,
+        'allow_unknown_functions': False,
         'contract': True,
         'dereference': set(),
         'error_on_reserved': False,

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -54,7 +54,7 @@ class CodePrinter(StrPrinter):
         'reserved_word_suffix': '_',
         'human': True,
         'inline': False,
-        'allow_unknown_functions': True,
+        'allow_unknown_functions': False,
     }
 
     def __init__(self, settings=None):
@@ -382,7 +382,7 @@ class CodePrinter(StrPrinter):
         elif hasattr(expr, '_imp_') and isinstance(expr._imp_, Lambda):
             # inlined function
             return self._print(expr._imp_(*expr.args))
-        elif expr.is_Function and self._settings.get('allow_unknown_functions', True):
+        elif expr.is_Function and self._settings.get('allow_unknown_functions', False):
             return '%s(%s)' % (self._print(expr.func), ', '.join(map(self._print, expr.args)))
         else:
             return self._print_not_supported(expr)

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -98,7 +98,7 @@ class FCodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
-        'allow_unknown_functions': True,
+        'allow_unknown_functions': False,
         'source_format': 'fixed',
         'contract': True,
         'standard': 77,

--- a/sympy/printing/glsl.py
+++ b/sympy/printing/glsl.py
@@ -50,7 +50,7 @@ class GLSLPrinter(CodePrinter):
         'precision': 9,
         'user_functions': {},
         'human': True,
-        'allow_unknown_functions': True,
+        'allow_unknown_functions': False,
         'contract': True,
         'error_on_reserved': False,
         'reserved_word_suffix': '_'

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -55,7 +55,7 @@ class JavascriptCodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
-        'allow_unknown_functions': True,
+        'allow_unknown_functions': False,
         'contract': True
     }
 

--- a/sympy/printing/julia.py
+++ b/sympy/printing/julia.py
@@ -62,7 +62,7 @@ class JuliaCodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
-        'allow_unknown_functions': True,
+        'allow_unknown_functions': False,
         'contract': True,
         'inline': True,
     }

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -47,7 +47,7 @@ class MCodePrinter(CodePrinter):
         'precision': 15,
         'user_functions': {},
         'human': True,
-        'allow_unknown_functions': True,
+        'allow_unknown_functions': False,
     }
 
     _number_symbols = set()

--- a/sympy/printing/octave.py
+++ b/sympy/printing/octave.py
@@ -78,7 +78,7 @@ class OctaveCodePrinter(CodePrinter):
         'precision': 17,
         'user_functions': {},
         'human': True,
-        'allow_unknown_functions': True,
+        'allow_unknown_functions': False,
         'contract': True,
         'inline': True,
     }

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -133,8 +133,12 @@ def test_ccode_inline_function():
 
 def test_ccode_exceptions():
     assert ccode(gamma(x), standard='C99') == "tgamma(x)"
+    gamma_c89 = ccode(gamma(x), standard='C89')
+    assert 'not supported in c' in gamma_c89.lower()
     gamma_c89 = ccode(gamma(x), standard='C89', allow_unknown_functions=False)
     assert 'not supported in c' in gamma_c89.lower()
+    gamma_c89 = ccode(gamma(x), standard='C89', allow_unknown_functions=True)
+    assert not 'not supported in c' in gamma_c89.lower()
     assert ccode(ceiling(x)) == "ceil(x)"
     assert ccode(Abs(x)) == "fabs(x)"
     assert ccode(gamma(x)) == "tgamma(x)"

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -168,10 +168,10 @@ def test_implicit():
 def test_not_fortran():
     x = symbols('x')
     g = Function('g')
-    gamma_f = fcode(gamma(x), allow_unknown_functions=False)
+    gamma_f = fcode(gamma(x))
     assert gamma_f == "C     Not supported in Fortran:\nC     gamma\n      gamma(x)"
     assert fcode(Integral(sin(x))) == "C     Not supported in Fortran:\nC     Integral\n      Integral(sin(x), x)"
-    assert fcode(g(x), allow_unknown_functions=False) == "C     Not supported in Fortran:\nC     g\n      g(x)"
+    assert fcode(g(x)) == "C     Not supported in Fortran:\nC     g\n      g(x)"
 
 
 def test_user_functions():

--- a/sympy/printing/tests/test_octave.py
+++ b/sympy/printing/tests/test_octave.py
@@ -374,6 +374,15 @@ def test_octave_not_supported():
     )
 
 
+def test_octave_not_supported_not_on_whitelist():
+    from sympy import assoc_laguerre
+    assert mcode(assoc_laguerre(x, y, z)) == (
+        "% Not supported in Octave:\n"
+        "% assoc_laguerre\n"
+        "assoc_laguerre(x, y, z)"
+    )
+
+
 def test_octave_expint():
     assert mcode(expint(1, x)) == "expint(x)"
     assert mcode(expint(2, x)) == (

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -425,6 +425,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
                 for k in m:
                     user_functions[k] = k
         printer = Printer({'fully_qualified_modules': False, 'inline': True,
+                           'allow_unknown_functions': True,
                            'user_functions': user_functions})
 
     # Get the names of the args, for creating a docstring


### PR DESCRIPTION
Recent commits added a new `allow_unknown_functions` flag to
CodePrinter and children.  Change the default of this flag to False
to revert to the previous behaviour.  Update tests and documentation.
    
`lambdify` apparently needs this new flag for #15071 so turn on the
flag there.


#### Release Notes for the bot:

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

#### Release Notes for the humans:

TODO: if this is merged, this entry should be edited:

> CodePrinter now generates code for unkown Function instances unless
> the new printer option allow_unknown_functions is set to False.

Suggested text: "CodePrinter can generate code for unknown Functions if the new option `allow_unknown_functions=True` is passed. (#15085 by @bjodah, #15215 by @cbm755)

I'd also suggest moving it to the codegen section instead of printing.
