### PR TITLE
Allow permutation of dimensions to be sunk into the expression tree

### DIFF
--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -430,9 +430,7 @@ class CodegenArrayPermuteDims(_CodegenArrayAbstract):
             p = [self.permutation(i) for i in l]
             dargs = {}
             counter = 0
-            print(subranks)
             for i, arg in zip(subranks, expr.args):
-                print(arg)
                 p0 = p[counter:counter+i]
                 counter += i
                 s0 = sorted(p0)
@@ -446,7 +444,6 @@ class CodegenArrayPermuteDims(_CodegenArrayAbstract):
             return CodegenArrayTensorProduct(*args)
         elif isinstance(expr, CodegenArrayContraction):
             # Invert tree hierarchy: put the contraction above.
-            #plist = self.permutation.args[0]
             shifts = expr._get_index_shifts(expr)
             cycles = self.permutation.cyclic_form
             newcycles = CodegenArrayContraction._convert_outer_indices_to_inner_indices(expr, *cycles)

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -106,6 +106,9 @@ class CodegenArrayContraction(_CodegenArrayAbstract):
         ========
 
         >>> from sympy.codegen.array_utils import CodegenArrayContraction, CodegenArrayTensorProduct
+        >>> from sympy import MatrixSymbol
+        >>> M = MatrixSymbol("M", 3, 3)
+        >>> N = MatrixSymbol("N", 3, 3)
         >>> cg = CodegenArrayContraction(CodegenArrayTensorProduct(M, N), [1, 2])
         >>> cg._get_index_shifts(cg)
         [0, 2]

--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -420,9 +420,9 @@ class CodegenArrayPermuteDims(_CodegenArrayAbstract):
     def permutation(self):
         return self.args[1]
 
-    def sink_permutation(self, deep=False):
+    def nest_permutation(self, deep=False):
         r"""
-        Sink the permutation down the expression tree.
+        Nest the permutation down the expression tree.
         """
         expr = self.expr
         if isinstance(expr, CodegenArrayTensorProduct):
@@ -438,7 +438,7 @@ class CodegenArrayPermuteDims(_CodegenArrayAbstract):
                 counter += i
                 s0 = sorted(p0)
                 if not all([s0[j+1]-s0[j] == 1 for j in range(len(s0)-1)]):
-                    # Cross-argument permutations, impossible to sink the object:
+                    # Cross-argument permutations, impossible to nest the object:
                     return self
                 subpermutation = [p0.index(j) for j in s0]
                 dargs[s0[0]] = CodegenArrayPermuteDims(arg, subpermutation)
@@ -457,9 +457,9 @@ class CodegenArrayPermuteDims(_CodegenArrayAbstract):
         return self
 
 
-def sink_permutation(expr, deep=False):
+def nest_permutation(expr, deep=False):
     if isinstance(expr, CodegenArrayPermuteDims):
-        return expr.sink_permutation()
+        return expr.nest_permutation()
     else:
         return expr
 

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -284,20 +284,20 @@ def test_codegen_array_parse_out_of_bounds():
 def test_codegen_permutedims_sink():
 
     cg = CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [0, 1, 3, 2])
-    sunk = cg.sink_permutation()
+    sunk = cg.nest_permutation()
     assert sunk == CodegenArrayTensorProduct(M, CodegenArrayPermuteDims(N, [1, 0]))
     assert recognize_matrix_expression(sunk) == [M, N.T]
 
     cg = CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [1, 0, 3, 2])
-    sunk = cg.sink_permutation()
+    sunk = cg.nest_permutation()
     assert sunk == CodegenArrayTensorProduct(CodegenArrayPermuteDims(M, [1, 0]), CodegenArrayPermuteDims(N, [1, 0]))
     assert recognize_matrix_expression(sunk) == [M.T, N.T]
 
     cg = CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [3, 2, 1, 0])
-    sunk = cg.sink_permutation()
+    sunk = cg.nest_permutation()
     assert sunk == CodegenArrayTensorProduct(CodegenArrayPermuteDims(N, [1, 0]), CodegenArrayPermuteDims(M, [1, 0]))
     assert recognize_matrix_expression(sunk) == [N.T, M.T]
 
     cg = CodegenArrayPermuteDims(CodegenArrayContraction(CodegenArrayTensorProduct(M, N), (1, 2)), [1, 0])
-    sunk = cg.sink_permutation()
+    sunk = cg.nest_permutation()
     assert sunk == CodegenArrayContraction(CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [[0, 3]]), (1, 2))

--- a/sympy/codegen/tests/test_array_utils.py
+++ b/sympy/codegen/tests/test_array_utils.py
@@ -22,6 +22,9 @@ Q = MatrixSymbol("Q", k, k)
 
 
 def test_codegen_array_contraction_construction():
+    cg = CodegenArrayContraction(A)
+    assert cg == A
+
     s = Sum(A[i]*B[i], (i, 0, 3))
     cg = parse_indexed_expression(s)
     assert cg == CodegenArrayContraction(CodegenArrayTensorProduct(A, B), (0, 1))
@@ -301,3 +304,12 @@ def test_codegen_permutedims_sink():
     cg = CodegenArrayPermuteDims(CodegenArrayContraction(CodegenArrayTensorProduct(M, N), (1, 2)), [1, 0])
     sunk = cg.nest_permutation()
     assert sunk == CodegenArrayContraction(CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [[0, 3]]), (1, 2))
+
+    cg = CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [1, 0, 3, 2])
+    sunk = cg.nest_permutation()
+    assert sunk == CodegenArrayTensorProduct(CodegenArrayPermuteDims(M, [1, 0]), CodegenArrayPermuteDims(N, [1, 0]))
+
+    cg = CodegenArrayPermuteDims(CodegenArrayContraction(CodegenArrayTensorProduct(M, N, P), (1, 2), (3, 4)), [1, 0])
+    sunk = cg.nest_permutation()
+    assert sunk == CodegenArrayContraction(CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N, P), [[0, 5]]), (1, 2), (3, 4))
+    sunk2 = sunk.expr.nest_permutation()


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* codegen
  * Allow permutation of dimensions to be sunk into the expression tree.
<!-- END RELEASE NOTES -->
