### PR TITLE
Add LaTeX printing for matrix symbol trace

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -291,7 +291,7 @@ class LatexPrinter(Printer):
 
     def _print_Basic(self, expr):
         l = [self._print(o) for o in expr.args]
-        return expr.__class__.__name__ + "(%s)" % ", ".join(l)
+        return self._deal_with_super_sub(expr.__class__.__name__) + "(%s)" % ", ".join(l)
 
     def _print_bool(self, e):
         return r"\mathrm{%s}" % e

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -289,6 +289,10 @@ class LatexPrinter(Printer):
         else:
             return expr
 
+    def _print_Basic(self, expr):
+        l = [self._print(o) for o in expr.args]
+        return expr.__class__.__name__ + "(%s)" % ", ".join(l)
+
     def _print_bool(self, e):
         return r"\mathrm{%s}" % e
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1468,7 +1468,7 @@ class LatexPrinter(Printer):
 
     def _print_Trace(self, expr):
         mat = expr.arg
-        return r"\operatorname{Tr} %s" % self._print(mat)
+        return r"\mathrm{tr}\left (%s \right )" % self._print(mat)
 
     def _print_Adjoint(self, expr):
         mat = expr.arg

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1462,6 +1462,10 @@ class LatexPrinter(Printer):
         else:
             return "%s^T" % self._print(mat)
 
+    def _print_Trace(self, expr):
+        mat = expr.arg
+        return r"\operatorname{Tr} %s" % self._print(mat)
+
     def _print_Adjoint(self, expr):
         mat = expr.arg
         from sympy.matrices import MatrixSymbol

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -291,7 +291,7 @@ class LatexPrinter(Printer):
 
     def _print_Basic(self, expr):
         l = [self._print(o) for o in expr.args]
-        return self._deal_with_super_sub(expr.__class__.__name__) + "(%s)" % ", ".join(l)
+        return self._deal_with_super_sub(expr.__class__.__name__) + r"\left(%s\right)" % ", ".join(l)
 
     def _print_bool(self, e):
         return r"\mathrm{%s}" % e

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1851,8 +1851,8 @@ def test_trace():
     # Issue 15303
     from sympy import trace
     A = MatrixSymbol("A", 2, 2)
-    assert latex(trace(A)) == r"\operatorname{Tr} A"
-    assert latex(trace(A**2)) == r"\operatorname{Tr} A^{2}"
+    assert latex(trace(A)) == r"\mathrm{tr}\left (A \right )"
+    assert latex(trace(A**2)) == r"\mathrm{tr}\left (A^{2} \right )"
 
 
 def test_print_basic():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1845,3 +1845,11 @@ def test_latex_printer_tensor():
 
     expr = A(i) + 3*B(i)
     assert latex(expr) == "3B{}^{i} + A{}^{i}"
+
+
+def test_trace():
+    # Issue 15303
+    from sympy import trace
+    A = MatrixSymbol("A", 2, 2)
+    assert latex(trace(A)) == r"\operatorname{Tr} A"
+    assert latex(trace(A**2)) == r"\operatorname{Tr} A^{2}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1868,19 +1868,12 @@ def test_print_basic():
     def unimplemented_expr(expr):
         return UnimplementedExpr(expr).doit()
 
-    # override class name to use superscript
-    def unimplemented_expr_sub(expr):
+    # override class name to use superscript / subscript
+    def unimplemented_expr_sup_sub(expr):
         result = UnimplementedExpr(expr)
         result.__class__.__name__ = 'UnimplementedExpr_x^1'
         return result
 
-    # override class name to use subscript
-    def unimplemented_expr_sup(expr):
-        result = UnimplementedExpr(expr)
-        result.__class__.__name__ = 'UnimplementedExpr_sub1__sup_sub2'
-        return result
-
     assert latex(unimplemented_expr(x)) == r'UnimplementedExpr\left(x\right)'
     assert latex(unimplemented_expr(x**2)) == r'UnimplementedExpr\left(x^{2}\right)'
-    assert latex(unimplemented_expr_sub(x)) == r'UnimplementedExpr^{1}_{x}\left(x\right)'
-    assert latex(unimplemented_expr_sup(x)) == r'UnimplementedExpr^{sup}_{sub1 sub2}\left(x\right)'
+    assert latex(unimplemented_expr_sup_sub(x)) == r'UnimplementedExpr^{1}_{x}\left(x\right)'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1859,14 +1859,28 @@ def test_print_basic():
     # Issue 15303
     from sympy import Basic, Expr
 
-    # dummy class and function for testing printing where the function is not implemented in latex.py
+    # dummy class for testing printing where the function is not implemented in latex.py
     class UnimplementedExpr(Expr):
         def __new__(cls, e):
             return Basic.__new__(cls, e)
 
+    # dummy function for testing
     def unimplemented_expr(expr):
-        # dummy function for testing
         return UnimplementedExpr(expr).doit()
+
+    # override class name to use superscript
+    def unimplemented_expr_sub(expr):
+        result = UnimplementedExpr(expr)
+        result.__class__.__name__ = 'UnimplementedExpr_x^1'
+        return result
+
+    # override class name to use subscript
+    def unimplemented_expr_sup(expr):
+        result = UnimplementedExpr(expr)
+        result.__class__.__name__ = 'UnimplementedExpr_sub1__sup_sub2'
+        return result
 
     assert latex(unimplemented_expr(x)) == r'UnimplementedExpr\left(x\right)'
     assert latex(unimplemented_expr(x**2)) == r'UnimplementedExpr\left(x^{2}\right)'
+    assert latex(unimplemented_expr_sub(x)) == r'UnimplementedExpr^{1}_{x}\left(x\right)'
+    assert latex(unimplemented_expr_sup(x)) == r'UnimplementedExpr^{sup}_{sub1 sub2}\left(x\right)'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1853,3 +1853,20 @@ def test_trace():
     A = MatrixSymbol("A", 2, 2)
     assert latex(trace(A)) == r"\operatorname{Tr} A"
     assert latex(trace(A**2)) == r"\operatorname{Tr} A^{2}"
+
+
+def test_print_basic():
+    # Issue 15303
+    from sympy import Basic, Expr
+
+    # dummy class and function for testing printing where the function is not implemented in latex.py
+    class UnimplementedExpr(Expr):
+        def __new__(cls, e):
+            return Basic.__new__(cls, e)
+
+    def unimplemented_expr(expr):
+        # dummy function for testing
+        return UnimplementedExpr(expr).doit()
+
+    assert latex(unimplemented_expr(x)) == 'UnimplementedExpr(x)'
+    assert latex(unimplemented_expr(x**2)) == 'UnimplementedExpr(x^{2})'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1868,5 +1868,5 @@ def test_print_basic():
         # dummy function for testing
         return UnimplementedExpr(expr).doit()
 
-    assert latex(unimplemented_expr(x)) == 'UnimplementedExpr(x)'
-    assert latex(unimplemented_expr(x**2)) == 'UnimplementedExpr(x^{2})'
+    assert latex(unimplemented_expr(x)) == r'UnimplementedExpr\left(x\right)'
+    assert latex(unimplemented_expr(x**2)) == r'UnimplementedExpr\left(x^{2}\right)'


### PR DESCRIPTION
Fixes #15303. Adds a _print_Trace method and test. Also adds a _print_Basic method to handle unimplemented types.

<!-- BEGIN RELEASE NOTES -->
* printing
  * added a method to correctly LaTeX print the trace of a MatrixSymbol
  * fixed a bug in LaTeX.py where subexpressions of an unimplemented basic expression were not printed correctly
<!-- END RELEASE NOTES -->
