### PR TITLE
add parentheses while pretty printing MatMul and KroneckerProduct

### DIFF
--- a/examples/beginner/print_pretty.py
+++ b/examples/beginner/print_pretty.py
@@ -5,12 +5,16 @@
 Demonstrates pretty printing.
 """
 
-from sympy import Symbol, pprint, sin, cos, exp, sqrt
+from sympy import Symbol, pprint, sin, cos, exp, sqrt, MatrixSymbol, KroneckerProduct
 
 
 def main():
     x = Symbol("x")
     y = Symbol("y")
+
+    a = MatrixSymbol("a", 1, 1)
+    b = MatrixSymbol("b", 1, 1)
+    c = MatrixSymbol("c", 1, 1)
 
     pprint( x**x )
     print('\n')  # separate with two blank likes
@@ -37,6 +41,9 @@ def main():
     print('\n')
 
     pprint( (1/cos(x)).series(x, 0, 10) )
+    print('\n')
+
+    pprint(a*(KroneckerProduct(b, c)))
     print('\n')
 
 if __name__ == "__main__":

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -837,9 +837,9 @@ class PrettyPrinter(Printer):
 
     def _print_MatMul(self, expr):
         args = list(expr.args)
-        from sympy import Add, MatAdd, HadamardProduct
+        from sympy import Add, MatAdd, HadamardProduct, KroneckerProduct
         for i, a in enumerate(args):
-            if (isinstance(a, (Add, MatAdd, HadamardProduct))
+            if (isinstance(a, (Add, MatAdd, HadamardProduct, KroneckerProduct))
                     and len(expr.args) > 1):
                 args[i] = prettyForm(*self._print(a).parens())
             else:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6483,5 +6483,3 @@ def test_issue_15560():
     e = pretty(a*(KroneckerProduct(a, a)))
     result = 'a*(a x a)'
     assert e == result
-
-

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -6479,15 +6479,9 @@ H    \n\
 
 
 def test_issue_15560():
-    import sys
-    from sympy.core.compatibility import StringIO
-    fd = StringIO()
-    a = MatrixSymbol("a", 1, 1)
-    sso = sys.stdout
-    sys.stdout = fd
-    try:
-        pprint(a*(KroneckerProduct(a, a)), use_unicode=False, wrap_line=False)
-    finally:
-        sys.stdout = sso
-    assert fd.getvalue() == 'a*(a x a)\n'
+    a = MatrixSymbol('a', 1, 1)
+    e = pretty(a*(KroneckerProduct(a, a)))
+    result = 'a*(a x a)'
+    assert e == result
+
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -19,7 +19,7 @@ from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
 from sympy.codegen.ast import (Assignment, AddAugmentedAssignment,
     SubAugmentedAssignment, MulAugmentedAssignment, DivAugmentedAssignment, ModAugmentedAssignment)
 
-from sympy.matrices import Adjoint, Inverse, MatrixSymbol, Transpose
+from sympy.matrices import Adjoint, Inverse, MatrixSymbol, Transpose, KroneckerProduct
 
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
@@ -6476,3 +6476,18 @@ H    \n\
     ucode_str = ascii_str
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
+
+
+def test_issue_15560():
+    import sys
+    from sympy.core.compatibility import StringIO
+    fd = StringIO()
+    a = MatrixSymbol("a", 1, 1)
+    sso = sys.stdout
+    sys.stdout = fd
+    try:
+        pprint(a*(KroneckerProduct(a, a)), use_unicode=False, wrap_line=False)
+    finally:
+        sys.stdout = sso
+    assert fd.getvalue() == 'a*(a x a)\n'
+


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
"Fixes #15560"

#### Brief description of what is fixed or changed
Modified `_print_MatMul` such that if matrix multiplication contains `KroneckerProduct` then it would add parentheses to it.
for example
`pprint(a*(KroneckerProduct(b, c)))`
`a⋅(b ⨂ c)`


#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - MatMuls with KroneckerProducts now parenthesize correctly
<!-- END RELEASE NOTES -->
