### PR TITLE
Avoid infinite integration by parts in manualintegrate

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -497,10 +497,11 @@ def parts_rule(integral):
             return
 
         # Set a limit on the number of times u can be used
-        cachekey = u.xreplace({symbol: _cache_dummy})
-        if _parts_u_cache[cachekey] > 5:
-            return
-        _parts_u_cache[cachekey] += 1
+        if isinstance(u, (sympy.sin, sympy.cos, sympy.exp, sympy.sinh, sympy.cosh)):
+            cachekey = u.xreplace({symbol: _cache_dummy})
+            if _parts_u_cache[cachekey] > 2:
+                return
+            _parts_u_cache[cachekey] += 1
 
         while True:
             if (integrand / (v * du)).cancel() == 1:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -548,7 +548,6 @@ def parts_rule(integral):
         if (constant != 1) and rule:
             rule = ConstantTimesRule(constant, integrand, rule,
                                      constant * integrand, symbol)
-        cachekey = u.xreplace({symbol: _cache_dummy})
         return rule
 
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -18,7 +18,7 @@ To enable simple substitutions, add the match to find_substitutions.
 """
 from __future__ import print_function, division
 
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 
 import sympy
 
@@ -496,6 +496,12 @@ def parts_rule(integral):
         if isinstance(v, sympy.Integral):
             return
 
+        # Set a limit on the number of times u can be used
+        cachekey = u.xreplace({symbol: _cache_dummy})
+        if _parts_u_cache[cachekey] > 5:
+            return
+        _parts_u_cache[cachekey] += 1
+
         while True:
             if (integrand / (v * du)).cancel() == 1:
                 break
@@ -541,6 +547,7 @@ def parts_rule(integral):
         if (constant != 1) and rule:
             rule = ConstantTimesRule(constant, integrand, rule,
                                      constant * integrand, symbol)
+        cachekey = u.xreplace({symbol: _cache_dummy})
         return rule
 
 
@@ -1008,7 +1015,9 @@ def fallback_rule(integral):
 
 # Cache is used to break cyclic integrals.
 # Need to use the same dummy variable in cached expressions for them to match.
+# Also record "u" of integration by parts, to avoid infinite repetition.
 _integral_cache = {}
+_parts_u_cache = defaultdict(int)
 _cache_dummy = sympy.Dummy("z")
 
 def integral_steps(integrand, symbol, **options):
@@ -1390,6 +1399,8 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral
     """
     result = _manualintegrate(integral_steps(f, var))
+    # Clear the cache of u-parts
+    _parts_u_cache.clear()
     # If we got Piecewise with two parts, put generic first
     if isinstance(result, Piecewise) and len(result.args) == 2:
         cond = result.args[0][1]

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -396,3 +396,9 @@ def test_issue_9858():
     res = manualintegrate(exp(10*x)*sin(exp(x)), x)
     assert not res.has(Integral)
     assert res.diff(x) == exp(10*x)*sin(exp(x))
+    # an example with many similar integrations by parts
+    assert manualintegrate(sum([x*exp(k*x) for k in range(1, 8)]), x) == (
+        x*exp(7*x)/7 + x*exp(6*x)/6 + x*exp(5*x)/5 + x*exp(4*x)/4 +
+        x*exp(3*x)/3 + x*exp(2*x)/2 + x*exp(x) - exp(7*x)/49 -exp(6*x)/36 -
+        exp(5*x)/25 - exp(4*x)/16 - exp(3*x)/9 - exp(2*x)/4 - exp(x))
+

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -387,3 +387,12 @@ def test_issue_13297():
 def test_issue_14470():
     assert manualintegrate(1/(x*sqrt(x + 1)), x) == \
         log(-1 + 1/sqrt(x + 1)) - log(1 + 1/sqrt(x + 1))
+
+
+def test_issue_9858():
+    assert manualintegrate(exp(x)*cos(exp(x)), x) == sin(exp(x))
+    assert manualintegrate(exp(2*x)*cos(exp(x)), x) == \
+        exp(x)*sin(exp(x)) + cos(exp(x))
+    res = manualintegrate(exp(10*x)*sin(exp(x)), x)
+    assert not res.has(Integral)
+    assert res.diff(x) == exp(10*x)*sin(exp(x))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -401,4 +401,3 @@ def test_issue_9858():
         x*exp(7*x)/7 + x*exp(6*x)/6 + x*exp(5*x)/5 + x*exp(4*x)/4 +
         x*exp(3*x)/3 + x*exp(2*x)/2 + x*exp(x) - exp(7*x)/49 -exp(6*x)/36 -
         exp(5*x)/25 - exp(4*x)/16 - exp(3*x)/9 - exp(2*x)/4 - exp(x))
-


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #9858 

#### Brief description of what is fixed or changed

With an integral like `exp(x) * cos(exp(x))`, manualintegrate attempts integration by parts with `u = cos(exp(x))`, which "succeeds", but leads to an infinite chain of different integrals such as `exp(n*x) * cos(exp(x))` and `exp(n*x) * sin(exp(x))`. While repeated integration with the same `dv` term can be useful (like `x**9 * exp(x)`), the same is not true for repeated use of `u` term, i.e., differentiating a factor and getting the same factor back. This is now prevented by keeping track of u-terms used by integration by parts.
 
#### Release Notes
 
<!-- BEGIN RELEASE NOTES -->
* integrals
  * prevented creation of infinite chains of integration by parts 
<!-- END RELEASE NOTES -->
