### PR TITLE
broaden dummy_eq capabilities

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -189,7 +189,7 @@ class ExprWithLimits(Expr):
 
     @property
     def variables(self):
-        """Return a list of the dummy variables
+        """Return a list of the limit variables.
 
         >>> from sympy import Sum
         >>> from sympy.abc import x, i
@@ -204,6 +204,27 @@ class ExprWithLimits(Expr):
         transform : Perform mapping on the dummy variable
         """
         return [l[0] for l in self.limits]
+
+    @property
+    def dummy_variables(self):
+        """Return only variables that are dummy variables.
+
+        Examples
+        ========
+
+        >>> from sympy import Integral
+        >>> from sympy.abc import x, i, j, k
+        >>> Integral(x**i, (i, 1, 3), (j, 2), k).dummy_variables
+        [i, j]
+
+        See Also
+        ========
+
+        function, limits, free_symbols
+        as_dummy : Rename dummy variables
+        transform : Perform mapping on the dummy variable
+        """
+        return [l[0] for l in self.limits if len(l) != 1]
 
     @property
     def free_symbols(self):
@@ -240,55 +261,6 @@ class ExprWithLimits(Expr):
     def is_number(self):
         """Return True if the Sum has no free symbols, else False."""
         return not self.free_symbols
-
-    def as_dummy(self):
-        """
-        Replace instances of the given dummy variables with explicit dummy
-        counterparts to make clear what are dummy variables and what
-        are real-world symbols in an object.
-
-        Examples
-        ========
-
-        >>> from sympy import Integral
-        >>> from sympy.abc import x, y
-        >>> Integral(x, (x, x, y), (y, x, y)).as_dummy()
-        Integral(_x, (_x, x, _y), (_y, x, y))
-
-        If the object supperts the "integral at" limit ``(x,)`` it
-        is not treated as a dummy, but the explicit form, ``(x, x)``
-        of length 2 does treat the variable as a dummy.
-
-        >>> Integral(x, x).as_dummy()
-        Integral(x, x)
-        >>> Integral(x, (x, x)).as_dummy()
-        Integral(_x, (_x, x))
-
-        If there were no dummies in the original expression, then the
-        the symbols which cannot be changed by subs() are clearly seen as
-        those with an underscore prefix.
-
-        See Also
-        ========
-
-        variables : Lists the integration variables
-        transform : Perform mapping on the integration variable
-        """
-        reps = {}
-        f = self.function
-        limits = list(self.limits)
-        for i in range(-1, -len(limits) - 1, -1):
-            xab = list(limits[i])
-            if len(xab) == 1:
-                continue
-            x = xab[0]
-            xab[0] = x.as_dummy()
-            for j in range(1, len(xab)):
-                xab[j] = xab[j].subs(reps)
-            reps[x] = xab[0]
-            limits[i] = xab
-        f = f.subs(reps)
-        return self.func(f, *limits)
 
     def _eval_interval(self, x, a, b):
         limits = [(i if i[0] != x else (x, a, b)) for i in self.limits]
@@ -341,7 +313,10 @@ class ExprWithLimits(Expr):
             sub_into_func = True
             for i, xab in enumerate(limits):
                 if 1 == len(xab) and old == xab[0]:
-                    xab = (old, old)
+                    if new._diff_wrt:
+                        xab = (new,)
+                    else:
+                        xab = (old, old)
                 limits[i] = Tuple(xab[0], *[l._subs(old, new) for l in xab[1:]])
                 if len(xab[0].free_symbols.intersection(old.free_symbols)) != 0:
                     sub_into_func = False

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -206,7 +206,7 @@ class ExprWithLimits(Expr):
         return [l[0] for l in self.limits]
 
     @property
-    def dummy_variables(self):
+    def bound_symbols(self):
         """Return only variables that are dummy variables.
 
         Examples
@@ -214,7 +214,7 @@ class ExprWithLimits(Expr):
 
         >>> from sympy import Integral
         >>> from sympy.abc import x, i, j, k
-        >>> Integral(x**i, (i, 1, 3), (j, 2), k).dummy_variables
+        >>> Integral(x**i, (i, 1, 3), (j, 2), k).bound_symbols
         [i, j]
 
         See Also

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -165,19 +165,6 @@ class Sum(AddWithLimits, ExprWithIntLimits):
 
         return obj
 
