### PR TITLE
functions/special/zeta_functions.py: fix docstring in eta

### DIFF
--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -509,7 +509,7 @@ class dirichlet_eta(Function):
 
     For `\operatorname{Re}(s) > 0`, this function is defined as
 
-    .. math:: \eta(s) = \sum_{n=1}^\infty \frac{(-1)^n}{n^s}.
+    .. math:: \eta(s) = \sum_{n=1}^\infty \frac{(-1)^{n-1}}{n^s}.
 
     It admits a unique analytic continuation to all of :math:`\mathbb{C}`.
     It is an entire, unbranched function.


### PR DESCRIPTION
From time immemorial, the doc string of the class dirichlet_eta is wrong. Let's finally fix it.

The code is correct, dirichlet_eta(2) correctly produces the positive result pi**2/12. With the definition given in the doc string, the result would obviously be negative. Or see
https://en.wikipedia.org/wiki/Dirichlet_eta_function
http://mathworld.wolfram.com/DirichletEtaFunction.html
or any relevant book.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->