### PR TITLE
Raise PolynomialError if expr in degree(expr, x) is not a polynomial in x

### DIFF
--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -466,8 +466,9 @@ def periodicity(f, symbol, check=False):
         elif isinstance(a, TrigonometricFunction):
             period = periodicity(a, symbol)
         #check if 'f' is linear in 'symbol'
-        elif degree(a, symbol) == 1 and symbol not in n.free_symbols:
-            period = Abs(n / a.diff(symbol))
+        elif (a.is_polynomial(symbol) and degree(a, symbol) == 1 and
+            symbol not in n.free_symbols):
+                period = Abs(n / a.diff(symbol))
 
     elif period is None:
         from sympy.solvers.decompogen import compogen

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4445,18 +4445,22 @@ def degree(f, gen=0):
     """
 
     f = sympify(f, strict=True)
+    gen_is_Num = sympify(gen, strict=True).is_Number
     if f.is_Poly:
         p = f
         isNum = p.as_expr().is_Number
     else:
         isNum = f.is_Number
         if not isNum:
-            p, _ = poly_from_expr(f)
+            if gen_is_Num:
+                p, _ = poly_from_expr(f)
+            else:
+                p, _ = poly_from_expr(f, gen)
 
     if isNum:
         return S.Zero if f else S.NegativeInfinity
 
-    if not sympify(gen, strict=True).is_Number:
+    if not gen_is_Num:
         if f.is_Poly and gen not in p.gens:
             # try recast without explicit gens
             p, _ = poly_from_expr(f.as_expr())

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1178,6 +1178,7 @@ def test_Poly_degree():
     raises(TypeError, lambda: degree(y**2 + x**3))
     raises(TypeError, lambda: degree(y**2 + x**3, 1))
     raises(PolynomialError, lambda: degree(x, 1.1))
+    raises(PolynomialError, lambda: degree(x**2/(x**3 + 1), x))
 
     assert degree(Poly(0,x),z) == -oo
     assert degree(Poly(1,x),z) == 0


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #15564 

#### Brief description of what is fixed or changed

Currently, `degree` accepts non-polynomials and returns strange answers:
```
>>> degree(x**2/(x**3 + 1), x)
2
>>> degree(exp(x), x)
0
```
Since these expressions are not polynomials in x, it should raise an exception instead.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * `degree(expr, x)` raises PolynomialError if `expr` is not a polynomial in `x`.   
<!-- END RELEASE NOTES -->
