### PR TITLE
[WIP] Remove incorrect method Order._eval_derivative

### DIFF
--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -458,9 +458,6 @@ class Order(Expr):
         if expr is not None:
             return self.func(expr, *self.args[1:])
 
-    def _eval_derivative(self, x):
-        return self.func(self.expr.diff(x), *self.args[1:]) or self
-
     def _eval_transpose(self):
         expr = self.expr._eval_transpose()
         if expr is not None:

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -497,7 +497,7 @@ def test_issue_5183():
     assert ((1 + x)**2).series(x, n=6) == 1 + 2*x + x**2
     assert (1 + 1/x).series() == 1 + 1/x
     assert Derivative(exp(x).series(), x).doit() == \
-        1 + x + x**2/2 + x**3/6 + x**4/24 + O(x**5)
+        1 + x + x**2/2 + x**3/6 + x**4/24 + Derivative(O(x**6), x)
 
 
 def test_issue_5654():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, Rational, Order, exp, ln, log, nan, oo, O, pi, I,
     S, Integral, sin, cos, sqrt, conjugate, expand, transpose, symbols,
-    Function, Add)
+    Function, Add, Derivative)
 from sympy.utilities.pytest import raises
 from sympy.abc import w, x, y, z
 
@@ -262,7 +262,7 @@ def test_getn():
 
 
 def test_diff():
-    assert O(x**2).diff(x) == O(x)
+    assert O(x**2).diff(x) == Derivative(O(x**2), x)
 
 
 def test_getO():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15570 

#### Brief description of what is fixed or changed

The method `Order._eval_derivative` and some of tests asserted that `O(x**2).diff(x)` is `O(x)`. This is incorrect, as is shown by examples like 

- `x**2 * sin(1/x**2)` (the expression is `O(x**2)` at 0, but its derivative is not even bounded there) 
- `x**2 * sin(exp(x))` (the expression is `O(x**2)` at infinity but its derivative grows exponentially)

The derivative of Order should remain un-evaluated, as there is no way to determine its size.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* series
  * the derivative of Order objects returns un-evaluated.
<!-- END RELEASE NOTES -->
