### PR TITLE
Fix nth_linear_match when prep=False

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4194,7 +4194,9 @@ def _nth_linear_match(eq, func, order):
             terms[-1] += i
         else:
             c, f = i.as_independent(func)
-            if isinstance(f, Derivative) and set(f.variables) == one_x:
+            if (isinstance(f, Derivative)
+                    and set(f.variables) == one_x
+                    and f.args[0] == func):
                 terms[f.derivative_count] += c
             elif f == func:
                 terms[len(f.args[1:])] += c

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1734,6 +1734,12 @@ def test_nth_linear_constant_coeff_homogeneous():
     assert checkodesol(eq29, sol29, order=4, solve_for_func=False)[0]
     assert checkodesol(eq30, sol30, order=5, solve_for_func=False)[0]
 
+    # Issue #15237
+    eqn = Derivative(x*f(x), x, x, x)
+    hint = 'nth_linear_constant_coeff_homogeneous'
+    raises(ValueError, lambda: dsolve(eqn, f(x), hint, prep=True))
+    raises(ValueError, lambda: dsolve(eqn, f(x), hint, prep=False))
+
 
 def test_nth_linear_constant_coeff_homogeneous_rootof():
     eq = f(x).diff(x, 5) + 11*f(x).diff(x) - 2*f(x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15237 

#### Brief description of what is fixed or changed

Changes the matching code in `nth_linear_match` so that it distinguishes between a `Derivative` of `f(x)` and a `Derivative` of some expression involving `f(x)`. As an example the code currently matches something like `Derivative(x*f(x), x, x, x)` as if it were `Derivative(f(x), x, x, x)`.

#### Other comments

This issue only shows up when calling `dsolve(..., prep=False)` because `prep=True` would expand the `Derivative` first. It seems that `dsolve(..., prep=False)` is a relatively untested codepath.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * Don't incorrectly match ODEs as linear, constant coefficient, homogeneous when dsolve is called with prep=False
<!-- END RELEASE NOTES -->
