### PR TITLE
New classes in codegen to help generate NumPy array operations

### DIFF
--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -1,0 +1,74 @@
+from collections import defaultdict
+from sympy.core.basic import Basic
+from sympy.core.mul import Mul
+from sympy.matrices.expressions import MatMul
+from sympy.matrices.expressions.matexpr import MatrixExpr
+
+
+class CodegenArrayContraction(Basic):
+    """
+    This class is meant to represent contractions of arrays in a form easily
+    processable by the code printers.
+    """
+    def __new__(cls, expr, *indices):
+        return Basic.__new__(cls, expr, *indices)
+
+    @staticmethod
+    def from_summation(summation):
+        from sympy import Indexed
+        from sympy.matrices.expressions.matexpr import MatrixElement
+        function = summation.function
+        indices = summation.variables
+        if function.is_Mul:
+            pass
+            args = []
+            ranks = []
+            total_rank = 0
+            axes_contraction = defaultdict(list)
+            for arg in function.args:
+                loc_indices = None
+                if isinstance(arg, Indexed):
+                    args.append(arg.base)
+                    loc_indices = arg.indices
+                    ranks.append(len(arg.indices))
+                elif isinstance(arg, MatrixElement):
+                    args.append(arg.parent)
+                    loc_indices = arg.indices
+                    ranks.append(2)
+                elif isinstance(arg, Matrix):
+                    args.append(arg)
+                    ranks.append(2)
+                else:
+                    args.append(arg)
+                    ranks.append(0)
+                for i, ind in enumerate(loc_indices):
+                    if ind in indices:
+                        axes_contraction[ind].append(total_rank + i)
+                total_rank += ranks[-1]
+            return CodegenArrayContraction(
+                    CodegenArrayTensorProduct(*args),
+                    *[tuple(v) for v in axes_contraction.values()]
+                )
+
+    @staticmethod
+    def from_MatMul(expr):
+        args_nonmat = []
+        args = []
+        contractions = []
+        for arg in expr.args:
+            if isinstance(arg, MatrixExpr):
+                args.append(arg)
+            else:
+                args_nonmat.append(arg)
+        contractions = [(2*i+1, 2*i+2) for i in range(len(args)-1)]
+        return Mul.fromiter(args_nonmat)*CodegenArrayContraction(
+                CodegenArrayTensorProduct(*args),
+                *contractions
+            )
+
+
+class CodegenArrayTensorProduct(Basic):
+    def __new__(cls, *args):
+        if len(args) == 1:
+            return args[0]
+        return Basic.__new__(cls, *args)

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
+from sympy import Indexed, IndexedBase, Tuple
 from sympy.core.basic import Basic
 from sympy.core.sympify import _sympify
 from sympy.core.mul import Mul
 from sympy.core.compatibility import accumulate, default_sort_key
-from sympy.matrices.expressions import MatMul
-from sympy.matrices.expressions.matexpr import MatrixExpr
+from sympy.matrices.expressions import MatMul, Trace, Transpose
+from sympy.matrices.expressions.matexpr import MatrixExpr, MatrixElement
 from sympy.tensor.array import NDimArray
 
 
