### PR TITLE
Check for empty list in lie_group solver

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -5645,6 +5645,8 @@ def ode_lie_group(eq, func, order, match):
     else:
         try:
             sol = solve(eq, df)
+            if sol == []:
+                raise NotImplementedError
         except NotImplementedError:
             raise NotImplementedError("Unable to solve the differential equation " +
                 str(eq) + " by the lie group method")

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2798,6 +2798,10 @@ def test_lie_group():
     assert sol == Eq(f(x), 2/(C1 + x**2))
     assert checkodesol(eq, sol)[0]
 
+@XFAIL
+def test_lie_group_issue15219():
+    eqn = exp(f(x).diff(x)-f(x))
+    assert 'lie_group' not in classify_ode(eqn, f(x))
 
 def test_user_infinitesimals():
     C2 = Symbol("C2")


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Partially fixes #15219 

#### Brief description of what is fixed or changed

The Lie group solver in `dsolve` doesn't check for `solve` returning an empty list leading to an `IndexError`. This patch changes it to check for the empty list so that it raises a more informative error message:

```julia
In [1]: dsolve(exp(f(x).diff(x)-f(x)), f(x))
...
~/current/sympy/sympy/sympy/solvers/ode.py in ode_lie_group(eq, func, order, match)
   5650         except NotImplementedError:
   5651             raise NotImplementedError("Unable to solve the differential equation " +
-> 5652                 str(eq) + " by the lie group method")
   5653         else:
   5654             y = Dummy("y")

NotImplementedError: Unable to solve the differential equation exp(-f(x) + Derivative(f(x), x)) by the lie group method
```

#### Other comments

This problem is probably down to the fact that the Lie group solver shouldn't be matching this eqn in `classify_ode`:
```julia
In [3]: classify_ode(exp(f(x).diff(x)-f(x)), f(x))
Out[3]: ('lie_group',)
```
I don't know this solution method well enough to work out exactly why that is but I've added an `XFAIL` test for this.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * dsolve now raises NotImplementedError instead of IndexError for a particular type of invalid ODE.
<!-- END RELEASE NOTES -->