-    def dummy_eq(self, other, symbol=None):
-        if type(self) != type(other):
-            return False
-        if len(self.variables) != len(other.variables):
-            return False
-        if len(self.free_symbols) != len(other.free_symbols):
-            return False
-        reps = dict(zip(self.variables, other.variables))
-        aligned = self.xreplace(reps)
-        if symbol:
-            return super(Sum, aligned).dummy_eq(other, symbol=symbol)
-        return aligned == other
-
     def _eval_is_zero(self):
         # a Sum is only zero if its function is zero or if all terms
         # cancel out. This only answers whether the summand is zero; if

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -542,11 +542,12 @@ def test_equality():
             assert F(1, x) != F(1, y)
         except ValueError:
             pass
-        assert F(a, (x, 1, 2)) != F(a, (x, 1, 3))
-        assert F(a, (x, 1, 2)) != F(b, (x, 1, 2))
-        assert F(x, (x, 1, 2)) != F(r, (r, 1, 2))
-        assert F(1, (x, 1, x)) != F(1, (y, 1, x))
-        assert F(1, (x, 1, x)) != F(1, (y, 1, y))
+        assert F(a, (x, 1, 2)) != F(a, (x, 1, 3))  # diff limit
+        assert F(a, (x, 1, x)) != F(a, (y, 1, y))
+        assert F(a, (x, 1, 2)) != F(b, (x, 1, 2))  # diff expression
+        assert F(x, (x, 1, 2)) != F(r, (r, 1, 2))  # diff assumptions
+        assert F(1, (x, 1, x)) != F(1, (y, 1, x))  # only dummy is diff
+        assert F(1, (x, 1, x)).dummy_eq(F(1, (y, 1, x)))
 
     # issue 5265
     assert Sum(x, (x, 1, x)).subs(x, a) == Sum(x, (x, 1, a))

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -374,9 +374,9 @@ class Basic(with_metaclass(ManagedProperties)):
         False
 
         """
-        s = self.as_dummy(canonical=True)
+        s = self.as_dummy(syms='')
         o = _sympify(other)
-        o = o.as_dummy(canonical=True)
+        o = o.as_dummy(syms='')
 
         dummy_symbols = [i for i in s.free_symbols if i.is_Dummy]
 
@@ -509,86 +509,133 @@ class Basic(with_metaclass(ManagedProperties)):
     def expr_free_symbols(self):
         return set([])
 
-    def as_dummy(self, canonical=False, plain=False):
+    def as_dummy(self, syms=None, default=None):
         """Return the expression with any objects having structural
         dummy symbols replaced with unique, canonical symbols within
-        the object in which they appear.
+        the object in which they appear and having only the default
+        assumption for commutativity being True.
 
         Examples
         ========
 
         >>> from sympy import Integral, Symbol
         >>> from sympy.abc import x, u, v
-        >>> (x + Integral(x, (x, x))).as_dummy()
-        x + Integral(_x, (_x, x))
-
-        >>> Integral(u, (u, x)).as_dummy(canonical=True)
-        Integral(u, (u, x))
-        >>> Integral(v, (v, x)).as_dummy(canonical=True)
-        Integral(u, (u, x))
-        >>> Integral(u, (u, u)).as_dummy(canonical=True)
-        Integral(v, (v, u))
-
-        The default is to use Dummy symbols with the assumptions as
-        the symbols they are replacing. To ignore assumptions set
-        `plain=True`.
-
         >>> r = Symbol('r', real=True)
-        >>> i = Integral(r, (r, 1))
-        >>> v = i.as_dummy().variables[0]
-        >>> v.is_real
+        >>> Integral(r, (r, x)).as_dummy()
+        Integral(_r, (_r, x))
+        >>> _.variables[0].is_real is None
         True
-        >>> v = i.as_dummy(plain=True).variables[0]
-        >>> v.is_real is None
-        True
+
+        >>> Integral(u, (u, x)).as_dummy(syms='')
+        Integral(u, (u, x))
+        >>> Integral(v, (v, x)).as_dummy(syms='')
+        Integral(u, (u, x))
+        >>> Integral(u, (u, u)).as_dummy(syms='')
+        Integral(v, (v, u))
+        >>> Integral(u, (u, u)).as_dummy(syms='x')
+        Integral(x, (x, u))
 
         Any object that has structural dummy variables should have
-        a property, `dummy_variables` that returns a list of structural
+        a property, `bound_symbols` that returns a list of structural
         dummy symbols of the object itself.
 
         >>> from sympy import Derivative, Sum, Subs, Lambda
         >>> from sympy.abc import y
 
-        >>> Derivative(Integral(y, (x, x)), y).as_dummy(canonical=True)
+        >>> Derivative(Integral(y, (x, x)), y).as_dummy(syms='')
         Derivative(Integral(y, (u, x)), y)
 
         >>> eq = Subs(Integral(x, (x, x)), x, Sum(x, (x, 1, 2)))
