### PR TITLE
Check that the output of solveset is an iterable before iterating over it

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -12,6 +12,7 @@ from sympy.functions.elementary.miscellaneous import Min, Max
 from sympy.utilities import filldedent
 from sympy.simplify.radsimp import denom
 from sympy.polys.rationaltools import together
+from sympy.core.compatibility import iterable
 
 def continuous_domain(f, symbol, domain):
     """
@@ -167,7 +168,7 @@ def function_range(f, symbol, domain):
 
             solution = solveset(f.diff(symbol), symbol, interval)
 
-            if isinstance(solution, ConditionSet):
+            if not iterable(solution):
                 raise NotImplementedError('Unable to find critical points for {}'.format(f))
 
             critical_points += solution

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,8 +1,8 @@
 from sympy import (
     Abs, acos, acosh, Add, And, asin, asinh, atan, Ci, cos, sinh, cosh,
     tanh, Derivative, diff, DiracDelta, E, Ei, Eq, exp, erf, erfi,
-    EulerGamma, Expr, factor, Function, gamma, I, Idx, im, IndexedBase, Integral, integrate,
-    Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
+    EulerGamma, Expr, factor, Function, gamma, gammasimp, I, Idx, im, IndexedBase,
+    Integral, integrate, Interval, Lambda, LambertW, log, Matrix, Max, meijerg, Min, nan,
     Ne, O, oo, pi, Piecewise, polar_lift, Poly, polygamma, Rational, re, S, Si, sign,
     simplify, sin, sinc, SingularityFunction, sqrt, sstr, Sum, Symbol,
     symbols, sympify, tan, trigsimp, Tuple
@@ -1408,3 +1408,9 @@ def test_issue_15124():
     m, p = symbols('m p', cls=Idx)
     assert integrate(exp(x*I*(omega[m] + omega[p])), x, conds='none') == \
         -I*exp(I*x*omega[m])*exp(I*x*omega[p])/(omega[m] + omega[p])
+
+
+def test_issue_15292():
+    res = integrate(exp(-x**2*cos(2*t)) * cos(x**2*sin(2*t)), (x, 0, oo))
+    assert isinstance(res, Piecewise)
+    assert gammasimp((res - sqrt(pi)/2 * cos(t)).subs(t, pi/6)) == 0


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15292 

#### Brief description of what is fixed or changed

The method `function_range` attempted to loop over the solution set returned by `solveset` without checking that the set is indeed iterable. Only a check against ConditionSet was made, but there are other non-iterable set types such as Interval.  

https://github.com/sympy/sympy/blob/cfda1bca775cca98ba8f2533d2d67876fdc0df6a/sympy/calculus/util.py#L168-L175
 
Changed the condition to `if not iterable(solution)`.

The integral from the linked issue now evaluates as a Piecewise, and simplifies to the expected result if a specific value of parameter is given.  

#### Release Notes 

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Fixed a bug in the iteration over the set of critical points 
<!-- END RELEASE NOTES -->
