### PR TITLE
codegen.array_utils: added support for multiple Kronecker deltas

### DIFF
--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -181,6 +181,8 @@ def test_codegen_array_parse():
             CodegenArrayTensorProduct(M, N),
             CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), Permutation(0, 2)(1, 3))
         ), (1, 2)), (i, l, frozenset({j, m, k})))
+    expr = KroneckerDelta(i, j)*KroneckerDelta(j, k)*KroneckerDelta(k,m)*M[i, 0]*KroneckerDelta(m, n)
+    assert _codegen_array_parse(expr) == (M, ({i,j,k,m,n}, 0))
     expr = M[i, i]
     assert _codegen_array_parse(expr) == (CodegenArrayDiagonal(M, (0, 1)), (i,))
 

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -169,11 +169,18 @@ def test_codegen_array_parse():
     assert str(ret2) == "(i, j, _i_1, _i_2)"
     expr = KroneckerDelta(i, j)*M[i, k]
     assert _codegen_array_parse(expr) == (M, ({i, j}, k))
+    expr = KroneckerDelta(i, j)*KroneckerDelta(j, k)*M[i, l]
+    assert _codegen_array_parse(expr) == (M, ({i, j, k}, l))
     expr = KroneckerDelta(j, k)*(M[i, j]*N[k, l] + N[i, j]*M[k, l])
     assert _codegen_array_parse(expr) == (CodegenArrayDiagonal(CodegenArrayElementwiseAdd(
             CodegenArrayTensorProduct(M, N),
             CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), Permutation(0, 2)(1, 3))
         ), (1, 2)), (i, l, frozenset({j, k})))
+    expr = KroneckerDelta(j, m)*KroneckerDelta(m, k)*(M[i, j]*N[k, l] + N[i, j]*M[k, l])
+    assert _codegen_array_parse(expr) == (CodegenArrayDiagonal(CodegenArrayElementwiseAdd(
+            CodegenArrayTensorProduct(M, N),
+            CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), Permutation(0, 2)(1, 3))
+        ), (1, 2)), (i, l, frozenset({j, m, k})))
     expr = M[i, i]
     assert _codegen_array_parse(expr) == (CodegenArrayDiagonal(M, (0, 1)), (i,))
 

--- a/sympy/printing/tensorflow.py
+++ b/sympy/printing/tensorflow.py
@@ -128,7 +128,7 @@ class TensorflowPrinter(AbstractPythonCodePrinter):
         data = "["+", ".join(["["+", ".join([self._print(j) for j in i])+"]" for i in expr.tolist()])+"]"
         return "%s(%s)" % (
             self._module_format(tensorflow_f),
-            str(data),
+            data,
         )
 
     def _print_MatMul(self, expr):

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -55,7 +55,7 @@ def test_tensorflow_matrix():
     _compare_tensorflow_matrix((M,), expr)
 
     expr = M + N
-    assert tensorflow_code(expr) == "M + N"
+    assert tensorflow_code(expr) == "tensorflow.add(M, N)"
     _compare_tensorflow_matrix((M, N), expr)
 
     expr = M*N
@@ -172,7 +172,7 @@ def test_MatrixElement_printing():
     assert tensorflow_code(3 * A[0, 0]) == "3*A[0, 0]"
 
     F = C[0, 0].subs(C, A - B)
-    assert tensorflow_code(F) == "((-1)*B + A)[0, 0]"
+    assert tensorflow_code(F) == "(tensorflow.add((-1)*B, A))[0, 0]"
 
 
 def test_tensorflow_Derivative():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * Parser in array utils now supports multiple Kronecker deltas.
<!-- END RELEASE NOTES -->