-        >>> eq.as_dummy(canonical=True)
+        >>> eq.as_dummy(syms='')
         Subs(Integral(u, (u, x)), u, Sum(u, (u, 1, 2)))
 
         >>> Lambda(x, Integral(y, (x, x))).as_dummy()
         Lambda(_x, Integral(y, (_x, _x)))
-        >>> Lambda(x, Integral(y, (x, x))).as_dummy(canonical=True)
+        >>> Lambda(x, Integral(y, (x, x))).as_dummy(syms='')
         Lambda(v, Integral(y, (u, v)))
         """
         from sympy.core.symbol import Symbol
         def can(x):
-            d = dict([(i, i.as_dummy()) for i in x.dummy_variables])
+            d = dict([(i, i.as_dummy()) for i in x.bound_symbols])
             x = x.subs(d)  # targets non-dummy that shadow dummy
-            if canonical:
-                c = x.canonical_variables
+            if syms is None and default is None:
+                c = dict([(i, i.as_dummy()) for i in x.bound_symbols])
             else:
-                c = dict([(i, i.as_dummy()) for i in x.dummy_variables])
-            if plain:
-                c = dict((k, Symbol(v.name)) for k, v in c.items())
+                c = x._canonical_bound(
+                    '' if syms is None else (syms or 'u:z'),
+                    'iota_' if default is None else default)
             x = x.xreplace(c)
             # undo shadow masking
             x = x.xreplace(dict((v, k) for k, v in d.items()))
             return x
         rv = self.replace(
-            lambda x: hasattr(x, 'dummy_variables'),
+            lambda x: hasattr(x, 'bound_symbols'),
             lambda x: can(x))
-        if hasattr(rv, 'dummy_variables'):
+        if hasattr(rv, 'bound_symbols'):
             rv = can(rv)
         return rv
+
+    def _canonical_bound(self, syms=None, default=None):
+        """Return a dictionary mapping any variable defined in
+        ``self.bound_symbols`` to symbols that do not clash
+        with any existing symbol in the expression using, first,
+        the symbols given in syms and then falling back to numbered
+        instances of the default symbol.
+
+        Examples
+        ========
+
+        >>> from sympy import Lambda
+        >>> from sympy.abc import a, b, x, y
+        >>> Lambda(x, 2*x)._canonical_bound()
+        {x: 0}
+        >>> Lambda(x, 2*x)._canonical_bound('i')
+        {x: i}
+        >>> Lambda(x, 2*x)._canonical_bound('x')
+        {x: x}
+        >>> Lambda(x, 2*x)._canonical_bound(default='i')
+        {x: i0}
+
+        The first non-clashing symbol will be used:
+
+        >>> Lambda(y, a + b + y)._canonical_bound('a:c')
+        {y: c}
+
+        If all the syms given clash with existing free symbols
+        then the default value will be used:
+
+        >>> Lambda(y, 2*x + y)._canonical_bound('x')
+        {y: _0}
+        >>> Lambda(y, 2*x + y)._canonical_bound('x', 'i')
+        {y: i0}
+        >>> Lambda(y, 2*x + y)._canonical_bound(default='i_')
+        {y: i_0}
+        """
+        from itertools import chain
+        from sympy import symbols, Symbol, Derivative
+        from sympy.utilities.iterables import numbered_symbols
+        if not hasattr(self, 'bound_symbols'):
+            return {}
+        if syms:
+            dums = chain(symbols(syms, seq=True), numbered_symbols(default or '_'))
+        else:
+            dums = numbered_symbols(default or '')
+        reps = {}
+        v = self.bound_symbols
+        syms = [i.name for i in self.atoms(Symbol) - set(v)]
+        for v in v:
+            d = next(dums).name
+            while v == d or d in syms:
+                d = next(dums).name
+            if v != d:
+                reps[v] = Symbol(d)
+        return reps
 
     @property
     def canonical_variables(self):
         """Return a dictionary mapping any variable defined in
-        ``self.dummy_variables`` to variables that do not clash with
-        any existing symbol in the expression. The
-        variables are attempted in the order u, v, w, x, y, z,
-        and then number-subscripted ``iota``.
+        ``self.bound_symbols`` to symbols that do not clash
+        with any existing symbol in the expression.
 
         Examples
         ========
@@ -596,23 +643,23 @@ class Basic(with_metaclass(ManagedProperties)):
         >>> from sympy import Lambda
         >>> from sympy.abc import x
         >>> Lambda(x, 2*x).canonical_variables
