### PR TITLE
restore 1.0 subs behavior wrt new

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -871,21 +871,18 @@ class Basic(with_metaclass(ManagedProperties)):
             raise ValueError("subs accepts either 1 or 2 arguments")
 
         sequence = list(sequence)
-        for i in range(len(sequence)):
-            s = list(sequence[i])
-            for j, si in enumerate(s):
-                try:
-                    si = sympify(si, strict=True)
-                except SympifyError:
-                    if type(si) is str:
-                        si = Symbol(si)
-                    else:
-                        # if it can't be sympified, skip it
-                        sequence[i] = None
-                        break
-                s[j] = si
-            else:
-                sequence[i] = None if _aresame(*s) else tuple(s)
+        for i, s in enumerate(sequence):
+            if type(s[0]) is str:
+                # when old is a string we prefer Symbol
+                s = Symbol(s[0]), s[1]
+            try:
+                s = [sympify(_, strict=type(_) is not str) for _ in s]
+            except SympifyError:
+                # if it can't be sympified, skip it
+                sequence[i] = None
+                continue
+            # skip if there is no change
+            sequence[i] = None if _aresame(*s) else tuple(s)
         sequence = list(filter(None, sequence))
 
         if unordered:

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -112,6 +112,10 @@ def test_subs():
 
     raises(ValueError, lambda: b21.subs('bad arg'))
     raises(ValueError, lambda: b21.subs(b1, b2, b3))
+    # dict(b1=foo) creates a string 'b1' but leaves foo unchanged; subs
+    # will convert the first to a symbol but will raise an error if foo
+    # cannot be sympified; sympification is strict if foo is not string
+    raises(ValueError, lambda: b21.subs(b1='bad arg'))
 
 
 def test_atoms():

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -804,3 +804,9 @@ def test_Subs_subs():
     g = Function('g')
     assert Subs(2*f(x, y) + g(x), f(x, y), 1).subs(y, 2) == Subs(
         2*f(x, y) + g(x), (f(x, y), y), (1, 2))
+
+
+def test_issue_13333():
+    eq = 1/x
+    assert eq.subs(dict(x='1/2')) == 2
+    assert eq.subs(dict(x='(1/2)')) == 2


### PR DESCRIPTION


<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
closes #13734 
fixes #13333
fixes #13654

#### Brief description of what is fixed or changed


#### Other comments
For foo.subs(old, new):

The 1.0 behavior of subs would sympify both old and new.
The new bahvior is to sympify strictly anything that is
not a string, but to convert 'old' to Symbol if it is a
string and convert 'new' to an expression, if possible.


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * the new part of subs args are now sympified as in 1.0

<!-- END RELEASE NOTES -->
