### PR TITLE
numbers: changed behavior of Number.__divmod__  to builtin divmod

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -575,7 +575,7 @@ class Number(AtomicExpr):
             return Tuple(*divmod(self.p, other.p))
         else:
             rat = self/other
-        w = sign(rat)*int(abs(rat))  # = rat.floor()
+        w = int(rat) if rat > 0 else int(rat) - 1
         r = self - other*w
         return Tuple(w, r)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -192,6 +192,8 @@ def test_divmod():
     assert divmod(S(-3), 2) == (-2, 1)
 
     assert divmod(S(4), S(-3.1)) == Tuple(-2, -2.2)
+    assert divmod(S(4), S(-2.1)) == divmod(4, -2.1)
+    assert divmod(S(-8), S(-2.5) ) == Tuple(3 , -0.5)
 
 def test_igcd():
     assert igcd(0, 0) == 0

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -191,6 +191,7 @@ def test_divmod():
     assert divmod(S(-3), S(2)) == (-2, 1)
     assert divmod(S(-3), 2) == (-2, 1)
 
+    assert divmod(S(4), S(-3.1)) == Tuple(-2, -2.2)
 
 def test_igcd():
     assert igcd(0, 0) == 0


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->
Fixes #15561 

#### Brief description of what is fixed or changed
`Number.__divmod__()` now gives quotient that has same sign as of divisor.  

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Other comments
`assert divmod(S(4), S(-2.1)) == Tuple(-2,-0.2)`  fails.
Although both give same result.

`>>> divmod(S(4), S(-2.1))[1] `
`-0.200000000000000`

I guess that `divmod(S(4), S(-2.1))[1] ` is the cause.
I have not added it as a testcase.  

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
    * `Number.__divmod__` now works like the builtin divmod for negative numbers
<!-- END RELEASE NOTES -->
