### PR TITLE
Rename TestingException for pytest compatibility

### DIFF
--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -594,7 +594,7 @@ def test_DifferentialExtension_Rothstein():
         [None, 'exp', 'exp'], [None, x, 1/(t0 + 1) - 10*x])
 
 
-class TestingException(Exception):
+class _TestingException(Exception):
     """Dummy Exception class for testing."""
     pass
 
@@ -631,8 +631,8 @@ def test_DecrementLevel():
     # Test that __exit__ is called after an exception correctly
     try:
         with DecrementLevel(DE):
-            raise TestingException
-    except TestingException:
+            raise _TestingException
+    except _TestingException:
         pass
     else:
         raise AssertionError("Did not raise.")


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Rename `TestingException` in `test_risch.py`. This class causes an error when running the tests under pytest because pytest tries to collect tests from it. The name of the class is arbitrary: it is just used to check that it gets raised.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
