### PR TITLE
Eq.rewrite(Add) defined

### DIFF
--- a/sympy/codegen/cfunctions.py
+++ b/sympy/codegen/cfunctions.py
@@ -59,7 +59,7 @@ class expm1(Function):
     def _eval_expand_func(self, **hints):
         return _expm1(*self.args)
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         return exp(arg) - S.One
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_exp
@@ -124,7 +124,7 @@ class log1p(Function):
     def _eval_expand_func(self, **hints):
         return _log1p(*self.args)
 
-    def _eval_rewrite_as_log(self, arg):
+    def _eval_rewrite_as_log(self, arg, **kwargs):
         return _log1p(arg)
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_log
@@ -194,7 +194,7 @@ class exp2(Function):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         return _exp2(arg)
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_Pow
@@ -259,7 +259,7 @@ class log2(Function):
     def _eval_expand_func(self, **hints):
         return _log2(*self.args)
 
-    def _eval_rewrite_as_log(self, arg):
+    def _eval_rewrite_as_log(self, arg, **kwargs):
         return _log2(arg)
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_log
@@ -302,7 +302,7 @@ class fma(Function):
     def _eval_expand_func(self, **hints):
         return _fma(*self.args)
 
-    def _eval_rewrite_as_tractable(self, arg):
+    def _eval_rewrite_as_tractable(self, arg, **kwargs):
         return _fma(arg)
 
 
@@ -355,7 +355,7 @@ class log10(Function):
     def _eval_expand_func(self, **hints):
         return _log10(*self.args)
 
-    def _eval_rewrite_as_log(self, arg):
+    def _eval_rewrite_as_log(self, arg, **kwargs):
         return _log10(arg)
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_log
@@ -401,7 +401,7 @@ class Sqrt(Function):  # 'sqrt' already defined in sympy.functions.elementary.mi
     def _eval_expand_func(self, **hints):
         return _Sqrt(*self.args)
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         return _Sqrt(arg)
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_Pow
@@ -449,7 +449,7 @@ class Cbrt(Function):  # 'cbrt' already defined in sympy.functions.elementary.mi
     def _eval_expand_func(self, **hints):
         return _Cbrt(*self.args)
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         return _Cbrt(arg)
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_Pow
@@ -495,7 +495,7 @@ class hypot(Function):
     def _eval_expand_func(self, **hints):
         return _hypot(*self.args)
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         return _hypot(arg)
 
     _eval_rewrite_as_tractable = _eval_rewrite_as_Pow

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -193,7 +193,7 @@ class Product(ExprWithIntLimits):
         obj = ExprWithIntLimits.__new__(cls, function, *symbols, **assumptions)
         return obj
 
-    def _eval_rewrite_as_Sum(self, *args):
+    def _eval_rewrite_as_Sum(self, *args, **kwargs):
         from sympy.concrete.summations import Sum
         return exp(Sum(log(self.function), *self.limits))
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1586,10 +1586,11 @@ class Basic(with_metaclass(ManagedProperties)):
 
         if pattern is None or isinstance(self, pattern):
             if hasattr(self, rule):
-                rewritten = getattr(self, rule)(*args)
+                rewritten = getattr(self, rule)(*args, **hints)
                 if rewritten is not None:
                     return rewritten
-        return self.func(*args)
+
+        return self.func(*args) if hints.get('evaluate', True) else self
 
     def _accept_eval_derivative(self, s):
         # This method needs to be overridden by array-like objects

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3475,12 +3475,12 @@ class Exp1(with_metaclass(Singleton, NumberSymbol)):
         from sympy import exp
         return exp(expt)
 
-    def _eval_rewrite_as_sin(self):
+    def _eval_rewrite_as_sin(self, **kwargs):
         from sympy import sin
         I = S.ImaginaryUnit
         return sin(I + S.Pi/2) - I*sin(I)
 
-    def _eval_rewrite_as_cos(self):
+    def _eval_rewrite_as_cos(self, **kwargs):
         from sympy import cos
         I = S.ImaginaryUnit
         return cos(I) + I*cos(I + S.Pi/2)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1232,7 +1232,7 @@ class Pow(Expr):
         else:
             return True
 
-    def _eval_rewrite_as_exp(self, base, expo):
+    def _eval_rewrite_as_exp(self, base, expo, **kwargs):
         from sympy import exp, log, I, arg
 
         if base.is_zero or base.has(exp) or expo.has(exp):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from .add import _unevaluated_Add, Add
 from .basic import S
 from .compatibility import ordered
 from .expr import Expr
@@ -295,6 +296,9 @@ class Equality(Relational):
     the Equality.  If None is returned by `_eval_Eq`, an Equality object will
     be created as usual.
 
+    Since this object is already an expression, it does not respond to
+    the method `as_expr` if one tries to create `x - y` from Eq(x, y).
+    This can be done with the `rewrite(Add)` method.
     """
     rel_op = '=='
 
@@ -387,6 +391,38 @@ class Equality(Relational):
     @classmethod
     def _eval_relation(cls, lhs, rhs):
         return _sympify(lhs == rhs)
+
+    def _eval_rewrite_as_Add(self, *args, **kwargs):
+        """return Eq(L, R) as L - R. To control the evaluation of
+        the result set pass `evaluate=True` to give L - R;
+        if `evaluate=None` then terms in L and R will not cancel
+        but they will be listed in canonical order; otherwise
+        non-canonical args will be returned.
+
+        Examples
+        ========
+
+        >>> from sympy import Eq, Add
+        >>> from sympy.abc import b, x
+        >>> eq = Eq(x + b, x - b)
+        >>> eq.rewrite(Add)
+        2*b
+        >>> eq.rewrite(Add, evaluate=None).args
+        (b, b, x, -x)
+        >>> eq.rewrite(Add, evaluate=False).args
+        (b, x, b, -x)
+        """
+        L, R = args
+        eval = kwargs.get('evaluate', True)
+        if eval:
+            # allow cancellation of args
+            return L - R
+        args = Add.make_args(L) + Add.make_args(-R)
+        if eval is None:
+            # no cancellation, but canonical
+            return _unevaluated_Add(*args)
+        # no cancellation, not canonical
+        return Add._from_args(args)
 
     @property
     def binary_symbols(self):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -413,12 +413,12 @@ class Equality(Relational):
         (b, x, b, -x)
         """
         L, R = args
-        eval = kwargs.get('evaluate', True)
-        if eval:
+        evaluate = kwargs.get('evaluate', True)
+        if evaluate:
             # allow cancellation of args
             return L - R
         args = Add.make_args(L) + Add.make_args(-R)
-        if eval is None:
+        if evaluate is None:
             # no cancellation, but canonical
             return _unevaluated_Add(*args)
         # no cancellation, not canonical

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,7 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or,
     Not, Implies, Xor, zoo, sqrt, Rational, simplify, Function, Eq,
-    log, cos, sin)
+    log, cos, sin, Add)
 from sympy.core.compatibility import range
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
@@ -786,3 +786,10 @@ def test_rel_args():
         for b in (S.true, x < 1, And(x, y)):
             for v in (0.1, 1, 2**32, t, S(1)):
                 raises(TypeError, lambda: Relational(b, v, op))
+
+
+def test_Equality_rewrite_as_Add():
+    eq = Eq(x + y, y - x)
+    assert eq.rewrite(Add) == 2*x
+    assert eq.rewrite(Add, evaluate=None).args == (x, x, y, -y)
+    assert eq.rewrite(Add, evaluate=False).args == (x, y, x, -y)

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -234,11 +234,11 @@ class factorial(CombinatorialFunction):
 
                     return Integer(fc % q)
 
-    def _eval_rewrite_as_gamma(self, n):
+    def _eval_rewrite_as_gamma(self, n, **kwargs):
         from sympy import gamma
         return gamma(n + 1)
 
-    def _eval_rewrite_as_Product(self, n):
+    def _eval_rewrite_as_Product(self, n, **kwargs):
         from sympy import Product
         if n.is_nonnegative and n.is_integer:
             i = Dummy('i', integer=True)
@@ -341,7 +341,7 @@ class subfactorial(CombinatorialFunction):
         if self.args[0].is_integer and self.args[0].is_nonnegative:
             return True
 
-    def _eval_rewrite_as_uppergamma(self, arg):
+    def _eval_rewrite_as_uppergamma(self, arg, **kwargs):
         from sympy import uppergamma
         return uppergamma(arg + 1, -1)/S.Exp1
 
@@ -460,7 +460,7 @@ class factorial2(CombinatorialFunction):
             if n.is_odd:
                 return ((n + 1) / 2).is_even
 
-    def _eval_rewrite_as_gamma(self, n):
+    def _eval_rewrite_as_gamma(self, n, **kwargs):
         from sympy import gamma, Piecewise, sqrt
         return 2**(n/2)*gamma(n/2 + 1) * Piecewise((1, Eq(Mod(n, 2), 0)),
                 (sqrt(2/pi), Eq(Mod(n, 2), 1)))
@@ -580,18 +580,18 @@ class RisingFactorial(CombinatorialFunction):
                                             r*(x - i),
                                             range(1, abs(int(k)) + 1), 1)
 
-    def _eval_rewrite_as_gamma(self, x, k):
+    def _eval_rewrite_as_gamma(self, x, k, **kwargs):
         from sympy import gamma
         return gamma(x + k) / gamma(x)
 
-    def _eval_rewrite_as_FallingFactorial(self, x, k):
+    def _eval_rewrite_as_FallingFactorial(self, x, k, **kwargs):
         return FallingFactorial(x + k - 1, k)
 
-    def _eval_rewrite_as_factorial(self, x, k):
+    def _eval_rewrite_as_factorial(self, x, k, **kwargs):
         if x.is_integer and k.is_integer:
             return factorial(k + x - 1) / factorial(x - 1)
 
-    def _eval_rewrite_as_binomial(self, x, k):
+    def _eval_rewrite_as_binomial(self, x, k, **kwargs):
         if k.is_integer:
             return factorial(k) * binomial(x + k - 1, k)
 
@@ -713,18 +713,18 @@ class FallingFactorial(CombinatorialFunction):
                             return 1/reduce(lambda r, i: r*(x + i),
                                             range(1, abs(int(k)) + 1), 1)
 
-    def _eval_rewrite_as_gamma(self, x, k):
+    def _eval_rewrite_as_gamma(self, x, k, **kwargs):
         from sympy import gamma
         return (-1)**k*gamma(k - x) / gamma(-x)
 
-    def _eval_rewrite_as_RisingFactorial(self, x, k):
+    def _eval_rewrite_as_RisingFactorial(self, x, k, **kwargs):
         return rf(x - k + 1, k)
 
-    def _eval_rewrite_as_binomial(self, x, k):
+    def _eval_rewrite_as_binomial(self, x, k, **kwargs):
         if k.is_integer:
             return factorial(k) * binomial(x, k)
 
-    def _eval_rewrite_as_factorial(self, x, k):
+    def _eval_rewrite_as_factorial(self, x, k, **kwargs):
         if x.is_integer and k.is_integer:
             return factorial(x) / factorial(x - k)
 
@@ -1003,17 +1003,17 @@ class binomial(CombinatorialFunction):
         else:
             return binomial(*self.args)
 
-    def _eval_rewrite_as_factorial(self, n, k):
+    def _eval_rewrite_as_factorial(self, n, k, **kwargs):
         return factorial(n)/(factorial(k)*factorial(n - k))
 
-    def _eval_rewrite_as_gamma(self, n, k):
+    def _eval_rewrite_as_gamma(self, n, k, **kwargs):
         from sympy import gamma
         return gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
 
-    def _eval_rewrite_as_tractable(self, n, k):
+    def _eval_rewrite_as_tractable(self, n, k, **kwargs):
         return self._eval_rewrite_as_gamma(n, k).rewrite('tractable')
 
-    def _eval_rewrite_as_FallingFactorial(self, n, k):
+    def _eval_rewrite_as_FallingFactorial(self, n, k, **kwargs):
         if k.is_integer:
             return ff(n, k) / factorial(k)
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -113,10 +113,10 @@ class fibonacci(Function):
                        "only for positive integer indices.")
                 return cls._fibpoly(n).subs(_sym, sym)
 
-    def _eval_rewrite_as_sqrt(self, n):
+    def _eval_rewrite_as_sqrt(self, n, **kwargs):
         return 2**(-n)*sqrt(5)*((1 + sqrt(5))**n - (-sqrt(5) + 1)**n) / 5
 
-    def _eval_rewrite_as_GoldenRatio(self,n):
+    def _eval_rewrite_as_GoldenRatio(self,n, **kwargs):
         return (S.GoldenRatio**n - 1/(-S.GoldenRatio)**n)/(2*S.GoldenRatio-1)
 
 
@@ -166,7 +166,7 @@ class lucas(Function):
         if n.is_Integer:
             return fibonacci(n + 1) + fibonacci(n - 1)
 
-    def _eval_rewrite_as_sqrt(self, n):
+    def _eval_rewrite_as_sqrt(self, n, **kwargs):
         return 2**(-n)*((1 + sqrt(5))**n + (-sqrt(5) + 1)**n)
 
 
@@ -242,7 +242,7 @@ class tribonacci(Function):
                        "only for non-negative integer indices.")
                 return cls._tribpoly(n).subs(_sym, sym)
 
-    def _eval_rewrite_as_sqrt(self, n):
+    def _eval_rewrite_as_sqrt(self, n, **kwargs):
         w = (-1 + S.ImaginaryUnit * sqrt(3)) / 2
         a = (1 + cbrt(19 + 3*sqrt(33)) + cbrt(19 - 3*sqrt(33))) / 3
         b = (1 + w*cbrt(19 + 3*sqrt(33)) + w**2*cbrt(19 - 3*sqrt(33))) / 3
@@ -252,7 +252,7 @@ class tribonacci(Function):
             + c**(n + 1)/((c - a)*(c - b)))
         return Tn
 
-    def _eval_rewrite_as_TribonacciConstant(self, n):
+    def _eval_rewrite_as_TribonacciConstant(self, n, **kwargs):
         b = cbrt(586 + 102*sqrt(33))
         Tn = 3 * b * S.TribonacciConstant**n / (b**2 - 2*b + 4)
         return floor(Tn + S.Half)
@@ -538,7 +538,7 @@ class bell(Function):
                 r = cls._bell_incomplete_poly(int(n), int(k_sym), symbols)
                 return r
 
-    def _eval_rewrite_as_Sum(self, n, k_sym=None, symbols=None):
+    def _eval_rewrite_as_Sum(self, n, k_sym=None, symbols=None, **kwargs):
         from sympy import Sum
         if (k_sym is not None) or (symbols is not None):
             return self
@@ -720,19 +720,19 @@ class harmonic(Function):
                 cls._functions[m] = f
             return cls._functions[m](int(n))
 
-    def _eval_rewrite_as_polygamma(self, n, m=1):
+    def _eval_rewrite_as_polygamma(self, n, m=1, **kwargs):
         from sympy.functions.special.gamma_functions import polygamma
         return S.NegativeOne**m/factorial(m - 1) * (polygamma(m - 1, 1) - polygamma(m - 1, n + 1))
 
-    def _eval_rewrite_as_digamma(self, n, m=1):
+    def _eval_rewrite_as_digamma(self, n, m=1, **kwargs):
         from sympy.functions.special.gamma_functions import polygamma
         return self.rewrite(polygamma)
 
