### PR TITLE
Add doc build tutorial for windows users.

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -38,10 +38,12 @@ And view it at::
 Windows 10
 ----------
 
-Some dependencies like dvipng or docbook2x are not available for windows.
+Making your sphinx build successful on the Windows system is tricky because of
+some dependencies like dvipng or docbook2x not available.
 
-For Windows 10, however, the Windows Subsystem for Linux is available, and you
-can install Ubuntu shell on top of it after following up the tutorial below
+For Windows 10, however, the Windows Subsystem for Linux can be a possible
+workaround solution, and you can install Ubuntu shell on your Windows system
+after following up the tutorial below
 
 https://github.com/MicrosoftDocs/WSL/blob/live/WSL/install-win10.md
 
@@ -57,6 +59,6 @@ and run in your shell to navigate to the folder.
 
 This method would provide better compatability than cygwin or msys2,
 and more convenience than a virtual machine, if you partially need linux
-environment for your work.
+environment for your workflow.
 
 However this method is only viable for Windows 10 64-bit users.

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -34,3 +34,29 @@ If you get **mpmath** error, install python3-mpmath package::
 And view it at::
 
     _build/html/index.html
+
+Windows 10
+----------
+
+Some dependencies like dvipng or docbook2x are not available for windows.
+
+For Windows 10, however, the Windows Subsystem for Linux is available, and you
+can install Ubuntu shell on top of it after following up the tutorial below.
+
+    https://github.com/MicrosoftDocs/WSL/blob/live/WSL/install-win10.md
+
+In your command prompt, simply run `ubuntu` to transfer to linux terminal,
+and follow up the Debian/Ubuntu tutorial above to install all the dependencies,
+and then you can run `make html` to build.
+(Note that you would also have to install `make` via `apt-get install make`)
+
+If you want to change directory in your prompt to your working folder of sympy
+in windows file system, you can prepend `cd /mnt/` to your file path in windows,
+and run in your shell to navigate to the folder.
+(Also note that linux uses `/` instead of `\` for path)
+
+This method would provide better compatability than cygwin or msys2,
+and more convenience than a virtual machine, if you partially need linux
+environment for your work.
+
+However this method is only viable for Windows 10 64-bit users.

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -55,9 +55,9 @@ and then you can run 'make html' to build.
 If you want to change directory in your prompt to your working folder of sympy
 in windows file system, you can prepend 'cd /mnt/' to your file path in windows,
 and run in your shell to navigate to the folder.
-(Also note that linux uses '/' instead of '\' for path)
+(Also note that linux uses '/' instead of '\\' for path)
 
-This method would provide better compatability than cygwin or msys2,
+This method would provide better compatibility than cygwin or msys2,
 and more convenience than a virtual machine, if you partially need linux
 environment for your workflow.
 

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -41,9 +41,9 @@ Windows 10
 Some dependencies like dvipng or docbook2x are not available for windows.
 
 For Windows 10, however, the Windows Subsystem for Linux is available, and you
-can install Ubuntu shell on top of it after following up the tutorial below::
+can install Ubuntu shell on top of it after following up the tutorial below
 
-    https://github.com/MicrosoftDocs/WSL/blob/live/WSL/install-win10.md
+https://github.com/MicrosoftDocs/WSL/blob/live/WSL/install-win10.md
 
 In your command prompt, simply run 'ubuntu' to transfer to linux terminal,
 and follow up the Debian/Ubuntu tutorial above to install all the dependencies,

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -41,19 +41,19 @@ Windows 10
 Some dependencies like dvipng or docbook2x are not available for windows.
 
 For Windows 10, however, the Windows Subsystem for Linux is available, and you
-can install Ubuntu shell on top of it after following up the tutorial below.
+can install Ubuntu shell on top of it after following up the tutorial below::
 
     https://github.com/MicrosoftDocs/WSL/blob/live/WSL/install-win10.md
 
-In your command prompt, simply run `ubuntu` to transfer to linux terminal,
+In your command prompt, simply run 'ubuntu' to transfer to linux terminal,
 and follow up the Debian/Ubuntu tutorial above to install all the dependencies,
-and then you can run `make html` to build.
-(Note that you would also have to install `make` via `apt-get install make`)
+and then you can run 'make html' to build.
+(Note that you would also have to install 'make' via 'apt-get install make')
 
 If you want to change directory in your prompt to your working folder of sympy
-in windows file system, you can prepend `cd /mnt/` to your file path in windows,
+in windows file system, you can prepend 'cd /mnt/' to your file path in windows,
 and run in your shell to navigate to the folder.
-(Also note that linux uses `/` instead of `\` for path)
+(Also note that linux uses '/' instead of '\' for path)
 
 This method would provide better compatability than cygwin or msys2,
 and more convenience than a virtual machine, if you partially need linux


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

I think there is lack of support for Windows systems, for building SymPy docs.
I could get a only possible workaround by installing Ubuntu on WSL, and could get my successful build out of it, and would like to share my discovery about it.

However, for windows 7, 8 or other users, I think there should be other workaround for this.
I had tried using cygwin, msys2, and mingw, but could not get the build successful because of some errors.

#### Other comments


#### Release Notes


<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
