### PR TITLE
trigsimp: changes order of TRmorrie and TR10i in trigsimp.py

### DIFF
--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -361,11 +361,11 @@ def test_issue_2827_trigsimp_methods():
 def test_issue_15129_trigsimp_methods():
     t1 = Matrix([sin(Rational(1, 50)), cos(Rational(1, 50)), 0])
     t2 = Matrix([sin(Rational(1, 25)), cos(Rational(1, 25)), 0])
-    t3 = Matrix([cos(Rational(1, 25)), sin(Rational(1, 50)), 0])
+    t3 = Matrix([cos(Rational(1, 25)), sin(Rational(1, 25)), 0])
     r1 = t1.dot(t2)
     r2 = t1.dot(t3)
-    assert r1.simplify() == cos(1/50)
-    assert r2.simplify() == sin(3/50)
+    assert r1.simplify() == cos(Rational(1,50))
+    assert r2.simplify() == sin(Rational(3,50))
 
 def test_exptrigsimp():
     def valid(a, b):

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -364,8 +364,8 @@ def test_issue_15129_trigsimp_methods():
     t3 = Matrix([cos(Rational(1, 25)), sin(Rational(1, 25)), 0])
     r1 = t1.dot(t2)
     r2 = t1.dot(t3)
-    assert r1.simplify() == cos(Rational(1,50))
-    assert r2.simplify() == sin(Rational(3,50))
+    assert trigsimp(r1) == cos(S(1)/50)
+    assert trigsimp(r2) == sin(S(3)/50)
 
 def test_exptrigsimp():
     def valid(a, b):

--- a/sympy/simplify/tests/test_trigsimp.py
+++ b/sympy/simplify/tests/test_trigsimp.py
@@ -1,7 +1,8 @@
 from sympy import (
     symbols, sin, simplify, cos, trigsimp, rad, tan, exptrigsimp,sinh,
     cosh, diff, cot, Subs, exp, tanh, exp, S, integrate, I,Matrix,
-    Symbol, coth, pi, log, count_ops, sqrt, E, expand, Piecewise)
+    Symbol, coth, pi, log, count_ops, sqrt, E, expand, Piecewise , Rational
+    )
 
 from sympy.core.compatibility import long
 from sympy.utilities.pytest import XFAIL
@@ -357,6 +358,14 @@ def test_issue_2827_trigsimp_methods():
     eq = 1/sqrt(E) + E
     assert exptrigsimp(eq) == eq
 
+def test_issue_15129_trigsimp_methods():
+    t1 = Matrix([sin(Rational(1, 50)), cos(Rational(1, 50)), 0])
+    t2 = Matrix([sin(Rational(1, 25)), cos(Rational(1, 25)), 0])
+    t3 = Matrix([cos(Rational(1, 25)), sin(Rational(1, 50)), 0])
+    r1 = t1.dot(t2)
+    r2 = t1.dot(t3)
+    assert r1.simplify() == cos(1/50)
+    assert r2.simplify() == sin(3/50)
 
 def test_exptrigsimp():
     def valid(a, b):

--- a/sympy/simplify/trigsimp.py
+++ b/sympy/simplify/trigsimp.py
@@ -1143,8 +1143,8 @@ def _futrig(e, **kwargs):
         lambda x: _eapply(factor, x, trigs),
         TR14,  # factored powers of identities
         [identity, lambda x: _eapply(_mexpand, x, trigs)],
-        TRmorrie,
         TR10i,  # sin-cos products > sin-cos of sums
+        TRmorrie,
         [identity, TR8],  # sin-cos products -> sin-cos of sums
         [identity, lambda x: TR2i(TR2(x))],  # tan -> sin-cos -> tan
         [


### PR DESCRIPTION
simplify : Fix order of TR10i and TRmorrie in trgsimp.py 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15129 

#### Brief description of what is fixed or changed
In some cases , `.simplify()`  failed to simplify trigonometric expressions .
Examples : 
`
t1 = Matrix([sin(Rational(1, 50)), cos(Rational(1, 50)), 0]
`
`
t2 = Matrix([sin(Rational(1, 25)), cos(Rational(1, 25)), 0])
`
`
r = t1.dot(t2)`
gives 
output :
`
sin(1/50)*sin(1/25) + cos(1/50)*cos(1/25)
`
as mentioned in [#15129](https://github.com/sympy/sympy/issues/15129) .
This patch changes the order of `TR10i` and `TRmorrie` in 'trigsimp.py' as
the order was blamed in [#15129](https://github.com/sympy/sympy/issues/15129).
Now all input cases where `.simplify()' gives wrong output give right output 
as mentioned in [#15129]( https://github.com/sympy/sympy/issues/15129) .
These inputs have been added as a test in `test_trigsimp.py`

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * change order of TR10i and TRmorrie
<!-- END RELEASE NOTES -->
