### PR TITLE
Reverts backwards incompatible changes to theano_function()

### DIFF
--- a/doc/src/modules/numeric-computation.rst
+++ b/doc/src/modules/numeric-computation.rst
@@ -103,12 +103,12 @@ compiled using the Theano compiler chain.
     >>> expr = sin(x)/x
 
     >>> from sympy.printing.theanocode import theano_function
-    >>> f = theano_function([x], expr)
+    >>> f = theano_function([x], [expr])
 
 If array broadcasting or types are desired then Theano requires this extra
 information
 
-    >>> f = theano_function([x], expr, dims={x: 1}, dtypes={x: 'float64'})
+    >>> f = theano_function([x], [expr], dims={x: 1}, dtypes={x: 'float64'})
 
 Theano has a more sophisticated code generation system than SymPy's C/Fortran
 code printers.  Among other things it handles common sub-expressions and

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -11,7 +11,6 @@ import logging
 
 from sympy.external import import_module
 from sympy.utilities.pytest import raises, SKIP
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 theanologger = logging.getLogger('theano.configdefaults')
 theanologger.setLevel(logging.CRITICAL)
@@ -275,7 +274,7 @@ def test_Derivative():
 
 def test_theano_function_simple():
     """ Test theano_function() with single output. """
-    f = theano_function_([x, y], x+y)
+    f = theano_function_([x, y], [x+y])
     assert f(2, 3) == 5
 
 def test_theano_function_multi():
@@ -285,46 +284,27 @@ def test_theano_function_multi():
     assert o1 == 5
     assert o2 == -1
 
-def test_theano_function_squeeze():
-    """ Test theano_function() with list of length one as outputs.
-
-    The "squeeze" argument determines whether the created function will return a
-    single array or a list containing a single array in this condition. Current
-    default is squeeze=True, which is deprecated and will be removed in a future
-    release.
-    """
-    import warnings
-
-    # squeeze=True deprecated
-    raises(SymPyDeprecationWarning, lambda: theano_function_([x, y], [x+y]))
-    raises(SymPyDeprecationWarning, lambda: theano_function_([x, y], [x+y], squeeze=True))
-
-    # Test deprecated behavior
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', category=SymPyDeprecationWarning)
-
-        assert theano_function_([x, y], [x + y])(2, 3) == 5
-        assert theano_function_([x, y], [x + y], squeeze=True)(2, 3) == 5
-
-    # squeeze=false keeps as list
-    assert theano_function_([x, y], [x+y], squeeze=False)(2, 3) == [5]
-
-    # No deprecation warning when value doesn't actually matter
-    assert theano_function_([x, y], [x+y, x-y])(2, 3) == [5, -1]
-    assert theano_function_([x, y], [x+y, x-y], squeeze=True)(2, 3) == [5, -1]
-    assert theano_function_([x, y], [x+y, x-y], squeeze=False)(2, 3) == [5, -1]
-
 def test_theano_function_numpy():
     """ Test theano_function() vs Numpy implementation. """
