### PR TITLE
Implement Idx.name property

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,7 +1,7 @@
 from sympy import (
     Abs, acos, acosh, Add, And, asin, asinh, atan, Ci, cos, sinh, cosh,
     tanh, Derivative, diff, DiracDelta, E, Ei, Eq, exp, erf, erfi,
-    EulerGamma, Expr, factor, Function, gamma, I, im, Integral, integrate,
+    EulerGamma, Expr, factor, Function, gamma, I, Idx, im, IndexedBase, Integral, integrate,
     Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
     Ne, O, oo, pi, Piecewise, polar_lift, Poly, polygamma, Rational, re, S, Si, sign,
     simplify, sin, sinc, SingularityFunction, sqrt, sstr, Sum, Symbol,
@@ -1401,3 +1401,10 @@ def test_issue_15432():
     assert integrate(x**n * exp(-x) * log(x), (x, 0, oo)).gammasimp() == Piecewise(
         (gamma(n + 1)*polygamma(0, n) + gamma(n + 1)/n, re(n) + 1 > 0),
         (Integral(x**n*exp(-x)*log(x), (x, 0, oo)), True))
+
+
+def test_issue_15124():
+    omega = IndexedBase('omega')
+    m, p = symbols('m p', cls=Idx)
+    assert integrate(exp(x*I*(omega[m] + omega[p])), x, conds='none') == \
+        -I*exp(I*x*omega[m])*exp(I*x*omega[p])/(omega[m] + omega[p])

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -679,6 +679,10 @@ class Idx(Expr):
         return p.doprint(self.label)
 
     @property
+    def name(self):
+        return self.label.name if self.label.is_Symbol else str(self.label)
+
+    @property
     def free_symbols(self):
         return {self}
 

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -27,6 +27,9 @@ def test_Idx_construction():
 def test_Idx_properties():
     i, a, b = symbols('i a b', integer=True)
     assert Idx(i).is_integer
+    assert Idx(i).name == 'i'
+    assert Idx(i + 2).name == 'i + 2'
+    assert Idx('foo').name == 'foo'
 
 
 def test_Idx_bounds():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15124 

#### Brief description of what is fixed or changed

Added "name" property to Idx objects. It is usually the name of the symbol used as a label of Idx. If an Idx is created from an expression like `Idx(2*k+1)`, then the string representation of that expression is used.

Rationale: Idx class is considered symbol-like (is_symbol set on True) but it does not have a property "name" like other symbols and symbol-like objects (Indexed, IndexedBase, MatrixSymbol). This inconsistency causes errors as in the linked issue, because symbols are expected to have names.

#### Release Notes
 
<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added "name" property for Idx objects. 
<!-- END RELEASE NOTES -->
