### PR TITLE
In nsolve, convert initial vector x0 to a list

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2909,6 +2909,8 @@ def nsolve(*args, **kwargs):
             if isinstance(fi, Equality):
                 f[i] = fi.lhs - fi.rhs
         f = Matrix(f).T
+    if iterable(x0):
+        x0 = list(x0)
     if not isinstance(f, Matrix):
         # assume it's a sympy expression
         if isinstance(f, Equality):

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -124,3 +124,11 @@ def test_nsolve_dict_kwarg():
 def test_nsolve_rational():
     x = symbols('x')
     assert nsolve(x - Rational(1, 3), 0, prec=100) == Rational(1, 3).evalf(100)
+
+
+def test_issue_14950():
+    x = Matrix(symbols('t s'))
+    x0 = Matrix([17, 23])
+    eqn = x + x0
+    assert nsolve(eqn, x, x0) == -x0
+    assert nsolve(eqn.T, x.T, x0.T) == -x0


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #14950 

#### Brief description of what is fixed or changed

The function `nsolve(f, vars, x0)` accepts any iterable f, for example a Matrix, and brings it to a canonical form via `f = list(f)`. Same thing is now done for x0, so that it can also be a SymPy Matrix.

#### Release Notes
 
<!-- BEGIN RELEASE NOTES -->
* solvers
  * nsolve accepts a SymPy Matrix as the initial guess. 
<!-- END RELEASE NOTES -->
