### PR TITLE
Fix doctest printing style by setting print_cyclic

### DIFF
--- a/sympy/codegen/array_utils.py
+++ b/sympy/codegen/array_utils.py
@@ -432,6 +432,9 @@ class CodegenArrayPermuteDims(_CodegenArrayAbstract):
 
         >>> from sympy.codegen.array_utils import (CodegenArrayPermuteDims, CodegenArrayTensorProduct, nest_permutation)
         >>> from sympy import MatrixSymbol
+        >>> from sympy.combinatorics import Permutation
+        >>> Permutation.print_cyclic = True
+
         >>> M = MatrixSymbol("M", 3, 3)
         >>> N = MatrixSymbol("N", 3, 3)
         >>> cg = CodegenArrayPermuteDims(CodegenArrayTensorProduct(M, N), [1, 0, 3, 2])
@@ -768,6 +771,9 @@ def parse_indexed_expression(expr, first_indices=[]):
 
     >>> from sympy.codegen.array_utils import parse_indexed_expression
     >>> from sympy import MatrixSymbol, Sum, symbols
+    >>> from sympy.combinatorics import Permutation
+    >>> Permutation.print_cyclic = True
+
     >>> i, j, k, d = symbols("i j k d")
     >>> M = MatrixSymbol("M", d, d)
     >>> N = MatrixSymbol("N", d, d)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

Fixes #15588 

#### Brief description of what is fixed or changed

Sets `print_cyclic` to `True` to fix the output style used in an array_utils doctest so that it doesn't depend on the order that doctests are run.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
