### PR TITLE
Implement divmod on Expr

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -217,6 +217,19 @@ class Expr(Basic, EvalfMixin):
         from sympy.functions.elementary.integers import floor
         return floor(other / self)
 
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rdivmod__')
+    def __divmod__(self, other):
+        from sympy.functions.elementary.integers import floor
+        return floor(self / other), Mod(self, other)
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__divmod__')
+    def __rdivmod__(self, other):
+        from sympy.functions.elementary.integers import floor
+        return floor(other / self), Mod(other, self)
+
     def __int__(self):
         # Although we only need to round to the units position, we'll
         # get one more digit so the extra testing below can be avoided

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1985,3 +1985,8 @@ def test_Add_is_zero():
 
 def test_issue_14392():
     assert (sin(zoo)**2).as_real_imag() == (nan, nan)
+
+def test_divmod():
+    assert divmod(x, y) == (x//y, x % y)
+    assert divmod(x, 3) == (x//3, x % 3)
+    assert divmod(3, x) == (3//x, 3 % x)

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -1,4 +1,4 @@
-from sympy import I, symbols, Matrix, eye
+from sympy import I, symbols, Matrix, eye, Mod, floor
 from sympy.matrices import ShapeError, MatrixSymbol, Identity
 from sympy.matrices.expressions import det, trace
 
@@ -10,7 +10,7 @@ from sympy.core.trace import Tr
 mat1 = Matrix([[1, 2 * I], [1 + I, 3]])
 mat2 = Matrix([[2 * I, 3], [4 * I, 2]])
 
-n, m, k, x = symbols('n,m,k,x')
+i, j, k, n, m, o, p, x = symbols('i,j,k,n,m,o,p,x')
 Z = MatrixSymbol('Z', n, n)
 W = MatrixSymbol('W', m, m)
 A = MatrixSymbol('A', n, m)
@@ -136,3 +136,9 @@ def test_KroneckerProduct_expand():
     assert KroneckerProduct(X + Y, Y + Z).expand(kroneckerproduct=True) == \
         KroneckerProduct(X, Y) + KroneckerProduct(X, Z) + \
         KroneckerProduct(Y, Y) + KroneckerProduct(Y, Z)
+
+def test_KroneckerProduct_entry():
+    A = MatrixSymbol('A', n, m)
+    B = MatrixSymbol('B', o, p)
+
+    assert KroneckerProduct(A, B)._entry(i, j) == A[Mod(floor(i/o), n), Mod(floor(j/p), m)]*B[Mod(i, o), Mod(j, p)]


### PR DESCRIPTION
Closes #7889.

Note there is a separate issue with a discrepancy between the builtin divmod
and divmod on SymPy number types that is not fixed here (#15561).

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * `divmod` now works on SymPy expressions
* matrices
  * `KroneckerProduct._entry` now works with matrices with symbolic shapes
<!-- END RELEASE NOTES -->
