### PR TITLE
Add _latex methods for DifferentialOperator , GroebnerBasis

### DIFF
--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -30,7 +30,8 @@ from sympy.polys.polyclasses import DMF
 from sympy.polys.polyroots import roots
 from sympy.polys.polytools import Poly
 
-from sympy.core import Basic,Add
+from sympy.core import Add
+from sympy.interactive.printing import Printable
 
 def DifferentialOperators(base, generator):
     r"""
@@ -136,7 +137,7 @@ class DifferentialOperatorAlgebra(object):
             return False
 
 
-class DifferentialOperator(Basic):
+class DifferentialOperator(Printable):
     """
     Differential Operators are elements of Weyl Algebra. The Operators
     are defined by a list of polynomials in the base ring and the

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division
 
 from sympy import (Symbol, diff, S, Dummy, Order, rf, meijerint, I,
     solve, limit, Float, nsimplify, gamma)
-from sympy.printing import sstr,latex
+from sympy.printing import sstr
 from sympy.core.compatibility import range, ordered
 from sympy.functions.combinatorial.factorials import binomial, factorial
 from sympy.core.sympify import sympify
@@ -380,10 +380,10 @@ class DifferentialOperator(Printable):
             if v == self.parent.base.zero:
                 continue
 
-            lv = latex(v)
+            lv = printer._print(v)
             if v == self.parent.base.one:
                 lv = ""
-            elif (not v.is_monomial) or lv.strip()[0] == "-" :
+            elif printer._needs_add_brackets( v.ring.to_sympy(v) ) :
                 lv = '(' + lv + ')'
 
             if i == 0:
@@ -394,10 +394,10 @@ class DifferentialOperator(Printable):
                 print_str += ' + '
 
             if i == 1:
-                print_str += lv + '%s' %(self.parent.gen_symbol)
+                print_str += lv + '%s' % self.parent.gen_symbol
                 continue
 
-            print_str += lv +  '%s^' %(self.parent.gen_symbol) + latex(i)
+            print_str += lv +  '%s^' % self.parent.gen_symbol + printer._print(i)
         return print_str
 
 class HolonomicFunction(object):

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division
 
 from sympy import (Symbol, diff, S, Dummy, Order, rf, meijerint, I,
     solve, limit, Float, nsimplify, gamma)
-from sympy.printing import sstr
+from sympy.printing import sstr,latex
 from sympy.core.compatibility import range, ordered
 from sympy.functions.combinatorial.factorials import binomial, factorial
 from sympy.core.sympify import sympify
@@ -30,6 +30,7 @@ from sympy.polys.polyclasses import DMF
 from sympy.polys.polyroots import roots
 from sympy.polys.polytools import Poly
 
+from sympy.core import Basic,Add
 
 def DifferentialOperators(base, generator):
     r"""
@@ -135,7 +136,7 @@ class DifferentialOperatorAlgebra(object):
             return False
 
 
-class DifferentialOperator(object):
+class DifferentialOperator(Basic):
     """
     Differential Operators are elements of Weyl Algebra. The Operators
     are defined by a list of polynomials in the base ring and the
@@ -371,6 +372,32 @@ class DifferentialOperator(object):
         base = self.parent.base
         return x0 in roots(base.to_sympy(self.listofpoly[-1]), self.x)
 