@@ -13,43 +14,89 @@ class CodegenArrayContraction(Basic):
     This class is meant to represent contractions of arrays in a form easily
     processable by the code printers.
     """
-    def __new__(cls, expr, *contraction_indices):
-        contraction_indices = [_sympify(ind) for ind in contraction_indices]
+    def __new__(cls, expr, *contraction_indices, **kwargs):
+        contraction_indices = cls._sort_contraction_indices(contraction_indices)
         expr = _sympify(expr)
         obj = Basic.__new__(cls, expr, *contraction_indices)
-        obj._mapping = cls._get_mapping_from_contraction_indices(expr, *contraction_indices)
+        obj._mapping, obj._ranks = cls._get_mapping_from_contraction_indices(expr, *contraction_indices)
+        free_indices = kwargs.get("free_indices", None)
+        if "free_indices" in kwargs:
+            free_indices = kwargs["free_indices"]
+        else:
+            free_indices = {i: i for i in range(sum(obj._ranks)) if all([i not in cind for cind in contraction_indices])}
+        obj._free_indices = free_indices
         return obj
 
     @staticmethod
+    def _sort_contraction_indices(contraction_indices):
+        contraction_indices = [Tuple(*sorted(i)) for i in contraction_indices]
+        contraction_indices.sort(key=lambda x: min(x))
+        return contraction_indices
+
+    @staticmethod
     def _get_mapping_from_contraction_indices(expr, *contraction_indices):
-        if not isinstance(expr, CodegenArrayTensorProduct):
-            return {}
-        args = expr.args
-        ranks = expr.ranks
+        if isinstance(expr, CodegenArrayTensorProduct):
+            args = expr.args
+            ranks = expr.ranks
+        else:
+            args = [expr]
+            ranks = [CodegenArrayTensorProduct.get_rank(expr)]
         mapping = {}
         counter = 0
         for i, rank in enumerate(ranks):
             for j in range(rank):
                 mapping[counter] = (i, j)
                 counter += 1
-        return mapping
+        return mapping, ranks
 
-    def _contraction_indices_to_contraction_tuples(self):
+    def _get_contraction_tuples(self):
+        """
+        Return tuples containing the argument index and position within the
+        argument of the index position.
+
+        Examples
+        ========
+
+        >>> from sympy import MatrixSymbol, MatrixExpr, Sum, Symbol
+        >>> from sympy.abc import i, j, k, l, N
+        >>> from sympy.codegen.array_utils import CodegenArrayContraction, CodegenArrayTensorProduct
+        >>> A = MatrixSymbol("A", N, N)
+        >>> B = MatrixSymbol("B", N, N)
+
+        >>> cg = CodegenArrayContraction(CodegenArrayTensorProduct(A, B), (1, 2))
+        >>> cg._get_contraction_tuples()
+        [[(0, 1), (1, 0)]]
+
+        Here the contraction pair `(1, 2)` meaning that the 2nd and 3rd indices
+        of the tensor product `A\otimes B` are contracted, has been transformed
+        into `(0, 1)` and `(1, 0)`, identifying the same indices in a different
+        notation. `(0, 1)` is the second index (1) of the first argument (i.e.
+                0 or `A`). `(1, 0)` is the first index (i.e. 0) of the second
+        argument (i.e. 1 or `B`).
+        """
         mapping = self._mapping
-        if not mapping:
-            raise NotImplementedError
+        #if mapping is None:
+            #raise NotImplementedError
         return [[mapping[j] for j in i] for i in self.contraction_indices]
 
     @staticmethod
-    def _contraction_tuple_to_contraction_indices(expr, contraction_tuples):
+    def _contraction_tuples_to_contraction_indices(expr, contraction_tuples):
         # TODO: check that `expr` has `.ranks`:
         ranks = expr.ranks
         cumulative_ranks = [0] + list(accumulate(ranks))
         return [tuple(cumulative_ranks[j]+k for j, k in i) for i in contraction_tuples]
 
     @property
+    def free_indices(self):
+        return dict(self._free_indices)
+
+    @property
     def expr(self):
         return self.args[0]
+
+    @property
+    def ranks(self):
+        return self._ranks[:]
 
     @property
     def contraction_indices(self):
@@ -71,6 +118,26 @@ class CodegenArrayContraction(Basic):
         return mapping
 
     def sort_args_by_name(self):
+        """
+        Sort arguments in the tensor product so that their order is lexicographical.
+
+        Examples
+        ========
+
+        >>> from sympy import MatrixSymbol, MatrixExpr, Sum, Symbol
+        >>> from sympy.abc import i, j, k, l, N
+        >>> from sympy.codegen.array_utils import CodegenArrayContraction
+        >>> A = MatrixSymbol("A", N, N)
+        >>> B = MatrixSymbol("B", N, N)
+        >>> C = MatrixSymbol("C", N, N)
+        >>> D = MatrixSymbol("D", N, N)
+
+        >>> cg = CodegenArrayContraction.from_MatMul(C*D*A*B)
+        >>> cg
+        CodegenArrayContraction(CodegenArrayTensorProduct(C, D, A, B), (1, 2), (3, 4), (5, 6))
+        >>> cg.sort_args_by_name()
+        CodegenArrayContraction(CodegenArrayTensorProduct(A, B, C, D), (0, 7), (1, 2), (5, 6))
+        """
         expr = self.expr
         if not isinstance(expr, CodegenArrayTensorProduct):
             return self
@@ -78,14 +145,182 @@ class CodegenArrayContraction(Basic):
         sorted_data = sorted(enumerate(args), key=lambda x: default_sort_key(x[1]))
         pos_sorted, args_sorted = zip(*sorted_data)
         reordering_map = {i: pos_sorted.index(i) for i, arg in enumerate(args)}
-        contraction_tuples = self._contraction_indices_to_contraction_tuples()
+        contraction_tuples = self._get_contraction_tuples()
         contraction_tuples = [[(reordering_map[j], k) for j, k in i] for i in contraction_tuples]
         c_tp = CodegenArrayTensorProduct(*args_sorted)
-        new_contr_indices = self._contraction_tuple_to_contraction_indices(
+        new_contr_indices = self._contraction_tuples_to_contraction_indices(
                 c_tp,
                 contraction_tuples
         )
         return CodegenArrayContraction(c_tp, *new_contr_indices)
+
+    def _get_contraction_links(self):
+        """
+        Returns a dictionary of links between arguments in the tensor product
+        being contracted.
+
+        See the example for an explanation of the values.
+
+        Examples
+        ========
+
+        >>> from sympy import MatrixSymbol, MatrixExpr, Sum, Symbol
+        >>> from sympy.abc import i, j, k, l, N
+        >>> from sympy.codegen.array_utils import CodegenArrayContraction
+        >>> A = MatrixSymbol("A", N, N)
+        >>> B = MatrixSymbol("B", N, N)
+        >>> C = MatrixSymbol("C", N, N)
+        >>> D = MatrixSymbol("D", N, N)
+
+        Matrix multiplications are pairwise contractions between neighboring
+        matrices:
+
+        `A_{ij} B_{jk} C_{kl} D_{lm}`
+
+        >>> cg = CodegenArrayContraction.from_MatMul(A*B*C*D)
+        >>> cg
+        CodegenArrayContraction(CodegenArrayTensorProduct(A, B, C, D), (1, 2), (3, 4), (5, 6))
+        >>> cg._get_contraction_links()
+        {0: [(1, 0)], 1: [(0, 1), (2, 0)], 2: [(1, 1), (3, 0)], 3: [(2, 1)]}
+
+        This dictionary is interpreted as follows: argument in position 0 (i.e.
+        matrix `A`) is contracted to `(1, 0)`, that is argument in position 1
+        (matrix `B`) on the first index slot of `B`, this is the contraction
+        provided by the index `j` from `A`.
+
+        The argument in position 1 (that is, matrix `B`) has two contractions,
+        the ones provided by the indices `j` and `k`.  The link `(0, 1)` and
+        `(2, 0)` respectively. `(0, 1)` is the index slot 1 (the 2nd) of
+        argument in position 0 (that is, `A_{\ldot j}`), and so on.
+        """
+        contraction_tuples = self._get_contraction_tuples()
+        dlinks = defaultdict(list)
+        for links in contraction_tuples:
+            if len(links) > 2:
+                raise NotImplementedError("three or more axes contracted at the same time")
+            (arg1, pos1), (arg2, pos2) = links
+            dlinks[arg1].append((arg2, pos2))
+            dlinks[arg2].append((arg1, pos1))
+        return dict(dlinks)
+
+    def _recognize_matrix_mul_lines(self, first_indices=None):
+        r"""
+        Recognize lines of matrix multiplications in the contractions of tensor
+        products of two-dimensional array.  If the ``CodegenArrayContraction``
+        object was created from a summation of indexed expressions, it will
+        remember the starting and ending free indices.
+
+        This can help perform the transformation expressed in mathematical
+        notation as:
+
+        `\sum_{j=0}^{N-1} A_{i,j} B_{j,k} \Longrightarrow \mathbf{A}\cdot \mathbf{B}`
+
+        Optional parameter ``first_indices``: specify a list of free indices to
+        use as the indices of the starting mat-mul lines in the expression.
+
+        Examples
+        ========
+
+        >>> from sympy import MatrixSymbol, MatrixExpr, Sum, Symbol
+        >>> from sympy.abc import i, j, k, l, N
+        >>> from sympy.codegen.array_utils import CodegenArrayContraction
+        >>> A = MatrixSymbol("A", N, N)
+        >>> B = MatrixSymbol("B", N, N)
+
+        >>> expr = Sum(A[i, j]*B[j, k], (j, 0, N-1))
+        >>> cg = CodegenArrayContraction.from_summation(expr)
+        >>> cg.free_indices
+        {i: 0, k: 3}
+        >>> cg._recognize_matrix_mul_lines()
+        [(i, k, [A, B])]
+        >>> cg._recognize_matrix_mul_lines(first_indices=[k])
+        [(k, i, [B.T, A.T])]
+
+        Transposition is detected:
+
+        >>> expr = Sum(A[j, i]*B[j, k], (j, 0, N-1))
+        >>> cg = CodegenArrayContraction.from_summation(expr)
+        >>> cg.free_indices
+        {i: 1, k: 3}
+        >>> cg._recognize_matrix_mul_lines()
+        [(i, k, [A.T, B])]
+        >>> cg._recognize_matrix_mul_lines(first_indices=[k])
+        [(k, i, [B.T, A])]
+
+        Detect the trace:
+
+        >>> expr = Sum(A[i, i], (i, 0, N-1))
+        >>> cg = CodegenArrayContraction.from_summation(expr)
+        >>> cg._recognize_matrix_mul_lines()
+        [(None, None, [Trace(A)])]
+
+        More complicated expressions:
+
+        >>> expr = Sum(A[i, j]*B[k, j]*A[l, k], (j, 0, N-1), (k, 0, N-1))
+        >>> cg = CodegenArrayContraction.from_summation(expr)
+        >>> cg._recognize_matrix_mul_lines()
+        [(i, l, [A, B.T, A.T])]
+
+        Expressions constructed from matrix expressions do not contain literal indices,
+        the positions of free indices are returned instead:
+
+        >>> expr = A*B
+        >>> cg = CodegenArrayContraction.from_MatMul(expr)
+        >>> cg.free_indices
+        {0: 0, 3: 3}
+        >>> cg._recognize_matrix_mul_lines()
+        [(0, 3, [A, B])]
+        """
+        expr = self.expr
+        if not isinstance(expr, CodegenArrayTensorProduct):
+            args = [expr]
+        else:
+            args = expr.args
+        free_indices = self.free_indices
+        dlinks = self._get_contraction_links()
+        # TODO: check that all elements have rank-2
+        if free_indices:
+            if first_indices:
+                first_index = first_indices[0]
+                starting_argind = free_indices.pop(first_index)
+            else:
+                first_index, starting_argind = min(free_indices.items(), key=lambda x: x[1])
+                free_indices.pop(first_index)
+            current_argind = starting_argind
+        else:
+            first_index = None
+            starting_argind = 0
+            current_argind = 0
+        current_argind, current_pos = self._mapping[current_argind]
+        starting_argind, starting_pos = self._mapping[starting_argind]
+        matmul_args = []
+        prev_argind = None
+        prev_pos = 0
+        last_index = None
+        while True:
+            elem = args[current_argind]
+            if current_pos != prev_pos:
+                elem = Transpose(elem)
+            matmul_args.append(elem)
+            if current_argind not in dlinks:
+                break
+            link_list = [(i, p) for i, p in dlinks.pop(current_argind) if i != prev_argind]
+            if len(link_list) == 0:
+                if free_indices:
+                    last_index = [i for i, j in free_indices.items() if self._mapping[j] == (current_argind, 1-current_pos)][0]
+                else:
+                    last_index = None
+                break
+            if len(link_list) != 1:
+                if len(link_list) != 2 and link_list[0][0] != link_list[1][0]:
+                    raise NotImplementedError("not a matrix multiplication line")
+            prev_argind = current_argind
+            current_argind, current_pos = link_list[0]
+            if current_argind == starting_argind:
+                # This is a trace:
+                matmul_args = [Trace(*matmul_args)]
+                break
+        return [(first_index, last_index, matmul_args)]
 
     @staticmethod
     def from_summation(summation):
@@ -93,36 +328,49 @@ class CodegenArrayContraction(Basic):
         from sympy.matrices.expressions.matexpr import MatrixElement
         function = summation.function
         indices = summation.variables
+        free_indices = {}
         if function.is_Mul:
+            function_args = function.args
+        elif function.is_Add:
             pass
-            args = []
-            ranks = []
-            total_rank = 0
-            axes_contraction = defaultdict(list)
-            for arg in function.args:
-                loc_indices = None
-                if isinstance(arg, Indexed):
-                    args.append(arg.base)
-                    loc_indices = arg.indices
-                    ranks.append(len(arg.indices))
-                elif isinstance(arg, MatrixElement):
-                    args.append(arg.parent)
-                    loc_indices = arg.indices
-                    ranks.append(2)
-                elif isinstance(arg, Matrix):
-                    args.append(arg)
-                    ranks.append(2)
-                else:
-                    args.append(arg)
-                    ranks.append(0)
-                for i, ind in enumerate(loc_indices):
-                    if ind in indices:
-                        axes_contraction[ind].append(total_rank + i)
-                total_rank += ranks[-1]
-            return CodegenArrayContraction(
-                    CodegenArrayTensorProduct(*args),
-                    *[tuple(v) for v in axes_contraction.values()]
-                )
+        elif isinstance(function, MatrixElement):
+            function_args = [function]
+        elif isinstance(function, Indexed):
+            function_args = [function]
+        else:
+            return summation
+        args = []
+        ranks = []
+        total_rank = 0
+        axes_contraction = defaultdict(list)
+        for arg in function_args:
+            loc_indices = None
+            if isinstance(arg, Indexed):
+                args.append(arg.base)
+                loc_indices = arg.indices
+                ranks.append(len(arg.indices))
+            elif isinstance(arg, MatrixElement):
+                args.append(arg.parent)
+                loc_indices = arg.indices
+                ranks.append(2)
+            elif isinstance(arg, Matrix):
+                args.append(arg)
+                ranks.append(2)
+            else:
+                args.append(arg)
+                ranks.append(0)
+            for i, ind in enumerate(loc_indices):
+                if ind in indices:
+                    axes_contraction[ind].append(total_rank + i)
+            for i, ind in enumerate(loc_indices):
+                if ind not in indices:
+                    free_indices[ind] = total_rank + i
+            total_rank += ranks[-1]
+        return CodegenArrayContraction(
+                CodegenArrayTensorProduct(*args),
+                *[tuple(v) for v in axes_contraction.values()],
+                free_indices=free_indices
+            )
 
     @staticmethod
     def from_MatMul(expr):
@@ -157,8 +405,16 @@ class CodegenArrayTensorProduct(Basic):
 
     @classmethod
     def get_rank(cls, expr):
-        if isinstance(expr, MatrixExpr):
+        if isinstance(expr, (MatrixExpr, MatrixElement)):
             return 2
         if isinstance(expr, NDimArray):
             return expr.rank()
+        if isinstance(expr, Indexed):
+            return expr.rank
+        if isinstance(expr, IndexedBase):
+            shape = expr.shape
+            if shape is None:
+                return -1
+            else:
+                return len(shape)
         return 0

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -155,7 +155,7 @@ class CodegenArrayContraction(Basic):
         return CodegenArrayContraction(c_tp, *new_contr_indices)
 
     def _get_contraction_links(self):
-        """
+        r"""
         Returns a dictionary of links between arguments in the tensor product
         being contracted.
 

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -4,6 +4,7 @@ from sympy.core.sympify import _sympify
 from sympy.core.mul import Mul
 from sympy.matrices.expressions import MatMul
 from sympy.matrices.expressions.matexpr import MatrixExpr
+from sympy.tensor.array import NDimArray
 
 
 class CodegenArrayContraction(Basic):

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -546,7 +546,7 @@ class CodegenArrayDiagonal(Basic):
     """
     def __new__(cls, expr, *diagonal_indices):
         expr = _sympify(expr)
