### PR TITLE
Regression in matrix docs

### DIFF
--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -504,17 +504,17 @@ MatrixDeterminant Class Reference
    :members:
 
 MatrixSubspaces Class Reference
----------------------------------
+-------------------------------
 .. autoclass:: MatrixSubspaces
    :members:
 
 MatrixEigen Class Reference
----------------------------------
+---------------------------
 .. autoclass:: MatrixEigen
    :members:
 
 MatrixCalculus Class Reference
----------------------------------
+------------------------------
 .. autoclass:: MatrixCalculus
    :members:
 

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -503,6 +503,7 @@ MatrixDeterminant Class Reference
 .. autoclass:: MatrixDeterminant
    :members:
 
+<<<<<<< HEAD
 MatrixSubspaces Class Reference
 -------------------------------
 .. autoclass:: MatrixSubspaces
@@ -516,6 +517,11 @@ MatrixEigen Class Reference
 MatrixCalculus Class Reference
 ------------------------------
 .. autoclass:: MatrixCalculus
+=======
+MatrixReductions Class Reference
+--------------------------------
+.. autoclass:: MatrixReductions
+>>>>>>> 6d21d3405... Added docs from MatrixReductions class
    :members:
 
 MatrixBase Class Reference

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -503,6 +503,11 @@ MatrixDeterminant Class Reference
 .. autoclass:: MatrixDeterminant
    :members:
 
+MatrixReductions Class Reference
+--------------------------------
+.. autoclass:: MatrixReductions
+   :members:
+
 MatrixBase Class Reference
 --------------------------
 .. autoclass:: MatrixBase

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -503,11 +503,6 @@ MatrixDeterminant Class Reference
 .. autoclass:: MatrixDeterminant
    :members:
 
-MatrixReductions Class Reference
---------------------------------
-.. autoclass:: MatrixReductions
-   :members:
-
 MatrixBase Class Reference
 --------------------------
 .. autoclass:: MatrixBase

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -513,6 +513,11 @@ MatrixEigen Class Reference
 .. autoclass:: MatrixEigen
    :members:
 
+MatrixCalculus Class Reference
+---------------------------------
+.. autoclass:: MatrixCalculus
+   :members:
+
 MatrixBase Class Reference
 --------------------------
 .. autoclass:: MatrixBase

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -503,7 +503,11 @@ MatrixDeterminant Class Reference
 .. autoclass:: MatrixDeterminant
    :members:
 
-<<<<<<< HEAD
+MatrixReductions Class Reference
+--------------------------------
+.. autoclass:: MatrixReductions
+    :members:
+
 MatrixSubspaces Class Reference
 -------------------------------
 .. autoclass:: MatrixSubspaces
@@ -517,11 +521,6 @@ MatrixEigen Class Reference
 MatrixCalculus Class Reference
 ------------------------------
 .. autoclass:: MatrixCalculus
-=======
-MatrixReductions Class Reference
---------------------------------
-.. autoclass:: MatrixReductions
->>>>>>> 6d21d3405... Added docs from MatrixReductions class
    :members:
 
 MatrixBase Class Reference

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -508,6 +508,11 @@ MatrixSubspaces Class Reference
 .. autoclass:: MatrixSubspaces
    :members:
 
+MatrixEigen Class Reference
+---------------------------------
+.. autoclass:: MatrixEigen
+   :members:
+
 MatrixBase Class Reference
 --------------------------
 .. autoclass:: MatrixBase

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -503,6 +503,11 @@ MatrixDeterminant Class Reference
 .. autoclass:: MatrixDeterminant
    :members:
 
+MatrixSubspaces Class Reference
+---------------------------------
+.. autoclass:: MatrixSubspaces
+   :members:
+
 MatrixBase Class Reference
 --------------------------
 .. autoclass:: MatrixBase

--- a/doc/src/modules/matrices/matrices.rst
+++ b/doc/src/modules/matrices/matrices.rst
@@ -498,6 +498,11 @@ So there is quite a bit that can be done with the module including eigenvalues,
 eigenvectors, nullspace calculation, cofactor expansion tools, and so on. From
 here one might want to look over the ``matrices.py`` file for all functionality.
 
+MatrixDeterminant Class Reference
+---------------------------------
+.. autoclass:: MatrixDeterminant
+   :members:
+
 MatrixBase Class Reference
 --------------------------
 .. autoclass:: MatrixBase

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -997,7 +997,7 @@ class MatrixSubspaces(MatrixReductions):
         Parameters
         ==========
 
-        vecs :
+        vecs
             vectors to be made orthogonal
 
         normalize : bool

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -745,7 +745,7 @@ class MatrixReductions(MatrixDeterminant):
             * "n->n+km" (column n goes to column n + k*column m)
 
         Parameters
-        =========
+        ==========
 
         op : string; the elementary row operation
         col : the column to apply the column operation

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -850,29 +850,29 @@ class MatrixReductions(MatrixDeterminant):
 
         iszerofunc : Function
             A function used for detecting whether an element can
