### PR TITLE
Use dont_inherit arg to compile in test runner

### DIFF
--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1857,9 +1857,9 @@ def test_numpy_to_float():
         y = Float(ratval, precision=prec)
         assert abs((x - y)/y) < 2**(-(prec + 1))
 
-    check_prec_and_relerr(np.float16(2/3), S(2)/3)
-    check_prec_and_relerr(np.float32(2/3), S(2)/3)
-    check_prec_and_relerr(np.float64(2/3), S(2)/3)
+    check_prec_and_relerr(np.float16(2.0/3), S(2)/3)
+    check_prec_and_relerr(np.float32(2.0/3), S(2)/3)
+    check_prec_and_relerr(np.float64(2.0/3), S(2)/3)
     # extended precision, on some arch/compilers:
     x = np.longdouble(2)/3
     check_prec_and_relerr(x, S(2)/3)

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -46,11 +46,11 @@ def test_plane():
 
     assert pl3.projection(Point(0, 0)) == p1
     p = pl3.projection(Point3D(1, 1, 0))
-    assert p == Point3D(7/6, 2/3, 1/6)
+    assert p == Point3D(S(7)/6, S(2)/3, S(1)/6)
     assert p in pl3
 
     l = pl3.projection_line(Line(Point(0, 0), Point(1, 1)))
-    assert l == Line3D(Point3D(0, 0, 0), Point3D(7/6, 2/3, 1/6))
+    assert l == Line3D(Point3D(0, 0, 0), Point3D(S(7)/6, S(2)/3, S(1)/6))
     assert l in pl3
     # get a segment that does not intersect the plane which is also
     # parallel to pl3's normal veector
@@ -61,9 +61,9 @@ def test_plane():
     assert s.p1 not in pl3 and s.p2 not in pl3
     assert pl3.projection_line(s).equals(r)
     assert pl3.projection_line(Segment(Point(1, 0), Point(1, 1))) == \
-               Segment3D(Point3D(5/6, 1/3, -1/6), Point3D(7/6, 2/3, 1/6))
+               Segment3D(Point3D(S(5)/6, S(1)/3, -S(1)/6), Point3D(S(7)/6, S(2)/3, S(1)/6))
     assert pl6.projection_line(Ray(Point(1, 0), Point(1, 1))) == \
-               Ray3D(Point3D(14/3, 11/3, 11/3), Point3D(13/3, 13/3, 10/3))
+               Ray3D(Point3D(S(14)/3, S(11)/3, S(11)/3), Point3D(S(13)/3, S(13)/3, S(10)/3))
     assert pl3.perpendicular_line(r.args) == pl3.perpendicular_line(r)
 
     assert pl3.is_parallel(pl6) is False