-        {x: u}
+        {x: iota_0}
         """
         from itertools import chain
         from sympy import symbols, Symbol, Derivative
         from sympy.utilities.iterables import numbered_symbols
-        if not hasattr(self, 'dummy_variables'):
+        if not hasattr(self, 'bound_symbols'):
             return {}
-        dums = chain(symbols('u:z'), symbols('a:t'), numbered_symbols('iota_'))
+        dums = numbered_symbols('iota_')
         reps = {}
-        v = self.dummy_variables
+        v = self.bound_symbols
         syms = [i.name for i in self.atoms(Symbol) - set(v)]
         for v in v:
             d = next(dums).name
             while v == d or d in syms:
                 d = next(dums).name
             if v != d:
-                reps[v] = Symbol(d, **v.assumptions0)
+                reps[v] = Symbol(d)
         return reps
 
     def rcall(self, *args):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -578,7 +578,7 @@ class Basic(with_metaclass(ManagedProperties)):
         rv = self.replace(
             lambda x: hasattr(x, 'dummy_variables'),
             lambda x: can(x))
-        if rv != self and hasattr(rv, 'dummy_variables'):
+        if hasattr(rv, 'dummy_variables'):
             rv = can(rv)
         return rv
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1685,7 +1685,7 @@ class Lambda(Expr):
         """The variables used in the internal representation of the function"""
         return self._args[0]
 
-    dummy_variables = variables
+    bound_symbols = variables
 
     @property
     def expr(self):
@@ -1866,7 +1866,7 @@ class Subs(Expr):
         """The variables to be evaluated"""
         return self._args[1]
 
-    dummy_variables = variables
+    bound_symbols = variables
 
     @property
     def expr(self):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1472,7 +1472,11 @@ class Derivative(Expr):
     def variables(self):
         # TODO: deprecate?
         # TODO: support for `d^n`?
-        return tuple(v for v, count in self.variable_count if count.is_Integer for i in (range(count) if count.is_Integer else [1]))
+        rv = []
+        for v, count in self.variable_count:
+            if count.is_Integer:
+                rv.extend([v]*count)
+        return tuple(rv)
 
     @property
     def variable_count(self):
@@ -1681,6 +1685,8 @@ class Lambda(Expr):
         """The variables used in the internal representation of the function"""
         return self._args[0]
 
+    dummy_variables = variables
+
     @property
     def expr(self):
         """The return value of the function"""
@@ -1859,6 +1865,8 @@ class Subs(Expr):
     def variables(self):
         """The variables to be evaluated"""
         return self._args[1]
+
+    dummy_variables = variables
 
     @property
     def expr(self):

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -260,9 +260,8 @@ class Symbol(AtomicExpr, Boolean):
     def sort_key(self, order=None):
         return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One
 
-    def as_dummy(self, canonical=False, plain=False):
-        return (Symbol if canonical else Dummy)(self.name,
-            **({} if plain else self._assumptions.generator))
+    def as_dummy(self, syms=None):
+        return (Dummy if syms is None else Symbol)(self.name)
 
     def as_real_imag(self, deep=True, **hints):
         from sympy import im, re

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -260,8 +260,8 @@ class Symbol(AtomicExpr, Boolean):
     def sort_key(self, order=None):
         return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One
 
-    def as_dummy(self, syms=None):
-        return (Dummy if syms is None else Symbol)(self.name)
+    def as_dummy(self):
+        return Dummy(self.name)
 
     def as_real_imag(self, deep=True, **hints):
         from sympy import im, re

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -260,9 +260,9 @@ class Symbol(AtomicExpr, Boolean):
     def sort_key(self, order=None):
         return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One
 
-    def as_dummy(self):
-        """Return a Dummy having the same name and same assumptions as self."""
-        return Dummy(self.name, **self._assumptions.generator)
+    def as_dummy(self, canonical=False, plain=False):
+        return (Symbol if canonical else Dummy)(self.name,
+            **({} if plain else self._assumptions.generator))
 
     def as_real_imag(self, deep=True, **hints):
         from sympy import im, re

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -8,10 +8,10 @@ from sympy.core.basic import (Basic, Atom, preorder_traversal, as_Basic,
     _atomic)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
-from sympy.core.function import Function
+from sympy.core.function import Function, Lambda
 from sympy.core.compatibility import default_sort_key
 
-from sympy import sin, Lambda, Q, cos, gamma, Tuple, Integral
+from sympy import sin, Q, cos, gamma, Tuple, Integral
 from sympy.functions.elementary.exponential import exp
 from sympy.utilities.pytest import raises
 from sympy.core import I, pi
@@ -247,7 +247,15 @@ def test_atomic():
 
 
 def test_as_dummy():
-    u, v, x = symbols('u, v, x')
+    u, v, x, y, z, i0 = symbols('u v x y z i0')
+    L = Lambda(x, x + 1)
+    assert L.as_dummy().variables[0].name == 'x'
+    assert L.as_dummy('').variables[0].name == 'u'
+    assert L.as_dummy('a').variables[0].name == 'a'
+    assert L.as_dummy('', default='i').variables[0].name == 'u'
+    assert L.as_dummy(default='i').variables[0].name == 'i0'
+    assert Lambda(x, x + i0).as_dummy(default='i').variables[0].name == 'i1'
+
     d = x.as_dummy()
     assert d != x
     assert d.as_dummy() != d
@@ -256,29 +264,27 @@ def test_as_dummy():
     i = symbols('i', integer=True)
     d = i.as_dummy()
     assert d.name == i.name
-    assert d.assumptions0 == i.assumptions0
-    assert i.as_dummy(plain=True).assumptions0 == x.assumptions0
-    d = i.as_dummy(canonical=True)
-    assert d.name == i.name
-    assert d.assumptions0 == i.assumptions0
-    d = i.as_dummy(canonical=True, plain=True)
+    assert d.assumptions0 == x.assumptions0
+    d = i.as_dummy(syms='u')
     assert d.name == i.name
     assert d.assumptions0 == x.assumptions0
     for i in range(2):
         assert (i + Integral(x, (x, x))).as_dummy(
-            canonical=True) == Integral(u, (u, x)) + i
+            syms='u') == Integral(u, (u, x)) + i
         assert (i + Integral(u, (u, x))).as_dummy(
-            canonical=True) == Integral(u, (u, x)) + i
+            syms='u') == Integral(u, (u, x)) + i
         assert (i + Integral(v, (v, x))).as_dummy(
-            canonical=True) == Integral(u, (u, x)) + i
+            syms='u') == Integral(u, (u, x)) + i
         assert (i + Integral(u, (u, u))).as_dummy(
-            canonical=True) == Integral(v, (v, u)) + i
+            syms='u v') == Integral(v, (v, u)) + i
     assert str((x + Integral(x, (x, x))).as_dummy(
             )) == 'x + Integral(_x, (_x, x))'
     r = symbols('r', real=True)
     i = Integral(r, (r, 1))
-    assert i.as_dummy().variables[0].is_real is True
-    assert i.as_dummy(plain=True).variables[0].is_real is None
-    d = i.as_dummy(canonical=True, plain=True)
-    assert d.variables[0].name == u.name
-    assert d.function == u
+    assert i.as_dummy().variables[0].is_real is None
+
+
+def test_canonical_variables():
+    x, i0, i1 = symbols('x iota_:2')
+    assert Lambda(x, x + 1).canonical_variables == {x: i0}
+    assert Lambda(x, x + i0).canonical_variables == {x: i1}

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -11,7 +11,7 @@ from sympy.core.symbol import symbols
 from sympy.core.function import Function, Lambda
 from sympy.core.compatibility import default_sort_key
 
-from sympy import sin, Q, cos, gamma, Tuple, Integral
+from sympy import sin, Q, cos, gamma, Tuple, Integral, Sum
 from sympy.functions.elementary.exponential import exp
 from sympy.utilities.pytest import raises
 from sympy.core import I, pi
@@ -247,44 +247,13 @@ def test_atomic():
 
 
 def test_as_dummy():
-    u, v, x, y, z, i0 = symbols('u v x y z i0')
-    L = Lambda(x, x + 1)
-    assert L.as_dummy().variables[0].name == 'x'
-    assert L.as_dummy('').variables[0].name == 'u'
-    assert L.as_dummy('a').variables[0].name == 'a'
-    assert L.as_dummy('', default='i').variables[0].name == 'u'
-    assert L.as_dummy(default='i').variables[0].name == 'i0'
-    assert Lambda(x, x + i0).as_dummy(default='i').variables[0].name == 'i1'
-
-    d = x.as_dummy()
-    assert d != x
-    assert d.as_dummy() != d
-    assert d.name == x.name
-    assert d.assumptions0 == x.assumptions0
-    i = symbols('i', integer=True)
-    d = i.as_dummy()
-    assert d.name == i.name
-    assert d.assumptions0 == x.assumptions0
-    d = i.as_dummy(syms='u')
-    assert d.name == i.name
-    assert d.assumptions0 == x.assumptions0
-    for i in range(2):
-        assert (i + Integral(x, (x, x))).as_dummy(
-            syms='u') == Integral(u, (u, x)) + i
-        assert (i + Integral(u, (u, x))).as_dummy(
-            syms='u') == Integral(u, (u, x)) + i
-        assert (i + Integral(v, (v, x))).as_dummy(
-            syms='u') == Integral(u, (u, x)) + i
-        assert (i + Integral(u, (u, u))).as_dummy(
-            syms='u v') == Integral(v, (v, u)) + i
-    assert str((x + Integral(x, (x, x))).as_dummy(
-            )) == 'x + Integral(_x, (_x, x))'
-    r = symbols('r', real=True)
-    i = Integral(r, (r, 1))
-    assert i.as_dummy().variables[0].is_real is None
+    u, v, x, y, z, _0, _1 = symbols('u v x y z _0 _1')
+    assert Lambda(x, x + 1).as_dummy() == Lambda(_0, _0 + 1)
+    assert Lambda(x, x + _0).as_dummy() == Lambda(_1, _0 + _1)
+    assert (1 + Sum(x, (x, 1, x))).as_dummy() == 1 + Sum(_0, (_0, 1, x))
 
 
 def test_canonical_variables():
-    x, i0, i1 = symbols('x iota_:2')
-    assert Lambda(x, x + 1).canonical_variables == {x: i0}
-    assert Lambda(x, x + i0).canonical_variables == {x: i1}
+    x, i0, i1 = symbols('x _:2')
+    assert Integral(x, (x, x + 1)).canonical_variables == {x: i0}
+    assert Integral(x, (x, x + i0)).canonical_variables == {x: i1}

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -4,7 +4,6 @@ from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         Tuple, Dummy, Eq, Expr, symbols, nfloat, Piecewise, Indexed,
         Matrix, Basic)
 from sympy.utilities.pytest import XFAIL, raises
-from sympy.abc import t, w, x, y, z
 from sympy.core.basic import _aresame
 from sympy.core.function import PoleError, _mexpand
 from sympy.core.sympify import sympify
@@ -14,6 +13,7 @@ from sympy.utilities.iterables import subsets, variations
 from sympy.core.cache import clear_cache
 from sympy.core.compatibility import range
 
+from sympy.abc import t, u, v, w, x, y, z
 f, g, h = symbols('f g h', cls=Function)
 
 
@@ -1068,3 +1068,14 @@ def test_issue_15241():
     assert (G + y*Gy).diff(Gy, y) == 1
     assert (y*G + y*Gy*G).diff(G, y) == y*Gy.diff(y) + Gy + 1
     assert (y*G + y*Gy*G).diff(y, G) == y*Gy.diff(y) + Gy + 1
+
+
+def test_as_dummy():
+    assert Lambda(x, x + v).as_dummy(canonical=True
+        ) == Lambda(u, u + v).as_dummy(canonical=True
+        ) == Lambda(u, u + v)
+    assert Subs(x, x, x + v).as_dummy(canonical=True
+        ) == Subs(u, u, x + v).as_dummy(canonical=True
+        ) == Subs(u, u, x + v)
+    assert Subs(x, x, u + v).as_dummy(canonical=True
+        ) == Subs(w, w, u + v)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1068,14 +1068,3 @@ def test_issue_15241():
     assert (G + y*Gy).diff(Gy, y) == 1
     assert (y*G + y*Gy*G).diff(G, y) == y*Gy.diff(y) + Gy + 1
     assert (y*G + y*Gy*G).diff(y, G) == y*Gy.diff(y) + Gy + 1
-
-
-def test_as_dummy():
-    assert Lambda(x, x + v).as_dummy(syms='u:w'
-        ) == Lambda(u, u + v).as_dummy(syms='u:w'
-        ) == Lambda(u, u + v)
-    assert Subs(x, x, x + v).as_dummy(syms='u:w'
-        ) == Subs(u, u, x + v).as_dummy(syms='u:w'
-        ) == Subs(u, u, x + v)
-    assert Subs(x, x, u + v).as_dummy(syms='u:w'
-        ) == Subs(w, w, u + v)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1071,11 +1071,11 @@ def test_issue_15241():
 
 
 def test_as_dummy():
-    assert Lambda(x, x + v).as_dummy(canonical=True
-        ) == Lambda(u, u + v).as_dummy(canonical=True
+    assert Lambda(x, x + v).as_dummy(syms='u:w'
+        ) == Lambda(u, u + v).as_dummy(syms='u:w'
         ) == Lambda(u, u + v)
-    assert Subs(x, x, x + v).as_dummy(canonical=True
-        ) == Subs(u, u, x + v).as_dummy(canonical=True
+    assert Subs(x, x, x + v).as_dummy(syms='u:w'
+        ) == Subs(u, u, x + v).as_dummy(syms='u:w'
         ) == Subs(u, u, x + v)
-    assert Subs(x, x, u + v).as_dummy(canonical=True
+    assert Subs(x, x, u + v).as_dummy(syms='u:w'
         ) == Subs(w, w, u + v)

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -47,18 +47,6 @@ def test_Dummy_force_dummy_index():
     assert Dummy()._count == Dummy('d', dummy_index=3)._count
 
 
-def test_as_dummy():
-    x = Symbol('x')
-    x1 = x.as_dummy()
-    assert x1 != x
-    assert x1 != x.as_dummy()
-
-    x = Symbol('x', commutative=False)
-    x1 = x.as_dummy()
-    assert x1 != x
-    assert x1.is_commutative is False
-
-
 def test_lt_gt():
     from sympy import sympify as S
     x, y = Symbol('x'), Symbol('y')

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -245,16 +245,11 @@ class CoordSystem(Basic):
 
     @staticmethod
     def _inv_transf(from_coords, to_exprs):
-        # TODO, check for results, get solve to return results in definite
-        # format instead of wondering dict/tuple/whatever.
-        # As it is at the moment this is an ugly hack for changing the format
         inv_from = [i.as_dummy() for i in from_coords]
         inv_to = solve(
-            [t[0] - t[1] for t in zip(inv_from, to_exprs)], list(from_coords))
-        if isinstance(inv_to, dict):
-            inv_to = [inv_to[fc] for fc in from_coords]
-        else:
-            inv_to = inv_to[0]
+            [t[0] - t[1] for t in zip(inv_from, to_exprs)],
+            list(from_coords), dict=True)[0]
+        inv_to = [inv_to[fc] for fc in from_coords]
         return Matrix(inv_from), Matrix(inv_to)
 
     @staticmethod
@@ -1297,7 +1292,8 @@ def intcurve_diffequ(vector_field, param, start_point, coord_sys=None):
 def dummyfy(args, exprs):
     # TODO Is this a good idea?
     d_args = Matrix([s.as_dummy() for s in args])
-    d_exprs = Matrix([sympify(expr).subs(list(zip(args, d_args))) for expr in exprs])
+    reps = dict(zip(args, d_args))
+    d_exprs = Matrix([sympify(expr).subs(reps) for expr in exprs])
     return d_args, d_exprs
 
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -68,7 +68,7 @@ class Integral(AddWithLimits):
         >>> i.as_dummy()
         Integral(x, x)
         >>> at.as_dummy()
-        Integral(_x, (_x, x))
+        Integral(_0, (_0, x))
 
         """
 

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -174,9 +174,8 @@ def test_Dummy_from_Symbol():
     # should not get the full dictionary of assumptions
     n = Symbol('n', integer=True)
     d = n.as_dummy()