-        diagonal_indices = [tuple(sorted(i)) for i in diagonal_indices]
+        diagonal_indices = [Tuple(*sorted(i)) for i in diagonal_indices]
         if isinstance(expr, CodegenArrayDiagonal):
             return cls._flatten(expr, *diagonal_indices)
         obj = Basic.__new__(cls, expr, *diagonal_indices)
@@ -640,9 +640,8 @@ def _codegen_array_parse(expr):
         flattened_indices = tuple(i for i in flattened_indices if i is not None)
         flattened_indices += tuple(held_back)
         if axes_contraction:
-            return CodegenArrayDiagonal(tp,
-                *[tuple(v) for v in axes_contraction.values()],
-            ), flattened_indices
+            return (CodegenArrayDiagonal(tp,
+                *[Tuple(*v) for v in axes_contraction.values()]), flattened_indices)
         else:
             return tp, flattened_indices
     if isinstance(expr, MatrixElement):
@@ -662,7 +661,7 @@ def _codegen_array_parse(expr):
         for i in range(1, len(args)):
             if set(indices[i]) != index0set:
                 raise NotImplementedError("indices must be the same")
-            permutation = Permutation([index0.index(i) for i in indices[i]])
+            permutation = Permutation([index0.index(j) for j in indices[i]])
             # Perform index permutations:
             args[i] = CodegenArrayPermuteDims(args[i], permutation)
         return CodegenArrayElementwiseAdd(*args), index0

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -50,7 +50,7 @@ class CodegenArrayContraction(Basic):
         return mapping, ranks
 
     def _get_contraction_tuples(self):
