### PR TITLE
disallow non-symbol generator for RootOf

### DIFF
--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -176,7 +176,8 @@ class ComplexRootOf(RootOf):
     Roots of a univariate polynomial separated into disjoint
     real or complex intervals and indexed in a fixed order.
     Currently only rational coefficients are allowed.
-    Can be imported as ``CRootOf``.
+    Can be imported as ``CRootOf``. To avoid confusion, the
+    generator must be a Symbol.
 
 
     Examples
@@ -270,6 +271,23 @@ class ComplexRootOf(RootOf):
     >>> t.eval_rational(n=2)
     104755/2097152 - 6634255*I/2097152
 
+    Notes
+    =====
+
+    Although a PurePoly can be constructed from a non-symbol generator
+    RootOf instances of non-symbols are disallowed to avoid confusion
+    over what root is being represented.
+
+    >>> from sympy import exp, PurePoly
+    >>> PurePoly(x) == PurePoly(exp(x))
+    True
+    >>> CRootOf(x - 1, 0)
+    1
+    >>> CRootOf(exp(x) - 1, 0)  # would correspond to x == 0
+    Traceback (most recent call last):
+    ...
+    sympy.polys.polyerrors.PolynomialError: generator must be a Symbol
+
     See Also
     ========
     eval_approx
@@ -305,6 +323,11 @@ class ComplexRootOf(RootOf):
 
         if not poly.is_univariate:
             raise PolynomialError("only univariate polynomials are allowed")
+
+        if not poly.gen.is_Symbol:
+            # PurePoly(sin(x) + 1) == PurePoly(x + 1) but the roots of
+            # x for each are not the same: issue 8617
+            raise PolynomialError("generator must be a Symbol")
 
         degree = poly.degree()
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2500,10 +2500,9 @@ def test_factor_large():
             x**6 - x**5 + x**4 - x**3 + x**2 - x + 1, 1)])
 
 
-@XFAIL
 def test_factor_noeval():
-    assert factor(6*x - 10) == 2*(3*x - 5)
-    assert factor((6*x - 10)/(3*x - 6)) == S(2)/3*((3*x - 5)/(x - 2))
+    assert factor(6*x - 10) == Mul(2, 3*x - 5, evaluate=False)
+    assert factor((6*x - 10)/(3*x - 6)) == Mul(S(2)/3, 3*x - 5, 1/(x - 2))
 
 
 def test_intervals():

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -79,8 +79,9 @@ def test_CRootOf___new__():
 
     raises(PolynomialError, lambda: rootof(Poly(0, x), 0))
     raises(PolynomialError, lambda: rootof(Poly(1, x), 0))
-
     raises(PolynomialError, lambda: rootof(x - y, 0))
+    # issue 8617
+    raises(PolynomialError, lambda: rootof(exp(x), 0))
 
     raises(NotImplementedError, lambda: rootof(x**3 - x + sqrt(2), 0))
     raises(NotImplementedError, lambda: rootof(x**3 - x + I, 0))
@@ -237,9 +238,6 @@ def test_CRootOf_evalf():
     # issue 6451
     r = rootof(legendre_poly(64, x), 7)
     assert r.n(2) == r.n(100).n(2)
-    # issue 8617
-    ans = [w.n(2) for w in solve(x**3 - x - 4)]
-    assert rootof(exp(x)**3 - exp(x) - 4, 0).n(2) in ans
     # issue 9019
     r0 = rootof(x**2 + 1, 0, radicals=False)
     r1 = rootof(x**2 + 1, 1, radicals=False)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

closes #8617 

#### Brief description of what is fixed or changed

It is a potential source of confusion that `RootOf(exp(x) - 1, 0) == RootOf(x - 1, 0)` because the RootOf roots correspond to the generators, not the free symbol. Now a PolynomialError is raised in the generator is not a symbol.

#### Other comments

An XFAIL test was un-XFAILed by writing the exected result with an unevaluated expression; it is unrelated to the changes to RootOf.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * RootOf no longer accepts an expression with a non-Symbol generator
<!-- END RELEASE NOTES -->
