### PR TITLE
Application & Subs mods

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1857,13 +1857,7 @@ class Subs(Expr):
     def __eq__(self, other):
         if not isinstance(other, Subs):
             return False
-        s = self._hashable_content()
-        o = other._hashable_content()
-        if len(s) != len(o):
-            return False
-        if s[0] != o[0]:
-            return False
-        return s[1:] == o[1:]
+        return self._hashable_content() == other._hashable_content()
 
     def __ne__(self, other):
         return not(self == other)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -49,7 +49,7 @@ from sympy.core.logic import fuzzy_and
 from sympy.core.compatibility import string_types, with_metaclass, range
 from sympy.utilities import default_sort_key
 from sympy.utilities.misc import filldedent
-from sympy.utilities.iterables import uniq
+from sympy.utilities.iterables import has_dups
 from sympy.core.evaluate import global_evaluate
 
 import sys
@@ -128,8 +128,6 @@ def _getnargs_new(eval_):
         if not num_with_default:
             return num_no_default
         return tuple(range(num_no_default, num_no_default+num_with_default+1))
-
-
 
 
 class FunctionClass(ManagedProperties):
@@ -314,7 +312,7 @@ class Application(with_metaclass(FunctionClass, Basic)):
         if (old.is_Function and new.is_Function and
             callable(old) and callable(new) and
             old == self.func and len(self.args) in new.nargs):
-            return new(*self.args)
+            return new(*[i._subs(old, new) for i in self.args])
 
 
 class Function(Application, Expr):
@@ -512,7 +510,7 @@ class Function(Application, Expr):
     def _eval_evalf(self, prec):
         # Lookup mpmath function based on name
         try:
-            if isinstance(self.func, UndefinedFunction):
+            if isinstance(self, AppliedUndef):
                 # Shouldn't lookup in mpmath but might have ._imp_
                 raise AttributeError
             fname = self.func.__name__
@@ -605,6 +603,7 @@ class Function(Application, Expr):
         """
         This function does compute series for multivariate functions,
         but the expansion is always in terms of *one* variable.
+
         Examples
         ========
 
@@ -834,6 +833,7 @@ class UndefinedFunction(FunctionClass):
 
     def __ne__(self, other):
         return not self == other
+
 
 class WildFunction(Function, AtomicExpr):
     """
