### PR TITLE
ordinal(1)->1st: ordinal added to misc

### DIFF
--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -7,7 +7,7 @@ import os
 import re as _re
 import struct
 from textwrap import fill, dedent
-from sympy.core.compatibility import get_function_name, range
+from sympy.core.compatibility import get_function_name, range, as_int
 
 
 
@@ -421,3 +421,30 @@ def translate(s, a, b=None, c=None):
             s = s.translate(dict(
                 [(i, ord(c)) for i, c in enumerate(table)]))
         return s
+
+
+def ordinal(num):
+    """Return ordinal number string of num, e.g. 1 becomes 1st.
+    """
+    # modified from https://codereview.stackexchange.com/questions/41298/producing-ordinal-numbers
+    n = as_int(num)
+    if n < 0:
+        return '-%s' % ordinal(-n)
+    if n == 0 or 4 <= n <= 20:
+        suffix = 'th'
+    elif n == 1 or (n % 10) == 1:
+        suffix = 'st'
+    elif n == 2 or (n % 10) == 2:
+        suffix = 'nd'
+    elif n == 3 or (n % 10) == 3:
+        suffix = 'rd'
+    elif n < 101:
+        suffix = 'th'
+    else:
+        suffix = ordinal(n % 100)
+        if len(suffix) == 3:
+            # e.g. 103 -> 3rd
+            # so add other 0 back
+            suffix = '0' + suffix
+        n = str(n)[:-2]
+    return str(n) + suffix

--- a/sympy/utilities/tests/test_misc.py
+++ b/sympy/utilities/tests/test_misc.py
@@ -1,5 +1,5 @@
 from sympy.core.compatibility import unichr
-from sympy.utilities.misc import translate, replace
+from sympy.utilities.misc import translate, replace, ordinal
 
 def test_translate():
     abc = 'abc'
@@ -20,3 +20,18 @@ def test_replace():
     assert replace('abc', ('a', 'b')) == 'bbc'
     assert replace('abc', {'a': 'Aa'}) == 'Aabc'
     assert replace('abc', ('a', 'b'), ('c', 'C')) == 'bbC'
+
+
+def test_ordinal():
+    assert ordinal(-1) == '-1st'
+    assert ordinal(0) == '0th'
+    assert ordinal(1) == '1st'
+    assert ordinal(2) == '2nd'
+    assert ordinal(3) == '3rd'
+    assert all(ordinal(i).endswith('th') for i in range(4, 21))
+    assert ordinal(100) == '100th'
+    assert ordinal(101) == '101st'
+    assert ordinal(102) == '102nd'
+    assert ordinal(103) == '103rd'
+    assert ordinal(104) == '104th'
+    assert ordinal(200) == '200th'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->


#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

This utility function corrects and extends an inline version that is present in a Derivative error message. Since that error message (smthng like "Can't calculate the nth derivative wrt foo") can be rewritten without using an ordinal number (and is removed in a future commit) this function is not necessary. 

Should we have it as a utility function?

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * ordinal will convert an int to its ordinal representation, e.g. 12 -> 12th

<!-- END RELEASE NOTES -->