@@ -150,7 +150,7 @@ def test_plane():
     assert pl3.intersection(pl6) == [
         Line3D(Point3D(8, 4, 0), Point3D(2, 4, 6))]
     assert pl3.intersection(Line3D(Point3D(1,2,4), Point3D(4,4,2))) == [
-        Point3D(2, 8/3, 10/3)]
+        Point3D(2, S(8)/3, S(10)/3)]
     assert pl3.intersection(Plane(Point3D(6, 0, 0), normal_vector=(2, -5, 3))
         ) == [Line3D(Point3D(-24, -12, 0), Point3D(-25, -13, -1))]
     assert pl6.intersection(Ray3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == [
@@ -158,7 +158,7 @@ def test_plane():
     assert pl6.intersection(Segment3D(Point3D(2, 3, 1), Point3D(1, 3, 4))) == [
         Point3D(-1, 3, 10)]
     assert pl7.intersection(Line(Point(2, 3), Point(4, 2))) == [
-        Point3D(13/2, 3/4, 0)]
+        Point3D(S(13)/2, S(3)/4, 0)]
     r = Ray(Point(2, 3), Point(4, 2))
     assert Plane((1,2,0), normal_vector=(0,0,1)).intersection(r) == [
         Ray3D(Point(2, 3), Point(4, 2))]

--- a/sympy/geometry/tests/test_polygon.py
+++ b/sympy/geometry/tests/test_polygon.py
@@ -113,7 +113,7 @@ def test_polygon():
         Point(0, 0)
     raises(ValueError, lambda: Polygon(
         Point(x, 0), Point(0, y), Point(x, y)).arbitrary_point('x'))
-    assert p6.intersection(r) == [Point(-9, -84/13), Point(-9, 33/5)]
+    assert p6.intersection(r) == [Point(-9, -S(84)/13), Point(-9, S(33)/5)]
     #
     # Regular polygon
     #
@@ -159,7 +159,7 @@ def test_polygon():
     assert p1 == p1_old
 
     assert p1.area == (-250*sqrt(5) + 1250)/(4*tan(pi/5))
-    assert p1.length == 20*sqrt(-sqrt(5)/8 + 5/8)
+    assert p1.length == 20*sqrt(-sqrt(5)/8 + S(5)/8)
     assert p1.scale(2, 2) == \
         RegularPolygon(p1.center, p1.radius*2, p1._n, p1.rotation)
     assert RegularPolygon((0, 0), 1, 4).scale(2, 3) == \

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -476,5 +476,5 @@ def test_manual_subs():
 
 def test_issue_15471():
     f = log(x)*cos(log(x))/x**(S(3)/4)
-    F = -128*x**(1/4)*sin(log(x))/289 + 240*x**(1/4)*cos(log(x))/289 + (16*x**(1/4)*sin(log(x))/17 + 4*x**(1/4)*cos(log(x))/17)*log(x)
+    F = -128*x**(S(1)/4)*sin(log(x))/289 + 240*x**(S(1)/4)*cos(log(x))/289 + (16*x**(S(1)/4)*sin(log(x))/17 + 4*x**(S(1)/4)*cos(log(x))/17)*log(x)
     assert manualintegrate(f, x) == F and F.diff(x).equals(f)

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,4 +1,4 @@
-from sympy.core.backend import symbols, Matrix, cos, sin, atan, sqrt
+from sympy.core.backend import symbols, Matrix, cos, sin, atan, sqrt, S
 from sympy import solve, simplify
 from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
     dot, cross, inertia, KanesMethod, Particle, RigidBody, Lagrangian,\
@@ -117,7 +117,7 @@ def test_linearize_rolling_disc_kane():
                     [0, 0, 0, 0, 0, 0, 1, 0],
                     [sin(q1)*q3d, 0, 0, 0, 0, -sin(q1), -cos(q1), 0],
                     [-cos(q1)*q3d, 0, 0, 0, 0, cos(q1), -sin(q1), 0],
-                    [0, 4/5, 0, 0, 0, 0, 0, 6*q3d/5],
+                    [0, S(4)/5, 0, 0, 0, 0, 0, 6*q3d/5],
                     [0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, -2*q3d, 0, 0]])
     B_sol = Matrix([])

--- a/sympy/plotting/intervalmath/tests/test_interval_functions.py
+++ b/sympy/plotting/intervalmath/tests/test_interval_functions.py
@@ -22,15 +22,15 @@ def test_interval_pow():
     assert a.is_valid is None
     a = interval(-2, -1) ** interval(1, 2)
     assert a.is_valid is False
-    a = interval(-2, -1) ** (1 / 2)
+    a = interval(-2, -1) ** (1.0 / 2)
     assert a.is_valid is False
-    a = interval(-1, 1)**(1 / 2)
+    a = interval(-1, 1)**(1.0 / 2)
     assert a.is_valid is None
-    a = interval(-1, 1)**(1 / 3) == interval(-1, 1)
+    a = interval(-1, 1)**(1.0 / 3) == interval(-1, 1)
     assert a == (True, True)
     a = interval(-1, 1)**2 == interval(0, 1)
     assert a == (True, True)
-    a = interval(-1, 1) ** (1 / 29) == interval(-1, 1)
+    a = interval(-1, 1) ** (1.0 / 29) == interval(-1, 1)
     assert a == (True, True)
     a = -2**interval(1, 1) == interval(-2, -2)
     assert a == (True, True)
@@ -44,10 +44,10 @@ def test_interval_pow():
     assert a.is_valid is False
     assert ((-3)**interval(1, 1) == interval(-3, -3)) == (True, True)
 
-    a = interval(8, 64)**(2 / 3)
+    a = interval(8, 64)**(2.0 / 3)
     assert abs(a.start - 4) < 1e-10  # eps
     assert abs(a.end - 16) < 1e-10
-    a = interval(-8, 64)**(2 / 3)
+    a = interval(-8, 64)**(2.0 / 3)
     assert abs(a.start - 4) < 1e-10  # eps
     assert abs(a.end - 16) < 1e-10
 

