### PR TITLE
boolalg _eval_simplify method does more than `simplify_logic`

### DIFF
--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -264,6 +264,9 @@ def test_simplification():
     assert simplify((A & B) | (A & C)) == And(A, Or(B, C))
     assert simplify(And(x, Not(x))) == False
     assert simplify(Or(x, Not(x))) == True
+    assert simplify(And(Eq(x, 0), Eq(x, y))) == And(Eq(x, 0), Eq(y, 0))
+    assert And(Eq(x, 0), Eq(x, y)).simplify() == And(Eq(x, 0), Eq(y, 0))
+    assert And(Eq(x, 0), Ne(x, y)).simplify() == And(Eq(x, 0), Ne(y, 0))
 
 
 def test_bool_map():
@@ -818,4 +821,4 @@ def test_binary_symbols():
 
 
 def test_BooleanFunction_diff():
-    assert And(x, y).diff(x) == Piecewise((0, Eq(False, y)), (1, True))
+    assert And(x, y).diff(x) == Piecewise((0, Eq(y, False)), (1, True))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

```python
>>> And(Eq(x, 0), Eq(x, y)).simplify() == And(Eq(x, 0), Eq(y, 0))
True
```
#### Other comments

This will be used in Piecewise simplification and is going to be used in future Derivative-related modifications.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * BooleanFunction._eval_simplify includes some basic simplification of And with Eq args
<!-- END RELEASE NOTES -->
