### PR TITLE
Sum gets dummy_eq method

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -165,6 +165,19 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         return obj
 
+    def dummy_eq(self, other, symbol=None):
+        if type(self) != type(other):
+            return False
+        if len(self.variables) != len(other.variables):
+            return False
+        if len(self.free_symbols) != len(other.free_symbols):
+            return False
+        reps = dict(zip(self.variables, other.variables))
+        aligned = self.xreplace(reps)
+        if symbol:
+            return super(Sum, aligned).dummy_eq(other, symbol=symbol)
+        return aligned == other
+
     def _eval_is_zero(self):
         # a Sum is only zero if its function is zero or if all terms
         # cancel out. This only answers whether the summand is zero; if

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -3,7 +3,7 @@ from sympy import (
     factorial, Function, harmonic, I, Integral, KroneckerDelta, log,
     nan, Ne, Or, oo, pi, Piecewise, Product, product, Rational, S, simplify,
     sin, sqrt, Sum, summation, Symbol, symbols, sympify, zeta, gamma, Le,
-    Indexed, Idx, IndexedBase, prod)
+    Indexed, Idx, IndexedBase, prod, Dummy)
 from sympy.abc import a, b, c, d, f, k, m, x, y, z
 from sympy.concrete.summations import telescopic
 from sympy.utilities.pytest import XFAIL, raises
@@ -614,7 +614,7 @@ def test_Sum_interface():
     raises(ValueError, lambda: summation(1))
 
 
-def test_eval_diff():
+def test_diff():
     assert Sum(x, (x, 1, 2)).diff(x) == 0
     assert Sum(x*y, (x, 1, 2)).diff(x) == 0
     assert Sum(x*y, (y, 1, 2)).diff(x) == Sum(y, (y, 1, 2))
@@ -1049,3 +1049,13 @@ def test_issue_14640():
     s = Sum(i*(a**(n - i) - b**(n - i))/(a - b), (i, 0, n)).doit()
     assert not s.has(Sum)
     assert s.subs({a: 2, b: 3, n: 5}) == 122
+
+
+def test_Sum_dummy_eq():
+    assert Sum(x, (x, a, b)).dummy_eq(Sum(x, (x, a, b)))
+    d = Dummy()
+    assert Sum(x, (x, a, d)).dummy_eq(Sum(x, (x, a, c)), c)
+    assert not Sum(x, (x, a, d)).dummy_eq(Sum(x, (x, a, c)))
+    assert Sum(x, (x, a, c)).dummy_eq(Sum(y, (y, a, c)))
+    assert Sum(x, (x, a, d)).dummy_eq(Sum(y, (y, a, c)), c)
+    assert not Sum(x, (x, a, d)).dummy_eq(Sum(y, (y, a, c)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

Subs already has an `__eq__` method to compare expressions that differ only in symbols getting replaced:
```python
>>> Subs(x+y,x,a)==Subs(z+y,z,a)
True
```
Sum does not:
```python
>>> Sum(x,(x,1,a))==Sum(y,(y,1,a))
False
```
a `dummy_eq` method was added to allow this (and a case involving a dummy symbol) to be handled:
```
>>> Sum(x,(x,1,a)).dummy_eq(Sum(y,(y,1,a)))
True
```
There is an example of the dummy symbol case in the tests that are added.

#### Other comments

This is in preparation for results of n-times differentiation that will be returned in a future commit:
```python
>>> diff(2*x, (x, n))
Sum(Piecewise((2*x*factorial(n)/(factorial(_k1)*factorial(-_k1 + n)), Eq(_k1, 0)
 & Eq(Max(0, -_k1 + n), 0)), (2*factorial(n)/(factorial(_k1)*factorial(-_k1 + n)),
 Eq(_k1, 0) & Eq(Max(0, -_k1 + n), 1)), (0, True)), (_k1, 0, n))
```

#### Release Notes
<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* concrete
  * Sum.dummy_eq added to allow comparisons of Sums that have a dummy symbol in them

<!-- END RELEASE NOTES -->
