### PR TITLE
Correct check for whether nested powers (x**a)**b can be combined

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -674,9 +674,9 @@ class Pow(Expr):
                         pow = as_int(pow)
                         combines = True
                     except ValueError:
-                        combines = Pow._eval_power(
+                        combines = isinstance(Pow._eval_power(
                             Pow(*old.as_base_exp(), evaluate=False),
-                            pow) is not None
+                            pow), (Pow, exp))
                     return combines, pow, None
                 else:
                     # With noncommutative symbols, substitute only integer powers

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -799,3 +799,14 @@ def test_issue_13333():
     eq = 1/x
     assert eq.subs(dict(x='1/2')) == 2
     assert eq.subs(dict(x='(1/2)')) == 2
+
+
+def test_issue_15234():
+    x, y = symbols('x y', real=True)
+    p = 6*x**5 + x**4 - 4*x**3 + 4*x**2 - 2*x + 3
+    p_subbed = 6*x**5 - 4*x**3 - 2*x + y**4 + 4*y**2 + 3
+    assert p.subs([(x**i, y**i) for i in [2, 4]]) == p_subbed
+    x, y = symbols('x y', complex=True)
+    p = 6*x**5 + x**4 - 4*x**3 + 4*x**2 - 2*x + 3
+    p_subbed = 6*x**5 - 4*x**3 - 2*x + y**4 + 4*y**2 + 3
+    assert p.subs([(x**i, y**i) for i in [2, 4]]) == p_subbed


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #15234

#### Brief description of what is fixed or changed

Currently `Pow.subs` decides whether (x**a)**b can be combined on the basis of `Pow._eval_power(x**a, b)` not returning None. However, the return value can be Mul, as in `(x**2)**(3/2)` evaluating to `x**2*Abs(x)` when x is real. This does not mean the exponents could be combined. The correct check is `isinstance(..., (Pow, exp))` instead of `is not None`.

For example, `(x**3).subs(x**2, y**2)` previously returned `y**2*Abs(y)` when x, y are real (which is incorrect, for example if x = y = -1). Now it returns `x**3` unchanged.
 
#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in the substitution of powers of a real variable.
<!-- END RELEASE NOTES -->
