### PR TITLE
Implement Order at negative infinity

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2652,11 +2652,12 @@ class Expr(Basic, EvalfMixin):
             raise ValueError("Dir must be '+' or '-'")
 
         if x0 in [S.Infinity, S.NegativeInfinity]:
-            dir = {S.Infinity: '+', S.NegativeInfinity: '-'}[x0]
-            s = self.subs(x, 1/x).series(x, n=n, dir=dir)
+            sgn = 1 if x0 is S.Infinity else -1
+            s = self.subs(x, sgn/x).series(x, n=n, dir='+')
             if n is None:
-                return (si.subs(x, 1/x) for si in s)
-            return s.subs(x, 1/x)
+                return (si.subs(x, sgn/x) for si in s)
+            return s.subs(x, sgn/x)
+
 
         # use rep to shift origin to x0 and change sign (if dir is negative)
         # and undo the process with rep2

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -184,6 +184,9 @@ class Order(Expr):
             if point[0] is S.Infinity:
                 s = {k: 1/Dummy() for k in variables}
                 rs = {1/v: 1/k for k, v in s.items()}
+            elif point[0] is S.NegativeInfinity:
+                s = {k: -1/Dummy() for k in variables}
+                rs = {-1/v: -1/k for k, v in s.items()}
             elif point[0] is not S.Zero:
                 s = dict((k, Dummy() + point[0]) for k in variables)
                 rs = dict((v - point[0], k - point[0]) for k, v in s.items())

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -428,3 +428,10 @@ def test_issue_14622():
     assert O(x, (x, oo)).contains(O(x, (x, 0))) is None
     assert O(x, (x, 0)).contains(O(x, (x, oo))) is None
     raises(NotImplementedError, lambda: O(x**3).contains(x**w))
+
+
+def test_issue_15539():
+    assert O(1/x**2 + 1/x**4, (x, -oo)) == O(1/x**2, (x, -oo))
+    assert O(1/x**4 + exp(x), (x, -oo)) == O(1/x**4, (x, -oo))
+    assert O(1/x**4 + exp(-x), (x, -oo)) == O(exp(-x), (x, -oo))
+    assert O(1/x, (x, oo)).subs(x, -x) == O(-1/x, (x, -oo))

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -206,3 +206,7 @@ def test_issue_14885():
     assert series(x**(-S(3)/2)*exp(x), x, 0) == (x**(-S(3)/2) + 1/sqrt(x) +
         sqrt(x)/2 + x**(S(3)/2)/6 + x**(S(5)/2)/24 + x**(S(7)/2)/120 +
         x**(S(9)/2)/720 + x**(S(11)/2)/5040 + O(x**6))
+
+
+def test_issue_15539():
+    assert series(exp(x), x, -oo) == O(x**(-6), (x, -oo))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15539 

#### Brief description of what is fixed or changed

`O(expr, (x, -oo))` is now allowed, and `series(expr, x, -oo)` will return an Order term in this form. The required changes were small: using the substitution `subs(x, -1/x)` instead of `subs(x, 1/x)` when negative infinity is considered.

#### Release Notes
 
<!-- BEGIN RELEASE NOTES -->
* series
  * Implemented order at negative infinity: `O(expression, (x, -oo))`.
<!-- END RELEASE NOTES -->
