### PR TITLE
Add nth_algebraic solver to dsolve

### DIFF
--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -108,8 +108,8 @@ the various ODE solving methods. For this reason, they are documented here.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_nth_linear_constant_coeff_variation_of_parameters
 
-:obj:`ode_nth_algebraic`
-^^^^^^^^^^^^^^^^
+:obj:`nth_algebraic`
+^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_nth_algebraic
 
 :obj:`separable`

--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -110,6 +110,10 @@ the various ODE solving methods. For this reason, they are documented here.
 
 :obj:`separable`
 ^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.ode.ode_nth_algebraic
+
+:obj:`separable`
+^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_separable
 
 :obj:`almost_linear`

--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -108,7 +108,7 @@ the various ODE solving methods. For this reason, they are documented here.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_nth_linear_constant_coeff_variation_of_parameters
 
-:obj:`separable`
+:obj:`ode_nth_algebraic`
 ^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_nth_algebraic
 

--- a/doc/src/tutorial/solvers.rst
+++ b/doc/src/tutorial/solvers.rst
@@ -237,8 +237,8 @@ To solve the ODE, pass it and the function to solve for to ``dsolve``.
 solutions to differential equations cannot be solved explicitly for the
 function.
 
-    >>> dsolve(f(x).diff(x)*(1 - sin(f(x))), f(x))
-    f(x) + cos(f(x)) = C₁
+    >>> dsolve(f(x).diff(x)*(1 - sin(f(x))) - 1, f(x))
+    -x + f(x) + cos(f(x)) = C₁
 
 The arbitrary constants in the solutions from dsolve are symbols of the form
 ``C1``, ``C2``, ``C3``, and so on.

--- a/sympy/physics/continuum_mechanics/beam.py
+++ b/sympy/physics/continuum_mechanics/beam.py
@@ -1508,10 +1508,10 @@ class Beam3D(Beam):
     is restricted.
 
     >>> from sympy.physics.continuum_mechanics.beam import Beam3D
-    >>> from sympy import symbols
+    >>> from sympy import symbols, simplify
     >>> l, E, G, I, A = symbols('l, E, G, I, A')
     >>> b = Beam3D(l, E, G, I, A)
-    >>> q, m = symbols('q, m')
+    >>> x, q, m = symbols('x, q, m')
     >>> b.apply_load(q, 0, 0, dir="y")
     >>> b.apply_moment_load(m, 0, -1, dir="z")
     >>> b.shear_force()
@@ -1525,10 +1525,18 @@ class Beam3D(Beam):
     [0, 0, l*x*(-l*q + 3*l*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*(A*G*l**2 + 12*E*I)) + 3*m)/(6*E*I)
     + q*x**3/(6*E*I) + x**2*(-l*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*(A*G*l**2 + 12*E*I))
     - m)/(2*E*I)]
-    >>> b.deflection()
-    [0, -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I))
-    + l*m*x**2/(4*E*I) - l*x**3*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I)) - m*x**3/(6*E*I)
-    + q*x**4/(24*E*I) + l*x*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I)) - q*x**2/(2*A*G), 0]
+    >>> dx, dy, dz = b.deflection()
+    >>> dx
+    0
+    >>> dz
+    0
+    >>> expectedy = (
+    ... -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I))
+    ... + l*m*x**2/(4*E*I) - l*x**3*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I)) - m*x**3/(6*E*I)
+    ... + q*x**4/(24*E*I) + l*x*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I)) - q*x**2/(2*A*G)
+    ... )
+    >>> simplify(dy - expectedy)
+    0
 
     References
     ==========

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, symbols, S
+from sympy import Symbol, symbols, S, simplify
 from sympy.physics.continuum_mechanics.beam import Beam
 from sympy.functions import SingularityFunction, Piecewise, meijerg, Abs, log
 from sympy.utilities.pytest import raises
@@ -473,12 +473,16 @@ def test_Beam3D():
 
     assert b.shear_force() == [0, -q*x, 0]
     assert b.bending_moment() == [0, 0, -m*x + q*x**2/2]
-    assert b.deflection() == [0, -l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l*(l*q - 2*m)
+    expected_deflection = (-l**2*q*x**2/(12*E*I) + l**2*x**2*(A*G*l*(l*q - 2*m)
             + 12*E*I*q)/(8*E*I*(A*G*l**2 + 12*E*I)) + l*m*x**2/(4*E*I)
             - l*x**3*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(12*E*I*(A*G*l**2 + 12*E*I))
             - m*x**3/(6*E*I) + q*x**4/(24*E*I)
             + l*x*(A*G*l*(l*q - 2*m) + 12*E*I*q)/(2*A*G*(A*G*l**2 + 12*E*I))
-            - q*x**2/(2*A*G), 0]
+            - q*x**2/(2*A*G)
+            )
+    dx, dy, dz = b.deflection()
+    assert dx == dz == 0
+    assert simplify(dy - expected_deflection) == 0  # == doesn't work
 
 
     b2 = Beam3D(30, E, G, I, A, x)
