### PR TITLE
remove unused multinomial0

### DIFF
--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from collections import defaultdict
-from sympy.core.compatibility import range
+from sympy.core.compatibility import range, as_int
 
 
 def binomial_coefficients(n):
@@ -20,6 +20,7 @@ def binomial_coefficients(n):
 
     binomial_coefficients_list, multinomial_coefficients
     """
+    n = as_int(n)
     d = {(0, n): 1, (n, 0): 1}
     a = 1
     for k in range(1, n//2 + 1):
@@ -44,70 +45,13 @@ def binomial_coefficients_list(n):
 
     binomial_coefficients, multinomial_coefficients
     """
+    n = as_int(n)
     d = [1] * (n + 1)
     a = 1
     for k in range(1, n//2 + 1):
         a = (a * (n - k + 1))//k
         d[k] = d[n - k] = a
     return d
-
-
-def multinomial_coefficients0(m, n, _tuple=tuple, _zip=zip):
-    """Return a dictionary containing pairs ``{(k1,k2,..,km) : C_kn}``
-    where ``C_kn`` are multinomial coefficients such that
-    ``n=k1+k2+..+km``.
-
-    For example:
-
-    >>> from sympy import multinomial_coefficients
-    >>> multinomial_coefficients(2, 5) # indirect doctest
-    {(0, 5): 1, (1, 4): 5, (2, 3): 10, (3, 2): 10, (4, 1): 5, (5, 0): 1}
-
-    The algorithm is based on the following result:
-
-       Consider a polynomial and its ``n``-th exponent::
-
-         P(x) = sum_{i=0}^m p_i x^i
-         P(x)^n = sum_{k=0}^{m n} a(n,k) x^k
-
-       The coefficients ``a(n,k)`` can be computed using the
-       J.C.P. Miller Pure Recurrence [see D.E.Knuth, Seminumerical
-       Algorithms, The art of Computer Programming v.2, Addison
-       Wesley, Reading, 1981;]::
-
-         a(n,k) = 1/(k p_0) sum_{i=1}^m p_i ((n+1)i-k) a(n,k-i),
-
-       where ``a(n,0) = p_0^n``.
-    """
-
-    if not m:
-        if n:
-            return {}
-        return {(): 1}
-    if m == 2:
-        return binomial_coefficients(n)
-    symbols = [(0,)*i + (1,) + (0,)*(m - i - 1) for i in range(m)]
-    s0 = symbols[0]
-    p0 = [_tuple(aa - bb for aa, bb in _zip(s, s0)) for s in symbols]
-    r = {_tuple(aa*n for aa in s0): 1}
-    l = [0] * (n*(m - 1) + 1)
-    l[0] = r.items()
-    for k in range(1, n*(m - 1) + 1):
-        d = defaultdict(int)
-        for i in range(1, min(m, k + 1)):
-            nn = (n + 1)*i - k
-            if not nn:
-                continue
-            t = p0[i]
-            for t2, c2 in l[k - i]:
-                tt = _tuple([aa + bb for aa, bb in _zip(t2, t)])
-                d[tt] += nn*c2
-                if not d[tt]:
-                    del d[tt]
-        r1 = [(t, c//k) for (t, c) in d.items()]
-        l[k] = r1
-        r.update(r1)
-    return r
 
 
 def multinomial_coefficients(m, n):
@@ -135,6 +79,8 @@ def multinomial_coefficients(m, n):
 
     binomial_coefficients_list, binomial_coefficients
     """
+    m = as_int(m)
+    n = as_int(n)
     if not m:
         if n:
             return {}
@@ -200,6 +146,8 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
     >>> next(it)
     ((3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), 1)
     """
+    m = as_int(m)
+    n = as_int(n)
     if m < 2*n or n == 1:
         mc = multinomial_coefficients(m, n)
         for k, v in mc.items():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

multinomial_coefficients0 is similar to the version without the appended 0 but is unused in SymPy and gives negative k values, e.g.

```python
>>> (list(multinomial_coefficients0(3,1)))
[(1, 0, 0), (0, 1, 0), (0, 0, 1), (-1, 1, 1)]
```

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* ntheory
  * remove unused multinomial0

<!-- END RELEASE NOTES -->