-            act as a pivot.  `lambda x: x.is_zero` is used by default.
+            act as a pivot.  ``lambda x: x.is_zero`` is used by default.
         simplify : Function
             A function used to simplify elements when looking for a pivot.
-            By default SymPy's `simplify` is used.
+            By default SymPy's ``simplify`` is used.
         pivots : True or False
             If `True`, a tuple containing the row-reduced matrix and a tuple
-            of pivot columns is returned.  If `False` just the row-reduced
+            of pivot columns is returned.  If ``False`` just the row-reduced
             matrix is returned.
         normalize_last : True or False
-            If `True`, no pivots are normalized to `1` until after all entries
+            If ``True``, no pivots are normalized to ``1`` until after all entries
             above and below each pivot are zeroed.  This means the row
             reduction algorithm is fraction free until the very last step.
-            If `False`, the naive row reduction procedure is used where
-            each pivot is normalized to be `1` before row operations are
+            If ``False``, the naive row reduction procedure is used where
+            each pivot is normalized to be ``1`` before row operations are
             used to zero above and below the pivot.
 
         Notes
         =====
 
-        The default value of `normalize_last=True` can provide significant
+        The default value of ``normalize_last=True`` can provide significant
         speedup to row reduction, especially on matrices with symbols.  However,
         if you depend on the form row reduction algorithm leaves entries
-        of the matrix, set `noramlize_last=False`
+        of the matrix, set ``noramlize_last=False``
 
 
         Examples

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -645,7 +645,7 @@ class MatrixReductions(MatrixDeterminant):
         normalize : whether pivot rows should be normalized so that
             the pivot value is 1
         zero_above : whether entries above the pivot should be zeroed.
-            If `zero_above=False` , an echelon matrix will be returned.
+            If `zero_above=False`, an echelon matrix will be returned.
         """
         rows, cols = self.rows, self.cols
         mat = list(self)
@@ -736,7 +736,7 @@ class MatrixReductions(MatrixDeterminant):
         return mat
 
     def elementary_col_op(self, op="n->kn", col=None, k=None, col1=None, col2=None):
-        """Performs the elementary column operation `op` .
+        """Performs the elementary column operation `op`.
 
         `op` may be one of
 
@@ -766,7 +766,7 @@ class MatrixReductions(MatrixDeterminant):
             return self._eval_col_op_add_multiple_to_other_col(col, k, col2)
 
     def elementary_row_op(self, op="n->kn", row=None, k=None, row1=None, row2=None):
-        """Performs the elementary row operation `op` .
+        """Performs the elementary row operation `op`.
 
         `op` may be one of
 
@@ -855,14 +855,14 @@ class MatrixReductions(MatrixDeterminant):
             A function used to simplify elements when looking for a pivot.
             By default SymPy's `simplify` is used.
         pivots : True or False
-            If `True` , a tuple containing the row-reduced matrix and a tuple
+            If `True`, a tuple containing the row-reduced matrix and a tuple
             of pivot columns is returned.  If `False` just the row-reduced
             matrix is returned.
         normalize_last : True or False
-            If `True` , no pivots are normalized to `1` until after all entries
+            If `True`, no pivots are normalized to `1` until after all entries
             above and below each pivot are zeroed.  This means the row
             reduction algorithm is fraction free until the very last step.
-            If `False` , the naive row reduction procedure is used where
+            If `False`, the naive row reduction procedure is used where
             each pivot is normalized to be `1` before row operations are
             used to zero above and below the pivot.
 
@@ -992,7 +992,7 @@ class MatrixSubspaces(MatrixReductions):
     @classmethod
     def orthogonalize(cls, *vecs, **kwargs):
         """Apply the Gram-Schmidt orthogonalization procedure
-        to vectors supplied in `vecs` .
+        to vectors supplied in `vecs`.
 
         Arguments
         =========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -859,11 +859,11 @@ class MatrixReductions(MatrixDeterminant):
             of pivot columns is returned.  If ``False`` just the row-reduced
             matrix is returned.
         normalize_last : True or False
-            If ``True``, no pivots are normalized to ``1`` until after all
+            If ``True``, no pivots are normalized to `1` until after all
             entries above and below each pivot are zeroed.  This means the row
             reduction algorithm is fraction free until the very last step.
             If ``False``, the naive row reduction procedure is used where
-            each pivot is normalized to be ``1`` before row operations are
+            each pivot is normalized to be `1` before row operations are
             used to zero above and below the pivot.
 
         Notes

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -994,12 +994,15 @@ class MatrixSubspaces(MatrixReductions):
         """Apply the Gram-Schmidt orthogonalization procedure
         to vectors supplied in `vecs`.
 
-        Arguments
-        =========
+        Parameters
+        ==========
 
-        vecs : vectors to be made orthogonal
-        normalize : bool. Whether the returned vectors should be renormalized
-        to be unit vectors.
+        vecs :
+            vectors to be made orthogonal
+
+        normalize : bool
+            Whether the returned vectors should be renormalized to be unit
+            vectors.
         """
 
         normalize = kwargs.get('normalize', False)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -855,12 +855,12 @@ class MatrixReductions(MatrixDeterminant):
             A function used to simplify elements when looking for a pivot.
             By default SymPy's ``simplify`` is used.
         pivots : True or False
