### PR TITLE
exprtools: modify _mask_nc for functions

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1312,10 +1312,7 @@ def _mask_nc(eq, name=None):
             if a.is_Symbol:
                 nc_syms.add(a)
             elif not (a.is_Add or a.is_Mul or a.is_Pow):
-                if all(s.is_commutative for s in a.free_symbols):
-                    rep.append((a, Dummy()))
-                else:
-                    nc_obj.add(a)
+                nc_obj.add(a)
                 pot.skip()
 
     # If there is only one nc symbol or object, it can be factored regularly

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -1,10 +1,10 @@
 """Tests for tools for manipulating of large commutative expressions. """
 
-from sympy import (S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple, I,
+from sympy import (S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple, I, Function,
                    Interval, O, symbols, simplify, collect, Sum, Basic, Dict,
                    root, exp, cos, sin, oo, Dummy, log)
 from sympy.core.exprtools import (decompose_power, Factors, Term, _gcd_terms,
-                                  gcd_terms, factor_terms, factor_nc,
+                                  gcd_terms, factor_terms, factor_nc, _mask_nc,
                                   _monotonic_sign)
 from sympy.core.mul import _keep_coeff as _keep_coeff
 from sympy.simplify.cse_opts import sub_pre
@@ -376,6 +376,13 @@ def test_issue_7903():
     t = exp(I*cos(a)) + exp(-I*sin(a))
     assert t.simplify()
 
+def test_issue_8263():
+    F, G = symbols('F, G', commutative=False, cls=Function)
+    x, y = symbols('x, y')
+    expr, dummies, _ = _mask_nc(F(x)*G(y) - G(y)*F(x))
+    for v in dummies.values():
+        assert not v.is_commutative
+    assert not expr.is_zero
 
 def test_monotonic_sign():
     F = _monotonic_sign


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #8263

As pointed out in issue #8263, _mask_nc treats noncommutative objects
with all commutative arguments as commutative. This commit changes
_mask_nc to replace any object for which is_commutative is False with a
noncommutative Dummy.

#### Brief description of what is fixed or changed

Prior to this change one obtains the following

```python
F, G = symbols('F, G', commutative=False, cls=Function)
x, y = symbols('x, y')
factor_nc(F(x)*G(y) - G(y)*F(x)).is_zero # True
```
This is unintuitive and inconvenient when working with non-commutative functions. After this change in this commit the above expression is left alone by factor_nc.


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * `factor(F(x)*F(y) - F(y)*F(x)) != 0` now for `F = Function('F', commutative=False)`

<!-- END RELEASE NOTES -->
