### PR TITLE
LaTeX printing: $$...$$ -> $\displaystyle ...$

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -173,7 +173,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         if _can_print_latex(o):
             s = latex(o, mode=latex_mode, **settings)
             s = s.strip('$')
-            return '$$%s$$' % s
+            return '$\\displaystyle %s$' % s
 
     def _result_display(self, arg):
         """IPython's pretty-printer display hook, for use in IPython 0.10


### PR DESCRIPTION
#### References to other Issues or PRs

Same thing for IPython: https://github.com/ipython/ipython/pull/11357

Somewhat related: https://github.com/jupyter/nbconvert/pull/892

#### Brief description of what is fixed or changed

Change the LaTeX wrapping from `$$`...`$$` to `$\displaystyle `...`$`

#### Other comments

This left-aligns expressions when exporting to LaTeX.

Before:

![grafik](https://user-images.githubusercontent.com/705404/46369833-5642c800-c684-11e8-9d11-600ab87c3dc2.png)

After:

![grafik](https://user-images.githubusercontent.com/705404/46369898-7bcfd180-c684-11e8-8e71-275a7ba45bca.png)

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * change from `$$`...`$$` to `$\displaystyle `...`$` to allow left-aligning in LaTeX documents
<!-- END RELEASE NOTES -->
