### PR TITLE
Partially reverts backwards incompatible changes made in PR 13641

### DIFF
--- a/doc/src/modules/physics/mechanics/examples/rollingdisc_example_lagrange.rst
+++ b/doc/src/modules/physics/mechanics/examples/rollingdisc_example_lagrange.rst
@@ -56,14 +56,12 @@ accelerations(q double dots) with the ``rhs`` method. ::
   >>> q = [q1, q2, q3]
   >>> l = LagrangesMethod(Lag, q)
   >>> le = l.form_lagranges_equations()
-  >>> le = le.simplify()
-  >>> le
+  >>> le.simplify(); le
   Matrix([
   [m*r**2*(6*sin(q2)*q3'' + 5*sin(2*q2)*q1'*q2' + 6*cos(q2)*q2'*q3' - 5*cos(2*q2)*q1''/2 + 7*q1''/2)/4],
   [                      m*r*(4*g*sin(q2) - 5*r*sin(2*q2)*q1'**2/2 - 6*r*cos(q2)*q1'*q3' + 5*r*q2'')/4],
   [                                                 3*m*r**2*(sin(q2)*q1'' + cos(q2)*q1'*q2' + q3'')/2]])
-  >>> lrhs = l.rhs().simplify()
-  >>> lrhs
+  >>> lrhs = l.rhs(); lrhs.simplify(); lrhs
   Matrix([
   [                                                          q1'],
   [                                                          q2'],

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1706,11 +1706,7 @@ class MatrixCalculus(MatrixCommon):
         integrate
         limit
         """
-        from sympy import Derivative
-        return Derivative(self, *args, evaluate=True)
-
-    def _eval_derivative(self, arg):
-        return self.applyfunc(lambda x: x.diff(arg))
+        return self.applyfunc(lambda x: x.diff(*args))
 
     def _accept_eval_derivative(self, s):
         return s._visit_eval_derivative_array(self)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1706,7 +1706,15 @@ class MatrixCalculus(MatrixCommon):
         integrate
         limit
         """
-        return self.applyfunc(lambda x: x.diff(*args))
+        from sympy import Derivative
+        deriv = Derivative(self, *args, evaluate=True)
+        if not isinstance(self, Basic):
+            return deriv.as_mutable()
+        else:
+            return deriv
+
+    def _eval_derivative(self, arg):
+        return self.applyfunc(lambda x: x.diff(arg))
 
     def _accept_eval_derivative(self, s):
         return s._visit_eval_derivative_array(self)

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1331,9 +1331,11 @@ def test_singular_values():
 
 
 # CalculusOnlyMatrix tests
+@XFAIL
 def test_diff():
     x, y = symbols('x y')
     m = CalculusOnlyMatrix(2, 1, [x, y])
+    # TODO: currently not working as ``_MinimalMatrix`` cannot be sympified:
     assert m.diff(x) == Matrix(2, 1, [1, 0])
 
 def test_integrate():

--- a/sympy/matrices/tests/test_commonmatrix.py
+++ b/sympy/matrices/tests/test_commonmatrix.py
@@ -1331,11 +1331,9 @@ def test_singular_values():
 
 
 # CalculusOnlyMatrix tests
-@XFAIL
 def test_diff():
     x, y = symbols('x y')
     m = CalculusOnlyMatrix(2, 1, [x, y])
-    # TODO: currently not working as ``_MinimalMatrix`` cannot be sympified:
     assert m.diff(x) == Matrix(2, 1, [1, 0])
 
 def test_integrate():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1944,6 +1944,10 @@ def test_diff():
     assert diff(A_imm, x) == ImmutableDenseMatrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
     assert diff(A_imm, y) == ImmutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
 
+
+@XFAIL
+def test_diff_by_matrix():
+
     # Derive matrix by matrix:
 
     A = MutableDenseMatrix([[x, y], [z, t]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1947,7 +1947,6 @@ def test_diff():
     assert diff(A_imm, y) == ImmutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
 
 
-@XFAIL
 def test_diff_by_matrix():
 
     # Derive matrix by matrix:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1931,6 +1931,7 @@ def test_limit():
 
 def test_diff():
     A = MutableDenseMatrix(((1, 4, x), (y, 2, 4), (10, 5, x**2 + 1)))
+    assert isinstance(A.diff(x), type(A))
     assert A.diff(x) == MutableDenseMatrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
     assert A.diff(y) == MutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
 
@@ -1938,6 +1939,7 @@ def test_diff():
     assert diff(A, y) == MutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
 
     A_imm = A.as_immutable()
+    assert isinstance(A_imm.diff(x), type(A_imm))
     assert A_imm.diff(x) == ImmutableDenseMatrix(((0, 0, 1), (0, 0, 0), (0, 0, 2*x)))
     assert A_imm.diff(y) == ImmutableDenseMatrix(((0, 0, 0), (1, 0, 0), (0, 0, 0)))
 

--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -216,11 +216,11 @@ def test_rolling_disc():
     q3 = Function('q3')
     l = LagrangesMethod(Lag, q)
     l.form_lagranges_equations()
-    RHS = l.rhs().as_mutable()
+    RHS = l.rhs()
     RHS.simplify()
     t = symbols('t')
 
-    assert tuple(l.mass_matrix[3:6]) == (0, 5*m*r**2/4, 0)
+    assert (l.mass_matrix[3:6] == [0, 5*m*r**2/4, 0])
     assert RHS[4].simplify() == (
         (-8*g*sin(q2(t)) + r*(5*sin(2*q2(t))*Derivative(q1(t), t) +
         12*cos(q2(t))*Derivative(q3(t), t))*Derivative(q1(t), t))/(10*r))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Partially reverts #13641 

Fixes #14958 

#### Brief description of what is fixed or changed

    Reverts backwards incompatible changes to Matrix.diff()
    
    PR #13641 introduced a new feature: differentiating Matrices by Matrices
    and Arrays. To do this, three existing tests were changed, breaking
    backwards compatibility. The changes to the code caused
    MutableDenseMatrix.diff() to return an ImmutableDenseMatrix. This breaks
    user code that relies on the mutability of the matrices. In particular,
    it has large effects to the sympy.physics.mechanics code that relies
    heavily on matrix differentiation. This PR reverts the three changed
    tests, reverts the change to MatrixCalculus.diff() that causes the type
    change, and moves all subsequent tests related to differentiating
    Matrices with respect to Matrices/Array/etc into an XFAIL test, as they
    are now broken.


#### Other comments

This should be applied as a bugfix patch to SymPy 1.2 and 1.3.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
  * Reverts backwards incompatible change introduced in SymPy 1.2 and 1.3 for matrix differentiation and moves Matrix by Matrix differentiation to expected to fail.

<!-- END RELEASE NOTES -->
