### PR TITLE
Use matrix exp for linear systems in dsolve

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -8095,7 +8095,10 @@ def matrix_exp_jordan_form(A, t):
                 blocks.append(exp(e * t) * expJblock)
 
     expJ = Matrix.diag(*blocks)
-    P = Matrix.hstack(*vectors)
+    if len(vectors):
+        P = vectors[0].hstack(*vectors)
+    else:
+        P = Matrix(0, 0)
 
     return P, expJ
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -7982,6 +7982,121 @@ def sysode_linear_neq_order1(match_):
     sol = _linear_neq_order1_type1(match_)
     return sol
 
+def matrix_exp(A, t):
+    '''Matrix exponential exp(A*t) for the matrix A and scalar t.
+
+    The matrix exponential exp(A*t) appears in the solution of linear
+    differential equations. For example if x is a vector and A is a matrix
+    then the initial value problem
+
+        dx(t)/dt = A x(t),   x(0) = x0
+
+    has the unique solution
+
+        x(t) = exp(A t) x0
+
+    Example:
+
+    >>> from sympy import Symbol, Matrix, pprint
+    >>> from sympy.solvers.ode import matrix_exp
+    >>> t = Symbol('t')
+    >>> A = Matrix([[2, -5], [2, -4]])
+    >>> pprint(A)
+    [2  -5]
+    [     ]
+    [2  -4]
+    >>> pprint(matrix_exp(A, t))
+    [   -t           -t                    -t              ]
+    [3*e  *sin(t) + e  *cos(t)         -5*e  *sin(t)       ]
+    [                                                      ]
+    [         -t                     -t           -t       ]
+    [      2*e  *sin(t)         - 3*e  *sin(t) + e  *cos(t)]
+    '''
+    P, J = matrix_exp_jordan_form(A, t)
+    return P * J * P.inv()
+
+def matrix_exp_jordan_form(A, t):
+    '''Matrix exponential exp(A*t) for the matrix A and scalar t.
+
+    Returns the Jordan form of the exp(A t).
+
+    >>> from sympy import Matrix, Symbol
+    >>> from sympy.solvers.ode import matrix_exp, matrix_exp_jordan_form
+    >>> t = Symbol('t')
+    >>> A = Matrix([[1, 1], [0, 1]])
+    >>> P, J = matrix_exp_jordan_form(A, t)
+    >>> P * J * P.inv() == matrix_exp(A, t)
+    True
+    '''
+
+    N, M = A.shape
+    if N != M:
+        raise ValueError('Needed square matrix but got shape (%s, %s)' % (N, M))
+    elif A.has(t):
+        raise ValueError('Matrix A should not depend on t')
+
+    def jordan_chains(A):
+        '''Chains from Jordan normal form analogous to M.eigenvects().
+
+        Returns a dict with eignevalues as keys like:
+            {e1: [[v111,v112,...], [v121, v122,...]], e2:...}
+        where vijk is the kth vector in the jth chain for eigenvalue i.
+        '''
+        P, blocks = A.jordan_cells()
+        basis = [P[:,i] for i in range(P.shape[1])]
+        n = 0
+        chains = {}
+        for b in blocks:
+            eigval = b[0, 0]
+            size = b.shape[0]
+            if eigval not in chains:
+                chains[eigval] = []
+            chains[eigval].append(basis[n:n+size])
+            n += size
+        return chains
+
+    eigenchains = jordan_chains(A)
+
+    blocks = []
+    vectors = []
+    seen_conjugate = set()
+    for e, chains in eigenchains.items():
+        for chain in chains:
+            n = len(chain)
+            if im(e).is_nonzero:
+                if e in seen_conjugate:
+                    continue
+                seen_conjugate.add(e.conjugate())
+                exprt = exp(re(e) * t)
+                imrt = im(e) * t
+                imblock = Matrix([[cos(imrt), sin(imrt)],
+                                  [-sin(imrt), cos(imrt)]])
+                expJblock = Matrix(0, 2*n, [])
+                for i in range(n):
+                    subblockrow = Matrix(2, 0, [])
+                    for j in range(n):
+                        if j >= i:
+                            subblock = imblock * t**(j-i) / factorial(j-i)
+                        else:
+                            subblock = zeros(2, 2)
+                        subblockrow = subblockrow.row_join(subblock)
+                    expJblock = expJblock.col_join(subblockrow)
+                blocks.append(exprt * expJblock)
+                for i in range(n):
+                    vectors.append(re(chain[i]))
+                    vectors.append(im(chain[i]))
+            else:
+                vectors.extend(chain)
+                fun = lambda i,j: t**(j-i)/factorial(j-i) if j >= i else 0
+                expJblock = Matrix(n, n, fun)
+                blocks.append(exp(e * t) * expJblock)
+
+    expJ = Matrix.diag(*blocks)
+    P = Matrix.hstack(*vectors)
+
+    return P, expJ
+
+
 def _linear_neq_order1_type1(match_):
     r"""
     System of n first-order constant-coefficient linear nonhomogeneous differential equation
@@ -8056,47 +8171,16 @@ def _linear_neq_order1_type1(match_):
     n = len(eq)
     t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
     constants = numbered_symbols(prefix='C', cls=Symbol, start=1)
+
     M = Matrix(n,n,lambda i,j:-fc[i,func[j],0])
-    evector = M.eigenvects(simplify=True)
-    def is_complex(mat, root):
-        return Matrix(n, 1, lambda i,j: re(mat[i])*cos(im(root)*t) - im(mat[i])*sin(im(root)*t))
-    def is_complex_conjugate(mat, root):
-        return Matrix(n, 1, lambda i,j: re(mat[i])*sin(abs(im(root))*t) + im(mat[i])*cos(im(root)*t)*abs(im(root))/im(root))
-    conjugate_root = []
-    e_vector = zeros(n,1)
-    for evects in evector:
-        if evects[0] not in conjugate_root:
-            # If number of column of an eigenvector is not equal to the multiplicity
-            # of its eigenvalue then the legt eigenvectors are calculated
-            if len(evects[2])!=evects[1]:
-                var_mat = Matrix(n, 1, lambda i,j: Symbol('x'+str(i)))
-                Mnew = (M - evects[0]*eye(evects[2][-1].rows))*var_mat
-                w = [0 for i in range(evects[1])]
-                w[0] = evects[2][-1]
-                for r in range(1, evects[1]):
-                    w_ = Mnew - w[r-1]
-                    sol_dict = solve(list(w_), var_mat[1:])
-                    sol_dict[var_mat[0]] = var_mat[0]
-                    for key, value in sol_dict.items():
-                        sol_dict[key] = value.subs(var_mat[0],1)
-                    w[r] = Matrix(n, 1, lambda i,j: sol_dict[var_mat[i]])
-                    evects[2].append(w[r])
-            for i in range(evects[1]):
-                C = next(constants)
-                for j in range(i+1):
-                    if evects[0].has(I):
-                        evects[2][j] = simplify(evects[2][j])
-                        e_vector += C*is_complex(evects[2][j], evects[0])*t**(i-j)*exp(re(evects[0])*t)/factorial(i-j)
-                        C = next(constants)
-                        e_vector += C*is_complex_conjugate(evects[2][j], evects[0])*t**(i-j)*exp(re(evects[0])*t)/factorial(i-j)
-                    else:
-                        e_vector += C*evects[2][j]*t**(i-j)*exp(evects[0]*t)/factorial(i-j)
-            if evects[0].has(I):
-                conjugate_root.append(conjugate(evects[0]))
-    sol = []
-    for i in range(len(eq)):
-        sol.append(Eq(func[i],e_vector[i]))
-    return sol
+    P, J = matrix_exp_jordan_form(M, t)
+    P = simplify(P)
+    Cvect = Matrix(list(next(constants) for _ in range(n)))
+    sol_vector = P * J * Cvect
+
+    sol_dict = [Eq(func[i], sol_vector[i]) for i in range(n)]
+    return sol_dict
+
 
 def sysode_nonlinear_2eq_order1(match_):
     func = match_['func']

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -8057,10 +8057,13 @@ def matrix_exp_jordan_form(A, t):
 
     eigenchains = jordan_chains(A)
 
+    # Needed for consistency across Python versions:
+    eigenchains = sorted(eigenchains.items(), key=default_sort_key)
+
     blocks = []
     vectors = []
     seen_conjugate = set()
-    for e, chains in eigenchains.items():
+    for e, chains in eigenchains:
         for chain in chains:
             n = len(chain)
             if im(e).is_nonzero:

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -8074,16 +8074,11 @@ def matrix_exp_jordan_form(A, t):
                 imrt = im(e) * t
                 imblock = Matrix([[cos(imrt), sin(imrt)],
                                   [-sin(imrt), cos(imrt)]])
-                expJblock = Matrix(0, 2*n, [])
-                for i in range(n):
-                    subblockrow = Matrix(2, 0, [])
-                    for j in range(n):
-                        if j >= i:
-                            subblock = imblock * t**(j-i) / factorial(j-i)
-                        else:
-                            subblock = zeros(2, 2)
-                        subblockrow = subblockrow.row_join(subblock)
-                    expJblock = expJblock.col_join(subblockrow)
+                expJblock2 = Matrix(n, n, lambda i,j:
+                        imblock * t**(j-i) / factorial(j-i) if j >= i
+                        else zeros(2, 2))
+                expJblock = Matrix(2*n, 2*n, lambda i,j: expJblock2[i//2,j//2][i%2,j%2])
+
                 blocks.append(exprt * expJblock)
                 for i in range(n):
                     vectors.append(re(chain[i]))
@@ -8095,10 +8090,7 @@ def matrix_exp_jordan_form(A, t):
                 blocks.append(exp(e * t) * expJblock)
 
     expJ = Matrix.diag(*blocks)
-    if len(vectors):
-        P = vectors[0].hstack(*vectors)
-    else:
-        P = Matrix(0, 0)
+    P = Matrix(N, N, lambda i,j: vectors[j][i])
 
     return P, expJ
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -8059,6 +8059,7 @@ def matrix_exp_jordan_form(A, t):
 
     # Needed for consistency across Python versions:
     eigenchains = sorted(eigenchains.items(), key=default_sort_key)
+    isreal = not A.has(I)
 
     blocks = []
     vectors = []
@@ -8066,7 +8067,7 @@ def matrix_exp_jordan_form(A, t):
     for e, chains in eigenchains:
         for chain in chains:
             n = len(chain)
-            if im(e).is_nonzero:
+            if isreal and im(e).is_nonzero:
                 if e in seen_conjugate:
                     continue
                 seen_conjugate.add(e.conjugate())

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3028,6 +3028,12 @@ def test_matrix_exp():
     #[ 0,  0, -c - e - f,  0],
     #[ 0,  0,          f, -d]])
 
+    A = Matrix([[0, I], [I, 0]])
+    expAt = Matrix([
+    [exp(I*t)/2 + exp(-I*t)/2, exp(I*t)/2 - exp(-I*t)/2],
+    [exp(I*t)/2 - exp(-I*t)/2, exp(I*t)/2 + exp(-I*t)/2]])
+    assert matrix_exp(A, t) == expAt
+
 def test_sysode_linear_neq_order1():
 
     x, y = symbols('x y', cls=Function)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3029,7 +3029,108 @@ def test_matrix_exp():
     #[ 0,  0,          f, -d]])
 
 def test_sysode_linear_neq_order1():
-    from sympy.abc import t
+
+    x, y = symbols('x y', cls=Function)
+    a, b, c, t = symbols('a b c t')
+
+    # The 2x2 systems tested below are all handled by _linear_2eq_order1_type1
+    # rather than _linear_neq_order1_type1. I'm adding the tests here because
+    # I think that _linear_2eq_order1_type1 should be removed in favour of
+    # _linear_neq_order1_type1.
+
+    eq1 = [Eq(x(t).diff(t), x(t)), Eq(y(t).diff(t), y(t))]
+    sol1 = [Eq(x(t), C1*exp(t)), Eq(y(t), C2*exp(t))]
+    assert dsolve(eq1) == sol1
+    assert checksysodesol(eq1, sol1) == (True, [0, 0])
+
+    eq2 = [Eq(x(t).diff(t), 2*x(t)), Eq(y(t).diff(t), 3*y(t))]
+    #sol2 = [Eq(x(t), C1*exp(2*t)), Eq(y(t), C2*exp(3*t))]
+    sol2 = [Eq(x(t), -C2*exp(2*t)), Eq(y(t), C1*exp(3*t))]
+    assert dsolve(eq2) == sol2
+    assert checksysodesol(eq2, sol2) == (True, [0, 0])
+
+    eq3 = [Eq(x(t).diff(t), a*x(t)), Eq(y(t).diff(t), a*y(t))]
+    sol3 = [Eq(x(t), C1*exp(a*t)), Eq(y(t), C2*exp(a*t))]
+    assert dsolve(eq3) == sol3
+    assert checksysodesol(eq3, sol3) == (True, [0, 0])
+
+    eq4 = [Eq(x(t).diff(t), a*x(t)), Eq(y(t).diff(t), b*y(t))]
+    sol4 = [Eq(x(t), C1*exp(a*t)), Eq(y(t), C2*exp(b*t))]
+    #assert dsolve(eq4) == sol4
+    assert checksysodesol(eq4, sol4) == (True, [0, 0])
+
+    eq5 = [Eq(x(t).diff(t), -y(t)), Eq(y(t).diff(t), x(t))]
+    #sol5 = [Eq(x(t), C1*cos(t) - C2*sin(t)), Eq(y(t), C1*sin(t) + C2*cos(t))]
+    sol5 = [Eq(x(t), -C1*cos(t) - C2*sin(t)), Eq(y(t), -C1*sin(t) + C2*cos(t))]
+    assert dsolve(eq5) == sol5
+    assert checksysodesol(eq5, sol5) == (True, [0, 0])
+
+    eq6 = [Eq(x(t).diff(t), -2*y(t)), Eq(y(t).diff(t), 2*x(t))]
+    #sol6 = [Eq(x(t), C1*cos(2*t) + C2*sin(2*t)), Eq(y(t), C1*sin(2*t) - C2*cos(2*t))]
+    sol6 = [Eq(x(t), -2*C1*cos(2*t) - 2*C2*sin(2*t)), Eq(y(t), -2*C1*sin(2*t) + 2*C2*cos(2*t))]
+    assert dsolve(eq6) == sol6
+    assert checksysodesol(eq6, sol6) == (True, [0, 0])
+
+    eq7 = [Eq(x(t).diff(t), I*y(t)), Eq(y(t).diff(t), I*x(t))]
+    #sol7 = [Eq(x(t), C1*exp(I*t) + C2*exp(-I*t)), Eq(y(t), C1*exp(I*t) - C2*exp(-I*t))]
+    sol7 = [Eq(x(t), I*C1*exp(I*t) + I*C2*exp(-I*t)), Eq(y(t), I*C1*exp(I*t) - I*C2*exp(-I*t))]
+    assert dsolve(eq7) == sol7
+    assert checksysodesol(eq7, sol7) == (True, [0, 0])
+
+    eq8 = [Eq(x(t).diff(t), -a*y(t)), Eq(y(t).diff(t), a*x(t))]
+    sol8 = [Eq(x(t), C1*cos(a*t) + C2*sin(a*t)), Eq(y(t), C1*sin(a*t) - C2*cos(a*t))]
+    #assert dsolve(eq8) == sol8
+    assert checksysodesol(eq8, sol8) == (True, [0, 0])
+
+    eq9 = [Eq(x(t).diff(t), x(t) + y(t)), Eq(y(t).diff(t), x(t) - y(t))]
+    sol9 = [Eq(x(t), C1*exp(sqrt(2)*t) + C2*exp(-sqrt(2)*t)),
+            Eq(y(t), C1*(-1 + sqrt(2))*exp(sqrt(2)*t) + C2*(-sqrt(2) - 1)*exp(-sqrt(2)*t))]
+    assert dsolve(eq9) == sol9
+    assert checksysodesol(eq9, sol9) == (True, [0, 0])
+
+    eq10 = [Eq(x(t).diff(t), x(t) + y(t)), Eq(y(t).diff(t), x(t) + y(t))]
+    sol10 = [Eq(x(t), C1*exp(2*t) + C2), Eq(y(t), C1 * exp(2*t) - C2)]
+    assert dsolve(eq10) == sol10
+    assert checksysodesol(eq10, sol10) == (True, [0, 0])
+
+    eq11 = [Eq(x(t).diff(t), 2*x(t) + y(t)), Eq(y(t).diff(t), -x(t) + 2*y(t))]
+    sol11 = [Eq(x(t), (C1*cos(t) + C2*sin(t)) * exp(2*t)),
+             Eq(y(t), (-C1*sin(t) + C2*cos(t)) * exp(2*t))]
+    assert dsolve(eq11) == sol11
+    assert checksysodesol(eq11, sol11) == (True, [0, 0])
+
+    eq12 = [Eq(x(t).diff(t), x(t) + 2*y(t)), Eq(y(t).diff(t), 2*x(t) + y(t))]
+    #sol12 = [Eq(x(t), C1*exp(-t) + C2*exp(3*t)),
+    #         Eq(y(t), -C1*exp(-t) + C2*exp(3*t))]
+    sol12 = [Eq(x(t), 2*C2*exp(-t) + 2*C1*exp(3*t)),
+             Eq(y(t), -2*C2*exp(-t) + 2*C1*exp(3*t))]
+    assert dsolve(eq12) == sol12
+    assert checksysodesol(eq12, sol12) == (True, [0, 0])
+
+    eq13 = [Eq(x(t).diff(t), 4*x(t) + y(t)), Eq(y(t).diff(t), -x(t) + 2*y(t))]
+    sol13 = [Eq(x(t), (C1 + C2*(t+1)) * exp(3*t)),
+             Eq(y(t), -(C1 + C2*t) * exp(3*t))]
+    assert dsolve(eq13) == sol13
+    assert checksysodesol(eq13, sol13) == (True, [0, 0])
+
+    eq14 = [Eq(x(t).diff(t), a*y(t)), Eq(y(t).diff(t), a*x(t))]
+    sol14 = [Eq(x(t), C1*exp(a*t) + C2*exp(-a*t)), Eq(y(t), C1*exp(a*t) - C2*exp(-a*t))]
+    #assert dsolve(eq14) == sol14
+    assert checksysodesol(eq14, sol14) == (True, [0, 0])
+
+    eq15 = [Eq(x(t).diff(t), a*y(t)), Eq(y(t).diff(t), b*x(t))]
+    sol15 = [Eq(x(t), -C1*a*exp(-t*sqrt(a*b))/sqrt(a*b) + C2*a*exp(t*sqrt(a*b))/sqrt(a*b)),
+             Eq(y(t), C1*exp(-t*sqrt(a*b)) + C2*exp(t*sqrt(a*b)))]
+    #assert dsolve(eq15) == sol15
+    assert checksysodesol(eq15, sol15) == (True, [0, 0])
+
+    eq16 = [Eq(x(t).diff(t), a*x(t) + b*y(t)), Eq(y(t).diff(t), c*x(t))]
+    sol16 = [Eq(x(t), -2*C2*b*exp(t*(a/2 - sqrt(a**2 + 4*b*c)/2))/(a + sqrt(a**2 + 4*b*c))
+                     - 2*C3*b*exp(t*(a/2 + sqrt(a**2 + 4*b*c)/2))/(a - sqrt(a**2 + 4*b*c))),
+            Eq(y(t), C2*exp(t*(a/2 - sqrt(a**2 + 4*b*c)/2))
+                   + C3*exp(t*(a/2 + sqrt(a**2 + 4*b*c)/2)))]
+    #assert dsolve(eq16) == sol16
+    assert checksysodesol(eq16, sol16) == (True, [0, 0])
 
     Z0 = Function('Z0')
     Z1 = Function('Z1')


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #14312

See also #15474 and #15407 

#### Brief description of what is fixed or changed

Add matrix exponential `matrix_exp(A, t)` to compute `exp(A t)` for a matrix `A`. Use this to solve first order systems of linear homogeneous constant coefficient ODEs with `dsolve`.

The existing code for this only works for systems whose matrix has a particular structure of Jordan blocks (discussed in #14312. This version uses the `jordan_form` to fully form the matrix exponential in all cases.

Using the matrix exponential directly results in overly complicated expressions in the case of symbolic coefficients. Given `exp(A t)` the solution for any initial value problemis `exp(A t) x0` where `x0` is the vector of initial conditions. Since we only compute the general solution here `x0` is an arbitrary constant vector `c` so we would naturally return `exp(A t) c`.

This method computes the `exp(A t)` through it's Jordan normal form as `P * J * P.inv()`. Evaluating that directly and using it for the general solution leads to complicated expressions and fails the only existing test for `linear_neq_order1_type1`. Instead I use the fact that:
```
     exp(A t) c = P * J * P.inv() * c = P * J * c'
```
where `c'` is a different arbitrary constant vector. Further down the line this might make it more complicated for the initial condition handling code. It gives solutions that are as close as possible to the current behaviour though and also results in simpler general solutions. It also means we don't need to invert `P` and is efficient.

Complex conjugate eigenvalue pairs are handled using the "real Jordan form" as described
[here on Wikipedia](https://en.wikipedia.org/wiki/Jordan_normal_form#Real_matrices). This allows us to naturally get solutions in terms of sin/cos rather than exp where appropriate. This is only done for real matrices: if `A.has(I)` then no sin/cos rewriting is done.

#### Other comments

This PR should mean that `linear_neq_order1_type1` can theoretically handle any system of linear, constant coefficient, homogeneous ODEs. There are a number of other system solvers such as `linear_2eq_order1_type1` that are special cases of this. If this solver can be made good enough then those others should probably be removed.

The matrix exponential can also be used to solve the corresponding non-homogeneous problems [as described here](https://en.wikipedia.org/wiki/Matrix_exponential#Inhomogeneous_case_generalization:_variation_of_parameters). It is also possible to rewrite any higher-order linear, constant coefficient ODE as a first order system.

With these things together this solver could solve any system of linear, constant coefficient ODEs homogeneous or non-homogeneous of any order (including mixed). That would be a big improvement in `dsolve` for systems which otherwise only handles a few special cases each involving a fixed number of equations.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
    * Use matrix exponential to solve homogeneous systems of first order ODEs with constant coefficients.
<!-- END RELEASE NOTES -->
