### PR TITLE
In test_series, replace exp by atan for tests at infinity

### DIFF
--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -1,5 +1,5 @@
 from sympy import sin, cos, exp, E, series, oo, S, Derivative, O, Integral, \
-    Function, log, sqrt, Symbol, Subs, pi, symbols, IndexedBase
+    Function, log, sqrt, Symbol, Subs, pi, symbols, IndexedBase, atan
 from sympy.abc import x, y, n, k
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import range
@@ -209,4 +209,7 @@ def test_issue_14885():
 
 
 def test_issue_15539():
-    assert series(exp(x), x, -oo) == O(x**(-6), (x, -oo))
+    assert series(atan(x), x, -oo) == (-1/(5*x**5) + 1/(3*x**3) - 1/x - pi/2
+        + O(x**(-6), (x, -oo)))
+    assert series(atan(x), x, oo) == (-1/(5*x**5) + 1/(3*x**3) - 1/x + pi/2
+        + O(x**(-6), (x, oo)))


### PR DESCRIPTION
#### Brief description of what is fixed or changed

[As suggested by jksuom](https://github.com/sympy/sympy/pull/15540#issuecomment-441557166), the test for Order at infinity uses atan instead of exp. The exponential function is not represented by a power series at infinity (i.e., a series in terms of 1/x), but atan is. The series for atan has different forms for oo and -oo, which tests that Order at -oo is implemented correctly.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
