### PR TITLE
Raise exception when collecting a noncommutative symbol

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -371,6 +371,9 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
                 print("DEBUG: returned %s" % str(result))
 
             if result is not None:
+                if not symbol.is_commutative:
+                    raise AttributeError("Can not collect noncommutative symbol")
+
                 terms, elems, common_expo, has_deriv = result
 
                 # when there was derivative in current pattern we

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -420,3 +420,15 @@ def test_issue_5933():
     x = Polygon(*RegularPolygon((0, 0), 1, 5).vertices).centroid.x
     assert abs(denom(x).n()) > 1e-12
     assert abs(denom(radsimp(x))) > 1e-12  # in case simplify didn't handle it
+
+
+def test_issue_14608():
+    a, b = symbols('a b', commutative=False)
+    x, y = symbols('x y')
+    try:
+        collect(a*b + b*a, a)
+        raise AssertionError("Collect did not raise AttributeError")
+    except AttributeError:
+        pass
+    assert collect(x*y + y*(x+1), a) == x*y + y*(x+1)
+    assert collect(x*y + y*(x+1) + a*b + b*a, y) == y*(2*x + 1) + a*b + b*a

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -5,7 +5,7 @@ from sympy import (
 
 from sympy.core.mul import _unevaluated_Mul as umul
 from sympy.simplify.radsimp import _unevaluated_Add, collect_sqrt, fraction_expand
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 
@@ -425,10 +425,6 @@ def test_issue_5933():
 def test_issue_14608():
     a, b = symbols('a b', commutative=False)
     x, y = symbols('x y')
-    try:
-        collect(a*b + b*a, a)
-        raise AssertionError("Collect did not raise AttributeError")
-    except AttributeError:
-        pass
+    raises(AttributeError, lambda: collect(a*b + b*a, a))
     assert collect(x*y + y*(x+1), a) == x*y + y*(x+1)
     assert collect(x*y + y*(x+1) + a*b + b*a, y) == y*(2*x + 1) + a*b + b*a


### PR DESCRIPTION
Fixes #14608
The exception is only raised when the expression contains the noncommutative symbol

As stated in https://github.com/sympy/sympy/issues/14608#issuecomment-434138072

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Raise exception when collecting a noncommutative symbol
<!-- END RELEASE NOTES -->