-    s1 = "Dummy('n', dummy_index=%s, integer=True)" % str(d.dummy_index)
-    s2 = "Dummy('n', integer=True, dummy_index=%s)" % str(d.dummy_index)
-    assert srepr(d) in (s1, s2)
+    assert srepr(d
+        ) == "Dummy('n', dummy_index=%s)" % str(d.dummy_index)
 
 
 def test_tuple():

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1290,8 +1290,8 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         if r and r[d] != 0:
             y = Dummy('y')
             g = simplify(r[e]/r[d]).subs(f(x), y)
-            h = simplify(r[k]/r[d])
-            if h.has(f(x)) or g.has(x):
+            h = simplify(r[k]/r[d]).subs(f(x), y)
+            if y in h.free_symbols or x in g.free_symbols:
                 pass
             else:
                 r = {'g': g, 'h': h, 'y': y}

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1286,21 +1286,17 @@ def test_separable2():
     eq10 = (x*cos(f(x)) + x**2*sin(f(x))*f(x).diff(x) -
             a**2*sin(f(x))*f(x).diff(x))
     sol6 = Eq(Integral((u - 2)/u**3, (u, f(x))),
-        C1 + Integral(x**(-2), x)
-        ).as_dummy(canonical=True, plain=True)
+        C1 + Integral(x**(-2), x))
     sol7 = Eq(-log(-1 + f(x)**2)/2, C1 - log(2 + x))
     sol8 = Eq(asinh(f(x)), C1 - log(log(x)))
     # integrate cannot handle the integral on the lhs (cos/tan)
     sol9 = Eq(Integral(cos(u)/tan(u), (u, f(x))),
-        C1 + Integral(-exp(1)*exp(x), x)
-        ).as_dummy(canonical=True, plain=True)
+        C1 + Integral(-exp(1)*exp(x), x))
     sol10 = Eq(-log(cos(f(x))), C1 - log(- a**2 + x**2)/2)
