### PR TITLE
Replaces _gcdcache wtih lru_cache

### DIFF
--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division
 
 from distutils.version import LooseVersion as V
-
+from sympy.core.compatibility import lru_cache
 class _cache(list):
     """ List of cached functions """
 
@@ -59,6 +59,7 @@ try:
     import platform
     if platform.python_implementation() == 'PyPy':
         raise ImportError
+    lru_cache = fastcache.clru_cache
 
 except ImportError:
 

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division
 
 from distutils.version import LooseVersion as V
-from sympy.core.compatibility import lru_cache
+
 class _cache(list):
     """ List of cached functions """
 

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -772,7 +772,7 @@ def _make_key(args, kwds, typed,
         return key[0]
     return _HashedSeq(key)
 
-def lru_cache(maxsize=100, typed=False):
+def lru_cache(maxsize=1024, typed=False):
     """Least-recently-used cache decorator.
 
     If *maxsize* is set to None, the LRU features are disabled and the cache

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -772,7 +772,7 @@ def _make_key(args, kwds, typed,
         return key[0]
     return _HashedSeq(key)
 
-def lru_cache(maxsize=1024, typed=False):
+def lru_cache(maxsize=100, typed=False):
     """Least-recently-used cache decorator.
 
     If *maxsize* is set to None, the LRU features are disabled and the cache

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -29,6 +29,7 @@ from mpmath.libmp.libmpf import (
     prec_to_dps)
 from sympy.utilities.misc import debug, filldedent
 from .evaluate import global_evaluate
+from sympy.core.compatibility import lru_cache
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -154,10 +155,11 @@ def _literal_float(f):
     return bool(regex.match(pat, f))
 
 # (a,b) -> gcd(a,b)
-_gcdcache = {}
+#_gcdcache = {}
 
 # TODO caching with decorator, but not to degrade performance
 
+@lru_cache()
 
 def igcd(*args):
     """Computes nonnegative integer greatest common divisor.
@@ -189,7 +191,7 @@ def igcd(*args):
             b = args[k]
             k += 1
             try:
-                a = _gcdcache[(a, b)]
+              #  a = _gcdcache[(a, b)]
             except KeyError:
                 b = as_int(b)
                 if not b:
@@ -201,7 +203,7 @@ def igcd(*args):
                     b = -b
                 t = a, b
                 a = igcd2(a, b)
-                _gcdcache[t] = _gcdcache[t[1], t[0]] = a
+             #   _gcdcache[t] = _gcdcache[t[1], t[0]] = a
     while k < len(args):
         ok = as_int(args[k])
         k += 1

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -155,11 +155,10 @@ def _literal_float(f):
     return bool(regex.match(pat, f))
 
 # (a,b) -> gcd(a,b)
-_gcdcache = {}
 
 # TODO caching with decorator, but not to degrade performance
 
-@lru_cache()
+@lru_cache(1024)
 def igcd(*args):
     """Computes nonnegative integer greatest common divisor.
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -15,7 +15,7 @@ from .decorators import _sympifyit
 from .cache import cacheit, clear_cache
 from .logic import fuzzy_not
 from sympy.core.compatibility import (
-    as_int, integer_types, long, string_types, with_metaclass, HAS_GMPY,
+    as_int, integer_types, long, string_types, with_metaclass, HAS_GMPY, lru_cache ,
     SYMPY_INTS, int_info)
 
 import mpmath
@@ -29,7 +29,6 @@ from mpmath.libmp.libmpf import (
     prec_to_dps)
 from sympy.utilities.misc import debug, filldedent
 from .evaluate import global_evaluate
-from sympy.core.compatibility import lru_cache
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -197,7 +196,6 @@ def igcd(*args):
                 break
             if b < 0:
                 b = -b
-            t = a, b
             a = igcd2(a, b)
     while k < len(args):
         ok = as_int(args[k])

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -155,12 +155,11 @@ def _literal_float(f):
     return bool(regex.match(pat, f))
 
 # (a,b) -> gcd(a,b)
-#_gcdcache = {}
+_gcdcache = {}
 
 # TODO caching with decorator, but not to degrade performance
 
 @lru_cache()
-
 def igcd(*args):
     """Computes nonnegative integer greatest common divisor.
 
@@ -190,20 +189,16 @@ def igcd(*args):
         while k < len(args):
             b = args[k]
             k += 1
-            try:
-              #  a = _gcdcache[(a, b)]
-            except KeyError:
-                b = as_int(b)
-                if not b:
-                    continue
-                if b == 1:
-                    a = 1
-                    break
-                if b < 0:
-                    b = -b
-                t = a, b
-                a = igcd2(a, b)
-             #   _gcdcache[t] = _gcdcache[t[1], t[0]] = a
+            b = as_int(b)
+            if not b:
+                continue
+            if b == 1:
+                a = 1
+                break
+            if b < 0:
+                b = -b
+            t = a, b
+            a = igcd2(a, b)
     while k < len(args):
         ok = as_int(args[k])
         k += 1

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -15,8 +15,9 @@ from .decorators import _sympifyit
 from .cache import cacheit, clear_cache
 from .logic import fuzzy_not
 from sympy.core.compatibility import (
-    as_int, integer_types, long, string_types, with_metaclass, HAS_GMPY, lru_cache ,
+    as_int, integer_types, long, string_types, with_metaclass, HAS_GMPY,
     SYMPY_INTS, int_info)
+from sympy.core.cache import lru_cache
 
 import mpmath
 import mpmath.libmp as mlib


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15405 

#### Brief description of what is fixed or changed
Removed `sympy.core.numbers._gcdcache` and the code in `igcd` handling the cache.
Import `lru_cache` from `sympy.core.cache` where it is redefined as `fastcache` if import is successful .

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * replaced ` _gcdcache` with `lru_cache` in `numbers.py`
    * increased size of `lru_cache` from 100 to 1024
<!-- END RELEASE NOTES -->
