### PR TITLE
print Subs with singleton replacement without tuple

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1026,11 +1026,9 @@ class Derivative(Expr):
         >>> from sympy import symbols, Function
         >>> f, g = symbols('f g', cls=Function)
         >>> f(2*g(x)).diff(x)
-        2*Derivative(g(x), x)*Subs(Derivative(f(_xi_1), _xi_1),
-                                              (_xi_1,), (2*g(x),))
+        2*Derivative(g(x), x)*Subs(Derivative(f(_xi_1), _xi_1), _xi_1, 2*g(x))
         >>> f(g(x)).diff(x)
-        Derivative(g(x), x)*Subs(Derivative(f(_xi_1), _xi_1),
-                                            (_xi_1,), (g(x),))
+        Derivative(g(x), x)*Subs(Derivative(f(_xi_1), _xi_1), _xi_1, g(x))
 
     Finally, note that, to be consistent with variational calculus, and to
     ensure that the definition of substituting a Function for a Symbol in an
@@ -1076,8 +1074,7 @@ class Derivative(Expr):
         >>> Derivative(f(x)**2, f(x), evaluate=True)
         2*f(x)
         >>> Derivative(f(g(x)), x, evaluate=True)
-        Derivative(g(x), x)*Subs(Derivative(f(_xi_1), _xi_1),
-                                            (_xi_1,), (g(x),))
+        Derivative(g(x), x)*Subs(Derivative(f(_xi_1), _xi_1), _xi_1, g(x))
 
     """
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1742,7 +1742,7 @@ class Subs(Expr):
     >>> f = Function('f')
     >>> e = Subs(f(x).diff(x), x, y)
     >>> e.subs(y, 0)
-    Subs(Derivative(f(x), x), (x,), (0,))
+    Subs(Derivative(f(x), x), x, 0)
     >>> e.subs(f, sin).doit()
     cos(y)
 

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -647,7 +647,7 @@ def test_simultaneous_subs():
     assert (x/y).subs(reps, simultaneous=True) == \
         (y/x).subs(reps, simultaneous=True)
     assert Derivative(x, y, z).subs(reps, simultaneous=True) == \
-        Subs(Derivative(0, y, z), (y,), (0,))
+        Subs(Derivative(0, y, z), y, 0)
 
 
 def test_issue_6419_6421():

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -404,6 +404,14 @@ class StrPrinter(Printer):
                 use = trim
             return 'Permutation(%s)' % use
 
+    def _print_Subs(self, obj):
+        expr, old, new = obj.args
+        if len(obj.point) == 1:
+            old = old[0]
+            new = new[0]
+        return "Subs(%s, %s, %s)" % (
+            self._print(expr), self._print(old), self._print(new))
+
     def _print_TensorIndex(self, expr):
         return expr._print()
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -6,7 +6,7 @@ from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     Rational, Float, Rel, S, sin, SparseMatrix, sqrt, summation, Sum, Symbol,
     symbols, Wild, WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet, factor,
     subfactorial, true, false, Equivalent, Xor, Complement, SymmetricDifference,
-    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion)
+    AccumBounds, UnevaluatedExpr, Eq, Ne, Quaternion, Subs)
 from sympy.core import Expr, Mul
 from sympy.physics.units import second, joule
 from sympy.polys import Poly, rootof, RootSum, groebner, ring, field, ZZ, QQ, lex, grlex
@@ -804,3 +804,8 @@ def test_MatrixSymbol_printing():
 
     assert str(A - A*B - B) == "-B - A*B + A"
     assert str(A*B - (A+B)) == "-(A + B) + A*B"
+
+
+def test_Subs_printing():
+    assert str(Subs(x, (x,), (1,))) == 'Subs(x, x, 1)'
+    assert str(Subs(x + y, (x, y), (1, 2))) == 'Subs(x + y, (x, y), (1, 2))'

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -103,14 +103,14 @@ def test_issue_11313():
 def test_series_of_Subs():
     from sympy.abc import x, y, z
 
-    subs1 = Subs(sin(x), (x,), (y,))
-    subs2 = Subs(sin(x) * cos(z), (x,), (y,))
+    subs1 = Subs(sin(x), x, y)
+    subs2 = Subs(sin(x) * cos(z), x, y)
     subs3 = Subs(sin(x * z), (x, z), (y, x))
 
     assert subs1.series(x) == subs1
-    assert subs1.series(y) == Subs(x, (x,), (y,)) + Subs(-x**3/6, (x,), (y,)) + Subs(x**5/120, (x,), (y,)) + O(y**6)
+    assert subs1.series(y) == Subs(x, x, y) + Subs(-x**3/6, x, y) + Subs(x**5/120, x, y) + O(y**6)
     assert subs1.series(z) == subs1
-    assert subs2.series(z) == Subs(z**4*sin(x)/24, (x,), (y,)) + Subs(-z**2*sin(x)/2, (x,), (y,)) + Subs(sin(x), (x,), (y,)) + O(z**6)
+    assert subs2.series(z) == Subs(z**4*sin(x)/24, x, y) + Subs(-z**2*sin(x)/2, x, y) + Subs(sin(x), x, y) + O(z**6)
     assert subs3.series(x).doit() == subs3.doit().series(x)
     assert subs3.series(z).doit() == sin(x*y)
 
@@ -118,22 +118,22 @@ def test_series_of_Subs():
 def test_issue_3978():
     f = Function('f')
     assert f(x).series(x, 0, 3, dir='-') == \
-            f(0) + x*Subs(Derivative(f(x), x), (x,), (0,)) + \
-            x**2*Subs(Derivative(f(x), x, x), (x,), (0,))/2 + O(x**3)
+            f(0) + x*Subs(Derivative(f(x), x), x, 0) + \
+            x**2*Subs(Derivative(f(x), x, x), x, 0)/2 + O(x**3)
     assert f(x).series(x, 0, 3) == \
-            f(0) + x*Subs(Derivative(f(x), x), (x,), (0,)) + \
-            x**2*Subs(Derivative(f(x), x, x), (x,), (0,))/2 + O(x**3)
+            f(0) + x*Subs(Derivative(f(x), x), x, 0) + \
+            x**2*Subs(Derivative(f(x), x, x), x, 0)/2 + O(x**3)
     assert f(x**2).series(x, 0, 3) == \
-            f(0) + x**2*Subs(Derivative(f(x), x), (x,), (0,)) + O(x**3)
+            f(0) + x**2*Subs(Derivative(f(x), x), x, 0) + O(x**3)
     assert f(x**2+1).series(x, 0, 3) == \
-            f(1) + x**2*Subs(Derivative(f(x), x), (x,), (1,)) + O(x**3)
+            f(1) + x**2*Subs(Derivative(f(x), x), x, 1) + O(x**3)
 
     class TestF(Function):
         pass
 
     assert TestF(x).series(x, 0, 3) ==  TestF(0) + \
-            x*Subs(Derivative(TestF(x), x), (x,), (0,)) + \
-            x**2*Subs(Derivative(TestF(x), x, x), (x,), (0,))/2 + O(x**3)
+            x*Subs(Derivative(TestF(x), x), x, 0) + \
+            x**2*Subs(Derivative(TestF(x), x, x), x, 0)/2 + O(x**3)
 
 from sympy.series.acceleration import richardson, shanks
 from sympy import Sum, Integer

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -429,7 +429,7 @@ def checkpdesol(pde, sol, func=None, solve_for_func=True):
     >>> assert checkpdesol(eq, sol)[0]
     >>> eq = x*f(x,y) + f(x,y).diff(x)
     >>> checkpdesol(eq, sol)
-    (False, (x*F(4*x - 3*y) - 6*F(4*x - 3*y)/25 + 4*Subs(Derivative(F(_xi_1), _xi_1), (_xi_1,), (4*x - 3*y,)))*exp(-6*x/25 - 8*y/25))
+    (False, (x*F(4*x - 3*y) - 6*F(4*x - 3*y)/25 + 4*Subs(Derivative(F(_xi_1), _xi_1), _xi_1, 4*x - 3*y))*exp(-6*x/25 - 8*y/25))
     """
 
     # Converting the pde into an equation

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -161,18 +161,15 @@ def test_dsolve_linsystem_symbol_piecewise():
     u = Symbol('u')
     eq = (Eq(diff(f(x), x), 2*f(x) + g(x)),
            Eq(diff(g(x), x), u*f(x)))
