### PR TITLE
Request an integer number of terms from _eval_nseries

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2628,7 +2628,7 @@ class Expr(Basic, EvalfMixin):
         -x
 
         """
-        from sympy import collect, Dummy, Order, Rational, Symbol
+        from sympy import collect, Dummy, Order, Rational, Symbol, ceiling
         if x is None:
             syms = self.free_symbols
             if not syms:
@@ -2707,7 +2707,7 @@ class Expr(Basic, EvalfMixin):
                         s1 = self._eval_nseries(x, n=n + more, logx=logx)
                         newn = s1.getn()
                         if newn != ngot:
-                            ndo = n + (n - ngot)*more/(newn - ngot)
+                            ndo = n + ceiling((n - ngot)*more/(newn - ngot))
                             s1 = self._eval_nseries(x, n=ndo, logx=logx)
                             while s1.getn() < n:
                                 s1 = self._eval_nseries(x, n=ndo, logx=logx)

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -197,5 +197,12 @@ def test_exp_product_positive_factors():
 def test_issue_8805():
     assert series(1, n=8) == 1
 
+
 def test_issue_10761():
     assert series(1/(x**-2 + x**-3), x, 0) == x**3 - x**4 + x**5 + O(x**6)
+
+
+def test_issue_14885():
+    assert series(x**(-S(3)/2)*exp(x), x, 0) == (x**(-S(3)/2) + 1/sqrt(x) +
+        sqrt(x)/2 + x**(S(3)/2)/6 + x**(S(5)/2)/24 + x**(S(7)/2)/120 +
+        x**(S(9)/2)/720 + x**(S(11)/2)/5040 + O(x**6))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14885 

#### Brief description of what is fixed or changed

The method `Expr.series` predicts the number of terms to be requested from `_eval_nseries` with the linear extrapolation formula 
```
ndo = n + (n - ngot)*more/(newn - ngot)
```
But this quantity may be fractional, which does not fit "the number of terms" concept and is not expected by `_eval_nseries`. Replaced with
```
ndo = n + ceiling((n - ngot)*more/(newn - ngot))
```
that is, rounding up.
 


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed a bug in the computation of Taylor series of expressions with a fractional power of the variable.
<!-- END RELEASE NOTES -->
