### PR TITLE
Enable Jupyter LaTeX formatting by default

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -411,6 +411,24 @@ class Basic(with_metaclass(ManagedProperties)):
         from sympy.printing import sstr
         return sstr(self, order=None)
 
+    # We don't define _repr_png_ here because it would add a large amount of
+    # data to any notebook containing SymPy expressions, without adding
+    # anything useful to the notebook. It can still enabled manually, e.g.,
+    # for the qtconsole, with init_printing().
+    def _repr_latex_(self):
+        """
+        IPython/Jupyter LaTeX printing
+
+        To change the behavior of this (e.g., pass in some settings to LaTeX),
+        use init_printing(). init_printing() will also enable LaTeX printing
+        for built in numeric types like ints and container types that contain
+        SymPy objects, like lists and dictionaries of expressions.
+        """
+        from sympy.printing.latex import latex
+        s = latex(self, mode='equation*')
+        s = s.strip('$')
+        return "$$%s$$" % s
+
     def atoms(self, *types):
         """Returns the atoms that form the current object.
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -429,6 +429,8 @@ class Basic(with_metaclass(ManagedProperties)):
         s = s.strip('$')
         return "$$%s$$" % s
 
+    _repr_latex_orig = _repr_latex_
+
     def atoms(self, *types):
         """Returns the atoms that form the current object.
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -224,6 +224,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             debug("init_printing: using mathjax formatter")
             for cls in printable_types:
                 latex_formatter.for_type(cls, _print_latex_text)
+            Basic._repr_latex_ = Basic._repr_latex_orig
+            MatrixBase._repr_latex_ = MatrixBase._repr_latex_orig
         else:
             debug("init_printing: not using text/latex formatter")
             for cls in printable_types:
@@ -231,6 +233,9 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                 #latex_formatter.for_type(cls, None)
                 if cls in latex_formatter.type_printers:
                     latex_formatter.type_printers.pop(cls)
+
+            Basic._repr_latex_ = None
+            MatrixBase._repr_latex_ = None
 
     else:
         ip.set_hook('result_display', _result_display)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -96,6 +96,16 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             debug('matplotlib exception caught:', repr(e))
             return None
 
+
+    from sympy import Basic
+    from sympy.matrices import MatrixBase
+    from sympy.physics.vector import Vector, Dyadic
+    from sympy.tensor.array import NDimArray
+
+    # These should all have _repr_latex_ and _repr_latex_orig. If you update
+    # this also update printable_types below.
+    sympy_latex_types = (Basic, MatrixBase, Vector, Dyadic, NDimArray)
+
     def _can_print_latex(o):
         """Return True if type o can be printed with LaTeX.
 
@@ -104,10 +114,6 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         """
 
         try:
-            from sympy import Basic
-            from sympy.matrices import MatrixBase
-            from sympy.physics.vector import Vector, Dyadic
-            from sympy.tensor.array import NDimArray
             # If you're adding another type, make sure you add it to printable_types
             # later in this file as well
 
@@ -125,7 +131,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                 return False
             # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
             # to use here, than these explicit imports.
-            elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic, NDimArray)):
+            elif isinstance(o, sympy_latex_types):
                 return True
             elif isinstance(o, (float, integer_types)) and print_builtin:
                 return True
@@ -224,8 +230,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             debug("init_printing: using mathjax formatter")
             for cls in printable_types:
                 latex_formatter.for_type(cls, _print_latex_text)
-            Basic._repr_latex_ = Basic._repr_latex_orig
-            MatrixBase._repr_latex_ = MatrixBase._repr_latex_orig
+            for typ in sympy_latex_types:
+                typ._repr_latex_ = typ._repr_latex_orig
         else:
             debug("init_printing: not using text/latex formatter")
             for cls in printable_types:
@@ -234,8 +240,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                 if cls in latex_formatter.type_printers:
                     latex_formatter.type_printers.pop(cls)
 
