### PR TITLE
Sets module supports Python sets

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -608,7 +608,7 @@ class ProductSet(Set):
             elif iterable(arg):
                 return sum(map(flatten, arg), [])
             raise TypeError("Input must be Sets or iterables of Sets")
-        sets = flatten(list(sets))
+        sets = flatten(list(map(lambda x: _sympify(x) if isinstance(x, set) else x, sets)))
 
         if EmptySet() in sets or len(sets) == 0:
             return EmptySet()
@@ -1014,7 +1014,7 @@ class Union(Set, EvalfMixin):
         evaluate = kwargs.get('evaluate', global_evaluate[0])
 
         # flatten inputs to merge intersections and iterables
-        args = list(args)
+        args = list(map(lambda arg: _sympify(arg) if isinstance(arg, set) else arg, args))
 
         def flatten(arg):
             if isinstance(arg, Set):
@@ -1195,7 +1195,7 @@ class Intersection(Set):
         evaluate = kwargs.get('evaluate', global_evaluate[0])
 
         # flatten inputs to merge intersections and iterables
-        args = list(args)
+        args = list(map(lambda arg: _sympify(arg) if isinstance(arg, set) else arg, args))
 
         def flatten(arg):
             if isinstance(arg, Set):
@@ -1350,6 +1350,8 @@ class Complement(Set, EvalfMixin):
     is_Complement = True
 
     def __new__(cls, a, b, evaluate=True):
+        a = _sympify(a) if isinstance(a, set) else a
+        b = _sympify(b) if isinstance(a, set) else b
         if evaluate:
             return Complement.reduce(a, b)
 
@@ -1706,6 +1708,8 @@ class SymmetricDifference(Set):
     is_SymmetricDifference = True
 
     def __new__(cls, a, b, evaluate=True):
+        a = _sympify(a) if isinstance(a, set) else a
+        b = _sympify(b) if isinstance(b, set) else b
         if evaluate:
             return SymmetricDifference.reduce(a, b)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15448 

#### Brief description of what is fixed or changed
`Union`, `Intersection`, `Complement`, `SymmetricDifference` and `ProductSet` now support Python sets by calling `_sympify` on arguments that are Python sets.

```
>>> Union({1,2,3}, {3,4,5})
{1, 2, 3, 4, 5}
>>> Intersection({1,2,3}, {1,2})
{1, 2}
>>> Complement({1,2,3}, {1})
{2, 3}
>>> ProductSet({1,2,3}, {2,3})
{1, 2, 3} x {2, 3}
>>> SymmetricDifference({1,2,3}, {1,2,4})
{3, 4}
```

#### Other comments
@asmeurer Does this resolve the issue of lack of Python sets support in the `sets` module?

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* sets
    *  `Union` now supports Python sets `Union({1,2,3}, {3,4,5}) = {1,2,3,4,5}`
    * `Intersection` now supports Python sets `Intersection({1,2,3}, {1,2}) = {1,2}`
    * `Complement` now supports Python sets `Complement({1,2,3}, {1}) = {2,3}`
    * `ProductSet` now supports Python sets `ProductSet({1,2,3}, {2,3}) = {1, 2, 3} x {2, 3}`
    * `SymmetricDifference` now supports Python sets `SymmetricDifference({1,2,3}, {1,2,4}) = {3,4}`

<!-- END RELEASE NOTES -->
