### PR TITLE
Matrix.dot can now calculate dot product between two complex vectors

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2655,7 +2655,7 @@ class MatrixBase(MatrixDeprecated,
 
         if conjugate_convention is not None and hermitian is None:
             hermitian = True
-        if hermitian == True and conjugate_convention is None:
+        if hermitian and conjugate_convention is None:
             conjugate_convention = "maths"
 
         if hermitian == True:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2664,13 +2664,14 @@ class MatrixBase(MatrixDeprecated,
 
         if hermitian == True:
             if conjugate_convention in ("maths", "left", "math"):
-                return (mat.conjugate()*b)[0]
+                mat = mat.conjugate()
             elif conjugate_convention in ("physics", "right"):
-                return (mat*b.conjugate())[0]
+                b = b.conjugate()
             else:
-                raise ValueError("Invalid conjugate_convention is entered.")
-        else:
-            return (mat * b)[0]
+                raise ValueError("Unknown conjugate_convention was entered."
+                                 " conjugate_convention must be one of the"
+                                 " following: math, maths, left, physics or right.")
+        return (mat * b)[0]
 
     def dual(self):
         """Returns the dual of a matrix, which is:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2565,12 +2565,12 @@ class MatrixBase(MatrixDeprecated,
         """Return the dot product of two vectors of equal length. ``self`` must
         be a ``Matrix`` of size 1 x n or n x 1, and ``b`` must be either a
         matrix of size 1 x n, n x 1, or a list/tuple of length n. A scalar is returned.
-		
-		In case one or both of the vector is complex then we need to calculate the inner product 
-		of the two vectors. To calculate the inner product we call the inner_product function. 
 
-        The expected kwargs are hermitian and conjugate_convention. Hermitian takes two True or False 
-        depending on wether dot product is to be calculated or inner product is to be used. 
+        In case one or both of the vector is complex then we need to calculate the inner product
+        of the two vectors. To calculate the inner product we call the inner_product function.
+
+        The expected kwargs are hermitian and conjugate_convention. Hermitian takes two True or False
+        depending on wether dot product is to be calculated or inner product is to be used.
         conjugate_convention has basically two inputs ("maths", "left", "math") or ("physics", "right").
         conjugate_convention is used to  determine which convention is to be followed when calculating the inner product.
 
@@ -2587,16 +2587,16 @@ class MatrixBase(MatrixDeprecated,
         >>> v = [3, 2, 1]
         >>> M.row(0).dot(v)
         10
-		
-		>>> v.dot(v, hermitian = False)
+        >>> q = Matrix([1j, 1j, 1j])
+        >>> q.dot(q, hermitian = False)
         -3.00000000000000
 
-        >>> v.dot(v, hermitian = True)
+        >>> q.dot(q, hermitian = True)
         3.00000000000000
 
         See Also
         ========
-		inner_product
+        inner_product
         cross
         multiply
         multiply_elementwise
@@ -2631,37 +2631,36 @@ class MatrixBase(MatrixDeprecated,
         if b.shape != (n, 1):
             b = b.reshape(n, 1)
 
-
         """ Retrive the calue of hermitian and conjugate_convention from kwargs.
-        If it so happens that only conjugate_convention is passed then automatically set 
+        If it so happens that only conjugate_convention is passed then automatically set
         hermitian to True. If only hermitian is true but no conjugate_convention is not passed
         then automatically set it to "maths"
-      	"""
+        """
 
         hermitian = kwargs.get("hermitian")
         conjugate_convention = kwargs.get("conjugate_convention")
-        
+
         if(conjugate_convention != None and hermitian == None):
-        	hermitian = True
+            hermitian = True
         if(hermitian == True and conjugate_convention == None):
-        	conjugate_convention = "maths"
+            conjugate_convention = "maths"
 
         if(hermitian == True):
             return mat.inner_product(b, conjugate_convention)
-       	elif(hermitian == False):
-       		return (mat*b)[0]
-       	else:
-       		warning_to_print =  "Warning: taking the non-Hermitian dot product of complex vectors. To suppress this warning, explicitly set hermitian=False."
-	        if mat.is_symbolic() == True:
-	            if b.is_symbolic() == False and b.conjugate() != b:
-	                print(warning_to_print)
-	        else:
-	            if b.is_symbolic() == True:
-	                if mat.conjugate() != mat:
-	                    print(warning_to_print)
-	            else:
-	                if b.conjugate() != b or mat.conjugate() != mat:
-	                    print(warning_to_print)
+        elif(hermitian == False):
+            return (mat*b)[0]
+        else:
+            warning_to_print =  "Warning: taking the non-Hermitian dot product of complex vectors. To suppress this warning, explicitly set hermitian=False."
+            if mat.is_symbolic() == True:
+                if b.is_symbolic() == False and b.conjugate() != b:
+                    print(warning_to_print)
+            else:
+                if b.is_symbolic() == True:
+                    if mat.conjugate() != mat:
+                        print(warning_to_print)
+                else:
+                    if b.conjugate() != b or mat.conjugate() != mat:
+                        print(warning_to_print)
 
         return (mat * b)[0]
 
@@ -2882,25 +2881,24 @@ class MatrixBase(MatrixDeprecated,
             return sol, tau
 
     def inner_product(self, b, conjugate_convention):
-    	""" Used to calculate the inner_product if hermitian flag is set to True in the dot function.
-    	If conjugate_convention is ("maths", "left", "math") then conjugate the first matrix, conversely
-    	if conjugate_convention is ("physics", "right") then conjugate the second matrix. 
-    	
-		See Also
-		===
+        """ Used to calculate the inner_product if hermitian flag is set to True in the dot function.
+        If conjugate_convention is ("maths", "left", "math") then conjugate the first matrix, conversely
+        if conjugate_convention is ("physics", "right") then conjugate the second matrix.
 
-		dot
-    	"""
-    	
-    	mat = self
+        See Also
+        ===
 
-    	if conjugate_convention in ("maths", "left", "math"):
-    		return (mat.conjugate()*b)[0]
-    	elif conjugate_convention in ("physics", "right"):
-    		return (mat*b.conjugate())[0]
-    	else:
-    		print("Invalid conjugate_convention is entered.")
-        
+        dot
+        """
+
+        mat = self
+
+        if conjugate_convention in ("maths", "left", "math"):
+            return (mat.conjugate()*b)[0]
+        elif conjugate_convention in ("physics", "right"):
+            return (mat*b.conjugate())[0]
+        else:
+            print("Invalid conjugate_convention is entered.")
 
     def inv_mod(self, m):
         r"""

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2562,28 +2562,27 @@ class MatrixBase(MatrixDeprecated,
         return self._diagonal_solve(rhs)
 
     def dot(self, b, hermitian=None, conjugate_convention=None):
-        """Return the dot product of two vectors of equal length. ``self``
-        must be a ``Matrix`` of size 1 x n or n x 1, and ``b`` must be
-        either a matrix of size 1 x n, n x 1, or a list/tuple of length n.
+        """Return the dot or inner product of two vectors of equal length.
+        Here ``self`` must be a ``Matrix`` of size 1 x n or n x 1, and ``b``
+        must be either a matrix of size 1 x n, n x 1, or a list/tuple of length n.
         A scalar is returned.
 
         In case one or both of the vectors are complex and the hermitian
-        flag is set to true we need to calculate the hermitian inner
+        flag is set to ``True`` this will calculate the hermitian inner
         product of the two vectors.
 
-        The expected kwargs are hermitian and conjugate_convention.
+        Possible kwargs are hermitian and conjugate_convention.
         Hermitian takes argument as either True or False depending on
         whether dot product is to be calculated or hermitian inner
         product is to be calculated.
 
         Conjugate_convention takes one argument as input. The accepted
-        arguments are: "maths", "left", "math", "physics" or "right".
-        "maths", "math" or "left" all correspond to the same convention
+        arguments are: ``"maths"`` ,``"math"`` ,``"left"`` ,``"physics"``
+        or ``"right"``.
+        ``"maths"``, ``"math"`` or ``"left"`` all correspond to the same convention
         in which hermitian of the first vector is used.
-        i.e. (a.conjugate() * b)[0]
-        "physics" or "right" both correspond to the same convention in
+        ``"physics"`` or ``"right"`` both correspond to the same convention in
         which hermitian of the second vector is used.
-        i.e. (a * b.conjugate())[0]
 
         Examples
         ========
@@ -2616,6 +2615,7 @@ class MatrixBase(MatrixDeprecated,
 
         See Also
         ========
+
         cross
         multiply
         multiply_elementwise
@@ -2655,11 +2655,11 @@ class MatrixBase(MatrixDeprecated,
         # If it so happens that only conjugate_convention is passed
         # then automatically set hermitian to True. If only hermitian
         # is true but no conjugate_convention is not passed then
-        # automatically set it to "maths"
+        # automatically set it to ``"maths"``
 
-        if (conjugate_convention is not None) and (hermitian is None):
+        if conjugate_convention is not None and hermitian is None:
             hermitian = True
-        if (hermitian == True) and (conjugate_convention is None):
+        if hermitian == True and conjugate_convention is None:
             conjugate_convention = "maths"
 
         if hermitian == True:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2578,7 +2578,7 @@ class MatrixBase(MatrixDeprecated,
 
         If ``conjugate_convention`` is ``"left"``, ``"math"`` or ``"maths"``,
         the conjugate of the first vector (``self``) is used.  If ``"right"``
-        or ``"right"``.
+        or ``"physics"`` is specified, the conjugate of the second vector ``b`` is used.
         ``"maths"``, ``"math"`` or ``"left"`` all correspond to the same convention
         in which hermitian of the first vector is used.
         ``"physics"`` or ``"right"`` both correspond to the same convention in

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2598,18 +2598,21 @@ class MatrixBase(MatrixDeprecated,
         >>> v = [3, 2, 1]
         >>> M.row(0).dot(v)
         10
-        >>> q = Matrix([1j, 1j, 1j])
+
+        >>> from sympy import I
+        >>> q = Matrix([1*I, 1*I, 1*I])
         >>> q.dot(q, hermitian=False)
-        -3.00000000000000
+        -3
 
         >>> q.dot(q, hermitian=True)
-        3.00000000000000
+        3
 
-        >>> q1 = Matrix([1, 1, 1j])
+        >>> q1 = Matrix([1, 1, 1*I])
         >>> q.dot(q1, hermitian=True, conjugate_convention="maths")
-        1.0 - 2.0*I
+        1 - 2*I
         >>> q.dot(q1, hermitian=True, conjugate_convention="physics")
-        1.0 + 2.0*I
+        1 + 2*I
+
 
         See Also
         ========
@@ -2654,9 +2657,9 @@ class MatrixBase(MatrixDeprecated,
         # is true but no conjugate_convention is not passed then
         # automatically set it to "maths"
 
-        if (conjugate_convention != None) and (hermitian == None):
+        if (conjugate_convention is not None) and (hermitian is None):
             hermitian = True
-        if (hermitian == True) and (conjugate_convention == None):
+        if (hermitian == True) and (conjugate_convention is None):
             conjugate_convention = "maths"
 
         if hermitian == True:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2567,14 +2567,11 @@ class MatrixBase(MatrixDeprecated,
         must be either a matrix of size 1 x n, n x 1, or a list/tuple of length n.
         A scalar is returned.
 
-        In case one or both of the vectors are complex and the hermitian
-        flag is set to ``True`` this will calculate the hermitian inner
-        product of the two vectors.
+        By default, ``dot`` does not conjugate ``self`` or ``b``, even if there are
+        complex entries. Set ``hermitian=True`` (and optionally a ``conjugate_convention``)
+        to compute the hermitian inner product.
 
-        Possible kwargs are hermitian and conjugate_convention.
-        Hermitian takes argument as either True or False depending on
-        whether dot product is to be calculated or hermitian inner
-        product is to be calculated.
+        Possible kwargs are ``hermitian`` and ``conjugate_convention``.
 
         If ``conjugate_convention`` is ``"left"``, ``"math"`` or ``"maths"``,
         the conjugate of the first vector (``self``) is used.  If ``"right"``

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2579,7 +2579,6 @@ class MatrixBase(MatrixDeprecated,
         If ``conjugate_convention`` is ``"left"``, ``"math"`` or ``"maths"``,
         the conjugate of the first vector (``self``) is used.  If ``"right"``
         or ``"physics"`` is specified, the conjugate of the second vector ``b`` is used.
-        ``"maths"``, ``"math"`` or ``"left"`` all correspond to the same convention
         ``"physics"`` or ``"right"`` both correspond to the same convention in
         which hermitian of the second vector is used.
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2577,7 +2577,7 @@ class MatrixBase(MatrixDeprecated,
         product is to be calculated.
 
         If ``conjugate_convention`` is ``"left"``, ``"math"`` or ``"maths"``,
-        arguments are: ``"maths"`` ,``"math"`` ,``"left"`` ,``"physics"``
+        the conjugate of the first vector (``self``) is used.  If ``"right"``
         or ``"right"``.
         ``"maths"``, ``"math"`` or ``"left"`` all correspond to the same convention
         in which hermitian of the first vector is used.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2580,7 +2580,6 @@ class MatrixBase(MatrixDeprecated,
         the conjugate of the first vector (``self``) is used.  If ``"right"``
         or ``"physics"`` is specified, the conjugate of the second vector ``b`` is used.
         ``"maths"``, ``"math"`` or ``"left"`` all correspond to the same convention
-        in which hermitian of the first vector is used.
         ``"physics"`` or ``"right"`` both correspond to the same convention in
         which hermitian of the second vector is used.
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2579,7 +2579,6 @@ class MatrixBase(MatrixDeprecated,
         If ``conjugate_convention`` is ``"left"``, ``"math"`` or ``"maths"``,
         the conjugate of the first vector (``self``) is used.  If ``"right"``
         or ``"physics"`` is specified, the conjugate of the second vector ``b`` is used.
-        which hermitian of the second vector is used.
 
         Examples
         ========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2579,7 +2579,6 @@ class MatrixBase(MatrixDeprecated,
         If ``conjugate_convention`` is ``"left"``, ``"math"`` or ``"maths"``,
         the conjugate of the first vector (``self``) is used.  If ``"right"``
         or ``"physics"`` is specified, the conjugate of the second vector ``b`` is used.
-        ``"physics"`` or ``"right"`` both correspond to the same convention in
         which hermitian of the second vector is used.
 
         Examples

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2576,13 +2576,9 @@ class MatrixBase(MatrixDeprecated,
         whether dot product is to be calculated or hermitian inner
         product is to be calculated.
 
-        Conjugate_convention takes one argument as input. The accepted
-        arguments are: ``"maths"`` ,``"math"`` ,``"left"`` ,``"physics"``
-        or ``"right"``.
-        ``"maths"``, ``"math"`` or ``"left"`` all correspond to the same convention
-        in which hermitian of the first vector is used.
-        ``"physics"`` or ``"right"`` both correspond to the same convention in
-        which hermitian of the second vector is used.
+        If ``conjugate_convention`` is ``"left"``, ``"math"`` or ``"maths"``,
+        the conjugate of the first vector (``self``) is used.  If ``"right"``
+        or ``"physics"`` is specified, the conjugate of the second vector ``b`` is used.
 
         Examples
         ========
@@ -2659,7 +2655,7 @@ class MatrixBase(MatrixDeprecated,
 
         if conjugate_convention is not None and hermitian is None:
             hermitian = True
-        if hermitian == True and conjugate_convention is None:
+        if hermitian and conjugate_convention is None:
             conjugate_convention = "maths"
 
         if hermitian == True:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2576,7 +2576,7 @@ class MatrixBase(MatrixDeprecated,
         whether dot product is to be calculated or hermitian inner
         product is to be calculated.
 
-        Conjugate_convention takes one argument as input. The accepted
+        If ``conjugate_convention`` is ``"left"``, ``"math"`` or ``"maths"``,
         arguments are: ``"maths"`` ,``"math"`` ,``"left"`` ,``"physics"``
         or ``"right"``.
         ``"maths"``, ``"math"`` or ``"left"`` all correspond to the same convention

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2503,12 +2503,14 @@ def test_dot():
     assert ones(1, 3).dot(ones(3, 1)) == 3
     assert ones(1, 3).dot([1, 1, 1]) == 3
     assert Matrix([1, 2, 3]).dot(Matrix([1, 2, 3])) == 14
-    assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I])) == -5 + 1*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I])) == -5 + I
     assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I]), hermitian=False) == -5 + I
     assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I]), hermitian=True) == 13 + I
     assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I]), hermitian=True, conjugate_convention="physics") == 13 - I
     assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian=True, conjugate_convention="right") == 4 + 8*I
     assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian=True, conjugate_convention="left") == 4 - 8*I
+    assert Matrix([I, 2*I, 3]).dot(Matrix([I, 2*I, 3]), hermitian=False, conjugate_convention="left") == 4
+    assert Matrix([I, 2*I, 3]).dot(Matrix([I, 2*I, 3]), conjugate_convention="left") == 14
 
 
 def test_dual():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2509,8 +2509,8 @@ def test_dot():
     assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I]), hermitian=True, conjugate_convention="physics") == 13 - I
     assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian=True, conjugate_convention="right") == 4 + 8*I
     assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian=True, conjugate_convention="left") == 4 - 8*I