-    f = theano_function_([x, y], x+y, dim=1,
+    f = theano_function_([x, y], [x+y], dim=1,
                          dtypes={x: 'float64', y: 'float64'})
     assert np.linalg.norm(f([1, 2], [3, 4]) - np.asarray([4, 6])) < 1e-9
 
-    f = theano_function_([x, y], x+y, dtypes={x: 'float64', y: 'float64'},
-                                     dim=1)
+    f = theano_function_([x, y], [x+y], dtypes={x: 'float64', y: 'float64'},
+                         dim=1)
     xx = np.arange(3).astype('float64')
     yy = 2*np.arange(3).astype('float64')
     assert np.linalg.norm(f(xx, yy) - 3*np.arange(3)) < 1e-9
+
+
+def test_theano_function_matrix():
+    m = sy.Matrix([[x, y], [z, x + y + z]])
+    expected = np.array([[1.0, 2.0], [3.0, 1.0 + 2.0 + 3.0]])
+    f = theano_function_([x, y, z], [m])
+    np.testing.assert_allclose(f(1.0, 2.0, 3.0), expected)
+    f = theano_function_([x, y, z], [m], scalar=True)
+    np.testing.assert_allclose(f(1.0, 2.0, 3.0), expected)
+
 
 def test_dim_handling():
     assert dim_handling([x], dim=2) == {x: (False, False)}
@@ -337,11 +317,11 @@ def test_theano_function_kwargs():
     Test passing additional kwargs from theano_function() to theano.function().
     """
     import numpy as np
-    f = theano_function_([x, y, z], x+y, dim=1, on_unused_input='ignore',
+    f = theano_function_([x, y, z], [x+y], dim=1, on_unused_input='ignore',
             dtypes={x: 'float64', y: 'float64', z: 'float64'})
     assert np.linalg.norm(f([1, 2], [3, 4], [0, 0]) - np.asarray([4, 6])) < 1e-9
 
-    f = theano_function_([x, y, z], x+y,
+    f = theano_function_([x, y, z], [x+y],
                         dtypes={x: 'float64', y: 'float64', z: 'float64'},
                         dim=1, on_unused_input='ignore')
     xx = np.arange(3).astype('float64')
@@ -353,9 +333,9 @@ def test_theano_function_scalar():
     """ Test the "scalar" argument to theano_function(). """
 
     args = [
-        ([x, y], x + y, None, [0]),  # Single 0d output
-        ([X, Y], X + Y, None, [2]),  # Single 2d output
-        ([x, y], x + y, {x: 0, y: 1}, [1]),  # Single 1d output
+        ([x, y], [x + y], None, [0]),  # Single 0d output
+        ([X, Y], [X + Y], None, [2]),  # Single 2d output
+        ([x, y], [x + y], {x: 0, y: 1}, [1]),  # Single 1d output
         ([x, y], [x + y, x - y], None, [0, 0]),  # Two 0d outputs
         ([x, y, X, Y], [x + y, X + Y], None, [0, 2]),  # One 0d output, one 2d
     ]
@@ -396,7 +376,7 @@ def test_theano_function_bad_kwarg():
     Passing an unknown keyword argument to theano_function() should raise an
     exception.
     """
-    raises(Exception, lambda : theano_function_([x], x+1, foobar=3))
+    raises(Exception, lambda : theano_function_([x], [x+1], foobar=3))
 
 
 def test_slice():
@@ -467,8 +447,8 @@ def test_BlockMatrix_Inverse_execution():
     cutoutput = output.subs(dict(zip(inputs, cutinputs)))
 
     dtypes = dict(zip(inputs, [dtype]*len(inputs)))
-    f = theano_function_(inputs, output, dtypes=dtypes, cache={})
-    fblocked = theano_function_(inputs, sy.block_collapse(cutoutput),
+    f = theano_function_(inputs, [output], dtypes=dtypes, cache={})
+    fblocked = theano_function_(inputs, [sy.block_collapse(cutoutput)],
                                 dtypes=dtypes, cache={})
 
     ninputs = [np.random.rand(*x.shape).astype(dtype) for x in inputs]

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -304,7 +304,10 @@ def test_theano_function_matrix():
     np.testing.assert_allclose(f(1.0, 2.0, 3.0), expected)
     f = theano_function_([x, y, z], [m], scalar=True)
     np.testing.assert_allclose(f(1.0, 2.0, 3.0), expected)
-
+    f = theano_function_([x, y, z], [m, m])
+    assert isinstance(f(1.0, 2.0, 3.0), type([]))
+    np.testing.assert_allclose(f(1.0, 2.0, 3.0)[0], expected)
+    np.testing.assert_allclose(f(1.0, 2.0, 3.0)[1], expected)
 
 def test_dim_handling():
     assert dim_handling([x], dim=2) == {x: (False, False)}

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division
 from sympy.external import import_module
 from sympy.printing.printer import Printer
 from sympy.core.compatibility import range, is_sequence
-from sympy.utilities.exceptions import SymPyDeprecationWarning
 import sympy
 from functools import partial
 
@@ -388,7 +387,7 @@ def dim_handling(inputs, dim=None, dims=None, broadcastables=None):
     return {}
 
 
-def theano_function(inputs, outputs, squeeze=True, scalar=False, **kwargs):
+def theano_function(inputs, outputs, scalar=False, **kwargs):
     """ Create a Theano function from SymPy expressions.
 
     The inputs and outputs are converted to Theano variables using
@@ -401,17 +400,9 @@ def theano_function(inputs, outputs, squeeze=True, scalar=False, **kwargs):
         Sequence of symbols which constitute the inputs of the function.
 
     outputs
-        Expression or sequence of expressions which constitute the outputs(s) of
-        the function. The free symbols of each expression must be a subset of
+        Sequence of expressions which constitute the outputs(s) of the
+        function. The free symbols of each expression must be a subset of
         ``inputs``.
-
-    squeeze : bool
-        If ``outputs`` is a sequence of length one, pass the printed value of
-        the lone element of the sequence to :func:`theano.function` instead of
-        the sequence itself. This has the effect of making a function which
-        returns a single array instead of a list containing one array. This
-        behavior is deprecated and the default value will be changed to False in
-        a future release. To get a function that returns a single
 
     scalar : bool
         Convert 0-dimensional arrays in output to scalars. This will return a
@@ -461,13 +452,13 @@ def theano_function(inputs, outputs, squeeze=True, scalar=False, **kwargs):
 
     A simple function with one input and one output:
 
-    >>> f1 = theano_function([x], x**2 - 1, scalar=True)
+    >>> f1 = theano_function([x], [x**2 - 1], scalar=True)
     >>> f1(3)
     8.0
 
     A function with multiple inputs and one output:
 
-    >>> f2 = theano_function([x, y, z], (x**z + y**z)**(1/z), scalar=True)
+    >>> f2 = theano_function([x, y, z], [(x**z + y**z)**(1/z)], scalar=True)
     >>> f2(3, 4, 2)
     5.0
 
@@ -485,16 +476,6 @@ def theano_function(inputs, outputs, squeeze=True, scalar=False, **kwargs):
     if not theano:
         raise ImportError("theano is required for theano_function")
 
-    # Squeeze output sequence of length one
-    if squeeze and is_sequence(outputs) and len(outputs) == 1:
-        SymPyDeprecationWarning(
-            feature='theano_function() with squeeze=True',
-            issue=14986,
-            deprecated_since_version='1.2.1',
-            useinstead='a single expression as "outputs" (not a list)',
-        ).warn()
-        outputs = outputs[0]
-
     # Pop off non-theano keyword args
     cache = kwargs.pop('cache', {})
     dtypes = kwargs.pop('dtypes', {})
@@ -509,13 +490,11 @@ def theano_function(inputs, outputs, squeeze=True, scalar=False, **kwargs):
     # Print inputs/outputs
     code = partial(theano_code, cache=cache, dtypes=dtypes,
                    broadcastables=broadcastables)
-    tinputs  = list(map(code, inputs))
+    tinputs = list(map(code, inputs))
+    toutputs = list(map(code, outputs))
 
-    is_seq = is_sequence(outputs)
-    if is_seq:
-        toutputs = list(map(code, outputs))
-    else:
-        toutputs = code(outputs)
+    if len(toutputs) == 1:
+        toutputs = toutputs[0]
 
     # Compile theano func
     func = theano.function(tinputs, toutputs, **kwargs)
@@ -530,12 +509,12 @@ def theano_function(inputs, outputs, squeeze=True, scalar=False, **kwargs):
     # Create wrapper to convert 0-dimensional outputs to scalars
     def wrapper(*args):
         out = func(*args)
+        # out can be array(1.0) or [array(1.0), array(2.0)]
 
-        if not is_seq:
-            return out[()]
-
-        else:
+        if is_sequence(out):
             return [o[()] if is_0d[i] else o for i, o in enumerate(out)]
+        else:
+            return out[()]
 
     wrapper.__wrapped__ = func
     wrapper.__doc__ = func.__doc__


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #14986

#### Brief description of what is fixed or changed

PR #14949 introduced a backwards incompatible change to the public API
of the theano_function() function. The change allowed the output
expressions to be passed in without being encased in a sequence, but did
not retain the prior behavior. The expressed reasons for the change were
to allow a user to type `my_expr` instead of `[my_expr]` and to have a
similar call signature with `theano.function()`. Neither of these
warrant a necessary deprecation. In particular, commit
a833af605791c38518d133fd98d7d0e99190ff97 is reverted.

Secondly, this change inadvertently broke (seemingly) untested behavior
if the output expressions are matrices. Prior to the change a numpy
array of the same dimensions of the matrix would be returned. The change
caused lists of arrays to be returned. This returns that behavior and
adds a regression test.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
(NOTE: The release notes for this PR need to be fixed manually once this is merged, see https://github.com/sympy/sympy/pull/15423#issuecomment-432519197)