### PR TITLE
Added Auxiliary Circle Feature For Ellipse

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -544,7 +544,7 @@ class Ellipse(GeometrySet):
         return Point.distance(self.center, self.foci[0])
 
     def auxiliary_circle(self, x='x', y='y'):
-         """The equation of auxiliary circle of the ellipse.
+        """The equation of auxiliary circle of the ellipse.
 
          Returns
          =======

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -544,26 +544,26 @@ class Ellipse(GeometrySet):
         return Point.distance(self.center, self.foci[0])
 
     def auxiliary_circle(self, x='x', y='y'):
-        """The equation of auxiliary circle of the ellipse.
+         """The equation of auxiliary circle of the ellipse.
 
-        Returns
-        =======
+         Returns
+         =======
 
-        equation : sympy expression
+         equation : sympy expression
 
-        Parameters
-        ==========
+         Parameters
+         ==========
 
-        x : str, optional Label for the x-axis. Default value is 'x'.
-        y : str, optional Label for the y-axis. Default value is 'y'.
+         x : str, optional Label for the x-axis. Default value is 'x'.
+         y : str, optional Label for the y-axis. Default value is 'y'.
 
-        Examples
-        ========
+         Examples
+         ========
 
-        >>> from sympy import Ellipse, Point
-        >>> ellipse = Ellipse(Point(2, 4), 9, 1)
-        >>> ellipse.auxiliary_circle()
-        (x - 2)**2 + (y - 4)**2 - 81
+         >>> from sympy import Ellipse, Point
+         >>> ellipse = Ellipse(Point(2, 4), 9, 1)
+         >>> ellipse.auxiliary_circle()
+         (x - 2)**2 + (y - 4)**2 - 81
 
         """
         hr, vr = self.hradius, self.vradius

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -612,6 +612,7 @@ class Ellipse(GeometrySet):
 
         Notes
         -----
+
         Currently supports intersections with Point, Line, Segment, Ray,
         Circle and Ellipse types.
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -544,8 +544,8 @@ class Ellipse(GeometrySet):
         return Point.distance(self.center, self.foci[0])
 
     def auxiliary_circle(self, x='x', y='y'):
-        """The equation of auxiliary circle of the ellipse.
-
+         """The equation of auxiliary circle of the ellipse.
+ 
         Returns
         =======
 
@@ -564,12 +564,11 @@ class Ellipse(GeometrySet):
         >>> ellipse = Ellipse(Point(2, 4), 9, 1)
         >>> ellipse.auxiliary_circle()
         (x - 2)**2 + (y - 4)**2 - 81
-
         """
         hr, vr = self.hradius, self.vradius
         m = max(hr, vr)
         return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2
-
+    
     @property
     def hradius(self):
         """The horizontal radius of the ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -543,6 +543,33 @@ class Ellipse(GeometrySet):
         """
         return Point.distance(self.center, self.foci[0])
 
+    def auxiliary_circle(self, x='x', y='y'):
+        """The equation of auxiliary circle of the ellipse.
+
+        Returns
+        =======
+
+        equation : sympy expression
+
+        Parameters
+        ==========
+
+        x : str, optional Label for the x-axis. Default value is 'x'.
+        y : str, optional Label for the y-axis. Default value is 'y'.
+
+        Examples
+        ========
+
+        >>> from sympy import Ellipse, Point
+        >>> ellipse = Ellipse(Point(2, 4), 9, 1)
+        >>> ellipse.auxiliary_circle()
+        (x - 2)**2 + (y - 4)**2 - 81
+
+        """
+        hr, vr = self.hradius, self.vradius
+        m = max(hr, vr)
+        return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2
+
     @property
     def hradius(self):
         """The horizontal radius of the ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -546,29 +546,29 @@ class Ellipse(GeometrySet):
     def auxiliary_circle(self, x='x', y='y'):
         """The equation of auxiliary circle of the ellipse.
 
-         Returns
-         =======
+        Returns
+        =======
 
-         equation : sympy expression
+        equation : sympy expression
 
-         Parameters
-         ==========
+        Parameters
+        ==========
 
-         x : str, optional Label for the x-axis. Default value is 'x'.
-         y : str, optional Label for the y-axis. Default value is 'y'.
+        x : str, optional Label for the x-axis. Default value is 'x'.
+        y : str, optional Label for the y-axis. Default value is 'y'.
 
-         Examples
-         ========
+        Examples
+        ========
 
-         >>> from sympy import Ellipse, Point
-         >>> ellipse = Ellipse(Point(2, 4), 9, 1)
-         >>> ellipse.auxiliary_circle()
-         (x - 2)**2 + (y - 4)**2 - 81
+        >>> from sympy import Ellipse, Point
+        >>> ellipse = Ellipse(Point(2, 4), 9, 1)
+        >>> ellipse.auxiliary_circle()
+        (x - 2)**2 + (y - 4)**2 - 81
 
-         """
-         hr, vr = self.hradius, self.vradius
-         m = max(hr, vr)
-         return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2
+        """
+        hr, vr = self.hradius, self.vradius
+        m = max(hr, vr)
+        return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2
 
     @property
     def hradius(self):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -565,10 +565,10 @@ class Ellipse(GeometrySet):
          >>> ellipse.auxiliary_circle()
          (x - 2)**2 + (y - 4)**2 - 81
 
-        """
-        hr, vr = self.hradius, self.vradius
-        m = max(hr, vr)
-        return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2
+         """
+         hr, vr = self.hradius, self.vradius
+         m = max(hr, vr)
+         return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2
 
     @property
     def hradius(self):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -612,7 +612,6 @@ class Ellipse(GeometrySet):
 
         Notes
         -----
-
         Currently supports intersections with Point, Line, Segment, Ray,
         Circle and Ellipse types.
 


### PR DESCRIPTION
Auxiliary Circle of an ellipse is the circumcircle of an ellipse i.e. the circle whose centre concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.

The centre of the auxiliary circle is always the same as the ellipse's centre, the circle itself touches both vertices. Hence, the distance between a vertex and the centre is the circle's radius. In an ellipse, the distance between a vertex and the centre is given by the semi-major axis.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- geometry
  - Added Auxiliary Circle Feature For Ellipse

<!-- END RELEASE NOTES -->
