### PR TITLE
Limit rounding to concrete integers in hyperexpand

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,9 +1,9 @@
 from sympy import (
     Abs, acos, acosh, Add, And, asin, asinh, atan, Ci, cos, sinh, cosh,
     tanh, Derivative, diff, DiracDelta, E, Ei, Eq, exp, erf, erfi,
-    EulerGamma, Expr, factor, Function, I, im, Integral, integrate,
+    EulerGamma, Expr, factor, Function, gamma, I, im, Integral, integrate,
     Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
-    Ne, O, oo, pi, Piecewise, polar_lift, Poly, Rational, re, S, Si, sign,
+    Ne, O, oo, pi, Piecewise, polar_lift, Poly, polygamma, Rational, re, S, Si, sign,
     simplify, sin, sinc, SingularityFunction, sqrt, sstr, Sum, Symbol,
     symbols, sympify, tan, trigsimp, Tuple
 )
@@ -1395,3 +1395,9 @@ def test_issue_15285():
     y = 1/x - 1
     f = 4*y*exp(-2*y)/x**2
     assert integrate(f, [x, 0, 1]) == 1
+
+
+def test_issue_15432():
+    assert integrate(x**n * exp(-x) * log(x), (x, 0, oo)).gammasimp() == Piecewise(
+        (gamma(n + 1)*polygamma(0, n) + gamma(n + 1)/n, re(n) + 1 > 0),
+        (Integral(x**n*exp(-x)*log(x), (x, 0, oo)), True))

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2298,7 +2298,7 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default',
                 s = Dummy('s')
                 integrand = z**s
                 for b in bm:
-                    if not Mod(b, 1):
+                    if not Mod(b, 1) and b.is_Number:
                         b = int(round(b))
                     integrand *= gamma(b - s)
                 for a in an:


### PR DESCRIPTION




<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #15432 


#### Brief description of what is fixed or changed
An attempt to fix integer-valued floats
```
                    if not Mod(b, 1):
                        b = int(round(b))
```
is problematic when b is an integer symbol. Replaced by
```
                    if not Mod(b, 1) and b.is_Number:
                        b = int(round(b))
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * fixed a bug in the hyperexpand function
<!-- END RELEASE NOTES -->