-            Basic._repr_latex_ = None
-            MatrixBase._repr_latex_ = None
+            for typ in sympy_latex_types:
+                typ._repr_latex_ = None
 
     else:
         ip.set_hook('result_display', _result_display)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1968,6 +1968,8 @@ class MatrixBase(MatrixDeprecated,
         s = s.strip('$')
         return "$$%s$$" % s
 
+    _repr_latex_orig = _repr_latex_
+
     def __array__(self, dtype=object):
         from .dense import matrix2numpy
         return matrix2numpy(self, dtype=dtype)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1948,6 +1948,26 @@ class MatrixBase(MatrixDeprecated,
 
     __hash__ = None  # Mutable
 
+    # Defined here the same as on Basic.
+
+    # We don't define _repr_png_ here because it would add a large amount of
+    # data to any notebook containing SymPy expressions, without adding
+    # anything useful to the notebook. It can still enabled manually, e.g.,
+    # for the qtconsole, with init_printing().
+    def _repr_latex_(self):
+        """
+        IPython/Jupyter LaTeX printing
+
+        To change the behavior of this (e.g., pass in some settings to LaTeX),
+        use init_printing(). init_printing() will also enable LaTeX printing
+        for built in numeric types like ints and container types that contain
+        SymPy objects, like lists and dictionaries of expressions.
+        """
+        from sympy.printing.latex import latex
+        s = latex(self, mode='equation*')
+        s = s.strip('$')
+        return "$$%s$$" % s
+
     def __array__(self, dtype=object):
         from .dense import matrix2numpy
         return matrix2numpy(self, dtype=dtype)

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -373,6 +373,26 @@ class Dyadic(object):
             ol += v[0] * (v[1] | (v[2] ^ other))
         return ol
 
+    # We don't define _repr_png_ here because it would add a large amount of
+    # data to any notebook containing SymPy expressions, without adding
+    # anything useful to the notebook. It can still enabled manually, e.g.,
+    # for the qtconsole, with init_printing().
+    def _repr_latex_(self):
+        """
+        IPython/Jupyter LaTeX printing
+
+        To change the behavior of this (e.g., pass in some settings to LaTeX),
+        use init_printing(). init_printing() will also enable LaTeX printing
+        for built in numeric types like ints and container types that contain
+        SymPy objects, like lists and dictionaries of expressions.
+        """
+        from sympy.printing.latex import latex
+        s = latex(self, mode='equation*')
+        s = s.strip('$')
+        return "$$%s$$" % s
+
+    _repr_latex_orig = _repr_latex_
+
     _sympystr = __str__
     _sympyrepr = _sympystr
     __repr__ = __str__

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -448,6 +448,27 @@ class Vector(object):
             outlist += _det(tempm).args
         return Vector(outlist)
 
+
+    # We don't define _repr_png_ here because it would add a large amount of
+    # data to any notebook containing SymPy expressions, without adding
+    # anything useful to the notebook. It can still enabled manually, e.g.,
+    # for the qtconsole, with init_printing().
+    def _repr_latex_(self):
+        """
+        IPython/Jupyter LaTeX printing
+
+        To change the behavior of this (e.g., pass in some settings to LaTeX),
+        use init_printing(). init_printing() will also enable LaTeX printing
+        for built in numeric types like ints and container types that contain
+        SymPy objects, like lists and dictionaries of expressions.
+        """
+        from sympy.printing.latex import latex
+        s = latex(self, mode='equation*')
+        s = s.strip('$')
+        return "$$%s$$" % s
+
+    _repr_latex_orig = _repr_latex_
+
     _sympystr = __str__
     _sympyrepr = _sympystr
     __repr__ = __str__

--- a/sympy/tensor/array/ndim_array.py
+++ b/sympy/tensor/array/ndim_array.py
@@ -291,6 +291,26 @@ class NDimArray(object):
     def __repr__(self):
         return self.__str__()
 
+    # We don't define _repr_png_ here because it would add a large amount of
+    # data to any notebook containing SymPy expressions, without adding
+    # anything useful to the notebook. It can still enabled manually, e.g.,
+    # for the qtconsole, with init_printing().
+    def _repr_latex_(self):
+        """
+        IPython/Jupyter LaTeX printing
+
+        To change the behavior of this (e.g., pass in some settings to LaTeX),
+        use init_printing(). init_printing() will also enable LaTeX printing
+        for built in numeric types like ints and container types that contain
+        SymPy objects, like lists and dictionaries of expressions.
+        """
+        from sympy.printing.latex import latex
+        s = latex(self, mode='equation*')
+        s = s.strip('$')
+        return "$$%s$$" % s
+
+    _repr_latex_orig = _repr_latex_
+
     def tolist(self):
         """
         Converting MutableDenseNDimArray to one-dim list


### PR DESCRIPTION
It is still often preferable to use `init_printing()`, however, as this will
also cause builtin numeric types like int to format as LaTeX, as well as
container types like lists and dicts that contain SymPy objects.
`init_printing()` can also be used to change the LaTeX settings, like setting a
custom printer (`init_printing()` overrides the default `_repr_latex_`).

I did not add `_repr_png_` because it would add a large amount of data to any
notebook containing SymPy expressions, and it is only useful in the qtconsole.
`init_printing()` can still be used to get png LaTeX printing.

I have used `'equation*'` here, c.f. #15367.
If we decide to not change the default from `'plain'` to `'equation*'` in that
pull request, we should change that here too.

I was not able to find a way to test this. The IPython printing tests seem to
not render LaTeX at all unless `init_printing()` is used (even if I do
`inst.display_formatter.formatters['text/latex'].enabled = True`).

Fixes #7003.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* interactive
  * SymPy objects now render as LaTeX automatically in the Jupyter notebook. `init_printing()` is still required to make Python builtin numeric types (such as `int` and `float`) render as LaTeX, Python container types (such as `list` and `dict`) containing SymPy objects render as LaTeX, to change the printer settings, or to get LaTeX printing in the qtconsole. 
<!-- END RELEASE NOTES -->
