### PR TITLE
Fix order of substitutions in subs_func_doit (rebased)

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -232,6 +232,7 @@ from __future__ import print_function, division
 
 from collections import defaultdict
 from itertools import islice
+from functools import cmp_to_key
 
 from sympy.core import Add, S, Mul, Pow, oo
 from sympy.core.compatibility import ordered, iterable, is_sequence, range

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -366,7 +366,14 @@ def sub_func_doit(eq, func, new):
 
     # Make sure that expressions such as ``Derivative(f(x), (x, 2))`` get
     # replaced before ``Derivative(f(x), x)``:
-    reps = sorted(reps.items(), key=lambda x: -x[0].derivative_count)
+    #
+    # Also replace e.g. Derivative(x*Derivative(f(x), x), x) before
+    # Derivative(f(x), x)
+    def cmp(subs1, subs2):
+        return subs2[0].has(subs1[0]) - subs1[0].has(subs2[0])
+    key = lambda x: (-x[0].derivative_count, cmp_to_key(cmp)(x))
+    reps = sorted(reps.items(), key=key)
+
     return eq.subs(reps).subs(func, new).subs(repu)
 
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -636,7 +636,10 @@ def test_checkodesol():
     eq3 = x*exp(f(x)/x) + f(x) - x*f(x).diff(x)
     sol3 = Eq(f(x), log(log(C1/x)**(-x)))
     assert not checkodesol(eq3, sol3)[1].has(f(x))
-
+    # This case was failing intermittently depending on hash-seed:
+    eqn = Eq(Derivative(x*Derivative(f(x), x), x)/x, exp(x))
+    sol = Eq(f(x), C1 + C2*log(x) + exp(x) - Ei(x))
+    assert checkodesol(eqn, sol, order=2, solve_for_func=False)[0]
 
 @slow
 def test_dsolve_options():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -599,6 +599,7 @@ def test_nonlinear_3eq_order1():
 
 
 def test_checkodesol():
+    from sympy import Ei
     # For the most part, checkodesol is well tested in the tests below.
     # These tests only handle cases not checked below.
     raises(ValueError, lambda: checkodesol(f(x, y).diff(x), Eq(f(x, y), x)))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15288 

#### Brief description of what is fixed or changed

With unexpanded derivatives `subs_func_doit` can make substitutions in the wrong order which changes the result:

```julia
In [7]: eq = -exp(x) + Derivative(x*Derivative(f(x), x), x)/x

In [8]: _u = Symbol('u')

In [9]: reps = [(Derivative(f(x), x), _u), (Derivative(x*Derivative(f(x), x), x), _u)]

In [10]: eq.subs(reps)
Out[10]: 
       ∂      
       ──(u⋅x)
   x   ∂x     
- ℯ  + ───────
          x   

In [11]: eq.subs(reps[::-1])
Out[11]: 
u    x
─ - ℯ 
x    
```

This patch ensures that if an expression `expra` to be substituted contains another expression `exprb` to be substituted then `expra` will be substituted first.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * improved checkodesol handling of expressions with unexpanded derivatives
<!-- END RELEASE NOTES -->
