### PR TITLE
tm_sympy - Do not shadow the builtin pi

### DIFF
--- a/data/TeXmacs/bin/tm_sympy
+++ b/data/TeXmacs/bin/tm_sympy
@@ -65,7 +65,7 @@ f = Function('f')
 Gamma, Zeta = gamma, zeta
 
 _greek = 'alpha beta gamma delta epsilon zeta eta '  \
-         'theta iota kappa mu nu xi omicron pi rho ' \
+         'theta iota kappa mu nu xi omicron rho ' \
          'sigma tau upsilon phi chi psi omega'
 
 for _symbol in _greek.split(' '):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

Defining a symbol pi shadows the builtin sympy.pi symbol, which will be
confusing and frustrating for most users.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * sympy.pi is no longer shadowed by another symbol called pi in the TeXmacs integration
<!-- END RELEASE NOTES -->
