### PR TITLE
_atomic gets recurse flag

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1807,11 +1807,11 @@ def _aresame(a, b):
         return True
 
 
-def _atomic(e):
+def _atomic(e, recursive=False):
     """Return atom-like quantities as far as substitution is
     concerned: Derivatives, Functions and Symbols. Don't
     return any 'atoms' that are inside such quantities unless
-    they also appear outside, too.
+    they also appear outside, too, unless `recursive` is True.
 
     Examples
     ========
@@ -1831,10 +1831,13 @@ def _atomic(e):
     from sympy import Derivative, Function, Symbol
     pot = preorder_traversal(e)
     seen = set()
-    try:
-        free = e.free_symbols
-    except AttributeError:
-        return {e}
+    if isinstance(e, Basic):
+        try:
+            free = e.free_symbols
+        except AttributeError:
+            return {e}
+    else:
+        return set()
     atoms = set()
     for p in pot:
         if p in seen:
@@ -1844,7 +1847,8 @@ def _atomic(e):
         if isinstance(p, Symbol) and p in free:
             atoms.add(p)
         elif isinstance(p, (Derivative, Function)):
-            pot.skip()
+            if not recursive:
+                pot.skip()
             atoms.add(p)
     return atoms
 

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -4,9 +4,11 @@ of Basic or Atom."""
 import collections
 import sys
 
-from sympy.core.basic import Basic, Atom, preorder_traversal, as_Basic
+from sympy.core.basic import (Basic, Atom, preorder_traversal, as_Basic,
+    _atomic)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
+from sympy.core.function import Function
 from sympy.core.compatibility import default_sort_key
 
 from sympy import sin, Lambda, Q, cos, gamma, Tuple
@@ -235,3 +237,10 @@ def test_as_Basic():
     assert as_Basic(1) is S.One
     assert as_Basic(()) == Tuple()
     raises(TypeError, lambda: as_Basic([]))
+
+
+def test_atomic():
+    g, h = map(Function, 'gh')
+    x = symbols('x')
+    assert _atomic(g(x + h(x))) == {g(x + h(x))}
+    assert _atomic(g(x + h(x)), recursive=True) == {h(x), x, g(x + h(x))}


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

This is needed in anticipation of Derivative-related modifications. It just allows `_atomic` to recurse into arguments.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  *`_atomic` can recurse into arguments
<!-- END RELEASE NOTES -->
