### PR TITLE
 Use `is` operator to compare to None

### DIFF
--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -461,7 +461,7 @@ by injecting a custom zero test with warnings enabled.
     ...         result = None
     ...
     ...     # Warnings if evaluated into None
-    ...     if not result:
+    ...     if not isinstance(result, bool):
     ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
     ...     return result
     ...
@@ -487,7 +487,7 @@ while being harmless to other polynomials or transcendental functions.
     ...         result = None
     ...
     ...     # Warnings if evaluated into None
-    ...     if not result:
+    ...     if not isinstance(result, bool):
     ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
     ...     return result
     ...

--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -462,7 +462,7 @@ by injecting a custom zero test with warnings enabled.
     ...
     ...     # Warnings if evaluated into None
     ...     if result is None:
-    ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
+    ...         warnings.warn("Zero testing of {} evaluated into None".format(x))
     ...     return result
     ...
     >>> m.nullspace(iszerofunc=my_iszero) # doctest: +SKIP
@@ -488,7 +488,7 @@ while being harmless to other polynomials or transcendental functions.
     ...
     ...     # Warnings if evaluated into None
     ...     if result is None:
-    ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
+    ...         warnings.warn("Zero testing of {} evaluated into None".format(x))
     ...     return result
     ...
     >>> m.nullspace(iszerofunc=my_iszero) # doctest: +SKIP

--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -461,7 +461,7 @@ by injecting a custom zero test with warnings enabled.
     ...         result = None
     ...
     ...     # Warnings if evaluated into None
-    ...     if result == None:
+    ...     if result is None:
     ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
     ...     return result
     ...
@@ -487,7 +487,7 @@ while being harmless to other polynomials or transcendental functions.
     ...         result = None
     ...
     ...     # Warnings if evaluated into None
-    ...     if result == None:
+    ...     if result is None:
     ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
     ...     return result
     ...

--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -461,7 +461,7 @@ by injecting a custom zero test with warnings enabled.
     ...         result = None
     ...
     ...     # Warnings if evaluated into None
-    ...     if not isinstance(result, bool):
+    ...     if result is None:
     ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
     ...     return result
     ...
@@ -487,7 +487,7 @@ while being harmless to other polynomials or transcendental functions.
     ...         result = None
     ...
     ...     # Warnings if evaluated into None
-    ...     if not isinstance(result, bool):
+    ...     if result is None:
     ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
     ...     return result
     ...

--- a/doc/src/tutorial/matrices.rst
+++ b/doc/src/tutorial/matrices.rst
@@ -461,7 +461,7 @@ by injecting a custom zero test with warnings enabled.
     ...         result = None
     ...
     ...     # Warnings if evaluated into None
-    ...     if result is None:
+    ...     if not result:
     ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
     ...     return result
     ...
@@ -487,7 +487,7 @@ while being harmless to other polynomials or transcendental functions.
     ...         result = None
     ...
     ...     # Warnings if evaluated into None
-    ...     if result is None:
+    ...     if not result:
     ...         warnings.warn("Zero testing of {} evaluated into {}".format(x, result))
     ...     return result
     ...

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -40,7 +40,7 @@ class AskFiniteHandler(CommonHandler):
         >>> from sympy.assumptions.handlers.calculus import AskFiniteHandler
         >>> from sympy.abc import x
         >>> a = AskFiniteHandler()
-        >>> a.Symbol(x, Q.positive(x)) == None
+        >>> a.Symbol(x, Q.positive(x)) is None
         True
         >>> a.Symbol(x, Q.finite(x))
         True

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -21,7 +21,7 @@ class AskFiniteHandler(CommonHandler):
     >>> from sympy.assumptions.handlers.calculus import AskFiniteHandler
     >>> from sympy.abc import x
     >>> a = AskFiniteHandler()
-    >>> a.Symbol(x, Q.positive(x)) == None
+    >>> a.Symbol(x, Q.positive(x)) is None
     True
     >>> a.Symbol(x, Q.finite(x))
     True

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1470,7 +1470,7 @@ class Variable(Node):
         Examples
         ========
 
