### PR TITLE
Returns correct result to Mod(3*i, 2).

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division
 
 from sympy.core.numbers import nan
 from .function import Function
-from sympy.simplify.radsimp import denom
 
 
 class Mod(Function):
@@ -36,6 +35,7 @@ class Mod(Function):
             """Try to return p % q if both are numbers or +/-p is known
             to be less than or equal q.
             """
+            from sympy.simplify.radsimp import denom
 
             if q == S.Zero:
                 raise ZeroDivisionError("Modulo by zero")

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -117,15 +117,17 @@ class Mod(Function):
                 net = Add(*non_mod_l) + Add(*[i.args[0] for i in mod_l])
                 return cls(net, q)
 
-        elif isinstance(p, Mul):
+        if isinstance(p, Mul):
             # separating into modulus and non modulus
             both_l = non_mod_l, mod_l = [], []
             for arg in p.args:
                 both_l[isinstance(arg, cls)].append(arg)
 
-            if mod_l and all(inner.args[1] == q for inner in mod_l):
+            was = non_mod_l[:]
+            non_mod_l = [cls(x, q) for x in n]
+            changed = was != non_mod_l
+            if changed or mod_l and all(inner.args[1] == q for inner in mod_l):
                 # finding distributive term
-                non_mod_l = [cls(x, q) for x in non_mod_l]
                 mod = []
                 non_mod = []
                 for j in non_mod_l:

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -30,12 +30,12 @@ class Mod(Function):
         from sympy.core.singleton import S
         from sympy.core.exprtools import gcd_terms
         from sympy.polys.polytools import gcd
+        from sympy.simplify.radsimp import denom
 
         def doit(p, q):
             """Try to return p % q if both are numbers or +/-p is known
             to be less than or equal q.
             """
-            from sympy.simplify.radsimp import denom
 
             if q == S.Zero:
                 raise ZeroDivisionError("Modulo by zero")

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core.numbers import nan
 from .function import Function
+from sympy.simplify.radsimp import denom
 
 
 class Mod(Function):
@@ -117,15 +118,14 @@ class Mod(Function):
                 net = Add(*non_mod_l) + Add(*[i.args[0] for i in mod_l])
                 return cls(net, q)
 
-        if isinstance(p, Mul):
+        if isinstance(p, Mul) and denom(p) == 1:
             # separating into modulus and non modulus
             both_l = non_mod_l, mod_l = [], []
             for arg in p.args:
                 both_l[isinstance(arg, cls)].append(arg)
 
-            was = non_mod_l[:]
-            non_mod_l = [cls(x, q) for x in n]
-            changed = was != non_mod_l
+            non_mod_l = [cls(x, q) for x in non_mod_l]
+            changed = not all(isinstance(i, cls) for i in non_mod_l)
             if changed or mod_l and all(inner.args[1] == q for inner in mod_l):
                 # finding distributive term
                 mod = []

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division
 
 from sympy.core.numbers import nan
 from .function import Function
-from sympy.simplify.radsimp import denom
 
 
 class Mod(Function):
@@ -31,6 +30,7 @@ class Mod(Function):
         from sympy.core.singleton import S
         from sympy.core.exprtools import gcd_terms
         from sympy.polys.polytools import gcd