@@ -491,8 +495,11 @@ def test_Beam3D():
 
     b2.solve_slope_deflection()
     assert b2.slope() == [0, 0, 25*x**3/(3*E*I) - 375*x**2/(E*I) + 3750*x/(E*I)]
-    assert b2.deflection() == [0, 25*x**4/(12*E*I) - 125*x**3/(E*I) + 1875*x**2/(E*I)
-                        - 25*x**2/(A*G) + 750*x/(A*G), 0]
+    expected_deflection = (25*x**4/(12*E*I) - 125*x**3/(E*I) + 1875*x**2/(E*I)
+                        - 25*x**2/(A*G) + 750*x/(A*G))
+    dx, dy, dz = b2.deflection()
+    assert dx == dz == 0
+    assert simplify(dy - expected_deflection) == 0  # == doesn't work
 
     # Test for solve_for_reaction_loads
     b3 = Beam3D(30, E, G, I, A, x)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -62,6 +62,8 @@ information on each (run ``help(ode)``):
   - 2nd order Liouville differential equations.
   - Power series solutions for second order differential equations
     at ordinary and regular singular points.
+  - `n`\th order differential equation that can be solved with algebraic
+    rearrangement and integration.
   - `n`\th order linear homogeneous differential equation with constant
     coefficients.
   - `n`\th order linear inhomogeneous differential equation with constant
