### PR TITLE
sympy.simplify.radsimp.collect rectified to give correct results

### DIFF
--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -326,7 +326,7 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
 
     if evaluate:
         if expr.is_Add:
-            o = expr.get0() or 0
+            o = expr.getO() or 0
             expr = expr.func(*[
                     collect(a, syms, func, True, exact, distribute_order_term)
                     for a in expr.args if a != o]) + o

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -325,7 +325,12 @@ def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_
             return [_f for _f in terms if _f], elems, common_expo, has_deriv
 
     if evaluate:
-        if expr.is_Mul:
+        if expr.is_Add:
+            o = expr.get0() or 0
+            expr = expr.func(*[
+                    collect(a, syms, func, True, exact, distribute_order_term)
+                    for a in expr.args if a != o]) + o
+        elif expr.is_Mul:
             return expr.func(*[
                 collect(term, syms, func, True, exact, distribute_order_term)
                 for term in expr.args])

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -227,7 +227,7 @@ def test_collect_D():
     x, a, b = symbols('x,a,b')
     fx = D(f(x), x)
     fxx = D(f(x), x, x)
-
+    
     assert collect(a*fx + b*fx, fx) == (a + b)*fx
     assert collect(a*D(fx, x) + b*D(fx, x), fx) == (a + b)*D(fx, x)
     assert collect(a*fxx + b*fxx, fx) == (a + b)*D(fx, x)
@@ -239,6 +239,8 @@ def test_collect_D():
         (x*f(x) + f(x))*D(f(x), x) + f(x)
     assert collect(1/f(x) + 1/f(x)*diff(f(x), x) + x*diff(f(x), x)/f(x), f(x).diff(x), exact=True) == \
         (1/f(x) + x/f(x))*D(f(x), x) + 1/f(x)
+    e = (1 + x*fx + fx)/f(x)
+    assert collect(e.expand(), fx) == fx*(x/f(x) + 1/f(x)) + 1/f(x)
 
 
 def test_collect_func():
@@ -289,13 +291,6 @@ def test_rcollect():
 
 
 @XFAIL
-def test_collect_issues():
-    D = Derivative
-    f = Function('f')
-    e = (1 + x*D(f(x), x) + D(f(x), x))/f(x)
-    assert collect(e.expand(), f(x).diff(x)) != e
-
-
 def test_collect_D_0():
     D = Derivative
     f = Function('f')

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -227,7 +227,7 @@ def test_collect_D():
     x, a, b = symbols('x,a,b')
     fx = D(f(x), x)
     fxx = D(f(x), x, x)
-    
+
     assert collect(a*fx + b*fx, fx) == (a + b)*fx
     assert collect(a*D(fx, x) + b*D(fx, x), fx) == (a + b)*D(fx, x)
     assert collect(a*fxx + b*fxx, fx) == (a + b)*D(fx, x)


### PR DESCRIPTION
Fixes #15394 

collect method has been modified by adding a condition for expressions
which have is_Add = True. A test has also been added in
sympy.simplify.tests.test_radsimp

<!-- BEGIN RELEASE NOTES -->
* simplify
  * collect method modified to give correct results for expressions belonging to Add class

<!-- END RELEASE NOTES -->