-    def _eval_rewrite_as_trigamma(self, n, m=1):
+    def _eval_rewrite_as_trigamma(self, n, m=1, **kwargs):
         from sympy.functions.special.gamma_functions import polygamma
         return self.rewrite(polygamma)
 
-    def _eval_rewrite_as_Sum(self, n, m=None):
+    def _eval_rewrite_as_Sum(self, n, m=None, **kwargs):
         from sympy import Sum
         k = Dummy("k", integer=True)
         if m is None:
@@ -772,7 +772,7 @@ class harmonic(Function):
 
         return self
 
-    def _eval_rewrite_as_tractable(self, n, m=1):
+    def _eval_rewrite_as_tractable(self, n, m=1, **kwargs):
         from sympy import polygamma
         return self.rewrite(polygamma).rewrite("tractable", deep=True)
 
@@ -900,7 +900,7 @@ class euler(Function):
             if m.is_odd and m.is_positive:
                 return S.Zero
 
-    def _eval_rewrite_as_Sum(self, n, x=None):
+    def _eval_rewrite_as_Sum(self, n, x=None, **kwargs):
         from sympy import Sum
         if x is None and n.is_even:
             k = Dummy("k", integer=True)
@@ -1036,22 +1036,22 @@ class catalan(Function):
         n = self.args[0]
         return catalan(n)*(polygamma(0, n + Rational(1, 2)) - polygamma(0, n + 2) + log(4))
 
-    def _eval_rewrite_as_binomial(self, n):
+    def _eval_rewrite_as_binomial(self, n, **kwargs):
         return binomial(2*n, n)/(n + 1)
 
-    def _eval_rewrite_as_factorial(self, n):
+    def _eval_rewrite_as_factorial(self, n, **kwargs):
         return factorial(2*n) / (factorial(n+1) * factorial(n))
 
-    def _eval_rewrite_as_gamma(self, n):
+    def _eval_rewrite_as_gamma(self, n, **kwargs):
         from sympy import gamma
         # The gamma function allows to generalize Catalan numbers to complex n
         return 4**n*gamma(n + S.Half)/(gamma(S.Half)*gamma(n + 2))
 
-    def _eval_rewrite_as_hyper(self, n):
+    def _eval_rewrite_as_hyper(self, n, **kwargs):
         from sympy import hyper
         return hyper([1 - n, -n], [2], 1)
 
-    def _eval_rewrite_as_Product(self, n):
+    def _eval_rewrite_as_Product(self, n, **kwargs):
         from sympy import Product
         if not (n.is_integer and n.is_nonnegative):
             return self
@@ -1129,7 +1129,7 @@ class genocchi(Function):
         if (n - 1).is_zero:
             return S.One
 
-    def _eval_rewrite_as_bernoulli(self, n):
+    def _eval_rewrite_as_bernoulli(self, n, **kwargs):
         if n.is_integer and n.is_nonnegative:
             return (1 - S(2) ** n) * bernoulli(n) * 2
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -103,7 +103,7 @@ class re(Function):
             return -S.ImaginaryUnit \
                 * im(Derivative(self.args[0], x, evaluate=True))
 
-    def _eval_rewrite_as_im(self, arg):
+    def _eval_rewrite_as_im(self, arg, **kwargs):
         return self.args[0] - S.ImaginaryUnit*im(self.args[0])
 
     def _eval_is_algebraic(self):
@@ -214,7 +214,7 @@ class im(Function):
         import sage.all as sage
         return sage.imag_part(self.args[0]._sage_())
 
-    def _eval_rewrite_as_re(self, arg):
+    def _eval_rewrite_as_re(self, arg, **kwargs):
         return -S.ImaginaryUnit*(self.args[0] - re(self.args[0]))
 
     def _eval_is_algebraic(self):
@@ -369,11 +369,11 @@ class sign(Function):
         import sage.all as sage
         return sage.sgn(self.args[0]._sage_())
 
-    def _eval_rewrite_as_Piecewise(self, arg):
+    def _eval_rewrite_as_Piecewise(self, arg, **kwargs):
         if arg.is_real:
             return Piecewise((1, arg > 0), (-1, arg < 0), (0, True))
 
-    def _eval_rewrite_as_Heaviside(self, arg):
+    def _eval_rewrite_as_Heaviside(self, arg, **kwargs):
         from sympy.functions.special.delta_functions import Heaviside
         if arg.is_real:
             return Heaviside(arg)*2-1
@@ -581,18 +581,18 @@ class Abs(Function):
             evaluate=True) + im(self.args[0]) * Derivative(im(self.args[0]),
                 x, evaluate=True)) / Abs(self.args[0])
 
-    def _eval_rewrite_as_Heaviside(self, arg):
+    def _eval_rewrite_as_Heaviside(self, arg, **kwargs):
         # Note this only holds for real arg (since Heaviside is not defined
         # for complex arguments).
         from sympy.functions.special.delta_functions import Heaviside
         if arg.is_real:
             return arg*(Heaviside(arg) - Heaviside(-arg))
 
-    def _eval_rewrite_as_Piecewise(self, arg):
+    def _eval_rewrite_as_Piecewise(self, arg, **kwargs):
         if arg.is_real:
             return Piecewise((arg, arg >= 0), (-arg, True))
 
-    def _eval_rewrite_as_sign(self, arg):
+    def _eval_rewrite_as_sign(self, arg, **kwargs):
         return arg/sign(arg)
 
 
@@ -644,7 +644,7 @@ class arg(Function):
         return (x * Derivative(y, t, evaluate=True) - y *
                     Derivative(x, t, evaluate=True)) / (x**2 + y**2)
 
-    def _eval_rewrite_as_atan2(self, arg):
+    def _eval_rewrite_as_atan2(self, arg, **kwargs):
         x, y = self.args[0].as_real_imag()
         return atan2(y, x)
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -444,21 +444,21 @@ class exp(ExpBase):
             return S.One
         return exp(arg)
 
-    def _eval_rewrite_as_sin(self, arg):
+    def _eval_rewrite_as_sin(self, arg, **kwargs):
         from sympy import sin
         I = S.ImaginaryUnit
         return sin(I*arg + S.Pi/2) - I*sin(I*arg)
 
-    def _eval_rewrite_as_cos(self, arg):
+    def _eval_rewrite_as_cos(self, arg, **kwargs):
         from sympy import cos
         I = S.ImaginaryUnit
         return cos(I*arg) + I*cos(I*arg + S.Pi/2)
 
-    def _eval_rewrite_as_tanh(self, arg):
+    def _eval_rewrite_as_tanh(self, arg, **kwargs):
         from sympy import tanh
         return (1 + tanh(arg/2))/(1 - tanh(arg/2))
 
-    def _eval_rewrite_as_sqrt(self, arg):
+    def _eval_rewrite_as_sqrt(self, arg, **kwargs):
         from sympy.functions.elementary.trigonometric import sin, cos
         if arg.is_Mul:
             coeff = arg.coeff(S.Pi*S.ImaginaryUnit)

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -200,20 +200,20 @@ class sinh(HyperbolicFunction):
             return (sinh(x)*cosh(y) + sinh(y)*cosh(x)).expand(trig=True)
         return sinh(arg)
 
-    def _eval_rewrite_as_tractable(self, arg):
+    def _eval_rewrite_as_tractable(self, arg, **kwargs):
         return (exp(arg) - exp(-arg)) / 2
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         return (exp(arg) - exp(-arg)) / 2
 
-    def _eval_rewrite_as_cosh(self, arg):
+    def _eval_rewrite_as_cosh(self, arg, **kwargs):
         return -S.ImaginaryUnit*cosh(arg + S.Pi*S.ImaginaryUnit/2)
 
-    def _eval_rewrite_as_tanh(self, arg):
+    def _eval_rewrite_as_tanh(self, arg, **kwargs):
         tanh_half = tanh(S.Half*arg)
         return 2*tanh_half/(1 - tanh_half**2)
 
-    def _eval_rewrite_as_coth(self, arg):
+    def _eval_rewrite_as_coth(self, arg, **kwargs):
         coth_half = coth(S.Half*arg)
         return 2*coth_half/(coth_half**2 - 1)
 
@@ -361,20 +361,20 @@ class cosh(HyperbolicFunction):
             return (cosh(x)*cosh(y) + sinh(x)*sinh(y)).expand(trig=True)
         return cosh(arg)
 
-    def _eval_rewrite_as_tractable(self, arg):
+    def _eval_rewrite_as_tractable(self, arg, **kwargs):
         return (exp(arg) + exp(-arg)) / 2
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         return (exp(arg) + exp(-arg)) / 2
 
-    def _eval_rewrite_as_sinh(self, arg):
+    def _eval_rewrite_as_sinh(self, arg, **kwargs):
         return -S.ImaginaryUnit*sinh(arg + S.Pi*S.ImaginaryUnit/2)
 
-    def _eval_rewrite_as_tanh(self, arg):
+    def _eval_rewrite_as_tanh(self, arg, **kwargs):
         tanh_half = tanh(S.Half*arg)**2
         return (1 + tanh_half)/(1 - tanh_half)
 
-    def _eval_rewrite_as_coth(self, arg):
+    def _eval_rewrite_as_coth(self, arg, **kwargs):
         coth_half = coth(S.Half*arg)**2
         return (coth_half + 1)/(coth_half - 1)
 
@@ -508,21 +508,21 @@ class tanh(HyperbolicFunction):
         denom = sinh(re)**2 + cos(im)**2
         return (sinh(re)*cosh(re)/denom, sin(im)*cos(im)/denom)
 
-    def _eval_rewrite_as_tractable(self, arg):
+    def _eval_rewrite_as_tractable(self, arg, **kwargs):
         neg_exp, pos_exp = exp(-arg), exp(arg)
         return (pos_exp - neg_exp)/(pos_exp + neg_exp)
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         neg_exp, pos_exp = exp(-arg), exp(arg)
         return (pos_exp - neg_exp)/(pos_exp + neg_exp)
 
-    def _eval_rewrite_as_sinh(self, arg):
+    def _eval_rewrite_as_sinh(self, arg, **kwargs):
         return S.ImaginaryUnit*sinh(arg)/sinh(S.Pi*S.ImaginaryUnit/2 - arg)
 
-    def _eval_rewrite_as_cosh(self, arg):
+    def _eval_rewrite_as_cosh(self, arg, **kwargs):
         return S.ImaginaryUnit*cosh(S.Pi*S.ImaginaryUnit/2 - arg)/cosh(arg)
 
-    def _eval_rewrite_as_coth(self, arg):
+    def _eval_rewrite_as_coth(self, arg, **kwargs):
         return 1/coth(arg)
 
     def _eval_as_leading_term(self, x):
@@ -658,21 +658,21 @@ class coth(HyperbolicFunction):
         denom = sinh(re)**2 + sin(im)**2
         return (sinh(re)*cosh(re)/denom, -sin(im)*cos(im)/denom)
 
-    def _eval_rewrite_as_tractable(self, arg):
+    def _eval_rewrite_as_tractable(self, arg, **kwargs):
         neg_exp, pos_exp = exp(-arg), exp(arg)
         return (pos_exp + neg_exp)/(pos_exp - neg_exp)
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         neg_exp, pos_exp = exp(-arg), exp(arg)
         return (pos_exp + neg_exp)/(pos_exp - neg_exp)
 
-    def _eval_rewrite_as_sinh(self, arg):
+    def _eval_rewrite_as_sinh(self, arg, **kwargs):
         return -S.ImaginaryUnit*sinh(S.Pi*S.ImaginaryUnit/2 - arg)/sinh(arg)
 
-    def _eval_rewrite_as_cosh(self, arg):
+    def _eval_rewrite_as_cosh(self, arg, **kwargs):
         return -S.ImaginaryUnit*cosh(arg)/cosh(S.Pi*S.ImaginaryUnit/2 - arg)
 
-    def _eval_rewrite_as_tanh(self, arg):
+    def _eval_rewrite_as_tanh(self, arg, **kwargs):
         return 1/tanh(arg)
 
     def _eval_is_positive(self):
@@ -732,16 +732,16 @@ class ReciprocalHyperbolicFunction(HyperbolicFunction):
         if t != None and t != self._reciprocal_of(arg):
             return 1/t
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_exp", arg)
 
