### PR TITLE
Add support for overdetermined systems to LUsolve

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -640,6 +640,25 @@ def test_LUsolve():
     b = A*x
     soln = A.LUsolve(b)
     assert soln == x
+    A = Matrix([[2, 1], [1, 0], [1, 0]])   # issue 14548
+    b = Matrix([3, 1, 1])
+    assert A.LUsolve(b) == Matrix([1, 1])
+    b = Matrix([3, 1, 2])                  # inconsistent
+    raises(ValueError, lambda: A.LUsolve(b))
+    A = Matrix([[0, -1, 2],
+                [5, 10, 7],
+                [8,  3, 4],
+                [2, 3, 5],
+                [3, 6, 2],
+                [8, 3, 6]])
+    x = Matrix([2, 1, -4])
+    b = A*x
+    soln = A.LUsolve(b)
+    assert soln == x
+    A = Matrix([[0, -1, 2], [5, 10, 7]])  # underdetermined
+    x = Matrix([-1, 2, 0])
+    b = A*x
+    raises(NotImplementedError, lambda: A.LUsolve(b))
 
 
 def test_QRsolve():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14548 

#### Brief description of what is fixed or changed

Some overdetermined linear systems (with more equations than unknowns) are nonetheless consistent, i.e., have a solution. The present LUsolve algorithm requires only minimal modifications to handle such systems.  Indeed, after row permutation and forward substitution, the redundant rows of the coefficient matrix are at the bottom and have zero entries. So the consistency check amounts to verifying that the right hand side is also zero in those rows. If this is the case, the trivial equations "0 = 0" are ignored, and a solution is obtained. 

In contrast, the present LUsolve algorithm is not well fit for underdetermined systems, for which
it can give absurd results: `Matrix([[0, 1]]).LUsolve(Matrix([1]))` returns `[[zoo]]` instead of `[[0], [1]]` or `[[whatever], [1]]`.  So I added NotImplementedError for the underdetermined case. 
 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Added support for overdetermined systems to LUsolve
<!-- END RELEASE NOTES -->