-        """
+        r"""
         Return tuples containing the argument index and position within the
         argument of the index position.
 

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from sympy.core.basic import Basic
+from sympy.core.sympify import _sympify
 from sympy.core.mul import Mul
 from sympy.matrices.expressions import MatMul
 from sympy.matrices.expressions.matexpr import MatrixExpr
@@ -69,6 +70,7 @@ class CodegenArrayContraction(Basic):
 
 class CodegenArrayTensorProduct(Basic):
     def __new__(cls, *args):
+        args = [_sympify(arg) for arg in args]
         if len(args) == 1:
             return args[0]
         return Basic.__new__(cls, *args)

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -13,6 +13,8 @@ class CodegenArrayContraction(Basic):
     processable by the code printers.
     """
     def __new__(cls, expr, *indices):
+        indices = [_sympify(ind) for ind in indices]
+        expr = _sympify(expr)
         return Basic.__new__(cls, expr, *indices)
 
     @property

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -329,7 +329,7 @@ class CodegenArrayElementwiseAdd(_CodegenArrayAbstract):
             raise ValueError("summing arrays of different ranks")
         obj._subranks = ranks
         shapes = [arg.shape for arg in args]
-        if len(set([i for i in shapes if i is not None])) != 1:
+        if len(set([i for i in shapes if i is not None])) > 1:
             raise ValueError("mismatching shapes in addition")
         if any(i is None for i in shapes):
             obj._shape = None

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -14,6 +14,14 @@ class CodegenArrayContraction(Basic):
     def __new__(cls, expr, *indices):
         return Basic.__new__(cls, expr, *indices)
 
+    @property
+    def expr(self):
+        return self.args[0]
+
+    @property
+    def contraction_indices(self):
+        return self.args[1:]
+
     @staticmethod
     def from_summation(summation):
         from sympy import Indexed
@@ -71,6 +79,21 @@ class CodegenArrayContraction(Basic):
 class CodegenArrayTensorProduct(Basic):
     def __new__(cls, *args):
         args = [_sympify(arg) for arg in args]
+        ranks = [cls.get_rank(arg) for arg in args]
         if len(args) == 1:
             return args[0]
-        return Basic.__new__(cls, *args)
+        obj = Basic.__new__(cls, *args)
+        obj._ranks = ranks
+        return obj
+
+    @property
+    def ranks(self):
+        return self._ranks[:]
+
+    @classmethod
+    def get_rank(cls, expr):
+        if isinstance(expr, MatrixExpr):
+            return 2
+        if isinstance(expr, NDimArray):
+            return expr.rank()
+        return 0

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from sympy.core.basic import Basic
 from sympy.core.sympify import _sympify
 from sympy.core.mul import Mul
+from sympy.core.compatibility import accumulate, default_sort_key
 from sympy.matrices.expressions import MatMul
 from sympy.matrices.expressions.matexpr import MatrixExpr
 from sympy.tensor.array import NDimArray
@@ -12,10 +13,39 @@ class CodegenArrayContraction(Basic):
     This class is meant to represent contractions of arrays in a form easily
     processable by the code printers.
     """
-    def __new__(cls, expr, *indices):
-        indices = [_sympify(ind) for ind in indices]
+    def __new__(cls, expr, *contraction_indices):
+        contraction_indices = [_sympify(ind) for ind in contraction_indices]
         expr = _sympify(expr)
-        return Basic.__new__(cls, expr, *indices)
+        obj = Basic.__new__(cls, expr, *contraction_indices)
+        obj._mapping = cls._get_mapping_from_contraction_indices(expr, *contraction_indices)
+        return obj
+
+    @staticmethod
+    def _get_mapping_from_contraction_indices(expr, *contraction_indices):
+        if not isinstance(expr, CodegenArrayTensorProduct):
+            return {}
+        args = expr.args
+        ranks = expr.ranks
+        mapping = {}
+        counter = 0
+        for i, rank in enumerate(ranks):
+            for j in range(rank):
+                mapping[counter] = (i, j)
+                counter += 1
+        return mapping
+
+    def _contraction_indices_to_contraction_tuples(self):
+        mapping = self._mapping
+        if not mapping:
+            raise NotImplementedError
+        return [[mapping[j] for j in i] for i in self.contraction_indices]
+
+    @staticmethod
+    def _contraction_tuple_to_contraction_indices(expr, contraction_tuples):
+        # TODO: check that `expr` has `.ranks`:
+        ranks = expr.ranks
+        cumulative_ranks = [0] + list(accumulate(ranks))
+        return [tuple(cumulative_ranks[j]+k for j, k in i) for i in contraction_tuples]
 
     @property
     def expr(self):