-    def _eval_rewrite_as_tractable(self, arg):
+    def _eval_rewrite_as_tractable(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_tractable", arg)
 
-    def _eval_rewrite_as_tanh(self, arg):
+    def _eval_rewrite_as_tanh(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_tanh", arg)
 
-    def _eval_rewrite_as_coth(self, arg):
+    def _eval_rewrite_as_coth(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_coth", arg)
 
     def as_real_imag(self, deep = True, **hints):
@@ -807,7 +807,7 @@ class csch(ReciprocalHyperbolicFunction):
 
             return 2 * (1 - 2**n) * B/F * x**n
 
-    def _eval_rewrite_as_cosh(self, arg):
+    def _eval_rewrite_as_cosh(self, arg, **kwargs):
         return S.ImaginaryUnit / cosh(arg + S.ImaginaryUnit * S.Pi / 2)
 
     def _eval_is_positive(self):
@@ -854,7 +854,7 @@ class sech(ReciprocalHyperbolicFunction):
             x = sympify(x)
             return euler(n) / factorial(n) * x**(n)
 
-    def _eval_rewrite_as_sinh(self, arg):
+    def _eval_rewrite_as_sinh(self, arg, **kwargs):
         return S.ImaginaryUnit / sinh(arg + S.ImaginaryUnit * S.Pi /2)
 
     def _eval_is_positive(self):
@@ -952,7 +952,7 @@ class asinh(InverseHyperbolicFunction):
         else:
             return self.func(arg)
 
-    def _eval_rewrite_as_log(self, x):
+    def _eval_rewrite_as_log(self, x, **kwargs):
         return log(x + sqrt(x**2 + 1))
 
     def inverse(self, argindex=1):
@@ -1061,7 +1061,7 @@ class acosh(InverseHyperbolicFunction):
         else:
             return self.func(arg)
 
-    def _eval_rewrite_as_log(self, x):
+    def _eval_rewrite_as_log(self, x, **kwargs):
         return log(x + sqrt(x + 1) * sqrt(x - 1))
 
     def inverse(self, argindex=1):
@@ -1140,7 +1140,7 @@ class atanh(InverseHyperbolicFunction):
         else:
             return self.func(arg)
 
-    def _eval_rewrite_as_log(self, x):
+    def _eval_rewrite_as_log(self, x, **kwargs):
         return (log(1 + x) - log(1 - x)) / 2
 
     def inverse(self, argindex=1):
@@ -1215,7 +1215,7 @@ class acoth(InverseHyperbolicFunction):
         else:
             return self.func(arg)
 
-    def _eval_rewrite_as_log(self, x):
+    def _eval_rewrite_as_log(self, x, **kwargs):
         return (log(1 + 1/x) - log(1 - 1/x)) / 2
 
     def inverse(self, argindex=1):
@@ -1349,7 +1349,7 @@ class asech(InverseHyperbolicFunction):
         """
         return sech
 
-    def _eval_rewrite_as_log(self, arg):
+    def _eval_rewrite_as_log(self, arg, **kwargs):
         return log(1/arg + sqrt(1/arg - 1) * sqrt(1/arg + 1))
 
 
@@ -1443,5 +1443,5 @@ class acsch(InverseHyperbolicFunction):
         """
         return csch
 
-    def _eval_rewrite_as_log(self, arg):
+    def _eval_rewrite_as_log(self, arg, **kwargs):
         return log(1/arg + sqrt(1/arg**2 + 1))

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -141,10 +141,10 @@ class floor(RoundFunction):
         else:
             return r
 
-    def _eval_rewrite_as_ceiling(self, arg):
+    def _eval_rewrite_as_ceiling(self, arg, **kwargs):
         return -ceiling(-arg)
 
-    def _eval_rewrite_as_frac(self, arg):
+    def _eval_rewrite_as_frac(self, arg, **kwargs):
         return arg - frac(arg)
 
     def _eval_Eq(self, other):
@@ -225,10 +225,10 @@ class ceiling(RoundFunction):
         else:
             return r
 
-    def _eval_rewrite_as_floor(self, arg):
+    def _eval_rewrite_as_floor(self, arg, **kwargs):
         return -floor(-arg)
 
-    def _eval_rewrite_as_frac(self, arg):
+    def _eval_rewrite_as_frac(self, arg, **kwargs):
         return arg + frac(-arg)
 
     def _eval_Eq(self, other):
@@ -333,10 +333,10 @@ class frac(Function):
         imag = _eval(imag)
         return real + S.ImaginaryUnit*imag
 
-    def _eval_rewrite_as_floor(self, arg):
+    def _eval_rewrite_as_floor(self, arg, **kwargs):
         return arg - floor(arg)
 
-    def _eval_rewrite_as_ceiling(self, arg):
+    def _eval_rewrite_as_ceiling(self, arg, **kwargs):
         return arg + ceiling(-arg)
 
     def _eval_Eq(self, other):

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -606,7 +606,7 @@ class MinMaxBase(Expr, LatticeOp):
             l.append(df * da)
         return Add(*l)
 
-    def _eval_rewrite_as_Abs(self, *args):
+    def _eval_rewrite_as_Abs(self, *args, **kwargs):
         from sympy.functions.elementary.complexes import Abs
         s = (args[0] + self.func(*args[1:]))/2
         d = abs(args[0] - self.func(*args[1:]))/2
@@ -742,12 +742,12 @@ class Max(MinMaxBase, Application):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_Heaviside(self, *args):
+    def _eval_rewrite_as_Heaviside(self, *args, **kwargs):
         from sympy import Heaviside
         return Add(*[j*Mul(*[Heaviside(j - i) for i in args if i!=j]) \
                 for j in args])
 
-    def _eval_rewrite_as_Piecewise(self, *args):
+    def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
         is_real = all(i.is_real for i in args)
         if is_real:
             return _minmax_as_Piecewise('>=', *args)
@@ -807,12 +807,12 @@ class Min(MinMaxBase, Application):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_Heaviside(self, *args):
+    def _eval_rewrite_as_Heaviside(self, *args, **kwargs):
         from sympy import Heaviside
         return Add(*[j*Mul(*[Heaviside(i-j) for i in args if i!=j]) \
                 for j in args])
 
-    def _eval_rewrite_as_Piecewise(self, *args):
+    def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
         is_real = all(i.is_real for i in args)
         if is_real:
             return _minmax_as_Piecewise('<=', *args)

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -905,7 +905,7 @@ class Piecewise(Function):
             exp_sets.append((expr, cond_int))
         return exp_sets
 
-    def _eval_rewrite_as_ITE(self, *args):
+    def _eval_rewrite_as_ITE(self, *args, **kwargs):
         byfree = {}
         args = list(args)
         default = any(c == True for b, c in args)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -378,45 +378,45 @@ class sin(TrigonometricFunction):
             else:
                 return (-1)**(n//2) * x**(n)/factorial(n)
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         I = S.ImaginaryUnit
         if isinstance(arg, TrigonometricFunction) or isinstance(arg, HyperbolicFunction):
             arg = arg.func(arg.args[0]).rewrite(exp)
         return (exp(arg*I) - exp(-arg*I)) / (2*I)
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         if isinstance(arg, log):
             I = S.ImaginaryUnit
             x = arg.args[0]
             return I*x**-I / 2 - I*x**I /2
 
-    def _eval_rewrite_as_cos(self, arg):
+    def _eval_rewrite_as_cos(self, arg, **kwargs):
         return cos(arg - S.Pi / 2, evaluate=False)
 
-    def _eval_rewrite_as_tan(self, arg):
+    def _eval_rewrite_as_tan(self, arg, **kwargs):
         tan_half = tan(S.Half*arg)
         return 2*tan_half/(1 + tan_half**2)
 
-    def _eval_rewrite_as_sincos(self, arg):
+    def _eval_rewrite_as_sincos(self, arg, **kwargs):
         return sin(arg)*cos(arg)/cos(arg)
 
-    def _eval_rewrite_as_cot(self, arg):
+    def _eval_rewrite_as_cot(self, arg, **kwargs):
         cot_half = cot(S.Half*arg)
         return 2*cot_half/(1 + cot_half**2)
 
-    def _eval_rewrite_as_pow(self, arg):
+    def _eval_rewrite_as_pow(self, arg, **kwargs):
         return self.rewrite(cos).rewrite(pow)
 
-    def _eval_rewrite_as_sqrt(self, arg):
+    def _eval_rewrite_as_sqrt(self, arg, **kwargs):
         return self.rewrite(cos).rewrite(sqrt)
 
-    def _eval_rewrite_as_csc(self, arg):
+    def _eval_rewrite_as_csc(self, arg, **kwargs):
         return 1/csc(arg)
 
-    def _eval_rewrite_as_sec(self, arg):
+    def _eval_rewrite_as_sec(self, arg, **kwargs):
         return 1 / sec(arg - S.Pi / 2, evaluate=False)
 
-    def _eval_rewrite_as_sinc(self, arg):
+    def _eval_rewrite_as_sinc(self, arg, **kwargs):
         return arg*sinc(arg)
 
     def _eval_conjugate(self):
@@ -681,36 +681,36 @@ class cos(TrigonometricFunction):
             else:
                 return (-1)**(n//2)*x**(n)/factorial(n)
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         I = S.ImaginaryUnit
         if isinstance(arg, TrigonometricFunction) or isinstance(arg, HyperbolicFunction):
             arg = arg.func(arg.args[0]).rewrite(exp)
         return (exp(arg*I) + exp(-arg*I)) / 2
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         if isinstance(arg, log):
             I = S.ImaginaryUnit
             x = arg.args[0]
             return x**I/2 + x**-I/2
 
-    def _eval_rewrite_as_sin(self, arg):
+    def _eval_rewrite_as_sin(self, arg, **kwargs):
         return sin(arg + S.Pi / 2, evaluate=False)
 
-    def _eval_rewrite_as_tan(self, arg):
+    def _eval_rewrite_as_tan(self, arg, **kwargs):
         tan_half = tan(S.Half*arg)**2
         return (1 - tan_half)/(1 + tan_half)
 
-    def _eval_rewrite_as_sincos(self, arg):
+    def _eval_rewrite_as_sincos(self, arg, **kwargs):
         return sin(arg)*cos(arg)/sin(arg)
 
-    def _eval_rewrite_as_cot(self, arg):
+    def _eval_rewrite_as_cot(self, arg, **kwargs):
         cot_half = cot(S.Half*arg)**2
         return (cot_half - 1)/(cot_half + 1)
 
-    def _eval_rewrite_as_pow(self, arg):
+    def _eval_rewrite_as_pow(self, arg, **kwargs):
         return self._eval_rewrite_as_sqrt(arg)
 
-    def _eval_rewrite_as_sqrt(self, arg):
+    def _eval_rewrite_as_sqrt(self, arg, **kwargs):
         from sympy.functions.special.polynomials import chebyshevt
 
         def migcdex(x):
@@ -848,10 +848,10 @@ class cos(TrigonometricFunction):
             pcls = cos(sum([x[0] for x in X]))._eval_expand_trig().subs(X)
             return pcls
 
-    def _eval_rewrite_as_sec(self, arg):
+    def _eval_rewrite_as_sec(self, arg, **kwargs):
         return 1/sec(arg)
 
-    def _eval_rewrite_as_csc(self, arg):
+    def _eval_rewrite_as_csc(self, arg, **kwargs):
         return 1 / sec(arg)._eval_rewrite_as_csc(arg)
 
     def _eval_conjugate(self):
@@ -1094,7 +1094,7 @@ class tan(TrigonometricFunction):
             return self.rewrite(cos)._eval_nseries(x, n=n, logx=logx)
         return Function._eval_nseries(self, x, n=n, logx=logx)
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         if isinstance(arg, log):
             I = S.ImaginaryUnit
             x = arg.args[0]
@@ -1140,42 +1140,42 @@ class tan(TrigonometricFunction):
                 return (im(P)/re(P)).subs([(z, tan(terms))])
         return tan(arg)
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         I = S.ImaginaryUnit
         if isinstance(arg, TrigonometricFunction) or isinstance(arg, HyperbolicFunction):
             arg = arg.func(arg.args[0]).rewrite(exp)
         neg_exp, pos_exp = exp(-arg*I), exp(arg*I)
         return I*(neg_exp - pos_exp)/(neg_exp + pos_exp)
 
-    def _eval_rewrite_as_sin(self, x):
+    def _eval_rewrite_as_sin(self, x, **kwargs):
         return 2*sin(x)**2/sin(2*x)
 
-    def _eval_rewrite_as_cos(self, x):
+    def _eval_rewrite_as_cos(self, x, **kwargs):
         return cos(x - S.Pi / 2, evaluate=False) / cos(x)
 
-    def _eval_rewrite_as_sincos(self, arg):
+    def _eval_rewrite_as_sincos(self, arg, **kwargs):
         return sin(arg)/cos(arg)
 
-    def _eval_rewrite_as_cot(self, arg):
+    def _eval_rewrite_as_cot(self, arg, **kwargs):
         return 1/cot(arg)
 
-    def _eval_rewrite_as_sec(self, arg):
+    def _eval_rewrite_as_sec(self, arg, **kwargs):
         sin_in_sec_form = sin(arg)._eval_rewrite_as_sec(arg)
         cos_in_sec_form = cos(arg)._eval_rewrite_as_sec(arg)
         return sin_in_sec_form / cos_in_sec_form
 
-    def _eval_rewrite_as_csc(self, arg):
+    def _eval_rewrite_as_csc(self, arg, **kwargs):
         sin_in_csc_form = sin(arg)._eval_rewrite_as_csc(arg)
         cos_in_csc_form = cos(arg)._eval_rewrite_as_csc(arg)
         return sin_in_csc_form / cos_in_csc_form
 
-    def _eval_rewrite_as_pow(self, arg):
+    def _eval_rewrite_as_pow(self, arg, **kwargs):
         y = self.rewrite(cos).rewrite(pow)
         if y.has(cos):
             return None
         return y
 
-    def _eval_rewrite_as_sqrt(self, arg):
+    def _eval_rewrite_as_sqrt(self, arg, **kwargs):
         y = self.rewrite(cos).rewrite(sqrt)
         if y.has(cos):
             return None
@@ -1390,48 +1390,48 @@ class cot(TrigonometricFunction):
         else:
             return (self.func(re), S.Zero)
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         I = S.ImaginaryUnit
         if isinstance(arg, TrigonometricFunction) or isinstance(arg, HyperbolicFunction):
             arg = arg.func(arg.args[0]).rewrite(exp)
         neg_exp, pos_exp = exp(-arg*I), exp(arg*I)
         return I*(pos_exp + neg_exp)/(pos_exp - neg_exp)
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         if isinstance(arg, log):
             I = S.ImaginaryUnit
             x = arg.args[0]
             return -I*(x**-I + x**I)/(x**-I - x**I)
 
-    def _eval_rewrite_as_sin(self, x):
+    def _eval_rewrite_as_sin(self, x, **kwargs):
         return sin(2*x)/(2*(sin(x)**2))
 
-    def _eval_rewrite_as_cos(self, x):
+    def _eval_rewrite_as_cos(self, x, **kwargs):
         return cos(x) / cos(x - S.Pi / 2, evaluate=False)
 
-    def _eval_rewrite_as_sincos(self, arg):
+    def _eval_rewrite_as_sincos(self, arg, **kwargs):
         return cos(arg)/sin(arg)
 
-    def _eval_rewrite_as_tan(self, arg):
+    def _eval_rewrite_as_tan(self, arg, **kwargs):
         return 1/tan(arg)
 
-    def _eval_rewrite_as_sec(self, arg):
+    def _eval_rewrite_as_sec(self, arg, **kwargs):
         cos_in_sec_form = cos(arg)._eval_rewrite_as_sec(arg)
         sin_in_sec_form = sin(arg)._eval_rewrite_as_sec(arg)
         return cos_in_sec_form / sin_in_sec_form
 
-    def _eval_rewrite_as_csc(self, arg):
+    def _eval_rewrite_as_csc(self, arg, **kwargs):
         cos_in_csc_form = cos(arg)._eval_rewrite_as_csc(arg)
         sin_in_csc_form = sin(arg)._eval_rewrite_as_csc(arg)
         return cos_in_csc_form / sin_in_csc_form
 
-    def _eval_rewrite_as_pow(self, arg):
+    def _eval_rewrite_as_pow(self, arg, **kwargs):
         y = self.rewrite(cos).rewrite(pow)
         if y.has(cos):
             return None
         return y
 
-    def _eval_rewrite_as_sqrt(self, arg):
+    def _eval_rewrite_as_sqrt(self, arg, **kwargs):
         y = self.rewrite(cos).rewrite(sqrt)
         if y.has(cos):
             return None
@@ -1565,25 +1565,25 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
     def fdiff(self, argindex=1):
         return -self._calculate_reciprocal("fdiff", argindex)/self**2
 
-    def _eval_rewrite_as_exp(self, arg):
+    def _eval_rewrite_as_exp(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_exp", arg)
 
-    def _eval_rewrite_as_Pow(self, arg):
+    def _eval_rewrite_as_Pow(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_Pow", arg)
 
-    def _eval_rewrite_as_sin(self, arg):
+    def _eval_rewrite_as_sin(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_sin", arg)
 
-    def _eval_rewrite_as_cos(self, arg):
+    def _eval_rewrite_as_cos(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_cos", arg)
 
-    def _eval_rewrite_as_tan(self, arg):
+    def _eval_rewrite_as_tan(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_tan", arg)
 
-    def _eval_rewrite_as_pow(self, arg):
+    def _eval_rewrite_as_pow(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_pow", arg)
 
-    def _eval_rewrite_as_sqrt(self, arg):
+    def _eval_rewrite_as_sqrt(self, arg, **kwargs):
         return self._rewrite_reciprocal("_eval_rewrite_as_sqrt", arg)
 
     def _eval_conjugate(self):
@@ -1650,23 +1650,23 @@ class sec(ReciprocalTrigonometricFunction):
     def period(self, symbol=None):
         return self._period(symbol)
 
-    def _eval_rewrite_as_cot(self, arg):
+    def _eval_rewrite_as_cot(self, arg, **kwargs):
         cot_half_sq = cot(arg/2)**2
         return (cot_half_sq + 1)/(cot_half_sq - 1)
 
-    def _eval_rewrite_as_cos(self, arg):
+    def _eval_rewrite_as_cos(self, arg, **kwargs):
         return (1/cos(arg))
 
-    def _eval_rewrite_as_sincos(self, arg):
+    def _eval_rewrite_as_sincos(self, arg, **kwargs):
         return sin(arg)/(cos(arg)*sin(arg))
 
-    def _eval_rewrite_as_sin(self, arg):
+    def _eval_rewrite_as_sin(self, arg, **kwargs):
         return (1 / cos(arg)._eval_rewrite_as_sin(arg))
 
-    def _eval_rewrite_as_tan(self, arg):
+    def _eval_rewrite_as_tan(self, arg, **kwargs):
         return (1 / cos(arg)._eval_rewrite_as_tan(arg))
 
-    def _eval_rewrite_as_csc(self, arg):
+    def _eval_rewrite_as_csc(self, arg, **kwargs):
         return csc(pi / 2 - arg, evaluate=False)
 
     def fdiff(self, argindex=1):
@@ -1730,23 +1730,23 @@ class csc(ReciprocalTrigonometricFunction):
     def period(self, symbol=None):
         return self._period(symbol)
 
-    def _eval_rewrite_as_sin(self, arg):
+    def _eval_rewrite_as_sin(self, arg, **kwargs):
         return (1/sin(arg))
 
-    def _eval_rewrite_as_sincos(self, arg):
+    def _eval_rewrite_as_sincos(self, arg, **kwargs):
         return cos(arg)/(sin(arg)*cos(arg))
 
-    def _eval_rewrite_as_cot(self, arg):
+    def _eval_rewrite_as_cot(self, arg, **kwargs):
         cot_half = cot(arg/2)
         return (1 + cot_half**2)/(2*cot_half)
 
-    def _eval_rewrite_as_cos(self, arg):
+    def _eval_rewrite_as_cos(self, arg, **kwargs):
         return (1 / sin(arg)._eval_rewrite_as_cos(arg))
 
-    def _eval_rewrite_as_sec(self, arg):
+    def _eval_rewrite_as_sec(self, arg, **kwargs):
         return sec(pi / 2 - arg, evaluate=False)
 
-    def _eval_rewrite_as_tan(self, arg):
+    def _eval_rewrite_as_tan(self, arg, **kwargs):
         return (1 / sin(arg)._eval_rewrite_as_tan(arg))
 
     def fdiff(self, argindex=1):
@@ -1845,11 +1845,11 @@ class sinc(Function):
         x = self.args[0]
         return (sin(x)/x)._eval_nseries(x, n, logx)
 
-    def _eval_rewrite_as_jn(self, arg):
+    def _eval_rewrite_as_jn(self, arg, **kwargs):
         from sympy.functions.special.bessel import jn
         return jn(0, arg)
 
-    def _eval_rewrite_as_sin(self, arg):
+    def _eval_rewrite_as_sin(self, arg, **kwargs):
         return Piecewise((sin(arg)/arg, Ne(arg, 0)), (1, True))
 
 
@@ -2016,22 +2016,22 @@ class asin(InverseTrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_rewrite_as_acos(self, x):
+    def _eval_rewrite_as_acos(self, x, **kwargs):
         return S.Pi/2 - acos(x)
 
-    def _eval_rewrite_as_atan(self, x):
+    def _eval_rewrite_as_atan(self, x, **kwargs):
         return 2*atan(x/(1 + sqrt(1 - x**2)))
 
-    def _eval_rewrite_as_log(self, x):
+    def _eval_rewrite_as_log(self, x, **kwargs):
         return -S.ImaginaryUnit*log(S.ImaginaryUnit*x + sqrt(1 - x**2))
 
-    def _eval_rewrite_as_acot(self, arg):
+    def _eval_rewrite_as_acot(self, arg, **kwargs):
         return 2*acot((1 + sqrt(1 - arg**2))/arg)
 
-    def _eval_rewrite_as_asec(self, arg):
+    def _eval_rewrite_as_asec(self, arg, **kwargs):
         return S.Pi/2 - asec(1/arg)
 
-    def _eval_rewrite_as_acsc(self, arg):
+    def _eval_rewrite_as_acsc(self, arg, **kwargs):
         return acsc(1/arg)
 
     def _eval_is_real(self):
@@ -2184,14 +2184,14 @@ class acos(InverseTrigonometricFunction):
     def _eval_nseries(self, x, n, logx):
         return self._eval_rewrite_as_log(self.args[0])._eval_nseries(x, n, logx)
 
-    def _eval_rewrite_as_log(self, x):
+    def _eval_rewrite_as_log(self, x, **kwargs):
         return S.Pi/2 + S.ImaginaryUnit * \
             log(S.ImaginaryUnit * x + sqrt(1 - x**2))
 
-    def _eval_rewrite_as_asin(self, x):
+    def _eval_rewrite_as_asin(self, x, **kwargs):
         return S.Pi/2 - asin(x)
 
-    def _eval_rewrite_as_atan(self, x):
+    def _eval_rewrite_as_atan(self, x, **kwargs):
         return atan(sqrt(1 - x**2)/x) + (S.Pi/2)*(1 - x*sqrt(1/x**2))
 
     def inverse(self, argindex=1):
@@ -2200,13 +2200,13 @@ class acos(InverseTrigonometricFunction):
         """
         return cos
 
-    def _eval_rewrite_as_acot(self, arg):
+    def _eval_rewrite_as_acot(self, arg, **kwargs):
         return S.Pi/2 - 2*acot((1 + sqrt(1 - arg**2))/arg)
 
-    def _eval_rewrite_as_asec(self, arg):
+    def _eval_rewrite_as_asec(self, arg, **kwargs):
         return asec(1/arg)
 
-    def _eval_rewrite_as_acsc(self, arg):
+    def _eval_rewrite_as_acsc(self, arg, **kwargs):
         return S.Pi/2 - acsc(1/arg)
 
     def _eval_conjugate(self):
@@ -2361,7 +2361,7 @@ class atan(InverseTrigonometricFunction):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_rewrite_as_log(self, x):
+    def _eval_rewrite_as_log(self, x, **kwargs):
         return S.ImaginaryUnit/2 * (log(S(1) - S.ImaginaryUnit * x)
             - log(S(1) + S.ImaginaryUnit * x))
 
@@ -2379,19 +2379,19 @@ class atan(InverseTrigonometricFunction):
         """
         return tan
 
-    def _eval_rewrite_as_asin(self, arg):
+    def _eval_rewrite_as_asin(self, arg, **kwargs):
         return sqrt(arg**2)/arg*(S.Pi/2 - asin(1/sqrt(1 + arg**2)))
 
-    def _eval_rewrite_as_acos(self, arg):
+    def _eval_rewrite_as_acos(self, arg, **kwargs):
         return sqrt(arg**2)/arg*acos(1/sqrt(1 + arg**2))
 
-    def _eval_rewrite_as_acot(self, arg):
+    def _eval_rewrite_as_acot(self, arg, **kwargs):
         return acot(1/arg)
 
-    def _eval_rewrite_as_asec(self, arg):
+    def _eval_rewrite_as_asec(self, arg, **kwargs):
         return sqrt(arg**2)/arg*asec(sqrt(1 + arg**2))
 
-    def _eval_rewrite_as_acsc(self, arg):
+    def _eval_rewrite_as_acsc(self, arg, **kwargs):
         return sqrt(arg**2)/arg*(S.Pi/2 - acsc(sqrt(1 + arg**2)))
 
 
@@ -2534,7 +2534,7 @@ class acot(InverseTrigonometricFunction):
         else:
             return super(atan, self)._eval_aseries(n, args0, x, logx)
 
-    def _eval_rewrite_as_log(self, x):
+    def _eval_rewrite_as_log(self, x, **kwargs):
         return S.ImaginaryUnit/2 * (log(1 - S.ImaginaryUnit/x)
             - log(1 + S.ImaginaryUnit/x))
 
@@ -2544,20 +2544,20 @@ class acot(InverseTrigonometricFunction):
         """
         return cot
 
-    def _eval_rewrite_as_asin(self, arg):
+    def _eval_rewrite_as_asin(self, arg, **kwargs):
         return (arg*sqrt(1/arg**2)*
                 (S.Pi/2 - asin(sqrt(-arg**2)/sqrt(-arg**2 - 1))))
 
-    def _eval_rewrite_as_acos(self, arg):
+    def _eval_rewrite_as_acos(self, arg, **kwargs):
         return arg*sqrt(1/arg**2)*acos(sqrt(-arg**2)/sqrt(-arg**2 - 1))
 
-    def _eval_rewrite_as_atan(self, arg):
+    def _eval_rewrite_as_atan(self, arg, **kwargs):
         return atan(1/arg)
 
-    def _eval_rewrite_as_asec(self, arg):
+    def _eval_rewrite_as_asec(self, arg, **kwargs):
         return arg*sqrt(1/arg**2)*asec(sqrt((1 + arg**2)/arg**2))
 
-    def _eval_rewrite_as_acsc(self, arg):
+    def _eval_rewrite_as_acsc(self, arg, **kwargs):
         return arg*sqrt(1/arg**2)*(S.Pi/2 - acsc(sqrt((1 + arg**2)/arg**2)))
 
 
@@ -2669,22 +2669,22 @@ class asec(InverseTrigonometricFunction):
             return False
         return fuzzy_or(((x - 1).is_nonnegative, (-x - 1).is_nonnegative))
 
-    def _eval_rewrite_as_log(self, arg):
+    def _eval_rewrite_as_log(self, arg, **kwargs):
         return S.Pi/2 + S.ImaginaryUnit*log(S.ImaginaryUnit/arg + sqrt(1 - 1/arg**2))
 
-    def _eval_rewrite_as_asin(self, arg):
+    def _eval_rewrite_as_asin(self, arg, **kwargs):
         return S.Pi/2 - asin(1/arg)
 
-    def _eval_rewrite_as_acos(self, arg):
+    def _eval_rewrite_as_acos(self, arg, **kwargs):
         return acos(1/arg)
 
-    def _eval_rewrite_as_atan(self, arg):
+    def _eval_rewrite_as_atan(self, arg, **kwargs):
         return sqrt(arg**2)/arg*(-S.Pi/2 + 2*atan(arg + sqrt(arg**2 - 1)))
 
-    def _eval_rewrite_as_acot(self, arg):
+    def _eval_rewrite_as_acot(self, arg, **kwargs):
         return sqrt(arg**2)/arg*(-S.Pi/2 + 2*acot(arg - sqrt(arg**2 - 1)))
 
-    def _eval_rewrite_as_acsc(self, arg):
+    def _eval_rewrite_as_acsc(self, arg, **kwargs):
         return S.Pi/2 - acsc(arg)
 
 
@@ -2775,22 +2775,22 @@ class acsc(InverseTrigonometricFunction):
         else:
             return self.func(arg)
 
-    def _eval_rewrite_as_log(self, arg):
+    def _eval_rewrite_as_log(self, arg, **kwargs):
         return -S.ImaginaryUnit*log(S.ImaginaryUnit/arg + sqrt(1 - 1/arg**2))
 
-    def _eval_rewrite_as_asin(self, arg):
+    def _eval_rewrite_as_asin(self, arg, **kwargs):
         return asin(1/arg)
 
-    def _eval_rewrite_as_acos(self, arg):
+    def _eval_rewrite_as_acos(self, arg, **kwargs):
         return S.Pi/2 - acos(1/arg)
 
-    def _eval_rewrite_as_atan(self, arg):
+    def _eval_rewrite_as_atan(self, arg, **kwargs):
         return sqrt(arg**2)/arg*(S.Pi/2 - atan(sqrt(arg**2 - 1)))
 
-    def _eval_rewrite_as_acot(self, arg):
+    def _eval_rewrite_as_acot(self, arg, **kwargs):
         return sqrt(arg**2)/arg*(S.Pi/2 - acot(1/sqrt(arg**2 - 1)))
 
-    def _eval_rewrite_as_asec(self, arg):
+    def _eval_rewrite_as_asec(self, arg, **kwargs):
         return S.Pi/2 - asec(arg)
 
 
@@ -2924,13 +2924,13 @@ class atan2(InverseTrigonometricFunction):
             return -S.ImaginaryUnit*log(
                 (x + S.ImaginaryUnit*y)/sqrt(x**2 + y**2))
 
-    def _eval_rewrite_as_log(self, y, x):
+    def _eval_rewrite_as_log(self, y, x, **kwargs):
         return -S.ImaginaryUnit*log((x + S.ImaginaryUnit*y) / sqrt(x**2 + y**2))
 
-    def _eval_rewrite_as_atan(self, y, x):
+    def _eval_rewrite_as_atan(self, y, x, **kwargs):
         return 2*atan(y / (sqrt(x**2 + y**2) + x))
 
-    def _eval_rewrite_as_arg(self, y, x):
+    def _eval_rewrite_as_arg(self, y, x, **kwargs):
         from sympy import arg
         if x.is_real and y.is_real:
             return arg(x + y*S.ImaginaryUnit)

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -189,15 +189,15 @@ class besselj(BesselBase):
         if nu != nnu:
             return besselj(nnu, z)
 
-    def _eval_rewrite_as_besseli(self, nu, z):
+    def _eval_rewrite_as_besseli(self, nu, z, **kwargs):
         from sympy import polar_lift, exp
         return exp(I*pi*nu/2)*besseli(nu, polar_lift(-I)*z)
 
-    def _eval_rewrite_as_bessely(self, nu, z):
+    def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
         if nu.is_integer is False:
             return csc(pi*nu)*bessely(-nu, z) - cot(pi*nu)*bessely(nu, z)
 
-    def _eval_rewrite_as_jn(self, nu, z):
+    def _eval_rewrite_as_jn(self, nu, z, **kwargs):
         return sqrt(2*z/pi)*jn(nu - S.Half, self.argument)
 
     def _eval_is_real(self):
@@ -267,16 +267,16 @@ class bessely(BesselBase):
             if nu.could_extract_minus_sign():
                 return S(-1)**(-nu)*bessely(-nu, z)
 
-    def _eval_rewrite_as_besselj(self, nu, z):
+    def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         if nu.is_integer is False:
             return csc(pi*nu)*(cos(pi*nu)*besselj(nu, z) - besselj(-nu, z))
 
-    def _eval_rewrite_as_besseli(self, nu, z):
+    def _eval_rewrite_as_besseli(self, nu, z, **kwargs):
         aj = self._eval_rewrite_as_besselj(*self.args)
         if aj:
             return aj.rewrite(besseli)
 
-    def _eval_rewrite_as_yn(self, nu, z):
+    def _eval_rewrite_as_yn(self, nu, z, **kwargs):
         return sqrt(2*z/pi) * yn(nu - S.Half, self.argument)
 
     def _eval_is_real(self):
@@ -367,16 +367,16 @@ class besseli(BesselBase):
         if nu != nnu:
             return besseli(nnu, z)
 
-    def _eval_rewrite_as_besselj(self, nu, z):
+    def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         from sympy import polar_lift, exp
         return exp(-I*pi*nu/2)*besselj(nu, polar_lift(I)*z)
 
-    def _eval_rewrite_as_bessely(self, nu, z):
+    def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
         aj = self._eval_rewrite_as_besselj(*self.args)
         if aj:
             return aj.rewrite(bessely)
 
-    def _eval_rewrite_as_jn(self, nu, z):
+    def _eval_rewrite_as_jn(self, nu, z, **kwargs):
         return self._eval_rewrite_as_besselj(*self.args).rewrite(jn)
 
     def _eval_is_real(self):
@@ -444,21 +444,21 @@ class besselk(BesselBase):
             if nu.could_extract_minus_sign():
                 return besselk(-nu, z)
 
-    def _eval_rewrite_as_besseli(self, nu, z):
+    def _eval_rewrite_as_besseli(self, nu, z, **kwargs):
         if nu.is_integer is False:
             return pi*csc(pi*nu)*(besseli(-nu, z) - besseli(nu, z))/2
 
-    def _eval_rewrite_as_besselj(self, nu, z):
+    def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         ai = self._eval_rewrite_as_besseli(*self.args)
         if ai:
             return ai.rewrite(besselj)
 
-    def _eval_rewrite_as_bessely(self, nu, z):
+    def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
         aj = self._eval_rewrite_as_besselj(*self.args)
         if aj:
             return aj.rewrite(bessely)
 
-    def _eval_rewrite_as_yn(self, nu, z):
+    def _eval_rewrite_as_yn(self, nu, z, **kwargs):
         ay = self._eval_rewrite_as_bessely(*self.args)
         if ay:
             return ay.rewrite(yn)
@@ -672,13 +672,13 @@ class jn(SphericalBesselBase):
     def _rewrite(self):
         return self._eval_rewrite_as_besselj(self.order, self.argument)
 
-    def _eval_rewrite_as_besselj(self, nu, z):
+    def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         return sqrt(pi/(2*z)) * besselj(nu + S.Half, z)
 
-    def _eval_rewrite_as_bessely(self, nu, z):
+    def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
         return (-1)**nu * sqrt(pi/(2*z)) * bessely(-nu - S.Half, z)
 
-    def _eval_rewrite_as_yn(self, nu, z):
+    def _eval_rewrite_as_yn(self, nu, z, **kwargs):
         return (-1)**(nu) * yn(-nu - 1, z)
 
     def _expand(self, **hints):
@@ -734,14 +734,14 @@ class yn(SphericalBesselBase):
         return self._eval_rewrite_as_bessely(self.order, self.argument)
 
     @assume_integer_order
-    def _eval_rewrite_as_besselj(self, nu, z):
+    def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         return (-1)**(nu+1) * sqrt(pi/(2*z)) * besselj(-nu - S.Half, z)
 
     @assume_integer_order
-    def _eval_rewrite_as_bessely(self, nu, z):
+    def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
         return sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
 
-    def _eval_rewrite_as_jn(self, nu, z):
+    def _eval_rewrite_as_jn(self, nu, z, **kwargs):
         return (-1)**(nu + 1) * jn(-nu - 1, z)
 
     def _expand(self, **hints):
@@ -754,7 +754,7 @@ class SphericalHankelBase(SphericalBesselBase):
         return self._eval_rewrite_as_besselj(self.order, self.argument)
 
     @assume_integer_order
-    def _eval_rewrite_as_besselj(self, nu, z):
+    def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         # jn +- I*yn
         # jn as beeselj: sqrt(pi/(2*z)) * besselj(nu + S.Half, z)
         # yn as besselj: (-1)**(nu+1) * sqrt(pi/(2*z)) * besselj(-nu - S.Half, z)
@@ -763,7 +763,7 @@ class SphericalHankelBase(SphericalBesselBase):
                                hks*I*(-1)**(nu+1)*besselj(-nu - S.Half, z))
 
     @assume_integer_order
-    def _eval_rewrite_as_bessely(self, nu, z):
+    def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
         # jn +- I*yn
         # jn as bessely: (-1)**nu * sqrt(pi/(2*z)) * bessely(-nu - S.Half, z)
         # yn as bessely: sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
@@ -771,11 +771,11 @@ class SphericalHankelBase(SphericalBesselBase):
         return sqrt(pi/(2*z))*((-1)**nu*bessely(-nu - S.Half, z) +
                                hks*I*bessely(nu + S.Half, z))
 
-    def _eval_rewrite_as_yn(self, nu, z):
+    def _eval_rewrite_as_yn(self, nu, z, **kwargs):
         hks = self._hankel_kind_sign
         return jn(nu, z).rewrite(yn) + hks*I*yn(nu, z)
 
-    def _eval_rewrite_as_jn(self, nu, z):
+    def _eval_rewrite_as_jn(self, nu, z, **kwargs):
         hks = self._hankel_kind_sign
         return jn(nu, z) + hks*I*yn(nu, z).rewrite(jn)
 
@@ -853,7 +853,7 @@ class hn1(SphericalHankelBase):
     _hankel_kind_sign = S.One
 
     @assume_integer_order
-    def _eval_rewrite_as_hankel1(self, nu, z):
+    def _eval_rewrite_as_hankel1(self, nu, z, **kwargs):
         return sqrt(pi/(2*z))*hankel1(nu, z)
 
 
@@ -906,7 +906,7 @@ class hn2(SphericalHankelBase):
     _hankel_kind_sign = -S.One
 
     @assume_integer_order
-    def _eval_rewrite_as_hankel2(self, nu, z):
+    def _eval_rewrite_as_hankel2(self, nu, z, **kwargs):
         return sqrt(pi/(2*z))*hankel2(nu, z)
 
 
@@ -1139,14 +1139,14 @@ class airyai(AiryBase):
                 return (S.One/(3**(S(2)/3)*pi) * gamma((n+S.One)/S(3)) * sin(2*pi*(n+S.One)/S(3)) /
                         factorial(n) * (root(3, 3)*x)**n)
 
-    def _eval_rewrite_as_besselj(self, z):
+    def _eval_rewrite_as_besselj(self, z, **kwargs):
         ot = Rational(1, 3)
         tt = Rational(2, 3)
         a = Pow(-z, Rational(3, 2))
         if re(z).is_negative:
             return ot*sqrt(-z) * (besselj(-ot, tt*a) + besselj(ot, tt*a))
 
-    def _eval_rewrite_as_besseli(self, z):
+    def _eval_rewrite_as_besseli(self, z, **kwargs):
         ot = Rational(1, 3)
         tt = Rational(2, 3)
         a = Pow(z, Rational(3, 2))
@@ -1155,7 +1155,7 @@ class airyai(AiryBase):
         else:
             return ot*(Pow(a, ot)*besseli(-ot, tt*a) - z*Pow(a, -ot)*besseli(ot, tt*a))
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         pf1 = S.One / (3**(S(2)/3)*gamma(S(2)/3))
         pf2 = z / (root(3, 3)*gamma(S(1)/3))
         return pf1 * hyper([], [S(2)/3], z**3/9) - pf2 * hyper([], [S(4)/3], z**3/9)
@@ -1307,14 +1307,14 @@ class airybi(AiryBase):
                 return (S.One/(root(3, 6)*pi) * gamma((n + S.One)/S(3)) * Abs(sin(2*pi*(n + S.One)/S(3))) /
                         factorial(n) * (root(3, 3)*x)**n)
 
-    def _eval_rewrite_as_besselj(self, z):
+    def _eval_rewrite_as_besselj(self, z, **kwargs):
         ot = Rational(1, 3)
         tt = Rational(2, 3)
         a = Pow(-z, Rational(3, 2))
         if re(z).is_negative:
             return sqrt(-z/3) * (besselj(-ot, tt*a) - besselj(ot, tt*a))
 
-    def _eval_rewrite_as_besseli(self, z):
+    def _eval_rewrite_as_besseli(self, z, **kwargs):
         ot = Rational(1, 3)
         tt = Rational(2, 3)
         a = Pow(z, Rational(3, 2))
@@ -1325,7 +1325,7 @@ class airybi(AiryBase):
             c = Pow(a, -ot)
             return sqrt(ot)*(b*besseli(-ot, tt*a) + z*c*besseli(ot, tt*a))
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         pf1 = S.One / (root(3, 6)*gamma(S(2)/3))
         pf2 = z*root(3, 6) / gamma(S(1)/3)
         return pf1 * hyper([], [S(2)/3], z**3/9) + pf2 * hyper([], [S(4)/3], z**3/9)
@@ -1457,13 +1457,13 @@ class airyaiprime(AiryBase):
             res = mp.airyai(z, derivative=1)
         return Expr._from_mpmath(res, prec)
 
-    def _eval_rewrite_as_besselj(self, z):
+    def _eval_rewrite_as_besselj(self, z, **kwargs):
         tt = Rational(2, 3)
         a = Pow(-z, Rational(3, 2))
         if re(z).is_negative:
             return z/3 * (besselj(-tt, tt*a) - besselj(tt, tt*a))
 
-    def _eval_rewrite_as_besseli(self, z):
+    def _eval_rewrite_as_besseli(self, z, **kwargs):
         ot = Rational(1, 3)
         tt = Rational(2, 3)
         a = tt * Pow(z, Rational(3, 2))
@@ -1475,7 +1475,7 @@ class airyaiprime(AiryBase):
             c = Pow(a, -tt)
             return ot * (z**2*c*besseli(tt, tt*a) - b*besseli(-ot, tt*a))
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         pf1 = z**2 / (2*3**(S(2)/3)*gamma(S(2)/3))
         pf2 = 1 / (root(3, 3)*gamma(S(1)/3))
         return pf1 * hyper([], [S(5)/3], z**3/9) - pf2 * hyper([], [S(1)/3], z**3/9)
@@ -1613,13 +1613,13 @@ class airybiprime(AiryBase):
             res = mp.airybi(z, derivative=1)
         return Expr._from_mpmath(res, prec)
 
-    def _eval_rewrite_as_besselj(self, z):
+    def _eval_rewrite_as_besselj(self, z, **kwargs):
         tt = Rational(2, 3)
         a = tt * Pow(-z, Rational(3, 2))
         if re(z).is_negative:
             return -z/sqrt(3) * (besselj(-tt, a) + besselj(tt, a))
 
-    def _eval_rewrite_as_besseli(self, z):
+    def _eval_rewrite_as_besseli(self, z, **kwargs):
         ot = Rational(1, 3)
         tt = Rational(2, 3)
         a = tt * Pow(z, Rational(3, 2))
@@ -1631,7 +1631,7 @@ class airybiprime(AiryBase):
             c = Pow(a, -tt)
             return sqrt(ot) * (b*besseli(-tt, tt*a) + z**2*c*besseli(tt, tt*a))
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         pf1 = z**2 / (2*root(3, 6)*gamma(S(2)/3))
         pf2 = root(3, 6) / gamma(S(1)/3)
         return pf1 * hyper([], [S(5)/3], z**3/9) + pf2 * hyper([], [S(1)/3], z**3/9)

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -317,7 +317,7 @@ class DiracDelta(Function):
             return p.degree() == 1
         return False
 
-    def _eval_rewrite_as_Piecewise(self, *args):
+    def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
         """Represents DiracDelta in a Piecewise form
 
            Examples
@@ -342,7 +342,7 @@ class DiracDelta(Function):
         if len(args) == 1:
             return Piecewise((DiracDelta(0), Eq(args[0], 0)), (0, True))
 
-    def _eval_rewrite_as_SingularityFunction(self, *args):
+    def _eval_rewrite_as_SingularityFunction(self, *args, **kwargs):
         """
         Returns the DiracDelta expression written in the form of Singularity Functions.
 
@@ -515,7 +515,7 @@ class Heaviside(Function):
         elif fuzzy_not(im(arg).is_zero):
             raise ValueError("Function defined only for Real Values. Complex part: %s  found in %s ." % (repr(im(arg)), repr(arg)) )
 
-    def _eval_rewrite_as_Piecewise(self, arg, H0=None):
+    def _eval_rewrite_as_Piecewise(self, arg, H0=None, **kwargs):
         """Represents Heaviside in a Piecewise form
 
            Examples
@@ -542,7 +542,7 @@ class Heaviside(Function):
             return Piecewise((0, arg < 0), (1, arg >= 0))
         return Piecewise((0, arg < 0), (H0, Eq(arg, 0)), (1, arg > 0))
 
-    def _eval_rewrite_as_sign(self, arg, H0=None):
+    def _eval_rewrite_as_sign(self, arg, H0=None, **kwargs):
         """Represents the Heaviside function in the form of sign function.
         The value of the second argument of Heaviside must specify Heaviside(0)
         = 1/2 for rewritting as sign to be strictly equivalent.  For easier
@@ -584,7 +584,7 @@ class Heaviside(Function):
             if H0 is None or H0 == S.Half:
                 return (sign(arg)+1)/2
 
-    def _eval_rewrite_as_SingularityFunction(self, args):
+    def _eval_rewrite_as_SingularityFunction(self, args, **kwargs):
         """
         Returns the Heaviside expression written in the form of Singularity Functions.
 

--- a/sympy/functions/special/elliptic_integrals.py
+++ b/sympy/functions/special/elliptic_integrals.py
@@ -79,10 +79,10 @@ class elliptic_k(Function):
         from sympy.simplify import hyperexpand
         return hyperexpand(self.rewrite(hyper)._eval_nseries(x, n=n, logx=logx))
 
-    def _eval_rewrite_as_hyper(self, m):
+    def _eval_rewrite_as_hyper(self, m, **kwargs):
         return (pi/2)*hyper((S.Half, S.Half), (S.One,), m)
 
-    def _eval_rewrite_as_meijerg(self, m):
+    def _eval_rewrite_as_meijerg(self, m, **kwargs):
         return meijerg(((S.Half, S.Half), []), ((S.Zero,), (S.Zero,)), -m)/2
 
     def _sage_(self):
@@ -258,12 +258,12 @@ class elliptic_e(Function):
             return hyperexpand(self.rewrite(hyper)._eval_nseries(x, n=n, logx=logx))
         return super(elliptic_e, self)._eval_nseries(x, n=n, logx=logx)
 
-    def _eval_rewrite_as_hyper(self, *args):
+    def _eval_rewrite_as_hyper(self, *args, **kwargs):
         if len(args) == 1:
             m = args[0]
             return (pi/2)*hyper((-S.Half, S.Half), (S.One,), m)
 
-    def _eval_rewrite_as_meijerg(self, *args):
+    def _eval_rewrite_as_meijerg(self, *args, **kwargs):
         if len(args) == 1:
             m = args[0]
             return -meijerg(((S.Half, S(3)/2), []), \

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -159,34 +159,34 @@ class erf(Function):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_rewrite_as_uppergamma(self, z):
+    def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy import uppergamma
         return sqrt(z**2)/z*(S.One - uppergamma(S.Half, z**2)/sqrt(S.Pi))
 
-    def _eval_rewrite_as_fresnels(self, z):
+    def _eval_rewrite_as_fresnels(self, z, **kwargs):
         arg = (S.One - S.ImaginaryUnit)*z/sqrt(pi)
         return (S.One + S.ImaginaryUnit)*(fresnelc(arg) - I*fresnels(arg))
 
-    def _eval_rewrite_as_fresnelc(self, z):
+    def _eval_rewrite_as_fresnelc(self, z, **kwargs):
         arg = (S.One - S.ImaginaryUnit)*z/sqrt(pi)
         return (S.One + S.ImaginaryUnit)*(fresnelc(arg) - I*fresnels(arg))
 
-    def _eval_rewrite_as_meijerg(self, z):
+    def _eval_rewrite_as_meijerg(self, z, **kwargs):
         return z/sqrt(pi)*meijerg([S.Half], [], [0], [-S.Half], z**2)
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         return 2*z/sqrt(pi)*hyper([S.Half], [3*S.Half], -z**2)
 
-    def _eval_rewrite_as_expint(self, z):
+    def _eval_rewrite_as_expint(self, z, **kwargs):
         return sqrt(z**2)/z - z*expint(S.Half, z**2)/sqrt(S.Pi)
 
-    def _eval_rewrite_as_tractable(self, z):
+    def _eval_rewrite_as_tractable(self, z, **kwargs):
         return S.One - _erfs(z)*exp(-z**2)
 
-    def _eval_rewrite_as_erfc(self, z):
+    def _eval_rewrite_as_erfc(self, z, **kwargs):
         return S.One - erfc(z)
 
-    def _eval_rewrite_as_erfi(self, z):
+    def _eval_rewrite_as_erfi(self, z, **kwargs):
         return -I*erfi(I*z)
 
     def _eval_as_leading_term(self, x):
@@ -348,34 +348,34 @@ class erfc(Function):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_rewrite_as_tractable(self, z):
+    def _eval_rewrite_as_tractable(self, z, **kwargs):
         return self.rewrite(erf).rewrite("tractable", deep=True)
 
-    def _eval_rewrite_as_erf(self, z):
+    def _eval_rewrite_as_erf(self, z, **kwargs):
         return S.One - erf(z)
 
-    def _eval_rewrite_as_erfi(self, z):
+    def _eval_rewrite_as_erfi(self, z, **kwargs):
         return S.One + I*erfi(I*z)
 
-    def _eval_rewrite_as_fresnels(self, z):
+    def _eval_rewrite_as_fresnels(self, z, **kwargs):
         arg = (S.One - S.ImaginaryUnit)*z/sqrt(pi)
         return S.One - (S.One + S.ImaginaryUnit)*(fresnelc(arg) - I*fresnels(arg))
 
-    def _eval_rewrite_as_fresnelc(self, z):
+    def _eval_rewrite_as_fresnelc(self, z, **kwargs):
         arg = (S.One-S.ImaginaryUnit)*z/sqrt(pi)
         return S.One - (S.One + S.ImaginaryUnit)*(fresnelc(arg) - I*fresnels(arg))
 
-    def _eval_rewrite_as_meijerg(self, z):
+    def _eval_rewrite_as_meijerg(self, z, **kwargs):
         return S.One - z/sqrt(pi)*meijerg([S.Half], [], [0], [-S.Half], z**2)
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         return S.One - 2*z/sqrt(pi)*hyper([S.Half], [3*S.Half], -z**2)
 
-    def _eval_rewrite_as_uppergamma(self, z):
+    def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy import uppergamma
         return S.One - sqrt(z**2)/z*(S.One - uppergamma(S.Half, z**2)/sqrt(S.Pi))
 
-    def _eval_rewrite_as_expint(self, z):
+    def _eval_rewrite_as_expint(self, z, **kwargs):
         return S.One - sqrt(z**2)/z + z*expint(S.Half, z**2)/sqrt(S.Pi)
 
     def _eval_expand_func(self, **hints):
@@ -529,34 +529,34 @@ class erfi(Function):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_rewrite_as_tractable(self, z):
+    def _eval_rewrite_as_tractable(self, z, **kwargs):
         return self.rewrite(erf).rewrite("tractable", deep=True)
 
-    def _eval_rewrite_as_erf(self, z):
+    def _eval_rewrite_as_erf(self, z, **kwargs):
         return -I*erf(I*z)
 
-    def _eval_rewrite_as_erfc(self, z):
+    def _eval_rewrite_as_erfc(self, z, **kwargs):
         return I*erfc(I*z) - I
 
-    def _eval_rewrite_as_fresnels(self, z):
+    def _eval_rewrite_as_fresnels(self, z, **kwargs):
         arg = (S.One + S.ImaginaryUnit)*z/sqrt(pi)
         return (S.One - S.ImaginaryUnit)*(fresnelc(arg) - I*fresnels(arg))
 
-    def _eval_rewrite_as_fresnelc(self, z):
+    def _eval_rewrite_as_fresnelc(self, z, **kwargs):
         arg = (S.One + S.ImaginaryUnit)*z/sqrt(pi)
         return (S.One - S.ImaginaryUnit)*(fresnelc(arg) - I*fresnels(arg))
 
-    def _eval_rewrite_as_meijerg(self, z):
+    def _eval_rewrite_as_meijerg(self, z, **kwargs):
         return z/sqrt(pi)*meijerg([S.Half], [], [0], [-S.Half], -z**2)
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         return 2*z/sqrt(pi)*hyper([S.Half], [3*S.Half], z**2)
 
-    def _eval_rewrite_as_uppergamma(self, z):
+    def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy import uppergamma
         return sqrt(-z**2)/z*(uppergamma(S.Half, -z**2)/sqrt(S.Pi) - S.One)
 
-    def _eval_rewrite_as_expint(self, z):
+    def _eval_rewrite_as_expint(self, z, **kwargs):
         return sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
 
     def _eval_expand_func(self, **hints):
@@ -682,33 +682,33 @@ class erf2(Function):
     def _eval_is_real(self):
         return self.args[0].is_real and self.args[1].is_real
 
-    def _eval_rewrite_as_erf(self, x, y):
+    def _eval_rewrite_as_erf(self, x, y, **kwargs):
         return erf(y) - erf(x)
 
-    def _eval_rewrite_as_erfc(self, x, y):
+    def _eval_rewrite_as_erfc(self, x, y, **kwargs):
         return erfc(x) - erfc(y)
 
-    def _eval_rewrite_as_erfi(self, x, y):
+    def _eval_rewrite_as_erfi(self, x, y, **kwargs):
         return I*(erfi(I*x)-erfi(I*y))
 
-    def _eval_rewrite_as_fresnels(self, x, y):
+    def _eval_rewrite_as_fresnels(self, x, y, **kwargs):
         return erf(y).rewrite(fresnels) - erf(x).rewrite(fresnels)
 
-    def _eval_rewrite_as_fresnelc(self, x, y):
+    def _eval_rewrite_as_fresnelc(self, x, y, **kwargs):
         return erf(y).rewrite(fresnelc) - erf(x).rewrite(fresnelc)
 
-    def _eval_rewrite_as_meijerg(self, x, y):
+    def _eval_rewrite_as_meijerg(self, x, y, **kwargs):
         return erf(y).rewrite(meijerg) - erf(x).rewrite(meijerg)
 
-    def _eval_rewrite_as_hyper(self, x, y):
+    def _eval_rewrite_as_hyper(self, x, y, **kwargs):
         return erf(y).rewrite(hyper) - erf(x).rewrite(hyper)
 
-    def _eval_rewrite_as_uppergamma(self, x, y):
+    def _eval_rewrite_as_uppergamma(self, x, y, **kwargs):
         from sympy import uppergamma
         return (sqrt(y**2)/y*(S.One - uppergamma(S.Half, y**2)/sqrt(S.Pi)) -
             sqrt(x**2)/x*(S.One - uppergamma(S.Half, x**2)/sqrt(S.Pi)))
 
-    def _eval_rewrite_as_expint(self, x, y):
+    def _eval_rewrite_as_expint(self, x, y, **kwargs):
         return erf(y).rewrite(expint) - erf(x).rewrite(expint)
 
     def _eval_expand_func(self, **hints):
@@ -796,7 +796,7 @@ class erfinv(Function):
         if nz is not None and (isinstance(nz, erf) and (nz.args[0]).is_real):
             return -nz.args[0]
 
-    def _eval_rewrite_as_erfcinv(self, z):
+    def _eval_rewrite_as_erfcinv(self, z, **kwargs):
        return erfcinv(1-z)
 
 
@@ -867,7 +867,7 @@ class erfcinv (Function):
         elif z == 2:
             return S.NegativeInfinity
 
-    def _eval_rewrite_as_erfinv(self, z):
+    def _eval_rewrite_as_erfinv(self, z, **kwargs):
         return erfinv(1-z)
 
 
@@ -1066,16 +1066,16 @@ class Ei(Function):
             return Function._eval_evalf(self, prec) + (I*pi)._eval_evalf(prec)
         return Function._eval_evalf(self, prec)
 
-    def _eval_rewrite_as_uppergamma(self, z):
+    def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy import uppergamma
         # XXX this does not currently work usefully because uppergamma
         #     immediately turns into expint
         return -uppergamma(0, polar_lift(-1)*z) - I*pi
 
-    def _eval_rewrite_as_expint(self, z):
+    def _eval_rewrite_as_expint(self, z, **kwargs):
         return -expint(1, polar_lift(-1)*z) - I*pi
 
-    def _eval_rewrite_as_li(self, z):
+    def _eval_rewrite_as_li(self, z, **kwargs):
         if isinstance(z, log):
             return li(z.args[0])
         # TODO:
@@ -1084,13 +1084,13 @@ class Ei(Function):
         # for -pi < imag(z) <= pi
         return li(exp(z))
 
-    def _eval_rewrite_as_Si(self, z):
+    def _eval_rewrite_as_Si(self, z, **kwargs):
         return Shi(z) + Chi(z)
     _eval_rewrite_as_Ci = _eval_rewrite_as_Si
     _eval_rewrite_as_Chi = _eval_rewrite_as_Si
     _eval_rewrite_as_Shi = _eval_rewrite_as_Si
 
-    def _eval_rewrite_as_tractable(self, z):
+    def _eval_rewrite_as_tractable(self, z, **kwargs):
         return exp(z) * _eis(z)
 
     def _eval_nseries(self, x, n, logx):
@@ -1235,11 +1235,11 @@ class expint(Function):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_uppergamma(self, nu, z):
+    def _eval_rewrite_as_uppergamma(self, nu, z, **kwargs):
         from sympy import uppergamma
         return z**(nu - 1)*uppergamma(1 - nu, z)
 
-    def _eval_rewrite_as_Ei(self, nu, z):
+    def _eval_rewrite_as_Ei(self, nu, z, **kwargs):
         from sympy import exp_polar, unpolarify, exp, factorial
         if nu == 1:
             return -Ei(z*exp_polar(-I*pi)) - I*pi
@@ -1255,7 +1255,7 @@ class expint(Function):
     def _eval_expand_func(self, **hints):
         return self.rewrite(Ei).rewrite(expint, **hints)
 
-    def _eval_rewrite_as_Si(self, nu, z):
+    def _eval_rewrite_as_Si(self, nu, z, **kwargs):
         if nu != 1:
             return self
         return Shi(z) - Chi(z)
@@ -1412,37 +1412,37 @@ class li(Function):
         if not (z.is_real and z.is_negative):
             return self.func(z.conjugate())
 
-    def _eval_rewrite_as_Li(self, z):
+    def _eval_rewrite_as_Li(self, z, **kwargs):
         return Li(z) + li(2)
 
-    def _eval_rewrite_as_Ei(self, z):
+    def _eval_rewrite_as_Ei(self, z, **kwargs):
         return Ei(log(z))
 
-    def _eval_rewrite_as_uppergamma(self, z):
+    def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy import uppergamma
         return (-uppergamma(0, -log(z)) +
                 S.Half*(log(log(z)) - log(S.One/log(z))) - log(-log(z)))
 
-    def _eval_rewrite_as_Si(self, z):
+    def _eval_rewrite_as_Si(self, z, **kwargs):
         return (Ci(I*log(z)) - I*Si(I*log(z)) -
                 S.Half*(log(S.One/log(z)) - log(log(z))) - log(I*log(z)))
 
     _eval_rewrite_as_Ci = _eval_rewrite_as_Si
 
-    def _eval_rewrite_as_Shi(self, z):
+    def _eval_rewrite_as_Shi(self, z, **kwargs):
         return (Chi(log(z)) - Shi(log(z)) - S.Half*(log(S.One/log(z)) - log(log(z))))
 
     _eval_rewrite_as_Chi = _eval_rewrite_as_Shi
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         return (log(z)*hyper((1, 1), (2, 2), log(z)) +
                 S.Half*(log(log(z)) - log(S.One/log(z))) + S.EulerGamma)
 
-    def _eval_rewrite_as_meijerg(self, z):
+    def _eval_rewrite_as_meijerg(self, z, **kwargs):
         return (-log(-log(z)) - S.Half*(log(S.One/log(z)) - log(log(z)))
                 - meijerg(((), (1,)), ((0, 0), ()), -log(z)))
 
-    def _eval_rewrite_as_tractable(self, z):
+    def _eval_rewrite_as_tractable(self, z, **kwargs):
         return z * _eis(log(z))
 
 
@@ -1524,10 +1524,10 @@ class Li(Function):
     def _eval_evalf(self, prec):
         return self.rewrite(li).evalf(prec)
 
-    def _eval_rewrite_as_li(self, z):
+    def _eval_rewrite_as_li(self, z, **kwargs):
         return li(z) - li(2)
 
-    def _eval_rewrite_as_tractable(self, z):
+    def _eval_rewrite_as_tractable(self, z, **kwargs):
         return self.rewrite(li).rewrite("tractable", deep=True)
 
 ###############################################################################
@@ -1573,10 +1573,10 @@ class TrigonometricIntegral(Function):
         if argindex == 1:
             return self._trigfunc(arg)/arg
 
-    def _eval_rewrite_as_Ei(self, z):
+    def _eval_rewrite_as_Ei(self, z, **kwargs):
         return self._eval_rewrite_as_expint(z).rewrite(Ei)
 
-    def _eval_rewrite_as_uppergamma(self, z):
+    def _eval_rewrite_as_uppergamma(self, z, **kwargs):
         from sympy import uppergamma
         return self._eval_rewrite_as_expint(z).rewrite(uppergamma)
 
@@ -1682,11 +1682,11 @@ class Si(TrigonometricIntegral):
     def _Ifactor(cls, z, sign):
         return I*Shi(z)*sign
 
-    def _eval_rewrite_as_expint(self, z):
+    def _eval_rewrite_as_expint(self, z, **kwargs):
         # XXX should we polarify z?
         return pi/2 + (E1(polar_lift(I)*z) - E1(polar_lift(-I)*z))/2/I
 
-    def _eval_rewrite_as_sinc(self, z):
+    def _eval_rewrite_as_sinc(self, z, **kwargs):
         from sympy import Integral
         t = Symbol('t', Dummy=True)
         return Integral(sinc(t), (t, 0, z))
@@ -1790,7 +1790,7 @@ class Ci(TrigonometricIntegral):
     def _Ifactor(cls, z, sign):
         return Chi(z) + I*pi/2*sign
 
-    def _eval_rewrite_as_expint(self, z):
+    def _eval_rewrite_as_expint(self, z, **kwargs):
         return -(E1(polar_lift(I)*z) + E1(polar_lift(-I)*z))/2
 
     def _sage_(self):
@@ -1877,7 +1877,7 @@ class Shi(TrigonometricIntegral):
     def _Ifactor(cls, z, sign):
         return I*Si(z)*sign
 
-    def _eval_rewrite_as_expint(self, z):
+    def _eval_rewrite_as_expint(self, z, **kwargs):
         from sympy import exp_polar
         # XXX should we polarify z?
         return (E1(z) - E1(exp_polar(I*pi)*z))/2 - I*pi/2
@@ -1977,7 +1977,7 @@ class Chi(TrigonometricIntegral):
     def _Ifactor(cls, z, sign):
         return Ci(z) + I*pi/2*sign
 
-    def _eval_rewrite_as_expint(self, z):
+    def _eval_rewrite_as_expint(self, z, **kwargs):
         from sympy import exp_polar
         return -I*pi/2 - (E1(z) + E1(exp_polar(I*pi)*z))/2
 
@@ -2166,13 +2166,13 @@ class fresnels(FresnelIntegral):
             else:
                 return x**3 * (-x**4)**n * (S(2)**(-2*n - 1)*pi**(2*n + 1)) / ((4*n + 3)*factorial(2*n + 1))
 
-    def _eval_rewrite_as_erf(self, z):
+    def _eval_rewrite_as_erf(self, z, **kwargs):
         return (S.One + I)/4 * (erf((S.One + I)/2*sqrt(pi)*z) - I*erf((S.One - I)/2*sqrt(pi)*z))
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         return pi*z**3/6 * hyper([S(3)/4], [S(3)/2, S(7)/4], -pi**2*z**4/16)
 
-    def _eval_rewrite_as_meijerg(self, z):
+    def _eval_rewrite_as_meijerg(self, z, **kwargs):
         return (pi*z**(S(9)/4) / (sqrt(2)*(z**2)**(S(3)/4)*(-z)**(S(3)/4))
                 * meijerg([], [1], [S(3)/4], [S(1)/4, 0], -pi**2*z**4/16))
 
@@ -2298,13 +2298,13 @@ class fresnelc(FresnelIntegral):
             else:
                 return x * (-x**4)**n * (S(2)**(-2*n)*pi**(2*n)) / ((4*n + 1)*factorial(2*n))
 
-    def _eval_rewrite_as_erf(self, z):
+    def _eval_rewrite_as_erf(self, z, **kwargs):
         return (S.One - I)/4 * (erf((S.One + I)/2*sqrt(pi)*z) + I*erf((S.One - I)/2*sqrt(pi)*z))
 
-    def _eval_rewrite_as_hyper(self, z):
+    def _eval_rewrite_as_hyper(self, z, **kwargs):
         return z * hyper([S.One/4], [S.One/2, S(5)/4], -pi**2*z**4/16)
 
-    def _eval_rewrite_as_meijerg(self, z):
+    def _eval_rewrite_as_meijerg(self, z, **kwargs):
         return (pi*z**(S(3)/4) / (sqrt(2)*root(z**2, 4)*root(-z, 4))
                 * meijerg([], [1], [S(1)/4], [S(3)/4, 0], -pi**2*z**4/16))
 
@@ -2379,7 +2379,7 @@ class _erfs(Function):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_intractable(self, z):
+    def _eval_rewrite_as_intractable(self, z, **kwargs):
         return (S.One - erf(z))*exp(z**2)
 
 
@@ -2409,7 +2409,7 @@ class _eis(Function):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_intractable(self, z):
+    def _eval_rewrite_as_intractable(self, z, **kwargs):
         return exp(-z)*Ei(z)
 
     def _eval_nseries(self, x, n, logx):

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -169,10 +169,10 @@ class gamma(Function):
         elif x.is_noninteger:
             return floor(x).is_even
 
-    def _eval_rewrite_as_tractable(self, z):
+    def _eval_rewrite_as_tractable(self, z, **kwargs):
         return exp(loggamma(z))
 
-    def _eval_rewrite_as_factorial(self, z):
+    def _eval_rewrite_as_factorial(self, z, **kwargs):
         return factorial(z - 1)
 
     def _eval_nseries(self, x, n, logx):
@@ -316,10 +316,10 @@ class lowergamma(Function):
         if not z in (S.Zero, S.NegativeInfinity):
             return self.func(self.args[0].conjugate(), z.conjugate())
 
-    def _eval_rewrite_as_uppergamma(self, s, x):
+    def _eval_rewrite_as_uppergamma(self, s, x, **kwargs):
         return gamma(s) - uppergamma(s, x)
 
-    def _eval_rewrite_as_expint(self, s, x):
+    def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy import expint
         if s.is_integer and s.is_nonpositive:
             return self
@@ -457,10 +457,10 @@ class uppergamma(Function):
         if not z in (S.Zero, S.NegativeInfinity):
             return self.func(self.args[0].conjugate(), z.conjugate())
 
-    def _eval_rewrite_as_lowergamma(self, s, x):
+    def _eval_rewrite_as_lowergamma(self, s, x, **kwargs):
         return gamma(s) - lowergamma(s, x)
 
-    def _eval_rewrite_as_expint(self, s, x):
+    def _eval_rewrite_as_expint(self, s, x, **kwargs):
         from sympy import expint
         return expint(1 - s, x)*x**s
 
@@ -722,13 +722,13 @@ class polygamma(Function):
 
         return polygamma(n, z)
 
-    def _eval_rewrite_as_zeta(self, n, z):
+    def _eval_rewrite_as_zeta(self, n, z, **kwargs):
         if n >= S.One:
             return (-1)**(n + 1)*factorial(n)*zeta(n + 1, z)
         else:
             return self
 
-    def _eval_rewrite_as_harmonic(self, n, z):
+    def _eval_rewrite_as_harmonic(self, n, z, **kwargs):
         if n.is_integer:
             if n == S.Zero:
                 return harmonic(z - 1) - S.EulerGamma
@@ -920,7 +920,7 @@ class loggamma(Function):
         # It is very inefficient to first add the order and then do the nseries
         return (r + Add(*l))._eval_nseries(x, n, logx) + o
 
-    def _eval_rewrite_as_intractable(self, z):
+    def _eval_rewrite_as_intractable(self, z, **kwargs):
         return log(gamma(z))
 
     def _eval_is_real(self):

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -206,7 +206,7 @@ class hyper(TupleParametersBase):
             return gamma(c)*gamma(c - a - b)/gamma(c - a)/gamma(c - b)
         return hyperexpand(self)
 
-    def _eval_rewrite_as_Sum(self, ap, bq, z):
+    def _eval_rewrite_as_Sum(self, ap, bq, z, **kwargs):
         from sympy.functions import factorial, RisingFactorial, Piecewise
         from sympy import Sum
         n = Dummy("n", integer=True)
@@ -754,7 +754,7 @@ class HyperRep(Function):
         """ An expression for F(exp_polar(2*I*pi*n + pi*I)*x), |x| > 1. """
         raise NotImplementedError
 
-    def _eval_rewrite_as_nonrep(self, *args):
+    def _eval_rewrite_as_nonrep(self, *args, **kwargs):
         from sympy import Piecewise
         x, n = self.args[-1].extract_branch_factor(allow_half=True)
         minus = False
@@ -774,7 +774,7 @@ class HyperRep(Function):
             return small
         return Piecewise((big, abs(x) > 1), (small, True))
 
-    def _eval_rewrite_as_nonrepsmall(self, *args):
+    def _eval_rewrite_as_nonrepsmall(self, *args, **kwargs):
         x, n = self.args[-1].extract_branch_factor(allow_half=True)
         args = self.args[:-1] + (x,)
         if not n.is_Integer:

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -198,7 +198,7 @@ class jacobi(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, a, b, x):
+    def _eval_rewrite_as_polynomial(self, n, a, b, x, **kwargs):
         from sympy import Sum
         # Make sure n \in N
         if n.is_negative or n.is_integer is False:
@@ -405,7 +405,7 @@ class gegenbauer(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, a, x):
+    def _eval_rewrite_as_polynomial(self, n, a, x, **kwargs):
         from sympy import Sum
         k = Dummy("k")
         kern = ((-1)**k * RisingFactorial(a, n - k) * (2*x)**(n - 2*k) /
@@ -522,7 +522,7 @@ class chebyshevt(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, x):
+    def _eval_rewrite_as_polynomial(self, n, x, **kwargs):
         from sympy import Sum
         k = Dummy("k")
         kern = binomial(n, 2*k) * (x**2 - 1)**k * x**(n - 2*k)
@@ -636,7 +636,7 @@ class chebyshevu(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, x):
+    def _eval_rewrite_as_polynomial(self, n, x, **kwargs):
         from sympy import Sum
         k = Dummy("k")
         kern = S.NegativeOne**k * factorial(
@@ -815,7 +815,7 @@ class legendre(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, x):
+    def _eval_rewrite_as_polynomial(self, n, x, **kwargs):
         from sympy import Sum
         k = Dummy("k")
         kern = (-1)**k*binomial(n, k)**2*((1 + x)/2)**(n - k)*((1 - x)/2)**k
@@ -913,7 +913,7 @@ class assoc_legendre(Function):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, m, x):
+    def _eval_rewrite_as_polynomial(self, n, m, x, **kwargs):
         from sympy import Sum
         k = Dummy("k")
         kern = factorial(2*n - 2*k)/(2**n*factorial(n - k)*factorial(
@@ -1010,7 +1010,7 @@ class hermite(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, x):
+    def _eval_rewrite_as_polynomial(self, n, x, **kwargs):
         from sympy import Sum
         k = Dummy("k")
         kern = (-1)**k / (factorial(k)*factorial(n - 2*k)) * (2*x)**(n - 2*k)
@@ -1112,7 +1112,7 @@ class laguerre(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, x):
+    def _eval_rewrite_as_polynomial(self, n, x, **kwargs):
         from sympy import Sum
         # Make sure n \in N_0
         if n.is_negative or n.is_integer is False:
@@ -1230,7 +1230,7 @@ class assoc_laguerre(OrthogonalPolynomial):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, x):
+    def _eval_rewrite_as_polynomial(self, n, x, **kwargs):
         from sympy import Sum
         # Make sure n \in N_0
         if n.is_negative or n.is_integer is False:

--- a/sympy/functions/special/singularity_functions.py
+++ b/sympy/functions/special/singularity_functions.py
@@ -168,7 +168,7 @@ class SingularityFunction(Function):
             if shift.is_zero:
                 return S.Infinity
 
-    def _eval_rewrite_as_Piecewise(self, *args):
+    def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
         '''
         Converts a Singularity Function expression into its Piecewise form.
 
@@ -182,7 +182,7 @@ class SingularityFunction(Function):
         elif n.is_nonnegative:
             return Piecewise(((x - a)**n, (x - a) > 0), (0, True))
 
-    def _eval_rewrite_as_Heaviside(self, *args):
+    def _eval_rewrite_as_Heaviside(self, *args, **kwargs):
         '''
         Rewrites a Singularity Function expression using Heavisides and DiracDeltas.
 

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -184,15 +184,15 @@ class Ynm(Function):
         else:
             raise ArgumentIndexError(self, argindex)
 
-    def _eval_rewrite_as_polynomial(self, n, m, theta, phi):
+    def _eval_rewrite_as_polynomial(self, n, m, theta, phi, **kwargs):
         # TODO: Make sure n \in N
         # TODO: Assert |m| <= n ortherwise we should return 0
         return self.expand(func=True)
 
-    def _eval_rewrite_as_sin(self, n, m, theta, phi):
+    def _eval_rewrite_as_sin(self, n, m, theta, phi, **kwargs):
         return self.rewrite(cos)
 
-    def _eval_rewrite_as_cos(self, n, m, theta, phi):
+    def _eval_rewrite_as_cos(self, n, m, theta, phi, **kwargs):
         # This method can be expensive due to extensive use of simplification!
         from sympy.simplify import simplify, trigsimp
         # TODO: Make sure n \in N

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -192,10 +192,10 @@ class lerchphi(Function):
         else:
             return self
 
-    def _eval_rewrite_as_zeta(self, z, s, a):
+    def _eval_rewrite_as_zeta(self, z, s, a, **kwargs):
         return self._eval_rewrite_helper(z, s, a, zeta)
 
-    def _eval_rewrite_as_polylog(self, z, s, a):
+    def _eval_rewrite_as_polylog(self, z, s, a, **kwargs):
         return self._eval_rewrite_helper(z, s, a, polylog)
 
 ###############################################################################
@@ -310,7 +310,7 @@ class polylog(Function):
             return polylog(s - 1, z)/z
         raise ArgumentIndexError
 
-    def _eval_rewrite_as_lerchphi(self, s, z):
+    def _eval_rewrite_as_lerchphi(self, s, z, **kwargs):
         return z*lerchphi(z, s, 1)
 
     def _eval_expand_func(self, **hints):
@@ -478,13 +478,13 @@ class zeta(Function):
                     return zeta - harmonic(a - 1, z)
 
 
-    def _eval_rewrite_as_dirichlet_eta(self, s, a=1):
+    def _eval_rewrite_as_dirichlet_eta(self, s, a=1, **kwargs):
         if a != 1:
             return self
         s = self.args[0]
         return dirichlet_eta(s)/(1 - 2**(1 - s))
 
-    def _eval_rewrite_as_lerchphi(self, s, a=1):
+    def _eval_rewrite_as_lerchphi(self, s, a=1, **kwargs):
         return lerchphi(1, s, a)
 
     def _eval_is_finite(self):
@@ -544,7 +544,7 @@ class dirichlet_eta(Function):
         if not z.has(zeta):
             return (1 - 2**(1 - s))*z
 
-    def _eval_rewrite_as_zeta(self, s):
+    def _eval_rewrite_as_zeta(self, s, **kwargs):
         return (1 - 2**(1 - s)) * zeta(s)
 
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1411,11 +1411,9 @@ class Circle(Ellipse):
             y = find(y, equation)
 
             try:
-                co = linear_coeffs(equation, x**2, y**2, x, y)
+                a, b, c, d, e = linear_coeffs(equation, x**2, y**2, x, y)
             except ValueError:
                 raise GeometryError("The given equation is not that of a circle.")
-
-            a, b, c, d, e = [co[i] for i in (x**2, y**2, x, y, 0)]
 
             if a == 0 or b == 0 or a != b:
                 raise GeometryError("The given equation is not that of a circle.")

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1112,8 +1112,7 @@ class Line(LinearEntity):
             x = find(x, equation) or Dummy()
             y = find(y, equation) or Dummy()
 
-            co = linear_coeffs(equation, x, y)
-            a, b, c = [co[i] for i in (x, y, 0)]
+            a, b, c = linear_coeffs(equation, x, y)
 
             if b:
                 return Line((0, -c/b), slope=-a/b)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -158,7 +158,7 @@ class IntegralTransform(Function):
         return self._as_integral(self.function, self.function_variable,
                                  self.transform_variable)
 
-    def _eval_rewrite_as_Integral(self, *args):
+    def _eval_rewrite_as_Integral(self, *args, **kwargs):
         return self.as_integral
 
 from sympy.solvers.inequalities import _solve_inequality

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -1186,7 +1186,7 @@ class ITE(BooleanFunction):
     def _eval_as_set(self):
         return self.to_nnf().as_set()
 
-    def _eval_rewrite_as_Piecewise(self, *args):
+    def _eval_rewrite_as_Piecewise(self, *args, **kwargs):
         from sympy.functions import Piecewise
         return Piecewise((args[1], args[0]), (args[2], True))
 

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -67,7 +67,7 @@ class Trace(Expr):
                 return Trace(self.arg)
 
 
-    def _eval_rewrite_as_Sum(self):
+    def _eval_rewrite_as_Sum(self, **kwargs):
         from sympy import Sum, Dummy
         i = Dummy('i')
         return Sum(self.arg[i, i], (i, 0, self.arg.rows-1)).doit()

--- a/sympy/physics/optics/waves.py
+++ b/sympy/physics/optics/waves.py
@@ -279,21 +279,21 @@ class TWave(Expr):
         else:
             raise TypeError(type(other).__name__ + " and TWave objects can't be added.")
 
-    def _eval_rewrite_as_sin(self, *args):
+    def _eval_rewrite_as_sin(self, *args, **kwargs):
         return self._amplitude*sin(self.wavenumber*Symbol('x')
             - self.angular_velocity*Symbol('t') + self._phase + pi/2, evaluate=False)
 
-    def _eval_rewrite_as_cos(self, *args):
+    def _eval_rewrite_as_cos(self, *args, **kwargs):
         return self._amplitude*cos(self.wavenumber*Symbol('x')
             - self.angular_velocity*Symbol('t') + self._phase)
 
-    def _eval_rewrite_as_pde(self, *args):
+    def _eval_rewrite_as_pde(self, *args, **kwargs):
         from sympy import Function
         mu, epsilon, x, t = symbols('mu, epsilon, x, t')
         E = Function('E')
         return Derivative(E(x, t), x, 2) + mu*epsilon*Derivative(E(x, t), t, 2)
 
-    def _eval_rewrite_as_exp(self, *args):
+    def _eval_rewrite_as_exp(self, *args, **kwargs):
         from sympy import exp, I
         return self._amplitude*exp(I*(self.wavenumber*Symbol('x')
             - self.angular_velocity*Symbol('t') + self._phase))

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -322,25 +322,6 @@ class QExpr(Expr):
     def doit(self, **kw_args):
         return self
 
-    def _eval_rewrite(self, pattern, rule, **hints):
-        if hints.get('deep', False):
-            args = [ a._eval_rewrite(pattern, rule, **hints)
-                    for a in self.args ]
-        else:
-            args = self.args
-
-        # TODO: Make Basic.rewrite use hints in evaluating
-        # self.rule(*args, **hints), not having hints breaks spin state
-        # (un)coupling on rewrite
-        if pattern is None or isinstance(self, pattern):
-            if hasattr(self, rule):
-                rewritten = getattr(self, rule)(*args, **hints)
-
-                if rewritten is not None:
-                    return rewritten
-
-        return self
-
     #-------------------------------------------------------------------------
     # Represent
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -103,7 +103,7 @@ class RaisingOp(SHOOp):
 
     """
 
-    def _eval_rewrite_as_xp(self, *args):
+    def _eval_rewrite_as_xp(self, *args, **kwargs):
         return (Integer(1)/sqrt(Integer(2)*hbar*m*omega))*(
             Integer(-1)*I*Px + m*omega*X)
 
@@ -242,7 +242,7 @@ class LoweringOp(SHOOp):
 
     """
 
-    def _eval_rewrite_as_xp(self, *args):
+    def _eval_rewrite_as_xp(self, *args, **kwargs):
         return (Integer(1)/sqrt(Integer(2)*hbar*m*omega))*(
             I*Px + m*omega*X)
 
@@ -361,14 +361,14 @@ class NumberOp(SHOOp):
 
     """
 
-    def _eval_rewrite_as_a(self, *args):
+    def _eval_rewrite_as_a(self, *args, **kwargs):
         return ad*a
 
-    def _eval_rewrite_as_xp(self, *args):
+    def _eval_rewrite_as_xp(self, *args, **kwargs):
         return (Integer(1)/(Integer(2)*m*hbar*omega))*(Px**2 + (
             m*omega*X)**2) - Integer(1)/Integer(2)
 
-    def _eval_rewrite_as_H(self, *args):
+    def _eval_rewrite_as_H(self, *args, **kwargs):
         return H/(hbar*omega) - Integer(1)/Integer(2)
 
     def _apply_operator_SHOKet(self, ket):
@@ -475,13 +475,13 @@ class Hamiltonian(SHOOp):
 
     """
 
-    def _eval_rewrite_as_a(self, *args):
+    def _eval_rewrite_as_a(self, *args, **kwargs):
         return hbar*omega*(ad*a + Integer(1)/Integer(2))
 
-    def _eval_rewrite_as_xp(self, *args):
+    def _eval_rewrite_as_xp(self, *args, **kwargs):
         return (Integer(1)/(Integer(2)*m))*(Px**2 + (m*omega*X)**2)
 
-    def _eval_rewrite_as_N(self, *args):
+    def _eval_rewrite_as_N(self, *args, **kwargs):
         return hbar*omega*(N + Integer(1)/Integer(2))
 
     def _apply_operator_SHOKet(self, ket):

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -199,7 +199,7 @@ class JplusOp(SpinOpBase, Operator):
     def _represent_JzOp(self, basis, **options):
         return self._represent_base(basis, **options)
 
-    def _eval_rewrite_as_xyz(self, *args):
+    def _eval_rewrite_as_xyz(self, *args, **kwargs):
         return JxOp(args[0]) + I*JyOp(args[0])
 
 
@@ -240,7 +240,7 @@ class JminusOp(SpinOpBase, Operator):
     def _represent_JzOp(self, basis, **options):
         return self._represent_base(basis, **options)
 
-    def _eval_rewrite_as_xyz(self, *args):
+    def _eval_rewrite_as_xyz(self, *args, **kwargs):
         return JxOp(args[0]) - I*JyOp(args[0])
 
 
@@ -275,7 +275,7 @@ class JxOp(SpinOpBase, HermitianOperator):
         jm = JminusOp(self.name)._represent_JzOp(basis, **options)
         return (jp + jm)/Integer(2)
 
-    def _eval_rewrite_as_plusminus(self, *args):
+    def _eval_rewrite_as_plusminus(self, *args, **kwargs):
         return (JplusOp(args[0]) + JminusOp(args[0]))/2
 
 
@@ -310,7 +310,7 @@ class JyOp(SpinOpBase, HermitianOperator):
         jm = JminusOp(self.name)._represent_JzOp(basis, **options)
         return (jp - jm)/(Integer(2)*I)
 
-    def _eval_rewrite_as_plusminus(self, *args):
+    def _eval_rewrite_as_plusminus(self, *args, **kwargs):
         return (JplusOp(args[0]) - JminusOp(args[0]))/(2*I)
 
 
@@ -410,10 +410,10 @@ class J2Op(SpinOpBase, HermitianOperator):
     def _print_contents_latex(self, printer, *args):
         return r'%s^2' % str(self.name)
 
-    def _eval_rewrite_as_xyz(self, *args):
+    def _eval_rewrite_as_xyz(self, *args, **kwargs):
         return JxOp(args[0])**2 + JyOp(args[0])**2 + JzOp(args[0])**2
 
-    def _eval_rewrite_as_plusminus(self, *args):
+    def _eval_rewrite_as_plusminus(self, *args, **kwargs):
         a = args[0]
         return JzOp(a)**2 + \
             Rational(1, 2)*(JplusOp(a)*JminusOp(a) + JminusOp(a)*JplusOp(a))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2667,6 +2667,8 @@ def _tsolve(eq, sym, **flags):
                 return _solve(lhs.exp*log(lhs.base) - log(rhs), sym, **flags)
             elif lhs.base == 0 and rhs == 1:
                 return _solve(lhs.exp, sym, **flags)
+            else:
+                raise NotImplementedError
 
         elif lhs.is_Mul and rhs.is_positive:
             llhs = expand_log(log(lhs))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1432,7 +1432,7 @@ def _solve(f, *symbols, **flags):
 
     # /!\ capture this flag then set it to False so that no checking in
     # recursive calls will be done; only the final answer is checked
-    flags['check']=checkdens = check = flags.pop('check', True)
+    flags['check'] = checkdens = check = flags.pop('check', True)
 
     # build up solutions if f is a Mul
     if f.is_Mul:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -253,7 +253,7 @@ def checksol(f, symbol, sol=None, **flags):
             if f not in (S.true, S.false):
                 return
         else:
-            f = Add(f.lhs, -f.rhs, evaluate=False)
+            f = f.rewrite(Add, evaluate=False)
 
     if isinstance(f, BooleanAtom):
         return bool(f)
@@ -973,7 +973,7 @@ def solve(f, *symbols, **flags):
                             is True or False.
                         '''))
                 else:
-                    fi = Add(fi.lhs, -fi.rhs, evaluate=False)
+                    fi = fi.rewrite(Add, evaluate=False)
             f[i] = fi
 
         if isinstance(fi, (bool, BooleanAtom)) or fi.is_Relational:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1970,10 +1970,12 @@ def test_issue_14721():
         (a, 0, -sqrt(2)/2), (a, 0, sqrt(2)/2)]
     assert solve((a + b**2 - 1, a + b**2 - 2)) == []
 
+
 def test_issue_14779():
     x = symbols('x', real=True)
     assert solve(sqrt(x**4 - 130*x**2 + 1089) + sqrt(x**4 - 130*x**2
                  + 3969) - 96*Abs(x)/x,x) == [sqrt(130)]
+
 
 def test_issue_15307():
     assert solve((y - 2, Mul(x + 3,x - 2, evaluate=False))) == \
@@ -1982,3 +1984,6 @@ def test_issue_15307():
         {x: 2, y: 2}
     assert solve((y - 2, Add(x + 4, x - 2, evaluate=False))) == \
         {x: -1, y: 2}
+    eq1 = Eq(12513*x + 2*y - 219093, -5726*x - y)
+    eq2 = Eq(-2*x + 8, 2*x - 40)
+    assert solve([eq1, eq2]) == {x:12, y:75}

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -448,6 +448,9 @@ def test_solve_transcendental():
     assert str(solve(Eq(a, 0.5 - cos(pi*b)/2), b)) == \
         '[-0.318309886183791*acos(-2.0*a + 1.0) + 2.0, 0.318309886183791*acos(-2.0*a + 1.0)]'
 
+    # issue 15325
+    assert solve(y**(1/x) - z, x) == [log(y)/log(z)]
+
 
 def test_solve_for_functions_derivatives():
     t = Symbol('t')

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1056,6 +1056,10 @@ def test_linear_eq_to_matrix():
         [[a*x + b*y - 7], [5*x + 6*y - c]]), x, y) == (
         Matrix([[a, b], [5, 6]]), Matrix([[7], [c]]))
 
+    # issue 15312
+    assert linear_eq_to_matrix(Eq(x + 2, 1), x) == (
+        Matrix([[1]]), Matrix([[-1]]))
+
 
 def test_linsolve():
     x, y, z, u, v, w = symbols("x, y, z, u, v, w")
@@ -2010,3 +2014,16 @@ def test_solve_logarithm():
     assert _solve_logarithm(log(x)*log(y), 0, x, S.Reals) == FiniteSet(1)
 
 # end of logarithmic tests
+
+
+def test_linear_coeffs():
+    from sympy.solvers.solveset import linear_coeffs
+    assert linear_coeffs(0, x) == [0, 0]
+    assert all(i is S.Zero for i in linear_coeffs(0, x))
+    assert linear_coeffs(x + 2*y + 3, x, y) == [1, 2, 3]
+    assert linear_coeffs(x + 2*y + 3, y, x) == [2, 1, 3]
+    assert linear_coeffs(x + 2*x**2 + 3, x, x**2) == [1, 2, 3]
+    raises(ValueError, lambda:
+        linear_coeffs(x + 2*x**2 + x**3, x, x**2))
+    raises(ValueError, lambda:
+        linear_coeffs(1/x*(x - 1) + 1/x, x))

--- a/sympy/stats/symbolic_probability.py
+++ b/sympy/stats/symbolic_probability.py
@@ -46,10 +46,10 @@ class Probability(Expr):
         obj._condition = condition
         return obj
 
-    def _eval_rewrite_as_Integral(self, arg, condition=None):
+    def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
         return probability(arg, condition, evaluate=False)
 
-    def _eval_rewrite_as_Sum(self, arg, condition=None):
+    def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
         return self.rewrite(Integral)
 
     def evaluate_integral(self):
@@ -135,7 +135,7 @@ class Expectation(Expr):
 
         return self
 
-    def _eval_rewrite_as_Probability(self, arg, condition=None):
+    def _eval_rewrite_as_Probability(self, arg, condition=None, **kwargs):
         rvs = arg.atoms(RandomSymbol)
         if len(rvs) > 1:
             raise NotImplementedError()
@@ -160,10 +160,10 @@ class Expectation(Expr):
             else:
                 return Sum(arg.replace(rv, symbol)*Probability(Eq(rv, symbol), condition), (symbol, rv.pspace.domain.set.inf, rv.pspace.set.sup))
 
-    def _eval_rewrite_as_Integral(self, arg, condition=None):
+    def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
         return expectation(arg, condition=condition, evaluate=False)
 
-    def _eval_rewrite_as_Sum(self, arg, condition=None):
+    def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
         return self.rewrite(Integral)
 
     def evaluate_integral(self):
@@ -262,18 +262,18 @@ class Variance(Expr):
         # this expression contains a RandomSymbol somehow:
         return self
 
-    def _eval_rewrite_as_Expectation(self, arg, condition=None):
+    def _eval_rewrite_as_Expectation(self, arg, condition=None, **kwargs):
             e1 = Expectation(arg**2, condition)
             e2 = Expectation(arg, condition)**2
             return e1 - e2
 
-    def _eval_rewrite_as_Probability(self, arg, condition=None):
+    def _eval_rewrite_as_Probability(self, arg, condition=None, **kwargs):
         return self.rewrite(Expectation).rewrite(Probability)
 
-    def _eval_rewrite_as_Integral(self, arg, condition=None):
+    def _eval_rewrite_as_Integral(self, arg, condition=None, **kwargs):
         return variance(self.args[0], self._condition, evaluate=False)
 
-    def _eval_rewrite_as_Sum(self, arg, condition=None):
+    def _eval_rewrite_as_Sum(self, arg, condition=None, **kwargs):
         return self.rewrite(Integral)
 
     def evaluate_integral(self):
@@ -395,18 +395,18 @@ class Covariance(Expr):
                 nonrv.append(a)
         return (Mul(*nonrv), Mul(*rv))
 
-    def _eval_rewrite_as_Expectation(self, arg1, arg2, condition=None):
+    def _eval_rewrite_as_Expectation(self, arg1, arg2, condition=None, **kwargs):
         e1 = Expectation(arg1*arg2, condition)
         e2 = Expectation(arg1, condition)*Expectation(arg2, condition)
         return e1 - e2
 
-    def _eval_rewrite_as_Probability(self, arg1, arg2, condition=None):
+    def _eval_rewrite_as_Probability(self, arg1, arg2, condition=None, **kwargs):
         return self.rewrite(Expectation).rewrite(Probability)
 
-    def _eval_rewrite_as_Integral(self, arg1, arg2, condition=None):
+    def _eval_rewrite_as_Integral(self, arg1, arg2, condition=None, **kwargs):
         return covariance(self.args[0], self.args[1], self._condition, evaluate=False)
 
-    def _eval_rewrite_as_Sum(self, arg1, arg2, condition=None):
+    def _eval_rewrite_as_Sum(self, arg1, arg2, condition=None, **kwargs):
         return self.rewrite(Integral)
 
     def evaluate_integral(self):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

fixes #15319 
fixes #15307 
fixes #15312 
fixes #15325 
closes #5023 referenced `as_basic` and `as_expr` as possibilities for rewriting Eq

#### Brief description of what is fixed or changed

Rewriting Eq as lhs - rhs in an unevaluated way is a delicate operation so a robust rewrite method was added. Modifications to `linear_coeffs` and related code that uses such rewriting was added to address the issues that were fixed. A rewrite method was used instead of giving Eq the `as_expr` method since there was resistance to this idea in the past (#5032)

kwargs are now passed to the rewrite methods. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * kwargs are now passed to all rewrite methods
  * `Eq._eval_rewrite_Add` has been defined
* solvers
  * `linear_coeffs` returns list of coeffs by default instead of dict
<!-- END RELEASE NOTES -->
