### PR TITLE
Add float sanitization to xlim and ylim in plot

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -996,7 +996,16 @@ class MatplotlibBackend(BaseBackend):
                 ends = [s.end for s in parent._series]
                 self.ax.set_xlim(min(starts), max(ends))
         if parent.ylim:
-            self.ax.set_ylim(parent.ylim)
+            from sympy.core.basic import Basic
+            ylim = parent.ylim
+            if any(isinstance(i,Basic) and not i.is_real for i in ylim):
+                raise ValueError(
+                "All numbers from ylim={} must be real".format(ylim))
+            if any(isinstance(i,Basic) and not i.is_finite for i in ylim):
+                raise ValueError(
+                "All numbers from ylim={} must be finite".format(ylim))
+            ylim = (float(i) for i in ylim)
+            self.ax.set_ylim(ylim)
         if not isinstance(self.ax, Axes3D) or self.matplotlib.__version__ >= '1.2.0':  # XXX in the distant future remove this check
             self.ax.set_autoscale_on(parent.autoscale)
         if parent.axis_center:

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -980,7 +980,16 @@ class MatplotlibBackend(BaseBackend):
         if parent.yscale and not isinstance(self.ax, Axes3D):
             self.ax.set_yscale(parent.yscale)
         if parent.xlim:
-            self.ax.set_xlim(parent.xlim)
+            from sympy.core.basic import Basic
+            xlim = parent.xlim
+            if any(isinstance(i,Basic) and not i.is_real for i in xlim):
+                raise ValueError(
+                "All numbers from xlim={} must be real".format(xlim))
+            if any(isinstance(i,Basic) and not i.is_finite for i in xlim):
+                raise ValueError(
+                "All numbers from xlim={} must be finite".format(xlim))
+            xlim = (float(i) for i in xlim)
+            self.ax.set_xlim(xlim)
         else:
             if all(isinstance(s, LineOver1DRangeSeries) for s in parent._series):
                 starts = [s.start for s in parent._series]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15261

#### Brief description of what is fixed or changed

I found that the issue had been caused by sympy number types directly passed to matplotlib's backend, and getting checked by numpy's `isfinite()`, which cannot handle sympy's numbers.

Any sympy's constants, or sympified numbers passed into plot's `xlim` and `ylim` would repeat the issue in this context.

```
>>> from sympy import *
>>>
>>> x    = symbols('x')
>>> eqn  = sin(x)
>>> p    = plot(eqn,(x,-10,10), xlim=(-5, sympify('5')), ylim=(-1, 1))
TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

I think every sympy's numbers should be sanitized into python default `float` type, before passed into matplotlib backend.

And also, I had added `is_real` check and `is_finite` check, to make sure that `float()` can be safely applied to, and to implement numpy's `isfinite()` check in sympy's own way.

I think `range` parameter has implicit way of sanitizing sympy's types unlike `xlim` or `ylim`,
so that the method could possibly be a workaround for original poster.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- plotting
  - Fixed `xlim` and `ylim` from `plot()` not properly handling sympy's number classes.
<!-- END RELEASE NOTES -->
