### PR TITLE
Integrate both sides of a relation with `integrate`

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1456,17 +1456,21 @@ def integrate(*args, **kwargs):
     Integral, Integral.doit
 
     """
-    meijerg = kwargs.pop('meijerg', None)
-    conds = kwargs.pop('conds', 'piecewise')
-    risch = kwargs.pop('risch', None)
-    manual = kwargs.pop('manual', None)
+    doit_flags = {
+        'deep': False,
+        'meijerg': kwargs.pop('meijerg', None),
+        'conds': kwargs.pop('conds', 'piecewise'),
+        'risch': kwargs.pop('risch', None),
+        'manual': kwargs.pop('manual', None)
+        }
     integral = Integral(*args, **kwargs)
 
     if isinstance(integral, Integral):
-        return integral.doit(deep=False, meijerg=meijerg, conds=conds,
-                             risch=risch, manual=manual)
+        return integral.doit(**doit_flags)
     else:
-        return integral
+        new_args = [a.doit(**doit_flags) if isinstance(a, Integral) else a
+            for a in integral.args]
+        return integral.func(*new_args)
 
 
 def line_integrate(field, curve, vars):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1408,3 +1408,9 @@ def test_issue_15124():
     m, p = symbols('m p', cls=Idx)
     assert integrate(exp(x*I*(omega[m] + omega[p])), x, conds='none') == \
         -I*exp(I*x*omega[m])*exp(I*x*omega[p])/(omega[m] + omega[p])
+
+
+def test_issue_15218():
+    assert Eq(x, y).integrate(x) == Eq(x**2/2, x*y)
+    assert Integral(Eq(x, y), x) == Eq(Integral(x, x), Integral(y, x))
+    assert Integral(Eq(x, y), x).doit() == Eq(x**2/2, x*y)


### PR DESCRIPTION
#### References to other Issues or PRs
 
Fixes #15218 

#### Brief description of what is fixed or changed

Currently `Eq(x, y).integrate(x)` proceeds to form `Integral(Eq(x, y), x)` which automatically becomes `Eq(Integral(x, x), Integral(y, x))` by the design of `AddWithLimits.__new__`. Then `integrate` fails to apply `doit` because the object is not an instance of Integral.

Corrected by applying doit to eligible arguments of the expression obtained from Integral(...) if the expression is not an instance of Integral.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Applying `integrate` to an `Equality` object integrates both sides.
<!-- END RELEASE NOTES -->
