### PR TITLE
Don't collect tests from rubi_tests under pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,10 @@ import pytest
 durations_path = os.path.join(os.path.dirname(__file__), '.ci', 'durations.json')
 blacklist_path = os.path.join(os.path.dirname(__file__), '.ci', 'blacklisted.json')
 
+# Collecting tests from rubi_tests under pytest leads to errors even if the
+# tests will be skipped.
+collect_ignore = ["sympy/integrals/rubi/rubi_tests"]
+
 def _mk_group(group_dict):
     return list(chain(*[[k+'::'+v for v in files] for k, files in group_dict.items()]))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->


#### Brief description of what is fixed or changed

Sets pytest to ignore the tests in `sympy/integrals/rubi/rubi_tests`.

Collecting these tests causes errors and a segfault when testing with pytest:
```console
$ pytest sympy
====================================================== test session starts =======================================================
platform darwin -- Python 2.7.10, pytest-4.0.1.dev15+gcdbe2299, py-1.7.0, pluggy-0.8.0
architecture: 64-bit
cache:        yes
ground types: python 

rootdir: /Users/enojb/current/sympy/sympy, inifile:
plugins: xdist-1.24.1, forked-0.2
collecting 2937 items / 7 errors                                                                                                 Segmentation fault: 11
```

I've reported the segfault to pytest: [https://github.com/pytest-dev/pytest/issues/4406](https://github.com/pytest-dev/pytest/issues/4406). It is semi-fixed in CPython 2.7 (no segfault) but is caused by pytest's excessive assertion rewriting which I will hopefully find time to investigate at some point. This is caused by `test_trinomials.py` which is an excessively large auto-generated test file.

The other errors are to do with imports:
```console
$ python
Python 2.7.10 (default, Oct  6 2017, 22:29:07) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sympy.integrals.rubi.rubi_tests.tests.test_inverse_sine
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy/integrals/rubi/rubi_tests/tests/test_inverse_sine.py", line 12, in <module>
    from sympy.integrals.rubi.utility_function import (
ImportError: cannot import name sympy_op_factory
```

Maybe that's something that should be fixed in rubi but for now I think that pytest should ignore these tests (as `bin/test` does).

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * Make tests compatible with pytest
<!-- END RELEASE NOTES -->
