### PR TITLE
name now works correctly for undefined functions

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -138,7 +138,7 @@ class FunctionClass(ManagedProperties):
     undefined function classes.
     """
     _new = type.__new__
-        
+
     def __init__(cls, *args, **kwargs):
         # honor kwarg value or class-defined value before using
         # the number of arguments in the eval function (if present)
@@ -408,7 +408,7 @@ class Function(Application, Expr):
     >>>
 
     """
-    
+
     @property
     def _diff_wrt(self):
         return False

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -138,7 +138,7 @@ class FunctionClass(ManagedProperties):
     undefined function classes.
     """
     _new = type.__new__
-
+        
     def __init__(cls, *args, **kwargs):
         # honor kwarg value or class-defined value before using
         # the number of arguments in the eval function (if present)
@@ -408,7 +408,7 @@ class Function(Application, Expr):
     >>>
 
     """
-
+    
     @property
     def _diff_wrt(self):
         return False
@@ -843,6 +843,7 @@ class UndefinedFunction(FunctionClass):
         __dict__.update({'_extra_kwargs': kwargs})
         __dict__['__module__'] = None # For pickling
         ret = super(UndefinedFunction, mcl).__new__(mcl, name, bases, __dict__)
+        ret.name = name
         return ret
 
     def __instancecheck__(cls, instance):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1220,3 +1220,7 @@ def test_Subs_Derivative():
     ans = 3*x**2*exp(1/x)*exp(x**3) - exp(1/x)*exp(x**3)/x**2
     assert all(subs(i).doit().expand() == ans for i in eqs)
     assert all(subs(i.doit()).doit().expand() == ans for i in eqs)
+
+def test_issue_15360():
+    f = Function('f')
+    assert f.name == 'f'


### PR DESCRIPTION
Fixes #15360 
The f.name functionality will work correctly for UndefinedFunctions, that is, for , Functions('f').
This PR doesn't solves the complete issue, that is, the issue also wants, sin.name to return,
'sin' but this PR has not worked on that.

<!-- BEGIN RELEASE NOTES -->
* core
  * UndefinedFunction class modified to give correct results to f.name for functions of type Functions('f')
<!-- END RELEASE NOTES -->
