### PR TITLE
Reducing matrix expressions involving transpose and powers

### DIFF
--- a/sympy/discrete/recurrences.py
+++ b/sympy/discrete/recurrences.py
@@ -30,7 +30,7 @@ def linrec(coeffs, init, n):
     Then,
 
     .. math :: y(n) = \begin{cases} b_n & 0 \le n < k \\
-        c_0 y(n-1) + c_1 y(n-2) + \cdots + c_{k-1} y(n-k) & n > k
+        c_0 y(n-1) + c_1 y(n-2) + \cdots + c_{k-1} y(n-k) & n \ge k
         \end{cases}
 
     Let `x_0, x_1, \ldots, x_n` be a sequence and consider the transformation

--- a/sympy/matrices/expressions/determinant.py
+++ b/sympy/matrices/expressions/determinant.py
@@ -9,11 +9,13 @@ class Determinant(Expr):
 
     Represents the determinant of a matrix expression.
 
+    Examples
+    ========
+
     >>> from sympy import MatrixSymbol, Determinant, eye
     >>> A = MatrixSymbol('A', 3, 3)
     >>> Determinant(A)
     Determinant(A)
-
     >>> Determinant(eye(3)).doit()
     1
     """
@@ -41,11 +43,13 @@ class Determinant(Expr):
 def det(matexpr):
     """ Matrix Determinant
 
+    Examples
+    ========
+
     >>> from sympy import MatrixSymbol, det, eye
     >>> A = MatrixSymbol('A', 3, 3)
     >>> det(A)
     Determinant(A)
-
     >>> det(eye(3))
     1
     """

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -18,6 +18,9 @@ class MatAdd(MatrixExpr, AssocOp):
 
     MatAdd inherits from and operates like SymPy Add
 
+    Examples
+    ========
+
     >>> from sympy import MatAdd, MatrixSymbol
     >>> A = MatrixSymbol('A', 5, 5)
     >>> B = MatrixSymbol('B', 5, 5)
@@ -82,6 +85,9 @@ def combine(cnt, mat):
 
 def merge_explicit(matadd):
     """ Merge explicit MatrixBase arguments
+
+    Examples
+    ========
 
     >>> from sympy import MatrixSymbol, eye, Matrix, MatAdd, pprint
     >>> from sympy.matrices.expressions.matadd import merge_explicit

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -132,7 +132,7 @@ class MatrixExpr(Expr):
             return Identity(self.rows)
         elif other is S.One:
             return self
-        return MatPow(self, other).doit()
+        return MatPow(self, other).doit(deep=False)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__pow__')

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -31,7 +31,7 @@ def _sympifyit(arg, retval=None):
 
 
 class MatrixExpr(Expr):
-    """ Superclass for Matrix Expressions
+    """Superclass for Matrix Expressions
 
     MatrixExprs represent abstract matrices, linear transformations represented
     within a particular basis.
@@ -46,11 +46,8 @@ class MatrixExpr(Expr):
 
     See Also
     ========
-        MatrixSymbol
-        MatAdd
-        MatMul
-        Transpose
-        Inverse
+
+    MatrixSymbol, MatAdd, MatMul, Transpose, Inverse
     """
 
     # Should not be considered iterable by the
@@ -648,6 +645,9 @@ class MatrixSymbol(MatrixExpr):
     Creates a SymPy Symbol to represent a Matrix. This matrix has a shape and
     can be included in Matrix Expressions
 
+    Examples
+    ========
+
     >>> from sympy import MatrixSymbol, Identity
     >>> A = MatrixSymbol('A', 3, 4) # A 3 by 4 Matrix
     >>> B = MatrixSymbol('B', 4, 3) # A 4 by 3 Matrix
@@ -665,7 +665,7 @@ class MatrixSymbol(MatrixExpr):
         return obj
 
     def _hashable_content(self):
-        return(self.name, self.shape)
+        return (self.name, self.shape)
 
     @property
     def shape(self):
@@ -681,7 +681,7 @@ class MatrixSymbol(MatrixExpr):
         return MatrixSymbol(self.name, *shape)
 
     def __call__(self, *args):
-        raise TypeError( "%s object is not callable" % self.__class__ )
+        raise TypeError("%s object is not callable" % self.__class__)
 
     def _entry(self, i, j, **kwargs):
         return MatrixElement(self, i, j)
@@ -703,6 +703,9 @@ class MatrixSymbol(MatrixExpr):
 
 class Identity(MatrixExpr):
     """The Matrix Identity I - multiplicative identity
