### PR TITLE
CodePrinter deleted `_not_supported` prematurely

### DIFF
--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -117,8 +117,8 @@ class CodePrinter(StrPrinter):
             lines = self._format_code(lines)
             num_syms = set([(k, self._print(v)) for k, v in self._number_symbols])
             result = (num_syms, self._not_supported, "\n".join(lines))
-        del self._not_supported
-        del self._number_symbols
+        self._not_supported = set()
+        self._number_symbols = set()
         return result
 
     def _doprint_loops(self, expr, assign_to=None):

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -839,6 +839,19 @@ def test_issue_12092():
     f = implemented_function('f', lambda x: x**2)
     assert f(f(2)).evalf() == Float(16)
 
+def test_issue_14911():
+    class Variable(sympy.Symbol):
+        def _sympystr(self, printer):
+            return printer.doprint(self.name)
+
+        _lambdacode = _sympystr
+        _numpycode = _sympystr
+
+    x = Variable('x')
+    y = 2 * x
+    code = LambdaPrinter().doprint(y)
+    assert code.replace(' ', '') == '2*x'
+
 def test_ITE():
     assert lambdify((x, y, z), ITE(x, y, z))(True, 5, 3) == 5
     assert lambdify((x, y, z), ITE(x, y, z))(False, 5, 3) == 3


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #14911 


#### Brief description of what is fixed or changed
In `CodePrinter.doprint` the sets `_not_supported` and `_number_symbols` were deleted at the end of this recursive function, leading to an AttributeError for certain Symbol subclasses. Fixed by setting an empty `set` instead of deleting.

#### Other comments

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