@@ -24,6 +54,38 @@ class CodegenArrayContraction(Basic):
     @property
     def contraction_indices(self):
         return self.args[1:]
+
+    def _contraction_indices_to_components(self):
+        expr = self.expr
+        if not isinstance(expr, CodegenArrayTensorProduct):
+            raise NotImplementedError("only for contractions of tensor products")
+        contraction_indices = self.contraction_indices
+        args = expr.args
+        ranks = expr.ranks
+        mapping = {}
+        counter = 0
+        for i, rank in enumerate(ranks):
+            for j in range(rank):
+                mapping[counter] = (i, j)
+                counter += 1
+        return mapping
+
+    def sort_args_by_name(self):
+        expr = self.expr
+        if not isinstance(expr, CodegenArrayTensorProduct):
+            return self
+        args = expr.args
+        sorted_data = sorted(enumerate(args), key=lambda x: default_sort_key(x[1]))
+        pos_sorted, args_sorted = zip(*sorted_data)
+        reordering_map = {i: pos_sorted.index(i) for i, arg in enumerate(args)}
+        contraction_tuples = self._contraction_indices_to_contraction_tuples()
+        contraction_tuples = [[(reordering_map[j], k) for j, k in i] for i in contraction_tuples]
+        c_tp = CodegenArrayTensorProduct(*args_sorted)
+        new_contr_indices = self._contraction_tuple_to_contraction_indices(
+                c_tp,
+                contraction_tuples
+        )
+        return CodegenArrayContraction(c_tp, *new_contr_indices)
 
     @staticmethod
     def from_summation(summation):

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -158,6 +158,12 @@ def test_codegen_array_parse():
     assert _codegen_array_parse(expr) == (CodegenArrayElementwiseAdd(M, CodegenArrayPermuteDims(N, Permutation([1,0]))), (i, j))
     expr = M[i, j] + M[j, i]
     assert _codegen_array_parse(expr) == (CodegenArrayElementwiseAdd(M, CodegenArrayPermuteDims(M, Permutation([1,0]))), (i, j))
+    expr = (M*N*P)[i, j]
+    assert _codegen_array_parse(expr) == (CodegenArrayContraction(CodegenArrayTensorProduct(M, N, P), (1, 2), (3, 4)), (i, j))
+    expr = expr.function  # Disregard summation in previous expression
+    ret1, ret2 =  _codegen_array_parse(expr)
+    assert ret1 == CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P), (1, 2), (3, 4))
+    assert str(ret2) == "(i, j, _i_1, _i_2)"
     expr = KroneckerDelta(i, j)*M[i, k]
     assert _codegen_array_parse(expr) == (M, ({i, j}, k))
     expr = KroneckerDelta(j, k)*(M[i, j]*N[k, l] + N[i, j]*M[k, l])
@@ -165,6 +171,9 @@ def test_codegen_array_parse():
             CodegenArrayTensorProduct(M, N),
             CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), Permutation(0, 2)(1, 3))
         ), (1, 2)), (i, l, frozenset({j, k})))
+    expr = M[i, i]
+    assert _codegen_array_parse(expr) == (CodegenArrayDiagonal(M, (0, 1)), (i,))
+
 
 def test_codegen_array_diagonal():
     cg = CodegenArrayDiagonal(M, (1, 0))

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -1,6 +1,10 @@
 from sympy import symbols, IndexedBase
-from sympy.codegen.array_utils import CodegenArrayContraction, CodegenArrayTensorProduct
+from sympy.codegen.array_utils import (CodegenArrayContraction,
+        CodegenArrayTensorProduct, CodegenArrayDiagonal,
+        CodegenArrayPermuteDims, CodegenArrayElementwiseAdd,
+        _codegen_array_parse)
 from sympy import (MatrixSymbol, Sum)
+from sympy.combinatorics import Permutation
 from sympy.matrices.expressions.matexpr import MatrixElement
 from sympy.matrices import Trace
 
@@ -16,6 +20,9 @@ Q = MatrixSymbol("Q", k, k)
 def test_codegen_array_contraction_construction():
     s = Sum(A[i]*B[i], (i, 0, 3))
     cg = CodegenArrayContraction.from_summation(s)
+    assert cg == CodegenArrayContraction(CodegenArrayTensorProduct(A, B), (0, 1))
+
+    cg = CodegenArrayContraction(CodegenArrayTensorProduct(A, B), (1, 0))
     assert cg == CodegenArrayContraction(CodegenArrayTensorProduct(A, B), (0, 1))
 
     expr = M*N
@@ -118,3 +125,41 @@ def test_codegen_array_flatten():
 
     cgnested = CodegenArrayContraction(cg4, (0, 1), (2, 3))
     assert cgnested == CodegenArrayContraction(CodegenArrayTensorProduct(M, N, P, Q), (0, 2), (1, 5), (3, 7), (4, 6))