+
+    Examples
+    ========
 
     >>> from sympy.matrices import Identity, MatrixSymbol
     >>> A = MatrixSymbol('A', 3, 5)
@@ -755,10 +758,13 @@ class Identity(MatrixExpr):
 class ZeroMatrix(MatrixExpr):
     """The Matrix Zero 0 - additive identity
 
+    Examples
+    ========
+
     >>> from sympy import MatrixSymbol, ZeroMatrix
     >>> A = MatrixSymbol('A', 3, 5)
     >>> Z = ZeroMatrix(3, 5)
-    >>> A+Z
+    >>> A + Z
     A
     >>> Z*A.T
     0
@@ -771,7 +777,6 @@ class ZeroMatrix(MatrixExpr):
     @property
     def shape(self):
         return (self.args[0], self.args[1])
-
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rpow__')

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -231,8 +231,9 @@ def remove_ids(mul):
     as args.
 
     See Also
-    --------
-        sympy.strategies.rm_id
+    ========
+
+    sympy.strategies.rm_id
     """
     # Separate Exprs from MatrixExprs in args
     factor, mmul = mul.as_coeff_mmul()
@@ -286,7 +287,7 @@ rules = (any_zeros, remove_ids, xxinv, unpack, rm_id(lambda x: x == 1),
 canonicalize = exhaust(typed({MatMul: do_one(*rules)}))
 
 def only_squares(*matrices):
-    """ factor matrices only if they are square """
+    """factor matrices only if they are square"""
     if matrices[0].rows != matrices[-1].cols:
         raise RuntimeError("Invalid matrices being multiplied")
     out = []

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -52,7 +52,7 @@ class MatPow(MatrixExpr):
 
     def doit(self, **kwargs):
         from sympy.matrices.expressions import Inverse
-        deep = kwargs.get('deep', False)
+        deep = kwargs.get('deep', True)
         if deep:
             args = [arg.doit(**kwargs) for arg in self.args]
         else:
@@ -82,9 +82,8 @@ class MatPow(MatrixExpr):
             return Inverse(base).doit(**kwargs)
         elif exp is S.One:
             return base
-        elif isinstance(base, Transpose) and isinstance(base.arg, MatPow):
-            return Transpose(MatPow(base.arg, exp).doit())
-
+        elif isinstance(base, Transpose):
+            return Transpose(MatPow(base.arg, exp).doit(deep=False))
         return MatPow(base, exp)
 
     def _eval_transpose(self):

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from .matexpr import MatrixExpr, ShapeError, Identity, ZeroMatrix
+from .transpose import Transpose
 from sympy.core.sympify import _sympify
 from sympy.core.compatibility import range
 from sympy.matrices import MatrixBase
@@ -51,14 +52,13 @@ class MatPow(MatrixExpr):
 
     def doit(self, **kwargs):
         from sympy.matrices.expressions import Inverse
-        deep = kwargs.get('deep', True)
+        deep = kwargs.get('deep', False)
         if deep:
             args = [arg.doit(**kwargs) for arg in self.args]
         else:
             args = self.args
 
-        base = args[0]
-        exp = args[1]
+        base, exp = args
         # combine all powers, e.g. (A**2)**3 = A**6
         while isinstance(base, MatPow):
             exp = exp*base.args[1]
@@ -69,7 +69,7 @@ class MatPow(MatrixExpr):
                 return base.func(Identity(base.shape[0]))
             return Identity(base.shape[0])
         elif isinstance(base, ZeroMatrix) and exp.is_negative:
-            raise ValueError("Matrix det == 0; not invertible.")
+            raise ValueError("Matrix determinant is 0, not invertible.")
         elif isinstance(base, (Identity, ZeroMatrix)):
             return base
         elif isinstance(base, MatrixBase) and exp.is_number:
@@ -82,4 +82,11 @@ class MatPow(MatrixExpr):
             return Inverse(base).doit(**kwargs)
         elif exp is S.One:
             return base
+        elif isinstance(base, Transpose) and isinstance(base.arg, MatPow):
+            return Transpose(MatPow(base.arg, exp).doit())
+
         return MatPow(base, exp)
+
+    def _eval_transpose(self):
+        base, exp = self.args
+        return MatPow(base.arg, exp) if base.is_Transpose else Transpose(self)

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -82,10 +82,8 @@ class MatPow(MatrixExpr):
             return Inverse(base).doit(**kwargs)
         elif exp is S.One:
             return base
-        elif isinstance(base, Transpose):
-            return Transpose(MatPow(base.arg, exp).doit(deep=False))
         return MatPow(base, exp)
 
     def _eval_transpose(self):
         base, exp = self.args
-        return MatPow(base.arg, exp) if base.is_Transpose else Transpose(self)
+        return MatPow(base.T, exp)

--- a/sympy/matrices/expressions/tests/test_matexpr.py
+++ b/sympy/matrices/expressions/tests/test_matexpr.py
@@ -3,7 +3,7 @@ from sympy import Sum, Dummy
 
 from sympy.core import S, symbols, Add, Mul
 from sympy.core.compatibility import long
-from sympy.functions import transpose, sin, cos, sqrt
+from sympy.functions import transpose, sin, cos, sqrt, cbrt
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
         MatPow, Matrix, MatrixExpr, MatrixSymbol, ShapeError, ZeroMatrix,
@@ -162,6 +162,7 @@ def test_MatPow():
     assert (A**-1)**-1 == A
     assert (A**2)**3 == A**6
     assert A**S.Half == sqrt(A)
+    assert A**(S(1)/3) == cbrt(A)
     raises(ShapeError, lambda: MatrixSymbol('B', 3, 2)**2)
 
 

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -91,8 +91,8 @@ def test_doit_nonsquare():
 def test_doit_nested_MatrixExpr():
     X = ImmutableMatrix([[1, 2], [3, 4]])
     Y = ImmutableMatrix([[2, 3], [4, 5]])
-    assert MatPow(MatMul(X, Y), 2).doit(deep=True) == (X*Y)**2
-    assert MatPow(MatAdd(X, Y), 2).doit(deep=True) == (X + Y)**2
+    assert MatPow(MatMul(X, Y), 2).doit() == (X*Y)**2
+    assert MatPow(MatAdd(X, Y), 2).doit() == (X + Y)**2
 
 
 def test_identity_power():
@@ -125,11 +125,15 @@ def test_zero_power():
 def test_transpose_power():
     from sympy.matrices.expressions.transpose import Transpose as TP
 
-    assert str(TP(C*D)**5) == '(C*D).T**5'
+    assert TP(C*D)**5 == ((C*D)**5).T
+    assert (TP(C*D)**5).T == (C*D)**5
 
     assert (C.T.I.T)**7 == C**-7
-    assert (((TP(A*E))**5).T)**7 == (A*E)**35
-    assert (((C.T)**l).T)**k == C**(l*k)
+    assert (C.T**l).T**k == C**(l*k)
 
-    assert (D**-5).T**-5 == (D**25).T
+    assert (TP(A*E)**5).T == (A*E)**5
+    assert (TP(A*E)**5).T**7 == (A*E)**35
+    assert TP(TP(C**2 * D**3)**5).doit() == (C**2 * D**3)**5
+
+    assert ((D*C)**-5).T**-5 == ((D*C)**25).T
     assert (((D*C)**l).T**k).T == (D*C)**(l*k)

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -91,8 +91,8 @@ def test_doit_nonsquare():
 def test_doit_nested_MatrixExpr():
     X = ImmutableMatrix([[1, 2], [3, 4]])
     Y = ImmutableMatrix([[2, 3], [4, 5]])
-    assert MatPow(MatMul(X, Y), 2).doit() == (X*Y)**2
-    assert MatPow(MatAdd(X, Y), 2).doit() == (X + Y)**2
+    assert MatPow(MatMul(X, Y), 2).doit(deep=True) == (X*Y)**2
+    assert MatPow(MatAdd(X, Y), 2).doit(deep=True) == (X + Y)**2
 
 
 def test_identity_power():
@@ -120,3 +120,16 @@ def test_zero_power():
     assert MatPow(z2, 2).doit() == z2
     assert MatPow(z2, 0).doit() == Identity(4)
     raises(ValueError, lambda:MatPow(z2, -1).doit())
+
+
+def test_transpose_power():
+    from sympy.matrices.expressions.transpose import Transpose as TP
+
+    assert str(TP(C*D)**5) == '(C*D).T**5'
+
+    assert (C.T.I.T)**7 == C**-7
+    assert (((TP(A*E))**5).T)**7 == (A*E)**35
+    assert (((C.T)**l).T)**k == C**(l*k)
+
+    assert (D**-5).T**-5 == (D**25).T
+    assert (((D*C)**l).T**k).T == (D*C)**(l*k)

--- a/sympy/matrices/expressions/tests/test_matpow.py
+++ b/sympy/matrices/expressions/tests/test_matpow.py
@@ -125,14 +125,14 @@ def test_zero_power():
 def test_transpose_power():
     from sympy.matrices.expressions.transpose import Transpose as TP
 
-    assert TP(C*D)**5 == ((C*D)**5).T
-    assert (TP(C*D)**5).T == (C*D)**5
+    assert (C*D).T**5 == ((C*D)**5).T == (D.T * C.T)**5
+    assert ((C*D).T**5).T == (C*D)**5
 
     assert (C.T.I.T)**7 == C**-7
     assert (C.T**l).T**k == C**(l*k)
 
-    assert (TP(A*E)**5).T == (A*E)**5
-    assert (TP(A*E)**5).T**7 == (A*E)**35
+    assert ((E.T * A.T)**5).T == (A*E)**5
+    assert ((A*E).T**5).T**7 == (A*E)**35
     assert TP(TP(C**2 * D**3)**5).doit() == (C**2 * D**3)**5
 
     assert ((D*C)**-5).T**-5 == ((D*C)**25).T

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -10,13 +10,13 @@ class Trace(Expr):
 
     Represents the trace of a matrix expression.
 
+    Examples
+    ========
+
     >>> from sympy import MatrixSymbol, Trace, eye
     >>> A = MatrixSymbol('A', 3, 3)
     >>> Trace(A)
     Trace(A)
-
-    See Also:
-        trace
     """
     is_Trace = True
 
@@ -74,18 +74,17 @@ class Trace(Expr):
 
 
 def trace(expr):
-    """ Trace of a Matrix.  Sum of the diagonal elements
+    """Trace of a Matrix.  Sum of the diagonal elements.
+
+    Examples
+    ========
 
     >>> from sympy import trace, Symbol, MatrixSymbol, pprint, eye
     >>> n = Symbol('n')
     >>> X = MatrixSymbol('X', n, n)  # A square matrix
     >>> trace(2*X)
     2*Trace(X)
-
     >>> trace(eye(3))
     3
-
-    See Also:
-        Trace
     """
     return Trace(expr).doit()

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -72,7 +72,7 @@ class Transpose(MatrixExpr):
 
 def transpose(expr):
     """Matrix transpose"""
-    return Transpose(expr).doit()
+    return Transpose(expr).doit(deep=False)
 
 
 from sympy.assumptions.ask import ask, Q

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -71,7 +71,7 @@ class Transpose(MatrixExpr):
         return det(self.arg)
 
 def transpose(expr):
-    """ Matrix transpose """
+    """Matrix transpose"""
     return Transpose(expr).doit()
 
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed
- Reduction of matrix expressions with intermixed transpose and powers
```
>>> A = MatrixSymbol('A', n, n)
>>> B = MatrixSymbol('B', n, n)
>>> ((A.T)**5).T
A**5
>>> ((A**5).T**5).T
A**25
```
Here `A` can be `MatrixExpr` (of square shape) as well.
- `deep=False` is passed to `MatPow.doit()` from `MatrixExpr.__pow__`
Motivation:
```
# old behaviour
>>> Transponse(A*B)**5
(B.T*A.T)**5

# new behaviour
>>> Transponse(A*B)**5
(A*B).T**5
>>> _.doit()
(B.T*A.T)**5
```
- Documentation improvements

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
     * matrix expressions involving transpose and powers are now automatically reduced
     * `Transponse(A*B)**5` now requires invocation of `.doit()` method to carry out reductions

<!-- END RELEASE NOTES -->
