### PR TITLE
tm_sympy - Separate the REPL-handling code from SymPy initialization

### DIFF
--- a/data/TeXmacs/bin/tm_sympy
+++ b/data/TeXmacs/bin/tm_sympy
@@ -51,7 +51,12 @@ send("verbatim", "Welcome to SymPy " + __version__)
 
 _globals = {}
 
-_init = open(os.path.join(sys.path[0], "init.py"))
+py2or3 = sys.version_info[0];
+
+if py2or3 == 2:
+    _init = open(os.path.join(sys.path[0], "init-py2.py"))
+else:
+    _init = open(os.path.join(sys.path[0], "init-py3.py"))
 
 try:
     eval(compile(_init.read(), 'init.py', 'exec'), _globals)

--- a/data/TeXmacs/bin/tm_sympy
+++ b/data/TeXmacs/bin/tm_sympy
@@ -22,7 +22,7 @@
 #  http://dkbza.org/tmPython.html
 #
 
-import os
+import os, sys
 import re
 import traceback
 
@@ -51,30 +51,14 @@ send("verbatim", "Welcome to SymPy " + __version__)
 
 _globals = {}
 
-_init = \
-"""
-from sympy import *
+_init = open(os.path.join(sys.path[0], "init.py"))
 
-_ = None
+try:
+    eval(compile(_init.read(), 'init.py', 'exec'), _globals)
+except Exception as e:
+    send("verbatim", ''.join(traceback.format_exception_only(type(e), e)))
 
-x, y, z, t = symbols('x,y,z,t')
-k, i, m, n = symbols('k,i,m,n', integer=True)
-
-f = Function('f')
-
-Gamma, Zeta = gamma, zeta
-
-_greek = 'alpha beta gamma delta epsilon zeta eta '  \
-         'theta iota kappa mu nu xi omicron rho ' \
-         'sigma tau upsilon phi chi psi omega'
-
-for _symbol in _greek.split(' '):
-    exec("%s = Symbol('%s')" % (_symbol, _symbol))
-
-del _symbol
-"""
-
-eval(compile(_init, 'tm_sympy', 'exec'), _globals)
+_init.close()
 
 while True:
     line = os.sys.stdin.readline().strip()

--- a/init-py2.py
+++ b/init-py2.py
@@ -1,0 +1,12 @@
+from __future__ import division
+from sympy import *
+
+from sympy.plotting import plot_parametric, plot3d
+
+# Output of last expression
+_ = None
+
+x, y, z, t = symbols('x,y,z,t')
+k, m, n = symbols('k,m,n', integer=True)
+f, g, h = symbols('f,g,h', cls=Function)
+

--- a/init-py3.py
+++ b/init-py3.py
@@ -1,0 +1,31 @@
+from __future__ import division
+from sympy import *
+
+from sympy.plotting import plot_parametric, plot3d
+
+# Output of the last expression
+_ = None
+
+x, y, z, t = symbols('x,y,z,t')
+k, m, n = symbols('k,m,n', integer=True)
+f, g, h = symbols('f,g,h', cls=Function)
+
+# lambda is a reserved word, pi is a built-in symbol
+
+_greek = 'alpha beta gamma delta epsilon zeta eta ' \
+         'theta iota kappa mu nu xi omicron rho '   \
+         'sigma tau upsilon phi chi psi omega '     \
+         'Alpha Beta Gamma Delta Epsilon Zeta Eta ' \
+         'Theta Iota Kappa Mu Nu Xi Omicron Rho '   \
+         'Sigma Tau Upsilon Phi Chi Psi Omega '     \
+         'α β γ δ ε ζ η θ'     \
+         'ι κ λ μ ν ξ ο π ρ '  \
+         'σ τ υ φ χ ψ ω '      \
+         'Α Β Γ Δ Ε Ζ Η Θ'     \
+         'Ι Κ Λ Μ Ν Ξ Ο Π Ρ '  \
+         'Σ Τ Υ Φ Χ Ψ Ω'
+
+for _symbol in _greek.split(' '):
+    exec("%s = Symbol('%s', real=True)" % (_symbol, _symbol))
+
+del _symbol


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

The code that initializes the SymPy session is no longer hard-coded in tm_sympy. Instead, it is read from an external file.

#### Other comments

Every user will want to set up the SymPy session differently. Moreover, this code can become very lengthy. Therefore, it is more convenient to separate it from the REPL-handling code.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* other
  * [TeXmacs] The SymPy session can now be setup with a user-provided init.py script
  * [TeXmacs] Separate init files are provided for Python 2 and Python 3 (supports Greek letters)
<!-- END RELEASE NOTES -->