+
+    # Flatten nested CodegenArrayDiagonal objects:
+    cg1 = CodegenArrayDiagonal(expr1, (1, 2))
+    cg2 = CodegenArrayDiagonal(expr2, (0, 3))
+    cg3 = CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P, Q), (1, 3), (2, 4))
+    cg4 = CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P, Q), (1, 5), (3, 7))
+
+    cgnested = CodegenArrayDiagonal(cg1, (0, 1))
+    assert cgnested == CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N), (1, 2), (0, 3))
+
+    cgnested = CodegenArrayDiagonal(cg3, (1, 2))
+    assert cgnested == CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P, Q), (1, 3), (2, 4), (5, 6))
+
+    cgnested = CodegenArrayDiagonal(cg4, (1, 2))
+    assert cgnested == CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P, Q), (1, 5), (3, 7), (2, 4))
+
+
+def test_codegen_array_parse():
+    expr = M[i, j]
+    assert _codegen_array_parse(expr) == (M, (i, j))
+    expr = M[i, j]*N[k, l]
+    assert _codegen_array_parse(expr) == (CodegenArrayTensorProduct(M, N), (i, j, k, l))
+    expr = M[i, j]*N[j, k]
+    assert _codegen_array_parse(expr) == (CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N), (1, 2)), (i, k, j))
+    expr = Sum(M[i, j]*N[j, k], (j, 0, k-1))
+    assert _codegen_array_parse(expr) == (CodegenArrayContraction(CodegenArrayTensorProduct(M, N), (1, 2)), (i, k))
+    expr = M[i, j] + N[i, j]
+    assert _codegen_array_parse(expr) == (CodegenArrayElementwiseAdd(M, N), (i, j))
+    expr = M[i, j] + N[j, i]
+    assert _codegen_array_parse(expr) == (CodegenArrayElementwiseAdd(M, CodegenArrayPermuteDims(N, Permutation([1,0]))), (i, j))
+
+
+def test_codegen_array_diagonal():
+    cg = CodegenArrayDiagonal(M, (1, 0))
+    assert cg == CodegenArrayDiagonal(M, (0, 1))
+
+    cg = CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P), (4, 1), (2, 0))
+    assert cg == CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P), (1, 4), (0, 2))

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -25,25 +25,24 @@ def test_codegen_array_contraction_construction():
     result = CodegenArrayContraction(CodegenArrayTensorProduct(M, N, M), (1, 2), (3, 4))
     assert CodegenArrayContraction.from_MatMul(expr) == result
     elem = expr[i, j]
-    result1 = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (1, 4), (2, 5))
-    result2 = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (3, 4), (1, 5))
+    result = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (1, 4), (2, 5))
     cg = CodegenArrayContraction.from_summation(elem)
     cg = cg.sort_args_by_name()
-    assert cg in (result1, result2)
+    assert cg == result
 
 
 def test_codegen_array_contraction_indices_types():
     cg = CodegenArrayContraction(CodegenArrayTensorProduct(M, N), (0, 1))
-    indtup = cg._contraction_indices_to_contraction_tuples()
+    indtup = cg._get_contraction_tuples()
     assert indtup == [[(0, 0), (0, 1)]]
-    assert cg._contraction_tuple_to_contraction_indices(cg.expr, indtup) == [(0, 1)]
+    assert cg._contraction_tuples_to_contraction_indices(cg.expr, indtup) == [(0, 1)]
 
     cg = CodegenArrayContraction(CodegenArrayTensorProduct(M, N), (1, 2))
-    indtup = cg._contraction_indices_to_contraction_tuples()
+    indtup = cg._get_contraction_tuples()
     assert indtup == [[(0, 1), (1, 0)]]
-    assert cg._contraction_tuple_to_contraction_indices(cg.expr, indtup) == [(1, 2)]
+    assert cg._contraction_tuples_to_contraction_indices(cg.expr, indtup) == [(1, 2)]
 
     cg = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (1, 4), (2, 5))
-    indtup = cg._contraction_indices_to_contraction_tuples()
+    indtup = cg._get_contraction_tuples()
     assert indtup == [[(0, 1), (2, 0)], [(1, 0), (2, 1)]]
-    assert cg._contraction_tuple_to_contraction_indices(cg.expr, indtup) == [(1, 4), (2, 5)]
+    assert cg._contraction_tuples_to_contraction_indices(cg.expr, indtup) == [(1, 4), (2, 5)]

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -26,5 +26,24 @@ def test_codegen_array_contraction_construction():
     assert CodegenArrayContraction.from_MatMul(expr) == result
     elem = expr[i, j]
     result1 = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (1, 4), (2, 5))
-    result2 = CodegenArrayContraction(CodegenArrayTensorProduct(M, N, M), (1, 2), (3, 4))
-    assert CodegenArrayContraction.from_summation(elem) in (result1, result2)
+    result2 = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (3, 4), (1, 5))
+    cg = CodegenArrayContraction.from_summation(elem)
+    cg = cg.sort_args_by_name()
+    assert cg in (result1, result2)
+
+
+def test_codegen_array_contraction_indices_types():
+    cg = CodegenArrayContraction(CodegenArrayTensorProduct(M, N), (0, 1))
+    indtup = cg._contraction_indices_to_contraction_tuples()
+    assert indtup == [[(0, 0), (0, 1)]]
+    assert cg._contraction_tuple_to_contraction_indices(cg.expr, indtup) == [(0, 1)]
+
+    cg = CodegenArrayContraction(CodegenArrayTensorProduct(M, N), (1, 2))
+    indtup = cg._contraction_indices_to_contraction_tuples()
+    assert indtup == [[(0, 1), (1, 0)]]
+    assert cg._contraction_tuple_to_contraction_indices(cg.expr, indtup) == [(1, 2)]
+
+    cg = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (1, 4), (2, 5))
+    indtup = cg._contraction_indices_to_contraction_tuples()
+    assert indtup == [[(0, 1), (2, 0)], [(1, 0), (2, 1)]]
+    assert cg._contraction_tuple_to_contraction_indices(cg.expr, indtup) == [(1, 4), (2, 5)]

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -25,5 +25,6 @@ def test_codegen_array_contraction_construction():
     result = CodegenArrayContraction(CodegenArrayTensorProduct(M, N, M), (1, 2), (3, 4))
     assert CodegenArrayContraction.from_MatMul(expr) == result
     elem = expr[i, j]
-    result = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (1, 4), (2, 5))
-    assert CodegenArrayContraction.from_summation(elem) == result
+    result1 = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (1, 4), (2, 5))
+    result2 = CodegenArrayContraction(CodegenArrayTensorProduct(M, N, M), (1, 2), (3, 4))
+    assert CodegenArrayContraction.from_summation(elem) in (result1, result2)

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -1,0 +1,29 @@
+from sympy import symbols, IndexedBase
+from sympy.codegen.array_utils import CodegenArrayContraction, CodegenArrayTensorProduct
+from sympy import (MatrixSymbol, Sum)
+from sympy.matrices.expressions.matexpr import MatrixElement
+
+A, B = symbols("A B", cls=IndexedBase)
+i, j, k, l, m, n = symbols("i j k l m n")
+
+M = MatrixSymbol("M", k, k)
+N = MatrixSymbol("N", k, k)
+
+
+def test_codegen_array_contraction_construction():
+    s = Sum(A[i]*B[i], (i, 0, 3))
+    cg = CodegenArrayContraction.from_summation(s)
+    assert cg == CodegenArrayContraction(CodegenArrayTensorProduct(A, B), (0, 1))
+
+    expr = M*N
+    result = CodegenArrayContraction(CodegenArrayTensorProduct(M, N), (1, 2))
+    assert CodegenArrayContraction.from_MatMul(expr) == result
+    elem = expr[i, j]
+    assert CodegenArrayContraction.from_summation(elem) == result
+
+    expr = M*N*M
+    result = CodegenArrayContraction(CodegenArrayTensorProduct(M, N, M), (1, 2), (3, 4))
+    assert CodegenArrayContraction.from_MatMul(expr) == result
+    elem = expr[i, j]
+    result = CodegenArrayContraction(CodegenArrayTensorProduct(M, M, N), (1, 4), (2, 5))
+    assert CodegenArrayContraction.from_summation(elem) == result

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -155,6 +155,8 @@ def test_codegen_array_parse():
     assert _codegen_array_parse(expr) == (CodegenArrayElementwiseAdd(M, N), (i, j))
     expr = M[i, j] + N[j, i]
     assert _codegen_array_parse(expr) == (CodegenArrayElementwiseAdd(M, CodegenArrayPermuteDims(N, Permutation([1,0]))), (i, j))