-            If `True`, a tuple containing the row-reduced matrix and a tuple
+            If ``True``, a tuple containing the row-reduced matrix and a tuple
             of pivot columns is returned.  If ``False`` just the row-reduced
             matrix is returned.
         normalize_last : True or False
-            If ``True``, no pivots are normalized to ``1`` until after all entries
-            above and below each pivot are zeroed.  This means the row
+            If ``True``, no pivots are normalized to ``1`` until after all
+            entries above and below each pivot are zeroed.  This means the row
             reduction algorithm is fraction free until the very last step.
             If ``False``, the naive row reduction procedure is used where
             each pivot is normalized to be ``1`` before row operations are

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1001,8 +1001,7 @@ class MatrixSubspaces(MatrixReductions):
             vectors to be made orthogonal
 
         normalize : bool
-            Whether the returned vectors should be renormalized to be unit
-            vectors.
+            If true, return an orthonormal basis.
         """
 
         normalize = kwargs.get('normalize', False)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -645,7 +645,7 @@ class MatrixReductions(MatrixDeterminant):
         normalize : whether pivot rows should be normalized so that
             the pivot value is 1
         zero_above : whether entries above the pivot should be zeroed.
-            If `zero_above=False`, an echelon matrix will be returned.
+            If `zero_above=False` , an echelon matrix will be returned.
         """
         rows, cols = self.rows, self.cols
         mat = list(self)
@@ -736,7 +736,7 @@ class MatrixReductions(MatrixDeterminant):
         return mat
 
     def elementary_col_op(self, op="n->kn", col=None, k=None, col1=None, col2=None):
-        """Performs the elementary column operation `op`.
+        """Performs the elementary column operation `op` .
 
         `op` may be one of
 
@@ -766,7 +766,7 @@ class MatrixReductions(MatrixDeterminant):
             return self._eval_col_op_add_multiple_to_other_col(col, k, col2)
 
     def elementary_row_op(self, op="n->kn", row=None, k=None, row1=None, row2=None):
-        """Performs the elementary row operation `op`.
+        """Performs the elementary row operation `op` .
 
         `op` may be one of
 
@@ -853,16 +853,16 @@ class MatrixReductions(MatrixDeterminant):
             act as a pivot.  `lambda x: x.is_zero` is used by default.
         simplify : Function
             A function used to simplify elements when looking for a pivot.
-            By default SymPy's `simplify`is used.
+            By default SymPy's `simplify` is used.
         pivots : True or False
-            If `True`, a tuple containing the row-reduced matrix and a tuple
+            If `True` , a tuple containing the row-reduced matrix and a tuple
             of pivot columns is returned.  If `False` just the row-reduced
             matrix is returned.
         normalize_last : True or False
-            If `True`, no pivots are normalized to `1` until after all entries
+            If `True` , no pivots are normalized to `1` until after all entries
             above and below each pivot are zeroed.  This means the row
             reduction algorithm is fraction free until the very last step.
-            If `False`, the naive row reduction procedure is used where
+            If `False` , the naive row reduction procedure is used where
             each pivot is normalized to be `1` before row operations are
             used to zero above and below the pivot.
 
@@ -992,7 +992,7 @@ class MatrixSubspaces(MatrixReductions):
     @classmethod
     def orthogonalize(cls, *vecs, **kwargs):
         """Apply the Gram-Schmidt orthogonalization procedure
-        to vectors supplied in `vecs`.
+        to vectors supplied in `vecs` .
 
         Arguments
         =========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -998,8 +998,8 @@ class MatrixSubspaces(MatrixReductions):
         =========
 
         vecs : vectors to be made orthogonal
-        normalize : bool. Whether the returned vectors
-                    should be renormalized to be unit vectors.
+        normalize : bool. Whether the returned vectors should be renormalized
+        to be unit vectors.
         """
 
         normalize = kwargs.get('normalize', False)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

I have found a lot of matrix docs for methods like `det()` `eigenvals()` missing after changes made between [1.0](https://docs.sympy.org/1.0/modules/matrices/matrices.html#matrixbase-class-reference) and [1.1](https://docs.sympy.org/1.1/modules/matrices/matrices.html#matrixbase-class-reference).

I think that there had been several changes to separate matrix classes,
however docs had not been updated since then.
I think sphinx does not automatically load parent classes of `MatrixBase`
So I have added all the matrix classes to the sphinx to restore the docs.

I'm still working on the `MatrixReduction`, because there are some sphinx formatting errors making my build to fail.
And I would also want to hear your opinions about where the classes like `MatrixDeprecated` and `DeferredVector` should be added to.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

*  matrices
   * Added missing docs from matrices.py

<!-- END RELEASE NOTES -->
