### PR TITLE
Fixed autowrap helpers regression.

### DIFF
--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -149,7 +149,7 @@ def runtest_issue_15337(language, backend):
     # the kwarg "helpers", but in issue 10274 the user mistakenly thought that
     # if there was only a single helper it did not need to be passed via an
     # iterable that wrapped the helper tuple. There were no tests for this
-    # behavior so when the code was changed to accept a single tuple it broken
+    # behavior so when the code was changed to accept a single tuple it broke
     # the original behavior. These tests below ensure that both now work.
     a, b, c, d, e = symbols('a, b, c, d, e')
     expr = (a - b + c - d + e)**13

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -556,11 +556,12 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
         helpful for debugging.
     helpers : 3-tuple or iterable of 3-tuples, optional
         Used to define auxiliary expressions needed for the main expr. If the
-        main expression needs to call a specialized function it should be pass
-        in via ``helpers``. Autowrap will then make sure that the compiled main
-        expression can link to the helper routine. Items should be 3-tuples
-        with (<function_name>, <sympy_expression>, <argument tuple>). It is
-        mandatory to supply an argument sequence to helper routines.
+        main expression needs to call a specialized function it should be
+        passed in via ``helpers``. Autowrap will then make sure that the
+        compiled main expression can link to the helper routine. Items should
+        be 3-tuples with (<function_name>, <sympy_expression>,
+        <argument_tuple>). It is mandatory to supply an argument sequence to
+        helper routines.
     code_gen : CodeGen instance
         An instance of a CodeGen subclass. Overrides ``language``.
     include_dirs : [string]

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -554,13 +554,13 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
     verbose : bool, optional
         If True, autowrap will not mute the command line backends. This can be
         helpful for debugging.
-    helpers : iterable, optional
+    helpers : 3-tuple or iterable of 3-tuples, optional
         Used to define auxiliary expressions needed for the main expr. If the
-        main expression needs to call a specialized function it should be put
-        in the ``helpers`` iterable. Autowrap will then make sure that the
-        compiled main expression can link to the helper routine. Items should
-        be tuples with (<funtion_name>, <sympy_expression>, <arguments>). It
-        is mandatory to supply an argument sequence to helper routines.
+        main expression needs to call a specialized function it should be pass
+        in via ``helpers``. Autowrap will then make sure that the compiled main
+        expression can link to the helper routine. Items should be 3-tuples
+        with (<function_name>, <sympy_expression>, <argument tuple>). It is
+        mandatory to supply an argument sequence to helper routines.
     code_gen : CodeGen instance
         An instance of a CodeGen subclass. Overrides ``language``.
     include_dirs : [string]
@@ -596,7 +596,12 @@ def autowrap(expr, language=None, backend='f2py', tempdir=None, args=None,
     else:
         language = _infer_language(backend)
 
-    helpers = [helpers] if helpers else ()
+    # two cases 1) helpers is an iterable of 3-tuples and 2) helpers is a
+    # 3-tuple
+    if iterable(helpers) and len(helpers) != 0 and iterable(helpers[0]):
+        helpers = helpers if helpers else ()
+    else:
+        helpers = [helpers] if helpers else ()
     args = list(args) if iterable(args, exclude=set) else args
 
     if code_gen is None:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15337

#### Brief description of what is fixed or changed

The helpers kwarg in autowrap originally supported passing in an
iterable of 3-tuples. In PR #10282 this was changed to support only
passing in a single 3-tuple. This PR brings back the original behavior
which was broken by #10282 and support the single 3-tuple case also.

#### Other comments

This is a bug fix that should technically be applied to SymPy 1.0 through SymPy 1.3.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* utilities
  * Fixed regression with autowrap helpers kwarg.

<!-- END RELEASE NOTES -->
