### PR TITLE
Fixed docstring in latex parser

### DIFF
--- a/sympy/parsing/latex/__init__.py
+++ b/sympy/parsing/latex/__init__.py
@@ -10,10 +10,13 @@ def parse_latex(s):
     ==========
 
     s : str
-    The LaTeX string to parse. In Python source containing LaTeX, *raw strings*
-    (denoted with `r''`, like this one) are preferred, as LaTeX makes liberal
-    use of the ``\`` character, which would trigger escaping in normal Python
-    strings.
+        The LaTeX string to parse. In Python source containing LaTeX,
+        *raw strings* (denoted with ``r"``, like this one) are preferred,
+        as LaTeX makes liberal use of the ``\`` character, which would
+        trigger escaping in normal Python strings.
+
+    Examples
+    ========
 
     >>> from sympy.parsing.latex import parse_latex  # doctest: +SKIP
     >>> expr = parse_latex(r"\frac {1 + \sqrt {\a}} {\b}")  # doctest: +SKIP


### PR DESCRIPTION
Fixed latex parser not working

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15399

#### Brief description of what is fixed or changed
Fixed indentation in latex parser so that code is properly rendered. 

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
   NO ENTRY
<!-- END RELEASE NOTES -->
 