### PR TITLE
Minor fix to ode.py (sysode_linear_neq_order1)

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -7789,6 +7789,7 @@ def _linear_3eq_order1_type4(x, y, z, t, r, eq):
 
 def sysode_linear_neq_order1(match_):
     sol = _linear_neq_order1_type1(match_)
+    return sol
 
 def _linear_neq_order1_type1(match_):
     r"""

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2901,3 +2901,33 @@ def test_issue_14395():
     sol = Eq(f(x), (C1 - x/3 + sin(2*x)/3)*sin(3*x) + (C2 + log(cos(x))
         - 2*log(cos(x)**2)/3 + 2*cos(x)**2/3)*cos(3*x))
     assert dsolve(Derivative(f(x), x, x) + 9*f(x) - sec(x), f(x)) == sol
+
+
+def test_sysode_linear_neq_order1():
+    
+    from sympy import Funtcion
+    from sympy import symbols
+    from sympy import dsolve
+    from sympy.abc import t
+    
+    Z0 = Function('Z0')
+    Z1 = Function('Z1')
+    Z2 = Function('Z2')
+    Z3 = Function('Z3')
+    
+    k01, k10, k20, k21, k23, k30 = symbols('k01 k10 k20 k21 k23 k30')
+
+    eq = (Eq(Derivative(Z0(t), t), -k01*Z0(t) + k10*Z1(t) + k20*Z2(t) + k30*Z3(t)), Eq(Derivative(Z1(t), t),
+          k01*Z0(t) - k10*Z1(t) + k21*Z2(t)), Eq(Derivative(Z2(t), t), -(k20 + k21 + k23)*Z2(t)), Eq(Derivative(Z3(t),
+          t), k23*Z2(t) - k30*Z3(t)))
+
+    sols_eq = [Eq(Z0(t), C1*k10/k01 + C2*(-k10 + k30)*exp(-k30*t)/(k01 + k10 - k30) - C3*exp(t*(-
+                k01 - k10)) + C4*(k10*k20 + k10*k21 - k10*k30 - k20**2 - k20*k21 - k20*k23 + k20*k30 +
+                k23*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10 - k20 - k21 - k23))),
+               Eq(Z1(t), C1 - C2*k01*exp(-k30*t)/(k01 + k10 - k30) + C3*exp(t*(-k01 - k10)) + C4*(k01*k20 + k01*k21
+                - k01*k30 - k20*k21 - k21**2 - k21*k23 + k21*k30)*exp(t*(-k20 - k21 - k23))/(k23*(k01 + k10 - k20 -
+                k21 - k23))),
+               Eq(Z2(t), C4*(-k20 - k21 - k23 + k30)*exp(t*(-k20 - k21 - k23))/k23),
+               Eq(Z3(t), C2*exp(-k30*t) + C4*exp(t*(-k20 - k21 - k23)))]
+    
+    assert dsolve(eq, simplify=False) == sols_eq

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2904,17 +2904,13 @@ def test_issue_14395():
 
 
 def test_sysode_linear_neq_order1():
-    
-    from sympy import Function
-    from sympy import symbols
-    from sympy import dsolve
     from sympy.abc import t
-    
+
     Z0 = Function('Z0')
     Z1 = Function('Z1')
     Z2 = Function('Z2')
     Z3 = Function('Z3')
-    
+
     k01, k10, k20, k21, k23, k30 = symbols('k01 k10 k20 k21 k23 k30')
 
     eq = (Eq(Derivative(Z0(t), t), -k01*Z0(t) + k10*Z1(t) + k20*Z2(t) + k30*Z3(t)), Eq(Derivative(Z1(t), t),
@@ -2929,5 +2925,5 @@ def test_sysode_linear_neq_order1():
                 k21 - k23))),
                Eq(Z2(t), C4*(-k20 - k21 - k23 + k30)*exp(t*(-k20 - k21 - k23))/k23),
                Eq(Z3(t), C2*exp(-k30*t) + C4*exp(t*(-k20 - k21 - k23)))]
-    
+
     assert dsolve(eq, simplify=False) == sols_eq

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2905,7 +2905,7 @@ def test_issue_14395():
 
 def test_sysode_linear_neq_order1():
     
-    from sympy import Funtcion
+    from sympy import Function
     from sympy import symbols
     from sympy import dsolve
     from sympy.abc import t


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Cleaner PR from #15294

#### Brief description of what is fixed or changed
Currently, the function _linear_neq_order1_type1 (line 7794) is called by sysode_linear_neq_order1 (line 7790) which is in turn called by dsolve for linear systems of first order differential equations systems. The thing is that the solutions returned by _linear_neq_order1_type1 are lost by sysode_linear_neq_order1 since it simply doesn't return anything to dsolve. The minor fix (I think) is only to add the "return sol" to the sysode_linear_neq_order1 function at line 7792.

Added line 7792 which returns the solutions to the ODE system.
"return sol"
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed a bug where `dsolve` would return no solutions to a linear system of n first order ODEs
<!-- END RELEASE NOTES -->