@@ -1756,14 +1756,17 @@ class Subs(Expr):
     """
     def __new__(cls, expr, variables, point, **assumptions):
         from sympy import Symbol
+
         if not is_sequence(variables, Tuple):
             variables = [variables]
-        variables = list(sympify(variables))
+        variables = Tuple(*variables)
 
-        if list(uniq(variables)) != variables:
-            repeated = [ v for v in set(variables) if variables.count(v) > 1 ]
-            raise ValueError('cannot substitute expressions %s more than '
-                             'once.' % repeated)
+        if has_dups(variables):
+            repeated = [str(v) for v, i in Counter(variables).items() if i > 1]
+            __ = ', '.join(repeated)
+            raise ValueError(filldedent('''
+                The following expressions appear more than once: %s
+                ''' % __))
 
         point = Tuple(*(point if is_sequence(point, Tuple) else [point]))
 
@@ -1771,7 +1774,16 @@ class Subs(Expr):
             raise ValueError('Number of point values must be the same as '
                              'the number of variables.')
 
-        expr = sympify(expr)
+        if not point:
+            return sympify(expr)
+
+        # denest
+        if isinstance(expr, Subs):
+            variables = expr.variables + variables
+            point = expr.point + point
+            expr = expr.expr
+        else:
+            expr = sympify(expr)
 
         # use symbols with names equal to the point value (with preppended _)
         # to give a variable-independent expression
@@ -1842,15 +1854,16 @@ class Subs(Expr):
         return (self.expr.expr_free_symbols - set(self.variables) |
             set(self.point.expr_free_symbols))
 
-    def _has(self, pattern):
-        if pattern in self.variables and pattern not in self.point:
-            return False
-        return super(Subs, self)._has(pattern)
-
     def __eq__(self, other):
         if not isinstance(other, Subs):
             return False
-        return self._expr == other._expr
+        s = self._hashable_content()
+        o = other._hashable_content()
+        if len(s) != len(o):
+            return False
+        if s[0] != o[0]:
+            return False
+        return s[1:] == o[1:]
 
     def __ne__(self, other):
         return not(self == other)
@@ -1859,14 +1872,29 @@ class Subs(Expr):
         return super(Subs, self).__hash__()
 
     def _hashable_content(self):
-        return (self._expr.xreplace(self.canonical_variables),)
+        return (self._expr.xreplace(self.canonical_variables),
+            ) + tuple(ordered([(v, p) for v, p in
+            zip(self.variables, self.point) if not self.expr.has(v)]))
 
     def _eval_subs(self, old, new):
+        # Subs doit will do the variables in order; the semantics
+        # of subs for Subs is have the following invariant for
+        # Subs object foo:
+        #    foo.doit().subs(reps) == foo.subs(reps).doit()
+        pt = list(self.point)
         if old in self.variables:
-            if old in self.point:
-                newpoint = tuple(new if i == old else i for i in self.point)
-                return self.func(self.expr, self.variables, newpoint)
-            return self
+            i = self.variables.index(old)
+            # any occurance of old before this point will get
+            # handled by replacements from here on
+            for j in range(i, len(self.variables)):
+                pt[j] = pt[j]._subs(old, new)
+            return self.func(self.expr, self.variables, pt)
+        v = [i._subs(old, new) for i in self.variables]
+        if v != list(self.variables):
+            return self.func(self.expr, self.variables + (old,), pt + [new])
+        expr = self.expr._subs(old, new)
+        pt = [i._subs(old, new) for i in self.point]
+        return self.func(expr, v, pt)
 
     def _eval_derivative(self, s):
         # Apply the chain rule of the derivative on the substitution variables:

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -191,7 +191,6 @@ def test_Lambda():
     assert Lambda(x, 1)(1) is S.One
 
 
-
 def test_IdentityFunction():
     assert Lambda(x, x) is Lambda(y, y) is S.IdentityFunction
     assert Lambda(x, 2*x) is not S.IdentityFunction
@@ -221,6 +220,15 @@ def test_Lambda_equality():
 
 
 def test_Subs():
+    assert Subs(1, (), ()) is S.One
+    # check null subs influence on hashing
+    assert Subs(x, y, z) != Subs(x, y, 1)
+    # self mapping var/point
+    assert Subs(Derivative(f(x), (x, 2)), x, x).doit() == f(x).diff(x, x)
+    assert Subs(x, x, 0).has(x)  # it's a structural answer
+    assert not Subs(x, x, 0).free_symbols
+    assert Subs(Subs(x + y, x, 2), y, 1) == Subs(x + y, (x, y), (2, 1))
+    assert Subs(x, (x,), (0,)) == Subs(x, x, 0)
     assert Subs(x, x, 0) == Subs(y, y, 0)
     assert Subs(x, x, 0).subs(x, 1) == Subs(x, x, 0)
     assert Subs(y, x, 0).subs(y, 1) == Subs(1, x, 0)
@@ -228,8 +236,7 @@ def test_Subs():
     assert Subs(f(x**2), x**2, 0).doit() == f(0)
     assert Subs(f(x, y, z), (x, y, z), (0, 1, 1)) != \
         Subs(f(x, y, z), (x, y, z), (0, 0, 1))
-    assert Subs(f(x, y), (x, y, z), (0, 1, 1)) == \
-        Subs(f(x, y), (x, y, z), (0, 1, 2))
+    assert Subs(x, y, 2).subs(x, y).doit() == 2
     assert Subs(f(x, y), (x, y, z), (0, 1, 1)) != \
         Subs(f(x, y) + z, (x, y, z), (0, 1, 0))
     assert Subs(f(x, y), (x, y), (0, 1)).doit() == f(0, 1)
@@ -926,6 +933,7 @@ def test_order_could_be_zero():
     assert diff(y, (x, n + 1)) == S.Zero
     assert diff(y, (x, m)) == S.Zero
 
+
 def test_undefined_function_eq():
     f = Function('f')
     f2 = Function('f')
@@ -940,6 +948,7 @@ def test_undefined_function_eq():
     assert f != g
 
     assert f != f_real
+
 
 def test_function_assumptions():
     x = Symbol('x')

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -780,3 +780,27 @@ def test_issue_12657():
     reps = [(-oo, 2), (oo, 1)]
     assert (x < oo).subs(reps) == (x < 1)
     assert (x < oo).subs(list(reversed(reps))) == (x < 1)
+
+
+def test_recurse_Application_args():
+    F = Lambda((x, y), exp(2*x + 3*y))
+    f = Function('f')
+    A = f(x, f(x, x))
+    C = F(x, F(x, x))
+    assert A.subs(f, F) == A.replace(f, F) == C
+
+
+def test_Subs_subs():
+    assert Subs(x*y, x, x).subs(x, y) == Subs(x*y, x, y)
+    assert Subs(x*y, x, x + 1).subs(x, y) == \
+        Subs(x*y, x, y + 1)
+    assert Subs(x*y, y, x + 1).subs(x, y) == \
+        Subs(y**2, y, y + 1)
+    a = Subs(x*y*z, (y, x, z), (x + 1, x + z, x))
+    b = Subs(x*y*z, (y, x, z), (x + 1, y + z, y))
+    assert a.subs(x, y) == b and \
+        a.doit().subs(x, y) == a.subs(x, y).doit()
+    f = Function('f')
+    g = Function('g')
+    assert Subs(2*f(x, y) + g(x), f(x, y), 1).subs(y, 2) == Subs(
+        2*f(x, y) + g(x), (f(x, y), y), (1, 2))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

fixes #15138 

#### Brief description of what is fixed or changed

* `f(x, f(x,y)).subs(f, atan2)` will now give `atan2(x, atan2(x, y))` instead of `atan2(x, f(x, y))` In addition, subs involving Subs now give a result that should be the same whether doit is applied before or after the subs, e.g. `Subs(x*y, x, x + 1).subs(x, y).doit() == Subs(x*y, x, x + 1).doit().subs(x, y)`
* `Subs(x, x, 0).has(x)` is now True
* `Subs(Subs(x + y, x, 1), y, 2)` -> `Subs(x + y, (x, y), (1, 2))`
* `Subs(x, a, b)` no longer compares equal to `Subs(x, a, c)`

#### Other comments

The invariant that `Subs.subs.doit == Subs.doit.subs` does not apply when there are null-subs active. `Subs(x, y, 2).doit().subs(x, y) == y != Subs(x, y, 2).subs(x, y).doit() == 2`.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Application will recurse into args to do subs
  * Subs.has gives structural (not mathematical) answer
  * Subs(Subs) will denest
  * Subs hash includes null subs information

<!-- END RELEASE NOTES -->
