### PR TITLE
Fix Definite Integral for functions with ConditionSet singularities

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -871,21 +871,25 @@ class Expr(Basic, EvalfMixin):
             else:
                 domain = Interval(b, a)
             # check the singularities of self within the interval
+            # if singularities is a ConditionSet (not iterable), catch the exception and pass
             singularities = solveset(self.cancel().as_numer_denom()[1], x,
                 domain=domain)
             for logterm in self.atoms(log):
                 singularities = singularities | solveset(logterm.args[0], x,
                     domain=domain)
-            for s in singularities:
-                if value is S.NaN:
-                    # no need to keep adding, it will stay NaN
-                    break
-                if not s.is_comparable:
-                    continue
-                if (a < s) == (s < b) == True:
-                    value += -limit(self, x, s, "+") + limit(self, x, s, "-")
-                elif (b < s) == (s < a) == True:
-                    value += limit(self, x, s, "+") - limit(self, x, s, "-")
+            try:
+                for s in singularities:
+                    if value is S.NaN:
+                        # no need to keep adding, it will stay NaN
+                        break
+                    if not s.is_comparable:
+                        continue
+                    if (a < s) == (s < b) == True:
+                        value += -limit(self, x, s, "+") + limit(self, x, s, "-")
+                    elif (b < s) == (s < a) == True:
+                        value += limit(self, x, s, "+") - limit(self, x, s, "-")
+            except TypeError:
+                pass
 
         return value
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1389,7 +1389,8 @@ def test_issue_12081():
     f = x**(-S(3)/2)*exp(-x)
     assert integrate(f, [x, 0, oo]) == oo
 
+
 def test_issue_15285():
     y = 1/x - 1
-    f = (4 * y * exp(-2 * y)) / (x**2)
-    assert(integrate(f,[x,0,1]) == 1)
+    f = (4*y*exp(-2*y))/(x**2)
+    assert(integrate(f, [x, 0, 1]) == 1)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1388,3 +1388,8 @@ def test_issue_14782():
 def test_issue_12081():
     f = x**(-S(3)/2)*exp(-x)
     assert integrate(f, [x, 0, oo]) == oo
+
+def test_issue_15285():
+    y = 1/x - 1
+    f = (4 * y * exp(-2 * y)) / (x**2)
+    assert(integrate(f,[x,0,1]) == 1)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1392,5 +1392,5 @@ def test_issue_12081():
 
 def test_issue_15285():
     y = 1/x - 1
-    f = (4*y*exp(-2*y))/(x**2)
-    assert(integrate(f, [x, 0, 1]) == 1)
+    f = 4*y*exp(-2*y)/x**2
+    assert integrate(f, [x, 0, 1]) == 1


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15285


#### Brief description of what is fixed or changed
Certain functions cause evaluating a definite integral to fail, due
to the set of singularities of the function being a ConditionSet
(and therefore not iterable). The change just catches the TypeError
and passes it.

#### Other comments


#### Release Notes


<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * fixed bug that occurred when integrating certain functions over an interval
<!-- END RELEASE NOTES -->