--- a/sympy/series/tests/test_limitseq.py
+++ b/sympy/series/tests/test_limitseq.py
@@ -91,7 +91,7 @@ def test_alternating_sign():
     assert limit_seq(sin(pi*n), n) == 0
     assert limit_seq(cos(2*pi*n), n) == 1
     assert limit_seq((S(-1)/5)**n, n) == 0
-    assert limit_seq((-1/5)**n, n) == 0
+    assert limit_seq((-S(1)/5)**n, n) == 0
     assert limit_seq((I/3)**n, n) == 0
     assert limit_seq(sqrt(n)*(I/2)**n, n) == 0
     assert limit_seq(n**7*(I/3)**n, n) == 0

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2921,7 +2921,7 @@ def test_lie_group():
 
     eq = Eq(f(x).diff(x), x**2*f(x))
     sol = dsolve(eq, f(x), hint='lie_group')
-    assert sol == Eq(f(x), C1*exp(x**3)**(1/3))
+    assert sol == Eq(f(x), C1*exp(x**3)**(S(1)/3))
     assert checkodesol(eq, sol)[0]
 
     eq = f(x).diff(x) + a*f(x) - c*exp(b*x)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -473,9 +473,9 @@ def test_solve_sqrt_3():
     eq = -sqrt((m - q)**2 + (-m/(2*q) + S(1)/2)**2) + sqrt((-m**2/2 - sqrt(
         4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2 + (m**2/2 - m - sqrt(
             4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2)
-    unsolved_object = ConditionSet(q, Eq(sqrt((m - q)**2 + (-m/(2*q) + 1/2)**2) -
-        sqrt((-m**2/2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - 1/4)**2 + (m**2/2 - m -
-        sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - 1/4)**2), 0), S.Reals)
+    unsolved_object = ConditionSet(q, Eq(sqrt((m - q)**2 + (-m/(2*q) + S(1)/2)**2) -
+        sqrt((-m**2/2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2 + (m**2/2 - m -
+        sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2), 0), S.Reals)
     assert solveset_real(eq, q) == unsolved_object
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1223,7 +1223,7 @@ def test_nonlinsolve_abs():
 def test_raise_exception_nonlinsolve():
     raises(IndexError, lambda: nonlinsolve([x**2 -1], []))
     raises(ValueError, lambda: nonlinsolve([x**2 -1]))
-    raises(NotImplementedError, lambda: nonlinsolve([(x+y)**2 - 9, x**2 - y**2 -3/4], (x, y)))
+    raises(NotImplementedError, lambda: nonlinsolve([(x+y)**2 - 9, x**2 - y**2 - 0.75], (x, y)))
 
 
 def test_trig_system():

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1190,7 +1190,7 @@ class SymPyTests(object):
                     except ImportError:
                         pass
 
-                code = compile(source, filename, "exec")
+                code = compile(source, filename, "exec", flags=0, dont_inherit=True)
                 exec_(code, gl)
             except (SystemExit, KeyboardInterrupt):
                 raise


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes the test runner to avoid the situations seen in #15522 , #15579 , #15515 

#### Brief description of what is fixed or changed

~~The test runner is changed to use `importlib.import_module` rather than `compile/exec`. This means that each test file is compiled as it would be if directly imported in an `import` statement.~~

~~The previous compile/exec code for this treated all files as utf8 even if no encoding declaration was present. This meant that the tests would pass under PY2 even if the test module was not normally importable.~~

EDIT: I've changed this patch and force-pushed. The new changes are: Pass `flag=0, no_inherit=True` arguments to compile in the test runner.

This means that test modules won't inherit the `__future__` flags of the `sympy.utilities.runtests` module. The problem with files having no encoding declaration is unsolved by the latest version of this patch but that's not such a big problem anyway.

Previously `compile` implicitly injects the `__future__` flags from the calling module into the code that is compiled. This means that all tests are implicitly run with `from __future__ import division` when under the test runner. This also can mean that the result of the test is different when run under the test runner compare to when imported and called directly.

I found a number of other integer division bugs in the tests as a result of this. The first commit is the changes to the test runner. The others are fixes to integer division in various test files.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
    * Test runner no longer forces `__future__` division so that the test behaviour is the same under the runner as when imported normally.
<!-- END RELEASE NOTES -->
