### PR TITLE
Pass the latex_mode flag of init_printing() through to the latex formatter

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -165,7 +165,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         A function to generate the latex representation of sympy expressions.
         """
         if _can_print_latex(o):
-            s = latex(o, mode='plain', **settings)
+            s = latex(o, mode=latex_mode, **settings)
             s = s.strip('$')
             return '$$%s$$' % s
 

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -88,7 +88,7 @@ def test_print_builtin_option():
                     u'{n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}',
                     "{n_i: 3, pi: 3.14}",
                     u'{\N{GREEK SMALL LETTER PI}: 3.14, n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3}')
-    assert latex == r'$$\left \{ n_{i} : 3, \quad \pi : 3.14\right \}$$'
+    assert latex == r'$$\begin{equation*}\left \{ n_{i} : 3, \quad \pi : 3.14\right \}\end{equation*}$$'
 
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
     app.run_cell("init_printing(use_latex=True, print_builtin=False)")
@@ -135,7 +135,7 @@ def test_builtin_containers():
 ([ ],)
  [2]  \
 """
-        assert app.user_ns['c']['text/latex'] == '$$\\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )$$'
+        assert app.user_ns['c']['text/latex'] == '$$\\begin{equation*}\\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )\\end{equation*}$$'
     else:
         assert app.user_ns['a'][0]['text/plain'] ==  '(True, False)'
         assert 'text/latex' not in app.user_ns['a'][0]
@@ -147,7 +147,7 @@ def test_builtin_containers():
 ([ ],)
  [2]  \
 """
-        assert app.user_ns['c'][0]['text/latex'] == '$$\\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )$$'
+        assert app.user_ns['c'][0]['text/latex'] == '$$\\begin{equation*}\\left ( \\left[\\begin{matrix}1\\\\2\\end{matrix}\\right]\\right )\\end{equation*}$$'
 
 def test_matplotlib_bad_latex():
     # Initialize and setup IPython session


### PR DESCRIPTION
This also has the effect of making the default mode 'equation*', instead of
'plain'. This mode was already being used for the png formatter, and it seems
more appropriate for the notebook, as it does large equation formatting. For
instance, integration limits are rendered above and below the integral sign
with equation*, whereas with plain they are rendered to the right of the
integral sign.

Example:

<img width="605" alt="screen shot 2018-10-09 at 2 15 43 pm" src="https://user-images.githubusercontent.com/71486/46695909-086f1800-cbce-11e8-8297-2476b1588a7c.png">

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* interactive
  * The latex_mode flag of init_printing() now works in the notebook
  * The default latex_mode in the notebook is now `'equation*'` (previously it was `'plain'`). This makes some expressions, such as definite integrals, render slightly larger.
<!-- END RELEASE NOTES -->
