### PR TITLE
Fix dsolve for linear irrational coefficients

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -256,7 +256,7 @@ from sympy.functions.combinatorial.factorials import factorial
 from sympy.integrals.integrals import Integral, integrate
 from sympy.matrices import wronskian, Matrix, eye, zeros
 from sympy.polys import (Poly, RootOf, rootof, terms_gcd,
-                         PolynomialError, lcm)
+                         PolynomialError, lcm, roots)
 from sympy.polys.polyroots import roots_quartic
 from sympy.polys.polytools import cancel, degree, div
 from sympy.series import Order
@@ -4927,7 +4927,12 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
             chareq += r[i]*symbol**i
 
     chareq = Poly(chareq, symbol)
-    chareqroots = [rootof(chareq, k) for k in range(chareq.degree())]
+    # Can't just call roots because it doesn't return rootof for unsolveable
+    # polynomials.
+    try:
+        chareqroots = [rootof(chareq, k) for k in range(chareq.degree())]
+    except NotImplementedError:
+        chareqroots = roots(chareq, multiple=True)
     chareq_is_complex = not all([i.is_real for i in chareq.all_coeffs()])
 
     # A generator of constants

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4929,10 +4929,10 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     chareq = Poly(chareq, symbol)
     # Can't just call roots because it doesn't return rootof for unsolveable
     # polynomials.
-    try:
+    chareqroots = roots(chareq, multiple=True)
+    if chareqroots == []:
         chareqroots = [rootof(chareq, k) for k in range(chareq.degree())]
-    except NotImplementedError:
-        chareqroots = roots(chareq, multiple=True)
+
     chareq_is_complex = not all([i.is_real for i in chareq.all_coeffs()])
 
     # A generator of constants

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1604,6 +1604,8 @@ def test_nth_linear_constant_coeff_homogeneous():
     eq28 = f(x).diff(x, 3) + 8*f(x)
     eq29 = f(x).diff(x, 4) + 4*f(x).diff(x, 2)
     eq30 = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x)
+    eq31 = f(x).diff(x, 4) + f(x).diff(x, 2) + f(x)
+    eq32 = f(x).diff(x, 4) + 4*f(x).diff(x, 2) + f(x)
     sol1 = Eq(f(x), C1 + C2*exp(-2*x))
     sol2 = Eq(f(x), (C1 + C2*exp(x))*exp(x))
     sol3 = Eq(f(x), C1*exp(x) + C2*exp(-x))
@@ -1643,6 +1645,10 @@ def test_nth_linear_constant_coeff_homogeneous():
         (C1*sin(x*sqrt(3)) + C2*cos(x*sqrt(3)))*exp(x) + C3*exp(-2*x))
     sol29 = Eq(f(x), C1 + C2*sin(2*x) + C3*cos(2*x) + C4*x)
     sol30 = Eq(f(x), C1 + (C2 + C3*x)*sin(x) + (C4 + C5*x)*cos(x))
+    sol31 = Eq(f(x), (C1*sin(sqrt(3)*x/2) + C2*cos(sqrt(3)*x/2))/sqrt(exp(x))
+                   + (C3*sin(sqrt(3)*x/2) + C4*cos(sqrt(3)*x/2))*sqrt(exp(x)))
+    sol32 = Eq(f(x), C1*sin(x*sqrt(-sqrt(3) + 2)) + C2*sin(x*sqrt(sqrt(3) + 2))
+                   + C3*cos(x*sqrt(-sqrt(3) + 2)) + C4*cos(x*sqrt(sqrt(3) + 2)))
     sol1s = constant_renumber(sol1, 'C', 1, 2)
     sol2s = constant_renumber(sol2, 'C', 1, 2)
     sol3s = constant_renumber(sol3, 'C', 1, 2)
@@ -1703,6 +1709,8 @@ def test_nth_linear_constant_coeff_homogeneous():
     assert dsolve(eq28) in (sol28, sol28s)
     assert dsolve(eq29) in (sol29, sol29s)
     assert dsolve(eq30) in (sol30, sol30s)
+    assert dsolve(eq31) in (sol31,)
+    assert dsolve(eq32) in (sol32,)
     assert checkodesol(eq1, sol1, order=2, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=2, solve_for_func=False)[0]
