### PR TITLE
modified 'get_numbered_constants' and test 9239, added another test

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -395,6 +395,9 @@ def get_numbered_constants(eq, num=1, start=1, prefix='C'):
         raise ValueError("Expected Expr or iterable but got %s" % eq)
 
     atom_set = set().union(*[i.free_symbols for i in eq])
+    func_set = set().union(*[i.atoms(Function) for i in eq])
+    if func_set:
+        atom_set |= {Symbol(str(f.func)) for f in func_set}
     ncs = numbered_symbols(start=start, prefix=prefix, exclude=atom_set)
     Cs = [next(ncs) for i in range(num)]
     return (Cs[0] if num == 1 else tuple(Cs))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -6,9 +6,8 @@ from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
     Rational, rootof, S, simplify, sin, sqrt, Subs, Symbol, tan, asin, sinh,
     Piecewise, symbols, Poly, sec, Ei)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
-                               classify_ode, classify_sysode, constant_renumber, constantsimp,
-                               homogeneous_order, infinitesimals, checkinfsol, checksysodesol, solve_ics,
-                               dsolve, get_numbered_constants)
+    classify_ode, classify_sysode, constant_renumber, constantsimp, homogeneous_order,
+    infinitesimals, checkinfsol, checksysodesol, solve_ics, dsolve, get_numbered_constants)
 from sympy.solvers.deutils import ode_order
 from sympy.utilities.pytest import XFAIL, skip, raises, slow, ON_TRAVIS
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -6,9 +6,9 @@ from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
     Rational, rootof, S, simplify, sin, sqrt, Subs, Symbol, tan, asin, sinh,
     Piecewise, symbols, Poly, sec, Ei)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
-    classify_ode, classify_sysode, constant_renumber, constantsimp,
-    homogeneous_order, infinitesimals, checkinfsol, checksysodesol, solve_ics,
-    dsolve)
+                               classify_ode, classify_sysode, constant_renumber, constantsimp,
+                               homogeneous_order, infinitesimals, checkinfsol, checksysodesol, solve_ics,
+                               dsolve, get_numbered_constants)
 from sympy.solvers.deutils import ode_order
 from sympy.utilities.pytest import XFAIL, skip, raises, slow, ON_TRAVIS
 
@@ -2963,12 +2963,19 @@ def test_C1_function_9239():
     t = Symbol('t')
     C1 = Function('C1')
     C2 = Function('C2')
-    C3 = Symbol('C1')  # XXX: update these after
-    C4 = Symbol('C2')  # XXX: https://github.com/sympy/sympy/issues/15056
+    C3 = Symbol('C3')
+    C4 = Symbol('C4')
     eq = (Eq(diff(C1(t), t), 9*C2(t)), Eq(diff(C2(t), t), 12*C1(t)))
     sol = [Eq(C1(t), 9*C3*exp(6*sqrt(3)*t) + 9*C4*exp(-6*sqrt(3)*t)),
            Eq(C2(t), 6*sqrt(3)*C3*exp(6*sqrt(3)*t) - 6*sqrt(3)*C4*exp(-6*sqrt(3)*t))]
     assert checksysodesol(eq, sol) == (True, [0, 0])
+
+
+
+def test_issue_15056():
+    t = Symbol('t')
+    C3 = Symbol('C3')
+    assert get_numbered_constants(Symbol('C1') * Function('C2')(t)) == C3
 
 
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2957,8 +2957,6 @@ def test_dsolve_linsystem_symbol():
             Eq(g(x), -C1*eps*sin(eps*x) + C2*eps*cos(eps*x))]
     assert checksysodesol(eq1, sol1) == (True, [0, 0])
 
-
-
 def test_C1_function_9239():
     t = Symbol('t')
     C1 = Function('C1')
@@ -2970,14 +2968,10 @@ def test_C1_function_9239():
            Eq(C2(t), 6*sqrt(3)*C3*exp(6*sqrt(3)*t) - 6*sqrt(3)*C4*exp(-6*sqrt(3)*t))]
     assert checksysodesol(eq, sol) == (True, [0, 0])
 
-
-
 def test_issue_15056():
     t = Symbol('t')
     C3 = Symbol('C3')
     assert get_numbered_constants(Symbol('C1') * Function('C2')(t)) == C3
-
-
 
 def test_issue_10379():
     t,y = symbols('t,y')

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -5,9 +5,10 @@ from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
     Dummy, Eq, Ne, erf, erfi, exp, Function, I, Integral, LambertW, log, O, pi,
     Rational, rootof, S, simplify, sin, sqrt, Subs, Symbol, tan, asin, sinh,
     Piecewise, symbols, Poly, sec, Ei)
-from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
-    classify_ode, classify_sysode, constant_renumber, constantsimp, homogeneous_order,
-    infinitesimals, checkinfsol, checksysodesol, solve_ics, dsolve, get_numbered_constants)
+from sympy.solvers.ode import (_undetermined_coefficients_match,
+    checkodesol, classify_ode, classify_sysode, constant_renumber,
+    constantsimp, homogeneous_order, infinitesimals, checkinfsol,
+    checksysodesol, solve_ics, dsolve, get_numbered_constants)
 from sympy.solvers.deutils import ode_order
 from sympy.utilities.pytest import XFAIL, skip, raises, slow, ON_TRAVIS
 


### PR DESCRIPTION
modified 'get_numbered_constants' and test_C1_function_9239
added another test

Fixes #15056 

Earlier 
```
from sympy.solves.ode import get_numbered_constants
get_numbered_constants(Symbol('C1')*Function('C2')(t))
``` 
gave `Symbol('C2')` which is technically ok but could lead to confusion (see `test_C1_function_9239` in the `master branch`; it's been updated in this PR).
It's been corrected now and it returns `Symbol('C3')`


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
    * `get_numbered_constants` in `dsolve` now considers functions, in case you have a function named, for example, `C1(t)`.
<!-- END RELEASE NOTES -->