-        >>> from sympy.codegen.ast import Variable
+        >>> from sympy.codegen.ast import Variable, NoneToken
         >>> x = Variable('x')
         >>> decl1 = x.as_Declaration()
         # value is special NoneToken() which must be tested with == operator
@@ -1567,7 +1567,7 @@ class Declaration(Token):
     ========
 
     >>> from sympy import Symbol
-    >>> from sympy.codegen.ast import Declaration, Type, Variable, integer, untyped
+    >>> from sympy.codegen.ast import Declaration, Type, Variable, NoneToken, integer, untyped
     >>> z = Declaration('z')
     >>> z.variable.type == untyped
     True

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -1473,7 +1473,7 @@ class Variable(Node):
         >>> from sympy.codegen.ast import Variable, NoneToken
         >>> x = Variable('x')
         >>> decl1 = x.as_Declaration()
-        # value is special NoneToken() which must be tested with == operator
+        >>> # value is special NoneToken() which must be tested with == operator
         >>> decl1.variable.value is None  # won't work
         False
         >>> decl1.variable.value == None  # not PEP-8 compliant
@@ -1571,7 +1571,7 @@ class Declaration(Token):
     >>> z = Declaration('z')
     >>> z.variable.type == untyped
     True
-    # value is special NoneToken() which must be tested with == operator
+    >>> # value is special NoneToken() which must be tested with == operator
     >>> z.variable.value is None  # won't work
     False
     >>> z.variable.value == None  # not PEP-8 compliant

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -189,7 +189,8 @@ class Token(Basic):
     @classmethod
     def _construct(cls, attr, arg):
         """ Construct an attribute value from argument passed to ``__new__()``. """
-        if arg == None: # Must be "== None", cannot be "is None"
+        # arg may be ``NoneToken()``, so comparation is done using == instead of ``is`` operator
+        if arg == None:
             return cls.defaults.get(attr, none)
         else:
             if isinstance(arg, Dummy):  # sympy's replace uses Dummy instances
@@ -1472,7 +1473,12 @@ class Variable(Node):
         >>> from sympy.codegen.ast import Variable
         >>> x = Variable('x')
         >>> decl1 = x.as_Declaration()
-        >>> decl1.variable.value == None
+        # value is special NoneToken() which must be tested with == operator
+        >>> decl1.variable.value is None  # won't work
+        False
+        >>> decl1.variable.value == None  # not PEP-8 compliant
+        True
+        >>> decl1.variable.value == NoneToken()  # OK
         True
         >>> decl2 = x.as_Declaration(value=42.0)
         >>> decl2.variable.value == 42
@@ -1565,7 +1571,12 @@ class Declaration(Token):
     >>> z = Declaration('z')
     >>> z.variable.type == untyped
     True
-    >>> z.variable.value == None
+    # value is special NoneToken() which must be tested with == operator
+    >>> z.variable.value is None  # won't work
+    False
+    >>> z.variable.value == None  # not PEP-8 compliant
+    True
+    >>> z.variable.value == NoneToken()  # OK
     True
     """
     __slots__ = ['variable']

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -95,7 +95,7 @@ def separatevars(expr, symbols=[], dict=False, force=False):
     >>> eq = 2*x + y*sin(x)
     >>> separatevars(eq) == eq
     True
-    >>> separatevars(2*x + y*sin(x), symbols=(x, y), dict=True) == None
+    >>> separatevars(2*x + y*sin(x), symbols=(x, y), dict=True) is None
     True
 
     """


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Fix equality testing in several `Examples` sections; add comments in cases where comparations MUST be done using `==` operator (cases involving `sympy.codegen.ast.NoneToken`).

#### Other comments

Edits were done entirely with GitHub online editor, therefore one file per commit. Please, squash commits before merge for sanity's sake.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