@@ -284,6 +286,7 @@ from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 #: ``best``, and ``all_Integral`` meta-hints should not be included in this
 #: list, but ``_best`` and ``_Integral`` hints should be included.
 allhints = (
+    "nth_algebraic",
     "separable",
     "1st_exact",
     "1st_linear",
@@ -306,6 +309,7 @@ allhints = (
     "Liouville",
     "2nd_power_series_ordinary",
     "2nd_power_series_regular",
+    "nth_algebraic_Integral",
     "separable_Integral",
     "1st_exact_Integral",
     "1st_linear_Integral",
@@ -926,11 +930,11 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     >>> from sympy.abc import x
     >>> f = Function('f')
     >>> classify_ode(Eq(f(x).diff(x), 0), f(x))
-    ('separable', '1st_linear', '1st_homogeneous_coeff_best',
+    ('nth_algebraic', 'separable', '1st_linear', '1st_homogeneous_coeff_best',
     '1st_homogeneous_coeff_subs_indep_div_dep',
     '1st_homogeneous_coeff_subs_dep_div_indep',
     '1st_power_series', 'lie_group',
-    'nth_linear_constant_coeff_homogeneous',
+    'nth_linear_constant_coeff_homogeneous', 'nth_algebraic_Integral',
     'separable_Integral', '1st_linear_Integral',
     '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
     '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
@@ -1347,6 +1351,14 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
 
 
     if order > 0:
+        # Any ODE that can be solved with a combination of algebra and
+        # integrals e.g.:
+        # d^3/dx^3(x y) = F(x)
+        r = _nth_algebraic_match(reduced_eq, func)
+        if r['solutions']:
+            matching_hints['nth_algebraic'] = r
+            matching_hints['nth_algebraic_Integral'] = r
+
         # nth order linear ODE
         # a_n(x)y^(n) + ... + a_1(x)y' + a_0(x)y = F(x) = b
 
@@ -3975,6 +3987,168 @@ def _frobenius(n, m, p0, q0, p, q, x0, x, c, check=None):
             frobdict[numsyms[i]] = -num/(indicial.subs(d, m+i))
 
     return frobdict
+
+def _nth_algebraic_match(eq, func):
+    r"""
+    Matches any differential equation that nth_algebraic can solve. Uses
+    `sympy.solve` but teaches it how to integrate derivatives.
+
+    This involves calling `sympy.solve` and does most of the work of finding a
+    solution (apart from evaluating the integrals).
+    """
+
+    # Each integration should generate a different constant
+    constants = iter(numbered_symbols(prefix='C', cls=Symbol, start=1))
+    constant = lambda: next(constants, None)
+
+    # Like Derivative but "invertible"
+    class diffx(Function):
+        def inverse(self):
+            # We mustn't use integrate here because fx has been replaced by _t
+            # in the equation so integrals will not be correct while solve is
+            # still working.
+            return lambda expr: Integral(expr, var) + constant()
+
+    # Replace derivatives wrt the independent variable with diffx
+    def replace(eq, var):
+        def expand_diffx(*args):
+            differand, diffs = args[0], args[1:]
+            toreplace = differand
+            for v, n in diffs:
+                for _ in range(n):
+                    if v == var:
+                        toreplace = diffx(toreplace)
+                    else:
+                        toreplace = Derivative(toreplace, v)
+            return toreplace
+        return eq.replace(Derivative, expand_diffx)
+
+    # Restore derivatives in solution afterwards
+    def unreplace(eq, var):
+        return eq.replace(diffx, lambda e: Derivative(e, var))
+
+    # The independent variable
+    var = func.args[0]
+    subs_eqn = replace(eq, var)
+    try:
+        solns = solve(subs_eqn, func)
+    except NotImplementedError:
+        solns = []
+
+    solns = [unreplace(soln, var) for soln in solns]
+    solns = [Equality(func, soln) for soln in solns]
+    return {'var':var, 'solutions':solns}
+
+def ode_nth_algebraic(eq, func, order, match):
+    r"""
+    Solves an `n`\th order ordinary differential equation using algebra and
+    integrals.
+
+    There is no general form for the kind of equation that this can solve. The
+    the equation is solved algebraically treating differentiation as an
+    invertible algebraic function.
+
+    Examples
+    ========
+
+    >>> from sympy import Function, dsolve, Eq
+    >>> from sympy.abc import x
+    >>> f = Function('f')
+    >>> eq = Eq(f(x) * (f(x).diff(x)**2 - 1), 0)
+    >>> dsolve(eq, f(x), hint='nth_algebraic')
+    ... # doctest: +NORMALIZE_WHITESPACE
+    [Eq(f(x), 0), Eq(f(x), C1 - x), Eq(f(x), C1 + x)]
+
+    Note that this solver can return algebraic solutions that do not have any
+    integration constants (f(x) = 0 in the above example).
+
+    # indirect doctest
+
+    """
+    solns = match['solutions']
+    var = match['var']
+    solns = _nth_algebraic_remove_redundant_solutions(eq, solns, order, var)
+    if len(solns) == 1:
+        return solns[0]
+    else:
+        return solns
+
+# FIXME: Maybe something like this function should be applied to the solutions
+# returned by dsolve in general rather than just for nth_algebraic...
+
+def _nth_algebraic_remove_redundant_solutions(eq, solns, order, var):
+    r"""
+    Remove redundant solutions from the set of solutions returned by
+    nth_algebraic.
+
+    This function is needed because otherwise nth_algebraic can return
+    redundant solutions where both algebraic solutions and integral
+    solutions are found to the ODE. As an example consider:
+
+        eq = Eq(f(x) * f(x).diff(x), 0)
+
+    There are two ways to find solutions to eq. The first is the algebraic
+    solution f(x)=0. The second is to solve the equation f(x).diff(x) = 0
+    leading to the solution f(x) = C1. In this particular case we then see
+    that the first solution is a special case of the second and we don't
+    want to return it.
+
+    This does not always happen for algebraic solutions though since if we
+    have
+
+        eq = Eq(f(x)*(1 + f(x).diff(x)), 0)
+
+    then we get the algebraic solution f(x) = 0 and the integral solution
+    f(x) = -x + C1 and in this case the two solutions are not equivalent wrt
+    initial conditions so both should be returned.
+    """
+    # I believe that any algebraic solutions can only emerge before *any*
+    # integrations occur (although I haven't proved this and it depends on the
+    # particular way that diffx is defined at the time of writing). This means
+    # that an algebraic solution for f(x) will not have any integration
+    # constants and any integral solution will have a number of constants that
+    # matches the order of the ODE.
+    solns_algebraic = []
+    solns_integral = {} # {soln1: constants1, ...}
+    for soln in solns:
+        constants = soln.free_symbols - eq.free_symbols
+        if len(constants) == 0:
+            solns_algebraic.append(soln)
+        elif len(constants) == order:
+            solns_integral[soln] = constants
+        else:
+            assert False, "Solution should have 0 or order constants..."
+
+    # Compare each algebraic solution with each integral solution to remove
+    # redundant algebraic solutions.
+    solns = solns[:]
+    for soln in solns_algebraic:
+        for soln_integral, constants in solns_integral.items():
+            if _nth_algebraic_is_special_case_of(soln, soln_integral, constants, var):
+                solns.remove(soln)
+                break
+
+    return solns
+
+def _nth_algebraic_is_special_case_of(soln1, soln2, constants2, var):
+    r"""
+    True if soln1 is found to be a special case of soln2 wrt some value of the
+    constants that appear in soln2. False otherwise.
+    """
+    # solns are in the form Eq(f(x), expr)
+    # We're going to assert the equality of the two solutions for f(x)
+    expr1 = soln1.rhs
+    expr2 = soln2.rhs
+
+    # FIXME: We don't want to call .doit() if it can be avoided...
+    expr1 = expr1.doit()
+    expr2 = expr2.doit()
+
+    # FIXME: We don't know if we can reasonably substitute these values for x
+    # into the expression...
+    values = range(2*len(constants2))
+    equations = [Eq(expr1, expr2.subs(var, v)) for v in values]
+    return len(solve(equations, constants2)) > 0
 
 def _nth_linear_match(eq, func, order):
     r"""

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2955,11 +2955,13 @@ def test_sysode_linear_neq_order1():
 def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))
     sol = Eq(f(x), C1 + g(x))
+    assert checkodesol(eqn, sol, order=1, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x), hint='nth_algebraic')
     assert sol == dsolve(eqn, f(x))
 
     eqn = (diff(f(x)) - x)*(diff(f(x)) + x)
     sol = [Eq(f(x), C1 - x**2/2), Eq(f(x), C1 + x**2/2)]
+    assert checkodesol(eqn, sol, order=1, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x), hint='nth_algebraic')
     assert sol == dsolve(eqn, f(x))
 
@@ -2973,12 +2975,14 @@ def test_nth_algebraic_redundant_solutions():
     # This one has a redundant solution that should be removed
     eqn = f(x)*f(x).diff(x)
     soln = Eq(f(x), C1)
+    assert checkodesol(eqn, soln, order=1, solve_for_func=False)[0]
     assert soln == dsolve(eqn, f(x), hint='nth_algebraic')
     assert soln == dsolve(eqn, f(x))
 
     # This has two integral solutions and no algebraic solutions
     eqn = (diff(f(x)) - x)*(diff(f(x)) + x)
     sol = [Eq(f(x), C1 - x**2/2), Eq(f(x), C1 + x**2/2)]
+    assert all(c[0] for c in checkodesol(eqn, sol, order=1, solve_for_func=False))
     assert set(sol) == set(dsolve(eqn, f(x), hint='nth_algebraic'))
     assert set(sol) == set(dsolve(eqn, f(x)))
 
@@ -2989,6 +2993,7 @@ def test_nth_algebraic_redundant_solutions():
     solns = [Eq(f(x), 0),
              Eq(f(x), C1 - x)]
     solns_final =  _nth_algebraic_remove_redundant_solutions(eqn, solns, 1, x)
+    assert all(c[0] for c in checkodesol(eqn, solns, order=1, solve_for_func=False))
     assert set(solns) == set(solns_final)
 
 
@@ -3004,6 +3009,7 @@ def test_nth_algebraic_find_multiple1():
     eqn = f(x) + f(x)*f(x).diff(x)
     solns = [Eq(f(x), 0),
              Eq(f(x), C1 - x)]
+    assert all(c[0] for c in checkodesol(eqn, solns, order=1, solve_for_func=False))
     assert set(solns) == set(dsolve(eqn, f(x)))
 
 
@@ -3011,6 +3017,7 @@ def test_nth_algebraic_find_multiple1():
 def test_nth_algebraic_noprep1():
     eqn = Derivative(x*f(x), x, x, x)
     sol = Eq(f(x), (C1 + C2*x + C3*x**2) / x)
+    assert checkodesol(eqn, sol, order=3, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x), prep=False, hint='nth_algebraic')
 
 
@@ -3018,6 +3025,7 @@ def test_nth_algebraic_noprep1():
 def test_nth_algebraic_prep1():
     eqn = Derivative(x*f(x), x, x, x)
     sol = Eq(f(x), (C1 + C2*x + C3*x**2) / x)
+    assert checkodesol(eqn, sol, order=3, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x), prep=True, hint='nth_algebraic')
     assert sol == dsolve(eqn, f(x))
 
@@ -3026,13 +3034,15 @@ def test_nth_algebraic_prep1():
 def test_nth_algebraic_noprep2():
     eqn = Eq(Derivative(x*Derivative(f(x), x), x)/x, exp(x))
     sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x), prep=False, hint='nth_algebraic')
 
 
 @XFAIL
 def test_nth_algebraic_prep2():
     eqn = Eq(Derivative(x*Derivative(f(x), x), x)/x, exp(x))
-    sol = Eq(f(x), C1 + C2*log(x) + exp(x) + Ei(x))
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x), prep=True, hint='nth_algebraic')
     assert sol == dsolve(eqn, f(x))
 
@@ -3041,7 +3051,8 @@ def test_nth_algebraic_prep2():
 @XFAIL
 def test_2nd_order_substitution():
     eqn = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
-    sol = Eq(f(x), C1 + C2*log(x) + exp(x) + Ei(x))
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
     assert sol == dsolve(eqn, f(x))
 
 # This needs a combination of solutions from nth_algebraic and some other
@@ -3051,6 +3062,7 @@ def test_nth_algebraic_find_multiple2():
     eqn = f(x)**2 + f(x)*f(x).diff(x)
     solns = [Eq(f(x), 0),
              Eq(f(x), C1*exp(-x))]
+    assert all(c[0] for c in checkodesol(eqn, solns, order=1, solve_for_func=False))
     assert set(solns) == dsolve(eqn, f(x))
 
 
@@ -3058,5 +3070,6 @@ def test_nth_algebraic_find_multiple2():
 @XFAIL
 def test_factoring_ode():
     eqn = Derivative(x*f(x), x, x, x) + Derivative(f(x), x, x, x)
-    soln = Eq(f(x), (C1*x**2/2 + C2*x + C3 - x)/x)
+    soln = Eq(f(x), (C1*x**2/2 + C2*x + C3 - x)/(1 + x))
+    assert checkodesol(eqn, soln, order=2, solve_for_func=False)[0]
     assert soln == dsolve(eqn, f(x))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2996,6 +2996,10 @@ def test_nth_algebraic_redundant_solutions():
     assert all(c[0] for c in checkodesol(eqn, solns, order=1, solve_for_func=False))
     assert set(solns) == set(solns_final)
 
+    solns = [Eq(f(x), exp(x)),
+             Eq(f(x), C1*exp(C2*x))]
+    solns_final =  _nth_algebraic_remove_redundant_solutions(eqn, solns, 2, x)
+    assert solns_final == [Eq(f(x), C1*exp(C2*x))]
 
 #
 # These tests can be combined with the above test if they get fixed

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1277,21 +1277,25 @@ def test_separable1():
     eq3 = f(x).diff(x) + sin(x)
     eq4 = f(x)**2 + 1 - (x**2 + 1)*f(x).diff(x)
     eq5 = f(x).diff(x)/tan(x) - f(x) - 2
+    eq6 = f(x).diff(x) * (1 - sin(f(x))) - 1
     sol1 = Eq(f(x), C1*exp(x))
     sol2 = Eq(f(x), C1*x)
     sol3 = Eq(f(x), C1 + cos(x))
     sol4 = Eq(atan(f(x)), C1 + atan(x))
     sol5 = Eq(f(x), C1/cos(x) - 2)
+    sol6 = Eq(-x + f(x) + cos(f(x)), C1)
     assert dsolve(eq1, hint='separable') == sol1
     assert dsolve(eq2, hint='separable') == sol2
     assert dsolve(eq3, hint='separable') == sol3
     assert dsolve(eq4, hint='separable', simplify=False) == sol4
     assert dsolve(eq5, hint='separable') == sol5
+    assert dsolve(eq6, hint='separable') == sol6
     assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
     assert checkodesol(eq4, sol4, order=1, solve_for_func=False)[0]
     assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq6, sol6, order=1, solve_for_func=False)[0]
 
 
 def test_separable2():
@@ -2952,9 +2956,15 @@ def test_nth_algebraic():
     eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))
     sol = Eq(f(x), C1 + g(x))
     assert sol == dsolve(eqn, f(x), hint='nth_algebraic')
+    assert sol == dsolve(eqn, f(x))
 
     eqn = (diff(f(x)) - x)*(diff(f(x)) + x)
     sol = [Eq(f(x), C1 - x**2/2), Eq(f(x), C1 + x**2/2)]
+    assert sol == dsolve(eqn, f(x), hint='nth_algebraic')
+    assert sol == dsolve(eqn, f(x))
+
+    eqn = (1 - sin(f(x))) * f(x).diff(x)
+    sol = Eq(f(x), C1)
     assert sol == dsolve(eqn, f(x), hint='nth_algebraic')
     assert sol == dsolve(eqn, f(x))
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -4,10 +4,11 @@ from __future__ import division
 from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
     Dummy, Eq, Ne, erf, erfi, exp, Function, I, Integral, LambertW, log, O, pi,
     Rational, rootof, S, simplify, sin, sqrt, Subs, Symbol, tan, asin, sinh,
-    Piecewise, symbols, Poly, sec)
+    Piecewise, symbols, Poly, sec, Ei)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
     classify_ode, classify_sysode, constant_renumber, constantsimp,
-    homogeneous_order, infinitesimals, checkinfsol, checksysodesol, solve_ics)
+    homogeneous_order, infinitesimals, checkinfsol, checksysodesol, solve_ics,
+    dsolve)
 from sympy.solvers.deutils import ode_order
 from sympy.utilities.pytest import XFAIL, skip, raises, slow, ON_TRAVIS
 
@@ -715,20 +716,31 @@ def test_dsolve_options():
 
 def test_classify_ode():
     assert classify_ode(f(x).diff(x, 2), f(x)) == \
-        ('nth_linear_constant_coeff_homogeneous', 'Liouville',
-            '2nd_power_series_ordinary' ,'Liouville_Integral')
+        ('nth_algebraic',
+        'nth_linear_constant_coeff_homogeneous',
+        'Liouville',
+        '2nd_power_series_ordinary',
+        'nth_algebraic_Integral',
+        'Liouville_Integral',
+        )
     assert classify_ode(f(x), f(x)) == ()
-    assert classify_ode(Eq(f(x).diff(x), 0), f(x)) == ('separable',
+    assert classify_ode(Eq(f(x).diff(x), 0), f(x)) == (
+        'nth_algebraic',
+        'separable',
         '1st_linear', '1st_homogeneous_coeff_best',
         '1st_homogeneous_coeff_subs_indep_div_dep',
         '1st_homogeneous_coeff_subs_dep_div_indep',
         '1st_power_series', 'lie_group',
         'nth_linear_constant_coeff_homogeneous',
+        'nth_algebraic_Integral',
         'separable_Integral',
         '1st_linear_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
-    assert classify_ode(f(x).diff(x)**2, f(x)) == ('lie_group',)
+    assert classify_ode(f(x).diff(x)**2, f(x)) == (
+        'nth_algebraic',
+        'lie_group',
+        'nth_algebraic_Integral')
     # issue 4749: f(x) should be cleared from highest derivative before classifying
     a = classify_ode(Eq(f(x).diff(x) + f(x), x), f(x))
     b = classify_ode(f(x).diff(x)*f(x) + f(x)*f(x) - x*f(x), f(x))
@@ -759,13 +771,14 @@ def test_classify_ode():
         ('separable', '1st_exact', '1st_power_series', 'lie_group',
          'separable_Integral', '1st_exact_Integral')
     # preprocessing
-    ans = ('separable', '1st_exact', '1st_linear', 'Bernoulli',
+    ans = ('nth_algebraic', 'separable', '1st_exact', '1st_linear', 'Bernoulli',
         '1st_homogeneous_coeff_best',
         '1st_homogeneous_coeff_subs_indep_div_dep',
         '1st_homogeneous_coeff_subs_dep_div_indep',
         '1st_power_series', 'lie_group',
         'nth_linear_constant_coeff_undetermined_coefficients',
         'nth_linear_constant_coeff_variation_of_parameters',
+        'nth_algebraic_Integral',
         'separable_Integral', '1st_exact_Integral',
         '1st_linear_Integral',
         'Bernoulli_Integral',
@@ -779,10 +792,11 @@ def test_classify_ode():
                         prep=True) == ans
 
     assert classify_ode(Eq(2*x**3*f(x).diff(x), 0), f(x)) == \
-        ('separable', '1st_linear', '1st_power_series', 'lie_group',
-         'separable_Integral', '1st_linear_Integral')
+        ('nth_algebraic', 'separable', '1st_linear', '1st_power_series', 'lie_group',
+         'nth_algebraic_Integral', 'separable_Integral', '1st_linear_Integral')
     assert classify_ode(Eq(2*f(x)**3*f(x).diff(x), 0), f(x)) == \
-        ('separable', '1st_power_series', 'lie_group', 'separable_Integral')
+        ('nth_algebraic', 'separable', '1st_power_series', 'lie_group',
+                'nth_algebraic_Integral', 'separable_Integral')
     # test issue 13864
     assert classify_ode(Eq(diff(f(x), x) - f(x)**x, 0), f(x)) == \
         ('1st_power_series', 'lie_group')
@@ -2559,9 +2573,9 @@ def test_issue_6989():
         ))
     eq = -f(x).diff(x) + x*exp(-k*x)
     sol = dsolve(eq, f(x))
-    actual_sol = Eq(f(x), Piecewise(
-        (C1 - x*exp(-k*x)/k - exp(-k*x)/k**2, Ne(k**2, 0)),
-        (C1 + x**2/2, True)
+    actual_sol = Eq(f(x), C1 + Piecewise(
+        ((-k*x - 1)*exp(-k*x)/k**2, Ne(k**2, 0)),
+        (+x**2/2, True)
     ))
     errstr = str(eq) + ' : ' + str(sol) + ' == ' + str(actual_sol)
     assert sol == actual_sol, errstr
@@ -2853,10 +2867,11 @@ def test_2nd_power_series_regular():
 
 def test_issue_7093():
     x = Symbol("x") # assuming x is real leads to an error
-    sol = Eq(f(x), C1 - 2*x*sqrt(x**3)/5)
+    sol = [Eq(f(x), C1 - 2*x*sqrt(x**3)/5),
+           Eq(f(x), C1 + 2*x*sqrt(x**3)/5)]
     eq = Derivative(f(x), x)**2 - x**3
-    assert dsolve(eq) == sol and checkodesol(eq, sol) == (True, 0)
-
+    assert (set(dsolve(eq)) == set(sol) and
+            checkodesol(eq, sol) == [(True, 0)] * 2)
 
 def test_dsolve_linsystem_symbol():
     eps = Symbol('epsilon', positive=True)
@@ -2931,3 +2946,107 @@ def test_sysode_linear_neq_order1():
                Eq(Z3(t), C2*exp(-k30*t) + C4*exp(t*(-k20 - k21 - k23)))]
 
     assert dsolve(eq, simplify=False) == sols_eq
+
+
+def test_nth_algebraic():
+    eqn = Eq(Derivative(f(x), x), Derivative(g(x), x))
+    sol = Eq(f(x), C1 + g(x))
+    assert sol == dsolve(eqn, f(x), hint='nth_algebraic')
+
+    eqn = (diff(f(x)) - x)*(diff(f(x)) + x)
+    sol = [Eq(f(x), C1 - x**2/2), Eq(f(x), C1 + x**2/2)]
+    assert sol == dsolve(eqn, f(x), hint='nth_algebraic')
+    assert sol == dsolve(eqn, f(x))
+
+
+def test_nth_algebraic_redundant_solutions():
+    # This one has a redundant solution that should be removed
+    eqn = f(x)*f(x).diff(x)
+    soln = Eq(f(x), C1)
+    assert soln == dsolve(eqn, f(x), hint='nth_algebraic')
+    assert soln == dsolve(eqn, f(x))
+
+    # This has two integral solutions and no algebraic solutions
+    eqn = (diff(f(x)) - x)*(diff(f(x)) + x)
+    sol = [Eq(f(x), C1 - x**2/2), Eq(f(x), C1 + x**2/2)]
+    assert set(sol) == set(dsolve(eqn, f(x), hint='nth_algebraic'))
+    assert set(sol) == set(dsolve(eqn, f(x)))
+
+    # This one doesn't work with dsolve at the time of writing but the
+    # redundancy checking code should not remove the algebraic solution.
+    from sympy.solvers.ode import _nth_algebraic_remove_redundant_solutions
+    eqn = f(x) + f(x)*f(x).diff(x)
+    solns = [Eq(f(x), 0),
+             Eq(f(x), C1 - x)]
+    solns_final =  _nth_algebraic_remove_redundant_solutions(eqn, solns, 1, x)
+    assert set(solns) == set(solns_final)
+
+
+#
+# These tests can be combined with the above test if they get fixed
+# so that dsolve actually works in all these cases.
+#
+
+# Fails due to division by f(x) eliminating the solution before nth_algebraic
+# is called.
+@XFAIL
+def test_nth_algebraic_find_multiple1():
+    eqn = f(x) + f(x)*f(x).diff(x)
+    solns = [Eq(f(x), 0),
+             Eq(f(x), C1 - x)]
+    assert set(solns) == set(dsolve(eqn, f(x)))
+
+
+# prep = True breaks this
+def test_nth_algebraic_noprep1():
+    eqn = Derivative(x*f(x), x, x, x)
+    sol = Eq(f(x), (C1 + C2*x + C3*x**2) / x)
+    assert sol == dsolve(eqn, f(x), prep=False, hint='nth_algebraic')
+
+
+@XFAIL
+def test_nth_algebraic_prep1():
+    eqn = Derivative(x*f(x), x, x, x)
+    sol = Eq(f(x), (C1 + C2*x + C3*x**2) / x)
+    assert sol == dsolve(eqn, f(x), prep=True, hint='nth_algebraic')
+    assert sol == dsolve(eqn, f(x))
+
+
+# prep = True breaks this
+def test_nth_algebraic_noprep2():
+    eqn = Eq(Derivative(x*Derivative(f(x), x), x)/x, exp(x))
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
+    assert sol == dsolve(eqn, f(x), prep=False, hint='nth_algebraic')
+
+
+@XFAIL
+def test_nth_algebraic_prep2():
+    eqn = Eq(Derivative(x*Derivative(f(x), x), x)/x, exp(x))
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) + Ei(x))
+    assert sol == dsolve(eqn, f(x), prep=True, hint='nth_algebraic')
+    assert sol == dsolve(eqn, f(x))
+
+
+# This one needs a substitution f' = g. Should be doable...
+@XFAIL
+def test_2nd_order_substitution():
+    eqn = -exp(x) + (x*Derivative(f(x), (x, 2)) + Derivative(f(x), x))/x
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) + Ei(x))
+    assert sol == dsolve(eqn, f(x))
+
+# This needs a combination of solutions from nth_algebraic and some other
+# method from dsolve
+@XFAIL
+def test_nth_algebraic_find_multiple2():
+    eqn = f(x)**2 + f(x)*f(x).diff(x)
+    solns = [Eq(f(x), 0),
+             Eq(f(x), C1*exp(-x))]
+    assert set(solns) == dsolve(eqn, f(x))
+
+
+# Needs to be a way to know how to combine derivatives in the expression
+@XFAIL
+def test_factoring_ode():
+    eqn = Derivative(x*f(x), x, x, x) + Derivative(f(x), x, x, x)
+    soln = Eq(f(x), (C1*x**2/2 + C2*x + C3 - x)/x)
+    assert soln == dsolve(eqn, f(x))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

This is a replacement for #15254  because that needed rebasing and included irrelevant commits.

This is following on from a discussion in #6259 and goes some way to fixing that issue.

#### Brief description of what is fixed or changed

Adds a new ODE solver called `nth_algebraic`. The solver uses `sympy.solve` but teaches it to be able to invert derivatives algebraically. This means that ODEs that can be solved simply with algebra and integrals can be solved by `dsolve`.

This increases the number of ODEs that can be solved by `dsolve` and in some cases increases the number of solutions that `dsolve` can find. It does not work as well as it could though due to other parts of the `ode` module.

In particular `dsolve` (with `prep=True` (default)) preprocesses the ODE before passing it to the solver: [https://github.com/sympy/sympy/blob/sympy-1.3/sympy/solvers/deutils.py#L173](https://github.com/sympy/sympy/blob/sympy-1.3/sympy/solvers/deutils.py#L173)
This means that with this patch there are cases that `dsolve` can now solve provided the user passes `prep=False` but still cannot solve with the default `prep=True`.

For example, if `prep=True` then `_preprocess` will expand `Derivative(x*f(x), x, x, x)` using the product rule into `x*Derivative(f(x), (x, 3)) + 3*Derivative(f(x), (x, 2))`. This means that `nth_algebraic` still can't solve this ODE even though it could if it wasn't pre-expanded.

Also in some other cases `dsolve` simplifies equations removing solutions: [https://github.com/sympy/sympy/blob/sympy-1.3/sympy/solvers/ode.py#L1040](https://github.com/sympy/sympy/blob/sympy-1.3/sympy/solvers/ode.py#L1040)
For example in the case of `f(x)*(1+f(x).diff(x))` that line will divide by `f(x)` which removes the solution `f(x)=0` that would otherwise be found by `nth_algebraic`.

Because this solver can find algebraic solutions it can find some solutions that are *purely algebraic* and do not have integration constants e.g.:
```julia
In [4]: dsolve((f(x) - 1)*(f(x).diff(x) - 1))
Out[4]: [f(x) = 1, f(x) = C₁ + x]
```

In this example we have the solution `f(x)=1` which is purely algebraic and therefore doesn't have any integration constants.

In some cases it is possible that the additional algebraic solutions are redundant in the context of the general integral solutions since they represent a particular choice for the integration constants. I have had to add additional code to filter out solutions such as those so that only non-redundant solutions are returned:
```julia
In [5]: dsolve((f(x) - 1)*f(x).diff(x))
Out[5]: f(x) = C₁
```

The code for removing redundant solutions feels like it could be improved. At the moment it substitutes a load of values for `x` into both solutions and then uses `solve` to detect if the equations are inconsistent but there are problems with that (need to cll `.doit()` and don't know if the values can reasonably be substituted).

#### Other comments

As it stands I think that the solver in this PR represents an improvement in correctness for `dsolve`. It could be better if other parts of the code were changed.

I don't know what the best way is to do the redundancy checking. The question is: how can I tell that `f(x) = 1` is a special case of `f(x) = 1 + C1*x + C2*x**2`?

I also haven't checked what happens when initial conditions are combined with this solver. Since some of the returned solutions don't have integration constants it is possible that that would confuse the IC handling code.

It is also possible that the solver could be made more powerful if `solve` could be taught to understand other parts of the algebra of derivatives.

This results in a slow-down when running the test-suite (due to a slow-down in `dsolve` rather than the additional tests) of around 20%. The main performance cost is that the matching code calls `solve` to see if it can find solutions.

I had to change a test in `test_beam.py`. This is because `dsolve` now returns the solution of that particular ODE in a rearranged (factored) form and sympy's `==` cannot tell that it is the same solution without simplifying.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* solvers
  * Add an 'nth_algebraic' solver for ODEs that can be solved by algebra and integration

<!-- END RELEASE NOTES -->