### PR TITLE
DOC: '+' and '-' is the fourth arg to limit(), not the third

### DIFF
--- a/doc/src/tutorial/calculus.rst
+++ b/doc/src/tutorial/calculus.rst
@@ -259,7 +259,7 @@ counterpart, ``Limit``.  To evaluate it, use ``doit``.
     >>> expr.doit()
     0
 
-To evaluate a limit at one side only, pass ``'+'`` or ``'-'`` as a third
+To evaluate a limit at one side only, pass ``'+'`` or ``'-'`` as a fourth
 argument to ``limit``.  For example, to compute
 
 .. math::


### PR DESCRIPTION
Just fixing a little mistake in the docs.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
