### PR TITLE
Account for multiple "extra" types in IntegralTransform.doit

### DIFF
--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -598,7 +598,7 @@ def test_inverse_laplace_transform_delta():
 
 
 def test_inverse_laplace_transform_delta_cond():
-    from sympy import DiracDelta, Eq, im
+    from sympy import DiracDelta, Eq, im, Heaviside
     ILT = inverse_laplace_transform
     t = symbols('t')
     r = Symbol('r', real=True)
@@ -612,7 +612,9 @@ def test_inverse_laplace_transform_delta_cond():
         f = ILT(exp(z*s), s, t, noconds=False)
         f = f[0] if isinstance(f, tuple) else f
         assert f.func != DiracDelta
-
+    # issue 15043
+    assert ILT(1/s + exp(r*s)/s, s, t, noconds=False) == (
+        Heaviside(t) + Heaviside(r + t), True)
 
 def test_fourier_transform():
     from sympy import simplify, expand, expand_complex, factor, expand_trig

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core import S
-from sympy.core.compatibility import reduce, range
+from sympy.core.compatibility import reduce, range, iterable
 from sympy.core.function import Function
 from sympy.core.numbers import oo
 from sympy.core.symbol import Dummy
@@ -87,6 +87,7 @@ class IntegralTransform(Function):
         cond = And(*extra)
         if cond == False:
             raise IntegralTransformError(self.__class__.name, None, '')
+        return cond
 
     def doit(self, **hints):
         """
@@ -132,14 +133,21 @@ class IntegralTransform(Function):
                 if not isinstance(x, tuple):
                     x = [x]
                 ress.append(x[0])
-                if len(x) > 1:
+                if len(x) == 2:
+                    # only a condition
+                    extra.append(x[1])
+                elif len(x) > 2:
+                    # some region parameters and a condition (Mellin, Laplace)
                     extra += [x[1:]]
             res = Add(*ress)
             if not extra:
                 return res
             try:
                 extra = self._collapse_extra(extra)
-                return tuple([res]) + tuple(extra)
+                if iterable(extra):
+                    return tuple([res]) + tuple(extra)
+                else:
+                    return (res, extra)
             except IntegralTransformError:
                 pass
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15043. Fixes #15044

#### Brief description of what is fixed or changed

The method `IntegralTransform.doit` is common to several types of transforms, which present conditions for convergence in different ways: just a condition, or (abscissa of convergence, condition) for Laplace transform, or ((abscissa1, abscissa2), condition) for Mellin Transform. The method needed to be more aware of this distinction by checking the kinds of objects it's handling.
 
#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed a bug in the handling of convergence conditions in some integral transforms.
<!-- END RELEASE NOTES -->
