### PR TITLE
Sets : Union Supports Python set

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1017,6 +1017,10 @@ class Union(Set, EvalfMixin):
         args = list(args)
 
         def flatten(arg):
+            if isinstance(arg, set):
+                # If any element of python set is a Set, it should not be sympified
+                if all(not isinstance(x, Set) for x in arg):
+                    return [_sympify(arg)]
             if isinstance(arg, Set):
                 if arg.is_Union:
                     return sum(map(flatten, arg.args), [])

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1018,9 +1018,7 @@ class Union(Set, EvalfMixin):
 
         def flatten(arg):
             if isinstance(arg, set):
-                # If any element of python set is a Set, it should not be sympified
-                if all(not isinstance(x, Set) for x in arg):
-                    return [_sympify(arg)]
+                return [_sympify(arg)]
             if isinstance(arg, Set):
                 if arg.is_Union:
                     return sum(map(flatten, arg.args), [])
@@ -1891,7 +1889,7 @@ def simplify_union(args):
     if len(args) == 1:
         return args.pop()
     else:
-        return Union(args, evaluate=False)
+        return Union(list(args), evaluate=False)
 
 
 def simplify_intersection(args):

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -97,7 +97,7 @@ def test_union():
     assert Union(Interval(1, 2), S.EmptySet) == Interval(1, 2)
     assert Union(S.EmptySet) == S.EmptySet
 
-    assert Union(Interval(0, 1), [FiniteSet(1.0/n) for n in range(1, 10)]) == \
+    assert Union(Interval(0, 1), *[FiniteSet(1.0/n) for n in range(1, 10)]) == \
         Interval(0, 1)
 
     assert Interval(1, 2).union(Interval(2, 3)) == \

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -107,6 +107,8 @@ def test_union():
 
     assert Union(Set()) == Set()
 
+    assert Union({1},{2},{3}) == FiniteSet(1,2,3)
+
     assert FiniteSet(1) + FiniteSet(2) + FiniteSet(3) == FiniteSet(1, 2, 3)
     assert FiniteSet('ham') + FiniteSet('eggs') == FiniteSet('ham', 'eggs')
     assert FiniteSet(1, 2, 3) + S.EmptySet == FiniteSet(1, 2, 3)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -126,7 +126,7 @@ def solve_poly_inequalities(polys):
     Union(Interval.open(-oo, -sqrt(3)), Interval.open(-1, 1), Interval.open(sqrt(3), oo))
     """
     from sympy import Union
-    return Union(*sum([solve_poly_inequality(*p) for p in polys],[]))
+    return Union(*[i for p in polys for i in solve_poly_inequality(*p)])
 
 
 def solve_rational_inequalities(eqs):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -126,7 +126,7 @@ def solve_poly_inequalities(polys):
     Union(Interval.open(-oo, -sqrt(3)), Interval.open(-1, 1), Interval.open(sqrt(3), oo))
     """
     from sympy import Union
-    return Union(*[solve_poly_inequality(*p) for p in polys])
+    return Union(*sum([solve_poly_inequality(*p) for p in polys],[]))
 
 
 def solve_rational_inequalities(eqs):


### PR DESCRIPTION
Union Calls _sympify when an argument is a python set, except when
any element of that set is a sympy Set. This is because _sympify gives
unintended result when an element of set is a Set.
@asmeurer Does this solve the issue?
Example

    >>> Union({1},{2},{3})
    {1,2,3}
    >>> type(Union({1},{2},{3}))
    <class 'sympy.sets.sets.FiniteSet'>

However, This does not work.
        
    >>> Union({1,Interval(0,1)})
        TypeError: Input must be Sets or iterables of Sets

Adds Test in test_union() for checking this functionality.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #15448 
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* sets
    *  `Union` now supports Python set `Union({1,2},{3,4})={1,2,3,4}`

<!-- END RELEASE NOTES -->
