### PR TITLE
Make the substitution of symbols consistent with powers of symbols

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -676,7 +676,7 @@ class Pow(Expr):
                     except ValueError:
                         combines = isinstance(Pow._eval_power(
                             Pow(*old.as_base_exp(), evaluate=False),
-                            pow), (Pow, exp))
+                            pow), (Pow, exp, Symbol))
                     return combines, pow, None
                 else:
                     # With noncommutative symbols, substitute only integer powers

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -251,6 +251,11 @@ class Symbol(AtomicExpr, Boolean):
         # Note: user-specified assumptions not hashed, just derived ones
         return (self.name,) + tuple(sorted(self.assumptions0.items()))
 
+    def _eval_subs(self, old, new):
+        from sympy.core.power import Pow
+        if old.is_Pow:
+            return Pow(self, S.One, evaluate=False)._eval_subs(old, new)
+
     @property
     def assumptions0(self):
         return dict((key, value) for key, value

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -194,7 +194,7 @@ def test_mul():
     x, y, z, a, b, c = symbols('x y z a b c')
     A, B, C = symbols('A B C', commutative=0)
     assert (x*y*z).subs(z*x, y) == y**2
-    assert (z*x).subs(1/x, z) == z*x
+    assert (z*x).subs(1/x, z) == 1
     assert (x*y/z).subs(1/z, a) == a*x*y
     assert (x*y/z).subs(x/z, a) == a*y
     assert (x*y/z).subs(y/z, a) == a*x
@@ -810,3 +810,19 @@ def test_issue_15234():
     p = 6*x**5 + x**4 - 4*x**3 + 4*x**2 - 2*x + 3
     p_subbed = 6*x**5 - 4*x**3 - 2*x + y**4 + 4*y**2 + 3
     assert p.subs([(x**i, y**i) for i in [2, 4]]) == p_subbed
+
+
+def test_issue_6976():
+    x, y = symbols('x y')
+    assert (sqrt(x)**3 + sqrt(x) + x + x**2).subs(sqrt(x), y) == \
+        y**4 + y**3 + y**2 + y
+    assert (x**4 + x**3 + x**2 + x + sqrt(x)).subs(x**2, y) == \
+        sqrt(x) + x**3 + x + y**2 + y
+    assert x.subs(x**3, y) == x
+    assert x.subs(x**(S(1)/3), y) == y**3
+
+    # More substitutions are possible with nonnegative symbols
+    x, y = symbols('x y', nonnegative=True)
+    assert (x**4 + x**3 + x**2 + x + sqrt(x)).subs(x**2, y) == \
+        y**(1/4) + y**(3/2) + sqrt(y) + y**2 + y
+    assert x.subs(x**3, y) == y**(1/3)

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -44,12 +44,6 @@ def test_issue_4511():
 
 
 @XFAIL
-def test_issue_4514():
-    # The correct answer is 2*sin(x)
-    assert not integrate(sin(2*x)/ sin(x)).has(Integral)
-
-
-@XFAIL
 def test_issue_4525():
     # Warning: takes a long time
     assert not integrate((x**m * (1 - x)**n * (a + b*x + c*x**2))/(1 + x**2), (x, 0, 1)).has(Integral)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1421,3 +1421,7 @@ def test_issue_15292():
     res = integrate(exp(-x**2*cos(2*t)) * cos(x**2*sin(2*t)), (x, 0, oo))
     assert isinstance(res, Piecewise)
     assert gammasimp((res - sqrt(pi)/2 * cos(t)).subs(t, pi/6)) == 0
+
+
+def test_issue_4514():
+    assert integrate(sin(2*x)/sin(x), x) == 2*sin(x)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -323,8 +323,8 @@ def test_issue_2850():
             log(x**2 + 1)/2)*log(x) + log(x**2 + 1)/2 + Integral(log(x**2 + 1)/x, x)/2
 
 def test_issue_9462():
-    assert manualintegrate(sin(2*x)*exp(x), x) == -3*exp(x)*sin(2*x) \
-                           - 2*exp(x)*cos(2*x) + 4*Integral(2*exp(x)*cos(2*x), x)
+    assert manualintegrate(sin(2*x)*exp(x), x) == exp(x)*sin(2*x) \
+                           - 2*exp(x)*cos(2*x) - 4*Integral(exp(x)*sin(2*x), x)
     assert manualintegrate((x - 3) / (x**2 - 2*x + 2)**2, x) == \
                            Integral(x/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x) \
                            - 3*Integral(1/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x)
@@ -361,7 +361,8 @@ def test_issue_10847():
     assert manualintegrate(sqrt(2*x + 3) / 2 * x, x) == (2*x + 3)**(5/2)/20 - (2*x + 3)**(3/2)/4
     assert manualintegrate(x**Rational(3,2) * log(x), x) == 2*x**Rational(5,2)*log(x)/5 - 4*x**Rational(5/2)/25
     assert manualintegrate(x**(-3) * log(x), x) == -log(x)/(2*x**2) - 1/(4*x**2)
-    assert manualintegrate(log(y)/(y**2*(1 - 1/y)), y) == (-log(y) + log(y - 1))*log(y) + log(y)**2/2 - Integral(log(y - 1)/y, y)
+    assert manualintegrate(log(y)/(y**2*(1 - 1/y)), y) == \
+        log(y)*log(-1 + 1/y) - Integral(log(-1 + 1/y)/y, y)
 
 def test_issue_12899():
     assert manualintegrate(f(x,y).diff(x),y) == Integral(Derivative(f(x,y),x),y)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #6976. Closes #4514 which was already fixed; removed XFAIL from its test

#### Brief description of what is fixed or changed

The `subs` method now applies the same logic to symbols as to their powers, by calling `Pow._eval_subs`. Old behavior:
```
>>> (log(x)**2/x).subs(1/x, u)
u*log(x)**2
```
New behavior:
```
>>> (log(x)**2/x).subs(1/x, u)
u*log(1/u)**2
```
This uncovered some issues with `manualintegrate`: it is prone to infinite recursion, which was previously prevented by the failure of subs. This is corrected as well.

#### Other comments

The integral of `log(x)**2/x` becomes `log(1/u)**2/u` after `subs(1/x, u)`, and then another substitution `subs(1/u, v)` is made, returning to the original form. This did not happen before only because `subs` did not succeed in replacing x.

The dictionary `_integral_cache` of manualintegrate was meant to prevent infinite recursion but it never worked because each substitution introduces a new dummy, and dummy variables are considered different. For the above example, this dictionary would look like
```
{(log(x)**2/x, x): None,
(log(1/_u)**2/_u, _u): None,
(log(_u)**2/_u, _u): None,
(log(1/_u)**2/_u, _u): None, 
(log(_u)**2/_u, _u): None, 
(log(1/_u)**2/_u, _u): None, 
(log(_u)**2/_u, _u): None, 
(log(1/_u)**2/_u, _u): None}
```
This is corrected now by using the same dummy in all cached integrands. The type of return value after cache hit was fixed; as written, it would throw errors if there was ever a cache hit.

Another issue that came up is that the manual integration of `(x+1)/x` tried substitution `u = 1/x` before partial fractions, which resulted in a suboptimal form of the integrand (now that the substitution was successful). A clause is added to prevent substitution in a rational function when it increases its degree.

Two of manualintegrate tests now return cosmetically different (slightly simpler) expressions due to earlier exit when hitting the cache. 

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * substitution of powers of symbols is applied to those symbols as well
* integrals
  * manual integration algorithm is prevented from making infinite circular substitutions
<!-- END RELEASE NOTES -->
