### PR TITLE
Reverted changes to code printer due to performance issues.

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -291,9 +291,8 @@ class C89CodePrinter(CodePrinter):
     def _print_Mod(self, expr):
         num, den = expr.args
         if num.is_integer and den.is_integer:
-            template = "(({}) % ({}))"
-            return template.format(self._print(num), self._print(den))
-        elif not num.is_integer or not den.is_integer:
+            return "(({}) % ({}))".format(self._print(num), self._print(den))
+        else:
             return self._print_math_func(expr, known='fmod')
 
     def _print_Rational(self, expr):

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -373,12 +373,9 @@ class CodePrinter(StrPrinter):
                         break
             if func is not None:
                 try:
-                    return func(self, *[self.parenthesize(item, 0) for item in expr.args])
+                    return func(*[self.parenthesize(item, 0) for item in expr.args])
                 except TypeError:
-                    try:
-                        return func(*[self.parenthesize(item, 0) for item in expr.args])
-                    except TypeError:
-                        return "%s(%s)" % (func, self.stringify(expr.args, ", "))
+                    return "%s(%s)" % (func, self.stringify(expr.args, ", "))
         elif hasattr(expr, '_imp_') and isinstance(expr._imp_, Lambda):
             # inlined function
             return self._print(expr._imp_(*expr.args))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15377

#### Brief description of what is fixed or changed

The C code printer was changed in #13692 to support the Mod function by
including a set of lambda statements in known_function. This required
many more recursions in the printer, slowing things considerably for
function printing. Some of that change has been reverted and the printer
now uses a _print_Mod to handle the logic.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Improved performance of function printing in the code printers.

<!-- END RELEASE NOTES -->