+    def _latex(self,expr):
+        listofpoly = self.listofpoly
+        print_str = ''
+        for i,v in enumerate(listofpoly):
+            if v == self.parent.base.zero:
+                continue
+
+            lv = latex(v)
+            if v == self.parent.base.one:
+                lv = ""
+            elif (not v.is_monomial) or lv.strip()[0] == "-" :
+                lv = '(' + lv + ')'
+
+            if i == 0:
+                print_str += lv
+                continue
+
+            if print_str:
+                print_str += ' + '
+
+            if i == 1:
+                print_str += lv + '%s' %(self.parent.gen_symbol)
+                continue
+
+            print_str += lv +  '%s^' %(self.parent.gen_symbol) + latex(i)
+        return print_str
 
 class HolonomicFunction(object):
     r"""

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -372,7 +372,7 @@ class DifferentialOperator(Basic):
         base = self.parent.base
         return x0 in roots(base.to_sympy(self.listofpoly[-1]), self.x)
 
-    def _latex(self,expr):
+    def _latex(self,printer):
         listofpoly = self.listofpoly
         print_str = ''
         for i,v in enumerate(listofpoly):

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -11,6 +11,10 @@ from sympy import preview
 from sympy.core.compatibility import integer_types
 from sympy.utilities.misc import debug
 
+""" empty class for marked as printable types """
+class Printable(object):
+    pass
+
 
 def _init_python_printing(stringify_func, **settings):
     """Setup printing in Python interactive session. """
@@ -123,8 +127,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                 return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
             elif isinstance(o, bool):
                 return False
-            # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
-            # to use here, than these explicit imports.
+            elif hasattr(o, '_latex') :
+                return True
             elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic, NDimArray)):
                 return True
             elif isinstance(o, (float, integer_types)) and print_builtin:
@@ -194,7 +198,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         from sympy.physics.vector import Vector, Dyadic
         from sympy.tensor.array import NDimArray
 
-        printable_types = [Basic, MatrixBase, float, tuple, list, set,
+        printable_types = [Printable , Basic, MatrixBase, float, tuple, list, set,
                 frozenset, dict, Vector, Dyadic, NDimArray] + list(integer_types)
 
         plaintext_formatter = ip.display_formatter.formatters['text/plain']

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -56,8 +56,6 @@ from sympy.polys.constructor import construct_domain
 
 from sympy.polys import polyoptions as options
 
-from sympy.printing import latex
-
 from sympy.core.compatibility import iterable, range, ordered
 
 @public
@@ -7039,11 +7037,11 @@ class GroebnerBasis(Basic):
         return self.reduce(poly)[1] == 0
 
     def _latex(self,printer):
-        pls = ",".join([ latex(p.as_expr()) for p in self.polys])
-        gens = ",".join( map(latex,self.gens) )
-        dm = latex(self.domain)
-        order = latex(self.order)
-        return "GroebnerBasis([%s],%s,domain=%s,order=%s)" % (pls,gens,dm,order)
+        pls = ",".join( [ printer._print(p.as_expr()) for p in self.polys] )
+        gens = ",".join( [ printer._print(gen) for gen in self.gens] )
+        dm = printer._print(self.domain)
+        order = printer._print(self.order)
+        return r"\mathrm{GroebnerBasis}([%s],%s,\mathrm{domain=}%s,\mathrm{order=}%s)" % (pls,gens,dm,order)
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -7038,7 +7038,7 @@ class GroebnerBasis(Basic):
         """
         return self.reduce(poly)[1] == 0
 
-    def _latex(self,expr):
+    def _latex(self,printer):
         pls = ",".join([ latex(p.as_expr()) for p in self.polys])
         gens = ",".join( map(latex,self.gens) )
         dm = latex(self.domain)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -56,6 +56,8 @@ from sympy.polys.constructor import construct_domain
 
 from sympy.polys import polyoptions as options
 
+from sympy.printing import latex
+
 from sympy.core.compatibility import iterable, range, ordered
 
 @public
@@ -7035,6 +7037,13 @@ class GroebnerBasis(Basic):
 
         """
         return self.reduce(poly)[1] == 0
+
+    def _latex(self,expr):
+        pls = ",".join([ latex(p.as_expr()) for p in self.polys])
+        gens = ",".join( map(latex,self.gens) )
+        dm = latex(self.domain)
+        order = latex(self.order)
+        return "GroebnerBasis([%s],%s,domain=%s,order=%s)" % (pls,gens,dm,order)
 
 
 @public


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

Add _latex methods for GroebnerBasis and DifferentialOperator
because they are printed like "t**3-x,t*x-y,t*y-?z,t*z-x**2,x**3..." in Jupyter

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* holonomic
   * Add a _latex method for DifferentialOperator class

* polys
   * Add a _latex method for GroebnerBasis class

* interactive
   * Add empty class Printable just for mark class as printable_types
   * Impremented TODO about hasattr(o, '_latex') in _can_print_latex

<!-- END RELEASE NOTES -->
