### PR TITLE
Added Auxiliary Circle Feature For Ellipse

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -566,9 +566,6 @@ class Ellipse(GeometrySet):
         (x - 2)**2 + (y - 4)**2 - 81
 
         """
-        x = _symbol(x)
-        y = _symbol(y)
-        m =_symbol(m)
         hr, vr = self.hradius, self.vradius
         m = max(hr, vr)
         return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -543,6 +543,36 @@ class Ellipse(GeometrySet):
         """
         return Point.distance(self.center, self.foci[0])
 
+    def auxiliary_circle(self, x='x', y='y'):
+        """The equation of auxiliary circle of the ellipse.
+
+        Returns
+        =======
+
+        equation : sympy expression
+
+        Parameters
+        ==========
+
+        x : str, optional Label for the x-axis. Default value is 'x'.
+        y : str, optional Label for the y-axis. Default value is 'y'.
+
+        Examples
+        ========
+
+        >>> from sympy import Ellipse, Point
+        >>> ellipse = Ellipse(Point(2, 4), 9, 1)
+        >>> ellipse.auxiliary_circle()
+        (x - 2)**2 + (y - 4)**2 - 81
+
+        """
+        x = _symbol(x)
+        y = _symbol(y)
+        m =_symbol(m)
+        hr, vr = self.hradius, self.vradius
+        m = max(hr, vr)
+        return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2
+
     @property
     def hradius(self):
         """The horizontal radius of the ellipse.

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -451,3 +451,12 @@ def test_circumference():
     assert abs(Ellipse(None, hradius=5, vradius=3).circumference.evalf(16) - 25.52699886339813) < 1e-10
 def test_issue_15259():
     assert Circle((1, 2), 0) == Point(1, 2)
+
+def test_auxiliary_circle():
+    p, q = symbols('p, q')
+    # circle p = q
+    assert Ellipse(Point(0,0), p, q).auxiliary_circle == x**2 + y**2 - p**2
+    # horizontal ellipse p > q
+    assert Ellipse(Point(0,0), p, q).auxiliary_circle == x**2 + y**2 - p**2
+    # vertical ellipse p < q
+    assert Ellipse(Point(0,0), p, q).auxiliary_circle == x**2 + y**2 - q**2

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -454,9 +454,12 @@ def test_issue_15259():
 
 def test_auxiliary_circle():
     p, q = symbols('p, q')
+
     # circle p = q
     assert Ellipse(Point(0,0), p, q).auxiliary_circle == x**2 + y**2 - p**2
+
     # horizontal ellipse p > q
     assert Ellipse(Point(0,0), p, q).auxiliary_circle == x**2 + y**2 - p**2
+
     # vertical ellipse p < q
     assert Ellipse(Point(0,0), p, q).auxiliary_circle == x**2 + y**2 - q**2

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -10,8 +10,7 @@ from sympy.functions.special.elliptic_integrals import elliptic_e
 
 def test_object_from_equation():
     from sympy.abc import x, y, a, b
-    assert Circle(x**2 + y**2 + 3*x + 4*y - 8) == Circle(Point2D(S(-3) / 2, -2),
-                                                                                      sqrt(57) / 2)
+    assert Circle(x**2 + y**2 + 3*x + 4*y - 8) == Circle(Point2D(S(-3) / 2, -2),                                                                                sqrt(57) / 2)
     assert Circle(x**2 + y**2 + 6*x + 8*y + 25) == Circle(Point2D(-3, -4), 0)
     assert Circle(a**2 + b**2 + 6*a + 8*b + 25, x='a', y='b') == Circle(Point2D(-3, -4), 0)
     assert Circle(x**2 + y**2 - 25) == Circle(Point2D(0, 0), 5)


### PR DESCRIPTION
Auxiliary Circle of an ellipse is the circumcircle of an ellipse i.e. the circle whose centre concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.

The centre of the auxiliary circle is always the same as the ellipse's centre, the circle itself touches both vertices. Hence, the distance between a vertex and the centre is the circle's radius. In an ellipse, the distance between a vertex and the centre is given by the semi-major axis.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- geometry
  - Added Auxiliary Circle Feature For Ellipse

<!-- END RELEASE NOTES -->
