### PR TITLE
Exit _eval_derivative_n_times when None is obtained

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1686,10 +1686,10 @@ class Basic(with_metaclass(ManagedProperties)):
             obj = self
             for i in range(n):
                 obj2 = obj._accept_eval_derivative(s)
-                if obj == obj2:
+                if obj == obj2 or obj2 is None:
                     break
                 obj = obj2
-            return obj
+            return obj2
         else:
             return None
 

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, Rational, cos, sin, tan, cot, exp, log,
     Function, Derivative, Expr, symbols, pi, I, S, diff, Piecewise,
-    Eq, ff, Sum, And, factorial, Max, NDimArray)
+    Eq, ff, Sum, And, factorial, Max, NDimArray, re, im)
 from sympy.utilities.pytest import raises
 
 
@@ -88,6 +88,10 @@ def test_diff_no_eval_derivative():
     x, y = symbols('x y')
     # My doesn't have its own _eval_derivative method
     assert My(x).diff(x).func is Derivative
+    assert My(x).diff(x, 3).func is Derivative
+    assert re(x).diff(x, 2) == Derivative(re(x), (x, 2))  # issue 15518
+    assert diff(NDimArray([re(x), im(x)]), (x, 2)) == NDimArray(
+        [Derivative(re(x), (x, 2)), Derivative(im(x), (x, 2))])
     # it doesn't have y so it shouldn't need a method for this case
     assert My(x).diff(y) == 0
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15518 

#### Brief description of what is fixed or changed

The method `_eval_derivative_n_times` contains a loop that involves calling `_eval_derivative`. The latter may return None when evaluation is not implemented. In such a case the loop should be aborted (returning None) instead of trying to differentiate None.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in the creation of higher order derivatives that cannot be evaluated.  
<!-- END RELEASE NOTES -->
