### PR TITLE
Fix dsolve rootof when some roots are solvable

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -4959,7 +4959,7 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     # Can't just call roots because it doesn't return rootof for unsolveable
     # polynomials.
     chareqroots = roots(chareq, multiple=True)
-    if chareqroots == []:
+    if len(chareqroots) != order:
         chareqroots = [rootof(chareq, k) for k in range(chareq.degree())]
 
     chareq_is_complex = not all([i.is_real for i in chareq.all_coeffs()])

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1769,6 +1769,17 @@ def test_nth_linear_constant_coeff_homogeneous_rootof():
         C5*exp(x*rootof(x**5 + 11*x - 2, 4)))
     assert dsolve(eq) == sol
 
+    eq = f(x).diff(x, 6) - 6*f(x).diff(x, 5) + 5*f(x).diff(x, 4) + 10*f(x).diff(x) - 50 * f(x)
+    sol = Eq(f(x),
+          C1*exp(5*x)
+        + C2*exp(x*rootof(x**5 - x**4 + 10, 0))
+        + C3*exp(x*rootof(x**5 - x**4 + 10, 1))
+        + C4*exp(x*rootof(x**5 - x**4 + 10, 2))
+        + C5*exp(x*rootof(x**5 - x**4 + 10, 3))
+        + C6*exp(x*rootof(x**5 - x**4 + 10, 4))
+            )
+    assert dsolve(eq) == sol
+
 def test_nth_linear_constant_coeff_homogeneous_irrational():
     our_hint='nth_linear_constant_coeff_homogeneous'
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15527 

#### Brief description of what is fixed or changed

After #15408 `dsolve` tries to find roots of the characteristic polynomial using `roots`. If `roots` returns an empty list it then tries `rootof` which can return `CRootOf` instances. That change was introduced because `rootof` doesn't work for some polynomials with irrational coefficients.

However in some cases `roots` will return a non-empty but incomplete set of roots e.g.:
```julia
In [10]: p = expand((x-5)*(x**5-x+1))                                                                                                                         

In [11]: p                                                                                                                                                    
Out[11]: 
 6      5    2          
x  - 5⋅x  - x  + 6⋅x - 5

In [12]: roots(p)                                                                                                                                             
Out[12]: {5: 1}

In [13]: [rootof(p, n) for n in range(6)]                                                                                                                     
Out[13]: 
⎡       ⎛ 5           ⎞            ⎛ 5           ⎞         ⎛ 5           ⎞         ⎛ 5           ⎞         ⎛ 5           ⎞⎤
⎣CRootOf⎝x  - x + 1, 0⎠, 5, CRootOf⎝x  - x + 1, 1⎠, CRootOf⎝x  - x + 1, 2⎠, CRootOf⎝x  - x + 1, 3⎠, CRootOf⎝x  - x + 1, 4⎠⎦
```

This means that `dsolve` returns an incorrect result for the corresponding ODEs:
```julia
In [1]: eq = f(x).diff(x,6) - 5*f(x).diff(x,5) - f(x).diff(x,2) + 6*f(x).diff(x) - 5*f(x)                                                                     

In [2]: dsolve(eq)                                                                                                                                            
Out[2]: 
           5⋅x
f(x) = C₁⋅ℯ  
```

With this patch instead we get:
```julia
In [1]: eq = f(x).diff(x,6) - 5*f(x).diff(x,5) - f(x).diff(x,2) + 6*f(x).diff(x) - 5*f(x)                                                                     

In [2]: dsolve(eq)                                                                                                                                            
Out[2]: 
                              ⎛ 5           ⎞                ⎛ 5           ⎞                ⎛ 5           ⎞                ⎛ 5           ⎞                ⎛ 
           5⋅x       x⋅CRootOf⎝x  - x + 1, 0⎠       x⋅CRootOf⎝x  - x + 1, 1⎠       x⋅CRootOf⎝x  - x + 1, 2⎠       x⋅CRootOf⎝x  - x + 1, 3⎠       x⋅CRootOf⎝x
f(x) = C₁⋅ℯ    + C₂⋅ℯ                         + C₃⋅ℯ                         + C₄⋅ℯ                         + C₅⋅ℯ                         + C₆⋅ℯ           

5           ⎞
  - x + 1, 4⎠
```

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

Release notes not needed as this is a correction to #15408 

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