-    assert dsolve(eq6, hint='separable_Integral').as_dummy(
-        canonical=True, plain=True) == sol6
+    assert dsolve(eq6, hint='separable_Integral').dummy_eq(sol6)
     assert dsolve(eq7, hint='separable', simplify=False) == sol7
     assert dsolve(eq8, hint='separable', simplify=False) == sol8
-    assert dsolve(eq9, hint='separable_Integral').as_dummy(
-        canonical=True, plain=True) == sol9
+    assert dsolve(eq9, hint='separable_Integral').dummy_eq(sol9)
     assert dsolve(eq10, hint='separable', simplify=False) == sol10
     assert checkodesol(eq7, sol7, order=1, solve_for_func=False)[0]
     assert checkodesol(eq8, sol8, order=1, solve_for_func=False)[0]
@@ -2895,9 +2891,11 @@ def test_issue_10867():
 
 def test_issue_11290():
     eq = cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x)
-    sol_1 = dsolve(eq, f(x), simplify=False, hint='1st_exact_Integral').as_dummy(canonical=True)
+    sol_1 = dsolve(eq, f(x), simplify=False, hint='1st_exact_Integral')
     sol_0 = dsolve(eq, f(x), simplify=False, hint='1st_exact')
-    assert sol_1 == Eq(Subs(Integral(u**2 - x*sin(u) - Integral(-sin(u), x), u) + Integral(cos(u), x), u, f(x)), C1).as_dummy(canonical=True)
+    assert sol_1.dummy_eq(Eq(Subs(
+        Integral(u**2 - x*sin(u) - Integral(-sin(u), x), u) +
+        Integral(cos(u), x), u, f(x)), C1))
     assert sol_1.doit() == sol_0
 
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

