### PR TITLE
 Extend Matrix.pinv for rank deficient matrices 

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3825,11 +3825,10 @@ class MatrixBase(MatrixDeprecated,
                 return AH * (A * AH).inv()
         except ValueError:
             # Matrix is not full rank, so A*AH cannot be inverted.
-            P, D = (A.H * A).diagonalize()
-            for i in range(P.cols):
-                P[:,i] = P.col(i) / P.col(i).norm()
+            # However, it is Hermitian, so we can diagonalize it.
+            P, D = (AH * A).diagonalize(normalize=True)
             D_pinv = D.applyfunc(lambda x: 0 if x==0 else 1/x)
-            return P * D_pinv * P.H * A.H
+            return P * D_pinv * P.H * AH
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3825,14 +3825,15 @@ class MatrixBase(MatrixDeprecated,
                 return AH * (A * AH).inv()
         except ValueError:
             # Matrix is not full rank, so A*AH cannot be inverted.
+            pass
+        try:
             # However, it is Hermitian, so we can diagonalize it.
-            try:
-                P, D = (AH * A).diagonalize(normalize=True)
-                D_pinv = D.applyfunc(lambda x: 0 if x==0 else 1/x)
-                return P * D_pinv * P.H * AH
-            except MatrixError:
-                raise NotImplementedError('pinv for rank-deficient matrices where diagonalization '
-                                          'of A.H*A fails is not yet supported.')
+            P, D = (AH * A).diagonalize(normalize=True)
+            D_pinv = D.applyfunc(lambda x: 0 if x==0 else 1/x)
+            return P * D_pinv * P.H * AH
+        except MatrixError:
+            raise NotImplementedError('pinv for rank-deficient matrices where diagonalization '
+                                      'of A.H*A fails is not yet supported.')
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3830,11 +3830,11 @@ class MatrixBase(MatrixDeprecated,
             # However, A*AH is Hermitian, so we can diagonalize it.
             if self.rows >= self.cols:
                 P, D = (AH * A).diagonalize(normalize=True)
-                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1/x)
+                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1 / x)
                 return P * D_pinv * P.H * AH
             else:
                 P, D = (A * AH).diagonalize(normalize=True)
-                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1/x)
+                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1 / x)
                 return AH * P * D_pinv * P.H
         except MatrixError:
             raise NotImplementedError('pinv for rank-deficient matrices where diagonalization '

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3826,9 +3826,13 @@ class MatrixBase(MatrixDeprecated,
         except ValueError:
             # Matrix is not full rank, so A*AH cannot be inverted.
             # However, it is Hermitian, so we can diagonalize it.
-            P, D = (AH * A).diagonalize(normalize=True)
-            D_pinv = D.applyfunc(lambda x: 0 if x==0 else 1/x)
-            return P * D_pinv * P.H * AH
+            try:
+                P, D = (AH * A).diagonalize(normalize=True)
+                D_pinv = D.applyfunc(lambda x: 0 if x==0 else 1/x)
+                return P * D_pinv * P.H * AH
+            except MatrixError:
+                raise NotImplementedError('pinv for rank-deficient matrices where diagonalization '
+                                          'of A.H*A fails is not yet supported.')
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3827,13 +3827,18 @@ class MatrixBase(MatrixDeprecated,
             # Matrix is not full rank, so A*AH cannot be inverted.
             pass
         try:
-            # However, it is Hermitian, so we can diagonalize it.
-            P, D = (AH * A).diagonalize(normalize=True)
-            D_pinv = D.applyfunc(lambda x: 0 if x==0 else 1/x)
-            return P * D_pinv * P.H * AH
+            # However, A*AH is Hermitian, so we can diagonalize it.
+            if self.rows >= self.cols:
+                P, D = (AH * A).diagonalize(normalize=True)
+                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1/x)
+                return P * D_pinv * P.H * AH
+            else:
+                P, D = (A * AH).diagonalize(normalize=True)
+                D_pinv = D.applyfunc(lambda x: 0 if _iszero(x) else 1/x)
+                return AH * P * D_pinv * P.H
         except MatrixError:
             raise NotImplementedError('pinv for rank-deficient matrices where diagonalization '
-                                      'of A.H*A fails is not yet supported.')
+                                      'of A.H*A fails is not supported yet.')
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3825,8 +3825,11 @@ class MatrixBase(MatrixDeprecated,
                 return AH * (A * AH).inv()
         except ValueError:
             # Matrix is not full rank, so A*AH cannot be inverted.
-            raise NotImplementedError('Rank-deficient matrices are not yet '
-                                      'supported.')
+            P, D = (A.H * A).diagonalize()
+            for i in range(P.cols):
+                P[:,i] = P.col(i) / P.col(i).norm()
+            D_pinv = D.applyfunc(lambda x: 0 if x==0 else 1/x)
+            return P * D_pinv * P.H * A.H
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2771,11 +2771,11 @@ def test_pinv_rank_deficient():
 def test_pinv_rank_deficient_when_diagonalization_fails():
     print('Test the four properties of the pseudoinverse for matrices when diagonalization of A.H*A fails.')
     As = [Matrix([
-        [0.61, 0.89, 0.55, 0.20, 0.71, 0],
-        [0.62, 0.96, 0.85, 0.85, 0.16, 0],
-        [0.69, 0.56, 0.17, 0.04, 0.54, 0],
-        [0.10, 0.54, 0.91, 0.41, 0.71, 0],
-        [0.07, 0.30, 0.10, 0.48, 0.90, 0],
+        [61, 89, 55, 20, 71, 0],
+        [62, 96, 85, 85, 16, 0],
+        [69, 56, 17,  4, 54, 0],
+        [10, 54, 91, 41, 71, 0],
+        [ 7, 30, 10, 48, 90, 0],
         [0,0,0,0,0,0]])]
     for A in As:
         A_pinv = A.pinv()

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2767,6 +2767,25 @@ def test_pinv_rank_deficient():
     assert solution == Matrix([3, w1])
     assert A * A.pinv() * B != B
 
+@XFAIL
+def test_pinv_rank_deficient_when_diagonalization_fails():
+    print('Test the four properties of the pseudoinverse for matrices when diagonalization of A.H*A fails.')
+    As = [Matrix([
+        [0.61, 0.89, 0.55, 0.20, 0.71, 0],
+        [0.62, 0.96, 0.85, 0.85, 0.16, 0],
+        [0.69, 0.56, 0.17, 0.04, 0.54, 0],
+        [0.10, 0.54, 0.91, 0.41, 0.71, 0],
+        [0.07, 0.30, 0.10, 0.48, 0.90, 0],
+        [0,0,0,0,0,0]])]
+    for A in As:
+        A_pinv = A.pinv()
+        AAp = A * A_pinv
+        ApA = A_pinv * A
+        assert simplify(AAp * A) == A
+        assert simplify(ApA * A_pinv) == A_pinv
+        assert AAp.H == AAp
+        assert ApA.H == ApA
+
 
 def test_gauss_jordan_solve():
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2737,7 +2737,6 @@ def test_pinv_solve():
     # Proof the solution is not exact.
     assert A * A.pinv() * B != B
 
-@XFAIL
 def test_pinv_rank_deficient():
     # Test the four properties of the pseudoinverse for various matrices.
     As = [Matrix([[1, 1, 1], [2, 2, 2]]),

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2740,7 +2740,8 @@ def test_pinv_solve():
 def test_pinv_rank_deficient():
     # Test the four properties of the pseudoinverse for various matrices.
     As = [Matrix([[1, 1, 1], [2, 2, 2]]),
-          Matrix([[1, 0], [0, 0]])]
+          Matrix([[1, 0], [0, 0]]),
+          Matrix([[1, 2], [2, 4], [3, 6]])]
     for A in As:
         A_pinv = A.pinv()
         AAp = A * A_pinv


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
    * Extend pinv() with the implementation for rank deficient matrices.
<!-- END RELEASE NOTES -->