-    assert Matrix([I, 2*I, 3]).dot(Matrix([I, 2*I, 3]), hermitian=False, conjugate_convention="left") == 4
-    assert Matrix([I, 2*I, 3]).dot(Matrix([I, 2*I, 3]), conjugate_convention="left") == 14
+    assert Matrix([I, 2*I]).dot(Matrix([I, 2*I]), hermitian=False, conjugate_convention="left") == -5
+    assert Matrix([I, 2*I]).dot(Matrix([I, 2*I]), conjugate_convention="left") == 5
 
 
 def test_dual():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2503,6 +2503,12 @@ def test_dot():
     assert ones(1, 3).dot(ones(3, 1)) == 3
     assert ones(1, 3).dot([1, 1, 1]) == 3
     assert Matrix([1, 2, 3]).dot(Matrix([1, 2, 3])) == 14
+    assert Matrix([1, 2, 3*I]).dot(Matrix([1*I, 2, 3*I])) == -5 + 1*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([1*I, 2, 3*I]), hermitian = False) == -5 + 1*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([1*I, 2, 3*I]), hermitian = True) == 13 + 1*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([1*I, 2, 3*I]), hermitian = True, conjugate_convention = "physics") == 13.0 - 1.0*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian = True, conjugate_convention = "right") == 4 + 8*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian = True, conjugate_convention = "left") == 4 - 8*I
 
 
 def test_dual():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2503,12 +2503,12 @@ def test_dot():
     assert ones(1, 3).dot(ones(3, 1)) == 3
     assert ones(1, 3).dot([1, 1, 1]) == 3
     assert Matrix([1, 2, 3]).dot(Matrix([1, 2, 3])) == 14
