### PR TITLE
Correctly test for zeros in add_terms helper of evalf

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -441,7 +441,7 @@ def add_terms(terms, prec, target_prec):
     XXX explain why this is needed and why one can't just loop using mpf_add
     """
 
-    terms = [t for t in terms if not iszero(t)]
+    terms = [t for t in terms if not iszero(t[0])]
     if not terms:
         return None, None
     elif len(terms) == 1:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -527,3 +527,11 @@ def test_issue_13098():
     assert ceiling(log(S('9.'+'9'*20), 10)) == 1
     assert floor(log(20 - S('9.'+'9'*20), 10)) == 1
     assert ceiling(log(20 - S('9.'+'9'*20), 10)) == 2
+
+
+def test_issue_14601():
+    e = 5*x*y/2 - y*(35*(x**3)/2 - 15*x/2)
+    subst = {x:0.0, y:0.0}
+    e2 = e.evalf(subs=subst)
+    assert float(e2) == 0.0
+    assert float((x + x*(x**2 + x)).evalf(subs={x: 0.0})) == 0.0


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14601

#### Brief description of what is fixed or changed

The function `add_terms` in evalf.py receives a list of terms, where each term is a tuple (mpf, accuracy). It tried to remove zeros from the list using
```
  [t for t in terms if not iszero(t)]
```
which is problematic because `iszero` expects its argument to be an mpf, not (mpf, accuracy). Consequently, the filter never worked. The correct form is
```
  [t for t in terms if not iszero(t[0])]
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in evaluation of sums with floating-point zeros. 
<!-- END RELEASE NOTES -->
