### PR TITLE
Use S() to avoid integer division in test_subs.py

### DIFF
--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -823,5 +823,5 @@ def test_issue_6976():
     # More substitutions are possible with nonnegative symbols
     x, y = symbols('x y', nonnegative=True)
     assert (x**4 + x**3 + x**2 + x + sqrt(x)).subs(x**2, y) == \
-        y**(1/4) + y**(3/2) + sqrt(y) + y**2 + y
-    assert x.subs(x**3, y) == y**(1/3)
+        y**(S(1)/4) + y**(S(3)/2) + sqrt(y) + y**2 + y
+    assert x.subs(x**3, y) == y**(S(1)/3)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Following on from #15515 

#### Brief description of what is fixed or changed

Fixes another case of integer division in the tests. This one snuck in while #15515 was waiting.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