fixes #15240 while retaining `Sum(x, (x, 1, 2)) != Sum(y, (y, 1, 2))`
fixes #14324

#### Brief description of what is fixed or changed

Subs and Lambda compute hashable content
so expressions that are trivially different compare the same.
The same has not been done for ExprWithLimits. To aid in
their comparison (and in the general representation of objects
with structural dummy symbols) the `as_dummy` method now
can return non-clashing Symbol instances instead of Dummy.

Any object that defines a `bound_symbols` property will be
targeted by symbol-substitution when calling `as_dummy` on
an expression.


#### Other comments

The `as_dummy` function will now allow for simplification of expressions and canonical representation of objects that involve dummy (structural or otherwise) symbols:

```python
>>> eq=4*y*Sum(z, (z, n, k)) + 3*Sum(x**3 + x, (x, n, k)) + 1
>>> simplify(eq)
4*y*Sum(z, (z, n, k)) + 3*Sum(x**3 + x, (x, n, k)) + 1
>>> eq.as_dummy()
4*y*Sum(_0, (_0, n, k)) + 3*Sum(_0**3 + _0, (_0, n, k)) + 1
>>> simplify(_).subs(var('_0'), i)
Sum(u*(3*i**2 + 4*y + 3), (i, n, k)) + 1
```
Here, a dummy variable of integration is returned. It can be folded to a canonical form:
```python
>>> dsolve(x*f(x).diff(x) - f(x) - x*sin(f(x)/x), f(x), 
... hint='1st_homogeneous_coeff_subs_indep_div_dep_Integral',
... simplify=False)
Eq(log(f(x)), log(C1) + Integral(-(_u2 + 1/sin(1/_u2))/_u2**2, (_u2, x/f(x))))
>>> _.as_dummy()
Eq(log(f(x)), log(C1) + Integral(-(_0 + 1/sin(1/_0))/_0**2, (_0, x/f(x))))
```
The folded symbols are Symbol objects, not Dummy, so they should print well and are WYSIWYG when it comes to replacement. They will never clash with existing variables. If the ode above is written, with malice aforethought, in term of `_0` instead of `x`, then the result of folding is
```python
Eq(log(f(_u)), log(C1) + Integral(-(_1 + 1/sin(1/_1))/_1**2, (_1, _0/f(_0))))
```
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `dummy_eq` now compares expressions with canonical dummy variables
  * `canonical_variables` now returns non-clashing Symbols with simple names
* concrete
  * `bound_symbols` returns the bound symbols of the expr

<!-- END RELEASE NOTES -->
