### PR TITLE
Solvers:fixed _invert method to get correct solutions for 2-D linear system

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -3006,6 +3006,9 @@ def _invert(eq, *symbols, **kwargs):
     dointpow = bool(kwargs.get('integer_power', False))
 
     lhs = eq
+    if eq.args:
+        # make sure we are working with flat eq
+        lhs = eq.func(*eq.args)
     rhs = S.Zero
     while True:
         was = lhs

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -5,7 +5,7 @@ from sympy import (
     erfcinv, exp, im, log, pi, re, sec, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
     root, simplify, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve, oo,
-    E, cbrt, denom)
+    E, cbrt, denom, Add)
 
 from sympy.core.compatibility import range
 from sympy.core.function import nfloat
@@ -1974,3 +1974,11 @@ def test_issue_14779():
     x = symbols('x', real=True)
     assert solve(sqrt(x**4 - 130*x**2 + 1089) + sqrt(x**4 - 130*x**2
                  + 3969) - 96*Abs(x)/x,x) == [sqrt(130)]
+
+def test_issue_15307():
+    assert solve((y - 2, Mul(x + 3,x - 2, evaluate=False))) == \
+        [{x: -3, y: 2}, {x: 2, y: 2}]
+    assert solve((y - 2, Mul(3, x - 2, evaluate=False))) == \
+        {x: 2, y: 2}
+    assert solve((y - 2, Add(x + 4, x - 2, evaluate=False))) == \
+        {x: -1, y: 2}


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15307 

#### Brief description of what is fixed or changed
Improved `_invert` method in `solvers.py` to get the correct solutions for the 2-D linear system and wrote a new test case `def test_issue_15307()` in `solvers/tests/test_solvers.py`
For example:
```
eq1 = sympify('Eq(12513*u + 2*v - 219093, -5726*u - v)')
eq2 = sympify('Eq(-2*u + 8, 2*u - 40)')
solve([eq1, eq2])
```

Earlier Output: {u: 0, v: 73031}
Corrected Output: {v: 75, u: 12}

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
   *  improved _invert method to help solver to solve 2-D linear system

<!-- END RELEASE NOTES -->