-    assert Matrix([1, 2, 3*I]).dot(Matrix([1*I, 2, 3*I])) == -5 + 1*I
-    assert Matrix([1, 2, 3*I]).dot(Matrix([1*I, 2, 3*I]), hermitian = False) == -5 + 1*I
-    assert Matrix([1, 2, 3*I]).dot(Matrix([1*I, 2, 3*I]), hermitian = True) == 13 + 1*I
-    assert Matrix([1, 2, 3*I]).dot(Matrix([1*I, 2, 3*I]), hermitian = True, conjugate_convention = "physics") == 13.0 - 1.0*I
-    assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian = True, conjugate_convention = "right") == 4 + 8*I
-    assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian = True, conjugate_convention = "left") == 4 - 8*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I])) == -5 + 1*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I]), hermitian=False) == -5 + I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I]), hermitian=True) == 13 + I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([I, 2, 3*I]), hermitian=True, conjugate_convention="physics") == 13 - I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian=True, conjugate_convention="right") == 4 + 8*I
+    assert Matrix([1, 2, 3*I]).dot(Matrix([4, 5*I, 6]), hermitian=True, conjugate_convention="left") == 4 - 8*I
 
 
 def test_dual():


### PR DESCRIPTION
Changed the dot product function so that it can also calculate the Hermitian inner product

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #14920  

#### Brief description of what is fixed or changed
Changed the dot product function so that it can now calculate Hermitian inner product.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * dot function can also calculate hermitian inner product.
<!-- END RELEASE NOTES -->
