### PR TITLE
Use appropriate NumPy methods for MatrixSymbol inverses and powers

### DIFF
--- a/doc/src/modules/matrices/expressions.rst
+++ b/doc/src/modules/matrices/expressions.rst
@@ -9,7 +9,7 @@ The Matrix expression module allows users to write down statements like
     >>> X = MatrixSymbol('X', 3, 3)
     >>> Y = MatrixSymbol('Y', 3, 3)
     >>> (X.T*X).I*Y
-    X^-1*X.T^-1*Y
+    X**(-1)*X.T**(-1)*Y
 
     >>> Matrix(X)
     Matrix([

--- a/sympy/matrices/expressions/inverse.py
+++ b/sympy/matrices/expressions/inverse.py
@@ -22,13 +22,13 @@ class Inverse(MatPow):
     >>> A = MatrixSymbol('A', 3, 3)
     >>> B = MatrixSymbol('B', 3, 3)
     >>> Inverse(A)
-    A^-1
+    A**(-1)
     >>> A.inverse() == Inverse(A)
     True
     >>> (A*B).inverse()
-    B^-1*A^-1
+    B**(-1)*A**(-1)
     >>> Inverse(A*B)
-    (A*B)^-1
+    (A*B)**(-1)
 
     """
     is_Inverse = True
@@ -77,7 +77,7 @@ def refine_Inverse(expr, assumptions):
     >>> from sympy import MatrixSymbol, Q, assuming, refine
     >>> X = MatrixSymbol('X', 2, 2)
     >>> X.I
-    X^-1
+    X**(-1)
     >>> with assuming(Q.orthogonal(X)):
     ...     print(refine(X.I))
     X.T

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -499,6 +499,16 @@ class NumPyPrinter(PythonCodePrinter):
         "Matrix multiplication printer"
         return '({0})'.format(').dot('.join(self._print(i) for i in expr.args))
 
+    def _print_MatPow(self, expr):
+        "Matrix power printer"
+        return '{0}({1}, {2})'.format(self._module_format('numpy.linalg.matrix_power'),
+            self._print(expr.args[0]), self._print(expr.args[1]))
+
+    def _print_Inverse(self, expr):
+        "Matrix inverse printer"
+        return '{0}({1})'.format(self._module_format('numpy.linalg.inv'),
+            self._print(expr.args[0]))
+
     def _print_DotProduct(self, expr):
         # DotProduct allows any shape order, but numpy.dot does matrix
         # multiplication, so we have to make sure it gets 1 x n by n x 1.

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -209,7 +209,7 @@ class StrPrinter(Printer):
                                         self._print(i.max))
 
     def _print_Inverse(self, I):
-        return "%s^-1" % self.parenthesize(I.arg, PRECEDENCE["Pow"])
+        return "%s**(-1)" % self.parenthesize(I.arg, PRECEDENCE["Pow"])
 
     def _print_Lambda(self, obj):
         args, expr = obj.args

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -8,7 +8,7 @@ from sympy.codegen.ast import none
 from sympy.external import import_module
 from sympy.logic import And, Or
 from sympy.functions import acos, Piecewise, sign
-from sympy.matrices import SparseMatrix
+from sympy.matrices import SparseMatrix, MatrixSymbol
 from sympy.printing.pycode import (
     MpmathPrinter, NumPyPrinter, PythonCodePrinter, pycode, SciPyPrinter
 )
@@ -45,6 +45,9 @@ def test_MpmathPrinter():
 def test_NumPyPrinter():
     p = NumPyPrinter()
     assert p.doprint(sign(x)) == 'numpy.sign(x)'
+    A = MatrixSymbol("A", 2, 2)
+    assert p.doprint(A**(-1)) == "numpy.linalg.inv(A)"
+    assert p.doprint(A**5) == "numpy.linalg.matrix_power(A, 5)"
 
 
 def test_SciPyPrinter():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -802,6 +802,8 @@ def test_MatrixSymbol_printing():
 
     assert str(A - A*B - B) == "A - A*B - B"
     assert str(A*B - (A+B)) == "-(A + B) + A*B"
+    assert str(A**(-1)) == "A**(-1)"
+    assert str(A**3) == "A**3"
 
 
 def test_Subs_printing():

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -92,7 +92,7 @@ NUMEXPR_TRANSLATIONS = {}
 MODULES = {
     "math": (MATH, MATH_DEFAULT, MATH_TRANSLATIONS, ("from math import *",)),
     "mpmath": (MPMATH, MPMATH_DEFAULT, MPMATH_TRANSLATIONS, ("from mpmath import *",)),
-    "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *",)),
+    "numpy": (NUMPY, NUMPY_DEFAULT, NUMPY_TRANSLATIONS, ("import numpy; from numpy import *; from numpy.linalg import *",)),
     "scipy": (SCIPY, SCIPY_DEFAULT, SCIPY_TRANSLATIONS, ("import numpy; import scipy; from scipy import *; from scipy.special import *",)),
     "tensorflow": (TENSORFLOW, TENSORFLOW_DEFAULT, TENSORFLOW_TRANSLATIONS, ("import_module('tensorflow')",)),
     "sympy": (SYMPY, SYMPY_DEFAULT, {}, (

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -10,7 +10,8 @@ from sympy import (
     Float, Matrix, Lambda, Piecewise, exp, Integral, oo, I, Abs, Function,
     true, false, And, Or, Not, ITE, Min, Max, floor, diff, IndexedBase, Sum,
     DotProduct, Eq, Dummy, sinc, erf, erfc, factorial, gamma, loggamma,
-    digamma, RisingFactorial, besselj, bessely, besseli, besselk, S)
+    digamma, RisingFactorial, besselj, bessely, besseli, besselk, S,
+    MatrixSymbol)
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy.printing.pycode import NumPyPrinter
 from sympy.utilities.lambdify import implemented_function, lambdastr
@@ -1045,3 +1046,14 @@ def test_imag_real():
 
     f_im = lambdify([z], sympy.im(z))  # see #15400
     assert f_im(val) == val.imag
+
+
+def test_MatrixSymbol_issue_15578():
+    if not numpy:
+        skip("numpy not installed")
+    A = MatrixSymbol('A', 2, 2)
+    A0 = numpy.array([[1, 2], [3, 4]])
+    f = lambdify(A, A**(-1))
+    assert numpy.allclose(f(A0), numpy.array([[-2., 1.], [1.5, -0.5]]))
+    g = lambdify(A, A**3)
+    assert numpy.allclose(g(A0), numpy.array([[37, 54], [81, 118]]))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15578 

#### Brief description of what is fixed or changed

Currently NumPy printer prints `A**2` as such even if A is a MatrixSymbol, resulting in elementwise squaring.  It should use `numpy.linalg.matrix_power` instead. Similarly for matrix inverse. Changes are tested with lambdify as well.

In addition, a string representation of `A**(-1)` is corrected: previously `str(A**(-1))` returned `A^-1`, in contrast with `str(A**(-2))` returning `A**(-2)`.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * MatrixSymbol powers and inverses are printed as the corresponding NumPy methods
<!-- END RELEASE NOTES -->