-    s1 = [
-        Eq(f(x), Piecewise((C1*exp(x*(sqrt(4*u + 4)/2 + 1))
-            + C2*exp(x*(-sqrt(4*u + 4)/2 + 1)), Ne(4*u + 4, 0)),
-            ((C1 + C2*(x + Piecewise((0, Eq(sqrt(4*u + 4)/2 + 1, 2)),
-            (1/(-sqrt(4*u + 4)/2 + 1), True))))*exp(x*(sqrt(4*u + 4)/2 + 1)),
-            True))),
-        Eq(g(x), Piecewise((C1*(sqrt(4*u + 4)/2 - 1)*exp(x*(sqrt(4*u + 4)/2 + 1))
-            + C2*(-sqrt(4*u + 4)/2 - 1)*exp(x*(-sqrt(4*u + 4)/2 + 1)),
-            Ne(4*u + 4, 0)), ((C1*(sqrt(4*u + 4)/2 - 1) + C2*(x*(sqrt(4*u + 4)/2 - 1)
-            + Piecewise((1, Eq(sqrt(4*u + 4)/2 + 1, 2)),
-            (0, True))))*exp(x*(sqrt(4*u + 4)/2 + 1)), True)))
-    ]
+    s1 = [Eq(f(x), Piecewise((C1*exp(x*(sqrt(4*u + 4)/2 + 1)) +
+        C2*exp(x*(-sqrt(4*u + 4)/2 + 1)), Ne(4*u + 4, 0)), ((C1 + C2*(x +
+        Piecewise((0, Eq(sqrt(4*u + 4)/2 + 1, 2)), (1/(-sqrt(4*u + 4)/2 + 1),
+        True))))*exp(x*(sqrt(4*u + 4)/2 + 1)), True))), Eq(g(x),
+        Piecewise((C1*(sqrt(4*u + 4)/2 - 1)*exp(x*(sqrt(4*u + 4)/2 + 1)) +
+        C2*(-sqrt(4*u + 4)/2 - 1)*exp(x*(-sqrt(4*u + 4)/2 + 1)), Ne(4*u + 4,
+        0)), ((C1*(sqrt(4*u + 4)/2 - 1) + C2*(x*(sqrt(4*u + 4)/2 - 1) +
+        Piecewise((1, Eq(sqrt(4*u + 4)/2 + 1, 2)), (0,
+        True))))*exp(x*(sqrt(4*u + 4)/2 + 1)), True)))]
     s = dsolve(eq)
     assert s == s1
     s = [(l.lhs, l.rhs) for l in s]
@@ -2896,7 +2893,7 @@ def test_issue_10867():
 def test_issue_11290():
     sol_1 = dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x), f(x), simplify=False, hint='1st_exact_Integral')
     sol_0 = dsolve(cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x), f(x), simplify=False, hint='1st_exact')
-    assert str(sol_1)== "Eq(Subs(Integral(_y**2 - x*sin(_y) - Integral(-sin(_y), x), _y) + Integral(cos(_y), x), (_y,), (f(x),)), C1)"
+    assert str(sol_1)== "Eq(Subs(Integral(_y**2 - x*sin(_y) - Integral(-sin(_y), x), _y) + Integral(cos(_y), x), _y, f(x)), C1)"
     assert sol_1.doit() == sol_0
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

This simplifies printing of Subs so that if there is only a single replacement it is printed without being wrapped as a tuple:
```python
>>> Subs(x, x, 1)
Subs(x, x, 1)  # instead of Subs(x, (x,), (1,))
```
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Subs with singleton args prints without wrapping variable/point as tuple

<!-- END RELEASE NOTES -->
