### PR TITLE
Fix latex printing of ProductSet when exponent has more than one digit

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1739,7 +1739,7 @@ class LatexPrinter(Printer):
 
     def _print_ProductSet(self, p):
         if len(p.sets) > 1 and not has_variety(p.sets):
-            return self._print(p.sets[0]) + "^%d" % len(p.sets)
+            return self._print(p.sets[0]) + "^{%d}" % len(p.sets)
         else:
             return r" \times ".join(self._print(set) for set in p.sets)
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -755,7 +755,8 @@ def test_latex_productset():
     line = Interval(0, 1)
     bigline = Interval(0, 10)
     fset = FiniteSet(1, 2, 3)
-    assert latex(line**2) == r"%s^2" % latex(line)
+    assert latex(line**2) == r"%s^{2}" % latex(line)
+    assert latex(line**10) == r"%s^{10}" % latex(line)
     assert latex(line * bigline * fset) == r"%s \times %s \times %s" % (
         latex(line), latex(bigline), latex(fset))
 


### PR DESCRIPTION
Printing of `ProductSet` does not enclose exponent in braces, so digits after the first are not printed correctly. Fixed this and added a test for it.

<!-- BEGIN RELEASE NOTES -->
* printing
   * Fix latex printing of ProductSet when exponent has more than one digit
<!-- END RELEASE NOTES -->