@@ -1733,6 +1741,8 @@ def test_nth_linear_constant_coeff_homogeneous():
     assert checkodesol(eq28, sol28, order=3, solve_for_func=False)[0]
     assert checkodesol(eq29, sol29, order=4, solve_for_func=False)[0]
     assert checkodesol(eq30, sol30, order=5, solve_for_func=False)[0]
+    assert checkodesol(eq31, sol31, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq32, sol32, order=4, solve_for_func=False)[0]
 
     # Issue #15237
     eqn = Derivative(x*f(x), x, x, x)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1751,6 +1751,38 @@ def test_nth_linear_constant_coeff_homogeneous_rootof():
         C5*exp(x*rootof(x**5 + 11*x - 2, 4)))
     assert dsolve(eq) == sol
 
+def test_nth_linear_constant_coeff_homogeneous_irrational():
+    our_hint='nth_linear_constant_coeff_homogeneous'
+
+    eq = Eq(sqrt(2) * f(x).diff(x,x,x) + f(x).diff(x), 0)
+    sol = Eq(f(x), C1 + C2*sin(2**(S(3)/4)*x/2) + C3*cos(2**(S(3)/4)*x/2))
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint) == sol
+    assert dsolve(eq, f(x)) == sol
+    assert checkodesol(eq, sol, order=3, solve_for_func=False)[0]
+
+    E = exp(1)
+    eq = Eq(E * f(x).diff(x,x,x) + f(x).diff(x), 0)
+    sol = Eq(f(x), C1 + C2*sin(x/sqrt(E)) + C3*cos(x/sqrt(E)))
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint) == sol
+    assert dsolve(eq, f(x)) == sol
+    assert checkodesol(eq, sol, order=3, solve_for_func=False)[0]
+
+    eq = Eq(pi * f(x).diff(x,x,x) + f(x).diff(x), 0)
+    sol = Eq(f(x), C1 + C2*sin(x/sqrt(pi)) + C3*cos(x/sqrt(pi)))
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint) == sol
+    assert dsolve(eq, f(x)) == sol
+    assert checkodesol(eq, sol, order=3, solve_for_func=False)[0]
+
+    eq = Eq(I * f(x).diff(x,x,x) + f(x).diff(x), 0)
+    sol = Eq(f(x), C1 + C2*exp(-sqrt(I)*x) + C3*exp(sqrt(I)*x))
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint) == sol
+    assert dsolve(eq, f(x)) == sol
+    assert checkodesol(eq, sol, order=3, solve_for_func=False)[0]
+
 
 @XFAIL
 @slow


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15311 

#### Brief description of what is fixed or changed

The constant coefficient solver in dsolve fails for ODEs whose characteristic polynomials cannot be solved over the EX domain. This patch adds a fallback to call `roots` if it fails. The result is that we can solve e.g.:

```julia
In [2]: eqn = Eq(sqrt(2) * f(x).diff(x,x,x) + f(x).diff(x), 0)

In [3]: dsolve(eqn)
Out[3]: 
                  ⎛ 3/4  ⎞         ⎛ 3/4  ⎞
                  ⎜2   ⋅x⎟         ⎜2   ⋅x⎟
f(x) = C₁ + C₂⋅sin⎜──────⎟ + C₃⋅cos⎜──────⎟
                  ⎝  2   ⎠         ⎝  2   ⎠
```

#### Other comments

Setting the domain of the `Poly` to `CC` doesn't solve the problem since it then fails to find an exact solution.

Using `roots` alone doesn't work with `test_nth_linear_constant_coeff_homogeneous_rootof_sol` because `roots` returns an empty list in that case. I'm not sure if that's a bug:

```julia
In [1]: roots(x**5 + 11*x - 2)
Out[1]: {}

In [3]: rootof(x**5 + 11*x - 2, 0)
Out[3]: 
       ⎛ 5              ⎞
CRootOf⎝x  + 11⋅x - 2, 0⎠
```

I've opted to use `rootof` and fall back to `roots` but it's possible that either/both of those should be improved instead of changing the code here in the ode module.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * fix solving linear ODEs with constant irrational coefficients
<!-- END RELEASE NOTES -->