+    expr = M[i, j] + M[j, i]
+    assert _codegen_array_parse(expr) == (CodegenArrayElementwiseAdd(M, CodegenArrayPermuteDims(M, Permutation([1,0]))), (i, j))
 
 
 def test_codegen_array_diagonal():
@@ -163,3 +165,9 @@ def test_codegen_array_diagonal():
 
     cg = CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P), (4, 1), (2, 0))
     assert cg == CodegenArrayDiagonal(CodegenArrayTensorProduct(M, N, P), (1, 4), (0, 2))
+
+
+def test_codegen_recognize_matrix_expression():
+
+    expr = CodegenArrayElementwiseAdd(M, CodegenArrayPermuteDims(M, [1, 0]))
+    assert _recognize_matrix_expression(expr) == _RecognizeMatAdd([M, Trace(M)])

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -98,6 +98,7 @@ if PY3:
         MutableSet, Iterable, Hashable)
 
     from inspect import unwrap
+    from itertools import accumulate
 else:
     import codecs
     import types
@@ -176,6 +177,14 @@ else:
                 raise ValueError('wrapper loop when unwrapping {!r}'.format(f))
             memo.add(id_func)
         return func
+
+    def accumulate(iterable, func=operator.add):
+        state = iterable[0]
+        yield state
+        for i in iterable[1:]:
+            state = func(state, i)
+            yield state
+
 
 def with_metaclass(meta, *bases):
     """

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4242,15 +4242,15 @@ def test_sympy__physics__optics__medium__Medium():
 def test_sympy__codegen__array_utils__CodegenArrayContraction():
     from sympy.codegen.array_utils import CodegenArrayContraction
     from sympy import IndexedBase
-    A, B = symbols("A B", cls=IndexedBase)
-    assert _test_args(CodegenArrayContraction(A, B))
+    A = symbols("A", cls=IndexedBase)
+    assert _test_args(CodegenArrayContraction(A, (0, 1)))
 
 
 def test_sympy__codegen__array_utils__CodegenArrayTensorProduct():
     from sympy.codegen.array_utils import CodegenArrayTensorProduct
     from sympy import IndexedBase
-    A = symbols("A", cls=IndexedBase)
-    assert _test_args(CodegenArrayTensorProduct(A, (0, 1)))
+    A, B = symbols("A B", cls=IndexedBase)
+    assert _test_args(CodegenArrayTensorProduct(A, B))
 
 
 def test_sympy__codegen__ast__Assignment():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4246,11 +4246,32 @@ def test_sympy__codegen__array_utils__CodegenArrayContraction():
     assert _test_args(CodegenArrayContraction(A, (0, 1)))
 
 
+def test_sympy__codegen__array_utils__CodegenArrayDiagonal():
+    from sympy.codegen.array_utils import CodegenArrayDiagonal
+    from sympy import IndexedBase
+    A = symbols("A", cls=IndexedBase)
+    assert _test_args(CodegenArrayDiagonal(A, (0, 1)))
+
+
 def test_sympy__codegen__array_utils__CodegenArrayTensorProduct():
     from sympy.codegen.array_utils import CodegenArrayTensorProduct
     from sympy import IndexedBase
     A, B = symbols("A B", cls=IndexedBase)
     assert _test_args(CodegenArrayTensorProduct(A, B))
+
+
+def test_sympy__codegen__array_utils__CodegenArrayElementwiseAdd():
+    from sympy.codegen.array_utils import CodegenArrayElementwiseAdd
+    from sympy import IndexedBase
+    A, B = symbols("A B", cls=IndexedBase)
+    assert _test_args(CodegenArrayElementwiseAdd(A, B))
+
+
+def test_sympy__codegen__array_utils__CodegenArrayPermuteDims():
+    from sympy.codegen.array_utils import CodegenArrayPermuteDims
+    from sympy import IndexedBase
+    A = symbols("A", cls=IndexedBase)
+    assert _test_args(CodegenArrayPermuteDims(A, (1, 0)))
 
 
 def test_sympy__codegen__ast__Assignment():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -4239,6 +4239,20 @@ def test_sympy__physics__optics__medium__Medium():
     assert _test_args(Medium('m'))
 
 
+def test_sympy__codegen__array_utils__CodegenArrayContraction():
+    from sympy.codegen.array_utils import CodegenArrayContraction
+    from sympy import IndexedBase
+    A, B = symbols("A B", cls=IndexedBase)
+    assert _test_args(CodegenArrayContraction(A, B))
+
+
+def test_sympy__codegen__array_utils__CodegenArrayTensorProduct():
+    from sympy.codegen.array_utils import CodegenArrayTensorProduct
+    from sympy import IndexedBase
+    A = symbols("A", cls=IndexedBase)
+    assert _test_args(CodegenArrayTensorProduct(A, (0, 1)))
+
+
 def test_sympy__codegen__ast__Assignment():
     from sympy.codegen.ast import Assignment
     assert _test_args(Assignment(x, y))

--- a/sympy/matrices/expressions/funcmatrix.py
+++ b/sympy/matrices/expressions/funcmatrix.py
@@ -45,7 +45,8 @@ class FunctionMatrix(MatrixExpr):
 
     def _eval_trace(self):
         from sympy.matrices.expressions.trace import Trace
-        return Trace._eval_rewrite_as_Sum(Trace(self)).doit()
+        from sympy import Sum
+        return Trace(self).rewrite(Sum).doit()
 
     def as_real_imag(self):
         return (re(Matrix(self)), im(Matrix(self)))

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -215,6 +215,7 @@ class MatrixExpr(Expr):
             return Sum(x.args[0], (di, 0, x.args[0].shape[0]-1))
         M = M.replace(lambda x: isinstance(x, Trace), getsum)
 
+        print("Input: ", M, "\n\n")
         repl = {}
         if self.shape[0] == 1:
             repl[i] = 0
@@ -231,6 +232,7 @@ class MatrixExpr(Expr):
         if len(repl) < 2:
             parsed = res
         else:
+            print(res, "\n\n")
             if m not in repl:
                 parsed = MatrixExpr.from_index_summation(res, m)
             elif i not in repl:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -215,7 +215,6 @@ class MatrixExpr(Expr):
             return Sum(x.args[0], (di, 0, x.args[0].shape[0]-1))
         M = M.replace(lambda x: isinstance(x, Trace), getsum)
 
-        print("Input: ", M, "\n\n")
         repl = {}
         if self.shape[0] == 1:
             repl[i] = 0
@@ -232,7 +231,6 @@ class MatrixExpr(Expr):
         if len(repl) < 2:
             parsed = res
         else:
-            print(res, "\n\n")
             if m not in repl:
                 parsed = MatrixExpr.from_index_summation(res, m)
             elif i not in repl:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -618,6 +618,10 @@ class MatrixElement(Expr):
             args = self.args
         return args[0][args[1], args[2]]
 
+    @property
+    def indices(self):
+        return self.args[1:]
+
     def _eval_derivative(self, v):
         from sympy import Sum, symbols, Dummy
 

--- a/sympy/matrices/expressions/tests/test_trace.py
+++ b/sympy/matrices/expressions/tests/test_trace.py
@@ -90,6 +90,5 @@ def test_trace_constant_factor():
     assert trace(MatMul(2, X)) == 10
 
 
-@XFAIL
 def test_rewrite():
     assert isinstance(trace(A).rewrite(Sum), Sum)

--- a/sympy/matrices/expressions/trace.py
+++ b/sympy/matrices/expressions/trace.py
@@ -42,6 +42,7 @@ class Trace(Expr):
         t1 = Dummy("t_1")
         m = Dummy("m")
         n = Dummy("n")
+        # TODO: use self.rewrite(Sum) instead:
         return MatrixExpr.from_index_summation(
                 Sum(self.args[0][t1, t1].diff(v[m, n]), (t1, 0, self.args[0].shape[0]-1)),
                 m,
@@ -66,8 +67,7 @@ class Trace(Expr):
             else:
                 return Trace(self.arg)
 
-
-    def _eval_rewrite_as_Sum(self, **kwargs):
+    def _eval_rewrite_as_Sum(self, expr, **kwargs):
         from sympy import Sum, Dummy
         i = Dummy('i')
         return Sum(self.arg[i, i], (i, 0, self.arg.rows-1)).doit()

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -519,7 +519,7 @@ class NumPyPrinter(PythonCodePrinter):
             counter = 0
             d = {j: min(i) for i in contraction_indices for j in i}
             indices = []
-            for rank_arg in base.ranks:
+            for rank_arg in base.subranks:
                 lindices = []
                 for i in range(rank_arg):
                     if counter in d:

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -504,6 +504,37 @@ class NumPyPrinter(PythonCodePrinter):
             func = self._module_format('numpy.array')
         return "%s(%s)" % (func, self._print(expr.tolist()))
 
+    def _print_CodegenArrayTensorProduct(self, expr):
+        array_list = [j for i, arg in enumerate(expr.args) for j in
+                (self._print(arg), "[%i]" % i)]
+        return "%s(%s)" % (self._module_format('numpy.einsum'), ", ".join(array_list))
+
+    def _print_CodegenArrayContraction(self, expr):
+        from sympy.codegen.array_utils import CodegenArrayTensorProduct
+        base = expr.expr
+        contraction_indices = expr.contraction_indices
+        if len(contraction_indices) == 0:
+            return self._print(base)
+        if isinstance(base, CodegenArrayTensorProduct):
+            counter = 0
+            d = {j: min(i) for i in contraction_indices for j in i}
+            indices = []
+            for rank_arg in base.ranks:
+                lindices = []
+                for i in range(rank_arg):
+                    if counter in d:
+                        lindices.append(d[counter])
+                    else:
+                        lindices.append(counter)
+                    counter += 1
+                indices.append(lindices)
+            elems = ["%s, %s" % (self._print(arg), ind) for arg, ind in zip(base.args, indices)]
+            return "%s(%s)" % (
+                self._module_format('numpy.einsum'),
+                ", ".join(elems)
+            )
+        raise NotImplementedError()
+
 
 for k in NumPyPrinter._kf:
     setattr(NumPyPrinter, '_print_%s' % k, _print_known_func)

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -1,6 +1,8 @@
-from sympy import Piecewise, lambdify, Equality, Unequality, Sum, Mod, cbrt, sqrt
+from sympy import (Piecewise, lambdify, Equality, Unequality, Sum, Mod, cbrt,
+        sqrt, MatrixSymbol)
 from sympy.abc import x, i, j, a, b, c, d
 from sympy.codegen.cfunctions import log1p, expm1, hypot, log10, exp2, log2, Cbrt, Sqrt
+from sympy.codegen.array_utils import CodegenArrayContraction
 from sympy.printing.lambdarepr import NumPyPrinter
 
 from sympy.utilities.pytest import skip
@@ -49,6 +51,21 @@ def test_multiple_sums():
     x_ = np.linspace(-1, +1, 10)
     assert np.allclose(f(a_, b_, c_, d_, x_),
                        sum((x_ + j_) * i_ for i_ in range(a_, b_ + 1) for j_ in range(c_, d_ + 1)))
+
+
+def test_codegen_einsum():
+    if not np:
+        skip("NumPy not installed")
+
+    M = MatrixSymbol("M", 2, 2)
+    N = MatrixSymbol("N", 2, 2)
+
+    cg = CodegenArrayContraction.from_MatMul(M*N)
+    f = lambdify((M, N), cg, 'numpy')
+
+    ma = np.matrix([[1, 2], [3, 4]])
+    mb = np.matrix([[1,-2], [-1, 3]])
+    assert (f(ma, mb) == ma*mb).all()
 
 
 def test_relational():


### PR DESCRIPTION
In this PR:

- [x] create some classes representing the abstract syntax tree of tensor products and contractions of array.
- [ ] create code printers for the new classes
- [ ] make sure ordinary expressions with indices can be transformed into this form.
- [x] check bounds of contraction (axes numbers have to lie within the total rank, no repetitions allowed).

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * Added classes to support generation of array operations in printers.
<!-- END RELEASE NOTES -->
