### PR TITLE
tm_sympy - LaTeX math output using dollar signs

### DIFF
--- a/data/TeXmacs/bin/tm_sympy
+++ b/data/TeXmacs/bin/tm_sympy
@@ -40,7 +40,10 @@ def send(kind, output=None):
     elif kind == "latex":
         output = latex(output)
 
-    message = "%s:%s" %  (kind, output)
+    if len(output) > 0:
+        message = "%s:$%s$" %  (kind, output)
+    else:
+        message = "%s:%s" %  (kind, output)
 
     os.sys.stdout.write(BEGIN)
     os.sys.stdout.write(message)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

It is desirable to render SymPy expressions using the math mode in TeXmacs.
Therefore, we enclose SymPy's LaTeX output in dollar signs.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * In the TeXmacs plugin, SymPy now sends LaTeX inline math to TeXmacs for proper rendering
<!-- END RELEASE NOTES -->