+        from sympy.simplify.radsimp import denom
 
         def doit(p, q):
             """Try to return p % q if both are numbers or +/-p is known

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1627,6 +1627,9 @@ def test_Mod():
     assert (3*i*x) % (2*i*y) == i*Mod(3*x, 2*y)
     assert Mod(4*i, 4) == 0
 
+    # issue 15493
+    assert mod(3*i, 2) == Mod(i, 2)
+
     # issue 8677
     n = Symbol('n', integer=True, positive=True)
     assert factorial(n) % n == 0

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1629,7 +1629,9 @@ def test_Mod():
 
     # issue 15493
     assert Mod(3*i, 2) == Mod(i, 2)
-    
+    e = symbols('e', even=True)
+    assert Mod(e / 2, 2).subs(e, 6) == Mod(3, 2)
+
     # issue 8677
     n = Symbol('n', integer=True, positive=True)
     assert factorial(n) % n == 0

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1463,7 +1463,8 @@ def test_Add_as_content_primitive():
 
     assert (3/x + 2*x*y*z**2).as_content_primitive() == (1, 3/x + 2*x*y*z**2)
     assert (3/x + 3*x*y*z**2).as_content_primitive() == (3, 1/x + x*y*z**2)
-    assert (3/x + 6*x*y*z**2).as_content_pr
+    assert (3/x + 6*x*y*z**2).as_content_primitive() == (3, 1/x + 2*x*y*z**2)
+
     assert (2*x/3 + 4*y/9).as_content_primitive() == \
         (Rational(2, 9), 3*x + 2*y)
     assert (2*x/3 + 2.5*y).as_content_primitive() == \
@@ -1627,9 +1628,10 @@ def test_Mod():
     assert Mod(4*i, 4) == 0
 
     # issue 15493
-    assert Mod(3*i, 2) == Mod(i, 2)
+    assert mod(3*i, 2) == Mod(i, 2)
+    assert Mod(3 * i, 2) == Mod(i, 2)
     e = symbols('e', even=True)
-    assert Mod(e/2, 2) != 0
+    assert Mod(e / 2, 2) != 0
 
     # issue 8677
     n = Symbol('n', integer=True, positive=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1463,8 +1463,7 @@ def test_Add_as_content_primitive():
 
     assert (3/x + 2*x*y*z**2).as_content_primitive() == (1, 3/x + 2*x*y*z**2)
     assert (3/x + 3*x*y*z**2).as_content_primitive() == (3, 1/x + x*y*z**2)
-    assert (3/x + 6*x*y*z**2).as_content_primitive() == (3, 1/x + 2*x*y*z**2)
-
+    assert (3/x + 6*x*y*z**2).as_content_pr
     assert (2*x/3 + 4*y/9).as_content_primitive() == \
         (Rational(2, 9), 3*x + 2*y)
     assert (2*x/3 + 2.5*y).as_content_primitive() == \
@@ -1628,7 +1627,9 @@ def test_Mod():
     assert Mod(4*i, 4) == 0
 
     # issue 15493
-    assert mod(3*i, 2) == Mod(i, 2)
+    assert Mod(3*i, 2) == Mod(i, 2)
+    e = symbols('e', even=True)
+    assert Mod(e/2, 2) != 0
 
     # issue 8677
     n = Symbol('n', integer=True, positive=True)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1628,10 +1628,8 @@ def test_Mod():
     assert Mod(4*i, 4) == 0
 
     # issue 15493
-    assert mod(3*i, 2) == Mod(i, 2)
-    e = symbols('e', even=True)
-    assert Mod(e / 2, 2) != 0
-
+    assert Mod(3*i, 2) == Mod(i, 2)
+    
     # issue 8677
     n = Symbol('n', integer=True, positive=True)
     assert factorial(n) % n == 0

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1629,7 +1629,6 @@ def test_Mod():
 
     # issue 15493
     assert mod(3*i, 2) == Mod(i, 2)
-    assert Mod(3 * i, 2) == Mod(i, 2)
     e = symbols('e', even=True)
     assert Mod(e / 2, 2) != 0
 


### PR DESCRIPTION
modified the mod.py to return correct answer to Mod(3*i, 2).
added a test (All as suggested by @smichr )

Fixes #15493 

Earlier
` sympify(3*k%2)
Mod(3*k,2)`

Now
` sympify(3*k%2)
Mod(k,2)`

 **Release Notes**
<!-- BEGIN RELEASE NOTES -->
* functions
  * fixed a bug in mod 
  * added a test
<!-- END RELEASE NOTES -->