### PR TITLE
Add args to SymPyDeprecation warning for pickling

### DIFF
--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -171,6 +171,9 @@ https://github.com/sympy/sympy/wiki/Deprecating-policy.\
 
         self.fullMessage += value
 
+        self.args = (value, feature, last_supported_version, useinstead,
+                issue, deprecated_since_version)
+
     def __str__(self):
         return '\n%s\n' % filldedent(self.fullMessage)
 

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -134,6 +134,10 @@ class SymPyDeprecationWarning(DeprecationWarning):
 
     def __init__(self, value=None, feature=None, last_supported_version=None,
                  useinstead=None, issue=None, deprecated_since_version=None):
+
+        self.args = (value, feature, last_supported_version, useinstead,
+                issue, deprecated_since_version)
+
         self.fullMessage = ""
 
         if not feature:
@@ -170,9 +174,6 @@ https://github.com/sympy/sympy/wiki/Deprecating-policy.\
             value = ""
 
         self.fullMessage += value
-
-        self.args = (value, feature, last_supported_version, useinstead,
-                issue, deprecated_since_version)
 
     def __str__(self):
         return '\n%s\n' % filldedent(self.fullMessage)

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -674,3 +674,7 @@ def test_concrete():
     x = Symbol("x")
     for c in (Product, Product(x, (x, 2, 4)), Sum, Sum(x, (x, 2, 4))):
         check(c)
+
+def test_deprecation_warning():
+    w = SymPyDeprecationWarning('value', 'feature', issue=12345, deprecated_since_version='1.0')
+    check(w)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

Adds the `args` attribute to `SymPyDeprecationWarning`. Exception subclasses should generally defined this attribute so that e.g. they can be pickled. Not being able to pickle these warnings causes problems running the tests under `pytest-xdist` which runs tests in parallel using subprocesses. The worker processes need to be able to pickle warnings to send them back to the main process for printing at the end of the test run.

This shouldn't make any different to the tests under `bin/test` or to current expected behaviour of sympy's warnings.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * made SympyDeprecationWarning picklable so tests can be run in subprocesses
<!-- END RELEASE NOTES -->
