### PR TITLE
Added heuristics kwarg for Limit.doit solving big-oh notation error, added tests

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -193,6 +193,8 @@ class Limit(Expr):
         if not e.has(z):
             return e
 
+        use_heuristics = hints.get('heuristics', True)
+
         # gruntz fails on factorials but works with the gamma function
         # If no factorial term is present, e should remain unchanged.
         # factorial is defined to be zero for negative inputs (which
@@ -229,7 +231,9 @@ class Limit(Expr):
             if r is S.NaN:
                 raise PoleError()
         except (PoleError, ValueError):
-            r = heuristics(e, z, z0, dir)
+            r = None
+            if use_heuristics:
+                r = heuristics(e, z, z0, dir)
             if r is None:
                 return self
         except NotImplementedError:

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -334,6 +334,18 @@ def test_issue_6753():
     assert (1 + x**2)**10000*O(x) == O(x)
 
 
+def test_issue_9917():
+    from sympy.abc import n
+    from sympy import O, oo, sin
+
+    assert O(n*sin(n) + 1, (n, oo)) == O(n*sin(n) + 1, (n, oo))
+    assert O((n*sin(n))**2 + 1, (n, oo)) == O(n**2*sin(n)**2 + 1, (n, oo))
+    assert O(((n**2)*sin(n))**2 + 1, (n, oo)) == O(n**4*sin(n)**2 + 1, (n, oo))
+    assert O((n**2)*sin(n) + 1, (n, oo)) == O(n**2*sin(n) + 1, (n, oo))
+    assert O(n*((sin(n))**2) + 1, (n, oo)) == O(n*sin(n)**2 + 1, (n, oo))
+    assert O((n**2)*((sin(n))**2) + 1, (n, oo)) == O(n**2*sin(n)**2 + 1, (n, oo))
+
+
 def test_order_at_infinity():
     assert Order(1 + x, (x, oo)) == Order(x, (x, oo))
     assert Order(3*x, (x, oo)) == Order(x, (x, oo))


### PR DESCRIPTION
Added heuristics `kwarg` for `limit.doit` solving big-oh notation error, added tests

Fixes #9917
Note : I've used the changes implemented by Sergey Kirpichev in diofant [here](https://github.com/diofant/diofant/commit/8b7a103fb4baeefb9efc1241452e22240eb04af0)
#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* series
   * Added heuristics `kwarg` for `limit.doit`
   * Added tests 
<!-- END RELEASE NOTES -->
